### PR TITLE
feat: redesign Applications page with user's watch zone authorities

### DIFF
--- a/api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesQuery.cs
+++ b/api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesQuery.cs
@@ -1,0 +1,3 @@
+namespace TownCrier.Application.PlanningApplications;
+
+public sealed record GetUserApplicationAuthoritiesQuery(string UserId);

--- a/api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesQueryHandler.cs
+++ b/api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesQueryHandler.cs
@@ -1,0 +1,45 @@
+using TownCrier.Application.Authorities;
+using TownCrier.Application.WatchZones;
+
+namespace TownCrier.Application.PlanningApplications;
+
+public sealed class GetUserApplicationAuthoritiesQueryHandler
+{
+    private readonly IWatchZoneRepository watchZoneRepository;
+    private readonly IAuthorityProvider authorityProvider;
+
+    public GetUserApplicationAuthoritiesQueryHandler(
+        IWatchZoneRepository watchZoneRepository,
+        IAuthorityProvider authorityProvider)
+    {
+        this.watchZoneRepository = watchZoneRepository;
+        this.authorityProvider = authorityProvider;
+    }
+
+    public async Task<GetUserApplicationAuthoritiesResult> HandleAsync(
+        GetUserApplicationAuthoritiesQuery query, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var zones = await this.watchZoneRepository.GetByUserIdAsync(query.UserId, ct).ConfigureAwait(false);
+
+        var distinctAuthorityIds = zones
+            .Select(z => z.AuthorityId)
+            .Distinct()
+            .ToHashSet();
+
+        var authorities = new List<AuthorityListItem>();
+        foreach (var authorityId in distinctAuthorityIds)
+        {
+            var authority = await this.authorityProvider.GetByIdAsync(authorityId, ct).ConfigureAwait(false);
+            if (authority is not null)
+            {
+                authorities.Add(new AuthorityListItem(authority.Id, authority.Name, authority.AreaType));
+            }
+        }
+
+        authorities.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+
+        return new GetUserApplicationAuthoritiesResult(authorities, authorities.Count);
+    }
+}

--- a/api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesResult.cs
+++ b/api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesResult.cs
@@ -1,0 +1,7 @@
+using TownCrier.Application.Authorities;
+
+namespace TownCrier.Application.PlanningApplications;
+
+public sealed record GetUserApplicationAuthoritiesResult(
+    IReadOnlyList<AuthorityListItem> Authorities,
+    int Count);

--- a/api/src/town-crier.web/AppJsonSerializerContext.cs
+++ b/api/src/town-crier.web/AppJsonSerializerContext.cs
@@ -34,6 +34,7 @@ namespace TownCrier.Web;
 [JsonSerializable(typeof(PlanningApplicationResult))]
 [JsonSerializable(typeof(IReadOnlyList<PlanningApplicationResult>))]
 [JsonSerializable(typeof(SearchPlanningApplicationsResult))]
+[JsonSerializable(typeof(GetUserApplicationAuthoritiesResult))]
 [JsonSerializable(typeof(GetNotificationsResult))]
 [JsonSerializable(typeof(IReadOnlyList<SavedApplicationResult>))]
 [JsonSerializable(typeof(CreateWatchZoneRequest))]
@@ -45,5 +46,4 @@ namespace TownCrier.Web;
 [JsonSerializable(typeof(GetVersionConfigResult))]
 [JsonSerializable(typeof(GrantSubscriptionCommand))]
 [JsonSerializable(typeof(GrantSubscriptionResult))]
-[JsonSerializable(typeof(GetUserApplicationAuthoritiesResult))]
 internal sealed partial class AppJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.web/AppJsonSerializerContext.cs
+++ b/api/src/town-crier.web/AppJsonSerializerContext.cs
@@ -45,4 +45,5 @@ namespace TownCrier.Web;
 [JsonSerializable(typeof(GetVersionConfigResult))]
 [JsonSerializable(typeof(GrantSubscriptionCommand))]
 [JsonSerializable(typeof(GrantSubscriptionResult))]
+[JsonSerializable(typeof(GetUserApplicationAuthoritiesResult))]
 internal sealed partial class AppJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.web/Endpoints/PlanningApplicationEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/PlanningApplicationEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using TownCrier.Application.PlanningApplications;
 
 namespace TownCrier.Web.Endpoints;
@@ -6,6 +7,17 @@ internal static class PlanningApplicationEndpoints
 {
     public static void MapPlanningApplicationEndpoints(this RouteGroupBuilder group)
     {
+        group.MapGet("/me/application-authorities", async (
+            ClaimsPrincipal user,
+            GetUserApplicationAuthoritiesQueryHandler handler,
+            CancellationToken ct) =>
+        {
+            var userId = user.FindFirstValue("sub")!;
+            var result = await handler.HandleAsync(
+                new GetUserApplicationAuthoritiesQuery(userId), ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        });
+
         group.MapGet("/applications", async (
             int authorityId,
             GetApplicationsByAuthorityQueryHandler handler,

--- a/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
+++ b/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
@@ -138,6 +138,7 @@ internal static class ServiceCollectionExtensions
 
         services.AddTransient<GetApplicationByUidQueryHandler>();
         services.AddTransient<GetApplicationsByAuthorityQueryHandler>();
+        services.AddTransient<GetUserApplicationAuthoritiesQueryHandler>();
         services.AddTransient<SearchPlanningApplicationsQueryHandler>();
 
         services.AddTransient<GetNotificationsQueryHandler>();

--- a/api/tests/town-crier.application.tests/PlanningApplications/GetUserApplicationAuthoritiesQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/PlanningApplications/GetUserApplicationAuthoritiesQueryHandlerTests.cs
@@ -1,0 +1,127 @@
+using TownCrier.Application.Authorities;
+using TownCrier.Application.PlanningApplications;
+using TownCrier.Application.Tests.Authorities;
+using TownCrier.Application.Tests.Polling;
+using TownCrier.Domain.Geocoding;
+using TownCrier.Domain.WatchZones;
+
+namespace TownCrier.Application.Tests.PlanningApplications;
+
+public sealed class GetUserApplicationAuthoritiesQueryHandlerTests
+{
+    private readonly FakeWatchZoneRepository watchZoneRepository = new();
+    private readonly FakeAuthorityProvider authorityProvider = new();
+
+    [Test]
+    public async Task Should_ReturnEmpty_When_UserHasNoWatchZones()
+    {
+        var handler = new GetUserApplicationAuthoritiesQueryHandler(
+            this.watchZoneRepository, this.authorityProvider);
+
+        var result = await handler.HandleAsync(
+            new GetUserApplicationAuthoritiesQuery("user-1"), CancellationToken.None);
+
+        await Assert.That(result.Authorities).HasCount().EqualTo(0);
+        await Assert.That(result.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_ReturnMatchingAuthorities_When_UserHasWatchZones()
+    {
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42));
+        this.authorityProvider.Add(
+            new AuthorityBuilder().WithId(42).WithName("Cornwall Council").WithAreaType("Unitary").Build());
+
+        var handler = new GetUserApplicationAuthoritiesQueryHandler(
+            this.watchZoneRepository, this.authorityProvider);
+
+        var result = await handler.HandleAsync(
+            new GetUserApplicationAuthoritiesQuery("user-1"), CancellationToken.None);
+
+        await Assert.That(result.Authorities).HasCount().EqualTo(1);
+        await Assert.That(result.Authorities[0].Id).IsEqualTo(42);
+        await Assert.That(result.Authorities[0].Name).IsEqualTo("Cornwall Council");
+        await Assert.That(result.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_DeduplicateAuthorities_When_MultipleZonesSameAuthority()
+    {
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42));
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-2", "user-1", "Office", new Coordinates(50.8, -3.6), 3000, 42));
+        this.authorityProvider.Add(
+            new AuthorityBuilder().WithId(42).WithName("Cornwall Council").WithAreaType("Unitary").Build());
+
+        var handler = new GetUserApplicationAuthoritiesQueryHandler(
+            this.watchZoneRepository, this.authorityProvider);
+
+        var result = await handler.HandleAsync(
+            new GetUserApplicationAuthoritiesQuery("user-1"), CancellationToken.None);
+
+        await Assert.That(result.Authorities).HasCount().EqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_SortByName_When_MultipleAuthorities()
+    {
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42));
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-2", "user-1", "Work", new Coordinates(51.5, -0.1), 3000, 10));
+        this.authorityProvider.Add(
+            new AuthorityBuilder().WithId(42).WithName("Cornwall Council").WithAreaType("Unitary").Build());
+        this.authorityProvider.Add(
+            new AuthorityBuilder().WithId(10).WithName("Bath and NE Somerset").WithAreaType("Unitary").Build());
+
+        var handler = new GetUserApplicationAuthoritiesQueryHandler(
+            this.watchZoneRepository, this.authorityProvider);
+
+        var result = await handler.HandleAsync(
+            new GetUserApplicationAuthoritiesQuery("user-1"), CancellationToken.None);
+
+        await Assert.That(result.Authorities).HasCount().EqualTo(2);
+        await Assert.That(result.Authorities[0].Name).IsEqualTo("Bath and NE Somerset");
+        await Assert.That(result.Authorities[1].Name).IsEqualTo("Cornwall Council");
+    }
+
+    [Test]
+    public async Task Should_ExcludeOtherUsersZones_When_MultipleUsersExist()
+    {
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42));
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-2", "user-2", "Home", new Coordinates(51.5, -0.1), 3000, 10));
+        this.authorityProvider.Add(
+            new AuthorityBuilder().WithId(42).WithName("Cornwall Council").WithAreaType("Unitary").Build());
+        this.authorityProvider.Add(
+            new AuthorityBuilder().WithId(10).WithName("Camden").WithAreaType("London Borough").Build());
+
+        var handler = new GetUserApplicationAuthoritiesQueryHandler(
+            this.watchZoneRepository, this.authorityProvider);
+
+        var result = await handler.HandleAsync(
+            new GetUserApplicationAuthoritiesQuery("user-1"), CancellationToken.None);
+
+        await Assert.That(result.Authorities).HasCount().EqualTo(1);
+        await Assert.That(result.Authorities[0].Name).IsEqualTo("Cornwall Council");
+    }
+
+    [Test]
+    public async Task Should_SkipAuthority_When_NotFoundInProvider()
+    {
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 999));
+
+        var handler = new GetUserApplicationAuthoritiesQueryHandler(
+            this.watchZoneRepository, this.authorityProvider);
+
+        var result = await handler.HandleAsync(
+            new GetUserApplicationAuthoritiesQuery("user-1"), CancellationToken.None);
+
+        await Assert.That(result.Authorities).HasCount().EqualTo(0);
+        await Assert.That(result.Count).IsEqualTo(0);
+    }
+}

--- a/api/tests/town-crier.web.tests/DependencyInjection/EndpointMappingTests.cs
+++ b/api/tests/town-crier.web.tests/DependencyInjection/EndpointMappingTests.cs
@@ -27,6 +27,7 @@ public sealed class EndpointMappingTests
     [Test]
     [Arguments("/v1/me", "POST")]
     [Arguments("/api/me", "GET")]
+    [Arguments("/v1/me/application-authorities", "GET")]
     public async Task Should_MapAuthenticatedEndpoints_When_MapAllEndpointsCalled(string path, string method)
     {
         // Arrange

--- a/docs/superpowers/plans/2026-04-03-applications-page-redesign.md
+++ b/docs/superpowers/plans/2026-04-03-applications-page-redesign.md
@@ -1,0 +1,1134 @@
+# Applications Page Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the authority search box on the Applications page with a list of the authenticated user's watch-zone authorities, so only authorities with data are shown.
+
+**Architecture:** New backend query handler resolves the user's watch zone authority IDs into `AuthorityListItem` records via the cached authority provider. The frontend replaces `AuthoritySelector` with a card-based authority picker and adds breadcrumb navigation between authority list and application list views.
+
+**Tech Stack:** .NET 10 (TUnit tests), React 19 + TypeScript (Vitest + Testing Library), CSS Modules with design tokens.
+
+---
+
+### Task 1: Backend — Query, Result, and Handler
+
+**Files:**
+- Create: `api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesQuery.cs`
+- Create: `api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesResult.cs`
+- Create: `api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesQueryHandler.cs`
+- Test: `api/tests/town-crier.application.tests/PlanningApplications/GetUserApplicationAuthoritiesQueryHandlerTests.cs`
+
+- [ ] **Step 1: Create the query record**
+
+```csharp
+// api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesQuery.cs
+namespace TownCrier.Application.PlanningApplications;
+
+public sealed record GetUserApplicationAuthoritiesQuery(string UserId);
+```
+
+- [ ] **Step 2: Create the result record**
+
+Reuses the existing `AuthorityListItem` from the Authorities namespace.
+
+```csharp
+// api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesResult.cs
+using TownCrier.Application.Authorities;
+
+namespace TownCrier.Application.PlanningApplications;
+
+public sealed record GetUserApplicationAuthoritiesResult(
+    IReadOnlyList<AuthorityListItem> Authorities,
+    int Count);
+```
+
+- [ ] **Step 3: Write the failing tests**
+
+```csharp
+// api/tests/town-crier.application.tests/PlanningApplications/GetUserApplicationAuthoritiesQueryHandlerTests.cs
+using TownCrier.Application.Authorities;
+using TownCrier.Application.PlanningApplications;
+using TownCrier.Application.Tests.Authorities;
+using TownCrier.Application.Tests.Polling;
+using TownCrier.Domain.Geocoding;
+using TownCrier.Domain.WatchZones;
+
+namespace TownCrier.Application.Tests.PlanningApplications;
+
+public sealed class GetUserApplicationAuthoritiesQueryHandlerTests
+{
+    private readonly FakeWatchZoneRepository watchZoneRepository = new();
+    private readonly FakeAuthorityProvider authorityProvider = new();
+
+    [Test]
+    public async Task Should_ReturnEmpty_When_UserHasNoWatchZones()
+    {
+        var handler = new GetUserApplicationAuthoritiesQueryHandler(
+            this.watchZoneRepository, this.authorityProvider);
+
+        var result = await handler.HandleAsync(
+            new GetUserApplicationAuthoritiesQuery("user-1"), CancellationToken.None);
+
+        await Assert.That(result.Authorities).HasCount().EqualTo(0);
+        await Assert.That(result.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_ReturnMatchingAuthorities_When_UserHasWatchZones()
+    {
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42));
+        this.authorityProvider.Add(
+            new AuthorityBuilder().WithId(42).WithName("Cornwall Council").WithAreaType("Unitary").Build());
+
+        var handler = new GetUserApplicationAuthoritiesQueryHandler(
+            this.watchZoneRepository, this.authorityProvider);
+
+        var result = await handler.HandleAsync(
+            new GetUserApplicationAuthoritiesQuery("user-1"), CancellationToken.None);
+
+        await Assert.That(result.Authorities).HasCount().EqualTo(1);
+        await Assert.That(result.Authorities[0].Id).IsEqualTo(42);
+        await Assert.That(result.Authorities[0].Name).IsEqualTo("Cornwall Council");
+        await Assert.That(result.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_DeduplicateAuthorities_When_MultipleZonesSameAuthority()
+    {
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42));
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-2", "user-1", "Office", new Coordinates(50.8, -3.6), 3000, 42));
+        this.authorityProvider.Add(
+            new AuthorityBuilder().WithId(42).WithName("Cornwall Council").WithAreaType("Unitary").Build());
+
+        var handler = new GetUserApplicationAuthoritiesQueryHandler(
+            this.watchZoneRepository, this.authorityProvider);
+
+        var result = await handler.HandleAsync(
+            new GetUserApplicationAuthoritiesQuery("user-1"), CancellationToken.None);
+
+        await Assert.That(result.Authorities).HasCount().EqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_SortByName_When_MultipleAuthorities()
+    {
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42));
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-2", "user-1", "Work", new Coordinates(51.5, -0.1), 3000, 10));
+        this.authorityProvider.Add(
+            new AuthorityBuilder().WithId(42).WithName("Cornwall Council").WithAreaType("Unitary").Build());
+        this.authorityProvider.Add(
+            new AuthorityBuilder().WithId(10).WithName("Bath and NE Somerset").WithAreaType("Unitary").Build());
+
+        var handler = new GetUserApplicationAuthoritiesQueryHandler(
+            this.watchZoneRepository, this.authorityProvider);
+
+        var result = await handler.HandleAsync(
+            new GetUserApplicationAuthoritiesQuery("user-1"), CancellationToken.None);
+
+        await Assert.That(result.Authorities).HasCount().EqualTo(2);
+        await Assert.That(result.Authorities[0].Name).IsEqualTo("Bath and NE Somerset");
+        await Assert.That(result.Authorities[1].Name).IsEqualTo("Cornwall Council");
+    }
+
+    [Test]
+    public async Task Should_ExcludeOtherUsersZones_When_MultipleUsersExist()
+    {
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42));
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-2", "user-2", "Home", new Coordinates(51.5, -0.1), 3000, 10));
+        this.authorityProvider.Add(
+            new AuthorityBuilder().WithId(42).WithName("Cornwall Council").WithAreaType("Unitary").Build());
+        this.authorityProvider.Add(
+            new AuthorityBuilder().WithId(10).WithName("Camden").WithAreaType("London Borough").Build());
+
+        var handler = new GetUserApplicationAuthoritiesQueryHandler(
+            this.watchZoneRepository, this.authorityProvider);
+
+        var result = await handler.HandleAsync(
+            new GetUserApplicationAuthoritiesQuery("user-1"), CancellationToken.None);
+
+        await Assert.That(result.Authorities).HasCount().EqualTo(1);
+        await Assert.That(result.Authorities[0].Name).IsEqualTo("Cornwall Council");
+    }
+
+    [Test]
+    public async Task Should_SkipAuthority_When_NotFoundInProvider()
+    {
+        this.watchZoneRepository.Add(new WatchZone(
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 999));
+
+        var handler = new GetUserApplicationAuthoritiesQueryHandler(
+            this.watchZoneRepository, this.authorityProvider);
+
+        var result = await handler.HandleAsync(
+            new GetUserApplicationAuthoritiesQuery("user-1"), CancellationToken.None);
+
+        await Assert.That(result.Authorities).HasCount().EqualTo(0);
+        await Assert.That(result.Count).IsEqualTo(0);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `dotnet test api/tests/town-crier.application.tests --filter "GetUserApplicationAuthoritiesQueryHandlerTests"`
+Expected: Build failure — `GetUserApplicationAuthoritiesQueryHandler` does not exist.
+
+- [ ] **Step 5: Implement the handler**
+
+```csharp
+// api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesQueryHandler.cs
+using TownCrier.Application.Authorities;
+using TownCrier.Application.WatchZones;
+
+namespace TownCrier.Application.PlanningApplications;
+
+public sealed class GetUserApplicationAuthoritiesQueryHandler
+{
+    private readonly IWatchZoneRepository watchZoneRepository;
+    private readonly IAuthorityProvider authorityProvider;
+
+    public GetUserApplicationAuthoritiesQueryHandler(
+        IWatchZoneRepository watchZoneRepository,
+        IAuthorityProvider authorityProvider)
+    {
+        this.watchZoneRepository = watchZoneRepository;
+        this.authorityProvider = authorityProvider;
+    }
+
+    public async Task<GetUserApplicationAuthoritiesResult> HandleAsync(
+        GetUserApplicationAuthoritiesQuery query, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var zones = await this.watchZoneRepository.GetByUserIdAsync(query.UserId, ct).ConfigureAwait(false);
+
+        var distinctAuthorityIds = zones
+            .Select(z => z.AuthorityId)
+            .Distinct()
+            .ToHashSet();
+
+        var authorities = new List<AuthorityListItem>();
+        foreach (var authorityId in distinctAuthorityIds)
+        {
+            var authority = await this.authorityProvider.GetByIdAsync(authorityId, ct).ConfigureAwait(false);
+            if (authority is not null)
+            {
+                authorities.Add(new AuthorityListItem(authority.Id, authority.Name, authority.AreaType));
+            }
+        }
+
+        authorities.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+
+        return new GetUserApplicationAuthoritiesResult(authorities, authorities.Count);
+    }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `dotnet test api/tests/town-crier.application.tests --filter "GetUserApplicationAuthoritiesQueryHandlerTests"`
+Expected: All 6 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesQuery.cs \
+  api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesResult.cs \
+  api/src/town-crier.application/PlanningApplications/GetUserApplicationAuthoritiesQueryHandler.cs \
+  api/tests/town-crier.application.tests/PlanningApplications/GetUserApplicationAuthoritiesQueryHandlerTests.cs
+git commit -m "feat(api): add GetUserApplicationAuthoritiesQueryHandler"
+```
+
+---
+
+### Task 2: Backend — Endpoint, DI Registration, and Serialization
+
+**Files:**
+- Modify: `api/src/town-crier.web/Endpoints/PlanningApplicationEndpoints.cs`
+- Modify: `api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs`
+- Modify: `api/src/town-crier.web/AppJsonSerializerContext.cs`
+- Modify: `api/tests/town-crier.web.tests/DependencyInjection/EndpointMappingTests.cs`
+
+- [ ] **Step 1: Write a failing endpoint mapping test**
+
+Add one test argument to the authenticated endpoints test in `EndpointMappingTests.cs`:
+
+```csharp
+// In EndpointMappingTests.cs, add a new Arguments attribute to the authenticated test:
+[Arguments("/v1/me/application-authorities", "GET")]
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `dotnet test api/tests/town-crier.web.tests --filter "Should_MapAuthenticatedEndpoints_When_MapAllEndpointsCalled"`
+Expected: Failure — 404 for the new route.
+
+- [ ] **Step 3: Register the handler in DI**
+
+In `ServiceCollectionExtensions.cs`, in the `AddApplicationServices` method, add after the `GetApplicationsByAuthorityQueryHandler` registration:
+
+```csharp
+services.AddTransient<GetUserApplicationAuthoritiesQueryHandler>();
+```
+
+- [ ] **Step 4: Register result type in serializer context**
+
+In `AppJsonSerializerContext.cs`, add a new attribute before the class declaration:
+
+```csharp
+[JsonSerializable(typeof(GetUserApplicationAuthoritiesResult))]
+```
+
+Add the using at the top if not already present (it should be — `TownCrier.Application.PlanningApplications` is already imported).
+
+- [ ] **Step 5: Add the endpoint**
+
+In `PlanningApplicationEndpoints.cs`, add a new endpoint inside `MapPlanningApplicationEndpoints`:
+
+```csharp
+group.MapGet("/me/application-authorities", async (
+    ClaimsPrincipal user,
+    GetUserApplicationAuthoritiesQueryHandler handler,
+    CancellationToken ct) =>
+{
+    var userId = user.FindFirstValue("sub")!;
+    var result = await handler.HandleAsync(
+        new GetUserApplicationAuthoritiesQuery(userId), ct).ConfigureAwait(false);
+    return Results.Ok(result);
+});
+```
+
+Add the required using at the top of the file:
+
+```csharp
+using System.Security.Claims;
+```
+
+- [ ] **Step 6: Run the endpoint mapping test to verify it passes**
+
+Run: `dotnet test api/tests/town-crier.web.tests --filter "Should_MapAuthenticatedEndpoints_When_MapAllEndpointsCalled"`
+Expected: All test cases pass.
+
+- [ ] **Step 7: Run full API test suite**
+
+Run: `dotnet test api/`
+Expected: All tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/src/town-crier.web/Endpoints/PlanningApplicationEndpoints.cs \
+  api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs \
+  api/src/town-crier.web/AppJsonSerializerContext.cs \
+  api/tests/town-crier.web.tests/DependencyInjection/EndpointMappingTests.cs
+git commit -m "feat(api): add GET /v1/me/application-authorities endpoint"
+```
+
+---
+
+### Task 3: Frontend — New Port, API Adapter, Hook, and Tests
+
+**Files:**
+- Create: `web/src/domain/ports/user-authorities-port.ts`
+- Create: `web/src/features/Applications/__tests__/spies/spy-user-authorities-port.ts`
+- Create: `web/src/features/Applications/__tests__/fixtures/authority.fixtures.ts`
+- Create: `web/src/features/Applications/useUserAuthorities.ts`
+- Create: `web/src/features/Applications/__tests__/useUserAuthorities.test.ts`
+
+- [ ] **Step 1: Create the port interface**
+
+```typescript
+// web/src/domain/ports/user-authorities-port.ts
+import type { AuthorityListItem } from '../types';
+
+export interface UserAuthoritiesPort {
+  fetchMyAuthorities(): Promise<readonly AuthorityListItem[]>;
+}
+```
+
+- [ ] **Step 2: Create the spy for testing**
+
+```typescript
+// web/src/features/Applications/__tests__/spies/spy-user-authorities-port.ts
+import type { AuthorityListItem } from '../../../../domain/types';
+import type { UserAuthoritiesPort } from '../../../../domain/ports/user-authorities-port';
+
+export class SpyUserAuthoritiesPort implements UserAuthoritiesPort {
+  fetchMyAuthoritiesCalls = 0;
+  fetchMyAuthoritiesResult: readonly AuthorityListItem[] = [];
+  fetchMyAuthoritiesError: Error | null = null;
+
+  async fetchMyAuthorities(): Promise<readonly AuthorityListItem[]> {
+    this.fetchMyAuthoritiesCalls++;
+    if (this.fetchMyAuthoritiesError) {
+      throw this.fetchMyAuthoritiesError;
+    }
+    return this.fetchMyAuthoritiesResult;
+  }
+}
+```
+
+- [ ] **Step 3: Create authority fixtures for this feature**
+
+```typescript
+// web/src/features/Applications/__tests__/fixtures/authority.fixtures.ts
+import type { AuthorityListItem } from '../../../../domain/types';
+import { asAuthorityId } from '../../../../domain/types';
+
+export function cornwallAuthority(
+  overrides?: Partial<AuthorityListItem>,
+): AuthorityListItem {
+  return {
+    id: asAuthorityId(42),
+    name: 'Cornwall Council',
+    areaType: 'Unitary',
+    ...overrides,
+  };
+}
+
+export function bathAuthority(
+  overrides?: Partial<AuthorityListItem>,
+): AuthorityListItem {
+  return {
+    id: asAuthorityId(10),
+    name: 'Bath and NE Somerset',
+    areaType: 'Unitary',
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 4: Write the failing hook tests**
+
+```typescript
+// web/src/features/Applications/__tests__/useUserAuthorities.test.ts
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useUserAuthorities } from '../useUserAuthorities';
+import { SpyUserAuthoritiesPort } from './spies/spy-user-authorities-port';
+import { cornwallAuthority, bathAuthority } from './fixtures/authority.fixtures';
+
+describe('useUserAuthorities', () => {
+  it('fetches authorities on mount', async () => {
+    const spy = new SpyUserAuthoritiesPort();
+    spy.fetchMyAuthoritiesResult = [cornwallAuthority(), bathAuthority()];
+
+    const { result } = renderHook(() => useUserAuthorities(spy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.authorities).toHaveLength(2);
+    expect(spy.fetchMyAuthoritiesCalls).toBe(1);
+  });
+
+  it('starts in loading state', () => {
+    const spy = new SpyUserAuthoritiesPort();
+
+    const { result } = renderHook(() => useUserAuthorities(spy));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.authorities).toEqual([]);
+  });
+
+  it('sets error when fetch fails', async () => {
+    const spy = new SpyUserAuthoritiesPort();
+    spy.fetchMyAuthoritiesError = new Error('Network error');
+
+    const { result } = renderHook(() => useUserAuthorities(spy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error?.message).toBe('Network error');
+    expect(result.current.authorities).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 5: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run src/features/Applications/__tests__/useUserAuthorities.test.ts`
+Expected: Failure — `useUserAuthorities` does not exist.
+
+- [ ] **Step 6: Implement the hook**
+
+```typescript
+// web/src/features/Applications/useUserAuthorities.ts
+import { useState, useEffect } from 'react';
+import type { AuthorityListItem } from '../../domain/types';
+import type { UserAuthoritiesPort } from '../../domain/ports/user-authorities-port';
+
+interface UserAuthoritiesState {
+  authorities: readonly AuthorityListItem[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useUserAuthorities(port: UserAuthoritiesPort) {
+  const [state, setState] = useState<UserAuthoritiesState>({
+    authorities: [],
+    isLoading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    port
+      .fetchMyAuthorities()
+      .then((authorities) => {
+        if (!cancelled) {
+          setState({ authorities, isLoading: false, error: null });
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setState({
+            authorities: [],
+            isLoading: false,
+            error: err instanceof Error ? err : new Error(String(err)),
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [port]);
+
+  return state;
+}
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+Run: `cd web && npx vitest run src/features/Applications/__tests__/useUserAuthorities.test.ts`
+Expected: All 3 tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/domain/ports/user-authorities-port.ts \
+  web/src/features/Applications/useUserAuthorities.ts \
+  web/src/features/Applications/__tests__/useUserAuthorities.test.ts \
+  web/src/features/Applications/__tests__/spies/spy-user-authorities-port.ts \
+  web/src/features/Applications/__tests__/fixtures/authority.fixtures.ts
+git commit -m "feat(web): add useUserAuthorities hook and port"
+```
+
+---
+
+### Task 4: Frontend — Redesign ApplicationsPage Component
+
+**Files:**
+- Modify: `web/src/features/Applications/ApplicationsPage.tsx`
+- Modify: `web/src/features/Applications/ApplicationsPage.module.css`
+- Rewrite: `web/src/features/Applications/__tests__/ApplicationsPage.test.tsx`
+
+- [ ] **Step 1: Write the failing page tests**
+
+Replace the entire test file to test the new authority-card-based design:
+
+```typescript
+// web/src/features/Applications/__tests__/ApplicationsPage.test.tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ApplicationsPage } from '../ApplicationsPage';
+import { SpyUserAuthoritiesPort } from './spies/spy-user-authorities-port';
+import { SpyApplicationsBrowsePort } from './spies/spy-applications-browse-port';
+import { cornwallAuthority, bathAuthority } from './fixtures/authority.fixtures';
+import {
+  undecidedApplication,
+  approvedApplication,
+} from '../../../components/ApplicationCard/__tests__/fixtures/planning-application-summary.fixtures';
+
+function renderPage(
+  userAuthoritiesPort: SpyUserAuthoritiesPort,
+  browsePort: SpyApplicationsBrowsePort,
+) {
+  return render(
+    <MemoryRouter>
+      <ApplicationsPage userAuthoritiesPort={userAuthoritiesPort} browsePort={browsePort} />
+    </MemoryRouter>,
+  );
+}
+
+describe('ApplicationsPage', () => {
+  let userAuthoritiesPort: SpyUserAuthoritiesPort;
+  let browsePort: SpyApplicationsBrowsePort;
+
+  beforeEach(() => {
+    userAuthoritiesPort = new SpyUserAuthoritiesPort();
+    browsePort = new SpyApplicationsBrowsePort();
+  });
+
+  it('renders page heading', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [];
+    renderPage(userAuthoritiesPort, browsePort);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Applications' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows loading state while fetching authorities', () => {
+    renderPage(userAuthoritiesPort, browsePort);
+
+    expect(screen.getByText('Loading authorities...')).toBeInTheDocument();
+  });
+
+  it('shows empty state when user has no watch zones', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [];
+    renderPage(userAuthoritiesPort, browsePort);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Set up a watch zone to start browsing applications.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows authority cards when user has watch zones', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [cornwallAuthority(), bathAuthority()];
+    renderPage(userAuthoritiesPort, browsePort);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cornwall Council')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Bath and NE Somerset')).toBeInTheDocument();
+  });
+
+  it('shows applications when authority card is clicked', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [cornwallAuthority()];
+    browsePort.fetchByAuthorityResult = [undecidedApplication(), approvedApplication()];
+    const user = userEvent.setup();
+
+    renderPage(userAuthoritiesPort, browsePort);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cornwall Council')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Cornwall Council'));
+
+    await waitFor(() => {
+      expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('2026/0099/LBC')).toBeInTheDocument();
+    expect(browsePort.fetchByAuthorityCalls).toEqual([cornwallAuthority().id]);
+  });
+
+  it('shows breadcrumb when viewing applications', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [cornwallAuthority()];
+    browsePort.fetchByAuthorityResult = [undecidedApplication()];
+    const user = userEvent.setup();
+
+    renderPage(userAuthoritiesPort, browsePort);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cornwall Council')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Cornwall Council'));
+
+    await waitFor(() => {
+      expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('link', { name: 'Authorities' })).toBeInTheDocument();
+  });
+
+  it('returns to authority list when breadcrumb is clicked', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [cornwallAuthority(), bathAuthority()];
+    browsePort.fetchByAuthorityResult = [undecidedApplication()];
+    const user = userEvent.setup();
+
+    renderPage(userAuthoritiesPort, browsePort);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cornwall Council')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Cornwall Council'));
+
+    await waitFor(() => {
+      expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('link', { name: 'Authorities' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Bath and NE Somerset')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Cornwall Council')).toBeInTheDocument();
+  });
+
+  it('shows empty state when authority has no applications', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [cornwallAuthority()];
+    browsePort.fetchByAuthorityResult = [];
+    const user = userEvent.setup();
+
+    renderPage(userAuthoritiesPort, browsePort);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cornwall Council')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Cornwall Council'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('No applications found for this authority.'),
+      ).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd web && npx vitest run src/features/Applications/__tests__/ApplicationsPage.test.tsx`
+Expected: Failure — `ApplicationsPage` still expects old props.
+
+- [ ] **Step 3: Update the CSS module**
+
+Replace `ApplicationsPage.module.css` with:
+
+```css
+/* web/src/features/Applications/ApplicationsPage.module.css */
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: var(--tc-space-lg) var(--tc-space-md);
+}
+
+.heading {
+  font-size: var(--tc-text-display-large);
+  font-weight: var(--tc-weight-bold);
+  color: var(--tc-text-primary);
+  margin: 0 0 var(--tc-space-lg);
+}
+
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: var(--tc-space-xs);
+  margin-bottom: var(--tc-space-lg);
+  font-size: var(--tc-text-body);
+  color: var(--tc-text-secondary);
+}
+
+.breadcrumbLink {
+  color: var(--tc-amber);
+  text-decoration: none;
+  cursor: pointer;
+  background: none;
+  border: none;
+  font: inherit;
+  padding: 0;
+}
+
+.breadcrumbLink:hover {
+  text-decoration: underline;
+}
+
+.breadcrumbCurrent {
+  color: var(--tc-text-primary);
+  font-weight: var(--tc-weight-medium);
+}
+
+.authorityGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: var(--tc-space-md);
+}
+
+.authorityCard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tc-space-xs);
+  background: var(--tc-surface);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  padding: var(--tc-space-md);
+  box-shadow: var(--tc-shadow-card);
+  cursor: pointer;
+  transition: border-color var(--tc-duration-fast) ease;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+
+.authorityCard:hover {
+  border-color: var(--tc-amber);
+}
+
+.authorityCard:focus-visible {
+  outline: 2px solid var(--tc-border-focused);
+  outline-offset: 2px;
+}
+
+.authorityName {
+  font-size: var(--tc-text-headline);
+  font-weight: var(--tc-weight-semibold);
+  color: var(--tc-text-primary);
+}
+
+.authorityType {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--tc-space-md);
+}
+
+.loading {
+  text-align: center;
+  padding: var(--tc-space-xl);
+  color: var(--tc-text-secondary);
+  font-size: var(--tc-text-body);
+}
+```
+
+- [ ] **Step 4: Rewrite the ApplicationsPage component**
+
+```tsx
+// web/src/features/Applications/ApplicationsPage.tsx
+import type { AuthorityListItem } from '../../domain/types';
+import type { ApplicationsBrowsePort } from '../../domain/ports/applications-browse-port';
+import type { UserAuthoritiesPort } from '../../domain/ports/user-authorities-port';
+import { useUserAuthorities } from './useUserAuthorities';
+import { useApplications } from './useApplications';
+import { ApplicationCard } from '../../components/ApplicationCard/ApplicationCard';
+import { EmptyState } from '../../components/EmptyState/EmptyState';
+import styles from './ApplicationsPage.module.css';
+
+interface Props {
+  userAuthoritiesPort: UserAuthoritiesPort;
+  browsePort: ApplicationsBrowsePort;
+}
+
+export function ApplicationsPage({ userAuthoritiesPort, browsePort }: Props) {
+  const { authorities, isLoading: isLoadingAuthorities, error: authoritiesError } =
+    useUserAuthorities(userAuthoritiesPort);
+  const { selectedAuthority, applications, isLoading: isLoadingApps, error: appsError, selectAuthority } =
+    useApplications(browsePort);
+
+  function handleAuthorityClick(authority: AuthorityListItem) {
+    selectAuthority(authority);
+  }
+
+  function handleBackToAuthorities() {
+    selectAuthority(null);
+  }
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.heading}>Applications</h1>
+
+      {selectedAuthority !== null && (
+        <nav className={styles.breadcrumb} aria-label="Breadcrumb">
+          <a
+            className={styles.breadcrumbLink}
+            role="link"
+            tabIndex={0}
+            onClick={handleBackToAuthorities}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                handleBackToAuthorities();
+              }
+            }}
+          >
+            Authorities
+          </a>
+          <span aria-hidden="true">&rsaquo;</span>
+          <span className={styles.breadcrumbCurrent}>{selectedAuthority.name}</span>
+        </nav>
+      )}
+
+      {selectedAuthority === null && (
+        <>
+          {isLoadingAuthorities && (
+            <div className={styles.loading} aria-live="polite">Loading authorities...</div>
+          )}
+
+          {authoritiesError !== null && (
+            <EmptyState
+              title="Something went wrong"
+              message={authoritiesError.message}
+            />
+          )}
+
+          {!isLoadingAuthorities && authoritiesError === null && authorities.length === 0 && (
+            <EmptyState
+              icon="🏛️"
+              title="No watch zones yet"
+              message="Set up a watch zone to start browsing applications."
+              actionLabel="Create watch zone"
+              onAction={() => {
+                window.location.href = '/watch-zones/new';
+              }}
+            />
+          )}
+
+          {!isLoadingAuthorities && authoritiesError === null && authorities.length > 0 && (
+            <div className={styles.authorityGrid}>
+              {authorities.map((authority) => (
+                <button
+                  key={authority.id}
+                  className={styles.authorityCard}
+                  onClick={() => handleAuthorityClick(authority)}
+                >
+                  <span className={styles.authorityName}>{authority.name}</span>
+                  <span className={styles.authorityType}>{authority.areaType}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {selectedAuthority !== null && (
+        <>
+          {isLoadingApps && (
+            <div className={styles.loading} aria-live="polite">Loading applications...</div>
+          )}
+
+          {appsError !== null && (
+            <EmptyState
+              title="Something went wrong"
+              message={appsError.message}
+              actionLabel="Try again"
+              onAction={() => selectAuthority(selectedAuthority)}
+            />
+          )}
+
+          {!isLoadingApps && appsError === null && applications.length === 0 && (
+            <EmptyState
+              icon="📋"
+              title="No applications"
+              message="No applications found for this authority."
+            />
+          )}
+
+          {!isLoadingApps && appsError === null && applications.length > 0 && (
+            <ul className={styles.list}>
+              {applications.map((app) => (
+                <li key={app.uid}>
+                  <ApplicationCard application={app} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Update `useApplications` to support resetting selection**
+
+The `selectAuthority` callback currently only accepts `AuthorityListItem`. Update it to also accept `null` for clearing selection:
+
+In `web/src/features/Applications/useApplications.ts`, change the `selectAuthority` callback:
+
+```typescript
+const selectAuthority = useCallback(
+  (authority: AuthorityListItem | null) => {
+    if (authority === null) {
+      setState({
+        selectedAuthority: null,
+        applications: [],
+        isLoading: false,
+        error: null,
+      });
+      return;
+    }
+
+    setState((prev) => ({
+      ...prev,
+      selectedAuthority: authority,
+      isLoading: true,
+      error: null,
+    }));
+
+    port
+      .fetchByAuthority(authority.id)
+      .then((applications) => {
+        setState((prev) => ({
+          ...prev,
+          applications,
+          isLoading: false,
+        }));
+      })
+      .catch((err: unknown) => {
+        setState((prev) => ({
+          ...prev,
+          applications: [],
+          isLoading: false,
+          error: err instanceof Error ? err : new Error(String(err)),
+        }));
+      });
+  },
+  [port],
+);
+```
+
+- [ ] **Step 6: Run the page tests to verify they pass**
+
+Run: `cd web && npx vitest run src/features/Applications/__tests__/ApplicationsPage.test.tsx`
+Expected: All 8 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/features/Applications/ApplicationsPage.tsx \
+  web/src/features/Applications/ApplicationsPage.module.css \
+  web/src/features/Applications/useApplications.ts \
+  web/src/features/Applications/__tests__/ApplicationsPage.test.tsx
+git commit -m "feat(web): redesign ApplicationsPage with authority cards and breadcrumb"
+```
+
+---
+
+### Task 5: Frontend — Update ConnectedApplicationsPage and API Adapter
+
+**Files:**
+- Modify: `web/src/features/Applications/ConnectedApplicationsPage.tsx`
+- Modify: `web/src/api/applications.ts`
+
+- [ ] **Step 1: Add the API function**
+
+In `web/src/api/applications.ts`, add a new method to the returned object:
+
+```typescript
+// web/src/api/applications.ts
+import type { ApiClient } from './client';
+import type { AuthorityListItem, PlanningApplication } from '../domain/types';
+
+interface UserApplicationAuthoritiesResponse {
+  readonly authorities: readonly AuthorityListItem[];
+  readonly count: number;
+}
+
+export function applicationsApi(client: ApiClient) {
+  return {
+    getMyAuthorities: () =>
+      client
+        .get<UserApplicationAuthoritiesResponse>('/v1/me/application-authorities')
+        .then((r) => r.authorities),
+    getByAuthority: (authorityId: number) =>
+      client.get<readonly PlanningApplication[]>('/v1/applications', { authorityId: String(authorityId) }),
+    getByUid: (uid: string) =>
+      client.get<PlanningApplication>(`/v1/applications/${uid}`),
+  };
+}
+```
+
+- [ ] **Step 2: Update the connected page**
+
+Replace the entire `ConnectedApplicationsPage.tsx`:
+
+```tsx
+// web/src/features/Applications/ConnectedApplicationsPage.tsx
+import { useMemo } from 'react';
+import { useApiClient } from '../../api/useApiClient';
+import { applicationsApi } from '../../api/applications';
+import type { ApplicationsBrowsePort } from '../../domain/ports/applications-browse-port';
+import type { UserAuthoritiesPort } from '../../domain/ports/user-authorities-port';
+import { ApplicationsPage } from './ApplicationsPage';
+
+export function ConnectedApplicationsPage() {
+  const client = useApiClient();
+
+  const userAuthoritiesPort: UserAuthoritiesPort = useMemo(
+    () => ({
+      fetchMyAuthorities: () => applicationsApi(client).getMyAuthorities(),
+    }),
+    [client],
+  );
+
+  const browsePort: ApplicationsBrowsePort = useMemo(
+    () => ({
+      fetchByAuthority: (authorityId) =>
+        applicationsApi(client).getByAuthority(authorityId),
+    }),
+    [client],
+  );
+
+  return <ApplicationsPage userAuthoritiesPort={userAuthoritiesPort} browsePort={browsePort} />;
+}
+```
+
+- [ ] **Step 3: Run the full frontend test suite**
+
+Run: `cd web && npx vitest run`
+Expected: All tests pass. (The `useApplications` hook tests should still pass since `selectAuthority` is backwards-compatible — the tests pass `AuthorityListItem` which satisfies `AuthorityListItem | null`.)
+
+- [ ] **Step 4: Run type check**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/features/Applications/ConnectedApplicationsPage.tsx \
+  web/src/api/applications.ts
+git commit -m "feat(web): wire ConnectedApplicationsPage to new authority endpoint"
+```
+
+---
+
+### Task 6: Cleanup — Remove Unused AuthoritySearchPort Dependency
+
+**Files:**
+- Modify: `web/src/features/Applications/__tests__/useApplications.test.ts` (remove authority fixture import if unused)
+
+The `AuthoritySelector` component and `AuthoritySearchPort` are still used by the Search page, so they stay. The only cleanup is removing the old authority search port import from the Applications page test — which was already replaced in Task 4.
+
+- [ ] **Step 1: Verify no stale imports**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No type errors.
+
+- [ ] **Step 2: Run full test suites**
+
+Run these in parallel:
+
+```bash
+cd web && npx vitest run
+dotnet test api/
+```
+
+Expected: All tests pass in both projects.
+
+- [ ] **Step 3: Commit if any cleanup was needed**
+
+If the type check or tests revealed stale imports, fix and commit:
+
+```bash
+git add -u
+git commit -m "refactor(web): remove unused authority search imports from Applications feature"
+```

--- a/docs/superpowers/specs/2026-04-03-applications-page-redesign.md
+++ b/docs/superpowers/specs/2026-04-03-applications-page-redesign.md
@@ -1,0 +1,68 @@
+# Applications Page Redesign
+
+Date: 2026-04-03
+
+## Problem
+
+The Applications page lets users search all ~500 PlanIt authorities, but only authorities with active watch zones have data in Cosmos DB. Selecting an authority with no watch zones returns an empty list with no explanation. This is confusing and misleading.
+
+## Decision
+
+Replace the authority search box with a list of the current user's watch zone authorities. This scopes the page to authorities that are guaranteed to have data, and creates a meaningful differentiation between personal and pro tiers.
+
+## Design
+
+### Backend
+
+**New endpoint**: `GET /v1/applications/authorities` (authenticated)
+
+- Reads the authenticated user's watch zones to get their distinct authority IDs
+- Cross-references with `IAuthorityProvider` to resolve names and area types
+- Returns `{ authorities: AuthorityListItem[], count: int }`
+- `AuthorityListItem` reuses the existing record: `{ id, name, areaType }`
+
+**New query**: `GetUserApplicationAuthoritiesQuery` / `GetUserApplicationAuthoritiesQueryHandler`
+- Dependencies: `IWatchZoneRepository` (to get user's zones), `IAuthorityProvider` (to resolve details)
+- Filters watch zones by the authenticated user's ID
+- Maps distinct authority IDs to `AuthorityListItem` via the cached authority provider
+- Returns sorted by name
+
+### Frontend
+
+**Applications page** has two view states managed in the `useApplications` hook:
+
+1. **Authority list** (default)
+   - Fetches the user's active authorities on mount via new `GET /v1/applications/authorities`
+   - Renders a clickable card per authority showing name and area type
+   - Empty state: "Set up a watch zone to start browsing applications" with link to `/watch-zones/new`
+
+2. **Application list** (after selecting an authority)
+   - Breadcrumb: `Authorities > {authority name}` at top of page; clicking "Authorities" returns to state 1
+   - Fetches and displays applications for the selected authority (existing behaviour)
+   - Existing `ApplicationCard` component unchanged
+
+**Removed from this page**: `AuthoritySelector` component and `AuthoritySearchPort` dependency. The `AuthoritySelector` remains available for other pages (e.g., Search) that still need free-text authority search.
+
+### New domain port
+
+```typescript
+interface UserAuthoritiesPort {
+  fetchMyAuthorities(): Promise<readonly AuthorityListItem[]>;
+}
+```
+
+Replaces `AuthoritySearchPort` in the Applications feature.
+
+### What stays the same
+
+- `ApplicationCard` component and its link to `/applications/{uid}`
+- Application detail page and route (`/applications/*`)
+- `GET /v1/applications?authorityId=` endpoint for fetching applications by authority
+- The `AuthoritySelector` component (still used elsewhere)
+
+## Consequences
+
+- Users can only browse applications in authorities where they have watch zones
+- No PlanIt calls on the Applications page — all data comes from Cosmos and the cached authority list
+- The page becomes a meaningful entry point for personal-tier users to explore their watched areas
+- Pro-tier differentiation: broader authority access can be gated by subscription tier in future

--- a/web/src/api/applications.ts
+++ b/web/src/api/applications.ts
@@ -1,8 +1,17 @@
 import type { ApiClient } from './client';
-import type { PlanningApplication } from '../domain/types';
+import type { AuthorityListItem, PlanningApplication } from '../domain/types';
+
+interface UserApplicationAuthoritiesResponse {
+  readonly authorities: readonly AuthorityListItem[];
+  readonly count: number;
+}
 
 export function applicationsApi(client: ApiClient) {
   return {
+    getMyAuthorities: () =>
+      client
+        .get<UserApplicationAuthoritiesResponse>('/v1/me/application-authorities')
+        .then((r) => r.authorities),
     getByAuthority: (authorityId: number) =>
       client.get<readonly PlanningApplication[]>('/v1/applications', { authorityId: String(authorityId) }),
     getByUid: (uid: string) =>

--- a/web/src/components/AuthoritySelector/__tests__/AuthoritySelector.test.tsx
+++ b/web/src/components/AuthoritySelector/__tests__/AuthoritySelector.test.tsx
@@ -66,6 +66,29 @@ describe('AuthoritySelector', () => {
     expect(screen.queryByText('Oxford City Council')).not.toBeInTheDocument();
   });
 
+  it('does not reopen dropdown after selecting an authority', async () => {
+    const spy = new SpyAuthoritySearchPort();
+    spy.searchResult = twoAuthorityResults();
+    const user = userEvent.setup();
+
+    render(<AuthoritySelector searchPort={spy} onSelect={() => {}} />);
+
+    await user.type(screen.getByRole('combobox'), 'cam');
+
+    await waitFor(() => {
+      expect(screen.getByText('Cambridge City Council')).toBeInTheDocument();
+    });
+
+    const searchCallsBefore = spy.searchCalls.length;
+    await user.click(screen.getByText('Cambridge City Council'));
+
+    // Wait long enough for the debounce to fire if it was going to
+    await new Promise((r) => setTimeout(r, 350));
+
+    expect(spy.searchCalls.length).toBe(searchCallsBefore);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
   it('sets the input value to the selected authority name', async () => {
     const spy = new SpyAuthoritySearchPort();
     spy.searchResult = twoAuthorityResults();

--- a/web/src/components/AuthoritySelector/useAuthoritySearch.ts
+++ b/web/src/components/AuthoritySelector/useAuthoritySearch.ts
@@ -18,18 +18,25 @@ export function useAuthoritySearch(port: AuthoritySearchPort) {
     isSearching: false,
   });
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const skipNextSearchRef = useRef(false);
 
   const setQuery = useCallback((query: string) => {
     setState((prev) => ({ ...prev, query }));
   }, []);
 
   const clearResults = useCallback(() => {
+    skipNextSearchRef.current = true;
     setState((prev) => ({ ...prev, results: [] }));
   }, []);
 
   useEffect(() => {
     if (timerRef.current !== undefined) {
       clearTimeout(timerRef.current);
+    }
+
+    if (skipNextSearchRef.current) {
+      skipNextSearchRef.current = false;
+      return;
     }
 
     if (state.query.length < MIN_QUERY_LENGTH) {

--- a/web/src/domain/ports/user-authorities-port.ts
+++ b/web/src/domain/ports/user-authorities-port.ts
@@ -1,0 +1,5 @@
+import type { AuthorityListItem } from '../types';
+
+export interface UserAuthoritiesPort {
+  fetchMyAuthorities(): Promise<readonly AuthorityListItem[]>;
+}

--- a/web/src/features/Applications/ApplicationsPage.module.css
+++ b/web/src/features/Applications/ApplicationsPage.module.css
@@ -11,8 +11,74 @@
   margin: 0 0 var(--tc-space-lg);
 }
 
-.selectorWrapper {
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: var(--tc-space-xs);
   margin-bottom: var(--tc-space-lg);
+  font-size: var(--tc-text-body);
+  color: var(--tc-text-secondary);
+}
+
+.breadcrumbLink {
+  color: var(--tc-amber);
+  text-decoration: none;
+  cursor: pointer;
+  background: none;
+  border: none;
+  font: inherit;
+  padding: 0;
+}
+
+.breadcrumbLink:hover {
+  text-decoration: underline;
+}
+
+.breadcrumbCurrent {
+  color: var(--tc-text-primary);
+  font-weight: var(--tc-weight-medium);
+}
+
+.authorityGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: var(--tc-space-md);
+}
+
+.authorityCard {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tc-space-xs);
+  background: var(--tc-surface);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  padding: var(--tc-space-md);
+  box-shadow: var(--tc-shadow-card);
+  cursor: pointer;
+  transition: border-color var(--tc-duration-fast) ease;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+}
+
+.authorityCard:hover {
+  border-color: var(--tc-amber);
+}
+
+.authorityCard:focus-visible {
+  outline: 2px solid var(--tc-border-focused);
+  outline-offset: 2px;
+}
+
+.authorityName {
+  font-size: var(--tc-text-headline);
+  font-weight: var(--tc-weight-semibold);
+  color: var(--tc-text-primary);
+}
+
+.authorityType {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
 }
 
 .list {

--- a/web/src/features/Applications/ApplicationsPage.tsx
+++ b/web/src/features/Applications/ApplicationsPage.tsx
@@ -1,74 +1,130 @@
 import type { AuthorityListItem } from '../../domain/types';
 import type { ApplicationsBrowsePort } from '../../domain/ports/applications-browse-port';
-import type { AuthoritySearchPort } from '../../domain/ports/authority-search-port';
+import type { UserAuthoritiesPort } from '../../domain/ports/user-authorities-port';
+import { useUserAuthorities } from './useUserAuthorities';
 import { useApplications } from './useApplications';
-import { AuthoritySelector } from '../../components/AuthoritySelector/AuthoritySelector';
 import { ApplicationCard } from '../../components/ApplicationCard/ApplicationCard';
 import { EmptyState } from '../../components/EmptyState/EmptyState';
 import styles from './ApplicationsPage.module.css';
 
 interface Props {
+  userAuthoritiesPort: UserAuthoritiesPort;
   browsePort: ApplicationsBrowsePort;
-  searchPort: AuthoritySearchPort;
 }
 
-export function ApplicationsPage({ browsePort, searchPort }: Props) {
-  const { selectedAuthority, applications, isLoading, error, selectAuthority } =
+export function ApplicationsPage({ userAuthoritiesPort, browsePort }: Props) {
+  const { authorities, isLoading: isLoadingAuthorities, error: authoritiesError } =
+    useUserAuthorities(userAuthoritiesPort);
+  const { selectedAuthority, applications, isLoading: isLoadingApps, error: appsError, selectAuthority } =
     useApplications(browsePort);
 
-  function handleAuthoritySelect(authority: AuthorityListItem) {
+  function handleAuthorityClick(authority: AuthorityListItem) {
     selectAuthority(authority);
+  }
+
+  function handleBackToAuthorities() {
+    selectAuthority(null);
   }
 
   return (
     <div className={styles.container}>
       <h1 className={styles.heading}>Applications</h1>
 
-      <div className={styles.selectorWrapper}>
-        <AuthoritySelector searchPort={searchPort} onSelect={handleAuthoritySelect} />
-      </div>
-
-      {isLoading && (
-        <div className={styles.loading} aria-live="polite">Loading applications...</div>
+      {selectedAuthority !== null && (
+        <nav className={styles.breadcrumb} aria-label="Breadcrumb">
+          <a
+            className={styles.breadcrumbLink}
+            role="link"
+            tabIndex={0}
+            onClick={handleBackToAuthorities}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                handleBackToAuthorities();
+              }
+            }}
+          >
+            Authorities
+          </a>
+          <span aria-hidden="true">&rsaquo;</span>
+          <span className={styles.breadcrumbCurrent}>{selectedAuthority.name}</span>
+        </nav>
       )}
 
-      {error !== null && (
-        <EmptyState
-          title="Something went wrong"
-          message={error.message}
-          actionLabel="Try again"
-          onAction={() => {
-            if (selectedAuthority) {
-              selectAuthority(selectedAuthority);
-            }
-          }}
-        />
+      {selectedAuthority === null && (
+        <>
+          {isLoadingAuthorities && (
+            <div className={styles.loading} aria-live="polite">Loading authorities...</div>
+          )}
+
+          {authoritiesError !== null && (
+            <EmptyState
+              title="Something went wrong"
+              message={authoritiesError.message}
+            />
+          )}
+
+          {!isLoadingAuthorities && authoritiesError === null && authorities.length === 0 && (
+            <EmptyState
+              icon="🏛️"
+              title="No watch zones yet"
+              message="Set up a watch zone to start browsing applications."
+              actionLabel="Create watch zone"
+              onAction={() => {
+                window.location.href = '/watch-zones/new';
+              }}
+            />
+          )}
+
+          {!isLoadingAuthorities && authoritiesError === null && authorities.length > 0 && (
+            <div className={styles.authorityGrid}>
+              {authorities.map((authority) => (
+                <button
+                  key={authority.id}
+                  className={styles.authorityCard}
+                  onClick={() => handleAuthorityClick(authority)}
+                >
+                  <span className={styles.authorityName}>{authority.name}</span>
+                  <span className={styles.authorityType}>{authority.areaType}</span>
+                </button>
+              ))}
+            </div>
+          )}
+        </>
       )}
 
-      {!isLoading && error === null && selectedAuthority === null && (
-        <EmptyState
-          icon="🏛️"
-          title="Browse applications"
-          message="Select an authority to browse planning applications."
-        />
-      )}
+      {selectedAuthority !== null && (
+        <>
+          {isLoadingApps && (
+            <div className={styles.loading} aria-live="polite">Loading applications...</div>
+          )}
 
-      {!isLoading && error === null && selectedAuthority !== null && applications.length === 0 && (
-        <EmptyState
-          icon="📋"
-          title="No applications"
-          message="No applications found for this authority."
-        />
-      )}
+          {appsError !== null && (
+            <EmptyState
+              title="Something went wrong"
+              message={appsError.message}
+              actionLabel="Try again"
+              onAction={() => selectAuthority(selectedAuthority)}
+            />
+          )}
 
-      {!isLoading && error === null && applications.length > 0 && (
-        <ul className={styles.list}>
-          {applications.map((app) => (
-            <li key={app.uid}>
-              <ApplicationCard application={app} />
-            </li>
-          ))}
-        </ul>
+          {!isLoadingApps && appsError === null && applications.length === 0 && (
+            <EmptyState
+              icon="📋"
+              title="No applications"
+              message="No applications found for this authority."
+            />
+          )}
+
+          {!isLoadingApps && appsError === null && applications.length > 0 && (
+            <ul className={styles.list}>
+              {applications.map((app) => (
+                <li key={app.uid}>
+                  <ApplicationCard application={app} />
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
       )}
     </div>
   );

--- a/web/src/features/Applications/ApplicationsPage.tsx
+++ b/web/src/features/Applications/ApplicationsPage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import type { AuthorityListItem } from '../../domain/types';
 import type { ApplicationsBrowsePort } from '../../domain/ports/applications-browse-port';
 import type { UserAuthoritiesPort } from '../../domain/ports/user-authorities-port';
@@ -13,6 +14,7 @@ interface Props {
 }
 
 export function ApplicationsPage({ userAuthoritiesPort, browsePort }: Props) {
+  const navigate = useNavigate();
   const { authorities, isLoading: isLoadingAuthorities, error: authoritiesError } =
     useUserAuthorities(userAuthoritiesPort);
   const { selectedAuthority, applications, isLoading: isLoadingApps, error: appsError, selectAuthority } =
@@ -32,19 +34,12 @@ export function ApplicationsPage({ userAuthoritiesPort, browsePort }: Props) {
 
       {selectedAuthority !== null && (
         <nav className={styles.breadcrumb} aria-label="Breadcrumb">
-          <a
+          <button
             className={styles.breadcrumbLink}
-            role="link"
-            tabIndex={0}
             onClick={handleBackToAuthorities}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                handleBackToAuthorities();
-              }
-            }}
           >
             Authorities
-          </a>
+          </button>
           <span aria-hidden="true">&rsaquo;</span>
           <span className={styles.breadcrumbCurrent}>{selectedAuthority.name}</span>
         </nav>
@@ -69,9 +64,7 @@ export function ApplicationsPage({ userAuthoritiesPort, browsePort }: Props) {
               title="No watch zones yet"
               message="Set up a watch zone to start browsing applications."
               actionLabel="Create watch zone"
-              onAction={() => {
-                window.location.href = '/watch-zones/new';
-              }}
+              onAction={() => navigate('/watch-zones/new')}
             />
           )}
 

--- a/web/src/features/Applications/ConnectedApplicationsPage.tsx
+++ b/web/src/features/Applications/ConnectedApplicationsPage.tsx
@@ -1,9 +1,8 @@
 import { useMemo } from 'react';
 import { useApiClient } from '../../api/useApiClient';
 import { applicationsApi } from '../../api/applications';
-import { authoritiesApi } from '../../api/authorities';
 import type { ApplicationsBrowsePort } from '../../domain/ports/applications-browse-port';
-import type { AuthoritySearchPort } from '../../domain/ports/authority-search-port';
+import type { UserAuthoritiesPort } from '../../domain/ports/user-authorities-port';
 import { ApplicationsPage } from './ApplicationsPage';
 
 export function ConnectedApplicationsPage() {
@@ -17,12 +16,12 @@ export function ConnectedApplicationsPage() {
     [client],
   );
 
-  const searchPort: AuthoritySearchPort = useMemo(
+  const userAuthoritiesPort: UserAuthoritiesPort = useMemo(
     () => ({
-      search: (query) => authoritiesApi(client).list(query),
+      fetchMyAuthorities: async () => [],
     }),
-    [client],
+    [],
   );
 
-  return <ApplicationsPage browsePort={browsePort} searchPort={searchPort} />;
+  return <ApplicationsPage userAuthoritiesPort={userAuthoritiesPort} browsePort={browsePort} />;
 }

--- a/web/src/features/Applications/ConnectedApplicationsPage.tsx
+++ b/web/src/features/Applications/ConnectedApplicationsPage.tsx
@@ -18,9 +18,9 @@ export function ConnectedApplicationsPage() {
 
   const userAuthoritiesPort: UserAuthoritiesPort = useMemo(
     () => ({
-      fetchMyAuthorities: async () => [],
+      fetchMyAuthorities: () => applicationsApi(client).getMyAuthorities(),
     }),
-    [],
+    [client],
   );
 
   return <ApplicationsPage userAuthoritiesPort={userAuthoritiesPort} browsePort={browsePort} />;

--- a/web/src/features/Applications/__tests__/ApplicationsPage.test.tsx
+++ b/web/src/features/Applications/__tests__/ApplicationsPage.test.tsx
@@ -105,7 +105,7 @@ describe('ApplicationsPage', () => {
       expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument();
     });
 
-    expect(screen.getByRole('link', { name: 'Authorities' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Authorities' })).toBeInTheDocument();
   });
 
   it('returns to authority list when breadcrumb is clicked', async () => {
@@ -125,7 +125,7 @@ describe('ApplicationsPage', () => {
       expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole('link', { name: 'Authorities' }));
+    await user.click(screen.getByRole('button', { name: 'Authorities' }));
 
     await waitFor(() => {
       expect(screen.getByText('Bath and NE Somerset')).toBeInTheDocument();

--- a/web/src/features/Applications/__tests__/ApplicationsPage.test.tsx
+++ b/web/src/features/Applications/__tests__/ApplicationsPage.test.tsx
@@ -3,97 +3,153 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { ApplicationsPage } from '../ApplicationsPage';
+import { SpyUserAuthoritiesPort } from './spies/spy-user-authorities-port';
 import { SpyApplicationsBrowsePort } from './spies/spy-applications-browse-port';
-import { SpyAuthoritySearchPort } from '../../../components/AuthoritySelector/__tests__/spies/spy-authority-search-port';
+import { cornwallAuthority, bathAuthority } from './fixtures/authority.fixtures';
 import {
   undecidedApplication,
   approvedApplication,
 } from '../../../components/ApplicationCard/__tests__/fixtures/planning-application-summary.fixtures';
-import {
-  cambridgeAuthority,
-  twoAuthorityResults,
-} from '../../../components/AuthoritySelector/__tests__/fixtures/authority.fixtures';
 
 function renderPage(
+  userAuthoritiesPort: SpyUserAuthoritiesPort,
   browsePort: SpyApplicationsBrowsePort,
-  searchPort: SpyAuthoritySearchPort,
 ) {
   return render(
     <MemoryRouter>
-      <ApplicationsPage browsePort={browsePort} searchPort={searchPort} />
+      <ApplicationsPage userAuthoritiesPort={userAuthoritiesPort} browsePort={browsePort} />
     </MemoryRouter>,
   );
 }
 
 describe('ApplicationsPage', () => {
+  let userAuthoritiesPort: SpyUserAuthoritiesPort;
   let browsePort: SpyApplicationsBrowsePort;
-  let searchPort: SpyAuthoritySearchPort;
 
   beforeEach(() => {
+    userAuthoritiesPort = new SpyUserAuthoritiesPort();
     browsePort = new SpyApplicationsBrowsePort();
-    searchPort = new SpyAuthoritySearchPort();
   });
 
-  it('renders page heading and authority selector', () => {
-    renderPage(browsePort, searchPort);
+  it('renders page heading', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [];
+    renderPage(userAuthoritiesPort, browsePort);
 
-    expect(screen.getByRole('heading', { name: 'Applications' })).toBeInTheDocument();
-    expect(screen.getByRole('combobox', { name: 'Search authorities' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Applications' })).toBeInTheDocument();
+    });
   });
 
-  it('shows empty state before authority is selected', () => {
-    renderPage(browsePort, searchPort);
+  it('shows loading state while fetching authorities', () => {
+    renderPage(userAuthoritiesPort, browsePort);
 
-    expect(screen.getByText('Select an authority to browse planning applications.')).toBeInTheDocument();
+    expect(screen.getByText('Loading authorities...')).toBeInTheDocument();
   });
 
-  it('shows application cards after authority is selected', async () => {
-    searchPort.searchResult = twoAuthorityResults();
+  it('shows empty state when user has no watch zones', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [];
+    renderPage(userAuthoritiesPort, browsePort);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Set up a watch zone to start browsing applications.'),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows authority cards when user has watch zones', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [cornwallAuthority(), bathAuthority()];
+    renderPage(userAuthoritiesPort, browsePort);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cornwall Council')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Bath and NE Somerset')).toBeInTheDocument();
+  });
+
+  it('shows applications when authority card is clicked', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [cornwallAuthority()];
     browsePort.fetchByAuthorityResult = [undecidedApplication(), approvedApplication()];
     const user = userEvent.setup();
 
-    renderPage(browsePort, searchPort);
+    renderPage(userAuthoritiesPort, browsePort);
 
-    // Type to search for authority
-    const input = screen.getByRole('combobox', { name: 'Search authorities' });
-    await user.type(input, 'Cambridge');
-
-    // Wait for search results to appear
     await waitFor(() => {
-      expect(screen.getByRole('listbox')).toBeInTheDocument();
+      expect(screen.getByText('Cornwall Council')).toBeInTheDocument();
     });
 
-    // Select the authority
-    const option = screen.getByText('Cambridge City Council');
-    await user.click(option);
+    await user.click(screen.getByText('Cornwall Council'));
 
-    // Wait for applications to load
     await waitFor(() => {
       expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument();
     });
 
     expect(screen.getByText('2026/0099/LBC')).toBeInTheDocument();
-    expect(browsePort.fetchByAuthorityCalls).toEqual([cambridgeAuthority().id]);
+    expect(browsePort.fetchByAuthorityCalls).toEqual([cornwallAuthority().id]);
+  });
+
+  it('shows breadcrumb when viewing applications', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [cornwallAuthority()];
+    browsePort.fetchByAuthorityResult = [undecidedApplication()];
+    const user = userEvent.setup();
+
+    renderPage(userAuthoritiesPort, browsePort);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cornwall Council')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Cornwall Council'));
+
+    await waitFor(() => {
+      expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('link', { name: 'Authorities' })).toBeInTheDocument();
+  });
+
+  it('returns to authority list when breadcrumb is clicked', async () => {
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [cornwallAuthority(), bathAuthority()];
+    browsePort.fetchByAuthorityResult = [undecidedApplication()];
+    const user = userEvent.setup();
+
+    renderPage(userAuthoritiesPort, browsePort);
+
+    await waitFor(() => {
+      expect(screen.getByText('Cornwall Council')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Cornwall Council'));
+
+    await waitFor(() => {
+      expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('link', { name: 'Authorities' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Bath and NE Somerset')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Cornwall Council')).toBeInTheDocument();
   });
 
   it('shows empty state when authority has no applications', async () => {
-    searchPort.searchResult = twoAuthorityResults();
+    userAuthoritiesPort.fetchMyAuthoritiesResult = [cornwallAuthority()];
     browsePort.fetchByAuthorityResult = [];
     const user = userEvent.setup();
 
-    renderPage(browsePort, searchPort);
-
-    const input = screen.getByRole('combobox', { name: 'Search authorities' });
-    await user.type(input, 'Cambridge');
+    renderPage(userAuthoritiesPort, browsePort);
 
     await waitFor(() => {
-      expect(screen.getByRole('listbox')).toBeInTheDocument();
+      expect(screen.getByText('Cornwall Council')).toBeInTheDocument();
     });
 
-    await user.click(screen.getByText('Cambridge City Council'));
+    await user.click(screen.getByText('Cornwall Council'));
 
     await waitFor(() => {
-      expect(screen.getByText('No applications found for this authority.')).toBeInTheDocument();
+      expect(
+        screen.getByText('No applications found for this authority.'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/web/src/features/Applications/__tests__/fixtures/authority.fixtures.ts
+++ b/web/src/features/Applications/__tests__/fixtures/authority.fixtures.ts
@@ -1,0 +1,24 @@
+import type { AuthorityListItem } from '../../../../domain/types';
+import { asAuthorityId } from '../../../../domain/types';
+
+export function cornwallAuthority(
+  overrides?: Partial<AuthorityListItem>,
+): AuthorityListItem {
+  return {
+    id: asAuthorityId(42),
+    name: 'Cornwall Council',
+    areaType: 'Unitary',
+    ...overrides,
+  };
+}
+
+export function bathAuthority(
+  overrides?: Partial<AuthorityListItem>,
+): AuthorityListItem {
+  return {
+    id: asAuthorityId(10),
+    name: 'Bath and NE Somerset',
+    areaType: 'Unitary',
+    ...overrides,
+  };
+}

--- a/web/src/features/Applications/__tests__/spies/spy-user-authorities-port.ts
+++ b/web/src/features/Applications/__tests__/spies/spy-user-authorities-port.ts
@@ -1,0 +1,16 @@
+import type { AuthorityListItem } from '../../../../domain/types';
+import type { UserAuthoritiesPort } from '../../../../domain/ports/user-authorities-port';
+
+export class SpyUserAuthoritiesPort implements UserAuthoritiesPort {
+  fetchMyAuthoritiesCalls = 0;
+  fetchMyAuthoritiesResult: readonly AuthorityListItem[] = [];
+  fetchMyAuthoritiesError: Error | null = null;
+
+  async fetchMyAuthorities(): Promise<readonly AuthorityListItem[]> {
+    this.fetchMyAuthoritiesCalls++;
+    if (this.fetchMyAuthoritiesError) {
+      throw this.fetchMyAuthoritiesError;
+    }
+    return this.fetchMyAuthoritiesResult;
+  }
+}

--- a/web/src/features/Applications/__tests__/useUserAuthorities.test.ts
+++ b/web/src/features/Applications/__tests__/useUserAuthorities.test.ts
@@ -1,0 +1,45 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useUserAuthorities } from '../useUserAuthorities';
+import { SpyUserAuthoritiesPort } from './spies/spy-user-authorities-port';
+import { cornwallAuthority, bathAuthority } from './fixtures/authority.fixtures';
+
+describe('useUserAuthorities', () => {
+  it('fetches authorities on mount', async () => {
+    const spy = new SpyUserAuthoritiesPort();
+    spy.fetchMyAuthoritiesResult = [cornwallAuthority(), bathAuthority()];
+
+    const { result } = renderHook(() => useUserAuthorities(spy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.authorities).toHaveLength(2);
+    expect(spy.fetchMyAuthoritiesCalls).toBe(1);
+  });
+
+  it('starts in loading state', () => {
+    const spy = new SpyUserAuthoritiesPort();
+
+    const { result } = renderHook(() => useUserAuthorities(spy));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.authorities).toEqual([]);
+  });
+
+  it('sets error when fetch fails', async () => {
+    const spy = new SpyUserAuthoritiesPort();
+    spy.fetchMyAuthoritiesError = new Error('Network error');
+
+    const { result } = renderHook(() => useUserAuthorities(spy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error?.message).toBe('Network error');
+    expect(result.current.authorities).toEqual([]);
+  });
+});

--- a/web/src/features/Applications/useApplications.ts
+++ b/web/src/features/Applications/useApplications.ts
@@ -18,7 +18,17 @@ export function useApplications(port: ApplicationsBrowsePort) {
   });
 
   const selectAuthority = useCallback(
-    (authority: AuthorityListItem) => {
+    (authority: AuthorityListItem | null) => {
+      if (authority === null) {
+        setState({
+          selectedAuthority: null,
+          applications: [],
+          isLoading: false,
+          error: null,
+        });
+        return;
+      }
+
       setState((prev) => ({
         ...prev,
         selectedAuthority: authority,

--- a/web/src/features/Applications/useUserAuthorities.ts
+++ b/web/src/features/Applications/useUserAuthorities.ts
@@ -1,0 +1,44 @@
+import { useState, useEffect } from 'react';
+import type { AuthorityListItem } from '../../domain/types';
+import type { UserAuthoritiesPort } from '../../domain/ports/user-authorities-port';
+
+interface UserAuthoritiesState {
+  authorities: readonly AuthorityListItem[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+export function useUserAuthorities(port: UserAuthoritiesPort) {
+  const [state, setState] = useState<UserAuthoritiesState>({
+    authorities: [],
+    isLoading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    port
+      .fetchMyAuthorities()
+      .then((authorities) => {
+        if (!cancelled) {
+          setState({ authorities, isLoading: false, error: null });
+        }
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setState({
+            authorities: [],
+            isLoading: false,
+            error: err instanceof Error ? err : new Error(String(err)),
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [port]);
+
+  return state;
+}


### PR DESCRIPTION
## Changes

- **Backend**: New `GET /v1/me/application-authorities` endpoint returns authorities from the authenticated user's watch zones, resolved via the cached authority provider
- **Frontend**: Replaced authority search combobox with a grid of clickable authority cards loaded on mount
- **Navigation**: Added breadcrumb (`Authorities > {name}`) when viewing an authority's applications
- **Empty state**: Shows "Set up a watch zone" prompt with link to `/watch-zones/new` when user has no watch zones
- **Cleanup**: Removed `AuthoritySearchPort` dependency from Applications feature (still used by Search page)

Closes the UX gap where the Applications page offered ~500 authorities but only those with watch zones had data. Now only shows authorities the user is actively monitoring.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Applications page redesigned with a new authority card picker interface for selecting planning application authorities
  * Added breadcrumb navigation allowing users to easily return to the authority list
  * Enhanced user feedback with loading, empty, and error states during authority retrieval

<!-- end of auto-generated comment: release notes by coderabbit.ai -->