### PR TITLE
fix(api): generate ZoneId server-side to fix 500 on watch zone creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,10 @@ ALWAYS use installed CLI tools to complete tasks before asking the user to do so
 
 When a task involves any of these services, use the corresponding CLI directly. If a command fails or requires interactive auth, only then ask the user to intervene.
 
+### Deployments — PR-Only Policy
+
+NEVER deploy code directly using `az`, `pulumi`, or any other CLI tool. ALL code changes MUST be shipped via pull requests and deployed through CI/CD (GitHub Actions). Direct deployments bypass review, testing, and audit trails.
+
 ## Shell Commands — Non-Interactive Mode
 
 Always use non-interactive flags with file operations to avoid hanging on confirmation prompts (some systems alias `cp`, `mv`, `rm` to include `-i`):

--- a/api/src/town-crier.application/WatchZones/CreateWatchZoneRequest.cs
+++ b/api/src/town-crier.application/WatchZones/CreateWatchZoneRequest.cs
@@ -1,0 +1,8 @@
+namespace TownCrier.Application.WatchZones;
+
+public sealed record CreateWatchZoneRequest(
+    string Name,
+    double Latitude,
+    double Longitude,
+    double RadiusMetres,
+    int? AuthorityId = null);

--- a/api/src/town-crier.web/AppJsonSerializerContext.cs
+++ b/api/src/town-crier.web/AppJsonSerializerContext.cs
@@ -42,7 +42,7 @@ namespace TownCrier.Web;
 [JsonSerializable(typeof(SearchPlanningApplicationsResult))]
 [JsonSerializable(typeof(GetNotificationsResult))]
 [JsonSerializable(typeof(IReadOnlyList<SavedApplicationResult>))]
-[JsonSerializable(typeof(CreateWatchZoneCommand))]
+[JsonSerializable(typeof(CreateWatchZoneRequest))]
 [JsonSerializable(typeof(CreateWatchZoneResult))]
 [JsonSerializable(typeof(ListWatchZonesResult))]
 [JsonSerializable(typeof(UpdateZonePreferencesCommand))]

--- a/api/src/town-crier.web/Endpoints/WatchZoneEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/WatchZoneEndpoints.cs
@@ -16,6 +16,18 @@ internal static class WatchZoneEndpoints
             CancellationToken ct) =>
         {
             var userId = user.FindFirstValue("sub")!;
+            if (string.IsNullOrWhiteSpace(request.Name) ||
+                request.RadiusMetres <= 0 ||
+                request.Latitude is < -90 or > 90 ||
+                request.Longitude is < -180 or > 180 ||
+                request.AuthorityId is <= 0)
+            {
+                return Results.Json(
+                    new ApiErrorResponse("Invalid watch zone payload."),
+                    AppJsonSerializerContext.Default.ApiErrorResponse,
+                    statusCode: 400);
+            }
+
             var zoneId = Guid.NewGuid().ToString();
             var command = new CreateWatchZoneCommand(
                 userId,

--- a/api/src/town-crier.web/Endpoints/WatchZoneEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/WatchZoneEndpoints.cs
@@ -11,21 +11,22 @@ internal static class WatchZoneEndpoints
     {
         group.MapPost("/me/watch-zones", async (
             ClaimsPrincipal user,
-            CreateWatchZoneCommand command,
+            CreateWatchZoneRequest request,
             CreateWatchZoneCommandHandler handler,
             CancellationToken ct) =>
         {
             var userId = user.FindFirstValue("sub")!;
-            var fullCommand = new CreateWatchZoneCommand(
+            var zoneId = Guid.NewGuid().ToString();
+            var command = new CreateWatchZoneCommand(
                 userId,
-                command.ZoneId,
-                command.Name,
-                command.Latitude,
-                command.Longitude,
-                command.RadiusMetres,
-                command.AuthorityId);
-            var result = await handler.HandleAsync(fullCommand, ct).ConfigureAwait(false);
-            return Results.Created($"/v1/me/watch-zones/{command.ZoneId}", result);
+                zoneId,
+                request.Name,
+                request.Latitude,
+                request.Longitude,
+                request.RadiusMetres,
+                request.AuthorityId);
+            var result = await handler.HandleAsync(command, ct).ConfigureAwait(false);
+            return Results.Created($"/v1/me/watch-zones/{zoneId}", result);
         });
 
         group.MapGet("/me/watch-zones", async (

--- a/api/tests/town-crier.integration-tests/WatchZoneTests.cs
+++ b/api/tests/town-crier.integration-tests/WatchZoneTests.cs
@@ -23,12 +23,11 @@ public sealed class WatchZoneTests
         // Defensively create profile first (watch zones require a profile)
         await client.PostAsync(new Uri("/v1/me", UriKind.Relative), null).ConfigureAwait(false);
 
-        // Arrange -- unique zone ID and name (name has a unique key constraint per user)
-        var zoneId = Guid.NewGuid().ToString();
+        // Arrange -- unique name (name has a unique key constraint per user)
+        var uniqueSuffix = Guid.NewGuid().ToString()[..8];
         var createPayload = new
         {
-            zoneId,
-            name = $"Integration Test Zone {zoneId[..8]}",
+            name = $"Integration Test Zone {uniqueSuffix}",
             latitude = 51.5074,
             longitude = -0.1278,
             radiusMetres = 1000.0,
@@ -41,6 +40,10 @@ public sealed class WatchZoneTests
 
         // Assert -- create returns 201
         await Assert.That(createResponse.StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+        // Extract server-generated zone ID from Location header
+        var location = createResponse.Headers.Location?.ToString() ?? string.Empty;
+        var zoneId = location.Split('/')[^1];
 
         // Act -- list watch zones
         using var listResponse = await client


### PR DESCRIPTION
## Changes
- Created `CreateWatchZoneRequest` DTO for the POST body (name, latitude, longitude, radiusMetres, authorityId only)
- Endpoint now generates `ZoneId` via `Guid.NewGuid()` server-side instead of expecting it from the client
- Updated `AppJsonSerializerContext` for Native AOT compatibility
- Added PR-only deployment policy to CLAUDE.md

**Root cause:** The endpoint deserialized the request body into `CreateWatchZoneCommand` which includes `UserId` and `ZoneId`. The client doesn't send either — `ZoneId` defaulted to null, causing `WatchZone` constructor to throw `ArgumentException`.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Watch zone creation now validates name, radius, latitude, longitude, and authority, returning clear 400 errors for invalid payloads.
  * Zone identifiers are generated server-side; creation returns 201 Created with the new zone ID in Location.

* **Tests**
  * Integration tests updated to rely on server-generated zone IDs by extracting the Location header after creation.

* **Documentation**
  * Added deployment policy: all changes must go through pull requests and CI/CD (no direct CLI deployments).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->