### PR TITLE
feat(infra+ci): Go app Auth0/CORS/M2M env + contract-job test creds

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -460,6 +460,15 @@ jobs:
         env:
           DOTNET_BASE_URL: ${{ steps.dotnet-url.outputs.url }}
           GO_BASE_URL: ${{ needs.go-staging.outputs.staging-url }}
+          # Same Auth0 test-user creds as the .NET integration tests, so the
+          # harness can mint a real token for valid-token contract scenarios
+          # (it3+ /v1/me). Scenarios skip when these are unset locally.
+          INTEGRATION_TEST_AUTH0_DOMAIN: ${{ vars.VITE_AUTH0_DOMAIN }}
+          INTEGRATION_TEST_AUTH0_CLIENT_ID: ${{ vars.VITE_AUTH0_CLIENT_ID }}
+          INTEGRATION_TEST_AUTH0_CLIENT_SECRET: ${{ secrets.AUTH0_CLIENT_SECRET }}
+          INTEGRATION_TEST_AUTH0_AUDIENCE: ${{ vars.VITE_AUTH0_AUDIENCE }}
+          INTEGRATION_TEST_USERNAME: ${{ secrets.INTEGRATION_TEST_USERNAME }}
+          INTEGRATION_TEST_PASSWORD: ${{ secrets.INTEGRATION_TEST_PASSWORD }}
         run: go test -tags e2e -v ./tests/e2e/...
         working-directory: api-go
 

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -409,6 +409,11 @@ public static class EnvironmentStack
                             Identity = acrPullIdentityId,
                         },
                     },
+                    Secrets = new[]
+                    {
+                        new SecretArgs { Name = "auth0-m2m-client-id", Value = auth0M2mClientId },
+                        new SecretArgs { Name = "auth0-m2m-client-secret", Value = auth0M2mClientSecret },
+                    },
                 },
                 Identity = new Pulumi.AzureNative.App.Inputs.ManagedServiceIdentityArgs
                 {
@@ -438,6 +443,14 @@ public static class EnvironmentStack
                                 new EnvironmentVarArgs { Name = "COSMOS_ENDPOINT", Value = cosmosAccountEndpoint },
                                 new EnvironmentVarArgs { Name = "COSMOS_DATABASE", Value = cosmosDatabase.Name },
                                 new EnvironmentVarArgs { Name = "AZURE_CLIENT_ID", Value = cosmosDataIdentityClientId },
+                                // Mirrors the .NET app's Auth0__*/Cors__* env in Go naming
+                                // (GH#418 it2/it3): without these the Go validator is
+                                // deny-all and CORS falls back to the localhost dev origin.
+                                new EnvironmentVarArgs { Name = "AUTH0_DOMAIN", Value = auth0Domain },
+                                new EnvironmentVarArgs { Name = "AUTH0_AUDIENCE", Value = auth0Audience },
+                                new EnvironmentVarArgs { Name = "CORS_ALLOWED_ORIGINS", Value = $"https://{frontendDomain}" },
+                                new EnvironmentVarArgs { Name = "AUTH0_M2M_CLIENT_ID", SecretRef = "auth0-m2m-client-id" },
+                                new EnvironmentVarArgs { Name = "AUTH0_M2M_CLIENT_SECRET", SecretRef = "auth0-m2m-client-secret" },
                             },
                         },
                     },


### PR DESCRIPTION
## Changes

Enablers for Go API it3+ contract verification (GH #418), filed as follow-ups from it2:

- **infra (tc-ry3l):** `ca-town-crier-api-go-dev` gains `AUTH0_DOMAIN`, `AUTH0_AUDIENCE`, `CORS_ALLOWED_ORIGINS`, and `AUTH0_M2M_CLIENT_ID/SECRET` secret refs — mirroring the .NET app's `Auth0__*`/`Cors__*` env in Go naming. Without these the it2 validator runs deny-all (all protected routes 401) and it3's M2M tier sync would silently no-op.
- **ci (tc-dgmr):** the `go-contract` job now passes the same `INTEGRATION_TEST_*` Auth0 creds the .NET integration tests use, so the harness can mint a real token for valid-token contract scenarios (`/v1/me` in it3).

Beads: tc-ry3l, tc-dgmr · Epic: tc-7g3i

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced API contract testing infrastructure with Auth0 authentication credentials and CORS configuration
  * Provisioned container secrets and environment variables to support proper authentication integration testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->