### PR TITLE
fix: web pricing/FAQ copy — Personal 3 zones, 7-day trial, weekly Free digest (tc-eryu.7)

### DIFF
--- a/web/src/components/Faq/Faq.tsx
+++ b/web/src/components/Faq/Faq.tsx
@@ -19,7 +19,7 @@ const FAQ_ITEMS: FaqItem[] = [
   {
     question: 'Is there a free tier?',
     answer:
-      'Yes. The Free plan lets you monitor one watch zone with daily email digests at no cost, forever. Upgrade any time if you need more zones, wider radii, or instant push notifications.',
+      'Yes. The Free plan lets you monitor one watch zone with weekly email digests at no cost, forever. Upgrade any time if you need more zones, wider radii, or instant push notifications.',
   },
   {
     question: 'Can communities use Town Crier?',
@@ -29,7 +29,7 @@ const FAQ_ITEMS: FaqItem[] = [
   {
     question: 'How quickly will I be notified?',
     answer:
-      'Most applications appear within hours of being published by the local authority. Paid plans receive instant push notifications; the Free plan delivers a daily digest email each morning.',
+      'Most applications appear within hours of being published by the local authority. Paid plans receive instant push notifications; the Free plan delivers a weekly digest email.',
   },
 ];
 

--- a/web/src/components/Faq/__tests__/Faq.test.tsx
+++ b/web/src/components/Faq/__tests__/Faq.test.tsx
@@ -68,4 +68,15 @@ describe('Faq', () => {
       expect(answerText.length).toBeGreaterThan(0);
     });
   });
+
+  it('describes Free tier digest as weekly (not daily)', () => {
+    render(<Faq />);
+
+    // The free tier FAQ answer must say weekly, not daily
+    const freeAnswer = screen.getByText(/is there a free tier/i)
+      .closest('details')!
+      .querySelector('p')!;
+    expect(freeAnswer.textContent).toMatch(/weekly/i);
+    expect(freeAnswer.textContent).not.toMatch(/daily/i);
+  });
 });

--- a/web/src/components/Pricing/Pricing.tsx
+++ b/web/src/components/Pricing/Pricing.tsx
@@ -8,7 +8,7 @@ interface Feature {
 }
 
 const FEATURES: Feature[] = [
-  { label: 'Watch Zones', free: '1', personal: '5', pro: 'Unlimited' },
+  { label: 'Watch Zones', free: '1', personal: '3', pro: 'Unlimited' },
   { label: 'Radius', free: '500m', personal: '2km', pro: '5km' },
   { label: 'Notifications', free: 'Weekly digest', personal: 'Instant', pro: 'Instant' },
   { label: 'Search', free: 'Basic', personal: 'Advanced', pro: 'Advanced + Filters' },
@@ -25,7 +25,7 @@ interface Tier {
 
 const TIERS: Tier[] = [
   { name: 'Free', price: '£0' },
-  { name: 'Personal', price: '£1.99', period: '/mo', recommended: true, trialText: '14-day free trial' },
+  { name: 'Personal', price: '£1.99', period: '/mo', recommended: true, trialText: '7-day free trial' },
   { name: 'Pro', price: '£5.99', period: '/mo' },
 ];
 

--- a/web/src/components/Pricing/__tests__/Pricing.test.tsx
+++ b/web/src/components/Pricing/__tests__/Pricing.test.tsx
@@ -66,6 +66,24 @@ describe('Pricing', () => {
     expect(screen.getByText(/free trial/i)).toBeInTheDocument();
   });
 
+  it('shows 7-day free trial (not 14-day) on Personal tier', () => {
+    render(<Pricing />);
+
+    expect(screen.getByText('7-day free trial')).toBeInTheDocument();
+  });
+
+  it('shows Personal watch zone quota as 3 (matching EntitlementMap)', () => {
+    render(<Pricing />);
+
+    const cards = screen.getAllByRole('article');
+    const personalCard = cards.find((card) => within(card).queryByText('Personal'));
+    expect(personalCard).toBeDefined();
+
+    const watchZoneRow = within(personalCard!).getByText('Watch Zones').closest('li');
+    expect(watchZoneRow).toBeDefined();
+    expect(within(watchZoneRow!).getByText('3')).toBeInTheDocument();
+  });
+
   it('renders feature rows with label/value pairs', () => {
     render(<Pricing />);
 


### PR DESCRIPTION
Web copy corrections for the subscriptions launch (epic tc-eryu, issue #401).

- Pricing: Personal watch zones 5 → 3 (matches `EntitlementMap` in api/ and ios/).
- Pricing: free trial "14-day" → "7-day" (matches ADR 0010).
- FAQ: Free tier digest "daily" → "weekly".

Vitest: 642 tests pass; `tsc --noEmit` and `npm run build` clean.

Closes bead tc-eryu.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)