### PR TITLE
feat(web): add Map page with Leaflet and OpenStreetMap

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "leaflet": "^1.9.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.13.2"
       },
       "devDependencies": {
@@ -878,6 +879,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3573,6 +3585,20 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/react-router": {
       "version": "7.13.2",

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "leaflet": "^1.9.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.13.2"
   },
   "devDependencies": {

--- a/web/src/AppRoutes.tsx
+++ b/web/src/AppRoutes.tsx
@@ -5,7 +5,7 @@ import { LegalPage } from './features/legal/LegalPage';
 import { AuthGuard } from './auth/AuthGuard';
 import { OnboardingGate } from './auth/OnboardingGate';
 import { AppShell } from './components/AppShell/AppShell';
-import { PlaceholderPage } from './features/placeholder/PlaceholderPage';
+import { ConnectedMapPage } from './features/Map/ConnectedMapPage';
 import { ConnectedOnboardingPage } from './features/onboarding/ConnectedOnboardingPage';
 import { ConnectedApplicationsPage } from './features/Applications/ConnectedApplicationsPage';
 import { ConnectedDashboardPage } from './features/Dashboard/ConnectedDashboardPage';
@@ -41,7 +41,7 @@ export function AppRoutes() {
             <Route path="/watch-zones" element={<WiredWatchZoneListPage />} />
             <Route path="/watch-zones/new" element={<WiredWatchZoneCreatePage />} />
             <Route path="/watch-zones/:zoneId" element={<WiredWatchZoneEditPage />} />
-            <Route path="/map" element={<PlaceholderPage title="Map" />} />
+            <Route path="/map" element={<ConnectedMapPage />} />
             <Route path="/search" element={<ConnectedSearchPage />} />
             <Route path="/saved" element={<WiredSavedApplicationsPage />} />
             <Route path="/groups" element={<WiredGroupsListPage />} />

--- a/web/src/domain/ports/map-applications-port.ts
+++ b/web/src/domain/ports/map-applications-port.ts
@@ -1,0 +1,5 @@
+import type { AuthorityId, PlanningApplication } from '../types';
+
+export interface MapApplicationsPort {
+  fetchByAuthority(authorityId: AuthorityId): Promise<readonly PlanningApplication[]>;
+}

--- a/web/src/features/Map/ConnectedMapPage.tsx
+++ b/web/src/features/Map/ConnectedMapPage.tsx
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import { useApiClient } from '../../api/useApiClient';
+import { watchZonesApi } from '../../api/watchZones';
+import { applicationsApi } from '../../api/applications';
+import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
+import type { MapApplicationsPort } from '../../domain/ports/map-applications-port';
+import { MapPage } from './MapPage';
+
+export function ConnectedMapPage() {
+  const client = useApiClient();
+
+  const watchZoneRepo: WatchZoneRepository = useMemo(
+    () => ({
+      list: () => watchZonesApi(client).list(),
+      create: (data) => watchZonesApi(client).create(data),
+      delete: (zoneId) => watchZonesApi(client).delete(zoneId),
+      getPreferences: (zoneId) => watchZonesApi(client).getPreferences(zoneId),
+      updatePreferences: (zoneId, data) =>
+        watchZonesApi(client).updatePreferences(zoneId, data),
+    }),
+    [client],
+  );
+
+  const applicationsPort: MapApplicationsPort = useMemo(
+    () => ({
+      fetchByAuthority: (authorityId) =>
+        applicationsApi(client).getByAuthority(authorityId),
+    }),
+    [client],
+  );
+
+  return (
+    <MapPage watchZoneRepo={watchZoneRepo} applicationsPort={applicationsPort} />
+  );
+}

--- a/web/src/features/Map/MapPage.module.css
+++ b/web/src/features/Map/MapPage.module.css
@@ -1,0 +1,82 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.heading {
+  font-size: var(--tc-text-display-small);
+  font-weight: var(--tc-weight-semibold);
+  color: var(--tc-text-primary);
+  margin: 0;
+  padding: var(--tc-space-md);
+}
+
+.mapWrapper {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--tc-text-secondary);
+  font-size: var(--tc-text-body);
+}
+
+.error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--tc-status-refused);
+  font-size: var(--tc-text-body);
+  padding: var(--tc-space-md);
+}
+
+.popupName {
+  font-weight: var(--tc-weight-semibold);
+  font-size: var(--tc-text-body);
+  color: var(--tc-text-primary);
+  margin: 0 0 var(--tc-space-xs) 0;
+}
+
+.popupAddress {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+  margin: 0 0 var(--tc-space-xs) 0;
+}
+
+.popupDescription {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+  margin: 0 0 var(--tc-space-sm) 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.popupLink {
+  font-size: var(--tc-text-caption);
+  font-weight: var(--tc-weight-medium);
+  color: var(--tc-amber);
+  text-decoration: none;
+}
+
+.popupLink:hover {
+  text-decoration: underline;
+}
+
+.popupStatus {
+  display: inline-block;
+  font-size: var(--tc-text-caption);
+  font-weight: var(--tc-weight-medium);
+  padding: var(--tc-space-xs) var(--tc-space-sm);
+  border-radius: var(--tc-radius-full);
+  margin-bottom: var(--tc-space-sm);
+}

--- a/web/src/features/Map/MapPage.tsx
+++ b/web/src/features/Map/MapPage.tsx
@@ -1,0 +1,77 @@
+import { Link } from 'react-router-dom';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import 'leaflet/dist/leaflet.css';
+import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
+import type { MapApplicationsPort } from '../../domain/ports/map-applications-port';
+import { useMapData } from './useMapData';
+import styles from './MapPage.module.css';
+
+const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const OSM_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+const DEFAULT_ZOOM = 13;
+
+interface Props {
+  watchZoneRepo: WatchZoneRepository;
+  applicationsPort: MapApplicationsPort;
+}
+
+export function MapPage({ watchZoneRepo, applicationsPort }: Props) {
+  const { applications, center, isLoading, error } = useMapData(
+    watchZoneRepo,
+    applicationsPort,
+  );
+
+  if (isLoading) {
+    return (
+      <div className={styles.container}>
+        <h1 className={styles.heading}>Map</h1>
+        <div className={styles.loading}>Loading map data...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className={styles.container}>
+        <h1 className={styles.heading}>Map</h1>
+        <div className={styles.error}>{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.heading}>Map</h1>
+      <div className={styles.mapWrapper}>
+        <MapContainer
+          center={[center.lat, center.lng]}
+          zoom={DEFAULT_ZOOM}
+          style={{ height: '100%', width: '100%' }}
+        >
+          <TileLayer url={OSM_TILE_URL} attribution={OSM_ATTRIBUTION} />
+          {applications.map((app) => (
+            <Marker
+              key={app.uid}
+              position={[app.latitude!, app.longitude!]}
+            >
+              <Popup>
+                <p className={styles.popupName}>{app.name}</p>
+                <p className={styles.popupAddress}>{app.address}</p>
+                <p className={styles.popupDescription}>{app.description}</p>
+                <span className={styles.popupStatus}>{app.appState}</span>
+                <br />
+                <Link
+                  to={`/applications/${app.uid}`}
+                  className={styles.popupLink}
+                >
+                  View details
+                </Link>
+              </Popup>
+            </Marker>
+          ))}
+        </MapContainer>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/Map/__tests__/MapPage.test.tsx
+++ b/web/src/features/Map/__tests__/MapPage.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { MapPage } from '../MapPage';
+import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';
+import { SpyMapApplicationsPort } from './spies/spy-applications-browse-port';
+import { aWatchZone, anApplication, aSecondApplication } from './fixtures/map.fixtures';
+
+// Mock react-leaflet — Leaflet cannot render in jsdom (no canvas/DOM layout)
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children, center, zoom }: {
+    children: React.ReactNode;
+    center: [number, number];
+    zoom: number;
+  }) => (
+    <div data-testid="map-container" data-center={center.join(',')} data-zoom={zoom}>
+      {children}
+    </div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: ({ children, position }: {
+    children: React.ReactNode;
+    position: [number, number];
+  }) => (
+    <div data-testid="marker" data-position={position.join(',')}>
+      {children}
+    </div>
+  ),
+  Popup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popup">{children}</div>
+  ),
+}));
+
+function renderPage(
+  watchZoneRepo: SpyWatchZoneRepository,
+  applicationsPort: SpyMapApplicationsPort,
+) {
+  return render(
+    <MemoryRouter>
+      <MapPage watchZoneRepo={watchZoneRepo} applicationsPort={applicationsPort} />
+    </MemoryRouter>,
+  );
+}
+
+describe('MapPage', () => {
+  let zoneSpy: SpyWatchZoneRepository;
+  let appsSpy: SpyMapApplicationsPort;
+
+  beforeEach(() => {
+    zoneSpy = new SpyWatchZoneRepository();
+    appsSpy = new SpyMapApplicationsPort();
+  });
+
+  it('renders loading state initially', () => {
+    zoneSpy.listResult = [aWatchZone()];
+    appsSpy.fetchByAuthorityResults.set(1, []);
+
+    renderPage(zoneSpy, appsSpy);
+
+    expect(screen.getByText('Loading map data...')).toBeInTheDocument();
+  });
+
+  it('renders the map container after data loads', async () => {
+    zoneSpy.listResult = [aWatchZone()];
+    appsSpy.fetchByAuthorityResults.set(1, []);
+
+    renderPage(zoneSpy, appsSpy);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    });
+  });
+
+  it('renders markers for applications with coordinates', async () => {
+    zoneSpy.listResult = [aWatchZone()];
+    const app1 = anApplication();
+    const app2 = aSecondApplication();
+    appsSpy.fetchByAuthorityResults.set(1, [app1, app2]);
+
+    renderPage(zoneSpy, appsSpy);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('marker')).toHaveLength(2);
+    });
+  });
+
+  it('renders application name in marker popup', async () => {
+    zoneSpy.listResult = [aWatchZone()];
+    const app = anApplication({ name: '2026/0042/FUL' });
+    appsSpy.fetchByAuthorityResults.set(1, [app]);
+
+    renderPage(zoneSpy, appsSpy);
+
+    await waitFor(() => {
+      expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument();
+    });
+  });
+
+  it('renders application address in marker popup', async () => {
+    zoneSpy.listResult = [aWatchZone()];
+    const app = anApplication({ address: '12 Mill Road, Cambridge, CB1 2AD' });
+    appsSpy.fetchByAuthorityResults.set(1, [app]);
+
+    renderPage(zoneSpy, appsSpy);
+
+    await waitFor(() => {
+      expect(screen.getByText('12 Mill Road, Cambridge, CB1 2AD')).toBeInTheDocument();
+    });
+  });
+
+  it('renders a link to the application detail page', async () => {
+    zoneSpy.listResult = [aWatchZone()];
+    const app = anApplication();
+    appsSpy.fetchByAuthorityResults.set(1, [app]);
+
+    renderPage(zoneSpy, appsSpy);
+
+    await waitFor(() => {
+      const link = screen.getByRole('link', { name: 'View details' });
+      expect(link).toBeInTheDocument();
+      expect(link).toHaveAttribute('href', `/applications/${app.uid}`);
+    });
+  });
+
+  it('renders error message when data fails to load', async () => {
+    zoneSpy.listError = new Error('Network unavailable');
+
+    renderPage(zoneSpy, appsSpy);
+
+    await waitFor(() => {
+      expect(screen.getByText('Network unavailable')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when there are no applications', async () => {
+    zoneSpy.listResult = [aWatchZone()];
+    appsSpy.fetchByAuthorityResults.set(1, []);
+
+    renderPage(zoneSpy, appsSpy);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    });
+
+    // Map should render even with no markers
+    expect(screen.queryAllByTestId('marker')).toHaveLength(0);
+  });
+});

--- a/web/src/features/Map/__tests__/fixtures/map.fixtures.ts
+++ b/web/src/features/Map/__tests__/fixtures/map.fixtures.ts
@@ -1,0 +1,74 @@
+import type { WatchZoneSummary, PlanningApplication } from '../../../../domain/types';
+import { asWatchZoneId, asAuthorityId, asApplicationUid } from '../../../../domain/types';
+
+export function aWatchZone(overrides?: Partial<WatchZoneSummary>): WatchZoneSummary {
+  return {
+    id: asWatchZoneId('zone-1'),
+    name: 'Home',
+    latitude: 52.2053,
+    longitude: 0.1218,
+    radiusMetres: 2000,
+    authorityId: asAuthorityId(1),
+    ...overrides,
+  };
+}
+
+export function aSecondWatchZone(overrides?: Partial<WatchZoneSummary>): WatchZoneSummary {
+  return {
+    id: asWatchZoneId('zone-2'),
+    name: 'Office',
+    latitude: 51.5074,
+    longitude: -0.1278,
+    radiusMetres: 5000,
+    authorityId: asAuthorityId(2),
+    ...overrides,
+  };
+}
+
+export function anApplication(overrides?: Partial<PlanningApplication>): PlanningApplication {
+  return {
+    uid: asApplicationUid('APP-001'),
+    name: '2026/0042/FUL',
+    address: '12 Mill Road, Cambridge, CB1 2AD',
+    postcode: 'CB1 2AD',
+    description: 'Erection of two-storey rear extension',
+    appType: 'Full Planning',
+    appState: 'Undecided',
+    appSize: null,
+    areaName: 'Cambridge City Council',
+    areaId: asAuthorityId(1),
+    startDate: '2026-01-15',
+    decidedDate: null,
+    consultedDate: '2026-02-01',
+    latitude: 52.2053,
+    longitude: 0.1218,
+    url: 'https://council.example.com/planning/APP-001',
+    link: 'https://planit.org.uk/planapplic/APP-001',
+    lastDifferent: '2026-01-20',
+    ...overrides,
+  };
+}
+
+export function aSecondApplication(overrides?: Partial<PlanningApplication>): PlanningApplication {
+  return {
+    uid: asApplicationUid('APP-002'),
+    name: '2026/0099/LBC',
+    address: '45 High Street, Cambridge, CB2 1LA',
+    postcode: 'CB2 1LA',
+    description: 'Change of use from retail to residential',
+    appType: 'Listed Building Consent',
+    appState: 'Approved',
+    appSize: null,
+    areaName: 'Cambridge City Council',
+    areaId: asAuthorityId(1),
+    startDate: '2026-02-01',
+    decidedDate: '2026-03-10',
+    consultedDate: null,
+    latitude: 52.2070,
+    longitude: 0.1200,
+    url: 'https://council.example.com/planning/APP-002',
+    link: 'https://planit.org.uk/planapplic/APP-002',
+    lastDifferent: '2026-03-10',
+    ...overrides,
+  };
+}

--- a/web/src/features/Map/__tests__/spies/spy-applications-browse-port.ts
+++ b/web/src/features/Map/__tests__/spies/spy-applications-browse-port.ts
@@ -1,0 +1,16 @@
+import type { AuthorityId, PlanningApplication } from '../../../../domain/types';
+import type { MapApplicationsPort } from '../../../../domain/ports/map-applications-port';
+
+export class SpyMapApplicationsPort implements MapApplicationsPort {
+  fetchByAuthorityCalls: AuthorityId[] = [];
+  fetchByAuthorityResults: Map<number, readonly PlanningApplication[]> = new Map();
+  fetchByAuthorityError: Error | null = null;
+
+  async fetchByAuthority(authorityId: AuthorityId): Promise<readonly PlanningApplication[]> {
+    this.fetchByAuthorityCalls.push(authorityId);
+    if (this.fetchByAuthorityError) {
+      throw this.fetchByAuthorityError;
+    }
+    return this.fetchByAuthorityResults.get(authorityId as number) ?? [];
+  }
+}

--- a/web/src/features/Map/__tests__/spies/spy-watch-zone-repository.ts
+++ b/web/src/features/Map/__tests__/spies/spy-watch-zone-repository.ts
@@ -1,0 +1,49 @@
+import type {
+  WatchZoneSummary,
+  CreateWatchZoneRequest,
+  ZoneNotificationPreferences,
+  UpdateZonePreferencesRequest,
+} from '../../../../domain/types';
+import type { WatchZoneRepository } from '../../../../domain/ports/watch-zone-repository';
+
+export class SpyWatchZoneRepository implements WatchZoneRepository {
+  listCalls = 0;
+  listResult: readonly WatchZoneSummary[] = [];
+  listError: Error | null = null;
+
+  async list(): Promise<readonly WatchZoneSummary[]> {
+    this.listCalls++;
+    if (this.listError) {
+      throw this.listError;
+    }
+    return this.listResult;
+  }
+
+  createCalls: CreateWatchZoneRequest[] = [];
+  createResult: WatchZoneSummary | null = null;
+
+  async create(data: CreateWatchZoneRequest): Promise<WatchZoneSummary> {
+    this.createCalls.push(data);
+    return this.createResult!;
+  }
+
+  deleteCalls: string[] = [];
+
+  async delete(zoneId: string): Promise<void> {
+    this.deleteCalls.push(zoneId);
+  }
+
+  getPreferencesCalls: string[] = [];
+  getPreferencesResult: ZoneNotificationPreferences | null = null;
+
+  async getPreferences(zoneId: string): Promise<ZoneNotificationPreferences> {
+    this.getPreferencesCalls.push(zoneId);
+    return this.getPreferencesResult!;
+  }
+
+  updatePreferencesCalls: Array<{ zoneId: string; data: UpdateZonePreferencesRequest }> = [];
+
+  async updatePreferences(zoneId: string, data: UpdateZonePreferencesRequest): Promise<void> {
+    this.updatePreferencesCalls.push({ zoneId, data });
+  }
+}

--- a/web/src/features/Map/__tests__/useMapData.test.ts
+++ b/web/src/features/Map/__tests__/useMapData.test.ts
@@ -1,0 +1,134 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useMapData } from '../useMapData';
+import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';
+import { SpyMapApplicationsPort } from './spies/spy-applications-browse-port';
+import { aWatchZone, aSecondWatchZone, anApplication, aSecondApplication } from './fixtures/map.fixtures';
+import { asAuthorityId } from '../../../domain/types';
+
+describe('useMapData', () => {
+  let zoneSpy: SpyWatchZoneRepository;
+  let appsSpy: SpyMapApplicationsPort;
+
+  beforeEach(() => {
+    zoneSpy = new SpyWatchZoneRepository();
+    appsSpy = new SpyMapApplicationsPort();
+  });
+
+  it('fetches watch zones and then applications per zone authority', async () => {
+    const zone1 = aWatchZone();
+    const zone2 = aSecondWatchZone();
+    zoneSpy.listResult = [zone1, zone2];
+
+    const app1 = anApplication();
+    const app2 = aSecondApplication();
+    appsSpy.fetchByAuthorityResults.set(1, [app1, app2]);
+    appsSpy.fetchByAuthorityResults.set(2, []);
+
+    const { result } = renderHook(() => useMapData(zoneSpy, appsSpy));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(zoneSpy.listCalls).toBe(1);
+    expect(appsSpy.fetchByAuthorityCalls).toContainEqual(asAuthorityId(1));
+    expect(appsSpy.fetchByAuthorityCalls).toContainEqual(asAuthorityId(2));
+    expect(result.current.applications).toHaveLength(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('centers on the first watch zone', async () => {
+    const zone = aWatchZone({ latitude: 52.2053, longitude: 0.1218 });
+    zoneSpy.listResult = [zone];
+    appsSpy.fetchByAuthorityResults.set(1, []);
+
+    const { result } = renderHook(() => useMapData(zoneSpy, appsSpy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.center).toEqual({ lat: 52.2053, lng: 0.1218 });
+  });
+
+  it('defaults center to London when no zones exist', async () => {
+    zoneSpy.listResult = [];
+
+    const { result } = renderHook(() => useMapData(zoneSpy, appsSpy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.center).toEqual({ lat: 51.505, lng: -0.09 });
+    expect(result.current.applications).toEqual([]);
+  });
+
+  it('deduplicates applications across zones with the same authority', async () => {
+    const zone1 = aWatchZone({ authorityId: asAuthorityId(1) });
+    const zone2 = aSecondWatchZone({ authorityId: asAuthorityId(1) });
+    zoneSpy.listResult = [zone1, zone2];
+
+    const app = anApplication();
+    appsSpy.fetchByAuthorityResults.set(1, [app]);
+
+    const { result } = renderHook(() => useMapData(zoneSpy, appsSpy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Should only fetch once for the same authority
+    const auth1Calls = appsSpy.fetchByAuthorityCalls.filter(
+      (id) => (id as number) === 1,
+    );
+    expect(auth1Calls).toHaveLength(1);
+    expect(result.current.applications).toHaveLength(1);
+  });
+
+  it('sets error when watch zone fetch fails', async () => {
+    zoneSpy.listError = new Error('Network unavailable');
+
+    const { result } = renderHook(() => useMapData(zoneSpy, appsSpy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Network unavailable');
+    expect(result.current.applications).toEqual([]);
+  });
+
+  it('sets error when applications fetch fails', async () => {
+    zoneSpy.listResult = [aWatchZone()];
+    appsSpy.fetchByAuthorityError = new Error('Applications unavailable');
+
+    const { result } = renderHook(() => useMapData(zoneSpy, appsSpy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Applications unavailable');
+  });
+
+  it('filters out applications without coordinates', async () => {
+    zoneSpy.listResult = [aWatchZone()];
+
+    const withCoords = anApplication({ latitude: 52.2053, longitude: 0.1218 });
+    const withoutCoords = aSecondApplication({ latitude: null, longitude: null });
+    appsSpy.fetchByAuthorityResults.set(1, [withCoords, withoutCoords]);
+
+    const { result } = renderHook(() => useMapData(zoneSpy, appsSpy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.applications).toHaveLength(1);
+    expect(result.current.applications[0]?.uid).toBe(withCoords.uid);
+  });
+});

--- a/web/src/features/Map/useMapData.ts
+++ b/web/src/features/Map/useMapData.ts
@@ -1,0 +1,89 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { PlanningApplication } from '../../domain/types';
+import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
+import type { MapApplicationsPort } from '../../domain/ports/map-applications-port';
+
+interface MapCenter {
+  readonly lat: number;
+  readonly lng: number;
+}
+
+const DEFAULT_CENTER: MapCenter = { lat: 51.505, lng: -0.09 };
+
+interface MapDataState {
+  applications: readonly PlanningApplication[];
+  center: MapCenter;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useMapData(
+  watchZoneRepo: WatchZoneRepository,
+  applicationsPort: MapApplicationsPort,
+) {
+  const [state, setState] = useState<MapDataState>({
+    applications: [],
+    center: DEFAULT_CENTER,
+    isLoading: true,
+    error: null,
+  });
+
+  const loadData = useCallback(async () => {
+    setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+    try {
+      const zones = await watchZoneRepo.list();
+
+      const center: MapCenter =
+        zones.length > 0
+          ? { lat: zones[0]!.latitude, lng: zones[0]!.longitude }
+          : DEFAULT_CENTER;
+
+      if (zones.length === 0) {
+        setState({ applications: [], center, isLoading: false, error: null });
+        return;
+      }
+
+      // Deduplicate authority IDs across zones
+      const uniqueAuthorityIds = [...new Set(zones.map((z) => z.authorityId))];
+
+      const applicationArrays = await Promise.all(
+        uniqueAuthorityIds.map((authorityId) =>
+          applicationsPort.fetchByAuthority(authorityId),
+        ),
+      );
+
+      const allApplications = applicationArrays.flat();
+
+      // Filter out applications without coordinates
+      const withCoordinates = allApplications.filter(
+        (app): app is PlanningApplication =>
+          app.latitude !== null && app.longitude !== null,
+      );
+
+      setState({
+        applications: withCoordinates,
+        center,
+        isLoading: false,
+        error: null,
+      });
+    } catch (err: unknown) {
+      setState((prev) => ({
+        ...prev,
+        isLoading: false,
+        error: err instanceof Error ? err.message : String(err),
+      }));
+    }
+  }, [watchZoneRepo, applicationsPort]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  return {
+    applications: state.applications,
+    center: state.center,
+    isLoading: state.isLoading,
+    error: state.error,
+  };
+}


### PR DESCRIPTION
## Summary

Implements `tc-z5w.1`: Map page with Leaflet and OpenStreetMap

Adds a full MapPage feature with react-leaflet, fetching watch zones and plotting planning application markers with popups. Wired into router at `/map`.

## Bead

`tc-z5w.1` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive map displaying planning applications with location markers
  * Users can click markers to view application details (name, address, description, status)
  * Map automatically centers on monitored zones
  * Added loading and error states for map operations

* **Tests**
  * Added comprehensive test coverage for map functionality and data retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->