### PR TITLE
fix(api): URL-encode document IDs in Cosmos REST client

### DIFF
--- a/api/src/town-crier.infrastructure/Cosmos/CosmosRestClient.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosRestClient.cs
@@ -34,7 +34,8 @@ internal sealed class CosmosRestClient : ICosmosRestClient
         JsonTypeInfo<T> typeInfo,
         CancellationToken ct)
     {
-        var resourceLink = $"dbs/{this.databaseName}/colls/{collection}/docs/{id}";
+        var encodedId = Uri.EscapeDataString(id);
+        var resourceLink = $"dbs/{this.databaseName}/colls/{collection}/docs/{encodedId}";
         using var request = new HttpRequestMessage(HttpMethod.Get, $"/{resourceLink}");
         await this.AddHeadersAsync(request, partitionKey, ct).ConfigureAwait(false);
 
@@ -81,7 +82,8 @@ internal sealed class CosmosRestClient : ICosmosRestClient
         string partitionKey,
         CancellationToken ct)
     {
-        var resourceLink = $"dbs/{this.databaseName}/colls/{collection}/docs/{id}";
+        var encodedId = Uri.EscapeDataString(id);
+        var resourceLink = $"dbs/{this.databaseName}/colls/{collection}/docs/{encodedId}";
         using var request = new HttpRequestMessage(HttpMethod.Delete, $"/{resourceLink}");
         await this.AddHeadersAsync(request, partitionKey, ct).ConfigureAwait(false);
 


### PR DESCRIPTION
## Summary
- Auth0 user IDs contain `|` (e.g. `auth0|abc123`) which causes .NET's `Uri` parser to silently truncate the path segment
- The Cosmos REST client was hitting `GET .../docs/` (list endpoint) instead of `GET .../docs/{id}` (read endpoint)
- Cosmos returned a 200 with a collection wrapper, deserialization failed, and the API returned 500
- Fix: `Uri.EscapeDataString(id)` encodes `|` → `%7C` in both `ReadDocumentAsync` and `DeleteDocumentAsync`

## Test plan
- [x] `dotnet build` passes
- [x] `dotnet test` — 43/43 pass
- [ ] After deploy, verify `https://dev.towncrierapp.uk/dashboard` loads without 500 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of special characters in document identifiers. Database read and delete operations now safely process documents containing special characters in their IDs, ensuring reliable query execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->