### PR TITLE
fix(web): unwrap geocode API response envelope

### DIFF
--- a/web/src/api/geocoding.ts
+++ b/web/src/api/geocoding.ts
@@ -1,9 +1,15 @@
 import type { ApiClient } from './client';
 import type { GeocodeResult } from '../domain/types';
 
+interface GeocodeResponse {
+  readonly coordinates: GeocodeResult;
+}
+
 export function geocodingApi(client: ApiClient) {
   return {
-    geocode: (postcode: string) =>
-      client.get<GeocodeResult>(`/v1/geocode/${encodeURIComponent(postcode)}`),
+    geocode: async (postcode: string): Promise<GeocodeResult> => {
+      const response = await client.get<GeocodeResponse>(`/v1/geocode/${encodeURIComponent(postcode)}`);
+      return response.coordinates;
+    },
   };
 }


### PR DESCRIPTION
## Changes
- Unwrap the `coordinates` envelope from the geocode API response in `web/src/api/geocoding.ts`
- The adapter was returning `{ coordinates: { latitude, longitude } }` raw, causing `TypeError: Cannot read properties of undefined (reading 'toFixed')` on the onboarding confirm step
- Same class of envelope bug as #103 (watch zones)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced geocoding API to improve response handling consistency and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->