### PR TITLE
feat: wire up Auth0 on new towncrierapp.uk tenant

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -14,6 +14,8 @@ public static class EnvironmentStack
     {
         var frontendDomain = config.Require("frontendDomain");
         var apiDomain = config.Require("apiDomain");
+        var auth0Domain = config.Require("auth0Domain");
+        var auth0Audience = config.Require("auth0Audience");
         var customDomainPhase = config.GetInt32("customDomainPhase") ?? 2;
 
         // Shared stack outputs
@@ -286,6 +288,11 @@ public static class EnvironmentStack
                         {
                             Cpu = 0.25,
                             Memory = "0.5Gi",
+                        },
+                        Env = new[]
+                        {
+                            new EnvironmentVarArgs { Name = "Auth0__Domain", Value = auth0Domain },
+                            new EnvironmentVarArgs { Name = "Auth0__Audience", Value = auth0Audience },
                         },
                     },
                 },

--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -3,3 +3,5 @@ config:
   town-crier:environment: dev
   town-crier:frontendDomain: dev.towncrierapp.uk
   town-crier:apiDomain: api-dev.towncrierapp.uk
+  town-crier:auth0Domain: towncrierapp.uk.auth0.com
+  town-crier:auth0Audience: https://api-dev.towncrierapp.uk

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -3,4 +3,6 @@ config:
   town-crier:environment: prod
   town-crier:frontendDomain: towncrierapp.uk
   town-crier:apiDomain: api.towncrierapp.uk
+  town-crier:auth0Domain: towncrierapp.uk.auth0.com
+  town-crier:auth0Audience: https://api.towncrierapp.uk
   town-crier:customDomainPhase: "2"

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -26,13 +26,13 @@ struct TownCrierApp: App {
 
         #if DEBUG
         let auth0Config = Auth0Config(
-            clientId: "6fJtwrskZKwWkJsmfNiJNN7vZdsZ374b",
-            domain: "dev-4z121ifjj10rzg3x.uk.auth0.com"
+            clientId: "a9O67fPgvXtqiWqwowhYjK0tvHF4hCMZ",
+            domain: "towncrierapp.uk.auth0.com"
         )
         #else
         let auth0Config = Auth0Config(
-            clientId: "PROD_CLIENT_ID",
-            domain: "PROD_DOMAIN.auth0.com"
+            clientId: "a9O67fPgvXtqiWqwowhYjK0tvHF4hCMZ",
+            domain: "towncrierapp.uk.auth0.com"
         )
         #endif
 

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -24,17 +24,10 @@ struct TownCrierApp: App {
         let repository = InMemoryPlanningApplicationRepository()
         #endif
 
-        #if DEBUG
         let auth0Config = Auth0Config(
             clientId: "a9O67fPgvXtqiWqwowhYjK0tvHF4hCMZ",
             domain: "towncrierapp.uk.auth0.com"
         )
-        #else
-        let auth0Config = Auth0Config(
-            clientId: "a9O67fPgvXtqiWqwowhYjK0tvHF4hCMZ",
-            domain: "towncrierapp.uk.auth0.com"
-        )
-        #endif
 
         let authService = Auth0AuthenticationService(config: auth0Config)
         let subscriptionService = StoreKitSubscriptionService()


### PR DESCRIPTION
## Changes
- Read `auth0Domain` and `auth0Audience` from Pulumi config and pass as `Auth0__Domain` / `Auth0__Audience` env vars to the Container App
- Update dev and prod Pulumi configs to use the new `towncrierapp.uk.auth0.com` tenant
- Point iOS app (both DEBUG and PROD) at the new tenant with client ID `a9O67fPgvXtqiWqwowhYjK0tvHF4hCMZ`

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Auth0 configuration entries for dev and prod and injected them into the API container runtime environment.
  * Updated the mobile app initialization to use the consolidated Auth0 configuration so it aligns with the deployment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->