### PR TITLE
Fix Auth0 redirect loop when callback fails

### DIFF
--- a/web/src/auth/Auth0AuthAdapter.tsx
+++ b/web/src/auth/Auth0AuthAdapter.tsx
@@ -9,15 +9,16 @@ interface Props {
 }
 
 export function Auth0AuthAdapter({ children }: Props) {
-  const { isAuthenticated, isLoading, loginWithRedirect } = useAuth0();
+  const { isAuthenticated, isLoading, loginWithRedirect, error } = useAuth0();
 
   const auth: AuthPort = useMemo(
     () => ({
       isAuthenticated,
       isLoading,
+      error,
       loginWithRedirect: () => loginWithRedirect(),
     }),
-    [isAuthenticated, isLoading, loginWithRedirect],
+    [isAuthenticated, isLoading, error, loginWithRedirect],
   );
 
   return (

--- a/web/src/auth/AuthGuard.tsx
+++ b/web/src/auth/AuthGuard.tsx
@@ -3,13 +3,13 @@ import { Outlet } from 'react-router-dom';
 import { useAuth } from './auth-context.ts';
 
 export function AuthGuard() {
-  const { isAuthenticated, isLoading, loginWithRedirect } = useAuth();
+  const { isAuthenticated, isLoading, error, loginWithRedirect } = useAuth();
 
   useEffect(() => {
-    if (!isLoading && !isAuthenticated) {
+    if (!isLoading && !isAuthenticated && !error) {
       void loginWithRedirect();
     }
-  }, [isLoading, isAuthenticated, loginWithRedirect]);
+  }, [isLoading, isAuthenticated, error, loginWithRedirect]);
 
   if (isLoading || !isAuthenticated) {
     return null;

--- a/web/src/auth/CallbackPage.tsx
+++ b/web/src/auth/CallbackPage.tsx
@@ -2,10 +2,14 @@ import { Navigate } from 'react-router-dom';
 import { useAuth } from './auth-context';
 
 export function CallbackPage() {
-  const { isLoading } = useAuth();
+  const { isLoading, isAuthenticated, error } = useAuth();
 
   if (isLoading) {
     return null;
+  }
+
+  if (error || !isAuthenticated) {
+    return <Navigate to="/" replace />;
   }
 
   return <Navigate to="/dashboard" replace />;

--- a/web/src/auth/__tests__/AuthGuard.test.tsx
+++ b/web/src/auth/__tests__/AuthGuard.test.tsx
@@ -50,4 +50,15 @@ describe('AuthGuard', () => {
     });
     expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
   });
+
+  it('does not call loginWithRedirect when there is an auth error', () => {
+    const spy = new SpyAuthPort();
+    spy.isAuthenticated = false;
+    spy.isLoading = false;
+    spy.error = new Error('callback_failed');
+
+    renderWithAuth(spy);
+
+    expect(spy.loginWithRedirectCalls).toBe(0);
+  });
 });

--- a/web/src/auth/__tests__/CallbackPage.test.tsx
+++ b/web/src/auth/__tests__/CallbackPage.test.tsx
@@ -8,6 +8,7 @@ function renderWithAuth(authOverrides: Partial<AuthPort> = {}) {
   const auth: AuthPort = {
     isAuthenticated: false,
     isLoading: false,
+    error: undefined,
     loginWithRedirect: vi.fn(),
     ...authOverrides,
   };
@@ -18,6 +19,7 @@ function renderWithAuth(authOverrides: Partial<AuthPort> = {}) {
         <Routes>
           <Route path="/callback" element={<CallbackPage />} />
           <Route path="/dashboard" element={<div>Dashboard</div>} />
+          <Route path="/" element={<div>Landing</div>} />
         </Routes>
       </MemoryRouter>
     </AuthProvider>,
@@ -25,8 +27,8 @@ function renderWithAuth(authOverrides: Partial<AuthPort> = {}) {
 }
 
 describe('CallbackPage', () => {
-  it('redirects to /dashboard when auth is not loading', () => {
-    renderWithAuth({ isLoading: false });
+  it('redirects to /dashboard when authenticated', () => {
+    renderWithAuth({ isAuthenticated: true, isLoading: false });
 
     expect(screen.getByText('Dashboard')).toBeInTheDocument();
   });
@@ -35,5 +37,21 @@ describe('CallbackPage', () => {
     const { container } = renderWithAuth({ isLoading: true });
 
     expect(container.innerHTML).toBe('');
+  });
+
+  it('redirects to landing page when not authenticated', () => {
+    renderWithAuth({ isAuthenticated: false, isLoading: false });
+
+    expect(screen.getByText('Landing')).toBeInTheDocument();
+  });
+
+  it('redirects to landing page on auth error', () => {
+    renderWithAuth({
+      isAuthenticated: false,
+      isLoading: false,
+      error: new Error('callback_failed'),
+    });
+
+    expect(screen.getByText('Landing')).toBeInTheDocument();
   });
 });

--- a/web/src/auth/__tests__/spies/spy-auth-port.ts
+++ b/web/src/auth/__tests__/spies/spy-auth-port.ts
@@ -3,6 +3,7 @@ import type { AuthPort } from '../../../domain/ports/auth-port.ts';
 export class SpyAuthPort implements AuthPort {
   isAuthenticated = false;
   isLoading = false;
+  error: Error | undefined = undefined;
   loginWithRedirectCalls = 0;
 
   loginWithRedirect = async (): Promise<void> => {

--- a/web/src/domain/ports/auth-port.ts
+++ b/web/src/domain/ports/auth-port.ts
@@ -1,5 +1,6 @@
 export interface AuthPort {
   readonly isAuthenticated: boolean;
   readonly isLoading: boolean;
+  readonly error: Error | undefined;
   loginWithRedirect(): Promise<void>;
 }


### PR DESCRIPTION
## Summary
- Added `error` field to `AuthPort` interface and wired it through `Auth0AuthAdapter`
- `CallbackPage` now checks `isAuthenticated` before redirecting — on failure, redirects to `/` instead of `/dashboard`, breaking the loop
- `AuthGuard` skips `loginWithRedirect()` when an auth error is present, preventing re-triggering

## Root cause
The previous fix (#86) added an `isLoading` guard but didn't check whether authentication actually succeeded. If the Auth0 token exchange failed (audience mismatch, CORS, config error), `isLoading` would become `false` with `isAuthenticated` still `false`, and `CallbackPage` would redirect to `/dashboard` — where `AuthGuard` would call `loginWithRedirect()` again, creating an infinite loop.

## Test plan
- [x] All 413 web tests pass (3 new)
- [x] TypeScript compiles clean
- [ ] Manual: trigger Auth0 login from `/dashboard` and verify redirect completes without looping
- [ ] Manual: verify failed auth (e.g. wrong audience) redirects to landing page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication system now tracks and propagates error states throughout the auth flow.
  * Error states prevent automatic redirects when authentication issues occur.
  * Improved callback page handling for authentication errors, redirecting users appropriately.

* **Tests**
  * Expanded test coverage to validate authentication error handling and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->