### PR TITLE
fix(ci): use separate secret set step for admin API key

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -135,13 +135,19 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Set Container App secrets
+        run: |
+          az containerapp secret set \
+            --name "ca-town-crier-api-dev" \
+            --resource-group "rg-town-crier-dev" \
+            --secrets "admin-api-key=${{ secrets.ADMIN_API_KEY }}"
+
       - name: Deploy to Container App
         run: |
           az containerapp update \
             --name "ca-town-crier-api-dev" \
             --resource-group "rg-town-crier-dev" \
             --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}" \
-            --set-secrets "admin-api-key=${{ secrets.ADMIN_API_KEY }}" \
             --set-env-vars "Admin__ApiKey=secretref:admin-api-key"
 
   # ── Web: deploy to dev ──────────────────────────────

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -116,13 +116,21 @@ jobs:
             exit 1
           fi
 
+      - name: Set Container App secrets
+        run: |
+          az containerapp secret set \
+            --name "ca-town-crier-api-prod" \
+            --resource-group "$RESOURCE_GROUP" \
+            --secrets "admin-api-key=${{ secrets.ADMIN_API_KEY }}"
+        env:
+          RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
+
       - name: Deploy API image to prod
         run: |
           az containerapp update \
             --name "ca-town-crier-api-prod" \
             --resource-group "$RESOURCE_GROUP" \
             --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ steps.check-image.outputs.tag }}" \
-            --set-secrets "admin-api-key=${{ secrets.ADMIN_API_KEY }}" \
             --set-env-vars "Admin__ApiKey=secretref:admin-api-key"
         env:
           RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}


### PR DESCRIPTION
## Changes
- Split `az containerapp secret set` into its own step before `az containerapp update`, since `--set-secrets` is not a valid flag on `update`
- Applies to both dev and prod CD workflows

---
*Auto-shipped via ship skill*