### PR TITLE
feat(infra): add Auth0 M2M credentials to Container Apps

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -94,6 +94,8 @@ jobs:
           pulumi stack select dev
           pulumi config set --secret adminApiKey "${{ secrets.ADMIN_API_KEY }}"
           pulumi config set --secret autoGrantProDomains "${{ secrets.AUTO_GRANT_PRO_DOMAINS }}"
+          pulumi config set --secret auth0M2mClientId "${{ secrets.AUTH0_M2M_CLIENT_ID }}"
+          pulumi config set --secret auth0M2mClientSecret "${{ secrets.AUTH0_M2M_CLIENT_SECRET }}"
           pulumi up --yes --non-interactive
 
   # ── API: build & push image ─────────────────────────

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -64,6 +64,8 @@ jobs:
           pulumi stack select prod
           pulumi config set --secret adminApiKey "${{ secrets.ADMIN_API_KEY }}"
           pulumi config set --secret autoGrantProDomains "${{ secrets.AUTO_GRANT_PRO_DOMAINS }}"
+          pulumi config set --secret auth0M2mClientId "${{ secrets.AUTH0_M2M_CLIENT_ID }}"
+          pulumi config set --secret auth0M2mClientSecret "${{ secrets.AUTH0_M2M_CLIENT_SECRET }}"
           pulumi up --yes --non-interactive
 
       - name: Extract Pulumi outputs

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -34,6 +34,8 @@ public static class EnvironmentStack
         var customDomainPhase = config.GetInt32("customDomainPhase") ?? 2;
         var adminApiKey = config.RequireSecret("adminApiKey");
         var autoGrantProDomains = config.RequireSecret("autoGrantProDomains");
+        var auth0M2mClientId = config.RequireSecret("auth0M2mClientId");
+        var auth0M2mClientSecret = config.RequireSecret("auth0M2mClientSecret");
 
         // Shared stack outputs
         var shared = new StackReference("AmyDe/town-crier/shared");
@@ -215,6 +217,8 @@ public static class EnvironmentStack
                     new SecretArgs { Name = "admin-api-key", Value = adminApiKey },
                     new SecretArgs { Name = "auto-grant-pro-domains", Value = autoGrantProDomains },
                     new SecretArgs { Name = "acs-connection-string", Value = acsConnectionString },
+                    new SecretArgs { Name = "auth0-m2m-client-id", Value = auth0M2mClientId },
+                    new SecretArgs { Name = "auth0-m2m-client-secret", Value = auth0M2mClientSecret },
                 },
                 Ingress = new IngressArgs
                 {
@@ -284,6 +288,8 @@ public static class EnvironmentStack
                             new EnvironmentVarArgs { Name = "Admin__ApiKey", SecretRef = "admin-api-key" },
                             new EnvironmentVarArgs { Name = "Subscription__AutoGrant__ProDomains", SecretRef = "auto-grant-pro-domains" },
                             new EnvironmentVarArgs { Name = "AzureCommunicationServices__ConnectionString", SecretRef = "acs-connection-string" },
+                            new EnvironmentVarArgs { Name = "Auth0__M2M__ClientId", SecretRef = "auth0-m2m-client-id" },
+                            new EnvironmentVarArgs { Name = "Auth0__M2M__ClientSecret", SecretRef = "auth0-m2m-client-secret" },
                         },
                     },
                 },


### PR DESCRIPTION
## Changes

- Add `auth0M2mClientId` and `auth0M2mClientSecret` as Pulumi secrets in `EnvironmentStack.cs`
- Wire as Container App secrets (`auth0-m2m-client-id`, `auth0-m2m-client-secret`)
- Inject as environment variables (`Auth0__M2M__ClientId`, `Auth0__M2M__ClientSecret`)
- Update `cd-dev.yml` and `cd-prod.yml` to set secrets from GitHub Actions

## Required

Add these GitHub Actions repository secrets before merging:
- `AUTH0_M2M_CLIENT_ID` = `ZD56SkSPbPCFP3zTerdrY3ud48mpOq84`
- `AUTH0_M2M_CLIENT_SECRET` = (stored in Auth0 dashboard)

---
*Auto-shipped via ship skill*