### PR TITLE
ci: add workflow_dispatch trigger to cd-dev

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -16,6 +16,7 @@ name: CD Dev
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: cd-dev


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to CD Dev workflow so deployments can be re-run manually
- Needed now to redeploy the web frontend with newly-configured Auth0 and API environment variables

## Test plan
- [ ] PR gate passes
- [ ] After merge, CD Dev deploys web with correct `VITE_*` variables
- [ ] `https://dev.towncrierapp.uk` loads without blank white screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configuration to support manual triggering for the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->