### PR TITLE
feat(api): add manual subscription grants admin endpoint

### DIFF
--- a/api/src/town-crier.application/Admin/GrantSubscriptionCommand.cs
+++ b/api/src/town-crier.application/Admin/GrantSubscriptionCommand.cs
@@ -1,0 +1,5 @@
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.Admin;
+
+public sealed record GrantSubscriptionCommand(string Email, SubscriptionTier Tier);

--- a/api/src/town-crier.application/Admin/GrantSubscriptionCommandHandler.cs
+++ b/api/src/town-crier.application/Admin/GrantSubscriptionCommandHandler.cs
@@ -1,0 +1,37 @@
+using TownCrier.Application.UserProfiles;
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.Admin;
+
+public sealed class GrantSubscriptionCommandHandler
+{
+    private static readonly DateTimeOffset FarFutureExpiry = new(2099, 12, 31, 0, 0, 0, TimeSpan.Zero);
+
+    private readonly IUserProfileRepository repository;
+
+    public GrantSubscriptionCommandHandler(IUserProfileRepository repository)
+    {
+        this.repository = repository;
+    }
+
+    public async Task<GrantSubscriptionResult> HandleAsync(GrantSubscriptionCommand command, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var profile = await this.repository.GetByEmailAsync(command.Email, ct).ConfigureAwait(false)
+            ?? throw new UserProfileNotFoundException($"No user profile found for email '{command.Email}'.");
+
+        if (command.Tier == SubscriptionTier.Free)
+        {
+            profile.ExpireSubscription();
+        }
+        else
+        {
+            profile.ActivateSubscription(command.Tier, FarFutureExpiry);
+        }
+
+        await this.repository.SaveAsync(profile, ct).ConfigureAwait(false);
+
+        return new GrantSubscriptionResult(profile.UserId, profile.Email, profile.Tier);
+    }
+}

--- a/api/src/town-crier.application/Admin/GrantSubscriptionResult.cs
+++ b/api/src/town-crier.application/Admin/GrantSubscriptionResult.cs
@@ -1,0 +1,8 @@
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.Admin;
+
+public sealed record GrantSubscriptionResult(
+    string UserId,
+    string? Email,
+    SubscriptionTier Tier);

--- a/api/src/town-crier.application/UserProfiles/CreateUserProfileCommand.cs
+++ b/api/src/town-crier.application/UserProfiles/CreateUserProfileCommand.cs
@@ -1,3 +1,3 @@
 namespace TownCrier.Application.UserProfiles;
 
-public sealed record CreateUserProfileCommand(string UserId);
+public sealed record CreateUserProfileCommand(string UserId, string? Email = null);

--- a/api/src/town-crier.application/UserProfiles/CreateUserProfileCommandHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/CreateUserProfileCommandHandler.cs
@@ -25,7 +25,7 @@ public sealed class CreateUserProfileCommandHandler
                 existing.Tier);
         }
 
-        var profile = UserProfile.Register(command.UserId);
+        var profile = UserProfile.Register(command.UserId, command.Email);
         await this.repository.SaveAsync(profile, ct).ConfigureAwait(false);
 
         return new CreateUserProfileResult(

--- a/api/src/town-crier.application/UserProfiles/IUserProfileRepository.cs
+++ b/api/src/town-crier.application/UserProfiles/IUserProfileRepository.cs
@@ -6,6 +6,8 @@ public interface IUserProfileRepository
 {
     Task<UserProfile?> GetByUserIdAsync(string userId, CancellationToken ct);
 
+    Task<UserProfile?> GetByEmailAsync(string email, CancellationToken ct);
+
     Task<IReadOnlyList<UserProfile>> GetAllByTierAsync(SubscriptionTier tier, CancellationToken ct);
 
     Task<UserProfile?> GetByOriginalTransactionIdAsync(string originalTransactionId, CancellationToken ct);

--- a/api/src/town-crier.domain/UserProfiles/SubscriptionTier.cs
+++ b/api/src/town-crier.domain/UserProfiles/SubscriptionTier.cs
@@ -3,5 +3,6 @@ namespace TownCrier.Domain.UserProfiles;
 public enum SubscriptionTier
 {
     Free,
+    Personal,
     Pro,
 }

--- a/api/src/town-crier.domain/UserProfiles/UserProfile.cs
+++ b/api/src/town-crier.domain/UserProfiles/UserProfile.cs
@@ -26,7 +26,7 @@ public sealed class UserProfile
 
     public string UserId { get; }
 
-    public string? Email { get; private set; }
+    public string? Email { get; }
 
     public string? Postcode { get; private set; }
 

--- a/api/src/town-crier.domain/UserProfiles/UserProfile.cs
+++ b/api/src/town-crier.domain/UserProfiles/UserProfile.cs
@@ -6,6 +6,7 @@ public sealed class UserProfile
 
     private UserProfile(
         string userId,
+        string? email,
         string? postcode,
         NotificationPreferences notificationPreferences,
         SubscriptionTier tier,
@@ -14,6 +15,7 @@ public sealed class UserProfile
         DateTimeOffset? gracePeriodExpiry)
     {
         this.UserId = userId;
+        this.Email = email;
         this.Postcode = postcode;
         this.NotificationPreferences = notificationPreferences;
         this.Tier = tier;
@@ -23,6 +25,8 @@ public sealed class UserProfile
     }
 
     public string UserId { get; }
+
+    public string? Email { get; private set; }
 
     public string? Postcode { get; private set; }
 
@@ -38,12 +42,13 @@ public sealed class UserProfile
 
     public DateTimeOffset? GracePeriodExpiry { get; private set; }
 
-    public static UserProfile Register(string userId)
+    public static UserProfile Register(string userId, string? email = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
 
         return new UserProfile(
             userId,
+            email,
             postcode: null,
             notificationPreferences: NotificationPreferences.Default,
             tier: SubscriptionTier.Free,
@@ -117,6 +122,7 @@ public sealed class UserProfile
 
     internal static UserProfile Reconstitute(
         string userId,
+        string? email,
         string? postcode,
         NotificationPreferences notificationPreferences,
         Dictionary<string, ZoneNotificationPreferences> zonePreferences,
@@ -127,6 +133,7 @@ public sealed class UserProfile
     {
         var profile = new UserProfile(
             userId,
+            email,
             postcode,
             notificationPreferences,
             tier,

--- a/api/src/town-crier.infrastructure/UserProfiles/CosmosUserProfileRepository.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/CosmosUserProfileRepository.cs
@@ -26,6 +26,19 @@ public sealed class CosmosUserProfileRepository : IUserProfileRepository
         return document?.ToDomain();
     }
 
+    public async Task<UserProfile?> GetByEmailAsync(string email, CancellationToken ct)
+    {
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Users,
+            "SELECT * FROM c WHERE c.email = @email",
+            [new QueryParameter("@email", email)],
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.UserProfileDocument,
+            ct).ConfigureAwait(false);
+
+        return documents.Count > 0 ? documents[0].ToDomain() : null;
+    }
+
     public async Task<IReadOnlyList<UserProfile>> GetAllByTierAsync(SubscriptionTier tier, CancellationToken ct)
     {
         var documents = await this.client.QueryAsync(

--- a/api/src/town-crier.infrastructure/UserProfiles/InMemoryUserProfileRepository.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/InMemoryUserProfileRepository.cs
@@ -22,6 +22,13 @@ public sealed class InMemoryUserProfileRepository : IUserProfileRepository
         return Task.FromResult<IReadOnlyList<UserProfile>>(profiles);
     }
 
+    public Task<UserProfile?> GetByEmailAsync(string email, CancellationToken ct)
+    {
+        var profile = this.store.Values
+            .FirstOrDefault(p => string.Equals(p.Email, email, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(profile);
+    }
+
     public Task<UserProfile?> GetByOriginalTransactionIdAsync(string originalTransactionId, CancellationToken ct)
     {
         var profile = this.store.Values

--- a/api/src/town-crier.infrastructure/UserProfiles/UserProfileDocument.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/UserProfileDocument.cs
@@ -8,6 +8,8 @@ internal sealed class UserProfileDocument
 
     public required string UserId { get; init; }
 
+    public string? Email { get; init; }
+
     public string? Postcode { get; init; }
 
     public required bool PushEnabled { get; init; }
@@ -32,6 +34,7 @@ internal sealed class UserProfileDocument
         {
             Id = profile.UserId,
             UserId = profile.UserId,
+            Email = profile.Email,
             Postcode = profile.Postcode,
             PushEnabled = profile.NotificationPreferences.PushEnabled,
             DigestDay = profile.NotificationPreferences.DigestDay,
@@ -50,6 +53,7 @@ internal sealed class UserProfileDocument
 
         return UserProfile.Reconstitute(
             this.UserId,
+            this.Email,
             this.Postcode,
             notificationPreferences,
             this.ZonePreferences,

--- a/api/src/town-crier.web/AppJsonSerializerContext.cs
+++ b/api/src/town-crier.web/AppJsonSerializerContext.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using TownCrier.Application.Admin;
 using TownCrier.Application.Authorities;
 using TownCrier.Application.DemoAccount;
 using TownCrier.Application.Designations;
@@ -42,4 +43,6 @@ namespace TownCrier.Web;
 [JsonSerializable(typeof(UpdateZonePreferencesResult))]
 [JsonSerializable(typeof(GetZonePreferencesResult))]
 [JsonSerializable(typeof(GetVersionConfigResult))]
+[JsonSerializable(typeof(GrantSubscriptionCommand))]
+[JsonSerializable(typeof(GrantSubscriptionResult))]
 internal sealed partial class AppJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.web/Endpoints/AdminApiKeyFilter.cs
+++ b/api/src/town-crier.web/Endpoints/AdminApiKeyFilter.cs
@@ -1,0 +1,27 @@
+namespace TownCrier.Web.Endpoints;
+
+internal sealed class AdminApiKeyFilter : IEndpointFilter
+{
+    private const string ApiKeyHeaderName = "X-Admin-Key";
+
+    private readonly string expectedApiKey;
+
+    public AdminApiKeyFilter(IConfiguration configuration)
+    {
+        this.expectedApiKey = configuration["Admin:ApiKey"]
+            ?? throw new InvalidOperationException("Admin:ApiKey configuration is required.");
+    }
+
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        if (!context.HttpContext.Request.Headers.TryGetValue(ApiKeyHeaderName, out var providedKey)
+            || !string.Equals(this.expectedApiKey, providedKey.ToString(), StringComparison.Ordinal))
+        {
+            return Results.Unauthorized();
+        }
+
+        return await next(context).ConfigureAwait(false);
+    }
+}

--- a/api/src/town-crier.web/Endpoints/AdminEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/AdminEndpoints.cs
@@ -1,0 +1,30 @@
+using TownCrier.Application.Admin;
+using TownCrier.Application.UserProfiles;
+
+namespace TownCrier.Web.Endpoints;
+
+internal static class AdminEndpoints
+{
+    public static void MapAdminEndpoints(this RouteGroupBuilder group)
+    {
+        var admin = group.MapGroup("/admin")
+            .AddEndpointFilter<AdminApiKeyFilter>()
+            .AllowAnonymous();
+
+        admin.MapPut("/subscriptions", async (
+            GrantSubscriptionCommand command,
+            GrantSubscriptionCommandHandler handler,
+            CancellationToken ct) =>
+        {
+            try
+            {
+                var result = await handler.HandleAsync(command, ct).ConfigureAwait(false);
+                return Results.Ok(result);
+            }
+            catch (UserProfileNotFoundException)
+            {
+                return Results.NotFound();
+            }
+        });
+    }
+}

--- a/api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
@@ -14,7 +14,8 @@ internal static class UserProfileEndpoints
             CancellationToken ct) =>
         {
             var userId = user.FindFirstValue("sub")!;
-            var result = await handler.HandleAsync(new CreateUserProfileCommand(userId), ct).ConfigureAwait(false);
+            var email = user.FindFirstValue("email");
+            var result = await handler.HandleAsync(new CreateUserProfileCommand(userId, email), ct).ConfigureAwait(false);
             return Results.Ok(result);
         });
 

--- a/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
+++ b/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using TownCrier.Application.Admin;
 using TownCrier.Application.Authorities;
 using TownCrier.Application.DecisionAlerts;
 using TownCrier.Application.DemoAccount;
@@ -142,6 +143,8 @@ internal static class ServiceCollectionExtensions
         services.AddTransient<GetSavedApplicationsQueryHandler>();
 
         services.AddTransient<GetDemoAccountQueryHandler>();
+
+        services.AddTransient<GrantSubscriptionCommandHandler>();
 
         return services;
     }

--- a/api/src/town-crier.web/Extensions/WebApplicationExtensions.cs
+++ b/api/src/town-crier.web/Extensions/WebApplicationExtensions.cs
@@ -39,6 +39,7 @@ internal static class WebApplicationExtensions
         v1.MapSavedApplicationEndpoints();
         v1.MapWatchZoneEndpoints();
         v1.MapDemoAccountEndpoints();
+        v1.MapAdminEndpoints();
 
         app.MapApiEndpoints();
     }

--- a/api/tests/town-crier.application.tests/Admin/GrantSubscriptionCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Admin/GrantSubscriptionCommandHandlerTests.cs
@@ -1,0 +1,97 @@
+using TownCrier.Application.Admin;
+using TownCrier.Application.Tests.UserProfiles;
+using TownCrier.Application.UserProfiles;
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.Tests.Admin;
+
+public sealed class GrantSubscriptionCommandHandlerTests
+{
+    [Test]
+    public async Task Should_ActivateProTier_When_UserFoundByEmail()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-1", "friend@example.com");
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new GrantSubscriptionCommandHandler(repository);
+        var command = new GrantSubscriptionCommand("friend@example.com", SubscriptionTier.Pro);
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Pro);
+        await Assert.That(result.Email).IsEqualTo("friend@example.com");
+    }
+
+    [Test]
+    public async Task Should_ActivatePersonalTier_When_Requested()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-1", "friend@example.com");
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new GrantSubscriptionCommandHandler(repository);
+        var command = new GrantSubscriptionCommand("friend@example.com", SubscriptionTier.Personal);
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Personal);
+    }
+
+    [Test]
+    public async Task Should_RevokeToFree_When_FreeTierRequested()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-1", "friend@example.com");
+        profile.ActivateSubscription(SubscriptionTier.Pro, DateTimeOffset.UtcNow.AddYears(73));
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new GrantSubscriptionCommandHandler(repository);
+        var command = new GrantSubscriptionCommand("friend@example.com", SubscriptionTier.Free);
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);
+    }
+
+    [Test]
+    public async Task Should_PersistTierChange_When_Granted()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-1", "friend@example.com");
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new GrantSubscriptionCommandHandler(repository);
+        var command = new GrantSubscriptionCommand("friend@example.com", SubscriptionTier.Pro);
+
+        // Act
+        await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        var saved = repository.GetByUserId("auth0|user-1");
+        await Assert.That(saved!.Tier).IsEqualTo(SubscriptionTier.Pro);
+    }
+
+    [Test]
+    public async Task Should_ThrowUserProfileNotFoundException_When_EmailNotFound()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var handler = new GrantSubscriptionCommandHandler(repository);
+        var command = new GrantSubscriptionCommand("nobody@example.com", SubscriptionTier.Pro);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<UserProfileNotFoundException>(
+            () => handler.HandleAsync(command, CancellationToken.None));
+    }
+}

--- a/api/tests/town-crier.application.tests/Notifications/UserProfileBuilder.cs
+++ b/api/tests/town-crier.application.tests/Notifications/UserProfileBuilder.cs
@@ -5,6 +5,7 @@ namespace TownCrier.Application.Tests.Notifications;
 internal sealed class UserProfileBuilder
 {
     private string userId = "user-1";
+    private string? email;
     private SubscriptionTier tier = SubscriptionTier.Free;
     private bool pushEnabled = true;
     private DayOfWeek digestDay = DayOfWeek.Monday;
@@ -12,6 +13,12 @@ internal sealed class UserProfileBuilder
     public UserProfileBuilder WithUserId(string userId)
     {
         this.userId = userId;
+        return this;
+    }
+
+    public UserProfileBuilder WithEmail(string? email)
+    {
+        this.email = email;
         return this;
     }
 
@@ -35,7 +42,7 @@ internal sealed class UserProfileBuilder
 
     public UserProfile Build()
     {
-        var profile = UserProfile.Register(this.userId);
+        var profile = UserProfile.Register(this.userId, this.email);
         profile.UpdatePreferences(
             postcode: null,
             new NotificationPreferences(this.pushEnabled, this.digestDay));

--- a/api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs
@@ -41,6 +41,22 @@ public sealed class CreateUserProfileCommandHandlerTests
     }
 
     [Test]
+    public async Task Should_StoreEmail_When_ProfileCreated()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var handler = new CreateUserProfileCommandHandler(repository);
+        var command = new CreateUserProfileCommand("auth0|user-email", "user@example.com");
+
+        // Act
+        await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        var saved = repository.GetByUserId("auth0|user-email");
+        await Assert.That(saved!.Email).IsEqualTo("user@example.com");
+    }
+
+    [Test]
     public async Task Should_ReturnExistingProfile_When_UserAlreadyExists()
     {
         // Arrange

--- a/api/tests/town-crier.application.tests/UserProfiles/FakeUserProfileRepository.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/FakeUserProfileRepository.cs
@@ -15,6 +15,13 @@ internal sealed class FakeUserProfileRepository : IUserProfileRepository
         return Task.FromResult(profile);
     }
 
+    public Task<UserProfile?> GetByEmailAsync(string email, CancellationToken ct)
+    {
+        var profile = this.store.Values
+            .FirstOrDefault(p => string.Equals(p.Email, email, StringComparison.OrdinalIgnoreCase));
+        return Task.FromResult(profile);
+    }
+
     public Task<IReadOnlyList<UserProfile>> GetAllByTierAsync(SubscriptionTier tier, CancellationToken ct)
     {
         var profiles = this.store.Values

--- a/api/tests/town-crier.application.tests/UserProfiles/FakeUserProfileRepositoryTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/FakeUserProfileRepositoryTests.cs
@@ -1,0 +1,36 @@
+using TownCrier.Application.UserProfiles;
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.Tests.UserProfiles;
+
+public sealed class FakeUserProfileRepositoryTests
+{
+    [Test]
+    public async Task GetByEmailAsync_Should_ReturnProfile_When_EmailMatches()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-1", "test@example.com");
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        // Act
+        var result = await repository.GetByEmailAsync("test@example.com", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.UserId).IsEqualTo("auth0|user-1");
+    }
+
+    [Test]
+    public async Task GetByEmailAsync_Should_ReturnNull_When_NoMatch()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+
+        // Act
+        var result = await repository.GetByEmailAsync("nobody@example.com", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNull();
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/UserProfiles/UserProfileDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/UserProfiles/UserProfileDocumentTests.cs
@@ -108,4 +108,34 @@ public sealed class UserProfileDocumentTests
         await Assert.That(document.ZonePreferences).IsNotNull();
         await Assert.That(document.ZonePreferences).IsEmpty();
     }
+
+    [Test]
+    public async Task Should_PreserveEmail_When_RoundTripped()
+    {
+        // Arrange
+        var original = UserProfile.Register("auth0|user-1", "test@example.com");
+
+        // Act
+        var document = UserProfileDocument.FromDomain(original);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(document.Email).IsEqualTo("test@example.com");
+        await Assert.That(roundTripped.Email).IsEqualTo("test@example.com");
+    }
+
+    [Test]
+    public async Task Should_HandleNullEmail_When_RoundTripped()
+    {
+        // Arrange
+        var original = UserProfile.Register("auth0|user-1");
+
+        // Act
+        var document = UserProfileDocument.FromDomain(original);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(document.Email).IsNull();
+        await Assert.That(roundTripped.Email).IsNull();
+    }
 }


### PR DESCRIPTION
## Changes
- Add `Personal` tier to `SubscriptionTier` enum (was only Free/Pro)
- Add `Email` property to `UserProfile` domain model, populated from Auth0 claims at profile creation
- Add `Email` field to `UserProfileDocument` with Cosmos round-trip tests
- Add `GetByEmailAsync` to `IUserProfileRepository` (interface, Cosmos impl, InMemory impl, fake)
- Pass email from Auth0 JWT claims through `CreateUserProfileCommand` on profile creation
- Create `GrantSubscriptionCommandHandler` — looks up user by email, sets tier with far-future expiry (5 tests)
- Add `AdminApiKeyFilter` endpoint filter for `X-Admin-Key` header authentication
- Wire up `PUT /v1/admin/subscriptions` endpoint with DI registration and AOT-compatible JSON serializer
- Add `Admin:ApiKey` dev configuration (gitignored)

## Usage
```bash
curl -X PUT https://api.dev.towncrierapp.uk/v1/admin/subscriptions \
  -H "X-Admin-Key: <key>" \
  -H "Content-Type: application/json" \
  -d '{"email": "friend@example.com", "tier": "Pro"}'
```

## Test Plan
- [x] 296 unit/integration tests pass (144 application + 109 infrastructure + 43 web)
- [x] `dotnet format --verify-no-changes` clean
- [x] Build succeeds with 0 warnings
- [x] Native AOT compatible (no reflection, source-generated JSON serializers)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Admin subscription management—admins can now grant subscription tiers to users
  * New "Personal" subscription tier added
  * User profiles now store email addresses
  * Admin endpoints secured with API key authentication

* **Tests**
  * Added tests for subscription management workflows and email storage functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->