### PR TITLE
fix(ios): use app_store_connect_api_key for spaceship token init (tc-tcih)

### DIFF
--- a/mobile/ios/fastlane/Fastfile
+++ b/mobile/ios/fastlane/Fastfile
@@ -91,16 +91,20 @@ platform :ios do
     # Run via workflow_dispatch only; do NOT wire into the beta lane.
     bundle_id = "uk.towncrierapp.mobile"
 
-    # Spaceship needs an App Store Connect API token. Reuse the same env vars
-    # the beta lane consumes so CI plumbing stays identical.
-    require "spaceship"
-
-    token = Spaceship::ConnectAPI::Token.create(
+    # The action sets Spaceship::ConnectAPI.token as a side effect (default
+    # set_spaceship_token: true), so direct Spaceship calls below can omit
+    # explicit token wiring. Going through the action also avoids hand-rolling
+    # the file-path resolution — fastlane chdir's into the Fastfile directory
+    # before running a lane, which doubled the relative path when we read the
+    # P8 ourselves.
+    app_store_connect_api_key(
       key_id: ENV.fetch("APP_STORE_CONNECT_API_KEY_ID"),
       issuer_id: ENV.fetch("APP_STORE_CONNECT_ISSUER_ID"),
-      filepath: File.absolute_path(ENV.fetch("APP_STORE_CONNECT_API_KEY_PATH")),
+      key_filepath: ENV.fetch("APP_STORE_CONNECT_API_KEY_PATH"),
+      in_house: false,
     )
-    Spaceship::ConnectAPI.token = token
+
+    require "spaceship"
 
     app = Spaceship::ConnectAPI::BundleId.find(bundle_id)
     UI.user_error!("Bundle ID #{bundle_id} not found in App Store Connect") if app.nil?


### PR DESCRIPTION
## Summary
Follow-up to #367. The previous fix corrected the Spaceship constructor name but left the underlying file-resolution bug: fastlane `chdir`s into the Fastfile directory before running a lane, so the relative env path \`fastlane/certs/AuthKey.p8\` resolved to \`mobile/ios/fastlane/fastlane/certs/AuthKey.p8\` (doubled \`fastlane/\`) and the load failed with ENOENT.

Switched \`enable_associated_domains\` to invoke the \`app_store_connect_api_key\` fastlane action (same as the beta lane). The action resolves the path against the project root *and* sets \`Spaceship::ConnectAPI.token\` as a side effect (default \`set_spaceship_token: true\`), so the manual token construction drops out entirely.

## Why this matters
Run 25316167263 surfaced the path bug right after #367 merged. TestFlight is still blocked.

## Test plan
- [x] `ruby -c Fastfile` — syntax OK
- [x] Verified \`app_store_connect_api_key\` sets \`Spaceship::ConnectAPI.token\` by default in fastlane 2.233.1
- [ ] After merge, dispatch \`enable_associated_domains\` then \`regenerate_appstore_profile\`
- [ ] Re-run failed v0.13.2 TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)