### PR TITLE
fix(api): polling resilience — nullable pagination & per-authority error isolation

### DIFF
--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -99,6 +99,12 @@ public sealed partial class PollPlanItCommandHandler
 
                 LogRateLimitSkip(this.logger, authorityId, ex);
             }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                PollingMetrics.AuthoritiesSkipped.Add(1);
+                PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
+                LogAuthorityError(this.logger, authorityId, ex);
+            }
         }
 
         return new PollPlanItResult(count, authoritiesPolled);
@@ -109,4 +115,7 @@ public sealed partial class PollPlanItCommandHandler
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Rate limited polling authority {AuthorityId} (second 429 this cycle), stopping polling cycle")]
     private static partial void LogRateLimitBreak(ILogger logger, int authorityId, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Error polling authority {AuthorityId}, skipping to next authority")]
+    private static partial void LogAuthorityError(ILogger logger, int authorityId, Exception exception);
 }

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -93,7 +93,7 @@ public sealed class PlanItClient : IPlanItClient
             .Select(MapToDomain)
             .ToList();
 
-        return new PlanItSearchResult(applications, planItResponse.Total);
+        return new PlanItSearchResult(applications, planItResponse.Total ?? 0);
     }
 
     private static string BuildSearchUrl(string searchText, int authorityId, int page)

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItResponse.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItResponse.cs
@@ -8,11 +8,11 @@ internal sealed class PlanItResponse
     public List<PlanItApplicationRecord> Records { get; set; } = [];
 
     [JsonPropertyName("pg_sz")]
-    public int PageSize { get; set; }
+    public int? PageSize { get; set; }
 
     [JsonPropertyName("from")]
-    public int From { get; set; }
+    public int? From { get; set; }
 
     [JsonPropertyName("total")]
-    public int Total { get; set; }
+    public int? Total { get; set; }
 }

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -327,20 +327,75 @@ public sealed class PollPlanItCommandHandlerTests
     }
 
     [Test]
-    public async Task Should_PropagateException_When_NonRateLimitHttpError()
+    public async Task Should_ContinueToNextAuthority_When_NonRateLimitExceptionOccurs()
     {
         var authorityProvider = new FakeActiveAuthorityProvider();
         authorityProvider.Add(100);
         authorityProvider.Add(200);
+        authorityProvider.Add(300);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.ThrowForAuthority(200, new InvalidOperationException("Unexpected JSON structure"));
+        planItClient.Add(300, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(300).Build());
+
+        var handler = CreateHandler(planItClient: planItClient, authorityProvider: authorityProvider);
+
+        var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        // Authority 200 failed but 100 and 300 should still succeed
+        await Assert.That(result.ApplicationCount).IsEqualTo(2);
+        await Assert.That(result.AuthoritiesPolled).IsEqualTo(2);
+        await Assert.That(planItClient.AuthorityIdsRequested).Contains(300);
+    }
+
+    [Test]
+    public async Task Should_ContinueToNextAuthority_When_NonRateLimitHttpErrorOccurs()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+        authorityProvider.Add(300);
 
         var planItClient = new FakePlanItClient();
         planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
         planItClient.ThrowForAuthority(200, new HttpRequestException("Internal Server Error", null, HttpStatusCode.InternalServerError));
+        planItClient.Add(300, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(300).Build());
 
         var handler = CreateHandler(planItClient: planItClient, authorityProvider: authorityProvider);
 
-        await Assert.ThrowsAsync<HttpRequestException>(
-            () => handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None));
+        var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(result.ApplicationCount).IsEqualTo(2);
+        await Assert.That(result.AuthoritiesPolled).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Should_SavePollStateForSuccessfulAuthorities_When_OtherAuthorityFails()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+        authorityProvider.Add(300);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.ThrowForAuthority(200, new HttpRequestException("timeout"));
+        planItClient.Add(300, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(300).Build());
+
+        var pollStateStore = new FakePollStateStore();
+        var fakeTime = new DateTimeOffset(2026, 4, 5, 12, 0, 0, TimeSpan.Zero);
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            pollStateStore: pollStateStore,
+            authorityProvider: authorityProvider,
+            timeProvider: new FakeTimeProvider(fakeTime));
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        // Poll state saved for authority 100 and 300 (not 200 which failed)
+        await Assert.That(pollStateStore.SaveCallCount).IsEqualTo(2);
+        await Assert.That(pollStateStore.LastPollTime).IsEqualTo(fakeTime);
     }
 
     private static PollPlanItCommandHandler CreateHandler(

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -372,34 +372,6 @@ public sealed class PollPlanItCommandHandlerTests
         await Assert.That(result.AuthoritiesPolled).IsEqualTo(2);
     }
 
-    [Test]
-    public async Task Should_SavePollStateForSuccessfulAuthorities_When_OtherAuthorityFails()
-    {
-        var authorityProvider = new FakeActiveAuthorityProvider();
-        authorityProvider.Add(100);
-        authorityProvider.Add(200);
-        authorityProvider.Add(300);
-
-        var planItClient = new FakePlanItClient();
-        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
-        planItClient.ThrowForAuthority(200, new HttpRequestException("timeout"));
-        planItClient.Add(300, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(300).Build());
-
-        var pollStateStore = new FakePollStateStore();
-        var fakeTime = new DateTimeOffset(2026, 4, 5, 12, 0, 0, TimeSpan.Zero);
-        var handler = CreateHandler(
-            planItClient: planItClient,
-            pollStateStore: pollStateStore,
-            authorityProvider: authorityProvider,
-            timeProvider: new FakeTimeProvider(fakeTime));
-
-        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
-
-        // Poll state saved for authority 100 and 300 (not 200 which failed)
-        await Assert.That(pollStateStore.SaveCallCount).IsEqualTo(2);
-        await Assert.That(pollStateStore.LastPollTime).IsEqualTo(fakeTime);
-    }
-
     private static PollPlanItCommandHandler CreateHandler(
         FakePlanItClient? planItClient = null,
         FakePollStateStore? pollStateStore = null,

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -218,7 +218,7 @@ public sealed class PollPlanItCommandHandlerTests
     }
 
     [Test]
-    public async Task Should_RethrowException_When_PlanItFails()
+    public async Task Should_ReturnZeroApplications_When_SingleAuthorityFails()
     {
         var authorityProvider = new FakeActiveAuthorityProvider();
         authorityProvider.Add(1);
@@ -226,12 +226,14 @@ public sealed class PollPlanItCommandHandlerTests
 
         var handler = CreateHandler(planItClient: failingClient, authorityProvider: authorityProvider);
 
-        await Assert.ThrowsAsync<HttpRequestException>(async () =>
-            await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None));
+        var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(result.ApplicationCount).IsEqualTo(0);
+        await Assert.That(result.AuthoritiesPolled).IsEqualTo(0);
     }
 
     [Test]
-    public async Task Should_PreserveProgressForCompletedAuthorities_When_LaterAuthorityFails()
+    public async Task Should_ContinueAndPreserveProgress_When_MiddleAuthorityFails()
     {
         var authorityProvider = new FakeActiveAuthorityProvider();
         authorityProvider.Add(100);
@@ -251,16 +253,17 @@ public sealed class PollPlanItCommandHandlerTests
             authorityProvider: authorityProvider,
             timeProvider: new FakeTimeProvider(fakeTime));
 
-        await Assert.ThrowsAsync<HttpRequestException>(
-            () => handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None));
+        var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
 
-        // Authority 100 completed before the failure, so poll state should be saved
-        await Assert.That(pollStateStore.SaveCallCount).IsEqualTo(1);
+        // Authority 100 and 300 completed, 200 failed but was isolated
+        await Assert.That(result.ApplicationCount).IsEqualTo(2);
+        await Assert.That(result.AuthoritiesPolled).IsEqualTo(2);
+        await Assert.That(pollStateStore.SaveCallCount).IsEqualTo(2);
         await Assert.That(pollStateStore.LastPollTime).IsEqualTo(fakeTime);
     }
 
     [Test]
-    public async Task Should_NotSavePollState_When_PollFails()
+    public async Task Should_NotSavePollState_When_OnlyAuthorityFails()
     {
         var authorityProvider = new FakeActiveAuthorityProvider();
         authorityProvider.Add(1);
@@ -272,8 +275,7 @@ public sealed class PollPlanItCommandHandlerTests
             pollStateStore: pollStateStore,
             authorityProvider: authorityProvider);
 
-        await Assert.ThrowsAsync<HttpRequestException>(
-            () => handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None));
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
 
         await Assert.That(pollStateStore.LastPollTime).IsNull();
     }

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -351,6 +351,89 @@ public sealed class PlanItClientTests
     }
 
     [Test]
+    public async Task Should_DeserializeAndReturnApplications_When_PaginationFieldsAreNull()
+    {
+        // Arrange
+        const string nullPaginationResponse = """
+            {
+                "records": [
+                    {
+                        "name": "Leeds/26/01471/TR",
+                        "uid": "26/01471/TR",
+                        "area_name": "Leeds",
+                        "area_id": 292,
+                        "address": "Highgate House Grove Lane Leeds",
+                        "postcode": "LS6 2AP",
+                        "description": "T1 lime tree - crown reduction",
+                        "app_type": "Trees",
+                        "app_state": "Undecided",
+                        "app_size": "Small",
+                        "start_date": "2026-03-13",
+                        "decided_date": null,
+                        "consulted_date": null,
+                        "location_x": -1.577373,
+                        "location_y": 53.824035,
+                        "url": "https://publicaccess.leeds.gov.uk/example",
+                        "link": "https://www.planit.org.uk/planapplic/26-01471-TR",
+                        "last_different": "2026-03-14T11:59:17.642"
+                    }
+                ],
+                "pg_sz": null,
+                "from": null,
+                "total": null
+            }
+            """;
+
+        using var handler = new FakePlanItHandler();
+        handler.SetupJsonResponse("page=1", nullPaginationResponse);
+        var client = CreateClient(handler);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert — should deserialize without throwing
+        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(results[0].Name).IsEqualTo("Leeds/26/01471/TR");
+    }
+
+    [Test]
+    public async Task Should_ReturnZeroTotal_When_SearchResponseHasNullTotal()
+    {
+        // Arrange
+        const string nullTotalSearchResponse = """
+            {
+                "records": [
+                    {
+                        "name": "Leeds/26/01471/TR",
+                        "uid": "26/01471/TR",
+                        "area_name": "Leeds",
+                        "area_id": 292,
+                        "address": "Highgate House Grove Lane Leeds",
+                        "description": "T1 lime tree - crown reduction",
+                        "app_type": "Trees",
+                        "app_state": "Undecided",
+                        "last_different": "2026-03-14T11:59:17.642"
+                    }
+                ],
+                "pg_sz": null,
+                "from": null,
+                "total": null
+            }
+            """;
+
+        using var handler = new FakePlanItHandler();
+        handler.SetupJsonResponse("/api/applics/json", nullTotalSearchResponse);
+        var client = CreateClient(handler);
+
+        // Act
+        var result = await client.SearchApplicationsAsync("tree", 292, 1, CancellationToken.None);
+
+        // Assert — null total should be treated as 0
+        await Assert.That(result.Total).IsEqualTo(0);
+        await Assert.That(result.Applications).HasCount().EqualTo(1);
+    }
+
+    [Test]
     public async Task Should_UseDefaultOneSecondDelay_When_NoThrottleOptionsProvided()
     {
         // Arrange


### PR DESCRIPTION
## Changes
- **fix:** Make `PlanItResponse` pagination fields (`From`, `Total`, `PageSize`) nullable (`int?`) to handle null values from PlanIt API — fixes deserialization crash that killed entire poll cycles
- **fix:** Add per-authority error isolation in `PollPlanItCommandHandler` — non-429 exceptions now logged and skipped instead of propagating, preserving partial progress
- **test:** Added TDD tests for both fixes (null pagination deserialization, error isolation across authorities)
- **refactor:** Removed redundant poll state test

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Polling system now gracefully handles errors during authority processing, continuing with remaining authorities instead of stopping completely.
  * Improved handling of null pagination values from API responses.
  * Enhanced error tracking and logging for failed authority polling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->