### PR TITLE
fix(api): use smaller page size for PlanIt search queries

### DIFF
--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -11,6 +11,7 @@ namespace TownCrier.Infrastructure.PlanIt;
 public sealed class PlanItClient : IPlanItClient
 {
     private const int DefaultPageSize = 5000;
+    private const int SearchPageSize = 20;
 
     [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Jitter for backoff delay does not require cryptographic randomness")]
     private static readonly Random Jitter = new();
@@ -95,7 +96,7 @@ public sealed class PlanItClient : IPlanItClient
     private static string BuildSearchUrl(string searchText, int authorityId, int page)
     {
         var encodedQuery = Uri.EscapeDataString(searchText);
-        return $"/api/applics/json?pg_sz={DefaultPageSize}&sort=-last_different&page={page}&auth={authorityId}&search={encodedQuery}";
+        return $"/api/applics/json?pg_sz={SearchPageSize}&sort=-last_different&page={page}&auth={authorityId}&search={encodedQuery}";
     }
 
     private static string BuildUrl(int authorityId, DateTimeOffset? differentStart, int page)

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -254,10 +254,11 @@ public sealed class PlanItClientTests
         // Act
         await client.SearchApplicationsAsync("car park", 314, 1, CancellationToken.None);
 
-        // Assert — must use 'search=' not 'q='
+        // Assert — must use 'search=' not 'q=', and pg_sz must be small (not 5000)
         await Assert.That(handler.RequestUrls).HasCount().EqualTo(1);
         await Assert.That(handler.RequestUrls[0]).Contains("search=car%20park");
         await Assert.That(handler.RequestUrls[0]).DoesNotContain("&q=");
+        await Assert.That(handler.RequestUrls[0]).Contains("pg_sz=20");
     }
 
     private static PlanItClient CreateClient(


### PR DESCRIPTION
## Changes
- PlanIt API rejects `pg_sz=5000` on search queries with HTTP 400, which surfaced as 500 errors in the frontend
- Added separate `SearchPageSize = 20` constant for search, keeping the 5000 bulk ingestion size unchanged
- Extended regression test to assert correct page size in search URL

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized search result pagination to use smaller page sizes, improving response times and reducing memory overhead for search queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->