### PR TITLE
feat: add admin list-users API and CLI command

### DIFF
--- a/api/src/town-crier.application/Admin/ListUsersItem.cs
+++ b/api/src/town-crier.application/Admin/ListUsersItem.cs
@@ -1,0 +1,5 @@
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.Admin;
+
+public sealed record ListUsersItem(string UserId, string? Email, SubscriptionTier Tier);

--- a/api/src/town-crier.application/Admin/ListUsersQuery.cs
+++ b/api/src/town-crier.application/Admin/ListUsersQuery.cs
@@ -1,0 +1,3 @@
+namespace TownCrier.Application.Admin;
+
+public sealed record ListUsersQuery(string? SearchTerm, int PageSize, string? ContinuationToken);

--- a/api/src/town-crier.application/Admin/ListUsersQueryHandler.cs
+++ b/api/src/town-crier.application/Admin/ListUsersQueryHandler.cs
@@ -1,0 +1,30 @@
+using TownCrier.Application.UserProfiles;
+
+namespace TownCrier.Application.Admin;
+
+public sealed class ListUsersQueryHandler
+{
+    private readonly IUserProfileRepository repository;
+
+    public ListUsersQueryHandler(IUserProfileRepository repository)
+    {
+        this.repository = repository;
+    }
+
+    public async Task<ListUsersResult> HandleAsync(ListUsersQuery query, CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var page = await this.repository.ListAsync(
+            query.SearchTerm,
+            query.PageSize,
+            query.ContinuationToken,
+            ct).ConfigureAwait(false);
+
+        var items = page.Profiles
+            .Select(p => new ListUsersItem(p.UserId, p.Email, p.Tier))
+            .ToList();
+
+        return new ListUsersResult(items, page.ContinuationToken);
+    }
+}

--- a/api/src/town-crier.application/Admin/ListUsersResult.cs
+++ b/api/src/town-crier.application/Admin/ListUsersResult.cs
@@ -1,0 +1,3 @@
+namespace TownCrier.Application.Admin;
+
+public sealed record ListUsersResult(IReadOnlyList<ListUsersItem> Items, string? ContinuationToken);

--- a/api/src/town-crier.application/UserProfiles/IUserProfileRepository.cs
+++ b/api/src/town-crier.application/UserProfiles/IUserProfileRepository.cs
@@ -14,6 +14,9 @@ public interface IUserProfileRepository
 
     Task<UserProfile?> GetByOriginalTransactionIdAsync(string originalTransactionId, CancellationToken ct);
 
+    Task<UserProfilePage> ListAsync(
+        string? emailSearch, int pageSize, string? continuationToken, CancellationToken ct);
+
     Task SaveAsync(UserProfile profile, CancellationToken ct);
 
     Task DeleteAsync(string userId, CancellationToken ct);

--- a/api/src/town-crier.application/UserProfiles/UserProfilePage.cs
+++ b/api/src/town-crier.application/UserProfiles/UserProfilePage.cs
@@ -1,0 +1,5 @@
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.UserProfiles;
+
+public sealed record UserProfilePage(IReadOnlyList<UserProfile> Profiles, string? ContinuationToken);

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosRestClient.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosRestClient.cs
@@ -232,7 +232,7 @@ internal sealed class CosmosRestClient : ICosmosRestClient
         activity?.SetTag("db.cosmosdb.container", collection);
         activity?.SetTag("db.operation.name", "QueryPage");
 
-#pragma warning disable CA2000
+#pragma warning disable CA2000 // using var disposes request on all paths
         using var request = this.BuildQueryRequest(collection, sql, parameters);
 #pragma warning restore CA2000
         await this.AddHeadersAsync(request, partitionKey, ct).ConfigureAwait(false);

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosRestClient.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosRestClient.cs
@@ -217,6 +217,58 @@ internal sealed class CosmosRestClient : ICosmosRestClient
             : throw new InvalidOperationException("Query returned no results.");
     }
 
+    public async Task<PagedQueryResult<T>> QueryPageAsync<T>(
+        string collection,
+        string sql,
+        IReadOnlyList<QueryParameter>? parameters,
+        string? partitionKey,
+        int maxItemCount,
+        string? continuationToken,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken ct)
+    {
+        using var activity = CosmosInstrumentation.Source.StartActivity("Cosmos QueryPage");
+        activity?.SetTag("db.system", "cosmosdb");
+        activity?.SetTag("db.cosmosdb.container", collection);
+        activity?.SetTag("db.operation.name", "QueryPage");
+
+#pragma warning disable CA2000
+        using var request = this.BuildQueryRequest(collection, sql, parameters);
+#pragma warning restore CA2000
+        await this.AddHeadersAsync(request, partitionKey, ct).ConfigureAwait(false);
+        AddQueryHeaders(request, partitionKey);
+        request.Headers.TryAddWithoutValidation(
+            "x-ms-max-item-count", maxItemCount.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+        if (continuationToken is not null)
+        {
+            request.Headers.TryAddWithoutValidation("x-ms-continuation", continuationToken);
+        }
+
+        using var response = await this.httpClient.SendAsync(request, ct).ConfigureAwait(false);
+        await ThrowOnCosmosErrorAsync(response, sql, ct).ConfigureAwait(false);
+        RecordResponseMetrics(activity, response);
+
+        var items = new List<T>();
+        var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        await using (stream.ConfigureAwait(false))
+        {
+            using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: ct)
+                .ConfigureAwait(false);
+
+            foreach (var element in doc.RootElement.GetProperty("Documents").EnumerateArray())
+            {
+                items.Add(element.Deserialize(typeInfo)!);
+            }
+        }
+
+        var nextContinuation = response.Headers.TryGetValues("x-ms-continuation", out var values)
+            ? values.FirstOrDefault()
+            : null;
+
+        return new PagedQueryResult<T>(items, nextContinuation);
+    }
+
     private static bool RequiresFanOut(string sql) =>
         sql.Contains("DISTINCT", StringComparison.OrdinalIgnoreCase) ||
         sql.Contains("GROUP BY", StringComparison.OrdinalIgnoreCase);

--- a/api/src/town-crier.infrastructure/Cosmos/ICosmosRestClient.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/ICosmosRestClient.cs
@@ -39,6 +39,16 @@ public interface ICosmosRestClient
         string? partitionKey,
         JsonTypeInfo<T> typeInfo,
         CancellationToken ct);
+
+    Task<PagedQueryResult<T>> QueryPageAsync<T>(
+        string collection,
+        string sql,
+        IReadOnlyList<QueryParameter>? parameters,
+        string? partitionKey,
+        int maxItemCount,
+        string? continuationToken,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken ct);
 }
 
 public readonly record struct QueryParameter(string Name, object Value);

--- a/api/src/town-crier.infrastructure/Cosmos/PagedQueryResult.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/PagedQueryResult.cs
@@ -1,0 +1,3 @@
+namespace TownCrier.Infrastructure.Cosmos;
+
+public sealed record PagedQueryResult<T>(IReadOnlyList<T> Items, string? ContinuationToken);

--- a/api/src/town-crier.infrastructure/UserProfiles/CosmosUserProfileRepository.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/CosmosUserProfileRepository.cs
@@ -80,6 +80,34 @@ public sealed class CosmosUserProfileRepository : IUserProfileRepository
         return documents.Count > 0 ? documents[0].ToDomain() : null;
     }
 
+    public async Task<UserProfilePage> ListAsync(
+        string? emailSearch,
+        int pageSize,
+        string? continuationToken,
+        CancellationToken ct)
+    {
+        var sql = emailSearch is not null
+            ? "SELECT * FROM c WHERE CONTAINS(c.email, @search, true) ORDER BY c.email"
+            : "SELECT * FROM c ORDER BY c.email";
+
+        var parameters = emailSearch is not null
+            ? new[] { new QueryParameter("@search", emailSearch) }
+            : Array.Empty<QueryParameter>();
+
+        var result = await this.client.QueryPageAsync(
+            CosmosContainerNames.Users,
+            sql,
+            parameters,
+            partitionKey: null,
+            pageSize,
+            continuationToken,
+            CosmosJsonSerializerContext.Default.UserProfileDocument,
+            ct).ConfigureAwait(false);
+
+        var profiles = result.Items.Select(doc => doc.ToDomain()).ToList();
+        return new UserProfilePage(profiles, result.ContinuationToken);
+    }
+
     public async Task SaveAsync(UserProfile profile, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(profile);

--- a/api/src/town-crier.infrastructure/UserProfiles/InMemoryUserProfileRepository.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/InMemoryUserProfileRepository.cs
@@ -57,6 +57,7 @@ public sealed class InMemoryUserProfileRepository : IUserProfileRepository
         return Task.CompletedTask;
     }
 
+    // pageSize and continuationToken are not emulated — returns all matching profiles in one page.
     public Task<UserProfilePage> ListAsync(
         string? emailSearch, int pageSize, string? continuationToken, CancellationToken ct)
     {

--- a/api/src/town-crier.infrastructure/UserProfiles/InMemoryUserProfileRepository.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/InMemoryUserProfileRepository.cs
@@ -56,4 +56,20 @@ public sealed class InMemoryUserProfileRepository : IUserProfileRepository
         this.store.TryRemove(userId, out _);
         return Task.CompletedTask;
     }
+
+    public Task<UserProfilePage> ListAsync(
+        string? emailSearch, int pageSize, string? continuationToken, CancellationToken ct)
+    {
+        var profiles = this.store.Values.AsEnumerable();
+
+        if (emailSearch is not null)
+        {
+            profiles = profiles.Where(p =>
+                p.Email is not null &&
+                p.Email.Contains(emailSearch, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var result = profiles.OrderBy(p => p.Email, StringComparer.OrdinalIgnoreCase).ToList();
+        return Task.FromResult(new UserProfilePage(result, null));
+    }
 }

--- a/api/src/town-crier.web/AppJsonSerializerContext.cs
+++ b/api/src/town-crier.web/AppJsonSerializerContext.cs
@@ -52,4 +52,5 @@ namespace TownCrier.Web;
 [JsonSerializable(typeof(GetLegalDocumentResult))]
 [JsonSerializable(typeof(GrantSubscriptionCommand))]
 [JsonSerializable(typeof(GrantSubscriptionResult))]
+[JsonSerializable(typeof(ListUsersResult))]
 internal sealed partial class AppJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.web/Endpoints/AdminEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/AdminEndpoints.cs
@@ -26,5 +26,17 @@ internal static class AdminEndpoints
                 return Results.NotFound();
             }
         });
+
+        admin.MapGet("/users", async (
+            string? search,
+            int? pageSize,
+            string? continuationToken,
+            ListUsersQueryHandler handler,
+            CancellationToken ct) =>
+        {
+            var query = new ListUsersQuery(search, pageSize ?? 20, continuationToken);
+            var result = await handler.HandleAsync(query, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        });
     }
 }

--- a/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
+++ b/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
@@ -168,6 +168,7 @@ internal static class ServiceCollectionExtensions
         services.AddTransient<GetDemoAccountQueryHandler>();
 
         services.AddTransient<GrantSubscriptionCommandHandler>();
+        services.AddTransient<ListUsersQueryHandler>();
 
         return services;
     }

--- a/api/tests/town-crier.application.tests/Admin/ListUsersQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Admin/ListUsersQueryHandlerTests.cs
@@ -1,0 +1,87 @@
+using TownCrier.Application.Admin;
+using TownCrier.Application.Tests.UserProfiles;
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Application.Tests.Admin;
+
+public sealed class ListUsersQueryHandlerTests
+{
+    [Test]
+    public async Task Should_ReturnMappedItems_When_ProfilesExist()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        await repository.SaveAsync(
+            UserProfile.Register("auth0|user-1", "alice@example.com"), CancellationToken.None);
+        await repository.SaveAsync(
+            UserProfile.Register("auth0|user-2", "bob@example.com"), CancellationToken.None);
+
+        var handler = new ListUsersQueryHandler(repository);
+        var query = new ListUsersQuery(null, 20, null);
+
+        // Act
+        var result = await handler.HandleAsync(query, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Items).HasCount().EqualTo(2);
+        await Assert.That(result.Items[0].UserId).IsEqualTo("auth0|user-1");
+        await Assert.That(result.Items[0].Email).IsEqualTo("alice@example.com");
+        await Assert.That(result.Items[0].Tier).IsEqualTo(SubscriptionTier.Free);
+    }
+
+    [Test]
+    public async Task Should_FilterByEmail_When_SearchTermProvided()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        await repository.SaveAsync(
+            UserProfile.Register("auth0|user-1", "alice@gmail.com"), CancellationToken.None);
+        await repository.SaveAsync(
+            UserProfile.Register("auth0|user-2", "bob@outlook.com"), CancellationToken.None);
+
+        var handler = new ListUsersQueryHandler(repository);
+        var query = new ListUsersQuery("gmail", 20, null);
+
+        // Act
+        var result = await handler.HandleAsync(query, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Items).HasCount().EqualTo(1);
+        await Assert.That(result.Items[0].Email).IsEqualTo("alice@gmail.com");
+    }
+
+    [Test]
+    public async Task Should_ReturnEmptyList_When_NoProfilesExist()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var handler = new ListUsersQueryHandler(repository);
+        var query = new ListUsersQuery(null, 20, null);
+
+        // Act
+        var result = await handler.HandleAsync(query, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Items).HasCount().EqualTo(0);
+        await Assert.That(result.ContinuationToken).IsNull();
+    }
+
+    [Test]
+    public async Task Should_MapTierCorrectly_When_UserHasProSubscription()
+    {
+        // Arrange
+        var repository = new FakeUserProfileRepository();
+        var profile = UserProfile.Register("auth0|user-1", "alice@example.com");
+        profile.ActivateSubscription(SubscriptionTier.Pro, DateTimeOffset.UtcNow.AddYears(1));
+        await repository.SaveAsync(profile, CancellationToken.None);
+
+        var handler = new ListUsersQueryHandler(repository);
+        var query = new ListUsersQuery(null, 20, null);
+
+        // Act
+        var result = await handler.HandleAsync(query, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Items[0].Tier).IsEqualTo(SubscriptionTier.Pro);
+    }
+}

--- a/api/tests/town-crier.application.tests/UserProfiles/FakeUserProfileRepository.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/FakeUserProfileRepository.cs
@@ -57,6 +57,22 @@ internal sealed class FakeUserProfileRepository : IUserProfileRepository
         return Task.CompletedTask;
     }
 
+    public Task<UserProfilePage> ListAsync(
+        string? emailSearch, int pageSize, string? continuationToken, CancellationToken ct)
+    {
+        var profiles = this.store.Values.AsEnumerable();
+
+        if (emailSearch is not null)
+        {
+            profiles = profiles.Where(p =>
+                p.Email is not null &&
+                p.Email.Contains(emailSearch, StringComparison.OrdinalIgnoreCase));
+        }
+
+        var result = profiles.OrderBy(p => p.Email, StringComparer.OrdinalIgnoreCase).ToList();
+        return Task.FromResult(new UserProfilePage(result, null));
+    }
+
     public UserProfile? GetByUserId(string userId)
     {
         this.store.TryGetValue(userId, out var profile);

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/FakeCosmosRestClient.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/FakeCosmosRestClient.cs
@@ -12,6 +12,7 @@ internal sealed class FakeCosmosRestClient : ICosmosRestClient
 {
     private readonly Dictionary<(string Collection, string Id, string PartitionKey), string> store = new();
     private readonly Dictionary<string, object> cannedQueryResults = new();
+    private readonly Dictionary<string, (object Results, string? ContinuationToken)> cannedPageResults = new();
 
     /// <summary>
     /// Registers a pre-canned result list that <see cref="QueryAsync{T}"/> will return
@@ -25,6 +26,11 @@ internal sealed class FakeCosmosRestClient : ICosmosRestClient
     public void SetQueryResults<T>(string sqlPrefix, List<T> results)
     {
         this.cannedQueryResults[sqlPrefix] = results;
+    }
+
+    public void SetPageQueryResults<T>(string sqlPrefix, List<T> results, string? continuationToken = null)
+    {
+        this.cannedPageResults[sqlPrefix] = (results, continuationToken);
     }
 
     public Task<T?> ReadDocumentAsync<T>(
@@ -146,6 +152,47 @@ internal sealed class FakeCosmosRestClient : ICosmosRestClient
         // Convert count to T (works for int, long, etc.)
         var result = (T)(object)count;
         return Task.FromResult(result);
+    }
+
+    public Task<PagedQueryResult<T>> QueryPageAsync<T>(
+        string collection,
+        string sql,
+        IReadOnlyList<QueryParameter>? parameters,
+        string? partitionKey,
+        int maxItemCount,
+        string? continuationToken,
+        JsonTypeInfo<T> typeInfo,
+        CancellationToken ct)
+    {
+        foreach (var (prefix, (value, token)) in this.cannedPageResults)
+        {
+            if (sql.StartsWith(prefix, StringComparison.Ordinal) && value is List<T> canned)
+            {
+                return Task.FromResult(new PagedQueryResult<T>(canned, token));
+            }
+        }
+
+        var results = new List<T>();
+        foreach (var ((c, _, pk), json) in this.store)
+        {
+            if (c != collection)
+            {
+                continue;
+            }
+
+            if (partitionKey is not null && pk != partitionKey)
+            {
+                continue;
+            }
+
+            var item = JsonSerializer.Deserialize(json, typeInfo);
+            if (item is not null)
+            {
+                results.Add(item);
+            }
+        }
+
+        return Task.FromResult(new PagedQueryResult<T>(results, null));
     }
 
     private static string ExtractId(JsonDocument doc)

--- a/api/tests/town-crier.infrastructure.tests/UserProfiles/CosmosUserProfileRepositoryListTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/UserProfiles/CosmosUserProfileRepositoryListTests.cs
@@ -1,0 +1,87 @@
+using TownCrier.Infrastructure.Cosmos;
+using TownCrier.Infrastructure.Tests.Cosmos;
+using TownCrier.Infrastructure.UserProfiles;
+
+namespace TownCrier.Infrastructure.Tests.UserProfiles;
+
+public sealed class CosmosUserProfileRepositoryListTests
+{
+    [Test]
+    public async Task Should_ReturnProfiles_When_NoSearchTerm()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosUserProfileRepository(client);
+
+        var docs = new List<UserProfileDocument>
+        {
+            CreateDocument("user-1", "alice@example.com", "Pro"),
+            CreateDocument("user-2", "bob@example.com", "Free"),
+        };
+        client.SetPageQueryResults("SELECT * FROM c ORDER BY", docs);
+
+        // Act
+        var result = await repo.ListAsync(null, 20, null, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Profiles).HasCount().EqualTo(2);
+        await Assert.That(result.Profiles[0].UserId).IsEqualTo("user-1");
+        await Assert.That(result.Profiles[0].Email).IsEqualTo("alice@example.com");
+    }
+
+    [Test]
+    public async Task Should_ReturnProfiles_When_SearchTermProvided()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosUserProfileRepository(client);
+
+        var docs = new List<UserProfileDocument>
+        {
+            CreateDocument("user-1", "alice@gmail.com", "Personal"),
+        };
+        client.SetPageQueryResults("SELECT * FROM c WHERE CONTAINS", docs);
+
+        // Act
+        var result = await repo.ListAsync("gmail", 20, null, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Profiles).HasCount().EqualTo(1);
+        await Assert.That(result.Profiles[0].Email).IsEqualTo("alice@gmail.com");
+    }
+
+    [Test]
+    public async Task Should_ForwardContinuationToken_When_MorePagesExist()
+    {
+        // Arrange
+        var client = new FakeCosmosRestClient();
+        var repo = new CosmosUserProfileRepository(client);
+
+        var docs = new List<UserProfileDocument>
+        {
+            CreateDocument("user-1", "alice@example.com", "Free"),
+        };
+        client.SetPageQueryResults("SELECT * FROM c ORDER BY", docs, "next-page-token");
+
+        // Act
+        var result = await repo.ListAsync(null, 1, null, CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.ContinuationToken).IsEqualTo("next-page-token");
+    }
+
+    private static UserProfileDocument CreateDocument(string userId, string email, string tier)
+    {
+        return new UserProfileDocument
+        {
+            Id = userId,
+            UserId = userId,
+            Email = email,
+            PushEnabled = true,
+            DigestDay = DayOfWeek.Monday,
+            EmailDigestEnabled = true,
+            ZonePreferences = new Dictionary<string, TownCrier.Domain.UserProfiles.ZoneNotificationPreferences>(),
+            Tier = tier,
+        };
+    }
+}

--- a/api/tests/town-crier.web.tests/Observability/ServerRequestTracingTests.cs
+++ b/api/tests/town-crier.web.tests/Observability/ServerRequestTracingTests.cs
@@ -188,5 +188,9 @@ public sealed class ServerRequestTracingTests
 
         public Task DeleteAsync(string userId, CancellationToken ct) =>
             throw new InvalidOperationException("Simulated repository failure");
+
+        public Task<UserProfilePage> ListAsync(
+            string? emailSearch, int pageSize, string? continuationToken, CancellationToken ct) =>
+            throw new InvalidOperationException("Simulated repository failure");
     }
 }

--- a/cli/.editorconfig
+++ b/cli/.editorconfig
@@ -14,6 +14,9 @@ dotnet_diagnostic.SA1601.severity = none
 dotnet_diagnostic.SA1602.severity = none
 dotnet_diagnostic.SA1200.severity = none
 
+# CA1303: CLI is English-only — no localisation resources required
+dotnet_diagnostic.CA1303.severity = none
+
 # IL trim/AOT warnings are false positives in dotnet format (source generators handle them at build time)
 dotnet_diagnostic.IL2026.severity = none
 dotnet_diagnostic.IL3050.severity = none

--- a/cli/src/tc/ApiClient.cs
+++ b/cli/src/tc/ApiClient.cs
@@ -27,6 +27,23 @@ internal sealed class ApiClient : IDisposable
         return await this.client.PutAsJsonAsync(path, body, typeInfo, ct).ConfigureAwait(false);
     }
 
+    public async Task<TResponse?> GetFromJsonAsync<TResponse>(
+        string path,
+        JsonTypeInfo<TResponse> typeInfo,
+        CancellationToken ct)
+    {
+        using var response = await this.client.GetAsync(new Uri(path, UriKind.Relative), ct).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            throw new HttpRequestException(
+                $"API error ({(int)response.StatusCode}): {body}");
+        }
+
+        return await response.Content.ReadFromJsonAsync(typeInfo, ct).ConfigureAwait(false);
+    }
+
     public void Dispose()
     {
         this.client.Dispose();

--- a/cli/src/tc/Commands/ListUsersCommand.cs
+++ b/cli/src/tc/Commands/ListUsersCommand.cs
@@ -1,0 +1,99 @@
+using System.Globalization;
+using System.Text;
+using Tc.Json;
+
+namespace Tc.Commands;
+
+internal static class ListUsersCommand
+{
+    public static async Task<int> RunAsync(ApiClient client, ParsedArgs args, CancellationToken ct)
+    {
+        var search = args.GetOptional("search");
+        var pageSizeStr = args.GetOptional("page-size");
+        var pageSize = 20;
+
+        if (pageSizeStr is not null
+            && (!int.TryParse(pageSizeStr, NumberStyles.None, CultureInfo.InvariantCulture, out pageSize)
+                || pageSize <= 0))
+        {
+            await Console.Error.WriteLineAsync("Invalid --page-size: must be a positive integer")
+                .ConfigureAwait(false);
+            return 1;
+        }
+
+        string? continuationToken = null;
+
+        do
+        {
+            var path = BuildPath(search, pageSize, continuationToken);
+
+            ListUsersResponse? response;
+            try
+            {
+                response = await client.GetFromJsonAsync(path, TcJsonContext.Default.ListUsersResponse, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (HttpRequestException ex)
+            {
+                await Console.Error.WriteLineAsync(ex.Message).ConfigureAwait(false);
+                return 2;
+            }
+
+            if (response is null)
+            {
+                await Console.Error.WriteLineAsync("Empty response from API").ConfigureAwait(false);
+                return 2;
+            }
+
+            PrintTable(response);
+            continuationToken = response.ContinuationToken;
+
+            if (continuationToken is null)
+            {
+                break;
+            }
+
+            await Console.Out.WriteAsync("Next page? [y/N] ").ConfigureAwait(false);
+            var input = Console.ReadLine();
+            if (!string.Equals(input?.Trim(), "y", StringComparison.OrdinalIgnoreCase))
+            {
+                break;
+            }
+        }
+        while (true);
+
+        return 0;
+    }
+
+    private static string BuildPath(string? search, int pageSize, string? continuationToken)
+    {
+        var sb = new StringBuilder("/v1/admin/users?pageSize=");
+        sb.Append(pageSize.ToString(CultureInfo.InvariantCulture));
+
+        if (search is not null)
+        {
+            sb.Append("&search=");
+            sb.Append(Uri.EscapeDataString(search));
+        }
+
+        if (continuationToken is not null)
+        {
+            sb.Append("&continuationToken=");
+            sb.Append(Uri.EscapeDataString(continuationToken));
+        }
+
+        return sb.ToString();
+    }
+
+    private static void PrintTable(ListUsersResponse response)
+    {
+        Console.WriteLine($"{"UserId",-24} {"Email",-32} {"Tier",-10}");
+        Console.WriteLine(new string('-', 66));
+
+        foreach (var item in response.Items)
+        {
+            Console.WriteLine(
+                $"{item.UserId,-24} {item.Email ?? "(none)",-32} {item.Tier,-10}");
+        }
+    }
+}

--- a/cli/src/tc/Json/ListUsersItemResponse.cs
+++ b/cli/src/tc/Json/ListUsersItemResponse.cs
@@ -1,0 +1,10 @@
+namespace Tc.Json;
+
+internal sealed class ListUsersItemResponse
+{
+    public required string UserId { get; init; }
+
+    public string? Email { get; init; }
+
+    public required string Tier { get; init; }
+}

--- a/cli/src/tc/Json/ListUsersResponse.cs
+++ b/cli/src/tc/Json/ListUsersResponse.cs
@@ -1,0 +1,8 @@
+namespace Tc.Json;
+
+internal sealed class ListUsersResponse
+{
+    public required IReadOnlyList<ListUsersItemResponse> Items { get; init; }
+
+    public string? ContinuationToken { get; init; }
+}

--- a/cli/src/tc/Json/TcJsonContext.cs
+++ b/cli/src/tc/Json/TcJsonContext.cs
@@ -6,5 +6,4 @@ namespace Tc.Json;
 [JsonSerializable(typeof(ConfigFile))]
 [JsonSerializable(typeof(GrantSubscriptionRequest))]
 [JsonSerializable(typeof(ListUsersResponse))]
-[JsonSerializable(typeof(ListUsersItemResponse))]
 internal sealed partial class TcJsonContext : JsonSerializerContext;

--- a/cli/src/tc/Json/TcJsonContext.cs
+++ b/cli/src/tc/Json/TcJsonContext.cs
@@ -2,6 +2,9 @@ using System.Text.Json.Serialization;
 
 namespace Tc.Json;
 
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 [JsonSerializable(typeof(ConfigFile))]
 [JsonSerializable(typeof(GrantSubscriptionRequest))]
+[JsonSerializable(typeof(ListUsersResponse))]
+[JsonSerializable(typeof(ListUsersItemResponse))]
 internal sealed partial class TcJsonContext : JsonSerializerContext;

--- a/cli/src/tc/Program.cs
+++ b/cli/src/tc/Program.cs
@@ -40,6 +40,7 @@ Console.CancelKeyPress += (_, e) =>
 return parsed.Command switch
 {
     "grant-subscription" => await GrantSubscriptionCommand.RunAsync(client, parsed, cts.Token).ConfigureAwait(false),
+    "list-users" => await ListUsersCommand.RunAsync(client, parsed, cts.Token).ConfigureAwait(false),
     _ => await UnknownCommandAsync(parsed.Command).ConfigureAwait(false),
 };
 
@@ -59,8 +60,13 @@ static async Task PrintHelpAsync()
 
         Commands:
           grant-subscription   Grant or change a user's subscription tier
+          list-users           List users with email, ID, and subscription tier
           help                 Show this help message
           version              Print version
+
+        list-users options:
+          --search <term>      Filter by email substring (case-insensitive)
+          --page-size <n>      Results per page (default: 20)
 
         Global options:
           --url <url>          API base URL (overrides config file)


### PR DESCRIPTION
## Changes
- Add `PagedQueryResult<T>` and `QueryPageAsync` to Cosmos REST client for single-page queries with continuation tokens
- Add paginated `ListAsync` to user profile repository with optional email substring search and ORDER BY email
- Add `ListUsersQueryHandler` (CQRS query) for paginated admin user listing
- Wire `GET /v1/admin/users` endpoint with `search`, `pageSize`, and `continuationToken` query params
- Add `tc list-users` CLI command with interactive auto-paging and `--search`/`--page-size` flags
- Add `GetFromJsonAsync` to CLI `ApiClient` and camelCase JSON source generation

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin endpoint to list users with optional email search and pagination support.
  * Added a new CLI `list-users` command with `--search` and `--page-size` options to retrieve and display users in a formatted table with interactive page navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->