### PR TITLE
chore: harden ship skill and streamline release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -22,7 +22,7 @@ If the request is ambiguous (e.g., just "release" or "new version"), look at the
 - If there are only `fix`, `docs`, `chore`, `perf`, `ci`, `refactor`, `test` commits → default to **patch**
 - If any commit message contains `BREAKING CHANGE` or uses `!` after the type (e.g., `feat!:`) → default to **major**
 
-Present your reasoning and the proposed version to the user before creating the release, so they can confirm or override.
+Proceed automatically with the computed version — no confirmation needed.
 
 ## Workflow
 
@@ -84,16 +84,7 @@ Rules:
 - Omit the `(scope)` part if the original commit had no scope
 - Prefix `ci` and `chore` entries with the type in lowercase (e.g., `chore(ci): ...`) rather than bolding them, to match the established style for those categories
 
-### Step 5: Confirm with the user
-
-Present:
-1. The proposed version (`vX.Y.Z`)
-2. The formatted release notes
-3. The number of commits included
-
-Ask the user to confirm before creating the release.
-
-### Step 6: Create the release
+### Step 5: Create the release
 
 ```bash
 gh release create <version> \
@@ -116,7 +107,7 @@ EOF
 
 After creation, report the release URL to the user.
 
-### Step 7: Sync beads
+### Step 6: Sync beads
 
 If there are any open beads that were completed by the released commits, offer to close them. Then run `bd dolt push` to sync beads state.
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Automate the push-to-main flow when you have local commits and/or unstaged changes on main. Creates a feature branch, opens a PR via `gh`, then watches for the PR Gate CI check to pass — auto-merge is enabled automatically by a GitHub Actions workflow. MUST use this skill whenever the user says "ship", "ship it", "push to main", "push my changes", "get this on main", "merge to main", "create a PR and merge", or any variation of wanting to get local work from main onto the remote. Also trigger when the user has been working on main and wants to push but can't due to branch protection. Do NOT use for: creating PRs without merging, pushing feature branches, or work that isn't on main.
+description: Automate the push-to-main flow when you have local commits and/or unstaged changes on main, or when you're on a feature branch (e.g., from a worktree) ready to PR and merge. Creates a feature branch (if on main), opens a PR via `gh`, then watches for the PR Gate CI check to pass — auto-merge is enabled automatically by a GitHub Actions workflow. MUST use this skill whenever the user says "ship", "ship it", "push to main", "push my changes", "get this on main", "merge to main", "create a PR and merge", or any variation of wanting to get local work merged. Also trigger when the user has been working on main and wants to push but can't due to branch protection, or when work on a feature branch/worktree is ready to ship. Do NOT use for: creating PRs without merging.
 ---
 
 # Ship to Main
@@ -19,8 +19,11 @@ There are no reviewer approvals required. The merge flow is entirely CI-driven:
 
 ### Step 1: Pre-flight
 
-1. Confirm you're on `main`. If not, stop and tell the user — don't switch branches when there might be in-progress work elsewhere.
-2. `git fetch origin` to get the latest remote state.
+1. Run `git fetch origin` to get the latest remote state.
+2. Detect which branch you're on:
+   - **On `main`:** proceed normally through Steps 2–5.
+   - **On a feature branch** (e.g., work done in a worktree): skip Steps 2–4 and go directly to Step 5 (Push and create PR). Note the branch name and whether you're in a worktree (`git worktree list`) for cleanup later.
+   - **On an unrelated branch with uncommitted work:** stop and tell the user.
 3. Check there's actually work to ship:
    - `git log origin/main..HEAD --oneline` — local commits ahead of origin
    - `git status --short` — unstaged or untracked changes
@@ -99,20 +102,25 @@ The **PR Gate** (`gate` job in `pr-gate.yml`) is the sole required status check.
 
 The `gate` job passes if every triggered check passes (skipped checks are fine).
 
-**Poll loop** (repeat every 30 seconds, up to 15 minutes):
+**Watch for checks to complete** — use `--watch` to block until done instead of manual sleep loops:
 
 ```bash
-gh pr checks <pr-number> --json name,state,conclusion
+gh pr checks <pr-number> --watch --fail-fast
 ```
 
-**On each poll iteration:**
+Run this with the Bash tool's **timeout set to 600000ms** (10 minutes). The command blocks until all checks complete (exit 0 = all passed) or any check fails (non-zero exit).
 
-1. Check if the `PR Gate` check has completed:
-   - **Conclusion `success`** → proceed to Step 7.
-   - **Conclusion `failure`** → enter the **failure handling** below.
-2. If still pending, report which checks are running and continue polling.
+- **Exit 0** → all checks passed. Proceed to Step 7.
+- **Non-zero exit** → a check failed. Enter the **failure handling** below.
+- **Timeout** → report the PR URL and stop. Auto-merge remains enabled — no work is lost.
 
-**Timeout:** If 15 minutes pass without the gate completing, report the current check states and the PR URL, then stop. Auto-merge remains enabled — no work is lost.
+If you need to inspect individual check statuses (e.g., after a failure), query with JSON:
+
+```bash
+gh pr checks <pr-number> --json name,state,bucket
+```
+
+**IMPORTANT:** The field is `bucket` (not `conclusion`). Valid bucket values: `pass`, `fail`, `pending`, `skipping`.
 
 ### Step 6a: Handle CI failures
 
@@ -149,40 +157,50 @@ Once the gate passes, auto-merge will squash-merge the PR. Wait for it:
 gh pr view <pr-number> --json state -q '.state'
 ```
 
-Once state is `"MERGED"`:
+Once state is `"MERGED"`, detect your context before cleanup:
 
 ```bash
-git checkout main
-git pull origin main
+git worktree list
 ```
 
-**Full cleanup — worktrees, local branches, and remote branches:**
+**If you're in a worktree** (feature branch is in a secondary worktree, `main` is in the primary):
 
-1. **Remove any worktrees** for the feature branch:
+1. Note the primary worktree path (the one on `main`).
+2. All remaining cleanup commands target the **primary worktree** — use `git -C <primary-path>`:
    ```bash
-   # List worktrees and remove any pointing to the feature branch
-   git worktree list
-   # If the feature branch appears, remove its worktree
-   git worktree remove <worktree-path>
+   git -C <primary-path> worktree remove <this-worktree-path>
+   git -C <primary-path> branch -D <branch-name>
    ```
 
-2. **Delete the local branch:**
+**If you're on the feature branch directly** (no worktree):
+
+1. Switch to main and delete the branch:
    ```bash
+   git checkout main
    git branch -D <branch-name>
    ```
 
-3. **Delete the remote branch** (if GitHub's auto-delete-on-merge didn't catch it):
-   ```bash
-   git push origin --delete <branch-name>
-   ```
-   Ignore "remote ref does not exist" errors — that means auto-delete already handled it.
+**Then, from the primary worktree (on `main`), pull and prune:**
 
-4. **Prune stale remote tracking refs:**
+1. Stash any uncommitted changes first (other in-progress work on main):
+   ```bash
+   git status --short
+   # Only if there are changes:
+   git stash
+   ```
+2. Pull with rebase to handle divergent local commits (e.g., spec/doc commits made before the worktree):
+   ```bash
+   git pull --rebase origin main
+   ```
+3. Restore stashed changes:
+   ```bash
+   git stash pop   # only if you stashed above
+   ```
+4. Prune stale remote-tracking refs. **Do NOT use `git push origin --delete`** — the pre-push hook blocks it on main, and GitHub auto-deletes merged branches anyway:
    ```bash
    git remote prune origin
    ```
-
-5. **Verify** only `main` remains locally:
+5. Verify only `main` remains locally:
    ```bash
    git branch -a
    ```
@@ -203,7 +221,7 @@ Report success with the PR URL.
 
 ## Error Handling
 
-- **Not on main:** Stop. Tell the user which branch they're on.
+- **Not on main or a feature branch:** Stop. Tell the user which branch they're on and ask what to do.
 - **Nothing to ship:** Tell the user. Don't create empty PRs.
 - **CI gate failed:** Report which checks failed, show relevant log output, and the PR URL. Fix mechanical issues (format, lint, tests) up to 3 rounds. For infrastructure/environment failures, stop and report.
 - **Timeout (15 min, gate not complete):** Report current check states and PR URL. Auto-merge remains enabled — no work lost.

--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,5 @@ node_modules/
 # Beads / Dolt files (added by bd init)
 .beads-credential-key
 .claude/worktrees/autopilot-tc-kkc.1/
+# bd worktree
+extract-polling-job/

--- a/docs/specs/email-notifications.md
+++ b/docs/specs/email-notifications.md
@@ -1,0 +1,177 @@
+# Email Notifications
+
+## Overview
+
+Two email features sharing a single `IEmailSender` port backed by Azure Communication Services (ACS):
+
+1. **Weekly digest email** — available to all tiers. A daily Container Apps Job runs `GenerateWeeklyDigestsCommand`, filters users whose `DigestDay` matches the current day, builds a grouped card-style HTML email per user, and sends via ACS.
+2. **Instant notification email** — available to Personal/Pro tiers only. `DispatchNotificationCommandHandler` (change feed path) sends a per-application email alongside the existing push notification. No monthly cap for paid tiers.
+
+Sender address for all emails: `hello@towncrierapp.uk`.
+
+## Port & Adapter
+
+New application port mirroring the existing `IPushNotificationSender` pattern:
+
+```csharp
+public interface IEmailSender
+{
+    Task SendDigestAsync(string email, IReadOnlyList<WatchZoneDigest> digests, CancellationToken ct);
+    Task SendNotificationAsync(string email, Notification notification, CancellationToken ct);
+}
+```
+
+`WatchZoneDigest` is a new DTO grouping notifications by watch zone:
+
+```csharp
+public sealed record WatchZoneDigest(string WatchZoneName, IReadOnlyList<Notification> Notifications);
+```
+
+Infrastructure implementations:
+- `AcsEmailSender` — production adapter using the Azure Communication Services Email SDK.
+- `NoOpEmailSender` — dev/test adapter that does nothing.
+
+## User Preferences
+
+Extend `NotificationPreferences` with two new fields:
+
+| Field | Type | Default | Tier restriction |
+|-------|------|---------|-----------------|
+| `EmailDigestEnabled` | bool | `true` | None (all tiers) |
+| `EmailInstantEnabled` | bool | `false` | Only honoured for Personal/Pro |
+
+The user's email address is already stored on the user profile document in Cosmos (set during onboarding). No Auth0 lookup is needed at send time.
+
+## Weekly Digest Email
+
+### Trigger
+
+A daily Container Apps Job runs on a cron schedule (e.g. `0 8 * * *` — 08:00 UTC daily). It invokes the existing `GenerateWeeklyDigestsCommand`.
+
+### Handler Changes
+
+The current `GenerateWeeklyDigestsCommandHandler`:
+1. Loads all Pro users.
+2. Filters by `DigestDay == today`, `PushEnabled`, and notification count > 0 in the past 7 days.
+3. Sends a push digest with the application count.
+
+Changes required:
+- **Load all users** (not just Pro) who have `EmailDigestEnabled == true` and `DigestDay == today`.
+- **Load the actual notification records** for the past 7 days (not just the count). This requires a new repository method or reuse of an existing one that returns `IReadOnlyList<Notification>`.
+- **Load watch zones** for each user to group notifications by zone.
+- **Build `WatchZoneDigest` list** by matching notifications to watch zones.
+- **Call `IEmailSender.SendDigestAsync()`** with the user's email and the grouped digests.
+- **Preserve existing push digest behaviour** — Pro users with `PushEnabled` still get push digests as before.
+
+### Repository Extension
+
+`INotificationRepository` needs a method to return full notification records for a user since a given date:
+
+```csharp
+Task<IReadOnlyList<Notification>> GetByUserSinceAsync(string userId, DateTimeOffset since, CancellationToken ct);
+```
+
+Note: `CountByUserSinceAsync` already exists — this is the list-returning counterpart.
+
+### Email Content
+
+Card-per-application layout grouped by watch zone:
+
+```
+┌──────────────────────────────────┐
+│         Town Crier               │
+│     Weekly Planning Digest       │
+├──────────────────────────────────┤
+│ 📍 Home — SE1 Watch Zone        │
+│ ┌──────────────────────────────┐ │
+│ │ 14 Elm Street               │ │
+│ │ Householder Application     │ │
+│ │ Single storey rear ext...   │ │
+│ │ View details →              │ │
+│ └──────────────────────────────┘ │
+│ ┌──────────────────────────────┐ │
+│ │ 3 Oak Lane                  │ │
+│ │ Listed Building Consent     │ │
+│ │ Replacement of timber wi... │ │
+│ │ View details →              │ │
+│ └──────────────────────────────┘ │
+│                                  │
+│ 📍 Office — EC2 Watch Zone      │
+│ ┌──────────────────────────────┐ │
+│ │ 100 Bishopsgate             │ │
+│ │ Change of Use               │ │
+│ │ Conversion of ground fl...  │ │
+│ │ View details →              │ │
+│ └──────────────────────────────┘ │
+│                                  │
+│        [ View All in App ]       │
+│                                  │
+│  5 applications · Unsubscribe    │
+└──────────────────────────────────┘
+```
+
+HTML is built inline in `AcsEmailSender` — no templating engine. Keep it simple, table-based HTML for email client compatibility.
+
+## Instant Notification Email
+
+### Trigger
+
+Fires from the existing `DispatchNotificationCommandHandler` (change feed processor path) when a new planning application matches a user's watch zone.
+
+### Handler Changes
+
+After the existing push notification logic:
+- Check if the user is Personal/Pro tier **and** has `EmailInstantEnabled == true`.
+- If so, call `IEmailSender.SendNotificationAsync()` with the user's email and the notification.
+- No monthly cap for paid-tier email notifications.
+
+### Email Content
+
+Mirrors push notification content:
+- Application address
+- Application type
+- Application description
+- Link to view in app
+
+Same inline HTML approach as the digest, but a simpler single-application layout.
+
+## Infrastructure (Pulumi)
+
+### Shared Stack
+
+- **Azure Communication Services** resource.
+- **Email Communication Service** linked to the ACS resource.
+- **Custom domain** `towncrierapp.uk` on the Email Communication Service.
+- **Sender address** `hello@towncrierapp.uk`.
+
+### DNS (Cloudflare)
+
+Verification records for the custom domain:
+- SPF record
+- DKIM records (provided by ACS during domain verification)
+- DMARC record
+
+### Environment Stack
+
+- ACS connection string passed to the Container App as an environment variable or secret.
+- Daily Container Apps Job for the digest trigger (cron schedule, shares the same container image as the API).
+
+## Error Handling
+
+- Failed email sends should be logged but not block the handler (same pattern as failed push notifications).
+- ACS SDK throws on transient failures — wrap calls with retry policy or let the Container Apps Job retry on failure.
+- If a user has no email address on their profile, skip email delivery silently (log a warning).
+
+## Testing
+
+- `SpyEmailSender` test double (mirrors `SpyPushNotificationSender`) — records sent emails for assertions.
+- Unit tests for `GenerateWeeklyDigestsCommandHandler` covering:
+  - Free user with `EmailDigestEnabled` receives digest email.
+  - User with `EmailDigestEnabled == false` does not receive email.
+  - Pro user receives both push and email digest.
+  - Notifications grouped correctly by watch zone.
+  - User with no email address is skipped.
+- Unit tests for `DispatchNotificationCommandHandler` covering:
+  - Personal/Pro user with `EmailInstantEnabled` receives instant email.
+  - Free user does not receive instant email regardless of setting.
+  - Email mirrors notification content.


### PR DESCRIPTION
## Changes

- **Ship skill**: replace sleep-loop CI polling with `gh pr checks --watch --fail-fast`, handle worktree cleanup with `git -C`, use `pull --rebase` with stash, remove `git push origin --delete` (blocked by pre-push hook), add feature-branch entry point
- **Release skill**: remove confirmation step — proceed automatically with computed version bump
- **Gitignore**: add leftover worktree directory from previous session
- **Email spec**: add spec for email notifications (weekly digest + instant)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email notification system supporting weekly digests and instant notifications across select user tiers
  * Introduced email notification preferences for user control

* **Documentation**
  * Published email notifications specification detailing delivery features and user preferences

* **Chores**
  * Streamlined release workflow by removing confirmation step
  * Enhanced deployment workflow to support feature branch shipping and improved CI check monitoring
  * Updated ignore patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->