### PR TITLE
fix(ios): push-tap crash + mark-all-read stale chip + Auth0 keychain caching

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/Auth/Auth0AuthenticationService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Auth/Auth0AuthenticationService.swift
@@ -23,6 +23,10 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
   @unchecked Sendable {
   private let config: Auth0Config
   private let credentialsManager: CredentialsManager
+  /// In-memory session cache that lets a foreground burst share a single
+  /// keychain read. See `SessionCache` for the contention rationale
+  /// (tc-3d7b).
+  private let sessionCache = SessionCache()
 
   public init(config: Auth0Config) {
     self.config = config
@@ -44,8 +48,9 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
         .start()
 
       _ = credentialsManager.store(credentials: credentials)
-
-      return mapToSession(credentials)
+      let session = Self.mapToSession(credentials)
+      await sessionCache.store(session)
+      return session
     } catch let error as WebAuthError {
       if case .userCancelled = error {
         throw DomainError.authenticationFailed("cancelled")
@@ -60,6 +65,7 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
     do {
       try await Auth0.webAuth(clientId: config.clientId, domain: config.domain).clearSession()
       _ = credentialsManager.clear()
+      await sessionCache.clear()
     } catch {
       throw DomainError.logoutFailed(error.localizedDescription)
     }
@@ -68,10 +74,13 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
   public func refreshSession() async throws -> AuthSession {
     do {
       let credentials = try await credentialsManager.credentials()
-      return mapToSession(credentials)
+      let session = Self.mapToSession(credentials)
+      await sessionCache.store(session)
+      return session
     } catch let error as CredentialsManagerError {
       if Self.isUnrecoverable(error) {
         _ = credentialsManager.clear()
+        await sessionCache.clear()
       }
       throw DomainError.sessionExpired
     } catch {
@@ -83,25 +92,36 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
     do {
       try await Auth0.webAuth(clientId: config.clientId, domain: config.domain).clearSession()
       _ = credentialsManager.clear()
+      await sessionCache.clear()
     } catch {
       throw DomainError.logoutFailed(error.localizedDescription)
     }
   }
 
   public func currentSession() async -> AuthSession? {
-    // `hasValid()` only checks access-token expiry. Per Auth0 SDK docs, apps
-    // using refresh tokens must also consult `canRenew()` at startup —
-    // otherwise an expired access token forces a fresh login even though
-    // the refresh token is still valid (tc-funq).
-    guard credentialsManager.canRenew() || credentialsManager.hasValid() else {
-      return nil
+    // Fast path: in-memory cache. Most foreground bursts hit this and skip
+    // securityd entirely (tc-3d7b).
+    if let cached = await sessionCache.current() {
+      return cached
     }
 
-    do {
-      let credentials = try await credentialsManager.credentials()
-      return mapToSession(credentials)
-    } catch {
-      return nil
+    // Slow path: consult the keychain. `currentOrLoad` deduplicates
+    // concurrent callers so a four-way burst with a cold cache still
+    // issues at most one `SecItemCopyMatching`.
+    return await sessionCache.currentOrLoad { [credentialsManager] in
+      // `hasValid()` only checks access-token expiry. Per Auth0 SDK docs,
+      // apps using refresh tokens must also consult `canRenew()` at
+      // startup — otherwise an expired access token forces a fresh login
+      // even though the refresh token is still valid (tc-funq).
+      guard credentialsManager.canRenew() || credentialsManager.hasValid() else {
+        return nil
+      }
+      do {
+        let credentials = try await credentialsManager.credentials()
+        return Self.mapToSession(credentials)
+      } catch {
+        return nil
+      }
     }
   }
 
@@ -123,7 +143,7 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
     }
   }
 
-  private func mapToSession(_ credentials: Credentials) -> AuthSession {
+  private static func mapToSession(_ credentials: Credentials) -> AuthSession {
     let profile = UserProfile(
       userId: extractUserId(from: credentials) ?? credentials.idToken,
       email: extractEmail(from: credentials) ?? "",
@@ -143,17 +163,17 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
     )
   }
 
-  private func extractUserId(from credentials: Credentials) -> String? {
+  private static func extractUserId(from credentials: Credentials) -> String? {
     JWTSubscriptionTierExtractor.extractSubject(from: credentials.idToken)
   }
 
-  private func extractEmail(from credentials: Credentials) -> String? {
+  private static func extractEmail(from credentials: Credentials) -> String? {
     guard let jwt = JWTSubscriptionTierExtractor.decodePayload(from: credentials.idToken)
     else { return nil }
     return jwt["email"] as? String
   }
 
-  private func extractName(from credentials: Credentials) -> String? {
+  private static func extractName(from credentials: Credentials) -> String? {
     guard let jwt = JWTSubscriptionTierExtractor.decodePayload(from: credentials.idToken)
     else { return nil }
     return jwt["name"] as? String

--- a/mobile/ios/packages/town-crier-data/Sources/Auth/SessionCache.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Auth/SessionCache.swift
@@ -1,0 +1,91 @@
+import Foundation
+import TownCrierDomain
+
+/// Thread-safe in-memory cache for the current Auth0 session.
+///
+/// `Auth0AuthenticationService.currentSession()` was hitting
+/// `SimpleKeychain.data(forKey:)` -> `SecItemCopyMatching` -> securityd on
+/// every call, via `CredentialsManager.canRenew()` / `hasValid()` /
+/// `credentials()`. Concurrent foreground bursts (e.g. a push tap arriving
+/// while `LoginViewModel.checkExistingSession` and
+/// `AppCoordinator.resolveSubscriptionTier` are already in flight) caused
+/// four-way contention on securityd's connection pool, adding tens to
+/// hundreds of milliseconds to cold-launch latency and amplifying the
+/// resumption gap that drove the tc-cbmk notification-tap crash.
+///
+/// This cache holds the most recent valid `AuthSession` in memory. When the
+/// session's access token has at least `leadTime` seconds before
+/// `expiresAt`, callers get the cached value without touching the keychain.
+/// Concurrent callers on a cold cache share a single in-flight load via
+/// `currentOrLoad`, so a four-way burst issues at most one
+/// `SecItemCopyMatching` (tc-3d7b).
+actor SessionCache {
+  private var cached: AuthSession?
+  private var inFlight: Task<AuthSession?, Never>?
+  private let leadTime: TimeInterval
+  private let now: @Sendable () -> Date
+
+  /// - Parameters:
+  ///   - leadTime: How many seconds before `expiresAt` to consider the
+  ///     cache stale. Mirrors Auth0's default 60-second renewal window so
+  ///     we hand off to `CredentialsManager` before the access token
+  ///     genuinely expires.
+  ///   - now: Clock override for tests.
+  init(
+    leadTime: TimeInterval = 60,
+    now: @Sendable @escaping () -> Date = { Date() }
+  ) {
+    self.leadTime = leadTime
+    self.now = now
+  }
+
+  /// Returns a cached session if one is held and its access token is still
+  /// at least `leadTime` seconds before `expiresAt`. Otherwise returns nil
+  /// without populating the cache — callers should use `currentOrLoad` to
+  /// fetch fresh credentials.
+  func current() -> AuthSession? {
+    guard let cached else { return nil }
+    if cached.expiresAt.addingTimeInterval(-leadTime) > now() {
+      return cached
+    }
+    return nil
+  }
+
+  /// Returns the cached session if valid, otherwise invokes `loader` and
+  /// caches the result. Concurrent callers on a cold cache share the same
+  /// in-flight load — this is the single-flight behaviour that prevents
+  /// a foreground burst from issuing N keychain reads for the same token.
+  func currentOrLoad(
+    _ loader: @Sendable @escaping () async -> AuthSession?
+  ) async -> AuthSession? {
+    if let valid = current() {
+      return valid
+    }
+    if let inFlight {
+      return await inFlight.value
+    }
+    let task = Task<AuthSession?, Never> {
+      await loader()
+    }
+    inFlight = task
+    let result = await task.value
+    cached = result
+    inFlight = nil
+    return result
+  }
+
+  /// Stores `session` as the current cached value. Used by `login` and
+  /// `refreshSession` after a successful network round-trip so the next
+  /// `currentSession()` short-circuits the keychain.
+  func store(_ session: AuthSession) {
+    cached = session
+  }
+
+  /// Drops the cached session and cancels any in-flight load. Called from
+  /// `logout`, `deleteAccount`, and unrecoverable refresh failures.
+  func clear() {
+    cached = nil
+    inFlight?.cancel()
+    inFlight = nil
+  }
+}

--- a/mobile/ios/packages/town-crier-data/Sources/Persistence/InMemoryApplicationCacheStore.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Persistence/InMemoryApplicationCacheStore.swift
@@ -18,4 +18,8 @@ public actor InMemoryApplicationCacheStore: ApplicationCacheStore {
   public func invalidate(for zoneId: WatchZoneId) {
     entries.removeValue(forKey: zoneId.value)
   }
+
+  public func invalidateAll() {
+    entries.removeAll()
+  }
 }

--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/OfflineAwareRepository.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/OfflineAwareRepository.swift
@@ -60,4 +60,17 @@ public final class OfflineAwareRepository: Sendable {
   public func invalidateCache(for zoneId: WatchZoneId) async {
     await cache.invalidate(for: zoneId)
   }
+
+  /// Invalidates every cached zone.
+  ///
+  /// Callers should invoke this after a global state mutation that affects
+  /// every zone's view of applications — e.g. mark-all-read, where the
+  /// server advances the unread watermark so each row's
+  /// `latestUnreadEvent` becomes `nil`. Without invalidation, a TTL-fresh
+  /// per-zone cache hit would keep serving the old unread flags for up to
+  /// the cache TTL, leaving the `Unread (N)` chip stuck on the prior count
+  /// (tc-e3bu).
+  public func invalidateAllCaches() async {
+    await cache.invalidateAll()
+  }
 }

--- a/mobile/ios/packages/town-crier-domain/Sources/Protocols/ApplicationCacheStore.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Protocols/ApplicationCacheStore.swift
@@ -10,4 +10,13 @@ public protocol ApplicationCacheStore: Sendable {
   /// changes, otherwise a fresh-cache hit can outlive the change for up to
   /// the cache TTL and serve applications matching the previous geometry.
   func invalidate(for zoneId: WatchZoneId) async
+
+  /// Removes every cached entry, regardless of zone.
+  ///
+  /// Used after a global state mutation that affects every zone's view of
+  /// applications — e.g. mark-all-read, where the server-side watermark
+  /// advance changes each row's `latestUnreadEvent` and a TTL-fresh cache
+  /// hit would otherwise serve stale unread flags for up to the cache TTL
+  /// (tc-e3bu).
+  func invalidateAll() async
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -244,6 +244,12 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   /// to `nil` (which in turn zeros `unreadCount` via the computed property).
   /// Repository failures are swallowed — a subsequent fetch will reconcile
   /// any drift. Spec decision #8 (silent optimistic).
+  ///
+  /// When backed by an `OfflineAwareRepository`, every cached zone is
+  /// invalidated before the refetch — mark-all-read is a global mutation
+  /// and a TTL-fresh per-zone cache hit would otherwise keep returning
+  /// rows with the old `latestUnreadEvent`, leaving the `Unread (N)` chip
+  /// stuck on the prior count (tc-e3bu).
   public func markAllRead() async {
     guard let notificationStateRepository else { return }
     do {
@@ -251,6 +257,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     } catch {
       // Swallow — optimistic UI per spec decision #8.
     }
+    await offlineRepository?.invalidateAllCaches()
     guard let activeZone = selectedZone ?? zone else { return }
     do {
       applications = try await fetchApplications(for: activeZone)

--- a/mobile/ios/town-crier-app/Sources/NotificationDelegate.swift
+++ b/mobile/ios/town-crier-app/Sources/NotificationDelegate.swift
@@ -17,8 +17,13 @@ import UserNotifications
 /// inheritance carry the body is Apple's WWDC23 guidance for
 /// `UNUserNotificationCenterDelegate` async overloads on a `@MainActor`
 /// class. Do not reintroduce `nonisolated` here.
+///
+/// The `@preconcurrency` on the conformance suppresses the strict-
+/// concurrency diagnostic that `UNUserNotificationCenter` /
+/// `UNNotificationResponse` are not `Sendable` — they are passed in by
+/// UIKit on the main thread already, so the actor crossing is safe.
 @MainActor
-final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+final class NotificationDelegate: NSObject, @preconcurrency UNUserNotificationCenterDelegate {
   let coordinator: AppCoordinator
 
   init(coordinator: AppCoordinator) {

--- a/mobile/ios/town-crier-app/Sources/NotificationDelegate.swift
+++ b/mobile/ios/town-crier-app/Sources/NotificationDelegate.swift
@@ -1,56 +1,49 @@
 import TownCrierPresentation
 import UserNotifications
 
-/// Handles notification tap responses for both cold launch and background scenarios.
+/// Handles notification tap responses for both cold launch and background
+/// scenarios.
 ///
-/// Both `userNotificationCenter` overloads are declared `nonisolated async`
-/// because the conforming protocol API is not isolated to MainActor. Swift's
-/// compiler-synthesized `@objc` thunk calls the original ObjC
-/// `withCompletionHandler:` selector when the function returns; UIKit asserts
-/// that completion runs on the main thread. We therefore wrap each body in
-/// `await MainActor.run { ... }` so the function always returns on MainActor
-/// regardless of which path is taken (tc-fcwv).
+/// The class is `@MainActor`; both delegate overloads inherit that isolation
+/// (no `nonisolated`). Swift's compiler-synthesized `@objc` thunk that
+/// bridges the `async` return to the original `withCompletionHandler:` ObjC
+/// selector then fires on the main thread deterministically — which is what
+/// UIKit's `UNUserNotificationCenter` asserts (tc-cbmk).
+///
+/// The prior shape (tc-fcwv) used `nonisolated async` + `await MainActor.run`
+/// to hop back to main inside the body. That left a gap: the @objc thunk's
+/// completion still fired on whatever cooperative thread the runtime resumed
+/// us on. Removing `nonisolated` and letting class-level MainActor
+/// inheritance carry the body is Apple's WWDC23 guidance for
+/// `UNUserNotificationCenterDelegate` async overloads on a `@MainActor`
+/// class. Do not reintroduce `nonisolated` here.
 @MainActor
 final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
-  private let coordinator: AppCoordinator
+  let coordinator: AppCoordinator
 
   init(coordinator: AppCoordinator) {
     self.coordinator = coordinator
   }
 
   /// Called when the user taps a notification (cold launch or background).
-  nonisolated func userNotificationCenter(
+  /// Forwards the APNs `userInfo` payload to `AppCoordinator.handlePushTap`,
+  /// which parses the deep link and the watermark instant independently.
+  /// Each branch is no-oppable: digest pushes carry neither field, older
+  /// builds may omit `createdAt`.
+  func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     didReceive response: UNNotificationResponse
   ) async {
-    // Parse the (non-Sendable) userInfo on the calling actor into Sendable
-    // values, then hop to MainActor. The hop must run unconditionally —
-    // even when neither a deep link nor a createdAt surfaces — because
-    // Swift's synthesized @objc thunk fires the original ObjC completion
-    // handler when this function returns, and UIKit asserts that
-    // completion runs on the main thread (tc-fcwv).
-    let userInfo = response.notification.request.content.userInfo
-    let deepLink = NotificationPayloadParser.parseDeepLink(from: userInfo)
-    let createdAt = NotificationPayloadParser.parseCreatedAt(from: userInfo)
-    await MainActor.run {
-      // Each branch is independently no-oppable when the payload omits
-      // the relevant field (tc-1nsa.9).
-      if let deepLink {
-        coordinator.handleDeepLink(deepLink)
-      }
-      if let createdAt {
-        coordinator.advanceWatermark(asOf: createdAt)
-      }
-    }
+    coordinator.handlePushTap(
+      userInfo: response.notification.request.content.userInfo
+    )
   }
 
   /// Show notification banners when the app is in the foreground.
-  nonisolated func userNotificationCenter(
+  func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     willPresent notification: UNNotification
   ) async -> UNNotificationPresentationOptions {
-    await MainActor.run {
-      [.banner, .sound]
-    }
+    [.banner, .sound]
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelMarkAllReadCacheTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelMarkAllReadCacheTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Cache-invalidation contract for `ApplicationListViewModel.markAllRead`
+/// when backed by an `OfflineAwareRepository` (tc-e3bu).
+///
+/// Mark-all-read is a global mutation: the server advances the watermark
+/// for every zone the user can see. The per-zone applications cache must
+/// be cleared before the refetch, otherwise a TTL-fresh cache hit will
+/// keep serving rows with the old `latestUnreadEvent` and the
+/// `Unread (N)` chip will stay stuck until the cache TTL expires.
+@Suite("ApplicationListViewModel.markAllRead — cache invalidation (tc-e3bu)")
+@MainActor
+struct ApplicationListViewModelMarkAllReadCacheTests {
+
+  private func makeSUT(
+    cachedApplications: [PlanningApplication],
+    refetchedApplications: [PlanningApplication]
+  ) -> (
+    ApplicationListViewModel,
+    SpyApplicationCacheStore,
+    SpyPlanningApplicationRepository,
+    SpyNotificationStateRepository
+  ) {
+    let remote = SpyPlanningApplicationRepository()
+    remote.fetchApplicationsResult = .success(refetchedApplications)
+    let cache = SpyApplicationCacheStore()
+    cache.storedEntry = CacheEntry(
+      data: cachedApplications,
+      fetchedAt: Date().addingTimeInterval(-60),
+      ttlSeconds: 900
+    )
+    let offlineRepository = OfflineAwareRepository(
+      remote: remote,
+      cache: cache,
+      connectivity: StubConnectivityMonitor(isConnected: true)
+    )
+    let stateRepo = SpyNotificationStateRepository()
+    stateRepo.markAllReadResult = .success(())
+    let sut = ApplicationListViewModel(
+      offlineRepository: offlineRepository,
+      zone: .cambridge,
+      notificationStateRepository: stateRepo
+    )
+    return (sut, cache, remote, stateRepo)
+  }
+
+  private func event(at seconds: TimeInterval) -> LatestUnreadEvent {
+    LatestUnreadEvent(
+      type: "NewApplication",
+      decision: nil,
+      createdAt: Date(timeIntervalSince1970: seconds)
+    )
+  }
+
+  /// Without invalidation, the refetch after the mark-all-read POST would
+  /// short-circuit on the TTL-fresh cache and the chip would stay stuck
+  /// at the prior count. The view-model must clear every cached zone
+  /// before refetching.
+  @Test func markAllRead_invalidatesEveryCachedZoneBeforeRefetch() async {
+    let cachedUnread = PlanningApplication.pendingReview
+      .withLatestUnreadEvent(event(at: 1_700_500_000))
+    let refetchedRead = PlanningApplication.pendingReview
+      .withLatestUnreadEvent(nil)
+    let (sut, cache, _, _) = makeSUT(
+      cachedApplications: [cachedUnread],
+      refetchedApplications: [refetchedRead]
+    )
+
+    await sut.loadApplications()
+    #expect(sut.unreadCount == 1)
+
+    await sut.markAllRead()
+
+    #expect(cache.invalidateAllCallCount == 1)
+  }
+
+  /// End-to-end behavioural assertion: a TTL-fresh cache must not stop the
+  /// chip from zeroing after mark-all-read. With the invalidation in place,
+  /// the refetch goes to the network, returns rows with `latestUnreadEvent
+  /// == nil`, and `unreadCount` drops to 0 (tc-e3bu repro path).
+  @Test func markAllRead_zeroesUnreadCount_evenWhenCacheIsFresh() async {
+    let cachedUnread = PlanningApplication.pendingReview
+      .withLatestUnreadEvent(event(at: 1_700_500_000))
+    let refetchedRead = PlanningApplication.pendingReview
+      .withLatestUnreadEvent(nil)
+    let (sut, _, remote, _) = makeSUT(
+      cachedApplications: [cachedUnread],
+      refetchedApplications: [refetchedRead]
+    )
+
+    await sut.loadApplications()
+    let remoteCallsBeforeMar = remote.fetchApplicationsCalls.count
+    #expect(sut.unreadCount == 1)
+
+    await sut.markAllRead()
+
+    #expect(sut.unreadCount == 0)
+    #expect(!sut.hasUnread)
+    #expect(remote.fetchApplicationsCalls.count > remoteCallsBeforeMar)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/InMemoryApplicationCacheStoreTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/InMemoryApplicationCacheStoreTests.swift
@@ -83,4 +83,27 @@ struct InMemoryApplicationCacheStoreTests {
 
     #expect(result == nil)
   }
+
+  // MARK: - invalidateAll (tc-e3bu)
+
+  @Test func invalidateAll_clearsEveryCachedZone() async {
+    let sut = InMemoryApplicationCacheStore()
+    let camEntry = CacheEntry(data: [PlanningApplication.pendingReview], fetchedAt: Date())
+    let londonEntry = CacheEntry(data: [PlanningApplication.permitted], fetchedAt: Date())
+    await sut.store(camEntry, for: WatchZone.cambridge)
+    await sut.store(londonEntry, for: WatchZone.london)
+
+    await sut.invalidateAll()
+
+    #expect(await sut.retrieve(for: WatchZone.cambridge) == nil)
+    #expect(await sut.retrieve(for: WatchZone.london) == nil)
+  }
+
+  @Test func invalidateAll_isNoOp_whenEmpty() async {
+    let sut = InMemoryApplicationCacheStore()
+
+    await sut.invalidateAll()
+
+    #expect(await sut.retrieve(for: WatchZone.cambridge) == nil)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/NotificationDelegateActorHopTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/NotificationDelegateActorHopTests.swift
@@ -1,72 +1,80 @@
 import Foundation
 import Testing
+import TownCrierDomain
 
 @testable import TownCrierPresentation
 
-/// Regression guard for tc-fcwv (build 16 TestFlight crash on every push tap).
+/// Isolation contract for the `NotificationDelegate` callback shape (tc-cbmk).
 ///
-/// `UNUserNotificationCenterDelegate` callbacks declared as `nonisolated async`
-/// are bridged by Swift's compiler-synthesized `@objc` thunk, which calls the
-/// original `withCompletionHandler:` ObjC selector when the function returns.
-/// UIKit's `UNUserNotificationCenter` asserts that the completion handler runs
-/// on the main thread; if it fires on a Swift Concurrency cooperative thread
-/// the process aborts with `NSInternalInconsistencyException`.
+/// `UNUserNotificationCenterDelegate` async overloads are bridged by Swift's
+/// compiler-synthesized `@objc` thunk, which calls the original
+/// `withCompletionHandler:` ObjC selector when the function returns. UIKit's
+/// `UNUserNotificationCenter` asserts that completion runs on the main
+/// thread; if it fires on a Swift Concurrency cooperative thread the process
+/// aborts with `NSInternalInconsistencyException`.
 ///
-/// The fix is to wrap the delegate body in `await MainActor.run { ... }` so
-/// the function always returns on MainActor regardless of which path is taken.
-/// We can't directly reproduce the UIKit assertion in unit tests (the bridge
-/// only fires for real `UNUserNotificationCenter` invocations), but we can
-/// document and verify the actor-hop contract: a `nonisolated async` function
-/// that wraps its body in `MainActor.run` is on the main thread at exit.
-@Suite("NotificationDelegate actor-hop contract (tc-fcwv)")
+/// The fix is to declare the conforming class `@MainActor` and **not** mark
+/// the delegate overloads `nonisolated`. The method bodies then inherit
+/// MainActor isolation and the synthesized @objc thunk's completion fires on
+/// main deterministically.
+///
+/// The previous fix (tc-fcwv) wrapped the body in `await MainActor.run` from
+/// a `nonisolated async` method; that left a gap where the @objc thunk could
+/// resume on whatever cooperative thread the runtime picked. tc-cbmk reverses
+/// that pattern. These tests document the new contract via a surrogate that
+/// mirrors the production delegate body shape — including the no-op
+/// (early-return) path that was the original tc-fcwv repro and remains the
+/// path most sensitive to isolation regressions.
+@Suite("NotificationDelegate isolation contract (tc-cbmk)")
+@MainActor
 struct NotificationDelegateActorHopTests {
 
-  /// Mirrors the no-deep-link early-return path: the delegate parses a
-  /// payload, finds nothing to route, and returns. With the fix in place the
-  /// function is on MainActor when it returns. Without the fix it would
-  /// return on whatever cooperative thread the parse happened on.
-  @Test func nonisolatedAsyncWrappedInMainActorRun_landsOnMainAtExit_forNoOpBody() async {
-    // Digest-shaped payload — no applicationRef, parser yields nil.
-    let (didExitOnMain, returnedDeepLink) = await simulateDelegateBody(
-      applicationRef: nil
-    )
+  /// Digest-shaped payload — `handlePushTap` finds no deep link and no
+  /// `createdAt`. The body completes without an actor hop, and because the
+  /// method is `@MainActor` (inherited), the synthesized @objc completion
+  /// fires on main. Regression guard for tc-fcwv (no-deep-link path) and
+  /// tc-cbmk (isolation regression to `nonisolated`).
+  @Test func userNotificationCenter_didReceive_runsOnMain_forDigestPayload() async {
+    let wasOnMain = await runDelegateBody(applicationRef: nil)
 
-    #expect(didExitOnMain == true)
-    #expect(returnedDeepLink == nil)
+    #expect(wasOnMain == true)
   }
 
-  /// Mirrors the routed-deep-link path: a valid `applicationRef` payload
-  /// produces a deep link and the body completes on MainActor.
-  @Test func nonisolatedAsyncWrappedInMainActorRun_landsOnMainAtExit_forRoutedDeepLink() async {
-    let (didExitOnMain, returnedDeepLink) = await simulateDelegateBody(
-      applicationRef: "APP-001"
-    )
+  /// Routed deep-link path: a valid `applicationRef` produces a deep link
+  /// and the body completes on main. Same isolation contract as the no-op
+  /// path — class-level `@MainActor` carries both.
+  @Test func userNotificationCenter_didReceive_runsOnMain_forRoutedDeepLink() async {
+    let wasOnMain = await runDelegateBody(applicationRef: "APP-001")
 
-    #expect(didExitOnMain == true)
-    #expect(returnedDeepLink != nil)
+    #expect(wasOnMain == true)
   }
 
-  /// Surrogate for the production delegate body. Mirrors the exact shape of
-  /// `NotificationDelegate.userNotificationCenter(_:didReceive:)`:
-  /// 1. `nonisolated async` outer function (same as the protocol callback).
-  /// 2. Parse the non-Sendable `userInfo` dict on the calling actor.
-  /// 3. Hop to MainActor with only a Sendable `DeepLink?` payload.
-  /// 4. Return on MainActor regardless of whether a deep link was parsed.
+  /// Mirrors the production delegate body: a `@MainActor` method that
+  /// forwards a `userInfo` dict to a `@MainActor` collaborator. No
+  /// `nonisolated`, no `MainActor.run` — the method-level isolation is the
+  /// only thing keeping the @objc thunk's completion on main.
   ///
-  /// The shape is load-bearing: dropping `await MainActor.run` (e.g. a
-  /// refactor that relies on `AppCoordinator`'s `@MainActor` to hop
-  /// implicitly only on the routed path) reintroduces the early-return
-  /// crash that this test guards against.
-  private nonisolated func simulateDelegateBody(
-    applicationRef: String?
-  ) async -> (didExitOnMain: Bool, deepLink: DeepLink?) {
+  /// Reintroducing `nonisolated` on this surrogate (or on the production
+  /// `userNotificationCenter(_:didReceive:)`) would resume the body on a
+  /// cooperative thread and the `Thread.isMainThread` assertion at exit
+  /// would fail.
+  @MainActor
+  private func runDelegateBody(applicationRef: String?) async -> Bool {
     var userInfo: [AnyHashable: Any] = [:]
     if let applicationRef {
       userInfo["applicationRef"] = applicationRef
     }
-    let deepLink = NotificationPayloadParser.parseDeepLink(from: userInfo)
-    return await MainActor.run {
-      (Thread.isMainThread, deepLink)
+    if let deepLink = NotificationPayloadParser.parseDeepLink(from: userInfo) {
+      _ = deepLink  // production path: coordinator.handleDeepLink(deepLink)
     }
+    return isOnMainThread()
+  }
+
+  /// `Thread.isMainThread` is unavailable from async contexts, but it's
+  /// fine to read from a synchronous `@MainActor` helper — and a synchronous
+  /// helper is the only honest way to assert "this line ran on main".
+  @MainActor
+  private func isOnMainThread() -> Bool {
+    Thread.isMainThread
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/OfflineAwareRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/OfflineAwareRepositoryTests.swift
@@ -167,4 +167,36 @@ struct OfflineAwareRepositoryTests {
     #expect(result.data.first?.id == PlanningApplication.pendingReview.id)
   }
 
+  // MARK: - Global cache invalidation (tc-e3bu)
+
+  @Test func invalidateAllCaches_delegatesToCacheStore() async {
+    let (sut, _, cache, _) = makeSUT()
+
+    await sut.invalidateAllCaches()
+
+    #expect(cache.invalidateAllCallCount == 1)
+  }
+
+  @Test func invalidateAllCaches_thenFetch_skipsStaleCacheAndHitsRemote() async throws {
+    // Mark-all-read invalidates every zone. After the call, a refetch on
+    // an otherwise-fresh cache must still go to the network so the new
+    // `latestUnreadEvent` (nil) propagates and zeros the chip (tc-e3bu).
+    let staleEntry = CacheEntry(
+      data: [PlanningApplication.pendingReview],
+      fetchedAt: Date().addingTimeInterval(-60),
+      ttlSeconds: 900
+    )
+    let freshApps = [PlanningApplication.permitted]
+    let (sut, remote, _, _) = makeSUT(
+      remoteApplications: freshApps,
+      cachedEntry: staleEntry
+    )
+
+    await sut.invalidateAllCaches()
+    let result = try await sut.fetchApplications(for: WatchZone.cambridge)
+
+    #expect(remote.fetchApplicationsCalls.count == 1)
+    #expect(result.data.first?.id == PlanningApplication.permitted.id)
+  }
+
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/SessionCacheTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SessionCacheTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+/// Behaviour contract for `SessionCache` (tc-3d7b).
+///
+/// The cache lives inside `Auth0AuthenticationService` and is the reason
+/// repeated `currentSession()` calls within a single foreground burst issue
+/// at most one `SecItemCopyMatching`. It must:
+///
+/// - Return cached sessions while their access token is still beyond the
+///   renewal lead time.
+/// - Single-flight concurrent cold-cache callers so a four-way burst loads
+///   credentials from the keychain just once.
+/// - Drop the cache on logout/refresh-failure so subsequent callers cannot
+///   reuse a torn-down session.
+@Suite("SessionCache (tc-3d7b)")
+struct SessionCacheTests {
+
+  private static let fixedNow = Date(timeIntervalSince1970: 1_700_000_000)
+  private let fixedClock: @Sendable () -> Date = { Self.fixedNow }
+
+  private func makeSession(expiresIn seconds: TimeInterval) -> AuthSession {
+    AuthSession(
+      accessToken: "a",
+      idToken: "i",
+      expiresAt: Self.fixedNow.addingTimeInterval(seconds),
+      userProfile: UserProfile(userId: "u", email: "u@example.com", name: nil)
+    )
+  }
+
+  // MARK: - current()
+
+  @Test func current_returnsNil_whenEmpty() async {
+    let sut = SessionCache(leadTime: 60, now: fixedClock)
+
+    let result = await sut.current()
+
+    #expect(result == nil)
+  }
+
+  @Test func current_returnsCached_whenAccessTokenIsBeyondLeadTime() async {
+    let sut = SessionCache(leadTime: 60, now: fixedClock)
+    let valid = makeSession(expiresIn: 300)  // 5 min from now, past 60s lead
+    await sut.store(valid)
+
+    let result = await sut.current()
+
+    #expect(result == valid)
+  }
+
+  @Test func current_returnsNil_whenAccessTokenIsWithinLeadTime() async {
+    let sut = SessionCache(leadTime: 60, now: fixedClock)
+    let stale = makeSession(expiresIn: 30)  // inside the 60s renewal window
+    await sut.store(stale)
+
+    let result = await sut.current()
+
+    #expect(result == nil)
+  }
+
+  @Test func current_returnsNil_whenAccessTokenAlreadyExpired() async {
+    let sut = SessionCache(leadTime: 60, now: fixedClock)
+    let expired = makeSession(expiresIn: -10)
+    await sut.store(expired)
+
+    let result = await sut.current()
+
+    #expect(result == nil)
+  }
+
+  // MARK: - currentOrLoad()
+
+  @Test func currentOrLoad_returnsCachedSession_withoutInvokingLoader() async {
+    let sut = SessionCache(leadTime: 60, now: fixedClock)
+    let valid = makeSession(expiresIn: 300)
+    await sut.store(valid)
+    let counter = CallCounter()
+    let fallback = makeSession(expiresIn: 300)
+
+    let result = await sut.currentOrLoad {
+      await counter.increment()
+      return fallback
+    }
+
+    #expect(result == valid)
+    #expect(await counter.invocations == 0)
+  }
+
+  @Test func currentOrLoad_invokesLoader_whenCacheIsCold() async {
+    let sut = SessionCache(leadTime: 60, now: fixedClock)
+    let loaded = makeSession(expiresIn: 300)
+    let counter = CallCounter()
+
+    let result = await sut.currentOrLoad {
+      await counter.increment()
+      return loaded
+    }
+
+    #expect(result == loaded)
+    #expect(await counter.invocations == 1)
+  }
+
+  @Test func currentOrLoad_cachesLoaderResult_forNextCall() async {
+    let sut = SessionCache(leadTime: 60, now: fixedClock)
+    let loaded = makeSession(expiresIn: 300)
+    let counter = CallCounter()
+    let other = makeSession(expiresIn: 300)
+
+    _ = await sut.currentOrLoad {
+      await counter.increment()
+      return loaded
+    }
+    let second = await sut.currentOrLoad {
+      await counter.increment()
+      return other
+    }
+
+    #expect(second == loaded)
+    #expect(await counter.invocations == 1)
+  }
+
+  /// The acceptance-criteria scenario: four concurrent callers hit the
+  /// service on a cold cache. The single-flight contract means only one of
+  /// them runs the loader, the rest await the same result.
+  @Test func currentOrLoad_singleFlights_concurrentColdCacheLoaders() async {
+    let sut = SessionCache(leadTime: 60, now: fixedClock)
+    let loaded = makeSession(expiresIn: 300)
+    let counter = CallCounter()
+
+    async let result0 = sut.currentOrLoad {
+      try? await Task.sleep(nanoseconds: 10_000_000)
+      await counter.increment()
+      return loaded
+    }
+    async let result1 = sut.currentOrLoad {
+      try? await Task.sleep(nanoseconds: 10_000_000)
+      await counter.increment()
+      return loaded
+    }
+    async let result2 = sut.currentOrLoad {
+      try? await Task.sleep(nanoseconds: 10_000_000)
+      await counter.increment()
+      return loaded
+    }
+    async let result3 = sut.currentOrLoad {
+      try? await Task.sleep(nanoseconds: 10_000_000)
+      await counter.increment()
+      return loaded
+    }
+    let results = await [result0, result1, result2, result3]
+
+    #expect(results.allSatisfy { $0 == loaded })
+    #expect(await counter.invocations == 1)
+  }
+
+  // MARK: - clear()
+
+  @Test func clear_dropsCachedSession() async {
+    let sut = SessionCache(leadTime: 60, now: fixedClock)
+    await sut.store(makeSession(expiresIn: 300))
+
+    await sut.clear()
+
+    #expect(await sut.current() == nil)
+  }
+
+  @Test func clear_forcesNextCurrentOrLoad_toInvokeLoader() async {
+    let sut = SessionCache(leadTime: 60, now: fixedClock)
+    let stored = makeSession(expiresIn: 300)
+    await sut.store(stored)
+    let counter = CallCounter()
+
+    await sut.clear()
+    let reloaded = makeSession(expiresIn: 600)
+    let result = await sut.currentOrLoad {
+      await counter.increment()
+      return reloaded
+    }
+
+    #expect(result == reloaded)
+    #expect(await counter.invocations == 1)
+  }
+}
+
+private actor CallCounter {
+  private(set) var invocations = 0
+  func increment() { invocations += 1 }
+}

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyApplicationCacheStore.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyApplicationCacheStore.swift
@@ -6,6 +6,7 @@ final class SpyApplicationCacheStore: ApplicationCacheStore, @unchecked Sendable
   private(set) var storeCalls: [(WatchZone, CacheEntry<[PlanningApplication]>)] = []
   private(set) var retrieveCalls: [WatchZone] = []
   private(set) var invalidateCalls: [WatchZoneId] = []
+  private(set) var invalidateAllCallCount = 0
 
   func store(_ entry: CacheEntry<[PlanningApplication]>, for zone: WatchZone) async {
     storeCalls.append((zone, entry))
@@ -19,6 +20,11 @@ final class SpyApplicationCacheStore: ApplicationCacheStore, @unchecked Sendable
 
   func invalidate(for zoneId: WatchZoneId) async {
     invalidateCalls.append(zoneId)
+    storedEntry = nil
+  }
+
+  func invalidateAll() async {
+    invalidateAllCallCount += 1
     storedEntry = nil
   }
 }


### PR DESCRIPTION
## Changes

- **tc-cbmk (P0)** — Every push notification tap was crashing on TestFlight build 23 (cold-launch + background). Removed `nonisolated` from both `NotificationDelegate` overloads so they inherit the class-level `@MainActor`; the synthesized `@objc` completion thunk now lands on the main thread deterministically. `didReceive` forwards to the existing `AppCoordinator.handlePushTap(userInfo:)`. Apple WWDC23 guidance; reverses the tc-fcwv `nonisolated async` + `MainActor.run` pattern that left a resumption gap.

- **tc-e3bu (P1)** — Mark all read cleared the OS badge but the in-app `Unread (N)` chip stayed stuck on the prior count until the offline cache TTL expired. Added `invalidateAll()` to `ApplicationCacheStore` and `invalidateAllCaches()` to `OfflineAwareRepository`; `ApplicationListViewModel.markAllRead()` now drops every cached zone before refetching, so the chip zeroes within one round-trip.

- **tc-3d7b (P3)** — `Auth0AuthenticationService.currentSession()` hit `SecItemCopyMatching` on every call via `canRenew()` / `hasValid()` / `credentials()`. A push tap arriving during a foreground burst caused 4-way contention on securityd. Added a `SessionCache` actor with a 60-second renewal lead time and single-flight on cold-cache loads; `currentSession()` now skips the keychain entirely under steady state and serialises concurrent callers through one in-flight load.

## Test plan

- SwiftLint strict: 0 violations across 358 files.
- Swift Testing: 1193 tests passing locally.
- New behavioural coverage: `NotificationDelegateActorHopTests` (isolation contract), `OfflineAwareRepositoryTests.invalidateAllCaches_*`, `InMemoryApplicationCacheStoreTests.invalidateAll_*`, `ApplicationListViewModelMarkAllReadCacheTests` (cache-invalidation end-to-end), `SessionCacheTests` (10 cases incl. 4-way single-flight).
- Manual repro on TestFlight after merge: tap a push notification on cold launch + background — app launches without crash; press Mark all read on a zone with `Unread (17)` — chip drops to 0 within one round-trip.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized authentication session retrieval through in-memory caching to reduce load times during repeated access.

* **Bug Fixes**
  * Fixed unread state display when marking all notifications as read to ensure counts update immediately.

* **Improvements**
  * Enhanced notification handling for improved reliability across app launch and foreground scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmyDe/town-crier/pull/394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->