### PR TITLE
fix(ios): keep zone picker and status filters visible on empty state

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -75,9 +75,10 @@ public final class AppCoordinator: ObservableObject {
     let viewModel: ApplicationListViewModel
     if let offlineRepository {
       viewModel = ApplicationListViewModel(
-        offlineRepository: offlineRepository, zone: zone)
+        offlineRepository: offlineRepository, zone: zone, tier: subscriptionTier)
     } else {
-      viewModel = ApplicationListViewModel(repository: repository, zone: zone)
+      viewModel = ApplicationListViewModel(
+        repository: repository, zone: zone, tier: subscriptionTier)
     }
     viewModel.onApplicationSelected = { [weak self] id in
       self?.showApplicationDetail(id)
@@ -92,12 +93,14 @@ public final class AppCoordinator: ObservableObject {
     if let offlineRepository {
       viewModel = ApplicationListViewModel(
         watchZoneRepository: watchZoneRepository,
-        offlineRepository: offlineRepository
+        offlineRepository: offlineRepository,
+        tier: subscriptionTier
       )
     } else {
       viewModel = ApplicationListViewModel(
         watchZoneRepository: watchZoneRepository,
-        repository: repository
+        repository: repository,
+        tier: subscriptionTier
       )
     }
     viewModel.onApplicationSelected = { [weak self] id in

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
@@ -10,6 +10,33 @@ public struct ApplicationListView: View {
   }
 
   public var body: some View {
+    VStack(spacing: 0) {
+      if viewModel.showZonePicker {
+        zonePickerHeader
+      }
+
+      if viewModel.canFilter {
+        filterHeader
+      }
+
+      listBody
+    }
+    .background(Color.tcBackground)
+    .navigationTitle("Applications")
+    #if os(iOS)
+      .navigationBarTitleDisplayMode(.large)
+    #endif
+    .task {
+      await viewModel.loadApplications()
+    }
+    .refreshable {
+      await viewModel.loadApplications()
+    }
+  }
+
+  // MARK: - List Body
+
+  private var listBody: some View {
     ZStack {
       Color.tcBackground.ignoresSafeArea()
 
@@ -26,81 +53,51 @@ public struct ApplicationListView: View {
           description: "No planning applications found in your watch zone yet."
         )
       } else {
-        applicationList
-      }
-    }
-    .navigationTitle("Applications")
-    #if os(iOS)
-      .navigationBarTitleDisplayMode(.large)
-    #endif
-    .task {
-      await viewModel.loadApplications()
-    }
-    .refreshable {
-      await viewModel.loadApplications()
-    }
-  }
-
-  // MARK: - Application List
-
-  private var applicationList: some View {
-    List {
-      if viewModel.showZonePicker {
-        zonePickerSection
-      }
-
-      if viewModel.canFilter {
-        filterSection
-      }
-
-      ForEach(viewModel.filteredApplications) { application in
-        ApplicationListRow(application: application)
-          .listRowBackground(Color.tcSurface)
-          .contentShape(Rectangle())
-          .onTapGesture {
-            viewModel.selectApplication(application.id)
+        List {
+          ForEach(viewModel.filteredApplications) { application in
+            ApplicationListRow(application: application)
+              .listRowBackground(Color.tcSurface)
+              .contentShape(Rectangle())
+              .onTapGesture {
+                viewModel.selectApplication(application.id)
+              }
           }
+        }
+        .listStyle(.plain)
       }
     }
-    .listStyle(.plain)
   }
 
   // MARK: - Zone Picker
 
-  private var zonePickerSection: some View {
-    Section {
-      ZonePickerView(
-        zones: viewModel.zones,
-        selectedZoneId: viewModel.selectedZone?.id
-      ) { zone in
-        Task {
-          await viewModel.selectZone(zone)
-        }
+  private var zonePickerHeader: some View {
+    ZonePickerView(
+      zones: viewModel.zones,
+      selectedZoneId: viewModel.selectedZone?.id
+    ) { zone in
+      Task {
+        await viewModel.selectZone(zone)
       }
     }
-    .listRowInsets(EdgeInsets())
-    .listRowBackground(Color.tcBackground)
+    .background(Color.tcBackground)
   }
 
   // MARK: - Filter Section
 
-  private var filterSection: some View {
-    Section {
-      ScrollView(.horizontal, showsIndicators: false) {
-        HStack(spacing: TCSpacing.small) {
-          filterChip(label: "All", status: nil)
-          filterChip(label: "Pending", status: .undecided)
-          filterChip(label: "Approved", status: .approved)
-          filterChip(label: "Refused", status: .refused)
-          filterChip(label: "Withdrawn", status: .withdrawn)
-          filterChip(label: "Appealed", status: .appealed)
-        }
-        .padding(.horizontal, TCSpacing.medium)
-        .padding(.vertical, TCSpacing.small)
+  private var filterHeader: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: TCSpacing.small) {
+        filterChip(label: "All", status: nil)
+        filterChip(label: "Pending", status: .undecided)
+        filterChip(label: "Approved", status: .approved)
+        filterChip(label: "Refused", status: .refused)
+        filterChip(label: "Withdrawn", status: .withdrawn)
+        filterChip(label: "Appealed", status: .appealed)
       }
+      .padding(.horizontal, TCSpacing.medium)
+      .padding(.vertical, TCSpacing.small)
     }
-    .listRowInsets(EdgeInsets())
-    .listRowBackground(Color.tcBackground)
+    .background(Color.tcBackground)
   }
 
   private func filterChip(label: String, status: ApplicationStatus?) -> some View {


### PR DESCRIPTION
## Changes
- Restructure `ApplicationListView` to render zone picker and status filter chips in a `VStack` above the content `ZStack`, so they remain accessible when the selected zone has no applications (previously trapped behind `EmptyStateView`)
- Pass `subscriptionTier` from `AppCoordinator` to `ApplicationListViewModel` factory methods — status filter chips were never rendering because `tier` defaulted to `.free`

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed subscription tier handling to properly reflect in the application list.

* **Improvements**
  * Restructured application list layout for better organization and filtering display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->