### PR TITLE
fix(api): include application details in saved applications response

### DIFF
--- a/api/src/town-crier.application/SavedApplications/GetSavedApplicationsQueryHandler.cs
+++ b/api/src/town-crier.application/SavedApplications/GetSavedApplicationsQueryHandler.cs
@@ -1,20 +1,39 @@
+using TownCrier.Application.PlanningApplications;
+
 namespace TownCrier.Application.SavedApplications;
 
 public sealed class GetSavedApplicationsQueryHandler
 {
-    private readonly ISavedApplicationRepository repository;
+    private readonly ISavedApplicationRepository savedRepository;
+    private readonly IPlanningApplicationRepository applicationRepository;
 
-    public GetSavedApplicationsQueryHandler(ISavedApplicationRepository repository)
+    public GetSavedApplicationsQueryHandler(
+        ISavedApplicationRepository savedRepository,
+        IPlanningApplicationRepository applicationRepository)
     {
-        this.repository = repository;
+        this.savedRepository = savedRepository;
+        this.applicationRepository = applicationRepository;
     }
 
     public async Task<IReadOnlyList<SavedApplicationResult>> HandleAsync(GetSavedApplicationsQuery query, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        var saved = await this.repository.GetByUserIdAsync(query.UserId, ct).ConfigureAwait(false);
+        var saved = await this.savedRepository.GetByUserIdAsync(query.UserId, ct).ConfigureAwait(false);
 
-        return saved.Select(s => new SavedApplicationResult(s.ApplicationUid, s.SavedAt)).ToList();
+        var results = new List<SavedApplicationResult>();
+        foreach (var s in saved)
+        {
+            var application = await this.applicationRepository.GetByUidAsync(s.ApplicationUid, ct).ConfigureAwait(false);
+            if (application is not null)
+            {
+                results.Add(new SavedApplicationResult(
+                    s.ApplicationUid,
+                    s.SavedAt,
+                    GetApplicationByUidQueryHandler.ToResult(application)));
+            }
+        }
+
+        return results;
     }
 }

--- a/api/src/town-crier.application/SavedApplications/SavedApplicationResult.cs
+++ b/api/src/town-crier.application/SavedApplications/SavedApplicationResult.cs
@@ -1,3 +1,8 @@
+using TownCrier.Application.PlanningApplications;
+
 namespace TownCrier.Application.SavedApplications;
 
-public sealed record SavedApplicationResult(string ApplicationUid, DateTimeOffset SavedAt);
+public sealed record SavedApplicationResult(
+    string ApplicationUid,
+    DateTimeOffset SavedAt,
+    PlanningApplicationResult Application);

--- a/api/tests/town-crier.application.tests/SavedApplications/GetSavedApplicationsQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/SavedApplications/GetSavedApplicationsQueryHandlerTests.cs
@@ -1,4 +1,7 @@
+using TownCrier.Application.PlanningApplications;
 using TownCrier.Application.SavedApplications;
+using TownCrier.Application.Tests.Polling;
+using TownCrier.Domain.PlanningApplications;
 using TownCrier.Domain.SavedApplications;
 
 namespace TownCrier.Application.Tests.SavedApplications;
@@ -9,8 +12,9 @@ public sealed class GetSavedApplicationsQueryHandlerTests
     public async Task Should_ReturnEmptyList_When_UserHasNoSavedApplications()
     {
         // Arrange
-        var repository = new FakeSavedApplicationRepository();
-        var handler = new GetSavedApplicationsQueryHandler(repository);
+        var savedRepository = new FakeSavedApplicationRepository();
+        var applicationRepository = new FakePlanningApplicationRepository();
+        var handler = new GetSavedApplicationsQueryHandler(savedRepository, applicationRepository);
         var query = new GetSavedApplicationsQuery("auth0|user-1");
 
         // Act
@@ -21,17 +25,24 @@ public sealed class GetSavedApplicationsQueryHandlerTests
     }
 
     [Test]
-    public async Task Should_ReturnSavedApplications_When_UserHasSaved()
+    public async Task Should_ReturnSavedApplicationsWithDetails_When_UserHasSaved()
     {
         // Arrange
-        var repository = new FakeSavedApplicationRepository();
+        var savedRepository = new FakeSavedApplicationRepository();
+        var applicationRepository = new FakePlanningApplicationRepository();
         var savedAt = new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero);
-        await repository.SaveAsync(
+
+        var app1 = CreateApplication("planit-uid-abc", "APP/2026/001", "Wiltshire");
+        var app2 = CreateApplication("planit-uid-def", "APP/2026/002", "Somerset");
+        await applicationRepository.UpsertAsync(app1, CancellationToken.None);
+        await applicationRepository.UpsertAsync(app2, CancellationToken.None);
+
+        await savedRepository.SaveAsync(
             SavedApplication.Create("auth0|user-1", "planit-uid-abc", savedAt), CancellationToken.None);
-        await repository.SaveAsync(
+        await savedRepository.SaveAsync(
             SavedApplication.Create("auth0|user-1", "planit-uid-def", savedAt.AddHours(1)), CancellationToken.None);
 
-        var handler = new GetSavedApplicationsQueryHandler(repository);
+        var handler = new GetSavedApplicationsQueryHandler(savedRepository, applicationRepository);
         var query = new GetSavedApplicationsQuery("auth0|user-1");
 
         // Act
@@ -40,21 +51,31 @@ public sealed class GetSavedApplicationsQueryHandlerTests
         // Assert
         await Assert.That(result).HasCount().EqualTo(2);
         await Assert.That(result[0].ApplicationUid).IsEqualTo("planit-uid-abc");
+        await Assert.That(result[0].Application.Name).IsEqualTo("APP/2026/001");
+        await Assert.That(result[0].Application.AreaName).IsEqualTo("Wiltshire");
         await Assert.That(result[1].ApplicationUid).IsEqualTo("planit-uid-def");
+        await Assert.That(result[1].Application.Name).IsEqualTo("APP/2026/002");
     }
 
     [Test]
     public async Task Should_OnlyReturnOwnApplications_When_MultipleUsersHaveSaved()
     {
         // Arrange
-        var repository = new FakeSavedApplicationRepository();
+        var savedRepository = new FakeSavedApplicationRepository();
+        var applicationRepository = new FakePlanningApplicationRepository();
         var savedAt = DateTimeOffset.UtcNow;
-        await repository.SaveAsync(
+
+        var app1 = CreateApplication("planit-uid-abc", "APP/2026/001", "Wiltshire");
+        var app2 = CreateApplication("planit-uid-def", "APP/2026/002", "Somerset");
+        await applicationRepository.UpsertAsync(app1, CancellationToken.None);
+        await applicationRepository.UpsertAsync(app2, CancellationToken.None);
+
+        await savedRepository.SaveAsync(
             SavedApplication.Create("auth0|user-1", "planit-uid-abc", savedAt), CancellationToken.None);
-        await repository.SaveAsync(
+        await savedRepository.SaveAsync(
             SavedApplication.Create("auth0|user-2", "planit-uid-def", savedAt), CancellationToken.None);
 
-        var handler = new GetSavedApplicationsQueryHandler(repository);
+        var handler = new GetSavedApplicationsQueryHandler(savedRepository, applicationRepository);
         var query = new GetSavedApplicationsQuery("auth0|user-1");
 
         // Act
@@ -63,5 +84,55 @@ public sealed class GetSavedApplicationsQueryHandlerTests
         // Assert
         await Assert.That(result).HasCount().EqualTo(1);
         await Assert.That(result[0].ApplicationUid).IsEqualTo("planit-uid-abc");
+    }
+
+    [Test]
+    public async Task Should_ExcludeSavedApplication_When_PlanningApplicationNoLongerExists()
+    {
+        // Arrange
+        var savedRepository = new FakeSavedApplicationRepository();
+        var applicationRepository = new FakePlanningApplicationRepository();
+        var savedAt = new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero);
+
+        var app = CreateApplication("planit-uid-abc", "APP/2026/001", "Wiltshire");
+        await applicationRepository.UpsertAsync(app, CancellationToken.None);
+
+        await savedRepository.SaveAsync(
+            SavedApplication.Create("auth0|user-1", "planit-uid-abc", savedAt), CancellationToken.None);
+        await savedRepository.SaveAsync(
+            SavedApplication.Create("auth0|user-1", "planit-uid-orphaned", savedAt.AddHours(1)), CancellationToken.None);
+
+        var handler = new GetSavedApplicationsQueryHandler(savedRepository, applicationRepository);
+        var query = new GetSavedApplicationsQuery("auth0|user-1");
+
+        // Act
+        var result = await handler.HandleAsync(query, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].ApplicationUid).IsEqualTo("planit-uid-abc");
+    }
+
+    private static PlanningApplication CreateApplication(string uid, string name, string areaName)
+    {
+        return new PlanningApplication(
+            name: name,
+            uid: uid,
+            areaName: areaName,
+            areaId: 1,
+            address: "1 Test Street",
+            postcode: "BA1 1AA",
+            description: "Test application",
+            appType: "Full",
+            appState: "Undecided",
+            appSize: null,
+            startDate: new DateOnly(2026, 1, 15),
+            decidedDate: null,
+            consultedDate: null,
+            longitude: -2.36,
+            latitude: 51.38,
+            url: null,
+            link: null,
+            lastDifferent: DateTimeOffset.UtcNow);
     }
 }


### PR DESCRIPTION
## Summary
- The `GET /v1/me/saved-applications` endpoint only returned `{ applicationUid, savedAt }`, but the web frontend expected each item to include an `application` field with the full planning application summary
- This caused the Saved tab to crash silently — `ApplicationCard` received `undefined` as its `application` prop and threw when accessing properties like `appState` and `uid`
- Enriched `GetSavedApplicationsQueryHandler` to look up each saved application's details via `IPlanningApplicationRepository`, filtering out orphaned saves where the application no longer exists

## Test plan
- [x] All 145 application tests pass (including 4 updated/new tests for the query handler)
- [x] All 110 infrastructure tests pass
- [x] All 43 web tests pass
- [x] All 406 frontend tests pass
- [x] `dotnet format --verify-no-changes` clean
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)