### PR TITLE
feat(api): auto-grant Pro tier for configured email domains

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -10,6 +10,7 @@
 #   ACR_LOGIN_SERVER       — Azure Container Registry login server
 #   PULUMI_ACCESS_TOKEN    — Pulumi Cloud access token
 #   ADMIN_API_KEY          — API key for admin endpoints
+#   AUTO_GRANT_PRO_DOMAINS — Comma-separated email domains for automatic Pro tier
 #
 # Requires GitHub Environment:
 #   development            — with OIDC federated credential (environment:development)
@@ -140,7 +141,9 @@ jobs:
           az containerapp secret set \
             --name "ca-town-crier-api-dev" \
             --resource-group "rg-town-crier-dev" \
-            --secrets "admin-api-key=${{ secrets.ADMIN_API_KEY }}"
+            --secrets \
+              "admin-api-key=${{ secrets.ADMIN_API_KEY }}" \
+              "auto-grant-pro-domains=${{ secrets.AUTO_GRANT_PRO_DOMAINS }}"
 
       - name: Deploy to Container App
         run: |
@@ -148,7 +151,9 @@ jobs:
             --name "ca-town-crier-api-dev" \
             --resource-group "rg-town-crier-dev" \
             --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}" \
-            --set-env-vars "Admin__ApiKey=secretref:admin-api-key"
+            --set-env-vars \
+              "Admin__ApiKey=secretref:admin-api-key" \
+              "Subscription__AutoGrant__ProDomains=secretref:auto-grant-pro-domains"
 
   # ── Web: deploy to dev ──────────────────────────────
   web-deploy:

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -7,6 +7,7 @@
 #   AZURE_SUBSCRIPTION_ID  — Azure subscription
 #   PULUMI_ACCESS_TOKEN    — Pulumi Cloud access token
 #   ADMIN_API_KEY          — API key for admin endpoints
+#   AUTO_GRANT_PRO_DOMAINS — Comma-separated email domains for automatic Pro tier
 #
 # Requires GitHub Environment:
 #   production             — with OIDC federated credential (environment:production)
@@ -120,7 +121,9 @@ jobs:
           az containerapp secret set \
             --name "ca-town-crier-api-prod" \
             --resource-group "$RESOURCE_GROUP" \
-            --secrets "admin-api-key=${{ secrets.ADMIN_API_KEY }}"
+            --secrets \
+              "admin-api-key=${{ secrets.ADMIN_API_KEY }}" \
+              "auto-grant-pro-domains=${{ secrets.AUTO_GRANT_PRO_DOMAINS }}"
         env:
           RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
 
@@ -130,7 +133,9 @@ jobs:
             --name "ca-town-crier-api-prod" \
             --resource-group "$RESOURCE_GROUP" \
             --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ steps.check-image.outputs.tag }}" \
-            --set-env-vars "Admin__ApiKey=secretref:admin-api-key"
+            --set-env-vars \
+              "Admin__ApiKey=secretref:admin-api-key" \
+              "Subscription__AutoGrant__ProDomains=secretref:auto-grant-pro-domains"
         env:
           RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
 

--- a/api/src/town-crier.application/UserProfiles/AutoGrantOptions.cs
+++ b/api/src/town-crier.application/UserProfiles/AutoGrantOptions.cs
@@ -1,0 +1,26 @@
+namespace TownCrier.Application.UserProfiles;
+
+public sealed class AutoGrantOptions
+{
+    public string ProDomains { get; set; } = string.Empty;
+
+    public bool IsProDomain(string? email)
+    {
+        if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(this.ProDomains))
+        {
+            return false;
+        }
+
+        var atIndex = email.IndexOf('@', StringComparison.Ordinal);
+        if (atIndex < 0)
+        {
+            return false;
+        }
+
+        var emailDomain = email[(atIndex + 1)..];
+
+        var domains = this.ProDomains.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        return Array.Exists(domains, d => emailDomain.Equals(d, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/api/src/town-crier.application/UserProfiles/CreateUserProfileCommand.cs
+++ b/api/src/town-crier.application/UserProfiles/CreateUserProfileCommand.cs
@@ -1,3 +1,3 @@
 namespace TownCrier.Application.UserProfiles;
 
-public sealed record CreateUserProfileCommand(string UserId, string? Email = null);
+public sealed record CreateUserProfileCommand(string UserId, string? Email = null, bool EmailVerified = false);

--- a/api/src/town-crier.application/UserProfiles/CreateUserProfileCommandHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/CreateUserProfileCommandHandler.cs
@@ -4,11 +4,15 @@ namespace TownCrier.Application.UserProfiles;
 
 public sealed class CreateUserProfileCommandHandler
 {
-    private readonly IUserProfileRepository repository;
+    private static readonly DateTimeOffset FarFutureExpiry = new(2099, 12, 31, 0, 0, 0, TimeSpan.Zero);
 
-    public CreateUserProfileCommandHandler(IUserProfileRepository repository)
+    private readonly IUserProfileRepository repository;
+    private readonly AutoGrantOptions autoGrantOptions;
+
+    public CreateUserProfileCommandHandler(IUserProfileRepository repository, AutoGrantOptions autoGrantOptions)
     {
         this.repository = repository;
+        this.autoGrantOptions = autoGrantOptions;
     }
 
     public async Task<CreateUserProfileResult> HandleAsync(CreateUserProfileCommand command, CancellationToken ct)
@@ -26,6 +30,12 @@ public sealed class CreateUserProfileCommandHandler
         }
 
         var profile = UserProfile.Register(command.UserId, command.Email);
+
+        if (this.autoGrantOptions.IsProDomain(command.Email))
+        {
+            profile.ActivateSubscription(SubscriptionTier.Pro, FarFutureExpiry);
+        }
+
         await this.repository.SaveAsync(profile, ct).ConfigureAwait(false);
 
         return new CreateUserProfileResult(

--- a/api/src/town-crier.application/UserProfiles/CreateUserProfileCommandHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/CreateUserProfileCommandHandler.cs
@@ -31,7 +31,7 @@ public sealed class CreateUserProfileCommandHandler
 
         var profile = UserProfile.Register(command.UserId, command.Email);
 
-        if (this.autoGrantOptions.IsProDomain(command.Email))
+        if (command.EmailVerified && this.autoGrantOptions.IsProDomain(command.Email))
         {
             profile.ActivateSubscription(SubscriptionTier.Pro, FarFutureExpiry);
         }

--- a/api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
@@ -15,7 +15,8 @@ internal static class UserProfileEndpoints
         {
             var userId = user.FindFirstValue("sub")!;
             var email = user.FindFirstValue("email");
-            var result = await handler.HandleAsync(new CreateUserProfileCommand(userId, email), ct).ConfigureAwait(false);
+            var emailVerified = string.Equals(user.FindFirstValue("email_verified"), "true", StringComparison.OrdinalIgnoreCase);
+            var result = await handler.HandleAsync(new CreateUserProfileCommand(userId, email, emailVerified), ct).ConfigureAwait(false);
             return Results.Ok(result);
         });
 

--- a/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
+++ b/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
@@ -108,7 +108,7 @@ internal static class ServiceCollectionExtensions
     }
 
     public static IServiceCollection AddApplicationServices(
-        this IServiceCollection services)
+        this IServiceCollection services, IConfiguration configuration)
     {
         services.AddTransient<GeocodePostcodeQueryHandler>();
         services.AddTransient<GetAuthoritiesQueryHandler>();
@@ -117,6 +117,10 @@ internal static class ServiceCollectionExtensions
 
         services.AddTransient<PollPlanItCommandHandler>();
 
+        services.AddSingleton(new AutoGrantOptions
+        {
+            ProDomains = configuration["Subscription:AutoGrant:ProDomains"] ?? string.Empty,
+        });
         services.AddTransient<CreateUserProfileCommandHandler>();
         services.AddTransient<GetUserProfileQueryHandler>();
         services.AddTransient<UpdateUserProfileCommandHandler>();

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -24,7 +24,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 });
 
 builder.Services.AddInfrastructureServices(builder.Configuration);
-builder.Services.AddApplicationServices();
+builder.Services.AddApplicationServices(builder.Configuration);
 builder.Services.AddAuthenticationServices(builder.Configuration);
 builder.Services.AddHostedService<PlanItPollingService>();
 

--- a/api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs
@@ -10,7 +10,7 @@ public sealed class CreateUserProfileCommandHandlerTests
     {
         // Arrange
         var repository = new FakeUserProfileRepository();
-        var handler = new CreateUserProfileCommandHandler(repository);
+        var handler = new CreateUserProfileCommandHandler(repository, NoAutoGrant());
         var command = new CreateUserProfileCommand("auth0|user-123");
 
         // Act
@@ -28,7 +28,7 @@ public sealed class CreateUserProfileCommandHandlerTests
     {
         // Arrange
         var repository = new FakeUserProfileRepository();
-        var handler = new CreateUserProfileCommandHandler(repository);
+        var handler = new CreateUserProfileCommandHandler(repository, NoAutoGrant());
         var command = new CreateUserProfileCommand("auth0|user-123");
 
         // Act
@@ -45,7 +45,7 @@ public sealed class CreateUserProfileCommandHandlerTests
     {
         // Arrange
         var repository = new FakeUserProfileRepository();
-        var handler = new CreateUserProfileCommandHandler(repository);
+        var handler = new CreateUserProfileCommandHandler(repository, NoAutoGrant());
         var command = new CreateUserProfileCommand("auth0|user-email", "user@example.com");
 
         // Act
@@ -61,7 +61,7 @@ public sealed class CreateUserProfileCommandHandlerTests
     {
         // Arrange
         var repository = new FakeUserProfileRepository();
-        var handler = new CreateUserProfileCommandHandler(repository);
+        var handler = new CreateUserProfileCommandHandler(repository, NoAutoGrant());
         var command = new CreateUserProfileCommand("auth0|user-123");
 
         // Create first
@@ -74,4 +74,103 @@ public sealed class CreateUserProfileCommandHandlerTests
         await Assert.That(repository.Count).IsEqualTo(1);
         await Assert.That(result.UserId).IsEqualTo("auth0|user-123");
     }
+
+    [Test]
+    public async Task Should_AutoGrantProTier_When_EmailMatchesConfiguredDomain()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var handler = new CreateUserProfileCommandHandler(repository, AutoGrantFor("family.uk"));
+        var command = new CreateUserProfileCommand("auth0|family-1", "alice@family.uk");
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Pro);
+        var saved = repository.GetByUserId("auth0|family-1");
+        await Assert.That(saved!.Tier).IsEqualTo(SubscriptionTier.Pro);
+    }
+
+    [Test]
+    public async Task Should_RemainFreeTier_When_EmailDoesNotMatchConfiguredDomain()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var handler = new CreateUserProfileCommandHandler(repository, AutoGrantFor("family.uk"));
+        var command = new CreateUserProfileCommand("auth0|other-1", "someone@gmail.com");
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);
+    }
+
+    [Test]
+    public async Task Should_RemainFreeTier_When_NoEmailProvided()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var handler = new CreateUserProfileCommandHandler(repository, AutoGrantFor("family.uk"));
+        var command = new CreateUserProfileCommand("auth0|no-email");
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);
+    }
+
+    [Test]
+    public async Task Should_AutoGrantProTier_When_EmailMatchesAnyConfiguredDomain()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var handler = new CreateUserProfileCommandHandler(repository, AutoGrantFor("family.uk, vip.com"));
+        var command = new CreateUserProfileCommand("auth0|vip-1", "bob@vip.com");
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Pro);
+    }
+
+    [Test]
+    public async Task Should_MatchDomainCaseInsensitively()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var handler = new CreateUserProfileCommandHandler(repository, AutoGrantFor("family.uk"));
+        var command = new CreateUserProfileCommand("auth0|upper-1", "Alice@FAMILY.UK");
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Pro);
+    }
+
+    [Test]
+    public async Task Should_NotAutoGrant_When_ExistingUserReturned()
+    {
+        // Arrange — existing user is on Free tier
+        var repository = new FakeUserProfileRepository();
+        var noAutoGrant = new CreateUserProfileCommandHandler(repository, NoAutoGrant());
+        await noAutoGrant.HandleAsync(
+            new CreateUserProfileCommand("auth0|existing", "alice@family.uk"), CancellationToken.None);
+
+        // Act — re-register with auto-grant enabled (should return existing, not upgrade)
+        var handler = new CreateUserProfileCommandHandler(repository, AutoGrantFor("family.uk"));
+        var result = await handler.HandleAsync(
+            new CreateUserProfileCommand("auth0|existing", "alice@family.uk"), CancellationToken.None);
+
+        // Assert — still Free because existing profile is returned as-is
+        await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);
+    }
+
+    private static AutoGrantOptions NoAutoGrant() => new();
+
+    private static AutoGrantOptions AutoGrantFor(string domains) => new() { ProDomains = domains };
 }

--- a/api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs
@@ -81,7 +81,7 @@ public sealed class CreateUserProfileCommandHandlerTests
         // Arrange
         var repository = new FakeUserProfileRepository();
         var handler = new CreateUserProfileCommandHandler(repository, AutoGrantFor("family.uk"));
-        var command = new CreateUserProfileCommand("auth0|family-1", "alice@family.uk");
+        var command = new CreateUserProfileCommand("auth0|family-1", "alice@family.uk", EmailVerified: true);
 
         // Act
         var result = await handler.HandleAsync(command, CancellationToken.None);
@@ -90,6 +90,21 @@ public sealed class CreateUserProfileCommandHandlerTests
         await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Pro);
         var saved = repository.GetByUserId("auth0|family-1");
         await Assert.That(saved!.Tier).IsEqualTo(SubscriptionTier.Pro);
+    }
+
+    [Test]
+    public async Task Should_RemainFreeTier_When_EmailNotVerified()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var handler = new CreateUserProfileCommandHandler(repository, AutoGrantFor("family.uk"));
+        var command = new CreateUserProfileCommand("auth0|unverified-1", "alice@family.uk", EmailVerified: false);
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);
     }
 
     [Test]
@@ -128,7 +143,7 @@ public sealed class CreateUserProfileCommandHandlerTests
         // Arrange
         var repository = new FakeUserProfileRepository();
         var handler = new CreateUserProfileCommandHandler(repository, AutoGrantFor("family.uk, vip.com"));
-        var command = new CreateUserProfileCommand("auth0|vip-1", "bob@vip.com");
+        var command = new CreateUserProfileCommand("auth0|vip-1", "bob@vip.com", EmailVerified: true);
 
         // Act
         var result = await handler.HandleAsync(command, CancellationToken.None);
@@ -143,7 +158,7 @@ public sealed class CreateUserProfileCommandHandlerTests
         // Arrange
         var repository = new FakeUserProfileRepository();
         var handler = new CreateUserProfileCommandHandler(repository, AutoGrantFor("family.uk"));
-        var command = new CreateUserProfileCommand("auth0|upper-1", "Alice@FAMILY.UK");
+        var command = new CreateUserProfileCommand("auth0|upper-1", "Alice@FAMILY.UK", EmailVerified: true);
 
         // Act
         var result = await handler.HandleAsync(command, CancellationToken.None);

--- a/api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs
@@ -113,7 +113,7 @@ public sealed class CreateUserProfileCommandHandlerTests
         // Arrange
         var repository = new FakeUserProfileRepository();
         var handler = new CreateUserProfileCommandHandler(repository, AutoGrantFor("family.uk"));
-        var command = new CreateUserProfileCommand("auth0|other-1", "someone@gmail.com");
+        var command = new CreateUserProfileCommand("auth0|other-1", "someone@gmail.com", EmailVerified: true);
 
         // Act
         var result = await handler.HandleAsync(command, CancellationToken.None);
@@ -174,12 +174,12 @@ public sealed class CreateUserProfileCommandHandlerTests
         var repository = new FakeUserProfileRepository();
         var noAutoGrant = new CreateUserProfileCommandHandler(repository, NoAutoGrant());
         await noAutoGrant.HandleAsync(
-            new CreateUserProfileCommand("auth0|existing", "alice@family.uk"), CancellationToken.None);
+            new CreateUserProfileCommand("auth0|existing", "alice@family.uk", EmailVerified: true), CancellationToken.None);
 
         // Act — re-register with auto-grant enabled (should return existing, not upgrade)
         var handler = new CreateUserProfileCommandHandler(repository, AutoGrantFor("family.uk"));
         var result = await handler.HandleAsync(
-            new CreateUserProfileCommand("auth0|existing", "alice@family.uk"), CancellationToken.None);
+            new CreateUserProfileCommand("auth0|existing", "alice@family.uk", EmailVerified: true), CancellationToken.None);
 
         // Assert — still Free because existing profile is returned as-is
         await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);

--- a/api/tests/town-crier.web.tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
+++ b/api/tests/town-crier.web.tests/DependencyInjection/ServiceRegistrationExtensionsTests.cs
@@ -65,7 +65,7 @@ public sealed class ServiceRegistrationExtensionsTests
         services.AddInfrastructureServices(configuration);
 
         // Act
-        services.AddApplicationServices();
+        services.AddApplicationServices(configuration);
 
         // Assert — verify key handler registrations exist
         var provider = services.BuildServiceProvider();

--- a/docs/memo/0005-admin-web-app.md
+++ b/docs/memo/0005-admin-web-app.md
@@ -1,0 +1,102 @@
+# 0005. Separate Admin Web App
+
+Date: 2026-04-03
+
+## Status
+
+Open
+
+## Question
+
+Should we build a separate static web app for admin functionality (dashboards and user management), and how should admin access be modelled?
+
+## Analysis
+
+### Current State
+
+- One admin endpoint exists: `PUT /admin/subscriptions` protected by a hardcoded API key (`X-Admin-Key` header)
+- No RBAC, no admin role in the user profile or identity provider
+- The API key is also used by CI/CD for `AUTO_GRANT_PRO_DOMAINS` grants
+- The main web app at `towncrierapp.uk` / `dev.towncrierapp.uk` is a React 19 + Vite SPA deployed as an Azure Static Web App
+
+### Proposed Admin Functionality
+
+**Operational dashboards (read-only):**
+- User counts, subscription stats, system health
+- Planning application ingestion metrics
+
+**User management (read-write):**
+- Look up users by email or ID
+- Grant/revoke subscriptions
+- No impersonation
+
+### Admin Identity Model
+
+Auth0 RBAC was chosen over alternatives (domain-based allow list, UserProfile flag, or a combination). Rationale:
+
+- Auth0 roles are purpose-built for identity-level access control
+- The admin role changes rarely (manual assignment) — unlike subscription tier which has a rich lifecycle driven by the App Store
+- The role claim travels with the JWT, so both the admin SPA and the API can use it without extra DB lookups
+- Keeps admin logic out of the domain model, which should remain focused on subscription/notification concerns
+
+**Auth0 free tier caveat:** RBAC features (roles, permissions, enforcement, Actions) all work on the free plan today, but Auth0's pricing page officially lists RBAC as a paid feature. The risk is that Auth0 could start enforcing the paywall, requiring the Essentials plan ($35/mo). For 1-2 admin users this is an acceptable risk.
+
+**Why not use Auth0 roles for subscription tier?** Subscription tier (Free/Pro) was explicitly excluded from RBAC because it has a time-based lifecycle (activate, renew, grace period, expire) driven by App Store server-to-server notifications. Putting tier in Auth0 would create token staleness issues (user pays but token still says Free until refresh) and require background jobs to call Auth0's Management API on expiry. Tier remains a domain concern in the UserProfile model.
+
+### Implementation Approach
+
+A post-login Auth0 Action stamps the user's roles as a custom claim (e.g. `https://towncrierapp.uk/roles`) on the access token. The API validates this claim on admin endpoints. The admin SPA reads the claim client-side for UI gating, but server-side enforcement is the real security boundary.
+
+## Options Considered
+
+### 1. Separate static web app (recommended)
+
+A new React 19 + Vite SPA deployed as its own Azure Static Web App at `admin.towncrierapp.uk`. Uses the same Auth0 SPA application registration as the main app (just add the admin subdomain to allowed callback/logout URLs). Admin vs user access is determined by the Auth0 role claim.
+
+**Pros:**
+- Clean separation of concerns — admin UI doesn't ship to end users
+- Independent deploy cycle — admin changes don't require a user-facing release
+- Follows existing DNS/infra pattern (new SWA + custom domain)
+- Same tech stack (React 19, Vite, Auth0 React SDK, TanStack Query) — no new learning curve
+
+**Cons:**
+- Second SWA to provision and maintain
+- Some shared code (auth adapter, API client) will need to be duplicated or extracted
+
+### 2. Admin routes within the main web app
+
+Add `/admin/*` routes to the existing SWA, gated by the role claim.
+
+**Pros:**
+- No new infrastructure
+- Shared code is trivially shared
+
+**Cons:**
+- Admin code ships in the user-facing bundle (even if lazy-loaded)
+- Coupled deploy cycle — admin changes require a user-facing release
+- Route-level gating is easier to misconfigure than app-level separation
+
+### 3. Separate API for admin
+
+A second .NET container serving only admin endpoints.
+
+**Pros:**
+- Complete isolation of admin logic
+
+**Cons:**
+- Duplicates infrastructure (container, identity, Cosmos DB access)
+- Same domain model, same database — separation is artificial
+- Significantly more operational overhead for marginal benefit
+
+## Recommendation
+
+**Option 1 — separate static web app** with:
+
+- `admin.towncrierapp.uk` (prod) and `admin-dev.towncrierapp.uk` (dev)
+- Auth0 `admin` role via RBAC, stamped as a custom claim by a post-login Action
+- Shared Auth0 SPA application registration (add admin callback URLs)
+- Same tech stack as the main web app (React 19 + Vite + TanStack Query)
+- Admin API endpoints remain in the existing API under the `/admin` route group
+- Existing API key auth on `/admin` routes replaced by JWT + role claim validation (immediate cut-over, no transition period)
+- CI/CD pipeline extended with an admin SWA build/deploy step
+- The `AUTO_GRANT_PRO_DOMAINS` grant mechanism (currently using the API key) will need reworking — either moved into the admin app or converted to a service-to-service flow


### PR DESCRIPTION
## Changes
- Add `AutoGrantOptions` with configurable comma-separated `ProDomains` list
- `CreateUserProfileCommandHandler` auto-activates Pro tier when a new user's email domain matches
- Wire up `Subscription:AutoGrant:ProDomains` config binding in DI
- Pass `AUTO_GRANT_PRO_DOMAINS` GitHub secret as Container App env var in both CD workflows
- Add 5 new test cases: domain match, no match, no email, multi-domain, case-insensitive, existing user not upgraded

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users with email addresses from configured domains are now automatically granted Pro subscriptions on account creation (when email is verified).
  * Admins can configure comma-separated domains to control automatic Pro eligibility.

* **Tests**
  * Added and updated tests covering domain matching, verification gating, case-insensitivity, and existing-user behavior.

* **Chores**
  * CI/CD updated to support a new secret for the auto-grant domains configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->