### PR TITLE
chore(ci): force Node.js 24 for pulumi/actions@v6

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -32,6 +32,7 @@ permissions:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # ── Infrastructure: shared stack ─────────────────────

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -29,6 +29,7 @@ permissions:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # ── Infrastructure ────────────────────────────────────

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -29,6 +29,7 @@ permissions:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   changes:


### PR DESCRIPTION
## Changes
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var to cd-dev, cd-prod, and pr-gate workflows
- Silences Node.js 20 deprecation warnings from `pulumi/actions@v6` (latest v6.6.1 still hardcodes `using: node20`)
- Upstream fix tracked in pulumi/actions#1403 — this env var is the recommended workaround until Pulumi ships a native node24 update

---
*Auto-shipped via ship skill*