### PR TITLE
feat(ios): zone filtering for Applications and Map tabs

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
@@ -45,6 +45,10 @@ public struct ApplicationListView: View {
 
   private var applicationList: some View {
     List {
+      if viewModel.showZonePicker {
+        zonePickerSection
+      }
+
       if viewModel.canFilter {
         filterSection
       }
@@ -59,6 +63,23 @@ public struct ApplicationListView: View {
       }
     }
     .listStyle(.plain)
+  }
+
+  // MARK: - Zone Picker
+
+  private var zonePickerSection: some View {
+    Section {
+      ZonePickerView(
+        zones: viewModel.zones,
+        selectedZoneId: viewModel.selectedZone?.id
+      ) { zone in
+        Task {
+          await viewModel.selectZone(zone)
+        }
+      }
+    }
+    .listRowInsets(EdgeInsets())
+    .listRowBackground(Color.tcBackground)
   }
 
   // MARK: - Filter Section

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import TownCrierDomain
 
 /// ViewModel driving the filterable list of planning applications.
@@ -8,17 +9,25 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   @Published var selectedStatusFilter: ApplicationStatus?
   @Published private(set) var isLoading = false
   @Published var error: DomainError?
+  @Published private(set) var zones: [WatchZone] = []
+  @Published private(set) var selectedZone: WatchZone?
 
   private let repository: PlanningApplicationRepository?
   private let offlineRepository: OfflineAwareRepository?
   private let watchZoneRepository: WatchZoneRepository?
   private var zone: WatchZone?
   private let tier: SubscriptionTier
+  private let userDefaults: UserDefaults
+  private let zoneSelectionKey: String
 
   var onApplicationSelected: ((PlanningApplicationId) -> Void)?
 
   public var canFilter: Bool {
     tier != .free
+  }
+
+  public var showZonePicker: Bool {
+    zones.count > 1
   }
 
   public var filteredApplications: [PlanningApplication] {
@@ -55,6 +64,8 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     self.watchZoneRepository = nil
     self.zone = zone
     self.tier = tier
+    self.userDefaults = .standard
+    self.zoneSelectionKey = ""
   }
 
   public init(
@@ -67,57 +78,75 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     self.watchZoneRepository = nil
     self.zone = zone
     self.tier = tier
+    self.userDefaults = .standard
+    self.zoneSelectionKey = ""
   }
 
   public init(
     watchZoneRepository: WatchZoneRepository,
     repository: PlanningApplicationRepository,
-    tier: SubscriptionTier = .free
+    tier: SubscriptionTier = .free,
+    userDefaults: UserDefaults = .standard,
+    zoneSelectionKey: String = "lastSelectedZone.applications"
   ) {
     self.repository = repository
     self.offlineRepository = nil
     self.watchZoneRepository = watchZoneRepository
     self.zone = nil
     self.tier = tier
+    self.userDefaults = userDefaults
+    self.zoneSelectionKey = zoneSelectionKey
   }
 
   public init(
     watchZoneRepository: WatchZoneRepository,
     offlineRepository: OfflineAwareRepository,
-    tier: SubscriptionTier = .free
+    tier: SubscriptionTier = .free,
+    userDefaults: UserDefaults = .standard,
+    zoneSelectionKey: String = "lastSelectedZone.applications"
   ) {
     self.repository = nil
     self.offlineRepository = offlineRepository
     self.watchZoneRepository = watchZoneRepository
     self.zone = nil
     self.tier = tier
+    self.userDefaults = userDefaults
+    self.zoneSelectionKey = zoneSelectionKey
   }
 
   public func loadApplications() async {
     isLoading = true
     error = nil
     do {
-      if zone == nil, let watchZoneRepository {
-        let zones = try await watchZoneRepository.loadAll()
-        zone = zones.first
+      if let watchZoneRepository {
+        let loadedZones = try await watchZoneRepository.loadAll()
+        zones = loadedZones
+        if selectedZone == nil || !loadedZones.contains(where: { $0.id == selectedZone?.id }) {
+          selectedZone = resolveInitialZone(from: loadedZones)
+        }
       }
-
-      guard let zone else {
+      guard let activeZone = selectedZone ?? zone else {
         applications = []
         isLoading = false
         return
       }
+      applications = try await fetchApplications(for: activeZone)
+        .sorted { $0.receivedDate > $1.receivedDate }
+    } catch {
+      handleError(error)
+    }
+    isLoading = false
+  }
 
-      let fetched: [PlanningApplication]
-      if let offlineRepository {
-        let entry = try await offlineRepository.fetchApplications(for: zone)
-        fetched = entry.data
-      } else if let repository {
-        fetched = try await repository.fetchApplications(for: zone)
-      } else {
-        fetched = []
-      }
-      applications = fetched.sorted { $0.receivedDate > $1.receivedDate }
+  public func selectZone(_ zone: WatchZone) async {
+    selectedZone = zone
+    selectedStatusFilter = nil
+    userDefaults.set(zone.id.value, forKey: zoneSelectionKey)
+    isLoading = true
+    error = nil
+    do {
+      applications = try await fetchApplications(for: zone)
+        .sorted { $0.receivedDate > $1.receivedDate }
     } catch {
       handleError(error)
     }
@@ -126,5 +155,22 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
 
   public func selectApplication(_ id: PlanningApplicationId) {
     onApplicationSelected?(id)
+  }
+
+  private func resolveInitialZone(from zones: [WatchZone]) -> WatchZone? {
+    if let savedId = userDefaults.string(forKey: zoneSelectionKey),
+       let savedZone = zones.first(where: { $0.id.value == savedId }) {
+      return savedZone
+    }
+    return zones.first
+  }
+
+  private func fetchApplications(for zone: WatchZone) async throws -> [PlanningApplication] {
+    if let offlineRepository {
+      return try await offlineRepository.fetchApplications(for: zone).data
+    } else if let repository {
+      return try await repository.fetchApplications(for: zone)
+    }
+    return []
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
@@ -5,40 +5,28 @@ import TownCrierDomain
 /// Map view displaying planning application pins colour-coded by status.
 public struct MapView: View {
   @StateObject private var viewModel: MapViewModel
+  @State private var mapPosition: MapCameraPosition = .automatic
 
   public init(viewModel: MapViewModel) {
     _viewModel = StateObject(wrappedValue: viewModel)
   }
 
   public var body: some View {
-    ZStack {
-      if viewModel.isLoading && !viewModel.hasLoaded {
-        mapPlaceholder
-      } else if let error = viewModel.error {
-        ErrorStateView(error: error) {
-          await viewModel.loadApplications()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.tcBackground)
-      } else if viewModel.isEmpty {
-        EmptyStateView(
-          icon: "map",
-          title: "No Applications",
-          description: "No planning applications found in your watch zone yet. Check back soon."
-        )
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.tcBackground)
-      } else {
-        mapContent
-        if viewModel.isLoading {
-          ProgressView()
-            .controlSize(.large)
-        }
+    VStack(spacing: 0) {
+      if viewModel.showZonePicker {
+        zonePickerSection
       }
+      mapBody
     }
     .background(Color.tcBackground)
     .task {
       await viewModel.loadApplications()
+      updateMapPosition()
+    }
+    .onChange(of: viewModel.selectedZone?.id) { _, _ in
+      withAnimation {
+        updateMapPosition()
+      }
     }
     .sheet(
       item: Binding(
@@ -52,18 +40,7 @@ public struct MapView: View {
 
   @ViewBuilder
   private var mapContent: some View {
-    Map(
-      initialPosition: .region(
-        MKCoordinateRegion(
-          center: CLLocationCoordinate2D(
-            latitude: viewModel.centreLat,
-            longitude: viewModel.centreLon
-          ),
-          latitudinalMeters: viewModel.radiusMetres * 2.5,
-          longitudinalMeters: viewModel.radiusMetres * 2.5
-        )
-      )
-    ) {
+    Map(position: $mapPosition) {
       ForEach(viewModel.annotations) { annotation in
         Annotation(
           annotation.title,
@@ -105,6 +82,48 @@ public struct MapView: View {
       .accessibilityLabel("\(annotation.title), \(annotation.status.displayLabel)")
   }
 
+  // MARK: - Zone Picker
+
+  private var zonePickerSection: some View {
+    ZonePickerView(
+      zones: viewModel.zones,
+      selectedZoneId: viewModel.selectedZone?.id
+    ) { zone in
+      Task {
+        await viewModel.selectZone(zone)
+      }
+    }
+    .background(Color.tcBackground)
+  }
+
+  private var mapBody: some View {
+    ZStack {
+      if viewModel.isLoading && !viewModel.hasLoaded {
+        mapPlaceholder
+      } else if let error = viewModel.error {
+        ErrorStateView(error: error) {
+          await viewModel.loadApplications()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.tcBackground)
+      } else if viewModel.isEmpty {
+        EmptyStateView(
+          icon: "map",
+          title: "No Applications",
+          description: "No planning applications found in your watch zone yet. Check back soon."
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.tcBackground)
+      } else {
+        mapContent
+        if viewModel.isLoading {
+          ProgressView()
+            .controlSize(.large)
+        }
+      }
+    }
+  }
+
   private var mapPlaceholder: some View {
     ZStack {
       Color.tcBackground.ignoresSafeArea()
@@ -112,5 +131,18 @@ public struct MapView: View {
       ProgressView()
         .controlSize(.large)
     }
+  }
+
+  private func updateMapPosition() {
+    mapPosition = .region(
+      MKCoordinateRegion(
+        center: CLLocationCoordinate2D(
+          latitude: viewModel.centreLat,
+          longitude: viewModel.centreLon
+        ),
+        latitudinalMeters: viewModel.radiusMetres * 2.5,
+        longitudinalMeters: viewModel.radiusMetres * 2.5
+      )
+    )
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
@@ -1,4 +1,5 @@
 import Combine
+import Foundation
 import TownCrierDomain
 
 /// ViewModel driving the map view with planning application pins.
@@ -9,6 +10,8 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
   @Published var error: DomainError?
   @Published private(set) var selectedApplication: PlanningApplication?
   @Published private(set) var hasLoaded = false
+  @Published private(set) var zones: [WatchZone] = []
+  @Published private(set) var selectedZone: WatchZone?
 
   @Published private(set) var centreLat: Double = 51.5074
   @Published private(set) var centreLon: Double = -0.1278
@@ -17,9 +20,15 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
   private let repository: PlanningApplicationRepository
   private let watchZoneRepository: WatchZoneRepository
   private var applications: [PlanningApplication] = []
+  private let userDefaults: UserDefaults
+  private let zoneSelectionKey: String
 
   public var isEmpty: Bool {
     hasLoaded && annotations.isEmpty && error == nil && !isLoading
+  }
+
+  public var showZonePicker: Bool {
+    zones.count > 1
   }
 
   public var isNetworkError: Bool {
@@ -37,17 +46,28 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
 
   var onApplicationSelected: ((PlanningApplicationId) -> Void)?
 
-  public init(repository: PlanningApplicationRepository, watchZoneRepository: WatchZoneRepository) {
+  public init(
+    repository: PlanningApplicationRepository,
+    watchZoneRepository: WatchZoneRepository,
+    userDefaults: UserDefaults = .standard,
+    zoneSelectionKey: String = "lastSelectedZone.map"
+  ) {
     self.repository = repository
     self.watchZoneRepository = watchZoneRepository
+    self.userDefaults = userDefaults
+    self.zoneSelectionKey = zoneSelectionKey
   }
 
   public func loadApplications() async {
     isLoading = true
     error = nil
     do {
-      let zones = try await watchZoneRepository.loadAll()
-      guard let zone = zones.first else {
+      let loadedZones = try await watchZoneRepository.loadAll()
+      zones = loadedZones
+      if selectedZone == nil || !loadedZones.contains(where: { $0.id == selectedZone?.id }) {
+        selectedZone = resolveInitialZone(from: loadedZones)
+      }
+      guard let zone = selectedZone else {
         isLoading = false
         hasLoaded = true
         return
@@ -68,6 +88,35 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
     }
     isLoading = false
     hasLoaded = true
+  }
+
+  public func selectZone(_ zone: WatchZone) async {
+    selectedZone = zone
+    userDefaults.set(zone.id.value, forKey: zoneSelectionKey)
+    centreLat = zone.centre.latitude
+    centreLon = zone.centre.longitude
+    radiusMetres = zone.radiusMetres
+    isLoading = true
+    error = nil
+    do {
+      let fetched = try await repository.fetchApplications(for: zone)
+      applications = fetched
+      annotations = fetched.compactMap { app in
+        guard let location = app.location else { return nil }
+        return MapAnnotationItem(application: app, coordinate: location)
+      }
+    } catch {
+      handleError(error)
+    }
+    isLoading = false
+  }
+
+  private func resolveInitialZone(from zones: [WatchZone]) -> WatchZone? {
+    if let savedId = userDefaults.string(forKey: zoneSelectionKey),
+       let savedZone = zones.first(where: { $0.id.value == savedId }) {
+      return savedZone
+    }
+    return zones.first
   }
 
   public func selectApplication(_ id: PlanningApplicationId) {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ZonePicker/ZonePickerView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ZonePicker/ZonePickerView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import TownCrierDomain
+
+/// Horizontal scrollable pill bar for switching between watch zones.
+public struct ZonePickerView: View {
+  let zones: [WatchZone]
+  let selectedZoneId: WatchZoneId?
+  let onSelect: (WatchZone) -> Void
+
+  public init(
+    zones: [WatchZone],
+    selectedZoneId: WatchZoneId?,
+    onSelect: @escaping (WatchZone) -> Void
+  ) {
+    self.zones = zones
+    self.selectedZoneId = selectedZoneId
+    self.onSelect = onSelect
+  }
+
+  public var body: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: TCSpacing.small) {
+        ForEach(zones) { zone in
+          zoneChip(zone: zone, isSelected: zone.id == selectedZoneId)
+        }
+      }
+      .padding(.horizontal, TCSpacing.medium)
+      .padding(.vertical, TCSpacing.small)
+    }
+  }
+
+  private func zoneChip(zone: WatchZone, isSelected: Bool) -> some View {
+    Button {
+      onSelect(zone)
+    } label: {
+      Text(zone.name)
+        .font(TCTypography.captionEmphasis)
+        .foregroundStyle(isSelected ? Color.tcTextOnAccent : Color.tcTextPrimary)
+        .padding(.horizontal, TCSpacing.small)
+        .padding(.vertical, TCSpacing.extraSmall)
+        .background(isSelected ? Color.tcAmber : Color.tcSurface)
+        .clipShape(Capsule())
+        .overlay(
+          Capsule()
+            .stroke(Color.tcBorder, lineWidth: isSelected ? 0 : 1)
+        )
+    }
+    .buttonStyle(.plain)
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ZonePicker/ZonePickerView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ZonePicker/ZonePickerView.swift
@@ -3,9 +3,9 @@ import TownCrierDomain
 
 /// Horizontal scrollable pill bar for switching between watch zones.
 public struct ZonePickerView: View {
-  let zones: [WatchZone]
-  let selectedZoneId: WatchZoneId?
-  let onSelect: (WatchZone) -> Void
+  private let zones: [WatchZone]
+  private let selectedZoneId: WatchZoneId?
+  private let onSelect: (WatchZone) -> Void
 
   public init(
     zones: [WatchZone],

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTests.swift
@@ -257,7 +257,7 @@ struct ApplicationListViewModelTests {
     #expect(appSpy.fetchApplicationsCalls.isEmpty)
   }
 
-  @Test func loadApplications_withWatchZoneRepository_cachesResolvedZoneOnRetry() async throws {
+  @Test func loadApplications_withWatchZoneRepository_refreshesZonesOnEveryCall() async throws {
     let appSpy = SpyPlanningApplicationRepository()
     appSpy.fetchApplicationsResult = .success([.pendingReview])
     let zoneSpy = SpyWatchZoneRepository()
@@ -270,7 +270,7 @@ struct ApplicationListViewModelTests {
     await sut.loadApplications()
     await sut.loadApplications()
 
-    #expect(zoneSpy.loadAllCallCount == 1)
+    #expect(zoneSpy.loadAllCallCount == 2)
     #expect(appSpy.fetchApplicationsCalls.count == 2)
   }
 
@@ -288,5 +288,103 @@ struct ApplicationListViewModelTests {
     await sut.loadApplications()
 
     #expect(!sut.isEmpty)
+  }
+
+  // MARK: - Zone Selection
+
+  private func makeSUTWithZones(
+    zones: [WatchZone] = [.cambridge, .london],
+    applications: [PlanningApplication] = [.pendingReview],
+    tier: SubscriptionTier = .free,
+    persistedZoneId: String? = nil
+  ) throws -> (ApplicationListViewModel, SpyPlanningApplicationRepository, SpyWatchZoneRepository, UserDefaults) {
+    let appSpy = SpyPlanningApplicationRepository()
+    appSpy.fetchApplicationsResult = .success(applications)
+    let zoneSpy = SpyWatchZoneRepository()
+    zoneSpy.loadAllResult = .success(zones)
+    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
+    if let persistedZoneId {
+      defaults.set(persistedZoneId, forKey: "test.zone")
+    }
+    let vm = ApplicationListViewModel(
+      watchZoneRepository: zoneSpy,
+      repository: appSpy,
+      tier: tier,
+      userDefaults: defaults,
+      zoneSelectionKey: "test.zone"
+    )
+    return (vm, appSpy, zoneSpy, defaults)
+  }
+
+  @Test func loadApplications_populatesZonesFromRepository() async throws {
+    let (sut, _, _, _) = try makeSUTWithZones()
+    await sut.loadApplications()
+    #expect(sut.zones.count == 2)
+    #expect(sut.zones[0].id == WatchZone.cambridge.id)
+    #expect(sut.zones[1].id == WatchZone.london.id)
+  }
+
+  @Test func loadApplications_selectsFirstZoneByDefault() async throws {
+    let (sut, appSpy, _, _) = try makeSUTWithZones()
+    await sut.loadApplications()
+    #expect(sut.selectedZone?.id == WatchZone.cambridge.id)
+    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+  }
+
+  @Test func loadApplications_restoresPersistedZoneSelection() async throws {
+    let (sut, appSpy, _, _) = try makeSUTWithZones(persistedZoneId: "zone-002")
+    await sut.loadApplications()
+    #expect(sut.selectedZone?.id == WatchZone.london.id)
+    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.london.id)
+  }
+
+  @Test func loadApplications_fallsBackToFirstZone_whenPersistedZoneDeleted() async throws {
+    let (sut, appSpy, _, _) = try makeSUTWithZones(persistedZoneId: "zone-deleted")
+    await sut.loadApplications()
+    #expect(sut.selectedZone?.id == WatchZone.cambridge.id)
+    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+  }
+
+  @Test func selectZone_fetchesApplicationsForNewZone() async throws {
+    let (sut, appSpy, _, _) = try makeSUTWithZones()
+    await sut.loadApplications()
+    let callsBefore = appSpy.fetchApplicationsCalls.count
+    await sut.selectZone(.london)
+    #expect(sut.selectedZone?.id == WatchZone.london.id)
+    #expect(appSpy.fetchApplicationsCalls.count == callsBefore + 1)
+    #expect(appSpy.fetchApplicationsCalls.last?.id == WatchZone.london.id)
+  }
+
+  @Test func selectZone_persistsSelectionToUserDefaults() async throws {
+    let (sut, _, _, defaults) = try makeSUTWithZones()
+    await sut.loadApplications()
+    await sut.selectZone(.london)
+    #expect(defaults.string(forKey: "test.zone") == "zone-002")
+  }
+
+  @Test func selectZone_resetsStatusFilter() async throws {
+    let (sut, _, _, _) = try makeSUTWithZones(tier: .personal)
+    await sut.loadApplications()
+    sut.selectedStatusFilter = .approved
+    await sut.selectZone(.london)
+    #expect(sut.selectedStatusFilter == nil)
+  }
+
+  @Test func showZonePicker_trueWhenMultipleZones() async throws {
+    let (sut, _, _, _) = try makeSUTWithZones()
+    await sut.loadApplications()
+    #expect(sut.showZonePicker)
+  }
+
+  @Test func showZonePicker_falseWhenSingleZone() async throws {
+    let (sut, _, _, _) = try makeSUTWithZones(zones: [.cambridge])
+    await sut.loadApplications()
+    #expect(!sut.showZonePicker)
+  }
+
+  @Test func showZonePicker_falseWhenNoZones() async throws {
+    let (sut, _, _, _) = try makeSUTWithZones(zones: [])
+    await sut.loadApplications()
+    #expect(!sut.showZonePicker)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
@@ -275,4 +275,105 @@ struct MapViewModelTests {
     #expect(sut.annotations.isEmpty)
     #expect(sut.isEmpty)
   }
+
+  // MARK: - Zone Selection
+
+  private func makeSUTWithZones(
+    zones: [WatchZone] = [.cambridge, .london],
+    applications: [PlanningApplication] = [.pendingReview],
+    persistedZoneId: String? = nil
+  ) throws -> (MapViewModel, SpyPlanningApplicationRepository, SpyWatchZoneRepository, UserDefaults) {
+    let appSpy = SpyPlanningApplicationRepository()
+    appSpy.fetchApplicationsResult = .success(applications)
+    let zoneSpy = SpyWatchZoneRepository()
+    zoneSpy.loadAllResult = .success(zones)
+    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
+    if let persistedZoneId {
+      defaults.set(persistedZoneId, forKey: "test.zone")
+    }
+    let vm = MapViewModel(
+      repository: appSpy,
+      watchZoneRepository: zoneSpy,
+      userDefaults: defaults,
+      zoneSelectionKey: "test.zone"
+    )
+    return (vm, appSpy, zoneSpy, defaults)
+  }
+
+  @Test func loadApplications_populatesZones() async throws {
+    let (sut, _, _, _) = try makeSUTWithZones()
+
+    await sut.loadApplications()
+
+    #expect(sut.zones.count == 2)
+    #expect(sut.zones[0].id == WatchZone.cambridge.id)
+    #expect(sut.zones[1].id == WatchZone.london.id)
+  }
+
+  @Test func loadApplications_selectsFirstZoneByDefault() async throws {
+    let (sut, appSpy, _, _) = try makeSUTWithZones()
+
+    await sut.loadApplications()
+
+    #expect(sut.selectedZone?.id == WatchZone.cambridge.id)
+    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+  }
+
+  @Test func loadApplications_restoresPersistedZoneSelection() async throws {
+    let (sut, appSpy, _, _) = try makeSUTWithZones(persistedZoneId: "zone-002")
+
+    await sut.loadApplications()
+
+    #expect(sut.selectedZone?.id == WatchZone.london.id)
+    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.london.id)
+    #expect(sut.centreLat == WatchZone.london.centre.latitude)
+    #expect(sut.centreLon == WatchZone.london.centre.longitude)
+  }
+
+  @Test func loadApplications_fallsBackToFirstZone_whenPersistedZoneDeleted() async throws {
+    let (sut, appSpy, _, _) = try makeSUTWithZones(persistedZoneId: "zone-deleted")
+
+    await sut.loadApplications()
+
+    #expect(sut.selectedZone?.id == WatchZone.cambridge.id)
+    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+  }
+
+  @Test func selectZone_fetchesApplicationsAndUpdatesCentre() async throws {
+    let (sut, appSpy, _, _) = try makeSUTWithZones()
+    await sut.loadApplications()
+    let initialCallCount = appSpy.fetchApplicationsCalls.count
+
+    await sut.selectZone(.london)
+
+    #expect(sut.selectedZone?.id == WatchZone.london.id)
+    #expect(appSpy.fetchApplicationsCalls.count == initialCallCount + 1)
+    #expect(appSpy.fetchApplicationsCalls.last?.id == WatchZone.london.id)
+    #expect(sut.centreLat == WatchZone.london.centre.latitude)
+    #expect(sut.centreLon == WatchZone.london.centre.longitude)
+    #expect(sut.radiusMetres == WatchZone.london.radiusMetres)
+  }
+
+  @Test func selectZone_persistsSelectionToUserDefaults() async throws {
+    let (sut, _, _, defaults) = try makeSUTWithZones()
+    await sut.loadApplications()
+
+    await sut.selectZone(.london)
+
+    #expect(defaults.string(forKey: "test.zone") == "zone-002")
+  }
+
+  @Test func showZonePicker_trueWhenMultipleZones() async throws {
+    let (sut, _, _, _) = try makeSUTWithZones()
+    await sut.loadApplications()
+
+    #expect(sut.showZonePicker)
+  }
+
+  @Test func showZonePicker_falseWhenSingleZone() async throws {
+    let (sut, _, _, _) = try makeSUTWithZones(zones: [.cambridge])
+    await sut.loadApplications()
+
+    #expect(!sut.showZonePicker)
+  }
 }


### PR DESCRIPTION
## Changes
- Add reusable `ZonePickerView` component — horizontal scrollable pill bar matching existing filter chip styling
- Add zone selection to `ApplicationListViewModel` with UserDefaults persistence, status filter reset on zone switch, and TDD tests
- Wire zone picker into `ApplicationListView` above existing status filter chips
- Add zone selection to `MapViewModel` with UserDefaults persistence, map re-centering, and TDD tests
- Wire zone picker into `MapView` with `Map(position:)` binding for programmatic re-centering

Users with multiple watch zones can now switch between them independently on both tabs. Single-zone users see no change (picker is hidden).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added zone selection functionality with a horizontal scrollable zone picker across the app.
  * Zones now appear in both application list and map views; user selections persist automatically.
  * Applications and map display update dynamically based on the selected zone.

* **Tests**
  * Expanded test coverage for zone selection behavior and persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->