### PR TITLE
fix(ios): persist session across access-token expiry via canRenew() (tc-funq)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/Auth/Auth0AuthenticationService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Auth/Auth0AuthenticationService.swift
@@ -69,8 +69,12 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
     do {
       let credentials = try await credentialsManager.credentials()
       return mapToSession(credentials)
+    } catch let error as CredentialsManagerError {
+      if Self.isUnrecoverable(error) {
+        _ = credentialsManager.clear()
+      }
+      throw DomainError.sessionExpired
     } catch {
-      _ = credentialsManager.clear()
       throw DomainError.sessionExpired
     }
   }
@@ -85,7 +89,11 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
   }
 
   public func currentSession() async -> AuthSession? {
-    guard credentialsManager.hasValid() else {
+    // `hasValid()` only checks access-token expiry. Per Auth0 SDK docs, apps
+    // using refresh tokens must also consult `canRenew()` at startup —
+    // otherwise an expired access token forces a fresh login even though
+    // the refresh token is still valid (tc-funq).
+    guard credentialsManager.canRenew() || credentialsManager.hasValid() else {
       return nil
     }
 
@@ -94,6 +102,24 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
       return mapToSession(credentials)
     } catch {
       return nil
+    }
+  }
+
+  /// Whether a credentials-manager failure means the refresh token is
+  /// permanently unusable. Only these failures justify wiping the keychain;
+  /// transient errors (network, biometrics, store failures) must not force
+  /// the user to re-authenticate.
+  private static func isUnrecoverable(_ error: CredentialsManagerError) -> Bool {
+    switch error {
+    case .noRefreshToken, .noCredentials:
+      return true
+    case .renewFailed, .apiExchangeFailed, .ssoExchangeFailed:
+      if let cause = error.cause as? AuthenticationError {
+        return cause.isInvalidRefreshToken || cause.isRefreshTokenDeleted
+      }
+      return false
+    default:
+      return false
     }
   }
 


### PR DESCRIPTION
## Changes
- `Auth0AuthenticationService.currentSession()` now uses `canRenew() || hasValid()` so an expired access token with a valid refresh token still restores the session. Auth0 SDK docs are explicit that apps using refresh tokens must consult `canRenew()` at startup — `hasValid()` only checks the access-token expiry. Tenant logs confirm the symptom: zero `seccft` (refresh-token exchange) events for the iOS client.
- `refreshSession()` no longer clears the keychain on every thrown error. Transient errors (network, biometrics, store failures) used to wipe credentials and force re-authentication. Now restricted to permanent failures: `noRefreshToken`, `noCredentials`, and `renewFailed`/`apiExchangeFailed`/`ssoExchangeFailed` where the underlying `AuthenticationError` reports `isInvalidRefreshToken` or `isRefreshTokenDeleted`.

User-visible effect: users who leave the app overnight will no longer be forced through Universal Login on the next open.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session management reliability with enhanced error handling for authentication failures.
  * Refined session validation to more accurately determine active session status.
  * Better recovery handling for unrecoverable credential errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmyDe/town-crier/pull/388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->