### PR TITLE
chore(ci): bump actions/cache@v4 → v5 in iOS TestFlight workflow

### DIFF
--- a/.github/workflows/cd-ios-testflight.yml
+++ b/.github/workflows/cd-ios-testflight.yml
@@ -88,7 +88,7 @@ jobs:
           xcode-version: latest-stable
 
       - name: Cache SPM build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: mobile/ios/.build
           key: spm-test-${{ hashFiles('mobile/ios/Package.resolved') }}
@@ -122,7 +122,7 @@ jobs:
           xcode-version: latest-stable
 
       - name: Cache SPM
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
           key: spm-archive-${{ hashFiles('mobile/ios/Package.resolved', 'mobile/ios/packages/**/Package.resolved') }}


### PR DESCRIPTION
## Changes
- Bump `actions/cache` v4 → v5 in `cd-ios-testflight.yml` (lines 91 and 125), resolving the Node.js 20 deprecation warning surfaced on the latest iOS unit tests + lint run.
- Matches the sweep done in #129 for `pr-gate.yml`, `cd-dev.yml`, and `cd-prod.yml` — the iOS workflow was added after that PR and missed the bump.

Bead: tc-l8my

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS build workflow to use the latest cache infrastructure version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->