### PR TITLE
chore(ios): set DEVELOPMENT_TEAM in project.yml

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -21,6 +21,7 @@ targets:
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: uk.towncrierapp.mobile
+        DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
         MARKETING_VERSION: "1.0.0"


### PR DESCRIPTION
## Summary

Adds \`DEVELOPMENT_TEAM: 4574VQ7N2X\` to \`mobile/ios/project.yml\` so the xcodegen-generated Xcode project has the team baked in. Required by the \`cd-ios-testflight\` workflow (#318) so CI archive can sign the build.

This was meant to land with #318 but auto-merge fired first.

Closes tc-v71z (Development Team selection was the last open step).

## Test plan

- [ ] CI checks pass
- [ ] After merge, the next iOS-affecting \`v*\` tag triggers the TestFlight workflow and archive succeeds with team-based signing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build configuration to support proper code signing for the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->