### PR TITLE
feat(infra): add ca-town-crier-api-go-dev container app (tc-7g3i.1)

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -375,6 +375,88 @@ public static class EnvironmentStack
                 new CustomResourceOptions { DependsOn = { containerApp } });
         }
 
+        // Container App (Go API) — runs ALONGSIDE the .NET API during the Go
+        // migration (GH#418). Dev-only until cutover; Iteration 10 adds prod.
+        // No custom domain: it serves on its default ACA FQDN, and cutover is a
+        // Cloudflare DNS flip of the api domain once parity is verified.
+        // Same placeholder-image bootstrap as the .NET app: the quickstart image
+        // listens on 80 (not 8080), so the first revision stays unhealthy until
+        // CD pushes the real town-crier-api-go image.
+        if (env == "dev")
+        {
+            _ = new ContainerApp($"ca-town-crier-api-go-{env}", new ContainerAppArgs
+            {
+                ContainerAppName = $"ca-town-crier-api-go-{env}",
+                ResourceGroupName = resourceGroup.Name,
+                ManagedEnvironmentId = containerAppsEnvironmentId,
+                Configuration = new ConfigurationArgs
+                {
+                    // Multiple: pr-gate.yml stages per-PR Go revisions with
+                    // --revision-suffix and pinned traffic, same as the .NET flow.
+                    ActiveRevisionsMode = ActiveRevisionsMode.Multiple,
+                    MaxInactiveRevisions = 5,
+                    Ingress = new IngressArgs
+                    {
+                        External = true,
+                        TargetPort = 8080,
+                        Transport = IngressTransportMethod.Http,
+                    },
+                    Registries = new[]
+                    {
+                        new RegistryCredentialsArgs
+                        {
+                            Server = acrLoginServer,
+                            Identity = acrPullIdentityId,
+                        },
+                    },
+                },
+                Identity = new Pulumi.AzureNative.App.Inputs.ManagedServiceIdentityArgs
+                {
+                    Type = ManagedServiceIdentityType.UserAssigned,
+                    UserAssignedIdentities = new InputList<string>
+                    {
+                        acrPullIdentityId,
+                        cosmosDataIdentityId,
+                    },
+                },
+                Template = new TemplateArgs
+                {
+                    Containers = new[]
+                    {
+                        new ContainerArgs
+                        {
+                            Name = "api-go",
+                            Image = "mcr.microsoft.com/k8se/quickstart:latest",
+                            Resources = new ContainerResourcesArgs
+                            {
+                                Cpu = ContainerCpu,
+                                Memory = ContainerMemory,
+                            },
+                            Env = new[]
+                            {
+                                new EnvironmentVarArgs { Name = "OTEL_SERVICE_NAME", Value = "town-crier-api-go" },
+                                new EnvironmentVarArgs { Name = "COSMOS_ENDPOINT", Value = cosmosAccountEndpoint },
+                                new EnvironmentVarArgs { Name = "COSMOS_DATABASE", Value = cosmosDatabase.Name },
+                                new EnvironmentVarArgs { Name = "AZURE_CLIENT_ID", Value = cosmosDataIdentityClientId },
+                            },
+                        },
+                    },
+                    Scale = new ScaleArgs
+                    {
+                        // Scale-to-zero: no traffic until cutover, so idle cost stays nil.
+                        MinReplicas = 0,
+                        MaxReplicas = 1,
+                    },
+                },
+                Tags = tags,
+            }, new CustomResourceOptions
+            {
+                // CD updates the image via `az containerapp update`; the PR gate
+                // manages staging-revision traffic. Pulumi must not reset either.
+                IgnoreChanges = { "template.containers[0].image", "configuration.ingress.traffic" },
+            });
+        }
+
         // Service Bus — adaptive polling trigger (prod only for now; dev stays on cron).
         // The polling worker consumes one message per run and re-enqueues the next run with
         // a scheduled enqueue time calculated from Retry-After headers and natural cadence.


### PR DESCRIPTION
## Summary
Iteration 0 (PR 1 of 2) of the Go API migration — design home: #418.

Adds the **separate** Container App `ca-town-crier-api-go-dev` that the Go API will deploy to, alongside the untouched .NET app:

- Same managed environment, ACR pull identity, and cosmos-data identity as the .NET app
- `Multiple` revisions mode so the PR gate can stage zero-traffic Go revisions (same flow as the .NET lane)
- Scale 0–1 (no idle cost), no custom domain (cutover is a later Cloudflare DNS flip)
- Placeholder quickstart image with `IgnoreChanges` on image + traffic — the first revision stays unhealthy until PR 2 of 2 lands the Go binary and CD pushes the real image (same bootstrap the .NET app used)

Dev-only for now; iteration 10 adds prod.

## Test plan
- [x] `dotnet build` + `dotnet format --verify-no-changes` green in /infra
- [ ] PR-gate `infra-preview` shows exactly one new resource (the Go container app)
- [ ] cd-dev `pulumi up` creates the app after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new Go API service in the development environment with auto-scaling capabilities (scales from zero to one replica based on demand).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->