### PR TITLE
fix(web): prevent authority dropdown from reopening after selection

### DIFF
--- a/web/src/components/AuthoritySelector/__tests__/AuthoritySelector.test.tsx
+++ b/web/src/components/AuthoritySelector/__tests__/AuthoritySelector.test.tsx
@@ -66,6 +66,29 @@ describe('AuthoritySelector', () => {
     expect(screen.queryByText('Oxford City Council')).not.toBeInTheDocument();
   });
 
+  it('does not reopen dropdown after selecting an authority', async () => {
+    const spy = new SpyAuthoritySearchPort();
+    spy.searchResult = twoAuthorityResults();
+    const user = userEvent.setup();
+
+    render(<AuthoritySelector searchPort={spy} onSelect={() => {}} />);
+
+    await user.type(screen.getByRole('combobox'), 'cam');
+
+    await waitFor(() => {
+      expect(screen.getByText('Cambridge City Council')).toBeInTheDocument();
+    });
+
+    const searchCallsBefore = spy.searchCalls.length;
+    await user.click(screen.getByText('Cambridge City Council'));
+
+    // Wait long enough for the debounce to fire if it was going to
+    await new Promise((r) => setTimeout(r, 350));
+
+    expect(spy.searchCalls.length).toBe(searchCallsBefore);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
   it('sets the input value to the selected authority name', async () => {
     const spy = new SpyAuthoritySearchPort();
     spy.searchResult = twoAuthorityResults();

--- a/web/src/components/AuthoritySelector/useAuthoritySearch.ts
+++ b/web/src/components/AuthoritySelector/useAuthoritySearch.ts
@@ -18,18 +18,25 @@ export function useAuthoritySearch(port: AuthoritySearchPort) {
     isSearching: false,
   });
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const skipNextSearchRef = useRef(false);
 
   const setQuery = useCallback((query: string) => {
     setState((prev) => ({ ...prev, query }));
   }, []);
 
   const clearResults = useCallback(() => {
+    skipNextSearchRef.current = true;
     setState((prev) => ({ ...prev, results: [] }));
   }, []);
 
   useEffect(() => {
     if (timerRef.current !== undefined) {
       clearTimeout(timerRef.current);
+    }
+
+    if (skipNextSearchRef.current) {
+      skipNextSearchRef.current = false;
+      return;
     }
 
     if (state.query.length < MIN_QUERY_LENGTH) {


### PR DESCRIPTION
## Summary
- Selecting an authority in the `AuthoritySelector` caused the dropdown to briefly close then reopen, because `setQuery(name)` re-triggered the debounced search effect
- Added a `skipNextSearchRef` in `useAuthoritySearch` so selection-driven query changes don't fire a new search
- Added a regression test that verifies no search is triggered and the listbox stays closed after selection

## Test plan
- [x] All 409 web tests pass
- [ ] Manual: type a partial name, select from dropdown — dropdown stays closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed authority selection behavior to prevent unnecessary search requests after an authority is selected from the dropdown, ensuring the selection completes cleanly and the dropdown closes properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->