### PR TITLE
feat: wire up email notification service

### DIFF
--- a/api/src/town-crier.application/Observability/ApiMetrics.cs
+++ b/api/src/town-crier.application/Observability/ApiMetrics.cs
@@ -36,5 +36,15 @@ public static class ApiMetrics
         Meter.CreateCounter<long>(
             "towncrier.notifications.created",
             description: "Notification records created (may or may not result in push)");
+
+    public static readonly Counter<long> EmailsSent =
+        Meter.CreateCounter<long>(
+            "towncrier.emails.sent",
+            description: "Emails successfully queued for delivery");
+
+    public static readonly Counter<long> EmailsFailed =
+        Meter.CreateCounter<long>(
+            "towncrier.emails.failed",
+            description: "Email send failures");
 }
 #pragma warning restore SA1202

--- a/api/src/town-crier.application/UserProfiles/UpdateUserProfileCommand.cs
+++ b/api/src/town-crier.application/UserProfiles/UpdateUserProfileCommand.cs
@@ -2,4 +2,7 @@ namespace TownCrier.Application.UserProfiles;
 
 public sealed record UpdateUserProfileCommand(
     string UserId,
-    bool PushEnabled);
+    bool PushEnabled,
+    DayOfWeek DigestDay = DayOfWeek.Monday,
+    bool EmailDigestEnabled = true,
+    bool EmailInstantEnabled = false);

--- a/api/src/town-crier.application/UserProfiles/UpdateUserProfileCommandHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/UpdateUserProfileCommandHandler.cs
@@ -18,12 +18,19 @@ public sealed class UpdateUserProfileCommandHandler
         var profile = await this.repository.GetByUserIdAsync(command.UserId, ct).ConfigureAwait(false)
             ?? throw UserProfileNotFoundException.ForUser(command.UserId);
 
-        profile.UpdatePreferences(new NotificationPreferences(command.PushEnabled));
+        profile.UpdatePreferences(new NotificationPreferences(
+            command.PushEnabled,
+            command.DigestDay,
+            command.EmailDigestEnabled,
+            command.EmailInstantEnabled));
         await this.repository.SaveAsync(profile, ct).ConfigureAwait(false);
 
         return new UpdateUserProfileResult(
             profile.UserId,
             profile.NotificationPreferences.PushEnabled,
+            profile.NotificationPreferences.DigestDay,
+            profile.NotificationPreferences.EmailDigestEnabled,
+            profile.NotificationPreferences.EmailInstantEnabled,
             profile.Tier);
     }
 }

--- a/api/src/town-crier.application/UserProfiles/UpdateUserProfileResult.cs
+++ b/api/src/town-crier.application/UserProfiles/UpdateUserProfileResult.cs
@@ -5,4 +5,7 @@ namespace TownCrier.Application.UserProfiles;
 public sealed record UpdateUserProfileResult(
     string UserId,
     bool PushEnabled,
+    DayOfWeek DigestDay,
+    bool EmailDigestEnabled,
+    bool EmailInstantEnabled,
     SubscriptionTier Tier);

--- a/api/src/town-crier.infrastructure/Notifications/AcsEmailSender.cs
+++ b/api/src/town-crier.infrastructure/Notifications/AcsEmailSender.cs
@@ -1,6 +1,8 @@
 using Azure;
 using Azure.Communication.Email;
+using Microsoft.Extensions.Logging;
 using TownCrier.Application.Notifications;
+using TownCrier.Application.Observability;
 using TownCrier.Domain.Notifications;
 
 namespace TownCrier.Infrastructure.Notifications;
@@ -9,10 +11,12 @@ public sealed class AcsEmailSender : IEmailSender
 {
     private const string SenderAddress = "hello@towncrierapp.uk";
     private readonly EmailClient emailClient;
+    private readonly ILogger<AcsEmailSender> logger;
 
-    public AcsEmailSender(string connectionString)
+    public AcsEmailSender(string connectionString, ILogger<AcsEmailSender> logger)
     {
         this.emailClient = new EmailClient(connectionString);
+        this.logger = logger;
     }
 
     public async Task SendDigestAsync(string email, IReadOnlyList<WatchZoneDigest> digests, CancellationToken ct)
@@ -28,7 +32,18 @@ public sealed class AcsEmailSender : IEmailSender
             },
             recipients: new EmailRecipients([new EmailAddress(email)]));
 
-        await this.emailClient.SendAsync(WaitUntil.Started, emailMessage, ct).ConfigureAwait(false);
+        try
+        {
+            await this.emailClient.SendAsync(WaitUntil.Started, emailMessage, ct).ConfigureAwait(false);
+            ApiMetrics.EmailsSent.Add(1, new KeyValuePair<string, object?>("email.type", "digest"));
+        }
+#pragma warning disable CA1031 // Failed emails must not block the handler
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            ApiMetrics.EmailsFailed.Add(1, new KeyValuePair<string, object?>("email.type", "digest"));
+            EmailLog.DigestSendFailed(this.logger, email, ex);
+        }
     }
 
     public async Task SendNotificationAsync(string email, Notification notification, CancellationToken ct)
@@ -44,7 +59,18 @@ public sealed class AcsEmailSender : IEmailSender
             },
             recipients: new EmailRecipients([new EmailAddress(email)]));
 
-        await this.emailClient.SendAsync(WaitUntil.Started, emailMessage, ct).ConfigureAwait(false);
+        try
+        {
+            await this.emailClient.SendAsync(WaitUntil.Started, emailMessage, ct).ConfigureAwait(false);
+            ApiMetrics.EmailsSent.Add(1, new KeyValuePair<string, object?>("email.type", "instant"));
+        }
+#pragma warning disable CA1031 // Failed emails must not block the handler
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            ApiMetrics.EmailsFailed.Add(1, new KeyValuePair<string, object?>("email.type", "instant"));
+            EmailLog.NotificationSendFailed(this.logger, email, ex);
+        }
     }
 
     private static string BuildDigestHtml(IReadOnlyList<WatchZoneDigest> digests, int totalCount)

--- a/api/src/town-crier.infrastructure/Notifications/EmailLog.cs
+++ b/api/src/town-crier.infrastructure/Notifications/EmailLog.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Logging;
+
+namespace TownCrier.Infrastructure.Notifications;
+
+internal static partial class EmailLog
+{
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to send digest email to {Email}")]
+    internal static partial void DigestSendFailed(ILogger logger, string email, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Failed to send notification email to {Email}")]
+    internal static partial void NotificationSendFailed(ILogger logger, string email, Exception exception);
+}

--- a/api/src/town-crier.infrastructure/WatchZones/DispatchNotificationEnqueuer.cs
+++ b/api/src/town-crier.infrastructure/WatchZones/DispatchNotificationEnqueuer.cs
@@ -1,0 +1,22 @@
+using TownCrier.Application.Notifications;
+using TownCrier.Application.WatchZones;
+using TownCrier.Domain.PlanningApplications;
+using TownCrier.Domain.WatchZones;
+
+namespace TownCrier.Infrastructure.WatchZones;
+
+public sealed class DispatchNotificationEnqueuer : INotificationEnqueuer
+{
+    private readonly DispatchNotificationCommandHandler handler;
+
+    public DispatchNotificationEnqueuer(DispatchNotificationCommandHandler handler)
+    {
+        this.handler = handler;
+    }
+
+    public async Task EnqueueAsync(PlanningApplication application, WatchZone matchedZone, CancellationToken ct)
+    {
+        var command = new DispatchNotificationCommand(application, matchedZone);
+        await this.handler.HandleAsync(command, ct).ConfigureAwait(false);
+    }
+}

--- a/api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
@@ -37,7 +37,12 @@ internal static class UserProfileEndpoints
             CancellationToken ct) =>
         {
             var userId = user.FindFirstValue("sub")!;
-            var profileCommand = new UpdateUserProfileCommand(userId, command.PushEnabled);
+            var profileCommand = new UpdateUserProfileCommand(
+                userId,
+                command.PushEnabled,
+                command.DigestDay,
+                command.EmailDigestEnabled,
+                command.EmailInstantEnabled);
 
             try
             {

--- a/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
+++ b/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
@@ -50,7 +50,8 @@ internal static class ServiceCollectionExtensions
         {
             try
             {
-                services.AddSingleton<IEmailSender>(new AcsEmailSender(acsConnectionString));
+                services.AddSingleton<IEmailSender>(sp =>
+                    new AcsEmailSender(acsConnectionString, sp.GetRequiredService<ILogger<AcsEmailSender>>()));
             }
             catch (InvalidOperationException)
             {

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -98,6 +98,7 @@ builder.Services.AddHttpClient<IPlanItClient, PlanItClient>(client =>
 });
 
 builder.Services.AddTransient<PollPlanItCommandHandler>();
+builder.Services.AddSingleton<GenerateWeeklyDigestsCommandHandler>();
 
 using var host = builder.Build();
 
@@ -107,35 +108,68 @@ using var host = builder.Build();
 _ = host.Services.GetRequiredService<MeterProvider>();
 _ = host.Services.GetRequiredService<TracerProvider>();
 
-var handler = host.Services.GetRequiredService<PollPlanItCommandHandler>();
+var mode = builder.Configuration["WORKER_MODE"] ?? "poll";
 var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("TownCrier.Worker");
 
 var exitCode = 0;
 
-try
+switch (mode)
 {
-    using var activity = PollingInstrumentation.Source.StartActivity("Polling Cycle");
-    var cycleStart = Stopwatch.GetTimestamp();
+    case "poll":
+        try
+        {
+            using var activity = PollingInstrumentation.Source.StartActivity("Polling Cycle");
+            var cycleStart = Stopwatch.GetTimestamp();
 
-    WorkerLog.PollCycleStarting(logger);
+            WorkerLog.PollCycleStarting(logger);
 
-    var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None)
-        .ConfigureAwait(false);
+            var pollHandler = host.Services.GetRequiredService<PollPlanItCommandHandler>();
+            var result = await pollHandler.HandleAsync(new PollPlanItCommand(), CancellationToken.None)
+                .ConfigureAwait(false);
 
-    PollingMetrics.CycleDuration.Record(Stopwatch.GetElapsedTime(cycleStart).TotalMilliseconds);
+            PollingMetrics.CycleDuration.Record(Stopwatch.GetElapsedTime(cycleStart).TotalMilliseconds);
 
-    activity?.SetTag("polling.authorities_polled", result.AuthoritiesPolled);
-    activity?.SetTag("polling.applications_ingested", result.ApplicationCount);
+            activity?.SetTag("polling.authorities_polled", result.AuthoritiesPolled);
+            activity?.SetTag("polling.applications_ingested", result.ApplicationCount);
 
-    WorkerLog.PollCycleCompleted(logger, result.ApplicationCount, result.AuthoritiesPolled);
-}
+            WorkerLog.PollCycleCompleted(logger, result.ApplicationCount, result.AuthoritiesPolled);
+        }
 #pragma warning disable CA1031 // Worker must return exit code on any failure
-catch (Exception ex)
+        catch (Exception ex)
 #pragma warning restore CA1031
-{
-    PollingMetrics.PollFailures.Add(1);
-    WorkerLog.PollCycleFailed(logger, ex);
-    exitCode = 1;
+        {
+            PollingMetrics.PollFailures.Add(1);
+            WorkerLog.PollCycleFailed(logger, ex);
+            exitCode = 1;
+        }
+
+        break;
+
+    case "digest":
+        try
+        {
+            WorkerLog.DigestCycleStarting(logger);
+
+            var digestHandler = host.Services.GetRequiredService<GenerateWeeklyDigestsCommandHandler>();
+            await digestHandler.HandleAsync(new GenerateWeeklyDigestsCommand(), CancellationToken.None)
+                .ConfigureAwait(false);
+
+            WorkerLog.DigestCycleCompleted(logger);
+        }
+#pragma warning disable CA1031 // Worker must return exit code on any failure
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            WorkerLog.DigestCycleFailed(logger, ex);
+            exitCode = 1;
+        }
+
+        break;
+
+    default:
+        WorkerLog.UnknownWorkerMode(logger, mode);
+        exitCode = 1;
+        break;
 }
 
 // Force-flush OpenTelemetry before the short-lived process exits.

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -48,6 +48,7 @@ builder.Services.AddOpenTelemetry()
         metrics
             .AddHttpClientInstrumentation()
             .AddMeter(PollingMetrics.MeterName)
+            .AddMeter(ApiMetrics.MeterName)
             .AddMeter(CosmosInstrumentation.MeterName)
             .AddMeter(PlanItInstrumentation.MeterName);
 
@@ -73,7 +74,8 @@ if (!string.IsNullOrEmpty(acsConnectionString))
 {
     try
     {
-        builder.Services.AddSingleton<IEmailSender>(new AcsEmailSender(acsConnectionString));
+        builder.Services.AddSingleton<IEmailSender>(sp =>
+            new AcsEmailSender(acsConnectionString, sp.GetRequiredService<ILogger<AcsEmailSender>>()));
     }
     catch (InvalidOperationException)
     {

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -6,16 +6,22 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Trace;
+using TownCrier.Application.DeviceRegistrations;
+using TownCrier.Application.Notifications;
 using TownCrier.Application.Observability;
 using TownCrier.Application.PlanIt;
 using TownCrier.Application.PlanningApplications;
 using TownCrier.Application.Polling;
+using TownCrier.Application.UserProfiles;
 using TownCrier.Application.WatchZones;
 using TownCrier.Infrastructure.Cosmos;
+using TownCrier.Infrastructure.DeviceRegistrations;
+using TownCrier.Infrastructure.Notifications;
 using TownCrier.Infrastructure.Observability;
 using TownCrier.Infrastructure.PlanIt;
 using TownCrier.Infrastructure.PlanningApplications;
 using TownCrier.Infrastructure.Polling;
+using TownCrier.Infrastructure.UserProfiles;
 using TownCrier.Infrastructure.WatchZones;
 using TownCrier.Worker;
 
@@ -57,7 +63,30 @@ builder.Services.AddSingleton<IPlanningApplicationRepository, CosmosPlanningAppl
 builder.Services.AddSingleton<IWatchZoneRepository, CosmosWatchZoneRepository>();
 builder.Services.AddSingleton<IPollStateStore, CosmosPollStateStore>();
 builder.Services.AddSingleton<IActiveAuthorityProvider, WatchZoneActiveAuthorityProvider>();
-builder.Services.AddSingleton<INotificationEnqueuer, LogNotificationEnqueuer>();
+builder.Services.AddSingleton<INotificationRepository, CosmosNotificationRepository>();
+builder.Services.AddSingleton<IUserProfileRepository, CosmosUserProfileRepository>();
+builder.Services.AddSingleton<IDeviceRegistrationRepository, CosmosDeviceRegistrationRepository>();
+builder.Services.AddSingleton<IPushNotificationSender, NoOpPushNotificationSender>();
+
+var acsConnectionString = builder.Configuration["AzureCommunicationServices:ConnectionString"];
+if (!string.IsNullOrEmpty(acsConnectionString))
+{
+    try
+    {
+        builder.Services.AddSingleton<IEmailSender>(new AcsEmailSender(acsConnectionString));
+    }
+    catch (InvalidOperationException)
+    {
+        builder.Services.AddSingleton<IEmailSender, NoOpEmailSender>();
+    }
+}
+else
+{
+    builder.Services.AddSingleton<IEmailSender, NoOpEmailSender>();
+}
+
+builder.Services.AddSingleton<DispatchNotificationCommandHandler>();
+builder.Services.AddSingleton<INotificationEnqueuer, DispatchNotificationEnqueuer>();
 builder.Services.AddSingleton(TimeProvider.System);
 
 #pragma warning disable S1075 // Hardcoded URI is a sensible default

--- a/api/src/town-crier.worker/WorkerLog.cs
+++ b/api/src/town-crier.worker/WorkerLog.cs
@@ -14,4 +14,16 @@ internal static partial class WorkerLog
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Poll cycle failed")]
     internal static partial void PollCycleFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Starting weekly digest generation")]
+    internal static partial void DigestCycleStarting(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Weekly digest generation completed")]
+    internal static partial void DigestCycleCompleted(ILogger logger);
+
+    [LoggerMessage(Level = LogLevel.Error, Message = "Weekly digest generation failed")]
+    internal static partial void DigestCycleFailed(ILogger logger, Exception exception);
+
+    [LoggerMessage(Level = LogLevel.Critical, Message = "Unknown WORKER_MODE '{WorkerMode}'. Valid values: poll, digest")]
+    internal static partial void UnknownWorkerMode(ILogger logger, string workerMode);
 }

--- a/api/tests/town-crier.application.tests/UserProfiles/UpdateUserProfileCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/UpdateUserProfileCommandHandlerTests.cs
@@ -90,4 +90,64 @@ public sealed class UpdateUserProfileCommandHandlerTests
         // Assert — tier should remain Free (not modifiable via preferences update)
         await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);
     }
+
+    [Test]
+    public async Task Should_UpdateEmailDigestEnabled_When_SetToFalse()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-789");
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new UpdateUserProfileCommandHandler(repository);
+        var command = new UpdateUserProfileCommand("auth0|user-789", true, EmailDigestEnabled: false);
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.EmailDigestEnabled).IsFalse();
+        var saved = repository.GetByUserId("auth0|user-789");
+        await Assert.That(saved!.NotificationPreferences.EmailDigestEnabled).IsFalse();
+    }
+
+    [Test]
+    public async Task Should_UpdateEmailInstantEnabled_When_SetToTrue()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-789");
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new UpdateUserProfileCommandHandler(repository);
+        var command = new UpdateUserProfileCommand("auth0|user-789", true, EmailInstantEnabled: true);
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.EmailInstantEnabled).IsTrue();
+        var saved = repository.GetByUserId("auth0|user-789");
+        await Assert.That(saved!.NotificationPreferences.EmailInstantEnabled).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_UpdateDigestDay_When_SetToFriday()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-789");
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new UpdateUserProfileCommandHandler(repository);
+        var command = new UpdateUserProfileCommand("auth0|user-789", true, DigestDay: DayOfWeek.Friday);
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.DigestDay).IsEqualTo(DayOfWeek.Friday);
+        var saved = repository.GetByUserId("auth0|user-789");
+        await Assert.That(saved!.NotificationPreferences.DigestDay).IsEqualTo(DayOfWeek.Friday);
+    }
 }

--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -291,6 +291,17 @@ public static class SharedStack
                                     "customMetrics | where name == 'towncrier.planit.http_errors' | extend status = tostring(customDimensions['http.response.status_code']) | where status != '429' | summarize Value=sum(value) by timestamp=bin(timestamp, 1h), status | render timechart",
                                     "PlanIt Errors"),
                             },
+                            // Row 5: Email
+                            new DashboardPartsArgs
+                            {
+                                Position = new DashboardPartsPositionArgs { X = 0, Y = 16, ColSpan = 6, RowSpan = 4 },
+                                Metadata = MetricTile(appInsights.Id, "towncrier.emails.sent", "Emails Sent"),
+                            },
+                            new DashboardPartsArgs
+                            {
+                                Position = new DashboardPartsPositionArgs { X = 6, Y = 16, ColSpan = 6, RowSpan = 4 },
+                                Metadata = MetricTile(appInsights.Id, "towncrier.emails.failed", "Email Failures"),
+                            },
                         },
                     },
                 },


### PR DESCRIPTION
## Changes

- **Expose email preferences in PATCH /v1/me** — `UpdateUserProfileCommand` now accepts `DigestDay`, `EmailDigestEnabled`, `EmailInstantEnabled` with backwards-compatible defaults. Includes 3 new unit tests.
- **Wire DispatchNotificationCommandHandler into polling worker** — Replace no-op `LogNotificationEnqueuer` with `DispatchNotificationEnqueuer` that calls the real handler. Register all notification dependencies in worker DI.
- **Add WORKER_MODE switch for digest container job** — Worker accepts `WORKER_MODE=digest` env var to run `GenerateWeeklyDigestsCommandHandler` instead of polling. Source-generated log messages for digest lifecycle.
- **Add OTel email metrics and dashboard tiles** — `towncrier.emails.sent` and `towncrier.emails.failed` counters with `email.type` tags. AcsEmailSender instrumented with try/catch (failures logged, not thrown). Two new dashboard tiles at Row 5.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email digest preferences to user profiles (frequency and enable/disable settings)
  * Introduced weekly digest generation capability for notifications
  
* **Bug Fixes**
  * Email send failures now log gracefully without disrupting the system

* **Observability**
  * Added email metrics tracking (sent and failed) to the operational dashboard
  * Enhanced logging for email delivery failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->