### PR TITLE
feat(api): log retry delay source on PlanIt 429

### DIFF
--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -3,13 +3,14 @@ using System.Globalization;
 using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using TownCrier.Application.PlanIt;
 using TownCrier.Domain.PlanningApplications;
 using TownCrier.Infrastructure.Observability;
 
 namespace TownCrier.Infrastructure.PlanIt;
 
-public sealed class PlanItClient : IPlanItClient
+public sealed partial class PlanItClient : IPlanItClient
 {
     private const int DefaultPageSize = 100;
     private const int SearchPageSize = 20;
@@ -18,17 +19,20 @@ public sealed class PlanItClient : IPlanItClient
     private static readonly Random Jitter = new();
 
     private readonly HttpClient httpClient;
+    private readonly ILogger<PlanItClient> logger;
     private readonly PlanItRetryOptions retryOptions;
     private readonly PlanItThrottleOptions throttleOptions;
     private readonly Func<TimeSpan, CancellationToken, Task> delayFunc;
 
     public PlanItClient(
         HttpClient httpClient,
+        ILogger<PlanItClient> logger,
         PlanItRetryOptions? retryOptions = null,
         PlanItThrottleOptions? throttleOptions = null,
         Func<TimeSpan, CancellationToken, Task>? delayFunc = null)
     {
         this.httpClient = httpClient;
+        this.logger = logger;
         this.retryOptions = retryOptions ?? new PlanItRetryOptions();
         this.throttleOptions = throttleOptions ?? new PlanItThrottleOptions();
         this.delayFunc = delayFunc ?? Task.Delay;
@@ -170,6 +174,9 @@ public sealed class PlanItClient : IPlanItClient
         return null;
     }
 
+    [LoggerMessage(Level = LogLevel.Warning, Message = "PlanIt 429 for authority {AuthorityId}, attempt {Attempt}/{MaxRetries}, waiting {DelayMs}ms ({Source})")]
+    private static partial void LogRetryDelay(ILogger logger, int authorityId, int attempt, int maxRetries, int delayMs, string source);
+
     private async Task<HttpResponseMessage> SendWithRetryAsync(Uri url, int authorityId, CancellationToken ct)
     {
         for (var attempt = 0; attempt <= this.retryOptions.MaxRetries; attempt++)
@@ -206,6 +213,8 @@ public sealed class PlanItClient : IPlanItClient
             }
 
             var delay = retryAfterDelay ?? this.CalculateBackoffDelay(attempt);
+            var source = retryAfterDelay.HasValue ? "Retry-After" : "exponential backoff";
+            LogRetryDelay(this.logger, authorityId, attempt + 1, this.retryOptions.MaxRetries, (int)delay.TotalMilliseconds, source);
             await this.delayFunc(delay, ct).ConfigureAwait(false);
         }
 

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/FakePlanItLogger.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/FakePlanItLogger.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Logging;
+using TownCrier.Infrastructure.PlanIt;
+
+namespace TownCrier.Infrastructure.Tests.PlanIt;
+
+internal sealed class FakePlanItLogger : ILogger<PlanItClient>
+{
+    public List<string> Messages { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+    {
+        this.Messages.Add(formatter(state, exception));
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -2,6 +2,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Diagnostics.Metrics;
 using System.Globalization;
 using System.Net;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using TownCrier.Infrastructure.PlanIt;
 
 namespace TownCrier.Infrastructure.Tests.PlanIt;
@@ -641,6 +643,45 @@ public sealed class PlanItClientTests
     }
 
     [Test]
+    public async Task Should_LogRetryAfterSource_When_429ResponseHasRetryAfterHeader()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupRateLimitWithRetryAfter("page=1", count: 1, SingleRecordResponse, retryAfterValue: "10");
+        var logger = new FakePlanItLogger();
+        var options = new PlanItRetryOptions { MaxRetries = 3, BaseDelaySeconds = 1 };
+        var client = CreateClient(handler, retryOptions: options, logger: logger);
+
+        // Act
+        await ConsumeAsync(client, differentStart: null, authorityId: 292);
+
+        // Assert — logged that Retry-After header was used
+        await Assert.That(logger.Messages).HasCount().EqualTo(1);
+        await Assert.That(logger.Messages[0]).Contains("Retry-After");
+        await Assert.That(logger.Messages[0]).Contains("10");
+        await Assert.That(logger.Messages[0]).Contains("292");
+    }
+
+    [Test]
+    public async Task Should_LogBackoffSource_When_429ResponseHasNoRetryAfterHeader()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupRateLimitThenSuccess("page=1", count: 1, SingleRecordResponse);
+        var logger = new FakePlanItLogger();
+        var options = new PlanItRetryOptions { MaxRetries = 3, BaseDelaySeconds = 1 };
+        var client = CreateClient(handler, retryOptions: options, logger: logger);
+
+        // Act
+        await ConsumeAsync(client, differentStart: null, authorityId: 292);
+
+        // Assert — logged that exponential backoff was used
+        await Assert.That(logger.Messages).HasCount().EqualTo(1);
+        await Assert.That(logger.Messages[0]).Contains("backoff");
+        await Assert.That(logger.Messages[0]).Contains("292");
+    }
+
+    [Test]
     public async Task Should_UseRetryAfterDelay_When_HeaderContainsHttpDate()
     {
         // Arrange
@@ -694,7 +735,8 @@ public sealed class PlanItClientTests
         PlanItRetryOptions? retryOptions = null,
         PlanItThrottleOptions? throttleOptions = null,
         List<TimeSpan>? delays = null,
-        List<TimeSpan>? throttleDelays = null)
+        List<TimeSpan>? throttleDelays = null,
+        ILogger<PlanItClient>? logger = null)
     {
         var httpClient = new HttpClient(handler, disposeHandler: false)
         {
@@ -718,7 +760,7 @@ public sealed class PlanItClientTests
             };
         }
 
-        return new PlanItClient(httpClient, retryOptions ?? new PlanItRetryOptions(), throttleOptions, delayFunc);
+        return new PlanItClient(httpClient, logger ?? NullLogger<PlanItClient>.Instance, retryOptions ?? new PlanItRetryOptions(), throttleOptions, delayFunc);
     }
 
     private static async Task<List<TownCrier.Domain.PlanningApplications.PlanningApplication>> ConsumeAsync(


### PR DESCRIPTION
## Summary
- Adds a warning log line when PlanIt returns 429, showing whether the delay came from a `Retry-After` header or exponential backoff, plus the actual delay in milliseconds and authority ID
- Adds `ILogger<PlanItClient>` to the client constructor (auto-injected by DI)
- Uses `[LoggerMessage]` source generator for Native AOT compatibility

## Context
Production logs show PlanIt consistently rate-limiting us but we couldn't tell whether the API was sending `Retry-After` headers. Timing analysis suggests it isn't, but this logging will confirm definitively and make future rate-limit debugging much easier.

## Test plan
- [x] New test: `Should_LogRetryAfterSource_When_429ResponseHasRetryAfterHeader`
- [x] New test: `Should_LogBackoffSource_When_429ResponseHasNoRetryAfterHeader`
- [x] All 144 infrastructure tests pass
- [x] Full build succeeds with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced logging for API rate-limit scenarios, providing visibility into retry attempts, calculated delays, and whether delays originate from server headers or exponential backoff algorithms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->