### PR TITLE
docs(legal): switch controller to Ivo and the Bea Ltd (tc-7xa4)

### DIFF
--- a/api/src/town-crier.application/Legal/Resources/privacy.json
+++ b/api/src/town-crier.application/Legal/Resources/privacy.json
@@ -1,11 +1,11 @@
 {
   "documentType": "privacy",
   "title": "Privacy Policy",
-  "lastUpdated": "2026-04-20",
+  "lastUpdated": "2026-05-16",
   "sections": [
     {
       "heading": "Who We Are",
-      "body": "Town Crier is operated by Amy Salter, a sole trader based in the United Kingdom. We are the data controller for the personal information you give us. For any data query, write to privacy@towncrierapp.uk."
+      "body": "Town Crier is operated by Ivo and the Bea Ltd, a UK-registered company. We are the data controller for the personal information you give us. For any data query, write to privacy@towncrierapp.uk."
     },
     {
       "heading": "What We Collect",

--- a/api/tests/town-crier.application.tests/Legal/GetLegalDocumentQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Legal/GetLegalDocumentQueryHandlerTests.cs
@@ -14,7 +14,7 @@ public sealed class GetLegalDocumentQueryHandlerTests
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.DocumentType).IsEqualTo("privacy");
         await Assert.That(result.Title).IsEqualTo("Privacy Policy");
-        await Assert.That(result.LastUpdated).IsEqualTo("2026-04-20");
+        await Assert.That(result.LastUpdated).IsEqualTo("2026-05-16");
         await Assert.That(result.Sections).HasCount().EqualTo(10);
         await Assert.That(result.Sections[0].Heading).IsEqualTo("Who We Are");
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Resources/legal/privacy.json
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Resources/legal/privacy.json
@@ -1,11 +1,11 @@
 {
   "documentType": "privacy",
   "title": "Privacy Policy",
-  "lastUpdated": "2026-04-20",
+  "lastUpdated": "2026-05-16",
   "sections": [
     {
       "heading": "Who We Are",
-      "body": "Town Crier is operated by Amy Salter, a sole trader based in the United Kingdom. We are the data controller for the personal information you give us. For any data query, write to privacy@towncrierapp.uk."
+      "body": "Town Crier is operated by Ivo and the Bea Ltd, a UK-registered company. We are the data controller for the personal information you give us. For any data query, write to privacy@towncrierapp.uk."
     },
     {
       "heading": "What We Collect",


### PR DESCRIPTION
## Changes
- Replace "Amy Salter, a sole trader based in the United Kingdom" with "Ivo and the Bea Ltd, a UK-registered company" in privacy.json
- Bump `lastUpdated` to 2026-05-16
- Mirror to iOS bundle via `scripts/sync-legal.sh`

Apple developer account is moving from individual to business. Registered office intentionally omitted — Companies House is the public source of truth; privacy@towncrierapp.uk remains the contact channel.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Privacy policy updated with new effective date (2026-05-16)
  * Updated operator information in the privacy policy

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmyDe/town-crier/pull/386?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->