### PR TITLE
fix(api): Cosmos camelCase JSON policy + CORS on 500s + CD image safety net

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -144,12 +144,15 @@ jobs:
         working-directory: api
 
   # ── API: deploy to dev ──────────────────────────────
+  # Runs when API code changed (new image) OR when infra changed (Pulumi may
+  # reset the container image to the placeholder — re-deploy the latest tag to
+  # recover).
   api-deploy:
     name: "API: Deploy to dev"
     needs: [changes, api-image, infra-dev]
     if: >-
       !failure() && !cancelled()
-      && needs.changes.outputs.api == 'true'
+      && (needs.changes.outputs.api == 'true' || needs.changes.outputs.infra == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: development
@@ -164,10 +167,15 @@ jobs:
 
       - name: Deploy to Container App
         run: |
+          if [ "${{ needs.changes.outputs.api }}" = "true" ]; then
+            TAG="${{ github.sha }}"
+          else
+            TAG="latest"
+          fi
           az containerapp update \
             --name "ca-town-crier-api-dev" \
             --resource-group "rg-town-crier-dev" \
-            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}"
+            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${TAG}"
 
   # ── Web: deploy to dev ──────────────────────────────
   web-deploy:

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
@@ -12,6 +12,7 @@ using TownCrier.Infrastructure.WatchZones;
 
 namespace TownCrier.Infrastructure.Cosmos;
 
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(Coordinates))]
 [JsonSerializable(typeof(NotificationPreferences))]
 [JsonSerializable(typeof(ZoneNotificationPreferences))]

--- a/api/src/town-crier.web/Observability/ErrorResponseMiddleware.cs
+++ b/api/src/town-crier.web/Observability/ErrorResponseMiddleware.cs
@@ -8,7 +8,19 @@ internal sealed class ErrorResponseMiddleware(RequestDelegate next)
 
     public async Task InvokeAsync(HttpContext context)
     {
-        await next(context).ConfigureAwait(false);
+        try
+        {
+            await next(context).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Global error handler must catch all exceptions
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+            if (!context.Response.HasStarted)
+            {
+                context.Response.StatusCode = 500;
+            }
+        }
 
         if (context.Response.StatusCode >= 400
             && !context.Response.HasStarted


### PR DESCRIPTION
## Summary
- **Cosmos REST deserialization fix**: Added `JsonKnownNamingPolicy.CamelCase` to `CosmosJsonSerializerContext`. The migration to the REST client (PR #94) omitted this, causing all document reads to fail because Cosmos stores camelCase properties but the deserializer expected PascalCase.
- **Error middleware hardening**: `ErrorResponseMiddleware` now catches unhandled exceptions so 500 responses include CORS headers and a JSON body, instead of a raw connection reset that browsers report as a CORS error.
- **CD pipeline safety net**: `api-deploy` now also runs after infra-only changes, re-deploying the `latest` ACR tag. This prevents Pulumi's `IgnoreChanges` bug from leaving the quickstart placeholder image deployed.

## Test plan
- [x] `dotnet build` — passes
- [x] `dotnet test` — 43/43 pass
- [ ] Verify `https://dev.towncrierapp.uk/dashboard` loads without CORS errors after merge & deploy
- [ ] Verify an infra-only commit triggers API image re-deploy in CD

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced exception handling to properly capture unhandled errors and return appropriate HTTP 500 status codes, with safeguards to prevent response headers from being modified if transmission has already begun.

* **Chores**
  * Updated deployment workflow to intelligently trigger based on code and infrastructure changes.
  * Configured internal data serialization to use standardized naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->