### PR TITLE
Autopilot: shared formatters, useFetchData hook, Cosmos REST client, dead code removal

### DIFF
--- a/.claude/skills/autopilot/SKILL.md
+++ b/.claude/skills/autopilot/SKILL.md
@@ -120,7 +120,14 @@ Determine the worker's allowed path scope (this table is the single source of tr
 | `pulumi-infra-worker` | `infra/` |
 | `github-actions-worker` | `.github/workflows/`, `.github/actions/` |
 
-Dispatch the worker:
+Resolve the main repo's beads directory for the worker. The worktree won't have `.beads/` — workers need `BEADS_DIR` set so `bd` finds the shared database:
+
+```bash
+beads_dir=$(bd where 2>/dev/null | head -1)
+# e.g. /Users/christy/Dev/town-crier/.beads
+```
+
+Dispatch the worker with `BEADS_DIR` in the prompt:
 
 ```
 Agent({
@@ -131,7 +138,7 @@ Agent({
   "model": "opus",
   "mode": "bypassPermissions",
   "run_in_background": true,
-  "prompt": "Work on bead `<bead-id>`.\n\nCritical requirements:\n- Record a bead comment after EVERY Red and EVERY Green phase — this is your primary deliverable\n- Only modify files under `<allowed-path>` — do not touch anything outside this boundary\n- If you are unsure about scope or design, add a bead comment explaining the ambiguity and stop"
+  "prompt": "Work on bead `<bead-id>`.\n\nWorktree beads setup — run this FIRST, before any bd command:\n```bash\nexport BEADS_DIR=\"<beads_dir>\"\n```\n\nCritical requirements:\n- Record a bead comment after EVERY Red and EVERY Green phase — this is your primary deliverable\n- Only modify files under `<allowed-path>` — do not touch anything outside this boundary\n- If you are unsure about scope or design, add a bead comment explaining the ambiguity and stop\n- NEVER run `bd init`, `bd init --force`, or `bd doctor --fix` — these destroy the shared beads database. If bd commands fail, add a bead comment describing the error and continue with code work."
 })
 ```
 

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
@@ -1,7 +1,10 @@
+using System.Net;
 using Azure.Identity;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
+using Polly;
 
 namespace TownCrier.Infrastructure.Cosmos;
 
@@ -53,6 +56,26 @@ public static class CosmosServiceExtensions
 #pragma warning disable CA2000 // DI container owns the lifetime and will dispose on shutdown
         services.AddSingleton(new CosmosAuthProvider(new DefaultAzureCredential()));
 #pragma warning restore CA2000
+
+        services.AddHttpClient("CosmosRest", client =>
+        {
+            client.BaseAddress = new Uri(accountEndpoint);
+        })
+        .AddResilienceHandler("CosmosRetry", builder =>
+        {
+            builder.AddRetry(new HttpRetryStrategyOptions
+            {
+                MaxRetryAttempts = 5,
+                BackoffType = DelayBackoffType.Exponential,
+                Delay = TimeSpan.FromMilliseconds(500),
+                ShouldHandle = args => ValueTask.FromResult(
+                    args.Outcome.Result?.StatusCode is
+                        HttpStatusCode.TooManyRequests or // 429
+                        HttpStatusCode.RequestTimeout or // 408
+                        HttpStatusCode.ServiceUnavailable or // 503
+                        (HttpStatusCode)449), // 449 Retry With
+            });
+        });
 
         return services;
     }

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
@@ -77,6 +77,15 @@ public static class CosmosServiceExtensions
             });
         });
 
+        services.AddSingleton<ICosmosRestClient>(sp =>
+        {
+            var factory = sp.GetRequiredService<IHttpClientFactory>();
+            var httpClient = factory.CreateClient("CosmosRest");
+            var auth = sp.GetRequiredService<CosmosAuthProvider>();
+            var opts = sp.GetRequiredService<CosmosRestOptions>();
+            return new CosmosRestClient(httpClient, auth, opts);
+        });
+
         return services;
     }
 }

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
@@ -30,4 +30,26 @@ public static class CosmosServiceExtensions
 
         return services;
     }
+
+    public static IServiceCollection AddCosmosRestClient(
+        this IServiceCollection services, IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var cosmosSection = configuration.GetSection("Cosmos");
+        var accountEndpoint = cosmosSection["AccountEndpoint"]
+            ?? throw new InvalidOperationException("Cosmos:AccountEndpoint configuration is required.");
+        var databaseName = cosmosSection["DatabaseName"]
+            ?? throw new InvalidOperationException("Cosmos:DatabaseName configuration is required.");
+
+        var options = new CosmosRestOptions
+        {
+            AccountEndpoint = accountEndpoint,
+            DatabaseName = databaseName,
+        };
+
+        services.AddSingleton(options);
+
+        return services;
+    }
 }

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
@@ -10,30 +10,6 @@ namespace TownCrier.Infrastructure.Cosmos;
 
 public static class CosmosServiceExtensions
 {
-    public static IServiceCollection AddCosmosClient(this IServiceCollection services, IConfiguration configuration)
-    {
-        services.AddSingleton(_ =>
-        {
-            var accountEndpoint = configuration["Cosmos:AccountEndpoint"];
-            if (!string.IsNullOrWhiteSpace(accountEndpoint))
-            {
-                return CosmosClientFactory.Create(accountEndpoint, new DefaultAzureCredential());
-            }
-
-            var connectionString = configuration.GetConnectionString("CosmosDb");
-            if (!string.IsNullOrWhiteSpace(connectionString))
-            {
-                return CosmosClientFactory.Create(connectionString);
-            }
-
-            throw new InvalidOperationException(
-                "Cosmos DB is not configured. Set 'Cosmos:AccountEndpoint' (managed identity) "
-                + "or 'ConnectionStrings:CosmosDb' (connection string).");
-        });
-
-        return services;
-    }
-
     public static IServiceCollection AddCosmosRestClient(
         this IServiceCollection services, IConfiguration configuration)
     {

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
@@ -50,6 +50,10 @@ public static class CosmosServiceExtensions
 
         services.AddSingleton(options);
 
+#pragma warning disable CA2000 // DI container owns the lifetime and will dispose on shutdown
+        services.AddSingleton(new CosmosAuthProvider(new DefaultAzureCredential()));
+#pragma warning restore CA2000
+
         return services;
     }
 }

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
@@ -86,6 +86,11 @@ public static class CosmosServiceExtensions
             return new CosmosRestClient(httpClient, auth, opts);
         });
 
+        // Backward compat: existing repos still depend on CosmosClient via SDK.
+        // Remove once all repos are migrated to ICosmosRestClient (tc-pgp.3).
+        services.AddSingleton(_ =>
+            CosmosClientFactory.Create(accountEndpoint, new DefaultAzureCredential()));
+
         return services;
     }
 }

--- a/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
+++ b/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
@@ -38,7 +38,7 @@ internal static class ServiceCollectionExtensions
     public static IServiceCollection AddInfrastructureServices(
         this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddCosmosClient(configuration);
+        services.AddCosmosRestClient(configuration);
 
         services.AddSingleton<IDecisionAlertRepository, CosmosDecisionAlertRepository>();
         services.AddSingleton<IPlanningApplicationRepository, CosmosPlanningApplicationRepository>();
@@ -47,11 +47,8 @@ internal static class ServiceCollectionExtensions
         services.AddSingleton<IGroupRepository, CosmosGroupRepository>();
         services.AddSingleton<IGroupInvitationRepository, CosmosGroupInvitationRepository>();
         services.AddSingleton<ISavedApplicationRepository, CosmosSavedApplicationRepository>();
-
-        services.AddSingleton<IDeviceRegistrationRepository>(sp =>
-            new CosmosDeviceRegistrationRepository(sp.GetRequiredService<Microsoft.Azure.Cosmos.CosmosClient>()));
-        services.AddSingleton<INotificationRepository>(sp =>
-            new CosmosNotificationRepository(sp.GetRequiredService<Microsoft.Azure.Cosmos.CosmosClient>()));
+        services.AddSingleton<IDeviceRegistrationRepository, CosmosDeviceRegistrationRepository>();
+        services.AddSingleton<INotificationRepository, CosmosNotificationRepository>();
 
         var pollStateFilePath = configuration["Polling:StateFilePath"]
             ?? Path.Combine(AppContext.BaseDirectory, "poll-state.txt");

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
@@ -30,4 +30,24 @@ public sealed class CosmosServiceRegistrationTests
         await Assert.That(options.AccountEndpoint).IsEqualTo("https://test-account.documents.azure.com:443");
         await Assert.That(options.DatabaseName).IsEqualTo("town-crier");
     }
+
+    [Test]
+    public async Task Should_RegisterCosmosAuthProviderAsSingleton_When_AddCosmosRestClientCalled()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(ValidCosmosConfig)
+            .Build();
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddCosmosRestClient(config);
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        var authProvider1 = provider.GetRequiredService<CosmosAuthProvider>();
+        var authProvider2 = provider.GetRequiredService<CosmosAuthProvider>();
+        await Assert.That(authProvider1).IsNotNull();
+        await Assert.That(authProvider1).IsSameReferenceAs(authProvider2);
+    }
 }

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
@@ -91,4 +91,40 @@ public sealed class CosmosServiceRegistrationTests
         await Assert.That(client1).IsNotNull();
         await Assert.That(client1).IsSameReferenceAs(client2);
     }
+
+    [Test]
+    public async Task Should_ThrowInvalidOperationException_When_AccountEndpointMissing()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Cosmos:DatabaseName"] = "town-crier",
+            })
+            .Build();
+        var services = new ServiceCollection();
+
+        // Act & Assert
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddCosmosRestClient(config));
+        await Assert.That(exception.Message).Contains("AccountEndpoint");
+    }
+
+    [Test]
+    public async Task Should_ThrowInvalidOperationException_When_DatabaseNameMissing()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Cosmos:AccountEndpoint"] = "https://test.documents.azure.com:443",
+            })
+            .Build();
+        var services = new ServiceCollection();
+
+        // Act & Assert
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => services.AddCosmosRestClient(config));
+        await Assert.That(exception.Message).Contains("DatabaseName");
+    }
 }

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
@@ -71,4 +71,24 @@ public sealed class CosmosServiceRegistrationTests
         await Assert.That(httpClient.BaseAddress!.Host)
             .IsEqualTo("test-account.documents.azure.com");
     }
+
+    [Test]
+    public async Task Should_RegisterICosmosRestClientAsSingleton_When_AddCosmosRestClientCalled()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(ValidCosmosConfig)
+            .Build();
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddCosmosRestClient(config);
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        var client1 = provider.GetRequiredService<ICosmosRestClient>();
+        var client2 = provider.GetRequiredService<ICosmosRestClient>();
+        await Assert.That(client1).IsNotNull();
+        await Assert.That(client1).IsSameReferenceAs(client2);
+    }
 }

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
@@ -50,4 +50,25 @@ public sealed class CosmosServiceRegistrationTests
         await Assert.That(authProvider1).IsNotNull();
         await Assert.That(authProvider1).IsSameReferenceAs(authProvider2);
     }
+
+    [Test]
+    public async Task Should_RegisterNamedHttpClient_When_AddCosmosRestClientCalled()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(ValidCosmosConfig)
+            .Build();
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddCosmosRestClient(config);
+        using var provider = services.BuildServiceProvider();
+
+        // Assert
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+        using var httpClient = factory.CreateClient("CosmosRest");
+        await Assert.That(httpClient).IsNotNull();
+        await Assert.That(httpClient.BaseAddress!.ToString())
+            .IsEqualTo("https://test-account.documents.azure.com:443/");
+    }
 }

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using TownCrier.Infrastructure.Cosmos;
 
 namespace TownCrier.Infrastructure.Tests.Cosmos;
@@ -27,7 +26,7 @@ public sealed class CosmosServiceRegistrationTests
         using var provider = services.BuildServiceProvider();
 
         // Assert
-        var options = provider.GetRequiredService<IOptions<CosmosRestOptions>>().Value;
+        var options = provider.GetRequiredService<CosmosRestOptions>();
         await Assert.That(options.AccountEndpoint).IsEqualTo("https://test-account.documents.azure.com:443");
         await Assert.That(options.DatabaseName).IsEqualTo("town-crier");
     }

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
@@ -68,7 +68,7 @@ public sealed class CosmosServiceRegistrationTests
         var factory = provider.GetRequiredService<IHttpClientFactory>();
         using var httpClient = factory.CreateClient("CosmosRest");
         await Assert.That(httpClient).IsNotNull();
-        await Assert.That(httpClient.BaseAddress!.ToString())
-            .IsEqualTo("https://test-account.documents.azure.com:443/");
+        await Assert.That(httpClient.BaseAddress!.Host)
+            .IsEqualTo("test-account.documents.azure.com");
     }
 }

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosServiceRegistrationTests.cs
@@ -1,50 +1,34 @@
-using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using TownCrier.Infrastructure.Cosmos;
 
 namespace TownCrier.Infrastructure.Tests.Cosmos;
 
 public sealed class CosmosServiceRegistrationTests
 {
+    private static readonly Dictionary<string, string?> ValidCosmosConfig = new()
+    {
+        ["Cosmos:AccountEndpoint"] = "https://test-account.documents.azure.com:443",
+        ["Cosmos:DatabaseName"] = "town-crier",
+    };
+
     [Test]
-    public async Task Should_ResolveSingletonCosmosClient_When_ConnectionStringIsConfigured()
+    public async Task Should_RegisterCosmosRestOptions_When_AddCosmosRestClientCalled()
     {
         // Arrange
         var config = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["ConnectionStrings:CosmosDb"] = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
-            })
+            .AddInMemoryCollection(ValidCosmosConfig)
             .Build();
-
         var services = new ServiceCollection();
-        services.AddSingleton<IConfiguration>(config);
-        services.AddCosmosClient(config);
-        using var provider = services.BuildServiceProvider();
 
         // Act
-        var client1 = provider.GetRequiredService<CosmosClient>();
-        var client2 = provider.GetRequiredService<CosmosClient>();
+        services.AddCosmosRestClient(config);
+        using var provider = services.BuildServiceProvider();
 
         // Assert
-        await Assert.That(client1).IsNotNull();
-        await Assert.That(client1).IsSameReferenceAs(client2);
-    }
-
-    [Test]
-    public void Should_ThrowInvalidOperationException_When_ConnectionStringIsMissing()
-    {
-        // Arrange
-        var config = new ConfigurationBuilder().Build();
-
-        // Act & Assert
-        Assert.Throws<InvalidOperationException>(() =>
-        {
-            var services = new ServiceCollection();
-            services.AddCosmosClient(config);
-            using var provider = services.BuildServiceProvider();
-            provider.GetRequiredService<CosmosClient>();
-        });
+        var options = provider.GetRequiredService<IOptions<CosmosRestOptions>>().Value;
+        await Assert.That(options.AccountEndpoint).IsEqualTo("https://test-account.documents.azure.com:443");
+        await Assert.That(options.DatabaseName).IsEqualTo("town-crier");
     }
 }

--- a/api/tests/town-crier.web.tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
+++ b/api/tests/town-crier.web.tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
@@ -15,22 +15,26 @@ using TownCrier.Application.SavedApplications;
 using TownCrier.Application.Search;
 using TownCrier.Application.UserProfiles;
 using TownCrier.Application.WatchZones;
+using TownCrier.Infrastructure.Cosmos;
 using TownCrier.Web.Extensions;
 
 namespace TownCrier.Web.Tests.DependencyInjection;
 
 public sealed class ServiceRegistrationExtensionsTests
 {
+    private static readonly Dictionary<string, string?> CosmosRestConfig = new()
+    {
+        ["Cosmos:AccountEndpoint"] = "https://test-account.documents.azure.com:443",
+        ["Cosmos:DatabaseName"] = "town-crier",
+    };
+
     [Test]
     public async Task Should_RegisterInfrastructureServices_When_AddInfrastructureServicesCalled()
     {
         // Arrange
         var services = new ServiceCollection();
         var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["ConnectionStrings:CosmosDb"] = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
-            })
+            .AddInMemoryCollection(CosmosRestConfig)
             .Build();
 
         // Act
@@ -38,6 +42,7 @@ public sealed class ServiceRegistrationExtensionsTests
 
         // Assert — verify key infrastructure registrations exist
         var provider = services.BuildServiceProvider();
+        await Assert.That(provider.GetService<ICosmosRestClient>()).IsNotNull();
         await Assert.That(provider.GetService<IPlanningApplicationRepository>()).IsNotNull();
         await Assert.That(provider.GetService<IUserProfileRepository>()).IsNotNull();
         await Assert.That(provider.GetService<IWatchZoneRepository>()).IsNotNull();
@@ -56,10 +61,7 @@ public sealed class ServiceRegistrationExtensionsTests
         // Arrange
         var services = new ServiceCollection();
         var configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["ConnectionStrings:CosmosDb"] = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
-            })
+            .AddInMemoryCollection(CosmosRestConfig)
             .Build();
 
         // Infrastructure services needed as dependencies for handlers

--- a/api/tests/town-crier.web.tests/TestWebApplicationFactory.cs
+++ b/api/tests/town-crier.web.tests/TestWebApplicationFactory.cs
@@ -32,9 +32,8 @@ internal sealed class TestWebApplicationFactory : WebApplicationFactory<Program>
         builder.UseSetting("Auth0:Domain", "test.auth0.com");
         builder.UseSetting("Auth0:Audience", "https://api.towncrier.app");
         builder.UseSetting("Cors:AllowedOrigins:0", "http://localhost:5173");
-        builder.UseSetting(
-            "ConnectionStrings:CosmosDb",
-            "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==");
+        builder.UseSetting("Cosmos:AccountEndpoint", "https://test-account.documents.azure.com:443");
+        builder.UseSetting("Cosmos:DatabaseName", "town-crier");
 
         builder.ConfigureTestServices(services =>
         {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
@@ -36,20 +36,12 @@ public final class ApplicationDetailViewModel: ObservableObject {
         !timelineItems.isEmpty
     }
 
-    private static let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "d MMM yyyy"
-        formatter.locale = Locale(identifier: "en_GB")
-        formatter.timeZone = TimeZone(identifier: "UTC")
-        return formatter
-    }()
-
     public init(application: PlanningApplication) {
         description = application.description
         address = application.address
         reference = application.reference.value
         authorityName = application.authority.name
-        receivedDateFormatted = Self.dateFormatter.string(from: application.receivedDate)
+        receivedDateFormatted = application.receivedDate.formattedForDisplay
         status = application.status
         portalUrl = application.portalUrl
 
@@ -65,7 +57,7 @@ public final class ApplicationDetailViewModel: ObservableObject {
             return TimelineItem(
                 label: event.status.displayLabel,
                 icon: event.status.displayIcon,
-                dateFormatted: Self.dateFormatter.string(from: event.date),
+                dateFormatted: event.date.formattedForDisplay,
                 isCurrent: isLast,
                 status: event.status
             )

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListRow.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListRow.swift
@@ -5,20 +5,12 @@ import TownCrierDomain
 struct ApplicationListRow: View {
     let application: PlanningApplication
 
-    private static let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "d MMM yyyy"
-        formatter.locale = Locale(identifier: "en_GB")
-        formatter.timeZone = TimeZone(identifier: "UTC")
-        return formatter
-    }()
-
     var body: some View {
         VStack(alignment: .leading, spacing: TCSpacing.small) {
             HStack {
                 statusBadge
                 Spacer()
-                Text(Self.dateFormatter.string(from: application.receivedDate))
+                Text(application.receivedDate.formattedForDisplay)
                     .font(TCTypography.caption)
                     .foregroundStyle(Color.tcTextSecondary)
             }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ForceUpdate/ForceUpdateViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ForceUpdate/ForceUpdateViewModel.swift
@@ -7,7 +7,6 @@ import TownCrierDomain
 public final class ForceUpdateViewModel: ObservableObject {
     @Published public private(set) var requiresUpdate = false
     @Published public private(set) var isChecking = false
-    @Published public private(set) var hasChecked = false
 
     private let versionConfigService: VersionConfigService
     private let appVersionProvider: AppVersionProvider
@@ -24,7 +23,6 @@ public final class ForceUpdateViewModel: ObservableObject {
         isChecking = true
         defer {
             isChecking = false
-            hasChecked = true
         }
 
         guard let currentVersion = AppVersion(appVersionProvider.version) else {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/RadiusPickerStepView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/RadiusPickerStepView.swift
@@ -23,7 +23,7 @@ struct RadiusPickerStepView: View {
                         viewModel.selectedRadiusMetres = radius
                     } label: {
                         HStack {
-                            Text(radiusLabel(radius))
+                            Text(formatRadius(radius))
                                 .font(TCTypography.bodyEmphasis)
                             Spacer()
                             if viewModel.selectedRadiusMetres == radius {
@@ -61,10 +61,4 @@ struct RadiusPickerStepView: View {
         .padding(TCSpacing.extraLarge)
     }
 
-    private func radiusLabel(_ metres: Double) -> String {
-        if metres >= 1000 {
-            return "\(Int(metres / 1000)) km"
-        }
-        return "\(Int(metres)) m"
-    }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
@@ -76,7 +76,7 @@ public struct WatchZoneEditorView: View {
         Section("Radius") {
             Picker("Radius", selection: $viewModel.selectedRadiusMetres) {
                 ForEach(viewModel.availableRadiusOptions, id: \.self) { option in
-                    Text(radiusLabel(option)).tag(option)
+                    Text(formatRadius(option)).tag(option)
                 }
             }
             .pickerStyle(.segmented)
@@ -116,15 +116,6 @@ public struct WatchZoneEditorView: View {
         }
     }
 
-    private func radiusLabel(_ metres: Double) -> String {
-        if metres >= 1000 {
-            let km = metres / 1000
-            return km.truncatingRemainder(dividingBy: 1) == 0
-                ? "\(Int(km)) km"
-                : String(format: "%.1f km", km)
-        }
-        return "\(Int(metres)) m"
-    }
 }
 
 /// Larger map preview for the editor screen.

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -86,7 +86,7 @@ private struct WatchZoneRow: View {
             VStack(alignment: .leading, spacing: TCSpacing.extraSmall) {
                 Text(zone.postcode.value)
                     .font(.system(.headline).weight(.semibold))
-                Text(radiusLabel(zone.radiusMetres))
+                Text(formatRadius(zone.radiusMetres))
                     .font(.system(.caption))
                     .foregroundStyle(Color.tcTextSecondary)
             }
@@ -100,15 +100,6 @@ private struct WatchZoneRow: View {
         .padding(.vertical, TCSpacing.extraSmall)
     }
 
-    private func radiusLabel(_ metres: Double) -> String {
-        if metres >= 1000 {
-            let km = metres / 1000
-            return km.truncatingRemainder(dividingBy: 1) == 0
-                ? "\(Int(km)) km radius"
-                : String(format: "%.1f km radius", km)
-        }
-        return "\(Int(metres)) m radius"
-    }
 }
 
 /// A small non-interactive map preview showing the zone circle.

--- a/mobile/ios/packages/town-crier-presentation/Sources/Formatters/Date+TownCrier.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Formatters/Date+TownCrier.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension Date {
+    /// Shared display formatter: "d MMM yyyy", en_GB locale, UTC timezone.
+    private static let displayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "d MMM yyyy"
+        formatter.locale = Locale(identifier: "en_GB")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        return formatter
+    }()
+
+    /// Formats the date for user-facing display (e.g. "14 Nov 2023").
+    public var formattedForDisplay: String {
+        Self.displayFormatter.string(from: self)
+    }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Formatters/RadiusFormatter.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Formatters/RadiusFormatter.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Formats a radius in metres for user-facing display.
+///
+/// - Values under 1000 m show as whole metres (e.g. "500 m").
+/// - Values of 1000 m or above show as kilometres, with one decimal
+///   place for fractional values (e.g. "1.5 km") and no decimal
+///   for whole values (e.g. "2 km").
+public func formatRadius(_ metres: Double) -> String {
+    if metres >= 1000 {
+        let km = metres / 1000
+        if km.truncatingRemainder(dividingBy: 1) == 0 {
+            return "\(Int(km)) km"
+        }
+        return String(format: "%.1f km", km)
+    }
+    return "\(Int(metres)) m"
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/DateFormattingTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DateFormattingTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import Testing
+
+@testable import TownCrierPresentation
+
+@Suite("Date+TownCrier")
+struct DateFormattingTests {
+
+    @Test func formattedForDisplay_producesUKFormat() {
+        // 1_700_000_000 = 14 Nov 2023 in UTC
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+
+        #expect(date.formattedForDisplay == "14 Nov 2023")
+    }
+
+    @Test func formattedForDisplay_firstJanuary_showsSingleDigitDay() {
+        // 1 Jan 2024 00:00:00 UTC = 1704067200
+        let date = Date(timeIntervalSince1970: 1_704_067_200)
+
+        #expect(date.formattedForDisplay == "1 Jan 2024")
+    }
+
+    @Test func formattedForDisplay_usesUTCNotLocalTimezone() {
+        // 31 Dec 2023 23:30:00 UTC = 1704065400
+        // This is already 1 Jan 2024 in UTC+1 timezones, but should show 31 Dec in UTC
+        let date = Date(timeIntervalSince1970: 1_704_065_400)
+
+        #expect(date.formattedForDisplay == "31 Dec 2023")
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/ForceUpdateViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ForceUpdateViewModelTests.swift
@@ -120,13 +120,4 @@ struct ForceUpdateViewModelTests {
         #expect(!sut.isChecking)
     }
 
-    @Test func checkVersion_hasChecked_isTrueAfterCheck() async {
-        let (sut, _, _) = makeSUT()
-
-        #expect(!sut.hasChecked)
-
-        await sut.checkVersion()
-
-        #expect(sut.hasChecked)
-    }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/RadiusFormattingTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/RadiusFormattingTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import Testing
+
+@testable import TownCrierPresentation
+
+@Suite("formatRadius")
+struct RadiusFormattingTests {
+
+    @Test func formatRadius_under1000_showsMetres() {
+        #expect(formatRadius(500) == "500 m")
+    }
+
+    @Test func formatRadius_exactly1000_showsWholeKm() {
+        #expect(formatRadius(1000) == "1 km")
+    }
+
+    @Test func formatRadius_over1000_wholeKm_showsWholeKm() {
+        #expect(formatRadius(2000) == "2 km")
+    }
+
+    @Test func formatRadius_fractionalKm_showsOneDecimal() {
+        #expect(formatRadius(1500) == "1.5 km")
+    }
+
+    @Test func formatRadius_5000_shows5Km() {
+        #expect(formatRadius(5000) == "5 km")
+    }
+
+    @Test func formatRadius_smallValue_shows250m() {
+        #expect(formatRadius(250) == "250 m")
+    }
+}

--- a/web/src/components/ApplicationCard/ApplicationCard.tsx
+++ b/web/src/components/ApplicationCard/ApplicationCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import type { PlanningApplicationSummary } from '../../domain/types';
+import { formatDate, statusClassName } from '../../utils/formatting';
 import styles from './ApplicationCard.module.css';
 
 interface Props {
@@ -8,23 +9,6 @@ interface Props {
 
 const MAX_DESCRIPTION_LENGTH = 120;
 
-function statusClassName(appState: string): string {
-  switch (appState) {
-    case 'Undecided':
-      return styles.statusUndecided ?? '';
-    case 'Approved':
-      return styles.statusApproved ?? '';
-    case 'Refused':
-      return styles.statusRefused ?? '';
-    case 'Withdrawn':
-      return styles.statusWithdrawn ?? '';
-    case 'Appealed':
-      return styles.statusAppealed ?? '';
-    default:
-      return styles.statusDefault ?? '';
-  }
-}
-
 function truncate(text: string, maxLength: number): string {
   if (text.length <= maxLength) {
     return text;
@@ -32,17 +16,8 @@ function truncate(text: string, maxLength: number): string {
   return text.slice(0, maxLength) + '...';
 }
 
-function formatDate(isoDate: string): string {
-  const date = new Date(isoDate);
-  return date.toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  });
-}
-
 export function ApplicationCard({ application }: Props) {
-  const statusClass = statusClassName(application.appState);
+  const statusClass = statusClassName(application.appState, styles);
 
   return (
     <Link

--- a/web/src/features/ApplicationDetail/ApplicationDetailPage.tsx
+++ b/web/src/features/ApplicationDetail/ApplicationDetailPage.tsx
@@ -3,6 +3,7 @@ import { asApplicationUid } from '../../domain/types';
 import type { ApplicationRepository } from '../../domain/ports/application-repository';
 import type { DesignationRepository } from '../../domain/ports/designation-repository';
 import type { SavedApplicationRepository } from '../../domain/ports/saved-application-repository';
+import { formatDate, statusClassName } from '../../utils/formatting';
 import { useApplication } from './useApplication';
 import { useDesignations } from './useDesignations';
 import { useSavedApplication } from './useSavedApplication';
@@ -12,34 +13,6 @@ interface Props {
   applicationRepository: ApplicationRepository;
   designationRepository: DesignationRepository;
   savedApplicationRepository: SavedApplicationRepository;
-}
-
-function statusClassName(appState: string): string {
-  switch (appState) {
-    case 'Undecided':
-      return styles.statusUndecided ?? '';
-    case 'Approved':
-      return styles.statusApproved ?? '';
-    case 'Refused':
-      return styles.statusRefused ?? '';
-    case 'Withdrawn':
-      return styles.statusWithdrawn ?? '';
-    case 'Appealed':
-      return styles.statusAppealed ?? '';
-    case 'Not Available':
-      return styles.statusNotAvailable ?? '';
-    default:
-      return '';
-  }
-}
-
-function formatDate(dateStr: string): string {
-  const date = new Date(dateStr);
-  return date.toLocaleDateString('en-GB', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-  });
 }
 
 export function ApplicationDetailPage({
@@ -82,7 +55,7 @@ export function ApplicationDetailPage({
         <div className={styles.topRow}>
           <h1 className={styles.reference}>{application.name}</h1>
           <span
-            className={`${styles.badge ?? ''} ${statusClassName(application.appState)}`}
+            className={`${styles.badge ?? ''} ${statusClassName(application.appState, styles)}`}
             role="status"
           >
             {application.appState}

--- a/web/src/features/ApplicationDetail/useApplication.ts
+++ b/web/src/features/ApplicationDetail/useApplication.ts
@@ -1,34 +1,12 @@
-import { useState, useEffect } from 'react';
-import type { ApplicationUid, PlanningApplication } from '../../domain/types';
+import type { ApplicationUid } from '../../domain/types';
 import type { ApplicationRepository } from '../../domain/ports/application-repository';
-
-interface ApplicationState {
-  application: PlanningApplication | null;
-  isLoading: boolean;
-  error: string | null;
-}
+import { useFetchData } from '../../hooks/useFetchData';
 
 export function useApplication(repository: ApplicationRepository, uid: ApplicationUid) {
-  const [state, setState] = useState<ApplicationState>({
-    application: null,
-    isLoading: true,
-    error: null,
-  });
+  const { data: application, isLoading, error } = useFetchData(
+    () => repository.fetchApplication(uid),
+    [repository, uid],
+  );
 
-  useEffect(() => {
-    let cancelled = false;
-    repository.fetchApplication(uid).then(application => {
-      if (!cancelled) {
-        setState({ application, isLoading: false, error: null });
-      }
-    }).catch((err: unknown) => {
-      if (!cancelled) {
-        const message = err instanceof Error ? err.message : 'Unknown error';
-        setState({ application: null, isLoading: false, error: message });
-      }
-    });
-    return () => { cancelled = true; };
-  }, [repository, uid]);
-
-  return state;
+  return { application, isLoading, error };
 }

--- a/web/src/features/ApplicationDetail/useDesignations.ts
+++ b/web/src/features/ApplicationDetail/useDesignations.ts
@@ -9,22 +9,11 @@ export function useDesignations(
 ) {
   const hasCoordinates = latitude !== null && longitude !== null;
 
-  const fetchResult = useFetchData<DesignationContext>(
+  const { data: designations, isLoading, error } = useFetchData<DesignationContext>(
     () => repository.fetchDesignations(latitude!, longitude!),
     [repository, latitude, longitude],
+    { enabled: hasCoordinates },
   );
 
-  if (!hasCoordinates) {
-    return {
-      designations: null as DesignationContext | null,
-      isLoading: false,
-      error: null as string | null,
-    };
-  }
-
-  return {
-    designations: fetchResult.data,
-    isLoading: fetchResult.isLoading,
-    error: fetchResult.error,
-  };
+  return { designations, isLoading, error };
 }

--- a/web/src/features/ApplicationDetail/useDesignations.ts
+++ b/web/src/features/ApplicationDetail/useDesignations.ts
@@ -1,12 +1,6 @@
-import { useState, useEffect } from 'react';
 import type { DesignationContext } from '../../domain/types';
 import type { DesignationRepository } from '../../domain/ports/designation-repository';
-
-interface DesignationsState {
-  designations: DesignationContext | null;
-  isLoading: boolean;
-  error: string | null;
-}
+import { useFetchData } from '../../hooks/useFetchData';
 
 export function useDesignations(
   repository: DesignationRepository,
@@ -15,27 +9,22 @@ export function useDesignations(
 ) {
   const hasCoordinates = latitude !== null && longitude !== null;
 
-  const [state, setState] = useState<DesignationsState>({
-    designations: null,
-    isLoading: hasCoordinates,
-    error: null,
-  });
+  const fetchResult = useFetchData<DesignationContext>(
+    () => repository.fetchDesignations(latitude!, longitude!),
+    [repository, latitude, longitude],
+  );
 
-  useEffect(() => {
-    if (!hasCoordinates) return;
-    let cancelled = false;
-    repository.fetchDesignations(latitude!, longitude!).then(designations => {
-      if (!cancelled) {
-        setState({ designations, isLoading: false, error: null });
-      }
-    }).catch((err: unknown) => {
-      if (!cancelled) {
-        const message = err instanceof Error ? err.message : 'Unknown error';
-        setState({ designations: null, isLoading: false, error: message });
-      }
-    });
-    return () => { cancelled = true; };
-  }, [hasCoordinates, repository, latitude, longitude]);
+  if (!hasCoordinates) {
+    return {
+      designations: null as DesignationContext | null,
+      isLoading: false,
+      error: null as string | null,
+    };
+  }
 
-  return state;
+  return {
+    designations: fetchResult.data,
+    isLoading: fetchResult.isLoading,
+    error: fetchResult.error,
+  };
 }

--- a/web/src/features/Dashboard/useDashboard.ts
+++ b/web/src/features/Dashboard/useDashboard.ts
@@ -1,25 +1,15 @@
-import { useState, useEffect, useCallback } from 'react';
 import type { DashboardPort } from '../../domain/ports/dashboard-port';
 import type { PlanningApplicationSummary, WatchZoneSummary } from '../../domain/types';
+import { useFetchData } from '../../hooks/useFetchData';
 
-interface DashboardState {
+interface DashboardData {
   zones: readonly WatchZoneSummary[];
   recentApplications: readonly PlanningApplicationSummary[];
-  isLoading: boolean;
-  error: string | null;
 }
 
 export function useDashboard(port: DashboardPort) {
-  const [state, setState] = useState<DashboardState>({
-    zones: [],
-    recentApplications: [],
-    isLoading: true,
-    error: null,
-  });
-
-  const load = useCallback(async () => {
-    setState(prev => ({ ...prev, isLoading: true, error: null }));
-    try {
+  const { data, isLoading, error, refresh } = useFetchData<DashboardData>(
+    async () => {
       const zones = await port.fetchWatchZones();
 
       const uniqueAuthorityIds = [...new Set(zones.map(z => z.authorityId))];
@@ -28,35 +18,16 @@ export function useDashboard(port: DashboardPort) {
       );
       const recentApplications = applicationsByAuthority.flat();
 
-      setState({ zones, recentApplications, isLoading: false, error: null });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load dashboard';
-      setState(prev => ({ ...prev, isLoading: false, error: message }));
-    }
-  }, [port]);
+      return { zones, recentApplications };
+    },
+    [port],
+  );
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const zones = await port.fetchWatchZones();
-        const uniqueAuthorityIds = [...new Set(zones.map(z => z.authorityId))];
-        const applicationsByAuthority = await Promise.all(
-          uniqueAuthorityIds.map(id => port.fetchRecentApplications(id)),
-        );
-        const recentApplications = applicationsByAuthority.flat();
-        if (!cancelled) {
-          setState({ zones, recentApplications, isLoading: false, error: null });
-        }
-      } catch (err) {
-        if (!cancelled) {
-          const message = err instanceof Error ? err.message : 'Failed to load dashboard';
-          setState(prev => ({ ...prev, isLoading: false, error: message }));
-        }
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [port]);
-
-  return { ...state, refresh: load };
+  return {
+    zones: data?.zones ?? [],
+    recentApplications: data?.recentApplications ?? [],
+    isLoading,
+    error,
+    refresh,
+  };
 }

--- a/web/src/features/Groups/useAcceptInvitation.ts
+++ b/web/src/features/Groups/useAcceptInvitation.ts
@@ -1,43 +1,15 @@
-import { useState, useEffect } from 'react';
 import type { InvitationId } from '../../domain/types';
 import type { GroupsRepository } from '../../domain/ports/groups-repository';
-
-interface AcceptInvitationState {
-  isLoading: boolean;
-  isAccepted: boolean;
-  error: string | null;
-}
+import { useFetchData } from '../../hooks/useFetchData';
 
 export function useAcceptInvitation(repository: GroupsRepository, invitationId: InvitationId) {
-  const [state, setState] = useState<AcceptInvitationState>({
-    isLoading: true,
-    isAccepted: false,
-    error: null,
-  });
+  const { data: isAccepted, isLoading, error } = useFetchData(
+    async () => {
+      await repository.acceptInvitation(invitationId);
+      return true;
+    },
+    [repository, invitationId],
+  );
 
-  useEffect(() => {
-    let cancelled = false;
-
-    async function accept() {
-      try {
-        await repository.acceptInvitation(invitationId);
-        if (!cancelled) {
-          setState({ isLoading: false, isAccepted: true, error: null });
-        }
-      } catch (err) {
-        if (!cancelled) {
-          const message = err instanceof Error ? err.message : 'Failed to accept invitation';
-          setState({ isLoading: false, isAccepted: false, error: message });
-        }
-      }
-    }
-
-    void accept();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [repository, invitationId]);
-
-  return state;
+  return { isLoading, isAccepted: isAccepted ?? false, error };
 }

--- a/web/src/features/Groups/useGroupDetail.ts
+++ b/web/src/features/Groups/useGroupDetail.ts
@@ -1,91 +1,62 @@
-import { useState, useEffect, useCallback } from 'react';
-import type { GroupDetail, GroupId } from '../../domain/types';
+import { useState, useCallback } from 'react';
+import type { GroupId } from '../../domain/types';
 import type { GroupsRepository } from '../../domain/ports/groups-repository';
-
-interface GroupDetailState {
-  group: GroupDetail | null;
-  isLoading: boolean;
-  error: string | null;
-  actionError: string | null;
-}
+import { useFetchData } from '../../hooks/useFetchData';
 
 export function useGroupDetail(repository: GroupsRepository, groupId: GroupId) {
-  const [state, setState] = useState<GroupDetailState>({
-    group: null,
-    isLoading: true,
-    error: null,
-    actionError: null,
-  });
+  const [actionError, setActionError] = useState<string | null>(null);
 
-  const loadGroup = useCallback(async () => {
-    setState((prev) => ({ ...prev, isLoading: true, error: null }));
-    try {
-      const group = await repository.getGroup(groupId);
-      setState({ group, isLoading: false, error: null, actionError: null });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load group';
-      setState({ group: null, isLoading: false, error: message, actionError: null });
-    }
-  }, [repository, groupId]);
-
-  useEffect(() => {
-    let cancelled = false;
-    repository.getGroup(groupId).then(group => {
-      if (!cancelled) {
-        setState({ group, isLoading: false, error: null, actionError: null });
-      }
-    }).catch((err: unknown) => {
-      if (!cancelled) {
-        const message = err instanceof Error ? err.message : 'Failed to load group';
-        setState({ group: null, isLoading: false, error: message, actionError: null });
-      }
-    });
-    return () => { cancelled = true; };
-  }, [repository, groupId]);
+  const { data: group, isLoading, error: fetchError, refresh } = useFetchData(
+    () => repository.getGroup(groupId),
+    [repository, groupId],
+  );
 
   const inviteMember = useCallback(
     async (email: string) => {
-      setState((prev) => ({ ...prev, actionError: null }));
+      setActionError(null);
       try {
         await repository.inviteMember(groupId, { inviteeEmail: email });
-        await loadGroup();
+        refresh();
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to send invitation';
-        setState((prev) => ({ ...prev, actionError: message }));
+        setActionError(message);
       }
     },
-    [repository, groupId, loadGroup],
+    [repository, groupId, refresh],
   );
 
   const removeMember = useCallback(
     async (memberUserId: string) => {
-      setState((prev) => ({ ...prev, actionError: null }));
+      setActionError(null);
       try {
         await repository.removeMember(groupId, memberUserId);
-        await loadGroup();
+        refresh();
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Failed to remove member';
-        setState((prev) => ({ ...prev, actionError: message }));
+        setActionError(message);
       }
     },
-    [repository, groupId, loadGroup],
+    [repository, groupId, refresh],
   );
 
   const deleteGroup = useCallback(async () => {
-    setState((prev) => ({ ...prev, actionError: null }));
+    setActionError(null);
     try {
       await repository.deleteGroup(groupId);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to delete group';
-      setState((prev) => ({ ...prev, actionError: message }));
+      setActionError(message);
     }
   }, [repository, groupId]);
 
   return {
-    ...state,
+    group,
+    isLoading,
+    error: fetchError,
+    actionError,
     inviteMember,
     removeMember,
     deleteGroup,
-    refresh: loadGroup,
+    refresh,
   };
 }

--- a/web/src/features/Groups/useUserGroups.ts
+++ b/web/src/features/Groups/useUserGroups.ts
@@ -1,45 +1,12 @@
-import { useState, useEffect, useCallback } from 'react';
 import type { GroupSummary } from '../../domain/types';
 import type { GroupsRepository } from '../../domain/ports/groups-repository';
-
-interface UserGroupsState {
-  groups: readonly GroupSummary[];
-  isLoading: boolean;
-  error: string | null;
-}
+import { useFetchData } from '../../hooks/useFetchData';
 
 export function useUserGroups(repository: GroupsRepository) {
-  const [state, setState] = useState<UserGroupsState>({
-    groups: [],
-    isLoading: true,
-    error: null,
-  });
+  const { data, isLoading, error, refresh } = useFetchData<readonly GroupSummary[]>(
+    () => repository.listGroups(),
+    [repository],
+  );
 
-  const loadGroups = useCallback(async () => {
-    setState((prev) => ({ ...prev, isLoading: true, error: null }));
-    try {
-      const groups = await repository.listGroups();
-      setState({ groups, isLoading: false, error: null });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to load groups';
-      setState({ groups: [], isLoading: false, error: message });
-    }
-  }, [repository]);
-
-  useEffect(() => {
-    let cancelled = false;
-    repository.listGroups().then(groups => {
-      if (!cancelled) {
-        setState({ groups, isLoading: false, error: null });
-      }
-    }).catch((err: unknown) => {
-      if (!cancelled) {
-        const message = err instanceof Error ? err.message : 'Failed to load groups';
-        setState({ groups: [], isLoading: false, error: message });
-      }
-    });
-    return () => { cancelled = true; };
-  }, [repository]);
-
-  return { ...state, refresh: loadGroups };
+  return { groups: data ?? [], isLoading, error, refresh };
 }

--- a/web/src/features/Map/useMapData.ts
+++ b/web/src/features/Map/useMapData.ts
@@ -1,73 +1,33 @@
-import { useState, useEffect, useCallback } from 'react';
 import type { PlanningApplication, WatchZoneSummary } from '../../domain/types';
 import type { MapPort } from '../../domain/ports/map-port';
+import { useFetchData } from '../../hooks/useFetchData';
 
-interface MapDataState {
-  readonly zones: readonly WatchZoneSummary[];
-  readonly applications: readonly PlanningApplication[];
-  readonly isLoading: boolean;
-  readonly error: string | null;
+interface MapData {
+  zones: readonly WatchZoneSummary[];
+  applications: readonly PlanningApplication[];
 }
 
 export function useMapData(port: MapPort) {
-  const [state, setState] = useState<MapDataState>({
-    zones: [],
-    applications: [],
-    isLoading: true,
-    error: null,
-  });
-
-  const loadData = useCallback(async () => {
-    setState(prev => ({ ...prev, isLoading: true, error: null }));
-    try {
+  const { data, isLoading, error, refresh } = useFetchData<MapData>(
+    async () => {
       const zones = await port.fetchWatchZones();
 
       const uniqueAuthorityIds = [...new Set(zones.map(z => z.authorityId))];
-
       const applicationArrays = await Promise.all(
         uniqueAuthorityIds.map(id => port.fetchApplicationsByAuthority(id)),
       );
-
       const applications = applicationArrays.flat();
 
-      setState({
-        zones,
-        applications,
-        isLoading: false,
-        error: null,
-      });
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'An error occurred';
-      setState(prev => ({
-        ...prev,
-        isLoading: false,
-        error: message,
-      }));
-    }
-  }, [port]);
+      return { zones, applications };
+    },
+    [port],
+  );
 
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const zones = await port.fetchWatchZones();
-        const uniqueAuthorityIds = [...new Set(zones.map(z => z.authorityId))];
-        const applicationArrays = await Promise.all(
-          uniqueAuthorityIds.map(id => port.fetchApplicationsByAuthority(id)),
-        );
-        const applications = applicationArrays.flat();
-        if (!cancelled) {
-          setState({ zones, applications, isLoading: false, error: null });
-        }
-      } catch (err: unknown) {
-        if (!cancelled) {
-          const message = err instanceof Error ? err.message : 'An error occurred';
-          setState(prev => ({ ...prev, isLoading: false, error: message }));
-        }
-      }
-    })();
-    return () => { cancelled = true; };
-  }, [port]);
-
-  return { ...state, refresh: loadData };
+  return {
+    zones: data?.zones ?? [],
+    applications: data?.applications ?? [],
+    isLoading,
+    error,
+    refresh,
+  };
 }

--- a/web/src/features/Settings/useUserProfile.ts
+++ b/web/src/features/Settings/useUserProfile.ts
@@ -1,50 +1,26 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import type { SettingsRepository } from '../../domain/ports/settings-repository';
 import type { UserProfile } from '../../domain/types';
-
-interface UserProfileState {
-  profile: UserProfile | null;
-  isLoading: boolean;
-  isExporting: boolean;
-  isDeleting: boolean;
-  error: string | null;
-}
+import { useFetchData } from '../../hooks/useFetchData';
 
 export function useUserProfile(
   repository: SettingsRepository,
   logout: () => void,
 ) {
-  const [state, setState] = useState<UserProfileState>({
-    profile: null,
-    isLoading: true,
-    isExporting: false,
-    isDeleting: false,
-    error: null,
-  });
+  const [isExporting, setIsExporting] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
 
-  useEffect(() => {
-    let cancelled = false;
+  const { data: profile, isLoading, error: fetchError } = useFetchData<UserProfile>(
+    () => repository.fetchProfile(),
+    [repository],
+  );
 
-    async function load() {
-      try {
-        const profile = await repository.fetchProfile();
-        if (!cancelled) {
-          setState(prev => ({ ...prev, profile, isLoading: false }));
-        }
-      } catch (err) {
-        if (!cancelled) {
-          const message = err instanceof Error ? err.message : 'Failed to load profile';
-          setState(prev => ({ ...prev, isLoading: false, error: message }));
-        }
-      }
-    }
-
-    load();
-    return () => { cancelled = true; };
-  }, [repository]);
+  const error = actionError ?? fetchError;
 
   const exportData = useCallback(async () => {
-    setState(prev => ({ ...prev, isExporting: true, error: null }));
+    setIsExporting(true);
+    setActionError(null);
     try {
       const blob = await repository.exportData();
       const url = URL.createObjectURL(blob);
@@ -53,27 +29,34 @@ export function useUserProfile(
       link.download = 'town-crier-data.json';
       link.click();
       URL.revokeObjectURL(url);
-      setState(prev => ({ ...prev, isExporting: false }));
+      setIsExporting(false);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to export data';
-      setState(prev => ({ ...prev, isExporting: false, error: message }));
+      setIsExporting(false);
+      setActionError(message);
     }
   }, [repository]);
 
   const deleteAccount = useCallback(async () => {
-    setState(prev => ({ ...prev, isDeleting: true, error: null }));
+    setIsDeleting(true);
+    setActionError(null);
     try {
       await repository.deleteAccount();
-      setState(prev => ({ ...prev, isDeleting: false }));
+      setIsDeleting(false);
       logout();
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to delete account';
-      setState(prev => ({ ...prev, isDeleting: false, error: message }));
+      setIsDeleting(false);
+      setActionError(message);
     }
   }, [repository, logout]);
 
   return {
-    ...state,
+    profile,
+    isLoading,
+    isExporting,
+    isDeleting,
+    error,
     exportData,
     deleteAccount,
   };

--- a/web/src/features/WatchZones/useWatchZones.ts
+++ b/web/src/features/WatchZones/useWatchZones.ts
@@ -1,60 +1,30 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import type { WatchZoneSummary } from '../../domain/types';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
-
-interface WatchZonesState {
-  zones: readonly WatchZoneSummary[];
-  isLoading: boolean;
-  error: string | null;
-}
+import { useFetchData } from '../../hooks/useFetchData';
 
 export function useWatchZones(repository: WatchZoneRepository) {
-  const [state, setState] = useState<WatchZonesState>({
-    zones: [],
-    isLoading: true,
-    error: null,
-  });
+  const [actionError, setActionError] = useState<string | null>(null);
 
-  const loadZones = useCallback(async () => {
-    setState(prev => ({ ...prev, isLoading: true, error: null }));
-    try {
-      const zones = await repository.list();
-      setState({ zones, isLoading: false, error: null });
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'An error occurred';
-      setState(prev => ({ ...prev, isLoading: false, error: message }));
-    }
-  }, [repository]);
-
-  useEffect(() => {
-    let cancelled = false;
-    repository.list().then(zones => {
-      if (!cancelled) {
-        setState({ zones, isLoading: false, error: null });
-      }
-    }).catch((err: unknown) => {
-      if (!cancelled) {
-        const message = err instanceof Error ? err.message : 'An error occurred';
-        setState(prev => ({ ...prev, isLoading: false, error: message }));
-      }
-    });
-    return () => { cancelled = true; };
-  }, [repository]);
+  const { data: zones, isLoading, error: fetchError, refresh } = useFetchData<readonly WatchZoneSummary[]>(
+    () => repository.list(),
+    [repository],
+  );
 
   const deleteZone = useCallback(async (zoneId: string) => {
     try {
       await repository.delete(zoneId);
-      await loadZones();
+      refresh();
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'An error occurred';
-      setState(prev => ({ ...prev, error: message }));
+      setActionError(message);
     }
-  }, [repository, loadZones]);
+  }, [repository, refresh]);
 
   return {
-    zones: state.zones,
-    isLoading: state.isLoading,
-    error: state.error,
+    zones: zones ?? [],
+    isLoading,
+    error: actionError ?? fetchError,
     deleteZone,
   };
 }

--- a/web/src/features/WatchZones/useZonePreferences.ts
+++ b/web/src/features/WatchZones/useZonePreferences.ts
@@ -1,65 +1,36 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import type { ZoneNotificationPreferences, UpdateZonePreferencesRequest } from '../../domain/types';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
-
-interface ZonePreferencesState {
-  preferences: ZoneNotificationPreferences | null;
-  isLoading: boolean;
-  isSaving: boolean;
-  error: string | null;
-}
+import { useFetchData } from '../../hooks/useFetchData';
 
 export function useZonePreferences(repository: WatchZoneRepository, zoneId: string) {
-  const [state, setState] = useState<ZonePreferencesState>({
-    preferences: null,
-    isLoading: true,
-    isSaving: false,
-    error: null,
-  });
+  const [isSaving, setIsSaving] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
 
-  const loadPreferences = useCallback(async () => {
-    setState(prev => ({ ...prev, isLoading: true, error: null }));
-    try {
-      const preferences = await repository.getPreferences(zoneId);
-      setState({ preferences, isLoading: false, isSaving: false, error: null });
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'An error occurred';
-      setState(prev => ({ ...prev, isLoading: false, error: message }));
-    }
-  }, [repository, zoneId]);
-
-  useEffect(() => {
-    let cancelled = false;
-    repository.getPreferences(zoneId).then(preferences => {
-      if (!cancelled) {
-        setState({ preferences, isLoading: false, isSaving: false, error: null });
-      }
-    }).catch((err: unknown) => {
-      if (!cancelled) {
-        const message = err instanceof Error ? err.message : 'An error occurred';
-        setState(prev => ({ ...prev, isLoading: false, error: message }));
-      }
-    });
-    return () => { cancelled = true; };
-  }, [repository, zoneId]);
+  const { data: preferences, isLoading, error: fetchError, refresh } = useFetchData<ZoneNotificationPreferences>(
+    () => repository.getPreferences(zoneId),
+    [repository, zoneId],
+  );
 
   const updatePreferences = useCallback(async (data: UpdateZonePreferencesRequest) => {
-    setState(prev => ({ ...prev, isSaving: true, error: null }));
+    setIsSaving(true);
+    setActionError(null);
     try {
       await repository.updatePreferences(zoneId, data);
-      await loadPreferences();
-      setState(prev => ({ ...prev, isSaving: false }));
+      refresh();
+      setIsSaving(false);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : 'An error occurred';
-      setState(prev => ({ ...prev, isSaving: false, error: message }));
+      setIsSaving(false);
+      setActionError(message);
     }
-  }, [repository, zoneId, loadPreferences]);
+  }, [repository, zoneId, refresh]);
 
   return {
-    preferences: state.preferences,
-    isLoading: state.isLoading,
-    isSaving: state.isSaving,
-    error: state.error,
+    preferences,
+    isLoading,
+    isSaving,
+    error: actionError ?? fetchError,
     updatePreferences,
   };
 }

--- a/web/src/hooks/__tests__/useFetchData.test.ts
+++ b/web/src/hooks/__tests__/useFetchData.test.ts
@@ -102,6 +102,28 @@ describe('useFetchData', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('skips fetch when enabled is false', async () => {
+    let callCount = 0;
+    const fetcher = async () => {
+      callCount += 1;
+      return 'data';
+    };
+
+    const { result } = renderHook(() =>
+      useFetchData(fetcher, [], { enabled: false }),
+    );
+
+    // Should not be loading and should not have fetched
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    // Give time for any async work to complete
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(callCount).toBe(0);
+  });
+
   it('refetches when deps change', async () => {
     let callCount = 0;
     const fetcher = async () => {

--- a/web/src/hooks/__tests__/useFetchData.test.ts
+++ b/web/src/hooks/__tests__/useFetchData.test.ts
@@ -1,0 +1,22 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useFetchData } from '../useFetchData';
+
+describe('useFetchData', () => {
+  it('returns data on successful fetch', async () => {
+    const fetcher = async () => ({ name: 'Alice' });
+
+    const { result } = renderHook(() => useFetchData(fetcher, []));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual({ name: 'Alice' });
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/web/src/hooks/__tests__/useFetchData.test.ts
+++ b/web/src/hooks/__tests__/useFetchData.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { useFetchData } from '../useFetchData';
 
@@ -73,5 +73,32 @@ describe('useFetchData', () => {
     // (no state update occurred)
     expect(result.current.isLoading).toBe(true);
     expect(result.current.data).toBeNull();
+  });
+
+  it('refresh re-fetches and updates data', async () => {
+    let callCount = 0;
+    const fetcher = async () => {
+      callCount += 1;
+      return { count: callCount };
+    };
+
+    const { result } = renderHook(() => useFetchData(fetcher, []));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual({ count: 1 });
+
+    await act(async () => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual({ count: 2 });
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
   });
 });

--- a/web/src/hooks/__tests__/useFetchData.test.ts
+++ b/web/src/hooks/__tests__/useFetchData.test.ts
@@ -19,4 +19,34 @@ describe('useFetchData', () => {
     expect(result.current.data).toEqual({ name: 'Alice' });
     expect(result.current.error).toBeNull();
   });
+
+  it('sets error on fetch failure with Error instance', async () => {
+    const fetcher = async () => {
+      throw new Error('Network unavailable');
+    };
+
+    const { result } = renderHook(() => useFetchData<string>(fetcher, []));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Network unavailable');
+    expect(result.current.data).toBeNull();
+  });
+
+  it('sets fallback error message for non-Error throws', async () => {
+    const fetcher = async () => {
+      throw 'something went wrong';
+    };
+
+    const { result } = renderHook(() => useFetchData<string>(fetcher, []));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('An error occurred');
+    expect(result.current.data).toBeNull();
+  });
 });

--- a/web/src/hooks/__tests__/useFetchData.test.ts
+++ b/web/src/hooks/__tests__/useFetchData.test.ts
@@ -101,4 +101,31 @@ describe('useFetchData', () => {
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
   });
+
+  it('refetches when deps change', async () => {
+    let callCount = 0;
+    const fetcher = async () => {
+      callCount += 1;
+      return `result-${callCount}`;
+    };
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useFetchData(fetcher, [id]),
+      { initialProps: { id: 'a' } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toBe('result-1');
+
+    rerender({ id: 'b' });
+
+    await waitFor(() => {
+      expect(result.current.data).toBe('result-2');
+    });
+
+    expect(result.current.isLoading).toBe(false);
+  });
 });

--- a/web/src/hooks/__tests__/useFetchData.test.ts
+++ b/web/src/hooks/__tests__/useFetchData.test.ts
@@ -49,4 +49,29 @@ describe('useFetchData', () => {
     expect(result.current.error).toBe('An error occurred');
     expect(result.current.data).toBeNull();
   });
+
+  it('does not update state after unmount', async () => {
+    let resolvePromise: (value: string) => void;
+    const fetcher = () =>
+      new Promise<string>((resolve) => {
+        resolvePromise = resolve;
+      });
+
+    const { result, unmount } = renderHook(() => useFetchData(fetcher, []));
+
+    expect(result.current.isLoading).toBe(true);
+
+    unmount();
+
+    // Resolve after unmount — state should not update
+    resolvePromise!('late data');
+
+    // Give microtasks a chance to flush
+    await new Promise((r) => setTimeout(r, 50));
+
+    // After unmount, the last captured state should still show isLoading: true
+    // (no state update occurred)
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeNull();
+  });
 });

--- a/web/src/hooks/useFetchData.ts
+++ b/web/src/hooks/useFetchData.ts
@@ -14,6 +14,10 @@ interface FetchDataOptions {
   enabled?: boolean;
 }
 
+function extractErrorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : 'An error occurred';
+}
+
 export function useFetchData<T>(
   fetcher: () => Promise<T>,
   deps: DependencyList,
@@ -33,8 +37,7 @@ export function useFetchData<T>(
       const data = await fetcher();
       setState({ data, isLoading: false, error: null });
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'An error occurred';
-      setState(prev => ({ ...prev, isLoading: false, error: message }));
+      setState(prev => ({ ...prev, isLoading: false, error: extractErrorMessage(err) }));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
@@ -50,8 +53,7 @@ export function useFetchData<T>(
         }
       } catch (err: unknown) {
         if (!cancelled) {
-          const message = err instanceof Error ? err.message : 'An error occurred';
-          setState(prev => ({ ...prev, isLoading: false, error: message }));
+          setState(prev => ({ ...prev, isLoading: false, error: extractErrorMessage(err) }));
         }
       }
     })();

--- a/web/src/hooks/useFetchData.ts
+++ b/web/src/hooks/useFetchData.ts
@@ -1,0 +1,55 @@
+import { useState, useEffect, useCallback, type DependencyList } from 'react';
+
+interface FetchDataState<T> {
+  data: T | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+interface FetchDataResult<T> extends FetchDataState<T> {
+  refresh: () => void;
+}
+
+export function useFetchData<T>(
+  fetcher: () => Promise<T>,
+  deps: DependencyList,
+): FetchDataResult<T> {
+  const [state, setState] = useState<FetchDataState<T>>({
+    data: null,
+    isLoading: true,
+    error: null,
+  });
+
+  const load = useCallback(async () => {
+    setState(prev => ({ ...prev, isLoading: true, error: null }));
+    try {
+      const data = await fetcher();
+      setState({ data, isLoading: false, error: null });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'An error occurred';
+      setState(prev => ({ ...prev, isLoading: false, error: message }));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await fetcher();
+        if (!cancelled) {
+          setState({ data, isLoading: false, error: null });
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : 'An error occurred';
+          setState(prev => ({ ...prev, isLoading: false, error: message }));
+        }
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+
+  return { ...state, refresh: load };
+}

--- a/web/src/hooks/useFetchData.ts
+++ b/web/src/hooks/useFetchData.ts
@@ -10,13 +10,20 @@ interface FetchDataResult<T> extends FetchDataState<T> {
   refresh: () => void;
 }
 
+interface FetchDataOptions {
+  enabled?: boolean;
+}
+
 export function useFetchData<T>(
   fetcher: () => Promise<T>,
   deps: DependencyList,
+  options?: FetchDataOptions,
 ): FetchDataResult<T> {
+  const enabled = options?.enabled ?? true;
+
   const [state, setState] = useState<FetchDataState<T>>({
     data: null,
-    isLoading: true,
+    isLoading: enabled,
     error: null,
   });
 
@@ -33,6 +40,7 @@ export function useFetchData<T>(
   }, deps);
 
   useEffect(() => {
+    if (!enabled) return;
     let cancelled = false;
     (async () => {
       try {
@@ -49,7 +57,7 @@ export function useFetchData<T>(
     })();
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, deps);
+  }, [enabled, ...deps]);
 
   return { ...state, refresh: load };
 }

--- a/web/src/utils/__tests__/formatting.test.ts
+++ b/web/src/utils/__tests__/formatting.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { formatDate } from '../formatting';
+
+describe('formatDate', () => {
+  it('formats an ISO date string as "day month year" in en-GB locale', () => {
+    const result = formatDate('2026-01-15');
+
+    expect(result).toBe('15 Jan 2026');
+  });
+});

--- a/web/src/utils/__tests__/formatting.test.ts
+++ b/web/src/utils/__tests__/formatting.test.ts
@@ -1,10 +1,31 @@
 import { describe, it, expect } from 'vitest';
-import { formatDate } from '../formatting';
+import { formatDate, statusClassName } from '../formatting';
 
 describe('formatDate', () => {
   it('formats an ISO date string as "day month year" in en-GB locale', () => {
     const result = formatDate('2026-01-15');
 
     expect(result).toBe('15 Jan 2026');
+  });
+});
+
+describe('statusClassName', () => {
+  const fakeStyles: Record<string, string> = {
+    statusUndecided: 'statusUndecided_abc123',
+    statusApproved: 'statusApproved_abc123',
+    statusRefused: 'statusRefused_abc123',
+    statusWithdrawn: 'statusWithdrawn_abc123',
+    statusAppealed: 'statusAppealed_abc123',
+    statusNotAvailable: 'statusNotAvailable_abc123',
+    statusDefault: 'statusDefault_abc123',
+  };
+
+  it('returns the correct class for each known application status', () => {
+    expect(statusClassName('Undecided', fakeStyles)).toBe('statusUndecided_abc123');
+    expect(statusClassName('Approved', fakeStyles)).toBe('statusApproved_abc123');
+    expect(statusClassName('Refused', fakeStyles)).toBe('statusRefused_abc123');
+    expect(statusClassName('Withdrawn', fakeStyles)).toBe('statusWithdrawn_abc123');
+    expect(statusClassName('Appealed', fakeStyles)).toBe('statusAppealed_abc123');
+    expect(statusClassName('Not Available', fakeStyles)).toBe('statusNotAvailable_abc123');
   });
 });

--- a/web/src/utils/__tests__/formatting.test.ts
+++ b/web/src/utils/__tests__/formatting.test.ts
@@ -28,4 +28,16 @@ describe('statusClassName', () => {
     expect(statusClassName('Appealed', fakeStyles)).toBe('statusAppealed_abc123');
     expect(statusClassName('Not Available', fakeStyles)).toBe('statusNotAvailable_abc123');
   });
+
+  it('returns the statusDefault class for an unknown status', () => {
+    expect(statusClassName('SomeUnknownStatus', fakeStyles)).toBe('statusDefault_abc123');
+  });
+
+  it('returns an empty string when unknown status and no statusDefault in styles', () => {
+    const stylesWithoutDefault: Record<string, string> = {
+      statusUndecided: 'statusUndecided_abc123',
+    };
+
+    expect(statusClassName('SomeUnknownStatus', stylesWithoutDefault)).toBe('');
+  });
 });

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -6,3 +6,23 @@ export function formatDate(isoDate: string): string {
     year: 'numeric',
   });
 }
+
+const STATUS_CLASS_MAP: Record<string, string> = {
+  Undecided: 'statusUndecided',
+  Approved: 'statusApproved',
+  Refused: 'statusRefused',
+  Withdrawn: 'statusWithdrawn',
+  Appealed: 'statusAppealed',
+  'Not Available': 'statusNotAvailable',
+};
+
+export function statusClassName(
+  appState: string,
+  styles: Record<string, string | undefined>,
+): string {
+  const key = STATUS_CLASS_MAP[appState];
+  if (key !== undefined) {
+    return styles[key] ?? '';
+  }
+  return styles['statusDefault'] ?? '';
+}

--- a/web/src/utils/formatting.ts
+++ b/web/src/utils/formatting.ts
@@ -1,0 +1,8 @@
+export function formatDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  return date.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}


### PR DESCRIPTION
## Changes

### Web — shared formatting utils (`utils/formatting.ts`)
- Extract `formatDate` and `statusClassName` to shared module with full TDD coverage

### Web — `useFetchData` custom hook
- New generic data-fetching hook with enabled/deps/refresh/unmount-safety support
- Migrate 10 existing hooks to `useFetchData`, eliminating duplication
- Extract `extractErrorMessage` helper

### iOS — shared formatters
- Extract `Date+TownCrier` extension and `formatRadius` utility with TDD
- Remove dead `hasChecked` property from `ForceUpdateViewModel`

### .NET API — Cosmos REST client
- Register `ICosmosRestClient` via `AddCosmosRestClient` with auth provider, options, and named HTTP client
- Config validation tests for missing `AccountEndpoint` and `DatabaseName`
- Remove unused `AddCosmosClient` method; add `appsettings.Development.json`

### Infra
- Fix autopilot `BEADS_DIR` propagation to worktree workers

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added REST-based Cosmos client integration with HTTP resilience and retry policies for improved reliability
  * Introduced `useFetchData` hook for centralized data fetching and state management
  * Added shared date and radius formatting utilities for consistent display across the app

* **Refactoring**
  * Migrated Cosmos connectivity from SDK client to REST API
  * Consolidated date formatting logic into reusable utilities
  * Simplified data-fetching patterns across multiple hooks
  * Updated worker configuration for improved database access

* **Tests**
  * Added comprehensive test coverage for new formatting utilities and data-fetching hook
  * Updated tests to reflect configuration and architecture changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->