### PR TITLE
fix(infra): guard KQL tile against empty result sets

### DIFF
--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -189,7 +189,7 @@ public static class SharedStack
                                 Position = new DashboardPartsPositionArgs { X = 0, Y = 0, ColSpan = 4, RowSpan = 4 },
                                 Metadata = KqlTile(
                                     appInsights.Id,
-                                    "requests | where name == 'GET /v1/me' | summarize dcount(user_AuthenticatedId) by bin(timestamp, 1h) | render timechart",
+                                    "let data = requests | where name == 'GET /v1/me' | summarize Value=dcount(user_AuthenticatedId) by timestamp=bin(timestamp, 1h); let empty = datatable(timestamp:datetime, Value:long)[]; union data, empty | render timechart",
                                     "Active Users"),
                             },
                             new DashboardPartsArgs


### PR DESCRIPTION
## Changes
- Fix `e.forEach is not a function` crash on the Active Users dashboard tile when no request data exists for the query period
- Union the KQL query with an empty `datatable` so the result always carries typed column schema (`timestamp:datetime, Value:long`), even with zero rows
- Root cause: Azure Portal's `LogsDashboardPart` receives `undefined` column metadata instead of an empty array when KQL returns no rows

---
*Auto-shipped via ship skill*