### PR TITLE
fix: revert Log Analytics retention to 30 days (SKU minimum)

### DIFF
--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -84,7 +84,7 @@ public static class SharedStack
             {
                 Name = WorkspaceSkuNameEnum.PerGB2018,
             },
-            RetentionInDays = 14,
+            RetentionInDays = 30, // PerGB2018 SKU minimum is 30 days
             WorkspaceCapping = new Pulumi.AzureNative.OperationalInsights.Inputs.WorkspaceCappingArgs
             {
                 DailyQuotaGb = 1.0,


### PR DESCRIPTION
## Changes
- Revert Log Analytics workspace retention from 14 → 30 days — PerGB2018 SKU enforces a 30-day minimum, which caused `Pulumi up` to fail with `InvalidParameter` on CD Dev
- App Insights retention stays at 14 days (different API, different limits)

Fixes CD Dev failures on #237 and #238.

---
*Auto-shipped via ship skill*