### PR TITLE
feat(go): it4 device tokens + notification state (tc-7g3i.5)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
@@ -40,6 +42,28 @@ func main() {
 		store = profiles.NewCosmosStore(cosmos)
 	}
 
+	devices, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosDeviceRegistrationsContainer, logger)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var deviceStore *devicetokens.CosmosStore
+	if devices != nil {
+		deviceStore = devicetokens.NewCosmosStore(devices)
+	}
+
+	stateContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationStateContainer, logger)
+	if err != nil {
+		log.Fatal(err)
+	}
+	notifications, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationsContainer, logger)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var stateStore *notificationstate.CosmosStore
+	if stateContainer != nil && notifications != nil {
+		stateStore = notificationstate.NewCosmosStore(stateContainer, notifications)
+	}
+
 	// Real M2M client only when fully configured; otherwise the no-op fallback,
 	// matching .NET's conditional IAuth0ManagementClient registration.
 	var manager profiles.Auth0Manager = profiles.NoOpAuth0Client{}
@@ -52,7 +76,7 @@ func main() {
 		)
 	}
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, logger))
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, deviceStore, stateStore, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -8,9 +8,11 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/api"
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/authorities"
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/health"
 	"github.com/AmyDe/town-crier/api-go/internal/legal"
 	"github.com/AmyDe/town-crier/api-go/internal/middleware"
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/versionconfig"
 )
@@ -60,8 +62,10 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 //
 // store is nil when Cosmos is not configured (local boot without env): the
 // /v1/me routes are then unwired — requests fall to the 401 fallback — and the
-// profile-backed rate-limit/activity middlewares are skipped entirely.
-func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, logger *slog.Logger) http.Handler {
+// profile-backed rate-limit/activity middlewares are skipped entirely. The
+// device-token and notification-state stores follow the same nil-means-unwired
+// convention.
+func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)
@@ -75,6 +79,12 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 		dispatch = middleware.RateLimit(middleware.NewRateLimitStore(), profiles.NewTierLookup(store), logger)(
 			middleware.RecordActivity(profiles.NewActivityRecorder(store), time.Now, logger)(mux),
 		)
+	}
+	if deviceStore != nil {
+		devicetokens.Routes(mux, deviceStore, time.Now, logger)
+	}
+	if stateStore != nil {
+		notificationstate.Routes(mux, stateStore, time.Now, logger)
 	}
 
 	authed := auth.RequireAuth(validator, &dispatchMux{ServeMux: mux, dispatch: dispatch}, anonymousPatterns)

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -88,7 +88,7 @@ func idFromDoc(raw []byte) string {
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -185,7 +185,7 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	store := profiles.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", nil, nil, logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")

--- a/api-go/internal/devicetokens/document.go
+++ b/api-go/internal/devicetokens/document.go
@@ -1,0 +1,61 @@
+package devicetokens
+
+import (
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// deviceTTLSeconds is the Cosmos document TTL: device registrations that stop
+// refreshing (app uninstalled, logged out) are purged after 180 days so the
+// push-token store doesn't accumulate stale records. Every PUT re-upserts and
+// resets _ts. Mirrors .NET DeviceRegistrationDocument's 180-day TTL constant
+// (UK GDPR Art. 5(1)(e) storage limitation for device identifiers).
+const deviceTTLSeconds = 180 * 24 * 60 * 60
+
+// deviceDocument is the Cosmos persistence shape for a DeviceRegistration. The
+// JSON tags reproduce the camelCase keys the .NET CosmosDeviceRegistrationRepository
+// writes, so a Go-written document is byte-compatible with the existing
+// DeviceRegistrations container and an existing document hydrates here unchanged.
+//
+// Partition key: the container is partitioned by /userId and the document id is
+// the token, so every operation is a single-partition point operation keyed on
+// (userId, token).
+type deviceDocument struct {
+	ID           string              `json:"id"`
+	UserID       string              `json:"userId"`
+	Token        string              `json:"token"`
+	Platform     string              `json:"platform"`
+	RegisteredAt platform.DotNetTime `json:"registeredAt"`
+	TTL          int                 `json:"ttl"`
+}
+
+// newDeviceDocument maps a domain registration to its persistence shape. The
+// document id equals the token (the .NET FromDomain mapping); the partition key
+// is the user id, supplied separately to the store's upsert.
+func newDeviceDocument(r DeviceRegistration) deviceDocument {
+	return deviceDocument{
+		ID:           r.Token,
+		UserID:       r.UserID,
+		Token:        r.Token,
+		Platform:     r.Platform.String(),
+		RegisteredAt: platform.DotNetTime(r.RegisteredAt),
+		TTL:          deviceTTLSeconds,
+	}
+}
+
+// toDomain reconstitutes a domain registration from its stored document,
+// parsing the string platform (an unknown value is an error, matching .NET's
+// Enum.Parse).
+func (d deviceDocument) toDomain() (DeviceRegistration, error) {
+	platformValue, err := ParsePlatform(d.Platform)
+	if err != nil {
+		return DeviceRegistration{}, err
+	}
+	return DeviceRegistration{
+		UserID:       d.UserID,
+		Token:        d.Token,
+		Platform:     platformValue,
+		RegisteredAt: time.Time(d.RegisteredAt),
+	}, nil
+}

--- a/api-go/internal/devicetokens/document_test.go
+++ b/api-go/internal/devicetokens/document_test.go
@@ -1,0 +1,93 @@
+package devicetokens
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestDeviceDocument_WireShape pins the exact Cosmos document the .NET
+// CosmosDeviceRegistrationRepository writes: id == token, partition field
+// userId, token, the string platform, the +00:00 registeredAt, and the 180-day
+// TTL. A drift here would make a Go-written document incompatible with the
+// existing container and break the GDPR export contract.
+func TestDeviceDocument_WireShape(t *testing.T) {
+	t.Parallel()
+
+	reg := DeviceRegistration{
+		UserID:       "auth0|u1",
+		Token:        "tok-abc",
+		Platform:     PlatformIos,
+		RegisteredAt: time.Date(2026, 6, 12, 9, 30, 0, 0, time.UTC),
+	}
+
+	raw, err := json.Marshal(newDeviceDocument(reg))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	want := map[string]any{
+		"id":           "tok-abc",
+		"userId":       "auth0|u1",
+		"token":        "tok-abc",
+		"platform":     "Ios",
+		"registeredAt": "2026-06-12T09:30:00+00:00",
+		"ttl":          float64(180 * 24 * 60 * 60),
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Errorf("doc[%q] = %v (%T), want %v (%T)", k, got[k], got[k], v, v)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("doc has %d keys, want %d: %v", len(got), len(want), got)
+	}
+}
+
+// TestDeviceDocument_RoundTrip rehydrates a stored document back to the domain
+// value, including parsing the string platform.
+func TestDeviceDocument_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	reg := DeviceRegistration{
+		UserID:       "auth0|u1",
+		Token:        "tok-abc",
+		Platform:     PlatformAndroid,
+		RegisteredAt: time.Date(2026, 6, 12, 9, 30, 0, 0, time.UTC),
+	}
+	raw, err := json.Marshal(newDeviceDocument(reg))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var doc deviceDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	back, err := doc.toDomain()
+	if err != nil {
+		t.Fatalf("toDomain: %v", err)
+	}
+	if back.UserID != reg.UserID || back.Token != reg.Token || back.Platform != reg.Platform {
+		t.Errorf("round-trip mismatch: got %+v want %+v", back, reg)
+	}
+	if !back.RegisteredAt.Equal(reg.RegisteredAt) {
+		t.Errorf("RegisteredAt round-trip: got %v want %v", back.RegisteredAt, reg.RegisteredAt)
+	}
+}
+
+// TestDeviceDocument_RejectsUnknownPlatform mirrors .NET Enum.Parse throwing on
+// an unrecognised stored platform.
+func TestDeviceDocument_RejectsUnknownPlatform(t *testing.T) {
+	t.Parallel()
+
+	doc := deviceDocument{UserID: "u", Token: "t", Platform: "Windows"}
+	if _, err := doc.toDomain(); err == nil {
+		t.Error("toDomain with unknown platform: want error")
+	}
+}

--- a/api-go/internal/devicetokens/handler.go
+++ b/api-go/internal/devicetokens/handler.go
@@ -1,0 +1,102 @@
+package devicetokens
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+)
+
+// registrationStore is the consumer-side slice of the store the handlers use.
+// *CosmosStore satisfies it; tests substitute a hand-written fake.
+type registrationStore interface {
+	GetByToken(ctx context.Context, userID, token string) (*DeviceRegistration, error)
+	Save(ctx context.Context, reg DeviceRegistration) error
+	Delete(ctx context.Context, userID, token string) error
+}
+
+// registerRequest mirrors .NET RegisterDeviceTokenRequest. Platform arrives as
+// the string-enum form ("Ios"/"Android", bound case-insensitively).
+type registerRequest struct {
+	Token    string `json:"token"`
+	Platform string `json:"platform"`
+}
+
+// Routes registers the device-token endpoints on mux. Both are authenticated:
+// the auth middleware guarantees a subject in context before these run.
+func Routes(mux *http.ServeMux, store registrationStore, now func() time.Time, logger *slog.Logger) {
+	h := handler{store: store, now: now, logger: logger}
+	mux.HandleFunc("PUT /v1/me/device-token", h.register)
+	mux.HandleFunc("DELETE /v1/me/device-token/{token}", h.remove)
+}
+
+type handler struct {
+	store  registrationStore
+	now    func() time.Time
+	logger *slog.Logger
+}
+
+// register PUTs a device token: refresh the registration instant when the
+// (user, token) pair already exists, create it otherwise. 204 on success,
+// mirroring .NET RegisterDeviceToken -> Results.NoContent(). A malformed body
+// or unknown platform fails JSON binding in .NET and yields a bodyless 400
+// (backfilled by the error middleware) — reproduced here.
+func (h handler) register(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var req registerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	platform, err := ParsePlatform(req.Platform)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	reg, err := NewRegistration(userID, req.Token, platform, h.now())
+	if err != nil {
+		// .NET reaches the domain guard only after binding succeeds, so a blank
+		// token surfaces as an unhandled ArgumentException -> 500. Mirror the
+		// status; the Detail string is .NET-internal and not contract-pinned.
+		h.logger.ErrorContext(r.Context(), "register device token", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	existing, err := h.store.GetByToken(r.Context(), userID, req.Token)
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "read device token", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if existing != nil {
+		existing.Refresh(h.now())
+		reg = *existing
+	}
+	if err := h.store.Save(r.Context(), reg); err != nil {
+		h.logger.ErrorContext(r.Context(), "save device token", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// remove DELETEs a (user, token) registration. Idempotent: removing an absent
+// token still returns 204, mirroring .NET RemoveInvalidDeviceToken.
+func (h handler) remove(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+	token := r.PathValue("token")
+
+	if err := h.store.Delete(r.Context(), userID, token); err != nil {
+		h.logger.ErrorContext(r.Context(), "delete device token", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/api-go/internal/devicetokens/handler_test.go
+++ b/api-go/internal/devicetokens/handler_test.go
@@ -1,0 +1,152 @@
+package devicetokens
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+)
+
+type fakeRegStore struct {
+	regs    map[string]DeviceRegistration // keyed by userID + "|" + token
+	getErr  error
+	saveErr error
+	delErr  error
+}
+
+func newFakeRegStore() *fakeRegStore {
+	return &fakeRegStore{regs: map[string]DeviceRegistration{}}
+}
+
+func (f *fakeRegStore) GetByToken(_ context.Context, userID, token string) (*DeviceRegistration, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	reg, ok := f.regs[userID+"|"+token]
+	if !ok {
+		return nil, nil //nolint:nilnil // mirrors the store contract: absent is not an error
+	}
+	return &reg, nil
+}
+
+func (f *fakeRegStore) Save(_ context.Context, reg DeviceRegistration) error {
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	f.regs[reg.UserID+"|"+reg.Token] = reg
+	return nil
+}
+
+func (f *fakeRegStore) Delete(_ context.Context, userID, token string) error {
+	if f.delErr != nil {
+		return f.delErr
+	}
+	delete(f.regs, userID+"|"+token)
+	return nil
+}
+
+func testMux(t *testing.T, store registrationStore, now time.Time) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	Routes(mux, store, func() time.Time { return now }, slog.New(slog.DiscardHandler))
+	return mux
+}
+
+func doReq(t *testing.T, mux *http.ServeMux, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	req := httptest.NewRequestWithContext(auth.WithSubject(ctx, "auth0|dev1"), method, path, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHandler_Register(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 12, 8, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		body       string
+		wantStatus int
+	}{
+		{"valid ios", `{"token":"tok-1","platform":"ios"}`, http.StatusNoContent},
+		{"valid canonical case", `{"token":"tok-2","platform":"Android"}`, http.StatusNoContent},
+		{"unknown platform", `{"token":"tok-3","platform":"spectrum"}`, http.StatusBadRequest},
+		{"malformed json", `{"token":`, http.StatusBadRequest},
+		{"blank token reaches the domain guard", `{"token":" ","platform":"ios"}`, http.StatusInternalServerError},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := newFakeRegStore()
+			rec := doReq(t, testMux(t, store, now), http.MethodPut, "/v1/me/device-token", tc.body)
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d (body %s)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if rec.Code == http.StatusNoContent && rec.Body.Len() != 0 {
+				t.Errorf("204 must be bodyless, got %s", rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandler_Register_RefreshesExisting(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	refreshed := time.Date(2026, 6, 12, 8, 0, 0, 0, time.UTC)
+
+	store := newFakeRegStore()
+	store.regs["auth0|dev1|tok-1"] = DeviceRegistration{
+		UserID: "auth0|dev1", Token: "tok-1", Platform: PlatformIos, RegisteredAt: created,
+	}
+
+	rec := doReq(t, testMux(t, store, refreshed), http.MethodPut, "/v1/me/device-token", `{"token":"tok-1","platform":"ios"}`)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	got := store.regs["auth0|dev1|tok-1"]
+	if !got.RegisteredAt.Equal(refreshed) {
+		t.Errorf("RegisteredAt = %v, want refreshed %v", got.RegisteredAt, refreshed)
+	}
+}
+
+func TestHandler_Register_StoreFailure(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeRegStore()
+	store.saveErr = errors.New("cosmos down")
+	rec := doReq(t, testMux(t, store, time.Now()), http.MethodPut, "/v1/me/device-token", `{"token":"tok-1","platform":"ios"}`)
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", rec.Code)
+	}
+}
+
+func TestHandler_Remove(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeRegStore()
+	store.regs["auth0|dev1|tok-1"] = DeviceRegistration{UserID: "auth0|dev1", Token: "tok-1"}
+
+	rec := doReq(t, testMux(t, store, time.Now()), http.MethodDelete, "/v1/me/device-token/tok-1", "")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", rec.Code)
+	}
+	if _, ok := store.regs["auth0|dev1|tok-1"]; ok {
+		t.Error("registration should be removed")
+	}
+
+	// Idempotent: a second delete of the now-absent token is still 204.
+	rec = doReq(t, testMux(t, store, time.Now()), http.MethodDelete, "/v1/me/device-token/tok-1", "")
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("repeat delete status = %d, want 204", rec.Code)
+	}
+}

--- a/api-go/internal/devicetokens/registration.go
+++ b/api-go/internal/devicetokens/registration.go
@@ -1,0 +1,89 @@
+// Package devicetokens owns the device-token feature: the DeviceRegistration
+// domain value, its Cosmos document shape, the Cosmos store, and the
+// PUT/DELETE /v1/me/device-token HTTP handlers. It mirrors the .NET
+// TownCrier.{Domain,Application,Infrastructure}.DeviceRegistrations slice
+// (GH#418 iteration 4) but follows idiomatic Go: a plain struct validated at
+// construction, a consumer-side store interface, and hand-written test fakes.
+package devicetokens
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+// DevicePlatform enumerates the push platforms. The string forms ("Ios",
+// "Android") are the exact values the .NET DevicePlatform enum serialises to
+// (UseStringEnumConverter) and stores in Cosmos, so they are preserved here.
+type DevicePlatform int
+
+const (
+	// PlatformIos is Apple Push Notification service.
+	PlatformIos DevicePlatform = iota
+	// PlatformAndroid is Firebase Cloud Messaging.
+	PlatformAndroid
+)
+
+// String returns the canonical wire/storage form of the platform.
+func (p DevicePlatform) String() string {
+	switch p {
+	case PlatformIos:
+		return "Ios"
+	case PlatformAndroid:
+		return "Android"
+	default:
+		return "Ios"
+	}
+}
+
+// ErrUnknownPlatform is returned by ParsePlatform for an unrecognised value.
+var ErrUnknownPlatform = errors.New("unknown device platform")
+
+// ParsePlatform converts a wire/stored platform string to the enum. The match is
+// case-insensitive — the .NET System.Text.Json string-enum converter is
+// case-insensitive by default, so "ios" and "Ios" both bind on the inbound side.
+func ParsePlatform(s string) (DevicePlatform, error) {
+	switch {
+	case strings.EqualFold(s, "Ios"):
+		return PlatformIos, nil
+	case strings.EqualFold(s, "Android"):
+		return PlatformAndroid, nil
+	default:
+		return 0, ErrUnknownPlatform
+	}
+}
+
+// DeviceRegistration is one (user, token) push registration. Exported fields
+// keep it a plain Go value; the constructor enforces the only real invariants
+// (non-blank user id and token), matching .NET DeviceRegistration.Create.
+type DeviceRegistration struct {
+	UserID       string
+	Token        string
+	Platform     DevicePlatform
+	RegisteredAt time.Time
+}
+
+// NewRegistration builds a registration, rejecting a blank user id or token —
+// the same guard as .NET's ArgumentException.ThrowIfNullOrWhiteSpace.
+func NewRegistration(userID, token string, platform DevicePlatform, now time.Time) (DeviceRegistration, error) {
+	if strings.TrimSpace(userID) == "" {
+		return DeviceRegistration{}, errors.New("user id is required")
+	}
+	if strings.TrimSpace(token) == "" {
+		return DeviceRegistration{}, errors.New("token is required")
+	}
+	return DeviceRegistration{
+		UserID:       userID,
+		Token:        token,
+		Platform:     platform,
+		RegisteredAt: now,
+	}, nil
+}
+
+// Refresh stamps RegisteredAt to now unconditionally, mirroring .NET
+// RefreshRegistration: a re-PUT records the client's instant even when it is
+// earlier than the stored one (the client's clock is authoritative, and the
+// re-write resets the Cosmos TTL).
+func (r *DeviceRegistration) Refresh(now time.Time) {
+	r.RegisteredAt = now
+}

--- a/api-go/internal/devicetokens/registration_test.go
+++ b/api-go/internal/devicetokens/registration_test.go
@@ -1,0 +1,102 @@
+package devicetokens
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParsePlatform(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      string
+		want    DevicePlatform
+		wantErr bool
+	}{
+		{"ios canonical", "Ios", PlatformIos, false},
+		{"android canonical", "Android", PlatformAndroid, false},
+		{"ios lowercase", "ios", PlatformIos, false},
+		{"android mixed", "ANDROID", PlatformAndroid, false},
+		{"unknown", "windows", 0, true},
+		{"empty", "", 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParsePlatform(tc.in)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParsePlatform(%q): err=%v wantErr=%v", tc.in, err, tc.wantErr)
+			}
+			if err == nil && got != tc.want {
+				t.Errorf("ParsePlatform(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDevicePlatform_String pins the .NET enum names ("Ios"/"Android"), which are
+// both the stored Platform value and the UseStringEnumConverter export value.
+func TestDevicePlatform_String(t *testing.T) {
+	t.Parallel()
+
+	if got := PlatformIos.String(); got != "Ios" {
+		t.Errorf("PlatformIos.String() = %q, want Ios", got)
+	}
+	if got := PlatformAndroid.String(); got != "Android" {
+		t.Errorf("PlatformAndroid.String() = %q, want Android", got)
+	}
+}
+
+func TestNewRegistration(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC)
+
+	t.Run("valid", func(t *testing.T) {
+		t.Parallel()
+		reg, err := NewRegistration("auth0|u1", "tok-abc", PlatformIos, now)
+		if err != nil {
+			t.Fatalf("NewRegistration: %v", err)
+		}
+		if reg.UserID != "auth0|u1" || reg.Token != "tok-abc" || reg.Platform != PlatformIos {
+			t.Errorf("registration fields wrong: %+v", reg)
+		}
+		if !reg.RegisteredAt.Equal(now) {
+			t.Errorf("RegisteredAt = %v, want %v", reg.RegisteredAt, now)
+		}
+	})
+
+	for _, tc := range []struct {
+		name   string
+		userID string
+		token  string
+	}{
+		{"blank user", "  ", "tok"},
+		{"blank token", "auth0|u1", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := NewRegistration(tc.userID, tc.token, PlatformIos, now); err == nil {
+				t.Errorf("NewRegistration(%q,%q): want error", tc.userID, tc.token)
+			}
+		})
+	}
+}
+
+// TestRegistration_Refresh advances RegisteredAt unconditionally, mirroring
+// .NET DeviceRegistration.RefreshRegistration (a re-PUT stamps the new instant
+// even if it is earlier — the client's clock is authoritative).
+func TestRegistration_Refresh(t *testing.T) {
+	t.Parallel()
+
+	reg, err := NewRegistration("auth0|u1", "tok", PlatformIos, time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewRegistration: %v", err)
+	}
+	later := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	reg.Refresh(later)
+	if !reg.RegisteredAt.Equal(later) {
+		t.Errorf("RegisteredAt = %v, want %v", reg.RegisteredAt, later)
+	}
+}

--- a/api-go/internal/devicetokens/store_cosmos.go
+++ b/api-go/internal/devicetokens/store_cosmos.go
@@ -1,0 +1,118 @@
+package devicetokens
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// CosmosItems is the consumer-side slice of the DeviceRegistrations container
+// the store uses: single-partition point read/upsert/delete keyed on
+// (userId, token) plus a single-partition query for the per-user list the GDPR
+// export needs. Defining it here keeps azcosmos types out of the store's unit
+// tests, which substitute a hand-written fake. platform.CosmosContainer
+// satisfies it structurally.
+type CosmosItems interface {
+	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
+	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
+	DeleteItem(ctx context.Context, partitionKey, id string) error
+	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
+}
+
+// CosmosStore reads and writes device registrations in the DeviceRegistrations
+// container. It holds only the consumer-side item interface, so no SDK type
+// leaks past it.
+//
+// Partition strategy: the container is partitioned by /userId and the document
+// id is the token, so every operation is a single-partition point operation
+// keyed on (userId, token). The export's per-user list is a single-partition
+// query — never cross-partition.
+type CosmosStore struct {
+	items CosmosItems
+}
+
+// NewCosmosStore returns a store backed by the given Cosmos item accessor.
+func NewCosmosStore(items CosmosItems) *CosmosStore {
+	return &CosmosStore{items: items}
+}
+
+// GetByToken point-reads the registration for (userID, token). A missing
+// document returns (nil, nil) — the "not registered yet" signal the PUT handler
+// branches on, mirroring .NET's null return; any other failure is wrapped.
+func (s *CosmosStore) GetByToken(ctx context.Context, userID, token string) (*DeviceRegistration, error) {
+	raw, err := s.items.ReadItem(ctx, userID, token)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil //nolint:nilnil // absent registration is a valid "not found" signal, not an error
+		}
+		return nil, fmt.Errorf("read device token %q: %w", token, err)
+	}
+	var doc deviceDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("decode device token %q: %w", token, err)
+	}
+	reg, err := doc.toDomain()
+	if err != nil {
+		return nil, fmt.Errorf("hydrate device token %q: %w", token, err)
+	}
+	return &reg, nil
+}
+
+// Save upserts the registration document (partition key == user id, id == token).
+func (s *CosmosStore) Save(ctx context.Context, reg DeviceRegistration) error {
+	body, err := json.Marshal(newDeviceDocument(reg))
+	if err != nil {
+		return fmt.Errorf("encode device token %q: %w", reg.Token, err)
+	}
+	if err := s.items.UpsertItem(ctx, reg.UserID, body); err != nil {
+		return fmt.Errorf("upsert device token %q: %w", reg.Token, err)
+	}
+	return nil
+}
+
+// Delete removes the registration for (userID, token). A 404 is tolerated so the
+// operation is idempotent — the token may already be gone (prior call or TTL),
+// matching .NET DeleteByTokenAsync.
+func (s *CosmosStore) Delete(ctx context.Context, userID, token string) error {
+	if err := s.items.DeleteItem(ctx, userID, token); err != nil {
+		if isNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("delete device token %q: %w", token, err)
+	}
+	return nil
+}
+
+// ListByUser returns every registration in the user's partition, for the GDPR
+// export. Single-partition query keyed on the user id, mirroring .NET
+// GetByUserIdAsync.
+func (s *CosmosStore) ListByUser(ctx context.Context, userID string) ([]DeviceRegistration, error) {
+	const query = "SELECT * FROM c WHERE c.userId = @userId"
+	items, err := s.items.QueryItems(ctx, userID, query, map[string]any{"@userId": userID})
+	if err != nil {
+		return nil, fmt.Errorf("query device tokens for %q: %w", userID, err)
+	}
+	regs := make([]DeviceRegistration, 0, len(items))
+	for _, raw := range items {
+		var doc deviceDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("decode device token list for %q: %w", userID, err)
+		}
+		reg, err := doc.toDomain()
+		if err != nil {
+			return nil, fmt.Errorf("hydrate device token list for %q: %w", userID, err)
+		}
+		regs = append(regs, reg)
+	}
+	return regs, nil
+}
+
+// isNotFound reports whether err is a Cosmos 404 response.
+func isNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}

--- a/api-go/internal/devicetokens/store_cosmos_test.go
+++ b/api-go/internal/devicetokens/store_cosmos_test.go
@@ -1,0 +1,179 @@
+package devicetokens
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// fakeItems is an in-memory CosmosItems keyed by (partitionKey, id). It records
+// the last upsert partition key so tests can assert single-partition scoping.
+type fakeItems struct {
+	docs        map[string][]byte // key: partitionKey + "\x00" + id
+	upsertPart  string
+	upsertErr   error
+	deleteErr   error
+	readErr     error
+	queryErr    error
+	deleteCalls int
+}
+
+func newFakeItems() *fakeItems { return &fakeItems{docs: map[string][]byte{}} }
+
+func key(pk, id string) string { return pk + "\x00" + id }
+
+func (f *fakeItems) ReadItem(_ context.Context, pk, id string) ([]byte, error) {
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	raw, ok := f.docs[key(pk, id)]
+	if !ok {
+		return nil, notFound()
+	}
+	return raw, nil
+}
+
+func (f *fakeItems) UpsertItem(_ context.Context, pk string, item []byte) error {
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	f.upsertPart = pk
+	var doc struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(item, &doc)
+	f.docs[key(pk, doc.ID)] = item
+	return nil
+}
+
+func (f *fakeItems) DeleteItem(_ context.Context, pk, id string) error {
+	f.deleteCalls++
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	delete(f.docs, key(pk, id))
+	return nil
+}
+
+func (f *fakeItems) QueryItems(_ context.Context, pk, _ string, _ map[string]any) ([][]byte, error) {
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	var out [][]byte
+	prefix := pk + "\x00"
+	for k, v := range f.docs {
+		if len(k) >= len(prefix) && k[:len(prefix)] == prefix {
+			out = append(out, v)
+		}
+	}
+	return out, nil
+}
+
+func notFound() error { return &azcore.ResponseError{StatusCode: http.StatusNotFound} }
+
+func TestCosmosStore_SaveThenGetByToken(t *testing.T) {
+	t.Parallel()
+
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC)
+
+	reg, err := NewRegistration("auth0|u1", "tok-abc", PlatformIos, now)
+	if err != nil {
+		t.Fatalf("NewRegistration: %v", err)
+	}
+	if err := store.Save(ctx, reg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if items.upsertPart != "auth0|u1" {
+		t.Errorf("upsert partition = %q, want the user id", items.upsertPart)
+	}
+
+	got, err := store.GetByToken(ctx, "auth0|u1", "tok-abc")
+	if err != nil {
+		t.Fatalf("GetByToken: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetByToken: got nil, want the saved registration")
+	}
+	if got.Token != "tok-abc" || got.Platform != PlatformIos {
+		t.Errorf("GetByToken returned %+v", got)
+	}
+}
+
+// TestCosmosStore_GetByToken_Missing returns (nil, nil) for an absent token,
+// mirroring .NET's null return — the handler's existence check, not an error.
+func TestCosmosStore_GetByToken_Missing(t *testing.T) {
+	t.Parallel()
+
+	store := NewCosmosStore(newFakeItems())
+	got, err := store.GetByToken(context.Background(), "auth0|u1", "missing")
+	if err != nil {
+		t.Fatalf("GetByToken missing: got err %v, want nil", err)
+	}
+	if got != nil {
+		t.Errorf("GetByToken missing: got %+v, want nil", got)
+	}
+}
+
+// TestCosmosStore_Delete_Idempotent: a 404 on delete is tolerated (the token was
+// already removed by a prior call or the TTL), matching .NET's idempotent delete.
+func TestCosmosStore_Delete_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	items := newFakeItems()
+	items.deleteErr = notFound()
+	store := NewCosmosStore(items)
+
+	if err := store.Delete(context.Background(), "auth0|u1", "gone"); err != nil {
+		t.Errorf("Delete on absent token: got err %v, want nil (idempotent)", err)
+	}
+}
+
+// TestCosmosStore_Delete_PropagatesRealError: a non-404 delete failure is
+// surfaced, not swallowed.
+func TestCosmosStore_Delete_PropagatesRealError(t *testing.T) {
+	t.Parallel()
+
+	items := newFakeItems()
+	items.deleteErr = errors.New("cosmos down")
+	store := NewCosmosStore(items)
+
+	if err := store.Delete(context.Background(), "auth0|u1", "tok"); err == nil {
+		t.Error("Delete with a real failure: want error")
+	}
+}
+
+func TestCosmosStore_ListByUser(t *testing.T) {
+	t.Parallel()
+
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC)
+
+	for _, tok := range []string{"t1", "t2"} {
+		reg, _ := NewRegistration("auth0|u1", tok, PlatformIos, now)
+		if err := store.Save(ctx, reg); err != nil {
+			t.Fatalf("Save %s: %v", tok, err)
+		}
+	}
+	other, _ := NewRegistration("auth0|other", "t3", PlatformAndroid, now)
+	if err := store.Save(ctx, other); err != nil {
+		t.Fatalf("Save other: %v", err)
+	}
+
+	got, err := store.ListByUser(ctx, "auth0|u1")
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("ListByUser returned %d registrations, want 2", len(got))
+	}
+}

--- a/api-go/internal/notificationstate/document.go
+++ b/api-go/internal/notificationstate/document.go
@@ -1,0 +1,35 @@
+package notificationstate
+
+import (
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// stateDocument is the stored Cosmos shape, byte-compatible with the .NET
+// NotificationStateDocument: camelCase keys, userId doubling as id and
+// partition key (one document per user), lastReadAt in the .NET
+// DateTimeOffset wire format.
+type stateDocument struct {
+	ID         string              `json:"id"`
+	UserID     string              `json:"userId"`
+	LastReadAt platform.DotNetTime `json:"lastReadAt"`
+	Version    int                 `json:"version"`
+}
+
+func newStateDocument(s State) stateDocument {
+	return stateDocument{
+		ID:         s.UserID,
+		UserID:     s.UserID,
+		LastReadAt: platform.DotNetTime(s.LastReadAt),
+		Version:    s.Version,
+	}
+}
+
+func (d stateDocument) toDomain() State {
+	return State{
+		UserID:     d.UserID,
+		LastReadAt: time.Time(d.LastReadAt),
+		Version:    d.Version,
+	}
+}

--- a/api-go/internal/notificationstate/handler.go
+++ b/api-go/internal/notificationstate/handler.go
@@ -1,0 +1,192 @@
+package notificationstate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// stateStore is the consumer-side slice of the store the handlers use.
+// *CosmosStore satisfies it; tests substitute a hand-written fake.
+type stateStore interface {
+	Get(ctx context.Context, userID string) (*State, error)
+	Save(ctx context.Context, st State) error
+	UnreadCount(ctx context.Context, userID string, lastReadAt time.Time) (int, error)
+}
+
+// stateResult mirrors .NET GetNotificationStateResult via Results.Ok:
+// camelCase keys, lastReadAt in DateTimeOffset wire format.
+type stateResult struct {
+	LastReadAt       platform.DotNetTime `json:"lastReadAt"`
+	Version          int                 `json:"version"`
+	TotalUnreadCount int                 `json:"totalUnreadCount"`
+}
+
+// advanceRequest mirrors .NET AdvanceNotificationStateRequest.
+type advanceRequest struct {
+	AsOf platform.DotNetTime `json:"asOf"`
+}
+
+// Routes registers the notification-state endpoints on mux. All are
+// authenticated: the auth middleware guarantees a subject in context.
+func Routes(mux *http.ServeMux, store stateStore, now func() time.Time, logger *slog.Logger) {
+	h := handler{store: store, now: now, logger: logger}
+	mux.HandleFunc("GET /v1/me/notification-state", h.get)
+	mux.HandleFunc("POST /v1/me/notification-state/mark-all-read", h.markAllRead)
+	mux.HandleFunc("POST /v1/me/notification-state/advance", h.advance)
+}
+
+type handler struct {
+	store  stateStore
+	now    func() time.Time
+	logger *slog.Logger
+}
+
+// get loads the watermark — seeding and persisting a first-touch one at now,
+// so the unread count is zero by definition — then returns it with the unread
+// tally, mirroring GetNotificationStateQueryHandler.
+func (h handler) get(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+
+	st, err := h.store.Get(r.Context(), userID)
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "read notification state", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if st == nil {
+		seeded, err := NewState(userID, h.now())
+		if err != nil {
+			h.logger.ErrorContext(r.Context(), "seed notification state", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if err := h.store.Save(r.Context(), seeded); err != nil {
+			h.logger.ErrorContext(r.Context(), "persist seeded notification state", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		st = &seeded
+	}
+
+	unread, err := h.store.UnreadCount(r.Context(), userID, st.LastReadAt)
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "count unread notifications", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	h.writeJSON(w, r, stateResult{
+		LastReadAt:       platform.DotNetTime(st.LastReadAt),
+		Version:          st.Version,
+		TotalUnreadCount: unread,
+	})
+}
+
+// markAllRead moves the watermark to now. First-touch users get a fresh seed
+// (same end-state as create-then-mark, without the redundant version bump),
+// mirroring MarkAllNotificationsReadCommandHandler. 204 on success.
+func (h handler) markAllRead(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+	now := h.now()
+
+	st, err := h.store.Get(r.Context(), userID)
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "read notification state", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if st == nil {
+		seeded, err := NewState(userID, now)
+		if err != nil {
+			h.logger.ErrorContext(r.Context(), "seed notification state", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		st = &seeded
+	} else {
+		st.MarkAllReadAt(now)
+	}
+	if err := h.store.Save(r.Context(), *st); err != nil {
+		h.logger.ErrorContext(r.Context(), "save notification state", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// advance moves the watermark forward to the request's asOf. First-touch users
+// are seeded at now and the advance applied on top; for existing state a stale
+// asOf is a no-op without a write. Mirrors AdvanceNotificationStateCommandHandler.
+// 204 on success; a malformed body fails binding -> bodyless 400 like .NET.
+func (h handler) advance(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var req advanceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	asOf := time.Time(req.AsOf)
+
+	st, err := h.store.Get(r.Context(), userID)
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "read notification state", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if st == nil {
+		// First-touch: seed at now, attempt the advance, persist regardless so a
+		// subsequent GET sees the seed even when asOf was stale against it.
+		seeded, err := NewState(userID, h.now())
+		if err != nil {
+			h.logger.ErrorContext(r.Context(), "seed notification state", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		seeded.AdvanceTo(asOf)
+		if err := h.store.Save(r.Context(), seeded); err != nil {
+			h.logger.ErrorContext(r.Context(), "save notification state", "error", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	if !st.AdvanceTo(asOf) {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if err := h.store.Save(r.Context(), *st); err != nil {
+		h.logger.ErrorContext(r.Context(), "save notification state", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// writeJSON encodes compactly with HTML escaping off and the trailing newline
+// trimmed, matching the .NET Results.Ok wire bytes (same idiom as the legal and
+// profiles handlers).
+func (h handler) writeJSON(w http.ResponseWriter, r *http.Request, v any) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		h.logger.ErrorContext(r.Context(), "encode notification state", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if _, err := w.Write(bytes.TrimRight(buf.Bytes(), "\n")); err != nil {
+		h.logger.ErrorContext(r.Context(), "write notification state", "error", err)
+	}
+}

--- a/api-go/internal/notificationstate/handler_test.go
+++ b/api-go/internal/notificationstate/handler_test.go
@@ -1,0 +1,216 @@
+package notificationstate
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+)
+
+type fakeStateStore struct {
+	states  map[string]State
+	unread  int
+	getErr  error
+	saveErr error
+	cntErr  error
+}
+
+func newFakeStateStore() *fakeStateStore {
+	return &fakeStateStore{states: map[string]State{}}
+}
+
+func (f *fakeStateStore) Get(_ context.Context, userID string) (*State, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	st, ok := f.states[userID]
+	if !ok {
+		return nil, nil //nolint:nilnil // mirrors the store contract: absent is the first-touch signal
+	}
+	return &st, nil
+}
+
+func (f *fakeStateStore) Save(_ context.Context, st State) error {
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	f.states[st.UserID] = st
+	return nil
+}
+
+func (f *fakeStateStore) UnreadCount(_ context.Context, _ string, _ time.Time) (int, error) {
+	if f.cntErr != nil {
+		return 0, f.cntErr
+	}
+	return f.unread, nil
+}
+
+func testMux(t *testing.T, store stateStore, now time.Time) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	Routes(mux, store, func() time.Time { return now }, slog.New(slog.DiscardHandler))
+	return mux
+}
+
+func doReq(t *testing.T, mux *http.ServeMux, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	req := httptest.NewRequestWithContext(auth.WithSubject(ctx, "auth0|ns1"), method, path, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHandler_Get_ExistingState(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStateStore()
+	store.states["auth0|ns1"] = State{
+		UserID:     "auth0|ns1",
+		LastReadAt: time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+		Version:    3,
+	}
+	store.unread = 7
+
+	rec := doReq(t, testMux(t, store, time.Now()), http.MethodGet, "/v1/me/notification-state", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json; charset=utf-8" {
+		t.Errorf("content-type = %q", got)
+	}
+	// .NET DateTimeOffset wire format: numeric offset, never Z.
+	want := `{"lastReadAt":"2026-06-01T12:00:00+00:00","version":3,"totalUnreadCount":7}`
+	if rec.Body.String() != want {
+		t.Errorf("body = %s, want %s", rec.Body.String(), want)
+	}
+}
+
+func TestHandler_Get_FirstTouchSeedsAndPersists(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 12, 9, 30, 0, 0, time.UTC)
+	store := newFakeStateStore()
+
+	rec := doReq(t, testMux(t, store, now), http.MethodGet, "/v1/me/notification-state", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	want := `{"lastReadAt":"2026-06-12T09:30:00+00:00","version":1,"totalUnreadCount":0}`
+	if rec.Body.String() != want {
+		t.Errorf("body = %s, want %s", rec.Body.String(), want)
+	}
+	// The seed must persist so subsequent reads are idempotent.
+	if st, ok := store.states["auth0|ns1"]; !ok || st.Version != 1 || !st.LastReadAt.Equal(now) {
+		t.Errorf("seed not persisted: %+v", store.states)
+	}
+}
+
+func TestHandler_MarkAllRead(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+
+	t.Run("existing state bumps version", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+		store.states["auth0|ns1"] = State{UserID: "auth0|ns1", LastReadAt: now.Add(-time.Hour), Version: 2}
+
+		rec := doReq(t, testMux(t, store, now), http.MethodPost, "/v1/me/notification-state/mark-all-read", "")
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", rec.Code)
+		}
+		st := store.states["auth0|ns1"]
+		if !st.LastReadAt.Equal(now) || st.Version != 3 {
+			t.Errorf("state = %+v, want lastReadAt=now version=3", st)
+		}
+	})
+
+	t.Run("first touch seeds without extra bump", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+
+		rec := doReq(t, testMux(t, store, now), http.MethodPost, "/v1/me/notification-state/mark-all-read", "")
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", rec.Code)
+		}
+		st := store.states["auth0|ns1"]
+		if !st.LastReadAt.Equal(now) || st.Version != 1 {
+			t.Errorf("state = %+v, want seeded version=1", st)
+		}
+	})
+}
+
+func TestHandler_Advance(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
+	baseline := State{UserID: "auth0|ns1", LastReadAt: now.Add(-time.Hour), Version: 2}
+
+	tests := []struct {
+		name        string
+		body        string
+		wantStatus  int
+		wantVersion int
+	}{
+		{"forward advance bumps", `{"asOf":"2026-06-12T09:45:00+00:00"}`, http.StatusNoContent, 3},
+		{"stale asOf is a no-op", `{"asOf":"2026-06-12T08:00:00+00:00"}`, http.StatusNoContent, 2},
+		{"boundary instant is a no-op", `{"asOf":"2026-06-12T09:00:00+00:00"}`, http.StatusNoContent, 2},
+		{"Z suffix accepted on input", `{"asOf":"2026-06-12T09:50:00Z"}`, http.StatusNoContent, 3},
+		{"malformed body", `{"asOf":`, http.StatusBadRequest, 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := newFakeStateStore()
+			store.states["auth0|ns1"] = baseline
+
+			rec := doReq(t, testMux(t, store, now), http.MethodPost, "/v1/me/notification-state/advance", tc.body)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if got := store.states["auth0|ns1"].Version; got != tc.wantVersion {
+				t.Errorf("version = %d, want %d", got, tc.wantVersion)
+			}
+		})
+	}
+
+	t.Run("first touch seeds at now then advances", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+
+		// asOf earlier than the seed: persists the seed untouched (version 1).
+		rec := doReq(t, testMux(t, store, now), http.MethodPost, "/v1/me/notification-state/advance", `{"asOf":"2020-01-01T00:00:00+00:00"}`)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", rec.Code)
+		}
+		st := store.states["auth0|ns1"]
+		if !st.LastReadAt.Equal(now) || st.Version != 1 {
+			t.Errorf("state = %+v, want seed at now version=1", st)
+		}
+	})
+}
+
+func TestHandler_StoreFailures(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStateStore()
+	store.getErr = errors.New("cosmos down")
+	for _, tc := range []struct{ method, path, body string }{
+		{http.MethodGet, "/v1/me/notification-state", ""},
+		{http.MethodPost, "/v1/me/notification-state/mark-all-read", ""},
+		{http.MethodPost, "/v1/me/notification-state/advance", `{"asOf":"2026-06-12T09:45:00+00:00"}`},
+	} {
+		rec := doReq(t, testMux(t, store, time.Now()), tc.method, tc.path, tc.body)
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("%s %s status = %d, want 500", tc.method, tc.path, rec.Code)
+		}
+	}
+}

--- a/api-go/internal/notificationstate/state.go
+++ b/api-go/internal/notificationstate/state.go
@@ -1,0 +1,51 @@
+// Package notificationstate owns the per-user read-watermark feature: the
+// State domain value, its Cosmos document shape, the store (watermark document
+// + unread count over the Notifications container), and the
+// GET/mark-all-read/advance HTTP handlers. It mirrors the .NET
+// TownCrier.{Domain,Application,Infrastructure}.NotificationState slice
+// (GH#418 iteration 4).
+package notificationstate
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+// State is one user's notification read watermark. It mirrors the .NET
+// NotificationStateAggregate: LastReadAt is the cutoff (notifications created
+// at exactly that instant count as read), Version increments on every change.
+type State struct {
+	UserID     string
+	LastReadAt time.Time
+	Version    int
+}
+
+// NewState seeds a first-touch watermark at the given instant with version 1,
+// matching NotificationStateAggregate.Create: all existing notifications count
+// as already read ("clean slate", spec pre-resolved decision #13).
+func NewState(userID string, lastReadAt time.Time) (State, error) {
+	if strings.TrimSpace(userID) == "" {
+		return State{}, errors.New("user id is required")
+	}
+	return State{UserID: userID, LastReadAt: lastReadAt, Version: 1}, nil
+}
+
+// MarkAllReadAt moves the watermark to now unconditionally and bumps the
+// version, mirroring MarkAllReadAt.
+func (s *State) MarkAllReadAt(now time.Time) {
+	s.LastReadAt = now
+	s.Version++
+}
+
+// AdvanceTo moves the watermark forward to asOf, reporting whether anything
+// changed. A stale asOf (<= the current watermark) is a no-op returning false,
+// mirroring AdvanceTo's redundant-write guard.
+func (s *State) AdvanceTo(asOf time.Time) bool {
+	if !asOf.After(s.LastReadAt) {
+		return false
+	}
+	s.LastReadAt = asOf
+	s.Version++
+	return true
+}

--- a/api-go/internal/notificationstate/store_cosmos.go
+++ b/api-go/internal/notificationstate/store_cosmos.go
@@ -1,0 +1,93 @@
+package notificationstate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// CosmosItems is the consumer-side slice of the NotificationState container the
+// store uses: point read/upsert keyed on the user id (one document per user,
+// id == partition key). platform.CosmosContainer satisfies it structurally.
+type CosmosItems interface {
+	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
+	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
+}
+
+// CosmosCounter is the consumer-side slice of the Notifications container the
+// store uses: a single-partition scalar COUNT query for the unread tally.
+type CosmosCounter interface {
+	CountItems(ctx context.Context, partitionKey, query string, params map[string]any) (int, error)
+}
+
+// CosmosStore reads and writes the per-user watermark in the NotificationState
+// container and derives the unread count from the Notifications container.
+type CosmosStore struct {
+	state         CosmosItems
+	notifications CosmosCounter
+}
+
+// NewCosmosStore returns a store over the two container accessors.
+func NewCosmosStore(state CosmosItems, notifications CosmosCounter) *CosmosStore {
+	return &CosmosStore{state: state, notifications: notifications}
+}
+
+// Get point-reads the user's watermark. A missing document returns (nil, nil) —
+// the first-touch signal the handlers branch on, mirroring .NET's null return.
+func (s *CosmosStore) Get(ctx context.Context, userID string) (*State, error) {
+	raw, err := s.state.ReadItem(ctx, userID, userID)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, nil //nolint:nilnil // absent watermark is the first-touch signal, not an error
+		}
+		return nil, fmt.Errorf("read notification state %q: %w", userID, err)
+	}
+	var doc stateDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("decode notification state %q: %w", userID, err)
+	}
+	st := doc.toDomain()
+	return &st, nil
+}
+
+// Save upserts the watermark document.
+func (s *CosmosStore) Save(ctx context.Context, st State) error {
+	body, err := json.Marshal(newStateDocument(st))
+	if err != nil {
+		return fmt.Errorf("encode notification state %q: %w", st.UserID, err)
+	}
+	if err := s.state.UpsertItem(ctx, st.UserID, body); err != nil {
+		return fmt.Errorf("upsert notification state %q: %w", st.UserID, err)
+	}
+	return nil
+}
+
+// UnreadCount counts the user's notifications created strictly after the
+// watermark (the boundary instant itself counts as read), mirroring .NET
+// GetUnreadCountAsync. The parameter is passed in the .NET DateTimeOffset
+// string form so Cosmos's lexicographic string comparison lines up with the
+// "+00:00"-formatted createdAt values .NET writes.
+func (s *CosmosStore) UnreadCount(ctx context.Context, userID string, lastReadAt time.Time) (int, error) {
+	const query = "SELECT VALUE COUNT(1) FROM c WHERE c.userId = @userId AND c.createdAt > @lastReadAt"
+	count, err := s.notifications.CountItems(ctx, userID, query, map[string]any{
+		"@userId":     userID,
+		"@lastReadAt": platform.DotNetTime(lastReadAt).String(),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("count unread for %q: %w", userID, err)
+	}
+	return count, nil
+}
+
+// isNotFound reports whether err is a Cosmos 404 response.
+func isNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}

--- a/api-go/internal/notificationstate/store_cosmos_test.go
+++ b/api-go/internal/notificationstate/store_cosmos_test.go
@@ -1,0 +1,97 @@
+package notificationstate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+type fakeItems struct {
+	docs map[string][]byte
+}
+
+func (f *fakeItems) ReadItem(_ context.Context, _, id string) ([]byte, error) {
+	raw, ok := f.docs[id]
+	if !ok {
+		return nil, &azcore.ResponseError{StatusCode: http.StatusNotFound}
+	}
+	return raw, nil
+}
+
+func (f *fakeItems) UpsertItem(_ context.Context, _ string, item []byte) error {
+	if f.docs == nil {
+		f.docs = map[string][]byte{}
+	}
+	f.docs[idOf(item)] = item
+	return nil
+}
+
+func idOf(raw []byte) string {
+	var doc stateDocument
+	_ = json.Unmarshal(raw, &doc)
+	return doc.ID
+}
+
+type fakeCounter struct {
+	count     int
+	lastQuery string
+	params    map[string]any
+}
+
+func (f *fakeCounter) CountItems(_ context.Context, _, query string, params map[string]any) (int, error) {
+	f.lastQuery = query
+	f.params = params
+	return f.count, nil
+}
+
+func TestCosmosStore_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	items := &fakeItems{}
+	store := NewCosmosStore(items, &fakeCounter{})
+
+	missing, err := store.Get(context.Background(), "auth0|s1")
+	if err != nil || missing != nil {
+		t.Fatalf("missing state: got (%v, %v), want (nil, nil)", missing, err)
+	}
+
+	st := State{UserID: "auth0|s1", LastReadAt: time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC), Version: 4}
+	if err := store.Save(context.Background(), st); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// Stored shape pins the .NET document contract.
+	want := `{"id":"auth0|s1","userId":"auth0|s1","lastReadAt":"2026-06-12T09:00:00+00:00","version":4}`
+	if got := string(items.docs["auth0|s1"]); got != want {
+		t.Errorf("stored doc = %s, want %s", got, want)
+	}
+
+	loaded, err := store.Get(context.Background(), "auth0|s1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if loaded.Version != 4 || !loaded.LastReadAt.Equal(st.LastReadAt) {
+		t.Errorf("loaded = %+v, want %+v", loaded, st)
+	}
+}
+
+func TestCosmosStore_UnreadCount_CutoffFormat(t *testing.T) {
+	t.Parallel()
+
+	counter := &fakeCounter{count: 5}
+	store := NewCosmosStore(&fakeItems{}, counter)
+
+	got, err := store.UnreadCount(context.Background(), "auth0|s1",
+		time.Date(2026, 6, 12, 9, 0, 0, 0, time.UTC))
+	if err != nil || got != 5 {
+		t.Fatalf("count: got (%d, %v), want (5, nil)", got, err)
+	}
+	// The cutoff parameter must use the .NET DateTimeOffset string form so the
+	// lexicographic comparison against .NET-written createdAt values holds.
+	if cutoff := counter.params["@lastReadAt"]; cutoff != "2026-06-12T09:00:00+00:00" {
+		t.Errorf("cutoff param = %v, want +00:00 form", cutoff)
+	}
+}

--- a/api-go/internal/platform/cosmos.go
+++ b/api-go/internal/platform/cosmos.go
@@ -2,6 +2,7 @@ package platform
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"time"
@@ -48,8 +49,17 @@ type CosmosContainer struct {
 // routes are then simply unwired). The SDK opens connections lazily on first
 // call, preserving cold-start latency.
 func NewCosmosContainer(cfg Config, logger *slog.Logger) (*CosmosContainer, error) {
+	return NewCosmosContainerNamed(cfg, cosmosUsersContainer, logger)
+}
+
+// NewCosmosContainerNamed is NewCosmosContainer for an arbitrary container in
+// the same database — the it4 DeviceRegistrations / NotificationState /
+// Notifications stores reuse the same pinned-identity client wiring as Users.
+// An empty endpoint short-circuits to a nil container so the routes that depend
+// on it stay unwired until infra provisions Cosmos.
+func NewCosmosContainerNamed(cfg Config, name string, logger *slog.Logger) (*CosmosContainer, error) {
 	if cfg.CosmosEndpoint == "" {
-		logger.Warn("cosmos endpoint unset; profile routes unavailable")
+		logger.Warn("cosmos endpoint unset; container routes unavailable", "container", name)
 		return nil, nil //nolint:nilnil // absent config is a valid "no container" state, not an error
 	}
 
@@ -69,16 +79,28 @@ func NewCosmosContainer(cfg Config, logger *slog.Logger) (*CosmosContainer, erro
 		return nil, fmt.Errorf("build cosmos client: %w", err)
 	}
 
-	container, err := client.NewContainer(cfg.CosmosDatabase, cosmosUsersContainer)
+	container, err := client.NewContainer(cfg.CosmosDatabase, name)
 	if err != nil {
-		return nil, fmt.Errorf("open container %q: %w", cosmosUsersContainer, err)
+		return nil, fmt.Errorf("open container %q: %w", name, err)
 	}
 	return &CosmosContainer{container: container}, nil
 }
 
-// cosmosUsersContainer is the Users container name, matching the .NET
-// CosmosContainerNames.Users.
-const cosmosUsersContainer = "Users"
+// Cosmos container names mirror the .NET CosmosContainerNames constants so the
+// Go stores target the exact same physical containers the .NET API reads and
+// writes.
+const (
+	cosmosUsersContainer = "Users"
+	// CosmosDeviceRegistrationsContainer holds one document per (user, token);
+	// partition key /userId, document id == token.
+	CosmosDeviceRegistrationsContainer = "DeviceRegistrations"
+	// CosmosNotificationStateContainer holds one watermark document per user;
+	// partition key /userId, document id == userId.
+	CosmosNotificationStateContainer = "NotificationState"
+	// CosmosNotificationsContainer holds dispatched notifications; partition key
+	// /userId. Read-only here for the unread COUNT query.
+	CosmosNotificationsContainer = "Notifications"
+)
 
 // ReadItem point-reads the document with the given id from its partition.
 func (c *CosmosContainer) ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error) {
@@ -99,4 +121,53 @@ func (c *CosmosContainer) UpsertItem(ctx context.Context, partitionKey string, i
 func (c *CosmosContainer) DeleteItem(ctx context.Context, partitionKey, id string) error {
 	_, err := c.container.DeleteItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), id, nil)
 	return err
+}
+
+// QueryItems runs a single-partition parametrised query and returns the raw
+// document bodies. The query must already be scoped to partitionKey (the SDK
+// targets that logical partition), so it never fans out cross-partition. params
+// binds @name placeholders.
+func (c *CosmosContainer) QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error) {
+	opts := &azcosmos.QueryOptions{QueryParameters: queryParams(params)}
+	pager := c.container.NewQueryItemsPager(query, azcosmos.NewPartitionKeyString(partitionKey), opts)
+	var items [][]byte
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, page.Items...)
+	}
+	return items, nil
+}
+
+// CountItems runs a SELECT VALUE COUNT(1) scalar query in a single partition and
+// returns the integer result, mirroring .NET's ScalarQueryAsync<int>. An empty
+// result set (no rows match) yields 0.
+func (c *CosmosContainer) CountItems(ctx context.Context, partitionKey, query string, params map[string]any) (int, error) {
+	items, err := c.QueryItems(ctx, partitionKey, query, params)
+	if err != nil {
+		return 0, err
+	}
+	if len(items) == 0 {
+		return 0, nil
+	}
+	var count int
+	if err := json.Unmarshal(items[0], &count); err != nil {
+		return 0, fmt.Errorf("decode scalar count: %w", err)
+	}
+	return count, nil
+}
+
+// queryParams converts a name/value map into the SDK's parameter slice. The
+// map's iteration order is irrelevant — Cosmos binds by @name, not position.
+func queryParams(params map[string]any) []azcosmos.QueryParameter {
+	if len(params) == 0 {
+		return nil
+	}
+	out := make([]azcosmos.QueryParameter, 0, len(params))
+	for name, value := range params {
+		out = append(out, azcosmos.QueryParameter{Name: name, Value: value})
+	}
+	return out
 }

--- a/api-go/internal/platform/cosmos_test.go
+++ b/api-go/internal/platform/cosmos_test.go
@@ -42,3 +42,36 @@ func TestNewCosmosContainer_RequiresConfig(t *testing.T) {
 		t.Errorf("NewCosmosContainer with no endpoint: got %v, want nil container", container)
 	}
 }
+
+func TestNewCosmosContainerNamed_RequiresConfig(t *testing.T) {
+	t.Parallel()
+
+	// The named-container factory shares the no-endpoint short-circuit so the
+	// it4 device-token / notification-state containers are simply unwired when
+	// Cosmos env is absent, exactly like the Users container.
+	cfg := Config{CosmosEndpoint: "", CosmosDatabase: "town-crier", AzureClientID: "id"}
+	container, err := NewCosmosContainerNamed(cfg, "DeviceRegistrations", slog.New(slog.DiscardHandler))
+	if err != nil {
+		t.Fatalf("NewCosmosContainerNamed with no endpoint: got err %v, want nil", err)
+	}
+	if container != nil {
+		t.Errorf("NewCosmosContainerNamed with no endpoint: got %v, want nil container", container)
+	}
+}
+
+func TestCosmosContainerNames_MirrorDotNet(t *testing.T) {
+	t.Parallel()
+
+	// These constants mirror .NET CosmosContainerNames; the device-token and
+	// notification-state stores read them so a typo here would silently target
+	// the wrong container.
+	if CosmosDeviceRegistrationsContainer != "DeviceRegistrations" {
+		t.Errorf("DeviceRegistrations container = %q", CosmosDeviceRegistrationsContainer)
+	}
+	if CosmosNotificationStateContainer != "NotificationState" {
+		t.Errorf("NotificationState container = %q", CosmosNotificationStateContainer)
+	}
+	if CosmosNotificationsContainer != "Notifications" {
+		t.Errorf("Notifications container = %q", CosmosNotificationsContainer)
+	}
+}

--- a/api-go/internal/platform/dotnettime.go
+++ b/api-go/internal/platform/dotnettime.go
@@ -14,9 +14,16 @@ import (
 // use this type so the contract-diff harness sees byte-identical timestamps.
 type DotNetTime time.Time
 
+// String renders the instant in the .NET DateTimeOffset wire format. Exposed
+// for Cosmos query parameters, where the comparison against stored
+// "+00:00"-formatted strings is lexicographic and must use the same layout.
+func (t DotNetTime) String() string {
+	return time.Time(t).Format("2006-01-02T15:04:05.9999999-07:00")
+}
+
 // MarshalJSON renders the instant in the .NET DateTimeOffset wire format.
 func (t DotNetTime) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.9999999-07:00") + `"`), nil
+	return []byte(`"` + t.String() + `"`), nil
 }
 
 // UnmarshalJSON parses a stored timestamp, accepting both the .NET "+00:00"

--- a/api-go/internal/platform/dotnettime.go
+++ b/api-go/internal/platform/dotnettime.go
@@ -1,0 +1,26 @@
+package platform
+
+import "time"
+
+// DotNetTime marshals like System.Text.Json's DateTimeOffset: ISO 8601 with a
+// numeric UTC offset ("2099-12-31T00:00:00+00:00"), never Go's RFC 3339 "Z"
+// suffix; fractional seconds appear only when non-zero, trailing zeros trimmed —
+// the same trimming STJ applies. Cosmos documents and wire responses that carry
+// a .NET DateTimeOffset (device RegisteredAt, notification-state LastReadAt) must
+// use this type so the contract-diff harness sees byte-identical timestamps.
+type DotNetTime time.Time
+
+// MarshalJSON renders the instant in the .NET DateTimeOffset wire format.
+func (t DotNetTime) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.9999999-07:00") + `"`), nil
+}
+
+// DotNetTimePtr converts an optional time, preserving nil so an absent value
+// serialises as null rather than a zero instant.
+func DotNetTimePtr(t *time.Time) *DotNetTime {
+	if t == nil {
+		return nil
+	}
+	dt := DotNetTime(*t)
+	return &dt
+}

--- a/api-go/internal/platform/dotnettime.go
+++ b/api-go/internal/platform/dotnettime.go
@@ -1,6 +1,10 @@
 package platform
 
-import "time"
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
 
 // DotNetTime marshals like System.Text.Json's DateTimeOffset: ISO 8601 with a
 // numeric UTC offset ("2099-12-31T00:00:00+00:00"), never Go's RFC 3339 "Z"
@@ -13,6 +17,22 @@ type DotNetTime time.Time
 // MarshalJSON renders the instant in the .NET DateTimeOffset wire format.
 func (t DotNetTime) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.9999999-07:00") + `"`), nil
+}
+
+// UnmarshalJSON parses a stored timestamp, accepting both the .NET "+00:00"
+// offset form this type writes and the RFC 3339 "Z" form, so a Cosmos document
+// written by either implementation hydrates correctly.
+func (t *DotNetTime) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, s)
+	if err != nil {
+		return fmt.Errorf("parse dotnet time %q: %w", s, err)
+	}
+	*t = DotNetTime(parsed)
+	return nil
 }
 
 // DotNetTimePtr converts an optional time, preserving nil so an absent value

--- a/api-go/internal/platform/dotnettime_test.go
+++ b/api-go/internal/platform/dotnettime_test.go
@@ -1,0 +1,72 @@
+package platform
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestDotNetTime_WireFormat pins the exact System.Text.Json DateTimeOffset wire
+// shape: ISO 8601 with a numeric UTC offset ("+00:00"), never Go's RFC 3339 "Z"
+// suffix, with trailing fractional zeros trimmed. Every Cosmos timestamp the Go
+// API writes or returns must match this so the contract-diff harness passes.
+func TestDotNetTime_WireFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   time.Time
+		want string
+	}{
+		{
+			name: "whole second UTC",
+			in:   time.Date(2026, 6, 12, 9, 30, 0, 0, time.UTC),
+			want: `"2026-06-12T09:30:00+00:00"`,
+		},
+		{
+			name: "far future expiry",
+			in:   time.Date(2099, 12, 31, 0, 0, 0, 0, time.UTC),
+			want: `"2099-12-31T00:00:00+00:00"`,
+		},
+		{
+			name: "fractional seconds trimmed",
+			in:   time.Date(2026, 6, 12, 9, 30, 0, 123400000, time.UTC),
+			want: `"2026-06-12T09:30:00.1234+00:00"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := json.Marshal(DotNetTime(tc.in))
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if string(got) != tc.want {
+				t.Errorf("wire format: got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDotNetTimePtr preserves nil so an absent timestamp serialises as null,
+// not a zero instant.
+func TestDotNetTimePtr(t *testing.T) {
+	t.Parallel()
+
+	if got := DotNetTimePtr(nil); got != nil {
+		t.Errorf("DotNetTimePtr(nil): got %v, want nil", got)
+	}
+
+	ts := time.Date(2026, 6, 12, 9, 30, 0, 0, time.UTC)
+	got := DotNetTimePtr(&ts)
+	if got == nil {
+		t.Fatal("DotNetTimePtr(&ts): got nil, want value")
+	}
+	raw, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if want := `"2026-06-12T09:30:00+00:00"`; string(raw) != want {
+		t.Errorf("wire format: got %s, want %s", raw, want)
+	}
+}

--- a/api-go/internal/platform/dotnettime_test.go
+++ b/api-go/internal/platform/dotnettime_test.go
@@ -48,6 +48,36 @@ func TestDotNetTime_WireFormat(t *testing.T) {
 	}
 }
 
+// TestDotNetTime_RoundTrip confirms a value survives marshal then unmarshal, so
+// stored Cosmos documents carrying a DotNetTime hydrate back to the same
+// instant. The unmarshal side accepts both the "+00:00" .NET form and Go's "Z"
+// form so legacy documents parse too.
+func TestDotNetTime_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, in := range []string{
+		`"2026-06-12T09:30:00+00:00"`,
+		`"2026-06-12T09:30:00Z"`,
+		`"2026-06-12T09:30:00.1234+00:00"`,
+	} {
+		var dt DotNetTime
+		if err := json.Unmarshal([]byte(in), &dt); err != nil {
+			t.Fatalf("unmarshal %s: %v", in, err)
+		}
+		out, err := json.Marshal(dt)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if !time.Time(dt).Equal(time.Date(2026, 6, 12, 9, 30, 0, time.Time(dt).Nanosecond(), time.UTC)) {
+			t.Errorf("unmarshal %s parsed to %v", in, time.Time(dt))
+		}
+		// Marshalling always normalises to the +00:00 .NET form.
+		if got := string(out); got[len(got)-7:len(got)-1] != "+00:00" {
+			t.Errorf("re-marshal of %s = %s, want +00:00 offset", in, out)
+		}
+	}
+}
+
 // TestDotNetTimePtr preserves nil so an absent timestamp serialises as null,
 // not a zero instant.
 func TestDotNetTimePtr(t *testing.T) {

--- a/api-go/tests/e2e/contract_devices_state_test.go
+++ b/api-go/tests/e2e/contract_devices_state_test.go
@@ -1,0 +1,168 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// Iteration-4 contract scenarios: device tokens and notification state. All
+// scenarios are sequenced to leave the shared integration-test user's data as
+// they found it (the PUT/DELETE pair restores the device-token set; the
+// notification-state writes only move the user's own watermark, which the
+// .NET-side state was already moving on every mark-all-read in normal app use).
+
+// TestContract_DeviceTokenLifecycle diffs the PUT -> DELETE round trip. The
+// .NET call runs first (create), the Go call second (refresh of the same
+// token) — both must answer an identical bodyless 204. The DELETE pair then
+// diffs remove (on .NET) against idempotent re-remove (on Go), also 204s.
+func TestContract_DeviceTokenLifecycle(t *testing.T) {
+	dotnetURL := baseURL(t, "DOTNET_BASE_URL")
+	goURL := baseURL(t, "GO_BASE_URL")
+	token := integrationToken(t)
+	client := &http.Client{Timeout: requestTimeout}
+
+	const body = `{"token":"contract-test-token-it4","platform":"ios"}`
+
+	t.Run("PUT registers", func(t *testing.T) {
+		want := authedBodyRequest(t, client, dotnetURL, http.MethodPut, "/v1/me/device-token", token, body)
+		got := authedBodyRequest(t, client, goURL, http.MethodPut, "/v1/me/device-token", token, body)
+		diffAuthedShort(t, got, want)
+	})
+
+	t.Run("PUT rejects unknown platform", func(t *testing.T) {
+		const bad = `{"token":"contract-test-token-it4","platform":"spectrum"}`
+		want := authedBodyRequest(t, client, dotnetURL, http.MethodPut, "/v1/me/device-token", token, bad)
+		got := authedBodyRequest(t, client, goURL, http.MethodPut, "/v1/me/device-token", token, bad)
+		diffAuthedShort(t, got, want)
+	})
+
+	t.Run("DELETE removes idempotently", func(t *testing.T) {
+		want := authedRequest(t, client, dotnetURL, http.MethodDelete, "/v1/me/device-token/contract-test-token-it4", token)
+		got := authedRequest(t, client, goURL, http.MethodDelete, "/v1/me/device-token/contract-test-token-it4", token)
+		diffAuthedShort(t, got, want)
+	})
+}
+
+// TestContract_NotificationState diffs the read-watermark surface. The
+// sequencing keeps every diffed call state-deterministic: an un-diffed .NET GET
+// seeds the first-touch document if needed; mark-all-read responses are
+// bodyless on both sides regardless of the watermark value; the advance uses a
+// fixed past instant so it is a no-op against both implementations; and the
+// trailing GETs read whatever the latest write left, identically for both.
+func TestContract_NotificationState(t *testing.T) {
+	dotnetURL := baseURL(t, "DOTNET_BASE_URL")
+	goURL := baseURL(t, "GO_BASE_URL")
+	token := integrationToken(t)
+	client := &http.Client{Timeout: requestTimeout}
+
+	// Seed, not a diff: guarantee the watermark document exists so neither
+	// diffed GET takes the first-touch write path at a different instant.
+	_ = authedRequest(t, client, dotnetURL, http.MethodGet, "/v1/me/notification-state", token)
+
+	diffState := func(t *testing.T) {
+		t.Helper()
+		want := authedRequest(t, client, dotnetURL, http.MethodGet, "/v1/me/notification-state", token)
+		got := authedRequest(t, client, goURL, http.MethodGet, "/v1/me/notification-state", token)
+		diffAuthedShort(t, got, want)
+	}
+
+	t.Run("GET state", diffState)
+
+	t.Run("POST mark-all-read", func(t *testing.T) {
+		want := authedBodyRequest(t, client, dotnetURL, http.MethodPost, "/v1/me/notification-state/mark-all-read", token, "")
+		got := authedBodyRequest(t, client, goURL, http.MethodPost, "/v1/me/notification-state/mark-all-read", token, "")
+		diffAuthedShort(t, got, want)
+	})
+
+	t.Run("GET state after mark-all-read", diffState)
+
+	t.Run("POST advance with stale asOf is a no-op", func(t *testing.T) {
+		const body = `{"asOf":"2020-01-01T00:00:00+00:00"}`
+		want := authedBodyRequest(t, client, dotnetURL, http.MethodPost, "/v1/me/notification-state/advance", token, body)
+		got := authedBodyRequest(t, client, goURL, http.MethodPost, "/v1/me/notification-state/advance", token, body)
+		diffAuthedShort(t, got, want)
+	})
+
+	t.Run("POST advance rejects malformed body", func(t *testing.T) {
+		const body = `{"asOf":`
+		want := authedBodyRequest(t, client, dotnetURL, http.MethodPost, "/v1/me/notification-state/advance", token, body)
+		got := authedBodyRequest(t, client, goURL, http.MethodPost, "/v1/me/notification-state/advance", token, body)
+		diffAuthedShort(t, got, want)
+	})
+
+	t.Run("GET state after advance", diffState)
+}
+
+// diffAuthedShort asserts status, content type, body, and rate-limit-header
+// presence parity with truncated error output (long lines truncate CI logs).
+func diffAuthedShort(t *testing.T, got, want authedResponse) {
+	t.Helper()
+
+	if got.status != want.status {
+		t.Errorf("status: go=%d dotnet=%d", got.status, want.status)
+	}
+	if got.contentType != want.contentType {
+		t.Errorf("content-type: go=%q dotnet=%q", got.contentType, want.contentType)
+	}
+	switch {
+	case len(want.body) == 0 || len(got.body) == 0:
+		if !bytes.Equal(got.body, want.body) {
+			t.Errorf("body: go=%s dotnet=%s", truncate(got.body), truncate(want.body))
+		}
+	case !jsonEqual(t, got.body, want.body):
+		t.Errorf("body: go=%s dotnet=%s", truncate(got.body), truncate(want.body))
+	}
+	if got.rateLimit != want.rateLimit {
+		t.Errorf("X-RateLimit-Limit: go=%q dotnet=%q", got.rateLimit, want.rateLimit)
+	}
+}
+
+func truncate(b []byte) string {
+	const max = 512
+	if len(b) <= max {
+		return string(b)
+	}
+	return string(b[:max]) + "...(truncated)"
+}
+
+// authedBodyRequest is authedRequest with a JSON request body.
+func authedBodyRequest(t *testing.T, client *http.Client, base, method, path, token, body string) authedResponse {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, method, base+path, strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("new request %s %s: %v", method, path, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		t.Fatalf("read body %s %s: %v", method, path, err)
+	}
+
+	return authedResponse{
+		status:        resp.StatusCode,
+		contentType:   resp.Header.Get("Content-Type"),
+		body:          raw,
+		rateLimit:     resp.Header.Get("X-RateLimit-Limit"),
+		rateRemaining: resp.Header.Get("X-RateLimit-Remaining"),
+	}
+}

--- a/api-go/tests/e2e/contract_me_test.go
+++ b/api-go/tests/e2e/contract_me_test.go
@@ -106,8 +106,28 @@ func integrationToken(t *testing.T) string {
 	if cachedToken == "" {
 		t.Fatal("mint integration token: empty access_token")
 	}
+
+	// Warm-up, not a diff, once per run and BEFORE whichever authed scenario
+	// happens to execute first: the first authenticated request on a cold app
+	// pays the lazy Cosmos connect + AAD token fetch, which can blow the
+	// bounded 1.5s retry budget and make the rate-limit tier lookup fail open
+	// to the free limit (PR #424 round 1 and PR #426 round 1: go=60 vs
+	// dotnet=600 on the first diffed call only). Both implementations share
+	// that fail-open design, so a cold first call is an environmental
+	// artifact, not a contract difference.
+	warmOnce.Do(func() {
+		client := &http.Client{Timeout: requestTimeout}
+		for _, base := range []string{os.Getenv("DOTNET_BASE_URL"), os.Getenv("GO_BASE_URL")} {
+			if base != "" {
+				_ = authedRequest(t, client, base, http.MethodGet, "/v1/me", cachedToken)
+			}
+		}
+	})
+
 	return cachedToken
 }
+
+var warmOnce sync.Once
 
 // TestContract_AuthenticatedProfileSurface diffs the /api/me + /v1/me read and
 // idempotent-write surface with a real token. The profile is first ensured to
@@ -126,15 +146,6 @@ func TestContract_AuthenticatedProfileSurface(t *testing.T) {
 	if setup.status >= 500 {
 		t.Fatalf("setup POST /v1/me on .NET failed: %d %s", setup.status, setup.body)
 	}
-
-	// Warm-up, not a diff: the first authenticated request on a cold app pays
-	// the lazy Cosmos connect + AAD token fetch, which can blow the bounded
-	// 1.5s retry budget and make the rate-limit tier lookup fail open to the
-	// free limit (observed on PR #424: go=60 vs dotnet=600 on the first diffed
-	// call only). Both implementations share that fail-open design, so a cold
-	// first call is an environmental artifact, not a contract difference.
-	_ = authedRequest(t, client, dotnetURL, http.MethodGet, "/v1/me", token)
-	_ = authedRequest(t, client, goURL, http.MethodGet, "/v1/me", token)
 
 	scenarios := []struct {
 		method string

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -413,6 +413,7 @@ public static class EnvironmentStack
                     {
                         new SecretArgs { Name = "auth0-m2m-client-id", Value = auth0M2mClientId },
                         new SecretArgs { Name = "auth0-m2m-client-secret", Value = auth0M2mClientSecret },
+                        new SecretArgs { Name = "auto-grant-pro-domains", Value = autoGrantProDomains },
                     },
                 },
                 Identity = new Pulumi.AzureNative.App.Inputs.ManagedServiceIdentityArgs
@@ -451,6 +452,7 @@ public static class EnvironmentStack
                                 new EnvironmentVarArgs { Name = "CORS_ALLOWED_ORIGINS", Value = $"https://{frontendDomain}" },
                                 new EnvironmentVarArgs { Name = "AUTH0_M2M_CLIENT_ID", SecretRef = "auth0-m2m-client-id" },
                                 new EnvironmentVarArgs { Name = "AUTH0_M2M_CLIENT_SECRET", SecretRef = "auth0-m2m-client-secret" },
+                                new EnvironmentVarArgs { Name = "SUBSCRIPTION_AUTOGRANT_PRODOMAINS", SecretRef = "auto-grant-pro-domains" },
                             },
                         },
                     },


### PR DESCRIPTION
## Changes

Iteration 4 of the Go API migration (GH #418).

- `internal/devicetokens` — registration domain (string-enum platforms "Ios"/"Android", case-insensitive binding), Cosmos store (partition /userId, id = token), `PUT /v1/me/device-token` (refresh-or-create → 204) and `DELETE /v1/me/device-token/{token}` (idempotent → 204)
- `internal/notificationstate` — read-watermark domain (version bumps, stale-asOf no-op), two-container store (NotificationState watermark + Notifications unread COUNT with the cutoff in .NET DateTimeOffset string form for lexicographic parity), `GET /v1/me/notification-state` (first-touch seeds-and-persists, clean-slate semantics), `POST .../mark-all-read`, `POST .../advance`
- `platform.DotNetTime` — exported DateTimeOffset wire-format type (it3's lesson, now shared) + named-container constructor and query/count helpers
- Contract scenarios for all five routes incl. error paths, sequenced state-deterministically for the shared integration-test user; error output truncated to keep CI logs intact

Bead: tc-7g3i.5 · Epic: tc-7g3i

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device token registration endpoints to manage mobile device tokens.
  * Added notification state endpoints to track and advance notification read watermarks.

* **Tests**
  * Added comprehensive unit and integration test coverage for device token and notification state features.
  * Added end-to-end contract tests to verify compatibility across backends.

* **Chores**
  * Updated infrastructure configuration for secret management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->