### PR TITLE
chore: enforce beads usage via hook and update ship skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,54 +1,86 @@
 {
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.command' | grep -qE '^git\\s+push' && { branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$branch\" = \"main\" ]; then echo '{\"decision\":\"block\",\"reason\":\"You are on the main branch. Do NOT push directly to main. Instead: 1) Create a new feature branch with git checkout -b <descriptive-branch-name>, 2) Push that branch with git push -u origin <branch-name>, 3) Create a PR using gh pr create.\"}'; fi; } || true",
-            "timeout": 10,
-            "statusMessage": "Checking branch protection..."
-          },
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.command' | grep -qE '^git\\s+commit' || exit 0; root=$(git rev-parse --show-toplevel); staged=$(git diff --cached --name-only -- '*.swift' | grep '^mobile/ios/' | sed \"s|^|$root/|\" || true); [ -z \"$staged\" ] && exit 0; lint=$(cd \"$root/mobile/ios\" && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swiftlint lint $staged --quiet 2>/dev/null | grep -E ':[0-9]+:[0-9]+: (error|warning):'); [ -z \"$lint\" ] && exit 0; jq -n --arg reason \"SwiftLint violations in staged files — fix before committing:\\n$lint\" '{\"decision\":\"block\",\"reason\":$reason}'",
-            "timeout": 30,
-            "statusMessage": "SwiftLint pre-commit check..."
-          },
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.command' | { read -r cmd; echo \"$cmd\" | grep -qE '^git\\s+commit' || exit 0; root=$(git rev-parse --show-toplevel); staged=$(git diff --cached --name-only -- '*.ts' '*.tsx' '*.css' 2>/dev/null | grep '^web/src/' | sed \"s|^|$root/|\" || true); [ -z \"$staged\" ] && exit 0; lint=$(cd \"$root/web\" && npx eslint --no-warn-ignored $staged 2>/dev/null | grep -E '^\\s+[0-9]+:[0-9]+\\s+error' | head -20); [ -z \"$lint\" ] && exit 0; jq -n --arg reason \"ESLint errors in staged web files — fix before committing:\\n$lint\" '{\"decision\":\"block\",\"reason\":$reason}'; }",
-            "timeout": 30,
-            "statusMessage": "ESLint pre-commit check..."
-          }
-        ]
-      }
-    ],
-    "PostToolUse": [
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; [[ \"$f\" == */mobile/ios/*.swift ]] || exit 0; lint=$(cd mobile/ios && DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swiftlint lint \"$f\" --quiet 2>/dev/null | grep \"^$f:\"); [ -z \"$lint\" ] && exit 0; jq -n --arg ctx \"SwiftLint violations — fix before continuing:\\n$lint\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":$ctx}}'; } 2>/dev/null || true",
-            "timeout": 30,
-            "statusMessage": "Running SwiftLint..."
-          },
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; [[ \"$f\" == */web/src/*.ts ]] || [[ \"$f\" == */web/src/*.tsx ]] || [[ \"$f\" == */web/src/*.css ]] || exit 0; root=$(git rev-parse --show-toplevel); lint=$(cd \"$root/web\" && npx eslint --no-warn-ignored \"$f\" 2>/dev/null | grep -E '^\\s+[0-9]+:[0-9]+\\s+(error|warning)' | head -20); [ -z \"$lint\" ] && exit 0; jq -n --arg ctx \"ESLint violations — fix before continuing:\\n$lint\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":$ctx}}'; } 2>/dev/null || true",
-            "timeout": 30,
-            "statusMessage": "Running ESLint..."
-          }
-        ]
-      }
-    ]
-  },
   "enabledPlugins": {
+    "beads@beads-marketplace": true,
     "code-review@claude-plugins-official": true,
     "skill-creator@claude-plugins-official": true,
-    "superpowers@claude-plugins-official": true,
-    "beads@beads-marketplace": true
+    "superpowers@claude-plugins-official": true
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; [[ \"$f\" == */mobile/ios/*.swift ]] || exit 0; lint=$(cd mobile/ios \u0026\u0026 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swiftlint lint \"$f\" --quiet 2\u003e/dev/null | grep \"^$f:\"); [ -z \"$lint\" ] \u0026\u0026 exit 0; jq -n --arg ctx \"SwiftLint violations — fix before continuing:\\n$lint\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":$ctx}}'; } 2\u003e/dev/null || true",
+            "statusMessage": "Running SwiftLint...",
+            "timeout": 30,
+            "type": "command"
+          },
+          {
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; [[ \"$f\" == */web/src/*.ts ]] || [[ \"$f\" == */web/src/*.tsx ]] || [[ \"$f\" == */web/src/*.css ]] || exit 0; root=$(git rev-parse --show-toplevel); lint=$(cd \"$root/web\" \u0026\u0026 npx eslint --no-warn-ignored \"$f\" 2\u003e/dev/null | grep -E '^\\s+[0-9]+:[0-9]+\\s+(error|warning)' | head -20); [ -z \"$lint\" ] \u0026\u0026 exit 0; jq -n --arg ctx \"ESLint violations — fix before continuing:\\n$lint\" '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":$ctx}}'; } 2\u003e/dev/null || true",
+            "statusMessage": "Running ESLint...",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": "Write|Edit"
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "echo '{\"decision\":\"block\",\"reason\":\"This project uses beads (bd) for task tracking. Use bd commands instead: bd create --title=\\\"...\\\" --description=\\\"...\\\" --type=task --priority=2, bd update <id> --claim, bd close <id>. See CLAUDE.md for details.\"}'",
+            "timeout": 5,
+            "type": "command"
+          }
+        ],
+        "matcher": "TaskCreate|TodoWrite|TaskUpdate|TaskOutput|TaskGet|TaskList|TaskStop"
+      },
+      {
+        "hooks": [
+          {
+            "command": "jq -r '.tool_input.command' | grep -qE '^git\\s+push' \u0026\u0026 { branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$branch\" = \"main\" ]; then echo '{\"decision\":\"block\",\"reason\":\"You are on the main branch. Do NOT push directly to main. Instead: 1) Create a new feature branch with git checkout -b \u003cdescriptive-branch-name\u003e, 2) Push that branch with git push -u origin \u003cbranch-name\u003e, 3) Create a PR using gh pr create.\"}'; fi; } || true",
+            "statusMessage": "Checking branch protection...",
+            "timeout": 10,
+            "type": "command"
+          },
+          {
+            "command": "jq -r '.tool_input.command' | grep -qE '^git\\s+commit' || exit 0; root=$(git rev-parse --show-toplevel); staged=$(git diff --cached --name-only -- '*.swift' | grep '^mobile/ios/' | sed \"s|^|$root/|\" || true); [ -z \"$staged\" ] \u0026\u0026 exit 0; lint=$(cd \"$root/mobile/ios\" \u0026\u0026 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swiftlint lint $staged --quiet 2\u003e/dev/null | grep -E ':[0-9]+:[0-9]+: (error|warning):'); [ -z \"$lint\" ] \u0026\u0026 exit 0; jq -n --arg reason \"SwiftLint violations in staged files — fix before committing:\\n$lint\" '{\"decision\":\"block\",\"reason\":$reason}'",
+            "statusMessage": "SwiftLint pre-commit check...",
+            "timeout": 30,
+            "type": "command"
+          },
+          {
+            "command": "jq -r '.tool_input.command' | { read -r cmd; echo \"$cmd\" | grep -qE '^git\\s+commit' || exit 0; root=$(git rev-parse --show-toplevel); staged=$(git diff --cached --name-only -- '*.ts' '*.tsx' '*.css' 2\u003e/dev/null | grep '^web/src/' | sed \"s|^|$root/|\" || true); [ -z \"$staged\" ] \u0026\u0026 exit 0; lint=$(cd \"$root/web\" \u0026\u0026 npx eslint --no-warn-ignored $staged 2\u003e/dev/null | grep -E '^\\s+[0-9]+:[0-9]+\\s+error' | head -20); [ -z \"$lint\" ] \u0026\u0026 exit 0; jq -n --arg reason \"ESLint errors in staged web files — fix before committing:\\n$lint\" '{\"decision\":\"block\",\"reason\":$reason}'; }",
+            "statusMessage": "ESLint pre-commit check...",
+            "timeout": 30,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
   }
 }

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: ship
-description: Automate the push-to-main flow when you have local commits and/or unstaged changes on main. Creates a feature branch, opens a PR via `gh`, enables auto-merge, then watches for Copilot and CodeRabbit approvals — addressing their feedback if needed. MUST use this skill whenever the user says "ship", "ship it", "push to main", "push my changes", "get this on main", "merge to main", "create a PR and merge", or any variation of wanting to get local work from main onto the remote. Also trigger when the user has been working on main and wants to push but can't due to branch protection. Do NOT use for: creating PRs without merging, pushing feature branches, or work that isn't on main.
+description: Automate the push-to-main flow when you have local commits and/or unstaged changes on main. Creates a feature branch, opens a PR via `gh`, then watches for the PR Gate CI check to pass — auto-merge is enabled automatically by a GitHub Actions workflow. MUST use this skill whenever the user says "ship", "ship it", "push to main", "push my changes", "get this on main", "merge to main", "create a PR and merge", or any variation of wanting to get local work from main onto the remote. Also trigger when the user has been working on main and wants to push but can't due to branch protection. Do NOT use for: creating PRs without merging, pushing feature branches, or work that isn't on main.
 ---
 
 # Ship to Main
 
-Route local work on `main` through a PR, because direct pushes to main are blocked by branch protection and a local pre-push hook. This skill handles the flow: branch, push, create PR, wait for checks, and merge — fully hands-off by default.
+Route local work on `main` through a PR, because direct pushes to main are blocked by branch protection and a local pre-push hook. This skill handles the flow: branch, push, create PR, wait for CI, and merge — fully hands-off by default.
+
+## How merging works
+
+There are no reviewer approvals required. The merge flow is entirely CI-driven:
+
+1. **`auto-merge.yml`** — A GitHub Actions workflow that automatically enables squash auto-merge on every newly opened PR. The skill does NOT need to run `gh pr merge --auto`.
+2. **`pr-gate.yml`** — The CI pipeline. It detects which areas changed (API, iOS, web, infra) and runs only the relevant checks. A single **`gate`** job aggregates all results — this is the sole required status check for branch protection.
+3. When `gate` passes, auto-merge fires and the PR is squash-merged automatically.
 
 ## Workflow
 
@@ -70,82 +78,71 @@ EOF
 
 **PR body:** List each commit as a bullet point under "## Changes".
 
-### Step 6: Enable auto-merge and start watching
-
-The PR will auto-merge via branch protection once both **Copilot** and **CodeRabbit** approve. Enable auto-merge so it triggers the moment approvals land:
-
-```bash
-gh pr merge <pr-number> --squash --delete-branch --auto
-```
-
-**Default behavior:** Report the PR URL and proceed straight to Step 7 (watch for reviews). Do not ask — just do it. The user expects to walk away after typing "ship it".
+**Default behavior:** Report the PR URL and proceed straight to Step 6 (watch CI). Do not ask — just do it. The user expects to walk away after typing "ship it". Auto-merge is enabled automatically by the `auto-merge.yml` workflow — do not run `gh pr merge --auto` yourself.
 
 > PR created: <url>
 >
-> Auto-merge enabled. Watching for Copilot and CodeRabbit reviews...
+> Auto-merge will be enabled by CI. Watching for PR Gate...
 
-**Exception:** If the user explicitly says "leave it open", "don't merge", or similar — report the PR URL and stop. Do not enable auto-merge. The skill ends here.
+**Exception:** If the user explicitly says "leave it open", "don't merge", or similar — report the PR URL and stop. The skill ends here.
 
-### Step 7: Watch for reviewer feedback
+### Step 6: Watch for CI checks
 
-Poll for reviews from both Copilot and CodeRabbit. These are the two required reviewers — the PR cannot merge until both approve.
+The **PR Gate** (`gate` job in `pr-gate.yml`) is the sole required status check. It runs checks only for changed areas:
 
-**Poll loop** (repeat every 30 seconds, up to 10 minutes):
+| Area | Checks | Trigger |
+|------|--------|---------|
+| API | Format, Build & test, Staging deploy, Integration tests, Staging cleanup | Files in `api/` changed |
+| iOS | SwiftLint, Build & test | Files in `mobile/ios/` changed |
+| Web | Lint, Type-check + test + build | Files in `web/` changed |
+| Infra | Pulumi preview | Files in `infra/` changed |
+
+The `gate` job passes if every triggered check passes (skipped checks are fine).
+
+**Poll loop** (repeat every 30 seconds, up to 15 minutes):
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/<pr-number>/reviews
-gh api repos/{owner}/{repo}/pulls/<pr-number>/comments
+gh pr checks <pr-number> --json name,state,conclusion
 ```
-
-Track the state of each reviewer:
-
-| Reviewer | Identified by | Approval signal |
-|----------|--------------|-----------------|
-| Copilot | `user.login` is `"copilot-pull-request-reviewer[bot]"` or contains `"copilot"` | Review with `state: "APPROVED"` |
-| CodeRabbit | `user.login` is `"coderabbitai[bot]"` or contains `"coderabbit"` | Review with `state: "APPROVED"` |
 
 **On each poll iteration:**
 
-1. Fetch reviews and comments.
-2. Check if both reviewers have approved → if yes, proceed to Step 8 (the auto-merge will handle the actual merge).
-3. Check if either reviewer left non-approval feedback (comments, change requests, or suggestions). If so, enter the **feedback loop** below.
-4. If neither condition, continue polling.
+1. Check if the `PR Gate` check has completed:
+   - **Conclusion `success`** → proceed to Step 7.
+   - **Conclusion `failure`** → enter the **failure handling** below.
+2. If still pending, report which checks are running and continue polling.
 
-**Timeout:** If 10 minutes pass without both approvals and no feedback to act on, report the current state and the PR URL, then stop. The auto-merge will still trigger when approvals arrive — no work is lost.
+**Timeout:** If 15 minutes pass without the gate completing, report the current check states and the PR URL, then stop. Auto-merge remains enabled — no work is lost.
 
-### Step 7a: Feedback loop — respond to reviewer comments
+### Step 6a: Handle CI failures
 
-If Copilot or CodeRabbit leaves comments or requests changes instead of approving:
+If any check fails:
 
-1. **Read the feedback carefully.** Fetch full comment bodies:
+1. **Identify what failed.** Fetch the failed check details:
    ```bash
-   gh api repos/{owner}/{repo}/pulls/<pr-number>/comments
-   gh api repos/{owner}/{repo}/pulls/<pr-number>/reviews
+   gh pr checks <pr-number>
+   gh run view <run-id> --log-failed
    ```
 
-2. **Assess each comment:**
-   - **Actionable code suggestion** (e.g., "add null check", "rename variable", "simplify this expression"): Fix it. These are small, mechanical changes — apply them directly.
-   - **Style/formatting nit:** Fix it.
-   - **Substantive design concern** (e.g., "this approach has a race condition", "consider a different pattern"): Create a bead to track it, do NOT fix it in this PR. Summarise it for the user.
-   - **Informational only / praise** (e.g., "LGTM with minor note", summary comments): No action needed.
+2. **Assess each failure:**
+   - **Format/lint failure** (e.g., `dotnet format`, `swiftlint`, `npm run lint`): Fix it locally, commit, and push. These are mechanical fixes.
+   - **Test failure:** Read the test output, diagnose the issue, fix it, commit, and push.
+   - **Build failure:** Read the build output, fix the issue, commit, and push.
+   - **Infrastructure/deployment failure** (staging deploy, integration tests): These may involve secrets or environment issues. Report the failure details and the PR URL, then stop — the user needs to investigate.
 
-3. **For actionable fixes:** Make the change, commit with a message like `fix: address <reviewer> feedback — <brief description>`, and push:
+3. **For fixable failures:** Make the change, commit, and push:
    ```bash
    git add <files>
-   git commit -m "fix: address <reviewer> feedback — <brief description>"
+   git commit -m "fix: <brief description of what was fixed>"
    git push
    ```
-   This will re-trigger the reviewers. Return to the poll loop in Step 7.
+   This re-triggers the CI pipeline. Return to the poll loop in Step 6.
 
-4. **For substantive concerns tracked as beads:** Report them:
-   > <Reviewer> flagged the following (tracked in bead <id>):
-   > - <brief summary of each concern>
+4. **Limit:** Make at most **3 rounds** of fixes. If the gate still hasn't passed after 3 rounds, report the outstanding failures and the PR URL, then stop. Auto-merge remains enabled.
 
-5. **Limit:** Make at most **3 rounds** of fixes per reviewer. If a reviewer still hasn't approved after 3 rounds of addressing their feedback, report the situation and the PR URL, then stop. The auto-merge remains enabled — the user can take over manually.
+### Step 7: Confirm merge and clean up
 
-### Step 8: Confirm merge and clean up
-
-Once both reviewers approve, auto-merge will squash-merge the PR. Wait for it:
+Once the gate passes, auto-merge will squash-merge the PR. Wait for it:
 
 ```bash
 # Confirm the PR merged (poll briefly if needed)
@@ -164,7 +161,7 @@ If the branch wasn't deleted automatically:
 git branch -d <branch-name>
 ```
 
-### Step 9: Sync beads and verify
+### Step 8: Sync beads and verify
 
 Push beads data to the Dolt remote — this is separate from git and must happen after every merge:
 
@@ -182,7 +179,6 @@ Report success with the PR URL.
 
 - **Not on main:** Stop. Tell the user which branch they're on.
 - **Nothing to ship:** Tell the user. Don't create empty PRs.
-- **Checks failed:** Report which checks failed and the PR URL. Do not retry or force-merge.
-- **Reviewer won't approve after 3 rounds:** Report the outstanding feedback, the PR URL, and stop. Auto-merge remains enabled.
-- **Timeout (10 min no approvals):** Report status and PR URL. Auto-merge remains enabled — no work lost.
+- **CI gate failed:** Report which checks failed, show relevant log output, and the PR URL. Fix mechanical issues (format, lint, tests) up to 3 rounds. For infrastructure/environment failures, stop and report.
+- **Timeout (15 min, gate not complete):** Report current check states and PR URL. Auto-merge remains enabled — no work lost.
 - **gh CLI not authenticated:** Tell the user to run `gh auth login`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,3 +241,51 @@ Current thinking, even if no decision has been made.
 Standard linting/formatting configs are bundled with their respective skills:
 - `.claude/skills/dotnet-coding-standards/assets/.editorconfig` and `Directory.Build.props` (SonarAnalyzer, StyleCop, warnings-as-errors)
 - `.claude/skills/ios-coding-standards/assets/.swiftlint.yml` (force cast/try/unwrap as errors)
+
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->


### PR DESCRIPTION
## Changes
- Add PreToolUse hook to block TaskCreate/TodoWrite/TaskUpdate and redirect agents to `bd` commands
- Update ship skill to use CI-driven auto-merge (auto-merge.yml + pr-gate.yml) instead of polling for Copilot/CodeRabbit approvals
- Add beads quick reference and session completion checklist to CLAUDE.md

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated merge gating and monitoring workflow documentation with revised CI integration approach.
  * Added integration guidelines for issue tracking and session completion procedures.

* **Configuration**
  * Updated plugin enablement configuration and hook control flow settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->