### PR TITLE
Pin Azure credentials to cosmos-data managed identity (tc-6ig5)

### DIFF
--- a/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
+++ b/api/src/town-crier.infrastructure/Cosmos/CosmosServiceExtensions.cs
@@ -1,6 +1,6 @@
-using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using TownCrier.Infrastructure.Identity;
 
 namespace TownCrier.Infrastructure.Cosmos;
 
@@ -35,8 +35,14 @@ public static class CosmosServiceExtensions
 
         services.AddSingleton(options);
 
+        // Pin to the cosmos-data user-assigned identity (AZURE_CLIENT_ID env var)
+        // rather than DefaultAzureCredential, which walks the credential chain and
+        // costs ~3s on the first token fetch after a deploy/restart (tc-6ig5).
+        var managedIdentityClientId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
+
 #pragma warning disable CA2000 // DI container owns the lifetime and will dispose on shutdown
-        services.AddSingleton(new CosmosAuthProvider(new DefaultAzureCredential()));
+        services.AddSingleton(new CosmosAuthProvider(
+            ManagedIdentityCredentialFactory.Create(managedIdentityClientId)));
 #pragma warning restore CA2000
 
         services.AddTransient<CosmosThrottleRetryHandler>(_ => new CosmosThrottleRetryHandler(

--- a/api/src/town-crier.infrastructure/Identity/ManagedIdentityCredentialFactory.cs
+++ b/api/src/town-crier.infrastructure/Identity/ManagedIdentityCredentialFactory.cs
@@ -1,0 +1,31 @@
+using Azure.Core;
+using Azure.Identity;
+
+namespace TownCrier.Infrastructure.Identity;
+
+/// <summary>
+/// Builds the <see cref="TokenCredential"/> used for all Azure data-plane and
+/// management-plane calls (Cosmos, Service Bus, ARM).
+/// </summary>
+/// <remarks>
+/// The container runs with two user-assigned managed identities
+/// (id-town-crier-acr-pull and id-town-crier-cosmos-data). Using
+/// <c>DefaultAzureCredential</c> walks the full credential chain
+/// (Environment → WorkloadIdentity → ManagedIdentity), probing and failing the
+/// first links — absent in Azure Container Apps — before reaching IMDS, costing
+/// ~3s on the first token fetch after a deploy or restart.
+///
+/// <see cref="ManagedIdentityCredential"/> pinned to the cosmos-data client ID
+/// (injected as the <c>AZURE_CLIENT_ID</c> env var) skips chain-probing, is
+/// deterministic about which identity to use, and is more AOT-trim-friendly.
+/// When no client ID is supplied (e.g. local development) it falls back to the
+/// system-assigned / default managed identity behaviour.
+/// </remarks>
+internal static class ManagedIdentityCredentialFactory
+{
+    public static TokenCredential Create(string? clientId) =>
+        new ManagedIdentityCredential(
+            string.IsNullOrWhiteSpace(clientId)
+                ? ManagedIdentityId.SystemAssigned
+                : ManagedIdentityId.FromUserAssignedClientId(clientId));
+}

--- a/api/src/town-crier.infrastructure/ServiceBus/ServiceBusServiceExtensions.cs
+++ b/api/src/town-crier.infrastructure/ServiceBus/ServiceBusServiceExtensions.cs
@@ -1,9 +1,9 @@
 using System.Net;
-using Azure.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http.Resilience;
 using Polly;
+using TownCrier.Infrastructure.Identity;
 
 namespace TownCrier.Infrastructure.ServiceBus;
 
@@ -45,13 +45,23 @@ public static class ServiceBusServiceExtensions
         services.AddSingleton(options);
         services.AddSingleton(managementOptions);
 
+        // Pin to the cosmos-data user-assigned identity (AZURE_CLIENT_ID env var)
+        // rather than DefaultAzureCredential, which walks the credential chain and
+        // costs ~3s on the first token fetch after a deploy/restart (tc-6ig5).
+        // DefaultAzureCredential already resolved this same identity via its
+        // ManagedIdentity step (it reads AZURE_CLIENT_ID), so RBAC is unchanged —
+        // the cosmos-data identity holds the SB data-plane and ARM read roles.
+        var managedIdentityClientId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID");
+
 #pragma warning disable CA2000 // DI container owns the lifetime and will dispose on shutdown
         services.AddKeyedSingleton(
             DataPlaneScope,
-            (_, _) => new AzureAdTokenProvider(new DefaultAzureCredential(), [DataPlaneScope]));
+            (_, _) => new AzureAdTokenProvider(
+                ManagedIdentityCredentialFactory.Create(managedIdentityClientId), [DataPlaneScope]));
         services.AddKeyedSingleton(
             ManagementScope,
-            (_, _) => new AzureAdTokenProvider(new DefaultAzureCredential(), [ManagementScope]));
+            (_, _) => new AzureAdTokenProvider(
+                ManagedIdentityCredentialFactory.Create(managedIdentityClientId), [ManagementScope]));
 #pragma warning restore CA2000
 
         // Accept both bare namespace ("sb-town-crier-prod") and full FQDN

--- a/api/tests/town-crier.infrastructure.tests/Identity/ManagedIdentityCredentialFactoryTests.cs
+++ b/api/tests/town-crier.infrastructure.tests/Identity/ManagedIdentityCredentialFactoryTests.cs
@@ -1,0 +1,31 @@
+using Azure.Identity;
+using TownCrier.Infrastructure.Identity;
+
+namespace TownCrier.Infrastructure.Tests.Identity;
+
+public sealed class ManagedIdentityCredentialFactoryTests
+{
+    [Test]
+    public async Task Should_ReturnManagedIdentityCredential_When_ClientIdProvided()
+    {
+        var credential = ManagedIdentityCredentialFactory.Create("11111111-2222-3333-4444-555555555555");
+
+        await Assert.That(credential).IsTypeOf<ManagedIdentityCredential>();
+    }
+
+    [Test]
+    public async Task Should_ReturnManagedIdentityCredential_When_ClientIdIsNull()
+    {
+        var credential = ManagedIdentityCredentialFactory.Create(null);
+
+        await Assert.That(credential).IsTypeOf<ManagedIdentityCredential>();
+    }
+
+    [Test]
+    public async Task Should_ReturnManagedIdentityCredential_When_ClientIdIsWhitespace()
+    {
+        var credential = ManagedIdentityCredentialFactory.Create("   ");
+
+        await Assert.That(credential).IsTypeOf<ManagedIdentityCredential>();
+    }
+}


### PR DESCRIPTION
## Changes
- Replace `new DefaultAzureCredential()` with a pinned `ManagedIdentityCredential` at all three infra sites (Cosmos, Service Bus data-plane, Service Bus management) to cut ~3s of cold-start MSI token-chain probing on fresh replicas.
- Introduce internal `ManagedIdentityCredentialFactory` using the modern `ManagedIdentityId.FromUserAssignedClientId(...)` API (Azure.Identity 1.19.0 deprecated the string constructor), reading the cosmos-data client ID from the `AZURE_CLIENT_ID` env var, with `SystemAssigned` fallback for local/test.
- Add unit tests for the factory's client-ID branching.

Closes tc-6ig5.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reduced authentication startup latency during deployment and service restarts.
  * Enhanced managed identity credential configuration and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->