### PR TITLE
fix(api): suppress unused Data Protection warnings

### DIFF
--- a/api/src/town-crier.web/appsettings.json
+++ b/api/src/town-crier.web/appsettings.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.DataProtection": "Error"
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
## Changes
- Set `Microsoft.AspNetCore.DataProtection` log level to `Error` in appsettings.json
- The API uses JWT bearer auth (not cookies/antiforgery), so Data Protection is auto-registered but never called — these 4-6 warning traces per container restart are pure telemetry noise

Closes tc-bik

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application logging configuration to enhance error tracking and system monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->