### PR TITLE
fix(ios): update test mock URLs and add SwiftLint hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,12 @@
             "command": "jq -r '.tool_input.command' | grep -qE '^git\\s+push' && { branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$branch\" = \"main\" ]; then echo '{\"decision\":\"block\",\"reason\":\"You are on the main branch. Do NOT push directly to main. Instead: 1) Create a new feature branch with git checkout -b <descriptive-branch-name>, 2) Push that branch with git push -u origin <branch-name>, 3) Create a PR using gh pr create.\"}'; fi; } || true",
             "timeout": 10,
             "statusMessage": "Checking branch protection..."
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command' | grep -qE '^git\\s+commit' || exit 0; root=$(git rev-parse --show-toplevel); staged=$(git diff --cached --name-only -- '*.swift' | grep '^mobile/ios/' | sed \"s|^|$root/|\" || true); [ -z \"$staged\" ] && exit 0; lint=$(cd \"$root/mobile/ios\" && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swiftlint lint $staged --quiet 2>/dev/null | grep -E ':[0-9]+:[0-9]+: (error|warning):'); [ -z \"$lint\" ] && exit 0; jq -n --arg reason \"SwiftLint violations in staged files — fix before committing:\\n$lint\" '{\"decision\":\"block\",\"reason\":$reason}'",
+            "timeout": 30,
+            "statusMessage": "SwiftLint pre-commit check..."
           }
         ]
       }

--- a/mobile/ios/town-crier-tests/Sources/Features/APINotificationServiceTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APINotificationServiceTests.swift
@@ -6,7 +6,7 @@ import TownCrierDomain
 @Suite("APINotificationService")
 struct APINotificationServiceTests {
     // swiftlint:disable:next force_unwrapping
-    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
+    private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
 
     private func makeTransport(
         statusCode: Int = 204,

--- a/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryTests.swift
@@ -10,7 +10,7 @@ struct APIPlanningApplicationRepositoryTests {
     // MARK: - Helpers
 
     // swiftlint:disable:next force_unwrapping
-    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
+    private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
 
     private func makeSUT(
         responses: [(Data, URLResponse)]

--- a/mobile/ios/town-crier-tests/Sources/Features/APIPostcodeGeocoderTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIPostcodeGeocoderTests.swift
@@ -10,7 +10,7 @@ struct APIPostcodeGeocoderTests {
     // MARK: - Helpers
 
     // swiftlint:disable:next force_unwrapping
-    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
+    private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
 
     private func makeSUT(
         responses: [(Data, URLResponse)]

--- a/mobile/ios/town-crier-tests/Sources/Features/APIVersionConfigServiceTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIVersionConfigServiceTests.swift
@@ -6,7 +6,7 @@ import TownCrierDomain
 @Suite("APIVersionConfigService")
 struct APIVersionConfigServiceTests {
     // swiftlint:disable:next force_unwrapping
-    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
+    private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
 
     @Test("Sends GET request to /v1/version-config")
     func sendsGetToCorrectPath() async throws {

--- a/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryTests.swift
@@ -10,7 +10,7 @@ struct APIWatchZoneRepositoryTests {
     // MARK: - Helpers
 
     // swiftlint:disable:next force_unwrapping
-    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
+    private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
 
     private func makeSUT(
         responses: [(Data, URLResponse)]

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositeNotificationServiceTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositeNotificationServiceTests.swift
@@ -5,7 +5,7 @@ import TownCrierDomain
 
 @Suite("CompositeNotificationService")
 struct CompositeNotificationServiceTests {
-    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")
+    private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")
 
     private func makeSUT() throws -> (
         CompositeNotificationService, SpyNotificationPermissionProvider, StubHTTPTransport

--- a/mobile/ios/town-crier-tests/Sources/Features/URLSessionAPIClientTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/URLSessionAPIClientTests.swift
@@ -19,7 +19,7 @@ private struct TestBody: Codable, Sendable {
 @Suite("URLSessionAPIClient")
 struct URLSessionAPIClientTests {
     // swiftlint:disable:next force_unwrapping
-    private let baseURL = URL(string: "https://api.dev.towncrierapp.uk")!
+    private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
 
     // MARK: - Authenticated requests
 
@@ -45,7 +45,7 @@ struct URLSessionAPIClientTests {
         #expect(transport.requests.count == 1)
         let request = transport.requests[0]
         #expect(request.value(forHTTPHeaderField: "Authorization") == "Bearer test-access-token")
-        #expect(request.url?.absoluteString == "https://api.dev.towncrierapp.uk/applications")
+        #expect(request.url?.absoluteString == "https://api-dev.towncrierapp.uk/applications")
         #expect(request.httpMethod == "GET")
     }
 


### PR DESCRIPTION
## Changes
- Update 8 hardcoded `api.dev.towncrierapp.uk` mock URLs to `api-dev.towncrierapp.uk` across 7 iOS test files for consistency with `APIEnvironment.swift`
- Add SwiftLint pre-commit hook to Claude Code project settings

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated automated code quality checks into the development build process.
  * Updated development environment endpoint configurations.

* **Tests**
  * Corrected and standardized endpoint URLs used in service tests to ensure consistent behavior across test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->