### PR TITLE
fix(api): eliminate spurious Cosmos 400/404 from poll cycle telemetry

### DIFF
--- a/api/src/town-crier.application/Polling/IPollStateStore.cs
+++ b/api/src/town-crier.application/Polling/IPollStateStore.cs
@@ -6,8 +6,6 @@ public interface IPollStateStore
 
     Task SaveLastPollTimeAsync(int authorityId, DateTimeOffset pollTime, CancellationToken ct);
 
-    Task DeleteGlobalPollStateAsync(CancellationToken ct);
-
     Task<IReadOnlyList<int>> GetLeastRecentlyPolledAsync(
         IReadOnlyList<int> candidateAuthorityIds,
         CancellationToken ct);

--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -131,8 +131,6 @@ public sealed partial class PollPlanItCommandHandler
             }
         }
 
-        await this.pollStateStore.DeleteGlobalPollStateAsync(ct).ConfigureAwait(false);
-
         return new PollPlanItResult(count, authoritiesPolled, rateLimited);
     }
 

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosRestClient.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosRestClient.cs
@@ -135,6 +135,12 @@ internal sealed class CosmosRestClient : ICosmosRestClient
         activity?.SetTag("db.cosmosdb.container", collection);
         activity?.SetTag("db.operation.name", "Query");
 
+        if (partitionKey is null && RequiresFanOut(sql))
+        {
+            return await this.QueryWithFanOutAsync(
+                collection, sql, parameters, typeInfo, activity, ct).ConfigureAwait(false);
+        }
+
         var results = new List<T>();
         string? continuation = null;
 
@@ -210,6 +216,10 @@ internal sealed class CosmosRestClient : ICosmosRestClient
             ? results[0]
             : throw new InvalidOperationException("Query returned no results.");
     }
+
+    private static bool RequiresFanOut(string sql) =>
+        sql.Contains("DISTINCT", StringComparison.OrdinalIgnoreCase) ||
+        sql.Contains("GROUP BY", StringComparison.OrdinalIgnoreCase);
 
     private static void AddQueryHeaders(HttpRequestMessage request, string? partitionKey)
     {

--- a/api/src/town-crier.infrastructure/Polling/CosmosPollStateStore.cs
+++ b/api/src/town-crier.infrastructure/Polling/CosmosPollStateStore.cs
@@ -6,8 +6,6 @@ namespace TownCrier.Infrastructure.Polling;
 
 public sealed class CosmosPollStateStore : IPollStateStore
 {
-    private const string GlobalDocumentId = "poll-state";
-
     private readonly ICosmosRestClient client;
 
     public CosmosPollStateStore(ICosmosRestClient client)
@@ -49,15 +47,6 @@ public sealed class CosmosPollStateStore : IPollStateStore
             doc,
             documentId,
             CosmosJsonSerializerContext.Default.PollStateDocument,
-            ct).ConfigureAwait(false);
-    }
-
-    public async Task DeleteGlobalPollStateAsync(CancellationToken ct)
-    {
-        await this.client.DeleteDocumentAsync(
-            CosmosContainerNames.PollState,
-            GlobalDocumentId,
-            GlobalDocumentId,
             ct).ConfigureAwait(false);
     }
 

--- a/api/tests/town-crier.application.tests/Polling/FakePollStateStore.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakePollStateStore.cs
@@ -8,8 +8,6 @@ internal sealed class FakePollStateStore : IPollStateStore
 
     public int SaveCallCount { get; private set; }
 
-    public bool DeleteGlobalCalled { get; private set; }
-
     public DateTimeOffset? GetLastPollTimeFor(int authorityId)
     {
         return this.pollTimes.TryGetValue(authorityId, out var time) ? time : null;
@@ -30,12 +28,6 @@ internal sealed class FakePollStateStore : IPollStateStore
     {
         this.pollTimes[authorityId] = pollTime;
         this.SaveCallCount++;
-        return Task.CompletedTask;
-    }
-
-    public Task DeleteGlobalPollStateAsync(CancellationToken ct)
-    {
-        this.DeleteGlobalCalled = true;
         return Task.CompletedTask;
     }
 

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -482,31 +482,6 @@ public sealed class PollPlanItCommandHandlerTests
     }
 
     [Test]
-    public async Task Should_DeleteGlobalPollState_When_CycleCompletes()
-    {
-        var authorityProvider = new FakeActiveAuthorityProvider();
-        authorityProvider.Add(1);
-
-        var pollStateStore = new FakePollStateStore();
-        var handler = CreateHandler(pollStateStore: pollStateStore, authorityProvider: authorityProvider);
-
-        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
-
-        await Assert.That(pollStateStore.DeleteGlobalCalled).IsTrue();
-    }
-
-    [Test]
-    public async Task Should_DeleteGlobalPollState_When_NoActiveAuthorities()
-    {
-        var pollStateStore = new FakePollStateStore();
-        var handler = CreateHandler(pollStateStore: pollStateStore);
-
-        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
-
-        await Assert.That(pollStateStore.DeleteGlobalCalled).IsTrue();
-    }
-
-    [Test]
     public async Task Should_StopAndSetRateLimited_When_429Hit()
     {
         var authorityProvider = new FakeActiveAuthorityProvider();

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosRestClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosRestClientTests.cs
@@ -210,6 +210,7 @@ public sealed class CosmosRestClientTests
         var (client, handler) = CreateClient();
 
         // Request 1: cross-partition query returns 400 with fan-out marker
+        // (uses SELECT * to exercise the runtime probe path — DISTINCT/GROUP BY skip this)
         handler.EnqueueResponse(
             HttpStatusCode.BadRequest,
             """{"code":"BadRequest","message":"Cross partition query ... partitionedQueryExecutionInfoVersion"}""");
@@ -231,7 +232,7 @@ public sealed class CosmosRestClientTests
 
         var results = await client.QueryAsync(
             "Users",
-            "SELECT DISTINCT VALUE c.name FROM c",
+            "SELECT * FROM c WHERE ST_DISTANCE(c.location, @point) < 1000",
             null,
             null,
             TestSerializerContext.Default.TestDocument,
@@ -269,6 +270,7 @@ public sealed class CosmosRestClientTests
         var (client, handler) = CreateClient();
 
         // Request 1: cross-partition query returns 400 with fan-out marker
+        // (uses non-DISTINCT query to exercise the runtime probe path)
         handler.EnqueueResponse(
             HttpStatusCode.BadRequest,
             """{"code":"BadRequest","message":"partitionedQueryExecutionInfoVersion"}""");
@@ -291,7 +293,7 @@ public sealed class CosmosRestClientTests
 
         var results = await client.QueryAsync(
             "Users",
-            "SELECT DISTINCT VALUE c.name FROM c",
+            "SELECT * FROM c WHERE ST_DISTANCE(c.location, @point) < 1000",
             null,
             null,
             TestSerializerContext.Default.TestDocument,
@@ -331,6 +333,98 @@ public sealed class CosmosRestClientTests
                 CancellationToken.None));
 
         await Assert.That(exception.Message).Contains("syntax error");
+    }
+
+    [Test]
+    public async Task Should_SkipProbeAndFanOutDirectly_When_DistinctCrossPartitionQuery()
+    {
+        var (client, handler) = CreateClient();
+
+        // No 400 probe — first request is GET pkranges
+        handler.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"PartitionKeyRanges":[{"id":"0"},{"id":"1"}],"_count":2}""");
+
+        // Per-range queries return results directly
+        handler.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"Documents":[{"id":"d1","name":"Alpha"}],"_count":1}""");
+        handler.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"Documents":[{"id":"d2","name":"Beta"}],"_count":1}""");
+
+        var results = await client.QueryAsync(
+            "Users",
+            "SELECT DISTINCT VALUE c.name FROM c",
+            null,
+            null,
+            TestSerializerContext.Default.TestDocument,
+            CancellationToken.None);
+
+        // Results from both partitions
+        await Assert.That(results).HasCount().EqualTo(2);
+
+        // Only 3 requests: pkranges + 2 partition queries (no initial probe)
+        await Assert.That(handler.SentRequests).HasCount().EqualTo(3);
+
+        // First request is GET pkranges, NOT a POST query probe
+        var firstRequest = handler.SentRequests[0];
+        await Assert.That(firstRequest.Method).IsEqualTo(HttpMethod.Get);
+        await Assert.That(firstRequest.RequestUri!.AbsolutePath)
+            .IsEqualTo("/dbs/test-db/colls/Users/pkranges");
+    }
+
+    [Test]
+    public async Task Should_SkipProbeAndFanOutDirectly_When_GroupByCrossPartitionQuery()
+    {
+        var (client, handler) = CreateClient();
+
+        // No 400 probe — first request is GET pkranges
+        handler.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"PartitionKeyRanges":[{"id":"0"}],"_count":1}""");
+
+        // Single partition query
+        handler.EnqueueResponse(
+            HttpStatusCode.OK,
+            """{"Documents":[{"id":"d1","name":"GroupResult"}],"_count":1}""");
+
+        var results = await client.QueryAsync(
+            "Users",
+            "SELECT c.category, COUNT(1) AS total FROM c GROUP BY c.category",
+            null,
+            null,
+            TestSerializerContext.Default.TestDocument,
+            CancellationToken.None);
+
+        await Assert.That(results).HasCount().EqualTo(1);
+
+        // Only 2 requests: pkranges + 1 partition query (no initial probe)
+        await Assert.That(handler.SentRequests).HasCount().EqualTo(2);
+        await Assert.That(handler.SentRequests[0].Method).IsEqualTo(HttpMethod.Get);
+    }
+
+    [Test]
+    public async Task Should_StillProbeNormally_When_SimpleCrossPartitionQuery()
+    {
+        var (client, handler) = CreateClient();
+
+        // Simple cross-partition SELECT * should NOT skip to fan-out
+        handler.EnqueueResponse(HttpStatusCode.OK, """{"Documents":[{"id":"d1","name":"Test"}],"_count":1}""");
+
+        var results = await client.QueryAsync(
+            "Users",
+            "SELECT * FROM c WHERE c.active = true",
+            null,
+            null,
+            TestSerializerContext.Default.TestDocument,
+            CancellationToken.None);
+
+        await Assert.That(results).HasCount().EqualTo(1);
+
+        // Normal path: single POST query, no fan-out
+        await Assert.That(handler.SentRequests).HasCount().EqualTo(1);
+        await Assert.That(handler.SentRequests[0].Method).IsEqualTo(HttpMethod.Post);
     }
 
     private static (CosmosRestClient Client, StubHttpHandler Handler) CreateClient()


### PR DESCRIPTION
## Changes
- Skip 400 probe for DISTINCT/GROUP BY cross-partition queries by detecting them upfront via SQL inspection and going directly to fan-out
- Remove dead `DeleteGlobalPollStateAsync` code that deleted a never-created document, producing a 404 every cycle
- Update existing fan-out tests to exercise the runtime probe path with non-DISTINCT queries

Closes tc-x06.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized query execution for cross-partition operations to improve performance when handling certain query patterns.

* **Refactor**
  * Removed global polling state deletion from the polling operation lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->