### PR TITLE
fix(api): capture CLR exceptions in OTel exception pipeline

### DIFF
--- a/api/src/town-crier.web/Observability/ErrorResponseMiddleware.cs
+++ b/api/src/town-crier.web/Observability/ErrorResponseMiddleware.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 
 namespace TownCrier.Web.Observability;
@@ -14,6 +15,9 @@ internal sealed partial class ErrorResponseMiddleware(RequestDelegate next, ILog
         catch (Exception ex)
 #pragma warning restore CA1031
         {
+            Activity.Current?.AddException(ex);
+            Activity.Current?.SetStatus(ActivityStatusCode.Error, ex.Message);
+
             LogUnhandledException(logger, ex, context.Request.Method, context.Request.Path.Value ?? "/");
             context.Items["ErrorDetail"] = ex.Message;
             if (!context.Response.HasStarted)

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -17,8 +17,8 @@ builder.Services.AddOpenTelemetry()
     .WithTracing(tracing =>
     {
         tracing
-            .AddAspNetCoreInstrumentation()
-            .AddHttpClientInstrumentation()
+            .AddAspNetCoreInstrumentation(options => options.RecordException = true)
+            .AddHttpClientInstrumentation(options => options.RecordException = true)
             .AddSource(PollingInstrumentation.ActivitySourceName)
             .AddSource(CosmosInstrumentation.ActivitySourceName);
 

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -131,64 +131,64 @@ var exitCode = 0;
 switch (mode)
 {
     case "poll":
-    {
-        using var activity = PollingInstrumentation.Source.StartActivity("Polling Cycle");
-        try
         {
-            var cycleStart = Stopwatch.GetTimestamp();
+            using var activity = PollingInstrumentation.Source.StartActivity("Polling Cycle");
+            try
+            {
+                var cycleStart = Stopwatch.GetTimestamp();
 
-            WorkerLog.PollCycleStarting(logger);
+                WorkerLog.PollCycleStarting(logger);
 
-            var pollHandler = host.Services.GetRequiredService<PollPlanItCommandHandler>();
-            var result = await pollHandler.HandleAsync(new PollPlanItCommand(), CancellationToken.None)
-                .ConfigureAwait(false);
+                var pollHandler = host.Services.GetRequiredService<PollPlanItCommandHandler>();
+                var result = await pollHandler.HandleAsync(new PollPlanItCommand(), CancellationToken.None)
+                    .ConfigureAwait(false);
 
-            PollingMetrics.CycleDuration.Record(Stopwatch.GetElapsedTime(cycleStart).TotalMilliseconds);
+                PollingMetrics.CycleDuration.Record(Stopwatch.GetElapsedTime(cycleStart).TotalMilliseconds);
 
-            activity?.SetTag("polling.authorities_polled", result.AuthoritiesPolled);
-            activity?.SetTag("polling.applications_ingested", result.ApplicationCount);
+                activity?.SetTag("polling.authorities_polled", result.AuthoritiesPolled);
+                activity?.SetTag("polling.applications_ingested", result.ApplicationCount);
 
-            WorkerLog.PollCycleCompleted(logger, result.ApplicationCount, result.AuthoritiesPolled);
-        }
+                WorkerLog.PollCycleCompleted(logger, result.ApplicationCount, result.AuthoritiesPolled);
+            }
 #pragma warning disable CA1031 // Worker must return exit code on any failure
-        catch (Exception ex)
+            catch (Exception ex)
 #pragma warning restore CA1031
-        {
-            activity?.AddException(ex);
-            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-            PollingMetrics.PollFailures.Add(1);
-            WorkerLog.PollCycleFailed(logger, ex);
-            exitCode = 1;
-        }
+            {
+                activity?.AddException(ex);
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                PollingMetrics.PollFailures.Add(1);
+                WorkerLog.PollCycleFailed(logger, ex);
+                exitCode = 1;
+            }
 
-        break;
-    }
+            break;
+        }
 
     case "digest":
-    {
-        using var digestActivity = PollingInstrumentation.Source.StartActivity("Digest Cycle");
-        try
         {
-            WorkerLog.DigestCycleStarting(logger);
+            using var digestActivity = PollingInstrumentation.Source.StartActivity("Digest Cycle");
+            try
+            {
+                WorkerLog.DigestCycleStarting(logger);
 
-            var digestHandler = host.Services.GetRequiredService<GenerateWeeklyDigestsCommandHandler>();
-            await digestHandler.HandleAsync(new GenerateWeeklyDigestsCommand(), CancellationToken.None)
-                .ConfigureAwait(false);
+                var digestHandler = host.Services.GetRequiredService<GenerateWeeklyDigestsCommandHandler>();
+                await digestHandler.HandleAsync(new GenerateWeeklyDigestsCommand(), CancellationToken.None)
+                    .ConfigureAwait(false);
 
-            WorkerLog.DigestCycleCompleted(logger);
-        }
+                WorkerLog.DigestCycleCompleted(logger);
+            }
 #pragma warning disable CA1031 // Worker must return exit code on any failure
-        catch (Exception ex)
+            catch (Exception ex)
 #pragma warning restore CA1031
-        {
-            digestActivity?.AddException(ex);
-            digestActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-            WorkerLog.DigestCycleFailed(logger, ex);
-            exitCode = 1;
-        }
+            {
+                digestActivity?.AddException(ex);
+                digestActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                WorkerLog.DigestCycleFailed(logger, ex);
+                exitCode = 1;
+            }
 
-        break;
-    }
+            break;
+        }
 
     default:
         WorkerLog.UnknownWorkerMode(logger, mode);

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -35,7 +35,7 @@ builder.Services.AddOpenTelemetry()
     .WithTracing(tracing =>
     {
         tracing
-            .AddHttpClientInstrumentation()
+            .AddHttpClientInstrumentation(options => options.RecordException = true)
             .AddSource(PollingInstrumentation.ActivitySourceName)
             .AddSource(CosmosInstrumentation.ActivitySourceName);
 
@@ -131,9 +131,10 @@ var exitCode = 0;
 switch (mode)
 {
     case "poll":
+    {
+        using var activity = PollingInstrumentation.Source.StartActivity("Polling Cycle");
         try
         {
-            using var activity = PollingInstrumentation.Source.StartActivity("Polling Cycle");
             var cycleStart = Stopwatch.GetTimestamp();
 
             WorkerLog.PollCycleStarting(logger);
@@ -153,14 +154,19 @@ switch (mode)
         catch (Exception ex)
 #pragma warning restore CA1031
         {
+            activity?.AddException(ex);
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             PollingMetrics.PollFailures.Add(1);
             WorkerLog.PollCycleFailed(logger, ex);
             exitCode = 1;
         }
 
         break;
+    }
 
     case "digest":
+    {
+        using var digestActivity = PollingInstrumentation.Source.StartActivity("Digest Cycle");
         try
         {
             WorkerLog.DigestCycleStarting(logger);
@@ -175,11 +181,14 @@ switch (mode)
         catch (Exception ex)
 #pragma warning restore CA1031
         {
+            digestActivity?.AddException(ex);
+            digestActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             WorkerLog.DigestCycleFailed(logger, ex);
             exitCode = 1;
         }
 
         break;
+    }
 
     default:
         WorkerLog.UnknownWorkerMode(logger, mode);


### PR DESCRIPTION
## Changes
- Record exceptions on `Activity.Current` in `ErrorResponseMiddleware` before swallowing them, so the OTel ASP.NET Core exporter sees them
- Restructure worker poll/digest catch blocks to record exceptions on their activity spans via `Activity.AddException`
- Enable `RecordException = true` on `AddAspNetCoreInstrumentation()` and `AddHttpClientInstrumentation()` in both web and worker

Closes: tc-4jt

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced error tracking in middleware and background services for clearer diagnostics.
  * Exceptions are now captured in tracing for HTTP requests, improving end-to-end request traces.
  * Improved visibility and error status reporting across services to speed up issue detection and resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->