### PR TITLE
fix(web): fetch map applications via user authorities

### DIFF
--- a/.claude/require-bead.sh
+++ b/.claude/require-bead.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# PreToolUse hook: block code edits when no bead is in_progress.
+# Ensures every code change — even trivial fixes — is tracked in beads.
+
+file_path=$(jq -r '.tool_input.file_path // empty')
+[ -z "$file_path" ] && exit 0
+
+# Only gate source code files
+case "$file_path" in
+  *.swift|*.cs|*.ts|*.tsx|*.css|*.csproj) ;;
+  *) exit 0 ;;
+esac
+
+# Skip non-project paths (skills, node_modules, build artifacts, beads DB)
+case "$file_path" in
+  */.claude/*|*/node_modules/*|*/bin/*|*/obj/*|*/.beads/*) exit 0 ;;
+esac
+
+# Check for in_progress beads (fast local query)
+count=$(bd list --status=in_progress --flat 2>/dev/null | grep -c '^◐' || true)
+[ "${count:-0}" -gt 0 ] && exit 0
+
+jq -n '{
+  "decision": "block",
+  "reason": "No in-progress bead. ALL code changes must be tracked — even one-line fixes.\n\n  bd create --title=\"<describe the change>\" --type=task --priority=3\n  bd update <id> --claim\n\nThen retry your edit."
+}'

--- a/.claude/require-worktree.sh
+++ b/.claude/require-worktree.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# PreToolUse hook: block code edits outside a git worktree.
+# Ensures isolation when multiple conversations run in parallel.
+
+file_path=$(jq -r '.tool_input.file_path // empty')
+[ -z "$file_path" ] && exit 0
+
+# Only gate source code files
+case "$file_path" in
+  *.swift|*.cs|*.ts|*.tsx|*.css|*.csproj) ;;
+  *) exit 0 ;;
+esac
+
+# Skip non-project paths
+case "$file_path" in
+  */.claude/*|*/node_modules/*|*/bin/*|*/obj/*|*/.beads/*) exit 0 ;;
+esac
+
+# Check 1: file path is under a worktree directory
+[[ "$file_path" == *"/.claude/worktrees/"* ]] && exit 0
+
+# Check 2: session CWD is inside a linked worktree
+# (In a linked worktree, --git-dir contains /worktrees/)
+git_dir=$(git rev-parse --git-dir 2>/dev/null)
+[[ "$git_dir" == *"/worktrees/"* ]] && exit 0
+
+jq -n '{
+  "decision": "block",
+  "reason": "Not in a worktree. Code changes must happen in an isolated worktree to avoid conflicts with parallel sessions.\n\nRun EnterWorktree to create one, then retry your edit."
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,17 @@
       {
         "hooks": [
           {
+            "command": ".claude/require-bead.sh",
+            "statusMessage": "Checking bead ledger...",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": "Write|Edit"
+      },
+      {
+        "hooks": [
+          {
             "command": "jq -r '.tool_input.command' | grep -qE '^git\\s+push' && { branch=$(git rev-parse --abbrev-ref HEAD); if [ \"$branch\" = \"main\" ]; then echo '{\"decision\":\"block\",\"reason\":\"You are on the main branch. Do NOT push directly to main. Instead: 1) Create a new feature branch with git checkout -b <descriptive-branch-name>, 2) Push that branch with git push -u origin <branch-name>, 3) Create a PR using gh pr create.\"}'; fi; } || true",
             "statusMessage": "Checking branch protection...",
             "timeout": 10,

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -56,6 +56,12 @@
       {
         "hooks": [
           {
+            "command": ".claude/require-worktree.sh",
+            "statusMessage": "Checking worktree isolation...",
+            "timeout": 5,
+            "type": "command"
+          },
+          {
             "command": ".claude/require-bead.sh",
             "statusMessage": "Checking bead ledger...",
             "timeout": 10,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,29 @@ Use `bd` for ALL task tracking. Do NOT use TodoWrite, TaskCreate, or markdown fi
 - Do NOT use `bd edit` — it opens an interactive editor that blocks agents
 - Run `bd dolt push` to sync beads to GitHub (separate from `git push`)
 
+### Bead-First Rule
+
+**Every code change requires a bead — no exceptions.** Even a one-line typo fix gets a bead. Beads are the ledger of all work done; if it's not in a bead, it didn't happen.
+
+Before editing any source file (`.swift`, `.cs`, `.ts`, `.tsx`, `.css`, `.csproj`):
+1. `bd create --title="<describe the change>" --type=task --priority=3`
+2. `bd update <id> --claim`
+3. Make your changes
+4. `bd close <id>`
+
+A PreToolUse hook (`.claude/require-bead.sh`) enforces this — Write/Edit on code files is blocked when no bead is in_progress. Do not try to work around it.
+
+### Worktree-First Rule
+
+**All code changes must happen in a worktree — never in the main working tree.** Multiple conversations often run in parallel; editing the main tree causes conflicts.
+
+Before editing code, enter an isolated worktree:
+1. `EnterWorktree` (optionally with a descriptive name)
+2. Make your changes within the worktree
+3. Use the `/ship` skill or `ExitWorktree` when done
+
+A PreToolUse hook (`.claude/require-worktree.sh`) enforces this — Write/Edit on code files is blocked when the session is not inside a worktree. Do not try to work around it.
+
 ### Superpowers Workflow Integration
 
 When using the superpowers brainstorm → plan → execute workflow, beads are the task ledger:

--- a/api/src/town-crier.infrastructure/PlanIt/CachedPlanItAuthorityProvider.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/CachedPlanItAuthorityProvider.cs
@@ -61,22 +61,42 @@ public sealed class CachedPlanItAuthorityProvider : IAuthorityProvider, IDisposa
                 return;
             }
 
-            var url = new Uri("/api/areas/json?pg_sz=500&select=area_id,area_name,area_type,url,planning_url", UriKind.Relative);
-            using var response = await this.httpClient.GetAsync(url, ct).ConfigureAwait(false);
-            response.EnsureSuccessStatusCode();
+            const int pageSize = 100;
+            var allRecords = new List<PlanItAreaRecord>();
+            var page = 1;
+            int fetched;
 
-            var areasResponse = await JsonSerializer.DeserializeAsync(
-                await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false),
-                PlanItJsonSerializerContext.Default.PlanItAreasResponse,
-                ct).ConfigureAwait(false);
+            do
+            {
+                var url = new Uri(
+                    $"/api/areas/json?pg_sz={pageSize}&page={page}&select=area_id,area_name,area_type,url,planning_url",
+                    UriKind.Relative);
+                using var response = await this.httpClient.GetAsync(url, ct).ConfigureAwait(false);
+                response.EnsureSuccessStatusCode();
 
-            if (areasResponse is null)
+                var areasResponse = await JsonSerializer.DeserializeAsync(
+                    await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false),
+                    PlanItJsonSerializerContext.Default.PlanItAreasResponse,
+                    ct).ConfigureAwait(false);
+
+                if (areasResponse is null)
+                {
+                    break;
+                }
+
+                fetched = areasResponse.Records.Count;
+                allRecords.AddRange(areasResponse.Records);
+                page++;
+            }
+            while (fetched >= pageSize);
+
+            if (allRecords.Count == 0)
             {
                 this.cachedAuthorities ??= [];
                 return;
             }
 
-            this.cachedAuthorities = areasResponse.Records
+            this.cachedAuthorities = allRecords
                 .Select(r => new Authority(r.Id, r.Name, r.AreaType, r.CouncilUrl, r.PlanningUrl))
                 .OrderBy(a => a.Name, StringComparer.OrdinalIgnoreCase)
                 .ToList()

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -10,7 +10,7 @@ namespace TownCrier.Infrastructure.PlanIt;
 
 public sealed class PlanItClient : IPlanItClient
 {
-    private const int DefaultPageSize = 5000;
+    private const int DefaultPageSize = 100;
     private const int SearchPageSize = 20;
 
     [SuppressMessage("Security", "CA5394:Do not use insecure randomness", Justification = "Jitter for backoff delay does not require cryptographic randomness")]

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/CachedPlanItAuthorityProviderTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/CachedPlanItAuthorityProviderTests.cs
@@ -1,0 +1,177 @@
+using System.Diagnostics.CodeAnalysis;
+using TownCrier.Infrastructure.PlanIt;
+
+namespace TownCrier.Infrastructure.Tests.PlanIt;
+
+[SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "HttpClient disposes the handler")]
+[SuppressMessage("Minor Code Smell", "S1075:URIs should not be hardcoded", Justification = "Test base address")]
+public sealed class CachedPlanItAuthorityProviderTests
+{
+    private const string BaseUrl = "https://www.planit.org.uk";
+
+    [Test]
+    public async Task Should_ReturnAllAuthorities_When_SinglePageOfResults()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        var json = BuildAreasResponseJson(CreateAreaRecordsJson(3), total: 3);
+        handler.SetupJsonResponse("/api/areas/json", json);
+        using var provider = CreateProvider(handler);
+
+        // Act
+        var authorities = await provider.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(authorities).HasCount().EqualTo(3);
+    }
+
+    [Test]
+    public async Task Should_PaginateThroughAllPages_When_FirstPageIsFull()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+
+        var page1Json = BuildAreasResponseJson(CreateAreaRecordsJson(100), total: 150);
+        handler.SetupJsonResponse("page=1", page1Json);
+
+        var page2Json = BuildAreasResponseJson(CreateAreaRecordsJson(50, startIndex: 100), total: 150);
+        handler.SetupJsonResponse("page=2", page2Json);
+
+        using var provider = CreateProvider(handler);
+
+        // Act
+        var authorities = await provider.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(authorities).HasCount().EqualTo(150);
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task Should_UsePageSizeOf100_When_FetchingAreas()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        var json = BuildAreasResponseJson(CreateAreaRecordsJson(1), total: 1);
+        handler.SetupJsonResponse("/api/areas/json", json);
+        using var provider = CreateProvider(handler);
+
+        // Act
+        await provider.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(1);
+        await Assert.That(handler.RequestUrls[0]).Contains("pg_sz=100");
+        await Assert.That(handler.RequestUrls[0]).DoesNotContain("pg_sz=500");
+    }
+
+    [Test]
+    public async Task Should_StopPaginating_When_PageHasFewerRecordsThanPageSize()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        var json = BuildAreasResponseJson(CreateAreaRecordsJson(50), total: 50);
+        handler.SetupJsonResponse("/api/areas/json", json);
+        using var provider = CreateProvider(handler);
+
+        // Act
+        await provider.GetAllAsync(CancellationToken.None);
+
+        // Assert - only one request made
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_AccumulateRecordsAcrossPages_When_MultiplePagesFetched()
+    {
+        // Arrange - simulate 3 pages: 100 + 100 + 25 = 225 authorities
+        using var handler = new FakePlanItHandler();
+
+        var page1Json = BuildAreasResponseJson(CreateAreaRecordsJson(100), total: 225);
+        handler.SetupJsonResponse("page=1", page1Json);
+
+        var page2Json = BuildAreasResponseJson(CreateAreaRecordsJson(100, startIndex: 100), total: 225);
+        handler.SetupJsonResponse("page=2", page2Json);
+
+        var page3Json = BuildAreasResponseJson(CreateAreaRecordsJson(25, startIndex: 200), total: 225);
+        handler.SetupJsonResponse("page=3", page3Json);
+
+        using var provider = CreateProvider(handler);
+
+        // Act
+        var authorities = await provider.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(authorities).HasCount().EqualTo(225);
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(3);
+    }
+
+    [Test]
+    public async Task Should_IncludePageParameterInUrl_When_Paginating()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+
+        var page1Json = BuildAreasResponseJson(CreateAreaRecordsJson(100), total: 150);
+        handler.SetupJsonResponse("page=1", page1Json);
+
+        var page2Json = BuildAreasResponseJson(CreateAreaRecordsJson(50, startIndex: 100), total: 150);
+        handler.SetupJsonResponse("page=2", page2Json);
+
+        using var provider = CreateProvider(handler);
+
+        // Act
+        await provider.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(handler.RequestUrls[0]).Contains("page=1");
+        await Assert.That(handler.RequestUrls[1]).Contains("page=2");
+    }
+
+    private static CachedPlanItAuthorityProvider CreateProvider(FakePlanItHandler handler)
+    {
+        var httpClient = new HttpClient(handler, disposeHandler: false)
+        {
+            BaseAddress = new Uri(BaseUrl),
+        };
+
+        return new CachedPlanItAuthorityProvider(httpClient, TimeProvider.System);
+    }
+
+    private static string BuildAreasResponseJson(string recordsJson, int total)
+    {
+        return $$"""
+            {
+                "records": {{recordsJson}},
+                "total": {{total}}
+            }
+            """;
+    }
+
+    private static string CreateAreaRecordsJson(int count, int startIndex = 0)
+    {
+        var records = new System.Text.StringBuilder("[");
+        for (var i = 0; i < count; i++)
+        {
+            if (i > 0)
+            {
+                records.Append(',');
+            }
+
+            var index = startIndex + i;
+            var record = $$"""
+                {
+                    "area_name": "Authority {{index}}",
+                    "area_id": {{index}},
+                    "area_type": "London borough",
+                    "url": "https://example.com/{{index}}",
+                    "planning_url": "https://planning.example.com/{{index}}"
+                }
+                """;
+            records.Append(record);
+        }
+
+        records.Append(']');
+        return records.ToString();
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -34,7 +34,7 @@ public sealed class PlanItClientTests
                     "last_different": "2026-03-14T11:59:17.642"
                 }
             ],
-            "pg_sz": 5000,
+            "pg_sz": 100,
             "from": 0,
             "total": 1
         }
@@ -43,7 +43,7 @@ public sealed class PlanItClientTests
     private const string EmptyResponse = """
         {
             "records": [],
-            "pg_sz": 5000,
+            "pg_sz": 100,
             "from": 0,
             "total": 0
         }
@@ -120,12 +120,12 @@ public sealed class PlanItClientTests
         // Arrange
         using var handler = new FakePlanItHandler();
 
-        var page1Records = CreateRecordsJson(5000);
-        var page1Json = BuildResponseJson(page1Records, total: 5500);
+        var page1Records = CreateRecordsJson(100);
+        var page1Json = BuildResponseJson(page1Records, total: 150);
         handler.SetupJsonResponse("page=1", page1Json);
 
-        var page2Records = CreateRecordsJson(500, startIndex: 5000);
-        var page2Json = BuildResponseJson(page2Records, total: 5500, from: 5000);
+        var page2Records = CreateRecordsJson(50, startIndex: 100);
+        var page2Json = BuildResponseJson(page2Records, total: 150, from: 100);
         handler.SetupJsonResponse("page=2", page2Json);
 
         var client = CreateClient(handler);
@@ -134,7 +134,7 @@ public sealed class PlanItClientTests
         var results = await ConsumeAsync(client, differentStart: null);
 
         // Assert
-        await Assert.That(results).HasCount().EqualTo(5500);
+        await Assert.That(results).HasCount().EqualTo(150);
         await Assert.That(handler.RequestUrls).HasCount().EqualTo(2);
         await Assert.That(handler.RequestUrls[0]).Contains("page=1");
         await Assert.That(handler.RequestUrls[1]).Contains("page=2");
@@ -255,7 +255,7 @@ public sealed class PlanItClientTests
         // Act
         await client.SearchApplicationsAsync("car park", 314, 1, CancellationToken.None);
 
-        // Assert — must use 'search=' not 'q=', and pg_sz must be small (not 5000)
+        // Assert — must use 'search=' not 'q=', and pg_sz must be small (not 100)
         await Assert.That(handler.RequestUrls).HasCount().EqualTo(1);
         await Assert.That(handler.RequestUrls[0]).Contains("search=car%20park");
         await Assert.That(handler.RequestUrls[0]).DoesNotContain("&q=");
@@ -304,7 +304,7 @@ public sealed class PlanItClientTests
         return $$$"""
             {
                 "records": {{{recordsJson}}},
-                "pg_sz": 5000,
+                "pg_sz": 100,
                 "from": {{{from}}},
                 "total": {{{total}}}
             }

--- a/web/src/domain/ports/map-port.ts
+++ b/web/src/domain/ports/map-port.ts
@@ -1,6 +1,6 @@
-import type { AuthorityId, PlanningApplication, WatchZoneSummary } from '../types';
+import type { AuthorityId, AuthorityListItem, PlanningApplication } from '../types';
 
 export interface MapPort {
-  fetchWatchZones(): Promise<readonly WatchZoneSummary[]>;
+  fetchMyAuthorities(): Promise<readonly AuthorityListItem[]>;
   fetchApplicationsByAuthority(authorityId: AuthorityId): Promise<readonly PlanningApplication[]>;
 }

--- a/web/src/features/Map/ApiMapAdapter.ts
+++ b/web/src/features/Map/ApiMapAdapter.ts
@@ -1,20 +1,17 @@
 import type { ApiClient } from '../../api/client';
-import type { AuthorityId, PlanningApplication, WatchZoneSummary } from '../../domain/types';
+import type { AuthorityId, AuthorityListItem, PlanningApplication } from '../../domain/types';
 import type { MapPort } from '../../domain/ports/map-port';
-import { watchZonesApi } from '../../api/watchZones';
 import { applicationsApi } from '../../api/applications';
 
 export class ApiMapAdapter implements MapPort {
-  private readonly zones: ReturnType<typeof watchZonesApi>;
   private readonly apps: ReturnType<typeof applicationsApi>;
 
   constructor(client: ApiClient) {
-    this.zones = watchZonesApi(client);
     this.apps = applicationsApi(client);
   }
 
-  async fetchWatchZones(): Promise<readonly WatchZoneSummary[]> {
-    return this.zones.list();
+  async fetchMyAuthorities(): Promise<readonly AuthorityListItem[]> {
+    return this.apps.getMyAuthorities();
   }
 
   async fetchApplicationsByAuthority(authorityId: AuthorityId): Promise<readonly PlanningApplication[]> {

--- a/web/src/features/Map/MapPage.tsx
+++ b/web/src/features/Map/MapPage.tsx
@@ -9,7 +9,7 @@ const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 const OSM_ATTRIBUTION =
   '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
 
-const DEFAULT_CENTER: [number, number] = [51.5074, -0.1278];
+const UK_CENTER: [number, number] = [51.5074, -0.1278];
 const DEFAULT_ZOOM = 13;
 
 interface Props {
@@ -17,7 +17,7 @@ interface Props {
 }
 
 export function MapPage({ port }: Props) {
-  const { zones, applications, isLoading, error } = useMapData(port);
+  const { applications, isLoading, error } = useMapData(port);
 
   if (isLoading) {
     return (
@@ -37,14 +37,14 @@ export function MapPage({ port }: Props) {
     );
   }
 
-  const center: [number, number] =
-    zones.length > 0
-      ? [zones[0]!.latitude, zones[0]!.longitude]
-      : DEFAULT_CENTER;
-
   const markableApplications = applications.filter(
     app => app.latitude !== null && app.longitude !== null,
   );
+
+  const center: [number, number] =
+    markableApplications.length > 0
+      ? [markableApplications[0]!.latitude!, markableApplications[0]!.longitude!]
+      : UK_CENTER;
 
   return (
     <div className={styles.container}>

--- a/web/src/features/Map/__tests__/MapPage.test.tsx
+++ b/web/src/features/Map/__tests__/MapPage.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MapPage } from '../MapPage';
 import { SpyMapPort } from './spies/spy-map-port';
-import { aWatchZone, anApplication } from './fixtures/map.fixtures';
+import { anAuthority, anApplication } from './fixtures/map.fixtures';
 
 // Mock react-leaflet — Leaflet doesn't render in jsdom
 vi.mock('react-leaflet', () => ({
@@ -37,7 +37,7 @@ describe('MapPage', () => {
   });
 
   it('renders map heading and container', async () => {
-    spy.fetchWatchZonesResult = [aWatchZone()];
+    spy.fetchMyAuthoritiesResult = [anAuthority()];
 
     render(
       <MemoryRouter>
@@ -63,7 +63,7 @@ describe('MapPage', () => {
   });
 
   it('renders error state on failure', async () => {
-    spy.fetchWatchZonesError = new Error('Network unavailable');
+    spy.fetchMyAuthoritiesError = new Error('Network unavailable');
 
     render(
       <MemoryRouter>
@@ -77,10 +77,10 @@ describe('MapPage', () => {
   });
 
   it('renders application markers with popups showing summary info', async () => {
-    const zone = aWatchZone();
+    const auth = anAuthority();
     const app = anApplication();
-    spy.fetchWatchZonesResult = [zone];
-    spy.fetchApplicationsByAuthorityResults.set(zone.authorityId as number, [app]);
+    spy.fetchMyAuthoritiesResult = [auth];
+    spy.fetchApplicationsByAuthorityResults.set(auth.id as number, [app]);
 
     render(
       <MemoryRouter>
@@ -101,15 +101,15 @@ describe('MapPage', () => {
   });
 
   it('skips applications without coordinates', async () => {
-    const zone = aWatchZone();
+    const auth = anAuthority();
     const appWithCoords = anApplication();
     const appWithoutCoords = anApplication({
       uid: 'no-coords' as never,
       latitude: null,
       longitude: null,
     });
-    spy.fetchWatchZonesResult = [zone];
-    spy.fetchApplicationsByAuthorityResults.set(zone.authorityId as number, [
+    spy.fetchMyAuthoritiesResult = [auth];
+    spy.fetchApplicationsByAuthorityResults.set(auth.id as number, [
       appWithCoords,
       appWithoutCoords,
     ]);

--- a/web/src/features/Map/__tests__/fixtures/map.fixtures.ts
+++ b/web/src/features/Map/__tests__/fixtures/map.fixtures.ts
@@ -1,26 +1,20 @@
-import type { PlanningApplication, WatchZoneSummary } from '../../../../domain/types';
-import { asWatchZoneId, asAuthorityId, asApplicationUid } from '../../../../domain/types';
+import type { AuthorityListItem, PlanningApplication } from '../../../../domain/types';
+import { asAuthorityId, asApplicationUid } from '../../../../domain/types';
 
-export function aWatchZone(overrides?: Partial<WatchZoneSummary>): WatchZoneSummary {
+export function anAuthority(overrides?: Partial<AuthorityListItem>): AuthorityListItem {
   return {
-    id: asWatchZoneId('zone-1'),
-    name: 'Home',
-    latitude: 52.2053,
-    longitude: 0.1218,
-    radiusMetres: 2000,
-    authorityId: asAuthorityId(1),
+    id: asAuthorityId(1),
+    name: 'Cambridge City Council',
+    areaType: 'District',
     ...overrides,
   };
 }
 
-export function aSecondWatchZone(overrides?: Partial<WatchZoneSummary>): WatchZoneSummary {
+export function aSecondAuthority(overrides?: Partial<AuthorityListItem>): AuthorityListItem {
   return {
-    id: asWatchZoneId('zone-2'),
-    name: 'Office',
-    latitude: 51.5074,
-    longitude: -0.1278,
-    radiusMetres: 5000,
-    authorityId: asAuthorityId(2),
+    id: asAuthorityId(2),
+    name: 'Westminster City Council',
+    areaType: 'London Borough',
     ...overrides,
   };
 }

--- a/web/src/features/Map/__tests__/spies/spy-map-port.ts
+++ b/web/src/features/Map/__tests__/spies/spy-map-port.ts
@@ -1,17 +1,17 @@
-import type { AuthorityId, PlanningApplication, WatchZoneSummary } from '../../../../domain/types';
+import type { AuthorityId, AuthorityListItem, PlanningApplication } from '../../../../domain/types';
 import type { MapPort } from '../../../../domain/ports/map-port';
 
 export class SpyMapPort implements MapPort {
-  fetchWatchZonesCalls = 0;
-  fetchWatchZonesResult: readonly WatchZoneSummary[] = [];
-  fetchWatchZonesError: Error | null = null;
+  fetchMyAuthoritiesCalls = 0;
+  fetchMyAuthoritiesResult: readonly AuthorityListItem[] = [];
+  fetchMyAuthoritiesError: Error | null = null;
 
-  async fetchWatchZones(): Promise<readonly WatchZoneSummary[]> {
-    this.fetchWatchZonesCalls++;
-    if (this.fetchWatchZonesError) {
-      throw this.fetchWatchZonesError;
+  async fetchMyAuthorities(): Promise<readonly AuthorityListItem[]> {
+    this.fetchMyAuthoritiesCalls++;
+    if (this.fetchMyAuthoritiesError) {
+      throw this.fetchMyAuthoritiesError;
     }
-    return this.fetchWatchZonesResult;
+    return this.fetchMyAuthoritiesResult;
   }
 
   fetchApplicationsByAuthorityCalls: AuthorityId[] = [];

--- a/web/src/features/Map/__tests__/useMapData.test.ts
+++ b/web/src/features/Map/__tests__/useMapData.test.ts
@@ -2,15 +2,15 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
 import { useMapData } from '../useMapData';
 import { SpyMapPort } from './spies/spy-map-port';
-import { aWatchZone, aSecondWatchZone, anApplication, aSecondApplication } from './fixtures/map.fixtures';
+import { anAuthority, aSecondAuthority, anApplication, aSecondApplication } from './fixtures/map.fixtures';
 import { asAuthorityId } from '../../../domain/types';
 
 describe('useMapData', () => {
-  it('fetches watch zones and applications per zone authority', async () => {
+  it('fetches authorities and applications per authority', async () => {
     const spy = new SpyMapPort();
-    const zone1 = aWatchZone();
-    const zone2 = aSecondWatchZone();
-    spy.fetchWatchZonesResult = [zone1, zone2];
+    const auth1 = anAuthority();
+    const auth2 = aSecondAuthority();
+    spy.fetchMyAuthoritiesResult = [auth1, auth2];
 
     const app1 = anApplication();
     const app2 = aSecondApplication();
@@ -23,17 +23,16 @@ describe('useMapData', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.zones).toEqual([zone1, zone2]);
     expect(result.current.applications).toEqual([app1, app2]);
     expect(result.current.error).toBeNull();
-    expect(spy.fetchWatchZonesCalls).toBe(1);
+    expect(spy.fetchMyAuthoritiesCalls).toBe(1);
     expect(spy.fetchApplicationsByAuthorityCalls).toContainEqual(asAuthorityId(1));
     expect(spy.fetchApplicationsByAuthorityCalls).toContainEqual(asAuthorityId(2));
   });
 
-  it('sets error state when watch zone fetch fails', async () => {
+  it('sets error state when authority fetch fails', async () => {
     const spy = new SpyMapPort();
-    spy.fetchWatchZonesError = new Error('Network unavailable');
+    spy.fetchMyAuthoritiesError = new Error('Network unavailable');
 
     const { result } = renderHook(() => useMapData(spy));
 
@@ -42,28 +41,25 @@ describe('useMapData', () => {
     });
 
     expect(result.current.error).toBe('Network unavailable');
-    expect(result.current.zones).toEqual([]);
     expect(result.current.applications).toEqual([]);
   });
 
   it('returns loading state while fetching', () => {
     const spy = new SpyMapPort();
-    // Don't resolve the promise — keep it pending
-    spy.fetchWatchZonesResult = [];
+    spy.fetchMyAuthoritiesResult = [];
 
     const { result } = renderHook(() => useMapData(spy));
 
     expect(result.current.isLoading).toBe(true);
-    expect(result.current.zones).toEqual([]);
     expect(result.current.applications).toEqual([]);
     expect(result.current.error).toBeNull();
   });
 
-  it('deduplicates authority IDs across zones', async () => {
+  it('deduplicates authority IDs', async () => {
     const spy = new SpyMapPort();
-    const zone1 = aWatchZone({ authorityId: asAuthorityId(1) });
-    const zone2 = aSecondWatchZone({ authorityId: asAuthorityId(1) });
-    spy.fetchWatchZonesResult = [zone1, zone2];
+    const auth1 = anAuthority({ id: asAuthorityId(1) });
+    const auth2 = aSecondAuthority({ id: asAuthorityId(1) });
+    spy.fetchMyAuthoritiesResult = [auth1, auth2];
 
     const app1 = anApplication();
     spy.fetchApplicationsByAuthorityResults.set(1, [app1]);
@@ -74,7 +70,6 @@ describe('useMapData', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    // Should only call fetchApplicationsByAuthority once for the shared authority
     expect(spy.fetchApplicationsByAuthorityCalls).toHaveLength(1);
     expect(spy.fetchApplicationsByAuthorityCalls[0]).toEqual(asAuthorityId(1));
   });

--- a/web/src/features/Map/useMapData.ts
+++ b/web/src/features/Map/useMapData.ts
@@ -1,31 +1,23 @@
-import type { PlanningApplication, WatchZoneSummary } from '../../domain/types';
+import type { PlanningApplication } from '../../domain/types';
 import type { MapPort } from '../../domain/ports/map-port';
 import { useFetchData } from '../../hooks/useFetchData';
 
-interface MapData {
-  zones: readonly WatchZoneSummary[];
-  applications: readonly PlanningApplication[];
-}
-
 export function useMapData(port: MapPort) {
-  const { data, isLoading, error, refresh } = useFetchData<MapData>(
+  const { data, isLoading, error, refresh } = useFetchData<readonly PlanningApplication[]>(
     async () => {
-      const zones = await port.fetchWatchZones();
+      const authorities = await port.fetchMyAuthorities();
 
-      const uniqueAuthorityIds = [...new Set(zones.map(z => z.authorityId))];
+      const uniqueAuthorityIds = [...new Set(authorities.map(a => a.id))];
       const applicationArrays = await Promise.all(
         uniqueAuthorityIds.map(id => port.fetchApplicationsByAuthority(id)),
       );
-      const applications = applicationArrays.flat();
-
-      return { zones, applications };
+      return applicationArrays.flat();
     },
     [port],
   );
 
   return {
-    zones: data?.zones ?? [],
-    applications: data?.applications ?? [],
+    applications: data ?? [],
     isLoading,
     error,
     refresh,


### PR DESCRIPTION
## Changes
- **Map fix:** Replaced watch-zone-based data fetching with user-authorities approach — the map now calls `GET /v1/me/application-authorities` (same as the applications page) instead of depending on watch zones to derive authority IDs. This fixes the bug where no pins appeared when the user had no watch zones.
- **Map centering:** Map now centers on the first application with coordinates instead of the first watch zone.
- **PlanIt pagination:** Authority provider now paginates at 100 per page instead of requesting all 500 at once. Application client page size reduced from 5000 to 100.
- **Hook config:** Added bead-ledger check hook for Write/Edit operations.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized backend retrieval process for planning applications and authorities to improve data loading efficiency and responsiveness when handling large datasets.

* **Map Feature Updates**
  * Map functionality now uses authorities instead of watch zones for positioning and data fetching.
  * Enhanced map center selection to prioritize authorities with available geographic coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->