### PR TITLE
feat(api): migrate all 9 Cosmos repositories to REST client

### DIFF
--- a/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using Azure.Identity;
-using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
@@ -61,11 +60,6 @@ public static class CosmosServiceExtensions
             var opts = sp.GetRequiredService<CosmosRestOptions>();
             return new CosmosRestClient(httpClient, auth, opts);
         });
-
-        // Backward compat: existing repos still depend on CosmosClient via SDK.
-        // Remove once all repos are migrated to ICosmosRestClient (tc-pgp.3).
-        services.AddSingleton(_ =>
-            CosmosClientFactory.Create(accountEndpoint, new DefaultAzureCredential()));
 
         return services;
     }

--- a/api/src/town-crier.infrastructure/DecisionAlerts/CosmosDecisionAlertRepository.cs
+++ b/api/src/town-crier.infrastructure/DecisionAlerts/CosmosDecisionAlertRepository.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using Microsoft.Azure.Cosmos;
 using TownCrier.Application.DecisionAlerts;
 using TownCrier.Domain.DecisionAlerts;
 using TownCrier.Infrastructure.Cosmos;
@@ -8,12 +6,12 @@ namespace TownCrier.Infrastructure.DecisionAlerts;
 
 public sealed class CosmosDecisionAlertRepository : IDecisionAlertRepository
 {
-    private readonly Container container;
+    private readonly ICosmosRestClient client;
 
-    public CosmosDecisionAlertRepository(CosmosClient client)
+    public CosmosDecisionAlertRepository(ICosmosRestClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.DecisionAlerts);
+        this.client = client;
     }
 
     public async Task<DecisionAlert?> GetByUserAndApplicationAsync(
@@ -21,19 +19,14 @@ public sealed class CosmosDecisionAlertRepository : IDecisionAlertRepository
     {
         var documentId = DecisionAlertDocument.MakeId(userId, applicationUid);
 
-        try
-        {
-            var response = await this.container.ReadItemAsync<DecisionAlertDocument>(
-                documentId,
-                new PartitionKey(userId),
-                cancellationToken: ct).ConfigureAwait(false);
+        var document = await this.client.ReadDocumentAsync(
+            CosmosContainerNames.DecisionAlerts,
+            documentId,
+            userId,
+            CosmosJsonSerializerContext.Default.DecisionAlertDocument,
+            ct).ConfigureAwait(false);
 
-            return response.Resource.ToDomain();
-        }
-        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-        {
-            return null;
-        }
+        return document?.ToDomain();
     }
 
     public async Task SaveAsync(DecisionAlert alert, CancellationToken ct)
@@ -42,9 +35,11 @@ public sealed class CosmosDecisionAlertRepository : IDecisionAlertRepository
 
         var document = DecisionAlertDocument.FromDomain(alert);
 
-        await this.container.UpsertItemAsync(
+        await this.client.UpsertDocumentAsync(
+            CosmosContainerNames.DecisionAlerts,
             document,
-            new PartitionKey(document.UserId),
-            cancellationToken: ct).ConfigureAwait(false);
+            document.UserId,
+            CosmosJsonSerializerContext.Default.DecisionAlertDocument,
+            ct).ConfigureAwait(false);
     }
 }

--- a/api/src/town-crier.infrastructure/DeviceRegistrations/CosmosDeviceRegistrationRepository.cs
+++ b/api/src/town-crier.infrastructure/DeviceRegistrations/CosmosDeviceRegistrationRepository.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using Microsoft.Azure.Cosmos;
 using TownCrier.Application.DeviceRegistrations;
 using TownCrier.Domain.DeviceRegistrations;
 using TownCrier.Infrastructure.Cosmos;
@@ -8,39 +6,38 @@ namespace TownCrier.Infrastructure.DeviceRegistrations;
 
 public sealed class CosmosDeviceRegistrationRepository : IDeviceRegistrationRepository
 {
-    private readonly Container container;
+    private readonly ICosmosRestClient client;
 
-    public CosmosDeviceRegistrationRepository(CosmosClient client)
+    public CosmosDeviceRegistrationRepository(ICosmosRestClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.DeviceRegistrations);
+        this.client = client;
     }
 
     public async Task<DeviceRegistration?> GetByTokenAsync(string token, CancellationToken ct)
     {
-        var query = new QueryDefinition("SELECT * FROM c WHERE c.token = @token")
-            .WithParameter("@token", token);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.DeviceRegistrations,
+            "SELECT * FROM c WHERE c.token = @token",
+            [new QueryParameter("@token", token)],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.DeviceRegistrationDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<DeviceRegistrationDocument>(
-            query,
-            requestOptions: new QueryRequestOptions { MaxItemCount = 1 });
-
-        return await iterator.FirstOrDefaultAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.Count > 0 ? documents[0].ToDomain() : null;
     }
 
     public async Task<IReadOnlyList<DeviceRegistration>> GetByUserIdAsync(string userId, CancellationToken ct)
     {
-        var query = new QueryDefinition("SELECT * FROM c WHERE c.userId = @userId")
-            .WithParameter("@userId", userId);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.DeviceRegistrations,
+            "SELECT * FROM c WHERE c.userId = @userId",
+            [new QueryParameter("@userId", userId)],
+            userId,
+            CosmosJsonSerializerContext.Default.DeviceRegistrationDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<DeviceRegistrationDocument>(
-            query,
-            requestOptions: new QueryRequestOptions
-            {
-                PartitionKey = new PartitionKey(userId),
-            });
-
-        return await iterator.CollectAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.ConvertAll(doc => doc.ToDomain());
     }
 
     public async Task SaveAsync(DeviceRegistration registration, CancellationToken ct)
@@ -49,36 +46,33 @@ public sealed class CosmosDeviceRegistrationRepository : IDeviceRegistrationRepo
 
         var document = DeviceRegistrationDocument.FromDomain(registration);
 
-        await this.container.UpsertItemAsync(
+        await this.client.UpsertDocumentAsync(
+            CosmosContainerNames.DeviceRegistrations,
             document,
-            new PartitionKey(document.UserId),
-            cancellationToken: ct).ConfigureAwait(false);
+            document.UserId,
+            CosmosJsonSerializerContext.Default.DeviceRegistrationDocument,
+            ct).ConfigureAwait(false);
     }
 
     public async Task DeleteByTokenAsync(string token, CancellationToken ct)
     {
         // Token is not the partition key, so we must find the document first
         // to get the userId (partition key) needed for deletion.
-        var query = new QueryDefinition("SELECT c.id, c.userId FROM c WHERE c.token = @token")
-            .WithParameter("@token", token);
-
-        using var iterator = this.container.GetItemQueryIterator<DeviceRegistrationDocument>(query);
-
-        var documents = await iterator.CollectAsync(ct).ConfigureAwait(false);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.DeviceRegistrations,
+            "SELECT c.id, c.userId FROM c WHERE c.token = @token",
+            [new QueryParameter("@token", token)],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.DeviceRegistrationDocument,
+            ct).ConfigureAwait(false);
 
         foreach (var document in documents)
         {
-            try
-            {
-                await this.container.DeleteItemAsync<DeviceRegistrationDocument>(
-                    document.Id,
-                    new PartitionKey(document.UserId),
-                    cancellationToken: ct).ConfigureAwait(false);
-            }
-            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-            {
-                // Already deleted — idempotent
-            }
+            await this.client.DeleteDocumentAsync(
+                CosmosContainerNames.DeviceRegistrations,
+                document.Id,
+                document.UserId,
+                ct).ConfigureAwait(false);
         }
     }
 }

--- a/api/src/town-crier.infrastructure/Groups/CosmosGroupInvitationRepository.cs
+++ b/api/src/town-crier.infrastructure/Groups/CosmosGroupInvitationRepository.cs
@@ -1,4 +1,3 @@
-using Microsoft.Azure.Cosmos;
 using TownCrier.Application.Groups;
 using TownCrier.Domain.Groups;
 using TownCrier.Infrastructure.Cosmos;
@@ -7,45 +6,49 @@ namespace TownCrier.Infrastructure.Groups;
 
 public sealed class CosmosGroupInvitationRepository : IGroupInvitationRepository
 {
-    private readonly Container container;
+    private readonly ICosmosRestClient client;
 
-    public CosmosGroupInvitationRepository(CosmosClient client)
+    public CosmosGroupInvitationRepository(ICosmosRestClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.Groups);
+        this.client = client;
     }
 
     public async Task<GroupInvitation?> GetByIdAsync(string invitationId, CancellationToken ct)
     {
-        var query = new QueryDefinition(
-            "SELECT * FROM c WHERE c.id = @id AND c.type = 'invitation'")
-            .WithParameter("@id", GroupInvitationDocument.ToDocumentId(invitationId));
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Groups,
+            "SELECT * FROM c WHERE c.id = @id AND c.type = 'invitation'",
+            [new QueryParameter("@id", GroupInvitationDocument.ToDocumentId(invitationId))],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.GroupInvitationDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<GroupInvitationDocument>(
-            query,
-            requestOptions: new QueryRequestOptions { MaxItemCount = 1 });
-
-        return await iterator.FirstOrDefaultAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.Count > 0 ? documents[0].ToDomain() : null;
     }
 
     public async Task SaveAsync(GroupInvitation invitation, CancellationToken ct)
     {
         var document = GroupInvitationDocument.FromDomain(invitation);
-        await this.container.UpsertItemAsync(
+        await this.client.UpsertDocumentAsync(
+            CosmosContainerNames.Groups,
             document,
-            new PartitionKey(document.OwnerId),
-            cancellationToken: ct).ConfigureAwait(false);
+            document.OwnerId,
+            CosmosJsonSerializerContext.Default.GroupInvitationDocument,
+            ct).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<GroupInvitation>> GetPendingByGroupIdAsync(string groupId, CancellationToken ct)
     {
-        var query = new QueryDefinition(
-            "SELECT * FROM c WHERE c.type = 'invitation' AND c.groupId = @groupId AND c.status = 'Pending'")
-            .WithParameter("@groupId", groupId);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Groups,
+            "SELECT * FROM c WHERE c.type = 'invitation' AND c.groupId = @groupId AND c.status = 'Pending'",
+            [new QueryParameter("@groupId", groupId)],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.GroupInvitationDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<GroupInvitationDocument>(query);
-
-        return await iterator.CollectAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.ConvertAll(doc => doc.ToDomain());
     }
 
     public async Task<IReadOnlyList<GroupInvitation>> GetPendingByEmailAsync(string email, CancellationToken ct)
@@ -56,12 +59,14 @@ public sealed class CosmosGroupInvitationRepository : IGroupInvitationRepository
         var normalizedEmail = email.Trim().ToLowerInvariant();
 #pragma warning restore CA1308
 
-        var query = new QueryDefinition(
-            "SELECT * FROM c WHERE c.type = 'invitation' AND LOWER(c.inviteeEmail) = @email AND c.status = 'Pending'")
-            .WithParameter("@email", normalizedEmail);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Groups,
+            "SELECT * FROM c WHERE c.type = 'invitation' AND LOWER(c.inviteeEmail) = @email AND c.status = 'Pending'",
+            [new QueryParameter("@email", normalizedEmail)],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.GroupInvitationDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<GroupInvitationDocument>(query);
-
-        return await iterator.CollectAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.ConvertAll(doc => doc.ToDomain());
     }
 }

--- a/api/src/town-crier.infrastructure/Groups/CosmosGroupRepository.cs
+++ b/api/src/town-crier.infrastructure/Groups/CosmosGroupRepository.cs
@@ -1,4 +1,3 @@
-using Microsoft.Azure.Cosmos;
 using TownCrier.Application.Groups;
 using TownCrier.Domain.Groups;
 using TownCrier.Infrastructure.Cosmos;
@@ -7,64 +6,73 @@ namespace TownCrier.Infrastructure.Groups;
 
 public sealed class CosmosGroupRepository : IGroupRepository
 {
-    private readonly Container container;
+    private readonly ICosmosRestClient client;
 
-    public CosmosGroupRepository(CosmosClient client)
+    public CosmosGroupRepository(ICosmosRestClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.Groups);
+        this.client = client;
     }
 
     public async Task<Group?> GetByIdAsync(string groupId, CancellationToken ct)
     {
-        var query = new QueryDefinition(
-            "SELECT * FROM c WHERE c.id = @id AND c.type = 'group'")
-            .WithParameter("@id", groupId);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Groups,
+            "SELECT * FROM c WHERE c.id = @id AND c.type = 'group'",
+            [new QueryParameter("@id", groupId)],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.GroupDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<GroupDocument>(
-            query,
-            requestOptions: new QueryRequestOptions { MaxItemCount = 1 });
-
-        return await iterator.FirstOrDefaultAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.Count > 0 ? documents[0].ToDomain() : null;
     }
 
     public async Task SaveAsync(Group group, CancellationToken ct)
     {
         var document = GroupDocument.FromDomain(group);
-        await this.container.UpsertItemAsync(
+        await this.client.UpsertDocumentAsync(
+            CosmosContainerNames.Groups,
             document,
-            new PartitionKey(document.OwnerId),
-            cancellationToken: ct).ConfigureAwait(false);
+            document.OwnerId,
+            CosmosJsonSerializerContext.Default.GroupDocument,
+            ct).ConfigureAwait(false);
     }
 
     public async Task DeleteAsync(string groupId, CancellationToken ct)
     {
-        var query = new QueryDefinition(
-            "SELECT c.id, c.ownerId FROM c WHERE c.id = @id AND c.type = 'group'")
-            .WithParameter("@id", groupId);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Groups,
+            "SELECT c.id, c.ownerId FROM c WHERE c.id = @id AND c.type = 'group'",
+            [new QueryParameter("@id", groupId)],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.GroupDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<GroupDocument>(
-            query,
-            requestOptions: new QueryRequestOptions { MaxItemCount = 1 });
-
-        var document = await iterator.FirstOrDefaultAsync(doc => doc, ct).ConfigureAwait(false);
-        if (document is not null)
+        if (documents.Count > 0)
         {
-            await this.container.DeleteItemAsync<GroupDocument>(
+            var document = documents[0];
+            await this.client.DeleteDocumentAsync(
+                CosmosContainerNames.Groups,
                 document.Id,
-                new PartitionKey(document.OwnerId),
-                cancellationToken: ct).ConfigureAwait(false);
+                document.OwnerId,
+                ct).ConfigureAwait(false);
         }
     }
 
     public async Task<IReadOnlyList<Group>> GetByUserIdAsync(string userId, CancellationToken ct)
     {
-        var query = new QueryDefinition(
-            "SELECT * FROM c WHERE c.type = 'group' AND ARRAY_CONTAINS(c.members, {\"userId\": @userId}, true)")
-            .WithParameter("@userId", userId);
+        const string sql =
+            "SELECT * FROM c WHERE c.type = 'group' " +
+            "AND ARRAY_CONTAINS(c.members, {\"userId\": @userId}, true)";
 
-        using var iterator = this.container.GetItemQueryIterator<GroupDocument>(query);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Groups,
+            sql,
+            [new QueryParameter("@userId", userId)],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.GroupDocument,
+            ct).ConfigureAwait(false);
 
-        return await iterator.CollectAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.ConvertAll(doc => doc.ToDomain());
     }
 }

--- a/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
@@ -1,4 +1,3 @@
-using Microsoft.Azure.Cosmos;
 using TownCrier.Application.Notifications;
 using TownCrier.Domain.Notifications;
 using TownCrier.Infrastructure.Cosmos;
@@ -7,30 +6,26 @@ namespace TownCrier.Infrastructure.Notifications;
 
 public sealed class CosmosNotificationRepository : INotificationRepository
 {
-    private readonly Container container;
+    private readonly ICosmosRestClient client;
 
-    public CosmosNotificationRepository(CosmosClient client)
+    public CosmosNotificationRepository(ICosmosRestClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.Notifications);
+        this.client = client;
     }
 
     public async Task<Notification?> GetByUserAndApplicationAsync(
         string userId, string applicationName, CancellationToken ct)
     {
-        var query = new QueryDefinition(
-            "SELECT * FROM c WHERE c.userId = @userId AND c.applicationName = @appName")
-            .WithParameter("@userId", userId)
-            .WithParameter("@appName", applicationName);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Notifications,
+            "SELECT * FROM c WHERE c.userId = @userId AND c.applicationName = @appName",
+            [new QueryParameter("@userId", userId), new QueryParameter("@appName", applicationName)],
+            userId,
+            CosmosJsonSerializerContext.Default.NotificationDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<NotificationDocument>(
-            query,
-            requestOptions: new QueryRequestOptions
-            {
-                PartitionKey = new PartitionKey(userId),
-            });
-
-        return await iterator.FirstOrDefaultAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.Count > 0 ? documents[0].ToDomain() : null;
     }
 
     public async Task<int> CountByUserInMonthAsync(
@@ -39,80 +34,64 @@ public sealed class CosmosNotificationRepository : INotificationRepository
         var startOfMonth = new DateTimeOffset(year, month, 1, 0, 0, 0, TimeSpan.Zero);
         var startOfNextMonth = startOfMonth.AddMonths(1);
 
-        var query = new QueryDefinition(
-            "SELECT VALUE COUNT(1) FROM c WHERE c.userId = @userId AND c.createdAt >= @start AND c.createdAt < @end")
-            .WithParameter("@userId", userId)
-            .WithParameter("@start", startOfMonth)
-            .WithParameter("@end", startOfNextMonth);
-
-        using var iterator = this.container.GetItemQueryIterator<int>(
-            query,
-            requestOptions: new QueryRequestOptions
-            {
-                PartitionKey = new PartitionKey(userId),
-            });
-
-        return await iterator.ScalarAsync(ct).ConfigureAwait(false);
+        return await this.client.ScalarQueryAsync(
+            CosmosContainerNames.Notifications,
+            "SELECT VALUE COUNT(1) FROM c WHERE c.userId = @userId AND c.createdAt >= @start AND c.createdAt < @end",
+            [
+                new QueryParameter("@userId", userId),
+                new QueryParameter("@start", startOfMonth),
+                new QueryParameter("@end", startOfNextMonth),
+            ],
+            userId,
+            CosmosJsonSerializerContext.Default.Int32,
+            ct).ConfigureAwait(false);
     }
 
     public async Task<int> CountByUserSinceAsync(
         string userId, DateTimeOffset since, CancellationToken ct)
     {
-        var query = new QueryDefinition(
-            "SELECT VALUE COUNT(1) FROM c WHERE c.userId = @userId AND c.createdAt >= @since")
-            .WithParameter("@userId", userId)
-            .WithParameter("@since", since);
-
-        using var iterator = this.container.GetItemQueryIterator<int>(
-            query,
-            requestOptions: new QueryRequestOptions
-            {
-                PartitionKey = new PartitionKey(userId),
-            });
-
-        return await iterator.ScalarAsync(ct).ConfigureAwait(false);
+        return await this.client.ScalarQueryAsync(
+            CosmosContainerNames.Notifications,
+            "SELECT VALUE COUNT(1) FROM c WHERE c.userId = @userId AND c.createdAt >= @since",
+            [new QueryParameter("@userId", userId), new QueryParameter("@since", since)],
+            userId,
+            CosmosJsonSerializerContext.Default.Int32,
+            ct).ConfigureAwait(false);
     }
 
     public async Task<(IReadOnlyList<Notification> Items, int Total)> GetByUserPaginatedAsync(
         string userId, int page, int pageSize, CancellationToken ct)
     {
         // Count total notifications for this user
-        var countQuery = new QueryDefinition(
-            "SELECT VALUE COUNT(1) FROM c WHERE c.userId = @userId")
-            .WithParameter("@userId", userId);
-
-        int total;
-        using (var countIterator = this.container.GetItemQueryIterator<int>(
-            countQuery,
-            requestOptions: new QueryRequestOptions
-            {
-                PartitionKey = new PartitionKey(userId),
-            }))
-        {
-            total = await countIterator.ScalarAsync(ct).ConfigureAwait(false);
-        }
+        var total = await this.client.ScalarQueryAsync(
+            CosmosContainerNames.Notifications,
+            "SELECT VALUE COUNT(1) FROM c WHERE c.userId = @userId",
+            [new QueryParameter("@userId", userId)],
+            userId,
+            CosmosJsonSerializerContext.Default.Int32,
+            ct).ConfigureAwait(false);
 
         if (total == 0)
         {
             return (Array.Empty<Notification>(), 0);
         }
 
-        // Fetch page — reverse-chronological by _ts
+        // Fetch page -- reverse-chronological by _ts
         var offset = (page - 1) * pageSize;
-        var itemsQuery = new QueryDefinition(
-            "SELECT * FROM c WHERE c.userId = @userId ORDER BY c._ts DESC OFFSET @offset LIMIT @limit")
-            .WithParameter("@userId", userId)
-            .WithParameter("@offset", offset)
-            .WithParameter("@limit", pageSize);
 
-        using var itemsIterator = this.container.GetItemQueryIterator<NotificationDocument>(
-            itemsQuery,
-            requestOptions: new QueryRequestOptions
-            {
-                PartitionKey = new PartitionKey(userId),
-            });
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Notifications,
+            "SELECT * FROM c WHERE c.userId = @userId ORDER BY c._ts DESC OFFSET @offset LIMIT @limit",
+            [
+                new QueryParameter("@userId", userId),
+                new QueryParameter("@offset", offset),
+                new QueryParameter("@limit", pageSize),
+            ],
+            userId,
+            CosmosJsonSerializerContext.Default.NotificationDocument,
+            ct).ConfigureAwait(false);
 
-        var items = await itemsIterator.CollectAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        var items = documents.ConvertAll(doc => doc.ToDomain());
 
         return (items, total);
     }
@@ -122,9 +101,11 @@ public sealed class CosmosNotificationRepository : INotificationRepository
         ArgumentNullException.ThrowIfNull(notification);
         var document = NotificationDocument.FromDomain(notification);
 
-        await this.container.UpsertItemAsync(
+        await this.client.UpsertDocumentAsync(
+            CosmosContainerNames.Notifications,
             document,
-            new PartitionKey(document.UserId),
-            cancellationToken: ct).ConfigureAwait(false);
+            document.UserId,
+            CosmosJsonSerializerContext.Default.NotificationDocument,
+            ct).ConfigureAwait(false);
     }
 }

--- a/api/src/town-crier.infrastructure/PlanningApplications/CosmosPlanningApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/PlanningApplications/CosmosPlanningApplicationRepository.cs
@@ -1,4 +1,3 @@
-using Microsoft.Azure.Cosmos;
 using TownCrier.Application.PlanningApplications;
 using TownCrier.Domain.PlanningApplications;
 using TownCrier.Infrastructure.Cosmos;
@@ -7,12 +6,12 @@ namespace TownCrier.Infrastructure.PlanningApplications;
 
 public sealed class CosmosPlanningApplicationRepository : IPlanningApplicationRepository
 {
-    private readonly Container container;
+    private readonly ICosmosRestClient client;
 
-    public CosmosPlanningApplicationRepository(CosmosClient client)
+    public CosmosPlanningApplicationRepository(ICosmosRestClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.Applications);
+        this.client = client;
     }
 
     public async Task UpsertAsync(PlanningApplication application, CancellationToken ct)
@@ -20,37 +19,42 @@ public sealed class CosmosPlanningApplicationRepository : IPlanningApplicationRe
         ArgumentNullException.ThrowIfNull(application);
 
         var document = PlanningApplicationDocument.FromDomain(application);
-        await this.container.UpsertItemAsync(
+        await this.client.UpsertDocumentAsync(
+            CosmosContainerNames.Applications,
             document,
-            new PartitionKey(document.AuthorityCode),
-            cancellationToken: ct).ConfigureAwait(false);
+            document.AuthorityCode,
+            CosmosJsonSerializerContext.Default.PlanningApplicationDocument,
+            ct).ConfigureAwait(false);
     }
 
     public async Task<PlanningApplication?> GetByUidAsync(string uid, CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(uid);
 
-        var query = new QueryDefinition("SELECT * FROM c WHERE c.Uid = @uid")
-            .WithParameter("@uid", uid);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Applications,
+            "SELECT * FROM c WHERE c.Uid = @uid",
+            [new QueryParameter("@uid", uid)],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.PlanningApplicationDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<PlanningApplicationDocument>(query);
-
-        return await iterator.FirstOrDefaultAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.Count > 0 ? documents[0].ToDomain() : null;
     }
 
     public async Task<IReadOnlyCollection<PlanningApplication>> GetByAuthorityIdAsync(int authorityId, CancellationToken ct)
     {
         var authorityCode = authorityId.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
-        var query = new QueryDefinition("SELECT * FROM c");
-        var requestOptions = new QueryRequestOptions
-        {
-            PartitionKey = new PartitionKey(authorityCode),
-        };
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Applications,
+            "SELECT * FROM c",
+            parameters: null,
+            authorityCode,
+            CosmosJsonSerializerContext.Default.PlanningApplicationDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<PlanningApplicationDocument>(query, requestOptions: requestOptions);
-
-        return await iterator.CollectAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.ConvertAll(doc => doc.ToDomain());
     }
 
     public async Task<IReadOnlyCollection<PlanningApplication>> FindNearbyAsync(
@@ -58,19 +62,22 @@ public sealed class CosmosPlanningApplicationRepository : IPlanningApplicationRe
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(authorityCode);
 
-        var query = new QueryDefinition(
-            "SELECT * FROM c WHERE ST_DISTANCE(c.location, {\"type\": \"Point\", \"coordinates\": [@lng, @lat]}) <= @radius")
-            .WithParameter("@lng", longitude)
-            .WithParameter("@lat", latitude)
-            .WithParameter("@radius", radiusMetres);
+        const string sql =
+            "SELECT * FROM c WHERE ST_DISTANCE(c.location, " +
+            "{\"type\": \"Point\", \"coordinates\": [@lng, @lat]}) <= @radius";
 
-        var requestOptions = new QueryRequestOptions
-        {
-            PartitionKey = new PartitionKey(authorityCode),
-        };
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Applications,
+            sql,
+            [
+                new QueryParameter("@lng", longitude),
+                new QueryParameter("@lat", latitude),
+                new QueryParameter("@radius", radiusMetres),
+            ],
+            authorityCode,
+            CosmosJsonSerializerContext.Default.PlanningApplicationDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<PlanningApplicationDocument>(query, requestOptions: requestOptions);
-
-        return await iterator.CollectAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.ConvertAll(doc => doc.ToDomain());
     }
 }

--- a/api/src/town-crier.infrastructure/SavedApplications/CosmosSavedApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/SavedApplications/CosmosSavedApplicationRepository.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using Microsoft.Azure.Cosmos;
 using TownCrier.Application.SavedApplications;
 using TownCrier.Domain.SavedApplications;
 using TownCrier.Infrastructure.Cosmos;
@@ -8,12 +6,12 @@ namespace TownCrier.Infrastructure.SavedApplications;
 
 public sealed class CosmosSavedApplicationRepository : ISavedApplicationRepository
 {
-    private readonly Container container;
+    private readonly ICosmosRestClient client;
 
-    public CosmosSavedApplicationRepository(CosmosClient client)
+    public CosmosSavedApplicationRepository(ICosmosRestClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.SavedApplications);
+        this.client = client;
     }
 
     public async Task SaveAsync(SavedApplication savedApplication, CancellationToken ct)
@@ -21,68 +19,60 @@ public sealed class CosmosSavedApplicationRepository : ISavedApplicationReposito
         ArgumentNullException.ThrowIfNull(savedApplication);
 
         var document = SavedApplicationDocument.FromDomain(savedApplication);
-        await this.container.UpsertItemAsync(
+        await this.client.UpsertDocumentAsync(
+            CosmosContainerNames.SavedApplications,
             document,
-            new PartitionKey(document.UserId),
-            cancellationToken: ct).ConfigureAwait(false);
+            document.UserId,
+            CosmosJsonSerializerContext.Default.SavedApplicationDocument,
+            ct).ConfigureAwait(false);
     }
 
     public async Task DeleteAsync(string userId, string applicationUid, CancellationToken ct)
     {
         var id = SavedApplicationDocument.MakeId(userId, applicationUid);
 
-        try
-        {
-            await this.container.DeleteItemAsync<SavedApplicationDocument>(
-                id,
-                new PartitionKey(userId),
-                cancellationToken: ct).ConfigureAwait(false);
-        }
-        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-        {
-            // Idempotent delete — item already removed
-        }
+        await this.client.DeleteDocumentAsync(
+            CosmosContainerNames.SavedApplications,
+            id,
+            userId,
+            ct).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyList<SavedApplication>> GetByUserIdAsync(string userId, CancellationToken ct)
     {
-        var query = new QueryDefinition("SELECT * FROM c WHERE c.userId = @userId")
-            .WithParameter("@userId", userId);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.SavedApplications,
+            "SELECT * FROM c WHERE c.userId = @userId",
+            [new QueryParameter("@userId", userId)],
+            userId,
+            CosmosJsonSerializerContext.Default.SavedApplicationDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<SavedApplicationDocument>(
-            query,
-            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(userId) });
-
-        return await iterator.CollectAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.ConvertAll(doc => doc.ToDomain());
     }
 
     public async Task<bool> ExistsAsync(string userId, string applicationUid, CancellationToken ct)
     {
         var id = SavedApplicationDocument.MakeId(userId, applicationUid);
 
-        try
-        {
-            await this.container.ReadItemAsync<SavedApplicationDocument>(
-                id,
-                new PartitionKey(userId),
-                cancellationToken: ct).ConfigureAwait(false);
-            return true;
-        }
-        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-        {
-            return false;
-        }
+        var document = await this.client.ReadDocumentAsync(
+            CosmosContainerNames.SavedApplications,
+            id,
+            userId,
+            CosmosJsonSerializerContext.Default.SavedApplicationDocument,
+            ct).ConfigureAwait(false);
+
+        return document is not null;
     }
 
     public async Task<IReadOnlyList<string>> GetUserIdsByApplicationUidAsync(string applicationUid, CancellationToken ct)
     {
-        var query = new QueryDefinition("SELECT VALUE c.userId FROM c WHERE c.applicationUid = @applicationUid")
-            .WithParameter("@applicationUid", applicationUid);
-
-        using var iterator = this.container.GetItemQueryIterator<string>(
-            query,
-            requestOptions: new QueryRequestOptions { PartitionKey = null });
-
-        return await iterator.CollectAsync(ct).ConfigureAwait(false);
+        return await this.client.QueryAsync(
+            CosmosContainerNames.SavedApplications,
+            "SELECT VALUE c.userId FROM c WHERE c.applicationUid = @applicationUid",
+            [new QueryParameter("@applicationUid", applicationUid)],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.String,
+            ct).ConfigureAwait(false);
     }
 }

--- a/api/src/town-crier.infrastructure/UserProfiles/CosmosUserProfileRepository.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/CosmosUserProfileRepository.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using Microsoft.Azure.Cosmos;
 using TownCrier.Application.UserProfiles;
 using TownCrier.Domain.UserProfiles;
 using TownCrier.Infrastructure.Cosmos;
@@ -8,52 +6,52 @@ namespace TownCrier.Infrastructure.UserProfiles;
 
 public sealed class CosmosUserProfileRepository : IUserProfileRepository
 {
-    private readonly Container container;
+    private readonly ICosmosRestClient client;
 
-    public CosmosUserProfileRepository(CosmosClient client)
+    public CosmosUserProfileRepository(ICosmosRestClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.Users);
+        this.client = client;
     }
 
     public async Task<UserProfile?> GetByUserIdAsync(string userId, CancellationToken ct)
     {
-        try
-        {
-            var response = await this.container.ReadItemAsync<UserProfileDocument>(
-                userId,
-                new PartitionKey(userId),
-                cancellationToken: ct).ConfigureAwait(false);
+        var document = await this.client.ReadDocumentAsync(
+            CosmosContainerNames.Users,
+            userId,
+            userId,
+            CosmosJsonSerializerContext.Default.UserProfileDocument,
+            ct).ConfigureAwait(false);
 
-            return response.Resource.ToDomain();
-        }
-        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-        {
-            return null;
-        }
+        return document?.ToDomain();
     }
 
     public async Task<IReadOnlyList<UserProfile>> GetAllByTierAsync(SubscriptionTier tier, CancellationToken ct)
     {
-        var queryDefinition = new QueryDefinition("SELECT * FROM c WHERE c.tier = @tier")
-            .WithParameter("@tier", tier.ToString());
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Users,
+            "SELECT * FROM c WHERE c.tier = @tier",
+            [new QueryParameter("@tier", tier.ToString())],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.UserProfileDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<UserProfileDocument>(queryDefinition);
-
-        return await iterator.CollectAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.ConvertAll(doc => doc.ToDomain());
     }
 
     public async Task<UserProfile?> GetByOriginalTransactionIdAsync(
         string originalTransactionId,
         CancellationToken ct)
     {
-        var queryDefinition = new QueryDefinition(
-            "SELECT * FROM c WHERE c.originalTransactionId = @txnId")
-            .WithParameter("@txnId", originalTransactionId);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Users,
+            "SELECT * FROM c WHERE c.originalTransactionId = @txnId",
+            [new QueryParameter("@txnId", originalTransactionId)],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.UserProfileDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<UserProfileDocument>(queryDefinition);
-
-        return await iterator.FirstOrDefaultAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.Count > 0 ? documents[0].ToDomain() : null;
     }
 
     public async Task SaveAsync(UserProfile profile, CancellationToken ct)
@@ -61,24 +59,20 @@ public sealed class CosmosUserProfileRepository : IUserProfileRepository
         ArgumentNullException.ThrowIfNull(profile);
 
         var document = UserProfileDocument.FromDomain(profile);
-        await this.container.UpsertItemAsync(
+        await this.client.UpsertDocumentAsync(
+            CosmosContainerNames.Users,
             document,
-            new PartitionKey(document.Id),
-            cancellationToken: ct).ConfigureAwait(false);
+            document.Id,
+            CosmosJsonSerializerContext.Default.UserProfileDocument,
+            ct).ConfigureAwait(false);
     }
 
     public async Task DeleteAsync(string userId, CancellationToken ct)
     {
-        try
-        {
-            await this.container.DeleteItemAsync<UserProfileDocument>(
-                userId,
-                new PartitionKey(userId),
-                cancellationToken: ct).ConfigureAwait(false);
-        }
-        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-        {
-            // Idempotent delete — already gone
-        }
+        await this.client.DeleteDocumentAsync(
+            CosmosContainerNames.Users,
+            userId,
+            userId,
+            ct).ConfigureAwait(false);
     }
 }

--- a/api/src/town-crier.infrastructure/WatchZones/CosmosWatchZoneRepository.cs
+++ b/api/src/town-crier.infrastructure/WatchZones/CosmosWatchZoneRepository.cs
@@ -1,5 +1,3 @@
-using System.Net;
-using Microsoft.Azure.Cosmos;
 using TownCrier.Application.WatchZones;
 using TownCrier.Domain.WatchZones;
 using TownCrier.Infrastructure.Cosmos;
@@ -8,12 +6,12 @@ namespace TownCrier.Infrastructure.WatchZones;
 
 public sealed class CosmosWatchZoneRepository : IWatchZoneRepository
 {
-    private readonly Container container;
+    private readonly ICosmosRestClient client;
 
-    public CosmosWatchZoneRepository(CosmosClient client)
+    public CosmosWatchZoneRepository(ICosmosRestClient client)
     {
         ArgumentNullException.ThrowIfNull(client);
-        this.container = client.GetContainer(CosmosContainerNames.DatabaseName, CosmosContainerNames.WatchZones);
+        this.client = client;
     }
 
     public async Task SaveAsync(WatchZone zone, CancellationToken ct)
@@ -21,24 +19,27 @@ public sealed class CosmosWatchZoneRepository : IWatchZoneRepository
         ArgumentNullException.ThrowIfNull(zone);
 
         var document = WatchZoneDocument.FromDomain(zone);
-        await this.container.UpsertItemAsync(
+        await this.client.UpsertDocumentAsync(
+            CosmosContainerNames.WatchZones,
             document,
-            new PartitionKey(document.UserId),
-            cancellationToken: ct).ConfigureAwait(false);
+            document.UserId,
+            CosmosJsonSerializerContext.Default.WatchZoneDocument,
+            ct).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyCollection<WatchZone>> GetByUserIdAsync(string userId, CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
 
-        var query = new QueryDefinition("SELECT * FROM c WHERE c.userId = @userId")
-            .WithParameter("@userId", userId);
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.WatchZones,
+            "SELECT * FROM c WHERE c.userId = @userId",
+            [new QueryParameter("@userId", userId)],
+            userId,
+            CosmosJsonSerializerContext.Default.WatchZoneDocument,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<WatchZoneDocument>(
-            query,
-            requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey(userId) });
-
-        return await iterator.CollectAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.ConvertAll(doc => doc.ToDomain());
     }
 
     public async Task DeleteAsync(string userId, string zoneId, CancellationToken ct)
@@ -46,56 +47,66 @@ public sealed class CosmosWatchZoneRepository : IWatchZoneRepository
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
         ArgumentException.ThrowIfNullOrWhiteSpace(zoneId);
 
-        try
-        {
-            await this.container.DeleteItemAsync<WatchZoneDocument>(
-                zoneId,
-                new PartitionKey(userId),
-                cancellationToken: ct).ConfigureAwait(false);
-        }
-        catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        // Read first to preserve WatchZoneNotFoundException semantics,
+        // since REST DeleteDocumentAsync is idempotent (no 404 error).
+        var existing = await this.client.ReadDocumentAsync(
+            CosmosContainerNames.WatchZones,
+            zoneId,
+            userId,
+            CosmosJsonSerializerContext.Default.WatchZoneDocument,
+            ct).ConfigureAwait(false);
+
+        if (existing is null)
         {
             throw new WatchZoneNotFoundException();
         }
+
+        await this.client.DeleteDocumentAsync(
+            CosmosContainerNames.WatchZones,
+            zoneId,
+            userId,
+            ct).ConfigureAwait(false);
     }
 
     public async Task<IReadOnlyCollection<WatchZone>> FindZonesContainingAsync(
         double latitude, double longitude, CancellationToken ct)
     {
-        var query = new QueryDefinition(
+        const string sql =
             "SELECT * FROM c WHERE ST_DISTANCE({'type': 'Point', 'coordinates': [c.longitude, c.latitude]}, " +
-            "{'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres")
-            .WithParameter("@latitude", latitude)
-            .WithParameter("@longitude", longitude);
+            "{'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres";
 
-        using var iterator = this.container.GetItemQueryIterator<WatchZoneDocument>(
-            query,
-            requestOptions: new QueryRequestOptions { PartitionKey = null });
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.WatchZones,
+            sql,
+            [new QueryParameter("@latitude", latitude), new QueryParameter("@longitude", longitude)],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.WatchZoneDocument,
+            ct).ConfigureAwait(false);
 
-        return await iterator.CollectAsync(doc => doc.ToDomain(), ct).ConfigureAwait(false);
+        return documents.ConvertAll(doc => doc.ToDomain());
     }
 
     public async Task<IReadOnlyCollection<int>> GetDistinctAuthorityIdsAsync(CancellationToken ct)
     {
-        var query = new QueryDefinition("SELECT DISTINCT VALUE c.authorityId FROM c");
-
-        using var iterator = this.container.GetItemQueryIterator<int>(
-            query,
-            requestOptions: new QueryRequestOptions { PartitionKey = null });
-
-        return await iterator.CollectAsync(ct).ConfigureAwait(false);
+        return await this.client.QueryAsync(
+            CosmosContainerNames.WatchZones,
+            "SELECT DISTINCT VALUE c.authorityId FROM c",
+            parameters: null,
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.Int32,
+            ct).ConfigureAwait(false);
     }
 
     public async Task<Dictionary<int, int>> GetZoneCountsByAuthorityAsync(CancellationToken ct)
     {
-        var query = new QueryDefinition(
-            "SELECT c.authorityId, COUNT(1) AS zoneCount FROM c GROUP BY c.authorityId");
+        var items = await this.client.QueryAsync(
+            CosmosContainerNames.WatchZones,
+            "SELECT c.authorityId, COUNT(1) AS zoneCount FROM c GROUP BY c.authorityId",
+            parameters: null,
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.AuthorityZoneCountResult,
+            ct).ConfigureAwait(false);
 
-        using var iterator = this.container.GetItemQueryIterator<AuthorityZoneCountResult>(
-            query,
-            requestOptions: new QueryRequestOptions { PartitionKey = null });
-
-        var items = await iterator.CollectAsync(ct).ConfigureAwait(false);
         return items.ToDictionary(item => item.AuthorityId, item => item.ZoneCount);
     }
 }

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/FakeCosmosRestClient.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/FakeCosmosRestClient.cs
@@ -1,0 +1,140 @@
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using TownCrier.Infrastructure.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.Cosmos;
+
+/// <summary>
+/// In-memory fake of <see cref="ICosmosRestClient"/> for testing Cosmos repository adapters.
+/// Stores documents as raw JSON strings keyed by (collection, id, partitionKey).
+/// </summary>
+internal sealed class FakeCosmosRestClient : ICosmosRestClient
+{
+    private readonly Dictionary<(string Collection, string Id, string PartitionKey), string> store = new();
+
+    public Task<T?> ReadDocumentAsync<T>(
+        string collection,
+        string id,
+        string partitionKey,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken ct)
+    {
+        if (this.store.TryGetValue((collection, id, partitionKey), out var json))
+        {
+            var result = JsonSerializer.Deserialize(json, typeInfo);
+            return Task.FromResult(result);
+        }
+
+        return Task.FromResult(default(T));
+    }
+
+    public Task UpsertDocumentAsync<T>(
+        string collection,
+        T document,
+        string partitionKey,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken ct)
+    {
+        var json = JsonSerializer.Serialize(document, typeInfo);
+
+        // Extract id from the serialized JSON to use as the key
+        using var doc = JsonDocument.Parse(json);
+        var id = ExtractId(doc);
+
+        this.store[(collection, id, partitionKey)] = json;
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteDocumentAsync(
+        string collection,
+        string id,
+        string partitionKey,
+        CancellationToken ct)
+    {
+        // Idempotent — no error if not found (matches REST API behavior)
+        this.store.Remove((collection, id, partitionKey));
+        return Task.CompletedTask;
+    }
+
+    public Task<List<T>> QueryAsync<T>(
+        string collection,
+        string sql,
+        IReadOnlyList<QueryParameter>? parameters,
+        string? partitionKey,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken ct)
+    {
+        // Return all documents in the collection, optionally filtered by partition key.
+        // The fake does not parse SQL — tests must set up data so that
+        // "return everything matching the partition" is a valid approximation.
+        var results = new List<T>();
+
+        foreach (var ((c, _, pk), json) in this.store)
+        {
+            if (c != collection)
+            {
+                continue;
+            }
+
+            if (partitionKey is not null && pk != partitionKey)
+            {
+                continue;
+            }
+
+            var item = JsonSerializer.Deserialize(json, typeInfo);
+            if (item is not null)
+            {
+                results.Add(item);
+            }
+        }
+
+        return Task.FromResult(results);
+    }
+
+    public Task<T> ScalarQueryAsync<T>(
+        string collection,
+        string sql,
+        IReadOnlyList<QueryParameter>? parameters,
+        string? partitionKey,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken ct)
+    {
+        // For scalar queries (COUNT etc.), return the count of matching documents
+        // wrapped as the requested type. This works for int counts.
+        var count = 0;
+
+        foreach (var ((c, _, pk), _) in this.store)
+        {
+            if (c != collection)
+            {
+                continue;
+            }
+
+            if (partitionKey is not null && pk != partitionKey)
+            {
+                continue;
+            }
+
+            count++;
+        }
+
+        // Convert count to T (works for int, long, etc.)
+        var result = (T)(object)count;
+        return Task.FromResult(result);
+    }
+
+    private static string ExtractId(JsonDocument doc)
+    {
+        if (doc.RootElement.TryGetProperty("id", out var idProp))
+        {
+            return idProp.GetString()!;
+        }
+
+        if (doc.RootElement.TryGetProperty("Id", out var idProp2))
+        {
+            return idProp2.GetString()!;
+        }
+
+        throw new InvalidOperationException("Document must have an 'id' or 'Id' property.");
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/DecisionAlerts/CosmosDecisionAlertRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/DecisionAlerts/CosmosDecisionAlertRepositoryTests.cs
@@ -1,0 +1,59 @@
+using TownCrier.Domain.DecisionAlerts;
+using TownCrier.Infrastructure.DecisionAlerts;
+using TownCrier.Infrastructure.Tests.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.DecisionAlerts;
+
+public sealed class CosmosDecisionAlertRepositoryTests
+{
+    [Test]
+    public async Task Should_ReturnAlert_When_AlertExists()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosDecisionAlertRepository(client);
+
+        var alert = DecisionAlert.Create("user-1", "app-uid-1", "APP/001", "123 Main St", "Approved", DateTimeOffset.UtcNow);
+        await repo.SaveAsync(alert, CancellationToken.None);
+
+        // Act
+        var result = await repo.GetByUserAndApplicationAsync("user-1", "app-uid-1", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.UserId).IsEqualTo("user-1");
+        await Assert.That(result.ApplicationUid).IsEqualTo("app-uid-1");
+    }
+
+    [Test]
+    public async Task Should_ReturnNull_When_AlertDoesNotExist()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosDecisionAlertRepository(client);
+
+        // Act
+        var result = await repo.GetByUserAndApplicationAsync("user-1", "nonexistent", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task Should_PersistAlert_When_SaveCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosDecisionAlertRepository(client);
+
+        var alert = DecisionAlert.Create("user-2", "app-uid-2", "APP/002", "456 High St", "Refused", DateTimeOffset.UtcNow);
+
+        // Act
+        await repo.SaveAsync(alert, CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByUserAndApplicationAsync("user-2", "app-uid-2", CancellationToken.None);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Decision).IsEqualTo("Refused");
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/DeviceRegistrations/CosmosDeviceRegistrationRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/DeviceRegistrations/CosmosDeviceRegistrationRepositoryTests.cs
@@ -1,0 +1,73 @@
+using TownCrier.Domain.DeviceRegistrations;
+using TownCrier.Infrastructure.DeviceRegistrations;
+using TownCrier.Infrastructure.Tests.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.DeviceRegistrations;
+
+public sealed class CosmosDeviceRegistrationRepositoryTests
+{
+    [Test]
+    public async Task Should_PersistRegistration_When_SaveCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosDeviceRegistrationRepository(client);
+        var reg = DeviceRegistration.Create("user-1", "token-abc", DevicePlatform.Ios, DateTimeOffset.UtcNow);
+
+        // Act
+        await repo.SaveAsync(reg, CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByUserIdAsync("user-1", CancellationToken.None);
+        await Assert.That(result.Count).IsEqualTo(1);
+        await Assert.That(result[0].Token).IsEqualTo("token-abc");
+    }
+
+    [Test]
+    public async Task Should_ReturnRegistration_When_GetByTokenCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosDeviceRegistrationRepository(client);
+        var reg = DeviceRegistration.Create("user-1", "token-abc", DevicePlatform.Ios, DateTimeOffset.UtcNow);
+        await repo.SaveAsync(reg, CancellationToken.None);
+
+        // Act — fake returns all in collection, no SQL filtering
+        var result = await repo.GetByTokenAsync("token-abc", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Token).IsEqualTo("token-abc");
+    }
+
+    [Test]
+    public async Task Should_ReturnNull_When_GetByTokenForMissingToken()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosDeviceRegistrationRepository(client);
+
+        // Act
+        var result = await repo.GetByTokenAsync("nonexistent", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task Should_DeleteRegistration_When_DeleteByTokenCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosDeviceRegistrationRepository(client);
+        var reg = DeviceRegistration.Create("user-1", "token-abc", DevicePlatform.Ios, DateTimeOffset.UtcNow);
+        await repo.SaveAsync(reg, CancellationToken.None);
+
+        // Act
+        await repo.DeleteByTokenAsync("token-abc", CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByUserIdAsync("user-1", CancellationToken.None);
+        await Assert.That(result.Count).IsEqualTo(0);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/Groups/CosmosGroupInvitationRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Groups/CosmosGroupInvitationRepositoryTests.cs
@@ -1,0 +1,77 @@
+using TownCrier.Domain.Groups;
+using TownCrier.Infrastructure.Groups;
+using TownCrier.Infrastructure.Tests.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.Groups;
+
+public sealed class CosmosGroupInvitationRepositoryTests
+{
+    [Test]
+    public async Task Should_PersistInvitation_When_SaveCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosGroupInvitationRepository(client);
+        var invitation = GroupInvitation.Create(
+            "inv-1", "group-1", "user@example.com", "user-1",
+            DateTimeOffset.UtcNow, TimeSpan.FromDays(7));
+
+        // Act
+        await repo.SaveAsync(invitation, CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByIdAsync("inv-1", CancellationToken.None);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.GroupId).IsEqualTo("group-1");
+    }
+
+    [Test]
+    public async Task Should_ReturnNull_When_GetByIdForMissingInvitation()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosGroupInvitationRepository(client);
+
+        // Act
+        var result = await repo.GetByIdAsync("nonexistent", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task Should_ReturnInvitations_When_GetPendingByGroupIdCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosGroupInvitationRepository(client);
+        var invitation = GroupInvitation.Create(
+            "inv-1", "group-1", "user@example.com", "user-1",
+            DateTimeOffset.UtcNow, TimeSpan.FromDays(7));
+        await repo.SaveAsync(invitation, CancellationToken.None);
+
+        // Act -- fake returns all docs in collection
+        var result = await repo.GetPendingByGroupIdAsync("group-1", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Count).IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_ReturnInvitations_When_GetPendingByEmailCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosGroupInvitationRepository(client);
+        var invitation = GroupInvitation.Create(
+            "inv-1", "group-1", "user@example.com", "user-1",
+            DateTimeOffset.UtcNow, TimeSpan.FromDays(7));
+        await repo.SaveAsync(invitation, CancellationToken.None);
+
+        // Act
+        var result = await repo.GetPendingByEmailAsync("user@example.com", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Count).IsGreaterThanOrEqualTo(1);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/Groups/CosmosGroupInvitationRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Groups/CosmosGroupInvitationRepositoryTests.cs
@@ -13,8 +13,12 @@ public sealed class CosmosGroupInvitationRepositoryTests
         var client = new FakeCosmosRestClient();
         var repo = new CosmosGroupInvitationRepository(client);
         var invitation = GroupInvitation.Create(
-            "inv-1", "group-1", "user@example.com", "user-1",
-            DateTimeOffset.UtcNow, TimeSpan.FromDays(7));
+            "inv-1",
+            "group-1",
+            "user@example.com",
+            "user-1",
+            DateTimeOffset.UtcNow,
+            TimeSpan.FromDays(7));
 
         // Act
         await repo.SaveAsync(invitation, CancellationToken.None);
@@ -46,8 +50,12 @@ public sealed class CosmosGroupInvitationRepositoryTests
         var client = new FakeCosmosRestClient();
         var repo = new CosmosGroupInvitationRepository(client);
         var invitation = GroupInvitation.Create(
-            "inv-1", "group-1", "user@example.com", "user-1",
-            DateTimeOffset.UtcNow, TimeSpan.FromDays(7));
+            "inv-1",
+            "group-1",
+            "user@example.com",
+            "user-1",
+            DateTimeOffset.UtcNow,
+            TimeSpan.FromDays(7));
         await repo.SaveAsync(invitation, CancellationToken.None);
 
         // Act -- fake returns all docs in collection
@@ -64,8 +72,12 @@ public sealed class CosmosGroupInvitationRepositoryTests
         var client = new FakeCosmosRestClient();
         var repo = new CosmosGroupInvitationRepository(client);
         var invitation = GroupInvitation.Create(
-            "inv-1", "group-1", "user@example.com", "user-1",
-            DateTimeOffset.UtcNow, TimeSpan.FromDays(7));
+            "inv-1",
+            "group-1",
+            "user@example.com",
+            "user-1",
+            DateTimeOffset.UtcNow,
+            TimeSpan.FromDays(7));
         await repo.SaveAsync(invitation, CancellationToken.None);
 
         // Act

--- a/api/tests/town-crier.infrastructure.tests/Groups/CosmosGroupRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Groups/CosmosGroupRepositoryTests.cs
@@ -1,0 +1,73 @@
+using TownCrier.Domain.Geocoding;
+using TownCrier.Domain.Groups;
+using TownCrier.Infrastructure.Groups;
+using TownCrier.Infrastructure.Tests.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.Groups;
+
+public sealed class CosmosGroupRepositoryTests
+{
+    [Test]
+    public async Task Should_PersistGroup_When_SaveCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosGroupRepository(client);
+        var group = Group.Create("group-1", "Test Group", "user-1", new Coordinates(51.5, -0.1), 500, 100, DateTimeOffset.UtcNow);
+
+        // Act
+        await repo.SaveAsync(group, CancellationToken.None);
+
+        // Assert -- GetByIdAsync uses a cross-partition query
+        var result = await repo.GetByIdAsync("group-1", CancellationToken.None);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Name).IsEqualTo("Test Group");
+    }
+
+    [Test]
+    public async Task Should_ReturnNull_When_GetByIdForMissingGroup()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosGroupRepository(client);
+
+        // Act
+        var result = await repo.GetByIdAsync("nonexistent", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task Should_ReturnGroups_When_GetByUserIdCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosGroupRepository(client);
+        var group = Group.Create("group-1", "Test Group", "user-1", new Coordinates(51.5, -0.1), 500, 100, DateTimeOffset.UtcNow);
+        await repo.SaveAsync(group, CancellationToken.None);
+
+        // Act -- fake returns all docs, no SQL filtering for membership
+        var result = await repo.GetByUserIdAsync("user-1", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Count).IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_DeleteGroup_When_DeleteCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosGroupRepository(client);
+        var group = Group.Create("group-1", "Test Group", "user-1", new Coordinates(51.5, -0.1), 500, 100, DateTimeOffset.UtcNow);
+        await repo.SaveAsync(group, CancellationToken.None);
+
+        // Act
+        await repo.DeleteAsync("group-1", CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByIdAsync("group-1", CancellationToken.None);
+        await Assert.That(result).IsNull();
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/Notifications/CosmosNotificationRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Notifications/CosmosNotificationRepositoryTests.cs
@@ -1,0 +1,87 @@
+using TownCrier.Infrastructure.Notifications;
+using TownCrier.Infrastructure.Tests.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.Notifications;
+
+public sealed class CosmosNotificationRepositoryTests
+{
+    [Test]
+    public async Task Should_PersistNotification_When_SaveCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosNotificationRepository(client);
+        var notification = new NotificationBuilder().Build();
+
+        // Act
+        await repo.SaveAsync(notification, CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByUserAndApplicationAsync("user-1", "APP/2026/0001", CancellationToken.None);
+        await Assert.That(result).IsNotNull();
+    }
+
+    [Test]
+    public async Task Should_ReturnNull_When_GetByUserAndApplicationForMissing()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosNotificationRepository(client);
+
+        // Act
+        var result = await repo.GetByUserAndApplicationAsync("user-1", "nonexistent", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task Should_ReturnCount_When_CountByUserInMonthCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosNotificationRepository(client);
+        var notification = new NotificationBuilder().Build();
+        await repo.SaveAsync(notification, CancellationToken.None);
+
+        // Act -- scalar query returns count of docs in partition
+        var result = await repo.CountByUserInMonthAsync("user-1", 2026, 3, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_ReturnCount_When_CountByUserSinceCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosNotificationRepository(client);
+        var notification = new NotificationBuilder().Build();
+        await repo.SaveAsync(notification, CancellationToken.None);
+
+        // Act
+        var since = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var result = await repo.CountByUserSinceAsync("user-1", since, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_ReturnPaginatedResults_When_GetByUserPaginatedCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosNotificationRepository(client);
+        var notification = new NotificationBuilder().Build();
+        await repo.SaveAsync(notification, CancellationToken.None);
+
+        // Act
+        var (items, total) = await repo.GetByUserPaginatedAsync("user-1", 1, 10, CancellationToken.None);
+
+        // Assert
+        await Assert.That(total).IsGreaterThanOrEqualTo(1);
+        await Assert.That(items.Count).IsGreaterThanOrEqualTo(1);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/PlanningApplications/CosmosPlanningApplicationRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanningApplications/CosmosPlanningApplicationRepositoryTests.cs
@@ -1,0 +1,96 @@
+using TownCrier.Domain.PlanningApplications;
+using TownCrier.Infrastructure.PlanningApplications;
+using TownCrier.Infrastructure.Tests.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.PlanningApplications;
+
+public sealed class CosmosPlanningApplicationRepositoryTests
+{
+    [Test]
+    public async Task Should_PersistApplication_When_UpsertCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosPlanningApplicationRepository(client);
+        var app = CreateTestApplication();
+
+        // Act
+        await repo.UpsertAsync(app, CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByUidAsync("uid-1", CancellationToken.None);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Uid).IsEqualTo("uid-1");
+    }
+
+    [Test]
+    public async Task Should_ReturnNull_When_GetByUidForMissingApplication()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosPlanningApplicationRepository(client);
+
+        // Act
+        var result = await repo.GetByUidAsync("nonexistent", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task Should_ReturnApplications_When_GetByAuthorityIdCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosPlanningApplicationRepository(client);
+        var app = CreateTestApplication();
+        await repo.UpsertAsync(app, CancellationToken.None);
+
+        // Act
+        var result = await repo.GetByAuthorityIdAsync(100, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Count).IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_ReturnApplications_When_FindNearbyCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosPlanningApplicationRepository(client);
+        var app = CreateTestApplication();
+        await repo.UpsertAsync(app, CancellationToken.None);
+
+        // Act -- fake returns all in partition, not geo-filtered
+        var result = await repo.FindNearbyAsync("100", 51.5, -0.1, 500, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Count).IsGreaterThanOrEqualTo(1);
+    }
+
+#pragma warning disable S1075 // Test data URIs are intentionally hardcoded
+    private static PlanningApplication CreateTestApplication(string name = "APP/001", string uid = "uid-1", int areaId = 100)
+    {
+        return new PlanningApplication(
+            name: name,
+            uid: uid,
+            areaName: "Test Area",
+            areaId: areaId,
+            address: "123 Main St",
+            postcode: "SW1A 1AA",
+            description: "Test application",
+            appType: "Full",
+            appState: "Pending",
+            appSize: null,
+            startDate: new DateOnly(2026, 1, 1),
+            decidedDate: null,
+            consultedDate: null,
+            longitude: -0.1,
+            latitude: 51.5,
+            url: "https://example.com",
+            link: "https://example.com/link",
+            lastDifferent: DateTimeOffset.UtcNow);
+    }
+#pragma warning restore S1075
+}

--- a/api/tests/town-crier.infrastructure.tests/SavedApplications/CosmosSavedApplicationRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/SavedApplications/CosmosSavedApplicationRepositoryTests.cs
@@ -1,0 +1,97 @@
+using TownCrier.Domain.SavedApplications;
+using TownCrier.Infrastructure.SavedApplications;
+using TownCrier.Infrastructure.Tests.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.SavedApplications;
+
+public sealed class CosmosSavedApplicationRepositoryTests
+{
+    [Test]
+    public async Task Should_PersistSavedApplication_When_SaveCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosSavedApplicationRepository(client);
+        var saved = SavedApplication.Create("user-1", "app-uid-1", DateTimeOffset.UtcNow);
+
+        // Act
+        await repo.SaveAsync(saved, CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByUserIdAsync("user-1", CancellationToken.None);
+        await Assert.That(result.Count).IsEqualTo(1);
+        await Assert.That(result[0].ApplicationUid).IsEqualTo("app-uid-1");
+    }
+
+    [Test]
+    public async Task Should_DeleteSavedApplication_When_DeleteCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosSavedApplicationRepository(client);
+        var saved = SavedApplication.Create("user-1", "app-uid-1", DateTimeOffset.UtcNow);
+        await repo.SaveAsync(saved, CancellationToken.None);
+
+        // Act
+        await repo.DeleteAsync("user-1", "app-uid-1", CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByUserIdAsync("user-1", CancellationToken.None);
+        await Assert.That(result.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_NotThrow_When_DeleteCalledForMissingApplication()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosSavedApplicationRepository(client);
+
+        // Act & Assert — should not throw (idempotent delete)
+        await repo.DeleteAsync("user-1", "nonexistent", CancellationToken.None);
+    }
+
+    [Test]
+    public async Task Should_ReturnTrue_When_ExistsForExistingApplication()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosSavedApplicationRepository(client);
+        var saved = SavedApplication.Create("user-1", "app-uid-1", DateTimeOffset.UtcNow);
+        await repo.SaveAsync(saved, CancellationToken.None);
+
+        // Act
+        var result = await repo.ExistsAsync("user-1", "app-uid-1", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_ReturnFalse_When_ExistsForMissingApplication()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosSavedApplicationRepository(client);
+
+        // Act
+        var result = await repo.ExistsAsync("user-1", "nonexistent", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsFalse();
+    }
+
+    [Test]
+    public async Task Should_ReturnEmptyList_When_GetUserIdsByApplicationUidWithNoData()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosSavedApplicationRepository(client);
+
+        // Act -- empty store, verifies wiring
+        var result = await repo.GetUserIdsByApplicationUidAsync("nonexistent", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Count).IsEqualTo(0);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/UserProfiles/CosmosUserProfileRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/UserProfiles/CosmosUserProfileRepositoryTests.cs
@@ -1,0 +1,108 @@
+using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.Tests.Cosmos;
+using TownCrier.Infrastructure.UserProfiles;
+
+namespace TownCrier.Infrastructure.Tests.UserProfiles;
+
+public sealed class CosmosUserProfileRepositoryTests
+{
+    [Test]
+    public async Task Should_ReturnProfile_When_ProfileExists()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosUserProfileRepository(client);
+
+        var profile = UserProfile.Register("user-1");
+        profile.UpdatePreferences("SW1A 1AA", NotificationPreferences.Default);
+        await repo.SaveAsync(profile, CancellationToken.None);
+
+        // Act
+        var result = await repo.GetByUserIdAsync("user-1", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.UserId).IsEqualTo("user-1");
+        await Assert.That(result.Postcode).IsEqualTo("SW1A 1AA");
+    }
+
+    [Test]
+    public async Task Should_ReturnNull_When_ProfileDoesNotExist()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosUserProfileRepository(client);
+
+        // Act
+        var result = await repo.GetByUserIdAsync("nonexistent", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task Should_PersistProfile_When_SaveCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosUserProfileRepository(client);
+
+        var profile = UserProfile.Register("user-2");
+
+        // Act
+        await repo.SaveAsync(profile, CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByUserIdAsync("user-2", CancellationToken.None);
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.UserId).IsEqualTo("user-2");
+    }
+
+    [Test]
+    public async Task Should_RemoveProfile_When_DeleteCalledForExistingProfile()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosUserProfileRepository(client);
+
+        var profile = UserProfile.Register("user-3");
+        await repo.SaveAsync(profile, CancellationToken.None);
+
+        // Act
+        await repo.DeleteAsync("user-3", CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByUserIdAsync("user-3", CancellationToken.None);
+        await Assert.That(result).IsNull();
+    }
+
+    [Test]
+    public async Task Should_NotThrow_When_DeleteCalledForMissingProfile()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosUserProfileRepository(client);
+
+        // Act & Assert — should not throw
+        await repo.DeleteAsync("nonexistent", CancellationToken.None);
+    }
+
+    [Test]
+    public async Task Should_ReturnProfiles_When_GetAllByTierCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosUserProfileRepository(client);
+
+        var profile1 = UserProfile.Register("user-a");
+        var profile2 = UserProfile.Register("user-b");
+        await repo.SaveAsync(profile1, CancellationToken.None);
+        await repo.SaveAsync(profile2, CancellationToken.None);
+
+        // Act — both default to Free tier
+        var result = await repo.GetAllByTierAsync(SubscriptionTier.Free, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Count).IsGreaterThanOrEqualTo(2);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/WatchZones/CosmosWatchZoneRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/WatchZones/CosmosWatchZoneRepositoryTests.cs
@@ -1,0 +1,122 @@
+using TownCrier.Application.WatchZones;
+using TownCrier.Domain.Geocoding;
+using TownCrier.Domain.WatchZones;
+using TownCrier.Infrastructure.Tests.Cosmos;
+using TownCrier.Infrastructure.WatchZones;
+
+namespace TownCrier.Infrastructure.Tests.WatchZones;
+
+public sealed class CosmosWatchZoneRepositoryTests
+{
+    [Test]
+    public async Task Should_PersistZone_When_SaveCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosWatchZoneRepository(client);
+
+        var zone = new WatchZone("zone-1", "user-1", "Home", new Coordinates(51.5, -0.1), 500, 100);
+
+        // Act
+        await repo.SaveAsync(zone, CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByUserIdAsync("user-1", CancellationToken.None);
+        await Assert.That(result.Count).IsEqualTo(1);
+        await Assert.That(result.First().Id).IsEqualTo("zone-1");
+    }
+
+    [Test]
+    public async Task Should_ReturnZones_When_GetByUserIdCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosWatchZoneRepository(client);
+
+        var zone1 = new WatchZone("zone-1", "user-1", "Home", new Coordinates(51.5, -0.1), 500, 100);
+        var zone2 = new WatchZone("zone-2", "user-1", "Work", new Coordinates(51.6, -0.2), 1000, 200);
+        await repo.SaveAsync(zone1, CancellationToken.None);
+        await repo.SaveAsync(zone2, CancellationToken.None);
+
+        // Act
+        var result = await repo.GetByUserIdAsync("user-1", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Should_DeleteZone_When_ZoneExists()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosWatchZoneRepository(client);
+
+        var zone = new WatchZone("zone-1", "user-1", "Home", new Coordinates(51.5, -0.1), 500, 100);
+        await repo.SaveAsync(zone, CancellationToken.None);
+
+        // Act
+        await repo.DeleteAsync("user-1", "zone-1", CancellationToken.None);
+
+        // Assert
+        var result = await repo.GetByUserIdAsync("user-1", CancellationToken.None);
+        await Assert.That(result.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_ThrowWatchZoneNotFoundException_When_DeletingMissingZone()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosWatchZoneRepository(client);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<WatchZoneNotFoundException>(
+            () => repo.DeleteAsync("user-1", "nonexistent", CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Should_ReturnZones_When_FindZonesContainingCalled()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosWatchZoneRepository(client);
+
+        var zone = new WatchZone("zone-1", "user-1", "Home", new Coordinates(51.5, -0.1), 500, 100);
+        await repo.SaveAsync(zone, CancellationToken.None);
+
+        // Act — fake returns all documents in collection (no SQL parsing)
+        var result = await repo.FindZonesContainingAsync(51.5, -0.1, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Count).IsGreaterThanOrEqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_ReturnEmptyCollection_When_GetDistinctAuthorityIdsCalledWithNoData()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosWatchZoneRepository(client);
+
+        // Act — empty store, verifies wiring compiles and runs
+        var result = await repo.GetDistinctAuthorityIdsAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_ReturnEmptyDictionary_When_GetZoneCountsByAuthorityCalledWithNoData()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosWatchZoneRepository(client);
+
+        // Act — empty store, verifies wiring compiles and runs
+        var result = await repo.GetZoneCountsByAuthorityAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Count).IsEqualTo(0);
+    }
+}


### PR DESCRIPTION
## Changes
- Rewrite all 9 Cosmos DB repository implementations to use `ICosmosRestClient` instead of the SDK's `Container` type
- Add 43 new infrastructure tests covering all repository operations via `FakeCosmosRestClient`
- Remove backward-compat `CosmosClient` registration from `CosmosServiceExtensions`
- Preserve `WatchZoneNotFoundException` semantics via read-then-delete pattern

All 345 tests passing (155 application + 147 infrastructure + 43 web).

Part of epic `tc-pgp` (Cosmos DB REST client migration).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated Cosmos database repositories from direct Azure SDK usage to a REST-based client abstraction for improved resilience and flexibility.

* **Tests**
  * Added comprehensive test suites for all Cosmos repositories covering save, retrieve, delete, and query operations.
  * Introduced `FakeCosmosRestClient` test infrastructure enabling in-memory repository testing without external dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->