### PR TITLE
fix(web): resolve broken Leaflet marker icons

### DIFF
--- a/web/src/features/Map/MapPage.tsx
+++ b/web/src/features/Map/MapPage.tsx
@@ -1,9 +1,19 @@
+import L from 'leaflet';
+import iconUrl from 'leaflet/dist/images/marker-icon.png';
+import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
 import { Link } from 'react-router-dom';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import type { MapPort } from '../../domain/ports/map-port';
 import { useMapData } from './useMapData';
 import styles from './MapPage.module.css';
 import 'leaflet/dist/leaflet.css';
+
+L.Icon.Default.mergeOptions({
+  iconUrl,
+  iconRetinaUrl,
+  shadowUrl,
+});
 
 const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 const OSM_ATTRIBUTION =


### PR DESCRIPTION
## Summary
- Leaflet's default marker icon URLs aren't resolved by Vite's bundler, causing map pins to render as "?" placeholder images
- Explicitly import marker icon assets (`marker-icon.png`, `marker-icon-2x.png`, `marker-shadow.png`) and configure `L.Icon.Default` so Vite processes them correctly

## Test plan
- [ ] Open the map page and verify markers display as proper blue teardrop pins
- [ ] Verify marker popups still work (description, address, "View details" link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed map marker icons to display properly with bundled image assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->