### PR TITLE
fix(ci): add VITE env vars to prod web build

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -158,6 +158,11 @@ jobs:
       - name: Build
         run: npm run build
         working-directory: web
+        env:
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+          VITE_AUTH0_DOMAIN: ${{ vars.VITE_AUTH0_DOMAIN }}
+          VITE_AUTH0_CLIENT_ID: ${{ vars.VITE_AUTH0_CLIENT_ID }}
+          VITE_AUTH0_AUDIENCE: ${{ vars.VITE_AUTH0_AUDIENCE }}
 
       - uses: ./.github/actions/azure-login
         with:


### PR DESCRIPTION
## Changes
- Add `VITE_API_BASE_URL`, `VITE_AUTH0_DOMAIN`, `VITE_AUTH0_CLIENT_ID`, and `VITE_AUTH0_AUDIENCE` env vars to the prod CD web build step, matching the dev workflow

The prod web build was running without any VITE environment variables, so the React app loaded but had no API URL or Auth0 config — making the site non-functional.

Also set production-specific GitHub environment variables and added `https://towncrierapp.uk` to the Auth0 Web app's allowed origins/callbacks.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated production deployment workflow to configure build-time environment variables for API and authentication services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->