### PR TITLE
feat(web): show loading indicator during cold start

### DIFF
--- a/web/src/auth/AuthGuard.tsx
+++ b/web/src/auth/AuthGuard.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
+import { FullPageLoader } from '../components/FullPageLoader/FullPageLoader.tsx';
 import { useAuth } from './auth-context.ts';
 
 export function AuthGuard() {
@@ -12,7 +13,7 @@ export function AuthGuard() {
   }, [isLoading, isAuthenticated, error, loginWithRedirect]);
 
   if (isLoading || !isAuthenticated) {
-    return null;
+    return <FullPageLoader message="Signing you in\u2026" />;
   }
 
   return <Outlet />;

--- a/web/src/auth/AuthGuard.tsx
+++ b/web/src/auth/AuthGuard.tsx
@@ -13,7 +13,7 @@ export function AuthGuard() {
   }, [isLoading, isAuthenticated, error, loginWithRedirect]);
 
   if (isLoading || !isAuthenticated) {
-    return <FullPageLoader message="Signing you in\u2026" />;
+    return <FullPageLoader message="Signing you in…" />;
   }
 
   return <Outlet />;

--- a/web/src/auth/OnboardingGate.tsx
+++ b/web/src/auth/OnboardingGate.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Outlet, Navigate } from 'react-router-dom';
+import { FullPageLoader } from '../components/FullPageLoader/FullPageLoader.tsx';
 import { useProfileRepository } from './profile-context.ts';
 
 type GateState = 'loading' | 'has-profile' | 'needs-onboarding';
@@ -23,7 +24,7 @@ export function OnboardingGate() {
   }, [repository]);
 
   if (state === 'loading') {
-    return null;
+    return <FullPageLoader message="Loading your profile\u2026" />;
   }
 
   if (state === 'needs-onboarding') {

--- a/web/src/auth/OnboardingGate.tsx
+++ b/web/src/auth/OnboardingGate.tsx
@@ -24,7 +24,7 @@ export function OnboardingGate() {
   }, [repository]);
 
   if (state === 'loading') {
-    return <FullPageLoader message="Loading your profile\u2026" />;
+    return <FullPageLoader message="Loading your profile…" />;
   }
 
   if (state === 'needs-onboarding') {

--- a/web/src/auth/__tests__/AuthGuard.test.tsx
+++ b/web/src/auth/__tests__/AuthGuard.test.tsx
@@ -19,14 +19,15 @@ function renderWithAuth(spy: SpyAuthPort) {
 }
 
 describe('AuthGuard', () => {
-  it('shows nothing while loading', () => {
+  it('shows loading indicator while loading', () => {
     const spy = new SpyAuthPort();
     spy.isLoading = true;
 
-    const { container } = renderWithAuth(spy);
+    renderWithAuth(spy);
 
     expect(screen.queryByText('Protected Content')).not.toBeInTheDocument();
-    expect(container.innerHTML).toBe('');
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText('Signing you in…')).toBeInTheDocument();
   });
 
   it('renders child when authenticated', () => {

--- a/web/src/auth/__tests__/OnboardingGate.test.tsx
+++ b/web/src/auth/__tests__/OnboardingGate.test.tsx
@@ -52,17 +52,18 @@ describe('OnboardingGate', () => {
     expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
   });
 
-  it('shows nothing while loading', () => {
+  it('shows loading indicator while loading', () => {
     // Create a spy that never resolves
     const spy = new SpyProfileRepository();
     spy.fetchProfileResult = existingProfile;
     // Override to return a never-resolving promise
     spy.fetchProfile = () => new Promise<UserProfile | null>(() => {});
 
-    const { container } = renderWithProfile(spy);
+    renderWithProfile(spy);
 
     expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
     expect(screen.queryByText('Onboarding')).not.toBeInTheDocument();
-    expect(container.innerHTML).toBe('');
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText('Loading your profile…')).toBeInTheDocument();
   });
 });

--- a/web/src/components/FullPageLoader/FullPageLoader.module.css
+++ b/web/src/components/FullPageLoader/FullPageLoader.module.css
@@ -1,0 +1,32 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: var(--tc-background);
+  gap: var(--tc-space-lg);
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid var(--tc-border);
+  border-top-color: var(--tc-amber);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+.message {
+  color: var(--tc-text-secondary);
+  font-family: var(--tc-font-family);
+  font-size: var(--tc-text-body);
+  font-weight: var(--tc-weight-medium);
+  margin: 0;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/web/src/components/FullPageLoader/FullPageLoader.tsx
+++ b/web/src/components/FullPageLoader/FullPageLoader.tsx
@@ -1,0 +1,14 @@
+import styles from './FullPageLoader.module.css';
+
+interface FullPageLoaderProps {
+  message?: string;
+}
+
+export function FullPageLoader({ message = 'Loading\u2026' }: FullPageLoaderProps) {
+  return (
+    <div className={styles.container} role="status" aria-label={message}>
+      <div className={styles.spinner} />
+      <p className={styles.message}>{message}</p>
+    </div>
+  );
+}

--- a/web/src/components/FullPageLoader/FullPageLoader.tsx
+++ b/web/src/components/FullPageLoader/FullPageLoader.tsx
@@ -4,7 +4,7 @@ interface FullPageLoaderProps {
   message?: string;
 }
 
-export function FullPageLoader({ message = 'Loading\u2026' }: FullPageLoaderProps) {
+export function FullPageLoader({ message = 'Loading…' }: FullPageLoaderProps) {
   return (
     <div className={styles.container} role="status" aria-label={message}>
       <div className={styles.spinner} />

--- a/web/src/components/FullPageLoader/__tests__/FullPageLoader.test.tsx
+++ b/web/src/components/FullPageLoader/__tests__/FullPageLoader.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { FullPageLoader } from '../FullPageLoader';
+
+describe('FullPageLoader', () => {
+  it('renders with default message', () => {
+    render(<FullPageLoader />);
+
+    const status = screen.getByRole('status');
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveAttribute('aria-label', 'Loading…');
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+
+  it('renders with a custom message', () => {
+    render(<FullPageLoader message="Signing you in…" />);
+
+    const status = screen.getByRole('status');
+    expect(status).toHaveAttribute('aria-label', 'Signing you in…');
+    expect(screen.getByText('Signing you in…')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Changes
- Add `FullPageLoader` component with amber-branded spinner and message text
- `AuthGuard` now shows "Signing you in…" instead of a blank screen while Auth0 initializes
- `OnboardingGate` now shows "Loading your profile…" instead of a blank screen during API cold start
- Uses design tokens so it works across dark, light, and OLED dark themes

---
*Auto-shipped via ship skill*