### PR TITLE
perf(web): fix render-blocking leaflet preload and Google Fonts

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -13,10 +13,12 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://towncrierapp.uk" />
 
-    <!-- Inter font -->
+    <!-- Inter font (non-render-blocking) -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="preload" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" as="style" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" media="print" onload="this.media='all'" />
+    <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" /></noscript>
   </head>
   <body>
     <div id="root"></div>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -16,9 +16,8 @@ export default defineConfig({
           if (id.includes('node_modules/@tanstack/')) {
             return 'query';
           }
-          if (id.includes('node_modules/leaflet') || id.includes('node_modules/react-leaflet')) {
-            return 'maps';
-          }
+          // leaflet intentionally omitted — only used by lazy-loaded
+          // MapPage, so Vite naturally splits it into that route chunk.
         },
       },
     },


### PR DESCRIPTION
## Changes

- **Remove leaflet from manualChunks**: The named `maps` chunk was being preloaded on every page (157KB JS + leaflet CSS) despite the Map route being lazy-loaded. Now Vite naturally bundles leaflet into the `ConnectedMapPage` lazy chunk — only fetched when visiting `/map`.
- **Async Google Fonts**: The stylesheet link to `fonts.googleapis.com` was render-blocking first paint. Switched to `media="print" onload="this.media='all'"` pattern so the page paints immediately with system fonts and swaps to Inter once loaded.

**Net effect on initial page load**: ~157KB less JS, 1 fewer render-blocking CSS file, and font loading no longer blocks first paint.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized font loading to prevent blocking initial page rendering

* **Chores**
  * Simplified build configuration for improved code-splitting efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->