### PR TITLE
Fix CI pipeline failures across all workflows

### DIFF
--- a/api/global.json
+++ b/api/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/mobile/ios/.swiftlint.yml
+++ b/mobile/ios/.swiftlint.yml
@@ -26,8 +26,9 @@ analyzer_rules:
   - unused_import
 
 included:
-  - Sources
-  - Tests
+  - packages
+  - town-crier-app/Sources
+  - town-crier-tests/Sources
 
 excluded:
   - .build

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -154,20 +154,4 @@ struct AppCoordinatorTests {
         #expect(sut.isOnboardingComplete)
     }
 
-    // MARK: - Map selection triggers detail
-
-    @Test func mapViewModel_onApplicationSelected_fetchesAndSetsDetail() async throws {
-        let (sut, spy) = makeSUT()
-        spy.fetchApplicationResult = .success(.approved)
-        let mapVM = sut.makeMapViewModel(watchZone: .cambridge)
-
-        // Simulate the map selecting an application
-        mapVM.onApplicationSelected?(PlanningApplicationId("APP-002"))
-
-        // Give the async Task time to complete
-        try await Task.sleep(for: .milliseconds(50))
-
-        #expect(sut.detailApplication == .approved)
-        #expect(spy.fetchApplicationCalls == [PlanningApplicationId("APP-002")])
-    }
 }


### PR DESCRIPTION
## Changes
- Add `api/global.json` pinning .NET SDK 10.0.100 — both Infra CI and API CI reference this file for `setup-dotnet`
- Update `.swiftlint.yml` included paths from `Sources`/`Tests` to `packages`/`town-crier-app/Sources`/`town-crier-tests/Sources` to match the actual SPM directory structure
- Remove orphaned `mapViewModel_onApplicationSelected_fetchesAndSetsDetail` test — the coordinator no longer wires that callback (simplified in PR #8)
- Web CI should now pass with the `AZURE_STATIC_WEB_APPS_API_TOKEN` secret set

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated .NET SDK configuration.
  * Refined code analysis tool configuration.

* **Tests**
  * Removed an obsolete test case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->