### PR TITLE
ci: extract CI composite actions for Azure login and setup

### DIFF
--- a/.github/actions/azure-login/action.yml
+++ b/.github/actions/azure-login/action.yml
@@ -1,0 +1,25 @@
+# Wraps azure/login@v2 with OIDC federated credentials.
+# Centralises the three-input pattern used across all deployment workflows.
+name: Azure Login (OIDC)
+description: Login to Azure using OIDC federated credentials
+
+inputs:
+  client-id:
+    description: Azure AD application (client) ID
+    required: true
+  tenant-id:
+    description: Azure AD tenant ID
+    required: true
+  subscription-id:
+    description: Azure subscription ID
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Login to Azure
+      uses: azure/login@v2
+      with:
+        client-id: ${{ inputs.client-id }}
+        tenant-id: ${{ inputs.tenant-id }}
+        subscription-id: ${{ inputs.subscription-id }}

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,0 +1,111 @@
+# Monorepo change detection for push and pull_request events.
+# Outputs boolean flags for each component category that changed.
+#
+# Modes:
+#   push — compares HEAD~1..HEAD (squash-merge assumed)
+#   pr   — compares origin/<base-ref>...HEAD
+#
+# Trigger files:
+#   Workflow files (e.g., cd-dev.yml, pr-gate.yml) can force categories
+#   to true when they themselves change. Pass trigger-files as a
+#   newline-separated list of "file:cat1,cat2" pairs.
+name: Detect Changes
+description: Monorepo change detection with push/pr modes
+
+inputs:
+  mode:
+    description: "Detection mode: 'push' (HEAD~1..HEAD) or 'pr' (origin/base...HEAD)"
+    required: true
+  base-ref:
+    description: "Base branch for PR mode (e.g., github.base_ref). Ignored in push mode."
+    required: false
+    default: ""
+  categories:
+    description: "Comma-separated list of categories to detect (e.g., api,web,infra,ios)"
+    required: true
+  trigger-files:
+    description: |
+      Newline-separated list of workflow files that force categories when changed.
+      Format: "path:cat1,cat2,..." per line.
+      Example:
+        .github/workflows/pr-gate.yml:api,ios,web,infra
+        .github/workflows/cd-dev.yml:api,web,infra
+    required: false
+    default: ""
+
+outputs:
+  api:
+    description: "true if api/ changed"
+    value: ${{ steps.detect.outputs.api }}
+  ios:
+    description: "true if mobile/ios/ changed"
+    value: ${{ steps.detect.outputs.ios }}
+  web:
+    description: "true if web/ changed"
+    value: ${{ steps.detect.outputs.web }}
+  infra:
+    description: "true if infra/ changed"
+    value: ${{ steps.detect.outputs.infra }}
+
+runs:
+  using: composite
+  steps:
+    - name: Detect changed paths
+      id: detect
+      shell: bash
+      run: |
+        # Determine changed files based on mode
+        if [[ "${{ inputs.mode }}" == "push" ]]; then
+          CHANGED=$(git diff --name-only HEAD~1 HEAD)
+        elif [[ "${{ inputs.mode }}" == "pr" ]]; then
+          CHANGED=$(git diff --name-only origin/${{ inputs.base-ref }}...HEAD)
+        else
+          echo "::error::Unknown mode '${{ inputs.mode }}'. Use 'push' or 'pr'."
+          exit 1
+        fi
+
+        echo "Changed files:"
+        echo "$CHANGED"
+
+        # Initialise all requested categories to false
+        IFS=',' read -ra CATS <<< "${{ inputs.categories }}"
+        declare -A flags
+        for cat in "${CATS[@]}"; do
+          flags["$cat"]=false
+        done
+
+        # Process trigger files — workflow files that force categories
+        TRIGGER_FILES="${{ inputs.trigger-files }}"
+        if [[ -n "$TRIGGER_FILES" ]]; then
+          while IFS= read -r line; do
+            [[ -z "$line" ]] && continue
+            trigger_path="${line%%:*}"
+            trigger_cats="${line#*:}"
+            if echo "$CHANGED" | grep -q "$trigger_path"; then
+              IFS=',' read -ra tcats <<< "$trigger_cats"
+              for tc in "${tcats[@]}"; do
+                if [[ -v "flags[$tc]" ]]; then
+                  flags["$tc"]=true
+                fi
+              done
+            fi
+          done <<< "$TRIGGER_FILES"
+        fi
+
+        # Map file paths to categories
+        while IFS= read -r file; do
+          [[ -z "$file" ]] && continue
+          case "$file" in
+            api/*) [[ -v "flags[api]" ]] && flags[api]=true ;;
+            mobile/ios/*) [[ -v "flags[ios]" ]] && flags[ios]=true ;;
+            web/*) [[ -v "flags[web]" ]] && flags[web]=true ;;
+            infra/*) [[ -v "flags[infra]" ]] && flags[infra]=true ;;
+          esac
+        done <<< "$CHANGED"
+
+        # Write outputs
+        for cat in "${CATS[@]}"; do
+          echo "${cat}=${flags[$cat]}" >> "$GITHUB_OUTPUT"
+        done
+
+        echo "Results: $(for cat in "${CATS[@]}"; do echo -n "${cat}=${flags[$cat]} "; done)"

--- a/.github/actions/setup-dotnet-infra/action.yml
+++ b/.github/actions/setup-dotnet-infra/action.yml
@@ -1,0 +1,19 @@
+# Sets up .NET SDK (via global.json) and caches NuGet packages for infra projects.
+# Centralises the setup-dotnet + cache pair used across infra jobs.
+name: Setup .NET for Infra
+description: Install .NET SDK from global.json and cache NuGet packages for infra projects
+
+runs:
+  using: composite
+  steps:
+    - name: Setup .NET SDK
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: api/global.json
+
+    - name: Cache NuGet packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.nuget/packages
+        key: nuget-infra-${{ runner.os }}-${{ hashFiles('infra/**/*.csproj') }}
+        restore-keys: nuget-infra-${{ runner.os }}-

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -36,42 +36,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      api: ${{ steps.filter.outputs.api }}
-      web: ${{ steps.filter.outputs.web }}
-      infra: ${{ steps.filter.outputs.infra }}
+      api: ${{ steps.detect.outputs.api }}
+      web: ${{ steps.detect.outputs.web }}
+      infra: ${{ steps.detect.outputs.infra }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Detect changed paths
-        id: filter
-        run: |
-          CHANGED=$(git diff --name-only HEAD~1 HEAD)
-          echo "Changed files:"
-          echo "$CHANGED"
-
-          has_api=false
-          has_web=false
-          has_infra=false
-
-          # cd-dev.yml triggers all components — check before per-file loop
-          if echo "$CHANGED" | grep -q '.github/workflows/cd-dev.yml'; then
-            has_api=true; has_web=true; has_infra=true
-          fi
-
-          while IFS= read -r file; do
-            case "$file" in
-              api/*) has_api=true ;;
-              web/*) has_web=true ;;
-              infra/*) has_infra=true ;;
-            esac
-          done <<< "$CHANGED"
-
-          echo "api=$has_api" >> "$GITHUB_OUTPUT"
-          echo "web=$has_web" >> "$GITHUB_OUTPUT"
-          echo "infra=$has_infra" >> "$GITHUB_OUTPUT"
-
-          echo "Results: api=$has_api web=$has_web infra=$has_infra"
+        id: detect
+        uses: ./.github/actions/detect-changes
+        with:
+          mode: push
+          categories: api,web,infra
+          trigger-files: |
+            .github/workflows/cd-dev.yml:api,web,infra
 
   # ── Infrastructure: shared stack ─────────────────────
   infra-shared:
@@ -84,17 +63,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: api/global.json
+      - uses: ./.github/actions/setup-dotnet-infra
 
-      - uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-infra-${{ runner.os }}-${{ hashFiles('infra/**/*.csproj') }}
-          restore-keys: nuget-infra-${{ runner.os }}-
-
-      - uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -126,17 +97,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: api/global.json
+      - uses: ./.github/actions/setup-dotnet-infra
 
-      - uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-infra-${{ runner.os }}-${{ hashFiles('infra/**/*.csproj') }}
-          restore-keys: nuget-infra-${{ runner.os }}-
-
-      - uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -174,7 +137,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -202,7 +165,9 @@ jobs:
     timeout-minutes: 5
     environment: development
     steps:
-      - uses: azure/login@v2
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -247,7 +212,7 @@ jobs:
           VITE_AUTH0_CLIENT_ID: ${{ vars.VITE_AUTH0_CLIENT_ID }}
           VITE_AUTH0_AUDIENCE: ${{ vars.VITE_AUTH0_AUDIENCE }}
 
-      - uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -42,19 +42,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: api/global.json
+      - uses: ./.github/actions/setup-dotnet-infra
 
-      - name: Cache NuGet packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-infra-${{ runner.os }}-${{ hashFiles('infra/**/*.csproj') }}
-          restore-keys: nuget-infra-${{ runner.os }}-
-
-      - name: Login to Azure
-        uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -98,8 +88,7 @@ jobs:
         id: resolve
         run: echo "sha=$(git rev-parse "$GITHUB_REF_NAME")" >> "$GITHUB_OUTPUT"
 
-      - name: Login to Azure
-        uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -159,8 +148,7 @@ jobs:
         run: npm run build
         working-directory: web
 
-      - name: Login to Azure
-        uses: azure/login@v2
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -21,52 +21,25 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
-      api: ${{ steps.filter.outputs.api }}
-      ios: ${{ steps.filter.outputs.ios }}
-      web: ${{ steps.filter.outputs.web }}
-      infra: ${{ steps.filter.outputs.infra }}
+      api: ${{ steps.detect.outputs.api }}
+      ios: ${{ steps.detect.outputs.ios }}
+      web: ${{ steps.detect.outputs.web }}
+      infra: ${{ steps.detect.outputs.infra }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Detect changed paths
-        id: filter
-        run: |
-          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
-          echo "Changed files:"
-          echo "$CHANGED"
-
-          has_api=false
-          has_ios=false
-          has_web=false
-          has_infra=false
-
-          # Shared workflow files trigger multiple components — check before per-file loop
-          if echo "$CHANGED" | grep -q '.github/workflows/pr-gate.yml'; then
-            has_api=true; has_ios=true; has_web=true; has_infra=true
-          fi
-          if echo "$CHANGED" | grep -q '.github/workflows/cd-dev.yml'; then
-            has_api=true; has_web=true; has_infra=true
-          fi
-          if echo "$CHANGED" | grep -q '.github/workflows/cd-prod.yml'; then
-            has_infra=true
-          fi
-
-          while IFS= read -r file; do
-            case "$file" in
-              api/*) has_api=true ;;
-              mobile/ios/*) has_ios=true ;;
-              web/*) has_web=true ;;
-              infra/*) has_infra=true ;;
-            esac
-          done <<< "$CHANGED"
-
-          echo "api=$has_api" >> "$GITHUB_OUTPUT"
-          echo "ios=$has_ios" >> "$GITHUB_OUTPUT"
-          echo "web=$has_web" >> "$GITHUB_OUTPUT"
-          echo "infra=$has_infra" >> "$GITHUB_OUTPUT"
-
-          echo "Results: api=$has_api ios=$has_ios web=$has_web infra=$has_infra"
+        id: detect
+        uses: ./.github/actions/detect-changes
+        with:
+          mode: pr
+          base-ref: ${{ github.base_ref }}
+          categories: api,ios,web,infra
+          trigger-files: |
+            .github/workflows/pr-gate.yml:api,ios,web,infra
+            .github/workflows/cd-dev.yml:api,web,infra
+            .github/workflows/cd-prod.yml:infra
 
   # ── API ──────────────────────────────────────────────
 
@@ -205,19 +178,15 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
-        with:
-          global-json-file: api/global.json
-      - uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-infra-${{ runner.os }}-${{ hashFiles('infra/**/*.csproj') }}
-          restore-keys: nuget-infra-${{ runner.os }}-
-      - uses: azure/login@v2
+
+      - uses: ./.github/actions/setup-dotnet-infra
+
+      - uses: ./.github/actions/azure-login
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - uses: pulumi/actions@v6
         with:
           command: preview


### PR DESCRIPTION
## Summary

Implements `tc-bf06137a`: Extract CI composite actions for Azure login and setup

Extracts three composite actions (azure-login, setup-dotnet-infra, detect-changes) to eliminate duplication across cd-dev, cd-prod, and pr-gate workflows. Net reduction of ~120 lines across 3 workflows.

## Bead

`tc-bf06137a` — see bead comments for pipeline evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added reusable GitHub Actions for Azure authentication with OIDC support, detecting monorepo changes, and configuring .NET infrastructure with NuGet caching.
  * Refactored deployment workflows to use the new composite actions, reducing duplication and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->