### PR TITLE
refactor(ios): extract shared PrimaryButton component

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/EmptyStateView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/EmptyStateView.swift
@@ -39,16 +39,8 @@ public struct EmptyStateView: View {
                 .multilineTextAlignment(.center)
 
             if let actionLabel, let action {
-                Button(action: action) {
-                    Text(actionLabel)
-                        .font(TCTypography.bodyEmphasis)
-                        .frame(height: 44)
-                        .padding(.horizontal, TCSpacing.medium)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(Color.tcAmber)
-                .foregroundStyle(Color.tcTextOnAccent)
-                .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+                PrimaryButton(actionLabel, action: action)
+                    .padding(.horizontal, TCSpacing.medium)
             }
         }
         .padding(TCSpacing.extraLarge)

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ErrorStateView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ErrorStateView.swift
@@ -28,21 +28,15 @@ public struct ErrorStateView: View {
                 .multilineTextAlignment(.center)
 
             if error.isRetryable, let retryAction {
-                Button {
+                PrimaryButton {
                     Task { await retryAction() }
                 } label: {
                     HStack(spacing: TCSpacing.extraSmall) {
                         Image(systemName: "arrow.clockwise")
                         Text("Try Again")
-                            .font(TCTypography.bodyEmphasis)
                     }
-                    .frame(height: 44)
-                    .padding(.horizontal, TCSpacing.medium)
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(Color.tcAmber)
-                .foregroundStyle(Color.tcTextOnAccent)
-                .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+                .padding(.horizontal, TCSpacing.medium)
             }
         }
         .padding(TCSpacing.extraLarge)

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/PrimaryButton.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/PrimaryButton.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// Primary call-to-action button following the Town Crier design language.
+///
+/// Applies `borderedProminent` style with `tcAmber` tint, `tcTextOnAccent` foreground,
+/// `bodyEmphasis` font, full-width layout, 44pt minimum height, and medium corner radius.
+///
+/// Usage:
+/// ```swift
+/// // Simple text label
+/// PrimaryButton("Subscribe") {
+///     await viewModel.subscribe()
+/// }
+///
+/// // Custom label with icon
+/// PrimaryButton {
+///     viewModel.openPortal()
+/// } label: {
+///     HStack {
+///         Image(systemName: "safari")
+///         Text("View on Council Portal")
+///     }
+/// }
+/// ```
+public struct PrimaryButton<Label: View>: View {
+    private let action: () -> Void
+    private let label: Label
+
+    public init(action: @escaping () -> Void, @ViewBuilder label: () -> Label) {
+        self.action = action
+        self.label = label()
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            label
+                .font(TCTypography.bodyEmphasis)
+                .frame(maxWidth: .infinity)
+                .frame(height: 44)
+        }
+        .buttonStyle(.borderedProminent)
+        .tint(Color.tcAmber)
+        .foregroundStyle(Color.tcTextOnAccent)
+        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+    }
+}
+
+extension PrimaryButton where Label == Text {
+    /// Convenience initializer for simple text-only buttons.
+    public init(_ title: String, action: @escaping () -> Void) {
+        self.action = action
+        self.label = Text(title)
+    }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
@@ -107,21 +107,14 @@ public struct ApplicationDetailView: View {
     // MARK: - Portal Button
 
     private var portalButton: some View {
-        Button {
+        PrimaryButton {
             showingSafari = true
         } label: {
             HStack {
                 Image(systemName: "safari")
                 Text("View on Council Portal")
-                    .font(TCTypography.bodyEmphasis)
             }
-            .frame(maxWidth: .infinity)
-            .frame(height: 44)
         }
-        .buttonStyle(.borderedProminent)
-        .tint(Color.tcAmber)
-        .foregroundStyle(Color.tcTextOnAccent)
-        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
     }
 
     // MARK: - Status Color

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Login/LoginView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Login/LoginView.swift
@@ -51,27 +51,18 @@ public struct LoginView: View {
     }
 
     private var loginButton: some View {
-        Button {
+        PrimaryButton {
             Task {
                 await viewModel.login()
             }
         } label: {
-            Group {
-                if viewModel.isLoading {
-                    ProgressView()
-                        .tint(Color.tcTextOnAccent)
-                } else {
-                    Text("Sign in")
-                        .font(TCTypography.bodyEmphasis)
-                }
+            if viewModel.isLoading {
+                ProgressView()
+                    .tint(Color.tcTextOnAccent)
+            } else {
+                Text("Sign in")
             }
-            .frame(maxWidth: .infinity)
-            .frame(height: 44)
         }
-        .buttonStyle(.borderedProminent)
-        .tint(Color.tcAmber)
-        .foregroundStyle(Color.tcTextOnAccent)
-        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
         .disabled(viewModel.isLoading)
     }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionView.swift
@@ -107,24 +107,16 @@ public struct SubscriptionView: View {
     }
 
     private func purchaseButton(for product: SubscriptionProduct) -> some View {
-        Button {
+        PrimaryButton {
             Task { await viewModel.purchase(productId: product.id) }
         } label: {
-            Group {
-                if viewModel.isPurchasing {
-                    ProgressView()
-                        .tint(Color.tcTextOnAccent)
-                } else {
-                    Text(product.hasFreeTrial ? "Start Free Trial" : "Subscribe")
-                        .font(TCTypography.bodyEmphasis)
-                }
+            if viewModel.isPurchasing {
+                ProgressView()
+                    .tint(Color.tcTextOnAccent)
+            } else {
+                Text(product.hasFreeTrial ? "Start Free Trial" : "Subscribe")
             }
-            .frame(maxWidth: .infinity)
-            .frame(minHeight: 44)
         }
-        .foregroundStyle(Color.tcTextOnAccent)
-        .background(Color.tcAmber)
-        .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
         .disabled(viewModel.isPurchasing)
     }
 
@@ -179,17 +171,9 @@ public struct SubscriptionView: View {
                 .foregroundStyle(Color.tcTextSecondary)
                 .multilineTextAlignment(.center)
 
-            Button {
+            PrimaryButton("Try Again") {
                 Task { await viewModel.loadProducts() }
-            } label: {
-                Text("Try Again")
-                    .font(TCTypography.bodyEmphasis)
-                    .frame(maxWidth: .infinity)
-                    .frame(minHeight: 44)
             }
-            .foregroundStyle(Color.tcTextOnAccent)
-            .background(Color.tcAmber)
-            .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
         }
         .padding(.top, TCSpacing.large)
     }

--- a/mobile/ios/town-crier-tests/Sources/Features/PrimaryButtonTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/PrimaryButtonTests.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+import Testing
+
+@testable import TownCrierPresentation
+
+@Suite("PrimaryButton")
+@MainActor
+struct PrimaryButtonTests {
+
+    // MARK: - Initialization
+
+    @Test func init_withTitleAndAction_createsButton() {
+        var actionCalled = false
+        let sut = PrimaryButton("Sign in") { actionCalled = true }
+        _ = sut
+        // The button should exist without crashing.
+        #expect(!actionCalled)
+    }
+
+    @Test func init_acceptsStringTitle() {
+        let sut = PrimaryButton("Subscribe") {}
+        _ = sut.body
+        // Should compile and render without crashing.
+    }
+
+    // MARK: - Custom label
+
+    @Test func init_withCustomLabel_rendersBody() {
+        let sut = PrimaryButton {
+            // action
+        } label: {
+            HStack {
+                Image(systemName: "safari")
+                Text("View on Council Portal")
+            }
+        }
+        _ = sut.body
+        // Should compile and render without crashing.
+    }
+}


### PR DESCRIPTION
## Summary

Implements `tc-b06a7cb7`: Simplify: extract shared PrimaryButton component (iOS)

Creates a generic `PrimaryButton<Label>` component in DesignSystem/Components with standard styling (borderedProminent, tcAmber, bodyEmphasis, full-width, 44pt height). Replaces duplicated button styling across 5 views (6 button instances). Tests use @MainActor (fixed from PR #56).

## Bead

`tc-b06a7cb7` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced a new unified button component that standardizes button styling and behavior across multiple application screens. This consolidation replaces previously scattered button implementations found in login, subscription, error states, and detail screens.

* **Tests**
  * Added test coverage for the button component, validating initialization and action execution logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->