### PR TITLE
fix(infra): add CORS origin env var for dev frontend

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -266,6 +266,7 @@ public static class EnvironmentStack
                             new EnvironmentVarArgs { Name = "Auth0__Audience", Value = auth0Audience },
                             new EnvironmentVarArgs { Name = "Cosmos__AccountEndpoint", Value = cosmosAccountEndpoint },
                             new EnvironmentVarArgs { Name = "AZURE_CLIENT_ID", Value = cosmosDataIdentityClientId },
+                            new EnvironmentVarArgs { Name = "Cors__AllowedOrigins__0", Value = $"https://{frontendDomain}" },
                         },
                     },
                 },


### PR DESCRIPTION
## Summary
- The dev API (`api-dev.towncrierapp.uk`) was rejecting browser requests from `dev.towncrierapp.uk` — the CORS allowed origins only included the production domain (`towncrierapp.uk`)
- OPTIONS preflight returned 204 with **no CORS headers**, causing the browser to block `GET /v1/me` (`TypeError: Failed to fetch`)
- Adds `Cors__AllowedOrigins__0` environment variable to the Container App, derived from the per-environment `frontendDomain` Pulumi config — each environment now allows its own frontend origin

## Test plan
- [ ] `cd infra && dotnet build` passes (verified locally)
- [ ] After merge, `cd-dev.yml` runs `pulumi up --stack dev` which updates the Container App env vars
- [ ] Verify `curl -sv -X OPTIONS https://api-dev.towncrierapp.uk/v1/me -H "Origin: https://dev.towncrierapp.uk"` returns `Access-Control-Allow-Origin: https://dev.towncrierapp.uk`
- [ ] Verify `fetchProfile` succeeds on `dev.towncrierapp.uk/dashboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured API settings to enable frontend and backend communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->