### PR TITLE
feat: wire Cosmos DB managed identity and Auth0 audience

### DIFF
--- a/api/src/town-crier.infrastructure/Cosmos/CosmosClientFactory.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosClientFactory.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Azure.Core;
 using Microsoft.Azure.Cosmos;
 
 namespace TownCrier.Infrastructure.Cosmos;
@@ -8,18 +9,27 @@ public static class CosmosClientFactory
     public static CosmosClient Create(string connectionString)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        return new CosmosClient(connectionString, BuildOptions());
+    }
 
+    public static CosmosClient Create(string accountEndpoint, TokenCredential credential)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(accountEndpoint);
+        ArgumentNullException.ThrowIfNull(credential);
+        return new CosmosClient(accountEndpoint, credential, BuildOptions());
+    }
+
+    private static CosmosClientOptions BuildOptions()
+    {
         var jsonOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         };
         jsonOptions.TypeInfoResolverChain.Add(CosmosJsonSerializerContext.Default);
 
-        var cosmosOptions = new CosmosClientOptions
+        return new CosmosClientOptions
         {
             Serializer = new SystemTextJsonCosmosSerializer(jsonOptions),
         };
-
-        return new CosmosClient(connectionString, cosmosOptions);
     }
 }

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+using Azure.Identity;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,11 +11,21 @@ public static class CosmosServiceExtensions
     {
         services.AddSingleton(_ =>
         {
-            var connectionString = configuration.GetConnectionString("CosmosDb")
-                ?? throw new InvalidOperationException(
-                    "Cosmos DB connection string is required. Set 'ConnectionStrings:CosmosDb' in configuration.");
+            var accountEndpoint = configuration["Cosmos:AccountEndpoint"];
+            if (!string.IsNullOrWhiteSpace(accountEndpoint))
+            {
+                return CosmosClientFactory.Create(accountEndpoint, new DefaultAzureCredential());
+            }
 
-            return CosmosClientFactory.Create(connectionString);
+            var connectionString = configuration.GetConnectionString("CosmosDb");
+            if (!string.IsNullOrWhiteSpace(connectionString))
+            {
+                return CosmosClientFactory.Create(connectionString);
+            }
+
+            throw new InvalidOperationException(
+                "Cosmos DB is not configured. Set 'Cosmos:AccountEndpoint' (managed identity) "
+                + "or 'ConnectionStrings:CosmosDb' (connection string).");
         });
 
         return services;

--- a/api/src/town-crier.infrastructure/town-crier.infrastructure.csproj
+++ b/api/src/town-crier.infrastructure/town-crier.infrastructure.csproj
@@ -13,10 +13,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.19.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.58.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.0-preview.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0-preview.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0-preview.3.25171.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.*" />
     <!-- Required at runtime by Cosmos SDK v3 internals. Not used in our code — we use STJ
          via SystemTextJsonCosmosSerializer. AOT/trim warnings from this assembly are
          suppressed in the web project. -->

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -24,6 +24,8 @@ public static class EnvironmentStack
         var acrPullIdentityId = shared.GetOutput("acrPullIdentityId").Apply(o => o?.ToString() ?? "");
         var acrPullIdentityClientId = shared.GetOutput("acrPullIdentityClientId").Apply(o => o?.ToString() ?? "");
         var containerAppsEnvironmentId = shared.GetOutput("containerAppsEnvironmentId").Apply(o => o?.ToString() ?? "");
+        var cosmosDataIdentityId = shared.GetOutput("cosmosDataIdentityId").Apply(o => o?.ToString() ?? "");
+        var cosmosDataIdentityClientId = shared.GetOutput("cosmosDataIdentityClientId").Apply(o => o?.ToString() ?? "");
         var cosmosAccountName = shared.GetOutput("cosmosAccountName").Apply(o => o?.ToString() ?? "");
         var cosmosAccountEndpoint = shared.GetOutput("cosmosAccountEndpoint").Apply(o => o?.ToString() ?? "");
         // Extract the CAE name from its resource ID to avoid
@@ -346,6 +348,7 @@ public static class EnvironmentStack
                 UserAssignedIdentities = new InputList<string>
                 {
                     acrPullIdentityId,
+                    cosmosDataIdentityId,
                 },
             },
             Template = new TemplateArgs
@@ -365,6 +368,8 @@ public static class EnvironmentStack
                         {
                             new EnvironmentVarArgs { Name = "Auth0__Domain", Value = auth0Domain },
                             new EnvironmentVarArgs { Name = "Auth0__Audience", Value = auth0Audience },
+                            new EnvironmentVarArgs { Name = "Cosmos__AccountEndpoint", Value = cosmosAccountEndpoint },
+                            new EnvironmentVarArgs { Name = "AZURE_CLIENT_ID", Value = cosmosDataIdentityClientId },
                         },
                     },
                 },

--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -104,6 +104,14 @@ public static class SharedStack
             Tags = tags,
         });
 
+        // User-assigned managed identity for Cosmos DB data access
+        var cosmosDataIdentity = new UserAssignedIdentity("id-town-crier-cosmos-data", new UserAssignedIdentityArgs
+        {
+            ResourceName = "id-town-crier-cosmos-data",
+            ResourceGroupName = resourceGroup.Name,
+            Tags = tags,
+        });
+
         // Cosmos DB Account (shared across environments — serverless)
         var cosmosAccount = new DatabaseAccount("cosmos-town-crier-shared", new DatabaseAccountArgs
         {
@@ -130,12 +138,28 @@ public static class SharedStack
             Tags = tags,
         });
 
+        // Cosmos DB Built-in Data Contributor role — allows CRUD on documents.
+        // Role definition ID is well-known: 00000000-0000-0000-0000-000000000002.
+        // Scoped to the Cosmos account; environment-level isolation is via database name.
+        var cosmosRoleAssignment = new SqlResourceSqlRoleAssignment("cosmos-data-role", new SqlResourceSqlRoleAssignmentArgs
+        {
+            AccountName = cosmosAccount.Name,
+            ResourceGroupName = resourceGroup.Name,
+            RoleAssignmentId = "a3e0b382-7e3a-4b2d-9c4f-1a2b3c4d5e6f",
+            RoleDefinitionId = cosmosAccount.Id.Apply(id =>
+                $"{id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002"),
+            Scope = cosmosAccount.Id,
+            PrincipalId = cosmosDataIdentity.PrincipalId,
+        });
+
         return new Dictionary<string, object?>
         {
             ["resourceGroupName"] = resourceGroup.Name,
             ["containerRegistryLoginServer"] = containerRegistry.LoginServer,
             ["acrPullIdentityId"] = acrPullIdentity.Id,
             ["acrPullIdentityClientId"] = acrPullIdentity.ClientId,
+            ["cosmosDataIdentityId"] = cosmosDataIdentity.Id,
+            ["cosmosDataIdentityClientId"] = cosmosDataIdentity.ClientId,
             ["containerAppsEnvironmentId"] = containerAppsEnv.Id,
             ["cosmosAccountName"] = cosmosAccount.Name,
             ["cosmosAccountEndpoint"] = cosmosAccount.DocumentEndpoint,

--- a/mobile/ios/packages/town-crier-data/Sources/Auth/Auth0AuthenticationService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Auth/Auth0AuthenticationService.swift
@@ -9,10 +9,12 @@ import TownCrierDomain
 public struct Auth0Config: Sendable {
     public let clientId: String
     public let domain: String
+    public let audience: String
 
-    public init(clientId: String, domain: String) {
+    public init(clientId: String, domain: String, audience: String) {
         self.clientId = clientId
         self.domain = domain
+        self.audience = audience
     }
 }
 
@@ -35,6 +37,7 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
             let credentials = try await Auth0
                 .webAuth(clientId: config.clientId, domain: config.domain)
                 .scope("openid profile email offline_access")
+                .audience(config.audience)
                 .start()
 
             _ = credentialsManager.store(credentials: credentials)

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -18,7 +18,8 @@ struct TownCrierApp: App {
     init() {
         let auth0Config = Auth0Config(
             clientId: "a9O67fPgvXtqiWqwowhYjK0tvHF4hCMZ",
-            domain: "towncrierapp.uk.auth0.com"
+            domain: "towncrierapp.uk.auth0.com",
+            audience: APIEnvironment.current.baseURL.absoluteString
         )
 
         let authService = Auth0AuthenticationService(config: auth0Config)

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -14,7 +14,11 @@ import TownCrierDomain
 struct CompositionRootTests {
 
     @Test func allConcreteDependenciesInitialise() {
-        let auth0Config = Auth0Config(clientId: "test-client-id", domain: "test.uk.auth0.com")
+        let auth0Config = Auth0Config(
+            clientId: "test-client-id",
+            domain: "test.uk.auth0.com",
+            audience: "https://api-test.example.com"
+        )
         let authService = Auth0AuthenticationService(config: auth0Config)
         let subscriptionService = StoreKitSubscriptionService()
         let appVersionProvider = BundleAppVersionProvider()
@@ -67,7 +71,11 @@ struct CompositionRootTests {
         defaults.set(true, forKey: "isOnboardingComplete")
         let onboardingRepo = UserDefaultsOnboardingRepository(defaults: defaults)
 
-        let auth0Config = Auth0Config(clientId: "test-client-id", domain: "test.uk.auth0.com")
+        let auth0Config = Auth0Config(
+            clientId: "test-client-id",
+            domain: "test.uk.auth0.com",
+            audience: "https://api-test.example.com"
+        )
         let authService = Auth0AuthenticationService(config: auth0Config)
         // swiftlint:disable:next force_unwrapping
         let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
@@ -88,7 +96,11 @@ struct CompositionRootTests {
     }
 
     @Test func offlineAwareRepositoryWiresWithConcreteTypes() throws {
-        let auth0Config = Auth0Config(clientId: "test-client-id", domain: "test.uk.auth0.com")
+        let auth0Config = Auth0Config(
+            clientId: "test-client-id",
+            domain: "test.uk.auth0.com",
+            audience: "https://api-test.example.com"
+        )
         let authService = Auth0AuthenticationService(config: auth0Config)
         let apiBaseURL = try #require(URL(string: "https://api.towncrierapp.uk"))
         let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
@@ -123,7 +135,11 @@ struct CompositionRootTests {
     // MARK: - Helpers
 
     private func makeCoordinator() -> AppCoordinator {
-        let auth0Config = Auth0Config(clientId: "test-client-id", domain: "test.uk.auth0.com")
+        let auth0Config = Auth0Config(
+            clientId: "test-client-id",
+            domain: "test.uk.auth0.com",
+            audience: "https://api-test.example.com"
+        )
         let authService = Auth0AuthenticationService(config: auth0Config)
         // swiftlint:disable:next force_unwrapping
         let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!


### PR DESCRIPTION
## Changes
- **Infra**: Create `id-town-crier-cosmos-data` user-assigned managed identity with Cosmos DB Built-in Data Contributor SQL role assignment scoped to the shared Cosmos account
- **Infra**: Add `Cosmos__AccountEndpoint` and `AZURE_CLIENT_ID` env vars to Container App, attach new identity
- **API**: Add `Azure.Identity` package, update `CosmosClientFactory` with `TokenCredential` overload
- **API**: Update `CosmosServiceExtensions` to prefer `DefaultAzureCredential` (deployed) with connection string fallback (local dev/tests)
- **iOS**: Add `audience` parameter to Auth0 config so Auth0 issues JWT access tokens scoped to the API

## Context
The dev API was returning 500s because the Cosmos DB connection string was never wired into the Container App. Rather than adding a connection string, this switches to managed identity (user-assigned) for keyless auth. The iOS app was also missing the Auth0 audience parameter, causing opaque tokens that the API's JWT middleware rejected.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added managed identity authentication for secure Cosmos database access
  * Integrated Auth0 audience configuration in mobile authentication flow

* **Chores**
  * Updated Azure Identity and related dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->