### PR TITLE
fix(api): backfill email on existing user profiles

### DIFF
--- a/api/src/town-crier.application/UserProfiles/CreateUserProfileCommandHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/CreateUserProfileCommandHandler.cs
@@ -23,6 +23,12 @@ public sealed class CreateUserProfileCommandHandler
         var existing = await this.repository.GetByUserIdAsync(command.UserId, ct).ConfigureAwait(false);
         if (existing is not null)
         {
+            if (existing.Email is null && !string.IsNullOrWhiteSpace(command.Email))
+            {
+                existing.BackfillEmail(command.Email);
+                await this.repository.SaveAsync(existing, ct).ConfigureAwait(false);
+            }
+
             return new CreateUserProfileResult(
                 existing.UserId,
                 existing.NotificationPreferences.PushEnabled,

--- a/api/src/town-crier.domain/UserProfiles/UserProfile.cs
+++ b/api/src/town-crier.domain/UserProfiles/UserProfile.cs
@@ -24,7 +24,7 @@ public sealed class UserProfile
 
     public string UserId { get; }
 
-    public string? Email { get; }
+    public string? Email { get; private set; }
 
     public NotificationPreferences NotificationPreferences { get; private set; }
 
@@ -50,6 +50,18 @@ public sealed class UserProfile
             subscriptionExpiry: null,
             originalTransactionId: null,
             gracePeriodExpiry: null);
+    }
+
+    public void BackfillEmail(string email)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(email);
+
+        if (this.Email is not null)
+        {
+            return;
+        }
+
+        this.Email = email;
     }
 
     public void UpdatePreferences(NotificationPreferences notificationPreferences)

--- a/api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/CreateUserProfileCommandHandlerTests.cs
@@ -184,6 +184,45 @@ public sealed class CreateUserProfileCommandHandlerTests
         await Assert.That(result.Tier).IsEqualTo(SubscriptionTier.Free);
     }
 
+    [Test]
+    public async Task Should_BackfillEmail_When_ExistingProfileHasNullEmail()
+    {
+        // Arrange — profile created without email (the bug scenario)
+        var repository = new FakeUserProfileRepository();
+        var handler = new CreateUserProfileCommandHandler(repository, NoAutoGrant());
+        await handler.HandleAsync(
+            new CreateUserProfileCommand("auth0|no-email-user"), CancellationToken.None);
+
+        var before = repository.GetByUserId("auth0|no-email-user");
+        await Assert.That(before!.Email).IsNull();
+
+        // Act — re-register now that the token includes email
+        await handler.HandleAsync(
+            new CreateUserProfileCommand("auth0|no-email-user", "user@example.com"), CancellationToken.None);
+
+        // Assert — email has been backfilled
+        var after = repository.GetByUserId("auth0|no-email-user");
+        await Assert.That(after!.Email).IsEqualTo("user@example.com");
+    }
+
+    [Test]
+    public async Task Should_NotOverwriteEmail_When_ExistingProfileAlreadyHasEmail()
+    {
+        // Arrange — profile created with email
+        var repository = new FakeUserProfileRepository();
+        var handler = new CreateUserProfileCommandHandler(repository, NoAutoGrant());
+        await handler.HandleAsync(
+            new CreateUserProfileCommand("auth0|has-email", "original@example.com"), CancellationToken.None);
+
+        // Act — re-register with a different email
+        await handler.HandleAsync(
+            new CreateUserProfileCommand("auth0|has-email", "different@example.com"), CancellationToken.None);
+
+        // Assert — original email preserved
+        var saved = repository.GetByUserId("auth0|has-email");
+        await Assert.That(saved!.Email).IsEqualTo("original@example.com");
+    }
+
     private static AutoGrantOptions NoAutoGrant() => new();
 
     private static AutoGrantOptions AutoGrantFor(string domains) => new() { ProDomains = domains };


### PR DESCRIPTION
## Changes
- Updated Auth0 post-login Action to include `email` and `email_verified` claims in the access token (deployed via CLI)
- Added `BackfillEmail` method to `UserProfile` domain entity — sets email only when currently null
- Updated `CreateUserProfileCommandHandler` to backfill email on existing profiles when a subsequent registration call provides one
- Added tests for backfill and no-overwrite scenarios

## Root Cause
Auth0 access tokens don't include `email` by default — only the ID token does. The sole Auth0 Action ("Add Subscription Tier Claim") added `subscription_tier` but not `email`. So when `POST /v1/me` extracted claims from the access token, email was always null.

## Test plan
- [x] `Should_BackfillEmail_When_ExistingProfileHasNullEmail` — passes
- [x] `Should_NotOverwriteEmail_When_ExistingProfileAlreadyHasEmail` — passes
- [x] Full application test suite (187 tests) — passes
- [x] Full infra test suite (144 tests) — passes
- [ ] Existing users (`auth0|69cd868e22e8ebfae4899d1a`, `auth0|69d3dfe57b7567753e62be0c`) will get email backfilled on next login

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced user profile email handling to backfill missing email addresses when resubmitting profile information, preventing data loss when email was previously unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->