### PR TITLE
feat: PlanIt HTTP error metrics with dashboard tiles

### DIFF
--- a/api/src/town-crier.infrastructure/Observability/PlanItInstrumentation.cs
+++ b/api/src/town-crier.infrastructure/Observability/PlanItInstrumentation.cs
@@ -1,0 +1,17 @@
+using System.Diagnostics.Metrics;
+
+namespace TownCrier.Infrastructure.Observability;
+
+#pragma warning disable SA1202 // Meter must be initialized before public fields that reference it
+public static class PlanItInstrumentation
+{
+    public const string MeterName = "TownCrier.PlanIt";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    public static readonly Counter<long> HttpErrors =
+        Meter.CreateCounter<long>(
+            "towncrier.planit.http_errors",
+            description: "Non-2xx HTTP responses from PlanIt API");
+}
+#pragma warning restore SA1202

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using TownCrier.Application.PlanIt;
 using TownCrier.Domain.PlanningApplications;
+using TownCrier.Infrastructure.Observability;
 
 namespace TownCrier.Infrastructure.PlanIt;
 
@@ -44,7 +45,7 @@ public sealed class PlanItClient : IPlanItClient
         do
         {
             var url = new Uri(BuildUrl(authorityId, differentStart, page), UriKind.Relative);
-            using var response = await this.SendWithRetryAsync(url, ct).ConfigureAwait(false);
+            using var response = await this.SendWithRetryAsync(url, authorityId, ct).ConfigureAwait(false);
             response.EnsureSuccessStatusCode();
 
             var planItResponse = await JsonSerializer.DeserializeAsync(
@@ -76,7 +77,7 @@ public sealed class PlanItClient : IPlanItClient
         CancellationToken ct)
     {
         var url = new Uri(BuildSearchUrl(searchText, authorityId, page), UriKind.Relative);
-        using var response = await this.SendWithRetryAsync(url, ct).ConfigureAwait(false);
+        using var response = await this.SendWithRetryAsync(url, authorityId, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         var planItResponse = await JsonSerializer.DeserializeAsync(
@@ -147,7 +148,7 @@ public sealed class PlanItClient : IPlanItClient
         return DateOnly.Parse(value, CultureInfo.InvariantCulture);
     }
 
-    private async Task<HttpResponseMessage> SendWithRetryAsync(Uri url, CancellationToken ct)
+    private async Task<HttpResponseMessage> SendWithRetryAsync(Uri url, int authorityId, CancellationToken ct)
     {
         for (var attempt = 0; attempt <= this.retryOptions.MaxRetries; attempt++)
         {
@@ -157,6 +158,14 @@ public sealed class PlanItClient : IPlanItClient
             }
 
             var response = await this.httpClient.GetAsync(url, ct).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                PlanItInstrumentation.HttpErrors.Add(
+                    1,
+                    new KeyValuePair<string, object?>("http.response.status_code", (int)response.StatusCode),
+                    new KeyValuePair<string, object?>("planit.authority_code", authorityId));
+            }
 
             if (response.StatusCode != (HttpStatusCode)429)
             {

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -34,7 +34,8 @@ builder.Services.AddOpenTelemetry()
             .AddHttpClientInstrumentation()
             .AddMeter(ApiMetrics.MeterName)
             .AddMeter(PollingMetrics.MeterName)
-            .AddMeter(CosmosInstrumentation.MeterName);
+            .AddMeter(CosmosInstrumentation.MeterName)
+            .AddMeter(PlanItInstrumentation.MeterName);
 
         if (hasAppInsights)
         {

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -42,7 +42,8 @@ builder.Services.AddOpenTelemetry()
         metrics
             .AddHttpClientInstrumentation()
             .AddMeter(PollingMetrics.MeterName)
-            .AddMeter(CosmosInstrumentation.MeterName);
+            .AddMeter(CosmosInstrumentation.MeterName)
+            .AddMeter(PlanItInstrumentation.MeterName);
 
         if (hasAppInsights)
         {

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/FakePlanItHandler.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/FakePlanItHandler.cs
@@ -9,6 +9,7 @@ internal sealed class FakePlanItHandler : HttpMessageHandler
     private readonly Dictionary<string, string> responses = new();
     private readonly List<string> requestUrls = [];
     private readonly Dictionary<string, int> rateLimitCounters = new();
+    private readonly Dictionary<string, HttpStatusCode> statusCodeResponses = new();
 
     public IReadOnlyList<string> RequestUrls => this.requestUrls;
 
@@ -28,6 +29,11 @@ internal sealed class FakePlanItHandler : HttpMessageHandler
         this.rateLimitCounters[urlContains] = int.MaxValue;
     }
 
+    public void SetupStatusCodeResponse(string urlContains, HttpStatusCode statusCode)
+    {
+        this.statusCodeResponses[urlContains] = statusCode;
+    }
+
     protected override Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken)
@@ -41,6 +47,14 @@ internal sealed class FakePlanItHandler : HttpMessageHandler
             {
                 this.rateLimitCounters[key]--;
                 return Task.FromResult(new HttpResponseMessage((HttpStatusCode)429));
+            }
+        }
+
+        foreach (var (key, statusCode) in this.statusCodeResponses)
+        {
+            if (url.Contains(key, StringComparison.Ordinal))
+            {
+                return Task.FromResult(new HttpResponseMessage(statusCode));
             }
         }
 

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.Metrics;
 using System.Globalization;
+using System.Net;
 using TownCrier.Infrastructure.PlanIt;
 
 namespace TownCrier.Infrastructure.Tests.PlanIt;
@@ -485,6 +487,135 @@ public sealed class PlanItClientTests
         // Assert
         await Assert.That(results).HasCount().EqualTo(1);
         await Assert.That(results[0].Description).IsEqualTo(string.Empty);
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task Should_RecordHttpErrorMetric_When_ApiReturns429()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupRateLimitThenSuccess("page=1", count: 2, SingleRecordResponse);
+        var client = CreateClient(handler, retryOptions: new PlanItRetryOptions { MaxRetries = 3, BaseDelay = TimeSpan.FromMilliseconds(1) });
+
+        var recorded = new List<(long Value, int StatusCode, int AuthorityCode)>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Name == "towncrier.planit.http_errors")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            var statusCode = 0;
+            var authorityCode = 0;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "http.response.status_code")
+                {
+                    statusCode = (int)tag.Value!;
+                }
+
+                if (tag.Key == "planit.authority_code")
+                {
+                    authorityCode = (int)tag.Value!;
+                }
+            }
+
+            recorded.Add((measurement, statusCode, authorityCode));
+        });
+        listener.Start();
+
+        // Act
+        await ConsumeAsync(client, differentStart: null, authorityId: 292);
+
+        // Assert — 2 rate limit responses recorded
+        await Assert.That(recorded).HasCount().EqualTo(2);
+        await Assert.That(recorded[0].StatusCode).IsEqualTo(429);
+        await Assert.That(recorded[0].AuthorityCode).IsEqualTo(292);
+        await Assert.That(recorded[1].StatusCode).IsEqualTo(429);
+        await Assert.That(recorded[1].AuthorityCode).IsEqualTo(292);
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task Should_RecordHttpErrorMetric_When_ApiReturns500()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupStatusCodeResponse("page=1", HttpStatusCode.InternalServerError);
+        var client = CreateClient(handler);
+
+        var recorded = new List<(long Value, int StatusCode, int AuthorityCode)>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Name == "towncrier.planit.http_errors")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            var statusCode = 0;
+            var authorityCode = 0;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "http.response.status_code")
+                {
+                    statusCode = (int)tag.Value!;
+                }
+
+                if (tag.Key == "planit.authority_code")
+                {
+                    authorityCode = (int)tag.Value!;
+                }
+            }
+
+            recorded.Add((measurement, statusCode, authorityCode));
+        });
+        listener.Start();
+
+        // Act & Assert — EnsureSuccessStatusCode throws, but metric should still be recorded
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await ConsumeAsync(client, differentStart: null, authorityId: 314));
+
+        await Assert.That(recorded).HasCount().EqualTo(1);
+        await Assert.That(recorded[0].StatusCode).IsEqualTo(500);
+        await Assert.That(recorded[0].AuthorityCode).IsEqualTo(314);
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task Should_NotRecordHttpErrorMetric_When_ApiReturns200()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupJsonResponse("page=1", SingleRecordResponse);
+        var client = CreateClient(handler);
+
+        var recorded = new List<long>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Name == "towncrier.planit.http_errors")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            recorded.Add(measurement);
+        });
+        listener.Start();
+
+        // Act
+        await ConsumeAsync(client, differentStart: null);
+
+        // Assert — no errors recorded for successful response
+        await Assert.That(recorded).HasCount().EqualTo(0);
     }
 
     private static PlanItClient CreateClient(

--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -270,6 +270,23 @@ public static class SharedStack
                                 Position = new DashboardPartsPositionArgs { X = 9, Y = 8, ColSpan = 3, RowSpan = 4 },
                                 Metadata = MetricTile(appInsights.Id, "towncrier.api.errors", "API Errors"),
                             },
+                            // Row 4: PlanIt API Health
+                            new DashboardPartsArgs
+                            {
+                                Position = new DashboardPartsPositionArgs { X = 0, Y = 12, ColSpan = 6, RowSpan = 4 },
+                                Metadata = KqlTile(
+                                    appInsights.Id,
+                                    "customMetrics | where name == 'towncrier.planit.http_errors' | extend status = tostring(customDimensions['http.response.status_code']) | where status == '429' | summarize Value=sum(value) by timestamp=bin(timestamp, 1h) | render timechart",
+                                    "PlanIt 429s"),
+                            },
+                            new DashboardPartsArgs
+                            {
+                                Position = new DashboardPartsPositionArgs { X = 6, Y = 12, ColSpan = 6, RowSpan = 4 },
+                                Metadata = KqlTile(
+                                    appInsights.Id,
+                                    "customMetrics | where name == 'towncrier.planit.http_errors' | extend status = tostring(customDimensions['http.response.status_code']) | where status != '429' | summarize Value=sum(value) by timestamp=bin(timestamp, 1h), status | render timechart",
+                                    "PlanIt Errors"),
+                            },
                         },
                     },
                 },


### PR DESCRIPTION
## Changes
- Add `PlanItInstrumentation` class with `towncrier.planit.http_errors` counter (tagged by status code and authority)
- Instrument `PlanItClient.SendWithRetryAsync` to record every non-2xx PlanIt response
- Add 3 MeterListener-based tests verifying metric recording for 429, 500, and 200 responses
- Register `TownCrier.PlanIt` meter in worker and web OTel configuration
- Add two KQL dashboard tiles: "PlanIt 429s" (dedicated 429 monitoring) and "PlanIt Errors" (other HTTP errors by status code)

## Spec
`docs/superpowers/specs/2026-04-05-planit-http-error-metrics-design.md`

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP error tracking and monitoring for PlanIt API interactions, capturing rate-limit and error responses
  * New dashboard tiles for visualizing PlanIt API health metrics, including rate-limit events and error status breakdowns

* **Tests**
  * Added integration tests validating HTTP error metric instrumentation with tagged attributes

* **Chores**
  * Extended observability configuration to register new metrics across services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->