### PR TITLE
chore: no-op change to trigger API image build for prod

### DIFF
--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -1,3 +1,4 @@
+// Trigger cd-dev image build for v0.1.9 prod deployment
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using TownCrier.Application.Authorities;


### PR DESCRIPTION
## Changes
- No-op comment in Program.cs to trigger cd-dev API image build
- Once merged, we'll tag v0.1.9 to deploy the image to prod

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal infrastructure update with no impact to end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->