### PR TITLE
feat(infra): wire SUBSCRIPTION_AUTOGRANT_PRODOMAINS onto Go dev app (tc-vzmo)

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -413,6 +413,7 @@ public static class EnvironmentStack
                     {
                         new SecretArgs { Name = "auth0-m2m-client-id", Value = auth0M2mClientId },
                         new SecretArgs { Name = "auth0-m2m-client-secret", Value = auth0M2mClientSecret },
+                        new SecretArgs { Name = "auto-grant-pro-domains", Value = autoGrantProDomains },
                     },
                 },
                 Identity = new Pulumi.AzureNative.App.Inputs.ManagedServiceIdentityArgs
@@ -451,6 +452,7 @@ public static class EnvironmentStack
                                 new EnvironmentVarArgs { Name = "CORS_ALLOWED_ORIGINS", Value = $"https://{frontendDomain}" },
                                 new EnvironmentVarArgs { Name = "AUTH0_M2M_CLIENT_ID", SecretRef = "auth0-m2m-client-id" },
                                 new EnvironmentVarArgs { Name = "AUTH0_M2M_CLIENT_SECRET", SecretRef = "auth0-m2m-client-secret" },
+                                new EnvironmentVarArgs { Name = "SUBSCRIPTION_AUTOGRANT_PRODOMAINS", SecretRef = "auto-grant-pro-domains" },
                             },
                         },
                     },


### PR DESCRIPTION
## Changes

- `ca-town-crier-api-go-dev` gains the `auto-grant-pro-domains` secret + `SUBSCRIPTION_AUTOGRANT_PRODOMAINS` env (secret ref), mirroring the .NET app's `Subscription__AutoGrant__ProDomains`. Without it, it3's pro-domain auto-grant silently no-ops on profile create in dev.

Bead: tc-vzmo · Epic: tc-7g3i (discovered-from tc-7g3i.4)

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)