### PR TITLE
feat: add entitlement framework for subscription tier gating

### DIFF
--- a/api/src/town-crier.application/Admin/GrantSubscriptionCommandHandler.cs
+++ b/api/src/town-crier.application/Admin/GrantSubscriptionCommandHandler.cs
@@ -1,3 +1,4 @@
+using TownCrier.Application.Auth;
 using TownCrier.Application.UserProfiles;
 using TownCrier.Domain.UserProfiles;
 
@@ -8,10 +9,12 @@ public sealed class GrantSubscriptionCommandHandler
     private static readonly DateTimeOffset FarFutureExpiry = new(2099, 12, 31, 0, 0, 0, TimeSpan.Zero);
 
     private readonly IUserProfileRepository repository;
+    private readonly IAuth0ManagementClient auth0Client;
 
-    public GrantSubscriptionCommandHandler(IUserProfileRepository repository)
+    public GrantSubscriptionCommandHandler(IUserProfileRepository repository, IAuth0ManagementClient auth0Client)
     {
         this.repository = repository;
+        this.auth0Client = auth0Client;
     }
 
     public async Task<GrantSubscriptionResult> HandleAsync(GrantSubscriptionCommand command, CancellationToken ct)
@@ -31,6 +34,8 @@ public sealed class GrantSubscriptionCommandHandler
         }
 
         await this.repository.SaveAsync(profile, ct).ConfigureAwait(false);
+        await this.auth0Client.UpdateSubscriptionTierAsync(profile.UserId, profile.Tier.ToString(), ct)
+            .ConfigureAwait(false);
 
         return new GrantSubscriptionResult(profile.UserId, profile.Email, profile.Tier);
     }

--- a/api/src/town-crier.application/Auth/IAuth0ManagementClient.cs
+++ b/api/src/town-crier.application/Auth/IAuth0ManagementClient.cs
@@ -1,0 +1,6 @@
+namespace TownCrier.Application.Auth;
+
+public interface IAuth0ManagementClient
+{
+    Task UpdateSubscriptionTierAsync(string userId, string tier, CancellationToken ct);
+}

--- a/api/src/town-crier.application/Notifications/DispatchNotificationCommandHandler.cs
+++ b/api/src/town-crier.application/Notifications/DispatchNotificationCommandHandler.cs
@@ -1,6 +1,7 @@
 using TownCrier.Application.DeviceRegistrations;
 using TownCrier.Application.Observability;
 using TownCrier.Application.UserProfiles;
+using TownCrier.Domain.Entitlements;
 using TownCrier.Domain.Notifications;
 using TownCrier.Domain.UserProfiles;
 
@@ -113,8 +114,9 @@ public sealed class DispatchNotificationCommandHandler
             ApiMetrics.NotificationsSent.Add(1);
         }
 
-        // Send instant email notification for paid tiers
-        if (profile.Tier != SubscriptionTier.Free
+        // Send instant email notification for entitled tiers
+        var entitlements = EntitlementMap.EntitlementsFor(profile.Tier);
+        if (entitlements.Contains(Entitlement.InstantEmails)
             && profile.NotificationPreferences.EmailInstantEnabled
             && !string.IsNullOrEmpty(profile.Email))
         {

--- a/api/src/town-crier.application/Search/SearchPlanningApplicationsQueryHandler.cs
+++ b/api/src/town-crier.application/Search/SearchPlanningApplicationsQueryHandler.cs
@@ -2,7 +2,6 @@ using TownCrier.Application.Observability;
 using TownCrier.Application.PlanIt;
 using TownCrier.Application.PlanningApplications;
 using TownCrier.Application.UserProfiles;
-using TownCrier.Domain.UserProfiles;
 
 namespace TownCrier.Application.Search;
 
@@ -28,13 +27,8 @@ public sealed class SearchPlanningApplicationsQueryHandler
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        var profile = await this.userProfileRepository.GetByUserIdAsync(query.UserId, ct).ConfigureAwait(false)
+        _ = await this.userProfileRepository.GetByUserIdAsync(query.UserId, ct).ConfigureAwait(false)
             ?? throw UserProfileNotFoundException.ForUser(query.UserId);
-
-        if (profile.Tier != SubscriptionTier.Pro)
-        {
-            throw new ProTierRequiredException();
-        }
 
         var result = await this.planItClient.SearchApplicationsAsync(
             query.SearchText, query.AuthorityId, query.Page, ct).ConfigureAwait(false);

--- a/api/src/town-crier.domain/Entitlements/Entitlement.cs
+++ b/api/src/town-crier.domain/Entitlements/Entitlement.cs
@@ -1,0 +1,9 @@
+namespace TownCrier.Domain.Entitlements;
+
+public enum Entitlement
+{
+    InstantEmails,
+    SearchApplications,
+    StatusChangeAlerts,
+    DecisionUpdateAlerts,
+}

--- a/api/src/town-crier.domain/Entitlements/EntitlementMap.cs
+++ b/api/src/town-crier.domain/Entitlements/EntitlementMap.cs
@@ -1,0 +1,41 @@
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Domain.Entitlements;
+
+public static class EntitlementMap
+{
+    private static readonly IReadOnlySet<Entitlement> EmptySet =
+        new HashSet<Entitlement>();
+
+    private static readonly IReadOnlySet<Entitlement> PersonalEntitlements =
+        new HashSet<Entitlement>
+        {
+            Entitlement.InstantEmails,
+            Entitlement.StatusChangeAlerts,
+            Entitlement.DecisionUpdateAlerts,
+        };
+
+    private static readonly IReadOnlySet<Entitlement> ProEntitlements =
+        new HashSet<Entitlement>
+        {
+            Entitlement.InstantEmails,
+            Entitlement.SearchApplications,
+            Entitlement.StatusChangeAlerts,
+            Entitlement.DecisionUpdateAlerts,
+        };
+
+    public static IReadOnlySet<Entitlement> EntitlementsFor(SubscriptionTier tier) => tier switch
+    {
+        SubscriptionTier.Personal => PersonalEntitlements,
+        SubscriptionTier.Pro => ProEntitlements,
+        _ => EmptySet,
+    };
+
+    public static int LimitFor(SubscriptionTier tier, Quota quota) => (tier, quota) switch
+    {
+        (SubscriptionTier.Free, Quota.WatchZones) => 1,
+        (SubscriptionTier.Personal, Quota.WatchZones) => 3,
+        (SubscriptionTier.Pro, Quota.WatchZones) => int.MaxValue,
+        _ => 1,
+    };
+}

--- a/api/src/town-crier.domain/Entitlements/Quota.cs
+++ b/api/src/town-crier.domain/Entitlements/Quota.cs
@@ -1,0 +1,6 @@
+namespace TownCrier.Domain.Entitlements;
+
+public enum Quota
+{
+    WatchZones,
+}

--- a/api/src/town-crier.infrastructure/Auth/Auth0AppMetadata.cs
+++ b/api/src/town-crier.infrastructure/Auth/Auth0AppMetadata.cs
@@ -1,0 +1,6 @@
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Infrastructure.Auth;
+
+internal sealed record Auth0AppMetadata(
+    [property: JsonPropertyName("subscription_tier")] string SubscriptionTier);

--- a/api/src/town-crier.infrastructure/Auth/Auth0ManagementClient.cs
+++ b/api/src/town-crier.infrastructure/Auth/Auth0ManagementClient.cs
@@ -1,0 +1,64 @@
+using System.Net.Http.Json;
+using TownCrier.Application.Auth;
+
+namespace TownCrier.Infrastructure.Auth;
+
+public sealed class Auth0ManagementClient : IAuth0ManagementClient
+{
+    private readonly HttpClient httpClient;
+    private readonly string domain;
+    private readonly string clientId;
+    private readonly string clientSecret;
+    private string? cachedToken;
+    private DateTimeOffset tokenExpiry;
+
+    public Auth0ManagementClient(HttpClient httpClient, string domain, string clientId, string clientSecret)
+    {
+        this.httpClient = httpClient;
+        this.domain = domain;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+    }
+
+    public async Task UpdateSubscriptionTierAsync(string userId, string tier, CancellationToken ct)
+    {
+        var token = await this.GetTokenAsync(ct).ConfigureAwait(false);
+
+        var url = $"https://{this.domain}/api/v2/users/{Uri.EscapeDataString(userId)}";
+        using var request = new HttpRequestMessage(HttpMethod.Patch, url);
+        request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        request.Content = JsonContent.Create(
+            new Auth0UpdateMetadataRequest(new Auth0AppMetadata(tier)),
+            Auth0ManagementClientJsonSerializerContext.Default.Auth0UpdateMetadataRequest);
+
+        using var response = await this.httpClient.SendAsync(request, ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+    }
+
+    private async Task<string> GetTokenAsync(CancellationToken ct)
+    {
+        if (this.cachedToken is not null && DateTimeOffset.UtcNow < this.tokenExpiry)
+        {
+            return this.cachedToken;
+        }
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, $"https://{this.domain}/oauth/token");
+        request.Content = JsonContent.Create(
+            new Auth0TokenRequest(
+                GrantType: "client_credentials",
+                ClientId: this.clientId,
+                ClientSecret: this.clientSecret,
+                Audience: $"https://{this.domain}/api/v2/"),
+            Auth0ManagementClientJsonSerializerContext.Default.Auth0TokenRequest);
+
+        using var response = await this.httpClient.SendAsync(request, ct).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var tokenResponse = await response.Content.ReadFromJsonAsync(
+            Auth0ManagementClientJsonSerializerContext.Default.Auth0TokenResponse, ct).ConfigureAwait(false);
+
+        this.cachedToken = tokenResponse!.AccessToken;
+        this.tokenExpiry = DateTimeOffset.UtcNow.AddSeconds(tokenResponse.ExpiresIn - 60);
+        return this.cachedToken;
+    }
+}

--- a/api/src/town-crier.infrastructure/Auth/Auth0ManagementClientJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Auth/Auth0ManagementClientJsonSerializerContext.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Infrastructure.Auth;
+
+[JsonSerializable(typeof(Auth0TokenResponse))]
+[JsonSerializable(typeof(Auth0TokenRequest))]
+[JsonSerializable(typeof(Auth0UpdateMetadataRequest))]
+internal sealed partial class Auth0ManagementClientJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Auth/Auth0TokenRequest.cs
+++ b/api/src/town-crier.infrastructure/Auth/Auth0TokenRequest.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Infrastructure.Auth;
+
+internal sealed record Auth0TokenRequest(
+    [property: JsonPropertyName("grant_type")] string GrantType,
+    [property: JsonPropertyName("client_id")] string ClientId,
+    [property: JsonPropertyName("client_secret")] string ClientSecret,
+    [property: JsonPropertyName("audience")] string Audience);

--- a/api/src/town-crier.infrastructure/Auth/Auth0TokenResponse.cs
+++ b/api/src/town-crier.infrastructure/Auth/Auth0TokenResponse.cs
@@ -1,0 +1,7 @@
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Infrastructure.Auth;
+
+internal sealed record Auth0TokenResponse(
+    [property: JsonPropertyName("access_token")] string AccessToken,
+    [property: JsonPropertyName("expires_in")] int ExpiresIn);

--- a/api/src/town-crier.infrastructure/Auth/Auth0UpdateMetadataRequest.cs
+++ b/api/src/town-crier.infrastructure/Auth/Auth0UpdateMetadataRequest.cs
@@ -1,0 +1,6 @@
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Infrastructure.Auth;
+
+internal sealed record Auth0UpdateMetadataRequest(
+    [property: JsonPropertyName("app_metadata")] Auth0AppMetadata AppMetadata);

--- a/api/src/town-crier.infrastructure/Auth/NoOpAuth0ManagementClient.cs
+++ b/api/src/town-crier.infrastructure/Auth/NoOpAuth0ManagementClient.cs
@@ -1,0 +1,11 @@
+using TownCrier.Application.Auth;
+
+namespace TownCrier.Infrastructure.Auth;
+
+public sealed class NoOpAuth0ManagementClient : IAuth0ManagementClient
+{
+    public Task UpdateSubscriptionTierAsync(string userId, string tier, CancellationToken ct)
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/api/src/town-crier.web/AppJsonSerializerContext.cs
+++ b/api/src/town-crier.web/AppJsonSerializerContext.cs
@@ -13,10 +13,12 @@ using TownCrier.Application.Search;
 using TownCrier.Application.UserProfiles;
 using TownCrier.Application.VersionConfig;
 using TownCrier.Application.WatchZones;
+using TownCrier.Web.Endpoints;
 
 namespace TownCrier.Web;
 
 [JsonSerializable(typeof(ApiErrorResponse))]
+[JsonSerializable(typeof(EntitlementErrorResponse))]
 [JsonSerializable(typeof(UserIdResponse))]
 [JsonSerializable(typeof(GetAuthoritiesResult))]
 [JsonSerializable(typeof(GetAuthorityByIdResult))]

--- a/api/src/town-crier.web/Endpoints/EntitlementEndpointFilter.cs
+++ b/api/src/town-crier.web/Endpoints/EntitlementEndpointFilter.cs
@@ -1,0 +1,38 @@
+using TownCrier.Domain.Entitlements;
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Web.Endpoints;
+
+internal sealed class EntitlementEndpointFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        var endpoint = context.HttpContext.GetEndpoint();
+        var attribute = endpoint?.Metadata.GetMetadata<RequiresEntitlementAttribute>();
+        if (attribute is null)
+        {
+            return await next(context).ConfigureAwait(false);
+        }
+
+        var tierClaim = context.HttpContext.User.FindFirst("subscription_tier")?.Value;
+        var tier = Enum.TryParse<SubscriptionTier>(tierClaim, ignoreCase: true, out var parsed)
+            ? parsed
+            : SubscriptionTier.Free;
+
+        var entitlements = EntitlementMap.EntitlementsFor(tier);
+        if (!entitlements.Contains(attribute.Entitlement))
+        {
+            return Results.Json(
+                new EntitlementErrorResponse(
+                    "insufficient_entitlement",
+                    attribute.Entitlement.ToString(),
+                    "This feature requires a paid subscription."),
+                AppJsonSerializerContext.Default.EntitlementErrorResponse,
+                statusCode: 403);
+        }
+
+        return await next(context).ConfigureAwait(false);
+    }
+}

--- a/api/src/town-crier.web/Endpoints/EntitlementErrorResponse.cs
+++ b/api/src/town-crier.web/Endpoints/EntitlementErrorResponse.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Web.Endpoints;
+
+internal sealed record EntitlementErrorResponse(
+    [property: JsonPropertyName("error")] string Error,
+    [property: JsonPropertyName("required")] string Required,
+    [property: JsonPropertyName("message")] string Message);

--- a/api/src/town-crier.web/Endpoints/RequiresEntitlementAttribute.cs
+++ b/api/src/town-crier.web/Endpoints/RequiresEntitlementAttribute.cs
@@ -1,0 +1,9 @@
+using TownCrier.Domain.Entitlements;
+
+namespace TownCrier.Web.Endpoints;
+
+[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class)]
+internal sealed class RequiresEntitlementAttribute(Entitlement entitlement) : Attribute
+{
+    public Entitlement Entitlement { get; } = entitlement;
+}

--- a/api/src/town-crier.web/Endpoints/SearchEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/SearchEndpoints.cs
@@ -1,7 +1,7 @@
 using System.Security.Claims;
 using TownCrier.Application.Search;
 using TownCrier.Application.UserProfiles;
-using TownCrier.Domain.UserProfiles;
+using TownCrier.Domain.Entitlements;
 
 namespace TownCrier.Web.Endpoints;
 
@@ -25,17 +25,12 @@ internal static class SearchEndpoints
                 var result = await handler.HandleAsync(query, ct).ConfigureAwait(false);
                 return Results.Ok(result);
             }
-            catch (ProTierRequiredException)
-            {
-                return Results.Json(
-                    new ApiErrorResponse("This feature requires a Pro subscription."),
-                    AppJsonSerializerContext.Default.ApiErrorResponse,
-                    statusCode: 403);
-            }
             catch (UserProfileNotFoundException)
             {
                 return Results.NotFound();
             }
-        });
+        })
+        .AddEndpointFilter<EntitlementEndpointFilter>()
+        .WithMetadata(new RequiresEntitlementAttribute(Entitlement.SearchApplications));
     }
 }

--- a/api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using TownCrier.Application.UserProfiles;
+using TownCrier.Domain.Entitlements;
 using TownCrier.Domain.UserProfiles;
 
 namespace TownCrier.Web.Endpoints;
@@ -36,6 +37,25 @@ internal static class UserProfileEndpoints
             UpdateUserProfileCommandHandler handler,
             CancellationToken ct) =>
         {
+            if (command.EmailInstantEnabled)
+            {
+                var tierClaim = user.FindFirst("subscription_tier")?.Value;
+                var tier = Enum.TryParse<SubscriptionTier>(tierClaim, ignoreCase: true, out var parsed)
+                    ? parsed
+                    : SubscriptionTier.Free;
+
+                if (!EntitlementMap.EntitlementsFor(tier).Contains(Entitlement.InstantEmails))
+                {
+                    return Results.Json(
+                        new EntitlementErrorResponse(
+                            "insufficient_entitlement",
+                            Entitlement.InstantEmails.ToString(),
+                            "This feature requires a paid subscription."),
+                        AppJsonSerializerContext.Default.EntitlementErrorResponse,
+                        statusCode: 403);
+                }
+            }
+
             var userId = user.FindFirstValue("sub")!;
             var profileCommand = new UpdateUserProfileCommand(
                 userId,

--- a/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
+++ b/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using TownCrier.Application.Admin;
+using TownCrier.Application.Auth;
 using TownCrier.Application.Authorities;
 using TownCrier.Application.DecisionAlerts;
 using TownCrier.Application.DemoAccount;
@@ -14,6 +15,7 @@ using TownCrier.Application.SavedApplications;
 using TownCrier.Application.Search;
 using TownCrier.Application.UserProfiles;
 using TownCrier.Application.WatchZones;
+using TownCrier.Infrastructure.Auth;
 using TownCrier.Infrastructure.Authorities;
 using TownCrier.Infrastructure.Cosmos;
 using TownCrier.Infrastructure.DecisionAlerts;
@@ -61,6 +63,19 @@ internal static class ServiceCollectionExtensions
         else
         {
             services.AddSingleton<IEmailSender, NoOpEmailSender>();
+        }
+
+        var auth0M2mClientId = configuration["Auth0:M2M:ClientId"];
+        var auth0M2mClientSecret = configuration["Auth0:M2M:ClientSecret"];
+        var auth0Domain = configuration["Auth0:Domain"];
+        if (!string.IsNullOrEmpty(auth0M2mClientId) && !string.IsNullOrEmpty(auth0M2mClientSecret) && !string.IsNullOrEmpty(auth0Domain))
+        {
+            services.AddHttpClient<IAuth0ManagementClient, Auth0ManagementClient>((httpClient, sp) =>
+                new Auth0ManagementClient(httpClient, auth0Domain, auth0M2mClientId, auth0M2mClientSecret));
+        }
+        else
+        {
+            services.AddSingleton<IAuth0ManagementClient, NoOpAuth0ManagementClient>();
         }
 
         services.AddSingleton(TimeProvider.System);

--- a/api/tests/town-crier.application.tests/Admin/FakeAuth0ManagementClient.cs
+++ b/api/tests/town-crier.application.tests/Admin/FakeAuth0ManagementClient.cs
@@ -1,0 +1,14 @@
+using TownCrier.Application.Auth;
+
+namespace TownCrier.Application.Tests.Admin;
+
+internal sealed class FakeAuth0ManagementClient : IAuth0ManagementClient
+{
+    public List<(string UserId, string Tier)> Updates { get; } = [];
+
+    public Task UpdateSubscriptionTierAsync(string userId, string tier, CancellationToken ct)
+    {
+        this.Updates.Add((userId, tier));
+        return Task.CompletedTask;
+    }
+}

--- a/api/tests/town-crier.application.tests/Admin/GrantSubscriptionCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Admin/GrantSubscriptionCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using TownCrier.Application.Admin;
+using TownCrier.Application.Tests.Notifications;
 using TownCrier.Application.Tests.UserProfiles;
 using TownCrier.Application.UserProfiles;
 using TownCrier.Domain.UserProfiles;
@@ -12,10 +13,11 @@ public sealed class GrantSubscriptionCommandHandlerTests
     {
         // Arrange
         var repository = new FakeUserProfileRepository();
+        var auth0Client = new FakeAuth0ManagementClient();
         var profile = UserProfile.Register("auth0|user-1", "friend@example.com");
         await repository.SaveAsync(profile, CancellationToken.None);
 
-        var handler = new GrantSubscriptionCommandHandler(repository);
+        var handler = new GrantSubscriptionCommandHandler(repository, auth0Client);
         var command = new GrantSubscriptionCommand("friend@example.com", SubscriptionTier.Pro);
 
         // Act
@@ -31,10 +33,11 @@ public sealed class GrantSubscriptionCommandHandlerTests
     {
         // Arrange
         var repository = new FakeUserProfileRepository();
+        var auth0Client = new FakeAuth0ManagementClient();
         var profile = UserProfile.Register("auth0|user-1", "friend@example.com");
         await repository.SaveAsync(profile, CancellationToken.None);
 
-        var handler = new GrantSubscriptionCommandHandler(repository);
+        var handler = new GrantSubscriptionCommandHandler(repository, auth0Client);
         var command = new GrantSubscriptionCommand("friend@example.com", SubscriptionTier.Personal);
 
         // Act
@@ -49,11 +52,12 @@ public sealed class GrantSubscriptionCommandHandlerTests
     {
         // Arrange
         var repository = new FakeUserProfileRepository();
+        var auth0Client = new FakeAuth0ManagementClient();
         var profile = UserProfile.Register("auth0|user-1", "friend@example.com");
         profile.ActivateSubscription(SubscriptionTier.Pro, DateTimeOffset.UtcNow.AddYears(73));
         await repository.SaveAsync(profile, CancellationToken.None);
 
-        var handler = new GrantSubscriptionCommandHandler(repository);
+        var handler = new GrantSubscriptionCommandHandler(repository, auth0Client);
         var command = new GrantSubscriptionCommand("friend@example.com", SubscriptionTier.Free);
 
         // Act
@@ -68,10 +72,11 @@ public sealed class GrantSubscriptionCommandHandlerTests
     {
         // Arrange
         var repository = new FakeUserProfileRepository();
+        var auth0Client = new FakeAuth0ManagementClient();
         var profile = UserProfile.Register("auth0|user-1", "friend@example.com");
         await repository.SaveAsync(profile, CancellationToken.None);
 
-        var handler = new GrantSubscriptionCommandHandler(repository);
+        var handler = new GrantSubscriptionCommandHandler(repository, auth0Client);
         var command = new GrantSubscriptionCommand("friend@example.com", SubscriptionTier.Pro);
 
         // Act
@@ -87,11 +92,60 @@ public sealed class GrantSubscriptionCommandHandlerTests
     {
         // Arrange
         var repository = new FakeUserProfileRepository();
-        var handler = new GrantSubscriptionCommandHandler(repository);
+        var auth0Client = new FakeAuth0ManagementClient();
+        var handler = new GrantSubscriptionCommandHandler(repository, auth0Client);
         var command = new GrantSubscriptionCommand("nobody@example.com", SubscriptionTier.Pro);
 
         // Act & Assert
         await Assert.ThrowsAsync<UserProfileNotFoundException>(
             () => handler.HandleAsync(command, CancellationToken.None));
+    }
+
+    [Test]
+    public async Task Should_SyncTierToAuth0_When_GrantingProSubscription()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var auth0Client = new FakeAuth0ManagementClient();
+        var profile = new UserProfileBuilder()
+            .WithUserId("auth0|user-1")
+            .WithEmail("user@example.com")
+            .Build();
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new GrantSubscriptionCommandHandler(repository, auth0Client);
+        var command = new GrantSubscriptionCommand("user@example.com", SubscriptionTier.Pro);
+
+        // Act
+        await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(auth0Client.Updates).HasCount().EqualTo(1);
+        await Assert.That(auth0Client.Updates[0].UserId).IsEqualTo("auth0|user-1");
+        await Assert.That(auth0Client.Updates[0].Tier).IsEqualTo("Pro");
+    }
+
+    [Test]
+    public async Task Should_SyncTierToAuth0_When_DowngradingToFree()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var auth0Client = new FakeAuth0ManagementClient();
+        var profile = new UserProfileBuilder()
+            .WithUserId("auth0|user-1")
+            .WithEmail("user@example.com")
+            .WithTier(SubscriptionTier.Pro)
+            .Build();
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new GrantSubscriptionCommandHandler(repository, auth0Client);
+        var command = new GrantSubscriptionCommand("user@example.com", SubscriptionTier.Free);
+
+        // Act
+        await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        await Assert.That(auth0Client.Updates).HasCount().EqualTo(1);
+        await Assert.That(auth0Client.Updates[0].Tier).IsEqualTo("Free");
     }
 }

--- a/api/tests/town-crier.application.tests/Entitlements/EntitlementMapTests.cs
+++ b/api/tests/town-crier.application.tests/Entitlements/EntitlementMapTests.cs
@@ -1,0 +1,61 @@
+using TownCrier.Domain.Entitlements;
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Domain.Tests.Entitlements;
+
+public sealed class EntitlementMapTests
+{
+    [Test]
+    public async Task FreeTier_Should_HaveNoEntitlements()
+    {
+        var entitlements = EntitlementMap.EntitlementsFor(SubscriptionTier.Free);
+
+        await Assert.That(entitlements).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task PersonalTier_Should_HaveInstantEmailsAndAlerts()
+    {
+        var entitlements = EntitlementMap.EntitlementsFor(SubscriptionTier.Personal);
+
+        await Assert.That(entitlements).Contains(Entitlement.InstantEmails);
+        await Assert.That(entitlements).Contains(Entitlement.StatusChangeAlerts);
+        await Assert.That(entitlements).Contains(Entitlement.DecisionUpdateAlerts);
+        await Assert.That(entitlements).DoesNotContain(Entitlement.SearchApplications);
+    }
+
+    [Test]
+    public async Task ProTier_Should_HaveAllEntitlements()
+    {
+        var entitlements = EntitlementMap.EntitlementsFor(SubscriptionTier.Pro);
+
+        await Assert.That(entitlements).Contains(Entitlement.InstantEmails);
+        await Assert.That(entitlements).Contains(Entitlement.SearchApplications);
+        await Assert.That(entitlements).Contains(Entitlement.StatusChangeAlerts);
+        await Assert.That(entitlements).Contains(Entitlement.DecisionUpdateAlerts);
+    }
+
+    [Test]
+    public async Task FreeTier_WatchZoneLimit_Should_Be1()
+    {
+        var limit = EntitlementMap.LimitFor(SubscriptionTier.Free, Quota.WatchZones);
+
+        await Assert.That(limit).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task PersonalTier_WatchZoneLimit_Should_Be3()
+    {
+        var limit = EntitlementMap.LimitFor(SubscriptionTier.Personal, Quota.WatchZones);
+
+        await Assert.That(limit).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task ProTier_WatchZoneLimit_Should_BeUnlimited()
+    {
+        var limit = EntitlementMap.LimitFor(SubscriptionTier.Pro, Quota.WatchZones);
+
+        await Assert.That(limit).IsEqualTo(int.MaxValue);
+    }
+}

--- a/api/tests/town-crier.application.tests/Entitlements/EntitlementMapTests.cs
+++ b/api/tests/town-crier.application.tests/Entitlements/EntitlementMapTests.cs
@@ -18,6 +18,7 @@ public sealed class EntitlementMapTests
     {
         var entitlements = EntitlementMap.EntitlementsFor(SubscriptionTier.Personal);
 
+        await Assert.That(entitlements).HasCount().EqualTo(3);
         await Assert.That(entitlements).Contains(Entitlement.InstantEmails);
         await Assert.That(entitlements).Contains(Entitlement.StatusChangeAlerts);
         await Assert.That(entitlements).Contains(Entitlement.DecisionUpdateAlerts);
@@ -29,6 +30,7 @@ public sealed class EntitlementMapTests
     {
         var entitlements = EntitlementMap.EntitlementsFor(SubscriptionTier.Pro);
 
+        await Assert.That(entitlements).HasCount().EqualTo(4);
         await Assert.That(entitlements).Contains(Entitlement.InstantEmails);
         await Assert.That(entitlements).Contains(Entitlement.SearchApplications);
         await Assert.That(entitlements).Contains(Entitlement.StatusChangeAlerts);

--- a/api/tests/town-crier.application.tests/Search/SearchPlanningApplicationsQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Search/SearchPlanningApplicationsQueryHandlerTests.cs
@@ -10,9 +10,9 @@ namespace TownCrier.Application.Tests.Search;
 public sealed class SearchPlanningApplicationsQueryHandlerTests
 {
     [Test]
-    public async Task Should_ThrowProTierRequired_When_UserIsFreeTier()
+    public async Task Should_ReturnResults_When_UserIsFreeTier()
     {
-        // Arrange
+        // Arrange — tier check is now in the endpoint filter, not the handler
         var profile = new UserProfileBuilder()
             .WithUserId("user-1")
             .WithTier(SubscriptionTier.Free)
@@ -21,14 +21,17 @@ public sealed class SearchPlanningApplicationsQueryHandlerTests
         await userProfileRepository.SaveAsync(profile, CancellationToken.None);
 
         var planItClient = new FakePlanItClient();
+        planItClient.SearchTotal = 0;
         var appRepo = new FakePlanningApplicationRepository();
         var handler = new SearchPlanningApplicationsQueryHandler(userProfileRepository, planItClient, appRepo);
 
         var query = new SearchPlanningApplicationsQuery("user-1", "extension", AuthorityId: 42);
 
-        // Act & Assert
-        await Assert.ThrowsAsync<ProTierRequiredException>(
-            () => handler.HandleAsync(query, CancellationToken.None));
+        // Act
+        var result = await handler.HandleAsync(query, CancellationToken.None);
+
+        // Assert — handler no longer rejects free tier
+        await Assert.That(result.Applications).HasCount().EqualTo(0);
     }
 
     [Test]

--- a/api/tests/town-crier.web.tests/Entitlements/EntitlementEndpointFilterTests.cs
+++ b/api/tests/town-crier.web.tests/Entitlements/EntitlementEndpointFilterTests.cs
@@ -74,4 +74,55 @@ public sealed class EntitlementEndpointFilterTests
 
         await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
+
+    [Test]
+    public async Task Should_Return403_When_FreeTierAccessesSearch()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var token = TestJwtToken.Generate(claims:
+        [
+            new Claim("subscription_tier", "Free"),
+        ]);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync(new Uri("/v1/search?q=test&authorityId=42&page=1", UriKind.Relative));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    public async Task Should_AllowSearch_When_ProTier()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var token = TestJwtToken.Generate(
+            userId: "auth0|pro-search-user",
+            claims: [new Claim("subscription_tier", "Pro")]);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        // Create user profile first so search handler doesn't 404
+        await client.PostAsync(new Uri("/v1/me", UriKind.Relative), null);
+
+        var response = await client.GetAsync(new Uri("/v1/search?q=test&authorityId=42&page=1", UriKind.Relative));
+
+        // Should NOT be 403 — may be 200 with empty results
+        await Assert.That(response.StatusCode).IsNotEqualTo(HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    public async Task Should_DefaultToFree_When_TierClaimMissing()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var token = TestJwtToken.Generate();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        var response = await client.GetAsync(new Uri("/v1/search?q=test&authorityId=42&page=1", UriKind.Relative));
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Forbidden);
+    }
 }

--- a/api/tests/town-crier.web.tests/Entitlements/EntitlementEndpointFilterTests.cs
+++ b/api/tests/town-crier.web.tests/Entitlements/EntitlementEndpointFilterTests.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using TownCrier.Domain.Entitlements;
+using TownCrier.Web.Tests.Auth;
+
+namespace TownCrier.Web.Tests.Entitlements;
+
+public sealed class EntitlementEndpointFilterTests
+{
+    [Test]
+    public async Task Should_Return403_When_FreeTierEnablesInstantEmails()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var token = TestJwtToken.Generate(
+            userId: "auth0|free-user",
+            claims: [new Claim("subscription_tier", "Free")]);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        (await client.PostAsync(new Uri("/v1/me", UriKind.Relative), null)).Dispose();
+
+        using var content = new StringContent(
+            """{"pushEnabled":true,"emailInstantEnabled":true}""",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        using var response = await client.PatchAsync(new Uri("/v1/me", UriKind.Relative), content);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Forbidden);
+    }
+
+    [Test]
+    public async Task Should_AllowInstantEmails_When_PersonalTier()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var token = TestJwtToken.Generate(
+            userId: "auth0|personal-user",
+            claims: [new Claim("subscription_tier", "Personal")]);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        (await client.PostAsync(new Uri("/v1/me", UriKind.Relative), null)).Dispose();
+
+        using var content = new StringContent(
+            """{"pushEnabled":true,"emailInstantEnabled":true}""",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        using var response = await client.PatchAsync(new Uri("/v1/me", UriKind.Relative), content);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+
+    [Test]
+    public async Task Should_AllowNonEntitledPreferences_When_FreeTier()
+    {
+        await using var factory = new TestWebApplicationFactory();
+        using var client = factory.CreateClient();
+
+        var token = TestJwtToken.Generate(
+            userId: "auth0|free-user-2",
+            claims: [new Claim("subscription_tier", "Free")]);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+        (await client.PostAsync(new Uri("/v1/me", UriKind.Relative), null)).Dispose();
+
+        // Free user can still update non-entitled preferences
+        using var content = new StringContent(
+            """{"pushEnabled":false,"emailDigestEnabled":false,"emailInstantEnabled":false}""",
+            System.Text.Encoding.UTF8,
+            "application/json");
+        using var response = await client.PatchAsync(new Uri("/v1/me", UriKind.Relative), content);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+    }
+}


### PR DESCRIPTION
## Changes

- Add `Entitlement` enum, `Quota` enum, and `EntitlementMap` in the domain layer — single source of truth for what each subscription tier grants
- Add `EntitlementEndpointFilter` with `RequiresEntitlementAttribute` for declarative endpoint gating via JWT `subscription_tier` claim
- Migrate search endpoint from ad-hoc `ProTierRequiredException` to the declarative filter pattern
- Fix bug: gate instant emails on PATCH `/me` so free-tier users cannot enable `emailInstantEnabled` (fixes tc-xsq)
- Refactor `DispatchNotificationCommandHandler` to use `EntitlementMap` for instant email tier check
- Add `IAuth0ManagementClient` port and adapters for syncing subscription tier to Auth0 `app_metadata`
- Wire Auth0 metadata sync into `GrantSubscriptionCommandHandler`

## Spec

`docs/specs/entitlement-framework.md`

## Remaining (non-code)

- Deploy Auth0 Post-Login Action (tc-1tb.8)
- Create Auth0 M2M application and configure credentials

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced entitlements-based access control system replacing subscription tier checks
  * Integrated Auth0 for real-time subscription synchronization
  * Added tier-specific quota limits for watch zones
  * Granular feature entitlements now govern access to instant emails and application search
  * Enhanced feature availability model with flexible entitlement mapping across subscription levels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->