### PR TITLE
fix(web): fix pre-existing test failures breaking PR gate

### DIFF
--- a/web/src/__tests__/routes.test.tsx
+++ b/web/src/__tests__/routes.test.tsx
@@ -150,7 +150,7 @@ describe('AppRoutes', () => {
       renderRoutes({ route: '/dashboard', authSpy, profileSpy });
 
       await waitFor(() => {
-        expect(screen.getByText('Onboarding')).toBeInTheDocument();
+        expect(screen.getByText('Welcome to Town Crier')).toBeInTheDocument();
       });
     });
 

--- a/web/src/__tests__/static-web-app-config.test.ts
+++ b/web/src/__tests__/static-web-app-config.test.ts
@@ -17,7 +17,7 @@ interface StaticWebAppConfig {
 }
 
 function loadConfig(): StaticWebAppConfig {
-  const configPath = resolve(__dirname, '../../staticwebapp.config.json');
+  const configPath = resolve(__dirname, '../../public/staticwebapp.config.json');
   const raw = readFileSync(configPath, 'utf-8');
   return JSON.parse(raw) as StaticWebAppConfig;
 }


### PR DESCRIPTION
## Changes
- Fix `static-web-app-config.test.ts` path: was resolving to `web/staticwebapp.config.json` (doesn't exist) instead of `web/public/staticwebapp.config.json` (where the file actually lives)
- Fix `routes.test.tsx` onboarding redirect assertion: test expected stub text `'Onboarding'` but the real `OnboardingPage` component renders `'Welcome to Town Crier'`

These two failures were pre-existing on main, causing every PR touching web components to fail the PR gate — which was blocking autopilot from merging multiple features (CI composite actions, Map page, Program.cs decomposition).

---
*Auto-shipped via ship skill*