### PR TITLE
fix(ios): resolve watch zone from repository instead of placeholder

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -85,16 +85,24 @@ public final class AppCoordinator: ObservableObject {
     return viewModel
   }
 
-  /// Creates a list view model using a placeholder zone.
-  /// Callers should prefer `makeApplicationListViewModel(zone:)` when a real zone is available.
+  /// Creates a list view model that resolves the user's first watch zone at load time.
+  /// Callers should prefer `makeApplicationListViewModel(zone:)` when a specific zone is known.
   public func makeApplicationListViewModel() -> ApplicationListViewModel {
-    // swiftlint:disable:next force_try
-    let placeholder = try! WatchZone(
-      name: "Default",
-      centre: Coordinate(latitude: 0, longitude: 0),
-      radiusMetres: 1
-    )
-    let viewModel = makeApplicationListViewModel(zone: placeholder)
+    let viewModel: ApplicationListViewModel
+    if let offlineRepository {
+      viewModel = ApplicationListViewModel(
+        watchZoneRepository: watchZoneRepository,
+        offlineRepository: offlineRepository
+      )
+    } else {
+      viewModel = ApplicationListViewModel(
+        watchZoneRepository: watchZoneRepository,
+        repository: repository
+      )
+    }
+    viewModel.onApplicationSelected = { [weak self] id in
+      self?.showApplicationDetail(id)
+    }
     return viewModel
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -11,7 +11,8 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
 
   private let repository: PlanningApplicationRepository?
   private let offlineRepository: OfflineAwareRepository?
-  private let zone: WatchZone
+  private let watchZoneRepository: WatchZoneRepository?
+  private var zone: WatchZone?
   private let tier: SubscriptionTier
 
   var onApplicationSelected: ((PlanningApplicationId) -> Void)?
@@ -51,6 +52,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   ) {
     self.repository = repository
     self.offlineRepository = nil
+    self.watchZoneRepository = nil
     self.zone = zone
     self.tier = tier
   }
@@ -62,7 +64,32 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   ) {
     self.repository = nil
     self.offlineRepository = offlineRepository
+    self.watchZoneRepository = nil
     self.zone = zone
+    self.tier = tier
+  }
+
+  public init(
+    watchZoneRepository: WatchZoneRepository,
+    repository: PlanningApplicationRepository,
+    tier: SubscriptionTier = .free
+  ) {
+    self.repository = repository
+    self.offlineRepository = nil
+    self.watchZoneRepository = watchZoneRepository
+    self.zone = nil
+    self.tier = tier
+  }
+
+  public init(
+    watchZoneRepository: WatchZoneRepository,
+    offlineRepository: OfflineAwareRepository,
+    tier: SubscriptionTier = .free
+  ) {
+    self.repository = nil
+    self.offlineRepository = offlineRepository
+    self.watchZoneRepository = watchZoneRepository
+    self.zone = nil
     self.tier = tier
   }
 
@@ -70,6 +97,17 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     isLoading = true
     error = nil
     do {
+      if zone == nil, let watchZoneRepository {
+        let zones = try await watchZoneRepository.loadAll()
+        zone = zones.first
+      }
+
+      guard let zone else {
+        applications = []
+        isLoading = false
+        return
+      }
+
       let fetched: [PlanningApplication]
       if let offlineRepository {
         let entry = try await offlineRepository.fetchApplications(for: zone)

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -69,14 +69,28 @@ struct AppCoordinatorTests {
     #expect(spy.fetchApplicationCalls == [PlanningApplicationId("APP-002")])
   }
 
-  @Test func makeApplicationListViewModel_noArgUsesPlaceholderZone() async {
-    let (sut, spy) = makeSUT()
-    spy.fetchApplicationsResult = .success([.pendingReview])
-    let vm = sut.makeApplicationListViewModel()
+  @Test func makeApplicationListViewModel_noArg_resolvesZoneFromRepository() async {
+    let appSpy = SpyPlanningApplicationRepository()
+    appSpy.fetchApplicationsResult = .success([.pendingReview])
+    let zoneSpy = SpyWatchZoneRepository()
+    zoneSpy.loadAllResult = .success([.cambridge])
+    let coordinator = AppCoordinator(
+      repository: appSpy,
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: SpyUserProfileRepository(),
+      watchZoneRepository: zoneSpy,
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService()
+    )
+    let vm = coordinator.makeApplicationListViewModel()
 
     await vm.loadApplications()
 
-    #expect(spy.fetchApplicationsCalls.count == 1)
+    #expect(zoneSpy.loadAllCallCount == 1)
+    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
     #expect(vm.filteredApplications.count == 1)
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTests.swift
@@ -206,6 +206,74 @@ struct ApplicationListViewModelTests {
     #expect(!sut.isSessionExpired)
   }
 
+  // MARK: - Zone Resolution
+
+  @Test func loadApplications_withWatchZoneRepository_resolvesFirstZoneAndFetches() async throws {
+    let appSpy = SpyPlanningApplicationRepository()
+    appSpy.fetchApplicationsResult = .success([.pendingReview])
+    let zoneSpy = SpyWatchZoneRepository()
+    zoneSpy.loadAllResult = .success([.cambridge, .london])
+    let sut = ApplicationListViewModel(
+      watchZoneRepository: zoneSpy,
+      repository: appSpy
+    )
+
+    await sut.loadApplications()
+
+    #expect(zoneSpy.loadAllCallCount == 1)
+    #expect(appSpy.fetchApplicationsCalls.count == 1)
+    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+    #expect(sut.filteredApplications.count == 1)
+  }
+
+  @Test func loadApplications_withWatchZoneRepository_noZones_showsEmptyNotError() async throws {
+    let appSpy = SpyPlanningApplicationRepository()
+    let zoneSpy = SpyWatchZoneRepository()
+    zoneSpy.loadAllResult = .success([])
+    let sut = ApplicationListViewModel(
+      watchZoneRepository: zoneSpy,
+      repository: appSpy
+    )
+
+    await sut.loadApplications()
+
+    #expect(sut.filteredApplications.isEmpty)
+    #expect(sut.error == nil)
+    #expect(!sut.isLoading)
+  }
+
+  @Test func loadApplications_withWatchZoneRepository_zoneFetchFails_setsError() async throws {
+    let appSpy = SpyPlanningApplicationRepository()
+    let zoneSpy = SpyWatchZoneRepository()
+    zoneSpy.loadAllResult = .failure(DomainError.networkUnavailable)
+    let sut = ApplicationListViewModel(
+      watchZoneRepository: zoneSpy,
+      repository: appSpy
+    )
+
+    await sut.loadApplications()
+
+    #expect(sut.error == .networkUnavailable)
+    #expect(appSpy.fetchApplicationsCalls.isEmpty)
+  }
+
+  @Test func loadApplications_withWatchZoneRepository_cachesResolvedZoneOnRetry() async throws {
+    let appSpy = SpyPlanningApplicationRepository()
+    appSpy.fetchApplicationsResult = .success([.pendingReview])
+    let zoneSpy = SpyWatchZoneRepository()
+    zoneSpy.loadAllResult = .success([.cambridge])
+    let sut = ApplicationListViewModel(
+      watchZoneRepository: zoneSpy,
+      repository: appSpy
+    )
+
+    await sut.loadApplications()
+    await sut.loadApplications()
+
+    #expect(zoneSpy.loadAllCallCount == 1)
+    #expect(appSpy.fetchApplicationsCalls.count == 2)
+  }
+
   // MARK: - Empty State
 
   @Test func isEmpty_trueWhenNoApplicationsLoaded() async throws {


### PR DESCRIPTION
## Changes
- Fix Applications page showing "Something Went Wrong" after spatial filtering migration
- `ApplicationListViewModel` now lazily resolves the user's first real watch zone via `WatchZoneRepository.loadAll()` instead of using a placeholder zone with a random UUID
- Caches resolved zone so retries don't re-fetch zones
- Shows empty state (not error) when user has no zones
- Remove placeholder zone hack from `AppCoordinator.makeApplicationListViewModel()`
- 4 new tests covering zone resolution, empty zones, error propagation, and caching

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Application zones are now dynamically determined at runtime instead of using hardcoded defaults, improving compatibility across different configurations.
  * Enhanced offline functionality with better zone detection and error handling when zone data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->