### PR TITLE
fix(infra): use structured ComponentId for dashboard KQL tiles

### DIFF
--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -441,6 +441,18 @@ public static class SharedStack
     private static DashboardPartMetadataArgs KqlTile(
         Output<string> appInsightsId, string query, string title)
     {
+        var componentId = appInsightsId.Apply(id =>
+        {
+            var segments = id.Split('/');
+            return new Dictionary<string, object>
+            {
+                ["SubscriptionId"] = segments[2],
+                ["ResourceGroup"] = segments[4],
+                ["Name"] = segments[8],
+                ["ResourceId"] = id,
+            };
+        });
+
         return new DashboardPartMetadataArgs
         {
             Type = "Extension/AppInsightsExtension/PartType/AnalyticsPart",
@@ -476,7 +488,7 @@ public static class SharedStack
                 (object)new Dictionary<string, object>
                 {
                     ["name"] = "ComponentId",
-                    ["value"] = appInsightsId,
+                    ["value"] = componentId,
                 },
             },
         };


### PR DESCRIPTION
## Changes
- Fix all 3 KQL dashboard tiles (Active Users, PlanIt 429s, PlanIt Errors) showing "Invalid input: 'ComponentId'" by passing ComponentId as a structured object `{SubscriptionId, ResourceGroup, Name, ResourceId}` instead of a plain resource ID string, which is what Azure's AnalyticsPart expects.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dashboard component configuration to improve identifier derivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->