### PR TITLE
feat(ios): wire up iOS app to Town Crier API

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,19 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; [[ \"$f\" == */mobile/ios/*.swift ]] || exit 0; lint=$(cd mobile/ios && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swiftlint lint \"$f\" --quiet 2>/dev/null | grep \"^$f:\"); [ -z \"$lint\" ] && exit 0; jq -n --arg ctx \"SwiftLint violations — fix before continuing:\\n$lint\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":$ctx}}'; } 2>/dev/null || true",
+            "timeout": 30,
+            "statusMessage": "Running SwiftLint..."
+          }
+        ]
+      }
     ]
   }
 }

--- a/api/src/town-crier.application/Authorities/IAuthorityResolver.cs
+++ b/api/src/town-crier.application/Authorities/IAuthorityResolver.cs
@@ -1,0 +1,6 @@
+namespace TownCrier.Application.Authorities;
+
+public interface IAuthorityResolver
+{
+    Task<int> ResolveFromCoordinatesAsync(double latitude, double longitude, CancellationToken ct);
+}

--- a/api/src/town-crier.application/PlanningApplications/GetApplicationByUidQuery.cs
+++ b/api/src/town-crier.application/PlanningApplications/GetApplicationByUidQuery.cs
@@ -1,0 +1,3 @@
+namespace TownCrier.Application.PlanningApplications;
+
+public sealed record GetApplicationByUidQuery(string Uid);

--- a/api/src/town-crier.application/PlanningApplications/GetApplicationByUidQueryHandler.cs
+++ b/api/src/town-crier.application/PlanningApplications/GetApplicationByUidQueryHandler.cs
@@ -1,0 +1,49 @@
+using TownCrier.Domain.PlanningApplications;
+
+namespace TownCrier.Application.PlanningApplications;
+
+public sealed class GetApplicationByUidQueryHandler
+{
+    private readonly IPlanningApplicationRepository repository;
+
+    public GetApplicationByUidQueryHandler(IPlanningApplicationRepository repository)
+    {
+        this.repository = repository;
+    }
+
+    public async Task<PlanningApplicationResult?> HandleAsync(GetApplicationByUidQuery query, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var application = await this.repository.GetByUidAsync(query.Uid, ct).ConfigureAwait(false);
+        if (application is null)
+        {
+            return null;
+        }
+
+        return ToResult(application);
+    }
+
+    internal static PlanningApplicationResult ToResult(PlanningApplication application)
+    {
+        return new PlanningApplicationResult(
+            application.Name,
+            application.Uid,
+            application.AreaName,
+            application.AreaId,
+            application.Address,
+            application.Postcode,
+            application.Description,
+            application.AppType,
+            application.AppState,
+            application.AppSize,
+            application.StartDate,
+            application.DecidedDate,
+            application.ConsultedDate,
+            application.Longitude,
+            application.Latitude,
+            application.Url,
+            application.Link,
+            application.LastDifferent);
+    }
+}

--- a/api/src/town-crier.application/PlanningApplications/GetApplicationsByAuthorityQuery.cs
+++ b/api/src/town-crier.application/PlanningApplications/GetApplicationsByAuthorityQuery.cs
@@ -1,0 +1,3 @@
+namespace TownCrier.Application.PlanningApplications;
+
+public sealed record GetApplicationsByAuthorityQuery(int AuthorityId);

--- a/api/src/town-crier.application/PlanningApplications/GetApplicationsByAuthorityQueryHandler.cs
+++ b/api/src/town-crier.application/PlanningApplications/GetApplicationsByAuthorityQueryHandler.cs
@@ -1,0 +1,20 @@
+namespace TownCrier.Application.PlanningApplications;
+
+public sealed class GetApplicationsByAuthorityQueryHandler
+{
+    private readonly IPlanningApplicationRepository repository;
+
+    public GetApplicationsByAuthorityQueryHandler(IPlanningApplicationRepository repository)
+    {
+        this.repository = repository;
+    }
+
+    public async Task<IReadOnlyList<PlanningApplicationResult>> HandleAsync(GetApplicationsByAuthorityQuery query, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var applications = await this.repository.GetByAuthorityIdAsync(query.AuthorityId, ct).ConfigureAwait(false);
+
+        return applications.Select(GetApplicationByUidQueryHandler.ToResult).ToList();
+    }
+}

--- a/api/src/town-crier.application/PlanningApplications/IPlanningApplicationRepository.cs
+++ b/api/src/town-crier.application/PlanningApplications/IPlanningApplicationRepository.cs
@@ -6,6 +6,10 @@ public interface IPlanningApplicationRepository
 {
     Task UpsertAsync(PlanningApplication application, CancellationToken ct);
 
+    Task<PlanningApplication?> GetByUidAsync(string uid, CancellationToken ct);
+
+    Task<IReadOnlyCollection<PlanningApplication>> GetByAuthorityIdAsync(int authorityId, CancellationToken ct);
+
     Task<IReadOnlyCollection<PlanningApplication>> FindNearbyAsync(
         string authorityCode, double latitude, double longitude, double radiusMetres, CancellationToken ct);
 }

--- a/api/src/town-crier.application/PlanningApplications/PlanningApplicationResult.cs
+++ b/api/src/town-crier.application/PlanningApplications/PlanningApplicationResult.cs
@@ -1,0 +1,23 @@
+#pragma warning disable CA1054, CA1056
+namespace TownCrier.Application.PlanningApplications;
+
+public sealed record PlanningApplicationResult(
+    string Name,
+    string Uid,
+    string AreaName,
+    int AreaId,
+    string Address,
+    string? Postcode,
+    string Description,
+    string AppType,
+    string AppState,
+    string? AppSize,
+    DateOnly? StartDate,
+    DateOnly? DecidedDate,
+    DateOnly? ConsultedDate,
+    double? Longitude,
+    double? Latitude,
+    string? Url,
+    string? Link,
+    DateTimeOffset LastDifferent);
+#pragma warning restore CA1054, CA1056

--- a/api/src/town-crier.application/VersionConfig/GetVersionConfigQuery.cs
+++ b/api/src/town-crier.application/VersionConfig/GetVersionConfigQuery.cs
@@ -1,0 +1,3 @@
+namespace TownCrier.Application.VersionConfig;
+
+public sealed record GetVersionConfigQuery;

--- a/api/src/town-crier.application/VersionConfig/GetVersionConfigQueryHandler.cs
+++ b/api/src/town-crier.application/VersionConfig/GetVersionConfigQueryHandler.cs
@@ -1,0 +1,9 @@
+namespace TownCrier.Application.VersionConfig;
+
+public static class GetVersionConfigQueryHandler
+{
+    public static Task<GetVersionConfigResult> HandleAsync(GetVersionConfigQuery query, CancellationToken ct)
+    {
+        return Task.FromResult(new GetVersionConfigResult(MinimumVersion: "1.0.0"));
+    }
+}

--- a/api/src/town-crier.application/VersionConfig/GetVersionConfigResult.cs
+++ b/api/src/town-crier.application/VersionConfig/GetVersionConfigResult.cs
@@ -1,0 +1,3 @@
+namespace TownCrier.Application.VersionConfig;
+
+public sealed record GetVersionConfigResult(string MinimumVersion);

--- a/api/src/town-crier.application/WatchZones/CreateWatchZoneCommand.cs
+++ b/api/src/town-crier.application/WatchZones/CreateWatchZoneCommand.cs
@@ -7,4 +7,4 @@ public sealed record CreateWatchZoneCommand(
     double Latitude,
     double Longitude,
     double RadiusMetres,
-    int AuthorityId);
+    int? AuthorityId = null);

--- a/api/src/town-crier.application/WatchZones/CreateWatchZoneCommandHandler.cs
+++ b/api/src/town-crier.application/WatchZones/CreateWatchZoneCommandHandler.cs
@@ -1,3 +1,4 @@
+using TownCrier.Application.Authorities;
 using TownCrier.Application.PlanIt;
 using TownCrier.Application.PlanningApplications;
 using TownCrier.Application.UserProfiles;
@@ -11,6 +12,7 @@ public sealed class CreateWatchZoneCommandHandler
 {
     private static readonly TimeSpan BackfillWindow = TimeSpan.FromDays(90);
 
+    private readonly IAuthorityResolver authorityResolver;
     private readonly IPlanItClient planItClient;
     private readonly IPlanningApplicationRepository planningApplicationRepository;
     private readonly TimeProvider timeProvider;
@@ -22,12 +24,14 @@ public sealed class CreateWatchZoneCommandHandler
         IUserProfileRepository userProfileRepository,
         IPlanItClient planItClient,
         IPlanningApplicationRepository planningApplicationRepository,
+        IAuthorityResolver authorityResolver,
         TimeProvider timeProvider)
     {
         this.watchZoneRepository = watchZoneRepository;
         this.userProfileRepository = userProfileRepository;
         this.planItClient = planItClient;
         this.planningApplicationRepository = planningApplicationRepository;
+        this.authorityResolver = authorityResolver;
         this.timeProvider = timeProvider;
     }
 
@@ -38,13 +42,16 @@ public sealed class CreateWatchZoneCommandHandler
         var profile = await this.userProfileRepository.GetByUserIdAsync(command.UserId, ct).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"User profile not found: {command.UserId}");
 
+        var authorityId = command.AuthorityId
+            ?? await this.authorityResolver.ResolveFromCoordinatesAsync(command.Latitude, command.Longitude, ct).ConfigureAwait(false);
+
         var zone = new WatchZone(
             command.ZoneId,
             command.UserId,
             command.Name,
             new Coordinates(command.Latitude, command.Longitude),
             command.RadiusMetres,
-            command.AuthorityId);
+            authorityId);
 
         await this.watchZoneRepository.SaveAsync(zone, ct).ConfigureAwait(false);
 
@@ -53,13 +60,13 @@ public sealed class CreateWatchZoneCommandHandler
             var backfillSince = this.timeProvider.GetUtcNow() - BackfillWindow;
 
             await foreach (var application in this.planItClient.FetchApplicationsAsync(
-                command.AuthorityId, backfillSince, ct).ConfigureAwait(false))
+                authorityId, backfillSince, ct).ConfigureAwait(false))
             {
                 await this.planningApplicationRepository.UpsertAsync(application, ct).ConfigureAwait(false);
             }
         }
 
-        var authorityCode = command.AuthorityId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var authorityCode = authorityId.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var nearbyApplications = await this.planningApplicationRepository.FindNearbyAsync(
             authorityCode, command.Latitude, command.Longitude, command.RadiusMetres, ct).ConfigureAwait(false);
 

--- a/api/src/town-crier.application/WatchZones/DeleteWatchZoneCommand.cs
+++ b/api/src/town-crier.application/WatchZones/DeleteWatchZoneCommand.cs
@@ -1,0 +1,3 @@
+namespace TownCrier.Application.WatchZones;
+
+public sealed record DeleteWatchZoneCommand(string UserId, string ZoneId);

--- a/api/src/town-crier.application/WatchZones/DeleteWatchZoneCommandHandler.cs
+++ b/api/src/town-crier.application/WatchZones/DeleteWatchZoneCommandHandler.cs
@@ -1,0 +1,18 @@
+namespace TownCrier.Application.WatchZones;
+
+public sealed class DeleteWatchZoneCommandHandler
+{
+    private readonly IWatchZoneRepository watchZoneRepository;
+
+    public DeleteWatchZoneCommandHandler(IWatchZoneRepository watchZoneRepository)
+    {
+        this.watchZoneRepository = watchZoneRepository;
+    }
+
+    public async Task HandleAsync(DeleteWatchZoneCommand command, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        await this.watchZoneRepository.DeleteAsync(command.UserId, command.ZoneId, ct).ConfigureAwait(false);
+    }
+}

--- a/api/src/town-crier.application/WatchZones/IWatchZoneRepository.cs
+++ b/api/src/town-crier.application/WatchZones/IWatchZoneRepository.cs
@@ -6,6 +6,10 @@ public interface IWatchZoneRepository
 {
     Task SaveAsync(WatchZone zone, CancellationToken ct);
 
+    Task<IReadOnlyCollection<WatchZone>> GetByUserIdAsync(string userId, CancellationToken ct);
+
+    Task DeleteAsync(string userId, string zoneId, CancellationToken ct);
+
     Task<IReadOnlyCollection<WatchZone>> FindZonesContainingAsync(
         double latitude, double longitude, CancellationToken ct);
 

--- a/api/src/town-crier.application/WatchZones/ListWatchZonesQuery.cs
+++ b/api/src/town-crier.application/WatchZones/ListWatchZonesQuery.cs
@@ -1,0 +1,3 @@
+namespace TownCrier.Application.WatchZones;
+
+public sealed record ListWatchZonesQuery(string UserId);

--- a/api/src/town-crier.application/WatchZones/ListWatchZonesQueryHandler.cs
+++ b/api/src/town-crier.application/WatchZones/ListWatchZonesQueryHandler.cs
@@ -1,0 +1,30 @@
+namespace TownCrier.Application.WatchZones;
+
+public sealed class ListWatchZonesQueryHandler
+{
+    private readonly IWatchZoneRepository watchZoneRepository;
+
+    public ListWatchZonesQueryHandler(IWatchZoneRepository watchZoneRepository)
+    {
+        this.watchZoneRepository = watchZoneRepository;
+    }
+
+    public async Task<ListWatchZonesResult> HandleAsync(ListWatchZonesQuery query, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var zones = await this.watchZoneRepository.GetByUserIdAsync(query.UserId, ct).ConfigureAwait(false);
+
+        var summaries = zones
+            .Select(z => new WatchZoneSummary(
+                z.Id,
+                z.Name,
+                z.Centre.Latitude,
+                z.Centre.Longitude,
+                z.RadiusMetres,
+                z.AuthorityId))
+            .ToList();
+
+        return new ListWatchZonesResult(summaries);
+    }
+}

--- a/api/src/town-crier.application/WatchZones/ListWatchZonesResult.cs
+++ b/api/src/town-crier.application/WatchZones/ListWatchZonesResult.cs
@@ -1,0 +1,3 @@
+namespace TownCrier.Application.WatchZones;
+
+public sealed record ListWatchZonesResult(IReadOnlyCollection<WatchZoneSummary> Zones);

--- a/api/src/town-crier.application/WatchZones/WatchZoneNotFoundException.cs
+++ b/api/src/town-crier.application/WatchZones/WatchZoneNotFoundException.cs
@@ -1,0 +1,19 @@
+namespace TownCrier.Application.WatchZones;
+
+public sealed class WatchZoneNotFoundException : Exception
+{
+    public WatchZoneNotFoundException()
+        : base("Watch zone not found.")
+    {
+    }
+
+    public WatchZoneNotFoundException(string message)
+        : base(message)
+    {
+    }
+
+    public WatchZoneNotFoundException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/api/src/town-crier.application/WatchZones/WatchZoneSummary.cs
+++ b/api/src/town-crier.application/WatchZones/WatchZoneSummary.cs
@@ -1,0 +1,9 @@
+namespace TownCrier.Application.WatchZones;
+
+public sealed record WatchZoneSummary(
+    string Id,
+    string Name,
+    double Latitude,
+    double Longitude,
+    double RadiusMetres,
+    int AuthorityId);

--- a/api/src/town-crier.infrastructure/Geocoding/GeocodingJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Geocoding/GeocodingJsonSerializerContext.cs
@@ -3,4 +3,5 @@ using System.Text.Json.Serialization;
 namespace TownCrier.Infrastructure.Geocoding;
 
 [JsonSerializable(typeof(PostcodesIoResponse))]
+[JsonSerializable(typeof(PostcodesIoReverseResponse))]
 internal sealed partial class GeocodingJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Geocoding/PostcodesIoAuthorityResolver.cs
+++ b/api/src/town-crier.infrastructure/Geocoding/PostcodesIoAuthorityResolver.cs
@@ -1,0 +1,56 @@
+using System.Globalization;
+using System.Net.Http.Json;
+using TownCrier.Application.Authorities;
+
+namespace TownCrier.Infrastructure.Geocoding;
+
+public sealed class PostcodesIoAuthorityResolver : IAuthorityResolver
+{
+    private readonly IAuthorityProvider authorityProvider;
+    private readonly HttpClient httpClient;
+
+    public PostcodesIoAuthorityResolver(HttpClient httpClient, IAuthorityProvider authorityProvider)
+    {
+        this.httpClient = httpClient;
+        this.authorityProvider = authorityProvider;
+    }
+
+    public async Task<int> ResolveFromCoordinatesAsync(double latitude, double longitude, CancellationToken ct)
+    {
+        var lat = latitude.ToString(CultureInfo.InvariantCulture);
+        var lon = longitude.ToString(CultureInfo.InvariantCulture);
+        var requestUri = new Uri($"postcodes?lon={lon}&lat={lat}", UriKind.Relative);
+
+        var response = await this.httpClient.GetAsync(requestUri, ct).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new InvalidOperationException(
+                $"Failed to reverse geocode coordinates ({latitude}, {longitude}): {response.StatusCode}");
+        }
+
+        var body = await response.Content.ReadFromJsonAsync(
+            GeocodingJsonSerializerContext.Default.PostcodesIoReverseResponse,
+            ct).ConfigureAwait(false);
+
+        var adminDistrict = body?.Result?.FirstOrDefault()?.AdminDistrict;
+
+        if (string.IsNullOrEmpty(adminDistrict))
+        {
+            throw new InvalidOperationException(
+                $"No local authority found for coordinates ({latitude}, {longitude})");
+        }
+
+        var authorities = await this.authorityProvider.GetAllAsync(ct).ConfigureAwait(false);
+        var match = authorities.FirstOrDefault(a =>
+            string.Equals(a.Name, adminDistrict, StringComparison.OrdinalIgnoreCase));
+
+        if (match is null)
+        {
+            throw new InvalidOperationException(
+                $"No PlanIt authority matches local authority '{adminDistrict}' for coordinates ({latitude}, {longitude})");
+        }
+
+        return match.Id;
+    }
+}

--- a/api/src/town-crier.infrastructure/Geocoding/PostcodesIoResult.cs
+++ b/api/src/town-crier.infrastructure/Geocoding/PostcodesIoResult.cs
@@ -12,4 +12,7 @@ internal sealed class PostcodesIoResult
 
     [JsonPropertyName("longitude")]
     public double Longitude { get; set; }
+
+    [JsonPropertyName("admin_district")]
+    public string? AdminDistrict { get; set; }
 }

--- a/api/src/town-crier.infrastructure/Geocoding/PostcodesIoReverseResponse.cs
+++ b/api/src/town-crier.infrastructure/Geocoding/PostcodesIoReverseResponse.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Infrastructure.Geocoding;
+
+internal sealed class PostcodesIoReverseResponse
+{
+    [JsonPropertyName("status")]
+    public int Status { get; set; }
+
+    [JsonPropertyName("result")]
+    public List<PostcodesIoResult>? Result { get; set; }
+}

--- a/api/src/town-crier.infrastructure/PlanningApplications/CosmosPlanningApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/PlanningApplications/CosmosPlanningApplicationRepository.cs
@@ -26,6 +26,53 @@ public sealed class CosmosPlanningApplicationRepository : IPlanningApplicationRe
             cancellationToken: ct).ConfigureAwait(false);
     }
 
+    public async Task<PlanningApplication?> GetByUidAsync(string uid, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(uid);
+
+        var query = new QueryDefinition("SELECT * FROM c WHERE c.Uid = @uid")
+            .WithParameter("@uid", uid);
+
+        using var iterator = this.container.GetItemQueryIterator<PlanningApplicationDocument>(query);
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            var document = response.FirstOrDefault();
+            if (document is not null)
+            {
+                return document.ToDomain();
+            }
+        }
+
+        return null;
+    }
+
+    public async Task<IReadOnlyCollection<PlanningApplication>> GetByAuthorityIdAsync(int authorityId, CancellationToken ct)
+    {
+        var authorityCode = authorityId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+
+        var query = new QueryDefinition("SELECT * FROM c");
+        var requestOptions = new QueryRequestOptions
+        {
+            PartitionKey = new PartitionKey(authorityCode),
+        };
+
+        var results = new List<PlanningApplication>();
+        using var iterator = this.container.GetItemQueryIterator<PlanningApplicationDocument>(query, requestOptions: requestOptions);
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            foreach (var document in response)
+            {
+                results.Add(document.ToDomain());
+            }
+        }
+
+        return results;
+    }
+
     public async Task<IReadOnlyCollection<PlanningApplication>> FindNearbyAsync(
         string authorityCode, double latitude, double longitude, double radiusMetres, CancellationToken ct)
     {

--- a/api/src/town-crier.infrastructure/PlanningApplications/InMemoryPlanningApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/PlanningApplications/InMemoryPlanningApplicationRepository.cs
@@ -15,6 +15,18 @@ public sealed class InMemoryPlanningApplicationRepository : IPlanningApplication
         return Task.CompletedTask;
     }
 
+    public Task<PlanningApplication?> GetByUidAsync(string uid, CancellationToken ct)
+    {
+        var app = this.store.Values.FirstOrDefault(a => a.Uid == uid);
+        return Task.FromResult(app);
+    }
+
+    public Task<IReadOnlyCollection<PlanningApplication>> GetByAuthorityIdAsync(int authorityId, CancellationToken ct)
+    {
+        var apps = this.store.Values.Where(a => a.AreaId == authorityId).ToList();
+        return Task.FromResult<IReadOnlyCollection<PlanningApplication>>(apps);
+    }
+
     public Task<IReadOnlyCollection<PlanningApplication>> FindNearbyAsync(
         string authorityCode, double latitude, double longitude, double radiusMetres, CancellationToken ct)
     {

--- a/api/src/town-crier.infrastructure/WatchZones/CosmosWatchZoneRepository.cs
+++ b/api/src/town-crier.infrastructure/WatchZones/CosmosWatchZoneRepository.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Microsoft.Azure.Cosmos;
 using TownCrier.Application.WatchZones;
 using TownCrier.Domain.WatchZones;
@@ -23,6 +24,46 @@ public sealed class CosmosWatchZoneRepository : IWatchZoneRepository
             document,
             new PartitionKey(document.UserId),
             cancellationToken: ct).ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyCollection<WatchZone>> GetByUserIdAsync(string userId, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+
+        var query = new QueryDefinition("SELECT * FROM c WHERE c.userId = @userId")
+            .WithParameter("@userId", userId);
+
+        using var iterator = this.container.GetItemQueryIterator<WatchZoneDocument>(
+            query,
+            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(userId) });
+
+        var results = new List<WatchZone>();
+
+        while (iterator.HasMoreResults)
+        {
+            var response = await iterator.ReadNextAsync(ct).ConfigureAwait(false);
+            results.AddRange(response.Select(doc => doc.ToDomain()));
+        }
+
+        return results;
+    }
+
+    public async Task DeleteAsync(string userId, string zoneId, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(zoneId);
+
+        try
+        {
+            await this.container.DeleteItemAsync<WatchZoneDocument>(
+                zoneId,
+                new PartitionKey(userId),
+                cancellationToken: ct).ConfigureAwait(false);
+        }
+        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            throw new WatchZoneNotFoundException();
+        }
     }
 
     public async Task<IReadOnlyCollection<WatchZone>> FindZonesContainingAsync(

--- a/api/src/town-crier.infrastructure/WatchZones/InMemoryWatchZoneRepository.cs
+++ b/api/src/town-crier.infrastructure/WatchZones/InMemoryWatchZoneRepository.cs
@@ -16,6 +16,24 @@ public sealed class InMemoryWatchZoneRepository : IWatchZoneRepository
         return Task.CompletedTask;
     }
 
+    public Task<IReadOnlyCollection<WatchZone>> GetByUserIdAsync(string userId, CancellationToken ct)
+    {
+        var matching = this.zones.Values.Where(z => z.UserId == userId).ToList();
+        return Task.FromResult<IReadOnlyCollection<WatchZone>>(matching);
+    }
+
+    public Task DeleteAsync(string userId, string zoneId, CancellationToken ct)
+    {
+        var key = this.zones.Keys.FirstOrDefault(k => this.zones[k].Id == zoneId && this.zones[k].UserId == userId);
+        if (key is null)
+        {
+            throw new WatchZoneNotFoundException();
+        }
+
+        this.zones.TryRemove(key, out _);
+        return Task.CompletedTask;
+    }
+
     public Task<IReadOnlyCollection<WatchZone>> FindZonesContainingAsync(
         double latitude, double longitude, CancellationToken ct)
     {

--- a/api/src/town-crier.web/AppJsonSerializerContext.cs
+++ b/api/src/town-crier.web/AppJsonSerializerContext.cs
@@ -11,6 +11,7 @@ using TownCrier.Application.PlanningApplications;
 using TownCrier.Application.SavedApplications;
 using TownCrier.Application.Search;
 using TownCrier.Application.UserProfiles;
+using TownCrier.Application.WatchZones;
 
 namespace TownCrier.Web;
 
@@ -40,6 +41,9 @@ namespace TownCrier.Web;
 [JsonSerializable(typeof(SearchPlanningApplicationsResult))]
 [JsonSerializable(typeof(GetNotificationsResult))]
 [JsonSerializable(typeof(IReadOnlyList<SavedApplicationResult>))]
+[JsonSerializable(typeof(CreateWatchZoneCommand))]
+[JsonSerializable(typeof(CreateWatchZoneResult))]
+[JsonSerializable(typeof(ListWatchZonesResult))]
 [JsonSerializable(typeof(UpdateZonePreferencesCommand))]
 [JsonSerializable(typeof(UpdateZonePreferencesResult))]
 [JsonSerializable(typeof(GetZonePreferencesResult))]

--- a/api/src/town-crier.web/AppJsonSerializerContext.cs
+++ b/api/src/town-crier.web/AppJsonSerializerContext.cs
@@ -11,6 +11,7 @@ using TownCrier.Application.PlanningApplications;
 using TownCrier.Application.SavedApplications;
 using TownCrier.Application.Search;
 using TownCrier.Application.UserProfiles;
+using TownCrier.Application.VersionConfig;
 using TownCrier.Application.WatchZones;
 
 namespace TownCrier.Web;
@@ -47,4 +48,5 @@ namespace TownCrier.Web;
 [JsonSerializable(typeof(UpdateZonePreferencesCommand))]
 [JsonSerializable(typeof(UpdateZonePreferencesResult))]
 [JsonSerializable(typeof(GetZonePreferencesResult))]
+[JsonSerializable(typeof(GetVersionConfigResult))]
 internal sealed partial class AppJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.web/AppJsonSerializerContext.cs
+++ b/api/src/town-crier.web/AppJsonSerializerContext.cs
@@ -7,6 +7,7 @@ using TownCrier.Application.Geocoding;
 using TownCrier.Application.Groups;
 using TownCrier.Application.Health;
 using TownCrier.Application.Notifications;
+using TownCrier.Application.PlanningApplications;
 using TownCrier.Application.SavedApplications;
 using TownCrier.Application.Search;
 using TownCrier.Application.UserProfiles;
@@ -34,6 +35,8 @@ namespace TownCrier.Web;
 [JsonSerializable(typeof(ExportUserDataResult))]
 [JsonSerializable(typeof(RegisterDeviceTokenRequest))]
 [JsonSerializable(typeof(RemoveInvalidDeviceTokenRequest))]
+[JsonSerializable(typeof(PlanningApplicationResult))]
+[JsonSerializable(typeof(IReadOnlyList<PlanningApplicationResult>))]
 [JsonSerializable(typeof(SearchPlanningApplicationsResult))]
 [JsonSerializable(typeof(GetNotificationsResult))]
 [JsonSerializable(typeof(IReadOnlyList<SavedApplicationResult>))]

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -58,6 +58,13 @@ builder.Services.AddHttpClient<IPostcodeGeocoder, PostcodesIoGeocoder>(client =>
     client.BaseAddress = new Uri(postcodesIoBaseUrl);
 });
 builder.Services.AddTransient<GeocodePostcodeQueryHandler>();
+builder.Services.AddSingleton<IAuthorityResolver>(sp =>
+{
+    var factory = sp.GetRequiredService<IHttpClientFactory>();
+    var httpClient = factory.CreateClient("PostcodesIoResolver");
+    httpClient.BaseAddress = new Uri(postcodesIoBaseUrl);
+    return new PostcodesIoAuthorityResolver(httpClient, sp.GetRequiredService<IAuthorityProvider>());
+});
 
 #pragma warning disable S1075 // Hardcoded URI is a sensible default
 var planItBaseUrl = builder.Configuration["PlanIt:BaseUrl"] ?? "https://www.planit.org.uk/";

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -118,6 +118,8 @@ builder.Services.AddSingleton<IDeviceRegistrationRepository>(sp =>
 builder.Services.AddTransient<RegisterDeviceTokenCommandHandler>();
 builder.Services.AddTransient<RemoveInvalidDeviceTokenCommandHandler>();
 
+builder.Services.AddTransient<GetApplicationByUidQueryHandler>();
+builder.Services.AddTransient<GetApplicationsByAuthorityQueryHandler>();
 builder.Services.AddTransient<SearchPlanningApplicationsQueryHandler>();
 
 builder.Services.AddSingleton<INotificationRepository>(sp =>
@@ -203,6 +205,26 @@ v1.MapGet("/authorities/{id:int}", async (
     var result = await handler.HandleAsync(new GetAuthorityByIdQuery(id), ct).ConfigureAwait(false);
     return result is null ? Results.NotFound() : Results.Ok(result);
 }).AllowAnonymous();
+
+v1.MapGet("/applications", async (
+    int authorityId,
+    GetApplicationsByAuthorityQueryHandler handler,
+    CancellationToken ct) =>
+{
+    var result = await handler.HandleAsync(
+        new GetApplicationsByAuthorityQuery(authorityId), ct).ConfigureAwait(false);
+    return Results.Ok(result);
+});
+
+v1.MapGet("/applications/{uid}", async (
+    string uid,
+    GetApplicationByUidQueryHandler handler,
+    CancellationToken ct) =>
+{
+    var result = await handler.HandleAsync(
+        new GetApplicationByUidQuery(uid), ct).ConfigureAwait(false);
+    return result is null ? Results.NotFound() : Results.Ok(result);
+});
 
 v1.MapGet("/geocode/{postcode}", async (string postcode, GeocodePostcodeQueryHandler handler, CancellationToken ct) =>
 {

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -16,6 +16,7 @@ using TownCrier.Application.RateLimiting;
 using TownCrier.Application.SavedApplications;
 using TownCrier.Application.Search;
 using TownCrier.Application.UserProfiles;
+using TownCrier.Application.VersionConfig;
 using TownCrier.Application.WatchZones;
 using TownCrier.Domain.Groups;
 using TownCrier.Domain.Polling;
@@ -178,6 +179,9 @@ app.MapGet("/health", () => CheckHealthQueryHandler.HandleAsync(new CheckHealthQ
 
 var v1 = app.MapGroup("/v1");
 v1.MapGet("/health", () => CheckHealthQueryHandler.HandleAsync(new CheckHealthQuery(), CancellationToken.None))
+    .AllowAnonymous();
+
+v1.MapGet("/version-config", () => GetVersionConfigQueryHandler.HandleAsync(new GetVersionConfigQuery(), CancellationToken.None))
     .AllowAnonymous();
 
 v1.MapGet("/designations", async (

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -112,6 +112,9 @@ builder.Services.AddTransient<ExportUserDataQueryHandler>();
 builder.Services.AddTransient<DeleteUserProfileCommandHandler>();
 builder.Services.AddTransient<UpdateZonePreferencesCommandHandler>();
 builder.Services.AddTransient<GetZonePreferencesQueryHandler>();
+builder.Services.AddTransient<CreateWatchZoneCommandHandler>();
+builder.Services.AddTransient<ListWatchZonesQueryHandler>();
+builder.Services.AddTransient<DeleteWatchZoneCommandHandler>();
 
 builder.Services.AddSingleton<IDeviceRegistrationRepository>(sp =>
     new CosmosDeviceRegistrationRepository(sp.GetRequiredService<Microsoft.Azure.Cosmos.CosmosClient>()));
@@ -373,6 +376,55 @@ v1.MapGet("/me/saved-applications", async (
     var userId = user.FindFirstValue("sub")!;
     var result = await handler.HandleAsync(new GetSavedApplicationsQuery(userId), ct).ConfigureAwait(false);
     return Results.Ok(result);
+});
+
+v1.MapPost("/me/watch-zones", async (
+    ClaimsPrincipal user,
+    CreateWatchZoneCommand command,
+    CreateWatchZoneCommandHandler handler,
+    CancellationToken ct) =>
+{
+    var userId = user.FindFirstValue("sub")!;
+    var fullCommand = new CreateWatchZoneCommand(
+        userId,
+        command.ZoneId,
+        command.Name,
+        command.Latitude,
+        command.Longitude,
+        command.RadiusMetres,
+        command.AuthorityId);
+    var result = await handler.HandleAsync(fullCommand, ct).ConfigureAwait(false);
+    return Results.Created($"/v1/me/watch-zones/{command.ZoneId}", result);
+});
+
+v1.MapGet("/me/watch-zones", async (
+    ClaimsPrincipal user,
+    ListWatchZonesQueryHandler handler,
+    CancellationToken ct) =>
+{
+    var userId = user.FindFirstValue("sub")!;
+    var result = await handler.HandleAsync(new ListWatchZonesQuery(userId), ct).ConfigureAwait(false);
+    return Results.Ok(result);
+});
+
+v1.MapDelete("/me/watch-zones/{zoneId}", async (
+    ClaimsPrincipal user,
+    string zoneId,
+    DeleteWatchZoneCommandHandler handler,
+    CancellationToken ct) =>
+{
+    var userId = user.FindFirstValue("sub")!;
+
+    try
+    {
+        await handler.HandleAsync(
+            new DeleteWatchZoneCommand(userId, zoneId), ct).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+    catch (WatchZoneNotFoundException)
+    {
+        return Results.NotFound();
+    }
 });
 
 v1.MapGet("/me/watch-zones/{zoneId}/preferences", async (

--- a/api/tests/town-crier.application.tests/PlanningApplications/GetApplicationByUidQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/PlanningApplications/GetApplicationByUidQueryHandlerTests.cs
@@ -1,0 +1,50 @@
+using TownCrier.Application.PlanningApplications;
+using TownCrier.Application.Tests.Polling;
+
+namespace TownCrier.Application.Tests.PlanningApplications;
+
+public sealed class GetApplicationByUidQueryHandlerTests
+{
+    [Test]
+    public async Task Should_ReturnApplication_When_FoundByUid()
+    {
+        // Arrange
+        var application = new PlanningApplicationBuilder()
+            .WithUid("planit-uid-001")
+            .WithName("APP/2024/001")
+            .WithAreaId(42)
+            .WithAreaName("Camden")
+            .Build();
+
+        var repository = new FakePlanningApplicationRepository();
+        await repository.UpsertAsync(application, CancellationToken.None);
+
+        var handler = new GetApplicationByUidQueryHandler(repository);
+
+        // Act
+        var result = await handler.HandleAsync(
+            new GetApplicationByUidQuery("planit-uid-001"), CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Uid).IsEqualTo("planit-uid-001");
+        await Assert.That(result.Name).IsEqualTo("APP/2024/001");
+        await Assert.That(result.AreaId).IsEqualTo(42);
+        await Assert.That(result.AreaName).IsEqualTo("Camden");
+    }
+
+    [Test]
+    public async Task Should_ReturnNull_When_UidNotFound()
+    {
+        // Arrange
+        var repository = new FakePlanningApplicationRepository();
+        var handler = new GetApplicationByUidQueryHandler(repository);
+
+        // Act
+        var result = await handler.HandleAsync(
+            new GetApplicationByUidQuery("nonexistent-uid"), CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNull();
+    }
+}

--- a/api/tests/town-crier.application.tests/PlanningApplications/GetApplicationsByAuthorityQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/PlanningApplications/GetApplicationsByAuthorityQueryHandlerTests.cs
@@ -1,0 +1,85 @@
+using TownCrier.Application.PlanningApplications;
+using TownCrier.Application.Tests.Polling;
+
+namespace TownCrier.Application.Tests.PlanningApplications;
+
+public sealed class GetApplicationsByAuthorityQueryHandlerTests
+{
+    [Test]
+    public async Task Should_ReturnApplications_When_AuthorityHasApplications()
+    {
+        // Arrange
+        var app1 = new PlanningApplicationBuilder()
+            .WithUid("uid-001")
+            .WithName("APP/2024/001")
+            .WithAreaId(42)
+            .WithAreaName("Camden")
+            .Build();
+        var app2 = new PlanningApplicationBuilder()
+            .WithUid("uid-002")
+            .WithName("APP/2024/002")
+            .WithAreaId(42)
+            .WithAreaName("Camden")
+            .Build();
+
+        var repository = new FakePlanningApplicationRepository();
+        await repository.UpsertAsync(app1, CancellationToken.None);
+        await repository.UpsertAsync(app2, CancellationToken.None);
+
+        var handler = new GetApplicationsByAuthorityQueryHandler(repository);
+
+        // Act
+        var result = await handler.HandleAsync(
+            new GetApplicationsByAuthorityQuery(42), CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task Should_ReturnEmpty_When_AuthorityHasNoApplications()
+    {
+        // Arrange
+        var repository = new FakePlanningApplicationRepository();
+        var handler = new GetApplicationsByAuthorityQueryHandler(repository);
+
+        // Act
+        var result = await handler.HandleAsync(
+            new GetApplicationsByAuthorityQuery(999), CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsEmpty();
+    }
+
+    [Test]
+    public async Task Should_OnlyReturnApplications_ForRequestedAuthority()
+    {
+        // Arrange
+        var camdenApp = new PlanningApplicationBuilder()
+            .WithUid("uid-001")
+            .WithName("APP/2024/001")
+            .WithAreaId(42)
+            .WithAreaName("Camden")
+            .Build();
+        var islingtonApp = new PlanningApplicationBuilder()
+            .WithUid("uid-002")
+            .WithName("APP/2024/002")
+            .WithAreaId(99)
+            .WithAreaName("Islington")
+            .Build();
+
+        var repository = new FakePlanningApplicationRepository();
+        await repository.UpsertAsync(camdenApp, CancellationToken.None);
+        await repository.UpsertAsync(islingtonApp, CancellationToken.None);
+
+        var handler = new GetApplicationsByAuthorityQueryHandler(repository);
+
+        // Act
+        var result = await handler.HandleAsync(
+            new GetApplicationsByAuthorityQuery(42), CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].AreaId).IsEqualTo(42);
+    }
+}

--- a/api/tests/town-crier.application.tests/Polling/FakePlanningApplicationRepository.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakePlanningApplicationRepository.cs
@@ -21,6 +21,18 @@ internal sealed class FakePlanningApplicationRepository : IPlanningApplicationRe
         return Task.CompletedTask;
     }
 
+    public Task<PlanningApplication?> GetByUidAsync(string uid, CancellationToken ct)
+    {
+        var app = this.store.Values.FirstOrDefault(a => a.Uid == uid);
+        return Task.FromResult(app);
+    }
+
+    public Task<IReadOnlyCollection<PlanningApplication>> GetByAuthorityIdAsync(int authorityId, CancellationToken ct)
+    {
+        var apps = this.store.Values.Where(a => a.AreaId == authorityId).ToList();
+        return Task.FromResult<IReadOnlyCollection<PlanningApplication>>(apps);
+    }
+
     public Task<IReadOnlyCollection<PlanningApplication>> FindNearbyAsync(
         string authorityCode, double latitude, double longitude, double radiusMetres, CancellationToken ct)
     {

--- a/api/tests/town-crier.application.tests/Polling/FakeWatchZoneRepository.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakeWatchZoneRepository.cs
@@ -25,6 +25,23 @@ internal sealed class FakeWatchZoneRepository : IWatchZoneRepository
         this.zones.RemoveAll(z => z.Id == zoneId);
     }
 
+    public Task<IReadOnlyCollection<WatchZone>> GetByUserIdAsync(string userId, CancellationToken ct)
+    {
+        var matching = this.zones.Where(z => z.UserId == userId).ToList();
+        return Task.FromResult<IReadOnlyCollection<WatchZone>>(matching);
+    }
+
+    public Task DeleteAsync(string userId, string zoneId, CancellationToken ct)
+    {
+        var removed = this.zones.RemoveAll(z => z.Id == zoneId && z.UserId == userId);
+        if (removed == 0)
+        {
+            throw new WatchZoneNotFoundException();
+        }
+
+        return Task.CompletedTask;
+    }
+
     public Task<IReadOnlyCollection<int>> GetDistinctAuthorityIdsAsync(CancellationToken ct)
     {
         var authorityIds = this.zones

--- a/api/tests/town-crier.application.tests/VersionConfig/GetVersionConfigQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/VersionConfig/GetVersionConfigQueryHandlerTests.cs
@@ -1,0 +1,19 @@
+using TownCrier.Application.VersionConfig;
+
+namespace TownCrier.Application.Tests.VersionConfig;
+
+public sealed class GetVersionConfigQueryHandlerTests
+{
+    [Test]
+    public async Task Should_ReturnMinimumVersion_When_Queried()
+    {
+        // Arrange
+        var query = new GetVersionConfigQuery();
+
+        // Act
+        var result = await GetVersionConfigQueryHandler.HandleAsync(query, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.MinimumVersion).IsEqualTo("1.0.0");
+    }
+}

--- a/api/tests/town-crier.application.tests/WatchZones/CreateWatchZoneCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/WatchZones/CreateWatchZoneCommandHandlerTests.cs
@@ -9,6 +9,7 @@ public sealed class CreateWatchZoneCommandHandlerTests
 {
     private static readonly DateTimeOffset FixedNow = new(2026, 3, 17, 12, 0, 0, TimeSpan.Zero);
 
+    private readonly FakeAuthorityResolver authorityResolver = new();
     private readonly FakePlanItClient planItClient = new();
     private readonly FakePlanningApplicationRepository planningApplicationRepository = new();
     private readonly FakeUserProfileRepository userProfileRepository = new();
@@ -263,6 +264,72 @@ public sealed class CreateWatchZoneCommandHandlerTests
             () => handler.HandleAsync(command, CancellationToken.None));
     }
 
+    [Test]
+    public async Task Should_ResolveAuthorityFromCoordinates_When_AuthorityIdNotProvided()
+    {
+        // Arrange
+        var profile = UserProfile.Register("user-1");
+        await this.userProfileRepository.SaveAsync(profile, CancellationToken.None);
+
+        this.authorityResolver.Add(51.5074, -0.1278, 42);
+
+        var handler = this.CreateHandler();
+        var command = new CreateWatchZoneCommand(
+            UserId: "user-1",
+            ZoneId: "zone-1",
+            Name: "My Zone",
+            Latitude: 51.5074,
+            Longitude: -0.1278,
+            RadiusMetres: 5000);
+
+        // Act
+        await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        var zones = await this.watchZoneRepository.FindZonesContainingAsync(51.5074, -0.1278, CancellationToken.None);
+        await Assert.That(zones).HasCount().EqualTo(1);
+        await Assert.That(zones.First().AuthorityId).IsEqualTo(42);
+    }
+
+    [Test]
+    public async Task Should_NotCallAuthorityResolver_When_AuthorityIdProvided()
+    {
+        // Arrange
+        var profile = UserProfile.Register("user-1");
+        await this.userProfileRepository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = this.CreateHandler();
+        var command = CreateCommand();
+
+        // Act
+        await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(this.authorityResolver.CallCount).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_ThrowInvalidOperation_When_AuthorityCannotBeResolved()
+    {
+        // Arrange
+        var profile = UserProfile.Register("user-1");
+        await this.userProfileRepository.SaveAsync(profile, CancellationToken.None);
+
+        // No authority resolver mapping configured — resolution will fail
+        var handler = this.CreateHandler();
+        var command = new CreateWatchZoneCommand(
+            UserId: "user-1",
+            ZoneId: "zone-1",
+            Name: "My Zone",
+            Latitude: 99.0,
+            Longitude: 99.0,
+            RadiusMetres: 5000);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => handler.HandleAsync(command, CancellationToken.None));
+    }
+
     private static CreateWatchZoneCommand CreateCommand(string userId = "user-1")
     {
         return new CreateWatchZoneCommand(
@@ -282,6 +349,7 @@ public sealed class CreateWatchZoneCommandHandlerTests
             this.userProfileRepository,
             this.planItClient,
             this.planningApplicationRepository,
+            this.authorityResolver,
             new FakeTimeProvider(FixedNow));
     }
 }

--- a/api/tests/town-crier.application.tests/WatchZones/DeleteWatchZoneCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/WatchZones/DeleteWatchZoneCommandHandlerTests.cs
@@ -1,0 +1,91 @@
+using TownCrier.Application.Tests.Polling;
+using TownCrier.Application.WatchZones;
+
+namespace TownCrier.Application.Tests.WatchZones;
+
+public sealed class DeleteWatchZoneCommandHandlerTests
+{
+    private readonly FakeWatchZoneRepository watchZoneRepository = new();
+
+    [Test]
+    public async Task Should_DeleteZone_When_ZoneExistsForUser()
+    {
+        // Arrange
+        var zone = new WatchZoneBuilder()
+            .WithId("zone-1")
+            .WithUserId("user-1")
+            .WithName("My Zone")
+            .Build();
+        this.watchZoneRepository.Add(zone);
+
+        var handler = new DeleteWatchZoneCommandHandler(this.watchZoneRepository);
+        var command = new DeleteWatchZoneCommand("user-1", "zone-1");
+
+        // Act
+        await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        var remaining = await this.watchZoneRepository.GetByUserIdAsync("user-1", CancellationToken.None);
+        await Assert.That(remaining).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_ThrowWatchZoneNotFound_When_ZoneDoesNotExist()
+    {
+        // Arrange
+        var handler = new DeleteWatchZoneCommandHandler(this.watchZoneRepository);
+        var command = new DeleteWatchZoneCommand("user-1", "nonexistent-zone");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<WatchZoneNotFoundException>(
+            () => handler.HandleAsync(command, CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Should_ThrowWatchZoneNotFound_When_ZoneBelongsToDifferentUser()
+    {
+        // Arrange
+        var zone = new WatchZoneBuilder()
+            .WithId("zone-1")
+            .WithUserId("user-2")
+            .WithName("Other User Zone")
+            .Build();
+        this.watchZoneRepository.Add(zone);
+
+        var handler = new DeleteWatchZoneCommandHandler(this.watchZoneRepository);
+        var command = new DeleteWatchZoneCommand("user-1", "zone-1");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<WatchZoneNotFoundException>(
+            () => handler.HandleAsync(command, CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Should_NotDeleteOtherZones_When_DeletingOneZone()
+    {
+        // Arrange
+        var zone1 = new WatchZoneBuilder()
+            .WithId("zone-1")
+            .WithUserId("user-1")
+            .WithName("Zone One")
+            .Build();
+        var zone2 = new WatchZoneBuilder()
+            .WithId("zone-2")
+            .WithUserId("user-1")
+            .WithName("Zone Two")
+            .Build();
+        this.watchZoneRepository.Add(zone1);
+        this.watchZoneRepository.Add(zone2);
+
+        var handler = new DeleteWatchZoneCommandHandler(this.watchZoneRepository);
+        var command = new DeleteWatchZoneCommand("user-1", "zone-1");
+
+        // Act
+        await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        var remaining = await this.watchZoneRepository.GetByUserIdAsync("user-1", CancellationToken.None);
+        await Assert.That(remaining).HasCount().EqualTo(1);
+        await Assert.That(remaining.First().Id).IsEqualTo("zone-2");
+    }
+}

--- a/api/tests/town-crier.application.tests/WatchZones/FakeAuthorityResolver.cs
+++ b/api/tests/town-crier.application.tests/WatchZones/FakeAuthorityResolver.cs
@@ -1,0 +1,27 @@
+using TownCrier.Application.Authorities;
+
+namespace TownCrier.Application.Tests.WatchZones;
+
+internal sealed class FakeAuthorityResolver : IAuthorityResolver
+{
+    private readonly Dictionary<(double Latitude, double Longitude), int> mappings = [];
+
+    public int CallCount { get; private set; }
+
+    public void Add(double latitude, double longitude, int authorityId)
+    {
+        this.mappings[(latitude, longitude)] = authorityId;
+    }
+
+    public Task<int> ResolveFromCoordinatesAsync(double latitude, double longitude, CancellationToken ct)
+    {
+        this.CallCount++;
+
+        if (this.mappings.TryGetValue((latitude, longitude), out var authorityId))
+        {
+            return Task.FromResult(authorityId);
+        }
+
+        throw new InvalidOperationException($"No authority found for coordinates ({latitude}, {longitude})");
+    }
+}

--- a/api/tests/town-crier.application.tests/WatchZones/ListWatchZonesQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/WatchZones/ListWatchZonesQueryHandlerTests.cs
@@ -1,0 +1,83 @@
+using TownCrier.Application.Tests.Polling;
+using TownCrier.Application.WatchZones;
+
+namespace TownCrier.Application.Tests.WatchZones;
+
+public sealed class ListWatchZonesQueryHandlerTests
+{
+    private readonly FakeWatchZoneRepository watchZoneRepository = new();
+
+    [Test]
+    public async Task Should_ReturnUserZones_When_UserHasZones()
+    {
+        // Arrange
+        var zone1 = new WatchZoneBuilder()
+            .WithId("zone-1")
+            .WithUserId("user-1")
+            .WithName("Home")
+            .WithCentre(51.5074, -0.1278)
+            .WithRadiusMetres(5000)
+            .WithAuthorityId(42)
+            .Build();
+        var zone2 = new WatchZoneBuilder()
+            .WithId("zone-2")
+            .WithUserId("user-1")
+            .WithName("Office")
+            .WithCentre(51.5155, -0.1419)
+            .WithRadiusMetres(3000)
+            .WithAuthorityId(42)
+            .Build();
+        this.watchZoneRepository.Add(zone1);
+        this.watchZoneRepository.Add(zone2);
+
+        var handler = new ListWatchZonesQueryHandler(this.watchZoneRepository);
+
+        // Act
+        var result = await handler.HandleAsync(new ListWatchZonesQuery("user-1"), CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Zones).HasCount().EqualTo(2);
+        await Assert.That(result.Zones.First(z => z.Id == "zone-1").Name).IsEqualTo("Home");
+        await Assert.That(result.Zones.First(z => z.Id == "zone-2").Name).IsEqualTo("Office");
+    }
+
+    [Test]
+    public async Task Should_ReturnEmptyList_When_UserHasNoZones()
+    {
+        // Arrange
+        var handler = new ListWatchZonesQueryHandler(this.watchZoneRepository);
+
+        // Act
+        var result = await handler.HandleAsync(new ListWatchZonesQuery("user-1"), CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Zones).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_ExcludeOtherUsersZones_When_ListingZones()
+    {
+        // Arrange
+        var myZone = new WatchZoneBuilder()
+            .WithId("zone-1")
+            .WithUserId("user-1")
+            .WithName("My Zone")
+            .Build();
+        var otherZone = new WatchZoneBuilder()
+            .WithId("zone-2")
+            .WithUserId("user-2")
+            .WithName("Other Zone")
+            .Build();
+        this.watchZoneRepository.Add(myZone);
+        this.watchZoneRepository.Add(otherZone);
+
+        var handler = new ListWatchZonesQueryHandler(this.watchZoneRepository);
+
+        // Act
+        var result = await handler.HandleAsync(new ListWatchZonesQuery("user-1"), CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Zones).HasCount().EqualTo(1);
+        await Assert.That(result.Zones.First().Name).IsEqualTo("My Zone");
+    }
+}

--- a/mobile/ios/packages/town-crier-data/Sources/API/APIEndpoint.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/APIEndpoint.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/// Describes an API endpoint with method, path, optional body, and query parameters.
+public struct APIEndpoint: Sendable {
+    public let method: HTTPMethod
+    public let path: String
+    public let body: (any Encodable & Sendable)?
+    public let queryItems: [URLQueryItem]?
+
+    public init(method: HTTPMethod, path: String, body: (any Encodable & Sendable)? = nil, queryItems: [URLQueryItem]? = nil) {
+        self.method = method
+        self.path = path
+        self.body = body
+        self.queryItems = queryItems
+    }
+
+    public static func get(_ path: String, query: [URLQueryItem]? = nil) -> APIEndpoint {
+        APIEndpoint(method: .get, path: path, queryItems: query)
+    }
+
+    public static func post(_ path: String, body: some Encodable & Sendable) -> APIEndpoint {
+        APIEndpoint(method: .post, path: path, body: body)
+    }
+
+    public static func put(_ path: String, body: some Encodable & Sendable) -> APIEndpoint {
+        APIEndpoint(method: .put, path: path, body: body)
+    }
+
+    public static func delete(_ path: String) -> APIEndpoint {
+        APIEndpoint(method: .delete, path: path)
+    }
+
+    public static func patch(_ path: String, body: some Encodable & Sendable) -> APIEndpoint {
+        APIEndpoint(method: .patch, path: path, body: body)
+    }
+}
+
+public enum HTTPMethod: String, Sendable {
+    case get = "GET"
+    case post = "POST"
+    case put = "PUT"
+    case delete = "DELETE"
+    case patch = "PATCH"
+}

--- a/mobile/ios/packages/town-crier-data/Sources/API/APIEndpoint.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/APIEndpoint.swift
@@ -7,7 +7,12 @@ public struct APIEndpoint: Sendable {
     public let body: (any Encodable & Sendable)?
     public let queryItems: [URLQueryItem]?
 
-    public init(method: HTTPMethod, path: String, body: (any Encodable & Sendable)? = nil, queryItems: [URLQueryItem]? = nil) {
+    public init(
+        method: HTTPMethod,
+        path: String,
+        body: (any Encodable & Sendable)? = nil,
+        queryItems: [URLQueryItem]? = nil
+    ) {
         self.method = method
         self.path = path
         self.body = body

--- a/mobile/ios/packages/town-crier-data/Sources/API/APIEnvironment.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/APIEnvironment.swift
@@ -4,12 +4,17 @@ public enum APIEnvironment: Equatable, Sendable {
     case development
     case production
 
+    // swiftlint:disable:next force_unwrapping
+    private static let developmentURL = URL(string: "https://api.dev.towncrierapp.uk")!
+    // swiftlint:disable:next force_unwrapping
+    private static let productionURL = URL(string: "https://api.towncrierapp.uk")!
+
     public var baseURL: URL {
         switch self {
         case .development:
-            URL(string: "https://api.dev.towncrierapp.uk")!
+            Self.developmentURL
         case .production:
-            URL(string: "https://api.towncrierapp.uk")!
+            Self.productionURL
         }
     }
 

--- a/mobile/ios/packages/town-crier-data/Sources/API/APIEnvironment.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/APIEnvironment.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public enum APIEnvironment: Equatable, Sendable {
+    case development
+    case production
+
+    public var baseURL: URL {
+        switch self {
+        case .development:
+            URL(string: "https://api.dev.towncrierapp.uk")!
+        case .production:
+            URL(string: "https://api.towncrierapp.uk")!
+        }
+    }
+
+    public static var current: APIEnvironment {
+        #if DEBUG
+        .development
+        #else
+        .production
+        #endif
+    }
+}

--- a/mobile/ios/packages/town-crier-data/Sources/API/APIError.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/APIError.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// HTTP-level errors thrown by the API client.
+/// Repositories should catch these and map to appropriate DomainError cases.
+public enum APIError: Error, Sendable {
+    case unauthorized
+    case notFound
+    case serverError(statusCode: Int, message: String?)
+    case decodingFailed(String)
+}

--- a/mobile/ios/packages/town-crier-data/Sources/API/EmptyResponse.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/EmptyResponse.swift
@@ -1,0 +1,2 @@
+/// Placeholder type for API responses with no body (e.g. 204 No Content).
+public struct EmptyResponse: Decodable, Sendable {}

--- a/mobile/ios/packages/town-crier-data/Sources/API/HTTPTransport.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/HTTPTransport.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Abstraction over URLSession for testability.
+/// URLSession conforms to this via extension.
+public protocol HTTPTransport: Sendable {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: HTTPTransport {}

--- a/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
@@ -1,0 +1,115 @@
+import Foundation
+import TownCrierDomain
+
+/// Foundation HTTP client that injects Auth0 bearer tokens and handles
+/// common response parsing, error mapping, and token refresh on 401.
+public final class URLSessionAPIClient: Sendable {
+    private let baseURL: URL
+    private let authService: AuthenticationService
+    private let transport: HTTPTransport
+    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+
+    public init(
+        baseURL: URL,
+        authService: AuthenticationService,
+        transport: HTTPTransport = URLSession.shared
+    ) {
+        self.baseURL = baseURL
+        self.authService = authService
+        self.transport = transport
+        self.decoder = JSONDecoder()
+        self.encoder = JSONEncoder()
+    }
+
+    public func request<T: Decodable & Sendable>(_ endpoint: APIEndpoint) async throws -> T {
+        guard let session = await authService.currentSession() else {
+            throw DomainError.sessionExpired
+        }
+
+        do {
+            return try await executeRequest(endpoint, accessToken: session.accessToken)
+        } catch APIError.unauthorized {
+            do {
+                let refreshed = try await authService.refreshSession()
+                return try await executeRequest(endpoint, accessToken: refreshed.accessToken)
+            } catch {
+                throw DomainError.sessionExpired
+            }
+        } catch is URLError {
+            throw DomainError.networkUnavailable
+        }
+    }
+
+    // MARK: - Private
+
+    private func executeRequest<T: Decodable>(
+        _ endpoint: APIEndpoint,
+        accessToken: String
+    ) async throws -> T {
+        let urlRequest = try buildRequest(endpoint, accessToken: accessToken)
+        let (data, response) = try await transport.data(for: urlRequest)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw APIError.serverError(statusCode: 0, message: "Invalid response")
+        }
+
+        try mapHTTPStatus(httpResponse.statusCode, data: data)
+
+        if T.self == EmptyResponse.self {
+            // swiftlint:disable:next force_cast
+            return EmptyResponse() as! T
+        }
+
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw APIError.decodingFailed(error.localizedDescription)
+        }
+    }
+
+    private func buildRequest(
+        _ endpoint: APIEndpoint,
+        accessToken: String
+    ) throws -> URLRequest {
+        var components = URLComponents(
+            url: baseURL.appendingPathComponent(endpoint.path),
+            resolvingAgainstBaseURL: false
+        )!
+        if let queryItems = endpoint.queryItems, !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+
+        guard let url = components.url else {
+            throw APIError.serverError(statusCode: 0, message: "Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = endpoint.method.rawValue
+        request.setValue("Bearer \(accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let body = endpoint.body {
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            request.httpBody = try encoder.encode(body)
+        }
+
+        return request
+    }
+
+    private func mapHTTPStatus(_ statusCode: Int, data: Data) throws {
+        switch statusCode {
+        case 200...299:
+            return
+        case 401:
+            throw APIError.unauthorized
+        case 404:
+            throw APIError.notFound
+        default:
+            if statusCode >= 400 {
+                let message = String(data: data, encoding: .utf8)
+                throw APIError.serverError(statusCode: statusCode, message: message)
+            }
+        }
+    }
+}

--- a/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
@@ -72,10 +72,12 @@ public final class URLSessionAPIClient: Sendable {
         _ endpoint: APIEndpoint,
         accessToken: String
     ) throws -> URLRequest {
-        var components = URLComponents(
+        guard var components = URLComponents(
             url: baseURL.appendingPathComponent(endpoint.path),
             resolvingAgainstBaseURL: false
-        )!
+        ) else {
+            throw APIError.serverError(statusCode: 0, message: "Invalid URL components")
+        }
         if let queryItems = endpoint.queryItems, !queryItems.isEmpty {
             components.queryItems = queryItems
         }

--- a/mobile/ios/packages/town-crier-data/Sources/CrashReporting/MetricKitCrashReporter.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/CrashReporting/MetricKitCrashReporter.swift
@@ -8,8 +8,7 @@ import os
 /// MetricKit delivers crash diagnostic payloads up to 24 hours after the crash occurs.
 /// Call `start()` once during app launch to subscribe to diagnostics.
 public final class MetricKitCrashReporter: NSObject, CrashReporter, MXMetricManagerSubscriber,
-    @unchecked Sendable
-{
+    @unchecked Sendable {
     private let logger = Logger(
         subsystem: "uk.co.towncrier",
         category: "CrashReporting"

--- a/mobile/ios/packages/town-crier-data/Sources/Geocoding/APIPostcodeGeocoder.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Geocoding/APIPostcodeGeocoder.swift
@@ -1,0 +1,39 @@
+import Foundation
+import TownCrierDomain
+
+/// Geocodes UK postcodes via the Town Crier API's `/v1/geocode/{postcode}` endpoint.
+public final class APIPostcodeGeocoder: PostcodeGeocoder, Sendable {
+    private let apiClient: URLSessionAPIClient
+
+    public init(apiClient: URLSessionAPIClient) {
+        self.apiClient = apiClient
+    }
+
+    public func geocode(_ postcode: Postcode) async throws -> Coordinate {
+        let response: GeocodeResponse
+        do {
+            response = try await apiClient.request(
+                .get("/v1/geocode/\(postcode.value)")
+            )
+        } catch let domainError as DomainError {
+            throw domainError
+        } catch {
+            throw DomainError.geocodingFailed(postcode.value)
+        }
+        return try Coordinate(
+            latitude: response.coordinates.latitude,
+            longitude: response.coordinates.longitude
+        )
+    }
+}
+
+// MARK: - Response DTO
+
+struct GeocodeResponse: Decodable, Sendable {
+    let coordinates: CoordinatesDTO
+}
+
+struct CoordinatesDTO: Decodable, Sendable {
+    let latitude: Double
+    let longitude: Double
+}

--- a/mobile/ios/packages/town-crier-data/Sources/Notifications/APINotificationService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Notifications/APINotificationService.swift
@@ -1,0 +1,31 @@
+import Foundation
+import TownCrierDomain
+
+/// Registers and removes APNs device tokens via the Town Crier API.
+/// Stores the last registered token so `removeDeviceToken()` can unregister
+/// without callers needing to track the token value.
+public actor APINotificationService {
+    private let apiClient: URLSessionAPIClient
+    private var storedToken: String?
+
+    public init(apiClient: URLSessionAPIClient) {
+        self.apiClient = apiClient
+    }
+
+    public func registerDeviceToken(_ token: String) async throws {
+        let body = RegisterDeviceTokenBody(token: token, platform: "Ios")
+        let _: EmptyResponse = try await apiClient.request(.put("v1/me/device-token", body: body))
+        storedToken = token
+    }
+
+    public func removeDeviceToken() async throws {
+        guard let token = storedToken else { return }
+        let _: EmptyResponse = try await apiClient.request(.delete("v1/me/device-token/\(token)"))
+        storedToken = nil
+    }
+}
+
+private struct RegisterDeviceTokenBody: Encodable, Sendable {
+    let token: String
+    let platform: String
+}

--- a/mobile/ios/packages/town-crier-data/Sources/Notifications/CompositeNotificationService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Notifications/CompositeNotificationService.swift
@@ -1,0 +1,29 @@
+import TownCrierDomain
+
+/// Bridges notification permission (from a platform-specific provider like UNUserNotificationCenter)
+/// with device token registration (from the API).
+/// Conforms to `NotificationService` so it can be injected wherever the domain protocol is required.
+public final class CompositeNotificationService: NotificationService, @unchecked Sendable {
+    private let permissionProvider: any NotificationPermissionProvider
+    private let apiService: APINotificationService
+
+    public init(
+        permissionProvider: any NotificationPermissionProvider,
+        apiService: APINotificationService
+    ) {
+        self.permissionProvider = permissionProvider
+        self.apiService = apiService
+    }
+
+    public func requestPermission() async throws -> Bool {
+        try await permissionProvider.requestPermission()
+    }
+
+    public func registerDeviceToken(_ token: String) async throws {
+        try await apiService.registerDeviceToken(token)
+    }
+
+    public func removeDeviceToken() async throws {
+        try await apiService.removeDeviceToken()
+    }
+}

--- a/mobile/ios/packages/town-crier-data/Sources/Onboarding/UserDefaultsOnboardingRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Onboarding/UserDefaultsOnboardingRepository.swift
@@ -1,0 +1,21 @@
+import Foundation
+import TownCrierDomain
+
+/// Persists onboarding completion state to UserDefaults.
+/// Onboarding is a device-local concern — reinstalling the app resets it.
+public final class UserDefaultsOnboardingRepository: OnboardingRepository, @unchecked Sendable {
+    private let defaults: UserDefaults
+    private let key = "isOnboardingComplete"
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    public var isOnboardingComplete: Bool {
+        defaults.bool(forKey: key)
+    }
+
+    public func markOnboardingComplete() {
+        defaults.set(true, forKey: key)
+    }
+}

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
@@ -1,0 +1,140 @@
+import Foundation
+import TownCrierDomain
+
+/// Fetches planning applications from the Town Crier API.
+public final class APIPlanningApplicationRepository: PlanningApplicationRepository, Sendable {
+    private let apiClient: URLSessionAPIClient
+
+    public init(apiClient: URLSessionAPIClient) {
+        self.apiClient = apiClient
+    }
+
+    public func fetchApplications(for authority: LocalAuthority) async throws -> [PlanningApplication] {
+        let dtos: [PlanningApplicationDTO]
+        do {
+            dtos = try await apiClient.request(
+                .get("/v1/applications", query: [URLQueryItem(name: "authorityId", value: authority.code)])
+            )
+        } catch let domainError as DomainError {
+            throw domainError
+        } catch {
+            throw DomainError.networkUnavailable
+        }
+        return dtos.map { $0.toDomain() }
+    }
+
+    public func fetchApplication(by id: PlanningApplicationId) async throws -> PlanningApplication {
+        let dto: PlanningApplicationDTO
+        do {
+            dto = try await apiClient.request(
+                .get("/v1/applications/\(id.value)")
+            )
+        } catch APIError.notFound {
+            throw DomainError.applicationNotFound(id)
+        } catch let domainError as DomainError {
+            throw domainError
+        } catch {
+            throw DomainError.networkUnavailable
+        }
+        return dto.toDomain()
+    }
+}
+
+// MARK: - Response DTO
+
+struct PlanningApplicationDTO: Decodable, Sendable {
+    let name: String
+    let uid: String
+    let areaName: String
+    let areaId: Int
+    let address: String
+    let postcode: String?
+    let description: String
+    let appType: String
+    let appState: String
+    let appSize: String?
+    let startDate: String?
+    let decidedDate: String?
+    let consultedDate: String?
+    let longitude: Double?
+    let latitude: Double?
+    let url: String?
+    let link: String?
+    let lastDifferent: String
+
+    func toDomain() -> PlanningApplication {
+        let status = mapAppState(appState)
+        let location = mapLocation()
+        let portalUrl = url.flatMap { URL(string: $0) }
+        let receivedDate = parseDate(startDate) ?? Date()
+        let history = synthesizeStatusHistory(status: status, receivedDate: receivedDate)
+
+        return PlanningApplication(
+            id: PlanningApplicationId(uid),
+            reference: ApplicationReference(name),
+            authority: LocalAuthority(code: String(areaId), name: areaName),
+            status: status,
+            receivedDate: receivedDate,
+            description: description,
+            address: address,
+            location: location,
+            portalUrl: portalUrl,
+            statusHistory: history
+        )
+    }
+
+    private func mapAppState(_ state: String) -> ApplicationStatus {
+        switch state {
+        case "Under Review": return .underReview
+        case "Approved": return .approved
+        case "Refused": return .refused
+        case "Withdrawn": return .withdrawn
+        case "Appealed": return .appealed
+        default: return .unknown
+        }
+    }
+
+    private func mapLocation() -> Coordinate? {
+        guard let lat = latitude, let lon = longitude else { return nil }
+        return try? Coordinate(latitude: lat, longitude: lon)
+    }
+
+    private func synthesizeStatusHistory(
+        status: ApplicationStatus,
+        receivedDate: Date
+    ) -> [StatusEvent] {
+        var history: [StatusEvent] = []
+
+        if startDate != nil {
+            history.append(StatusEvent(status: .underReview, date: receivedDate))
+        }
+
+        if let decidedDateString = decidedDate, let decidedDate = parseDate(decidedDateString) {
+            let decidedStatus: ApplicationStatus
+            switch status {
+            case .approved: decidedStatus = .approved
+            case .refused: decidedStatus = .refused
+            case .withdrawn: decidedStatus = .withdrawn
+            default: decidedStatus = status
+            }
+            if decidedStatus != .underReview {
+                history.append(StatusEvent(status: decidedStatus, date: decidedDate))
+            }
+        }
+
+        return history
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }()
+
+    private func parseDate(_ dateString: String?) -> Date? {
+        guard let dateString else { return nil }
+        return Self.dateFormatter.date(from: dateString)
+    }
+}

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
@@ -85,12 +85,18 @@ struct PlanningApplicationDTO: Decodable, Sendable {
 
     private func mapAppState(_ state: String) -> ApplicationStatus {
         switch state {
-        case "Under Review": return .underReview
-        case "Approved": return .approved
-        case "Refused": return .refused
-        case "Withdrawn": return .withdrawn
-        case "Appealed": return .appealed
-        default: return .unknown
+        case "Under Review":
+            return .underReview
+        case "Approved":
+            return .approved
+        case "Refused":
+            return .refused
+        case "Withdrawn":
+            return .withdrawn
+        case "Appealed":
+            return .appealed
+        default:
+            return .unknown
         }
     }
 
@@ -112,10 +118,14 @@ struct PlanningApplicationDTO: Decodable, Sendable {
         if let decidedDateString = decidedDate, let decidedDate = parseDate(decidedDateString) {
             let decidedStatus: ApplicationStatus
             switch status {
-            case .approved: decidedStatus = .approved
-            case .refused: decidedStatus = .refused
-            case .withdrawn: decidedStatus = .withdrawn
-            default: decidedStatus = status
+            case .approved:
+                decidedStatus = .approved
+            case .refused:
+                decidedStatus = .refused
+            case .withdrawn:
+                decidedStatus = .withdrawn
+            default:
+                decidedStatus = status
             }
             if decidedStatus != .underReview {
                 history.append(StatusEvent(status: decidedStatus, date: decidedDate))

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIWatchZoneRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIWatchZoneRepository.swift
@@ -1,0 +1,94 @@
+import Foundation
+import TownCrierDomain
+
+/// Persists and retrieves watch zones via the Town Crier API.
+public final class APIWatchZoneRepository: WatchZoneRepository, Sendable {
+    private let apiClient: URLSessionAPIClient
+
+    public init(apiClient: URLSessionAPIClient) {
+        self.apiClient = apiClient
+    }
+
+    public func save(_ zone: WatchZone) async throws {
+        let body = CreateWatchZoneRequest(
+            zoneId: zone.id.value,
+            name: zone.postcode.value,
+            latitude: zone.centre.latitude,
+            longitude: zone.centre.longitude,
+            radiusMetres: zone.radiusMetres
+        )
+        do {
+            let _: EmptyResponse = try await apiClient.request(.post("/v1/me/watch-zones", body: body))
+        } catch is URLError {
+            throw DomainError.networkUnavailable
+        } catch let domainError as DomainError {
+            throw domainError
+        } catch {
+            throw DomainError.networkUnavailable
+        }
+    }
+
+    public func loadAll() async throws -> [WatchZone] {
+        let result: ListWatchZonesResponse
+        do {
+            result = try await apiClient.request(.get("/v1/me/watch-zones"))
+        } catch let domainError as DomainError {
+            throw domainError
+        } catch {
+            throw DomainError.networkUnavailable
+        }
+        return result.zones.compactMap { $0.toDomain() }
+    }
+
+    public func delete(_ id: WatchZoneId) async throws {
+        do {
+            let _: EmptyResponse = try await apiClient.request(
+                .delete("/v1/me/watch-zones/\(id.value)")
+            )
+        } catch APIError.notFound {
+            // Idempotent delete — if the zone is already gone, succeed silently
+            return
+        } catch let domainError as DomainError {
+            throw domainError
+        } catch {
+            throw DomainError.networkUnavailable
+        }
+    }
+}
+
+// MARK: - Request/Response DTOs
+
+struct CreateWatchZoneRequest: Encodable, Sendable {
+    let zoneId: String
+    let name: String
+    let latitude: Double
+    let longitude: Double
+    let radiusMetres: Double
+}
+
+struct ListWatchZonesResponse: Decodable, Sendable {
+    let zones: [WatchZoneSummaryDTO]
+}
+
+struct WatchZoneSummaryDTO: Decodable, Sendable {
+    let id: String
+    let name: String
+    let latitude: Double
+    let longitude: Double
+    let radiusMetres: Double
+    let authorityId: Int
+
+    func toDomain() -> WatchZone? {
+        guard let postcode = try? Postcode(name),
+              let centre = try? Coordinate(latitude: latitude, longitude: longitude)
+        else {
+            return nil
+        }
+        return try? WatchZone(
+            id: WatchZoneId(id),
+            postcode: postcode,
+            centre: centre,
+            radiusMetres: radiusMetres
+        )
+    }
+}

--- a/mobile/ios/packages/town-crier-data/Sources/Subscriptions/StoreKitSubscriptionService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Subscriptions/StoreKitSubscriptionService.swift
@@ -88,9 +88,11 @@ public final class StoreKitSubscriptionService: SubscriptionService, @unchecked 
             if let transaction = try? checkVerification(result) {
                 let ent = entitlement(from: transaction)
                 if ent.isActive {
-                    if latestEntitlement == nil
-                        || tierOrder(ent.tier) > tierOrder(latestEntitlement!.tier)
-                    {
+                    if let current = latestEntitlement {
+                        if tierOrder(ent.tier) > tierOrder(current.tier) {
+                            latestEntitlement = ent
+                        }
+                    } else {
                         latestEntitlement = ent
                     }
                 }
@@ -141,9 +143,12 @@ public final class StoreKitSubscriptionService: SubscriptionService, @unchecked 
 
     private func tierOrder(_ tier: SubscriptionTier) -> Int {
         switch tier {
-        case .free: return 0
-        case .personal: return 1
-        case .pro: return 2
+        case .free:
+            return 0
+        case .personal:
+            return 1
+        case .pro:
+            return 2
         }
     }
 }

--- a/mobile/ios/packages/town-crier-data/Sources/VersionConfig/APIVersionConfigService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/VersionConfig/APIVersionConfigService.swift
@@ -1,0 +1,55 @@
+import Foundation
+import TownCrierDomain
+
+/// Fetches the minimum supported app version from the Town Crier API.
+/// This is an unauthenticated endpoint — it must work before the user logs in
+/// so the force-update check can block outdated app versions.
+public struct APIVersionConfigService: VersionConfigService {
+    private let baseURL: URL
+    private let transport: HTTPTransport
+
+    public init(baseURL: URL, transport: HTTPTransport = URLSession.shared) {
+        self.baseURL = baseURL
+        self.transport = transport
+    }
+
+    public func fetchMinimumVersion() async throws -> AppVersion {
+        let url = baseURL.appendingPathComponent("v1/version-config")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await transport.data(for: request)
+        } catch is URLError {
+            throw DomainError.networkUnavailable
+        } catch {
+            throw DomainError.unexpected(error.localizedDescription)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode)
+        else {
+            throw DomainError.unexpected("Version config request failed")
+        }
+
+        let dto: VersionConfigDTO
+        do {
+            dto = try JSONDecoder().decode(VersionConfigDTO.self, from: data)
+        } catch {
+            throw DomainError.unexpected("Invalid version config response")
+        }
+
+        guard let version = AppVersion(dto.minimumVersion) else {
+            throw DomainError.unexpected("Invalid version string: \(dto.minimumVersion)")
+        }
+
+        return version
+    }
+}
+
+private struct VersionConfigDTO: Decodable {
+    let minimumVersion: String
+}

--- a/mobile/ios/packages/town-crier-domain/Sources/Protocols/NotificationPermissionProvider.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Protocols/NotificationPermissionProvider.swift
@@ -1,0 +1,5 @@
+/// Abstracts the system's notification permission request (e.g. UNUserNotificationCenter)
+/// so that code depending on it can be tested without a live notification centre.
+public protocol NotificationPermissionProvider: Sendable {
+    func requestPermission() async throws -> Bool
+}

--- a/mobile/ios/packages/town-crier-domain/Sources/Protocols/NotificationService.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Protocols/NotificationService.swift
@@ -1,4 +1,6 @@
-/// Requests and checks push notification permission.
+/// Manages push notification permission and device token registration with the backend.
 public protocol NotificationService: Sendable {
     func requestPermission() async throws -> Bool
+    func registerDeviceToken(_ token: String) async throws
+    func removeDeviceToken() async throws
 }

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/AuthMethod.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/AuthMethod.swift
@@ -7,10 +7,14 @@ public enum AuthMethod: String, Equatable, Sendable {
 
     public var displayName: String {
         switch self {
-        case .emailPassword: "Email & Password"
-        case .google: "Google"
-        case .apple: "Apple"
-        case .unknown: "Unknown"
+        case .emailPassword:
+            "Email & Password"
+        case .google:
+            "Google"
+        case .apple:
+            "Apple"
+        case .unknown:
+            "Unknown"
         }
     }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -92,13 +92,16 @@ public final class AppCoordinator: ObservableObject {
     }
 
     public func makeSettingsViewModel() -> SettingsViewModel {
-        guard let appVersionProvider = appVersionProvider else {
-            preconditionFailure("AppVersionProvider not provided to AppCoordinator")
+        guard let appVersionProvider = appVersionProvider,
+              let notificationService = notificationService
+        else {
+            preconditionFailure("AppVersionProvider or NotificationService not provided to AppCoordinator")
         }
         let viewModel = SettingsViewModel(
             authService: authService,
             subscriptionService: subscriptionService,
-            appVersionProvider: appVersionProvider
+            appVersionProvider: appVersionProvider,
+            notificationService: notificationService
         )
         return viewModel
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -18,6 +18,7 @@ public final class AppCoordinator: ObservableObject {
     private let watchZoneRepository: WatchZoneRepository?
     private let onboardingRepository: OnboardingRepository?
     private let notificationService: NotificationService?
+    private let offlineRepository: OfflineAwareRepository?
     private let appVersionProvider: AppVersionProvider?
     private let versionConfigService: VersionConfigService?
 
@@ -25,6 +26,7 @@ public final class AppCoordinator: ObservableObject {
         repository: PlanningApplicationRepository,
         authService: AuthenticationService,
         subscriptionService: SubscriptionService,
+        offlineRepository: OfflineAwareRepository? = nil,
         geocoder: PostcodeGeocoder? = nil,
         watchZoneRepository: WatchZoneRepository? = nil,
         onboardingRepository: OnboardingRepository? = nil,
@@ -35,6 +37,7 @@ public final class AppCoordinator: ObservableObject {
         self.repository = repository
         self.authService = authService
         self.subscriptionService = subscriptionService
+        self.offlineRepository = offlineRepository
         self.geocoder = geocoder
         self.watchZoneRepository = watchZoneRepository
         self.onboardingRepository = onboardingRepository
@@ -58,13 +61,21 @@ public final class AppCoordinator: ObservableObject {
     }
 
     public func makeMapViewModel(watchZone: WatchZone) -> MapViewModel {
-        MapViewModel(repository: repository, watchZone: watchZone)
+        if let offlineRepository {
+            return MapViewModel(offlineRepository: offlineRepository, watchZone: watchZone)
+        }
+        return MapViewModel(repository: repository, watchZone: watchZone)
     }
 
     public func makeApplicationListViewModel(
         authority: LocalAuthority
     ) -> ApplicationListViewModel {
-        let viewModel = ApplicationListViewModel(repository: repository, authority: authority)
+        let viewModel: ApplicationListViewModel
+        if let offlineRepository {
+            viewModel = ApplicationListViewModel(offlineRepository: offlineRepository, authority: authority)
+        } else {
+            viewModel = ApplicationListViewModel(repository: repository, authority: authority)
+        }
         viewModel.onApplicationSelected = { [weak self] id in
             self?.showApplicationDetail(id)
         }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
@@ -128,12 +128,18 @@ public struct ApplicationDetailView: View {
 
     private var statusColor: Color {
         switch viewModel.status {
-        case .underReview: return .tcStatusPending
-        case .approved: return .tcStatusApproved
-        case .refused: return .tcStatusRefused
-        case .withdrawn: return .tcStatusWithdrawn
-        case .appealed: return .tcStatusAppealed
-        case .unknown: return .tcTextTertiary
+        case .underReview:
+            return .tcStatusPending
+        case .approved:
+            return .tcStatusApproved
+        case .refused:
+            return .tcStatusRefused
+        case .withdrawn:
+            return .tcStatusWithdrawn
+        case .appealed:
+            return .tcStatusAppealed
+        case .unknown:
+            return .tcTextTertiary
         }
     }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
@@ -93,12 +93,18 @@ public final class ApplicationDetailViewModel: ObservableObject {
 
     private static func displayValues(for status: ApplicationStatus) -> (label: String, icon: String) {
         switch status {
-        case .underReview: ("Pending", "clock")
-        case .approved: ("Approved", "checkmark.circle")
-        case .refused: ("Refused", "xmark.circle")
-        case .withdrawn: ("Withdrawn", "arrow.uturn.backward.circle")
-        case .appealed: ("Appealed", "exclamationmark.triangle")
-        case .unknown: ("Unknown", "questionmark.circle")
+        case .underReview:
+            ("Pending", "clock")
+        case .approved:
+            ("Approved", "checkmark.circle")
+        case .refused:
+            ("Refused", "xmark.circle")
+        case .withdrawn:
+            ("Withdrawn", "arrow.uturn.backward.circle")
+        case .appealed:
+            ("Appealed", "exclamationmark.triangle")
+        case .unknown:
+            ("Unknown", "questionmark.circle")
         }
     }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/StatusTimelineView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/StatusTimelineView.swift
@@ -63,12 +63,18 @@ struct StatusTimelineView: View {
 
     private func statusColor(for status: ApplicationStatus) -> Color {
         switch status {
-        case .underReview: .tcStatusPending
-        case .approved: .tcStatusApproved
-        case .refused: .tcStatusRefused
-        case .withdrawn: .tcStatusWithdrawn
-        case .appealed: .tcStatusAppealed
-        case .unknown: .tcTextTertiary
+        case .underReview:
+            .tcStatusPending
+        case .approved:
+            .tcStatusApproved
+        case .refused:
+            .tcStatusRefused
+        case .withdrawn:
+            .tcStatusWithdrawn
+        case .appealed:
+            .tcStatusAppealed
+        case .unknown:
+            .tcTextTertiary
         }
     }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListRow.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListRow.swift
@@ -53,34 +53,52 @@ struct ApplicationListRow: View {
 
     private var statusLabel: String {
         switch application.status {
-        case .underReview: "Pending"
-        case .approved: "Approved"
-        case .refused: "Refused"
-        case .withdrawn: "Withdrawn"
-        case .appealed: "Appealed"
-        case .unknown: "Unknown"
+        case .underReview:
+            "Pending"
+        case .approved:
+            "Approved"
+        case .refused:
+            "Refused"
+        case .withdrawn:
+            "Withdrawn"
+        case .appealed:
+            "Appealed"
+        case .unknown:
+            "Unknown"
         }
     }
 
     private var statusIcon: String {
         switch application.status {
-        case .underReview: "clock"
-        case .approved: "checkmark.circle"
-        case .refused: "xmark.circle"
-        case .withdrawn: "arrow.uturn.backward.circle"
-        case .appealed: "exclamationmark.triangle"
-        case .unknown: "questionmark.circle"
+        case .underReview:
+            "clock"
+        case .approved:
+            "checkmark.circle"
+        case .refused:
+            "xmark.circle"
+        case .withdrawn:
+            "arrow.uturn.backward.circle"
+        case .appealed:
+            "exclamationmark.triangle"
+        case .unknown:
+            "questionmark.circle"
         }
     }
 
     private var statusColor: Color {
         switch application.status {
-        case .underReview: .tcStatusPending
-        case .approved: .tcStatusApproved
-        case .refused: .tcStatusRefused
-        case .withdrawn: .tcStatusWithdrawn
-        case .appealed: .tcStatusAppealed
-        case .unknown: .tcTextTertiary
+        case .underReview:
+            .tcStatusPending
+        case .approved:
+            .tcStatusApproved
+        case .refused:
+            .tcStatusRefused
+        case .withdrawn:
+            .tcStatusWithdrawn
+        case .appealed:
+            .tcStatusAppealed
+        case .unknown:
+            .tcTextTertiary
         }
     }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ApplicationSummarySheet.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ApplicationSummarySheet.swift
@@ -49,34 +49,52 @@ struct ApplicationSummarySheet: View {
 
     private var statusColor: Color {
         switch application.status {
-        case .underReview: return .tcStatusPending
-        case .approved: return .tcStatusApproved
-        case .refused: return .tcStatusRefused
-        case .withdrawn: return .tcStatusWithdrawn
-        case .appealed: return .tcStatusAppealed
-        case .unknown: return .tcTextTertiary
+        case .underReview:
+            return .tcStatusPending
+        case .approved:
+            return .tcStatusApproved
+        case .refused:
+            return .tcStatusRefused
+        case .withdrawn:
+            return .tcStatusWithdrawn
+        case .appealed:
+            return .tcStatusAppealed
+        case .unknown:
+            return .tcTextTertiary
         }
     }
 
     private var statusLabel: String {
         switch application.status {
-        case .underReview: return "Pending"
-        case .approved: return "Approved"
-        case .refused: return "Refused"
-        case .withdrawn: return "Withdrawn"
-        case .appealed: return "Appealed"
-        case .unknown: return "Unknown"
+        case .underReview:
+            return "Pending"
+        case .approved:
+            return "Approved"
+        case .refused:
+            return "Refused"
+        case .withdrawn:
+            return "Withdrawn"
+        case .appealed:
+            return "Appealed"
+        case .unknown:
+            return "Unknown"
         }
     }
 
     private var statusIcon: String {
         switch application.status {
-        case .underReview: return "clock"
-        case .approved: return "checkmark.circle"
-        case .refused: return "xmark.circle"
-        case .withdrawn: return "arrow.uturn.backward.circle"
-        case .appealed: return "exclamationmark.triangle"
-        case .unknown: return "questionmark.circle"
+        case .underReview:
+            return "clock"
+        case .approved:
+            return "checkmark.circle"
+        case .refused:
+            return "xmark.circle"
+        case .withdrawn:
+            return "arrow.uturn.backward.circle"
+        case .appealed:
+            return "exclamationmark.triangle"
+        case .unknown:
+            return "questionmark.circle"
         }
     }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapAnnotationItem.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapAnnotationItem.swift
@@ -32,12 +32,18 @@ public struct MapAnnotationItem: Identifiable, Sendable {
 
     private static func color(for status: ApplicationStatus) -> StatusColor {
         switch status {
-        case .underReview: return .pending
-        case .approved: return .approved
-        case .refused: return .refused
-        case .withdrawn: return .withdrawn
-        case .appealed: return .appealed
-        case .unknown: return .unknown
+        case .underReview:
+            return .pending
+        case .approved:
+            return .approved
+        case .refused:
+            return .refused
+        case .withdrawn:
+            return .withdrawn
+        case .appealed:
+            return .appealed
+        case .unknown:
+            return .unknown
         }
     }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
@@ -107,23 +107,35 @@ public struct MapView: View {
 
     private func pinColor(for status: StatusColor) -> Color {
         switch status {
-        case .pending: return .tcStatusPending
-        case .approved: return .tcStatusApproved
-        case .refused: return .tcStatusRefused
-        case .withdrawn: return .tcStatusWithdrawn
-        case .appealed: return .tcStatusAppealed
-        case .unknown: return .tcTextTertiary
+        case .pending:
+            return .tcStatusPending
+        case .approved:
+            return .tcStatusApproved
+        case .refused:
+            return .tcStatusRefused
+        case .withdrawn:
+            return .tcStatusWithdrawn
+        case .appealed:
+            return .tcStatusAppealed
+        case .unknown:
+            return .tcTextTertiary
         }
     }
 
     private func statusLabel(for status: StatusColor) -> String {
         switch status {
-        case .pending: return "Pending"
-        case .approved: return "Approved"
-        case .refused: return "Refused"
-        case .withdrawn: return "Withdrawn"
-        case .appealed: return "Appealed"
-        case .unknown: return "Unknown"
+        case .pending:
+            return "Pending"
+        case .approved:
+            return "Approved"
+        case .refused:
+            return "Refused"
+        case .withdrawn:
+            return "Withdrawn"
+        case .appealed:
+            return "Appealed"
+        case .unknown:
+            return "Unknown"
         }
     }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
@@ -19,15 +19,18 @@ public final class SettingsViewModel: ObservableObject {
     private let authService: AuthenticationService
     private let subscriptionService: SubscriptionService
     private let appVersionProvider: AppVersionProvider
+    private let notificationService: NotificationService
 
     public init(
         authService: AuthenticationService,
         subscriptionService: SubscriptionService,
-        appVersionProvider: AppVersionProvider
+        appVersionProvider: AppVersionProvider,
+        notificationService: NotificationService
     ) {
         self.authService = authService
         self.subscriptionService = subscriptionService
         self.appVersionProvider = appVersionProvider
+        self.notificationService = notificationService
     }
 
     public var appVersion: String {
@@ -81,6 +84,7 @@ public final class SettingsViewModel: ObservableObject {
     public func logout() async {
         error = nil
         do {
+            try? await notificationService.removeDeviceToken()
             try await authService.logout()
             clearSession()
             onLogout?()
@@ -103,6 +107,7 @@ public final class SettingsViewModel: ObservableObject {
         isShowingDeleteConfirmation = false
         error = nil
         do {
+            try? await notificationService.removeDeviceToken()
             try await authService.deleteAccount()
             clearSession()
             onLogout?()

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionViewModel.swift
@@ -68,12 +68,22 @@ public final class SubscriptionViewModel: ObservableObject {
 
     /// Returns subscription disclosure text for App Store compliance.
     public func subscriptionDisclosure(for product: SubscriptionProduct) -> String {
-        var disclosure =
-            "Your subscription will automatically renew at \(product.displayPrice)/month unless cancelled at least 24 hours before the end of the current period. You can manage or cancel your subscription in your App Store settings."
+        var disclosure = """
+            Your subscription will automatically renew at \
+            \(product.displayPrice)/month unless cancelled at least \
+            24 hours before the end of the current period. You can \
+            manage or cancel your subscription in your App Store settings.
+            """
 
         if product.hasFreeTrial {
-            disclosure =
-                "Start with a \(product.trialDays)-day free trial. After the trial, your subscription will automatically renew at \(product.displayPrice)/month unless cancelled at least 24 hours before the end of the current period. You can manage or cancel your subscription in your App Store settings."
+            disclosure = """
+                Start with a \(product.trialDays)-day free trial. \
+                After the trial, your subscription will automatically \
+                renew at \(product.displayPrice)/month unless cancelled \
+                at least 24 hours before the end of the current period. \
+                You can manage or cancel your subscription in your \
+                App Store settings.
+                """
         }
 
         return disclosure

--- a/mobile/ios/town-crier-app/Sources/SampleData.swift
+++ b/mobile/ios/town-crier-app/Sources/SampleData.swift
@@ -10,6 +10,7 @@ enum SampleData {
         let now = Date()
 
         func daysAgo(_ days: Int) -> Date {
+            // swiftlint:disable:next force_unwrapping
             calendar.date(byAdding: .day, value: -days, to: now)!
         }
 
@@ -34,6 +35,7 @@ enum SampleData {
                 authority: camden,
                 status: .approved,
                 receivedDate: daysAgo(45),
+                // swiftlint:disable:next line_length
                 description: "Change of use from retail (Class E) to restaurant (Sui Generis) with extraction flue to rear",
                 address: "87 Kentish Town Road, London NW1 8NY",
                 location: try? Coordinate(latitude: 51.5475, longitude: -0.1420),
@@ -78,6 +80,7 @@ enum SampleData {
                 authority: camden,
                 status: .approved,
                 receivedDate: daysAgo(60),
+                // swiftlint:disable:next line_length
                 description: "Listed building consent for internal alterations including removal of non-original partition walls and installation of new kitchen",
                 address: "12 Church Row, Hampstead, London NW3 6UP",
                 location: try? Coordinate(latitude: 51.5575, longitude: -0.1775),
@@ -122,6 +125,7 @@ enum SampleData {
                 authority: camden,
                 status: .underReview,
                 receivedDate: daysAgo(2),
+                // swiftlint:disable:next line_length
                 description: "Construction of basement level beneath existing garden for use as home gym and cinema room",
                 address: "8 Nassington Road, London NW3 2TY",
                 location: try? Coordinate(latitude: 51.5635, longitude: -0.1540),
@@ -134,9 +138,12 @@ enum SampleData {
     }()
 
     static let watchZone: WatchZone = {
+        // swiftlint:disable force_try
         let centre = try! Coordinate(latitude: 51.5550, longitude: -0.1450)
         let postcode = try! Postcode("NW5 1SU")
-        return try! WatchZone(postcode: postcode, centre: centre, radiusMetres: 2000)
+        let zone = try! WatchZone(postcode: postcode, centre: centre, radiusMetres: 2000)
+        // swiftlint:enable force_try
+        return zone
     }()
 }
 #endif

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -30,6 +30,7 @@ struct TownCrierApp: App {
         let repository = APIPlanningApplicationRepository(apiClient: apiClient)
         let geocoder = APIPostcodeGeocoder(apiClient: apiClient)
         let watchZoneRepository = APIWatchZoneRepository(apiClient: apiClient)
+        let onboardingRepository = UserDefaultsOnboardingRepository()
 
         let appCoordinator = AppCoordinator(
             repository: repository,
@@ -37,6 +38,7 @@ struct TownCrierApp: App {
             subscriptionService: subscriptionService,
             geocoder: geocoder,
             watchZoneRepository: watchZoneRepository,
+            onboardingRepository: onboardingRepository,
             appVersionProvider: appVersionProvider,
             versionConfigService: versionConfigService
         )

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -16,14 +16,6 @@ struct TownCrierApp: App {
     private let notificationDelegate: NotificationDelegate
 
     init() {
-        #if DEBUG
-        let repository = InMemoryPlanningApplicationRepository(
-            applications: SampleData.applications
-        )
-        #else
-        let repository = InMemoryPlanningApplicationRepository()
-        #endif
-
         let auth0Config = Auth0Config(
             clientId: "a9O67fPgvXtqiWqwowhYjK0tvHF4hCMZ",
             domain: "towncrierapp.uk.auth0.com"
@@ -35,6 +27,7 @@ struct TownCrierApp: App {
         let apiBaseURL = APIEnvironment.current.baseURL
         let versionConfigService = APIVersionConfigService(baseURL: apiBaseURL)
         let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
+        let repository = APIPlanningApplicationRepository(apiClient: apiClient)
         let geocoder = APIPostcodeGeocoder(apiClient: apiClient)
         let watchZoneRepository = APIWatchZoneRepository(apiClient: apiClient)
 

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -32,7 +32,8 @@ struct TownCrierApp: App {
         let authService = Auth0AuthenticationService(config: auth0Config)
         let subscriptionService = StoreKitSubscriptionService()
         let appVersionProvider = BundleAppVersionProvider()
-        let versionConfigService = StubVersionConfigService()
+        let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
+        let versionConfigService = APIVersionConfigService(baseURL: apiBaseURL)
 
         let appCoordinator = AppCoordinator(
             repository: repository,

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -34,11 +34,14 @@ struct TownCrierApp: App {
         let appVersionProvider = BundleAppVersionProvider()
         let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
         let versionConfigService = APIVersionConfigService(baseURL: apiBaseURL)
+        let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
+        let geocoder = APIPostcodeGeocoder(apiClient: apiClient)
 
         let appCoordinator = AppCoordinator(
             repository: repository,
             authService: authService,
             subscriptionService: subscriptionService,
+            geocoder: geocoder,
             appVersionProvider: appVersionProvider,
             versionConfigService: versionConfigService
         )

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -36,12 +36,14 @@ struct TownCrierApp: App {
         let versionConfigService = APIVersionConfigService(baseURL: apiBaseURL)
         let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
         let geocoder = APIPostcodeGeocoder(apiClient: apiClient)
+        let watchZoneRepository = APIWatchZoneRepository(apiClient: apiClient)
 
         let appCoordinator = AppCoordinator(
             repository: repository,
             authService: authService,
             subscriptionService: subscriptionService,
             geocoder: geocoder,
+            watchZoneRepository: watchZoneRepository,
             appVersionProvider: appVersionProvider,
             versionConfigService: versionConfigService
         )

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -35,11 +35,19 @@ struct TownCrierApp: App {
             permissionProvider: UNNotificationPermissionProvider(),
             apiService: APINotificationService(apiClient: apiClient)
         )
+        let connectivityMonitor = NWPathConnectivityMonitor()
+        let cacheStore = InMemoryApplicationCacheStore()
+        let offlineRepository = OfflineAwareRepository(
+            remote: repository,
+            cache: cacheStore,
+            connectivity: connectivityMonitor
+        )
 
         let appCoordinator = AppCoordinator(
             repository: repository,
             authService: authService,
             subscriptionService: subscriptionService,
+            offlineRepository: offlineRepository,
             geocoder: geocoder,
             watchZoneRepository: watchZoneRepository,
             onboardingRepository: onboardingRepository,

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -73,6 +73,7 @@ struct TownCrierApp: App {
         let listVM = appCoordinator.makeApplicationListViewModel(
             authority: LocalAuthority(code: "", name: "")
         )
+        // swiftlint:disable force_try
         let mapVM = appCoordinator.makeMapViewModel(
             watchZone: try! WatchZone(
                 postcode: try! Postcode("SW1A 1AA"),
@@ -80,6 +81,7 @@ struct TownCrierApp: App {
                 radiusMetres: 1000
             )
         )
+        // swiftlint:enable force_try
         #endif
 
         _applicationListViewModel = StateObject(wrappedValue: listVM)

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -32,7 +32,7 @@ struct TownCrierApp: App {
         let authService = Auth0AuthenticationService(config: auth0Config)
         let subscriptionService = StoreKitSubscriptionService()
         let appVersionProvider = BundleAppVersionProvider()
-        let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
+        let apiBaseURL = APIEnvironment.current.baseURL
         let versionConfigService = APIVersionConfigService(baseURL: apiBaseURL)
         let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
         let geocoder = APIPostcodeGeocoder(apiClient: apiClient)

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -31,6 +31,10 @@ struct TownCrierApp: App {
         let geocoder = APIPostcodeGeocoder(apiClient: apiClient)
         let watchZoneRepository = APIWatchZoneRepository(apiClient: apiClient)
         let onboardingRepository = UserDefaultsOnboardingRepository()
+        let notificationService = CompositeNotificationService(
+            permissionProvider: UNNotificationPermissionProvider(),
+            apiService: APINotificationService(apiClient: apiClient)
+        )
 
         let appCoordinator = AppCoordinator(
             repository: repository,
@@ -39,6 +43,7 @@ struct TownCrierApp: App {
             geocoder: geocoder,
             watchZoneRepository: watchZoneRepository,
             onboardingRepository: onboardingRepository,
+            notificationService: notificationService,
             appVersionProvider: appVersionProvider,
             versionConfigService: versionConfigService
         )

--- a/mobile/ios/town-crier-app/Sources/UNNotificationPermissionProvider.swift
+++ b/mobile/ios/town-crier-app/Sources/UNNotificationPermissionProvider.swift
@@ -1,0 +1,10 @@
+import TownCrierDomain
+import UserNotifications
+
+/// Adapts `UNUserNotificationCenter` to the `NotificationPermissionProvider` protocol,
+/// bridging the system notification permission request into the domain layer.
+struct UNNotificationPermissionProvider: NotificationPermissionProvider {
+    func requestPermission() async throws -> Bool {
+        try await UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/APIEnvironmentTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIEnvironmentTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+import TownCrierData
+
+@Suite("APIEnvironment")
+struct APIEnvironmentTests {
+
+    @Test func development_baseURL_pointsToDevDomain() {
+        let sut = APIEnvironment.development
+
+        #expect(sut.baseURL == URL(string: "https://api.dev.towncrierapp.uk")!)
+    }
+
+    @Test func production_baseURL_pointsToProductionDomain() {
+        let sut = APIEnvironment.production
+
+        #expect(sut.baseURL == URL(string: "https://api.towncrierapp.uk")!)
+    }
+
+    @Test func current_returnsDevelopmentInDebug_productionInRelease() {
+        let current = APIEnvironment.current
+
+        #if DEBUG
+        #expect(current == .development)
+        #else
+        #expect(current == .production)
+        #endif
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/APIEnvironmentTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIEnvironmentTests.swift
@@ -8,13 +8,13 @@ struct APIEnvironmentTests {
     @Test func development_baseURL_pointsToDevDomain() {
         let sut = APIEnvironment.development
 
-        #expect(sut.baseURL == URL(string: "https://api.dev.towncrierapp.uk")!)
+        #expect(sut.baseURL.absoluteString == "https://api.dev.towncrierapp.uk")
     }
 
     @Test func production_baseURL_pointsToProductionDomain() {
         let sut = APIEnvironment.production
 
-        #expect(sut.baseURL == URL(string: "https://api.towncrierapp.uk")!)
+        #expect(sut.baseURL.absoluteString == "https://api.towncrierapp.uk")
     }
 
     @Test func current_returnsDevelopmentInDebug_productionInRelease() {

--- a/mobile/ios/town-crier-tests/Sources/Features/APINotificationServiceTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APINotificationServiceTests.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Testing
+import TownCrierData
+import TownCrierDomain
+
+@Suite("APINotificationService")
+struct APINotificationServiceTests {
+    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
+
+    private func makeTransport(
+        statusCode: Int = 204,
+        body: String = "{}"
+    ) -> StubHTTPTransport {
+        let transport = StubHTTPTransport()
+        transport.responses = [
+            (Data(body.utf8), httpResponse(url: baseURL, statusCode: statusCode)),
+        ]
+        return transport
+    }
+
+    private func makeSUT(
+        transport: StubHTTPTransport? = nil,
+        session: AuthSession? = .valid
+    ) -> (APINotificationService, StubHTTPTransport, SpyAuthenticationService) {
+        let transport = transport ?? makeTransport()
+        let authSpy = SpyAuthenticationService()
+        authSpy.currentSessionResult = session
+        let apiClient = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authSpy,
+            transport: transport
+        )
+        let sut = APINotificationService(apiClient: apiClient)
+        return (sut, transport, authSpy)
+    }
+
+    // MARK: - Register Device Token
+
+    @Test("registerDeviceToken sends PUT /v1/me/device-token with correct body")
+    func registerDeviceToken_sendsCorrectRequest() async throws {
+        let (sut, transport, _) = makeSUT()
+
+        try await sut.registerDeviceToken("abc123-device-token")
+
+        let request = try #require(transport.requests.first)
+        #expect(request.httpMethod == "PUT")
+        #expect(request.url?.path().contains("v1/me/device-token") == true)
+
+        let body = try #require(request.httpBody)
+        let json = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        #expect(json?["token"] as? String == "abc123-device-token")
+        #expect(json?["platform"] as? String == "Ios")
+    }
+
+    @Test("registerDeviceToken stores token for later removal")
+    func registerDeviceToken_storesToken() async throws {
+        let transport = makeTransport()
+        // Two responses: one for register, one for remove
+        transport.responses.append(
+            (Data("{}".utf8), httpResponse(url: baseURL, statusCode: 204))
+        )
+        let (sut, _, _) = makeSUT(transport: transport)
+
+        try await sut.registerDeviceToken("stored-token-123")
+        try await sut.removeDeviceToken()
+
+        let removeRequest = transport.requests.last!
+        #expect(removeRequest.httpMethod == "DELETE")
+        #expect(removeRequest.url?.path().contains("stored-token-123") == true)
+    }
+
+    // MARK: - Remove Device Token
+
+    @Test("removeDeviceToken sends DELETE /v1/me/device-token/{token}")
+    func removeDeviceToken_sendsDeleteRequest() async throws {
+        let transport = makeTransport()
+        // Two responses: register then remove
+        transport.responses.append(
+            (Data("{}".utf8), httpResponse(url: baseURL, statusCode: 204))
+        )
+        let (sut, _, _) = makeSUT(transport: transport)
+
+        try await sut.registerDeviceToken("token-to-remove")
+        try await sut.removeDeviceToken()
+
+        let request = transport.requests.last!
+        #expect(request.httpMethod == "DELETE")
+        #expect(request.url?.path().contains("v1/me/device-token/token-to-remove") == true)
+    }
+
+    @Test("removeDeviceToken with no stored token is a no-op")
+    func removeDeviceToken_noStoredToken_doesNothing() async throws {
+        let (sut, transport, _) = makeSUT()
+
+        try await sut.removeDeviceToken()
+
+        #expect(transport.requests.isEmpty)
+    }
+}
+
+// MARK: - Test helpers
+
+private final class StubHTTPTransport: HTTPTransport, @unchecked Sendable {
+    var responses: [(Data, URLResponse)] = []
+    private var callIndex = 0
+    private(set) var requests: [URLRequest] = []
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        requests.append(request)
+        guard callIndex < responses.count else {
+            throw URLError(.badServerResponse)
+        }
+        let response = responses[callIndex]
+        callIndex += 1
+        return response
+    }
+}
+
+private func httpResponse(url: URL, statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/APINotificationServiceTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APINotificationServiceTests.swift
@@ -5,6 +5,7 @@ import TownCrierDomain
 
 @Suite("APINotificationService")
 struct APINotificationServiceTests {
+    // swiftlint:disable:next force_unwrapping
     private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
 
     private func makeTransport(
@@ -64,7 +65,7 @@ struct APINotificationServiceTests {
         try await sut.registerDeviceToken("stored-token-123")
         try await sut.removeDeviceToken()
 
-        let removeRequest = transport.requests.last!
+        let removeRequest = try #require(transport.requests.last)
         #expect(removeRequest.httpMethod == "DELETE")
         #expect(removeRequest.url?.path().contains("stored-token-123") == true)
     }
@@ -83,7 +84,7 @@ struct APINotificationServiceTests {
         try await sut.registerDeviceToken("token-to-remove")
         try await sut.removeDeviceToken()
 
-        let request = transport.requests.last!
+        let request = try #require(transport.requests.last)
         #expect(request.httpMethod == "DELETE")
         #expect(request.url?.path().contains("v1/me/device-token/token-to-remove") == true)
     }
@@ -97,4 +98,3 @@ struct APINotificationServiceTests {
         #expect(transport.requests.isEmpty)
     }
 }
-

--- a/mobile/ios/town-crier-tests/Sources/Features/APINotificationServiceTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APINotificationServiceTests.swift
@@ -98,24 +98,3 @@ struct APINotificationServiceTests {
     }
 }
 
-// MARK: - Test helpers
-
-private final class StubHTTPTransport: HTTPTransport, @unchecked Sendable {
-    var responses: [(Data, URLResponse)] = []
-    private var callIndex = 0
-    private(set) var requests: [URLRequest] = []
-
-    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        requests.append(request)
-        guard callIndex < responses.count else {
-            throw URLError(.badServerResponse)
-        }
-        let response = responses[callIndex]
-        callIndex += 1
-        return response
-    }
-}
-
-private func httpResponse(url: URL, statusCode: Int) -> HTTPURLResponse {
-    HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
-}

--- a/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryTests.swift
@@ -1,0 +1,325 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+@Suite("APIPlanningApplicationRepository")
+struct APIPlanningApplicationRepositoryTests {
+
+    // MARK: - Helpers
+
+    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
+
+    private func makeSUT(
+        responses: [(Data, URLResponse)]
+    ) -> (APIPlanningApplicationRepository, SpyAuthenticationService, StubHTTPTransport) {
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+        let transport = StubHTTPTransport()
+        transport.responses = responses
+        let apiClient = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+        let sut = APIPlanningApplicationRepository(apiClient: apiClient)
+        return (sut, authService, transport)
+    }
+
+    private func httpResponse(statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: baseURL,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    // MARK: - fetchApplications
+
+    @Test("fetchApplications sends GET /v1/applications with authorityId query param")
+    func fetchApplications_sendsCorrectRequest() async throws {
+        let json = "[]"
+        let authority = LocalAuthority(code: "123", name: "Cambridge")
+        let (sut, _, transport) = makeSUT(responses: [
+            (Data(json.utf8), httpResponse(statusCode: 200)),
+        ])
+
+        _ = try await sut.fetchApplications(for: authority)
+
+        #expect(transport.requests.count == 1)
+        let request = transport.requests[0]
+        #expect(request.httpMethod == "GET")
+        let url = request.url!
+        #expect(url.path().contains("/v1/applications"))
+        #expect(url.query()?.contains("authorityId=123") == true)
+    }
+
+    @Test("fetchApplications maps API response to domain models")
+    func fetchApplications_mapsToDomainModels() async throws {
+        let json = """
+            [
+                {
+                    "name": "2026/0042",
+                    "uid": "app-001",
+                    "areaName": "Cambridge",
+                    "areaId": 123,
+                    "address": "12 Mill Road, Cambridge, CB1 2AD",
+                    "postcode": "CB1 2AD",
+                    "description": "Erection of two-storey rear extension",
+                    "appType": "Full",
+                    "appState": "Under Review",
+                    "appSize": null,
+                    "startDate": "2026-01-15",
+                    "decidedDate": null,
+                    "consultedDate": null,
+                    "longitude": 0.1243,
+                    "latitude": 52.2043,
+                    "url": "https://planning.cambridge.gov.uk/2026/0042",
+                    "link": null,
+                    "lastDifferent": "2026-01-15T00:00:00+00:00"
+                }
+            ]
+            """
+        let authority = LocalAuthority(code: "123", name: "Cambridge")
+        let (sut, _, _) = makeSUT(responses: [
+            (Data(json.utf8), httpResponse(statusCode: 200)),
+        ])
+
+        let result = try await sut.fetchApplications(for: authority)
+
+        #expect(result.count == 1)
+        let app = result[0]
+        #expect(app.id == PlanningApplicationId("app-001"))
+        #expect(app.reference == ApplicationReference("2026/0042"))
+        #expect(app.authority.code == "123")
+        #expect(app.authority.name == "Cambridge")
+        #expect(app.status == ApplicationStatus.underReview)
+        #expect(app.description == "Erection of two-storey rear extension")
+        #expect(app.address == "12 Mill Road, Cambridge, CB1 2AD")
+        let expectedLocation = try Coordinate(latitude: 52.2043, longitude: 0.1243)
+        #expect(app.location == expectedLocation)
+        #expect(app.portalUrl == URL(string: "https://planning.cambridge.gov.uk/2026/0042"))
+    }
+
+    @Test("fetchApplications synthesizes status history from startDate")
+    func fetchApplications_synthesizesStatusHistory() async throws {
+        let json = """
+            [
+                {
+                    "name": "2026/0042",
+                    "uid": "app-001",
+                    "areaName": "Cambridge",
+                    "areaId": 123,
+                    "address": "12 Mill Road",
+                    "postcode": null,
+                    "description": "Extension",
+                    "appType": "Full",
+                    "appState": "Approved",
+                    "appSize": null,
+                    "startDate": "2026-01-15",
+                    "decidedDate": "2026-03-01",
+                    "consultedDate": null,
+                    "longitude": null,
+                    "latitude": null,
+                    "url": null,
+                    "link": null,
+                    "lastDifferent": "2026-03-01T00:00:00+00:00"
+                }
+            ]
+            """
+        let authority = LocalAuthority(code: "123", name: "Cambridge")
+        let (sut, _, _) = makeSUT(responses: [
+            (Data(json.utf8), httpResponse(statusCode: 200)),
+        ])
+
+        let result = try await sut.fetchApplications(for: authority)
+
+        let app = result[0]
+        #expect(app.statusHistory.count == 2)
+        #expect(app.statusHistory[0].status == ApplicationStatus.underReview)
+        #expect(app.statusHistory[1].status == ApplicationStatus.approved)
+    }
+
+    @Test("fetchApplications with network error throws networkUnavailable")
+    func fetchApplications_networkError_throwsNetworkUnavailable() async throws {
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+        let transport = StubHTTPTransport()
+        transport.error = URLError(.notConnectedToInternet)
+        let apiClient = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+        let sut = APIPlanningApplicationRepository(apiClient: apiClient)
+        let authority = LocalAuthority(code: "123", name: "Cambridge")
+
+        await #expect(throws: DomainError.networkUnavailable) {
+            _ = try await sut.fetchApplications(for: authority)
+        }
+    }
+
+    // MARK: - fetchApplication
+
+    @Test("fetchApplication sends GET /v1/applications/{uid}")
+    func fetchApplication_sendsCorrectRequest() async throws {
+        let json = """
+            {
+                "name": "2026/0042",
+                "uid": "app-001",
+                "areaName": "Cambridge",
+                "areaId": 123,
+                "address": "12 Mill Road, Cambridge, CB1 2AD",
+                "postcode": "CB1 2AD",
+                "description": "Erection of two-storey rear extension",
+                "appType": "Full",
+                "appState": "Under Review",
+                "appSize": null,
+                "startDate": "2026-01-15",
+                "decidedDate": null,
+                "consultedDate": null,
+                "longitude": 0.1243,
+                "latitude": 52.2043,
+                "url": null,
+                "link": null,
+                "lastDifferent": "2026-01-15T00:00:00+00:00"
+            }
+            """
+        let (sut, _, transport) = makeSUT(responses: [
+            (Data(json.utf8), httpResponse(statusCode: 200)),
+        ])
+
+        _ = try await sut.fetchApplication(by: PlanningApplicationId("app-001"))
+
+        #expect(transport.requests.count == 1)
+        let request = transport.requests[0]
+        #expect(request.httpMethod == "GET")
+        #expect(request.url?.path().contains("/v1/applications/app-001") == true)
+    }
+
+    @Test("fetchApplication maps single API response to domain model")
+    func fetchApplication_mapsToDomainModel() async throws {
+        let json = """
+            {
+                "name": "2026/0099",
+                "uid": "app-002",
+                "areaName": "Oxford",
+                "areaId": 456,
+                "address": "45 High Street, Oxford, OX1 4AS",
+                "postcode": "OX1 4AS",
+                "description": "Change of use",
+                "appType": "Full",
+                "appState": "Refused",
+                "appSize": null,
+                "startDate": "2026-02-01",
+                "decidedDate": "2026-03-15",
+                "consultedDate": null,
+                "longitude": -1.2577,
+                "latitude": 51.7520,
+                "url": null,
+                "link": null,
+                "lastDifferent": "2026-03-15T00:00:00+00:00"
+            }
+            """
+        let (sut, _, _) = makeSUT(responses: [
+            (Data(json.utf8), httpResponse(statusCode: 200)),
+        ])
+
+        let app = try await sut.fetchApplication(by: PlanningApplicationId("app-002"))
+
+        #expect(app.id == PlanningApplicationId("app-002"))
+        #expect(app.reference == ApplicationReference("2026/0099"))
+        #expect(app.authority == LocalAuthority(code: "456", name: "Oxford"))
+        #expect(app.status == ApplicationStatus.refused)
+        #expect(app.address == "45 High Street, Oxford, OX1 4AS")
+        let expectedLocation = try Coordinate(latitude: 51.7520, longitude: -1.2577)
+        #expect(app.location == expectedLocation)
+    }
+
+    @Test("fetchApplication with 404 throws applicationNotFound")
+    func fetchApplication_notFound_throwsApplicationNotFound() async throws {
+        let (sut, _, _) = makeSUT(responses: [
+            (Data("null".utf8), httpResponse(statusCode: 404)),
+        ])
+
+        await #expect(throws: DomainError.applicationNotFound(PlanningApplicationId("missing"))) {
+            _ = try await sut.fetchApplication(by: PlanningApplicationId("missing"))
+        }
+    }
+
+    // MARK: - AppState mapping
+
+    @Test("maps known AppState strings to ApplicationStatus", arguments: [
+        ("Under Review", ApplicationStatus.underReview),
+        ("Approved", ApplicationStatus.approved),
+        ("Refused", ApplicationStatus.refused),
+        ("Withdrawn", ApplicationStatus.withdrawn),
+        ("Appealed", ApplicationStatus.appealed),
+    ])
+    func appStateMapping(appState: String, expected: ApplicationStatus) async throws {
+        let json = """
+            {
+                "name": "REF/001",
+                "uid": "id-1",
+                "areaName": "Test",
+                "areaId": 1,
+                "address": "1 Test St",
+                "postcode": null,
+                "description": "Test",
+                "appType": "Full",
+                "appState": "\(appState)",
+                "appSize": null,
+                "startDate": null,
+                "decidedDate": null,
+                "consultedDate": null,
+                "longitude": null,
+                "latitude": null,
+                "url": null,
+                "link": null,
+                "lastDifferent": "2026-01-01T00:00:00+00:00"
+            }
+            """
+        let (sut, _, _) = makeSUT(responses: [
+            (Data(json.utf8), httpResponse(statusCode: 200)),
+        ])
+
+        let app = try await sut.fetchApplication(by: PlanningApplicationId("id-1"))
+
+        #expect(app.status == expected)
+    }
+
+    @Test("maps unknown AppState to .unknown")
+    func unknownAppState_mapsToUnknown() async throws {
+        let json = """
+            {
+                "name": "REF/001",
+                "uid": "id-1",
+                "areaName": "Test",
+                "areaId": 1,
+                "address": "1 Test St",
+                "postcode": null,
+                "description": "Test",
+                "appType": "Full",
+                "appState": "Something Unexpected",
+                "appSize": null,
+                "startDate": null,
+                "decidedDate": null,
+                "consultedDate": null,
+                "longitude": null,
+                "latitude": null,
+                "url": null,
+                "link": null,
+                "lastDifferent": "2026-01-01T00:00:00+00:00"
+            }
+            """
+        let (sut, _, _) = makeSUT(responses: [
+            (Data(json.utf8), httpResponse(statusCode: 200)),
+        ])
+
+        let app = try await sut.fetchApplication(by: PlanningApplicationId("id-1"))
+
+        #expect(app.status == .unknown)
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryTests.swift
@@ -9,6 +9,7 @@ struct APIPlanningApplicationRepositoryTests {
 
     // MARK: - Helpers
 
+    // swiftlint:disable:next force_unwrapping
     private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
 
     private func makeSUT(
@@ -27,6 +28,7 @@ struct APIPlanningApplicationRepositoryTests {
         return (sut, authService, transport)
     }
 
+    // swiftlint:disable force_unwrapping
     private func httpResponse(statusCode: Int) -> HTTPURLResponse {
         HTTPURLResponse(
             url: baseURL,
@@ -35,6 +37,7 @@ struct APIPlanningApplicationRepositoryTests {
             headerFields: nil
         )!
     }
+    // swiftlint:enable force_unwrapping
 
     // MARK: - fetchApplications
 
@@ -51,7 +54,7 @@ struct APIPlanningApplicationRepositoryTests {
         #expect(transport.requests.count == 1)
         let request = transport.requests[0]
         #expect(request.httpMethod == "GET")
-        let url = request.url!
+        let url = try #require(request.url)
         #expect(url.path().contains("/v1/applications"))
         #expect(url.query()?.contains("authorityId=123") == true)
     }

--- a/mobile/ios/town-crier-tests/Sources/Features/APIPostcodeGeocoderTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIPostcodeGeocoderTests.swift
@@ -9,6 +9,7 @@ struct APIPostcodeGeocoderTests {
 
     // MARK: - Helpers
 
+    // swiftlint:disable:next force_unwrapping
     private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
 
     private func makeSUT(
@@ -27,6 +28,7 @@ struct APIPostcodeGeocoderTests {
         return (sut, authService, transport)
     }
 
+    // swiftlint:disable force_unwrapping
     private func httpResponse(statusCode: Int) -> HTTPURLResponse {
         HTTPURLResponse(
             url: baseURL,
@@ -35,6 +37,7 @@ struct APIPostcodeGeocoderTests {
             headerFields: nil
         )!
     }
+    // swiftlint:enable force_unwrapping
 
     // MARK: - Success
 

--- a/mobile/ios/town-crier-tests/Sources/Features/APIPostcodeGeocoderTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIPostcodeGeocoderTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+@Suite("APIPostcodeGeocoder")
+struct APIPostcodeGeocoderTests {
+
+    // MARK: - Helpers
+
+    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
+
+    private func makeSUT(
+        responses: [(Data, URLResponse)]
+    ) -> (APIPostcodeGeocoder, SpyAuthenticationService, StubHTTPTransport) {
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+        let transport = StubHTTPTransport()
+        transport.responses = responses
+        let apiClient = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+        let sut = APIPostcodeGeocoder(apiClient: apiClient)
+        return (sut, authService, transport)
+    }
+
+    private func httpResponse(statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: baseURL,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    // MARK: - Success
+
+    @Test("geocode sends GET /v1/geocode/{postcode} and returns mapped Coordinate")
+    func geocode_success_returnsMappedCoordinate() async throws {
+        let json = #"{"coordinates":{"latitude":52.2053,"longitude":0.1218}}"#
+        let (sut, _, transport) = makeSUT(responses: [
+            (Data(json.utf8), httpResponse(statusCode: 200)),
+        ])
+
+        let postcode = try Postcode("CB2 1TN")
+        let result = try await sut.geocode(postcode)
+
+        let expected = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+        #expect(result == expected)
+        #expect(transport.requests.count == 1)
+        let request = transport.requests[0]
+        #expect(request.url?.path().contains("/v1/geocode/CB2%201TN") == true
+            || request.url?.path().contains("/v1/geocode/CB2 1TN") == true)
+    }
+
+    // MARK: - Error mapping
+
+    @Test("geocode with 404 throws geocodingFailed")
+    func geocode_notFound_throwsGeocodingFailed() async throws {
+        let errorJson = #"{"message":"Postcode 'ZZ9 9ZZ' could not be geocoded."}"#
+        let (sut, _, _) = makeSUT(responses: [
+            (Data(errorJson.utf8), httpResponse(statusCode: 404)),
+        ])
+
+        let postcode = try Postcode("ZZ9 9ZZ")
+        await #expect(throws: DomainError.self) {
+            _ = try await sut.geocode(postcode)
+        }
+    }
+
+    @Test("geocode with server error throws geocodingFailed")
+    func geocode_serverError_throwsGeocodingFailed() async throws {
+        let (sut, _, _) = makeSUT(responses: [
+            (Data(), httpResponse(statusCode: 500)),
+        ])
+
+        let postcode = try Postcode("CB2 1TN")
+        await #expect(throws: DomainError.self) {
+            _ = try await sut.geocode(postcode)
+        }
+    }
+
+    @Test("geocode with network error throws networkUnavailable")
+    func geocode_networkError_throwsNetworkUnavailable() async throws {
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+        let transport = StubHTTPTransport()
+        transport.error = URLError(.notConnectedToInternet)
+        let apiClient = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+        let sut = APIPostcodeGeocoder(apiClient: apiClient)
+
+        let postcode = try Postcode("CB2 1TN")
+        await #expect(throws: DomainError.networkUnavailable) {
+            _ = try await sut.geocode(postcode)
+        }
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/APIVersionConfigServiceTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIVersionConfigServiceTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+import TownCrierData
+import TownCrierDomain
+
+
+@Suite("APIVersionConfigService")
+struct APIVersionConfigServiceTests {
+    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
+
+    @Test("Sends GET request to /v1/version-config")
+    func sendsGetToCorrectPath() async throws {
+        let transport = StubHTTPTransport()
+        let json = #"{"minimumVersion":"1.0.0"}"#
+        transport.responses = [
+            (Data(json.utf8), httpResponse(url: baseURL, statusCode: 200)),
+        ]
+
+        let sut = APIVersionConfigService(baseURL: baseURL, transport: transport)
+
+        _ = try await sut.fetchMinimumVersion()
+
+        #expect(transport.requests.count == 1)
+        let request = transport.requests[0]
+        #expect(request.httpMethod == "GET")
+        #expect(request.url?.path().contains("v1/version-config") == true)
+    }
+
+    @Test("Parses valid version response into AppVersion")
+    func parsesValidResponse() async throws {
+        let transport = StubHTTPTransport()
+        let json = #"{"minimumVersion":"2.1.3"}"#
+        transport.responses = [
+            (Data(json.utf8), httpResponse(url: baseURL, statusCode: 200)),
+        ]
+
+        let sut = APIVersionConfigService(baseURL: baseURL, transport: transport)
+
+        let result = try await sut.fetchMinimumVersion()
+
+        #expect(result == AppVersion(major: 2, minor: 1, patch: 3))
+    }
+
+    @Test("Network error throws networkUnavailable")
+    func networkErrorThrowsNetworkUnavailable() async {
+        let transport = StubHTTPTransport()
+        transport.error = URLError(.notConnectedToInternet)
+
+        let sut = APIVersionConfigService(baseURL: baseURL, transport: transport)
+
+        await #expect(throws: DomainError.networkUnavailable) {
+            _ = try await sut.fetchMinimumVersion()
+        }
+    }
+
+    @Test("Non-2xx status throws unexpected error")
+    func nonSuccessStatusThrowsUnexpected() async {
+        let transport = StubHTTPTransport()
+        transport.responses = [
+            (Data(), httpResponse(url: baseURL, statusCode: 500)),
+        ]
+
+        let sut = APIVersionConfigService(baseURL: baseURL, transport: transport)
+
+        await #expect(throws: DomainError.self) {
+            _ = try await sut.fetchMinimumVersion()
+        }
+    }
+
+    @Test("Invalid JSON throws unexpected error")
+    func invalidJsonThrowsUnexpected() async {
+        let transport = StubHTTPTransport()
+        transport.responses = [
+            (Data("not json".utf8), httpResponse(url: baseURL, statusCode: 200)),
+        ]
+
+        let sut = APIVersionConfigService(baseURL: baseURL, transport: transport)
+
+        await #expect(throws: DomainError.self) {
+            _ = try await sut.fetchMinimumVersion()
+        }
+    }
+
+    @Test("Invalid version string in response throws unexpected error")
+    func invalidVersionStringThrowsUnexpected() async {
+        let transport = StubHTTPTransport()
+        let json = #"{"minimumVersion":"not-a-version"}"#
+        transport.responses = [
+            (Data(json.utf8), httpResponse(url: baseURL, statusCode: 200)),
+        ]
+
+        let sut = APIVersionConfigService(baseURL: baseURL, transport: transport)
+
+        await #expect(throws: DomainError.self) {
+            _ = try await sut.fetchMinimumVersion()
+        }
+    }
+
+    @Test("Request does not include Authorization header")
+    func noAuthorizationHeader() async throws {
+        let transport = StubHTTPTransport()
+        let json = #"{"minimumVersion":"1.0.0"}"#
+        transport.responses = [
+            (Data(json.utf8), httpResponse(url: baseURL, statusCode: 200)),
+        ]
+
+        let sut = APIVersionConfigService(baseURL: baseURL, transport: transport)
+
+        _ = try await sut.fetchMinimumVersion()
+
+        let request = transport.requests[0]
+        #expect(request.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/APIVersionConfigServiceTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIVersionConfigServiceTests.swift
@@ -3,9 +3,9 @@ import Testing
 import TownCrierData
 import TownCrierDomain
 
-
 @Suite("APIVersionConfigService")
 struct APIVersionConfigServiceTests {
+    // swiftlint:disable:next force_unwrapping
     private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
 
     @Test("Sends GET request to /v1/version-config")

--- a/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryTests.swift
@@ -9,6 +9,7 @@ struct APIWatchZoneRepositoryTests {
 
     // MARK: - Helpers
 
+    // swiftlint:disable:next force_unwrapping
     private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
 
     private func makeSUT(
@@ -27,6 +28,7 @@ struct APIWatchZoneRepositoryTests {
         return (sut, authService, transport)
     }
 
+    // swiftlint:disable force_unwrapping
     private func httpResponse(statusCode: Int) -> HTTPURLResponse {
         HTTPURLResponse(
             url: baseURL,
@@ -35,6 +37,7 @@ struct APIWatchZoneRepositoryTests {
             headerFields: nil
         )!
     }
+    // swiftlint:enable force_unwrapping
 
     // MARK: - save
 
@@ -53,7 +56,7 @@ struct APIWatchZoneRepositoryTests {
         #expect(request.url?.path().contains("/v1/me/watch-zones") == true)
 
         let body = try #require(request.httpBody)
-        let json = try JSONSerialization.jsonObject(with: body) as! [String: Any]
+        let json = try #require(try JSONSerialization.jsonObject(with: body) as? [String: Any])
         #expect(json["zoneId"] as? String == "zone-001")
         #expect(json["name"] as? String == "CB1 2AD")
         #expect(json["latitude"] as? Double == 52.2053)

--- a/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryTests.swift
@@ -1,0 +1,196 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+@Suite("APIWatchZoneRepository")
+struct APIWatchZoneRepositoryTests {
+
+    // MARK: - Helpers
+
+    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
+
+    private func makeSUT(
+        responses: [(Data, URLResponse)]
+    ) -> (APIWatchZoneRepository, SpyAuthenticationService, StubHTTPTransport) {
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+        let transport = StubHTTPTransport()
+        transport.responses = responses
+        let apiClient = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+        let sut = APIWatchZoneRepository(apiClient: apiClient)
+        return (sut, authService, transport)
+    }
+
+    private func httpResponse(statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(
+            url: baseURL,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    // MARK: - save
+
+    @Test("save sends POST /v1/me/watch-zones with correct body")
+    func save_sendsCorrectRequest() async throws {
+        let zone = WatchZone.cambridge
+        let (sut, _, transport) = makeSUT(responses: [
+            (Data("{}".utf8), httpResponse(statusCode: 201)),
+        ])
+
+        try await sut.save(zone)
+
+        #expect(transport.requests.count == 1)
+        let request = transport.requests[0]
+        #expect(request.httpMethod == "POST")
+        #expect(request.url?.path().contains("/v1/me/watch-zones") == true)
+
+        let body = try #require(request.httpBody)
+        let json = try JSONSerialization.jsonObject(with: body) as! [String: Any]
+        #expect(json["zoneId"] as? String == "zone-001")
+        #expect(json["name"] as? String == "CB1 2AD")
+        #expect(json["latitude"] as? Double == 52.2053)
+        #expect(json["longitude"] as? Double == 0.1218)
+        #expect(json["radiusMetres"] as? Double == 2000)
+    }
+
+    @Test("save with network error throws networkUnavailable")
+    func save_networkError_throwsNetworkUnavailable() async {
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+        let transport = StubHTTPTransport()
+        transport.error = URLError(.notConnectedToInternet)
+        let apiClient = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+        let sut = APIWatchZoneRepository(apiClient: apiClient)
+
+        await #expect(throws: DomainError.networkUnavailable) {
+            try await sut.save(.cambridge)
+        }
+    }
+
+    // MARK: - loadAll
+
+    @Test("loadAll sends GET /v1/me/watch-zones and maps response to domain models")
+    func loadAll_mapsResponseToDomain() async throws {
+        let json = """
+            {
+                "zones": [
+                    {
+                        "id": "zone-001",
+                        "name": "CB1 2AD",
+                        "latitude": 52.2053,
+                        "longitude": 0.1218,
+                        "radiusMetres": 2000,
+                        "authorityId": 123
+                    }
+                ]
+            }
+            """
+        let (sut, _, transport) = makeSUT(responses: [
+            (Data(json.utf8), httpResponse(statusCode: 200)),
+        ])
+
+        let zones = try await sut.loadAll()
+
+        #expect(transport.requests.count == 1)
+        let request = transport.requests[0]
+        #expect(request.httpMethod == "GET")
+        #expect(request.url?.path().contains("/v1/me/watch-zones") == true)
+
+        #expect(zones.count == 1)
+        let zone = zones[0]
+        #expect(zone.id == WatchZoneId("zone-001"))
+        let expectedPostcode = try Postcode("CB1 2AD")
+        #expect(zone.postcode == expectedPostcode)
+        let expectedCentre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+        #expect(zone.centre == expectedCentre)
+        #expect(zone.radiusMetres == 2000)
+    }
+
+    @Test("loadAll returns empty array when no zones")
+    func loadAll_emptyZones_returnsEmptyArray() async throws {
+        let json = """
+            { "zones": [] }
+            """
+        let (sut, _, _) = makeSUT(responses: [
+            (Data(json.utf8), httpResponse(statusCode: 200)),
+        ])
+
+        let zones = try await sut.loadAll()
+
+        #expect(zones.isEmpty)
+    }
+
+    @Test("loadAll with network error throws networkUnavailable")
+    func loadAll_networkError_throwsNetworkUnavailable() async {
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+        let transport = StubHTTPTransport()
+        transport.error = URLError(.notConnectedToInternet)
+        let apiClient = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+        let sut = APIWatchZoneRepository(apiClient: apiClient)
+
+        await #expect(throws: DomainError.networkUnavailable) {
+            _ = try await sut.loadAll()
+        }
+    }
+
+    // MARK: - delete
+
+    @Test("delete sends DELETE /v1/me/watch-zones/{zoneId}")
+    func delete_sendsCorrectRequest() async throws {
+        let (sut, _, transport) = makeSUT(responses: [
+            (Data(), httpResponse(statusCode: 204)),
+        ])
+
+        try await sut.delete(WatchZoneId("zone-001"))
+
+        #expect(transport.requests.count == 1)
+        let request = transport.requests[0]
+        #expect(request.httpMethod == "DELETE")
+        #expect(request.url?.path().contains("/v1/me/watch-zones/zone-001") == true)
+    }
+
+    @Test("delete with 404 succeeds silently (idempotent)")
+    func delete_notFound_succeedsSilently() async throws {
+        let (sut, _, _) = makeSUT(responses: [
+            (Data("null".utf8), httpResponse(statusCode: 404)),
+        ])
+
+        // Should not throw — if the zone is already gone, that's fine
+        try await sut.delete(WatchZoneId("nonexistent"))
+    }
+
+    @Test("delete with network error throws networkUnavailable")
+    func delete_networkError_throwsNetworkUnavailable() async {
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+        let transport = StubHTTPTransport()
+        transport.error = URLError(.notConnectedToInternet)
+        let apiClient = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+        let sut = APIWatchZoneRepository(apiClient: apiClient)
+
+        await #expect(throws: DomainError.networkUnavailable) {
+            try await sut.delete(WatchZoneId("zone-001"))
+        }
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -53,6 +53,55 @@ struct AppCoordinatorTests {
         #expect(!vm.isLoading)
     }
 
+    // MARK: - Offline-Aware Factory
+
+    @Test func makeApplicationListViewModel_withOfflineRepository_usesOfflinePath() async {
+        let remote = SpyPlanningApplicationRepository()
+        remote.fetchApplicationsResult = .success([.pendingReview])
+        let cache = SpyApplicationCacheStore()
+        let connectivity = StubConnectivityMonitor(isConnected: true)
+        let offlineRepo = OfflineAwareRepository(
+            remote: remote,
+            cache: cache,
+            connectivity: connectivity
+        )
+        let sut = AppCoordinator(
+            repository: remote,
+            authService: SpyAuthenticationService(),
+            subscriptionService: SpySubscriptionService(),
+            offlineRepository: offlineRepo
+        )
+
+        let vm = sut.makeApplicationListViewModel(authority: .cambridge)
+        await vm.loadApplications()
+
+        #expect(vm.dataFreshness == .fresh)
+        #expect(vm.filteredApplications.count == 1)
+    }
+
+    @Test func makeMapViewModel_withOfflineRepository_usesOfflinePath() async {
+        let remote = SpyPlanningApplicationRepository()
+        remote.fetchApplicationsResult = .success([.pendingReview])
+        let cache = SpyApplicationCacheStore()
+        let connectivity = StubConnectivityMonitor(isConnected: true)
+        let offlineRepo = OfflineAwareRepository(
+            remote: remote,
+            cache: cache,
+            connectivity: connectivity
+        )
+        let sut = AppCoordinator(
+            repository: remote,
+            authService: SpyAuthenticationService(),
+            subscriptionService: SpySubscriptionService(),
+            offlineRepository: offlineRepo
+        )
+
+        let vm = sut.makeMapViewModel(watchZone: .cambridge)
+        await vm.loadApplications()
+
+        #expect(vm.dataFreshness == .fresh)
+    }
+
     // MARK: - Application List Factory
 
     @Test func makeApplicationListViewModel_createsViewModelWithAuthority() async {

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositeNotificationServiceTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositeNotificationServiceTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+import TownCrierData
+import TownCrierDomain
+
+@Suite("CompositeNotificationService")
+struct CompositeNotificationServiceTests {
+    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")
+
+    private func makeSUT() throws -> (
+        CompositeNotificationService, SpyNotificationPermissionProvider, StubHTTPTransport
+    ) {
+        let url = try #require(baseURL)
+        let permissionSpy = SpyNotificationPermissionProvider()
+        let transport = StubHTTPTransport()
+        let authSpy = SpyAuthenticationService()
+        authSpy.currentSessionResult = .valid
+        let apiClient = URLSessionAPIClient(
+            baseURL: url,
+            authService: authSpy,
+            transport: transport
+        )
+        let apiService = APINotificationService(apiClient: apiClient)
+        let sut = CompositeNotificationService(
+            permissionProvider: permissionSpy,
+            apiService: apiService
+        )
+        return (sut, permissionSpy, transport)
+    }
+
+    private func makeResponse() throws -> (Data, HTTPURLResponse) {
+        let url = try #require(baseURL)
+        return (Data("{}".utf8), httpResponse(url: url, statusCode: 204))
+    }
+
+    // MARK: - requestPermission
+
+    @Test("requestPermission delegates to permission provider and returns true")
+    func requestPermission_delegatesToProvider_returnsTrue() async throws {
+        let (sut, permissionSpy, _) = try makeSUT()
+        permissionSpy.requestPermissionResult = .success(true)
+
+        let result = try await sut.requestPermission()
+
+        #expect(result == true)
+        #expect(permissionSpy.requestPermissionCallCount == 1)
+    }
+
+    @Test("requestPermission delegates to permission provider and returns false")
+    func requestPermission_delegatesToProvider_returnsFalse() async throws {
+        let (sut, permissionSpy, _) = try makeSUT()
+        permissionSpy.requestPermissionResult = .success(false)
+
+        let result = try await sut.requestPermission()
+
+        #expect(result == false)
+    }
+
+    @Test("requestPermission propagates errors from permission provider")
+    func requestPermission_propagatesError() async throws {
+        let (sut, permissionSpy, _) = try makeSUT()
+        permissionSpy.requestPermissionResult = .failure(DomainError.notificationPermissionDenied)
+
+        await #expect(throws: DomainError.self) {
+            try await sut.requestPermission()
+        }
+    }
+
+    // MARK: - registerDeviceToken
+
+    @Test("registerDeviceToken delegates to API service")
+    func registerDeviceToken_delegatesToAPIService() async throws {
+        let (sut, _, transport) = try makeSUT()
+        transport.responses = [try makeResponse()]
+
+        try await sut.registerDeviceToken("test-token-abc")
+
+        let request = try #require(transport.requests.first)
+        #expect(request.httpMethod == "PUT")
+        #expect(request.url?.path().contains("v1/me/device-token") == true)
+        let body = try #require(request.httpBody)
+        let json = try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        #expect(json?["token"] as? String == "test-token-abc")
+    }
+
+    // MARK: - removeDeviceToken
+
+    @Test("removeDeviceToken delegates to API service")
+    func removeDeviceToken_delegatesToAPIService() async throws {
+        let (sut, _, transport) = try makeSUT()
+        transport.responses = [try makeResponse(), try makeResponse()]
+
+        // Must register first so there's a stored token to remove
+        try await sut.registerDeviceToken("token-to-remove")
+        try await sut.removeDeviceToken()
+
+        let removeRequest = try #require(transport.requests.last)
+        #expect(removeRequest.httpMethod == "DELETE")
+        #expect(removeRequest.url?.path().contains("token-to-remove") == true)
+    }
+
+    @Test("removeDeviceToken with no prior registration is a no-op")
+    func removeDeviceToken_noPriorRegistration_noOp() async throws {
+        let (sut, _, transport) = try makeSUT()
+
+        try await sut.removeDeviceToken()
+
+        #expect(transport.requests.isEmpty)
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -24,6 +24,10 @@ struct CompositionRootTests {
         let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
         let repository = APIPlanningApplicationRepository(apiClient: apiClient)
         let geocoder = APIPostcodeGeocoder(apiClient: apiClient)
+        let notificationService = CompositeNotificationService(
+            permissionProvider: SpyNotificationPermissionProvider(),
+            apiService: APINotificationService(apiClient: apiClient)
+        )
 
         let coordinator = AppCoordinator(
             repository: repository,
@@ -31,6 +35,7 @@ struct CompositionRootTests {
             subscriptionService: subscriptionService,
             geocoder: geocoder,
             onboardingRepository: onboardingRepository,
+            notificationService: notificationService,
             appVersionProvider: appVersionProvider,
             versionConfigService: versionConfigService
         )

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -52,6 +52,33 @@ struct CompositionRootTests {
         #expect(!forceUpdateViewModel.requiresUpdate)
     }
 
+    @Test func coordinatorReportsOnboardingStateFromConcreteRepository() {
+        let suiteName = "test-onboarding-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: "isOnboardingComplete")
+        let onboardingRepo = UserDefaultsOnboardingRepository(defaults: defaults)
+
+        let auth0Config = Auth0Config(clientId: "test-client-id", domain: "test.uk.auth0.com")
+        let authService = Auth0AuthenticationService(config: auth0Config)
+        let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
+        let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
+
+        let coordinator = AppCoordinator(
+            repository: APIPlanningApplicationRepository(apiClient: apiClient),
+            authService: authService,
+            subscriptionService: StoreKitSubscriptionService(),
+            geocoder: APIPostcodeGeocoder(apiClient: apiClient),
+            watchZoneRepository: APIWatchZoneRepository(apiClient: apiClient),
+            onboardingRepository: onboardingRepo,
+            appVersionProvider: BundleAppVersionProvider(),
+            versionConfigService: APIVersionConfigService(baseURL: apiBaseURL)
+        )
+
+        #expect(coordinator.isOnboardingComplete)
+    }
+
     @Test func metricKitCrashReporterInitialises() {
         let reporter = MetricKitCrashReporter()
         reporter.start()

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -84,6 +84,34 @@ struct CompositionRootTests {
         #expect(coordinator.isOnboardingComplete)
     }
 
+    @Test func offlineAwareRepositoryWiresWithConcreteTypes() throws {
+        let auth0Config = Auth0Config(clientId: "test-client-id", domain: "test.uk.auth0.com")
+        let authService = Auth0AuthenticationService(config: auth0Config)
+        let apiBaseURL = try #require(URL(string: "https://api.towncrierapp.uk"))
+        let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
+        let repository = APIPlanningApplicationRepository(apiClient: apiClient)
+        let connectivity = NWPathConnectivityMonitor()
+        let cache = InMemoryApplicationCacheStore()
+        let offlineRepository = OfflineAwareRepository(
+            remote: repository,
+            cache: cache,
+            connectivity: connectivity
+        )
+
+        let coordinator = AppCoordinator(
+            repository: repository,
+            authService: authService,
+            subscriptionService: StoreKitSubscriptionService(),
+            offlineRepository: offlineRepository,
+            geocoder: APIPostcodeGeocoder(apiClient: apiClient),
+            onboardingRepository: UserDefaultsOnboardingRepository(),
+            appVersionProvider: BundleAppVersionProvider(),
+            versionConfigService: APIVersionConfigService(baseURL: apiBaseURL)
+        )
+
+        #expect(coordinator.detailApplication == nil)
+    }
+
     @Test func metricKitCrashReporterInitialises() {
         let reporter = MetricKitCrashReporter()
         reporter.start()

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -18,6 +18,7 @@ struct CompositionRootTests {
         let authService = Auth0AuthenticationService(config: auth0Config)
         let subscriptionService = StoreKitSubscriptionService()
         let appVersionProvider = BundleAppVersionProvider()
+        // swiftlint:disable:next force_unwrapping
         let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
         let versionConfigService = APIVersionConfigService(baseURL: apiBaseURL)
         let onboardingRepository = UserDefaultsOnboardingRepository()
@@ -59,6 +60,7 @@ struct CompositionRootTests {
 
     @Test func coordinatorReportsOnboardingStateFromConcreteRepository() {
         let suiteName = "test-onboarding-\(UUID().uuidString)"
+        // swiftlint:disable:next force_unwrapping
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
 
@@ -67,6 +69,7 @@ struct CompositionRootTests {
 
         let auth0Config = Auth0Config(clientId: "test-client-id", domain: "test.uk.auth0.com")
         let authService = Auth0AuthenticationService(config: auth0Config)
+        // swiftlint:disable:next force_unwrapping
         let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
         let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
 
@@ -122,6 +125,7 @@ struct CompositionRootTests {
     private func makeCoordinator() -> AppCoordinator {
         let auth0Config = Auth0Config(clientId: "test-client-id", domain: "test.uk.auth0.com")
         let authService = Auth0AuthenticationService(config: auth0Config)
+        // swiftlint:disable:next force_unwrapping
         let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
         let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
         return AppCoordinator(

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -14,7 +14,6 @@ import TownCrierDomain
 struct CompositionRootTests {
 
     @Test func allConcreteDependenciesInitialise() {
-        let repository = InMemoryPlanningApplicationRepository()
         let auth0Config = Auth0Config(clientId: "test-client-id", domain: "test.uk.auth0.com")
         let authService = Auth0AuthenticationService(config: auth0Config)
         let subscriptionService = StoreKitSubscriptionService()
@@ -23,6 +22,7 @@ struct CompositionRootTests {
         let versionConfigService = APIVersionConfigService(baseURL: apiBaseURL)
         let onboardingRepository = UserDefaultsOnboardingRepository()
         let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
+        let repository = APIPlanningApplicationRepository(apiClient: apiClient)
         let geocoder = APIPostcodeGeocoder(apiClient: apiClient)
 
         let coordinator = AppCoordinator(
@@ -65,7 +65,7 @@ struct CompositionRootTests {
         let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
         let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
         return AppCoordinator(
-            repository: InMemoryPlanningApplicationRepository(),
+            repository: APIPlanningApplicationRepository(apiClient: apiClient),
             authService: authService,
             subscriptionService: StoreKitSubscriptionService(),
             geocoder: APIPostcodeGeocoder(apiClient: apiClient),

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 import TownCrierData
 import TownCrierDomain
@@ -18,12 +19,15 @@ struct CompositionRootTests {
         let authService = Auth0AuthenticationService(config: auth0Config)
         let subscriptionService = StoreKitSubscriptionService()
         let appVersionProvider = BundleAppVersionProvider()
-        let versionConfigService = StubVersionConfigService()
+        let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
+        let versionConfigService = APIVersionConfigService(baseURL: apiBaseURL)
+        let onboardingRepository = UserDefaultsOnboardingRepository()
 
         let coordinator = AppCoordinator(
             repository: repository,
             authService: authService,
             subscriptionService: subscriptionService,
+            onboardingRepository: onboardingRepository,
             appVersionProvider: appVersionProvider,
             versionConfigService: versionConfigService
         )
@@ -54,12 +58,14 @@ struct CompositionRootTests {
 
     private func makeCoordinator() -> AppCoordinator {
         let auth0Config = Auth0Config(clientId: "test-client-id", domain: "test.uk.auth0.com")
+        let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
         return AppCoordinator(
             repository: InMemoryPlanningApplicationRepository(),
             authService: Auth0AuthenticationService(config: auth0Config),
             subscriptionService: StoreKitSubscriptionService(),
+            onboardingRepository: UserDefaultsOnboardingRepository(),
             appVersionProvider: BundleAppVersionProvider(),
-            versionConfigService: StubVersionConfigService()
+            versionConfigService: APIVersionConfigService(baseURL: apiBaseURL)
         )
     }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -22,11 +22,14 @@ struct CompositionRootTests {
         let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
         let versionConfigService = APIVersionConfigService(baseURL: apiBaseURL)
         let onboardingRepository = UserDefaultsOnboardingRepository()
+        let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
+        let geocoder = APIPostcodeGeocoder(apiClient: apiClient)
 
         let coordinator = AppCoordinator(
             repository: repository,
             authService: authService,
             subscriptionService: subscriptionService,
+            geocoder: geocoder,
             onboardingRepository: onboardingRepository,
             appVersionProvider: appVersionProvider,
             versionConfigService: versionConfigService
@@ -58,11 +61,14 @@ struct CompositionRootTests {
 
     private func makeCoordinator() -> AppCoordinator {
         let auth0Config = Auth0Config(clientId: "test-client-id", domain: "test.uk.auth0.com")
+        let authService = Auth0AuthenticationService(config: auth0Config)
         let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
+        let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
         return AppCoordinator(
             repository: InMemoryPlanningApplicationRepository(),
-            authService: Auth0AuthenticationService(config: auth0Config),
+            authService: authService,
             subscriptionService: StoreKitSubscriptionService(),
+            geocoder: APIPostcodeGeocoder(apiClient: apiClient),
             onboardingRepository: UserDefaultsOnboardingRepository(),
             appVersionProvider: BundleAppVersionProvider(),
             versionConfigService: APIVersionConfigService(baseURL: apiBaseURL)

--- a/mobile/ios/town-crier-tests/Sources/Features/SettingsViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SettingsViewModelTests.swift
@@ -12,7 +12,7 @@ struct SettingsViewModelTests {
         entitlement: SubscriptionEntitlement? = nil,
         version: String = "1.0.0",
         buildNumber: String = "42"
-    ) -> (SettingsViewModel, SpyAuthenticationService, SpySubscriptionService, SpyAppVersionProvider) {
+    ) -> (SettingsViewModel, SpyAuthenticationService, SpySubscriptionService, SpyAppVersionProvider, SpyNotificationService) {
         let authSpy = SpyAuthenticationService()
         authSpy.currentSessionResult = session
         let subscriptionSpy = SpySubscriptionService()
@@ -20,18 +20,20 @@ struct SettingsViewModelTests {
         let versionProvider = SpyAppVersionProvider()
         versionProvider.version = version
         versionProvider.buildNumber = buildNumber
+        let notificationSpy = SpyNotificationService()
         let vm = SettingsViewModel(
             authService: authSpy,
             subscriptionService: subscriptionSpy,
-            appVersionProvider: versionProvider
+            appVersionProvider: versionProvider,
+            notificationService: notificationSpy
         )
-        return (vm, authSpy, subscriptionSpy, versionProvider)
+        return (vm, authSpy, subscriptionSpy, versionProvider, notificationSpy)
     }
 
     // MARK: - Loading
 
     @Test func load_populatesUserEmailFromSession() async {
-        let (sut, _, _, _) = makeSUT(session: .valid)
+        let (sut, _, _, _, _) = makeSUT(session: .valid)
 
         await sut.load()
 
@@ -39,7 +41,7 @@ struct SettingsViewModelTests {
     }
 
     @Test func load_populatesUserNameFromSession() async {
-        let (sut, _, _, _) = makeSUT(session: .valid)
+        let (sut, _, _, _, _) = makeSUT(session: .valid)
 
         await sut.load()
 
@@ -47,7 +49,7 @@ struct SettingsViewModelTests {
     }
 
     @Test func load_populatesAuthMethodFromSession() async {
-        let (sut, _, _, _) = makeSUT(session: .valid)
+        let (sut, _, _, _, _) = makeSUT(session: .valid)
 
         await sut.load()
 
@@ -55,7 +57,7 @@ struct SettingsViewModelTests {
     }
 
     @Test func load_noSession_leavesUserFieldsNil() async {
-        let (sut, _, _, _) = makeSUT(session: nil)
+        let (sut, _, _, _, _) = makeSUT(session: nil)
 
         await sut.load()
 
@@ -65,7 +67,7 @@ struct SettingsViewModelTests {
     }
 
     @Test func load_populatesSubscriptionTier() async {
-        let (sut, _, _, _) = makeSUT(entitlement: .personalActive)
+        let (sut, _, _, _, _) = makeSUT(entitlement: .personalActive)
 
         await sut.load()
 
@@ -73,7 +75,7 @@ struct SettingsViewModelTests {
     }
 
     @Test func load_noEntitlement_showsFreeTier() async {
-        let (sut, _, _, _) = makeSUT(entitlement: nil)
+        let (sut, _, _, _, _) = makeSUT(entitlement: nil)
 
         await sut.load()
 
@@ -81,7 +83,7 @@ struct SettingsViewModelTests {
     }
 
     @Test func load_trialEntitlement_showsTrialFlag() async {
-        let (sut, _, _, _) = makeSUT(entitlement: .personalTrial)
+        let (sut, _, _, _, _) = makeSUT(entitlement: .personalTrial)
 
         await sut.load()
 
@@ -91,7 +93,7 @@ struct SettingsViewModelTests {
     // MARK: - App Version
 
     @Test func appVersion_returnsVersionFromProvider() {
-        let (sut, _, _, _) = makeSUT(version: "2.1.0", buildNumber: "99")
+        let (sut, _, _, _, _) = makeSUT(version: "2.1.0", buildNumber: "99")
 
         #expect(sut.appVersion == "2.1.0 (99)")
     }
@@ -99,7 +101,7 @@ struct SettingsViewModelTests {
     // MARK: - Logout
 
     @Test func logout_callsAuthService() async {
-        let (sut, authSpy, _, _) = makeSUT()
+        let (sut, authSpy, _, _, _) = makeSUT()
 
         await sut.logout()
 
@@ -107,7 +109,7 @@ struct SettingsViewModelTests {
     }
 
     @Test func logout_clearsSession() async {
-        let (sut, _, _, _) = makeSUT()
+        let (sut, _, _, _, _) = makeSUT()
         await sut.load()
         #expect(sut.userEmail != nil)
 
@@ -118,7 +120,7 @@ struct SettingsViewModelTests {
 
     @Test func logout_notifiesCoordinator() async {
         var logoutCalled = false
-        let (sut, _, _, _) = makeSUT()
+        let (sut, _, _, _, _) = makeSUT()
         sut.onLogout = { logoutCalled = true }
 
         await sut.logout()
@@ -127,7 +129,7 @@ struct SettingsViewModelTests {
     }
 
     @Test func logout_setsErrorOnFailure() async {
-        let (sut, authSpy, _, _) = makeSUT()
+        let (sut, authSpy, _, _, _) = makeSUT()
         authSpy.logoutResult = .failure(DomainError.logoutFailed("network"))
 
         await sut.logout()
@@ -138,7 +140,7 @@ struct SettingsViewModelTests {
     // MARK: - Account Deletion
 
     @Test func deleteAccount_requiresConfirmation() async {
-        let (sut, authSpy, _, _) = makeSUT()
+        let (sut, authSpy, _, _, _) = makeSUT()
 
         #expect(!sut.isShowingDeleteConfirmation)
 
@@ -149,7 +151,7 @@ struct SettingsViewModelTests {
     }
 
     @Test func confirmDeleteAccount_callsAuthService() async {
-        let (sut, authSpy, _, _) = makeSUT()
+        let (sut, authSpy, _, _, _) = makeSUT()
         sut.requestAccountDeletion()
 
         await sut.confirmDeleteAccount()
@@ -159,7 +161,7 @@ struct SettingsViewModelTests {
 
     @Test func confirmDeleteAccount_clearsSessionAndNotifies() async {
         var logoutCalled = false
-        let (sut, _, _, _) = makeSUT()
+        let (sut, _, _, _, _) = makeSUT()
         sut.onLogout = { logoutCalled = true }
         await sut.load()
         sut.requestAccountDeletion()
@@ -171,7 +173,7 @@ struct SettingsViewModelTests {
     }
 
     @Test func confirmDeleteAccount_setsErrorOnFailure() async {
-        let (sut, authSpy, _, _) = makeSUT()
+        let (sut, authSpy, _, _, _) = makeSUT()
         authSpy.deleteAccountResult = .failure(DomainError.unexpected("deletion failed"))
         sut.requestAccountDeletion()
 
@@ -181,7 +183,7 @@ struct SettingsViewModelTests {
     }
 
     @Test func cancelDeletion_dismissesConfirmation() {
-        let (sut, _, _, _) = makeSUT()
+        let (sut, _, _, _, _) = makeSUT()
         sut.requestAccountDeletion()
         #expect(sut.isShowingDeleteConfirmation)
 
@@ -190,10 +192,41 @@ struct SettingsViewModelTests {
         #expect(!sut.isShowingDeleteConfirmation)
     }
 
+    // MARK: - Device Token Removal on Logout
+
+    @Test func logout_callsRemoveDeviceToken() async {
+        let (sut, _, _, _, notificationSpy) = makeSUT()
+
+        await sut.logout()
+
+        #expect(notificationSpy.removeDeviceTokenCallCount == 1)
+    }
+
+    @Test func logout_succeedsWhenDeviceTokenRemovalFails() async {
+        var logoutCalled = false
+        let (sut, _, _, _, notificationSpy) = makeSUT()
+        notificationSpy.removeDeviceTokenResult = .failure(DomainError.networkUnavailable)
+        sut.onLogout = { logoutCalled = true }
+
+        await sut.logout()
+
+        #expect(logoutCalled)
+        #expect(sut.error == nil)
+    }
+
+    @Test func confirmDeleteAccount_callsRemoveDeviceToken() async {
+        let (sut, _, _, _, notificationSpy) = makeSUT()
+        sut.requestAccountDeletion()
+
+        await sut.confirmDeleteAccount()
+
+        #expect(notificationSpy.removeDeviceTokenCallCount == 1)
+    }
+
     // MARK: - Attribution
 
     @Test func attributionItems_containsExpectedSources() {
-        let (sut, _, _, _) = makeSUT()
+        let (sut, _, _, _, _) = makeSUT()
 
         let items = sut.attributionItems
         #expect(items.count == 4)

--- a/mobile/ios/town-crier-tests/Sources/Features/SettingsViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SettingsViewModelTests.swift
@@ -12,7 +12,10 @@ struct SettingsViewModelTests {
         entitlement: SubscriptionEntitlement? = nil,
         version: String = "1.0.0",
         buildNumber: String = "42"
-    ) -> (SettingsViewModel, SpyAuthenticationService, SpySubscriptionService, SpyAppVersionProvider, SpyNotificationService) {
+    ) -> (
+        SettingsViewModel, SpyAuthenticationService, SpySubscriptionService,
+        SpyAppVersionProvider, SpyNotificationService
+    ) {
         let authSpy = SpyAuthenticationService()
         authSpy.currentSessionResult = session
         let subscriptionSpy = SpySubscriptionService()

--- a/mobile/ios/town-crier-tests/Sources/Features/URLSessionAPIClientTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/URLSessionAPIClientTests.swift
@@ -14,11 +14,11 @@ private struct TestBody: Codable, Sendable {
     let title: String
 }
 
-
 // MARK: - Tests
 
 @Suite("URLSessionAPIClient")
 struct URLSessionAPIClientTests {
+    // swiftlint:disable:next force_unwrapping
     private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
 
     // MARK: - Authenticated requests
@@ -290,7 +290,7 @@ struct URLSessionAPIClientTests {
         let _: TestResponse = try await sut.request(endpoint)
 
         let url = try #require(transport.requests[0].url)
-        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
         let queryItems = try #require(components.queryItems)
         #expect(queryItems.contains(URLQueryItem(name: "authority", value: "camden")))
         #expect(queryItems.contains(URLQueryItem(name: "status", value: "pending")))

--- a/mobile/ios/town-crier-tests/Sources/Features/URLSessionAPIClientTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/URLSessionAPIClientTests.swift
@@ -1,0 +1,318 @@
+import Foundation
+import Testing
+import TownCrierData
+import TownCrierDomain
+
+// MARK: - Test helpers
+
+private struct TestResponse: Decodable, Equatable, Sendable {
+    let id: String
+    let name: String
+}
+
+private struct TestBody: Codable, Sendable {
+    let title: String
+}
+
+/// Stub transport that records requests and returns preconfigured responses.
+private final class StubHTTPTransport: HTTPTransport, @unchecked Sendable {
+    var responses: [(Data, URLResponse)] = []
+    private var callIndex = 0
+    private(set) var requests: [URLRequest] = []
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        requests.append(request)
+        guard callIndex < responses.count else {
+            throw URLError(.badServerResponse)
+        }
+        let response = responses[callIndex]
+        callIndex += 1
+        return response
+    }
+}
+
+private func httpResponse(url: URL, statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+}
+
+// MARK: - Tests
+
+@Suite("URLSessionAPIClient")
+struct URLSessionAPIClientTests {
+    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
+
+    // MARK: - Authenticated requests
+
+    @Test("GET request includes Bearer token from current session")
+    func getRequestIncludesBearerToken() async throws {
+        let transport = StubHTTPTransport()
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+
+        let json = #"{"id":"1","name":"Test"}"#
+        transport.responses = [
+            (Data(json.utf8), httpResponse(url: baseURL, statusCode: 200)),
+        ]
+
+        let sut = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+
+        let _: TestResponse = try await sut.request(.get("/applications"))
+
+        #expect(transport.requests.count == 1)
+        let request = transport.requests[0]
+        #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-access-token")
+        #expect(request.url?.absoluteString == "https://api.dev.towncrierapp.uk/applications")
+        #expect(request.httpMethod == "GET")
+    }
+
+    // MARK: - JSON decoding
+
+    @Test("Successful JSON response is decoded to expected type")
+    func successfulJsonDecoding() async throws {
+        let transport = StubHTTPTransport()
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+
+        let json = #"{"id":"42","name":"Extension"}"#
+        transport.responses = [
+            (Data(json.utf8), httpResponse(url: baseURL, statusCode: 200)),
+        ]
+
+        let sut = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+
+        let result: TestResponse = try await sut.request(.get("/applications"))
+
+        #expect(result == TestResponse(id: "42", name: "Extension"))
+    }
+
+    // MARK: - Token refresh on 401
+
+    @Test("On 401, refreshes session and retries the request")
+    func refreshesOnUnauthorized() async throws {
+        let transport = StubHTTPTransport()
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+        authService.refreshSessionResult = .success(.valid)
+
+        let json = #"{"id":"1","name":"Test"}"#
+        transport.responses = [
+            (Data(), httpResponse(url: baseURL, statusCode: 401)),
+            (Data(json.utf8), httpResponse(url: baseURL, statusCode: 200)),
+        ]
+
+        let sut = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+
+        let result: TestResponse = try await sut.request(.get("/applications"))
+
+        #expect(result == TestResponse(id: "1", name: "Test"))
+        #expect(authService.refreshSessionCallCount == 1)
+        #expect(transport.requests.count == 2)
+    }
+
+    @Test("On 401 when refresh fails, throws sessionExpired")
+    func sessionExpiredWhenRefreshFails() async throws {
+        let transport = StubHTTPTransport()
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+        authService.refreshSessionResult = .failure(DomainError.sessionExpired)
+
+        transport.responses = [
+            (Data(), httpResponse(url: baseURL, statusCode: 401)),
+        ]
+
+        let sut = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+
+        await #expect(throws: DomainError.sessionExpired) {
+            let _: TestResponse = try await sut.request(.get("/applications"))
+        }
+    }
+
+    // MARK: - No session (unauthenticated)
+
+    @Test("When no session exists, throws sessionExpired")
+    func noSessionThrowsSessionExpired() async throws {
+        let transport = StubHTTPTransport()
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = nil
+
+        let sut = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+
+        await #expect(throws: DomainError.sessionExpired) {
+            let _: TestResponse = try await sut.request(.get("/applications"))
+        }
+    }
+
+    // MARK: - HTTP error mapping
+
+    @Test("404 response throws APIError.notFound")
+    func notFoundResponse() async throws {
+        let transport = StubHTTPTransport()
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+
+        transport.responses = [
+            (Data(), httpResponse(url: baseURL, statusCode: 404)),
+        ]
+
+        let sut = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+
+        await #expect(throws: APIError.self) {
+            let _: TestResponse = try await sut.request(.get("/applications/999"))
+        }
+    }
+
+    @Test("500 response throws APIError.serverError")
+    func serverErrorResponse() async throws {
+        let transport = StubHTTPTransport()
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+
+        transport.responses = [
+            (Data(), httpResponse(url: baseURL, statusCode: 500)),
+        ]
+
+        let sut = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+
+        await #expect(throws: APIError.self) {
+            let _: TestResponse = try await sut.request(.get("/applications"))
+        }
+    }
+
+    // MARK: - Network errors
+
+    @Test("Network error maps to DomainError.networkUnavailable")
+    func networkErrorMapping() async throws {
+        let transport = StubHTTPTransport()
+        transport.responses = [] // will throw URLError
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+
+        let sut = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+
+        await #expect(throws: DomainError.networkUnavailable) {
+            let _: TestResponse = try await sut.request(.get("/applications"))
+        }
+    }
+
+    // MARK: - POST with body
+
+    @Test("POST request encodes body as JSON")
+    func postRequestEncodesBody() async throws {
+        let transport = StubHTTPTransport()
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+
+        let json = #"{"id":"new","name":"Created"}"#
+        transport.responses = [
+            (Data(json.utf8), httpResponse(url: baseURL, statusCode: 201)),
+        ]
+
+        let sut = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+
+        let body = TestBody(title: "New Application")
+        let result: TestResponse = try await sut.request(.post("/applications", body: body))
+
+        #expect(result == TestResponse(id: "new", name: "Created"))
+        let request = transport.requests[0]
+        #expect(request.httpMethod == "POST")
+        #expect(request.value(forHTTPHeaderField: "Content-Type") == "application/json")
+
+        let sentBody = try #require(request.httpBody)
+        let decoded = try JSONDecoder().decode(TestBody.self, from: sentBody)
+        #expect(decoded.title == "New Application")
+    }
+
+    // MARK: - DELETE with no response body
+
+    @Test("DELETE request sends correct method and path")
+    func deleteRequest() async throws {
+        let transport = StubHTTPTransport()
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+
+        transport.responses = [
+            (Data("{}".utf8), httpResponse(url: baseURL, statusCode: 204)),
+        ]
+
+        let sut = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+
+        let _: EmptyResponse = try await sut.request(.delete("/watch-zones/123"))
+
+        let request = transport.requests[0]
+        #expect(request.httpMethod == "DELETE")
+        #expect(request.url?.path() == "/watch-zones/123")
+    }
+
+    // MARK: - Query parameters
+
+    @Test("Request includes query parameters in URL")
+    func queryParameters() async throws {
+        let transport = StubHTTPTransport()
+        let authService = SpyAuthenticationService()
+        authService.currentSessionResult = .valid
+
+        let json = #"{"id":"1","name":"Test"}"#
+        transport.responses = [
+            (Data(json.utf8), httpResponse(url: baseURL, statusCode: 200)),
+        ]
+
+        let sut = URLSessionAPIClient(
+            baseURL: baseURL,
+            authService: authService,
+            transport: transport
+        )
+
+        let endpoint = APIEndpoint.get("/applications", query: [
+            URLQueryItem(name: "authority", value: "camden"),
+            URLQueryItem(name: "status", value: "pending"),
+        ])
+
+        let _: TestResponse = try await sut.request(endpoint)
+
+        let url = try #require(transport.requests[0].url)
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        let queryItems = try #require(components.queryItems)
+        #expect(queryItems.contains(URLQueryItem(name: "authority", value: "camden")))
+        #expect(queryItems.contains(URLQueryItem(name: "status", value: "pending")))
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/URLSessionAPIClientTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/URLSessionAPIClientTests.swift
@@ -14,26 +14,6 @@ private struct TestBody: Codable, Sendable {
     let title: String
 }
 
-/// Stub transport that records requests and returns preconfigured responses.
-private final class StubHTTPTransport: HTTPTransport, @unchecked Sendable {
-    var responses: [(Data, URLResponse)] = []
-    private var callIndex = 0
-    private(set) var requests: [URLRequest] = []
-
-    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-        requests.append(request)
-        guard callIndex < responses.count else {
-            throw URLError(.badServerResponse)
-        }
-        let response = responses[callIndex]
-        callIndex += 1
-        return response
-    }
-}
-
-private func httpResponse(url: URL, statusCode: Int) -> HTTPURLResponse {
-    HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
-}
 
 // MARK: - Tests
 

--- a/mobile/ios/town-crier-tests/Sources/Features/UserDefaultsOnboardingRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/UserDefaultsOnboardingRepositoryTests.swift
@@ -4,22 +4,22 @@ import TownCrierData
 
 @Suite("UserDefaultsOnboardingRepository")
 struct UserDefaultsOnboardingRepositoryTests {
-    private func makeSUT() -> (UserDefaultsOnboardingRepository, UserDefaults) {
-        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    private func makeSUT() throws -> (UserDefaultsOnboardingRepository, UserDefaults) {
+        let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
         let sut = UserDefaultsOnboardingRepository(defaults: defaults)
         return (sut, defaults)
     }
 
     @Test("isOnboardingComplete defaults to false")
-    func defaultsToFalse() {
-        let (sut, _) = makeSUT()
+    func defaultsToFalse() throws {
+        let (sut, _) = try makeSUT()
 
         #expect(!sut.isOnboardingComplete)
     }
 
     @Test("markOnboardingComplete sets isOnboardingComplete to true")
-    func markCompleteSetsTrueFlag() {
-        let (sut, _) = makeSUT()
+    func markCompleteSetsTrueFlag() throws {
+        let (sut, _) = try makeSUT()
 
         sut.markOnboardingComplete()
 
@@ -27,8 +27,8 @@ struct UserDefaultsOnboardingRepositoryTests {
     }
 
     @Test("isOnboardingComplete reads from UserDefaults")
-    func readsFromUserDefaults() {
-        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+    func readsFromUserDefaults() throws {
+        let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
         defaults.set(true, forKey: "isOnboardingComplete")
         let sut = UserDefaultsOnboardingRepository(defaults: defaults)
 
@@ -36,8 +36,8 @@ struct UserDefaultsOnboardingRepositoryTests {
     }
 
     @Test("markOnboardingComplete persists to UserDefaults")
-    func persistsToUserDefaults() {
-        let (sut, defaults) = makeSUT()
+    func persistsToUserDefaults() throws {
+        let (sut, defaults) = try makeSUT()
 
         sut.markOnboardingComplete()
 

--- a/mobile/ios/town-crier-tests/Sources/Features/UserDefaultsOnboardingRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/UserDefaultsOnboardingRepositoryTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+import TownCrierData
+
+@Suite("UserDefaultsOnboardingRepository")
+struct UserDefaultsOnboardingRepositoryTests {
+    private func makeSUT() -> (UserDefaultsOnboardingRepository, UserDefaults) {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        let sut = UserDefaultsOnboardingRepository(defaults: defaults)
+        return (sut, defaults)
+    }
+
+    @Test("isOnboardingComplete defaults to false")
+    func defaultsToFalse() {
+        let (sut, _) = makeSUT()
+
+        #expect(!sut.isOnboardingComplete)
+    }
+
+    @Test("markOnboardingComplete sets isOnboardingComplete to true")
+    func markCompleteSetsTrueFlag() {
+        let (sut, _) = makeSUT()
+
+        sut.markOnboardingComplete()
+
+        #expect(sut.isOnboardingComplete)
+    }
+
+    @Test("isOnboardingComplete reads from UserDefaults")
+    func readsFromUserDefaults() {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        defaults.set(true, forKey: "isOnboardingComplete")
+        let sut = UserDefaultsOnboardingRepository(defaults: defaults)
+
+        #expect(sut.isOnboardingComplete)
+    }
+
+    @Test("markOnboardingComplete persists to UserDefaults")
+    func persistsToUserDefaults() {
+        let (sut, defaults) = makeSUT()
+
+        sut.markOnboardingComplete()
+
+        #expect(defaults.bool(forKey: "isOnboardingComplete"))
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelTests.swift
@@ -165,9 +165,9 @@ struct WatchZoneEditorEditTests {
         #expect(saved?.id == WatchZoneId("zone-001"))
     }
 
-    @Test func submitPostcode_updatesCoordinateForNewPostcode() async {
+    @Test func submitPostcode_updatesCoordinateForNewPostcode() async throws {
         sut.postcodeInput = "SW1A 1AA"
-        let london = try! Coordinate(latitude: 51.5014, longitude: -0.1419)
+        let london = try Coordinate(latitude: 51.5014, longitude: -0.1419)
         spyGeocoder.geocodeResult = .success(london)
 
         await sut.submitPostcode()

--- a/mobile/ios/town-crier-tests/Sources/Fixtures/PlanningApplication+Fixtures.swift
+++ b/mobile/ios/town-crier-tests/Sources/Fixtures/PlanningApplication+Fixtures.swift
@@ -1,6 +1,8 @@
 import Foundation
 import TownCrierDomain
 
+// swiftlint:disable force_try
+
 extension PlanningApplication {
     static let pendingReview = PlanningApplication(
         id: PlanningApplicationId("APP-001"),

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyNotificationPermissionProvider.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyNotificationPermissionProvider.swift
@@ -1,0 +1,12 @@
+import Foundation
+import TownCrierDomain
+
+final class SpyNotificationPermissionProvider: NotificationPermissionProvider, @unchecked Sendable {
+    private(set) var requestPermissionCallCount = 0
+    var requestPermissionResult: Result<Bool, Error> = .success(true)
+
+    func requestPermission() async throws -> Bool {
+        requestPermissionCallCount += 1
+        return try requestPermissionResult.get()
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyNotificationService.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyNotificationService.swift
@@ -9,4 +9,20 @@ final class SpyNotificationService: NotificationService, @unchecked Sendable {
         requestPermissionCallCount += 1
         return try requestPermissionResult.get()
     }
+
+    private(set) var registerDeviceTokenCalls: [String] = []
+    var registerDeviceTokenResult: Result<Void, Error> = .success(())
+
+    func registerDeviceToken(_ token: String) async throws {
+        registerDeviceTokenCalls.append(token)
+        try registerDeviceTokenResult.get()
+    }
+
+    private(set) var removeDeviceTokenCallCount = 0
+    var removeDeviceTokenResult: Result<Void, Error> = .success(())
+
+    func removeDeviceToken() async throws {
+        removeDeviceTokenCallCount += 1
+        try removeDeviceTokenResult.get()
+    }
 }

--- a/mobile/ios/town-crier-tests/Sources/Spies/StubHTTPTransport.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/StubHTTPTransport.swift
@@ -21,5 +21,6 @@ final class StubHTTPTransport: HTTPTransport, @unchecked Sendable {
 }
 
 func httpResponse(url: URL, statusCode: Int) -> HTTPURLResponse {
+    // swiftlint:disable:next force_unwrapping
     HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
 }

--- a/mobile/ios/town-crier-tests/Sources/Spies/StubHTTPTransport.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/StubHTTPTransport.swift
@@ -1,0 +1,25 @@
+import Foundation
+import TownCrierData
+
+/// Stub transport that records requests and returns preconfigured responses.
+final class StubHTTPTransport: HTTPTransport, @unchecked Sendable {
+    var responses: [(Data, URLResponse)] = []
+    private var callIndex = 0
+    private(set) var requests: [URLRequest] = []
+    var error: (any Error)?
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        requests.append(request)
+        if let error { throw error }
+        guard callIndex < responses.count else {
+            throw URLError(.badServerResponse)
+        }
+        let response = responses[callIndex]
+        callIndex += 1
+        return response
+    }
+}
+
+func httpResponse(url: URL, statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+}


### PR DESCRIPTION
## Changes
- Add API HTTP client with Auth0 token injection
- Wire up device token registration via NotificationService
- Replace stub services with real VersionConfig and Onboarding implementations
- Implement APIPostcodeGeocoder backed by Town Crier API
- Add planning application read endpoints (by authority, by UID)
- Add watch zone CRUD API endpoints (create, list, delete)
- Add GET /v1/version-config endpoint
- Implement APIPlanningApplicationRepository backed by Town Crier API
- Make AuthorityId optional in CreateWatchZoneCommand
- Implement APIWatchZoneRepository backed by Town Crier API

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create, list and delete watch zones (authority auto-resolved from coordinates); postcode geocoding support.
  * Lookup planning applications by UID or by authority; anonymous app lookup endpoints.
  * Device token register/remove and composite notification support; Settings attempts token removal on logout/delete.
  * API version-config endpoint, onboarding persistence, mobile app wired to API backend with offline-aware repository.

* **Tests**
  * Expanded unit and integration tests covering applications, watch zones, geocoding, notifications, API client, version config, onboarding, and repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->