### PR TITLE
fix(api): fix CorsMiddlewareTests failing on main

### DIFF
--- a/api/tests/town-crier.web.tests/TestWebApplicationFactory.cs
+++ b/api/tests/town-crier.web.tests/TestWebApplicationFactory.cs
@@ -31,6 +31,7 @@ internal sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
     {
         builder.UseSetting("Auth0:Domain", "test.auth0.com");
         builder.UseSetting("Auth0:Audience", "https://api.towncrier.app");
+        builder.UseSetting("Cors:AllowedOrigins:0", "http://localhost:5173");
         builder.UseSetting(
             "ConnectionStrings:CosmosDb",
             "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==");


### PR DESCRIPTION
## Summary

Implements `tc-z72`: Fix CorsMiddlewareTests failing on main

Added CORS origin override in TestWebApplicationFactory so tests use http://localhost:5173 as an allowed origin, matching the Origin header sent in CORS tests.

## Bead

`tc-z72` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for CORS compatibility with local development environments.

---

**Note:** This is a test infrastructure update with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->