### PR TITLE
fix(infra): replace LogsDashboardPart with App Insights AnalyticsPart

### DIFF
--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -316,15 +316,16 @@ public static class SharedStack
     {
         return new DashboardPartMetadataArgs
         {
-            Type = "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+            Type = "Extension/AppInsightsExtension/PartType/AnalyticsPart",
             Settings = new InputMap<object>
             {
                 ["content"] = new Dictionary<string, object>
                 {
                     ["Query"] = query,
-                    ["ControlType"] = "AnalyticsChart",
+                    ["ControlType"] = "FrameControlChart",
                     ["SpecificChart"] = "Line",
                     ["PartTitle"] = title,
+                    ["IsQueryContainTimeRange"] = false,
                     ["Dimensions"] = new Dictionary<string, object>
                     {
                         ["xAxis"] = new Dictionary<string, object>
@@ -332,21 +333,19 @@ public static class SharedStack
                             ["name"] = "timestamp",
                             ["type"] = "datetime",
                         },
-                        ["yAxis"] = new Dictionary<string, object>
+                        ["yAxis"] = new object[]
                         {
-                            ["name"] = "aggregation",
-                            ["type"] = "long",
+                            new Dictionary<string, object>
+                            {
+                                ["name"] = "Value",
+                                ["type"] = "long",
+                            },
                         },
                     },
                 },
             },
             Inputs = new[]
             {
-                (object)new Dictionary<string, object>
-                {
-                    ["name"] = "resourceTypeMode",
-                    ["value"] = "components",
-                },
                 (object)new Dictionary<string, object>
                 {
                     ["name"] = "ComponentId",


### PR DESCRIPTION
## Changes
- Replace `LogsDashboardPart` (OMS extension) with `AnalyticsPart` (App Insights native extension) to fix persistent `e.forEach is not a function` portal error
- Fix `Dimensions.yAxis` from single object to array (portal iterates with `forEach`)
- Align yAxis column name from `aggregation` to `Value` matching the KQL alias
- Use `FrameControlChart` control type (correct for AnalyticsPart)

Closes the dashboard tile crash that persisted through #150 and #151.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dashboard analytics visualization configuration and chart rendering controls for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->