### PR TITLE
feat: enable Cosmos DB for prod (retry UK South)

### DIFF
--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -1,4 +1,3 @@
-// Trigger cd-dev image build for v0.1.9 prod deployment
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using TownCrier.Application.Authorities;

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -5,4 +5,3 @@ config:
   town-crier:frontendDomain: towncrierapp.uk
   town-crier:apiDomain: api.towncrierapp.uk
   town-crier:customDomainPhase: "2"
-  town-crier:skipCosmosDb: "true"


### PR DESCRIPTION
## Changes
- Remove `skipCosmosDb: "true"` from prod config — retry Cosmos DB provisioning in UK South
- Remove no-op trigger comment from Program.cs

Previous attempt failed with "UK West" capacity error despite config targeting `uksouth`. Retrying to see if capacity has freed up.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->