### PR TITLE
chore: remove Pulumi refresh step from prod pipeline

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -60,19 +60,6 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Pulumi refresh
-        uses: pulumi/actions@v6
-        with:
-          command: refresh
-          stack-name: prod
-          work-dir: infra
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-          ARM_USE_OIDC: true
-          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - name: Pulumi up
         uses: pulumi/actions@v6
         with:


### PR DESCRIPTION
## Changes
- Remove the Pulumi `refresh` step from `cd-prod.yml` — it was added during initial prod deployment troubleshooting and is no longer needed (~30s saved per deploy)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the infrastructure deployment workflow by streamlining provisioning steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->