### PR TITLE
Improve autopilot and ship skills

### DIFF
--- a/.claude/skills/autopilot/SKILL.md
+++ b/.claude/skills/autopilot/SKILL.md
@@ -1,25 +1,64 @@
 ---
 name: autopilot
-description: "Autonomous single-bead worker loop. Picks one ready bead, dispatches the right engineer agent (dotnet-tdd-worker, ios-tdd-worker, react-tdd-worker, pulumi-infra-worker, github-actions-worker) in an isolated worktree, validates TDD evidence, creates a PR, watches CodeRabbit and CI gates, and either merges on green or updates the bead with failure context for retry. Designed for `/loop` — invoke every few minutes to continuously ship beads without supervision. Trigger on: 'autopilot', 'auto-work', 'work the backlog', 'pick up a bead', 'start the loop', 'ship beads automatically', or any request for autonomous bead processing from the ready queue."
+description: "Autonomous single-bead worker loop. Picks a ready bead, dispatches the right engineer agent in an isolated worktree, validates TDD evidence, and merges the result. Designed for `/loop` — invoke every few minutes to continuously ship beads without supervision. Trigger on: 'autopilot', 'auto-work', 'work the backlog', 'pick up a bead', 'start the loop', 'ship beads automatically', or any request for autonomous bead processing from the ready queue."
 ---
 
 # Autopilot
 
-You are the **Town Crier's autopilot** — an autonomous loop that picks one ready bead, ships it through a complete PR lifecycle, and returns. Designed for `/loop` — each invocation handles exactly one bead, then exits so the loop can fire again.
+You are the **Town Crier's autopilot** — an autonomous loop that picks one ready bead, ships it via a worker agent, and merges the result into a session branch. Designed for `/loop` — each invocation handles exactly one bead, then exits so the loop can fire again.
 
 ## Each Invocation
 
 ```
-Find work → Dispatch worker → Validate evidence → Create PR → Watch gates → Merge or follow up → Return
+Ensure session branch → Find work → Dispatch worker → Validate evidence → Merge to session branch → Return
 ```
 
 If no beads are ready, return immediately. The loop retries later.
 
-## Phase 1: Find Work
+## Phase 0: Ensure Session Branch
 
-Prune stale worktrees from prior runs:
+The autopilot always works on a branch — never directly on main. All worker output accumulates on a single session branch. The user creates a PR and merges manually the next morning.
+
+### If on `main`
+
+Create or resume a session branch:
 
 ```bash
+git pull --rebase
+if git show-ref --verify --quiet refs/heads/autopilot/<date>; then
+  git checkout autopilot/<date>
+  git pull --rebase origin main
+else
+  git checkout -b autopilot/<date>    # e.g. autopilot/2026-03-29
+fi
+```
+
+### If already on a branch
+
+Verify it's an `autopilot/` branch. If so, continue using it. If it's some other branch, **do not switch** — report `Autopilot: on unexpected branch <name> — expected main or autopilot/*. Returning.` and exit.
+
+### Push the branch
+
+Ensure the branch is tracked on the remote:
+
+```bash
+git push -u origin HEAD
+```
+
+## Phase 1: Find Work
+
+Clean up orphaned worktrees from prior runs. Log each removal so the user can see what was cleaned:
+
+```bash
+for wt in $(git worktree list --porcelain | grep '^worktree ' | awk '{print $2}' | grep '\.claude/worktrees/'); do
+  uncommitted=$(git -C "$wt" status --short 2>/dev/null)
+  if [ -n "$uncommitted" ]; then
+    echo "Autopilot: warning — orphaned worktree $wt has uncommitted changes:"
+    echo "$uncommitted"
+  fi
+  echo "Autopilot: removing orphaned worktree $wt"
+  git worktree remove --force "$wt" 2>/dev/null
+done
 git worktree prune
 ```
 
@@ -27,24 +66,17 @@ Invoke `/beads:ready` to find beads with no blockers.
 
 **No beads ready?** Report `Autopilot: no ready beads — idle` and return.
 
-**Beads available?** Walk the list from highest priority to lowest, selecting the first bead that passes all filters below. For each candidate, invoke `/beads:show <bead-id>` and apply these filters in order:
+**Beads available?** Walk the list from highest priority to lowest, selecting the first bead that passes all filters below. For each candidate, invoke `/beads:show <bead-id>` and apply these filters in order.
+
+> **Note:** Candidates are evaluated one at a time because each requires a `/beads:show` call. If many beads are filtered out (epics, unclassifiable), this adds up. Keep bead hygiene tight to minimize wasted cycles.
 
 ### Filter: Skip Epics
 
 If the bead's type is `epic`, skip it — epics are containers, not implementable units. Continue to the next candidate.
 
-### Filter: Retry Guard
-
-If the bead's notes already contain **two or more** `Autopilot:` failure entries (from prior failed PR attempts), this bead has been tried and failed repeatedly. Do **not** retry it — instead:
-
-1. Invoke `/beads:update <bead-id> --notes="Autopilot: flagged for human review after repeated failures"`.
-2. Skip to the next candidate.
-
-This prevents infinite retry loops. A human needs to look at it.
-
 ### Filter: Classify Worker Type
 
-Determine the worker type from the bead's description and any labels:
+Determine the worker type from the bead's description, labels, and any paths mentioned:
 
 | Signals | Worker |
 |---------|--------|
@@ -54,23 +86,31 @@ Determine the worker type from the bead's description and any labels:
 | Pulumi, infrastructure, IaC, Azure, Container Apps, resource group, `infra` paths | `pulumi-infra-worker` |
 | CI/CD, pipeline, GitHub Actions, workflow, deployment, `.github/workflows` paths | `github-actions-worker` |
 
-Read the description carefully. If the bead cannot be mapped to any worker (e.g., manual tasks like App Store setup, or genuinely ambiguous), skip it and continue to the next candidate. Do not guess.
+If the bead cannot be mapped to any worker (e.g., manual tasks, genuinely ambiguous), **mark it blocked**:
+
+```
+/beads:update <bead-id> --status=blocked --append-notes="Autopilot: cannot classify worker type. <date>. Needs human triage."
+```
+
+Continue to the next candidate.
 
 ### No Candidate Found
 
-If every ready bead was filtered out, report `Autopilot: no dispatchable beads — <N> ready but all filtered (epics, retry-limited, or unclassifiable)` and return.
+If no workable candidate was found, report `Autopilot: no dispatchable beads — idle` and return.
 
-## Phase 2: Dispatch
+### Claim Immediately
 
-You now have a selected bead and its worker type from the filters above.
-
-Mark the bead in-progress:
+Once a candidate passes all filters, mark it in-progress **before** anything else — this prevents a concurrent `/loop` invocation from selecting the same bead:
 
 ```
 /beads:update <bead-id> --status=in_progress
 ```
 
-Determine the worker's allowed path scope:
+## Phase 2: Dispatch
+
+You now have a claimed bead and its worker type.
+
+Determine the worker's allowed path scope (this table is the single source of truth — also used in Check 4 during validation):
 
 | Worker | Allowed Path |
 |--------|-------------|
@@ -80,7 +120,7 @@ Determine the worker's allowed path scope:
 | `pulumi-infra-worker` | `infra/` |
 | `github-actions-worker` | `.github/workflows/`, `.github/actions/` |
 
-Dispatch the worker with the critical requirements reinforced in the prompt:
+Dispatch the worker:
 
 ```
 Agent({
@@ -99,172 +139,81 @@ You are notified automatically when the worker completes — do not poll.
 
 ## Phase 3: Validate Evidence
 
-The Agent result includes the **worktree path and branch name** if the worker made changes.
+The Agent result includes the **worktree path and branch name** if the worker made changes. **Store both** — you need them for merge and cleanup.
 
-**No changes reported?** The worker failed silently. Jump to [Failure Recovery](#failure-recovery).
+**No changes reported?** The worker failed silently. Jump to [Failure](#failure).
 
 ### Audit Checklist
 
-Run every check below. If **any** check fails, jump to [Failure Recovery](#failure-recovery) with a specific description of what was missing.
+Run every check below. If **any** check fails, jump to [Failure](#failure) with a specific description of what was missing.
 
 #### Check 1: Commits Exist
 
 ```bash
-git log main..<branch-name> --oneline
+git log main..<worker-branch> --oneline
 ```
 
 If no commits, fail with: "no commits on branch."
 
 #### Check 2: Evidence Comments Exist
 
-Invoke `/beads:show <bead-id>` and read the comments. Count the evidence comments recorded by the worker.
+Invoke `/beads:show <bead-id>` and read the comments.
 
 **For TDD workers (dotnet, ios, react):**
 - Count comments containing `— Red` (failing test output)
 - Count comments containing `— Green` (passing test output)
-- There must be **at least one Red comment and at least one Green comment** — a single summary with no per-cycle evidence is not sufficient
-- There must be a **summary comment** containing `## TDD Summary` with final test output
+- There must be **at least one Red comment and at least one Green comment**
+- There must be a **summary comment** containing `## TDD Summary`
 
-If Red comments = 0, fail with: "no Red phase evidence found — worker may not have followed TDD."
-If Green comments = 0, fail with: "no Green phase evidence found."
-If summary is missing, fail with: "no TDD Summary comment found."
+If Red = 0, fail: "no Red phase evidence."
+If Green = 0, fail: "no Green phase evidence."
+If summary missing, fail: "no TDD Summary comment."
 
 **For infra worker:**
-- There must be at least one comment containing `## Infrastructure Change`
-- There must be a summary comment containing `## Infrastructure Summary`
+- At least one comment containing `## Infrastructure Change`
+- A summary comment containing `## Infrastructure Summary`
 
 **For CI/CD worker:**
-- There must be at least one comment containing `## Pipeline Change`
-- There must be a summary comment containing `## Pipeline Summary`
+- At least one comment containing `## Pipeline Change`
+- A summary comment containing `## Pipeline Summary`
 
 #### Check 3: Commit Count Plausibility
 
-For TDD workers, count commits on the branch and count Red-Green pairs in comments:
+For TDD workers:
 
 ```bash
-git log main..<branch-name> --oneline | wc -l
+git log main..<worker-branch> --oneline | wc -l
 ```
 
-There should be at least 2 commits (one Red, one Green). If there's only 1 commit, fail with: "only 1 commit found — TDD requires at least one Red and one Green commit."
+At least 2 commits required (one Red, one Green). If only 1, fail: "only 1 commit — TDD requires at least Red and Green."
 
 #### Check 4: Scope Verification
 
-Check that all changed files fall within the worker's allowed path boundary:
-
 ```bash
-git diff main..<branch-name> --name-only
+git diff main..<worker-branch> --name-only
 ```
 
-| Worker | Allowed Paths |
-|--------|--------------|
-| `dotnet-tdd-worker` | `api/` |
-| `ios-tdd-worker` | `mobile/ios/` |
-| `react-tdd-worker` | `web/` |
-| `pulumi-infra-worker` | `infra/` |
-| `github-actions-worker` | `.github/` |
-
-If any files fall outside the allowed paths, fail with: "files modified outside scope: `<list of offending files>`."
+All changed files must fall within the worker's allowed path (see the table in Phase 2 — that's the single source of truth). If any are outside, fail: "files modified outside scope: `<list>`."
 
 #### All Checks Pass
 
 Continue to Phase 4.
 
-## Phase 4: Create Pull Request
+## Phase 4: Merge to Session Branch
 
-Push the branch to the remote:
+The worker produced validated work on its worktree branch. Verify the branch is available, then merge:
 
 ```bash
-git push -u origin <branch-name>
+git branch --list <worker-branch>   # verify it exists in local refs
+git merge <worker-branch> --no-edit
 ```
 
-Get the repo owner/name for API calls:
+If the merge has conflicts, this is a failure — jump to [Failure](#failure) with: "merge conflict with session branch."
+
+Push the updated session branch:
 
 ```bash
-gh repo view --json nameWithOwner --jq '.nameWithOwner'
-```
-
-Create the PR:
-
-```bash
-gh pr create \
-  --head <branch-name> \
-  --base main \
-  --title "<bead title (keep under 70 chars)>" \
-  --body "$(cat <<'EOF'
-## Summary
-
-Implements `<bead-id>`: <bead title>
-
-<one-line description of what changed>
-
-## Bead
-
-`<bead-id>` — see bead comments for TDD evidence.
-
----
-Shipped by Town Crier autopilot
-EOF
-)"
-```
-
-Record the PR number from the output.
-
-## Phase 5: Watch Gates
-
-Wait for CI checks to complete:
-
-```bash
-gh pr checks <pr-number> --watch 2>&1
-```
-
-Capture the output and exit code. Notes:
-- If no checks are configured, `gh pr checks` returns immediately — that's fine, proceed.
-- Do **not** use `--fail-fast` — wait for all checks so you can report the full picture.
-- If the command hangs beyond 15 minutes, treat as a timeout failure.
-
-### CodeRabbit Review
-
-After CI checks resolve, fetch CodeRabbit's review:
-
-```bash
-gh api repos/<owner>/<repo>/pulls/<pr-number>/reviews \
-  --jq '.[] | select(.user.login == "coderabbitai") | .body' 2>/dev/null
-
-gh api repos/<owner>/<repo>/pulls/<pr-number>/comments \
-  --jq '.[] | select(.user.login == "coderabbitai") | .body' 2>/dev/null
-```
-
-If CodeRabbit hasn't reviewed yet (empty results), wait 30 seconds and retry once. If still no review, proceed without it — CodeRabbit may not be configured.
-
-### Classify Comments
-
-Read all CodeRabbit comments and classify each:
-
-**Nitpicks** (merge anyway):
-- Style or formatting preferences
-- Naming suggestions where both options are valid
-- Minor documentation wording
-- Comments CodeRabbit labels as "nitpick" or "suggestion"
-- "Consider using X" where both approaches are correct
-
-**Substantive** (block merge):
-- Bugs or logic errors
-- Security vulnerabilities
-- Missing error handling for real failure modes
-- Architectural violations
-- Missing test coverage for important paths
-- Performance issues with measurable impact
-
-When in doubt, treat as substantive. Better to retry than to merge a real problem.
-
-## Phase 6: Resolve
-
-### Path A: All Green — Merge
-
-All CI checks pass **and** no substantive CodeRabbit comments.
-
-```bash
-gh pr merge <pr-number> --squash --delete-branch
+git push
 ```
 
 Close the bead:
@@ -273,102 +222,73 @@ Close the bead:
 /beads:close <bead-id>
 ```
 
-Clean up and sync:
+Clean up the worktree:
 
 ```bash
-git pull --rebase
+git worktree remove --force <worktree-path>
 git worktree prune
 ```
 
-Sync beads to remote (no plugin skill for Dolt sync — use CLI):
+Sync beads:
 
 ```bash
 bd dolt push
 ```
 
-Report: `Autopilot: merged PR #<number> for <bead-id>: <title>`
+Build a session tally by counting commits on the session branch and blocked beads:
 
-### Path B: Gates Failed — Retry Later
-
-CI checks failed **or** substantive CodeRabbit comments found.
-
-**Step 1: Collect failure details**
-
-For CI failures:
 ```bash
-gh pr checks <pr-number> 2>&1
+merged_count=$(git log main..HEAD --oneline | wc -l | tr -d ' ')
+blocked_count=$(bd list --status=blocked 2>/dev/null | grep -c '^beads-' || echo 0)
+remaining=$(bd ready 2>/dev/null | grep -c '^beads-' || echo 0)
 ```
 
-For CodeRabbit: note the substantive comments from Phase 5.
+Report with the tally:
 
-**Step 2: Close the PR and clean up the branch**
+```
+Autopilot: merged <bead-id> — <title>
+Session: <merged_count> commits, <blocked_count> blocked | <remaining> beads remaining | branch: autopilot/<date>
+```
+
+If `remaining` is 0, add: `All beads closed. Run /ship to PR and merge the session branch.`
+
+## Failure
+
+Used when the worker fails, evidence validation fails, or merge fails. **One strike — mark blocked and move on.**
+
+1. Record what went wrong:
+
+```
+/beads:update <bead-id> --status=blocked --append-notes="Autopilot: failed <date>. Reason: <specific failure description>"
+```
+
+2. Clean up the worktree (if one exists):
 
 ```bash
-gh pr close <pr-number>
-git push origin --delete <branch-name>
+git worktree remove --force <worktree-path> 2>/dev/null
 git worktree prune
 ```
 
-**Step 3: Update the bead for retry**
-
-Add the failure context to the bead so the next worker attempt can address it:
-
-```
-/beads:update <bead-id> --status=open
-/beads:update <bead-id> --notes="Autopilot: PR #<number> failed. <date>
-
-CI failures:
-<failed check names and brief error descriptions>
-
-CodeRabbit issues:
-<substantive comments, quoted>
-
-The next implementation attempt should address these issues."
-```
-
-The bead is now `open` again with failure context in its notes. The next autopilot cycle will pick it up, and the worker will see the notes when it reads the bead via `/beads:show`.
-
-**Step 4: Sync beads** (no plugin skill for Dolt sync — use CLI)
+3. Sync beads:
 
 ```bash
 bd dolt push
 ```
 
-Report: `Autopilot: PR #<number> for <bead-id> failed — bead updated with failure context for retry`
+4. Report: `Autopilot: <bead-id> blocked — <reason>`
 
----
-
-## Failure Recovery
-
-Used when the worker fails before a PR is created (no evidence, no commits, silent failure).
-
-```
-/beads:update <bead-id> --status=open
-/beads:update <bead-id> --notes="Autopilot: worker failed to produce evidence. <date>. <brief description of what went wrong if known>"
-```
-
-```bash
-git worktree prune
-```
-
-Sync beads (no plugin skill for Dolt sync — use CLI):
-
-```bash
-bd dolt push
-```
-
-Report: `Autopilot: worker failed for <bead-id> — bead reset to open for retry`
+The bead will not appear in `bd ready` again. The user reviews blocked beads in the morning.
 
 ## Rules
 
 - **One bead per invocation.** Pick one, ship it, return. The loop handles repetition.
 - **Never write code.** Worker agents handle all implementation. You orchestrate.
-- **Never skip evidence validation.** No PR without verified test/build evidence on the bead.
-- **Always use PRs.** Never push directly to main. PRs provide gate enforcement and review.
-- **Respect CodeRabbit.** Only ignore comments that are genuinely nitpicks. When in doubt, treat as substantive and retry.
-- **Two-strike retry limit.** If a bead has failed twice already (two `Autopilot:` failure entries in notes), flag it for human review instead of retrying.
-- **Always `bd dolt push` after any bead state change.** No plugin skill for Dolt sync — use CLI directly. Sync immediately, not at session end.
-- **Always clean up.** Prune worktrees and delete remote branches after every cycle.
-- **Return fast when idle.** No beads = return immediately. Don't wait or poll.
-- **Fail safe.** Unexpected errors → reset bead to open → clean up → return. The next cycle retries.
+- **Never skip evidence validation.** No merge without verified evidence on the bead.
+- **Never commit to main.** All work goes to the session branch.
+- **One strike.** If a bead fails for any reason, mark it blocked immediately. No retries.
+- **Always use `--append-notes`** when adding failure context — never `--notes`, which overwrites.
+- **Always `bd dolt push` after any bead state change.**
+- **Always clean up.** Remove worktrees with `git worktree remove --force <path>` and prune.
+- **Return fast when idle.** No beads = return immediately.
+- **Fail safe.** Unexpected errors → mark bead blocked → clean up → return.
 - **Use `/beads:*` skills for all tracking.** No TodoWrite, no TaskCreate.

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Automate the push-to-main flow when you have local commits and/or unstaged changes on main. Creates a feature branch, opens a PR via `gh`, and waits for PR gate checks before merging. MUST use this skill whenever the user says "ship", "ship it", "push to main", "push my changes", "get this on main", "merge to main", "create a PR and merge", or any variation of wanting to get local work from main onto the remote. Also trigger when the user has been working on main and wants to push but can't due to branch protection. Do NOT use for: creating PRs without merging, pushing feature branches, or work that isn't on main.
+description: Automate the push-to-main flow when you have local commits and/or unstaged changes on main. Creates a feature branch, opens a PR via `gh`, enables auto-merge, then watches for Copilot and CodeRabbit approvals — addressing their feedback if needed. MUST use this skill whenever the user says "ship", "ship it", "push to main", "push my changes", "get this on main", "merge to main", "create a PR and merge", or any variation of wanting to get local work from main onto the remote. Also trigger when the user has been working on main and wants to push but can't due to branch protection. Do NOT use for: creating PRs without merging, pushing feature branches, or work that isn't on main.
 ---
 
 # Ship to Main
@@ -70,56 +70,98 @@ EOF
 
 **PR body:** List each commit as a bullet point under "## Changes".
 
-### Step 6: Default to wait mode
+### Step 6: Enable auto-merge and start watching
 
-**NEVER merge the PR immediately.** The PR gate checks and CodeRabbit review must complete first.
+The PR will auto-merge via branch protection once both **Copilot** and **CodeRabbit** approve. Enable auto-merge so it triggers the moment approvals land:
 
-**Default behavior:** Report the PR URL and proceed straight to Step 7 (wait for checks, then merge). Do not ask — just do it. The user expects to walk away after typing "ship it".
+```bash
+gh pr merge <pr-number> --squash --delete-branch --auto
+```
+
+**Default behavior:** Report the PR URL and proceed straight to Step 7 (watch for reviews). Do not ask — just do it. The user expects to walk away after typing "ship it".
 
 > PR created: <url>
 >
-> Waiting for checks and CodeRabbit review before merging...
+> Auto-merge enabled. Watching for Copilot and CodeRabbit reviews...
 
-**Exception:** If the user explicitly says "leave it open", "don't merge", or similar — report the PR URL and stop. Do not proceed further. Do not merge. Do not clean up branches. The skill ends here.
+**Exception:** If the user explicitly says "leave it open", "don't merge", or similar — report the PR URL and stop. Do not enable auto-merge. The skill ends here.
 
-### Step 7: Wait for checks and CodeRabbit review
+### Step 7: Watch for reviewer feedback
 
-First, wait for CI checks to pass:
+Poll for reviews from both Copilot and CodeRabbit. These are the two required reviewers — the PR cannot merge until both approve.
 
-```bash
-gh pr checks <pr-number> --watch --fail-fast
-```
-
-If checks fail, report which checks failed, provide the PR URL, and stop — do not retry or force-merge.
-
-Once checks pass, fetch the CodeRabbit review. CodeRabbit posts a review comment on the PR. Use the GitHub API to read it:
+**Poll loop** (repeat every 30 seconds, up to 10 minutes):
 
 ```bash
 gh api repos/{owner}/{repo}/pulls/<pr-number>/reviews
 gh api repos/{owner}/{repo}/pulls/<pr-number>/comments
 ```
 
-**If CodeRabbit has suggestions or comments:**
+Track the state of each reviewer:
 
-**Default behavior:** Create a bead tracking the suggestions, then proceed to merge. Do not ask — the user expects hands-off operation. Summarise what CodeRabbit flagged in the output so the user sees it when they return:
+| Reviewer | Identified by | Approval signal |
+|----------|--------------|-----------------|
+| Copilot | `user.login` is `"copilot-pull-request-reviewer[bot]"` or contains `"copilot"` | Review with `state: "APPROVED"` |
+| CodeRabbit | `user.login` is `"coderabbitai[bot]"` or contains `"coderabbit"` | Review with `state: "APPROVED"` |
 
-> CodeRabbit flagged the following (tracked in bead <id>):
-> - <brief summary of each suggestion>
->
-> Merging...
+**On each poll iteration:**
 
-**CRITICAL: NEVER fix CodeRabbit suggestions within this skill.** Do not edit code, do not push additional commits. This skill ships work — it does not do development.
+1. Fetch reviews and comments.
+2. Check if both reviewers have approved → if yes, proceed to Step 8 (the auto-merge will handle the actual merge).
+3. Check if either reviewer left non-approval feedback (comments, change requests, or suggestions). If so, enter the **feedback loop** below.
+4. If neither condition, continue polling.
 
-**If CodeRabbit has no suggestions (or approved without comments):**
+**Timeout:** If 10 minutes pass without both approvals and no feedback to act on, report the current state and the PR URL, then stop. The auto-merge will still trigger when approvals arrive — no work is lost.
 
-Proceed directly to Step 8.
+### Step 7a: Feedback loop — respond to reviewer comments
 
-### Step 8: Merge and clean up
+If Copilot or CodeRabbit leaves comments or requests changes instead of approving:
+
+1. **Read the feedback carefully.** Fetch full comment bodies:
+   ```bash
+   gh api repos/{owner}/{repo}/pulls/<pr-number>/comments
+   gh api repos/{owner}/{repo}/pulls/<pr-number>/reviews
+   ```
+
+2. **Assess each comment:**
+   - **Actionable code suggestion** (e.g., "add null check", "rename variable", "simplify this expression"): Fix it. These are small, mechanical changes — apply them directly.
+   - **Style/formatting nit:** Fix it.
+   - **Substantive design concern** (e.g., "this approach has a race condition", "consider a different pattern"): Create a bead to track it, do NOT fix it in this PR. Summarise it for the user.
+   - **Informational only / praise** (e.g., "LGTM with minor note", summary comments): No action needed.
+
+3. **For actionable fixes:** Make the change, commit with a message like `fix: address <reviewer> feedback — <brief description>`, and push:
+   ```bash
+   git add <files>
+   git commit -m "fix: address <reviewer> feedback — <brief description>"
+   git push
+   ```
+   This will re-trigger the reviewers. Return to the poll loop in Step 7.
+
+4. **For substantive concerns tracked as beads:** Report them:
+   > <Reviewer> flagged the following (tracked in bead <id>):
+   > - <brief summary of each concern>
+
+5. **Limit:** Make at most **3 rounds** of fixes per reviewer. If a reviewer still hasn't approved after 3 rounds of addressing their feedback, report the situation and the PR URL, then stop. The auto-merge remains enabled — the user can take over manually.
+
+### Step 8: Confirm merge and clean up
+
+Once both reviewers approve, auto-merge will squash-merge the PR. Wait for it:
 
 ```bash
-gh pr merge --squash --delete-branch
+# Confirm the PR merged (poll briefly if needed)
+gh pr view <pr-number> --json state -q '.state'
+```
+
+Once state is `"MERGED"`:
+
+```bash
 git checkout main
 git pull origin main
+```
+
+If the branch wasn't deleted automatically:
+```bash
+git branch -d <branch-name>
 ```
 
 ### Step 9: Sync beads and verify
@@ -141,4 +183,6 @@ Report success with the PR URL.
 - **Not on main:** Stop. Tell the user which branch they're on.
 - **Nothing to ship:** Tell the user. Don't create empty PRs.
 - **Checks failed:** Report which checks failed and the PR URL. Do not retry or force-merge.
+- **Reviewer won't approve after 3 rounds:** Report the outstanding feedback, the PR URL, and stop. Auto-merge remains enabled.
+- **Timeout (10 min no approvals):** Report status and PR URL. Auto-merge remains enabled — no work lost.
 - **gh CLI not authenticated:** Tell the user to run `gh auth login`.


### PR DESCRIPTION
## Changes
- **Autopilot skill**: claim beads before dispatch to prevent double-selection, explicit branch existence checks, worktree cleanup logging with uncommitted-change warnings, session tally in reports, `/ship` integration when backlog is empty, deduplicate allowed-paths table, tighten description for triggering, note about serial filter cost
- **Ship skill**: enable auto-merge via `gh pr merge --auto`, watch for both Copilot and CodeRabbit reviews, address actionable feedback automatically (up to 3 rounds per reviewer), timeout after 10 minutes

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Autopilot workflow refactored to use session-branch merge flow with improved phase logic and branch tracking
  * Autopilot failure handling simplified to single-strike blocking mode, preventing retry cycles
  * Ship workflow enhanced with GitHub branch-protection auto-merge capability
  * Ship workflow now includes approval-watching loop and automated mechanical fix handling for reviewer feedback

<!-- end of auto-generated comment: release notes by coderabbit.ai -->