### PR TITLE
fix: prod CD — Pulumi refresh, remove Cosmos import, increase timeout

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -34,7 +34,7 @@ jobs:
   infra:
     name: Deploy infrastructure
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     environment: production
     outputs:
       resource-group: ${{ steps.outputs.outputs.resource-group }}
@@ -59,6 +59,19 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Pulumi refresh
+        uses: pulumi/actions@v6
+        with:
+          command: refresh
+          stack-name: prod
+          work-dir: infra
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          ARM_USE_OIDC: true
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Pulumi up
         uses: pulumi/actions@v6

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -4,5 +4,4 @@ config:
   town-crier:cosmosConsistencyLevel: Session
   town-crier:frontendDomain: towncrierapp.uk
   town-crier:apiDomain: api.towncrierapp.uk
-  town-crier:importExistingCosmos: "true"
   town-crier:customDomainPhase: "1"


### PR DESCRIPTION
## Changes
- Add `pulumi refresh` step before `pulumi up` in CD prod to sync state with Azure (the failed Cosmos DB account was deleted from Azure and needs to be cleared from Pulumi state)
- Remove `importExistingCosmos` config flag — account deleted, Pulumi will create fresh
- Increase infra job timeout from 15 → 30 minutes (Cosmos DB provisioning can take time)
- Added `asuid.api.towncrierapp.uk` TXT verification record in Cloudflare for Container App custom domain

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended production deployment workflow timeout limits for improved reliability.
  * Added infrastructure refresh step to the production deployment process.
  * Updated production environment configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->