### PR TITLE
fix(api): save partial poll progress and emit metrics on mid-pagination 429

### DIFF
--- a/.github/actions/acr-build-push/action.yml
+++ b/.github/actions/acr-build-push/action.yml
@@ -1,0 +1,45 @@
+# Logs into Azure Container Registry, builds a Docker image, and pushes
+# it tagged with both the commit SHA and "latest".
+#
+# Assumes azure/login has already been called in an earlier step.
+name: ACR Build & Push
+description: Login to ACR, build a Docker image, and push with SHA + latest tags
+
+inputs:
+  acr-login-server:
+    description: ACR login server (e.g., myregistry.azurecr.io)
+    required: true
+  image-name:
+    description: Image name without registry prefix (e.g., town-crier-api)
+    required: true
+  dockerfile:
+    description: Dockerfile path relative to working-directory (e.g., Dockerfile, Dockerfile.worker)
+    required: false
+    default: Dockerfile
+  working-directory:
+    description: Build context directory
+    required: false
+    default: "."
+  tag:
+    description: Primary image tag (defaults to github.sha)
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Login to ACR
+      shell: bash
+      run: az acr login --name "${{ inputs.acr-login-server }}"
+
+    - name: Build and push image
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        TAG="${{ inputs.tag }}"
+        TAG="${TAG:-${{ github.sha }}}"
+        IMAGE="${{ inputs.acr-login-server }}/${{ inputs.image-name }}:${TAG}"
+        LATEST="${{ inputs.acr-login-server }}/${{ inputs.image-name }}:latest"
+        docker build -f "${{ inputs.dockerfile }}" -t "$IMAGE" -t "$LATEST" .
+        docker push "$IMAGE"
+        docker push "$LATEST"

--- a/.github/actions/deploy-container-app/action.yml
+++ b/.github/actions/deploy-container-app/action.yml
@@ -1,0 +1,52 @@
+# Deploys a new image to an Azure Container App, then deactivates the
+# previously-active revision to keep the revision list clean.
+#
+# Assumes azure/login has already been called in an earlier step.
+name: Deploy Container App
+description: Update a Container App with a new image and deactivate the old revision
+
+inputs:
+  app-name:
+    description: Container App name (e.g., ca-town-crier-api-dev)
+    required: true
+  resource-group:
+    description: Azure resource group
+    required: true
+  image:
+    description: Full image reference including tag (e.g., myregistry.azurecr.io/app:sha)
+    required: true
+
+outputs:
+  old-revision:
+    description: The revision that was deactivated (empty if none)
+    value: ${{ steps.old-revision.outputs.revision }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get current active revision
+      id: old-revision
+      shell: bash
+      run: |
+        REV=$(az containerapp ingress traffic show \
+          --name "${{ inputs.app-name }}" \
+          --resource-group "${{ inputs.resource-group }}" \
+          --query "[?weight==\`100\`].revisionName | [0]" -o tsv)
+        echo "revision=$REV" >> "$GITHUB_OUTPUT"
+
+    - name: Deploy new image
+      shell: bash
+      run: |
+        az containerapp update \
+          --name "${{ inputs.app-name }}" \
+          --resource-group "${{ inputs.resource-group }}" \
+          --image "${{ inputs.image }}"
+
+    - name: Deactivate old revision
+      if: steps.old-revision.outputs.revision != ''
+      shell: bash
+      run: |
+        az containerapp revision deactivate \
+          --name "${{ inputs.app-name }}" \
+          --resource-group "${{ inputs.resource-group }}" \
+          --revision "${{ steps.old-revision.outputs.revision }}" || true

--- a/.github/actions/deploy-worker-jobs/action.yml
+++ b/.github/actions/deploy-worker-jobs/action.yml
@@ -1,0 +1,33 @@
+# Updates all Container App Jobs for the worker with a new image.
+# Iterates over the standard job names (poll, digest) with the
+# naming convention job-town-crier-{name}-{env-suffix}.
+#
+# Assumes azure/login has already been called in an earlier step.
+name: Deploy Worker Jobs
+description: Update all worker Container App Jobs with a new image
+
+inputs:
+  env-suffix:
+    description: Environment suffix for job names (e.g., dev, prod)
+    required: true
+  resource-group:
+    description: Azure resource group
+    required: true
+  image:
+    description: Full image reference including tag
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Deploy worker image to all jobs
+      shell: bash
+      run: |
+        for JOB in poll digest; do
+          echo "::group::Deploying to job-town-crier-${JOB}-${{ inputs.env-suffix }}"
+          az containerapp job update \
+            --name "job-town-crier-${JOB}-${{ inputs.env-suffix }}" \
+            --resource-group "${{ inputs.resource-group }}" \
+            --image "${{ inputs.image }}"
+          echo "::endgroup::"
+        done

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -113,16 +113,11 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Login to ACR
-        run: az acr login --name ${{ secrets.ACR_LOGIN_SERVER }}
-
-      - name: Build and push image
-        run: |
-          IMAGE="${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}"
-          docker build -t "$IMAGE" -t "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:latest" .
-          docker push "$IMAGE"
-          docker push "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:latest"
-        working-directory: api
+      - uses: ./.github/actions/acr-build-push
+        with:
+          acr-login-server: ${{ secrets.ACR_LOGIN_SERVER }}
+          image-name: town-crier-api
+          working-directory: api
 
   # ── Worker: build & push image ──────────────────────────
   worker-image:
@@ -139,16 +134,12 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Login to ACR
-        run: az acr login --name ${{ secrets.ACR_LOGIN_SERVER }}
-
-      - name: Build and push worker image
-        run: |
-          IMAGE="${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:${{ github.sha }}"
-          docker build -f Dockerfile.worker -t "$IMAGE" -t "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:latest" .
-          docker push "$IMAGE"
-          docker push "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:latest"
-        working-directory: api
+      - uses: ./.github/actions/acr-build-push
+        with:
+          acr-login-server: ${{ secrets.ACR_LOGIN_SERVER }}
+          image-name: town-crier-worker
+          dockerfile: Dockerfile.worker
+          working-directory: api
 
   # ── API: deploy to dev ──────────────────────────────
   api-deploy:
@@ -166,29 +157,11 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Get current active revision
-        id: old-revision
-        run: |
-          REV=$(az containerapp ingress traffic show \
-            --name ca-town-crier-api-dev \
-            --resource-group rg-town-crier-dev \
-            --query "[?weight==\`100\`].revisionName | [0]" -o tsv)
-          echo "revision=$REV" >> "$GITHUB_OUTPUT"
-
-      - name: Deploy to Container App
-        run: |
-          az containerapp update \
-            --name "ca-town-crier-api-dev" \
-            --resource-group "rg-town-crier-dev" \
-            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}"
-
-      - name: Deactivate old revision
-        if: steps.old-revision.outputs.revision != ''
-        run: |
-          az containerapp revision deactivate \
-            --name ca-town-crier-api-dev \
-            --resource-group rg-town-crier-dev \
-            --revision "${{ steps.old-revision.outputs.revision }}" || true
+      - uses: ./.github/actions/deploy-container-app
+        with:
+          app-name: ca-town-crier-api-dev
+          resource-group: rg-town-crier-dev
+          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}
 
   # ── Worker: deploy to dev ───────────────────────────────
   worker-deploy:
@@ -206,17 +179,11 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Deploy worker image to all jobs
-        run: |
-          IMAGE="${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:${{ github.sha }}"
-          for JOB in poll digest; do
-            echo "::group::Deploying to job-town-crier-${JOB}-dev"
-            az containerapp job update \
-              --name "job-town-crier-${JOB}-dev" \
-              --resource-group "rg-town-crier-dev" \
-              --image "$IMAGE"
-            echo "::endgroup::"
-          done
+      - uses: ./.github/actions/deploy-worker-jobs
+        with:
+          env-suffix: dev
+          resource-group: rg-town-crier-dev
+          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:${{ github.sha }}
 
   # ── Web: deploy to dev ──────────────────────────────
   web-deploy:

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -120,35 +120,11 @@ jobs:
             exit 1
           fi
 
-      - name: Get current active revision
-        id: old-revision
-        run: |
-          REV=$(az containerapp ingress traffic show \
-            --name ca-town-crier-api-prod \
-            --resource-group "$RESOURCE_GROUP" \
-            --query "[?weight==\`100\`].revisionName | [0]" -o tsv)
-          echo "revision=$REV" >> "$GITHUB_OUTPUT"
-        env:
-          RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
-
-      - name: Deploy API image to prod
-        run: |
-          az containerapp update \
-            --name "ca-town-crier-api-prod" \
-            --resource-group "$RESOURCE_GROUP" \
-            --image "${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ steps.check-image.outputs.tag }}"
-        env:
-          RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
-
-      - name: Deactivate old revision
-        if: steps.old-revision.outputs.revision != ''
-        run: |
-          az containerapp revision deactivate \
-            --name ca-town-crier-api-prod \
-            --resource-group "$RESOURCE_GROUP" \
-            --revision "${{ steps.old-revision.outputs.revision }}" || true
-        env:
-          RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
+      - uses: ./.github/actions/deploy-container-app
+        with:
+          app-name: ca-town-crier-api-prod
+          resource-group: ${{ needs.infra.outputs.resource-group }}
+          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ steps.check-image.outputs.tag }}
 
   # ── Worker ───────────────────────────────────────────────
   worker:
@@ -193,19 +169,11 @@ jobs:
             exit 1
           fi
 
-      - name: Deploy worker image to all jobs
-        run: |
-          IMAGE="${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:${{ steps.check-image.outputs.tag }}"
-          for JOB in poll digest; do
-            echo "::group::Deploying to job-town-crier-${JOB}-prod"
-            az containerapp job update \
-              --name "job-town-crier-${JOB}-prod" \
-              --resource-group "$RESOURCE_GROUP" \
-              --image "$IMAGE"
-            echo "::endgroup::"
-          done
-        env:
-          RESOURCE_GROUP: ${{ needs.infra.outputs.resource-group }}
+      - uses: ./.github/actions/deploy-worker-jobs
+        with:
+          env-suffix: prod
+          resource-group: ${{ needs.infra.outputs.resource-group }}
+          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:${{ steps.check-image.outputs.tag }}
 
   # ── Web ───────────────────────────────────────────────
   web:

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,5 @@ email-notifications/
 .claude/skills/*-workspace/
 .claude/worktrees/autopilot-tc-k2v/
 .claude/worktrees/autopilot-tc-2v1/
+.claude/worktrees/autopilot-tc-xd8/
+.claude/worktrees/autopilot-tc-c6i/

--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -55,12 +55,15 @@ public sealed partial class PollPlanItCommandHandler
             authorityActivity?.SetTag("polling.authority_code", authorityId);
             var authorityStart = Stopwatch.GetTimestamp();
 
+            var authorityAppCount = 0;
+            DateTimeOffset? highWaterMark = null;
+            var completedSuccessfully = false;
+
             try
             {
                 var lastPollTime = await this.pollStateStore.GetLastPollTimeAsync(authorityId, ct).ConfigureAwait(false);
                 lastPollTime ??= now.AddDays(-30);
 
-                var authorityAppCount = 0;
                 await foreach (var application in this.planItClient.FetchApplicationsAsync(authorityId, lastPollTime, ct).ConfigureAwait(false))
                 {
                     await this.applicationRepository.UpsertAsync(application, ct).ConfigureAwait(false);
@@ -77,31 +80,45 @@ public sealed partial class PollPlanItCommandHandler
                     }
 
                     authorityAppCount++;
+
+                    if (application.LastDifferent > (highWaterMark ?? DateTimeOffset.MinValue))
+                    {
+                        highWaterMark = application.LastDifferent;
+                    }
                 }
 
-                PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
-                authorityActivity?.SetTag("polling.applications_found", authorityAppCount);
-
-                await this.pollStateStore.SaveLastPollTimeAsync(authorityId, now, ct).ConfigureAwait(false);
-                PollingMetrics.AuthoritiesPolled.Add(1);
-                PollingMetrics.ApplicationsIngested.Add(authorityAppCount);
-                authoritiesPolled++;
-                count += authorityAppCount;
+                completedSuccessfully = true;
             }
             catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
             {
-                PollingMetrics.AuthoritiesSkipped.Add(1);
                 PollingMetrics.RateLimited.Add(1);
-                PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
                 rateLimited = true;
                 LogRateLimitStop(this.logger, authorityId, ex);
-                break;
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                PollingMetrics.AuthoritiesSkipped.Add(1);
-                PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
                 LogAuthorityError(this.logger, authorityId, ex);
+            }
+
+            PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
+            authorityActivity?.SetTag("polling.applications_found", authorityAppCount);
+
+            if (completedSuccessfully || authorityAppCount > 0)
+            {
+                PollingMetrics.AuthoritiesPolled.Add(1);
+                PollingMetrics.ApplicationsIngested.Add(authorityAppCount);
+                await this.pollStateStore.SaveLastPollTimeAsync(authorityId, highWaterMark ?? now, ct).ConfigureAwait(false);
+                authoritiesPolled++;
+                count += authorityAppCount;
+            }
+            else
+            {
+                PollingMetrics.AuthoritiesSkipped.Add(1);
+            }
+
+            if (rateLimited)
+            {
+                break;
             }
         }
 

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -97,7 +97,7 @@ public sealed class PlanItClient : IPlanItClient
 
     private static string BuildUrl(int authorityId, DateTimeOffset? differentStart, int page)
     {
-        var url = $"/api/applics/json?pg_sz={DefaultPageSize}&sort=-last_different&page={page}&auth={authorityId}";
+        var url = $"/api/applics/json?pg_sz={DefaultPageSize}&sort=last_different&page={page}&auth={authorityId}";
 
         if (differentStart.HasValue)
         {

--- a/api/tests/town-crier.application.tests/Polling/FakePlanItClient.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakePlanItClient.cs
@@ -7,6 +7,7 @@ internal sealed class FakePlanItClient : IPlanItClient
 {
     private readonly Dictionary<int, List<PlanningApplication>> applicationsByAuthority = [];
     private readonly Dictionary<int, Exception> exceptionsByAuthority = [];
+    private readonly Dictionary<int, (int Count, Exception Exception)> throwAfterYieldingByAuthority = [];
     private readonly List<PlanningApplication> searchResults = [];
 
     public DateTimeOffset? LastDifferentStartUsed { get; private set; }
@@ -37,6 +38,11 @@ internal sealed class FakePlanItClient : IPlanItClient
     public void ThrowForAuthority(int authorityId, Exception exception)
     {
         this.exceptionsByAuthority[authorityId] = exception;
+    }
+
+    public void ThrowAfterYielding(int authorityId, int count, Exception exception)
+    {
+        this.throwAfterYieldingByAuthority[authorityId] = (count, exception);
     }
 
     public void Add(int authorityId, PlanningApplication application)
@@ -81,9 +87,17 @@ internal sealed class FakePlanItClient : IPlanItClient
 
         if (this.applicationsByAuthority.TryGetValue(authorityId, out var applications))
         {
+            var yielded = 0;
             foreach (var app in applications)
             {
+                if (this.throwAfterYieldingByAuthority.TryGetValue(authorityId, out var rule)
+                    && yielded >= rule.Count)
+                {
+                    throw rule.Exception;
+                }
+
                 yield return app;
+                yielded++;
             }
         }
 

--- a/api/tests/town-crier.application.tests/Polling/PlanningApplicationBuilder.cs
+++ b/api/tests/town-crier.application.tests/Polling/PlanningApplicationBuilder.cs
@@ -8,7 +8,7 @@ internal sealed class PlanningApplicationBuilder
     private readonly string? postcode = "SW1A 1AA";
     private readonly string description = "Test planning application";
     private readonly string appType = "Full";
-    private readonly DateTimeOffset lastDifferent = DateTimeOffset.UtcNow;
+    private DateTimeOffset lastDifferent = DateTimeOffset.UtcNow;
     private string areaName = "Test Council";
     private int areaId = 1;
     private string name = "Test Application";
@@ -51,6 +51,12 @@ internal sealed class PlanningApplicationBuilder
     {
         this.latitude = latitude;
         this.longitude = longitude;
+        return this;
+    }
+
+    public PlanningApplicationBuilder WithLastDifferent(DateTimeOffset lastDifferent)
+    {
+        this.lastDifferent = lastDifferent;
         return this;
     }
 

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -533,6 +533,124 @@ public sealed class PollPlanItCommandHandlerTests
         await Assert.That(planItClient.AuthorityIdsRequested[0]).IsEqualTo(200);
     }
 
+    [Test]
+    public async Task Should_SavePollState_When_429HitAfterSomeApplicationsIngested()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+
+        var planItClient = new FakePlanItClient();
+        var app1 = new PlanningApplicationBuilder()
+            .WithUid("app-1").WithAreaId(100)
+            .WithLastDifferent(new DateTimeOffset(2026, 3, 10, 0, 0, 0, TimeSpan.Zero))
+            .Build();
+        var app2 = new PlanningApplicationBuilder()
+            .WithUid("app-2").WithAreaId(100)
+            .WithLastDifferent(new DateTimeOffset(2026, 3, 12, 0, 0, 0, TimeSpan.Zero))
+            .Build();
+        var app3 = new PlanningApplicationBuilder()
+            .WithUid("app-3").WithAreaId(100)
+            .WithLastDifferent(new DateTimeOffset(2026, 3, 14, 0, 0, 0, TimeSpan.Zero))
+            .Build();
+        planItClient.Add(100, app1);
+        planItClient.Add(100, app2);
+        planItClient.Add(100, app3);
+        planItClient.ThrowAfterYielding(
+            100,
+            2,
+            new HttpRequestException("Rate limited", null, HttpStatusCode.TooManyRequests));
+
+        var pollStateStore = new FakePollStateStore();
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            pollStateStore: pollStateStore,
+            authorityProvider: authorityProvider);
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(pollStateStore.GetLastPollTimeFor(100)).IsNotNull();
+        await Assert.That(pollStateStore.SaveCallCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_EmitApplicationsIngested_When_429HitMidPagination()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-2").WithAreaId(100).Build());
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(100).Build());
+        planItClient.ThrowAfterYielding(
+            100,
+            2,
+            new HttpRequestException("Rate limited", null, HttpStatusCode.TooManyRequests));
+
+        var handler = CreateHandler(planItClient: planItClient, authorityProvider: authorityProvider);
+
+        var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(result.ApplicationCount).IsEqualTo(2);
+        await Assert.That(result.RateLimited).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_EmitAuthoritiesPolled_When_429HitMidPagination()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-2").WithAreaId(100).Build());
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(100).Build());
+        planItClient.ThrowAfterYielding(
+            100,
+            2,
+            new HttpRequestException("Rate limited", null, HttpStatusCode.TooManyRequests));
+
+        var handler = CreateHandler(planItClient: planItClient, authorityProvider: authorityProvider);
+
+        var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(result.AuthoritiesPolled).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_AdvanceToNextAuthority_When_PreviousAuthorityPartiallyCompleted()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        authorityProvider.Add(200);
+
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-2").WithAreaId(100).Build());
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(100).Build());
+
+        // Mid-pagination 429 on authority 100 after 2 apps
+        planItClient.ThrowAfterYielding(
+            100,
+            2,
+            new HttpRequestException("Rate limited", null, HttpStatusCode.TooManyRequests));
+        planItClient.Add(200, new PlanningApplicationBuilder().WithUid("app-4").WithAreaId(200).Build());
+
+        var pollStateStore = new FakePollStateStore();
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            pollStateStore: pollStateStore,
+            authorityProvider: authorityProvider);
+
+        var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(result.ApplicationCount).IsEqualTo(2);
+
+        await Assert.That(pollStateStore.GetLastPollTimeFor(100)).IsNotNull();
+
+        await Assert.That(result.RateLimited).IsTrue();
+    }
+
     private static PollPlanItCommandHandler CreateHandler(
         FakePlanItClient? planItClient = null,
         FakePollStateStore? pollStateStore = null,

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -240,18 +240,21 @@ public sealed class PollPlanItCommandHandlerTests
         authorityProvider.Add(200);
         authorityProvider.Add(300);
 
+        var app100LastDifferent = new DateTimeOffset(2026, 4, 4, 10, 0, 0, TimeSpan.Zero);
+        var app300LastDifferent = new DateTimeOffset(2026, 4, 4, 14, 0, 0, TimeSpan.Zero);
+
         var planItClient = new FakePlanItClient();
-        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
-        planItClient.Add(300, new PlanningApplicationBuilder().WithUid("app-3").WithAreaId(300).Build());
+        planItClient.Add(100, new PlanningApplicationBuilder()
+            .WithUid("app-1").WithAreaId(100).WithLastDifferent(app100LastDifferent).Build());
+        planItClient.Add(300, new PlanningApplicationBuilder()
+            .WithUid("app-3").WithAreaId(300).WithLastDifferent(app300LastDifferent).Build());
         planItClient.ThrowForAuthority(200, new HttpRequestException("rate limited"));
 
         var pollStateStore = new FakePollStateStore();
-        var fakeTime = new DateTimeOffset(2026, 4, 5, 12, 0, 0, TimeSpan.Zero);
         var handler = CreateHandler(
             planItClient: planItClient,
             pollStateStore: pollStateStore,
-            authorityProvider: authorityProvider,
-            timeProvider: new FakeTimeProvider(fakeTime));
+            authorityProvider: authorityProvider);
 
         var result = await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
 
@@ -259,8 +262,8 @@ public sealed class PollPlanItCommandHandlerTests
         await Assert.That(result.ApplicationCount).IsEqualTo(2);
         await Assert.That(result.AuthoritiesPolled).IsEqualTo(2);
         await Assert.That(pollStateStore.SaveCallCount).IsEqualTo(2);
-        await Assert.That(pollStateStore.GetLastPollTimeFor(100)).IsEqualTo(fakeTime);
-        await Assert.That(pollStateStore.GetLastPollTimeFor(300)).IsEqualTo(fakeTime);
+        await Assert.That(pollStateStore.GetLastPollTimeFor(100)).IsEqualTo(app100LastDifferent);
+        await Assert.That(pollStateStore.GetLastPollTimeFor(300)).IsEqualTo(app300LastDifferent);
         await Assert.That(pollStateStore.GetLastPollTimeFor(200)).IsNull();
     }
 
@@ -394,21 +397,21 @@ public sealed class PollPlanItCommandHandlerTests
         pollStateStore.SetLastPollTime(100, authority100Time);
         pollStateStore.SetLastPollTime(200, authority200Time);
 
-        var now = new DateTimeOffset(2026, 4, 5, 12, 0, 0, TimeSpan.Zero);
+        var app100LastDifferent = new DateTimeOffset(2026, 4, 5, 10, 0, 0, TimeSpan.Zero);
         var planItClient = new FakePlanItClient();
-        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        planItClient.Add(100, new PlanningApplicationBuilder()
+            .WithUid("app-1").WithAreaId(100).WithLastDifferent(app100LastDifferent).Build());
         planItClient.ThrowForAuthority(200, new HttpRequestException("Rate limited", null, HttpStatusCode.TooManyRequests));
 
         var handler = CreateHandler(
             planItClient: planItClient,
             pollStateStore: pollStateStore,
-            authorityProvider: authorityProvider,
-            timeProvider: new FakeTimeProvider(now));
+            authorityProvider: authorityProvider);
 
         await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
 
-        // Authority 100 should be advanced to now
-        await Assert.That(pollStateStore.GetLastPollTimeFor(100)).IsEqualTo(now);
+        // Authority 100 should be advanced to high-water mark
+        await Assert.That(pollStateStore.GetLastPollTimeFor(100)).IsEqualTo(app100LastDifferent);
 
         // Authority 200 should retain its original poll time (rate limited, not advanced)
         await Assert.That(pollStateStore.GetLastPollTimeFor(200)).IsEqualTo(authority200Time);

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -407,6 +407,37 @@ public sealed class PlanItClientTests
     }
 
     [Test]
+    public async Task Should_UseAscendingSortOrder_When_FetchingApplicationsForPolling()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupJsonResponse("page=1", EmptyResponse);
+        var client = CreateClient(handler);
+
+        // Act
+        await ConsumeAsync(client, differentStart: null, authorityId: 292);
+
+        // Assert — polling uses ascending sort for resumable progress
+        await Assert.That(handler.RequestUrls[0]).Contains("sort=last_different");
+        await Assert.That(handler.RequestUrls[0]).DoesNotContain("sort=-last_different");
+    }
+
+    [Test]
+    public async Task Should_UseDescendingSortOrder_When_SearchingApplications()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupJsonResponse("/api/applics/json", SingleRecordResponse);
+        var client = CreateClient(handler);
+
+        // Act
+        await client.SearchApplicationsAsync("car park", 314, 1, CancellationToken.None);
+
+        // Assert — search uses descending sort (newest first)
+        await Assert.That(handler.RequestUrls[0]).Contains("sort=-last_different");
+    }
+
+    [Test]
     public async Task Should_DefaultToEmptyString_When_DescriptionIsNull()
     {
         // Arrange

--- a/docs/specs/polling-partial-progress.md
+++ b/docs/specs/polling-partial-progress.md
@@ -1,0 +1,120 @@
+# Polling Partial Progress and Metrics Accuracy
+
+Date: 2026-04-09
+
+## Problem
+
+The poll handler treats per-authority pagination as atomic: either all pages succeed (save poll state + emit metrics) or nothing is recorded. But `FetchApplicationsAsync` is a streaming `IAsyncEnumerable` where a 429 exception propagates out of the `await foreach` on page N, after pages 1 through N-1 have already been upserted to Cosmos.
+
+### Observed impact (production, 2026-04-09)
+
+- Authority 52 is polled every 15 minutes, fetching ~800-1200 applications over ~48 seconds across 8-12 pages before hitting a 429
+- Applications ARE written to Cosmos (~18,800 RU per cycle) but `authorities_polled` and `applications_ingested` metrics never emit
+- `SaveLastPollTimeAsync` never fires, so `GetLeastRecentlyPolledAsync` returns authority 52 every cycle (groundhog day)
+- Dashboard correctly shows zero sync successes / zero applications ingested — the metrics are accurate reflections of a code bug, not a metrics pipeline problem
+
+### Root cause
+
+```
+try {
+    await foreach (app in FetchApplicationsAsync...)    // 429 thrown mid-iteration
+        upsert(app)                                      // ~800 apps already written
+
+    SavePollState(authorityId, now)                      // never reached
+    AuthoritiesPolled.Add(1)                             // never reached
+    ApplicationsIngested.Add(authorityAppCount)          // never reached
+}
+catch (429) {
+    AuthoritiesSkipped.Add(1)
+    break
+}
+```
+
+### Three compounding issues
+
+1. **Groundhog day** — poll state never advances, so the same authority is retried with the same date range every cycle
+2. **Invisible work** — ~800 apps upserted per cycle with zero metric emission
+3. **No test coverage** — `FakePlanItClient.ThrowForAuthority` throws before yielding anything; mid-pagination 429s are untested
+
+## Design
+
+### Change 1: Switch polling to ascending sort order
+
+Currently: `sort=-last_different` (descending — newest first). With a mid-pagination 429 on page 8, we've processed pages 1-7 (the newest 700 apps) and missed the oldest tail. There's no good resume point.
+
+Change to: `sort=last_different` (ascending — oldest first). Now pages 1-7 contain the oldest 700 apps. The high-water mark (latest `LastDifferent` from what we processed) is a precise resume point — next cycle picks up exactly where we left off.
+
+**Verified**: PlanIt supports ascending sort. Tested with `sort=last_different` on authority 52 — returns 6,722 results in chronological order with correct pagination.
+
+The search endpoint stays `sort=-last_different` (descending) — only the polling URL changes.
+
+### Change 2: Track high-water mark and save partial progress
+
+Track the latest `LastDifferent` from ingested applications as they stream through. After the loop — whether it completes normally, 429s, or errors — if any applications were ingested, save the high-water mark as poll state.
+
+With ascending sort, the high-water mark precisely represents "where we got to" in chronological order.
+
+### Change 3: Restructure handler — metrics fire regardless of exit path
+
+Move metrics and poll-state logic out of the success-only path:
+
+```
+for each authority:
+    authorityAppCount = 0
+    highWaterMark = null
+
+    try:
+        foreach app in FetchApplicationsAsync(...):
+            upsert(app)
+            notify(app)
+            authorityAppCount++
+            highWaterMark = max(highWaterMark, app.LastDifferent)
+    catch 429:
+        RateLimited.Add(1)
+        rateLimited = true
+    catch other:
+        log error
+
+    // Always record duration
+    AuthorityProcessingDuration.Record(elapsed)
+
+    // Record actual work done (partial or full)
+    if authorityAppCount > 0:
+        AuthoritiesPolled.Add(1)
+        ApplicationsIngested.Add(authorityAppCount)
+        SavePollState(authorityId, highWaterMark)
+    else:
+        AuthoritiesSkipped.Add(1)
+
+    if rateLimited: break
+```
+
+### Change 4: Extend FakePlanItClient for mid-pagination failures
+
+Add `ThrowAfterYielding(authorityId, count, exception)` — yields `count` applications then throws. New test cases:
+
+- `Should_SavePollState_When_429HitAfterSomeApplicationsIngested`
+- `Should_EmitApplicationsIngested_When_429HitMidPagination`
+- `Should_ResumeFromHighWaterMark_When_PreviousCycleWasPartial`
+- `Should_AdvanceToNextAuthority_When_PreviousAuthorityPartiallyCompleted`
+
+## Implementation order
+
+1. Add `ThrowAfterYielding` to `FakePlanItClient`
+2. Write failing tests for partial-progress scenarios (red)
+3. Restructure handler with high-water mark tracking (green)
+4. Switch `sort=-last_different` to `sort=last_different` in polling URL only
+5. Verify all existing tests still pass
+
+## Future follow-up
+
+**Continue to next authority on 429** — currently any 429 breaks the entire authority loop. We could save partial progress and attempt the next authority, breaking only after N consecutive 429s (heuristic for global rate limit). Separate bead.
+
+## Expected impact
+
+| Scenario | Before | After |
+|---|---|---|
+| Mid-pagination 429 (current prod) | Re-fetches same 800 apps forever, 0 metrics | Advances past them, accurate counts |
+| First-request 429 (no apps fetched) | Skipped, no poll state change | Same — skip, no change |
+| Full success | Save `now`, emit metrics | Save high-water mark, emit metrics |
+| Catchup from 30-day lookback | Processes newest first, gets stuck on 429 | Processes oldest first, resumes on 429 |

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -41,7 +41,6 @@ public static class EnvironmentStack
         var shared = new StackReference("AmyDe/town-crier/shared");
         var acrLoginServer = shared.GetOutput("containerRegistryLoginServer").Apply(o => o?.ToString() ?? "");
         var acrPullIdentityId = shared.GetOutput("acrPullIdentityId").Apply(o => o?.ToString() ?? "");
-        var acrPullIdentityClientId = shared.GetOutput("acrPullIdentityClientId").Apply(o => o?.ToString() ?? "");
         var containerAppsEnvironmentId = shared.GetOutput("containerAppsEnvironmentId").Apply(o => o?.ToString() ?? "");
         var cosmosDataIdentityId = shared.GetOutput("cosmosDataIdentityId").Apply(o => o?.ToString() ?? "");
         var cosmosDataIdentityClientId = shared.GetOutput("cosmosDataIdentityClientId").Apply(o => o?.ToString() ?? "");

--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -313,7 +313,6 @@ public static class SharedStack
             ["resourceGroupName"] = resourceGroup.Name,
             ["containerRegistryLoginServer"] = containerRegistry.LoginServer,
             ["acrPullIdentityId"] = acrPullIdentity.Id,
-            ["acrPullIdentityClientId"] = acrPullIdentity.ClientId,
             ["cosmosDataIdentityId"] = cosmosDataIdentity.Id,
             ["cosmosDataIdentityClientId"] = cosmosDataIdentity.ClientId,
             ["containerAppsEnvironmentId"] = containerAppsEnv.Id,

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/StatusBadgeView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/StatusBadgeView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import TownCrierDomain
+
+/// A compact capsule badge showing the icon, label, and color for a planning application status.
+///
+/// Uses the design system's `tcCaptionEmphasis` typography and the semantic `tcStatus*` colors
+/// with a 15% opacity background, following the design language specification for status badges.
+struct StatusBadgeView: View {
+    let status: ApplicationStatus
+
+    var body: some View {
+        HStack(spacing: TCSpacing.extraSmall) {
+            Image(systemName: status.displayIcon)
+            Text(status.displayLabel)
+        }
+        .font(TCTypography.captionEmphasis)
+        .foregroundStyle(status.displayColor)
+        .padding(.horizontal, TCSpacing.small)
+        .padding(.vertical, TCSpacing.extraSmall)
+        .background(status.displayColor.opacity(0.15))
+        .clipShape(Capsule())
+    }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
@@ -17,7 +17,7 @@ public struct ApplicationDetailView: View {
     public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: TCSpacing.large) {
-                statusBadge
+                StatusBadgeView(status: viewModel.status)
 
                 Text(viewModel.description)
                     .font(TCTypography.displaySmall)
@@ -52,21 +52,6 @@ public struct ApplicationDetailView: View {
             }
         }
         #endif
-    }
-
-    // MARK: - Status Badge
-
-    private var statusBadge: some View {
-        HStack(spacing: TCSpacing.extraSmall) {
-            Image(systemName: viewModel.statusIcon)
-            Text(viewModel.statusLabel)
-        }
-        .font(TCTypography.captionEmphasis)
-        .foregroundStyle(statusColor)
-        .padding(.horizontal, TCSpacing.small)
-        .padding(.vertical, TCSpacing.extraSmall)
-        .background(statusColor.opacity(0.15))
-        .clipShape(Capsule())
     }
 
     // MARK: - Detail Card
@@ -117,11 +102,6 @@ public struct ApplicationDetailView: View {
         }
     }
 
-    // MARK: - Status Color
-
-    private var statusColor: Color {
-        viewModel.status.displayColor
-    }
 }
 
 #if os(iOS)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListRow.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListRow.swift
@@ -8,7 +8,7 @@ struct ApplicationListRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: TCSpacing.small) {
             HStack {
-                statusBadge
+                StatusBadgeView(status: application.status)
                 Spacer()
                 Text(application.receivedDate.formattedForDisplay)
                     .font(TCTypography.caption)
@@ -28,30 +28,4 @@ struct ApplicationListRow: View {
         .padding(.vertical, TCSpacing.small)
     }
 
-    // MARK: - Status Badge
-
-    private var statusBadge: some View {
-        HStack(spacing: TCSpacing.extraSmall) {
-            Image(systemName: statusIcon)
-            Text(statusLabel)
-        }
-        .font(TCTypography.captionEmphasis)
-        .foregroundStyle(statusColor)
-        .padding(.horizontal, TCSpacing.small)
-        .padding(.vertical, TCSpacing.extraSmall)
-        .background(statusColor.opacity(0.15))
-        .clipShape(Capsule())
-    }
-
-    private var statusLabel: String {
-        application.status.displayLabel
-    }
-
-    private var statusIcon: String {
-        application.status.displayIcon
-    }
-
-    private var statusColor: Color {
-        application.status.displayColor
-    }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -3,11 +3,11 @@ import TownCrierDomain
 
 /// ViewModel driving the filterable list of planning applications.
 @MainActor
-public final class ApplicationListViewModel: ObservableObject {
+public final class ApplicationListViewModel: ObservableObject, ErrorHandlingViewModel {
     @Published private(set) var applications: [PlanningApplication] = []
     @Published var selectedStatusFilter: ApplicationStatus?
     @Published private(set) var isLoading = false
-    @Published private(set) var error: DomainError?
+    @Published var error: DomainError?
 
     private let repository: PlanningApplicationRepository?
     private let offlineRepository: OfflineAwareRepository?
@@ -75,10 +75,8 @@ public final class ApplicationListViewModel: ObservableObject {
                 fetched = []
             }
             applications = fetched.sorted { $0.receivedDate > $1.receivedDate }
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .unexpected(error.localizedDescription)
+            handleError(error)
         }
         isLoading = false
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ErrorHandlingViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ErrorHandlingViewModel.swift
@@ -1,0 +1,33 @@
+import TownCrierDomain
+
+/// A protocol for ViewModels that handle errors by setting a `DomainError?` property.
+///
+/// Provides a shared `handleError(_:fallback:)` method that eliminates the
+/// repeated catch boilerplate across ViewModels:
+///
+/// ```swift
+/// } catch {
+///     handleError(error)
+/// }
+/// ```
+///
+/// When the caught error is already a `DomainError`, it is assigned directly.
+/// Otherwise, the `fallback` closure wraps the localised description into
+/// the appropriate `DomainError` case (defaulting to `.unexpected`).
+@MainActor
+protocol ErrorHandlingViewModel: AnyObject {
+    var error: DomainError? { get set }
+}
+
+extension ErrorHandlingViewModel {
+    func handleError(
+        _ error: Error,
+        fallback: (String) -> DomainError = { .unexpected($0) }
+    ) {
+        if let domainError = error as? DomainError {
+            self.error = domainError
+        } else {
+            self.error = fallback(error.localizedDescription)
+        }
+    }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Login/LoginViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Login/LoginViewModel.swift
@@ -3,9 +3,9 @@ import TownCrierDomain
 
 /// ViewModel managing login, logout, and session restoration.
 @MainActor
-public final class LoginViewModel: ObservableObject {
+public final class LoginViewModel: ObservableObject, ErrorHandlingViewModel {
     @Published public private(set) var isLoading = false
-    @Published public private(set) var error: DomainError?
+    @Published public internal(set) var error: DomainError?
     @Published public private(set) var session: AuthSession?
 
     private let authService: AuthenticationService
@@ -24,10 +24,8 @@ public final class LoginViewModel: ObservableObject {
         error = nil
         do {
             session = try await authService.login()
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .authenticationFailed(error.localizedDescription)
+            handleError(error) { .authenticationFailed($0) }
         }
         isLoading = false
     }
@@ -38,10 +36,8 @@ public final class LoginViewModel: ObservableObject {
         do {
             try await authService.logout()
             session = nil
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .logoutFailed(error.localizedDescription)
+            handleError(error) { .logoutFailed($0) }
         }
     }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ApplicationSummarySheet.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ApplicationSummarySheet.swift
@@ -8,7 +8,7 @@ struct ApplicationSummarySheet: View {
     var body: some View {
         VStack(alignment: .leading, spacing: TCSpacing.medium) {
             HStack {
-                statusBadge
+                StatusBadgeView(status: application.status)
                 Spacer()
                 Text(application.reference.value)
                     .font(.system(.caption))
@@ -34,28 +34,4 @@ struct ApplicationSummarySheet: View {
         .presentationDragIndicator(.visible)
     }
 
-    private var statusBadge: some View {
-        HStack(spacing: TCSpacing.extraSmall) {
-            Image(systemName: statusIcon)
-            Text(statusLabel)
-        }
-        .font(.system(.caption, weight: .medium))
-        .foregroundStyle(statusColor)
-        .padding(.horizontal, TCSpacing.small)
-        .padding(.vertical, TCSpacing.extraSmall)
-        .background(statusColor.opacity(0.15))
-        .clipShape(Capsule())
-    }
-
-    private var statusColor: Color {
-        application.status.displayColor
-    }
-
-    private var statusLabel: String {
-        application.status.displayLabel
-    }
-
-    private var statusIcon: String {
-        application.status.displayIcon
-    }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
@@ -3,10 +3,10 @@ import TownCrierDomain
 
 /// ViewModel driving the map view with planning application pins.
 @MainActor
-public final class MapViewModel: ObservableObject {
+public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
     @Published private(set) var annotations: [MapAnnotationItem] = []
     @Published private(set) var isLoading = false
-    @Published private(set) var error: DomainError?
+    @Published var error: DomainError?
     @Published private(set) var selectedApplication: PlanningApplication?
     @Published private(set) var hasLoaded = false
 
@@ -69,10 +69,8 @@ public final class MapViewModel: ObservableObject {
                 guard let location = app.location else { return nil }
                 return MapAnnotationItem(application: app, coordinate: location)
             }
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .unexpected(error.localizedDescription)
+            handleError(error)
         }
         isLoading = false
         hasLoaded = true

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
@@ -11,11 +11,11 @@ public enum OnboardingStep: CaseIterable, Equatable, Sendable {
 
 /// Drives the onboarding flow: welcome → postcode entry → radius picker → notification permission → complete.
 @MainActor
-public final class OnboardingViewModel: ObservableObject {
+public final class OnboardingViewModel: ObservableObject, ErrorHandlingViewModel {
     @Published public private(set) var currentStep: OnboardingStep = .welcome
     @Published public var postcodeInput: String = ""
     @Published public private(set) var isLoading = false
-    @Published public private(set) var error: DomainError?
+    @Published public internal(set) var error: DomainError?
     @Published public private(set) var validatedPostcode: Postcode?
     @Published public private(set) var geocodedCoordinate: Coordinate?
     @Published public var selectedRadiusMetres: Double = 1000
@@ -75,12 +75,8 @@ public final class OnboardingViewModel: ObservableObject {
         let postcode: Postcode
         do {
             postcode = try Postcode(postcodeInput)
-        } catch let domainError as DomainError {
-            error = domainError
-            isLoading = false
-            return
         } catch {
-            self.error = .unexpected(error.localizedDescription)
+            handleError(error)
             isLoading = false
             return
         }
@@ -89,10 +85,8 @@ public final class OnboardingViewModel: ObservableObject {
             validatedPostcode = postcode
             geocodedCoordinate = try await geocoder.geocode(postcode)
             currentStep = .radiusPicker
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .unexpected(error.localizedDescription)
+            handleError(error)
         }
 
         isLoading = false

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
@@ -4,14 +4,14 @@ import TownCrierDomain
 
 /// ViewModel managing the settings and account screen.
 @MainActor
-public final class SettingsViewModel: ObservableObject {
+public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
     @Published public private(set) var userEmail: String?
     @Published public private(set) var userName: String?
     @Published public private(set) var authMethod: AuthMethod?
     @Published public private(set) var subscriptionTier: SubscriptionTier = .free
     @Published public private(set) var isTrialPeriod = false
     @Published public private(set) var isLoading = false
-    @Published public private(set) var error: DomainError?
+    @Published public internal(set) var error: DomainError?
     @Published public var isShowingDeleteConfirmation = false
 
     public var onLogout: (() -> Void)?
@@ -88,10 +88,8 @@ public final class SettingsViewModel: ObservableObject {
             try await authService.logout()
             clearSession()
             onLogout?()
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .logoutFailed(error.localizedDescription)
+            handleError(error) { .logoutFailed($0) }
         }
     }
 
@@ -111,10 +109,8 @@ public final class SettingsViewModel: ObservableObject {
             try await authService.deleteAccount()
             clearSession()
             onLogout?()
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .unexpected(error.localizedDescription)
+            handleError(error)
         }
     }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionViewModel.swift
@@ -3,12 +3,12 @@ import TownCrierDomain
 
 /// ViewModel managing subscription product display, purchasing, and restoration.
 @MainActor
-public final class SubscriptionViewModel: ObservableObject {
+public final class SubscriptionViewModel: ObservableObject, ErrorHandlingViewModel {
     @Published public private(set) var products: [SubscriptionProduct] = []
     @Published public private(set) var isLoading = false
     @Published public private(set) var isPurchasing = false
     @Published public private(set) var isRestoring = false
-    @Published public private(set) var error: DomainError?
+    @Published public internal(set) var error: DomainError?
     @Published public private(set) var currentEntitlement: SubscriptionEntitlement?
 
     private let subscriptionService: SubscriptionService
@@ -28,10 +28,8 @@ public final class SubscriptionViewModel: ObservableObject {
         do {
             products = try await subscriptionService.availableProducts()
             currentEntitlement = await subscriptionService.currentEntitlement()
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .unexpected(error.localizedDescription)
+            handleError(error)
         }
         isLoading = false
     }
@@ -44,10 +42,8 @@ public final class SubscriptionViewModel: ObservableObject {
             currentEntitlement = try await subscriptionService.purchase(productId)
         } catch DomainError.purchaseCancelled {
             // User cancelled — not an error
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .purchaseFailed(error.localizedDescription)
+            handleError(error) { .purchaseFailed($0) }
         }
         isPurchasing = false
     }
@@ -58,10 +54,8 @@ public final class SubscriptionViewModel: ObservableObject {
         error = nil
         do {
             currentEntitlement = try await subscriptionService.restorePurchases()
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .restoreFailed(error.localizedDescription)
+            handleError(error) { .restoreFailed($0) }
         }
         isRestoring = false
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
@@ -4,12 +4,12 @@ import TownCrierDomain
 
 /// Drives create/edit of a single watch zone with postcode geocoding and tier-based radius limits.
 @MainActor
-public final class WatchZoneEditorViewModel: ObservableObject {
+public final class WatchZoneEditorViewModel: ObservableObject, ErrorHandlingViewModel {
     @Published public var postcodeInput: String = ""
     @Published public var selectedRadiusMetres: Double = 1000
     @Published public private(set) var geocodedCoordinate: Coordinate?
     @Published public private(set) var isLoading = false
-    @Published public private(set) var error: DomainError?
+    @Published public internal(set) var error: DomainError?
 
     var onSave: ((WatchZone) -> Void)?
 
@@ -50,22 +50,16 @@ public final class WatchZoneEditorViewModel: ObservableObject {
         let postcode: Postcode
         do {
             postcode = try Postcode(postcodeInput)
-        } catch let domainError as DomainError {
-            error = domainError
-            isLoading = false
-            return
         } catch {
-            self.error = .unexpected(error.localizedDescription)
+            handleError(error)
             isLoading = false
             return
         }
 
         do {
             geocodedCoordinate = try await geocoder.geocode(postcode)
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .unexpected(error.localizedDescription)
+            handleError(error)
         }
 
         isLoading = false
@@ -94,10 +88,8 @@ public final class WatchZoneEditorViewModel: ObservableObject {
             )
             try await repository.save(zone)
             onSave?(zone)
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .unexpected(error.localizedDescription)
+            handleError(error)
         }
     }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListViewModel.swift
@@ -4,10 +4,10 @@ import TownCrierDomain
 
 /// Manages the list of user's watch zones with tier-based limits.
 @MainActor
-public final class WatchZoneListViewModel: ObservableObject {
+public final class WatchZoneListViewModel: ObservableObject, ErrorHandlingViewModel {
     @Published public private(set) var zones: [WatchZone] = []
     @Published public private(set) var isLoading = false
-    @Published public private(set) var error: DomainError?
+    @Published public internal(set) var error: DomainError?
     @Published public private(set) var currentTier: SubscriptionTier = .free
 
     var onAddZone: (() -> Void)?
@@ -42,10 +42,8 @@ public final class WatchZoneListViewModel: ObservableObject {
 
         do {
             zones = try await repository.loadAll()
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .unexpected(error.localizedDescription)
+            handleError(error)
         }
 
         isLoading = false
@@ -56,10 +54,8 @@ public final class WatchZoneListViewModel: ObservableObject {
         do {
             try await repository.delete(zone.id)
             zones.removeAll { $0.id == zone.id }
-        } catch let domainError as DomainError {
-            error = domainError
         } catch {
-            self.error = .unexpected(error.localizedDescription)
+            handleError(error)
         }
     }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/ErrorHandlingViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ErrorHandlingViewModelTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 import TownCrierDomain
 
@@ -35,8 +36,8 @@ struct ErrorHandlingViewModelTests {
 
     @Test func handleError_withGenericError_usesUnexpectedFallback() {
         let sut = TestViewModel()
-        struct SomeError: Error, CustomStringConvertible {
-            var description: String { "boom" }
+        struct SomeError: Error, LocalizedError {
+            var errorDescription: String? { "boom" }
         }
 
         sut.handleError(SomeError())
@@ -48,8 +49,8 @@ struct ErrorHandlingViewModelTests {
 
     @Test func handleError_withGenericError_usesCustomFallback() {
         let sut = TestViewModel()
-        struct SomeError: Error, CustomStringConvertible {
-            var description: String { "network" }
+        struct SomeError: Error, LocalizedError {
+            var errorDescription: String? { "network" }
         }
 
         sut.handleError(SomeError()) { .authenticationFailed($0) }

--- a/mobile/ios/town-crier-tests/Sources/Features/ErrorHandlingViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ErrorHandlingViewModelTests.swift
@@ -1,0 +1,70 @@
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@Suite("ErrorHandlingViewModel")
+@MainActor
+struct ErrorHandlingViewModelTests {
+
+    // MARK: - Test helper conforming to the protocol
+
+    final class TestViewModel: ErrorHandlingViewModel {
+        var error: DomainError?
+    }
+
+    // MARK: - handleError with DomainError
+
+    @Test func handleError_withDomainError_setsErrorDirectly() {
+        let sut = TestViewModel()
+
+        sut.handleError(DomainError.networkUnavailable)
+
+        #expect(sut.error == .networkUnavailable)
+    }
+
+    @Test func handleError_withDomainError_ignoresFallback() {
+        let sut = TestViewModel()
+
+        sut.handleError(DomainError.sessionExpired) { .unexpected($0) }
+
+        #expect(sut.error == .sessionExpired)
+    }
+
+    // MARK: - handleError with non-DomainError (default fallback)
+
+    @Test func handleError_withGenericError_usesUnexpectedFallback() {
+        let sut = TestViewModel()
+        struct SomeError: Error, CustomStringConvertible {
+            var description: String { "boom" }
+        }
+
+        sut.handleError(SomeError())
+
+        #expect(sut.error == .unexpected("boom"))
+    }
+
+    // MARK: - handleError with non-DomainError (custom fallback)
+
+    @Test func handleError_withGenericError_usesCustomFallback() {
+        let sut = TestViewModel()
+        struct SomeError: Error, CustomStringConvertible {
+            var description: String { "network" }
+        }
+
+        sut.handleError(SomeError()) { .authenticationFailed($0) }
+
+        #expect(sut.error == .authenticationFailed("network"))
+    }
+
+    // MARK: - Overwrites previous error
+
+    @Test func handleError_overwritesPreviousError() {
+        let sut = TestViewModel()
+        sut.error = .networkUnavailable
+
+        sut.handleError(DomainError.sessionExpired)
+
+        #expect(sut.error == .sessionExpired)
+    }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/StatusBadgeViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/StatusBadgeViewTests.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@Suite("StatusBadgeView")
+@MainActor
+struct StatusBadgeViewTests {
+
+    // MARK: - Initialization
+
+    @Test func init_withStatus_createsView() {
+        let sut = StatusBadgeView(status: .underReview)
+        _ = sut.body
+    }
+
+    @Test func init_withApprovedStatus_createsView() {
+        let sut = StatusBadgeView(status: .approved)
+        _ = sut.body
+    }
+
+    @Test func init_withRefusedStatus_createsView() {
+        let sut = StatusBadgeView(status: .refused)
+        _ = sut.body
+    }
+
+    @Test func init_withWithdrawnStatus_createsView() {
+        let sut = StatusBadgeView(status: .withdrawn)
+        _ = sut.body
+    }
+
+    @Test func init_withAppealedStatus_createsView() {
+        let sut = StatusBadgeView(status: .appealed)
+        _ = sut.body
+    }
+
+    @Test func init_withUnknownStatus_createsView() {
+        let sut = StatusBadgeView(status: .unknown)
+        _ = sut.body
+    }
+
+    // MARK: - All statuses render without crashing
+
+    @Test(arguments: [
+        ApplicationStatus.underReview,
+        ApplicationStatus.approved,
+        ApplicationStatus.refused,
+        ApplicationStatus.withdrawn,
+        ApplicationStatus.appealed,
+        ApplicationStatus.unknown,
+    ])
+    func allStatuses_renderWithoutCrashing(status: ApplicationStatus) {
+        let sut = StatusBadgeView(status: status)
+        _ = sut.body
+    }
+}

--- a/web/src/components/PostcodeInput/usePostcodeGeocode.ts
+++ b/web/src/components/PostcodeInput/usePostcodeGeocode.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { GeocodeResult } from '../../domain/types';
 import type { GeocodingPort } from '../../domain/ports/geocoding-port';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
 export function usePostcodeGeocode(port: GeocodingPort) {
   const [postcode, setPostcodeRaw] = useState('');
@@ -20,7 +21,7 @@ export function usePostcodeGeocode(port: GeocodingPort) {
       setIsGeocoding(false);
       return result;
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Geocode failed';
+      const message = extractErrorMessage(err, 'Geocode failed');
       setError(message);
       setIsGeocoding(false);
       return null;

--- a/web/src/features/ApplicationDetail/useSavedApplication.ts
+++ b/web/src/features/ApplicationDetail/useSavedApplication.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import type { ApplicationUid } from '../../domain/types';
 import type { SavedApplicationRepository } from '../../domain/ports/saved-application-repository';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
 interface SavedApplicationState {
   isSaved: boolean;
@@ -30,7 +31,7 @@ export function useSavedApplication(
         }
       } catch (err: unknown) {
         if (!cancelled) {
-          const message = err instanceof Error ? err.message : 'Unknown error';
+          const message = extractErrorMessage(err, 'Unknown error');
           setState({ isSaved: false, isLoading: false, error: message });
         }
       }
@@ -53,7 +54,7 @@ export function useSavedApplication(
         await repository.save(uid);
       }
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
+      const message = extractErrorMessage(err, 'Unknown error');
       setState((prev) => ({ ...prev, isSaved: wasSaved, error: message }));
     }
   }, [repository, uid, state.isSaved]);

--- a/web/src/features/Notifications/useNotifications.ts
+++ b/web/src/features/Notifications/useNotifications.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import type { NotificationItem } from '../../domain/types';
 import type { NotificationRepository } from '../../domain/ports/notification-repository';
 import { usePagination } from '../../hooks/usePagination';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
 const PAGE_SIZE = 20;
 
@@ -32,7 +33,7 @@ export function useNotifications(repository: NotificationRepository) {
       paginationRef.current.setTotal(result.total);
       paginationRef.current.setPage(result.page);
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'An error occurred';
+      const message = extractErrorMessage(err);
       setState(prev => ({
         ...prev,
         isLoading: false,
@@ -61,7 +62,7 @@ export function useNotifications(repository: NotificationRepository) {
       }
     }).catch((err: unknown) => {
       if (!cancelled) {
-        const message = err instanceof Error ? err.message : 'An error occurred';
+        const message = extractErrorMessage(err);
         setState(prev => ({ ...prev, isLoading: false, error: message }));
       }
     });

--- a/web/src/features/Search/useSearch.ts
+++ b/web/src/features/Search/useSearch.ts
@@ -3,6 +3,7 @@ import type { AuthorityId, PlanningApplicationSummary } from '../../domain/types
 import type { SearchRepository } from '../../domain/ports/search-repository';
 import { ApiRequestError } from '../../api/client';
 import { usePagination } from '../../hooks/usePagination';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
 const PAGE_SIZE = 20;
 
@@ -48,7 +49,7 @@ export function useSearch(repository: SearchRepository) {
         }));
         return;
       }
-      const message = err instanceof Error ? err.message : 'An error occurred';
+      const message = extractErrorMessage(err);
       setState(prev => ({
         ...prev,
         isLoading: false,

--- a/web/src/features/Settings/useUserProfile.ts
+++ b/web/src/features/Settings/useUserProfile.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import type { SettingsRepository } from '../../domain/ports/settings-repository';
 import type { UpdateProfileRequest, UserProfile } from '../../domain/types';
 import { useFetchData } from '../../hooks/useFetchData';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
 export function useUserProfile(
   repository: SettingsRepository,
@@ -41,7 +42,7 @@ export function useUserProfile(
       setOptimisticProfile(updated);
     } catch (err) {
       setOptimisticProfile(previous);
-      const message = err instanceof Error ? err.message : 'Failed to update preferences';
+      const message = extractErrorMessage(err, 'Failed to update preferences');
       setActionError(message);
     }
   }, [optimisticProfile, fetchedProfile, repository]);
@@ -59,7 +60,7 @@ export function useUserProfile(
       URL.revokeObjectURL(url);
       setIsExporting(false);
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to export data';
+      const message = extractErrorMessage(err, 'Failed to export data');
       setIsExporting(false);
       setActionError(message);
     }
@@ -73,7 +74,7 @@ export function useUserProfile(
       setIsDeleting(false);
       logout();
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to delete account';
+      const message = extractErrorMessage(err, 'Failed to delete account');
       setIsDeleting(false);
       setActionError(message);
     }

--- a/web/src/features/WatchZones/useCreateWatchZone.ts
+++ b/web/src/features/WatchZones/useCreateWatchZone.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { GeocodeResult } from '../../domain/types';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
 type CreateStep = 'postcode' | 'details' | 'confirm';
 
@@ -70,7 +71,7 @@ export function useCreateWatchZone(
       });
       navigate('/watch-zones');
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'An error occurred';
+      const message = extractErrorMessage(err);
       setState(prev => ({ ...prev, isSaving: false, error: message }));
     }
   }, [state.coordinates, state.name, state.radiusMetres, repository, navigate]);

--- a/web/src/features/WatchZones/useWatchZones.ts
+++ b/web/src/features/WatchZones/useWatchZones.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import type { WatchZoneSummary } from '../../domain/types';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
 import { useFetchData } from '../../hooks/useFetchData';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
 export function useWatchZones(repository: WatchZoneRepository) {
   const [actionError, setActionError] = useState<string | null>(null);
@@ -16,7 +17,7 @@ export function useWatchZones(repository: WatchZoneRepository) {
       await repository.delete(zoneId);
       refresh();
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'An error occurred';
+      const message = extractErrorMessage(err);
       setActionError(message);
     }
   }, [repository, refresh]);

--- a/web/src/features/WatchZones/useZonePreferences.ts
+++ b/web/src/features/WatchZones/useZonePreferences.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import type { ZoneNotificationPreferences, UpdateZonePreferencesRequest } from '../../domain/types';
 import type { WatchZoneRepository } from '../../domain/ports/watch-zone-repository';
 import { useFetchData } from '../../hooks/useFetchData';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
 export function useZonePreferences(repository: WatchZoneRepository, zoneId: string) {
   const [isSaving, setIsSaving] = useState(false);
@@ -20,7 +21,7 @@ export function useZonePreferences(repository: WatchZoneRepository, zoneId: stri
       refresh();
       setIsSaving(false);
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'An error occurred';
+      const message = extractErrorMessage(err);
       setIsSaving(false);
       setActionError(message);
     }

--- a/web/src/features/legal/useLegalDocument.ts
+++ b/web/src/features/legal/useLegalDocument.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import type { LegalDocument } from '../../domain/types';
 import type { LegalDocumentPort } from '../../domain/ports/legal-document-port';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
 interface LegalDocumentState {
   document: LegalDocument | null;
@@ -33,7 +34,7 @@ export function useLegalDocument(port: LegalDocumentPort, documentType: string) 
       },
       (err: unknown) => {
         if (!cancelled) {
-          const message = err instanceof Error ? err.message : 'Failed to load document';
+          const message = extractErrorMessage(err, 'Failed to load document');
           setState({ document: null, isLoading: false, error: message });
         }
       },

--- a/web/src/features/onboarding/useOnboarding.ts
+++ b/web/src/features/onboarding/useOnboarding.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import type { GeocodeResult } from '../../domain/types';
 import type { OnboardingPort } from '../../domain/ports/onboarding-port';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
 
 export type OnboardingStep = 'welcome' | 'postcode' | 'radius' | 'confirm';
 
@@ -46,7 +47,7 @@ export function useOnboarding(port: OnboardingPort) {
       });
       setIsComplete(true);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Something went wrong');
+      setError(extractErrorMessage(err, 'Something went wrong'));
     } finally {
       setIsSubmitting(false);
     }

--- a/web/src/hooks/useFetchData.ts
+++ b/web/src/hooks/useFetchData.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, type DependencyList } from 'react';
+import { extractErrorMessage } from '../utils/extractErrorMessage';
 
 interface FetchDataState<T> {
   data: T | null;
@@ -12,10 +13,6 @@ interface FetchDataResult<T> extends FetchDataState<T> {
 
 interface FetchDataOptions {
   enabled?: boolean;
-}
-
-function extractErrorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : 'An error occurred';
 }
 
 export function useFetchData<T>(

--- a/web/src/utils/__tests__/extractErrorMessage.test.ts
+++ b/web/src/utils/__tests__/extractErrorMessage.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { extractErrorMessage } from '../extractErrorMessage';
+
+describe('extractErrorMessage', () => {
+  it('returns the message when given an Error instance', () => {
+    const err = new Error('Something broke');
+
+    const result = extractErrorMessage(err);
+
+    expect(result).toBe('Something broke');
+  });
+
+  it('returns the default fallback when given a non-Error value', () => {
+    const result = extractErrorMessage('a raw string');
+
+    expect(result).toBe('An error occurred');
+  });
+
+  it('returns a custom fallback when given a non-Error value and a fallback', () => {
+    const result = extractErrorMessage(42, 'Custom fallback');
+
+    expect(result).toBe('Custom fallback');
+  });
+
+  it('returns the default fallback for null', () => {
+    const result = extractErrorMessage(null);
+
+    expect(result).toBe('An error occurred');
+  });
+
+  it('returns the default fallback for undefined', () => {
+    const result = extractErrorMessage(undefined);
+
+    expect(result).toBe('An error occurred');
+  });
+
+  it('returns the message from an Error subclass', () => {
+    class CustomError extends Error {
+      constructor(message: string) {
+        super(message);
+        this.name = 'CustomError';
+      }
+    }
+
+    const result = extractErrorMessage(new CustomError('Custom error happened'));
+
+    expect(result).toBe('Custom error happened');
+  });
+
+  it('returns a custom fallback for an object that is not an Error', () => {
+    const result = extractErrorMessage({ code: 404 }, 'Not found');
+
+    expect(result).toBe('Not found');
+  });
+});

--- a/web/src/utils/extractErrorMessage.ts
+++ b/web/src/utils/extractErrorMessage.ts
@@ -1,0 +1,8 @@
+const DEFAULT_FALLBACK = 'An error occurred';
+
+export function extractErrorMessage(
+  err: unknown,
+  fallback: string = DEFAULT_FALLBACK,
+): string {
+  return err instanceof Error ? err.message : fallback;
+}


### PR DESCRIPTION
## Summary

- **Polling partial progress (tc-c61):** Restructure poll handler so mid-pagination 429s save poll state and emit metrics for applications already ingested. Switch to ascending sort order (`sort=last_different`) with high-water mark tracking so each cycle resumes from where the last one stopped.
- **CI composite actions:** Extract shared `acr-build-push`, `deploy-container-app`, and `deploy-worker-jobs` actions to deduplicate CD workflows.
- **iOS refactors:** Extract shared `StatusBadgeView` component and `ErrorHandlingViewModel` protocol to reduce duplication across ViewModels.
- **Infra cleanup:** Remove unused `acrPullIdentityClientId` stack outputs.

## Test plan

- [ ] `dotnet test` passes — new partial-progress and ascending-sort tests
- [ ] `swift test` passes — new StatusBadgeView and ErrorHandlingViewModel tests
- [ ] PR Gate workflow passes
- [ ] Verify poll job ingests applications and emits `authorities_polled` / `applications_ingested` metrics after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added reusable automation actions for container image building and deployment workflows
  * Improved polling to track and resume from high-water marks during partial progress
  * Introduced status badge component for unified visual application status display

* **Bug Fixes**
  * Fixed polling query sort order to enable reliable resume on partial failures
  * Enhanced metrics accuracy when polling is interrupted mid-iteration

* **Refactor**
  * Centralized error message extraction across web features
  * Standardized error handling in view models via shared protocol

* **Documentation**
  * Added polling partial progress specification

* **Tests**
  * Added comprehensive test coverage for status rendering and error handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->