### PR TITLE
feat: polling resilience — throttle, per-authority save, 429 handling, OTel flush, hourly cron

### DIFF
--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -42,6 +42,7 @@ public sealed class PollPlanItCommandHandler
         var authorityIds = await this.activeAuthorityProvider.GetActiveAuthorityIdsAsync(ct).ConfigureAwait(false);
 
         var count = 0;
+        var authoritiesPolled = 0;
         foreach (var authorityId in authorityIds)
         {
             using var authorityActivity = PollingInstrumentation.Source.StartActivity("Poll Authority");
@@ -71,12 +72,12 @@ public sealed class PollPlanItCommandHandler
             PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
             PollingMetrics.ApplicationsIngested.Add(authorityAppCount);
             authorityActivity?.SetTag("polling.applications_found", authorityAppCount);
+
+            PollingMetrics.AuthoritiesPolled.Add(1);
+            await this.pollStateStore.SaveLastPollTimeAsync(now, ct).ConfigureAwait(false);
+            authoritiesPolled++;
         }
 
-        PollingMetrics.AuthoritiesPolled.Add(authorityIds.Count);
-
-        await this.pollStateStore.SaveLastPollTimeAsync(now, ct).ConfigureAwait(false);
-
-        return new PollPlanItResult(count, authorityIds.Count);
+        return new PollPlanItResult(count, authoritiesPolled);
     }
 }

--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Net;
+using Microsoft.Extensions.Logging;
 using TownCrier.Application.Observability;
 using TownCrier.Application.PlanIt;
 using TownCrier.Application.PlanningApplications;
@@ -6,7 +8,7 @@ using TownCrier.Application.WatchZones;
 
 namespace TownCrier.Application.Polling;
 
-public sealed class PollPlanItCommandHandler
+public sealed partial class PollPlanItCommandHandler
 {
     private readonly IPlanItClient planItClient;
     private readonly IPollStateStore pollStateStore;
@@ -15,6 +17,7 @@ public sealed class PollPlanItCommandHandler
     private readonly IActiveAuthorityProvider activeAuthorityProvider;
     private readonly IWatchZoneRepository watchZoneRepository;
     private readonly INotificationEnqueuer notificationEnqueuer;
+    private readonly ILogger<PollPlanItCommandHandler> logger;
 
     public PollPlanItCommandHandler(
         IPlanItClient planItClient,
@@ -23,7 +26,8 @@ public sealed class PollPlanItCommandHandler
         TimeProvider timeProvider,
         IActiveAuthorityProvider activeAuthorityProvider,
         IWatchZoneRepository watchZoneRepository,
-        INotificationEnqueuer notificationEnqueuer)
+        INotificationEnqueuer notificationEnqueuer,
+        ILogger<PollPlanItCommandHandler> logger)
     {
         this.planItClient = planItClient;
         this.pollStateStore = pollStateStore;
@@ -32,6 +36,7 @@ public sealed class PollPlanItCommandHandler
         this.activeAuthorityProvider = activeAuthorityProvider;
         this.watchZoneRepository = watchZoneRepository;
         this.notificationEnqueuer = notificationEnqueuer;
+        this.logger = logger;
     }
 
     public async Task<PollPlanItResult> HandleAsync(PollPlanItCommand command, CancellationToken ct)
@@ -43,41 +48,64 @@ public sealed class PollPlanItCommandHandler
 
         var count = 0;
         var authoritiesPolled = 0;
+        var rateLimitHitCount = 0;
         foreach (var authorityId in authorityIds)
         {
             using var authorityActivity = PollingInstrumentation.Source.StartActivity("Poll Authority");
             authorityActivity?.SetTag("polling.authority_code", authorityId);
             var authorityStart = Stopwatch.GetTimestamp();
 
-            var authorityAppCount = 0;
-            await foreach (var application in this.planItClient.FetchApplicationsAsync(authorityId, lastPollTime, ct).ConfigureAwait(false))
+            try
             {
-                await this.applicationRepository.UpsertAsync(application, ct).ConfigureAwait(false);
-
-                if (application.Latitude.HasValue && application.Longitude.HasValue)
+                var authorityAppCount = 0;
+                await foreach (var application in this.planItClient.FetchApplicationsAsync(authorityId, lastPollTime, ct).ConfigureAwait(false))
                 {
-                    var matchingZones = await this.watchZoneRepository.FindZonesContainingAsync(
-                        application.Latitude.Value, application.Longitude.Value, ct).ConfigureAwait(false);
+                    await this.applicationRepository.UpsertAsync(application, ct).ConfigureAwait(false);
 
-                    foreach (var zone in matchingZones)
+                    if (application.Latitude.HasValue && application.Longitude.HasValue)
                     {
-                        await this.notificationEnqueuer.EnqueueAsync(application, zone, ct).ConfigureAwait(false);
+                        var matchingZones = await this.watchZoneRepository.FindZonesContainingAsync(
+                            application.Latitude.Value, application.Longitude.Value, ct).ConfigureAwait(false);
+
+                        foreach (var zone in matchingZones)
+                        {
+                            await this.notificationEnqueuer.EnqueueAsync(application, zone, ct).ConfigureAwait(false);
+                        }
                     }
+
+                    authorityAppCount++;
+                    count++;
                 }
 
-                authorityAppCount++;
-                count++;
+                PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
+                PollingMetrics.ApplicationsIngested.Add(authorityAppCount);
+                authorityActivity?.SetTag("polling.applications_found", authorityAppCount);
+
+                PollingMetrics.AuthoritiesPolled.Add(1);
+                await this.pollStateStore.SaveLastPollTimeAsync(now, ct).ConfigureAwait(false);
+                authoritiesPolled++;
             }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                rateLimitHitCount++;
+                PollingMetrics.AuthoritiesSkipped.Add(1);
 
-            PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
-            PollingMetrics.ApplicationsIngested.Add(authorityAppCount);
-            authorityActivity?.SetTag("polling.applications_found", authorityAppCount);
+                if (rateLimitHitCount >= 2)
+                {
+                    LogRateLimitBreak(this.logger, authorityId, ex);
+                    break;
+                }
 
-            PollingMetrics.AuthoritiesPolled.Add(1);
-            await this.pollStateStore.SaveLastPollTimeAsync(now, ct).ConfigureAwait(false);
-            authoritiesPolled++;
+                LogRateLimitSkip(this.logger, authorityId, ex);
+            }
         }
 
         return new PollPlanItResult(count, authoritiesPolled);
     }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Rate limited polling authority {AuthorityId}, skipping to next authority")]
+    private static partial void LogRateLimitSkip(ILogger logger, int authorityId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Rate limited polling authority {AuthorityId} (second consecutive 429), stopping polling cycle")]
+    private static partial void LogRateLimitBreak(ILogger logger, int authorityId, Exception exception);
 }

--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -89,6 +89,7 @@ public sealed partial class PollPlanItCommandHandler
             {
                 rateLimitHitCount++;
                 PollingMetrics.AuthoritiesSkipped.Add(1);
+                PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
 
                 if (rateLimitHitCount >= 2)
                 {
@@ -106,6 +107,6 @@ public sealed partial class PollPlanItCommandHandler
     [LoggerMessage(Level = LogLevel.Warning, Message = "Rate limited polling authority {AuthorityId}, skipping to next authority")]
     private static partial void LogRateLimitSkip(ILogger logger, int authorityId, Exception exception);
 
-    [LoggerMessage(Level = LogLevel.Error, Message = "Rate limited polling authority {AuthorityId} (second consecutive 429), stopping polling cycle")]
+    [LoggerMessage(Level = LogLevel.Error, Message = "Rate limited polling authority {AuthorityId} (second 429 this cycle), stopping polling cycle")]
     private static partial void LogRateLimitBreak(ILogger logger, int authorityId, Exception exception);
 }

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -149,7 +149,10 @@ public sealed class PlanItClient : IPlanItClient
 
     private async Task<HttpResponseMessage> SendWithRetryAsync(Uri url, CancellationToken ct)
     {
-        _ = this.throttleOptions;
+        if (this.throttleOptions.DelayBetweenRequests > TimeSpan.Zero)
+        {
+            await this.delayFunc(this.throttleOptions.DelayBetweenRequests, ct).ConfigureAwait(false);
+        }
 
         for (var attempt = 0; attempt <= this.retryOptions.MaxRetries; attempt++)
         {

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -149,13 +149,13 @@ public sealed class PlanItClient : IPlanItClient
 
     private async Task<HttpResponseMessage> SendWithRetryAsync(Uri url, CancellationToken ct)
     {
-        if (this.throttleOptions.DelayBetweenRequests > TimeSpan.Zero)
-        {
-            await this.delayFunc(this.throttleOptions.DelayBetweenRequests, ct).ConfigureAwait(false);
-        }
-
         for (var attempt = 0; attempt <= this.retryOptions.MaxRetries; attempt++)
         {
+            if (this.throttleOptions.DelayBetweenRequests > TimeSpan.Zero)
+            {
+                await this.delayFunc(this.throttleOptions.DelayBetweenRequests, ct).ConfigureAwait(false);
+            }
+
             var response = await this.httpClient.GetAsync(url, ct).ConfigureAwait(false);
 
             if (response.StatusCode != (HttpStatusCode)429)

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -18,15 +18,18 @@ public sealed class PlanItClient : IPlanItClient
 
     private readonly HttpClient httpClient;
     private readonly PlanItRetryOptions retryOptions;
+    private readonly PlanItThrottleOptions throttleOptions;
     private readonly Func<TimeSpan, CancellationToken, Task> delayFunc;
 
     public PlanItClient(
         HttpClient httpClient,
         PlanItRetryOptions? retryOptions = null,
+        PlanItThrottleOptions? throttleOptions = null,
         Func<TimeSpan, CancellationToken, Task>? delayFunc = null)
     {
         this.httpClient = httpClient;
         this.retryOptions = retryOptions ?? new PlanItRetryOptions();
+        this.throttleOptions = throttleOptions ?? new PlanItThrottleOptions();
         this.delayFunc = delayFunc ?? Task.Delay;
     }
 
@@ -146,6 +149,8 @@ public sealed class PlanItClient : IPlanItClient
 
     private async Task<HttpResponseMessage> SendWithRetryAsync(Uri url, CancellationToken ct)
     {
+        _ = this.throttleOptions;
+
         for (var attempt = 0; attempt <= this.retryOptions.MaxRetries; attempt++)
         {
             var response = await this.httpClient.GetAsync(url, ct).ConfigureAwait(false);

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItThrottleOptions.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItThrottleOptions.cs
@@ -1,0 +1,6 @@
+namespace TownCrier.Infrastructure.PlanIt;
+
+public sealed record PlanItThrottleOptions
+{
+    public TimeSpan DelayBetweenRequests { get; init; } = TimeSpan.FromSeconds(1);
+}

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -62,6 +62,7 @@ builder.Services.AddSingleton(TimeProvider.System);
 #pragma warning disable S1075 // Hardcoded URI is a sensible default
 var planItBaseUrl = builder.Configuration["PlanIt:BaseUrl"] ?? "https://www.planit.org.uk/";
 #pragma warning restore S1075
+builder.Services.AddSingleton(new PlanItThrottleOptions());
 builder.Services.AddHttpClient<IPlanItClient, PlanItClient>(client =>
 {
     client.BaseAddress = new Uri(planItBaseUrl);

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -62,7 +62,6 @@ builder.Services.AddSingleton(TimeProvider.System);
 #pragma warning disable S1075 // Hardcoded URI is a sensible default
 var planItBaseUrl = builder.Configuration["PlanIt:BaseUrl"] ?? "https://www.planit.org.uk/";
 #pragma warning restore S1075
-builder.Services.AddSingleton(new PlanItThrottleOptions());
 builder.Services.AddHttpClient<IPlanItClient, PlanItClient>(client =>
 {
     client.BaseAddress = new Uri(planItBaseUrl);

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -74,6 +74,8 @@ using var host = builder.Build();
 var handler = host.Services.GetRequiredService<PollPlanItCommandHandler>();
 var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("TownCrier.Worker");
 
+var exitCode = 0;
+
 try
 {
     using var activity = PollingInstrumentation.Source.StartActivity("Polling Cycle");
@@ -90,8 +92,6 @@ try
     activity?.SetTag("polling.applications_ingested", result.ApplicationCount);
 
     WorkerLog.PollCycleCompleted(logger, result.ApplicationCount, result.AuthoritiesPolled);
-
-    return 0;
 }
 #pragma warning disable CA1031 // Worker must return exit code on any failure
 catch (Exception ex)
@@ -99,5 +99,32 @@ catch (Exception ex)
 {
     PollingMetrics.PollFailures.Add(1);
     WorkerLog.PollCycleFailed(logger, ex);
-    return 1;
+    exitCode = 1;
 }
+
+// Force-flush OpenTelemetry before the short-lived process exits.
+// The Azure Monitor exporter batches on ~30 s intervals; without this,
+// the worker terminates before the first batch window.
+try
+{
+    host.Services.GetService<MeterProvider>()?.ForceFlush(timeoutMilliseconds: 10_000);
+}
+#pragma warning disable CA1031 // Flush failure must not mask the original error
+catch (Exception)
+{
+    // Intentionally swallowed — flush failure must not mask the original exit code.
+}
+#pragma warning restore CA1031
+
+try
+{
+    host.Services.GetService<TracerProvider>()?.ForceFlush(timeoutMilliseconds: 10_000);
+}
+#pragma warning disable CA1031 // Flush failure must not mask the original error
+catch (Exception)
+{
+    // Intentionally swallowed — flush failure must not mask the original exit code.
+}
+#pragma warning restore CA1031
+
+return exitCode;

--- a/api/tests/town-crier.application.tests/Polling/FakePlanItClient.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakePlanItClient.cs
@@ -6,6 +6,7 @@ namespace TownCrier.Application.Tests.Polling;
 internal sealed class FakePlanItClient : IPlanItClient
 {
     private readonly Dictionary<int, List<PlanningApplication>> applicationsByAuthority = [];
+    private readonly Dictionary<int, Exception> exceptionsByAuthority = [];
     private readonly List<PlanningApplication> searchResults = [];
 
     public DateTimeOffset? LastDifferentStartUsed { get; private set; }
@@ -23,6 +24,11 @@ internal sealed class FakePlanItClient : IPlanItClient
     public void AddSearchResult(PlanningApplication application)
     {
         this.searchResults.Add(application);
+    }
+
+    public void ThrowForAuthority(int authorityId, Exception exception)
+    {
+        this.exceptionsByAuthority[authorityId] = exception;
     }
 
     public void Add(int authorityId, PlanningApplication application)
@@ -48,6 +54,11 @@ internal sealed class FakePlanItClient : IPlanItClient
     {
         this.LastDifferentStartUsed = differentStart;
         this.AuthorityIdsRequested.Add(authorityId);
+
+        if (this.exceptionsByAuthority.TryGetValue(authorityId, out var authorityException))
+        {
+            throw authorityException;
+        }
 
         if (this.ExceptionToThrow is not null)
         {

--- a/api/tests/town-crier.application.tests/Polling/FakePollStateStore.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakePollStateStore.cs
@@ -6,6 +6,8 @@ internal sealed class FakePollStateStore : IPollStateStore
 {
     public DateTimeOffset? LastPollTime { get; private set; }
 
+    public int SaveCallCount { get; private set; }
+
     public void SetLastPollTime(DateTimeOffset pollTime)
     {
         this.LastPollTime = pollTime;
@@ -19,6 +21,7 @@ internal sealed class FakePollStateStore : IPollStateStore
     public Task SaveLastPollTimeAsync(DateTimeOffset pollTime, CancellationToken ct)
     {
         this.LastPollTime = pollTime;
+        this.SaveCallCount++;
         return Task.CompletedTask;
     }
 }

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -228,6 +228,41 @@ public sealed class PollPlanItCommandHandlerTests
     }
 
     [Test]
+    public async Task Should_PreserveProgressForCompletedAuthorities_When_LaterAuthorityFails()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+        authorityProvider.Add(300);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.Add(300, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(300).Build());
+        planItClient.ThrowForAuthority(200, new HttpRequestException("rate limited"));
+
+        var pollStateStore = new FakePollStateStore();
+        var fakeTime = new DateTimeOffset(2026, 4, 5, 12, 0, 0, TimeSpan.Zero);
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            pollStateStore: pollStateStore,
+            authorityProvider: authorityProvider,
+            timeProvider: new FakeTimeProvider(fakeTime));
+
+        try
+        {
+            await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+        }
+        catch (HttpRequestException)
+        {
+            // expected — authority 200 fails
+        }
+
+        // Authority 100 completed before the failure, so poll state should be saved
+        await Assert.That(pollStateStore.SaveCallCount).IsEqualTo(1);
+        await Assert.That(pollStateStore.LastPollTime).IsEqualTo(fakeTime);
+    }
+
+    [Test]
     public async Task Should_NotSavePollState_When_PollFails()
     {
         var authorityProvider = new FakeActiveAuthorityProvider();

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using TownCrier.Application.Polling;
 
 namespace TownCrier.Application.Tests.Polling;
@@ -274,6 +275,27 @@ public sealed class PollPlanItCommandHandlerTests
             () => handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None));
 
         await Assert.That(pollStateStore.LastPollTime).IsNull();
+    }
+
+    [Test]
+    public async Task Should_SkipAuthorityAndContinue_When_FirstRateLimitHit()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+        authorityProvider.Add(300);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.ThrowForAuthority(200, new HttpRequestException("Rate limited", null, HttpStatusCode.TooManyRequests));
+        planItClient.Add(300, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(300).Build());
+
+        var handler = CreateHandler(planItClient: planItClient, authorityProvider: authorityProvider);
+
+        var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(result.ApplicationCount).IsEqualTo(2);
+        await Assert.That(result.AuthoritiesPolled).IsEqualTo(2);
     }
 
     private static PollPlanItCommandHandler CreateHandler(

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -185,6 +185,30 @@ public sealed class PollPlanItCommandHandlerTests
     }
 
     [Test]
+    public async Task Should_SavePollStateAfterEachAuthority_When_MultipleAuthoritiesPolled()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+        authorityProvider.Add(300);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.Add(200, new PlanningApplicationBuilder().WithUid("app-2").WithAreaId(200).Build());
+        planItClient.Add(300, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(300).Build());
+
+        var pollStateStore = new FakePollStateStore();
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            pollStateStore: pollStateStore,
+            authorityProvider: authorityProvider);
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(pollStateStore.SaveCallCount).IsEqualTo(3);
+    }
+
+    [Test]
     public async Task Should_RethrowException_When_PlanItFails()
     {
         var authorityProvider = new FakeActiveAuthorityProvider();

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -104,9 +104,15 @@ public sealed class PollPlanItCommandHandlerTests
     [Test]
     public async Task Should_PersistCurrentTime_When_PollSucceeds()
     {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(1);
+
         var pollStateStore = new FakePollStateStore();
         var fakeTime = new DateTimeOffset(2026, 3, 16, 12, 0, 0, TimeSpan.Zero);
-        var handler = CreateHandler(pollStateStore: pollStateStore, timeProvider: new FakeTimeProvider(fakeTime));
+        var handler = CreateHandler(
+            pollStateStore: pollStateStore,
+            authorityProvider: authorityProvider,
+            timeProvider: new FakeTimeProvider(fakeTime));
 
         await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
 

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -299,6 +299,50 @@ public sealed class PollPlanItCommandHandlerTests
         await Assert.That(result.AuthoritiesPolled).IsEqualTo(2);
     }
 
+    [Test]
+    public async Task Should_BreakLoop_When_SecondRateLimitHit()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+        authorityProvider.Add(300);
+        authorityProvider.Add(400);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.ThrowForAuthority(200, new HttpRequestException("Rate limited", null, HttpStatusCode.TooManyRequests));
+        planItClient.ThrowForAuthority(300, new HttpRequestException("Rate limited", null, HttpStatusCode.TooManyRequests));
+        planItClient.Add(400, new PlanningApplicationBuilder().WithUid("app-4").WithAreaId(400).Build());
+
+        var handler = CreateHandler(planItClient: planItClient, authorityProvider: authorityProvider);
+
+        var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        // Only authority 100 completed before two 429s stopped the loop
+        await Assert.That(result.ApplicationCount).IsEqualTo(1);
+        await Assert.That(result.AuthoritiesPolled).IsEqualTo(1);
+
+        // Authority 400 was never attempted
+        await Assert.That(planItClient.AuthorityIdsRequested).DoesNotContain(400);
+    }
+
+    [Test]
+    public async Task Should_PropagateException_When_NonRateLimitHttpError()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.ThrowForAuthority(200, new HttpRequestException("Internal Server Error", null, HttpStatusCode.InternalServerError));
+
+        var handler = CreateHandler(planItClient: planItClient, authorityProvider: authorityProvider);
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None));
+    }
+
     private static PollPlanItCommandHandler CreateHandler(
         FakePlanItClient? planItClient = null,
         FakePollStateStore? pollStateStore = null,

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -117,6 +117,7 @@ public sealed class PollPlanItCommandHandlerTests
         await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
 
         await Assert.That(pollStateStore.LastPollTime).IsEqualTo(fakeTime);
+        await Assert.That(pollStateStore.SaveCallCount).IsEqualTo(1);
     }
 
     [Test]
@@ -248,14 +249,8 @@ public sealed class PollPlanItCommandHandlerTests
             authorityProvider: authorityProvider,
             timeProvider: new FakeTimeProvider(fakeTime));
 
-        try
-        {
-            await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
-        }
-        catch (HttpRequestException)
-        {
-            // expected — authority 200 fails
-        }
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None));
 
         // Authority 100 completed before the failure, so poll state should be saved
         await Assert.That(pollStateStore.SaveCallCount).IsEqualTo(1);
@@ -275,14 +270,8 @@ public sealed class PollPlanItCommandHandlerTests
             pollStateStore: pollStateStore,
             authorityProvider: authorityProvider);
 
-        try
-        {
-            await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
-        }
-        catch (HttpRequestException)
-        {
-            // expected
-        }
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None));
 
         await Assert.That(pollStateStore.LastPollTime).IsNull();
     }

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
 using TownCrier.Application.Polling;
 
 namespace TownCrier.Application.Tests.Polling;
@@ -314,6 +315,7 @@ public sealed class PollPlanItCommandHandlerTests
             timeProvider ?? TimeProvider.System,
             authorityProvider ?? new FakeActiveAuthorityProvider(),
             watchZoneRepository ?? new FakeWatchZoneRepository(),
-            notificationEnqueuer ?? new FakeNotificationEnqueuer());
+            notificationEnqueuer ?? new FakeNotificationEnqueuer(),
+            NullLogger<PollPlanItCommandHandler>.Instance);
     }
 }

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -354,6 +354,12 @@ public sealed class PlanItClientTests
             BaseAddress = new Uri(BaseUrl),
         };
 
+        // When tracking backoff delays but not throttle delays, disable throttle
+        // so throttle delays don't pollute the backoff delay list.
+        throttleOptions ??= delays is not null && throttleDelays is null
+            ? new PlanItThrottleOptions { DelayBetweenRequests = TimeSpan.Zero }
+            : new PlanItThrottleOptions();
+
         Func<TimeSpan, CancellationToken, Task>? delayFunc = null;
         if (delays is not null || throttleDelays is not null)
         {

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -262,10 +262,92 @@ public sealed class PlanItClientTests
         await Assert.That(handler.RequestUrls[0]).Contains("pg_sz=20");
     }
 
+    [Test]
+    public async Task Should_DelayBeforeEachRequest_When_ThrottleConfigured()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupJsonResponse("page=1", SingleRecordResponse);
+        var throttleDelays = new List<TimeSpan>();
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequests = TimeSpan.FromMilliseconds(500) };
+        var client = CreateClient(handler, throttleOptions: throttleOptions, throttleDelays: throttleDelays);
+
+        // Act
+        await ConsumeAsync(client, differentStart: null);
+
+        // Assert — one throttle delay before the single request
+        await Assert.That(throttleDelays).HasCount().EqualTo(1);
+        await Assert.That(throttleDelays[0]).IsEqualTo(TimeSpan.FromMilliseconds(500));
+    }
+
+    [Test]
+    public async Task Should_DelayBeforeEachPageRequest_When_Paginating()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+
+        var page1Records = CreateRecordsJson(100);
+        var page1Json = BuildResponseJson(page1Records, total: 150);
+        handler.SetupJsonResponse("page=1", page1Json);
+
+        var page2Records = CreateRecordsJson(50, startIndex: 100);
+        var page2Json = BuildResponseJson(page2Records, total: 150, from: 100);
+        handler.SetupJsonResponse("page=2", page2Json);
+
+        var throttleDelays = new List<TimeSpan>();
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequests = TimeSpan.FromMilliseconds(200) };
+        var client = CreateClient(handler, throttleOptions: throttleOptions, throttleDelays: throttleDelays);
+
+        // Act
+        await ConsumeAsync(client, differentStart: null);
+
+        // Assert — one throttle delay per page (2 pages = 2 delays)
+        await Assert.That(throttleDelays).HasCount().EqualTo(2);
+        await Assert.That(throttleDelays[0]).IsEqualTo(TimeSpan.FromMilliseconds(200));
+        await Assert.That(throttleDelays[1]).IsEqualTo(TimeSpan.FromMilliseconds(200));
+    }
+
+    [Test]
+    public async Task Should_DelayBeforeSearchRequest_When_ThrottleConfigured()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupJsonResponse("/api/applics/json", SingleRecordResponse);
+        var throttleDelays = new List<TimeSpan>();
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequests = TimeSpan.FromMilliseconds(300) };
+        var client = CreateClient(handler, throttleOptions: throttleOptions, throttleDelays: throttleDelays);
+
+        // Act
+        await client.SearchApplicationsAsync("car park", 314, 1, CancellationToken.None);
+
+        // Assert — one throttle delay before the search request
+        await Assert.That(throttleDelays).HasCount().EqualTo(1);
+        await Assert.That(throttleDelays[0]).IsEqualTo(TimeSpan.FromMilliseconds(300));
+    }
+
+    [Test]
+    public async Task Should_UseDefaultOneSecondDelay_When_NoThrottleOptionsProvided()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupJsonResponse("page=1", SingleRecordResponse);
+        var throttleDelays = new List<TimeSpan>();
+        var client = CreateClient(handler, throttleDelays: throttleDelays);
+
+        // Act
+        await ConsumeAsync(client, differentStart: null);
+
+        // Assert — default 1s throttle delay
+        await Assert.That(throttleDelays).HasCount().EqualTo(1);
+        await Assert.That(throttleDelays[0]).IsEqualTo(TimeSpan.FromSeconds(1));
+    }
+
     private static PlanItClient CreateClient(
         FakePlanItHandler handler,
         PlanItRetryOptions? retryOptions = null,
-        List<TimeSpan>? delays = null)
+        PlanItThrottleOptions? throttleOptions = null,
+        List<TimeSpan>? delays = null,
+        List<TimeSpan>? throttleDelays = null)
     {
         var httpClient = new HttpClient(handler, disposeHandler: false)
         {
@@ -273,16 +355,17 @@ public sealed class PlanItClientTests
         };
 
         Func<TimeSpan, CancellationToken, Task>? delayFunc = null;
-        if (delays is not null)
+        if (delays is not null || throttleDelays is not null)
         {
             delayFunc = (delay, _) =>
             {
-                delays.Add(delay);
+                delays?.Add(delay);
+                throttleDelays?.Add(delay);
                 return Task.CompletedTask;
             };
         }
 
-        return new PlanItClient(httpClient, retryOptions ?? new PlanItRetryOptions(), delayFunc);
+        return new PlanItClient(httpClient, retryOptions ?? new PlanItRetryOptions(), throttleOptions, delayFunc);
     }
 
     private static async Task<List<TownCrier.Domain.PlanningApplications.PlanningApplication>> ConsumeAsync(

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -326,6 +326,31 @@ public sealed class PlanItClientTests
     }
 
     [Test]
+    public async Task Should_ThrottleBeforeEveryRetryAttempt_When_RateLimitedThenSucceeds()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupRateLimitThenSuccess("page=1", count: 1, SingleRecordResponse);
+        var allDelays = new List<TimeSpan>();
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequests = TimeSpan.FromMilliseconds(100) };
+        var retryOptions = new PlanItRetryOptions { MaxRetries = 3, BaseDelay = TimeSpan.FromMilliseconds(10) };
+        var client = CreateClient(handler, retryOptions: retryOptions, throttleOptions: throttleOptions, throttleDelays: allDelays);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert — got results after retry
+        await Assert.That(results).HasCount().EqualTo(1);
+
+        // 1 x 429 + 1 success = 2 total HTTP requests
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(2);
+
+        // Throttle fires before EVERY HTTP request (2 throttle delays) plus 1 backoff delay after 429 = 3 total
+        var throttleCount = allDelays.Count(d => d == TimeSpan.FromMilliseconds(100));
+        await Assert.That(throttleCount).IsEqualTo(2);
+    }
+
+    [Test]
     public async Task Should_UseDefaultOneSecondDelay_When_NoThrottleOptionsProvided()
     {
         // Arrange

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -318,10 +318,10 @@ public static class EnvironmentStack
             Configuration = new JobConfigurationArgs
             {
                 TriggerType = Pulumi.AzureNative.App.TriggerType.Schedule,
-                ReplicaTimeout = 300,
+                ReplicaTimeout = 600,
                 ScheduleTriggerConfig = new JobConfigurationScheduleTriggerConfigArgs
                 {
-                    CronExpression = "*/15 * * * *",
+                    CronExpression = "0 * * * *",
                     Parallelism = 1,
                     ReplicaCompletionCount = 1,
                 },


### PR DESCRIPTION
## Changes

- **Throttle PlanIt requests** — 1s configurable delay before every HTTP request (including retries) to be a good citizen to PlanIt API
- **Save poll progress per-authority** — persist poll state and metrics after each authority completes, preventing cascading re-fetch on failure
- **Handle 429 with skip-then-stop** — first rate-limit skips the authority and continues; second stops the cycle gracefully with partial results
- **Add OTel ForceFlush before worker exit** — ensures telemetry reaches App Insights from the short-lived Container Apps Job
- **Change polling cron to hourly** — `*/15 * * * *` → `0 * * * *`, timeout increased to 10 minutes
- **Kill zombie prod revision 0000023** — deactivated old API revision that was running the pre-extraction polling service (done via az CLI, not in this PR)

Spec: `docs/superpowers/specs/2026-04-05-polling-resilience-design.md`

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request throttling with configurable delays between API calls

* **Improvements**
  * More resilient rate-limit handling (continues after a first 429, stops after repeated 429s)
  * Poll progress persisted per authority so partial progress is saved
  * Improved telemetry flushing on shutdown for more reliable metrics/traces

* **Configuration**
  * Polling frequency changed to hourly; poll timeout increased to 10 minutes

* **Tests**
  * Expanded tests for throttling, rate-limit behavior, and poll-state persistence
<!-- end of auto-generated comment: release notes by coderabbit.ai -->