### PR TITLE
fix(infra): ignore Container App secrets in Pulumi

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -285,7 +285,9 @@ public static class EnvironmentStack
             // causing activation failure (quickstart listens on port 80, not 8080).
             // Traffic weights are managed by CI (staging revisions with 0% traffic),
             // so Pulumi must not reset them on the next `pulumi up`.
-            IgnoreChanges = { "template.containers[0].image", "configuration.ingress.traffic" },
+            // Secrets are managed by `az containerapp secret set` in the CD pipeline;
+            // Pulumi must not try to remove them when updating the template.
+            IgnoreChanges = { "template.containers[0].image", "configuration.ingress.traffic", "configuration.secrets" },
         });
 
         if (customDomainPhase == 1)


### PR DESCRIPTION
## Summary

- Add `configuration.secrets` to the Container App's `IgnoreChanges` list in Pulumi
- Secrets are managed by `az containerapp secret set` in the CD pipeline, not Pulumi
- Without this, `pulumi up` tries to remove secrets that old revisions still reference, causing a 409 `ContainerAppSecretInUse` error

## Context

This was discovered when the OTEL PR (#145) added a new env var to the Container App template. The template update triggered Pulumi to reconcile the full Container App state, which tried to remove CD-managed secrets.

## Test Plan

- [x] Infra builds successfully
- [ ] `pulumi up` for dev stack succeeds without 409 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where secrets modified outside Pulumi would be inadvertently reverted during infrastructure updates. The API configuration now preserves external secret modifications during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->