### PR TITLE
fix(web): add missing staticwebapp.config.json for PR Gate

### DIFF
--- a/web/staticwebapp.config.json
+++ b/web/staticwebapp.config.json
@@ -1,0 +1,13 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": [
+      "*.{css,js,svg,png,jpg,jpeg,gif,ico,woff,woff2,ttf,eot,json,txt}"
+    ]
+  },
+  "globalHeaders": {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "strict-origin-when-cross-origin"
+  }
+}


### PR DESCRIPTION
## Summary

Implements `tc-th4`: Fix missing staticwebapp.config.json breaking PR Gate web tests

Creates the missing `web/staticwebapp.config.json` fixture that `static-web-app-config.test.ts` reads via `readFileSync`. The test was committed without its fixture, causing ENOENT crashes on every PR touching `web/`. Adds navigation fallback for SPA routing and security headers.

## Bead

`tc-th4` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced app security with additional HTTP security headers to protect against common web vulnerabilities.
  * Improved single-page app routing behavior with fallback navigation support for seamless user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->