### PR TITLE
docs(adr): audit — amend 0002, 0007, 0008, 0011; create 0014

### DIFF
--- a/.beads/push-state.json
+++ b/.beads/push-state.json
@@ -1,4 +1,4 @@
 {
-  "last_push": "2026-03-27T21:52:27Z",
-  "last_commit": "0oq75nl9qdo2r8fodmodq1vpltjg4aeh"
+  "last_push": "2026-03-27T22:00:55Z",
+  "last_commit": "scau53d4t7ifb84ugab0f34iinorgg10"
 }

--- a/docs/adr/0002-monorepo-structure.md
+++ b/docs/adr/0002-monorepo-structure.md
@@ -58,3 +58,9 @@ Located in `/infra`, utilizing **.NET 10 (C#)**:
     - `api/`: Source code for the .NET 10 backend API (including Dockerfile).
     - `infra/`: Pulumi infrastructure code (C#/.NET 10).
 - Project templates (sln, xcodeproj) must be configured to respect these internal structures.
+
+## Amendments
+
+### 2026-03-27
+- Updated: iOS test framework changed from XCTest to **Swift Testing** (`import Testing`, `@Suite`, `@Test`, `#expect()`). The `swift-testing` package (v0.99.0) is declared as an SPM dependency. Test doubles follow a spy/stub pattern with async support.
+- Updated: iOS data layer does not use **SwiftData**. Persistence uses `UserDefaults` for onboarding state and an `Actor`-based in-memory cache (`InMemoryApplicationCacheStore`) with TTL for offline support. No on-device database is currently in use.

--- a/docs/adr/0007-auth0-authentication.md
+++ b/docs/adr/0007-auth0-authentication.md
@@ -116,3 +116,9 @@ At Town Crier's projected growth rate, the 25K MAU ceiling is unlikely to be rea
 - **Free tier dependency** — if Auth0 changes pricing or removes free tier features, we must migrate or pay. Mitigated by low switching cost on the API side (standard JWT) and moderate cost on the iOS side (swap Auth0.swift for another SDK).
 - **Limited customisation on free plan** — no custom domains, limited Actions/Rules, basic email templates. Acceptable for MVP; revisit if branding requirements increase.
 - **No SLA on free tier** — Auth0 outages would prevent login. Mitigated by refresh token rotation (existing sessions survive short outages) and by the fact that planning data viewing could be made available without authentication in a degraded mode.
+
+## Amendments
+
+### 2026-03-27
+- Updated: Auth0 uses a **custom domain** (`towncrierapp.uk.auth0.com`) rather than separate default tenants (`town-crier-dev.auth0.com` / `town-crier-prod.auth0.com`). Dev and prod environments are differentiated by **API audience** (`https://api-dev.towncrierapp.uk` vs `https://api.towncrierapp.uk`), not by tenant.
+- Added: **Town Crier Web** application (type: SPA) registered in Auth0, using `@auth0/auth0-react` v2.16.0. The web app uses the same Auth0 domain and differentiates environments via audience. Auth integration follows a port/adapter pattern (`Auth0AuthAdapter` implements `AuthPort`) with `AuthGuard` and `OnboardingGate` route protection components.

--- a/docs/adr/0008-cosmos-db-data-model.md
+++ b/docs/adr/0008-cosmos-db-data-model.md
@@ -76,3 +76,18 @@ The Applications container change feed is consumed by the notification processor
 - **Spatial queries on Applications are cross-partition.** Acceptable because spatial matching runs in a background change feed processor, not in user-facing request paths. Users browse applications via pre-matched results in their notification feed or zone-scoped list (which queries by authority code partition).
 - **Separate WatchZones container** means the notification processor can query all active zones without loading user profile data. Adds one container to manage but keeps concerns cleanly separated.
 - **TTL on Applications** means very old applications disappear from the local cache. This is acceptable — PlanIt retains historical data and the app is focused on recent/active applications.
+
+## Amendments
+
+### 2026-03-27
+- Added containers to reflect features implemented since the original data model:
+
+| Container | Partition Key | Rationale |
+|-----------|--------------|-----------|
+| `DeviceRegistrations` | `/userId` | APNs device tokens per user, supporting multiple devices per platform. Queried when dispatching push notifications |
+| `SavedApplications` | `/userId` | User-bookmarked planning applications. Always queried per-user for the saved applications list |
+| `Groups` | `/ownerId` | Community groups with shared watch zones. Owner-scoped queries for group management |
+| `GroupInvitations` | `/groupId` | Pending/accepted/declined invitations to join a group. Group-scoped for invitation management, with cross-partition query by invitee email on acceptance |
+| `DecisionAlerts` | `/userId` | Alerts triggered when a watched application receives a decision. Per-user feed similar to Notifications |
+
+- Total containers: 10 (original 5 + 5 new). The `Leases` container for change feed checkpointing remains as documented.

--- a/docs/adr/0011-web-frontend-stack.md
+++ b/docs/adr/0011-web-frontend-stack.md
@@ -36,3 +36,16 @@ No SSR framework (Next.js, Remix) is used. The landing page is a pure client-sid
 - **Simpler:** CSS Modules with design tokens ensure visual consistency with the iOS app without introducing a component library dependency (e.g., Chakra, MUI).
 - **Harder:** No SSR means the landing page relies on client-side rendering. If SEO or first-contentful-paint becomes critical, we would need to revisit this (e.g., adopt Vite SSG plugin or migrate to a framework with SSR support).
 - **Harder:** Adding a second language ecosystem (Node.js/TypeScript) to the monorepo increases CI complexity and onboarding surface area.
+
+## Amendments
+
+### 2026-03-27
+The web frontend has evolved from a landing page and marketing site into a **full authenticated application** with feature parity approaching the iOS app. The core technology choices (React 19, TypeScript 5.9, Vite 8, CSS Modules, Vitest) remain unchanged. The following additions reflect the expanded scope:
+
+- Added: **React Router DOM** v7.13.2 for client-side routing. 17 routes spanning public pages (landing, legal, callback), onboarding, and authenticated features (dashboard, applications, watch zones, groups, notifications, search, saved applications, settings, map).
+- Added: **@auth0/auth0-react** v2.16.0 for authentication. Integrates with the same Auth0 tenant as the iOS app (see [ADR 0007](0007-auth0-authentication.md)). Route protection via `AuthGuard` and `OnboardingGate` components.
+- Added: **TanStack React Query** v5.95.2 for server state management and data fetching. Currently used selectively (saved applications) alongside manual `useState`/`useEffect` patterns in other features.
+- Added: **Leaflet** v1.9.4 for interactive maps (watch zone visualisation, application pins). Map components are integrated into watch zone and application detail features.
+- Added: **Port/Adapter architecture** in the web layer. Domain ports (interfaces) defined in `src/domain/ports/`, with API adapters composing typed API modules. Components receive repositories as props for testability ("Connected" components create adapters; presentational components receive them).
+- Added: **Branded types** (`ApplicationUid`, `WatchZoneId`, `GroupId`, etc.) and **union types** (instead of enums, respecting `erasableSyntaxOnly`) for type-safe domain modelling in TypeScript.
+- Updated: The web frontend is no longer just a public-facing landing page. It serves as the primary web client for authenticated users, with 14 implemented feature modules.

--- a/docs/adr/0014-ios-offline-first-architecture.md
+++ b/docs/adr/0014-ios-offline-first-architecture.md
@@ -1,0 +1,50 @@
+# 0014. iOS Offline-First Architecture
+
+Date: 2026-03-27
+
+## Status
+
+Accepted
+
+## Context
+
+Town Crier's iOS app must remain useful when network connectivity is degraded or unavailable. Users may open the app on public transport, in areas with poor signal, or when their device is in airplane mode. Planning application data viewed recently should still be accessible, and the app should degrade gracefully rather than showing error screens.
+
+Additionally, the app needs crash reporting for production diagnostics and network state awareness to make intelligent data-fetching decisions. These are capability-level architectural choices that affect how the app behaves under adverse conditions.
+
+## Decision
+
+### Offline Caching via Decorator Pattern
+
+An `OfflineAwareRepository` decorator wraps any `PlanningApplicationRepository` implementation. The decorator manages a cache layer transparently:
+
+1. **Online + cache fresh**: return cached data without network call
+2. **Online + cache stale/empty**: fetch from remote, cache result, return fresh data
+3. **Offline + cache available**: return stale cached data with `DataFreshness.stale` signal
+4. **Offline + no cache**: throw `DomainError.networkUnavailable`
+
+Cache entries use a `CacheEntry<T>` value type with a configurable TTL (default 900 seconds). The `DataFreshness` enum (`.fresh` / `.stale`) is propagated to the UI layer, enabling stale-data banners without blocking the user.
+
+### In-Memory Cache with Actor Isolation
+
+The cache store (`InMemoryApplicationCacheStore`) is implemented as a Swift **Actor**, providing thread-safe access without manual locks or dispatch queues. Cache entries are keyed by authority code. No on-device persistence (SwiftData, Core Data, SQLite) is used — the cache is populated on each app session from the API and retained in memory.
+
+This is a deliberate simplicity choice: planning data changes frequently, sessions are typically short, and the API is the source of truth. Persistent offline storage may be added later if usage patterns demand it.
+
+### Connectivity Monitoring
+
+`NWPathConnectivityMonitor` wraps Apple's **Network.framework** `NWPathMonitor` to provide real-time connectivity state via the `ConnectivityMonitor` protocol. The offline-aware repository checks connectivity before deciding whether to attempt network requests, avoiding unnecessary timeouts.
+
+### Crash Reporting via MetricKit
+
+Apple's **MetricKit** framework (`MXMetricManagerSubscriber`) is used for crash diagnostics rather than a third-party service (Sentry, Firebase Crashlytics, Bugsnag). `MetricKitCrashReporter` implements the `CrashReporter` protocol and logs crash reports (signal, termination reason, VM region info) to the OS unified logger.
+
+This eliminates a third-party dependency and associated privacy implications. The trade-off is delayed delivery (crash reports arrive 0–24 hours post-crash) and no aggregation dashboard. Acceptable at the current scale; a third-party service can be swapped in via the `CrashReporter` protocol if needed.
+
+## Consequences
+
+- **Better UX under poor connectivity** — users see cached data with a staleness indicator instead of error screens or loading spinners.
+- **Simpler data layer** — in-memory cache avoids the complexity of on-device database schemas, migrations, and sync conflicts. The decorator pattern keeps the caching concern separate from repository logic.
+- **No persistent offline data** — closing and reopening the app with no connectivity shows empty state until the network returns. This is acceptable for the current use case but limits true offline-first capability.
+- **Actor-based thread safety** — eliminates a class of concurrency bugs in cache access, leveraging Swift 6.0 strict concurrency checking.
+- **MetricKit limitations** — no real-time crash alerting or dashboards. Crash data is delayed and requires manual log inspection. The `CrashReporter` protocol provides a swap path to a third-party service when scale demands it.


### PR DESCRIPTION
## Changes
- **ADR 0002**: Amended — iOS uses Swift Testing (not XCTest), no SwiftData in use
- **ADR 0007**: Amended — Auth0 custom domain replaces separate tenants, added web SPA client
- **ADR 0008**: Amended — Added 5 new Cosmos containers (DeviceRegistrations, SavedApplications, Groups, GroupInvitations, DecisionAlerts)
- **ADR 0011**: Amended — Web evolved from landing page to full 14-feature authenticated app with React Router, Auth0, React Query, Leaflet, port/adapter architecture, branded types
- **ADR 0014**: Created — iOS offline-first architecture (caching decorator pattern, Actor-based in-memory cache, NWPathMonitor connectivity monitoring, MetricKit crash reporting)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * iOS app architecture now supports offline-first functionality with automatic data caching and intelligent refresh handling
  * Web frontend enhanced with user authentication, navigation, and interactive mapping capabilities
  * Database schema extended to support device management, saved applications, group collaboration, and notification alerts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->