### PR TITLE
refactor(ios): extract shared PrimaryButton component

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/EmptyStateView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/EmptyStateView.swift
@@ -39,16 +39,7 @@ public struct EmptyStateView: View {
                 .multilineTextAlignment(.center)
 
             if let actionLabel, let action {
-                Button(action: action) {
-                    Text(actionLabel)
-                        .font(TCTypography.bodyEmphasis)
-                        .frame(height: 44)
-                        .padding(.horizontal, TCSpacing.medium)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(Color.tcAmber)
-                .foregroundStyle(Color.tcTextOnAccent)
-                .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+                PrimaryButton(actionLabel, action: action)
             }
         }
         .padding(TCSpacing.extraLarge)

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ErrorStateView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ErrorStateView.swift
@@ -28,21 +28,15 @@ public struct ErrorStateView: View {
                 .multilineTextAlignment(.center)
 
             if error.isRetryable, let retryAction {
-                Button {
-                    Task { await retryAction() }
-                } label: {
-                    HStack(spacing: TCSpacing.extraSmall) {
-                        Image(systemName: "arrow.clockwise")
-                        Text("Try Again")
-                            .font(TCTypography.bodyEmphasis)
+                PrimaryButton(
+                    action: { Task { await retryAction() } },
+                    label: {
+                        HStack(spacing: TCSpacing.extraSmall) {
+                            Image(systemName: "arrow.clockwise")
+                            Text("Try Again")
+                        }
                     }
-                    .frame(height: 44)
-                    .padding(.horizontal, TCSpacing.medium)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(Color.tcAmber)
-                .foregroundStyle(Color.tcTextOnAccent)
-                .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+                )
             }
         }
         .padding(TCSpacing.extraLarge)

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/PrimaryButton.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/PrimaryButton.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+/// Primary action button following the Town Crier design language.
+///
+/// Renders a full-width, amber-tinted bordered-prominent button with
+/// `tcTextOnAccent` foreground, `bodyEmphasis` font, 44pt minimum height,
+/// and medium corner radius. Supports an optional loading state that
+/// replaces the label with a progress spinner.
+///
+/// Usage with a title string:
+/// ```swift
+/// PrimaryButton("Subscribe") {
+///     await viewModel.subscribe()
+/// }
+/// ```
+///
+/// Usage with a custom label:
+/// ```swift
+/// PrimaryButton(action: { showSafari = true }) {
+///     HStack {
+///         Image(systemName: "safari")
+///         Text("View on Council Portal")
+///     }
+/// }
+/// ```
+public struct PrimaryButton<Label: View>: View {
+    private let action: () -> Void
+    private let isLoading: Bool
+    private let isDisabled: Bool
+    private let label: () -> Label
+
+    public init(
+        isLoading: Bool = false,
+        isDisabled: Bool = false,
+        action: @escaping () -> Void,
+        label: @escaping () -> Label
+    ) {
+        self.action = action
+        self.isLoading = isLoading
+        self.isDisabled = isDisabled
+        self.label = label
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            Group {
+                if isLoading {
+                    ProgressView()
+                        .tint(Color.tcTextOnAccent)
+                } else {
+                    label()
+                        .font(TCTypography.bodyEmphasis)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(minHeight: 44)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(Color.tcAmber)
+        .foregroundStyle(Color.tcTextOnAccent)
+        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+        .disabled(isLoading || isDisabled)
+    }
+}
+
+// MARK: - Convenience initializer for text-only labels
+
+extension PrimaryButton where Label == Text {
+    public init(
+        _ title: String,
+        isLoading: Bool = false,
+        isDisabled: Bool = false,
+        action: @escaping () -> Void
+    ) {
+        self.action = action
+        self.isLoading = isLoading
+        self.isDisabled = isDisabled
+        self.label = { Text(title) }
+    }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
@@ -107,21 +107,15 @@ public struct ApplicationDetailView: View {
     // MARK: - Portal Button
 
     private var portalButton: some View {
-        Button {
-            showingSafari = true
-        } label: {
-            HStack {
-                Image(systemName: "safari")
-                Text("View on Council Portal")
-                    .font(TCTypography.bodyEmphasis)
+        PrimaryButton(
+            action: { showingSafari = true },
+            label: {
+                HStack {
+                    Image(systemName: "safari")
+                    Text("View on Council Portal")
+                }
             }
-            .frame(maxWidth: .infinity)
-            .frame(height: 44)
-        }
-        .buttonStyle(.borderedProminent)
-        .tint(Color.tcAmber)
-        .foregroundStyle(Color.tcTextOnAccent)
-        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+        )
     }
 
     // MARK: - Status Color

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Login/LoginView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Login/LoginView.swift
@@ -51,28 +51,14 @@ public struct LoginView: View {
     }
 
     private var loginButton: some View {
-        Button {
+        PrimaryButton(
+            "Sign in",
+            isLoading: viewModel.isLoading
+        ) {
             Task {
                 await viewModel.login()
             }
-        } label: {
-            Group {
-                if viewModel.isLoading {
-                    ProgressView()
-                        .tint(Color.tcTextOnAccent)
-                } else {
-                    Text("Sign in")
-                        .font(TCTypography.bodyEmphasis)
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .frame(height: 44)
         }
-        .buttonStyle(.borderedProminent)
-        .tint(Color.tcAmber)
-        .foregroundStyle(Color.tcTextOnAccent)
-        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
-        .disabled(viewModel.isLoading)
     }
 
     private func errorMessage(_ error: DomainError) -> some View {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionView.swift
@@ -107,25 +107,12 @@ public struct SubscriptionView: View {
     }
 
     private func purchaseButton(for product: SubscriptionProduct) -> some View {
-        Button {
+        PrimaryButton(
+            product.hasFreeTrial ? "Start Free Trial" : "Subscribe",
+            isLoading: viewModel.isPurchasing
+        ) {
             Task { await viewModel.purchase(productId: product.id) }
-        } label: {
-            Group {
-                if viewModel.isPurchasing {
-                    ProgressView()
-                        .tint(Color.tcTextOnAccent)
-                } else {
-                    Text(product.hasFreeTrial ? "Start Free Trial" : "Subscribe")
-                        .font(TCTypography.bodyEmphasis)
-                }
-            }
-            .frame(maxWidth: .infinity)
-            .frame(minHeight: 44)
         }
-        .foregroundStyle(Color.tcTextOnAccent)
-        .background(Color.tcAmber)
-        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
-        .disabled(viewModel.isPurchasing)
     }
 
     private var currentPlanLabel: some View {
@@ -179,17 +166,9 @@ public struct SubscriptionView: View {
                 .foregroundStyle(Color.tcTextSecondary)
                 .multilineTextAlignment(.center)
 
-            Button {
+            PrimaryButton("Try Again") {
                 Task { await viewModel.loadProducts() }
-            } label: {
-                Text("Try Again")
-                    .font(TCTypography.bodyEmphasis)
-                    .frame(maxWidth: .infinity)
-                    .frame(minHeight: 44)
             }
-            .foregroundStyle(Color.tcTextOnAccent)
-            .background(Color.tcAmber)
-            .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
         }
         .padding(.top, TCSpacing.large)
     }

--- a/mobile/ios/town-crier-tests/Sources/Features/PrimaryButtonTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/PrimaryButtonTests.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+import Testing
+
+@testable import TownCrierPresentation
+
+@Suite("PrimaryButton")
+struct PrimaryButtonTests {
+
+    // MARK: - Title convenience initializer
+
+    @Test func init_withTitle_isAView() {
+        let sut = PrimaryButton("Submit") {}
+        // PrimaryButton conforms to View — the compiler enforces this.
+        // Verifying instantiation succeeds with all default parameters.
+        let _: any View = sut
+    }
+
+    @Test func init_withTitleAndLoading_isAView() {
+        let sut = PrimaryButton("Subscribe", isLoading: true) {}
+        let _: any View = sut
+    }
+
+    @Test func init_withTitleAndDisabled_isAView() {
+        let sut = PrimaryButton("Subscribe", isDisabled: true) {}
+        let _: any View = sut
+    }
+
+    // MARK: - Custom label initializer
+
+    @Test func init_withCustomLabel_isAView() {
+        let sut = PrimaryButton(
+            action: {},
+            label: {
+                HStack {
+                    Image(systemName: "safari")
+                    Text("View on Council Portal")
+                }
+            }
+        )
+        let _: any View = sut
+    }
+
+    @Test func init_withCustomLabelAndLoading_isAView() {
+        let sut = PrimaryButton(
+            isLoading: true,
+            action: {},
+            label: { Text("Loading") }
+        )
+        let _: any View = sut
+    }
+
+    // MARK: - Default parameter values
+
+    @Test func init_defaultsLoadingToFalse() {
+        // Compiles without specifying isLoading — verifies default exists.
+        let _: any View = PrimaryButton("Go") {}
+    }
+
+    @Test func init_defaultsDisabledToFalse() {
+        // Compiles without specifying isDisabled — verifies default exists.
+        let _: any View = PrimaryButton("Go") {}
+    }
+}


### PR DESCRIPTION
## Summary

Implements `tc-b06a7cb7`: Simplify: extract shared PrimaryButton component (iOS)

Creates a reusable PrimaryButton component in DesignSystem/Components, replacing duplicate button styling across 5 views (LoginView, ErrorStateView, EmptyStateView, ApplicationDetailView, SubscriptionView). Includes isLoading/isDisabled support and 7 new tests.

## Bead

`tc-b06a7cb7` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a unified primary button component with consistent styling, loading state support, and disabled state handling across the app.

* **Refactor**
  * Updated various views to use the new button component, ensuring visual consistency and reducing code duplication.

* **Tests**
  * Added comprehensive test coverage for the new button component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->