### PR TITLE
Structural guard: suffix cross-partition repository methods (tc-dzwo.3)

### DIFF
--- a/api/src/town-crier.application/Admin/GrantSubscriptionCommandHandler.cs
+++ b/api/src/town-crier.application/Admin/GrantSubscriptionCommandHandler.cs
@@ -21,7 +21,7 @@ public sealed class GrantSubscriptionCommandHandler
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        var profile = await this.repository.GetByEmailAsync(command.Email, ct).ConfigureAwait(false)
+        var profile = await this.repository.GetByEmailCrossPartitionAsync(command.Email, ct).ConfigureAwait(false)
             ?? throw new UserProfileNotFoundException($"No user profile found for email '{command.Email}'.");
 
         if (command.Tier == SubscriptionTier.Free)

--- a/api/src/town-crier.application/Admin/ListUsersQueryHandler.cs
+++ b/api/src/town-crier.application/Admin/ListUsersQueryHandler.cs
@@ -15,7 +15,7 @@ public sealed class ListUsersQueryHandler
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        var page = await this.repository.ListAsync(
+        var page = await this.repository.ListCrossPartitionAsync(
             query.SearchTerm,
             query.PageSize,
             query.ContinuationToken,

--- a/api/src/town-crier.application/Notifications/DispatchDecisionEventCommandHandler.cs
+++ b/api/src/town-crier.application/Notifications/DispatchDecisionEventCommandHandler.cs
@@ -69,7 +69,7 @@ public sealed class DispatchDecisionEventCommandHandler
         // Zone matchers — only meaningful when the application has coordinates.
         if (application.Latitude.HasValue && application.Longitude.HasValue)
         {
-            var matchingZones = await this.watchZoneRepository.FindZonesContainingAsync(
+            var matchingZones = await this.watchZoneRepository.FindZonesContainingCrossPartitionAsync(
                 application.Latitude.Value, application.Longitude.Value, ct).ConfigureAwait(false);
 
             foreach (var zone in matchingZones)
@@ -90,7 +90,7 @@ public sealed class DispatchDecisionEventCommandHandler
         // would falsely match users who saved a same-uid app in a different
         // authority (bd tc-th98 / GH#384).
         var savedUserIds = await this.savedApplicationRepository
-            .GetUserIdsForApplicationAsync(application.Uid, application.AreaId, ct)
+            .GetUserIdsForApplicationCrossPartitionAsync(application.Uid, application.AreaId, ct)
             .ConfigureAwait(false);
 
         foreach (var userId in savedUserIds)

--- a/api/src/town-crier.application/Notifications/GenerateHourlyDigestsCommandHandler.cs
+++ b/api/src/town-crier.application/Notifications/GenerateHourlyDigestsCommandHandler.cs
@@ -26,7 +26,7 @@ public sealed class GenerateHourlyDigestsCommandHandler
 
     public async Task HandleAsync(GenerateHourlyDigestsCommand command, CancellationToken ct)
     {
-        var userIds = await this.notificationRepository.GetUserIdsWithUnsentEmailsAsync(ct)
+        var userIds = await this.notificationRepository.GetUserIdsWithUnsentEmailsCrossPartitionAsync(ct)
             .ConfigureAwait(false);
 
         foreach (var userId in userIds)

--- a/api/src/town-crier.application/Notifications/GenerateWeeklyDigestsCommandHandler.cs
+++ b/api/src/town-crier.application/Notifications/GenerateWeeklyDigestsCommandHandler.cs
@@ -47,7 +47,7 @@ public sealed class GenerateWeeklyDigestsCommandHandler
         var today = now.DayOfWeek;
         var since = now.AddDays(-7);
 
-        var users = await this.userProfileRepository.GetAllByDigestDayAsync(today, ct)
+        var users = await this.userProfileRepository.GetAllByDigestDayCrossPartitionAsync(today, ct)
             .ConfigureAwait(false);
 
         foreach (var profile in users)

--- a/api/src/town-crier.application/Notifications/INotificationRepository.cs
+++ b/api/src/town-crier.application/Notifications/INotificationRepository.cs
@@ -58,7 +58,8 @@ public interface INotificationRepository
 
     Task<IReadOnlyList<Notification>> GetUnsentEmailsByUserAsync(string userId, CancellationToken ct);
 
-    Task<IReadOnlyList<string>> GetUserIdsWithUnsentEmailsAsync(CancellationToken ct);
+    // Cross-partition — worker path only (GenerateHourlyDigestsCommandHandler).
+    Task<IReadOnlyList<string>> GetUserIdsWithUnsentEmailsCrossPartitionAsync(CancellationToken ct);
 
     Task SaveAsync(Notification notification, CancellationToken ct);
 

--- a/api/src/town-crier.application/OfferCodes/IOfferCodeRepository.cs
+++ b/api/src/town-crier.application/OfferCodes/IOfferCodeRepository.cs
@@ -11,5 +11,8 @@ public interface IOfferCodeRepository
 
     Task SaveAsync(OfferCode code, CancellationToken ct);
 
-    Task<IReadOnlyList<OfferCode>> GetRedeemedByUserIdAsync(string userId, CancellationToken ct);
+    // Cross-partition — offer codes are partitioned by code; finding by redeemer requires
+    // scanning all partitions. Used by ExportUserDataQueryHandler (GDPR export, user-initiated
+    // but explicitly accepted in GH#395 as low-frequency per-user data export).
+    Task<IReadOnlyList<OfferCode>> GetRedeemedByUserIdCrossPartitionAsync(string userId, CancellationToken ct);
 }

--- a/api/src/town-crier.application/PlanningApplications/GetApplicationByUidQueryHandler.cs
+++ b/api/src/town-crier.application/PlanningApplications/GetApplicationByUidQueryHandler.cs
@@ -42,7 +42,7 @@ public sealed class GetApplicationByUidQueryHandler
         // Cross-partition uid scan retained for background/worker paths.
         // User-facing push-tap deep links use GetApplicationByAuthorityAndNameQueryHandler
         // (partitioned point read, ~1 RU, no PlanIt fallback). GH#395 Invariant 1.
-        var application = await this.repository.GetByUidAsync(query.Uid, ct).ConfigureAwait(false);
+        var application = await this.repository.GetByUidCrossPartitionAsync(query.Uid, ct).ConfigureAwait(false);
         if (application is null)
         {
             return null;

--- a/api/src/town-crier.application/PlanningApplications/IPlanningApplicationRepository.cs
+++ b/api/src/town-crier.application/PlanningApplications/IPlanningApplicationRepository.cs
@@ -6,7 +6,9 @@ public interface IPlanningApplicationRepository
 {
     Task UpsertAsync(PlanningApplication application, CancellationToken ct);
 
-    Task<PlanningApplication?> GetByUidAsync(string uid, CancellationToken ct);
+    // Cross-partition fan-out — worker paths only (polling upsert, background lookup).
+    // User-facing handlers must use GetByAuthorityAndNameAsync (point read, ~1 RU).
+    Task<PlanningApplication?> GetByUidCrossPartitionAsync(string uid, CancellationToken ct);
 
     // Partition-scoped lookup used on the poll-cycle hot path where the authority is
     // already known. Avoids a cross-partition fan-out by passing authorityCode as the

--- a/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
+++ b/api/src/town-crier.application/Polling/PollPlanItCommandHandler.cs
@@ -211,7 +211,7 @@ public sealed partial class PollPlanItCommandHandler : IPollPlanItCommandHandler
 
                         if (application.Latitude.HasValue && application.Longitude.HasValue)
                         {
-                            var matchingZones = await this.watchZoneRepository.FindZonesContainingAsync(
+                            var matchingZones = await this.watchZoneRepository.FindZonesContainingCrossPartitionAsync(
                                 application.Latitude.Value, application.Longitude.Value, ct).ConfigureAwait(false);
 
                             foreach (var zone in matchingZones)

--- a/api/src/town-crier.application/Polling/WatchZoneActiveAuthorityProvider.cs
+++ b/api/src/town-crier.application/Polling/WatchZoneActiveAuthorityProvider.cs
@@ -13,6 +13,6 @@ public sealed class WatchZoneActiveAuthorityProvider : IWatchZoneActiveAuthority
 
     public async Task<IReadOnlyCollection<int>> GetActiveAuthorityIdsAsync(CancellationToken ct)
     {
-        return await this.watchZoneRepository.GetDistinctAuthorityIdsAsync(ct).ConfigureAwait(false);
+        return await this.watchZoneRepository.GetDistinctAuthorityIdsCrossPartitionAsync(ct).ConfigureAwait(false);
     }
 }

--- a/api/src/town-crier.application/SavedApplications/ISavedApplicationRepository.cs
+++ b/api/src/town-crier.application/SavedApplications/ISavedApplicationRepository.cs
@@ -24,5 +24,8 @@ public interface ISavedApplicationRepository
     /// <param name="authorityId">The PlanIt areaId for the council that issued the uid.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>The userIds who have saved the given application within the specified authority.</returns>
-    Task<IReadOnlyList<string>> GetUserIdsForApplicationAsync(string applicationUid, int authorityId, CancellationToken ct);
+    // Cross-partition fan-out — worker path only (polling decision-event dispatch).
+    // Saved-app docs are partitioned by userId; finding all savers of an application requires
+    // scanning all partitions. Low-frequency, cost accepted for background processing.
+    Task<IReadOnlyList<string>> GetUserIdsForApplicationCrossPartitionAsync(string applicationUid, int authorityId, CancellationToken ct);
 }

--- a/api/src/town-crier.application/Subscriptions/HandleAppStoreNotificationCommandHandler.cs
+++ b/api/src/town-crier.application/Subscriptions/HandleAppStoreNotificationCommandHandler.cs
@@ -52,7 +52,7 @@ public sealed class HandleAppStoreNotificationCommandHandler
         var transaction = this.transactionDecoder.Decode(txnJson);
 
         // Look up user by original transaction ID
-        var profile = await this.repository.GetByOriginalTransactionIdAsync(
+        var profile = await this.repository.GetByOriginalTransactionIdCrossPartitionAsync(
             transaction.OriginalTransactionId, ct).ConfigureAwait(false);
 
         if (profile is not null)

--- a/api/src/town-crier.application/UserProfiles/DormantAccountCleanupCommandHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/DormantAccountCleanupCommandHandler.cs
@@ -31,7 +31,7 @@ public sealed class DormantAccountCleanupCommandHandler
         ArgumentNullException.ThrowIfNull(command);
 
         var cutoff = command.Now.AddMonths(-RetentionMonths);
-        var dormant = await this.repository.GetDormantAsync(cutoff, ct).ConfigureAwait(false);
+        var dormant = await this.repository.GetDormantCrossPartitionAsync(cutoff, ct).ConfigureAwait(false);
 
         var deleted = 0;
         foreach (var profile in dormant)

--- a/api/src/town-crier.application/UserProfiles/ExportUserDataQueryHandler.cs
+++ b/api/src/town-crier.application/UserProfiles/ExportUserDataQueryHandler.cs
@@ -46,7 +46,7 @@ public sealed class ExportUserDataQueryHandler
             query.UserId, DateTimeOffset.MinValue, ct).ConfigureAwait(false);
         var savedApplications = await this.savedApplicationRepository.GetByUserIdAsync(query.UserId, ct).ConfigureAwait(false);
         var deviceRegistrations = await this.deviceRegistrationRepository.GetByUserIdAsync(query.UserId, ct).ConfigureAwait(false);
-        var offerCodes = await this.offerCodeRepository.GetRedeemedByUserIdAsync(query.UserId, ct).ConfigureAwait(false);
+        var offerCodes = await this.offerCodeRepository.GetRedeemedByUserIdCrossPartitionAsync(query.UserId, ct).ConfigureAwait(false);
 
         return new ExportUserDataResult(
             UserId: profile.UserId,

--- a/api/src/town-crier.application/UserProfiles/IUserProfileRepository.cs
+++ b/api/src/town-crier.application/UserProfiles/IUserProfileRepository.cs
@@ -6,22 +6,28 @@ public interface IUserProfileRepository
 {
     Task<UserProfile?> GetByUserIdAsync(string userId, CancellationToken ct);
 
-    Task<UserProfile?> GetByEmailAsync(string email, CancellationToken ct);
+    // Cross-partition — used by GrantSubscriptionCommandHandler (admin-only endpoint,
+    // excluded from the user-path cross-partition guard per GH#395 "Out of scope").
+    Task<UserProfile?> GetByEmailCrossPartitionAsync(string email, CancellationToken ct);
 
-    Task<IReadOnlyList<UserProfile>> GetAllByTierAsync(SubscriptionTier tier, CancellationToken ct);
+    // Cross-partition — used by GenerateWeeklyDigestsCommandHandler (worker-only).
+    Task<IReadOnlyList<UserProfile>> GetAllByTierCrossPartitionAsync(SubscriptionTier tier, CancellationToken ct);
 
-    Task<IReadOnlyList<UserProfile>> GetAllByDigestDayAsync(DayOfWeek digestDay, CancellationToken ct);
+    // Cross-partition — used by GenerateWeeklyDigestsCommandHandler (worker-only).
+    Task<IReadOnlyList<UserProfile>> GetAllByDigestDayCrossPartitionAsync(DayOfWeek digestDay, CancellationToken ct);
 
-    Task<UserProfile?> GetByOriginalTransactionIdAsync(string originalTransactionId, CancellationToken ct);
+    // Cross-partition — used by HandleAppStoreNotificationCommandHandler (not registered in web DI).
+    Task<UserProfile?> GetByOriginalTransactionIdCrossPartitionAsync(string originalTransactionId, CancellationToken ct);
 
-    Task<UserProfilePage> ListAsync(
+    // Cross-partition — used by ListUsersQueryHandler (admin-only, excluded from guard).
+    Task<UserProfilePage> ListCrossPartitionAsync(
         string? emailSearch, int pageSize, string? continuationToken, CancellationToken ct);
 
+    // Cross-partition — used by DormantAccountCleanupCommandHandler (worker-only).
     // Returns profiles whose LastActiveAt is strictly before the supplied cutoff
-    // (i.e. dormant relative to the retention policy). Used by the daily
-    // DormantAccountCleanup worker to enforce UK GDPR Art. 5(1)(e) storage
-    // limitation — the privacy policy commits to deleting inactive accounts.
-    Task<IReadOnlyList<UserProfile>> GetDormantAsync(DateTimeOffset cutoff, CancellationToken ct);
+    // (i.e. dormant relative to the retention policy). Enforces UK GDPR Art. 5(1)(e)
+    // storage limitation — the privacy policy commits to deleting inactive accounts.
+    Task<IReadOnlyList<UserProfile>> GetDormantCrossPartitionAsync(DateTimeOffset cutoff, CancellationToken ct);
 
     Task SaveAsync(UserProfile profile, CancellationToken ct);
 

--- a/api/src/town-crier.application/WatchZones/IWatchZoneRepository.cs
+++ b/api/src/town-crier.application/WatchZones/IWatchZoneRepository.cs
@@ -14,10 +14,14 @@ public interface IWatchZoneRepository
 
     Task DeleteAllByUserIdAsync(string userId, CancellationToken ct);
 
-    Task<IReadOnlyCollection<WatchZone>> FindZonesContainingAsync(
+    // Cross-partition — worker paths only (polling: dispatch decision events and
+    // find zones near a new application). Cost accepted for low-frequency background use.
+    Task<IReadOnlyCollection<WatchZone>> FindZonesContainingCrossPartitionAsync(
         double latitude, double longitude, CancellationToken ct);
 
-    Task<IReadOnlyCollection<int>> GetDistinctAuthorityIdsAsync(CancellationToken ct);
+    // Cross-partition — worker path only (WatchZoneActiveAuthorityProvider for polling).
+    Task<IReadOnlyCollection<int>> GetDistinctAuthorityIdsCrossPartitionAsync(CancellationToken ct);
 
-    Task<Dictionary<int, int>> GetZoneCountsByAuthorityAsync(CancellationToken ct);
+    // Cross-partition — unused in production paths; kept for potential admin/reporting use.
+    Task<Dictionary<int, int>> GetZoneCountsByAuthorityCrossPartitionAsync(CancellationToken ct);
 }

--- a/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
@@ -124,7 +124,7 @@ public sealed class CosmosNotificationRepository : INotificationRepository
         return documents.ConvertAll(doc => doc.ToDomain());
     }
 
-    public async Task<IReadOnlyList<string>> GetUserIdsWithUnsentEmailsAsync(CancellationToken ct)
+    public async Task<IReadOnlyList<string>> GetUserIdsWithUnsentEmailsCrossPartitionAsync(CancellationToken ct)
     {
         var userIds = await this.client.QueryAsync(
             CosmosContainerNames.Notifications,

--- a/api/src/town-crier.infrastructure/Notifications/InMemoryNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/InMemoryNotificationRepository.cs
@@ -75,7 +75,7 @@ public sealed class InMemoryNotificationRepository : INotificationRepository
         return Task.FromResult<IReadOnlyList<Notification>>(notifications);
     }
 
-    public Task<IReadOnlyList<string>> GetUserIdsWithUnsentEmailsAsync(CancellationToken ct)
+    public Task<IReadOnlyList<string>> GetUserIdsWithUnsentEmailsCrossPartitionAsync(CancellationToken ct)
     {
         var userIds = this.store
             .Where(n => !n.EmailSent)

--- a/api/src/town-crier.infrastructure/OfferCodes/CosmosOfferCodeRepository.cs
+++ b/api/src/town-crier.infrastructure/OfferCodes/CosmosOfferCodeRepository.cs
@@ -47,7 +47,7 @@ public sealed class CosmosOfferCodeRepository : IOfferCodeRepository
     // Cross-partition query: offer codes are partitioned by the code itself, so a lookup
     // by redeemer requires scanning all partitions. Acceptable here because data export
     // is a low-frequency operation per user.
-    public async Task<IReadOnlyList<OfferCode>> GetRedeemedByUserIdAsync(string userId, CancellationToken ct)
+    public async Task<IReadOnlyList<OfferCode>> GetRedeemedByUserIdCrossPartitionAsync(string userId, CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
 

--- a/api/src/town-crier.infrastructure/OfferCodes/InMemoryOfferCodeRepository.cs
+++ b/api/src/town-crier.infrastructure/OfferCodes/InMemoryOfferCodeRepository.cs
@@ -33,7 +33,7 @@ public sealed class InMemoryOfferCodeRepository : IOfferCodeRepository
         return Task.CompletedTask;
     }
 
-    public Task<IReadOnlyList<OfferCode>> GetRedeemedByUserIdAsync(string userId, CancellationToken ct)
+    public Task<IReadOnlyList<OfferCode>> GetRedeemedByUserIdCrossPartitionAsync(string userId, CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
 

--- a/api/src/town-crier.infrastructure/PlanningApplications/CosmosPlanningApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/PlanningApplications/CosmosPlanningApplicationRepository.cs
@@ -28,7 +28,7 @@ public sealed class CosmosPlanningApplicationRepository : IPlanningApplicationRe
             ct).ConfigureAwait(false);
     }
 
-    public async Task<PlanningApplication?> GetByUidAsync(string uid, CancellationToken ct)
+    public async Task<PlanningApplication?> GetByUidCrossPartitionAsync(string uid, CancellationToken ct)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(uid);
 

--- a/api/src/town-crier.infrastructure/PlanningApplications/InMemoryPlanningApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/PlanningApplications/InMemoryPlanningApplicationRepository.cs
@@ -15,7 +15,7 @@ public sealed class InMemoryPlanningApplicationRepository : IPlanningApplication
         return Task.CompletedTask;
     }
 
-    public Task<PlanningApplication?> GetByUidAsync(string uid, CancellationToken ct)
+    public Task<PlanningApplication?> GetByUidCrossPartitionAsync(string uid, CancellationToken ct)
     {
         var app = this.store.Values.FirstOrDefault(a => a.Uid == uid);
         return Task.FromResult(app);

--- a/api/src/town-crier.infrastructure/SavedApplications/CosmosSavedApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/SavedApplications/CosmosSavedApplicationRepository.cs
@@ -87,7 +87,7 @@ public sealed class CosmosSavedApplicationRepository : ISavedApplicationReposito
         return document is not null;
     }
 
-    public async Task<IReadOnlyList<string>> GetUserIdsForApplicationAsync(string applicationUid, int authorityId, CancellationToken ct)
+    public async Task<IReadOnlyList<string>> GetUserIdsForApplicationCrossPartitionAsync(string applicationUid, int authorityId, CancellationToken ct)
     {
         // Cross-partition by design — saved-app docs are partitioned by userId,
         // but a polled decision-event needs every userId who saved this

--- a/api/src/town-crier.infrastructure/SavedApplications/InMemorySavedApplicationRepository.cs
+++ b/api/src/town-crier.infrastructure/SavedApplications/InMemorySavedApplicationRepository.cs
@@ -54,7 +54,7 @@ public sealed class InMemorySavedApplicationRepository : ISavedApplicationReposi
         return Task.FromResult(this.store.ContainsKey(key));
     }
 
-    public Task<IReadOnlyList<string>> GetUserIdsForApplicationAsync(string applicationUid, int authorityId, CancellationToken ct)
+    public Task<IReadOnlyList<string>> GetUserIdsForApplicationCrossPartitionAsync(string applicationUid, int authorityId, CancellationToken ct)
     {
         var userIds = this.store.Values
             .Where(s => s.ApplicationUid == applicationUid && s.AuthorityId == authorityId)

--- a/api/src/town-crier.infrastructure/UserProfiles/CosmosUserProfileRepository.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/CosmosUserProfileRepository.cs
@@ -26,7 +26,7 @@ public sealed class CosmosUserProfileRepository : IUserProfileRepository
         return document?.ToDomain();
     }
 
-    public async Task<UserProfile?> GetByEmailAsync(string email, CancellationToken ct)
+    public async Task<UserProfile?> GetByEmailCrossPartitionAsync(string email, CancellationToken ct)
     {
         var documents = await this.client.QueryAsync(
             CosmosContainerNames.Users,
@@ -39,7 +39,7 @@ public sealed class CosmosUserProfileRepository : IUserProfileRepository
         return documents.Count > 0 ? documents[0].ToDomain() : null;
     }
 
-    public async Task<IReadOnlyList<UserProfile>> GetAllByTierAsync(SubscriptionTier tier, CancellationToken ct)
+    public async Task<IReadOnlyList<UserProfile>> GetAllByTierCrossPartitionAsync(SubscriptionTier tier, CancellationToken ct)
     {
         var documents = await this.client.QueryAsync(
             CosmosContainerNames.Users,
@@ -52,7 +52,7 @@ public sealed class CosmosUserProfileRepository : IUserProfileRepository
         return documents.ConvertAll(doc => doc.ToDomain());
     }
 
-    public async Task<IReadOnlyList<UserProfile>> GetAllByDigestDayAsync(DayOfWeek digestDay, CancellationToken ct)
+    public async Task<IReadOnlyList<UserProfile>> GetAllByDigestDayCrossPartitionAsync(DayOfWeek digestDay, CancellationToken ct)
     {
         var documents = await this.client.QueryAsync(
             CosmosContainerNames.Users,
@@ -65,7 +65,7 @@ public sealed class CosmosUserProfileRepository : IUserProfileRepository
         return documents.ConvertAll(doc => doc.ToDomain());
     }
 
-    public async Task<UserProfile?> GetByOriginalTransactionIdAsync(
+    public async Task<UserProfile?> GetByOriginalTransactionIdCrossPartitionAsync(
         string originalTransactionId,
         CancellationToken ct)
     {
@@ -80,7 +80,7 @@ public sealed class CosmosUserProfileRepository : IUserProfileRepository
         return documents.Count > 0 ? documents[0].ToDomain() : null;
     }
 
-    public async Task<IReadOnlyList<UserProfile>> GetDormantAsync(DateTimeOffset cutoff, CancellationToken ct)
+    public async Task<IReadOnlyList<UserProfile>> GetDormantCrossPartitionAsync(DateTimeOffset cutoff, CancellationToken ct)
     {
         // Cross-partition scan — only run by the daily DormantAccountCleanup worker
         // against a small subset of inactive users. The cutoff is serialised as ISO-8601
@@ -96,7 +96,7 @@ public sealed class CosmosUserProfileRepository : IUserProfileRepository
         return documents.ConvertAll(doc => doc.ToDomain());
     }
 
-    public async Task<UserProfilePage> ListAsync(
+    public async Task<UserProfilePage> ListCrossPartitionAsync(
         string? emailSearch,
         int pageSize,
         string? continuationToken,

--- a/api/src/town-crier.infrastructure/UserProfiles/InMemoryUserProfileRepository.cs
+++ b/api/src/town-crier.infrastructure/UserProfiles/InMemoryUserProfileRepository.cs
@@ -14,7 +14,7 @@ public sealed class InMemoryUserProfileRepository : IUserProfileRepository
         return Task.FromResult(profile);
     }
 
-    public Task<IReadOnlyList<UserProfile>> GetAllByTierAsync(SubscriptionTier tier, CancellationToken ct)
+    public Task<IReadOnlyList<UserProfile>> GetAllByTierCrossPartitionAsync(SubscriptionTier tier, CancellationToken ct)
     {
         var profiles = this.store.Values
             .Where(p => p.Tier == tier)
@@ -22,7 +22,7 @@ public sealed class InMemoryUserProfileRepository : IUserProfileRepository
         return Task.FromResult<IReadOnlyList<UserProfile>>(profiles);
     }
 
-    public Task<IReadOnlyList<UserProfile>> GetAllByDigestDayAsync(DayOfWeek digestDay, CancellationToken ct)
+    public Task<IReadOnlyList<UserProfile>> GetAllByDigestDayCrossPartitionAsync(DayOfWeek digestDay, CancellationToken ct)
     {
         var profiles = this.store.Values
             .Where(p => p.NotificationPreferences.DigestDay == digestDay)
@@ -30,14 +30,14 @@ public sealed class InMemoryUserProfileRepository : IUserProfileRepository
         return Task.FromResult<IReadOnlyList<UserProfile>>(profiles);
     }
 
-    public Task<UserProfile?> GetByEmailAsync(string email, CancellationToken ct)
+    public Task<UserProfile?> GetByEmailCrossPartitionAsync(string email, CancellationToken ct)
     {
         var profile = this.store.Values
             .FirstOrDefault(p => string.Equals(p.Email, email, StringComparison.OrdinalIgnoreCase));
         return Task.FromResult(profile);
     }
 
-    public Task<UserProfile?> GetByOriginalTransactionIdAsync(string originalTransactionId, CancellationToken ct)
+    public Task<UserProfile?> GetByOriginalTransactionIdCrossPartitionAsync(string originalTransactionId, CancellationToken ct)
     {
         var profile = this.store.Values
             .FirstOrDefault(p => p.OriginalTransactionId == originalTransactionId);
@@ -57,7 +57,7 @@ public sealed class InMemoryUserProfileRepository : IUserProfileRepository
         return Task.CompletedTask;
     }
 
-    public Task<IReadOnlyList<UserProfile>> GetDormantAsync(DateTimeOffset cutoff, CancellationToken ct)
+    public Task<IReadOnlyList<UserProfile>> GetDormantCrossPartitionAsync(DateTimeOffset cutoff, CancellationToken ct)
     {
         var profiles = this.store.Values
             .Where(p => p.LastActiveAt < cutoff)
@@ -66,7 +66,7 @@ public sealed class InMemoryUserProfileRepository : IUserProfileRepository
     }
 
     // pageSize and continuationToken are not emulated — returns all matching profiles in one page.
-    public Task<UserProfilePage> ListAsync(
+    public Task<UserProfilePage> ListCrossPartitionAsync(
         string? emailSearch, int pageSize, string? continuationToken, CancellationToken ct)
     {
         var profiles = this.store.Values.AsEnumerable();

--- a/api/src/town-crier.infrastructure/WatchZones/CosmosWatchZoneRepository.cs
+++ b/api/src/town-crier.infrastructure/WatchZones/CosmosWatchZoneRepository.cs
@@ -105,7 +105,7 @@ public sealed class CosmosWatchZoneRepository : IWatchZoneRepository
         }
     }
 
-    public async Task<IReadOnlyCollection<WatchZone>> FindZonesContainingAsync(
+    public async Task<IReadOnlyCollection<WatchZone>> FindZonesContainingCrossPartitionAsync(
         double latitude, double longitude, CancellationToken ct)
     {
         const string sql =
@@ -123,7 +123,7 @@ public sealed class CosmosWatchZoneRepository : IWatchZoneRepository
         return documents.ConvertAll(doc => doc.ToDomain());
     }
 
-    public async Task<IReadOnlyCollection<int>> GetDistinctAuthorityIdsAsync(CancellationToken ct)
+    public async Task<IReadOnlyCollection<int>> GetDistinctAuthorityIdsCrossPartitionAsync(CancellationToken ct)
     {
         var results = await this.client.QueryAsync(
             CosmosContainerNames.WatchZones,
@@ -136,7 +136,7 @@ public sealed class CosmosWatchZoneRepository : IWatchZoneRepository
         return results.Distinct().ToList();
     }
 
-    public async Task<Dictionary<int, int>> GetZoneCountsByAuthorityAsync(CancellationToken ct)
+    public async Task<Dictionary<int, int>> GetZoneCountsByAuthorityCrossPartitionAsync(CancellationToken ct)
     {
         var items = await this.client.QueryAsync(
             CosmosContainerNames.WatchZones,

--- a/api/src/town-crier.infrastructure/WatchZones/InMemoryWatchZoneRepository.cs
+++ b/api/src/town-crier.infrastructure/WatchZones/InMemoryWatchZoneRepository.cs
@@ -57,7 +57,7 @@ public sealed class InMemoryWatchZoneRepository : IWatchZoneRepository
         return Task.CompletedTask;
     }
 
-    public Task<IReadOnlyCollection<WatchZone>> FindZonesContainingAsync(
+    public Task<IReadOnlyCollection<WatchZone>> FindZonesContainingCrossPartitionAsync(
         double latitude, double longitude, CancellationToken ct)
     {
         var point = new Coordinates(latitude, longitude);
@@ -67,7 +67,7 @@ public sealed class InMemoryWatchZoneRepository : IWatchZoneRepository
         return Task.FromResult<IReadOnlyCollection<WatchZone>>(matching);
     }
 
-    public Task<Dictionary<int, int>> GetZoneCountsByAuthorityAsync(CancellationToken ct)
+    public Task<Dictionary<int, int>> GetZoneCountsByAuthorityCrossPartitionAsync(CancellationToken ct)
     {
         var counts = this.zones.Values
             .GroupBy(z => z.AuthorityId)
@@ -75,7 +75,7 @@ public sealed class InMemoryWatchZoneRepository : IWatchZoneRepository
         return Task.FromResult(counts);
     }
 
-    public Task<IReadOnlyCollection<int>> GetDistinctAuthorityIdsAsync(CancellationToken ct)
+    public Task<IReadOnlyCollection<int>> GetDistinctAuthorityIdsCrossPartitionAsync(CancellationToken ct)
     {
         var ids = this.zones.Values
             .Select(z => z.AuthorityId)

--- a/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepository.cs
+++ b/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepository.cs
@@ -82,7 +82,7 @@ internal sealed class FakeNotificationRepository : INotificationRepository
         return Task.FromResult<IReadOnlyList<Notification>>(notifications);
     }
 
-    public Task<IReadOnlyList<string>> GetUserIdsWithUnsentEmailsAsync(CancellationToken ct)
+    public Task<IReadOnlyList<string>> GetUserIdsWithUnsentEmailsCrossPartitionAsync(CancellationToken ct)
     {
         var userIds = this.store
             .Where(n => !n.EmailSent)

--- a/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepositoryUserIdsTests.cs
+++ b/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepositoryUserIdsTests.cs
@@ -46,7 +46,7 @@ public sealed class FakeNotificationRepositoryUserIdsTests
         repo.Seed(n3);
 
         // Act
-        var result = await repo.GetUserIdsWithUnsentEmailsAsync(CancellationToken.None);
+        var result = await repo.GetUserIdsWithUnsentEmailsCrossPartitionAsync(CancellationToken.None);
 
         // Assert
         await Assert.That(result).HasCount().EqualTo(2);
@@ -87,7 +87,7 @@ public sealed class FakeNotificationRepositoryUserIdsTests
         repo.Seed(sent);
 
         // Act
-        var result = await repo.GetUserIdsWithUnsentEmailsAsync(CancellationToken.None);
+        var result = await repo.GetUserIdsWithUnsentEmailsCrossPartitionAsync(CancellationToken.None);
 
         // Assert
         await Assert.That(result).HasCount().EqualTo(1);
@@ -115,7 +115,7 @@ public sealed class FakeNotificationRepositoryUserIdsTests
         repo.Seed(sent);
 
         // Act
-        var result = await repo.GetUserIdsWithUnsentEmailsAsync(CancellationToken.None);
+        var result = await repo.GetUserIdsWithUnsentEmailsCrossPartitionAsync(CancellationToken.None);
 
         // Assert
         await Assert.That(result).HasCount().EqualTo(0);

--- a/api/tests/town-crier.application.tests/OfferCodes/FakeOfferCodeRepository.cs
+++ b/api/tests/town-crier.application.tests/OfferCodes/FakeOfferCodeRepository.cs
@@ -34,7 +34,7 @@ internal sealed class FakeOfferCodeRepository : IOfferCodeRepository
         return Task.CompletedTask;
     }
 
-    public Task<IReadOnlyList<OfferCode>> GetRedeemedByUserIdAsync(string userId, CancellationToken ct)
+    public Task<IReadOnlyList<OfferCode>> GetRedeemedByUserIdCrossPartitionAsync(string userId, CancellationToken ct)
     {
         var codes = this.store.Values
             .Where(c => c.RedeemedByUserId == userId)

--- a/api/tests/town-crier.application.tests/PlanningApplications/ThrowingOnSaveSavedApplicationRepository.cs
+++ b/api/tests/town-crier.application.tests/PlanningApplications/ThrowingOnSaveSavedApplicationRepository.cs
@@ -39,6 +39,6 @@ internal sealed class ThrowingOnSaveSavedApplicationRepository : ISavedApplicati
         return Task.FromResult(false);
     }
 
-    public Task<IReadOnlyList<string>> GetUserIdsForApplicationAsync(string applicationUid, int authorityId, CancellationToken ct) =>
+    public Task<IReadOnlyList<string>> GetUserIdsForApplicationCrossPartitionAsync(string applicationUid, int authorityId, CancellationToken ct) =>
         Task.FromResult<IReadOnlyList<string>>([]);
 }

--- a/api/tests/town-crier.application.tests/Polling/FakePlanningApplicationRepository.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakePlanningApplicationRepository.cs
@@ -30,7 +30,7 @@ internal sealed class FakePlanningApplicationRepository : IPlanningApplicationRe
         return Task.CompletedTask;
     }
 
-    public Task<PlanningApplication?> GetByUidAsync(string uid, CancellationToken ct)
+    public Task<PlanningApplication?> GetByUidCrossPartitionAsync(string uid, CancellationToken ct)
     {
         this.GetByUidWithoutAuthorityCallCount++;
         var app = this.store.Values.FirstOrDefault(a => a.Uid == uid);

--- a/api/tests/town-crier.application.tests/Polling/FakeWatchZoneRepository.cs
+++ b/api/tests/town-crier.application.tests/Polling/FakeWatchZoneRepository.cs
@@ -56,7 +56,7 @@ internal sealed class FakeWatchZoneRepository : IWatchZoneRepository
         return Task.CompletedTask;
     }
 
-    public Task<IReadOnlyCollection<int>> GetDistinctAuthorityIdsAsync(CancellationToken ct)
+    public Task<IReadOnlyCollection<int>> GetDistinctAuthorityIdsCrossPartitionAsync(CancellationToken ct)
     {
         var authorityIds = this.zones
             .Select(z => z.AuthorityId)
@@ -66,7 +66,7 @@ internal sealed class FakeWatchZoneRepository : IWatchZoneRepository
         return Task.FromResult<IReadOnlyCollection<int>>(authorityIds);
     }
 
-    public Task<Dictionary<int, int>> GetZoneCountsByAuthorityAsync(CancellationToken ct)
+    public Task<Dictionary<int, int>> GetZoneCountsByAuthorityCrossPartitionAsync(CancellationToken ct)
     {
         var counts = this.zones
             .GroupBy(z => z.AuthorityId)
@@ -74,7 +74,7 @@ internal sealed class FakeWatchZoneRepository : IWatchZoneRepository
         return Task.FromResult(counts);
     }
 
-    public Task<IReadOnlyCollection<WatchZone>> FindZonesContainingAsync(
+    public Task<IReadOnlyCollection<WatchZone>> FindZonesContainingCrossPartitionAsync(
         double latitude, double longitude, CancellationToken ct)
     {
         this.FindZonesContainingCallCount++;

--- a/api/tests/town-crier.application.tests/SavedApplications/FailIfCalledPlanningApplicationRepository.cs
+++ b/api/tests/town-crier.application.tests/SavedApplications/FailIfCalledPlanningApplicationRepository.cs
@@ -15,7 +15,7 @@ internal sealed class FailIfCalledPlanningApplicationRepository : IPlanningAppli
         throw new InvalidOperationException(
             "Planning repository must not be touched on the saved-list happy path. See bd tc-udby.");
 
-    public Task<PlanningApplication?> GetByUidAsync(string uid, CancellationToken ct) =>
+    public Task<PlanningApplication?> GetByUidCrossPartitionAsync(string uid, CancellationToken ct) =>
         throw new InvalidOperationException(
             "Planning repository must not be touched on the saved-list happy path. See bd tc-udby.");
 

--- a/api/tests/town-crier.application.tests/SavedApplications/FakeSavedApplicationRepository.cs
+++ b/api/tests/town-crier.application.tests/SavedApplications/FakeSavedApplicationRepository.cs
@@ -50,7 +50,7 @@ internal sealed class FakeSavedApplicationRepository : ISavedApplicationReposito
         return Task.FromResult(exists);
     }
 
-    public Task<IReadOnlyList<string>> GetUserIdsForApplicationAsync(string applicationUid, int authorityId, CancellationToken ct)
+    public Task<IReadOnlyList<string>> GetUserIdsForApplicationCrossPartitionAsync(string applicationUid, int authorityId, CancellationToken ct)
     {
         var userIds = this.store
             .Where(s => s.ApplicationUid == applicationUid && s.AuthorityId == authorityId)

--- a/api/tests/town-crier.application.tests/SavedApplications/SaveApplicationCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/SavedApplications/SaveApplicationCommandHandlerTests.cs
@@ -35,7 +35,7 @@ public sealed class SaveApplicationCommandHandlerTests
 
         // Assert — application was also upserted to the planning repository.
         await Assert.That(planningRepository.UpsertCallCount).IsEqualTo(1);
-        var stored = await planningRepository.GetByUidAsync("planit-uid-abc", CancellationToken.None);
+        var stored = await planningRepository.GetByUidCrossPartitionAsync("planit-uid-abc", CancellationToken.None);
         await Assert.That(stored).IsNotNull();
         await Assert.That(stored!.Name).IsEqualTo("Camden/CAM/24/0042/FUL");
     }

--- a/api/tests/town-crier.application.tests/UserProfiles/FakeUserProfileRepository.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/FakeUserProfileRepository.cs
@@ -15,14 +15,14 @@ internal sealed class FakeUserProfileRepository : IUserProfileRepository
         return Task.FromResult(profile);
     }
 
-    public Task<UserProfile?> GetByEmailAsync(string email, CancellationToken ct)
+    public Task<UserProfile?> GetByEmailCrossPartitionAsync(string email, CancellationToken ct)
     {
         var profile = this.store.Values
             .FirstOrDefault(p => string.Equals(p.Email, email, StringComparison.OrdinalIgnoreCase));
         return Task.FromResult(profile);
     }
 
-    public Task<IReadOnlyList<UserProfile>> GetAllByTierAsync(SubscriptionTier tier, CancellationToken ct)
+    public Task<IReadOnlyList<UserProfile>> GetAllByTierCrossPartitionAsync(SubscriptionTier tier, CancellationToken ct)
     {
         var profiles = this.store.Values
             .Where(p => p.Tier == tier)
@@ -30,7 +30,7 @@ internal sealed class FakeUserProfileRepository : IUserProfileRepository
         return Task.FromResult<IReadOnlyList<UserProfile>>(profiles);
     }
 
-    public Task<IReadOnlyList<UserProfile>> GetAllByDigestDayAsync(DayOfWeek digestDay, CancellationToken ct)
+    public Task<IReadOnlyList<UserProfile>> GetAllByDigestDayCrossPartitionAsync(DayOfWeek digestDay, CancellationToken ct)
     {
         var profiles = this.store.Values
             .Where(p => p.NotificationPreferences.DigestDay == digestDay)
@@ -38,7 +38,7 @@ internal sealed class FakeUserProfileRepository : IUserProfileRepository
         return Task.FromResult<IReadOnlyList<UserProfile>>(profiles);
     }
 
-    public Task<UserProfile?> GetByOriginalTransactionIdAsync(string originalTransactionId, CancellationToken ct)
+    public Task<UserProfile?> GetByOriginalTransactionIdCrossPartitionAsync(string originalTransactionId, CancellationToken ct)
     {
         var profile = this.store.Values
             .FirstOrDefault(p => p.OriginalTransactionId == originalTransactionId);
@@ -57,7 +57,7 @@ internal sealed class FakeUserProfileRepository : IUserProfileRepository
         return Task.CompletedTask;
     }
 
-    public Task<IReadOnlyList<UserProfile>> GetDormantAsync(DateTimeOffset cutoff, CancellationToken ct)
+    public Task<IReadOnlyList<UserProfile>> GetDormantCrossPartitionAsync(DateTimeOffset cutoff, CancellationToken ct)
     {
         var profiles = this.store.Values
             .Where(p => p.LastActiveAt < cutoff)
@@ -65,7 +65,7 @@ internal sealed class FakeUserProfileRepository : IUserProfileRepository
         return Task.FromResult<IReadOnlyList<UserProfile>>(profiles);
     }
 
-    public Task<UserProfilePage> ListAsync(
+    public Task<UserProfilePage> ListCrossPartitionAsync(
         string? emailSearch, int pageSize, string? continuationToken, CancellationToken ct)
     {
         var profiles = this.store.Values.AsEnumerable();

--- a/api/tests/town-crier.application.tests/UserProfiles/FakeUserProfileRepositoryTests.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/FakeUserProfileRepositoryTests.cs
@@ -14,7 +14,7 @@ public sealed class FakeUserProfileRepositoryTests
         await repository.SaveAsync(profile, CancellationToken.None);
 
         // Act
-        var result = await repository.GetByEmailAsync("test@example.com", CancellationToken.None);
+        var result = await repository.GetByEmailCrossPartitionAsync("test@example.com", CancellationToken.None);
 
         // Assert
         await Assert.That(result).IsNotNull();
@@ -28,7 +28,7 @@ public sealed class FakeUserProfileRepositoryTests
         var repository = new FakeUserProfileRepository();
 
         // Act
-        var result = await repository.GetByEmailAsync("nobody@example.com", CancellationToken.None);
+        var result = await repository.GetByEmailCrossPartitionAsync("nobody@example.com", CancellationToken.None);
 
         // Assert
         await Assert.That(result).IsNull();

--- a/api/tests/town-crier.application.tests/UserProfiles/SaveCountingUserProfileRepository.cs
+++ b/api/tests/town-crier.application.tests/UserProfiles/SaveCountingUserProfileRepository.cs
@@ -21,39 +21,39 @@ internal sealed class SaveCountingUserProfileRepository : IUserProfileRepository
         return Task.FromResult(profile);
     }
 
-    public Task<UserProfile?> GetByEmailAsync(string email, CancellationToken ct)
+    public Task<UserProfile?> GetByEmailCrossPartitionAsync(string email, CancellationToken ct)
     {
         var profile = this.store.Values
             .FirstOrDefault(p => string.Equals(p.Email, email, StringComparison.OrdinalIgnoreCase));
         return Task.FromResult(profile);
     }
 
-    public Task<IReadOnlyList<UserProfile>> GetAllByTierAsync(SubscriptionTier tier, CancellationToken ct)
+    public Task<IReadOnlyList<UserProfile>> GetAllByTierCrossPartitionAsync(SubscriptionTier tier, CancellationToken ct)
     {
         IReadOnlyList<UserProfile> profiles = this.store.Values.Where(p => p.Tier == tier).ToList();
         return Task.FromResult(profiles);
     }
 
-    public Task<IReadOnlyList<UserProfile>> GetAllByDigestDayAsync(DayOfWeek digestDay, CancellationToken ct)
+    public Task<IReadOnlyList<UserProfile>> GetAllByDigestDayCrossPartitionAsync(DayOfWeek digestDay, CancellationToken ct)
     {
         IReadOnlyList<UserProfile> profiles =
             this.store.Values.Where(p => p.NotificationPreferences.DigestDay == digestDay).ToList();
         return Task.FromResult(profiles);
     }
 
-    public Task<UserProfile?> GetByOriginalTransactionIdAsync(string originalTransactionId, CancellationToken ct)
+    public Task<UserProfile?> GetByOriginalTransactionIdCrossPartitionAsync(string originalTransactionId, CancellationToken ct)
     {
         var profile = this.store.Values.FirstOrDefault(p => p.OriginalTransactionId == originalTransactionId);
         return Task.FromResult(profile);
     }
 
-    public Task<IReadOnlyList<UserProfile>> GetDormantAsync(DateTimeOffset cutoff, CancellationToken ct)
+    public Task<IReadOnlyList<UserProfile>> GetDormantCrossPartitionAsync(DateTimeOffset cutoff, CancellationToken ct)
     {
         IReadOnlyList<UserProfile> profiles = this.store.Values.Where(p => p.LastActiveAt < cutoff).ToList();
         return Task.FromResult(profiles);
     }
 
-    public Task<UserProfilePage> ListAsync(
+    public Task<UserProfilePage> ListCrossPartitionAsync(
         string? emailSearch, int pageSize, string? continuationToken, CancellationToken ct)
     {
         IReadOnlyList<UserProfile> profiles = this.store.Values.ToList();

--- a/api/tests/town-crier.application.tests/WatchZones/CreateWatchZoneCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/WatchZones/CreateWatchZoneCommandHandlerTests.cs
@@ -30,7 +30,7 @@ public sealed class CreateWatchZoneCommandHandlerTests
         await handler.HandleAsync(command, CancellationToken.None);
 
         // Assert
-        var zones = await this.watchZoneRepository.FindZonesContainingAsync(51.5074, -0.1278, CancellationToken.None);
+        var zones = await this.watchZoneRepository.FindZonesContainingCrossPartitionAsync(51.5074, -0.1278, CancellationToken.None);
         await Assert.That(zones).HasCount().EqualTo(1);
         await Assert.That(zones.First().UserId).IsEqualTo("user-1");
         await Assert.That(zones.First().AuthorityId).IsEqualTo(42);
@@ -51,7 +51,7 @@ public sealed class CreateWatchZoneCommandHandlerTests
         await handler.HandleAsync(command, CancellationToken.None);
 
         // Assert
-        var zones = await this.watchZoneRepository.FindZonesContainingAsync(51.5074, -0.1278, CancellationToken.None);
+        var zones = await this.watchZoneRepository.FindZonesContainingCrossPartitionAsync(51.5074, -0.1278, CancellationToken.None);
         await Assert.That(zones.First().CreatedAt).IsEqualTo(FixedNow);
     }
 
@@ -106,7 +106,7 @@ public sealed class CreateWatchZoneCommandHandlerTests
         await handler.HandleAsync(command, CancellationToken.None);
 
         // Assert
-        var zones = await this.watchZoneRepository.FindZonesContainingAsync(51.5074, -0.1278, CancellationToken.None);
+        var zones = await this.watchZoneRepository.FindZonesContainingCrossPartitionAsync(51.5074, -0.1278, CancellationToken.None);
         await Assert.That(zones).HasCount().EqualTo(1);
     }
 
@@ -269,7 +269,7 @@ public sealed class CreateWatchZoneCommandHandlerTests
         await handler.HandleAsync(command, CancellationToken.None);
 
         // Assert
-        var zones = await this.watchZoneRepository.FindZonesContainingAsync(51.5074, -0.1278, CancellationToken.None);
+        var zones = await this.watchZoneRepository.FindZonesContainingCrossPartitionAsync(51.5074, -0.1278, CancellationToken.None);
         await Assert.That(zones).HasCount().EqualTo(1);
         await Assert.That(zones.First().AuthorityId).IsEqualTo(42);
     }

--- a/api/tests/town-crier.infrastructure.tests/PlanningApplications/CosmosPlanningApplicationRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/PlanningApplications/CosmosPlanningApplicationRepositoryTests.cs
@@ -18,7 +18,7 @@ public sealed class CosmosPlanningApplicationRepositoryTests
         await repo.UpsertAsync(app, CancellationToken.None);
 
         // Assert
-        var result = await repo.GetByUidAsync("uid-1", CancellationToken.None);
+        var result = await repo.GetByUidCrossPartitionAsync("uid-1", CancellationToken.None);
         await Assert.That(result).IsNotNull();
         await Assert.That(result!.Uid).IsEqualTo("uid-1");
     }
@@ -31,7 +31,7 @@ public sealed class CosmosPlanningApplicationRepositoryTests
         var repo = new CosmosPlanningApplicationRepository(client);
 
         // Act
-        var result = await repo.GetByUidAsync("nonexistent", CancellationToken.None);
+        var result = await repo.GetByUidCrossPartitionAsync("nonexistent", CancellationToken.None);
 
         // Assert
         await Assert.That(result).IsNull();

--- a/api/tests/town-crier.infrastructure.tests/SavedApplications/CosmosSavedApplicationRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/SavedApplications/CosmosSavedApplicationRepositoryTests.cs
@@ -89,7 +89,7 @@ public sealed class CosmosSavedApplicationRepositoryTests
         var repo = new CosmosSavedApplicationRepository(client);
 
         // Act -- empty store, verifies wiring
-        var result = await repo.GetUserIdsForApplicationAsync("nonexistent", authorityId: 1, CancellationToken.None);
+        var result = await repo.GetUserIdsForApplicationCrossPartitionAsync("nonexistent", authorityId: 1, CancellationToken.None);
 
         // Assert
         await Assert.That(result.Count).IsEqualTo(0);

--- a/api/tests/town-crier.infrastructure.tests/UserProfiles/CosmosUserProfileRepositoryListTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/UserProfiles/CosmosUserProfileRepositoryListTests.cs
@@ -21,7 +21,7 @@ public sealed class CosmosUserProfileRepositoryListTests
         client.SetPageQueryResults("SELECT * FROM c", docs);
 
         // Act
-        var result = await repo.ListAsync(null, 20, null, CancellationToken.None);
+        var result = await repo.ListCrossPartitionAsync(null, 20, null, CancellationToken.None);
 
         // Assert
         await Assert.That(result.Profiles).HasCount().EqualTo(2);
@@ -43,7 +43,7 @@ public sealed class CosmosUserProfileRepositoryListTests
         client.SetPageQueryResults("SELECT * FROM c WHERE CONTAINS", docs);
 
         // Act
-        var result = await repo.ListAsync("gmail", 20, null, CancellationToken.None);
+        var result = await repo.ListCrossPartitionAsync("gmail", 20, null, CancellationToken.None);
 
         // Assert
         await Assert.That(result.Profiles).HasCount().EqualTo(1);
@@ -60,7 +60,7 @@ public sealed class CosmosUserProfileRepositoryListTests
         var client = new FakeCosmosRestClient();
         var repo = new CosmosUserProfileRepository(client);
 
-        await repo.ListAsync(null, 20, null, CancellationToken.None);
+        await repo.ListCrossPartitionAsync(null, 20, null, CancellationToken.None);
 
         await Assert.That(client.LastPageQuerySql).IsNotNull();
         await Assert.That(client.LastPageQuerySql!).DoesNotContain("ORDER BY");
@@ -72,7 +72,7 @@ public sealed class CosmosUserProfileRepositoryListTests
         var client = new FakeCosmosRestClient();
         var repo = new CosmosUserProfileRepository(client);
 
-        await repo.ListAsync("gmail", 20, null, CancellationToken.None);
+        await repo.ListCrossPartitionAsync("gmail", 20, null, CancellationToken.None);
 
         await Assert.That(client.LastPageQuerySql).IsNotNull();
         await Assert.That(client.LastPageQuerySql!).DoesNotContain("ORDER BY");
@@ -92,7 +92,7 @@ public sealed class CosmosUserProfileRepositoryListTests
         client.SetPageQueryResults("SELECT * FROM c", docs, "next-page-token");
 
         // Act
-        var result = await repo.ListAsync(null, 1, null, CancellationToken.None);
+        var result = await repo.ListCrossPartitionAsync(null, 1, null, CancellationToken.None);
 
         // Assert
         await Assert.That(result.ContinuationToken).IsEqualTo("next-page-token");

--- a/api/tests/town-crier.infrastructure.tests/UserProfiles/CosmosUserProfileRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/UserProfiles/CosmosUserProfileRepositoryTests.cs
@@ -99,7 +99,7 @@ public sealed class CosmosUserProfileRepositoryTests
         await repo.SaveAsync(profile2, CancellationToken.None);
 
         // Act — both default to Free tier
-        var result = await repo.GetAllByTierAsync(SubscriptionTier.Free, CancellationToken.None);
+        var result = await repo.GetAllByTierCrossPartitionAsync(SubscriptionTier.Free, CancellationToken.None);
 
         // Assert
         await Assert.That(result.Count).IsGreaterThanOrEqualTo(2);

--- a/api/tests/town-crier.infrastructure.tests/WatchZones/CosmosWatchZoneRepositoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/WatchZones/CosmosWatchZoneRepositoryTests.cs
@@ -86,7 +86,7 @@ public sealed class CosmosWatchZoneRepositoryTests
         await repo.SaveAsync(zone, CancellationToken.None);
 
         // Act — fake returns all documents in collection (no SQL parsing)
-        var result = await repo.FindZonesContainingAsync(51.5, -0.1, CancellationToken.None);
+        var result = await repo.FindZonesContainingCrossPartitionAsync(51.5, -0.1, CancellationToken.None);
 
         // Assert
         await Assert.That(result.Count).IsGreaterThanOrEqualTo(1);
@@ -100,7 +100,7 @@ public sealed class CosmosWatchZoneRepositoryTests
         var repo = new CosmosWatchZoneRepository(client);
 
         // Act — empty store, verifies wiring compiles and runs
-        var result = await repo.GetDistinctAuthorityIdsAsync(CancellationToken.None);
+        var result = await repo.GetDistinctAuthorityIdsCrossPartitionAsync(CancellationToken.None);
 
         // Assert
         await Assert.That(result.Count).IsEqualTo(0);
@@ -115,7 +115,7 @@ public sealed class CosmosWatchZoneRepositoryTests
         var repo = new CosmosWatchZoneRepository(client);
 
         // Act
-        var result = await repo.GetDistinctAuthorityIdsAsync(CancellationToken.None);
+        var result = await repo.GetDistinctAuthorityIdsCrossPartitionAsync(CancellationToken.None);
 
         // Assert — duplicates from overlapping partition ranges must be removed
         await Assert.That(result.Count).IsEqualTo(3);
@@ -132,7 +132,7 @@ public sealed class CosmosWatchZoneRepositoryTests
         var repo = new CosmosWatchZoneRepository(client);
 
         // Act — empty store, verifies wiring compiles and runs
-        var result = await repo.GetZoneCountsByAuthorityAsync(CancellationToken.None);
+        var result = await repo.GetZoneCountsByAuthorityCrossPartitionAsync(CancellationToken.None);
 
         // Assert
         await Assert.That(result.Count).IsEqualTo(0);
@@ -156,7 +156,7 @@ public sealed class CosmosWatchZoneRepositoryTests
         var repo = new CosmosWatchZoneRepository(client);
 
         // Act
-        var result = await repo.GetZoneCountsByAuthorityAsync(CancellationToken.None);
+        var result = await repo.GetZoneCountsByAuthorityCrossPartitionAsync(CancellationToken.None);
 
         // Assert — partial aggregates for same authority must be summed
         await Assert.That(result.Count).IsEqualTo(2);

--- a/api/tests/town-crier.web.tests/Architecture/CrossPartitionGuardTests.cs
+++ b/api/tests/town-crier.web.tests/Architecture/CrossPartitionGuardTests.cs
@@ -1,0 +1,373 @@
+using System.Reflection;
+using TownCrier.Application.Notifications;
+using TownCrier.Application.OfferCodes;
+using TownCrier.Application.PlanningApplications;
+using TownCrier.Application.SavedApplications;
+using TownCrier.Application.UserProfiles;
+using TownCrier.Application.WatchZones;
+using TownCrier.Domain.UserProfiles;
+
+namespace TownCrier.Web.Tests.Architecture;
+
+/// <summary>
+/// Structural guard for GH#395 Invariant 2: repository methods that execute
+/// cross-partition Cosmos queries are tagged with the <c>CrossPartition</c>
+/// suffix, and no user-facing handler (registered in the web DI container) may
+/// call any such method. Tests use IL reflection — allowed in test code which
+/// is NOT AOT-compiled.
+/// </summary>
+public sealed class CrossPartitionGuardTests
+{
+    // Admin handlers are explicitly excluded — owner-only ad-hoc tools (GH#395 "Out of scope").
+    private static readonly HashSet<string> AdminHandlerNames = new(StringComparer.Ordinal)
+    {
+        "ListUsersQueryHandler",
+        "GrantSubscriptionCommandHandler",
+    };
+
+    // Mirrors AddApplicationServices in ServiceCollectionExtensions.cs.
+    // Must be kept in sync when new handlers are added to the web DI container.
+    private static readonly HashSet<string> WebDiHandlerNames = new(StringComparer.Ordinal)
+    {
+        "GeocodePostcodeQueryHandler",
+        "GetAuthoritiesQueryHandler",
+        "GetAuthorityByIdQueryHandler",
+        "GetDesignationContextQueryHandler",
+        "CreateUserProfileCommandHandler",
+        "GetUserProfileQueryHandler",
+        "UpdateUserProfileCommandHandler",
+        "ExportUserDataQueryHandler",
+        "DeleteUserProfileCommandHandler",
+        "UpdateZonePreferencesCommandHandler",
+        "GetZonePreferencesQueryHandler",
+        "RecordUserActivityCommandHandler",
+        "CreateWatchZoneCommandHandler",
+        "UpdateWatchZoneCommandHandler",
+        "ListWatchZonesQueryHandler",
+        "DeleteWatchZoneCommandHandler",
+        "GetApplicationsByZoneQueryHandler",
+        "RegisterDeviceTokenCommandHandler",
+        "RemoveInvalidDeviceTokenCommandHandler",
+        "GetApplicationByUidQueryHandler",
+        "GetApplicationByAuthorityAndNameQueryHandler",
+        "GetUserApplicationAuthoritiesQueryHandler",
+        "SaveApplicationCommandHandler",
+        "RemoveSavedApplicationCommandHandler",
+        "GetSavedApplicationsQueryHandler",
+        "GetNotificationStateQueryHandler",
+        "MarkAllNotificationsReadCommandHandler",
+        "AdvanceNotificationStateCommandHandler",
+        "GetDemoAccountQueryHandler",
+        "GenerateOfferCodesCommandHandler",
+        "RedeemOfferCodeCommandHandler",
+    };
+
+    // Part 1: cross-partition suffix exists on the repository interfaces.
+    // Each test below will FAIL (Red) until the methods are renamed, then
+    // PASS (Green) once the interface signatures carry the CrossPartition suffix.
+    [Test]
+    public async Task IPlanningApplicationRepository_Should_ExposeGetByUidCrossPartitionAsync()
+    {
+        var method = typeof(IPlanningApplicationRepository).GetMethod(
+            "GetByUidCrossPartitionAsync",
+            [typeof(string), typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    [Test]
+    public async Task ISavedApplicationRepository_Should_ExposeGetUserIdsForApplicationCrossPartitionAsync()
+    {
+        var method = typeof(ISavedApplicationRepository).GetMethod(
+            "GetUserIdsForApplicationCrossPartitionAsync",
+            [typeof(string), typeof(int), typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    [Test]
+    public async Task IUserProfileRepository_Should_ExposeGetByEmailCrossPartitionAsync()
+    {
+        var method = typeof(IUserProfileRepository).GetMethod(
+            "GetByEmailCrossPartitionAsync",
+            [typeof(string), typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    [Test]
+    public async Task IUserProfileRepository_Should_ExposeGetAllByTierCrossPartitionAsync()
+    {
+        var method = typeof(IUserProfileRepository).GetMethod(
+            "GetAllByTierCrossPartitionAsync",
+            [typeof(SubscriptionTier), typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    [Test]
+    public async Task IUserProfileRepository_Should_ExposeGetAllByDigestDayCrossPartitionAsync()
+    {
+        var method = typeof(IUserProfileRepository).GetMethod(
+            "GetAllByDigestDayCrossPartitionAsync",
+            [typeof(DayOfWeek), typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    [Test]
+    public async Task IUserProfileRepository_Should_ExposeGetByOriginalTransactionIdCrossPartitionAsync()
+    {
+        var method = typeof(IUserProfileRepository).GetMethod(
+            "GetByOriginalTransactionIdCrossPartitionAsync",
+            [typeof(string), typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    [Test]
+    public async Task IUserProfileRepository_Should_ExposeGetDormantCrossPartitionAsync()
+    {
+        var method = typeof(IUserProfileRepository).GetMethod(
+            "GetDormantCrossPartitionAsync",
+            [typeof(DateTimeOffset), typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    [Test]
+    public async Task IUserProfileRepository_Should_ExposeListCrossPartitionAsync()
+    {
+        var method = typeof(IUserProfileRepository).GetMethod(
+            "ListCrossPartitionAsync",
+            [typeof(string), typeof(int), typeof(string), typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    [Test]
+    public async Task IWatchZoneRepository_Should_ExposeFindZonesContainingCrossPartitionAsync()
+    {
+        var method = typeof(IWatchZoneRepository).GetMethod(
+            "FindZonesContainingCrossPartitionAsync",
+            [typeof(double), typeof(double), typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    [Test]
+    public async Task IWatchZoneRepository_Should_ExposeGetDistinctAuthorityIdsCrossPartitionAsync()
+    {
+        var method = typeof(IWatchZoneRepository).GetMethod(
+            "GetDistinctAuthorityIdsCrossPartitionAsync",
+            [typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    [Test]
+    public async Task IWatchZoneRepository_Should_ExposeGetZoneCountsByAuthorityCrossPartitionAsync()
+    {
+        var method = typeof(IWatchZoneRepository).GetMethod(
+            "GetZoneCountsByAuthorityCrossPartitionAsync",
+            [typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    [Test]
+    public async Task INotificationRepository_Should_ExposeGetUserIdsWithUnsentEmailsCrossPartitionAsync()
+    {
+        var method = typeof(INotificationRepository).GetMethod(
+            "GetUserIdsWithUnsentEmailsCrossPartitionAsync",
+            [typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    [Test]
+    public async Task IOfferCodeRepository_Should_ExposeGetRedeemedByUserIdCrossPartitionAsync()
+    {
+        var method = typeof(IOfferCodeRepository).GetMethod(
+            "GetRedeemedByUserIdCrossPartitionAsync",
+            [typeof(string), typeof(CancellationToken)]);
+
+        await Assert.That(method).IsNotNull();
+    }
+
+    // Part 2: no user-facing web handler calls a *CrossPartitionAsync method.
+    // Uses IL inspection to walk bytecode of every HandleAsync on every handler
+    // registered in the web DI. Fails hard if any call site resolves to a
+    // method whose name contains "CrossPartition".
+    [Test]
+    public async Task No_WebFacingHandler_Should_CallCrossPartitionAsync_Method()
+    {
+        var applicationAssembly = typeof(IPlanningApplicationRepository).Assembly;
+
+        var handlerTypes = applicationAssembly.GetTypes()
+            .Where(t =>
+                !t.IsAbstract
+                && !t.IsInterface
+                && (t.Name.EndsWith("CommandHandler", StringComparison.Ordinal)
+                    || t.Name.EndsWith("QueryHandler", StringComparison.Ordinal))
+                && WebDiHandlerNames.Contains(t.Name)
+                && !AdminHandlerNames.Contains(t.Name))
+            .ToList();
+
+        var violations = new List<string>();
+
+        foreach (var handlerType in handlerTypes)
+        {
+            // NonPublic needed to inspect async state-machine MoveNext methods —
+            // the compiler lowers async lambdas into private nested types.
+#pragma warning disable S3011 // Accessibility bypass is intentional for IL inspection of async state machines
+            var methods = handlerType.GetMethods(
+                BindingFlags.Instance
+                | BindingFlags.Public
+                | BindingFlags.NonPublic
+                | BindingFlags.DeclaredOnly);
+#pragma warning restore S3011
+
+            foreach (var method in methods)
+            {
+                var body = method.GetMethodBody();
+                if (body is null)
+                {
+                    continue;
+                }
+
+                var il = body.GetILAsByteArray();
+                if (il is null)
+                {
+                    continue;
+                }
+
+                var crossPartitionCalls = FindCrossPartitionCallsInIl(handlerType.Module, il);
+                foreach (var callName in crossPartitionCalls)
+                {
+                    violations.Add($"{handlerType.Name}.{method.Name} calls {callName}");
+                }
+            }
+        }
+
+        await Assert.That(violations).IsEmpty()
+            .Because(
+                "User-facing web handlers must not call *CrossPartitionAsync methods. "
+                + "Background workers accept the cost; user requests do not. "
+                + $"Violations: {string.Join(", ", violations)}");
+    }
+
+    private static List<string> FindCrossPartitionCallsInIl(Module module, byte[] il)
+    {
+        var found = new List<string>();
+        var i = 0;
+
+        while (i < il.Length)
+        {
+            int opcode = il[i++];
+
+            // Two-byte opcode prefix
+            if (opcode == 0xFE && i < il.Length)
+            {
+                opcode = (opcode << 8) | il[i++];
+            }
+
+            // call = 0x28, callvirt = 0x6F, ldftn = 0xFE06, ldvirtftn = 0xFE07
+            bool isCallSite = opcode is 0x28 or 0x6F or 0xFE06 or 0xFE07;
+
+            if (isCallSite && i + 3 < il.Length)
+            {
+                var token = il[i] | (il[i + 1] << 8) | (il[i + 2] << 16) | (il[i + 3] << 24);
+                i += 4;
+
+                try
+                {
+                    var calledMethod = module.ResolveMethod(token);
+                    if (calledMethod is not null
+                        && calledMethod.Name.Contains("CrossPartition", StringComparison.OrdinalIgnoreCase))
+                    {
+                        found.Add($"{calledMethod.DeclaringType?.Name}.{calledMethod.Name}");
+                    }
+                }
+#pragma warning disable CA1031 // Swallow token resolution errors — generic tokens may not resolve
+                catch (Exception)
+#pragma warning restore CA1031
+                {
+                    // Generic instantiation tokens may not resolve; skip and continue.
+                }
+            }
+            else
+            {
+                i += GetInlineOperandSize(opcode);
+            }
+        }
+
+        return found;
+    }
+
+    // Returns inline operand byte count for each opcode per ECMA-335 Table III.1.
+    // Used to advance the IL scanner past instructions that are not call sites.
+    private static int GetInlineOperandSize(int opcode) => opcode switch
+    {
+        0x00 or 0x01 or 0x02 or 0x03 or 0x04 or 0x05 => 0, // nop/break/ldarg.0-3
+        0x06 or 0x07 or 0x08 or 0x09 => 0,                  // ldloc.0-3
+        0x0A or 0x0B or 0x0C or 0x0D => 0,                  // stloc.0-3
+        0x0E or 0x0F or 0x10 or 0x11 or 0x12 or 0x13 => 1, // ldarg.s ldarga.s starg.s ldloc.s ldloca.s stloc.s
+        >= 0x14 and <= 0x1E => 0,                            // ldnull ldc.i4.m1 ldc.i4.0-8
+        0x1F => 1,                                           // ldc.i4.s
+        0x20 => 4,                                           // ldc.i4
+        0x21 => 8,                                           // ldc.i8
+        0x22 => 4,                                           // ldc.r4
+        0x23 => 8,                                           // ldc.r8
+        0x25 or 0x26 => 0,                                   // dup pop
+        0x27 => 4,                                           // jmp
+        0x29 => 4,                                           // calli
+        0x2A => 0,                                           // ret
+        0x2B or 0x2C or 0x2D => 1,                          // br.s brfalse.s brtrue.s
+        >= 0x2E and <= 0x37 => 1,                            // short branch comparisons
+        >= 0x38 and <= 0x44 => 4,                            // long branches
+        >= 0x46 and <= 0x57 => 0,                            // ldind/stind
+        >= 0x58 and <= 0x66 => 0,                            // arithmetic/bitwise
+        >= 0x67 and <= 0x6E => 0,                            // conv.i1 conv.i2 conv.i4 conv.i8 conv.r4 conv.r8 conv.u4 conv.u8
+        0x70 or 0x71 or 0x72 or 0x73 or 0x74 or 0x75 => 4, // cpobj ldobj ldstr newobj castclass isinst
+        0x76 => 0,                                           // conv.r.un
+        0x79 => 4,                                           // unbox
+        0x7A => 0,                                           // throw
+        0x7B or 0x7C or 0x7D => 4,                          // ldfld ldflda stfld
+        0x7E or 0x7F or 0x80 => 4,                          // ldsfld ldsflda stsfld
+        0x81 => 4,                                           // stobj
+        >= 0x82 and <= 0x8B => 0,                            // conv.ovf.*
+        0x8C or 0x8D => 4,                                   // box newarr
+        0x8E => 0,                                           // ldlen
+        0x8F => 4,                                           // ldelema
+        >= 0x90 and <= 0xA2 => 0,                            // ldelem/stelem short forms
+        0xA3 or 0xA4 or 0xA5 => 4,                          // ldelem stelem unbox.any
+        >= 0xB3 and <= 0xBA => 0,                            // conv.ovf.*
+        0xC2 => 4,                                           // refanyval
+        0xC3 => 0,                                           // ckfinite
+        0xC6 => 4,                                           // mkrefany
+        0xD0 => 4,                                           // ldtoken
+        0xD1 or 0xD2 or 0xD3 => 0,                          // conv.u2 conv.u1 conv.i
+        0xD4 or 0xD5 => 0,                                   // conv.ovf.i conv.ovf.u
+        >= 0xD6 and <= 0xDB => 0,                            // add/sub/mul ovf variants
+        0xDC => 0,                                           // endfinally
+        0xDD => 4,                                           // leave
+        0xDE => 1,                                           // leave.s
+        0xDF => 0,                                           // stind.i
+        0xE0 => 0,                                           // conv.u
+        0xFE00 => 0,                                         // arglist
+        >= 0xFE01 and <= 0xFE05 => 0,                        // ceq cgt cgt.un clt clt.un
+        0xFE08 or 0xFE09 or 0xFE0A => 2,                    // ldarg ldarga starg
+        0xFE0B or 0xFE0C or 0xFE0D => 2,                    // ldloc ldloca stloc
+        0xFE0E => 0,                                         // localloc
+        0xFE10 => 0,                                         // endfilter
+        0xFE11 => 1,                                         // unaligned.
+        0xFE12 or 0xFE13 => 0,                              // volatile. tail.
+        0xFE14 or 0xFE15 => 4,                              // initobj constrained.
+        0xFE16 or 0xFE17 => 0,                              // cpblk initblk
+        0xFE19 => 0,                                         // rethrow
+        0xFE1B => 4,                                         // sizeof
+        0xFE1C or 0xFE1D => 0,                              // refanytype readonly.
+        _ => 0,
+    };
+}

--- a/api/tests/town-crier.web.tests/Observability/ServerRequestTracingTests.cs
+++ b/api/tests/town-crier.web.tests/Observability/ServerRequestTracingTests.cs
@@ -226,16 +226,16 @@ public sealed class ServerRequestTracingTests
         public Task<UserProfile?> GetByUserIdAsync(string userId, CancellationToken ct) =>
             throw new InvalidOperationException("Simulated repository failure");
 
-        public Task<UserProfile?> GetByEmailAsync(string email, CancellationToken ct) =>
+        public Task<UserProfile?> GetByEmailCrossPartitionAsync(string email, CancellationToken ct) =>
             throw new InvalidOperationException("Simulated repository failure");
 
-        public Task<IReadOnlyList<UserProfile>> GetAllByTierAsync(SubscriptionTier tier, CancellationToken ct) =>
+        public Task<IReadOnlyList<UserProfile>> GetAllByTierCrossPartitionAsync(SubscriptionTier tier, CancellationToken ct) =>
             throw new InvalidOperationException("Simulated repository failure");
 
-        public Task<IReadOnlyList<UserProfile>> GetAllByDigestDayAsync(DayOfWeek digestDay, CancellationToken ct) =>
+        public Task<IReadOnlyList<UserProfile>> GetAllByDigestDayCrossPartitionAsync(DayOfWeek digestDay, CancellationToken ct) =>
             throw new InvalidOperationException("Simulated repository failure");
 
-        public Task<UserProfile?> GetByOriginalTransactionIdAsync(string originalTransactionId, CancellationToken ct) =>
+        public Task<UserProfile?> GetByOriginalTransactionIdCrossPartitionAsync(string originalTransactionId, CancellationToken ct) =>
             throw new InvalidOperationException("Simulated repository failure");
 
         public Task SaveAsync(UserProfile profile, CancellationToken ct) =>
@@ -244,11 +244,11 @@ public sealed class ServerRequestTracingTests
         public Task DeleteAsync(string userId, CancellationToken ct) =>
             throw new InvalidOperationException("Simulated repository failure");
 
-        public Task<UserProfilePage> ListAsync(
+        public Task<UserProfilePage> ListCrossPartitionAsync(
             string? emailSearch, int pageSize, string? continuationToken, CancellationToken ct) =>
             throw new InvalidOperationException("Simulated repository failure");
 
-        public Task<IReadOnlyList<UserProfile>> GetDormantAsync(DateTimeOffset cutoff, CancellationToken ct) =>
+        public Task<IReadOnlyList<UserProfile>> GetDormantCrossPartitionAsync(DateTimeOffset cutoff, CancellationToken ct) =>
             throw new InvalidOperationException("Simulated repository failure");
     }
 }


### PR DESCRIPTION
## Summary
Implements Bead D of epic tc-dzwo (issue #395) — makes Invariant 2 structural.

- Every worker-only cross-partition Cosmos query method renamed with an explicit `*CrossPartitionAsync` suffix so the cost is visible at every call site (Notification, OfferCode, PlanningApplication `GetByUid`, SavedApplication, UserProfile ×6, WatchZone ×3)
- New architecture test (`CrossPartitionGuardTests`) asserts no user-facing handler depends on a `*CrossPartitionAsync` method
- User-facing handlers take partition-key-bearing parameters; background workers keep the cross-partition methods (correct, low-frequency)

## Test plan
- [x] `dotnet build` clean, `dotnet format` clean
- [x] 1033 unit/web/infrastructure tests pass, including the new architecture test
- [ ] CI green

Closes #395 (final bead of the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal database query patterns across multiple application modules to improve data retrieval efficiency. These changes are internal optimizations that do not affect user-facing functionality or behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmyDe/town-crier/pull/399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->