### PR TITLE
Move Container Apps Environment to shared stack

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -1,7 +1,6 @@
 using System.Collections.Immutable;
 using Pulumi;
 using Pulumi.AzureNative.Resources;
-using Pulumi.AzureNative.OperationalInsights;
 using Pulumi.AzureNative.App;
 using Pulumi.AzureNative.App.Inputs;
 using Pulumi.AzureNative.CosmosDB;
@@ -20,48 +19,12 @@ public static class EnvironmentStack
         var acrLoginServer = shared.GetOutput("containerRegistryLoginServer").Apply(o => o?.ToString() ?? "");
         var acrPullIdentityId = shared.GetOutput("acrPullIdentityId").Apply(o => o?.ToString() ?? "");
         var acrPullIdentityClientId = shared.GetOutput("acrPullIdentityClientId").Apply(o => o?.ToString() ?? "");
+        var containerAppsEnvironmentId = shared.GetOutput("containerAppsEnvironmentId").Apply(o => o?.ToString() ?? "");
 
         // Resource Group
         var resourceGroup = new ResourceGroup($"rg-town-crier-{env}", new ResourceGroupArgs
         {
             ResourceGroupName = $"rg-town-crier-{env}",
-            Tags = tags,
-        });
-
-        // Log Analytics Workspace
-        var logAnalytics = new Workspace($"log-town-crier-{env}", new WorkspaceArgs
-        {
-            WorkspaceName = $"log-town-crier-{env}",
-            ResourceGroupName = resourceGroup.Name,
-            Sku = new Pulumi.AzureNative.OperationalInsights.Inputs.WorkspaceSkuArgs
-            {
-                Name = WorkspaceSkuNameEnum.PerGB2018,
-            },
-            RetentionInDays = 30,
-            Tags = tags,
-        });
-
-        var logAnalyticsSharedKeys = Output.Tuple(resourceGroup.Name, logAnalytics.Name)
-            .Apply(names => GetSharedKeys.InvokeAsync(new GetSharedKeysArgs
-            {
-                ResourceGroupName = names.Item1,
-                WorkspaceName = names.Item2,
-            }));
-
-        // Container Apps Environment
-        var containerAppsEnv = new ManagedEnvironment($"cae-town-crier-{env}", new ManagedEnvironmentArgs
-        {
-            EnvironmentName = $"cae-town-crier-{env}",
-            ResourceGroupName = resourceGroup.Name,
-            AppLogsConfiguration = new AppLogsConfigurationArgs
-            {
-                Destination = "log-analytics",
-                LogAnalyticsConfiguration = new LogAnalyticsConfigurationArgs
-                {
-                    CustomerId = logAnalytics.CustomerId,
-                    SharedKey = logAnalyticsSharedKeys.Apply(keys => keys.PrimarySharedKey ?? ""),
-                },
-            },
             Tags = tags,
         });
 
@@ -266,7 +229,7 @@ public static class EnvironmentStack
         {
             ContainerAppName = $"ca-town-crier-api-{env}",
             ResourceGroupName = resourceGroup.Name,
-            ManagedEnvironmentId = containerAppsEnv.Id,
+            ManagedEnvironmentId = containerAppsEnvironmentId,
             Configuration = new ConfigurationArgs
             {
                 Ingress = new IngressArgs
@@ -338,11 +301,9 @@ public static class EnvironmentStack
         return new Dictionary<string, object?>
         {
             ["resourceGroupName"] = resourceGroup.Name,
-            ["containerAppsEnvironmentId"] = containerAppsEnv.Id,
             ["containerAppUrl"] = containerApp.LatestRevisionFqdn.Apply(fqdn => $"https://{fqdn}"),
             ["cosmosAccountEndpoint"] = cosmosAccount.DocumentEndpoint,
             ["cosmosDatabaseName"] = cosmosDatabase.Name,
-            ["logAnalyticsWorkspaceId"] = logAnalytics.Id,
             ["staticWebAppUrl"] = staticWebApp.DefaultHostname.Apply(hostname => $"https://{hostname}"),
             ["staticWebAppName"] = staticWebApp.Name,
         };

--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -3,6 +3,9 @@ using Pulumi.AzureNative.Resources;
 using Pulumi.AzureNative.ContainerRegistry;
 using Pulumi.AzureNative.ManagedIdentity;
 using Pulumi.AzureNative.Authorization;
+using Pulumi.AzureNative.OperationalInsights;
+using Pulumi.AzureNative.App;
+using Pulumi.AzureNative.App.Inputs;
 
 public static class SharedStack
 {
@@ -62,12 +65,50 @@ public static class SharedStack
             PrincipalType = PrincipalType.ServicePrincipal,
         });
 
+        // Log Analytics Workspace (shared across environments)
+        var logAnalytics = new Workspace("log-town-crier-shared", new WorkspaceArgs
+        {
+            WorkspaceName = "log-town-crier-shared",
+            ResourceGroupName = resourceGroup.Name,
+            Sku = new Pulumi.AzureNative.OperationalInsights.Inputs.WorkspaceSkuArgs
+            {
+                Name = WorkspaceSkuNameEnum.PerGB2018,
+            },
+            RetentionInDays = 30,
+            Tags = tags,
+        });
+
+        var logAnalyticsSharedKeys = Output.Tuple(resourceGroup.Name, logAnalytics.Name)
+            .Apply(names => GetSharedKeys.InvokeAsync(new GetSharedKeysArgs
+            {
+                ResourceGroupName = names.Item1,
+                WorkspaceName = names.Item2,
+            }));
+
+        // Container Apps Environment (shared across environments)
+        var containerAppsEnv = new ManagedEnvironment("cae-town-crier-shared", new ManagedEnvironmentArgs
+        {
+            EnvironmentName = "cae-town-crier-shared",
+            ResourceGroupName = resourceGroup.Name,
+            AppLogsConfiguration = new AppLogsConfigurationArgs
+            {
+                Destination = "log-analytics",
+                LogAnalyticsConfiguration = new LogAnalyticsConfigurationArgs
+                {
+                    CustomerId = logAnalytics.CustomerId,
+                    SharedKey = logAnalyticsSharedKeys.Apply(keys => keys.PrimarySharedKey ?? ""),
+                },
+            },
+            Tags = tags,
+        });
+
         return new Dictionary<string, object?>
         {
             ["resourceGroupName"] = resourceGroup.Name,
             ["containerRegistryLoginServer"] = containerRegistry.LoginServer,
             ["acrPullIdentityId"] = acrPullIdentity.Id,
             ["acrPullIdentityClientId"] = acrPullIdentity.ClientId,
+            ["containerAppsEnvironmentId"] = containerAppsEnv.Id,
         };
     }
 }


### PR DESCRIPTION
## Summary
- Moves Log Analytics Workspace and Container Apps Environment from per-environment stacks to the shared Pulumi stack
- Works around the subscription quota limit (1 Container Apps Environment per subscription)
- Both dev and prod Container Apps now share the same environment in uksouth

## What's deployed
- Shared stack: updated with Log Analytics + Container Apps Environment — live
- Dev stack: fully redeployed using shared environment — live
- Prod stack: partially deployed — Cosmos DB name `cosmos-town-crier-prod` is blocked by Azure DNS cache from a prior failed ukwest creation. Will resolve in a few hours, then `pulumi up --stack prod` completes.

## Test plan
- [x] Shared stack deployed with environment
- [x] Dev stack fully deployed and running against shared environment
- [ ] Retry prod deployment once Azure releases the Cosmos DB DNS name

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured cloud infrastructure to consolidate container logging and managed environment setup into a shared configuration layer. Individual deployment stacks now reference and consume these centralized shared resources instead of maintaining separate instances for each deployment, reducing redundancy and ensuring consistent logging and environment configuration across all container deployments throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->