### PR TITLE
feat(web): add sign-out to settings page

### DIFF
--- a/web/src/auth/Auth0AuthAdapter.tsx
+++ b/web/src/auth/Auth0AuthAdapter.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useMemo } from 'react';
+import { useMemo, useCallback } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { AuthProvider } from './auth-context';
 import type { AuthPort } from '../domain/ports/auth-port';
@@ -9,7 +9,17 @@ interface Props {
 }
 
 export function Auth0AuthAdapter({ children }: Props) {
-  const { isAuthenticated, isLoading, loginWithRedirect, error } = useAuth0();
+  const { isAuthenticated, isLoading, loginWithRedirect, logout: auth0Logout, error } = useAuth0();
+
+  const logout = useCallback(
+    () =>
+      auth0Logout({
+        logoutParams: {
+          returnTo: `${window.location.origin}?signed_out=true`,
+        },
+      }),
+    [auth0Logout],
+  );
 
   const auth: AuthPort = useMemo(
     () => ({
@@ -17,8 +27,9 @@ export function Auth0AuthAdapter({ children }: Props) {
       isLoading,
       error,
       loginWithRedirect: () => loginWithRedirect(),
+      logout,
     }),
-    [isAuthenticated, isLoading, error, loginWithRedirect],
+    [isAuthenticated, isLoading, error, loginWithRedirect, logout],
   );
 
   return (

--- a/web/src/auth/__tests__/Auth0AuthAdapter.test.tsx
+++ b/web/src/auth/__tests__/Auth0AuthAdapter.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Auth0AuthAdapter } from '../Auth0AuthAdapter';
+import { useAuth } from '../auth-context';
+
+const mockLogout = vi.fn<() => Promise<void>>();
+const mockLoginWithRedirect = vi.fn<() => Promise<void>>();
+
+vi.mock('@auth0/auth0-react', () => ({
+  useAuth0: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    error: undefined,
+    loginWithRedirect: mockLoginWithRedirect,
+    logout: mockLogout,
+  }),
+}));
+
+function Consumer() {
+  const auth = useAuth();
+  return (
+    <div>
+      <span data-testid="authenticated">{String(auth.isAuthenticated)}</span>
+      <button onClick={() => auth.logout()}>Sign Out</button>
+    </div>
+  );
+}
+
+describe('Auth0AuthAdapter', () => {
+  beforeEach(() => {
+    mockLogout.mockReset();
+    mockLoginWithRedirect.mockReset();
+  });
+
+  it('provides isAuthenticated from Auth0', () => {
+    render(
+      <Auth0AuthAdapter>
+        <Consumer />
+      </Auth0AuthAdapter>,
+    );
+
+    expect(screen.getByTestId('authenticated')).toHaveTextContent('true');
+  });
+
+  it('calls auth0 logout with returnTo including signed_out param', async () => {
+    render(
+      <Auth0AuthAdapter>
+        <Consumer />
+      </Auth0AuthAdapter>,
+    );
+
+    await act(async () => {
+      screen.getByRole('button', { name: /sign out/i }).click();
+    });
+
+    expect(mockLogout).toHaveBeenCalledTimes(1);
+    expect(mockLogout).toHaveBeenCalledWith({
+      logoutParams: {
+        returnTo: `${window.location.origin}?signed_out=true`,
+      },
+    });
+  });
+});

--- a/web/src/auth/__tests__/spies/spy-auth-port.ts
+++ b/web/src/auth/__tests__/spies/spy-auth-port.ts
@@ -5,8 +5,13 @@ export class SpyAuthPort implements AuthPort {
   isLoading = false;
   error: Error | undefined = undefined;
   loginWithRedirectCalls = 0;
+  logoutCalls = 0;
 
   loginWithRedirect = async (): Promise<void> => {
     this.loginWithRedirectCalls += 1;
+  };
+
+  logout = async (): Promise<void> => {
+    this.logoutCalls += 1;
   };
 }

--- a/web/src/components/Toast/Toast.module.css
+++ b/web/src/components/Toast/Toast.module.css
@@ -1,0 +1,14 @@
+.toast {
+  position: fixed;
+  top: var(--tc-space-md);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--tc-surface);
+  color: var(--tc-text-primary);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  padding: var(--tc-space-sm) var(--tc-space-lg);
+  font-size: var(--tc-text-body);
+  box-shadow: var(--tc-shadow-card);
+  z-index: 1000;
+}

--- a/web/src/components/Toast/Toast.tsx
+++ b/web/src/components/Toast/Toast.tsx
@@ -1,0 +1,15 @@
+import styles from './Toast.module.css';
+
+interface Props {
+  message: string;
+  onDismiss: () => void;
+  duration?: number;
+}
+
+export function Toast({ message }: Props) {
+  return (
+    <div className={styles.toast} role="status">
+      {message}
+    </div>
+  );
+}

--- a/web/src/components/Toast/Toast.tsx
+++ b/web/src/components/Toast/Toast.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import styles from './Toast.module.css';
 
 interface Props {
@@ -6,7 +7,12 @@ interface Props {
   duration?: number;
 }
 
-export function Toast({ message }: Props) {
+export function Toast({ message, onDismiss, duration = 4000 }: Props) {
+  useEffect(() => {
+    const timer = setTimeout(onDismiss, duration);
+    return () => clearTimeout(timer);
+  }, [onDismiss, duration]);
+
   return (
     <div className={styles.toast} role="status">
       {message}

--- a/web/src/components/Toast/__tests__/Toast.test.tsx
+++ b/web/src/components/Toast/__tests__/Toast.test.tsx
@@ -1,11 +1,30 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Toast } from '../Toast';
 
 describe('Toast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('renders the message', () => {
     render(<Toast message="You've been signed out" onDismiss={() => {}} />);
 
     expect(screen.getByText("You've been signed out")).toBeInTheDocument();
+  });
+
+  it('calls onDismiss after duration', () => {
+    const onDismiss = vi.fn();
+    render(<Toast message="Gone" onDismiss={onDismiss} duration={4000} />);
+
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(4000);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/components/Toast/__tests__/Toast.test.tsx
+++ b/web/src/components/Toast/__tests__/Toast.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Toast } from '../Toast';
+
+describe('Toast', () => {
+  it('renders the message', () => {
+    render(<Toast message="You've been signed out" onDismiss={() => {}} />);
+
+    expect(screen.getByText("You've been signed out")).toBeInTheDocument();
+  });
+});

--- a/web/src/domain/ports/auth-port.ts
+++ b/web/src/domain/ports/auth-port.ts
@@ -3,4 +3,5 @@ export interface AuthPort {
   readonly isLoading: boolean;
   readonly error: Error | undefined;
   loginWithRedirect(): Promise<void>;
+  logout(): Promise<void>;
 }

--- a/web/src/features/LandingPage/LandingPage.tsx
+++ b/web/src/features/LandingPage/LandingPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Navbar } from '../../components/Navbar/Navbar';
 import { Hero } from '../../components/Hero/Hero';
 import { StatsBar } from '../../components/StatsBar/StatsBar';
@@ -6,16 +7,30 @@ import { HowItWorks } from '../../components/HowItWorks/HowItWorks';
 import { Pricing } from '../../components/Pricing/Pricing';
 import { Faq } from '../../components/Faq/Faq';
 import { Footer } from '../../components/Footer/Footer';
+import { Toast } from '../../components/Toast/Toast';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string || 'http://localhost:5000';
 
 export function LandingPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [showSignedOut, setShowSignedOut] = useState(
+    () => searchParams.get('signed_out') === 'true',
+  );
+
   // Wake the API container while the user reads the landing page.
   // Azure Container Apps can take ~12s to cold-start from zero replicas;
   // by the time the user clicks sign-in and completes Auth0, it's warm.
   useEffect(() => {
     fetch(`${API_BASE_URL}/health`).catch(() => {});
   }, []);
+
+  // Remove the query param so the toast doesn't reappear on refresh
+  useEffect(() => {
+    if (searchParams.has('signed_out')) {
+      searchParams.delete('signed_out');
+      setSearchParams(searchParams, { replace: true });
+    }
+  }, [searchParams, setSearchParams]);
 
   return (
     <>
@@ -28,6 +43,12 @@ export function LandingPage() {
         <Faq />
       </main>
       <Footer />
+      {showSignedOut && (
+        <Toast
+          message="You've been signed out"
+          onDismiss={() => setShowSignedOut(false)}
+        />
+      )}
     </>
   );
 }

--- a/web/src/features/LandingPage/__tests__/LandingPage.test.tsx
+++ b/web/src/features/LandingPage/__tests__/LandingPage.test.tsx
@@ -80,6 +80,12 @@ describe('LandingPage', () => {
     ]);
   });
 
+  it('does not show signed-out toast without query param', () => {
+    renderLandingPage();
+
+    expect(screen.queryByText("You've been signed out")).not.toBeInTheDocument();
+  });
+
   it('shows signed-out toast when ?signed_out=true is present', () => {
     render(
       <MemoryRouter initialEntries={['/?signed_out=true']}>

--- a/web/src/features/LandingPage/__tests__/LandingPage.test.tsx
+++ b/web/src/features/LandingPage/__tests__/LandingPage.test.tsx
@@ -79,4 +79,16 @@ describe('LandingPage', () => {
       'faq',
     ]);
   });
+
+  it('shows signed-out toast when ?signed_out=true is present', () => {
+    render(
+      <MemoryRouter initialEntries={['/?signed_out=true']}>
+        <AuthProvider value={new SpyAuthPort()}>
+          <LandingPage />
+        </AuthProvider>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("You've been signed out")).toBeInTheDocument();
+  });
 });

--- a/web/src/features/Settings/SettingsPage.tsx
+++ b/web/src/features/Settings/SettingsPage.tsx
@@ -88,6 +88,19 @@ export function SettingsPage({ repository }: Props) {
         </div>
       </section>
 
+      {/* Session section */}
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Session</h2>
+        <div className={styles.card}>
+          <button
+            className={styles.secondaryButton}
+            onClick={() => logout()}
+          >
+            Sign Out
+          </button>
+        </div>
+      </section>
+
       {/* Danger zone */}
       <section className={styles.section}>
         <h2 className={styles.sectionTitle}>Account</h2>

--- a/web/src/features/Settings/SettingsPage.tsx
+++ b/web/src/features/Settings/SettingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useAuth0 } from '@auth0/auth0-react';
+import { useAuth } from '../../auth/auth-context';
 import { useTheme } from '../../hooks/useTheme';
 import { useUserProfile } from './useUserProfile';
 import { ThemeToggle } from '../../components/ThemeToggle/ThemeToggle';
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export function SettingsPage({ repository }: Props) {
-  const { logout } = useAuth0();
+  const { logout } = useAuth();
   const { theme, toggleTheme } = useTheme();
   const {
     profile,

--- a/web/src/features/Settings/__tests__/SettingsPage.test.tsx
+++ b/web/src/features/Settings/__tests__/SettingsPage.test.tsx
@@ -142,4 +142,20 @@ describe('SettingsPage', () => {
 
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
+
+  it('renders sign out button in Session section', async () => {
+    renderSettingsPage(spy);
+
+    expect(await screen.findByRole('button', { name: /sign out/i })).toBeInTheDocument();
+  });
+
+  it('calls logout when sign out button is clicked', async () => {
+    const user = userEvent.setup();
+    renderSettingsPage(spy);
+
+    const button = await screen.findByRole('button', { name: /sign out/i });
+    await user.click(button);
+
+    expect(spyAuth.logoutCalls).toBe(1);
+  });
 });

--- a/web/src/features/Settings/__tests__/SettingsPage.test.tsx
+++ b/web/src/features/Settings/__tests__/SettingsPage.test.tsx
@@ -5,6 +5,8 @@ import { MemoryRouter } from 'react-router-dom';
 import { SettingsPage } from '../SettingsPage';
 import { SpySettingsRepository } from './spies/spy-settings-repository';
 import { freeUserProfile, proUserProfile } from './fixtures/user-profile.fixtures';
+import { AuthProvider } from '../../../auth/auth-context';
+import { SpyAuthPort } from '../../../auth/__tests__/spies/spy-auth-port';
 
 // Stub useTheme — ThemeToggle receives theme/toggleTheme as props so we
 // only need to verify the toggle is rendered and clickable.
@@ -12,16 +14,15 @@ vi.mock('../../../hooks/useTheme', () => ({
   useTheme: () => ({ theme: 'light' as const, toggleTheme: vi.fn() }),
 }));
 
-// Stub useAuth0 — SettingsPage gets logout from Auth0.
-const mockLogout = vi.fn();
-vi.mock('@auth0/auth0-react', () => ({
-  useAuth0: () => ({ logout: mockLogout }),
-}));
+let spyAuth: SpyAuthPort;
 
 function renderSettingsPage(repository: SpySettingsRepository) {
+  spyAuth = new SpyAuthPort();
   return render(
     <MemoryRouter>
-      <SettingsPage repository={repository} />
+      <AuthProvider value={spyAuth}>
+        <SettingsPage repository={repository} />
+      </AuthProvider>
     </MemoryRouter>,
   );
 }
@@ -31,7 +32,6 @@ describe('SettingsPage', () => {
 
   beforeEach(() => {
     spy = new SpySettingsRepository();
-    mockLogout.mockReset();
   });
 
   it('renders the page heading', async () => {
@@ -107,6 +107,7 @@ describe('SettingsPage', () => {
     await user.click(confirmButton);
 
     expect(spy.deleteAccountCalls).toBe(1);
+    expect(spyAuth.logoutCalls).toBe(1);
   });
 
   it('renders attribution section', async () => {


### PR DESCRIPTION
## Changes
- Add `logout()` to `AuthPort` interface and `SpyAuthPort` test double
- Implement `logout()` in `Auth0AuthAdapter` with `returnTo` URL including `?signed_out=true`
- Add "Session" section to Settings page with "Sign Out" button (secondary style, above danger zone)
- Migrate SettingsPage tests from direct Auth0 mock to `AuthProvider` + `SpyAuthPort`
- Create reusable `Toast` component with auto-dismiss (4s default, `role="status"`)
- Show "You've been signed out" toast on landing page when `?signed_out=true` query param present; strip param after render

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sign-out functionality with configurable redirect behavior
  * Introduced Toast notification component for user feedback
  * Added "Sign Out" button in Settings page
  * Added "You've been signed out" confirmation message after logout

* **Tests**
  * Added comprehensive test coverage for authentication adapter
  * Added Toast component and notification tests
  * Added signed-out state verification tests
  * Updated Settings page test suite with authentication improvements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->