### PR TITLE
fix(infra): set OTEL_SERVICE_NAME for Container Apps

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -273,6 +273,7 @@ public static class EnvironmentStack
                         },
                         Env = new[]
                         {
+                            new EnvironmentVarArgs { Name = "OTEL_SERVICE_NAME", Value = "town-crier-api" },
                             new EnvironmentVarArgs { Name = "Auth0__Domain", Value = auth0Domain },
                             new EnvironmentVarArgs { Name = "Auth0__Audience", Value = auth0Audience },
                             new EnvironmentVarArgs { Name = "Cosmos__AccountEndpoint", Value = cosmosAccountEndpoint },
@@ -362,6 +363,7 @@ public static class EnvironmentStack
                         },
                         Env = new[]
                         {
+                            new EnvironmentVarArgs { Name = "OTEL_SERVICE_NAME", Value = "town-crier-worker" },
                             new EnvironmentVarArgs { Name = "Cosmos__AccountEndpoint", Value = cosmosAccountEndpoint },
                             new EnvironmentVarArgs { Name = "Cosmos__DatabaseName", Value = cosmosDatabase.Name },
                             new EnvironmentVarArgs { Name = "AZURE_CLIENT_ID", Value = cosmosDataIdentityClientId },
@@ -431,6 +433,7 @@ public static class EnvironmentStack
                         },
                         Env = new[]
                         {
+                            new EnvironmentVarArgs { Name = "OTEL_SERVICE_NAME", Value = "town-crier-worker" },
                             new EnvironmentVarArgs { Name = "WORKER_MODE", Value = "digest" },
                             new EnvironmentVarArgs { Name = "Cosmos__AccountEndpoint", Value = cosmosAccountEndpoint },
                             new EnvironmentVarArgs { Name = "Cosmos__DatabaseName", Value = cosmosDatabase.Name },


### PR DESCRIPTION
## Changes
- Set `OTEL_SERVICE_NAME` environment variable on all three container definitions in Pulumi infra:
  - Container App (API): `town-crier-api`
  - Polling Job: `town-crier-worker`
  - Digest Job: `town-crier-worker`
- Fixes `unknown_service:*` prefix in App Insights telemetry (`cloud_RoleName`)

Closes tc-263.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Updated infrastructure configuration to assign service identifiers to API and worker components, enabling consistent system identification across all deployed services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->