### PR TITLE
chore(ci): replace pulumi/actions with direct CLI calls

### DIFF
--- a/.github/actions/setup-dotnet-infra/action.yml
+++ b/.github/actions/setup-dotnet-infra/action.yml
@@ -1,7 +1,7 @@
-# Sets up .NET SDK (via global.json) and caches NuGet packages for infra projects.
-# Centralises the setup-dotnet + cache pair used across infra jobs.
-name: Setup .NET for Infra
-description: Install .NET SDK from global.json and cache NuGet packages for infra projects
+# Sets up .NET SDK (via global.json), Pulumi CLI, and caches NuGet packages
+# for infra projects. Centralises the setup used across infra jobs.
+name: Setup .NET & Pulumi for Infra
+description: Install .NET SDK, Pulumi CLI, and cache NuGet packages for infra projects
 
 runs:
   using: composite
@@ -10,6 +10,14 @@ runs:
       uses: actions/setup-dotnet@v5
       with:
         global-json-file: api/global.json
+
+    - name: Install Pulumi CLI
+      shell: bash
+      run: curl -fsSL https://get.pulumi.com | sh
+
+    - name: Add Pulumi to PATH
+      shell: bash
+      run: echo "$HOME/.pulumi/bin" >> "$GITHUB_PATH"
 
     - name: Cache NuGet packages
       uses: actions/cache@v5

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -32,7 +32,6 @@ permissions:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # ── Infrastructure: shared stack ─────────────────────
@@ -52,17 +51,17 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: pulumi/actions@v6
-        with:
-          command: up
-          stack-name: shared
-          work-dir: infra
+      - name: Pulumi up (shared)
+        working-directory: infra
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           ARM_USE_OIDC: true
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          pulumi stack select shared
+          pulumi up --yes --non-interactive
 
   # ── Infrastructure: dev stack ────────────────────────
   infra-dev:
@@ -82,17 +81,17 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: pulumi/actions@v6
-        with:
-          command: up
-          stack-name: dev
-          work-dir: infra
+      - name: Pulumi up (dev)
+        working-directory: infra
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           ARM_USE_OIDC: true
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          pulumi stack select dev
+          pulumi up --yes --non-interactive
 
   # ── API: build & push image ─────────────────────────
   api-image:

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -29,7 +29,6 @@ permissions:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # ── Infrastructure ────────────────────────────────────
@@ -52,18 +51,17 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Pulumi up
-        uses: pulumi/actions@v6
-        with:
-          command: up
-          stack-name: prod
-          work-dir: infra
+      - name: Pulumi up (prod)
+        working-directory: infra
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           ARM_USE_OIDC: true
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          pulumi stack select prod
+          pulumi up --yes --non-interactive
 
       - name: Extract Pulumi outputs
         id: outputs

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -29,7 +29,6 @@ permissions:
 env:
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   changes:
@@ -333,18 +332,25 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - uses: pulumi/actions@v6
-        with:
-          command: preview
-          stack-name: ${{ vars.PULUMI_STACK }}
-          work-dir: infra
-          comment-on-pr: true
+      - name: Pulumi preview
+        working-directory: infra
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
           ARM_USE_OIDC: true
           ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          pulumi stack select ${{ vars.PULUMI_STACK }}
+          pulumi preview --non-interactive 2>&1 | tee /tmp/pulumi-preview.txt
+
+      - name: Comment preview on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PREVIEW=$(cat /tmp/pulumi-preview.txt)
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body "$(printf '<details><summary>Pulumi preview — <code>${{ vars.PULUMI_STACK }}</code></summary>\n\n```\n%s\n```\n\n</details>' "$PREVIEW")"
 
   # ── Gate (sole required status check) ────────────────
 


### PR DESCRIPTION
## Changes
- Install Pulumi CLI via `curl` in the `setup-dotnet-infra` composite action (no Node.js runtime needed)
- Replace all `pulumi/actions@v6` steps with inline `pulumi` CLI commands in cd-dev, cd-prod, and pr-gate workflows
- Post Pulumi preview output as a PR comment via `gh pr comment` instead of the action's built-in `comment-on-pr`
- Remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var (no longer needed — no Node.js actions remain for Pulumi)

**Why:** `pulumi/actions@v6` (latest v6.6.1) hardcodes `using: node20`. GitHub is deprecating Node.js 20 runners, and there is no v7 yet ([pulumi/actions#1403](https://github.com/pulumi/actions/issues/1403)). The `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` workaround suppresses the runtime error but not the warning annotation. Replacing the action entirely eliminates the dependency.

---
*Auto-shipped via ship skill*