### PR TITLE
Update ship skill to wait for PR gate before merging

### DIFF
--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ship
-description: Automate the push-to-main flow when you have local commits and/or unstaged changes on main. Creates a feature branch, opens a squash-merge PR via `gh`, merges it, and cleans up. MUST use this skill whenever the user says "ship", "ship it", "push to main", "push my changes", "get this on main", "merge to main", "create a PR and merge", or any variation of wanting to get local work from main onto the remote. Also trigger when the user has been working on main and wants to push but can't due to branch protection. Do NOT use for: creating PRs without merging, pushing feature branches, or work that isn't on main.
+description: Automate the push-to-main flow when you have local commits and/or unstaged changes on main. Creates a feature branch, opens a PR via `gh`, and waits for PR gate checks before merging. MUST use this skill whenever the user says "ship", "ship it", "push to main", "push my changes", "get this on main", "merge to main", "create a PR and merge", or any variation of wanting to get local work from main onto the remote. Also trigger when the user has been working on main and wants to push but can't due to branch protection. Do NOT use for: creating PRs without merging, pushing feature branches, or work that isn't on main.
 ---
 
 # Ship to Main
 
-Route local work on `main` through a PR, because direct pushes to main are blocked by branch protection and a local pre-push hook. This skill handles the entire flow: branch, PR, squash-merge, cleanup.
+Route local work on `main` through a PR, because direct pushes to main are blocked by branch protection and a local pre-push hook. This skill handles the flow: branch, push, create PR, then ask the user whether to wait for checks or leave the PR open.
 
 ## Workflow
 
@@ -70,20 +70,38 @@ EOF
 
 **PR body:** List each commit as a bullet point under "## Changes".
 
-### Step 6: Merge the PR
+### Step 6: Ask user about merge strategy
+
+**NEVER merge the PR immediately.** The PR gate workflow must pass first. Present the PR URL and ask:
+
+> PR created: <url>
+>
+> The PR gate checks are running. Would you like me to:
+> 1. **Wait** for the checks to pass and then merge
+> 2. **Leave it open** for you to merge later
+
+**If the user chooses to wait:**
+
+Use `gh pr checks --watch` to monitor, then merge when green:
+
+```bash
+gh pr checks <pr-number> --watch --fail-fast
+```
+
+If checks pass, proceed to merge and cleanup (Step 7). If checks fail, report which checks failed, provide the PR URL, and stop — do not retry or force-merge.
+
+**If the user chooses to leave it open:**
+
+Report the PR URL and stop. Do not proceed to Step 7. Do not merge. Do not clean up branches. The skill ends here.
+
+### Step 7: Merge and clean up
+
+Only reach this step if the user chose to wait AND checks passed.
 
 ```bash
 gh pr merge --squash --delete-branch
-```
-
-If merge fails (e.g., required CI checks are pending), tell the user the PR was created, provide the URL, and suggest they merge manually when checks pass. Don't retry in a loop.
-
-### Step 7: Return to main and clean up
-
-```bash
 git checkout main
 git pull origin main
-git branch -d <branch-name>
 ```
 
 ### Step 8: Verify
@@ -98,5 +116,5 @@ Report success with the PR URL.
 
 - **Not on main:** Stop. Tell the user which branch they're on.
 - **Nothing to ship:** Tell the user. Don't create empty PRs.
-- **Merge conflict or CI failure:** Report the PR URL and let the user decide next steps. Don't force-merge or retry.
+- **Checks failed:** Report which checks failed and the PR URL. Do not retry or force-merge.
 - **gh CLI not authenticated:** Tell the user to run `gh auth login`.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -72,31 +72,64 @@ EOF
 
 ### Step 6: Ask user about merge strategy
 
-**NEVER merge the PR immediately.** The PR gate workflow must pass first. Present the PR URL and ask:
+**NEVER merge the PR immediately.** The PR gate checks and CodeRabbit review must complete first. Present the PR URL and ask:
 
 > PR created: <url>
 >
-> The PR gate checks are running. Would you like me to:
-> 1. **Wait** for the checks to pass and then merge
+> The PR gate checks and CodeRabbit review are running. Would you like me to:
+> 1. **Wait** for checks and review, then merge
 > 2. **Leave it open** for you to merge later
+
+**If the user chooses to leave it open:**
+
+Report the PR URL and stop. Do not proceed further. Do not merge. Do not clean up branches. The skill ends here.
 
 **If the user chooses to wait:**
 
-Use `gh pr checks --watch` to monitor, then merge when green:
+Proceed to Step 7.
+
+### Step 7: Wait for checks and CodeRabbit review
+
+First, wait for CI checks to pass:
 
 ```bash
 gh pr checks <pr-number> --watch --fail-fast
 ```
 
-If checks pass, proceed to merge and cleanup (Step 7). If checks fail, report which checks failed, provide the PR URL, and stop — do not retry or force-merge.
+If checks fail, report which checks failed, provide the PR URL, and stop — do not retry or force-merge.
 
-**If the user chooses to leave it open:**
+Once checks pass, fetch the CodeRabbit review. CodeRabbit posts a review comment on the PR. Use the GitHub API to read it:
 
-Report the PR URL and stop. Do not proceed to Step 7. Do not merge. Do not clean up branches. The skill ends here.
+```bash
+gh api repos/{owner}/{repo}/pulls/<pr-number>/reviews
+gh api repos/{owner}/{repo}/pulls/<pr-number>/comments
+```
 
-### Step 7: Merge and clean up
+**If CodeRabbit has suggestions or comments:**
 
-Only reach this step if the user chose to wait AND checks passed.
+Summarise the suggestions concisely for the user and ask what they'd like to do:
+
+> CodeRabbit flagged the following:
+> - <brief summary of each suggestion>
+>
+> How would you like to proceed?
+> 1. **Merge anyway** — suggestions are minor or not applicable
+> 2. **Create a bead** — track the suggestions as follow-up work, then merge
+> 3. **Leave the PR open** — review the suggestions yourself first
+
+**CRITICAL: NEVER fix CodeRabbit suggestions within this skill.** Do not edit code, do not push additional commits. This skill ships work — it does not do development. If the user wants fixes, they should do that in a separate session and re-ship.
+
+- If the user chooses **merge anyway**: proceed to Step 8.
+- If the user chooses **create a bead**: create a bead with `bd create` summarising the CodeRabbit suggestions, then proceed to Step 8.
+- If the user chooses **leave it open**: report the PR URL and stop. The skill ends here.
+
+**If CodeRabbit has no suggestions (or approved without comments):**
+
+Proceed directly to Step 8.
+
+### Step 8: Merge and clean up
+
+Only reach this step if the user chose to merge.
 
 ```bash
 gh pr merge --squash --delete-branch
@@ -104,7 +137,7 @@ git checkout main
 git pull origin main
 ```
 
-### Step 8: Verify
+### Step 9: Verify
 
 Run `git status` and `git log --oneline -3` to confirm:
 - On `main`, up to date with origin

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -27,22 +27,35 @@ jobs:
       infra: ${{ steps.filter.outputs.infra }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          filters: |
-            api:
-              - 'api/**'
-              - '.github/workflows/api-ci.yml'
-            ios:
-              - 'mobile/ios/**'
-              - '.github/workflows/ios-ci.yml'
-            web:
-              - 'web/**'
-              - '.github/workflows/web-ci.yml'
-            infra:
-              - 'infra/**'
-              - '.github/workflows/infra-ci.yml'
+          fetch-depth: 0
+      - name: Detect changed paths
+        id: filter
+        run: |
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          has_api=false
+          has_ios=false
+          has_web=false
+          has_infra=false
+
+          while IFS= read -r file; do
+            case "$file" in
+              api/*|.github/workflows/api-ci.yml) has_api=true ;;
+              mobile/ios/*|.github/workflows/ios-ci.yml) has_ios=true ;;
+              web/*|.github/workflows/web-ci.yml) has_web=true ;;
+              infra/*|.github/workflows/infra-ci.yml) has_infra=true ;;
+            esac
+          done <<< "$CHANGED"
+
+          echo "api=$has_api" >> "$GITHUB_OUTPUT"
+          echo "ios=$has_ios" >> "$GITHUB_OUTPUT"
+          echo "web=$has_web" >> "$GITHUB_OUTPUT"
+          echo "infra=$has_infra" >> "$GITHUB_OUTPUT"
+
+          echo "Results: api=$has_api ios=$has_ios web=$has_web infra=$has_infra"
 
   # ── API ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Changes
- Ship skill no longer auto-merges PRs immediately
- After creating a PR, asks the user whether to wait for checks or leave it open
- Wait option uses `gh pr checks --watch --fail-fast` to monitor, then merges when green
- Leave-open option stops the skill entirely — no merge, no cleanup

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR creation now pauses for user choice to wait for gate checks or leave the PR open; merge runs only after explicit confirmation.
  * When checks fail, users are informed which checks failed and no automatic force-merge or retry occurs; suggestions may be presented but edits are not performed automatically.

* **Documentation**
  * Clarified paused PR flow, conditional merge/cleanup behavior, and handling of failed checks and review suggestions.

* **Refactor**
  * CI change-detection replaced with a custom path-detection step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->