### PR TITLE
fix: prod deployment phase 1 — Cosmos import, cert, apex domain

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -15,6 +15,8 @@ public static class EnvironmentStack
         var cosmosConsistencyLevel = config.Require("cosmosConsistencyLevel");
         var frontendDomain = config.Require("frontendDomain");
         var apiDomain = config.Require("apiDomain");
+        var importExistingCosmos = config.GetBoolean("importExistingCosmos") == true;
+        var customDomainPhase = config.GetInt32("customDomainPhase") ?? 2;
 
         // Shared stack outputs
         var shared = new StackReference("AmyDe/town-crier/shared");
@@ -45,6 +47,13 @@ public static class EnvironmentStack
         });
 
         // Cosmos DB Account (Serverless)
+        var cosmosImportOpts = importExistingCosmos
+            ? new CustomResourceOptions
+            {
+                ImportId = $"/subscriptions/{Environment.GetEnvironmentVariable("ARM_SUBSCRIPTION_ID")}/resourceGroups/rg-town-crier-{env}/providers/Microsoft.DocumentDB/databaseAccounts/cosmos-town-crier-{env}",
+            }
+            : null;
+
         var cosmosAccount = new DatabaseAccount($"cosmos-town-crier-{env}", new DatabaseAccountArgs
         {
             AccountName = $"cosmos-town-crier-{env}",
@@ -76,7 +85,7 @@ public static class EnvironmentStack
                 },
             },
             Tags = tags,
-        });
+        }, cosmosImportOpts);
 
         // Cosmos DB Database
         var cosmosDatabase = new SqlResourceSqlDatabase($"db-town-crier-{env}", new SqlResourceSqlDatabaseArgs
@@ -241,17 +250,26 @@ public static class EnvironmentStack
         });
 
         // Managed Certificate for API custom domain
-        var apiManagedCert = new ManagedCertificate($"cert-api-{env}", new ManagedCertificateArgs
+        // Phase 1 (first deploy): Container App created first with disabled binding,
+        //   then cert created with DependsOn so Azure can validate the hostname.
+        // Phase 2 (after cert provisioned): Cert created first, Container App
+        //   binds it with SniEnabled. Set customDomainPhase in Pulumi config.
+        ManagedCertificate? apiManagedCert = null;
+
+        if (customDomainPhase >= 2)
         {
-            EnvironmentName = containerAppsEnvironmentName,
-            ManagedCertificateName = $"cert-api-{env}",
-            ResourceGroupName = sharedResourceGroupName,
-            Properties = new ManagedCertificatePropertiesArgs
+            apiManagedCert = new ManagedCertificate($"cert-api-{env}", new ManagedCertificateArgs
             {
-                SubjectName = apiDomain,
-                DomainControlValidation = "CNAME",
-            },
-        });
+                EnvironmentName = containerAppsEnvironmentName,
+                ManagedCertificateName = $"cert-api-{env}",
+                ResourceGroupName = sharedResourceGroupName,
+                Properties = new ManagedCertificatePropertiesArgs
+                {
+                    SubjectName = apiDomain,
+                    DomainControlValidation = "CNAME",
+                },
+            });
+        }
 
         // Container App (API) — placeholder image until CI/CD pushes real builds
         var containerApp = new ContainerApp($"ca-town-crier-api-{env}", new ContainerAppArgs
@@ -266,15 +284,24 @@ public static class EnvironmentStack
                     External = true,
                     TargetPort = 8080,
                     Transport = IngressTransportMethod.Http,
-                    CustomDomains = new[]
-                    {
-                        new CustomDomainArgs
+                    CustomDomains = customDomainPhase >= 2
+                        ? new[]
                         {
-                            Name = apiDomain,
-                            CertificateId = apiManagedCert.Id,
-                            BindingType = BindingType.SniEnabled,
+                            new CustomDomainArgs
+                            {
+                                Name = apiDomain,
+                                CertificateId = apiManagedCert!.Id,
+                                BindingType = BindingType.SniEnabled,
+                            },
+                        }
+                        : new[]
+                        {
+                            new CustomDomainArgs
+                            {
+                                Name = apiDomain,
+                                BindingType = BindingType.Disabled,
+                            },
                         },
-                    },
                 },
                 Registries = new[]
                 {
@@ -317,6 +344,21 @@ public static class EnvironmentStack
             Tags = tags,
         });
 
+        if (customDomainPhase == 1)
+        {
+            new ManagedCertificate($"cert-api-{env}", new ManagedCertificateArgs
+            {
+                EnvironmentName = containerAppsEnvironmentName,
+                ManagedCertificateName = $"cert-api-{env}",
+                ResourceGroupName = sharedResourceGroupName,
+                Properties = new ManagedCertificatePropertiesArgs
+                {
+                    SubjectName = apiDomain,
+                    DomainControlValidation = "CNAME",
+                },
+            }, new CustomResourceOptions { DependsOn = { containerApp } });
+        }
+
         // Static Web App (Landing Page)
         var staticWebApp = new StaticSite($"swa-town-crier-{env}", new StaticSiteArgs
         {
@@ -337,12 +379,21 @@ public static class EnvironmentStack
         });
 
         // Static Web App Custom Domain
-        var staticWebAppCustomDomain = new StaticSiteCustomDomain($"swa-domain-{env}", new StaticSiteCustomDomainArgs
+        // Apex domains (no subdomain) require TXT validation; subdomains use default CNAME.
+        var isApexDomain = frontendDomain.Split('.').Length == 2;
+        var swaCustomDomainArgs = new StaticSiteCustomDomainArgs
         {
             Name = staticWebApp.Name,
             DomainName = frontendDomain,
             ResourceGroupName = resourceGroup.Name,
-        });
+        };
+
+        if (isApexDomain)
+        {
+            swaCustomDomainArgs.ValidationMethod = "dns-txt-token";
+        }
+
+        var staticWebAppCustomDomain = new StaticSiteCustomDomain($"swa-domain-{env}", swaCustomDomainArgs);
 
         return new Dictionary<string, object?>
         {

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -4,3 +4,5 @@ config:
   town-crier:cosmosConsistencyLevel: Session
   town-crier:frontendDomain: towncrierapp.uk
   town-crier:apiDomain: api.towncrierapp.uk
+  town-crier:importExistingCosmos: "true"
+  town-crier:customDomainPhase: "1"


### PR DESCRIPTION
## Changes
- Config-driven Cosmos DB import (`importExistingCosmos`) to adopt the existing Azure account into Pulumi state
- Two-phase managed certificate deployment (`customDomainPhase`): phase 1 creates Container App with disabled custom domain binding, then provisions the managed cert via DependsOn
- SWA custom domain uses `dns-txt-token` validation for apex domain (`towncrierapp.uk`)
- Cloudflare DNS configured: apex + www CNAMEs to SWA, api CNAME to prod Container App

## Phase 2 follow-up
After this deploys successfully, a follow-up PR will remove `importExistingCosmos` and set `customDomainPhase: 2` to bind the cert with SniEnabled.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to import existing Cosmos DB instances during infrastructure deployment.
  * Implemented phased custom domain provisioning for flexible deployment workflows.
  * Added automatic domain validation method detection for apex domains in Static Web App configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->