### PR TITLE
feat(api): add round-robin polling with stop-on-429

### DIFF
--- a/api/src/town-crier.application/Polling/IPollStateStore.cs
+++ b/api/src/town-crier.application/Polling/IPollStateStore.cs
@@ -7,4 +7,8 @@ public interface IPollStateStore
     Task SaveLastPollTimeAsync(int authorityId, DateTimeOffset pollTime, CancellationToken ct);
 
     Task DeleteGlobalPollStateAsync(CancellationToken ct);
+
+    Task<IReadOnlyList<int>> GetLeastRecentlyPolledAsync(
+        IReadOnlyList<int> candidateAuthorityIds,
+        CancellationToken ct);
 }

--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -42,11 +42,14 @@ public sealed partial class PollPlanItCommandHandler
     public async Task<PollPlanItResult> HandleAsync(PollPlanItCommand command, CancellationToken ct)
     {
         var now = this.timeProvider.GetUtcNow();
-        var authorityIds = await this.activeAuthorityProvider.GetActiveAuthorityIdsAsync(ct).ConfigureAwait(false);
+        var activeIds = await this.activeAuthorityProvider.GetActiveAuthorityIdsAsync(ct).ConfigureAwait(false);
+        var sortedIds = await this.pollStateStore.GetLeastRecentlyPolledAsync(
+            activeIds.ToList(), ct).ConfigureAwait(false);
 
         var count = 0;
         var authoritiesPolled = 0;
-        foreach (var authorityId in authorityIds)
+        var rateLimited = false;
+        foreach (var authorityId in sortedIds)
         {
             using var authorityActivity = PollingInstrumentation.Source.StartActivity("Poll Authority");
             authorityActivity?.SetTag("polling.authority_code", authorityId);
@@ -90,7 +93,8 @@ public sealed partial class PollPlanItCommandHandler
                 PollingMetrics.AuthoritiesSkipped.Add(1);
                 PollingMetrics.RateLimited.Add(1);
                 PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
-                LogRateLimitBreak(this.logger, authorityId, ex);
+                rateLimited = true;
+                LogRateLimitStop(this.logger, authorityId, ex);
                 break;
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -103,11 +107,11 @@ public sealed partial class PollPlanItCommandHandler
 
         await this.pollStateStore.DeleteGlobalPollStateAsync(ct).ConfigureAwait(false);
 
-        return new PollPlanItResult(count, authoritiesPolled);
+        return new PollPlanItResult(count, authoritiesPolled, rateLimited);
     }
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Rate limited polling authority {AuthorityId}, stopping polling cycle")]
-    private static partial void LogRateLimitBreak(ILogger logger, int authorityId, Exception exception);
+    private static partial void LogRateLimitStop(ILogger logger, int authorityId, Exception exception);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Error polling authority {AuthorityId}, skipping to next authority")]
     private static partial void LogAuthorityError(ILogger logger, int authorityId, Exception exception);

--- a/api/src/town-crier.application/Polling/PollPlanItResult.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItResult.cs
@@ -1,3 +1,3 @@
 namespace TownCrier.Application.Polling;
 
-public sealed record PollPlanItResult(int ApplicationCount, int AuthoritiesPolled);
+public sealed record PollPlanItResult(int ApplicationCount, int AuthoritiesPolled, bool RateLimited);

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
@@ -33,6 +33,7 @@ namespace TownCrier.Infrastructure.Cosmos;
 [JsonSerializable(typeof(List<UserProfileDocument>))]
 [JsonSerializable(typeof(DecisionAlertDocument))]
 [JsonSerializable(typeof(PollStateDocument))]
+[JsonSerializable(typeof(List<PollStateDocument>))]
 [JsonSerializable(typeof(CosmosQueryBody))]
 [JsonSerializable(typeof(string))]
 internal sealed partial class CosmosJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Polling/CosmosPollStateStore.cs
+++ b/api/src/town-crier.infrastructure/Polling/CosmosPollStateStore.cs
@@ -61,6 +61,34 @@ public sealed class CosmosPollStateStore : IPollStateStore
             ct).ConfigureAwait(false);
     }
 
+    public async Task<IReadOnlyList<int>> GetLeastRecentlyPolledAsync(
+        IReadOnlyList<int> candidateAuthorityIds,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(candidateAuthorityIds);
+
+        if (candidateAuthorityIds.Count == 0)
+        {
+            return [];
+        }
+
+        var docs = await this.client.QueryAsync(
+            CosmosContainerNames.PollState,
+            "SELECT * FROM c WHERE c.authorityId != null",
+            parameters: null,
+            partitionKey: null,
+            CosmosJsonSerializerContext.Default.PollStateDocument,
+            ct).ConfigureAwait(false);
+
+        var polledSet = docs.ToDictionary(d => d.AuthorityId, d => d.LastPollTime);
+
+        // Never-polled authorities first, then by oldest lastPollTime
+        return candidateAuthorityIds
+            .OrderBy(id => polledSet.ContainsKey(id) ? 1 : 0)
+            .ThenBy(id => polledSet.TryGetValue(id, out var time) ? time : string.Empty)
+            .ToList();
+    }
+
     private static string FormatDocumentId(int authorityId)
     {
         return string.Create(CultureInfo.InvariantCulture, $"poll-state-{authorityId}");

--- a/api/src/town-crier.infrastructure/Polling/CosmosPollStateStore.cs
+++ b/api/src/town-crier.infrastructure/Polling/CosmosPollStateStore.cs
@@ -74,7 +74,7 @@ public sealed class CosmosPollStateStore : IPollStateStore
 
         var docs = await this.client.QueryAsync(
             CosmosContainerNames.PollState,
-            "SELECT * FROM c WHERE c.authorityId != null",
+            "SELECT * FROM c WHERE STARTSWITH(c.id, 'poll-state-')",
             parameters: null,
             partitionKey: null,
             CosmosJsonSerializerContext.Default.PollStateDocument,
@@ -85,7 +85,7 @@ public sealed class CosmosPollStateStore : IPollStateStore
         // Never-polled authorities first, then by oldest lastPollTime
         return candidateAuthorityIds
             .OrderBy(id => polledSet.ContainsKey(id) ? 1 : 0)
-            .ThenBy(id => polledSet.TryGetValue(id, out var time) ? time : string.Empty)
+            .ThenBy(id => polledSet.TryGetValue(id, out var time) ? DateTimeOffset.Parse(time, CultureInfo.InvariantCulture) : DateTimeOffset.MinValue)
             .ToList();
     }
 

--- a/api/src/town-crier.infrastructure/Polling/PollStateDocument.cs
+++ b/api/src/town-crier.infrastructure/Polling/PollStateDocument.cs
@@ -6,5 +6,5 @@ internal sealed class PollStateDocument
 
     public required string LastPollTime { get; init; }
 
-    public int? AuthorityId { get; init; }
+    public required int AuthorityId { get; init; }
 }

--- a/api/tests/town-crier.application.tests/Polling/FakePollStateStore.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakePollStateStore.cs
@@ -38,4 +38,15 @@ internal sealed class FakePollStateStore : IPollStateStore
         this.DeleteGlobalCalled = true;
         return Task.CompletedTask;
     }
+
+    public Task<IReadOnlyList<int>> GetLeastRecentlyPolledAsync(
+        IReadOnlyList<int> candidateAuthorityIds,
+        CancellationToken ct)
+    {
+        IReadOnlyList<int> sorted = candidateAuthorityIds
+            .OrderBy(id => this.pollTimes.ContainsKey(id) ? 1 : 0)
+            .ThenBy(id => this.pollTimes.TryGetValue(id, out var time) ? time : DateTimeOffset.MinValue)
+            .ToList();
+        return Task.FromResult(sorted);
+    }
 }

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -6,6 +6,8 @@ namespace TownCrier.Application.Tests.Polling;
 
 public sealed class PollPlanItCommandHandlerTests
 {
+    private static readonly int[] ExpectedRoundRobinOrder = [300, 100, 200];
+
     [Test]
     public async Task Should_ReturnApplicationCount_When_PlanItReturnsApplications()
     {
@@ -389,8 +391,8 @@ public sealed class PollPlanItCommandHandlerTests
         authorityProvider.Add(200);
 
         var pollStateStore = new FakePollStateStore();
-        var authority100Time = new DateTimeOffset(2026, 4, 4, 10, 0, 0, TimeSpan.Zero);
-        var authority200Time = new DateTimeOffset(2026, 4, 3, 8, 0, 0, TimeSpan.Zero);
+        var authority100Time = new DateTimeOffset(2026, 4, 3, 8, 0, 0, TimeSpan.Zero);
+        var authority200Time = new DateTimeOffset(2026, 4, 4, 10, 0, 0, TimeSpan.Zero);
         pollStateStore.SetLastPollTime(100, authority100Time);
         pollStateStore.SetLastPollTime(200, authority200Time);
 
@@ -437,6 +439,97 @@ public sealed class PollPlanItCommandHandlerTests
         await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
 
         await Assert.That(pollStateStore.DeleteGlobalCalled).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_StopAndSetRateLimited_When_429Hit()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+        authorityProvider.Add(300);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.ThrowForAuthority(200, new HttpRequestException("Rate limited", null, HttpStatusCode.TooManyRequests));
+        planItClient.Add(300, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(300).Build());
+
+        var handler = CreateHandler(planItClient: planItClient, authorityProvider: authorityProvider);
+
+        var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        // Authority 100 completed, 200 triggered 429, 300 never attempted
+        await Assert.That(result.ApplicationCount).IsEqualTo(1);
+        await Assert.That(result.AuthoritiesPolled).IsEqualTo(1);
+        await Assert.That(result.RateLimited).IsTrue();
+        await Assert.That(planItClient.AuthorityIdsRequested).DoesNotContain(300);
+    }
+
+    [Test]
+    public async Task Should_NotSetRateLimited_When_NoRateLimitHit()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+
+        var handler = CreateHandler(planItClient: planItClient, authorityProvider: authorityProvider);
+
+        var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(result.RateLimited).IsFalse();
+    }
+
+    [Test]
+    public async Task Should_PollLeastRecentlyPolledFirst_When_MultipleAuthorities()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+        authorityProvider.Add(300);
+
+        var pollStateStore = new FakePollStateStore();
+
+        // Authority 300 polled longest ago, 200 most recently, 100 in between
+        pollStateStore.SetLastPollTime(300, new DateTimeOffset(2026, 4, 1, 0, 0, 0, TimeSpan.Zero));
+        pollStateStore.SetLastPollTime(100, new DateTimeOffset(2026, 4, 3, 0, 0, 0, TimeSpan.Zero));
+        pollStateStore.SetLastPollTime(200, new DateTimeOffset(2026, 4, 5, 0, 0, 0, TimeSpan.Zero));
+
+        var planItClient = new FakePlanItClient();
+
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            pollStateStore: pollStateStore,
+            authorityProvider: authorityProvider);
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        // Should be polled in order: 300 (oldest), 100, 200 (newest)
+        await Assert.That(planItClient.AuthorityIdsRequested).IsEquivalentTo(ExpectedRoundRobinOrder);
+    }
+
+    [Test]
+    public async Task Should_PollNeverPolledAuthorityFirst_When_MixedPollState()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+
+        var pollStateStore = new FakePollStateStore();
+        pollStateStore.SetLastPollTime(100, new DateTimeOffset(2026, 4, 5, 0, 0, 0, TimeSpan.Zero));
+
+        var planItClient = new FakePlanItClient();
+
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            pollStateStore: pollStateStore,
+            authorityProvider: authorityProvider);
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        // Never-polled authority 200 should be first
+        await Assert.That(planItClient.AuthorityIdsRequested[0]).IsEqualTo(200);
     }
 
     private static PollPlanItCommandHandler CreateHandler(

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -6,8 +6,6 @@ namespace TownCrier.Application.Tests.Polling;
 
 public sealed class PollPlanItCommandHandlerTests
 {
-    private static readonly int[] ExpectedRoundRobinOrder = [300, 100, 200];
-
     [Test]
     public async Task Should_ReturnApplicationCount_When_PlanItReturnsApplications()
     {
@@ -506,7 +504,10 @@ public sealed class PollPlanItCommandHandlerTests
         await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
 
         // Should be polled in order: 300 (oldest), 100, 200 (newest)
-        await Assert.That(planItClient.AuthorityIdsRequested).IsEquivalentTo(ExpectedRoundRobinOrder);
+        await Assert.That(planItClient.AuthorityIdsRequested).HasCount().EqualTo(3);
+        await Assert.That(planItClient.AuthorityIdsRequested[0]).IsEqualTo(300);
+        await Assert.That(planItClient.AuthorityIdsRequested[1]).IsEqualTo(100);
+        await Assert.That(planItClient.AuthorityIdsRequested[2]).IsEqualTo(200);
     }
 
     [Test]


### PR DESCRIPTION
## Changes
- Add `GetLeastRecentlyPolledAsync` to `IPollStateStore` for least-recently-polled ordering
- Scope Cosmos poll state query to per-authority docs (avoid legacy global document)
- Rewrite poll handler to use round-robin ordering and return `RateLimited` flag on result
- Add 4 new tests for ordering and rate-limit behavior, fix ordered assertion

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Polling now prioritizes authorities that have not been polled recently, improving request distribution and fairness across services.
  * Rate-limiting detection is now tracked and reported in polling results, providing visibility into service throttling events.

* **Bug Fixes**
  * Improved handling of rate-limit responses to prevent continued polling of throttled services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->