### PR TITLE
refactor(ios): replace AppCoordinator optional deps with required injection

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -4,158 +4,141 @@ import TownCrierDomain
 /// Root coordinator managing top-level navigation.
 @MainActor
 public final class AppCoordinator: ObservableObject {
-    @Published public var detailApplication: PlanningApplication?
-    @Published public var deepLinkError: DomainError?
+  @Published public var detailApplication: PlanningApplication?
+  @Published public var deepLinkError: DomainError?
 
-    public var isOnboardingComplete: Bool {
-        onboardingRepository?.isOnboardingComplete ?? false
+  public var isOnboardingComplete: Bool {
+    onboardingRepository.isOnboardingComplete
+  }
+
+  private let repository: PlanningApplicationRepository
+  private let authService: AuthenticationService
+  private let subscriptionService: SubscriptionService
+  private let geocoder: PostcodeGeocoder
+  private let watchZoneRepository: WatchZoneRepository
+  private let onboardingRepository: OnboardingRepository
+  private let notificationService: NotificationService
+  private let offlineRepository: OfflineAwareRepository?
+  private let appVersionProvider: AppVersionProvider
+  private let versionConfigService: VersionConfigService
+
+  public init(
+    repository: PlanningApplicationRepository,
+    authService: AuthenticationService,
+    subscriptionService: SubscriptionService,
+    offlineRepository: OfflineAwareRepository? = nil,
+    geocoder: PostcodeGeocoder,
+    watchZoneRepository: WatchZoneRepository,
+    onboardingRepository: OnboardingRepository,
+    notificationService: NotificationService,
+    appVersionProvider: AppVersionProvider,
+    versionConfigService: VersionConfigService
+  ) {
+    self.repository = repository
+    self.authService = authService
+    self.subscriptionService = subscriptionService
+    self.offlineRepository = offlineRepository
+    self.geocoder = geocoder
+    self.watchZoneRepository = watchZoneRepository
+    self.onboardingRepository = onboardingRepository
+    self.notificationService = notificationService
+    self.appVersionProvider = appVersionProvider
+    self.versionConfigService = versionConfigService
+  }
+
+  public func makeLoginViewModel() -> LoginViewModel {
+    LoginViewModel(authService: authService)
+  }
+
+  public func makeHomeViewModel() -> HomeViewModel {
+    HomeViewModel()
+  }
+
+  public func makeLegalDocumentViewModel(
+    _ documentType: LegalDocumentType
+  ) -> LegalDocumentViewModel {
+    LegalDocumentViewModel(documentType: documentType)
+  }
+
+  public func makeMapViewModel(watchZone: WatchZone) -> MapViewModel {
+    if let offlineRepository {
+      return MapViewModel(offlineRepository: offlineRepository, watchZone: watchZone)
     }
+    return MapViewModel(repository: repository, watchZone: watchZone)
+  }
 
-    private let repository: PlanningApplicationRepository
-    private let authService: AuthenticationService
-    private let subscriptionService: SubscriptionService
-    private let geocoder: PostcodeGeocoder?
-    private let watchZoneRepository: WatchZoneRepository?
-    private let onboardingRepository: OnboardingRepository?
-    private let notificationService: NotificationService?
-    private let offlineRepository: OfflineAwareRepository?
-    private let appVersionProvider: AppVersionProvider?
-    private let versionConfigService: VersionConfigService?
-
-    public init(
-        repository: PlanningApplicationRepository,
-        authService: AuthenticationService,
-        subscriptionService: SubscriptionService,
-        offlineRepository: OfflineAwareRepository? = nil,
-        geocoder: PostcodeGeocoder? = nil,
-        watchZoneRepository: WatchZoneRepository? = nil,
-        onboardingRepository: OnboardingRepository? = nil,
-        notificationService: NotificationService? = nil,
-        appVersionProvider: AppVersionProvider? = nil,
-        versionConfigService: VersionConfigService? = nil
-    ) {
-        self.repository = repository
-        self.authService = authService
-        self.subscriptionService = subscriptionService
-        self.offlineRepository = offlineRepository
-        self.geocoder = geocoder
-        self.watchZoneRepository = watchZoneRepository
-        self.onboardingRepository = onboardingRepository
-        self.notificationService = notificationService
-        self.appVersionProvider = appVersionProvider
-        self.versionConfigService = versionConfigService
+  public func makeApplicationListViewModel(
+    authority: LocalAuthority
+  ) -> ApplicationListViewModel {
+    let viewModel: ApplicationListViewModel
+    if let offlineRepository {
+      viewModel = ApplicationListViewModel(
+        offlineRepository: offlineRepository, authority: authority)
+    } else {
+      viewModel = ApplicationListViewModel(repository: repository, authority: authority)
     }
-
-    public func makeLoginViewModel() -> LoginViewModel {
-        LoginViewModel(authService: authService)
+    viewModel.onApplicationSelected = { [weak self] id in
+      self?.showApplicationDetail(id)
     }
+    return viewModel
+  }
 
-    public func makeHomeViewModel() -> HomeViewModel {
-        HomeViewModel()
-    }
+  public func makeOnboardingViewModel() -> OnboardingViewModel {
+    OnboardingViewModel(
+      geocoder: geocoder,
+      watchZoneRepository: watchZoneRepository,
+      onboardingRepository: onboardingRepository,
+      notificationService: notificationService
+    )
+  }
 
-    public func makeLegalDocumentViewModel(
-        _ documentType: LegalDocumentType
-    ) -> LegalDocumentViewModel {
-        LegalDocumentViewModel(documentType: documentType)
-    }
+  public func makeSubscriptionViewModel() -> SubscriptionViewModel {
+    SubscriptionViewModel(subscriptionService: subscriptionService)
+  }
 
-    public func makeMapViewModel(watchZone: WatchZone) -> MapViewModel {
-        if let offlineRepository {
-            return MapViewModel(offlineRepository: offlineRepository, watchZone: watchZone)
-        }
-        return MapViewModel(repository: repository, watchZone: watchZone)
-    }
+  public func makeSettingsViewModel() -> SettingsViewModel {
+    SettingsViewModel(
+      authService: authService,
+      subscriptionService: subscriptionService,
+      appVersionProvider: appVersionProvider,
+      notificationService: notificationService
+    )
+  }
 
-    public func makeApplicationListViewModel(
-        authority: LocalAuthority
-    ) -> ApplicationListViewModel {
-        let viewModel: ApplicationListViewModel
-        if let offlineRepository {
-            viewModel = ApplicationListViewModel(offlineRepository: offlineRepository, authority: authority)
-        } else {
-            viewModel = ApplicationListViewModel(repository: repository, authority: authority)
-        }
-        viewModel.onApplicationSelected = { [weak self] id in
-            self?.showApplicationDetail(id)
-        }
-        return viewModel
-    }
+  public func makeForceUpdateViewModel() -> ForceUpdateViewModel {
+    ForceUpdateViewModel(
+      versionConfigService: versionConfigService,
+      appVersionProvider: appVersionProvider
+    )
+  }
 
-    public func makeOnboardingViewModel() -> OnboardingViewModel {
-        guard let geocoder = geocoder, let watchZoneRepository = watchZoneRepository,
-              let onboardingRepository = onboardingRepository,
-              let notificationService = notificationService
-        else {
-            preconditionFailure("Onboarding dependencies not provided to AppCoordinator")
-        }
-        let viewModel = OnboardingViewModel(
-            geocoder: geocoder,
-            watchZoneRepository: watchZoneRepository,
-            onboardingRepository: onboardingRepository,
-            notificationService: notificationService
-        )
-        return viewModel
+  public func makeApplicationDetailViewModel(
+    application: PlanningApplication
+  ) -> ApplicationDetailViewModel {
+    let viewModel = ApplicationDetailViewModel(application: application)
+    viewModel.onDismiss = { [weak self] in
+      self?.detailApplication = nil
     }
+    return viewModel
+  }
 
-    public func makeSubscriptionViewModel() -> SubscriptionViewModel {
-        SubscriptionViewModel(subscriptionService: subscriptionService)
+  public func handleDeepLink(_ deepLink: DeepLink) {
+    deepLinkError = nil
+    switch deepLink {
+    case .applicationDetail(let id):
+      showApplicationDetail(id)
     }
+  }
 
-    public func makeSettingsViewModel() -> SettingsViewModel {
-        guard let appVersionProvider = appVersionProvider,
-              let notificationService = notificationService
-        else {
-            preconditionFailure("AppVersionProvider or NotificationService not provided to AppCoordinator")
-        }
-        let viewModel = SettingsViewModel(
-            authService: authService,
-            subscriptionService: subscriptionService,
-            appVersionProvider: appVersionProvider,
-            notificationService: notificationService
-        )
-        return viewModel
+  private func showApplicationDetail(_ id: PlanningApplicationId) {
+    Task {
+      do {
+        detailApplication = try await repository.fetchApplication(by: id)
+      } catch let domainError as DomainError {
+        deepLinkError = domainError
+      } catch {
+        deepLinkError = .unexpected(error.localizedDescription)
+      }
     }
-
-    public func makeForceUpdateViewModel() -> ForceUpdateViewModel {
-        guard let appVersionProvider = appVersionProvider,
-              let versionConfigService = versionConfigService
-        else {
-            preconditionFailure("Version dependencies not provided to AppCoordinator")
-        }
-        return ForceUpdateViewModel(
-            versionConfigService: versionConfigService,
-            appVersionProvider: appVersionProvider
-        )
-    }
-
-    public func makeApplicationDetailViewModel(
-        application: PlanningApplication
-    ) -> ApplicationDetailViewModel {
-        let viewModel = ApplicationDetailViewModel(application: application)
-        viewModel.onDismiss = { [weak self] in
-            self?.detailApplication = nil
-        }
-        return viewModel
-    }
-
-    public func handleDeepLink(_ deepLink: DeepLink) {
-        deepLinkError = nil
-        switch deepLink {
-        case .applicationDetail(let id):
-            showApplicationDetail(id)
-        }
-    }
-
-    private func showApplicationDetail(_ id: PlanningApplicationId) {
-        Task {
-            do {
-                detailApplication = try await repository.fetchApplication(by: id)
-            } catch let domainError as DomainError {
-                deepLinkError = domainError
-            } catch {
-                deepLinkError = .unexpected(error.localizedDescription)
-            }
-        }
-    }
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -7,200 +7,202 @@ import TownCrierDomain
 @Suite("AppCoordinator")
 @MainActor
 struct AppCoordinatorTests {
-    private func makeSUT() -> (AppCoordinator, SpyPlanningApplicationRepository) {
-        let spy = SpyPlanningApplicationRepository()
-        let authSpy = SpyAuthenticationService()
-        let subscriptionSpy = SpySubscriptionService()
-        let coordinator = AppCoordinator(
-            repository: spy,
-            authService: authSpy,
-            subscriptionService: subscriptionSpy,
-            geocoder: SpyPostcodeGeocoder(),
-            watchZoneRepository: SpyWatchZoneRepository(),
-            onboardingRepository: SpyOnboardingRepository(),
-            notificationService: SpyNotificationService()
-        )
-        return (coordinator, spy)
-    }
+  private func makeSUT() -> (AppCoordinator, SpyPlanningApplicationRepository) {
+    let spy = SpyPlanningApplicationRepository()
+    let coordinator = AppCoordinator(
+      repository: spy,
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      geocoder: SpyPostcodeGeocoder(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService()
+    )
+    return (coordinator, spy)
+  }
 
-    // MARK: - Detail ViewModel Factory
+  // MARK: - Detail ViewModel Factory
 
-    @Test func makeApplicationDetailViewModel_createsViewModelWithApplication() {
-        let (sut, _) = makeSUT()
-        let vm = sut.makeApplicationDetailViewModel(application: .pendingReview)
+  @Test func makeApplicationDetailViewModel_createsViewModelWithApplication() {
+    let (sut, _) = makeSUT()
+    let vm = sut.makeApplicationDetailViewModel(application: .pendingReview)
 
-        #expect(vm.reference == "2026/0042")
-        #expect(vm.address == "12 Mill Road, Cambridge, CB1 2AD")
-    }
+    #expect(vm.reference == "2026/0042")
+    #expect(vm.address == "12 Mill Road, Cambridge, CB1 2AD")
+  }
 
-    @Test func makeApplicationDetailViewModel_dismissClearsDetailApplication() {
-        let (sut, _) = makeSUT()
-        sut.detailApplication = .pendingReview
-        let vm = sut.makeApplicationDetailViewModel(application: .pendingReview)
+  @Test func makeApplicationDetailViewModel_dismissClearsDetailApplication() {
+    let (sut, _) = makeSUT()
+    sut.detailApplication = .pendingReview
+    let vm = sut.makeApplicationDetailViewModel(application: .pendingReview)
 
-        vm.dismiss()
+    vm.dismiss()
 
-        #expect(sut.detailApplication == nil)
-    }
+    #expect(sut.detailApplication == nil)
+  }
 
-    // MARK: - Subscription ViewModel Factory
+  // MARK: - Subscription ViewModel Factory
 
-    @Test func makeSubscriptionViewModel_createsViewModel() {
-        let (sut, _) = makeSUT()
-        let vm = sut.makeSubscriptionViewModel()
+  @Test func makeSubscriptionViewModel_createsViewModel() {
+    let (sut, _) = makeSUT()
+    let vm = sut.makeSubscriptionViewModel()
 
-        #expect(vm.products.isEmpty)
-        #expect(!vm.isLoading)
-    }
+    #expect(vm.products.isEmpty)
+    #expect(!vm.isLoading)
+  }
 
-    // MARK: - Offline-Aware Factory
+  // MARK: - Offline-Aware Factory
 
-    @Test func makeApplicationListViewModel_withOfflineRepository_usesOfflinePath() async {
-        let remote = SpyPlanningApplicationRepository()
-        remote.fetchApplicationsResult = .success([.pendingReview])
-        let cache = SpyApplicationCacheStore()
-        let connectivity = StubConnectivityMonitor(isConnected: true)
-        let offlineRepo = OfflineAwareRepository(
-            remote: remote,
-            cache: cache,
-            connectivity: connectivity
-        )
-        let sut = AppCoordinator(
-            repository: remote,
-            authService: SpyAuthenticationService(),
-            subscriptionService: SpySubscriptionService(),
-            offlineRepository: offlineRepo
-        )
+  @Test func makeApplicationListViewModel_withOfflineRepository_usesOfflinePath() async {
+    let remote = SpyPlanningApplicationRepository()
+    remote.fetchApplicationsResult = .success([.pendingReview])
+    let cache = SpyApplicationCacheStore()
+    let connectivity = StubConnectivityMonitor(isConnected: true)
+    let offlineRepo = OfflineAwareRepository(
+      remote: remote,
+      cache: cache,
+      connectivity: connectivity
+    )
+    let sut = AppCoordinator(
+      repository: remote,
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      offlineRepository: offlineRepo,
+      geocoder: SpyPostcodeGeocoder(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService()
+    )
 
-        let vm = sut.makeApplicationListViewModel(authority: .cambridge)
-        await vm.loadApplications()
+    let vm = sut.makeApplicationListViewModel(authority: .cambridge)
+    await vm.loadApplications()
 
-        #expect(vm.dataFreshness == .fresh)
-        #expect(vm.filteredApplications.count == 1)
-    }
+    #expect(vm.dataFreshness == .fresh)
+    #expect(vm.filteredApplications.count == 1)
+  }
 
-    @Test func makeMapViewModel_withOfflineRepository_usesOfflinePath() async {
-        let remote = SpyPlanningApplicationRepository()
-        remote.fetchApplicationsResult = .success([.pendingReview])
-        let cache = SpyApplicationCacheStore()
-        let connectivity = StubConnectivityMonitor(isConnected: true)
-        let offlineRepo = OfflineAwareRepository(
-            remote: remote,
-            cache: cache,
-            connectivity: connectivity
-        )
-        let sut = AppCoordinator(
-            repository: remote,
-            authService: SpyAuthenticationService(),
-            subscriptionService: SpySubscriptionService(),
-            offlineRepository: offlineRepo
-        )
+  @Test func makeMapViewModel_withOfflineRepository_usesOfflinePath() async {
+    let remote = SpyPlanningApplicationRepository()
+    remote.fetchApplicationsResult = .success([.pendingReview])
+    let cache = SpyApplicationCacheStore()
+    let connectivity = StubConnectivityMonitor(isConnected: true)
+    let offlineRepo = OfflineAwareRepository(
+      remote: remote,
+      cache: cache,
+      connectivity: connectivity
+    )
+    let sut = AppCoordinator(
+      repository: remote,
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      offlineRepository: offlineRepo,
+      geocoder: SpyPostcodeGeocoder(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService()
+    )
 
-        let vm = sut.makeMapViewModel(watchZone: .cambridge)
-        await vm.loadApplications()
+    let vm = sut.makeMapViewModel(watchZone: .cambridge)
+    await vm.loadApplications()
 
-        #expect(vm.dataFreshness == .fresh)
-    }
+    #expect(vm.dataFreshness == .fresh)
+  }
 
-    // MARK: - Application List Factory
+  // MARK: - Application List Factory
 
-    @Test func makeApplicationListViewModel_createsViewModelWithAuthority() async {
-        let (sut, spy) = makeSUT()
-        spy.fetchApplicationsResult = .success([.pendingReview])
-        let vm = sut.makeApplicationListViewModel(authority: .cambridge)
+  @Test func makeApplicationListViewModel_createsViewModelWithAuthority() async {
+    let (sut, spy) = makeSUT()
+    spy.fetchApplicationsResult = .success([.pendingReview])
+    let vm = sut.makeApplicationListViewModel(authority: .cambridge)
 
-        await vm.loadApplications()
+    await vm.loadApplications()
 
-        #expect(spy.fetchApplicationsCalls.first?.code == "CAM")
-    }
+    #expect(spy.fetchApplicationsCalls.first?.code == "CAM")
+  }
 
-    @Test func applicationListViewModel_onApplicationSelected_fetchesAndSetsDetail() async throws {
-        let (sut, spy) = makeSUT()
-        spy.fetchApplicationResult = .success(.approved)
-        let vm = sut.makeApplicationListViewModel(authority: .cambridge)
+  @Test func applicationListViewModel_onApplicationSelected_fetchesAndSetsDetail() async throws {
+    let (sut, spy) = makeSUT()
+    spy.fetchApplicationResult = .success(.approved)
+    let vm = sut.makeApplicationListViewModel(authority: .cambridge)
 
-        vm.onApplicationSelected?(PlanningApplicationId("APP-002"))
+    vm.onApplicationSelected?(PlanningApplicationId("APP-002"))
 
-        try await Task.sleep(for: .milliseconds(50))
+    try await Task.sleep(for: .milliseconds(50))
 
-        #expect(sut.detailApplication == .approved)
-        #expect(spy.fetchApplicationCalls == [PlanningApplicationId("APP-002")])
-    }
+    #expect(sut.detailApplication == .approved)
+    #expect(spy.fetchApplicationCalls == [PlanningApplicationId("APP-002")])
+  }
 
-    // MARK: - Onboarding ViewModel Factory
+  // MARK: - Onboarding ViewModel Factory
 
-    @Test func makeOnboardingViewModel_createsViewModelWithDependencies() {
-        let spy = SpyPlanningApplicationRepository()
-        let authSpy = SpyAuthenticationService()
-        let subscriptionSpy = SpySubscriptionService()
-        let geocoderSpy = SpyPostcodeGeocoder()
-        let zoneRepoSpy = SpyWatchZoneRepository()
-        let onboardingRepoSpy = SpyOnboardingRepository()
-        let notificationSpy = SpyNotificationService()
-        let sut = AppCoordinator(
-            repository: spy,
-            authService: authSpy,
-            subscriptionService: subscriptionSpy,
-            geocoder: geocoderSpy,
-            watchZoneRepository: zoneRepoSpy,
-            onboardingRepository: onboardingRepoSpy,
-            notificationService: notificationSpy
-        )
+  @Test func makeOnboardingViewModel_createsViewModelWithDependencies() {
+    let (sut, _) = makeSUT()
 
-        let vm = sut.makeOnboardingViewModel()
+    let vm = sut.makeOnboardingViewModel()
 
-        #expect(vm.currentStep == .welcome)
-    }
+    #expect(vm.currentStep == .welcome)
+  }
 
-    @Test func makeOnboardingViewModel_completionSetsOnboardingComplete() async throws {
-        let spy = SpyPlanningApplicationRepository()
-        let authSpy = SpyAuthenticationService()
-        let subscriptionSpy = SpySubscriptionService()
-        let geocoderSpy = SpyPostcodeGeocoder()
-        let zoneRepoSpy = SpyWatchZoneRepository()
-        let onboardingRepoSpy = SpyOnboardingRepository()
-        let notificationSpy = SpyNotificationService()
-        let sut = AppCoordinator(
-            repository: spy,
-            authService: authSpy,
-            subscriptionService: subscriptionSpy,
-            geocoder: geocoderSpy,
-            watchZoneRepository: zoneRepoSpy,
-            onboardingRepository: onboardingRepoSpy,
-            notificationService: notificationSpy
-        )
+  @Test func makeOnboardingViewModel_completionSetsOnboardingComplete() async throws {
+    let (sut, _) = makeSUT()
 
-        let vm = sut.makeOnboardingViewModel()
-        vm.advance() // → postcodeEntry
-        vm.postcodeInput = "CB1 2AD"
-        await vm.submitPostcode() // → radiusPicker
-        vm.confirmRadius() // → notificationPermission
-        await vm.skipNotifications()
+    let vm = sut.makeOnboardingViewModel()
+    vm.advance()  // → postcodeEntry
+    vm.postcodeInput = "CB1 2AD"
+    await vm.submitPostcode()  // → radiusPicker
+    vm.confirmRadius()  // → notificationPermission
+    await vm.skipNotifications()
 
-        #expect(sut.isOnboardingComplete)
-    }
+    #expect(sut.isOnboardingComplete)
+  }
 
-    @Test func isOnboardingComplete_falseByDefault() {
-        let (sut, _) = makeSUT()
+  @Test func isOnboardingComplete_falseByDefault() {
+    let (sut, _) = makeSUT()
 
-        #expect(!sut.isOnboardingComplete)
-    }
+    #expect(!sut.isOnboardingComplete)
+  }
 
-    @Test func isOnboardingComplete_trueWhenRepositorySaysComplete() {
-        let spy = SpyPlanningApplicationRepository()
-        let onboardingRepoSpy = SpyOnboardingRepository()
-        onboardingRepoSpy.isOnboardingComplete = true
-        let sut = AppCoordinator(
-            repository: spy,
-            authService: SpyAuthenticationService(),
-            subscriptionService: SpySubscriptionService(),
-            geocoder: SpyPostcodeGeocoder(),
-            watchZoneRepository: SpyWatchZoneRepository(),
-            onboardingRepository: onboardingRepoSpy,
-            notificationService: SpyNotificationService()
-        )
+  @Test func isOnboardingComplete_trueWhenRepositorySaysComplete() {
+    let onboardingRepoSpy = SpyOnboardingRepository()
+    onboardingRepoSpy.isOnboardingComplete = true
+    let sut = AppCoordinator(
+      repository: SpyPlanningApplicationRepository(),
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      geocoder: SpyPostcodeGeocoder(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      onboardingRepository: onboardingRepoSpy,
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService()
+    )
 
-        #expect(sut.isOnboardingComplete)
-    }
+    #expect(sut.isOnboardingComplete)
+  }
 
+  // MARK: - Settings ViewModel Factory
+
+  @Test func makeSettingsViewModel_withRequiredDeps_createsViewModel() {
+    let (sut, _) = makeSUT()
+
+    let vm = sut.makeSettingsViewModel()
+
+    #expect(!vm.isLoading)
+  }
+
+  // MARK: - Force Update ViewModel Factory
+
+  @Test func makeForceUpdateViewModel_withRequiredDeps_createsViewModel() {
+    let (sut, _) = makeSUT()
+
+    let vm = sut.makeForceUpdateViewModel()
+
+    #expect(!vm.requiresUpdate)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -13,139 +13,154 @@ import TownCrierDomain
 @MainActor
 struct CompositionRootTests {
 
-    @Test func allConcreteDependenciesInitialise() {
-        let authService = Auth0AuthenticationService(config: makeTestAuth0Config())
-        let subscriptionService = StoreKitSubscriptionService()
-        let appVersionProvider = BundleAppVersionProvider()
-        // swiftlint:disable:next force_unwrapping
-        let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
-        let versionConfigService = APIVersionConfigService(baseURL: apiBaseURL)
-        let onboardingRepository = UserDefaultsOnboardingRepository()
-        let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
-        let repository = APIPlanningApplicationRepository(apiClient: apiClient)
-        let geocoder = APIPostcodeGeocoder(apiClient: apiClient)
-        let notificationService = CompositeNotificationService(
-            permissionProvider: SpyNotificationPermissionProvider(),
-            apiService: APINotificationService(apiClient: apiClient)
-        )
+  @Test func allConcreteDependenciesInitialise() {
+    let authService = Auth0AuthenticationService(config: makeTestAuth0Config())
+    let subscriptionService = StoreKitSubscriptionService()
+    let appVersionProvider = BundleAppVersionProvider()
+    // swiftlint:disable:next force_unwrapping
+    let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
+    let versionConfigService = APIVersionConfigService(baseURL: apiBaseURL)
+    let onboardingRepository = UserDefaultsOnboardingRepository()
+    let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
+    let repository = APIPlanningApplicationRepository(apiClient: apiClient)
+    let geocoder = APIPostcodeGeocoder(apiClient: apiClient)
+    let notificationService = CompositeNotificationService(
+      permissionProvider: SpyNotificationPermissionProvider(),
+      apiService: APINotificationService(apiClient: apiClient)
+    )
 
-        let coordinator = AppCoordinator(
-            repository: repository,
-            authService: authService,
-            subscriptionService: subscriptionService,
-            geocoder: geocoder,
-            onboardingRepository: onboardingRepository,
-            notificationService: notificationService,
-            appVersionProvider: appVersionProvider,
-            versionConfigService: versionConfigService
-        )
+    let coordinator = AppCoordinator(
+      repository: repository,
+      authService: authService,
+      subscriptionService: subscriptionService,
+      geocoder: geocoder,
+      watchZoneRepository: APIWatchZoneRepository(apiClient: apiClient),
+      onboardingRepository: onboardingRepository,
+      notificationService: notificationService,
+      appVersionProvider: appVersionProvider,
+      versionConfigService: versionConfigService
+    )
 
-        #expect(coordinator.detailApplication == nil)
-    }
+    #expect(coordinator.detailApplication == nil)
+  }
 
-    @Test func coordinatorCreatesLoginViewModel() {
-        let coordinator = makeCoordinator()
-        let loginViewModel = coordinator.makeLoginViewModel()
+  @Test func coordinatorCreatesLoginViewModel() {
+    let coordinator = makeCoordinator()
+    let loginViewModel = coordinator.makeLoginViewModel()
 
-        #expect(!loginViewModel.isAuthenticated)
-    }
+    #expect(!loginViewModel.isAuthenticated)
+  }
 
-    @Test func coordinatorCreatesForceUpdateViewModel() {
-        let coordinator = makeCoordinator()
-        let forceUpdateViewModel = coordinator.makeForceUpdateViewModel()
+  @Test func coordinatorCreatesForceUpdateViewModel() {
+    let coordinator = makeCoordinator()
+    let forceUpdateViewModel = coordinator.makeForceUpdateViewModel()
 
-        #expect(!forceUpdateViewModel.requiresUpdate)
-    }
+    #expect(!forceUpdateViewModel.requiresUpdate)
+  }
 
-    @Test func coordinatorReportsOnboardingStateFromConcreteRepository() {
-        let suiteName = "test-onboarding-\(UUID().uuidString)"
-        // swiftlint:disable:next force_unwrapping
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
+  @Test func coordinatorReportsOnboardingStateFromConcreteRepository() {
+    let suiteName = "test-onboarding-\(UUID().uuidString)"
+    // swiftlint:disable:next force_unwrapping
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defer { UserDefaults.standard.removePersistentDomain(forName: suiteName) }
 
-        defaults.set(true, forKey: "isOnboardingComplete")
-        let onboardingRepo = UserDefaultsOnboardingRepository(defaults: defaults)
+    defaults.set(true, forKey: "isOnboardingComplete")
+    let onboardingRepo = UserDefaultsOnboardingRepository(defaults: defaults)
 
-        let authService = Auth0AuthenticationService(config: makeTestAuth0Config())
-        // swiftlint:disable:next force_unwrapping
-        let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
-        let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
+    let authService = Auth0AuthenticationService(config: makeTestAuth0Config())
+    // swiftlint:disable:next force_unwrapping
+    let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
+    let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
 
-        let coordinator = AppCoordinator(
-            repository: APIPlanningApplicationRepository(apiClient: apiClient),
-            authService: authService,
-            subscriptionService: StoreKitSubscriptionService(),
-            geocoder: APIPostcodeGeocoder(apiClient: apiClient),
-            watchZoneRepository: APIWatchZoneRepository(apiClient: apiClient),
-            onboardingRepository: onboardingRepo,
-            appVersionProvider: BundleAppVersionProvider(),
-            versionConfigService: APIVersionConfigService(baseURL: apiBaseURL)
-        )
+    let coordinator = AppCoordinator(
+      repository: APIPlanningApplicationRepository(apiClient: apiClient),
+      authService: authService,
+      subscriptionService: StoreKitSubscriptionService(),
+      geocoder: APIPostcodeGeocoder(apiClient: apiClient),
+      watchZoneRepository: APIWatchZoneRepository(apiClient: apiClient),
+      onboardingRepository: onboardingRepo,
+      notificationService: CompositeNotificationService(
+        permissionProvider: SpyNotificationPermissionProvider(),
+        apiService: APINotificationService(apiClient: apiClient)
+      ),
+      appVersionProvider: BundleAppVersionProvider(),
+      versionConfigService: APIVersionConfigService(baseURL: apiBaseURL)
+    )
 
-        #expect(coordinator.isOnboardingComplete)
-    }
+    #expect(coordinator.isOnboardingComplete)
+  }
 
-    @Test func offlineAwareRepositoryWiresWithConcreteTypes() throws {
-        let authService = Auth0AuthenticationService(config: makeTestAuth0Config())
-        let apiBaseURL = try #require(URL(string: "https://api.towncrierapp.uk"))
-        let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
-        let repository = APIPlanningApplicationRepository(apiClient: apiClient)
-        let connectivity = NWPathConnectivityMonitor()
-        let cache = InMemoryApplicationCacheStore()
-        let offlineRepository = OfflineAwareRepository(
-            remote: repository,
-            cache: cache,
-            connectivity: connectivity
-        )
+  @Test func offlineAwareRepositoryWiresWithConcreteTypes() throws {
+    let authService = Auth0AuthenticationService(config: makeTestAuth0Config())
+    let apiBaseURL = try #require(URL(string: "https://api.towncrierapp.uk"))
+    let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
+    let repository = APIPlanningApplicationRepository(apiClient: apiClient)
+    let connectivity = NWPathConnectivityMonitor()
+    let cache = InMemoryApplicationCacheStore()
+    let offlineRepository = OfflineAwareRepository(
+      remote: repository,
+      cache: cache,
+      connectivity: connectivity
+    )
 
-        let coordinator = AppCoordinator(
-            repository: repository,
-            authService: authService,
-            subscriptionService: StoreKitSubscriptionService(),
-            offlineRepository: offlineRepository,
-            geocoder: APIPostcodeGeocoder(apiClient: apiClient),
-            onboardingRepository: UserDefaultsOnboardingRepository(),
-            appVersionProvider: BundleAppVersionProvider(),
-            versionConfigService: APIVersionConfigService(baseURL: apiBaseURL)
-        )
+    let coordinator = AppCoordinator(
+      repository: repository,
+      authService: authService,
+      subscriptionService: StoreKitSubscriptionService(),
+      offlineRepository: offlineRepository,
+      geocoder: APIPostcodeGeocoder(apiClient: apiClient),
+      watchZoneRepository: APIWatchZoneRepository(apiClient: apiClient),
+      onboardingRepository: UserDefaultsOnboardingRepository(),
+      notificationService: CompositeNotificationService(
+        permissionProvider: SpyNotificationPermissionProvider(),
+        apiService: APINotificationService(apiClient: apiClient)
+      ),
+      appVersionProvider: BundleAppVersionProvider(),
+      versionConfigService: APIVersionConfigService(baseURL: apiBaseURL)
+    )
 
-        #expect(coordinator.detailApplication == nil)
-    }
+    #expect(coordinator.detailApplication == nil)
+  }
 
-    @Test func metricKitCrashReporterInitialises() {
-        let reporter = MetricKitCrashReporter()
-        reporter.start()
-    }
+  @Test func metricKitCrashReporterInitialises() {
+    let reporter = MetricKitCrashReporter()
+    reporter.start()
+  }
 
-    @Test func auth0ConfigStoresAudience() {
-        let config = makeTestAuth0Config()
+  @Test func auth0ConfigStoresAudience() {
+    let config = makeTestAuth0Config()
 
-        #expect(config.audience == "https://api-test.example.com")
-    }
+    #expect(config.audience == "https://api-test.example.com")
+  }
 
-    // MARK: - Helpers
+  // MARK: - Helpers
 
-    private func makeTestAuth0Config() -> Auth0Config {
-        Auth0Config(
-            clientId: "test-client-id",
-            domain: "test.uk.auth0.com",
-            audience: "https://api-test.example.com"
-        )
-    }
+  private func makeTestAuth0Config() -> Auth0Config {
+    Auth0Config(
+      clientId: "test-client-id",
+      domain: "test.uk.auth0.com",
+      audience: "https://api-test.example.com"
+    )
+  }
 
-    private func makeCoordinator() -> AppCoordinator {
-        let authService = Auth0AuthenticationService(config: makeTestAuth0Config())
-        // swiftlint:disable:next force_unwrapping
-        let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
-        let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
-        return AppCoordinator(
-            repository: APIPlanningApplicationRepository(apiClient: apiClient),
-            authService: authService,
-            subscriptionService: StoreKitSubscriptionService(),
-            geocoder: APIPostcodeGeocoder(apiClient: apiClient),
-            onboardingRepository: UserDefaultsOnboardingRepository(),
-            appVersionProvider: BundleAppVersionProvider(),
-            versionConfigService: APIVersionConfigService(baseURL: apiBaseURL)
-        )
-    }
+  private func makeCoordinator() -> AppCoordinator {
+    let authService = Auth0AuthenticationService(config: makeTestAuth0Config())
+    // swiftlint:disable:next force_unwrapping
+    let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
+    let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
+    return AppCoordinator(
+      repository: APIPlanningApplicationRepository(apiClient: apiClient),
+      authService: authService,
+      subscriptionService: StoreKitSubscriptionService(),
+      geocoder: APIPostcodeGeocoder(apiClient: apiClient),
+      watchZoneRepository: APIWatchZoneRepository(apiClient: apiClient),
+      onboardingRepository: UserDefaultsOnboardingRepository(),
+      notificationService: CompositeNotificationService(
+        permissionProvider: SpyNotificationPermissionProvider(),
+        apiService: APINotificationService(apiClient: apiClient)
+      ),
+      appVersionProvider: BundleAppVersionProvider(),
+      versionConfigService: APIVersionConfigService(baseURL: apiBaseURL)
+    )
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/DeepLinkTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeepLinkTests.swift
@@ -7,78 +7,84 @@ import TownCrierDomain
 @Suite("Deep Link Handling")
 @MainActor
 struct DeepLinkTests {
-    private func makeSUT() -> (AppCoordinator, SpyPlanningApplicationRepository) {
-        let spy = SpyPlanningApplicationRepository()
-        let coordinator = AppCoordinator(
-            repository: spy,
-            authService: SpyAuthenticationService(),
-            subscriptionService: SpySubscriptionService()
-        )
-        return (coordinator, spy)
-    }
+  private func makeSUT() -> (AppCoordinator, SpyPlanningApplicationRepository) {
+    let spy = SpyPlanningApplicationRepository()
+    let coordinator = AppCoordinator(
+      repository: spy,
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      geocoder: SpyPostcodeGeocoder(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService()
+    )
+    return (coordinator, spy)
+  }
 
-    @Test func handleDeepLink_applicationDetail_fetchesAndSetsDetailApplication() async throws {
-        let (sut, spy) = makeSUT()
-        spy.fetchApplicationResult = .success(.approved)
+  @Test func handleDeepLink_applicationDetail_fetchesAndSetsDetailApplication() async throws {
+    let (sut, spy) = makeSUT()
+    spy.fetchApplicationResult = .success(.approved)
 
-        sut.handleDeepLink(.applicationDetail(PlanningApplicationId("APP-002")))
+    sut.handleDeepLink(.applicationDetail(PlanningApplicationId("APP-002")))
 
-        try await Task.sleep(for: .milliseconds(50))
+    try await Task.sleep(for: .milliseconds(50))
 
-        #expect(sut.detailApplication == .approved)
-        #expect(spy.fetchApplicationCalls == [PlanningApplicationId("APP-002")])
-    }
+    #expect(sut.detailApplication == .approved)
+    #expect(spy.fetchApplicationCalls == [PlanningApplicationId("APP-002")])
+  }
 
-    @Test func handleDeepLink_successClearsPreviousError() async throws {
-        let (sut, spy) = makeSUT()
-        sut.deepLinkError = .applicationNotFound(PlanningApplicationId("OLD"))
-        spy.fetchApplicationResult = .success(.approved)
+  @Test func handleDeepLink_successClearsPreviousError() async throws {
+    let (sut, spy) = makeSUT()
+    sut.deepLinkError = .applicationNotFound(PlanningApplicationId("OLD"))
+    spy.fetchApplicationResult = .success(.approved)
 
-        sut.handleDeepLink(.applicationDetail(PlanningApplicationId("APP-002")))
+    sut.handleDeepLink(.applicationDetail(PlanningApplicationId("APP-002")))
 
-        try await Task.sleep(for: .milliseconds(50))
+    try await Task.sleep(for: .milliseconds(50))
 
-        #expect(sut.deepLinkError == nil)
-        #expect(sut.detailApplication == .approved)
-    }
+    #expect(sut.deepLinkError == nil)
+    #expect(sut.detailApplication == .approved)
+  }
 
-    @Test func handleDeepLink_applicationNotFound_setsDeepLinkError() async throws {
-        let (sut, spy) = makeSUT()
-        let missingId = PlanningApplicationId("GONE-001")
-        spy.fetchApplicationResult = .failure(DomainError.applicationNotFound(missingId))
+  @Test func handleDeepLink_applicationNotFound_setsDeepLinkError() async throws {
+    let (sut, spy) = makeSUT()
+    let missingId = PlanningApplicationId("GONE-001")
+    spy.fetchApplicationResult = .failure(DomainError.applicationNotFound(missingId))
 
-        sut.handleDeepLink(.applicationDetail(missingId))
+    sut.handleDeepLink(.applicationDetail(missingId))
 
-        try await Task.sleep(for: .milliseconds(50))
+    try await Task.sleep(for: .milliseconds(50))
 
-        #expect(sut.detailApplication == nil)
-        #expect(sut.deepLinkError == .applicationNotFound(missingId))
-    }
+    #expect(sut.detailApplication == nil)
+    #expect(sut.deepLinkError == .applicationNotFound(missingId))
+  }
 }
 
 @Suite("NotificationPayloadParser")
 struct NotificationPayloadParserTests {
-    @Test func parseDeepLink_withApplicationId_returnsApplicationDetailLink() {
-        let userInfo: [AnyHashable: Any] = ["applicationId": "APP-001"]
+  @Test func parseDeepLink_withApplicationId_returnsApplicationDetailLink() {
+    let userInfo: [AnyHashable: Any] = ["applicationId": "APP-001"]
 
-        let result = NotificationPayloadParser.parseDeepLink(from: userInfo)
+    let result = NotificationPayloadParser.parseDeepLink(from: userInfo)
 
-        #expect(result == .applicationDetail(PlanningApplicationId("APP-001")))
-    }
+    #expect(result == .applicationDetail(PlanningApplicationId("APP-001")))
+  }
 
-    @Test func parseDeepLink_withoutApplicationId_returnsNil() {
-        let userInfo: [AnyHashable: Any] = ["unrelated": "data"]
+  @Test func parseDeepLink_withoutApplicationId_returnsNil() {
+    let userInfo: [AnyHashable: Any] = ["unrelated": "data"]
 
-        let result = NotificationPayloadParser.parseDeepLink(from: userInfo)
+    let result = NotificationPayloadParser.parseDeepLink(from: userInfo)
 
-        #expect(result == nil)
-    }
+    #expect(result == nil)
+  }
 
-    @Test func parseDeepLink_withEmptyPayload_returnsNil() {
-        let userInfo: [AnyHashable: Any] = [:]
+  @Test func parseDeepLink_withEmptyPayload_returnsNil() {
+    let userInfo: [AnyHashable: Any] = [:]
 
-        let result = NotificationPayloadParser.parseDeepLink(from: userInfo)
+    let result = NotificationPayloadParser.parseDeepLink(from: userInfo)
 
-        #expect(result == nil)
-    }
+    #expect(result == nil)
+  }
 }


### PR DESCRIPTION
## Summary

Implements `tc-hkr`: Simplify: replace AppCoordinator optional deps with required injection

Makes 7 optional dependencies required in AppCoordinator.init, removing 3 preconditionFailure crash paths and replacing runtime guards with compile-time safety. 399 tests pass (+2 new characterization tests).

## Bead

`tc-hkr` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal dependency management architecture to enhance code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->