### PR TITLE
refactor(web): extract context provider factory

### DIFF
--- a/web/src/__tests__/api/useApiClient.test.tsx
+++ b/web/src/__tests__/api/useApiClient.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { ApiClientContext, useApiClient } from '../../api/useApiClient';
+import { ApiClientProvider, useApiClient } from '../../api/useApiClient';
 import type { ApiClient } from '../../api/client';
 
 const fakeClient: ApiClient = {
@@ -16,9 +16,9 @@ describe('useApiClient', () => {
   it('returns the ApiClient from context', () => {
     function wrapper({ children }: { children: ReactNode }) {
       return (
-        <ApiClientContext.Provider value={fakeClient}>
+        <ApiClientProvider value={fakeClient}>
           {children}
-        </ApiClientContext.Provider>
+        </ApiClientProvider>
       );
     }
     const { result } = renderHook(() => useApiClient(), { wrapper });
@@ -28,6 +28,6 @@ describe('useApiClient', () => {
   it('throws when used outside provider', () => {
     expect(() => {
       renderHook(() => useApiClient());
-    }).toThrow('useApiClient must be used within an ApiClientProvider');
+    }).toThrow('useApiClient must be used within a ApiClient.Provider');
   });
 });

--- a/web/src/__tests__/routes.test.tsx
+++ b/web/src/__tests__/routes.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { AuthProvider } from '../auth/auth-context';
-import { ProfileRepositoryContext } from '../auth/profile-context';
+import { ProfileRepositoryProvider } from '../auth/profile-context';
 import { ApiClientContext } from '../api/useApiClient';
 import { SpyAuthPort } from '../auth/__tests__/spies/spy-auth-port';
 import { SpyProfileRepository } from '../auth/__tests__/spies/spy-profile-repository';
@@ -58,11 +58,11 @@ function renderRoutes({ route = '/', authSpy, profileSpy }: RenderOptions = {}) 
   return render(
     <MemoryRouter initialEntries={[route]}>
       <AuthProvider value={auth}>
-        <ProfileRepositoryContext.Provider value={profile}>
+        <ProfileRepositoryProvider value={profile}>
           <ApiClientContext.Provider value={stubApiClient}>
             <AppRoutes />
           </ApiClientContext.Provider>
-        </ProfileRepositoryContext.Provider>
+        </ProfileRepositoryProvider>
       </AuthProvider>
     </MemoryRouter>,
   );

--- a/web/src/__tests__/routes.test.tsx
+++ b/web/src/__tests__/routes.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { AuthContext } from '../auth/auth-context';
+import { AuthProvider } from '../auth/auth-context';
 import { ProfileRepositoryContext } from '../auth/profile-context';
 import { ApiClientContext } from '../api/useApiClient';
 import { SpyAuthPort } from '../auth/__tests__/spies/spy-auth-port';
@@ -57,13 +57,13 @@ function renderRoutes({ route = '/', authSpy, profileSpy }: RenderOptions = {}) 
 
   return render(
     <MemoryRouter initialEntries={[route]}>
-      <AuthContext.Provider value={auth}>
+      <AuthProvider value={auth}>
         <ProfileRepositoryContext.Provider value={profile}>
           <ApiClientContext.Provider value={stubApiClient}>
             <AppRoutes />
           </ApiClientContext.Provider>
         </ProfileRepositoryContext.Provider>
-      </AuthContext.Provider>
+      </AuthProvider>
     </MemoryRouter>,
   );
 }

--- a/web/src/__tests__/routes.test.tsx
+++ b/web/src/__tests__/routes.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { AuthProvider } from '../auth/auth-context';
 import { ProfileRepositoryProvider } from '../auth/profile-context';
-import { ApiClientContext } from '../api/useApiClient';
+import { ApiClientProvider } from '../api/useApiClient';
 import { SpyAuthPort } from '../auth/__tests__/spies/spy-auth-port';
 import { SpyProfileRepository } from '../auth/__tests__/spies/spy-profile-repository';
 import { AppRoutes } from '../AppRoutes';
@@ -59,9 +59,9 @@ function renderRoutes({ route = '/', authSpy, profileSpy }: RenderOptions = {}) 
     <MemoryRouter initialEntries={[route]}>
       <AuthProvider value={auth}>
         <ProfileRepositoryProvider value={profile}>
-          <ApiClientContext.Provider value={stubApiClient}>
+          <ApiClientProvider value={stubApiClient}>
             <AppRoutes />
-          </ApiClientContext.Provider>
+          </ApiClientProvider>
         </ProfileRepositoryProvider>
       </AuthProvider>
     </MemoryRouter>,

--- a/web/src/__tests__/utils/createRequiredContext.test.tsx
+++ b/web/src/__tests__/utils/createRequiredContext.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { createRequiredContext } from '../../utils/createRequiredContext';
 
 describe('createRequiredContext', () => {
@@ -9,5 +10,17 @@ describe('createRequiredContext', () => {
     expect(() => {
       renderHook(() => useValue());
     }).toThrow('useTestContext must be used within a TestContext.Provider');
+  });
+
+  it('returns value when hook is called inside provider', () => {
+    const [Provider, useValue] = createRequiredContext<string>('TestContext');
+
+    function wrapper({ children }: { children: ReactNode }) {
+      return <Provider value="hello">{children}</Provider>;
+    }
+
+    const { result } = renderHook(() => useValue(), { wrapper });
+
+    expect(result.current).toBe('hello');
   });
 });

--- a/web/src/__tests__/utils/createRequiredContext.test.tsx
+++ b/web/src/__tests__/utils/createRequiredContext.test.tsx
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { createRequiredContext } from '../../utils/createRequiredContext';
+
+describe('createRequiredContext', () => {
+  it('throws when hook is called outside provider', () => {
+    const [, useValue] = createRequiredContext<string>('TestContext');
+
+    expect(() => {
+      renderHook(() => useValue());
+    }).toThrow('useTestContext must be used within a TestContext.Provider');
+  });
+});

--- a/web/src/__tests__/utils/createRequiredContext.test.tsx
+++ b/web/src/__tests__/utils/createRequiredContext.test.tsx
@@ -23,4 +23,12 @@ describe('createRequiredContext', () => {
 
     expect(result.current).toBe('hello');
   });
+
+  it('uses the context name in the error message', () => {
+    const [, useAuth] = createRequiredContext<{ token: string }>('Auth');
+
+    expect(() => {
+      renderHook(() => useAuth());
+    }).toThrow('useAuth must be used within a Auth.Provider');
+  });
 });

--- a/web/src/api/ApiClientProvider.tsx
+++ b/web/src/api/ApiClientProvider.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { createApiClient } from './client';
-import { ApiClientContext } from './useApiClient';
+import { ApiClientProvider as ApiClientCtxProvider } from './useApiClient';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string || 'http://localhost:5000';
 
@@ -19,8 +19,8 @@ export function ApiClientProvider({ children }: Props) {
   );
 
   return (
-    <ApiClientContext.Provider value={client}>
+    <ApiClientCtxProvider value={client}>
       {children}
-    </ApiClientContext.Provider>
+    </ApiClientCtxProvider>
   );
 }

--- a/web/src/api/useApiClient.ts
+++ b/web/src/api/useApiClient.ts
@@ -1,12 +1,4 @@
-import { createContext, useContext } from 'react';
 import type { ApiClient } from './client';
+import { createRequiredContext } from '../utils/createRequiredContext.ts';
 
-export const ApiClientContext = createContext<ApiClient | null>(null);
-
-export function useApiClient(): ApiClient {
-  const client = useContext(ApiClientContext);
-  if (!client) {
-    throw new Error('useApiClient must be used within an ApiClientProvider');
-  }
-  return client;
-}
+export const [ApiClientProvider, useApiClient] = createRequiredContext<ApiClient>('ApiClient');

--- a/web/src/auth/Auth0AuthAdapter.tsx
+++ b/web/src/auth/Auth0AuthAdapter.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
-import { AuthContext } from './auth-context';
+import { AuthProvider } from './auth-context';
 import type { AuthPort } from '../domain/ports/auth-port';
 
 interface Props {
@@ -21,8 +21,8 @@ export function Auth0AuthAdapter({ children }: Props) {
   );
 
   return (
-    <AuthContext.Provider value={auth}>
+    <AuthProvider value={auth}>
       {children}
-    </AuthContext.Provider>
+    </AuthProvider>
   );
 }

--- a/web/src/auth/ProfileRepositoryProvider.tsx
+++ b/web/src/auth/ProfileRepositoryProvider.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { useApiClient } from '../api/useApiClient';
 import { userProfileApi } from '../api/userProfile';
-import { ProfileRepositoryContext } from './profile-context';
+import { ProfileRepositoryProvider as ProfileRepoProvider } from './profile-context';
 import type { ProfileRepository } from '../domain/ports/profile-repository';
 import type { UserProfile } from '../domain/types';
 import { ApiRequestError } from '../api/client';
@@ -31,8 +31,8 @@ export function ProfileRepositoryProvider({ children }: Props) {
   }, [client]);
 
   return (
-    <ProfileRepositoryContext.Provider value={repository}>
+    <ProfileRepoProvider value={repository}>
       {children}
-    </ProfileRepositoryContext.Provider>
+    </ProfileRepoProvider>
   );
 }

--- a/web/src/auth/__tests__/AuthGuard.test.tsx
+++ b/web/src/auth/__tests__/AuthGuard.test.tsx
@@ -1,19 +1,19 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { AuthContext } from '../auth-context.ts';
+import { AuthProvider } from '../auth-context.ts';
 import { AuthGuard } from '../AuthGuard.tsx';
 import { SpyAuthPort } from './spies/spy-auth-port.ts';
 
 function renderWithAuth(spy: SpyAuthPort) {
   return render(
     <MemoryRouter initialEntries={['/protected']}>
-      <AuthContext.Provider value={spy}>
+      <AuthProvider value={spy}>
         <Routes>
           <Route element={<AuthGuard />}>
             <Route path="/protected" element={<div>Protected Content</div>} />
           </Route>
         </Routes>
-      </AuthContext.Provider>
+      </AuthProvider>
     </MemoryRouter>,
   );
 }

--- a/web/src/auth/__tests__/OnboardingGate.test.tsx
+++ b/web/src/auth/__tests__/OnboardingGate.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { ProfileRepositoryContext } from '../profile-context.ts';
+import { ProfileRepositoryProvider } from '../profile-context.ts';
 import { OnboardingGate } from '../OnboardingGate.tsx';
 import { SpyProfileRepository } from './spies/spy-profile-repository.ts';
 import type { UserProfile } from '../../domain/types.ts';
@@ -15,14 +15,14 @@ const existingProfile: UserProfile = {
 function renderWithProfile(spy: SpyProfileRepository) {
   return render(
     <MemoryRouter initialEntries={['/app']}>
-      <ProfileRepositoryContext.Provider value={spy}>
+      <ProfileRepositoryProvider value={spy}>
         <Routes>
           <Route element={<OnboardingGate />}>
             <Route path="/app" element={<div>Dashboard</div>} />
           </Route>
           <Route path="/onboarding" element={<div>Onboarding</div>} />
         </Routes>
-      </ProfileRepositoryContext.Provider>
+      </ProfileRepositoryProvider>
     </MemoryRouter>,
   );
 }

--- a/web/src/auth/auth-context.ts
+++ b/web/src/auth/auth-context.ts
@@ -1,12 +1,4 @@
-import { createContext, useContext } from 'react';
 import type { AuthPort } from '../domain/ports/auth-port.ts';
+import { createRequiredContext } from '../utils/createRequiredContext.ts';
 
-export const AuthContext = createContext<AuthPort | null>(null);
-
-export function useAuth(): AuthPort {
-  const ctx = useContext(AuthContext);
-  if (ctx === null) {
-    throw new Error('useAuth must be used within an AuthContext.Provider');
-  }
-  return ctx;
-}
+export const [AuthProvider, useAuth] = createRequiredContext<AuthPort>('AuthContext');

--- a/web/src/auth/profile-context.ts
+++ b/web/src/auth/profile-context.ts
@@ -1,12 +1,4 @@
-import { createContext, useContext } from 'react';
 import type { ProfileRepository } from '../domain/ports/profile-repository.ts';
+import { createRequiredContext } from '../utils/createRequiredContext.ts';
 
-export const ProfileRepositoryContext = createContext<ProfileRepository | null>(null);
-
-export function useProfileRepository(): ProfileRepository {
-  const ctx = useContext(ProfileRepositoryContext);
-  if (ctx === null) {
-    throw new Error('useProfileRepository must be used within a ProfileRepositoryContext.Provider');
-  }
-  return ctx;
-}
+export const [ProfileRepositoryProvider, useProfileRepository] = createRequiredContext<ProfileRepository>('ProfileRepositoryContext');

--- a/web/src/utils/createRequiredContext.ts
+++ b/web/src/utils/createRequiredContext.ts
@@ -1,0 +1,18 @@
+import { createContext, useContext } from 'react';
+import type { Context, Provider } from 'react';
+
+export function createRequiredContext<T>(
+  name: string,
+): [Provider<T | null>, () => T] {
+  const ctx: Context<T | null> = createContext<T | null>(null);
+
+  function useRequiredContext(): T {
+    const value = useContext(ctx);
+    if (value === null) {
+      throw new Error(`use${name} must be used within a ${name}.Provider`);
+    }
+    return value;
+  }
+
+  return [ctx.Provider, useRequiredContext];
+}


### PR DESCRIPTION
## Summary

Implements `tc-i4o`: Extract context provider factory

Adds createRequiredContext<T> factory that returns [Provider, useHook], replacing duplicated createContext + null-check pattern across auth-context, profile-context, and useApiClient (12 lines each reduced to 3). 3 new tests.

## Bead

`tc-i4o` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal context provider implementation to enhance code consistency and maintainability across authentication, API client, and repository management.

* **Tests**
  * Updated test fixtures to reflect internal provider architecture changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->