### PR TITLE
fix: re-add skipCosmosDb — UK region capacity still unavailable

### DIFF
--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -5,3 +5,4 @@ config:
   town-crier:frontendDomain: towncrierapp.uk
   town-crier:apiDomain: api.towncrierapp.uk
   town-crier:customDomainPhase: "2"
+  town-crier:skipCosmosDb: "true"


### PR DESCRIPTION
## Changes
- Re-add `skipCosmosDb: "true"` to prod config — Azure Cosmos DB is still returning `ServiceUnavailable` for the UK region
- `customDomainPhase: "2"` remains, so the cert binding (SniEnabled) will be deployed

v0.1.7 failed on Cosmos DB provisioning. This fix allows the cert-only changes to go through.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration to enable conditional control over database service provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->