### PR TITLE
refactor(ios): remove Observable from static ViewModels

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Home/HomeView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Home/HomeView.swift
@@ -2,10 +2,10 @@ import SwiftUI
 
 /// Placeholder home screen displaying the app title and tagline.
 public struct HomeView: View {
-    @StateObject private var viewModel: HomeViewModel
+    private let viewModel: HomeViewModel
 
     public init(viewModel: HomeViewModel) {
-        _viewModel = StateObject(wrappedValue: viewModel)
+        self.viewModel = viewModel
     }
 
     public var body: some View {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Home/HomeViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Home/HomeViewModel.swift
@@ -1,11 +1,8 @@
-import Combine
-import TownCrierDomain
-
 /// ViewModel for the home screen placeholder.
-@MainActor
-public final class HomeViewModel: ObservableObject {
-    @Published private(set) var title: String
-    @Published private(set) var subtitle: String
+/// All properties are static after initialisation, so this is a plain value type.
+public struct HomeViewModel: Sendable {
+    public let title: String
+    public let subtitle: String
 
     public init() {
         title = "Town Crier"

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Legal/LegalDocumentView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Legal/LegalDocumentView.swift
@@ -3,10 +3,10 @@ import SwiftUI
 /// Displays a legal document (privacy policy or terms of service) with
 /// a scrollable list of titled sections.
 public struct LegalDocumentView: View {
-    @StateObject private var viewModel: LegalDocumentViewModel
+    private let viewModel: LegalDocumentViewModel
 
     public init(viewModel: LegalDocumentViewModel) {
-        _viewModel = StateObject(wrappedValue: viewModel)
+        self.viewModel = viewModel
     }
 
     public var body: some View {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Legal/LegalDocumentViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Legal/LegalDocumentViewModel.swift
@@ -1,12 +1,9 @@
-import Combine
-
 /// ViewModel for displaying a legal document (privacy policy or terms of service).
-@MainActor
-public final class LegalDocumentViewModel: ObservableObject {
-    @Published private(set) var title: String
-    @Published private(set) var lastUpdated: String
-    @Published private(set) var sections: [LegalDocumentSection]
-
+/// All properties are static after initialisation, so this is a plain value type.
+public struct LegalDocumentViewModel: Sendable {
+    public let title: String
+    public let lastUpdated: String
+    public let sections: [LegalDocumentSection]
     public let documentType: LegalDocumentType
 
     public init(documentType: LegalDocumentType) {

--- a/mobile/ios/town-crier-tests/Sources/Features/HomeViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/HomeViewModelTests.swift
@@ -2,7 +2,6 @@ import Testing
 @testable import TownCrierPresentation
 
 @Suite("HomeViewModel")
-@MainActor
 struct HomeViewModelTests {
     @Test func init_setsTitle() {
         let sut = HomeViewModel()

--- a/mobile/ios/town-crier-tests/Sources/Features/LegalDocumentViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/LegalDocumentViewModelTests.swift
@@ -2,7 +2,6 @@ import Testing
 @testable import TownCrierPresentation
 
 @Suite("LegalDocumentViewModel")
-@MainActor
 struct LegalDocumentViewModelTests {
     @Test func init_privacyPolicy_setsTitle() {
         let sut = LegalDocumentViewModel(documentType: .privacyPolicy)


### PR DESCRIPTION
## Summary

Implements `tc-bc33e354`: Simplify: remove Observable from static ViewModels (iOS)

Converts HomeViewModel and LegalDocumentViewModel from ObservableObject classes to Sendable structs with let properties, since their values never change after init. Removes unnecessary Combine dependency.

## Bead

`tc-bc33e354` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the architectural structure of Home and Legal Document features to enhance code organization and long-term maintainability.
  * Updated test configurations to align with the refactored architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->