### PR TITLE
fix(ios): subscription tier, zone parsing, feature gate, and StoreKit crash

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIWatchZoneRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIWatchZoneRepository.swift
@@ -11,7 +11,7 @@ public final class APIWatchZoneRepository: WatchZoneRepository, Sendable {
 
   public func save(_ zone: WatchZone) async throws {
     let body = CreateWatchZoneRequest(
-      name: zone.postcode.value,
+      name: zone.name,
       latitude: zone.centre.latitude,
       longitude: zone.centre.longitude,
       radiusMetres: zone.radiusMetres,
@@ -77,14 +77,12 @@ struct WatchZoneSummaryDTO: Decodable, Sendable {
   let authorityId: Int
 
   func toDomain() -> WatchZone? {
-    guard let postcode = try? Postcode(name),
-      let centre = try? Coordinate(latitude: latitude, longitude: longitude)
-    else {
+    guard let centre = try? Coordinate(latitude: latitude, longitude: longitude) else {
       return nil
     }
     return try? WatchZone(
       id: WatchZoneId(id),
-      postcode: postcode,
+      name: name,
       centre: centre,
       radiusMetres: radiusMetres,
       authorityId: authorityId

--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/DomainError.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/DomainError.swift
@@ -5,6 +5,7 @@ public enum DomainError: Error, Equatable, Sendable {
   case applicationNotFound(PlanningApplicationId)
   case invalidCoordinate
   case invalidWatchZoneRadius
+  case invalidWatchZoneName
   case networkUnavailable
   case serverError(statusCode: Int, message: String?)
   case authenticationFailed(String)
@@ -39,7 +40,7 @@ public enum DomainError: Error, Equatable, Sendable {
     case .insufficientEntitlement:
       return "Upgrade Required"
     case .invalidPostcode, .invalidCoordinate, .invalidWatchZoneRadius,
-      .invalidStatusTransition, .geocodingFailed,
+      .invalidWatchZoneName, .invalidStatusTransition, .geocodingFailed,
       .notificationPermissionDenied, .unexpected:
       return "Something Went Wrong"
     }
@@ -67,7 +68,7 @@ public enum DomainError: Error, Equatable, Sendable {
     case .insufficientEntitlement:
       return "This feature requires a higher subscription tier. Upgrade to unlock it."
     case .invalidPostcode, .invalidCoordinate, .invalidWatchZoneRadius,
-      .invalidStatusTransition, .geocodingFailed, .unexpected:
+      .invalidWatchZoneName, .invalidStatusTransition, .geocodingFailed, .unexpected:
       return "An unexpected error occurred. Please try again."
     }
   }
@@ -79,8 +80,8 @@ public enum DomainError: Error, Equatable, Sendable {
       .purchaseFailed, .restoreFailed, .logoutFailed:
       return true
     case .sessionExpired, .authenticationFailed, .invalidPostcode,
-      .invalidCoordinate, .invalidWatchZoneRadius, .invalidStatusTransition,
-      .applicationNotFound, .notificationPermissionDenied,
+      .invalidCoordinate, .invalidWatchZoneRadius, .invalidWatchZoneName,
+      .invalidStatusTransition, .applicationNotFound, .notificationPermissionDenied,
       .purchaseCancelled, .productNotFound, .insufficientEntitlement:
       return false
     }

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZone.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZone.swift
@@ -3,11 +3,33 @@ import Foundation
 /// A circular geographic area that a user monitors for planning applications.
 public struct WatchZone: Equatable, Hashable, Identifiable, Sendable {
   public let id: WatchZoneId
-  public let postcode: Postcode
+  public let name: String
   public let centre: Coordinate
   public let radiusMetres: Double
   public let authorityId: Int
 
+  public init(
+    id: WatchZoneId = WatchZoneId(),
+    name: String,
+    centre: Coordinate,
+    radiusMetres: Double,
+    authorityId: Int = 0
+  ) throws {
+    let trimmed = name.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else {
+      throw DomainError.invalidWatchZoneName
+    }
+    guard radiusMetres > 0 else {
+      throw DomainError.invalidWatchZoneRadius
+    }
+    self.id = id
+    self.name = trimmed
+    self.centre = centre
+    self.radiusMetres = radiusMetres
+    self.authorityId = authorityId
+  }
+
+  /// Convenience initializer that derives the zone name from a validated postcode.
   public init(
     id: WatchZoneId = WatchZoneId(),
     postcode: Postcode,
@@ -15,14 +37,13 @@ public struct WatchZone: Equatable, Hashable, Identifiable, Sendable {
     radiusMetres: Double,
     authorityId: Int = 0
   ) throws {
-    guard radiusMetres > 0 else {
-      throw DomainError.invalidWatchZoneRadius
-    }
-    self.id = id
-    self.postcode = postcode
-    self.centre = centre
-    self.radiusMetres = radiusMetres
-    self.authorityId = authorityId
+    try self.init(
+      id: id,
+      name: postcode.value,
+      centre: centre,
+      radiusMetres: radiusMetres,
+      authorityId: authorityId
+    )
   }
 
   /// Returns true if the given coordinate falls within this watch zone.

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -1,9 +1,12 @@
 import Combine
 import TownCrierDomain
+import os
 
 /// Root coordinator managing top-level navigation.
 @MainActor
 public final class AppCoordinator: ObservableObject {
+  private static let logger = Logger(subsystem: "uk.towncrierapp", category: "AppCoordinator")
+
   @Published public var detailApplication: PlanningApplication?
   @Published public var deepLinkError: DomainError?
   @Published public var presentedLegalDocument: LegalDocumentType?
@@ -11,6 +14,7 @@ public final class AppCoordinator: ObservableObject {
   @Published public var isSubscriptionPresented = false
   @Published public var isAddingWatchZone = false
   @Published public var editingWatchZone: WatchZone?
+  @Published public private(set) var subscriptionTier: SubscriptionTier = .free
 
   public var isOnboardingComplete: Bool {
     onboardingRepository.isOnboardingComplete
@@ -137,12 +141,42 @@ public final class AppCoordinator: ObservableObject {
     return viewModel
   }
 
+  // MARK: - Subscription Tier Resolution
+
+  /// Resolves the subscription tier by consulting the JWT session, StoreKit,
+  /// and the server profile, then picks the highest tier. Mirrors the same
+  /// triple-source resolution used by ``SettingsViewModel``.
+  public func resolveSubscriptionTier() async {
+    var jwtTier: SubscriptionTier = .free
+    if let session = await authService.currentSession() {
+      jwtTier = session.subscriptionTier
+    }
+
+    let serverTier = await fetchServerTier()
+    let storeKitTier = await subscriptionService.currentEntitlement()?.tier ?? .free
+    subscriptionTier = max(serverTier, max(storeKitTier, jwtTier))
+  }
+
+  private func fetchServerTier() async -> SubscriptionTier {
+    do {
+      if let profile = try await userProfileRepository.fetch() {
+        return profile.tier
+      }
+      return .free
+    } catch {
+      Self.logger.error(
+        "Failed to fetch server profile for subscription tier: \(error.localizedDescription)"
+      )
+      return .free
+    }
+  }
+
   // MARK: - Watch Zone Factories
 
   public func makeWatchZoneListViewModel() -> WatchZoneListViewModel {
     let viewModel = WatchZoneListViewModel(
       repository: watchZoneRepository,
-      featureGate: FeatureGate(tier: .free)
+      featureGate: FeatureGate(tier: subscriptionTier)
     )
     viewModel.onAddZone = { [weak self] in
       self?.isAddingWatchZone = true
@@ -165,7 +199,7 @@ public final class AppCoordinator: ObservableObject {
     let viewModel = WatchZoneEditorViewModel(
       geocoder: geocoder,
       repository: watchZoneRepository,
-      tier: .free,
+      tier: subscriptionTier,
       editing: zone
     )
     viewModel.onSave = { [weak self] _ in

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/Binding+MainThread.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/Binding+MainThread.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+extension Binding: @retroactive @unchecked Sendable {}
+
+extension Binding where Value: Sendable {
+  /// Returns a new binding that dispatches its setter onto the main thread.
+  ///
+  /// Use this when a framework (e.g. StoreKit's `manageSubscriptionsSheet`)
+  /// calls the binding setter from a background thread while the backing
+  /// store is `@MainActor`-isolated. `DispatchQueue.main.async` integrates
+  /// directly with the run loop, avoiding the race window that
+  /// `Task { @MainActor in }` introduces via Swift Concurrency's
+  /// cooperative executor.
+  public func dispatchingSetOnMain() -> Binding<Value> {
+    Binding<Value>(
+      get: { self.wrappedValue },
+      set: { newValue in
+        if Thread.isMainThread {
+          self.wrappedValue = newValue
+        } else {
+          DispatchQueue.main.async {
+            self.wrappedValue = newValue
+          }
+        }
+      }
+    )
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Dashboard/DashboardView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Dashboard/DashboardView.swift
@@ -213,7 +213,7 @@ private struct DashboardZoneRow: View {
         .foregroundStyle(Color.tcAmber)
 
       VStack(alignment: .leading, spacing: TCSpacing.extraSmall) {
-        Text(zone.postcode.value)
+        Text(zone.name)
           .font(TCTypography.bodyEmphasis)
           .foregroundStyle(Color.tcTextPrimary)
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
@@ -7,6 +7,7 @@ import os
 @MainActor
 public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
   private static let logger = Logger(subsystem: "uk.towncrierapp", category: "SettingsViewModel")
+
   @Published public private(set) var userEmail: String?
   @Published public private(set) var userName: String?
   @Published public private(set) var authMethod: AuthMethod?

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
@@ -1,10 +1,12 @@
 import Combine
 import Foundation
 import TownCrierDomain
+import os
 
 /// ViewModel managing the settings and account screen.
 @MainActor
 public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
+  private static let logger = Logger(subsystem: "uk.towncrierapp", category: "SettingsViewModel")
   @Published public private(set) var userEmail: String?
   @Published public private(set) var userName: String?
   @Published public private(set) var authMethod: AuthMethod?
@@ -67,13 +69,15 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
     isLoading = true
     error = nil
 
+    var jwtTier: SubscriptionTier = .free
     if let session = await authService.currentSession() {
       userEmail = session.userProfile.email
       userName = session.userProfile.name
       authMethod = session.userProfile.authMethod
+      jwtTier = session.subscriptionTier
     }
 
-    let resolvedTier = await resolveSubscriptionTier()
+    let resolvedTier = await resolveSubscriptionTier(jwtTier: jwtTier)
     subscriptionTier = resolvedTier.tier
     isTrialPeriod = resolvedTier.isTrialPeriod
 
@@ -114,21 +118,25 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
   }
 
   /// Resolves the subscription tier by consulting the backend API profile
-  /// (source of truth) and StoreKit (for App Store purchases), then picking
-  /// the higher tier. This handles web-purchased subscriptions that StoreKit
-  /// does not know about, and recently App-Store-purchased subscriptions
-  /// that the server may not have synced yet.
-  private func resolveSubscriptionTier() async -> (tier: SubscriptionTier, isTrialPeriod: Bool) {
+  /// (source of truth), StoreKit (for App Store purchases), and the JWT
+  /// access token claim, then picking the highest tier. This handles
+  /// web-purchased subscriptions that StoreKit does not know about, recently
+  /// App-Store-purchased subscriptions that the server may not have synced
+  /// yet, and API failures where the JWT claim provides a viable fallback.
+  private func resolveSubscriptionTier(
+    jwtTier: SubscriptionTier
+  ) async -> (tier: SubscriptionTier, isTrialPeriod: Bool) {
     let serverTier = await fetchServerTier()
     let storeKitEntitlement = await subscriptionService.currentEntitlement()
 
     let storeKitTier = storeKitEntitlement?.tier ?? .free
-    let highestTier = max(serverTier, storeKitTier)
+    let highestTier = max(serverTier, max(storeKitTier, jwtTier))
 
     // Only report trial status from StoreKit — the server profile doesn't
     // carry trial information. Trial period is only meaningful when the
     // StoreKit tier is the one that won.
-    let isTrialPeriod = storeKitEntitlement?.isTrialPeriod == true && storeKitTier >= serverTier
+    let isTrialPeriod =
+      storeKitEntitlement?.isTrialPeriod == true && storeKitTier >= max(serverTier, jwtTier)
 
     return (highestTier, isTrialPeriod)
   }
@@ -140,6 +148,9 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
       }
       return .free
     } catch {
+      Self.logger.error(
+        "Failed to fetch server profile for subscription tier: \(error.localizedDescription)"
+      )
       return .free
     }
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
@@ -33,7 +33,7 @@ public final class WatchZoneEditorViewModel: ObservableObject, ErrorHandlingView
     self.existingId = zone?.id
 
     if let zone {
-      self.postcodeInput = zone.postcode.value
+      self.postcodeInput = zone.name
       self.selectedRadiusMetres = zone.radiusMetres
       self.geocodedCoordinate = zone.centre
     }
@@ -69,6 +69,7 @@ public final class WatchZoneEditorViewModel: ObservableObject, ErrorHandlingView
     guard let coordinate = geocodedCoordinate else { return }
     error = nil
 
+    // Validate the postcode input before saving
     let postcode: Postcode
     do {
       postcode = try Postcode(postcodeInput)
@@ -82,7 +83,7 @@ public final class WatchZoneEditorViewModel: ObservableObject, ErrorHandlingView
     do {
       let zone = try WatchZone(
         id: existingId ?? WatchZoneId(),
-        postcode: postcode,
+        name: postcode.value,
         centre: coordinate,
         radiusMetres: clampedRadius
       )

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -105,7 +105,7 @@ private struct WatchZoneRow: View {
         .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.small))
 
       VStack(alignment: .leading, spacing: TCSpacing.extraSmall) {
-        Text(zone.postcode.value)
+        Text(zone.name)
           .font(.system(.headline).weight(.semibold))
         Text(formatRadius(zone.radiusMetres))
           .font(.system(.caption))

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -200,14 +200,7 @@ struct TownCrierApp: App {
       }
       #if os(iOS)
         .manageSubscriptionsSheet(
-          isPresented: Binding(
-            get: { coordinator.isManageSubscriptionPresented },
-            set: { newValue in
-              Task { @MainActor in
-                coordinator.isManageSubscriptionPresented = newValue
-              }
-            }
-          )
+          isPresented: $coordinator.isManageSubscriptionPresented.dispatchingSetOnMain()
         )
       #endif
       .tabItem {

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -13,7 +13,6 @@ struct TownCrierApp: App {
   @StateObject private var settingsViewModel: SettingsViewModel
   @StateObject private var applicationListViewModel: ApplicationListViewModel
   @StateObject private var mapViewModel: MapViewModel
-  @StateObject private var watchZoneListViewModel: WatchZoneListViewModel
   private let crashReporter: CrashReporter
   private let notificationDelegate: NotificationDelegate
 
@@ -78,9 +77,6 @@ struct TownCrierApp: App {
     _applicationListViewModel = StateObject(wrappedValue: listVM)
     _mapViewModel = StateObject(wrappedValue: mapVM)
 
-    let watchZoneListVM = appCoordinator.makeWatchZoneListViewModel()
-    _watchZoneListViewModel = StateObject(wrappedValue: watchZoneListVM)
-
     let settingsVM = appCoordinator.makeSettingsViewModel()
     settingsVM.onLogout = {
       Task { @MainActor in
@@ -115,6 +111,7 @@ struct TownCrierApp: App {
         AuthCallbackHandler.handle(url: url)
       }
       .task {
+        await coordinator.resolveSubscriptionTier()
         await forceUpdateViewModel.checkVersion()
       }
       .alert(
@@ -163,7 +160,8 @@ struct TownCrierApp: App {
       }
 
       NavigationStack {
-        WatchZoneListView(viewModel: watchZoneListViewModel)
+        WatchZoneListView(viewModel: coordinator.makeWatchZoneListViewModel())
+          .id(coordinator.subscriptionTier)
       }
       .sheet(isPresented: $coordinator.isAddingWatchZone) {
         WatchZoneEditorView(

--- a/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryTests.swift
@@ -157,6 +157,70 @@ struct APIWatchZoneRepositoryTests {
     #expect(zone.authorityId == 123)
   }
 
+  @Test("loadAll includes zones with freeform names (web-created)")
+  func loadAll_freeformName_includesZone() async throws {
+    let json = """
+      {
+          "zones": [
+              {
+                  "id": "zone-web-001",
+                  "name": "My Home Zone",
+                  "latitude": 51.5014,
+                  "longitude": -0.1419,
+                  "radiusMetres": 1500,
+                  "authorityId": 456
+              }
+          ]
+      }
+      """
+    let (sut, _, _) = makeSUT(responses: [
+      (Data(json.utf8), httpResponse(statusCode: 200))
+    ])
+
+    let zones = try await sut.loadAll()
+
+    #expect(zones.count == 1)
+    let zone = zones[0]
+    #expect(zone.id == WatchZoneId("zone-web-001"))
+    #expect(zone.name == "My Home Zone")
+    #expect(zone.authorityId == 456)
+  }
+
+  @Test("loadAll returns mix of postcode and freeform-named zones")
+  func loadAll_mixedNames_returnsAll() async throws {
+    let json = """
+      {
+          "zones": [
+              {
+                  "id": "zone-ios",
+                  "name": "CB1 2AD",
+                  "latitude": 52.2053,
+                  "longitude": 0.1218,
+                  "radiusMetres": 2000,
+                  "authorityId": 123
+              },
+              {
+                  "id": "zone-web",
+                  "name": "Office near Westminster",
+                  "latitude": 51.5014,
+                  "longitude": -0.1419,
+                  "radiusMetres": 1500,
+                  "authorityId": 456
+              }
+          ]
+      }
+      """
+    let (sut, _, _) = makeSUT(responses: [
+      (Data(json.utf8), httpResponse(statusCode: 200))
+    ])
+
+    let zones = try await sut.loadAll()
+
+    #expect(zones.count == 2)
+    #expect(zones[0].name == "CB1 2AD")
+    #expect(zones[1].name == "Office near Westminster")
+  }
+
   @Test("loadAll returns empty array when no zones")
   func loadAll_emptyZones_returnsEmptyArray() async throws {
     let json = """

--- a/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryTests.swift
@@ -150,8 +150,7 @@ struct APIWatchZoneRepositoryTests {
     #expect(zones.count == 1)
     let zone = zones[0]
     #expect(zone.id == WatchZoneId("zone-001"))
-    let expectedPostcode = try Postcode("CB1 2AD")
-    #expect(zone.postcode == expectedPostcode)
+    #expect(zone.name == "CB1 2AD")
     let expectedCentre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
     #expect(zone.centre == expectedCentre)
     #expect(zone.radiusMetres == 2000)

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTierResolutionTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTierResolutionTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@Suite("AppCoordinator — Subscription Tier Resolution")
+@MainActor
+struct AppCoordinatorTierResolutionTests {
+
+  // MARK: - Helpers
+
+  private func makeSUT(
+    authSession: AuthSession? = nil,
+    entitlement: SubscriptionEntitlement? = nil,
+    serverProfile: ServerProfile? = nil,
+    serverProfileError: Error? = nil
+  ) -> (AppCoordinator, SpyAuthenticationService, SpySubscriptionService, SpyUserProfileRepository) {
+    let authSpy = SpyAuthenticationService()
+    authSpy.currentSessionResult = authSession
+    let subscriptionSpy = SpySubscriptionService()
+    subscriptionSpy.currentEntitlementResult = entitlement
+    let profileSpy = SpyUserProfileRepository()
+    if let serverProfileError {
+      profileSpy.fetchResult = .failure(serverProfileError)
+    } else {
+      profileSpy.fetchResult = .success(serverProfile)
+    }
+    let coordinator = AppCoordinator(
+      repository: SpyPlanningApplicationRepository(),
+      authService: authSpy,
+      subscriptionService: subscriptionSpy,
+      userProfileRepository: profileSpy,
+      watchZoneRepository: SpyWatchZoneRepository(),
+      geocoder: SpyPostcodeGeocoder(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService()
+    )
+    return (coordinator, authSpy, subscriptionSpy, profileSpy)
+  }
+
+  private func makeServerProfile(tier: SubscriptionTier) -> ServerProfile {
+    ServerProfile(
+      userId: "u1",
+      tier: tier,
+      pushEnabled: true,
+      digestDay: .monday,
+      emailDigestEnabled: true
+    )
+  }
+
+  // MARK: - resolveSubscriptionTier
+
+  @Test func resolveSubscriptionTier_picksHighestFromAllSources() async {
+    let (sut, _, _, _) = makeSUT(
+      authSession: .pro,
+      serverProfile: makeServerProfile(tier: .personal)
+    )
+
+    await sut.resolveSubscriptionTier()
+
+    #expect(sut.subscriptionTier == .pro)
+  }
+
+  @Test func resolveSubscriptionTier_storeKitWins_whenHighest() async {
+    let (sut, _, _, _) = makeSUT(
+      authSession: .valid,
+      entitlement: .proActive
+    )
+
+    await sut.resolveSubscriptionTier()
+
+    #expect(sut.subscriptionTier == .pro)
+  }
+
+  @Test func resolveSubscriptionTier_serverWins_whenHighest() async {
+    let (sut, _, _, _) = makeSUT(
+      authSession: .valid,
+      serverProfile: makeServerProfile(tier: .pro)
+    )
+
+    await sut.resolveSubscriptionTier()
+
+    #expect(sut.subscriptionTier == .pro)
+  }
+
+  @Test func resolveSubscriptionTier_defaultsToFree_whenNoSession() async {
+    let (sut, _, _, _) = makeSUT()
+
+    await sut.resolveSubscriptionTier()
+
+    #expect(sut.subscriptionTier == .free)
+  }
+
+  @Test func resolveSubscriptionTier_fallsBackToJWT_whenServerFails() async {
+    let (sut, _, _, _) = makeSUT(
+      authSession: .personal,
+      serverProfileError: DomainError.networkUnavailable
+    )
+
+    await sut.resolveSubscriptionTier()
+
+    #expect(sut.subscriptionTier == .personal)
+  }
+
+  // MARK: - Factory methods use resolved tier
+
+  @Test func makeWatchZoneListViewModel_usesResolvedTier() async {
+    let (sut, _, _, _) = makeSUT(authSession: .pro)
+
+    await sut.resolveSubscriptionTier()
+    let vm = sut.makeWatchZoneListViewModel()
+
+    #expect(vm.featureGate.tier == .pro)
+  }
+
+  @Test func makeWatchZoneEditorViewModel_usesResolvedTier() async {
+    let (sut, _, _, _) = makeSUT(authSession: .personal)
+
+    await sut.resolveSubscriptionTier()
+    let vm = sut.makeWatchZoneEditorViewModel()
+
+    #expect(vm.availableRadiusOptions == WatchZoneLimits(tier: .personal).availableRadiusOptions)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/BindingMainThreadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/BindingMainThreadTests.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import Testing
+
+@testable import TownCrierPresentation
+
+@Suite("Binding+MainThread")
+@MainActor
+struct BindingMainThreadTests {
+
+  @Test func dispatchingSetOnMain_getReturnsCurrentValue() {
+    var value = false
+    let base = Binding(get: { value }, set: { value = $0 })
+
+    let sut = base.dispatchingSetOnMain()
+
+    #expect(sut.wrappedValue == false)
+  }
+
+  @Test func dispatchingSetOnMain_setUpdatesValue_whenAlreadyOnMainThread() {
+    var value = false
+    let base = Binding(get: { value }, set: { value = $0 })
+
+    let sut = base.dispatchingSetOnMain()
+    sut.wrappedValue = true
+
+    #expect(value == true)
+  }
+
+  @Test func dispatchingSetOnMain_setUpdatesValue_fromBackgroundThread() async {
+    var value = false
+    let base = Binding(get: { value }, set: { value = $0 })
+    let sut = base.dispatchingSetOnMain()
+
+    // Simulate StoreKit's behavior: setting the binding from a background thread
+    await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+      DispatchQueue.global(qos: .userInitiated).async {
+        sut.wrappedValue = true
+        // Give the main queue a chance to process
+        DispatchQueue.main.async {
+          continuation.resume()
+        }
+      }
+    }
+
+    #expect(value == true)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/SettingsViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SettingsViewModelTests.swift
@@ -193,6 +193,21 @@ struct SettingsViewModelTests {
     #expect(sut.subscriptionTier == .pro)
   }
 
+  @Test func load_noTrialFlag_whenJWTTierHigherThanStoreKitTrial() async {
+    // JWT says pro, StoreKit says personal trial — trial is not meaningful
+    // because the user's actual tier (pro) is above the trial tier
+    let (sut, _, _, _, _, _) = makeSUT(
+      session: .pro,
+      entitlement: .personalTrial,
+      serverProfile: .failure(DomainError.networkUnavailable)
+    )
+
+    await sut.load()
+
+    #expect(sut.subscriptionTier == .pro)
+    #expect(!sut.isTrialPeriod)
+  }
+
   @Test func load_defaultsToFree_whenAllSourcesReturnFree() async {
     let (sut, _, _, _, _, _) = makeSUT(
       session: .valid,

--- a/mobile/ios/town-crier-tests/Sources/Features/SettingsViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SettingsViewModelTests.swift
@@ -156,8 +156,46 @@ struct SettingsViewModelTests {
     #expect(sut.subscriptionTier == .personal)
   }
 
-  @Test func load_defaultsToFree_whenBothSourcesFail() async {
+  @Test func load_usesJWTTier_whenServerAndStoreKitBothUnavailable() async {
     let (sut, _, _, _, _, _) = makeSUT(
+      session: .pro,
+      entitlement: nil,
+      serverProfile: .failure(DomainError.networkUnavailable)
+    )
+
+    await sut.load()
+
+    #expect(sut.subscriptionTier == .pro)
+  }
+
+  @Test func load_usesJWTTier_whenServerFailsAndStoreKitNil() async {
+    let (sut, _, _, _, _, _) = makeSUT(
+      session: .personal,
+      entitlement: nil,
+      serverProfile: .failure(DomainError.networkUnavailable)
+    )
+
+    await sut.load()
+
+    #expect(sut.subscriptionTier == .personal)
+  }
+
+  @Test func load_picksHighestAcrossAllThreeSources() async {
+    // JWT says pro, server says free, StoreKit says personal — take pro
+    let (sut, _, _, _, _, _) = makeSUT(
+      session: .pro,
+      entitlement: .personalActive,
+      serverProfile: .success(.freeUser)
+    )
+
+    await sut.load()
+
+    #expect(sut.subscriptionTier == .pro)
+  }
+
+  @Test func load_defaultsToFree_whenAllSourcesReturnFree() async {
+    let (sut, _, _, _, _, _) = makeSUT(
+      session: .valid,
       entitlement: nil,
       serverProfile: .failure(DomainError.networkUnavailable)
     )

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelTests.swift
@@ -82,7 +82,7 @@ struct WatchZoneEditorCreateTests {
 
     #expect(spyRepository.saveCalls.count == 1)
     let saved = spyRepository.saveCalls.first
-    #expect(saved?.postcode == .cambridge)
+    #expect(saved?.name == "CB1 2AD")
     #expect(saved?.centre == .cambridge)
     #expect(saved?.radiusMetres == 2000)
   }

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneTests.swift
@@ -10,7 +10,7 @@ struct WatchZoneTests {
     let zone = try WatchZone(postcode: postcode, centre: centre, radiusMetres: 1000)
     #expect(zone.centre == centre)
     #expect(zone.radiusMetres == 1000)
-    #expect(zone.postcode == postcode)
+    #expect(zone.name == postcode.value)
   }
 
   @Test func init_zeroRadius_throws() throws {

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneTests.swift
@@ -71,4 +71,38 @@ struct WatchZoneTests {
     let zone = try WatchZone(postcode: postcode, centre: centre, radiusMetres: 1000)
     #expect(zone.authorityId == 0)
   }
+
+  // MARK: - Freeform name support (tc-y39l)
+
+  @Test func init_acceptsFreeformName() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    let zone = try WatchZone(name: "My Home Zone", centre: centre, radiusMetres: 1000)
+    #expect(zone.name == "My Home Zone")
+  }
+
+  @Test func init_freeformName_nonPostcodeName_succeeds() throws {
+    let centre = try Coordinate(latitude: 51.5014, longitude: -0.1419)
+    let zone = try WatchZone(
+      name: "Office near Westminster",
+      centre: centre,
+      radiusMetres: 2000,
+      authorityId: 456
+    )
+    #expect(zone.name == "Office near Westminster")
+    #expect(zone.authorityId == 456)
+  }
+
+  @Test func init_freeformName_emptyName_throws() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    #expect(throws: DomainError.invalidWatchZoneName) {
+      try WatchZone(name: "", centre: centre, radiusMetres: 1000)
+    }
+  }
+
+  @Test func init_freeformName_whitespaceOnlyName_throws() throws {
+    let centre = try Coordinate(latitude: 52.2053, longitude: 0.1218)
+    #expect(throws: DomainError.invalidWatchZoneName) {
+      try WatchZone(name: "   ", centre: centre, radiusMetres: 1000)
+    }
+  }
 }


### PR DESCRIPTION
## Changes

- **tc-gm9v** — Fix `manageSubscriptionsSheet` crash: replaced async `Task { @MainActor in }` with synchronous `DispatchQueue.main.async` via `Binding.dispatchingSetOnMain()`
- **tc-s88a** — Fix subscription tier always showing Free: added JWT tier as third source in `resolveSubscriptionTier()`, logged API errors instead of silently swallowing them
- **tc-y39l** — Fix zones created on web silently dropped: replaced `WatchZone.postcode: Postcode` with `WatchZone.name: String` so freeform web-created zone names are preserved
- **tc-mbem** — Fix `FeatureGate` hardcoded to `.free` in `AppCoordinator`: inject resolved subscription tier from session into `FeatureGate`

**Test results:** 810 iOS tests passing (20 net new)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription tier now resolves dynamically from multiple sources (JWT, server profile, StoreKit entitlements).
  * Added main thread binding dispatch for safer UI updates.

* **Bug Fixes**
  * Watch zones now display by name instead of postcode.

* **Refactor**
  * Streamlined zone domain model to use name-based identification instead of postcode objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->