### PR TITLE
fix(copy): remove AI writing tells from legal docs and UI strings

### DIFF
--- a/api/src/town-crier.application/Legal/Resources/privacy.json
+++ b/api/src/town-crier.application/Legal/Resources/privacy.json
@@ -1,7 +1,7 @@
 {
   "documentType": "privacy",
   "title": "Privacy Policy",
-  "lastUpdated": "2026-05-16",
+  "lastUpdated": "2026-05-17",
   "sections": [
     {
       "heading": "Who We Are",
@@ -9,7 +9,7 @@
     },
     {
       "heading": "What We Collect",
-      "body": "We keep the collection small. We store your email address (from sign-in), a unique user ID, and the notification preferences you choose. For each area you want to watch we store a label, coordinates, and a radius — not your exact address. We keep a short-lived history of the alerts we've sent you (new applications and decisions), and a list of the applications you've saved for later. If you subscribe we store an Apple App Store transaction ID so we know your tier; we never see your payment details. If you redeem an offer code, we record which code you redeemed and when. On iOS we store a push token so we can deliver notifications to your device."
+      "body": "We keep the collection small. We store your email address (from sign-in), a unique user ID, and the notification preferences you choose. For each area you want to watch we store a label, coordinates, and a radius, not your exact address. We keep a short-lived history of the alerts we've sent you (new applications and decisions), and a list of the applications you've saved for later. If you subscribe we store an Apple App Store transaction ID so we know your tier; we never see your payment details. If you redeem an offer code, we record which code you redeemed and when. On iOS we store a push token so we can deliver notifications to your device."
     },
     {
       "heading": "Why We Collect It",
@@ -17,11 +17,11 @@
     },
     {
       "heading": "Who Processes Your Data for Us",
-      "body": "We use Microsoft Azure to host the service. Your account, watch zones, notifications, and email delivery run on Azure services based in the UK (Cosmos DB, Container Apps, Communication Services, Application Insights). Our website is served from Azure Static Web Apps in the European Union; this serves the site's HTML, CSS, and JavaScript only, and none of your account data is stored there. We use Auth0 (an Okta company) for sign-in; Auth0 stores your email address and credentials in the United Kingdom. We use Apple's Push Notification Service to deliver iOS alerts, and Apple's App Store to handle subscription billing. We use postcodes.io (UK-hosted) to convert postcodes to coordinates, and the UK Government's Planning Data service (planning.data.gov.uk) to look up conservation areas, listed buildings, and other planning designations near an application — we only send coordinates, no personal data. On the web, map tiles are fetched directly from OpenStreetMap when you view a map. We use PlanIt (planit.org.uk) as our source of planning data; we only read from them, we do not send them any of your information."
+      "body": "We use Microsoft Azure to host the service. Your account, watch zones, notifications, and email delivery run on Azure services based in the UK (Cosmos DB, Container Apps, Communication Services, Application Insights). Our website is served from Azure Static Web Apps in the European Union; this serves the site's HTML, CSS, and JavaScript only, and none of your account data is stored there. We use Auth0 (an Okta company) for sign-in; Auth0 stores your email address and credentials in the United Kingdom. We use Apple's Push Notification Service to deliver iOS alerts, and Apple's App Store to handle subscription billing. We use postcodes.io (UK-hosted) to convert postcodes to coordinates, and the UK Government's Planning Data service (planning.data.gov.uk) to look up conservation areas, listed buildings, and other planning designations near an application (we only send coordinates, no personal data). On the web, map tiles are fetched directly from OpenStreetMap when you view a map. We use PlanIt (planit.org.uk) as our source of planning data; we only read from them, we do not send them any of your information."
     },
     {
       "heading": "International Transfers",
-      "body": "Most of your data stays in the United Kingdom. Apple's Push Notification Service and App Store operate in the United States under Apple's own transfer safeguards. Azure Static Web Apps, which serves our website, is in the European Union, which the UK recognises as providing adequate data protection. Some of our UK-based processors — notably Microsoft Azure and Auth0 — are subsidiaries of United States companies. Although your data is stored and processed in the UK, a US parent company could in principle receive a legal demand from US authorities. Both providers publish Data Processing Agreements committing to notify us of, and contest, any such demand where legally permitted. You can request a copy of those agreements by writing to privacy@towncrierapp.uk."
+      "body": "Most of your data stays in the United Kingdom. Apple's Push Notification Service and App Store operate in the United States under Apple's own transfer safeguards. Azure Static Web Apps, which serves our website, is in the European Union, which the UK recognises as providing adequate data protection. Some of our UK-based processors, notably Microsoft Azure and Auth0, are subsidiaries of United States companies. Although your data is stored and processed in the UK, a US parent company could in principle receive a legal demand from US authorities. Both providers publish Data Processing Agreements committing to notify us of, and contest, any such demand where legally permitted. You can request a copy of those agreements by writing to privacy@towncrierapp.uk."
     },
     {
       "heading": "Cookies and Similar Storage",
@@ -29,7 +29,7 @@
     },
     {
       "heading": "How Long We Keep It",
-      "body": "Your notifications and decision alerts are automatically deleted after 90 days. We remove iOS push tokens when Apple tells us they're no longer valid. Everything else — your account, watch zones, saved applications, preferences, and subscription status — is kept for as long as your account exists. You can delete your account at any time from the app settings, which removes your profile, preferences, watch zones, notifications, saved applications, and device registrations from our systems."
+      "body": "Your notifications and decision alerts are automatically deleted after 90 days. We remove iOS push tokens when Apple tells us they're no longer valid. Everything else (your account, watch zones, saved applications, preferences, and subscription status) is kept for as long as your account exists. You can delete your account at any time from the app settings, which removes your profile, preferences, watch zones, notifications, saved applications, and device registrations from our systems."
     },
     {
       "heading": "Your Rights Under UK GDPR",

--- a/api/tests/town-crier.application.tests/Legal/GetLegalDocumentQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Legal/GetLegalDocumentQueryHandlerTests.cs
@@ -14,7 +14,7 @@ public sealed class GetLegalDocumentQueryHandlerTests
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.DocumentType).IsEqualTo("privacy");
         await Assert.That(result.Title).IsEqualTo("Privacy Policy");
-        await Assert.That(result.LastUpdated).IsEqualTo("2026-05-16");
+        await Assert.That(result.LastUpdated).IsEqualTo("2026-05-17");
         await Assert.That(result.Sections).HasCount().EqualTo(10);
         await Assert.That(result.Sections[0].Heading).IsEqualTo("Who We Are");
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/LargeRadiusWarningView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/LargeRadiusWarningView.swift
@@ -25,7 +25,7 @@ public struct LargeRadiusWarningView: View {
         .accessibilityHidden(true)
 
       VStack(alignment: .leading, spacing: TCSpacing.extraSmall) {
-        Text("Heads up — large zones get noisy")
+        Text("Heads up: large zones get noisy")
           .font(TCTypography.bodyEmphasis)
           .foregroundStyle(Color.tcTextPrimary)
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Resources/legal/privacy.json
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Resources/legal/privacy.json
@@ -1,7 +1,7 @@
 {
   "documentType": "privacy",
   "title": "Privacy Policy",
-  "lastUpdated": "2026-05-16",
+  "lastUpdated": "2026-05-17",
   "sections": [
     {
       "heading": "Who We Are",
@@ -9,7 +9,7 @@
     },
     {
       "heading": "What We Collect",
-      "body": "We keep the collection small. We store your email address (from sign-in), a unique user ID, and the notification preferences you choose. For each area you want to watch we store a label, coordinates, and a radius — not your exact address. We keep a short-lived history of the alerts we've sent you (new applications and decisions), and a list of the applications you've saved for later. If you subscribe we store an Apple App Store transaction ID so we know your tier; we never see your payment details. If you redeem an offer code, we record which code you redeemed and when. On iOS we store a push token so we can deliver notifications to your device."
+      "body": "We keep the collection small. We store your email address (from sign-in), a unique user ID, and the notification preferences you choose. For each area you want to watch we store a label, coordinates, and a radius, not your exact address. We keep a short-lived history of the alerts we've sent you (new applications and decisions), and a list of the applications you've saved for later. If you subscribe we store an Apple App Store transaction ID so we know your tier; we never see your payment details. If you redeem an offer code, we record which code you redeemed and when. On iOS we store a push token so we can deliver notifications to your device."
     },
     {
       "heading": "Why We Collect It",
@@ -17,11 +17,11 @@
     },
     {
       "heading": "Who Processes Your Data for Us",
-      "body": "We use Microsoft Azure to host the service. Your account, watch zones, notifications, and email delivery run on Azure services based in the UK (Cosmos DB, Container Apps, Communication Services, Application Insights). Our website is served from Azure Static Web Apps in the European Union; this serves the site's HTML, CSS, and JavaScript only, and none of your account data is stored there. We use Auth0 (an Okta company) for sign-in; Auth0 stores your email address and credentials in the United Kingdom. We use Apple's Push Notification Service to deliver iOS alerts, and Apple's App Store to handle subscription billing. We use postcodes.io (UK-hosted) to convert postcodes to coordinates, and the UK Government's Planning Data service (planning.data.gov.uk) to look up conservation areas, listed buildings, and other planning designations near an application — we only send coordinates, no personal data. On the web, map tiles are fetched directly from OpenStreetMap when you view a map. We use PlanIt (planit.org.uk) as our source of planning data; we only read from them, we do not send them any of your information."
+      "body": "We use Microsoft Azure to host the service. Your account, watch zones, notifications, and email delivery run on Azure services based in the UK (Cosmos DB, Container Apps, Communication Services, Application Insights). Our website is served from Azure Static Web Apps in the European Union; this serves the site's HTML, CSS, and JavaScript only, and none of your account data is stored there. We use Auth0 (an Okta company) for sign-in; Auth0 stores your email address and credentials in the United Kingdom. We use Apple's Push Notification Service to deliver iOS alerts, and Apple's App Store to handle subscription billing. We use postcodes.io (UK-hosted) to convert postcodes to coordinates, and the UK Government's Planning Data service (planning.data.gov.uk) to look up conservation areas, listed buildings, and other planning designations near an application (we only send coordinates, no personal data). On the web, map tiles are fetched directly from OpenStreetMap when you view a map. We use PlanIt (planit.org.uk) as our source of planning data; we only read from them, we do not send them any of your information."
     },
     {
       "heading": "International Transfers",
-      "body": "Most of your data stays in the United Kingdom. Apple's Push Notification Service and App Store operate in the United States under Apple's own transfer safeguards. Azure Static Web Apps, which serves our website, is in the European Union, which the UK recognises as providing adequate data protection. Some of our UK-based processors — notably Microsoft Azure and Auth0 — are subsidiaries of United States companies. Although your data is stored and processed in the UK, a US parent company could in principle receive a legal demand from US authorities. Both providers publish Data Processing Agreements committing to notify us of, and contest, any such demand where legally permitted. You can request a copy of those agreements by writing to privacy@towncrierapp.uk."
+      "body": "Most of your data stays in the United Kingdom. Apple's Push Notification Service and App Store operate in the United States under Apple's own transfer safeguards. Azure Static Web Apps, which serves our website, is in the European Union, which the UK recognises as providing adequate data protection. Some of our UK-based processors, notably Microsoft Azure and Auth0, are subsidiaries of United States companies. Although your data is stored and processed in the UK, a US parent company could in principle receive a legal demand from US authorities. Both providers publish Data Processing Agreements committing to notify us of, and contest, any such demand where legally permitted. You can request a copy of those agreements by writing to privacy@towncrierapp.uk."
     },
     {
       "heading": "Cookies and Similar Storage",
@@ -29,7 +29,7 @@
     },
     {
       "heading": "How Long We Keep It",
-      "body": "Your notifications and decision alerts are automatically deleted after 90 days. We remove iOS push tokens when Apple tells us they're no longer valid. Everything else — your account, watch zones, saved applications, preferences, and subscription status — is kept for as long as your account exists. You can delete your account at any time from the app settings, which removes your profile, preferences, watch zones, notifications, saved applications, and device registrations from our systems."
+      "body": "Your notifications and decision alerts are automatically deleted after 90 days. We remove iOS push tokens when Apple tells us they're no longer valid. Everything else (your account, watch zones, saved applications, preferences, and subscription status) is kept for as long as your account exists. You can delete your account at any time from the app settings, which removes your profile, preferences, watch zones, notifications, saved applications, and device registrations from our systems."
     },
     {
       "heading": "Your Rights Under UK GDPR",

--- a/web/src/components/Faq/Faq.tsx
+++ b/web/src/components/Faq/Faq.tsx
@@ -9,12 +9,12 @@ const FAQ_ITEMS: FaqItem[] = [
   {
     question: 'Where does the data come from?',
     answer:
-      'Town Crier sources its data from PlanIt (planit.org.uk), the UK\u2019s most comprehensive aggregator of planning application data. We poll local authority feeds regularly so you see new applications shortly after they\u2019re published.',
+      'Town Crier sources its data from PlanIt (planit.org.uk), the UK\u2019s leading aggregator of planning application data. We poll local authority feeds regularly so you see new applications shortly after they\u2019re published.',
   },
   {
     question: 'Which areas do you cover?',
     answer:
-      'We cover local planning authorities across England, Scotland, and Wales. Coverage is expanding \u2014 if your area isn\u2019t listed yet, let us know and we\u2019ll prioritise it.',
+      'We cover local planning authorities across England, Scotland, and Wales. Coverage is expanding. If your area isn\u2019t listed yet, let us know and we\u2019ll prioritise it.',
   },
   {
     question: 'Is there a free tier?',

--- a/web/src/components/Hero/Hero.tsx
+++ b/web/src/components/Hero/Hero.tsx
@@ -11,7 +11,7 @@ export function Hero() {
       </h1>
       <p className={styles.subheading}>
         Monitoring planning applications across 417 local authorities in England
-        and Wales — so you don&apos;t have to.
+        and Wales, so you don&apos;t have to.
       </p>
       <div className={styles.ctaGroup}>
         <a

--- a/web/src/components/HowItWorks/HowItWorks.tsx
+++ b/web/src/components/HowItWorks/HowItWorks.tsx
@@ -17,7 +17,7 @@ const STEPS: Step[] = [
     icon: '🔭',
     title: 'Create a watch zone',
     description:
-      'Draw a circle around the area you care about — your street, neighbourhood, or an entire ward. You choose the radius.',
+      'Draw a circle around the area you care about: your street, neighbourhood, or an entire ward. You choose the radius.',
   },
   {
     icon: '🔔',

--- a/web/src/components/LargeRadiusWarning/LargeRadiusWarning.tsx
+++ b/web/src/components/LargeRadiusWarning/LargeRadiusWarning.tsx
@@ -23,7 +23,7 @@ export function LargeRadiusWarning({ radiusMetres }: Props) {
         !
       </span>
       <div className={styles.copy}>
-        <p className={styles.title}>Heads up — large zones get noisy</p>
+        <p className={styles.title}>Heads up: large zones get noisy</p>
         <p className={styles.body}>
           A wide watch zone can produce hundreds of notifications a day, especially in
           cities. We recommend 100–500m in built-up areas, and under 2km everywhere


### PR DESCRIPTION
## Changes
- `docs(legal): swap em-dashes for commas/parens in privacy copy (tc-njlv)` — 4 em-dashes in the privacy policy replaced with commas/parens. iOS bundle re-synced via `scripts/sync-legal.sh`. `lastUpdated` bumped to 2026-05-17. No substantive change to the policy.
- `fix(copy): remove AI writing tells from web and iOS UI strings (tc-cc2z)` — Hero, HowItWorks, FAQ, and the LargeRadiusWarning (web + iOS) cleaned of em-dashes used for parenthetical asides. FAQ "most comprehensive" → "leading". Number-range en-dashes (100–500 m, 2 km) and the pricing-table — placeholder kept (correct typography).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Privacy policy updated with current date and minor content refinements.

* **Content Updates**
  * FAQ enhanced with clearer messaging about data sourcing and coverage expansion opportunities.
  * Hero section messaging refined to clarify England and Wales service coverage.
  * Instructional text improved with standardized formatting across platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmyDe/town-crier/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->