### PR TITLE
feat: move Cosmos DB to shared stack for dev/prod

### DIFF
--- a/docs/superpowers/plans/2026-03-22-shared-cosmos-db.md
+++ b/docs/superpowers/plans/2026-03-22-shared-cosmos-db.md
@@ -1,0 +1,329 @@
+# Shared Cosmos DB Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the Cosmos DB serverless account from per-environment stacks to the shared stack so both dev and prod can use a single account.
+
+**Architecture:** The `DatabaseAccount` resource moves to `SharedStack.cs` and exposes account name and endpoint as outputs. `EnvironmentStack.cs` creates its database and containers in the shared account using `StackReference` outputs, the same pattern used for ACR and the Container Apps Environment.
+
+**Tech Stack:** Pulumi (C#/.NET 10), Azure Cosmos DB (Serverless), Azure Native provider
+
+**Spec:** `docs/superpowers/specs/2026-03-22-shared-cosmos-db-design.md`
+
+---
+
+### Task 1: Add Cosmos DB account to SharedStack
+
+**Files:**
+- Modify: `infra/SharedStack.cs`
+
+- [ ] **Step 1: Add CosmosDB using directives**
+
+Add at the top of `SharedStack.cs`, after the existing usings:
+
+```csharp
+using Pulumi.AzureNative.CosmosDB;
+using Pulumi.AzureNative.CosmosDB.Inputs;
+```
+
+- [ ] **Step 2: Add DatabaseAccount resource**
+
+Add after the `containerAppsEnv` resource (before the `return` statement):
+
+```csharp
+// Cosmos DB Account (shared across environments — serverless)
+var cosmosAccount = new DatabaseAccount("cosmos-town-crier-shared", new DatabaseAccountArgs
+{
+    AccountName = "cosmos-town-crier-shared",
+    ResourceGroupName = resourceGroup.Name,
+    Kind = DatabaseAccountKind.GlobalDocumentDB,
+    DatabaseAccountOfferType = DatabaseAccountOfferType.Standard,
+    Capabilities = new[]
+    {
+        new CapabilityArgs { Name = "EnableServerless" },
+    },
+    ConsistencyPolicy = new ConsistencyPolicyArgs
+    {
+        DefaultConsistencyLevel = DefaultConsistencyLevel.Session,
+    },
+    Locations = new[]
+    {
+        new LocationArgs
+        {
+            LocationName = resourceGroup.Location,
+            FailoverPriority = 0,
+        },
+    },
+    Tags = tags,
+});
+```
+
+- [ ] **Step 3: Add new stack outputs**
+
+Add to the return dictionary:
+
+```csharp
+["cosmosAccountName"] = cosmosAccount.Name,
+["cosmosAccountEndpoint"] = cosmosAccount.DocumentEndpoint,
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run: `dotnet build infra/`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/SharedStack.cs
+git commit -m "feat(infra): add shared Cosmos DB serverless account to SharedStack"
+```
+
+---
+
+### Task 2: Refactor EnvironmentStack to use shared Cosmos account
+
+**Files:**
+- Modify: `infra/EnvironmentStack.cs`
+
+- [ ] **Step 1: Add shared Cosmos stack references and simplify sharedResourceGroupName**
+
+After the existing `containerAppsEnvironmentId` shared output line (line 27), add:
+
+```csharp
+var cosmosAccountName = shared.GetOutput("cosmosAccountName").Apply(o => o?.ToString() ?? "");
+var cosmosAccountEndpoint = shared.GetOutput("cosmosAccountEndpoint").Apply(o => o?.ToString() ?? "");
+```
+
+Then replace the existing `sharedResourceGroupName` derivation (lines 36-41) that parses the CAE resource ID:
+
+```csharp
+var sharedResourceGroupName = containerAppsEnvironmentId.Apply(id =>
+{
+    var segments = id.Split('/');
+    var rgIndex = Array.IndexOf(segments, "resourceGroups");
+    return rgIndex >= 0 && rgIndex + 1 < segments.Length ? segments[rgIndex + 1] : "";
+});
+```
+
+With a direct stack reference:
+
+```csharp
+var sharedResourceGroupName = shared.GetOutput("resourceGroupName").Apply(o => o?.ToString() ?? "");
+```
+
+This is clearer and less fragile than parsing the resource group name from the CAE resource ID.
+
+- [ ] **Step 2: Remove Cosmos config reads and dead code**
+
+Remove these lines from the top of the `Run` method:
+
+```csharp
+var cosmosConsistencyLevel = config.Require("cosmosConsistencyLevel");
+```
+```csharp
+var importExistingCosmos = config.GetBoolean("importExistingCosmos") == true;
+```
+```csharp
+var skipCosmosDb = config.GetBoolean("skipCosmosDb") == true;
+```
+
+Remove the entire `cosmosImportOpts` block:
+
+```csharp
+var cosmosImportOpts = importExistingCosmos
+    ? new CustomResourceOptions
+    {
+        ImportId = $"/subscriptions/{Environment.GetEnvironmentVariable("ARM_SUBSCRIPTION_ID")}/resourceGroups/rg-town-crier-{env}/providers/Microsoft.DocumentDB/databaseAccounts/cosmos-town-crier-{env}",
+    }
+    : null;
+```
+
+- [ ] **Step 3: Remove DatabaseAccount creation and replace with shared references**
+
+> **Note:** Steps 3–6 restructure the Cosmos section as a unit. The code won't compile until Step 6 is complete. Apply them together before building.
+
+Remove the `DatabaseAccount? cosmosAccount = null;` and `SqlResourceSqlDatabase? cosmosDatabase = null;` declarations.
+
+Remove the `if (!skipCosmosDb)` guard and its opening brace. The `DatabaseAccount` creation block (the `new DatabaseAccount(...)` call, lines 64–95) is deleted entirely.
+
+Keep the database and container creation code but **un-indent it** (it's no longer inside an `if` block).
+
+- [ ] **Step 4: Update database creation to use shared account**
+
+Replace the database creation with:
+
+```csharp
+// Cosmos DB Database (in shared account)
+var cosmosDatabase = new SqlResourceSqlDatabase($"db-town-crier-{env}", new SqlResourceSqlDatabaseArgs
+{
+    AccountName = cosmosAccountName,
+    ResourceGroupName = sharedResourceGroupName,
+    DatabaseName = $"town-crier-{env}",
+    Resource = new SqlDatabaseResourceArgs
+    {
+        Id = $"town-crier-{env}",
+    },
+});
+```
+
+Key changes from the original:
+- `AccountName` uses `cosmosAccountName` (shared) instead of `cosmosAccount.Name` (local)
+- `ResourceGroupName` uses `sharedResourceGroupName` instead of `resourceGroup.Name`
+- `DatabaseName` and `Resource.Id` change from `"town-crier"` to `$"town-crier-{env}"`
+
+- [ ] **Step 5: Update all container resources**
+
+For each of the 5 containers (Applications, Users, WatchZones, Notifications, Leases), make these two substitutions:
+
+- `AccountName = cosmosAccount.Name,` → `AccountName = cosmosAccountName,`
+- `ResourceGroupName = resourceGroup.Name,` → `ResourceGroupName = sharedResourceGroupName,`
+
+The containers reference `cosmosDatabase.Name` for `DatabaseName` — this stays the same (it will now resolve to `town-crier-{env}`).
+
+- [ ] **Step 6: Remove the closing brace of the old `if (!skipCosmosDb)` block**
+
+The closing `}` on what was line 258 is no longer needed since we removed the `if` guard.
+
+- [ ] **Step 7: Update stack outputs**
+
+Replace:
+
+```csharp
+["cosmosAccountEndpoint"] = cosmosAccount?.DocumentEndpoint,
+["cosmosDatabaseName"] = cosmosDatabase?.Name,
+```
+
+With:
+
+```csharp
+["cosmosAccountEndpoint"] = cosmosAccountEndpoint,
+["cosmosDatabaseName"] = cosmosDatabase.Name,
+```
+
+No more nullable — Cosmos is always created now.
+
+- [ ] **Step 8: Clean up unused usings if needed**
+
+The `CosmosDB` usings should stay — they're still needed for `SqlResourceSqlDatabase`, `SqlResourceSqlContainer`, etc. But `DatabaseAccount`, `DatabaseAccountArgs`, `DatabaseAccountKind`, `DatabaseAccountOfferType`, `ConsistencyPolicyArgs`, `DefaultConsistencyLevel`, `CapabilityArgs`, and `LocationArgs` are no longer used in this file. The usings are namespace-level so they stay (other types from those namespaces are still used).
+
+- [ ] **Step 9: Build to verify**
+
+Run: `dotnet build infra/`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add infra/EnvironmentStack.cs
+git commit -m "refactor(infra): use shared Cosmos account in EnvironmentStack"
+```
+
+---
+
+### Task 3: Update Pulumi config files
+
+**Files:**
+- Modify: `infra/Pulumi.dev.yaml`
+- Modify: `infra/Pulumi.prod.yaml`
+
+- [ ] **Step 1: Remove cosmosConsistencyLevel from dev config**
+
+Edit `infra/Pulumi.dev.yaml` — remove the line:
+
+```yaml
+  town-crier:cosmosConsistencyLevel: Session
+```
+
+Final contents:
+
+```yaml
+config:
+  azure-native:location: uksouth
+  town-crier:environment: dev
+  town-crier:frontendDomain: dev.towncrierapp.uk
+  town-crier:apiDomain: api-dev.towncrierapp.uk
+```
+
+- [ ] **Step 2: Remove cosmosConsistencyLevel from prod config**
+
+Edit `infra/Pulumi.prod.yaml` — remove the line:
+
+```yaml
+  town-crier:cosmosConsistencyLevel: Session
+```
+
+Final contents:
+
+```yaml
+config:
+  azure-native:location: uksouth
+  town-crier:environment: prod
+  town-crier:frontendDomain: towncrierapp.uk
+  town-crier:apiDomain: api.towncrierapp.uk
+  town-crier:customDomainPhase: "2"
+```
+
+- [ ] **Step 3: Build to verify configs don't break anything**
+
+Run: `dotnet build infra/`
+Expected: Build succeeds (config is read at runtime, not build time, but this catches any compilation issues from previous tasks).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infra/Pulumi.dev.yaml infra/Pulumi.prod.yaml
+git commit -m "chore(infra): remove cosmosConsistencyLevel from env configs"
+```
+
+---
+
+### Task 4: Ship and deploy
+
+This task is manual — it requires CI/CD pipelines and Azure.
+
+- [ ] **Step 1: Ship to main**
+
+Use the ship skill to merge all commits to main via PR.
+
+- [ ] **Step 2: Wait for cd-dev to complete**
+
+cd-dev runs on push to main. It will:
+1. Deploy **shared stack** — creates `cosmos-town-crier-shared` account
+2. Deploy **dev stack** — deletes old `cosmos-town-crier-dev` account, creates `town-crier-dev` database and containers in the shared account
+
+Run: `gh run list --workflow=cd-dev.yml --limit 1`
+Watch: `gh run watch <run-id> --exit-status`
+
+If it fails, check logs with `gh run view <run-id> --log-failed`.
+
+- [ ] **Step 3: Tag for prod deployment**
+
+```bash
+git tag v0.2.1
+git push origin v0.2.1
+```
+
+cd-prod will deploy prod stack — creates `town-crier-prod` database and containers in the shared Cosmos account.
+
+- [ ] **Step 4: Watch cd-prod**
+
+Run: `gh run watch <run-id> --exit-status`
+
+- [ ] **Step 5: Validate**
+
+```bash
+# API should respond (still 500 until wired to Cosmos, but Kestrel is running)
+curl -sI --max-time 30 https://api.towncrierapp.uk/health
+
+# Frontend should be 200
+curl -sI --max-time 10 https://towncrierapp.uk
+
+# Verify Cosmos account exists
+az cosmosdb list --query "[].name" -o tsv
+# Expected: cosmos-town-crier-shared (and no cosmos-town-crier-dev)
+
+# Verify both databases exist in shared account
+az cosmosdb sql database list --account-name cosmos-town-crier-shared --resource-group rg-town-crier-shared --query "[].name" -o tsv
+# Expected: town-crier-dev, town-crier-prod
+```

--- a/docs/superpowers/specs/2026-03-22-shared-cosmos-db-design.md
+++ b/docs/superpowers/specs/2026-03-22-shared-cosmos-db-design.md
@@ -4,7 +4,7 @@ Date: 2026-03-22
 
 ## Problem
 
-Azure limits serverless Cosmos DB accounts per subscription per region. The dev environment already has a serverless account in UK South, so creating a second one for prod fails with `ServiceUnavailable` ("high demand in UK West region"). This blocks prod deployment.
+Azure limits serverless Cosmos DB accounts per subscription per region. The dev environment already has a serverless account in UK South, so creating a second one for prod fails with `ServiceUnavailable`. The error references "UK West region" despite the config targeting `uksouth` — Azure internally routes serverless provisioning across paired regions. This blocks prod deployment.
 
 ## Decision
 
@@ -39,11 +39,14 @@ No config changes to `Pulumi.shared.yaml` required.
 **Add:**
 - `cosmosAccountName` from shared stack via `StackReference` (same pattern as `acrLoginServer`)
 - `cosmosAccountEndpoint` from shared stack
+- `sharedResourceGroupName` from shared stack via `StackReference` — needed because Cosmos databases and containers must be created in the same resource group as the account (`rg-town-crier-shared`), not the per-env resource group. The shared stack already exports `resourceGroupName`; the env stack currently derives it from the CAE resource ID, but should use the direct output for clarity.
 
 **Modify:**
 - Database name changes from `town-crier` to `town-crier-{env}` (both envs share one account, so databases must have distinct names)
-- All container creation stays identical, just references `cosmosAccountName` from shared instead of a locally-created account
+- All `SqlResourceSqlDatabase` and `SqlResourceSqlContainer` resources change their `ResourceGroupName` from `resourceGroup.Name` (per-env) to the shared resource group name
 - `cosmosAccountEndpoint` replaces the local `cosmosAccount.DocumentEndpoint` in stack outputs
+
+**Note on database name:** The API is not yet wired to Cosmos at runtime. When it is, it must read the database name from configuration (e.g., stack output → env var) rather than hardcoding `town-crier`. The stack already exports `cosmosDatabaseName` for this purpose.
 
 ### Config changes
 
@@ -55,26 +58,24 @@ No config changes to `Pulumi.shared.yaml` required.
 
 ### Pulumi state
 
-The existing `cosmos-town-crier-dev` account in the dev stack state needs to be removed. Since there is no data worth preserving, we can either:
-- Let `pulumi up` on the dev stack destroy it (it will see the `DatabaseAccount` resource removed from the code and delete it)
-- The shared stack then creates the new `cosmos-town-crier-shared` account
+**Dev stack:** The existing `cosmos-town-crier-dev` account and its databases/containers are in the dev stack state. Since there is no data worth preserving, Pulumi will delete them when it sees the resources removed from code. The shared stack then creates the new `cosmos-town-crier-shared` account.
 
-The dev stack deploy must run after the shared stack deploy, which is already the case in cd-dev.yml (shared runs first, dev depends on it).
+**Prod stack:** Cosmos was never successfully provisioned in prod (`skipCosmosDb` was always `true`), so there are no Cosmos resources in the prod Pulumi state. No state cleanup needed.
 
 ### Deployment order
 
 1. **Shared stack** deploys first (creates the new Cosmos account)
-2. **Dev stack** deploys second (old Cosmos account gets deleted by Pulumi since it's no longer in code; new database and containers created using shared account)
+2. **Dev stack** deploys second (old Cosmos account deleted by Pulumi; new database and containers created using shared account)
 3. **Prod stack** deploys via tag (creates its database and containers using the shared account)
 
-cd-dev.yml already enforces shared-before-dev ordering. cd-prod.yml does not deploy the shared stack, but it doesn't need to — the shared stack will already have the Cosmos account after the next cd-dev run.
+cd-dev.yml already enforces shared-before-dev ordering. cd-prod.yml does not deploy the shared stack — the shared stack must have been deployed (via a cd-dev run) before a prod tag is cut. This is safe because any push to main that includes infra changes will trigger cd-dev first.
 
 ### What doesn't change
 
 - Container definitions (Applications, Users, WatchZones, Notifications, Leases) and their partition keys, indexes, TTLs, unique constraints
 - Container App, Static Web App, managed certificate resources
-- CI/CD workflow files
-- API application code (connection details come from environment variables at runtime)
+- CI/CD workflow files (cd-dev.yml already deploys shared before dev; cd-prod.yml doesn't need shared since it will exist)
+- API application code (not yet wired to Cosmos; when it is, it reads connection details from env vars)
 
 ## Consequences
 

--- a/docs/superpowers/specs/2026-03-22-shared-cosmos-db-design.md
+++ b/docs/superpowers/specs/2026-03-22-shared-cosmos-db-design.md
@@ -1,0 +1,83 @@
+# Shared Cosmos DB Account
+
+Date: 2026-03-22
+
+## Problem
+
+Azure limits serverless Cosmos DB accounts per subscription per region. The dev environment already has a serverless account in UK South, so creating a second one for prod fails with `ServiceUnavailable` ("high demand in UK West region"). This blocks prod deployment.
+
+## Decision
+
+Move the Cosmos DB serverless account from the per-environment stacks into the shared stack. Both dev and prod create their own databases and containers within the single shared account. This mirrors the existing pattern for ACR and the Container Apps Environment.
+
+## Design
+
+### SharedStack
+
+Add a `DatabaseAccount` resource:
+
+- **Name:** `cosmos-town-crier-shared`
+- **Kind:** `GlobalDocumentDB`
+- **Offer:** `Standard` with `EnableServerless` capability
+- **Consistency:** `Session` (hardcoded; both envs use Session)
+- **Location:** Inherits from `azure-native:location` (UK South)
+
+New stack outputs:
+- `cosmosAccountName` — account name string
+- `cosmosAccountEndpoint` — document endpoint URL
+
+No config changes to `Pulumi.shared.yaml` required.
+
+### EnvironmentStack
+
+**Remove:**
+- `DatabaseAccount` creation
+- `skipCosmosDb` flag and all conditional logic around it
+- `importExistingCosmos` flag and import options
+- `cosmosConsistencyLevel` config read
+
+**Add:**
+- `cosmosAccountName` from shared stack via `StackReference` (same pattern as `acrLoginServer`)
+- `cosmosAccountEndpoint` from shared stack
+
+**Modify:**
+- Database name changes from `town-crier` to `town-crier-{env}` (both envs share one account, so databases must have distinct names)
+- All container creation stays identical, just references `cosmosAccountName` from shared instead of a locally-created account
+- `cosmosAccountEndpoint` replaces the local `cosmosAccount.DocumentEndpoint` in stack outputs
+
+### Config changes
+
+| File | Change |
+|------|--------|
+| `Pulumi.shared.yaml` | No changes |
+| `Pulumi.dev.yaml` | Remove `cosmosConsistencyLevel` |
+| `Pulumi.prod.yaml` | Remove `cosmosConsistencyLevel` |
+
+### Pulumi state
+
+The existing `cosmos-town-crier-dev` account in the dev stack state needs to be removed. Since there is no data worth preserving, we can either:
+- Let `pulumi up` on the dev stack destroy it (it will see the `DatabaseAccount` resource removed from the code and delete it)
+- The shared stack then creates the new `cosmos-town-crier-shared` account
+
+The dev stack deploy must run after the shared stack deploy, which is already the case in cd-dev.yml (shared runs first, dev depends on it).
+
+### Deployment order
+
+1. **Shared stack** deploys first (creates the new Cosmos account)
+2. **Dev stack** deploys second (old Cosmos account gets deleted by Pulumi since it's no longer in code; new database and containers created using shared account)
+3. **Prod stack** deploys via tag (creates its database and containers using the shared account)
+
+cd-dev.yml already enforces shared-before-dev ordering. cd-prod.yml does not deploy the shared stack, but it doesn't need to — the shared stack will already have the Cosmos account after the next cd-dev run.
+
+### What doesn't change
+
+- Container definitions (Applications, Users, WatchZones, Notifications, Leases) and their partition keys, indexes, TTLs, unique constraints
+- Container App, Static Web App, managed certificate resources
+- CI/CD workflow files
+- API application code (connection details come from environment variables at runtime)
+
+## Consequences
+
+**Easier:** Prod deployment unblocked. No subscription-level Cosmos limits to worry about. One fewer resource to manage.
+
+**Harder:** Shared account becomes a single point of failure for both environments. Account-level settings (consistency, region) can't differ between envs. If the account is accidentally deleted, both envs lose their database. These trade-offs are acceptable for a solo project with no users; when that changes, split back into per-env accounts.

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -12,12 +12,9 @@ public static class EnvironmentStack
 {
     public static Dictionary<string, object?> Run(Config config, string env, InputMap<string> tags)
     {
-        var cosmosConsistencyLevel = config.Require("cosmosConsistencyLevel");
         var frontendDomain = config.Require("frontendDomain");
         var apiDomain = config.Require("apiDomain");
-        var importExistingCosmos = config.GetBoolean("importExistingCosmos") == true;
         var customDomainPhase = config.GetInt32("customDomainPhase") ?? 2;
-        var skipCosmosDb = config.GetBoolean("skipCosmosDb") == true;
 
         // Shared stack outputs
         var shared = new StackReference("AmyDe/town-crier/shared");
@@ -25,7 +22,9 @@ public static class EnvironmentStack
         var acrPullIdentityId = shared.GetOutput("acrPullIdentityId").Apply(o => o?.ToString() ?? "");
         var acrPullIdentityClientId = shared.GetOutput("acrPullIdentityClientId").Apply(o => o?.ToString() ?? "");
         var containerAppsEnvironmentId = shared.GetOutput("containerAppsEnvironmentId").Apply(o => o?.ToString() ?? "");
-        // Extract the CAE name and resource group from its resource ID to avoid
+        var cosmosAccountName = shared.GetOutput("cosmosAccountName").Apply(o => o?.ToString() ?? "");
+        var cosmosAccountEndpoint = shared.GetOutput("cosmosAccountEndpoint").Apply(o => o?.ToString() ?? "");
+        // Extract the CAE name from its resource ID to avoid
         // requiring a shared stack deploy before the env stack can preview.
         // ID format: /subscriptions/.../resourceGroups/{rg}/providers/Microsoft.App/managedEnvironments/{name}
         var containerAppsEnvironmentName = containerAppsEnvironmentId.Apply(id =>
@@ -33,12 +32,7 @@ public static class EnvironmentStack
             var segments = id.Split('/');
             return segments.Length > 0 ? segments[^1] : "";
         });
-        var sharedResourceGroupName = containerAppsEnvironmentId.Apply(id =>
-        {
-            var segments = id.Split('/');
-            var rgIndex = Array.IndexOf(segments, "resourceGroups");
-            return rgIndex >= 0 && rgIndex + 1 < segments.Length ? segments[rgIndex + 1] : "";
-        });
+        var sharedResourceGroupName = shared.GetOutput("resourceGroupName").Apply(o => o?.ToString() ?? "");
 
         // Resource Group
         var resourceGroup = new ResourceGroup($"rg-town-crier-{env}", new ResourceGroupArgs
@@ -47,215 +41,167 @@ public static class EnvironmentStack
             Tags = tags,
         });
 
-        // Cosmos DB Account (Serverless)
-        // Can be skipped via config when Azure region capacity is unavailable.
-        DatabaseAccount? cosmosAccount = null;
-        SqlResourceSqlDatabase? cosmosDatabase = null;
-
-        var cosmosImportOpts = importExistingCosmos
-            ? new CustomResourceOptions
-            {
-                ImportId = $"/subscriptions/{Environment.GetEnvironmentVariable("ARM_SUBSCRIPTION_ID")}/resourceGroups/rg-town-crier-{env}/providers/Microsoft.DocumentDB/databaseAccounts/cosmos-town-crier-{env}",
-            }
-            : null;
-
-        if (!skipCosmosDb)
+        // Cosmos DB Database (in shared account)
+        var cosmosDatabase = new SqlResourceSqlDatabase($"db-town-crier-{env}", new SqlResourceSqlDatabaseArgs
         {
-            cosmosAccount = new DatabaseAccount($"cosmos-town-crier-{env}", new DatabaseAccountArgs
+            AccountName = cosmosAccountName,
+            ResourceGroupName = sharedResourceGroupName,
+            DatabaseName = $"town-crier-{env}",
+            Resource = new SqlDatabaseResourceArgs
             {
-                AccountName = $"cosmos-town-crier-{env}",
-                ResourceGroupName = resourceGroup.Name,
-                Kind = DatabaseAccountKind.GlobalDocumentDB,
-                DatabaseAccountOfferType = DatabaseAccountOfferType.Standard,
-                Capabilities = new[]
-                {
-                    new CapabilityArgs { Name = "EnableServerless" },
-                },
-                ConsistencyPolicy = new ConsistencyPolicyArgs
-                {
-                    DefaultConsistencyLevel = cosmosConsistencyLevel switch
-                    {
-                        "Strong" => DefaultConsistencyLevel.Strong,
-                        "BoundedStaleness" => DefaultConsistencyLevel.BoundedStaleness,
-                        "Session" => DefaultConsistencyLevel.Session,
-                        "ConsistentPrefix" => DefaultConsistencyLevel.ConsistentPrefix,
-                        "Eventual" => DefaultConsistencyLevel.Eventual,
-                        _ => DefaultConsistencyLevel.Session,
-                    },
-                },
-                Locations = new[]
-                {
-                    new LocationArgs
-                    {
-                        LocationName = resourceGroup.Location,
-                        FailoverPriority = 0,
-                    },
-                },
-                Tags = tags,
-            }, cosmosImportOpts);
+                Id = $"town-crier-{env}",
+            },
+        });
 
-            // Cosmos DB Database
-            cosmosDatabase = new SqlResourceSqlDatabase($"db-town-crier-{env}", new SqlResourceSqlDatabaseArgs
+        // Cosmos DB Containers
+
+        // Applications container — partitioned by authority code, spatial index on location
+        var applicationsContainer = new SqlResourceSqlContainer($"container-applications-{env}", new SqlResourceSqlContainerArgs
+        {
+            AccountName = cosmosAccountName,
+            ResourceGroupName = sharedResourceGroupName,
+            DatabaseName = cosmosDatabase.Name,
+            ContainerName = "Applications",
+            Resource = new SqlContainerResourceArgs
             {
-                AccountName = cosmosAccount.Name,
-                ResourceGroupName = resourceGroup.Name,
-                DatabaseName = "town-crier",
-                Resource = new SqlDatabaseResourceArgs
+                Id = "Applications",
+                PartitionKey = new ContainerPartitionKeyArgs
                 {
-                    Id = "town-crier",
+                    Paths = new[] { "/authorityCode" },
+                    Kind = PartitionKind.Hash,
                 },
-            });
-
-            // Cosmos DB Containers
-
-            // Applications container — partitioned by authority code, spatial index on location
-            var applicationsContainer = new SqlResourceSqlContainer($"container-applications-{env}", new SqlResourceSqlContainerArgs
-            {
-                AccountName = cosmosAccount.Name,
-                ResourceGroupName = resourceGroup.Name,
-                DatabaseName = cosmosDatabase.Name,
-                ContainerName = "Applications",
-                Resource = new SqlContainerResourceArgs
+                DefaultTtl = -1, // TTL enabled, per-document control
+                UniqueKeyPolicy = new UniqueKeyPolicyArgs
                 {
-                    Id = "Applications",
-                    PartitionKey = new ContainerPartitionKeyArgs
+                    UniqueKeys = new[]
                     {
-                        Paths = new[] { "/authorityCode" },
-                        Kind = PartitionKind.Hash,
-                    },
-                    DefaultTtl = -1, // TTL enabled, per-document control
-                    UniqueKeyPolicy = new UniqueKeyPolicyArgs
-                    {
-                        UniqueKeys = new[]
+                        new UniqueKeyArgs
                         {
-                            new UniqueKeyArgs
+                            Paths = new[] { "/planitName" },
+                        },
+                    },
+                },
+                IndexingPolicy = new IndexingPolicyArgs
+                {
+                    Automatic = true,
+                    IndexingMode = IndexingMode.Consistent,
+                    IncludedPaths = new[]
+                    {
+                        new IncludedPathArgs { Path = "/authorityCode/?" },
+                        new IncludedPathArgs { Path = "/status/?" },
+                        new IncludedPathArgs { Path = "/applicationType/?" },
+                        new IncludedPathArgs { Path = "/decisionDate/?" },
+                        new IncludedPathArgs { Path = "/lastDifferent/?" },
+                    },
+                    ExcludedPaths = new[]
+                    {
+                        new ExcludedPathArgs { Path = "/*" },
+                        new ExcludedPathArgs { Path = "/\"_etag\"/?" },
+                    },
+                    SpatialIndexes = new[]
+                    {
+                        new SpatialSpecArgs
+                        {
+                            Path = "/location/?",
+                            Types = new InputList<Union<string, SpatialType>>
                             {
-                                Paths = new[] { "/planitName" },
+                                SpatialType.Point,
                             },
                         },
                     },
-                    IndexingPolicy = new IndexingPolicyArgs
+                    CompositeIndexes = new InputList<ImmutableArray<CompositePathArgs>>
                     {
-                        Automatic = true,
-                        IndexingMode = IndexingMode.Consistent,
-                        IncludedPaths = new[]
-                        {
-                            new IncludedPathArgs { Path = "/authorityCode/?" },
-                            new IncludedPathArgs { Path = "/status/?" },
-                            new IncludedPathArgs { Path = "/applicationType/?" },
-                            new IncludedPathArgs { Path = "/decisionDate/?" },
-                            new IncludedPathArgs { Path = "/lastDifferent/?" },
-                        },
-                        ExcludedPaths = new[]
-                        {
-                            new ExcludedPathArgs { Path = "/*" },
-                            new ExcludedPathArgs { Path = "/\"_etag\"/?" },
-                        },
-                        SpatialIndexes = new[]
-                        {
-                            new SpatialSpecArgs
-                            {
-                                Path = "/location/?",
-                                Types = new InputList<Union<string, SpatialType>>
-                                {
-                                    SpatialType.Point,
-                                },
-                            },
-                        },
-                        CompositeIndexes = new InputList<ImmutableArray<CompositePathArgs>>
-                        {
-                            ImmutableArray.Create(
-                                new CompositePathArgs { Path = "/authorityCode", Order = CompositePathSortOrder.Ascending },
-                                new CompositePathArgs { Path = "/lastDifferent", Order = CompositePathSortOrder.Descending }
-                            ),
-                        },
+                        ImmutableArray.Create(
+                            new CompositePathArgs { Path = "/authorityCode", Order = CompositePathSortOrder.Ascending },
+                            new CompositePathArgs { Path = "/lastDifferent", Order = CompositePathSortOrder.Descending }
+                        ),
                     },
                 },
-            });
+            },
+        });
 
-            // Users container — partitioned by id
-            var usersContainer = new SqlResourceSqlContainer($"container-users-{env}", new SqlResourceSqlContainerArgs
+        // Users container — partitioned by id
+        var usersContainer = new SqlResourceSqlContainer($"container-users-{env}", new SqlResourceSqlContainerArgs
+        {
+            AccountName = cosmosAccountName,
+            ResourceGroupName = sharedResourceGroupName,
+            DatabaseName = cosmosDatabase.Name,
+            ContainerName = "Users",
+            Resource = new SqlContainerResourceArgs
             {
-                AccountName = cosmosAccount.Name,
-                ResourceGroupName = resourceGroup.Name,
-                DatabaseName = cosmosDatabase.Name,
-                ContainerName = "Users",
-                Resource = new SqlContainerResourceArgs
+                Id = "Users",
+                PartitionKey = new ContainerPartitionKeyArgs
                 {
-                    Id = "Users",
-                    PartitionKey = new ContainerPartitionKeyArgs
-                    {
-                        Paths = new[] { "/id" },
-                        Kind = PartitionKind.Hash,
-                    },
+                    Paths = new[] { "/id" },
+                    Kind = PartitionKind.Hash,
                 },
-            });
+            },
+        });
 
-            // WatchZones container — partitioned by userId
-            var watchZonesContainer = new SqlResourceSqlContainer($"container-watchzones-{env}", new SqlResourceSqlContainerArgs
+        // WatchZones container — partitioned by userId
+        var watchZonesContainer = new SqlResourceSqlContainer($"container-watchzones-{env}", new SqlResourceSqlContainerArgs
+        {
+            AccountName = cosmosAccountName,
+            ResourceGroupName = sharedResourceGroupName,
+            DatabaseName = cosmosDatabase.Name,
+            ContainerName = "WatchZones",
+            Resource = new SqlContainerResourceArgs
             {
-                AccountName = cosmosAccount.Name,
-                ResourceGroupName = resourceGroup.Name,
-                DatabaseName = cosmosDatabase.Name,
-                ContainerName = "WatchZones",
-                Resource = new SqlContainerResourceArgs
+                Id = "WatchZones",
+                PartitionKey = new ContainerPartitionKeyArgs
                 {
-                    Id = "WatchZones",
-                    PartitionKey = new ContainerPartitionKeyArgs
+                    Paths = new[] { "/userId" },
+                    Kind = PartitionKind.Hash,
+                },
+                UniqueKeyPolicy = new UniqueKeyPolicyArgs
+                {
+                    UniqueKeys = new[]
                     {
-                        Paths = new[] { "/userId" },
-                        Kind = PartitionKind.Hash,
-                    },
-                    UniqueKeyPolicy = new UniqueKeyPolicyArgs
-                    {
-                        UniqueKeys = new[]
+                        new UniqueKeyArgs
                         {
-                            new UniqueKeyArgs
-                            {
-                                Paths = new[] { "/userId", "/name" },
-                            },
+                            Paths = new[] { "/userId", "/name" },
                         },
                     },
                 },
-            });
+            },
+        });
 
-            // Notifications container — partitioned by userId, 90-day TTL
-            var notificationsContainer = new SqlResourceSqlContainer($"container-notifications-{env}", new SqlResourceSqlContainerArgs
+        // Notifications container — partitioned by userId, 90-day TTL
+        var notificationsContainer = new SqlResourceSqlContainer($"container-notifications-{env}", new SqlResourceSqlContainerArgs
+        {
+            AccountName = cosmosAccountName,
+            ResourceGroupName = sharedResourceGroupName,
+            DatabaseName = cosmosDatabase.Name,
+            ContainerName = "Notifications",
+            Resource = new SqlContainerResourceArgs
             {
-                AccountName = cosmosAccount.Name,
-                ResourceGroupName = resourceGroup.Name,
-                DatabaseName = cosmosDatabase.Name,
-                ContainerName = "Notifications",
-                Resource = new SqlContainerResourceArgs
+                Id = "Notifications",
+                PartitionKey = new ContainerPartitionKeyArgs
                 {
-                    Id = "Notifications",
-                    PartitionKey = new ContainerPartitionKeyArgs
-                    {
-                        Paths = new[] { "/userId" },
-                        Kind = PartitionKind.Hash,
-                    },
-                    DefaultTtl = 90 * 24 * 60 * 60, // 90 days in seconds
+                    Paths = new[] { "/userId" },
+                    Kind = PartitionKind.Hash,
                 },
-            });
+                DefaultTtl = 90 * 24 * 60 * 60, // 90 days in seconds
+            },
+        });
 
-            // Leases container — for change feed processor checkpointing
-            var leasesContainer = new SqlResourceSqlContainer($"container-leases-{env}", new SqlResourceSqlContainerArgs
+        // Leases container — for change feed processor checkpointing
+        var leasesContainer = new SqlResourceSqlContainer($"container-leases-{env}", new SqlResourceSqlContainerArgs
+        {
+            AccountName = cosmosAccountName,
+            ResourceGroupName = sharedResourceGroupName,
+            DatabaseName = cosmosDatabase.Name,
+            ContainerName = "Leases",
+            Resource = new SqlContainerResourceArgs
             {
-                AccountName = cosmosAccount.Name,
-                ResourceGroupName = resourceGroup.Name,
-                DatabaseName = cosmosDatabase.Name,
-                ContainerName = "Leases",
-                Resource = new SqlContainerResourceArgs
+                Id = "Leases",
+                PartitionKey = new ContainerPartitionKeyArgs
                 {
-                    Id = "Leases",
-                    PartitionKey = new ContainerPartitionKeyArgs
-                    {
-                        Paths = new[] { "/id" },
-                        Kind = PartitionKind.Hash,
-                    },
+                    Paths = new[] { "/id" },
+                    Kind = PartitionKind.Hash,
                 },
-            });
-        }
+            },
+        });
 
         // Managed Certificate for API custom domain
         // Phase 1 (first deploy): Container App created first with disabled binding,
@@ -407,8 +353,8 @@ public static class EnvironmentStack
         {
             ["resourceGroupName"] = resourceGroup.Name,
             ["containerAppUrl"] = containerApp.LatestRevisionFqdn.Apply(fqdn => $"https://{fqdn}"),
-            ["cosmosAccountEndpoint"] = cosmosAccount?.DocumentEndpoint,
-            ["cosmosDatabaseName"] = cosmosDatabase?.Name,
+            ["cosmosAccountEndpoint"] = cosmosAccountEndpoint,
+            ["cosmosDatabaseName"] = cosmosDatabase.Name,
             ["staticWebAppUrl"] = staticWebApp.DefaultHostname.Apply(hostname => $"https://{hostname}"),
             ["staticWebAppName"] = staticWebApp.Name,
         };

--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -1,6 +1,5 @@
 config:
   azure-native:location: uksouth
   town-crier:environment: dev
-  town-crier:cosmosConsistencyLevel: Session
   town-crier:frontendDomain: dev.towncrierapp.uk
   town-crier:apiDomain: api-dev.towncrierapp.uk

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -1,7 +1,6 @@
 config:
   azure-native:location: uksouth
   town-crier:environment: prod
-  town-crier:cosmosConsistencyLevel: Session
   town-crier:frontendDomain: towncrierapp.uk
   town-crier:apiDomain: api.towncrierapp.uk
   town-crier:customDomainPhase: "2"

--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -6,6 +6,8 @@ using Pulumi.AzureNative.Authorization;
 using Pulumi.AzureNative.OperationalInsights;
 using Pulumi.AzureNative.App;
 using Pulumi.AzureNative.App.Inputs;
+using Pulumi.AzureNative.CosmosDB;
+using Pulumi.AzureNative.CosmosDB.Inputs;
 
 public static class SharedStack
 {
@@ -102,6 +104,32 @@ public static class SharedStack
             Tags = tags,
         });
 
+        // Cosmos DB Account (shared across environments — serverless)
+        var cosmosAccount = new DatabaseAccount("cosmos-town-crier-shared", new DatabaseAccountArgs
+        {
+            AccountName = "cosmos-town-crier-shared",
+            ResourceGroupName = resourceGroup.Name,
+            Kind = DatabaseAccountKind.GlobalDocumentDB,
+            DatabaseAccountOfferType = DatabaseAccountOfferType.Standard,
+            Capabilities = new[]
+            {
+                new CapabilityArgs { Name = "EnableServerless" },
+            },
+            ConsistencyPolicy = new ConsistencyPolicyArgs
+            {
+                DefaultConsistencyLevel = DefaultConsistencyLevel.Session,
+            },
+            Locations = new[]
+            {
+                new LocationArgs
+                {
+                    LocationName = resourceGroup.Location,
+                    FailoverPriority = 0,
+                },
+            },
+            Tags = tags,
+        });
+
         return new Dictionary<string, object?>
         {
             ["resourceGroupName"] = resourceGroup.Name,
@@ -109,6 +137,8 @@ public static class SharedStack
             ["acrPullIdentityId"] = acrPullIdentity.Id,
             ["acrPullIdentityClientId"] = acrPullIdentity.ClientId,
             ["containerAppsEnvironmentId"] = containerAppsEnv.Id,
+            ["cosmosAccountName"] = cosmosAccount.Name,
+            ["cosmosAccountEndpoint"] = cosmosAccount.DocumentEndpoint,
         };
     }
 }


### PR DESCRIPTION
## Changes
- Add Cosmos DB serverless account to `SharedStack` (shared across dev and prod)
- Refactor `EnvironmentStack` to create databases and containers in the shared account instead of per-env accounts
- Database names become `town-crier-dev` / `town-crier-prod` (distinct per env within shared account)
- Remove `skipCosmosDb`, `importExistingCosmos`, `cosmosConsistencyLevel` dead code and config
- Simplify `sharedResourceGroupName` to use direct stack reference instead of parsing CAE resource ID

## Why
Azure limits serverless Cosmos DB to one account per subscription per region. Dev already had one, so prod creation failed. Sharing the account unblocks prod deployment.

## Deployment notes
- cd-dev will deploy shared stack first (creates the new account), then dev stack (deletes old `cosmos-town-crier-dev`, creates database in shared)
- cd-prod (triggered by tag) creates `town-crier-prod` database in the shared account

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive design specification and deployment plan for shared Cosmos DB infrastructure.

* **Refactor**
  * Transitioned Cosmos DB from per-environment to shared account deployment model.
  * Removed environment-specific consistency level configuration.
  * Consolidated database and container creation under single shared resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->