### PR TITLE
fix(ios): wrap manageSubscriptionsSheet binding for main-actor safety

### DIFF
--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -176,7 +176,16 @@ struct TownCrierApp: App {
         }
       }
       #if os(iOS)
-        .manageSubscriptionsSheet(isPresented: $coordinator.isManageSubscriptionPresented)
+        .manageSubscriptionsSheet(
+          isPresented: Binding(
+            get: { coordinator.isManageSubscriptionPresented },
+            set: { newValue in
+              Task { @MainActor in
+                coordinator.isManageSubscriptionPresented = newValue
+              }
+            }
+          )
+        )
       #endif
       .tabItem {
         Label("Settings", systemImage: "gearshape")


### PR DESCRIPTION
## Summary

- StoreKit's `manageSubscriptionsSheet` dismisses from a background thread and writes to the `isPresented` binding off the main actor
- Since `AppCoordinator` is `@MainActor`-isolated, this caused data race warnings that will become runtime crashes in future SwiftUI versions
- Wrapped the binding with a setter that dispatches to `@MainActor` via `Task`

## Test plan

- [x] `swift build` passes
- [x] `swift test` — all 765 tests pass
- [ ] Open Settings > tap "Manage Subscription" in the simulator — verify no concurrency warnings in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)