### PR TITLE
feat(web): add web app entry points to landing page & fix optional authorityId

### DIFF
--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -2,6 +2,8 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, beforeEach } from 'vitest';
+import { AuthProvider } from '../auth/auth-context';
+import { SpyAuthPort } from '../auth/__tests__/spies/spy-auth-port';
 import { LandingPage } from '../features/LandingPage/LandingPage';
 
 function stubMatchMedia(prefersDark: boolean): void {
@@ -21,7 +23,9 @@ function stubMatchMedia(prefersDark: boolean): void {
 function renderLandingPage() {
   return render(
     <MemoryRouter>
-      <LandingPage />
+      <AuthProvider value={new SpyAuthPort()}>
+        <LandingPage />
+      </AuthProvider>
     </MemoryRouter>,
   );
 }

--- a/web/src/components/Hero/Hero.module.css
+++ b/web/src/components/Hero/Hero.module.css
@@ -32,6 +32,20 @@
   margin-bottom: var(--tc-space-xl);
 }
 
+.ctaGroup {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--tc-space-sm);
+}
+
+@media (min-width: 640px) {
+  .ctaGroup {
+    flex-direction: row;
+    gap: var(--tc-space-md);
+  }
+}
+
 .cta {
   display: inline-flex;
   align-items: center;
@@ -51,6 +65,28 @@
   background: var(--tc-amber-hover);
   color: var(--tc-text-on-accent);
   text-decoration: none;
+}
+
+.ctaSecondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  padding: var(--tc-space-sm) var(--tc-space-lg);
+  background: transparent;
+  color: var(--tc-text-secondary);
+  font-size: var(--tc-text-body);
+  font-weight: var(--tc-weight-semibold);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  cursor: pointer;
+  transition: color var(--tc-duration-fast) ease,
+    border-color var(--tc-duration-fast) ease;
+}
+
+.ctaSecondary:hover {
+  color: var(--tc-text-primary);
+  border-color: var(--tc-text-secondary);
 }
 
 .scrollIndicator {

--- a/web/src/components/Hero/Hero.tsx
+++ b/web/src/components/Hero/Hero.tsx
@@ -1,6 +1,9 @@
+import { useHeroCta } from './useHeroCta';
 import styles from './Hero.module.css';
 
 export function Hero() {
+  const { handleTryWebApp } = useHeroCta();
+
   return (
     <header className={styles.hero} role="banner">
       <h1 className={styles.headline}>
@@ -10,14 +13,22 @@ export function Hero() {
         Monitoring planning applications across 417 local authorities in England
         and Wales — so you don&apos;t have to.
       </p>
-      <a
-        className={styles.cta}
-        href="https://apps.apple.com/app/town-crier"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Download on the App Store
-      </a>
+      <div className={styles.ctaGroup}>
+        <a
+          className={styles.cta}
+          href="https://apps.apple.com/app/town-crier"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Download on the App Store
+        </a>
+        <button
+          className={styles.ctaSecondary}
+          onClick={() => void handleTryWebApp()}
+        >
+          Try the Web App
+        </button>
+      </div>
       <div className={styles.scrollIndicator} aria-label="Scroll down">
         &#8595;
       </div>

--- a/web/src/components/Hero/__tests__/Hero.test.tsx
+++ b/web/src/components/Hero/__tests__/Hero.test.tsx
@@ -1,10 +1,22 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect } from 'vitest';
+import { AuthProvider } from '../../../auth/auth-context';
+import { SpyAuthPort } from '../../../auth/__tests__/spies/spy-auth-port';
 import { Hero } from '../Hero';
+
+function renderHero(spy?: SpyAuthPort) {
+  const authSpy = spy ?? new SpyAuthPort();
+  return render(
+    <AuthProvider value={authSpy}>
+      <Hero />
+    </AuthProvider>,
+  );
+}
 
 describe('Hero', () => {
   it('renders the headline', () => {
-    render(<Hero />);
+    renderHero();
 
     expect(
       screen.getByRole('heading', {
@@ -15,13 +27,13 @@ describe('Hero', () => {
   });
 
   it('renders the subheading about 417 authorities', () => {
-    render(<Hero />);
+    renderHero();
 
     expect(screen.getByText(/417 local authorities/i)).toBeInTheDocument();
   });
 
   it('renders an App Store CTA link', () => {
-    render(<Hero />);
+    renderHero();
 
     const cta = screen.getByRole('link', { name: /app store/i });
     expect(cta).toBeInTheDocument();
@@ -29,15 +41,46 @@ describe('Hero', () => {
   });
 
   it('renders a scroll indicator', () => {
-    render(<Hero />);
+    renderHero();
 
     expect(screen.getByLabelText(/scroll down/i)).toBeInTheDocument();
   });
 
   it('uses a section element with appropriate landmark', () => {
-    render(<Hero />);
+    renderHero();
 
     const section = screen.getByRole('banner');
     expect(section).toBeInTheDocument();
+  });
+
+  describe('Try the Web App CTA', () => {
+    it('renders a Try the Web App button', () => {
+      renderHero();
+
+      const button = screen.getByRole('button', { name: /try the web app/i });
+      expect(button).toBeInTheDocument();
+    });
+
+    it('calls loginWithRedirect when Try the Web App is clicked', async () => {
+      const spy = new SpyAuthPort();
+      const user = userEvent.setup();
+
+      renderHero(spy);
+
+      const button = screen.getByRole('button', { name: /try the web app/i });
+      await user.click(button);
+
+      expect(spy.loginWithRedirectCalls).toBe(1);
+    });
+
+    it('keeps the App Store link as the primary CTA', () => {
+      renderHero();
+
+      const appStoreLink = screen.getByRole('link', { name: /app store/i });
+      const webAppButton = screen.getByRole('button', { name: /try the web app/i });
+
+      expect(appStoreLink).toBeInTheDocument();
+      expect(webAppButton).toBeInTheDocument();
+    });
   });
 });

--- a/web/src/components/Hero/__tests__/useHeroCta.test.tsx
+++ b/web/src/components/Hero/__tests__/useHeroCta.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { AuthProvider } from '../../../auth/auth-context';
+import { SpyAuthPort } from '../../../auth/__tests__/spies/spy-auth-port';
+import { useHeroCta } from '../useHeroCta';
+
+function createWrapper(spy: SpyAuthPort) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <AuthProvider value={spy}>{children}</AuthProvider>;
+  };
+}
+
+describe('useHeroCta', () => {
+  it('returns a handleTryWebApp function', () => {
+    const spy = new SpyAuthPort();
+
+    const { result } = renderHook(() => useHeroCta(), {
+      wrapper: createWrapper(spy),
+    });
+
+    expect(result.current.handleTryWebApp).toBeInstanceOf(Function);
+  });
+
+  it('calls loginWithRedirect when handleTryWebApp is invoked', async () => {
+    const spy = new SpyAuthPort();
+
+    const { result } = renderHook(() => useHeroCta(), {
+      wrapper: createWrapper(spy),
+    });
+
+    await result.current.handleTryWebApp();
+
+    expect(spy.loginWithRedirectCalls).toBe(1);
+  });
+});

--- a/web/src/components/Hero/useHeroCta.ts
+++ b/web/src/components/Hero/useHeroCta.ts
@@ -1,0 +1,16 @@
+import { useCallback } from 'react';
+import { useAuth } from '../../auth/auth-context';
+
+interface HeroCtaState {
+  readonly handleTryWebApp: () => Promise<void>;
+}
+
+export function useHeroCta(): HeroCtaState {
+  const { loginWithRedirect } = useAuth();
+
+  const handleTryWebApp = useCallback(async () => {
+    await loginWithRedirect();
+  }, [loginWithRedirect]);
+
+  return { handleTryWebApp };
+}

--- a/web/src/components/Navbar/Navbar.module.css
+++ b/web/src/components/Navbar/Navbar.module.css
@@ -84,6 +84,29 @@
   text-decoration: none;
 }
 
+.signIn {
+  display: inline-flex;
+  align-items: center;
+  height: 40px;
+  padding: 0 var(--tc-space-md);
+  background-color: transparent;
+  color: var(--tc-text-secondary);
+  font-weight: var(--tc-weight-medium);
+  font-size: var(--tc-text-caption);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  text-decoration: none;
+  cursor: pointer;
+  transition: color var(--tc-duration-fast) ease,
+    border-color var(--tc-duration-fast) ease;
+}
+
+.signIn:hover {
+  color: var(--tc-text-primary);
+  border-color: var(--tc-text-secondary);
+  text-decoration: none;
+}
+
 .hamburger {
   display: flex;
   align-items: center;

--- a/web/src/components/Navbar/Navbar.tsx
+++ b/web/src/components/Navbar/Navbar.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTheme } from '../../hooks/useTheme';
+import { useNavbarAuth } from './useNavbarAuth';
 import { ThemeToggle } from '../ThemeToggle/ThemeToggle';
 import styles from './Navbar.module.css';
 
@@ -11,6 +12,7 @@ const NAV_LINKS = [
 
 export function Navbar() {
   const { theme, toggleTheme } = useTheme();
+  const { isAuthenticated, handleSignIn } = useNavbarAuth();
   const [menuOpen, setMenuOpen] = useState(false);
 
   const handleMenuToggle = () => {
@@ -38,6 +40,19 @@ export function Navbar() {
 
         <div className={styles.actions}>
           <ThemeToggle theme={theme} toggleTheme={toggleTheme} />
+
+          {isAuthenticated ? (
+            <a href="/dashboard" className={styles.signIn}>
+              Sign In
+            </a>
+          ) : (
+            <button
+              className={styles.signIn}
+              onClick={() => void handleSignIn?.()}
+            >
+              Sign In
+            </button>
+          )}
 
           <a href="#download" className={styles.cta}>
             Download

--- a/web/src/components/Navbar/__tests__/Navbar.test.tsx
+++ b/web/src/components/Navbar/__tests__/Navbar.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, beforeEach } from 'vitest';
+import { AuthProvider } from '../../../auth/auth-context';
+import { SpyAuthPort } from '../../../auth/__tests__/spies/spy-auth-port';
 import { Navbar } from '../Navbar';
 
 function stubMatchMedia(prefersDark: boolean): void {
@@ -17,6 +20,17 @@ function stubMatchMedia(prefersDark: boolean): void {
   window.matchMedia = (() => mediaQueryList) as typeof window.matchMedia;
 }
 
+function renderNavbar(spy?: SpyAuthPort) {
+  const authSpy = spy ?? new SpyAuthPort();
+  return render(
+    <MemoryRouter>
+      <AuthProvider value={authSpy}>
+        <Navbar />
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
 describe('Navbar', () => {
   beforeEach(() => {
     window.localStorage.clear();
@@ -25,20 +39,20 @@ describe('Navbar', () => {
   });
 
   it('renders a nav element', () => {
-    render(<Navbar />);
+    renderNavbar();
 
     expect(screen.getByRole('navigation')).toBeInTheDocument();
   });
 
   it('renders logo link pointing to "#"', () => {
-    render(<Navbar />);
+    renderNavbar();
 
     const logo = screen.getByRole('link', { name: /town crier/i });
     expect(logo).toHaveAttribute('href', '#');
   });
 
   it('renders anchor links for Features, Pricing, and FAQ', () => {
-    render(<Navbar />);
+    renderNavbar();
 
     const nav = screen.getByRole('navigation');
     const features = within(nav).getByRole('link', { name: /features/i });
@@ -51,14 +65,14 @@ describe('Navbar', () => {
   });
 
   it('renders Download CTA link', () => {
-    render(<Navbar />);
+    renderNavbar();
 
     const cta = screen.getByRole('link', { name: /download/i });
     expect(cta).toBeInTheDocument();
   });
 
   it('renders a ThemeToggle button', () => {
-    render(<Navbar />);
+    renderNavbar();
 
     expect(
       screen.getByRole('button', { name: /switch to dark mode/i }),
@@ -66,7 +80,7 @@ describe('Navbar', () => {
   });
 
   it('renders a hamburger menu button', () => {
-    render(<Navbar />);
+    renderNavbar();
 
     expect(
       screen.getByRole('button', { name: /menu/i }),
@@ -74,7 +88,7 @@ describe('Navbar', () => {
   });
 
   it('nav links are hidden by default on mobile (menu closed)', () => {
-    render(<Navbar />);
+    renderNavbar();
 
     const navLinks = screen.getByTestId('nav-links');
     expect(navLinks).toHaveAttribute('data-open', 'false');
@@ -82,7 +96,7 @@ describe('Navbar', () => {
 
   it('clicking hamburger opens the mobile menu', async () => {
     const user = userEvent.setup();
-    render(<Navbar />);
+    renderNavbar();
 
     const menuButton = screen.getByRole('button', { name: /menu/i });
     await user.click(menuButton);
@@ -93,7 +107,7 @@ describe('Navbar', () => {
 
   it('clicking hamburger again closes the mobile menu', async () => {
     const user = userEvent.setup();
-    render(<Navbar />);
+    renderNavbar();
 
     const menuButton = screen.getByRole('button', { name: /menu/i });
     await user.click(menuButton);
@@ -105,12 +119,47 @@ describe('Navbar', () => {
 
   it('hamburger button aria-expanded reflects menu state', async () => {
     const user = userEvent.setup();
-    render(<Navbar />);
+    renderNavbar();
 
     const menuButton = screen.getByRole('button', { name: /menu/i });
     expect(menuButton).toHaveAttribute('aria-expanded', 'false');
 
     await user.click(menuButton);
     expect(menuButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  describe('Sign In entry point', () => {
+    it('renders a Sign In link to /dashboard when authenticated', () => {
+      const spy = new SpyAuthPort();
+      spy.isAuthenticated = true;
+
+      renderNavbar(spy);
+
+      const link = screen.getByRole('link', { name: /sign in/i });
+      expect(link).toHaveAttribute('href', '/dashboard');
+    });
+
+    it('renders a Sign In button when not authenticated', () => {
+      const spy = new SpyAuthPort();
+      spy.isAuthenticated = false;
+
+      renderNavbar(spy);
+
+      const button = screen.getByRole('button', { name: /sign in/i });
+      expect(button).toBeInTheDocument();
+    });
+
+    it('calls loginWithRedirect when Sign In button is clicked', async () => {
+      const spy = new SpyAuthPort();
+      spy.isAuthenticated = false;
+      const user = userEvent.setup();
+
+      renderNavbar(spy);
+
+      const button = screen.getByRole('button', { name: /sign in/i });
+      await user.click(button);
+
+      expect(spy.loginWithRedirectCalls).toBe(1);
+    });
   });
 });

--- a/web/src/components/Navbar/__tests__/useNavbarAuth.test.ts
+++ b/web/src/components/Navbar/__tests__/useNavbarAuth.test.ts
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { AuthProvider } from '../../../auth/auth-context';
+import { SpyAuthPort } from '../../../auth/__tests__/spies/spy-auth-port';
+import { useNavbarAuth } from '../useNavbarAuth';
+
+function createWrapper(spy: SpyAuthPort) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return AuthProvider({ value: spy, children });
+  };
+}
+
+describe('useNavbarAuth', () => {
+  it('returns isAuthenticated true and no handleSignIn when user is authenticated', () => {
+    const spy = new SpyAuthPort();
+    spy.isAuthenticated = true;
+
+    const { result } = renderHook(() => useNavbarAuth(), {
+      wrapper: createWrapper(spy),
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.handleSignIn).toBeUndefined();
+  });
+
+  it('returns isAuthenticated false and a handleSignIn function when user is not authenticated', () => {
+    const spy = new SpyAuthPort();
+    spy.isAuthenticated = false;
+
+    const { result } = renderHook(() => useNavbarAuth(), {
+      wrapper: createWrapper(spy),
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.handleSignIn).toBeInstanceOf(Function);
+  });
+
+  it('calls loginWithRedirect when handleSignIn is invoked', async () => {
+    const spy = new SpyAuthPort();
+    spy.isAuthenticated = false;
+
+    const { result } = renderHook(() => useNavbarAuth(), {
+      wrapper: createWrapper(spy),
+    });
+
+    await result.current.handleSignIn!();
+
+    expect(spy.loginWithRedirectCalls).toBe(1);
+  });
+});

--- a/web/src/components/Navbar/__tests__/useNavbarAuth.test.tsx
+++ b/web/src/components/Navbar/__tests__/useNavbarAuth.test.tsx
@@ -6,7 +6,7 @@ import { useNavbarAuth } from '../useNavbarAuth';
 
 function createWrapper(spy: SpyAuthPort) {
   return function Wrapper({ children }: { children: ReactNode }) {
-    return AuthProvider({ value: spy, children });
+    return <AuthProvider value={spy}>{children}</AuthProvider>;
   };
 }
 

--- a/web/src/components/Navbar/useNavbarAuth.ts
+++ b/web/src/components/Navbar/useNavbarAuth.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+import { useAuth } from '../../auth/auth-context';
+
+interface NavbarAuthState {
+  readonly isAuthenticated: boolean;
+  readonly handleSignIn: (() => Promise<void>) | undefined;
+}
+
+export function useNavbarAuth(): NavbarAuthState {
+  const { isAuthenticated, loginWithRedirect } = useAuth();
+
+  const handleSignIn = useCallback(async () => {
+    await loginWithRedirect();
+  }, [loginWithRedirect]);
+
+  return {
+    isAuthenticated,
+    handleSignIn: isAuthenticated ? undefined : handleSignIn,
+  };
+}

--- a/web/src/domain/types.ts
+++ b/web/src/domain/types.ts
@@ -202,7 +202,7 @@ export interface CreateWatchZoneRequest {
   readonly latitude: number;
   readonly longitude: number;
   readonly radiusMetres: number;
-  readonly authorityId: number;
+  readonly authorityId?: number;
 }
 
 export interface UpdateProfileRequest {

--- a/web/src/features/LandingPage/__tests__/LandingPage.test.tsx
+++ b/web/src/features/LandingPage/__tests__/LandingPage.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, beforeEach } from 'vitest';
+import { AuthProvider } from '../../../auth/auth-context';
+import { SpyAuthPort } from '../../../auth/__tests__/spies/spy-auth-port';
 import { LandingPage } from '../LandingPage';
 
 function stubMatchMedia(): void {
@@ -20,7 +22,9 @@ function stubMatchMedia(): void {
 function renderLandingPage() {
   return render(
     <MemoryRouter>
-      <LandingPage />
+      <AuthProvider value={new SpyAuthPort()}>
+        <LandingPage />
+      </AuthProvider>
     </MemoryRouter>,
   );
 }

--- a/web/src/features/WatchZones/useCreateWatchZone.ts
+++ b/web/src/features/WatchZones/useCreateWatchZone.ts
@@ -66,7 +66,7 @@ export function useCreateWatchZone(
         latitude: state.coordinates.latitude,
         longitude: state.coordinates.longitude,
         radiusMetres: state.radiusMetres,
-        authorityId: state.authorityId as unknown as number,
+        authorityId: state.authorityId ?? undefined,
       });
       navigate('/watch-zones');
     } catch (err: unknown) {

--- a/web/src/features/onboarding/__tests__/OnboardingPage.test.tsx
+++ b/web/src/features/onboarding/__tests__/OnboardingPage.test.tsx
@@ -110,7 +110,6 @@ describe('OnboardingPage', () => {
       latitude: 51.5074,
       longitude: -0.1278,
       radiusMetres: 2000,
-      authorityId: 0,
     });
   });
 

--- a/web/src/features/onboarding/__tests__/useOnboarding.test.ts
+++ b/web/src/features/onboarding/__tests__/useOnboarding.test.ts
@@ -86,7 +86,6 @@ describe('useOnboarding', () => {
       latitude: 51.5074,
       longitude: -0.1278,
       radiusMetres: 2000,
-      authorityId: 0,
     });
     expect(result.current.isComplete).toBe(true);
     expect(result.current.isSubmitting).toBe(false);

--- a/web/src/features/onboarding/useOnboarding.ts
+++ b/web/src/features/onboarding/useOnboarding.ts
@@ -41,7 +41,6 @@ export function useOnboarding(port: OnboardingPort) {
         latitude: geocode.latitude,
         longitude: geocode.longitude,
         radiusMetres,
-        authorityId: 0,
       });
       setIsComplete(true);
     } catch (err) {


### PR DESCRIPTION
## Changes
- **Navbar Sign In**: added `useNavbarAuth` hook — renders link to `/dashboard` when authenticated, button triggering `loginWithRedirect` when not
- **Hero "Try the Web App" CTA**: added `useHeroCta` hook — secondary button alongside the primary App Store link, triggers Auth0 login
- **Styling**: design-language tokens for `.signIn`, `.ctaGroup`, `.ctaSecondary` CSS classes; responsive stacking on mobile
- **Tests**: 11 new tests across Navbar, Hero, and their hooks; existing test wrappers updated with `AuthProvider`
- **Bugfix**: made `authorityId` optional in `CreateWatchZoneRequest` — stops sending hardcoded `0`, API resolves it server-side via Postcodes.io mapping (#107)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Try the Web App" button to the landing page hero section that initiates authentication flow
  * Enhanced navbar with authentication-aware Sign In functionality—displays dashboard link when authenticated, sign-in button otherwise
  * Made authority ID optional when creating watch zones

* **Tests**
  * Added comprehensive test coverage for new authentication features in Hero and Navbar components
  * Updated existing tests to include authentication context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->