### PR TITLE
fix: deactivate old Container App revisions after CD deploys

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -164,12 +164,29 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Get current active revision
+        id: old-revision
+        run: |
+          REV=$(az containerapp ingress traffic show \
+            --name ca-town-crier-api-dev \
+            --resource-group rg-town-crier-dev \
+            --query "[?weight==\`100\`].revisionName | [0]" -o tsv)
+          echo "revision=$REV" >> "$GITHUB_OUTPUT"
+
       - name: Deploy to Container App
         run: |
           az containerapp update \
             --name "ca-town-crier-api-dev" \
             --resource-group "rg-town-crier-dev" \
             --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}"
+
+      - name: Deactivate old revision
+        if: steps.old-revision.outputs.revision != ''
+        run: |
+          az containerapp revision deactivate \
+            --name ca-town-crier-api-dev \
+            --resource-group rg-town-crier-dev \
+            --revision "${{ steps.old-revision.outputs.revision }}" || true
 
   # ── Worker: deploy to dev ───────────────────────────────
   worker-deploy:

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -118,12 +118,33 @@ jobs:
             exit 1
           fi
 
+      - name: Get current active revision
+        id: old-revision
+        run: |
+          REV=$(az containerapp ingress traffic show \
+            --name ca-town-crier-api-prod \
+            --resource-group "$RESOURCE_GROUP" \
+            --query "[?weight==\`100\`].revisionName | [0]" -o tsv)
+          echo "revision=$REV" >> "$GITHUB_OUTPUT"
+        env:
+          RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
+
       - name: Deploy API image to prod
         run: |
           az containerapp update \
             --name "ca-town-crier-api-prod" \
             --resource-group "$RESOURCE_GROUP" \
             --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ steps.check-image.outputs.tag }}"
+        env:
+          RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
+
+      - name: Deactivate old revision
+        if: steps.old-revision.outputs.revision != ''
+        run: |
+          az containerapp revision deactivate \
+            --name ca-town-crier-api-prod \
+            --resource-group "$RESOURCE_GROUP" \
+            --revision "${{ steps.old-revision.outputs.revision }}" || true
         env:
           RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
 


### PR DESCRIPTION
## Changes
- Add "Get current active revision" step before API deploy in both `cd-dev.yml` and `cd-prod.yml`
- Add "Deactivate old revision" step after API deploy to clean up the previous revision
- Prevents stale revisions from accumulating toward Azure's 100-revision hard limit

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflows to improve container revision management during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->