### PR TITLE
fix(infra): set Location=global for Email Domain resource

### DIFF
--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -193,6 +193,7 @@ public static class SharedStack
             DomainName = "towncrierapp.uk",
             EmailServiceName = emailService.Name,
             ResourceGroupName = resourceGroup.Name,
+            Location = "global",
             DomainManagement = DomainManagement.CustomerManaged,
             Tags = tags,
         });


### PR DESCRIPTION
## Changes
- Set `Location = "global"` on the `Domain` resource under `EmailService` in the shared Pulumi stack
- The Domain resource does not inherit location from its parent EmailService — it also requires `global` explicitly
- Completes the fix from #164, which resolved CommunicationService and EmailService but missed Domain

---
*Auto-shipped via ship skill*