### PR TITLE
fix: handle null description from PlanIt API to prevent dashboard crash

### DIFF
--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -123,7 +123,7 @@ public sealed class PlanItClient : IPlanItClient
             areaId: record.AreaId,
             address: record.Address,
             postcode: record.Postcode,
-            description: record.Description,
+            description: record.Description ?? string.Empty,
             appType: record.AppType,
             appState: record.AppState,
             appSize: record.AppSize,

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -49,6 +49,27 @@ public sealed class PlanItClientTests
         }
         """;
 
+    private const string NullDescriptionResponse = """
+        {
+            "records": [
+                {
+                    "name": "Leeds/26/01500/FUL",
+                    "uid": "26/01500/FUL",
+                    "area_name": "Leeds",
+                    "area_id": 292,
+                    "address": "1 Example Road Leeds",
+                    "description": null,
+                    "app_type": "Full",
+                    "app_state": "Undecided",
+                    "last_different": "2026-03-14T11:59:17.642"
+                }
+            ],
+            "pg_sz": 100,
+            "from": 0,
+            "total": 1
+        }
+        """;
+
     [Test]
     public async Task Should_ReturnApplications_When_ApiReturnsResults()
     {
@@ -448,6 +469,22 @@ public sealed class PlanItClientTests
         // Assert — default 1s throttle delay
         await Assert.That(throttleDelays).HasCount().EqualTo(1);
         await Assert.That(throttleDelays[0]).IsEqualTo(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task Should_DefaultToEmptyString_When_DescriptionIsNull()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupJsonResponse("page=1", NullDescriptionResponse);
+        var client = CreateClient(handler);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert
+        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(results[0].Description).IsEqualTo(string.Empty);
     }
 
     private static PlanItClient CreateClient(

--- a/web/src/components/ApplicationCard/ApplicationCard.tsx
+++ b/web/src/components/ApplicationCard/ApplicationCard.tsx
@@ -9,9 +9,9 @@ interface Props {
 
 const MAX_DESCRIPTION_LENGTH = 120;
 
-function truncate(text: string, maxLength: number): string {
-  if (text.length <= maxLength) {
-    return text;
+function truncate(text: string | null, maxLength: number): string {
+  if (text === null || text.length <= maxLength) {
+    return text ?? '';
   }
   return text.slice(0, maxLength) + '...';
 }

--- a/web/src/components/ApplicationCard/__tests__/ApplicationCard.test.tsx
+++ b/web/src/components/ApplicationCard/__tests__/ApplicationCard.test.tsx
@@ -108,4 +108,11 @@ describe('ApplicationCard', () => {
 
     expect(screen.queryByTestId('application-start-date')).not.toBeInTheDocument();
   });
+
+  it('handles null description without crashing', () => {
+    renderCard({ description: null as unknown as string });
+
+    const description = screen.getByTestId('application-description');
+    expect(description.textContent).toBe('');
+  });
 });


### PR DESCRIPTION
## Changes
- Null-coalesce `record.Description` in `PlanItClient.MapToDomain()` so null PlanIt descriptions become empty strings before reaching Cosmos
- Guard `truncate()` in `ApplicationCard` against null text input
- Add backend test: `Should_DefaultToEmptyString_When_DescriptionIsNull`
- Add frontend test: `handles null description without crashing`

## Root cause
PlanIt API can return `"description": null`. JSON deserialization silently assigns null to non-nullable C# `string` properties. The null propagates through Cosmos to the frontend, where `truncate()` crashes on `null.length`. App Insights confirms 20 applications were ingested with null descriptions at 16:02:02 UTC, with the first crash 51 seconds later.

---
*Auto-shipped via ship skill*