### PR TITLE
ci: remove unused infra-dev job outputs in cd-dev workflow

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -91,9 +91,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: development
-    outputs:
-      resource-group: ${{ steps.outputs.outputs.resource-group }}
-      swa-name: ${{ steps.outputs.outputs.swa-name }}
     steps:
       - uses: actions/checkout@v4
 
@@ -116,15 +113,6 @@ jobs:
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Extract Pulumi outputs
-        id: outputs
-        working-directory: infra
-        run: |
-          echo "resource-group=$(pulumi stack output resourceGroupName --stack dev)" >> "$GITHUB_OUTPUT"
-          echo "swa-name=$(pulumi stack output staticWebAppName --stack dev)" >> "$GITHUB_OUTPUT"
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
   # ── API: build & push image ─────────────────────────
   api-image:


### PR DESCRIPTION
## Summary

Implements `tc-e00`: Remove unused infra-dev job outputs in cd-dev workflow

Removes 11 lines of dead workflow config — the infra-dev job declared resource-group and swa-name outputs that no downstream job consumed.

## Bead

`tc-e00` — see bead comments for pipeline evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified deployment workflow configuration by removing unused workflow output declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->