### PR TITLE
docs(adr): amend 0008 and 0020 to match codebase (tc-rxeq)

### DIFF
--- a/docs/adr/0008-cosmos-db-data-model.md
+++ b/docs/adr/0008-cosmos-db-data-model.md
@@ -104,3 +104,13 @@ The Applications container change feed is consumed by the notification processor
 - Clarified: the `Leases` container mentioned in the original decision is provisioned in Pulumi (required historically for the Cosmos change-feed processor contemplated in [ADR 0009](0009-notification-delivery-architecture.md)) but is not currently populated — see the ADR 0009 2026-04-21 amendment for the actual notification dispatch path.
 - Clarified: `FailedNotifications` (referenced in ADR 0009) was never created as a container. Failed notifications are surfaced through OpenTelemetry counters rather than a dead-letter collection.
 - Total containers provisioned: **10** (Applications, Users, WatchZones, Notifications, Leases, DeviceRegistrations, SavedApplications, DecisionAlerts, PollState, OfferCodes).
+
+### 2026-05-15
+- Removed: **`DecisionAlerts`** container. The standalone decision-alert feed was folded into the regular `Notifications` container — decision updates are now emitted as ordinary notifications with a `decision-update` kind discriminator rather than living in a separate per-user feed. No domain entity, repository, or Pulumi container definition for `DecisionAlerts` remains.
+- Added: **`NotificationState`** container, partitioned by `/userId`. Holds a single watermark document per user that records the read-state cutoff (last-read timestamp / unread count) used by the iOS unread-dot/chip UX and the foreground badge sync. Point reads and upserts are scoped to the partition (one document per user). No TTL.
+
+| Container | Partition Key | Rationale |
+|-----------|--------------|-----------|
+| `NotificationState` | `/userId` | One read-state watermark document per user. Drives unread badge, unread chip, and iOS app-icon badge sync (see `BadgeSync` coordinator in `mobile/ios`). Single-partition point reads on login and on mark-all-read |
+
+- Total containers provisioned remains **10** (Applications, Users, WatchZones, Notifications, NotificationState, Leases, DeviceRegistrations, SavedApplications, PollState, OfferCodes). DecisionAlerts removed; NotificationState added.

--- a/docs/adr/0020-email-notifications-via-acs.md
+++ b/docs/adr/0020-email-notifications-via-acs.md
@@ -30,3 +30,14 @@ Weekly digests are triggered by a daily Container Apps Job (shared with the futu
 - Custom domain requires DNS verification records in Cloudflare (SPF, DKIM, DMARC)
 - ACS SDK dependency added to infrastructure layer — must verify Native AOT compatibility
 - If ACS SDK has AOT issues, fallback to direct REST API
+
+## Amendments
+
+### 2026-05-15
+- Corrected: the original Decision section says instant emails "fire inline with the existing change feed notification path." There is no change-feed processor (see [ADR 0009](0009-notification-delivery-architecture.md) 2026-04-21 amendment). Instant emails fire inline within the polling worker via `DispatchNotificationCommandHandler`.
+- Added: **Hourly digest** as a paid-tier email cadence. The original ADR only contemplated weekly digests for all tiers; an intermediate hourly cadence has since been introduced as a tier-gated feature.
+  - New handler: `GenerateHourlyDigestsCommandHandler` in the application layer.
+  - New Container Apps Job: `digest-hourly`, cron `0 * * * *` (top of every hour, both dev and prod), `WORKER_MODE=hourly-digest`, 300s replica timeout. Wired in `infra/EnvironmentStack.cs` alongside the existing daily `digest` job (`0 7 * * *`).
+  - New entitlement: `Entitlement.HourlyDigestEmails`. Mapped to **Personal** and **Pro** tiers only; **Free** tier is explicitly excluded (see `EntitlementMap` and its tests). Free-tier users continue to receive the weekly digest only.
+  - Worker dispatcher in `town-crier.worker/Program.cs` adds `hourly-digest` to the `WORKER_MODE` switch (alongside `poll-sb`, `poll-bootstrap`, `digest`, `dormant-cleanup`); unknown modes fail fast.
+- Cost impact: hourly cadence multiplies email volume for Personal/Pro digest subscribers by up to ~24x compared to weekly, but absolute volume is still well under ACS's free tier. No change to the SDK or wiring.


### PR DESCRIPTION
## Changes

ADR audit found two real drift items vs the live codebase:

- **ADR 0008 (Cosmos DB Data Model):** `DecisionAlerts` container was removed in PR #341 (folded into the regular `Notifications` container with a `decision-update` kind discriminator). `NotificationState` container was added in PR #376 — one read-state watermark document per user, drives unread badge/chip UX and iOS app-icon badge sync. Net container count remains 10.
- **ADR 0020 (Email Notifications via ACS):** hourly digest now exists as a paid-tier feature — new `GenerateHourlyDigestsCommandHandler`, `digest-hourly` Container Apps Job at `0 * * * *`, and a tier-gated `Entitlement.HourlyDigestEmails` for Personal/Pro only. Also corrected the stale "change feed notification path" wording in the original Decision section (no change-feed processor exists; dispatch is inline in the polling worker).

No other ADRs drifted. Cross-reference graph (supersedes/narrows) is still clean.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added hourly email digest option for Personal and Pro tier users.
  * Improved notification read-state tracking for better iOS app unread badge accuracy.

* **Documentation**
  * Updated architecture documentation with notification and email delivery refinements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmyDe/town-crier/pull/383)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->