### PR TITLE
fix(api): mitigate PlanIt API 429 rate limiting

### DIFF
--- a/api/src/town-crier.application/Polling/PlanItPollingOptions.cs
+++ b/api/src/town-crier.application/Polling/PlanItPollingOptions.cs
@@ -1,0 +1,8 @@
+namespace TownCrier.Application.Polling;
+
+public sealed record PlanItPollingOptions
+{
+    public double RateLimitCooldownSeconds { get; init; } = 30;
+
+    public TimeSpan RateLimitCooldown => TimeSpan.FromSeconds(this.RateLimitCooldownSeconds);
+}

--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -18,6 +18,7 @@ public sealed partial class PollPlanItCommandHandler
     private readonly IWatchZoneRepository watchZoneRepository;
     private readonly INotificationEnqueuer notificationEnqueuer;
     private readonly ILogger<PollPlanItCommandHandler> logger;
+    private readonly PlanItPollingOptions pollingOptions;
 
     public PollPlanItCommandHandler(
         IPlanItClient planItClient,
@@ -27,7 +28,8 @@ public sealed partial class PollPlanItCommandHandler
         IActiveAuthorityProvider activeAuthorityProvider,
         IWatchZoneRepository watchZoneRepository,
         INotificationEnqueuer notificationEnqueuer,
-        ILogger<PollPlanItCommandHandler> logger)
+        ILogger<PollPlanItCommandHandler> logger,
+        PlanItPollingOptions? pollingOptions = null)
     {
         this.planItClient = planItClient;
         this.pollStateStore = pollStateStore;
@@ -37,6 +39,7 @@ public sealed partial class PollPlanItCommandHandler
         this.watchZoneRepository = watchZoneRepository;
         this.notificationEnqueuer = notificationEnqueuer;
         this.logger = logger;
+        this.pollingOptions = pollingOptions ?? new PlanItPollingOptions();
     }
 
     public async Task<PollPlanItResult> HandleAsync(PollPlanItCommand command, CancellationToken ct)
@@ -99,6 +102,7 @@ public sealed partial class PollPlanItCommandHandler
                 }
 
                 LogRateLimitSkip(this.logger, authorityId, ex);
+                await Task.Delay(this.pollingOptions.RateLimitCooldown, ct).ConfigureAwait(false);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -148,6 +148,28 @@ public sealed class PlanItClient : IPlanItClient
         return DateOnly.Parse(value, CultureInfo.InvariantCulture);
     }
 
+    private static TimeSpan? ParseRetryAfterHeader(HttpResponseMessage response)
+    {
+        var retryAfter = response.Headers.RetryAfter;
+        if (retryAfter is null)
+        {
+            return null;
+        }
+
+        if (retryAfter.Delta.HasValue)
+        {
+            return retryAfter.Delta.Value;
+        }
+
+        if (retryAfter.Date.HasValue)
+        {
+            var delay = retryAfter.Date.Value - DateTimeOffset.UtcNow;
+            return delay > TimeSpan.Zero ? delay : TimeSpan.Zero;
+        }
+
+        return null;
+    }
+
     private async Task<HttpResponseMessage> SendWithRetryAsync(Uri url, int authorityId, CancellationToken ct)
     {
         for (var attempt = 0; attempt <= this.retryOptions.MaxRetries; attempt++)
@@ -172,6 +194,7 @@ public sealed class PlanItClient : IPlanItClient
                 return response;
             }
 
+            var retryAfterDelay = ParseRetryAfterHeader(response);
             response.Dispose();
 
             if (attempt == this.retryOptions.MaxRetries)
@@ -182,7 +205,7 @@ public sealed class PlanItClient : IPlanItClient
                     HttpStatusCode.TooManyRequests);
             }
 
-            var delay = this.CalculateBackoffDelay(attempt);
+            var delay = retryAfterDelay ?? this.CalculateBackoffDelay(attempt);
             await this.delayFunc(delay, ct).ConfigureAwait(false);
         }
 

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItRetryOptions.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItRetryOptions.cs
@@ -4,5 +4,7 @@ public sealed record PlanItRetryOptions
 {
     public int MaxRetries { get; init; } = 5;
 
-    public TimeSpan BaseDelay { get; init; } = TimeSpan.FromSeconds(1);
+    public double BaseDelaySeconds { get; init; } = 1;
+
+    public TimeSpan BaseDelay => TimeSpan.FromSeconds(this.BaseDelaySeconds);
 }

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItThrottleOptions.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItThrottleOptions.cs
@@ -2,5 +2,7 @@ namespace TownCrier.Infrastructure.PlanIt;
 
 public sealed record PlanItThrottleOptions
 {
-    public TimeSpan DelayBetweenRequests { get; init; } = TimeSpan.FromSeconds(2);
+    public double DelayBetweenRequestsSeconds { get; init; } = 2;
+
+    public TimeSpan DelayBetweenRequests => TimeSpan.FromSeconds(this.DelayBetweenRequestsSeconds);
 }

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItThrottleOptions.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItThrottleOptions.cs
@@ -2,5 +2,5 @@ namespace TownCrier.Infrastructure.PlanIt;
 
 public sealed record PlanItThrottleOptions
 {
-    public TimeSpan DelayBetweenRequests { get; init; } = TimeSpan.FromSeconds(1);
+    public TimeSpan DelayBetweenRequests { get; init; } = TimeSpan.FromSeconds(2);
 }

--- a/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
+++ b/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
@@ -98,6 +98,14 @@ internal static class ServiceCollectionExtensions
             return new PostcodesIoAuthorityResolver(httpClient);
         });
 
+        var planItThrottle = new PlanItThrottleOptions();
+        configuration.GetSection("PlanIt:Throttle").Bind(planItThrottle);
+        services.AddSingleton(planItThrottle);
+
+        var planItRetry = new PlanItRetryOptions();
+        configuration.GetSection("PlanIt:Retry").Bind(planItRetry);
+        services.AddSingleton(planItRetry);
+
 #pragma warning disable S1075 // Hardcoded URI is a sensible default
         var planItBaseUrl = configuration["PlanIt:BaseUrl"] ?? "https://www.planit.org.uk/";
 #pragma warning restore S1075

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -100,6 +100,10 @@ var planItRetry = new PlanItRetryOptions();
 builder.Configuration.GetSection("PlanIt:Retry").Bind(planItRetry);
 builder.Services.AddSingleton(planItRetry);
 
+var planItPolling = new PlanItPollingOptions();
+builder.Configuration.GetSection("PlanIt:Polling").Bind(planItPolling);
+builder.Services.AddSingleton(planItPolling);
+
 #pragma warning disable S1075 // Hardcoded URI is a sensible default
 var planItBaseUrl = builder.Configuration["PlanIt:BaseUrl"] ?? "https://www.planit.org.uk/";
 #pragma warning restore S1075

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Azure.Monitor.OpenTelemetry.Exporter;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -90,6 +91,14 @@ else
 builder.Services.AddSingleton<DispatchNotificationCommandHandler>();
 builder.Services.AddSingleton<INotificationEnqueuer, DispatchNotificationEnqueuer>();
 builder.Services.AddSingleton(TimeProvider.System);
+
+var planItThrottle = new PlanItThrottleOptions();
+builder.Configuration.GetSection("PlanIt:Throttle").Bind(planItThrottle);
+builder.Services.AddSingleton(planItThrottle);
+
+var planItRetry = new PlanItRetryOptions();
+builder.Configuration.GetSection("PlanIt:Retry").Bind(planItRetry);
+builder.Services.AddSingleton(planItRetry);
 
 #pragma warning disable S1075 // Hardcoded URI is a sensible default
 var planItBaseUrl = builder.Configuration["PlanIt:BaseUrl"] ?? "https://www.planit.org.uk/";

--- a/api/tests/town-crier.application.tests/Polling/PlanItPollingOptionsTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PlanItPollingOptionsTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using TownCrier.Application.Polling;
 
 namespace TownCrier.Application.Tests.Polling;
@@ -27,5 +28,36 @@ public sealed class PlanItPollingOptionsTests
         var options = new PlanItPollingOptions { RateLimitCooldownSeconds = 0 };
 
         await Assert.That(options.RateLimitCooldown).IsEqualTo(TimeSpan.Zero);
+    }
+
+    [Test]
+    public async Task Should_BindFromConfiguration_When_SectionProvided()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["PlanIt:Polling:RateLimitCooldownSeconds"] = "45",
+            })
+            .Build();
+
+        var options = new PlanItPollingOptions();
+        config.GetSection("PlanIt:Polling").Bind(options);
+
+        await Assert.That(options.RateLimitCooldownSeconds).IsEqualTo(45);
+        await Assert.That(options.RateLimitCooldown).IsEqualTo(TimeSpan.FromSeconds(45));
+    }
+
+    [Test]
+    public async Task Should_KeepDefaults_When_ConfigSectionEmpty()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var options = new PlanItPollingOptions();
+        config.GetSection("PlanIt:Polling").Bind(options);
+
+        await Assert.That(options.RateLimitCooldownSeconds).IsEqualTo(30);
+        await Assert.That(options.RateLimitCooldown).IsEqualTo(TimeSpan.FromSeconds(30));
     }
 }

--- a/api/tests/town-crier.application.tests/Polling/PlanItPollingOptionsTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PlanItPollingOptionsTests.cs
@@ -12,4 +12,20 @@ public sealed class PlanItPollingOptionsTests
         await Assert.That(options.RateLimitCooldownSeconds).IsEqualTo(30);
         await Assert.That(options.RateLimitCooldown).IsEqualTo(TimeSpan.FromSeconds(30));
     }
+
+    [Test]
+    public async Task Should_ComputeCooldownFromSeconds_When_SecondsPropertySet()
+    {
+        var options = new PlanItPollingOptions { RateLimitCooldownSeconds = 15.5 };
+
+        await Assert.That(options.RateLimitCooldown).IsEqualTo(TimeSpan.FromSeconds(15.5));
+    }
+
+    [Test]
+    public async Task Should_ReturnZeroCooldown_When_SecondsSetToZero()
+    {
+        var options = new PlanItPollingOptions { RateLimitCooldownSeconds = 0 };
+
+        await Assert.That(options.RateLimitCooldown).IsEqualTo(TimeSpan.Zero);
+    }
 }

--- a/api/tests/town-crier.application.tests/Polling/PlanItPollingOptionsTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PlanItPollingOptionsTests.cs
@@ -1,0 +1,15 @@
+using TownCrier.Application.Polling;
+
+namespace TownCrier.Application.Tests.Polling;
+
+public sealed class PlanItPollingOptionsTests
+{
+    [Test]
+    public async Task Should_UseDefaultCooldown_When_NoOptionsProvided()
+    {
+        var options = new PlanItPollingOptions();
+
+        await Assert.That(options.RateLimitCooldownSeconds).IsEqualTo(30);
+        await Assert.That(options.RateLimitCooldown).IsEqualTo(TimeSpan.FromSeconds(30));
+    }
+}

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -462,6 +462,31 @@ public sealed class PollPlanItCommandHandlerTests
         await Assert.That(pollStateStore.DeleteGlobalCalled).IsTrue();
     }
 
+    [Test]
+    public async Task Should_ContinueToNextAuthority_When_RateLimitHitWithCooldown()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+        authorityProvider.Add(300);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.ThrowForAuthority(200, new HttpRequestException("Rate limited", null, HttpStatusCode.TooManyRequests));
+        planItClient.Add(300, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(300).Build());
+
+        var pollingOptions = new PlanItPollingOptions { RateLimitCooldownSeconds = 0 };
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            authorityProvider: authorityProvider,
+            pollingOptions: pollingOptions);
+
+        var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(result.ApplicationCount).IsEqualTo(2);
+        await Assert.That(result.AuthoritiesPolled).IsEqualTo(2);
+    }
+
     private static PollPlanItCommandHandler CreateHandler(
         FakePlanItClient? planItClient = null,
         FakePollStateStore? pollStateStore = null,
@@ -469,7 +494,8 @@ public sealed class PollPlanItCommandHandlerTests
         FakeActiveAuthorityProvider? authorityProvider = null,
         FakeWatchZoneRepository? watchZoneRepository = null,
         FakeNotificationEnqueuer? notificationEnqueuer = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        PlanItPollingOptions? pollingOptions = null)
     {
         return new PollPlanItCommandHandler(
             planItClient ?? new FakePlanItClient(),
@@ -479,6 +505,7 @@ public sealed class PollPlanItCommandHandlerTests
             authorityProvider ?? new FakeActiveAuthorityProvider(),
             watchZoneRepository ?? new FakeWatchZoneRepository(),
             notificationEnqueuer ?? new FakeNotificationEnqueuer(),
-            NullLogger<PollPlanItCommandHandler>.Instance);
+            NullLogger<PollPlanItCommandHandler>.Instance,
+            pollingOptions);
     }
 }

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -6,6 +6,8 @@ namespace TownCrier.Application.Tests.Polling;
 
 public sealed class PollPlanItCommandHandlerTests
 {
+    private static readonly PlanItPollingOptions ZeroCooldownOptions = new() { RateLimitCooldownSeconds = 0 };
+
     [Test]
     public async Task Should_ReturnApplicationCount_When_PlanItReturnsApplications()
     {
@@ -506,6 +508,6 @@ public sealed class PollPlanItCommandHandlerTests
             watchZoneRepository ?? new FakeWatchZoneRepository(),
             notificationEnqueuer ?? new FakeNotificationEnqueuer(),
             NullLogger<PollPlanItCommandHandler>.Instance,
-            pollingOptions);
+            pollingOptions ?? ZeroCooldownOptions);
     }
 }

--- a/api/tests/town-crier.application.tests/town-crier.application.tests.csproj
+++ b/api/tests/town-crier.application.tests/town-crier.application.tests.csproj
@@ -10,6 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.*" />
     <PackageReference Include="TUnit" Version="0.12.*" />
   </ItemGroup>
 

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/FakePlanItHandler.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/FakePlanItHandler.cs
@@ -9,6 +9,7 @@ internal sealed class FakePlanItHandler : HttpMessageHandler
     private readonly Dictionary<string, string> responses = new();
     private readonly List<string> requestUrls = [];
     private readonly Dictionary<string, int> rateLimitCounters = new();
+    private readonly Dictionary<string, string?> retryAfterHeaders = new();
     private readonly Dictionary<string, HttpStatusCode> statusCodeResponses = new();
 
     public IReadOnlyList<string> RequestUrls => this.requestUrls;
@@ -22,6 +23,13 @@ internal sealed class FakePlanItHandler : HttpMessageHandler
     {
         this.rateLimitCounters[urlContains] = count;
         this.responses[urlContains] = json;
+    }
+
+    public void SetupRateLimitWithRetryAfter(string urlContains, int count, string successJson, string retryAfterValue)
+    {
+        this.rateLimitCounters[urlContains] = count;
+        this.retryAfterHeaders[urlContains] = retryAfterValue;
+        this.responses[urlContains] = successJson;
     }
 
     public void SetupRateLimitForever(string urlContains)
@@ -46,7 +54,13 @@ internal sealed class FakePlanItHandler : HttpMessageHandler
             if (url.Contains(key, StringComparison.Ordinal) && this.rateLimitCounters[key] > 0)
             {
                 this.rateLimitCounters[key]--;
-                return Task.FromResult(new HttpResponseMessage((HttpStatusCode)429));
+                var rateLimitResponse = new HttpResponseMessage((HttpStatusCode)429);
+                if (this.retryAfterHeaders.TryGetValue(key, out var retryAfterValue) && retryAfterValue is not null)
+                {
+                    rateLimitResponse.Headers.TryAddWithoutValidation("Retry-After", retryAfterValue);
+                }
+
+                return Task.FromResult(rateLimitResponse);
             }
         }
 

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -457,7 +457,7 @@ public sealed class PlanItClientTests
     }
 
     [Test]
-    public async Task Should_UseDefaultOneSecondDelay_When_NoThrottleOptionsProvided()
+    public async Task Should_UseDefaultTwoSecondDelay_When_NoThrottleOptionsProvided()
     {
         // Arrange
         using var handler = new FakePlanItHandler();
@@ -468,9 +468,9 @@ public sealed class PlanItClientTests
         // Act
         await ConsumeAsync(client, differentStart: null);
 
-        // Assert — default 1s throttle delay
+        // Assert — default 2s throttle delay
         await Assert.That(throttleDelays).HasCount().EqualTo(1);
-        await Assert.That(throttleDelays[0]).IsEqualTo(TimeSpan.FromSeconds(1));
+        await Assert.That(throttleDelays[0]).IsEqualTo(TimeSpan.FromSeconds(2));
     }
 
     [Test]

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -618,6 +618,28 @@ public sealed class PlanItClientTests
         await Assert.That(recorded).HasCount().EqualTo(0);
     }
 
+    [Test]
+    public async Task Should_UseRetryAfterDelay_When_429ResponseHasDeltaSecondsHeader()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupRateLimitWithRetryAfter("page=1", count: 1, SingleRecordResponse, retryAfterValue: "10");
+        var backoffDelays = new List<TimeSpan>();
+        var options = new PlanItRetryOptions { MaxRetries = 3, BaseDelaySeconds = 1 };
+        var client = CreateClient(handler, retryOptions: options, delays: backoffDelays);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert — got results after retry
+        await Assert.That(results).HasCount().EqualTo(1);
+
+        // The backoff delay should be exactly 10 seconds (from Retry-After header),
+        // not the exponential backoff of ~1s (base delay * 2^0)
+        await Assert.That(backoffDelays).HasCount().EqualTo(1);
+        await Assert.That(backoffDelays[0]).IsEqualTo(TimeSpan.FromSeconds(10));
+    }
+
     private static PlanItClient CreateClient(
         FakePlanItHandler handler,
         PlanItRetryOptions? retryOptions = null,

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -641,6 +641,33 @@ public sealed class PlanItClientTests
     }
 
     [Test]
+    public async Task Should_UseRetryAfterDelay_When_HeaderContainsHttpDate()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+
+        // Use a date 30 seconds in the future from now
+        var futureDate = DateTimeOffset.UtcNow.AddSeconds(30);
+        var httpDateValue = futureDate.ToString("R");
+        handler.SetupRateLimitWithRetryAfter("page=1", count: 1, SingleRecordResponse, retryAfterValue: httpDateValue);
+        var backoffDelays = new List<TimeSpan>();
+        var options = new PlanItRetryOptions { MaxRetries = 3, BaseDelaySeconds = 1 };
+        var client = CreateClient(handler, retryOptions: options, delays: backoffDelays);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert — got results after retry
+        await Assert.That(results).HasCount().EqualTo(1);
+
+        // The delay should be approximately 30 seconds (from the HTTP-date Retry-After),
+        // not the exponential backoff of ~1s. Allow a generous range for clock drift.
+        await Assert.That(backoffDelays).HasCount().EqualTo(1);
+        await Assert.That(backoffDelays[0]).IsGreaterThanOrEqualTo(TimeSpan.FromSeconds(25))
+            .And.IsLessThanOrEqualTo(TimeSpan.FromSeconds(35));
+    }
+
+    [Test]
     public async Task Should_FallBackToExponentialBackoff_When_NoRetryAfterHeader()
     {
         // Arrange

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -200,7 +200,7 @@ public sealed class PlanItClientTests
         using var handler = new FakePlanItHandler();
         handler.SetupRateLimitThenSuccess("page=1", count: 2, SingleRecordResponse);
         var delays = new List<TimeSpan>();
-        var client = CreateClient(handler, retryOptions: new PlanItRetryOptions { MaxRetries = 3, BaseDelay = TimeSpan.FromMilliseconds(10) }, delays: delays);
+        var client = CreateClient(handler, retryOptions: new PlanItRetryOptions { MaxRetries = 3, BaseDelaySeconds = 0.01 }, delays: delays);
 
         // Act
         var results = await ConsumeAsync(client, differentStart: null);
@@ -219,7 +219,7 @@ public sealed class PlanItClientTests
         using var handler = new FakePlanItHandler();
         handler.SetupRateLimitThenSuccess("page=1", count: 3, SingleRecordResponse);
         var delays = new List<TimeSpan>();
-        var options = new PlanItRetryOptions { MaxRetries = 5, BaseDelay = TimeSpan.FromSeconds(1) };
+        var options = new PlanItRetryOptions { MaxRetries = 5, BaseDelaySeconds = 1 };
         var client = CreateClient(handler, retryOptions: options, delays: delays);
 
         // Act
@@ -241,7 +241,7 @@ public sealed class PlanItClientTests
         // Arrange
         using var handler = new FakePlanItHandler();
         handler.SetupRateLimitForever("page=1");
-        var options = new PlanItRetryOptions { MaxRetries = 3, BaseDelay = TimeSpan.FromMilliseconds(1) };
+        var options = new PlanItRetryOptions { MaxRetries = 3, BaseDelaySeconds = 0.001 };
         var client = CreateClient(handler, retryOptions: options);
 
         // Act & Assert
@@ -256,7 +256,7 @@ public sealed class PlanItClientTests
         using var handler = new FakePlanItHandler();
 
         // No response configured → returns 404, which is a non-429 error
-        var options = new PlanItRetryOptions { MaxRetries = 3, BaseDelay = TimeSpan.FromMilliseconds(1) };
+        var options = new PlanItRetryOptions { MaxRetries = 3, BaseDelaySeconds = 0.001 };
         var client = CreateClient(handler, retryOptions: options);
 
         // Act & Assert — should throw immediately without retrying
@@ -356,7 +356,7 @@ public sealed class PlanItClientTests
         handler.SetupRateLimitThenSuccess("page=1", count: 1, SingleRecordResponse);
         var allDelays = new List<TimeSpan>();
         var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0.1 };
-        var retryOptions = new PlanItRetryOptions { MaxRetries = 3, BaseDelay = TimeSpan.FromMilliseconds(10) };
+        var retryOptions = new PlanItRetryOptions { MaxRetries = 3, BaseDelaySeconds = 0.01 };
         var client = CreateClient(handler, retryOptions: retryOptions, throttleOptions: throttleOptions, throttleDelays: allDelays);
 
         // Act
@@ -496,7 +496,7 @@ public sealed class PlanItClientTests
         // Arrange
         using var handler = new FakePlanItHandler();
         handler.SetupRateLimitThenSuccess("page=1", count: 2, SingleRecordResponse);
-        var client = CreateClient(handler, retryOptions: new PlanItRetryOptions { MaxRetries = 3, BaseDelay = TimeSpan.FromMilliseconds(1) });
+        var client = CreateClient(handler, retryOptions: new PlanItRetryOptions { MaxRetries = 3, BaseDelaySeconds = 0.001 });
 
         var recorded = new List<(long Value, int StatusCode, int AuthorityCode)>();
         using var listener = new MeterListener();

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -292,7 +292,7 @@ public sealed class PlanItClientTests
         using var handler = new FakePlanItHandler();
         handler.SetupJsonResponse("page=1", SingleRecordResponse);
         var throttleDelays = new List<TimeSpan>();
-        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequests = TimeSpan.FromMilliseconds(500) };
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0.5 };
         var client = CreateClient(handler, throttleOptions: throttleOptions, throttleDelays: throttleDelays);
 
         // Act
@@ -318,7 +318,7 @@ public sealed class PlanItClientTests
         handler.SetupJsonResponse("page=2", page2Json);
 
         var throttleDelays = new List<TimeSpan>();
-        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequests = TimeSpan.FromMilliseconds(200) };
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0.2 };
         var client = CreateClient(handler, throttleOptions: throttleOptions, throttleDelays: throttleDelays);
 
         // Act
@@ -337,7 +337,7 @@ public sealed class PlanItClientTests
         using var handler = new FakePlanItHandler();
         handler.SetupJsonResponse("/api/applics/json", SingleRecordResponse);
         var throttleDelays = new List<TimeSpan>();
-        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequests = TimeSpan.FromMilliseconds(300) };
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0.3 };
         var client = CreateClient(handler, throttleOptions: throttleOptions, throttleDelays: throttleDelays);
 
         // Act
@@ -355,7 +355,7 @@ public sealed class PlanItClientTests
         using var handler = new FakePlanItHandler();
         handler.SetupRateLimitThenSuccess("page=1", count: 1, SingleRecordResponse);
         var allDelays = new List<TimeSpan>();
-        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequests = TimeSpan.FromMilliseconds(100) };
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0.1 };
         var retryOptions = new PlanItRetryOptions { MaxRetries = 3, BaseDelay = TimeSpan.FromMilliseconds(10) };
         var client = CreateClient(handler, retryOptions: retryOptions, throttleOptions: throttleOptions, throttleDelays: allDelays);
 
@@ -633,7 +633,7 @@ public sealed class PlanItClientTests
         // When tracking backoff delays but not throttle delays, disable throttle
         // so throttle delays don't pollute the backoff delay list.
         throttleOptions ??= delays is not null && throttleDelays is null
-            ? new PlanItThrottleOptions { DelayBetweenRequests = TimeSpan.Zero }
+            ? new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0 }
             : new PlanItThrottleOptions();
 
         Func<TimeSpan, CancellationToken, Task>? delayFunc = null;

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -640,6 +640,28 @@ public sealed class PlanItClientTests
         await Assert.That(backoffDelays[0]).IsEqualTo(TimeSpan.FromSeconds(10));
     }
 
+    [Test]
+    public async Task Should_FallBackToExponentialBackoff_When_NoRetryAfterHeader()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupRateLimitThenSuccess("page=1", count: 1, SingleRecordResponse);
+        var backoffDelays = new List<TimeSpan>();
+        var options = new PlanItRetryOptions { MaxRetries = 3, BaseDelaySeconds = 1 };
+        var client = CreateClient(handler, retryOptions: options, delays: backoffDelays);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert — got results after retry
+        await Assert.That(results).HasCount().EqualTo(1);
+
+        // Without Retry-After header, should use exponential backoff (~1s base * 2^0 = ~1s with jitter)
+        await Assert.That(backoffDelays).HasCount().EqualTo(1);
+        await Assert.That(backoffDelays[0]).IsGreaterThanOrEqualTo(TimeSpan.FromMilliseconds(500))
+            .And.IsLessThanOrEqualTo(TimeSpan.FromMilliseconds(1500));
+    }
+
     private static PlanItClient CreateClient(
         FakePlanItHandler handler,
         PlanItRetryOptions? retryOptions = null,

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItRetryOptionsTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItRetryOptionsTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using TownCrier.Infrastructure.PlanIt;
 
 namespace TownCrier.Infrastructure.Tests.PlanIt;
@@ -35,5 +36,43 @@ public sealed class PlanItRetryOptionsTests
         // Assert
         await Assert.That(options.MaxRetries).IsEqualTo(10);
         await Assert.That(options.BaseDelay).IsEqualTo(TimeSpan.FromSeconds(3));
+    }
+
+    [Test]
+    public async Task Should_BindFromConfiguration_When_SectionProvided()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["PlanIt:Retry:MaxRetries"] = "10",
+                ["PlanIt:Retry:BaseDelaySeconds"] = "3",
+            })
+            .Build();
+
+        var options = new PlanItRetryOptions();
+        config.GetSection("PlanIt:Retry").Bind(options);
+
+        // Assert
+        await Assert.That(options.MaxRetries).IsEqualTo(10);
+        await Assert.That(options.BaseDelaySeconds).IsEqualTo(3);
+        await Assert.That(options.BaseDelay).IsEqualTo(TimeSpan.FromSeconds(3));
+    }
+
+    [Test]
+    public async Task Should_KeepDefaults_When_ConfigSectionEmpty()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var options = new PlanItRetryOptions();
+        config.GetSection("PlanIt:Retry").Bind(options);
+
+        // Assert — defaults preserved
+        await Assert.That(options.MaxRetries).IsEqualTo(5);
+        await Assert.That(options.BaseDelaySeconds).IsEqualTo(1);
+        await Assert.That(options.BaseDelay).IsEqualTo(TimeSpan.FromSeconds(1));
     }
 }

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItRetryOptionsTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItRetryOptionsTests.cs
@@ -1,0 +1,39 @@
+using TownCrier.Infrastructure.PlanIt;
+
+namespace TownCrier.Infrastructure.Tests.PlanIt;
+
+public sealed class PlanItRetryOptionsTests
+{
+    [Test]
+    public async Task Should_DefaultToOneSecondBaseDelay_When_NoPropertiesSet()
+    {
+        // Arrange & Act
+        var options = new PlanItRetryOptions();
+
+        // Assert
+        await Assert.That(options.BaseDelaySeconds).IsEqualTo(1);
+        await Assert.That(options.BaseDelay).IsEqualTo(TimeSpan.FromSeconds(1));
+        await Assert.That(options.MaxRetries).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task Should_ComputeBaseDelayFromSeconds_When_SecondsPropertySet()
+    {
+        // Arrange & Act
+        var options = new PlanItRetryOptions { BaseDelaySeconds = 2.5 };
+
+        // Assert
+        await Assert.That(options.BaseDelay).IsEqualTo(TimeSpan.FromSeconds(2.5));
+    }
+
+    [Test]
+    public async Task Should_AllowCustomMaxRetries_When_Set()
+    {
+        // Arrange & Act
+        var options = new PlanItRetryOptions { MaxRetries = 10, BaseDelaySeconds = 3 };
+
+        // Assert
+        await Assert.That(options.MaxRetries).IsEqualTo(10);
+        await Assert.That(options.BaseDelay).IsEqualTo(TimeSpan.FromSeconds(3));
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItThrottleOptionsTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItThrottleOptionsTests.cs
@@ -1,0 +1,37 @@
+using TownCrier.Infrastructure.PlanIt;
+
+namespace TownCrier.Infrastructure.Tests.PlanIt;
+
+public sealed class PlanItThrottleOptionsTests
+{
+    [Test]
+    public async Task Should_DefaultToTwoSeconds_When_NoPropertiesSet()
+    {
+        // Arrange & Act
+        var options = new PlanItThrottleOptions();
+
+        // Assert
+        await Assert.That(options.DelayBetweenRequestsSeconds).IsEqualTo(2);
+        await Assert.That(options.DelayBetweenRequests).IsEqualTo(TimeSpan.FromSeconds(2));
+    }
+
+    [Test]
+    public async Task Should_ComputeDelayFromSeconds_When_SecondsPropertySet()
+    {
+        // Arrange & Act
+        var options = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 3.5 };
+
+        // Assert
+        await Assert.That(options.DelayBetweenRequests).IsEqualTo(TimeSpan.FromSeconds(3.5));
+    }
+
+    [Test]
+    public async Task Should_ReturnZeroDelay_When_SecondsSetToZero()
+    {
+        // Arrange & Act
+        var options = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0 };
+
+        // Assert
+        await Assert.That(options.DelayBetweenRequests).IsEqualTo(TimeSpan.Zero);
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItThrottleOptionsTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItThrottleOptionsTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Configuration;
 using TownCrier.Infrastructure.PlanIt;
 
 namespace TownCrier.Infrastructure.Tests.PlanIt;
@@ -33,5 +34,40 @@ public sealed class PlanItThrottleOptionsTests
 
         // Assert
         await Assert.That(options.DelayBetweenRequests).IsEqualTo(TimeSpan.Zero);
+    }
+
+    [Test]
+    public async Task Should_BindFromConfiguration_When_SectionProvided()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["PlanIt:Throttle:DelayBetweenRequestsSeconds"] = "5",
+            })
+            .Build();
+
+        var options = new PlanItThrottleOptions();
+        config.GetSection("PlanIt:Throttle").Bind(options);
+
+        // Assert
+        await Assert.That(options.DelayBetweenRequestsSeconds).IsEqualTo(5);
+        await Assert.That(options.DelayBetweenRequests).IsEqualTo(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Should_KeepDefaults_When_ConfigSectionEmpty()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        var options = new PlanItThrottleOptions();
+        config.GetSection("PlanIt:Throttle").Bind(options);
+
+        // Assert — defaults preserved
+        await Assert.That(options.DelayBetweenRequestsSeconds).IsEqualTo(2);
+        await Assert.That(options.DelayBetweenRequests).IsEqualTo(TimeSpan.FromSeconds(2));
     }
 }


### PR DESCRIPTION
## Summary

Addresses [SRE] PlanIt API 429 rate at 38% (tc-m51). Three changes to reduce rate limiting:

- **Configurable options**: `PlanItThrottleOptions`, `PlanItRetryOptions`, and new `PlanItPollingOptions` are now bound to `IConfiguration` (`PlanIt:Throttle`, `PlanIt:Retry`, `PlanIt:Polling` sections). No redeployment needed to tune.
- **Default throttle raised to 2s**: More conservative inter-request delay (was 1s).
- **Retry-After header support**: 429 responses with `Retry-After` (delta-seconds or HTTP-date) now drive the backoff delay instead of the calculated exponential.
- **Per-authority cooldown**: 30s configurable delay after a 429 before polling the next authority, preventing immediate re-triggering.

## Beads

- tc-65n — Make PlanIt throttle/retry options configurable via appsettings
- tc-921 — Parse Retry-After header on 429 responses from PlanIt
- tc-s3d — Add per-authority cooldown after 429 in polling loop

## Test plan

- [x] 142 infrastructure tests pass (including 3 new Retry-After tests, 10 new options binding tests)
- [x] 185 application tests pass (including 1 new cooldown test, updated handler tests)
- [ ] Monitor PlanIt 429 rate in App Insights after deployment — expect significant reduction

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added rate-limit cooldown configuration with automatic delays when rate limits are encountered
* Implemented Retry-After header support for server-guided retry timing
* Added configurable settings for request throttling and retry backoff strategies

## Tests
* Expanded test coverage for rate-limiting, retry, and throttling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->