### PR TITLE
feat: Cosmos DB Repository Migration — all 8 repositories

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -7,6 +7,22 @@ bd.sock
 bd.sock.startlock
 sync-state.json
 last-touched
+.exclusive-lock
+
+# Daemon runtime (lock, log, pid)
+daemon.*
+
+# Interactions log (runtime, not versioned)
+interactions.jsonl
+
+# Push state (runtime, per-machine)
+push-state.json
+
+# Lock files (various runtime locks)
+*.lock
+
+# Credential key (encryption key for federation peer auth — never commit)
+.beads-credential-key
 
 # Local version tracking (prevents upgrade notification spam after git ops)
 .local_version
@@ -31,9 +47,16 @@ dolt-server.pid
 dolt-server.log
 dolt-server.lock
 dolt-server.port
+dolt-server.activity
+
+# Corrupt backup directories (created by bd doctor --fix recovery)
+*.corrupt.backup/
 
 # Backup data (auto-exported JSONL, local-only)
 backup/
+
+# Per-project environment file (Dolt connection config, GH#2520)
+.env
 
 # Legacy files (from pre-Dolt versions)
 *.db

--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# --- BEGIN BEADS INTEGRATION v0.62.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
-  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run post-checkout "$@"
     _bd_exit=$?
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.60.0 ---
+# --- END BEADS INTEGRATION v0.62.0 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# --- BEGIN BEADS INTEGRATION v0.62.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
-  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run post-merge "$@"
     _bd_exit=$?
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.60.0 ---
+# --- END BEADS INTEGRATION v0.62.0 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# --- BEGIN BEADS INTEGRATION v0.62.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
-  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run pre-commit "$@"
     _bd_exit=$?
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.60.0 ---
+# --- END BEADS INTEGRATION v0.62.0 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# --- BEGIN BEADS INTEGRATION v0.62.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
-  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run pre-push "$@"
     _bd_exit=$?
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.60.0 ---
+# --- END BEADS INTEGRATION v0.62.0 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,9 +1,9 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v0.60.0 ---
+# --- BEGIN BEADS INTEGRATION v0.62.0 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
-  _bd_timeout=${BEADS_HOOK_TIMEOUT:-30}
+  _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
     _bd_exit=$?
@@ -21,4 +21,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v0.60.0 ---
+# --- END BEADS INTEGRATION v0.62.0 ---

--- a/.beads/interactions.jsonl
+++ b/.beads/interactions.jsonl
@@ -1,0 +1,6 @@
+{"id":"int-a1fe6c96","kind":"field_change","created_at":"2026-03-23T18:53:54.786029Z","actor":"AmeDe","issue_id":"tc-60b.2","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-c173ec9d","kind":"field_change","created_at":"2026-03-23T18:53:54.87274Z","actor":"AmeDe","issue_id":"tc-60b.3","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-78369a2a","kind":"field_change","created_at":"2026-03-23T18:53:54.945301Z","actor":"AmeDe","issue_id":"tc-60b.5","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-bae48b35","kind":"field_change","created_at":"2026-03-23T18:53:55.017302Z","actor":"AmeDe","issue_id":"tc-60b.8","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-bad67a7a","kind":"field_change","created_at":"2026-03-23T18:53:55.086201Z","actor":"AmeDe","issue_id":"tc-60b.9","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}
+{"id":"int-0676479c","kind":"field_change","created_at":"2026-03-23T18:53:55.154212Z","actor":"AmeDe","issue_id":"tc-60b.10","extra":{"field":"status","new_value":"closed","old_value":"in_progress","reason":"Closed"}}

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ Carthage/Build/
 
 # Superpowers brainstorm sessions
 .superpowers/
+
+# Beads / Dolt files (added by bd init)
+.beads-credential-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# Agent Instructions
+
+This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work atomically
+bd close <id>         # Complete work
+bd dolt push          # Push beads data to remote
+```
+
+## Non-Interactive Shell Commands
+
+**ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.
+
+Shell commands like `cp`, `mv`, and `rm` may be aliased to include `-i` (interactive) mode on some systems, causing the agent to hang indefinitely waiting for y/n input.
+
+**Use these forms instead:**
+```bash
+# Force overwrite without prompting
+cp -f source dest           # NOT: cp source dest
+mv -f source dest           # NOT: mv source dest
+rm -f file                  # NOT: rm file
+
+# For recursive operations
+rm -rf directory            # NOT: rm -r directory
+cp -rf source dest          # NOT: cp -r source dest
+```
+
+**Other commands that may prompt:**
+- `scp` - use `-o BatchMode=yes` for non-interactive
+- `ssh` - use `-o BatchMode=yes` to fail instead of prompting
+- `apt-get` - use `-y` flag
+- `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->

--- a/api/src/town-crier.application/DemoAccount/GetDemoAccountQueryHandler.cs
+++ b/api/src/town-crier.application/DemoAccount/GetDemoAccountQueryHandler.cs
@@ -44,7 +44,7 @@ public sealed class GetDemoAccountQueryHandler
             profile.ActivateSubscription(SubscriptionTier.Pro, DateTimeOffset.UtcNow.AddYears(10));
             await this.userProfileRepository.SaveAsync(profile, ct).ConfigureAwait(false);
 
-            var zone = new WatchZone(DemoZoneId, DemoUserId, new Coordinates(DemoLatitude, DemoLongitude), DemoRadiusMetres, DemoAuthorityId);
+            var zone = new WatchZone(DemoZoneId, DemoUserId, "Westminster Demo Zone", new Coordinates(DemoLatitude, DemoLongitude), DemoRadiusMetres, DemoAuthorityId);
             await this.watchZoneRepository.SaveAsync(zone, ct).ConfigureAwait(false);
 
             await this.SeedDemoApplicationsAsync(ct).ConfigureAwait(false);

--- a/api/src/town-crier.application/WatchZones/CreateWatchZoneCommand.cs
+++ b/api/src/town-crier.application/WatchZones/CreateWatchZoneCommand.cs
@@ -3,6 +3,7 @@ namespace TownCrier.Application.WatchZones;
 public sealed record CreateWatchZoneCommand(
     string UserId,
     string ZoneId,
+    string Name,
     double Latitude,
     double Longitude,
     double RadiusMetres,

--- a/api/src/town-crier.application/WatchZones/CreateWatchZoneCommandHandler.cs
+++ b/api/src/town-crier.application/WatchZones/CreateWatchZoneCommandHandler.cs
@@ -41,6 +41,7 @@ public sealed class CreateWatchZoneCommandHandler
         var zone = new WatchZone(
             command.ZoneId,
             command.UserId,
+            command.Name,
             new Coordinates(command.Latitude, command.Longitude),
             command.RadiusMetres,
             command.AuthorityId);

--- a/api/src/town-crier.domain/DecisionAlerts/DecisionAlert.cs
+++ b/api/src/town-crier.domain/DecisionAlerts/DecisionAlert.cs
@@ -65,4 +65,25 @@ public sealed class DecisionAlert
     {
         this.PushSent = true;
     }
+
+    internal static DecisionAlert Reconstitute(
+        string id,
+        string userId,
+        string applicationUid,
+        string applicationName,
+        string applicationAddress,
+        string decision,
+        bool pushSent,
+        DateTimeOffset createdAt)
+    {
+        return new DecisionAlert(
+            id,
+            userId,
+            applicationUid,
+            applicationName,
+            applicationAddress,
+            decision,
+            pushSent,
+            createdAt);
+    }
 }

--- a/api/src/town-crier.domain/Groups/Group.cs
+++ b/api/src/town-crier.domain/Groups/Group.cs
@@ -96,4 +96,19 @@ public sealed class Group
     {
         return this.members.Exists(m => m.UserId == userId);
     }
+
+    internal static Group Reconstitute(
+        string id,
+        string name,
+        string ownerId,
+        Coordinates centre,
+        double radiusMetres,
+        int authorityId,
+        DateTimeOffset createdAt,
+        IEnumerable<GroupMember> members)
+    {
+        var group = new Group(id, name, ownerId, centre, radiusMetres, authorityId, createdAt);
+        group.members.AddRange(members);
+        return group;
+    }
 }

--- a/api/src/town-crier.domain/Groups/GroupInvitation.cs
+++ b/api/src/town-crier.domain/Groups/GroupInvitation.cs
@@ -81,4 +81,16 @@ public sealed class GroupInvitation
 
         this.Status = InvitationStatus.Declined;
     }
+
+    internal static GroupInvitation Reconstitute(
+        string id,
+        string groupId,
+        string inviteeEmail,
+        string invitedByUserId,
+        InvitationStatus status,
+        DateTimeOffset createdAt,
+        DateTimeOffset expiresAt)
+    {
+        return new GroupInvitation(id, groupId, inviteeEmail, invitedByUserId, status, createdAt, expiresAt);
+    }
 }

--- a/api/src/town-crier.domain/Groups/GroupMember.cs
+++ b/api/src/town-crier.domain/Groups/GroupMember.cs
@@ -24,4 +24,9 @@ public sealed class GroupMember
     {
         return new GroupMember(userId, GroupRole.Member, now);
     }
+
+    internal static GroupMember Reconstitute(string userId, GroupRole role, DateTimeOffset joinedAt)
+    {
+        return new GroupMember(userId, role, joinedAt);
+    }
 }

--- a/api/src/town-crier.domain/Notifications/Notification.cs
+++ b/api/src/town-crier.domain/Notifications/Notification.cs
@@ -77,4 +77,29 @@ public sealed class Notification
     {
         this.PushSent = true;
     }
+
+    internal static Notification Reconstitute(
+        string id,
+        string userId,
+        string applicationName,
+        string watchZoneId,
+        string applicationAddress,
+        string applicationDescription,
+        string applicationType,
+        int authorityId,
+        bool pushSent,
+        DateTimeOffset createdAt)
+    {
+        return new Notification(
+            id,
+            userId,
+            applicationName,
+            watchZoneId,
+            applicationAddress,
+            applicationDescription,
+            applicationType,
+            authorityId,
+            pushSent,
+            createdAt);
+    }
 }

--- a/api/src/town-crier.domain/UserProfiles/UserProfile.cs
+++ b/api/src/town-crier.domain/UserProfiles/UserProfile.cs
@@ -114,4 +114,31 @@ public sealed class UserProfile
 
         this.zonePreferences[zoneId] = preferences;
     }
+
+    internal static UserProfile Reconstitute(
+        string userId,
+        string? postcode,
+        NotificationPreferences notificationPreferences,
+        Dictionary<string, ZoneNotificationPreferences> zonePreferences,
+        SubscriptionTier tier,
+        DateTimeOffset? subscriptionExpiry,
+        string? originalTransactionId,
+        DateTimeOffset? gracePeriodExpiry)
+    {
+        var profile = new UserProfile(
+            userId,
+            postcode,
+            notificationPreferences,
+            tier,
+            subscriptionExpiry,
+            originalTransactionId,
+            gracePeriodExpiry);
+
+        foreach (var (zoneId, prefs) in zonePreferences)
+        {
+            profile.zonePreferences[zoneId] = prefs;
+        }
+
+        return profile;
+    }
 }

--- a/api/src/town-crier.domain/WatchZones/WatchZone.cs
+++ b/api/src/town-crier.domain/WatchZones/WatchZone.cs
@@ -4,16 +4,18 @@ namespace TownCrier.Domain.WatchZones;
 
 public sealed class WatchZone
 {
-    public WatchZone(string id, string userId, Coordinates centre, double radiusMetres, int authorityId)
+    public WatchZone(string id, string userId, string name, Coordinates centre, double radiusMetres, int authorityId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(id);
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
         ArgumentNullException.ThrowIfNull(centre);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(radiusMetres);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(authorityId);
 
         this.Id = id;
         this.UserId = userId;
+        this.Name = name;
         this.Centre = centre;
         this.RadiusMetres = radiusMetres;
         this.AuthorityId = authorityId;
@@ -22,6 +24,8 @@ public sealed class WatchZone
     public string Id { get; }
 
     public string UserId { get; }
+
+    public string Name { get; }
 
     public Coordinates Centre { get; }
 

--- a/api/src/town-crier.domain/town-crier.domain.csproj
+++ b/api/src/town-crier.domain/town-crier.domain.csproj
@@ -8,5 +8,9 @@
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="town-crier.infrastructure" />
+    <InternalsVisibleTo Include="town-crier.infrastructure.tests" />
+  </ItemGroup>
 
 </Project>

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosClientFactory.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosClientFactory.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using Microsoft.Azure.Cosmos;
+
+namespace TownCrier.Infrastructure.Cosmos;
+
+public static class CosmosClientFactory
+{
+    public static CosmosClient Create(string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        jsonOptions.TypeInfoResolverChain.Add(CosmosJsonSerializerContext.Default);
+
+        var cosmosOptions = new CosmosClientOptions
+        {
+            Serializer = new SystemTextJsonCosmosSerializer(jsonOptions),
+        };
+
+        return new CosmosClient(connectionString, cosmosOptions);
+    }
+}

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
@@ -1,10 +1,21 @@
 using System.Text.Json.Serialization;
 using TownCrier.Domain.Geocoding;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.DeviceRegistrations;
+using TownCrier.Infrastructure.SavedApplications;
+using TownCrier.Infrastructure.WatchZones;
 
 namespace TownCrier.Infrastructure.Cosmos;
 
 [JsonSerializable(typeof(Coordinates))]
 [JsonSerializable(typeof(NotificationPreferences))]
 [JsonSerializable(typeof(ZoneNotificationPreferences))]
+[JsonSerializable(typeof(DeviceRegistrationDocument))]
+[JsonSerializable(typeof(List<DeviceRegistrationDocument>))]
+[JsonSerializable(typeof(SavedApplicationDocument))]
+[JsonSerializable(typeof(List<SavedApplicationDocument>))]
+[JsonSerializable(typeof(WatchZoneDocument))]
+[JsonSerializable(typeof(List<WatchZoneDocument>))]
+[JsonSerializable(typeof(AuthorityZoneCountResult))]
+[JsonSerializable(typeof(int))]
 internal sealed partial class CosmosJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
@@ -1,10 +1,14 @@
 using System.Text.Json.Serialization;
 using TownCrier.Domain.Geocoding;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.PlanningApplications;
 
 namespace TownCrier.Infrastructure.Cosmos;
 
 [JsonSerializable(typeof(Coordinates))]
 [JsonSerializable(typeof(NotificationPreferences))]
 [JsonSerializable(typeof(ZoneNotificationPreferences))]
+[JsonSerializable(typeof(PlanningApplicationDocument))]
+[JsonSerializable(typeof(List<PlanningApplicationDocument>))]
+[JsonSerializable(typeof(GeoJsonPoint))]
 internal sealed partial class CosmosJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
 using TownCrier.Domain.Geocoding;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.Notifications;
 
 namespace TownCrier.Infrastructure.Cosmos;
 
 [JsonSerializable(typeof(Coordinates))]
 [JsonSerializable(typeof(NotificationPreferences))]
 [JsonSerializable(typeof(ZoneNotificationPreferences))]
+[JsonSerializable(typeof(NotificationDocument))]
+[JsonSerializable(typeof(List<NotificationDocument>))]
 internal sealed partial class CosmosJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
@@ -1,10 +1,17 @@
 using System.Text.Json.Serialization;
 using TownCrier.Domain.Geocoding;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.Groups;
 
 namespace TownCrier.Infrastructure.Cosmos;
 
 [JsonSerializable(typeof(Coordinates))]
 [JsonSerializable(typeof(NotificationPreferences))]
 [JsonSerializable(typeof(ZoneNotificationPreferences))]
+[JsonSerializable(typeof(GroupDocument))]
+[JsonSerializable(typeof(List<GroupDocument>))]
+[JsonSerializable(typeof(GroupMemberDocument))]
+[JsonSerializable(typeof(List<GroupMemberDocument>))]
+[JsonSerializable(typeof(GroupInvitationDocument))]
+[JsonSerializable(typeof(List<GroupInvitationDocument>))]
 internal sealed partial class CosmosJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
@@ -1,10 +1,12 @@
 using System.Text.Json.Serialization;
 using TownCrier.Domain.Geocoding;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.DecisionAlerts;
 
 namespace TownCrier.Infrastructure.Cosmos;
 
 [JsonSerializable(typeof(Coordinates))]
 [JsonSerializable(typeof(NotificationPreferences))]
 [JsonSerializable(typeof(ZoneNotificationPreferences))]
+[JsonSerializable(typeof(DecisionAlertDocument))]
 internal sealed partial class CosmosJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
 using TownCrier.Domain.Geocoding;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.UserProfiles;
 
 namespace TownCrier.Infrastructure.Cosmos;
 
 [JsonSerializable(typeof(Coordinates))]
 [JsonSerializable(typeof(NotificationPreferences))]
 [JsonSerializable(typeof(ZoneNotificationPreferences))]
+[JsonSerializable(typeof(UserProfileDocument))]
+[JsonSerializable(typeof(List<UserProfileDocument>))]
 internal sealed partial class CosmosJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+using TownCrier.Domain.Geocoding;
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Infrastructure.Cosmos;
+
+[JsonSerializable(typeof(Coordinates))]
+[JsonSerializable(typeof(NotificationPreferences))]
+[JsonSerializable(typeof(ZoneNotificationPreferences))]
+internal sealed partial class CosmosJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
@@ -1,10 +1,13 @@
 using System.Text.Json.Serialization;
 using TownCrier.Domain.Geocoding;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.SavedApplications;
 
 namespace TownCrier.Infrastructure.Cosmos;
 
 [JsonSerializable(typeof(Coordinates))]
 [JsonSerializable(typeof(NotificationPreferences))]
 [JsonSerializable(typeof(ZoneNotificationPreferences))]
+[JsonSerializable(typeof(SavedApplicationDocument))]
+[JsonSerializable(typeof(List<SavedApplicationDocument>))]
 internal sealed partial class CosmosJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
@@ -1,0 +1,23 @@
+using System.Text.Json;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace TownCrier.Infrastructure.Cosmos;
+
+public static class CosmosServiceExtensions
+{
+    public static IServiceCollection AddCosmosClient(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddSingleton(_ =>
+        {
+            var connectionString = configuration.GetConnectionString("CosmosDb")
+                ?? throw new InvalidOperationException(
+                    "Cosmos DB connection string is required. Set 'ConnectionStrings:CosmosDb' in configuration.");
+
+            return CosmosClientFactory.Create(connectionString);
+        });
+
+        return services;
+    }
+}

--- a/api/src/town-crier.infrastructure/Cosmos/SystemTextJsonCosmosSerializer.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/SystemTextJsonCosmosSerializer.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using Microsoft.Azure.Cosmos;
+
+namespace TownCrier.Infrastructure.Cosmos;
+
+public sealed class SystemTextJsonCosmosSerializer : CosmosSerializer
+{
+    private readonly JsonSerializerOptions options;
+
+    public SystemTextJsonCosmosSerializer(JsonSerializerOptions options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        this.options = options;
+    }
+
+    public override T FromStream<T>(Stream stream)
+    {
+        using (stream)
+        {
+            if (typeof(Stream).IsAssignableFrom(typeof(T)))
+            {
+                return (T)(object)stream;
+            }
+
+            return JsonSerializer.Deserialize<T>(stream, this.options)!;
+        }
+    }
+
+    public override Stream ToStream<T>(T input)
+    {
+        var stream = new MemoryStream();
+        JsonSerializer.Serialize(stream, input, this.options);
+        stream.Position = 0;
+        return stream;
+    }
+}

--- a/api/src/town-crier.infrastructure/DecisionAlerts/CosmosDecisionAlertRepository.cs
+++ b/api/src/town-crier.infrastructure/DecisionAlerts/CosmosDecisionAlertRepository.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using TownCrier.Application.DecisionAlerts;
+using TownCrier.Domain.DecisionAlerts;
+
+namespace TownCrier.Infrastructure.DecisionAlerts;
+
+public sealed class CosmosDecisionAlertRepository : IDecisionAlertRepository
+{
+    private readonly Container container;
+
+    public CosmosDecisionAlertRepository(CosmosClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        this.container = client.GetContainer("town-crier", "DecisionAlerts");
+    }
+
+    public async Task<DecisionAlert?> GetByUserAndApplicationAsync(
+        string userId, string applicationUid, CancellationToken ct)
+    {
+        var documentId = DecisionAlertDocument.MakeId(userId, applicationUid);
+
+        try
+        {
+            var response = await this.container.ReadItemAsync<DecisionAlertDocument>(
+                documentId,
+                new PartitionKey(userId),
+                cancellationToken: ct).ConfigureAwait(false);
+
+            return response.Resource.ToDomain();
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task SaveAsync(DecisionAlert alert, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(alert);
+
+        var document = DecisionAlertDocument.FromDomain(alert);
+
+        await this.container.UpsertItemAsync(
+            document,
+            new PartitionKey(document.UserId),
+            cancellationToken: ct).ConfigureAwait(false);
+    }
+}

--- a/api/src/town-crier.infrastructure/DecisionAlerts/DecisionAlertDocument.cs
+++ b/api/src/town-crier.infrastructure/DecisionAlerts/DecisionAlertDocument.cs
@@ -1,0 +1,57 @@
+using TownCrier.Domain.DecisionAlerts;
+
+namespace TownCrier.Infrastructure.DecisionAlerts;
+
+internal sealed class DecisionAlertDocument
+{
+    public required string Id { get; init; }
+
+    public required string EntityId { get; init; }
+
+    public required string UserId { get; init; }
+
+    public required string ApplicationUid { get; init; }
+
+    public required string ApplicationName { get; init; }
+
+    public required string ApplicationAddress { get; init; }
+
+    public required string Decision { get; init; }
+
+    public required bool PushSent { get; init; }
+
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    public static DecisionAlertDocument FromDomain(DecisionAlert alert)
+    {
+        ArgumentNullException.ThrowIfNull(alert);
+
+        return new DecisionAlertDocument
+        {
+            Id = MakeId(alert.UserId, alert.ApplicationUid),
+            EntityId = alert.Id,
+            UserId = alert.UserId,
+            ApplicationUid = alert.ApplicationUid,
+            ApplicationName = alert.ApplicationName,
+            ApplicationAddress = alert.ApplicationAddress,
+            Decision = alert.Decision,
+            PushSent = alert.PushSent,
+            CreatedAt = alert.CreatedAt,
+        };
+    }
+
+    public DecisionAlert ToDomain()
+    {
+        return DecisionAlert.Reconstitute(
+            this.EntityId,
+            this.UserId,
+            this.ApplicationUid,
+            this.ApplicationName,
+            this.ApplicationAddress,
+            this.Decision,
+            this.PushSent,
+            this.CreatedAt);
+    }
+
+    internal static string MakeId(string userId, string applicationUid) => $"{userId}:{applicationUid}";
+}

--- a/api/src/town-crier.infrastructure/DeviceRegistrations/CosmosDeviceRegistrationRepository.cs
+++ b/api/src/town-crier.infrastructure/DeviceRegistrations/CosmosDeviceRegistrationRepository.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using TownCrier.Application.DeviceRegistrations;
+using TownCrier.Domain.DeviceRegistrations;
+
+namespace TownCrier.Infrastructure.DeviceRegistrations;
+
+public sealed class CosmosDeviceRegistrationRepository : IDeviceRegistrationRepository
+{
+    private readonly Container container;
+
+    public CosmosDeviceRegistrationRepository(CosmosClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        this.container = client.GetContainer("town-crier", "DeviceRegistrations");
+    }
+
+    public async Task<DeviceRegistration?> GetByTokenAsync(string token, CancellationToken ct)
+    {
+        var query = new QueryDefinition("SELECT * FROM c WHERE c.token = @token")
+            .WithParameter("@token", token);
+
+        using var iterator = this.container.GetItemQueryIterator<DeviceRegistrationDocument>(
+            query,
+            requestOptions: new QueryRequestOptions { MaxItemCount = 1 });
+
+        if (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            var document = response.FirstOrDefault();
+
+            return document?.ToDomain();
+        }
+
+        return null;
+    }
+
+    public async Task<IReadOnlyList<DeviceRegistration>> GetByUserIdAsync(string userId, CancellationToken ct)
+    {
+        var query = new QueryDefinition("SELECT * FROM c WHERE c.userId = @userId")
+            .WithParameter("@userId", userId);
+
+        using var iterator = this.container.GetItemQueryIterator<DeviceRegistrationDocument>(
+            query,
+            requestOptions: new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(userId),
+            });
+
+        var results = new List<DeviceRegistration>();
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+
+            foreach (var document in response)
+            {
+                results.Add(document.ToDomain());
+            }
+        }
+
+        return results;
+    }
+
+    public async Task SaveAsync(DeviceRegistration registration, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+
+        var document = DeviceRegistrationDocument.FromDomain(registration);
+
+        await this.container.UpsertItemAsync(
+            document,
+            new PartitionKey(document.UserId),
+            cancellationToken: ct).ConfigureAwait(false);
+    }
+
+    public async Task DeleteByTokenAsync(string token, CancellationToken ct)
+    {
+        // Token is not the partition key, so we must find the document first
+        // to get the userId (partition key) needed for deletion.
+        var query = new QueryDefinition("SELECT c.id, c.userId FROM c WHERE c.token = @token")
+            .WithParameter("@token", token);
+
+        using var iterator = this.container.GetItemQueryIterator<DeviceRegistrationDocument>(query);
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+
+            foreach (var document in response)
+            {
+                try
+                {
+                    await this.container.DeleteItemAsync<DeviceRegistrationDocument>(
+                        document.Id,
+                        new PartitionKey(document.UserId),
+                        cancellationToken: ct).ConfigureAwait(false);
+                }
+                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                {
+                    // Already deleted — idempotent
+                }
+            }
+        }
+    }
+}

--- a/api/src/town-crier.infrastructure/DeviceRegistrations/DeviceRegistrationDocument.cs
+++ b/api/src/town-crier.infrastructure/DeviceRegistrations/DeviceRegistrationDocument.cs
@@ -1,0 +1,36 @@
+using TownCrier.Domain.DeviceRegistrations;
+
+namespace TownCrier.Infrastructure.DeviceRegistrations;
+
+internal sealed class DeviceRegistrationDocument
+{
+    public required string Id { get; init; }
+
+    public required string UserId { get; init; }
+
+    public required string Token { get; init; }
+
+    public required string Platform { get; init; }
+
+    public required DateTimeOffset RegisteredAt { get; init; }
+
+    public static DeviceRegistrationDocument FromDomain(DeviceRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+
+        return new DeviceRegistrationDocument
+        {
+            Id = registration.Token,
+            UserId = registration.UserId,
+            Token = registration.Token,
+            Platform = registration.Platform.ToString(),
+            RegisteredAt = registration.RegisteredAt,
+        };
+    }
+
+    public DeviceRegistration ToDomain()
+    {
+        var platform = Enum.Parse<DevicePlatform>(this.Platform);
+        return DeviceRegistration.Create(this.UserId, this.Token, platform, this.RegisteredAt);
+    }
+}

--- a/api/src/town-crier.infrastructure/Groups/CosmosGroupInvitationRepository.cs
+++ b/api/src/town-crier.infrastructure/Groups/CosmosGroupInvitationRepository.cs
@@ -1,0 +1,85 @@
+using Microsoft.Azure.Cosmos;
+using TownCrier.Application.Groups;
+using TownCrier.Domain.Groups;
+
+namespace TownCrier.Infrastructure.Groups;
+
+public sealed class CosmosGroupInvitationRepository : IGroupInvitationRepository
+{
+    private readonly Container container;
+
+    public CosmosGroupInvitationRepository(CosmosClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        this.container = client.GetContainer("town-crier", "groups");
+    }
+
+    public async Task<GroupInvitation?> GetByIdAsync(string invitationId, CancellationToken ct)
+    {
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE c.id = @id AND c.type = 'invitation'")
+            .WithParameter("@id", invitationId);
+
+        using var iterator = this.container.GetItemQueryIterator<GroupInvitationDocument>(
+            query,
+            requestOptions: new QueryRequestOptions { MaxItemCount = 1 });
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            var document = response.FirstOrDefault();
+            if (document is not null)
+            {
+                return document.ToDomain();
+            }
+        }
+
+        return null;
+    }
+
+    public async Task SaveAsync(GroupInvitation invitation, CancellationToken ct)
+    {
+        var document = GroupInvitationDocument.FromDomain(invitation);
+        await this.container.UpsertItemAsync(
+            document,
+            new PartitionKey(document.OwnerId),
+            cancellationToken: ct).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<GroupInvitation>> GetPendingByGroupIdAsync(string groupId, CancellationToken ct)
+    {
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE c.type = 'invitation' AND c.groupId = @groupId AND c.status = 'Pending'")
+            .WithParameter("@groupId", groupId);
+
+        return await this.QueryInvitationsAsync(query, ct).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<GroupInvitation>> GetPendingByEmailAsync(string email, CancellationToken ct)
+    {
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE c.type = 'invitation' AND c.inviteeEmail = @email AND c.status = 'Pending'")
+            .WithParameter("@email", email);
+
+        return await this.QueryInvitationsAsync(query, ct).ConfigureAwait(false);
+    }
+
+    private async Task<IReadOnlyList<GroupInvitation>> QueryInvitationsAsync(
+        QueryDefinition query,
+        CancellationToken ct)
+    {
+        using var iterator = this.container.GetItemQueryIterator<GroupInvitationDocument>(query);
+
+        var invitations = new List<GroupInvitation>();
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            foreach (var document in response)
+            {
+                invitations.Add(document.ToDomain());
+            }
+        }
+
+        return invitations;
+    }
+}

--- a/api/src/town-crier.infrastructure/Groups/CosmosGroupRepository.cs
+++ b/api/src/town-crier.infrastructure/Groups/CosmosGroupRepository.cs
@@ -1,0 +1,94 @@
+using Microsoft.Azure.Cosmos;
+using TownCrier.Application.Groups;
+using TownCrier.Domain.Groups;
+
+namespace TownCrier.Infrastructure.Groups;
+
+public sealed class CosmosGroupRepository : IGroupRepository
+{
+    private readonly Container container;
+
+    public CosmosGroupRepository(CosmosClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        this.container = client.GetContainer("town-crier", "groups");
+    }
+
+    public async Task<Group?> GetByIdAsync(string groupId, CancellationToken ct)
+    {
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE c.id = @id AND c.type = 'group'")
+            .WithParameter("@id", groupId);
+
+        using var iterator = this.container.GetItemQueryIterator<GroupDocument>(
+            query,
+            requestOptions: new QueryRequestOptions { MaxItemCount = 1 });
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            var document = response.FirstOrDefault();
+            if (document is not null)
+            {
+                return document.ToDomain();
+            }
+        }
+
+        return null;
+    }
+
+    public async Task SaveAsync(Group group, CancellationToken ct)
+    {
+        var document = GroupDocument.FromDomain(group);
+        await this.container.UpsertItemAsync(
+            document,
+            new PartitionKey(document.OwnerId),
+            cancellationToken: ct).ConfigureAwait(false);
+    }
+
+    public async Task DeleteAsync(string groupId, CancellationToken ct)
+    {
+        var query = new QueryDefinition(
+            "SELECT c.id, c.ownerId FROM c WHERE c.id = @id AND c.type = 'group'")
+            .WithParameter("@id", groupId);
+
+        using var iterator = this.container.GetItemQueryIterator<GroupDocument>(
+            query,
+            requestOptions: new QueryRequestOptions { MaxItemCount = 1 });
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            var document = response.FirstOrDefault();
+            if (document is not null)
+            {
+                await this.container.DeleteItemAsync<GroupDocument>(
+                    document.Id,
+                    new PartitionKey(document.OwnerId),
+                    cancellationToken: ct).ConfigureAwait(false);
+                return;
+            }
+        }
+    }
+
+    public async Task<IReadOnlyList<Group>> GetByUserIdAsync(string userId, CancellationToken ct)
+    {
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE c.type = 'group' AND ARRAY_CONTAINS(c.members, {\"userId\": @userId}, true)")
+            .WithParameter("@userId", userId);
+
+        using var iterator = this.container.GetItemQueryIterator<GroupDocument>(query);
+
+        var groups = new List<Group>();
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            foreach (var document in response)
+            {
+                groups.Add(document.ToDomain());
+            }
+        }
+
+        return groups;
+    }
+}

--- a/api/src/town-crier.infrastructure/Groups/GroupDocument.cs
+++ b/api/src/town-crier.infrastructure/Groups/GroupDocument.cs
@@ -1,0 +1,61 @@
+using TownCrier.Domain.Geocoding;
+using TownCrier.Domain.Groups;
+
+namespace TownCrier.Infrastructure.Groups;
+
+internal sealed class GroupDocument
+{
+    public required string Id { get; init; }
+
+    public required string Type { get; init; }
+
+    public required string OwnerId { get; init; }
+
+    public required string Name { get; init; }
+
+    public required double CentreLatitude { get; init; }
+
+    public required double CentreLongitude { get; init; }
+
+    public required double RadiusMetres { get; init; }
+
+    public required int AuthorityId { get; init; }
+
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    public required List<GroupMemberDocument> Members { get; init; }
+
+    public static GroupDocument FromDomain(Group group)
+    {
+        ArgumentNullException.ThrowIfNull(group);
+
+        return new GroupDocument
+        {
+            Id = group.Id,
+            Type = "group",
+            OwnerId = group.OwnerId,
+            Name = group.Name,
+            CentreLatitude = group.Centre.Latitude,
+            CentreLongitude = group.Centre.Longitude,
+            RadiusMetres = group.RadiusMetres,
+            AuthorityId = group.AuthorityId,
+            CreatedAt = group.CreatedAt,
+            Members = group.Members.Select(GroupMemberDocument.FromDomain).ToList(),
+        };
+    }
+
+    public Group ToDomain()
+    {
+        var members = this.Members.Select(m => m.ToDomain());
+
+        return Group.Reconstitute(
+            this.Id,
+            this.Name,
+            this.OwnerId,
+            new Coordinates(this.CentreLatitude, this.CentreLongitude),
+            this.RadiusMetres,
+            this.AuthorityId,
+            this.CreatedAt,
+            members);
+    }
+}

--- a/api/src/town-crier.infrastructure/Groups/GroupInvitationDocument.cs
+++ b/api/src/town-crier.infrastructure/Groups/GroupInvitationDocument.cs
@@ -1,0 +1,55 @@
+using TownCrier.Domain.Groups;
+
+namespace TownCrier.Infrastructure.Groups;
+
+internal sealed class GroupInvitationDocument
+{
+    public required string Id { get; init; }
+
+    public required string Type { get; init; }
+
+    public required string OwnerId { get; init; }
+
+    public required string GroupId { get; init; }
+
+    public required string InviteeEmail { get; init; }
+
+    public required string InvitedByUserId { get; init; }
+
+    public required string Status { get; init; }
+
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    public required DateTimeOffset ExpiresAt { get; init; }
+
+    public static GroupInvitationDocument FromDomain(GroupInvitation invitation)
+    {
+        ArgumentNullException.ThrowIfNull(invitation);
+
+        return new GroupInvitationDocument
+        {
+            Id = invitation.Id,
+            Type = "invitation",
+            OwnerId = invitation.InvitedByUserId,
+            GroupId = invitation.GroupId,
+            InviteeEmail = invitation.InviteeEmail,
+            InvitedByUserId = invitation.InvitedByUserId,
+            Status = invitation.Status.ToString(),
+            CreatedAt = invitation.CreatedAt,
+            ExpiresAt = invitation.ExpiresAt,
+        };
+    }
+
+    public GroupInvitation ToDomain()
+    {
+        var status = Enum.Parse<InvitationStatus>(this.Status);
+        return GroupInvitation.Reconstitute(
+            this.Id,
+            this.GroupId,
+            this.InviteeEmail,
+            this.InvitedByUserId,
+            status,
+            this.CreatedAt,
+            this.ExpiresAt);
+    }
+}

--- a/api/src/town-crier.infrastructure/Groups/GroupMemberDocument.cs
+++ b/api/src/town-crier.infrastructure/Groups/GroupMemberDocument.cs
@@ -1,0 +1,28 @@
+using TownCrier.Domain.Groups;
+
+namespace TownCrier.Infrastructure.Groups;
+
+internal sealed class GroupMemberDocument
+{
+    public required string UserId { get; init; }
+
+    public required string Role { get; init; }
+
+    public required DateTimeOffset JoinedAt { get; init; }
+
+    public static GroupMemberDocument FromDomain(GroupMember member)
+    {
+        return new GroupMemberDocument
+        {
+            UserId = member.UserId,
+            Role = member.Role.ToString(),
+            JoinedAt = member.JoinedAt,
+        };
+    }
+
+    public GroupMember ToDomain()
+    {
+        var role = Enum.Parse<GroupRole>(this.Role);
+        return GroupMember.Reconstitute(this.UserId, role, this.JoinedAt);
+    }
+}

--- a/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
@@ -1,0 +1,158 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using TownCrier.Application.Notifications;
+using TownCrier.Domain.Notifications;
+
+namespace TownCrier.Infrastructure.Notifications;
+
+public sealed class CosmosNotificationRepository : INotificationRepository
+{
+    private readonly Container container;
+
+    public CosmosNotificationRepository(CosmosClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        this.container = client.GetContainer("town-crier", "notifications");
+    }
+
+    public async Task<Notification?> GetByUserAndApplicationAsync(
+        string userId, string applicationName, CancellationToken ct)
+    {
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE c.userId = @userId AND c.applicationName = @appName")
+            .WithParameter("@userId", userId)
+            .WithParameter("@appName", applicationName);
+
+        using var iterator = this.container.GetItemQueryIterator<NotificationDocument>(
+            query,
+            requestOptions: new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(userId),
+            });
+
+        if (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            var document = response.FirstOrDefault();
+            return document?.ToDomain();
+        }
+
+        return null;
+    }
+
+    public async Task<int> CountByUserInMonthAsync(
+        string userId, int year, int month, CancellationToken ct)
+    {
+        var startOfMonth = new DateTimeOffset(year, month, 1, 0, 0, 0, TimeSpan.Zero);
+        var startOfNextMonth = startOfMonth.AddMonths(1);
+
+        var query = new QueryDefinition(
+            "SELECT VALUE COUNT(1) FROM c WHERE c.userId = @userId AND c.createdAt >= @start AND c.createdAt < @end")
+            .WithParameter("@userId", userId)
+            .WithParameter("@start", startOfMonth)
+            .WithParameter("@end", startOfNextMonth);
+
+        using var iterator = this.container.GetItemQueryIterator<int>(
+            query,
+            requestOptions: new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(userId),
+            });
+
+        if (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            return response.FirstOrDefault();
+        }
+
+        return 0;
+    }
+
+    public async Task<int> CountByUserSinceAsync(
+        string userId, DateTimeOffset since, CancellationToken ct)
+    {
+        var query = new QueryDefinition(
+            "SELECT VALUE COUNT(1) FROM c WHERE c.userId = @userId AND c.createdAt >= @since")
+            .WithParameter("@userId", userId)
+            .WithParameter("@since", since);
+
+        using var iterator = this.container.GetItemQueryIterator<int>(
+            query,
+            requestOptions: new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(userId),
+            });
+
+        if (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            return response.FirstOrDefault();
+        }
+
+        return 0;
+    }
+
+    public async Task<(IReadOnlyList<Notification> Items, int Total)> GetByUserPaginatedAsync(
+        string userId, int page, int pageSize, CancellationToken ct)
+    {
+        // Count total notifications for this user
+        var countQuery = new QueryDefinition(
+            "SELECT VALUE COUNT(1) FROM c WHERE c.userId = @userId")
+            .WithParameter("@userId", userId);
+
+        int total = 0;
+        using (var countIterator = this.container.GetItemQueryIterator<int>(
+            countQuery,
+            requestOptions: new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(userId),
+            }))
+        {
+            if (countIterator.HasMoreResults)
+            {
+                var countResponse = await countIterator.ReadNextAsync(ct).ConfigureAwait(false);
+                total = countResponse.FirstOrDefault();
+            }
+        }
+
+        if (total == 0)
+        {
+            return (Array.Empty<Notification>(), 0);
+        }
+
+        // Fetch page — reverse-chronological by _ts
+        var offset = (page - 1) * pageSize;
+        var itemsQuery = new QueryDefinition(
+            "SELECT * FROM c WHERE c.userId = @userId ORDER BY c._ts DESC OFFSET @offset LIMIT @limit")
+            .WithParameter("@userId", userId)
+            .WithParameter("@offset", offset)
+            .WithParameter("@limit", pageSize);
+
+        var items = new List<Notification>();
+        using var itemsIterator = this.container.GetItemQueryIterator<NotificationDocument>(
+            itemsQuery,
+            requestOptions: new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey(userId),
+            });
+
+        while (itemsIterator.HasMoreResults)
+        {
+            var response = await itemsIterator.ReadNextAsync(ct).ConfigureAwait(false);
+            items.AddRange(response.Select(doc => doc.ToDomain()));
+        }
+
+        return (items, total);
+    }
+
+    public async Task SaveAsync(Notification notification, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+        var document = NotificationDocument.FromDomain(notification);
+
+        await this.container.UpsertItemAsync(
+            document,
+            new PartitionKey(document.UserId),
+            cancellationToken: ct).ConfigureAwait(false);
+    }
+}

--- a/api/src/town-crier.infrastructure/Notifications/NotificationDocument.cs
+++ b/api/src/town-crier.infrastructure/Notifications/NotificationDocument.cs
@@ -1,0 +1,75 @@
+using System.Text.Json.Serialization;
+using TownCrier.Domain.Notifications;
+
+namespace TownCrier.Infrastructure.Notifications;
+
+internal sealed class NotificationDocument
+{
+    private const int NinetyDaysInSeconds = 90 * 24 * 60 * 60;
+
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("userId")]
+    public required string UserId { get; init; }
+
+    [JsonPropertyName("applicationName")]
+    public required string ApplicationName { get; init; }
+
+    [JsonPropertyName("watchZoneId")]
+    public required string WatchZoneId { get; init; }
+
+    [JsonPropertyName("applicationAddress")]
+    public required string ApplicationAddress { get; init; }
+
+    [JsonPropertyName("applicationDescription")]
+    public required string ApplicationDescription { get; init; }
+
+    [JsonPropertyName("applicationType")]
+    public required string ApplicationType { get; init; }
+
+    [JsonPropertyName("authorityId")]
+    public required int AuthorityId { get; init; }
+
+    [JsonPropertyName("pushSent")]
+    public required bool PushSent { get; init; }
+
+    [JsonPropertyName("createdAt")]
+    public required DateTimeOffset CreatedAt { get; init; }
+
+    [JsonPropertyName("ttl")]
+    public int Ttl { get; init; } = NinetyDaysInSeconds;
+
+    public static NotificationDocument FromDomain(Notification notification)
+    {
+        return new NotificationDocument
+        {
+            Id = notification.Id,
+            UserId = notification.UserId,
+            ApplicationName = notification.ApplicationName,
+            WatchZoneId = notification.WatchZoneId,
+            ApplicationAddress = notification.ApplicationAddress,
+            ApplicationDescription = notification.ApplicationDescription,
+            ApplicationType = notification.ApplicationType,
+            AuthorityId = notification.AuthorityId,
+            PushSent = notification.PushSent,
+            CreatedAt = notification.CreatedAt,
+            Ttl = NinetyDaysInSeconds,
+        };
+    }
+
+    public Notification ToDomain()
+    {
+        return Notification.Reconstitute(
+            this.Id,
+            this.UserId,
+            this.ApplicationName,
+            this.WatchZoneId,
+            this.ApplicationAddress,
+            this.ApplicationDescription,
+            this.ApplicationType,
+            this.AuthorityId,
+            this.PushSent,
+            this.CreatedAt);
+    }
+}

--- a/api/src/town-crier.infrastructure/PlanningApplications/CosmosPlanningApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/PlanningApplications/CosmosPlanningApplicationRepository.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using TownCrier.Application.PlanningApplications;
+using TownCrier.Domain.PlanningApplications;
+
+namespace TownCrier.Infrastructure.PlanningApplications;
+
+public sealed class CosmosPlanningApplicationRepository : IPlanningApplicationRepository
+{
+    private readonly Container container;
+
+    public CosmosPlanningApplicationRepository(CosmosClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        this.container = client.GetContainer("town-crier", "Applications");
+    }
+
+    public async Task UpsertAsync(PlanningApplication application, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+
+        var document = PlanningApplicationDocument.FromDomain(application);
+        await this.container.UpsertItemAsync(
+            document,
+            new PartitionKey(document.AuthorityCode),
+            cancellationToken: ct).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyCollection<PlanningApplication>> FindNearbyAsync(
+        double latitude, double longitude, double radiusMetres, CancellationToken ct)
+    {
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE ST_DISTANCE(c.location, {\"type\": \"Point\", \"coordinates\": [@lng, @lat]}) <= @radius")
+            .WithParameter("@lng", longitude)
+            .WithParameter("@lat", latitude)
+            .WithParameter("@radius", radiusMetres);
+
+        var results = new List<PlanningApplication>();
+        using var iterator = this.container.GetItemQueryIterator<PlanningApplicationDocument>(query);
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            foreach (var document in response)
+            {
+                results.Add(document.ToDomain());
+            }
+        }
+
+        return results;
+    }
+}

--- a/api/src/town-crier.infrastructure/PlanningApplications/GeoJsonPoint.cs
+++ b/api/src/town-crier.infrastructure/PlanningApplications/GeoJsonPoint.cs
@@ -1,0 +1,8 @@
+namespace TownCrier.Infrastructure.PlanningApplications;
+
+internal sealed class GeoJsonPoint
+{
+    public string Type { get; init; } = "Point";
+
+    public double[] Coordinates { get; init; } = [];
+}

--- a/api/src/town-crier.infrastructure/PlanningApplications/PlanningApplicationDocument.cs
+++ b/api/src/town-crier.infrastructure/PlanningApplications/PlanningApplicationDocument.cs
@@ -1,0 +1,99 @@
+using System.Diagnostics.CodeAnalysis;
+using TownCrier.Domain.PlanningApplications;
+
+namespace TownCrier.Infrastructure.PlanningApplications;
+
+internal sealed class PlanningApplicationDocument
+{
+    public required string Id { get; init; }
+
+    public required string AuthorityCode { get; init; }
+
+    public required string PlanitName { get; init; }
+
+    public required string Uid { get; init; }
+
+    public required string AreaName { get; init; }
+
+    public required int AreaId { get; init; }
+
+    public required string Address { get; init; }
+
+    public string? Postcode { get; init; }
+
+    public required string Description { get; init; }
+
+    public required string AppType { get; init; }
+
+    public required string AppState { get; init; }
+
+    public string? AppSize { get; init; }
+
+    public DateOnly? StartDate { get; init; }
+
+    public DateOnly? DecidedDate { get; init; }
+
+    public DateOnly? ConsultedDate { get; init; }
+
+    public GeoJsonPoint? Location { get; init; }
+
+    [SuppressMessage("Design", "CA1056:URI properties should not be strings", Justification = "PlanIt API returns URLs as strings")]
+    public string? Url { get; init; }
+
+    public string? Link { get; init; }
+
+    public required DateTimeOffset LastDifferent { get; init; }
+
+    public static PlanningApplicationDocument FromDomain(PlanningApplication application)
+    {
+        ArgumentNullException.ThrowIfNull(application);
+
+        return new PlanningApplicationDocument
+        {
+            Id = application.Name,
+            AuthorityCode = application.AreaId.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            PlanitName = application.Name,
+            Uid = application.Uid,
+            AreaName = application.AreaName,
+            AreaId = application.AreaId,
+            Address = application.Address,
+            Postcode = application.Postcode,
+            Description = application.Description,
+            AppType = application.AppType,
+            AppState = application.AppState,
+            AppSize = application.AppSize,
+            StartDate = application.StartDate,
+            DecidedDate = application.DecidedDate,
+            ConsultedDate = application.ConsultedDate,
+            Location = application.Latitude.HasValue && application.Longitude.HasValue
+                ? new GeoJsonPoint { Coordinates = [application.Longitude.Value, application.Latitude.Value] }
+                : null,
+            Url = application.Url,
+            Link = application.Link,
+            LastDifferent = application.LastDifferent,
+        };
+    }
+
+    public PlanningApplication ToDomain()
+    {
+        return new PlanningApplication(
+            name: this.PlanitName,
+            uid: this.Uid,
+            areaName: this.AreaName,
+            areaId: this.AreaId,
+            address: this.Address,
+            postcode: this.Postcode,
+            description: this.Description,
+            appType: this.AppType,
+            appState: this.AppState,
+            appSize: this.AppSize,
+            startDate: this.StartDate,
+            decidedDate: this.DecidedDate,
+            consultedDate: this.ConsultedDate,
+            longitude: this.Location?.Coordinates.Length >= 2 ? this.Location.Coordinates[0] : null,
+            latitude: this.Location?.Coordinates.Length >= 2 ? this.Location.Coordinates[1] : null,
+            url: this.Url,
+            link: this.Link,
+            lastDifferent: this.LastDifferent);
+    }
+}

--- a/api/src/town-crier.infrastructure/SavedApplications/CosmosSavedApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/SavedApplications/CosmosSavedApplicationRepository.cs
@@ -1,0 +1,103 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using TownCrier.Application.SavedApplications;
+using TownCrier.Domain.SavedApplications;
+
+namespace TownCrier.Infrastructure.SavedApplications;
+
+public sealed class CosmosSavedApplicationRepository : ISavedApplicationRepository
+{
+    private readonly Container container;
+
+    public CosmosSavedApplicationRepository(CosmosClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        this.container = client.GetContainer("town-crier", "SavedApplications");
+    }
+
+    public async Task SaveAsync(SavedApplication savedApplication, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(savedApplication);
+
+        var document = SavedApplicationDocument.FromDomain(savedApplication);
+        await this.container.UpsertItemAsync(
+            document,
+            new PartitionKey(document.UserId),
+            cancellationToken: ct).ConfigureAwait(false);
+    }
+
+    public async Task DeleteAsync(string userId, string applicationUid, CancellationToken ct)
+    {
+        var id = SavedApplicationDocument.MakeId(userId, applicationUid);
+
+        try
+        {
+            await this.container.DeleteItemAsync<SavedApplicationDocument>(
+                id,
+                new PartitionKey(userId),
+                cancellationToken: ct).ConfigureAwait(false);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            // Idempotent delete — item already removed
+        }
+    }
+
+    public async Task<IReadOnlyList<SavedApplication>> GetByUserIdAsync(string userId, CancellationToken ct)
+    {
+        var query = new QueryDefinition("SELECT * FROM c WHERE c.userId = @userId")
+            .WithParameter("@userId", userId);
+
+        using var iterator = this.container.GetItemQueryIterator<SavedApplicationDocument>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(userId) });
+
+        var results = new List<SavedApplication>();
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            results.AddRange(response.Select(doc => doc.ToDomain()));
+        }
+
+        return results;
+    }
+
+    public async Task<bool> ExistsAsync(string userId, string applicationUid, CancellationToken ct)
+    {
+        var id = SavedApplicationDocument.MakeId(userId, applicationUid);
+
+        try
+        {
+            await this.container.ReadItemAsync<SavedApplicationDocument>(
+                id,
+                new PartitionKey(userId),
+                cancellationToken: ct).ConfigureAwait(false);
+            return true;
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return false;
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> GetUserIdsByApplicationUidAsync(string applicationUid, CancellationToken ct)
+    {
+        var query = new QueryDefinition("SELECT c.userId FROM c WHERE c.applicationUid = @applicationUid")
+            .WithParameter("@applicationUid", applicationUid);
+
+        using var iterator = this.container.GetItemQueryIterator<SavedApplicationDocument>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = null });
+
+        var userIds = new List<string>();
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            userIds.AddRange(response.Select(doc => doc.UserId));
+        }
+
+        return userIds;
+    }
+}

--- a/api/src/town-crier.infrastructure/SavedApplications/SavedApplicationDocument.cs
+++ b/api/src/town-crier.infrastructure/SavedApplications/SavedApplicationDocument.cs
@@ -1,0 +1,34 @@
+using TownCrier.Domain.SavedApplications;
+
+namespace TownCrier.Infrastructure.SavedApplications;
+
+internal sealed class SavedApplicationDocument
+{
+    public required string Id { get; init; }
+
+    public required string UserId { get; init; }
+
+    public required string ApplicationUid { get; init; }
+
+    public required DateTimeOffset SavedAt { get; init; }
+
+    public static SavedApplicationDocument FromDomain(SavedApplication savedApplication)
+    {
+        ArgumentNullException.ThrowIfNull(savedApplication);
+
+        return new SavedApplicationDocument
+        {
+            Id = MakeId(savedApplication.UserId, savedApplication.ApplicationUid),
+            UserId = savedApplication.UserId,
+            ApplicationUid = savedApplication.ApplicationUid,
+            SavedAt = savedApplication.SavedAt,
+        };
+    }
+
+    public SavedApplication ToDomain()
+    {
+        return SavedApplication.Create(this.UserId, this.ApplicationUid, this.SavedAt);
+    }
+
+    internal static string MakeId(string userId, string applicationUid) => $"{userId}:{applicationUid}";
+}

--- a/api/src/town-crier.infrastructure/UserProfiles/CosmosUserProfileRepository.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/CosmosUserProfileRepository.cs
@@ -1,0 +1,99 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using TownCrier.Application.UserProfiles;
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Infrastructure.UserProfiles;
+
+public sealed class CosmosUserProfileRepository : IUserProfileRepository
+{
+    private readonly Container container;
+
+    public CosmosUserProfileRepository(CosmosClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        this.container = client.GetContainer("town-crier", "Users");
+    }
+
+    public async Task<UserProfile?> GetByUserIdAsync(string userId, CancellationToken ct)
+    {
+        try
+        {
+            var response = await this.container.ReadItemAsync<UserProfileDocument>(
+                userId,
+                new PartitionKey(userId),
+                cancellationToken: ct).ConfigureAwait(false);
+
+            return response.Resource.ToDomain();
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+    }
+
+    public async Task<IReadOnlyList<UserProfile>> GetAllByTierAsync(SubscriptionTier tier, CancellationToken ct)
+    {
+        var queryDefinition = new QueryDefinition("SELECT * FROM c WHERE c.tier = @tier")
+            .WithParameter("@tier", tier.ToString());
+
+        var results = new List<UserProfile>();
+
+        using var iterator = this.container.GetItemQueryIterator<UserProfileDocument>(queryDefinition);
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            results.AddRange(response.Select(doc => doc.ToDomain()));
+        }
+
+        return results;
+    }
+
+    public async Task<UserProfile?> GetByOriginalTransactionIdAsync(
+        string originalTransactionId,
+        CancellationToken ct)
+    {
+        var queryDefinition = new QueryDefinition(
+            "SELECT * FROM c WHERE c.originalTransactionId = @txnId")
+            .WithParameter("@txnId", originalTransactionId);
+
+        using var iterator = this.container.GetItemQueryIterator<UserProfileDocument>(queryDefinition);
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            var document = response.FirstOrDefault();
+            if (document is not null)
+            {
+                return document.ToDomain();
+            }
+        }
+
+        return null;
+    }
+
+    public async Task SaveAsync(UserProfile profile, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        var document = UserProfileDocument.FromDomain(profile);
+        await this.container.UpsertItemAsync(
+            document,
+            new PartitionKey(document.Id),
+            cancellationToken: ct).ConfigureAwait(false);
+    }
+
+    public async Task DeleteAsync(string userId, CancellationToken ct)
+    {
+        try
+        {
+            await this.container.DeleteItemAsync<UserProfileDocument>(
+                userId,
+                new PartitionKey(userId),
+                cancellationToken: ct).ConfigureAwait(false);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            // Idempotent delete — already gone
+        }
+    }
+}

--- a/api/src/town-crier.infrastructure/UserProfiles/UserProfileDocument.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/UserProfileDocument.cs
@@ -1,0 +1,61 @@
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Infrastructure.UserProfiles;
+
+internal sealed class UserProfileDocument
+{
+    public required string Id { get; init; }
+
+    public required string UserId { get; init; }
+
+    public string? Postcode { get; init; }
+
+    public required bool PushEnabled { get; init; }
+
+    public required DayOfWeek DigestDay { get; init; }
+
+    public required Dictionary<string, ZoneNotificationPreferences> ZonePreferences { get; init; }
+
+    public required string Tier { get; init; }
+
+    public DateTimeOffset? SubscriptionExpiry { get; init; }
+
+    public string? OriginalTransactionId { get; init; }
+
+    public DateTimeOffset? GracePeriodExpiry { get; init; }
+
+    public static UserProfileDocument FromDomain(UserProfile profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        return new UserProfileDocument
+        {
+            Id = profile.UserId,
+            UserId = profile.UserId,
+            Postcode = profile.Postcode,
+            PushEnabled = profile.NotificationPreferences.PushEnabled,
+            DigestDay = profile.NotificationPreferences.DigestDay,
+            ZonePreferences = new Dictionary<string, ZoneNotificationPreferences>(profile.AllZonePreferences),
+            Tier = profile.Tier.ToString(),
+            SubscriptionExpiry = profile.SubscriptionExpiry,
+            OriginalTransactionId = profile.OriginalTransactionId,
+            GracePeriodExpiry = profile.GracePeriodExpiry,
+        };
+    }
+
+    public UserProfile ToDomain()
+    {
+        var tier = Enum.Parse<SubscriptionTier>(this.Tier);
+        var notificationPreferences = new NotificationPreferences(this.PushEnabled, this.DigestDay);
+
+        return UserProfile.Reconstitute(
+            this.UserId,
+            this.Postcode,
+            notificationPreferences,
+            this.ZonePreferences,
+            tier,
+            this.SubscriptionExpiry,
+            this.OriginalTransactionId,
+            this.GracePeriodExpiry);
+    }
+}

--- a/api/src/town-crier.infrastructure/WatchZones/AuthorityZoneCountResult.cs
+++ b/api/src/town-crier.infrastructure/WatchZones/AuthorityZoneCountResult.cs
@@ -1,0 +1,8 @@
+namespace TownCrier.Infrastructure.WatchZones;
+
+internal sealed class AuthorityZoneCountResult
+{
+    public int AuthorityId { get; init; }
+
+    public int ZoneCount { get; init; }
+}

--- a/api/src/town-crier.infrastructure/WatchZones/CosmosWatchZoneRepository.cs
+++ b/api/src/town-crier.infrastructure/WatchZones/CosmosWatchZoneRepository.cs
@@ -1,0 +1,94 @@
+using Microsoft.Azure.Cosmos;
+using TownCrier.Application.WatchZones;
+using TownCrier.Domain.WatchZones;
+
+namespace TownCrier.Infrastructure.WatchZones;
+
+public sealed class CosmosWatchZoneRepository : IWatchZoneRepository
+{
+    private readonly Container container;
+
+    public CosmosWatchZoneRepository(CosmosClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        this.container = client.GetContainer("town-crier", "WatchZones");
+    }
+
+    public async Task SaveAsync(WatchZone zone, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(zone);
+
+        var document = WatchZoneDocument.FromDomain(zone);
+        await this.container.UpsertItemAsync(
+            document,
+            new PartitionKey(document.UserId),
+            cancellationToken: ct).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyCollection<WatchZone>> FindZonesContainingAsync(
+        double latitude, double longitude, CancellationToken ct)
+    {
+        var query = new QueryDefinition(
+            "SELECT * FROM c WHERE ST_DISTANCE({'type': 'Point', 'coordinates': [c.longitude, c.latitude]}, " +
+            "{'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres")
+            .WithParameter("@latitude", latitude)
+            .WithParameter("@longitude", longitude);
+
+        using var iterator = this.container.GetItemQueryIterator<WatchZoneDocument>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = null });
+
+        var results = new List<WatchZone>();
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            results.AddRange(response.Select(doc => doc.ToDomain()));
+        }
+
+        return results;
+    }
+
+    public async Task<IReadOnlyCollection<int>> GetDistinctAuthorityIdsAsync(CancellationToken ct)
+    {
+        var query = new QueryDefinition("SELECT DISTINCT VALUE c.authorityId FROM c");
+
+        using var iterator = this.container.GetItemQueryIterator<int>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = null });
+
+        var results = new List<int>();
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            results.AddRange(response);
+        }
+
+        return results;
+    }
+
+    public async Task<Dictionary<int, int>> GetZoneCountsByAuthorityAsync(CancellationToken ct)
+    {
+        var query = new QueryDefinition(
+            "SELECT c.authorityId, COUNT(1) AS zoneCount FROM c GROUP BY c.authorityId");
+
+        using var iterator = this.container.GetItemQueryIterator<AuthorityZoneCountResult>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = null });
+
+        var results = new Dictionary<int, int>();
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+
+            foreach (var item in response)
+            {
+                results[item.AuthorityId] = item.ZoneCount;
+            }
+        }
+
+        return results;
+    }
+}

--- a/api/src/town-crier.infrastructure/WatchZones/WatchZoneDocument.cs
+++ b/api/src/town-crier.infrastructure/WatchZones/WatchZoneDocument.cs
@@ -1,0 +1,48 @@
+using TownCrier.Domain.Geocoding;
+using TownCrier.Domain.WatchZones;
+
+namespace TownCrier.Infrastructure.WatchZones;
+
+internal sealed class WatchZoneDocument
+{
+    public required string Id { get; init; }
+
+    public required string UserId { get; init; }
+
+    public required string Name { get; init; }
+
+    public required double Latitude { get; init; }
+
+    public required double Longitude { get; init; }
+
+    public required double RadiusMetres { get; init; }
+
+    public required int AuthorityId { get; init; }
+
+    public static WatchZoneDocument FromDomain(WatchZone zone)
+    {
+        ArgumentNullException.ThrowIfNull(zone);
+
+        return new WatchZoneDocument
+        {
+            Id = zone.Id,
+            UserId = zone.UserId,
+            Name = zone.Name,
+            Latitude = zone.Centre.Latitude,
+            Longitude = zone.Centre.Longitude,
+            RadiusMetres = zone.RadiusMetres,
+            AuthorityId = zone.AuthorityId,
+        };
+    }
+
+    public WatchZone ToDomain()
+    {
+        return new WatchZone(
+            this.Id,
+            this.UserId,
+            this.Name,
+            new Coordinates(this.Latitude, this.Longitude),
+            this.RadiusMetres,
+            this.AuthorityId);
+    }
+}

--- a/api/src/town-crier.infrastructure/town-crier.infrastructure.csproj
+++ b/api/src/town-crier.infrastructure/town-crier.infrastructure.csproj
@@ -9,7 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="town-crier.infrastructure.tests" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.*" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.3.25171.5" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -1,7 +1,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using TownCrier.Application.Authorities;
-
 using TownCrier.Application.DemoAccount;
 using TownCrier.Application.Designations;
 using TownCrier.Application.DeviceRegistrations;
@@ -20,6 +19,7 @@ using TownCrier.Application.WatchZones;
 using TownCrier.Domain.Groups;
 using TownCrier.Domain.Polling;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.Cosmos;
 using TownCrier.Infrastructure.DeviceRegistrations;
 using TownCrier.Infrastructure.Geocoding;
 using TownCrier.Infrastructure.GovUkPlanningData;
@@ -40,6 +40,7 @@ using TownCrier.Web.RateLimiting;
 var builder = WebApplication.CreateSlimBuilder(args);
 
 builder.Logging.AddJsonConsole();
+builder.Services.AddCosmosClient(builder.Configuration);
 
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
@@ -91,7 +92,7 @@ builder.Services.AddSingleton(new PollingHealthConfig(
     StalenessThreshold: TimeSpan.FromHours(1),
     MaxConsecutiveFailures: 5));
 builder.Services.AddSingleton(TimeProvider.System);
-builder.Services.AddSingleton<IWatchZoneRepository, InMemoryWatchZoneRepository>();
+builder.Services.AddSingleton<IWatchZoneRepository, CosmosWatchZoneRepository>();
 builder.Services.AddSingleton<INotificationEnqueuer, LogNotificationEnqueuer>();
 builder.Services.AddSingleton(new PollingScheduleConfig(
     HighThreshold: builder.Configuration.GetValue("Polling:HighThreshold", 5),
@@ -108,7 +109,8 @@ builder.Services.AddTransient<DeleteUserProfileCommandHandler>();
 builder.Services.AddTransient<UpdateZonePreferencesCommandHandler>();
 builder.Services.AddTransient<GetZonePreferencesQueryHandler>();
 
-builder.Services.AddSingleton<IDeviceRegistrationRepository, InMemoryDeviceRegistrationRepository>();
+builder.Services.AddSingleton<IDeviceRegistrationRepository>(sp =>
+    new CosmosDeviceRegistrationRepository(sp.GetRequiredService<Microsoft.Azure.Cosmos.CosmosClient>()));
 builder.Services.AddTransient<RegisterDeviceTokenCommandHandler>();
 builder.Services.AddTransient<RemoveInvalidDeviceTokenCommandHandler>();
 

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -1,7 +1,7 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using TownCrier.Application.Authorities;
-
+using TownCrier.Application.DecisionAlerts;
 using TownCrier.Application.DemoAccount;
 using TownCrier.Application.Designations;
 using TownCrier.Application.DeviceRegistrations;
@@ -20,6 +20,8 @@ using TownCrier.Application.WatchZones;
 using TownCrier.Domain.Groups;
 using TownCrier.Domain.Polling;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.Cosmos;
+using TownCrier.Infrastructure.DecisionAlerts;
 using TownCrier.Infrastructure.DeviceRegistrations;
 using TownCrier.Infrastructure.Geocoding;
 using TownCrier.Infrastructure.GovUkPlanningData;
@@ -80,6 +82,9 @@ builder.Services.AddHttpClient<IDesignationDataProvider, GovUkPlanningDataClient
     client.BaseAddress = new Uri(govUkBaseUrl);
 });
 builder.Services.AddTransient<GetDesignationContextQueryHandler>();
+
+builder.Services.AddCosmosClient(builder.Configuration);
+builder.Services.AddSingleton<IDecisionAlertRepository, CosmosDecisionAlertRepository>();
 
 var pollStateFilePath = builder.Configuration["Polling:StateFilePath"] ?? Path.Combine(AppContext.BaseDirectory, "poll-state.txt");
 builder.Services.AddSingleton<IPollStateStore>(new FilePollStateStore(pollStateFilePath));

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -20,6 +20,7 @@ using TownCrier.Application.WatchZones;
 using TownCrier.Domain.Groups;
 using TownCrier.Domain.Polling;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.Cosmos;
 using TownCrier.Infrastructure.DeviceRegistrations;
 using TownCrier.Infrastructure.Geocoding;
 using TownCrier.Infrastructure.GovUkPlanningData;
@@ -38,6 +39,8 @@ using TownCrier.Web.Polling;
 using TownCrier.Web.RateLimiting;
 
 var builder = WebApplication.CreateSlimBuilder(args);
+
+builder.Services.AddCosmosClient(builder.Configuration);
 
 builder.Logging.AddJsonConsole();
 
@@ -99,7 +102,7 @@ builder.Services.AddSingleton(new PollingScheduleConfig(
 builder.Services.AddTransient<PollPlanItCommandHandler>();
 builder.Services.AddHostedService<PlanItPollingService>();
 
-builder.Services.AddSingleton<IUserProfileRepository, InMemoryUserProfileRepository>();
+builder.Services.AddSingleton<IUserProfileRepository, CosmosUserProfileRepository>();
 builder.Services.AddTransient<CreateUserProfileCommandHandler>();
 builder.Services.AddTransient<GetUserProfileQueryHandler>();
 builder.Services.AddTransient<UpdateUserProfileCommandHandler>();

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -20,6 +20,7 @@ using TownCrier.Application.WatchZones;
 using TownCrier.Domain.Groups;
 using TownCrier.Domain.Polling;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.Cosmos;
 using TownCrier.Infrastructure.DeviceRegistrations;
 using TownCrier.Infrastructure.Geocoding;
 using TownCrier.Infrastructure.GovUkPlanningData;
@@ -40,6 +41,7 @@ using TownCrier.Web.RateLimiting;
 var builder = WebApplication.CreateSlimBuilder(args);
 
 builder.Logging.AddJsonConsole();
+builder.Services.AddCosmosClient(builder.Configuration);
 
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
@@ -117,7 +119,7 @@ builder.Services.AddTransient<SearchPlanningApplicationsQueryHandler>();
 builder.Services.AddSingleton<INotificationRepository, InMemoryNotificationRepository>();
 builder.Services.AddTransient<GetNotificationsQueryHandler>();
 
-builder.Services.AddSingleton<ISavedApplicationRepository, InMemorySavedApplicationRepository>();
+builder.Services.AddSingleton<ISavedApplicationRepository, CosmosSavedApplicationRepository>();
 builder.Services.AddTransient<SaveApplicationCommandHandler>();
 builder.Services.AddTransient<RemoveSavedApplicationCommandHandler>();
 builder.Services.AddTransient<GetSavedApplicationsQueryHandler>();

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -20,6 +20,7 @@ using TownCrier.Application.WatchZones;
 using TownCrier.Domain.Groups;
 using TownCrier.Domain.Polling;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.Cosmos;
 using TownCrier.Infrastructure.DeviceRegistrations;
 using TownCrier.Infrastructure.Geocoding;
 using TownCrier.Infrastructure.GovUkPlanningData;
@@ -124,8 +125,10 @@ builder.Services.AddTransient<GetSavedApplicationsQueryHandler>();
 
 builder.Services.AddTransient<GetDemoAccountQueryHandler>();
 
-builder.Services.AddSingleton<IGroupRepository, InMemoryGroupRepository>();
-builder.Services.AddSingleton<IGroupInvitationRepository, InMemoryGroupInvitationRepository>();
+builder.Services.AddCosmosClient(builder.Configuration);
+
+builder.Services.AddSingleton<IGroupRepository, CosmosGroupRepository>();
+builder.Services.AddSingleton<IGroupInvitationRepository, CosmosGroupInvitationRepository>();
 builder.Services.AddTransient<CreateGroupCommandHandler>();
 builder.Services.AddTransient<GetGroupQueryHandler>();
 builder.Services.AddTransient<GetUserGroupsQueryHandler>();

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -1,7 +1,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using TownCrier.Application.Authorities;
-
 using TownCrier.Application.DemoAccount;
 using TownCrier.Application.Designations;
 using TownCrier.Application.DeviceRegistrations;
@@ -20,6 +19,7 @@ using TownCrier.Application.WatchZones;
 using TownCrier.Domain.Groups;
 using TownCrier.Domain.Polling;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.Cosmos;
 using TownCrier.Infrastructure.DeviceRegistrations;
 using TownCrier.Infrastructure.Geocoding;
 using TownCrier.Infrastructure.GovUkPlanningData;
@@ -83,7 +83,8 @@ builder.Services.AddTransient<GetDesignationContextQueryHandler>();
 
 var pollStateFilePath = builder.Configuration["Polling:StateFilePath"] ?? Path.Combine(AppContext.BaseDirectory, "poll-state.txt");
 builder.Services.AddSingleton<IPollStateStore>(new FilePollStateStore(pollStateFilePath));
-builder.Services.AddSingleton<IPlanningApplicationRepository, InMemoryPlanningApplicationRepository>();
+builder.Services.AddCosmosClient(builder.Configuration);
+builder.Services.AddSingleton<IPlanningApplicationRepository, CosmosPlanningApplicationRepository>();
 builder.Services.AddSingleton<IActiveAuthorityProvider, InMemoryActiveAuthorityProvider>();
 builder.Services.AddSingleton<IPollingHealthStore, InMemoryPollingHealthStore>();
 builder.Services.AddSingleton<IPollingHealthAlerter, LogPollingHealthAlerter>();

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -20,6 +20,7 @@ using TownCrier.Application.WatchZones;
 using TownCrier.Domain.Groups;
 using TownCrier.Domain.Polling;
 using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.Cosmos;
 using TownCrier.Infrastructure.DeviceRegistrations;
 using TownCrier.Infrastructure.Geocoding;
 using TownCrier.Infrastructure.GovUkPlanningData;
@@ -40,6 +41,7 @@ using TownCrier.Web.RateLimiting;
 var builder = WebApplication.CreateSlimBuilder(args);
 
 builder.Logging.AddJsonConsole();
+builder.Services.AddCosmosClient(builder.Configuration);
 
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
@@ -114,7 +116,8 @@ builder.Services.AddTransient<RemoveInvalidDeviceTokenCommandHandler>();
 
 builder.Services.AddTransient<SearchPlanningApplicationsQueryHandler>();
 
-builder.Services.AddSingleton<INotificationRepository, InMemoryNotificationRepository>();
+builder.Services.AddSingleton<INotificationRepository>(sp =>
+    new CosmosNotificationRepository(sp.GetRequiredService<Microsoft.Azure.Cosmos.CosmosClient>()));
 builder.Services.AddTransient<GetNotificationsQueryHandler>();
 
 builder.Services.AddSingleton<ISavedApplicationRepository, InMemorySavedApplicationRepository>();

--- a/api/tests/town-crier.application.tests/Polling/WatchZoneBuilder.cs
+++ b/api/tests/town-crier.application.tests/Polling/WatchZoneBuilder.cs
@@ -7,6 +7,7 @@ internal sealed class WatchZoneBuilder
 {
     private string id = "zone-1";
     private string userId = "user-1";
+    private string name = "Default Zone";
     private double latitude = 51.5074;
     private double longitude = -0.1278;
     private double radiusMetres = 5000;
@@ -21,6 +22,12 @@ internal sealed class WatchZoneBuilder
     public WatchZoneBuilder WithUserId(string userId)
     {
         this.userId = userId;
+        return this;
+    }
+
+    public WatchZoneBuilder WithName(string name)
+    {
+        this.name = name;
         return this;
     }
 
@@ -48,6 +55,7 @@ internal sealed class WatchZoneBuilder
         return new WatchZone(
             this.id,
             this.userId,
+            this.name,
             new Coordinates(this.latitude, this.longitude),
             this.radiusMetres,
             this.authorityId);

--- a/api/tests/town-crier.application.tests/WatchZones/CreateWatchZoneCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/WatchZones/CreateWatchZoneCommandHandlerTests.cs
@@ -32,6 +32,7 @@ public sealed class CreateWatchZoneCommandHandlerTests
         await Assert.That(zones).HasCount().EqualTo(1);
         await Assert.That(zones.First().UserId).IsEqualTo("user-1");
         await Assert.That(zones.First().AuthorityId).IsEqualTo(42);
+        await Assert.That(zones.First().Name).IsEqualTo("My Zone");
     }
 
     [Test]
@@ -219,6 +220,7 @@ public sealed class CreateWatchZoneCommandHandlerTests
         var command = new CreateWatchZoneCommand(
             UserId: "nonexistent-user",
             ZoneId: "zone-1",
+            Name: "My Zone",
             Latitude: 51.5074,
             Longitude: -0.1278,
             RadiusMetres: 5000,
@@ -234,6 +236,7 @@ public sealed class CreateWatchZoneCommandHandlerTests
         return new CreateWatchZoneCommand(
             UserId: userId,
             ZoneId: "zone-1",
+            Name: "My Zone",
             Latitude: 51.5074,
             Longitude: -0.1278,
             RadiusMetres: 5000,

--- a/api/tests/town-crier.application.tests/town-crier.application.tests.csproj
+++ b/api/tests/town-crier.application.tests/town-crier.application.tests.csproj
@@ -22,7 +22,6 @@
     <Compile Remove="Polling\WatchZoneActiveAuthorityProviderTests.cs" />
     <Compile Remove="Polling\PollPlanItHealthMonitoringTests.cs" />
     <Compile Remove="Polling\PollingScheduleTests.cs" />
-    <Compile Remove="WatchZones\**" />
     <Compile Remove="Notifications\GetNotificationsQueryHandlerTests.cs" />
     <Compile Remove="SavedApplications\**" />
     <Compile Remove="DecisionAlerts\**" />

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosClientFactoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosClientFactoryTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Azure.Cosmos;
+using TownCrier.Infrastructure.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.Cosmos;
+
+public sealed class CosmosClientFactoryTests
+{
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    public void Should_ThrowArgumentException_When_ConnectionStringIsNullOrWhitespace(string? connectionString)
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => CosmosClientFactory.Create(connectionString!));
+    }
+
+    [Test]
+    public async Task Should_ReturnCosmosClient_When_ConnectionStringIsValid()
+    {
+        // Arrange — use the well-known Cosmos emulator connection string
+        const string emulatorConnectionString =
+            "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+
+        // Act
+        using var client = CosmosClientFactory.Create(emulatorConnectionString);
+
+        // Assert
+        await Assert.That(client).IsNotNull();
+        await Assert.That(client).IsTypeOf<CosmosClient>();
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
@@ -1,0 +1,50 @@
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TownCrier.Infrastructure.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.Cosmos;
+
+public sealed class CosmosServiceRegistrationTests
+{
+    [Test]
+    public async Task Should_ResolveSingletonCosmosClient_When_ConnectionStringIsConfigured()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:CosmosDb"] = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddSingleton<IConfiguration>(config);
+        services.AddCosmosClient(config);
+        using var provider = services.BuildServiceProvider();
+
+        // Act
+        var client1 = provider.GetRequiredService<CosmosClient>();
+        var client2 = provider.GetRequiredService<CosmosClient>();
+
+        // Assert
+        await Assert.That(client1).IsNotNull();
+        await Assert.That(client1).IsSameReferenceAs(client2);
+    }
+
+    [Test]
+    public void Should_ThrowInvalidOperationException_When_ConnectionStringIsMissing()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder().Build();
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() =>
+        {
+            var services = new ServiceCollection();
+            services.AddCosmosClient(config);
+            using var provider = services.BuildServiceProvider();
+            provider.GetRequiredService<CosmosClient>();
+        });
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/SystemTextJsonCosmosSerializerTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/SystemTextJsonCosmosSerializerTests.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+using TownCrier.Domain.Geocoding;
+using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.Cosmos;
+
+public sealed class SystemTextJsonCosmosSerializerTests
+{
+    private readonly SystemTextJsonCosmosSerializer serializer;
+
+    public SystemTextJsonCosmosSerializerTests()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        options.TypeInfoResolverChain.Add(CosmosJsonSerializerContext.Default);
+        this.serializer = new SystemTextJsonCosmosSerializer(options);
+    }
+
+    [Test]
+    public async Task Should_RoundTripCoordinates()
+    {
+        // Arrange
+        var original = new Coordinates(51.5074, -0.1278);
+
+        // Act
+        using var stream = this.serializer.ToStream(original);
+        var deserialized = this.serializer.FromStream<Coordinates>(stream);
+
+        // Assert
+        await Assert.That(deserialized.Latitude).IsEqualTo(original.Latitude);
+        await Assert.That(deserialized.Longitude).IsEqualTo(original.Longitude);
+    }
+
+    [Test]
+    public async Task Should_RoundTripNotificationPreferences()
+    {
+        // Arrange
+        var original = new NotificationPreferences(PushEnabled: true, DigestDay: DayOfWeek.Wednesday);
+
+        // Act
+        using var stream = this.serializer.ToStream(original);
+        var deserialized = this.serializer.FromStream<NotificationPreferences>(stream);
+
+        // Assert
+        await Assert.That(deserialized.PushEnabled).IsEqualTo(original.PushEnabled);
+        await Assert.That(deserialized.DigestDay).IsEqualTo(original.DigestDay);
+    }
+
+    [Test]
+    public async Task Should_RoundTripZoneNotificationPreferences()
+    {
+        // Arrange
+        var original = new ZoneNotificationPreferences(
+            NewApplications: true,
+            StatusChanges: false,
+            DecisionUpdates: true);
+
+        // Act
+        using var stream = this.serializer.ToStream(original);
+        var deserialized = this.serializer.FromStream<ZoneNotificationPreferences>(stream);
+
+        // Assert
+        await Assert.That(deserialized.NewApplications).IsEqualTo(original.NewApplications);
+        await Assert.That(deserialized.StatusChanges).IsEqualTo(original.StatusChanges);
+        await Assert.That(deserialized.DecisionUpdates).IsEqualTo(original.DecisionUpdates);
+    }
+
+    [Test]
+    public async Task Should_UseCamelCasePropertyNames_When_Serializing()
+    {
+        // Arrange
+        var coordinates = new Coordinates(51.5074, -0.1278);
+
+        // Act
+        using var stream = this.serializer.ToStream(coordinates);
+        using var reader = new StreamReader(stream);
+        var json = await reader.ReadToEndAsync();
+
+        // Assert
+        await Assert.That(json).Contains("\"latitude\"");
+        await Assert.That(json).Contains("\"longitude\"");
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/DecisionAlerts/DecisionAlertDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/DecisionAlerts/DecisionAlertDocumentTests.cs
@@ -1,0 +1,96 @@
+using TownCrier.Domain.DecisionAlerts;
+using TownCrier.Infrastructure.DecisionAlerts;
+
+namespace TownCrier.Infrastructure.Tests.DecisionAlerts;
+
+public sealed class DecisionAlertDocumentTests
+{
+    private static readonly DateTimeOffset March2026 = new(2026, 3, 15, 10, 0, 0, TimeSpan.Zero);
+
+    [Test]
+    public async Task Should_CreateCompositeId_When_MappedFromDomain()
+    {
+        // Arrange
+        var alert = DecisionAlert.Create(
+            "user-1", "app-uid-001", "Test App", "123 High St", "Approved", March2026);
+
+        // Act
+        var document = DecisionAlertDocument.FromDomain(alert);
+
+        // Assert
+        await Assert.That(document.Id).IsEqualTo("user-1:app-uid-001");
+    }
+
+    [Test]
+    public async Task Should_SetUserIdAsPartitionKey_When_MappedFromDomain()
+    {
+        // Arrange
+        var alert = DecisionAlert.Create(
+            "user-partition-test", "app-uid-001", "Test App", "123 High St", "Approved", March2026);
+
+        // Act
+        var document = DecisionAlertDocument.FromDomain(alert);
+
+        // Assert
+        await Assert.That(document.UserId).IsEqualTo("user-partition-test");
+    }
+
+    [Test]
+    public async Task Should_PreserveAllFields_When_MappedFromDomain()
+    {
+        // Arrange
+        var alert = DecisionAlert.Create(
+            "user-1", "app-uid-001", "Test App", "123 High St", "Refused", March2026);
+
+        // Act
+        var document = DecisionAlertDocument.FromDomain(alert);
+
+        // Assert
+        await Assert.That(document.EntityId).IsEqualTo(alert.Id);
+        await Assert.That(document.UserId).IsEqualTo("user-1");
+        await Assert.That(document.ApplicationUid).IsEqualTo("app-uid-001");
+        await Assert.That(document.ApplicationName).IsEqualTo("Test App");
+        await Assert.That(document.ApplicationAddress).IsEqualTo("123 High St");
+        await Assert.That(document.Decision).IsEqualTo("Refused");
+        await Assert.That(document.PushSent).IsFalse();
+        await Assert.That(document.CreatedAt).IsEqualTo(March2026);
+    }
+
+    [Test]
+    public async Task Should_RoundTripAllProperties_When_MappingFromDomainAndBack()
+    {
+        // Arrange
+        var alert = DecisionAlert.Create(
+            "user-1", "app-uid-001", "Test App", "123 High St", "Approved", March2026);
+
+        // Act
+        var document = DecisionAlertDocument.FromDomain(alert);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.Id).IsEqualTo(alert.Id);
+        await Assert.That(roundTripped.UserId).IsEqualTo("user-1");
+        await Assert.That(roundTripped.ApplicationUid).IsEqualTo("app-uid-001");
+        await Assert.That(roundTripped.ApplicationName).IsEqualTo("Test App");
+        await Assert.That(roundTripped.ApplicationAddress).IsEqualTo("123 High St");
+        await Assert.That(roundTripped.Decision).IsEqualTo("Approved");
+        await Assert.That(roundTripped.PushSent).IsFalse();
+        await Assert.That(roundTripped.CreatedAt).IsEqualTo(March2026);
+    }
+
+    [Test]
+    public async Task Should_PreservePushSentFlag_When_AlertHasPushSent()
+    {
+        // Arrange
+        var alert = DecisionAlert.Create(
+            "user-1", "app-uid-001", "Test App", "123 High St", "Approved", March2026);
+        alert.MarkPushSent();
+
+        // Act
+        var document = DecisionAlertDocument.FromDomain(alert);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.PushSent).IsTrue();
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/DeviceRegistrations/DeviceRegistrationDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/DeviceRegistrations/DeviceRegistrationDocumentTests.cs
@@ -1,0 +1,64 @@
+using TownCrier.Domain.DeviceRegistrations;
+using TownCrier.Infrastructure.DeviceRegistrations;
+
+namespace TownCrier.Infrastructure.Tests.DeviceRegistrations;
+
+public sealed class DeviceRegistrationDocumentTests
+{
+    [Test]
+    public async Task Should_RoundTripToDomainAndBack_When_ValidRegistration()
+    {
+        // Arrange
+        var original = DeviceRegistration.Create(
+            "auth0|user-123",
+            "apns-token-abc123",
+            DevicePlatform.Ios,
+            new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero));
+
+        // Act
+        var document = DeviceRegistrationDocument.FromDomain(original);
+        var restored = document.ToDomain();
+
+        // Assert
+        await Assert.That(restored.UserId).IsEqualTo(original.UserId);
+        await Assert.That(restored.Token).IsEqualTo(original.Token);
+        await Assert.That(restored.Platform).IsEqualTo(original.Platform);
+        await Assert.That(restored.RegisteredAt).IsEqualTo(original.RegisteredAt);
+    }
+
+    [Test]
+    public async Task Should_UseTokenAsDocumentId_When_ConvertingFromDomain()
+    {
+        // Arrange
+        var registration = DeviceRegistration.Create(
+            "auth0|user-456",
+            "fcm-token-xyz789",
+            DevicePlatform.Android,
+            new DateTimeOffset(2026, 3, 17, 12, 0, 0, TimeSpan.Zero));
+
+        // Act
+        var document = DeviceRegistrationDocument.FromDomain(registration);
+
+        // Assert
+        await Assert.That(document.Id).IsEqualTo("fcm-token-xyz789");
+        await Assert.That(document.UserId).IsEqualTo("auth0|user-456");
+        await Assert.That(document.Platform).IsEqualTo("Android");
+    }
+
+    [Test]
+    public async Task Should_SetUserIdAsPartitionKeyValue_When_ConvertingFromDomain()
+    {
+        // Arrange
+        var registration = DeviceRegistration.Create(
+            "auth0|user-789",
+            "apns-token-device1",
+            DevicePlatform.Ios,
+            new DateTimeOffset(2026, 3, 17, 14, 0, 0, TimeSpan.Zero));
+
+        // Act
+        var document = DeviceRegistrationDocument.FromDomain(registration);
+
+        // Assert
+        await Assert.That(document.UserId).IsEqualTo("auth0|user-789");
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/Groups/GroupDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Groups/GroupDocumentTests.cs
@@ -1,0 +1,102 @@
+using TownCrier.Domain.Geocoding;
+using TownCrier.Domain.Groups;
+using TownCrier.Infrastructure.Groups;
+
+namespace TownCrier.Infrastructure.Tests.Groups;
+
+public sealed class GroupDocumentTests
+{
+    [Test]
+    public async Task Should_RoundTripAllProperties_When_MappingFromDomainAndBack()
+    {
+        // Arrange
+        var group = Group.Create(
+            "group-1",
+            "Test Group",
+            "owner-1",
+            new Coordinates(51.5074, -0.1278),
+            5000,
+            42,
+            new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero));
+
+        // Act
+        var document = GroupDocument.FromDomain(group);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.Id).IsEqualTo(group.Id);
+        await Assert.That(roundTripped.Name).IsEqualTo(group.Name);
+        await Assert.That(roundTripped.OwnerId).IsEqualTo(group.OwnerId);
+        await Assert.That(roundTripped.Centre.Latitude).IsEqualTo(group.Centre.Latitude);
+        await Assert.That(roundTripped.Centre.Longitude).IsEqualTo(group.Centre.Longitude);
+        await Assert.That(roundTripped.RadiusMetres).IsEqualTo(group.RadiusMetres);
+        await Assert.That(roundTripped.AuthorityId).IsEqualTo(group.AuthorityId);
+        await Assert.That(roundTripped.CreatedAt).IsEqualTo(group.CreatedAt);
+    }
+
+    [Test]
+    public async Task Should_SetTypeDiscriminator_When_MappingFromDomain()
+    {
+        // Arrange
+        var group = Group.Create(
+            "group-1",
+            "Test Group",
+            "owner-1",
+            new Coordinates(51.5074, -0.1278),
+            5000,
+            42,
+            new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero));
+
+        // Act
+        var document = GroupDocument.FromDomain(group);
+
+        // Assert
+        await Assert.That(document.Type).IsEqualTo("group");
+    }
+
+    [Test]
+    public async Task Should_SetOwnerIdAsPartitionKey_When_MappingFromDomain()
+    {
+        // Arrange
+        var group = Group.Create(
+            "group-1",
+            "Test Group",
+            "owner-partition-test",
+            new Coordinates(51.5074, -0.1278),
+            5000,
+            42,
+            new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero));
+
+        // Act
+        var document = GroupDocument.FromDomain(group);
+
+        // Assert
+        await Assert.That(document.OwnerId).IsEqualTo("owner-partition-test");
+    }
+
+    [Test]
+    public async Task Should_PreserveMembers_When_MappingFromDomainAndBack()
+    {
+        // Arrange
+        var group = Group.Create(
+            "group-1",
+            "Test Group",
+            "owner-1",
+            new Coordinates(51.5074, -0.1278),
+            5000,
+            42,
+            new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero));
+        group.AddMember("member-1", new DateTimeOffset(2026, 3, 18, 10, 0, 0, TimeSpan.Zero));
+
+        // Act
+        var document = GroupDocument.FromDomain(group);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.Members).HasCount().EqualTo(2);
+        await Assert.That(roundTripped.Members[0].UserId).IsEqualTo("owner-1");
+        await Assert.That(roundTripped.Members[0].Role).IsEqualTo(GroupRole.Owner);
+        await Assert.That(roundTripped.Members[1].UserId).IsEqualTo("member-1");
+        await Assert.That(roundTripped.Members[1].Role).IsEqualTo(GroupRole.Member);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/Groups/GroupInvitationDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Groups/GroupInvitationDocumentTests.cs
@@ -1,0 +1,93 @@
+using TownCrier.Domain.Groups;
+using TownCrier.Infrastructure.Groups;
+
+namespace TownCrier.Infrastructure.Tests.Groups;
+
+public sealed class GroupInvitationDocumentTests
+{
+    [Test]
+    public async Task Should_RoundTripAllProperties_When_MappingFromDomainAndBack()
+    {
+        // Arrange
+        var invitation = GroupInvitation.Create(
+            "inv-1",
+            "group-1",
+            "jane@example.com",
+            "owner-1",
+            new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero),
+            TimeSpan.FromDays(7));
+
+        // Act
+        var document = GroupInvitationDocument.FromDomain(invitation);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.Id).IsEqualTo(invitation.Id);
+        await Assert.That(roundTripped.GroupId).IsEqualTo(invitation.GroupId);
+        await Assert.That(roundTripped.InviteeEmail).IsEqualTo(invitation.InviteeEmail);
+        await Assert.That(roundTripped.InvitedByUserId).IsEqualTo(invitation.InvitedByUserId);
+        await Assert.That(roundTripped.Status).IsEqualTo(InvitationStatus.Pending);
+        await Assert.That(roundTripped.CreatedAt).IsEqualTo(invitation.CreatedAt);
+        await Assert.That(roundTripped.ExpiresAt).IsEqualTo(invitation.ExpiresAt);
+    }
+
+    [Test]
+    public async Task Should_SetTypeDiscriminator_When_MappingFromDomain()
+    {
+        // Arrange
+        var invitation = GroupInvitation.Create(
+            "inv-1",
+            "group-1",
+            "jane@example.com",
+            "owner-1",
+            new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero),
+            TimeSpan.FromDays(7));
+
+        // Act
+        var document = GroupInvitationDocument.FromDomain(invitation);
+
+        // Assert
+        await Assert.That(document.Type).IsEqualTo("invitation");
+    }
+
+    [Test]
+    public async Task Should_SetOwnerIdFromInvitedByUserId_When_MappingFromDomain()
+    {
+        // Arrange
+        var invitation = GroupInvitation.Create(
+            "inv-1",
+            "group-1",
+            "jane@example.com",
+            "owner-partition-test",
+            new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero),
+            TimeSpan.FromDays(7));
+
+        // Act
+        var document = GroupInvitationDocument.FromDomain(invitation);
+
+        // Assert
+        await Assert.That(document.OwnerId).IsEqualTo("owner-partition-test");
+    }
+
+    [Test]
+    public async Task Should_PreserveAcceptedStatus_When_MappingAfterAcceptance()
+    {
+        // Arrange
+        var now = new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero);
+        var invitation = GroupInvitation.Create(
+            "inv-1",
+            "group-1",
+            "jane@example.com",
+            "owner-1",
+            now,
+            TimeSpan.FromDays(7));
+        invitation.Accept(now.AddHours(1));
+
+        // Act
+        var document = GroupInvitationDocument.FromDomain(invitation);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.Status).IsEqualTo(InvitationStatus.Accepted);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/Notifications/NotificationBuilder.cs
+++ b/api/tests/town-crier.infrastructure.tests/Notifications/NotificationBuilder.cs
@@ -1,0 +1,76 @@
+using TownCrier.Domain.Notifications;
+
+namespace TownCrier.Infrastructure.Tests.Notifications;
+
+internal sealed class NotificationBuilder
+{
+    private string userId = "user-1";
+    private string applicationName = "APP/2026/0001";
+    private string watchZoneId = "zone-1";
+    private string applicationAddress = "123 High Street";
+    private string applicationDescription = "Single storey rear extension";
+    private string applicationType = "Householder";
+    private int authorityId = 42;
+    private DateTimeOffset createdAt = new(2026, 3, 15, 10, 0, 0, TimeSpan.Zero);
+
+    public NotificationBuilder WithUserId(string userId)
+    {
+        this.userId = userId;
+        return this;
+    }
+
+    public NotificationBuilder WithApplicationName(string applicationName)
+    {
+        this.applicationName = applicationName;
+        return this;
+    }
+
+    public NotificationBuilder WithWatchZoneId(string watchZoneId)
+    {
+        this.watchZoneId = watchZoneId;
+        return this;
+    }
+
+    public NotificationBuilder WithApplicationAddress(string address)
+    {
+        this.applicationAddress = address;
+        return this;
+    }
+
+    public NotificationBuilder WithApplicationDescription(string description)
+    {
+        this.applicationDescription = description;
+        return this;
+    }
+
+    public NotificationBuilder WithApplicationType(string type)
+    {
+        this.applicationType = type;
+        return this;
+    }
+
+    public NotificationBuilder WithAuthorityId(int authorityId)
+    {
+        this.authorityId = authorityId;
+        return this;
+    }
+
+    public NotificationBuilder WithCreatedAt(DateTimeOffset createdAt)
+    {
+        this.createdAt = createdAt;
+        return this;
+    }
+
+    public Notification Build()
+    {
+        return Notification.Create(
+            this.userId,
+            this.applicationName,
+            this.watchZoneId,
+            this.applicationAddress,
+            this.applicationDescription,
+            this.applicationType,
+            this.authorityId,
+            this.createdAt);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/Notifications/NotificationDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Notifications/NotificationDocumentTests.cs
@@ -1,0 +1,83 @@
+using TownCrier.Domain.Notifications;
+using TownCrier.Infrastructure.Notifications;
+
+namespace TownCrier.Infrastructure.Tests.Notifications;
+
+public sealed class NotificationDocumentTests
+{
+    [Test]
+    public async Task Should_RoundTripAllProperties_When_MappingFromDomainAndBack()
+    {
+        // Arrange
+        var notification = new NotificationBuilder()
+            .WithUserId("user-42")
+            .WithApplicationName("APP/2026/0099")
+            .WithWatchZoneId("zone-7")
+            .WithApplicationAddress("99 Oak Lane")
+            .WithApplicationDescription("Loft conversion")
+            .WithApplicationType("Full Planning")
+            .WithAuthorityId(55)
+            .WithCreatedAt(new DateTimeOffset(2026, 3, 20, 14, 30, 0, TimeSpan.Zero))
+            .Build();
+
+        // Act
+        var document = NotificationDocument.FromDomain(notification);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.Id).IsEqualTo(notification.Id);
+        await Assert.That(roundTripped.UserId).IsEqualTo("user-42");
+        await Assert.That(roundTripped.ApplicationName).IsEqualTo("APP/2026/0099");
+        await Assert.That(roundTripped.WatchZoneId).IsEqualTo("zone-7");
+        await Assert.That(roundTripped.ApplicationAddress).IsEqualTo("99 Oak Lane");
+        await Assert.That(roundTripped.ApplicationDescription).IsEqualTo("Loft conversion");
+        await Assert.That(roundTripped.ApplicationType).IsEqualTo("Full Planning");
+        await Assert.That(roundTripped.AuthorityId).IsEqualTo(55);
+        await Assert.That(roundTripped.PushSent).IsEqualTo(notification.PushSent);
+        await Assert.That(roundTripped.CreatedAt).IsEqualTo(notification.CreatedAt);
+    }
+
+    [Test]
+    public async Task Should_PreservePushSentFlag_When_NotificationHasPushSent()
+    {
+        // Arrange
+        var notification = new NotificationBuilder().Build();
+        notification.MarkPushSent();
+
+        // Act
+        var document = NotificationDocument.FromDomain(notification);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.PushSent).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_SetUserIdAsPartitionKey_When_MappingFromDomain()
+    {
+        // Arrange
+        var notification = new NotificationBuilder()
+            .WithUserId("user-partition-test")
+            .Build();
+
+        // Act
+        var document = NotificationDocument.FromDomain(notification);
+
+        // Assert
+        await Assert.That(document.UserId).IsEqualTo("user-partition-test");
+    }
+
+    [Test]
+    public async Task Should_SetTtlTo90Days_When_MappingFromDomain()
+    {
+        // Arrange
+        var notification = new NotificationBuilder().Build();
+
+        // Act
+        var document = NotificationDocument.FromDomain(notification);
+
+        // Assert
+        var ninetyDaysInSeconds = (int)TimeSpan.FromDays(90).TotalSeconds;
+        await Assert.That(document.Ttl).IsEqualTo(ninetyDaysInSeconds);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/PlanningApplications/PlanningApplicationDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanningApplications/PlanningApplicationDocumentTests.cs
@@ -1,0 +1,253 @@
+using System.Diagnostics.CodeAnalysis;
+using TownCrier.Domain.PlanningApplications;
+using TownCrier.Infrastructure.PlanningApplications;
+
+namespace TownCrier.Infrastructure.Tests.PlanningApplications;
+
+[SuppressMessage("Design", "S1075:Hardcoded URIs", Justification = "Test data")]
+public sealed class PlanningApplicationDocumentTests
+{
+    [Test]
+    public async Task Should_MapAllFields_When_FromDomainCalled()
+    {
+        // Arrange
+        var application = new PlanningApplication(
+            name: "Westminster/12345",
+            uid: "12345",
+            areaName: "Westminster",
+            areaId: 42,
+            address: "10 Downing Street",
+            postcode: "SW1A 2AA",
+            description: "Extension to rear",
+            appType: "Full",
+            appState: "Undecided",
+            appSize: "Small",
+            startDate: new DateOnly(2026, 1, 15),
+            decidedDate: new DateOnly(2026, 3, 1),
+            consultedDate: new DateOnly(2026, 2, 1),
+            longitude: -0.1276,
+            latitude: 51.5034,
+            url: "https://planit.org.uk/app/12345",
+            link: "https://planit.org.uk/link/12345",
+            lastDifferent: new DateTimeOffset(2026, 3, 16, 12, 0, 0, TimeSpan.Zero));
+
+        // Act
+        var document = PlanningApplicationDocument.FromDomain(application);
+
+        // Assert
+        await Assert.That(document.Id).IsEqualTo("Westminster/12345");
+        await Assert.That(document.AuthorityCode).IsEqualTo("42");
+        await Assert.That(document.PlanitName).IsEqualTo("Westminster/12345");
+        await Assert.That(document.Uid).IsEqualTo("12345");
+        await Assert.That(document.AreaName).IsEqualTo("Westminster");
+        await Assert.That(document.AreaId).IsEqualTo(42);
+        await Assert.That(document.Address).IsEqualTo("10 Downing Street");
+        await Assert.That(document.Postcode).IsEqualTo("SW1A 2AA");
+        await Assert.That(document.Description).IsEqualTo("Extension to rear");
+        await Assert.That(document.AppType).IsEqualTo("Full");
+        await Assert.That(document.AppState).IsEqualTo("Undecided");
+        await Assert.That(document.AppSize).IsEqualTo("Small");
+        await Assert.That(document.StartDate).IsEqualTo(new DateOnly(2026, 1, 15));
+        await Assert.That(document.DecidedDate).IsEqualTo(new DateOnly(2026, 3, 1));
+        await Assert.That(document.ConsultedDate).IsEqualTo(new DateOnly(2026, 2, 1));
+        await Assert.That(document.Url).IsEqualTo("https://planit.org.uk/app/12345");
+        await Assert.That(document.Link).IsEqualTo("https://planit.org.uk/link/12345");
+        await Assert.That(document.LastDifferent).IsEqualTo(new DateTimeOffset(2026, 3, 16, 12, 0, 0, TimeSpan.Zero));
+    }
+
+    [Test]
+    public async Task Should_CreateGeoJsonPoint_When_CoordinatesPresent()
+    {
+        // Arrange
+        var application = new PlanningApplication(
+            name: "Westminster/12345",
+            uid: "12345",
+            areaName: "Westminster",
+            areaId: 42,
+            address: "10 Downing Street",
+            postcode: null,
+            description: "Extension",
+            appType: "Full",
+            appState: "Undecided",
+            appSize: null,
+            startDate: null,
+            decidedDate: null,
+            consultedDate: null,
+            longitude: -0.1276,
+            latitude: 51.5034,
+            url: null,
+            link: null,
+            lastDifferent: DateTimeOffset.UtcNow);
+
+        // Act
+        var document = PlanningApplicationDocument.FromDomain(application);
+
+        // Assert — GeoJSON uses [longitude, latitude] order
+        await Assert.That(document.Location).IsNotNull();
+        await Assert.That(document.Location!.Type).IsEqualTo("Point");
+        await Assert.That(document.Location.Coordinates[0]).IsEqualTo(-0.1276);
+        await Assert.That(document.Location.Coordinates[1]).IsEqualTo(51.5034);
+    }
+
+    [Test]
+    public async Task Should_SetLocationNull_When_CoordinatesMissing()
+    {
+        // Arrange
+        var application = new PlanningApplication(
+            name: "Westminster/12345",
+            uid: "12345",
+            areaName: "Westminster",
+            areaId: 42,
+            address: "10 Downing Street",
+            postcode: null,
+            description: "Extension",
+            appType: "Full",
+            appState: "Undecided",
+            appSize: null,
+            startDate: null,
+            decidedDate: null,
+            consultedDate: null,
+            longitude: null,
+            latitude: null,
+            url: null,
+            link: null,
+            lastDifferent: DateTimeOffset.UtcNow);
+
+        // Act
+        var document = PlanningApplicationDocument.FromDomain(application);
+
+        // Assert
+        await Assert.That(document.Location).IsNull();
+    }
+
+    [Test]
+    public async Task Should_MapBackToDomain_When_ToDomainCalled()
+    {
+        // Arrange
+        var document = new PlanningApplicationDocument
+        {
+            Id = "Westminster/12345",
+            AuthorityCode = "42",
+            PlanitName = "Westminster/12345",
+            Uid = "12345",
+            AreaName = "Westminster",
+            AreaId = 42,
+            Address = "10 Downing Street",
+            Postcode = "SW1A 2AA",
+            Description = "Extension to rear",
+            AppType = "Full",
+            AppState = "Undecided",
+            AppSize = "Small",
+            StartDate = new DateOnly(2026, 1, 15),
+            DecidedDate = new DateOnly(2026, 3, 1),
+            ConsultedDate = new DateOnly(2026, 2, 1),
+            Location = new GeoJsonPoint { Type = "Point", Coordinates = [-0.1276, 51.5034] },
+            Url = "https://planit.org.uk/app/12345",
+            Link = "https://planit.org.uk/link/12345",
+            LastDifferent = new DateTimeOffset(2026, 3, 16, 12, 0, 0, TimeSpan.Zero),
+        };
+
+        // Act
+        var application = document.ToDomain();
+
+        // Assert
+        await Assert.That(application.Name).IsEqualTo("Westminster/12345");
+        await Assert.That(application.Uid).IsEqualTo("12345");
+        await Assert.That(application.AreaName).IsEqualTo("Westminster");
+        await Assert.That(application.AreaId).IsEqualTo(42);
+        await Assert.That(application.Address).IsEqualTo("10 Downing Street");
+        await Assert.That(application.Postcode).IsEqualTo("SW1A 2AA");
+        await Assert.That(application.Description).IsEqualTo("Extension to rear");
+        await Assert.That(application.AppType).IsEqualTo("Full");
+        await Assert.That(application.AppState).IsEqualTo("Undecided");
+        await Assert.That(application.AppSize).IsEqualTo("Small");
+        await Assert.That(application.StartDate).IsEqualTo(new DateOnly(2026, 1, 15));
+        await Assert.That(application.DecidedDate).IsEqualTo(new DateOnly(2026, 3, 1));
+        await Assert.That(application.ConsultedDate).IsEqualTo(new DateOnly(2026, 2, 1));
+        await Assert.That(application.Longitude).IsEqualTo(-0.1276);
+        await Assert.That(application.Latitude).IsEqualTo(51.5034);
+        await Assert.That(application.Url).IsEqualTo("https://planit.org.uk/app/12345");
+        await Assert.That(application.Link).IsEqualTo("https://planit.org.uk/link/12345");
+        await Assert.That(application.LastDifferent).IsEqualTo(new DateTimeOffset(2026, 3, 16, 12, 0, 0, TimeSpan.Zero));
+    }
+
+    [Test]
+    public async Task Should_MapNullCoordinates_When_LocationIsNull()
+    {
+        // Arrange
+        var document = new PlanningApplicationDocument
+        {
+            Id = "Westminster/12345",
+            AuthorityCode = "42",
+            PlanitName = "Westminster/12345",
+            Uid = "12345",
+            AreaName = "Westminster",
+            AreaId = 42,
+            Address = "10 Downing Street",
+            Postcode = null,
+            Description = "Extension",
+            AppType = "Full",
+            AppState = "Undecided",
+            AppSize = null,
+            StartDate = null,
+            DecidedDate = null,
+            ConsultedDate = null,
+            Location = null,
+            Url = null,
+            Link = null,
+            LastDifferent = DateTimeOffset.UtcNow,
+        };
+
+        // Act
+        var application = document.ToDomain();
+
+        // Assert
+        await Assert.That(application.Longitude).IsNull();
+        await Assert.That(application.Latitude).IsNull();
+    }
+
+    [Test]
+    public async Task Should_RoundTrip_When_FromDomainThenToDomain()
+    {
+        // Arrange
+        var original = new PlanningApplication(
+            name: "Westminster/12345",
+            uid: "12345",
+            areaName: "Westminster",
+            areaId: 42,
+            address: "10 Downing Street",
+            postcode: "SW1A 2AA",
+            description: "Extension to rear",
+            appType: "Full",
+            appState: "Undecided",
+            appSize: "Small",
+            startDate: new DateOnly(2026, 1, 15),
+            decidedDate: new DateOnly(2026, 3, 1),
+            consultedDate: new DateOnly(2026, 2, 1),
+            longitude: -0.1276,
+            latitude: 51.5034,
+            url: "https://planit.org.uk/app/12345",
+            link: "https://planit.org.uk/link/12345",
+            lastDifferent: new DateTimeOffset(2026, 3, 16, 12, 0, 0, TimeSpan.Zero));
+
+        // Act
+        var roundTripped = PlanningApplicationDocument.FromDomain(original).ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.Name).IsEqualTo(original.Name);
+        await Assert.That(roundTripped.Uid).IsEqualTo(original.Uid);
+        await Assert.That(roundTripped.AreaName).IsEqualTo(original.AreaName);
+        await Assert.That(roundTripped.AreaId).IsEqualTo(original.AreaId);
+        await Assert.That(roundTripped.Address).IsEqualTo(original.Address);
+        await Assert.That(roundTripped.Postcode).IsEqualTo(original.Postcode);
+        await Assert.That(roundTripped.Description).IsEqualTo(original.Description);
+        await Assert.That(roundTripped.AppType).IsEqualTo(original.AppType);
+        await Assert.That(roundTripped.AppState).IsEqualTo(original.AppState);
+        await Assert.That(roundTripped.AppSize).IsEqualTo(original.AppSize);
+        await Assert.That(roundTripped.Longitude).IsEqualTo(original.Longitude);
+        await Assert.That(roundTripped.Latitude).IsEqualTo(original.Latitude);
+        await Assert.That(roundTripped.Url).IsEqualTo(original.Url);
+        await Assert.That(roundTripped.Link).IsEqualTo(original.Link);
+        await Assert.That(roundTripped.LastDifferent).IsEqualTo(original.LastDifferent);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/SavedApplications/SavedApplicationDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/SavedApplications/SavedApplicationDocumentTests.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using TownCrier.Domain.SavedApplications;
+using TownCrier.Infrastructure.Cosmos;
+using TownCrier.Infrastructure.SavedApplications;
+
+namespace TownCrier.Infrastructure.Tests.SavedApplications;
+
+public sealed class SavedApplicationDocumentTests
+{
+    [Test]
+    public async Task Should_CreateCompositeId_When_MappedFromDomain()
+    {
+        // Arrange
+        var savedAt = new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero);
+        var domain = SavedApplication.Create("auth0|user-1", "planit-uid-abc", savedAt);
+
+        // Act
+        var document = SavedApplicationDocument.FromDomain(domain);
+
+        // Assert
+        await Assert.That(document.Id).IsEqualTo("auth0|user-1:planit-uid-abc");
+    }
+
+    [Test]
+    public async Task Should_SetUserIdAsPartitionKey_When_MappedFromDomain()
+    {
+        // Arrange
+        var savedAt = new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero);
+        var domain = SavedApplication.Create("auth0|user-1", "planit-uid-abc", savedAt);
+
+        // Act
+        var document = SavedApplicationDocument.FromDomain(domain);
+
+        // Assert
+        await Assert.That(document.UserId).IsEqualTo("auth0|user-1");
+    }
+
+    [Test]
+    public async Task Should_PreserveAllFields_When_MappedFromDomain()
+    {
+        // Arrange
+        var savedAt = new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero);
+        var domain = SavedApplication.Create("auth0|user-1", "planit-uid-abc", savedAt);
+
+        // Act
+        var document = SavedApplicationDocument.FromDomain(domain);
+
+        // Assert
+        await Assert.That(document.ApplicationUid).IsEqualTo("planit-uid-abc");
+        await Assert.That(document.SavedAt).IsEqualTo(savedAt);
+    }
+
+    [Test]
+    public async Task Should_RoundTripToDomain_When_MappedBackAndForth()
+    {
+        // Arrange
+        var savedAt = new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero);
+        var original = SavedApplication.Create("auth0|user-1", "planit-uid-abc", savedAt);
+
+        // Act
+        var document = SavedApplicationDocument.FromDomain(original);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.UserId).IsEqualTo(original.UserId);
+        await Assert.That(roundTripped.ApplicationUid).IsEqualTo(original.ApplicationUid);
+        await Assert.That(roundTripped.SavedAt).IsEqualTo(original.SavedAt);
+    }
+
+    [Test]
+    public async Task Should_RoundTripThroughJsonSerialization_When_UsingCosmosSerializer()
+    {
+        // Arrange
+        var savedAt = new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero);
+        var original = SavedApplicationDocument.FromDomain(
+            SavedApplication.Create("auth0|user-1", "planit-uid-abc", savedAt));
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        jsonOptions.TypeInfoResolverChain.Add(CosmosJsonSerializerContext.Default);
+
+        var serializer = new SystemTextJsonCosmosSerializer(jsonOptions);
+
+        // Act
+        using var stream = serializer.ToStream(original);
+        var deserialized = serializer.FromStream<SavedApplicationDocument>(stream);
+
+        // Assert
+        await Assert.That(deserialized.Id).IsEqualTo(original.Id);
+        await Assert.That(deserialized.UserId).IsEqualTo(original.UserId);
+        await Assert.That(deserialized.ApplicationUid).IsEqualTo(original.ApplicationUid);
+        await Assert.That(deserialized.SavedAt).IsEqualTo(original.SavedAt);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/UserProfiles/UserProfileDocumentSerializationTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/UserProfiles/UserProfileDocumentSerializationTests.cs
@@ -1,0 +1,68 @@
+using System.Text.Json;
+using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.Cosmos;
+using TownCrier.Infrastructure.UserProfiles;
+
+namespace TownCrier.Infrastructure.Tests.UserProfiles;
+
+public sealed class UserProfileDocumentSerializationTests
+{
+    private readonly SystemTextJsonCosmosSerializer serializer;
+
+    public UserProfileDocumentSerializationTests()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        options.TypeInfoResolverChain.Add(CosmosJsonSerializerContext.Default);
+        this.serializer = new SystemTextJsonCosmosSerializer(options);
+    }
+
+    [Test]
+    public async Task Should_RoundTripUserProfileDocument_When_Serialized()
+    {
+        // Arrange
+        var profile = UserProfile.Register("auth0|user-1");
+        profile.UpdatePreferences("SW1A 1AA", new NotificationPreferences(true, DayOfWeek.Wednesday));
+        profile.ActivateSubscription(SubscriptionTier.Pro, new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        profile.LinkOriginalTransactionId("txn-ser-123");
+        profile.SetZonePreferences("zone-1", new ZoneNotificationPreferences(true, true, false));
+        var original = UserProfileDocument.FromDomain(profile);
+
+        // Act
+        using var stream = this.serializer.ToStream(original);
+        var deserialized = this.serializer.FromStream<UserProfileDocument>(stream);
+
+        // Assert
+        await Assert.That(deserialized.Id).IsEqualTo(original.Id);
+        await Assert.That(deserialized.UserId).IsEqualTo(original.UserId);
+        await Assert.That(deserialized.Postcode).IsEqualTo(original.Postcode);
+        await Assert.That(deserialized.PushEnabled).IsEqualTo(original.PushEnabled);
+        await Assert.That(deserialized.DigestDay).IsEqualTo(original.DigestDay);
+        await Assert.That(deserialized.Tier).IsEqualTo(original.Tier);
+        await Assert.That(deserialized.SubscriptionExpiry).IsEqualTo(original.SubscriptionExpiry);
+        await Assert.That(deserialized.OriginalTransactionId).IsEqualTo(original.OriginalTransactionId);
+        await Assert.That(deserialized.ZonePreferences).HasCount().EqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_UseCamelCasePropertyNames_When_Serialized()
+    {
+        // Arrange
+        var profile = UserProfile.Register("auth0|user-1");
+        var document = UserProfileDocument.FromDomain(profile);
+
+        // Act
+        using var stream = this.serializer.ToStream(document);
+        using var reader = new StreamReader(stream);
+        var json = await reader.ReadToEndAsync();
+
+        // Assert
+        await Assert.That(json).Contains("\"id\"");
+        await Assert.That(json).Contains("\"userId\"");
+        await Assert.That(json).Contains("\"pushEnabled\"");
+        await Assert.That(json).Contains("\"tier\"");
+        await Assert.That(json).Contains("\"zonePreferences\"");
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/UserProfiles/UserProfileDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/UserProfiles/UserProfileDocumentTests.cs
@@ -1,0 +1,111 @@
+using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.UserProfiles;
+
+namespace TownCrier.Infrastructure.Tests.UserProfiles;
+
+public sealed class UserProfileDocumentTests
+{
+    [Test]
+    public async Task Should_SetUserIdAsId_When_MappedFromDomain()
+    {
+        // Arrange
+        var profile = UserProfile.Register("auth0|user-1");
+
+        // Act
+        var document = UserProfileDocument.FromDomain(profile);
+
+        // Assert
+        await Assert.That(document.Id).IsEqualTo("auth0|user-1");
+    }
+
+    [Test]
+    public async Task Should_PreserveBasicFields_When_MappedFromDomain()
+    {
+        // Arrange
+        var profile = UserProfile.Register("auth0|user-1");
+        profile.UpdatePreferences("SW1A 1AA", new NotificationPreferences(true, DayOfWeek.Wednesday));
+        profile.ActivateSubscription(SubscriptionTier.Pro, new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        profile.LinkOriginalTransactionId("txn-abc-123");
+
+        // Act
+        var document = UserProfileDocument.FromDomain(profile);
+
+        // Assert
+        await Assert.That(document.UserId).IsEqualTo("auth0|user-1");
+        await Assert.That(document.Postcode).IsEqualTo("SW1A 1AA");
+        await Assert.That(document.PushEnabled).IsTrue();
+        await Assert.That(document.DigestDay).IsEqualTo(DayOfWeek.Wednesday);
+        await Assert.That(document.Tier).IsEqualTo("Pro");
+        await Assert.That(document.SubscriptionExpiry).IsEqualTo(new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        await Assert.That(document.OriginalTransactionId).IsEqualTo("txn-abc-123");
+    }
+
+    [Test]
+    public async Task Should_RoundTripToDomain_When_MappedBackAndForth()
+    {
+        // Arrange
+        var original = UserProfile.Register("auth0|user-1");
+        original.UpdatePreferences("SW1A 1AA", new NotificationPreferences(false, DayOfWeek.Friday));
+        original.ActivateSubscription(SubscriptionTier.Pro, new DateTimeOffset(2027, 6, 15, 0, 0, 0, TimeSpan.Zero));
+        original.LinkOriginalTransactionId("txn-round-trip");
+        original.EnterGracePeriod(new DateTimeOffset(2027, 7, 1, 0, 0, 0, TimeSpan.Zero));
+
+        // Act
+        var document = UserProfileDocument.FromDomain(original);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.UserId).IsEqualTo(original.UserId);
+        await Assert.That(roundTripped.Postcode).IsEqualTo(original.Postcode);
+        await Assert.That(roundTripped.NotificationPreferences.PushEnabled).IsEqualTo(original.NotificationPreferences.PushEnabled);
+        await Assert.That(roundTripped.NotificationPreferences.DigestDay).IsEqualTo(original.NotificationPreferences.DigestDay);
+        await Assert.That(roundTripped.Tier).IsEqualTo(original.Tier);
+        await Assert.That(roundTripped.SubscriptionExpiry).IsEqualTo(original.SubscriptionExpiry);
+        await Assert.That(roundTripped.OriginalTransactionId).IsEqualTo(original.OriginalTransactionId);
+        await Assert.That(roundTripped.GracePeriodExpiry).IsEqualTo(original.GracePeriodExpiry);
+    }
+
+    [Test]
+    public async Task Should_PreserveZonePreferences_When_RoundTripped()
+    {
+        // Arrange
+        var original = UserProfile.Register("auth0|user-1");
+        original.ActivateSubscription(SubscriptionTier.Pro, new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        original.SetZonePreferences("zone-1", new ZoneNotificationPreferences(true, true, false));
+        original.SetZonePreferences("zone-2", new ZoneNotificationPreferences(false, false, true));
+
+        // Act
+        var document = UserProfileDocument.FromDomain(original);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        var zone1 = roundTripped.GetZonePreferences("zone-1");
+        await Assert.That(zone1.NewApplications).IsTrue();
+        await Assert.That(zone1.StatusChanges).IsTrue();
+        await Assert.That(zone1.DecisionUpdates).IsFalse();
+
+        var zone2 = roundTripped.GetZonePreferences("zone-2");
+        await Assert.That(zone2.NewApplications).IsFalse();
+        await Assert.That(zone2.StatusChanges).IsFalse();
+        await Assert.That(zone2.DecisionUpdates).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_HandleNullOptionalFields_When_MappedFromDomain()
+    {
+        // Arrange — fresh profile has null postcode, subscription expiry, etc.
+        var profile = UserProfile.Register("auth0|user-1");
+
+        // Act
+        var document = UserProfileDocument.FromDomain(profile);
+
+        // Assert
+        await Assert.That(document.Postcode).IsNull();
+        await Assert.That(document.Tier).IsEqualTo("Free");
+        await Assert.That(document.SubscriptionExpiry).IsNull();
+        await Assert.That(document.OriginalTransactionId).IsNull();
+        await Assert.That(document.GracePeriodExpiry).IsNull();
+        await Assert.That(document.ZonePreferences).IsNotNull();
+        await Assert.That(document.ZonePreferences).IsEmpty();
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/WatchZones/WatchZoneDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/WatchZones/WatchZoneDocumentTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using TownCrier.Domain.Geocoding;
+using TownCrier.Domain.WatchZones;
+using TownCrier.Infrastructure.Cosmos;
+using TownCrier.Infrastructure.WatchZones;
+
+namespace TownCrier.Infrastructure.Tests.WatchZones;
+
+public sealed class WatchZoneDocumentTests
+{
+    [Test]
+    public async Task Should_PreserveAllFields_When_MappedFromDomain()
+    {
+        // Arrange
+        var zone = new WatchZone("zone-1", "user-1", "Home Area", new Coordinates(51.5074, -0.1278), 5000, 42);
+
+        // Act
+        var document = WatchZoneDocument.FromDomain(zone);
+
+        // Assert
+        await Assert.That(document.Id).IsEqualTo("zone-1");
+        await Assert.That(document.UserId).IsEqualTo("user-1");
+        await Assert.That(document.Name).IsEqualTo("Home Area");
+        await Assert.That(document.Latitude).IsEqualTo(51.5074);
+        await Assert.That(document.Longitude).IsEqualTo(-0.1278);
+        await Assert.That(document.RadiusMetres).IsEqualTo(5000);
+        await Assert.That(document.AuthorityId).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Should_RoundTripToDomain_When_MappedBackAndForth()
+    {
+        // Arrange
+        var original = new WatchZone("zone-1", "user-1", "Home Area", new Coordinates(51.5074, -0.1278), 5000, 42);
+
+        // Act
+        var document = WatchZoneDocument.FromDomain(original);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.Id).IsEqualTo(original.Id);
+        await Assert.That(roundTripped.UserId).IsEqualTo(original.UserId);
+        await Assert.That(roundTripped.Name).IsEqualTo(original.Name);
+        await Assert.That(roundTripped.Centre.Latitude).IsEqualTo(original.Centre.Latitude);
+        await Assert.That(roundTripped.Centre.Longitude).IsEqualTo(original.Centre.Longitude);
+        await Assert.That(roundTripped.RadiusMetres).IsEqualTo(original.RadiusMetres);
+        await Assert.That(roundTripped.AuthorityId).IsEqualTo(original.AuthorityId);
+    }
+
+    [Test]
+    public async Task Should_RoundTripThroughJsonSerialization_When_UsingCosmosSerializer()
+    {
+        // Arrange
+        var original = WatchZoneDocument.FromDomain(
+            new WatchZone("zone-1", "user-1", "Home Area", new Coordinates(51.5074, -0.1278), 5000, 42));
+
+        var jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        jsonOptions.TypeInfoResolverChain.Add(CosmosJsonSerializerContext.Default);
+
+        var serializer = new SystemTextJsonCosmosSerializer(jsonOptions);
+
+        // Act
+        using var stream = serializer.ToStream(original);
+        var deserialized = serializer.FromStream<WatchZoneDocument>(stream);
+
+        // Assert
+        await Assert.That(deserialized.Id).IsEqualTo(original.Id);
+        await Assert.That(deserialized.UserId).IsEqualTo(original.UserId);
+        await Assert.That(deserialized.Name).IsEqualTo(original.Name);
+        await Assert.That(deserialized.Latitude).IsEqualTo(original.Latitude);
+        await Assert.That(deserialized.Longitude).IsEqualTo(original.Longitude);
+        await Assert.That(deserialized.RadiusMetres).IsEqualTo(original.RadiusMetres);
+        await Assert.That(deserialized.AuthorityId).IsEqualTo(original.AuthorityId);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/town-crier.infrastructure.tests.csproj
+++ b/api/tests/town-crier.infrastructure.tests/town-crier.infrastructure.tests.csproj
@@ -9,6 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0-preview.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0-preview.*" />
     <PackageReference Include="TUnit" Version="0.12.*" />
   </ItemGroup>
 

--- a/api/tests/town-crier.web.tests/TestWebApplicationFactory.cs
+++ b/api/tests/town-crier.web.tests/TestWebApplicationFactory.cs
@@ -15,6 +15,9 @@ internal sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
     {
         builder.UseSetting("Auth0:Domain", "test.auth0.com");
         builder.UseSetting("Auth0:Audience", "https://api.towncrier.app");
+        builder.UseSetting(
+            "ConnectionStrings:CosmosDb",
+            "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==");
 
         builder.ConfigureTestServices(services =>
         {

--- a/api/tests/town-crier.web.tests/TestWebApplicationFactory.cs
+++ b/api/tests/town-crier.web.tests/TestWebApplicationFactory.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
+using TownCrier.Application.UserProfiles;
+using TownCrier.Infrastructure.UserProfiles;
 using TownCrier.Web.Tests.Auth;
 
 namespace TownCrier.Web.Tests;
@@ -15,9 +17,12 @@ internal sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
     {
         builder.UseSetting("Auth0:Domain", "test.auth0.com");
         builder.UseSetting("Auth0:Audience", "https://api.towncrier.app");
+        builder.UseSetting("ConnectionStrings:CosmosDb", "AccountEndpoint=https://localhost:8081/;AccountKey=dGVzdA==");
 
         builder.ConfigureTestServices(services =>
         {
+            services.AddSingleton<IUserProfileRepository, InMemoryUserProfileRepository>();
+
             services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
             {
                 options.Authority = null;

--- a/api/tests/town-crier.web.tests/TestWebApplicationFactory.cs
+++ b/api/tests/town-crier.web.tests/TestWebApplicationFactory.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
+using TownCrier.Application.Groups;
+using TownCrier.Infrastructure.Groups;
 using TownCrier.Web.Tests.Auth;
 
 namespace TownCrier.Web.Tests;
@@ -15,9 +17,13 @@ internal sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
     {
         builder.UseSetting("Auth0:Domain", "test.auth0.com");
         builder.UseSetting("Auth0:Audience", "https://api.towncrier.app");
+        builder.UseSetting("ConnectionStrings:CosmosDb", "AccountEndpoint=https://localhost:8081/;AccountKey=dGVzdA==");
 
         builder.ConfigureTestServices(services =>
         {
+            services.AddSingleton<IGroupRepository, InMemoryGroupRepository>();
+            services.AddSingleton<IGroupInvitationRepository, InMemoryGroupInvitationRepository>();
+
             services.PostConfigure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
             {
                 options.Authority = null;

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -205,6 +205,78 @@ public static class EnvironmentStack
             },
         });
 
+        // DeviceRegistrations container — partitioned by userId
+        var deviceRegistrationsContainer = new SqlResourceSqlContainer($"container-deviceregistrations-{env}", new SqlResourceSqlContainerArgs
+        {
+            AccountName = cosmosAccountName,
+            ResourceGroupName = sharedResourceGroupName,
+            DatabaseName = cosmosDatabase.Name,
+            ContainerName = "DeviceRegistrations",
+            Resource = new SqlContainerResourceArgs
+            {
+                Id = "DeviceRegistrations",
+                PartitionKey = new ContainerPartitionKeyArgs
+                {
+                    Paths = new[] { "/userId" },
+                    Kind = PartitionKind.Hash,
+                },
+            },
+        });
+
+        // SavedApplications container — partitioned by userId
+        var savedApplicationsContainer = new SqlResourceSqlContainer($"container-savedapplications-{env}", new SqlResourceSqlContainerArgs
+        {
+            AccountName = cosmosAccountName,
+            ResourceGroupName = sharedResourceGroupName,
+            DatabaseName = cosmosDatabase.Name,
+            ContainerName = "SavedApplications",
+            Resource = new SqlContainerResourceArgs
+            {
+                Id = "SavedApplications",
+                PartitionKey = new ContainerPartitionKeyArgs
+                {
+                    Paths = new[] { "/userId" },
+                    Kind = PartitionKind.Hash,
+                },
+            },
+        });
+
+        // Groups container — partitioned by ownerId
+        var groupsContainer = new SqlResourceSqlContainer($"container-groups-{env}", new SqlResourceSqlContainerArgs
+        {
+            AccountName = cosmosAccountName,
+            ResourceGroupName = sharedResourceGroupName,
+            DatabaseName = cosmosDatabase.Name,
+            ContainerName = "Groups",
+            Resource = new SqlContainerResourceArgs
+            {
+                Id = "Groups",
+                PartitionKey = new ContainerPartitionKeyArgs
+                {
+                    Paths = new[] { "/ownerId" },
+                    Kind = PartitionKind.Hash,
+                },
+            },
+        });
+
+        // DecisionAlerts container — partitioned by userId
+        var decisionAlertsContainer = new SqlResourceSqlContainer($"container-decisionalerts-{env}", new SqlResourceSqlContainerArgs
+        {
+            AccountName = cosmosAccountName,
+            ResourceGroupName = sharedResourceGroupName,
+            DatabaseName = cosmosDatabase.Name,
+            ContainerName = "DecisionAlerts",
+            Resource = new SqlContainerResourceArgs
+            {
+                Id = "DecisionAlerts",
+                PartitionKey = new ContainerPartitionKeyArgs
+                {
+                    Paths = new[] { "/userId" },
+                    Kind = PartitionKind.Hash,
+                },
+            },
+        });
+
         // Managed Certificate for API custom domain
         // Phase 1 (first deploy): Container App created first with disabled binding,
         //   then cert created with DependsOn so Azure can validate the hostname.


### PR DESCRIPTION
## Changes
- Bootstrap Cosmos SDK with System.Text.Json custom serializer, client factory, and DI registration (Native AOT-compatible)
- Add four Cosmos DB containers to Pulumi (DeviceRegistrations, SavedApplications, Groups, DecisionAlerts)
- Implement CosmosUserProfileRepository backed by Users container
- Implement CosmosPlanningApplicationRepository with GeoJSON spatial queries
- Implement CosmosWatchZoneRepository with Name property addition to domain entity
- Implement CosmosNotificationRepository with 90-day TTL
- Implement CosmosDeviceRegistrationRepository
- Implement CosmosSavedApplicationRepository with composite ID
- Implement CosmosGroupRepository + CosmosGroupInvitationRepository with type discriminator
- Implement CosmosDecisionAlertRepository with single-partition point reads
- Replace all InMemory repository DI registrations with Cosmos implementations
- 222 tests passing (132 application + 71 infrastructure + 19 web), 0 warnings

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Watch zones can now be created with custom names for easier identification and management.

* **Infrastructure**
  * Upgraded persistence layer to use Azure Cosmos DB for enhanced scalability and reliability.

* **Documentation**
  * Added agent setup and workflow guide for automated task handling.

* **Chores**
  * Updated build configuration and Git hooks to latest versions.
  * Enhanced local development environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->