### PR TITLE
feat(web): disclose operating company in footer (tc-eupw)

### DIFF
--- a/web/src/components/Footer/Footer.module.css
+++ b/web/src/components/Footer/Footer.module.css
@@ -75,6 +75,14 @@
   text-decoration: underline;
 }
 
+/* ---------- Statutory company disclosure (Companies Act 2006) ---------- */
+.companyInfo {
+  margin-top: var(--tc-space-md);
+  text-align: center;
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+}
+
 /* ---------- Responsive: side-by-side on tablet+ ---------- */
 @media (min-width: 640px) {
   .bottom {

--- a/web/src/components/Footer/Footer.tsx
+++ b/web/src/components/Footer/Footer.tsx
@@ -29,6 +29,10 @@ export function Footer() {
             <a href="/legal/terms" className={styles.legalLink}>Terms of Service</a>
           </nav>
         </div>
+
+        <p className={styles.companyInfo}>
+          Ivo and the Bea Ltd · Registered in England &amp; Wales · Company No. 17222369
+        </p>
       </div>
     </footer>
   );

--- a/web/src/components/Footer/__tests__/Footer.test.tsx
+++ b/web/src/components/Footer/__tests__/Footer.test.tsx
@@ -35,6 +35,16 @@ describe('Footer', () => {
     expect(screen.getByText(new RegExp(`© ${currentYear} Town Crier`))).toBeInTheDocument();
   });
 
+  it('discloses the operating company, place of registration, and company number', () => {
+    render(<Footer />);
+
+    expect(
+      screen.getByText(
+        /Ivo and the Bea Ltd · Registered in England & Wales · Company No\. 17222369/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('renders a Privacy Policy link', () => {
     render(<Footer />);
 


### PR DESCRIPTION
## Summary
- Add statutory company disclosure to the site footer: **Ivo and the Bea Ltd · Registered in England & Wales · Company No. 17222369**
- Required of UK Ltd companies by the Companies Act 2006 (SI 2008/495 — company name, place of registration, and registered number must appear on the website)
- Also satisfies Apple's website-to-organization "association" check for the in-progress individual→organization membership migration (case 102899134911), verified against Companies House record [17222369](https://find-and-update.company-information.service.gov.uk/company/17222369)

## Implementation
- New centered `.companyInfo` line below the existing copyright/legal bar, using design tokens (`--tc-text-caption`, `--tc-text-secondary`)
- TDD: added a failing Footer test asserting the disclosure text, then implemented

## Test plan
- [x] `npx vitest run` — 643 passed (8 in Footer suite)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — succeeds
- [ ] Visual check of the rendered footer on the deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the footer with statutory company registration disclosure, adding company information and registration details in a dedicated, styled section positioned beneath existing legal links for improved transparency.

* **Tests**
  * Added test coverage to verify the new company information section properly renders all registration details, jurisdiction information, and company registration number throughout the footer layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->