### PR TITLE
docs(adr): audit — add /web to monorepo ADR, create CI/CD ADR 0015

### DIFF
--- a/.beads/push-state.json
+++ b/.beads/push-state.json
@@ -1,4 +1,4 @@
 {
-  "last_push": "2026-03-27T22:00:55Z",
-  "last_commit": "scau53d4t7ifb84ugab0f34iinorgg10"
+  "last_push": "2026-03-28T10:18:02Z",
+  "last_commit": "5rsthl6b650jgjj69j19k0qvenckce35"
 }

--- a/.claude/skills/autopilot/SKILL.md
+++ b/.claude/skills/autopilot/SKILL.md
@@ -27,18 +27,22 @@ Invoke `/beads:ready` to find beads with no blockers.
 
 **No beads ready?** Report `Autopilot: no ready beads — idle` and return.
 
-**Beads available?** Pick the **first** one (highest priority). Invoke `/beads:show <bead-id>` to read its full context — title, description, notes, design, and any comments from previous autopilot attempts.
+**Beads available?** Walk the list from highest priority to lowest, selecting the first bead that passes all filters below. For each candidate, invoke `/beads:show <bead-id>` and apply these filters in order:
 
-### Retry Guard
+### Filter: Skip Epics
+
+If the bead's type is `epic`, skip it — epics are containers, not implementable units. Continue to the next candidate.
+
+### Filter: Retry Guard
 
 If the bead's notes already contain **two or more** `Autopilot:` failure entries (from prior failed PR attempts), this bead has been tried and failed repeatedly. Do **not** retry it — instead:
 
 1. Invoke `/beads:update <bead-id> --notes="Autopilot: flagged for human review after repeated failures"`.
-2. Report `Autopilot: <bead-id> flagged for human review (repeated failures)` and return.
+2. Skip to the next candidate.
 
 This prevents infinite retry loops. A human needs to look at it.
 
-## Phase 2: Classify and Dispatch
+### Filter: Classify Worker Type
 
 Determine the worker type from the bead's description and any labels:
 
@@ -50,7 +54,15 @@ Determine the worker type from the bead's description and any labels:
 | Pulumi, infrastructure, IaC, Azure, Container Apps, resource group, `infra` paths | `pulumi-infra-worker` |
 | CI/CD, pipeline, GitHub Actions, workflow, deployment, `.github/workflows` paths | `github-actions-worker` |
 
-**Ambiguous?** Read the description carefully. If still unclear, skip this bead — report `Autopilot: skipped <bead-id> — could not classify worker type` and return. Do not guess.
+Read the description carefully. If the bead cannot be mapped to any worker (e.g., manual tasks like App Store setup, or genuinely ambiguous), skip it and continue to the next candidate. Do not guess.
+
+### No Candidate Found
+
+If every ready bead was filtered out, report `Autopilot: no dispatchable beads — <N> ready but all filtered (epics, retry-limited, or unclassifiable)` and return.
+
+## Phase 2: Dispatch
+
+You now have a selected bead and its worker type from the filters above.
 
 Mark the bead in-progress:
 

--- a/docs/adr/0002-monorepo-structure.md
+++ b/docs/adr/0002-monorepo-structure.md
@@ -64,3 +64,6 @@ Located in `/infra`, utilizing **.NET 10 (C#)**:
 ### 2026-03-27
 - Updated: iOS test framework changed from XCTest to **Swift Testing** (`import Testing`, `@Suite`, `@Test`, `#expect()`). The `swift-testing` package (v0.99.0) is declared as an SPM dependency. Test doubles follow a spy/stub pattern with async support.
 - Updated: iOS data layer does not use **SwiftData**. Persistence uses `UserDefaults` for onboarding state and an `Actor`-based in-memory cache (`InMemoryApplicationCacheStore`) with TTL for offline support. No on-device database is currently in use.
+
+### 2026-03-28
+- Added: **`/web`** directory for the React + TypeScript web frontend (see [ADR 0011](0011-web-frontend-stack.md) for technology choices). Internal structure follows a feature-sliced layout with `src/` containing domain ports, API adapters, features, components, and hooks. Tests are colocated in `__tests__/` directories within each feature. Build tooling (Vite, ESLint, TypeScript) configured at the `/web` root.

--- a/docs/adr/0015-cicd-pipeline-and-deployment-strategy.md
+++ b/docs/adr/0015-cicd-pipeline-and-deployment-strategy.md
@@ -1,0 +1,74 @@
+# 0015. CI/CD Pipeline and Deployment Strategy
+
+Date: 2026-03-28
+
+## Status
+
+Accepted
+
+## Context
+
+Town Crier is a monorepo with four independently deployable components: a .NET API, an iOS app, a React web frontend, and Pulumi infrastructure. Each component has different build tools, test suites, and deployment targets. The CI/CD pipeline needs to validate changes efficiently (avoiding full rebuilds when only one component changes), deploy to multiple environments safely, and authenticate to Azure without storing long-lived secrets.
+
+ADR 0001 selected GitHub Actions for CI/CD but did not specify the pipeline architecture, environment promotion strategy, or authentication model.
+
+## Decision
+
+### Pipeline Architecture: Three Workflows
+
+1. **PR Gate** (`pr-gate.yml`) — runs on every pull request to `main`. Uses path-based change detection to determine which components changed (`api/`, `mobile/ios/`, `web/`, `infra/`) and only runs the relevant quality gates. A single required status check (`gate`) aggregates all component results, so GitHub branch protection needs only one check regardless of which components ran.
+
+2. **CD Dev** (`cd-dev.yml`) — runs on every push to `main` (i.e., after PR merge). Deploys changed components to the development environment automatically. Infrastructure stacks (`shared` then `dev`) are applied first, then API and web are deployed in parallel.
+
+3. **CD Prod** (`cd-prod.yml`) — runs on semver tags matching `v*`. Deploys to the production environment. The API image is resolved by the tag's commit SHA (falling back to `:latest` if the SHA-tagged image is unavailable). This ensures production always runs the exact code that was tagged.
+
+### Component-Aware Change Detection
+
+Each workflow detects changes per component directory. If only `/web` changed, only web quality gates and web deployment run. This keeps PR feedback fast and avoids unnecessary Azure resource churn. Shared workflow file changes trigger all component checks.
+
+### Quality Gates (PR)
+
+| Component | Checks |
+|-----------|--------|
+| API | `dotnet format --verify-no-changes`, `dotnet build` (Release), `dotnet test` |
+| iOS | SwiftLint (`--strict`), `xcodebuild` (iPhone 16 simulator), `swift test` |
+| Web | ESLint, TypeScript type-check (`tsc --noEmit`), Vitest, Vite production build |
+| Infra | `pulumi preview` with PR comment showing planned changes |
+
+### Azure Authentication: OIDC Federated Credentials
+
+All workflows authenticate to Azure using **OpenID Connect (OIDC) federated credentials** rather than stored service principal secrets. GitHub Actions requests a short-lived token from Azure AD using the workflow's OIDC identity, scoped to the specific environment (development or production). This eliminates secret rotation, reduces blast radius of credential compromise, and aligns with zero-trust principles.
+
+Secrets stored in GitHub:
+- `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` — identity coordinates (not sensitive on their own)
+- `ACR_LOGIN_SERVER` — container registry hostname
+- `PULUMI_ACCESS_TOKEN` — Pulumi Cloud state backend authentication
+
+No Azure service principal passwords or client secrets are stored.
+
+### Environment Promotion Strategy
+
+| Trigger | Target | Mechanism |
+|---------|--------|-----------|
+| PR opened/updated | Preview | Pulumi preview (comment on PR), web type-check and tests |
+| PR merged to `main` | Development | Automatic: infra up, API image build + deploy, web SWA deploy |
+| Semver tag (`v*`) | Production | Automatic: infra up, API image resolve + deploy, web SWA deploy |
+
+Production deployments require an explicit tagging action — they never happen automatically on merge. This provides a deliberate release gate while still keeping the deployment itself automated.
+
+### Container Image Strategy
+
+The API is built as a Docker image and pushed to Azure Container Registry with two tags: the commit SHA (`town-crier-api:{sha}`) and `:latest`. The dev CD pipeline always builds and pushes a fresh image. The prod CD pipeline resolves the tag's commit SHA and pulls the corresponding pre-built image from ACR, ensuring prod runs the exact same binary that was tested in dev.
+
+### Web Deployment
+
+The React SPA is deployed to **Azure Static Web Apps** using the official `Azure/static-web-apps-deploy` GitHub Action. Environment-specific configuration (API base URL, Auth0 domain/client ID/audience) is injected at build time via `VITE_*` environment variables stored as GitHub Actions variables.
+
+## Consequences
+
+- **Faster PR feedback** — component-aware detection means a web-only change doesn't wait for .NET builds or iOS simulator tests.
+- **No secret rotation burden** — OIDC federated credentials are ephemeral. No periodic rotation, no leaked-secret incident response.
+- **Deterministic production deploys** — SHA-tagged images guarantee prod runs the tested code, not whatever `:latest` happens to be.
+- **Tag-based release gating** — production deploys require human intent (creating a tag), preventing accidental releases from fast-forwarded merges.
+- **Single required check simplifies branch protection** — the `gate` job aggregates all components, so adding a new component doesn't require updating GitHub branch protection rules.
+- **iOS builds run on macOS runners** — GitHub's macOS runners are slower and more expensive than Linux. The component-aware detection mitigates this by only running iOS checks when `/mobile/ios` changes.


### PR DESCRIPTION
## Changes
- **ADR 0002 amended:** Added `/web` directory to the monorepo structure description, cross-referencing ADR 0011
- **ADR 0015 created:** Documents the CI/CD pipeline architecture — component-aware PR gates, OIDC federated credentials, dev-on-merge deployment, and tag-based production releases
- **Autopilot skill updated:** Skip epics, walk candidates instead of picking first, continue on retry-guard failures

---
*Auto-shipped via ship skill*