### PR TITLE
refactor(ios): remove unnecessary #if os(iOS) blocks

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
@@ -36,11 +36,9 @@ public struct ApplicationListView: View {
         .task {
             await viewModel.loadApplications()
         }
-        #if os(iOS)
         .refreshable {
             await viewModel.loadApplications()
         }
-        #endif
     }
 
     // MARK: - Application List

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -1,4 +1,3 @@
-#if os(iOS)
 import MapKit
 import SwiftUI
 import TownCrierDomain
@@ -139,4 +138,3 @@ private struct ZoneMapPreview: View {
         )
     }
 }
-#endif


### PR DESCRIPTION
## Summary

Implements `tc-6cdd9862`: Simplify: remove unnecessary #if os(iOS) blocks (iOS)

Removes 2 unnecessary `#if os(iOS)` guards (WatchZoneListView whole-file wrap, ApplicationListView .refreshable guard) while retaining 8 guards that protect genuinely iOS-only APIs. All 394 tests pass.

## Bead

`tc-6cdd9862` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Expanded cross-platform compatibility for application list pull-to-refresh functionality.
  * Expanded cross-platform compatibility for watch zone viewing and mapping features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->