### PR TITLE
fix(web): unwrap watch zones API response envelope

### DIFF
--- a/web/src/__tests__/routes.test.tsx
+++ b/web/src/__tests__/routes.test.tsx
@@ -19,7 +19,7 @@ const existingProfile: UserProfile = {
 
 const stubApiClient: ApiClient = {
   get: async (path: string) => {
-    if (path.includes('watch-zones')) return [] as unknown;
+    if (path.includes('watch-zones')) return { zones: [] } as unknown;
     if (path.includes('/groups')) return [] as unknown;
     if (path.includes('notifications')) return { notifications: [], total: 0, page: 1 } as unknown;
     if (path.includes('settings') || path.includes('profile')) return { postcode: null, pushEnabled: false, tier: 'Free' } as unknown;

--- a/web/src/api/watchZones.ts
+++ b/web/src/api/watchZones.ts
@@ -8,7 +8,10 @@ import type {
 
 export function watchZonesApi(client: ApiClient) {
   return {
-    list: () => client.get<readonly WatchZoneSummary[]>('/v1/me/watch-zones'),
+    list: async () => {
+      const result = await client.get<{ zones: readonly WatchZoneSummary[] }>('/v1/me/watch-zones');
+      return result.zones;
+    },
     create: (data: CreateWatchZoneRequest) =>
       client.post<WatchZoneSummary>('/v1/me/watch-zones', data),
     delete: (zoneId: string) => client.delete(`/v1/me/watch-zones/${zoneId}`),


### PR DESCRIPTION
## Summary
- The `GET /v1/me/watch-zones` endpoint returns `{ zones: [...] }` but the frontend API layer assumed a bare array, causing `t.map is not a function` on the dashboard
- Unwraps the response in `watchZones.ts` so callers receive the expected array
- Fixes the stub API client in `routes.test.tsx` to match the real response shape

## Test plan
- [x] TypeScript type-check passes
- [x] All 424 tests pass (including previously-failing routes test)
- [ ] Verify dashboard loads on `dev.towncrierapp.uk` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test stubs for watch-zones API response handling to ensure proper data shape validation.

* **Bug Fixes**
  * Fixed watch-zones API response handling to correctly parse and return zone data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->