### PR TITLE
docs: update README with web frontend and current tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,18 @@ Town Crier is a mobile-first app for monitoring UK local authority planning appl
 | Component | Technology |
 |-----------|-----------|
 | Backend API | .NET 10, ASP.NET Core, Native AOT |
+| Web Frontend | React 19, TypeScript, Vite |
 | Database | Azure Cosmos DB (Serverless) |
 | iOS App | Swift, SwiftUI, SwiftData |
 | Infrastructure | Pulumi (C# / .NET 10), Azure Container Apps |
 | CI/CD | GitHub Actions |
-| Testing | TUnit (.NET), XCTest (iOS) |
+| Testing | TUnit (.NET), Vitest (Web), XCTest (iOS) |
 
 ## Repository Structure
 
 ```plaintext
 /api          — .NET backend (Hexagonal Architecture / Ports & Adapters)
+/web          — React frontend (Vite, Leaflet maps, Auth0)
 /mobile/ios   — Native iOS app (MVVM-C)
 /infra        — Pulumi Infrastructure as Code
 /docs/adr     — Architecture Decision Records
@@ -27,6 +29,7 @@ Town Crier is a mobile-first app for monitoring UK local authority planning appl
 ### Prerequisites
 
 - [.NET 10 SDK](https://dotnet.microsoft.com/download)
+- [Node.js](https://nodejs.org/) (for web development)
 - [Xcode](https://developer.apple.com/xcode/) (for iOS development)
 - [Docker](https://www.docker.com/) (for running integration tests)
 
@@ -36,6 +39,16 @@ Town Crier is a mobile-first app for monitoring UK local authority planning appl
 cd api
 dotnet build
 dotnet test
+```
+
+### Web
+
+```bash
+cd web
+npm install
+npm run dev       # Vite dev server with hot reload
+npm run build     # Production build
+npx vitest run    # Run tests
 ```
 
 ### iOS
@@ -48,7 +61,7 @@ swift test
 
 ## Architecture
 
-Town Crier follows a **hexagonal architecture** (ports and adapters) on the backend with **CQRS** for command/query separation and **Domain-Driven Design** with rich domain models. The iOS app uses **MVVM-C** (Model-View-ViewModel-Coordinator) with Swift Concurrency.
+Town Crier follows a **hexagonal architecture** (ports and adapters) on the backend with **CQRS** for command/query separation and **Domain-Driven Design** with rich domain models. The web frontend uses **React** with **Leaflet** for interactive maps, **Auth0** for authentication, and **React Query** for server state. The iOS app uses **MVVM-C** (Model-View-ViewModel-Coordinator) with Swift Concurrency.
 
 Data is ingested from [PlanIt](https://www.planit.org.uk/) via a polling-based model. See the [Architecture Decision Records](docs/adr/) for detailed design rationale.
 


### PR DESCRIPTION
## Changes
- Added React 19 / TypeScript / Vite to the tech stack table
- Added `/web` to the repository structure
- Added Node.js to prerequisites
- Added web Getting Started section (dev, build, test commands)
- Updated architecture description with web frontend details (Leaflet maps, Auth0, React Query)
- Added Vitest to the testing row

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with Web Frontend setup and development instructions, including Node.js prerequisites, dependency installation, dev server commands, production build steps, and web testing procedures.
  * Extended architecture documentation to include the web frontend technology stack and testing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->