### PR TITLE
fix(ios): correct API in Fastfile capability ops lanes (tc-tcih)

### DIFF
--- a/mobile/ios/fastlane/Fastfile
+++ b/mobile/ios/fastlane/Fastfile
@@ -95,7 +95,7 @@ platform :ios do
     # the beta lane consumes so CI plumbing stays identical.
     require "spaceship"
 
-    token = Spaceship::ConnectAPI::Token.create_from_hash(
+    token = Spaceship::ConnectAPI::Token.create(
       key_id: ENV.fetch("APP_STORE_CONNECT_API_KEY_ID"),
       issuer_id: ENV.fetch("APP_STORE_CONNECT_ISSUER_ID"),
       filepath: File.absolute_path(ENV.fetch("APP_STORE_CONNECT_API_KEY_PATH")),
@@ -137,6 +137,7 @@ platform :ios do
     match(
       api_key: api_key,
       type: "appstore",
+      readonly: false,
       force: true,
     )
   end


### PR DESCRIPTION
## Summary
- `enable_associated_domains` lane called `Spaceship::ConnectAPI::Token.create_from_hash` — that method doesn't exist. Switched to the documented `Token.create(key_id:, issuer_id:, filepath:)` constructor.
- `regenerate_appstore_profile` lane silently failed because `setup_ci` flips match into readonly mode, overriding the lane's `force: true`. Added explicit `readonly: false` so match can write the regenerated profile back to the certs repo.

Both lanes were added in tc-o1s3 / PR \"iOS Capability Ops\" but never test-dispatched before merging. First real attempts today (runs 25313269758 and 25313377957) surfaced the bugs and kept TestFlight blocked.

## Why this matters
TestFlight has been blocked since v0.13.0 (Universal Links shipped) — the AppStore provisioning profile doesn't include the Associated Domains capability. v0.13.0, v0.13.1, v0.13.2 all failed. These ops lanes are the unblock path.

## Test plan
- [x] `ruby -c mobile/ios/fastlane/Fastfile` — syntax OK
- [x] Verified `Token.create` signature against fastlane 2.233.1 source: `spaceship/lib/spaceship/connect_api/token.rb:52`
- [ ] After merge, dispatch `enable_associated_domains` then `regenerate_appstore_profile` via `gh workflow run "iOS Capability Ops"`
- [ ] Re-run failed v0.13.2 TestFlight and confirm `build_app` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved app provisioning profile management in the build process to enable regeneration of AppStore signing credentials when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->