### PR TITLE
Add PR gate workflow with path-filtered checks

### DIFF
--- a/.github/workflows/api-ci.yml
+++ b/.github/workflows/api-ci.yml
@@ -15,11 +15,6 @@ on:
     paths:
       - "api/**"
       - ".github/workflows/api-ci.yml"
-  pull_request:
-    branches: [main]
-    paths:
-      - "api/**"
-      - ".github/workflows/api-ci.yml"
 
 concurrency:
   group: api-ci-${{ github.ref }}

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -15,11 +15,6 @@ on:
     paths:
       - "infra/**"
       - ".github/workflows/infra-ci.yml"
-  pull_request:
-    branches: [main]
-    paths:
-      - "infra/**"
-      - ".github/workflows/infra-ci.yml"
 
 concurrency:
   group: infra-ci-${{ github.ref }}

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -6,11 +6,6 @@ on:
     paths:
       - "mobile/ios/**"
       - ".github/workflows/ios-ci.yml"
-  pull_request:
-    branches: [main]
-    paths:
-      - "mobile/ios/**"
-      - ".github/workflows/ios-ci.yml"
 
 concurrency:
   group: ios-ci-${{ github.ref }}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,0 +1,205 @@
+name: PR Gate
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: pr-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      ios: ${{ steps.filter.outputs.ios }}
+      web: ${{ steps.filter.outputs.web }}
+      infra: ${{ steps.filter.outputs.infra }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            api:
+              - 'api/**'
+              - '.github/workflows/api-ci.yml'
+            ios:
+              - 'mobile/ios/**'
+              - '.github/workflows/ios-ci.yml'
+            web:
+              - 'web/**'
+              - '.github/workflows/web-ci.yml'
+            infra:
+              - 'infra/**'
+              - '.github/workflows/infra-ci.yml'
+
+  # ── API ──────────────────────────────────────────────
+
+  api-format:
+    name: "API: Format"
+    needs: changes
+    if: needs.changes.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: api/global.json
+      - run: dotnet format --verify-no-changes
+        working-directory: api
+
+  api-build-test:
+    name: "API: Build & test"
+    needs: changes
+    if: needs.changes.outputs.api == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: api/global.json
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('api/**/*.csproj', 'api/**/Directory.Build.props') }}
+          restore-keys: nuget-${{ runner.os }}-
+      - run: dotnet restore
+        working-directory: api
+      - run: dotnet build --no-restore --configuration Release
+        working-directory: api
+      - run: dotnet test --no-build --configuration Release
+        working-directory: api
+
+  # ── iOS ──────────────────────────────────────────────
+
+  ios-lint:
+    name: "iOS: SwiftLint"
+    needs: changes
+    if: needs.changes.outputs.ios == 'true'
+    runs-on: macos-15
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - run: brew install swiftlint
+      - run: swiftlint lint
+        working-directory: mobile/ios
+
+  ios-build-test:
+    name: "iOS: Build & test"
+    needs: changes
+    if: needs.changes.outputs.ios == 'true'
+    runs-on: macos-15
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: mobile/ios/.build
+          key: spm-${{ runner.os }}-${{ hashFiles('mobile/ios/Package.resolved') }}
+          restore-keys: spm-${{ runner.os }}-
+      - run: swift build
+        working-directory: mobile/ios
+      - run: swift test
+        working-directory: mobile/ios
+
+  # ── Web ──────────────────────────────────────────────
+
+  web-build:
+    name: "Web: Build & type-check"
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - run: npm ci
+        working-directory: web
+      - run: npx tsc --noEmit
+        working-directory: web
+      - run: npm run build
+        working-directory: web
+
+  # ── Infrastructure ───────────────────────────────────
+
+  infra-preview:
+    name: "Infra: Pulumi preview"
+    needs: changes
+    if: needs.changes.outputs.infra == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: api/global.json
+      - uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-infra-${{ runner.os }}-${{ hashFiles('infra/**/*.csproj') }}
+          restore-keys: nuget-infra-${{ runner.os }}-
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - uses: pulumi/actions@v6
+        with:
+          command: preview
+          stack-name: ${{ vars.PULUMI_STACK }}
+          work-dir: infra
+          comment-on-pr: true
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          ARM_USE_OIDC: true
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+  # ── Gate (sole required status check) ────────────────
+
+  gate:
+    name: PR Gate
+    needs: [api-format, api-build-test, ios-lint, ios-build-test, web-build, infra-preview]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Evaluate results
+        run: |
+          results=(
+            "${{ needs.api-format.result }}"
+            "${{ needs.api-build-test.result }}"
+            "${{ needs.ios-lint.result }}"
+            "${{ needs.ios-build-test.result }}"
+            "${{ needs.web-build.result }}"
+            "${{ needs.infra-preview.result }}"
+          )
+          for r in "${results[@]}"; do
+            if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then
+              echo "A required check failed or was cancelled: $r"
+              exit 1
+            fi
+          done
+          echo "All required checks passed or were skipped"


### PR DESCRIPTION
## Changes
- Add `pr-gate.yml` workflow that runs on all PRs with path-based change detection (`dorny/paths-filter`)
- Conditional check jobs: API format + build/test, iOS lint + build/test, Web build + type-check, Infra Pulumi preview
- Final `gate` job as the sole required status check — skipped jobs pass, only failures block merge
- Remove `pull_request` triggers from `api-ci.yml`, `ios-ci.yml`, `infra-ci.yml` to avoid double runs (web-ci kept for PR preview deploys)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflow configuration for pull requests. CI validation now runs through a consolidated workflow that conditionally executes checks based on which areas of the codebase have changed (API, iOS, web, or infrastructure), replacing the previous individual workflow triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->