### PR TITLE
fix(ios): correct dev API URL to match deployed hostname

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/API/APIEnvironment.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/APIEnvironment.swift
@@ -5,7 +5,7 @@ public enum APIEnvironment: Equatable, Sendable {
     case production
 
     // swiftlint:disable:next force_unwrapping
-    private static let developmentURL = URL(string: "https://api.dev.towncrierapp.uk")!
+    private static let developmentURL = URL(string: "https://api-dev.towncrierapp.uk")!
     // swiftlint:disable:next force_unwrapping
     private static let productionURL = URL(string: "https://api.towncrierapp.uk")!
 

--- a/mobile/ios/town-crier-tests/Sources/Features/APIEnvironmentTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIEnvironmentTests.swift
@@ -8,7 +8,7 @@ struct APIEnvironmentTests {
     @Test func development_baseURL_pointsToDevDomain() {
         let sut = APIEnvironment.development
 
-        #expect(sut.baseURL.absoluteString == "https://api.dev.towncrierapp.uk")
+        #expect(sut.baseURL.absoluteString == "https://api-dev.towncrierapp.uk")
     }
 
     @Test func production_baseURL_pointsToProductionDomain() {


### PR DESCRIPTION
## Changes
- Fix iOS dev API URL from `api.dev.towncrierapp.uk` (dot-separated, no DNS record) to `api-dev.towncrierapp.uk` (hyphenated, matching the actual deployed Container App)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the development API endpoint configuration to ensure reliable backend connectivity during development and testing.
  * Updated automated tests to align with the corrected endpoint, improving confidence in local and CI validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->