### PR TITLE
Add ADRs for web stack, polling prioritisation, and Gov.uk data provider

### DIFF
--- a/docs/adr/0011-web-frontend-stack.md
+++ b/docs/adr/0011-web-frontend-stack.md
@@ -1,0 +1,38 @@
+# 0011. Web Frontend Stack: Vite + React 19 + TypeScript
+
+Date: 2026-03-19
+
+## Status
+
+Accepted
+
+## Context
+
+Town Crier needed a public-facing web presence for the landing page and marketing site. The existing monorepo contained only a .NET API backend and native iOS app. We needed to choose a frontend framework, build tool, hosting strategy, and styling approach for a new `/web` directory.
+
+Key requirements:
+- Fast static site performance (landing page is content-heavy, no SSR needed)
+- Type safety consistent with the project's strict typing philosophy
+- Low hosting cost at early-stage scale
+- CI/CD with PR preview environments
+- Design system consistency with the existing iOS app (shared design tokens)
+
+## Decision
+
+We adopt the following web frontend stack:
+
+- **Framework:** React 19 with TypeScript 5.9 in strict mode (including `noUncheckedIndexedAccess`)
+- **Build tool:** Vite 8 with the `@vitejs/plugin-react` plugin
+- **Styling:** CSS Modules with CSS custom properties mapping to design tokens (colors, spacing, typography, radii, shadows), dark-first theming with light and OLED dark variants
+- **Testing:** Vitest + Testing Library (jsdom environment)
+- **Hosting:** Azure Static Web Apps (Free tier) with SPA fallback routing and security headers
+- **CI/CD:** GitHub Actions — build and type-check on PR, deploy to staging preview on PR, deploy to production on merge to main
+
+No SSR framework (Next.js, Remix) is used. The landing page is a pure client-side SPA served as static files, which keeps the build pipeline simple and the hosting free.
+
+## Consequences
+
+- **Simpler:** Pure SPA with Vite gives fast builds, minimal configuration, and zero server-side runtime costs. Azure Static Web Apps Free tier provides hosting, SSL, and PR preview environments at no cost.
+- **Simpler:** CSS Modules with design tokens ensure visual consistency with the iOS app without introducing a component library dependency (e.g., Chakra, MUI).
+- **Harder:** No SSR means the landing page relies on client-side rendering. If SEO or first-contentful-paint becomes critical, we would need to revisit this (e.g., adopt Vite SSG plugin or migrate to a framework with SSR support).
+- **Harder:** Adding a second language ecosystem (Node.js/TypeScript) to the monorepo increases CI complexity and onboarding surface area.

--- a/docs/adr/0012-dynamic-polling-prioritisation.md
+++ b/docs/adr/0012-dynamic-polling-prioritisation.md
@@ -1,0 +1,34 @@
+# 0012. Dynamic Polling Prioritisation by Watch Zone Density
+
+Date: 2026-03-17
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0006 established a 15-minute polling cycle against the PlanIt API to ingest new planning applications. With 417 local planning authorities (LPAs) in England, polling every authority on every cycle is wasteful — most authorities have few or no active watch zones, meaning we spend API calls and compute time fetching data that no user will see.
+
+We needed a strategy to allocate polling bandwidth proportionally to user demand while keeping the system simple and avoiding external scheduling infrastructure.
+
+## Decision
+
+We introduce a density-based polling schedule that tiers authorities by the number of active watch zones they contain:
+
+| Priority | Criteria | Polling Cadence |
+|----------|----------|-----------------|
+| **High** | Zone count >= `HighThreshold` | Every cycle |
+| **Normal** | Zone count >= `LowThreshold` | Every 2nd cycle |
+| **Low** | Zone count < `LowThreshold` | Every 4th cycle |
+
+The schedule is encapsulated in a `PollingSchedule` domain value object that is recalculated at the start of each polling cycle from current watch zone counts. Thresholds are configured via `PollingScheduleConfig` (injected at startup). The `ShouldPollInCycle(authorityId, cycleNumber)` method determines whether a given authority should be polled in the current cycle.
+
+Efficiency metrics (authorities polled, skipped, total) are logged each cycle for observability.
+
+## Consequences
+
+- **Simpler:** No external job scheduler or per-authority cron configuration — the priority logic is a pure domain calculation with no infrastructure dependencies.
+- **Simpler:** Low-activity authorities are still polled (every 4th cycle = ~60 minutes), so new applications are never missed entirely — just slightly delayed.
+- **Harder:** Data freshness is no longer uniform. Users watching a low-priority authority may see applications up to 60 minutes after ingestion vs. 15 minutes for high-priority ones. This is acceptable at current scale but may need revisiting if we introduce SLA guarantees per subscription tier.
+- **Harder:** Thresholds need tuning as the user base grows. The current thresholds are suitable for early-stage density distributions but may need adjustment or replacement with a percentile-based scheme.

--- a/docs/adr/0013-govuk-planning-data-provider.md
+++ b/docs/adr/0013-govuk-planning-data-provider.md
@@ -1,0 +1,32 @@
+# 0013. Gov.uk Planning Data as Secondary Data Provider
+
+Date: 2026-03-17
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0006 established PlanIt as the primary data provider for planning applications. However, PlanIt does not include planning designation data — whether a property falls within a conservation area, listed building curtilage, or Article 4 direction area. These designations significantly affect what permitted development rights apply and are important context for users evaluating a planning application's likelihood of approval.
+
+The Gov.uk Planning Data platform (planning.data.gov.uk) is a free, open-data API maintained by DLUHC that provides geospatial designation boundaries for England.
+
+## Decision
+
+We add Gov.uk Planning Data as a secondary data provider, accessed through a new `IDesignationDataProvider` port in the application layer. The `GovUkPlanningDataClient` adapter implements this interface, querying the Gov.uk API with a coordinate pair and returning a `DesignationContext` value object containing:
+
+- Whether the location is within a conservation area (and its name)
+- Whether it is within a listed building curtilage (and the grade)
+- Whether it is within an Article 4 direction area
+
+The adapter follows the hexagonal architecture established in ADR 0002. It uses `System.Text.Json` with a `[JsonSerializable]` source-generated context for Native AOT compatibility (ADR 0001).
+
+**Graceful degradation:** If the Gov.uk API is unavailable or returns an error, the handler returns `DesignationContext.None` rather than failing the request. Designation data enriches the user experience but is not essential to the core planning application feed.
+
+## Consequences
+
+- **Simpler:** The `IDesignationDataProvider` port establishes a pattern for adding further data sources (e.g., flood risk, environmental designations) without modifying existing application logic.
+- **Simpler:** Gov.uk Planning Data is free and open, so there is no cost or API key management overhead.
+- **Harder:** Introduces a runtime dependency on a third-party government API. Graceful degradation mitigates this, but prolonged outages would silently degrade the user experience without explicit notification.
+- **Harder:** The Gov.uk API has no SLA or rate limit guarantees. If call volume grows significantly, we may need to cache designation boundaries locally rather than querying per-request.


### PR DESCRIPTION
## Changes
- Add ADR 0011: Web Frontend Stack (Vite + React 19 + TypeScript on Azure Static Web Apps)
- Add ADR 0012: Dynamic Polling Prioritisation by Watch Zone Density (High/Normal/Low tiers)
- Add ADR 0013: Gov.uk Planning Data as Secondary Designation Data Provider

---
*Auto-shipped via ship skill*