### PR TITLE
refactor(ios): rename StoreKit product IDs to uk.towncrier.* (tc-tcaf)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/Subscriptions/StoreKitSubscriptionService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Subscriptions/StoreKitSubscriptionService.swift
@@ -6,13 +6,13 @@ import os
 /// StoreKit 2 adapter implementing the SubscriptionService domain protocol.
 public final class StoreKitSubscriptionService: SubscriptionService, @unchecked Sendable {
   private static let productIds = [
-    "uk.co.towncrier.personal.monthly",
-    "uk.co.towncrier.pro.monthly",
+    "uk.towncrier.personal.monthly",
+    "uk.towncrier.pro.monthly",
   ]
 
   private static let tierMapping: [String: SubscriptionTier] = [
-    "uk.co.towncrier.personal.monthly": .personal,
-    "uk.co.towncrier.pro.monthly": .pro,
+    "uk.towncrier.personal.monthly": .personal,
+    "uk.towncrier.pro.monthly": .pro,
   ]
 
   private static let logger = Logger(

--- a/mobile/ios/town-crier-app/TownCrier.storekit
+++ b/mobile/ios/town-crier-app/TownCrier.storekit
@@ -92,7 +92,7 @@
               "locale" : "en_GB"
             }
           ],
-          "productID" : "uk.co.towncrier.personal.monthly",
+          "productID" : "uk.towncrier.personal.monthly",
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Personal Monthly",
           "subscriptionGroupID" : "21001",
@@ -117,7 +117,7 @@
               "locale" : "en_GB"
             }
           ],
-          "productID" : "uk.co.towncrier.pro.monthly",
+          "productID" : "uk.towncrier.pro.monthly",
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Pro Monthly",
           "subscriptionGroupID" : "21001",

--- a/mobile/ios/town-crier-tests/Sources/Features/SubscriptionViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SubscriptionViewModelTests.swift
@@ -100,7 +100,7 @@ struct SubscriptionViewModelTests {
     let (sut, spy, _) = makeSUT()
     spy.purchaseResult = .success(.personalActive)
 
-    await sut.purchase(productId: "uk.co.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrier.personal.monthly")
 
     #expect(sut.currentEntitlement == .personalActive)
     #expect(!sut.isPurchasing)
@@ -111,16 +111,16 @@ struct SubscriptionViewModelTests {
     let (sut, spy, _) = makeSUT()
     spy.purchaseResult = .success(.personalActive)
 
-    await sut.purchase(productId: "uk.co.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrier.personal.monthly")
 
-    #expect(spy.purchaseCalls == ["uk.co.towncrier.personal.monthly"])
+    #expect(spy.purchaseCalls == ["uk.towncrier.personal.monthly"])
   }
 
   @Test func purchase_setsError_onFailure() async {
     let (sut, spy, _) = makeSUT()
     spy.purchaseResult = .failure(DomainError.purchaseFailed("payment declined"))
 
-    await sut.purchase(productId: "uk.co.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrier.personal.monthly")
 
     #expect(sut.currentEntitlement == nil)
     #expect(sut.error == .purchaseFailed("payment declined"))
@@ -130,7 +130,7 @@ struct SubscriptionViewModelTests {
     let (sut, spy, _) = makeSUT()
     spy.purchaseResult = .failure(DomainError.purchaseCancelled)
 
-    await sut.purchase(productId: "uk.co.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrier.personal.monthly")
 
     #expect(sut.error == nil)
     #expect(!sut.isPurchasing)
@@ -237,7 +237,7 @@ struct SubscriptionViewModelTests {
     subscriptionSpy.purchaseResult = .success(.personalActive)
     authSpy.refreshSessionResult = .success(.personal)
 
-    await sut.purchase(productId: "uk.co.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrier.personal.monthly")
 
     #expect(authSpy.refreshSessionCallCount == 1)
   }
@@ -246,7 +246,7 @@ struct SubscriptionViewModelTests {
     let (sut, subscriptionSpy, authSpy) = makeSUT()
     subscriptionSpy.purchaseResult = .failure(DomainError.purchaseFailed("declined"))
 
-    await sut.purchase(productId: "uk.co.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrier.personal.monthly")
 
     #expect(authSpy.refreshSessionCallCount == 0)
   }
@@ -255,7 +255,7 @@ struct SubscriptionViewModelTests {
     let (sut, subscriptionSpy, authSpy) = makeSUT()
     subscriptionSpy.purchaseResult = .failure(DomainError.purchaseCancelled)
 
-    await sut.purchase(productId: "uk.co.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrier.personal.monthly")
 
     #expect(authSpy.refreshSessionCallCount == 0)
   }
@@ -265,7 +265,7 @@ struct SubscriptionViewModelTests {
     subscriptionSpy.purchaseResult = .success(.personalActive)
     authSpy.refreshSessionResult = .failure(DomainError.sessionExpired)
 
-    await sut.purchase(productId: "uk.co.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrier.personal.monthly")
 
     #expect(sut.currentEntitlement == .personalActive)
     #expect(sut.error == nil)

--- a/mobile/ios/town-crier-tests/Sources/Fixtures/SubscriptionProduct+Fixtures.swift
+++ b/mobile/ios/town-crier-tests/Sources/Fixtures/SubscriptionProduct+Fixtures.swift
@@ -3,7 +3,7 @@ import TownCrierDomain
 
 extension SubscriptionProduct {
   static let personal = SubscriptionProduct(
-    id: "uk.co.towncrier.personal.monthly",
+    id: "uk.towncrier.personal.monthly",
     displayName: "Personal",
     displayPrice: "£1.99",
     tier: .personal,
@@ -12,7 +12,7 @@ extension SubscriptionProduct {
   )
 
   static let pro = SubscriptionProduct(
-    id: "uk.co.towncrier.pro.monthly",
+    id: "uk.towncrier.pro.monthly",
     displayName: "Pro",
     displayPrice: "£5.99",
     tier: .pro


### PR DESCRIPTION
## Summary
- Renames the two auto-renewing subscription product IDs to drop the `.co` segment, matching the `towncrierapp.uk` website convention.
- `uk.co.towncrier.personal.monthly` → `uk.towncrier.personal.monthly`
- `uk.co.towncrier.pro.monthly` → `uk.towncrier.pro.monthly`

Updates `TownCrier.storekit`, `StoreKitSubscriptionService` (productIds + tierMapping), and the test fixtures/references.

## Why
The App Store Connect products will be created with the new `uk.towncrier.*` IDs. The code must match byte-for-byte or `Product.products(for:)` returns empty and the paywall shows nothing.

## Out of scope
`MetricKitCrashReporter` logging subsystem still uses `uk.co.towncrier` — that's a logging identifier, not a product ID, and changing it could affect log/MetricKit filtering. Left untouched deliberately.

## Test plan
- [x] `swift build` clean
- [x] `swift test` — 1223 tests pass
- [x] `grep uk.co.towncrier` finds only the crash-reporter subsystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated subscription product identifiers to ensure in-app purchases are correctly matched and processed by the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->