### PR TITLE
refactor(ios): extract ApplicationStatus display helper

### DIFF
--- a/mobile/ios/.swiftlint.yml
+++ b/mobile/ios/.swiftlint.yml
@@ -55,6 +55,7 @@ disabled_rules:
   - implicitly_unwrapped_optional # Used in UIKit patterns and test fixtures
   - unused_parameter # SwiftUI lifecycle methods have required signatures
   - unused_closure_parameter
+  - prefer_nimble # Project uses XCTest, not Nimble
 
 analyzer_rules:
   - unused_declaration

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ApplicationStatus+Display.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ApplicationStatus+Display.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+import TownCrierDomain
+
+extension ApplicationStatus {
+
+    /// The user-facing label for this status (e.g. "Pending", "Approved").
+    public var displayLabel: String {
+        switch self {
+        case .underReview:
+            "Pending"
+        case .approved:
+            "Approved"
+        case .refused:
+            "Refused"
+        case .withdrawn:
+            "Withdrawn"
+        case .appealed:
+            "Appealed"
+        case .unknown:
+            "Unknown"
+        }
+    }
+
+    /// The SF Symbol name representing this status.
+    public var displayIcon: String {
+        switch self {
+        case .underReview:
+            "clock"
+        case .approved:
+            "checkmark.circle"
+        case .refused:
+            "xmark.circle"
+        case .withdrawn:
+            "arrow.uturn.backward.circle"
+        case .appealed:
+            "exclamationmark.triangle"
+        case .unknown:
+            "questionmark.circle"
+        }
+    }
+
+    /// The design-system color associated with this status.
+    public var displayColor: Color {
+        switch self {
+        case .underReview:
+            .tcStatusPending
+        case .approved:
+            .tcStatusApproved
+        case .refused:
+            .tcStatusRefused
+        case .withdrawn:
+            .tcStatusWithdrawn
+        case .appealed:
+            .tcStatusAppealed
+        case .unknown:
+            .tcTextTertiary
+        }
+    }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
@@ -127,20 +127,7 @@ public struct ApplicationDetailView: View {
     // MARK: - Status Color
 
     private var statusColor: Color {
-        switch viewModel.status {
-        case .underReview:
-            return .tcStatusPending
-        case .approved:
-            return .tcStatusApproved
-        case .refused:
-            return .tcStatusRefused
-        case .withdrawn:
-            return .tcStatusWithdrawn
-        case .appealed:
-            return .tcStatusAppealed
-        case .unknown:
-            return .tcTextTertiary
-        }
+        viewModel.status.displayColor
     }
 }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
@@ -53,26 +53,8 @@ public final class ApplicationDetailViewModel: ObservableObject {
         status = application.status
         portalUrl = application.portalUrl
 
-        switch application.status {
-        case .underReview:
-            statusLabel = "Pending"
-            statusIcon = "clock"
-        case .approved:
-            statusLabel = "Approved"
-            statusIcon = "checkmark.circle"
-        case .refused:
-            statusLabel = "Refused"
-            statusIcon = "xmark.circle"
-        case .withdrawn:
-            statusLabel = "Withdrawn"
-            statusIcon = "arrow.uturn.backward.circle"
-        case .appealed:
-            statusLabel = "Appealed"
-            statusIcon = "exclamationmark.triangle"
-        case .unknown:
-            statusLabel = "Unknown"
-            statusIcon = "questionmark.circle"
-        }
+        statusLabel = application.status.displayLabel
+        statusIcon = application.status.displayIcon
 
         let events = application.statusHistory.isEmpty
             ? [StatusEvent(status: application.status, date: application.receivedDate)]
@@ -80,31 +62,13 @@ public final class ApplicationDetailViewModel: ObservableObject {
 
         timelineItems = events.enumerated().map { index, event in
             let isLast = index == events.count - 1
-            let (label, icon) = Self.displayValues(for: event.status)
             return TimelineItem(
-                label: label,
-                icon: icon,
+                label: event.status.displayLabel,
+                icon: event.status.displayIcon,
                 dateFormatted: Self.dateFormatter.string(from: event.date),
                 isCurrent: isLast,
                 status: event.status
             )
-        }
-    }
-
-    private static func displayValues(for status: ApplicationStatus) -> (label: String, icon: String) {
-        switch status {
-        case .underReview:
-            ("Pending", "clock")
-        case .approved:
-            ("Approved", "checkmark.circle")
-        case .refused:
-            ("Refused", "xmark.circle")
-        case .withdrawn:
-            ("Withdrawn", "arrow.uturn.backward.circle")
-        case .appealed:
-            ("Appealed", "exclamationmark.triangle")
-        case .unknown:
-            ("Unknown", "questionmark.circle")
         }
     }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/StatusTimelineView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/StatusTimelineView.swift
@@ -62,19 +62,6 @@ struct StatusTimelineView: View {
     // MARK: - Color
 
     private func statusColor(for status: ApplicationStatus) -> Color {
-        switch status {
-        case .underReview:
-            .tcStatusPending
-        case .approved:
-            .tcStatusApproved
-        case .refused:
-            .tcStatusRefused
-        case .withdrawn:
-            .tcStatusWithdrawn
-        case .appealed:
-            .tcStatusAppealed
-        case .unknown:
-            .tcTextTertiary
-        }
+        status.displayColor
     }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListRow.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListRow.swift
@@ -52,53 +52,14 @@ struct ApplicationListRow: View {
     }
 
     private var statusLabel: String {
-        switch application.status {
-        case .underReview:
-            "Pending"
-        case .approved:
-            "Approved"
-        case .refused:
-            "Refused"
-        case .withdrawn:
-            "Withdrawn"
-        case .appealed:
-            "Appealed"
-        case .unknown:
-            "Unknown"
-        }
+        application.status.displayLabel
     }
 
     private var statusIcon: String {
-        switch application.status {
-        case .underReview:
-            "clock"
-        case .approved:
-            "checkmark.circle"
-        case .refused:
-            "xmark.circle"
-        case .withdrawn:
-            "arrow.uturn.backward.circle"
-        case .appealed:
-            "exclamationmark.triangle"
-        case .unknown:
-            "questionmark.circle"
-        }
+        application.status.displayIcon
     }
 
     private var statusColor: Color {
-        switch application.status {
-        case .underReview:
-            .tcStatusPending
-        case .approved:
-            .tcStatusApproved
-        case .refused:
-            .tcStatusRefused
-        case .withdrawn:
-            .tcStatusWithdrawn
-        case .appealed:
-            .tcStatusAppealed
-        case .unknown:
-            .tcTextTertiary
-        }
+        application.status.displayColor
     }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ApplicationSummarySheet.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ApplicationSummarySheet.swift
@@ -48,53 +48,14 @@ struct ApplicationSummarySheet: View {
     }
 
     private var statusColor: Color {
-        switch application.status {
-        case .underReview:
-            return .tcStatusPending
-        case .approved:
-            return .tcStatusApproved
-        case .refused:
-            return .tcStatusRefused
-        case .withdrawn:
-            return .tcStatusWithdrawn
-        case .appealed:
-            return .tcStatusAppealed
-        case .unknown:
-            return .tcTextTertiary
-        }
+        application.status.displayColor
     }
 
     private var statusLabel: String {
-        switch application.status {
-        case .underReview:
-            return "Pending"
-        case .approved:
-            return "Approved"
-        case .refused:
-            return "Refused"
-        case .withdrawn:
-            return "Withdrawn"
-        case .appealed:
-            return "Appealed"
-        case .unknown:
-            return "Unknown"
-        }
+        application.status.displayLabel
     }
 
     private var statusIcon: String {
-        switch application.status {
-        case .underReview:
-            return "clock"
-        case .approved:
-            return "checkmark.circle"
-        case .refused:
-            return "xmark.circle"
-        case .withdrawn:
-            return "arrow.uturn.backward.circle"
-        case .appealed:
-            return "exclamationmark.triangle"
-        case .unknown:
-            return "questionmark.circle"
-        }
+        application.status.displayIcon
     }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapAnnotationItem.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapAnnotationItem.swift
@@ -1,22 +1,12 @@
 import TownCrierDomain
 
-/// The status-derived color category for a map pin.
-public enum StatusColor: Sendable {
-    case pending
-    case approved
-    case refused
-    case withdrawn
-    case appealed
-    case unknown
-}
-
 /// A lightweight value representing a single pin on the map.
 public struct MapAnnotationItem: Identifiable, Sendable {
     public let id: String
     public let applicationId: PlanningApplicationId
     public let latitude: Double
     public let longitude: Double
-    public let statusColor: StatusColor
+    public let status: ApplicationStatus
     public let title: String
     public let address: String
 
@@ -25,25 +15,8 @@ public struct MapAnnotationItem: Identifiable, Sendable {
         self.applicationId = application.id
         self.latitude = coordinate.latitude
         self.longitude = coordinate.longitude
-        self.statusColor = Self.color(for: application.status)
+        self.status = application.status
         self.title = application.description
         self.address = application.address
-    }
-
-    private static func color(for status: ApplicationStatus) -> StatusColor {
-        switch status {
-        case .underReview:
-            return .pending
-        case .approved:
-            return .approved
-        case .refused:
-            return .refused
-        case .withdrawn:
-            return .withdrawn
-        case .appealed:
-            return .appealed
-        case .unknown:
-            return .unknown
-        }
     }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
@@ -96,47 +96,13 @@ public struct MapView: View {
     private func pinView(for annotation: MapAnnotationItem) -> some View {
         Image(systemName: "mappin.circle.fill")
             .font(.system(.title2))
-            .foregroundStyle(pinColor(for: annotation.statusColor))
+            .foregroundStyle(annotation.status.displayColor)
             .background(
                 Circle()
                     .fill(Color.tcSurface)
                     .frame(width: 20, height: 20)
             )
-            .accessibilityLabel("\(annotation.title), \(statusLabel(for: annotation.statusColor))")
-    }
-
-    private func pinColor(for status: StatusColor) -> Color {
-        switch status {
-        case .pending:
-            return .tcStatusPending
-        case .approved:
-            return .tcStatusApproved
-        case .refused:
-            return .tcStatusRefused
-        case .withdrawn:
-            return .tcStatusWithdrawn
-        case .appealed:
-            return .tcStatusAppealed
-        case .unknown:
-            return .tcTextTertiary
-        }
-    }
-
-    private func statusLabel(for status: StatusColor) -> String {
-        switch status {
-        case .pending:
-            return "Pending"
-        case .approved:
-            return "Approved"
-        case .refused:
-            return "Refused"
-        case .withdrawn:
-            return "Withdrawn"
-        case .appealed:
-            return "Appealed"
-        case .unknown:
-            return "Unknown"
-        }
+            .accessibilityLabel("\(annotation.title), \(annotation.status.displayLabel)")
     }
 
     private var mapPlaceholder: some View {

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationStatusDisplayTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationStatusDisplayTests.swift
@@ -1,0 +1,74 @@
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@Suite("ApplicationStatus+Display")
+struct ApplicationStatusDisplayTests {
+
+    // MARK: - displayLabel
+
+    @Test func displayLabel_underReview_returnsPending() {
+        #expect(ApplicationStatus.underReview.displayLabel == "Pending")
+    }
+
+    @Test func displayLabel_approved_returnsApproved() {
+        #expect(ApplicationStatus.approved.displayLabel == "Approved")
+    }
+
+    @Test func displayLabel_refused_returnsRefused() {
+        #expect(ApplicationStatus.refused.displayLabel == "Refused")
+    }
+
+    @Test func displayLabel_withdrawn_returnsWithdrawn() {
+        #expect(ApplicationStatus.withdrawn.displayLabel == "Withdrawn")
+    }
+
+    @Test func displayLabel_appealed_returnsAppealed() {
+        #expect(ApplicationStatus.appealed.displayLabel == "Appealed")
+    }
+
+    @Test func displayLabel_unknown_returnsUnknown() {
+        #expect(ApplicationStatus.unknown.displayLabel == "Unknown")
+    }
+
+    // MARK: - displayIcon
+
+    @Test func displayIcon_underReview_returnsClock() {
+        #expect(ApplicationStatus.underReview.displayIcon == "clock")
+    }
+
+    @Test func displayIcon_approved_returnsCheckmarkCircle() {
+        #expect(ApplicationStatus.approved.displayIcon == "checkmark.circle")
+    }
+
+    @Test func displayIcon_refused_returnsXmarkCircle() {
+        #expect(ApplicationStatus.refused.displayIcon == "xmark.circle")
+    }
+
+    @Test func displayIcon_withdrawn_returnsArrowUturnBackwardCircle() {
+        #expect(ApplicationStatus.withdrawn.displayIcon == "arrow.uturn.backward.circle")
+    }
+
+    @Test func displayIcon_appealed_returnsExclamationmarkTriangle() {
+        #expect(ApplicationStatus.appealed.displayIcon == "exclamationmark.triangle")
+    }
+
+    @Test func displayIcon_unknown_returnsQuestionmarkCircle() {
+        #expect(ApplicationStatus.unknown.displayIcon == "questionmark.circle")
+    }
+
+    // MARK: - displayColor (smoke test)
+
+    @Test func displayColor_allStatusesReturnColor() {
+        let allStatuses: [ApplicationStatus] = [
+            .underReview, .approved, .refused, .withdrawn, .appealed, .unknown,
+        ]
+        for status in allStatuses {
+            // Verify each status produces a color without crashing.
+            // SwiftUI Color is not equatable in a test-friendly way,
+            // so we verify the mapping is exhaustive and non-crashing.
+            _ = status.displayColor
+        }
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
@@ -48,7 +48,7 @@ struct MapViewModelTests {
 
     // MARK: - Annotations
 
-    @Test func annotations_haveCorrectStatusColor() async {
+    @Test func annotations_haveCorrectStatus() async {
         let apps: [PlanningApplication] = [.pendingReview, .approved, .refused, .withdrawn]
         let (sut, _) = makeSUT(applications: apps)
 
@@ -59,10 +59,10 @@ struct MapViewModelTests {
         let refused = sut.annotations.first { $0.applicationId == PlanningApplicationId("APP-003") }
         let withdrawn = sut.annotations.first { $0.applicationId == PlanningApplicationId("APP-004") }
 
-        #expect(pending?.statusColor == .pending)
-        #expect(approved?.statusColor == .approved)
-        #expect(refused?.statusColor == .refused)
-        #expect(withdrawn?.statusColor == .withdrawn)
+        #expect(pending?.status == .underReview)
+        #expect(approved?.status == .approved)
+        #expect(refused?.status == .refused)
+        #expect(withdrawn?.status == .withdrawn)
     }
 
     @Test func annotations_onlyIncludeApplicationsWithLocations() async {


### PR DESCRIPTION
## Summary

Implements `tc-9c9eae97`: Simplify: extract ApplicationStatus display helper (iOS)

Extracts duplicate ApplicationStatus-to-(label, icon, color) switch statements from 6 views into a single `ApplicationStatus+Display` extension. Adds 13 tests, removes 67 net lines.

## Bead

`tc-9c9eae97` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced centralized display properties for application statuses to ensure consistent presentation across the app.

* **Refactoring**
  * Consolidated status-to-display mapping logic throughout multiple views and components.

* **Tests**
  * Added comprehensive test coverage for status display properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->