### PR TITLE
feat: add SRE observatory skill

### DIFF
--- a/.claude/skills/sre-observatory/SKILL.md
+++ b/.claude/skills/sre-observatory/SKILL.md
@@ -1,0 +1,385 @@
+---
+name: sre-observatory
+description: "Autonomous SRE analysis of App Insights telemetry — queries logs, traces, exceptions, dependencies, and request metrics to find performance regressions, bugs, and user frustration patterns. Files beads for anything actionable. Trigger on: 'check production health', 'look at app insights', 'what's happening in prod', 'any errors lately', 'SRE review', 'observatory', 'analyze telemetry', 'production issues', 'check logs', 'performance review', 'error analysis'. Also trigger proactively when the user mentions slowness, outages, error spikes, or user complaints."
+---
+
+# SRE Observatory
+
+You are a senior Site Reliability Engineer conducting an autonomous telemetry review. Your job is to query Application Insights, reason about what the data tells you, and file beads for anything that needs human attention. You never fix things yourself — you observe, diagnose, and report.
+
+Think like an SRE: error budgets, SLO implications, blast radius, leading indicators vs lagging indicators. A 2% error rate on a low-traffic endpoint is noise. A 2% error rate on the authentication path is a fire. Context matters more than thresholds.
+
+## Principles
+
+- **Observe, don't intervene.** Your output is beads, not code changes.
+- **Severity is relative.** A slow dependency that only affects a background job is P3. The same latency on a user-facing request path is P1.
+- **Correlate before you report.** An exception spike that coincides with a deployment is one bead. The same exceptions filed as three separate beads is noise.
+- **Deduplicate against existing work.** Before filing a bead, search for open beads that already cover the issue. If one exists, update its notes instead of creating a duplicate.
+- **Show your working.** When you file a bead, include the KQL query and key data points in the description so the person picking it up has context.
+
+## Environment
+
+```
+App Insights:  appi-town-crier-shared
+Resource Group: rg-town-crier-shared
+Query tool:    az monitor app-insights query --app appi-town-crier-shared --resource-group rg-town-crier-shared
+```
+
+All queries use `az monitor app-insights query` with KQL via the `--analytics-query` flag. Parse the JSON output — results come back as `{ "tables": [{ "columns": [...], "rows": [...] }] }`.
+
+## Time Window
+
+Default to the last 24 hours (`ago(24h)`). If the user specifies a different window (e.g., "last week", "since the deploy"), adjust accordingly. For anomaly detection, always compare the analysis window against the previous 7-day baseline.
+
+## Understanding the Telemetry Model
+
+Town Crier uses OpenTelemetry with the Azure Monitor exporter. This means data doesn't always land where you'd expect in App Insights:
+
+- **Standard tables** (`requests`, `exceptions`, `dependencies`, `traces`) may be sparse or empty if the OTel exporter isn't fully wired. Don't assume empty tables mean nothing is happening.
+- **`customMetrics`** is where OTel metrics land — including `http.client.request.duration` (outbound HTTP calls), custom business meters (`towncrier.*`), and Cosmos instrumentation. This is often the richest data source.
+- **`performanceCounters`** captures .NET CLR counters — CPU, memory, GC, and crucially, exception rates. The CLR exception counter can reveal thrown exceptions even when the `exceptions` table is empty (meaning the OTel exception pipeline isn't configured).
+
+If a standard table returns empty results, **always check customMetrics for the equivalent signal** before concluding there's no data. An empty `dependencies` table with rich `http.client.request.duration` data in customMetrics is itself an actionable finding (OTel dependency tracking misconfigured).
+
+## Execution
+
+Run phases sequentially. Each phase queries App Insights, analyzes the results, and accumulates findings. File beads only after all phases complete — this lets you correlate across signals before deciding what's actionable. The query templates below are starting points — adapt, expand, and follow threads based on what you find. Your SRE judgment matters more than rigid adherence to the template.
+
+### Phase 1: Baseline & Orientation
+
+Get a high-level picture before diving in. This tells you whether the system is healthy, degraded, or on fire, and calibrates the rest of your analysis.
+
+```
+az monitor app-insights query --app appi-town-crier-shared --resource-group rg-town-crier-shared --analytics-query "QUERY" -o json
+```
+
+**1a. Traffic & Error Overview**
+```kql
+requests
+| where timestamp > ago(24h)
+| summarize
+    totalRequests = count(),
+    failedRequests = countif(resultCode startswith "5"),
+    clientErrors = countif(resultCode startswith "4"),
+    avgDuration = avg(duration),
+    p99Duration = percentile(duration, 99)
+| extend errorRate = round(100.0 * failedRequests / totalRequests, 2)
+```
+
+**1b. Comparison to Baseline**
+```kql
+let analysisWindow = ago(24h);
+let baselineStart = ago(8d);
+let baselineEnd = ago(1d);
+requests
+| where timestamp > baselineStart
+| extend period = iff(timestamp > analysisWindow, "current", "baseline")
+| summarize
+    count_ = count(),
+    errors = countif(resultCode startswith "5"),
+    avgDuration = avg(duration),
+    p99Duration = percentile(duration, 99)
+    by period
+```
+
+Interpret the delta. A 2x increase in p99 or a 3x increase in error rate is worth investigating. Smaller shifts are normal variance unless they represent a new pattern.
+
+### Phase 2: Exception Analysis
+
+Exceptions are the most direct signal of something broken.
+
+**2a. Exception Summary**
+```kql
+exceptions
+| where timestamp > ago(24h)
+| summarize count_ = count(), lastSeen = max(timestamp) by type, outerMessage
+| order by count_ desc
+```
+
+**2b. Exception Trend (are things getting worse?)**
+```kql
+exceptions
+| where timestamp > ago(7d)
+| summarize count_ = count() by bin(timestamp, 1h), type
+| order by timestamp asc
+```
+
+Look for: new exception types (not seen in baseline period), increasing frequency, exceptions correlated with specific endpoints or dependencies.
+
+**2c. Exception → Request Correlation**
+```kql
+exceptions
+| where timestamp > ago(24h)
+| join kind=inner (
+    requests | where timestamp > ago(24h)
+) on operation_Id
+| summarize count_ = count() by requestName = name1, exceptionType = type, exceptionMessage = outerMessage
+| order by count_ desc
+```
+
+### Phase 3: Performance Analysis
+
+Latency regressions often show up before users complain. Catch them early.
+
+**3a. Endpoint Latency (current vs baseline)**
+```kql
+let analysisWindow = ago(24h);
+let baselineStart = ago(8d);
+let baselineEnd = ago(1d);
+requests
+| where timestamp > baselineStart
+| extend period = iff(timestamp > analysisWindow, "current", "baseline")
+| summarize
+    avg_ = avg(duration),
+    p50 = percentile(duration, 50),
+    p95 = percentile(duration, 95),
+    p99 = percentile(duration, 99),
+    count_ = count()
+    by name, period
+| order by name asc, period asc
+```
+
+A meaningful regression: p99 increased by more than 50% AND the endpoint handles more than a handful of requests. Single-digit request counts are too noisy to act on.
+
+**3b. Slow Operations (absolute)**
+```kql
+requests
+| where timestamp > ago(24h) and duration > 5000
+| project timestamp, name, duration, resultCode, operation_Id
+| order by duration desc
+| take 20
+```
+
+For operations over 5s, drill into the operation trace to understand where time is spent:
+
+```kql
+dependencies
+| where timestamp > ago(24h) and operation_Id == "OPERATION_ID"
+| project timestamp, type, target, name, duration, success
+| order by timestamp asc
+```
+
+### Phase 4: Dependency Health
+
+External dependencies are the most common source of production issues. Cosmos DB, Auth0, PlanIt API — each has different failure modes.
+
+**4a. Dependency Overview**
+
+Start with the standard `dependencies` table, but if it returns empty, don't stop — proceed to Phase 4b (OTel custom metrics) which often contains the real dependency data.
+
+```kql
+dependencies
+| where timestamp > ago(24h)
+| summarize
+    calls = count(),
+    failures = countif(success == false),
+    avgDuration = avg(duration),
+    p99Duration = percentile(duration, 99)
+    by type, target
+| extend failureRate = round(100.0 * failures / calls, 2)
+| order by failureRate desc, calls desc
+```
+
+If this returns zero rows, note it as a potential instrumentation gap and continue — Phase 4b will check `customMetrics` for the OTel HTTP client data.
+
+**4a-ii. Dependency Failure Details**
+```kql
+dependencies
+| where timestamp > ago(24h) and success == false
+| project timestamp, type, target, name, resultCode, duration
+| order by timestamp desc
+| take 20
+```
+
+Known dependency context for Town Crier:
+- **Cosmos DB** (`cosmos-town-crier-shared.documents.azure.com`): Core datastore. Failures here affect everything. Watch for 429s (throttling) and elevated latency (partition hot spots).
+- **Auth0** (`towncrierapp.uk.auth0.com`): Authentication. Failures here block user sessions.
+- **PlanIt API** (`www.planit.org.uk`): External planning data. Known to be slow (10-30s is normal for search). Failures here affect data freshness but not user sessions.
+
+### Phase 4b: OTel Custom Metrics & Runtime Counters
+
+This phase often reveals the most actionable data. The Azure Monitor OTel exporter sends all OpenTelemetry metrics to `customMetrics`, and .NET CLR performance counters land in `performanceCounters`. These tables may contain rich signal even when standard tables (dependencies, exceptions) are empty.
+
+**4c. Outbound HTTP Client Metrics (OTel)**
+
+This is the OTel equivalent of the `dependencies` table — and may be the only place outbound call data appears if dependency tracking isn't fully wired.
+
+```kql
+customMetrics
+| where timestamp > ago(24h) and name == 'http.client.request.duration'
+| extend server = tostring(customDimensions['server.address']),
+         statusCode = tostring(customDimensions['http.response.status_code']),
+         errorType = tostring(customDimensions['error.type']),
+         method = tostring(customDimensions['http.request.method'])
+| summarize totalRequests = sum(valueCount), totalDurationSec = sum(valueSum),
+            avgLatency = round(sum(valueSum) / sum(valueCount), 4)
+    by server, statusCode, method
+| where server !has 'applicationinsights' and server != '169.254.169.254'
+| order by totalRequests desc
+```
+
+Watch for: high 429 rates (rate limiting by external APIs), 400/500 errors on Cosmos, latency outliers. Compare success vs failure counts per target.
+
+**4d. Town Crier Business Metrics**
+
+The app emits custom meters for polling, API usage, and Cosmos instrumentation. These are the best window into whether the system is actually doing its job.
+
+```kql
+customMetrics
+| where timestamp > ago(24h) and name startswith 'towncrier.'
+| summarize totalValue = sum(valueSum), totalCount = sum(valueCount),
+            avgValue = round(sum(valueSum) / sum(valueCount), 2),
+            maxValue = max(valueMax)
+    by name, cloud_RoleInstance
+| order by name asc
+```
+
+Key metrics to check:
+- `towncrier.polling.authorities_polled` vs `towncrier.polling.authorities_skipped` — skip ratio indicates data coverage
+- `towncrier.polling.applications_ingested` — are we actually pulling data?
+- `towncrier.polling.cycle_duration_ms` — how long is each poll cycle?
+- `towncrier.polling.failures` — explicit failure counter
+- `towncrier.cosmos.request_charge_ru` — RU consumption (watch for spikes, compare to serverless burst limit of 5000 RU/s)
+- `towncrier.cosmos.throttles` — Cosmos 429s
+
+**4e. .NET Runtime Health**
+
+Performance counters reveal process-level health that application telemetry can miss.
+
+```kql
+performanceCounters
+| where timestamp > ago(24h)
+| summarize firstSeen = min(timestamp), lastSeen = max(timestamp),
+            datapoints = count(), avgValue = avg(value), maxValue = max(value)
+    by name, cloud_RoleInstance
+| order by cloud_RoleInstance asc, name asc
+```
+
+Watch for:
+- `# of Exceps Thrown / sec` > 0 when the `exceptions` table is empty — means exceptions are being thrown but not captured by OTel (actionable finding)
+- `% Processor Time` sustained > 80% — CPU pressure
+- `Available Bytes` trending down — memory leak
+- Short runtime windows (firstSeen to lastSeen) — container churn or crash loops
+
+**4f. Service Identity Check**
+
+Verify that services are reporting with correct names. The `unknown_service:` prefix means `OTEL_SERVICE_NAME` isn't set.
+
+```kql
+union requests, traces, customMetrics, performanceCounters
+| where timestamp > ago(24h)
+| summarize count_ = count(), firstSeen = min(timestamp), lastSeen = max(timestamp)
+    by cloud_RoleName
+| order by count_ desc
+```
+
+If any `cloud_RoleName` starts with `unknown_service:`, that's a bead — it means the OTel resource configuration is incomplete.
+
+### Phase 5: User Frustration Signals
+
+These patterns indicate users are having a bad time, even if the system technically isn't "down."
+
+**5a. Repeated Client Errors (retry storms / confused users)**
+```kql
+requests
+| where timestamp > ago(24h) and resultCode startswith "4"
+| summarize errorCount = count() by name, resultCode
+| where errorCount > 3
+| order by errorCount desc
+```
+
+**5b. High-Latency User Journeys**
+```kql
+requests
+| where timestamp > ago(24h)
+| summarize
+    requestCount = count(),
+    avgDuration = avg(duration),
+    maxDuration = max(duration)
+    by operation_Id
+| where requestCount > 1 and avgDuration > 3000
+| order by avgDuration desc
+| take 10
+```
+
+Then for each slow operation, trace the full journey:
+
+```kql
+union requests, dependencies
+| where operation_Id == "OPERATION_ID"
+| project timestamp, itemType, name, duration, resultCode, success
+| order by timestamp asc
+```
+
+**5c. Trace Warnings & Errors**
+```kql
+traces
+| where timestamp > ago(24h) and severityLevel >= 2
+| summarize count_ = count() by message = substring(message, 0, 200)
+| order by count_ desc
+| take 20
+```
+
+Severity levels: 0=Verbose, 1=Information, 2=Warning, 3=Error, 4=Critical. Anything at 2+ deserves a look; 3+ is almost certainly actionable.
+
+### Phase 6: Triage & File Beads
+
+Now that you have the full picture, decide what's actionable.
+
+**Triage criteria — file a bead when:**
+
+| Signal | Priority | Example |
+|--------|----------|---------|
+| Unhandled exceptions on user-facing paths | P1 | 500s on GET /v1/me |
+| External API rate limiting > 20% | P1-P2 | PlanIt returning 429 on 42% of calls |
+| P99 latency regression > 50% vs baseline | P2 | /v1/applications p99 jumped from 200ms to 400ms |
+| Dependency failure rate > 5% | P1-P2 | Cosmos 429s, PlanIt timeouts |
+| New exception type not seen in baseline | P2 | New HttpRequestException pattern |
+| CLR exception counter > 0 with empty exceptions table | P2 | OTel exception pipeline not wired |
+| OTel service name showing `unknown_service:` prefix | P2 | OTEL_SERVICE_NAME not configured |
+| Polling skip ratio > 50% | P2 | Most authorities skipped due to rate limiting |
+| Cosmos RU consumption spiking or throttling (429) | P2 | 60k RU consumed in 3 minutes |
+| Warning/error log pattern with > 10 occurrences | P2-P3 | Repeated auth token refresh failures |
+| User frustration pattern (retry storms, repeated 4xx) | P2-P3 | Same endpoint getting hammered with 400s |
+| Latency outlier > 30s on user-facing endpoint | P3 | Single request took 46s |
+| No availability monitoring configured | P3 | Empty availabilityResults table |
+
+**Don't file a bead when:**
+- The signal is within normal variance of the baseline
+- It's a known, already-tracked issue (check `bd search`)
+- The request count is too low to be meaningful (< 5 in the window)
+- It's an OPTIONS preflight or health check endpoint
+
+**Before filing each bead:**
+1. Run `bd search "<key terms>"` to check for existing beads covering this issue
+2. If a match exists, update it with `bd update <id> --notes="..."` instead of creating a duplicate
+
+**Filing format:**
+```bash
+bd create \
+  --title="[SRE] <concise description of the issue>" \
+  --description="<what was observed, including KQL query and key metrics. Include: what's happening, since when, blast radius, and suggested investigation starting point>" \
+  --type=bug \
+  --priority=<0-4>
+```
+
+Prefix all titles with `[SRE]` so these are easy to filter. Use `--type=bug` for errors and failures; `--type=task` for performance investigations that aren't strictly broken.
+
+### Phase 7: Summary & Sync
+
+After filing all beads:
+
+1. Print a brief SRE summary to the conversation:
+   - Overall system health assessment (healthy / degraded / impaired)
+   - Number of findings filed as beads
+   - Top risk if any (the one thing you'd page someone about)
+2. Sync beads: `bd dolt push`
+3. That's it. Don't suggest fixes, don't open PRs, don't touch code.
+
+## What This Skill Does NOT Do
+
+- Modify code, config, or infrastructure
+- Create PRs or branches
+- Suggest specific code fixes (that's for the engineer who picks up the bead)
+- Alert or page anyone (it's a review, not a monitoring system)
+- Query resources outside App Insights (no Cosmos direct queries, no Auth0 management API)

--- a/.gitignore
+++ b/.gitignore
@@ -85,7 +85,8 @@ node_modules/
 # Beads / Dolt files (added by bd init)
 .beads-credential-key
 .claude/worktrees/autopilot-tc-kkc.1/
-# bd worktree
 extract-polling-job/
-# bd worktree
 email-notifications/
+
+# Skill evaluation workspaces
+.claude/skills/*-workspace/

--- a/docs/superpowers/plans/2026-04-05-planit-http-error-metrics.md
+++ b/docs/superpowers/plans/2026-04-05-planit-http-error-metrics.md
@@ -1,0 +1,478 @@
+# PlanIt HTTP Error Metrics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface every non-2xx HTTP response from PlanIt as an OTel counter tagged by status code and authority, with two dedicated Azure dashboard tiles (429s and other errors).
+
+**Architecture:** New `PlanItInstrumentation` static class in infrastructure layer (following `CosmosInstrumentation` pattern). Single instrumentation point in `PlanItClient.SendWithRetryAsync`. Two KQL-based dashboard tiles in the Pulumi-managed Azure dashboard.
+
+**Tech Stack:** System.Diagnostics.Metrics (.NET), Pulumi (C#), TUnit, KQL
+
+**Spec:** `docs/superpowers/specs/2026-04-05-planit-http-error-metrics-design.md`
+
+---
+
+### Task 1: Create PlanItInstrumentation class
+
+**Files:**
+- Create: `api/src/town-crier.infrastructure/Observability/PlanItInstrumentation.cs`
+
+- [ ] **Step 1: Create the instrumentation class**
+
+```csharp
+using System.Diagnostics.Metrics;
+
+namespace TownCrier.Infrastructure.Observability;
+
+#pragma warning disable SA1202 // Meter must be initialized before public fields that reference it
+public static class PlanItInstrumentation
+{
+    public const string MeterName = "TownCrier.PlanIt";
+
+    private static readonly Meter Meter = new(MeterName);
+
+    public static readonly Counter<long> HttpErrors =
+        Meter.CreateCounter<long>(
+            "towncrier.planit.http_errors",
+            description: "Non-2xx HTTP responses from PlanIt API");
+}
+#pragma warning restore SA1202
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `dotnet build api/src/town-crier.infrastructure/town-crier.infrastructure.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api/src/town-crier.infrastructure/Observability/PlanItInstrumentation.cs
+git commit -m "feat(api): add PlanItInstrumentation class with HTTP error counter"
+```
+
+---
+
+### Task 2: Instrument PlanItClient with HTTP error recording
+
+**Files:**
+- Modify: `api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs`
+
+The `SendWithRetryAsync` method (line 150) is the single point where all PlanIt HTTP requests go through. It already inspects status codes for 429 retry logic. We add `authorityId` as a parameter and record every non-2xx response.
+
+- [ ] **Step 1: Add authorityId parameter and metric recording to SendWithRetryAsync**
+
+Change the method signature at line 150 from:
+
+```csharp
+    private async Task<HttpResponseMessage> SendWithRetryAsync(Uri url, CancellationToken ct)
+```
+
+to:
+
+```csharp
+    private async Task<HttpResponseMessage> SendWithRetryAsync(Uri url, int authorityId, CancellationToken ct)
+```
+
+Add `using TownCrier.Infrastructure.Observability;` to the top of the file (after line 5, alongside other using statements).
+
+Replace the body of the for-loop (lines 154–177) to record the metric on every non-2xx response. The full updated method:
+
+```csharp
+    private async Task<HttpResponseMessage> SendWithRetryAsync(Uri url, int authorityId, CancellationToken ct)
+    {
+        for (var attempt = 0; attempt <= this.retryOptions.MaxRetries; attempt++)
+        {
+            if (this.throttleOptions.DelayBetweenRequests > TimeSpan.Zero)
+            {
+                await this.delayFunc(this.throttleOptions.DelayBetweenRequests, ct).ConfigureAwait(false);
+            }
+
+            var response = await this.httpClient.GetAsync(url, ct).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                PlanItInstrumentation.HttpErrors.Add(
+                    1,
+                    new KeyValuePair<string, object?>("http.response.status_code", (int)response.StatusCode),
+                    new KeyValuePair<string, object?>("planit.authority_code", authorityId));
+            }
+
+            if (response.StatusCode != (HttpStatusCode)429)
+            {
+                return response;
+            }
+
+            response.Dispose();
+
+            if (attempt == this.retryOptions.MaxRetries)
+            {
+                throw new HttpRequestException(
+                    $"Rate limited by PlanIt API after {this.retryOptions.MaxRetries} retries.",
+                    inner: null,
+                    HttpStatusCode.TooManyRequests);
+            }
+
+            var delay = this.CalculateBackoffDelay(attempt);
+            await this.delayFunc(delay, ct).ConfigureAwait(false);
+        }
+
+        // Unreachable — loop always returns or throws
+        throw new InvalidOperationException();
+    }
+```
+
+- [ ] **Step 2: Update FetchApplicationsAsync call site**
+
+At line 47, change:
+
+```csharp
+            using var response = await this.SendWithRetryAsync(url, ct).ConfigureAwait(false);
+```
+
+to:
+
+```csharp
+            using var response = await this.SendWithRetryAsync(url, authorityId, ct).ConfigureAwait(false);
+```
+
+- [ ] **Step 3: Update SearchApplicationsAsync call site**
+
+At line 79, change:
+
+```csharp
+        using var response = await this.SendWithRetryAsync(url, ct).ConfigureAwait(false);
+```
+
+to:
+
+```csharp
+        using var response = await this.SendWithRetryAsync(url, authorityId, ct).ConfigureAwait(false);
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `dotnet build api/src/town-crier.infrastructure/town-crier.infrastructure.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 5: Run existing tests to confirm no regressions**
+
+Run: `dotnet test api/tests/town-crier.infrastructure.tests/ --filter "PlanItClientTests"`
+Expected: All 16 existing tests pass (no signature changes visible to callers since `SendWithRetryAsync` is private)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+git commit -m "feat(api): record PlanIt HTTP errors in SendWithRetryAsync"
+```
+
+---
+
+### Task 3: Add tests for HTTP error metric recording
+
+**Files:**
+- Modify: `api/tests/town-crier.infrastructure.tests/PlanIt/FakePlanItHandler.cs`
+- Modify: `api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs`
+
+We need to verify the counter fires with correct tags. `System.Diagnostics.Metrics` provides `MeterListener` for in-process metric collection in tests.
+
+First, add `using System.Diagnostics.Metrics;` to `PlanItClientTests.cs` (for `MeterListener`). The file already has `using System.Net;` for `HttpStatusCode`.
+
+- [ ] **Step 1: Add SetupStatusCodeResponse to FakePlanItHandler**
+
+Add a new dictionary and method to `FakePlanItHandler` to return arbitrary status codes. Add this field after line 11:
+
+```csharp
+    private readonly Dictionary<string, HttpStatusCode> statusCodeResponses = new();
+```
+
+Add this method after the `SetupRateLimitForever` method (after line 29):
+
+```csharp
+    public void SetupStatusCodeResponse(string urlContains, HttpStatusCode statusCode)
+    {
+        this.statusCodeResponses[urlContains] = statusCode;
+    }
+```
+
+In `SendAsync`, add a check for status code responses before the existing response lookup. Insert after the rate limit block (after line 45), before the response lookup (line 47):
+
+```csharp
+        foreach (var (key, statusCode) in this.statusCodeResponses)
+        {
+            if (url.Contains(key, StringComparison.Ordinal))
+            {
+                return Task.FromResult(new HttpResponseMessage(statusCode));
+            }
+        }
+```
+
+- [ ] **Step 2: Write test for 429 metric recording**
+
+Add to `PlanItClientTests.cs`:
+
+```csharp
+    [Test]
+    public async Task Should_RecordHttpErrorMetric_When_ApiReturns429()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupRateLimitThenSuccess("page=1", count: 2, SingleRecordResponse);
+        var client = CreateClient(handler, retryOptions: new PlanItRetryOptions { MaxRetries = 3, BaseDelay = TimeSpan.FromMilliseconds(1) });
+
+        var recorded = new List<(long Value, int StatusCode, int AuthorityCode)>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Name == "towncrier.planit.http_errors")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            var statusCode = 0;
+            var authorityCode = 0;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "http.response.status_code")
+                {
+                    statusCode = (int)tag.Value!;
+                }
+
+                if (tag.Key == "planit.authority_code")
+                {
+                    authorityCode = (int)tag.Value!;
+                }
+            }
+
+            recorded.Add((measurement, statusCode, authorityCode));
+        });
+        listener.Start();
+
+        // Act
+        await ConsumeAsync(client, differentStart: null, authorityId: 292);
+
+        // Assert — 2 rate limit responses recorded
+        await Assert.That(recorded).HasCount().EqualTo(2);
+        await Assert.That(recorded[0].StatusCode).IsEqualTo(429);
+        await Assert.That(recorded[0].AuthorityCode).IsEqualTo(292);
+        await Assert.That(recorded[1].StatusCode).IsEqualTo(429);
+    }
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `dotnet test api/tests/town-crier.infrastructure.tests/ --filter "Should_RecordHttpErrorMetric_When_ApiReturns429"`
+Expected: PASS
+
+- [ ] **Step 4: Write test for non-429 error metric recording**
+
+Add to `PlanItClientTests.cs`:
+
+```csharp
+    [Test]
+    public async Task Should_RecordHttpErrorMetric_When_ApiReturns500()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupStatusCodeResponse("page=1", HttpStatusCode.InternalServerError);
+        var client = CreateClient(handler);
+
+        var recorded = new List<(long Value, int StatusCode, int AuthorityCode)>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Name == "towncrier.planit.http_errors")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            var statusCode = 0;
+            var authorityCode = 0;
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "http.response.status_code")
+                {
+                    statusCode = (int)tag.Value!;
+                }
+
+                if (tag.Key == "planit.authority_code")
+                {
+                    authorityCode = (int)tag.Value!;
+                }
+            }
+
+            recorded.Add((measurement, statusCode, authorityCode));
+        });
+        listener.Start();
+
+        // Act & Assert — EnsureSuccessStatusCode throws, but metric should still be recorded
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await ConsumeAsync(client, differentStart: null, authorityId: 314));
+
+        await Assert.That(recorded).HasCount().EqualTo(1);
+        await Assert.That(recorded[0].StatusCode).IsEqualTo(500);
+        await Assert.That(recorded[0].AuthorityCode).IsEqualTo(314);
+    }
+```
+
+- [ ] **Step 5: Write test for success (no metric recorded)**
+
+Add to `PlanItClientTests.cs`:
+
+```csharp
+    [Test]
+    public async Task Should_NotRecordHttpErrorMetric_When_ApiReturns200()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupJsonResponse("page=1", SingleRecordResponse);
+        var client = CreateClient(handler);
+
+        var recorded = new List<long>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Name == "towncrier.planit.http_errors")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            recorded.Add(measurement);
+        });
+        listener.Start();
+
+        // Act
+        await ConsumeAsync(client, differentStart: null);
+
+        // Assert — no errors recorded for successful response
+        await Assert.That(recorded).HasCount().EqualTo(0);
+    }
+```
+
+- [ ] **Step 6: Run all metric tests**
+
+Run: `dotnet test api/tests/town-crier.infrastructure.tests/ --filter "Should_RecordHttpErrorMetric|Should_NotRecordHttpErrorMetric"`
+Expected: All 3 new tests pass
+
+- [ ] **Step 7: Run full PlanItClient test suite for regressions**
+
+Run: `dotnet test api/tests/town-crier.infrastructure.tests/ --filter "PlanItClientTests"`
+Expected: All tests pass (existing + 3 new)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/tests/town-crier.infrastructure.tests/PlanIt/FakePlanItHandler.cs api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+git commit -m "test(api): add tests for PlanIt HTTP error metric recording"
+```
+
+---
+
+### Task 4: Register PlanIt meter in OTel configuration
+
+**Files:**
+- Modify: `api/src/town-crier.worker/Program.cs:44-45`
+- Modify: `api/src/town-crier.web/Program.cs:36-37`
+
+- [ ] **Step 1: Add using statement and meter registration in worker**
+
+In `api/src/town-crier.worker/Program.cs`, add `using TownCrier.Infrastructure.Observability;` alongside existing using statements at the top of the file (if not already present — check first).
+
+At line 45, after `.AddMeter(CosmosInstrumentation.MeterName)`, add:
+
+```csharp
+            .AddMeter(PlanItInstrumentation.MeterName)
+```
+
+- [ ] **Step 2: Add meter registration in web**
+
+In `api/src/town-crier.web/Program.cs`, add `using TownCrier.Infrastructure.Observability;` alongside existing using statements at the top of the file (if not already present — check first).
+
+At line 37, after `.AddMeter(CosmosInstrumentation.MeterName)`, add:
+
+```csharp
+            .AddMeter(PlanItInstrumentation.MeterName)
+```
+
+- [ ] **Step 3: Verify both projects compile**
+
+Run: `dotnet build api/src/town-crier.worker/town-crier.worker.csproj && dotnet build api/src/town-crier.web/town-crier.web.csproj`
+Expected: Both build succeeded
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/src/town-crier.worker/Program.cs api/src/town-crier.web/Program.cs
+git commit -m "feat(api): register PlanIt meter in worker and web OTel config"
+```
+
+---
+
+### Task 5: Add dashboard tiles for PlanIt errors
+
+**Files:**
+- Modify: `infra/SharedStack.cs:268-272`
+
+Two KQL tiles in a new row 4 (Y=12). Using `KqlTile` because the `MetricTile` helper doesn't support dimension filters.
+
+- [ ] **Step 1: Add the two new dashboard tiles**
+
+In `infra/SharedStack.cs`, after the last tile in the Parts array (the "API Errors" tile ending around line 272), add:
+
+```csharp
+                            // Row 4: PlanIt API Health
+                            new DashboardPartsArgs
+                            {
+                                Position = new DashboardPartsPositionArgs { X = 0, Y = 12, ColSpan = 6, RowSpan = 4 },
+                                Metadata = KqlTile(
+                                    appInsights.Id,
+                                    "customMetrics | where name == 'towncrier.planit.http_errors' | extend status = tostring(customDimensions['http.response.status_code']) | where status == '429' | summarize Value=sum(value) by timestamp=bin(timestamp, 1h) | render timechart",
+                                    "PlanIt 429s"),
+                            },
+                            new DashboardPartsArgs
+                            {
+                                Position = new DashboardPartsPositionArgs { X = 6, Y = 12, ColSpan = 6, RowSpan = 4 },
+                                Metadata = KqlTile(
+                                    appInsights.Id,
+                                    "customMetrics | where name == 'towncrier.planit.http_errors' | extend status = tostring(customDimensions['http.response.status_code']) | where status != '429' | summarize Value=sum(value) by timestamp=bin(timestamp, 1h), status | render timechart",
+                                    "PlanIt Errors"),
+                            },
+```
+
+- [ ] **Step 2: Verify infra project compiles**
+
+Run: `dotnet build infra/infra.csproj`
+Expected: Build succeeded
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add infra/SharedStack.cs
+git commit -m "feat(infra): add PlanIt 429s and PlanIt Errors dashboard tiles"
+```
+
+---
+
+### Task 6: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `dotnet test api/`
+Expected: All tests pass
+
+- [ ] **Step 2: Run full solution build**
+
+Run: `dotnet build api/ && dotnet build infra/`
+Expected: Both build successfully
+
+- [ ] **Step 3: Verify formatting**
+
+Run: `dotnet format api/ --verify-no-changes`
+Expected: No formatting issues

--- a/docs/superpowers/specs/2026-04-05-planit-http-error-metrics-design.md
+++ b/docs/superpowers/specs/2026-04-05-planit-http-error-metrics-design.md
@@ -1,0 +1,125 @@
+# PlanIt HTTP Error Metrics Design
+
+Date: 2026-04-05
+
+## Goal
+
+Surface every non-2xx HTTP response from PlanIt as an OTel counter, tagged by status code and authority. Add two Azure dashboard tiles: one dedicated to 429 rate limits (primary early-warning signal), and one for all other HTTP errors.
+
+## Metric
+
+| Field | Value |
+|-------|-------|
+| Meter | `TownCrier.PlanIt` |
+| Counter | `towncrier.planit.http_errors` (long) |
+| Tag: `http.response.status_code` | Numeric status code (e.g. `429`, `500`) |
+| Tag: `planit.authority_code` | Authority ID the request was for |
+
+Every non-2xx response is counted **at the point of receipt**, before retry logic. A request that receives three 429s before succeeding produces 3 counts.
+
+## Implementation
+
+### 1. PlanItInstrumentation class
+
+New file: `api/src/town-crier.infrastructure/Observability/PlanItInstrumentation.cs`
+
+Follows the `CosmosInstrumentation` pattern:
+
+```csharp
+public static class PlanItInstrumentation
+{
+    public const string MeterName = "TownCrier.PlanIt";
+    private static readonly Meter Meter = new(MeterName);
+
+    public static readonly Counter<long> HttpErrors =
+        Meter.CreateCounter<long>(
+            "towncrier.planit.http_errors",
+            description: "Non-2xx HTTP responses from PlanIt API");
+}
+```
+
+### 2. Instrumentation point in PlanItClient
+
+`SendWithRetryAsync` is the single method that sends HTTP requests. It already inspects the status code for 429 handling. Changes:
+
+- Add `int authorityId` parameter to `SendWithRetryAsync`.
+- Record the metric for **every** non-2xx response before retry/return:
+
+```
+SendWithRetryAsync(Uri url, int authorityId, CancellationToken ct)
+    for each attempt:
+        response = httpClient.GetAsync(url)
+
+        if response is not success:
+            PlanItInstrumentation.HttpErrors.Add(1,
+                ("http.response.status_code", (int)response.StatusCode),
+                ("planit.authority_code", authorityId))
+
+        if response is not 429:
+            return response          // caller calls EnsureSuccessStatusCode()
+
+        // existing 429 retry logic continues unchanged
+```
+
+This means:
+- 429s are counted on every retry attempt, then existing backoff logic runs.
+- Other non-2xx (400, 500, 502, etc.) are counted once, then returned to the caller which throws via `EnsureSuccessStatusCode()`.
+- 2xx responses are returned without recording.
+
+Call sites updated to pass `authorityId` through:
+- `FetchApplicationsAsync` line 47: `SendWithRetryAsync(url, authorityId, ct)`
+- `SearchApplicationsAsync` line 79: `SendWithRetryAsync(url, authorityId, ct)`
+
+### 3. OTel meter registration
+
+Add `PlanItInstrumentation.MeterName` to both:
+- `api/src/town-crier.worker/Program.cs` — alongside existing `PollingMetrics` and `CosmosInstrumentation` meters
+- `api/src/town-crier.web/Program.cs` — alongside existing meters
+
+### 4. Dashboard tiles
+
+Two new tiles in `infra/SharedStack.cs`, added as row 4 below the existing 3-row layout:
+
+| Position | Metric | Filter | Title |
+|----------|--------|--------|-------|
+| X=0, Y=12, ColSpan=6, RowSpan=4 | `towncrier.planit.http_errors` | `http.response.status_code == 429` | PlanIt 429s |
+| X=6, Y=12, ColSpan=6, RowSpan=4 | `towncrier.planit.http_errors` | `http.response.status_code != 429` | PlanIt Errors |
+
+Both use KQL tiles (not the simple `MetricTile` helper) because they need a `where` filter on the status code dimension. The KQL queries:
+
+**PlanIt 429s:**
+```kql
+customMetrics
+| where name == "towncrier.planit.http_errors"
+| extend status = tostring(customDimensions["http.response.status_code"])
+| where status == "429"
+| summarize Value=sum(value) by timestamp=bin(timestamp, 1h)
+| render timechart
+```
+
+**PlanIt Errors:**
+```kql
+customMetrics
+| where name == "towncrier.planit.http_errors"
+| extend status = tostring(customDimensions["http.response.status_code"])
+| where status != "429"
+| summarize Value=sum(value) by timestamp=bin(timestamp, 1h), status
+| render timechart
+```
+
+The second query splits by status code so different error types show as separate series.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `api/src/town-crier.infrastructure/Observability/PlanItInstrumentation.cs` | **New** — meter + counter |
+| `api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs` | Add `authorityId` to `SendWithRetryAsync`, record metric on non-2xx |
+| `api/src/town-crier.worker/Program.cs` | Register `PlanItInstrumentation.MeterName` |
+| `api/src/town-crier.web/Program.cs` | Register `PlanItInstrumentation.MeterName` |
+| `infra/SharedStack.cs` | Add two KQL tiles in row 4 |
+
+## Testing
+
+- Unit test `PlanItClient` with a fake `HttpMessageHandler` that returns various status codes (429, 400, 500). Verify the counter increments with correct tags.
+- Existing polling handler tests are unaffected — the metric recording is internal to `PlanItClient`.

--- a/docs/superpowers/specs/2026-04-05-sign-out-design.md
+++ b/docs/superpowers/specs/2026-04-05-sign-out-design.md
@@ -1,0 +1,85 @@
+# Sign Out Feature — Design Spec
+
+Date: 2026-04-05
+
+## Overview
+
+Add a "Sign out" button to the Settings page that ends the user's Auth0 session and redirects to the landing page with a confirmation toast.
+
+## Decisions
+
+### Placement: Settings page only
+
+The sign-out action lives in a new "Session" section on the Settings page, placed above the danger zone (Delete Account). No sidebar, header, or avatar-menu placement.
+
+**Why:** Settings already contains account-level actions (theme, profile, account deletion). Sign out fits naturally here without adding new UI chrome.
+
+### Button style: secondary/outlined
+
+A secondary/outlined button visually distinguishes sign out from the destructive "Delete Account" button while remaining clearly actionable.
+
+### Post-logout flow: landing page with toast
+
+After sign out, Auth0 redirects to `/?signed_out=true`. The landing page detects the query parameter and displays a brief auto-dismissing toast: "You've been signed out."
+
+### No explicit local storage clearing
+
+Auth0's `logout()` clears its own tokens from localStorage (used because `cacheLocation="localstorage"` is configured in App.tsx). React Query's in-memory cache is lost on the page redirect. The only app-specific localStorage key is `tc-theme` (light/dark preference), which is a device-level preference and should persist across sign-out.
+
+## Architecture
+
+### 1. AuthPort interface expansion
+
+**File:** `web/src/domain/ports/auth-port.ts`
+
+Add `logout(): Promise<void>` to the `AuthPort` interface. This keeps the domain layer decoupled from Auth0.
+
+### 2. Auth0AuthAdapter implementation
+
+**File:** `web/src/auth/Auth0AuthAdapter.tsx`
+
+Implement `logout()` by calling Auth0's `logout()` with:
+
+```typescript
+logout({
+  logoutParams: {
+    returnTo: `${window.location.origin}?signed_out=true`,
+  },
+});
+```
+
+This ends the Auth0 session server-side and redirects to the landing page with the toast trigger parameter.
+
+### 3. Settings page — Session section
+
+**File:** `web/src/features/Settings/SettingsPage.tsx`
+
+Add a "Session" section above the existing danger zone section containing a single secondary/outlined button labelled "Sign out". On click, it calls `logout()` from the auth context.
+
+No confirmation dialog — sign out is not destructive. The user can immediately sign back in from the landing page.
+
+### 4. Landing page — signed-out toast
+
+**File:** `web/src/features/LandingPage/LandingPage.tsx`
+
+On mount, check for `?signed_out=true` in the URL search params. If present:
+
+1. Display a toast notification: "You've been signed out"
+2. Remove the query parameter from the URL (using `history.replaceState`) to prevent the toast from reappearing on refresh
+3. Auto-dismiss the toast after 4 seconds
+
+The toast component should be a simple styled div positioned at the top of the page — no need for a toast library.
+
+## Out of Scope
+
+- User avatar or profile indicator in the sidebar
+- Sign out from sidebar, header, or other locations
+- "Sign out of all devices" functionality
+- Confirmation dialog before sign out
+- Clearing device-level preferences (theme) on sign out
+
+## Testing Strategy
+
+- **AuthPort/adapter:** Unit test that `logout()` calls Auth0's logout with the correct `returnTo` URL
+- **Settings page:** Test that the Session section renders with a "Sign out" button and that clicking it invokes `logout()`
+- **Landing page toast:** Test that the toast appears when `?signed_out=true` is in the URL, and that the parameter is removed from the URL after rendering


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/sre-observatory/SKILL.md` — an autonomous SRE analysis skill that queries App Insights telemetry and files beads for actionable findings
- Covers 7 phases: baseline orientation, exceptions, performance, dependency health, OTel custom metrics & .NET runtime counters, user frustration signals, and triage
- Headless operation: no user input needed, never modifies code, files beads with `[SRE]` prefix and priority levels
- Gitignores skill evaluation workspaces (`*-workspace/`)

## Test plan

- [x] Eval-tested across 3 prompts (basic invocation, custom 48h window, user frustration focus)
- [x] Iterated v1 → v2: added `customMetrics` and `performanceCounters` coverage, increasing findings by 91%
- [x] v2 exceeds no-skill baseline in both discovery (6.3 avg findings vs 6.0) and formatting quality (100% vs 87.5% on assertions)
- [x] Verified beads use `[SRE]` prefix, `--type`, and `--priority` consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Sign Out button to Settings page with auto-dismissing confirmation message.

* **Documentation**
  * Added SRE Observatory automated telemetry analysis workflow documentation.
  * Added HTTP error metrics observability specifications and implementation plan.
  * Updated .gitignore for skill evaluation workspace handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->