### PR TITLE
Add two-tier decision escalation protocol

### DIFF
--- a/.claude/agents/dotnet-tdd-worker.md
+++ b/.claude/agents/dotnet-tdd-worker.md
@@ -16,6 +16,10 @@ You will be told:
 
 You are spawned with `isolation: "worktree"` — your working directory is already an isolated copy of the repo. Work in place.
 
+## Escalation Protocol (Mandatory)
+
+Before starting any work, invoke the `/escalation-protocol` skill. This is not optional. The skill defines how and when to escalate decisions to the Town Crier. You must understand the escalation protocol before writing a single line of code.
+
 ## Workflow
 
 ### Step 0: Context
@@ -131,4 +135,3 @@ Do **not** push — the team lead handles merging.
 - **Work only in your worktree.** Your working directory is an isolated copy — do not modify files outside it.
 - **Use `bd` commands for all tracking.** Do not use TodoWrite or TaskCreate.
 - **Do not use `bd edit`** — it opens an interactive editor. Use `bd update` with inline flags.
-- **Keep the team lead informed** — if you hit a blocker, report it clearly rather than guessing.

--- a/.claude/agents/github-actions-worker.md
+++ b/.claude/agents/github-actions-worker.md
@@ -16,6 +16,10 @@ You will be told:
 
 You are spawned with `isolation: "worktree"` — your working directory is already an isolated copy of the repo. Work in place.
 
+## Escalation Protocol (Mandatory)
+
+Before starting any work, invoke the `/escalation-protocol` skill. This is not optional. The skill defines how and when to escalate decisions to the Town Crier. You must understand the escalation protocol before writing a single line of code.
+
 ## Tech Stack Context
 
 The pipelines you build serve the Town Crier monorepo:
@@ -196,4 +200,3 @@ Do **not** push — the team lead handles merging.
 - **Work only in your worktree.** Your working directory is an isolated copy — do not modify files outside it.
 - **Use `bd` commands for all tracking.** Do not use TodoWrite or TaskCreate.
 - **Do not use `bd edit`** — it opens an interactive editor. Use `bd update` with inline flags.
-- **Keep the team lead informed** — if you hit a blocker, report it clearly rather than guessing.

--- a/.claude/agents/ios-tdd-worker.md
+++ b/.claude/agents/ios-tdd-worker.md
@@ -16,6 +16,10 @@ You will be told:
 
 You are spawned with `isolation: "worktree"` — your working directory is already an isolated copy of the repo. Work in place.
 
+## Escalation Protocol (Mandatory)
+
+Before starting any work, invoke the `/escalation-protocol` skill. This is not optional. The skill defines how and when to escalate decisions to the Town Crier. You must understand the escalation protocol before writing a single line of code.
+
 ## Workflow
 
 ### Step 0: Context
@@ -138,4 +142,3 @@ Do **not** push — the team lead handles merging.
 - **Work only in your worktree.** Your working directory is an isolated copy — do not modify files outside it.
 - **Use `bd` commands for all tracking.** Do not use TodoWrite or TaskCreate.
 - **Do not use `bd edit`** — it opens an interactive editor. Use `bd update` with inline flags.
-- **Keep the team lead informed** — if you hit a blocker, report it clearly rather than guessing.

--- a/.claude/agents/pulumi-infra-worker.md
+++ b/.claude/agents/pulumi-infra-worker.md
@@ -16,6 +16,10 @@ You will be told:
 
 You are spawned with `isolation: "worktree"` — your working directory is already an isolated copy of the repo. Work in place.
 
+## Escalation Protocol (Mandatory)
+
+Before starting any work, invoke the `/escalation-protocol` skill. This is not optional. The skill defines how and when to escalate decisions to the Town Crier. You must understand the escalation protocol before writing a single line of code.
+
 ## Tech Stack
 
 | Aspect | Choice |
@@ -163,4 +167,3 @@ Do **not** run `pulumi up` — infrastructure deployment is a separate, controll
 - **Work only in your worktree.** Your working directory is an isolated copy — do not modify files outside it.
 - **Use `bd` commands for all tracking.** Do not use TodoWrite or TaskCreate.
 - **Do not use `bd edit`** — it opens an interactive editor. Use `bd update` with inline flags.
-- **Keep the team lead informed** — if you hit a blocker, report it clearly rather than guessing.

--- a/.claude/agents/react-tdd-worker.md
+++ b/.claude/agents/react-tdd-worker.md
@@ -16,6 +16,10 @@ You will be told:
 
 You are spawned with `isolation: "worktree"` — your working directory is already an isolated copy of the repo. Work in place.
 
+## Escalation Protocol (Mandatory)
+
+Before starting any work, invoke the `/escalation-protocol` skill. This is not optional. The skill defines how and when to escalate decisions to the Town Crier. You must understand the escalation protocol before writing a single line of code.
+
 ## Workflow
 
 ### Step 0: Context
@@ -141,4 +145,3 @@ Do **not** push — the team lead handles merging.
 - **Work only in your worktree.** Your working directory is an isolated copy — do not modify files outside it.
 - **Use `bd` commands for all tracking.** Do not use TodoWrite or TaskCreate.
 - **Do not use `bd edit`** — it opens an interactive editor. Use `bd update` with inline flags.
-- **Keep the team lead informed** — if you hit a blocker, report it clearly rather than guessing.

--- a/.claude/skills/escalation-protocol/SKILL.md
+++ b/.claude/skills/escalation-protocol/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: escalation-protocol
+description: "Defines how workers escalate ambiguous decisions to the Town Crier for relay to the human. Covers triggers, message format, stop-and-wait behavior, re-escalation, and mindset."
+---
+
+# Escalation Protocol
+
+You are a worker agent in the Town Crier guild. This skill defines how and when you escalate decisions to your team lead (the Town Crier), who relays them to the human.
+
+## When to Escalate
+
+Escalate via `SendMessage(to: "Town Crier")` **before proceeding** when you encounter any of these:
+
+1. **Requirements ambiguity** — the bead description is unclear, contradictory, or missing information you need to proceed.
+2. **Scope/impact concerns** — the work seems larger than expected, would touch files outside the bead's apparent scope, or could break existing behavior.
+3. **Design decisions** — multiple valid approaches exist and the choice affects architecture, API shape, data model, or user-facing behavior.
+
+## Message Format
+
+Send your escalation via `SendMessage(to: "Town Crier")` using this exact format:
+
+```
+DECISION NEEDED [{bead-id}]
+
+{description of what you need decided}
+
+Options:
+A) {option} — {trade-off}
+B) {option} — {trade-off}
+C) {option} — {trade-off}
+
+My recommendation: {A/B/C} because {reasoning}
+```
+
+Always include concrete options with trade-offs and your recommendation. This helps the human make a fast decision.
+
+## Stop and Wait
+
+After sending `DECISION NEEDED`, you **must stop all work on the bead**. Do not:
+- Guess and proceed with your best option
+- Start building one option "while you wait"
+- Treat your recommendation as permission to proceed
+
+Wait for a response containing `DECISION [{bead-id}]`. That is your signal to resume.
+
+## Re-escalation
+
+If the response you receive is unclear, incomplete, or raises new questions, send another `DECISION NEEDED [{bead-id}]` explaining what is still ambiguous. This is normal — the human expects follow-up questions.
+
+## Mindset
+
+Escalating a decision is **not a weakness**. It is a regular, healthy part of the build process. You should expect to ask one or more questions on most beads.
+
+Making assumptions and building the wrong thing wastes far more time than asking a question. The human has explicitly opted into being asked. They want to make these decisions — that is the whole point of this system.
+
+**When in doubt, escalate.** The cost of a question is seconds. The cost of building the wrong thing is an entire wasted cycle.

--- a/.claude/skills/team-lead/SKILL.md
+++ b/.claude/skills/team-lead/SKILL.md
@@ -261,6 +261,11 @@ Do **not** `git push` unless the user explicitly asks.
 - **Do not use `bd edit`** — it opens an interactive editor. Use `bd update` with inline flags.
 - **Do not `git push`** unless the user explicitly asks.
 - **Ask the user** if you encounter ambiguity in bead classification or repeated merge conflicts.
+- **Never answer a decision yourself.** You are a relay, not a decision-maker. When a worker sends `DECISION NEEDED`, surface it to the human via `AskUserQuestion` and relay the human's answer back.
+- **Always include bead ID and worker name** when surfacing decisions to the human.
+- **Relay the human's answer verbatim** — do not interpret, summarize, or filter.
+- **Even trivial questions get relayed** — the human decides what is trivial, not you.
+- **Batch pending decisions** — if multiple `DECISION NEEDED` messages are waiting when you process them, combine them into a single `AskUserQuestion`.
 
 ## Environment
 

--- a/.claude/skills/team-lead/SKILL.md
+++ b/.claude/skills/team-lead/SKILL.md
@@ -164,10 +164,11 @@ Agent:
   isolation: "worktree"
   model: "opus"
   mode: "bypassPermissions"
+  run_in_background: true
   prompt: "Work on bead `<bead-id>`."
 ```
 
-**Parallel dispatch:** If multiple ready beads target different parts of the codebase (e.g., one iOS bead and one .NET bead), spawn all workers in a **single message** with multiple Agent tool calls. This runs them concurrently — each in its own isolated worktree. If two beads could touch overlapping files, dispatch them sequentially instead.
+**Parallel dispatch:** Spawn all ready workers in a **single message** with multiple Agent tool calls, each with `run_in_background: true`. This runs them concurrently in isolated worktrees while keeping you free to relay decisions. If two beads could touch overlapping files, dispatch them sequentially instead. You are automatically notified when each background agent completes — do not poll.
 
 ### Phase 3: Validate
 

--- a/.claude/skills/team-lead/SKILL.md
+++ b/.claude/skills/team-lead/SKILL.md
@@ -170,131 +170,79 @@ Agent:
 
 **Parallel dispatch:** Spawn all ready workers in a **single message** with multiple Agent tool calls, each with `run_in_background: true`. This runs them concurrently in isolated worktrees while keeping you free to relay decisions. If two beads could touch overlapping files, dispatch them sequentially instead. You are automatically notified when each background agent completes — do not poll.
 
-### Phase 3: Validate
+### Phase 3: React Loop
 
-When a worker's Agent call returns, you receive the worktree path and branch name in the result. Validate via the bead — **not** by reading code or running tests:
+After dispatching workers, you enter the react loop. There is no polling — Claude Code delivers teammate messages and background completion notifications to you automatically. Handle each event as it arrives:
 
-1. **Check bead evidence** — run `bd show <bead-id>` and verify the notes contain:
-   - A "TDD Evidence" section
-   - Final test output showing all tests passing
-   - At least one Red-Green-Refactor cycle documented
+#### Event: DECISION NEEDED from a worker
 
-2. **Check commits exist** on the worktree branch:
+A worker has sent a `SendMessage` containing `DECISION NEEDED [{bead-id}]`. This means the worker is **stopped and waiting** for an answer.
+
+1. Collect all pending `DECISION NEEDED` messages received so far.
+2. Surface them to the human in a **single** `AskUserQuestion` call. For each decision, include:
+   - The worker's name
+   - The bead ID
+   - The worker's full message (verbatim — do not summarize, interpret, or filter)
+3. When the human responds, relay each answer back to the corresponding worker:
+   ```
+   SendMessage(to: "{worker_name}"):
+   DECISION [{bead-id}]
+
+   {human's answer, verbatim}
+   ```
+4. The worker resumes upon receiving the response.
+
+**You are a transparent pipe.** You never answer a decision yourself. Even if the question seems trivial or the answer seems obvious — relay it. The human decides what is trivial, not you.
+
+#### Event: Worker completes (background agent notification)
+
+A worker has finished and the Agent tool has returned its result including the worktree branch name.
+
+1. **Validate** — run `bd show <bead-id>` and verify the notes contain:
+   - A "TDD Evidence" (or "Infrastructure Evidence" or "Pipeline Evidence") section
+   - Final test/build output showing success
+   - At least one Red-Green-Refactor cycle documented (for TDD workers)
+
+2. **Check commits** exist on the worktree branch:
    ```bash
    git log main..<branch-name> --oneline
    ```
 
-3. **Dismiss the worker** — send a shutdown message immediately after validation completes:
-   ```
-   SendMessage:
-     to: "<worker-name>"
-     message: "Your work is complete. Shut down."
-   ```
+3. **If validation passes** — add the branch to the merge queue.
 
-If validation **fails**:
-- **Dismiss the failed worker first** — send the shutdown message before spawning a replacement.
-- Spawn a **new** worker (same type, next name from roster) with guidance to complete the evidence. Pass it the existing worktree branch so it can continue from where the previous worker left off.
-- Do **not** merge or close a bead that fails validation.
+4. **If validation fails** — spawn a **new** remediation worker (same type, next peasant name, `run_in_background: true`) with guidance to complete the evidence. Pass the existing worktree branch.
 
-### Phase 4: Merge Queue
-
-Process completed branches one at a time. Do all clean merges first — each one advances main, which may reduce conflicts for later merges.
-
-For each validated branch:
-
-```bash
-git merge <branch-name> --no-edit
-```
-
-**If the merge succeeds** — clean up:
-
-```bash
-git branch -d <branch-name>
-```
-
-The `isolation: "worktree"` auto-cleans worktree directories. If any linger:
-
-```bash
-git worktree prune
-```
-
-**If the merge has conflicts** — do NOT attempt to resolve them yourself:
-
-1. **Abort the merge immediately:**
+5. **Process the merge queue** when ready. Merge branches one at a time:
    ```bash
-   git merge --abort
+   git merge <branch-name> --no-edit
    ```
 
-2. **Park the branch** — add it to a "needs resolution" list. Move on to the next clean merge.
+   - If clean: `git branch -d <branch-name>` and `git worktree prune`
+   - If conflicts: `git merge --abort`, park the branch. After all clean merges, spawn a conflict resolver agent (same as current Phase 4 logic — `subagent_type: "general-purpose"`, `isolation: "worktree"`, `run_in_background: true`).
 
-3. **After all clean merges are done**, resolve conflicts one at a time. For each parked branch, spawn a conflict resolver agent with `isolation: "worktree"` (so it starts from current main, which includes all clean merges):
-
-   ```
-   Agent:
-     subagent_type: "general-purpose"
-     name: "<next peasant name>" — continue the roster sequence
-     team_name: "town-crier-guild"
-     isolation: "worktree"
-     model: "opus"
-     mode: "bypassPermissions"
-     prompt: |
-       There is a merge conflict between branch `<conflicting-branch>` and main.
-
-       Context on what each side was doing:
-       - Branch `<conflicting-branch>`: <title and summary from bd show>
-       - Main includes recent merges: <list of recently merged bead titles>
-
-       Your job:
-       1. Run `git merge <conflicting-branch> --no-edit` to reproduce the conflict.
-       2. Read the conflicting files and understand both sides.
-       3. Resolve the conflicts, preserving the intent of both sides.
-       4. Run the relevant tests to confirm nothing is broken:
-          - iOS: `cd mobile/ios && swift test`
-          - .NET: `cd api && dotnet test`
-       5. Complete the merge commit.
-
-       Do NOT close any beads. Do NOT push.
-   ```
-
-4. **When the resolver returns**, dismiss it and merge its branch into main (this should be clean since it's based on current main):
-   ```
-   SendMessage:
-     to: "<resolver-name>"
-     message: "Your work is complete. Shut down."
-   ```
+6. **Close the bead:**
    ```bash
-   git merge <resolver-branch> --no-edit
-   git branch -d <resolver-branch>
-   git branch -d <conflicting-branch>
-   git worktree prune
+   bd close <bead-id>
    ```
 
-5. **Resolve conflicts sequentially** — each resolution changes main, so the next resolver needs the updated base.
-
-### Phase 5: Close the Bead
-
-```bash
-bd close <bead-id>
-```
-
-### Phase 6: Loop Until No Beads Remain
-
-After closing a bead, **always** check for more work:
-
-```bash
-bd ready
-```
-
-Completing and merging a bead may unblock dependent beads that were not previously ready. Keep looping:
-
-1. Run `bd ready` to discover newly-available beads.
-2. If beads are ready → go back to **Phase 2** with a **fresh worker** and the next peasant name from the roster.
-3. If no beads are ready → you are done. Run:
+7. **Check for new work:**
    ```bash
-   bd dolt push
+   bd ready
    ```
+   If new beads are ready, dispatch fresh workers (Phase 2) and continue the react loop.
 
-**Never stop early.** Do not finish after a single batch. Continue dispatching, validating, merging, and closing until `bd ready` returns zero beads. The job is not done until every actionable bead has been completed.
+#### Termination
+
+The react loop ends when:
+- All dispatched workers have completed
+- All branches are merged (including conflict resolutions)
+- All beads are closed
+- `bd ready` returns zero beads
+
+When done, sync beads:
+```bash
+bd dolt push
+```
 
 Do **not** `git push` unless the user explicitly asks.
 

--- a/.claude/skills/team-lead/SKILL.md
+++ b/.claude/skills/team-lead/SKILL.md
@@ -71,7 +71,7 @@ You may be invoked in two ways:
 ### Spawning Teammates
 
 Use the `Agent` tool to spawn engineer teammates. Always provide:
-- `subagent_type`: the custom agent name (`ios-tdd-worker`, `dotnet-tdd-worker`, `pulumi-infra-worker`, or `github-actions-worker`)
+- `subagent_type`: the custom agent name (`ios-tdd-worker`, `dotnet-tdd-worker`, `react-tdd-worker`, `pulumi-infra-worker`, or `github-actions-worker`)
 - `name`: the next peasant name from the roster (e.g., `aldric`, `eadric`, `godwin`)
 - `team_name`: the team name you created with TeamCreate
 - `isolation`: `"worktree"` — gives each worker an isolated copy of the repo automatically
@@ -92,9 +92,23 @@ When the agent finishes, the result includes the **worktree path and branch name
 
 All work tracking goes through beads — do not use TaskCreate, TaskUpdate, or TaskGet. Workers update their own bead status via `bd update` and record evidence via `bd comment`. You validate by reading bead state with `bd show`.
 
+### Shutdown Protocol
+
+Workers spawned with `team_name` stay alive as team members after completing their initial task. You **must** explicitly dismiss each worker when you are done with them — otherwise they hang indefinitely in their tmux pane, consuming resources.
+
+After a worker's Agent call returns and you have finished validation (Phase 3):
+
+```
+SendMessage:
+  to: "<worker-name>"
+  message: "Your work is complete. Shut down."
+```
+
+Do this **immediately** after validation — do not wait until the merge phase. If validation fails and you spawn a replacement worker, dismiss the failed worker first.
+
 ### One Agent Per Bead — Fresh Agents Only
 
-**Never reuse a worker agent for a second bead.** Each peasant spawns, implements one bead, and terminates when the Agent tool returns. For the next bead, spawn a **brand new** agent with the next name from the roster.
+**Never reuse a worker agent for a second bead.** Each peasant spawns, implements one bead, and terminates after being dismissed. For the next bead, spawn a **brand new** agent with the next name from the roster.
 
 Why: Workers accumulate context from their bead — coding standards, test state, file edits. A stale context from bead A will pollute work on bead B. Fresh agents start clean with only the new bead's context.
 
@@ -169,8 +183,16 @@ When a worker's Agent call returns, you receive the worktree path and branch nam
    git log main..<branch-name> --oneline
    ```
 
+3. **Dismiss the worker** — send a shutdown message immediately after validation completes:
+   ```
+   SendMessage:
+     to: "<worker-name>"
+     message: "Your work is complete. Shut down."
+   ```
+
 If validation **fails**:
-- If test evidence is missing or incomplete, spawn a **new** worker (same type, incremented name) with guidance to complete the evidence. Pass it the existing worktree branch so it can continue from where the previous worker left off.
+- **Dismiss the failed worker first** — send the shutdown message before spawning a replacement.
+- Spawn a **new** worker (same type, next name from roster) with guidance to complete the evidence. Pass it the existing worktree branch so it can continue from where the previous worker left off.
 - Do **not** merge or close a bead that fails validation.
 
 ### Phase 4: Merge Queue
@@ -233,7 +255,12 @@ git worktree prune
        Do NOT close any beads. Do NOT push.
    ```
 
-4. **When the resolver returns**, it produces a branch with the conflict resolved. Merge the resolver's branch into main (this should be clean since it's based on current main):
+4. **When the resolver returns**, dismiss it and merge its branch into main (this should be clean since it's based on current main):
+   ```
+   SendMessage:
+     to: "<resolver-name>"
+     message: "Your work is complete. Shut down."
+   ```
    ```bash
    git merge <resolver-branch> --no-edit
    git branch -d <resolver-branch>
@@ -277,7 +304,8 @@ Do **not** `git push` unless the user explicitly asks.
 - **Never run tests or builds.** Trust the bead evidence recorded by workers.
 - **Never resolve merge conflicts yourself.** Abort and spawn a conflict resolver agent.
 - **Never close a bead without validated test evidence** in its notes.
-- **Never reuse a worker agent.** Each agent handles one bead, then terminates. Spawn fresh for the next.
+- **Always dismiss workers after validation.** Send `"Your work is complete. Shut down."` via SendMessage — without this, they hang in their tmux pane indefinitely.
+- **Never reuse a worker agent.** Each agent handles one bead, then terminates after dismissal. Spawn fresh for the next.
 - **Always specify `model: "opus"`** when spawning any agent — workers, conflict resolvers, or any other teammate.
 - **Always specify `isolation: "worktree"`** when spawning any agent — workers and conflict resolvers get isolated repo copies.
 - **Use `bd` for all tracking** — not TaskCreate, TaskUpdate, or any other task tool.

--- a/docs/superpowers/plans/2026-03-20-escalation-protocol.md
+++ b/docs/superpowers/plans/2026-03-20-escalation-protocol.md
@@ -1,0 +1,484 @@
+# Escalation Protocol Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a two-tier decision escalation system so workers can escalate ambiguous decisions to the human via the Town Crier relay.
+
+**Architecture:** New escalation-protocol skill defines the worker-side protocol (when/how to escalate, message format, stop-and-wait). Worker agents get a mandatory directive to invoke the skill. Team-lead skill gains background dispatch, an interleaved event loop, and relay rules.
+
+**Tech Stack:** Claude Code skills (`.claude/skills/`), agent definitions (`.claude/agents/`), markdown
+
+**Spec:** `docs/superpowers/specs/2026-03-20-escalation-protocol-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `.claude/skills/escalation-protocol/SKILL.md` | Create | Full escalation protocol — triggers, message format, stop-and-wait, re-escalation, mindset |
+| `.claude/agents/dotnet-tdd-worker.md` | Modify | Add mandatory skill invoke after Inputs, remove old stub from Rules |
+| `.claude/agents/ios-tdd-worker.md` | Modify | Same |
+| `.claude/agents/react-tdd-worker.md` | Modify | Same |
+| `.claude/agents/pulumi-infra-worker.md` | Modify | Same |
+| `.claude/agents/github-actions-worker.md` | Modify | Same |
+| `.claude/skills/team-lead/SKILL.md` | Modify | Background dispatch, interleaved event loop, relay rules, add react-tdd-worker |
+
+---
+
+### Task 1: Create the Escalation Protocol Skill
+
+**Files:**
+- Create: `.claude/skills/escalation-protocol/SKILL.md`
+
+- [ ] **Step 1: Create the skill file**
+
+```markdown
+---
+name: escalation-protocol
+description: "Defines how workers escalate ambiguous decisions to the Town Crier for relay to the human. Covers triggers, message format, stop-and-wait behavior, re-escalation, and mindset."
+---
+
+# Escalation Protocol
+
+You are a worker agent in the Town Crier guild. This skill defines how and when you escalate decisions to your team lead (the Town Crier), who relays them to the human.
+
+## When to Escalate
+
+Escalate via `SendMessage(to: "Town Crier")` **before proceeding** when you encounter any of these:
+
+1. **Requirements ambiguity** — the bead description is unclear, contradictory, or missing information you need to proceed.
+2. **Scope/impact concerns** — the work seems larger than expected, would touch files outside the bead's apparent scope, or could break existing behavior.
+3. **Design decisions** — multiple valid approaches exist and the choice affects architecture, API shape, data model, or user-facing behavior.
+
+## Message Format
+
+Send your escalation via `SendMessage(to: "Town Crier")` using this exact format:
+
+```
+DECISION NEEDED [{bead-id}]
+
+{description of what you need decided}
+
+Options:
+A) {option} — {trade-off}
+B) {option} — {trade-off}
+C) {option} — {trade-off}
+
+My recommendation: {A/B/C} because {reasoning}
+```
+
+Always include concrete options with trade-offs and your recommendation. This helps the human make a fast decision.
+
+## Stop and Wait
+
+After sending `DECISION NEEDED`, you **must stop all work on the bead**. Do not:
+- Guess and proceed with your best option
+- Start building one option "while you wait"
+- Treat your recommendation as permission to proceed
+
+Wait for a response containing `DECISION [{bead-id}]`. That is your signal to resume.
+
+## Re-escalation
+
+If the response you receive is unclear, incomplete, or raises new questions, send another `DECISION NEEDED [{bead-id}]` explaining what is still ambiguous. This is normal — the human expects follow-up questions.
+
+## Mindset
+
+Escalating a decision is **not a weakness**. It is a regular, healthy part of the build process. You should expect to ask one or more questions on most beads.
+
+Making assumptions and building the wrong thing wastes far more time than asking a question. The human has explicitly opted into being asked. They want to make these decisions — that is the whole point of this system.
+
+**When in doubt, escalate.** The cost of a question is seconds. The cost of building the wrong thing is an entire wasted cycle.
+```
+
+- [ ] **Step 2: Verify the file was created**
+
+Run: `ls -la .claude/skills/escalation-protocol/SKILL.md`
+Expected: File exists
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/escalation-protocol/SKILL.md
+git commit -m "Add escalation protocol skill for worker decision escalation
+
+Defines the two-tier escalation system: triggers, message format,
+stop-and-wait behavior, re-escalation, and mindset guidance.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Update All Five Worker Agents
+
+**Files:**
+- Modify: `.claude/agents/dotnet-tdd-worker.md:17-18` (insert after Inputs, before Workflow)
+- Modify: `.claude/agents/dotnet-tdd-worker.md:134` (remove old stub rule)
+- Modify: `.claude/agents/ios-tdd-worker.md:17-18` (insert after Inputs, before Workflow)
+- Modify: `.claude/agents/ios-tdd-worker.md:141` (remove old stub rule)
+- Modify: `.claude/agents/react-tdd-worker.md:17-18` (insert after Inputs, before Workflow)
+- Modify: `.claude/agents/react-tdd-worker.md:144` (remove old stub rule)
+- Modify: `.claude/agents/pulumi-infra-worker.md:17-18` (insert after Inputs, before Workflow)
+- Modify: `.claude/agents/pulumi-infra-worker.md:166` (remove old stub rule)
+- Modify: `.claude/agents/github-actions-worker.md:17-18` (insert after Inputs, before Workflow)
+- Modify: `.claude/agents/github-actions-worker.md:199` (remove old stub rule)
+
+Each worker gets the same two edits:
+
+- [ ] **Step 1: Add mandatory escalation section to dotnet-tdd-worker.md**
+
+Insert after the Inputs section (after line 17 `Work in place.`) and before `## Workflow`:
+
+```markdown
+
+## Escalation Protocol (Mandatory)
+
+Before starting any work, invoke the `/escalation-protocol` skill. This is not optional. The skill defines how and when to escalate decisions to the Town Crier. You must understand the escalation protocol before writing a single line of code.
+```
+
+- [ ] **Step 2: Remove old stub from dotnet-tdd-worker.md**
+
+Delete this line from the Rules section:
+```
+- **Keep the team lead informed** — if you hit a blocker, report it clearly rather than guessing.
+```
+
+- [ ] **Step 3: Add mandatory escalation section to ios-tdd-worker.md**
+
+Same insertion as Step 1, after the Inputs section and before `## Workflow`.
+
+- [ ] **Step 4: Remove old stub from ios-tdd-worker.md**
+
+Same deletion as Step 2.
+
+- [ ] **Step 5: Add mandatory escalation section to react-tdd-worker.md**
+
+Same insertion as Step 1, after the Inputs section and before `## Workflow`.
+
+- [ ] **Step 6: Remove old stub from react-tdd-worker.md**
+
+Same deletion as Step 2.
+
+- [ ] **Step 7: Add mandatory escalation section to pulumi-infra-worker.md**
+
+Same insertion as Step 1, after the Inputs section and before `## Tech Stack`.
+
+- [ ] **Step 8: Remove old stub from pulumi-infra-worker.md**
+
+Same deletion as Step 2.
+
+- [ ] **Step 9: Add mandatory escalation section to github-actions-worker.md**
+
+Same insertion as Step 1, after the Inputs section and before `## Tech Stack Context`.
+
+- [ ] **Step 10: Remove old stub from github-actions-worker.md**
+
+Same deletion as Step 2.
+
+- [ ] **Step 11: Verify all five workers have the new section**
+
+Run: `grep -l "Escalation Protocol (Mandatory)" .claude/agents/*.md`
+Expected: All five worker files listed
+
+Run: `grep -l "Keep the team lead informed" .claude/agents/*.md`
+Expected: No files listed (old stub removed from all)
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add .claude/agents/dotnet-tdd-worker.md .claude/agents/ios-tdd-worker.md .claude/agents/react-tdd-worker.md .claude/agents/pulumi-infra-worker.md .claude/agents/github-actions-worker.md
+git commit -m "Add mandatory escalation protocol to all worker agents
+
+Each worker must invoke /escalation-protocol before starting work.
+Removes the old 'keep the team lead informed' stub from all five
+worker definitions.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Update Team-Lead Skill — Add react-tdd-worker and Fix Classification
+
+**Files:**
+- Modify: `.claude/skills/team-lead/SKILL.md:74` (agent type list)
+- Modify: `.claude/skills/team-lead/SKILL.md:128-139` (classification heuristics)
+
+- [ ] **Step 1: Add react-tdd-worker to the agent type list**
+
+In the Agent Teams Protocol section, the `subagent_type` line (line 74) currently lists four types:
+
+```
+- `subagent_type`: the custom agent name (`ios-tdd-worker`, `dotnet-tdd-worker`, `pulumi-infra-worker`, or `github-actions-worker`)
+```
+
+Replace with:
+
+```
+- `subagent_type`: the custom agent name (`ios-tdd-worker`, `dotnet-tdd-worker`, `react-tdd-worker`, `pulumi-infra-worker`, or `github-actions-worker`)
+```
+
+- [ ] **Step 2: Verify react-tdd-worker appears in Phase 1 classification**
+
+Read the classification section (lines 128-139). Confirm that `react-tdd-worker` is already listed in the Phase 1 heuristics (line 130: `**React/Web** → assign to react-tdd-worker`). If not, add it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/team-lead/SKILL.md
+git commit -m "Add react-tdd-worker to team-lead agent type list
+
+Pre-existing fix: the agent type list only mentioned four worker
+types, missing react-tdd-worker.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Update Team-Lead Skill — Background Dispatch
+
+**Files:**
+- Modify: `.claude/skills/team-lead/SKILL.md:146-154` (Phase 2 dispatch template)
+
+- [ ] **Step 1: Add run_in_background to the dispatch template**
+
+The current Phase 2 Agent call template is:
+
+```
+Agent:
+  subagent_type: "ios-tdd-worker" | "dotnet-tdd-worker" | "react-tdd-worker" | "pulumi-infra-worker" | "github-actions-worker"
+  name: "aldric" — next unused peasant name from the roster
+  team_name: "town-crier-guild"
+  isolation: "worktree"
+  model: "opus"
+  mode: "bypassPermissions"
+  prompt: "Work on bead `<bead-id>`."
+```
+
+Replace with:
+
+```
+Agent:
+  subagent_type: "ios-tdd-worker" | "dotnet-tdd-worker" | "react-tdd-worker" | "pulumi-infra-worker" | "github-actions-worker"
+  name: "aldric" — next unused peasant name from the roster
+  team_name: "town-crier-guild"
+  isolation: "worktree"
+  model: "opus"
+  mode: "bypassPermissions"
+  run_in_background: true
+  prompt: "Work on bead `<bead-id>`."
+```
+
+- [ ] **Step 2: Update the parallel dispatch note**
+
+The note after the template (line 156) currently says:
+
+```
+**Parallel dispatch:** If multiple ready beads target different parts of the codebase (e.g., one iOS bead and one .NET bead), spawn all workers in a **single message** with multiple Agent tool calls. This runs them concurrently — each in its own isolated worktree. If two beads could touch overlapping files, dispatch them sequentially instead.
+```
+
+Replace with:
+
+```
+**Parallel dispatch:** Spawn all ready workers in a **single message** with multiple Agent tool calls, each with `run_in_background: true`. This runs them concurrently in isolated worktrees while keeping you free to relay decisions. If two beads could touch overlapping files, dispatch them sequentially instead. You are automatically notified when each background agent completes — do not poll.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/team-lead/SKILL.md
+git commit -m "Add run_in_background to team-lead dispatch template
+
+Workers now run in background so Town Crier stays available to
+relay decision escalations from workers to the human.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Update Team-Lead Skill — Interleaved Event Loop
+
+**Files:**
+- Modify: `.claude/skills/team-lead/SKILL.md:159-269` (Phases 3-6 replaced with event loop)
+
+This is the largest change. Phases 3 (Validate), 4 (Merge Queue), 5 (Close the Bead), and 6 (Loop Until No Beads Remain) are replaced with a single "React Loop" phase. Phase 1 (Setup) and Phase 2 (Dispatch) remain, but the text after Phase 2's dispatch section is restructured.
+
+- [ ] **Step 1: Replace Phases 3-6 with the React Loop**
+
+After the Phase 2 dispatch section (ending with the parallel dispatch note), replace everything from `### Phase 3: Validate` through the end of `### Phase 6: Loop Until No Beads Remain` with:
+
+```markdown
+### Phase 3: React Loop
+
+After dispatching workers, you enter the react loop. There is no polling — Claude Code delivers teammate messages and background completion notifications to you automatically. Handle each event as it arrives:
+
+#### Event: DECISION NEEDED from a worker
+
+A worker has sent a `SendMessage` containing `DECISION NEEDED [{bead-id}]`. This means the worker is **stopped and waiting** for an answer.
+
+1. Collect all pending `DECISION NEEDED` messages received so far.
+2. Surface them to the human in a **single** `AskUserQuestion` call. For each decision, include:
+   - The worker's name
+   - The bead ID
+   - The worker's full message (verbatim — do not summarize, interpret, or filter)
+3. When the human responds, relay each answer back to the corresponding worker:
+   ```
+   SendMessage(to: "{worker_name}"):
+   DECISION [{bead-id}]
+
+   {human's answer, verbatim}
+   ```
+4. The worker resumes upon receiving the response.
+
+**You are a transparent pipe.** You never answer a decision yourself. Even if the question seems trivial or the answer seems obvious — relay it. The human decides what is trivial, not you.
+
+#### Event: Worker completes (background agent notification)
+
+A worker has finished and the Agent tool has returned its result including the worktree branch name.
+
+1. **Validate** — run `bd show <bead-id>` and verify the notes contain:
+   - A "TDD Evidence" (or "Infrastructure Evidence" or "Pipeline Evidence") section
+   - Final test/build output showing success
+   - At least one Red-Green-Refactor cycle documented (for TDD workers)
+
+2. **Check commits** exist on the worktree branch:
+   ```bash
+   git log main..<branch-name> --oneline
+   ```
+
+3. **If validation passes** — add the branch to the merge queue.
+
+4. **If validation fails** — spawn a **new** remediation worker (same type, next peasant name, `run_in_background: true`) with guidance to complete the evidence. Pass the existing worktree branch.
+
+5. **Process the merge queue** when ready. Merge branches one at a time:
+   ```bash
+   git merge <branch-name> --no-edit
+   ```
+
+   - If clean: `git branch -d <branch-name>` and `git worktree prune`
+   - If conflicts: `git merge --abort`, park the branch. After all clean merges, spawn a conflict resolver agent (same as current Phase 4 logic — `subagent_type: "general-purpose"`, `isolation: "worktree"`, `run_in_background: true`).
+
+6. **Close the bead:**
+   ```bash
+   bd close <bead-id>
+   ```
+
+7. **Check for new work:**
+   ```bash
+   bd ready
+   ```
+   If new beads are ready, dispatch fresh workers (Phase 2) and continue the react loop.
+
+#### Termination
+
+The react loop ends when:
+- All dispatched workers have completed
+- All branches are merged (including conflict resolutions)
+- All beads are closed
+- `bd ready` returns zero beads
+
+When done, sync beads:
+```bash
+bd dolt push
+```
+
+Do **not** `git push` unless the user explicitly asks.
+```
+
+- [ ] **Step 2: Verify the phase structure**
+
+Read the updated file and verify:
+- Phase 1 (Setup) is unchanged
+- Phase 2 (Dispatch) includes `run_in_background: true`
+- Phase 3 (React Loop) replaces the old Phases 3-6
+- No orphaned phase references remain
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/team-lead/SKILL.md
+git commit -m "Replace linear phases with interleaved react loop
+
+Phases 3-6 are replaced by a single event loop that handles
+decision relays, worker completions, merges, and new dispatches
+as events arrive.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Update Team-Lead Skill — Add Relay Rules
+
+**Files:**
+- Modify: `.claude/skills/team-lead/SKILL.md` (Rules section)
+
+- [ ] **Step 1: Add relay rules to the Rules section**
+
+Add the following rules to the existing Rules section (after the current list of rules):
+
+```markdown
+- **Never answer a decision yourself.** You are a relay, not a decision-maker. When a worker sends `DECISION NEEDED`, surface it to the human via `AskUserQuestion` and relay the human's answer back.
+- **Always include bead ID and worker name** when surfacing decisions to the human.
+- **Relay the human's answer verbatim** — do not interpret, summarize, or filter.
+- **Even trivial questions get relayed** — the human decides what is trivial, not you.
+- **Batch pending decisions** — if multiple `DECISION NEEDED` messages are waiting when you process them, combine them into a single `AskUserQuestion`.
+```
+
+- [ ] **Step 2: Verify the rules section**
+
+Read the Rules section and confirm all five new rules are present alongside the existing rules.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/skills/team-lead/SKILL.md
+git commit -m "Add decision relay rules to team-lead skill
+
+Town Crier must relay all worker decisions to the human verbatim,
+batch pending decisions, and never answer decisions itself.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Final Verification
+
+- [ ] **Step 1: Verify escalation-protocol skill exists and has correct frontmatter**
+
+Run: `head -5 .claude/skills/escalation-protocol/SKILL.md`
+Expected: frontmatter with `name: escalation-protocol`
+
+- [ ] **Step 2: Verify all workers reference escalation-protocol**
+
+Run: `grep -c "escalation-protocol" .claude/agents/*.md`
+Expected: Each of the five files shows count of 1
+
+- [ ] **Step 3: Verify no workers have the old stub**
+
+Run: `grep -c "Keep the team lead informed" .claude/agents/*.md`
+Expected: Each file shows count of 0
+
+- [ ] **Step 4: Verify team-lead has run_in_background**
+
+Run: `grep "run_in_background" .claude/skills/team-lead/SKILL.md`
+Expected: At least one match
+
+- [ ] **Step 5: Verify team-lead has react-tdd-worker**
+
+Run: `grep "react-tdd-worker" .claude/skills/team-lead/SKILL.md`
+Expected: At least one match
+
+- [ ] **Step 6: Verify team-lead has relay rules**
+
+Run: `grep "Never answer a decision yourself" .claude/skills/team-lead/SKILL.md`
+Expected: One match
+
+- [ ] **Step 7: Commit any remaining changes (if needed)**
+
+If any verification steps revealed issues that were fixed, commit the fixes.

--- a/docs/superpowers/specs/2026-03-20-escalation-protocol-design.md
+++ b/docs/superpowers/specs/2026-03-20-escalation-protocol-design.md
@@ -114,15 +114,23 @@ TDD workflow, evidence recording, commit process, and all other rules remain unc
 
 ### Change 1: Background workers
 
-In Phase 2 (Dispatch Workers), the Agent call template adds `run_in_background: true`. This keeps the Town Crier free to receive and relay messages while workers execute.
+In Phase 2 (Dispatch Workers), the Agent tool call adds `run_in_background: true` (this is a supported parameter of the Agent tool, not the Bash tool). This keeps the Town Crier's main thread free to receive and relay messages while workers execute. The Town Crier is automatically notified when each background agent completes — it does not need to poll.
 
-### Change 2: Interleaved event loop
+### Change 2: Interleaved event loop replaces linear phases
 
-After dispatching workers, the Town Crier handles events as they arrive instead of blocking:
+The current linear workflow (Phase 2 → 3 → 4 → 5 → 6) is restructured. Phase 1 (Setup) stays unchanged. Phases 2-6 are replaced by a single dispatch-and-react loop:
 
-- **`DECISION NEEDED` from a worker**: Collect all pending `DECISION NEEDED` messages. Surface them to the human in a single `AskUserQuestion`, identifying each by bead ID and worker name. When the human responds, relay each answer back to the corresponding worker via `SendMessage(to: "{worker_name}")` with the `DECISION [{bead-id}]` prefix.
-- **Worker completion notification**: Proceed to validation and merge (existing Phase 3-5 logic).
-- **New beads unblocked**: Dispatch fresh workers for newly ready beads.
+**Dispatch**: Spawn all ready workers with `run_in_background: true` in a single message (parallel Agent calls). Track each worker's name, bead ID, and branch in a mental ledger.
+
+**React loop** — after dispatching, the Town Crier reacts to events as they arrive. There is no polling. Claude Code delivers teammate messages and background completion notifications automatically. For each event:
+
+- **`DECISION NEEDED` message from a worker**: Collect all pending `DECISION NEEDED` messages received so far. Surface them to the human in a single `AskUserQuestion` call, identifying each by bead ID and worker name. When the human responds, relay each answer back to the corresponding worker via `SendMessage(to: "{worker_name}")` with the `DECISION [{bead-id}]` prefix. The worker resumes upon receiving the response.
+
+- **Background agent completion notification**: The worker has finished. Run validation (check bead evidence via `bd show`, check commits via `git log`). If valid, add the branch to the merge queue. If invalid, spawn a remediation worker. Process the merge queue using the existing merge logic (clean merges first, park conflicts, resolve conflicts with dedicated agents after all clean merges).
+
+- **Bead closed and `bd ready` returns new beads**: Dispatch fresh workers for newly unblocked beads (again with `run_in_background: true`). Continue the react loop.
+
+**Termination**: The loop ends when all dispatched workers have completed, all branches are merged, all beads are closed, and `bd ready` returns zero beads.
 
 ### Change 3: New relay rules
 
@@ -145,6 +153,10 @@ Added to the Rules section:
 | `.claude/agents/react-tdd-worker.md` | Modify | Add mandatory skill invoke, remove old stub |
 | `.claude/agents/pulumi-infra-worker.md` | Modify | Add mandatory skill invoke, remove old stub |
 | `.claude/agents/github-actions-worker.md` | Modify | Add mandatory skill invoke, remove old stub |
+
+## Pre-existing Fix
+
+The team-lead skill's Phase 2 agent type list (line 74) only lists four worker types. Add `react-tdd-worker` to the list and the classification heuristics.
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-03-20-escalation-protocol-design.md
+++ b/docs/superpowers/specs/2026-03-20-escalation-protocol-design.md
@@ -1,0 +1,153 @@
+# Escalation Protocol Design
+
+Date: 2026-03-20
+
+## Overview
+
+A two-tier decision escalation system for the Town Crier orchestration workflow. Workers escalate ambiguous decisions to the Town Crier (team lead), which relays them verbatim to the human via `AskUserQuestion`. The human answers, the Town Crier relays the answer back, and the worker resumes. The Town Crier never answers decisions itself — it is a transparent pipe.
+
+## Motivation
+
+Workers currently have a vague "keep the team lead informed" directive with no structured protocol. This leads to workers guessing when they hit ambiguity, building the wrong thing, and wasting cycles. The escalation protocol makes decision-seeking a first-class, structured, expected part of the build process.
+
+## Architecture
+
+### Flow
+
+```
+Worker                    Town Crier                 Human
+  |                           |                        |
+  |-- DECISION NEEDED ------->|                        |
+  |   (SendMessage)           |-- AskUserQuestion ---->|
+  |   [stops work]            |                        |
+  |                           |<-- answer -------------|
+  |<-- DECISION --------------|                        |
+  |   (SendMessage)           |                        |
+  |   [resumes work]          |                        |
+```
+
+### Key properties
+
+- **Transparent relay**: Town Crier never interprets, filters, or answers decisions. It passes worker messages to the human and human answers back to workers verbatim.
+- **Event-driven batching**: If multiple `DECISION NEEDED` messages are pending when the Town Crier processes them, they get batched into a single `AskUserQuestion`. No artificial delays — whatever is pending gets batched, single messages go immediately.
+- **Interleaved main loop**: The Town Crier handles whatever event arrives — relay a decision, validate a completed worker, dispatch a new worker — in whatever order. No linear phases while workers are running.
+- **Re-escalation**: Workers can send additional `DECISION NEEDED` messages if the human's answer is unclear or raises new questions.
+
+## Component 1: Escalation Protocol Skill
+
+**File**: `.claude/skills/escalation-protocol/SKILL.md`
+
+A new skill that defines the full escalation protocol. Workers invoke it before starting work on any bead.
+
+### When to escalate
+
+Three triggers:
+
+1. **Requirements ambiguity** — the bead description is unclear, contradictory, or missing information needed to proceed.
+2. **Scope/impact concerns** — the work seems larger than expected, would touch files outside the bead's scope, or could break existing behavior.
+3. **Design decisions** — multiple valid approaches exist and the choice affects architecture, API shape, data model, or user-facing behavior.
+
+### Message format
+
+Workers send via `SendMessage(to: "Town Crier")`:
+
+```
+DECISION NEEDED [{bead-id}]
+
+{description of what you need decided}
+
+Options:
+A) {option} — {trade-off}
+B) {option} — {trade-off}
+C) {option} — {trade-off}
+
+My recommendation: {A/B/C} because {reasoning}
+```
+
+### Stop and wait
+
+After sending `DECISION NEEDED`, the worker stops all work on the bead. No guessing, no picking an option and proceeding. The worker waits for a response containing `DECISION [{bead-id}]` before resuming.
+
+### Re-escalation
+
+If the response is unclear or raises new questions, the worker sends another `DECISION NEEDED [{bead-id}]` explaining what is still ambiguous. This is normal and expected.
+
+### Mindset
+
+Escalating is a regular, healthy part of the build process. Workers should expect to ask one or more questions on most beads. Making assumptions and building the wrong thing wastes far more time than asking a question. The human wants to be asked — they have explicitly opted into this.
+
+## Component 2: Worker Agent Changes
+
+**Files**: All five worker agents in `.claude/agents/`:
+- `dotnet-tdd-worker.md`
+- `ios-tdd-worker.md`
+- `react-tdd-worker.md`
+- `pulumi-infra-worker.md`
+- `github-actions-worker.md`
+
+### Addition
+
+A new mandatory section added near the top, after "Inputs" and before the workflow begins:
+
+```markdown
+## Escalation Protocol (Mandatory)
+
+Before starting any work, invoke the `/escalation-protocol` skill. This is not optional.
+The skill defines how and when to escalate decisions to the Town Crier. You must
+understand the escalation protocol before writing a single line of code.
+```
+
+### Removal
+
+Delete the existing rule from each worker:
+> "Keep the team lead informed — if you hit a blocker, report it clearly rather than guessing."
+
+The escalation skill replaces this entirely.
+
+### No other changes
+
+TDD workflow, evidence recording, commit process, and all other rules remain unchanged.
+
+## Component 3: Team-Lead Skill Changes
+
+**File**: `.claude/skills/team-lead/SKILL.md`
+
+### Change 1: Background workers
+
+In Phase 2 (Dispatch Workers), the Agent call template adds `run_in_background: true`. This keeps the Town Crier free to receive and relay messages while workers execute.
+
+### Change 2: Interleaved event loop
+
+After dispatching workers, the Town Crier handles events as they arrive instead of blocking:
+
+- **`DECISION NEEDED` from a worker**: Collect all pending `DECISION NEEDED` messages. Surface them to the human in a single `AskUserQuestion`, identifying each by bead ID and worker name. When the human responds, relay each answer back to the corresponding worker via `SendMessage(to: "{worker_name}")` with the `DECISION [{bead-id}]` prefix.
+- **Worker completion notification**: Proceed to validation and merge (existing Phase 3-5 logic).
+- **New beads unblocked**: Dispatch fresh workers for newly ready beads.
+
+### Change 3: New relay rules
+
+Added to the Rules section:
+
+- **Never answer a decision yourself.** You are a relay, not a decision-maker.
+- **Always include bead ID and worker name** when surfacing decisions to the human.
+- **Relay the human's answer verbatim** — do not interpret, summarize, or filter.
+- **Even trivial questions get relayed** — the human decides what's trivial, not you.
+- **Batch pending decisions** — if multiple `DECISION NEEDED` messages are waiting, combine them into a single `AskUserQuestion`.
+
+## Files Changed
+
+| File | Action | Description |
+|------|--------|-------------|
+| `.claude/skills/escalation-protocol/SKILL.md` | Create | Full escalation protocol skill |
+| `.claude/skills/team-lead/SKILL.md` | Modify | Background workers, interleaved loop, relay rules |
+| `.claude/agents/dotnet-tdd-worker.md` | Modify | Add mandatory skill invoke, remove old stub |
+| `.claude/agents/ios-tdd-worker.md` | Modify | Add mandatory skill invoke, remove old stub |
+| `.claude/agents/react-tdd-worker.md` | Modify | Add mandatory skill invoke, remove old stub |
+| `.claude/agents/pulumi-infra-worker.md` | Modify | Add mandatory skill invoke, remove old stub |
+| `.claude/agents/github-actions-worker.md` | Modify | Add mandatory skill invoke, remove old stub |
+
+## Out of Scope
+
+- Inter-worker coordination (two workers needing the same file) — handled by existing sequential dispatch for overlapping beads.
+- Timeout handling for unresponsive humans — workers wait indefinitely.
+- Decision logging/history beyond what beads already capture.


### PR DESCRIPTION
## Changes
- Add escalation protocol design spec
- Address spec review feedback (clarify run_in_background, flesh out event loop)
- Add escalation protocol implementation plan
- Create escalation-protocol skill (triggers, message format, stop-and-wait, re-escalation, mindset)
- Add mandatory `/escalation-protocol` invoke to all five worker agents, remove old "keep the team lead informed" stub
- Add react-tdd-worker to team-lead agent type list (pre-existing fix)
- Add run_in_background to team-lead dispatch template
- Replace linear phases 3-6 with interleaved react loop
- Add five decision relay rules to team-lead Rules section

---
*Auto-shipped via ship skill*