### PR TITLE
fix(web): replace Remove button with × circle on saved cards

### DIFF
--- a/web/src/features/SavedApplications/SavedApplicationsPage.module.css
+++ b/web/src/features/SavedApplications/SavedApplicationsPage.module.css
@@ -24,6 +24,10 @@
   position: relative;
 }
 
+.item > a {
+  padding-right: var(--tc-space-xxl);
+}
+
 .removeButton {
   position: absolute;
   top: var(--tc-space-sm);
@@ -31,21 +35,26 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: var(--tc-space-xs) var(--tc-space-sm);
+  width: 28px;
+  height: 28px;
+  padding: 0;
   border: 1px solid var(--tc-border);
-  border-radius: var(--tc-radius-sm);
+  border-radius: 50%;
   background: var(--tc-surface);
   color: var(--tc-text-secondary);
-  font-size: var(--tc-text-caption);
+  font-size: var(--tc-text-body);
+  line-height: 1;
   cursor: pointer;
   z-index: 1;
   transition: color var(--tc-duration-fast) ease,
-    border-color var(--tc-duration-fast) ease;
+    border-color var(--tc-duration-fast) ease,
+    background-color var(--tc-duration-fast) ease;
 }
 
 .removeButton:hover {
   color: var(--tc-status-refused);
   border-color: var(--tc-status-refused);
+  background-color: color-mix(in srgb, var(--tc-status-refused) 10%, transparent);
 }
 
 .removeButton:focus-visible {

--- a/web/src/features/SavedApplications/SavedApplicationsPage.tsx
+++ b/web/src/features/SavedApplications/SavedApplicationsPage.tsx
@@ -78,7 +78,7 @@ export function SavedApplicationsPage({ repository }: Props) {
               }}
               aria-label={`Remove ${saved.application.name}`}
             >
-              Remove
+              ×
             </button>
           </li>
         ))}


### PR DESCRIPTION
## Changes
- Replace the rectangular "Remove" text button with a compact × circle icon on saved application cards
- Add right padding to the card so the status badge no longer collides with the remove button
- Add subtle red background tint on hover for the × button

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Improved remove button appearance with updated sizing, circular design, and enhanced hover interactions
* Adjusted link spacing for better visual layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->