### PR TITLE
chore: fix recurring git conflicts around .beads/issues.jsonl

### DIFF
--- a/.claude/skills/autopilot/SKILL.md
+++ b/.claude/skills/autopilot/SKILL.md
@@ -17,9 +17,19 @@ Always work on a branch, never main.
 
 **On `main`:**
 ```bash
+# If the working tree is dirty (typically auto-exported .beads/issues.jsonl from a
+# prior session's bd mutations), stash instead of committing. Creating a standalone
+# `chore(beads): sync` commit here causes rebase conflicts at the end of ship, because
+# squash-merge of the PR will replay a different jsonl snapshot on top of it.
+if ! git diff-index --quiet HEAD --; then
+  git stash -u -m "autopilot-phase0"
+  _stashed=1
+fi
 git pull --rebase
 git checkout -b "autopilot/$(date -u +%Y-%m-%dT%H%M%SZ)"
 git push -u origin HEAD
+# Drop the stash — it's pre-mutation bd state that the worker's own commits will supersede.
+if [ "$_stashed" = "1" ]; then git stash drop; fi
 ```
 
 **On `autopilot/*`:** Continue using it.
@@ -100,7 +110,14 @@ All files must be under the allowed path. Any outside -> failure.
 
 ### Check 3: Merge
 ```bash
+# Stash any auto-exported .beads/issues.jsonl / .gitignore churn first — those files
+# get re-touched by bd worktree create / bd close in the parent tree during Phase 2,
+# and block the merge even though they're not conflicts.
+git stash -u -m "autopilot-phase3" 2>/dev/null
 git merge <worker-branch> --no-edit
+# Drop the stash — worker's commits (and the `merge=theirs` driver on .beads/issues.jsonl)
+# are now authoritative.
+git stash drop 2>/dev/null
 ```
 Conflicts -> `git merge --abort` -> failure.
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -180,17 +180,18 @@ bd worktree list
    git branch -D <branch-name>
    ```
 
-**Then, from the primary worktree (on `main`), pull and prune:**
+**Then, from the primary worktree (on `main`), reset and prune:**
 
 1. Stash any uncommitted changes first (other in-progress work on main):
    ```bash
    git status --short
    # Only if there are changes:
-   git stash
+   git stash -u
    ```
-2. Pull with rebase to handle divergent local commits (e.g., spec/doc commits made before the worktree):
+2. Hard-reset to origin/main. Squash-merge means any local commits on main are already represented in the remote squash commit — rebasing them creates guaranteed conflicts on files like `.beads/issues.jsonl` that both branches touched. Reset is the correct move:
    ```bash
-   git pull --rebase origin main
+   git fetch origin
+   git reset --hard origin/main
    ```
 3. Restore stashed changes:
    ```bash

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# .beads/issues.jsonl is a derived snapshot of the Dolt DB, not hand-written source.
+# During merges/rebases, always take the incoming version — Dolt is the source of truth,
+# and any divergence will be reconciled by the next `bd dolt pull` / `bd export`.
+# Eliminates spurious merge conflicts that every autopilot cycle was hitting.
+.beads/issues.jsonl merge=theirs

--- a/.gitignore
+++ b/.gitignore
@@ -87,14 +87,11 @@ node_modules/
 
 # Beads / Dolt files (added by bd init)
 .beads-credential-key
-.claude/worktrees/autopilot-tc-kkc.1/
 extract-polling-job/
 email-notifications/
 
 # Skill evaluation workspaces
 .claude/skills/*-workspace/
-.claude/worktrees/autopilot-tc-k2v/
-.claude/worktrees/autopilot-tc-2v1/
-.claude/worktrees/autopilot-tc-xd8/
-.claude/worktrees/autopilot-tc-c6i/
-.claude/worktrees/autopilot-tc-rxze.7/
+
+# All beads/autopilot worktrees (blanket — prevents bd worktree create from appending per-worktree lines)
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,17 @@ When a task involves any of these services, use the corresponding CLI directly. 
 
 NEVER deploy code directly using `az`, `pulumi`, or any other CLI tool. ALL code changes MUST be shipped via pull requests and deployed through CI/CD (GitHub Actions). Direct deployments bypass review, testing, and audit trails.
 
+## Beads JSONL Merge Driver (one-time setup)
+
+`.beads/issues.jsonl` is a derived Dolt snapshot rewritten on every bead mutation, so any two branches that touched beads will conflict on merge/rebase. `.gitattributes` marks the file with `merge=theirs`. The driver itself is per-clone — register it once:
+
+```bash
+git config --local merge.theirs.driver 'cp -f "%B" "%A"'
+git config --local merge.theirs.name 'always take incoming version'
+```
+
+After squash-merge, never `git pull --rebase` local main onto origin/main — the local auto-export commits will conflict with the squashed version. Use `git fetch origin && git reset --hard origin/main` instead.
+
 ## Shell Commands — Non-Interactive Mode
 
 Always use non-interactive flags with file operations to avoid hanging on confirmation prompts (some systems alias `cp`, `mv`, `rm` to include `-i`):


### PR DESCRIPTION
## Changes

Every autopilot + ship cycle was hitting the same three git failures, all traceable to `.beads/issues.jsonl` (a derived Dolt snapshot treated as source code):

1. **Merge driver** — `.gitattributes` marks `.beads/issues.jsonl` with `merge=theirs`. On merge/rebase, always take the incoming version. Driver must be registered once per clone (documented in CLAUDE.md):
   ```
   git config --local merge.theirs.driver 'cp -f "%B" "%A"'
   ```
   Smoke-tested: two branches appending different lines to `.beads/issues.jsonl` now merge cleanly instead of conflicting.

2. **`.gitignore` consolidation** — replaced 6 per-worktree entries with a blanket `.claude/worktrees/`. Stops `bd worktree create` from appending a new line on every autopilot run.

3. **Ship skill cleanup step** — was `git pull --rebase`, now `git fetch && git reset --hard origin/main`. Squash-merge means local main's commits are already represented in origin's squash commit; rebasing replays them and guarantees conflicts on `.beads/issues.jsonl`.

4. **Autopilot Phase 0** — stash dirty working tree instead of creating a throwaway `chore(beads): sync` commit. That commit was the root cause of post-ship rebase conflicts.

5. **Autopilot Phase 3** — stash before `git merge <worker-branch>` so bd/worktree churn in the parent tree doesn't block the merge.

See the preceding session's postmortem analysis — all five symptoms are now addressed.

---
*Auto-shipped via ship skill*