### PR TITLE
feat: wire OfferCodeService + add .storekit config (tc-eryu.6)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+OfferCodes.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+OfferCodes.swift
@@ -2,6 +2,13 @@ import Foundation
 import TownCrierDomain
 
 extension AppCoordinator {
+  /// `true` when an `OfferCodeService` was injected, meaning the offer-code
+  /// redemption flow is wired end-to-end. The composition root reads this to
+  /// decide whether to surface the "Redeem Offer Code" row in Settings.
+  public var isOfferCodeRedemptionAvailable: Bool {
+    offerCodeService != nil
+  }
+
   /// Presents the "Redeem Offer Code" sheet from Settings. Has no effect if
   /// the Coordinator was constructed without an `OfferCodeService` (i.e. the
   /// feature is not wired).

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -18,6 +18,8 @@ targets:
     sources:
       - path: town-crier-app/Sources
       - path: town-crier-app/Resources
+      - path: town-crier-app/TownCrier.storekit
+        buildPhase: none
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: uk.towncrierapp.mobile
@@ -55,6 +57,11 @@ schemes:
     run:
       config: Debug
       simulateLocation: false
+      # StoreKit configuration file for Simulator IAP testing — defines the
+      # Personal and Pro products so purchases can be exercised without a
+      # sandbox App Store account. Emits StoreKitConfigurationFileReference
+      # into the generated .xcscheme.
+      storeKitConfiguration: town-crier-app/TownCrier.storekit
     profile:
       config: Release
     analyze:

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -57,6 +57,9 @@ struct TownCrierApp: App {
     let geocoder = APIPostcodeGeocoder(apiClient: apiClient)
     let savedApplicationRepository = APISavedApplicationRepository(apiClient: apiClient)
     let notificationStateRepository = APINotificationStateRepository(apiClient: apiClient)
+    // Offer-code redemption — POSTs to /v1/offer-codes/redeem (ADR 0022).
+    // Injecting the service unhides the "Redeem Offer Code" row in Settings.
+    let offerCodeService = HttpOfferCodeService(apiClient: apiClient)
 
     let appCoordinator = AppCoordinator(
       repository: repository,
@@ -72,6 +75,7 @@ struct TownCrierApp: App {
       appVersionProvider: appVersionProvider,
       versionConfigService: versionConfigService,
       savedApplicationRepository: savedApplicationRepository,
+      offerCodeService: offerCodeService,
       notificationStateRepository: notificationStateRepository,
       badgeSetter: UIApplicationBadgeSetter()
     )
@@ -277,7 +281,12 @@ struct TownCrierApp: App {
         },
         onTermsOfService: {
           coordinator.showTermsOfService()
-        }
+        },
+        // Surfacing the "Redeem Offer Code" row only when an OfferCodeService
+        // was injected — SettingsView hides the row when this callback is nil.
+        onRedeemOfferCode: coordinator.isOfferCodeRedemptionAvailable
+          ? { coordinator.showRedeemOfferCode() }
+          : nil
       )
       .navigationDestination(isPresented: $coordinator.isNotificationPreferencesPresented) {
         NotificationPreferencesView(
@@ -295,6 +304,17 @@ struct TownCrierApp: App {
     .sheet(item: $coordinator.presentedLegalDocument) { documentType in
       NavigationStack {
         LegalDocumentView(viewModel: LegalDocumentViewModel(documentType: documentType))
+      }
+    }
+    // Offer-code redemption — presented from the "Redeem Offer Code" row in
+    // Settings (ADR 0022). The factory returns nil if no OfferCodeService was
+    // injected, in which case the row is also hidden, so the sheet body is a
+    // no-op fallback that should never render.
+    .sheet(isPresented: $coordinator.isRedeemOfferCodePresented) {
+      NavigationStack {
+        if let viewModel = coordinator.makeRedeemOfferCodeViewModel() {
+          RedeemOfferCodeView(viewModel: viewModel)
+        }
       }
     }
     #if os(iOS)

--- a/mobile/ios/town-crier-app/TownCrier.storekit
+++ b/mobile/ios/town-crier-app/TownCrier.storekit
@@ -1,0 +1,133 @@
+{
+  "identifier" : "TownCrier-IAP",
+  "nonRenewingSubscriptions" : [
+
+  ],
+  "products" : [
+
+  ],
+  "settings" : {
+    "_compatibilityTimeRate" : {
+      "1" : 1
+    },
+    "_failTransactionsEnabled" : false,
+    "_locale" : "en_GB",
+    "_storefront" : "GBR",
+    "_storeKitErrors" : [
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Load Products"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Purchase"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Verification"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Store Sync"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Subscription Status"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "App Transaction"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Manage Subscriptions Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Refund Request Sheet"
+      },
+      {
+        "current" : null,
+        "enabled" : false,
+        "name" : "Offer Code Redeem Sheet"
+      }
+    ]
+  },
+  "subscriptionGroups" : [
+    {
+      "id" : "21001",
+      "localizations" : [
+
+      ],
+      "name" : "Town Crier Subscriptions",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "1.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "21010",
+          "introductoryOffer" : {
+            "internalID" : "21011",
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P1W"
+          },
+          "localizations" : [
+            {
+              "description" : "Up to 3 watch zones, status-change and decision alerts, and a daily digest.",
+              "displayName" : "Personal",
+              "locale" : "en_GB"
+            }
+          ],
+          "productID" : "uk.co.towncrier.personal.monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Personal Monthly",
+          "subscriptionGroupID" : "21001",
+          "type" : "RecurringSubscription"
+        },
+        {
+          "adHocOffers" : [
+
+          ],
+          "codeOffers" : [
+
+          ],
+          "displayPrice" : "4.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "21020",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Unlimited watch zones, all alert types, and an hourly digest.",
+              "displayName" : "Pro",
+              "locale" : "en_GB"
+            }
+          ],
+          "productID" : "uk.co.towncrier.pro.monthly",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Pro Monthly",
+          "subscriptionGroupID" : "21001",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    }
+  ],
+  "version" : {
+    "major" : 4,
+    "minor" : 0
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorOfferCodeTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorOfferCodeTests.swift
@@ -72,6 +72,22 @@ struct AppCoordinatorOfferCodeTests {
     #expect(sut.isRedeemOfferCodePresented == true)
   }
 
+  // MARK: - Feature availability
+
+  @Test("isOfferCodeRedemptionAvailable is false when no OfferCodeService is wired")
+  func isOfferCodeRedemptionAvailable_withoutService_isFalse() {
+    let (sut, _, _) = makeSUT(offerCodeService: nil)
+
+    #expect(sut.isOfferCodeRedemptionAvailable == false)
+  }
+
+  @Test("isOfferCodeRedemptionAvailable is true when an OfferCodeService is wired")
+  func isOfferCodeRedemptionAvailable_withService_isTrue() {
+    let (sut, _, _) = makeSUT(offerCodeService: SpyOfferCodeService())
+
+    #expect(sut.isOfferCodeRedemptionAvailable == true)
+  }
+
   // MARK: - Factory
 
   @Test("makeRedeemOfferCodeViewModel returns nil when no OfferCodeService is wired")


### PR DESCRIPTION
iOS loose ends for the subscriptions activation pipeline (epic tc-eryu, issue #401).

- Instantiate `HttpOfferCodeService` in the composition root and inject it into `AppCoordinator` — the "Redeem Offer Code" Settings row now appears and the redeem flow works against `POST /v1/offer-codes/redeem`.
- New `TownCrier.storekit` config defining both IAP products (`uk.co.towncrier.personal.monthly`, `uk.co.towncrier.pro.monthly`, 7-day intro offer per ADR 0010), wired into the Xcode scheme via XcodeGen for Simulator purchase testing.

`swift test`: 1215 pass; app target builds clean; SwiftLint clean on changed files.

Closes bead tc-eryu.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced offer code redemption capability accessible via Settings when available.
  * Enhanced StoreKit configuration to support in-app purchase testing in Simulator.

* **Tests**
  * Added tests validating offer code redemption feature availability.
  * Improved testing infrastructure for simulated purchase scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AmyDe/town-crier/pull/404?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->