### PR TITLE
feat: wire up email notification settings in web app

### DIFF
--- a/api/src/town-crier.application/UserProfiles/GetUserProfileQueryHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/GetUserProfileQueryHandler.cs
@@ -22,6 +22,9 @@ public sealed class GetUserProfileQueryHandler
         return new GetUserProfileResult(
             profile.UserId,
             profile.NotificationPreferences.PushEnabled,
+            profile.NotificationPreferences.DigestDay,
+            profile.NotificationPreferences.EmailDigestEnabled,
+            profile.NotificationPreferences.EmailInstantEnabled,
             profile.Tier);
     }
 }

--- a/api/src/town-crier.application/UserProfiles/GetUserProfileResult.cs
+++ b/api/src/town-crier.application/UserProfiles/GetUserProfileResult.cs
@@ -5,4 +5,7 @@ namespace TownCrier.Application.UserProfiles;
 public sealed record GetUserProfileResult(
     string UserId,
     bool PushEnabled,
+    DayOfWeek DigestDay,
+    bool EmailDigestEnabled,
+    bool EmailInstantEnabled,
     SubscriptionTier Tier);

--- a/api/tests/town-crier.application.tests/UserProfiles/GetUserProfileQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/GetUserProfileQueryHandlerTests.cs
@@ -40,4 +40,25 @@ public sealed class GetUserProfileQueryHandlerTests
         await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);
         await Assert.That(result.PushEnabled).IsTrue();
     }
+
+    [Test]
+    public async Task Should_ReturnDefaultEmailPreferences_When_ProfileExists()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|email-user");
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new GetUserProfileQueryHandler(repository);
+        var query = new GetUserProfileQuery("auth0|email-user");
+
+        // Act
+        var result = await handler.HandleAsync(query, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.EmailDigestEnabled).IsTrue();
+        await Assert.That(result.EmailInstantEnabled).IsFalse();
+        await Assert.That(result.DigestDay).IsEqualTo(DayOfWeek.Monday);
+    }
 }

--- a/web/src/components/Toggle/Toggle.module.css
+++ b/web/src/components/Toggle/Toggle.module.css
@@ -1,0 +1,34 @@
+.toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 44px;
+  height: 24px;
+  padding: 2px;
+  border: 1px solid var(--tc-border);
+  border-radius: 12px;
+  background: var(--tc-surface);
+  cursor: pointer;
+  transition: background-color var(--tc-duration-fast) ease,
+              border-color var(--tc-duration-fast) ease;
+}
+
+.toggle[data-checked] {
+  background: var(--tc-amber);
+  border-color: var(--tc-amber);
+}
+
+.thumb {
+  display: block;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--tc-text-secondary);
+  transition: transform var(--tc-duration-fast) ease,
+              background-color var(--tc-duration-fast) ease;
+}
+
+.toggle[data-checked] .thumb {
+  transform: translateX(20px);
+  background: var(--tc-text-on-accent);
+}

--- a/web/src/components/Toggle/Toggle.tsx
+++ b/web/src/components/Toggle/Toggle.tsx
@@ -1,0 +1,23 @@
+import styles from './Toggle.module.css';
+
+interface Props {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label: string;
+}
+
+export function Toggle({ checked, onChange, label }: Props) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      className={styles.toggle}
+      data-checked={checked || undefined}
+      onClick={() => onChange(!checked)}
+    >
+      <span className={styles.thumb} />
+    </button>
+  );
+}

--- a/web/src/domain/ports/settings-repository.ts
+++ b/web/src/domain/ports/settings-repository.ts
@@ -1,7 +1,8 @@
-import type { UserProfile } from '../types';
+import type { UpdateProfileRequest, UserProfile } from '../types';
 
 export interface SettingsRepository {
   fetchProfile(): Promise<UserProfile>;
+  updateProfile(request: UpdateProfileRequest): Promise<UserProfile>;
   exportData(): Promise<Blob>;
   deleteAccount(): Promise<void>;
 }

--- a/web/src/domain/types.ts
+++ b/web/src/domain/types.ts
@@ -53,6 +53,22 @@ export function isSubscriptionTier(value: unknown): value is SubscriptionTier {
   return typeof value === "string" && SUBSCRIPTION_TIERS.includes(value);
 }
 
+/**
+ * Matches .NET System.DayOfWeek numeric enum.
+ * 0 = Sunday, 1 = Monday, ..., 6 = Saturday.
+ */
+export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+
+export const DAY_OF_WEEK_LABELS: Record<DayOfWeek, string> = {
+  0: 'Sunday',
+  1: 'Monday',
+  2: 'Tuesday',
+  3: 'Wednesday',
+  4: 'Thursday',
+  5: 'Friday',
+  6: 'Saturday',
+};
+
 // ---------------------------------------------------------------------------
 // Shared value types
 // ---------------------------------------------------------------------------
@@ -69,6 +85,9 @@ export interface Coordinates {
 export interface UserProfile {
   readonly userId: string;
   readonly pushEnabled: boolean;
+  readonly emailDigestEnabled: boolean;
+  readonly emailInstantEnabled: boolean;
+  readonly digestDay: DayOfWeek;
   readonly tier: SubscriptionTier;
 }
 
@@ -206,6 +225,9 @@ export interface CreateWatchZoneRequest {
 
 export interface UpdateProfileRequest {
   readonly pushEnabled: boolean;
+  readonly emailDigestEnabled: boolean;
+  readonly emailInstantEnabled: boolean;
+  readonly digestDay: DayOfWeek;
 }
 
 export interface UpdateZonePreferencesRequest {

--- a/web/src/features/Settings/ApiSettingsRepository.ts
+++ b/web/src/features/Settings/ApiSettingsRepository.ts
@@ -1,6 +1,6 @@
 import type { ApiClient } from '../../api/client';
 import type { SettingsRepository } from '../../domain/ports/settings-repository';
-import type { UserProfile } from '../../domain/types';
+import type { UpdateProfileRequest, UserProfile } from '../../domain/types';
 import { userProfileApi } from '../../api/userProfile';
 
 export class ApiSettingsRepository implements SettingsRepository {
@@ -20,6 +20,10 @@ export class ApiSettingsRepository implements SettingsRepository {
 
   async fetchProfile(): Promise<UserProfile> {
     return this.api.get();
+  }
+
+  async updateProfile(request: UpdateProfileRequest): Promise<UserProfile> {
+    return this.api.update(request);
   }
 
   async exportData(): Promise<Blob> {

--- a/web/src/features/Settings/SettingsPage.module.css
+++ b/web/src/features/Settings/SettingsPage.module.css
@@ -159,3 +159,38 @@
 .legalLink:hover {
   text-decoration: underline;
 }
+
+.toggleRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--tc-space-sm) 0;
+}
+
+.toggleRow + .toggleRow,
+.toggleRow + .selectRow,
+.selectRow + .toggleRow {
+  border-top: 1px solid var(--tc-border);
+}
+
+.selectRow {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--tc-space-sm) 0;
+}
+
+.select {
+  padding: var(--tc-space-xs) var(--tc-space-sm);
+  font-size: var(--tc-text-body);
+  color: var(--tc-text-primary);
+  background: var(--tc-surface);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  cursor: pointer;
+  transition: border-color var(--tc-duration-fast);
+}
+
+.select:hover {
+  border-color: var(--tc-amber);
+}

--- a/web/src/features/Settings/SettingsPage.tsx
+++ b/web/src/features/Settings/SettingsPage.tsx
@@ -5,6 +5,8 @@ import { useTheme } from '../../hooks/useTheme';
 import { useUserProfile } from './useUserProfile';
 import { ThemeToggle } from '../../components/ThemeToggle/ThemeToggle';
 import { ConfirmDialog } from '../../components/ConfirmDialog/ConfirmDialog';
+import { Toggle } from '../../components/Toggle/Toggle';
+import { DAY_OF_WEEK_LABELS, type DayOfWeek } from '../../domain/types';
 import type { SettingsRepository } from '../../domain/ports/settings-repository';
 import styles from './SettingsPage.module.css';
 
@@ -23,6 +25,7 @@ export function SettingsPage({ repository }: Props) {
     error,
     exportData,
     deleteAccount,
+    updatePreferences,
   } = useUserProfile(repository, () => logout());
 
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -59,6 +62,46 @@ export function SettingsPage({ repository }: Props) {
           <div className={styles.field}>
             <span className={styles.label}>Subscription</span>
             <span className={styles.value}>{profile?.tier}</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Notifications section */}
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Notifications</h2>
+        <div className={styles.card}>
+          <div className={styles.toggleRow}>
+            <span className={styles.label}>Email digest</span>
+            <Toggle
+              checked={profile?.emailDigestEnabled ?? true}
+              onChange={(checked) => updatePreferences({ emailDigestEnabled: checked })}
+              label="Email digest"
+            />
+          </div>
+          {profile?.emailDigestEnabled && (
+            <div className={styles.selectRow}>
+              <label htmlFor="digest-day" className={styles.label}>Digest day</label>
+              <select
+                id="digest-day"
+                className={styles.select}
+                value={profile.digestDay}
+                onChange={(e) => updatePreferences({ digestDay: Number(e.target.value) as DayOfWeek })}
+              >
+                {([1, 2, 3, 4, 5, 6, 0] as const).map((day) => (
+                  <option key={day} value={day}>
+                    {DAY_OF_WEEK_LABELS[day]}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          <div className={styles.toggleRow}>
+            <span className={styles.label}>Instant emails</span>
+            <Toggle
+              checked={profile?.emailInstantEnabled ?? false}
+              onChange={(checked) => updatePreferences({ emailInstantEnabled: checked })}
+              label="Instant emails"
+            />
           </div>
         </div>
       </section>

--- a/web/src/features/Settings/__tests__/SettingsPage.test.tsx
+++ b/web/src/features/Settings/__tests__/SettingsPage.test.tsx
@@ -158,4 +158,66 @@ describe('SettingsPage', () => {
 
     expect(spyAuth.logoutCalls).toBe(1);
   });
+
+  it('renders email digest toggle', async () => {
+    spy.fetchProfileResult = freeUserProfile({ emailDigestEnabled: true });
+
+    renderSettingsPage(spy);
+
+    const toggle = await screen.findByRole('switch', { name: /email digest/i });
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('renders instant emails toggle', async () => {
+    spy.fetchProfileResult = freeUserProfile({ emailInstantEnabled: false });
+
+    renderSettingsPage(spy);
+
+    const toggle = await screen.findByRole('switch', { name: /instant email/i });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('renders digest day picker when digest is enabled', async () => {
+    spy.fetchProfileResult = freeUserProfile({ emailDigestEnabled: true, digestDay: 1 });
+
+    renderSettingsPage(spy);
+
+    const select = await screen.findByLabelText(/digest day/i);
+    expect(select).toHaveValue('1');
+  });
+
+  it('hides digest day picker when digest is disabled', async () => {
+    spy.fetchProfileResult = freeUserProfile({ emailDigestEnabled: false });
+
+    renderSettingsPage(spy);
+
+    await screen.findByRole('heading', { name: /notifications/i });
+    expect(screen.queryByLabelText(/digest day/i)).not.toBeInTheDocument();
+  });
+
+  it('calls updateProfile when email digest is toggled off', async () => {
+    const user = userEvent.setup();
+    spy.fetchProfileResult = freeUserProfile({ emailDigestEnabled: true });
+
+    renderSettingsPage(spy);
+
+    const toggle = await screen.findByRole('switch', { name: /email digest/i });
+    await user.click(toggle);
+
+    expect(spy.updateProfileCalls).toBe(1);
+    expect(spy.updateProfileLastRequest?.emailDigestEnabled).toBe(false);
+  });
+
+  it('calls updateProfile when digest day is changed', async () => {
+    const user = userEvent.setup();
+    spy.fetchProfileResult = freeUserProfile({ emailDigestEnabled: true, digestDay: 1 });
+
+    renderSettingsPage(spy);
+
+    const select = await screen.findByLabelText(/digest day/i);
+    await user.selectOptions(select, '5');
+
+    expect(spy.updateProfileCalls).toBe(1);
+    expect(spy.updateProfileLastRequest?.digestDay).toBe(5);
+  });
 });

--- a/web/src/features/Settings/__tests__/fixtures/user-profile.fixtures.ts
+++ b/web/src/features/Settings/__tests__/fixtures/user-profile.fixtures.ts
@@ -6,6 +6,9 @@ export function freeUserProfile(
   return {
     userId: 'auth0|abc123',
     pushEnabled: true,
+    emailDigestEnabled: true,
+    emailInstantEnabled: false,
+    digestDay: 1,
     tier: 'Free' as SubscriptionTier,
     ...overrides,
   };

--- a/web/src/features/Settings/__tests__/spies/spy-settings-repository.ts
+++ b/web/src/features/Settings/__tests__/spies/spy-settings-repository.ts
@@ -26,7 +26,7 @@ export class SpySettingsRepository implements SettingsRepository {
     if (this.updateProfileError) {
       throw this.updateProfileError;
     }
-    return this.updateProfileResult ?? this.fetchProfileResult;
+    return this.updateProfileResult ?? { ...this.fetchProfileResult, ...request };
   }
 
   exportDataCalls = 0;

--- a/web/src/features/Settings/__tests__/spies/spy-settings-repository.ts
+++ b/web/src/features/Settings/__tests__/spies/spy-settings-repository.ts
@@ -1,5 +1,5 @@
 import type { SettingsRepository } from '../../../../domain/ports/settings-repository';
-import type { UserProfile } from '../../../../domain/types';
+import type { UpdateProfileRequest, UserProfile } from '../../../../domain/types';
 import { freeUserProfile } from '../fixtures/user-profile.fixtures';
 
 export class SpySettingsRepository implements SettingsRepository {
@@ -13,6 +13,20 @@ export class SpySettingsRepository implements SettingsRepository {
       throw this.fetchProfileError;
     }
     return this.fetchProfileResult;
+  }
+
+  updateProfileCalls = 0;
+  updateProfileLastRequest: UpdateProfileRequest | null = null;
+  updateProfileResult: UserProfile | null = null;
+  updateProfileError: Error | null = null;
+
+  async updateProfile(request: UpdateProfileRequest): Promise<UserProfile> {
+    this.updateProfileCalls++;
+    this.updateProfileLastRequest = request;
+    if (this.updateProfileError) {
+      throw this.updateProfileError;
+    }
+    return this.updateProfileResult ?? this.fetchProfileResult;
   }
 
   exportDataCalls = 0;

--- a/web/src/features/Settings/__tests__/useUserProfile.test.ts
+++ b/web/src/features/Settings/__tests__/useUserProfile.test.ts
@@ -2,7 +2,7 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useUserProfile } from '../useUserProfile';
 import { SpySettingsRepository } from './spies/spy-settings-repository';
-import { proUserProfile } from './fixtures/user-profile.fixtures';
+import { freeUserProfile, proUserProfile } from './fixtures/user-profile.fixtures';
 
 describe('useUserProfile', () => {
   let spy: SpySettingsRepository;
@@ -140,5 +140,61 @@ describe('useUserProfile', () => {
     });
 
     expect(result.current.isDeleting).toBe(false);
+  });
+
+  it('updates preferences and calls repository', async () => {
+    spy.fetchProfileResult = freeUserProfile();
+
+    const { result } = renderHook(() => useUserProfile(spy, logout));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.updatePreferences({ emailDigestEnabled: false });
+    });
+
+    expect(spy.updateProfileCalls).toBe(1);
+    expect(spy.updateProfileLastRequest).toEqual({
+      pushEnabled: true,
+      emailDigestEnabled: false,
+      emailInstantEnabled: false,
+      digestDay: 1,
+    });
+  });
+
+  it('optimistically updates profile on preference change', async () => {
+    spy.fetchProfileResult = freeUserProfile();
+
+    const { result } = renderHook(() => useUserProfile(spy, logout));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.updatePreferences({ emailInstantEnabled: true });
+    });
+
+    expect(result.current.profile?.emailInstantEnabled).toBe(true);
+  });
+
+  it('reverts profile on preference update failure', async () => {
+    spy.fetchProfileResult = freeUserProfile({ emailDigestEnabled: true });
+    spy.updateProfileError = new Error('Network error');
+
+    const { result } = renderHook(() => useUserProfile(spy, logout));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.updatePreferences({ emailDigestEnabled: false });
+    });
+
+    expect(result.current.profile?.emailDigestEnabled).toBe(true);
+    expect(result.current.error).toBe('Network error');
   });
 });

--- a/web/src/features/Settings/useUserProfile.ts
+++ b/web/src/features/Settings/useUserProfile.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import type { SettingsRepository } from '../../domain/ports/settings-repository';
-import type { UserProfile } from '../../domain/types';
+import type { UpdateProfileRequest, UserProfile } from '../../domain/types';
 import { useFetchData } from '../../hooks/useFetchData';
 
 export function useUserProfile(
@@ -10,13 +10,41 @@ export function useUserProfile(
   const [isExporting, setIsExporting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [optimisticProfile, setOptimisticProfile] = useState<UserProfile | null>(null);
 
-  const { data: profile, isLoading, error: fetchError } = useFetchData<UserProfile>(
+  const { data: fetchedProfile, isLoading, error: fetchError } = useFetchData<UserProfile>(
     () => repository.fetchProfile(),
     [repository],
   );
 
+  const profile = optimisticProfile ?? fetchedProfile;
   const error = actionError ?? fetchError;
+
+  const updatePreferences = useCallback(async (changes: Partial<UpdateProfileRequest>) => {
+    const base = optimisticProfile ?? fetchedProfile;
+    if (!base) return;
+
+    const request: UpdateProfileRequest = {
+      pushEnabled: base.pushEnabled,
+      emailDigestEnabled: base.emailDigestEnabled,
+      emailInstantEnabled: base.emailInstantEnabled,
+      digestDay: base.digestDay,
+      ...changes,
+    };
+
+    const previous = optimisticProfile;
+    setOptimisticProfile({ ...base, ...changes });
+    setActionError(null);
+
+    try {
+      const updated = await repository.updateProfile(request);
+      setOptimisticProfile(updated);
+    } catch (err) {
+      setOptimisticProfile(previous);
+      const message = err instanceof Error ? err.message : 'Failed to update preferences';
+      setActionError(message);
+    }
+  }, [optimisticProfile, fetchedProfile, repository]);
 
   const exportData = useCallback(async () => {
     setIsExporting(true);
@@ -59,5 +87,6 @@ export function useUserProfile(
     error,
     exportData,
     deleteAccount,
+    updatePreferences,
   };
 }


### PR DESCRIPTION
## Changes
- Expose `emailDigestEnabled`, `emailInstantEnabled`, and `digestDay` on GET /v1/me response
- Add `DayOfWeek` type, update `UserProfile`/`UpdateProfileRequest`, repository port + implementation
- Create accessible `Toggle` switch component (`role="switch"`, design tokens)
- Add optimistic `updatePreferences` to `useUserProfile` hook with revert-on-failure
- Add Notifications section to settings page with digest toggle, day picker, instant email toggle

## Spec
`docs/superpowers/specs/2026-04-06-email-notification-settings-design.md`

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can manage email notification preferences in Settings: enable/disable digest and instant emails, and pick a digest day.
  * Settings now update preferences immediately (optimistic updates) and persist changes.

* **UI**
  * Added a Toggle switch component and styles; Settings page includes notification toggles and a digest-day picker.

* **Tests**
  * Added comprehensive tests covering UI, optimistic updates, repository interactions, and error/rollback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->