### PR TITLE
fix(api): PlanIt date format and default lookback for polling job

### DIFF
--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -37,8 +37,9 @@ public sealed class PollPlanItCommandHandler
     public async Task<PollPlanItResult> HandleAsync(PollPlanItCommand command, CancellationToken ct)
     {
         var lastPollTime = await this.pollStateStore.GetLastPollTimeAsync(ct).ConfigureAwait(false);
-        var authorityIds = await this.activeAuthorityProvider.GetActiveAuthorityIdsAsync(ct).ConfigureAwait(false);
         var now = this.timeProvider.GetUtcNow();
+        lastPollTime ??= now.AddDays(-30);
+        var authorityIds = await this.activeAuthorityProvider.GetActiveAuthorityIdsAsync(ct).ConfigureAwait(false);
 
         var count = 0;
         foreach (var authorityId in authorityIds)

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -105,7 +105,7 @@ public sealed class PlanItClient : IPlanItClient
 
         if (differentStart.HasValue)
         {
-            url += $"&different_start={differentStart.Value:yyyy-MM-ddTHH:mm:ss}";
+            url += $"&different_start={differentStart.Value:yyyy-MM-dd}";
         }
 
         return url;

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -65,17 +65,22 @@ public sealed class PollPlanItCommandHandlerTests
     }
 
     [Test]
-    public async Task Should_PassNullDifferentStart_When_NoPreviousPollState()
+    public async Task Should_UseDefault30DayLookback_When_NoPreviousPollState()
     {
         var authorityProvider = new FakeActiveAuthorityProvider();
         authorityProvider.Add(1);
 
         var planItClient = new FakePlanItClient();
-        var handler = CreateHandler(planItClient: planItClient, authorityProvider: authorityProvider);
+        var now = new DateTimeOffset(2026, 4, 5, 12, 0, 0, TimeSpan.Zero);
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            authorityProvider: authorityProvider,
+            timeProvider: new FakeTimeProvider(now));
 
         await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
 
-        await Assert.That(planItClient.LastDifferentStartUsed).IsNull();
+        var expected = new DateTimeOffset(2026, 3, 6, 12, 0, 0, TimeSpan.Zero);
+        await Assert.That(planItClient.LastDifferentStartUsed).IsEqualTo(expected);
     }
 
     [Test]

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -110,7 +110,8 @@ public sealed class PlanItClientTests
 
         // Assert
         await Assert.That(handler.RequestUrls).HasCount().EqualTo(1);
-        await Assert.That(handler.RequestUrls[0]).Contains("different_start=2026-03-15T10:30:00");
+        await Assert.That(handler.RequestUrls[0]).Contains("different_start=2026-03-15");
+        await Assert.That(handler.RequestUrls[0]).DoesNotContain("T10:30:00");
     }
 
     [Test]


### PR DESCRIPTION
## Changes

- Fix `different_start` date format from `yyyy-MM-ddTHH:mm:ss` to `yyyy-MM-dd` — PlanIt API rejects the ISO datetime format with time component
- Add 30-day default lookback when no poll state exists (first run), since PlanIt now requires a date restriction parameter
- Update tests to assert date-only format and default lookback behavior

## Context

The polling Container Apps Job (`job-town-crier-poll-dev`) has been failing every 15-minute execution with PlanIt 400 errors:
- `"Spatial, date or search restrictions required in query"` — when `different_start` is omitted
- `"different_start: Enter a valid date."` — when the datetime includes `T` and time

Confirmed via `curl` testing that `different_start=2026-04-01` (date-only) returns 200.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated initial polling behavior to default to a 30-day lookback window when no prior poll state exists, ensuring consistent data retrieval on first run.
  * Corrected date parameter formatting in external API requests to use date-only format instead of datetime, improving compatibility with service expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->