### PR TITLE
chore: no-op change to trigger API image build

### DIFF
--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using TownCrier.Application.Authorities;
+
 using TownCrier.Application.DemoAccount;
 using TownCrier.Application.Designations;
 using TownCrier.Application.DeviceRegistrations;


### PR DESCRIPTION
## Changes
- Whitespace-only change in Program.cs to trigger cd-dev API image build
- Ensures an ACR image exists for the latest commit SHA so cd-prod can promote it

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor code formatting update.

---

**Note:** This release contains only internal code formatting adjustments with no impact on user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->