### PR TITLE
fix(api): configure OTel resource name and explicit connection string

### DIFF
--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -2,6 +2,7 @@ using Azure.Monitor.OpenTelemetry.Exporter;
 using OpenTelemetry;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using TownCrier.Application.Observability;
 using TownCrier.Infrastructure.Observability;
@@ -10,10 +11,11 @@ using TownCrier.Web.Extensions;
 
 var builder = WebApplication.CreateSlimBuilder(args);
 
-var hasAppInsights = !string.IsNullOrEmpty(
-    builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]);
+var aiConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
+var hasAppInsights = !string.IsNullOrEmpty(aiConnectionString);
 
 builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService("town-crier-web"))
     .WithTracing(tracing =>
     {
         tracing
@@ -24,7 +26,7 @@ builder.Services.AddOpenTelemetry()
 
         if (hasAppInsights)
         {
-            tracing.AddAzureMonitorTraceExporter();
+            tracing.AddAzureMonitorTraceExporter(o => o.ConnectionString = aiConnectionString);
         }
     })
     .WithMetrics(metrics =>
@@ -39,7 +41,7 @@ builder.Services.AddOpenTelemetry()
 
         if (hasAppInsights)
         {
-            metrics.AddAzureMonitorMetricExporter();
+            metrics.AddAzureMonitorMetricExporter(o => o.ConnectionString = aiConnectionString);
         }
     });
 
@@ -47,7 +49,7 @@ builder.Logging.AddOpenTelemetry(logging =>
 {
     if (hasAppInsights)
     {
-        logging.AddAzureMonitorLogExporter();
+        logging.AddAzureMonitorLogExporter(o => o.ConnectionString = aiConnectionString);
     }
 });
 

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using TownCrier.Application.DeviceRegistrations;
 using TownCrier.Application.Notifications;
@@ -28,10 +29,11 @@ using TownCrier.Worker;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-var hasAppInsights = !string.IsNullOrEmpty(
-    builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"]);
+var aiConnectionString = builder.Configuration["APPLICATIONINSIGHTS_CONNECTION_STRING"];
+var hasAppInsights = !string.IsNullOrEmpty(aiConnectionString);
 
 builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService("town-crier-worker"))
     .WithTracing(tracing =>
     {
         tracing
@@ -41,7 +43,7 @@ builder.Services.AddOpenTelemetry()
 
         if (hasAppInsights)
         {
-            tracing.AddAzureMonitorTraceExporter();
+            tracing.AddAzureMonitorTraceExporter(o => o.ConnectionString = aiConnectionString);
         }
     })
     .WithMetrics(metrics =>
@@ -55,7 +57,7 @@ builder.Services.AddOpenTelemetry()
 
         if (hasAppInsights)
         {
-            metrics.AddAzureMonitorMetricExporter();
+            metrics.AddAzureMonitorMetricExporter(o => o.ConnectionString = aiConnectionString);
         }
     });
 


### PR DESCRIPTION
## Changes
- Add `ConfigureResource().AddService()` to set proper service names (`town-crier-web`, `town-crier-worker`) — fixes "unknown_service" cloud_RoleName in App Insights
- Pass connection string explicitly to all Azure Monitor exporters (trace, metric, log) instead of relying on parameterless env var resolution
- Applies to both web API and worker Program.cs

## Context
Resolves empty `requests` and `dependencies` tables in App Insights (tc-pxx). Metrics flowed to `customMetrics` but trace spans were silently dropped — the metric and trace exporters resolved the connection string via different IOptions paths.

---
*Auto-shipped via ship skill*