### PR TITLE
refactor(web): standardise Wired/Connected page wrapper naming

### DIFF
--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -2,6 +2,7 @@
   "database": "dolt",
   "backend": "dolt",
   "dolt_mode": "server",
+  "dolt_server_port": 57354,
   "dolt_database": "town_crier",
   "project_id": "8309f4e2-cdba-4e7e-9acf-61d481500188"
 }

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -2,7 +2,6 @@
   "database": "dolt",
   "backend": "dolt",
   "dolt_mode": "server",
-  "dolt_server_port": 57354,
   "dolt_database": "town_crier",
   "project_id": "8309f4e2-cdba-4e7e-9acf-61d481500188"
 }

--- a/web/src/AppRoutes.tsx
+++ b/web/src/AppRoutes.tsx
@@ -8,18 +8,18 @@ import { AppShell } from './components/AppShell/AppShell';
 import { ConnectedOnboardingPage } from './features/onboarding/ConnectedOnboardingPage';
 import { ConnectedApplicationsPage } from './features/Applications/ConnectedApplicationsPage';
 import { ConnectedDashboardPage } from './features/Dashboard/ConnectedDashboardPage';
-import { WiredNotificationsPage } from './features/Notifications/WiredNotificationsPage';
-import { WiredSettingsPage } from './features/Settings/WiredSettingsPage';
+import { ConnectedNotificationsPage } from './features/Notifications/ConnectedNotificationsPage';
+import { ConnectedSettingsPage } from './features/Settings/ConnectedSettingsPage';
 import { ConnectedSearchPage } from './features/Search/ConnectedSearchPage';
 import { ConnectedApplicationDetailPage } from './features/ApplicationDetail/ConnectedApplicationDetailPage';
-import { WiredWatchZoneListPage } from './features/WatchZones/WiredWatchZoneListPage';
-import { WiredWatchZoneCreatePage } from './features/WatchZones/WiredWatchZoneCreatePage';
-import { WiredWatchZoneEditPage } from './features/WatchZones/WiredWatchZoneEditPage';
-import { WiredGroupsListPage } from './features/Groups/WiredGroupsListPage';
-import { WiredGroupCreatePage } from './features/Groups/WiredGroupCreatePage';
-import { WiredGroupDetailPage } from './features/Groups/WiredGroupDetailPage';
-import { WiredAcceptInvitationPage } from './features/Groups/WiredAcceptInvitationPage';
-import { WiredSavedApplicationsPage } from './features/SavedApplications/WiredSavedApplicationsPage';
+import { ConnectedWatchZoneListPage } from './features/WatchZones/ConnectedWatchZoneListPage';
+import { ConnectedWatchZoneCreatePage } from './features/WatchZones/ConnectedWatchZoneCreatePage';
+import { ConnectedWatchZoneEditPage } from './features/WatchZones/ConnectedWatchZoneEditPage';
+import { ConnectedGroupsListPage } from './features/Groups/ConnectedGroupsListPage';
+import { ConnectedGroupCreatePage } from './features/Groups/ConnectedGroupCreatePage';
+import { ConnectedGroupDetailPage } from './features/Groups/ConnectedGroupDetailPage';
+import { ConnectedAcceptInvitationPage } from './features/Groups/ConnectedAcceptInvitationPage';
+import { ConnectedSavedApplicationsPage } from './features/SavedApplications/ConnectedSavedApplicationsPage';
 import { ConnectedMapPage } from './features/Map/ConnectedMapPage';
 
 export function AppRoutes() {
@@ -38,18 +38,18 @@ export function AppRoutes() {
             <Route path="/dashboard" element={<ConnectedDashboardPage />} />
             <Route path="/applications" element={<ConnectedApplicationsPage />} />
             <Route path="/applications/:uid" element={<ConnectedApplicationDetailPage />} />
-            <Route path="/watch-zones" element={<WiredWatchZoneListPage />} />
-            <Route path="/watch-zones/new" element={<WiredWatchZoneCreatePage />} />
-            <Route path="/watch-zones/:zoneId" element={<WiredWatchZoneEditPage />} />
+            <Route path="/watch-zones" element={<ConnectedWatchZoneListPage />} />
+            <Route path="/watch-zones/new" element={<ConnectedWatchZoneCreatePage />} />
+            <Route path="/watch-zones/:zoneId" element={<ConnectedWatchZoneEditPage />} />
             <Route path="/map" element={<ConnectedMapPage />} />
             <Route path="/search" element={<ConnectedSearchPage />} />
-            <Route path="/saved" element={<WiredSavedApplicationsPage />} />
-            <Route path="/groups" element={<WiredGroupsListPage />} />
-            <Route path="/groups/new" element={<WiredGroupCreatePage />} />
-            <Route path="/groups/:groupId" element={<WiredGroupDetailPage />} />
-            <Route path="/invitations/:invitationId/accept" element={<WiredAcceptInvitationPage />} />
-            <Route path="/notifications" element={<WiredNotificationsPage />} />
-            <Route path="/settings" element={<WiredSettingsPage />} />
+            <Route path="/saved" element={<ConnectedSavedApplicationsPage />} />
+            <Route path="/groups" element={<ConnectedGroupsListPage />} />
+            <Route path="/groups/new" element={<ConnectedGroupCreatePage />} />
+            <Route path="/groups/:groupId" element={<ConnectedGroupDetailPage />} />
+            <Route path="/invitations/:invitationId/accept" element={<ConnectedAcceptInvitationPage />} />
+            <Route path="/notifications" element={<ConnectedNotificationsPage />} />
+            <Route path="/settings" element={<ConnectedSettingsPage />} />
           </Route>
         </Route>
       </Route>

--- a/web/src/__tests__/naming-conventions.test.ts
+++ b/web/src/__tests__/naming-conventions.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, statSync } from 'fs';
+import { join, basename } from 'path';
+
+/**
+ * Convention test: all DI wrapper files (those that inject dependencies
+ * into presentation components via useMemo + context hooks) must use
+ * the "Connected" prefix, not "Wired".
+ *
+ * This enforces a single naming convention across the codebase.
+ */
+describe('DI wrapper naming convention', () => {
+  const featuresDir = join(__dirname, '..', 'features');
+
+  function findWiredFiles(dir: string): string[] {
+    const results: string[] = [];
+    const entries = readdirSync(dir);
+
+    for (const entry of entries) {
+      const fullPath = join(dir, entry);
+      const stat = statSync(fullPath);
+
+      if (stat.isDirectory()) {
+        results.push(...findWiredFiles(fullPath));
+      } else if (basename(entry).startsWith('Wired') && entry.endsWith('.tsx')) {
+        results.push(fullPath);
+      }
+    }
+
+    return results;
+  }
+
+  it('has no files using the Wired prefix — all DI wrappers use Connected', () => {
+    const wiredFiles = findWiredFiles(featuresDir);
+
+    expect(wiredFiles).toEqual([]);
+  });
+
+  it('has Connected wrapper files for all feature page wrappers', () => {
+    function findConnectedFiles(dir: string): string[] {
+      const results: string[] = [];
+      const entries = readdirSync(dir);
+
+      for (const entry of entries) {
+        const fullPath = join(dir, entry);
+        const stat = statSync(fullPath);
+
+        if (stat.isDirectory()) {
+          results.push(...findConnectedFiles(fullPath));
+        } else if (basename(entry).startsWith('Connected') && entry.endsWith('.tsx')) {
+          results.push(basename(entry));
+        }
+      }
+
+      return results;
+    }
+
+    const connectedFiles = findConnectedFiles(featuresDir).sort();
+
+    // All 16 DI wrapper files should use Connected prefix
+    expect(connectedFiles).toEqual([
+      'ConnectedAcceptInvitationPage.tsx',
+      'ConnectedApplicationDetailPage.tsx',
+      'ConnectedApplicationsPage.tsx',
+      'ConnectedDashboardPage.tsx',
+      'ConnectedGroupCreatePage.tsx',
+      'ConnectedGroupDetailPage.tsx',
+      'ConnectedGroupsListPage.tsx',
+      'ConnectedMapPage.tsx',
+      'ConnectedNotificationsPage.tsx',
+      'ConnectedOnboardingPage.tsx',
+      'ConnectedSavedApplicationsPage.tsx',
+      'ConnectedSearchPage.tsx',
+      'ConnectedSettingsPage.tsx',
+      'ConnectedWatchZoneCreatePage.tsx',
+      'ConnectedWatchZoneEditPage.tsx',
+      'ConnectedWatchZoneListPage.tsx',
+    ]);
+  });
+});

--- a/web/src/features/Groups/ConnectedAcceptInvitationPage.tsx
+++ b/web/src/features/Groups/ConnectedAcceptInvitationPage.tsx
@@ -5,7 +5,7 @@ import { asInvitationId } from '../../domain/types';
 import { ApiGroupsRepository } from './ApiGroupsRepository';
 import { AcceptInvitationPage } from './AcceptInvitationPage';
 
-export function WiredAcceptInvitationPage() {
+export function ConnectedAcceptInvitationPage() {
   const client = useApiClient();
   const { invitationId } = useParams<{ invitationId: string }>();
 

--- a/web/src/features/Groups/ConnectedGroupCreatePage.tsx
+++ b/web/src/features/Groups/ConnectedGroupCreatePage.tsx
@@ -7,7 +7,7 @@ import type { AuthoritySearchPort } from '../../domain/ports/authority-search-po
 import { ApiGroupsRepository } from './ApiGroupsRepository';
 import { GroupCreatePage } from './GroupCreatePage';
 
-export function WiredGroupCreatePage() {
+export function ConnectedGroupCreatePage() {
   const client = useApiClient();
 
   const repository = useMemo(() => new ApiGroupsRepository(client), [client]);

--- a/web/src/features/Groups/ConnectedGroupDetailPage.tsx
+++ b/web/src/features/Groups/ConnectedGroupDetailPage.tsx
@@ -6,7 +6,7 @@ import { asGroupId } from '../../domain/types';
 import { ApiGroupsRepository } from './ApiGroupsRepository';
 import { GroupDetailPage } from './GroupDetailPage';
 
-export function WiredGroupDetailPage() {
+export function ConnectedGroupDetailPage() {
   const client = useApiClient();
   const { groupId } = useParams<{ groupId: string }>();
   const { user } = useAuth0();

--- a/web/src/features/Groups/ConnectedGroupsListPage.tsx
+++ b/web/src/features/Groups/ConnectedGroupsListPage.tsx
@@ -4,7 +4,7 @@ import { useApiClient } from '../../api/useApiClient';
 import { ApiGroupsRepository } from './ApiGroupsRepository';
 import { GroupsListPage } from './GroupsListPage';
 
-export function WiredGroupsListPage() {
+export function ConnectedGroupsListPage() {
   const client = useApiClient();
   const navigate = useNavigate();
   const repository = useMemo(() => new ApiGroupsRepository(client), [client]);

--- a/web/src/features/Notifications/ConnectedNotificationsPage.tsx
+++ b/web/src/features/Notifications/ConnectedNotificationsPage.tsx
@@ -3,7 +3,7 @@ import { useApiClient } from '../../api/useApiClient';
 import { ApiNotificationRepository } from './ApiNotificationRepository';
 import { NotificationsPage } from './NotificationsPage';
 
-export function WiredNotificationsPage() {
+export function ConnectedNotificationsPage() {
   const client = useApiClient();
   const repository = useMemo(() => new ApiNotificationRepository(client), [client]);
 

--- a/web/src/features/SavedApplications/ConnectedSavedApplicationsPage.tsx
+++ b/web/src/features/SavedApplications/ConnectedSavedApplicationsPage.tsx
@@ -3,7 +3,7 @@ import { useApiClient } from '../../api/useApiClient';
 import { ApiSavedApplicationRepository } from './ApiSavedApplicationRepository';
 import { SavedApplicationsPage } from './SavedApplicationsPage';
 
-export function WiredSavedApplicationsPage() {
+export function ConnectedSavedApplicationsPage() {
   const client = useApiClient();
   const repository = useMemo(() => new ApiSavedApplicationRepository(client), [client]);
 

--- a/web/src/features/Settings/ConnectedSettingsPage.tsx
+++ b/web/src/features/Settings/ConnectedSettingsPage.tsx
@@ -6,7 +6,7 @@ import { SettingsPage } from './SettingsPage';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string || 'http://localhost:5000';
 
-export function WiredSettingsPage() {
+export function ConnectedSettingsPage() {
   const client = useApiClient();
   const { getAccessTokenSilently } = useAuth0();
   const repository = useMemo(

--- a/web/src/features/WatchZones/ConnectedWatchZoneCreatePage.tsx
+++ b/web/src/features/WatchZones/ConnectedWatchZoneCreatePage.tsx
@@ -6,7 +6,7 @@ import { ApiWatchZoneRepository } from './ApiWatchZoneRepository';
 import type { GeocodingPort } from '../../domain/ports/geocoding-port';
 import { WatchZoneCreatePage } from './WatchZoneCreatePage';
 
-export function WiredWatchZoneCreatePage() {
+export function ConnectedWatchZoneCreatePage() {
   const client = useApiClient();
   const navigate = useNavigate();
   const repository = useMemo(() => new ApiWatchZoneRepository(client), [client]);

--- a/web/src/features/WatchZones/ConnectedWatchZoneEditPage.tsx
+++ b/web/src/features/WatchZones/ConnectedWatchZoneEditPage.tsx
@@ -5,7 +5,7 @@ import { ApiWatchZoneRepository } from './ApiWatchZoneRepository';
 import { useWatchZones } from './useWatchZones';
 import { WatchZoneEditPage } from './WatchZoneEditPage';
 
-export function WiredWatchZoneEditPage() {
+export function ConnectedWatchZoneEditPage() {
   const { zoneId } = useParams<{ zoneId: string }>();
   const client = useApiClient();
   const repository = useMemo(() => new ApiWatchZoneRepository(client), [client]);

--- a/web/src/features/WatchZones/ConnectedWatchZoneListPage.tsx
+++ b/web/src/features/WatchZones/ConnectedWatchZoneListPage.tsx
@@ -3,7 +3,7 @@ import { useApiClient } from '../../api/useApiClient';
 import { ApiWatchZoneRepository } from './ApiWatchZoneRepository';
 import { WatchZoneListPage } from './WatchZoneListPage';
 
-export function WiredWatchZoneListPage() {
+export function ConnectedWatchZoneListPage() {
   const client = useApiClient();
   const repository = useMemo(() => new ApiWatchZoneRepository(client), [client]);
 


### PR DESCRIPTION
## Summary

Implements `tc-0xr`: Standardise Wired/Connected page wrapper naming

Renames 10 Wired*-prefixed DI wrapper files to Connected* prefix, aligning with React convention and the 6 existing Connected* files. Adds convention enforcement test. Pure rename refactor.

## Bead

`tc-0xr` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal component naming conventions for consistency across page components.

* **Tests**
  * Added automated test to enforce naming convention standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->