### PR TITLE
feat(api): per-authority poll state for polling loop

### DIFF
--- a/api/src/town-crier.application/Polling/IPollStateStore.cs
+++ b/api/src/town-crier.application/Polling/IPollStateStore.cs
@@ -2,7 +2,9 @@ namespace TownCrier.Application.Polling;
 
 public interface IPollStateStore
 {
-    Task<DateTimeOffset?> GetLastPollTimeAsync(CancellationToken ct);
+    Task<DateTimeOffset?> GetLastPollTimeAsync(int authorityId, CancellationToken ct);
 
-    Task SaveLastPollTimeAsync(DateTimeOffset pollTime, CancellationToken ct);
+    Task SaveLastPollTimeAsync(int authorityId, DateTimeOffset pollTime, CancellationToken ct);
+
+    Task DeleteGlobalPollStateAsync(CancellationToken ct);
 }

--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -41,9 +41,7 @@ public sealed partial class PollPlanItCommandHandler
 
     public async Task<PollPlanItResult> HandleAsync(PollPlanItCommand command, CancellationToken ct)
     {
-        var lastPollTime = await this.pollStateStore.GetLastPollTimeAsync(ct).ConfigureAwait(false);
         var now = this.timeProvider.GetUtcNow();
-        lastPollTime ??= now.AddDays(-30);
         var authorityIds = await this.activeAuthorityProvider.GetActiveAuthorityIdsAsync(ct).ConfigureAwait(false);
 
         var count = 0;
@@ -57,6 +55,9 @@ public sealed partial class PollPlanItCommandHandler
 
             try
             {
+                var lastPollTime = await this.pollStateStore.GetLastPollTimeAsync(authorityId, ct).ConfigureAwait(false);
+                lastPollTime ??= now.AddDays(-30);
+
                 var authorityAppCount = 0;
                 await foreach (var application in this.planItClient.FetchApplicationsAsync(authorityId, lastPollTime, ct).ConfigureAwait(false))
                 {
@@ -82,7 +83,7 @@ public sealed partial class PollPlanItCommandHandler
                 authorityActivity?.SetTag("polling.applications_found", authorityAppCount);
 
                 PollingMetrics.AuthoritiesPolled.Add(1);
-                await this.pollStateStore.SaveLastPollTimeAsync(now, ct).ConfigureAwait(false);
+                await this.pollStateStore.SaveLastPollTimeAsync(authorityId, now, ct).ConfigureAwait(false);
                 authoritiesPolled++;
             }
             catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
@@ -106,6 +107,8 @@ public sealed partial class PollPlanItCommandHandler
                 LogAuthorityError(this.logger, authorityId, ex);
             }
         }
+
+        await this.pollStateStore.DeleteGlobalPollStateAsync(ct).ConfigureAwait(false);
 
         return new PollPlanItResult(count, authoritiesPolled);
     }

--- a/api/src/town-crier.infrastructure/Polling/CosmosPollStateStore.cs
+++ b/api/src/town-crier.infrastructure/Polling/CosmosPollStateStore.cs
@@ -6,7 +6,7 @@ namespace TownCrier.Infrastructure.Polling;
 
 public sealed class CosmosPollStateStore : IPollStateStore
 {
-    private const string DocumentId = "poll-state";
+    private const string GlobalDocumentId = "poll-state";
 
     private readonly ICosmosRestClient client;
 
@@ -16,12 +16,13 @@ public sealed class CosmosPollStateStore : IPollStateStore
         this.client = client;
     }
 
-    public async Task<DateTimeOffset?> GetLastPollTimeAsync(CancellationToken ct)
+    public async Task<DateTimeOffset?> GetLastPollTimeAsync(int authorityId, CancellationToken ct)
     {
+        var documentId = FormatDocumentId(authorityId);
         var doc = await this.client.ReadDocumentAsync(
             CosmosContainerNames.PollState,
-            DocumentId,
-            DocumentId,
+            documentId,
+            documentId,
             CosmosJsonSerializerContext.Default.PollStateDocument,
             ct).ConfigureAwait(false);
 
@@ -33,19 +34,35 @@ public sealed class CosmosPollStateStore : IPollStateStore
         return DateTimeOffset.Parse(doc.LastPollTime, CultureInfo.InvariantCulture);
     }
 
-    public async Task SaveLastPollTimeAsync(DateTimeOffset pollTime, CancellationToken ct)
+    public async Task SaveLastPollTimeAsync(int authorityId, DateTimeOffset pollTime, CancellationToken ct)
     {
+        var documentId = FormatDocumentId(authorityId);
         var doc = new PollStateDocument
         {
-            Id = DocumentId,
+            Id = documentId,
             LastPollTime = pollTime.ToString("O", CultureInfo.InvariantCulture),
+            AuthorityId = authorityId,
         };
 
         await this.client.UpsertDocumentAsync(
             CosmosContainerNames.PollState,
             doc,
-            DocumentId,
+            documentId,
             CosmosJsonSerializerContext.Default.PollStateDocument,
             ct).ConfigureAwait(false);
+    }
+
+    public async Task DeleteGlobalPollStateAsync(CancellationToken ct)
+    {
+        await this.client.DeleteDocumentAsync(
+            CosmosContainerNames.PollState,
+            GlobalDocumentId,
+            GlobalDocumentId,
+            ct).ConfigureAwait(false);
+    }
+
+    private static string FormatDocumentId(int authorityId)
+    {
+        return string.Create(CultureInfo.InvariantCulture, $"poll-state-{authorityId}");
     }
 }

--- a/api/src/town-crier.infrastructure/Polling/PollStateDocument.cs
+++ b/api/src/town-crier.infrastructure/Polling/PollStateDocument.cs
@@ -5,4 +5,6 @@ internal sealed class PollStateDocument
     public required string Id { get; init; }
 
     public required string LastPollTime { get; init; }
+
+    public int? AuthorityId { get; init; }
 }

--- a/api/tests/town-crier.application.tests/Polling/FakePlanItClient.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakePlanItClient.cs
@@ -11,6 +11,8 @@ internal sealed class FakePlanItClient : IPlanItClient
 
     public DateTimeOffset? LastDifferentStartUsed { get; private set; }
 
+    public Dictionary<int, DateTimeOffset?> DifferentStartByAuthority { get; } = [];
+
     public List<int> AuthorityIdsRequested { get; } = [];
 
     public Exception? ExceptionToThrow { get; set; }
@@ -53,6 +55,7 @@ internal sealed class FakePlanItClient : IPlanItClient
         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct)
     {
         this.LastDifferentStartUsed = differentStart;
+        this.DifferentStartByAuthority[authorityId] = differentStart;
         this.AuthorityIdsRequested.Add(authorityId);
 
         if (this.exceptionsByAuthority.TryGetValue(authorityId, out var authorityException))

--- a/api/tests/town-crier.application.tests/Polling/FakePollStateStore.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakePollStateStore.cs
@@ -4,24 +4,38 @@ namespace TownCrier.Application.Tests.Polling;
 
 internal sealed class FakePollStateStore : IPollStateStore
 {
-    public DateTimeOffset? LastPollTime { get; private set; }
+    private readonly Dictionary<int, DateTimeOffset> pollTimes = [];
 
     public int SaveCallCount { get; private set; }
 
-    public void SetLastPollTime(DateTimeOffset pollTime)
+    public bool DeleteGlobalCalled { get; private set; }
+
+    public DateTimeOffset? GetLastPollTimeFor(int authorityId)
     {
-        this.LastPollTime = pollTime;
+        return this.pollTimes.TryGetValue(authorityId, out var time) ? time : null;
     }
 
-    public Task<DateTimeOffset?> GetLastPollTimeAsync(CancellationToken ct)
+    public void SetLastPollTime(int authorityId, DateTimeOffset pollTime)
     {
-        return Task.FromResult(this.LastPollTime);
+        this.pollTimes[authorityId] = pollTime;
     }
 
-    public Task SaveLastPollTimeAsync(DateTimeOffset pollTime, CancellationToken ct)
+    public Task<DateTimeOffset?> GetLastPollTimeAsync(int authorityId, CancellationToken ct)
     {
-        this.LastPollTime = pollTime;
+        DateTimeOffset? result = this.pollTimes.TryGetValue(authorityId, out var time) ? time : null;
+        return Task.FromResult(result);
+    }
+
+    public Task SaveLastPollTimeAsync(int authorityId, DateTimeOffset pollTime, CancellationToken ct)
+    {
+        this.pollTimes[authorityId] = pollTime;
         this.SaveCallCount++;
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteGlobalPollStateAsync(CancellationToken ct)
+    {
+        this.DeleteGlobalCalled = true;
         return Task.CompletedTask;
     }
 }

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -94,7 +94,7 @@ public sealed class PollPlanItCommandHandlerTests
         var planItClient = new FakePlanItClient();
         var pollStateStore = new FakePollStateStore();
         var lastPoll = new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero);
-        pollStateStore.SetLastPollTime(lastPoll);
+        pollStateStore.SetLastPollTime(1, lastPoll);
 
         var handler = CreateHandler(planItClient: planItClient, pollStateStore: pollStateStore, authorityProvider: authorityProvider);
 
@@ -118,7 +118,7 @@ public sealed class PollPlanItCommandHandlerTests
 
         await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
 
-        await Assert.That(pollStateStore.LastPollTime).IsEqualTo(fakeTime);
+        await Assert.That(pollStateStore.GetLastPollTimeFor(1)).IsEqualTo(fakeTime);
         await Assert.That(pollStateStore.SaveCallCount).IsEqualTo(1);
     }
 
@@ -259,7 +259,9 @@ public sealed class PollPlanItCommandHandlerTests
         await Assert.That(result.ApplicationCount).IsEqualTo(2);
         await Assert.That(result.AuthoritiesPolled).IsEqualTo(2);
         await Assert.That(pollStateStore.SaveCallCount).IsEqualTo(2);
-        await Assert.That(pollStateStore.LastPollTime).IsEqualTo(fakeTime);
+        await Assert.That(pollStateStore.GetLastPollTimeFor(100)).IsEqualTo(fakeTime);
+        await Assert.That(pollStateStore.GetLastPollTimeFor(300)).IsEqualTo(fakeTime);
+        await Assert.That(pollStateStore.GetLastPollTimeFor(200)).IsNull();
     }
 
     [Test]
@@ -277,7 +279,7 @@ public sealed class PollPlanItCommandHandlerTests
 
         await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
 
-        await Assert.That(pollStateStore.LastPollTime).IsNull();
+        await Assert.That(pollStateStore.GetLastPollTimeFor(1)).IsNull();
     }
 
     [Test]
@@ -370,6 +372,94 @@ public sealed class PollPlanItCommandHandlerTests
 
         await Assert.That(result.ApplicationCount).IsEqualTo(2);
         await Assert.That(result.AuthoritiesPolled).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task Should_Use30DayLookback_When_NewAuthorityHasNoPollState()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+
+        var pollStateStore = new FakePollStateStore();
+        var existingPollTime = new DateTimeOffset(2026, 4, 5, 10, 0, 0, TimeSpan.Zero);
+        pollStateStore.SetLastPollTime(100, existingPollTime);
+
+        var now = new DateTimeOffset(2026, 4, 5, 12, 0, 0, TimeSpan.Zero);
+        var planItClient = new FakePlanItClient();
+
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            pollStateStore: pollStateStore,
+            authorityProvider: authorityProvider,
+            timeProvider: new FakeTimeProvider(now));
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        // Authority 100 should use its existing poll time
+        await Assert.That(planItClient.DifferentStartByAuthority[100]).IsEqualTo(existingPollTime);
+
+        // Authority 200 should use 30-day lookback
+        var expected30DaysAgo = new DateTimeOffset(2026, 3, 6, 12, 0, 0, TimeSpan.Zero);
+        await Assert.That(planItClient.DifferentStartByAuthority[200]).IsEqualTo(expected30DaysAgo);
+    }
+
+    [Test]
+    public async Task Should_RetainPerAuthorityPollTime_When_AuthorityIsRateLimited()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+
+        var pollStateStore = new FakePollStateStore();
+        var authority100Time = new DateTimeOffset(2026, 4, 4, 10, 0, 0, TimeSpan.Zero);
+        var authority200Time = new DateTimeOffset(2026, 4, 3, 8, 0, 0, TimeSpan.Zero);
+        pollStateStore.SetLastPollTime(100, authority100Time);
+        pollStateStore.SetLastPollTime(200, authority200Time);
+
+        var now = new DateTimeOffset(2026, 4, 5, 12, 0, 0, TimeSpan.Zero);
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.ThrowForAuthority(200, new HttpRequestException("Rate limited", null, HttpStatusCode.TooManyRequests));
+
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            pollStateStore: pollStateStore,
+            authorityProvider: authorityProvider,
+            timeProvider: new FakeTimeProvider(now));
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        // Authority 100 should be advanced to now
+        await Assert.That(pollStateStore.GetLastPollTimeFor(100)).IsEqualTo(now);
+
+        // Authority 200 should retain its original poll time (rate limited, not advanced)
+        await Assert.That(pollStateStore.GetLastPollTimeFor(200)).IsEqualTo(authority200Time);
+    }
+
+    [Test]
+    public async Task Should_DeleteGlobalPollState_When_CycleCompletes()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(1);
+
+        var pollStateStore = new FakePollStateStore();
+        var handler = CreateHandler(pollStateStore: pollStateStore, authorityProvider: authorityProvider);
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(pollStateStore.DeleteGlobalCalled).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_DeleteGlobalPollState_When_NoActiveAuthorities()
+    {
+        var pollStateStore = new FakePollStateStore();
+        var handler = CreateHandler(pollStateStore: pollStateStore);
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(pollStateStore.DeleteGlobalCalled).IsTrue();
     }
 
     private static PollPlanItCommandHandler CreateHandler(


### PR DESCRIPTION
## Changes
- Store and retrieve `lastPollTime` per authority ID instead of a single global value
- New authorities automatically get a 30-day lookback (backfill on first poll)
- Rate-limited/errored authorities retain their own timestamps (no progress loss)
- Orphaned global `poll-state` document cleaned up after each cycle
- Updated `IPollStateStore` interface, `CosmosPollStateStore`, `PollPlanItCommandHandler`
- Added regression tests for per-authority lookback, rate-limit isolation, and cleanup

## Spec
`docs/superpowers/specs/2026-04-05-per-authority-poll-state-design.md`

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Poll state tracking is now scoped per authority instead of globally, improving data isolation and tracking accuracy for individual authorities.
  
* **Bug Fixes**
  * Added cleanup mechanism to remove obsolete global poll state after polling cycles complete, preventing stale state accumulation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->