### PR TITLE
fix(api): correct Cosmos container name casing for Notifications and Groups

### DIFF
--- a/api/src/town-crier.infrastructure/Cosmos/CosmosContainerNames.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosContainerNames.cs
@@ -9,8 +9,8 @@ public static class CosmosContainerNames
     public const string DatabaseName = "town-crier";
 
     public const string Users = "Users";
-    public const string Groups = "groups";
-    public const string Notifications = "notifications";
+    public const string Groups = "Groups";
+    public const string Notifications = "Notifications";
     public const string DeviceRegistrations = "DeviceRegistrations";
     public const string DecisionAlerts = "DecisionAlerts";
     public const string SavedApplications = "SavedApplications";


### PR DESCRIPTION
## Changes
- Fixed `CosmosContainerNames.Notifications` from `"notifications"` to `"Notifications"` (matching Pulumi-provisioned container)
- Fixed `CosmosContainerNames.Groups` from `"groups"` to `"Groups"` (matching Pulumi-provisioned container)

Cosmos DB container names are case-sensitive. The mismatch caused 404s on all queries to these containers, surfacing as 500 errors on `/v1/notifications` and `/v1/groups` endpoints.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal container naming conventions for data storage infrastructure to use consistent capitalization standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->