### PR TITLE
Fix Azure infra deployment and wire up iOS auth navigation

### DIFF
--- a/infra/Program.cs
+++ b/infra/Program.cs
@@ -344,11 +344,16 @@ return await Pulumi.Deployment.RunAsync(() =>
     {
         Name = $"swa-town-crier-{env}",
         ResourceGroupName = resourceGroup.Name,
-        Location = resourceGroup.Location,
+        Location = "westeurope",
         Sku = new Pulumi.AzureNative.Web.Inputs.SkuDescriptionArgs
         {
             Name = "Free",
             Tier = "Free",
+        },
+        BuildProperties = new Pulumi.AzureNative.Web.Inputs.StaticSiteBuildPropertiesArgs
+        {
+            AppLocation = "/",
+            OutputLocation = "",
         },
         Tags = tags,
     });

--- a/infra/Pulumi.yaml
+++ b/infra/Pulumi.yaml
@@ -1,6 +1,3 @@
 name: town-crier
-runtime:
-  name: dotnet
-  options:
-    binary: ./bin/Release/net10.0/town-crier.infra
+runtime: dotnet
 description: Town Crier infrastructure - Azure resources for planning application notifications

--- a/infra/town-crier.infra.csproj
+++ b/infra/town-crier.infra.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <PublishAot>true</PublishAot>
+    <PublishAot>false</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>

--- a/mobile/ios/packages/town-crier-data/Sources/Auth/AuthCallbackHandler.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Auth/AuthCallbackHandler.swift
@@ -1,0 +1,8 @@
+import Auth0
+import Foundation
+
+public enum AuthCallbackHandler {
+    public static func handle(url: URL) {
+        WebAuthentication.resume(with: url)
+    }
+}

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/InMemoryPlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/InMemoryPlanningApplicationRepository.swift
@@ -9,7 +9,10 @@ public final class InMemoryPlanningApplicationRepository: PlanningApplicationRep
     }
 
     public func fetchApplications(for authority: LocalAuthority) async throws -> [PlanningApplication] {
-        applications.filter { $0.authority == authority }
+        if authority.code.isEmpty {
+            return applications
+        }
+        return applications.filter { $0.authority == authority }
     }
 
     public func fetchApplication(by id: PlanningApplicationId) async throws -> PlanningApplication {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -58,11 +58,7 @@ public final class AppCoordinator: ObservableObject {
     }
 
     public func makeMapViewModel(watchZone: WatchZone) -> MapViewModel {
-        let viewModel = MapViewModel(repository: repository, watchZone: watchZone)
-        viewModel.onApplicationSelected = { [weak self] id in
-            self?.showApplicationDetail(id)
-        }
-        return viewModel
+        MapViewModel(repository: repository, watchZone: watchZone)
     }
 
     public func makeApplicationListViewModel(

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
@@ -14,7 +14,7 @@ public final class SettingsViewModel: ObservableObject {
     @Published public private(set) var error: DomainError?
     @Published public var isShowingDeleteConfirmation = false
 
-    var onLogout: (() -> Void)?
+    public var onLogout: (() -> Void)?
 
     private let authService: AuthenticationService
     private let subscriptionService: SubscriptionService

--- a/mobile/ios/town-crier-app/Sources/SampleData.swift
+++ b/mobile/ios/town-crier-app/Sources/SampleData.swift
@@ -1,0 +1,142 @@
+#if DEBUG
+import Foundation
+import TownCrierDomain
+
+enum SampleData {
+    static let camden = LocalAuthority(code: "CMD", name: "Camden")
+
+    static let applications: [PlanningApplication] = {
+        let calendar = Calendar.current
+        let now = Date()
+
+        func daysAgo(_ days: Int) -> Date {
+            calendar.date(byAdding: .day, value: -days, to: now)!
+        }
+
+        return [
+            PlanningApplication(
+                id: PlanningApplicationId("app-001"),
+                reference: ApplicationReference("2026/0142/P"),
+                authority: camden,
+                status: .underReview,
+                receivedDate: daysAgo(3),
+                description: "Erection of single-storey rear extension and associated landscaping",
+                address: "14 Dartmouth Park Road, London NW5 1SU",
+                location: try? Coordinate(latitude: 51.5615, longitude: -0.1378),
+                portalUrl: URL(string: "https://planit.org.uk/planapplic/example1"),
+                statusHistory: [
+                    StatusEvent(status: .underReview, date: daysAgo(3)),
+                ]
+            ),
+            PlanningApplication(
+                id: PlanningApplicationId("app-002"),
+                reference: ApplicationReference("2026/0098/F"),
+                authority: camden,
+                status: .approved,
+                receivedDate: daysAgo(45),
+                description: "Change of use from retail (Class E) to restaurant (Sui Generis) with extraction flue to rear",
+                address: "87 Kentish Town Road, London NW1 8NY",
+                location: try? Coordinate(latitude: 51.5475, longitude: -0.1420),
+                portalUrl: URL(string: "https://planit.org.uk/planapplic/example2"),
+                statusHistory: [
+                    StatusEvent(status: .underReview, date: daysAgo(45)),
+                    StatusEvent(status: .approved, date: daysAgo(5)),
+                ]
+            ),
+            PlanningApplication(
+                id: PlanningApplicationId("app-003"),
+                reference: ApplicationReference("2026/0201/P"),
+                authority: camden,
+                status: .underReview,
+                receivedDate: daysAgo(7),
+                description: "Conversion of existing loft space including rear dormer window and two front rooflights",
+                address: "31 Lady Margaret Road, London NW5 2NH",
+                location: try? Coordinate(latitude: 51.5560, longitude: -0.1445),
+                portalUrl: URL(string: "https://planit.org.uk/planapplic/example3"),
+                statusHistory: [
+                    StatusEvent(status: .underReview, date: daysAgo(7)),
+                ]
+            ),
+            PlanningApplication(
+                id: PlanningApplicationId("app-004"),
+                reference: ApplicationReference("2025/4871/F"),
+                authority: camden,
+                status: .refused,
+                receivedDate: daysAgo(90),
+                description: "Demolition of existing garage and erection of two-storey dwelling house",
+                address: "Rear of 5 Highgate West Hill, London N6 6BU",
+                location: try? Coordinate(latitude: 51.5680, longitude: -0.1490),
+                portalUrl: URL(string: "https://planit.org.uk/planapplic/example4"),
+                statusHistory: [
+                    StatusEvent(status: .underReview, date: daysAgo(90)),
+                    StatusEvent(status: .refused, date: daysAgo(12)),
+                ]
+            ),
+            PlanningApplication(
+                id: PlanningApplicationId("app-005"),
+                reference: ApplicationReference("2026/0055/L"),
+                authority: camden,
+                status: .approved,
+                receivedDate: daysAgo(60),
+                description: "Listed building consent for internal alterations including removal of non-original partition walls and installation of new kitchen",
+                address: "12 Church Row, Hampstead, London NW3 6UP",
+                location: try? Coordinate(latitude: 51.5575, longitude: -0.1775),
+                portalUrl: URL(string: "https://planit.org.uk/planapplic/example5"),
+                statusHistory: [
+                    StatusEvent(status: .underReview, date: daysAgo(60)),
+                    StatusEvent(status: .approved, date: daysAgo(8)),
+                ]
+            ),
+            PlanningApplication(
+                id: PlanningApplicationId("app-006"),
+                reference: ApplicationReference("2026/0178/P"),
+                authority: camden,
+                status: .underReview,
+                receivedDate: daysAgo(10),
+                description: "Installation of replacement windows to front and rear elevations (conservation area)",
+                address: "44 Grafton Terrace, London NW5 4JA",
+                location: try? Coordinate(latitude: 51.5530, longitude: -0.1465),
+                portalUrl: URL(string: "https://planit.org.uk/planapplic/example6"),
+                statusHistory: [
+                    StatusEvent(status: .underReview, date: daysAgo(10)),
+                ]
+            ),
+            PlanningApplication(
+                id: PlanningApplicationId("app-007"),
+                reference: ApplicationReference("2026/0033/F"),
+                authority: camden,
+                status: .withdrawn,
+                receivedDate: daysAgo(55),
+                description: "Erection of roof terrace with glazed balustrade at third-floor level",
+                address: "Unit 3, 199 Arlington Road, London NW1 7HA",
+                location: try? Coordinate(latitude: 51.5390, longitude: -0.1465),
+                portalUrl: URL(string: "https://planit.org.uk/planapplic/example7"),
+                statusHistory: [
+                    StatusEvent(status: .underReview, date: daysAgo(55)),
+                    StatusEvent(status: .withdrawn, date: daysAgo(20)),
+                ]
+            ),
+            PlanningApplication(
+                id: PlanningApplicationId("app-008"),
+                reference: ApplicationReference("2026/0210/P"),
+                authority: camden,
+                status: .underReview,
+                receivedDate: daysAgo(2),
+                description: "Construction of basement level beneath existing garden for use as home gym and cinema room",
+                address: "8 Nassington Road, London NW3 2TY",
+                location: try? Coordinate(latitude: 51.5635, longitude: -0.1540),
+                portalUrl: URL(string: "https://planit.org.uk/planapplic/example8"),
+                statusHistory: [
+                    StatusEvent(status: .underReview, date: daysAgo(2)),
+                ]
+            ),
+        ]
+    }()
+
+    static let watchZone: WatchZone = {
+        let centre = try! Coordinate(latitude: 51.5550, longitude: -0.1450)
+        let postcode = try! Postcode("NW5 1SU")
+        return try! WatchZone(postcode: postcode, centre: centre, radiusMetres: 2000)
+    }()
+}
+#endif

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -9,11 +9,20 @@ struct TownCrierApp: App {
     @StateObject private var coordinator: AppCoordinator
     @StateObject private var loginViewModel: LoginViewModel
     @StateObject private var forceUpdateViewModel: ForceUpdateViewModel
+    @StateObject private var settingsViewModel: SettingsViewModel
+    @StateObject private var applicationListViewModel: ApplicationListViewModel
+    @StateObject private var mapViewModel: MapViewModel
     private let crashReporter: CrashReporter
     private let notificationDelegate: NotificationDelegate
 
     init() {
+        #if DEBUG
+        let repository = InMemoryPlanningApplicationRepository(
+            applications: SampleData.applications
+        )
+        #else
         let repository = InMemoryPlanningApplicationRepository()
+        #endif
 
         #if DEBUG
         let auth0Config = Auth0Config(
@@ -40,12 +49,42 @@ struct TownCrierApp: App {
             versionConfigService: versionConfigService
         )
         _coordinator = StateObject(wrappedValue: appCoordinator)
-        _loginViewModel = StateObject(
-            wrappedValue: appCoordinator.makeLoginViewModel()
-        )
+
+        let loginVM = appCoordinator.makeLoginViewModel()
+        _loginViewModel = StateObject(wrappedValue: loginVM)
+
         _forceUpdateViewModel = StateObject(
             wrappedValue: appCoordinator.makeForceUpdateViewModel()
         )
+
+        #if DEBUG
+        let listVM = appCoordinator.makeApplicationListViewModel(
+            authority: SampleData.camden
+        )
+        let mapVM = appCoordinator.makeMapViewModel(watchZone: SampleData.watchZone)
+        #else
+        let listVM = appCoordinator.makeApplicationListViewModel(
+            authority: LocalAuthority(code: "", name: "")
+        )
+        let mapVM = appCoordinator.makeMapViewModel(
+            watchZone: try! WatchZone(
+                postcode: try! Postcode("SW1A 1AA"),
+                centre: try! Coordinate(latitude: 51.5074, longitude: -0.1278),
+                radiusMetres: 1000
+            )
+        )
+        #endif
+
+        _applicationListViewModel = StateObject(wrappedValue: listVM)
+        _mapViewModel = StateObject(wrappedValue: mapVM)
+
+        let settingsVM = appCoordinator.makeSettingsViewModel()
+        settingsVM.onLogout = {
+            Task { @MainActor in
+                await loginVM.logout()
+            }
+        }
+        _settingsViewModel = StateObject(wrappedValue: settingsVM)
 
         let delegate = NotificationDelegate(coordinator: appCoordinator)
         notificationDelegate = delegate
@@ -64,10 +103,13 @@ struct TownCrierApp: App {
                         appStoreURL: URL(string: "https://apps.apple.com/app/town-crier/id000000000")
                     )
                 } else if loginViewModel.isAuthenticated {
-                    HomeView(viewModel: coordinator.makeHomeViewModel())
+                    mainTabView
                 } else {
                     LoginView(viewModel: loginViewModel)
                 }
+            }
+            .onOpenURL { url in
+                AuthCallbackHandler.handle(url: url)
             }
             .task {
                 await forceUpdateViewModel.checkVersion()
@@ -86,5 +128,44 @@ struct TownCrierApp: App {
                 }
             }
         }
+    }
+
+    private var mainTabView: some View {
+        TabView {
+            NavigationStack {
+                ApplicationListView(viewModel: applicationListViewModel)
+            }
+            .sheet(item: $coordinator.detailApplication) { application in
+                NavigationStack {
+                    ApplicationDetailView(
+                        viewModel: coordinator.makeApplicationDetailViewModel(
+                            application: application
+                        )
+                    )
+                }
+            }
+            .tabItem {
+                Label("Applications", systemImage: "doc.text.magnifyingglass")
+            }
+
+            NavigationStack {
+                MapView(viewModel: mapViewModel)
+                    .navigationTitle("Map")
+                    #if os(iOS)
+                    .navigationBarTitleDisplayMode(.inline)
+                    #endif
+            }
+            .tabItem {
+                Label("Map", systemImage: "map")
+            }
+
+            NavigationStack {
+                SettingsView(viewModel: settingsViewModel)
+            }
+            .tabItem {
+                Label("Settings", systemImage: "gearshape")
+            }
+        }
+        .tint(Color.tcAmber)
     }
 }


### PR DESCRIPTION
## Changes
- **Infra:** Remove PublishAot from Pulumi project (incompatible with Pulumi SDK), use standard dotnet runtime, set SWA location to westeurope (Free tier unavailable in uksouth), add required BuildProperties for SWA creation
- **iOS:** Add AuthCallbackHandler for Auth0 redirects, add SampleData for debug builds, implement TabView-based navigation with app list/map/settings tabs, fix InMemoryRepository empty-authority handling, simplify MapViewModel creation, make SettingsViewModel.onLogout public

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tabbed navigation with separate sections for Applications, Map, and Settings.
  * Implemented authentication callback handling for seamless auth flow integration.
  * Enabled logout functionality in Settings.

* **Chores**
  * Updated infrastructure configuration and build settings for deployment.
  * Added debug sample data for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->