### PR TITLE
fix: ignore container image in Pulumi to prevent prod activation failure

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -296,6 +296,12 @@ public static class EnvironmentStack
                 },
             },
             Tags = tags,
+        }, new CustomResourceOptions
+        {
+            // CD pipeline updates the container image via `az containerapp update`.
+            // Without this, every `pulumi up` resets the image to the placeholder,
+            // causing activation failure (quickstart listens on port 80, not 8080).
+            IgnoreChanges = { "template.containers[0].image" },
         });
 
         if (customDomainPhase == 1)


### PR DESCRIPTION
## Changes
- Add `IgnoreChanges` for `template.containers[0].image` on the Container App resource in Pulumi
- Every `pulumi up` was resetting the container image to the quickstart placeholder (port 80), overriding the real image deployed by CD pipeline (port 8080), causing prod "Activation failed"

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to preserve externally deployed container images during infrastructure updates, preventing unintended image reversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->