### PR TITLE
Fix saved-screen duplicate bug: canonical uid keying + migration + iOS state check (tc-o88i, tc-sqr3, tc-jjl4)

### DIFF
--- a/api/src/town-crier.application/Notifications/DispatchDecisionEventCommandHandler.cs
+++ b/api/src/town-crier.application/Notifications/DispatchDecisionEventCommandHandler.cs
@@ -89,9 +89,20 @@ public sealed class DispatchDecisionEventCommandHandler
         // PlanIt uids are only unique within a council, so a uid-only lookup
         // would falsely match users who saved a same-uid app in a different
         // authority (bd tc-th98 / GH#384).
-        var savedUserIds = await this.savedApplicationRepository
-            .GetUserIdsForApplicationCrossPartitionAsync(application.Uid, application.AreaId, ct)
-            .ConfigureAwait(false);
+        //
+        // Saved rows are keyed two ways during the canonical-uid migration window:
+        // legacy rows hold the raw PlanIt uid, while rows saved after bd tc-o88i hold
+        // the canonical {areaId}/{name} uid. We query for both and union the userIds
+        // so decision pushes keep firing for both populations. The raw-uid leg can be
+        // dropped once the one-off legacy migration (bd tc-sqr3) has run.
+        var savedUserIds = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var candidateUid in DistinctSavedRowKeys(application))
+        {
+            var matched = await this.savedApplicationRepository
+                .GetUserIdsForApplicationCrossPartitionAsync(candidateUid, application.AreaId, ct)
+                .ConfigureAwait(false);
+            savedUserIds.UnionWith(matched);
+        }
 
         foreach (var userId in savedUserIds)
         {
@@ -109,6 +120,21 @@ public sealed class DispatchDecisionEventCommandHandler
         {
             await this.DispatchForUserAsync(userId, match.Sources, match.WatchZoneId, application, now, ct)
                 .ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Yields the distinct keys a saved row for this application may be stored under:
+    /// the raw PlanIt uid (legacy rows) and the canonical {areaId}/{name} uid (rows
+    /// saved after bd tc-o88i). Deduplicated so the cross-partition lookup runs once
+    /// when the two forms happen to coincide.
+    /// </summary>
+    private static IEnumerable<string> DistinctSavedRowKeys(PlanningApplication application)
+    {
+        yield return application.Uid;
+        if (!string.Equals(application.CanonicalUid, application.Uid, StringComparison.Ordinal))
+        {
+            yield return application.CanonicalUid;
         }
     }
 

--- a/api/src/town-crier.application/PlanningApplications/GetApplicationByAuthorityAndNameQueryHandler.cs
+++ b/api/src/town-crier.application/PlanningApplications/GetApplicationByAuthorityAndNameQueryHandler.cs
@@ -67,8 +67,12 @@ public sealed class GetApplicationByAuthorityAndNameQueryHandler
     {
         try
         {
+            // Saved rows are keyed on the canonical {areaId}/{name} uid, not the
+            // master record's raw Uid field — align the lookup on CanonicalUid so
+            // snapshot healing fires for stale-format saves (bd tc-o88i).
+            var canonicalUid = application.CanonicalUid;
             var hasSaved = await this.savedApplicationRepository
-                .ExistsAsync(userId, application.Uid, ct).ConfigureAwait(false);
+                .ExistsAsync(userId, canonicalUid, ct).ConfigureAwait(false);
 
             if (!hasSaved)
             {
@@ -79,7 +83,7 @@ public sealed class GetApplicationByAuthorityAndNameQueryHandler
                 .GetByUserIdAsync(userId, ct).ConfigureAwait(false);
 
             var existing = rows.FirstOrDefault(r =>
-                string.Equals(r.ApplicationUid, application.Uid, StringComparison.Ordinal));
+                string.Equals(r.ApplicationUid, canonicalUid, StringComparison.Ordinal));
             var savedAt = existing?.SavedAt ?? DateTimeOffset.UtcNow;
 
             var refreshed = SavedApplication.Create(userId, application, savedAt);

--- a/api/src/town-crier.application/PlanningApplications/GetApplicationByUidQueryHandler.cs
+++ b/api/src/town-crier.application/PlanningApplications/GetApplicationByUidQueryHandler.cs
@@ -87,7 +87,12 @@ public sealed class GetApplicationByUidQueryHandler
     {
         try
         {
-            var hasSaved = await this.savedApplicationRepository.ExistsAsync(userId, application.Uid, ct).ConfigureAwait(false);
+            // Saved rows are keyed on the canonical {areaId}/{name} uid, not the
+            // master record's raw Uid field. Aligning the lookup on CanonicalUid is
+            // what makes snapshot healing actually fire for stale-format saves
+            // (otherwise ExistsAsync silently misses the row — bd tc-o88i).
+            var canonicalUid = application.CanonicalUid;
+            var hasSaved = await this.savedApplicationRepository.ExistsAsync(userId, canonicalUid, ct).ConfigureAwait(false);
             if (!hasSaved)
             {
                 return;
@@ -98,7 +103,7 @@ public sealed class GetApplicationByUidQueryHandler
             // fresh save with the current time — better stale than to bubble.
             var rows = await this.savedApplicationRepository.GetByUserIdAsync(userId, ct).ConfigureAwait(false);
             var existing = rows.FirstOrDefault(r =>
-                string.Equals(r.ApplicationUid, application.Uid, StringComparison.Ordinal));
+                string.Equals(r.ApplicationUid, canonicalUid, StringComparison.Ordinal));
             var savedAt = existing?.SavedAt ?? DateTimeOffset.UtcNow;
 
             var refreshed = SavedApplication.Create(userId, application, savedAt);

--- a/api/src/town-crier.application/SavedApplications/GetSavedApplicationsQueryHandler.cs
+++ b/api/src/town-crier.application/SavedApplications/GetSavedApplicationsQueryHandler.cs
@@ -25,40 +25,108 @@ public sealed class GetSavedApplicationsQueryHandler
         // hydration. See bd tc-udby for the 429 storm this design eliminates.
         var saved = await this.savedRepository.GetByUserIdAsync(query.UserId, ct).ConfigureAwait(false);
 
+        // Track the canonical uids already emitted this read so a legacy+canonical
+        // duplicate pair for the same app collapses to a single row (bd tc-sqr3).
+        var emittedCanonicalUids = new HashSet<string>(StringComparer.Ordinal);
         var results = new List<SavedApplicationResult>(saved.Count);
+
         foreach (var record in saved)
         {
-            var snapshot = record.Application;
-            if (snapshot is null)
+            var hydrated = await this.HydrateAsync(record, ct).ConfigureAwait(false);
+            if (hydrated is null)
             {
-                // Lazy backfill: rows persisted before the snapshot column existed
-                // hold only the uid. Hydrate once and upsert so subsequent reads
-                // are zero-hydration. Self-heals on first read per legacy row.
-                // Uses the partition-scoped uid overload (authorityCode as pk) to
-                // avoid a cross-partition scan. GH#395 Invariant 2.
-                var authorityCode = record.AuthorityId.ToString(System.Globalization.CultureInfo.InvariantCulture);
-                var fetched = await this.applicationRepository.GetByUidAsync(record.ApplicationUid, authorityCode, ct).ConfigureAwait(false);
-                if (fetched is null)
-                {
-                    // Master record gone — exclude rather than failing the whole list.
-                    continue;
-                }
+                // Master record gone — exclude rather than failing the whole list.
+                continue;
+            }
 
-                // Rewrite in place: embed the snapshot but keep the row's existing
-                // ApplicationUid. SavedApplication.Create would re-key to the canonical
-                // uid, orphaning the legacy Cosmos doc and leaving a duplicate. Legacy
-                // re-keying is the dedicated migration's job (bd tc-sqr3 / tc-o88i).
-                var refreshed = record.WithEmbeddedSnapshot(fetched);
-                await this.savedRepository.SaveAsync(refreshed, ct).ConfigureAwait(false);
-                snapshot = fetched;
+            // Lazy migration (bd tc-sqr3): pre-PR#398 rows are keyed on the raw
+            // PlanIt bare ref rather than the canonical {areaId}/{name} uid. Re-key
+            // them to the canonical form so the saved icon colours in and re-saves
+            // stop minting duplicates.
+            var canonical = IsLegacyKeyed(hydrated)
+                ? await this.ReKeyToCanonicalAsync(hydrated, ct).ConfigureAwait(false)
+                : hydrated;
+
+            // Dedup the confirmed legacy+canonical pair: the legacy and canonical
+            // rows both resolve to the same canonical doc id, so emit it at most once.
+            if (!emittedCanonicalUids.Add(canonical.ApplicationUid))
+            {
+                continue;
             }
 
             results.Add(new SavedApplicationResult(
-                record.ApplicationUid,
-                record.SavedAt,
-                GetApplicationByUidQueryHandler.ToResult(snapshot)));
+                canonical.ApplicationUid,
+                canonical.SavedAt,
+                GetApplicationByUidQueryHandler.ToResult(canonical.Application!)));
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// True when the row is keyed on a legacy bare-ref uid rather than the canonical
+    /// {areaId}/{name} uid. Only decidable once the snapshot is embedded — the
+    /// canonical uid is derived from the snapshot.
+    /// </summary>
+    private static bool IsLegacyKeyed(SavedApplication record) =>
+        record.Application is not null
+        && !string.Equals(record.ApplicationUid, record.Application.CanonicalUid, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Ensures the saved record carries an embedded snapshot. Rows persisted before
+    /// the snapshot column existed hold only the uid; they are hydrated once via the
+    /// partition-scoped planning lookup and rewritten in place so subsequent reads are
+    /// zero-hydration. Returns null when the master planning application is gone.
+    /// </summary>
+    private async Task<SavedApplication?> HydrateAsync(SavedApplication record, CancellationToken ct)
+    {
+        if (record.Application is not null)
+        {
+            return record;
+        }
+
+        // Lazy backfill: rows persisted before the snapshot column existed hold only
+        // the uid. Hydrate once and upsert so subsequent reads are zero-hydration.
+        // Uses the partition-scoped uid overload (authorityCode as pk) to avoid a
+        // cross-partition scan. GH#395 Invariant 2.
+        var authorityCode = record.AuthorityId.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var fetched = await this.applicationRepository.GetByUidAsync(record.ApplicationUid, authorityCode, ct).ConfigureAwait(false);
+        if (fetched is null)
+        {
+            return null;
+        }
+
+        // Rewrite in place: embed the snapshot but keep the row's existing
+        // ApplicationUid. Re-keying to the canonical uid happens separately, after
+        // hydration, so the two migration steps stay independently testable.
+        var refreshed = record.WithEmbeddedSnapshot(fetched);
+        await this.savedRepository.SaveAsync(refreshed, ct).ConfigureAwait(false);
+        return refreshed;
+    }
+
+    /// <summary>
+    /// Re-keys a legacy-format saved row to the canonical {areaId}/{name} uid.
+    /// Cosmos doc ids are immutable, so a re-key is a write of the canonical doc plus
+    /// a delete of the legacy doc. When a canonical doc already exists for the same
+    /// user+app (the confirmed legacy+canonical duplicate case) the canonical doc is
+    /// kept untouched and only the legacy doc is deleted (bd tc-sqr3).
+    /// </summary>
+    private async Task<SavedApplication> ReKeyToCanonicalAsync(SavedApplication legacy, CancellationToken ct)
+    {
+        var canonical = SavedApplication.Create(legacy.UserId, legacy.Application!, legacy.SavedAt);
+
+        var canonicalAlreadyExists = await this.savedRepository
+            .ExistsAsync(canonical.UserId, canonical.ApplicationUid, ct).ConfigureAwait(false);
+        if (!canonicalAlreadyExists)
+        {
+            // Write the canonical doc before deleting the legacy one so an
+            // interrupted run leaves a recoverable duplicate, never a lost save.
+            await this.savedRepository.SaveAsync(canonical, ct).ConfigureAwait(false);
+        }
+
+        // The canonical doc is the survivor — drop the legacy duplicate.
+        await this.savedRepository.DeleteAsync(legacy.UserId, legacy.ApplicationUid, ct).ConfigureAwait(false);
+
+        return canonical;
     }
 }

--- a/api/src/town-crier.application/SavedApplications/GetSavedApplicationsQueryHandler.cs
+++ b/api/src/town-crier.application/SavedApplications/GetSavedApplicationsQueryHandler.cs
@@ -44,7 +44,11 @@ public sealed class GetSavedApplicationsQueryHandler
                     continue;
                 }
 
-                var refreshed = SavedApplication.Create(record.UserId, fetched, record.SavedAt);
+                // Rewrite in place: embed the snapshot but keep the row's existing
+                // ApplicationUid. SavedApplication.Create would re-key to the canonical
+                // uid, orphaning the legacy Cosmos doc and leaving a duplicate. Legacy
+                // re-keying is the dedicated migration's job (bd tc-sqr3 / tc-o88i).
+                var refreshed = record.WithEmbeddedSnapshot(fetched);
                 await this.savedRepository.SaveAsync(refreshed, ct).ConfigureAwait(false);
                 snapshot = fetched;
             }

--- a/api/src/town-crier.application/SavedApplications/SaveApplicationCommandHandler.cs
+++ b/api/src/town-crier.application/SavedApplications/SaveApplicationCommandHandler.cs
@@ -28,7 +28,12 @@ public sealed class SaveApplicationCommandHandler
         // the single write path for ad-hoc applications. See bead tc-if12.
         await this.planningApplicationRepository.UpsertAsync(command.Application, ct).ConfigureAwait(false);
 
-        var alreadySaved = await this.repository.ExistsAsync(command.UserId, command.Application.Uid, ct).ConfigureAwait(false);
+        // Idempotency keys on the canonical {areaId}/{name} uid, NOT the raw uid the
+        // client put in the request body. The raw uid format varies between clients
+        // (PR #398 changed it), so trusting it would let a re-save with a stale-format
+        // uid miss the existing row and insert a second saved doc (bd tc-o88i).
+        var canonicalUid = command.Application.CanonicalUid;
+        var alreadySaved = await this.repository.ExistsAsync(command.UserId, canonicalUid, ct).ConfigureAwait(false);
         if (alreadySaved)
         {
             return;

--- a/api/src/town-crier.domain/PlanningApplications/PlanningApplication.cs
+++ b/api/src/town-crier.domain/PlanningApplications/PlanningApplication.cs
@@ -83,6 +83,18 @@ public sealed class PlanningApplication
     public DateTimeOffset LastDifferent { get; }
 
     /// <summary>
+    /// Gets the canonical, server-derived identity of this application: <c>{AreaId}/{Name}</c>.
+    /// PlanIt case references are only unique within a council, so the authority must be
+    /// part of the key. This mirrors the iOS <c>PlanningApplicationId.value</c> form and is
+    /// deliberately independent of the raw <see cref="Uid"/> field — a client may send a
+    /// stale-format uid string, but two saves of the same (AreaId, Name) always produce the
+    /// same canonical uid, which keeps the saved-application Cosmos doc id stable and makes
+    /// re-saves genuinely idempotent (bd tc-o88i).
+    /// </summary>
+    public string CanonicalUid =>
+        $"{this.AreaId.ToString(System.Globalization.CultureInfo.InvariantCulture)}/{this.Name}";
+
+    /// <summary>
     /// Compares business-material fields against another instance. Excludes PlanIt bookkeeping
     /// (LastDifferent) which changes on every rescrape even when content is identical.
     /// Used by the poll cycle to skip redundant upserts and zone lookups when PlanIt returns

--- a/api/src/town-crier.domain/SavedApplications/SavedApplication.cs
+++ b/api/src/town-crier.domain/SavedApplications/SavedApplication.cs
@@ -47,7 +47,13 @@ public sealed class SavedApplication
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(userId);
         ArgumentNullException.ThrowIfNull(application);
-        return new SavedApplication(userId, application.Uid, application.AreaId, now, application);
+
+        // Key on the canonical {areaId}/{name} uid rather than the raw PlanIt uid
+        // string. The raw uid is client-supplied on the save path and may arrive in a
+        // stale format; the canonical uid is a deterministic server-side function of
+        // (AreaId, Name), so every re-save of the same application lands on the same
+        // {userId}:{applicationUid} Cosmos doc id and the upsert is idempotent (bd tc-o88i).
+        return new SavedApplication(userId, application.CanonicalUid, application.AreaId, now, application);
     }
 
     /// <summary>
@@ -55,16 +61,18 @@ public sealed class SavedApplication
     /// Used by the refresh-on-tap path (see bd tc-udby) so that opening an item silently
     /// updates its saved-list snapshot from the master applications container.
     /// </summary>
-    /// <param name="freshApplication">The latest application snapshot. Must share this saved record's uid.</param>
+    /// <param name="freshApplication">The latest application snapshot. Its canonical uid must match this saved record's uid.</param>
     /// <returns>A new instance with the same identity but the fresh snapshot.</returns>
     public SavedApplication WithFreshSnapshot(PlanningApplication freshApplication)
     {
         ArgumentNullException.ThrowIfNull(freshApplication);
 
-        if (!string.Equals(freshApplication.Uid, this.ApplicationUid, StringComparison.Ordinal))
+        // Compare on the canonical {areaId}/{name} uid, the same key Create stamps onto
+        // ApplicationUid. The raw Uid field is not the saved-record identity (bd tc-o88i).
+        if (!string.Equals(freshApplication.CanonicalUid, this.ApplicationUid, StringComparison.Ordinal))
         {
             throw new ArgumentException(
-                $"Snapshot uid '{freshApplication.Uid}' does not match saved record uid '{this.ApplicationUid}'.",
+                $"Snapshot canonical uid '{freshApplication.CanonicalUid}' does not match saved record uid '{this.ApplicationUid}'.",
                 nameof(freshApplication));
         }
 

--- a/api/src/town-crier.domain/SavedApplications/SavedApplication.cs
+++ b/api/src/town-crier.domain/SavedApplications/SavedApplication.cs
@@ -78,4 +78,25 @@ public sealed class SavedApplication
 
         return new SavedApplication(this.UserId, this.ApplicationUid, this.AuthorityId, this.SavedAt, freshApplication);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="SavedApplication"/> with the supplied snapshot embedded
+    /// while preserving this record's existing <see cref="ApplicationUid"/> key.
+    /// </summary>
+    /// <remarks>
+    /// Used by the lazy-backfill path for legacy uid-only rows persisted before either the
+    /// embedded snapshot column or the canonical-uid scheme existed. Unlike
+    /// <see cref="WithFreshSnapshot"/> it does NOT require the snapshot's canonical uid to
+    /// match the record key — a legacy row's key is a raw PlanIt uid by definition.
+    /// Re-keying such rows to the canonical form is the dedicated migration's job
+    /// (bd tc-sqr3); backfill must rewrite in place so it never orphans the Cosmos doc
+    /// or leaves a duplicate (bd tc-o88i).
+    /// </remarks>
+    /// <param name="snapshot">The application snapshot to embed.</param>
+    /// <returns>A new instance with the same identity but the embedded snapshot.</returns>
+    public SavedApplication WithEmbeddedSnapshot(PlanningApplication snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        return new SavedApplication(this.UserId, this.ApplicationUid, this.AuthorityId, this.SavedAt, snapshot);
+    }
 }

--- a/api/src/town-crier.infrastructure/SavedApplications/SavedApplicationDocument.cs
+++ b/api/src/town-crier.infrastructure/SavedApplications/SavedApplicationDocument.cs
@@ -57,9 +57,17 @@ internal sealed class SavedApplicationDocument
         // pattern as the snapshot null check below (bd tc-th98).
         var authorityId = this.AuthorityId ?? this.Application?.AreaId ?? 0;
 
+        // Always reconstruct the row on its STORED ApplicationUid. A legacy doc
+        // persisted before PR#398 is keyed on the raw PlanIt bare ref, not the
+        // canonical {areaId}/{name} uid; deriving the uid from the snapshot here
+        // would mask that and orphan the legacy Cosmos doc. The lazy re-key
+        // migration (bd tc-sqr3) detects a legacy doc precisely by the stored uid
+        // differing from the snapshot's canonical uid, so the stored uid must survive.
+        var record = SavedApplication.Create(this.UserId, this.ApplicationUid, authorityId, this.SavedAt);
+
         return this.Application is null
-            ? SavedApplication.Create(this.UserId, this.ApplicationUid, authorityId, this.SavedAt)
-            : SavedApplication.Create(this.UserId, this.Application.ToDomain(), this.SavedAt);
+            ? record
+            : record.WithEmbeddedSnapshot(this.Application.ToDomain());
     }
 
     internal static string MakeId(string userId, string applicationUid) => $"{userId}:{applicationUid}";

--- a/api/src/town-crier.web/Endpoints/SavedApplicationEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/SavedApplicationEndpoints.cs
@@ -16,10 +16,21 @@ internal static class SavedApplicationEndpoints
             CancellationToken ct) =>
         {
             var userId = user.FindFirstValue("sub")!;
-            if (request is null || string.IsNullOrWhiteSpace(request.Uid) || request.Uid != applicationUid)
+
+            // The {applicationUid} path segment is no longer authoritative: the saved
+            // record's identity is the canonical {areaId}/{name} uid the server derives
+            // from the body (see SaveApplicationCommandHandler / bd tc-o88i). We no
+            // longer reject a body/path uid mismatch — a stale-format client whose path
+            // uid differs from its body uid must still be able to save idempotently.
+            // We only validate that the body carries the fields needed to build the
+            // canonical key and the master planning-application record.
+            _ = applicationUid;
+            if (request is null
+                || string.IsNullOrWhiteSpace(request.Uid)
+                || string.IsNullOrWhiteSpace(request.Name))
             {
                 return Results.Json(
-                    new ApiErrorResponse("Body uid must match path uid."),
+                    new ApiErrorResponse("Body must include a non-empty uid and name."),
                     AppJsonSerializerContext.Default.ApiErrorResponse,
                     statusCode: 400);
             }

--- a/api/tests/town-crier.application.tests/Notifications/DispatchDecisionEventCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Notifications/DispatchDecisionEventCommandHandlerTests.cs
@@ -72,6 +72,36 @@ public sealed class DispatchDecisionEventCommandHandlerTests
     }
 
     [Test]
+    public async Task Should_CreateSavedDecisionNotification_When_BookmarkWasSavedWithCanonicalUidKey()
+    {
+        // Arrange — the row was saved through the canonical path (SaveApplicationCommandHandler),
+        // so its ApplicationUid is the canonical {areaId}/{name} uid, NOT the raw PlanIt
+        // uid. Decision dispatch must still find it, or every app saved after the
+        // canonical-uid change silently stops receiving decision pushes (bd tc-o88i).
+        var harness = new Harness();
+        await harness.SeedPaidUserAsync("user-1", "device-1");
+
+        var saved = new PlanningApplicationBuilder()
+            .WithUid("planit-raw-uid-xyz").WithName("app-001").WithAreaId(1).Build();
+        await harness.SavedApplicationRepo.SaveAsync(
+            SavedApplication.Create("user-1", saved, March2026), CancellationToken.None);
+
+        // Act — the polled application carries the raw PlanIt uid, as PlanIt master
+        // records always do; only its canonical {areaId}/{name} matches the saved row.
+        var application = new PlanningApplicationBuilder()
+            .WithUid("planit-raw-uid-xyz").WithName("app-001").WithAreaId(1)
+            .WithAppState("Rejected").Build();
+
+        await harness.Handler.HandleAsync(
+            new DispatchDecisionEventCommand(application), CancellationToken.None);
+
+        // Assert — the saved bookmark holder was matched and notified.
+        await Assert.That(harness.NotificationRepo.All).HasCount().EqualTo(1);
+        await Assert.That(harness.NotificationRepo.All[0].UserId).IsEqualTo("user-1");
+        await Assert.That(harness.NotificationRepo.All[0].Sources).IsEqualTo(NotificationSources.Saved);
+    }
+
+    [Test]
     public async Task Should_OrMergeIntoSingleNotification_When_UserMatchesViaBothZoneAndSaved()
     {
         // Arrange — Pro user has BOTH a covering zone AND a saved bookmark

--- a/api/tests/town-crier.application.tests/PlanningApplications/GetApplicationByUidQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/PlanningApplications/GetApplicationByUidQueryHandlerTests.cs
@@ -92,6 +92,42 @@ public sealed class GetApplicationByUidQueryHandlerTests
     }
 
     [Test]
+    public async Task Should_RefreshSavedSnapshot_When_MasterUidFormatDiffersFromCanonicalKey()
+    {
+        // Arrange — the regression PR #398 introduced: the master record's raw Uid
+        // field is in a stale format, but the saved row is keyed on the canonical
+        // {areaId}/{name} uid. Refresh-on-tap must align on the canonical key, not
+        // the raw Uid, or snapshot healing is a silent no-op (bd tc-o88i).
+        var savedAt = new DateTimeOffset(2026, 5, 1, 10, 0, 0, TimeSpan.Zero);
+        var stale = new PlanningApplicationBuilder()
+            .WithUid("legacy-uid-format").WithName("APP/2024/001").WithAreaId(42)
+            .WithAppState("Undecided").Build();
+        var fresh = new PlanningApplicationBuilder()
+            .WithUid("legacy-uid-format").WithName("APP/2024/001").WithAreaId(42)
+            .WithAppState("Permitted").Build();
+
+        var repository = new FakePlanningApplicationRepository();
+        await repository.UpsertAsync(fresh, CancellationToken.None);
+
+        var savedRepository = new FakeSavedApplicationRepository();
+        await savedRepository.SaveAsync(
+            SavedApplication.Create("auth0|user-1", stale, savedAt), CancellationToken.None);
+
+        var handler = new GetApplicationByUidQueryHandler(repository, savedRepository);
+
+        // Act
+        var result = await handler.HandleAsync(
+            new GetApplicationByUidQuery("legacy-uid-format", "auth0|user-1"), CancellationToken.None);
+
+        // Assert — the saved row's snapshot was healed despite the raw-uid mismatch.
+        await Assert.That(result).IsNotNull();
+        var rows = await savedRepository.GetByUserIdAsync("auth0|user-1", CancellationToken.None);
+        await Assert.That(rows).HasCount().EqualTo(1);
+        await Assert.That(rows[0].Application!.AppState).IsEqualTo("Permitted");
+        await Assert.That(rows[0].SavedAt).IsEqualTo(savedAt);
+    }
+
+    [Test]
     public async Task Should_NotRefreshSavedSnapshot_When_UserHasNotSavedApplication()
     {
         // Arrange — refresh-on-tap must only touch the saved row of the

--- a/api/tests/town-crier.application.tests/SavedApplications/FakeSavedApplicationRepository.cs
+++ b/api/tests/town-crier.application.tests/SavedApplications/FakeSavedApplicationRepository.cs
@@ -9,8 +9,15 @@ internal sealed class FakeSavedApplicationRepository : ISavedApplicationReposito
 
     public int Count => this.store.Count;
 
+    /// <summary>
+    /// Gets the number of times <see cref="SaveAsync"/> has been invoked. Lets tests
+    /// assert that an idempotent re-save short-circuits before the redundant write.
+    /// </summary>
+    public int SaveCallCount { get; private set; }
+
     public Task SaveAsync(SavedApplication savedApplication, CancellationToken ct)
     {
+        this.SaveCallCount++;
         var existing = this.store.FindIndex(
             s => s.UserId == savedApplication.UserId && s.ApplicationUid == savedApplication.ApplicationUid);
 

--- a/api/tests/town-crier.application.tests/SavedApplications/GetSavedApplicationsQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/SavedApplications/GetSavedApplicationsQueryHandlerTests.cs
@@ -114,8 +114,13 @@ public sealed class GetSavedApplicationsQueryHandlerTests
         await Assert.That(firstResult[0].Application.Name).IsEqualTo("APP/legacy");
 
         // Assert — saved row was rewritten with the embedded snapshot persisted.
+        // Crucially the backfill rewrites IN PLACE: it must keep the row's existing
+        // ApplicationUid key (the raw legacy uid), not re-key to the canonical uid,
+        // or it orphans the old Cosmos doc and leaves a duplicate. Re-keying of
+        // legacy rows is the dedicated migration's job (bd tc-sqr3 / tc-o88i).
         var rows = await savedRepository.GetByUserIdAsync("auth0|user-1", CancellationToken.None);
         await Assert.That(rows).HasCount().EqualTo(1);
+        await Assert.That(rows[0].ApplicationUid).IsEqualTo("planit-uid-legacy");
         await Assert.That(rows[0].Application).IsNotNull();
         await Assert.That(rows[0].Application!.Name).IsEqualTo("APP/legacy");
 

--- a/api/tests/town-crier.application.tests/SavedApplications/GetSavedApplicationsQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/SavedApplications/GetSavedApplicationsQueryHandlerTests.cs
@@ -89,15 +89,17 @@ public sealed class GetSavedApplicationsQueryHandlerTests
     public async Task Should_LazilyBackfillSnapshot_When_LegacyRowHasUidOnly()
     {
         // Arrange — rows persisted before the snapshot column existed hold only
-        // the uid. The handler hydrates them once via the planning repo and
-        // upserts the snapshot back so subsequent reads are zero-hydration.
+        // the uid. The handler hydrates them once via the planning repo, re-keys
+        // them to the canonical uid (bd tc-sqr3), and upserts so subsequent reads
+        // are zero-hydration.
         var savedRepository = new FakeSavedApplicationRepository();
         var planningRepository = new FakePlanningApplicationRepository();
         var savedAt = new DateTimeOffset(2026, 5, 1, 10, 0, 0, TimeSpan.Zero);
 
-        // Seed: planning record exists, saved row does NOT carry the snapshot.
+        // Seed: planning record exists, saved row does NOT carry the snapshot and
+        // is keyed on the raw legacy uid.
         var app = new PlanningApplicationBuilder()
-            .WithUid("planit-uid-legacy").WithName("APP/legacy").WithAreaName("Camden").Build();
+            .WithUid("planit-uid-legacy").WithName("APP/legacy").WithAreaId(1).WithAreaName("Camden").Build();
         await planningRepository.UpsertAsync(app, CancellationToken.None);
         await savedRepository.SaveAsync(
             SavedApplication.Create("auth0|user-1", "planit-uid-legacy", authorityId: 1, savedAt), CancellationToken.None);
@@ -105,24 +107,22 @@ public sealed class GetSavedApplicationsQueryHandlerTests
         var handler = new GetSavedApplicationsQueryHandler(savedRepository, planningRepository);
         var query = new GetSavedApplicationsQuery("auth0|user-1");
 
-        // Act — first read triggers backfill.
+        // Act — first read triggers hydration plus re-key.
         var firstResult = await handler.HandleAsync(query, CancellationToken.None);
 
-        // Assert — first read returned the hydrated snapshot.
+        // Assert — first read returned the hydrated snapshot under the canonical uid.
         await Assert.That(firstResult).HasCount().EqualTo(1);
-        await Assert.That(firstResult[0].ApplicationUid).IsEqualTo("planit-uid-legacy");
+        await Assert.That(firstResult[0].ApplicationUid).IsEqualTo("1/APP/legacy");
         await Assert.That(firstResult[0].Application.Name).IsEqualTo("APP/legacy");
 
-        // Assert — saved row was rewritten with the embedded snapshot persisted.
-        // Crucially the backfill rewrites IN PLACE: it must keep the row's existing
-        // ApplicationUid key (the raw legacy uid), not re-key to the canonical uid,
-        // or it orphans the old Cosmos doc and leaves a duplicate. Re-keying of
-        // legacy rows is the dedicated migration's job (bd tc-sqr3 / tc-o88i).
+        // Assert — the saved row was hydrated AND re-keyed: the legacy-uid doc is
+        // gone and a single canonical doc carrying the embedded snapshot remains.
         var rows = await savedRepository.GetByUserIdAsync("auth0|user-1", CancellationToken.None);
         await Assert.That(rows).HasCount().EqualTo(1);
-        await Assert.That(rows[0].ApplicationUid).IsEqualTo("planit-uid-legacy");
+        await Assert.That(rows[0].ApplicationUid).IsEqualTo("1/APP/legacy");
         await Assert.That(rows[0].Application).IsNotNull();
         await Assert.That(rows[0].Application!.Name).IsEqualTo("APP/legacy");
+        await Assert.That(rows[0].SavedAt).IsEqualTo(savedAt);
 
         // Act — second read with the planning repo unavailable: still works
         // because backfill self-healed and there are no more legacy rows.

--- a/api/tests/town-crier.application.tests/SavedApplications/GetSavedApplicationsQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/SavedApplications/GetSavedApplicationsQueryHandlerTests.cs
@@ -136,6 +136,110 @@ public sealed class GetSavedApplicationsQueryHandlerTests
     }
 
     [Test]
+    public async Task Should_ReKeyLegacyRowToCanonicalUid_When_StoredUidIsLegacyBareRefFormat()
+    {
+        // Arrange — a legacy-format saved row persisted before PR#398: its stored
+        // ApplicationUid is the raw PlanIt bare ref (e.g. 25/02755/CLC), not the
+        // canonical {areaId}/{name} key. All such rows carry an embedded snapshot,
+        // so the canonical uid is derivable in place — no cross-container lookup.
+        var savedRepository = new FakeSavedApplicationRepository();
+        var planningRepository = new FailIfCalledPlanningApplicationRepository();
+        var savedAt = new DateTimeOffset(2026, 5, 1, 10, 0, 0, TimeSpan.Zero);
+
+        var snapshot = new PlanningApplicationBuilder()
+            .WithUid("25/02755/CLC").WithName("Kingston/25/02755/CLC").WithAreaId(314).Build();
+
+        // Legacy row: keyed on the raw uid but carrying the snapshot.
+        var legacyRow = SavedApplication
+            .Create("auth0|user-1", "25/02755/CLC", authorityId: 314, savedAt)
+            .WithEmbeddedSnapshot(snapshot);
+        await savedRepository.SaveAsync(legacyRow, CancellationToken.None);
+
+        var handler = new GetSavedApplicationsQueryHandler(savedRepository, planningRepository);
+        var query = new GetSavedApplicationsQuery("auth0|user-1");
+
+        // Act — the read self-heals the legacy row.
+        var result = await handler.HandleAsync(query, CancellationToken.None);
+
+        // Assert — exactly one row, reported under the canonical uid.
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].ApplicationUid).IsEqualTo("314/Kingston/25/02755/CLC");
+
+        // Assert — the legacy doc was deleted and a canonical doc written in its
+        // place. Cosmos doc ids are immutable, so a re-key is delete + write.
+        var rows = await savedRepository.GetByUserIdAsync("auth0|user-1", CancellationToken.None);
+        await Assert.That(rows).HasCount().EqualTo(1);
+        await Assert.That(rows[0].ApplicationUid).IsEqualTo("314/Kingston/25/02755/CLC");
+        await Assert.That(rows[0].Application).IsNotNull();
+        await Assert.That(rows[0].SavedAt).IsEqualTo(savedAt);
+    }
+
+    [Test]
+    public async Task Should_NotReKey_When_StoredUidIsAlreadyCanonical()
+    {
+        // Arrange — an already-canonical row. Re-running the migration over it
+        // must be a no-op: no delete, no spurious rewrite.
+        var savedRepository = new FakeSavedApplicationRepository();
+        var planningRepository = new FailIfCalledPlanningApplicationRepository();
+        var savedAt = new DateTimeOffset(2026, 5, 1, 10, 0, 0, TimeSpan.Zero);
+
+        var app = new PlanningApplicationBuilder()
+            .WithUid("25/02755/CLC").WithName("Kingston/25/02755/CLC").WithAreaId(314).Build();
+        await savedRepository.SaveAsync(SavedApplication.Create("auth0|user-1", app, savedAt), CancellationToken.None);
+
+        var handler = new GetSavedApplicationsQueryHandler(savedRepository, planningRepository);
+        var query = new GetSavedApplicationsQuery("auth0|user-1");
+        var savesBefore = savedRepository.SaveCallCount;
+
+        // Act
+        var result = await handler.HandleAsync(query, CancellationToken.None);
+
+        // Assert — projected unchanged, and the canonical row was not rewritten.
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].ApplicationUid).IsEqualTo("314/Kingston/25/02755/CLC");
+        await Assert.That(savedRepository.SaveCallCount).IsEqualTo(savesBefore);
+        var rows = await savedRepository.GetByUserIdAsync("auth0|user-1", CancellationToken.None);
+        await Assert.That(rows).HasCount().EqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_DropLegacyRow_When_CanonicalDuplicateAlreadyExistsForSameUser()
+    {
+        // Arrange — the confirmed prod case: a user holds BOTH a legacy doc and a
+        // canonical doc for the same application. The re-key must keep the
+        // canonical doc and delete the legacy one, leaving a single row.
+        var savedRepository = new FakeSavedApplicationRepository();
+        var planningRepository = new FailIfCalledPlanningApplicationRepository();
+        var legacySavedAt = new DateTimeOffset(2026, 4, 1, 9, 0, 0, TimeSpan.Zero);
+        var canonicalSavedAt = new DateTimeOffset(2026, 5, 1, 10, 0, 0, TimeSpan.Zero);
+
+        var snapshot = new PlanningApplicationBuilder()
+            .WithUid("25/02755/CLC").WithName("Kingston/25/02755/CLC").WithAreaId(314).Build();
+
+        var legacyRow = SavedApplication
+            .Create("auth0|user-1", "25/02755/CLC", authorityId: 314, legacySavedAt)
+            .WithEmbeddedSnapshot(snapshot);
+        await savedRepository.SaveAsync(legacyRow, CancellationToken.None);
+        await savedRepository.SaveAsync(
+            SavedApplication.Create("auth0|user-1", snapshot, canonicalSavedAt), CancellationToken.None);
+
+        var handler = new GetSavedApplicationsQueryHandler(savedRepository, planningRepository);
+        var query = new GetSavedApplicationsQuery("auth0|user-1");
+
+        // Act
+        var result = await handler.HandleAsync(query, CancellationToken.None);
+
+        // Assert — one row only; the canonical doc survives, the legacy one is gone.
+        await Assert.That(result).HasCount().EqualTo(1);
+        await Assert.That(result[0].ApplicationUid).IsEqualTo("314/Kingston/25/02755/CLC");
+
+        var rows = await savedRepository.GetByUserIdAsync("auth0|user-1", CancellationToken.None);
+        await Assert.That(rows).HasCount().EqualTo(1);
+        await Assert.That(rows[0].ApplicationUid).IsEqualTo("314/Kingston/25/02755/CLC");
+        await Assert.That(rows[0].SavedAt).IsEqualTo(canonicalSavedAt);
+    }
+
+    [Test]
     public async Task Should_ExcludeSavedApplication_When_LegacyRowAndPlanningApplicationNoLongerExists()
     {
         // Arrange — legacy uid-only row whose master planning application is

--- a/api/tests/town-crier.application.tests/SavedApplications/GetSavedApplicationsQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/SavedApplications/GetSavedApplicationsQueryHandlerTests.cs
@@ -49,12 +49,13 @@ public sealed class GetSavedApplicationsQueryHandlerTests
         // Act
         var result = await handler.HandleAsync(query, CancellationToken.None);
 
-        // Assert — both items projected from the embedded snapshot
+        // Assert — both items projected from the embedded snapshot. ApplicationUid
+        // is the canonical {areaId}/{name} key, not the raw PlanIt uid (bd tc-o88i).
         await Assert.That(result).HasCount().EqualTo(2);
-        await Assert.That(result[0].ApplicationUid).IsEqualTo("planit-uid-abc");
+        await Assert.That(result[0].ApplicationUid).IsEqualTo("1/APP/2026/001");
         await Assert.That(result[0].Application.Name).IsEqualTo("APP/2026/001");
         await Assert.That(result[0].Application.AreaName).IsEqualTo("Wiltshire");
-        await Assert.That(result[1].ApplicationUid).IsEqualTo("planit-uid-def");
+        await Assert.That(result[1].ApplicationUid).IsEqualTo("1/APP/2026/002");
         await Assert.That(result[1].Application.Name).IsEqualTo("APP/2026/002");
     }
 
@@ -66,7 +67,8 @@ public sealed class GetSavedApplicationsQueryHandlerTests
         var planningRepository = new FailIfCalledPlanningApplicationRepository();
         var savedAt = DateTimeOffset.UtcNow;
 
-        var app1 = new PlanningApplicationBuilder().WithUid("planit-uid-abc").Build();
+        var app1 = new PlanningApplicationBuilder()
+            .WithUid("planit-uid-abc").WithAreaId(7).WithName("APP/own").Build();
         var app2 = new PlanningApplicationBuilder().WithUid("planit-uid-def").Build();
 
         await savedRepository.SaveAsync(SavedApplication.Create("auth0|user-1", app1, savedAt), CancellationToken.None);
@@ -78,9 +80,9 @@ public sealed class GetSavedApplicationsQueryHandlerTests
         // Act
         var result = await handler.HandleAsync(query, CancellationToken.None);
 
-        // Assert
+        // Assert — ApplicationUid is the canonical {areaId}/{name} key (bd tc-o88i).
         await Assert.That(result).HasCount().EqualTo(1);
-        await Assert.That(result[0].ApplicationUid).IsEqualTo("planit-uid-abc");
+        await Assert.That(result[0].ApplicationUid).IsEqualTo("7/APP/own");
     }
 
     [Test]
@@ -153,8 +155,8 @@ public sealed class GetSavedApplicationsQueryHandlerTests
         // Act
         var result = await handler.HandleAsync(query, CancellationToken.None);
 
-        // Assert
+        // Assert — the present row survives; ApplicationUid is the canonical key.
         await Assert.That(result).HasCount().EqualTo(1);
-        await Assert.That(result[0].ApplicationUid).IsEqualTo("planit-uid-abc");
+        await Assert.That(result[0].ApplicationUid).IsEqualTo("1/APP/abc");
     }
 }

--- a/api/tests/town-crier.application.tests/SavedApplications/SaveApplicationCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/SavedApplications/SaveApplicationCommandHandlerTests.cs
@@ -96,4 +96,36 @@ public sealed class SaveApplicationCommandHandlerTests
         var saved = await savedRepository.GetByUserIdAsync("auth0|user-1", CancellationToken.None);
         await Assert.That(saved).HasCount().EqualTo(1);
     }
+
+    [Test]
+    public async Task Should_BeIdempotent_When_ReSavedWithDifferentRawUidFormat()
+    {
+        // Arrange — the PR #398 regression: a re-save where the client sent a
+        // different raw uid format the second time (e.g. an old build still
+        // posting the bare PlanIt ref). The save must key on the canonical
+        // {areaId}/{name} uid so both saves land on the same record and the
+        // redundant write is skipped (bd tc-o88i).
+        var savedRepository = new FakeSavedApplicationRepository();
+        var planningRepository = new FakePlanningApplicationRepository();
+        var timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 5, 1, 10, 0, 0, TimeSpan.Zero));
+        var handler = new SaveApplicationCommandHandler(savedRepository, planningRepository, timeProvider);
+
+        var legacyFormat = new PlanningApplicationBuilder()
+            .WithAreaId(42).WithName("CAM/24/0042/FUL").WithUid("CAM/24/0042/FUL").Build();
+        var otherFormat = new PlanningApplicationBuilder()
+            .WithAreaId(42).WithName("CAM/24/0042/FUL").WithUid("planit-internal-987654").Build();
+
+        // Act — first save (legacy uid), then a re-save carrying a different raw uid.
+        await handler.HandleAsync(new SaveApplicationCommand("auth0|user-1", legacyFormat), CancellationToken.None);
+        await handler.HandleAsync(new SaveApplicationCommand("auth0|user-1", otherFormat), CancellationToken.None);
+
+        // Assert — exactly one saved row, keyed on the canonical uid.
+        var saved = await savedRepository.GetByUserIdAsync("auth0|user-1", CancellationToken.None);
+        await Assert.That(saved).HasCount().EqualTo(1);
+        await Assert.That(saved[0].ApplicationUid).IsEqualTo("42/CAM/24/0042/FUL");
+
+        // Assert — the second save short-circuited on the ExistsAsync check and did
+        // not issue a redundant write. Only the first save reached SaveAsync.
+        await Assert.That(savedRepository.SaveCallCount).IsEqualTo(1);
+    }
 }

--- a/api/tests/town-crier.application.tests/SavedApplications/SaveApplicationCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/SavedApplications/SaveApplicationCommandHandlerTests.cs
@@ -27,10 +27,11 @@ public sealed class SaveApplicationCommandHandlerTests
         // Act
         await handler.HandleAsync(command, CancellationToken.None);
 
-        // Assert — saved record persisted.
+        // Assert — saved record persisted. ApplicationUid is the canonical
+        // {areaId}/{name} key, not the client-supplied raw uid (bd tc-o88i).
         var saved = await savedRepository.GetByUserIdAsync("auth0|user-1", CancellationToken.None);
         await Assert.That(saved).HasCount().EqualTo(1);
-        await Assert.That(saved[0].ApplicationUid).IsEqualTo("planit-uid-abc");
+        await Assert.That(saved[0].ApplicationUid).IsEqualTo("42/Camden/CAM/24/0042/FUL");
         await Assert.That(saved[0].SavedAt).IsEqualTo(new DateTimeOffset(2026, 3, 17, 10, 0, 0, TimeSpan.Zero));
 
         // Assert — application was also upserted to the planning repository.

--- a/api/tests/town-crier.domain.tests/PlanningApplications/PlanningApplicationTests.cs
+++ b/api/tests/town-crier.domain.tests/PlanningApplications/PlanningApplicationTests.cs
@@ -149,4 +149,32 @@ public sealed class PlanningApplicationTests
         await Assert.ThrowsAsync<ArgumentNullException>(
             () => Task.FromResult(app.HasSameBusinessFieldsAs(null!)));
     }
+
+    [Test]
+    public async Task CanonicalUid_Should_JoinAreaIdAndName()
+    {
+        // The canonical uid is the stable server-side identity of an application:
+        // {areaId}/{name}. It mirrors the iOS PlanningApplicationId.value form and
+        // is independent of the client-supplied PlanIt uid string (bd tc-o88i).
+        var app = new PlanningApplicationBuilder()
+            .WithAreaId(42)
+            .WithName("CAM/24/0042/FUL")
+            .Build();
+
+        await Assert.That(app.CanonicalUid).IsEqualTo("42/CAM/24/0042/FUL");
+    }
+
+    [Test]
+    public async Task CanonicalUid_Should_BeIndependentOfTheRawUidField()
+    {
+        // Two applications for the same (areaId, name) must share a canonical uid
+        // even when their raw PlanIt uid strings differ — this is what makes the
+        // saved-application doc id stable across stale-format clients (bd tc-o88i).
+        var withRawUid = new PlanningApplicationBuilder()
+            .WithAreaId(7).WithName("APP/2024/001").WithUid("legacy-uid-format").Build();
+        var withCanonicalUid = new PlanningApplicationBuilder()
+            .WithAreaId(7).WithName("APP/2024/001").WithUid("7/APP/2024/001").Build();
+
+        await Assert.That(withRawUid.CanonicalUid).IsEqualTo(withCanonicalUid.CanonicalUid);
+    }
 }

--- a/api/tests/town-crier.domain.tests/SavedApplications/SavedApplicationTests.cs
+++ b/api/tests/town-crier.domain.tests/SavedApplications/SavedApplicationTests.cs
@@ -102,6 +102,30 @@ public sealed class SavedApplicationTests
     }
 
     [Test]
+    public async Task Should_AttachSnapshot_PreservingExistingKey_When_BackfillingLegacyRow()
+    {
+        // Arrange — a legacy uid-only row whose ApplicationUid predates the canonical
+        // {areaId}/{name} scheme. The lazy-backfill path embeds a snapshot but must
+        // NOT re-key the row, or it orphans the old Cosmos doc. Re-keying legacy rows
+        // is the dedicated migration's job (bd tc-sqr3 / tc-o88i).
+        var savedAt = new DateTimeOffset(2026, 5, 1, 10, 0, 0, TimeSpan.Zero);
+        var legacy = SavedApplication.Create("auth0|user-1", "planit-legacy-uid", authorityId: 9, savedAt);
+        var snapshot = new PlanningApplicationBuilder()
+            .WithAreaId(9).WithName("APP/legacy").WithAppState("Permitted").Build();
+
+        // Act
+        var backfilled = legacy.WithEmbeddedSnapshot(snapshot);
+
+        // Assert — identity preserved, snapshot attached.
+        await Assert.That(backfilled.ApplicationUid).IsEqualTo("planit-legacy-uid");
+        await Assert.That(backfilled.UserId).IsEqualTo("auth0|user-1");
+        await Assert.That(backfilled.AuthorityId).IsEqualTo(9);
+        await Assert.That(backfilled.SavedAt).IsEqualTo(savedAt);
+        await Assert.That(backfilled.Application).IsNotNull();
+        await Assert.That(backfilled.Application!.AppState).IsEqualTo("Permitted");
+    }
+
+    [Test]
     public async Task Should_RejectMismatchedSnapshot_When_RefreshedWithDifferentUid()
     {
         // Arrange — defensive: refusing to swap in a snapshot for the wrong uid

--- a/api/tests/town-crier.domain.tests/SavedApplications/SavedApplicationTests.cs
+++ b/api/tests/town-crier.domain.tests/SavedApplications/SavedApplicationTests.cs
@@ -21,14 +21,37 @@ public sealed class SavedApplicationTests
         // Act
         var saved = SavedApplication.Create("auth0|user-1", application, savedAt);
 
-        // Assert
+        // Assert — the saved record keys on the canonical {areaId}/{name} uid, NOT the
+        // raw PlanIt uid string. This is what keeps the Cosmos doc id stable and makes
+        // re-saves idempotent regardless of what uid format the client sent (bd tc-o88i).
         await Assert.That(saved.UserId).IsEqualTo("auth0|user-1");
-        await Assert.That(saved.ApplicationUid).IsEqualTo("planit-uid-abc");
+        await Assert.That(saved.ApplicationUid).IsEqualTo("42/Camden/CAM/24/0042/FUL");
         await Assert.That(saved.AuthorityId).IsEqualTo(42);
         await Assert.That(saved.SavedAt).IsEqualTo(savedAt);
         await Assert.That(saved.Application).IsNotNull();
         await Assert.That(saved.Application!.Uid).IsEqualTo("planit-uid-abc");
         await Assert.That(saved.Application.Name).IsEqualTo("Camden/CAM/24/0042/FUL");
+    }
+
+    [Test]
+    public async Task Should_KeyOnCanonicalUid_When_RawUidFormatDiffers()
+    {
+        // Arrange — two saves of the same application where the client supplied a
+        // different raw uid string each time (the PR #398 stale-format scenario).
+        var savedAt = new DateTimeOffset(2026, 5, 1, 10, 0, 0, TimeSpan.Zero);
+        var legacyFormat = new PlanningApplicationBuilder()
+            .WithAreaId(42).WithName("CAM/24/0042/FUL").WithUid("CAM/24/0042/FUL").Build();
+        var newFormat = new PlanningApplicationBuilder()
+            .WithAreaId(42).WithName("CAM/24/0042/FUL").WithUid("42/CAM/24/0042/FUL").Build();
+
+        // Act
+        var fromLegacy = SavedApplication.Create("auth0|user-1", legacyFormat, savedAt);
+        var fromNew = SavedApplication.Create("auth0|user-1", newFormat, savedAt);
+
+        // Assert — both land on the identical canonical key, so the Cosmos
+        // {userId}:{applicationUid} doc id is identical and the upsert is idempotent.
+        await Assert.That(fromLegacy.ApplicationUid).IsEqualTo("42/CAM/24/0042/FUL");
+        await Assert.That(fromNew.ApplicationUid).IsEqualTo(fromLegacy.ApplicationUid);
     }
 
     [Test]

--- a/api/tests/town-crier.infrastructure.tests/SavedApplications/SavedApplicationDocumentTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/SavedApplications/SavedApplicationDocumentTests.cs
@@ -127,6 +127,57 @@ public sealed class SavedApplicationDocumentTests
     }
 
     [Test]
+    public async Task Should_PreserveStoredLegacyUid_When_LegacyDocCarriesSnapshot()
+    {
+        // Arrange — a legacy doc persisted before PR#398: it is keyed on the raw
+        // PlanIt bare ref (e.g. 25/02755/CLC) yet carries an embedded snapshot whose
+        // canonical uid is the post-PR#398 {areaId}/{name} form. ToDomain must
+        // surface the STORED uid, not silently re-derive the canonical one — the
+        // lazy re-key migration (bd tc-sqr3) detects a legacy doc precisely by the
+        // stored uid differing from the snapshot's canonical uid.
+        var savedAt = new DateTimeOffset(2026, 4, 1, 9, 0, 0, TimeSpan.Zero);
+        var snapshot = new PlanningApplication(
+            name: "Kingston/25/02755/CLC",
+            uid: "25/02755/CLC",
+            areaName: "Kingston",
+            areaId: 314,
+            address: "10 Test Lane",
+            postcode: "KT1 1AA",
+            description: "Test application",
+            appType: "Full",
+            appState: "Undecided",
+            appSize: "Small",
+            startDate: new DateOnly(2026, 1, 15),
+            decidedDate: null,
+            consultedDate: null,
+            longitude: -0.3,
+            latitude: 51.4,
+            url: null,
+            link: null,
+            lastDifferent: new DateTimeOffset(2026, 3, 30, 12, 0, 0, TimeSpan.Zero));
+
+        var legacyDocument = new SavedApplicationDocument
+        {
+            Id = SavedApplicationDocument.MakeId("auth0|user-1", "25/02755/CLC"),
+            UserId = "auth0|user-1",
+            ApplicationUid = "25/02755/CLC",
+            AuthorityId = 314,
+            SavedAt = savedAt,
+            Application = SavedApplicationSnapshotDocument.FromDomain(snapshot),
+        };
+
+        // Act
+        var domain = legacyDocument.ToDomain();
+
+        // Assert — the stored legacy uid survives; the snapshot still hydrates.
+        await Assert.That(domain.ApplicationUid).IsEqualTo("25/02755/CLC");
+        await Assert.That(domain.Application).IsNotNull();
+        await Assert.That(domain.Application!.CanonicalUid).IsEqualTo("314/Kingston/25/02755/CLC");
+        await Assert.That(domain.SavedAt).IsEqualTo(savedAt);
+        await Assert.That(domain.AuthorityId).IsEqualTo(314);
+    }
+
+    [Test]
     public async Task Should_CreateCompositeId_When_MappedFromDomain()
     {
         // Arrange

--- a/mobile/ios/packages/town-crier-data/Sources/API/Error+DomainMapping.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/Error+DomainMapping.swift
@@ -11,7 +11,7 @@ extension Error {
   func toDomainError() -> DomainError {
     if let apiError = self as? APIError {
       switch apiError {
-      case let .serverError(statusCode, message):
+      case .serverError(let statusCode, let message):
         return .serverError(statusCode: statusCode, message: message)
       case .decodingFailed(let detail):
         return .unexpected(detail)

--- a/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
@@ -1,6 +1,6 @@
 import Foundation
-import os
 import TownCrierDomain
+import os
 
 /// Foundation HTTP client that injects Auth0 bearer tokens and handles
 /// common response parsing, error mapping, and token refresh on 401.
@@ -89,7 +89,8 @@ public final class URLSessionAPIClient: Sendable {
     let urlRequest = try buildRequest(endpoint, accessToken: accessToken)
 
     #if DEBUG
-      Self.logger.debug("→ \(urlRequest.httpMethod ?? "?") \(urlRequest.url?.absoluteString ?? "?")")
+      Self.logger.debug(
+        "→ \(urlRequest.httpMethod ?? "?") \(urlRequest.url?.absoluteString ?? "?")")
     #endif
 
     let (data, response) = try await transport.data(for: urlRequest)
@@ -177,7 +178,8 @@ public final class URLSessionAPIClient: Sendable {
 
   private func mapForbidden(data: Data) throws {
     if let body = try? decoder.decode(InsufficientEntitlementBody.self, from: data),
-      body.error == "insufficient_entitlement" {
+      body.error == "insufficient_entitlement"
+    {
       throw DomainError.insufficientEntitlement(required: body.required)
     }
     let message = String(data: data, encoding: .utf8)

--- a/mobile/ios/packages/town-crier-data/Sources/Auth/Auth0AuthenticationService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Auth/Auth0AuthenticationService.swift
@@ -20,7 +20,8 @@ public struct Auth0Config: Sendable {
 }
 
 public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationService,
-  @unchecked Sendable {
+  @unchecked Sendable
+{
   private let config: Auth0Config
   private let credentialsManager: CredentialsManager
   /// In-memory session cache that lets a foreground burst share a single

--- a/mobile/ios/packages/town-crier-data/Sources/CrashReporting/MetricKitCrashReporter.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/CrashReporting/MetricKitCrashReporter.swift
@@ -8,7 +8,8 @@ import os
 /// MetricKit delivers crash diagnostic payloads up to 24 hours after the crash occurs.
 /// Call `start()` once during app launch to subscribe to diagnostics.
 public final class MetricKitCrashReporter: NSObject, CrashReporter, MXMetricManagerSubscriber,
-  @unchecked Sendable {
+  @unchecked Sendable
+{
   private let logger = Logger(
     subsystem: "uk.co.towncrier",
     category: "CrashReporting"

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
@@ -10,7 +10,8 @@ public final class APIPlanningApplicationRepository: PlanningApplicationReposito
   }
 
   public func fetchApplications(for zone: WatchZone) async throws
-    -> [PlanningApplication] {
+    -> [PlanningApplication]
+  {
     let dtos: [PlanningApplicationDTO]
     do {
       dtos = try await apiClient.request(

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIWatchZoneRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIWatchZoneRepository.swift
@@ -5,7 +5,8 @@ import os
 /// Persists and retrieves watch zones via the Town Crier API.
 public final class APIWatchZoneRepository: WatchZoneRepository, Sendable {
   #if DEBUG
-    private static let logger = Logger(subsystem: "uk.towncrierapp", category: "WatchZoneRepository")
+    private static let logger = Logger(
+      subsystem: "uk.towncrierapp", category: "WatchZoneRepository")
   #endif
 
   private let apiClient: URLSessionAPIClient

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/InMemoryPlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/InMemoryPlanningApplicationRepository.swift
@@ -2,7 +2,8 @@ import TownCrierDomain
 
 /// An in-memory repository for development and testing.
 public final class InMemoryPlanningApplicationRepository: PlanningApplicationRepository,
-  @unchecked Sendable {
+  @unchecked Sendable
+{
   private var applications: [PlanningApplication]
 
   public init(applications: [PlanningApplication] = []) {

--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/EntitlementMap.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/EntitlementMap.swift
@@ -38,7 +38,8 @@ public enum EntitlementMap {
 
   /// Returns whether the given tier grants the specified entitlement.
   public static func hasEntitlement(_ entitlement: Entitlement, for tier: SubscriptionTier)
-    -> Bool {
+    -> Bool
+  {
     entitlements(for: tier).contains(entitlement)
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -118,7 +118,8 @@ public final class AppCoordinator: ObservableObject {
     // retain feature access immediately, even before the live resolution
     // completes (or when it fails on simulator).
     if let cached = self.tierCache.string(forKey: Self.tierCacheKey),
-      let tier = SubscriptionTier(rawValue: cached) {
+      let tier = SubscriptionTier(rawValue: cached)
+    {
       subscriptionTier = tier
     }
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Colors/Color+Resolve.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Colors/Color+Resolve.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+
 #if canImport(UIKit)
   import UIKit
 #endif
@@ -11,22 +12,23 @@ extension Color {
   /// stored in `UserDefaults`.
   static func themed(light: UInt32, dark: UInt32, oled: UInt32) -> Color {
     #if canImport(UIKit)
-      Color(uiColor: UIColor { traitCollection in
-        let isDark = traitCollection.userInterfaceStyle == .dark
-        let hex = ThemeColorResolver.resolveHex(
-          light: light,
-          dark: dark,
-          oled: oled,
-          isDarkMode: isDark,
-          isOledEnabled: isDark && ThemeColorResolver.isOledEnabled()
-        )
-        return UIColor(
-          red: CGFloat((hex >> 16) & 0xFF) / 255.0,
-          green: CGFloat((hex >> 8) & 0xFF) / 255.0,
-          blue: CGFloat(hex & 0xFF) / 255.0,
-          alpha: 1.0
-        )
-      })
+      Color(
+        uiColor: UIColor { traitCollection in
+          let isDark = traitCollection.userInterfaceStyle == .dark
+          let hex = ThemeColorResolver.resolveHex(
+            light: light,
+            dark: dark,
+            oled: oled,
+            isDarkMode: isDark,
+            isOledEnabled: isDark && ThemeColorResolver.isOledEnabled()
+          )
+          return UIColor(
+            red: CGFloat((hex >> 16) & 0xFF) / 255.0,
+            green: CGFloat((hex >> 8) & 0xFF) / 255.0,
+            blue: CGFloat(hex & 0xFF) / 255.0,
+            alpha: 1.0
+          )
+        })
     #else
       Color(hex: light)
     #endif

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
@@ -95,11 +95,19 @@ public final class ApplicationDetailViewModel: ObservableObject {
   /// Loads the saved state from the repository and updates `isSaved` accordingly.
   /// Call this after creating the ViewModel to reflect the server-side saved state.
   /// No-op if no repository was provided.
+  ///
+  /// The match compares the reconstructed ``PlanningApplicationId`` of each
+  /// saved item's embedded snapshot against this application's id — never the
+  /// raw top-level `applicationUid` string. The stored top-level uid can be in
+  /// a different format from the snapshot id reconstructed by
+  /// `PlanningApplicationDTO.toDomain()`, which would otherwise make a saved
+  /// item read as "unsaved" (bd tc-jjl4). The snapshot id is the source of
+  /// truth the rest of the Saved tab already uses.
   public func loadSavedState() async {
     guard let repository = savedApplicationRepository else { return }
     do {
       let saved = try await repository.loadAll()
-      isSaved = saved.contains { $0.applicationUid == applicationId.value }
+      isSaved = saved.contains { $0.application?.id == application.id }
     } catch {
       // Leave isSaved at its current value (false) on failure
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -202,7 +202,8 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
         // deleted — or nothing is selected yet — fall back to
         // `resolveInitialSelection`.
         if let currentId = selectedZone?.id,
-           let updated = loadedZones.first(where: { $0.id == currentId }) {
+          let updated = loadedZones.first(where: { $0.id == currentId })
+        {
           selectedZone = updated
         } else {
           resolveInitialSelection(from: loadedZones)
@@ -272,7 +273,8 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   private func resolveInitialSelection(from zones: [WatchZone]) {
     let savedId = userDefaults.string(forKey: zoneSelectionKey)
     if let savedId,
-       let savedZone = zones.first(where: { $0.id.value == savedId }) {
+      let savedZone = zones.first(where: { $0.id.value == savedId })
+    {
       selectedZone = savedZone
       return
     }
@@ -337,7 +339,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     }
     let sorted = scored.sorted { lhs, rhs in
       switch (lhs.distance, rhs.distance) {
-      case let (.some(left), .some(right)):
+      case (.some(let left), .some(let right)):
         return left < right
       case (.some, .none):
         return true
@@ -364,7 +366,8 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     key: String
   ) -> ApplicationsSort {
     if let raw = defaults.string(forKey: key),
-       let parsed = ApplicationsSort(rawValue: raw) {
+      let parsed = ApplicationsSort(rawValue: raw)
+    {
       return parsed
     }
     return .recentActivity

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/EntitlementGatingViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/EntitlementGatingViewModel.swift
@@ -30,7 +30,8 @@ extension EntitlementGatingViewModel {
     fallback: (String) -> DomainError = { .unexpected($0) }
   ) {
     if let domainError = error as? DomainError,
-      case .insufficientEntitlement(let required) = domainError {
+      case .insufficientEntitlement(let required) = domainError
+    {
       if let entitlement = Entitlement(rawValue: required) {
         self.entitlementGate = entitlement
         self.error = nil

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
@@ -93,7 +93,8 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
       // Falling back to `resolveInitialZone` only when the id is missing
       // (zone deleted) preserves the previous-session restore behaviour.
       if let currentId = selectedZone?.id,
-         let updated = loadedZones.first(where: { $0.id == currentId }) {
+        let updated = loadedZones.first(where: { $0.id == currentId })
+      {
         selectedZone = updated
       } else {
         selectedZone = resolveInitialZone(from: loadedZones)
@@ -157,7 +158,8 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
 
   private func resolveInitialZone(from zones: [WatchZone]) -> WatchZone? {
     if let savedId = userDefaults.string(forKey: zoneSelectionKey),
-       let savedZone = zones.first(where: { $0.id.value == savedId }) {
+      let savedZone = zones.first(where: { $0.id.value == savedId })
+    {
       return savedZone
     }
     return zones.first
@@ -176,7 +178,8 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
   /// No-op if no application is selected or no repository was provided.
   public func toggleSaveSelectedApplication() async {
     guard let repository = savedApplicationRepository,
-          let selected = selectedApplication else { return }
+      let selected = selectedApplication
+    else { return }
 
     let uid = selected.id.value
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/SavedApplicationList/SavedApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/SavedApplicationList/SavedApplicationListViewModel.swift
@@ -62,7 +62,8 @@ public final class SavedApplicationListViewModel: ObservableObject, ErrorHandlin
     error = nil
     do {
       let saved = try await savedApplicationRepository.loadAll()
-      applications = saved
+      applications =
+        saved
         .sorted { $0.savedAt > $1.savedAt }
         .compactMap(\.application)
     } catch {

--- a/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryTests.swift
@@ -392,7 +392,8 @@ struct APIPlanningApplicationRepositoryTests {
       }
       """
     let (sut, _, _) = makeSUT(responses: [(Data(json.utf8), httpResponse(statusCode: 200))])
-    let app = try await sut.fetchApplication(by: PlanningApplicationId(authority: "1", name: "REF/001"))
+    let app = try await sut.fetchApplication(
+      by: PlanningApplicationId(authority: "1", name: "REF/001"))
     #expect(app.status == .unknown)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorBadgeAndWatermarkTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorBadgeAndWatermarkTests.swift
@@ -167,7 +167,9 @@ struct AppCoordinatorBadgeAndWatermarkTests {
     await sut.waitForPendingDetailLoad()
     await sut.waitForPendingWatermarkAdvance()
 
-    #expect(planningSpy.fetchApplicationCalls == [PlanningApplicationId(authority: "42", name: "APP-002")])
+    #expect(
+      planningSpy.fetchApplicationCalls == [PlanningApplicationId(authority: "42", name: "APP-002")]
+    )
     let formatter = ISO8601DateFormatter()
     formatter.formatOptions = [.withInternetDateTime]
     #expect(stateRepo.advanceCalls == [formatter.date(from: "2026-05-04T08:11:57Z")])
@@ -198,7 +200,9 @@ struct AppCoordinatorBadgeAndWatermarkTests {
     await sut.waitForPendingDetailLoad()
     await sut.waitForPendingWatermarkAdvance()
 
-    #expect(planningSpy.fetchApplicationCalls == [PlanningApplicationId(authority: "42", name: "APP-003")])
+    #expect(
+      planningSpy.fetchApplicationCalls == [PlanningApplicationId(authority: "42", name: "APP-003")]
+    )
     #expect(stateRepo.advanceCalls.isEmpty)
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -67,8 +67,9 @@ struct AppCoordinatorTests {
     savedSpy.loadAllResult = .success([
       SavedApplication(
         applicationUid: PlanningApplication.pendingReview.id.value,
-        savedAt: Date()
-      ),
+        savedAt: Date(),
+        application: .pendingReview
+      )
     ])
     let (sut, _) = makeSUT(savedApplicationRepository: savedSpy)
     let vm = sut.makeApplicationDetailViewModel(application: .pendingReview)
@@ -219,7 +220,7 @@ struct AppCoordinatorTests {
   @Test func makeSavedApplicationListViewModel_returnsConfiguredViewModel() async {
     let savedSpy = SpySavedApplicationRepository()
     savedSpy.loadAllResult = .success([
-      SavedApplication.fixture(uid: "APP-A"),
+      SavedApplication.fixture(uid: "APP-A")
     ])
     let (sut, _) = makeSUT(savedApplicationRepository: savedSpy)
 

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTierResolutionTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTierResolutionTests.swift
@@ -17,7 +17,8 @@ struct AppCoordinatorTierResolutionTests {
     serverProfileError: Error? = nil,
     tierResolver: SubscriptionTierResolving? = nil,
     tierCache: UserDefaults = UserDefaults(suiteName: UUID().uuidString) ?? .standard
-  ) -> (AppCoordinator, SpyAuthenticationService, SpySubscriptionService, SpyUserProfileRepository) {
+  ) -> (AppCoordinator, SpyAuthenticationService, SpySubscriptionService, SpyUserProfileRepository)
+  {
     let authSpy = SpyAuthenticationService()
     authSpy.currentSessionResult = authSession
     let subscriptionSpy = SpySubscriptionService()

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailSaveTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailSaveTests.swift
@@ -137,7 +137,7 @@ struct ApplicationDetailSaveTests {
         applicationUid: PlanningApplication.pendingReview.id.value,
         savedAt: Date(),
         application: .pendingReview
-      ),
+      )
     ])
     let sut = ApplicationDetailViewModel(
       application: .pendingReview,
@@ -154,7 +154,7 @@ struct ApplicationDetailSaveTests {
   func loadSavedState_whenApplicationNotSaved_leavesIsSavedFalse() async {
     let spy = SpySavedApplicationRepository()
     spy.loadAllResult = .success([
-      SavedApplication(applicationUid: "OTHER-APP", savedAt: Date()),
+      SavedApplication(applicationUid: "OTHER-APP", savedAt: Date())
     ])
     let sut = ApplicationDetailViewModel(
       application: .pendingReview,
@@ -200,7 +200,7 @@ struct ApplicationDetailSaveTests {
         applicationUid: "legacy/uid/format-mismatch",
         savedAt: Date(),
         application: .pendingReview
-      ),
+      )
     ])
     let sut = ApplicationDetailViewModel(
       application: .pendingReview,
@@ -220,7 +220,7 @@ struct ApplicationDetailSaveTests {
         applicationUid: PlanningApplication.pendingReview.id.value,
         savedAt: Date(),
         application: PlanningApplication.permitted
-      ),
+      )
     ])
     let sut = ApplicationDetailViewModel(
       application: .pendingReview,

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailSaveTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailSaveTests.swift
@@ -135,7 +135,8 @@ struct ApplicationDetailSaveTests {
     spy.loadAllResult = .success([
       SavedApplication(
         applicationUid: PlanningApplication.pendingReview.id.value,
-        savedAt: Date()
+        savedAt: Date(),
+        application: .pendingReview
       ),
     ])
     let sut = ApplicationDetailViewModel(
@@ -183,6 +184,48 @@ struct ApplicationDetailSaveTests {
   @Test("loadSavedState is no-op when repository is nil")
   func loadSavedState_withoutRepository_isNoOp() async {
     let sut = ApplicationDetailViewModel(application: .pendingReview)
+
+    await sut.loadSavedState()
+
+    #expect(!sut.isSaved)
+  }
+
+  @Test("loadSavedState sets isSaved true when snapshot id matches despite a stale top-level uid")
+  func loadSavedState_whenTopLevelUidDiffersButSnapshotIdMatches_setsIsSavedTrue() async {
+    let spy = SpySavedApplicationRepository()
+    // The stored top-level uid is in a stale/different format from the
+    // reconstructed snapshot id — the compare must rely on the snapshot.
+    spy.loadAllResult = .success([
+      SavedApplication(
+        applicationUid: "legacy/uid/format-mismatch",
+        savedAt: Date(),
+        application: .pendingReview
+      ),
+    ])
+    let sut = ApplicationDetailViewModel(
+      application: .pendingReview,
+      savedApplicationRepository: spy
+    )
+
+    await sut.loadSavedState()
+
+    #expect(sut.isSaved)
+  }
+
+  @Test("loadSavedState leaves isSaved false when no embedded snapshot id matches")
+  func loadSavedState_whenSnapshotIdDoesNotMatch_leavesIsSavedFalse() async {
+    let spy = SpySavedApplicationRepository()
+    spy.loadAllResult = .success([
+      SavedApplication(
+        applicationUid: PlanningApplication.pendingReview.id.value,
+        savedAt: Date(),
+        application: PlanningApplication.permitted
+      ),
+    ])
+    let sut = ApplicationDetailViewModel(
+      application: .pendingReview,
+      savedApplicationRepository: spy
+    )
 
     await sut.loadSavedState()
 

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTests.swift
@@ -282,7 +282,9 @@ struct ApplicationListViewModelTests {
     zones: [WatchZone] = [.cambridge, .london],
     applications: [PlanningApplication] = [.pendingReview],
     persistedZoneId: String? = nil
-  ) throws -> (ApplicationListViewModel, SpyPlanningApplicationRepository, SpyWatchZoneRepository, UserDefaults) {
+  ) throws -> (
+    ApplicationListViewModel, SpyPlanningApplicationRepository, SpyWatchZoneRepository, UserDefaults
+  ) {
     let appSpy = SpyPlanningApplicationRepository()
     appSpy.fetchApplicationsResult = .success(applications)
     let zoneSpy = SpyWatchZoneRepository()

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
@@ -44,7 +44,8 @@ struct ApplicationListViewModelUnreadTests {
     return (sut, appSpy, stateSpy, defaults)
   }
 
-  private func event(at seconds: TimeInterval, type: String = "NewApplication") -> LatestUnreadEvent {
+  private func event(at seconds: TimeInterval, type: String = "NewApplication") -> LatestUnreadEvent
+  {
     LatestUnreadEvent(
       type: type,
       decision: nil,
@@ -199,11 +200,11 @@ struct ApplicationListViewModelUnreadTests {
     // app A: received earliest, but has a much-later unread event → top
     // app B: received in the middle, no unread event → middle
     // app C: received latest, no unread event → just below A
-    let appA = PlanningApplication.pendingReview // 1_700_000_000
+    let appA = PlanningApplication.pendingReview  // 1_700_000_000
       .withLatestUnreadEvent(event(at: 1_700_900_000))
-    let appB = PlanningApplication.permitted // 1_700_100_000
+    let appB = PlanningApplication.permitted  // 1_700_100_000
       .withLatestUnreadEvent(nil)
-    let appC = PlanningApplication.rejected // 1_700_200_000
+    let appC = PlanningApplication.rejected  // 1_700_200_000
       .withLatestUnreadEvent(nil)
     let (sut, _, _, _) = try makeSUT(applications: [appB, appA, appC])
 
@@ -215,9 +216,9 @@ struct ApplicationListViewModelUnreadTests {
 
   @Test("newest sort orders by receivedDate desc")
   func sort_newest_ordersByReceivedDateDesc() async throws {
-    let older = PlanningApplication.pendingReview // 1_700_000_000
-    let middle = PlanningApplication.permitted // 1_700_100_000
-    let newest = PlanningApplication.rejected // 1_700_200_000
+    let older = PlanningApplication.pendingReview  // 1_700_000_000
+    let middle = PlanningApplication.permitted  // 1_700_100_000
+    let newest = PlanningApplication.rejected  // 1_700_200_000
     let (sut, _, _, _) = try makeSUT(applications: [middle, older, newest])
 
     await sut.loadApplications()
@@ -241,9 +242,9 @@ struct ApplicationListViewModelUnreadTests {
 
   @Test("status sort orders by appState raw value")
   func sort_status_ordersByAppState() async throws {
-    let permitted = PlanningApplication.permitted // "Permitted"
-    let rejected = PlanningApplication.rejected // "Rejected"
-    let undecided = PlanningApplication.pendingReview // "Undecided"
+    let permitted = PlanningApplication.permitted  // "Permitted"
+    let rejected = PlanningApplication.rejected  // "Rejected"
+    let undecided = PlanningApplication.pendingReview  // "Undecided"
     let (sut, _, _, _) = try makeSUT(applications: [undecided, rejected, permitted])
 
     await sut.loadApplications()

--- a/mobile/ios/town-crier-tests/Sources/Features/DeepLinkTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeepLinkTests.swift
@@ -113,7 +113,8 @@ struct NotificationPayloadParserTests {
 
     let result = NotificationPayloadParser.parseDeepLink(from: userInfo)
 
-    #expect(result == .applicationDetail(PlanningApplicationId(authority: "42", name: "22/1234/FUL")))
+    #expect(
+      result == .applicationDetail(PlanningApplicationId(authority: "42", name: "22/1234/FUL")))
   }
 
   @Test func parseDeepLink_missingAuthorityId_returnsNil() {

--- a/mobile/ios/town-crier-tests/Sources/Features/DomainErrorMessageTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DomainErrorMessageTests.swift
@@ -113,7 +113,9 @@ struct DomainErrorMessageTests {
 
   @Test func invalidPostcode_hasSpecificMessage() {
     let error = DomainError.invalidPostcode("NOPE")
-    #expect(error.userMessage == "The postcode 'NOPE' doesn't look right. Please enter a valid UK postcode.")
+    #expect(
+      error.userMessage
+        == "The postcode 'NOPE' doesn't look right. Please enter a valid UK postcode.")
   }
 
   @Test func invalidPostcode_isNotRetryable() {
@@ -129,7 +131,9 @@ struct DomainErrorMessageTests {
 
   @Test func geocodingFailed_hasSpecificMessage() {
     let error = DomainError.geocodingFailed("SW1A 1AA")
-    #expect(error.userMessage == "We couldn't find the location for that postcode. Please check and try again.")
+    #expect(
+      error.userMessage
+        == "We couldn't find the location for that postcode. Please check and try again.")
   }
 
   @Test func geocodingFailed_isRetryable() {

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewModelSaveTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewModelSaveTests.swift
@@ -132,7 +132,7 @@ struct MapViewModelSaveTests {
   func loadSavedState_populatesUids() async {
     let (sut, spy) = makeSUT()
     spy.loadAllResult = .success([
-      SavedApplication(applicationUid: PlanningApplication.pendingReview.id.value, savedAt: Date()),
+      SavedApplication(applicationUid: PlanningApplication.pendingReview.id.value, savedAt: Date())
     ])
     await sut.loadApplications()
 

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
@@ -282,7 +282,8 @@ struct MapViewModelTests {
     zones: [WatchZone] = [.cambridge, .london],
     applications: [PlanningApplication] = [.pendingReview],
     persistedZoneId: String? = nil
-  ) throws -> (MapViewModel, SpyPlanningApplicationRepository, SpyWatchZoneRepository, UserDefaults) {
+  ) throws -> (MapViewModel, SpyPlanningApplicationRepository, SpyWatchZoneRepository, UserDefaults)
+  {
     let appSpy = SpyPlanningApplicationRepository()
     appSpy.fetchApplicationsResult = .success(applications)
     let zoneSpy = SpyWatchZoneRepository()

--- a/mobile/ios/town-crier-tests/Sources/Spies/ControllableSavedApplicationRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/ControllableSavedApplicationRepository.swift
@@ -4,7 +4,8 @@ import TownCrierDomain
 /// Test double for `SavedApplicationRepository` that suspends `loadAll()` until
 /// `resume(with:)` is called. Used to assert in-flight loading state on
 /// `ApplicationListViewModel` and `MapViewModel`.
-final class ControllableSavedApplicationRepository: SavedApplicationRepository, @unchecked Sendable {
+final class ControllableSavedApplicationRepository: SavedApplicationRepository, @unchecked Sendable
+{
   private var continuation: CheckedContinuation<[SavedApplication], Error>?
   private var pendingCallSignal: CheckedContinuation<Void, Never>?
   private var didReceiveCall = false


### PR DESCRIPTION
## Changes

Root-cause fix for the saved-screen duplicate bug introduced when PR #398 changed `PlanningApplicationId.value` from a bare ref to `{areaId}/{planitName}`.

**tc-o88i — server-derive canonical uid in save handler (idempotency fix)**
- New `PlanningApplication.CanonicalUid` (`{areaId}/{name}`), computed server-side, independent of the client-supplied `request.Uid`.
- `SavedApplication` keys `ApplicationUid` (and thus the Cosmos `{userId}:{applicationUid}` doc id) on `CanonicalUid` — re-saves are now genuinely idempotent across stale-format clients.
- `SaveApplicationCommandHandler` idempotency check and both refresh-on-tap handlers aligned to `CanonicalUid`.
- Save endpoint drops the body/path uid-equality 400.
- `DispatchDecisionEventCommandHandler` unions raw + canonical saved-row keys so decision push notifications keep firing during the migration window.

**tc-sqr3 — one-off migration of legacy-format uids in Cosmos**
- Lazy self-heal extending the `GetSavedApplicationsQueryHandler` backfill path: legacy-keyed docs are re-keyed to the canonical id (delete legacy + write canonical, since Cosmos doc ids are immutable).
- Dedup: a legacy+canonical pair for the same app/user collapses to the canonical doc.
- Idempotent — already-canonical rows hit no re-key branch.
- `SavedApplicationDocument.ToDomain()` now reconstructs on the stored uid so the lazy re-key actually detects legacy docs.

**tc-jjl4 — iOS: harden saved-state check**
- `ApplicationDetailViewModel.loadSavedState()` now matches on the reconstructed snapshot id (`$0.application?.id == application.id`) instead of the raw stored `applicationUid` string, so a saved item with a stale-format stored uid no longer shows as unsaved.

Follow-up filed: tc-euys (P3) — `SavedApplicationList` ForEach duplicate-row rendering.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed saved application matching to work correctly when application UIDs appear in different formats
  * Corrected snapshot refresh behavior to properly update saved applications during format transitions
  * Prevented duplicate saves when the same application is saved with varying UID formats
  * Improved legacy saved application handling during UID format migration

* **New Features**
  * Added automatic self-healing for legacy saved applications on first read

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmyDe/town-crier/pull/400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->