### PR TITLE
fix: rate limiter reads Cosmos tier, not the unmatched "paid" claim (tc-eryu.4)

### DIFF
--- a/api/src/town-crier.web/RateLimiting/RateLimitMiddleware.cs
+++ b/api/src/town-crier.web/RateLimiting/RateLimitMiddleware.cs
@@ -2,10 +2,16 @@ using System.Globalization;
 using System.Security.Claims;
 using Microsoft.Extensions.Options;
 using TownCrier.Application.RateLimiting;
+using TownCrier.Application.UserProfiles;
+using TownCrier.Domain.UserProfiles;
 
 namespace TownCrier.Web.RateLimiting;
 
-internal sealed class RateLimitMiddleware(RequestDelegate next, IRateLimitStore store, IOptions<RateLimitOptions> options)
+internal sealed class RateLimitMiddleware(
+    RequestDelegate next,
+    IRateLimitStore store,
+    IUserProfileRepository userProfileRepository,
+    IOptions<RateLimitOptions> options)
 {
     public async Task InvokeAsync(HttpContext context)
     {
@@ -20,10 +26,15 @@ internal sealed class RateLimitMiddleware(RequestDelegate next, IRateLimitStore 
         }
 
         var config = options.Value;
-        var tier = context.User.FindFirst("subscription_tier")?.Value;
-        var limit = string.Equals(tier, "paid", StringComparison.OrdinalIgnoreCase)
-            ? config.PaidTierLimit
-            : config.FreeTierLimit;
+
+        // ADR 0010: Cosmos DB is the single source of truth for entitlements.
+        // The subscription_tier JWT claim is at most a non-authoritative cache, so
+        // the paid rate limit is driven by the tier stored on the Cosmos UserProfile.
+        var profile = await userProfileRepository
+            .GetByUserIdAsync(userId, context.RequestAborted)
+            .ConfigureAwait(false);
+        var isPaid = profile is not null && profile.Tier != SubscriptionTier.Free;
+        var limit = isPaid ? config.PaidTierLimit : config.FreeTierLimit;
 
         var result = await store.CheckAndIncrementAsync(userId, limit, config.Window, context.RequestAborted).ConfigureAwait(false);
 

--- a/api/tests/town-crier.web.tests/RateLimiting/RateLimitMiddlewareTests.cs
+++ b/api/tests/town-crier.web.tests/RateLimiting/RateLimitMiddlewareTests.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using TownCrier.Application.RateLimiting;
+using TownCrier.Application.UserProfiles;
+using TownCrier.Domain.UserProfiles;
 using TownCrier.Web.Tests.Auth;
 
 namespace TownCrier.Web.Tests.RateLimiting;
@@ -70,13 +72,16 @@ public sealed class RateLimitMiddlewareTests
     }
 
     [Test]
-    public async Task Should_AllowMoreRequests_When_PaidTier()
+    [Arguments(SubscriptionTier.Personal)]
+    [Arguments(SubscriptionTier.Pro)]
+    public async Task Should_ApplyPaidLimit_When_CosmosTierIsPaid(SubscriptionTier tier)
     {
-        // Arrange
+        // Arrange — the user's authoritative tier lives in the Cosmos UserProfile,
+        // not the JWT claim (ADR 0010: Cosmos is the single source of truth).
+        const string userId = "auth0|paid-user";
         await using var factory = CreateFactoryWithRateLimiting();
-        var token = TestJwtToken.Generate(claims: [new("subscription_tier", "paid")]);
-        using var client = factory.CreateClient();
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        await SeedProfileAsync(factory, userId, tier);
+        using var client = CreateClientForUser(factory, userId);
 
         // Make more requests than the free tier limit
         HttpResponseMessage? lastResponse = null;
@@ -86,9 +91,32 @@ public sealed class RateLimitMiddlewareTests
             lastResponse = await client.GetAsync(new Uri("/api/me", UriKind.Relative));
         }
 
-        // Assert — paid tier has a higher limit, so this should still be allowed
+        // Assert — a paid Cosmos tier gets the higher limit, so this is still allowed
         await Assert.That(lastResponse!.StatusCode).IsEqualTo(HttpStatusCode.OK);
         lastResponse.Dispose();
+    }
+
+    [Test]
+    public async Task Should_ApplyFreeLimit_When_CosmosTierIsFree()
+    {
+        // Arrange
+        const string userId = "auth0|free-user";
+        await using var factory = CreateFactoryWithRateLimiting();
+        await SeedProfileAsync(factory, userId, SubscriptionTier.Free);
+        using var client = CreateClientForUser(factory, userId);
+
+        // Exhaust the free tier limit
+        for (var i = 0; i < TestFreeLimit; i++)
+        {
+            var warmup = await client.GetAsync(new Uri("/api/me", UriKind.Relative));
+            warmup.Dispose();
+        }
+
+        // Act — this request should be over the free limit
+        using var response = await client.GetAsync(new Uri("/api/me", UriKind.Relative));
+
+        // Assert — a Free Cosmos tier only gets the free limit
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.TooManyRequests);
     }
 
     [Test]
@@ -122,9 +150,27 @@ public sealed class RateLimitMiddlewareTests
 
     private static HttpClient CreateAuthenticatedClient(WebApplicationFactory<Program> factory)
     {
+        return CreateClientForUser(factory, "auth0|test-user-123");
+    }
+
+    private static HttpClient CreateClientForUser(WebApplicationFactory<Program> factory, string userId)
+    {
         var client = factory.CreateClient();
-        var token = TestJwtToken.Generate();
+        var token = TestJwtToken.Generate(userId);
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         return client;
+    }
+
+    private static async Task SeedProfileAsync(
+        WebApplicationFactory<Program> factory, string userId, SubscriptionTier tier)
+    {
+        var repository = factory.Services.GetRequiredService<IUserProfileRepository>();
+        var profile = UserProfile.Register(userId);
+        if (tier != SubscriptionTier.Free)
+        {
+            profile.ActivateSubscription(tier, DateTimeOffset.UtcNow.AddDays(30));
+        }
+
+        await repository.SaveAsync(profile, CancellationToken.None);
     }
 }


### PR DESCRIPTION
Tier-enforcement consistency for the subscriptions launch (epic tc-eryu, issue #401).

`RateLimitMiddleware` checked the JWT `subscription_tier` claim against the literal `"paid"`, but `SubscriptionTier` serialises as `Personal`/`Pro`/`Free` — so no user was ever rate-limited as paid. The middleware now loads `UserProfile` from Cosmos (the single source of truth per ADR 0010) and applies the paid limit when the tier is `Personal` or `Pro`.

`dotnet test`: domain/application/web/infrastructure all pass; build + format clean.

Closes bead tc-eryu.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)