### PR TITLE
fix(web): dark mode popups, save toggle, focus-visible

### DIFF
--- a/web/src/features/Map/BookmarkButton.module.css
+++ b/web/src/features/Map/BookmarkButton.module.css
@@ -15,6 +15,11 @@
   color: var(--tc-amber);
 }
 
+.button:focus-visible {
+  outline: 2px solid var(--tc-amber);
+  outline-offset: 2px;
+}
+
 .saved {
   color: var(--tc-amber);
 }

--- a/web/src/features/Map/MapPage.tsx
+++ b/web/src/features/Map/MapPage.tsx
@@ -8,6 +8,7 @@ import { FitBounds } from './FitBounds';
 import { BookmarkButton } from './BookmarkButton';
 import styles from './MapPage.module.css';
 import 'leaflet/dist/leaflet.css';
+import './leaflet-overrides.css';
 
 const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
 const OSM_ATTRIBUTION =

--- a/web/src/features/Map/__tests__/BookmarkButton.test.ts
+++ b/web/src/features/Map/__tests__/BookmarkButton.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const cssPath = resolve(__dirname, '../BookmarkButton.module.css');
+
+function readCss(): string {
+  return readFileSync(cssPath, 'utf-8');
+}
+
+describe('BookmarkButton styles', () => {
+  it('defines a :focus-visible outline using --tc-amber for keyboard accessibility', () => {
+    const css = readCss();
+
+    expect(css).toContain(':focus-visible');
+    expect(css).toContain('outline');
+    expect(css).toContain('var(--tc-amber)');
+  });
+});

--- a/web/src/features/Map/__tests__/leaflet-popup-overrides.test.ts
+++ b/web/src/features/Map/__tests__/leaflet-popup-overrides.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Leaflet ships popup styles with a hardcoded white background.
+ * In dark mode the app's text tokens resolve to light colours,
+ * making popup text invisible. These tests guarantee that override
+ * styles exist and use the correct design tokens so the bug cannot
+ * silently regress.
+ */
+describe('Leaflet popup dark-mode overrides', () => {
+  const cssPath = resolve(__dirname, '..', 'leaflet-overrides.css');
+  let css: string;
+
+  try {
+    css = readFileSync(cssPath, 'utf-8');
+  } catch {
+    css = '';
+  }
+
+  it('override stylesheet exists', () => {
+    expect(css.length).toBeGreaterThan(0);
+  });
+
+  it('overrides .leaflet-popup-content-wrapper background with --tc-surface', () => {
+    expect(css).toContain('.leaflet-popup-content-wrapper');
+    expect(css).toMatch(/\.leaflet-popup-content-wrapper[^}]*var\(--tc-surface\)/s);
+  });
+
+  it('overrides .leaflet-popup-tip background with --tc-surface', () => {
+    expect(css).toContain('.leaflet-popup-tip');
+    expect(css).toMatch(/\.leaflet-popup-tip[^}]*var\(--tc-surface\)/s);
+  });
+
+  it('sets popup text color to --tc-text-primary', () => {
+    expect(css).toMatch(/\.leaflet-popup-content-wrapper[^}]*var\(--tc-text-primary\)/s);
+  });
+
+  it('sets popup link color to --tc-amber', () => {
+    expect(css).toMatch(/\.leaflet-popup-content[^}]*var\(--tc-amber\)/s);
+  });
+});

--- a/web/src/features/Map/__tests__/useMapData.test.ts
+++ b/web/src/features/Map/__tests__/useMapData.test.ts
@@ -187,4 +187,64 @@ describe('useMapData', () => {
 
     expect(result.current.savedUids.has(asApplicationUid('app-001'))).toBe(true);
   });
+
+  it('shows uid as saved after save-unsave-save toggle sequence', async () => {
+    const spy = new SpyMapPort();
+    spy.fetchMyAuthoritiesResult = [anAuthority()];
+    spy.fetchApplicationsByAuthorityResults.set(1, [anApplication()]);
+    spy.fetchSavedApplicationsResult = [];
+
+    const { result } = renderHook(() => useMapData(spy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const uid = asApplicationUid('app-001');
+
+    await act(async () => {
+      await result.current.saveApplication(uid);
+    });
+    expect(result.current.savedUids.has(uid)).toBe(true);
+
+    await act(async () => {
+      await result.current.unsaveApplication(uid);
+    });
+    expect(result.current.savedUids.has(uid)).toBe(false);
+
+    await act(async () => {
+      await result.current.saveApplication(uid);
+    });
+    expect(result.current.savedUids.has(uid)).toBe(true);
+  });
+
+  it('shows uid as unsaved after unsave-save-unsave toggle sequence on initially saved item', async () => {
+    const spy = new SpyMapPort();
+    spy.fetchMyAuthoritiesResult = [anAuthority()];
+    spy.fetchApplicationsByAuthorityResults.set(1, [anApplication()]);
+    spy.fetchSavedApplicationsResult = [aSavedApplication()];
+
+    const { result } = renderHook(() => useMapData(spy));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const uid = asApplicationUid('app-001');
+
+    await act(async () => {
+      await result.current.unsaveApplication(uid);
+    });
+    expect(result.current.savedUids.has(uid)).toBe(false);
+
+    await act(async () => {
+      await result.current.saveApplication(uid);
+    });
+    expect(result.current.savedUids.has(uid)).toBe(true);
+
+    await act(async () => {
+      await result.current.unsaveApplication(uid);
+    });
+    expect(result.current.savedUids.has(uid)).toBe(false);
+  });
 });

--- a/web/src/features/Map/leaflet-overrides.css
+++ b/web/src/features/Map/leaflet-overrides.css
@@ -1,0 +1,32 @@
+/* ==========================================================================
+   Leaflet Popup Overrides
+   Leaflet ships popup styles with a hardcoded white background. In dark
+   mode the app's text tokens resolve to light colours, making popup text
+   invisible. These overrides replace hardcoded values with design tokens
+   so popups match the active theme in light, dark, and OLED dark modes.
+   ========================================================================== */
+
+.leaflet-popup-content-wrapper {
+  background: var(--tc-surface);
+  color: var(--tc-text-primary);
+  border-radius: var(--tc-radius-md);
+  box-shadow: var(--tc-shadow-elevated);
+}
+
+.leaflet-popup-tip {
+  background: var(--tc-surface);
+}
+
+.leaflet-popup-content a {
+  color: var(--tc-amber);
+}
+
+/* Override the default close button to match the theme */
+.leaflet-popup-close-button {
+  color: var(--tc-text-secondary);
+}
+
+.leaflet-popup-close-button:hover,
+.leaflet-popup-close-button:focus {
+  color: var(--tc-text-primary);
+}

--- a/web/src/features/Map/useMapData.ts
+++ b/web/src/features/Map/useMapData.ts
@@ -40,6 +40,11 @@ export function useMapData(port: MapPort) {
   }, [data?.fetchedSavedUids, pendingSaves, pendingRemoves]);
 
   const saveApplication = useCallback(async (uid: ApplicationUid) => {
+    setPendingRemoves(prev => {
+      const next = new Set(prev);
+      next.delete(uid);
+      return next;
+    });
     setPendingSaves(prev => new Set([...prev, uid]));
     try {
       await port.saveApplication(uid);
@@ -53,6 +58,11 @@ export function useMapData(port: MapPort) {
   }, [port]);
 
   const unsaveApplication = useCallback(async (uid: ApplicationUid) => {
+    setPendingSaves(prev => {
+      const next = new Set(prev);
+      next.delete(uid);
+      return next;
+    });
     setPendingRemoves(prev => new Set([...prev, uid]));
     try {
       await port.unsaveApplication(uid);


### PR DESCRIPTION
## Changes
- Fix map popup text contrast in dark mode — override Leaflet popup styles with design tokens (`--tc-surface`, `--tc-text-primary`)
- Fix stale optimistic state in save/unsave toggle — clear opposite pending set when toggling
- Add `:focus-visible` outline to BookmarkButton using `--tc-amber` for keyboard accessibility

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard focus indicator for the bookmark button with improved accessibility styling.
  * Enhanced map popup appearance with theme-aware colors for backgrounds, text, and links.

* **Style**
  * Refined popup styling to align with the application's design tokens and dark mode support.

* **Tests**
  * Added test coverage for bookmark button focus styling.
  * Added tests for map popup theme overrides and save/unsave functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->