### PR TITLE
fix(ios): clear 21 swiftlint --strict violations blocking CD TestFlight (tc-bl9c)

### DIFF
--- a/mobile/ios/.swiftlint.yml
+++ b/mobile/ios/.swiftlint.yml
@@ -22,7 +22,7 @@ disabled_rules:
   - let_var_whitespace
   - contrasted_opening_brace # Project uses K&R brace style
   - attributes # Inline attributes are the project convention
-  - cases_on_newline # Switch cases on same line is the convention
+  - switch_case_on_newline # Switch cases on same line is the convention
   - number_separator # Thousand separators not used in this project
   - vertical_whitespace_between_cases
   - sorted_enum_cases
@@ -51,7 +51,6 @@ disabled_rules:
   - discouraged_optional_collection
   - direct_return
   - file_name # Multi-type files are intentional
-  - opening_brace_spacing
   - implicitly_unwrapped_optional # Used in UIKit patterns and test fixtures
   - unused_parameter # SwiftUI lifecycle methods have required signatures
   - unused_closure_parameter

--- a/mobile/ios/packages/town-crier-data/Sources/API/Error+DomainMapping.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/Error+DomainMapping.swift
@@ -11,7 +11,7 @@ extension Error {
   func toDomainError() -> DomainError {
     if let apiError = self as? APIError {
       switch apiError {
-      case .serverError(let statusCode, let message):
+      case let .serverError(statusCode, message):
         return .serverError(statusCode: statusCode, message: message)
       case .decodingFailed(let detail):
         return .unexpected(detail)

--- a/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
@@ -178,8 +178,7 @@ public final class URLSessionAPIClient: Sendable {
 
   private func mapForbidden(data: Data) throws {
     if let body = try? decoder.decode(InsufficientEntitlementBody.self, from: data),
-      body.error == "insufficient_entitlement"
-    {
+      body.error == "insufficient_entitlement" {
       throw DomainError.insufficientEntitlement(required: body.required)
     }
     let message = String(data: data, encoding: .utf8)

--- a/mobile/ios/packages/town-crier-data/Sources/Auth/Auth0AuthenticationService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Auth/Auth0AuthenticationService.swift
@@ -20,8 +20,7 @@ public struct Auth0Config: Sendable {
 }
 
 public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationService,
-  @unchecked Sendable
-{
+  @unchecked Sendable {
   private let config: Auth0Config
   private let credentialsManager: CredentialsManager
   /// In-memory session cache that lets a foreground burst share a single

--- a/mobile/ios/packages/town-crier-data/Sources/CrashReporting/MetricKitCrashReporter.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/CrashReporting/MetricKitCrashReporter.swift
@@ -8,8 +8,7 @@ import os
 /// MetricKit delivers crash diagnostic payloads up to 24 hours after the crash occurs.
 /// Call `start()` once during app launch to subscribe to diagnostics.
 public final class MetricKitCrashReporter: NSObject, CrashReporter, MXMetricManagerSubscriber,
-  @unchecked Sendable
-{
+  @unchecked Sendable {
   private let logger = Logger(
     subsystem: "uk.co.towncrier",
     category: "CrashReporting"

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
@@ -10,8 +10,7 @@ public final class APIPlanningApplicationRepository: PlanningApplicationReposito
   }
 
   public func fetchApplications(for zone: WatchZone) async throws
-    -> [PlanningApplication]
-  {
+    -> [PlanningApplication] {
     let dtos: [PlanningApplicationDTO]
     do {
       dtos = try await apiClient.request(

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/InMemoryPlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/InMemoryPlanningApplicationRepository.swift
@@ -2,8 +2,7 @@ import TownCrierDomain
 
 /// An in-memory repository for development and testing.
 public final class InMemoryPlanningApplicationRepository: PlanningApplicationRepository,
-  @unchecked Sendable
-{
+  @unchecked Sendable {
   private var applications: [PlanningApplication]
 
   public init(applications: [PlanningApplication] = []) {

--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/EntitlementMap.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/EntitlementMap.swift
@@ -38,8 +38,7 @@ public enum EntitlementMap {
 
   /// Returns whether the given tier grants the specified entitlement.
   public static func hasEntitlement(_ entitlement: Entitlement, for tier: SubscriptionTier)
-    -> Bool
-  {
+    -> Bool {
     entitlements(for: tier).contains(entitlement)
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -118,8 +118,7 @@ public final class AppCoordinator: ObservableObject {
     // retain feature access immediately, even before the live resolution
     // completes (or when it fails on simulator).
     if let cached = self.tierCache.string(forKey: Self.tierCacheKey),
-      let tier = SubscriptionTier(rawValue: cached)
-    {
+      let tier = SubscriptionTier(rawValue: cached) {
       subscriptionTier = tier
     }
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -202,8 +202,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
         // deleted — or nothing is selected yet — fall back to
         // `resolveInitialSelection`.
         if let currentId = selectedZone?.id,
-          let updated = loadedZones.first(where: { $0.id == currentId })
-        {
+          let updated = loadedZones.first(where: { $0.id == currentId }) {
           selectedZone = updated
         } else {
           resolveInitialSelection(from: loadedZones)
@@ -273,8 +272,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   private func resolveInitialSelection(from zones: [WatchZone]) {
     let savedId = userDefaults.string(forKey: zoneSelectionKey)
     if let savedId,
-      let savedZone = zones.first(where: { $0.id.value == savedId })
-    {
+      let savedZone = zones.first(where: { $0.id.value == savedId }) {
       selectedZone = savedZone
       return
     }
@@ -339,7 +337,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     }
     let sorted = scored.sorted { lhs, rhs in
       switch (lhs.distance, rhs.distance) {
-      case (.some(let left), .some(let right)):
+      case let (.some(left), .some(right)):
         return left < right
       case (.some, .none):
         return true
@@ -366,8 +364,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     key: String
   ) -> ApplicationsSort {
     if let raw = defaults.string(forKey: key),
-      let parsed = ApplicationsSort(rawValue: raw)
-    {
+      let parsed = ApplicationsSort(rawValue: raw) {
       return parsed
     }
     return .recentActivity

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/EntitlementGatingViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/EntitlementGatingViewModel.swift
@@ -30,8 +30,7 @@ extension EntitlementGatingViewModel {
     fallback: (String) -> DomainError = { .unexpected($0) }
   ) {
     if let domainError = error as? DomainError,
-      case .insufficientEntitlement(let required) = domainError
-    {
+      case .insufficientEntitlement(let required) = domainError {
       if let entitlement = Entitlement(rawValue: required) {
         self.entitlementGate = entitlement
         self.error = nil

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
@@ -93,8 +93,7 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
       // Falling back to `resolveInitialZone` only when the id is missing
       // (zone deleted) preserves the previous-session restore behaviour.
       if let currentId = selectedZone?.id,
-        let updated = loadedZones.first(where: { $0.id == currentId })
-      {
+        let updated = loadedZones.first(where: { $0.id == currentId }) {
         selectedZone = updated
       } else {
         selectedZone = resolveInitialZone(from: loadedZones)
@@ -158,8 +157,7 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
 
   private func resolveInitialZone(from zones: [WatchZone]) -> WatchZone? {
     if let savedId = userDefaults.string(forKey: zoneSelectionKey),
-      let savedZone = zones.first(where: { $0.id.value == savedId })
-    {
+      let savedZone = zones.first(where: { $0.id.value == savedId }) {
       return savedZone
     }
     return zones.first

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTierResolutionTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTierResolutionTests.swift
@@ -17,8 +17,7 @@ struct AppCoordinatorTierResolutionTests {
     serverProfileError: Error? = nil,
     tierResolver: SubscriptionTierResolving? = nil,
     tierCache: UserDefaults = UserDefaults(suiteName: UUID().uuidString) ?? .standard
-  ) -> (AppCoordinator, SpyAuthenticationService, SpySubscriptionService, SpyUserProfileRepository)
-  {
+  ) -> (AppCoordinator, SpyAuthenticationService, SpySubscriptionService, SpyUserProfileRepository) {
     let authSpy = SpyAuthenticationService()
     authSpy.currentSessionResult = authSession
     let subscriptionSpy = SpySubscriptionService()

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
@@ -44,8 +44,7 @@ struct ApplicationListViewModelUnreadTests {
     return (sut, appSpy, stateSpy, defaults)
   }
 
-  private func event(at seconds: TimeInterval, type: String = "NewApplication") -> LatestUnreadEvent
-  {
+  private func event(at seconds: TimeInterval, type: String = "NewApplication") -> LatestUnreadEvent {
     LatestUnreadEvent(
       type: type,
       decision: nil,

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
@@ -282,8 +282,7 @@ struct MapViewModelTests {
     zones: [WatchZone] = [.cambridge, .london],
     applications: [PlanningApplication] = [.pendingReview],
     persistedZoneId: String? = nil
-  ) throws -> (MapViewModel, SpyPlanningApplicationRepository, SpyWatchZoneRepository, UserDefaults)
-  {
+  ) throws -> (MapViewModel, SpyPlanningApplicationRepository, SpyWatchZoneRepository, UserDefaults) {
     let appSpy = SpyPlanningApplicationRepository()
     appSpy.fetchApplicationsResult = .success(applications)
     let zoneSpy = SpyWatchZoneRepository()

--- a/mobile/ios/town-crier-tests/Sources/Spies/ControllableSavedApplicationRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/ControllableSavedApplicationRepository.swift
@@ -4,8 +4,7 @@ import TownCrierDomain
 /// Test double for `SavedApplicationRepository` that suspends `loadAll()` until
 /// `resume(with:)` is called. Used to assert in-flight loading state on
 /// `ApplicationListViewModel` and `MapViewModel`.
-final class ControllableSavedApplicationRepository: SavedApplicationRepository, @unchecked Sendable
-{
+final class ControllableSavedApplicationRepository: SavedApplicationRepository, @unchecked Sendable {
   private var continuation: CheckedContinuation<[SavedApplication], Error>?
   private var pendingCallSignal: CheckedContinuation<Void, Never>?
   private var didReceiveCall = false


### PR DESCRIPTION
## Summary
- v0.13.21's tag triggered **CD iOS TestFlight**, which failed at the `swiftlint lint --strict` step with 21 serious violations ([run 27275699514](https://github.com/AmyDe/town-crier/actions/runs/27275699514)). CD Production succeeded; only the TestFlight build was blocked.
- The 21 violations were **pre-existing** (unrelated to the v0.13.21 commits) and pre-tracked as tc-bl9c.
  - **17 × `opening_brace`** — auto-fixed via `swiftlint --fix` (braces moved inline, matching the project's stated K&R convention).
  - **4 × `pattern_matching_keywords`** (2 sites) — hand-fixed in `Error+DomainMapping.swift` and `ApplicationListViewModel.swift` (`case .x(let a, let b)` → `case let .x(a, b)`).
- **Root cause:** `.swiftlint.yml` uses `opt_in_rules: all` plus a `disabled_rules` list containing two identifiers SwiftLint 0.63 renamed — `cases_on_newline` → `switch_case_on_newline`, and a phantom `opening_brace_spacing`. The rename silently re-activated `opening_brace`. PR Gate runs non-strict lint so it never flagged them; they only surfaced in CD strict lint. Fixed the stale identifiers, which also clears the two "not a valid rule identifier" warnings.

## Test plan
- [x] `swiftlint lint --strict` → 0 violations, no config warnings
- [x] `swift build` → build complete
- [x] `swift test` → 1223 tests, all passing
- [ ] After merge: re-run the failed CD TestFlight workflow (or cut v0.13.22) for a clean TestFlight build

## Follow-up
- Filing a bead to make **PR Gate** run `swiftlint --strict` too, so these can't slip through to CD again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated code formatting standards and linting configuration across the codebase to improve consistency and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->