### PR TITLE
fix: use full ACS connection string to prevent API crash

### DIFF
--- a/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
+++ b/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
@@ -47,7 +47,14 @@ internal static class ServiceCollectionExtensions
         var acsConnectionString = configuration["AzureCommunicationServices:ConnectionString"];
         if (!string.IsNullOrEmpty(acsConnectionString))
         {
-            services.AddSingleton<IEmailSender>(new AcsEmailSender(acsConnectionString));
+            try
+            {
+                services.AddSingleton<IEmailSender>(new AcsEmailSender(acsConnectionString));
+            }
+            catch (InvalidOperationException)
+            {
+                services.AddSingleton<IEmailSender, NoOpEmailSender>();
+            }
         }
         else
         {

--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -288,7 +288,13 @@ public static class SharedStack
             ["cosmosAccountName"] = cosmosAccount.Name,
             ["cosmosAccountEndpoint"] = cosmosAccount.DocumentEndpoint,
             ["appInsightsConnectionString"] = appInsights.ConnectionString,
-            ["acsConnectionString"] = communicationService.HostName.Apply(h => $"endpoint=https://{h}/"),
+            ["acsConnectionString"] = Output.Tuple(resourceGroup.Name, communicationService.Name)
+                .Apply(names => ListCommunicationServiceKeys.InvokeAsync(new ListCommunicationServiceKeysArgs
+                {
+                    ResourceGroupName = names.Item1,
+                    CommunicationServiceName = names.Item2,
+                }))
+                .Apply(keys => keys.PrimaryConnectionString),
         };
     }
 


### PR DESCRIPTION
## Changes
- **infra/SharedStack.cs**: Use `ListCommunicationServiceKeys` to get `PrimaryConnectionString` instead of constructing an incomplete endpoint-only string. The missing `accesskey` was causing `EmailClient` to throw on startup, crashing the entire dev API container.
- **api/ServiceCollectionExtensions.cs**: Catch `InvalidOperationException` during `AcsEmailSender` construction and fall back to `NoOpEmailSender`, so a malformed connection string degrades email instead of crashing the app.

## Root cause
PR #160 added ACS email support. `SharedStack.cs` output only `endpoint=https://{hostname}/` — missing the `accesskey` keyword. The `EmailClient` constructor validates the connection string eagerly, so the container crashed in a loop (`ActivationFailed`), returning 404 to all requests (which browsers reported as a CORS error since no headers were present).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email service resilience with fallback mechanism for connection failures.
  
* **Chores**
  * Enhanced Azure Communication Services integration with dynamic connection string retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->