### PR TITLE
fix: filter Cosmos dependency spans and set daily ingestion cap

### DIFF
--- a/api/src/town-crier.infrastructure/Observability/SuccessfulCosmosDependencyFilter.cs
+++ b/api/src/town-crier.infrastructure/Observability/SuccessfulCosmosDependencyFilter.cs
@@ -1,0 +1,35 @@
+using System.Diagnostics;
+using OpenTelemetry;
+
+namespace TownCrier.Infrastructure.Observability;
+
+/// <summary>
+/// Drops successful (2xx) HTTP dependency spans targeting Cosmos DB.
+/// These generate high telemetry volume (~1.5 GB/week) with little diagnostic
+/// value — failures and the custom Cosmos activity spans (which carry RU metrics)
+/// are preserved.
+/// </summary>
+public sealed class SuccessfulCosmosDependencyFilter : BaseProcessor<Activity>
+{
+    public override void OnEnd(Activity activity)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+
+        if (activity.Kind != ActivityKind.Client)
+        {
+            return;
+        }
+
+        var peerName = activity.GetTagItem("server.address") as string;
+        if (peerName is null || !peerName.Contains(".documents.azure.com", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var statusCode = activity.GetTagItem("http.response.status_code") as int?;
+        if (statusCode is >= 200 and < 300)
+        {
+            activity.ActivityTraceFlags &= ~ActivityTraceFlags.Recorded;
+        }
+    }
+}

--- a/api/src/town-crier.infrastructure/town-crier.infrastructure.csproj
+++ b/api/src/town-crier.infrastructure/town-crier.infrastructure.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Communication.Email" Version="1.1.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.15.1" />
     <PackageReference Include="Azure.Identity" Version="1.19.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.*" />

--- a/api/src/town-crier.web/Program.cs
+++ b/api/src/town-crier.web/Program.cs
@@ -19,6 +19,7 @@ var otel = builder.Services.AddOpenTelemetry()
     .WithTracing(tracing =>
     {
         tracing
+            .AddProcessor<SuccessfulCosmosDependencyFilter>()
             .AddAspNetCoreInstrumentation(options => options.RecordException = true)
             .AddHttpClientInstrumentation(options => options.RecordException = true)
             .AddSource(PollingInstrumentation.ActivitySourceName)

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -38,6 +38,7 @@ var otel = builder.Services.AddOpenTelemetry()
     .WithTracing(tracing =>
     {
         tracing
+            .AddProcessor<SuccessfulCosmosDependencyFilter>()
             .AddHttpClientInstrumentation(options => options.RecordException = true)
             .AddSource(PollingInstrumentation.ActivitySourceName)
             .AddSource(CosmosInstrumentation.ActivitySourceName);

--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -85,6 +85,10 @@ public static class SharedStack
                 Name = WorkspaceSkuNameEnum.PerGB2018,
             },
             RetentionInDays = 14,
+            WorkspaceCapping = new Pulumi.AzureNative.OperationalInsights.Inputs.WorkspaceCappingArgs
+            {
+                DailyQuotaGb = 1.0,
+            },
             Tags = tags,
         });
 


### PR DESCRIPTION
## Changes
- Add `SuccessfulCosmosDependencyFilter` OTel processor that drops successful (2xx) HTTP dependency spans targeting Cosmos DB — these generated ~1.5 GB/week of `AppDependencies` telemetry with no diagnostic value. Failures and custom Cosmos spans (with RU metrics) are preserved.
- Wire the filter into both web and worker tracing pipelines
- Set 1 GB/day daily ingestion cap on the Log Analytics workspace as a cost safety net
- Note: switching `ContainerAppConsoleLogs_CL` to Basic tier was not possible — the table uses Classic custom log format which requires DCR migration first

---
*Auto-shipped via ship skill*