### PR TITLE
refactor(api): extract DemoAccount seed data from handler

### DIFF
--- a/api/src/town-crier.application/DemoAccount/DemoSeedData.cs
+++ b/api/src/town-crier.application/DemoAccount/DemoSeedData.cs
@@ -1,0 +1,92 @@
+using TownCrier.Domain.PlanningApplications;
+
+namespace TownCrier.Application.DemoAccount;
+
+public static class DemoSeedData
+{
+    public const string AuthorityName = "Westminster City Council";
+    public const int AuthorityId = 441;
+
+    public static IReadOnlyList<PlanningApplication> CreateApplications(DateTimeOffset lastDifferent)
+    {
+        return
+        [
+            new PlanningApplication(
+                name: "24/05678/FULL",
+                uid: "demo-app-001",
+                areaName: AuthorityName,
+                areaId: AuthorityId,
+                address: "10 Downing Street, London SW1A 2AA",
+                postcode: "SW1A 2AA",
+                description: "Replacement of entrance door and associated security improvements",
+                appType: "Full",
+                appState: "Under consideration",
+                appSize: null,
+                startDate: new DateOnly(2026, 1, 15),
+                decidedDate: null,
+                consultedDate: new DateOnly(2026, 2, 1),
+                longitude: -0.1276,
+                latitude: 51.5034,
+                url: null,
+                link: null,
+                lastDifferent: lastDifferent),
+            new PlanningApplication(
+                name: "24/05679/FULL",
+                uid: "demo-app-002",
+                areaName: AuthorityName,
+                areaId: AuthorityId,
+                address: "Westminster Abbey, 20 Deans Yd, London SW1P 3PA",
+                postcode: "SW1P 3PA",
+                description: "Installation of new lighting system in the nave and restoration of stonework",
+                appType: "Listed Building",
+                appState: "Approved",
+                appSize: null,
+                startDate: new DateOnly(2025, 11, 1),
+                decidedDate: new DateOnly(2026, 2, 20),
+                consultedDate: new DateOnly(2025, 12, 1),
+                longitude: -0.1273,
+                latitude: 51.4993,
+                url: null,
+                link: null,
+                lastDifferent: lastDifferent),
+            new PlanningApplication(
+                name: "24/05680/FULL",
+                uid: "demo-app-003",
+                areaName: AuthorityName,
+                areaId: AuthorityId,
+                address: "Buckingham Palace, London SW1A 1AA",
+                postcode: "SW1A 1AA",
+                description: "Erection of temporary scaffolding for facade cleaning and minor repairs to roof drainage",
+                appType: "Full",
+                appState: "Under consideration",
+                appSize: null,
+                startDate: new DateOnly(2026, 2, 10),
+                decidedDate: null,
+                consultedDate: null,
+                longitude: -0.1419,
+                latitude: 51.5014,
+                url: null,
+                link: null,
+                lastDifferent: lastDifferent),
+            new PlanningApplication(
+                name: "24/05681/FULL",
+                uid: "demo-app-004",
+                areaName: AuthorityName,
+                areaId: AuthorityId,
+                address: "St James's Park, London SW1A 2BJ",
+                postcode: "SW1A 2BJ",
+                description: "Construction of new accessible footpath and installation of park benches",
+                appType: "Full",
+                appState: "Refused",
+                appSize: null,
+                startDate: new DateOnly(2025, 10, 5),
+                decidedDate: new DateOnly(2026, 1, 30),
+                consultedDate: new DateOnly(2025, 11, 1),
+                longitude: -0.1340,
+                latitude: 51.5025,
+                url: null,
+                link: null,
+                lastDifferent: lastDifferent),
+        ];
+    }
+}

--- a/api/src/town-crier.application/DemoAccount/GetDemoAccountQueryHandler.cs
+++ b/api/src/town-crier.application/DemoAccount/GetDemoAccountQueryHandler.cs
@@ -2,7 +2,6 @@ using TownCrier.Application.PlanningApplications;
 using TownCrier.Application.UserProfiles;
 using TownCrier.Application.WatchZones;
 using TownCrier.Domain.Geocoding;
-using TownCrier.Domain.PlanningApplications;
 using TownCrier.Domain.UserProfiles;
 using TownCrier.Domain.WatchZones;
 
@@ -12,8 +11,6 @@ public sealed class GetDemoAccountQueryHandler
 {
     public const string DemoUserId = "demo|apple-reviewer";
     private const string DemoZoneId = "demo-zone";
-    private const string DemoAuthorityName = "Westminster City Council";
-    private const int DemoAuthorityId = 441;
     private const double DemoLatitude = 51.4975;
     private const double DemoLongitude = -0.1357;
     private const double DemoRadiusMetres = 2000;
@@ -44,18 +41,18 @@ public sealed class GetDemoAccountQueryHandler
             profile.ActivateSubscription(SubscriptionTier.Pro, DateTimeOffset.UtcNow.AddYears(10));
             await this.userProfileRepository.SaveAsync(profile, ct).ConfigureAwait(false);
 
-            var zone = new WatchZone(DemoZoneId, DemoUserId, "Westminster Demo Zone", new Coordinates(DemoLatitude, DemoLongitude), DemoRadiusMetres, DemoAuthorityId);
+            var zone = new WatchZone(DemoZoneId, DemoUserId, "Westminster Demo Zone", new Coordinates(DemoLatitude, DemoLongitude), DemoRadiusMetres, DemoSeedData.AuthorityId);
             await this.watchZoneRepository.SaveAsync(zone, ct).ConfigureAwait(false);
 
             await this.SeedDemoApplicationsAsync(ct).ConfigureAwait(false);
         }
 
-        var authorityCode = DemoAuthorityId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var authorityCode = DemoSeedData.AuthorityId.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var applications = await this.planningApplicationRepository.FindNearbyAsync(
             authorityCode, DemoLatitude, DemoLongitude, DemoRadiusMetres, ct).ConfigureAwait(false);
 
         var watchZoneResult = new DemoWatchZoneResult(
-            DemoZoneId, DemoAuthorityName, DemoLatitude, DemoLongitude, DemoRadiusMetres);
+            DemoZoneId, DemoSeedData.AuthorityName, DemoLatitude, DemoLongitude, DemoRadiusMetres);
 
         var applicationResults = applications
             .Select(a => new DemoApplicationResult(a.Uid, a.Name, a.Address, a.Description, a.AppType, a.AppState))
@@ -66,86 +63,7 @@ public sealed class GetDemoAccountQueryHandler
 
     private async Task SeedDemoApplicationsAsync(CancellationToken ct)
     {
-        var now = DateTimeOffset.UtcNow;
-        var demoApplications = new[]
-        {
-            new PlanningApplication(
-                name: "24/05678/FULL",
-                uid: "demo-app-001",
-                areaName: DemoAuthorityName,
-                areaId: DemoAuthorityId,
-                address: "10 Downing Street, London SW1A 2AA",
-                postcode: "SW1A 2AA",
-                description: "Replacement of entrance door and associated security improvements",
-                appType: "Full",
-                appState: "Under consideration",
-                appSize: null,
-                startDate: new DateOnly(2026, 1, 15),
-                decidedDate: null,
-                consultedDate: new DateOnly(2026, 2, 1),
-                longitude: -0.1276,
-                latitude: 51.5034,
-                url: null,
-                link: null,
-                lastDifferent: now),
-            new PlanningApplication(
-                name: "24/05679/FULL",
-                uid: "demo-app-002",
-                areaName: DemoAuthorityName,
-                areaId: DemoAuthorityId,
-                address: "Westminster Abbey, 20 Deans Yd, London SW1P 3PA",
-                postcode: "SW1P 3PA",
-                description: "Installation of new lighting system in the nave and restoration of stonework",
-                appType: "Listed Building",
-                appState: "Approved",
-                appSize: null,
-                startDate: new DateOnly(2025, 11, 1),
-                decidedDate: new DateOnly(2026, 2, 20),
-                consultedDate: new DateOnly(2025, 12, 1),
-                longitude: -0.1273,
-                latitude: 51.4993,
-                url: null,
-                link: null,
-                lastDifferent: now),
-            new PlanningApplication(
-                name: "24/05680/FULL",
-                uid: "demo-app-003",
-                areaName: DemoAuthorityName,
-                areaId: DemoAuthorityId,
-                address: "Buckingham Palace, London SW1A 1AA",
-                postcode: "SW1A 1AA",
-                description: "Erection of temporary scaffolding for facade cleaning and minor repairs to roof drainage",
-                appType: "Full",
-                appState: "Under consideration",
-                appSize: null,
-                startDate: new DateOnly(2026, 2, 10),
-                decidedDate: null,
-                consultedDate: null,
-                longitude: -0.1419,
-                latitude: 51.5014,
-                url: null,
-                link: null,
-                lastDifferent: now),
-            new PlanningApplication(
-                name: "24/05681/FULL",
-                uid: "demo-app-004",
-                areaName: DemoAuthorityName,
-                areaId: DemoAuthorityId,
-                address: "St James's Park, London SW1A 2BJ",
-                postcode: "SW1A 2BJ",
-                description: "Construction of new accessible footpath and installation of park benches",
-                appType: "Full",
-                appState: "Refused",
-                appSize: null,
-                startDate: new DateOnly(2025, 10, 5),
-                decidedDate: new DateOnly(2026, 1, 30),
-                consultedDate: new DateOnly(2025, 11, 1),
-                longitude: -0.1340,
-                latitude: 51.5025,
-                url: null,
-                link: null,
-                lastDifferent: now),
-        };
+        var demoApplications = DemoSeedData.CreateApplications(DateTimeOffset.UtcNow);
 
         foreach (var application in demoApplications)
         {

--- a/api/tests/town-crier.application.tests/DemoAccount/DemoSeedDataTests.cs
+++ b/api/tests/town-crier.application.tests/DemoAccount/DemoSeedDataTests.cs
@@ -1,0 +1,20 @@
+using TownCrier.Application.DemoAccount;
+
+namespace TownCrier.Application.Tests.DemoAccount;
+
+public sealed class DemoSeedDataTests
+{
+    [Test]
+    public async Task Should_HaveValidCoordinates_When_SeedDataCreated()
+    {
+        // Arrange & Act
+        var applications = DemoSeedData.CreateApplications(DateTimeOffset.UtcNow);
+
+        // Assert — every demo application must have non-null latitude and longitude
+        foreach (var app in applications)
+        {
+            await Assert.That(app.Latitude).IsNotNull();
+            await Assert.That(app.Longitude).IsNotNull();
+        }
+    }
+}

--- a/api/tests/town-crier.application.tests/DemoAccount/DemoSeedDataTests.cs
+++ b/api/tests/town-crier.application.tests/DemoAccount/DemoSeedDataTests.cs
@@ -17,4 +17,31 @@ public sealed class DemoSeedDataTests
             await Assert.That(app.Longitude).IsNotNull();
         }
     }
+
+    [Test]
+    public async Task Should_HaveNonEmptyAddresses_When_SeedDataCreated()
+    {
+        // Arrange & Act
+        var applications = DemoSeedData.CreateApplications(DateTimeOffset.UtcNow);
+
+        // Assert — every demo application must have a non-empty address
+        foreach (var app in applications)
+        {
+            await Assert.That(app.Address).IsNotEmpty();
+        }
+    }
+
+    [Test]
+    public async Task Should_UseSharedAuthorityConstants_When_SeedDataCreated()
+    {
+        // Arrange & Act
+        var applications = DemoSeedData.CreateApplications(DateTimeOffset.UtcNow);
+
+        // Assert — all applications use the shared authority from DemoSeedData constants
+        foreach (var app in applications)
+        {
+            await Assert.That(app.AreaName).IsEqualTo(DemoSeedData.AuthorityName);
+            await Assert.That(app.AreaId).IsEqualTo(DemoSeedData.AuthorityId);
+        }
+    }
 }

--- a/api/tests/town-crier.application.tests/DemoAccount/GetDemoAccountQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/DemoAccount/GetDemoAccountQueryHandlerTests.cs
@@ -78,8 +78,26 @@ public sealed class GetDemoAccountQueryHandlerTests
         // Act
         var result = await handler.HandleAsync(new GetDemoAccountQuery(), CancellationToken.None);
 
-        // Assert — should have seeded applications
-        await Assert.That(result.Applications.Count).IsGreaterThanOrEqualTo(3);
+        // Assert — should seed exactly the number of applications defined in DemoSeedData
+        var expectedCount = DemoSeedData.CreateApplications(DateTimeOffset.UtcNow).Count;
+        await Assert.That(result.Applications.Count).IsEqualTo(expectedCount);
+    }
+
+    [Test]
+    public async Task Should_UseAuthorityFromSeedData_When_CreatingWatchZone()
+    {
+        // Arrange
+        var userProfileRepository = new FakeUserProfileRepository();
+        var watchZoneRepository = new FakeWatchZoneRepository();
+        var planningApplicationRepository = new FakePlanningApplicationRepository();
+        var handler = new GetDemoAccountQueryHandler(
+            userProfileRepository, watchZoneRepository, planningApplicationRepository);
+
+        // Act
+        var result = await handler.HandleAsync(new GetDemoAccountQuery(), CancellationToken.None);
+
+        // Assert — watch zone authority name should match the DemoSeedData constant
+        await Assert.That(result.WatchZone.AuthorityName).IsEqualTo(DemoSeedData.AuthorityName);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Implements `tc-kdt`: Extract DemoAccount seed data from handler

Extracts 4 inline PlanningApplication constructions into DemoSeedData static class. Handler reduced from 155 to 73 lines, now a thin orchestrator. 4 new tests (283 total).

## Bead

`tc-kdt` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized demo account data management for improved consistency and maintainability.

* **Tests**
  * Added comprehensive validation tests to ensure demo account data maintains valid coordinates, addresses, and authority information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->