### PR TITLE
fix(ci): always deploy all components to dev on merge to main

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,3 +1,13 @@
+# Automatically enables squash-merge auto-merge on new PRs.
+#
+# IMPORTANT: Uses GH_AUTO_MERGE_TOKEN (a fine-grained PAT) instead of
+# GITHUB_TOKEN so that the merge push is attributed to a real user and
+# triggers downstream workflows (e.g., CD Dev). Pushes from GITHUB_TOKEN
+# do not trigger further workflow runs by GitHub's design.
+#
+# Requires secrets:
+#   GH_AUTO_MERGE_TOKEN — Fine-grained PAT with Contents: write + Pull requests: write
+
 name: Auto-merge
 
 on:
@@ -17,6 +27,6 @@ jobs:
       - name: Enable auto-merge (squash)
         run: gh pr merge "$PR" --auto --squash --repo "$REPO"
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_AUTO_MERGE_TOKEN }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,5 +1,7 @@
-# Deploys changed components to the dev environment.
+# Deploys all components to the dev environment.
 # Triggered on every push to main (squash merges assumed).
+#
+# All components deploy unconditionally to keep dev in sync with main.
 #
 # Requires secrets:
 #   AZURE_CLIENT_ID        — OIDC federated credential for Azure login
@@ -31,33 +33,9 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:
-  # ── Change detection ─────────────────────────────────
-  changes:
-    name: Detect changes
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    outputs:
-      api: ${{ steps.detect.outputs.api }}
-      web: ${{ steps.detect.outputs.web }}
-      infra: ${{ steps.detect.outputs.infra }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      - name: Detect changed paths
-        id: detect
-        uses: ./.github/actions/detect-changes
-        with:
-          mode: push
-          categories: api,web,infra
-          trigger-files: |
-            .github/workflows/cd-dev.yml:api,web,infra
-
   # ── Infrastructure: shared stack ─────────────────────
   infra-shared:
     name: "Infra: Pulumi up (shared)"
-    needs: changes
-    if: needs.changes.outputs.infra == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: development
@@ -87,8 +65,7 @@ jobs:
   # ── Infrastructure: dev stack ────────────────────────
   infra-dev:
     name: "Infra: Pulumi up (dev)"
-    needs: [changes, infra-shared]
-    if: needs.changes.outputs.infra == 'true'
+    needs: infra-shared
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: development
@@ -118,8 +95,6 @@ jobs:
   # ── API: build & push image ─────────────────────────
   api-image:
     name: "API: Build & push image"
-    needs: changes
-    if: needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: development
@@ -144,15 +119,9 @@ jobs:
         working-directory: api
 
   # ── API: deploy to dev ──────────────────────────────
-  # Runs when API code changed (new image) OR when infra changed (Pulumi may
-  # reset the container image to the placeholder — re-deploy the latest tag to
-  # recover).
   api-deploy:
     name: "API: Deploy to dev"
-    needs: [changes, api-image, infra-dev]
-    if: >-
-      !failure() && !cancelled()
-      && (needs.changes.outputs.api == 'true' || needs.changes.outputs.infra == 'true')
+    needs: [api-image, infra-dev]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: development
@@ -167,23 +136,15 @@ jobs:
 
       - name: Deploy to Container App
         run: |
-          if [ "${{ needs.changes.outputs.api }}" = "true" ]; then
-            TAG="${{ github.sha }}"
-          else
-            TAG="latest"
-          fi
           az containerapp update \
             --name "ca-town-crier-api-dev" \
             --resource-group "rg-town-crier-dev" \
-            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${TAG}"
+            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}"
 
   # ── Web: deploy to dev ──────────────────────────────
   web-deploy:
     name: "Web: Deploy to dev"
-    needs: [changes, infra-dev]
-    if: >-
-      !failure() && !cancelled()
-      && needs.changes.outputs.web == 'true'
+    needs: infra-dev
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: development

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -202,11 +202,12 @@ jobs:
           printenv | grep ^INTEGRATION_TEST_ > tests/town-crier.integration-tests/bin/Release/net10.0/.env
           dotnet exec tests/town-crier.integration-tests/bin/Release/net10.0/town-crier.integration-tests.dll
 
-  # ── API: promote staging to live ────────────────────
+  # ── API: clean up staging revision ───────────────────
 
-  api-promote:
-    name: "API: Promote staging"
+  api-staging-cleanup:
+    name: "API: Deactivate staging revision"
     needs: [api-staging, api-integration-test]
+    if: always() && needs.api-staging.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: development
@@ -219,20 +220,12 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Shift traffic to new revision
+      - name: Deactivate staging revision
         run: |
-          MODE=$(az containerapp show \
+          az containerapp revision deactivate \
             --name ca-town-crier-api-dev \
             --resource-group rg-town-crier-dev \
-            --query "properties.configuration.activeRevisionsMode" -o tsv)
-          if [ "$MODE" = "Single" ]; then
-            echo "Single-revision mode — traffic already routes to the latest revision"
-          else
-            az containerapp ingress traffic set \
-              --name ca-town-crier-api-dev \
-              --resource-group rg-town-crier-dev \
-              --revision-weight "${{ needs.api-staging.outputs.new-revision }}=100"
-          fi
+            --revision "${{ needs.api-staging.outputs.new-revision }}" || true
 
   # ── iOS ──────────────────────────────────────────────
 
@@ -356,7 +349,7 @@ jobs:
 
   gate:
     name: PR Gate
-    needs: [api-format, api-build-test, api-staging, api-integration-test, api-promote, ios-lint, ios-build-test, web-lint, web-build-test, infra-preview]
+    needs: [api-format, api-build-test, api-staging, api-integration-test, api-staging-cleanup, ios-lint, ios-build-test, web-lint, web-build-test, infra-preview]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -368,7 +361,7 @@ jobs:
             "${{ needs.api-build-test.result }}"
             "${{ needs.api-staging.result }}"
             "${{ needs.api-integration-test.result }}"
-            "${{ needs.api-promote.result }}"
+            "${{ needs.api-staging-cleanup.result }}"
             "${{ needs.ios-lint.result }}"
             "${{ needs.ios-build-test.result }}"
             "${{ needs.web-lint.result }}"

--- a/docs/adr/0017-cd-dev-always-deploy-and-pr-gate-no-promote.md
+++ b/docs/adr/0017-cd-dev-always-deploy-and-pr-gate-no-promote.md
@@ -22,7 +22,7 @@ The CI/CD pipeline had two issues causing the dev environment to drift from main
 
 - **Auto-merge**: Require a fine-grained PAT (`GH_AUTO_MERGE_TOKEN`) instead of `GITHUB_TOKEN` so the merge push triggers downstream workflows.
 
-- **GitHub Environments**: Configure deployment branch policies — production restricted to `main` branch and `v*` tags; development open to all branches (needed for PR staging tests).
+- **GitHub Environments**: Configure deployment branch policies — production restricted to `main` branch and `v*` tags; development has no branch restrictions (PR staging must deploy from any branch).
 
 ## Consequences
 

--- a/docs/adr/0017-cd-dev-always-deploy-and-pr-gate-no-promote.md
+++ b/docs/adr/0017-cd-dev-always-deploy-and-pr-gate-no-promote.md
@@ -1,0 +1,32 @@
+# 0017. CD Dev Always Deploys All Components; PR Gate No Longer Promotes
+
+Date: 2026-04-01
+
+## Status
+
+Accepted (supersedes deployment aspects of [0015](0015-cicd-pipeline-and-deployment-strategy.md))
+
+## Context
+
+The CI/CD pipeline had two issues causing the dev environment to drift from main:
+
+1. **PR Gate promoted API staging revisions to live traffic in dev.** This meant dev ran unmerged PR code after gate completion, and CD Dev redundantly rebuilt and redeployed the same code after merge.
+
+2. **CD Dev used change detection (`HEAD~1..HEAD`) to conditionally deploy only changed components.** This meant web-only or API-only merges left other components potentially out of sync. Combined with a GitHub Actions trigger gap (auto-merge via `GITHUB_TOKEN` can suppress downstream workflow triggers), some merges failed to deploy to dev at all.
+
+## Decision
+
+- **PR Gate**: Remove the `api-promote` step. The staging revision is deployed and integration-tested for validation, then deactivated after tests complete. Dev traffic is never shifted during a PR.
+
+- **CD Dev**: Remove change detection. Every push to main unconditionally deploys infrastructure (shared + dev stacks), API (build image + deploy), and web (build + deploy to SWA). This keeps dev in guaranteed sync with main.
+
+- **Auto-merge**: Require a fine-grained PAT (`GH_AUTO_MERGE_TOKEN`) instead of `GITHUB_TOKEN` so the merge push triggers downstream workflows.
+
+- **GitHub Environments**: Configure deployment branch policies — production restricted to `main` branch and `v*` tags; development open to all branches (needed for PR staging tests).
+
+## Consequences
+
+- Dev environment always reflects the latest state of main after every merge.
+- PR Gate no longer affects live dev traffic, eliminating orphaned staging revisions.
+- CD Dev runs take longer per merge (always builds API image + deploys web even if unchanged), but dev consistency is more valuable than saving a few minutes of CI time.
+- A fine-grained PAT must be created and stored as `GH_AUTO_MERGE_TOKEN` for auto-merge to work and trigger CD Dev.


### PR DESCRIPTION
## Summary

- **PR Gate**: Removed `api-promote` job — staging revision is now deactivated after integration tests instead of promoted to live. Dev traffic is never shifted during a PR.
- **CD Dev**: Removed change detection — every push to main unconditionally deploys infra (shared + dev), API (build + deploy), and web (build + deploy to SWA).
- **Auto-merge**: Now requires `GH_AUTO_MERGE_TOKEN` (fine-grained PAT) instead of `GITHUB_TOKEN` so merge pushes trigger downstream workflows like CD Dev.
- **GitHub Environments**: Configured deployment branch policies — production restricted to `main` + `v*` tags; development open to all branches.

See ADR 0017 for full context.

## Action required after merge

Create a **fine-grained PAT** with `Contents: write` + `Pull requests: write` scopes and add it as repo secret `GH_AUTO_MERGE_TOKEN`. Until then, auto-merge won't work (but CD Dev will still trigger on manual merges).

## Test plan

- [ ] PR Gate runs successfully — staging deploys, integration tests pass, cleanup deactivates revision
- [ ] Verify no live traffic shift occurs in dev during PR gate
- [ ] After merge, verify CD Dev deploys all 3 components (infra, API, web) regardless of what changed
- [ ] Create PAT, add as `GH_AUTO_MERGE_TOKEN`, verify auto-merge triggers CD Dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD now always deploys infra, API, and web on pushes to main; API images are deployed using the commit-specific tag.
  * PR validation deploys staging but no longer promotes staging traffic; staging revisions are deactivated after tests.
  * Auto-merge now uses a dedicated fine-grained token for authentication.

* **Documentation**
  * Added an ADR describing the updated deployment and PR validation strategy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->