### PR TITLE
feat: replace instant emails with hourly digest + OTel dependency fix

### DIFF
--- a/api/src/town-crier.application/DemoAccount/GetDemoAccountQueryHandler.cs
+++ b/api/src/town-crier.application/DemoAccount/GetDemoAccountQueryHandler.cs
@@ -41,7 +41,7 @@ public sealed class GetDemoAccountQueryHandler
             profile.ActivateSubscription(SubscriptionTier.Pro, DateTimeOffset.UtcNow.AddYears(10));
             await this.userProfileRepository.SaveAsync(profile, ct).ConfigureAwait(false);
 
-            var zone = new WatchZone(DemoZoneId, DemoUserId, "Westminster Demo Zone", new Coordinates(DemoLatitude, DemoLongitude), DemoRadiusMetres, DemoSeedData.AuthorityId);
+            var zone = new WatchZone(DemoZoneId, DemoUserId, "Westminster Demo Zone", new Coordinates(DemoLatitude, DemoLongitude), DemoRadiusMetres, DemoSeedData.AuthorityId, DateTimeOffset.MinValue);
             await this.watchZoneRepository.SaveAsync(zone, ct).ConfigureAwait(false);
 
             await this.SeedDemoApplicationsAsync(ct).ConfigureAwait(false);

--- a/api/src/town-crier.application/Notifications/DispatchNotificationCommandHandler.cs
+++ b/api/src/town-crier.application/Notifications/DispatchNotificationCommandHandler.cs
@@ -1,7 +1,6 @@
 using TownCrier.Application.DeviceRegistrations;
 using TownCrier.Application.Observability;
 using TownCrier.Application.UserProfiles;
-using TownCrier.Domain.Entitlements;
 using TownCrier.Domain.Notifications;
 using TownCrier.Domain.UserProfiles;
 
@@ -15,7 +14,6 @@ public sealed class DispatchNotificationCommandHandler
     private readonly IUserProfileRepository userProfileRepository;
     private readonly IDeviceRegistrationRepository deviceRegistrationRepository;
     private readonly IPushNotificationSender pushNotificationSender;
-    private readonly IEmailSender emailSender;
     private readonly TimeProvider timeProvider;
 
     public DispatchNotificationCommandHandler(
@@ -23,14 +21,12 @@ public sealed class DispatchNotificationCommandHandler
         IUserProfileRepository userProfileRepository,
         IDeviceRegistrationRepository deviceRegistrationRepository,
         IPushNotificationSender pushNotificationSender,
-        IEmailSender emailSender,
         TimeProvider timeProvider)
     {
         this.notificationRepository = notificationRepository;
         this.userProfileRepository = userProfileRepository;
         this.deviceRegistrationRepository = deviceRegistrationRepository;
         this.pushNotificationSender = pushNotificationSender;
-        this.emailSender = emailSender;
         this.timeProvider = timeProvider;
     }
 
@@ -112,16 +108,6 @@ public sealed class DispatchNotificationCommandHandler
                 .ConfigureAwait(false);
             notification.MarkPushSent();
             ApiMetrics.NotificationsSent.Add(1);
-        }
-
-        // Send instant email notification for entitled tiers
-        var entitlements = EntitlementMap.EntitlementsFor(profile.Tier);
-        if (entitlements.Contains(Entitlement.InstantEmails)
-            && profile.NotificationPreferences.EmailInstantEnabled
-            && !string.IsNullOrEmpty(profile.Email))
-        {
-            await this.emailSender.SendNotificationAsync(profile.Email, notification, ct)
-                .ConfigureAwait(false);
         }
 
         await this.notificationRepository.SaveAsync(notification, ct).ConfigureAwait(false);

--- a/api/src/town-crier.application/Notifications/GenerateHourlyDigestsCommand.cs
+++ b/api/src/town-crier.application/Notifications/GenerateHourlyDigestsCommand.cs
@@ -1,0 +1,3 @@
+namespace TownCrier.Application.Notifications;
+
+public sealed record GenerateHourlyDigestsCommand;

--- a/api/src/town-crier.application/Notifications/GenerateHourlyDigestsCommandHandler.cs
+++ b/api/src/town-crier.application/Notifications/GenerateHourlyDigestsCommandHandler.cs
@@ -1,0 +1,88 @@
+using TownCrier.Application.UserProfiles;
+using TownCrier.Application.WatchZones;
+using TownCrier.Domain.Entitlements;
+
+namespace TownCrier.Application.Notifications;
+
+public sealed class GenerateHourlyDigestsCommandHandler
+{
+    private readonly INotificationRepository notificationRepository;
+    private readonly IUserProfileRepository userProfileRepository;
+    private readonly IEmailSender emailSender;
+    private readonly IWatchZoneRepository watchZoneRepository;
+
+    public GenerateHourlyDigestsCommandHandler(
+        INotificationRepository notificationRepository,
+        IUserProfileRepository userProfileRepository,
+        IEmailSender emailSender,
+        IWatchZoneRepository watchZoneRepository)
+    {
+        this.notificationRepository = notificationRepository;
+        this.userProfileRepository = userProfileRepository;
+        this.emailSender = emailSender;
+        this.watchZoneRepository = watchZoneRepository;
+    }
+
+    public async Task HandleAsync(GenerateHourlyDigestsCommand command, CancellationToken ct)
+    {
+        var userIds = await this.notificationRepository.GetUserIdsWithUnsentEmailsAsync(ct)
+            .ConfigureAwait(false);
+
+        foreach (var userId in userIds)
+        {
+            var profile = await this.userProfileRepository.GetByUserIdAsync(userId, ct)
+                .ConfigureAwait(false);
+
+            if (profile is null)
+            {
+                continue;
+            }
+
+            var entitlements = EntitlementMap.EntitlementsFor(profile.Tier);
+            if (!entitlements.Contains(Entitlement.HourlyDigestEmails))
+            {
+                continue;
+            }
+
+            if (string.IsNullOrEmpty(profile.Email))
+            {
+                continue;
+            }
+
+            if (!profile.NotificationPreferences.EmailDigestEnabled)
+            {
+                continue;
+            }
+
+            var notifications = await this.notificationRepository.GetUnsentEmailsByUserAsync(userId, ct)
+                .ConfigureAwait(false);
+
+            if (notifications.Count == 0)
+            {
+                continue;
+            }
+
+            var zones = await this.watchZoneRepository.GetByUserIdAsync(userId, ct)
+                .ConfigureAwait(false);
+
+            var zoneLookup = zones.ToDictionary(z => z.Id, z => z.Name);
+
+            var digests = notifications
+                .GroupBy(n => n.WatchZoneId)
+                .Select(g => new WatchZoneDigest(
+                    zoneLookup.GetValueOrDefault(g.Key, "Unknown Zone"),
+                    g.ToList()))
+                .ToList();
+
+            await this.emailSender.SendDigestAsync(profile.Email, digests, ct)
+                .ConfigureAwait(false);
+
+            foreach (var notification in notifications)
+            {
+                notification.MarkEmailSent();
+                await this.notificationRepository.SaveAsync(notification, ct)
+                    .ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/api/src/town-crier.application/Notifications/INotificationRepository.cs
+++ b/api/src/town-crier.application/Notifications/INotificationRepository.cs
@@ -17,5 +17,7 @@ public interface INotificationRepository
 
     Task<IReadOnlyList<Notification>> GetUnsentEmailsByUserAsync(string userId, CancellationToken ct);
 
+    Task<IReadOnlyList<string>> GetUserIdsWithUnsentEmailsAsync(CancellationToken ct);
+
     Task SaveAsync(Notification notification, CancellationToken ct);
 }

--- a/api/src/town-crier.application/Notifications/INotificationRepository.cs
+++ b/api/src/town-crier.application/Notifications/INotificationRepository.cs
@@ -15,5 +15,7 @@ public interface INotificationRepository
     Task<(IReadOnlyList<Notification> Items, int Total)> GetByUserPaginatedAsync(
         string userId, int page, int pageSize, CancellationToken ct);
 
+    Task<IReadOnlyList<Notification>> GetUnsentEmailsByUserAsync(string userId, CancellationToken ct);
+
     Task SaveAsync(Notification notification, CancellationToken ct);
 }

--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -75,6 +75,11 @@ public sealed partial class PollPlanItCommandHandler
 
                         foreach (var zone in matchingZones)
                         {
+                            if (zone.CreatedAt > application.LastDifferent)
+                            {
+                                continue;
+                            }
+
                             await this.notificationEnqueuer.EnqueueAsync(application, zone, ct).ConfigureAwait(false);
                         }
                     }

--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -62,7 +62,7 @@ public sealed partial class PollPlanItCommandHandler
             try
             {
                 var lastPollTime = await this.pollStateStore.GetLastPollTimeAsync(authorityId, ct).ConfigureAwait(false);
-                lastPollTime ??= now.AddDays(-30);
+                lastPollTime ??= now.AddDays(-1);
 
                 await foreach (var application in this.planItClient.FetchApplicationsAsync(authorityId, lastPollTime, ct).ConfigureAwait(false))
                 {

--- a/api/src/town-crier.application/UserProfiles/GetUserProfileQueryHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/GetUserProfileQueryHandler.cs
@@ -24,7 +24,6 @@ public sealed class GetUserProfileQueryHandler
             profile.NotificationPreferences.PushEnabled,
             profile.NotificationPreferences.DigestDay,
             profile.NotificationPreferences.EmailDigestEnabled,
-            profile.NotificationPreferences.EmailInstantEnabled,
             profile.Tier);
     }
 }

--- a/api/src/town-crier.application/UserProfiles/GetUserProfileResult.cs
+++ b/api/src/town-crier.application/UserProfiles/GetUserProfileResult.cs
@@ -7,5 +7,4 @@ public sealed record GetUserProfileResult(
     bool PushEnabled,
     DayOfWeek DigestDay,
     bool EmailDigestEnabled,
-    bool EmailInstantEnabled,
     SubscriptionTier Tier);

--- a/api/src/town-crier.application/UserProfiles/UpdateUserProfileCommand.cs
+++ b/api/src/town-crier.application/UserProfiles/UpdateUserProfileCommand.cs
@@ -4,5 +4,4 @@ public sealed record UpdateUserProfileCommand(
     string UserId,
     bool PushEnabled,
     DayOfWeek DigestDay = DayOfWeek.Monday,
-    bool EmailDigestEnabled = true,
-    bool EmailInstantEnabled = false);
+    bool EmailDigestEnabled = true);

--- a/api/src/town-crier.application/UserProfiles/UpdateUserProfileCommandHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/UpdateUserProfileCommandHandler.cs
@@ -21,8 +21,7 @@ public sealed class UpdateUserProfileCommandHandler
         profile.UpdatePreferences(new NotificationPreferences(
             command.PushEnabled,
             command.DigestDay,
-            command.EmailDigestEnabled,
-            command.EmailInstantEnabled));
+            command.EmailDigestEnabled));
         await this.repository.SaveAsync(profile, ct).ConfigureAwait(false);
 
         return new UpdateUserProfileResult(
@@ -30,7 +29,6 @@ public sealed class UpdateUserProfileCommandHandler
             profile.NotificationPreferences.PushEnabled,
             profile.NotificationPreferences.DigestDay,
             profile.NotificationPreferences.EmailDigestEnabled,
-            profile.NotificationPreferences.EmailInstantEnabled,
             profile.Tier);
     }
 }

--- a/api/src/town-crier.application/UserProfiles/UpdateUserProfileResult.cs
+++ b/api/src/town-crier.application/UserProfiles/UpdateUserProfileResult.cs
@@ -7,5 +7,4 @@ public sealed record UpdateUserProfileResult(
     bool PushEnabled,
     DayOfWeek DigestDay,
     bool EmailDigestEnabled,
-    bool EmailInstantEnabled,
     SubscriptionTier Tier);

--- a/api/src/town-crier.application/WatchZones/CreateWatchZoneCommandHandler.cs
+++ b/api/src/town-crier.application/WatchZones/CreateWatchZoneCommandHandler.cs
@@ -60,7 +60,8 @@ public sealed partial class CreateWatchZoneCommandHandler
             command.Name,
             new Coordinates(command.Latitude, command.Longitude),
             command.RadiusMetres,
-            authorityId);
+            authorityId,
+            this.timeProvider.GetUtcNow());
 
         await this.watchZoneRepository.SaveAsync(zone, ct).ConfigureAwait(false);
         ApiMetrics.WatchZonesCreated.Add(1);

--- a/api/src/town-crier.domain/Entitlements/Entitlement.cs
+++ b/api/src/town-crier.domain/Entitlements/Entitlement.cs
@@ -2,7 +2,6 @@ namespace TownCrier.Domain.Entitlements;
 
 public enum Entitlement
 {
-    InstantEmails,
     SearchApplications,
     StatusChangeAlerts,
     DecisionUpdateAlerts,

--- a/api/src/town-crier.domain/Entitlements/Entitlement.cs
+++ b/api/src/town-crier.domain/Entitlements/Entitlement.cs
@@ -6,4 +6,5 @@ public enum Entitlement
     SearchApplications,
     StatusChangeAlerts,
     DecisionUpdateAlerts,
+    HourlyDigestEmails,
 }

--- a/api/src/town-crier.domain/Entitlements/EntitlementMap.cs
+++ b/api/src/town-crier.domain/Entitlements/EntitlementMap.cs
@@ -10,7 +10,6 @@ public static class EntitlementMap
     private static readonly IReadOnlySet<Entitlement> PersonalEntitlements =
         new HashSet<Entitlement>
         {
-            Entitlement.InstantEmails,
             Entitlement.StatusChangeAlerts,
             Entitlement.DecisionUpdateAlerts,
             Entitlement.HourlyDigestEmails,
@@ -19,7 +18,6 @@ public static class EntitlementMap
     private static readonly IReadOnlySet<Entitlement> ProEntitlements =
         new HashSet<Entitlement>
         {
-            Entitlement.InstantEmails,
             Entitlement.SearchApplications,
             Entitlement.StatusChangeAlerts,
             Entitlement.DecisionUpdateAlerts,

--- a/api/src/town-crier.domain/Entitlements/EntitlementMap.cs
+++ b/api/src/town-crier.domain/Entitlements/EntitlementMap.cs
@@ -13,6 +13,7 @@ public static class EntitlementMap
             Entitlement.InstantEmails,
             Entitlement.StatusChangeAlerts,
             Entitlement.DecisionUpdateAlerts,
+            Entitlement.HourlyDigestEmails,
         };
 
     private static readonly IReadOnlySet<Entitlement> ProEntitlements =
@@ -22,6 +23,7 @@ public static class EntitlementMap
             Entitlement.SearchApplications,
             Entitlement.StatusChangeAlerts,
             Entitlement.DecisionUpdateAlerts,
+            Entitlement.HourlyDigestEmails,
         };
 
     public static IReadOnlySet<Entitlement> EntitlementsFor(SubscriptionTier tier) => tier switch

--- a/api/src/town-crier.domain/Notifications/Notification.cs
+++ b/api/src/town-crier.domain/Notifications/Notification.cs
@@ -12,6 +12,7 @@ public sealed class Notification
         string applicationType,
         int authorityId,
         bool pushSent,
+        bool emailSent,
         DateTimeOffset createdAt)
     {
         this.Id = id;
@@ -23,6 +24,7 @@ public sealed class Notification
         this.ApplicationType = applicationType;
         this.AuthorityId = authorityId;
         this.PushSent = pushSent;
+        this.EmailSent = emailSent;
         this.CreatedAt = createdAt;
     }
 
@@ -43,6 +45,8 @@ public sealed class Notification
     public int AuthorityId { get; }
 
     public bool PushSent { get; private set; }
+
+    public bool EmailSent { get; private set; }
 
     public DateTimeOffset CreatedAt { get; }
 
@@ -70,12 +74,18 @@ public sealed class Notification
             applicationType: applicationType,
             authorityId: authorityId,
             pushSent: false,
+            emailSent: false,
             createdAt: now);
     }
 
     public void MarkPushSent()
     {
         this.PushSent = true;
+    }
+
+    public void MarkEmailSent()
+    {
+        this.EmailSent = true;
     }
 
     internal static Notification Reconstitute(
@@ -88,6 +98,7 @@ public sealed class Notification
         string applicationType,
         int authorityId,
         bool pushSent,
+        bool emailSent,
         DateTimeOffset createdAt)
     {
         return new Notification(
@@ -100,6 +111,7 @@ public sealed class Notification
             applicationType,
             authorityId,
             pushSent,
+            emailSent,
             createdAt);
     }
 }

--- a/api/src/town-crier.domain/UserProfiles/NotificationPreferences.cs
+++ b/api/src/town-crier.domain/UserProfiles/NotificationPreferences.cs
@@ -3,8 +3,7 @@ namespace TownCrier.Domain.UserProfiles;
 public sealed record NotificationPreferences(
     bool PushEnabled,
     DayOfWeek DigestDay = DayOfWeek.Monday,
-    bool EmailDigestEnabled = true,
-    bool EmailInstantEnabled = false)
+    bool EmailDigestEnabled = true)
 {
     public static NotificationPreferences Default => new(PushEnabled: true);
 }

--- a/api/src/town-crier.domain/WatchZones/WatchZone.cs
+++ b/api/src/town-crier.domain/WatchZones/WatchZone.cs
@@ -4,7 +4,7 @@ namespace TownCrier.Domain.WatchZones;
 
 public sealed class WatchZone
 {
-    public WatchZone(string id, string userId, string name, Coordinates centre, double radiusMetres, int authorityId)
+    public WatchZone(string id, string userId, string name, Coordinates centre, double radiusMetres, int authorityId, DateTimeOffset createdAt)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(id);
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
@@ -19,6 +19,7 @@ public sealed class WatchZone
         this.Centre = centre;
         this.RadiusMetres = radiusMetres;
         this.AuthorityId = authorityId;
+        this.CreatedAt = createdAt;
     }
 
     public string Id { get; }
@@ -32,4 +33,6 @@ public sealed class WatchZone
     public double RadiusMetres { get; }
 
     public int AuthorityId { get; }
+
+    public DateTimeOffset CreatedAt { get; }
 }

--- a/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
@@ -124,6 +124,19 @@ public sealed class CosmosNotificationRepository : INotificationRepository
         return documents.ConvertAll(doc => doc.ToDomain());
     }
 
+    public async Task<IReadOnlyList<string>> GetUserIdsWithUnsentEmailsAsync(CancellationToken ct)
+    {
+        var userIds = await this.client.QueryAsync(
+            CosmosContainerNames.Notifications,
+            "SELECT DISTINCT VALUE c.userId FROM c WHERE c.emailSent = false OR NOT IS_DEFINED(c.emailSent)",
+            null,
+            null,
+            CosmosJsonSerializerContext.Default.String,
+            ct).ConfigureAwait(false);
+
+        return userIds;
+    }
+
     public async Task SaveAsync(Notification notification, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(notification);

--- a/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
@@ -110,6 +110,20 @@ public sealed class CosmosNotificationRepository : INotificationRepository
         return (items, total);
     }
 
+    public async Task<IReadOnlyList<Notification>> GetUnsentEmailsByUserAsync(
+        string userId, CancellationToken ct)
+    {
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Notifications,
+            "SELECT * FROM c WHERE c.userId = @userId AND (c.emailSent = false OR NOT IS_DEFINED(c.emailSent)) ORDER BY c.createdAt ASC",
+            [new QueryParameter("@userId", userId)],
+            userId,
+            CosmosJsonSerializerContext.Default.NotificationDocument,
+            ct).ConfigureAwait(false);
+
+        return documents.ConvertAll(doc => doc.ToDomain());
+    }
+
     public async Task SaveAsync(Notification notification, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(notification);

--- a/api/src/town-crier.infrastructure/Notifications/InMemoryNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/InMemoryNotificationRepository.cs
@@ -58,6 +58,15 @@ public sealed class InMemoryNotificationRepository : INotificationRepository
         return Task.FromResult<(IReadOnlyList<Notification> Items, int Total)>((items, total));
     }
 
+    public Task<IReadOnlyList<Notification>> GetUnsentEmailsByUserAsync(string userId, CancellationToken ct)
+    {
+        var notifications = this.store
+            .Where(n => n.UserId == userId && !n.EmailSent)
+            .OrderBy(n => n.CreatedAt)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<Notification>>(notifications);
+    }
+
     public Task SaveAsync(Notification notification, CancellationToken ct)
     {
         this.store.Add(notification);

--- a/api/src/town-crier.infrastructure/Notifications/InMemoryNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/InMemoryNotificationRepository.cs
@@ -67,6 +67,16 @@ public sealed class InMemoryNotificationRepository : INotificationRepository
         return Task.FromResult<IReadOnlyList<Notification>>(notifications);
     }
 
+    public Task<IReadOnlyList<string>> GetUserIdsWithUnsentEmailsAsync(CancellationToken ct)
+    {
+        var userIds = this.store
+            .Where(n => !n.EmailSent)
+            .Select(n => n.UserId)
+            .Distinct()
+            .ToList();
+        return Task.FromResult<IReadOnlyList<string>>(userIds);
+    }
+
     public Task SaveAsync(Notification notification, CancellationToken ct)
     {
         this.store.Add(notification);

--- a/api/src/town-crier.infrastructure/Notifications/NotificationDocument.cs
+++ b/api/src/town-crier.infrastructure/Notifications/NotificationDocument.cs
@@ -34,6 +34,9 @@ internal sealed class NotificationDocument
     [JsonPropertyName("pushSent")]
     public required bool PushSent { get; init; }
 
+    [JsonPropertyName("emailSent")]
+    public bool EmailSent { get; init; }
+
     [JsonPropertyName("createdAt")]
     public required DateTimeOffset CreatedAt { get; init; }
 
@@ -53,6 +56,7 @@ internal sealed class NotificationDocument
             ApplicationType = notification.ApplicationType,
             AuthorityId = notification.AuthorityId,
             PushSent = notification.PushSent,
+            EmailSent = notification.EmailSent,
             CreatedAt = notification.CreatedAt,
             Ttl = NinetyDaysInSeconds,
         };
@@ -70,6 +74,7 @@ internal sealed class NotificationDocument
             this.ApplicationType,
             this.AuthorityId,
             this.PushSent,
+            this.EmailSent,
             this.CreatedAt);
     }
 }

--- a/api/src/town-crier.infrastructure/UserProfiles/UserProfileDocument.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/UserProfileDocument.cs
@@ -16,6 +16,8 @@ internal sealed class UserProfileDocument
 
     public bool EmailDigestEnabled { get; init; } = true;
 
+    // Legacy field — kept for backward compatibility with existing Cosmos documents.
+    // No longer written; ignored during domain reconstitution.
     public bool EmailInstantEnabled { get; init; }
 
     public required Dictionary<string, ZoneNotificationPreferences> ZonePreferences { get; init; }
@@ -40,7 +42,6 @@ internal sealed class UserProfileDocument
             PushEnabled = profile.NotificationPreferences.PushEnabled,
             DigestDay = profile.NotificationPreferences.DigestDay,
             EmailDigestEnabled = profile.NotificationPreferences.EmailDigestEnabled,
-            EmailInstantEnabled = profile.NotificationPreferences.EmailInstantEnabled,
             ZonePreferences = new Dictionary<string, ZoneNotificationPreferences>(profile.AllZonePreferences),
             Tier = profile.Tier.ToString(),
             SubscriptionExpiry = profile.SubscriptionExpiry,
@@ -55,8 +56,7 @@ internal sealed class UserProfileDocument
         var notificationPreferences = new NotificationPreferences(
             this.PushEnabled,
             this.DigestDay,
-            this.EmailDigestEnabled,
-            this.EmailInstantEnabled);
+            this.EmailDigestEnabled);
 
         return UserProfile.Reconstitute(
             this.UserId,

--- a/api/src/town-crier.infrastructure/WatchZones/WatchZoneDocument.cs
+++ b/api/src/town-crier.infrastructure/WatchZones/WatchZoneDocument.cs
@@ -19,6 +19,8 @@ internal sealed class WatchZoneDocument
 
     public required int AuthorityId { get; init; }
 
+    public DateTimeOffset? CreatedAt { get; init; }
+
     public static WatchZoneDocument FromDomain(WatchZone zone)
     {
         ArgumentNullException.ThrowIfNull(zone);
@@ -32,6 +34,7 @@ internal sealed class WatchZoneDocument
             Longitude = zone.Centre.Longitude,
             RadiusMetres = zone.RadiusMetres,
             AuthorityId = zone.AuthorityId,
+            CreatedAt = zone.CreatedAt,
         };
     }
 
@@ -43,6 +46,7 @@ internal sealed class WatchZoneDocument
             this.Name,
             new Coordinates(this.Latitude, this.Longitude),
             this.RadiusMetres,
-            this.AuthorityId);
+            this.AuthorityId,
+            this.CreatedAt ?? DateTimeOffset.MinValue);
     }
 }

--- a/api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/UserProfileEndpoints.cs
@@ -1,7 +1,5 @@
 using System.Security.Claims;
 using TownCrier.Application.UserProfiles;
-using TownCrier.Domain.Entitlements;
-using TownCrier.Domain.UserProfiles;
 
 namespace TownCrier.Web.Endpoints;
 
@@ -37,32 +35,12 @@ internal static class UserProfileEndpoints
             UpdateUserProfileCommandHandler handler,
             CancellationToken ct) =>
         {
-            if (command.EmailInstantEnabled)
-            {
-                var tierClaim = user.FindFirst("subscription_tier")?.Value;
-                var tier = Enum.TryParse<SubscriptionTier>(tierClaim, ignoreCase: true, out var parsed)
-                    ? parsed
-                    : SubscriptionTier.Free;
-
-                if (!EntitlementMap.EntitlementsFor(tier).Contains(Entitlement.InstantEmails))
-                {
-                    return Results.Json(
-                        new EntitlementErrorResponse(
-                            "insufficient_entitlement",
-                            Entitlement.InstantEmails.ToString(),
-                            "This feature requires a paid subscription."),
-                        AppJsonSerializerContext.Default.EntitlementErrorResponse,
-                        statusCode: 403);
-                }
-            }
-
             var userId = user.FindFirstValue("sub")!;
             var profileCommand = new UpdateUserProfileCommand(
                 userId,
                 command.PushEnabled,
                 command.DigestDay,
-                command.EmailDigestEnabled,
-                command.EmailInstantEnabled);
+                command.EmailDigestEnabled);
 
             try
             {

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -44,7 +44,18 @@ var otel = builder.Services.AddOpenTelemetry()
 
 if (hasAppInsights)
 {
-    otel.UseAzureMonitorExporter(o => o.ConnectionString = aiConnectionString);
+    otel.UseAzureMonitorExporter(o =>
+    {
+        o.ConnectionString = aiConnectionString;
+
+        // Azure Monitor Exporter 1.6.0+ defaults to RateLimitedSampler at 5 TPS,
+        // which drops most dependency spans under burst traffic (e.g., Cosmos polling
+        // with 900+ calls). Set TracesPerSecond=null to use ApplicationInsightsSampler
+        // with SamplingRatio=1.0 for 100% fixed-percentage sampling, ensuring all
+        // outbound calls appear in the App Insights dependencies table.
+        o.SamplingRatio = 1.0f;
+        o.TracesPerSecond = null;
+    });
 }
 
 var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>()

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -61,7 +61,18 @@ var otel = builder.Services.AddOpenTelemetry()
 
 if (hasAppInsights)
 {
-    otel.UseAzureMonitorExporter(o => o.ConnectionString = aiConnectionString);
+    otel.UseAzureMonitorExporter(o =>
+    {
+        o.ConnectionString = aiConnectionString;
+
+        // Azure Monitor Exporter 1.6.0+ defaults to RateLimitedSampler at 5 TPS,
+        // which drops most dependency spans under burst traffic (e.g., Cosmos polling
+        // with 900+ calls). Set TracesPerSecond=null to use ApplicationInsightsSampler
+        // with SamplingRatio=1.0 for 100% fixed-percentage sampling, ensuring all
+        // outbound calls appear in the App Insights dependencies table.
+        o.SamplingRatio = 1.0f;
+        o.TracesPerSecond = null;
+    });
 }
 
 builder.Services.Configure<MetricReaderOptions>(o =>

--- a/api/tests/town-crier.application.tests/Entitlements/EntitlementMapTests.cs
+++ b/api/tests/town-crier.application.tests/Entitlements/EntitlementMapTests.cs
@@ -18,10 +18,11 @@ public sealed class EntitlementMapTests
     {
         var entitlements = EntitlementMap.EntitlementsFor(SubscriptionTier.Personal);
 
-        await Assert.That(entitlements).HasCount().EqualTo(3);
+        await Assert.That(entitlements).HasCount().EqualTo(4);
         await Assert.That(entitlements).Contains(Entitlement.InstantEmails);
         await Assert.That(entitlements).Contains(Entitlement.StatusChangeAlerts);
         await Assert.That(entitlements).Contains(Entitlement.DecisionUpdateAlerts);
+        await Assert.That(entitlements).Contains(Entitlement.HourlyDigestEmails);
         await Assert.That(entitlements).DoesNotContain(Entitlement.SearchApplications);
     }
 
@@ -30,11 +31,12 @@ public sealed class EntitlementMapTests
     {
         var entitlements = EntitlementMap.EntitlementsFor(SubscriptionTier.Pro);
 
-        await Assert.That(entitlements).HasCount().EqualTo(4);
+        await Assert.That(entitlements).HasCount().EqualTo(5);
         await Assert.That(entitlements).Contains(Entitlement.InstantEmails);
         await Assert.That(entitlements).Contains(Entitlement.SearchApplications);
         await Assert.That(entitlements).Contains(Entitlement.StatusChangeAlerts);
         await Assert.That(entitlements).Contains(Entitlement.DecisionUpdateAlerts);
+        await Assert.That(entitlements).Contains(Entitlement.HourlyDigestEmails);
     }
 
     [Test]

--- a/api/tests/town-crier.application.tests/Entitlements/EntitlementMapTests.cs
+++ b/api/tests/town-crier.application.tests/Entitlements/EntitlementMapTests.cs
@@ -14,12 +14,11 @@ public sealed class EntitlementMapTests
     }
 
     [Test]
-    public async Task PersonalTier_Should_HaveInstantEmailsAndAlerts()
+    public async Task PersonalTier_Should_HaveAlertsAndHourlyDigest()
     {
         var entitlements = EntitlementMap.EntitlementsFor(SubscriptionTier.Personal);
 
-        await Assert.That(entitlements).HasCount().EqualTo(4);
-        await Assert.That(entitlements).Contains(Entitlement.InstantEmails);
+        await Assert.That(entitlements).HasCount().EqualTo(3);
         await Assert.That(entitlements).Contains(Entitlement.StatusChangeAlerts);
         await Assert.That(entitlements).Contains(Entitlement.DecisionUpdateAlerts);
         await Assert.That(entitlements).Contains(Entitlement.HourlyDigestEmails);
@@ -31,8 +30,7 @@ public sealed class EntitlementMapTests
     {
         var entitlements = EntitlementMap.EntitlementsFor(SubscriptionTier.Pro);
 
-        await Assert.That(entitlements).HasCount().EqualTo(5);
-        await Assert.That(entitlements).Contains(Entitlement.InstantEmails);
+        await Assert.That(entitlements).HasCount().EqualTo(4);
         await Assert.That(entitlements).Contains(Entitlement.SearchApplications);
         await Assert.That(entitlements).Contains(Entitlement.StatusChangeAlerts);
         await Assert.That(entitlements).Contains(Entitlement.DecisionUpdateAlerts);

--- a/api/tests/town-crier.application.tests/Entitlements/EntitlementMapTests.cs
+++ b/api/tests/town-crier.application.tests/Entitlements/EntitlementMapTests.cs
@@ -60,4 +60,28 @@ public sealed class EntitlementMapTests
 
         await Assert.That(limit).IsEqualTo(int.MaxValue);
     }
+
+    [Test]
+    public async Task PersonalTier_Should_HaveHourlyDigestEmails()
+    {
+        var entitlements = EntitlementMap.EntitlementsFor(SubscriptionTier.Personal);
+
+        await Assert.That(entitlements).Contains(Entitlement.HourlyDigestEmails);
+    }
+
+    [Test]
+    public async Task ProTier_Should_HaveHourlyDigestEmails()
+    {
+        var entitlements = EntitlementMap.EntitlementsFor(SubscriptionTier.Pro);
+
+        await Assert.That(entitlements).Contains(Entitlement.HourlyDigestEmails);
+    }
+
+    [Test]
+    public async Task FreeTier_Should_NotHaveHourlyDigestEmails()
+    {
+        var entitlements = EntitlementMap.EntitlementsFor(SubscriptionTier.Free);
+
+        await Assert.That(entitlements).DoesNotContain(Entitlement.HourlyDigestEmails);
+    }
 }

--- a/api/tests/town-crier.application.tests/Notifications/DispatchNotificationCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Notifications/DispatchNotificationCommandHandlerTests.cs
@@ -15,7 +15,7 @@ public sealed class DispatchNotificationCommandHandlerTests
     public async Task Should_CreateNotificationRecord_When_ApplicationMatchesWatchZone()
     {
         // Arrange
-        var (handler, notificationRepo, userProfileRepo, _, deviceRepo, _) = CreateHandler();
+        var (handler, notificationRepo, userProfileRepo, _, deviceRepo) = CreateHandler();
         await SeedFreeUserWithDevice(userProfileRepo, deviceRepo);
 
         // Act
@@ -32,7 +32,7 @@ public sealed class DispatchNotificationCommandHandlerTests
     public async Task Should_SendPushNotification_When_UserHasRegisteredDevice()
     {
         // Arrange
-        var (handler, _, userProfileRepo, pushSender, deviceRepo, _) = CreateHandler();
+        var (handler, _, userProfileRepo, pushSender, deviceRepo) = CreateHandler();
         await SeedFreeUserWithDevice(userProfileRepo, deviceRepo);
 
         // Act
@@ -48,7 +48,7 @@ public sealed class DispatchNotificationCommandHandlerTests
     public async Task Should_MarkPushSent_When_NotificationDispatched()
     {
         // Arrange
-        var (handler, notificationRepo, userProfileRepo, _, deviceRepo, _) = CreateHandler();
+        var (handler, notificationRepo, userProfileRepo, _, deviceRepo) = CreateHandler();
         await SeedFreeUserWithDevice(userProfileRepo, deviceRepo);
 
         // Act
@@ -62,7 +62,7 @@ public sealed class DispatchNotificationCommandHandlerTests
     public async Task Should_NotSendDuplicateNotification_When_SameApplicationAndUser()
     {
         // Arrange
-        var (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo, _) = CreateHandler();
+        var (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo) = CreateHandler();
         await SeedFreeUserWithDevice(userProfileRepo, deviceRepo);
 
         var command = CreateCommand();
@@ -80,7 +80,7 @@ public sealed class DispatchNotificationCommandHandlerTests
     public async Task Should_RecordNotificationButNotPush_When_PushDisabled()
     {
         // Arrange
-        var (handler, notificationRepo, userProfileRepo, pushSender, _, _) = CreateHandler();
+        var (handler, notificationRepo, userProfileRepo, pushSender, _) = CreateHandler();
 
         var profile = new UserProfileBuilder()
             .WithUserId("user-1")
@@ -101,7 +101,7 @@ public sealed class DispatchNotificationCommandHandlerTests
     public async Task Should_EnforceFreeTierCap_When_FiveNotificationsSentInMonth()
     {
         // Arrange
-        var (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo, _) = CreateHandler();
+        var (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo) = CreateHandler();
         await SeedFreeUserWithDevice(userProfileRepo, deviceRepo);
 
         for (var i = 0; i < 5; i++)
@@ -122,7 +122,7 @@ public sealed class DispatchNotificationCommandHandlerTests
     public async Task Should_AllowUnlimitedNotifications_When_ProTier()
     {
         // Arrange
-        var (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo, _) = CreateHandler();
+        var (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo) = CreateHandler();
 
         var profile = new UserProfileBuilder()
             .WithUserId("user-1")
@@ -153,7 +153,7 @@ public sealed class DispatchNotificationCommandHandlerTests
     {
         // Arrange
         var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 3, 28, 10, 0, 0, TimeSpan.Zero));
-        var (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo, _) = CreateHandler(timeProvider);
+        var (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo) = CreateHandler(timeProvider);
         await SeedFreeUserWithDevice(userProfileRepo, deviceRepo);
 
         for (var i = 0; i < 5; i++)
@@ -179,7 +179,7 @@ public sealed class DispatchNotificationCommandHandlerTests
     public async Task Should_NotCreateNotification_When_UserProfileNotFound()
     {
         // Arrange — no user profile seeded
-        var (handler, notificationRepo, _, pushSender, _, _) = CreateHandler();
+        var (handler, notificationRepo, _, pushSender, _) = CreateHandler();
 
         // Act
         await handler.HandleAsync(CreateCommand(), CancellationToken.None);
@@ -193,7 +193,7 @@ public sealed class DispatchNotificationCommandHandlerTests
     public async Task Should_NotSendPush_When_NoRegisteredDevices()
     {
         // Arrange
-        var (handler, notificationRepo, userProfileRepo, pushSender, _, _) = CreateHandler();
+        var (handler, notificationRepo, userProfileRepo, pushSender, _) = CreateHandler();
 
         var profile = new UserProfileBuilder().WithUserId("user-1").Build();
         await userProfileRepo.SaveAsync(profile, CancellationToken.None);
@@ -211,7 +211,7 @@ public sealed class DispatchNotificationCommandHandlerTests
     public async Task Should_RecordButNotPush_When_ZoneNewApplicationsDisabled()
     {
         // Arrange
-        var (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo, _) = CreateHandler();
+        var (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo) = CreateHandler();
 
         var profile = new UserProfileBuilder().WithUserId("user-1").Build();
         profile.SetZonePreferences(
@@ -238,7 +238,7 @@ public sealed class DispatchNotificationCommandHandlerTests
     public async Task Should_SendPush_When_ZoneNewApplicationsEnabled()
     {
         // Arrange
-        var (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo, _) = CreateHandler();
+        var (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo) = CreateHandler();
 
         var profile = new UserProfileBuilder().WithUserId("user-1").Build();
         profile.SetZonePreferences(
@@ -261,87 +261,22 @@ public sealed class DispatchNotificationCommandHandlerTests
         await Assert.That(pushSender.Sent).HasCount().EqualTo(1);
     }
 
-    [Test]
-    public async Task Should_SendInstantEmail_When_PersonalUserHasEmailInstantEnabled()
-    {
-        var (handler, _, userProfileRepo, _, deviceRepo, emailSender) = CreateHandler();
-
-        var profile = new UserProfileBuilder()
-            .WithUserId("user-1")
-            .WithEmail("user@example.com")
-            .WithTier(SubscriptionTier.Personal)
-            .WithEmailInstantEnabled(true)
-            .Build();
-        await userProfileRepo.SaveAsync(profile, CancellationToken.None);
-
-        var device = DeviceRegistration.Create("user-1", "device-token-1", DevicePlatform.Ios, March2026);
-        await deviceRepo.SaveAsync(device, CancellationToken.None);
-
-        await handler.HandleAsync(CreateCommand(), CancellationToken.None);
-
-        await Assert.That(emailSender.NotificationsSent).HasCount().EqualTo(1);
-        await Assert.That(emailSender.NotificationsSent[0].Email).IsEqualTo("user@example.com");
-    }
-
-    [Test]
-    public async Task Should_NotSendInstantEmail_When_FreeUserHasEmailInstantEnabled()
-    {
-        var (handler, _, userProfileRepo, _, deviceRepo, emailSender) = CreateHandler();
-
-        var profile = new UserProfileBuilder()
-            .WithUserId("user-1")
-            .WithEmail("user@example.com")
-            .WithEmailInstantEnabled(true)
-            .Build();
-        await userProfileRepo.SaveAsync(profile, CancellationToken.None);
-
-        var device = DeviceRegistration.Create("user-1", "device-token-1", DevicePlatform.Ios, March2026);
-        await deviceRepo.SaveAsync(device, CancellationToken.None);
-
-        await handler.HandleAsync(CreateCommand(), CancellationToken.None);
-
-        await Assert.That(emailSender.NotificationsSent).HasCount().EqualTo(0);
-    }
-
-    [Test]
-    public async Task Should_NotSendInstantEmail_When_EmailInstantDisabled()
-    {
-        var (handler, _, userProfileRepo, _, deviceRepo, emailSender) = CreateHandler();
-
-        var profile = new UserProfileBuilder()
-            .WithUserId("user-1")
-            .WithEmail("user@example.com")
-            .WithTier(SubscriptionTier.Pro)
-            .WithEmailInstantEnabled(false)
-            .Build();
-        await userProfileRepo.SaveAsync(profile, CancellationToken.None);
-
-        var device = DeviceRegistration.Create("user-1", "device-token-1", DevicePlatform.Ios, March2026);
-        await deviceRepo.SaveAsync(device, CancellationToken.None);
-
-        await handler.HandleAsync(CreateCommand(), CancellationToken.None);
-
-        await Assert.That(emailSender.NotificationsSent).HasCount().EqualTo(0);
-    }
-
     private static (DispatchNotificationCommandHandler Handler,
         FakeNotificationRepository NotificationRepo,
         FakeUserProfileRepository UserProfileRepo,
         SpyPushNotificationSender PushSender,
-        FakeDeviceRegistrationRepository DeviceRepo,
-        SpyEmailSender EmailSender) CreateHandler(FakeTimeProvider? timeProvider = null)
+        FakeDeviceRegistrationRepository DeviceRepo) CreateHandler(FakeTimeProvider? timeProvider = null)
     {
         var notificationRepo = new FakeNotificationRepository();
         var userProfileRepo = new FakeUserProfileRepository();
         var deviceRepo = new FakeDeviceRegistrationRepository();
         var pushSender = new SpyPushNotificationSender();
-        var emailSender = new SpyEmailSender();
         var tp = timeProvider ?? new FakeTimeProvider(March2026);
 
         var handler = new DispatchNotificationCommandHandler(
-            notificationRepo, userProfileRepo, deviceRepo, pushSender, emailSender, tp);
+            notificationRepo, userProfileRepo, deviceRepo, pushSender, tp);
 
-        return (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo, emailSender);
+        return (handler, notificationRepo, userProfileRepo, pushSender, deviceRepo);
     }
 
     private static async Task SeedFreeUserWithDevice(

--- a/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepository.cs
+++ b/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepository.cs
@@ -73,6 +73,16 @@ internal sealed class FakeNotificationRepository : INotificationRepository
         return Task.FromResult<IReadOnlyList<Notification>>(notifications);
     }
 
+    public Task<IReadOnlyList<string>> GetUserIdsWithUnsentEmailsAsync(CancellationToken ct)
+    {
+        var userIds = this.store
+            .Where(n => !n.EmailSent)
+            .Select(n => n.UserId)
+            .Distinct()
+            .ToList();
+        return Task.FromResult<IReadOnlyList<string>>(userIds);
+    }
+
     public Task SaveAsync(Notification notification, CancellationToken ct)
     {
         this.store.Add(notification);

--- a/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepository.cs
+++ b/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepository.cs
@@ -64,6 +64,15 @@ internal sealed class FakeNotificationRepository : INotificationRepository
         return Task.FromResult<(IReadOnlyList<Notification> Items, int Total)>((items, total));
     }
 
+    public Task<IReadOnlyList<Notification>> GetUnsentEmailsByUserAsync(string userId, CancellationToken ct)
+    {
+        var notifications = this.store
+            .Where(n => n.UserId == userId && !n.EmailSent)
+            .OrderBy(n => n.CreatedAt)
+            .ToList();
+        return Task.FromResult<IReadOnlyList<Notification>>(notifications);
+    }
+
     public Task SaveAsync(Notification notification, CancellationToken ct)
     {
         this.store.Add(notification);

--- a/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepositoryEmailTests.cs
+++ b/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepositoryEmailTests.cs
@@ -1,0 +1,102 @@
+using TownCrier.Domain.Notifications;
+
+namespace TownCrier.Application.Tests.Notifications;
+
+public sealed class FakeNotificationRepositoryEmailTests
+{
+    [Test]
+    public async Task Should_ReturnOnlyUnsentEmails_When_GetUnsentEmailsByUserAsyncCalled()
+    {
+        // Arrange
+        var repo = new FakeNotificationRepository();
+
+        var unsent = Notification.Create(
+            "user-1", "APP/2026/0001", "zone-1", "1 High St", "Extension", "Householder", 42,
+            new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero));
+
+        var sent = Notification.Create(
+            "user-1", "APP/2026/0002", "zone-1", "2 High St", "Garage", "Householder", 42,
+            new DateTimeOffset(2026, 3, 15, 11, 0, 0, TimeSpan.Zero));
+        sent.MarkEmailSent();
+
+        repo.Seed(unsent);
+        repo.Seed(sent);
+
+        // Act
+        var result = await repo.GetUnsentEmailsByUserAsync("user-1", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].ApplicationName).IsEqualTo("APP/2026/0001");
+    }
+
+    [Test]
+    public async Task Should_ReturnOrderedByCreatedAt_When_GetUnsentEmailsByUserAsyncCalled()
+    {
+        // Arrange
+        var repo = new FakeNotificationRepository();
+
+        var older = Notification.Create(
+            "user-1", "APP/2026/0001", "zone-1", "1 High St", "Extension", "Householder", 42,
+            new DateTimeOffset(2026, 3, 15, 8, 0, 0, TimeSpan.Zero));
+
+        var newer = Notification.Create(
+            "user-1", "APP/2026/0002", "zone-1", "2 High St", "Garage", "Householder", 42,
+            new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero));
+
+        repo.Seed(newer);
+        repo.Seed(older);
+
+        // Act
+        var result = await repo.GetUnsentEmailsByUserAsync("user-1", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result[0].CreatedAt).IsLessThan(result[1].CreatedAt);
+    }
+
+    [Test]
+    public async Task Should_ReturnEmpty_When_NoUnsentEmailsForUser()
+    {
+        // Arrange
+        var repo = new FakeNotificationRepository();
+
+        var sent = Notification.Create(
+            "user-1", "APP/2026/0001", "zone-1", "1 High St", "Extension", "Householder", 42,
+            new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero));
+        sent.MarkEmailSent();
+
+        repo.Seed(sent);
+
+        // Act
+        var result = await repo.GetUnsentEmailsByUserAsync("user-1", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_NotReturnOtherUsersNotifications_When_GetUnsentEmailsByUserAsyncCalled()
+    {
+        // Arrange
+        var repo = new FakeNotificationRepository();
+
+        var user1Notification = Notification.Create(
+            "user-1", "APP/2026/0001", "zone-1", "1 High St", "Extension", "Householder", 42,
+            new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero));
+
+        var user2Notification = Notification.Create(
+            "user-2", "APP/2026/0002", "zone-2", "2 High St", "Garage", "Householder", 42,
+            new DateTimeOffset(2026, 3, 15, 11, 0, 0, TimeSpan.Zero));
+
+        repo.Seed(user1Notification);
+        repo.Seed(user2Notification);
+
+        // Act
+        var result = await repo.GetUnsentEmailsByUserAsync("user-1", CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].UserId).IsEqualTo("user-1");
+    }
+}

--- a/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepositoryEmailTests.cs
+++ b/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepositoryEmailTests.cs
@@ -11,11 +11,23 @@ public sealed class FakeNotificationRepositoryEmailTests
         var repo = new FakeNotificationRepository();
 
         var unsent = Notification.Create(
-            "user-1", "APP/2026/0001", "zone-1", "1 High St", "Extension", "Householder", 42,
+            "user-1",
+            "APP/2026/0001",
+            "zone-1",
+            "1 High St",
+            "Extension",
+            "Householder",
+            42,
             new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero));
 
         var sent = Notification.Create(
-            "user-1", "APP/2026/0002", "zone-1", "2 High St", "Garage", "Householder", 42,
+            "user-1",
+            "APP/2026/0002",
+            "zone-1",
+            "2 High St",
+            "Garage",
+            "Householder",
+            42,
             new DateTimeOffset(2026, 3, 15, 11, 0, 0, TimeSpan.Zero));
         sent.MarkEmailSent();
 
@@ -37,11 +49,23 @@ public sealed class FakeNotificationRepositoryEmailTests
         var repo = new FakeNotificationRepository();
 
         var older = Notification.Create(
-            "user-1", "APP/2026/0001", "zone-1", "1 High St", "Extension", "Householder", 42,
+            "user-1",
+            "APP/2026/0001",
+            "zone-1",
+            "1 High St",
+            "Extension",
+            "Householder",
+            42,
             new DateTimeOffset(2026, 3, 15, 8, 0, 0, TimeSpan.Zero));
 
         var newer = Notification.Create(
-            "user-1", "APP/2026/0002", "zone-1", "2 High St", "Garage", "Householder", 42,
+            "user-1",
+            "APP/2026/0002",
+            "zone-1",
+            "2 High St",
+            "Garage",
+            "Householder",
+            42,
             new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero));
 
         repo.Seed(newer);
@@ -62,7 +86,13 @@ public sealed class FakeNotificationRepositoryEmailTests
         var repo = new FakeNotificationRepository();
 
         var sent = Notification.Create(
-            "user-1", "APP/2026/0001", "zone-1", "1 High St", "Extension", "Householder", 42,
+            "user-1",
+            "APP/2026/0001",
+            "zone-1",
+            "1 High St",
+            "Extension",
+            "Householder",
+            42,
             new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero));
         sent.MarkEmailSent();
 
@@ -82,11 +112,23 @@ public sealed class FakeNotificationRepositoryEmailTests
         var repo = new FakeNotificationRepository();
 
         var user1Notification = Notification.Create(
-            "user-1", "APP/2026/0001", "zone-1", "1 High St", "Extension", "Householder", 42,
+            "user-1",
+            "APP/2026/0001",
+            "zone-1",
+            "1 High St",
+            "Extension",
+            "Householder",
+            42,
             new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero));
 
         var user2Notification = Notification.Create(
-            "user-2", "APP/2026/0002", "zone-2", "2 High St", "Garage", "Householder", 42,
+            "user-2",
+            "APP/2026/0002",
+            "zone-2",
+            "2 High St",
+            "Garage",
+            "Householder",
+            42,
             new DateTimeOffset(2026, 3, 15, 11, 0, 0, TimeSpan.Zero));
 
         repo.Seed(user1Notification);

--- a/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepositoryUserIdsTests.cs
+++ b/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepositoryUserIdsTests.cs
@@ -1,0 +1,117 @@
+using TownCrier.Domain.Notifications;
+
+namespace TownCrier.Application.Tests.Notifications;
+
+public sealed class FakeNotificationRepositoryUserIdsTests
+{
+    [Test]
+    public async Task Should_ReturnDistinctUserIds_When_MultipleUsersHaveUnsentEmails()
+    {
+        // Arrange
+        var repo = new FakeNotificationRepository();
+
+        var n1 = Notification.Create(
+            "user-1",
+            "APP/001",
+            "zone-1",
+            "1 High St",
+            "Extension",
+            "Householder",
+            42,
+            new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero));
+        var n2 = Notification.Create(
+            "user-2",
+            "APP/002",
+            "zone-2",
+            "2 High St",
+            "Garage",
+            "Householder",
+            42,
+            new DateTimeOffset(2026, 3, 15, 11, 0, 0, TimeSpan.Zero));
+        var n3 = Notification.Create(
+            "user-1",
+            "APP/003",
+            "zone-1",
+            "3 High St",
+            "Loft",
+            "Householder",
+            42,
+            new DateTimeOffset(2026, 3, 15, 12, 0, 0, TimeSpan.Zero));
+
+        repo.Seed(n1);
+        repo.Seed(n2);
+        repo.Seed(n3);
+
+        // Act
+        var result = await repo.GetUserIdsWithUnsentEmailsAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result).Contains("user-1");
+        await Assert.That(result).Contains("user-2");
+    }
+
+    [Test]
+    public async Task Should_ExcludeUsersWithAllEmailsSent_When_GetUserIdsWithUnsentEmailsAsyncCalled()
+    {
+        // Arrange
+        var repo = new FakeNotificationRepository();
+
+        var unsent = Notification.Create(
+            "user-1",
+            "APP/001",
+            "zone-1",
+            "1 High St",
+            "Extension",
+            "Householder",
+            42,
+            new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero));
+
+        var sent = Notification.Create(
+            "user-2",
+            "APP/002",
+            "zone-2",
+            "2 High St",
+            "Garage",
+            "Householder",
+            42,
+            new DateTimeOffset(2026, 3, 15, 11, 0, 0, TimeSpan.Zero));
+        sent.MarkEmailSent();
+
+        repo.Seed(unsent);
+        repo.Seed(sent);
+
+        // Act
+        var result = await repo.GetUserIdsWithUnsentEmailsAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result).Contains("user-1");
+    }
+
+    [Test]
+    public async Task Should_ReturnEmpty_When_NoUnsentEmails()
+    {
+        // Arrange
+        var repo = new FakeNotificationRepository();
+
+        var sent = Notification.Create(
+            "user-1",
+            "APP/001",
+            "zone-1",
+            "1 High St",
+            "Extension",
+            "Householder",
+            42,
+            new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero));
+        sent.MarkEmailSent();
+
+        repo.Seed(sent);
+
+        // Act
+        var result = await repo.GetUserIdsWithUnsentEmailsAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).HasCount().EqualTo(0);
+    }
+}

--- a/api/tests/town-crier.application.tests/Notifications/GenerateHourlyDigestsCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Notifications/GenerateHourlyDigestsCommandHandlerTests.cs
@@ -1,0 +1,316 @@
+using TownCrier.Application.Notifications;
+using TownCrier.Application.Tests.Polling;
+using TownCrier.Application.Tests.UserProfiles;
+using TownCrier.Domain.Notifications;
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.Tests.Notifications;
+
+public sealed class GenerateHourlyDigestsCommandHandlerTests
+{
+    [Test]
+    public async Task Should_SendDigestEmail_When_PersonalUserHasUnsentNotifications()
+    {
+        // Arrange
+        var (handler, notificationRepo, userProfileRepo, emailSender, watchZoneRepo) = CreateHandler();
+
+        var profile = new UserProfileBuilder()
+            .WithUserId("user-1")
+            .WithEmail("test@example.com")
+            .WithTier(SubscriptionTier.Personal)
+            .Build();
+        await userProfileRepo.SaveAsync(profile, CancellationToken.None);
+
+        var zone = new WatchZoneBuilder()
+            .WithId("zone-1")
+            .WithUserId("user-1")
+            .WithName("Home")
+            .Build();
+        await watchZoneRepo.SaveAsync(zone, CancellationToken.None);
+
+        SeedUnsentNotifications(notificationRepo, "user-1", "zone-1", count: 3);
+
+        // Act
+        await handler.HandleAsync(new GenerateHourlyDigestsCommand(), CancellationToken.None);
+
+        // Assert
+        await Assert.That(emailSender.DigestsSent).HasCount().EqualTo(1);
+        await Assert.That(emailSender.DigestsSent[0].Email).IsEqualTo("test@example.com");
+        await Assert.That(emailSender.DigestsSent[0].Digests).HasCount().EqualTo(1);
+        await Assert.That(emailSender.DigestsSent[0].Digests[0].WatchZoneName).IsEqualTo("Home");
+        await Assert.That(emailSender.DigestsSent[0].Digests[0].Notifications).HasCount().EqualTo(3);
+    }
+
+    [Test]
+    public async Task Should_SkipUser_When_FreeTier()
+    {
+        // Arrange
+        var (handler, notificationRepo, userProfileRepo, emailSender, _) = CreateHandler();
+
+        var profile = new UserProfileBuilder()
+            .WithUserId("user-1")
+            .WithEmail("test@example.com")
+            .WithTier(SubscriptionTier.Free)
+            .Build();
+        await userProfileRepo.SaveAsync(profile, CancellationToken.None);
+
+        SeedUnsentNotifications(notificationRepo, "user-1", "zone-1", count: 3);
+
+        // Act
+        await handler.HandleAsync(new GenerateHourlyDigestsCommand(), CancellationToken.None);
+
+        // Assert
+        await Assert.That(emailSender.DigestsSent).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_SkipUser_When_NoEmail()
+    {
+        // Arrange
+        var (handler, notificationRepo, userProfileRepo, emailSender, _) = CreateHandler();
+
+        var profile = new UserProfileBuilder()
+            .WithUserId("user-1")
+            .WithTier(SubscriptionTier.Personal)
+            .Build();
+        await userProfileRepo.SaveAsync(profile, CancellationToken.None);
+
+        SeedUnsentNotifications(notificationRepo, "user-1", "zone-1", count: 3);
+
+        // Act
+        await handler.HandleAsync(new GenerateHourlyDigestsCommand(), CancellationToken.None);
+
+        // Assert
+        await Assert.That(emailSender.DigestsSent).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_SkipUser_When_EmailDigestDisabled()
+    {
+        // Arrange
+        var (handler, notificationRepo, userProfileRepo, emailSender, _) = CreateHandler();
+
+        var profile = new UserProfileBuilder()
+            .WithUserId("user-1")
+            .WithEmail("test@example.com")
+            .WithTier(SubscriptionTier.Personal)
+            .WithEmailDigestEnabled(false)
+            .Build();
+        await userProfileRepo.SaveAsync(profile, CancellationToken.None);
+
+        SeedUnsentNotifications(notificationRepo, "user-1", "zone-1", count: 3);
+
+        // Act
+        await handler.HandleAsync(new GenerateHourlyDigestsCommand(), CancellationToken.None);
+
+        // Assert
+        await Assert.That(emailSender.DigestsSent).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_CompleteImmediately_When_NoUsersHaveUnsentNotifications()
+    {
+        // Arrange
+        var (handler, _, _, emailSender, _) = CreateHandler();
+
+        // No notifications seeded
+
+        // Act
+        await handler.HandleAsync(new GenerateHourlyDigestsCommand(), CancellationToken.None);
+
+        // Assert
+        await Assert.That(emailSender.DigestsSent).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_GroupNotificationsByWatchZone_When_SendingDigest()
+    {
+        // Arrange
+        var (handler, notificationRepo, userProfileRepo, emailSender, watchZoneRepo) = CreateHandler();
+
+        var profile = new UserProfileBuilder()
+            .WithUserId("user-1")
+            .WithEmail("test@example.com")
+            .WithTier(SubscriptionTier.Personal)
+            .Build();
+        await userProfileRepo.SaveAsync(profile, CancellationToken.None);
+
+        var zone1 = new WatchZoneBuilder()
+            .WithId("zone-1")
+            .WithUserId("user-1")
+            .WithName("Home")
+            .Build();
+        var zone2 = new WatchZoneBuilder()
+            .WithId("zone-2")
+            .WithUserId("user-1")
+            .WithName("Office")
+            .Build();
+        await watchZoneRepo.SaveAsync(zone1, CancellationToken.None);
+        await watchZoneRepo.SaveAsync(zone2, CancellationToken.None);
+
+        SeedUnsentNotifications(notificationRepo, "user-1", "zone-1", count: 2);
+        SeedUnsentNotifications(notificationRepo, "user-1", "zone-2", count: 3);
+
+        // Act
+        await handler.HandleAsync(new GenerateHourlyDigestsCommand(), CancellationToken.None);
+
+        // Assert
+        await Assert.That(emailSender.DigestsSent).HasCount().EqualTo(1);
+        var digests = emailSender.DigestsSent[0].Digests;
+        await Assert.That(digests).HasCount().EqualTo(2);
+        await Assert.That(digests.Any(d => d.WatchZoneName == "Home" && d.Notifications.Count == 2)).IsTrue();
+        await Assert.That(digests.Any(d => d.WatchZoneName == "Office" && d.Notifications.Count == 3)).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_MarkNotificationsAsEmailSent_When_DigestSent()
+    {
+        // Arrange
+        var (handler, notificationRepo, userProfileRepo, _, watchZoneRepo) = CreateHandler();
+
+        var profile = new UserProfileBuilder()
+            .WithUserId("user-1")
+            .WithEmail("test@example.com")
+            .WithTier(SubscriptionTier.Personal)
+            .Build();
+        await userProfileRepo.SaveAsync(profile, CancellationToken.None);
+
+        var zone = new WatchZoneBuilder()
+            .WithId("zone-1")
+            .WithUserId("user-1")
+            .WithName("Home")
+            .Build();
+        await watchZoneRepo.SaveAsync(zone, CancellationToken.None);
+
+        SeedUnsentNotifications(notificationRepo, "user-1", "zone-1", count: 2);
+
+        // Act
+        await handler.HandleAsync(new GenerateHourlyDigestsCommand(), CancellationToken.None);
+
+        // Assert
+        var allNotifications = notificationRepo.All;
+        await Assert.That(allNotifications.All(n => n.EmailSent)).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_SendDigestsToMultipleUsers_When_BothHaveUnsentNotifications()
+    {
+        // Arrange
+        var (handler, notificationRepo, userProfileRepo, emailSender, watchZoneRepo) = CreateHandler();
+
+        var profile1 = new UserProfileBuilder()
+            .WithUserId("user-1")
+            .WithEmail("user1@example.com")
+            .WithTier(SubscriptionTier.Personal)
+            .Build();
+        var profile2 = new UserProfileBuilder()
+            .WithUserId("user-2")
+            .WithEmail("user2@example.com")
+            .WithTier(SubscriptionTier.Pro)
+            .Build();
+        await userProfileRepo.SaveAsync(profile1, CancellationToken.None);
+        await userProfileRepo.SaveAsync(profile2, CancellationToken.None);
+
+        var zone1 = new WatchZoneBuilder()
+            .WithId("zone-1")
+            .WithUserId("user-1")
+            .WithName("Home")
+            .Build();
+        var zone2 = new WatchZoneBuilder()
+            .WithId("zone-2")
+            .WithUserId("user-2")
+            .WithName("Work")
+            .Build();
+        await watchZoneRepo.SaveAsync(zone1, CancellationToken.None);
+        await watchZoneRepo.SaveAsync(zone2, CancellationToken.None);
+
+        SeedUnsentNotifications(notificationRepo, "user-1", "zone-1", count: 2);
+        SeedUnsentNotifications(notificationRepo, "user-2", "zone-2", count: 4);
+
+        // Act
+        await handler.HandleAsync(new GenerateHourlyDigestsCommand(), CancellationToken.None);
+
+        // Assert
+        await Assert.That(emailSender.DigestsSent).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task Should_SkipUser_When_ProfileNotFound()
+    {
+        // Arrange
+        var (handler, notificationRepo, _, emailSender, _) = CreateHandler();
+
+        // Seed notifications but no profile
+        SeedUnsentNotifications(notificationRepo, "user-1", "zone-1", count: 3);
+
+        // Act
+        await handler.HandleAsync(new GenerateHourlyDigestsCommand(), CancellationToken.None);
+
+        // Assert
+        await Assert.That(emailSender.DigestsSent).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_NotMarkAsSent_When_UserSkipped()
+    {
+        // Arrange
+        var (handler, notificationRepo, userProfileRepo, _, _) = CreateHandler();
+
+        var profile = new UserProfileBuilder()
+            .WithUserId("user-1")
+            .WithEmail("test@example.com")
+            .WithTier(SubscriptionTier.Free)
+            .Build();
+        await userProfileRepo.SaveAsync(profile, CancellationToken.None);
+
+        SeedUnsentNotifications(notificationRepo, "user-1", "zone-1", count: 2);
+
+        // Act
+        await handler.HandleAsync(new GenerateHourlyDigestsCommand(), CancellationToken.None);
+
+        // Assert -- notifications should remain unsent
+        var allNotifications = notificationRepo.All;
+        await Assert.That(allNotifications.All(n => !n.EmailSent)).IsTrue();
+    }
+
+    private static (GenerateHourlyDigestsCommandHandler Handler,
+        FakeNotificationRepository NotificationRepo,
+        FakeUserProfileRepository UserProfileRepo,
+        SpyEmailSender EmailSender,
+        FakeWatchZoneRepository WatchZoneRepo) CreateHandler()
+    {
+        var notificationRepo = new FakeNotificationRepository();
+        var userProfileRepo = new FakeUserProfileRepository();
+        var emailSender = new SpyEmailSender();
+        var watchZoneRepo = new FakeWatchZoneRepository();
+
+        var handler = new GenerateHourlyDigestsCommandHandler(
+            notificationRepo,
+            userProfileRepo,
+            emailSender,
+            watchZoneRepo);
+
+        return (handler, notificationRepo, userProfileRepo, emailSender, watchZoneRepo);
+    }
+
+    private static void SeedUnsentNotifications(
+        FakeNotificationRepository notificationRepo,
+        string userId,
+        string watchZoneId,
+        int count)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            var notification = Notification.Create(
+                userId: userId,
+                applicationName: $"APP/{watchZoneId}/{i:D3}",
+                watchZoneId: watchZoneId,
+                applicationAddress: $"{i} Test Street",
+                applicationDescription: "Test application",
+                applicationType: "Full",
+                authorityId: 1,
+                now: DateTimeOffset.UtcNow.AddMinutes(-i));
+            notificationRepo.Seed(notification);
+        }
+    }
+}

--- a/api/tests/town-crier.application.tests/Notifications/UserProfileBuilder.cs
+++ b/api/tests/town-crier.application.tests/Notifications/UserProfileBuilder.cs
@@ -10,7 +10,6 @@ internal sealed class UserProfileBuilder
     private bool pushEnabled = true;
     private DayOfWeek digestDay = DayOfWeek.Monday;
     private bool emailDigestEnabled = true;
-    private bool emailInstantEnabled;
 
     public UserProfileBuilder WithUserId(string userId)
     {
@@ -48,12 +47,6 @@ internal sealed class UserProfileBuilder
         return this;
     }
 
-    public UserProfileBuilder WithEmailInstantEnabled(bool enabled)
-    {
-        this.emailInstantEnabled = enabled;
-        return this;
-    }
-
     public UserProfile Build()
     {
         var profile = UserProfile.Register(this.userId, this.email);
@@ -61,8 +54,7 @@ internal sealed class UserProfileBuilder
             new NotificationPreferences(
                 this.pushEnabled,
                 this.digestDay,
-                this.emailDigestEnabled,
-                this.emailInstantEnabled));
+                this.emailDigestEnabled));
 
         if (this.tier != SubscriptionTier.Free)
         {

--- a/api/tests/town-crier.application.tests/PlanningApplications/GetUserApplicationAuthoritiesQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/PlanningApplications/GetUserApplicationAuthoritiesQueryHandlerTests.cs
@@ -29,7 +29,7 @@ public sealed class GetUserApplicationAuthoritiesQueryHandlerTests
     public async Task Should_ReturnMatchingAuthorities_When_UserHasWatchZones()
     {
         this.watchZoneRepository.Add(new WatchZone(
-            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42));
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42, DateTimeOffset.MinValue));
         this.authorityProvider.Add(
             new AuthorityBuilder().WithId(42).WithName("Cornwall Council").WithAreaType("Unitary").Build());
 
@@ -49,9 +49,9 @@ public sealed class GetUserApplicationAuthoritiesQueryHandlerTests
     public async Task Should_DeduplicateAuthorities_When_MultipleZonesSameAuthority()
     {
         this.watchZoneRepository.Add(new WatchZone(
-            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42));
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42, DateTimeOffset.MinValue));
         this.watchZoneRepository.Add(new WatchZone(
-            "zone-2", "user-1", "Office", new Coordinates(50.8, -3.6), 3000, 42));
+            "zone-2", "user-1", "Office", new Coordinates(50.8, -3.6), 3000, 42, DateTimeOffset.MinValue));
         this.authorityProvider.Add(
             new AuthorityBuilder().WithId(42).WithName("Cornwall Council").WithAreaType("Unitary").Build());
 
@@ -68,9 +68,9 @@ public sealed class GetUserApplicationAuthoritiesQueryHandlerTests
     public async Task Should_SortByName_When_MultipleAuthorities()
     {
         this.watchZoneRepository.Add(new WatchZone(
-            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42));
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42, DateTimeOffset.MinValue));
         this.watchZoneRepository.Add(new WatchZone(
-            "zone-2", "user-1", "Work", new Coordinates(51.5, -0.1), 3000, 10));
+            "zone-2", "user-1", "Work", new Coordinates(51.5, -0.1), 3000, 10, DateTimeOffset.MinValue));
         this.authorityProvider.Add(
             new AuthorityBuilder().WithId(42).WithName("Cornwall Council").WithAreaType("Unitary").Build());
         this.authorityProvider.Add(
@@ -91,9 +91,9 @@ public sealed class GetUserApplicationAuthoritiesQueryHandlerTests
     public async Task Should_ExcludeOtherUsersZones_When_MultipleUsersExist()
     {
         this.watchZoneRepository.Add(new WatchZone(
-            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42));
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 42, DateTimeOffset.MinValue));
         this.watchZoneRepository.Add(new WatchZone(
-            "zone-2", "user-2", "Home", new Coordinates(51.5, -0.1), 3000, 10));
+            "zone-2", "user-2", "Home", new Coordinates(51.5, -0.1), 3000, 10, DateTimeOffset.MinValue));
         this.authorityProvider.Add(
             new AuthorityBuilder().WithId(42).WithName("Cornwall Council").WithAreaType("Unitary").Build());
         this.authorityProvider.Add(
@@ -113,7 +113,7 @@ public sealed class GetUserApplicationAuthoritiesQueryHandlerTests
     public async Task Should_SkipAuthority_When_NotFoundInProvider()
     {
         this.watchZoneRepository.Add(new WatchZone(
-            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 999));
+            "zone-1", "user-1", "Home", new Coordinates(50.7, -3.5), 5000, 999, DateTimeOffset.MinValue));
 
         var handler = new GetUserApplicationAuthoritiesQueryHandler(
             this.watchZoneRepository, this.authorityProvider);

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -67,7 +67,7 @@ public sealed class PollPlanItCommandHandlerTests
     }
 
     [Test]
-    public async Task Should_UseDefault30DayLookback_When_NoPreviousPollState()
+    public async Task Should_UseDefault1DayLookback_When_NoPreviousPollState()
     {
         var authorityProvider = new FakeActiveAuthorityProvider();
         authorityProvider.Add(1);
@@ -81,7 +81,7 @@ public sealed class PollPlanItCommandHandlerTests
 
         await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
 
-        var expected = new DateTimeOffset(2026, 3, 6, 12, 0, 0, TimeSpan.Zero);
+        var expected = new DateTimeOffset(2026, 4, 4, 12, 0, 0, TimeSpan.Zero);
         await Assert.That(planItClient.LastDifferentStartUsed).IsEqualTo(expected);
     }
 
@@ -419,7 +419,7 @@ public sealed class PollPlanItCommandHandlerTests
     }
 
     [Test]
-    public async Task Should_Use30DayLookback_When_NewAuthorityHasNoPollState()
+    public async Task Should_Use1DayLookback_When_NewAuthorityHasNoPollState()
     {
         var authorityProvider = new FakeActiveAuthorityProvider();
         authorityProvider.Add(100);
@@ -443,9 +443,9 @@ public sealed class PollPlanItCommandHandlerTests
         // Authority 100 should use its existing poll time
         await Assert.That(planItClient.DifferentStartByAuthority[100]).IsEqualTo(existingPollTime);
 
-        // Authority 200 should use 30-day lookback
-        var expected30DaysAgo = new DateTimeOffset(2026, 3, 6, 12, 0, 0, TimeSpan.Zero);
-        await Assert.That(planItClient.DifferentStartByAuthority[200]).IsEqualTo(expected30DaysAgo);
+        // Authority 200 should use 1-day lookback
+        var expected1DayAgo = new DateTimeOffset(2026, 4, 4, 12, 0, 0, TimeSpan.Zero);
+        await Assert.That(planItClient.DifferentStartByAuthority[200]).IsEqualTo(expected1DayAgo);
     }
 
     [Test]

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -168,6 +168,70 @@ public sealed class PollPlanItCommandHandlerTests
     }
 
     [Test]
+    public async Task Should_NotEnqueueNotification_When_ZoneCreatedAfterApplicationLastDifferent()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(1);
+
+        var applicationLastDifferent = new DateTimeOffset(2026, 3, 10, 12, 0, 0, TimeSpan.Zero);
+        var zoneCreatedAt = new DateTimeOffset(2026, 3, 15, 14, 0, 0, TimeSpan.Zero);
+
+        var watchZoneRepository = new FakeWatchZoneRepository();
+        watchZoneRepository.Add(new WatchZoneBuilder()
+            .WithId("zone-1").WithUserId("user-1")
+            .WithCentre(51.5074, -0.1278).WithRadiusMetres(5000).WithAuthorityId(1)
+            .WithCreatedAt(zoneCreatedAt).Build());
+
+        var notificationEnqueuer = new FakeNotificationEnqueuer();
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(1, new PlanningApplicationBuilder()
+            .WithUid("app-1").WithAreaId(1).WithCoordinates(51.5080, -0.1270)
+            .WithLastDifferent(applicationLastDifferent).Build());
+
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            authorityProvider: authorityProvider,
+            watchZoneRepository: watchZoneRepository,
+            notificationEnqueuer: notificationEnqueuer);
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(notificationEnqueuer.Enqueued).HasCount().EqualTo(0);
+    }
+
+    [Test]
+    public async Task Should_EnqueueNotification_When_ZoneCreatedBeforeApplicationLastDifferent()
+    {
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(1);
+
+        var applicationLastDifferent = new DateTimeOffset(2026, 3, 15, 14, 0, 0, TimeSpan.Zero);
+        var zoneCreatedAt = new DateTimeOffset(2026, 3, 10, 12, 0, 0, TimeSpan.Zero);
+
+        var watchZoneRepository = new FakeWatchZoneRepository();
+        watchZoneRepository.Add(new WatchZoneBuilder()
+            .WithId("zone-1").WithUserId("user-1")
+            .WithCentre(51.5074, -0.1278).WithRadiusMetres(5000).WithAuthorityId(1)
+            .WithCreatedAt(zoneCreatedAt).Build());
+
+        var notificationEnqueuer = new FakeNotificationEnqueuer();
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(1, new PlanningApplicationBuilder()
+            .WithUid("app-1").WithAreaId(1).WithCoordinates(51.5080, -0.1270)
+            .WithLastDifferent(applicationLastDifferent).Build());
+
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            authorityProvider: authorityProvider,
+            watchZoneRepository: watchZoneRepository,
+            notificationEnqueuer: notificationEnqueuer);
+
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        await Assert.That(notificationEnqueuer.Enqueued).HasCount().EqualTo(1);
+    }
+
+    [Test]
     public async Task Should_NotEnqueueNotification_When_ApplicationHasNoCoordinates()
     {
         var authorityProvider = new FakeActiveAuthorityProvider();

--- a/api/tests/town-crier.application.tests/Polling/WatchZoneBuilder.cs
+++ b/api/tests/town-crier.application.tests/Polling/WatchZoneBuilder.cs
@@ -12,6 +12,7 @@ internal sealed class WatchZoneBuilder
     private double longitude = -0.1278;
     private double radiusMetres = 5000;
     private int authorityId = 1;
+    private DateTimeOffset createdAt = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
     public WatchZoneBuilder WithId(string id)
     {
@@ -50,6 +51,12 @@ internal sealed class WatchZoneBuilder
         return this;
     }
 
+    public WatchZoneBuilder WithCreatedAt(DateTimeOffset createdAt)
+    {
+        this.createdAt = createdAt;
+        return this;
+    }
+
     public WatchZone Build()
     {
         return new WatchZone(
@@ -58,6 +65,7 @@ internal sealed class WatchZoneBuilder
             this.name,
             new Coordinates(this.latitude, this.longitude),
             this.radiusMetres,
-            this.authorityId);
+            this.authorityId,
+            this.createdAt);
     }
 }

--- a/api/tests/town-crier.application.tests/UserProfiles/GetUserProfileQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/GetUserProfileQueryHandlerTests.cs
@@ -58,7 +58,6 @@ public sealed class GetUserProfileQueryHandlerTests
         // Assert
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.EmailDigestEnabled).IsTrue();
-        await Assert.That(result.EmailInstantEnabled).IsFalse();
         await Assert.That(result.DigestDay).IsEqualTo(DayOfWeek.Monday);
     }
 }

--- a/api/tests/town-crier.application.tests/UserProfiles/UpdateUserProfileCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/UpdateUserProfileCommandHandlerTests.cs
@@ -112,26 +112,6 @@ public sealed class UpdateUserProfileCommandHandlerTests
     }
 
     [Test]
-    public async Task Should_UpdateEmailInstantEnabled_When_SetToTrue()
-    {
-        // Arrange
-        var repository = new FakeUserProfileRepository();
-        var profile = UserProfile.Register("auth0|user-789");
-        await repository.SaveAsync(profile, CancellationToken.None);
-
-        var handler = new UpdateUserProfileCommandHandler(repository);
-        var command = new UpdateUserProfileCommand("auth0|user-789", true, EmailInstantEnabled: true);
-
-        // Act
-        var result = await handler.HandleAsync(command, CancellationToken.None);
-
-        // Assert
-        await Assert.That(result.EmailInstantEnabled).IsTrue();
-        var saved = repository.GetByUserId("auth0|user-789");
-        await Assert.That(saved!.NotificationPreferences.EmailInstantEnabled).IsTrue();
-    }
-
-    [Test]
     public async Task Should_UpdateDigestDay_When_SetToFriday()
     {
         // Arrange

--- a/api/tests/town-crier.application.tests/WatchZones/CreateWatchZoneCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/WatchZones/CreateWatchZoneCommandHandlerTests.cs
@@ -38,6 +38,24 @@ public sealed class CreateWatchZoneCommandHandlerTests
     }
 
     [Test]
+    public async Task Should_SetCreatedAtFromTimeProvider_When_ZoneCreated()
+    {
+        // Arrange
+        var profile = UserProfile.Register("user-1");
+        await this.userProfileRepository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = this.CreateHandler();
+        var command = CreateCommand();
+
+        // Act
+        await handler.HandleAsync(command, CancellationToken.None);
+
+        // Assert
+        var zones = await this.watchZoneRepository.FindZonesContainingAsync(51.5074, -0.1278, CancellationToken.None);
+        await Assert.That(zones.First().CreatedAt).IsEqualTo(FixedNow);
+    }
+
+    [Test]
     public async Task Should_NotCallPlanIt_When_FreeUserCreatesZone()
     {
         // Arrange

--- a/api/tests/town-crier.infrastructure.tests/Notifications/NotificationDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Notifications/NotificationDocumentTests.cs
@@ -34,6 +34,7 @@ public sealed class NotificationDocumentTests
         await Assert.That(roundTripped.ApplicationType).IsEqualTo("Full Planning");
         await Assert.That(roundTripped.AuthorityId).IsEqualTo(55);
         await Assert.That(roundTripped.PushSent).IsEqualTo(notification.PushSent);
+        await Assert.That(roundTripped.EmailSent).IsEqualTo(notification.EmailSent);
         await Assert.That(roundTripped.CreatedAt).IsEqualTo(notification.CreatedAt);
     }
 
@@ -50,6 +51,35 @@ public sealed class NotificationDocumentTests
 
         // Assert
         await Assert.That(roundTripped.PushSent).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_PreserveEmailSentFlag_When_NotificationHasEmailSent()
+    {
+        // Arrange
+        var notification = new NotificationBuilder().Build();
+        notification.MarkEmailSent();
+
+        // Act
+        var document = NotificationDocument.FromDomain(notification);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.EmailSent).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_DefaultEmailSentToFalse_When_NewlyCreated()
+    {
+        // Arrange
+        var notification = new NotificationBuilder().Build();
+
+        // Act
+        var document = NotificationDocument.FromDomain(notification);
+        var roundTripped = document.ToDomain();
+
+        // Assert
+        await Assert.That(roundTripped.EmailSent).IsFalse();
     }
 
     [Test]

--- a/api/tests/town-crier.infrastructure.tests/Notifications/NotificationEmailSentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Notifications/NotificationEmailSentTests.cs
@@ -1,0 +1,27 @@
+namespace TownCrier.Infrastructure.Tests.Notifications;
+
+public sealed class NotificationEmailSentTests
+{
+    [Test]
+    public async Task Should_HaveEmailSentFalse_When_NewlyCreated()
+    {
+        // Arrange & Act
+        var notification = new NotificationBuilder().Build();
+
+        // Assert
+        await Assert.That(notification.EmailSent).IsFalse();
+    }
+
+    [Test]
+    public async Task Should_HaveEmailSentTrue_When_MarkEmailSentCalled()
+    {
+        // Arrange
+        var notification = new NotificationBuilder().Build();
+
+        // Act
+        notification.MarkEmailSent();
+
+        // Assert
+        await Assert.That(notification.EmailSent).IsTrue();
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/WatchZones/CosmosWatchZoneRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/WatchZones/CosmosWatchZoneRepositoryTests.cs
@@ -15,7 +15,7 @@ public sealed class CosmosWatchZoneRepositoryTests
         var client = new FakeCosmosRestClient();
         var repo = new CosmosWatchZoneRepository(client);
 
-        var zone = new WatchZone("zone-1", "user-1", "Home", new Coordinates(51.5, -0.1), 500, 100);
+        var zone = new WatchZone("zone-1", "user-1", "Home", new Coordinates(51.5, -0.1), 500, 100, DateTimeOffset.MinValue);
 
         // Act
         await repo.SaveAsync(zone, CancellationToken.None);
@@ -33,8 +33,8 @@ public sealed class CosmosWatchZoneRepositoryTests
         var client = new FakeCosmosRestClient();
         var repo = new CosmosWatchZoneRepository(client);
 
-        var zone1 = new WatchZone("zone-1", "user-1", "Home", new Coordinates(51.5, -0.1), 500, 100);
-        var zone2 = new WatchZone("zone-2", "user-1", "Work", new Coordinates(51.6, -0.2), 1000, 200);
+        var zone1 = new WatchZone("zone-1", "user-1", "Home", new Coordinates(51.5, -0.1), 500, 100, DateTimeOffset.MinValue);
+        var zone2 = new WatchZone("zone-2", "user-1", "Work", new Coordinates(51.6, -0.2), 1000, 200, DateTimeOffset.MinValue);
         await repo.SaveAsync(zone1, CancellationToken.None);
         await repo.SaveAsync(zone2, CancellationToken.None);
 
@@ -52,7 +52,7 @@ public sealed class CosmosWatchZoneRepositoryTests
         var client = new FakeCosmosRestClient();
         var repo = new CosmosWatchZoneRepository(client);
 
-        var zone = new WatchZone("zone-1", "user-1", "Home", new Coordinates(51.5, -0.1), 500, 100);
+        var zone = new WatchZone("zone-1", "user-1", "Home", new Coordinates(51.5, -0.1), 500, 100, DateTimeOffset.MinValue);
         await repo.SaveAsync(zone, CancellationToken.None);
 
         // Act
@@ -82,7 +82,7 @@ public sealed class CosmosWatchZoneRepositoryTests
         var client = new FakeCosmosRestClient();
         var repo = new CosmosWatchZoneRepository(client);
 
-        var zone = new WatchZone("zone-1", "user-1", "Home", new Coordinates(51.5, -0.1), 500, 100);
+        var zone = new WatchZone("zone-1", "user-1", "Home", new Coordinates(51.5, -0.1), 500, 100, DateTimeOffset.MinValue);
         await repo.SaveAsync(zone, CancellationToken.None);
 
         // Act — fake returns all documents in collection (no SQL parsing)

--- a/api/tests/town-crier.infrastructure.tests/WatchZones/WatchZoneDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/WatchZones/WatchZoneDocumentTests.cs
@@ -8,11 +8,13 @@ namespace TownCrier.Infrastructure.Tests.WatchZones;
 
 public sealed class WatchZoneDocumentTests
 {
+    private static readonly DateTimeOffset TestCreatedAt = new(2026, 3, 15, 10, 0, 0, TimeSpan.Zero);
+
     [Test]
     public async Task Should_PreserveAllFields_When_MappedFromDomain()
     {
         // Arrange
-        var zone = new WatchZone("zone-1", "user-1", "Home Area", new Coordinates(51.5074, -0.1278), 5000, 42);
+        var zone = new WatchZone("zone-1", "user-1", "Home Area", new Coordinates(51.5074, -0.1278), 5000, 42, TestCreatedAt);
 
         // Act
         var document = WatchZoneDocument.FromDomain(zone);
@@ -25,13 +27,14 @@ public sealed class WatchZoneDocumentTests
         await Assert.That(document.Longitude).IsEqualTo(-0.1278);
         await Assert.That(document.RadiusMetres).IsEqualTo(5000);
         await Assert.That(document.AuthorityId).IsEqualTo(42);
+        await Assert.That(document.CreatedAt).IsEqualTo(TestCreatedAt);
     }
 
     [Test]
     public async Task Should_RoundTripToDomain_When_MappedBackAndForth()
     {
         // Arrange
-        var original = new WatchZone("zone-1", "user-1", "Home Area", new Coordinates(51.5074, -0.1278), 5000, 42);
+        var original = new WatchZone("zone-1", "user-1", "Home Area", new Coordinates(51.5074, -0.1278), 5000, 42, TestCreatedAt);
 
         // Act
         var document = WatchZoneDocument.FromDomain(original);
@@ -45,6 +48,7 @@ public sealed class WatchZoneDocumentTests
         await Assert.That(roundTripped.Centre.Longitude).IsEqualTo(original.Centre.Longitude);
         await Assert.That(roundTripped.RadiusMetres).IsEqualTo(original.RadiusMetres);
         await Assert.That(roundTripped.AuthorityId).IsEqualTo(original.AuthorityId);
+        await Assert.That(roundTripped.CreatedAt).IsEqualTo(original.CreatedAt);
     }
 
     [Test]
@@ -52,13 +56,9 @@ public sealed class WatchZoneDocumentTests
     {
         // Arrange
         var original = WatchZoneDocument.FromDomain(
-            new WatchZone("zone-1", "user-1", "Home Area", new Coordinates(51.5074, -0.1278), 5000, 42));
+            new WatchZone("zone-1", "user-1", "Home Area", new Coordinates(51.5074, -0.1278), 5000, 42, TestCreatedAt));
 
-        var jsonOptions = new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        };
-        jsonOptions.TypeInfoResolverChain.Add(CosmosJsonSerializerContext.Default);
+        var jsonOptions = CreateJsonOptions();
 
         // Act
         var json = JsonSerializer.Serialize(original, jsonOptions);
@@ -72,5 +72,32 @@ public sealed class WatchZoneDocumentTests
         await Assert.That(deserialized.Longitude).IsEqualTo(original.Longitude);
         await Assert.That(deserialized.RadiusMetres).IsEqualTo(original.RadiusMetres);
         await Assert.That(deserialized.AuthorityId).IsEqualTo(original.AuthorityId);
+        await Assert.That(deserialized.CreatedAt).IsEqualTo(original.CreatedAt);
+    }
+
+    [Test]
+    public async Task Should_DefaultCreatedAtToMinValue_When_CosmosDocumentHasNoCreatedAt()
+    {
+        // Arrange — simulate a legacy document with no createdAt field
+        var json = """{"id":"zone-1","userId":"user-1","name":"Old Zone","latitude":51.5,"longitude":-0.1,"radiusMetres":500,"authorityId":100}""";
+
+        var jsonOptions = CreateJsonOptions();
+
+        // Act
+        var document = JsonSerializer.Deserialize<WatchZoneDocument>(json, jsonOptions)!;
+        var zone = document.ToDomain();
+
+        // Assert — missing createdAt should default to MinValue
+        await Assert.That(zone.CreatedAt).IsEqualTo(DateTimeOffset.MinValue);
+    }
+
+    private static JsonSerializerOptions CreateJsonOptions()
+    {
+        var options = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+        options.TypeInfoResolverChain.Add(CosmosJsonSerializerContext.Default);
+        return options;
     }
 }

--- a/api/tests/town-crier.web.tests/Entitlements/EntitlementEndpointFilterTests.cs
+++ b/api/tests/town-crier.web.tests/Entitlements/EntitlementEndpointFilterTests.cs
@@ -9,51 +9,7 @@ namespace TownCrier.Web.Tests.Entitlements;
 public sealed class EntitlementEndpointFilterTests
 {
     [Test]
-    public async Task Should_Return403_When_FreeTierEnablesInstantEmails()
-    {
-        await using var factory = new TestWebApplicationFactory();
-        using var client = factory.CreateClient();
-
-        var token = TestJwtToken.Generate(
-            userId: "auth0|free-user",
-            claims: [new Claim("subscription_tier", "Free")]);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        (await client.PostAsync(new Uri("/v1/me", UriKind.Relative), null)).Dispose();
-
-        using var content = new StringContent(
-            """{"pushEnabled":true,"emailInstantEnabled":true}""",
-            System.Text.Encoding.UTF8,
-            "application/json");
-        using var response = await client.PatchAsync(new Uri("/v1/me", UriKind.Relative), content);
-
-        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Forbidden);
-    }
-
-    [Test]
-    public async Task Should_AllowInstantEmails_When_PersonalTier()
-    {
-        await using var factory = new TestWebApplicationFactory();
-        using var client = factory.CreateClient();
-
-        var token = TestJwtToken.Generate(
-            userId: "auth0|personal-user",
-            claims: [new Claim("subscription_tier", "Personal")]);
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
-
-        (await client.PostAsync(new Uri("/v1/me", UriKind.Relative), null)).Dispose();
-
-        using var content = new StringContent(
-            """{"pushEnabled":true,"emailInstantEnabled":true}""",
-            System.Text.Encoding.UTF8,
-            "application/json");
-        using var response = await client.PatchAsync(new Uri("/v1/me", UriKind.Relative), content);
-
-        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
-    }
-
-    [Test]
-    public async Task Should_AllowNonEntitledPreferences_When_FreeTier()
+    public async Task Should_AllowPreferenceUpdate_When_FreeTier()
     {
         await using var factory = new TestWebApplicationFactory();
         using var client = factory.CreateClient();
@@ -65,9 +21,9 @@ public sealed class EntitlementEndpointFilterTests
 
         (await client.PostAsync(new Uri("/v1/me", UriKind.Relative), null)).Dispose();
 
-        // Free user can still update non-entitled preferences
+        // Free user can update preferences
         using var content = new StringContent(
-            """{"pushEnabled":false,"emailDigestEnabled":false,"emailInstantEnabled":false}""",
+            """{"pushEnabled":false,"emailDigestEnabled":false}""",
             System.Text.Encoding.UTF8,
             "application/json");
         using var response = await client.PatchAsync(new Uri("/v1/me", UriKind.Relative), content);

--- a/api/tests/town-crier.web.tests/Observability/DependencyTracingTests.cs
+++ b/api/tests/town-crier.web.tests/Observability/DependencyTracingTests.cs
@@ -1,0 +1,161 @@
+using System.Diagnostics;
+using Azure.Monitor.OpenTelemetry.Exporter;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+
+namespace TownCrier.Web.Tests.Observability;
+
+public sealed class DependencyTracingTests
+{
+#pragma warning disable S1075 // Test URIs are intentionally hardcoded
+    private const string FakeDependencyUrl = "http://localhost:19999/fake-dependency";
+#pragma warning restore S1075
+
+    [Test]
+    [Retry(3)]
+    public async Task Should_ExportClientSpan_When_OutboundHttpCallIsMade()
+    {
+        // Arrange -- configure a fake App Insights connection string so the
+        // Azure Monitor exporter (and its sampler) are registered, matching
+        // the production code path in Program.cs. The sampler must not drop
+        // Client spans for them to appear in the App Insights dependencies table.
+        var exportedActivities = new List<Activity>();
+        await using var baseFactory = new TestWebApplicationFactory();
+        await using var factory = baseFactory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting(
+                "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://localhost/");
+
+            builder.ConfigureTestServices(services =>
+            {
+                services.AddOpenTelemetry()
+                    .WithTracing(tracing =>
+                    {
+                        tracing.AddInMemoryExporter(exportedActivities);
+                    });
+            });
+        });
+        using var client = factory.CreateClient();
+
+        // Act -- create an HttpClient from the DI container to simulate an
+        // outbound call within the traced pipeline.
+        var innerHttpClientFactory = factory.Services.GetRequiredService<IHttpClientFactory>();
+        using var innerClient = innerHttpClientFactory.CreateClient();
+
+        try
+        {
+            // This call will fail (no real server) but should still create a Client span
+            await innerClient.GetAsync(new Uri(FakeDependencyUrl));
+        }
+        catch (HttpRequestException)
+        {
+            // Expected -- the target doesn't exist, but the span should still be created
+        }
+
+        // Force flush to ensure all spans are exported
+        var tracerProvider = factory.Services.GetRequiredService<TracerProvider>();
+        tracerProvider.ForceFlush();
+
+        // Assert -- verify a Client span was exported (maps to App Insights dependencies table).
+        // If the Azure Monitor sampler is dropping these spans, this test fails.
+        var clientSpan = exportedActivities.Find(a => a.Kind == ActivityKind.Client);
+        await Assert.That(clientSpan).IsNotNull()
+            .Because("HTTP Client spans must be exported for the App Insights dependencies table");
+    }
+
+    [Test]
+    [Retry(3)]
+    public async Task Should_IncludeHttpAttributesOnClientSpan_When_OutboundHttpCallIsMade()
+    {
+        // Arrange
+        var exportedActivities = new List<Activity>();
+        await using var baseFactory = new TestWebApplicationFactory();
+        await using var factory = baseFactory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting(
+                "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://localhost/");
+
+            builder.ConfigureTestServices(services =>
+            {
+                services.AddOpenTelemetry()
+                    .WithTracing(tracing =>
+                    {
+                        tracing.AddInMemoryExporter(exportedActivities);
+                    });
+            });
+        });
+
+        var innerHttpClientFactory = factory.Services.GetRequiredService<IHttpClientFactory>();
+        using var innerClient = innerHttpClientFactory.CreateClient();
+
+        try
+        {
+            await innerClient.GetAsync(new Uri(FakeDependencyUrl));
+        }
+        catch (HttpRequestException)
+        {
+            // Expected
+        }
+
+        var tracerProvider = factory.Services.GetRequiredService<TracerProvider>();
+        tracerProvider.ForceFlush();
+
+        // Assert -- the Client span must have HTTP semantic attributes that the
+        // Azure Monitor exporter uses to populate the dependencies table.
+        var clientSpan = exportedActivities.Find(a => a.Kind == ActivityKind.Client);
+        await Assert.That(clientSpan).IsNotNull();
+
+        // Check for HTTP method attribute (new semantic conventions: http.request.method)
+        var httpMethod = clientSpan!.GetTagItem("http.request.method")
+            ?? clientSpan.GetTagItem("http.method");
+        await Assert.That(httpMethod).IsNotNull()
+            .Because("Client span must include http.request.method for App Insights dependency mapping");
+
+        // Check for server address (used for dependency target in App Insights)
+        var serverAddress = clientSpan.GetTagItem("server.address")
+            ?? clientSpan.GetTagItem("http.host")
+            ?? clientSpan.GetTagItem("net.peer.name");
+        await Assert.That(serverAddress).IsNotNull()
+            .Because("Client span must include server.address for App Insights dependency target");
+    }
+
+    [Test]
+    public async Task Should_UseFixedPercentageSampling_When_AzureMonitorExporterIsConfigured()
+    {
+        // Arrange -- Azure Monitor Exporter 1.6.0+ defaults to RateLimitedSampler
+        // at 5 TPS (TracesPerSecond=5.0), which drops most spans under burst traffic
+        // (e.g., Cosmos polling cycles with 900+ calls). Our configuration must set
+        // TracesPerSecond=null to use ApplicationInsightsSampler with SamplingRatio=1.0
+        // for 100% fixed-percentage sampling instead.
+        await using var baseFactory = new TestWebApplicationFactory();
+        await using var factory = baseFactory.WithWebHostBuilder(builder =>
+        {
+            builder.UseSetting(
+                "APPLICATIONINSIGHTS_CONNECTION_STRING",
+                "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://localhost/");
+        });
+
+        // Act -- resolve the configured options from DI
+        var optionsMonitor = factory.Services.GetRequiredService<IOptionsMonitor<AzureMonitorExporterOptions>>();
+        var options = optionsMonitor.CurrentValue;
+
+        // Assert -- TracesPerSecond must be null so the exporter uses
+        // ApplicationInsightsSampler(SamplingRatio) instead of RateLimitedSampler(TPS).
+        // SamplingRatio must be 1.0 for 100% trace capture.
+        await Assert.That(options.TracesPerSecond).IsNull()
+            .Because(
+                "TracesPerSecond must be null to disable the RateLimitedSampler; " +
+                "the default 5.0 TPS drops most dependency spans under burst traffic");
+
+        await Assert.That(options.SamplingRatio).IsEqualTo(1.0f)
+            .Because(
+                "SamplingRatio must be 1.0 (100%) so all dependency spans reach " +
+                "the App Insights dependencies table for full correlation");
+    }
+}

--- a/docs/specs/hourly-email-digest.md
+++ b/docs/specs/hourly-email-digest.md
@@ -1,0 +1,114 @@
+# Hourly Email Digest
+
+## Context
+
+Instant email notifications fire one email per planning application per user. In busy areas this causes email floods (100+ emails overnight), quickly exhausting the ACS free-tier quota of 100 emails/day. Planning applications move on timescales of weeks — sub-hour email latency has no practical value.
+
+This work replaces instant per-application emails with an hourly batched digest, and adds safeguards to prevent historical applications from triggering notifications on new WatchZones.
+
+See: ADR-0009 (notification architecture), ADR-0020 (ACS email), `docs/specs/email-notifications.md`.
+
+## Design
+
+### 1. Reduce first-poll lookback to 1 day
+
+`PollPlanItCommandHandler` currently defaults to a 30-day lookback when no poll state exists for an authority (line 65). Change this to 1 calendar day. The 30-day window served initial development; in production, once an authority is being polled, the high water mark provides continuous coverage. A 1-day lookback limits the first-poll burst to a handful of applications.
+
+**File:** `api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs`
+**Change:** `now.AddDays(-30)` → `now.AddDays(-1)`
+
+### 2. Add `CreatedAt` to WatchZone
+
+The `WatchZone` domain entity has no creation timestamp. Without it, there's no way to filter out applications that predate the zone. When a user creates a zone at 3pm but the authority was last polled at 8am, the next poll surfaces applications filed before the user existed — making the system feel broken.
+
+**Domain change:** Add `DateTimeOffset CreatedAt` property to `WatchZone`, set in the constructor and `Create` factory. Add to `Reconstitute` for hydration from Cosmos.
+
+**Polling filter:** In `PollPlanItCommandHandler`, after finding matching zones for an application, skip zones where `zone.CreatedAt > application.LastDifferent`. This ensures only applications that changed *after* the zone was created generate notifications.
+
+**Cosmos migration:** Existing WatchZone documents have no `createdAt` field. The `Reconstitute` method should default missing values to `DateTimeOffset.MinValue` (effectively: all existing zones see all applications, preserving current behaviour for existing users).
+
+**Files:**
+- `api/src/town-crier.domain/WatchZones/WatchZone.cs`
+- `api/src/town-crier.infrastructure/WatchZones/CosmosWatchZoneRepository.cs` (document mapping)
+- `api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs` (filter)
+- `api/src/town-crier.application/WatchZones/CreateWatchZoneCommandHandler.cs` (pass `now`)
+
+### 3. Add `EmailSent` flag to Notification
+
+The `Notification` entity tracks `PushSent` but has no equivalent for email. The hourly digest job needs to know which notifications haven't been emailed yet.
+
+**Domain change:** Add `bool EmailSent` property to `Notification` with a `MarkEmailSent()` method, mirroring `MarkPushSent()`.
+
+**Repository change:** Add `GetUnsentEmailsByUserAsync(string userId, CancellationToken ct)` to `INotificationRepository` — returns notifications where `EmailSent == false`, ordered by `CreatedAt`.
+
+**Files:**
+- `api/src/town-crier.domain/Notifications/Notification.cs`
+- `api/src/town-crier.application/Notifications/INotificationRepository.cs`
+- `api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs`
+
+### 4. Remove instant email from DispatchNotificationCommandHandler
+
+The dispatch handler currently sends an instant email for Pro users with `EmailInstantEnabled` (lines 117-125). Remove this block entirely. Email is now handled exclusively by the hourly digest job.
+
+The `EmailInstantEnabled` user preference becomes unused. Remove it from `NotificationPreferences` and mark the Cosmos field as ignored (existing documents may still have it).
+
+**Files:**
+- `api/src/town-crier.application/Notifications/DispatchNotificationCommandHandler.cs` (remove email block)
+- `api/src/town-crier.domain/UserProfiles/NotificationPreferences.cs` (remove `EmailInstantEnabled`)
+
+### 5. Hourly digest handler
+
+New `GenerateHourlyDigestsCommandHandler` — modelled on the existing weekly digest handler but runs for all users with pending unsent-email notifications.
+
+**Flow:**
+1. Query all distinct user IDs that have notifications with `EmailSent == false`
+2. For each user, load profile — skip if no email or `EmailDigestEnabled == false`
+3. Load unsent notifications via `GetUnsentEmailsByUserAsync`
+4. Group by WatchZone, build `WatchZoneDigest` list (reuse existing DTO)
+5. Send via `IEmailSender.SendDigestAsync` (reuse existing email template)
+6. Mark all included notifications as `EmailSent = true` and save
+
+**Entitlement check:** Only send hourly emails to users whose tier includes the `HourlyDigestEmails` entitlement (Personal/Pro). Free-tier users still get the weekly digest only.
+
+**Empty batches:** If a user has no unsent notifications, skip them. If no users have unsent notifications, the job completes immediately with no ACS calls.
+
+**Repository additions:**
+- `GetUserIdsWithUnsentEmailsAsync(CancellationToken ct)` on `INotificationRepository`
+- `GetUnsentEmailsByUserAsync(string userId, CancellationToken ct)` on `INotificationRepository`
+
+**Files:**
+- New: `api/src/town-crier.application/Notifications/GenerateHourlyDigestsCommandHandler.cs`
+- New: `api/src/town-crier.application/Notifications/GenerateHourlyDigestsCommand.cs`
+- `api/src/town-crier.application/Notifications/INotificationRepository.cs`
+- `api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs`
+
+### 6. Worker mode + Container Apps Job
+
+Add `"hourly-digest"` mode to the worker `Program.cs`, following the existing `"digest"` pattern. Wire up `GenerateHourlyDigestsCommandHandler` in the DI container.
+
+Add a Pulumi Container Apps Job with cron schedule `0 * * * *` (top of every hour).
+
+**Files:**
+- `api/src/town-crier.worker/Program.cs`
+- `infra/` (Pulumi job definition)
+
+### 7. Update entitlements
+
+Add `HourlyDigestEmails` to the `Entitlement` enum and wire it into `EntitlementMap` for Personal and Pro tiers. The existing `InstantEmails` entitlement becomes unused — remove it.
+
+**Files:**
+- `api/src/town-crier.domain/Entitlements/Entitlement.cs`
+- `api/src/town-crier.domain/Entitlements/EntitlementMap.cs`
+
+## Scope
+
+**In scope:**
+- All seven changes above
+- Tests for each change (TDD per coding standards)
+- ADR update: amend ADR-0020 to reflect hourly digest replacing instant emails
+- Update `docs/specs/email-notifications.md` to reflect new architecture
+
+**Out of scope:**
+- Rethinking the weekly digest (may become redundant but that's a separate decision)
+- User-configurable email cadence (instant vs hourly vs daily) — hourly is the only option
+- iOS or web UI changes for email preferences (removing `EmailInstantEnabled` toggle, if one exists)


### PR DESCRIPTION
## Changes
- Add `EmailSent` flag and `MarkEmailSent()` to Notification domain entity, plus `GetUnsentEmailsByUserAsync` repository method
- Add `CreatedAt` to WatchZone domain entity; filter notifications so pre-existing applications don't trigger alerts on new zones
- Implement `GenerateHourlyDigestsCommandHandler` with entitlement checks (Personal/Pro only), user profile filtering, watch zone grouping, and batch mark-as-sent
- Remove instant email block from `DispatchNotificationCommandHandler`; remove `EmailInstantEnabled` preference and `InstantEmails` entitlement
- Reduce first-poll lookback from 30 days to 1 day to limit initial notification burst
- Add `HourlyDigestEmails` entitlement for Personal and Pro tiers
- Fix OTel dependency tracking: set 100% fixed-percentage sampling to prevent `RateLimitedSampler` from dropping client spans
- Add hourly email digest spec (`docs/specs/hourly-email-digest.md`)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced hourly email digest feature for planning application notifications, consolidating multiple notifications into a single digest.

* **Improvements**
  * Reduced initial data lookback period from 30 days to 1 day on first synchronization to improve performance.
  * Simplified email notification preferences by removing redundant instant email settings.

* **Other Changes**
  * Enhanced observability configuration for Application Insights integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->