### PR TITLE
fix(web): fix legal page blank screen and Window.fetch error

### DIFF
--- a/web/src/components/Footer/Footer.tsx
+++ b/web/src/components/Footer/Footer.tsx
@@ -25,8 +25,8 @@ export function Footer() {
           </p>
 
           <nav aria-label="Legal" className={styles.legal}>
-            <a href="/privacy" className={styles.legalLink}>Privacy Policy</a>
-            <a href="/terms" className={styles.legalLink}>Terms of Service</a>
+            <a href="/legal/privacy" className={styles.legalLink}>Privacy Policy</a>
+            <a href="/legal/terms" className={styles.legalLink}>Terms of Service</a>
           </nav>
         </div>
       </div>

--- a/web/src/components/Footer/__tests__/Footer.test.tsx
+++ b/web/src/components/Footer/__tests__/Footer.test.tsx
@@ -40,7 +40,7 @@ describe('Footer', () => {
 
     const link = screen.getByRole('link', { name: /privacy policy/i });
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('href', '/privacy');
+    expect(link).toHaveAttribute('href', '/legal/privacy');
   });
 
   it('renders a Terms of Service link', () => {
@@ -48,7 +48,7 @@ describe('Footer', () => {
 
     const link = screen.getByRole('link', { name: /terms of service/i });
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute('href', '/terms');
+    expect(link).toHaveAttribute('href', '/legal/terms');
   });
 
   it('renders legal links inside a nav element for accessibility', () => {

--- a/web/src/features/legal/ApiLegalDocumentPort.ts
+++ b/web/src/features/legal/ApiLegalDocumentPort.ts
@@ -5,7 +5,7 @@ export class ApiLegalDocumentPort implements LegalDocumentPort {
   private readonly baseUrl: string;
   private readonly fetchFn: typeof globalThis.fetch;
 
-  constructor(baseUrl: string, fetchFn: typeof globalThis.fetch = globalThis.fetch) {
+  constructor(baseUrl: string, fetchFn: typeof globalThis.fetch = globalThis.fetch.bind(globalThis)) {
     this.baseUrl = baseUrl;
     this.fetchFn = fetchFn;
   }


### PR DESCRIPTION
## Changes
- Fix Footer links: `/privacy` → `/legal/privacy`, `/terms` → `/legal/terms` (routes didn't match, causing blank screen on splash page)
- Bind `globalThis.fetch` in `ApiLegalDocumentPort` to fix "Can only call Window.fetch on instances of Window" error on logged-in legal pages
- Update Footer tests to match corrected routes

---
*Auto-shipped via ship skill*