### PR TITLE
Reduce cold start: InvariantGlobalization + warm prod replica for App Store review

### DIFF
--- a/api/src/town-crier.web/town-crier.web.csproj
+++ b/api/src/town-crier.web/town-crier.web.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishAot>true</PublishAot>
+    <InvariantGlobalization>true</InvariantGlobalization>
     <InterceptorsNamespaces>$(InterceptorsNamespaces);Microsoft.AspNetCore.Http.Generated</InterceptorsNamespaces>
   </PropertyGroup>
 

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -351,7 +351,10 @@ public static class EnvironmentStack
                 },
                 Scale = new ScaleArgs
                 {
-                    MinReplicas = 0,
+                    // Prod keeps one warm instance so first requests (e.g. App Store
+                    // review) skip the ~15s ACA scale-from-zero cold start. Dev stays
+                    // scale-to-zero to avoid idle cost.
+                    MinReplicas = env == "prod" ? 1 : 0,
                     MaxReplicas = 1,
                 },
             },


### PR DESCRIPTION
## Summary
Two cold-start changes ahead of App Store submission, where a reviewer's first request must not hit the ~15s ACA scale-from-zero.

- **`feat(api)` (tc-49wn):** Enable `InvariantGlobalization` on the AOT API. Drops the ICU dependency, shrinks the image, and removes culture-data load from startup. Audited safe — every date/int parse already passes `CultureInfo.InvariantCulture` explicitly; the only implicit parse is the Cosmos RU-charge telemetry `double`, which becomes *more* robust under invariant. Permanent UX win for all users.
- **`feat(infra)` (tc-fjt6):** `MinReplicas = env == "prod" ? 1 : 0` on the API container app. Prod keeps one warm instance (kills the ~15s cold start for reviewers); dev stays scale-to-zero to avoid idle cost.

## Context
Image-base tuning was investigated and ruled out — the runtime base (`runtime-deps:10.0-alpine`) is already minimal for a self-contained AOT app, and the 15s is dominated by ACA node provisioning, which only a warm replica addresses.

## Follow-up
Revert prod `MinReplicas` to `0` after App Store approval unless paying-user revenue justifies the ~£2.40/mo (standing cost decision).

## Test plan
- [x] `dotnet build` — infra project (exit 0)
- [x] `dotnet build` — API web project (exit 0)
- [ ] CI green
- [ ] Verify prod revision shows min 1 replica after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved application responsiveness in production by keeping instances warm, reducing startup delays during scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->