### PR TITLE
ci: add CODEOWNERS and auto-merge workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default code owners — any 2 approvals satisfy the required-reviews gate.
+# GitHub resolves these as: human (AmyDe), Copilot, CodeRabbit.
+* @AmyDe @copilot @coderabbitai

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,22 @@
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Enable auto-merge (squash)
+        run: gh pr merge "$PR" --auto --squash --repo "$REPO"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` assigning `@AmyDe`, `@copilot`, and `@coderabbitai` as owners of all files
- Adds auto-merge workflow that enables squash-merge on every new/ready PR
- Branch protection on `main` updated to require 2 code owner approvals + `PR Gate` status check

## Test plan
- [ ] Verify CODEOWNERS triggers review requests from Copilot and CodeRabbit on this PR
- [ ] Verify auto-merge workflow runs and enables auto-merge on this PR
- [ ] Confirm PR auto-merges once 2 approvals + PR Gate pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated pull request merge workflow.
  * Established code ownership configuration for repository management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->