### PR TITLE
refactor(api): centralise Cosmos DB container name constants

### DIFF
--- a/api/src/town-crier.infrastructure/Cosmos/CosmosContainerNames.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosContainerNames.cs
@@ -1,0 +1,10 @@
+namespace TownCrier.Infrastructure.Cosmos;
+
+/// <summary>
+/// Central constants for Cosmos DB database and container names.
+/// All repository adapters must reference these constants rather than hardcoding strings.
+/// </summary>
+public static class CosmosContainerNames
+{
+    public const string DatabaseName = "town-crier";
+}

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosContainerNames.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosContainerNames.cs
@@ -7,4 +7,13 @@ namespace TownCrier.Infrastructure.Cosmos;
 public static class CosmosContainerNames
 {
     public const string DatabaseName = "town-crier";
+
+    public const string Users = "Users";
+    public const string Groups = "groups";
+    public const string Notifications = "notifications";
+    public const string DeviceRegistrations = "DeviceRegistrations";
+    public const string DecisionAlerts = "DecisionAlerts";
+    public const string SavedApplications = "SavedApplications";
+    public const string WatchZones = "WatchZones";
+    public const string Applications = "Applications";
 }

--- a/api/src/town-crier.infrastructure/DecisionAlerts/CosmosDecisionAlertRepository.cs
+++ b/api/src/town-crier.infrastructure/DecisionAlerts/CosmosDecisionAlertRepository.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Microsoft.Azure.Cosmos;
 using TownCrier.Application.DecisionAlerts;
 using TownCrier.Domain.DecisionAlerts;
+using TownCrier.Infrastructure.Cosmos;
 
 namespace TownCrier.Infrastructure.DecisionAlerts;
 
@@ -12,7 +13,7 @@ public sealed class CosmosDecisionAlertRepository : IDecisionAlertRepository
     public CosmosDecisionAlertRepository(CosmosClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer("town-crier", "DecisionAlerts");
+        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.DecisionAlerts);
     }
 
     public async Task<DecisionAlert?> GetByUserAndApplicationAsync(

--- a/api/src/town-crier.infrastructure/DeviceRegistrations/CosmosDeviceRegistrationRepository.cs
+++ b/api/src/town-crier.infrastructure/DeviceRegistrations/CosmosDeviceRegistrationRepository.cs
@@ -13,7 +13,7 @@ public sealed class CosmosDeviceRegistrationRepository : IDeviceRegistrationRepo
     public CosmosDeviceRegistrationRepository(CosmosClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer("town-crier", "DeviceRegistrations");
+        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.DeviceRegistrations);
     }
 
     public async Task<DeviceRegistration?> GetByTokenAsync(string token, CancellationToken ct)

--- a/api/src/town-crier.infrastructure/Groups/CosmosGroupInvitationRepository.cs
+++ b/api/src/town-crier.infrastructure/Groups/CosmosGroupInvitationRepository.cs
@@ -12,7 +12,7 @@ public sealed class CosmosGroupInvitationRepository : IGroupInvitationRepository
     public CosmosGroupInvitationRepository(CosmosClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer("town-crier", "groups");
+        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.Groups);
     }
 
     public async Task<GroupInvitation?> GetByIdAsync(string invitationId, CancellationToken ct)

--- a/api/src/town-crier.infrastructure/Groups/CosmosGroupRepository.cs
+++ b/api/src/town-crier.infrastructure/Groups/CosmosGroupRepository.cs
@@ -12,7 +12,7 @@ public sealed class CosmosGroupRepository : IGroupRepository
     public CosmosGroupRepository(CosmosClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer("town-crier", "groups");
+        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.Groups);
     }
 
     public async Task<Group?> GetByIdAsync(string groupId, CancellationToken ct)

--- a/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
@@ -12,7 +12,7 @@ public sealed class CosmosNotificationRepository : INotificationRepository
     public CosmosNotificationRepository(CosmosClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer("town-crier", "notifications");
+        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.Notifications);
     }
 
     public async Task<Notification?> GetByUserAndApplicationAsync(

--- a/api/src/town-crier.infrastructure/PlanningApplications/CosmosPlanningApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/PlanningApplications/CosmosPlanningApplicationRepository.cs
@@ -12,7 +12,7 @@ public sealed class CosmosPlanningApplicationRepository : IPlanningApplicationRe
     public CosmosPlanningApplicationRepository(CosmosClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer("town-crier", "Applications");
+        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.Applications);
     }
 
     public async Task UpsertAsync(PlanningApplication application, CancellationToken ct)

--- a/api/src/town-crier.infrastructure/SavedApplications/CosmosSavedApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/SavedApplications/CosmosSavedApplicationRepository.cs
@@ -13,7 +13,7 @@ public sealed class CosmosSavedApplicationRepository : ISavedApplicationReposito
     public CosmosSavedApplicationRepository(CosmosClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer("town-crier", "SavedApplications");
+        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.SavedApplications);
     }
 
     public async Task SaveAsync(SavedApplication savedApplication, CancellationToken ct)

--- a/api/src/town-crier.infrastructure/UserProfiles/CosmosUserProfileRepository.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/CosmosUserProfileRepository.cs
@@ -13,7 +13,7 @@ public sealed class CosmosUserProfileRepository : IUserProfileRepository
     public CosmosUserProfileRepository(CosmosClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer("town-crier", "Users");
+        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.Users);
     }
 
     public async Task<UserProfile?> GetByUserIdAsync(string userId, CancellationToken ct)

--- a/api/src/town-crier.infrastructure/WatchZones/CosmosWatchZoneRepository.cs
+++ b/api/src/town-crier.infrastructure/WatchZones/CosmosWatchZoneRepository.cs
@@ -13,7 +13,7 @@ public sealed class CosmosWatchZoneRepository : IWatchZoneRepository
     public CosmosWatchZoneRepository(CosmosClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer("town-crier", "WatchZones");
+        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.WatchZones);
     }
 
     public async Task SaveAsync(WatchZone zone, CancellationToken ct)

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosContainerNamesTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosContainerNamesTests.cs
@@ -10,4 +10,26 @@ public sealed class CosmosContainerNamesTests
         string databaseName = CosmosContainerNames.DatabaseName;
         await Assert.That(databaseName).IsEqualTo("town-crier");
     }
+
+    [Test]
+    public async Task Should_ExposeAllContainerNames_AsConstants()
+    {
+        string users = CosmosContainerNames.Users;
+        string groups = CosmosContainerNames.Groups;
+        string notifications = CosmosContainerNames.Notifications;
+        string deviceRegistrations = CosmosContainerNames.DeviceRegistrations;
+        string decisionAlerts = CosmosContainerNames.DecisionAlerts;
+        string savedApplications = CosmosContainerNames.SavedApplications;
+        string watchZones = CosmosContainerNames.WatchZones;
+        string applications = CosmosContainerNames.Applications;
+
+        await Assert.That(users).IsNotEmpty();
+        await Assert.That(groups).IsNotEmpty();
+        await Assert.That(notifications).IsNotEmpty();
+        await Assert.That(deviceRegistrations).IsNotEmpty();
+        await Assert.That(decisionAlerts).IsNotEmpty();
+        await Assert.That(savedApplications).IsNotEmpty();
+        await Assert.That(watchZones).IsNotEmpty();
+        await Assert.That(applications).IsNotEmpty();
+    }
 }

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosContainerNamesTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosContainerNamesTests.cs
@@ -7,6 +7,7 @@ public sealed class CosmosContainerNamesTests
     [Test]
     public async Task Should_ExposeDatabaseName_AsConstant()
     {
-        await Assert.That(CosmosContainerNames.DatabaseName).IsEqualTo("town-crier");
+        string databaseName = CosmosContainerNames.DatabaseName;
+        await Assert.That(databaseName).IsEqualTo("town-crier");
     }
 }

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosContainerNamesTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosContainerNamesTests.cs
@@ -1,0 +1,12 @@
+using TownCrier.Infrastructure.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.Cosmos;
+
+public sealed class CosmosContainerNamesTests
+{
+    [Test]
+    public async Task Should_ExposeDatabaseName_AsConstant()
+    {
+        await Assert.That(CosmosContainerNames.DatabaseName).IsEqualTo("town-crier");
+    }
+}


### PR DESCRIPTION
## Summary

Implements `tc-dxi`: Centralise Cosmos DB container name constants

Adds CosmosContainerNames static class with DatabaseName and 8 container constants, replaces hardcoded strings across 9 repository files. 2 new tests (285 total).

## Bead

`tc-dxi` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated database and container name identifiers into a unified configuration system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->