### PR TITLE
fix(ios): drop API key env before match in regen lane (tc-tcih)

### DIFF
--- a/mobile/ios/fastlane/Fastfile
+++ b/mobile/ios/fastlane/Fastfile
@@ -138,6 +138,12 @@ platform :ios do
 
     setup_ci if ENV["CI"]
 
+    # Match also reads APP_STORE_CONNECT_API_KEY_PATH (one of its api_key_path
+    # env_names). With api_key passed explicitly as a hash and api_key_path
+    # populated from the env, match's force: true codepath rejects the pair as
+    # conflicting_options. Drop the env so only the explicit hash remains.
+    ENV.delete("APP_STORE_CONNECT_API_KEY_PATH")
+
     match(
       api_key: api_key,
       type: "appstore",


### PR DESCRIPTION
## Summary
Follow-up to #368. \`enable_associated_domains\` now succeeds (run 25316415608: \"Enabled Associated Domains capability on uk.towncrierapp.mobile\"), but \`regenerate_appstore_profile\` still fails:

> [!] Unresolved conflict between options: 'api_key_path' and 'api_key'

\`match\`'s \`api_key_path\` config item lists \`APP_STORE_CONNECT_API_KEY_PATH\` as one of its env_names, and \`api_key_path\` declares \`api_key\` as a \`conflicting_option\`. With both populated (env → \`api_key_path\`, explicit hash → \`api_key\`) match's \`force: true\` codepath rejects the pair. The beta lane uses \`readonly: true\` and never hits the validation branch that surfaces the conflict — that's why this only fired when the regen lane ran.

After \`app_store_connect_api_key\` has consumed the env var, delete it so match sees only the explicit \`api_key\` hash.

## Test plan
- [x] \`ruby -c Fastfile\` — syntax OK
- [ ] After merge, dispatch \`regenerate_appstore_profile\` and confirm match writes the new profile to \`AmyDe/town-crier-ios-certs\`
- [ ] Re-run failed v0.13.2 TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)