### PR TITLE
fix(web): handle profile loading errors in OnboardingGate

### DIFF
--- a/web/src/auth/OnboardingGate.tsx
+++ b/web/src/auth/OnboardingGate.tsx
@@ -1,21 +1,40 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Outlet, Navigate } from 'react-router-dom';
 import { FullPageLoader } from '../components/FullPageLoader/FullPageLoader.tsx';
+import { FullPageError } from '../components/FullPageError/FullPageError.tsx';
 import { useProfileRepository } from './profile-context.ts';
+import { useAuth } from './auth-context.ts';
 
-type GateState = 'loading' | 'has-profile' | 'needs-onboarding';
+type GateState = 'loading' | 'has-profile' | 'needs-onboarding' | 'error';
 
 export function OnboardingGate() {
   const repository = useProfileRepository();
+  const { logout } = useAuth();
   const [state, setState] = useState<GateState>('loading');
+
+  const loadProfile = useCallback(async () => {
+    setState('loading');
+    try {
+      const profile = await repository.fetchProfile();
+      setState(profile ? 'has-profile' : 'needs-onboarding');
+    } catch {
+      setState('error');
+    }
+  }, [repository]);
 
   useEffect(() => {
     let cancelled = false;
 
     async function check() {
-      const profile = await repository.fetchProfile();
-      if (!cancelled) {
-        setState(profile ? 'has-profile' : 'needs-onboarding');
+      try {
+        const profile = await repository.fetchProfile();
+        if (!cancelled) {
+          setState(profile ? 'has-profile' : 'needs-onboarding');
+        }
+      } catch {
+        if (!cancelled) {
+          setState('error');
+        }
       }
     }
 
@@ -25,6 +44,16 @@ export function OnboardingGate() {
 
   if (state === 'loading') {
     return <FullPageLoader message="Loading your profile…" />;
+  }
+
+  if (state === 'error') {
+    return (
+      <FullPageError
+        message="We couldn't load your profile. This can happen when your session has expired."
+        onRetry={loadProfile}
+        onSignOut={logout}
+      />
+    );
   }
 
   if (state === 'needs-onboarding') {

--- a/web/src/auth/__tests__/OnboardingGate.test.tsx
+++ b/web/src/auth/__tests__/OnboardingGate.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { ProfileRepositoryProvider } from '../profile-context.ts';
+import { AuthProvider } from '../auth-context.ts';
 import { OnboardingGate } from '../OnboardingGate.tsx';
 import { SpyProfileRepository } from './spies/spy-profile-repository.ts';
+import type { AuthPort } from '../../domain/ports/auth-port.ts';
 import type { UserProfile } from '../../domain/types.ts';
 
 const existingProfile: UserProfile = {
@@ -12,17 +14,30 @@ const existingProfile: UserProfile = {
   tier: 'Free',
 };
 
-function renderWithProfile(spy: SpyProfileRepository) {
+function stubAuth(overrides?: Partial<AuthPort>): AuthPort {
+  return {
+    isAuthenticated: true,
+    isLoading: false,
+    error: undefined,
+    loginWithRedirect: async () => {},
+    logout: async () => {},
+    ...overrides,
+  };
+}
+
+function renderWithProfile(spy: SpyProfileRepository, auth: AuthPort = stubAuth()) {
   return render(
     <MemoryRouter initialEntries={['/app']}>
-      <ProfileRepositoryProvider value={spy}>
-        <Routes>
-          <Route element={<OnboardingGate />}>
-            <Route path="/app" element={<div>Dashboard</div>} />
-          </Route>
-          <Route path="/onboarding" element={<div>Onboarding</div>} />
-        </Routes>
-      </ProfileRepositoryProvider>
+      <AuthProvider value={auth}>
+        <ProfileRepositoryProvider value={spy}>
+          <Routes>
+            <Route element={<OnboardingGate />}>
+              <Route path="/app" element={<div>Dashboard</div>} />
+            </Route>
+            <Route path="/onboarding" element={<div>Onboarding</div>} />
+          </Routes>
+        </ProfileRepositoryProvider>
+      </AuthProvider>
     </MemoryRouter>,
   );
 }
@@ -65,5 +80,20 @@ describe('OnboardingGate', () => {
     expect(screen.queryByText('Onboarding')).not.toBeInTheDocument();
     expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.getByText('Loading your profile…')).toBeInTheDocument();
+  });
+
+  it('shows error state when fetchProfile throws', async () => {
+    const spy = new SpyProfileRepository();
+    spy.fetchProfileError = new Error('token refresh failed');
+
+    renderWithProfile(spy);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByText('Try again')).toBeInTheDocument();
+    expect(screen.getByText('Sign out')).toBeInTheDocument();
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/FullPageError/FullPageError.module.css
+++ b/web/src/components/FullPageError/FullPageError.module.css
@@ -1,0 +1,51 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100vh;
+  background: var(--tc-background);
+  padding: var(--tc-space-xl);
+  text-align: center;
+}
+
+.title {
+  font-size: var(--tc-text-display-small);
+  font-weight: var(--tc-weight-semibold);
+  color: var(--tc-text-primary);
+  margin-bottom: var(--tc-space-md);
+}
+
+.message {
+  font-size: var(--tc-text-body);
+  color: var(--tc-text-secondary);
+  margin-bottom: var(--tc-space-lg);
+  max-width: 400px;
+}
+
+.actions {
+  display: flex;
+  gap: var(--tc-space-md);
+}
+
+.retryButton {
+  padding: var(--tc-space-sm) var(--tc-space-lg);
+  background: var(--tc-amber);
+  color: var(--tc-text-on-accent);
+  border: none;
+  border-radius: var(--tc-radius-md);
+  font-size: var(--tc-text-body);
+  font-weight: var(--tc-weight-medium);
+  cursor: pointer;
+}
+
+.signOutButton {
+  padding: var(--tc-space-sm) var(--tc-space-lg);
+  background: transparent;
+  color: var(--tc-text-secondary);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  font-size: var(--tc-text-body);
+  font-weight: var(--tc-weight-medium);
+  cursor: pointer;
+}

--- a/web/src/components/FullPageError/FullPageError.tsx
+++ b/web/src/components/FullPageError/FullPageError.tsx
@@ -1,0 +1,24 @@
+import styles from './FullPageError.module.css';
+
+interface Props {
+  message: string;
+  onRetry: () => void;
+  onSignOut: () => void;
+}
+
+export function FullPageError({ message, onRetry, onSignOut }: Props) {
+  return (
+    <div className={styles.container} role="alert">
+      <h1 className={styles.title}>Something went wrong</h1>
+      <p className={styles.message}>{message}</p>
+      <div className={styles.actions}>
+        <button className={styles.retryButton} onClick={onRetry}>
+          Try again
+        </button>
+        <button className={styles.signOutButton} onClick={onSignOut}>
+          Sign out
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Changes
- Add try/catch error handling to `OnboardingGate` — if `fetchProfile()` throws (e.g. Safari ITP blocking Auth0 silent auth), show an error page with retry/sign-out instead of an infinite spinner
- Add `FullPageError` component with retry and sign-out actions
- Add test for error state in OnboardingGate
- Wrap test render helper with `AuthProvider` (newly required by the component)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced error handling with a full-page error screen displayed when profile loading fails.
  * Added recovery options: users can retry the operation or sign out directly from the error screen.

* **Tests**
  * Expanded test coverage to include error state scenarios and error recovery flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->