### PR TITLE
refactor: remove vestigial Postcode from UserProfile

### DIFF
--- a/api/src/town-crier.application/UserProfiles/CreateUserProfileCommandHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/CreateUserProfileCommandHandler.cs
@@ -25,7 +25,6 @@ public sealed class CreateUserProfileCommandHandler
         {
             return new CreateUserProfileResult(
                 existing.UserId,
-                existing.Postcode,
                 existing.NotificationPreferences.PushEnabled,
                 existing.Tier);
         }
@@ -42,7 +41,6 @@ public sealed class CreateUserProfileCommandHandler
 
         return new CreateUserProfileResult(
             profile.UserId,
-            profile.Postcode,
             profile.NotificationPreferences.PushEnabled,
             profile.Tier);
     }

--- a/api/src/town-crier.application/UserProfiles/CreateUserProfileResult.cs
+++ b/api/src/town-crier.application/UserProfiles/CreateUserProfileResult.cs
@@ -4,6 +4,5 @@ namespace TownCrier.Application.UserProfiles;
 
 public sealed record CreateUserProfileResult(
     string UserId,
-    string? Postcode,
     bool PushEnabled,
     SubscriptionTier Tier);

--- a/api/src/town-crier.application/UserProfiles/ExportUserDataQueryHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/ExportUserDataQueryHandler.cs
@@ -20,7 +20,6 @@ public sealed class ExportUserDataQueryHandler
 
         return new ExportUserDataResult(
             profile.UserId,
-            profile.Postcode,
             profile.NotificationPreferences.PushEnabled,
             profile.Tier);
     }

--- a/api/src/town-crier.application/UserProfiles/ExportUserDataResult.cs
+++ b/api/src/town-crier.application/UserProfiles/ExportUserDataResult.cs
@@ -4,6 +4,5 @@ namespace TownCrier.Application.UserProfiles;
 
 public sealed record ExportUserDataResult(
     string UserId,
-    string? Postcode,
     bool PushEnabled,
     SubscriptionTier Tier);

--- a/api/src/town-crier.application/UserProfiles/GetUserProfileQueryHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/GetUserProfileQueryHandler.cs
@@ -21,7 +21,6 @@ public sealed class GetUserProfileQueryHandler
 
         return new GetUserProfileResult(
             profile.UserId,
-            profile.Postcode,
             profile.NotificationPreferences.PushEnabled,
             profile.Tier);
     }

--- a/api/src/town-crier.application/UserProfiles/GetUserProfileResult.cs
+++ b/api/src/town-crier.application/UserProfiles/GetUserProfileResult.cs
@@ -4,6 +4,5 @@ namespace TownCrier.Application.UserProfiles;
 
 public sealed record GetUserProfileResult(
     string UserId,
-    string? Postcode,
     bool PushEnabled,
     SubscriptionTier Tier);

--- a/api/src/town-crier.application/UserProfiles/UpdateUserProfileCommand.cs
+++ b/api/src/town-crier.application/UserProfiles/UpdateUserProfileCommand.cs
@@ -2,5 +2,4 @@ namespace TownCrier.Application.UserProfiles;
 
 public sealed record UpdateUserProfileCommand(
     string UserId,
-    string? Postcode,
     bool PushEnabled);

--- a/api/src/town-crier.application/UserProfiles/UpdateUserProfileCommandHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/UpdateUserProfileCommandHandler.cs
@@ -18,12 +18,11 @@ public sealed class UpdateUserProfileCommandHandler
         var profile = await this.repository.GetByUserIdAsync(command.UserId, ct).ConfigureAwait(false)
             ?? throw UserProfileNotFoundException.ForUser(command.UserId);
 
-        profile.UpdatePreferences(command.Postcode, new NotificationPreferences(command.PushEnabled));
+        profile.UpdatePreferences(new NotificationPreferences(command.PushEnabled));
         await this.repository.SaveAsync(profile, ct).ConfigureAwait(false);
 
         return new UpdateUserProfileResult(
             profile.UserId,
-            profile.Postcode,
             profile.NotificationPreferences.PushEnabled,
             profile.Tier);
     }

--- a/api/src/town-crier.application/UserProfiles/UpdateUserProfileResult.cs
+++ b/api/src/town-crier.application/UserProfiles/UpdateUserProfileResult.cs
@@ -4,6 +4,5 @@ namespace TownCrier.Application.UserProfiles;
 
 public sealed record UpdateUserProfileResult(
     string UserId,
-    string? Postcode,
     bool PushEnabled,
     SubscriptionTier Tier);

--- a/api/src/town-crier.domain/UserProfiles/UserProfile.cs
+++ b/api/src/town-crier.domain/UserProfiles/UserProfile.cs
@@ -7,7 +7,6 @@ public sealed class UserProfile
     private UserProfile(
         string userId,
         string? email,
-        string? postcode,
         NotificationPreferences notificationPreferences,
         SubscriptionTier tier,
         DateTimeOffset? subscriptionExpiry,
@@ -16,7 +15,6 @@ public sealed class UserProfile
     {
         this.UserId = userId;
         this.Email = email;
-        this.Postcode = postcode;
         this.NotificationPreferences = notificationPreferences;
         this.Tier = tier;
         this.SubscriptionExpiry = subscriptionExpiry;
@@ -27,8 +25,6 @@ public sealed class UserProfile
     public string UserId { get; }
 
     public string? Email { get; }
-
-    public string? Postcode { get; private set; }
 
     public NotificationPreferences NotificationPreferences { get; private set; }
 
@@ -49,7 +45,6 @@ public sealed class UserProfile
         return new UserProfile(
             userId,
             email,
-            postcode: null,
             notificationPreferences: NotificationPreferences.Default,
             tier: SubscriptionTier.Free,
             subscriptionExpiry: null,
@@ -57,9 +52,8 @@ public sealed class UserProfile
             gracePeriodExpiry: null);
     }
 
-    public void UpdatePreferences(string? postcode, NotificationPreferences notificationPreferences)
+    public void UpdatePreferences(NotificationPreferences notificationPreferences)
     {
-        this.Postcode = postcode;
         this.NotificationPreferences = notificationPreferences;
     }
 
@@ -123,7 +117,6 @@ public sealed class UserProfile
     internal static UserProfile Reconstitute(
         string userId,
         string? email,
-        string? postcode,
         NotificationPreferences notificationPreferences,
         Dictionary<string, ZoneNotificationPreferences> zonePreferences,
         SubscriptionTier tier,
@@ -134,7 +127,6 @@ public sealed class UserProfile
         var profile = new UserProfile(
             userId,
             email,
-            postcode,
             notificationPreferences,
             tier,
             subscriptionExpiry,

--- a/api/src/town-crier.infrastructure/UserProfiles/UserProfileDocument.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/UserProfileDocument.cs
@@ -10,8 +10,6 @@ internal sealed class UserProfileDocument
 
     public string? Email { get; init; }
 
-    public string? Postcode { get; init; }
-
     public required bool PushEnabled { get; init; }
 
     public required DayOfWeek DigestDay { get; init; }
@@ -39,7 +37,6 @@ internal sealed class UserProfileDocument
             Id = profile.UserId,
             UserId = profile.UserId,
             Email = profile.Email,
-            Postcode = profile.Postcode,
             PushEnabled = profile.NotificationPreferences.PushEnabled,
             DigestDay = profile.NotificationPreferences.DigestDay,
             EmailDigestEnabled = profile.NotificationPreferences.EmailDigestEnabled,
@@ -64,7 +61,6 @@ internal sealed class UserProfileDocument
         return UserProfile.Reconstitute(
             this.UserId,
             this.Email,
-            this.Postcode,
             notificationPreferences,
             this.ZonePreferences,
             tier,

--- a/api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
@@ -37,7 +37,7 @@ internal static class UserProfileEndpoints
             CancellationToken ct) =>
         {
             var userId = user.FindFirstValue("sub")!;
-            var profileCommand = new UpdateUserProfileCommand(userId, command.Postcode, command.PushEnabled);
+            var profileCommand = new UpdateUserProfileCommand(userId, command.PushEnabled);
 
             try
             {

--- a/api/tests/town-crier.application.tests/Notifications/UserProfileBuilder.cs
+++ b/api/tests/town-crier.application.tests/Notifications/UserProfileBuilder.cs
@@ -58,7 +58,6 @@ internal sealed class UserProfileBuilder
     {
         var profile = UserProfile.Register(this.userId, this.email);
         profile.UpdatePreferences(
-            postcode: null,
             new NotificationPreferences(
                 this.pushEnabled,
                 this.digestDay,

--- a/api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs
@@ -20,7 +20,6 @@ public sealed class CreateUserProfileCommandHandlerTests
         await Assert.That(result.UserId).IsEqualTo("auth0|user-123");
         await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);
         await Assert.That(result.PushEnabled).IsTrue();
-        await Assert.That(result.Postcode).IsNull();
     }
 
     [Test]

--- a/api/tests/town-crier.application.tests/UserProfiles/ExportUserDataQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/ExportUserDataQueryHandlerTests.cs
@@ -11,7 +11,7 @@ public sealed class ExportUserDataQueryHandlerTests
         // Arrange
         var repository = new FakeUserProfileRepository();
         var profile = UserProfile.Register("auth0|user1");
-        profile.UpdatePreferences("SW1A 1AA", new NotificationPreferences(PushEnabled: true));
+        profile.UpdatePreferences(new NotificationPreferences(PushEnabled: true));
         await repository.SaveAsync(profile, CancellationToken.None);
         var handler = new ExportUserDataQueryHandler(repository);
 
@@ -22,7 +22,6 @@ public sealed class ExportUserDataQueryHandlerTests
         // Assert
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.UserId).IsEqualTo("auth0|user1");
-        await Assert.That(result.Postcode).IsEqualTo("SW1A 1AA");
         await Assert.That(result.PushEnabled).IsTrue();
         await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);
     }

--- a/api/tests/town-crier.application.tests/UserProfiles/GetUserProfileQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/GetUserProfileQueryHandlerTests.cs
@@ -39,6 +39,5 @@ public sealed class GetUserProfileQueryHandlerTests
         await Assert.That(result!.UserId).IsEqualTo("auth0|user-456");
         await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);
         await Assert.That(result.PushEnabled).IsTrue();
-        await Assert.That(result.Postcode).IsNull();
     }
 }

--- a/api/tests/town-crier.application.tests/UserProfiles/UpdateUserProfileCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/UpdateUserProfileCommandHandlerTests.cs
@@ -6,7 +6,7 @@ namespace TownCrier.Application.Tests.UserProfiles;
 public sealed class UpdateUserProfileCommandHandlerTests
 {
     [Test]
-    public async Task Should_UpdatePostcode_When_ProfileExists()
+    public async Task Should_UpdatePushEnabled_When_ProfileExists()
     {
         // Arrange
         var repository = new FakeUserProfileRepository();
@@ -14,13 +14,12 @@ public sealed class UpdateUserProfileCommandHandlerTests
         await repository.SaveAsync(profile, CancellationToken.None);
 
         var handler = new UpdateUserProfileCommandHandler(repository);
-        var command = new UpdateUserProfileCommand("auth0|user-789", "SW1A 1AA", true);
+        var command = new UpdateUserProfileCommand("auth0|user-789", true);
 
         // Act
         var result = await handler.HandleAsync(command, CancellationToken.None);
 
         // Assert
-        await Assert.That(result.Postcode).IsEqualTo("SW1A 1AA");
         await Assert.That(result.PushEnabled).IsTrue();
     }
 
@@ -33,14 +32,13 @@ public sealed class UpdateUserProfileCommandHandlerTests
         await repository.SaveAsync(profile, CancellationToken.None);
 
         var handler = new UpdateUserProfileCommandHandler(repository);
-        var command = new UpdateUserProfileCommand("auth0|user-789", null, false);
+        var command = new UpdateUserProfileCommand("auth0|user-789", false);
 
         // Act
         var result = await handler.HandleAsync(command, CancellationToken.None);
 
         // Assert
         await Assert.That(result.PushEnabled).IsFalse();
-        await Assert.That(result.Postcode).IsNull();
     }
 
     [Test]
@@ -52,15 +50,14 @@ public sealed class UpdateUserProfileCommandHandlerTests
         await repository.SaveAsync(profile, CancellationToken.None);
 
         var handler = new UpdateUserProfileCommandHandler(repository);
-        var command = new UpdateUserProfileCommand("auth0|user-789", "EC1A 1BB", false);
+        var command = new UpdateUserProfileCommand("auth0|user-789", false);
 
         // Act
         await handler.HandleAsync(command, CancellationToken.None);
 
         // Assert
         var saved = repository.GetByUserId("auth0|user-789");
-        await Assert.That(saved!.Postcode).IsEqualTo("EC1A 1BB");
-        await Assert.That(saved.NotificationPreferences.PushEnabled).IsFalse();
+        await Assert.That(saved!.NotificationPreferences.PushEnabled).IsFalse();
     }
 
     [Test]
@@ -69,7 +66,7 @@ public sealed class UpdateUserProfileCommandHandlerTests
         // Arrange
         var repository = new FakeUserProfileRepository();
         var handler = new UpdateUserProfileCommandHandler(repository);
-        var command = new UpdateUserProfileCommand("auth0|nonexistent", "SW1A 1AA", true);
+        var command = new UpdateUserProfileCommand("auth0|nonexistent", true);
 
         // Act & Assert
         await Assert.ThrowsAsync<UserProfileNotFoundException>(
@@ -85,7 +82,7 @@ public sealed class UpdateUserProfileCommandHandlerTests
         await repository.SaveAsync(profile, CancellationToken.None);
 
         var handler = new UpdateUserProfileCommandHandler(repository);
-        var command = new UpdateUserProfileCommand("auth0|user-789", "SW1A 1AA", false);
+        var command = new UpdateUserProfileCommand("auth0|user-789", false);
 
         // Act
         var result = await handler.HandleAsync(command, CancellationToken.None);

--- a/api/tests/town-crier.infrastructure.tests/UserProfiles/CosmosUserProfileRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/UserProfiles/CosmosUserProfileRepositoryTests.cs
@@ -14,7 +14,7 @@ public sealed class CosmosUserProfileRepositoryTests
         var repo = new CosmosUserProfileRepository(client);
 
         var profile = UserProfile.Register("user-1");
-        profile.UpdatePreferences("SW1A 1AA", NotificationPreferences.Default);
+        profile.UpdatePreferences(NotificationPreferences.Default);
         await repo.SaveAsync(profile, CancellationToken.None);
 
         // Act
@@ -23,7 +23,6 @@ public sealed class CosmosUserProfileRepositoryTests
         // Assert
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.UserId).IsEqualTo("user-1");
-        await Assert.That(result.Postcode).IsEqualTo("SW1A 1AA");
     }
 
     [Test]

--- a/api/tests/town-crier.infrastructure.tests/UserProfiles/UserProfileDocumentSerializationTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/UserProfiles/UserProfileDocumentSerializationTests.cs
@@ -23,7 +23,7 @@ public sealed class UserProfileDocumentSerializationTests
     {
         // Arrange
         var profile = UserProfile.Register("auth0|user-1");
-        profile.UpdatePreferences("SW1A 1AA", new NotificationPreferences(true, DayOfWeek.Wednesday));
+        profile.UpdatePreferences(new NotificationPreferences(true, DayOfWeek.Wednesday));
         profile.ActivateSubscription(SubscriptionTier.Pro, new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
         profile.LinkOriginalTransactionId("txn-ser-123");
         profile.SetZonePreferences("zone-1", new ZoneNotificationPreferences(true, true, false));
@@ -36,7 +36,6 @@ public sealed class UserProfileDocumentSerializationTests
         // Assert
         await Assert.That(deserialized.Id).IsEqualTo(original.Id);
         await Assert.That(deserialized.UserId).IsEqualTo(original.UserId);
-        await Assert.That(deserialized.Postcode).IsEqualTo(original.Postcode);
         await Assert.That(deserialized.PushEnabled).IsEqualTo(original.PushEnabled);
         await Assert.That(deserialized.DigestDay).IsEqualTo(original.DigestDay);
         await Assert.That(deserialized.Tier).IsEqualTo(original.Tier);

--- a/api/tests/town-crier.infrastructure.tests/UserProfiles/UserProfileDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/UserProfiles/UserProfileDocumentTests.cs
@@ -23,7 +23,7 @@ public sealed class UserProfileDocumentTests
     {
         // Arrange
         var profile = UserProfile.Register("auth0|user-1");
-        profile.UpdatePreferences("SW1A 1AA", new NotificationPreferences(true, DayOfWeek.Wednesday));
+        profile.UpdatePreferences(new NotificationPreferences(true, DayOfWeek.Wednesday));
         profile.ActivateSubscription(SubscriptionTier.Pro, new DateTimeOffset(2027, 1, 1, 0, 0, 0, TimeSpan.Zero));
         profile.LinkOriginalTransactionId("txn-abc-123");
 
@@ -32,7 +32,6 @@ public sealed class UserProfileDocumentTests
 
         // Assert
         await Assert.That(document.UserId).IsEqualTo("auth0|user-1");
-        await Assert.That(document.Postcode).IsEqualTo("SW1A 1AA");
         await Assert.That(document.PushEnabled).IsTrue();
         await Assert.That(document.DigestDay).IsEqualTo(DayOfWeek.Wednesday);
         await Assert.That(document.Tier).IsEqualTo("Pro");
@@ -45,7 +44,7 @@ public sealed class UserProfileDocumentTests
     {
         // Arrange
         var original = UserProfile.Register("auth0|user-1");
-        original.UpdatePreferences("SW1A 1AA", new NotificationPreferences(false, DayOfWeek.Friday));
+        original.UpdatePreferences(new NotificationPreferences(false, DayOfWeek.Friday));
         original.ActivateSubscription(SubscriptionTier.Pro, new DateTimeOffset(2027, 6, 15, 0, 0, 0, TimeSpan.Zero));
         original.LinkOriginalTransactionId("txn-round-trip");
         original.EnterGracePeriod(new DateTimeOffset(2027, 7, 1, 0, 0, 0, TimeSpan.Zero));
@@ -56,7 +55,6 @@ public sealed class UserProfileDocumentTests
 
         // Assert
         await Assert.That(roundTripped.UserId).IsEqualTo(original.UserId);
-        await Assert.That(roundTripped.Postcode).IsEqualTo(original.Postcode);
         await Assert.That(roundTripped.NotificationPreferences.PushEnabled).IsEqualTo(original.NotificationPreferences.PushEnabled);
         await Assert.That(roundTripped.NotificationPreferences.DigestDay).IsEqualTo(original.NotificationPreferences.DigestDay);
         await Assert.That(roundTripped.Tier).IsEqualTo(original.Tier);
@@ -93,14 +91,13 @@ public sealed class UserProfileDocumentTests
     [Test]
     public async Task Should_HandleNullOptionalFields_When_MappedFromDomain()
     {
-        // Arrange — fresh profile has null postcode, subscription expiry, etc.
+        // Arrange — fresh profile has null subscription expiry, etc.
         var profile = UserProfile.Register("auth0|user-1");
 
         // Act
         var document = UserProfileDocument.FromDomain(profile);
 
         // Assert
-        await Assert.That(document.Postcode).IsNull();
         await Assert.That(document.Tier).IsEqualTo("Free");
         await Assert.That(document.SubscriptionExpiry).IsNull();
         await Assert.That(document.OriginalTransactionId).IsNull();

--- a/web/src/domain/types.ts
+++ b/web/src/domain/types.ts
@@ -68,7 +68,6 @@ export interface Coordinates {
 
 export interface UserProfile {
   readonly userId: string;
-  readonly postcode: string | null;
   readonly pushEnabled: boolean;
   readonly tier: SubscriptionTier;
 }
@@ -206,7 +205,6 @@ export interface CreateWatchZoneRequest {
 }
 
 export interface UpdateProfileRequest {
-  readonly postcode: string | null;
   readonly pushEnabled: boolean;
 }
 

--- a/web/src/features/Settings/SettingsPage.tsx
+++ b/web/src/features/Settings/SettingsPage.tsx
@@ -57,10 +57,6 @@ export function SettingsPage({ repository }: Props) {
             <span className={styles.value}>{profile?.userId}</span>
           </div>
           <div className={styles.field}>
-            <span className={styles.label}>Postcode</span>
-            <span className={styles.value}>{profile?.postcode ?? 'Not set'}</span>
-          </div>
-          <div className={styles.field}>
             <span className={styles.label}>Subscription</span>
             <span className={styles.value}>{profile?.tier}</span>
           </div>

--- a/web/src/features/Settings/__tests__/SettingsPage.test.tsx
+++ b/web/src/features/Settings/__tests__/SettingsPage.test.tsx
@@ -41,14 +41,11 @@ describe('SettingsPage', () => {
   });
 
   it('renders profile info after loading', async () => {
-    spy.fetchProfileResult = proUserProfile({
-      postcode: 'SW1A 1AA',
-    });
+    spy.fetchProfileResult = proUserProfile();
 
     renderSettingsPage(spy);
 
-    expect(await screen.findByText('SW1A 1AA')).toBeInTheDocument();
-    expect(screen.getByText('Pro')).toBeInTheDocument();
+    expect(await screen.findByText('Pro')).toBeInTheDocument();
   });
 
   it('renders Free tier for free users', async () => {

--- a/web/src/features/Settings/__tests__/fixtures/user-profile.fixtures.ts
+++ b/web/src/features/Settings/__tests__/fixtures/user-profile.fixtures.ts
@@ -5,7 +5,6 @@ export function freeUserProfile(
 ): UserProfile {
   return {
     userId: 'auth0|abc123',
-    postcode: 'CB1 2AD',
     pushEnabled: true,
     tier: 'Free' as SubscriptionTier,
     ...overrides,


### PR DESCRIPTION
## Changes
- Remove `Postcode` property from `UserProfile` domain model, constructor, `UpdatePreferences`, and `Reconstitute`
- Remove `Postcode` from `UserProfileDocument` Cosmos DB mapping
- Remove `Postcode` from all CQRS commands, queries, and results (`UpdateUserProfileCommand`, `UpdateUserProfileResult`, `GetUserProfileResult`, `CreateUserProfileResult`, `ExportUserDataResult`)
- Remove postcode parameter from `PATCH /v1/me` endpoint
- Update all API tests (129 passing)
- Remove `postcode` from web `UserProfile` and `UpdateProfileRequest` types
- Remove "Postcode" row from Settings page (438 web tests passing)

The `Postcode` value object, geocoding service, `PlanningApplication.Postcode`, and iOS `WatchZone.postcode` are unaffected — they serve different purposes.

---
*Auto-shipped via ship skill*