### PR TITLE
fix(ios): remove deprecated swift-testing package dependency

### DIFF
--- a/.beads/push-state.json
+++ b/.beads/push-state.json
@@ -1,4 +1,0 @@
-{
-  "last_push": "2026-03-28T10:18:02Z",
-  "last_commit": "5rsthl6b650jgjj69j19k0qvenckce35"
-}

--- a/mobile/ios/Package.resolved
+++ b/mobile/ios/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "88db2919dc3197a3a67c08d07cd1046dfc10896e24f6a16705c865fe72d3eed7",
+  "originHash" : "1e73df50c9452a22c2e20f3995ea06c04c17bea86daeb9a7b74ddccfa243e55b",
   "pins" : [
     {
       "identity" : "auth0.swift",
@@ -26,24 +26,6 @@
       "state" : {
         "revision" : "776c4a6db74d5c6c143974be91c383680d468630",
         "version" : "1.3.0"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax.git",
-      "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
-      }
-    },
-    {
-      "identity" : "swift-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-testing.git",
-      "state" : {
-        "revision" : "399f76dcd91e4c688ca2301fa24a8cc6d9927211",
-        "version" : "0.99.0"
       }
     }
   ],

--- a/mobile/ios/Package.swift
+++ b/mobile/ios/Package.swift
@@ -14,7 +14,6 @@ let package = Package(
         .library(name: "TownCrierPresentation", targets: ["TownCrierPresentation"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/swiftlang/swift-testing.git", from: "0.12.0"),
         .package(url: "https://github.com/auth0/Auth0.swift.git", from: "2.0.0"),
     ],
     targets: [
@@ -41,7 +40,6 @@ let package = Package(
                 "TownCrierDomain",
                 "TownCrierData",
                 "TownCrierPresentation",
-                .product(name: "Testing", package: "swift-testing"),
             ],
             path: "town-crier-tests/Sources"
         ),


### PR DESCRIPTION
## Summary

Implements `tc-8jy`: Remove deprecated swift-testing dependency from Package.swift

Removes the explicit swift-testing 0.12.0 dependency that causes deprecation warnings and fatalError crashes on CI. Swift 6.1+ includes Swift Testing natively. 399 tests pass, 0 SwiftLint violations.

## Bead

`tc-8jy` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed push state metadata storage.
  * Updated iOS package dependency resolution.
  * Removed `swift-testing` dependency from iOS package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->