### PR TITLE
fix(api): eagerly initialize OTel providers in worker

### DIFF
--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -71,6 +71,12 @@ builder.Services.AddTransient<PollPlanItCommandHandler>();
 
 using var host = builder.Build();
 
+// Eagerly initialize OTel providers so they listen before metrics are recorded.
+// Without this, Counter.Add() / Histogram.Record() silently drop measurements
+// because the providers are lazy singletons first resolved at ForceFlush time.
+_ = host.Services.GetRequiredService<MeterProvider>();
+_ = host.Services.GetRequiredService<TracerProvider>();
+
 var handler = host.Services.GetRequiredService<PollPlanItCommandHandler>();
 var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("TownCrier.Worker");
 


### PR DESCRIPTION
## Summary
- MeterProvider and TracerProvider in the polling worker were lazy singletons, only resolved at ForceFlush time — after all metrics had already been recorded
- `Counter.Add()` and `Histogram.Record()` silently drop measurements when no provider is listening, so the dashboard showed zero for all polling metrics
- Fix: eagerly resolve both providers after `host.Build()` but before the handler runs

## Test plan
- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet test` — 162 tests pass
- [ ] After deploy, verify `towncrier.polling.*` metrics appear in App Insights (`customMetrics | where name startswith 'towncrier.polling'`)
- [ ] Verify dashboard tiles ("Sync Success vs Failure", "Applications Ingested") show data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted telemetry provider initialization timing in the background service to occur earlier in the startup sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->