### PR TITLE
fix(infra): move Container App secrets into Pulumi to fix 409 deploy failure

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -92,6 +92,8 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         run: |
           pulumi stack select dev
+          pulumi config set --secret adminApiKey "${{ secrets.ADMIN_API_KEY }}"
+          pulumi config set --secret autoGrantProDomains "${{ secrets.AUTO_GRANT_PRO_DOMAINS }}"
           pulumi up --yes --non-interactive
 
   # ── API: build & push image ─────────────────────────
@@ -136,37 +138,12 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Set Container App secrets
-        run: |
-          az containerapp secret set \
-            --name "ca-town-crier-api-dev" \
-            --resource-group "rg-town-crier-dev" \
-            --secrets \
-              "admin-api-key=${{ secrets.ADMIN_API_KEY }}" \
-              "auto-grant-pro-domains=${{ secrets.AUTO_GRANT_PRO_DOMAINS }}"
-
-      - uses: ./.github/actions/setup-dotnet-infra
-
-      - name: Get App Insights connection string
-        id: appinsights
-        working-directory: infra
-        run: |
-          CONNECTION_STRING=$(pulumi stack output appInsightsConnectionString --stack shared)
-          echo "::add-mask::$CONNECTION_STRING"
-          echo "connection-string=$CONNECTION_STRING" >> "$GITHUB_OUTPUT"
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-
       - name: Deploy to Container App
         run: |
           az containerapp update \
             --name "ca-town-crier-api-dev" \
             --resource-group "rg-town-crier-dev" \
-            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}" \
-            --set-env-vars \
-              "Admin__ApiKey=secretref:admin-api-key" \
-              "Subscription__AutoGrant__ProDomains=secretref:auto-grant-pro-domains" \
-              "APPLICATIONINSIGHTS_CONNECTION_STRING=${{ steps.appinsights.outputs.connection-string }}"
+            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}"
 
   # ── Web: deploy to dev ──────────────────────────────
   web-deploy:

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -62,6 +62,8 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         run: |
           pulumi stack select prod
+          pulumi config set --secret adminApiKey "${{ secrets.ADMIN_API_KEY }}"
+          pulumi config set --secret autoGrantProDomains "${{ secrets.AUTO_GRANT_PRO_DOMAINS }}"
           pulumi up --yes --non-interactive
 
       - name: Extract Pulumi outputs
@@ -116,39 +118,12 @@ jobs:
             exit 1
           fi
 
-      - name: Set Container App secrets
-        run: |
-          az containerapp secret set \
-            --name "ca-town-crier-api-prod" \
-            --resource-group "$RESOURCE_GROUP" \
-            --secrets \
-              "admin-api-key=${{ secrets.ADMIN_API_KEY }}" \
-              "auto-grant-pro-domains=${{ secrets.AUTO_GRANT_PRO_DOMAINS }}"
-        env:
-          RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
-
-      - uses: ./.github/actions/setup-dotnet-infra
-
-      - name: Get App Insights connection string
-        id: appinsights
-        working-directory: infra
-        run: |
-          CONNECTION_STRING=$(pulumi stack output appInsightsConnectionString --stack shared)
-          echo "::add-mask::$CONNECTION_STRING"
-          echo "connection-string=$CONNECTION_STRING" >> "$GITHUB_OUTPUT"
-        env:
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
-
       - name: Deploy API image to prod
         run: |
           az containerapp update \
             --name "ca-town-crier-api-prod" \
             --resource-group "$RESOURCE_GROUP" \
-            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ steps.check-image.outputs.tag }}" \
-            --set-env-vars \
-              "Admin__ApiKey=secretref:admin-api-key" \
-              "Subscription__AutoGrant__ProDomains=secretref:auto-grant-pro-domains" \
-              "APPLICATIONINSIGHTS_CONNECTION_STRING=${{ steps.appinsights.outputs.connection-string }}"
+            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ steps.check-image.outputs.tag }}"
         env:
           RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
 

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -32,6 +32,8 @@ public static class EnvironmentStack
         var auth0Domain = config.Require("auth0Domain");
         var auth0Audience = config.Require("auth0Audience");
         var customDomainPhase = config.GetInt32("customDomainPhase") ?? 2;
+        var adminApiKey = config.RequireSecret("adminApiKey");
+        var autoGrantProDomains = config.RequireSecret("autoGrantProDomains");
 
         // Shared stack outputs
         var shared = new StackReference("AmyDe/town-crier/shared");
@@ -204,6 +206,11 @@ public static class EnvironmentStack
             Configuration = new ConfigurationArgs
             {
                 ActiveRevisionsMode = ActiveRevisionsMode.Multiple,
+                Secrets = new[]
+                {
+                    new SecretArgs { Name = "admin-api-key", Value = adminApiKey },
+                    new SecretArgs { Name = "auto-grant-pro-domains", Value = autoGrantProDomains },
+                },
                 Ingress = new IngressArgs
                 {
                     External = true,
@@ -268,6 +275,8 @@ public static class EnvironmentStack
                             new EnvironmentVarArgs { Name = "AZURE_CLIENT_ID", Value = cosmosDataIdentityClientId },
                             new EnvironmentVarArgs { Name = "Cors__AllowedOrigins__0", Value = $"https://{frontendDomain}" },
                             new EnvironmentVarArgs { Name = "APPLICATIONINSIGHTS_CONNECTION_STRING", Value = appInsightsConnectionString },
+                            new EnvironmentVarArgs { Name = "Admin__ApiKey", SecretRef = "admin-api-key" },
+                            new EnvironmentVarArgs { Name = "Subscription__AutoGrant__ProDomains", SecretRef = "auto-grant-pro-domains" },
                         },
                     },
                 },
@@ -285,9 +294,7 @@ public static class EnvironmentStack
             // causing activation failure (quickstart listens on port 80, not 8080).
             // Traffic weights are managed by CI (staging revisions with 0% traffic),
             // so Pulumi must not reset them on the next `pulumi up`.
-            // Secrets are managed by `az containerapp secret set` in the CD pipeline;
-            // Pulumi must not try to remove them when updating the template.
-            IgnoreChanges = { "template.containers[0].image", "configuration.ingress.traffic", "configuration.secrets" },
+            IgnoreChanges = { "template.containers[0].image", "configuration.ingress.traffic" },
         });
 
         if (customDomainPhase == 1)


### PR DESCRIPTION
## Changes

- **Declare secrets in Pulumi** — `admin-api-key` and `auto-grant-pro-domains` are now defined in the ContainerApp `Configuration.Secrets` using `config.RequireSecret()`, with env vars referencing them via `SecretRef`
- **Set Pulumi config in CI** — both `cd-dev.yml` and `cd-prod.yml` now run `pulumi config set --secret` before `pulumi up`, feeding the GitHub secrets into Pulumi config
- **Simplify api-deploy jobs** — removed the `az containerapp secret set` step, the App Insights connection string lookup, and the `--set-env-vars` flags from `az containerapp update` (Pulumi handles all of this now)
- **Remove stale IgnoreChanges** — `configuration.secrets` removed from `IgnoreChanges` since Pulumi now owns the secrets

## Root Cause

The 409 `ContainerAppSecretInUse` error occurred because secrets were managed out-of-band via `az containerapp secret set` in the api-deploy job. Pulumi state had no knowledge of them, so every `pulumi up` sent an empty secrets array. Azure rejected this because the active revision still referenced those secrets. The previous fix (adding `configuration.secrets` to `IgnoreChanges`) didn't help because there was nothing in state to preserve — the old state was already empty.

## Test plan

- [ ] PR Gate passes (infra build)
- [ ] CD Dev run succeeds — Pulumi up creates secrets, api-deploy only swaps the image
- [ ] Verify Container App secrets and env vars are correct in Azure portal

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored secret management in deployment workflows to use infrastructure-as-code configuration, consolidating secrets across dev and production environments.
  * Updated container deployment process to manage secrets through infrastructure configuration rather than direct container updates, improving deployment consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->