### PR TITLE
fix: install clang and build tools for Native AOT in Docker build

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,6 @@
 # Town Crier API
 FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build
+RUN apk add --no-cache clang build-base zlib-dev
 WORKDIR /src
 
 COPY Directory.Build.props .editorconfig ./


### PR DESCRIPTION
## Changes
- Install `clang`, `build-base`, and `zlib-dev` in the Docker build stage so the .NET Native AOT linker can compile on Alpine

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build infrastructure dependencies to support the build process.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->