### PR TITLE
feat(web): add Map page with Leaflet and OpenStreetMap

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -13,6 +13,7 @@
         "leaflet": "^1.9.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-leaflet": "^5.0.0",
         "react-router-dom": "^7.13.2"
       },
       "devDependencies": {
@@ -878,6 +879,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3573,6 +3585,20 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/react-router": {
       "version": "7.13.2",

--- a/web/package.json
+++ b/web/package.json
@@ -15,6 +15,7 @@
     "leaflet": "^1.9.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-leaflet": "^5.0.0",
     "react-router-dom": "^7.13.2"
   },
   "devDependencies": {

--- a/web/src/AppRoutes.tsx
+++ b/web/src/AppRoutes.tsx
@@ -5,7 +5,6 @@ import { LegalPage } from './features/legal/LegalPage';
 import { AuthGuard } from './auth/AuthGuard';
 import { OnboardingGate } from './auth/OnboardingGate';
 import { AppShell } from './components/AppShell/AppShell';
-import { PlaceholderPage } from './features/placeholder/PlaceholderPage';
 import { ConnectedOnboardingPage } from './features/onboarding/ConnectedOnboardingPage';
 import { ConnectedApplicationsPage } from './features/Applications/ConnectedApplicationsPage';
 import { ConnectedDashboardPage } from './features/Dashboard/ConnectedDashboardPage';
@@ -21,6 +20,7 @@ import { WiredGroupCreatePage } from './features/Groups/WiredGroupCreatePage';
 import { WiredGroupDetailPage } from './features/Groups/WiredGroupDetailPage';
 import { WiredAcceptInvitationPage } from './features/Groups/WiredAcceptInvitationPage';
 import { WiredSavedApplicationsPage } from './features/SavedApplications/WiredSavedApplicationsPage';
+import { ConnectedMapPage } from './features/Map/ConnectedMapPage';
 
 export function AppRoutes() {
   return (
@@ -41,7 +41,7 @@ export function AppRoutes() {
             <Route path="/watch-zones" element={<WiredWatchZoneListPage />} />
             <Route path="/watch-zones/new" element={<WiredWatchZoneCreatePage />} />
             <Route path="/watch-zones/:zoneId" element={<WiredWatchZoneEditPage />} />
-            <Route path="/map" element={<PlaceholderPage title="Map" />} />
+            <Route path="/map" element={<ConnectedMapPage />} />
             <Route path="/search" element={<ConnectedSearchPage />} />
             <Route path="/saved" element={<WiredSavedApplicationsPage />} />
             <Route path="/groups" element={<WiredGroupsListPage />} />

--- a/web/src/domain/ports/map-port.ts
+++ b/web/src/domain/ports/map-port.ts
@@ -1,0 +1,6 @@
+import type { AuthorityId, PlanningApplication, WatchZoneSummary } from '../types';
+
+export interface MapPort {
+  fetchWatchZones(): Promise<readonly WatchZoneSummary[]>;
+  fetchApplicationsByAuthority(authorityId: AuthorityId): Promise<readonly PlanningApplication[]>;
+}

--- a/web/src/features/Map/ApiMapAdapter.ts
+++ b/web/src/features/Map/ApiMapAdapter.ts
@@ -1,0 +1,23 @@
+import type { ApiClient } from '../../api/client';
+import type { AuthorityId, PlanningApplication, WatchZoneSummary } from '../../domain/types';
+import type { MapPort } from '../../domain/ports/map-port';
+import { watchZonesApi } from '../../api/watchZones';
+import { applicationsApi } from '../../api/applications';
+
+export class ApiMapAdapter implements MapPort {
+  private readonly zones: ReturnType<typeof watchZonesApi>;
+  private readonly apps: ReturnType<typeof applicationsApi>;
+
+  constructor(client: ApiClient) {
+    this.zones = watchZonesApi(client);
+    this.apps = applicationsApi(client);
+  }
+
+  async fetchWatchZones(): Promise<readonly WatchZoneSummary[]> {
+    return this.zones.list();
+  }
+
+  async fetchApplicationsByAuthority(authorityId: AuthorityId): Promise<readonly PlanningApplication[]> {
+    return this.apps.getByAuthority(authorityId as number);
+  }
+}

--- a/web/src/features/Map/ConnectedMapPage.tsx
+++ b/web/src/features/Map/ConnectedMapPage.tsx
@@ -1,0 +1,11 @@
+import { useMemo } from 'react';
+import { useApiClient } from '../../api/useApiClient';
+import { ApiMapAdapter } from './ApiMapAdapter';
+import { MapPage } from './MapPage';
+
+export function ConnectedMapPage() {
+  const client = useApiClient();
+  const port = useMemo(() => new ApiMapAdapter(client), [client]);
+
+  return <MapPage port={port} />;
+}

--- a/web/src/features/Map/MapPage.module.css
+++ b/web/src/features/Map/MapPage.module.css
@@ -1,0 +1,62 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  padding: var(--tc-space-md);
+  gap: var(--tc-space-md);
+}
+
+.heading {
+  font-size: var(--tc-text-display-large);
+  font-weight: var(--tc-weight-bold);
+  color: var(--tc-text-primary);
+  margin: 0;
+}
+
+.mapWrapper {
+  flex: 1;
+  min-height: 400px;
+  border-radius: var(--tc-radius-md);
+  overflow: hidden;
+  border: 1px solid var(--tc-border);
+}
+
+.loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--tc-text-secondary);
+  font-size: var(--tc-text-body);
+}
+
+.error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--tc-status-refused);
+  font-size: var(--tc-text-body);
+}
+
+.popupDescription {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-primary);
+  margin: 0 0 var(--tc-space-xs) 0;
+}
+
+.popupAddress {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+  margin: 0 0 var(--tc-space-sm) 0;
+}
+
+.popupLink {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-amber);
+  text-decoration: none;
+}
+
+.popupLink:hover {
+  text-decoration: underline;
+}

--- a/web/src/features/Map/MapPage.tsx
+++ b/web/src/features/Map/MapPage.tsx
@@ -1,0 +1,80 @@
+import { Link } from 'react-router-dom';
+import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
+import type { MapPort } from '../../domain/ports/map-port';
+import { useMapData } from './useMapData';
+import styles from './MapPage.module.css';
+import 'leaflet/dist/leaflet.css';
+
+const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const OSM_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+
+const DEFAULT_CENTER: [number, number] = [51.5074, -0.1278];
+const DEFAULT_ZOOM = 13;
+
+interface Props {
+  port: MapPort;
+}
+
+export function MapPage({ port }: Props) {
+  const { zones, applications, isLoading, error } = useMapData(port);
+
+  if (isLoading) {
+    return (
+      <div className={styles.container}>
+        <h1 className={styles.heading}>Map</h1>
+        <div className={styles.loading}>Loading...</div>
+      </div>
+    );
+  }
+
+  if (error !== null) {
+    return (
+      <div className={styles.container}>
+        <h1 className={styles.heading}>Map</h1>
+        <div className={styles.error}>{error}</div>
+      </div>
+    );
+  }
+
+  const center: [number, number] =
+    zones.length > 0
+      ? [zones[0]!.latitude, zones[0]!.longitude]
+      : DEFAULT_CENTER;
+
+  const markableApplications = applications.filter(
+    app => app.latitude !== null && app.longitude !== null,
+  );
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.heading}>Map</h1>
+      <div className={styles.mapWrapper}>
+        <MapContainer
+          center={center}
+          zoom={DEFAULT_ZOOM}
+          style={{ height: '100%', width: '100%' }}
+        >
+          <TileLayer url={OSM_TILE_URL} attribution={OSM_ATTRIBUTION} />
+          {markableApplications.map(app => (
+            <Marker
+              key={app.uid}
+              position={[app.latitude!, app.longitude!]}
+            >
+              <Popup>
+                <p className={styles.popupDescription}>{app.description}</p>
+                <p className={styles.popupAddress}>{app.address}</p>
+                <Link
+                  className={styles.popupLink}
+                  to={`/applications/${app.uid}`}
+                >
+                  View details
+                </Link>
+              </Popup>
+            </Marker>
+          ))}
+        </MapContainer>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/Map/__tests__/MapPage.test.tsx
+++ b/web/src/features/Map/__tests__/MapPage.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MapPage } from '../MapPage';
+import { SpyMapPort } from './spies/spy-map-port';
+import { aWatchZone, anApplication } from './fixtures/map.fixtures';
+
+// Mock react-leaflet — Leaflet doesn't render in jsdom
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-marker">{children}</div>
+  ),
+  Popup: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-popup">{children}</div>
+  ),
+}));
+
+// Mock leaflet itself
+vi.mock('leaflet', () => ({
+  default: {
+    icon: () => ({}),
+    Icon: { Default: { mergeOptions: () => {} } },
+  },
+  icon: () => ({}),
+  Icon: { Default: { mergeOptions: () => {} } },
+}));
+
+describe('MapPage', () => {
+  let spy: SpyMapPort;
+
+  beforeEach(() => {
+    spy = new SpyMapPort();
+  });
+
+  it('renders map heading and container', async () => {
+    spy.fetchWatchZonesResult = [aWatchZone()];
+
+    render(
+      <MemoryRouter>
+        <MapPage port={spy} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Map' })).toBeInTheDocument();
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+  });
+
+  it('renders loading state initially', () => {
+    render(
+      <MemoryRouter>
+        <MapPage port={spy} />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('renders error state on failure', async () => {
+    spy.fetchWatchZonesError = new Error('Network unavailable');
+
+    render(
+      <MemoryRouter>
+        <MapPage port={spy} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Network unavailable')).toBeInTheDocument();
+    });
+  });
+
+  it('renders application markers with popups showing summary info', async () => {
+    const zone = aWatchZone();
+    const app = anApplication();
+    spy.fetchWatchZonesResult = [zone];
+    spy.fetchApplicationsByAuthorityResults.set(zone.authorityId as number, [app]);
+
+    render(
+      <MemoryRouter>
+        <MapPage port={spy} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('map-marker')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Erection of two-storey rear extension')).toBeInTheDocument();
+    expect(screen.getByText('12 Mill Road, Cambridge')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /View details/i })).toHaveAttribute(
+      'href',
+      '/applications/app-001',
+    );
+  });
+
+  it('skips applications without coordinates', async () => {
+    const zone = aWatchZone();
+    const appWithCoords = anApplication();
+    const appWithoutCoords = anApplication({
+      uid: 'no-coords' as never,
+      latitude: null,
+      longitude: null,
+    });
+    spy.fetchWatchZonesResult = [zone];
+    spy.fetchApplicationsByAuthorityResults.set(zone.authorityId as number, [
+      appWithCoords,
+      appWithoutCoords,
+    ]);
+
+    render(
+      <MemoryRouter>
+        <MapPage port={spy} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('map-marker')).toHaveLength(1);
+    });
+  });
+});

--- a/web/src/features/Map/__tests__/MapPage.test.tsx
+++ b/web/src/features/Map/__tests__/MapPage.test.tsx
@@ -45,8 +45,11 @@ describe('MapPage', () => {
       </MemoryRouter>,
     );
 
+    await waitFor(() => {
+      expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    });
+
     expect(screen.getByRole('heading', { name: 'Map' })).toBeInTheDocument();
-    expect(screen.getByTestId('map-container')).toBeInTheDocument();
   });
 
   it('renders loading state initially', () => {

--- a/web/src/features/Map/__tests__/fixtures/map.fixtures.ts
+++ b/web/src/features/Map/__tests__/fixtures/map.fixtures.ts
@@ -1,0 +1,74 @@
+import type { PlanningApplication, WatchZoneSummary } from '../../../../domain/types';
+import { asWatchZoneId, asAuthorityId, asApplicationUid } from '../../../../domain/types';
+
+export function aWatchZone(overrides?: Partial<WatchZoneSummary>): WatchZoneSummary {
+  return {
+    id: asWatchZoneId('zone-1'),
+    name: 'Home',
+    latitude: 52.2053,
+    longitude: 0.1218,
+    radiusMetres: 2000,
+    authorityId: asAuthorityId(1),
+    ...overrides,
+  };
+}
+
+export function aSecondWatchZone(overrides?: Partial<WatchZoneSummary>): WatchZoneSummary {
+  return {
+    id: asWatchZoneId('zone-2'),
+    name: 'Office',
+    latitude: 51.5074,
+    longitude: -0.1278,
+    radiusMetres: 5000,
+    authorityId: asAuthorityId(2),
+    ...overrides,
+  };
+}
+
+export function anApplication(overrides?: Partial<PlanningApplication>): PlanningApplication {
+  return {
+    name: 'Application 1',
+    uid: asApplicationUid('app-001'),
+    areaName: 'Cambridge City Council',
+    areaId: asAuthorityId(1),
+    address: '12 Mill Road, Cambridge',
+    postcode: 'CB1 2AD',
+    description: 'Erection of two-storey rear extension',
+    appType: 'Full Planning',
+    appState: 'Undecided',
+    appSize: null,
+    startDate: '2026-01-15',
+    decidedDate: null,
+    consultedDate: null,
+    longitude: 0.1340,
+    latitude: 52.1990,
+    url: null,
+    link: null,
+    lastDifferent: '2026-01-10',
+    ...overrides,
+  };
+}
+
+export function aSecondApplication(overrides?: Partial<PlanningApplication>): PlanningApplication {
+  return {
+    name: 'Application 2',
+    uid: asApplicationUid('app-002'),
+    areaName: 'Westminster City Council',
+    areaId: asAuthorityId(2),
+    address: '45 High Street, London',
+    postcode: 'SW1A 1AA',
+    description: 'Change of use from retail to residential',
+    appType: 'Change of Use',
+    appState: 'Approved',
+    appSize: null,
+    startDate: '2026-02-01',
+    decidedDate: '2026-03-01',
+    consultedDate: null,
+    longitude: -0.1357,
+    latitude: 51.5014,
+    url: null,
+    link: null,
+    lastDifferent: '2026-02-15',
+    ...overrides,
+  };
+}

--- a/web/src/features/Map/__tests__/spies/spy-map-port.ts
+++ b/web/src/features/Map/__tests__/spies/spy-map-port.ts
@@ -1,0 +1,28 @@
+import type { AuthorityId, PlanningApplication, WatchZoneSummary } from '../../../../domain/types';
+import type { MapPort } from '../../../../domain/ports/map-port';
+
+export class SpyMapPort implements MapPort {
+  fetchWatchZonesCalls = 0;
+  fetchWatchZonesResult: readonly WatchZoneSummary[] = [];
+  fetchWatchZonesError: Error | null = null;
+
+  async fetchWatchZones(): Promise<readonly WatchZoneSummary[]> {
+    this.fetchWatchZonesCalls++;
+    if (this.fetchWatchZonesError) {
+      throw this.fetchWatchZonesError;
+    }
+    return this.fetchWatchZonesResult;
+  }
+
+  fetchApplicationsByAuthorityCalls: AuthorityId[] = [];
+  fetchApplicationsByAuthorityResults: Map<number, readonly PlanningApplication[]> = new Map();
+  fetchApplicationsByAuthorityError: Error | null = null;
+
+  async fetchApplicationsByAuthority(authorityId: AuthorityId): Promise<readonly PlanningApplication[]> {
+    this.fetchApplicationsByAuthorityCalls.push(authorityId);
+    if (this.fetchApplicationsByAuthorityError) {
+      throw this.fetchApplicationsByAuthorityError;
+    }
+    return this.fetchApplicationsByAuthorityResults.get(authorityId as number) ?? [];
+  }
+}

--- a/web/src/features/Map/__tests__/useMapData.test.ts
+++ b/web/src/features/Map/__tests__/useMapData.test.ts
@@ -1,0 +1,33 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useMapData } from '../useMapData';
+import { SpyMapPort } from './spies/spy-map-port';
+import { aWatchZone, aSecondWatchZone, anApplication, aSecondApplication } from './fixtures/map.fixtures';
+import { asAuthorityId } from '../../../domain/types';
+
+describe('useMapData', () => {
+  it('fetches watch zones and applications per zone authority', async () => {
+    const spy = new SpyMapPort();
+    const zone1 = aWatchZone();
+    const zone2 = aSecondWatchZone();
+    spy.fetchWatchZonesResult = [zone1, zone2];
+
+    const app1 = anApplication();
+    const app2 = aSecondApplication();
+    spy.fetchApplicationsByAuthorityResults.set(1, [app1]);
+    spy.fetchApplicationsByAuthorityResults.set(2, [app2]);
+
+    const { result } = renderHook(() => useMapData(spy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.zones).toEqual([zone1, zone2]);
+    expect(result.current.applications).toEqual([app1, app2]);
+    expect(result.current.error).toBeNull();
+    expect(spy.fetchWatchZonesCalls).toBe(1);
+    expect(spy.fetchApplicationsByAuthorityCalls).toContainEqual(asAuthorityId(1));
+    expect(spy.fetchApplicationsByAuthorityCalls).toContainEqual(asAuthorityId(2));
+  });
+});

--- a/web/src/features/Map/__tests__/useMapData.test.ts
+++ b/web/src/features/Map/__tests__/useMapData.test.ts
@@ -30,4 +30,52 @@ describe('useMapData', () => {
     expect(spy.fetchApplicationsByAuthorityCalls).toContainEqual(asAuthorityId(1));
     expect(spy.fetchApplicationsByAuthorityCalls).toContainEqual(asAuthorityId(2));
   });
+
+  it('sets error state when watch zone fetch fails', async () => {
+    const spy = new SpyMapPort();
+    spy.fetchWatchZonesError = new Error('Network unavailable');
+
+    const { result } = renderHook(() => useMapData(spy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Network unavailable');
+    expect(result.current.zones).toEqual([]);
+    expect(result.current.applications).toEqual([]);
+  });
+
+  it('returns loading state while fetching', () => {
+    const spy = new SpyMapPort();
+    // Don't resolve the promise — keep it pending
+    spy.fetchWatchZonesResult = [];
+
+    const { result } = renderHook(() => useMapData(spy));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.zones).toEqual([]);
+    expect(result.current.applications).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('deduplicates authority IDs across zones', async () => {
+    const spy = new SpyMapPort();
+    const zone1 = aWatchZone({ authorityId: asAuthorityId(1) });
+    const zone2 = aSecondWatchZone({ authorityId: asAuthorityId(1) });
+    spy.fetchWatchZonesResult = [zone1, zone2];
+
+    const app1 = anApplication();
+    spy.fetchApplicationsByAuthorityResults.set(1, [app1]);
+
+    const { result } = renderHook(() => useMapData(spy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Should only call fetchApplicationsByAuthority once for the shared authority
+    expect(spy.fetchApplicationsByAuthorityCalls).toHaveLength(1);
+    expect(spy.fetchApplicationsByAuthorityCalls[0]).toEqual(asAuthorityId(1));
+  });
 });

--- a/web/src/features/Map/useMapData.ts
+++ b/web/src/features/Map/useMapData.ts
@@ -1,0 +1,73 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { PlanningApplication, WatchZoneSummary } from '../../domain/types';
+import type { MapPort } from '../../domain/ports/map-port';
+
+interface MapDataState {
+  readonly zones: readonly WatchZoneSummary[];
+  readonly applications: readonly PlanningApplication[];
+  readonly isLoading: boolean;
+  readonly error: string | null;
+}
+
+export function useMapData(port: MapPort) {
+  const [state, setState] = useState<MapDataState>({
+    zones: [],
+    applications: [],
+    isLoading: true,
+    error: null,
+  });
+
+  const loadData = useCallback(async () => {
+    setState(prev => ({ ...prev, isLoading: true, error: null }));
+    try {
+      const zones = await port.fetchWatchZones();
+
+      const uniqueAuthorityIds = [...new Set(zones.map(z => z.authorityId))];
+
+      const applicationArrays = await Promise.all(
+        uniqueAuthorityIds.map(id => port.fetchApplicationsByAuthority(id)),
+      );
+
+      const applications = applicationArrays.flat();
+
+      setState({
+        zones,
+        applications,
+        isLoading: false,
+        error: null,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'An error occurred';
+      setState(prev => ({
+        ...prev,
+        isLoading: false,
+        error: message,
+      }));
+    }
+  }, [port]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const zones = await port.fetchWatchZones();
+        const uniqueAuthorityIds = [...new Set(zones.map(z => z.authorityId))];
+        const applicationArrays = await Promise.all(
+          uniqueAuthorityIds.map(id => port.fetchApplicationsByAuthority(id)),
+        );
+        const applications = applicationArrays.flat();
+        if (!cancelled) {
+          setState({ zones, applications, isLoading: false, error: null });
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : 'An error occurred';
+          setState(prev => ({ ...prev, isLoading: false, error: message }));
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [port]);
+
+  return { ...state, refresh: loadData };
+}


### PR DESCRIPTION
## Summary

Implements `tc-ebf49e4f`: Map page with Leaflet and OpenStreetMap

Adds MapPage with react-leaflet showing watch zone applications as markers with popups on OpenStreetMap tiles. Includes useMapData hook, MapPort interface, and ConnectedMapPage wired at /map route. 9 new tests.

## Bead

`tc-ebf49e4f` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented an interactive map page accessible via the `/map` route, displaying watch zones and planning applications as markers on an OpenStreetMap-based visualization.
  * Added ability to click application markers and view detailed information (summary, address, and link to full application details) via popup overlays.
  * Included loading and error state indicators for better user feedback during data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->