### PR TITLE
fix(api): use camelCase property name in Cosmos DB UID query

### DIFF
--- a/api/src/town-crier.infrastructure/PlanningApplications/CosmosPlanningApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/PlanningApplications/CosmosPlanningApplicationRepository.cs
@@ -34,7 +34,7 @@ public sealed class CosmosPlanningApplicationRepository : IPlanningApplicationRe
 
         var documents = await this.client.QueryAsync(
             CosmosContainerNames.Applications,
-            "SELECT * FROM c WHERE c.Uid = @uid",
+            "SELECT * FROM c WHERE c.uid = @uid",
             [new QueryParameter("@uid", uid)],
             partitionKey: null,
             CosmosJsonSerializerContext.Default.PlanningApplicationDocument,


### PR DESCRIPTION
## Changes
- Fix case mismatch in Cosmos DB SQL query: `c.Uid` → `c.uid` in `GetByUidAsync`
- The `CosmosJsonSerializerContext` uses `CamelCase` naming policy, so documents store `uid` (lowercase), but the query was looking for `Uid` (PascalCase)
- This caused 404 errors on the application detail page after clicking search results or application list items

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a database query condition affecting planning applications retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->