### PR TITLE
feat: enable Cosmos DB and cert binding for prod

### DIFF
--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -4,5 +4,4 @@ config:
   town-crier:cosmosConsistencyLevel: Session
   town-crier:frontendDomain: towncrierapp.uk
   town-crier:apiDomain: api.towncrierapp.uk
-  town-crier:customDomainPhase: "1"
-  town-crier:skipCosmosDb: "true"
+  town-crier:customDomainPhase: "2"


### PR DESCRIPTION
## Changes
- Move `customDomainPhase` from `"1"` to `"2"` — binds the managed cert with SniEnabled on the API Container App
- Remove `skipCosmosDb: "true"` — Cosmos DB will now be provisioned in production

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production environment configuration settings to advance deployment phases and re-enable database functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->