### PR TITLE
docs: add implementation plans, design spec, and improve SRE observatory

### DIFF
--- a/.claude/skills/sre-observatory/SKILL.md
+++ b/.claude/skills/sre-observatory/SKILL.md
@@ -29,7 +29,21 @@ All queries use `az monitor app-insights query` with KQL via the `--analytics-qu
 
 ## Time Window
 
-Default to the last 24 hours (`ago(24h)`). If the user specifies a different window (e.g., "last week", "since the deploy"), adjust accordingly. For anomaly detection, always compare the analysis window against the previous 7-day baseline.
+The time window is determined in this priority order:
+
+1. **User-specified range** — If the user passes a time range (e.g., `sre-observatory last 6h`, `sre-observatory since 2026-04-05T10:00:00Z`, `sre-observatory last week`), use it directly. Convert relative expressions to KQL (`ago(6h)`, `ago(7d)`) or absolute `datetime()` as appropriate.
+
+2. **Default: since last prod deploy** — If no range is specified, look up the last successful "CD Production" workflow run and use its start time as the analysis window start:
+   ```bash
+   gh run list --workflow="CD Production" --status=completed --limit=1 --json startedAt -q '.[0].startedAt'
+   ```
+   Convert the ISO timestamp to a KQL `datetime()` literal. For example, if the deploy was at `2026-04-06T06:35:32Z`, use `where timestamp > datetime(2026-04-06T06:35:32Z)`.
+
+   If no completed CD Production run is found (e.g., first deploy hasn't happened yet), fall back to `ago(24h)`.
+
+3. **Baseline comparison** — For anomaly detection, always compare the analysis window against the previous 7-day baseline regardless of the analysis window chosen.
+
+Store the resolved time window in a variable at the start so all phases use the same boundary. Print the resolved window to the conversation at the start of Phase 1 so the user knows what's being analyzed (e.g., "Analyzing telemetry since last prod deploy at 2026-04-06T06:35:32Z (~3h window)").
 
 ## Understanding the Telemetry Model
 
@@ -44,6 +58,8 @@ If a standard table returns empty results, **always check customMetrics for the 
 ## Execution
 
 Run phases sequentially. Each phase queries App Insights, analyzes the results, and accumulates findings. File beads only after all phases complete — this lets you correlate across signals before deciding what's actionable. The query templates below are starting points — adapt, expand, and follow threads based on what you find. Your SRE judgment matters more than rigid adherence to the template.
+
+**Important:** All KQL templates below use `ago(24h)` as a placeholder. Replace every instance with the resolved time window from the Time Window section above (e.g., `datetime(2026-04-06T06:35:32Z)` if keying off the last deploy). Do the same for baseline window calculations — shift them relative to the analysis window, not hardcoded to `ago(8d)`/`ago(1d)`.
 
 ### Phase 1: Baseline & Orientation
 
@@ -354,16 +370,35 @@ Now that you have the full picture, decide what's actionable.
 1. Run `bd search "<key terms>"` to check for existing beads covering this issue
 2. If a match exists, update it with `bd update <id> --notes="..."` instead of creating a duplicate
 
-**Filing format:**
+#### Filing workflow: parent epic + child beads
+
+Every observatory run creates exactly **one parent epic** that groups all findings. Individual findings are filed as child beads under it.
+
+**Step 1 — Create the parent epic (always, even if zero findings):**
+```bash
+bd create \
+  --title="[SRE] Observatory run <YYYY-MM-DD>" \
+  --description="SRE telemetry review. Window: <resolved time window description>. Health: <healthy|degraded|impaired>. Findings: <N>." \
+  --type=epic \
+  --priority=3
+```
+Note the epic ID (e.g., `tc-abc`).
+
+**Step 2 — File each finding as a child bead:**
 ```bash
 bd create \
   --title="[SRE] <concise description of the issue>" \
   --description="<what was observed, including KQL query and key metrics. Include: what's happening, since when, blast radius, and suggested investigation starting point>" \
   --type=bug \
   --priority=<0-4>
+bd dep add <child-id> <epic-id>
 ```
 
-Prefix all titles with `[SRE]` so these are easy to filter. Use `--type=bug` for errors and failures; `--type=task` for performance investigations that aren't strictly broken.
+Use `--type=bug` for errors and failures; `--type=task` for performance investigations that aren't strictly broken. Prefix all titles with `[SRE]`.
+
+**Step 3 — Update the epic description** with the final finding count and list of child bead IDs once all are filed. If zero findings, close the epic immediately with `bd close <epic-id> --reason="Clean bill of health"`.
+
+The parent epic's priority should match the **highest severity** finding filed under it (e.g., if you file a P1 child, promote the epic to P1).
 
 ### Phase 7: Summary & Sync
 

--- a/docs/superpowers/plans/2026-04-05-per-authority-poll-state.md
+++ b/docs/superpowers/plans/2026-04-05-per-authority-poll-state.md
@@ -1,0 +1,650 @@
+# Per-Authority Poll State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Store and retrieve `lastPollTime` per authority ID instead of globally, so new authorities get a 30-day lookback and rate-limited authorities resume from where they left off.
+
+**Architecture:** Change the single-document poll state to per-authority documents (`poll-state-{authorityId}`) in the existing Cosmos PollState container. Move the poll-state read inside the per-authority loop in the handler. Clean up the orphaned global document.
+
+**Tech Stack:** .NET 10, Cosmos DB SDK (via CosmosRestClient), TUnit
+
+**Spec:** `docs/superpowers/specs/2026-04-05-per-authority-poll-state-design.md`
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|---------------|
+| `api/src/town-crier.application/Polling/IPollStateStore.cs` | Modify | Add `authorityId` param to both methods, add `DeleteGlobalPollStateAsync` |
+| `api/src/town-crier.infrastructure/Polling/PollStateDocument.cs` | Modify | Add `AuthorityId` property |
+| `api/src/town-crier.infrastructure/Polling/CosmosPollStateStore.cs` | Modify | Per-authority doc IDs, implement cleanup |
+| `api/tests/town-crier.application.tests/Polling/FakePollStateStore.cs` | Modify | Dictionary-based storage, track per-authority |
+| `api/tests/town-crier.application.tests/Polling/FakePlanItClient.cs` | Modify | Track `DifferentStartByAuthority` dictionary |
+| `api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs` | Modify | Move poll-state read inside loop, pass authority ID, call cleanup |
+| `api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs` | Modify | Update existing tests, add new tests |
+
+---
+
+### Task 1: Update interface and document model
+
+**Files:**
+- Modify: `api/src/town-crier.application/Polling/IPollStateStore.cs`
+- Modify: `api/src/town-crier.infrastructure/Polling/PollStateDocument.cs`
+
+- [ ] **Step 1: Update `IPollStateStore` interface**
+
+Replace the entire file content:
+
+```csharp
+namespace TownCrier.Application.Polling;
+
+public interface IPollStateStore
+{
+    Task<DateTimeOffset?> GetLastPollTimeAsync(int authorityId, CancellationToken ct);
+
+    Task SaveLastPollTimeAsync(int authorityId, DateTimeOffset pollTime, CancellationToken ct);
+
+    Task DeleteGlobalPollStateAsync(CancellationToken ct);
+}
+```
+
+- [ ] **Step 2: Update `PollStateDocument`**
+
+Replace the entire file content:
+
+```csharp
+namespace TownCrier.Infrastructure.Polling;
+
+internal sealed class PollStateDocument
+{
+    public required string Id { get; init; }
+
+    public required string LastPollTime { get; init; }
+
+    public int? AuthorityId { get; init; }
+}
+```
+
+`AuthorityId` is nullable so the existing global doc (which has no `AuthorityId`) can still be deserialized during cleanup.
+
+- [ ] **Step 3: Verify the solution builds (expect compile errors in consumers)**
+
+Run: `dotnet build api/src/town-crier.application/town-crier.application.csproj 2>&1 | tail -5`
+
+Expected: Build succeeds for the application project (interface has no consumers in this project).
+
+Run: `dotnet build api/ 2>&1 | grep -c "error CS"`
+
+Expected: Compile errors in `CosmosPollStateStore.cs`, `PollPlanItCommandHandler.cs`, `FakePollStateStore.cs`, and tests. This is correct — we fix them in subsequent tasks.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/src/town-crier.application/Polling/IPollStateStore.cs api/src/town-crier.infrastructure/Polling/PollStateDocument.cs
+git commit -m "refactor(api): add authorityId parameter to IPollStateStore interface
+
+Per-authority poll state allows new authorities to backfill 30 days
+and prevents rate-limited authorities from losing progress.
+Consumers will be updated in subsequent commits."
+```
+
+---
+
+### Task 2: Update Cosmos store implementation
+
+**Files:**
+- Modify: `api/src/town-crier.infrastructure/Polling/CosmosPollStateStore.cs`
+
+- [ ] **Step 1: Replace `CosmosPollStateStore` implementation**
+
+Replace the entire file content:
+
+```csharp
+using System.Globalization;
+using TownCrier.Application.Polling;
+using TownCrier.Infrastructure.Cosmos;
+
+namespace TownCrier.Infrastructure.Polling;
+
+public sealed class CosmosPollStateStore : IPollStateStore
+{
+    private const string GlobalDocumentId = "poll-state";
+
+    private readonly ICosmosRestClient client;
+
+    public CosmosPollStateStore(ICosmosRestClient client)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        this.client = client;
+    }
+
+    public async Task<DateTimeOffset?> GetLastPollTimeAsync(int authorityId, CancellationToken ct)
+    {
+        var documentId = FormatDocumentId(authorityId);
+        var doc = await this.client.ReadDocumentAsync(
+            CosmosContainerNames.PollState,
+            documentId,
+            documentId,
+            CosmosJsonSerializerContext.Default.PollStateDocument,
+            ct).ConfigureAwait(false);
+
+        if (doc is null)
+        {
+            return null;
+        }
+
+        return DateTimeOffset.Parse(doc.LastPollTime, CultureInfo.InvariantCulture);
+    }
+
+    public async Task SaveLastPollTimeAsync(int authorityId, DateTimeOffset pollTime, CancellationToken ct)
+    {
+        var documentId = FormatDocumentId(authorityId);
+        var doc = new PollStateDocument
+        {
+            Id = documentId,
+            LastPollTime = pollTime.ToString("O", CultureInfo.InvariantCulture),
+            AuthorityId = authorityId,
+        };
+
+        await this.client.UpsertDocumentAsync(
+            CosmosContainerNames.PollState,
+            doc,
+            documentId,
+            CosmosJsonSerializerContext.Default.PollStateDocument,
+            ct).ConfigureAwait(false);
+    }
+
+    public async Task DeleteGlobalPollStateAsync(CancellationToken ct)
+    {
+        await this.client.DeleteDocumentAsync(
+            CosmosContainerNames.PollState,
+            GlobalDocumentId,
+            GlobalDocumentId,
+            ct).ConfigureAwait(false);
+    }
+
+    private static string FormatDocumentId(int authorityId)
+    {
+        return string.Create(CultureInfo.InvariantCulture, $"poll-state-{authorityId}");
+    }
+}
+```
+
+Key changes:
+- `FormatDocumentId` produces `"poll-state-{authorityId}"` (e.g. `"poll-state-314"`)
+- Document ID is used as both ID and partition key (same pattern as before)
+- `DeleteGlobalPollStateAsync` deletes the old `"poll-state"` doc — `DeleteDocumentAsync` already swallows 404
+
+- [ ] **Step 2: Verify infrastructure project builds**
+
+Run: `dotnet build api/src/town-crier.infrastructure/town-crier.infrastructure.csproj`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api/src/town-crier.infrastructure/Polling/CosmosPollStateStore.cs
+git commit -m "refactor(api): implement per-authority poll state in Cosmos store
+
+Documents keyed as poll-state-{authorityId} instead of single
+global poll-state document. Includes DeleteGlobalPollStateAsync
+for cleaning up the orphaned global document."
+```
+
+---
+
+### Task 3: Update fake and test helpers
+
+**Files:**
+- Modify: `api/tests/town-crier.application.tests/Polling/FakePollStateStore.cs`
+- Modify: `api/tests/town-crier.application.tests/Polling/FakePlanItClient.cs`
+
+- [ ] **Step 1: Replace `FakePollStateStore`**
+
+Replace the entire file content:
+
+```csharp
+using TownCrier.Application.Polling;
+
+namespace TownCrier.Application.Tests.Polling;
+
+internal sealed class FakePollStateStore : IPollStateStore
+{
+    private readonly Dictionary<int, DateTimeOffset> pollTimes = [];
+
+    public int SaveCallCount { get; private set; }
+
+    public bool DeleteGlobalCalled { get; private set; }
+
+    public DateTimeOffset? GetLastPollTimeFor(int authorityId)
+    {
+        return this.pollTimes.TryGetValue(authorityId, out var time) ? time : null;
+    }
+
+    public void SetLastPollTime(int authorityId, DateTimeOffset pollTime)
+    {
+        this.pollTimes[authorityId] = pollTime;
+    }
+
+    public Task<DateTimeOffset?> GetLastPollTimeAsync(int authorityId, CancellationToken ct)
+    {
+        DateTimeOffset? result = this.pollTimes.TryGetValue(authorityId, out var time) ? time : null;
+        return Task.FromResult(result);
+    }
+
+    public Task SaveLastPollTimeAsync(int authorityId, DateTimeOffset pollTime, CancellationToken ct)
+    {
+        this.pollTimes[authorityId] = pollTime;
+        this.SaveCallCount++;
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteGlobalPollStateAsync(CancellationToken ct)
+    {
+        this.DeleteGlobalCalled = true;
+        return Task.CompletedTask;
+    }
+}
+```
+
+- [ ] **Step 2: Add `DifferentStartByAuthority` to `FakePlanItClient`**
+
+In `api/tests/town-crier.application.tests/Polling/FakePlanItClient.cs`, add a dictionary to track per-authority different_start values. Add this property after the existing `LastDifferentStartUsed` property (line 12):
+
+```csharp
+public Dictionary<int, DateTimeOffset?> DifferentStartByAuthority { get; } = [];
+```
+
+Then in the `FetchApplicationsAsync` method, after line 55 (`this.LastDifferentStartUsed = differentStart;`), add:
+
+```csharp
+this.DifferentStartByAuthority[authorityId] = differentStart;
+```
+
+- [ ] **Step 3: Verify test project compiles (expect errors in test file only)**
+
+Run: `dotnet build api/tests/town-crier.application.tests/ 2>&1 | grep "error CS"`
+
+Expected: Errors only in `PollPlanItCommandHandlerTests.cs` (old `pollStateStore.LastPollTime` references). The fakes themselves should compile.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add api/tests/town-crier.application.tests/Polling/FakePollStateStore.cs api/tests/town-crier.application.tests/Polling/FakePlanItClient.cs
+git commit -m "refactor(api): update test fakes for per-authority poll state
+
+FakePollStateStore now uses Dictionary<int, DateTimeOffset> for
+per-authority tracking. FakePlanItClient tracks DifferentStartByAuthority."
+```
+
+---
+
+### Task 4: Update handler to use per-authority poll state
+
+**Files:**
+- Modify: `api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs`
+
+- [ ] **Step 1: Update `HandleAsync` method**
+
+Replace the `HandleAsync` method body (lines 42–111) with:
+
+```csharp
+    public async Task<PollPlanItResult> HandleAsync(PollPlanItCommand command, CancellationToken ct)
+    {
+        var now = this.timeProvider.GetUtcNow();
+        var authorityIds = await this.activeAuthorityProvider.GetActiveAuthorityIdsAsync(ct).ConfigureAwait(false);
+
+        var count = 0;
+        var authoritiesPolled = 0;
+        var rateLimitHitCount = 0;
+        foreach (var authorityId in authorityIds)
+        {
+            using var authorityActivity = PollingInstrumentation.Source.StartActivity("Poll Authority");
+            authorityActivity?.SetTag("polling.authority_code", authorityId);
+            var authorityStart = Stopwatch.GetTimestamp();
+
+            try
+            {
+                var lastPollTime = await this.pollStateStore.GetLastPollTimeAsync(authorityId, ct).ConfigureAwait(false);
+                lastPollTime ??= now.AddDays(-30);
+
+                var authorityAppCount = 0;
+                await foreach (var application in this.planItClient.FetchApplicationsAsync(authorityId, lastPollTime, ct).ConfigureAwait(false))
+                {
+                    await this.applicationRepository.UpsertAsync(application, ct).ConfigureAwait(false);
+
+                    if (application.Latitude.HasValue && application.Longitude.HasValue)
+                    {
+                        var matchingZones = await this.watchZoneRepository.FindZonesContainingAsync(
+                            application.Latitude.Value, application.Longitude.Value, ct).ConfigureAwait(false);
+
+                        foreach (var zone in matchingZones)
+                        {
+                            await this.notificationEnqueuer.EnqueueAsync(application, zone, ct).ConfigureAwait(false);
+                        }
+                    }
+
+                    authorityAppCount++;
+                    count++;
+                }
+
+                PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
+                PollingMetrics.ApplicationsIngested.Add(authorityAppCount);
+                authorityActivity?.SetTag("polling.applications_found", authorityAppCount);
+
+                PollingMetrics.AuthoritiesPolled.Add(1);
+                await this.pollStateStore.SaveLastPollTimeAsync(authorityId, now, ct).ConfigureAwait(false);
+                authoritiesPolled++;
+            }
+            catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                rateLimitHitCount++;
+                PollingMetrics.AuthoritiesSkipped.Add(1);
+                PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
+
+                if (rateLimitHitCount >= 2)
+                {
+                    LogRateLimitBreak(this.logger, authorityId, ex);
+                    break;
+                }
+
+                LogRateLimitSkip(this.logger, authorityId, ex);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                PollingMetrics.AuthoritiesSkipped.Add(1);
+                PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
+                LogAuthorityError(this.logger, authorityId, ex);
+            }
+        }
+
+        await this.pollStateStore.DeleteGlobalPollStateAsync(ct).ConfigureAwait(false);
+
+        return new PollPlanItResult(count, authoritiesPolled);
+    }
+```
+
+Key changes from the original:
+- Removed: `var lastPollTime = await this.pollStateStore.GetLastPollTimeAsync(ct)` before the loop
+- Added: `var lastPollTime = await this.pollStateStore.GetLastPollTimeAsync(authorityId, ct)` inside the try block, per authority
+- Changed: `SaveLastPollTimeAsync(now, ct)` → `SaveLastPollTimeAsync(authorityId, now, ct)`
+- Added: `await this.pollStateStore.DeleteGlobalPollStateAsync(ct)` after the loop
+
+- [ ] **Step 2: Verify application project builds**
+
+Run: `dotnet build api/src/town-crier.application/town-crier.application.csproj`
+
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+git commit -m "feat(api): use per-authority poll state in polling handler
+
+Poll state is now read and written per authority ID inside the loop.
+New authorities automatically get a 30-day lookback. Rate-limited
+authorities retain their own last poll time. The orphaned global
+poll-state document is cleaned up after each cycle."
+```
+
+---
+
+### Task 5: Update existing tests
+
+**Files:**
+- Modify: `api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs`
+
+- [ ] **Step 1: Update `Should_UseDefault30DayLookback_When_NoPreviousPollState`**
+
+This test verifies new authorities use 30-day lookback. The FakePlanItClient's `LastDifferentStartUsed` still captures the last call. The test needs no assertion change — only the handler logic changed (poll state read moved inside loop). No changes needed to this test.
+
+- [ ] **Step 2: Update `Should_PassLastPollTime_When_PreviousPollStateExists`**
+
+Change the `SetLastPollTime` call to include the authority ID. Replace lines 96–98:
+
+Old:
+```csharp
+        var pollStateStore = new FakePollStateStore();
+        var lastPoll = new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero);
+        pollStateStore.SetLastPollTime(lastPoll);
+```
+
+New:
+```csharp
+        var pollStateStore = new FakePollStateStore();
+        var lastPoll = new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero);
+        pollStateStore.SetLastPollTime(1, lastPoll);
+```
+
+- [ ] **Step 3: Update `Should_PersistCurrentTime_When_PollSucceeds`**
+
+Replace the assertion on line 121. Old:
+```csharp
+        await Assert.That(pollStateStore.LastPollTime).IsEqualTo(fakeTime);
+```
+
+New:
+```csharp
+        await Assert.That(pollStateStore.GetLastPollTimeFor(1)).IsEqualTo(fakeTime);
+```
+
+(Authority ID is 1 because `FakeActiveAuthorityProvider` defaults to empty and the test adds authority `1` on line 110.)
+
+- [ ] **Step 4: Update `Should_SavePollStateAfterEachAuthority_When_MultipleAuthoritiesPolled`**
+
+No changes needed — `SaveCallCount` is still tracked the same way and the test only checks the count (3 saves for 3 authorities).
+
+- [ ] **Step 5: Update `Should_NotSavePollState_When_OnlyAuthorityFails`**
+
+Replace the assertion on line 280. Old:
+```csharp
+        await Assert.That(pollStateStore.LastPollTime).IsNull();
+```
+
+New:
+```csharp
+        await Assert.That(pollStateStore.GetLastPollTimeFor(1)).IsNull();
+```
+
+- [ ] **Step 6: Update `Should_ContinueAndPreserveProgress_When_MiddleAuthorityFails`**
+
+Replace the assertion on line 262. Old:
+```csharp
+        await Assert.That(pollStateStore.LastPollTime).IsEqualTo(fakeTime);
+```
+
+New:
+```csharp
+        await Assert.That(pollStateStore.GetLastPollTimeFor(100)).IsEqualTo(fakeTime);
+        await Assert.That(pollStateStore.GetLastPollTimeFor(300)).IsEqualTo(fakeTime);
+        await Assert.That(pollStateStore.GetLastPollTimeFor(200)).IsNull();
+```
+
+This is stronger than before — it verifies authority 200 (the failed one) didn't get its timestamp advanced, while 100 and 300 did.
+
+- [ ] **Step 7: Run all existing tests**
+
+Run: `dotnet test api/tests/town-crier.application.tests/ --filter "PollPlanItCommandHandler"`
+
+Expected: All 14 existing tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+git commit -m "test(api): update existing poll handler tests for per-authority state
+
+Mechanical update: SetLastPollTime and assertions now use authority IDs.
+ContinueAndPreserveProgress test now verifies per-authority isolation."
+```
+
+---
+
+### Task 6: Add new tests for per-authority behaviour
+
+**Files:**
+- Modify: `api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs`
+
+- [ ] **Step 1: Add test — new authority uses 30-day lookback when others have state**
+
+Add this test after the existing tests, before the `CreateHandler` method:
+
+```csharp
+    [Test]
+    public async Task Should_Use30DayLookback_When_NewAuthorityHasNoPollState()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+
+        var pollStateStore = new FakePollStateStore();
+        var existingPollTime = new DateTimeOffset(2026, 4, 5, 10, 0, 0, TimeSpan.Zero);
+        pollStateStore.SetLastPollTime(100, existingPollTime);
+        // Authority 200 has no poll state — should get 30-day lookback
+
+        var now = new DateTimeOffset(2026, 4, 5, 12, 0, 0, TimeSpan.Zero);
+        var planItClient = new FakePlanItClient();
+
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            pollStateStore: pollStateStore,
+            authorityProvider: authorityProvider,
+            timeProvider: new FakeTimeProvider(now));
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        // Authority 100 should use its existing poll time
+        await Assert.That(planItClient.DifferentStartByAuthority[100]).IsEqualTo(existingPollTime);
+
+        // Authority 200 should use 30-day lookback
+        var expected30DaysAgo = new DateTimeOffset(2026, 3, 6, 12, 0, 0, TimeSpan.Zero);
+        await Assert.That(planItClient.DifferentStartByAuthority[200]).IsEqualTo(expected30DaysAgo);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test api/tests/town-crier.application.tests/ --filter "Should_Use30DayLookback_When_NewAuthorityHasNoPollState"`
+
+Expected: PASS (the handler implementation from Task 4 already supports this).
+
+Note: This test would have FAILED against the old global-state implementation, where authority 200 would have received the same `existingPollTime` as authority 100. We're writing it to prevent regression.
+
+- [ ] **Step 3: Add test — rate-limited authority retains its own poll time**
+
+```csharp
+    [Test]
+    public async Task Should_RetainPerAuthorityPollTime_When_AuthorityIsRateLimited()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+
+        var pollStateStore = new FakePollStateStore();
+        var authority100Time = new DateTimeOffset(2026, 4, 4, 10, 0, 0, TimeSpan.Zero);
+        var authority200Time = new DateTimeOffset(2026, 4, 3, 8, 0, 0, TimeSpan.Zero);
+        pollStateStore.SetLastPollTime(100, authority100Time);
+        pollStateStore.SetLastPollTime(200, authority200Time);
+
+        var now = new DateTimeOffset(2026, 4, 5, 12, 0, 0, TimeSpan.Zero);
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.ThrowForAuthority(200, new HttpRequestException("Rate limited", null, HttpStatusCode.TooManyRequests));
+
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            pollStateStore: pollStateStore,
+            authorityProvider: authorityProvider,
+            timeProvider: new FakeTimeProvider(now));
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        // Authority 100 should be advanced to now
+        await Assert.That(pollStateStore.GetLastPollTimeFor(100)).IsEqualTo(now);
+
+        // Authority 200 should retain its original poll time (rate limited, not advanced)
+        await Assert.That(pollStateStore.GetLastPollTimeFor(200)).IsEqualTo(authority200Time);
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `dotnet test api/tests/town-crier.application.tests/ --filter "Should_RetainPerAuthorityPollTime_When_AuthorityIsRateLimited"`
+
+Expected: PASS.
+
+- [ ] **Step 5: Add test — global poll state cleanup**
+
+```csharp
+    [Test]
+    public async Task Should_DeleteGlobalPollState_When_CycleCompletes()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(1);
+
+        var pollStateStore = new FakePollStateStore();
+        var handler = CreateHandler(pollStateStore: pollStateStore, authorityProvider: authorityProvider);
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(pollStateStore.DeleteGlobalCalled).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_DeleteGlobalPollState_When_NoActiveAuthorities()
+    {
+        var pollStateStore = new FakePollStateStore();
+        var handler = CreateHandler(pollStateStore: pollStateStore);
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(pollStateStore.DeleteGlobalCalled).IsTrue();
+    }
+```
+
+- [ ] **Step 6: Run all new tests**
+
+Run: `dotnet test api/tests/town-crier.application.tests/ --filter "Should_DeleteGlobalPollState|Should_RetainPerAuthorityPollTime|Should_Use30DayLookback_When_NewAuthority"`
+
+Expected: All 4 new tests PASS.
+
+- [ ] **Step 7: Run full test suite**
+
+Run: `dotnet test api/`
+
+Expected: All tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+git commit -m "test(api): add per-authority poll state regression tests
+
+New authority 30-day lookback, rate-limited authority time retention,
+and global poll-state cleanup are now covered."
+```
+
+---
+
+### Task 7: Format check and final verification
+
+- [ ] **Step 1: Run formatter**
+
+Run: `dotnet format api/ --verify-no-changes`
+
+If formatting issues found, run: `dotnet format api/` and commit the fix.
+
+- [ ] **Step 2: Run full build**
+
+Run: `dotnet build api/`
+
+Expected: Build succeeds with no warnings.
+
+- [ ] **Step 3: Run full test suite one final time**
+
+Run: `dotnet test api/`
+
+Expected: All tests pass.

--- a/docs/superpowers/plans/2026-04-05-remove-profile-postcode.md
+++ b/docs/superpowers/plans/2026-04-05-remove-profile-postcode.md
@@ -1,0 +1,688 @@
+# Remove Vestigial Postcode from UserProfile
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the unused `Postcode` field from `UserProfile` across API, web, and tests. Watch zones are the real mechanism for location tracking; the profile-level postcode is never written during onboarding and always shows "Not set."
+
+**Architecture:** Strip `Postcode` from the domain model, Cosmos document mapping, all CQRS command/query/result records, the PATCH endpoint, web types, and the Settings page. The `Postcode` value object, geocoding service, `PlanningApplication.Postcode`, and iOS `WatchZone.postcode` are unaffected — they serve different purposes.
+
+**Tech Stack:** .NET 10 (C#), React/TypeScript, TUnit, Vitest
+
+---
+
+### Task 1: API Domain — Remove Postcode from UserProfile
+
+**Files:**
+- Modify: `api/src/town-crier.domain/UserProfiles/UserProfile.cs`
+
+- [ ] **Step 1: Remove `Postcode` from constructor, property, `Register`, `UpdatePreferences`, and `Reconstitute`**
+
+In `UserProfile.cs`, make these changes:
+
+**Constructor** — remove the `string? postcode` parameter and the `this.Postcode = postcode;` assignment:
+
+```csharp
+private UserProfile(
+    string userId,
+    string? email,
+    NotificationPreferences notificationPreferences,
+    SubscriptionTier tier,
+    DateTimeOffset? subscriptionExpiry,
+    string? originalTransactionId,
+    DateTimeOffset? gracePeriodExpiry)
+{
+    this.UserId = userId;
+    this.Email = email;
+    this.NotificationPreferences = notificationPreferences;
+    this.Tier = tier;
+    this.SubscriptionExpiry = subscriptionExpiry;
+    this.OriginalTransactionId = originalTransactionId;
+    this.GracePeriodExpiry = gracePeriodExpiry;
+}
+```
+
+**Remove the property:**
+```csharp
+// DELETE this line:
+public string? Postcode { get; private set; }
+```
+
+**`Register`** — remove `postcode: null` from the constructor call:
+```csharp
+public static UserProfile Register(string userId, string? email = null)
+{
+    ArgumentException.ThrowIfNullOrWhiteSpace(userId);
+
+    return new UserProfile(
+        userId,
+        email,
+        notificationPreferences: NotificationPreferences.Default,
+        tier: SubscriptionTier.Free,
+        subscriptionExpiry: null,
+        originalTransactionId: null,
+        gracePeriodExpiry: null);
+}
+```
+
+**`UpdatePreferences`** — remove the `string? postcode` parameter and the assignment:
+```csharp
+public void UpdatePreferences(NotificationPreferences notificationPreferences)
+{
+    this.NotificationPreferences = notificationPreferences;
+}
+```
+
+**`Reconstitute`** — remove the `string? postcode` parameter and propagation:
+```csharp
+internal static UserProfile Reconstitute(
+    string userId,
+    string? email,
+    NotificationPreferences notificationPreferences,
+    Dictionary<string, ZoneNotificationPreferences> zonePreferences,
+    SubscriptionTier tier,
+    DateTimeOffset? subscriptionExpiry,
+    string? originalTransactionId,
+    DateTimeOffset? gracePeriodExpiry)
+{
+    var profile = new UserProfile(
+        userId,
+        email,
+        notificationPreferences,
+        tier,
+        subscriptionExpiry,
+        originalTransactionId,
+        gracePeriodExpiry);
+
+    foreach (var (zoneId, prefs) in zonePreferences)
+    {
+        profile.zonePreferences[zoneId] = prefs;
+    }
+
+    return profile;
+}
+```
+
+- [ ] **Step 2: Verify the project compiles (expect downstream failures — that's fine)**
+
+Run: `dotnet build api/src/town-crier.domain/town-crier.domain.csproj`
+Expected: SUCCESS (this project has no downstream references within itself)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api/src/town-crier.domain/UserProfiles/UserProfile.cs
+git commit -m "refactor(domain): remove vestigial Postcode from UserProfile"
+```
+
+---
+
+### Task 2: API Infrastructure — Remove Postcode from Cosmos Document Mapping
+
+**Files:**
+- Modify: `api/src/town-crier.infrastructure/UserProfiles/UserProfileDocument.cs`
+
+- [ ] **Step 1: Remove `Postcode` from the document, `FromDomain`, and `ToDomain`**
+
+**Remove the property:**
+```csharp
+// DELETE this line:
+public string? Postcode { get; init; }
+```
+
+**In `FromDomain`** — remove the `Postcode = profile.Postcode,` line:
+```csharp
+public static UserProfileDocument FromDomain(UserProfile profile)
+{
+    ArgumentNullException.ThrowIfNull(profile);
+
+    return new UserProfileDocument
+    {
+        Id = profile.UserId,
+        UserId = profile.UserId,
+        Email = profile.Email,
+        PushEnabled = profile.NotificationPreferences.PushEnabled,
+        DigestDay = profile.NotificationPreferences.DigestDay,
+        EmailDigestEnabled = profile.NotificationPreferences.EmailDigestEnabled,
+        EmailInstantEnabled = profile.NotificationPreferences.EmailInstantEnabled,
+        ZonePreferences = new Dictionary<string, ZoneNotificationPreferences>(profile.AllZonePreferences),
+        Tier = profile.Tier.ToString(),
+        SubscriptionExpiry = profile.SubscriptionExpiry,
+        OriginalTransactionId = profile.OriginalTransactionId,
+        GracePeriodExpiry = profile.GracePeriodExpiry,
+    };
+}
+```
+
+**In `ToDomain`** — remove `this.Postcode` from the `Reconstitute` call (matches the updated signature from Task 1):
+```csharp
+public UserProfile ToDomain()
+{
+    var tier = Enum.Parse<SubscriptionTier>(this.Tier);
+    var notificationPreferences = new NotificationPreferences(
+        this.PushEnabled,
+        this.DigestDay,
+        this.EmailDigestEnabled,
+        this.EmailInstantEnabled);
+
+    return UserProfile.Reconstitute(
+        this.UserId,
+        this.Email,
+        notificationPreferences,
+        this.ZonePreferences,
+        tier,
+        this.SubscriptionExpiry,
+        this.OriginalTransactionId,
+        this.GracePeriodExpiry);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add api/src/town-crier.infrastructure/UserProfiles/UserProfileDocument.cs
+git commit -m "refactor(infra): remove Postcode from UserProfileDocument Cosmos mapping"
+```
+
+---
+
+### Task 3: API Application — Remove Postcode from Commands, Results, and Handlers
+
+**Files:**
+- Modify: `api/src/town-crier.application/UserProfiles/UpdateUserProfileCommand.cs`
+- Modify: `api/src/town-crier.application/UserProfiles/UpdateUserProfileResult.cs`
+- Modify: `api/src/town-crier.application/UserProfiles/UpdateUserProfileCommandHandler.cs`
+- Modify: `api/src/town-crier.application/UserProfiles/GetUserProfileResult.cs`
+- Modify: `api/src/town-crier.application/UserProfiles/GetUserProfileQueryHandler.cs`
+- Modify: `api/src/town-crier.application/UserProfiles/CreateUserProfileResult.cs`
+- Modify: `api/src/town-crier.application/UserProfiles/CreateUserProfileCommandHandler.cs`
+- Modify: `api/src/town-crier.application/UserProfiles/ExportUserDataResult.cs`
+- Modify: `api/src/town-crier.application/UserProfiles/ExportUserDataQueryHandler.cs`
+
+- [ ] **Step 1: Update `UpdateUserProfileCommand` — remove `Postcode` parameter**
+
+```csharp
+namespace TownCrier.Application.UserProfiles;
+
+public sealed record UpdateUserProfileCommand(
+    string UserId,
+    bool PushEnabled);
+```
+
+- [ ] **Step 2: Update `UpdateUserProfileResult` — remove `Postcode` parameter**
+
+```csharp
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.UserProfiles;
+
+public sealed record UpdateUserProfileResult(
+    string UserId,
+    bool PushEnabled,
+    SubscriptionTier Tier);
+```
+
+- [ ] **Step 3: Update `UpdateUserProfileCommandHandler` — remove postcode from `UpdatePreferences` call and result**
+
+```csharp
+public async Task<UpdateUserProfileResult> HandleAsync(UpdateUserProfileCommand command, CancellationToken ct)
+{
+    ArgumentNullException.ThrowIfNull(command);
+
+    var profile = await this.repository.GetByUserIdAsync(command.UserId, ct).ConfigureAwait(false)
+        ?? throw UserProfileNotFoundException.ForUser(command.UserId);
+
+    profile.UpdatePreferences(new NotificationPreferences(command.PushEnabled));
+    await this.repository.SaveAsync(profile, ct).ConfigureAwait(false);
+
+    return new UpdateUserProfileResult(
+        profile.UserId,
+        profile.NotificationPreferences.PushEnabled,
+        profile.Tier);
+}
+```
+
+- [ ] **Step 4: Update `GetUserProfileResult` — remove `Postcode` parameter**
+
+```csharp
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.UserProfiles;
+
+public sealed record GetUserProfileResult(
+    string UserId,
+    bool PushEnabled,
+    SubscriptionTier Tier);
+```
+
+- [ ] **Step 5: Update `GetUserProfileQueryHandler` — remove `profile.Postcode` from result construction**
+
+```csharp
+return new GetUserProfileResult(
+    profile.UserId,
+    profile.NotificationPreferences.PushEnabled,
+    profile.Tier);
+```
+
+- [ ] **Step 6: Update `CreateUserProfileResult` — remove `Postcode` parameter**
+
+```csharp
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.UserProfiles;
+
+public sealed record CreateUserProfileResult(
+    string UserId,
+    bool PushEnabled,
+    SubscriptionTier Tier);
+```
+
+- [ ] **Step 7: Update `CreateUserProfileCommandHandler` — remove `profile.Postcode` from both result constructions**
+
+In the existing-profile branch (line 26-30):
+```csharp
+return new CreateUserProfileResult(
+    existing.UserId,
+    existing.NotificationPreferences.PushEnabled,
+    existing.Tier);
+```
+
+In the new-profile branch (line 43-47):
+```csharp
+return new CreateUserProfileResult(
+    profile.UserId,
+    profile.NotificationPreferences.PushEnabled,
+    profile.Tier);
+```
+
+- [ ] **Step 8: Update `ExportUserDataResult` — remove `Postcode` parameter**
+
+```csharp
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.UserProfiles;
+
+public sealed record ExportUserDataResult(
+    string UserId,
+    bool PushEnabled,
+    SubscriptionTier Tier);
+```
+
+- [ ] **Step 9: Update `ExportUserDataQueryHandler` — remove `profile.Postcode` from result**
+
+```csharp
+return new ExportUserDataResult(
+    profile.UserId,
+    profile.NotificationPreferences.PushEnabled,
+    profile.Tier);
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add api/src/town-crier.application/UserProfiles/
+git commit -m "refactor(app): remove Postcode from all UserProfile commands, queries, and results"
+```
+
+---
+
+### Task 4: API Endpoint — Remove Postcode from PATCH /v1/me
+
+**Files:**
+- Modify: `api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs`
+
+- [ ] **Step 1: Update the PATCH endpoint to stop reading/passing postcode**
+
+Change line 40 from:
+```csharp
+var profileCommand = new UpdateUserProfileCommand(userId, command.Postcode, command.PushEnabled);
+```
+to:
+```csharp
+var profileCommand = new UpdateUserProfileCommand(userId, command.PushEnabled);
+```
+
+- [ ] **Step 2: Build the full API solution**
+
+Run: `dotnet build api/`
+Expected: SUCCESS (all postcode references in API source are now removed)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
+git commit -m "refactor(web): remove Postcode from PATCH /v1/me endpoint"
+```
+
+---
+
+### Task 5: API Tests — Update All Tests Referencing Profile Postcode
+
+**Files:**
+- Modify: `api/tests/town-crier.application.tests/UserProfiles/UpdateUserProfileCommandHandlerTests.cs`
+- Modify: `api/tests/town-crier.application.tests/UserProfiles/GetUserProfileQueryHandlerTests.cs`
+- Modify: `api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs`
+- Modify: `api/tests/town-crier.application.tests/UserProfiles/ExportUserDataQueryHandlerTests.cs`
+- Modify: `api/tests/town-crier.application.tests/Notifications/UserProfileBuilder.cs`
+- Modify: `api/tests/town-crier.infrastructure.tests/UserProfiles/UserProfileDocumentTests.cs`
+- Modify: `api/tests/town-crier.infrastructure.tests/UserProfiles/UserProfileDocumentSerializationTests.cs`
+
+- [ ] **Step 1: Update `UpdateUserProfileCommandHandlerTests`**
+
+Rewrite the entire file:
+
+```csharp
+using TownCrier.Application.UserProfiles;
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.Tests.UserProfiles;
+
+public sealed class UpdateUserProfileCommandHandlerTests
+{
+    [Test]
+    public async Task Should_UpdatePushEnabled_When_ProfileExists()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-789");
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new UpdateUserProfileCommandHandler(repository);
+        var command = new UpdateUserProfileCommand("auth0|user-789", true);
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.PushEnabled).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_DisablePush_When_SetToFalse()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-789");
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new UpdateUserProfileCommandHandler(repository);
+        var command = new UpdateUserProfileCommand("auth0|user-789", false);
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.PushEnabled).IsFalse();
+    }
+
+    [Test]
+    public async Task Should_PersistChanges_When_PreferencesUpdated()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-789");
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new UpdateUserProfileCommandHandler(repository);
+        var command = new UpdateUserProfileCommand("auth0|user-789", false);
+
+        // Act
+        await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        var saved = repository.GetByUserId("auth0|user-789");
+        await Assert.That(saved!.NotificationPreferences.PushEnabled).IsFalse();
+    }
+
+    [Test]
+    public async Task Should_ThrowUserProfileNotFoundException_When_ProfileDoesNotExist()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var handler = new UpdateUserProfileCommandHandler(repository);
+        var command = new UpdateUserProfileCommand("auth0|nonexistent", true);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<UserProfileNotFoundException>(
+            () => handler.HandleAsync(command, CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Should_PreserveTier_When_PreferencesUpdated()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-789");
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new UpdateUserProfileCommandHandler(repository);
+        var command = new UpdateUserProfileCommand("auth0|user-789", false);
+
+        // Act
+        var result = await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert — tier should remain Free (not modifiable via preferences update)
+        await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);
+    }
+}
+```
+
+- [ ] **Step 2: Update `GetUserProfileQueryHandlerTests` — remove `result.Postcode` assertion**
+
+In `Should_ReturnProfile_When_ProfileExists`, delete this line:
+```csharp
+await Assert.That(result.Postcode).IsNull();
+```
+
+- [ ] **Step 3: Update `CreateUserProfileCommandHandlerTests` — remove `result.Postcode` assertion**
+
+In `Should_CreateProfileWithFreeTier_When_NewUser`, delete this line:
+```csharp
+await Assert.That(result.Postcode).IsNull();
+```
+
+- [ ] **Step 4: Update `ExportUserDataQueryHandlerTests` — remove postcode from `UpdatePreferences` call and assertion**
+
+In `Should_ReturnUserData_When_ProfileExists`:
+
+Change:
+```csharp
+profile.UpdatePreferences("SW1A 1AA", new NotificationPreferences(PushEnabled: true));
+```
+to:
+```csharp
+profile.UpdatePreferences(new NotificationPreferences(PushEnabled: true));
+```
+
+Delete this assertion line:
+```csharp
+await Assert.That(result.Postcode).IsEqualTo("SW1A 1AA");
+```
+
+- [ ] **Step 5: Update `UserProfileBuilder` — remove postcode from `UpdatePreferences` call**
+
+In the `Build()` method, change:
+```csharp
+profile.UpdatePreferences(
+    postcode: null,
+    new NotificationPreferences(
+        this.pushEnabled,
+        this.digestDay,
+        this.emailDigestEnabled,
+        this.emailInstantEnabled));
+```
+to:
+```csharp
+profile.UpdatePreferences(
+    new NotificationPreferences(
+        this.pushEnabled,
+        this.digestDay,
+        this.emailDigestEnabled,
+        this.emailInstantEnabled));
+```
+
+- [ ] **Step 6: Update `UserProfileDocumentTests`**
+
+In `Should_PreserveBasicFields_When_MappedFromDomain`:
+
+Change:
+```csharp
+profile.UpdatePreferences("SW1A 1AA", new NotificationPreferences(true, DayOfWeek.Wednesday));
+```
+to:
+```csharp
+profile.UpdatePreferences(new NotificationPreferences(true, DayOfWeek.Wednesday));
+```
+
+Delete:
+```csharp
+await Assert.That(document.Postcode).IsEqualTo("SW1A 1AA");
+```
+
+In `Should_RoundTripToDomain_When_MappedBackAndForth`:
+
+Change:
+```csharp
+original.UpdatePreferences("SW1A 1AA", new NotificationPreferences(false, DayOfWeek.Friday));
+```
+to:
+```csharp
+original.UpdatePreferences(new NotificationPreferences(false, DayOfWeek.Friday));
+```
+
+Delete:
+```csharp
+await Assert.That(roundTripped.Postcode).IsEqualTo(original.Postcode);
+```
+
+In `Should_HandleNullOptionalFields_When_MappedFromDomain`:
+
+Delete:
+```csharp
+await Assert.That(document.Postcode).IsNull();
+```
+
+- [ ] **Step 7: Update `UserProfileDocumentSerializationTests`**
+
+In `Should_RoundTripUserProfileDocument_When_Serialized`:
+
+Change:
+```csharp
+profile.UpdatePreferences("SW1A 1AA", new NotificationPreferences(true, DayOfWeek.Wednesday));
+```
+to:
+```csharp
+profile.UpdatePreferences(new NotificationPreferences(true, DayOfWeek.Wednesday));
+```
+
+Delete:
+```csharp
+await Assert.That(deserialized.Postcode).IsEqualTo(original.Postcode);
+```
+
+- [ ] **Step 8: Run all API tests**
+
+Run: `dotnet test api/`
+Expected: All tests PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add api/tests/
+git commit -m "test(api): update all tests to remove profile postcode references"
+```
+
+---
+
+### Task 6: Web — Remove Postcode from Types, Settings Page, and Tests
+
+**Files:**
+- Modify: `web/src/domain/types.ts`
+- Modify: `web/src/features/Settings/SettingsPage.tsx`
+- Modify: `web/src/features/Settings/__tests__/SettingsPage.test.tsx`
+- Modify: `web/src/features/Settings/__tests__/fixtures/user-profile.fixtures.ts`
+
+- [ ] **Step 1: Remove `postcode` from `UserProfile` type**
+
+In `web/src/domain/types.ts`, change the `UserProfile` interface:
+```typescript
+export interface UserProfile {
+  readonly userId: string;
+  readonly pushEnabled: boolean;
+  readonly tier: SubscriptionTier;
+}
+```
+
+- [ ] **Step 2: Remove `postcode` from `UpdateProfileRequest` type**
+
+In `web/src/domain/types.ts`, change:
+```typescript
+export interface UpdateProfileRequest {
+  readonly pushEnabled: boolean;
+}
+```
+
+- [ ] **Step 3: Remove the Postcode row from `SettingsPage.tsx`**
+
+In `web/src/features/Settings/SettingsPage.tsx`, delete these 4 lines (59-62):
+```tsx
+<div className={styles.field}>
+  <span className={styles.label}>Postcode</span>
+  <span className={styles.value}>{profile?.postcode ?? 'Not set'}</span>
+</div>
+```
+
+- [ ] **Step 4: Update test fixtures — remove `postcode` from `freeUserProfile`**
+
+In `web/src/features/Settings/__tests__/fixtures/user-profile.fixtures.ts`:
+```typescript
+import type { UserProfile, SubscriptionTier } from '../../../../domain/types';
+
+export function freeUserProfile(
+  overrides?: Partial<UserProfile>,
+): UserProfile {
+  return {
+    userId: 'auth0|abc123',
+    pushEnabled: true,
+    tier: 'Free' as SubscriptionTier,
+    ...overrides,
+  };
+}
+
+export function proUserProfile(
+  overrides?: Partial<UserProfile>,
+): UserProfile {
+  return {
+    ...freeUserProfile(),
+    userId: 'auth0|pro456',
+    tier: 'Pro' as SubscriptionTier,
+    ...overrides,
+  };
+}
+```
+
+- [ ] **Step 5: Update `SettingsPage.test.tsx` — remove postcode test references**
+
+In the `'renders profile info after loading'` test, change:
+```typescript
+it('renders profile info after loading', async () => {
+  spy.fetchProfileResult = proUserProfile();
+
+  renderSettingsPage(spy);
+
+  expect(await screen.findByText('Pro')).toBeInTheDocument();
+});
+```
+
+This removes the `postcode: 'SW1A 1AA'` override and the assertion for 'SW1A 1AA'.
+
+- [ ] **Step 6: Run web type check and tests**
+
+Run: `cd web && npx tsc --noEmit && npx vitest run`
+Expected: All pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/domain/types.ts web/src/features/Settings/
+git commit -m "refactor(web): remove postcode from UserProfile type and Settings page"
+```

--- a/docs/superpowers/plans/2026-04-05-static-authority-list.md
+++ b/docs/superpowers/plans/2026-04-05-static-authority-list.md
@@ -1,0 +1,352 @@
+# Static Authority List Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the PlanIT-fetched authority list with a static JSON file embedded in the binary, eliminating pagination instability that causes missing authorities (e.g., Kingston).
+
+**Architecture:** A static `authorities.json` file is added as an embedded resource in the infrastructure project. A new `StaticAuthorityProvider` loads it once at construction time. The existing `CachedPlanItAuthorityProvider` and its area-specific models are deleted.
+
+**Tech Stack:** .NET 10, System.Text.Json source generators, TUnit
+
+---
+
+### Task 1: Create the static authorities.json data file
+
+**Files:**
+- Create: `api/src/town-crier.infrastructure/Authorities/authorities.json`
+
+- [ ] **Step 1: Generate the JSON file from PlanIT's current data**
+
+Run:
+```bash
+curl -s "https://www.planit.org.uk/api/areas/json?pg_sz=1000&page=1&select=area_id,area_name,area_type" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+records = data['records']
+entries = [{'id': r['area_id'], 'name': r['area_name'], 'areaType': r['area_type']} for r in records]
+entries.sort(key=lambda x: x['name'].lower())
+print(json.dumps(entries, indent=2))
+" > api/src/town-crier.infrastructure/Authorities/authorities.json
+```
+
+Expected: A JSON file with 485 authority objects, alphabetically sorted by name. Verify Kingston is present:
+```bash
+grep -c "Kingston" api/src/town-crier.infrastructure/Authorities/authorities.json
+```
+Expected: 2 matches (Kingston, Kingston upon Hull — or similar)
+
+- [ ] **Step 2: Register as embedded resource**
+
+In `api/src/town-crier.infrastructure/town-crier.infrastructure.csproj`, add to the existing `<ItemGroup>` that contains `EmbeddedResource`:
+
+```xml
+<EmbeddedResource Include="Authorities\authorities.json" />
+```
+
+The existing item group already has `Geocoding\authority-mapping.json`, so add the new line alongside it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add api/src/town-crier.infrastructure/Authorities/authorities.json api/src/town-crier.infrastructure/town-crier.infrastructure.csproj
+git commit -m "feat: add static authorities.json data file with 485 UK local authorities"
+```
+
+---
+
+### Task 2: Create StaticAuthorityProvider with tests (TDD)
+
+**Files:**
+- Create: `api/src/town-crier.infrastructure/Authorities/StaticAuthorityProvider.cs`
+- Create: `api/src/town-crier.infrastructure/Authorities/AuthorityRecord.cs`
+- Create: `api/src/town-crier.infrastructure/Authorities/AuthorityJsonSerializerContext.cs`
+- Create: `api/tests/town-crier.infrastructure.tests/Authorities/StaticAuthorityProviderTests.cs`
+
+- [ ] **Step 1: Write the failing test — loads all authorities**
+
+Create `api/tests/town-crier.infrastructure.tests/Authorities/StaticAuthorityProviderTests.cs`:
+
+```csharp
+namespace TownCrier.Infrastructure.Tests.Authorities;
+
+public sealed class StaticAuthorityProviderTests
+{
+    [Test]
+    public async Task Should_LoadAllAuthorities_From_EmbeddedJson()
+    {
+        // Arrange
+        var provider = new Infrastructure.Authorities.StaticAuthorityProvider();
+
+        // Act
+        var authorities = await provider.GetAllAsync(CancellationToken.None);
+
+        // Assert — the embedded JSON has 485 authorities
+        await Assert.That(authorities.Count).IsGreaterThan(400);
+    }
+
+    [Test]
+    public async Task Should_ContainKingston_When_Loaded()
+    {
+        // Arrange
+        var provider = new Infrastructure.Authorities.StaticAuthorityProvider();
+
+        // Act
+        var authorities = await provider.GetAllAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(authorities.Any(a => a.Name == "Kingston")).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_ReturnAuthority_When_GetByIdWithValidId()
+    {
+        // Arrange
+        var provider = new Infrastructure.Authorities.StaticAuthorityProvider();
+
+        // Act — Kingston has ID 314
+        var authority = await provider.GetByIdAsync(314, CancellationToken.None);
+
+        // Assert
+        await Assert.That(authority).IsNotNull();
+        await Assert.That(authority!.Name).IsEqualTo("Kingston");
+    }
+
+    [Test]
+    public async Task Should_ReturnNull_When_GetByIdWithInvalidId()
+    {
+        // Arrange
+        var provider = new Infrastructure.Authorities.StaticAuthorityProvider();
+
+        // Act
+        var authority = await provider.GetByIdAsync(99999, CancellationToken.None);
+
+        // Assert
+        await Assert.That(authority).IsNull();
+    }
+
+    [Test]
+    public async Task Should_SortAlphabetically_When_Loaded()
+    {
+        // Arrange
+        var provider = new Infrastructure.Authorities.StaticAuthorityProvider();
+
+        // Act
+        var authorities = await provider.GetAllAsync(CancellationToken.None);
+
+        // Assert — first authority alphabetically should be Aberdeen or similar
+        var names = authorities.Select(a => a.Name).ToList();
+        var sorted = names.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();
+        await Assert.That(names).IsEquivalentTo(sorted);
+    }
+
+    [Test]
+    public async Task Should_SetCouncilUrlAndPlanningUrlToNull()
+    {
+        // Arrange
+        var provider = new Infrastructure.Authorities.StaticAuthorityProvider();
+
+        // Act
+        var authority = await provider.GetByIdAsync(314, CancellationToken.None);
+
+        // Assert
+        await Assert.That(authority).IsNotNull();
+        await Assert.That(authority!.CouncilUrl).IsNull();
+        await Assert.That(authority.PlanningUrl).IsNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test api/tests/town-crier.infrastructure.tests --filter "StaticAuthorityProvider" --no-restore`
+Expected: FAIL — `StaticAuthorityProvider` does not exist yet.
+
+- [ ] **Step 3: Create the AuthorityRecord DTO**
+
+Create `api/src/town-crier.infrastructure/Authorities/AuthorityRecord.cs`:
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Infrastructure.Authorities;
+
+internal sealed class AuthorityRecord
+{
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("areaType")]
+    public string AreaType { get; set; } = string.Empty;
+}
+```
+
+- [ ] **Step 4: Create the JSON serializer context (Native AOT)**
+
+Create `api/src/town-crier.infrastructure/Authorities/AuthorityJsonSerializerContext.cs`:
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Infrastructure.Authorities;
+
+[JsonSerializable(typeof(List<AuthorityRecord>))]
+internal sealed partial class AuthorityJsonSerializerContext : JsonSerializerContext;
+```
+
+- [ ] **Step 5: Implement StaticAuthorityProvider**
+
+Create `api/src/town-crier.infrastructure/Authorities/StaticAuthorityProvider.cs`:
+
+```csharp
+using System.Reflection;
+using System.Text.Json;
+using TownCrier.Application.Authorities;
+using TownCrier.Domain.Authorities;
+
+namespace TownCrier.Infrastructure.Authorities;
+
+public sealed class StaticAuthorityProvider : IAuthorityProvider
+{
+    private readonly IReadOnlyList<Authority> authorities;
+    private readonly Dictionary<int, Authority> authoritiesById;
+
+    public StaticAuthorityProvider()
+    {
+        var records = LoadEmbeddedAuthorities();
+
+        this.authorities = records
+            .Select(r => new Authority(r.Id, r.Name, r.AreaType, councilUrl: null, planningUrl: null))
+            .OrderBy(a => a.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList()
+            .AsReadOnly();
+
+        this.authoritiesById = this.authorities.ToDictionary(a => a.Id);
+    }
+
+    public Task<IReadOnlyList<Authority>> GetAllAsync(CancellationToken ct)
+    {
+        return Task.FromResult(this.authorities);
+    }
+
+    public Task<Authority?> GetByIdAsync(int id, CancellationToken ct)
+    {
+        this.authoritiesById.TryGetValue(id, out var authority);
+        return Task.FromResult(authority);
+    }
+
+    private static List<AuthorityRecord> LoadEmbeddedAuthorities()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        const string resourceName = "TownCrier.Infrastructure.Authorities.authorities.json";
+
+        using var stream = assembly.GetManifestResourceStream(resourceName)
+            ?? throw new InvalidOperationException($"Embedded resource '{resourceName}' not found.");
+
+        return JsonSerializer.Deserialize(stream, AuthorityJsonSerializerContext.Default.ListAuthorityRecord)
+            ?? throw new InvalidOperationException("Failed to deserialize authorities.");
+    }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `dotnet test api/tests/town-crier.infrastructure.tests --filter "StaticAuthorityProvider" --no-restore`
+Expected: All 6 tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/src/town-crier.infrastructure/Authorities/ api/tests/town-crier.infrastructure.tests/Authorities/
+git commit -m "feat: add StaticAuthorityProvider backed by embedded JSON"
+```
+
+---
+
+### Task 3: Wire up StaticAuthorityProvider and remove CachedPlanItAuthorityProvider
+
+**Files:**
+- Modify: `api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs:91-97`
+- Delete: `api/src/town-crier.infrastructure/PlanIt/CachedPlanItAuthorityProvider.cs`
+- Delete: `api/src/town-crier.infrastructure/PlanIt/PlanItAreaRecord.cs`
+- Delete: `api/src/town-crier.infrastructure/PlanIt/PlanItAreasResponse.cs`
+- Modify: `api/src/town-crier.infrastructure/PlanIt/PlanItJsonSerializerContext.cs`
+- Delete: `api/tests/town-crier.infrastructure.tests/PlanIt/CachedPlanItAuthorityProviderTests.cs`
+
+- [ ] **Step 1: Replace the DI registration**
+
+In `api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs`, replace lines 91-97:
+
+```csharp
+        services.AddSingleton<IAuthorityProvider>(sp =>
+        {
+            var factory = sp.GetRequiredService<IHttpClientFactory>();
+            var httpClient = factory.CreateClient("PlanItAreas");
+            httpClient.BaseAddress = new Uri(planItBaseUrl);
+            return new CachedPlanItAuthorityProvider(httpClient, sp.GetRequiredService<TimeProvider>());
+        });
+```
+
+With:
+
+```csharp
+        services.AddSingleton<IAuthorityProvider>(new StaticAuthorityProvider());
+```
+
+Add this using statement at the top of the file:
+
+```csharp
+using TownCrier.Infrastructure.Authorities;
+```
+
+- [ ] **Step 2: Remove area types from PlanItJsonSerializerContext**
+
+In `api/src/town-crier.infrastructure/PlanIt/PlanItJsonSerializerContext.cs`, remove the two lines:
+
+```csharp
+[JsonSerializable(typeof(PlanItAreasResponse))]
+[JsonSerializable(typeof(List<PlanItAreaRecord>))]
+```
+
+The file should end up with only:
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Infrastructure.PlanIt;
+
+[JsonSerializable(typeof(PlanItResponse))]
+[JsonSerializable(typeof(List<PlanItApplicationRecord>))]
+internal sealed partial class PlanItJsonSerializerContext : JsonSerializerContext;
+```
+
+- [ ] **Step 3: Delete removed files**
+
+```bash
+rm -f api/src/town-crier.infrastructure/PlanIt/CachedPlanItAuthorityProvider.cs
+rm -f api/src/town-crier.infrastructure/PlanIt/PlanItAreaRecord.cs
+rm -f api/src/town-crier.infrastructure/PlanIt/PlanItAreasResponse.cs
+rm -f api/tests/town-crier.infrastructure.tests/PlanIt/CachedPlanItAuthorityProviderTests.cs
+```
+
+- [ ] **Step 4: Build to verify no compilation errors**
+
+Run: `dotnet build api/`
+Expected: Build succeeded with 0 errors. There may be warnings but no errors.
+
+- [ ] **Step 5: Run all tests to verify nothing broke**
+
+Run: `dotnet test api/`
+Expected: All tests pass. The old `CachedPlanItAuthorityProviderTests` are gone; the new `StaticAuthorityProviderTests` pass; the existing `GetAuthoritiesQueryHandlerTests` still pass (they use `FakeAuthorityProvider` and are unaffected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A api/
+git commit -m "refactor: replace PlanIT authority fetching with static embedded JSON
+
+Fixes missing authorities (e.g., Kingston) caused by PlanIT's
+unstable pagination returning duplicates and dropping records."
+```

--- a/docs/superpowers/specs/2026-04-05-per-authority-poll-state-design.md
+++ b/docs/superpowers/specs/2026-04-05-per-authority-poll-state-design.md
@@ -1,0 +1,72 @@
+# Per-Authority Poll State
+
+Date: 2026-04-05
+
+## Problem
+
+The polling worker stores a single global `lastPollTime` shared across all authorities. This causes two issues:
+
+1. **New authorities start from "now"** — when a user creates a watch zone for a new authority, the next poll cycle uses the global timestamp (e.g. "5 minutes ago") instead of backfilling 30 days of history. The new authority appears empty until councils publish fresh changes.
+
+2. **Rate-limited authorities lose progress** — if authority A succeeds and advances the global timestamp, then authority B gets rate-limited and skipped, B's next poll uses A's timestamp, potentially missing applications that changed between B's last real poll and A's.
+
+## Design
+
+### Approach: Per-authority documents in existing PollState container
+
+Store one Cosmos document per authority instead of a single global document. No new containers, indexes, or migrations required.
+
+### Interface change
+
+`IPollStateStore` gains an `authorityId` parameter on both methods:
+
+```csharp
+Task<DateTimeOffset?> GetLastPollTimeAsync(int authorityId, CancellationToken ct);
+Task SaveLastPollTimeAsync(int authorityId, DateTimeOffset pollTime, CancellationToken ct);
+```
+
+### Cosmos store
+
+- Document ID changes from `"poll-state"` to `"poll-state-{authorityId}"` (e.g. `"poll-state-314"`)
+- ID is used as both document ID and partition key (same pattern as current)
+- `PollStateDocument` gains an `AuthorityId` property for debuggability when browsing Cosmos Data Explorer
+
+### Handler
+
+- `GetLastPollTimeAsync` moves inside the per-authority loop, called once per authority
+- The 30-day fallback (`now.AddDays(-30)`) applies per authority — a brand-new authority automatically backfills
+- `SaveLastPollTimeAsync` is called after each authority succeeds (already the case), now scoped to that authority ID
+- A rate-limited or errored authority does not get its timestamp advanced
+
+### Cleanup
+
+Delete the orphaned global `"poll-state"` document from the PollState container. This is a one-time operation in the Cosmos store — on startup or as part of the first per-authority save cycle, attempt to delete `"poll-state"` and swallow NotFound. Simpler alternative: add a delete method to `ICosmosRestClient` (already exists as `DeleteDocumentAsync`) and call it once in the handler after the loop completes, guarded by a flag.
+
+Chosen approach: add a `DeleteGlobalPollStateAsync` method to `IPollStateStore` and call it at the end of the poll cycle in the handler. The Cosmos implementation deletes doc `"poll-state"` with partition key `"poll-state"`, swallowing 404. This is idempotent — safe to call every cycle until the doc is gone.
+
+### Test changes
+
+- `FakePollStateStore` stores a `Dictionary<int, DateTimeOffset?>` instead of a single value
+- Existing tests get mechanical `authorityId` parameter additions on Get/Save calls
+- New test: "new authority uses 30-day lookback when other authorities already have poll state"
+- New test: "rate-limited authority retains its own last poll time"
+- New test: "global poll state document is cleaned up after cycle"
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `api/src/town-crier.application/Polling/IPollStateStore.cs` | Add `authorityId` param, add `DeleteGlobalPollStateAsync` |
+| `api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs` | Move poll state read inside loop, pass authority ID, call cleanup |
+| `api/src/town-crier.infrastructure/Polling/CosmosPollStateStore.cs` | Per-authority doc IDs, implement cleanup |
+| `api/src/town-crier.infrastructure/Polling/PollStateDocument.cs` | Add `AuthorityId` property |
+| `api/tests/town-crier.application.tests/Polling/FakePollStateStore.cs` | Dictionary-based storage |
+| `api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs` | Update existing + add new tests |
+
+## What doesn't change
+
+- Cosmos PollState container — no schema or index changes
+- `PlanItClient` — already accepts `differentStart` per call
+- Worker `Program.cs` — doesn't touch poll state directly
+- `CosmosJsonSerializerContext` — `PollStateDocument` already registered
+- No migration needed — old doc becomes orphaned then cleaned up


### PR DESCRIPTION
## Changes
- Add per-authority poll state implementation plan and design spec
- Add remove-profile-postcode implementation plan
- Add static authority list implementation plan
- Improve SRE observatory skill: deploy-relative time windows, epic-based finding workflow

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced observatory analysis with improved time window resolution logic, deriving windows from production deployment history when available.
  * Transitioned to per-authority polling state tracking for more granular progress management.
  * Introduced static authority data source for improved performance and reliability.

* **Documentation**
  * Added implementation plans for per-authority polling infrastructure and profile data field removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->