### PR TITLE
refactor(infra): deduplicate managed certificate creation

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -194,17 +194,7 @@ public static class EnvironmentStack
 
         if (customDomainPhase >= 2)
         {
-            apiManagedCert = new ManagedCertificate($"cert-api-{env}", new ManagedCertificateArgs
-            {
-                EnvironmentName = containerAppsEnvironmentName,
-                ManagedCertificateName = $"cert-api-{env}",
-                ResourceGroupName = sharedResourceGroupName,
-                Properties = new ManagedCertificatePropertiesArgs
-                {
-                    SubjectName = apiDomain,
-                    DomainControlValidation = "CNAME",
-                },
-            });
+            apiManagedCert = CreateApiManagedCertificate(env, containerAppsEnvironmentName, sharedResourceGroupName, apiDomain);
         }
 
         // Container App (API) — placeholder image until CI/CD pushes real builds
@@ -296,17 +286,8 @@ public static class EnvironmentStack
 
         if (customDomainPhase == 1)
         {
-            new ManagedCertificate($"cert-api-{env}", new ManagedCertificateArgs
-            {
-                EnvironmentName = containerAppsEnvironmentName,
-                ManagedCertificateName = $"cert-api-{env}",
-                ResourceGroupName = sharedResourceGroupName,
-                Properties = new ManagedCertificatePropertiesArgs
-                {
-                    SubjectName = apiDomain,
-                    DomainControlValidation = "CNAME",
-                },
-            }, new CustomResourceOptions { DependsOn = { containerApp } });
+            CreateApiManagedCertificate(env, containerAppsEnvironmentName, sharedResourceGroupName, apiDomain,
+                new CustomResourceOptions { DependsOn = { containerApp } });
         }
 
         // Static Web App (Landing Page)
@@ -354,5 +335,25 @@ public static class EnvironmentStack
             ["staticWebAppUrl"] = staticWebApp.DefaultHostname.Apply(hostname => $"https://{hostname}"),
             ["staticWebAppName"] = staticWebApp.Name,
         };
+    }
+
+    private static ManagedCertificate CreateApiManagedCertificate(
+        string env,
+        Output<string> environmentName,
+        Output<string> resourceGroupName,
+        string subjectName,
+        CustomResourceOptions? options = null)
+    {
+        return new ManagedCertificate($"cert-api-{env}", new ManagedCertificateArgs
+        {
+            EnvironmentName = environmentName,
+            ManagedCertificateName = $"cert-api-{env}",
+            ResourceGroupName = resourceGroupName,
+            Properties = new ManagedCertificatePropertiesArgs
+            {
+                SubjectName = subjectName,
+                DomainControlValidation = "CNAME",
+            },
+        }, options);
     }
 }


### PR DESCRIPTION
## Summary

Implements `tc-df0388e2`: Simplify: deduplicate managed certificate creation (infra)

Extracts a `CreateApiManagedCertificate` helper method to eliminate duplicate ManagedCertificate constructor blocks for phase 1 vs phase 2 deployment, differing only in DependsOn.

## Bead

`tc-df0388e2` — see bead comments for Infrastructure Evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured infrastructure code for improved maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->