### PR TITLE
fix: set App Insights retention to 30 days (minimum allowed)

### DIFF
--- a/infra/SharedStack.cs
+++ b/infra/SharedStack.cs
@@ -101,7 +101,7 @@ public static class SharedStack
             ApplicationType = "web",
             Kind = "web",
             IngestionMode = IngestionMode.LogAnalytics,
-            RetentionInDays = 14,
+            RetentionInDays = 30, // Minimum allowed by Azure (30, 60, 90, 120, etc.)
             Tags = tags,
         });
 


### PR DESCRIPTION
## Changes
- Set App Insights retention to 30 days — Azure only accepts specific values (30, 60, 90, 120…), not arbitrary numbers. 14 days caused `Pulumi up` to fail with `BadRequest: Must use an allowed retention setting`.

Fixes CD Dev failure from #239.

---
*Auto-shipped via ship skill*