### PR TITLE
feat(polling): alternating watched/seed authority cycles

### DIFF
--- a/api/src/town-crier.application/Polling/CycleAlternatingAuthorityProvider.cs
+++ b/api/src/town-crier.application/Polling/CycleAlternatingAuthorityProvider.cs
@@ -1,0 +1,27 @@
+namespace TownCrier.Application.Polling;
+
+public sealed class CycleAlternatingAuthorityProvider : IActiveAuthorityProvider
+{
+    private readonly IWatchZoneActiveAuthorityProvider watchZoneProvider;
+    private readonly IAllAuthorityIdProvider allAuthorityProvider;
+    private readonly ICycleSelector cycleSelector;
+
+    public CycleAlternatingAuthorityProvider(
+        IWatchZoneActiveAuthorityProvider watchZoneProvider,
+        IAllAuthorityIdProvider allAuthorityProvider,
+        ICycleSelector cycleSelector)
+    {
+        this.watchZoneProvider = watchZoneProvider;
+        this.allAuthorityProvider = allAuthorityProvider;
+        this.cycleSelector = cycleSelector;
+    }
+
+    public Task<IReadOnlyCollection<int>> GetActiveAuthorityIdsAsync(CancellationToken ct)
+    {
+        return this.cycleSelector.GetCurrent() switch
+        {
+            CycleType.Seed => this.allAuthorityProvider.GetActiveAuthorityIdsAsync(ct),
+            _ => this.watchZoneProvider.GetActiveAuthorityIdsAsync(ct),
+        };
+    }
+}

--- a/api/src/town-crier.application/Polling/CycleType.cs
+++ b/api/src/town-crier.application/Polling/CycleType.cs
@@ -1,0 +1,7 @@
+namespace TownCrier.Application.Polling;
+
+public enum CycleType
+{
+    Watched,
+    Seed,
+}

--- a/api/src/town-crier.application/Polling/IAllAuthorityIdProvider.cs
+++ b/api/src/town-crier.application/Polling/IAllAuthorityIdProvider.cs
@@ -1,0 +1,5 @@
+namespace TownCrier.Application.Polling;
+
+public interface IAllAuthorityIdProvider : IActiveAuthorityProvider
+{
+}

--- a/api/src/town-crier.application/Polling/ICycleSelector.cs
+++ b/api/src/town-crier.application/Polling/ICycleSelector.cs
@@ -1,0 +1,6 @@
+namespace TownCrier.Application.Polling;
+
+public interface ICycleSelector
+{
+    CycleType GetCurrent();
+}

--- a/api/src/town-crier.application/Polling/IWatchZoneActiveAuthorityProvider.cs
+++ b/api/src/town-crier.application/Polling/IWatchZoneActiveAuthorityProvider.cs
@@ -1,0 +1,5 @@
+namespace TownCrier.Application.Polling;
+
+public interface IWatchZoneActiveAuthorityProvider : IActiveAuthorityProvider
+{
+}

--- a/api/src/town-crier.application/Polling/MinuteBasedCycleSelector.cs
+++ b/api/src/town-crier.application/Polling/MinuteBasedCycleSelector.cs
@@ -1,0 +1,17 @@
+namespace TownCrier.Application.Polling;
+
+public sealed class MinuteBasedCycleSelector : ICycleSelector
+{
+    private readonly TimeProvider timeProvider;
+
+    public MinuteBasedCycleSelector(TimeProvider timeProvider)
+    {
+        this.timeProvider = timeProvider;
+    }
+
+    public CycleType GetCurrent()
+    {
+        var minute = this.timeProvider.GetUtcNow().Minute;
+        return (minute % 30) < 15 ? CycleType.Watched : CycleType.Seed;
+    }
+}

--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -17,6 +17,7 @@ public sealed partial class PollPlanItCommandHandler
     private readonly IActiveAuthorityProvider activeAuthorityProvider;
     private readonly IWatchZoneRepository watchZoneRepository;
     private readonly INotificationEnqueuer notificationEnqueuer;
+    private readonly ICycleSelector cycleSelector;
     private readonly ILogger<PollPlanItCommandHandler> logger;
 
     public PollPlanItCommandHandler(
@@ -27,6 +28,7 @@ public sealed partial class PollPlanItCommandHandler
         IActiveAuthorityProvider activeAuthorityProvider,
         IWatchZoneRepository watchZoneRepository,
         INotificationEnqueuer notificationEnqueuer,
+        ICycleSelector cycleSelector,
         ILogger<PollPlanItCommandHandler> logger)
     {
         this.planItClient = planItClient;
@@ -36,12 +38,21 @@ public sealed partial class PollPlanItCommandHandler
         this.activeAuthorityProvider = activeAuthorityProvider;
         this.watchZoneRepository = watchZoneRepository;
         this.notificationEnqueuer = notificationEnqueuer;
+        this.cycleSelector = cycleSelector;
         this.logger = logger;
     }
 
     public async Task<PollPlanItResult> HandleAsync(PollPlanItCommand command, CancellationToken ct)
     {
         var now = this.timeProvider.GetUtcNow();
+        var cycleType = this.cycleSelector.GetCurrent();
+        var cycleTypeValue = cycleType switch
+        {
+            CycleType.Seed => "seed",
+            CycleType.Watched => "watched",
+            _ => "watched",
+        };
+        var cycleTypeTag = new KeyValuePair<string, object?>("cycle.type", cycleTypeValue);
         var activeIds = await this.activeAuthorityProvider.GetActiveAuthorityIdsAsync(ct).ConfigureAwait(false);
         var sortedIds = await this.pollStateStore.GetLeastRecentlyPolledAsync(
             activeIds.ToList(), ct).ConfigureAwait(false);
@@ -53,6 +64,7 @@ public sealed partial class PollPlanItCommandHandler
         {
             using var authorityActivity = PollingInstrumentation.Source.StartActivity("Poll Authority");
             authorityActivity?.SetTag("polling.authority_code", authorityId);
+            authorityActivity?.SetTag("cycle.type", cycleTypeValue);
             var authorityStart = Stopwatch.GetTimestamp();
 
             var authorityAppCount = 0;
@@ -98,7 +110,7 @@ public sealed partial class PollPlanItCommandHandler
             {
                 authorityActivity?.AddException(ex);
                 authorityActivity?.SetStatus(ActivityStatusCode.Error, ex.Message);
-                PollingMetrics.RateLimited.Add(1);
+                PollingMetrics.RateLimited.Add(1, cycleTypeTag);
                 rateLimited = true;
                 LogRateLimitStop(this.logger, authorityId, ex);
             }
@@ -109,20 +121,20 @@ public sealed partial class PollPlanItCommandHandler
                 LogAuthorityError(this.logger, authorityId, ex);
             }
 
-            PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds);
+            PollingMetrics.AuthorityProcessingDuration.Record(Stopwatch.GetElapsedTime(authorityStart).TotalMilliseconds, cycleTypeTag);
             authorityActivity?.SetTag("polling.applications_found", authorityAppCount);
 
             if (completedSuccessfully || authorityAppCount > 0)
             {
-                PollingMetrics.AuthoritiesPolled.Add(1);
-                PollingMetrics.ApplicationsIngested.Add(authorityAppCount);
+                PollingMetrics.AuthoritiesPolled.Add(1, cycleTypeTag);
+                PollingMetrics.ApplicationsIngested.Add(authorityAppCount, cycleTypeTag);
                 await this.pollStateStore.SaveLastPollTimeAsync(authorityId, highWaterMark ?? now, ct).ConfigureAwait(false);
                 authoritiesPolled++;
                 count += authorityAppCount;
             }
             else
             {
-                PollingMetrics.AuthoritiesSkipped.Add(1);
+                PollingMetrics.AuthoritiesSkipped.Add(1, cycleTypeTag);
             }
 
             if (rateLimited)

--- a/api/src/town-crier.application/Polling/WatchZoneActiveAuthorityProvider.cs
+++ b/api/src/town-crier.application/Polling/WatchZoneActiveAuthorityProvider.cs
@@ -2,7 +2,7 @@ using TownCrier.Application.WatchZones;
 
 namespace TownCrier.Application.Polling;
 
-public sealed class WatchZoneActiveAuthorityProvider : IActiveAuthorityProvider
+public sealed class WatchZoneActiveAuthorityProvider : IWatchZoneActiveAuthorityProvider
 {
     private readonly IWatchZoneRepository watchZoneRepository;
 

--- a/api/src/town-crier.infrastructure/Authorities/AllAuthorityIdProvider.cs
+++ b/api/src/town-crier.infrastructure/Authorities/AllAuthorityIdProvider.cs
@@ -1,0 +1,20 @@
+using TownCrier.Application.Authorities;
+using TownCrier.Application.Polling;
+
+namespace TownCrier.Infrastructure.Authorities;
+
+public sealed class AllAuthorityIdProvider : IAllAuthorityIdProvider
+{
+    private readonly IAuthorityProvider authorityProvider;
+
+    public AllAuthorityIdProvider(IAuthorityProvider authorityProvider)
+    {
+        this.authorityProvider = authorityProvider;
+    }
+
+    public async Task<IReadOnlyCollection<int>> GetActiveAuthorityIdsAsync(CancellationToken ct)
+    {
+        var authorities = await this.authorityProvider.GetAllAsync(ct).ConfigureAwait(false);
+        return authorities.Select(a => a.Id).ToList().AsReadOnly();
+    }
+}

--- a/api/src/town-crier.worker/Program.cs
+++ b/api/src/town-crier.worker/Program.cs
@@ -9,6 +9,7 @@ using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
+using TownCrier.Application.Authorities;
 using TownCrier.Application.DeviceRegistrations;
 using TownCrier.Application.Notifications;
 using TownCrier.Application.Observability;
@@ -17,6 +18,7 @@ using TownCrier.Application.PlanningApplications;
 using TownCrier.Application.Polling;
 using TownCrier.Application.UserProfiles;
 using TownCrier.Application.WatchZones;
+using TownCrier.Infrastructure.Authorities;
 using TownCrier.Infrastructure.Cosmos;
 using TownCrier.Infrastructure.DeviceRegistrations;
 using TownCrier.Infrastructure.Notifications;
@@ -98,7 +100,11 @@ builder.Services.AddCosmosRestClient(builder.Configuration);
 builder.Services.AddSingleton<IPlanningApplicationRepository, CosmosPlanningApplicationRepository>();
 builder.Services.AddSingleton<IWatchZoneRepository, CosmosWatchZoneRepository>();
 builder.Services.AddSingleton<IPollStateStore, CosmosPollStateStore>();
-builder.Services.AddSingleton<IActiveAuthorityProvider, WatchZoneActiveAuthorityProvider>();
+builder.Services.AddSingleton<IWatchZoneActiveAuthorityProvider, WatchZoneActiveAuthorityProvider>();
+builder.Services.AddSingleton<IAllAuthorityIdProvider, AllAuthorityIdProvider>();
+builder.Services.AddSingleton<IAuthorityProvider, StaticAuthorityProvider>();
+builder.Services.AddSingleton<ICycleSelector, MinuteBasedCycleSelector>();
+builder.Services.AddSingleton<IActiveAuthorityProvider, CycleAlternatingAuthorityProvider>();
 builder.Services.AddSingleton<INotificationRepository, CosmosNotificationRepository>();
 builder.Services.AddSingleton<IUserProfileRepository, CosmosUserProfileRepository>();
 builder.Services.AddSingleton<IDeviceRegistrationRepository, CosmosDeviceRegistrationRepository>();
@@ -173,6 +179,16 @@ switch (mode)
             try
             {
                 var cycleStart = Stopwatch.GetTimestamp();
+
+                var cycleSelector = host.Services.GetRequiredService<ICycleSelector>();
+                var cycleType = cycleSelector.GetCurrent();
+                var cycleTypeValue = cycleType switch
+                {
+                    CycleType.Seed => "seed",
+                    CycleType.Watched => "watched",
+                    _ => "watched",
+                };
+                activity?.SetTag("cycle.type", cycleTypeValue);
 
                 WorkerLog.PollCycleStarting(logger);
 

--- a/api/tests/town-crier.application.tests/Polling/CycleAlternatingAuthorityProviderTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/CycleAlternatingAuthorityProviderTests.cs
@@ -1,0 +1,51 @@
+using TownCrier.Application.Polling;
+
+namespace TownCrier.Application.Tests.Polling;
+
+public sealed class CycleAlternatingAuthorityProviderTests
+{
+    [Test]
+    public async Task Should_DelegateToWatchedProvider_When_CycleIsWatched()
+    {
+        // Arrange
+        var watched = new FakeWatchZoneActiveAuthorityProvider();
+        watched.Add(100);
+        watched.Add(200);
+        var all = new FakeAllAuthorityIdProvider();
+        all.Add(300);
+        all.Add(400);
+        var selector = new FakeCycleSelector(CycleType.Watched);
+        var provider = new CycleAlternatingAuthorityProvider(watched, all, selector);
+
+        // Act
+        var result = await provider.GetActiveAuthorityIdsAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).HasCount().EqualTo(2);
+        await Assert.That(result).Contains(100);
+        await Assert.That(result).Contains(200);
+    }
+
+    [Test]
+    public async Task Should_DelegateToAllProvider_When_CycleIsSeed()
+    {
+        // Arrange
+        var watched = new FakeWatchZoneActiveAuthorityProvider();
+        watched.Add(100);
+        var all = new FakeAllAuthorityIdProvider();
+        all.Add(300);
+        all.Add(400);
+        all.Add(500);
+        var selector = new FakeCycleSelector(CycleType.Seed);
+        var provider = new CycleAlternatingAuthorityProvider(watched, all, selector);
+
+        // Act
+        var result = await provider.GetActiveAuthorityIdsAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).HasCount().EqualTo(3);
+        await Assert.That(result).Contains(300);
+        await Assert.That(result).Contains(400);
+        await Assert.That(result).Contains(500);
+    }
+}

--- a/api/tests/town-crier.application.tests/Polling/FakeAllAuthorityIdProvider.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakeAllAuthorityIdProvider.cs
@@ -1,0 +1,13 @@
+using TownCrier.Application.Polling;
+
+namespace TownCrier.Application.Tests.Polling;
+
+internal sealed class FakeAllAuthorityIdProvider : IAllAuthorityIdProvider
+{
+    private readonly List<int> ids = [];
+
+    public void Add(int id) => this.ids.Add(id);
+
+    public Task<IReadOnlyCollection<int>> GetActiveAuthorityIdsAsync(CancellationToken ct)
+        => Task.FromResult<IReadOnlyCollection<int>>(this.ids.AsReadOnly());
+}

--- a/api/tests/town-crier.application.tests/Polling/FakeCycleSelector.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakeCycleSelector.cs
@@ -1,0 +1,21 @@
+using TownCrier.Application.Polling;
+
+namespace TownCrier.Application.Tests.Polling;
+
+internal sealed class FakeCycleSelector : ICycleSelector
+{
+    public FakeCycleSelector(CycleType cycleType = CycleType.Watched)
+    {
+        this.Current = cycleType;
+    }
+
+    public CycleType Current { get; set; }
+
+    public int GetCurrentCallCount { get; private set; }
+
+    public CycleType GetCurrent()
+    {
+        this.GetCurrentCallCount++;
+        return this.Current;
+    }
+}

--- a/api/tests/town-crier.application.tests/Polling/FakeWatchZoneActiveAuthorityProvider.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakeWatchZoneActiveAuthorityProvider.cs
@@ -1,0 +1,13 @@
+using TownCrier.Application.Polling;
+
+namespace TownCrier.Application.Tests.Polling;
+
+internal sealed class FakeWatchZoneActiveAuthorityProvider : IWatchZoneActiveAuthorityProvider
+{
+    private readonly List<int> ids = [];
+
+    public void Add(int id) => this.ids.Add(id);
+
+    public Task<IReadOnlyCollection<int>> GetActiveAuthorityIdsAsync(CancellationToken ct)
+        => Task.FromResult<IReadOnlyCollection<int>>(this.ids.AsReadOnly());
+}

--- a/api/tests/town-crier.application.tests/Polling/MinuteBasedCycleSelectorTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/MinuteBasedCycleSelectorTests.cs
@@ -1,0 +1,28 @@
+using TownCrier.Application.Polling;
+
+namespace TownCrier.Application.Tests.Polling;
+
+public sealed class MinuteBasedCycleSelectorTests
+{
+    [Test]
+    [Arguments(0, CycleType.Watched)]
+    [Arguments(14, CycleType.Watched)]
+    [Arguments(15, CycleType.Seed)]
+    [Arguments(29, CycleType.Seed)]
+    [Arguments(30, CycleType.Watched)]
+    [Arguments(44, CycleType.Watched)]
+    [Arguments(45, CycleType.Seed)]
+    [Arguments(59, CycleType.Seed)]
+    public async Task Should_ReturnExpectedCycleType_When_MinuteIsAtBoundary(int minute, CycleType expected)
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 4, 18, 12, minute, 0, TimeSpan.Zero));
+        var selector = new MinuteBasedCycleSelector(timeProvider);
+
+        // Act
+        var result = selector.GetCurrent();
+
+        // Assert
+        await Assert.That(result).IsEqualTo(expected);
+    }
+}

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerMetricsTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerMetricsTests.cs
@@ -447,6 +447,49 @@ public sealed class PollPlanItCommandHandlerMetricsTests
         await Assert.That(recorded.Sum()).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task Should_TagAuthoritiesPolled_With_CycleType()
+    {
+        // Arrange
+        var authorityProvider = new FakeActiveAuthorityProvider();
+        authorityProvider.Add(100);
+        var planItClient = new FakePlanItClient();
+        planItClient.Add(100, new PlanningApplicationBuilder().WithUid("app-1").WithAreaId(100).Build());
+        var cycleSelector = new FakeCycleSelector(CycleType.Seed);
+        var handler = CreateHandler(
+            planItClient: planItClient,
+            authorityProvider: authorityProvider,
+            cycleSelector: cycleSelector);
+
+        var recordedTags = new List<string?>();
+        using var listener = new MeterListener();
+        listener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Name == "towncrier.polling.authorities_polled")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+        {
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "cycle.type")
+                {
+                    recordedTags.Add(tag.Value?.ToString());
+                }
+            }
+        });
+        listener.Start();
+
+        // Act
+        await handler.HandleAsync(new PollPlanItCommand(), CancellationToken.None);
+
+        // Assert
+        await Assert.That(recordedTags).HasCount().EqualTo(1);
+        await Assert.That(recordedTags[0]).IsEqualTo("seed");
+    }
+
     private static PollPlanItCommandHandler CreateHandler(
         FakePlanItClient? planItClient = null,
         FakePollStateStore? pollStateStore = null,
@@ -454,7 +497,8 @@ public sealed class PollPlanItCommandHandlerMetricsTests
         FakeActiveAuthorityProvider? authorityProvider = null,
         FakeWatchZoneRepository? watchZoneRepository = null,
         FakeNotificationEnqueuer? notificationEnqueuer = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        ICycleSelector? cycleSelector = null)
     {
         return new PollPlanItCommandHandler(
             planItClient ?? new FakePlanItClient(),
@@ -464,6 +508,7 @@ public sealed class PollPlanItCommandHandlerMetricsTests
             authorityProvider ?? new FakeActiveAuthorityProvider(),
             watchZoneRepository ?? new FakeWatchZoneRepository(),
             notificationEnqueuer ?? new FakeNotificationEnqueuer(),
+            cycleSelector ?? new FakeCycleSelector(CycleType.Watched),
             NullLogger<PollPlanItCommandHandler>.Instance);
     }
 }

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTests.cs
@@ -700,7 +700,8 @@ public sealed class PollPlanItCommandHandlerTests
         FakeActiveAuthorityProvider? authorityProvider = null,
         FakeWatchZoneRepository? watchZoneRepository = null,
         FakeNotificationEnqueuer? notificationEnqueuer = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        ICycleSelector? cycleSelector = null)
     {
         return new PollPlanItCommandHandler(
             planItClient ?? new FakePlanItClient(),
@@ -710,6 +711,7 @@ public sealed class PollPlanItCommandHandlerTests
             authorityProvider ?? new FakeActiveAuthorityProvider(),
             watchZoneRepository ?? new FakeWatchZoneRepository(),
             notificationEnqueuer ?? new FakeNotificationEnqueuer(),
+            cycleSelector ?? new FakeCycleSelector(CycleType.Watched),
             NullLogger<PollPlanItCommandHandler>.Instance);
     }
 }

--- a/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTracingTests.cs
+++ b/api/tests/town-crier.application.tests/Polling/PollPlanItCommandHandlerTracingTests.cs
@@ -119,7 +119,8 @@ public sealed class PollPlanItCommandHandlerTracingTests : IDisposable
         FakeActiveAuthorityProvider? authorityProvider = null,
         FakeWatchZoneRepository? watchZoneRepository = null,
         FakeNotificationEnqueuer? notificationEnqueuer = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        ICycleSelector? cycleSelector = null)
     {
         return new PollPlanItCommandHandler(
             planItClient ?? new FakePlanItClient(),
@@ -129,6 +130,7 @@ public sealed class PollPlanItCommandHandlerTracingTests : IDisposable
             authorityProvider ?? new FakeActiveAuthorityProvider(),
             watchZoneRepository ?? new FakeWatchZoneRepository(),
             notificationEnqueuer ?? new FakeNotificationEnqueuer(),
+            cycleSelector ?? new FakeCycleSelector(CycleType.Watched),
             NullLogger<PollPlanItCommandHandler>.Instance);
     }
 }

--- a/api/tests/town-crier.infrastructure.tests/Authorities/AllAuthorityIdProviderTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Authorities/AllAuthorityIdProviderTests.cs
@@ -1,0 +1,35 @@
+using TownCrier.Infrastructure.Authorities;
+
+namespace TownCrier.Infrastructure.Tests.Authorities;
+
+public sealed class AllAuthorityIdProviderTests
+{
+    [Test]
+    public async Task Should_ReturnAllAuthorityIds_When_Queried()
+    {
+        // Arrange
+        var authorityProvider = new StaticAuthorityProvider();
+        var all = await authorityProvider.GetAllAsync(CancellationToken.None);
+        var provider = new AllAuthorityIdProvider(authorityProvider);
+
+        // Act
+        var result = await provider.GetActiveAuthorityIdsAsync(CancellationToken.None);
+
+        // Assert — count matches the embedded authority list
+        await Assert.That(result).HasCount().EqualTo(all.Count);
+    }
+
+    [Test]
+    public async Task Should_ReturnDistinctIds_When_Queried()
+    {
+        // Arrange
+        var authorityProvider = new StaticAuthorityProvider();
+        var provider = new AllAuthorityIdProvider(authorityProvider);
+
+        // Act
+        var result = await provider.GetActiveAuthorityIdsAsync(CancellationToken.None);
+
+        // Assert
+        await Assert.That(result.Distinct().Count()).IsEqualTo(result.Count);
+    }
+}


### PR DESCRIPTION
## Changes

Implements tc-ethl epic — poll worker now alternates between watched-only and full-417-authority input sets every 15 minutes (driven by `(utcNow.Minute % 30) < 15`). Seed authorities complete a full rotation in ~26 hours via natural LRU separation. Every metric and both span tiers are tagged `cycle.type` (`"watched"` | `"seed"`).

- **feat(polling): add CycleType enum** — `Watched`, `Seed`
- **feat(polling): add minute-based cycle selector** — `ICycleSelector` + `MinuteBasedCycleSelector` (TDD, 8 boundary cases)
- **feat(polling): add marker interfaces for cycle providers** — `IWatchZoneActiveAuthorityProvider`, `IAllAuthorityIdProvider` for DI discrimination
- **refactor(polling): mark WatchZoneActiveAuthorityProvider with specific interface**
- **feat(polling): add all-authority id provider for seed cycles** — infrastructure adapter over `IAuthorityProvider`
- **feat(polling): add cycle-alternating authority provider** — delegates to watched or all-authority provider based on `ICycleSelector`
- **feat(polling): tag poll metrics with cycle.type** — handler resolves cycle type once per run; tags all counters, histogram, and per-authority span
- **feat(polling): wire alternating seed/watched cycles in worker** — DI registrations + root-span `cycle.type` tag

Spec: `docs/specs/seed-polling.md` · Plan: `docs/superpowers/plans/2026-04-18-seed-polling.md`
Beads: closes epic tc-ethl (tc-ethl.1 through tc-ethl.5)
Follow-ups filed: tc-qyz2 (dedupe switch), tc-k2q9 (assert call count)

---
*Auto-shipped via ship skill*