### PR TITLE
refactor(ci): extract composite actions for Azure login and setup

### DIFF
--- a/.beads/push-state.json
+++ b/.beads/push-state.json
@@ -1,4 +1,0 @@
-{
-  "last_push": "2026-03-28T10:18:02Z",
-  "last_commit": "5rsthl6b650jgjj69j19k0qvenckce35"
-}

--- a/.github/actions/azure-login/action.yml
+++ b/.github/actions/azure-login/action.yml
@@ -1,0 +1,24 @@
+# Wraps azure/login@v2 with OIDC federated credentials.
+# Keeps the three secret inputs in one place so callers pass them once.
+name: Azure Login (OIDC)
+description: Login to Azure using OIDC federated credentials
+
+inputs:
+  client-id:
+    description: Azure AD application (client) ID
+    required: true
+  tenant-id:
+    description: Azure AD tenant ID
+    required: true
+  subscription-id:
+    description: Azure subscription ID
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: azure/login@v2
+      with:
+        client-id: ${{ inputs.client-id }}
+        tenant-id: ${{ inputs.tenant-id }}
+        subscription-id: ${{ inputs.subscription-id }}

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,0 +1,124 @@
+# Detects which monorepo components changed, using git diff.
+# Supports both push (HEAD~1) and pull_request (origin/base...HEAD) modes.
+#
+# Callers configure which workflow files trigger which component categories
+# via the trigger-all-paths, trigger-server-paths, and trigger-infra-paths inputs.
+name: Detect monorepo changes
+description: Detect which components changed in a monorepo push or PR
+
+inputs:
+  mode:
+    description: "'push' compares HEAD~1..HEAD; 'pr' compares origin/<base>...HEAD"
+    required: true
+  base-ref:
+    description: "Base branch for PR mode (e.g., github.base_ref). Ignored in push mode."
+    required: false
+    default: main
+  detect-ios:
+    description: "Whether to detect iOS changes (set 'false' for CD workflows that skip iOS)"
+    required: false
+    default: "true"
+  trigger-all-paths:
+    description: "Glob patterns (one per line) that trigger ALL components when changed"
+    required: false
+    default: ""
+  trigger-server-paths:
+    description: "Glob patterns (one per line) that trigger server components (api, web, infra)"
+    required: false
+    default: ""
+  trigger-infra-paths:
+    description: "Glob patterns (one per line) that trigger only infra"
+    required: false
+    default: ""
+
+outputs:
+  api:
+    description: "'true' if API changed"
+    value: ${{ steps.filter.outputs.api }}
+  ios:
+    description: "'true' if iOS changed (always 'false' when detect-ios is 'false')"
+    value: ${{ steps.filter.outputs.ios }}
+  web:
+    description: "'true' if web changed"
+    value: ${{ steps.filter.outputs.web }}
+  infra:
+    description: "'true' if infra changed"
+    value: ${{ steps.filter.outputs.infra }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect changed paths
+      id: filter
+      shell: bash
+      run: |
+        if [ "${{ inputs.mode }}" = "push" ]; then
+          CHANGED=$(git diff --name-only HEAD~1 HEAD)
+        else
+          CHANGED=$(git diff --name-only origin/${{ inputs.base-ref }}...HEAD)
+        fi
+
+        echo "Changed files:"
+        echo "$CHANGED"
+
+        has_api=false
+        has_ios=false
+        has_web=false
+        has_infra=false
+
+        # Check trigger-all-paths patterns
+        ALL_PATTERNS="${{ inputs.trigger-all-paths }}"
+        if [ -n "$ALL_PATTERNS" ]; then
+          while IFS= read -r pattern; do
+            [ -z "$pattern" ] && continue
+            if echo "$CHANGED" | grep -q "$pattern"; then
+              has_api=true; has_web=true; has_infra=true
+              if [ "${{ inputs.detect-ios }}" = "true" ]; then
+                has_ios=true
+              fi
+            fi
+          done <<< "$ALL_PATTERNS"
+        fi
+
+        # Check trigger-server-paths patterns (api, web, infra — no ios)
+        SERVER_PATTERNS="${{ inputs.trigger-server-paths }}"
+        if [ -n "$SERVER_PATTERNS" ]; then
+          while IFS= read -r pattern; do
+            [ -z "$pattern" ] && continue
+            if echo "$CHANGED" | grep -q "$pattern"; then
+              has_api=true; has_web=true; has_infra=true
+            fi
+          done <<< "$SERVER_PATTERNS"
+        fi
+
+        # Check trigger-infra-paths patterns (infra only)
+        INFRA_PATTERNS="${{ inputs.trigger-infra-paths }}"
+        if [ -n "$INFRA_PATTERNS" ]; then
+          while IFS= read -r pattern; do
+            [ -z "$pattern" ] && continue
+            if echo "$CHANGED" | grep -q "$pattern"; then
+              has_infra=true
+            fi
+          done <<< "$INFRA_PATTERNS"
+        fi
+
+        # Per-file component detection
+        while IFS= read -r file; do
+          case "$file" in
+            api/*) has_api=true ;;
+            mobile/ios/*)
+              if [ "${{ inputs.detect-ios }}" = "true" ]; then
+                has_ios=true
+              fi
+              ;;
+            web/*) has_web=true ;;
+            infra/*) has_infra=true ;;
+          esac
+        done <<< "$CHANGED"
+
+        echo "api=$has_api" >> "$GITHUB_OUTPUT"
+        echo "ios=$has_ios" >> "$GITHUB_OUTPUT"
+        echo "web=$has_web" >> "$GITHUB_OUTPUT"
+        echo "infra=$has_infra" >> "$GITHUB_OUTPUT"
+
+        echo "Results: api=$has_api ios=$has_ios web=$has_web infra=$has_infra"

--- a/.github/actions/setup-dotnet-infra/action.yml
+++ b/.github/actions/setup-dotnet-infra/action.yml
@@ -1,0 +1,17 @@
+# Sets up .NET SDK (from global.json) and restores NuGet cache for infra projects.
+# Used by infra jobs that need dotnet + Pulumi.
+name: Setup .NET + NuGet cache (infra)
+description: Install .NET SDK from global.json and cache NuGet packages for infra
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: api/global.json
+
+    - uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-infra-${{ runner.os }}-${{ hashFiles('infra/**/*.csproj') }}
+        restore-keys: nuget-infra-${{ runner.os }}-

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -36,42 +36,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      api: ${{ steps.filter.outputs.api }}
-      web: ${{ steps.filter.outputs.web }}
-      infra: ${{ steps.filter.outputs.infra }}
+      api: ${{ steps.detect.outputs.api }}
+      web: ${{ steps.detect.outputs.web }}
+      infra: ${{ steps.detect.outputs.infra }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - name: Detect changed paths
-        id: filter
-        run: |
-          CHANGED=$(git diff --name-only HEAD~1 HEAD)
-          echo "Changed files:"
-          echo "$CHANGED"
 
-          has_api=false
-          has_web=false
-          has_infra=false
-
-          # cd-dev.yml triggers all components — check before per-file loop
-          if echo "$CHANGED" | grep -q '.github/workflows/cd-dev.yml'; then
-            has_api=true; has_web=true; has_infra=true
-          fi
-
-          while IFS= read -r file; do
-            case "$file" in
-              api/*) has_api=true ;;
-              web/*) has_web=true ;;
-              infra/*) has_infra=true ;;
-            esac
-          done <<< "$CHANGED"
-
-          echo "api=$has_api" >> "$GITHUB_OUTPUT"
-          echo "web=$has_web" >> "$GITHUB_OUTPUT"
-          echo "infra=$has_infra" >> "$GITHUB_OUTPUT"
-
-          echo "Results: api=$has_api web=$has_web infra=$has_infra"
+      - uses: ./.github/actions/detect-changes
+        id: detect
+        with:
+          mode: push
+          detect-ios: "false"
+          trigger-server-paths: .github/workflows/cd-dev.yml
 
   # ── Infrastructure: shared stack ─────────────────────
   infra-shared:
@@ -84,17 +62,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: api/global.json
+      - uses: ./.github/actions/setup-dotnet-infra
 
-      - uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-infra-${{ runner.os }}-${{ hashFiles('infra/**/*.csproj') }}
-          restore-keys: nuget-infra-${{ runner.os }}-
-
-      - uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -126,17 +96,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: api/global.json
+      - uses: ./.github/actions/setup-dotnet-infra
 
-      - uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-infra-${{ runner.os }}-${{ hashFiles('infra/**/*.csproj') }}
-          restore-keys: nuget-infra-${{ runner.os }}-
-
-      - uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -174,7 +136,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -202,7 +164,9 @@ jobs:
     timeout-minutes: 5
     environment: development
     steps:
-      - uses: azure/login@v2
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -247,7 +211,7 @@ jobs:
           VITE_AUTH0_CLIENT_ID: ${{ vars.VITE_AUTH0_CLIENT_ID }}
           VITE_AUTH0_AUDIENCE: ${{ vars.VITE_AUTH0_AUDIENCE }}
 
-      - uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -42,19 +42,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: api/global.json
+      - uses: ./.github/actions/setup-dotnet-infra
 
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-infra-${{ runner.os }}-${{ hashFiles('infra/**/*.csproj') }}
-          restore-keys: nuget-infra-${{ runner.os }}-
-
-      - name: Login to Azure
-        uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -98,8 +88,7 @@ jobs:
         id: resolve
         run: echo "sha=$(git rev-parse "$GITHUB_REF_NAME")" >> "$GITHUB_OUTPUT"
 
-      - name: Login to Azure
-        uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -119,7 +108,7 @@ jobs:
           elif az acr manifest show \
             --registry "$ACR_NAME" \
             --name "town-crier-api:latest" 2>/dev/null; then
-            echo "No image for SHA $SHA — falling back to latest"
+            echo "No image for SHA $SHA -- falling back to latest"
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           else
             echo "::error::No API image found (tried SHA $SHA and latest)"
@@ -159,8 +148,7 @@ jobs:
         run: npm run build
         working-directory: web
 
-      - name: Login to Azure
-        uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -21,52 +21,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      api: ${{ steps.filter.outputs.api }}
-      ios: ${{ steps.filter.outputs.ios }}
-      web: ${{ steps.filter.outputs.web }}
-      infra: ${{ steps.filter.outputs.infra }}
+      api: ${{ steps.detect.outputs.api }}
+      ios: ${{ steps.detect.outputs.ios }}
+      web: ${{ steps.detect.outputs.web }}
+      infra: ${{ steps.detect.outputs.infra }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Detect changed paths
-        id: filter
-        run: |
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
-          echo "Changed files:"
-          echo "$CHANGED"
 
-          has_api=false
-          has_ios=false
-          has_web=false
-          has_infra=false
-
-          # Shared workflow files trigger multiple components — check before per-file loop
-          if echo "$CHANGED" | grep -q '.github/workflows/pr-gate.yml'; then
-            has_api=true; has_ios=true; has_web=true; has_infra=true
-          fi
-          if echo "$CHANGED" | grep -q '.github/workflows/cd-dev.yml'; then
-            has_api=true; has_web=true; has_infra=true
-          fi
-          if echo "$CHANGED" | grep -q '.github/workflows/cd-prod.yml'; then
-            has_infra=true
-          fi
-
-          while IFS= read -r file; do
-            case "$file" in
-              api/*) has_api=true ;;
-              mobile/ios/*) has_ios=true ;;
-              web/*) has_web=true ;;
-              infra/*) has_infra=true ;;
-            esac
-          done <<< "$CHANGED"
-
-          echo "api=$has_api" >> "$GITHUB_OUTPUT"
-          echo "ios=$has_ios" >> "$GITHUB_OUTPUT"
-          echo "web=$has_web" >> "$GITHUB_OUTPUT"
-          echo "infra=$has_infra" >> "$GITHUB_OUTPUT"
-
-          echo "Results: api=$has_api ios=$has_ios web=$has_web infra=$has_infra"
+      - uses: ./.github/actions/detect-changes
+        id: detect
+        with:
+          mode: pr
+          base-ref: ${{ github.base_ref }}
+          detect-ios: "true"
+          trigger-all-paths: .github/workflows/pr-gate.yml
+          trigger-server-paths: .github/workflows/cd-dev.yml
+          trigger-infra-paths: .github/workflows/cd-prod.yml
 
   # ── API ──────────────────────────────────────────────
 
@@ -205,19 +177,15 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: api/global.json
-      - uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-infra-${{ runner.os }}-${{ hashFiles('infra/**/*.csproj') }}
-          restore-keys: nuget-infra-${{ runner.os }}-
-      - uses: azure/login@v2
+
+      - uses: ./.github/actions/setup-dotnet-infra
+
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - uses: pulumi/actions@v6
         with:
           command: preview


### PR DESCRIPTION
## Summary

Implements `tc-bf06137a`: Simplify: extract CI composite actions for Azure login and setup

Extracts 3 composite actions (azure-login, setup-dotnet-infra, detect-changes) to eliminate duplication across cd-dev, cd-prod, and pr-gate workflows. Every job using a local composite action now has `actions/checkout@v4` as its first step (fixes the PR #58 failure). All YAML validated with actionlint.

## Bead

`tc-bf06137a` — see bead comments for Pipeline evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Introduced reusable GitHub Actions to standardize and consolidate .NET development environment setup, package management caching, and cloud authentication across all deployment pipelines.
* Enhanced consistency and maintainability of continuous integration and deployment workflows for development, production, and pull request validation stages.
* Removed deprecated push state persistence tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->