### PR TITLE
fix: replace anonymous types with named records for AOT compatibility

### DIFF
--- a/api/src/town-crier.web/ApiErrorResponse.cs
+++ b/api/src/town-crier.web/ApiErrorResponse.cs
@@ -1,0 +1,5 @@
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Web;
+
+internal sealed record ApiErrorResponse([property: JsonPropertyName("error")] string Error);

--- a/api/src/town-crier.web/AppJsonSerializerContext.cs
+++ b/api/src/town-crier.web/AppJsonSerializerContext.cs
@@ -13,6 +13,8 @@ using TownCrier.Application.UserProfiles;
 
 namespace TownCrier.Web;
 
+[JsonSerializable(typeof(ApiErrorResponse))]
+[JsonSerializable(typeof(UserIdResponse))]
 [JsonSerializable(typeof(CreateGroupCommand))]
 [JsonSerializable(typeof(CreateGroupResult))]
 [JsonSerializable(typeof(GetGroupResult))]

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -205,11 +205,11 @@ v1.MapGet("/geocode/{postcode}", async (string postcode, GeocodePostcodeQueryHan
     }
     catch (ArgumentException ex)
     {
-        return Results.BadRequest(new { error = ex.Message });
+        return Results.BadRequest(new ApiErrorResponse(ex.Message));
     }
     catch (InvalidOperationException ex)
     {
-        return Results.NotFound(new { error = ex.Message });
+        return Results.NotFound(new ApiErrorResponse(ex.Message));
     }
 });
 
@@ -292,7 +292,7 @@ v1.MapGet("/search", async (ClaimsPrincipal user, string q, int authorityId, int
     }
     catch (ProTierRequiredException)
     {
-        return Results.Json(new { error = "This feature requires a Pro subscription." }, statusCode: 403);
+        return Results.Json(new ApiErrorResponse("This feature requires a Pro subscription."), AppJsonSerializerContext.Default.ApiErrorResponse, statusCode: 403);
     }
     catch (UserProfileNotFoundException)
     {
@@ -391,7 +391,7 @@ v1.MapPut("/me/watch-zones/{zoneId}/preferences", async (
     }
     catch (InsufficientTierException)
     {
-        return Results.Json(new { error = "This feature requires a Pro subscription." }, statusCode: 403);
+        return Results.Json(new ApiErrorResponse("This feature requires a Pro subscription."), AppJsonSerializerContext.Default.ApiErrorResponse, statusCode: 403);
     }
 });
 
@@ -465,7 +465,7 @@ v1.MapDelete("/groups/{groupId}", async (
     }
     catch (UnauthorizedGroupOperationException)
     {
-        return Results.Json(new { error = "Only the group owner can delete the group." }, statusCode: 403);
+        return Results.Json(new ApiErrorResponse("Only the group owner can delete the group."), AppJsonSerializerContext.Default.ApiErrorResponse, statusCode: 403);
     }
 });
 
@@ -494,7 +494,7 @@ v1.MapPost("/groups/{groupId}/invitations", async (
     }
     catch (UnauthorizedGroupOperationException)
     {
-        return Results.Json(new { error = "Only the group owner can invite members." }, statusCode: 403);
+        return Results.Json(new ApiErrorResponse("Only the group owner can invite members."), AppJsonSerializerContext.Default.ApiErrorResponse, statusCode: 403);
     }
 });
 
@@ -514,7 +514,7 @@ v1.MapPost("/invitations/{invitationId}/accept", async (
     }
     catch (InvalidOperationException ex)
     {
-        return Results.BadRequest(new { error = ex.Message });
+        return Results.BadRequest(new ApiErrorResponse(ex.Message));
     }
     catch (GroupNotFoundException)
     {
@@ -543,7 +543,7 @@ v1.MapDelete("/groups/{groupId}/members/{memberUserId}", async (
     }
     catch (UnauthorizedGroupOperationException)
     {
-        return Results.Json(new { error = "Only the group owner can remove members." }, statusCode: 403);
+        return Results.Json(new ApiErrorResponse("Only the group owner can remove members."), AppJsonSerializerContext.Default.ApiErrorResponse, statusCode: 403);
     }
 });
 
@@ -560,7 +560,7 @@ var api = app.MapGroup("/api");
 api.MapGet("/me", (ClaimsPrincipal user) =>
 {
     var userId = user.FindFirstValue("sub")!;
-    return Results.Ok(new { userId });
+    return Results.Ok(new UserIdResponse(userId));
 });
 
 await app.RunAsync().ConfigureAwait(false);

--- a/api/src/town-crier.web/UserIdResponse.cs
+++ b/api/src/town-crier.web/UserIdResponse.cs
@@ -1,0 +1,5 @@
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Web;
+
+internal sealed record UserIdResponse([property: JsonPropertyName("userId")] string UserId);


### PR DESCRIPTION
## Changes
- Replace `new { error = "..." }` anonymous types in `Results.Json()` / `Results.BadRequest()` / `Results.NotFound()` with AOT-safe `ApiErrorResponse` record
- Replace `new { userId }` anonymous type with `UserIdResponse` record
- Register both types in `AppJsonSerializerContext` for source-generated serialization
- Verified with `dotnet publish` (Native AOT) locally — zero warnings

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved API response consistency by standardizing error and user response structures across endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->