### PR TITLE
refactor(ios): migrate onboarding buttons to PrimaryButton

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ForceUpdate/ForceUpdateView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ForceUpdate/ForceUpdateView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// Blocking full-screen modal shown when the app version is below
 /// the server-defined minimum. Cannot be dismissed by the user.
 public struct ForceUpdateView: View {
+    @Environment(\.openURL) private var openURL
+
     private let appStoreURL: URL?
 
     public init(appStoreURL: URL? = nil) {
@@ -27,16 +29,9 @@ public struct ForceUpdateView: View {
                 .multilineTextAlignment(.center)
 
             if let appStoreURL {
-                Link(destination: appStoreURL) {
-                    Text("Update Now")
-                        .font(TCTypography.bodyEmphasis)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 44)
+                PrimaryButton("Update Now") {
+                    openURL(appStoreURL)
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(Color.tcAmber)
-                .foregroundStyle(Color.tcTextOnAccent)
-                .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
             }
 
             Spacer()

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/NotificationPermissionStepView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/NotificationPermissionStepView.swift
@@ -19,18 +19,9 @@ struct NotificationPermissionStepView: View {
                 .foregroundStyle(Color.tcTextSecondary)
                 .multilineTextAlignment(.center)
 
-            Button {
+            PrimaryButton("Enable Notifications") {
                 Task { await viewModel.requestNotificationPermission() }
-            } label: {
-                Text("Enable Notifications")
-                    .font(TCTypography.bodyEmphasis)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 44)
             }
-            .buttonStyle(.borderedProminent)
-            .tint(Color.tcAmber)
-            .foregroundStyle(Color.tcTextOnAccent)
-            .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
 
             Button {
                 Task { await viewModel.skipNotifications() }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/PostcodeEntryStepView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/PostcodeEntryStepView.swift
@@ -28,24 +28,15 @@ struct PostcodeEntryStepView: View {
                     .foregroundStyle(Color.tcStatusRefused)
             }
 
-            Button {
+            PrimaryButton {
                 Task { await viewModel.submitPostcode() }
             } label: {
                 if viewModel.isLoading {
                     ProgressView()
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 44)
                 } else {
                     Text("Continue")
-                        .font(TCTypography.bodyEmphasis)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 44)
                 }
             }
-            .buttonStyle(.borderedProminent)
-            .tint(Color.tcAmber)
-            .foregroundStyle(Color.tcTextOnAccent)
-            .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
             .disabled(viewModel.postcodeInput.isEmpty || viewModel.isLoading)
 
             Button("Back") {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/RadiusPickerStepView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/RadiusPickerStepView.swift
@@ -48,18 +48,9 @@ struct RadiusPickerStepView: View {
                 }
             }
 
-            Button {
+            PrimaryButton("Continue") {
                 viewModel.confirmRadius()
-            } label: {
-                Text("Continue")
-                    .font(TCTypography.bodyEmphasis)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 44)
             }
-            .buttonStyle(.borderedProminent)
-            .tint(Color.tcAmber)
-            .foregroundStyle(Color.tcTextOnAccent)
-            .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
 
             Button("Back") {
                 viewModel.goBack()

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/WelcomeStepView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/WelcomeStepView.swift
@@ -20,16 +20,7 @@ struct WelcomeStepView: View {
                 .foregroundStyle(Color.tcTextSecondary)
                 .multilineTextAlignment(.center)
 
-            Button(action: onContinue) {
-                Text("Get Started")
-                    .font(TCTypography.bodyEmphasis)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 44)
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(Color.tcAmber)
-            .foregroundStyle(Color.tcTextOnAccent)
-            .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+            PrimaryButton("Get Started", action: onContinue)
         }
         .padding(TCSpacing.extraLarge)
     }

--- a/mobile/ios/town-crier-tests/Sources/Features/PrimaryButtonTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/PrimaryButtonTests.swift
@@ -37,4 +37,37 @@ struct PrimaryButtonTests {
         _ = sut.body
         // Should compile and render without crashing.
     }
+
+    // MARK: - Conditional label content
+
+    @Test func init_withConditionalLabel_rendersBodyWhenNotLoading() {
+        let isLoading = false
+        let sut = PrimaryButton {
+            // action
+        } label: {
+            if isLoading {
+                ProgressView()
+            } else {
+                Text("Continue")
+            }
+        }
+        _ = sut.body
+        // PrimaryButton must support conditional @ViewBuilder labels
+        // for onboarding views that show a ProgressView during loading.
+    }
+
+    @Test func init_withConditionalLabel_rendersBodyWhenLoading() {
+        let isLoading = true
+        let sut = PrimaryButton {
+            // action
+        } label: {
+            if isLoading {
+                ProgressView()
+            } else {
+                Text("Continue")
+            }
+        }
+        _ = sut.body
+        // Verify the ProgressView branch also renders.
+    }
 }


### PR DESCRIPTION
## Summary

Implements `tc-wng`: Migrate onboarding buttons to PrimaryButton

Replaces inline .borderedProminent + .tcAmber + .tcTextOnAccent styling in 5 views with PrimaryButton component. 2 new tests, -8 lines net.

## Bead

`tc-wng` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized button components across onboarding flows (welcome, postcode entry, radius selection, notifications) and force update screens for consistent styling throughout the app.

* **Tests**
  * Added test coverage for button components with conditional label rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->