### PR TITLE
feat: App Store Server Notifications v2 webhook (tc-eryu.2)

### DIFF
--- a/api/src/town-crier.infrastructure/Cosmos/CosmosContainerNames.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosContainerNames.cs
@@ -18,4 +18,5 @@ public static class CosmosContainerNames
     public const string PollState = "PollState";
     public const string OfferCodes = "OfferCodes";
     public const string Leases = "Leases";
+    public const string AppleNotifications = "AppleNotifications";
 }

--- a/api/src/town-crier.infrastructure/Subscriptions/AppleNotificationData.cs
+++ b/api/src/town-crier.infrastructure/Subscriptions/AppleNotificationData.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Infrastructure.Subscriptions;
+
+/// <summary>
+/// The <c>data</c> object of an App Store Server Notification v2, carrying the
+/// nested signed JWS payloads.
+/// </summary>
+internal sealed record AppleNotificationData(
+    [property: JsonPropertyName("signedTransactionInfo")] string? SignedTransactionInfo,
+    [property: JsonPropertyName("signedRenewalInfo")] string? SignedRenewalInfo);

--- a/api/src/town-crier.infrastructure/Subscriptions/AppleNotificationPayload.cs
+++ b/api/src/town-crier.infrastructure/Subscriptions/AppleNotificationPayload.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Infrastructure.Subscriptions;
+
+/// <summary>
+/// The decoded JSON payload of an Apple App Store Server Notification v2
+/// (the <c>responseBodyV2DecodedPayload</c> shape). The signed JWS strings
+/// for the transaction and renewal info are nested under <c>data</c>.
+/// </summary>
+internal sealed record AppleNotificationPayload(
+    [property: JsonPropertyName("notificationType")] string? NotificationType,
+    [property: JsonPropertyName("subtype")] string? Subtype,
+    [property: JsonPropertyName("notificationUUID")] string? NotificationUuid,
+    [property: JsonPropertyName("data")] AppleNotificationData? Data);

--- a/api/src/town-crier.infrastructure/Subscriptions/CosmosNotificationIdempotencyStore.cs
+++ b/api/src/town-crier.infrastructure/Subscriptions/CosmosNotificationIdempotencyStore.cs
@@ -1,0 +1,65 @@
+using TownCrier.Application.Subscriptions;
+using TownCrier.Infrastructure.Cosmos;
+
+namespace TownCrier.Infrastructure.Subscriptions;
+
+/// <summary>
+/// Cosmos-backed <see cref="INotificationIdempotencyStore"/>. Each processed
+/// App Store Server Notification is recorded as one document on the
+/// <c>AppleNotifications</c> container, keyed and partitioned by the Apple
+/// <c>notificationUUID</c>. A duplicate delivery is therefore a no-op:
+/// <see cref="IsProcessedAsync"/> finds the existing document and the handler
+/// returns early.
+/// </summary>
+public sealed class CosmosNotificationIdempotencyStore : INotificationIdempotencyStore
+{
+    private readonly ICosmosRestClient client;
+    private readonly TimeProvider timeProvider;
+
+    public CosmosNotificationIdempotencyStore(ICosmosRestClient client)
+        : this(client, TimeProvider.System)
+    {
+    }
+
+    public CosmosNotificationIdempotencyStore(ICosmosRestClient client, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        this.client = client;
+        this.timeProvider = timeProvider;
+    }
+
+    public async Task<bool> IsProcessedAsync(string notificationUuid, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(notificationUuid);
+
+        var document = await this.client.ReadDocumentAsync(
+            CosmosContainerNames.AppleNotifications,
+            notificationUuid,
+            notificationUuid,
+            SubscriptionsCosmosJsonContext.Default.ProcessedNotificationDocument,
+            ct).ConfigureAwait(false);
+
+        return document is not null;
+    }
+
+    public async Task MarkProcessedAsync(string notificationUuid, CancellationToken ct)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(notificationUuid);
+
+        var document = new ProcessedNotificationDocument
+        {
+            Id = notificationUuid,
+            ProcessedAt = this.timeProvider.GetUtcNow(),
+        };
+
+        // Upsert (last-writer-wins) so a re-delivery that races past the
+        // IsProcessedAsync check still completes without a conflict error.
+        await this.client.UpsertDocumentAsync(
+            CosmosContainerNames.AppleNotifications,
+            document,
+            notificationUuid,
+            SubscriptionsCosmosJsonContext.Default.ProcessedNotificationDocument,
+            ct).ConfigureAwait(false);
+    }
+}

--- a/api/src/town-crier.infrastructure/Subscriptions/NotificationDecoder.cs
+++ b/api/src/town-crier.infrastructure/Subscriptions/NotificationDecoder.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using TownCrier.Application.Subscriptions;
+
+namespace TownCrier.Infrastructure.Subscriptions;
+
+/// <summary>
+/// Maps the raw JSON payload of a verified Apple App Store Server Notification
+/// v2 onto the application-layer <see cref="DecodedNotification"/>. Native
+/// AOT-safe — uses System.Text.Json source generation only.
+/// </summary>
+public sealed class NotificationDecoder : INotificationDecoder
+{
+    public DecodedNotification Decode(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            throw new ArgumentException("The notification JSON is empty.", nameof(json));
+        }
+
+        AppleNotificationPayload? payload;
+        try
+        {
+            payload = JsonSerializer.Deserialize(
+                json, SubscriptionsJsonSerializerContext.Default.AppleNotificationPayload);
+        }
+        catch (JsonException ex)
+        {
+            throw new ArgumentException("The notification JSON is malformed.", nameof(json), ex);
+        }
+
+        if (payload is null)
+        {
+            throw new ArgumentException("The notification JSON is null.", nameof(json));
+        }
+
+        return new DecodedNotification(
+            NotificationType: Require(payload.NotificationType, "notificationType"),
+            Subtype: payload.Subtype,
+            NotificationUuid: Require(payload.NotificationUuid, "notificationUUID"),
+            SignedTransactionInfo: Require(
+                payload.Data?.SignedTransactionInfo, "data.signedTransactionInfo"),
+            SignedRenewalInfo: payload.Data?.SignedRenewalInfo);
+    }
+
+    private static string Require(string? value, string field) =>
+        string.IsNullOrEmpty(value)
+            ? throw new ArgumentException(
+                $"The notification JSON is missing the required '{field}' field.")
+            : value;
+}

--- a/api/src/town-crier.infrastructure/Subscriptions/ProcessedNotificationDocument.cs
+++ b/api/src/town-crier.infrastructure/Subscriptions/ProcessedNotificationDocument.cs
@@ -1,0 +1,14 @@
+namespace TownCrier.Infrastructure.Subscriptions;
+
+/// <summary>
+/// Cosmos document recording that an App Store Server Notification has been
+/// processed. The document <c>id</c> and partition key are both the Apple
+/// <c>notificationUUID</c>, so a duplicate delivery is detected with a single
+/// point read.
+/// </summary>
+internal sealed class ProcessedNotificationDocument
+{
+    public required string Id { get; init; }
+
+    public required DateTimeOffset ProcessedAt { get; init; }
+}

--- a/api/src/town-crier.infrastructure/Subscriptions/SubscriptionsCosmosJsonContext.cs
+++ b/api/src/town-crier.infrastructure/Subscriptions/SubscriptionsCosmosJsonContext.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace TownCrier.Infrastructure.Subscriptions;
+
+/// <summary>
+/// Source-generated JSON metadata for the subscription Cosmos documents — keeps
+/// the idempotency store Native AOT-compatible (no reflection-based
+/// serialization).
+/// </summary>
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
+[JsonSerializable(typeof(ProcessedNotificationDocument))]
+internal sealed partial class SubscriptionsCosmosJsonContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Subscriptions/SubscriptionsJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Subscriptions/SubscriptionsJsonSerializerContext.cs
@@ -10,4 +10,6 @@ namespace TownCrier.Infrastructure.Subscriptions;
 [JsonSourceGenerationOptions(WriteIndented = false)]
 [JsonSerializable(typeof(JwsHeader))]
 [JsonSerializable(typeof(AppleTransactionPayload))]
+[JsonSerializable(typeof(AppleNotificationPayload))]
+[JsonSerializable(typeof(AppleNotificationData))]
 internal sealed partial class SubscriptionsJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.web/AppJsonSerializerContext.cs
+++ b/api/src/town-crier.web/AppJsonSerializerContext.cs
@@ -77,6 +77,7 @@ namespace TownCrier.Web;
 [JsonSerializable(typeof(SaveApplicationRequest))]
 [JsonSerializable(typeof(VerifySubscriptionRequest))]
 [JsonSerializable(typeof(VerifySubscriptionResponse))]
+[JsonSerializable(typeof(AppStoreNotificationRequest))]
 [JsonSerializable(typeof(GetNotificationStateResult))]
 [JsonSerializable(typeof(AdvanceNotificationStateRequest))]
 internal sealed partial class AppJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.web/Endpoints/AppStoreNotificationRequest.cs
+++ b/api/src/town-crier.web/Endpoints/AppStoreNotificationRequest.cs
@@ -1,0 +1,8 @@
+namespace TownCrier.Web.Endpoints;
+
+/// <summary>
+/// Request body for <c>POST /v1/webhooks/appstore</c>. <see cref="SignedPayload"/>
+/// is the Apple App Store Server Notification v2 signed JWS payload (compact
+/// serialization).
+/// </summary>
+internal sealed record AppStoreNotificationRequest(string SignedPayload);

--- a/api/src/town-crier.web/Endpoints/SubscriptionEndpoints.cs
+++ b/api/src/town-crier.web/Endpoints/SubscriptionEndpoints.cs
@@ -75,6 +75,59 @@ internal static class SubscriptionEndpoints
                     statusCode: 404);
             }
         });
+
+        // App Store Server Notifications v2 (ADR 0010). Apple POSTs subscription
+        // lifecycle events here — renewal, billing-retry grace period, expiry,
+        // refund, revoke. The call is Apple -> API, not user-facing, so it is
+        // anonymous; the signed JWS is the authentication. The body is read and
+        // deserialized explicitly so a malformed payload returns a clean 400.
+        group.MapPost("/webhooks/appstore", async (
+            HttpContext context,
+            HandleAppStoreNotificationCommandHandler handler,
+            CancellationToken ct) =>
+        {
+            AppStoreNotificationRequest? request;
+            try
+            {
+                request = await context.Request
+                    .ReadFromJsonAsync(
+                        AppJsonSerializerContext.Default.AppStoreNotificationRequest, ct)
+                    .ConfigureAwait(false);
+            }
+            catch (JsonException)
+            {
+                return MalformedBody();
+            }
+
+            if (request is null || string.IsNullOrWhiteSpace(request.SignedPayload))
+            {
+                return MalformedBody();
+            }
+
+            try
+            {
+                await handler
+                    .HandleAsync(new HandleAppStoreNotificationCommand(request.SignedPayload), ct)
+                    .ConfigureAwait(false);
+
+                return Results.Ok();
+            }
+            catch (AppleJwsVerificationException ex)
+            {
+                return Results.Json(
+                    new ApiErrorResponse("invalid_notification", ex.Message),
+                    AppJsonSerializerContext.Default.ApiErrorResponse,
+                    statusCode: 401);
+            }
+            catch (ArgumentException ex)
+            {
+                return Results.Json(
+                    new ApiErrorResponse("invalid_notification_payload", ex.Message),
+                    AppJsonSerializerContext.Default.ApiErrorResponse,
+                    statusCode: 400);
+            }
+        })
+        .AllowAnonymous();
     }
 
     private static IResult MalformedBody() => Results.Json(

--- a/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
+++ b/api/src/town-crier.web/Extensions/ServiceCollectionExtensions.cs
@@ -97,6 +97,8 @@ internal static class ServiceCollectionExtensions
         services.AddSingleton<IAppleJwsVerifier>(
             new AppleJwsVerifier(AppleRootCertificates.Load()));
         services.AddSingleton<ITransactionDecoder, TransactionDecoder>();
+        services.AddSingleton<INotificationDecoder, NotificationDecoder>();
+        services.AddSingleton<INotificationIdempotencyStore, CosmosNotificationIdempotencyStore>();
 
         services.AddSingleton<IRateLimitStore, InMemoryRateLimitStore>();
         services.Configure<RateLimitOptions>(configuration.GetSection("RateLimiting"));
@@ -194,6 +196,7 @@ internal static class ServiceCollectionExtensions
             Environment = configuration["Apple:Environment"] ?? "Production",
         });
         services.AddTransient<VerifySubscriptionCommandHandler>();
+        services.AddTransient<HandleAppStoreNotificationCommandHandler>();
 
         return services;
     }

--- a/api/tests/town-crier.application.tests/Subscriptions/HandleAppStoreNotificationCommandHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/Subscriptions/HandleAppStoreNotificationCommandHandlerTests.cs
@@ -122,9 +122,10 @@ public sealed class HandleAppStoreNotificationCommandHandlerTests
         // Act
         await handler.HandleAsync(command, CancellationToken.None);
 
-        // Assert
+        // Assert -- grace period set; tier unchanged (access retained during billing retry)
         var saved = deps.Repository.GetByUserId(UserId);
         await Assert.That(saved!.GracePeriodExpiry).IsEqualTo(gracePeriodExpiry);
+        await Assert.That(saved.Tier).IsEqualTo(SubscriptionTier.Personal);
     }
 
     [Test]

--- a/api/tests/town-crier.infrastructure.tests/Subscriptions/CosmosNotificationIdempotencyStoreTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Subscriptions/CosmosNotificationIdempotencyStoreTests.cs
@@ -1,0 +1,58 @@
+using TownCrier.Infrastructure.Subscriptions;
+using TownCrier.Infrastructure.Tests.Cosmos;
+
+namespace TownCrier.Infrastructure.Tests.Subscriptions;
+
+public sealed class CosmosNotificationIdempotencyStoreTests
+{
+    private const string NotificationUuid = "9ad9eb1c-1f0b-4e21-9d2e-2f1f8c8e0001";
+
+    [Test]
+    public async Task Should_ReturnFalse_When_NotificationHasNotBeenProcessed()
+    {
+        var client = new FakeCosmosRestClient();
+        var store = new CosmosNotificationIdempotencyStore(client);
+
+        var processed = await store.IsProcessedAsync(NotificationUuid, CancellationToken.None);
+
+        await Assert.That(processed).IsFalse();
+    }
+
+    [Test]
+    public async Task Should_ReturnTrue_When_NotificationHasBeenMarkedProcessed()
+    {
+        var client = new FakeCosmosRestClient();
+        var store = new CosmosNotificationIdempotencyStore(client);
+
+        await store.MarkProcessedAsync(NotificationUuid, CancellationToken.None);
+        var processed = await store.IsProcessedAsync(NotificationUuid, CancellationToken.None);
+
+        await Assert.That(processed).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_NotThrow_When_SameNotificationMarkedProcessedTwice()
+    {
+        var client = new FakeCosmosRestClient();
+        var store = new CosmosNotificationIdempotencyStore(client);
+
+        await store.MarkProcessedAsync(NotificationUuid, CancellationToken.None);
+        await store.MarkProcessedAsync(NotificationUuid, CancellationToken.None);
+
+        var processed = await store.IsProcessedAsync(NotificationUuid, CancellationToken.None);
+        await Assert.That(processed).IsTrue();
+    }
+
+    [Test]
+    public async Task Should_TrackEachNotificationIndependently()
+    {
+        var client = new FakeCosmosRestClient();
+        var store = new CosmosNotificationIdempotencyStore(client);
+
+        await store.MarkProcessedAsync(NotificationUuid, CancellationToken.None);
+
+        var otherProcessed = await store.IsProcessedAsync(
+            "9ad9eb1c-1f0b-4e21-9d2e-2f1f8c8e0002", CancellationToken.None);
+        await Assert.That(otherProcessed).IsFalse();
+    }
+}

--- a/api/tests/town-crier.infrastructure.tests/Subscriptions/NotificationDecoderTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Subscriptions/NotificationDecoderTests.cs
@@ -1,0 +1,112 @@
+using TownCrier.Infrastructure.Subscriptions;
+
+namespace TownCrier.Infrastructure.Tests.Subscriptions;
+
+public sealed class NotificationDecoderTests
+{
+    // The shape of an App Store Server Notification v2 responseBodyV2DecodedPayload:
+    // notificationType / subtype / notificationUUID at the top level, with the
+    // signed JWS strings nested under "data".
+    private const string ValidJson =
+        """
+        {
+          "notificationType": "DID_RENEW",
+          "subtype": "BILLING_RECOVERY",
+          "notificationUUID": "9ad9eb1c-1f0b-4e21-9d2e-2f1f8c8e0001",
+          "version": "2.0",
+          "data": {
+            "appAppleId": 1234567890,
+            "bundleId": "uk.co.towncrier.ios",
+            "environment": "Production",
+            "signedTransactionInfo": "inner.txn.signature",
+            "signedRenewalInfo": "inner.renewal.signature"
+          }
+        }
+        """;
+
+    [Test]
+    public async Task Should_MapTopLevelFields_When_JsonIsWellFormed()
+    {
+        var decoder = new NotificationDecoder();
+
+        var notification = decoder.Decode(ValidJson);
+
+        await Assert.That(notification.NotificationType).IsEqualTo("DID_RENEW");
+        await Assert.That(notification.Subtype).IsEqualTo("BILLING_RECOVERY");
+        await Assert.That(notification.NotificationUuid)
+            .IsEqualTo("9ad9eb1c-1f0b-4e21-9d2e-2f1f8c8e0001");
+    }
+
+    [Test]
+    public async Task Should_MapNestedSignedJwsStrings_When_JsonIsWellFormed()
+    {
+        var decoder = new NotificationDecoder();
+
+        var notification = decoder.Decode(ValidJson);
+
+        await Assert.That(notification.SignedTransactionInfo).IsEqualTo("inner.txn.signature");
+        await Assert.That(notification.SignedRenewalInfo).IsEqualTo("inner.renewal.signature");
+    }
+
+    [Test]
+    public async Task Should_AllowNullSubtypeAndRenewalInfo_When_AbsentFromPayload()
+    {
+        var decoder = new NotificationDecoder();
+        const string minimalJson =
+            """
+            {
+              "notificationType": "EXPIRED",
+              "notificationUUID": "9ad9eb1c-1f0b-4e21-9d2e-2f1f8c8e0002",
+              "data": {
+                "signedTransactionInfo": "inner.txn.signature"
+              }
+            }
+            """;
+
+        var notification = decoder.Decode(minimalJson);
+
+        await Assert.That(notification.NotificationType).IsEqualTo("EXPIRED");
+        await Assert.That(notification.Subtype).IsNull();
+        await Assert.That(notification.SignedRenewalInfo).IsNull();
+        await Assert.That(notification.SignedTransactionInfo).IsEqualTo("inner.txn.signature");
+    }
+
+    [Test]
+    public void Should_Throw_When_NotificationTypeIsMissing()
+    {
+        var decoder = new NotificationDecoder();
+        const string missingType =
+            """
+            {
+              "notificationUUID": "9ad9eb1c-1f0b-4e21-9d2e-2f1f8c8e0003",
+              "data": { "signedTransactionInfo": "inner.txn.signature" }
+            }
+            """;
+
+        Assert.Throws<ArgumentException>(() => decoder.Decode(missingType));
+    }
+
+    [Test]
+    public void Should_Throw_When_SignedTransactionInfoIsMissing()
+    {
+        var decoder = new NotificationDecoder();
+        const string missingTxn =
+            """
+            {
+              "notificationType": "DID_RENEW",
+              "notificationUUID": "9ad9eb1c-1f0b-4e21-9d2e-2f1f8c8e0004",
+              "data": {}
+            }
+            """;
+
+        Assert.Throws<ArgumentException>(() => decoder.Decode(missingTxn));
+    }
+
+    [Test]
+    public void Should_Throw_When_JsonIsMalformed()
+    {
+        var decoder = new NotificationDecoder();
+
+        Assert.Throws<ArgumentException>(() => decoder.Decode("{not json"));
+    }
+}

--- a/api/tests/town-crier.web.tests/Subscriptions/AppStoreWebhookEndpointTests.cs
+++ b/api/tests/town-crier.web.tests/Subscriptions/AppStoreWebhookEndpointTests.cs
@@ -1,0 +1,162 @@
+using System.Net;
+using System.Net.Http.Json;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using TownCrier.Application.Subscriptions;
+using TownCrier.Application.UserProfiles;
+using TownCrier.Domain.UserProfiles;
+using TownCrier.Infrastructure.UserProfiles;
+using TownCrier.Web.Endpoints;
+
+namespace TownCrier.Web.Tests.Subscriptions;
+
+public sealed class AppStoreWebhookEndpointTests
+{
+    private const string UserId = "auth0|test-user-123";
+    private const string OriginalTransactionId = "orig-txn-1";
+    private const string OuterJws = "outer.notification.jws";
+    private const string InnerTransactionJws = "inner.transaction.jws";
+
+    private const string ExpiredNotificationJson =
+        $$"""
+        {
+          "notificationType": "EXPIRED",
+          "notificationUUID": "9ad9eb1c-1f0b-4e21-9d2e-2f1f8c8e0001",
+          "data": {
+            "signedTransactionInfo": "{{InnerTransactionJws}}"
+          }
+        }
+        """;
+
+    private const string TransactionJson =
+        $$"""
+        {
+          "transactionId": "txn-1",
+          "originalTransactionId": "{{OriginalTransactionId}}",
+          "productId": "uk.co.towncrier.personal.monthly",
+          "bundleId": "uk.co.towncrier.ios",
+          "purchaseDate": 1744329600000,
+          "expiresDate": 1746921600000,
+          "environment": "Sandbox"
+        }
+        """;
+
+    private static readonly Uri WebhookUri = new("/v1/webhooks/appstore", UriKind.Relative);
+
+    [Test]
+    public async Task Should_Return200AndRevertTierToFree_When_ExpiredNotificationIsValid()
+    {
+        var repository = SubscribedUserRepository();
+        var verifier = MappingAppleJwsVerifier.Create()
+            .WithPayload(OuterJws, ExpiredNotificationJson)
+            .WithPayload(InnerTransactionJws, TransactionJson);
+
+        await using var baseFactory = new TestWebApplicationFactory();
+        await using var factory = baseFactory.WithWebHostBuilder(
+            builder => ConfigureWebhookHost(builder, verifier, repository));
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            WebhookUri,
+            new AppStoreNotificationRequest(OuterJws),
+            AppJsonSerializerContext.Default.AppStoreNotificationRequest).ConfigureAwait(false);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var profile = repository.GetByUserIdAsync(UserId, CancellationToken.None).GetAwaiter().GetResult();
+        await Assert.That(profile!.Tier).IsEqualTo(SubscriptionTier.Free);
+    }
+
+    [Test]
+    public async Task Should_Return401_When_JwsSignatureIsInvalid()
+    {
+        await using var baseFactory = new TestWebApplicationFactory();
+        await using var factory = baseFactory.WithWebHostBuilder(
+            builder => ConfigureWebhookHost(
+                builder, MappingAppleJwsVerifier.ThatRejects(), SubscribedUserRepository()));
+        using var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync(
+            WebhookUri,
+            new AppStoreNotificationRequest("tampered.jws.payload"),
+            AppJsonSerializerContext.Default.AppStoreNotificationRequest).ConfigureAwait(false);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task Should_Return400_When_PayloadIsMalformed()
+    {
+        await using var baseFactory = new TestWebApplicationFactory();
+        await using var factory = baseFactory.WithWebHostBuilder(
+            builder => ConfigureWebhookHost(
+                builder, MappingAppleJwsVerifier.Create(), SubscribedUserRepository()));
+        using var client = factory.CreateClient();
+
+        using var content = new StringContent(
+            "{not json", System.Text.Encoding.UTF8, "application/json");
+        var response = await client.PostAsync(WebhookUri, content).ConfigureAwait(false);
+
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.BadRequest);
+    }
+
+    [Test]
+    public async Task Should_BeIdempotent_When_SameNotificationDeliveredTwice()
+    {
+        var repository = SubscribedUserRepository();
+        var verifier = MappingAppleJwsVerifier.Create()
+            .WithPayload(OuterJws, ExpiredNotificationJson)
+            .WithPayload(InnerTransactionJws, TransactionJson);
+
+        await using var baseFactory = new TestWebApplicationFactory();
+        await using var factory = baseFactory.WithWebHostBuilder(
+            builder => ConfigureWebhookHost(builder, verifier, repository));
+        using var client = factory.CreateClient();
+
+        var first = await client.PostAsJsonAsync(
+            WebhookUri,
+            new AppStoreNotificationRequest(OuterJws),
+            AppJsonSerializerContext.Default.AppStoreNotificationRequest).ConfigureAwait(false);
+        var second = await client.PostAsJsonAsync(
+            WebhookUri,
+            new AppStoreNotificationRequest(OuterJws),
+            AppJsonSerializerContext.Default.AppStoreNotificationRequest).ConfigureAwait(false);
+
+        await Assert.That(first.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        await Assert.That(second.StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+        var profile = repository.GetByUserIdAsync(UserId, CancellationToken.None).GetAwaiter().GetResult();
+        await Assert.That(profile!.Tier).IsEqualTo(SubscriptionTier.Free);
+    }
+
+    private static InMemoryUserProfileRepository SubscribedUserRepository()
+    {
+        var profile = UserProfile.Register(UserId);
+        profile.LinkOriginalTransactionId(OriginalTransactionId);
+        profile.ActivateSubscription(
+            SubscriptionTier.Personal,
+            new DateTimeOffset(2026, 5, 11, 0, 0, 0, TimeSpan.Zero));
+
+        var repository = new InMemoryUserProfileRepository();
+        repository.SaveAsync(profile, CancellationToken.None).GetAwaiter().GetResult();
+        return repository;
+    }
+
+    private static void ConfigureWebhookHost(
+        IWebHostBuilder builder,
+        IAppleJwsVerifier verifier,
+        InMemoryUserProfileRepository repository)
+    {
+        builder.UseSetting("Apple:BundleId", "uk.co.towncrier.ios");
+        builder.UseSetting("Apple:Environment", "Sandbox");
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddSingleton(verifier);
+            services.AddSingleton<IUserProfileRepository>(repository);
+            services.AddSingleton<INotificationIdempotencyStore, InMemoryNotificationIdempotencyStore>();
+        });
+    }
+}

--- a/api/tests/town-crier.web.tests/Subscriptions/InMemoryNotificationIdempotencyStore.cs
+++ b/api/tests/town-crier.web.tests/Subscriptions/InMemoryNotificationIdempotencyStore.cs
@@ -1,0 +1,23 @@
+using System.Collections.Concurrent;
+using TownCrier.Application.Subscriptions;
+
+namespace TownCrier.Web.Tests.Subscriptions;
+
+/// <summary>
+/// In-memory <see cref="INotificationIdempotencyStore"/> for endpoint tests —
+/// substitutes for the Cosmos-backed store so the webhook can be exercised
+/// without a database.
+/// </summary>
+internal sealed class InMemoryNotificationIdempotencyStore : INotificationIdempotencyStore
+{
+    private readonly ConcurrentDictionary<string, byte> processed = new();
+
+    public Task<bool> IsProcessedAsync(string notificationUuid, CancellationToken ct) =>
+        Task.FromResult(this.processed.ContainsKey(notificationUuid));
+
+    public Task MarkProcessedAsync(string notificationUuid, CancellationToken ct)
+    {
+        this.processed[notificationUuid] = 0;
+        return Task.CompletedTask;
+    }
+}

--- a/api/tests/town-crier.web.tests/Subscriptions/MappingAppleJwsVerifier.cs
+++ b/api/tests/town-crier.web.tests/Subscriptions/MappingAppleJwsVerifier.cs
@@ -1,0 +1,43 @@
+using TownCrier.Application.Subscriptions;
+
+namespace TownCrier.Web.Tests.Subscriptions;
+
+/// <summary>
+/// Test double for <see cref="IAppleJwsVerifier"/> that maps each signed JWS
+/// string to a fixed decoded payload. The App Store webhook verifies two
+/// nested JWS payloads (outer notification, inner transaction), so the stub
+/// must distinguish them by input. Configure with <see cref="WithPayload"/>,
+/// or use <see cref="ThatRejects"/> to simulate an invalid signature.
+/// </summary>
+internal sealed class MappingAppleJwsVerifier : IAppleJwsVerifier
+{
+    private readonly Dictionary<string, string> payloads = [];
+    private readonly bool rejects;
+
+    private MappingAppleJwsVerifier(bool rejects) => this.rejects = rejects;
+
+    public static MappingAppleJwsVerifier Create() => new(rejects: false);
+
+    public static MappingAppleJwsVerifier ThatRejects() => new(rejects: true);
+
+    public MappingAppleJwsVerifier WithPayload(string signedJws, string decodedJson)
+    {
+        this.payloads[signedJws] = decodedJson;
+        return this;
+    }
+
+    public Task<string> VerifyAndDecodeAsync(string signedPayload, CancellationToken ct)
+    {
+        if (this.rejects)
+        {
+            throw new AppleJwsVerificationException("Invalid JWS signature.");
+        }
+
+        if (this.payloads.TryGetValue(signedPayload, out var json))
+        {
+            return Task.FromResult(json);
+        }
+
+        throw new AppleJwsVerificationException($"Unknown signed payload: '{signedPayload}'.");
+    }
+}


### PR DESCRIPTION
Subscription lifecycle webhook for the activation pipeline (epic tc-eryu, issue #401).

- New `POST /v1/webhooks/appstore` — accepts an App Store Server Notification v2 signed payload (anonymous; the signed JWS is the authentication).
- `NotificationDecoder` — decodes the ASSN v2 payload, verifying its JWS with the existing `AppleJwsVerifier`.
- `CosmosNotificationIdempotencyStore` — Cosmos-backed (`AppleNotifications` container); a duplicate `notificationUUID` delivery is a no-op.
- DI wiring for `HandleAppStoreNotificationCommandHandler` + the two adapters.

Lifecycle: `DID_RENEW` extends expiry; `EXPIRED`/`REFUND` revert to `Free`; `DID_FAIL_TO_RENEW` sets the grace period without changing tier — all covered by handler + endpoint tests.

`dotnet test`: all four unit projects pass; build + format clean.

Closes bead tc-eryu.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)