### PR TITLE
chore(infra): set APNs Pulumi config on dev + prod

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -5,3 +5,7 @@ config:
   town-crier:apiDomain: api-dev.towncrierapp.uk
   town-crier:auth0Domain: towncrierapp.uk.auth0.com
   town-crier:auth0Audience: https://api-dev.towncrierapp.uk
+  town-crier:apnsKeyId: L2J5PQASN5
+  town-crier:apnsTeamId: 4574VQ7N2X
+  town-crier:apnsAuthKey:
+    secure: AAABAJGCaZXEDG8x2DVfI2ubWIyFsVbs/Wu9vhDOqbmw9oAEqEe0JulgqpvI1yeMw9J7xKkTKabPhIDQQFBr0qRV/a2ngb9M984mC/lKh0iaj7bAMNE9JpmQ09GeG79OzASS4JGLOmtjxbvrPX5gg9wwPxr9ZLtiMdrznaduAEXC+wKaIqRdhLIraBJ1XqK5cwiTIxtHrGghkCy3O+i16y0UnEVJWTuw7Gn62g/QCh1rTiUzEZqPIfkL5jvOQ3/+bSRnalcjMpK/FYQfVjyooCOk+tQO+HwWbq+WfJOZDT+jCqQQ6aoQdy94v9aBbjyAXpGjuMjHZTU0pIz/me8vImjNgP9t4AnCxvYs6KU0vi/vQ2TGaVpgyxsJj3HHLt0Krw==

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -6,3 +6,7 @@ config:
   town-crier:auth0Domain: towncrierapp.uk.auth0.com
   town-crier:auth0Audience: https://api.towncrierapp.uk
   town-crier:customDomainPhase: "2"
+  town-crier:apnsAuthKey:
+    secure: AAABAP37+De7jCYlvZRjpDywQNmh0191AtYoBN/lozkmkoquI2b7Ld/DLyOmO5Xj10N3f1CgtpeKHnE+JmqxbFkzfIn8p5mCy0aaW714XM/u1+Hnm+joY07yC50A/a/KbdCxpW99fv9QHueyNDelc3MVn+9/GPa3n1N1ljvIe7TPngFs6Hy62CDisKwgwo5lreNGAXOvcbxqWVTGqdiUi5+GLg5usi8WHIj4IRlYqxjEwXaiNA+Z3fbzuI/6r8mFlknMfDrKWI9C4TuVIdYoQxFnjR5HixGzt4/9o+3ItuJBJ5TLzi1eaM40AMenqSOyvn0KYmU2B/GReeG5pOfmtlPNGWxrIBuOS4hmbp7arJ8TDtgh+Lb2lrbhISdshO8UPQ==
+  town-crier:apnsKeyId: L2J5PQASN5
+  town-crier:apnsTeamId: 4574VQ7N2X


### PR DESCRIPTION
## Changes

- Sets `town-crier:apnsAuthKey` (secret), `town-crier:apnsKeyId`, `town-crier:apnsTeamId` on both `dev` and `prod` Pulumi stacks.
- Unblocks the next infra deploy after v0.10.12 — without these, `pulumi up` would fail at `config.RequireSecret("apnsAuthKey")` and the worker hosts would crash on startup at the eager `Apns:Enabled` validation.

The same `.p8` is used on both stacks; `UseSandbox` is automatically projected from `env` (dev → sandbox, prod → live).

Closes tc-g424. Unblocks a real APNs send path for tc-fqun.9 (TestFlight verification).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured push notification service credentials across development and production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->