### PR TITLE
feat(web): map preview on watch zone confirm step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ node_modules/
 # Superpowers brainstorm sessions
 .superpowers/
 
+# Git worktrees
+.worktrees/
+
 # Beads / Dolt files (added by bd init)
 .beads-credential-key
 .claude/worktrees/autopilot-tc-kkc.1/

--- a/docs/superpowers/plans/2026-04-03-map-confirm-step.md
+++ b/docs/superpowers/plans/2026-04-03-map-confirm-step.md
@@ -1,0 +1,786 @@
+# Map Confirm Step Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace raw lat/long on watch zone confirmation with an interactive Leaflet map showing a pin and radius circle, in both the onboarding and watch zone creation flows.
+
+**Architecture:** Shared `ConfirmMap` component wraps `react-leaflet` (`MapContainer`, `TileLayer`, `Marker`, `Circle`). Both `useOnboarding` and `useCreateWatchZone` hooks gain a `postcode` state field and thread it from `PostcodeInput`. The watch zone creation flow gains a new `confirm` step.
+
+**Tech Stack:** React, TypeScript, react-leaflet (already installed), Leaflet (already installed), CSS Modules with design tokens, Vitest + Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-04-03-map-confirm-step-design.md`
+
+---
+
+### File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `web/src/components/ConfirmMap/ConfirmMap.tsx` | Shared map preview with marker + radius circle |
+| Create | `web/src/components/ConfirmMap/ConfirmMap.module.css` | Map container styling |
+| Create | `web/src/components/ConfirmMap/__tests__/ConfirmMap.test.tsx` | Tests for map rendering |
+| Modify | `web/src/components/PostcodeInput/PostcodeInput.tsx` | Pass postcode string to `onGeocode` callback |
+| Modify | `web/src/features/onboarding/useOnboarding.ts` | Add `postcode` state, update `handleGeocode` signature |
+| Modify | `web/src/features/onboarding/OnboardingPage.tsx` | Use `ConfirmMap` + postcode label on confirm step |
+| Modify | `web/src/features/onboarding/OnboardingPage.module.css` | Add `.mapWrapper` style |
+| Modify | `web/src/features/onboarding/__tests__/OnboardingPage.test.tsx` | Add Leaflet mocks, verify postcode display |
+| Modify | `web/src/features/WatchZones/useCreateWatchZone.ts` | Add `postcode` state, add `confirm` step |
+| Modify | `web/src/features/WatchZones/WatchZoneCreatePage.tsx` | Add confirm step with `ConfirmMap` |
+| Modify | `web/src/features/WatchZones/WatchZoneCreatePage.module.css` | Add `.mapWrapper`, `.confirmRow`, `.confirmLabel`, `.confirmValue` styles |
+| Modify | `web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx` | Add Leaflet mocks, test confirm step in flow |
+
+---
+
+### Task 1: ConfirmMap Component
+
+**Files:**
+- Create: `web/src/components/ConfirmMap/__tests__/ConfirmMap.test.tsx`
+- Create: `web/src/components/ConfirmMap/ConfirmMap.tsx`
+- Create: `web/src/components/ConfirmMap/ConfirmMap.module.css`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `web/src/components/ConfirmMap/__tests__/ConfirmMap.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ConfirmMap } from '../ConfirmMap';
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: () => <div data-testid="map-marker" />,
+  Circle: () => <div data-testid="map-circle" />,
+  useMap: () => ({
+    fitBounds: vi.fn(),
+  }),
+}));
+
+vi.mock('leaflet', () => ({
+  default: {
+    icon: () => ({}),
+    Icon: { Default: { mergeOptions: () => {} } },
+    latLng: (lat: number, lng: number) => ({ lat, lng }),
+    latLngBounds: () => ({
+      pad: () => ({ lat: 0, lng: 0 }),
+    }),
+  },
+  icon: () => ({}),
+  Icon: { Default: { mergeOptions: () => {} } },
+  latLng: (lat: number, lng: number) => ({ lat, lng }),
+  latLngBounds: () => ({
+    pad: () => ({ lat: 0, lng: 0 }),
+  }),
+}));
+
+describe('ConfirmMap', () => {
+  it('renders map container with marker and circle', () => {
+    render(
+      <ConfirmMap latitude={51.5074} longitude={-0.1278} radiusMetres={2000} />,
+    );
+
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    expect(screen.getByTestId('tile-layer')).toBeInTheDocument();
+    expect(screen.getByTestId('map-marker')).toBeInTheDocument();
+    expect(screen.getByTestId('map-circle')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/components/ConfirmMap/__tests__/ConfirmMap.test.tsx`
+Expected: FAIL — cannot resolve `../ConfirmMap`
+
+- [ ] **Step 3: Write the ConfirmMap component**
+
+Create `web/src/components/ConfirmMap/ConfirmMap.module.css`:
+
+```css
+.container {
+  border-radius: var(--tc-radius-md);
+  overflow: hidden;
+  height: 250px;
+  margin-bottom: var(--tc-space-md);
+}
+```
+
+Create `web/src/components/ConfirmMap/ConfirmMap.tsx`:
+
+```tsx
+import { useEffect } from 'react';
+import { MapContainer, TileLayer, Marker, Circle, useMap } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import styles from './ConfirmMap.module.css';
+
+const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const OSM_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+
+const CIRCLE_OPTIONS = {
+  color: 'rgba(74, 108, 247, 0.8)',
+  fillColor: 'rgba(74, 108, 247, 0.15)',
+  fillOpacity: 1,
+  weight: 2,
+};
+
+interface Props {
+  latitude: number;
+  longitude: number;
+  radiusMetres: number;
+}
+
+function FitToCircle({ latitude, longitude, radiusMetres }: Props) {
+  const map = useMap();
+
+  useEffect(() => {
+    const centre = L.latLng(latitude, longitude);
+    const circle = L.circle(centre, { radius: radiusMetres });
+    map.fitBounds(circle.getBounds().pad(0.1));
+  }, [map, latitude, longitude, radiusMetres]);
+
+  return null;
+}
+
+export function ConfirmMap({ latitude, longitude, radiusMetres }: Props) {
+  const centre: [number, number] = [latitude, longitude];
+
+  return (
+    <div className={styles.container}>
+      <MapContainer
+        center={centre}
+        zoom={13}
+        style={{ height: '100%', width: '100%' }}
+        zoomControl={false}
+        attributionControl={true}
+      >
+        <TileLayer url={OSM_TILE_URL} attribution={OSM_ATTRIBUTION} />
+        <Marker position={centre} />
+        <Circle center={centre} radius={radiusMetres} pathOptions={CIRCLE_OPTIONS} />
+        <FitToCircle latitude={latitude} longitude={longitude} radiusMetres={radiusMetres} />
+      </MapContainer>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npx vitest run src/components/ConfirmMap/__tests__/ConfirmMap.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/components/ConfirmMap/
+git commit -m "feat(web): add ConfirmMap component with marker and radius circle"
+```
+
+---
+
+### Task 2: Thread Postcode Through PostcodeInput Callback
+
+**Files:**
+- Modify: `web/src/components/PostcodeInput/PostcodeInput.tsx:9,16-19`
+- Modify: `web/src/components/PostcodeInput/__tests__/PostcodeInput.test.tsx`
+
+- [ ] **Step 1: Update PostcodeInput test to verify postcode is passed**
+
+In `web/src/components/PostcodeInput/__tests__/PostcodeInput.test.tsx`, find the test that verifies the `onGeocode` callback is called. Update the assertion to check the second argument is the postcode string. In the test for successful geocode:
+
+```tsx
+// Existing assertion (update):
+expect(onGeocode).toHaveBeenCalledWith(geocodingSpy.geocodeResult, 'SW1A 1AA');
+```
+
+The `onGeocode` spy is `vi.fn()`. After the user types `'SW1A 1AA'` and clicks "Look up", the callback should now receive both the geocode result and the postcode string.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/components/PostcodeInput/__tests__/PostcodeInput.test.tsx`
+Expected: FAIL — `onGeocode` called with only one argument
+
+- [ ] **Step 3: Update PostcodeInput to pass postcode**
+
+In `web/src/components/PostcodeInput/PostcodeInput.tsx`:
+
+Change the `Props` interface:
+```tsx
+interface Props {
+  geocodingPort: GeocodingPort;
+  onGeocode: (result: GeocodeResult, postcode: string) => void;
+}
+```
+
+Change `handleLookup`:
+```tsx
+async function handleLookup() {
+  const result = await lookup();
+  if (result) {
+    onGeocode(result, postcode);
+  }
+}
+```
+
+Note: `postcode` is already destructured from `usePostcodeGeocode` on line 12.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npx vitest run src/components/PostcodeInput/__tests__/PostcodeInput.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite to check for breakage**
+
+Run: `cd web && npx vitest run`
+Expected: Some tests may fail if existing `onGeocode` handlers don't accept the second argument — this is expected and will be fixed in Tasks 3 and 4.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/components/PostcodeInput/PostcodeInput.tsx web/src/components/PostcodeInput/__tests__/PostcodeInput.test.tsx
+git commit -m "feat(web): pass postcode string through PostcodeInput onGeocode callback"
+```
+
+---
+
+### Task 3: Update Onboarding Flow
+
+**Files:**
+- Modify: `web/src/features/onboarding/useOnboarding.ts`
+- Modify: `web/src/features/onboarding/OnboardingPage.tsx`
+- Modify: `web/src/features/onboarding/__tests__/OnboardingPage.test.tsx`
+
+- [ ] **Step 1: Update onboarding test to verify postcode display**
+
+In `web/src/features/onboarding/__tests__/OnboardingPage.test.tsx`, add the Leaflet mocks at the top of the file (after imports, before `describe`):
+
+```tsx
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: () => <div data-testid="map-marker" />,
+  Circle: () => <div data-testid="map-circle" />,
+  useMap: () => ({
+    fitBounds: vi.fn(),
+  }),
+}));
+
+vi.mock('leaflet', () => ({
+  default: {
+    icon: () => ({}),
+    Icon: { Default: { mergeOptions: () => {} } },
+    latLng: (lat: number, lng: number) => ({ lat, lng }),
+    circle: () => ({ getBounds: () => ({ pad: () => ({}) }) }),
+  },
+  icon: () => ({}),
+  Icon: { Default: { mergeOptions: () => {} } },
+  latLng: (lat: number, lng: number) => ({ lat, lng }),
+  circle: () => ({ getBounds: () => ({ pad: () => ({}) }) }),
+}));
+```
+
+Add `vi` to the imports (if not already imported).
+
+Add a new test case:
+
+```tsx
+it('shows postcode and map on confirm step', async () => {
+  const user = userEvent.setup();
+  const geocodingSpy = new SpyGeocodingPort();
+  renderOnboarding(new SpyOnboardingPort(), geocodingSpy);
+
+  await user.click(screen.getByRole('button', { name: /get started/i }));
+  await user.type(screen.getByLabelText(/postcode/i), 'SW1A 1AA');
+  await user.click(screen.getByRole('button', { name: /look up/i }));
+
+  await waitFor(() => {
+    expect(screen.getByRole('radiogroup', { name: /radius/i })).toBeInTheDocument();
+  });
+
+  await user.click(screen.getByLabelText('2 km'));
+  await user.click(screen.getByRole('button', { name: /next/i }));
+
+  expect(screen.getByTestId('map-container')).toBeInTheDocument();
+  expect(screen.getByText('SW1A 1AA')).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run tests to verify the new test fails**
+
+Run: `cd web && npx vitest run src/features/onboarding/__tests__/OnboardingPage.test.tsx`
+Expected: FAIL — no `map-container` or `SW1A 1AA` text on confirm step
+
+- [ ] **Step 3: Update useOnboarding hook**
+
+In `web/src/features/onboarding/useOnboarding.ts`:
+
+Add `postcode` state:
+```tsx
+const [postcode, setPostcode] = useState('');
+```
+
+Update `handleGeocode` to accept and store postcode:
+```tsx
+const handleGeocode = useCallback((result: GeocodeResult, enteredPostcode: string) => {
+  setGeocode(result);
+  setPostcode(enteredPostcode);
+  setStep('radius');
+}, []);
+```
+
+Add `postcode` to the return object:
+```tsx
+return {
+  step,
+  geocode,
+  postcode,
+  radiusMetres,
+  // ... rest unchanged
+};
+```
+
+- [ ] **Step 4: Update OnboardingPage confirm step**
+
+In `web/src/features/onboarding/OnboardingPage.tsx`:
+
+Add `ConfirmMap` import:
+```tsx
+import { ConfirmMap } from '../../components/ConfirmMap/ConfirmMap';
+```
+
+Add `postcode` to the destructured hook values:
+```tsx
+const {
+  step,
+  geocode,
+  postcode,
+  radiusMetres,
+  // ... rest unchanged
+} = useOnboarding(onboardingPort);
+```
+
+Replace the confirm step JSX (lines 79–110) with:
+```tsx
+{step === 'confirm' && (
+  <>
+    <h2 className={styles.stepLabel}>Confirm your watch zone</h2>
+    {geocode && (
+      <ConfirmMap
+        latitude={geocode.latitude}
+        longitude={geocode.longitude}
+        radiusMetres={radiusMetres}
+      />
+    )}
+    <div className={styles.confirmDetails}>
+      <div className={styles.confirmRow}>
+        <span className={styles.confirmLabel}>Postcode</span>
+        <span className={styles.confirmValue}>{postcode}</span>
+      </div>
+      <div className={styles.confirmRow}>
+        <span className={styles.confirmLabel}>Radius</span>
+        <span className={styles.confirmValue}>
+          {radiusMetres >= 1000 ? `${radiusMetres / 1000} km` : `${radiusMetres} m`}
+        </span>
+      </div>
+    </div>
+    <button
+      type="button"
+      className={styles.primaryButton}
+      onClick={finish}
+      disabled={isSubmitting}
+    >
+      {isSubmitting ? 'Setting up...' : 'Confirm'}
+    </button>
+    {error && (
+      <p className={styles.error} role="alert">
+        {error}
+      </p>
+    )}
+  </>
+)}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd web && npx vitest run src/features/onboarding/__tests__/OnboardingPage.test.tsx`
+Expected: PASS (all tests including the new one)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/features/onboarding/ web/src/features/onboarding/__tests__/
+git commit -m "feat(web): replace lat/long with map preview on onboarding confirm step"
+```
+
+---
+
+### Task 4: Add Confirm Step to Watch Zone Creation
+
+**Files:**
+- Modify: `web/src/features/WatchZones/useCreateWatchZone.ts`
+- Modify: `web/src/features/WatchZones/WatchZoneCreatePage.tsx`
+- Modify: `web/src/features/WatchZones/WatchZoneCreatePage.module.css`
+- Modify: `web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx`
+
+- [ ] **Step 1: Update WatchZoneCreatePage test for new confirm step**
+
+In `web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx`, add the Leaflet mocks at the top (after imports, before `describe`):
+
+```tsx
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: () => <div data-testid="map-marker" />,
+  Circle: () => <div data-testid="map-circle" />,
+  useMap: () => ({
+    fitBounds: vi.fn(),
+  }),
+}));
+
+vi.mock('leaflet', () => ({
+  default: {
+    icon: () => ({}),
+    Icon: { Default: { mergeOptions: () => {} } },
+    latLng: (lat: number, lng: number) => ({ lat, lng }),
+    circle: () => ({ getBounds: () => ({ pad: () => ({}) }) }),
+  },
+  icon: () => ({}),
+  Icon: { Default: { mergeOptions: () => {} } },
+  latLng: (lat: number, lng: number) => ({ lat, lng }),
+  circle: () => ({ getBounds: () => ({ pad: () => ({}) }) }),
+}));
+```
+
+Add `vi` to the vitest imports if not already present.
+
+Update the "saves zone with form data" test — change the "Save" click to "Next", then add a confirm click:
+
+```tsx
+it('saves zone with form data', async () => {
+  const user = userEvent.setup();
+  repoSpy.createResult = aWatchZone();
+
+  renderWithRouter(
+    <WatchZoneCreatePage
+      repository={repoSpy}
+      geocodingPort={geocodingSpy}
+      navigate={navigate}
+    />,
+  );
+
+  // Step 1: Look up postcode
+  await user.type(screen.getByRole('textbox', { name: /postcode/i }), 'CB1 2AD');
+  await user.click(screen.getByRole('button', { name: /look up/i }));
+
+  // Step 2: Fill in details
+  const nameInput = await screen.findByLabelText(/zone name/i);
+  await user.type(nameInput, 'Home');
+  await user.click(screen.getByLabelText('5 km'));
+
+  // Advance to confirm step
+  await user.click(screen.getByRole('button', { name: /next/i }));
+
+  // Step 3: Confirm — should see map and postcode
+  expect(screen.getByTestId('map-container')).toBeInTheDocument();
+  expect(screen.getByText('CB1 2AD')).toBeInTheDocument();
+
+  // Confirm
+  await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+  expect(repoSpy.createCalls).toHaveLength(1);
+  expect(repoSpy.createCalls[0]?.name).toBe('Home');
+  expect(repoSpy.createCalls[0]?.radiusMetres).toBe(5000);
+  expect(navigatedTo).toBe('/watch-zones');
+});
+```
+
+Update the "shows error when save fails" test similarly — advance through the confirm step:
+
+```tsx
+it('shows error when save fails', async () => {
+  const user = userEvent.setup();
+  repoSpy.createError = new Error('Create failed');
+
+  renderWithRouter(
+    <WatchZoneCreatePage
+      repository={repoSpy}
+      geocodingPort={geocodingSpy}
+      navigate={navigate}
+    />,
+  );
+
+  await user.type(screen.getByRole('textbox', { name: /postcode/i }), 'CB1 2AD');
+  await user.click(screen.getByRole('button', { name: /look up/i }));
+
+  const nameInput = await screen.findByLabelText(/zone name/i);
+  await user.type(nameInput, 'Home');
+
+  await user.click(screen.getByRole('button', { name: /next/i }));
+  await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+  expect(await screen.findByText('Create failed')).toBeInTheDocument();
+  expect(navigatedTo).toBeNull();
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && npx vitest run src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx`
+Expected: FAIL — no "Next" button (currently "Save"), no confirm step
+
+- [ ] **Step 3: Update useCreateWatchZone hook**
+
+In `web/src/features/WatchZones/useCreateWatchZone.ts`:
+
+Change the step type:
+```tsx
+type CreateStep = 'postcode' | 'details' | 'confirm';
+```
+
+Add `postcode` to state interface:
+```tsx
+interface CreateWatchZoneState {
+  step: CreateStep;
+  name: string;
+  postcode: string;
+  coordinates: GeocodeResult | null;
+  radiusMetres: number;
+  authorityId: AuthorityId | null;
+  isSaving: boolean;
+  error: string | null;
+}
+```
+
+Add `postcode: ''` to the initial state object.
+
+Update `setGeocode` to accept and store the postcode:
+```tsx
+const setGeocode = useCallback((result: GeocodeResult, enteredPostcode: string) => {
+  setState(prev => ({
+    ...prev,
+    coordinates: result,
+    postcode: enteredPostcode,
+    step: 'details',
+    error: null,
+  }));
+}, []);
+```
+
+Add a `confirmDetails` callback:
+```tsx
+const confirmDetails = useCallback(() => {
+  if (!state.name.trim()) {
+    setState(prev => ({ ...prev, error: 'Please enter a name for this watch zone' }));
+    return;
+  }
+  setState(prev => ({ ...prev, step: 'confirm', error: null }));
+}, [state.name]);
+```
+
+Remove the name validation from `save` (it's now in `confirmDetails`):
+```tsx
+const save = useCallback(async () => {
+  if (!state.coordinates) {
+    setState(prev => ({ ...prev, error: 'Please look up a postcode first' }));
+    return;
+  }
+
+  setState(prev => ({ ...prev, isSaving: true, error: null }));
+  try {
+    await repository.create({
+      name: state.name.trim(),
+      latitude: state.coordinates.latitude,
+      longitude: state.coordinates.longitude,
+      radiusMetres: state.radiusMetres,
+      authorityId: state.authorityId ?? undefined,
+    });
+    navigate('/watch-zones');
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'An error occurred';
+    setState(prev => ({ ...prev, isSaving: false, error: message }));
+  }
+}, [state.coordinates, state.name, state.radiusMetres, state.authorityId, repository, navigate]);
+```
+
+Add `postcode` and `confirmDetails` to the return object:
+```tsx
+return {
+  step: state.step,
+  name: state.name,
+  postcode: state.postcode,
+  coordinates: state.coordinates,
+  radiusMetres: state.radiusMetres,
+  isSaving: state.isSaving,
+  error: state.error,
+  setGeocode,
+  setName,
+  setRadiusMetres,
+  setAuthorityId,
+  confirmDetails,
+  save,
+};
+```
+
+- [ ] **Step 4: Update WatchZoneCreatePage with confirm step**
+
+In `web/src/features/WatchZones/WatchZoneCreatePage.tsx`:
+
+Add `ConfirmMap` import:
+```tsx
+import { ConfirmMap } from '../../components/ConfirmMap/ConfirmMap';
+```
+
+Add `postcode`, `confirmDetails`, and `isSaving` to destructured hook values:
+```tsx
+const {
+  step,
+  name,
+  postcode,
+  coordinates,
+  radiusMetres,
+  isSaving,
+  error,
+  setGeocode,
+  setName,
+  setRadiusMetres,
+  confirmDetails,
+  save,
+} = useCreateWatchZone(repository, navigate);
+```
+
+In the details step, change the Save button to Next and call `confirmDetails`:
+```tsx
+<div className={styles.actions}>
+  <button
+    type="button"
+    className={styles.saveButton}
+    onClick={confirmDetails}
+  >
+    Next
+  </button>
+</div>
+```
+
+Add the new confirm step after the details step:
+```tsx
+{step === 'confirm' && (
+  <section className={styles.section}>
+    {coordinates && (
+      <ConfirmMap
+        latitude={coordinates.latitude}
+        longitude={coordinates.longitude}
+        radiusMetres={radiusMetres}
+      />
+    )}
+    <div className={styles.confirmDetails}>
+      <div className={styles.confirmRow}>
+        <span className={styles.confirmLabel}>Postcode</span>
+        <span className={styles.confirmValue}>{postcode}</span>
+      </div>
+      <div className={styles.confirmRow}>
+        <span className={styles.confirmLabel}>Name</span>
+        <span className={styles.confirmValue}>{name}</span>
+      </div>
+      <div className={styles.confirmRow}>
+        <span className={styles.confirmLabel}>Radius</span>
+        <span className={styles.confirmValue}>
+          {radiusMetres >= 1000 ? `${radiusMetres / 1000} km` : `${radiusMetres} m`}
+        </span>
+      </div>
+    </div>
+    {error && (
+      <p className={styles.error} role="alert">
+        {error}
+      </p>
+    )}
+    <div className={styles.actions}>
+      <button
+        type="button"
+        className={styles.saveButton}
+        onClick={save}
+        disabled={isSaving}
+      >
+        {isSaving ? 'Saving...' : 'Confirm'}
+      </button>
+    </div>
+  </section>
+)}
+```
+
+- [ ] **Step 5: Add confirm styles to WatchZoneCreatePage CSS**
+
+In `web/src/features/WatchZones/WatchZoneCreatePage.module.css`, add at the end:
+
+```css
+.confirmDetails {
+  background: var(--tc-surface-elevated);
+  border-radius: var(--tc-radius-sm);
+  padding: var(--tc-space-md);
+  margin-bottom: var(--tc-space-lg);
+}
+
+.confirmRow {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--tc-space-xs) 0;
+}
+
+.confirmLabel {
+  font-size: var(--tc-text-body);
+  color: var(--tc-text-secondary);
+}
+
+.confirmValue {
+  font-size: var(--tc-text-body);
+  font-weight: var(--tc-font-semibold);
+  color: var(--tc-text-primary);
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd web && npx vitest run src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/features/WatchZones/
+git commit -m "feat(web): add map confirm step to watch zone creation flow"
+```
+
+---
+
+### Task 5: Full Test Suite + Type Check
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run type checker**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd web && npx vitest run`
+Expected: All tests pass
+
+- [ ] **Step 3: Run dev server smoke test**
+
+Run: `cd web && npx vite build`
+Expected: Build succeeds with no errors
+
+- [ ] **Step 4: Commit any remaining fixes**
+
+If type check or tests revealed issues, fix and commit:
+```bash
+git add -A && git commit -m "fix(web): resolve type/test issues from map confirm step"
+```

--- a/docs/superpowers/specs/2026-04-03-map-confirm-step-design.md
+++ b/docs/superpowers/specs/2026-04-03-map-confirm-step-design.md
@@ -1,0 +1,98 @@
+# Map Preview on Watch Zone Confirmation
+
+Date: 2026-04-03
+
+## Problem
+
+When creating a watch zone (during onboarding or from the watch zones tab), the confirm step shows raw latitude/longitude decimals (e.g. `51.5007, -0.1246`). This is meaningless to users — they can't verify whether the geocode landed in the right place or visualise their coverage area.
+
+The watch zone creation flow has no confirmation step at all — it saves immediately after the user enters a name and radius.
+
+## Solution
+
+Replace coordinate text with an interactive Leaflet map showing a marker at the geocoded location and a translucent circle representing the selected radius. Display the user's entered postcode as a human-readable label. Apply this to both the onboarding and watch zone creation flows.
+
+## Components
+
+### `ConfirmMap` (new shared component)
+
+**Location:** `web/src/components/ConfirmMap/ConfirmMap.tsx`
+
+**Props:**
+- `latitude: number`
+- `longitude: number`
+- `radiusMetres: number`
+
+**Behaviour:**
+- Renders a `MapContainer` with `TileLayer` (OSM tiles, same URL as `MapPage`)
+- Places a `Marker` at the geocoded coordinates
+- Draws a `Circle` overlay with the given radius
+- Auto-fits zoom to contain the full circle with padding (using Leaflet `fitBounds` on the circle's bounding box)
+- Pan/zoom enabled, but marker is not draggable and circle is not resizable
+- Fixed height (~250px), fills card width
+
+**Circle styling:**
+- Fill: `rgba(74, 108, 247, 0.15)` (semi-transparent primary blue)
+- Stroke: `rgba(74, 108, 247, 0.8)`, weight 2
+
+### `PostcodeInput` callback change
+
+The `onGeocode` callback signature changes to include the postcode string:
+
+```typescript
+// Before
+onGeocode: (result: GeocodeResult) => void
+
+// After
+onGeocode: (result: GeocodeResult, postcode: string) => void
+```
+
+The `PostcodeInput` component already has the postcode value in local state — it just needs to pass it through.
+
+### Onboarding flow changes
+
+**`useOnboarding` hook:**
+- Add `postcode: string` state, set when `handleGeocode` fires
+- Expose `postcode` in the return value
+
+**`OnboardingPage` confirm step:**
+- Replace the coordinate row with `<ConfirmMap>` component
+- Show postcode below the map (e.g. "SW1A 1AA")
+- Keep radius text row as-is
+- Confirm button unchanged
+
+**Updated flow:** `welcome → postcode → radius → confirm (with map + postcode label) → done`
+
+### Watch zone creation flow changes
+
+**`useCreateWatchZone` hook:**
+- Add `postcode: string` state, set when `setGeocode` fires
+- Change step type from `'postcode' | 'details'` to `'postcode' | 'details' | 'confirm'`
+- Add `confirmDetails` callback that transitions from `details` to `confirm`
+- Expose `postcode` in the return value
+
+**`WatchZoneCreatePage` confirm step:**
+- Details step: "Save" button becomes "Next", calls `confirmDetails`
+- New confirm step shows:
+  - `<ConfirmMap>` component
+  - Postcode label
+  - Zone name
+  - Radius text
+  - "Confirm" button that calls `save()`
+
+**Updated flow:** `postcode → details (name + radius) → confirm (with map) → save`
+
+## What stays the same
+
+- All existing onboarding steps (welcome, postcode, radius)
+- The `finish()` / `save()` API calls
+- No new npm dependencies — `react-leaflet` and `leaflet` are already installed
+- No backend changes
+- `MapPage` is unaffected
+
+## Testing
+
+- `ConfirmMap` — renders without crashing with valid props
+- `OnboardingPage` — verify postcode is displayed (not coordinates) on confirm step
+- `WatchZoneCreatePage` — verify new confirm step appears with map before save
+- `useCreateWatchZone` — verify `details → confirm` step transition

--- a/web/src/components/ConfirmMap/ConfirmMap.module.css
+++ b/web/src/components/ConfirmMap/ConfirmMap.module.css
@@ -1,0 +1,6 @@
+.container {
+  border-radius: var(--tc-radius-md);
+  overflow: hidden;
+  height: 250px;
+  margin-bottom: var(--tc-space-md);
+}

--- a/web/src/components/ConfirmMap/ConfirmMap.tsx
+++ b/web/src/components/ConfirmMap/ConfirmMap.tsx
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+import { MapContainer, TileLayer, Marker, Circle, useMap } from 'react-leaflet';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import styles from './ConfirmMap.module.css';
+
+const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const OSM_ATTRIBUTION =
+  '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+
+// Leaflet SVG layers accept raw colour values, not CSS custom properties.
+// These match the app's interactive-blue palette for the radius overlay.
+const CIRCLE_OPTIONS = {
+  color: 'rgba(74, 108, 247, 0.8)',
+  fillColor: 'rgba(74, 108, 247, 0.15)',
+  fillOpacity: 1,
+  weight: 2,
+};
+
+interface Props {
+  latitude: number;
+  longitude: number;
+  radiusMetres: number;
+}
+
+function FitToCircle({ latitude, longitude, radiusMetres }: Props) {
+  const map = useMap();
+
+  useEffect(() => {
+    const bounds = L.latLng(latitude, longitude).toBounds(radiusMetres * 2);
+    map.fitBounds(bounds.pad(0.1));
+  }, [map, latitude, longitude, radiusMetres]);
+
+  return null;
+}
+
+export function ConfirmMap({ latitude, longitude, radiusMetres }: Props) {
+  const centre: [number, number] = [latitude, longitude];
+
+  return (
+    <div className={styles.container}>
+      <MapContainer
+        center={centre}
+        zoom={13}
+        style={{ height: '100%', width: '100%' }}
+        zoomControl={false}
+        attributionControl={true}
+      >
+        <TileLayer url={OSM_TILE_URL} attribution={OSM_ATTRIBUTION} />
+        <Marker position={centre} />
+        <Circle center={centre} radius={radiusMetres} pathOptions={CIRCLE_OPTIONS} />
+        <FitToCircle latitude={latitude} longitude={longitude} radiusMetres={radiusMetres} />
+      </MapContainer>
+    </div>
+  );
+}

--- a/web/src/components/ConfirmMap/__tests__/ConfirmMap.test.tsx
+++ b/web/src/components/ConfirmMap/__tests__/ConfirmMap.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ConfirmMap } from '../ConfirmMap';
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: () => <div data-testid="map-marker" />,
+  Circle: () => <div data-testid="map-circle" />,
+  useMap: () => ({
+    fitBounds: vi.fn(),
+  }),
+}));
+
+const fakeBounds = { pad: () => fakeBounds };
+
+vi.mock('leaflet', () => ({
+  default: {
+    icon: () => ({}),
+    Icon: { Default: { mergeOptions: () => {} } },
+    latLng: () => ({ toBounds: () => fakeBounds }),
+  },
+  icon: () => ({}),
+  Icon: { Default: { mergeOptions: () => {} } },
+  latLng: () => ({ toBounds: () => fakeBounds }),
+}));
+
+describe('ConfirmMap', () => {
+  it('renders map container with marker and circle', () => {
+    render(
+      <ConfirmMap latitude={51.5074} longitude={-0.1278} radiusMetres={2000} />,
+    );
+
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    expect(screen.getByTestId('tile-layer')).toBeInTheDocument();
+    expect(screen.getByTestId('map-marker')).toBeInTheDocument();
+    expect(screen.getByTestId('map-circle')).toBeInTheDocument();
+  });
+});

--- a/web/src/components/PostcodeInput/PostcodeInput.tsx
+++ b/web/src/components/PostcodeInput/PostcodeInput.tsx
@@ -5,7 +5,7 @@ import styles from './PostcodeInput.module.css';
 
 interface Props {
   geocodingPort: GeocodingPort;
-  onGeocode: (result: GeocodeResult) => void;
+  onGeocode: (result: GeocodeResult, postcode: string) => void;
 }
 
 export function PostcodeInput({ geocodingPort, onGeocode }: Props) {
@@ -15,7 +15,7 @@ export function PostcodeInput({ geocodingPort, onGeocode }: Props) {
   async function handleLookup() {
     const result = await lookup();
     if (result) {
-      onGeocode(result);
+      onGeocode(result, postcode);
     }
   }
 

--- a/web/src/components/PostcodeInput/__tests__/PostcodeInput.test.tsx
+++ b/web/src/components/PostcodeInput/__tests__/PostcodeInput.test.tsx
@@ -26,7 +26,7 @@ describe('PostcodeInput', () => {
     await user.click(screen.getByRole('button', { name: /look up/i }));
 
     await waitFor(() => {
-      expect(handleGeocode).toHaveBeenCalledWith({ latitude: 51.5074, longitude: -0.1278 });
+      expect(handleGeocode).toHaveBeenCalledWith({ latitude: 51.5074, longitude: -0.1278 }, 'SW1A 1AA');
     });
   });
 

--- a/web/src/features/WatchZones/WatchZoneCreatePage.module.css
+++ b/web/src/features/WatchZones/WatchZoneCreatePage.module.css
@@ -101,3 +101,27 @@
   opacity: 0.4;
   cursor: default;
 }
+
+.confirmDetails {
+  background: var(--tc-surface-elevated);
+  border-radius: var(--tc-radius-sm);
+  padding: var(--tc-space-md);
+  margin-bottom: var(--tc-space-lg);
+}
+
+.confirmRow {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--tc-space-xs) 0;
+}
+
+.confirmLabel {
+  font-size: var(--tc-text-body);
+  color: var(--tc-text-secondary);
+}
+
+.confirmValue {
+  font-size: var(--tc-text-body);
+  font-weight: var(--tc-font-semibold);
+  color: var(--tc-text-primary);
+}

--- a/web/src/features/WatchZones/WatchZoneCreatePage.tsx
+++ b/web/src/features/WatchZones/WatchZoneCreatePage.tsx
@@ -4,6 +4,7 @@ import type { GeocodingPort } from '../../domain/ports/geocoding-port';
 import { useCreateWatchZone } from './useCreateWatchZone';
 import { PostcodeInput } from '../../components/PostcodeInput/PostcodeInput';
 import { RadiusPicker } from '../../components/RadiusPicker/RadiusPicker';
+import { ConfirmMap } from '../../components/ConfirmMap/ConfirmMap';
 import styles from './WatchZoneCreatePage.module.css';
 
 interface Props {
@@ -16,12 +17,15 @@ export function WatchZoneCreatePage({ repository, geocodingPort, navigate }: Pro
   const {
     step,
     name,
+    postcode,
+    coordinates,
     radiusMetres,
     isSaving,
     error,
     setGeocode,
     setName,
     setRadiusMetres,
+    confirmDetails,
     save,
   } = useCreateWatchZone(repository, navigate);
 
@@ -71,10 +75,52 @@ export function WatchZoneCreatePage({ repository, geocodingPort, navigate }: Pro
             <button
               type="button"
               className={styles.saveButton}
+              onClick={confirmDetails}
+            >
+              Next
+            </button>
+          </div>
+        </section>
+      )}
+
+      {step === 'confirm' && (
+        <section className={styles.section}>
+          {coordinates && (
+            <ConfirmMap
+              latitude={coordinates.latitude}
+              longitude={coordinates.longitude}
+              radiusMetres={radiusMetres}
+            />
+          )}
+          <div className={styles.confirmDetails}>
+            <div className={styles.confirmRow}>
+              <span className={styles.confirmLabel}>Postcode</span>
+              <span className={styles.confirmValue}>{postcode}</span>
+            </div>
+            <div className={styles.confirmRow}>
+              <span className={styles.confirmLabel}>Name</span>
+              <span className={styles.confirmValue}>{name}</span>
+            </div>
+            <div className={styles.confirmRow}>
+              <span className={styles.confirmLabel}>Radius</span>
+              <span className={styles.confirmValue}>
+                {radiusMetres >= 1000 ? `${radiusMetres / 1000} km` : `${radiusMetres} m`}
+              </span>
+            </div>
+          </div>
+          {error && (
+            <p className={styles.error} role="alert">
+              {error}
+            </p>
+          )}
+          <div className={styles.actions}>
+            <button
+              type="button"
+              className={styles.saveButton}
               onClick={save}
               disabled={isSaving}
             >
-              {isSaving ? 'Saving...' : 'Save'}
+              {isSaving ? 'Saving...' : 'Confirm'}
             </button>
           </div>
         </section>

--- a/web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx
+++ b/web/src/features/WatchZones/__tests__/WatchZoneCreatePage.test.tsx
@@ -1,11 +1,35 @@
+import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { WatchZoneCreatePage } from '../WatchZoneCreatePage';
 import { SpyWatchZoneRepository } from './spies/spy-watch-zone-repository';
 import { aWatchZone } from './fixtures/watch-zone.fixtures';
 import type { GeocodingPort } from '../../../domain/ports/geocoding-port';
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: () => <div data-testid="map-marker" />,
+  Circle: () => <div data-testid="map-circle" />,
+  useMap: () => ({
+    fitBounds: vi.fn(),
+  }),
+}));
+
+vi.mock('leaflet', () => ({
+  default: {
+    icon: () => ({}),
+    Icon: { Default: { mergeOptions: () => {} } },
+    latLng: () => ({ toBounds: () => ({ pad: () => ({}) }) }),
+  },
+  icon: () => ({}),
+  Icon: { Default: { mergeOptions: () => {} } },
+  latLng: () => ({ toBounds: () => ({ pad: () => ({}) }) }),
+}));
 
 class SpyGeocodingPort implements GeocodingPort {
   geocodeCalls: string[] = [];
@@ -92,12 +116,17 @@ describe('WatchZoneCreatePage', () => {
     // Step 2: Fill in details
     const nameInput = await screen.findByLabelText(/zone name/i);
     await user.type(nameInput, 'Home');
-
-    // Select 5km radius
     await user.click(screen.getByLabelText('5 km'));
 
-    // Save
-    await user.click(screen.getByRole('button', { name: /save/i }));
+    // Advance to confirm step
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    // Step 3: Confirm — should see map and postcode
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    expect(screen.getByText('CB1 2AD')).toBeInTheDocument();
+
+    // Confirm
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
 
     expect(repoSpy.createCalls).toHaveLength(1);
     expect(repoSpy.createCalls[0]?.name).toBe('Home');
@@ -123,7 +152,8 @@ describe('WatchZoneCreatePage', () => {
     const nameInput = await screen.findByLabelText(/zone name/i);
     await user.type(nameInput, 'Home');
 
-    await user.click(screen.getByRole('button', { name: /save/i }));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
 
     expect(await screen.findByText('Create failed')).toBeInTheDocument();
     expect(navigatedTo).toBeNull();

--- a/web/src/features/WatchZones/__tests__/useCreateWatchZone.test.ts
+++ b/web/src/features/WatchZones/__tests__/useCreateWatchZone.test.ts
@@ -33,18 +33,19 @@ describe('useCreateWatchZone', () => {
     const { result } = renderHook(() => useCreateWatchZone(spy, navigate));
 
     act(() => {
-      result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 });
+      result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 }, 'CB1 2AD');
     });
 
     expect(result.current.step).toBe('details');
     expect(result.current.coordinates).toEqual({ latitude: 52.2053, longitude: 0.1218 });
+    expect(result.current.postcode).toBe('CB1 2AD');
   });
 
   it('allows setting name and radius', () => {
     const { result } = renderHook(() => useCreateWatchZone(spy, navigate));
 
     act(() => {
-      result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 });
+      result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 }, 'CB1 2AD');
     });
 
     act(() => {
@@ -62,7 +63,7 @@ describe('useCreateWatchZone', () => {
     const { result } = renderHook(() => useCreateWatchZone(spy, navigate));
 
     act(() => {
-      result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 });
+      result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 }, 'CB1 2AD');
     });
 
     act(() => {
@@ -91,7 +92,7 @@ describe('useCreateWatchZone', () => {
     const { result } = renderHook(() => useCreateWatchZone(spy, navigate));
 
     act(() => {
-      result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 });
+      result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 }, 'CB1 2AD');
       result.current.setName('Home');
       result.current.setAuthorityId(asAuthorityId(1));
     });
@@ -119,19 +120,18 @@ describe('useCreateWatchZone', () => {
     expect(result.current.error).toBe('Please look up a postcode first');
   });
 
-  it('does not save without a name', async () => {
+  it('does not advance to confirm without a name', () => {
     const { result } = renderHook(() => useCreateWatchZone(spy, navigate));
 
     act(() => {
-      result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 });
-      result.current.setAuthorityId(asAuthorityId(1));
+      result.current.setGeocode({ latitude: 52.2053, longitude: 0.1218 }, 'CB1 2AD');
     });
 
-    await act(async () => {
-      await result.current.save();
+    act(() => {
+      result.current.confirmDetails();
     });
 
-    expect(spy.createCalls).toHaveLength(0);
+    expect(result.current.step).toBe('details');
     expect(result.current.error).toBe('Please enter a name for this watch zone');
   });
 });

--- a/web/src/features/WatchZones/useCreateWatchZone.ts
+++ b/web/src/features/WatchZones/useCreateWatchZone.ts
@@ -2,11 +2,12 @@ import { useState, useCallback } from 'react';
 import type { GeocodeResult, AuthorityId } from '../../domain/types';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
 
-type CreateStep = 'postcode' | 'details';
+type CreateStep = 'postcode' | 'details' | 'confirm';
 
 interface CreateWatchZoneState {
   step: CreateStep;
   name: string;
+  postcode: string;
   coordinates: GeocodeResult | null;
   radiusMetres: number;
   authorityId: AuthorityId | null;
@@ -21,6 +22,7 @@ export function useCreateWatchZone(
   const [state, setState] = useState<CreateWatchZoneState>({
     step: 'postcode',
     name: '',
+    postcode: '',
     coordinates: null,
     radiusMetres: 2000,
     authorityId: null,
@@ -28,10 +30,11 @@ export function useCreateWatchZone(
     error: null,
   });
 
-  const setGeocode = useCallback((result: GeocodeResult) => {
+  const setGeocode = useCallback((result: GeocodeResult, enteredPostcode: string) => {
     setState(prev => ({
       ...prev,
       coordinates: result,
+      postcode: enteredPostcode,
       step: 'details',
       error: null,
     }));
@@ -49,13 +52,17 @@ export function useCreateWatchZone(
     setState(prev => ({ ...prev, authorityId }));
   }, []);
 
+  const confirmDetails = useCallback(() => {
+    if (!state.name.trim()) {
+      setState(prev => ({ ...prev, error: 'Please enter a name for this watch zone' }));
+      return;
+    }
+    setState(prev => ({ ...prev, step: 'confirm', error: null }));
+  }, [state.name]);
+
   const save = useCallback(async () => {
     if (!state.coordinates) {
       setState(prev => ({ ...prev, error: 'Please look up a postcode first' }));
-      return;
-    }
-    if (!state.name.trim()) {
-      setState(prev => ({ ...prev, error: 'Please enter a name for this watch zone' }));
       return;
     }
 
@@ -78,6 +85,7 @@ export function useCreateWatchZone(
   return {
     step: state.step,
     name: state.name,
+    postcode: state.postcode,
     coordinates: state.coordinates,
     radiusMetres: state.radiusMetres,
     isSaving: state.isSaving,
@@ -86,6 +94,7 @@ export function useCreateWatchZone(
     setName,
     setRadiusMetres,
     setAuthorityId,
+    confirmDetails,
     save,
   };
 }

--- a/web/src/features/onboarding/OnboardingPage.tsx
+++ b/web/src/features/onboarding/OnboardingPage.tsx
@@ -1,6 +1,7 @@
 import { Navigate } from 'react-router-dom';
 import type { OnboardingPort } from '../../domain/ports/onboarding-port';
 import type { GeocodingPort } from '../../domain/ports/geocoding-port';
+import { ConfirmMap } from '../../components/ConfirmMap/ConfirmMap';
 import { PostcodeInput } from '../../components/PostcodeInput/PostcodeInput';
 import { RadiusPicker } from '../../components/RadiusPicker/RadiusPicker';
 import { useOnboarding } from './useOnboarding';
@@ -15,6 +16,7 @@ export function OnboardingPage({ onboardingPort, geocodingPort }: Props) {
   const {
     step,
     geocode,
+    postcode,
     radiusMetres,
     isSubmitting,
     error,
@@ -79,12 +81,17 @@ export function OnboardingPage({ onboardingPort, geocodingPort }: Props) {
         {step === 'confirm' && (
           <>
             <h2 className={styles.stepLabel}>Confirm your watch zone</h2>
+            {geocode && (
+              <ConfirmMap
+                latitude={geocode.latitude}
+                longitude={geocode.longitude}
+                radiusMetres={radiusMetres}
+              />
+            )}
             <div className={styles.confirmDetails}>
               <div className={styles.confirmRow}>
-                <span className={styles.confirmLabel}>Location</span>
-                <span className={styles.confirmValue}>
-                  {geocode ? `${geocode.latitude.toFixed(4)}, ${geocode.longitude.toFixed(4)}` : ''}
-                </span>
+                <span className={styles.confirmLabel}>Postcode</span>
+                <span className={styles.confirmValue}>{postcode}</span>
               </div>
               <div className={styles.confirmRow}>
                 <span className={styles.confirmLabel}>Radius</span>

--- a/web/src/features/onboarding/__tests__/OnboardingPage.test.tsx
+++ b/web/src/features/onboarding/__tests__/OnboardingPage.test.tsx
@@ -1,9 +1,33 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
 import { OnboardingPage } from '../OnboardingPage';
 import { SpyOnboardingPort } from './spies/spy-onboarding-port';
 import { SpyGeocodingPort } from './spies/spy-geocoding-port';
+
+vi.mock('react-leaflet', () => ({
+  MapContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="map-container">{children}</div>
+  ),
+  TileLayer: () => <div data-testid="tile-layer" />,
+  Marker: () => <div data-testid="map-marker" />,
+  Circle: () => <div data-testid="map-circle" />,
+  useMap: () => ({
+    fitBounds: vi.fn(),
+  }),
+}));
+
+vi.mock('leaflet', () => ({
+  default: {
+    icon: () => ({}),
+    Icon: { Default: { mergeOptions: () => {} } },
+    latLng: () => ({ toBounds: () => ({ pad: () => ({}) }) }),
+  },
+  icon: () => ({}),
+  Icon: { Default: { mergeOptions: () => {} } },
+  latLng: () => ({ toBounds: () => ({ pad: () => ({}) }) }),
+}));
 
 function renderOnboarding(
   onboardingPort: SpyOnboardingPort,
@@ -77,6 +101,26 @@ describe('OnboardingPage', () => {
     await user.click(screen.getByRole('button', { name: /next/i }));
 
     expect(screen.getByRole('button', { name: /confirm/i })).toBeInTheDocument();
+  });
+
+  it('shows postcode and map on confirm step', async () => {
+    const user = userEvent.setup();
+    const geocodingSpy = new SpyGeocodingPort();
+    renderOnboarding(new SpyOnboardingPort(), geocodingSpy);
+
+    await user.click(screen.getByRole('button', { name: /get started/i }));
+    await user.type(screen.getByLabelText(/postcode/i), 'SW1A 1AA');
+    await user.click(screen.getByRole('button', { name: /look up/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('radiogroup', { name: /radius/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText('2 km'));
+    await user.click(screen.getByRole('button', { name: /next/i }));
+
+    expect(screen.getByTestId('map-container')).toBeInTheDocument();
+    expect(screen.getByText('SW1A 1AA')).toBeInTheDocument();
   });
 
   it('calls APIs and navigates to dashboard on confirm', async () => {

--- a/web/src/features/onboarding/useOnboarding.ts
+++ b/web/src/features/onboarding/useOnboarding.ts
@@ -7,6 +7,7 @@ export type OnboardingStep = 'welcome' | 'postcode' | 'radius' | 'confirm';
 export function useOnboarding(port: OnboardingPort) {
   const [step, setStep] = useState<OnboardingStep>('welcome');
   const [geocode, setGeocode] = useState<GeocodeResult | null>(null);
+  const [postcode, setPostcode] = useState('');
   const [radiusMetres, setRadiusMetres] = useState(1000);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -16,8 +17,9 @@ export function useOnboarding(port: OnboardingPort) {
     setStep('postcode');
   }, []);
 
-  const handleGeocode = useCallback((result: GeocodeResult) => {
+  const handleGeocode = useCallback((result: GeocodeResult, enteredPostcode: string) => {
     setGeocode(result);
+    setPostcode(enteredPostcode);
     setStep('radius');
   }, []);
 
@@ -53,6 +55,7 @@ export function useOnboarding(port: OnboardingPort) {
   return {
     step,
     geocode,
+    postcode,
     radiusMetres,
     isSubmitting,
     error,


### PR DESCRIPTION
## Summary
- Add shared `ConfirmMap` component (Leaflet map with marker + radius circle)
- Replace raw lat/long coordinates with interactive map preview + postcode label on onboarding confirm step
- Add new confirm step to watch zone creation flow (postcode → details → **confirm** → save)
- Thread entered postcode through `PostcodeInput.onGeocode` callback for display

## Test Plan
- [ ] Complete onboarding flow — confirm step shows map centred on postcode with radius circle
- [ ] Create a watch zone from watch zones tab — new confirm step shows map before saving
- [ ] Verify pan/zoom works on confirm maps but pin is not draggable
- [ ] Check light and dark themes render the map correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced interactive map-based confirmation step for location selection in onboarding and watch zone creation flows
  * Users can now visually verify selected locations on a map displaying marker position and service radius before confirming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->