### PR TITLE
chore(ci): bump GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/azure-login/action.yml
+++ b/.github/actions/azure-login/action.yml
@@ -1,4 +1,4 @@
-# Wraps azure/login@v2 with OIDC federated credentials.
+# Wraps azure/login@v3 with OIDC federated credentials.
 # Centralises the three-input pattern used across all deployment workflows.
 name: Azure Login (OIDC)
 description: Login to Azure using OIDC federated credentials
@@ -18,7 +18,7 @@ runs:
   using: composite
   steps:
     - name: Login to Azure
-      uses: azure/login@v2
+      uses: azure/login@v3
       with:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}

--- a/.github/actions/setup-dotnet-infra/action.yml
+++ b/.github/actions/setup-dotnet-infra/action.yml
@@ -7,12 +7,12 @@ runs:
   using: composite
   steps:
     - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         global-json-file: api/global.json
 
     - name: Cache NuGet packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.nuget/packages
         key: nuget-infra-${{ runner.os }}-${{ hashFiles('infra/**/*.csproj') }}

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 15
     environment: development
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-dotnet-infra
 
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 15
     environment: development
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-dotnet-infra
 
@@ -100,7 +100,7 @@ jobs:
     timeout-minutes: 10
     environment: development
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/azure-login
         with:
@@ -127,7 +127,7 @@ jobs:
     timeout-minutes: 5
     environment: development
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/azure-login
         with:
@@ -158,9 +158,9 @@ jobs:
     timeout-minutes: 10
     environment: development
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -41,7 +41,7 @@ jobs:
       resource-group: ${{ steps.outputs.outputs.resource-group }}
       swa-name: ${{ steps.outputs.outputs.swa-name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-dotnet-infra
 
@@ -81,7 +81,7 @@ jobs:
     timeout-minutes: 5
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -143,9 +143,9 @@ jobs:
     timeout-minutes: 10
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -41,7 +41,7 @@ jobs:
       web: ${{ steps.detect.outputs.web }}
       infra: ${{ steps.detect.outputs.infra }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Detect changed paths
@@ -65,8 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
         with:
           global-json-file: api/global.json
       - run: dotnet format --verify-no-changes
@@ -79,11 +79,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
         with:
           global-json-file: api/global.json
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: nuget-${{ runner.os }}-${{ hashFiles('api/**/*.csproj', 'api/**/Directory.Build.props') }}
@@ -112,7 +112,7 @@ jobs:
       staging-url: ${{ steps.staging-url.outputs.url }}
       new-revision: ${{ steps.deploy.outputs.revision }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/azure-login
         with:
@@ -178,9 +178,9 @@ jobs:
     timeout-minutes: 10
     environment: development
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@v5
         with:
           global-json-file: api/global.json
 
@@ -212,7 +212,7 @@ jobs:
     timeout-minutes: 5
     environment: development
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/azure-login
         with:
@@ -236,7 +236,7 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: brew install swiftlint
       - run: swiftlint lint
         working-directory: mobile/ios
@@ -248,8 +248,8 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
+      - uses: actions/checkout@v6
+      - uses: actions/cache@v5
         with:
           path: mobile/ios/.build
           key: ios-${{ runner.os }}-${{ hashFiles('mobile/ios/Package.resolved') }}
@@ -276,8 +276,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -294,8 +294,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -322,7 +322,7 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: ./.github/actions/setup-dotnet-infra
 

--- a/docs/memo/0003-ultra-subscription-tier.md
+++ b/docs/memo/0003-ultra-subscription-tier.md
@@ -1,0 +1,72 @@
+# 0003. Ultra Subscription Tier for Property Professionals
+
+Date: 2026-04-02
+
+## Status
+
+Open
+
+## Question
+
+What value-add features could justify a premium "Ultra" subscription tier (£15-25/mo) aimed at property professionals (developers, agents, planning consultants)?
+
+## Analysis
+
+The current tier structure is Free, Personal (£1.99/mo), and Pro (£5.99/mo). Pro gates search. There is room for a premium tier targeting professionals whose workflows revolve around monitoring, due diligence, and lead generation from planning data.
+
+Facebook and Nextdoor were investigated as community sentiment sources. Both are walled gardens with no viable API path for reading public discussion content. Facebook's Group API is restricted to admin management tools only; Nextdoor has no read API at all and actively blocks scraping. These are ruled out.
+
+UK government open data APIs are well-suited as enrichment sources — free, OGL-licensed, and covering property, environment, and heritage data.
+
+## Options Considered
+
+### Feature Set — Two Layers
+
+The recommended structure is a convenience base ("Research Desk") for daily stickiness, plus genuinely unique intelligence features as a competitive moat.
+
+**Research Desk (Convenience)**
+
+1. **Site Intelligence Card** — Enriched panel on each planning application showing last sale price (Land Registry Price Paid, free bulk CSV), EPC rating (Open EPC API, free), flood risk (EA Flood Risk API, free), listed building status (Historic England API, free), and conservation area designation (data.gov.uk / LPA datasets, free). Compresses 30 minutes of tabbing between government websites into one glance.
+
+2. **Planning History** — Full history of all past applications at a specific address, queryable from existing PlanIt data (~20M records). Useful for due diligence: "has this site been refused before?"
+
+3. **Authority Analytics** — Per-authority approval/refusal rates, average decision timelines, breakdowns by application type, regional comparisons. Derived entirely from existing PlanIt data.
+
+**Intelligence Layer (Moat)**
+
+4. **Scraped Public Comments + Sentiment** — Scrape comments from council planning portals (iDox, Uniform, etc.) and surface alongside the application with a sentiment summary. Separate investigation track already underway. High defensibility due to scraping infrastructure complexity.
+
+5. **Decision Prediction** — Statistical model predicting likely outcome and timeline based on authority history, application type, and size. Doesn't require sophisticated ML — even authority-level approval rates by app type would be valuable.
+
+6. **Opportunity Alerts** — Pattern-based signals beyond simple "new application in your zone":
+   - Refused-then-resubmitted detector (flags new applications at previously refused addresses)
+   - Lapsing permission detector (old permissions with no apparent build activity)
+   - Withdrawn pre-application alerts (someone tested the waters and backed off)
+
+7. **Application Change Timeline** — Full state change history for each application over time, built from existing PlanIt polling data (`lastDifferent` tracking). Shows how long each stage took.
+
+8. **Competitor/Agent Activity** — Text parsing of applicant/agent fields in PlanIt data to surface patterns: "This developer submitted 12 applications in your watch zone this year."
+
+### Data Sources
+
+| Source | Cost | Notes |
+|--------|------|-------|
+| HM Land Registry Price Paid | Free | OGL, monthly bulk CSV |
+| Open EPC API | Free | Registration required |
+| EA Flood Risk API | Free | Rivers/sea + surface water |
+| Historic England API | Free | Listed buildings, scheduled monuments |
+| Conservation Areas | Free (varies) | data.gov.uk / individual LPAs |
+| PlanIt | Free | Already integrated |
+| Council planning portals | Free (scraping) | Separate investigation |
+
+### Ruled Out
+
+- **Facebook / Nextdoor integration** — walled gardens, no viable API or scraping path
+- **PDF export / report builder** — deferred, rabbit hole
+- **Paid commercial data sources** — not viable until revenue justifies the spend
+
+## Recommendation
+
+This is a strong feature set for a £15-25/mo tier. Research Desk features (1-3) are mostly API integrations and could ship first. Intelligence features (4-8) are higher effort but provide genuine differentiation. Recommend building incrementally: Research Desk first for immediate value, then layering intelligence features over subsequent releases.
+
+No decision needed yet — this memo captures the initial exploration for further refinement.


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v6, `actions/setup-dotnet` v4 → v5, `actions/cache` v4 → v5, `actions/setup-node` v4 → v6, `azure/login` v2 → v3
- All bumps target Node.js 24 compatibility ahead of the June 2, 2026 deprecation deadline
- `pulumi/actions@v6` already on the correct major version — no change needed

## Test plan
- [ ] PR Gate pipeline passes (this PR touches all three workflow files, so all jobs should trigger)
- [ ] Verify no deprecation warnings in the Actions log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple GitHub Actions in CI/CD workflows and composite actions to their latest major versions, including checkout, Node.js setup, .NET SDK installation, and Azure authentication steps, for improved reliability and enhanced security.

* **Documentation**
  * Added documentation exploring a potential new "Ultra" subscription tier targeting property professionals, outlining proposed features, pricing considerations, and phased development approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->