### PR TITLE
ci(cd-dev): skip deploy on non-deployable changes

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,5 +1,7 @@
 # Deploys all components to the dev environment.
-# Triggered on every push to main (squash merges assumed).
+# Triggered on every push to main (squash merges assumed) that touches
+# deployable code or infra. Pushes that only change docs, iOS, beads, Claude
+# config, or markdown/license/git metadata are skipped via paths-ignore.
 #
 # All components deploy unconditionally to keep dev in sync with main.
 #
@@ -20,6 +22,15 @@ name: CD Dev
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - 'mobile/ios/**'
+      - '.beads/**'
+      - '.claude/**'
+      - '**/*.md'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.gitattributes'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Changes

- Add `paths-ignore` to `.github/workflows/cd-dev.yml` so the dev deploy is skipped when a push to `main` only touches non-deployable paths.
- Ignored: `docs/**`, `mobile/ios/**`, `.beads/**`, `.claude/**`, `**/*.md`, `LICENSE`, `.gitignore`, `.gitattributes`.
- Pushes that touch deployable code/infra (anywhere outside the ignore list) still trigger a full deploy as before. `workflow_dispatch` is preserved for manual runs.

Triggered by #307 (cost forecast doc), which kicked off a full dev redeploy despite being docs-only.

Closes tc-g8pq.

---
*Auto-shipped via ship skill*