### PR TITLE
refactor(ios): remove dead hasChecked from ForceUpdateViewModel

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ForceUpdate/ForceUpdateViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ForceUpdate/ForceUpdateViewModel.swift
@@ -7,7 +7,6 @@ import TownCrierDomain
 public final class ForceUpdateViewModel: ObservableObject {
     @Published public private(set) var requiresUpdate = false
     @Published public private(set) var isChecking = false
-    @Published public private(set) var hasChecked = false
 
     private let versionConfigService: VersionConfigService
     private let appVersionProvider: AppVersionProvider
@@ -24,7 +23,6 @@ public final class ForceUpdateViewModel: ObservableObject {
         isChecking = true
         defer {
             isChecking = false
-            hasChecked = true
         }
 
         guard let currentVersion = AppVersion(appVersionProvider.version) else {

--- a/mobile/ios/town-crier-tests/Sources/Features/ForceUpdateViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ForceUpdateViewModelTests.swift
@@ -119,14 +119,4 @@ struct ForceUpdateViewModelTests {
         // After completion, isChecking should be false
         #expect(!sut.isChecking)
     }
-
-    @Test func checkVersion_hasChecked_isTrueAfterCheck() async {
-        let (sut, _, _) = makeSUT()
-
-        #expect(!sut.hasChecked)
-
-        await sut.checkVersion()
-
-        #expect(sut.hasChecked)
-    }
 }


### PR DESCRIPTION
## Summary

Implements `tc-3nr`: Remove dead hasChecked property from ForceUpdateViewModel

Removes @Published hasChecked property (never read by any consumer), its assignment in checkVersion(), and the corresponding test.

## Bead

`tc-3nr` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined force update version checking by removing internal state tracking that was not essential to the feature's functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->