### PR TITLE
fix(infra): fix InvalidCastException in KqlTile InputList initialization

### DIFF
--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -340,14 +340,14 @@ public static class SharedStack
                     },
                 },
             },
-            Inputs = new InputList<object>
+            Inputs = new[]
             {
-                (Input<object>)(object)new Dictionary<string, object>
+                (object)new Dictionary<string, object>
                 {
                     ["name"] = "resourceTypeMode",
                     ["value"] = "components",
                 },
-                (Input<object>)(object)new Dictionary<string, object>
+                (object)new Dictionary<string, object>
                 {
                     ["name"] = "ComponentId",
                     ["value"] = appInsightsId,


### PR DESCRIPTION
## Changes
- Fix `System.InvalidCastException` in `SharedStack.KqlTile` that crashed `pulumi up` on the shared stack
- Replace `(Input<object>)(object)new Dictionary<...>` with `object[]` initialization — the double-cast fails at runtime because explicit casts don't invoke implicit conversion operators
- Pulumi's `InputList<T>` accepts `object[]` via implicit array conversion, avoiding both the runtime cast failure and the `CS0121` Add overload ambiguity

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal code structure for dashboard metadata construction while maintaining existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->