### PR TITLE
fix(ios): center map on user's actual watch zone

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -21,6 +21,7 @@ public final class AppCoordinator: ObservableObject {
   private let notificationService: NotificationService
   private let offlineRepository: OfflineAwareRepository?
   private let authorityRepository: ApplicationAuthorityRepository?
+  private let watchZoneRepository: WatchZoneRepository
   private let appVersionProvider: AppVersionProvider
   private let versionConfigService: VersionConfigService
 
@@ -31,6 +32,7 @@ public final class AppCoordinator: ObservableObject {
     userProfileRepository: UserProfileRepository,
     offlineRepository: OfflineAwareRepository? = nil,
     authorityRepository: ApplicationAuthorityRepository? = nil,
+    watchZoneRepository: WatchZoneRepository,
     onboardingRepository: OnboardingRepository,
     notificationService: NotificationService,
     appVersionProvider: AppVersionProvider,
@@ -42,6 +44,7 @@ public final class AppCoordinator: ObservableObject {
     self.userProfileRepository = userProfileRepository
     self.offlineRepository = offlineRepository
     self.authorityRepository = authorityRepository
+    self.watchZoneRepository = watchZoneRepository
     self.onboardingRepository = onboardingRepository
     self.notificationService = notificationService
     self.appVersionProvider = appVersionProvider
@@ -52,18 +55,19 @@ public final class AppCoordinator: ObservableObject {
     LoginViewModel(authService: authService)
   }
 
-  public func makeMapViewModel(watchZone: WatchZone) -> MapViewModel {
+  public func makeMapViewModel() -> MapViewModel {
     if let authorityRepository {
       return MapViewModel(
         authorityRepository: authorityRepository,
         applicationRepository: repository,
-        watchZone: watchZone
+        watchZoneRepository: watchZoneRepository
       )
     }
     if let offlineRepository {
-      return MapViewModel(offlineRepository: offlineRepository, watchZone: watchZone)
+      return MapViewModel(
+        offlineRepository: offlineRepository, watchZoneRepository: watchZoneRepository)
     }
-    return MapViewModel(repository: repository, watchZone: watchZone)
+    return MapViewModel(repository: repository, watchZoneRepository: watchZoneRepository)
   }
 
   public func makeApplicationListViewModel(

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
@@ -10,15 +10,15 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
   @Published private(set) var selectedApplication: PlanningApplication?
   @Published private(set) var hasLoaded = false
 
-  let centreLat: Double
-  let centreLon: Double
-  let radiusMetres: Double
+  @Published private(set) var centreLat: Double = 51.5074
+  @Published private(set) var centreLon: Double = -0.1278
+  @Published private(set) var radiusMetres: Double = 2000
 
   private let repository: PlanningApplicationRepository?
   private let offlineRepository: OfflineAwareRepository?
   private let authorityRepository: ApplicationAuthorityRepository?
   private let applicationRepository: PlanningApplicationRepository?
-  private let watchZone: WatchZone
+  private let watchZoneRepository: WatchZoneRepository
   private var applications: [PlanningApplication] = []
 
   public var isEmpty: Bool {
@@ -40,47 +40,44 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
 
   var onApplicationSelected: ((PlanningApplicationId) -> Void)?
 
-  public init(repository: PlanningApplicationRepository, watchZone: WatchZone) {
+  public init(repository: PlanningApplicationRepository, watchZoneRepository: WatchZoneRepository) {
     self.repository = repository
     self.offlineRepository = nil
     self.authorityRepository = nil
     self.applicationRepository = nil
-    self.watchZone = watchZone
-    self.centreLat = watchZone.centre.latitude
-    self.centreLon = watchZone.centre.longitude
-    self.radiusMetres = watchZone.radiusMetres
+    self.watchZoneRepository = watchZoneRepository
   }
 
-  public init(offlineRepository: OfflineAwareRepository, watchZone: WatchZone) {
+  public init(offlineRepository: OfflineAwareRepository, watchZoneRepository: WatchZoneRepository) {
     self.repository = nil
     self.offlineRepository = offlineRepository
     self.authorityRepository = nil
     self.applicationRepository = nil
-    self.watchZone = watchZone
-    self.centreLat = watchZone.centre.latitude
-    self.centreLon = watchZone.centre.longitude
-    self.radiusMetres = watchZone.radiusMetres
+    self.watchZoneRepository = watchZoneRepository
   }
 
   public init(
     authorityRepository: ApplicationAuthorityRepository,
     applicationRepository: PlanningApplicationRepository,
-    watchZone: WatchZone
+    watchZoneRepository: WatchZoneRepository
   ) {
     self.repository = nil
     self.offlineRepository = nil
     self.authorityRepository = authorityRepository
     self.applicationRepository = applicationRepository
-    self.watchZone = watchZone
-    self.centreLat = watchZone.centre.latitude
-    self.centreLon = watchZone.centre.longitude
-    self.radiusMetres = watchZone.radiusMetres
+    self.watchZoneRepository = watchZoneRepository
   }
 
   public func loadApplications() async {
     isLoading = true
     error = nil
     do {
+      if let zone = try? await watchZoneRepository.loadAll().first {
+        centreLat = zone.centre.latitude
+        centreLon = zone.centre.longitude
+        radiusMetres = zone.radiusMetres
+      }
+
       let fetched: [PlanningApplication]
       if let authorityRepository, let applicationRepository {
         fetched = try await fetchViaAuthorities(

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -45,6 +45,7 @@ struct TownCrierApp: App {
 
     let userProfileRepository = APIUserProfileRepository(apiClient: apiClient)
     let authorityRepository = APIApplicationAuthorityRepository(apiClient: apiClient)
+    let watchZoneRepository = APIWatchZoneRepository(apiClient: apiClient)
 
     let appCoordinator = AppCoordinator(
       repository: repository,
@@ -53,6 +54,7 @@ struct TownCrierApp: App {
       userProfileRepository: userProfileRepository,
       offlineRepository: offlineRepository,
       authorityRepository: authorityRepository,
+      watchZoneRepository: watchZoneRepository,
       onboardingRepository: onboardingRepository,
       notificationService: notificationService,
       appVersionProvider: appVersionProvider,
@@ -68,15 +70,7 @@ struct TownCrierApp: App {
     )
 
     let listVM = appCoordinator.makeApplicationListViewModel()
-    // swiftlint:disable force_try
-    let mapVM = appCoordinator.makeMapViewModel(
-      watchZone: try! WatchZone(
-        postcode: try! Postcode("NW5 1SU"),
-        centre: try! Coordinate(latitude: 51.5550, longitude: -0.1450),
-        radiusMetres: 2000
-      )
-    )
-    // swiftlint:enable force_try
+    let mapVM = appCoordinator.makeMapViewModel()
 
     _applicationListViewModel = StateObject(wrappedValue: listVM)
     _mapViewModel = StateObject(wrappedValue: mapVM)

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -14,6 +14,7 @@ struct AppCoordinatorTests {
       authService: SpyAuthenticationService(),
       subscriptionService: SpySubscriptionService(),
       userProfileRepository: SpyUserProfileRepository(),
+      watchZoneRepository: SpyWatchZoneRepository(),
       onboardingRepository: SpyOnboardingRepository(),
       notificationService: SpyNotificationService(),
       appVersionProvider: SpyAppVersionProvider(),
@@ -83,6 +84,7 @@ struct AppCoordinatorTests {
       subscriptionService: SpySubscriptionService(),
       userProfileRepository: SpyUserProfileRepository(),
       authorityRepository: authoritySpy,
+      watchZoneRepository: SpyWatchZoneRepository(),
       onboardingRepository: SpyOnboardingRepository(),
       notificationService: SpyNotificationService(),
       appVersionProvider: SpyAppVersionProvider(),
@@ -111,6 +113,7 @@ struct AppCoordinatorTests {
       authService: SpyAuthenticationService(),
       subscriptionService: SpySubscriptionService(),
       userProfileRepository: SpyUserProfileRepository(),
+      watchZoneRepository: SpyWatchZoneRepository(),
       onboardingRepository: onboardingRepoSpy,
       notificationService: SpyNotificationService(),
       appVersionProvider: SpyAppVersionProvider(),
@@ -138,12 +141,13 @@ struct AppCoordinatorTests {
       subscriptionService: SpySubscriptionService(),
       userProfileRepository: SpyUserProfileRepository(),
       authorityRepository: authoritySpy,
+      watchZoneRepository: SpyWatchZoneRepository(),
       onboardingRepository: SpyOnboardingRepository(),
       notificationService: SpyNotificationService(),
       appVersionProvider: SpyAppVersionProvider(),
       versionConfigService: SpyVersionConfigService()
     )
-    let vm = coordinator.makeMapViewModel(watchZone: .cambridge)
+    let vm = coordinator.makeMapViewModel()
 
     await vm.loadApplications()
 

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -30,11 +30,13 @@ struct CompositionRootTests {
 
     let userProfileRepository = APIUserProfileRepository(apiClient: apiClient)
 
+    let watchZoneRepository = APIWatchZoneRepository(apiClient: apiClient)
     let coordinator = AppCoordinator(
       repository: repository,
       authService: authService,
       subscriptionService: subscriptionService,
       userProfileRepository: userProfileRepository,
+      watchZoneRepository: watchZoneRepository,
       onboardingRepository: onboardingRepository,
       notificationService: notificationService,
       appVersionProvider: appVersionProvider,
@@ -77,6 +79,7 @@ struct CompositionRootTests {
       authService: authService,
       subscriptionService: StoreKitSubscriptionService(),
       userProfileRepository: APIUserProfileRepository(apiClient: apiClient),
+      watchZoneRepository: APIWatchZoneRepository(apiClient: apiClient),
       onboardingRepository: onboardingRepo,
       notificationService: CompositeNotificationService(
         permissionProvider: SpyNotificationPermissionProvider(),
@@ -107,12 +110,14 @@ struct CompositionRootTests {
     let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
     let authorityRepository = APIApplicationAuthorityRepository(apiClient: apiClient)
 
+    let watchZoneRepository = APIWatchZoneRepository(apiClient: apiClient)
     let coordinator = AppCoordinator(
       repository: APIPlanningApplicationRepository(apiClient: apiClient),
       authService: authService,
       subscriptionService: StoreKitSubscriptionService(),
       userProfileRepository: APIUserProfileRepository(apiClient: apiClient),
       authorityRepository: authorityRepository,
+      watchZoneRepository: watchZoneRepository,
       onboardingRepository: UserDefaultsOnboardingRepository(),
       notificationService: CompositeNotificationService(
         permissionProvider: SpyNotificationPermissionProvider(),
@@ -122,7 +127,7 @@ struct CompositionRootTests {
       versionConfigService: APIVersionConfigService(baseURL: apiBaseURL)
     )
 
-    let vm = coordinator.makeMapViewModel(watchZone: .cambridge)
+    let vm = coordinator.makeMapViewModel()
     #expect(vm.annotations.isEmpty)
   }
 
@@ -139,6 +144,7 @@ struct CompositionRootTests {
       subscriptionService: StoreKitSubscriptionService(),
       userProfileRepository: APIUserProfileRepository(apiClient: apiClient),
       authorityRepository: authorityRepository,
+      watchZoneRepository: APIWatchZoneRepository(apiClient: apiClient),
       onboardingRepository: UserDefaultsOnboardingRepository(),
       notificationService: CompositeNotificationService(
         permissionProvider: SpyNotificationPermissionProvider(),
@@ -173,6 +179,7 @@ struct CompositionRootTests {
       authService: authService,
       subscriptionService: StoreKitSubscriptionService(),
       userProfileRepository: APIUserProfileRepository(apiClient: apiClient),
+      watchZoneRepository: APIWatchZoneRepository(apiClient: apiClient),
       onboardingRepository: UserDefaultsOnboardingRepository(),
       notificationService: CompositeNotificationService(
         permissionProvider: SpyNotificationPermissionProvider(),

--- a/mobile/ios/town-crier-tests/Sources/Features/DeepLinkTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeepLinkTests.swift
@@ -14,6 +14,7 @@ struct DeepLinkTests {
       authService: SpyAuthenticationService(),
       subscriptionService: SpySubscriptionService(),
       userProfileRepository: SpyUserProfileRepository(),
+      watchZoneRepository: SpyWatchZoneRepository(),
       onboardingRepository: SpyOnboardingRepository(),
       notificationService: SpyNotificationService(),
       appVersionProvider: SpyAppVersionProvider(),

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
@@ -9,18 +9,20 @@ import TownCrierDomain
 struct MapViewModelTests {
   private func makeSUT(
     applications: [PlanningApplication] = [],
-    watchZone: WatchZone = .cambridge
-  ) -> (MapViewModel, SpyPlanningApplicationRepository) {
+    watchZones: [WatchZone] = [.cambridge]
+  ) -> (MapViewModel, SpyPlanningApplicationRepository, SpyWatchZoneRepository) {
     let spy = SpyPlanningApplicationRepository()
     spy.fetchApplicationsResult = .success(applications)
-    let vm = MapViewModel(repository: spy, watchZone: watchZone)
-    return (vm, spy)
+    let watchZoneSpy = SpyWatchZoneRepository()
+    watchZoneSpy.loadAllResult = .success(watchZones)
+    let vm = MapViewModel(repository: spy, watchZoneRepository: watchZoneSpy)
+    return (vm, spy, watchZoneSpy)
   }
 
   private func makeSUTWithAuthorities(
     authorities: [LocalAuthority] = [.cambridge],
     applicationsByAuthority: [String: [PlanningApplication]] = [:],
-    watchZone: WatchZone = .cambridge
+    watchZones: [WatchZone] = [.cambridge]
   ) -> (MapViewModel, SpyApplicationAuthorityRepository, SpyPlanningApplicationRepository) {
     let authoritySpy = SpyApplicationAuthorityRepository()
     authoritySpy.fetchAuthoritiesResult = .success(
@@ -28,10 +30,12 @@ struct MapViewModelTests {
     )
     let appSpy = SpyPlanningApplicationRepository()
     appSpy.fetchApplicationsByAuthority = applicationsByAuthority
+    let watchZoneSpy = SpyWatchZoneRepository()
+    watchZoneSpy.loadAllResult = .success(watchZones)
     let vm = MapViewModel(
       authorityRepository: authoritySpy,
       applicationRepository: appSpy,
-      watchZone: watchZone
+      watchZoneRepository: watchZoneSpy
     )
     return (vm, authoritySpy, appSpy)
   }
@@ -40,7 +44,7 @@ struct MapViewModelTests {
 
   @Test func loadApplications_populatesAnnotations() async {
     let apps = [PlanningApplication.pendingReview, .approved, .refused, .withdrawn]
-    let (sut, _) = makeSUT(applications: apps)
+    let (sut, _, _) = makeSUT(applications: apps)
 
     await sut.loadApplications()
 
@@ -48,7 +52,7 @@ struct MapViewModelTests {
   }
 
   @Test func loadApplications_setsIsLoadingDuringFetch() async {
-    let (sut, _) = makeSUT()
+    let (sut, _, _) = makeSUT()
 
     #expect(!sut.isLoading)
     await sut.loadApplications()
@@ -56,7 +60,7 @@ struct MapViewModelTests {
   }
 
   @Test func loadApplications_setsErrorOnFailure() async {
-    let (sut, spy) = makeSUT()
+    let (sut, spy, _) = makeSUT()
     spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
 
     await sut.loadApplications()
@@ -69,7 +73,7 @@ struct MapViewModelTests {
 
   @Test func annotations_haveCorrectStatus() async {
     let apps: [PlanningApplication] = [.pendingReview, .approved, .refused, .withdrawn]
-    let (sut, _) = makeSUT(applications: apps)
+    let (sut, _, _) = makeSUT(applications: apps)
 
     await sut.loadApplications()
 
@@ -95,7 +99,7 @@ struct MapViewModelTests {
       address: "Unknown",
       location: nil
     )
-    let (sut, _) = makeSUT(applications: [.pendingReview, noLocation])
+    let (sut, _, _) = makeSUT(applications: [.pendingReview, noLocation])
 
     await sut.loadApplications()
 
@@ -105,24 +109,47 @@ struct MapViewModelTests {
 
   // MARK: - Watch zone
 
-  @Test func watchZoneCentre_matchesProvidedZone() throws {
+  @Test func loadApplications_setsCentreFromWatchZone() async throws {
     let zone = try WatchZone(
       postcode: Postcode("SW1A 1AA"),
       centre: Coordinate(latitude: 51.5, longitude: -0.1),
       radiusMetres: 3000
     )
-    let (sut, _) = makeSUT(watchZone: zone)
+    let (sut, _, _) = makeSUT(watchZones: [zone])
+
+    await sut.loadApplications()
 
     #expect(sut.centreLat == 51.5)
     #expect(sut.centreLon == -0.1)
     #expect(sut.radiusMetres == 3000)
   }
 
+  @Test func loadApplications_usesDefaultCentre_whenWatchZoneFetchFails() async {
+    let (sut, _, watchZoneSpy) = makeSUT()
+    watchZoneSpy.loadAllResult = .failure(DomainError.networkUnavailable)
+
+    await sut.loadApplications()
+
+    // Falls back to London defaults
+    #expect(sut.centreLat == 51.5074)
+    #expect(sut.centreLon == -0.1278)
+    #expect(sut.radiusMetres == 2000)
+    #expect(sut.error == nil)
+  }
+
+  @Test func loadApplications_fetchesWatchZone() async {
+    let (sut, _, watchZoneSpy) = makeSUT()
+
+    await sut.loadApplications()
+
+    #expect(watchZoneSpy.loadAllCallCount == 1)
+  }
+
   // MARK: - Selection
 
   @Test func selectAnnotation_setsSelectedApplication() async {
     let apps = [PlanningApplication.pendingReview]
-    let (sut, _) = makeSUT(applications: apps)
+    let (sut, _, _) = makeSUT(applications: apps)
 
     await sut.loadApplications()
     sut.selectApplication(PlanningApplicationId("APP-001"))
@@ -132,7 +159,7 @@ struct MapViewModelTests {
 
   @Test func selectAnnotation_nilClearsSelection() async {
     let apps = [PlanningApplication.pendingReview]
-    let (sut, _) = makeSUT(applications: apps)
+    let (sut, _, _) = makeSUT(applications: apps)
 
     await sut.loadApplications()
     sut.selectApplication(PlanningApplicationId("APP-001"))
@@ -144,7 +171,7 @@ struct MapViewModelTests {
   // MARK: - Empty State
 
   @Test func isEmpty_trueWhenNoAnnotationsAfterLoad() async {
-    let (sut, _) = makeSUT(applications: [])
+    let (sut, _, _) = makeSUT(applications: [])
 
     await sut.loadApplications()
 
@@ -152,7 +179,7 @@ struct MapViewModelTests {
   }
 
   @Test func isEmpty_falseWhenAnnotationsExist() async {
-    let (sut, _) = makeSUT(applications: [.pendingReview])
+    let (sut, _, _) = makeSUT(applications: [.pendingReview])
 
     await sut.loadApplications()
 
@@ -160,13 +187,13 @@ struct MapViewModelTests {
   }
 
   @Test func isEmpty_falseWhileLoading() async {
-    let (sut, _) = makeSUT()
+    let (sut, _, _) = makeSUT()
 
     #expect(!sut.isEmpty)
   }
 
   @Test func isEmpty_falseWhenErrorOccurred() async {
-    let (sut, spy) = makeSUT()
+    let (sut, spy, _) = makeSUT()
     spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
 
     await sut.loadApplications()
@@ -177,7 +204,7 @@ struct MapViewModelTests {
   // MARK: - Error Classification
 
   @Test func isNetworkError_trueForNetworkUnavailable() async {
-    let (sut, spy) = makeSUT()
+    let (sut, spy, _) = makeSUT()
     spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
 
     await sut.loadApplications()
@@ -186,7 +213,7 @@ struct MapViewModelTests {
   }
 
   @Test func isNetworkError_falseForOtherErrors() async {
-    let (sut, spy) = makeSUT()
+    let (sut, spy, _) = makeSUT()
     spy.fetchApplicationsResult = .failure(DomainError.unexpected("Server error"))
 
     await sut.loadApplications()
@@ -195,7 +222,7 @@ struct MapViewModelTests {
   }
 
   @Test func isServerError_trueForServerError() async {
-    let (sut, spy) = makeSUT()
+    let (sut, spy, _) = makeSUT()
     spy.fetchApplicationsResult = .failure(
       DomainError.serverError(statusCode: 500, message: nil)
     )
@@ -207,7 +234,7 @@ struct MapViewModelTests {
   }
 
   @Test func isServerError_falseForNetworkError() async {
-    let (sut, spy) = makeSUT()
+    let (sut, spy, _) = makeSUT()
     spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
 
     await sut.loadApplications()
@@ -217,7 +244,7 @@ struct MapViewModelTests {
   }
 
   @Test func isSessionExpired_trueForSessionExpired() async {
-    let (sut, spy) = makeSUT()
+    let (sut, spy, _) = makeSUT()
     spy.fetchApplicationsResult = .failure(DomainError.sessionExpired)
 
     await sut.loadApplications()
@@ -226,7 +253,7 @@ struct MapViewModelTests {
   }
 
   @Test func isSessionExpired_falseForOtherErrors() async {
-    let (sut, spy) = makeSUT()
+    let (sut, spy, _) = makeSUT()
     spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
 
     await sut.loadApplications()


### PR DESCRIPTION
## Changes
- Wire `WatchZoneRepository` into `MapViewModel` so the map fetches the user's real watch zone from `GET /v1/me/watch-zones` before loading applications
- Replace hardcoded NW5 1SU (Camden) coordinate with the user's actual watch zone center and radius
- Make `centreLat`/`centreLon`/`radiusMetres` `@Published` so the map camera and radius circle use the fetched values
- Add `WatchZoneRepository` to `AppCoordinator` dependency graph
- Remove `force_try` and hardcoded `WatchZone` from `TownCrierApp.swift` composition root
- Watch zone fetch failure degrades gracefully to London default center (map still loads)
- Update all tests (`MapViewModelTests`, `AppCoordinatorTests`, `CompositionRootTests`, `DeepLinkTests`) with `SpyWatchZoneRepository`

## Test plan
- [x] All 765 existing tests pass
- [x] New tests: `loadApplications_setsCentreFromWatchZone`, `loadApplications_usesDefaultCentre_whenWatchZoneFetchFails`, `loadApplications_fetchesWatchZone`
- [ ] Manual: build and run on simulator, verify map centers on the user's watch zone (not Camden)
- [ ] Manual: verify radius circle renders at the correct location

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Map initialization now dynamically loads zone data from repository instead of using hardcoded values, providing more flexible and responsive map positioning.
  * Improved resilience by gracefully falling back to default coordinates when zone data fails to load, ensuring the map remains functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->