### PR TITLE
feat: add custom domain bindings for SWA and Container App

### DIFF
--- a/.beads/push-state.json
+++ b/.beads/push-state.json
@@ -1,4 +1,4 @@
 {
-  "last_push": "2026-03-19T17:49:47Z",
-  "last_commit": "ldfhot2co7s0d6socfv1a2efi73h1jqv"
+  "last_push": "2026-03-21T16:23:30Z",
+  "last_commit": "p4ndd6kvs2cftbqd5o2kgrn46p0585fh"
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,5 +3,20 @@
     "code-review@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
     "superpowers@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command' | grep -qE '^git\\s+push' && { branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$branch\" = \"main\" ]; then echo '{\"decision\":\"block\",\"reason\":\"You are on the main branch. Do NOT push directly to main. Instead: 1) Create a new feature branch with git checkout -b <descriptive-branch-name>, 2) Push that branch with git push -u origin <branch-name>, 3) Create a PR using gh pr create.\"}'; fi; } || true",
+            "timeout": 10,
+            "statusMessage": "Checking branch protection..."
+          }
+        ]
+      }
+    ]
   }
 }

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -22,8 +22,20 @@ public static class EnvironmentStack
         var acrPullIdentityId = shared.GetOutput("acrPullIdentityId").Apply(o => o?.ToString() ?? "");
         var acrPullIdentityClientId = shared.GetOutput("acrPullIdentityClientId").Apply(o => o?.ToString() ?? "");
         var containerAppsEnvironmentId = shared.GetOutput("containerAppsEnvironmentId").Apply(o => o?.ToString() ?? "");
-        var containerAppsEnvironmentName = shared.GetOutput("containerAppsEnvironmentName").Apply(o => o?.ToString() ?? "");
-        var sharedResourceGroupName = shared.GetOutput("sharedResourceGroupName").Apply(o => o?.ToString() ?? "");
+        // Extract the CAE name and resource group from its resource ID to avoid
+        // requiring a shared stack deploy before the env stack can preview.
+        // ID format: /subscriptions/.../resourceGroups/{rg}/providers/Microsoft.App/managedEnvironments/{name}
+        var containerAppsEnvironmentName = containerAppsEnvironmentId.Apply(id =>
+        {
+            var segments = id.Split('/');
+            return segments.Length > 0 ? segments[^1] : "";
+        });
+        var sharedResourceGroupName = containerAppsEnvironmentId.Apply(id =>
+        {
+            var segments = id.Split('/');
+            var rgIndex = Array.IndexOf(segments, "resourceGroups");
+            return rgIndex >= 0 && rgIndex + 1 < segments.Length ? segments[rgIndex + 1] : "";
+        });
 
         // Resource Group
         var resourceGroup = new ResourceGroup($"rg-town-crier-{env}", new ResourceGroupArgs

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -13,6 +13,8 @@ public static class EnvironmentStack
     public static Dictionary<string, object?> Run(Config config, string env, InputMap<string> tags)
     {
         var cosmosConsistencyLevel = config.Require("cosmosConsistencyLevel");
+        var frontendDomain = config.Require("frontendDomain");
+        var apiDomain = config.Require("apiDomain");
 
         // Shared stack outputs
         var shared = new StackReference("AmyDe/town-crier/shared");
@@ -20,6 +22,8 @@ public static class EnvironmentStack
         var acrPullIdentityId = shared.GetOutput("acrPullIdentityId").Apply(o => o?.ToString() ?? "");
         var acrPullIdentityClientId = shared.GetOutput("acrPullIdentityClientId").Apply(o => o?.ToString() ?? "");
         var containerAppsEnvironmentId = shared.GetOutput("containerAppsEnvironmentId").Apply(o => o?.ToString() ?? "");
+        var containerAppsEnvironmentName = shared.GetOutput("containerAppsEnvironmentName").Apply(o => o?.ToString() ?? "");
+        var sharedResourceGroupName = shared.GetOutput("sharedResourceGroupName").Apply(o => o?.ToString() ?? "");
 
         // Resource Group
         var resourceGroup = new ResourceGroup($"rg-town-crier-{env}", new ResourceGroupArgs
@@ -224,6 +228,19 @@ public static class EnvironmentStack
             },
         });
 
+        // Managed Certificate for API custom domain
+        var apiManagedCert = new ManagedCertificate($"cert-api-{env}", new ManagedCertificateArgs
+        {
+            EnvironmentName = containerAppsEnvironmentName,
+            ManagedCertificateName = $"cert-api-{env}",
+            ResourceGroupName = sharedResourceGroupName,
+            Properties = new ManagedCertificatePropertiesArgs
+            {
+                SubjectName = apiDomain,
+                DomainControlValidation = "CNAME",
+            },
+        });
+
         // Container App (API) — placeholder image until CI/CD pushes real builds
         var containerApp = new ContainerApp($"ca-town-crier-api-{env}", new ContainerAppArgs
         {
@@ -237,6 +254,15 @@ public static class EnvironmentStack
                     External = true,
                     TargetPort = 8080,
                     Transport = IngressTransportMethod.Http,
+                    CustomDomains = new[]
+                    {
+                        new CustomDomainArgs
+                        {
+                            Name = apiDomain,
+                            CertificateId = apiManagedCert.Id,
+                            BindingType = BindingType.SniEnabled,
+                        },
+                    },
                 },
                 Registries = new[]
                 {
@@ -296,6 +322,14 @@ public static class EnvironmentStack
                 OutputLocation = "",
             },
             Tags = tags,
+        });
+
+        // Static Web App Custom Domain
+        var staticWebAppCustomDomain = new StaticSiteCustomDomain($"swa-domain-{env}", new StaticSiteCustomDomainArgs
+        {
+            Name = staticWebApp.Name,
+            DomainName = frontendDomain,
+            ResourceGroupName = resourceGroup.Name,
         });
 
         return new Dictionary<string, object?>

--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -2,3 +2,5 @@ config:
   azure-native:location: uksouth
   town-crier:environment: dev
   town-crier:cosmosConsistencyLevel: Session
+  town-crier:frontendDomain: dev.towncrierapp.uk
+  town-crier:apiDomain: api-dev.towncrierapp.uk

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -2,3 +2,5 @@ config:
   azure-native:location: uksouth
   town-crier:environment: prod
   town-crier:cosmosConsistencyLevel: Session
+  town-crier:frontendDomain: towncrierapp.uk
+  town-crier:apiDomain: api.towncrierapp.uk

--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -109,8 +109,6 @@ public static class SharedStack
             ["acrPullIdentityId"] = acrPullIdentity.Id,
             ["acrPullIdentityClientId"] = acrPullIdentity.ClientId,
             ["containerAppsEnvironmentId"] = containerAppsEnv.Id,
-            ["containerAppsEnvironmentName"] = containerAppsEnv.Name,
-            ["sharedResourceGroupName"] = resourceGroup.Name,
         };
     }
 }

--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -109,6 +109,8 @@ public static class SharedStack
             ["acrPullIdentityId"] = acrPullIdentity.Id,
             ["acrPullIdentityClientId"] = acrPullIdentity.ClientId,
             ["containerAppsEnvironmentId"] = containerAppsEnv.Id,
+            ["containerAppsEnvironmentName"] = containerAppsEnv.Name,
+            ["sharedResourceGroupName"] = resourceGroup.Name,
         };
     }
 }


### PR DESCRIPTION
## Changes
- Add `frontendDomain` and `apiDomain` config values to dev and prod Pulumi stack files
- Export `containerAppsEnvironmentName` and `sharedResourceGroupName` from SharedStack
- Add `ManagedCertificate` for API custom domain with SNI binding on Container App
- Add `StaticSiteCustomDomain` for frontend custom domain on Static Web App
- Add pre-push hook to block direct pushes to main

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom domain support configured for frontend and API endpoints across development and production environments.

* **Chores**
  * Infrastructure configuration updated for domain management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->