### PR TITLE
docs(adr): remove stale Groups/GroupInvitations from ADR 0008

### DIFF
--- a/docs/adr/0008-cosmos-db-data-model.md
+++ b/docs/adr/0008-cosmos-db-data-model.md
@@ -86,8 +86,9 @@ The Applications container change feed is consumed by the notification processor
 |-----------|--------------|-----------|
 | `DeviceRegistrations` | `/userId` | APNs device tokens per user, supporting multiple devices per platform. Queried when dispatching push notifications |
 | `SavedApplications` | `/userId` | User-bookmarked planning applications. Always queried per-user for the saved applications list |
-| `Groups` | `/ownerId` | Community groups with shared watch zones. Owner-scoped queries for group management |
-| `GroupInvitations` | `/groupId` | Pending/accepted/declined invitations to join a group. Group-scoped for invitation management, with cross-partition query by invitee email on acceptance |
 | `DecisionAlerts` | `/userId` | Alerts triggered when a watched application receives a decision. Per-user feed similar to Notifications |
 
-- Total containers: 10 (original 5 + 5 new). The `Leases` container for change feed checkpointing remains as documented.
+- Total containers: 8 (original 5 + 3 new). The `Leases` container for change feed checkpointing remains as documented.
+
+### 2026-04-03
+- Removed: **Groups** and **GroupInvitations** containers. The community groups feature was removed from the codebase — no domain entities, API handlers, or Pulumi container definitions exist. Web frontend explicitly asserts no Group-related symbols are exported. Container count corrected from 10 to 8.


### PR DESCRIPTION
## Changes
- Updated ADR 0008 (Cosmos DB Data Model) to remove Groups and GroupInvitations containers from the 2026-03-27 amendment
- Corrected container count from 10 to 8
- Added 2026-04-03 amendment documenting the removal (groups feature was removed from codebase — no domain entities, API handlers, or Pulumi definitions exist)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architecture documentation to reflect the removal of community groups functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->