### PR TITLE
fix(api): upsert search results into Cosmos for detail page

### DIFF
--- a/api/src/town-crier.application/Search/SearchPlanningApplicationsQueryHandler.cs
+++ b/api/src/town-crier.application/Search/SearchPlanningApplicationsQueryHandler.cs
@@ -1,4 +1,5 @@
 using TownCrier.Application.PlanIt;
+using TownCrier.Application.PlanningApplications;
 using TownCrier.Application.UserProfiles;
 using TownCrier.Domain.UserProfiles;
 
@@ -8,13 +9,16 @@ public sealed class SearchPlanningApplicationsQueryHandler
 {
     private readonly IUserProfileRepository userProfileRepository;
     private readonly IPlanItClient planItClient;
+    private readonly IPlanningApplicationRepository applicationRepository;
 
     public SearchPlanningApplicationsQueryHandler(
         IUserProfileRepository userProfileRepository,
-        IPlanItClient planItClient)
+        IPlanItClient planItClient,
+        IPlanningApplicationRepository applicationRepository)
     {
         this.userProfileRepository = userProfileRepository;
         this.planItClient = planItClient;
+        this.applicationRepository = applicationRepository;
     }
 
     public async Task<SearchPlanningApplicationsResult> HandleAsync(
@@ -33,6 +37,11 @@ public sealed class SearchPlanningApplicationsQueryHandler
 
         var result = await this.planItClient.SearchApplicationsAsync(
             query.SearchText, query.AuthorityId, query.Page, ct).ConfigureAwait(false);
+
+        foreach (var application in result.Applications)
+        {
+            await this.applicationRepository.UpsertAsync(application, ct).ConfigureAwait(false);
+        }
 
         var summaries = result.Applications.Select(a => new PlanningApplicationSummary(
             a.Uid,

--- a/api/tests/town-crier.application.tests/Search/SearchPlanningApplicationsQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Search/SearchPlanningApplicationsQueryHandlerTests.cs
@@ -21,7 +21,8 @@ public sealed class SearchPlanningApplicationsQueryHandlerTests
         await userProfileRepository.SaveAsync(profile, CancellationToken.None);
 
         var planItClient = new FakePlanItClient();
-        var handler = new SearchPlanningApplicationsQueryHandler(userProfileRepository, planItClient);
+        var appRepo = new FakePlanningApplicationRepository();
+        var handler = new SearchPlanningApplicationsQueryHandler(userProfileRepository, planItClient, appRepo);
 
         var query = new SearchPlanningApplicationsQuery("user-1", "extension", AuthorityId: 42);
 
@@ -49,7 +50,8 @@ public sealed class SearchPlanningApplicationsQueryHandlerTests
         planItClient.AddSearchResult(application);
         planItClient.SearchTotal = 1;
 
-        var handler = new SearchPlanningApplicationsQueryHandler(userProfileRepository, planItClient);
+        var appRepo = new FakePlanningApplicationRepository();
+        var handler = new SearchPlanningApplicationsQueryHandler(userProfileRepository, planItClient, appRepo);
         var query = new SearchPlanningApplicationsQuery("user-1", "extension", AuthorityId: 42);
 
         // Act
@@ -66,6 +68,38 @@ public sealed class SearchPlanningApplicationsQueryHandlerTests
     }
 
     [Test]
+    public async Task Should_UpsertSearchResults_Into_Repository()
+    {
+        // Arrange
+        var profile = new UserProfileBuilder()
+            .WithUserId("user-1")
+            .WithTier(SubscriptionTier.Pro)
+            .Build();
+        var userProfileRepository = new FakeUserProfileRepository();
+        await userProfileRepository.SaveAsync(profile, CancellationToken.None);
+
+        var application = new PlanningApplicationBuilder()
+            .WithName("Extension to rear")
+            .WithUid("planit-123")
+            .Build();
+        var planItClient = new FakePlanItClient();
+        planItClient.AddSearchResult(application);
+        planItClient.SearchTotal = 1;
+
+        var appRepo = new FakePlanningApplicationRepository();
+        var handler = new SearchPlanningApplicationsQueryHandler(userProfileRepository, planItClient, appRepo);
+        var query = new SearchPlanningApplicationsQuery("user-1", "extension", AuthorityId: 42);
+
+        // Act
+        await handler.HandleAsync(query, CancellationToken.None);
+
+        // Assert
+        var stored = await appRepo.GetByUidAsync("planit-123", CancellationToken.None);
+        await Assert.That(stored).IsNotNull();
+        await Assert.That(stored!.Name).IsEqualTo("Extension to rear");
+    }
+
+    [Test]
     public async Task Should_ReturnEmptyResults_When_NoMatchesFound()
     {
         // Arrange
@@ -79,7 +113,8 @@ public sealed class SearchPlanningApplicationsQueryHandlerTests
         var planItClient = new FakePlanItClient();
         planItClient.SearchTotal = 0;
 
-        var handler = new SearchPlanningApplicationsQueryHandler(userProfileRepository, planItClient);
+        var appRepo = new FakePlanningApplicationRepository();
+        var handler = new SearchPlanningApplicationsQueryHandler(userProfileRepository, planItClient, appRepo);
         var query = new SearchPlanningApplicationsQuery("user-1", "nonexistent", AuthorityId: 42);
 
         // Act
@@ -96,7 +131,8 @@ public sealed class SearchPlanningApplicationsQueryHandlerTests
         // Arrange
         var userProfileRepository = new FakeUserProfileRepository();
         var planItClient = new FakePlanItClient();
-        var handler = new SearchPlanningApplicationsQueryHandler(userProfileRepository, planItClient);
+        var appRepo = new FakePlanningApplicationRepository();
+        var handler = new SearchPlanningApplicationsQueryHandler(userProfileRepository, planItClient, appRepo);
         var query = new SearchPlanningApplicationsQuery("nonexistent-user", "extension", AuthorityId: 42);
 
         // Act & Assert


### PR DESCRIPTION
## Summary
- Search queries PlanIt API directly, but the application detail page reads from Cosmos DB
- Applications found via search that weren't ingested via polling returned 404 on the detail page
- The search handler now upserts PlanIt results into Cosmos DB, ensuring they're available when clicked

## Test plan
- [ ] Search for applications, click a result — detail page should load (no more 404)
- [ ] Verify existing search functionality is unchanged (results, pagination)
- [ ] Verify polling-ingested applications still work on detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Planning application search results are now automatically persisted to the database upon completion of each search, enabling improved data consistency and faster retrieval of previously searched applications.

* **Tests**
  * Added comprehensive tests to validate that search results are correctly persisted to and retrievable from the database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->