### PR TITLE
fix: bind managed certificate to Container App (phase 2)

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -240,6 +240,19 @@ public static class EnvironmentStack
             },
         });
 
+        // Managed Certificate for API custom domain
+        var apiManagedCert = new ManagedCertificate($"cert-api-{env}", new ManagedCertificateArgs
+        {
+            EnvironmentName = containerAppsEnvironmentName,
+            ManagedCertificateName = $"cert-api-{env}",
+            ResourceGroupName = sharedResourceGroupName,
+            Properties = new ManagedCertificatePropertiesArgs
+            {
+                SubjectName = apiDomain,
+                DomainControlValidation = "CNAME",
+            },
+        });
+
         // Container App (API) — placeholder image until CI/CD pushes real builds
         var containerApp = new ContainerApp($"ca-town-crier-api-{env}", new ContainerAppArgs
         {
@@ -253,15 +266,13 @@ public static class EnvironmentStack
                     External = true,
                     TargetPort = 8080,
                     Transport = IngressTransportMethod.Http,
-                    // Phase 1: register hostname with Disabled binding so the managed
-                    // certificate can be provisioned. Phase 2 (next commit) switches to
-                    // SniEnabled with the certificate ID.
                     CustomDomains = new[]
                     {
                         new CustomDomainArgs
                         {
                             Name = apiDomain,
-                            BindingType = BindingType.Disabled,
+                            CertificateId = apiManagedCert.Id,
+                            BindingType = BindingType.SniEnabled,
                         },
                     },
                 },
@@ -305,20 +316,6 @@ public static class EnvironmentStack
             },
             Tags = tags,
         });
-
-        // Managed Certificate for API custom domain — must be created AFTER the
-        // Container App registers the hostname (Azure requirement).
-        var apiManagedCert = new ManagedCertificate($"cert-api-{env}", new ManagedCertificateArgs
-        {
-            EnvironmentName = containerAppsEnvironmentName,
-            ManagedCertificateName = $"cert-api-{env}",
-            ResourceGroupName = sharedResourceGroupName,
-            Properties = new ManagedCertificatePropertiesArgs
-            {
-                SubjectName = apiDomain,
-                DomainControlValidation = "CNAME",
-            },
-        }, new CustomResourceOptions { DependsOn = { containerApp } });
 
         // Static Web App (Landing Page)
         var staticWebApp = new StaticSite($"swa-town-crier-{env}", new StaticSiteArgs


### PR DESCRIPTION
## Changes
- Switch Container App custom domain from Disabled to SniEnabled with certificate ID
- Move ManagedCertificate declaration before Container App (no circular dependency now that cert exists in Azure)
- Remove DependsOn workaround from phase 1

Phase 2 of the two-phase custom domain setup. Phase 1 (#18) registered the hostname and provisioned the cert.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled SSL/TLS support for API custom domains with automatic certificate management.

* **Infrastructure**
  * Optimized Azure provisioning configuration by simplifying resource dependency ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->