### PR TITLE
fix(web): fix Auth0 infinite redirect loop on login

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,8 @@ export function App() {
         redirect_uri: `${window.location.origin}/callback`,
         audience: authConfig.audience,
       }}
+      useRefreshTokens
+      cacheLocation="localstorage"
     >
       <QueryClientProvider client={queryClient}>
         <Auth0AuthAdapter>

--- a/web/src/auth/CallbackPage.tsx
+++ b/web/src/auth/CallbackPage.tsx
@@ -1,5 +1,12 @@
 import { Navigate } from 'react-router-dom';
+import { useAuth } from './auth-context';
 
 export function CallbackPage() {
+  const { isLoading } = useAuth();
+
+  if (isLoading) {
+    return null;
+  }
+
   return <Navigate to="/dashboard" replace />;
 }

--- a/web/src/auth/__tests__/CallbackPage.test.tsx
+++ b/web/src/auth/__tests__/CallbackPage.test.tsx
@@ -1,18 +1,39 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { CallbackPage } from '../CallbackPage.tsx';
+import { AuthProvider } from '../auth-context.ts';
+import type { AuthPort } from '../../domain/ports/auth-port.ts';
 
-describe('CallbackPage', () => {
-  it('redirects to /dashboard', () => {
-    render(
+function renderWithAuth(authOverrides: Partial<AuthPort> = {}) {
+  const auth: AuthPort = {
+    isAuthenticated: false,
+    isLoading: false,
+    loginWithRedirect: vi.fn(),
+    ...authOverrides,
+  };
+
+  return render(
+    <AuthProvider value={auth}>
       <MemoryRouter initialEntries={['/callback']}>
         <Routes>
           <Route path="/callback" element={<CallbackPage />} />
           <Route path="/dashboard" element={<div>Dashboard</div>} />
         </Routes>
-      </MemoryRouter>,
-    );
+      </MemoryRouter>
+    </AuthProvider>,
+  );
+}
+
+describe('CallbackPage', () => {
+  it('redirects to /dashboard when auth is not loading', () => {
+    renderWithAuth({ isLoading: false });
 
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  });
+
+  it('renders nothing while auth is loading', () => {
+    const { container } = renderWithAuth({ isLoading: true });
+
+    expect(container.innerHTML).toBe('');
   });
 });


### PR DESCRIPTION
## Summary
- Add `useRefreshTokens` and `cacheLocation="localstorage"` to `Auth0Provider` so tokens survive page reloads without relying on third-party cookies (blocked by Safari, Brave, and most modern browsers)
- Make `CallbackPage` wait for Auth0 to finish processing the authorization callback before navigating to `/dashboard`

## Test plan
- [ ] Navigate to `https://dev.towncrierapp.uk/dashboard` — should redirect to Auth0 login
- [ ] Complete login — should land on `/dashboard` without looping
- [ ] Refresh the page — should stay authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication now persists across browser sessions so users remain signed in after closing and reopening the app.
  * Automatic token refresh keeps sessions active seamlessly without user intervention.

* **Bug Fixes**
  * Authentication callback page now avoids premature navigation while auth is loading, preventing flicker or incorrect redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->