### PR TITLE
feat(go): it5 watch zones — list/update/delete + per-zone preferences (tc-7g3i.6)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
 func main() {
@@ -64,6 +65,15 @@ func main() {
 		stateStore = notificationstate.NewCosmosStore(stateContainer, notifications)
 	}
 
+	watchZones, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosWatchZonesContainer, logger)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var watchZoneStore *watchzones.CosmosStore
+	if watchZones != nil {
+		watchZoneStore = watchzones.NewCosmosStore(watchZones)
+	}
+
 	// Real M2M client only when fully configured; otherwise the no-op fallback,
 	// matching .NET's conditional IAuth0ManagementClient registration.
 	var manager profiles.Auth0Manager = profiles.NoOpAuth0Client{}
@@ -76,7 +86,7 @@ func main() {
 		)
 	}
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, deviceStore, stateStore, logger))
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, deviceStore, stateStore, watchZoneStore, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -15,6 +15,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/versionconfig"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
 // anonymousPatterns lists the mux patterns registered with AllowAnonymous in
@@ -63,9 +64,11 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // store is nil when Cosmos is not configured (local boot without env): the
 // /v1/me routes are then unwired — requests fall to the 401 fallback — and the
 // profile-backed rate-limit/activity middlewares are skipped entirely. The
-// device-token and notification-state stores follow the same nil-means-unwired
-// convention.
-func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, logger *slog.Logger) http.Handler {
+// device-token, notification-state and watch-zone stores follow the same
+// nil-means-unwired convention. (The watch-zone preferences endpoints are
+// served by profiles.Routes off the profile store, so they come up with the
+// /v1/me routes, not the watch-zone store.)
+func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, watchZoneStore *watchzones.CosmosStore, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)
@@ -85,6 +88,9 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 	}
 	if stateStore != nil {
 		notificationstate.Routes(mux, stateStore, time.Now, logger)
+	}
+	if watchZoneStore != nil {
+		watchzones.Routes(mux, watchZoneStore, logger)
 	}
 
 	authed := auth.RequireAuth(validator, &dispatchMux{ServeMux: mux, dispatch: dispatch}, anonymousPatterns)

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
 // denyAllValidator is the validator the API runs with when Auth0 config is
@@ -71,6 +72,12 @@ func (f *fakeItems) DeleteItem(_ context.Context, _, id string) error {
 	return nil
 }
 
+// QueryItems lets fakeItems also back a watchzones store; the wiring tests only
+// need the empty-list path, so it returns no documents.
+func (f *fakeItems) QueryItems(_ context.Context, _, _ string, _ map[string]any) ([][]byte, error) {
+	return nil, nil
+}
+
 // notFoundErr mimics the azcore 404 the store's isNotFound detects.
 func notFoundErr() error {
 	return &azcore.ResponseError{StatusCode: http.StatusNotFound}
@@ -88,7 +95,7 @@ func idFromDoc(raw []byte) string {
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -184,8 +191,9 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 
 	logger := slog.New(slog.DiscardHandler)
 	store := profiles.NewCosmosStore(newFakeItems())
+	watchZoneStore := watchzones.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", nil, nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", nil, nil, watchZoneStore, logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -205,6 +213,16 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	}
 	if rec.Header().Get("X-RateLimit-Remaining") == "" {
 		t.Error("X-RateLimit-Remaining missing — rate limiter not in the dispatch path")
+	}
+
+	// Watch-zone routes are wired behind the same auth + dispatch chain: a
+	// valid token reaches the list handler and gets the empty-array body.
+	rec = serveReq(t, h, http.MethodGet, "/v1/me/watch-zones", "", "Bearer tok")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/me/watch-zones status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != `{"zones":[]}` {
+		t.Errorf("GET /v1/me/watch-zones body = %s, want {\"zones\":[]}", got)
 	}
 
 	// Anonymous routes stay unmetered even on the store-wired router.

--- a/api-go/internal/platform/cosmos.go
+++ b/api-go/internal/platform/cosmos.go
@@ -100,6 +100,9 @@ const (
 	// CosmosNotificationsContainer holds dispatched notifications; partition key
 	// /userId. Read-only here for the unread COUNT query.
 	CosmosNotificationsContainer = "Notifications"
+	// CosmosWatchZonesContainer holds one document per watch zone; partition key
+	// /userId, document id == zoneId.
+	CosmosWatchZonesContainer = "WatchZones"
 )
 
 // ReadItem point-reads the document with the given id from its partition.

--- a/api-go/internal/profiles/handler.go
+++ b/api-go/internal/profiles/handler.go
@@ -61,6 +61,11 @@ func Routes(mux *http.ServeMux, store profileStore, auth0 Auth0Manager, proDomai
 	mux.HandleFunc("PATCH /v1/me", h.patch)
 	mux.HandleFunc("DELETE /v1/me", h.delete)
 	mux.HandleFunc("GET /v1/me/data", h.exportData)
+	// Per-zone notification preferences read/write the profile document, so they
+	// are served here (over the profile store) even though their route sits under
+	// /me/watch-zones — mirroring .NET's UserProfiles-slice handlers.
+	mux.HandleFunc("GET /v1/me/watch-zones/{zoneId}/preferences", h.getZonePreferences)
+	mux.HandleFunc("PUT /v1/me/watch-zones/{zoneId}/preferences", h.putZonePreferences)
 }
 
 // createResult mirrors .NET CreateUserProfileResult: { userId, pushEnabled, tier }.

--- a/api-go/internal/profiles/zonepreferences.go
+++ b/api-go/internal/profiles/zonepreferences.go
@@ -1,0 +1,32 @@
+package profiles
+
+// DefaultZonePreferences returns the .NET ZoneNotificationPreferences.Default
+// value: every per-zone notification channel opted in.
+func DefaultZonePreferences() ZonePreferences {
+	return ZonePreferences{
+		NewApplicationPush:  true,
+		NewApplicationEmail: true,
+		DecisionPush:        true,
+		DecisionEmail:       true,
+	}
+}
+
+// GetZonePreferences returns the stored per-zone notification preferences for
+// zoneID, or the all-on defaults when the user has never customised that zone —
+// mirroring .NET UserProfile.GetZonePreferences.
+func (p *UserProfile) GetZonePreferences(zoneID string) ZonePreferences {
+	if prefs, ok := p.ZonePreferences[zoneID]; ok {
+		return prefs
+	}
+	return DefaultZonePreferences()
+}
+
+// SetZonePreferences stores (replacing any existing) the per-zone preferences
+// for zoneID, mirroring .NET UserProfile.SetZonePreferences. It is safe to call
+// on a profile whose preference map was never initialised.
+func (p *UserProfile) SetZonePreferences(zoneID string, prefs ZonePreferences) {
+	if p.ZonePreferences == nil {
+		p.ZonePreferences = map[string]ZonePreferences{}
+	}
+	p.ZonePreferences[zoneID] = prefs
+}

--- a/api-go/internal/profiles/zonepreferences_handler.go
+++ b/api-go/internal/profiles/zonepreferences_handler.go
@@ -1,0 +1,103 @@
+package profiles
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+)
+
+// Per-zone notification preferences live on the user profile document, so the
+// /v1/me/watch-zones/{zoneId}/preferences endpoints are served here (over the
+// profile store) rather than in the watchzones package — mirroring .NET, where
+// the Get/UpdateZonePreferences handlers sit in the UserProfiles application
+// slice even though the route is registered alongside the watch-zone endpoints.
+
+// zonePreferencesRequest is the PUT body. The four channel flags are plain
+// bools: an omitted field decodes to false, matching System.Text.Json on the
+// .NET UpdateZonePreferencesCommand record's non-nullable bools.
+type zonePreferencesRequest struct {
+	NewApplicationPush  bool `json:"newApplicationPush"`
+	NewApplicationEmail bool `json:"newApplicationEmail"`
+	DecisionPush        bool `json:"decisionPush"`
+	DecisionEmail       bool `json:"decisionEmail"`
+}
+
+// zonePreferencesResult mirrors .NET Get/UpdateZonePreferencesResult:
+// { zoneId, newApplicationPush, newApplicationEmail, decisionPush, decisionEmail }.
+type zonePreferencesResult struct {
+	ZoneID              string `json:"zoneId"`
+	NewApplicationPush  bool   `json:"newApplicationPush"`
+	NewApplicationEmail bool   `json:"newApplicationEmail"`
+	DecisionPush        bool   `json:"decisionPush"`
+	DecisionEmail       bool   `json:"decisionEmail"`
+}
+
+func zonePreferencesResultFrom(zoneID string, prefs ZonePreferences) zonePreferencesResult {
+	return zonePreferencesResult{
+		ZoneID:              zoneID,
+		NewApplicationPush:  prefs.NewApplicationPush,
+		NewApplicationEmail: prefs.NewApplicationEmail,
+		DecisionPush:        prefs.DecisionPush,
+		DecisionEmail:       prefs.DecisionEmail,
+	}
+}
+
+// getZonePreferences implements GET /v1/me/watch-zones/{zoneId}/preferences. A
+// zone the user never customised returns the all-on defaults; a missing profile
+// is a bodyless 404 (mirroring .NET's UserProfileNotFoundException -> NotFound).
+func (h *handler) getZonePreferences(w http.ResponseWriter, r *http.Request) {
+	subject := auth.Subject(r.Context())
+	zoneID := r.PathValue("zoneId")
+
+	profile, err := h.store.Get(r.Context(), subject)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		h.serverError(w, r, "load profile", err)
+		return
+	}
+	h.writeJSON(w, r, zonePreferencesResultFrom(zoneID, profile.GetZonePreferences(zoneID)))
+}
+
+// putZonePreferences implements PUT /v1/me/watch-zones/{zoneId}/preferences. It
+// replaces the zone's stored preferences with the body values and returns them;
+// a missing profile is a bodyless 404.
+func (h *handler) putZonePreferences(w http.ResponseWriter, r *http.Request) {
+	subject := auth.Subject(r.Context())
+	zoneID := r.PathValue("zoneId")
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	var req zonePreferencesRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	profile, err := h.store.Get(r.Context(), subject)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		h.serverError(w, r, "load profile", err)
+		return
+	}
+
+	prefs := ZonePreferences{
+		NewApplicationPush:  req.NewApplicationPush,
+		NewApplicationEmail: req.NewApplicationEmail,
+		DecisionPush:        req.DecisionPush,
+		DecisionEmail:       req.DecisionEmail,
+	}
+	profile.SetZonePreferences(zoneID, prefs)
+	if err := h.store.Save(r.Context(), profile); err != nil {
+		h.serverError(w, r, "save profile", err)
+		return
+	}
+	h.writeJSON(w, r, zonePreferencesResultFrom(zoneID, prefs))
+}

--- a/api-go/internal/profiles/zonepreferences_handler.go
+++ b/api-go/internal/profiles/zonepreferences_handler.go
@@ -88,12 +88,9 @@ func (h *handler) putZonePreferences(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	prefs := ZonePreferences{
-		NewApplicationPush:  req.NewApplicationPush,
-		NewApplicationEmail: req.NewApplicationEmail,
-		DecisionPush:        req.DecisionPush,
-		DecisionEmail:       req.DecisionEmail,
-	}
+	// zonePreferencesRequest and ZonePreferences are field-identical; the request
+	// type exists only to carry the JSON tags, so a direct conversion is exact.
+	prefs := ZonePreferences(req)
 	profile.SetZonePreferences(zoneID, prefs)
 	if err := h.store.Save(r.Context(), profile); err != nil {
 		h.serverError(w, r, "save profile", err)

--- a/api-go/internal/profiles/zonepreferences_handler_test.go
+++ b/api-go/internal/profiles/zonepreferences_handler_test.go
@@ -8,30 +8,38 @@ import (
 	"time"
 )
 
-func withZonePath(method, target, sub, zoneID, body string) *http.Request {
-	r := withSubject(method, target, sub, body)
-	r.SetPathValue("zoneId", zoneID)
+// prefsUser is the subject under test for the zone-preferences handlers; the
+// route's actual URL is irrelevant since the handlers read the path value and
+// the context subject, not r.URL.Path.
+const (
+	prefsUser = "auth0|u"
+	prefsZone = "z1"
+)
+
+func withZonePath(method, sub, body string) *http.Request {
+	r := withSubject(method, "/v1/me/watch-zones/"+prefsZone+"/preferences", sub, body)
+	r.SetPathValue("zoneId", prefsZone)
 	return r
 }
 
-func seededProfile(t *testing.T, store *fakeStore, userID string) *UserProfile {
+func seededProfile(t *testing.T, store *fakeStore) *UserProfile {
 	t.Helper()
-	p, err := NewProfile(userID, "", time.Now())
+	p, err := NewProfile(prefsUser, "", time.Now())
 	if err != nil {
 		t.Fatalf("NewProfile: %v", err)
 	}
-	store.byID[userID] = p
+	store.byID[prefsUser] = p
 	return p
 }
 
 func TestHandler_GetZonePreferences_DefaultsForNewZone(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
-	seededProfile(t, store, "auth0|u")
+	seededProfile(t, store)
 	h := newTestHandler(store, newFakeAuth0(), "")
 
 	rec := httptest.NewRecorder()
-	h.getZonePreferences(rec, withZonePath(http.MethodGet, "/v1/me/watch-zones/z1/preferences", "auth0|u", "z1", ""))
+	h.getZonePreferences(rec, withZonePath(http.MethodGet, prefsUser, ""))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200", rec.Code)
@@ -56,12 +64,12 @@ func TestHandler_GetZonePreferences_DefaultsForNewZone(t *testing.T) {
 func TestHandler_GetZonePreferences_ReflectsStored(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
-	p := seededProfile(t, store, "auth0|u")
+	p := seededProfile(t, store)
 	p.SetZonePreferences("z1", ZonePreferences{NewApplicationPush: false, NewApplicationEmail: true, DecisionPush: false, DecisionEmail: true})
 	h := newTestHandler(store, newFakeAuth0(), "")
 
 	rec := httptest.NewRecorder()
-	h.getZonePreferences(rec, withZonePath(http.MethodGet, "/v1/me/watch-zones/z1/preferences", "auth0|u", "z1", ""))
+	h.getZonePreferences(rec, withZonePath(http.MethodGet, prefsUser, ""))
 
 	var got map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
@@ -79,7 +87,7 @@ func TestHandler_GetZonePreferences_ProfileNotFound(t *testing.T) {
 	t.Parallel()
 	h := newTestHandler(newFakeStore(), newFakeAuth0(), "")
 	rec := httptest.NewRecorder()
-	h.getZonePreferences(rec, withZonePath(http.MethodGet, "/v1/me/watch-zones/z1/preferences", "auth0|missing", "z1", ""))
+	h.getZonePreferences(rec, withZonePath(http.MethodGet, "auth0|missing", ""))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status: got %d, want 404", rec.Code)
 	}
@@ -91,12 +99,12 @@ func TestHandler_GetZonePreferences_ProfileNotFound(t *testing.T) {
 func TestHandler_PutZonePreferences_PersistsAndReturns(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
-	seededProfile(t, store, "auth0|u")
+	seededProfile(t, store)
 	h := newTestHandler(store, newFakeAuth0(), "")
 
 	body := `{"newApplicationPush":false,"newApplicationEmail":true,"decisionPush":false,"decisionEmail":true}`
 	rec := httptest.NewRecorder()
-	h.putZonePreferences(rec, withZonePath(http.MethodPut, "/v1/me/watch-zones/z1/preferences", "auth0|u", "z1", body))
+	h.putZonePreferences(rec, withZonePath(http.MethodPut, prefsUser, body))
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200", rec.Code)
@@ -109,7 +117,7 @@ func TestHandler_PutZonePreferences_PersistsAndReturns(t *testing.T) {
 		t.Errorf("response mismatch: %+v", got)
 	}
 	// Persisted onto the profile.
-	stored := store.byID["auth0|u"].GetZonePreferences("z1")
+	stored := store.byID[prefsUser].GetZonePreferences("z1")
 	if stored.NewApplicationPush != false || stored.DecisionEmail != true {
 		t.Errorf("prefs not persisted: %+v", stored)
 	}
@@ -121,13 +129,13 @@ func TestHandler_PutZonePreferences_PersistsAndReturns(t *testing.T) {
 func TestHandler_PutZonePreferences_MissingFieldsDefaultFalse(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
-	seededProfile(t, store, "auth0|u")
+	seededProfile(t, store)
 	h := newTestHandler(store, newFakeAuth0(), "")
 
 	// Only one field present; the rest default to false (matching STJ on the
 	// .NET command record's non-nullable bools).
 	rec := httptest.NewRecorder()
-	h.putZonePreferences(rec, withZonePath(http.MethodPut, "/v1/me/watch-zones/z1/preferences", "auth0|u", "z1", `{"newApplicationPush":true}`))
+	h.putZonePreferences(rec, withZonePath(http.MethodPut, prefsUser, `{"newApplicationPush":true}`))
 
 	var got map[string]any
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
@@ -147,7 +155,7 @@ func TestHandler_PutZonePreferences_ProfileNotFound(t *testing.T) {
 	t.Parallel()
 	h := newTestHandler(newFakeStore(), newFakeAuth0(), "")
 	rec := httptest.NewRecorder()
-	h.putZonePreferences(rec, withZonePath(http.MethodPut, "/v1/me/watch-zones/z1/preferences", "auth0|missing", "z1", `{"decisionPush":true}`))
+	h.putZonePreferences(rec, withZonePath(http.MethodPut, "auth0|missing", `{"decisionPush":true}`))
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status: got %d, want 404", rec.Code)
 	}

--- a/api-go/internal/profiles/zonepreferences_handler_test.go
+++ b/api-go/internal/profiles/zonepreferences_handler_test.go
@@ -1,0 +1,157 @@
+package profiles
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func withZonePath(method, target, sub, zoneID, body string) *http.Request {
+	r := withSubject(method, target, sub, body)
+	r.SetPathValue("zoneId", zoneID)
+	return r
+}
+
+func seededProfile(t *testing.T, store *fakeStore, userID string) *UserProfile {
+	t.Helper()
+	p, err := NewProfile(userID, "", time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	store.byID[userID] = p
+	return p
+}
+
+func TestHandler_GetZonePreferences_DefaultsForNewZone(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	seededProfile(t, store, "auth0|u")
+	h := newTestHandler(store, newFakeAuth0(), "")
+
+	rec := httptest.NewRecorder()
+	h.getZonePreferences(rec, withZonePath(http.MethodGet, "/v1/me/watch-zones/z1/preferences", "auth0|u", "z1", ""))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("content-type: got %q", ct)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["zoneId"] != "z1" {
+		t.Errorf("zoneId: got %v", got["zoneId"])
+	}
+	for _, k := range []string{"newApplicationPush", "newApplicationEmail", "decisionPush", "decisionEmail"} {
+		if got[k] != true {
+			t.Errorf("%s: got %v, want true (default)", k, got[k])
+		}
+	}
+}
+
+func TestHandler_GetZonePreferences_ReflectsStored(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	p := seededProfile(t, store, "auth0|u")
+	p.SetZonePreferences("z1", ZonePreferences{NewApplicationPush: false, NewApplicationEmail: true, DecisionPush: false, DecisionEmail: true})
+	h := newTestHandler(store, newFakeAuth0(), "")
+
+	rec := httptest.NewRecorder()
+	h.getZonePreferences(rec, withZonePath(http.MethodGet, "/v1/me/watch-zones/z1/preferences", "auth0|u", "z1", ""))
+
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["newApplicationPush"] != false || got["decisionPush"] != false {
+		t.Errorf("stored prefs not reflected: %+v", got)
+	}
+	if got["newApplicationEmail"] != true || got["decisionEmail"] != true {
+		t.Errorf("stored prefs not reflected: %+v", got)
+	}
+}
+
+func TestHandler_GetZonePreferences_ProfileNotFound(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(newFakeStore(), newFakeAuth0(), "")
+	rec := httptest.NewRecorder()
+	h.getZonePreferences(rec, withZonePath(http.MethodGet, "/v1/me/watch-zones/z1/preferences", "auth0|missing", "z1", ""))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("404 must be bodyless, got %s", rec.Body)
+	}
+}
+
+func TestHandler_PutZonePreferences_PersistsAndReturns(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	seededProfile(t, store, "auth0|u")
+	h := newTestHandler(store, newFakeAuth0(), "")
+
+	body := `{"newApplicationPush":false,"newApplicationEmail":true,"decisionPush":false,"decisionEmail":true}`
+	rec := httptest.NewRecorder()
+	h.putZonePreferences(rec, withZonePath(http.MethodPut, "/v1/me/watch-zones/z1/preferences", "auth0|u", "z1", body))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["zoneId"] != "z1" || got["newApplicationPush"] != false || got["decisionEmail"] != true {
+		t.Errorf("response mismatch: %+v", got)
+	}
+	// Persisted onto the profile.
+	stored := store.byID["auth0|u"].GetZonePreferences("z1")
+	if stored.NewApplicationPush != false || stored.DecisionEmail != true {
+		t.Errorf("prefs not persisted: %+v", stored)
+	}
+	if len(store.saved) != 1 {
+		t.Errorf("expected one save, got %d", len(store.saved))
+	}
+}
+
+func TestHandler_PutZonePreferences_MissingFieldsDefaultFalse(t *testing.T) {
+	t.Parallel()
+	store := newFakeStore()
+	seededProfile(t, store, "auth0|u")
+	h := newTestHandler(store, newFakeAuth0(), "")
+
+	// Only one field present; the rest default to false (matching STJ on the
+	// .NET command record's non-nullable bools).
+	rec := httptest.NewRecorder()
+	h.putZonePreferences(rec, withZonePath(http.MethodPut, "/v1/me/watch-zones/z1/preferences", "auth0|u", "z1", `{"newApplicationPush":true}`))
+
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["newApplicationPush"] != true {
+		t.Errorf("newApplicationPush: got %v, want true", got["newApplicationPush"])
+	}
+	for _, k := range []string{"newApplicationEmail", "decisionPush", "decisionEmail"} {
+		if got[k] != false {
+			t.Errorf("%s: got %v, want false (omitted)", k, got[k])
+		}
+	}
+}
+
+func TestHandler_PutZonePreferences_ProfileNotFound(t *testing.T) {
+	t.Parallel()
+	h := newTestHandler(newFakeStore(), newFakeAuth0(), "")
+	rec := httptest.NewRecorder()
+	h.putZonePreferences(rec, withZonePath(http.MethodPut, "/v1/me/watch-zones/z1/preferences", "auth0|missing", "z1", `{"decisionPush":true}`))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("404 must be bodyless, got %s", rec.Body)
+	}
+}

--- a/api-go/internal/profiles/zonepreferences_test.go
+++ b/api-go/internal/profiles/zonepreferences_test.go
@@ -1,0 +1,47 @@
+package profiles
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDefaultZonePreferences_AllChannelsOn(t *testing.T) {
+	t.Parallel()
+	got := DefaultZonePreferences()
+	if !got.NewApplicationPush || !got.NewApplicationEmail || !got.DecisionPush || !got.DecisionEmail {
+		t.Errorf("default zone preferences must be all-on, got %+v", got)
+	}
+}
+
+func TestUserProfile_GetZonePreferences_DefaultsWhenAbsent(t *testing.T) {
+	t.Parallel()
+	p, _ := NewProfile("auth0|u", "", time.Now())
+	got := p.GetZonePreferences("never-set")
+	if got != DefaultZonePreferences() {
+		t.Errorf("absent zone must return defaults, got %+v", got)
+	}
+}
+
+func TestUserProfile_SetThenGetZonePreferences(t *testing.T) {
+	t.Parallel()
+	p, _ := NewProfile("auth0|u", "", time.Now())
+	want := ZonePreferences{NewApplicationPush: false, NewApplicationEmail: true, DecisionPush: false, DecisionEmail: true}
+	p.SetZonePreferences("zone-1", want)
+
+	if got := p.GetZonePreferences("zone-1"); got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+	// Other zones still default.
+	if got := p.GetZonePreferences("zone-2"); got != DefaultZonePreferences() {
+		t.Errorf("unrelated zone changed: %+v", got)
+	}
+}
+
+func TestUserProfile_SetZonePreferences_NilMapSafe(t *testing.T) {
+	t.Parallel()
+	p := &UserProfile{UserID: "u"} // ZonePreferences nil
+	p.SetZonePreferences("z", DefaultZonePreferences())
+	if got := p.GetZonePreferences("z"); got != DefaultZonePreferences() {
+		t.Errorf("set on nil map failed: %+v", got)
+	}
+}

--- a/api-go/internal/watchzones/document.go
+++ b/api-go/internal/watchzones/document.go
@@ -1,0 +1,91 @@
+package watchzones
+
+import (
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// watchZoneDocument is the Cosmos persistence shape for a WatchZone. The JSON
+// tags reproduce the camelCase keys the .NET CosmosWatchZoneRepository writes
+// (its serializer context uses the CamelCase naming policy), so a Go-written
+// document is byte-compatible with the existing WatchZones container and an
+// existing document hydrates here unchanged.
+//
+// Partition key: the WatchZones container is partitioned by /userId; the
+// document id equals the zone id. Every single-zone operation is therefore a
+// point operation keyed on (userId, zoneId), and a user's zones are listed with
+// a single-partition query on userId.
+type watchZoneDocument struct {
+	ID           string  `json:"id"`
+	UserID       string  `json:"userId"`
+	Name         string  `json:"name"`
+	Latitude     float64 `json:"latitude"`
+	Longitude    float64 `json:"longitude"`
+	RadiusMetres float64 `json:"radiusMetres"`
+	AuthorityID  int     `json:"authorityId"`
+
+	// createdAt carries a .NET DateTimeOffset, so it must serialise with a
+	// numeric UTC offset ("+00:00"), never Go's RFC 3339 "Z" — platform.DotNetTime
+	// handles that. Nullable so a legacy document missing it hydrates to the zero
+	// instant, mirroring .NET's `CreatedAt ?? DateTimeOffset.MinValue`.
+	CreatedAt *platform.DotNetTime `json:"createdAt"`
+
+	// pushEnabled / emailInstantEnabled are pointers so a document predating the
+	// per-zone flags (tc-kh1s) hydrates as opt-in (true) rather than the Go zero
+	// value (false) — mirroring .NET's bool? coalesce-to-true on read.
+	PushEnabled         *bool `json:"pushEnabled"`
+	EmailInstantEnabled *bool `json:"emailInstantEnabled"`
+}
+
+// newWatchZoneDocument maps a domain zone to its persistence shape. The flags are
+// always written explicitly (never absent) so a freshly written document carries
+// the user's actual preference; createdAt is written in .NET DateTimeOffset form.
+func newWatchZoneDocument(z WatchZone) watchZoneDocument {
+	createdAt := platform.DotNetTime(z.CreatedAt)
+	push := z.PushEnabled
+	email := z.EmailInstantEnabled
+	return watchZoneDocument{
+		ID:                  z.ID,
+		UserID:              z.UserID,
+		Name:                z.Name,
+		Latitude:            z.Latitude,
+		Longitude:           z.Longitude,
+		RadiusMetres:        z.RadiusMetres,
+		AuthorityID:         z.AuthorityID,
+		CreatedAt:           &createdAt,
+		PushEnabled:         &push,
+		EmailInstantEnabled: &email,
+	}
+}
+
+// toDomain reconstitutes a domain zone from its stored document, coalescing the
+// legacy-nullable flags to true and an absent createdAt to the zero instant,
+// exactly as .NET does on read.
+func (d watchZoneDocument) toDomain() (WatchZone, error) {
+	var createdAt time.Time
+	if d.CreatedAt != nil {
+		createdAt = time.Time(*d.CreatedAt)
+	}
+	return NewWatchZone(
+		d.ID,
+		d.UserID,
+		d.Name,
+		d.Latitude,
+		d.Longitude,
+		d.RadiusMetres,
+		d.AuthorityID,
+		createdAt,
+		coalesceTrue(d.PushEnabled),
+		coalesceTrue(d.EmailInstantEnabled),
+	)
+}
+
+// coalesceTrue defaults an absent (nil) nullable flag to true, preserving the
+// opt-in default for documents written before the flag existed.
+func coalesceTrue(v *bool) bool {
+	if v == nil {
+		return true
+	}
+	return *v
+}

--- a/api-go/internal/watchzones/document_test.go
+++ b/api-go/internal/watchzones/document_test.go
@@ -1,0 +1,94 @@
+package watchzones
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWatchZoneDocument_RoundTrip(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+
+	got, err := newWatchZoneDocument(z).toDomain()
+	if err != nil {
+		t.Fatalf("toDomain: %v", err)
+	}
+	if got.ID != z.ID || got.UserID != z.UserID || got.Name != z.Name {
+		t.Errorf("identity mismatch: got %+v", got)
+	}
+	if got.Latitude != z.Latitude || got.Longitude != z.Longitude || got.RadiusMetres != z.RadiusMetres {
+		t.Errorf("geometry mismatch: got %+v", got)
+	}
+	if got.AuthorityID != z.AuthorityID {
+		t.Errorf("authorityId: got %d, want %d", got.AuthorityID, z.AuthorityID)
+	}
+	if got.PushEnabled != z.PushEnabled || got.EmailInstantEnabled != z.EmailInstantEnabled {
+		t.Errorf("flags mismatch: got %+v", got)
+	}
+	if !got.CreatedAt.Equal(z.CreatedAt) {
+		t.Errorf("createdAt: got %v, want %v", got.CreatedAt, z.CreatedAt)
+	}
+}
+
+func TestWatchZoneDocument_CamelCaseAndDotNetTime(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+
+	raw, err := json.Marshal(newWatchZoneDocument(z))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(raw)
+
+	for _, key := range []string{
+		`"id":`, `"userId":`, `"name":`, `"latitude":`, `"longitude":`,
+		`"radiusMetres":`, `"authorityId":`, `"createdAt":`, `"pushEnabled":`, `"emailInstantEnabled":`,
+	} {
+		if !strings.Contains(body, key) {
+			t.Errorf("missing camelCase key %s in %s", key, body)
+		}
+	}
+	// .NET DateTimeOffset serialises with a numeric offset, never the RFC 3339 Z.
+	if !strings.Contains(body, "2026-06-01T09:00:00+00:00") {
+		t.Errorf("createdAt not in .NET DateTimeOffset format: %s", body)
+	}
+	if strings.Contains(body, "09:00:00Z") {
+		t.Errorf("createdAt used RFC 3339 Z suffix: %s", body)
+	}
+}
+
+func TestWatchZoneDocument_LegacyNullFlagsCoalesceTrue(t *testing.T) {
+	t.Parallel()
+	// A document written before the per-zone flags existed omits them; .NET
+	// hydrates the absent bool? as opt-in (true). The Go store must match.
+	raw := `{"id":"z1","userId":"u1","name":"Home","latitude":51,"longitude":-0.1,"radiusMetres":500,"authorityId":471,"createdAt":"2026-06-01T09:00:00+00:00"}`
+	var doc watchZoneDocument
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, err := doc.toDomain()
+	if err != nil {
+		t.Fatalf("toDomain: %v", err)
+	}
+	if !got.PushEnabled || !got.EmailInstantEnabled {
+		t.Errorf("absent flags must coalesce to true: push=%v email=%v", got.PushEnabled, got.EmailInstantEnabled)
+	}
+}
+
+func TestWatchZoneDocument_AbsentCreatedAtHydratesToZero(t *testing.T) {
+	t.Parallel()
+	raw := `{"id":"z1","userId":"u1","name":"Home","latitude":51,"longitude":-0.1,"radiusMetres":500,"authorityId":471}`
+	var doc watchZoneDocument
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got, err := doc.toDomain()
+	if err != nil {
+		t.Fatalf("toDomain: %v", err)
+	}
+	if !got.CreatedAt.Equal(time.Time{}) {
+		t.Errorf("absent createdAt should hydrate to zero time, got %v", got.CreatedAt)
+	}
+}

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -1,0 +1,257 @@
+package watchzones
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+)
+
+// maxBodyBytes caps the request body the PATCH handler reads.
+const maxBodyBytes = 1 << 20
+
+// invalidPayloadMessage is the .NET ApiErrorResponse error text for a watch-zone
+// validation failure (Create/Update endpoints).
+const invalidPayloadMessage = "Invalid watch zone payload."
+
+// zoneStore is the consumer-side store the handlers use. *CosmosStore satisfies
+// it; tests substitute a hand-written fake.
+type zoneStore interface {
+	GetByUserID(ctx context.Context, userID string) ([]WatchZone, error)
+	Get(ctx context.Context, userID, zoneID string) (WatchZone, error)
+	Save(ctx context.Context, z WatchZone) error
+	Delete(ctx context.Context, userID, zoneID string) error
+}
+
+// handler serves the /v1/me/watch-zones list/update/delete surface. The auth
+// middleware guarantees a subject in context before these handlers run.
+type handler struct {
+	store  zoneStore
+	logger *slog.Logger
+}
+
+// Routes registers the in-scope watch-zone endpoints on mux. POST create and
+// GET /{zoneId}/applications are intentionally absent (deferred to tc-5847).
+func Routes(mux *http.ServeMux, store zoneStore, logger *slog.Logger) {
+	h := &handler{store: store, logger: logger}
+	mux.HandleFunc("GET /v1/me/watch-zones", h.list)
+	mux.HandleFunc("PATCH /v1/me/watch-zones/{zoneId}", h.patch)
+	mux.HandleFunc("DELETE /v1/me/watch-zones/{zoneId}", h.delete)
+}
+
+// watchZoneSummary mirrors .NET WatchZoneSummary: the per-zone shape returned by
+// list and update. createdAt is deliberately absent, matching .NET.
+type watchZoneSummary struct {
+	ID                  string  `json:"id"`
+	Name                string  `json:"name"`
+	Latitude            float64 `json:"latitude"`
+	Longitude           float64 `json:"longitude"`
+	RadiusMetres        float64 `json:"radiusMetres"`
+	AuthorityID         int     `json:"authorityId"`
+	PushEnabled         bool    `json:"pushEnabled"`
+	EmailInstantEnabled bool    `json:"emailInstantEnabled"`
+}
+
+func summaryOf(z WatchZone) watchZoneSummary {
+	return watchZoneSummary{
+		ID:                  z.ID,
+		Name:                z.Name,
+		Latitude:            z.Latitude,
+		Longitude:           z.Longitude,
+		RadiusMetres:        z.RadiusMetres,
+		AuthorityID:         z.AuthorityID,
+		PushEnabled:         z.PushEnabled,
+		EmailInstantEnabled: z.EmailInstantEnabled,
+	}
+}
+
+// listResult mirrors .NET ListWatchZonesResult: { zones: [...] }.
+type listResult struct {
+	Zones []watchZoneSummary `json:"zones"`
+}
+
+// updateResult mirrors .NET UpdateWatchZoneResult: { zone: {...} }.
+type updateResult struct {
+	Zone watchZoneSummary `json:"zone"`
+}
+
+// list implements GET /v1/me/watch-zones, returning the user's zones as a
+// (possibly empty) array. Always a 200.
+func (h *handler) list(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+	zones, err := h.store.GetByUserID(r.Context(), userID)
+	if err != nil {
+		h.serverError(w, r, "list watch zones", err)
+		return
+	}
+	summaries := make([]watchZoneSummary, 0, len(zones))
+	for _, z := range zones {
+		summaries = append(summaries, summaryOf(z))
+	}
+	h.writeJSON(w, r, http.StatusOK, listResult{Zones: summaries})
+}
+
+// patchRequest is the PATCH body: every field optional (nil = unchanged),
+// mirroring .NET UpdateWatchZoneRequest.
+type patchRequest struct {
+	Name                *string  `json:"name"`
+	Latitude            *float64 `json:"latitude"`
+	Longitude           *float64 `json:"longitude"`
+	RadiusMetres        *float64 `json:"radiusMetres"`
+	AuthorityID         *int     `json:"authorityId"`
+	PushEnabled         *bool    `json:"pushEnabled"`
+	EmailInstantEnabled *bool    `json:"emailInstantEnabled"`
+}
+
+// rangeValid reports whether the present coordinate/radius/authority fields are
+// in range, mirroring the .NET endpoint's pre-handler guard. A nil field is not
+// checked. Name is deliberately not checked here — like .NET, that is enforced
+// by the domain merge (and a blank name there is a 500, not a 400).
+func (req patchRequest) rangeValid() bool {
+	if req.Latitude != nil && (*req.Latitude < -90 || *req.Latitude > 90) {
+		return false
+	}
+	if req.Longitude != nil && (*req.Longitude < -180 || *req.Longitude > 180) {
+		return false
+	}
+	if req.RadiusMetres != nil && *req.RadiusMetres <= 0 {
+		return false
+	}
+	if req.AuthorityID != nil && *req.AuthorityID <= 0 {
+		return false
+	}
+	return true
+}
+
+func (req patchRequest) toUpdate() ZoneUpdate {
+	return ZoneUpdate{
+		Name:                req.Name,
+		Latitude:            req.Latitude,
+		Longitude:           req.Longitude,
+		RadiusMetres:        req.RadiusMetres,
+		AuthorityID:         req.AuthorityID,
+		PushEnabled:         req.PushEnabled,
+		EmailInstantEnabled: req.EmailInstantEnabled,
+	}
+}
+
+// patch implements PATCH /v1/me/watch-zones/{zoneId}: range-validate the body
+// (400), load the zone (404 if absent), apply the merge, persist, and return the
+// updated summary. A merge that violates a domain invariant (e.g. a blank name)
+// is a 500, mirroring .NET's unhandled ArgumentException.
+func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+	zoneID := r.PathValue("zoneId")
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	var req patchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if !req.rangeValid() {
+		h.writeError(w, r, http.StatusBadRequest, invalidPayloadMessage)
+		return
+	}
+
+	zone, err := h.store.Get(r.Context(), userID, zoneID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		h.serverError(w, r, "load watch zone", err)
+		return
+	}
+
+	updated, err := zone.WithUpdates(req.toUpdate())
+	if err != nil {
+		h.serverError(w, r, "apply watch-zone update", err)
+		return
+	}
+	if err := h.store.Save(r.Context(), updated); err != nil {
+		h.serverError(w, r, "save watch zone", err)
+		return
+	}
+	h.writeJSON(w, r, http.StatusOK, updateResult{Zone: summaryOf(updated)})
+}
+
+// delete implements DELETE /v1/me/watch-zones/{zoneId}: 204 on success, 404 when
+// the zone does not exist.
+func (h *handler) delete(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+	zoneID := r.PathValue("zoneId")
+
+	if err := h.store.Delete(r.Context(), userID, zoneID); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		h.serverError(w, r, "delete watch zone", err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// apiErrorResponse mirrors the .NET ApiErrorResponse: { error, message } with
+// message serialised as an explicit null when unset.
+type apiErrorResponse struct {
+	Error   string  `json:"error"`
+	Message *string `json:"message"`
+}
+
+// writeJSON encodes v as an application/json; charset=utf-8 response with HTML
+// escaping off and no trailing newline, matching ASP.NET's Results.Ok byte
+// output (the same approach the profiles handler uses).
+func (h *handler) writeJSON(w http.ResponseWriter, r *http.Request, status int, v any) {
+	body, err := encodeJSON(v)
+	if err != nil {
+		h.serverError(w, r, "encode response", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if _, err := w.Write(body); err != nil {
+		h.logger.ErrorContext(r.Context(), "write response", "error", err)
+	}
+}
+
+// writeError emits the .NET ApiErrorResponse envelope at the given status with
+// the same content type as a success body (Results.Json defaults to
+// application/json; charset=utf-8).
+func (h *handler) writeError(w http.ResponseWriter, r *http.Request, status int, message string) {
+	body, err := encodeJSON(apiErrorResponse{Error: message})
+	if err != nil {
+		h.serverError(w, r, "encode error", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if _, err := w.Write(body); err != nil {
+		h.logger.ErrorContext(r.Context(), "write error body", "error", err)
+	}
+}
+
+// encodeJSON renders v with HTML escaping disabled and the trailing newline
+// trimmed, matching the relaxed-encoder byte output of the .NET web serializer.
+func encodeJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+// serverError logs and emits a bodyless 500; the error envelope (with Detail) is
+// backfilled by middleware.ErrorBody, mirroring the rest of the API.
+func (h *handler) serverError(w http.ResponseWriter, r *http.Request, op string, err error) {
+	h.logger.ErrorContext(r.Context(), "watch-zone request failed", "op", op, "error", err)
+	w.WriteHeader(http.StatusInternalServerError)
+}

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -129,15 +129,9 @@ func (req patchRequest) rangeValid() bool {
 }
 
 func (req patchRequest) toUpdate() ZoneUpdate {
-	return ZoneUpdate{
-		Name:                req.Name,
-		Latitude:            req.Latitude,
-		Longitude:           req.Longitude,
-		RadiusMetres:        req.RadiusMetres,
-		AuthorityID:         req.AuthorityID,
-		PushEnabled:         req.PushEnabled,
-		EmailInstantEnabled: req.EmailInstantEnabled,
-	}
+	// patchRequest and ZoneUpdate are field-identical; the request type exists
+	// only to carry the JSON tags, so a direct conversion is exact.
+	return ZoneUpdate(req)
 }
 
 // patch implements PATCH /v1/me/watch-zones/{zoneId}: range-validate the body

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -1,0 +1,235 @@
+package watchzones
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+)
+
+const testUser = "auth0|user"
+
+// fakeZoneStore is a hand-written zoneStore. It holds zones in an ordered slice
+// so list order is deterministic, and exposes hooks for forced errors.
+type fakeZoneStore struct {
+	zones     []WatchZone
+	getErr    error
+	listErr   error
+	saveErr   error
+	deleteErr error
+	saved     *WatchZone
+	deleted   []string
+}
+
+func (f *fakeZoneStore) GetByUserID(_ context.Context, _ string) ([]WatchZone, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.zones, nil
+}
+
+func (f *fakeZoneStore) Get(_ context.Context, _, zoneID string) (WatchZone, error) {
+	if f.getErr != nil {
+		return WatchZone{}, f.getErr
+	}
+	for _, z := range f.zones {
+		if z.ID == zoneID {
+			return z, nil
+		}
+	}
+	return WatchZone{}, ErrNotFound
+}
+
+func (f *fakeZoneStore) Save(_ context.Context, z WatchZone) error {
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	saved := z
+	f.saved = &saved
+	return nil
+}
+
+func (f *fakeZoneStore) Delete(_ context.Context, _, zoneID string) error {
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	for _, z := range f.zones {
+		if z.ID == zoneID {
+			f.deleted = append(f.deleted, zoneID)
+			return nil
+		}
+	}
+	return ErrNotFound
+}
+
+func testMux(t *testing.T, store zoneStore) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler))
+	return mux
+}
+
+func doReq(t *testing.T, mux *http.ServeMux, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	req := httptest.NewRequestWithContext(auth.WithSubject(ctx, testUser), method, path, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHandler_List(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	rec := doReq(t, testMux(t, store), http.MethodGet, "/v1/me/watch-zones", "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("content-type: got %q", ct)
+	}
+	var got struct {
+		Zones []watchZoneSummary `json:"zones"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Zones) != 1 || got.Zones[0].ID != z.ID || got.Zones[0].AuthorityID != z.AuthorityID {
+		t.Errorf("zones: got %+v", got.Zones)
+	}
+}
+
+func TestHandler_List_EmptyArray(t *testing.T) {
+	t.Parallel()
+	rec := doReq(t, testMux(t, &fakeZoneStore{}), http.MethodGet, "/v1/me/watch-zones", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d", rec.Code)
+	}
+	if body := strings.TrimSpace(rec.Body.String()); body != `{"zones":[]}` {
+		t.Errorf("empty list body: got %s, want {\"zones\":[]}", body)
+	}
+}
+
+func TestHandler_Patch_UpdatesAndReturnsZone(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	body := `{"name":"Office","radiusMetres":2500,"pushEnabled":false}`
+	rec := doReq(t, testMux(t, store), http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body %s)", rec.Code, rec.Body)
+	}
+	var got struct {
+		Zone watchZoneSummary `json:"zone"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Zone.Name != "Office" || got.Zone.RadiusMetres != 2500 || got.Zone.PushEnabled {
+		t.Errorf("zone not updated: %+v", got.Zone)
+	}
+	if store.saved == nil || store.saved.Name != "Office" {
+		t.Errorf("zone not persisted: %+v", store.saved)
+	}
+	// Unset fields preserved through the merge.
+	if got.Zone.AuthorityID != z.AuthorityID || got.Zone.Latitude != z.Latitude {
+		t.Errorf("unset fields changed: %+v", got.Zone)
+	}
+}
+
+func TestHandler_Patch_RangeInvalid(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"latitude too high", `{"latitude":91}`},
+		{"longitude too low", `{"longitude":-181}`},
+		{"zero radius", `{"radiusMetres":0}`},
+		{"zero authority", `{"authorityId":0}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := &fakeZoneStore{zones: []WatchZone{z}}
+			rec := doReq(t, testMux(t, store), http.MethodPatch, "/v1/me/watch-zones/"+z.ID, tc.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status: got %d, want 400", rec.Code)
+			}
+			if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+				t.Errorf("content-type: got %q", ct)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode error body: %v", err)
+			}
+			if got["error"] != "Invalid watch zone payload." {
+				t.Errorf("error field: got %v", got["error"])
+			}
+			if v, ok := got["message"]; !ok || v != nil {
+				t.Errorf("message must be present and null: got %v (present=%v)", v, ok)
+			}
+			if store.saved != nil {
+				t.Error("invalid patch must not persist")
+			}
+		})
+	}
+}
+
+func TestHandler_Patch_NotFound(t *testing.T) {
+	t.Parallel()
+	rec := doReq(t, testMux(t, &fakeZoneStore{}), http.MethodPatch, "/v1/me/watch-zones/missing", `{"name":"X"}`)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("404 must be bodyless, got %s", rec.Body)
+	}
+}
+
+func TestHandler_Patch_BlankNameIsServerError(t *testing.T) {
+	t.Parallel()
+	// .NET does not validate Name at the endpoint; WithUpdates' guard throws,
+	// surfacing as a 500. The Go merge re-validates and we mirror the 500.
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	rec := doReq(t, testMux(t, store), http.MethodPatch, "/v1/me/watch-zones/"+z.ID, `{"name":"   "}`)
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500", rec.Code)
+	}
+}
+
+func TestHandler_Delete(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	rec := doReq(t, testMux(t, store), http.MethodDelete, "/v1/me/watch-zones/"+z.ID, "")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status: got %d, want 204", rec.Code)
+	}
+	if len(store.deleted) != 1 || store.deleted[0] != z.ID {
+		t.Errorf("zone not deleted: %+v", store.deleted)
+	}
+}
+
+func TestHandler_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+	rec := doReq(t, testMux(t, &fakeZoneStore{}), http.MethodDelete, "/v1/me/watch-zones/missing", "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("404 must be bodyless, got %s", rec.Body)
+	}
+}

--- a/api-go/internal/watchzones/store_cosmos.go
+++ b/api-go/internal/watchzones/store_cosmos.go
@@ -1,0 +1,120 @@
+package watchzones
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// ErrNotFound signals that no watch zone exists for the given (user, zone) pair.
+// Callers use errors.Is to translate it to a 404, mirroring .NET's
+// WatchZoneNotFoundException / null-return paths.
+var ErrNotFound = errors.New("watch zone not found")
+
+// CosmosItems is the consumer-side slice of the Cosmos container the store uses:
+// a single-partition point read/upsert/delete plus a single-partition query for
+// the per-user list. Defining it here keeps azcosmos types out of the store's
+// unit tests, which substitute a hand-written fake. platform.CosmosContainer
+// satisfies it structurally.
+type CosmosItems interface {
+	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
+	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
+	DeleteItem(ctx context.Context, partitionKey, id string) error
+	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
+}
+
+// listByUserQuery lists a user's zones. It is scoped to the userId partition, so
+// it never fans out cross-partition — matching .NET's CosmosWatchZoneRepository.
+const listByUserQuery = "SELECT * FROM c WHERE c.userId = @userId"
+
+// CosmosStore reads and writes watch zones in the WatchZones container. It holds
+// only the consumer-side item interface, so no SDK type leaks past it.
+//
+// Partition strategy: the WatchZones container is partitioned by /userId; the
+// document id equals the zone id. A single-zone operation is a point operation
+// keyed on (userId, zoneId); a user's list is one single-partition query.
+type CosmosStore struct {
+	items CosmosItems
+}
+
+// NewCosmosStore returns a store backed by the given Cosmos item accessor.
+func NewCosmosStore(items CosmosItems) *CosmosStore {
+	return &CosmosStore{items: items}
+}
+
+// GetByUserID returns all of the user's zones via a single-partition query.
+func (s *CosmosStore) GetByUserID(ctx context.Context, userID string) ([]WatchZone, error) {
+	raws, err := s.items.QueryItems(ctx, userID, listByUserQuery, map[string]any{"@userId": userID})
+	if err != nil {
+		return nil, fmt.Errorf("query watch zones for %q: %w", userID, err)
+	}
+	zones := make([]WatchZone, 0, len(raws))
+	for _, raw := range raws {
+		var doc watchZoneDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("decode watch zone for %q: %w", userID, err)
+		}
+		zone, err := doc.toDomain()
+		if err != nil {
+			return nil, fmt.Errorf("hydrate watch zone for %q: %w", userID, err)
+		}
+		zones = append(zones, zone)
+	}
+	return zones, nil
+}
+
+// Get point-reads a single zone. A 404 from Cosmos surfaces as ErrNotFound.
+func (s *CosmosStore) Get(ctx context.Context, userID, zoneID string) (WatchZone, error) {
+	raw, err := s.items.ReadItem(ctx, userID, zoneID)
+	if err != nil {
+		if isNotFound(err) {
+			return WatchZone{}, ErrNotFound
+		}
+		return WatchZone{}, fmt.Errorf("read watch zone %q: %w", zoneID, err)
+	}
+	var doc watchZoneDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return WatchZone{}, fmt.Errorf("decode watch zone %q: %w", zoneID, err)
+	}
+	zone, err := doc.toDomain()
+	if err != nil {
+		return WatchZone{}, fmt.Errorf("hydrate watch zone %q: %w", zoneID, err)
+	}
+	return zone, nil
+}
+
+// Save upserts the zone document (partition key == user id, id == zone id).
+func (s *CosmosStore) Save(ctx context.Context, z WatchZone) error {
+	body, err := json.Marshal(newWatchZoneDocument(z))
+	if err != nil {
+		return fmt.Errorf("encode watch zone %q: %w", z.ID, err)
+	}
+	if err := s.items.UpsertItem(ctx, z.UserID, body); err != nil {
+		return fmt.Errorf("upsert watch zone %q: %w", z.ID, err)
+	}
+	return nil
+}
+
+// Delete removes a zone. A 404 surfaces as ErrNotFound so the handler can return
+// the .NET 404, mirroring WatchZoneNotFoundException. (The azcosmos delete is
+// not idempotent — it 404s on a missing id — so no read-first is needed, unlike
+// the .NET REST client.)
+func (s *CosmosStore) Delete(ctx context.Context, userID, zoneID string) error {
+	if err := s.items.DeleteItem(ctx, userID, zoneID); err != nil {
+		if isNotFound(err) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("delete watch zone %q: %w", zoneID, err)
+	}
+	return nil
+}
+
+// isNotFound reports whether err is a Cosmos 404 response.
+func isNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}

--- a/api-go/internal/watchzones/store_cosmos_test.go
+++ b/api-go/internal/watchzones/store_cosmos_test.go
@@ -1,0 +1,189 @@
+package watchzones
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// fakeItems is a hand-written stand-in for the azcosmos container item API the
+// store depends on. It records each call so partition-key / id / query routing
+// can be asserted, and lets a test inject stored documents or a specific error.
+type fakeItems struct {
+	stored       map[string][]byte // id -> raw document bytes (ReadItem source)
+	readErr      error
+	upsertErr    error
+	deleteErr    error
+	queryErr     error
+	queryResult  [][]byte
+	lastReadPK   string
+	lastReadID   string
+	lastUpsertPK string
+	lastUpsert   []byte
+	lastDeletePK string
+	lastDeleteID string
+	lastQueryPK  string
+	lastQuery    string
+	lastParams   map[string]any
+}
+
+func newFakeItems() *fakeItems {
+	return &fakeItems{stored: map[string][]byte{}}
+}
+
+func (f *fakeItems) ReadItem(_ context.Context, partitionKey, id string) ([]byte, error) {
+	f.lastReadPK = partitionKey
+	f.lastReadID = id
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	b, ok := f.stored[id]
+	if !ok {
+		return nil, &azcore.ResponseError{StatusCode: http.StatusNotFound}
+	}
+	return b, nil
+}
+
+func (f *fakeItems) UpsertItem(_ context.Context, partitionKey string, item []byte) error {
+	f.lastUpsertPK = partitionKey
+	f.lastUpsert = item
+	return f.upsertErr
+}
+
+func (f *fakeItems) DeleteItem(_ context.Context, partitionKey, id string) error {
+	f.lastDeletePK = partitionKey
+	f.lastDeleteID = id
+	return f.deleteErr
+}
+
+func (f *fakeItems) QueryItems(_ context.Context, partitionKey, query string, params map[string]any) ([][]byte, error) {
+	f.lastQueryPK = partitionKey
+	f.lastQuery = query
+	f.lastParams = params
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return f.queryResult, nil
+}
+
+func mustDocBytes(t *testing.T, z WatchZone) []byte {
+	t.Helper()
+	b, err := json.Marshal(newWatchZoneDocument(z))
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	return b
+}
+
+func TestCosmosStore_GetByUserID_SinglePartitionQuery(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	items := newFakeItems()
+	items.queryResult = [][]byte{mustDocBytes(t, z)}
+	store := NewCosmosStore(items)
+
+	zones, err := store.GetByUserID(context.Background(), "auth0|user")
+	if err != nil {
+		t.Fatalf("GetByUserID: %v", err)
+	}
+	if len(zones) != 1 || zones[0].ID != z.ID {
+		t.Fatalf("zones: got %+v", zones)
+	}
+	if items.lastQueryPK != "auth0|user" {
+		t.Errorf("query partition key: got %q, want auth0|user", items.lastQueryPK)
+	}
+	if items.lastParams["@userId"] != "auth0|user" {
+		t.Errorf("query param @userId: got %v", items.lastParams["@userId"])
+	}
+}
+
+func TestCosmosStore_GetByUserID_EmptyWhenNoZones(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+	zones, err := store.GetByUserID(context.Background(), "auth0|user")
+	if err != nil {
+		t.Fatalf("GetByUserID: %v", err)
+	}
+	if len(zones) != 0 {
+		t.Errorf("expected no zones, got %+v", zones)
+	}
+}
+
+func TestCosmosStore_Get_PointReadKeyedByUserAndZone(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	items := newFakeItems()
+	items.stored[z.ID] = mustDocBytes(t, z)
+	store := NewCosmosStore(items)
+
+	got, err := store.Get(context.Background(), z.UserID, z.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != z.ID {
+		t.Errorf("id: got %q, want %q", got.ID, z.ID)
+	}
+	if items.lastReadPK != z.UserID || items.lastReadID != z.ID {
+		t.Errorf("point read keys: pk=%q id=%q, want pk=%q id=%q", items.lastReadPK, items.lastReadID, z.UserID, z.ID)
+	}
+}
+
+func TestCosmosStore_Get_NotFound(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+	_, err := store.Get(context.Background(), "auth0|user", "missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestCosmosStore_Save_UpsertsKeyedByUser(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if err := store.Save(context.Background(), z); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if items.lastUpsertPK != z.UserID {
+		t.Errorf("upsert partition key: got %q, want %q", items.lastUpsertPK, z.UserID)
+	}
+	var doc watchZoneDocument
+	if err := json.Unmarshal(items.lastUpsert, &doc); err != nil {
+		t.Fatalf("unmarshal upserted doc: %v", err)
+	}
+	if doc.ID != z.ID || doc.UserID != z.UserID {
+		t.Errorf("upserted doc identity: got %+v", doc)
+	}
+}
+
+func TestCosmosStore_Delete_Success(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if err := store.Delete(context.Background(), z.UserID, z.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if items.lastDeletePK != z.UserID || items.lastDeleteID != z.ID {
+		t.Errorf("delete keys: pk=%q id=%q, want pk=%q id=%q", items.lastDeletePK, items.lastDeleteID, z.UserID, z.ID)
+	}
+}
+
+func TestCosmosStore_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	items.deleteErr = &azcore.ResponseError{StatusCode: http.StatusNotFound}
+	store := NewCosmosStore(items)
+
+	err := store.Delete(context.Background(), "auth0|user", "missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}

--- a/api-go/internal/watchzones/zone.go
+++ b/api-go/internal/watchzones/zone.go
@@ -1,0 +1,124 @@
+// Package watchzones owns the watch-zone feature: the domain model, the Cosmos
+// store over the WatchZones container, and the /v1/me/watch-zones HTTP handlers.
+// It mirrors the .NET TownCrier.{Domain,Application,Infrastructure}.WatchZones
+// slices (GH#418 iteration 5) but follows idiomatic Go — a plain struct
+// validated at construction, a consumer-side store interface, and hand-written
+// test fakes.
+//
+// Scope note: POST create (whose response body carries nearby applications) and
+// GET /{zoneId}/applications are deferred to bead tc-5847 — they hard-depend on
+// the geo/application stores that land in later iterations. This package ships
+// list, update (PATCH), and delete; per-zone notification preferences live on
+// the user profile and are served by the profiles package.
+package watchzones
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+// WatchZone is a user's geofenced monitoring area: a circle (centre + radius)
+// scoped to one planning authority. Exported fields keep it a plain Go value;
+// the constructor enforces the invariants .NET guards in WatchZone's ctor.
+type WatchZone struct {
+	ID                  string
+	UserID              string
+	Name                string
+	Latitude            float64
+	Longitude           float64
+	RadiusMetres        float64
+	AuthorityID         int
+	CreatedAt           time.Time
+	PushEnabled         bool
+	EmailInstantEnabled bool
+}
+
+// NewWatchZone validates and constructs a watch zone. It mirrors the .NET
+// WatchZone constructor: id, user id and name must be non-blank and radius and
+// authority id must be positive. Coordinate range is deliberately NOT checked
+// here — like .NET, that is an HTTP-layer validation, so the domain accepts any
+// latitude/longitude.
+func NewWatchZone(id, userID, name string, latitude, longitude, radiusMetres float64, authorityID int, createdAt time.Time, pushEnabled, emailInstantEnabled bool) (WatchZone, error) {
+	if strings.TrimSpace(id) == "" {
+		return WatchZone{}, errors.New("id is required")
+	}
+	if strings.TrimSpace(userID) == "" {
+		return WatchZone{}, errors.New("user id is required")
+	}
+	if strings.TrimSpace(name) == "" {
+		return WatchZone{}, errors.New("name is required")
+	}
+	if radiusMetres <= 0 {
+		return WatchZone{}, errors.New("radius must be positive")
+	}
+	if authorityID <= 0 {
+		return WatchZone{}, errors.New("authority id must be positive")
+	}
+	return WatchZone{
+		ID:                  id,
+		UserID:              userID,
+		Name:                name,
+		Latitude:            latitude,
+		Longitude:           longitude,
+		RadiusMetres:        radiusMetres,
+		AuthorityID:         authorityID,
+		CreatedAt:           createdAt,
+		PushEnabled:         pushEnabled,
+		EmailInstantEnabled: emailInstantEnabled,
+	}, nil
+}
+
+// ZoneUpdate is a partial PATCH: a nil field leaves the existing value
+// untouched, mirroring the nullable parameters of .NET's WatchZone.WithUpdates.
+type ZoneUpdate struct {
+	Name                *string
+	Latitude            *float64
+	Longitude           *float64
+	RadiusMetres        *float64
+	AuthorityID         *int
+	PushEnabled         *bool
+	EmailInstantEnabled *bool
+}
+
+// WithUpdates returns a copy of the zone with the non-nil fields of u applied,
+// re-validated through the constructor — so a merge that would violate an
+// invariant (e.g. a blank name) returns an error rather than a corrupt zone,
+// exactly as .NET's WithUpdates re-runs its guards. Identity (id, user id) and
+// the creation timestamp are immutable across an update.
+func (z WatchZone) WithUpdates(u ZoneUpdate) (WatchZone, error) {
+	updated := z
+	if u.Name != nil {
+		updated.Name = *u.Name
+	}
+	if u.Latitude != nil {
+		updated.Latitude = *u.Latitude
+	}
+	if u.Longitude != nil {
+		updated.Longitude = *u.Longitude
+	}
+	if u.RadiusMetres != nil {
+		updated.RadiusMetres = *u.RadiusMetres
+	}
+	if u.AuthorityID != nil {
+		updated.AuthorityID = *u.AuthorityID
+	}
+	if u.PushEnabled != nil {
+		updated.PushEnabled = *u.PushEnabled
+	}
+	if u.EmailInstantEnabled != nil {
+		updated.EmailInstantEnabled = *u.EmailInstantEnabled
+	}
+	return NewWatchZone(
+		updated.ID,
+		updated.UserID,
+		updated.Name,
+		updated.Latitude,
+		updated.Longitude,
+		updated.RadiusMetres,
+		updated.AuthorityID,
+		updated.CreatedAt,
+		updated.PushEnabled,
+		updated.EmailInstantEnabled,
+	)
+}

--- a/api-go/internal/watchzones/zone_test.go
+++ b/api-go/internal/watchzones/zone_test.go
@@ -1,0 +1,125 @@
+package watchzones
+
+import (
+	"testing"
+	"time"
+)
+
+func testZone(t *testing.T) WatchZone {
+	t.Helper()
+	z, err := NewWatchZone(
+		"zone-1", "auth0|user", "Home",
+		51.5074, -0.1278, 1000, 471,
+		time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC),
+		true, true)
+	if err != nil {
+		t.Fatalf("NewWatchZone: %v", err)
+	}
+	return z
+}
+
+func TestNewWatchZone_Validation(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		id          string
+		userID      string
+		zoneName    string
+		radius      float64
+		authorityID int
+		wantErr     bool
+	}{
+		{"valid", "z1", "u1", "Home", 500, 471, false},
+		{"blank id", "", "u1", "Home", 500, 471, true},
+		{"whitespace id", "  ", "u1", "Home", 500, 471, true},
+		{"blank user", "z1", "", "Home", 500, 471, true},
+		{"blank name", "z1", "u1", "", 500, 471, true},
+		{"whitespace name", "z1", "u1", "   ", 500, 471, true},
+		{"zero radius", "z1", "u1", "Home", 0, 471, true},
+		{"negative radius", "z1", "u1", "Home", -5, 471, true},
+		{"zero authority", "z1", "u1", "Home", 500, 0, true},
+		{"negative authority", "z1", "u1", "Home", 500, -3, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewWatchZone(tc.id, tc.userID, tc.zoneName, 51, -0.1, tc.radius, tc.authorityID, now, true, true)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("got err=%v, wantErr=%v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestNewWatchZone_DoesNotValidateCoordinateRange(t *testing.T) {
+	t.Parallel()
+	// Mirrors .NET WatchZone: latitude/longitude range is an HTTP-layer concern,
+	// not a domain invariant. The constructor accepts any coordinate.
+	now := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	if _, err := NewWatchZone("z1", "u1", "Home", 999, -999, 500, 471, now, true, true); err != nil {
+		t.Fatalf("constructor must not range-check coordinates: %v", err)
+	}
+}
+
+func TestWatchZone_WithUpdates_PartialMergePreservesUnsetFields(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	newName := "Office"
+	newRadius := 2500.0
+	push := false
+
+	updated, err := z.WithUpdates(ZoneUpdate{
+		Name:         &newName,
+		RadiusMetres: &newRadius,
+		PushEnabled:  &push,
+	})
+	if err != nil {
+		t.Fatalf("WithUpdates: %v", err)
+	}
+
+	if updated.Name != "Office" {
+		t.Errorf("name: got %q, want Office", updated.Name)
+	}
+	if updated.RadiusMetres != 2500 {
+		t.Errorf("radius: got %v, want 2500", updated.RadiusMetres)
+	}
+	if updated.PushEnabled != false {
+		t.Errorf("pushEnabled: got %v, want false", updated.PushEnabled)
+	}
+	// Unset fields preserved.
+	if updated.Latitude != z.Latitude || updated.Longitude != z.Longitude {
+		t.Errorf("coords changed: got (%v,%v), want (%v,%v)", updated.Latitude, updated.Longitude, z.Latitude, z.Longitude)
+	}
+	if updated.AuthorityID != z.AuthorityID {
+		t.Errorf("authorityId changed: got %d, want %d", updated.AuthorityID, z.AuthorityID)
+	}
+	if updated.EmailInstantEnabled != z.EmailInstantEnabled {
+		t.Errorf("emailInstantEnabled changed: got %v, want %v", updated.EmailInstantEnabled, z.EmailInstantEnabled)
+	}
+	// Identity and creation timestamp are immutable across an update.
+	if updated.ID != z.ID || updated.UserID != z.UserID || !updated.CreatedAt.Equal(z.CreatedAt) {
+		t.Errorf("identity/createdAt mutated: %+v", updated)
+	}
+}
+
+func TestWatchZone_WithUpdates_RejectsInvalidMergeResult(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	blank := "   "
+	if _, err := z.WithUpdates(ZoneUpdate{Name: &blank}); err == nil {
+		t.Fatal("WithUpdates must re-validate: blank name should error")
+	}
+}
+
+func TestWatchZone_WithUpdates_EmptyUpdateIsIdentity(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	updated, err := z.WithUpdates(ZoneUpdate{})
+	if err != nil {
+		t.Fatalf("WithUpdates: %v", err)
+	}
+	if updated != z {
+		t.Errorf("empty update changed zone: got %+v, want %+v", updated, z)
+	}
+}

--- a/api-go/tests/e2e/contract_watchzones_test.go
+++ b/api-go/tests/e2e/contract_watchzones_test.go
@@ -1,0 +1,189 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// Valid-token contract scenarios for the iteration-5 watch-zone surface. The
+// shipped surface is GET list, PATCH update, DELETE, and GET/PUT per-zone
+// preferences; POST create and GET /{zoneId}/applications are deferred (tc-5847)
+// and so a zone is created via the .NET API as un-diffed setup. Both APIs share
+// one Cosmos database, so every diffed call observes the same deterministic
+// state and body equality is exact.
+//
+// Quota-safe: exactly one zone is created and it is always deleted on cleanup
+// (only the zone this test created is touched). Scenarios skip when the token
+// env is absent so plain local runs stay green.
+
+// wzExchange is one authenticated request that may carry a JSON body; it also
+// captures the Location header (used to read a created zone's id).
+type wzExchange struct {
+	status      int
+	contentType string
+	location    string
+	body        []byte
+}
+
+func watchZoneRequest(t *testing.T, client *http.Client, base, method, path, token, body string) wzExchange {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, base+path, reader)
+	if err != nil {
+		t.Fatalf("new request %s %s: %v", method, path, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
+	if err != nil {
+		t.Fatalf("read body %s %s: %v", method, path, err)
+	}
+	return wzExchange{
+		status:      resp.StatusCode,
+		contentType: resp.Header.Get("Content-Type"),
+		location:    resp.Header.Get("Location"),
+		body:        raw,
+	}
+}
+
+// diffWatchZone runs the same authenticated request against both APIs and
+// asserts status, content type, and JSON body match (the .NET response is the
+// source of truth). Bodyless responses are compared as raw bytes.
+func diffWatchZone(t *testing.T, client *http.Client, dotnetURL, goURL, method, path, token, body string) {
+	t.Helper()
+
+	want := watchZoneRequest(t, client, dotnetURL, method, path, token, body)
+	got := watchZoneRequest(t, client, goURL, method, path, token, body)
+
+	if got.status != want.status {
+		t.Errorf("%s %s status: go=%d dotnet=%d (go body %s)", method, path, got.status, want.status, got.body)
+	}
+	if got.contentType != want.contentType {
+		t.Errorf("%s %s content-type: go=%q dotnet=%q", method, path, got.contentType, want.contentType)
+	}
+	if len(want.body) == 0 || len(got.body) == 0 {
+		if !bytes.Equal(got.body, want.body) {
+			t.Errorf("%s %s body: go=%q dotnet=%q", method, path, got.body, want.body)
+		}
+		return
+	}
+	if !jsonEqual(t, got.body, want.body) {
+		t.Errorf("%s %s body: go=%s dotnet=%s", method, path, got.body, want.body)
+	}
+}
+
+func TestContract_WatchZones(t *testing.T) {
+	dotnetURL := baseURL(t, "DOTNET_BASE_URL")
+	goURL := baseURL(t, "GO_BASE_URL")
+	token := integrationToken(t)
+	client := &http.Client{Timeout: requestTimeout}
+
+	// Setup, not a diff: ensure the profile exists (watch zones require one),
+	// then create a single zone on the .NET side. Its id comes back in the
+	// Location header (/v1/me/watch-zones/{zoneId}).
+	if setup := watchZoneRequest(t, client, dotnetURL, http.MethodPost, "/v1/me", token, ""); setup.status >= 500 {
+		t.Fatalf("setup POST /v1/me on .NET: %d %s", setup.status, setup.body)
+	}
+
+	suffix := newZoneSuffix(t)
+	createBody := fmt.Sprintf(
+		`{"name":"Contract Zone %s","latitude":51.5074,"longitude":-0.1278,"radiusMetres":1000,"authorityId":471}`,
+		suffix)
+	created := watchZoneRequest(t, client, dotnetURL, http.MethodPost, "/v1/me/watch-zones", token, createBody)
+	if created.status == http.StatusForbidden {
+		t.Skipf("watch-zone quota exhausted on the shared test user — skipping (%s)", created.body)
+	}
+	if created.status != http.StatusCreated {
+		t.Fatalf("setup create on .NET: status %d body %s", created.status, created.body)
+	}
+	zoneID := created.location[strings.LastIndex(created.location, "/")+1:]
+	if zoneID == "" {
+		t.Fatalf("setup create returned no zone id in Location %q", created.location)
+	}
+	zonePath := "/v1/me/watch-zones/" + zoneID
+	prefsPath := zonePath + "/preferences"
+
+	// Always remove the created zone, even if an assertion fails.
+	t.Cleanup(func() {
+		_ = watchZoneRequest(t, client, dotnetURL, http.MethodDelete, zonePath, token, "")
+	})
+
+	// List: both read the shared Cosmos partition, so the zone (and any others)
+	// appears identically.
+	t.Run("GET list", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodGet, "/v1/me/watch-zones", token, "")
+	})
+
+	// Update: a full PATCH body is fully deterministic, so applying it to both
+	// APIs (each over the same document) yields identical updated summaries.
+	t.Run("PATCH update", func(t *testing.T) {
+		patchBody := fmt.Sprintf(
+			`{"name":"Contract Zone %s Updated","latitude":52.4862,"longitude":-1.8904,"radiusMetres":1500,"authorityId":471,"pushEnabled":false,"emailInstantEnabled":false}`,
+			suffix)
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodPatch, zonePath, token, patchBody)
+	})
+
+	// Preferences default to all-on for a zone the user never customised.
+	t.Run("GET preferences (defaults)", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodGet, prefsPath, token, "")
+	})
+
+	// Update preferences: deterministic body, identical result on both.
+	t.Run("PUT preferences", func(t *testing.T) {
+		prefsBody := `{"newApplicationPush":false,"newApplicationEmail":true,"decisionPush":false,"decisionEmail":true}`
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodPut, prefsPath, token, prefsBody)
+	})
+
+	// Read-back reflects the PUT identically on both.
+	t.Run("GET preferences (after PUT)", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodGet, prefsPath, token, "")
+	})
+
+	// A present-but-out-of-range field is a 400 with the ApiErrorResponse
+	// envelope; the guard runs before the zone is loaded, so any id works.
+	t.Run("PATCH invalid payload", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodPatch, zonePath, token, `{"authorityId":0}`)
+	})
+
+	// Deleting a non-existent zone is a bodyless 404 on both — exercised on a
+	// random id so it never touches the zone this test created.
+	t.Run("DELETE not found", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodDelete, "/v1/me/watch-zones/"+newZoneSuffix(t), token, "")
+	})
+}
+
+// newZoneSuffix returns a random hex suffix for unique zone names / ids. The
+// WatchZones container enforces a per-user unique key on name, so each created
+// zone needs a distinct name even across overlapping CI runs.
+func newZoneSuffix(t *testing.T) string {
+	t.Helper()
+	var b [8]byte
+	if _, err := io.ReadFull(rand.Reader, b[:]); err != nil {
+		t.Fatalf("random suffix: %v", err)
+	}
+	return fmt.Sprintf("%x", b)
+}


### PR DESCRIPTION
Iteration 5 of the Go API migration (GH #418): ports the watch-zone web surface to `api-go/`.

## Scope shipped
- `GET /v1/me/watch-zones` — list the user's zones (`{zones:[…]}`)
- `PATCH /v1/me/watch-zones/{zoneId}` — partial update (`{zone:{…}}`; `400` ApiErrorResponse on out-of-range field; `404` if absent)
- `DELETE /v1/me/watch-zones/{zoneId}` — `204`; `404` if absent
- `GET`/`PUT /v1/me/watch-zones/{zoneId}/preferences` — per-zone notification prefs on the profile doc

## Deferred (tc-5847)
`POST` create (response carries nearby applications) and `GET /{zoneId}/applications` hard-depend on the geo/application stores from later iterations, so faking them would fail the contract diff. Filed as a discovered bead.

## Parity notes
- New `internal/watchzones` package: domain + `WithUpdates`, Cosmos document (camelCase, `createdAt` as .NET DateTimeOffset via `platform.DotNetTime`, nullable flags coalesce-true), store (single-partition list/point ops, `404→ErrNotFound`), handlers.
- Per-zone preferences live on the existing profile document, so their handlers sit in `profiles` (mirroring .NET's UserProfiles slice) and reuse the profile store.
- New container const `CosmosWatchZonesContainer = "WatchZones"`; store wired through `main.go`/`newRouter` with the nil-means-unwired convention.

## Tests
- Red/green TDD, hand-written fakes, table-driven; 288 unit tests pass with `-race`.
- e2e contract scenarios (`contract_watchzones_test.go`) diff list/patch/prefs(×2)/invalid-400/delete-404 against the live .NET dev API, creating one zone via .NET setup and deleting only that zone on cleanup (quota-safe, `authorityId` 471).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added watch zones API with support for listing, updating, and deleting user zones.
  * Added zone-specific notification preferences (GET/PUT) to manage per-zone alert settings for push and email notifications.
  * Watch zone operations support coordinate and radius validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->