### PR TITLE
infra: add Cosmos__DatabaseName env var to container app

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -265,6 +265,7 @@ public static class EnvironmentStack
                             new EnvironmentVarArgs { Name = "Auth0__Domain", Value = auth0Domain },
                             new EnvironmentVarArgs { Name = "Auth0__Audience", Value = auth0Audience },
                             new EnvironmentVarArgs { Name = "Cosmos__AccountEndpoint", Value = cosmosAccountEndpoint },
+                            new EnvironmentVarArgs { Name = "Cosmos__DatabaseName", Value = cosmosDatabase.Name },
                             new EnvironmentVarArgs { Name = "AZURE_CLIENT_ID", Value = cosmosDataIdentityClientId },
                             new EnvironmentVarArgs { Name = "Cors__AllowedOrigins__0", Value = $"https://{frontendDomain}" },
                         },


### PR DESCRIPTION
## Changes
- Add `Cosmos__DatabaseName` env var to the container app in `EnvironmentStack.cs`, using `cosmosDatabase.Name` so the API's REST client gets the per-environment database name (e.g. `town-crier-dev`, `town-crier-prod`)
- Verified `Cosmos__AccountEndpoint` already correctly set
- Confirmed no connection string references exist in infra

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API configuration to properly connect to the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->