### PR TITLE
feat: zones tab, upsell prompt, PlanIt retry, and prod monitoring

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -308,7 +308,7 @@ jobs:
           xcodebuild build
           -project TownCrier.xcodeproj
           -scheme TownCrierApp
-          -destination 'platform=iOS Simulator,name=iPhone 16'
+          -destination 'generic/platform=iOS Simulator'
           -derivedDataPath .derivedData
         working-directory: mobile/ios
       - run: swift test

--- a/api/src/town-crier.infrastructure/Observability/PlanItInstrumentation.cs
+++ b/api/src/town-crier.infrastructure/Observability/PlanItInstrumentation.cs
@@ -13,5 +13,10 @@ public static class PlanItInstrumentation
         Meter.CreateCounter<long>(
             "towncrier.planit.http_errors",
             description: "Non-2xx HTTP responses from PlanIt API");
+
+    public static readonly Counter<long> Retries =
+        Meter.CreateCounter<long>(
+            "towncrier.planit.retries",
+            description: "Retry attempts for transient PlanIt API failures");
 }
 #pragma warning restore SA1202

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItClient.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Net;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
 using TownCrier.Application.PlanIt;
@@ -14,15 +15,18 @@ public sealed class PlanItClient : IPlanItClient
 
     private readonly HttpClient httpClient;
     private readonly PlanItThrottleOptions throttleOptions;
+    private readonly PlanItRetryOptions retryOptions;
     private readonly Func<TimeSpan, CancellationToken, Task> delayFunc;
 
     public PlanItClient(
         HttpClient httpClient,
         PlanItThrottleOptions? throttleOptions = null,
+        PlanItRetryOptions? retryOptions = null,
         Func<TimeSpan, CancellationToken, Task>? delayFunc = null)
     {
         this.httpClient = httpClient;
         this.throttleOptions = throttleOptions ?? new PlanItThrottleOptions();
+        this.retryOptions = retryOptions ?? new PlanItRetryOptions();
         this.delayFunc = delayFunc ?? Task.Delay;
     }
 
@@ -140,23 +144,69 @@ public sealed class PlanItClient : IPlanItClient
         return DateOnly.Parse(value, CultureInfo.InvariantCulture);
     }
 
+    private static bool IsRetryable(HttpStatusCode statusCode)
+    {
+        return statusCode is
+            HttpStatusCode.GatewayTimeout or
+            HttpStatusCode.BadGateway or
+            HttpStatusCode.ServiceUnavailable or
+            HttpStatusCode.RequestTimeout or
+            HttpStatusCode.TooManyRequests;
+    }
+
     private async Task<HttpResponseMessage> SendWithThrottleAsync(Uri url, int authorityId, CancellationToken ct)
     {
-        if (this.throttleOptions.DelayBetweenRequests > TimeSpan.Zero)
-        {
-            await this.delayFunc(this.throttleOptions.DelayBetweenRequests, ct).ConfigureAwait(false);
-        }
+        var maxAttempts = 1 + this.retryOptions.MaxRetries;
 
-        var response = await this.httpClient.GetAsync(url, ct).ConfigureAwait(false);
-
-        if (!response.IsSuccessStatusCode)
+        for (var attempt = 0; attempt < maxAttempts; attempt++)
         {
+            if (this.throttleOptions.DelayBetweenRequests > TimeSpan.Zero)
+            {
+                await this.delayFunc(this.throttleOptions.DelayBetweenRequests, ct).ConfigureAwait(false);
+            }
+
+            var response = await this.httpClient.GetAsync(url, ct).ConfigureAwait(false);
+
+            if (response.IsSuccessStatusCode)
+            {
+                return response;
+            }
+
             PlanItInstrumentation.HttpErrors.Add(
                 1,
                 new KeyValuePair<string, object?>("http.response.status_code", (int)response.StatusCode),
                 new KeyValuePair<string, object?>("planit.authority_code", authorityId));
+
+            var isLastAttempt = attempt >= maxAttempts - 1;
+
+            if (!IsRetryable(response.StatusCode) || isLastAttempt)
+            {
+                return response;
+            }
+
+            var backoff = this.ComputeBackoff(response.StatusCode, attempt);
+            PlanItInstrumentation.Retries.Add(
+                1,
+                new KeyValuePair<string, object?>("http.response.status_code", (int)response.StatusCode),
+                new KeyValuePair<string, object?>("planit.authority_code", authorityId));
+
+            response.Dispose();
+            await this.delayFunc(backoff, ct).ConfigureAwait(false);
         }
 
-        return response;
+        // Unreachable -- the loop always returns
+        throw new InvalidOperationException("Retry loop exited unexpectedly.");
+    }
+
+    private TimeSpan ComputeBackoff(HttpStatusCode statusCode, int attempt)
+    {
+        if (statusCode == HttpStatusCode.TooManyRequests)
+        {
+            // Exponential backoff starting from rate limit backoff
+            return this.retryOptions.RateLimitBackoff * Math.Pow(2, attempt);
+        }
+
+        // Exponential backoff starting from initial backoff: 1s, 2s, 4s, ...
+        return this.retryOptions.InitialBackoff * Math.Pow(2, attempt);
     }
 }

--- a/api/src/town-crier.infrastructure/PlanIt/PlanItRetryOptions.cs
+++ b/api/src/town-crier.infrastructure/PlanIt/PlanItRetryOptions.cs
@@ -1,0 +1,14 @@
+namespace TownCrier.Infrastructure.PlanIt;
+
+public sealed record PlanItRetryOptions
+{
+    public int MaxRetries { get; init; } = 3;
+
+    public double InitialBackoffSeconds { get; init; } = 1;
+
+    public double RateLimitBackoffSeconds { get; init; } = 5;
+
+    public TimeSpan InitialBackoff => TimeSpan.FromSeconds(this.InitialBackoffSeconds);
+
+    public TimeSpan RateLimitBackoff => TimeSpan.FromSeconds(this.RateLimitBackoffSeconds);
+}

--- a/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
+++ b/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
@@ -102,6 +102,10 @@ internal static class ServiceCollectionExtensions
         configuration.GetSection("PlanIt:Throttle").Bind(planItThrottle);
         services.AddSingleton(planItThrottle);
 
+        var planItRetry = new PlanItRetryOptions();
+        configuration.GetSection("PlanIt:Retry").Bind(planItRetry);
+        services.AddSingleton(planItRetry);
+
 #pragma warning disable S1075 // Hardcoded URI is a sensible default
         var planItBaseUrl = configuration["PlanIt:BaseUrl"] ?? "https://www.planit.org.uk/";
 #pragma warning restore S1075

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -120,6 +120,10 @@ var planItThrottle = new PlanItThrottleOptions();
 builder.Configuration.GetSection("PlanIt:Throttle").Bind(planItThrottle);
 builder.Services.AddSingleton(planItThrottle);
 
+var planItRetry = new PlanItRetryOptions();
+builder.Configuration.GetSection("PlanIt:Retry").Bind(planItRetry);
+builder.Services.AddSingleton(planItRetry);
+
 #pragma warning disable S1075 // Hardcoded URI is a sensible default
 var planItBaseUrl = builder.Configuration["PlanIt:BaseUrl"] ?? "https://www.planit.org.uk/";
 #pragma warning restore S1075

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/FakePlanItHandler.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/FakePlanItHandler.cs
@@ -28,19 +28,11 @@ internal sealed class FakePlanItHandler : HttpMessageHandler
         this.statusCodeResponses[urlContains] = statusCode;
     }
 
-    /// <summary>
-    /// Returns <paramref name="statusCode"/> for the first <paramref name="failCount"/> requests
-    /// matching <paramref name="urlContains"/>, then returns 200 with <paramref name="successJson"/>.
-    /// </summary>
     public void SetupTransientFailure(string urlContains, int failCount, HttpStatusCode statusCode, string successJson)
     {
         this.transientFailures[urlContains] = (failCount, statusCode, successJson);
     }
 
-    /// <summary>
-    /// Returns 429 for the first <paramref name="failCount"/> requests matching <paramref name="urlContains"/>,
-    /// then returns 200 with <paramref name="successJson"/>.
-    /// </summary>
     public void SetupTransientRateLimit(string urlContains, int failCount, string successJson)
     {
         this.transientFailures[urlContains] = (failCount, HttpStatusCode.TooManyRequests, successJson);

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/FakePlanItHandler.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/FakePlanItHandler.cs
@@ -9,6 +9,7 @@ internal sealed class FakePlanItHandler : HttpMessageHandler
     private readonly List<string> requestUrls = [];
     private readonly Dictionary<string, int> rateLimitCounters = new();
     private readonly Dictionary<string, HttpStatusCode> statusCodeResponses = new();
+    private readonly Dictionary<string, (int RemainingFailures, HttpStatusCode StatusCode, string SuccessJson)> transientFailures = new();
 
     public IReadOnlyList<string> RequestUrls => this.requestUrls;
 
@@ -27,12 +28,48 @@ internal sealed class FakePlanItHandler : HttpMessageHandler
         this.statusCodeResponses[urlContains] = statusCode;
     }
 
+    /// <summary>
+    /// Returns <paramref name="statusCode"/> for the first <paramref name="failCount"/> requests
+    /// matching <paramref name="urlContains"/>, then returns 200 with <paramref name="successJson"/>.
+    /// </summary>
+    public void SetupTransientFailure(string urlContains, int failCount, HttpStatusCode statusCode, string successJson)
+    {
+        this.transientFailures[urlContains] = (failCount, statusCode, successJson);
+    }
+
+    /// <summary>
+    /// Returns 429 for the first <paramref name="failCount"/> requests matching <paramref name="urlContains"/>,
+    /// then returns 200 with <paramref name="successJson"/>.
+    /// </summary>
+    public void SetupTransientRateLimit(string urlContains, int failCount, string successJson)
+    {
+        this.transientFailures[urlContains] = (failCount, HttpStatusCode.TooManyRequests, successJson);
+    }
+
     protected override Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
         var url = request.RequestUri?.PathAndQuery ?? string.Empty;
         this.requestUrls.Add(url);
+
+        // Check transient failures first (they take priority)
+        var transientKey = this.transientFailures.Keys.FirstOrDefault(
+            k => url.Contains(k, StringComparison.Ordinal));
+        if (transientKey is not null)
+        {
+            var (remaining, statusCode, successJson) = this.transientFailures[transientKey];
+            if (remaining > 0)
+            {
+                this.transientFailures[transientKey] = (remaining - 1, statusCode, successJson);
+                return Task.FromResult(new HttpResponseMessage(statusCode));
+            }
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(successJson, Encoding.UTF8, "application/json"),
+            });
+        }
 
         foreach (var (key, _) in this.rateLimitCounters)
         {

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItClientTests.cs
@@ -194,19 +194,21 @@ public sealed class PlanItClientTests
     }
 
     [Test]
-    public async Task Should_ThrowImmediately_When_ApiReturns429()
+    public async Task Should_ThrowAfterRetries_When_ApiReturns429Forever()
     {
         // Arrange
         using var handler = new FakePlanItHandler();
         handler.SetupRateLimitForever("page=1");
-        var client = CreateClient(handler);
+        var delays = new List<TimeSpan>();
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0 };
+        var client = CreateClient(handler, throttleOptions: throttleOptions, delays: delays);
 
-        // Act & Assert — should throw immediately without retrying
+        // Act & Assert — should throw after exhausting retries (default 3)
         await Assert.ThrowsAsync<HttpRequestException>(
             async () => await ConsumeAsync(client, differentStart: null));
 
-        // Only 1 request — no retries, the client throws on first 429
-        await Assert.That(handler.RequestUrls).HasCount().EqualTo(1);
+        // 4 requests: 1 initial + 3 retries
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(4);
     }
 
     [Test]
@@ -460,7 +462,8 @@ public sealed class PlanItClientTests
         // Arrange
         using var handler = new FakePlanItHandler();
         handler.SetupRateLimitForever("page=1");
-        var client = CreateClient(handler);
+        var delays = new List<TimeSpan>();
+        var client = CreateClient(handler, delays: delays);
 
         var recorded = new List<(long Value, int StatusCode, int AuthorityCode)>();
         using var listener = new MeterListener();
@@ -492,12 +495,12 @@ public sealed class PlanItClientTests
         });
         listener.Start();
 
-        // Act — 429 throws immediately, no retries
+        // Act — 429 throws after exhausting retries (default 3)
         await Assert.ThrowsAsync<HttpRequestException>(
             async () => await ConsumeAsync(client, differentStart: null, authorityId: 292));
 
-        // Assert — single 429 response recorded
-        await Assert.That(recorded).HasCount().EqualTo(1);
+        // Assert — 4 error metrics recorded (1 initial + 3 retries)
+        await Assert.That(recorded).HasCount().EqualTo(4);
         await Assert.That(recorded[0].StatusCode).IsEqualTo(429);
         await Assert.That(recorded[0].AuthorityCode).IsEqualTo(292);
     }
@@ -551,6 +554,216 @@ public sealed class PlanItClientTests
     }
 
     [Test]
+    public async Task Should_RetryAndSucceed_When_504OccursOnce()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupTransientFailure("page=1", failCount: 1, HttpStatusCode.GatewayTimeout, SingleRecordResponse);
+        var delays = new List<TimeSpan>();
+        var retryOptions = new PlanItRetryOptions { MaxRetries = 3 };
+        var client = CreateClient(handler, retryOptions: retryOptions, delays: delays);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert — should succeed after retry
+        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(results[0].Name).IsEqualTo("Leeds/26/01471/TR");
+
+        // 2 HTTP requests: 1 failure + 1 success (plus throttle delays)
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task Should_RetryWithExponentialBackoff_When_504OccursTwice()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupTransientFailure("page=1", failCount: 2, HttpStatusCode.GatewayTimeout, SingleRecordResponse);
+        var delays = new List<TimeSpan>();
+        var retryOptions = new PlanItRetryOptions
+        {
+            MaxRetries = 3,
+            InitialBackoffSeconds = 1,
+        };
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0 };
+        var client = CreateClient(handler, throttleOptions: throttleOptions, retryOptions: retryOptions, delays: delays);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert — should succeed after 2 retries
+        await Assert.That(results).HasCount().EqualTo(1);
+
+        // 3 HTTP requests: 2 failures + 1 success
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(3);
+
+        // Backoff delays: 1s, then 2s (exponential)
+        // Filter out zero-length throttle delays to find retry delays
+        var retryDelays = delays.Where(d => d > TimeSpan.Zero).ToList();
+        await Assert.That(retryDelays).HasCount().EqualTo(2);
+        await Assert.That(retryDelays[0]).IsEqualTo(TimeSpan.FromSeconds(1));
+        await Assert.That(retryDelays[1]).IsEqualTo(TimeSpan.FromSeconds(2));
+    }
+
+    [Test]
+    public async Task Should_ThrowAfterMaxRetries_When_504PersistsForever()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupStatusCodeResponse("page=1", HttpStatusCode.GatewayTimeout);
+        var delays = new List<TimeSpan>();
+        var retryOptions = new PlanItRetryOptions { MaxRetries = 2 };
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0 };
+        var client = CreateClient(handler, throttleOptions: throttleOptions, retryOptions: retryOptions, delays: delays);
+
+        // Act & Assert — should throw after exhausting retries
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await ConsumeAsync(client, differentStart: null));
+
+        // 3 HTTP requests: 1 initial + 2 retries
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(3);
+    }
+
+    [Test]
+    public async Task Should_RetryOn429WithLongerBackoff_When_RateLimited()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupTransientRateLimit("page=1", failCount: 1, SingleRecordResponse);
+        var delays = new List<TimeSpan>();
+        var retryOptions = new PlanItRetryOptions
+        {
+            MaxRetries = 3,
+            RateLimitBackoffSeconds = 5,
+        };
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0 };
+        var client = CreateClient(handler, throttleOptions: throttleOptions, retryOptions: retryOptions, delays: delays);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert — should succeed after retry
+        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(2);
+
+        // Rate limit backoff: 5s (first attempt)
+        var retryDelays = delays.Where(d => d > TimeSpan.Zero).ToList();
+        await Assert.That(retryDelays).HasCount().EqualTo(1);
+        await Assert.That(retryDelays[0]).IsEqualTo(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Should_NotRetryOn400_When_BadRequest()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupStatusCodeResponse("page=1", HttpStatusCode.BadRequest);
+        var retryOptions = new PlanItRetryOptions { MaxRetries = 3 };
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0 };
+        var client = CreateClient(handler, throttleOptions: throttleOptions, retryOptions: retryOptions);
+
+        // Act & Assert — should throw immediately, no retries
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await ConsumeAsync(client, differentStart: null));
+
+        // Only 1 request — 400 is not retryable
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_RetryOn502_When_BadGateway()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupTransientFailure("page=1", failCount: 1, HttpStatusCode.BadGateway, SingleRecordResponse);
+        var delays = new List<TimeSpan>();
+        var retryOptions = new PlanItRetryOptions { MaxRetries = 3 };
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0 };
+        var client = CreateClient(handler, throttleOptions: throttleOptions, retryOptions: retryOptions, delays: delays);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert — should succeed after retry
+        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task Should_RetryOn503_When_ServiceUnavailable()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupTransientFailure("page=1", failCount: 1, HttpStatusCode.ServiceUnavailable, SingleRecordResponse);
+        var delays = new List<TimeSpan>();
+        var retryOptions = new PlanItRetryOptions { MaxRetries = 3 };
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0 };
+        var client = CreateClient(handler, throttleOptions: throttleOptions, retryOptions: retryOptions, delays: delays);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert — should succeed after retry
+        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task Should_RetryOn408_When_RequestTimeout()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupTransientFailure("page=1", failCount: 1, HttpStatusCode.RequestTimeout, SingleRecordResponse);
+        var delays = new List<TimeSpan>();
+        var retryOptions = new PlanItRetryOptions { MaxRetries = 3 };
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0 };
+        var client = CreateClient(handler, throttleOptions: throttleOptions, retryOptions: retryOptions, delays: delays);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert — should succeed after retry
+        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task Should_UseDefaultRetryOptions_When_NoneProvided()
+    {
+        // Arrange — no retry options provided, so the client should use defaults (3 retries)
+        using var handler = new FakePlanItHandler();
+        handler.SetupTransientFailure("page=1", failCount: 1, HttpStatusCode.GatewayTimeout, SingleRecordResponse);
+        var delays = new List<TimeSpan>();
+        var client = CreateClient(handler, delays: delays);
+
+        // Act
+        var results = await ConsumeAsync(client, differentStart: null);
+
+        // Assert — should succeed after retry using default options
+        await Assert.That(results).HasCount().EqualTo(1);
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(2);
+    }
+
+    [Test]
+    public async Task Should_DisableRetries_When_MaxRetriesIsZero()
+    {
+        // Arrange
+        using var handler = new FakePlanItHandler();
+        handler.SetupStatusCodeResponse("page=1", HttpStatusCode.GatewayTimeout);
+        var retryOptions = new PlanItRetryOptions { MaxRetries = 0 };
+        var throttleOptions = new PlanItThrottleOptions { DelayBetweenRequestsSeconds = 0 };
+        var client = CreateClient(handler, throttleOptions: throttleOptions, retryOptions: retryOptions);
+
+        // Act & Assert — should throw immediately, no retries
+        await Assert.ThrowsAsync<HttpRequestException>(
+            async () => await ConsumeAsync(client, differentStart: null));
+
+        // Only 1 request — retries disabled
+        await Assert.That(handler.RequestUrls).HasCount().EqualTo(1);
+    }
+
+    [Test]
     [NotInParallel]
     public async Task Should_NotRecordHttpErrorMetric_When_ApiReturns200()
     {
@@ -584,6 +797,7 @@ public sealed class PlanItClientTests
     private static PlanItClient CreateClient(
         FakePlanItHandler handler,
         PlanItThrottleOptions? throttleOptions = null,
+        PlanItRetryOptions? retryOptions = null,
         List<TimeSpan>? delays = null)
     {
         var httpClient = new HttpClient(handler, disposeHandler: false)
@@ -601,7 +815,7 @@ public sealed class PlanItClientTests
             };
         }
 
-        return new PlanItClient(httpClient, throttleOptions, delayFunc);
+        return new PlanItClient(httpClient, throttleOptions, retryOptions, delayFunc);
     }
 
     private static async Task<List<TownCrier.Domain.PlanningApplications.PlanningApplication>> ConsumeAsync(

--- a/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItRetryOptionsTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanIt/PlanItRetryOptionsTests.cs
@@ -1,0 +1,53 @@
+using TownCrier.Infrastructure.PlanIt;
+
+namespace TownCrier.Infrastructure.Tests.PlanIt;
+
+public sealed class PlanItRetryOptionsTests
+{
+    [Test]
+    public async Task Should_DefaultToThreeRetries_When_NoPropertiesSet()
+    {
+        // Arrange & Act
+        var options = new PlanItRetryOptions();
+
+        // Assert
+        await Assert.That(options.MaxRetries).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task Should_DefaultToOneSecondInitialBackoff_When_NoPropertiesSet()
+    {
+        // Arrange & Act
+        var options = new PlanItRetryOptions();
+
+        // Assert
+        await Assert.That(options.InitialBackoffSeconds).IsEqualTo(1);
+        await Assert.That(options.InitialBackoff).IsEqualTo(TimeSpan.FromSeconds(1));
+    }
+
+    [Test]
+    public async Task Should_DefaultToFiveSecondRateLimitBackoff_When_NoPropertiesSet()
+    {
+        // Arrange & Act
+        var options = new PlanItRetryOptions();
+
+        // Assert
+        await Assert.That(options.RateLimitBackoffSeconds).IsEqualTo(5);
+        await Assert.That(options.RateLimitBackoff).IsEqualTo(TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Should_ComputeBackoffFromSeconds_When_SecondsPropertySet()
+    {
+        // Arrange & Act
+        var options = new PlanItRetryOptions
+        {
+            InitialBackoffSeconds = 2.5,
+            RateLimitBackoffSeconds = 10,
+        };
+
+        // Assert
+        await Assert.That(options.InitialBackoff).IsEqualTo(TimeSpan.FromSeconds(2.5));
+        await Assert.That(options.RateLimitBackoff).IsEqualTo(TimeSpan.FromSeconds(10));
+    }
+}

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -7,6 +7,8 @@ using Pulumi.AzureNative.ApplicationInsights;
 using Pulumi.AzureNative.CosmosDB;
 using Pulumi.AzureNative.CosmosDB.Inputs;
 using Pulumi.AzureNative.Web;
+using Pulumi.AzureNative.Monitor;
+using Pulumi.AzureNative.Monitor.Inputs;
 using ManagedServiceIdentityType = Pulumi.AzureNative.App.ManagedServiceIdentityType;
 
 /// <summary>
@@ -62,6 +64,7 @@ public static class EnvironmentStack
         var appInsightsId = shared.GetOutput("appInsightsId").Apply(o => o?.ToString() ?? "");
         var appInsightsConnectionString = shared.GetOutput("appInsightsConnectionString").Apply(o => o?.ToString() ?? "");
         var acsConnectionString = shared.GetOutput("acsConnectionString").Apply(o => o?.ToString() ?? "");
+        var actionGroupId = shared.GetOutput("actionGroupId").Apply(o => o?.ToString() ?? "");
         // Extract the CAE name from its resource ID to avoid
         // requiring a shared stack deploy before the env stack can preview.
         // ID format: /subscriptions/.../resourceGroups/{rg}/providers/Microsoft.App/managedEnvironments/{name}
@@ -372,13 +375,25 @@ public static class EnvironmentStack
         // These populate the availabilityResults table in App Insights and enable
         // downtime alerting. Particularly important for a scale-to-zero architecture
         // where the container may be inactive between requests.
-        CreateAvailabilityTest(
+        var apiWebTest = CreateAvailabilityTest(
             "api-health", env, $"https://{apiDomain}/health", "API Health",
             sharedResourceGroupName, appInsightsId, tags);
 
-        CreateAvailabilityTest(
+        var webWebTest = CreateAvailabilityTest(
             "web-health", env, $"https://{frontendDomain}/health", "Web Health",
             sharedResourceGroupName, appInsightsId, tags);
+
+        // Availability Alert Rules — fire when 2+ test locations report failure.
+        // Linked to the shared action group for email notifications.
+        CreateAvailabilityAlert(
+            "api-health", env, apiWebTest.Id,
+            "API availability degraded — health check failing from multiple locations.",
+            sharedResourceGroupName, appInsightsId, actionGroupId, tags);
+
+        CreateAvailabilityAlert(
+            "web-health", env, webWebTest.Id,
+            "Web availability degraded — health check failing from multiple locations.",
+            sharedResourceGroupName, appInsightsId, actionGroupId, tags);
 
         // Static Web App Custom Domain
         // Apex domains (no subdomain) require TXT validation; subdomains use default CNAME.
@@ -436,7 +451,8 @@ public static class EnvironmentStack
     /// <param name="resourceGroupName">Resource group where the App Insights instance lives.</param>
     /// <param name="appInsightsId">Resource ID of the App Insights component.</param>
     /// <param name="tags">Standard resource tags.</param>
-    private static void CreateAvailabilityTest(
+    /// <returns>The created WebTest resource, for use as a scope in alert rules.</returns>
+    private static WebTest CreateAvailabilityTest(
         string nameSuffix,
         string env,
         string url,
@@ -461,7 +477,7 @@ public static class EnvironmentStack
             return merged;
         });
 
-        _ = new WebTest(testName, new WebTestArgs
+        return new WebTest(testName, new WebTestArgs
         {
             WebTestName = testName,
             ResourceGroupName = resourceGroupName,
@@ -504,6 +520,66 @@ public static class EnvironmentStack
                 SSLCertRemainingLifetimeCheck = 7,
             },
             Tags = webTestTags.Apply(t => (IDictionary<string, string>)t),
+        });
+    }
+
+    /// <summary>
+    /// Creates a metric alert rule that fires when an availability test fails from
+    /// 2 or more geo-locations. Uses the <c>WebtestLocationAvailabilityCriteria</c>
+    /// which links an App Insights component with a specific web test.
+    /// </summary>
+    /// <param name="nameSuffix">Short identifier matching the web test (e.g. "api-health").</param>
+    /// <param name="env">Environment name (dev/prod).</param>
+    /// <param name="webTestId">Resource ID of the web test to monitor.</param>
+    /// <param name="description">Alert description shown in notifications.</param>
+    /// <param name="resourceGroupName">Resource group where the App Insights instance lives.</param>
+    /// <param name="appInsightsId">Resource ID of the App Insights component.</param>
+    /// <param name="actionGroupId">Resource ID of the action group to notify.</param>
+    /// <param name="tags">Standard resource tags.</param>
+    private static void CreateAvailabilityAlert(
+        string nameSuffix,
+        string env,
+        Output<string> webTestId,
+        string description,
+        Output<string> resourceGroupName,
+        Output<string> appInsightsId,
+        Output<string> actionGroupId,
+        InputMap<string> tags)
+    {
+        var alertName = $"alert-{nameSuffix}-{env}";
+
+        _ = new MetricAlert(alertName, new MetricAlertArgs
+        {
+            RuleName = alertName,
+            ResourceGroupName = resourceGroupName,
+            Location = "global",
+            Description = description,
+            Severity = 1, // Sev 1 — Error
+            Enabled = true,
+            // Scopes must include both the App Insights component and the web test.
+            Scopes = new InputList<string>
+            {
+                appInsightsId,
+                webTestId,
+            },
+            EvaluationFrequency = "PT1M",  // Evaluate every 1 minute
+            WindowSize = "PT5M",           // Over a 5-minute window
+            Criteria = new WebtestLocationAvailabilityCriteriaArgs
+            {
+                OdataType = "Microsoft.Azure.Monitor.WebtestLocationAvailabilityCriteria",
+                WebTestId = webTestId,
+                ComponentId = appInsightsId,
+                FailedLocationCount = 2,  // Alert when 2+ of 3 locations fail
+            },
+            Actions = new[]
+            {
+                new Pulumi.AzureNative.Monitor.Inputs.MetricAlertActionArgs
+                {
+                    ActionGroupId = actionGroupId,
+                },
+            },
+            AutoMitigate = true,
+            Tags = tags,
         });
     }
 

--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -13,6 +13,7 @@ using Pulumi.AzureNative.Portal;
 using Pulumi.AzureNative.Portal.Inputs;
 using Pulumi.AzureNative.Communication;
 using Pulumi.AzureNative.Communication.Inputs;
+using Pulumi.AzureNative.Monitor;
 
 public static class SharedStack
 {
@@ -200,6 +201,33 @@ public static class SharedStack
             Tags = tags,
         });
 
+        // Action Group — shared notification target for availability and other alerts.
+        // The alert email is optional; when not configured, the action group is created
+        // but with no receivers (alerts still fire and appear in the portal).
+        var alertEmail = config.Get("alertEmail");
+
+        var actionGroupReceivers = new List<Pulumi.AzureNative.Monitor.Inputs.EmailReceiverArgs>();
+        if (!string.IsNullOrEmpty(alertEmail))
+        {
+            actionGroupReceivers.Add(new Pulumi.AzureNative.Monitor.Inputs.EmailReceiverArgs
+            {
+                Name = "town-crier-alerts",
+                EmailAddress = alertEmail,
+                UseCommonAlertSchema = true,
+            });
+        }
+
+        var actionGroup = new ActionGroup("ag-town-crier-availability", new ActionGroupArgs
+        {
+            ActionGroupName = "ag-town-crier-availability",
+            ResourceGroupName = resourceGroup.Name,
+            Location = "global",
+            GroupShortName = "tc-avail",
+            Enabled = true,
+            EmailReceivers = actionGroupReceivers,
+            Tags = tags,
+        });
+
         // Operational Dashboard
         var dashboard = new Dashboard("dash-towncrier-operational", new DashboardArgs
         {
@@ -322,6 +350,7 @@ public static class SharedStack
             ["cosmosAccountEndpoint"] = cosmosAccount.DocumentEndpoint,
             ["appInsightsId"] = appInsights.Id,
             ["appInsightsConnectionString"] = appInsights.ConnectionString,
+            ["actionGroupId"] = actionGroup.Id,
             ["acsConnectionString"] = Output.Tuple(resourceGroup.Name, communicationService.Name)
                 .Apply(names => ListCommunicationServiceKeys.InvokeAsync(new ListCommunicationServiceKeysArgs
                 {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -8,6 +8,8 @@ public final class AppCoordinator: ObservableObject {
   @Published public var deepLinkError: DomainError?
   @Published public var presentedLegalDocument: LegalDocumentType?
   @Published public var isManageSubscriptionPresented = false
+  @Published public var isAddingWatchZone = false
+  @Published public var editingWatchZone: WatchZone?
 
   public var isOnboardingComplete: Bool {
     onboardingRepository.isOnboardingComplete
@@ -22,6 +24,7 @@ public final class AppCoordinator: ObservableObject {
   private let offlineRepository: OfflineAwareRepository?
   private let authorityRepository: ApplicationAuthorityRepository?
   private let watchZoneRepository: WatchZoneRepository
+  private let geocoder: PostcodeGeocoder?
   private let appVersionProvider: AppVersionProvider
   private let versionConfigService: VersionConfigService
 
@@ -33,6 +36,7 @@ public final class AppCoordinator: ObservableObject {
     offlineRepository: OfflineAwareRepository? = nil,
     authorityRepository: ApplicationAuthorityRepository? = nil,
     watchZoneRepository: WatchZoneRepository,
+    geocoder: PostcodeGeocoder? = nil,
     onboardingRepository: OnboardingRepository,
     notificationService: NotificationService,
     appVersionProvider: AppVersionProvider,
@@ -45,6 +49,7 @@ public final class AppCoordinator: ObservableObject {
     self.offlineRepository = offlineRepository
     self.authorityRepository = authorityRepository
     self.watchZoneRepository = watchZoneRepository
+    self.geocoder = geocoder
     self.onboardingRepository = onboardingRepository
     self.notificationService = notificationService
     self.appVersionProvider = appVersionProvider
@@ -128,6 +133,37 @@ public final class AppCoordinator: ObservableObject {
     viewModel.onDismiss = { [weak self] in
       self?.detailApplication = nil
     }
+    return viewModel
+  }
+
+  // MARK: - Watch Zone Factories
+
+  public func makeWatchZoneListViewModel() -> WatchZoneListViewModel {
+    let viewModel = WatchZoneListViewModel(
+      repository: watchZoneRepository,
+      featureGate: FeatureGate(tier: .free)
+    )
+    viewModel.onAddZone = { [weak self] in
+      self?.isAddingWatchZone = true
+    }
+    viewModel.onEditZone = { [weak self] zone in
+      self?.editingWatchZone = zone
+    }
+    return viewModel
+  }
+
+  public func makeWatchZoneEditorViewModel(
+    editing zone: WatchZone? = nil
+  ) -> WatchZoneEditorViewModel {
+    guard let geocoder else {
+      fatalError("PostcodeGeocoder must be injected to create WatchZoneEditorViewModel")
+    }
+    let viewModel = WatchZoneEditorViewModel(
+      geocoder: geocoder,
+      repository: watchZoneRepository,
+      tier: .free,
+      editing: zone
+    )
     return viewModel
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -164,6 +164,10 @@ public final class AppCoordinator: ObservableObject {
       tier: .free,
       editing: zone
     )
+    viewModel.onSave = { [weak self] _ in
+      self?.isAddingWatchZone = false
+      self?.editingWatchZone = nil
+    }
     return viewModel
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -8,6 +8,7 @@ public final class AppCoordinator: ObservableObject {
   @Published public var deepLinkError: DomainError?
   @Published public var presentedLegalDocument: LegalDocumentType?
   @Published public var isManageSubscriptionPresented = false
+  @Published public var isSubscriptionPresented = false
   @Published public var isAddingWatchZone = false
   @Published public var editingWatchZone: WatchZone?
 
@@ -148,6 +149,9 @@ public final class AppCoordinator: ObservableObject {
     }
     viewModel.onEditZone = { [weak self] zone in
       self?.editingWatchZone = zone
+    }
+    viewModel.onViewPlans = { [weak self] in
+      self?.isSubscriptionPresented = true
     }
     return viewModel
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -55,6 +55,15 @@ public struct WatchZoneListView: View {
     .task {
       await viewModel.load()
     }
+    .sheet(isPresented: $viewModel.isUpgradePromptPresented) {
+      WatchZoneUpsellView(
+        valueProposition: viewModel.upgradeValueProposition,
+        onViewPlans: { viewModel.viewPlans() },
+        onDismiss: { viewModel.dismissUpgradePrompt() }
+      )
+      .presentationDetents([.medium])
+      .presentationDragIndicator(.visible)
+    }
   }
 
   private var emptyState: some View {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListViewModel.swift
@@ -12,6 +12,7 @@ public final class WatchZoneListViewModel: ObservableObject, ErrorHandlingViewMo
   @Published public private(set) var zones: [WatchZone] = []
   @Published public private(set) var isLoading = false
   @Published public internal(set) var error: DomainError?
+  @Published public var isUpgradePromptPresented = false
 
   /// The proactive feature gate derived from the user's subscription tier.
   public let featureGate: FeatureGate
@@ -19,6 +20,7 @@ public final class WatchZoneListViewModel: ObservableObject, ErrorHandlingViewMo
   var onAddZone: (() -> Void)?
   var onEditZone: ((WatchZone) -> Void)?
   var onUpgradeRequired: (() -> Void)?
+  var onViewPlans: (() -> Void)?
 
   private let repository: WatchZoneRepository
 
@@ -69,8 +71,25 @@ public final class WatchZoneListViewModel: ObservableObject, ErrorHandlingViewMo
     if canAddZone {
       onAddZone?()
     } else {
+      isUpgradePromptPresented = true
       onUpgradeRequired?()
     }
+  }
+
+  /// Dismisses the upgrade prompt without navigating to subscription plans.
+  public func dismissUpgradePrompt() {
+    isUpgradePromptPresented = false
+  }
+
+  /// Navigates to subscription plans and dismisses the upgrade prompt.
+  public func viewPlans() {
+    isUpgradePromptPresented = false
+    onViewPlans?()
+  }
+
+  /// Value proposition text shown in the upsell prompt.
+  public var upgradeValueProposition: String {
+    "Monitor multiple areas at once. Upgrade to add more watch zones and never miss a planning application near you."
   }
 
   public func editZone(_ zone: WatchZone) {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneUpsellView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneUpsellView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+/// A sheet presented when a free-tier user attempts to add a watch zone beyond
+/// their tier's limit.
+///
+/// Shows a zone-specific value proposition with a CTA to view subscription plans
+/// and a secondary dismiss action.
+///
+/// Presented via `.sheet(isPresented:)` binding on
+/// ``WatchZoneListViewModel/isUpgradePromptPresented``.
+public struct WatchZoneUpsellView: View {
+  private let valueProposition: String
+  private let onViewPlans: () -> Void
+  private let onDismiss: () -> Void
+
+  public init(
+    valueProposition: String,
+    onViewPlans: @escaping () -> Void,
+    onDismiss: @escaping () -> Void
+  ) {
+    self.valueProposition = valueProposition
+    self.onViewPlans = onViewPlans
+    self.onDismiss = onDismiss
+  }
+
+  public var body: some View {
+    VStack(spacing: TCSpacing.large) {
+      Spacer()
+        .frame(height: TCSpacing.medium)
+
+      // Icon
+      Image(systemName: "mappin.and.ellipse")
+        .font(.system(.largeTitle))
+        .foregroundStyle(Color.tcAmber)
+
+      // Title
+      Text("Add more watch zones")
+        .font(TCTypography.displaySmall)
+        .foregroundStyle(Color.tcTextPrimary)
+
+      // Value proposition
+      Text(valueProposition)
+        .font(TCTypography.body)
+        .foregroundStyle(Color.tcTextSecondary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, TCSpacing.medium)
+
+      Spacer()
+        .frame(height: TCSpacing.small)
+
+      // Primary CTA
+      PrimaryButton("View Plans", action: onViewPlans)
+        .padding(.horizontal, TCSpacing.medium)
+
+      // Secondary dismiss
+      Button(action: onDismiss) {
+        Text("Not now")
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+      .frame(minHeight: 44)
+
+      Spacer()
+        .frame(height: TCSpacing.medium)
+    }
+    .padding(.horizontal, TCSpacing.medium)
+    .background(Color.tcSurfaceElevated)
+  }
+
+  // MARK: - Test Helpers
+
+  /// Simulates tapping "View Plans" for unit testing.
+  func simulateViewPlansTap() {
+    onViewPlans()
+  }
+
+  /// Simulates tapping "Not now" for unit testing.
+  func simulateDismissTap() {
+    onDismiss()
+  }
+}

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -13,6 +13,7 @@ struct TownCrierApp: App {
   @StateObject private var settingsViewModel: SettingsViewModel
   @StateObject private var applicationListViewModel: ApplicationListViewModel
   @StateObject private var mapViewModel: MapViewModel
+  @StateObject private var watchZoneListViewModel: WatchZoneListViewModel
   private let crashReporter: CrashReporter
   private let notificationDelegate: NotificationDelegate
 
@@ -46,6 +47,7 @@ struct TownCrierApp: App {
     let userProfileRepository = APIUserProfileRepository(apiClient: apiClient)
     let authorityRepository = APIApplicationAuthorityRepository(apiClient: apiClient)
     let watchZoneRepository = APIWatchZoneRepository(apiClient: apiClient)
+    let geocoder = APIPostcodeGeocoder(apiClient: apiClient)
 
     let appCoordinator = AppCoordinator(
       repository: repository,
@@ -55,6 +57,7 @@ struct TownCrierApp: App {
       offlineRepository: offlineRepository,
       authorityRepository: authorityRepository,
       watchZoneRepository: watchZoneRepository,
+      geocoder: geocoder,
       onboardingRepository: onboardingRepository,
       notificationService: notificationService,
       appVersionProvider: appVersionProvider,
@@ -74,6 +77,9 @@ struct TownCrierApp: App {
 
     _applicationListViewModel = StateObject(wrappedValue: listVM)
     _mapViewModel = StateObject(wrappedValue: mapVM)
+
+    let watchZoneListVM = appCoordinator.makeWatchZoneListViewModel()
+    _watchZoneListViewModel = StateObject(wrappedValue: watchZoneListVM)
 
     let settingsVM = appCoordinator.makeSettingsViewModel()
     settingsVM.onLogout = {
@@ -154,6 +160,23 @@ struct TownCrierApp: App {
       }
       .tabItem {
         Label("Map", systemImage: "map")
+      }
+
+      NavigationStack {
+        WatchZoneListView(viewModel: watchZoneListViewModel)
+      }
+      .sheet(isPresented: $coordinator.isAddingWatchZone) {
+        WatchZoneEditorView(
+          viewModel: coordinator.makeWatchZoneEditorViewModel()
+        )
+      }
+      .sheet(item: $coordinator.editingWatchZone) { zone in
+        WatchZoneEditorView(
+          viewModel: coordinator.makeWatchZoneEditorViewModel(editing: zone)
+        )
+      }
+      .tabItem {
+        Label("Zones", systemImage: "mappin.and.ellipse")
       }
 
       NavigationStack {

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -276,4 +276,26 @@ struct AppCoordinatorTests {
     #expect(vm.isEditing)
     #expect(vm.postcodeInput == "CB1 2AD")
   }
+
+  @Test func makeWatchZoneEditorViewModel_onSave_dismissesEditor() {
+    let (sut, _) = makeSUT()
+    sut.isAddingWatchZone = true
+    let vm = sut.makeWatchZoneEditorViewModel()
+
+    vm.onSave?(.cambridge)
+
+    #expect(!sut.isAddingWatchZone)
+    #expect(sut.editingWatchZone == nil)
+  }
+
+  @Test func makeWatchZoneEditorViewModel_forEdit_onSave_dismissesEditor() {
+    let (sut, _) = makeSUT()
+    sut.editingWatchZone = .cambridge
+    let vm = sut.makeWatchZoneEditorViewModel(editing: .cambridge)
+
+    vm.onSave?(.cambridge)
+
+    #expect(sut.editingWatchZone == nil)
+    #expect(!sut.isAddingWatchZone)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -15,6 +15,7 @@ struct AppCoordinatorTests {
       subscriptionService: SpySubscriptionService(),
       userProfileRepository: SpyUserProfileRepository(),
       watchZoneRepository: SpyWatchZoneRepository(),
+      geocoder: SpyPostcodeGeocoder(),
       onboardingRepository: SpyOnboardingRepository(),
       notificationService: SpyNotificationService(),
       appVersionProvider: SpyAppVersionProvider(),

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -298,4 +298,21 @@ struct AppCoordinatorTests {
     #expect(sut.editingWatchZone == nil)
     #expect(!sut.isAddingWatchZone)
   }
+
+  // MARK: - Watch Zone Upsell
+
+  @Test func makeWatchZoneListViewModel_onViewPlans_setsIsSubscriptionPresented() {
+    let (sut, _) = makeSUT()
+    let vm = sut.makeWatchZoneListViewModel()
+
+    vm.viewPlans()
+
+    #expect(sut.isSubscriptionPresented)
+  }
+
+  @Test func isSubscriptionPresented_isFalseByDefault() {
+    let (sut, _) = makeSUT()
+
+    #expect(!sut.isSubscriptionPresented)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -215,4 +215,64 @@ struct AppCoordinatorTests {
 
     #expect(!sut.isManageSubscriptionPresented)
   }
+
+  // MARK: - Watch Zone List Factory
+
+  @Test func makeWatchZoneListViewModel_createsViewModel() {
+    let (sut, _) = makeSUT()
+
+    let vm = sut.makeWatchZoneListViewModel()
+
+    #expect(vm.zones.isEmpty)
+    #expect(!vm.isLoading)
+  }
+
+  @Test func makeWatchZoneListViewModel_onAddZone_setsIsAddingWatchZone() {
+    let (sut, _) = makeSUT()
+    let vm = sut.makeWatchZoneListViewModel()
+
+    vm.addZone()
+
+    #expect(sut.isAddingWatchZone)
+  }
+
+  @Test func makeWatchZoneListViewModel_onEditZone_setsEditingWatchZone() {
+    let (sut, _) = makeSUT()
+    let vm = sut.makeWatchZoneListViewModel()
+
+    vm.editZone(.cambridge)
+
+    #expect(sut.editingWatchZone == .cambridge)
+  }
+
+  @Test func isAddingWatchZone_isFalseByDefault() {
+    let (sut, _) = makeSUT()
+
+    #expect(!sut.isAddingWatchZone)
+  }
+
+  @Test func editingWatchZone_isNilByDefault() {
+    let (sut, _) = makeSUT()
+
+    #expect(sut.editingWatchZone == nil)
+  }
+
+  // MARK: - Watch Zone Editor Factory
+
+  @Test func makeWatchZoneEditorViewModel_forAdd_createsNonEditingViewModel() {
+    let (sut, _) = makeSUT()
+
+    let vm = sut.makeWatchZoneEditorViewModel()
+
+    #expect(!vm.isEditing)
+  }
+
+  @Test func makeWatchZoneEditorViewModel_forEdit_createsEditingViewModel() {
+    let (sut, _) = makeSUT()
+
+    let vm = sut.makeWatchZoneEditorViewModel(editing: .cambridge)
+
+    #expect(vm.isEditing)
+    #expect(vm.postcodeInput == "CB1 2AD")
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/CompositionRootTests.swift
@@ -103,6 +103,21 @@ struct CompositionRootTests {
     #expect(config.audience == "https://api-test.example.com")
   }
 
+  @Test func coordinatorCreatesWatchZoneListViewModel() {
+    let coordinator = makeCoordinator()
+    let vm = coordinator.makeWatchZoneListViewModel()
+
+    #expect(vm.zones.isEmpty)
+    #expect(!vm.isLoading)
+  }
+
+  @Test func coordinatorCreatesWatchZoneEditorViewModel() {
+    let coordinator = makeCoordinatorWithGeocoder()
+    let vm = coordinator.makeWatchZoneEditorViewModel()
+
+    #expect(!vm.isEditing)
+  }
+
   @Test func coordinatorCreatesMapViewModelWithAuthorityRepository() async {
     let authService = Auth0AuthenticationService(config: makeTestAuth0Config())
     // swiftlint:disable:next force_unwrapping
@@ -180,6 +195,28 @@ struct CompositionRootTests {
       subscriptionService: StoreKitSubscriptionService(),
       userProfileRepository: APIUserProfileRepository(apiClient: apiClient),
       watchZoneRepository: APIWatchZoneRepository(apiClient: apiClient),
+      onboardingRepository: UserDefaultsOnboardingRepository(),
+      notificationService: CompositeNotificationService(
+        permissionProvider: SpyNotificationPermissionProvider(),
+        apiService: APINotificationService(apiClient: apiClient)
+      ),
+      appVersionProvider: BundleAppVersionProvider(),
+      versionConfigService: APIVersionConfigService(baseURL: apiBaseURL)
+    )
+  }
+
+  private func makeCoordinatorWithGeocoder() -> AppCoordinator {
+    let authService = Auth0AuthenticationService(config: makeTestAuth0Config())
+    // swiftlint:disable:next force_unwrapping
+    let apiBaseURL = URL(string: "https://api.towncrierapp.uk")!
+    let apiClient = URLSessionAPIClient(baseURL: apiBaseURL, authService: authService)
+    return AppCoordinator(
+      repository: APIPlanningApplicationRepository(apiClient: apiClient),
+      authService: authService,
+      subscriptionService: StoreKitSubscriptionService(),
+      userProfileRepository: APIUserProfileRepository(apiClient: apiClient),
+      watchZoneRepository: APIWatchZoneRepository(apiClient: apiClient),
+      geocoder: APIPostcodeGeocoder(apiClient: apiClient),
       onboardingRepository: UserDefaultsOnboardingRepository(),
       notificationService: CompositeNotificationService(
         permissionProvider: SpyNotificationPermissionProvider(),

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewModelTests.swift
@@ -196,4 +196,79 @@ struct WatchZoneListViewModelTests {
 
     #expect(upgradeCalled)
   }
+
+  // MARK: - Upsell prompt
+
+  @Test func addZone_atLimit_setsIsUpgradePromptPresented() async {
+    let sut = WatchZoneListViewModel(
+      repository: spyRepository,
+      featureGate: FeatureGate(tier: .free)
+    )
+    spyRepository.loadAllResult = .success([.cambridge])
+    await sut.load()
+
+    sut.addZone()
+
+    #expect(sut.isUpgradePromptPresented)
+  }
+
+  @Test func addZone_underLimit_doesNotSetIsUpgradePromptPresented() async {
+    let sut = WatchZoneListViewModel(
+      repository: spyRepository,
+      featureGate: FeatureGate(tier: .free)
+    )
+    spyRepository.loadAllResult = .success([])
+    await sut.load()
+
+    sut.addZone()
+
+    #expect(!sut.isUpgradePromptPresented)
+  }
+
+  @Test func isUpgradePromptPresented_isFalseByDefault() {
+    #expect(!sut.isUpgradePromptPresented)
+  }
+
+  @Test func dismissUpgradePrompt_setsIsUpgradePromptPresentedToFalse() async {
+    let sut = WatchZoneListViewModel(
+      repository: spyRepository,
+      featureGate: FeatureGate(tier: .free)
+    )
+    spyRepository.loadAllResult = .success([.cambridge])
+    await sut.load()
+    sut.addZone()
+    #expect(sut.isUpgradePromptPresented)
+
+    sut.dismissUpgradePrompt()
+
+    #expect(!sut.isUpgradePromptPresented)
+  }
+
+  @Test func viewPlans_invokesOnViewPlansAndDismissesPrompt() async {
+    let sut = WatchZoneListViewModel(
+      repository: spyRepository,
+      featureGate: FeatureGate(tier: .free)
+    )
+    spyRepository.loadAllResult = .success([.cambridge])
+    await sut.load()
+    sut.addZone()
+    var viewPlansCalled = false
+    sut.onViewPlans = { viewPlansCalled = true }
+
+    sut.viewPlans()
+
+    #expect(viewPlansCalled)
+    #expect(!sut.isUpgradePromptPresented)
+  }
+
+  @Test func upgradeValueProposition_returnsNonEmptyString() async {
+    let sut = WatchZoneListViewModel(
+      repository: spyRepository,
+      featureGate: FeatureGate(tier: .free)
+    )
+    spyRepository.loadAllResult = .success([.cambridge])
+    await sut.load()
+
+    #expect(!sut.upgradeValueProposition.isEmpty)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewTests.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@Suite("WatchZoneListView")
+@MainActor
+struct WatchZoneListViewTests {
+
+  private func makeViewModel(
+    tier: SubscriptionTier = .free
+  ) -> (WatchZoneListViewModel, SpyWatchZoneRepository) {
+    let spy = SpyWatchZoneRepository()
+    let vm = WatchZoneListViewModel(
+      repository: spy,
+      featureGate: FeatureGate(tier: tier)
+    )
+    return (vm, spy)
+  }
+
+  @Test func body_renders_whenNoZones() {
+    let (vm, _) = makeViewModel()
+    let sut = WatchZoneListView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_whenUpgradePromptPresented() async {
+    let (vm, spy) = makeViewModel()
+    spy.loadAllResult = .success([.cambridge])
+    await vm.load()
+    vm.addZone()
+
+    #expect(vm.isUpgradePromptPresented)
+
+    let sut = WatchZoneListView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_withZones() async {
+    let (vm, spy) = makeViewModel()
+    spy.loadAllResult = .success([.cambridge])
+    await vm.load()
+
+    let sut = WatchZoneListView(viewModel: vm)
+    _ = sut.body
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneUpsellViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneUpsellViewTests.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@Suite("WatchZoneUpsellView")
+@MainActor
+struct WatchZoneUpsellViewTests {
+
+  // MARK: - Initialization
+
+  @Test func init_createsView() {
+    let sut = WatchZoneUpsellView(
+      valueProposition: "Upgrade to monitor multiple areas.",
+      onViewPlans: {},
+      onDismiss: {}
+    )
+    _ = sut.body
+  }
+
+  // MARK: - Callbacks
+
+  @Test func onViewPlans_isCalled_whenViewPlansTapped() {
+    var viewPlansCalled = false
+    let sut = WatchZoneUpsellView(
+      valueProposition: "Upgrade to monitor multiple areas.",
+      onViewPlans: { viewPlansCalled = true },
+      onDismiss: {}
+    )
+    sut.simulateViewPlansTap()
+    #expect(viewPlansCalled)
+  }
+
+  @Test func onDismiss_isCalled_whenNotNowTapped() {
+    var dismissCalled = false
+    let sut = WatchZoneUpsellView(
+      valueProposition: "Upgrade to monitor multiple areas.",
+      onViewPlans: {},
+      onDismiss: { dismissCalled = true }
+    )
+    sut.simulateDismissTap()
+    #expect(dismissCalled)
+  }
+}


### PR DESCRIPTION
## Changes

- **Zones tab** (`tc-4xj`): Added 4th "Zones" tab to iOS TabView, wiring WatchZoneListView with full navigation to WatchZoneEditorView for add/edit (6 commits, 11 tests)
- **Free-tier upsell** (`tc-5kq`): When free-tier users hit their 1-zone limit, show an upsell sheet with value proposition and path to subscription (7 commits, 14 tests)
- **PlanIt API resilience** (`tc-0keu`): Added manual retry with exponential backoff for transient failures (504/502/503/408) and rate limiting (429) in PlanItClient — no Polly, Native AOT compatible (3 commits, 12 tests)
- **Prod availability monitoring** (`tc-bkcd`): Added availability alert rules and shared action group in Pulumi for production API and web health checks (1 commit)

## Test results

| Area | Tests | Result |
|------|-------|--------|
| iOS | 790 | All pass |
| .NET (unit) | 402 | All pass |
| Infra | build | 0 warnings, 0 errors |

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable retry mechanism for transient API failures with exponential backoff delays
  * Azure Monitor health alerts for service uptime monitoring
  * Watch zone management features including add/edit capabilities with subscription tier-based upsell prompts

* **Tests**
  * Added test coverage for API retry behavior under various failure scenarios
  * Added comprehensive test coverage for watch zone management and tier-based features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->