### PR TITLE
fix(infra): shorten Container Apps Job name prefix to job-tc-

### DIFF
--- a/.github/actions/deploy-worker-jobs/action.yml
+++ b/.github/actions/deploy-worker-jobs/action.yml
@@ -1,6 +1,6 @@
 # Updates all Container App Jobs for the worker with a new image.
 # Iterates over the standard job names (poll, digest) with the
-# naming convention job-town-crier-{name}-{env-suffix}.
+# naming convention job-tc-{name}-{env-suffix}.
 #
 # Assumes azure/login has already been called in an earlier step.
 name: Deploy Worker Jobs
@@ -24,9 +24,9 @@ runs:
       shell: bash
       run: |
         for JOB in poll digest; do
-          echo "::group::Deploying to job-town-crier-${JOB}-${{ inputs.env-suffix }}"
+          echo "::group::Deploying to job-tc-${JOB}-${{ inputs.env-suffix }}"
           az containerapp job update \
-            --name "job-town-crier-${JOB}-${{ inputs.env-suffix }}" \
+            --name "job-tc-${JOB}-${{ inputs.env-suffix }}" \
             --resource-group "${{ inputs.resource-group }}" \
             --image "${{ inputs.image }}"
           echo "::endgroup::"

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -621,9 +621,9 @@ public static class EnvironmentStack
             envVars.Insert(1, new EnvironmentVarArgs { Name = "WORKER_MODE", Value = workerMode });
         }
 
-        return new Job($"job-town-crier-{nameSuffix}-{env}", new JobArgs
+        return new Job($"job-tc-{nameSuffix}-{env}", new JobArgs
         {
-            JobName = $"job-town-crier-{nameSuffix}-{env}",
+            JobName = $"job-tc-{nameSuffix}-{env}",
             ResourceGroupName = resourceGroupName,
             EnvironmentId = environmentId,
             Configuration = new JobConfigurationArgs


### PR DESCRIPTION
## Summary
- Prod CD failed because `job-town-crier-digest-hourly-prod` (33 chars) exceeds Azure's 32-char Container Apps Job name limit
- Dev worked by coincidence — `job-town-crier-digest-hourly-dev` is exactly 32 chars
- Shortened prefix from `job-town-crier-` to `job-tc-` in both Pulumi infra and CI deploy action
- Longest prod name is now `job-tc-digest-hourly-prod` (25 chars), well within limits

**Note:** Pulumi will delete+recreate the existing `job-town-crier-poll-{env}` and `job-town-crier-digest-{env}` jobs under the new names. These are scheduled cron jobs with no persistent state, so replacement is safe.

## Test plan
- [ ] PR Gate passes (infra builds)
- [ ] Dev CD creates jobs with `job-tc-` prefix
- [ ] Prod CD succeeds (previously failing)

Closes tc-t0wa

🤖 Generated with [Claude Code](https://claude.com/claude-code)