### PR TITLE
fix: batch N+1 Cosmos query in GetApplicationsByZoneQueryHandler (tc-1wkp)

### DIFF
--- a/api/src/town-crier.application/Notifications/INotificationRepository.cs
+++ b/api/src/town-crier.application/Notifications/INotificationRepository.cs
@@ -37,29 +37,12 @@ public interface INotificationRepository
     Task<int> GetUnreadCountAsync(string userId, DateTimeOffset lastReadAt, CancellationToken ct);
 
     /// <summary>
-    /// Returns the most-recent notification for the given user and application
-    /// whose <c>CreatedAt</c> is strictly greater than <paramref name="lastReadAt"/> —
-    /// i.e. the latest unread event under the watermark model. Returns <c>null</c>
-    /// when no qualifying notification exists. Drives the <c>latestUnreadEvent</c>
-    /// field on each row of the applications-by-zone result.
-    /// </summary>
-    /// <param name="userId">The Auth0 sub for the owning user.</param>
-    /// <param name="applicationUid">The PlanIt-assigned application uid.</param>
-    /// <param name="lastReadAt">The user's notification-state watermark. Boundary is exclusive.</param>
-    /// <param name="ct">Cancellation token.</param>
-    /// <returns>The most-recent unread notification, or <c>null</c> if none.</returns>
-    Task<Notification?> GetLatestUnreadByApplicationAsync(
-        string userId,
-        string applicationUid,
-        DateTimeOffset lastReadAt,
-        CancellationToken ct);
-
-    /// <summary>
-    /// Batched form of <see cref="GetLatestUnreadByApplicationAsync"/>: for a set of
-    /// application uids, returns the most-recent unread notification per uid in a
-    /// single round-trip. A uid with no qualifying notification is absent from the
-    /// result map. Collapses the per-application N+1 loop on the applications-by-zone
-    /// path into O(1) Cosmos queries (bd tc-1wkp).
+    /// For a set of application uids, returns the most-recent unread notification per
+    /// uid — i.e. the latest event under the watermark model whose <c>CreatedAt</c> is
+    /// strictly greater than <paramref name="lastReadAt"/> — in a single round-trip. A
+    /// uid with no qualifying notification is absent from the result map. Drives the
+    /// <c>latestUnreadEvent</c> field on each row of the applications-by-zone result;
+    /// collapses the per-application N+1 loop into O(1) Cosmos queries (bd tc-1wkp).
     /// </summary>
     /// <param name="userId">The Auth0 sub for the owning user (partition key).</param>
     /// <param name="applicationUids">The PlanIt application uids to look up.</param>

--- a/api/src/town-crier.application/Notifications/INotificationRepository.cs
+++ b/api/src/town-crier.application/Notifications/INotificationRepository.cs
@@ -54,6 +54,24 @@ public interface INotificationRepository
         DateTimeOffset lastReadAt,
         CancellationToken ct);
 
+    /// <summary>
+    /// Batched form of <see cref="GetLatestUnreadByApplicationAsync"/>: for a set of
+    /// application uids, returns the most-recent unread notification per uid in a
+    /// single round-trip. A uid with no qualifying notification is absent from the
+    /// result map. Collapses the per-application N+1 loop on the applications-by-zone
+    /// path into O(1) Cosmos queries (bd tc-1wkp).
+    /// </summary>
+    /// <param name="userId">The Auth0 sub for the owning user (partition key).</param>
+    /// <param name="applicationUids">The PlanIt application uids to look up.</param>
+    /// <param name="lastReadAt">The user's notification-state watermark. Boundary is exclusive.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>A map from application uid to its most-recent unread notification.</returns>
+    Task<IReadOnlyDictionary<string, Notification>> GetLatestUnreadByApplicationsAsync(
+        string userId,
+        IReadOnlyCollection<string> applicationUids,
+        DateTimeOffset lastReadAt,
+        CancellationToken ct);
+
     Task<IReadOnlyList<Notification>> GetByUserSinceAsync(string userId, DateTimeOffset since, CancellationToken ct);
 
     Task<IReadOnlyList<Notification>> GetUnsentEmailsByUserAsync(string userId, CancellationToken ct);

--- a/api/src/town-crier.application/WatchZones/GetApplicationsByZoneQueryHandler.cs
+++ b/api/src/town-crier.application/WatchZones/GetApplicationsByZoneQueryHandler.cs
@@ -2,11 +2,15 @@ using System.Globalization;
 using TownCrier.Application.Notifications;
 using TownCrier.Application.NotificationState;
 using TownCrier.Application.PlanningApplications;
+using TownCrier.Domain.Notifications;
 
 namespace TownCrier.Application.WatchZones;
 
 public sealed class GetApplicationsByZoneQueryHandler
 {
+    private static readonly IReadOnlyDictionary<string, Notification> EmptyLatestUnread =
+        new Dictionary<string, Notification>(StringComparer.Ordinal);
+
     private readonly IWatchZoneRepository watchZoneRepository;
     private readonly IPlanningApplicationRepository applicationRepository;
     private readonly INotificationRepository notificationRepository;
@@ -57,24 +61,32 @@ public sealed class GetApplicationsByZoneQueryHandler
         var state = await this.notificationStateRepository
             .GetByUserIdAsync(query.UserId, ct).ConfigureAwait(false);
 
+        // Batch the latest-unread lookup into a single Cosmos round-trip for every
+        // application in the zone, rather than one query per application. With ~237
+        // apps per zone the former N+1 loop dominated request latency (~6s); the
+        // batched query collapses it to O(1) (bd tc-1wkp). When the user has no
+        // watermark we can't classify anything as unread, so we skip the lookup.
+        IReadOnlyDictionary<string, Notification> latestUnreadByUid =
+            EmptyLatestUnread;
+        if (state is not null)
+        {
+            var uids = applications.Select(a => a.Uid).ToArray();
+            latestUnreadByUid = await this.notificationRepository
+                .GetLatestUnreadByApplicationsAsync(
+                    query.UserId, uids, state.LastReadAt, ct)
+                .ConfigureAwait(false);
+        }
+
         var results = new List<PlanningApplicationResult>(applications.Count);
         foreach (var application in applications)
         {
             LatestUnreadEvent? latestUnread = null;
-            if (state is not null)
+            if (latestUnreadByUid.TryGetValue(application.Uid, out var notification))
             {
-                var notification = await this.notificationRepository
-                    .GetLatestUnreadByApplicationAsync(
-                        query.UserId, application.Uid, state.LastReadAt, ct)
-                    .ConfigureAwait(false);
-
-                if (notification is not null)
-                {
-                    latestUnread = new LatestUnreadEvent(
-                        notification.EventType,
-                        notification.Decision,
-                        notification.CreatedAt);
-                }
+                latestUnread = new LatestUnreadEvent(
+                    notification.EventType,
+                    notification.Decision,
+                    notification.CreatedAt);
             }
 
             var row = GetApplicationByUidQueryHandler.ToResult(application) with

--- a/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosJsonSerializerContext.cs
@@ -41,4 +41,5 @@ namespace TownCrier.Infrastructure.Cosmos;
 [JsonSerializable(typeof(PollingLeaseDocument))]
 [JsonSerializable(typeof(CosmosQueryBody))]
 [JsonSerializable(typeof(string))]
+[JsonSerializable(typeof(string[]))]
 internal sealed partial class CosmosJsonSerializerContext : JsonSerializerContext;

--- a/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
@@ -6,6 +6,9 @@ namespace TownCrier.Infrastructure.Notifications;
 
 public sealed class CosmosNotificationRepository : INotificationRepository
 {
+    private static readonly IReadOnlyDictionary<string, Notification> EmptyMap =
+        new Dictionary<string, Notification>(StringComparer.Ordinal);
+
     private readonly ICosmosRestClient client;
 
     public CosmosNotificationRepository(ICosmosRestClient client)
@@ -94,6 +97,53 @@ public sealed class CosmosNotificationRepository : INotificationRepository
             ct).ConfigureAwait(false);
 
         return documents.Count > 0 ? documents[0].ToDomain() : null;
+    }
+
+    public async Task<IReadOnlyDictionary<string, Notification>> GetLatestUnreadByApplicationsAsync(
+        string userId,
+        IReadOnlyCollection<string> applicationUids,
+        DateTimeOffset lastReadAt,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(applicationUids);
+
+        if (applicationUids.Count == 0)
+        {
+            return EmptyMap;
+        }
+
+        // Single round-trip for every uid in the zone. ARRAY_CONTAINS binds the uid
+        // set as one parameter; partitioned by userId so this stays single-partition.
+        // We fetch all unread rows for the set, then reduce to the latest per uid in
+        // memory — collapsing the former per-application N+1 loop (bd tc-1wkp).
+        var uids = applicationUids as string[] ?? [.. applicationUids];
+
+        const string sql = "SELECT * FROM c "
+            + "WHERE c.userId = @userId AND ARRAY_CONTAINS(@uids, c.applicationUid) "
+            + "AND c.createdAt > @lastReadAt "
+            + "ORDER BY c.createdAt DESC";
+
+        var documents = await this.client.QueryAsync(
+            CosmosContainerNames.Notifications,
+            sql,
+            [
+                new QueryParameter("@userId", userId),
+                new QueryParameter("@uids", uids),
+                new QueryParameter("@lastReadAt", lastReadAt),
+            ],
+            userId,
+            CosmosJsonSerializerContext.Default.NotificationDocument,
+            ct).ConfigureAwait(false);
+
+        // Rows arrive newest-first, so the first row seen per uid is the latest.
+        var map = new Dictionary<string, Notification>(StringComparer.Ordinal);
+        foreach (var document in documents)
+        {
+            var notification = document.ToDomain();
+            map.TryAdd(notification.ApplicationUid, notification);
+        }
+
+        return map;
     }
 
     public async Task<IReadOnlyList<Notification>> GetByUserSinceAsync(

--- a/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/CosmosNotificationRepository.cs
@@ -71,34 +71,6 @@ public sealed class CosmosNotificationRepository : INotificationRepository
             ct).ConfigureAwait(false);
     }
 
-    public async Task<Notification?> GetLatestUnreadByApplicationAsync(
-        string userId,
-        string applicationUid,
-        DateTimeOffset lastReadAt,
-        CancellationToken ct)
-    {
-        // TOP 1 by createdAt DESC, strictly after the watermark — the most-recent
-        // unread event for (userId, applicationUid). Container is partitioned by
-        // userId so this stays single-partition.
-        const string sql = "SELECT TOP 1 * FROM c "
-            + "WHERE c.userId = @userId AND c.applicationUid = @appUid AND c.createdAt > @lastReadAt "
-            + "ORDER BY c.createdAt DESC";
-
-        var documents = await this.client.QueryAsync(
-            CosmosContainerNames.Notifications,
-            sql,
-            [
-                new QueryParameter("@userId", userId),
-                new QueryParameter("@appUid", applicationUid),
-                new QueryParameter("@lastReadAt", lastReadAt),
-            ],
-            userId,
-            CosmosJsonSerializerContext.Default.NotificationDocument,
-            ct).ConfigureAwait(false);
-
-        return documents.Count > 0 ? documents[0].ToDomain() : null;
-    }
-
     public async Task<IReadOnlyDictionary<string, Notification>> GetLatestUnreadByApplicationsAsync(
         string userId,
         IReadOnlyCollection<string> applicationUids,

--- a/api/src/town-crier.infrastructure/Notifications/InMemoryNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/InMemoryNotificationRepository.cs
@@ -41,22 +41,6 @@ public sealed class InMemoryNotificationRepository : INotificationRepository
         return Task.FromResult(count);
     }
 
-    public Task<Notification?> GetLatestUnreadByApplicationAsync(
-        string userId,
-        string applicationUid,
-        DateTimeOffset lastReadAt,
-        CancellationToken ct)
-    {
-        // Strictly greater than the watermark, ordered by CreatedAt desc.
-        var latest = this.store
-            .Where(n => n.UserId == userId
-                && n.ApplicationUid == applicationUid
-                && n.CreatedAt > lastReadAt)
-            .OrderByDescending(n => n.CreatedAt)
-            .FirstOrDefault();
-        return Task.FromResult(latest);
-    }
-
     public Task<IReadOnlyDictionary<string, Notification>> GetLatestUnreadByApplicationsAsync(
         string userId,
         IReadOnlyCollection<string> applicationUids,

--- a/api/src/town-crier.infrastructure/Notifications/InMemoryNotificationRepository.cs
+++ b/api/src/town-crier.infrastructure/Notifications/InMemoryNotificationRepository.cs
@@ -57,6 +57,27 @@ public sealed class InMemoryNotificationRepository : INotificationRepository
         return Task.FromResult(latest);
     }
 
+    public Task<IReadOnlyDictionary<string, Notification>> GetLatestUnreadByApplicationsAsync(
+        string userId,
+        IReadOnlyCollection<string> applicationUids,
+        DateTimeOffset lastReadAt,
+        CancellationToken ct)
+    {
+        var uids = applicationUids as ISet<string> ?? new HashSet<string>(applicationUids, StringComparer.Ordinal);
+
+        var map = this.store
+            .Where(n => n.UserId == userId
+                && n.CreatedAt > lastReadAt
+                && uids.Contains(n.ApplicationUid))
+            .GroupBy(n => n.ApplicationUid, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderByDescending(n => n.CreatedAt).First(),
+                StringComparer.Ordinal);
+
+        return Task.FromResult<IReadOnlyDictionary<string, Notification>>(map);
+    }
+
     public Task<IReadOnlyList<Notification>> GetByUserSinceAsync(
         string userId, DateTimeOffset since, CancellationToken ct)
     {

--- a/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepository.cs
+++ b/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepository.cs
@@ -9,6 +9,13 @@ internal sealed class FakeNotificationRepository : INotificationRepository
 
     public IReadOnlyList<Notification> All => this.store;
 
+    /// <summary>
+    /// Number of times the batched latest-unread lookup has been invoked. The
+    /// applications-by-zone handler must call it exactly once per request regardless
+    /// of how many applications are in scope (bd tc-1wkp).
+    /// </summary>
+    public int GetLatestUnreadByApplicationsCallCount { get; private set; }
+
     public void Seed(Notification notification)
     {
         this.store.Add(notification);
@@ -62,6 +69,29 @@ internal sealed class FakeNotificationRepository : INotificationRepository
             .OrderByDescending(n => n.CreatedAt)
             .FirstOrDefault();
         return Task.FromResult(latest);
+    }
+
+    public Task<IReadOnlyDictionary<string, Notification>> GetLatestUnreadByApplicationsAsync(
+        string userId,
+        IReadOnlyCollection<string> applicationUids,
+        DateTimeOffset lastReadAt,
+        CancellationToken ct)
+    {
+        this.GetLatestUnreadByApplicationsCallCount++;
+
+        var uids = new HashSet<string>(applicationUids, StringComparer.Ordinal);
+
+        var map = this.store
+            .Where(n => n.UserId == userId
+                && n.CreatedAt > lastReadAt
+                && uids.Contains(n.ApplicationUid))
+            .GroupBy(n => n.ApplicationUid, StringComparer.Ordinal)
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderByDescending(n => n.CreatedAt).First(),
+                StringComparer.Ordinal);
+
+        return Task.FromResult<IReadOnlyDictionary<string, Notification>>(map);
     }
 
     public Task<IReadOnlyList<Notification>> GetByUserSinceAsync(

--- a/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepository.cs
+++ b/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepository.cs
@@ -10,7 +10,7 @@ internal sealed class FakeNotificationRepository : INotificationRepository
     public IReadOnlyList<Notification> All => this.store;
 
     /// <summary>
-    /// Number of times the batched latest-unread lookup has been invoked. The
+    /// Gets number of times the batched latest-unread lookup has been invoked. The
     /// applications-by-zone handler must call it exactly once per request regardless
     /// of how many applications are in scope (bd tc-1wkp).
     /// </summary>

--- a/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepository.cs
+++ b/api/tests/town-crier.application.tests/Notifications/FakeNotificationRepository.cs
@@ -54,23 +54,6 @@ internal sealed class FakeNotificationRepository : INotificationRepository
         return Task.FromResult(count);
     }
 
-    public Task<Notification?> GetLatestUnreadByApplicationAsync(
-        string userId,
-        string applicationUid,
-        DateTimeOffset lastReadAt,
-        CancellationToken ct)
-    {
-        // Strictly greater than the watermark; pick the most-recent CreatedAt so
-        // the row's status pill reflects the latest event for this application.
-        var latest = this.store
-            .Where(n => n.UserId == userId
-                && n.ApplicationUid == applicationUid
-                && n.CreatedAt > lastReadAt)
-            .OrderByDescending(n => n.CreatedAt)
-            .FirstOrDefault();
-        return Task.FromResult(latest);
-    }
-
     public Task<IReadOnlyDictionary<string, Notification>> GetLatestUnreadByApplicationsAsync(
         string userId,
         IReadOnlyCollection<string> applicationUids,

--- a/api/tests/town-crier.application.tests/WatchZones/GetApplicationsByZoneQueryHandlerTests.cs
+++ b/api/tests/town-crier.application.tests/WatchZones/GetApplicationsByZoneQueryHandlerTests.cs
@@ -288,6 +288,80 @@ public sealed class GetApplicationsByZoneQueryHandlerTests
         await Assert.That(result[0].LatestUnreadEvent!.CreatedAt).IsEqualTo(laterCreated);
     }
 
+    [Test]
+    public async Task Should_IssueSingleNotificationLookup_When_ManyApplicationsInZone()
+    {
+        // Arrange — many applications in the zone. The handler must batch the
+        // latest-unread lookup into a single repository call regardless of count,
+        // rather than the former per-application N+1 loop (bd tc-1wkp).
+        var watermark = new DateTimeOffset(2026, 5, 1, 12, 0, 0, TimeSpan.Zero);
+
+        var notificationRepo = new FakeNotificationRepository();
+        var stateRepo = new FakeNotificationStateRepository();
+        stateRepo.Seed(NotificationStateAggregate.Create("user-1", watermark));
+
+        var watchZoneRepo = new FakeWatchZoneRepository();
+        watchZoneRepo.Add(BuildZone());
+
+        var appRepo = new FakePlanningApplicationRepository();
+        for (var i = 0; i < 50; i++)
+        {
+            await appRepo.UpsertAsync(
+                new PlanningApplicationBuilder()
+                    .WithName($"app-{i}")
+                    .WithUid($"uid-{i}")
+                    .WithAreaId(42)
+                    .WithCoordinates(51.5380, -0.1410)
+                    .Build(),
+                CancellationToken.None);
+        }
+
+        var handler = CreateHandler(watchZoneRepo, appRepo, notificationRepo, stateRepo);
+
+        // Act
+        var result = await handler.HandleAsync(
+            new GetApplicationsByZoneQuery("user-1", "zone-1"), CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result!.Count).IsEqualTo(50);
+        await Assert.That(notificationRepo.GetLatestUnreadByApplicationsCallCount).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Should_NotLookUpNotifications_When_UserHasNoState()
+    {
+        // Arrange — first-touch user, no watermark. With no state we can't classify
+        // anything as unread, so the handler must skip the notification lookup
+        // entirely rather than issue a batched query for nothing.
+        var notificationRepo = new FakeNotificationRepository();
+        var stateRepo = new FakeNotificationStateRepository();
+
+        var watchZoneRepo = new FakeWatchZoneRepository();
+        watchZoneRepo.Add(BuildZone());
+
+        var appRepo = new FakePlanningApplicationRepository();
+        await appRepo.UpsertAsync(
+            new PlanningApplicationBuilder()
+                .WithName("nearby-app")
+                .WithUid("uid-nearby")
+                .WithAreaId(42)
+                .WithCoordinates(51.5380, -0.1410)
+                .Build(),
+            CancellationToken.None);
+
+        var handler = CreateHandler(watchZoneRepo, appRepo, notificationRepo, stateRepo);
+
+        // Act
+        var result = await handler.HandleAsync(
+            new GetApplicationsByZoneQuery("user-1", "zone-1"), CancellationToken.None);
+
+        // Assert
+        await Assert.That(result).IsNotNull();
+        await Assert.That(result![0].LatestUnreadEvent).IsNull();
+        await Assert.That(notificationRepo.GetLatestUnreadByApplicationsCallCount).IsEqualTo(0);
+    }
+
     private static (GetApplicationsByZoneQueryHandler Handler,
         FakeNotificationRepository NotificationRepo,
         FakeNotificationStateRepository StateRepo) CreateBuilt()

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosRestClientTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/CosmosRestClientTests.cs
@@ -229,6 +229,29 @@ public sealed class CosmosRestClientTests
     }
 
     [Test]
+    public async Task Should_SerializeArrayParameterAsJsonArray_When_QueryUsesArrayContains()
+    {
+        // The batched latest-unread lookup (bd tc-1wkp) binds a string[] of uids as a
+        // single ARRAY_CONTAINS parameter. QueryParameter.Value is object-typed, so
+        // under Native AOT the array must round-trip through the source-gen context
+        // (string[] is registered) — guard that it lands as a JSON array, not a
+        // ToString() or a throw.
+        var (client, handler) = CreateClient();
+        handler.EnqueueResponse(HttpStatusCode.OK, """{"Documents":[],"_count":0}""");
+
+        var uids = new[] { "uid-1", "uid-2" };
+        await client.QueryAsync(
+            "Notifications",
+            "SELECT * FROM c WHERE ARRAY_CONTAINS(@uids, c.applicationUid)",
+            [new QueryParameter("@uids", uids)],
+            "pk1",
+            TestSerializerContext.Default.TestDocument,
+            CancellationToken.None);
+
+        await Assert.That(handler.SentBodies[0]).Contains("\"value\":[\"uid-1\",\"uid-2\"]");
+    }
+
+    [Test]
     public async Task Should_ReturnFirstValue_When_ScalarQuery()
     {
         var (client, handler) = CreateClient();

--- a/api/tests/town-crier.infrastructure.tests/Cosmos/StubHttpHandler.cs
+++ b/api/tests/town-crier.infrastructure.tests/Cosmos/StubHttpHandler.cs
@@ -10,6 +10,10 @@ internal sealed class StubHttpHandler : HttpMessageHandler
 
     public List<HttpRequestMessage> SentRequests { get; } = [];
 
+    // Request content is captured at send-time because the caller disposes the
+    // request (and its StringContent) once SendAsync returns.
+    public List<string?> SentBodies { get; } = [];
+
     public void EnqueueResponse(
         HttpStatusCode statusCode,
         string? content = null,
@@ -32,14 +36,18 @@ internal sealed class StubHttpHandler : HttpMessageHandler
         this.responses.Enqueue(response);
     }
 
-    protected override Task<HttpResponseMessage> SendAsync(
+    protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
         this.SentRequests.Add(request);
-        return Task.FromResult(this.responses.Count > 0
+        this.SentBodies.Add(request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false));
+
+        return this.responses.Count > 0
             ? this.responses.Dequeue()
-            : new HttpResponseMessage(HttpStatusCode.InternalServerError));
+            : new HttpResponseMessage(HttpStatusCode.InternalServerError);
     }
 }
 #pragma warning restore CA2000


### PR DESCRIPTION
## Changes
Collapses the applications-by-zone notification lookup from ~237 serialized Cosmos round-trips into a single batched query (validated from prod App Insights at ~6s/request).

- `red`: handler issues a single batched notification lookup for N applications
- `green`: batch latest-unread lookup into one query, drop per-app N+1 loop
- `refactor`: assert `string[]` query param serializes as a JSON array under source-gen (Native AOT requirement)
- `chore`: pre-flight fixes

**Root cause:** `GetApplicationsByZoneQueryHandler` looped over every nearby application and awaited a separate `GetLatestUnreadByApplicationAsync` per app. Replaced with one query: `WHERE c.userId = @userId AND ARRAY_CONTAINS(@uids, c.applicationUid) AND c.createdAt > @lastReadAt ORDER BY c.createdAt DESC`, single-partition by `userId`, reduced to latest-per-uid in memory. Expected ~6s → <100ms.

**AOT note:** registered `string[]` in `CosmosJsonSerializerContext` for the array query parameter, with a test proving it round-trips.

Closes tc-1wkp.

---
*Auto-shipped via ship skill*