### PR TITLE
fix(infra): add ACS connection string to polling job

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -333,6 +333,10 @@ public static class EnvironmentStack
                         Identity = acrPullIdentityId,
                     },
                 },
+                Secrets = new[]
+                {
+                    new SecretArgs { Name = "acs-connection-string", Value = acsConnectionString },
+                },
             },
             Identity = new Pulumi.AzureNative.App.Inputs.ManagedServiceIdentityArgs
             {
@@ -362,6 +366,7 @@ public static class EnvironmentStack
                             new EnvironmentVarArgs { Name = "Cosmos__DatabaseName", Value = cosmosDatabase.Name },
                             new EnvironmentVarArgs { Name = "AZURE_CLIENT_ID", Value = cosmosDataIdentityClientId },
                             new EnvironmentVarArgs { Name = "APPLICATIONINSIGHTS_CONNECTION_STRING", Value = appInsightsConnectionString },
+                            new EnvironmentVarArgs { Name = "AzureCommunicationServices__ConnectionString", SecretRef = "acs-connection-string" },
                         },
                     },
                 },


### PR DESCRIPTION
## Summary

- The polling job was missing the `AzureCommunicationServices__ConnectionString` env var and backing `acs-connection-string` secret
- Without it, the worker DI falls back to `NoOpEmailSender`, silently dropping all email notifications
- Adds the secret to the job's `Configuration.Secrets` and the env var to the container spec, matching the API container app

## Root cause

PR #187 wired up `AcsEmailSender` in both the API and worker DI, but the infra code (`EnvironmentStack.cs`) was never updated to pass the ACS connection string to the polling job — only the API container app had it.

## Test plan

- [ ] `dotnet build` passes in `/infra`
- [ ] After deploy, verify `job-town-crier-poll-dev` has `AzureCommunicationServices__ConnectionString` in its env vars
- [ ] Trigger a poll cycle and confirm email traces appear in App Insights

Closes town-crier-u7m

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to manage connection strings as secure secrets for API Container App and polling Job services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->