### PR TITLE
feat(go): scaffold api-go with health endpoints, Dockerfile, CI lane (tc-7g3i.1)

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -49,6 +49,9 @@ outputs:
   infra:
     description: "true if infra/ changed"
     value: ${{ steps.detect.outputs.infra }}
+  go:
+    description: "true if api-go/ changed"
+    value: ${{ steps.detect.outputs.go }}
 
 runs:
   using: composite
@@ -100,6 +103,7 @@ runs:
           [[ -z "$file" ]] && continue
           case "$file" in
             api/*) [[ -v "flags[api]" ]] && flags[api]=true ;;
+            api-go/*) [[ -v "flags[go]" ]] && flags[go]=true ;;
             cli/*) [[ -v "flags[cli]" ]] && flags[cli]=true ;;
             mobile/ios/*) [[ -v "flags[ios]" ]] && flags[ios]=true ;;
             web/*) [[ -v "flags[web]" ]] && flags[web]=true ;;

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -140,6 +140,27 @@ jobs:
           image-name: town-crier-api
           working-directory: api
 
+  # ── Go API: build & push image ──────────────────────
+  api-go-image:
+    name: "Go API: Build & push image"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: development
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/azure-login
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - uses: ./.github/actions/acr-build-push
+        with:
+          acr-login-server: ${{ secrets.ACR_LOGIN_SERVER }}
+          image-name: town-crier-api-go
+          working-directory: api-go
+
   # ── Worker: build & push image ──────────────────────────
   worker-image:
     name: "Worker: Build & push image"
@@ -183,6 +204,28 @@ jobs:
           app-name: ca-town-crier-api-dev
           resource-group: rg-town-crier-dev
           image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api:${{ github.sha }}
+
+  # ── Go API: deploy to dev ───────────────────────────
+  api-go-deploy:
+    name: "Go API: Deploy to dev"
+    needs: [api-go-image, infra-dev]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: development
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/azure-login
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - uses: ./.github/actions/deploy-container-app
+        with:
+          app-name: ca-town-crier-api-go-dev
+          resource-group: rg-town-crier-dev
+          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api-go:${{ github.sha }}
 
   # ── Worker: deploy to dev ───────────────────────────────
   worker-deploy:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -435,12 +435,26 @@ jobs:
 
       - name: Resolve .NET dev API URL
         id: dotnet-url
+        # Deliberately NOT the app-level FQDN: dev traffic is latestRevision-based
+        # and latestRevisionName can point at a PR staging revision that
+        # api-staging-cleanup has already deactivated, making the app FQDN serve
+        # ACA's 404 page between PR runs. Anchor on the newest ACTIVE mainline
+        # (non --pr) revision and use its revision-specific FQDN instead.
         run: |
+          REVISION=$(az containerapp revision list \
+            --name "${{ env.CONTAINER_APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --query "sort_by([?properties.active && !contains(name, \`--pr\`)], &properties.createdTime)[-1].name" -o tsv)
+          if [ -z "$REVISION" ]; then
+            echo "::error::No active mainline revision found on ${{ env.CONTAINER_APP_NAME }}"
+            exit 1
+          fi
           APP_FQDN=$(az containerapp show \
             --name "${{ env.CONTAINER_APP_NAME }}" \
             --resource-group "${{ env.RESOURCE_GROUP }}" \
             --query "properties.configuration.ingress.fqdn" -o tsv)
-          echo "url=https://${APP_FQDN}" >> "$GITHUB_OUTPUT"
+          ENV_DOMAIN="${APP_FQDN#*.}"
+          echo "url=https://${REVISION}.${ENV_DOMAIN}" >> "$GITHUB_OUTPUT"
 
       - name: Run contract tests
         env:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -33,6 +33,8 @@ env:
   CONTAINER_APP_NAME: ca-town-crier-api-dev
   RESOURCE_GROUP: rg-town-crier-dev
   API_IMAGE_NAME: town-crier-api
+  GO_CONTAINER_APP_NAME: ca-town-crier-api-go-dev
+  GO_IMAGE_NAME: town-crier-api-go
 
 jobs:
   changes:
@@ -46,6 +48,7 @@ jobs:
       ios: ${{ steps.detect.outputs.ios }}
       web: ${{ steps.detect.outputs.web }}
       infra: ${{ steps.detect.outputs.infra }}
+      go: ${{ steps.detect.outputs.go }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -56,10 +59,10 @@ jobs:
         with:
           mode: pr
           base-ref: ${{ github.base_ref }}
-          categories: api,cli,ios,web,infra
+          categories: api,cli,ios,web,infra,go
           trigger-files: |
-            .github/workflows/pr-gate.yml:api,cli,ios,web,infra
-            .github/workflows/cd-dev.yml:api,web,infra
+            .github/workflows/pr-gate.yml:api,cli,ios,web,infra,go
+            .github/workflows/cd-dev.yml:api,web,infra,go
             .github/workflows/cd-prod.yml:infra
             .github/workflows/cd-ios-testflight.yml:ios
 
@@ -278,6 +281,199 @@ jobs:
             --resource-group "${{ env.RESOURCE_GROUP }}" \
             --revision "${{ needs.api-staging.outputs.new-revision }}" || true
 
+  # ── Go API ───────────────────────────────────────────
+
+  go-lint:
+    name: "Go API: Lint"
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: api-go/go.mod
+          # No go.sum yet (zero dependencies); enable module caching when one appears.
+          cache: false
+      - name: gofmt
+        run: |
+          UNFORMATTED=$(gofmt -l .)
+          if [ -n "$UNFORMATTED" ]; then
+            echo "::error::gofmt required on: $UNFORMATTED"
+            exit 1
+          fi
+        working-directory: api-go
+      - run: go vet ./...
+        working-directory: api-go
+      - uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.12
+          working-directory: api-go
+
+  go-test:
+    name: "Go API: Build & test"
+    needs: changes
+    if: needs.changes.outputs.go == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: api-go/go.mod
+          cache: false
+      - run: go build ./...
+        working-directory: api-go
+      - name: Run tests (race detector + coverage)
+        run: go test -race -coverprofile=coverage.out ./...
+        working-directory: api-go
+      - uses: actions/upload-artifact@v4
+        with:
+          name: go-coverage
+          path: api-go/coverage.out
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # ── Go API: staging deploy ──────────────────────────
+  # Mirrors the .NET api-staging flow on the parallel Go container app:
+  # build/push the image, stage a zero-traffic revision, and hand its URL
+  # to the contract tests.
+
+  go-staging:
+    name: "Go API: Deploy staging revision"
+    needs: [changes, go-lint, go-test]
+    if: needs.changes.outputs.go == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: development
+    outputs:
+      staging-url: ${{ steps.staging-url.outputs.url }}
+      new-revision: ${{ steps.deploy.outputs.revision }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/azure-login
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Login to ACR
+        run: az acr login --name ${{ secrets.ACR_LOGIN_SERVER }}
+
+      - name: Build and push image
+        run: |
+          IMAGE="${{ secrets.ACR_LOGIN_SERVER }}/${{ env.GO_IMAGE_NAME }}:${{ github.event.pull_request.head.sha }}"
+          docker build -t "$IMAGE" .
+          docker push "$IMAGE"
+        working-directory: api-go
+
+      - name: Get current active revision
+        id: current
+        run: |
+          CURRENT=$(az containerapp ingress traffic show \
+            --name "${{ env.GO_CONTAINER_APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --query "[?weight==\`100\`].revisionName | [0]" -o tsv)
+          echo "revision=$CURRENT" >> "$GITHUB_OUTPUT"
+
+      - name: Deploy staging revision
+        id: deploy
+        run: |
+          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          az containerapp update \
+            --name "${{ env.GO_CONTAINER_APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --image "${{ secrets.ACR_LOGIN_SERVER }}/${{ env.GO_IMAGE_NAME }}:${{ github.event.pull_request.head.sha }}" \
+            --revision-suffix "pr${SHORT_SHA}"
+          echo "revision=${{ env.GO_CONTAINER_APP_NAME }}--pr${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Pin traffic to current revision
+        run: |
+          if [ -n "${{ steps.current.outputs.revision }}" ]; then
+            az containerapp ingress traffic set \
+              --name "${{ env.GO_CONTAINER_APP_NAME }}" \
+              --resource-group "${{ env.RESOURCE_GROUP }}" \
+              --revision-weight "${{ steps.current.outputs.revision }}=100"
+          fi
+
+      - name: Get staging URL
+        id: staging-url
+        run: |
+          APP_FQDN=$(az containerapp show \
+            --name "${{ env.GO_CONTAINER_APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --query "properties.configuration.ingress.fqdn" -o tsv)
+          ENV_DOMAIN="${APP_FQDN#*.}"
+          echo "url=https://${{ steps.deploy.outputs.revision }}.${ENV_DOMAIN}" >> "$GITHUB_OUTPUT"
+
+  # ── Go API: contract tests vs .NET ──────────────────
+  # Parity is observed, never assumed: every scenario runs against BOTH the
+  # deployed .NET dev API and the staged Go revision, and the responses are
+  # diffed. The .NET response is always the expected value (GH#418).
+
+  go-contract:
+    name: "Go API: Contract tests vs .NET"
+    needs: [go-staging]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: development
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: api-go/go.mod
+          cache: false
+
+      - uses: ./.github/actions/azure-login
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Resolve .NET dev API URL
+        id: dotnet-url
+        run: |
+          APP_FQDN=$(az containerapp show \
+            --name "${{ env.CONTAINER_APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --query "properties.configuration.ingress.fqdn" -o tsv)
+          echo "url=https://${APP_FQDN}" >> "$GITHUB_OUTPUT"
+
+      - name: Run contract tests
+        env:
+          DOTNET_BASE_URL: ${{ steps.dotnet-url.outputs.url }}
+          GO_BASE_URL: ${{ needs.go-staging.outputs.staging-url }}
+        run: go test -tags e2e -v ./tests/e2e/...
+        working-directory: api-go
+
+  # ── Go API: clean up staging revision ───────────────
+
+  go-staging-cleanup:
+    name: "Go API: Deactivate staging revision"
+    needs: [go-staging, go-contract]
+    if: always() && needs.go-staging.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment: development
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/azure-login
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Deactivate staging revision
+        run: |
+          az containerapp revision deactivate \
+            --name "${{ env.GO_CONTAINER_APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --revision "${{ needs.go-staging.outputs.new-revision }}" || true
+
   # ── PR-close cleanup: deactivate preview revision on merge/close ───
   # Catches PRs closed before api-staging-cleanup ran (e.g., closed
   # without merging, or where api-staging failed mid-flight). Reuses
@@ -306,6 +502,16 @@ jobs:
           echo "Deactivating revision: $REVISION"
           az containerapp revision deactivate \
             --name "${{ env.CONTAINER_APP_NAME }}" \
+            --resource-group "${{ env.RESOURCE_GROUP }}" \
+            --revision "$REVISION" || true
+
+      - name: Deactivate Go PR preview revision
+        run: |
+          SHORT_SHA=$(echo "${{ github.event.pull_request.head.sha }}" | cut -c1-7)
+          REVISION="${{ env.GO_CONTAINER_APP_NAME }}--pr${SHORT_SHA}"
+          echo "Deactivating revision: $REVISION"
+          az containerapp revision deactivate \
+            --name "${{ env.GO_CONTAINER_APP_NAME }}" \
             --resource-group "${{ env.RESOURCE_GROUP }}" \
             --revision "$REVISION" || true
 
@@ -478,7 +684,7 @@ jobs:
 
   gate:
     name: PR Gate
-    needs: [api-format, api-build-test, api-staging, api-integration-test, api-staging-cleanup, cli-format, cli-build-test, ios-lint, ios-build-test, web-lint, web-build-test, infra-preview]
+    needs: [api-format, api-build-test, api-staging, api-integration-test, api-staging-cleanup, go-lint, go-test, go-staging, go-contract, go-staging-cleanup, cli-format, cli-build-test, ios-lint, ios-build-test, web-lint, web-build-test, infra-preview]
     if: always() && github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -491,6 +697,11 @@ jobs:
             "${{ needs.api-staging.result }}"
             "${{ needs.api-integration-test.result }}"
             "${{ needs.api-staging-cleanup.result }}"
+            "${{ needs.go-lint.result }}"
+            "${{ needs.go-test.result }}"
+            "${{ needs.go-staging.result }}"
+            "${{ needs.go-contract.result }}"
+            "${{ needs.go-staging-cleanup.result }}"
             "${{ needs.cli-format.result }}"
             "${{ needs.cli-build-test.result }}"
             "${{ needs.ios-lint.result }}"

--- a/api-go/.golangci.yml
+++ b/api-go/.golangci.yml
@@ -1,0 +1,65 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  default: none
+  enable:
+    - errcheck         # unhandled errors — Go's #1 bug class
+    - govet            # standard vet checks
+    - staticcheck      # broad correctness (replaces gosimple, stylecheck, staticcheck)
+    - gosec            # security: weak crypto, command injection, SQL injection patterns
+    - sloglint         # log/slog key/value hygiene
+    - bodyclose        # http.Response.Body must be closed
+    - contextcheck     # context.Context propagation correctness
+    - errorlint        # %w wrapping, errors.Is / errors.As enforcement
+    - noctx            # outbound HTTP requests without context
+    - rowserrcheck     # sql.Rows.Err() must be checked
+    - sqlclosecheck    # sql.Rows.Close() must be called
+    - copyloopvar      # Go 1.22 loop-variable semantics
+    - intrange         # Go 1.22 integer range loops
+    - misspell         # catch common typos
+    - unparam          # unused function parameters
+    - unconvert        # unnecessary type conversions
+    - nilerr           # returning nil after checking err != nil
+    - prealloc         # slices that could be preallocated
+    - thelper          # missing t.Helper() in test helpers
+    - tparallel        # missing t.Parallel() in safe tests
+
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+      exclude-functions:
+        - (io.Closer).Close
+        - (*os.File).Close
+    gosec:
+      excludes:
+        # G104 is covered by errcheck more thoroughly
+        - G104
+        # G115 (integer overflow conversion) — too noisy on safe stdlib conversions;
+        # re-enable per-file with //nolint if a specific path warrants it
+        - G115
+    sloglint:
+      no-mixed-args: true
+      kv-only: false
+      attr-only: false
+      no-global: all
+      context: scope
+      static-msg: true
+      no-raw-keys: false
+      key-naming-case: camel
+      args-on-sep-lines: false
+
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck    # tests may discard errors deliberately for setup
+          - gosec       # tests may use weak randomness or HTTP for fixtures
+
+formatters:
+  enable:
+    - gofmt

--- a/api-go/Dockerfile
+++ b/api-go/Dockerfile
@@ -1,0 +1,20 @@
+# Town Crier API (Go)
+FROM golang:1.26-alpine AS build
+WORKDIR /src
+
+# go.* matches go.mod now and go.sum once dependencies arrive.
+COPY go.* ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /app/api ./cmd/api
+
+FROM gcr.io/distroless/static-debian12:nonroot AS runtime
+WORKDIR /app
+
+COPY --from=build /app/api .
+
+ENV PORT=8080
+EXPOSE 8080
+
+ENTRYPOINT ["./api"]

--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -1,0 +1,52 @@
+// Command api serves the Town Crier HTTP API — the Go port of the .NET API
+// (GH#418). It must stay contract-identical to the .NET implementation until
+// cutover.
+package main
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/health"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+func main() {
+	cfg, err := platform.LoadConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	logger := platform.NewLogger(os.Stdout, cfg.LogLevel)
+
+	mux := http.NewServeMux()
+	health.Routes(mux, logger)
+
+	srv := platform.NewServer(":"+cfg.Port, mux)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		logger.Info("api listening", "addr", srv.Addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("serve", "error", err)
+			stop()
+		}
+	}()
+
+	<-ctx.Done()
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		logger.Error("shutdown", "error", err)
+	}
+	logger.Info("api stopped")
+}

--- a/api-go/go.mod
+++ b/api-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/AmyDe/town-crier/api-go
+
+go 1.26

--- a/api-go/internal/health/handler.go
+++ b/api-go/internal/health/handler.go
@@ -1,0 +1,35 @@
+// Package health serves the liveness endpoints. They return a static body
+// without touching any dependency: Container Apps' readiness probe gates
+// traffic on them, so any work here delays the first request after a
+// scale-from-zero cold start.
+package health
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+// body is the .NET HealthStatus contract verbatim: {"status":"Healthy"}.
+// Kept as a pre-encoded constant so the handler does no work per request.
+const body = `{"status":"Healthy"}`
+
+// Routes registers the health endpoints. The .NET API exposes the check at
+// both the bare and the /v1 path; parity requires both.
+func Routes(mux *http.ServeMux, logger *slog.Logger) {
+	h := handler{logger: logger}
+	mux.HandleFunc("GET /health", h.check)
+	mux.HandleFunc("GET /v1/health", h.check)
+}
+
+type handler struct {
+	logger *slog.Logger
+}
+
+func (h handler) check(w http.ResponseWriter, r *http.Request) {
+	// Content-Type matches ASP.NET Core's JSON results byte-for-byte,
+	// including the charset parameter.
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if _, err := w.Write([]byte(body)); err != nil {
+		h.logger.ErrorContext(r.Context(), "write health response", "error", err)
+	}
+}

--- a/api-go/internal/health/handler_test.go
+++ b/api-go/internal/health/handler_test.go
@@ -1,0 +1,56 @@
+package health
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRoutes_HealthEndpoints(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	Routes(mux, slog.New(slog.DiscardHandler))
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"bare path", "/health"},
+		{"versioned path", "/v1/health"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+tc.path, nil)
+			if err != nil {
+				t.Fatalf("new request %s: %v", tc.path, err)
+			}
+			resp, err := srv.Client().Do(req)
+			if err != nil {
+				t.Fatalf("get %s: %v", tc.path, err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				t.Errorf("status: got %d, want %d", resp.StatusCode, http.StatusOK)
+			}
+			if got, want := resp.Header.Get("Content-Type"), "application/json; charset=utf-8"; got != want {
+				t.Errorf("content-type: got %q, want %q", got, want)
+			}
+
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			if got, want := string(body), `{"status":"Healthy"}`; got != want {
+				t.Errorf("body: got %s, want %s", got, want)
+			}
+		})
+	}
+}

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -1,0 +1,41 @@
+package platform
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+)
+
+// Config holds process configuration loaded from environment variables.
+// Container Apps provides env vars; load them, validate them, fail fast at
+// startup.
+type Config struct {
+	Port     string
+	LogLevel slog.Level
+}
+
+// LoadConfig reads configuration from the environment, applying defaults
+// where a variable is unset.
+func LoadConfig() (Config, error) {
+	cfg := Config{
+		Port:     getenv("PORT", "8080"),
+		LogLevel: slog.LevelInfo,
+	}
+
+	if raw := os.Getenv("LOG_LEVEL"); raw != "" {
+		var level slog.Level
+		if err := level.UnmarshalText([]byte(raw)); err != nil {
+			return Config{}, fmt.Errorf("parse LOG_LEVEL %q: %w", raw, err)
+		}
+		cfg.LogLevel = level
+	}
+
+	return cfg, nil
+}
+
+func getenv(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -1,0 +1,44 @@
+package platform
+
+import (
+	"log/slog"
+	"testing"
+)
+
+func TestLoadConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		port      string
+		logLevel  string
+		wantPort  string
+		wantLevel slog.Level
+		wantErr   bool
+	}{
+		{"defaults", "", "", "8080", slog.LevelInfo, false},
+		{"port override", "9090", "", "9090", slog.LevelInfo, false},
+		{"debug level", "", "debug", "8080", slog.LevelDebug, false},
+		{"warn level", "", "WARN", "8080", slog.LevelWarn, false},
+		{"invalid level", "", "noisy", "", slog.LevelInfo, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("PORT", tc.port)
+			t.Setenv("LOG_LEVEL", tc.logLevel)
+
+			cfg, err := LoadConfig()
+
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("got err=%v, wantErr=%v", err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if cfg.Port != tc.wantPort {
+				t.Errorf("Port: got %q, want %q", cfg.Port, tc.wantPort)
+			}
+			if cfg.LogLevel != tc.wantLevel {
+				t.Errorf("LogLevel: got %v, want %v", cfg.LogLevel, tc.wantLevel)
+			}
+		})
+	}
+}

--- a/api-go/internal/platform/logger.go
+++ b/api-go/internal/platform/logger.go
@@ -1,0 +1,12 @@
+package platform
+
+import (
+	"io"
+	"log/slog"
+)
+
+// NewLogger returns a JSON slog logger at the given level. Production wiring
+// passes os.Stdout; tests pass a buffer.
+func NewLogger(w io.Writer, level slog.Level) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level}))
+}

--- a/api-go/internal/platform/server.go
+++ b/api-go/internal/platform/server.go
@@ -1,0 +1,20 @@
+package platform
+
+import (
+	"net/http"
+	"time"
+)
+
+// NewServer returns an http.Server with hardened timeouts. The zero-valued
+// defaults on http.Server allow slowloris attacks; never accept them.
+func NewServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    1 << 20, // 1 MiB
+	}
+}

--- a/api-go/internal/platform/server_test.go
+++ b/api-go/internal/platform/server_test.go
@@ -1,0 +1,33 @@
+package platform
+
+import (
+	"net/http"
+	"testing"
+)
+
+// The hardened profile is the point of NewServer: a zero timeout reintroduces
+// slowloris exposure, so regressions must fail loudly.
+func TestNewServer_HardenedTimeouts(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer(":8080", http.NewServeMux())
+
+	if srv.ReadHeaderTimeout <= 0 {
+		t.Error("ReadHeaderTimeout must be positive")
+	}
+	if srv.ReadTimeout <= 0 {
+		t.Error("ReadTimeout must be positive")
+	}
+	if srv.WriteTimeout <= 0 {
+		t.Error("WriteTimeout must be positive")
+	}
+	if srv.IdleTimeout <= 0 {
+		t.Error("IdleTimeout must be positive")
+	}
+	if srv.MaxHeaderBytes <= 0 {
+		t.Error("MaxHeaderBytes must be positive")
+	}
+	if srv.Addr != ":8080" {
+		t.Errorf("Addr: got %q, want %q", srv.Addr, ":8080")
+	}
+}

--- a/api-go/tests/e2e/contract_test.go
+++ b/api-go/tests/e2e/contract_test.go
@@ -1,0 +1,108 @@
+//go:build e2e
+
+// Package e2e holds black-box contract-diff tests. Every scenario executes
+// against BOTH the deployed .NET API (DOTNET_BASE_URL) and the deployed Go
+// API (GO_BASE_URL) and diffs the responses. The .NET response is always the
+// expected value — parity is observed, never assumed from the source.
+//
+// Run: go test -tags e2e ./tests/e2e/...
+// Tests skip when the URLs are unset so a plain `go test ./...` stays green
+// locally.
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+// Generous timeout: both apps scale to zero in dev, so the first request may
+// absorb an Azure Container Apps cold start.
+const requestTimeout = 60 * time.Second
+
+func TestContract_Health(t *testing.T) {
+	dotnetURL := baseURL(t, "DOTNET_BASE_URL")
+	goURL := baseURL(t, "GO_BASE_URL")
+	client := &http.Client{Timeout: requestTimeout}
+
+	for _, path := range []string{"/health", "/v1/health"} {
+		t.Run(path, func(t *testing.T) {
+			want := get(t, client, dotnetURL+path)
+			got := get(t, client, goURL+path)
+
+			if got.status != want.status {
+				t.Errorf("status: go=%d dotnet=%d", got.status, want.status)
+			}
+			if got.contentType != want.contentType {
+				t.Errorf("content-type: go=%q dotnet=%q", got.contentType, want.contentType)
+			}
+			if !jsonEqual(t, got.body, want.body) {
+				t.Errorf("body: go=%s dotnet=%s", got.body, want.body)
+			}
+		})
+	}
+}
+
+type response struct {
+	status      int
+	contentType string
+	body        []byte
+}
+
+func get(t *testing.T, client *http.Client, url string) response {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("new request %s: %v", url, err)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("get %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		t.Fatalf("read body %s: %v", url, err)
+	}
+
+	return response{
+		status:      resp.StatusCode,
+		contentType: resp.Header.Get("Content-Type"),
+		body:        body,
+	}
+}
+
+// jsonEqual compares two JSON payloads structurally, ignoring key order.
+func jsonEqual(t *testing.T, a, b []byte) bool {
+	t.Helper()
+
+	var av, bv any
+	if err := json.Unmarshal(a, &av); err != nil {
+		t.Fatalf("unmarshal %q: %v", a, err)
+	}
+	if err := json.Unmarshal(b, &bv); err != nil {
+		t.Fatalf("unmarshal %q: %v", b, err)
+	}
+	return reflect.DeepEqual(av, bv)
+}
+
+func baseURL(t *testing.T, key string) string {
+	t.Helper()
+
+	v := os.Getenv(key)
+	if v == "" {
+		t.Skipf("%s not set — contract tests run in CI against deployed revisions", key)
+	}
+	return v
+}


### PR DESCRIPTION
## Summary
Iteration 0 (PR 2 of 2) of the Go API migration — design home: #418. Companion to #419, which created `ca-town-crier-api-go-dev`.

- **`api-go/` module** per `go-coding-standards`: `internal/platform` (env config, slog JSON logger, hardened `http.Server`), `internal/health` serving `GET /health` + `GET /v1/health` with the .NET contract verbatim (`{"status":"Healthy"}`, same Content-Type)
- **Contract-diff harness** (`tests/e2e`, `-tags e2e`): every scenario runs against BOTH the deployed .NET dev API and the staged Go revision and diffs status/Content-Type/JSON body — the .NET response is always the expected value
- **Dockerfile**: `CGO_ENABLED=0` static binary on distroless/static, non-root
- **pr-gate**: new `go` change category; `go-lint` (gofmt, vet, golangci-lint v2), `go-test` (`-race` + coverage), `go-staging` (zero-traffic PR revision on the Go app), `go-contract`, `go-staging-cleanup` — all feeding the required gate
- **cd-dev**: builds/pushes `town-crier-api-go` and deploys it to the Go dev app on main pushes (first deploy replaces the placeholder quickstart revision)

The .NET API and its pipeline are untouched apart from additive workflow jobs.

## Test plan
- [x] `gofmt` / `go vet` / `golangci-lint` clean locally
- [x] `go test -race ./...` — 10 tests green locally
- [ ] This PR's gate proves the full lane: lint → test → staged Go revision → contract tests vs live .NET dev API → cleanup
- [ ] After merge: cd-dev deploys the Go image and `https://ca-town-crier-api-go-dev.../health` matches the .NET response

🤖 Generated with [Claude Code](https://claude.com/claude-code)