### PR TITLE
ci: pass Admin__ApiKey to container app during deployment

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -9,6 +9,7 @@
 #   AZURE_SUBSCRIPTION_ID  — Azure subscription
 #   ACR_LOGIN_SERVER       — Azure Container Registry login server
 #   PULUMI_ACCESS_TOKEN    — Pulumi Cloud access token
+#   ADMIN_API_KEY          — API key for admin endpoints
 #
 # Requires GitHub Environment:
 #   development            — with OIDC federated credential (environment:development)
@@ -139,7 +140,8 @@ jobs:
           az containerapp update \
             --name "ca-town-crier-api-dev" \
             --resource-group "rg-town-crier-dev" \
-            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}"
+            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}" \
+            --set-env-vars "Admin__ApiKey=${{ secrets.ADMIN_API_KEY }}"
 
   # ── Web: deploy to dev ──────────────────────────────
   web-deploy:

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -6,6 +6,7 @@
 #   AZURE_TENANT_ID        — Azure AD tenant
 #   AZURE_SUBSCRIPTION_ID  — Azure subscription
 #   PULUMI_ACCESS_TOKEN    — Pulumi Cloud access token
+#   ADMIN_API_KEY          — API key for admin endpoints
 #
 # Requires GitHub Environment:
 #   production             — with OIDC federated credential (environment:production)
@@ -120,7 +121,8 @@ jobs:
           az containerapp update \
             --name "ca-town-crier-api-prod" \
             --resource-group "$RESOURCE_GROUP" \
-            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ steps.check-image.outputs.tag }}"
+            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ steps.check-image.outputs.tag }}" \
+            --set-env-vars "Admin__ApiKey=${{ secrets.ADMIN_API_KEY }}"
         env:
           RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
 


### PR DESCRIPTION
## Changes
- Add `ADMIN_API_KEY` GitHub Secret reference to both `cd-dev.yml` and `cd-prod.yml`
- Pass as `Admin__ApiKey` env var to the container app via `--set-env-vars` during `az containerapp update`

The `ADMIN_API_KEY` secret has been created with a placeholder value — update it to a real key before the next deployment.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous deployment workflows to configure admin API key authentication for both development and production environments. The admin API key is now injected as an environment variable during container deployment to enable secure access to admin endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->