### PR TITLE
feat(infra): add weekly digest Container Apps Job

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -204,10 +204,17 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Deploy worker image to Job
+      - name: Deploy worker image to poll job
         run: |
           az containerapp job update \
             --name "job-town-crier-poll-dev" \
+            --resource-group "rg-town-crier-dev" \
+            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:${{ github.sha }}"
+
+      - name: Deploy worker image to digest job
+        run: |
+          az containerapp job update \
+            --name "job-town-crier-digest-dev" \
             --resource-group "rg-town-crier-dev" \
             --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:${{ github.sha }}"
 

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -191,10 +191,19 @@ jobs:
             exit 1
           fi
 
-      - name: Deploy worker image to prod
+      - name: Deploy worker image to poll job
         run: |
           az containerapp job update \
             --name "job-town-crier-poll-prod" \
+            --resource-group "$RESOURCE_GROUP" \
+            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:${{ steps.check-image.outputs.tag }}"
+        env:
+          RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
+
+      - name: Deploy worker image to digest job
+        run: |
+          az containerapp job update \
+            --name "job-town-crier-digest-prod" \
             --resource-group "$RESOURCE_GROUP" \
             --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:${{ steps.check-image.outputs.tag }}"
         env:

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -378,6 +378,75 @@ public static class EnvironmentStack
             IgnoreChanges = { "template.containers[0].image" },
         });
 
+        // Container Apps Job (Digest Worker) — runs daily, handler filters by user's preferred day
+        _ = new Job($"job-town-crier-digest-{env}", new JobArgs
+        {
+            JobName = $"job-town-crier-digest-{env}",
+            ResourceGroupName = resourceGroup.Name,
+            EnvironmentId = containerAppsEnvironmentId,
+            Configuration = new JobConfigurationArgs
+            {
+                TriggerType = Pulumi.AzureNative.App.TriggerType.Schedule,
+                ReplicaTimeout = 600,
+                ScheduleTriggerConfig = new JobConfigurationScheduleTriggerConfigArgs
+                {
+                    CronExpression = "0 7 * * *",
+                    Parallelism = 1,
+                    ReplicaCompletionCount = 1,
+                },
+                Registries = new[]
+                {
+                    new RegistryCredentialsArgs
+                    {
+                        Server = acrLoginServer,
+                        Identity = acrPullIdentityId,
+                    },
+                },
+                Secrets = new[]
+                {
+                    new SecretArgs { Name = "acs-connection-string", Value = acsConnectionString },
+                },
+            },
+            Identity = new Pulumi.AzureNative.App.Inputs.ManagedServiceIdentityArgs
+            {
+                Type = ManagedServiceIdentityType.UserAssigned,
+                UserAssignedIdentities = new InputList<string>
+                {
+                    acrPullIdentityId,
+                    cosmosDataIdentityId,
+                },
+            },
+            Template = new JobTemplateArgs
+            {
+                Containers = new[]
+                {
+                    new ContainerArgs
+                    {
+                        Name = "worker",
+                        Image = "mcr.microsoft.com/k8se/quickstart:latest",
+                        Resources = new ContainerResourcesArgs
+                        {
+                            Cpu = 0.25,
+                            Memory = "0.5Gi",
+                        },
+                        Env = new[]
+                        {
+                            new EnvironmentVarArgs { Name = "WORKER_MODE", Value = "digest" },
+                            new EnvironmentVarArgs { Name = "Cosmos__AccountEndpoint", Value = cosmosAccountEndpoint },
+                            new EnvironmentVarArgs { Name = "Cosmos__DatabaseName", Value = cosmosDatabase.Name },
+                            new EnvironmentVarArgs { Name = "AZURE_CLIENT_ID", Value = cosmosDataIdentityClientId },
+                            new EnvironmentVarArgs { Name = "APPLICATIONINSIGHTS_CONNECTION_STRING", Value = appInsightsConnectionString },
+                            new EnvironmentVarArgs { Name = "AzureCommunicationServices__ConnectionString", SecretRef = "acs-connection-string" },
+                        },
+                    },
+                },
+            },
+            Tags = tags,
+        }, new CustomResourceOptions
+        {
+            IgnoreChanges = { "template.containers[0].image" },
+        });
+
         // Static Web App (Landing Page)
         var staticWebApp = new StaticSite($"swa-town-crier-{env}", new StaticSiteArgs
         {


### PR DESCRIPTION
## Changes
- Add `job-town-crier-digest-{env}` Container Apps Job in Pulumi with `WORKER_MODE=digest` and daily 07:00 UTC cron schedule
- Update `cd-prod.yml` to deploy the worker image to the digest job alongside the poll job
- Update `cd-dev.yml` to deploy the worker image to the digest job alongside the poll job

The worker already supports `WORKER_MODE=digest` for weekly email digests, but no job was provisioned — so the code path was unreachable in production.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new daily scheduled digest worker job to development and production environments.

* **Chores**
  * Updated deployment pipelines to manage multiple worker job instances across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->