### PR TITLE
fix(infra): set Location=global for ACS and Email resources

### DIFF
--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -174,6 +174,7 @@ public static class SharedStack
         {
             CommunicationServiceName = "acs-town-crier-shared",
             ResourceGroupName = resourceGroup.Name,
+            Location = "global",
             DataLocation = "Europe",
             Tags = tags,
         });
@@ -182,6 +183,7 @@ public static class SharedStack
         {
             EmailServiceName = "email-town-crier-shared",
             ResourceGroupName = resourceGroup.Name,
+            Location = "global",
             DataLocation = "Europe",
             Tags = tags,
         });


### PR DESCRIPTION
## Changes
- Set `Location = "global"` on `CommunicationService` and `EmailService` resources in the shared Pulumi stack
- These Azure resource types don't support regional locations — they require `global`, but were inheriting `uksouth` from the resource group

Fixes the CD Dev failure: `LocationNotAvailableForResourceType`

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cloud service resource configurations for Azure Communication Services and EmailService with regional location settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->