### PR TITLE
fix(web,api): support application UIDs containing slashes

### DIFF
--- a/api/src/town-crier.web/Endpoints/PlanningApplicationEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/PlanningApplicationEndpoints.cs
@@ -16,7 +16,7 @@ internal static class PlanningApplicationEndpoints
             return Results.Ok(result);
         });
 
-        group.MapGet("/applications/{uid}", async (
+        group.MapGet("/applications/{**uid}", async (
             string uid,
             GetApplicationByUidQueryHandler handler,
             CancellationToken ct) =>

--- a/api/src/town-crier.web/Endpoints/SavedApplicationEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/SavedApplicationEndpoints.cs
@@ -7,7 +7,7 @@ internal static class SavedApplicationEndpoints
 {
     public static void MapSavedApplicationEndpoints(this RouteGroupBuilder group)
     {
-        group.MapPut("/me/saved-applications/{applicationUid}", async (
+        group.MapPut("/me/saved-applications/{**applicationUid}", async (
             ClaimsPrincipal user,
             string applicationUid,
             SaveApplicationCommandHandler handler,
@@ -18,7 +18,7 @@ internal static class SavedApplicationEndpoints
             return Results.NoContent();
         });
 
-        group.MapDelete("/me/saved-applications/{applicationUid}", async (
+        group.MapDelete("/me/saved-applications/{**applicationUid}", async (
             ClaimsPrincipal user,
             string applicationUid,
             RemoveSavedApplicationCommandHandler handler,

--- a/web/src/AppRoutes.tsx
+++ b/web/src/AppRoutes.tsx
@@ -67,7 +67,7 @@ export function AppRoutes() {
           <Route element={<AppShell />}>
             <Route path="/dashboard" element={<ConnectedDashboardPage />} />
             <Route path="/applications" element={<ConnectedApplicationsPage />} />
-            <Route path="/applications/:uid" element={<ConnectedApplicationDetailPage />} />
+            <Route path="/applications/*" element={<ConnectedApplicationDetailPage />} />
             <Route path="/watch-zones" element={<ConnectedWatchZoneListPage />} />
             <Route path="/watch-zones/new" element={<ConnectedWatchZoneCreatePage />} />
             <Route path="/watch-zones/:zoneId" element={<ConnectedWatchZoneEditPage />} />

--- a/web/src/features/ApplicationDetail/ApplicationDetailPage.tsx
+++ b/web/src/features/ApplicationDetail/ApplicationDetailPage.tsx
@@ -20,7 +20,7 @@ export function ApplicationDetailPage({
   designationRepository,
   savedApplicationRepository,
 }: Props) {
-  const { uid: rawUid } = useParams<{ uid: string }>();
+  const { '*': rawUid } = useParams();
   const uid = asApplicationUid(rawUid ?? '');
 
   const { application, isLoading, error } = useApplication(applicationRepository, uid);

--- a/web/src/features/ApplicationDetail/__tests__/ApplicationDetailPage.test.tsx
+++ b/web/src/features/ApplicationDetail/__tests__/ApplicationDetailPage.test.tsx
@@ -29,7 +29,7 @@ function renderPage(
     <MemoryRouter initialEntries={[`/applications/${uid}`]}>
       <Routes>
         <Route
-          path="/applications/:uid"
+          path="/applications/*"
           element={
             <ApplicationDetailPage
               applicationRepository={appRepo}


### PR DESCRIPTION
## Summary
- PlanIt application UIDs contain forward slashes (e.g. `26/00402/CLC`) which React Router and ASP.NET Core interpret as path separators, causing a blank screen on the application detail page
- Uses splat routes (`/*`) on the frontend and catch-all route parameters (`{**uid}`) on the backend to capture the full UID including slashes
- Affects application detail, save, and unsave endpoints

## Test plan
- [ ] Navigate to search, find an application, click it — detail page should load
- [ ] Verify save/unsave buttons work on the detail page
- [ ] Verify `/applications` list page still works (not caught by splat route)
- [ ] Check map popup "View details" links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced routing infrastructure for API endpoints managing planning and saved applications to support more flexible URL parameter formats.
  * Updated web application routing configuration for application detail pages to align with backend endpoint structural changes.

* **Tests**
  * Updated test route configurations and test assertions throughout the test suite to reflect routing infrastructure updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->