### PR TITLE
fix(api): serialize SubscriptionTier as string instead of integer

### DIFF
--- a/api/src/town-crier.domain/UserProfiles/SubscriptionTier.cs
+++ b/api/src/town-crier.domain/UserProfiles/SubscriptionTier.cs
@@ -1,5 +1,8 @@
+using System.Text.Json.Serialization;
+
 namespace TownCrier.Domain.UserProfiles;
 
+[JsonConverter(typeof(JsonStringEnumConverter<SubscriptionTier>))]
 public enum SubscriptionTier
 {
     Free,


### PR DESCRIPTION
## Changes
- Add `JsonStringEnumConverter<SubscriptionTier>` attribute to the `SubscriptionTier` enum so it serializes as `"Free"`/`"Personal"`/`"Pro"` instead of `0`/`1`/`2`
- Fixes the web profile page showing `2` instead of `Pro` for subscription tier
- Fixes the admin endpoint requiring numeric values instead of string names in request payloads

---
*Auto-shipped via ship skill*