### PR TITLE
fix: wire correct authority provider and keep container alive for polling

### DIFF
--- a/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
+++ b/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
@@ -51,7 +51,7 @@ internal static class ServiceCollectionExtensions
             ?? Path.Combine(AppContext.BaseDirectory, "poll-state.txt");
         services.AddSingleton<IPollStateStore>(new FilePollStateStore(pollStateFilePath));
 
-        services.AddSingleton<IActiveAuthorityProvider, InMemoryActiveAuthorityProvider>();
+        services.AddSingleton<IActiveAuthorityProvider, WatchZoneActiveAuthorityProvider>();
         services.AddSingleton<IPollingHealthStore, InMemoryPollingHealthStore>();
         services.AddSingleton<IPollingHealthAlerter, LogPollingHealthAlerter>();
         services.AddSingleton(new PollingHealthConfig(

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -282,7 +282,7 @@ public static class EnvironmentStack
                 },
                 Scale = new ScaleArgs
                 {
-                    MinReplicas = 0,
+                    MinReplicas = 1,
                     MaxReplicas = 1,
                 },
             },


### PR DESCRIPTION
## Changes
- Swap `InMemoryActiveAuthorityProvider` (always empty, nothing ever calls `.Add()`) for `WatchZoneActiveAuthorityProvider` which queries Cosmos for authority IDs from user watch zones — fixes the 15-min poll cycle doing zero work
- Set `MinReplicas = 1` on the Container App so the `PlanItPollingService` BackgroundService survives idle periods instead of dying when the container scales to zero

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
* API service now maintains consistent availability with at least one active instance running at all times, reducing startup delays and improving responsiveness.
* Authority management system enhanced for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->