### PR TITLE
fix(api): use correct PlanIt search parameter name

### DIFF
--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -95,7 +95,7 @@ public sealed class PlanItClient : IPlanItClient
     private static string BuildSearchUrl(string searchText, int authorityId, int page)
     {
         var encodedQuery = Uri.EscapeDataString(searchText);
-        return $"/api/applics/json?pg_sz={DefaultPageSize}&sort=-last_different&page={page}&auth={authorityId}&q={encodedQuery}";
+        return $"/api/applics/json?pg_sz={DefaultPageSize}&sort=-last_different&page={page}&auth={authorityId}&search={encodedQuery}";
     }
 
     private static string BuildUrl(int authorityId, DateTimeOffset? differentStart, int page)

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -243,6 +243,23 @@ public sealed class PlanItClientTests
         await Assert.That(handler.RequestUrls).HasCount().EqualTo(1);
     }
 
+    [Test]
+    public async Task Should_UseSearchParameter_When_SearchingApplications()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupJsonResponse("/api/applics/json", SingleRecordResponse);
+        var client = CreateClient(handler);
+
+        // Act
+        await client.SearchApplicationsAsync("car park", 314, 1, CancellationToken.None);
+
+        // Assert — must use 'search=' not 'q='
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(1);
+        await Assert.That(handler.RequestUrls[0]).Contains("search=car%20park");
+        await Assert.That(handler.RequestUrls[0]).DoesNotContain("&q=");
+    }
+
     private static PlanItClient CreateClient(
         FakePlanItHandler handler,
         PlanItRetryOptions? retryOptions = null,


### PR DESCRIPTION
## Changes
- Fix PlanIt search query parameter from `q=` to `search=` — PlanIt API requires `search` for keyword searches, causing HTTP 400 responses that surfaced as 500 errors in the frontend

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search functionality to use the proper query-parameter format when sending search requests to the PlanIt backend.
* **Tests**
  * Added an automated test to verify search requests include the correct query parameter and do not use the previous incorrect parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->