### PR TITLE
refactor(ios): remove dead hasChecked from ForceUpdateViewModel

### DIFF
--- a/.beads/dolt
+++ b/.beads/dolt
@@ -1,1 +1,0 @@
-/Users/christy/Dev/town-crier/.beads/dolt

--- a/.beads/dolt
+++ b/.beads/dolt
@@ -1,0 +1,1 @@
+/Users/christy/Dev/town-crier/.beads/dolt

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ForceUpdate/ForceUpdateViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ForceUpdate/ForceUpdateViewModel.swift
@@ -7,8 +7,6 @@ import TownCrierDomain
 public final class ForceUpdateViewModel: ObservableObject {
     @Published public private(set) var requiresUpdate = false
     @Published public private(set) var isChecking = false
-    @Published public private(set) var hasChecked = false
-
     private let versionConfigService: VersionConfigService
     private let appVersionProvider: AppVersionProvider
 
@@ -24,7 +22,6 @@ public final class ForceUpdateViewModel: ObservableObject {
         isChecking = true
         defer {
             isChecking = false
-            hasChecked = true
         }
 
         guard let currentVersion = AppVersion(appVersionProvider.version) else {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ForceUpdate/ForceUpdateViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ForceUpdate/ForceUpdateViewModel.swift
@@ -7,6 +7,7 @@ import TownCrierDomain
 public final class ForceUpdateViewModel: ObservableObject {
     @Published public private(set) var requiresUpdate = false
     @Published public private(set) var isChecking = false
+
     private let versionConfigService: VersionConfigService
     private let appVersionProvider: AppVersionProvider
 

--- a/mobile/ios/town-crier-tests/Sources/Features/ForceUpdateViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ForceUpdateViewModelTests.swift
@@ -120,13 +120,4 @@ struct ForceUpdateViewModelTests {
         #expect(!sut.isChecking)
     }
 
-    @Test func checkVersion_hasChecked_isTrueAfterCheck() async {
-        let (sut, _, _) = makeSUT()
-
-        #expect(!sut.hasChecked)
-
-        await sut.checkVersion()
-
-        #expect(sut.hasChecked)
-    }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/ForceUpdateViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ForceUpdateViewModelTests.swift
@@ -119,5 +119,4 @@ struct ForceUpdateViewModelTests {
         // After completion, isChecking should be false
         #expect(!sut.isChecking)
     }
-
 }


### PR DESCRIPTION
## Summary

Implements `tc-3nr`: Remove dead hasChecked property from ForceUpdateViewModel

Removes @Published hasChecked property (never read by any consumer), its assignment in checkVersion(), and the corresponding test. 400 tests pass.

## Bead

`tc-3nr` — see bead comments for TDD evidence.

---
Shipped by Town Crier autopilot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified force update state management by removing a redundant tracking flag. The app now relies on existing state indicators to manage version checking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->