### PR TITLE
feat(go): it6 saved + planning applications (tc-7g3i.7)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -13,11 +13,13 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
@@ -74,6 +76,24 @@ func main() {
 		watchZoneStore = watchzones.NewCosmosStore(watchZones)
 	}
 
+	appsContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosApplicationsContainer, logger)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var appStore *applications.CosmosStore
+	if appsContainer != nil {
+		appStore = applications.NewCosmosStore(appsContainer)
+	}
+
+	savedContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosSavedApplicationsContainer, logger)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var savedStore *savedapplications.CosmosStore
+	if savedContainer != nil {
+		savedStore = savedapplications.NewCosmosStore(savedContainer)
+	}
+
 	// Real M2M client only when fully configured; otherwise the no-op fallback,
 	// matching .NET's conditional IAuth0ManagementClient registration.
 	var manager profiles.Auth0Manager = profiles.NoOpAuth0Client{}
@@ -86,7 +106,7 @@ func main() {
 		)
 	}
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, deviceStore, stateStore, watchZoneStore, logger))
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, deviceStore, stateStore, watchZoneStore, appStore, savedStore, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/api"
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/authorities"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
@@ -14,6 +15,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/middleware"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/versionconfig"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
@@ -68,7 +70,7 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // nil-means-unwired convention. (The watch-zone preferences endpoints are
 // served by profiles.Routes off the profile store, so they come up with the
 // /v1/me routes, not the watch-zone store.)
-func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, watchZoneStore *watchzones.CosmosStore, logger *slog.Logger) http.Handler {
+func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)
@@ -91,6 +93,17 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 	}
 	if watchZoneStore != nil {
 		watchzones.Routes(mux, watchZoneStore, logger)
+		// application-authorities derives from the user's watch zones plus the
+		// static authority data; it needs no Cosmos applications store.
+		applications.AuthoritiesRoutes(mux, watchZoneStore, authorities.NewLookup(), logger)
+	}
+	if appStore != nil {
+		applications.Routes(mux, appStore, logger)
+	}
+	if savedStore != nil && appStore != nil {
+		// The save path dual-writes: the master application record (appStore) then
+		// the saved row, so both stores are required to wire the endpoints.
+		savedapplications.Routes(mux, savedStore, appStore, time.Now, logger)
 	}
 
 	authed := auth.RequireAuth(validator, &dispatchMux{ServeMux: mux, dispatch: dispatch}, anonymousPatterns)

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -13,8 +13,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
@@ -95,7 +97,7 @@ func idFromDoc(raw []byte) string {
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -192,8 +194,10 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	store := profiles.NewCosmosStore(newFakeItems())
 	watchZoneStore := watchzones.NewCosmosStore(newFakeItems())
+	appStore := applications.NewCosmosStore(newFakeItems())
+	savedStore := savedapplications.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", nil, nil, watchZoneStore, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", nil, nil, watchZoneStore, appStore, savedStore, logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -223,6 +227,24 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	}
 	if got := strings.TrimSpace(rec.Body.String()); got != `{"zones":[]}` {
 		t.Errorf("GET /v1/me/watch-zones body = %s, want {\"zones\":[]}", got)
+	}
+
+	// Saved-application routes are wired behind the same chain (empty list array).
+	rec = serveReq(t, h, http.MethodGet, "/v1/me/saved-applications", "", "Bearer tok")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/me/saved-applications status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != `[]` {
+		t.Errorf("GET /v1/me/saved-applications body = %s, want []", got)
+	}
+
+	// application-authorities is wired off the watch-zone store (empty set).
+	rec = serveReq(t, h, http.MethodGet, "/v1/me/application-authorities", "", "Bearer tok")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/me/application-authorities status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if got := strings.TrimSpace(rec.Body.String()); got != `{"authorities":[],"count":0}` {
+		t.Errorf("GET /v1/me/application-authorities body = %s", got)
 	}
 
 	// Anonymous routes stay unmetered even on the store-wired router.

--- a/api-go/internal/applications/application.go
+++ b/api-go/internal/applications/application.go
@@ -1,0 +1,51 @@
+// Package applications owns the master planning-application feature: the domain
+// snapshot, the Cosmos store over the Applications container (point read by
+// authority + name), and the read endpoints (GET /v1/applications/{authorityCode}/{name}
+// and GET /v1/me/application-authorities). It mirrors the .NET
+// TownCrier.{Domain,Application,Infrastructure}.PlanningApplications slices
+// (GH#418 iteration 6).
+//
+// A PlanningApplication is a snapshot of a PlanIt case: a plain data carrier
+// (the values come from an external provider, validated at the HTTP boundary),
+// not a rich aggregate.
+package applications
+
+import (
+	"strconv"
+	"time"
+)
+
+// PlanningApplication is the planning-application snapshot. Nullable fields are
+// pointers so an absent value serialises as JSON null, matching the .NET
+// nullable properties. Coordinates are carried flat here; the Cosmos document
+// projects them into a GeoJSON point.
+type PlanningApplication struct {
+	Name          string
+	UID           string
+	AreaName      string
+	AreaID        int
+	Address       string
+	Postcode      *string
+	Description   string
+	AppType       *string
+	AppState      *string
+	AppSize       *string
+	StartDate     *time.Time
+	DecidedDate   *time.Time
+	ConsultedDate *time.Time
+	Longitude     *float64
+	Latitude      *float64
+	URL           *string
+	Link          *string
+	LastDifferent time.Time
+}
+
+// CanonicalUID is the server-derived identity "{AreaID}/{Name}". PlanIt case
+// references are only unique within a council, so the authority must be part of
+// the key. This is deliberately independent of the raw UID field — a client may
+// send a stale-format uid, but two saves of the same (AreaID, Name) always
+// produce the same canonical uid, keeping the saved-application doc id stable
+// and re-saves idempotent. Mirrors .NET PlanningApplication.CanonicalUid.
+func (a PlanningApplication) CanonicalUID() string {
+	return strconv.Itoa(a.AreaID) + "/" + a.Name
+}

--- a/api-go/internal/applications/application_test.go
+++ b/api-go/internal/applications/application_test.go
@@ -1,0 +1,59 @@
+package applications
+
+import (
+	"testing"
+	"time"
+)
+
+// testApplication is a fully-populated planning application used across the
+// package's tests.
+func testApplication(t *testing.T) PlanningApplication {
+	t.Helper()
+	postcode := "EC2V 5AE"
+	appType := "Full"
+	appState := "Permitted"
+	appSize := "Small"
+	start := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+	decided := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	consulted := time.Date(2026, 1, 20, 0, 0, 0, 0, time.UTC)
+	lon := -0.0931
+	lat := 51.5155
+	url := "https://planit.example/app"
+	link := "https://council.example/app"
+	return PlanningApplication{
+		Name:          "24/0123/FUL",
+		UID:           "ABC-24-0123",
+		AreaName:      "City of London",
+		AreaID:        471,
+		Address:       "1 Test Street",
+		Postcode:      &postcode,
+		Description:   "Single storey extension",
+		AppType:       &appType,
+		AppState:      &appState,
+		AppSize:       &appSize,
+		StartDate:     &start,
+		DecidedDate:   &decided,
+		ConsultedDate: &consulted,
+		Longitude:     &lon,
+		Latitude:      &lat,
+		URL:           &url,
+		Link:          &link,
+		LastDifferent: time.Date(2026, 3, 2, 9, 30, 0, 0, time.UTC),
+	}
+}
+
+func TestPlanningApplication_CanonicalUID(t *testing.T) {
+	t.Parallel()
+	a := PlanningApplication{Name: "24/0123/FUL", AreaID: 471}
+	if got := a.CanonicalUID(); got != "471/24/0123/FUL" {
+		t.Errorf("CanonicalUID: got %q, want 471/24/0123/FUL", got)
+	}
+}
+
+func TestPlanningApplication_CanonicalUID_PreservesNameWithSlashes(t *testing.T) {
+	t.Parallel()
+	a := PlanningApplication{Name: "P/2026/0044/HH", AreaID: 9}
+	if got := a.CanonicalUID(); got != "9/P/2026/0044/HH" {
+		t.Errorf("CanonicalUID: got %q", got)
+	}
+}

--- a/api-go/internal/applications/applicationauthorities.go
+++ b/api-go/internal/applications/applicationauthorities.go
@@ -1,0 +1,84 @@
+package applications
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"slices"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/authorities"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// zoneAuthorityLister yields the user's watch zones; the application-authorities
+// endpoint derives its authority set from their distinct authority ids.
+type zoneAuthorityLister interface {
+	GetByUserID(ctx context.Context, userID string) ([]watchzones.WatchZone, error)
+}
+
+// authorityLookup resolves an authority id to its display metadata.
+type authorityLookup interface {
+	ByID(id int) (authorities.Authority, bool)
+}
+
+// authoritiesHandler serves GET /v1/me/application-authorities.
+type authoritiesHandler struct {
+	zones  zoneAuthorityLister
+	lookup authorityLookup
+	logger *slog.Logger
+}
+
+// AuthoritiesRoutes registers GET /v1/me/application-authorities, the distinct
+// set of authorities across the user's watch zones, resolved to display
+// metadata and sorted by name.
+func AuthoritiesRoutes(mux *http.ServeMux, zones zoneAuthorityLister, lookup authorityLookup, logger *slog.Logger) {
+	h := &authoritiesHandler{zones: zones, lookup: lookup, logger: logger}
+	mux.HandleFunc("GET /v1/me/application-authorities", h.list)
+}
+
+// authorityItem mirrors .NET AuthorityListItem: { id, name, areaType }.
+type authorityItem struct {
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	AreaType string `json:"areaType"`
+}
+
+// applicationAuthoritiesResult mirrors .NET GetUserApplicationAuthoritiesResult:
+// { authorities: [...], count }.
+type applicationAuthoritiesResult struct {
+	Authorities []authorityItem `json:"authorities"`
+	Count       int             `json:"count"`
+}
+
+// list resolves the distinct authorities across the user's watch zones to
+// display metadata, sorts them by name (ordinal, case-insensitive) and returns
+// the list with its count. Authorities not present in the static data are
+// silently skipped, matching .NET's null-skip.
+func (h *authoritiesHandler) list(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+
+	zones, err := h.zones.GetByUserID(r.Context(), userID)
+	if err != nil {
+		serverError(w, r, h.logger, "list watch zones", err)
+		return
+	}
+
+	seen := make(map[int]struct{}, len(zones))
+	items := []authorityItem{}
+	for _, z := range zones {
+		if _, dup := seen[z.AuthorityID]; dup {
+			continue
+		}
+		seen[z.AuthorityID] = struct{}{}
+		if a, ok := h.lookup.ByID(z.AuthorityID); ok {
+			items = append(items, authorityItem{ID: a.ID, Name: a.Name, AreaType: a.AreaType})
+		}
+	}
+
+	slices.SortStableFunc(items, func(a, b authorityItem) int {
+		return authorities.CompareOrdinalIgnoreCase(a.Name, b.Name)
+	})
+
+	writeJSON(w, r, h.logger, applicationAuthoritiesResult{Authorities: items, Count: len(items)})
+}

--- a/api-go/internal/applications/applicationauthorities_test.go
+++ b/api-go/internal/applications/applicationauthorities_test.go
@@ -1,0 +1,108 @@
+package applications
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/authorities"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+type fakeZoneLister struct {
+	zones []watchzones.WatchZone
+	err   error
+}
+
+func (f *fakeZoneLister) GetByUserID(_ context.Context, _ string) ([]watchzones.WatchZone, error) {
+	return f.zones, f.err
+}
+
+// fakeLookup resolves only the ids it was seeded with.
+type fakeLookup map[int]authorities.Authority
+
+func (f fakeLookup) ByID(id int) (authorities.Authority, bool) {
+	a, ok := f[id]
+	return a, ok
+}
+
+func zone(t *testing.T, authorityID int) watchzones.WatchZone {
+	t.Helper()
+	z, err := watchzones.NewWatchZone("z"+time.Now().Format("150405.000000000"), "u", "Z", 51, -0.1, 100, authorityID, time.Now(), true, true)
+	if err != nil {
+		t.Fatalf("NewWatchZone: %v", err)
+	}
+	return z
+}
+
+func serveAuthorities(t *testing.T, zones zoneAuthorityLister, lookup authorityLookup) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	AuthoritiesRoutes(mux, zones, lookup, slog.New(slog.DiscardHandler))
+	req := httptest.NewRequestWithContext(auth.WithSubject(context.Background(), "auth0|u"), http.MethodGet, "/v1/me/application-authorities", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestApplicationAuthorities_DistinctSortedWithCount(t *testing.T) {
+	t.Parallel()
+	lister := &fakeZoneLister{zones: []watchzones.WatchZone{
+		zone(t, 471), zone(t, 9), zone(t, 471), // 471 duplicated
+	}}
+	lookup := fakeLookup{
+		471: {ID: 471, Name: "City of London", AreaType: "city"},
+		9:   {ID: 9, Name: "Aberdeen", AreaType: "council"},
+	}
+
+	rec := serveAuthorities(t, lister, lookup)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("content-type: got %q", ct)
+	}
+	var got struct {
+		Authorities []authorityItem `json:"authorities"`
+		Count       int             `json:"count"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Count != 2 || len(got.Authorities) != 2 {
+		t.Fatalf("expected 2 distinct authorities, got %+v", got)
+	}
+	// Sorted by name (Aberdeen before City of London), duplicate 471 collapsed.
+	if got.Authorities[0].ID != 9 || got.Authorities[1].ID != 471 {
+		t.Errorf("order: %+v", got.Authorities)
+	}
+}
+
+func TestApplicationAuthorities_EmptyArrayWhenNoZones(t *testing.T) {
+	t.Parallel()
+	rec := serveAuthorities(t, &fakeZoneLister{}, fakeLookup{})
+	if got := rec.Body.String(); got != `{"authorities":[],"count":0}` {
+		t.Errorf("empty body: got %s", got)
+	}
+}
+
+func TestApplicationAuthorities_SkipsUnknownAuthority(t *testing.T) {
+	t.Parallel()
+	lister := &fakeZoneLister{zones: []watchzones.WatchZone{zone(t, 471), zone(t, 99999)}}
+	lookup := fakeLookup{471: {ID: 471, Name: "City of London", AreaType: "city"}}
+
+	rec := serveAuthorities(t, lister, lookup)
+	var got struct {
+		Authorities []authorityItem `json:"authorities"`
+		Count       int             `json:"count"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &got)
+	if got.Count != 1 || got.Authorities[0].ID != 471 {
+		t.Errorf("unknown authority not skipped: %+v", got)
+	}
+}

--- a/api-go/internal/applications/document.go
+++ b/api-go/internal/applications/document.go
@@ -1,0 +1,127 @@
+package applications
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// geoJSONPoint is the Cosmos GeoJSON projection of an application's coordinates:
+// a Point with [longitude, latitude] order (GeoJSON convention). Mirrors the
+// .NET GeoJsonPoint so ST_DISTANCE spatial queries see the same shape.
+type geoJSONPoint struct {
+	Type        string    `json:"type"`
+	Coordinates []float64 `json:"coordinates"`
+}
+
+// applicationDocument is the Cosmos persistence shape for a PlanningApplication
+// in the Applications container. JSON tags reproduce the camelCase keys the .NET
+// CosmosPlanningApplicationRepository writes.
+//
+// Partition key: authorityCode (the AreaID as a string). Document id: the PlanIt
+// case reference (Name). A point read is keyed on (authorityCode, name); upserts
+// target the authorityCode partition.
+type applicationDocument struct {
+	ID            string              `json:"id"`
+	AuthorityCode string              `json:"authorityCode"`
+	PlanitName    string              `json:"planitName"`
+	UID           string              `json:"uid"`
+	AreaName      string              `json:"areaName"`
+	AreaID        int                 `json:"areaId"`
+	Address       string              `json:"address"`
+	Postcode      *string             `json:"postcode"`
+	Description   string              `json:"description"`
+	AppType       *string             `json:"appType"`
+	AppState      *string             `json:"appState"`
+	AppSize       *string             `json:"appSize"`
+	StartDate     *platform.DateOnly  `json:"startDate"`
+	DecidedDate   *platform.DateOnly  `json:"decidedDate"`
+	ConsultedDate *platform.DateOnly  `json:"consultedDate"`
+	Location      *geoJSONPoint       `json:"location"`
+	URL           *string             `json:"url"`
+	Link          *string             `json:"link"`
+	LastDifferent platform.DotNetTime `json:"lastDifferent"`
+}
+
+// newApplicationDocument maps a domain snapshot to its Applications-container
+// shape. The document id is the name and the partition key is the stringified
+// area id, matching .NET FromDomain.
+func newApplicationDocument(a PlanningApplication) applicationDocument {
+	return applicationDocument{
+		ID:            a.Name,
+		AuthorityCode: strconv.Itoa(a.AreaID),
+		PlanitName:    a.Name,
+		UID:           a.UID,
+		AreaName:      a.AreaName,
+		AreaID:        a.AreaID,
+		Address:       a.Address,
+		Postcode:      a.Postcode,
+		Description:   a.Description,
+		AppType:       a.AppType,
+		AppState:      a.AppState,
+		AppSize:       a.AppSize,
+		StartDate:     platform.DateOnlyPtr(a.StartDate),
+		DecidedDate:   platform.DateOnlyPtr(a.DecidedDate),
+		ConsultedDate: platform.DateOnlyPtr(a.ConsultedDate),
+		Location:      newGeoPoint(a.Longitude, a.Latitude),
+		URL:           a.URL,
+		Link:          a.Link,
+		LastDifferent: platform.DotNetTime(a.LastDifferent),
+	}
+}
+
+// toDomain reconstitutes a domain snapshot from a stored document, unpacking the
+// GeoJSON point back into flat longitude/latitude (coordinates[0]=lon, [1]=lat).
+func (d applicationDocument) toDomain() PlanningApplication {
+	lon, lat := coordsToLatLng(d.Location)
+	return PlanningApplication{
+		Name:          d.PlanitName,
+		UID:           d.UID,
+		AreaName:      d.AreaName,
+		AreaID:        d.AreaID,
+		Address:       d.Address,
+		Postcode:      d.Postcode,
+		Description:   d.Description,
+		AppType:       d.AppType,
+		AppState:      d.AppState,
+		AppSize:       d.AppSize,
+		StartDate:     dateOnlyToTime(d.StartDate),
+		DecidedDate:   dateOnlyToTime(d.DecidedDate),
+		ConsultedDate: dateOnlyToTime(d.ConsultedDate),
+		Longitude:     lon,
+		Latitude:      lat,
+		URL:           d.URL,
+		Link:          d.Link,
+		LastDifferent: time.Time(d.LastDifferent),
+	}
+}
+
+// newGeoPoint builds a GeoJSON point only when both coordinates are present,
+// matching .NET (which writes null when either is absent).
+func newGeoPoint(lon, lat *float64) *geoJSONPoint {
+	if lon == nil || lat == nil {
+		return nil
+	}
+	return &geoJSONPoint{Type: "Point", Coordinates: []float64{*lon, *lat}}
+}
+
+// coordsToLatLng unpacks a GeoJSON point into (longitude, latitude) pointers,
+// returning (nil, nil) when the point is absent or malformed.
+func coordsToLatLng(p *geoJSONPoint) (lon, lat *float64) {
+	if p == nil || len(p.Coordinates) < 2 {
+		return nil, nil
+	}
+	lo := p.Coordinates[0]
+	la := p.Coordinates[1]
+	return &lo, &la
+}
+
+// dateOnlyToTime converts an optional stored DateOnly back to the *time.Time the
+// domain carries.
+func dateOnlyToTime(d *platform.DateOnly) *time.Time {
+	if d == nil {
+		return nil
+	}
+	return d.TimePtr()
+}

--- a/api-go/internal/applications/document_test.go
+++ b/api-go/internal/applications/document_test.go
@@ -1,0 +1,75 @@
+package applications
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestApplicationDocument_RoundTrip(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	got := newApplicationDocument(a).toDomain()
+
+	if got.Name != a.Name || got.UID != a.UID || got.AreaName != a.AreaName || got.AreaID != a.AreaID {
+		t.Errorf("identity mismatch: got %+v", got)
+	}
+	if got.Address != a.Address || *got.Postcode != *a.Postcode || got.Description != a.Description {
+		t.Errorf("address fields mismatch: got %+v", got)
+	}
+	if *got.AppType != *a.AppType || *got.AppState != *a.AppState || *got.AppSize != *a.AppSize {
+		t.Errorf("app fields mismatch: got %+v", got)
+	}
+	if !got.StartDate.Equal(*a.StartDate) || !got.DecidedDate.Equal(*a.DecidedDate) || !got.ConsultedDate.Equal(*a.ConsultedDate) {
+		t.Errorf("dates mismatch: got start=%v decided=%v consulted=%v", got.StartDate, got.DecidedDate, got.ConsultedDate)
+	}
+	if *got.Longitude != *a.Longitude || *got.Latitude != *a.Latitude {
+		t.Errorf("coords mismatch: got lon=%v lat=%v", *got.Longitude, *got.Latitude)
+	}
+	if !got.LastDifferent.Equal(a.LastDifferent) {
+		t.Errorf("lastDifferent: got %v, want %v", got.LastDifferent, a.LastDifferent)
+	}
+}
+
+func TestApplicationDocument_CamelCaseGeoJSONAndDates(t *testing.T) {
+	t.Parallel()
+	raw, err := json.Marshal(newApplicationDocument(testApplication(t)))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(raw)
+	for _, key := range []string{
+		`"id":`, `"authorityCode":"471"`, `"planitName":`, `"uid":`, `"areaName":`, `"areaId":471`,
+		`"address":`, `"postcode":`, `"description":`, `"appType":`, `"appState":`, `"appSize":`,
+		`"startDate":"2026-01-05"`, `"decidedDate":"2026-03-01"`, `"consultedDate":"2026-01-20"`,
+		`"location":`, `"url":`, `"link":`, `"lastDifferent":"2026-03-02T09:30:00+00:00"`,
+	} {
+		if !strings.Contains(body, key) {
+			t.Errorf("missing %s in %s", key, body)
+		}
+	}
+	// GeoJSON point with [lon, lat] order and a "Point" type.
+	if !strings.Contains(body, `"type":"Point"`) || !strings.Contains(body, `"coordinates":[-0.0931,51.5155]`) {
+		t.Errorf("geojson point wrong: %s", body)
+	}
+}
+
+func TestApplicationDocument_AbsentCoordsAndDatesAreNull(t *testing.T) {
+	t.Parallel()
+	a := PlanningApplication{Name: "n", UID: "u", AreaName: "a", AreaID: 1, Address: "x", Description: "d"}
+	raw, err := json.Marshal(newApplicationDocument(a))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(raw)
+	for _, key := range []string{`"location":null`, `"startDate":null`, `"postcode":null`, `"appType":null`} {
+		if !strings.Contains(body, key) {
+			t.Errorf("expected %s in %s", key, body)
+		}
+	}
+	// And a round-trip leaves coordinates absent.
+	got := newApplicationDocument(a).toDomain()
+	if got.Longitude != nil || got.Latitude != nil || got.StartDate != nil {
+		t.Errorf("absent fields hydrated non-nil: %+v", got)
+	}
+}

--- a/api-go/internal/applications/handler.go
+++ b/api-go/internal/applications/handler.go
@@ -1,0 +1,72 @@
+package applications
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// appStore is the consumer-side store the application read handler uses.
+type appStore interface {
+	GetByAuthorityAndName(ctx context.Context, authorityCode, name string) (PlanningApplication, bool, error)
+}
+
+// handler serves GET /v1/applications/{authorityCode}/{name}.
+type handler struct {
+	store  appStore
+	logger *slog.Logger
+}
+
+// Routes registers the application read endpoint. The {name...} wildcard matches
+// the remainder of the path so a PlanIt case reference containing slashes (e.g.
+// "24/0123/FUL") is captured whole, mirroring the .NET {**name} catch-all.
+func Routes(mux *http.ServeMux, store appStore, logger *slog.Logger) {
+	h := &handler{store: store, logger: logger}
+	mux.HandleFunc("GET /v1/applications/{authorityCode}/{name...}", h.getByAuthorityAndName)
+}
+
+// getByAuthorityAndName point-reads an application by (authorityCode, name) and
+// returns it, or a bodyless 404 when it is not in Cosmos — there is no PlanIt
+// fallback (GH#395 Invariant 1). Refresh-on-tap (the saved-snapshot heal side
+// effect) is deferred to bead tc-wans.
+func (h *handler) getByAuthorityAndName(w http.ResponseWriter, r *http.Request) {
+	authorityCode := r.PathValue("authorityCode")
+	name := r.PathValue("name")
+
+	app, found, err := h.store.GetByAuthorityAndName(r.Context(), authorityCode, name)
+	if err != nil {
+		h.serverError(w, r, "read application", err)
+		return
+	}
+	if !found {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	h.writeJSON(w, r, resultFrom(app))
+}
+
+// writeJSON encodes v as a 200 application/json; charset=utf-8 response with HTML
+// escaping off and no trailing newline, matching ASP.NET's Results.Ok byte output.
+func (h *handler) writeJSON(w http.ResponseWriter, r *http.Request, v any) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		h.serverError(w, r, "encode response", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(bytes.TrimRight(buf.Bytes(), "\n")); err != nil {
+		h.logger.ErrorContext(r.Context(), "write response", "error", err)
+	}
+}
+
+// serverError logs and emits a bodyless 500; the error envelope is backfilled by
+// middleware.ErrorBody.
+func (h *handler) serverError(w http.ResponseWriter, r *http.Request, op string, err error) {
+	h.logger.ErrorContext(r.Context(), "application request failed", "op", op, "error", err)
+	w.WriteHeader(http.StatusInternalServerError)
+}

--- a/api-go/internal/applications/handler.go
+++ b/api-go/internal/applications/handler.go
@@ -42,5 +42,5 @@ func (h *handler) getByAuthorityAndName(w http.ResponseWriter, r *http.Request) 
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	writeJSON(w, r, h.logger, resultFrom(app))
+	writeJSON(w, r, h.logger, ResultOf(app))
 }

--- a/api-go/internal/applications/handler.go
+++ b/api-go/internal/applications/handler.go
@@ -1,9 +1,7 @@
 package applications
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"log/slog"
 	"net/http"
 )
@@ -37,36 +35,12 @@ func (h *handler) getByAuthorityAndName(w http.ResponseWriter, r *http.Request) 
 
 	app, found, err := h.store.GetByAuthorityAndName(r.Context(), authorityCode, name)
 	if err != nil {
-		h.serverError(w, r, "read application", err)
+		serverError(w, r, h.logger, "read application", err)
 		return
 	}
 	if !found {
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
-	h.writeJSON(w, r, resultFrom(app))
-}
-
-// writeJSON encodes v as a 200 application/json; charset=utf-8 response with HTML
-// escaping off and no trailing newline, matching ASP.NET's Results.Ok byte output.
-func (h *handler) writeJSON(w http.ResponseWriter, r *http.Request, v any) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(v); err != nil {
-		h.serverError(w, r, "encode response", err)
-		return
-	}
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(bytes.TrimRight(buf.Bytes(), "\n")); err != nil {
-		h.logger.ErrorContext(r.Context(), "write response", "error", err)
-	}
-}
-
-// serverError logs and emits a bodyless 500; the error envelope is backfilled by
-// middleware.ErrorBody.
-func (h *handler) serverError(w http.ResponseWriter, r *http.Request, op string, err error) {
-	h.logger.ErrorContext(r.Context(), "application request failed", "op", op, "error", err)
-	w.WriteHeader(http.StatusInternalServerError)
+	writeJSON(w, r, h.logger, resultFrom(app))
 }

--- a/api-go/internal/applications/handler_test.go
+++ b/api-go/internal/applications/handler_test.go
@@ -1,0 +1,89 @@
+package applications
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+)
+
+type fakeAppStore struct {
+	app   PlanningApplication
+	found bool
+	err   error
+
+	lastAuthorityCode string
+	lastName          string
+}
+
+func (f *fakeAppStore) GetByAuthorityAndName(_ context.Context, authorityCode, name string) (PlanningApplication, bool, error) {
+	f.lastAuthorityCode = authorityCode
+	f.lastName = name
+	return f.app, f.found, f.err
+}
+
+func serveGet(t *testing.T, store appStore, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler))
+	req := httptest.NewRequestWithContext(auth.WithSubject(context.Background(), "auth0|u"), http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestHandler_GetByAuthorityAndName_Found(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	store := &fakeAppStore{app: a, found: true}
+
+	rec := serveGet(t, store, "/v1/applications/471/24/0123/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("content-type: got %q", ct)
+	}
+	// The {name...} wildcard captures the slash-bearing case reference whole.
+	if store.lastAuthorityCode != "471" || store.lastName != "24/0123/FUL" {
+		t.Errorf("routing: authorityCode=%q name=%q", store.lastAuthorityCode, store.lastName)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["uid"] != a.UID || got["areaId"].(float64) != float64(a.AreaID) {
+		t.Errorf("body: %+v", got)
+	}
+	// Flat coordinates on the wire (no GeoJSON) and an explicit null unread event.
+	if got["longitude"].(float64) != *a.Longitude {
+		t.Errorf("longitude: got %v", got["longitude"])
+	}
+	if v, ok := got["latestUnreadEvent"]; !ok || v != nil {
+		t.Errorf("latestUnreadEvent must be present and null: %v (present=%v)", v, ok)
+	}
+}
+
+func TestHandler_GetByAuthorityAndName_NotFound(t *testing.T) {
+	t.Parallel()
+	rec := serveGet(t, &fakeAppStore{found: false}, "/v1/applications/471/missing")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("404 must be bodyless, got %s", rec.Body)
+	}
+}
+
+func TestHandler_GetByAuthorityAndName_StoreError(t *testing.T) {
+	t.Parallel()
+	rec := serveGet(t, &fakeAppStore{err: context.DeadlineExceeded}, "/v1/applications/471/x")
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500", rec.Code)
+	}
+}

--- a/api-go/internal/applications/respond.go
+++ b/api-go/internal/applications/respond.go
@@ -1,0 +1,32 @@
+package applications
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// writeJSON encodes v as a 200 application/json; charset=utf-8 response with HTML
+// escaping off and no trailing newline, matching ASP.NET's Results.Ok byte output.
+func writeJSON(w http.ResponseWriter, r *http.Request, logger *slog.Logger, v any) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		serverError(w, r, logger, "encode response", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(bytes.TrimRight(buf.Bytes(), "\n")); err != nil {
+		logger.ErrorContext(r.Context(), "write response", "error", err)
+	}
+}
+
+// serverError logs and emits a bodyless 500; the error envelope is backfilled by
+// middleware.ErrorBody.
+func serverError(w http.ResponseWriter, r *http.Request, logger *slog.Logger, op string, err error) {
+	logger.ErrorContext(r.Context(), "application request failed", "op", op, "error", err)
+	w.WriteHeader(http.StatusInternalServerError)
+}

--- a/api-go/internal/applications/result.go
+++ b/api-go/internal/applications/result.go
@@ -1,0 +1,59 @@
+package applications
+
+import (
+	"encoding/json"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// applicationResult mirrors .NET PlanningApplicationResult — the wire shape of a
+// planning application. Coordinates are flat (the GeoJSON projection is a Cosmos
+// storage concern only). latestUnreadEvent is always null on these endpoints
+// (the .NET ToResult never populates it); a nil json.RawMessage marshals to the
+// explicit null .NET emits.
+type applicationResult struct {
+	Name              string              `json:"name"`
+	UID               string              `json:"uid"`
+	AreaName          string              `json:"areaName"`
+	AreaID            int                 `json:"areaId"`
+	Address           string              `json:"address"`
+	Postcode          *string             `json:"postcode"`
+	Description       string              `json:"description"`
+	AppType           *string             `json:"appType"`
+	AppState          *string             `json:"appState"`
+	AppSize           *string             `json:"appSize"`
+	StartDate         *platform.DateOnly  `json:"startDate"`
+	DecidedDate       *platform.DateOnly  `json:"decidedDate"`
+	ConsultedDate     *platform.DateOnly  `json:"consultedDate"`
+	Longitude         *float64            `json:"longitude"`
+	Latitude          *float64            `json:"latitude"`
+	URL               *string             `json:"url"`
+	Link              *string             `json:"link"`
+	LastDifferent     platform.DotNetTime `json:"lastDifferent"`
+	LatestUnreadEvent json.RawMessage     `json:"latestUnreadEvent"`
+}
+
+// resultFrom maps a domain snapshot to its wire shape, mirroring .NET
+// GetApplicationByUidQueryHandler.ToResult.
+func resultFrom(a PlanningApplication) applicationResult {
+	return applicationResult{
+		Name:          a.Name,
+		UID:           a.UID,
+		AreaName:      a.AreaName,
+		AreaID:        a.AreaID,
+		Address:       a.Address,
+		Postcode:      a.Postcode,
+		Description:   a.Description,
+		AppType:       a.AppType,
+		AppState:      a.AppState,
+		AppSize:       a.AppSize,
+		StartDate:     platform.DateOnlyPtr(a.StartDate),
+		DecidedDate:   platform.DateOnlyPtr(a.DecidedDate),
+		ConsultedDate: platform.DateOnlyPtr(a.ConsultedDate),
+		Longitude:     a.Longitude,
+		Latitude:      a.Latitude,
+		URL:           a.URL,
+		Link:          a.Link,
+		LastDifferent: platform.DotNetTime(a.LastDifferent),
+	}
+}

--- a/api-go/internal/applications/result.go
+++ b/api-go/internal/applications/result.go
@@ -6,12 +6,12 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
-// applicationResult mirrors .NET PlanningApplicationResult — the wire shape of a
+// Result mirrors .NET PlanningApplicationResult — the wire shape of a
 // planning application. Coordinates are flat (the GeoJSON projection is a Cosmos
 // storage concern only). latestUnreadEvent is always null on these endpoints
 // (the .NET ToResult never populates it); a nil json.RawMessage marshals to the
 // explicit null .NET emits.
-type applicationResult struct {
+type Result struct {
 	Name              string              `json:"name"`
 	UID               string              `json:"uid"`
 	AreaName          string              `json:"areaName"`
@@ -33,10 +33,10 @@ type applicationResult struct {
 	LatestUnreadEvent json.RawMessage     `json:"latestUnreadEvent"`
 }
 
-// resultFrom maps a domain snapshot to its wire shape, mirroring .NET
+// ResultOf maps a domain snapshot to its wire shape, mirroring .NET
 // GetApplicationByUidQueryHandler.ToResult.
-func resultFrom(a PlanningApplication) applicationResult {
-	return applicationResult{
+func ResultOf(a PlanningApplication) Result {
+	return Result{
 		Name:          a.Name,
 		UID:           a.UID,
 		AreaName:      a.AreaName,

--- a/api-go/internal/applications/snapshot.go
+++ b/api-go/internal/applications/snapshot.go
@@ -1,0 +1,82 @@
+package applications
+
+import (
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// SnapshotDocument is the embedded planning-application snapshot stored inline on
+// a saved-application document. It carries the same fields as the master
+// applicationDocument minus the container identity (id / authorityCode /
+// planitName) — the case reference is the "name" key here. Mirrors .NET
+// SavedApplicationSnapshotDocument. The applications package owns it because it
+// is a PlanningApplication wire projection; the savedapplications package embeds
+// it without duplicating the GeoJSON / date mapping.
+type SnapshotDocument struct {
+	Name          string              `json:"name"`
+	UID           string              `json:"uid"`
+	AreaName      string              `json:"areaName"`
+	AreaID        int                 `json:"areaId"`
+	Address       string              `json:"address"`
+	Postcode      *string             `json:"postcode"`
+	Description   string              `json:"description"`
+	AppType       *string             `json:"appType"`
+	AppState      *string             `json:"appState"`
+	AppSize       *string             `json:"appSize"`
+	StartDate     *platform.DateOnly  `json:"startDate"`
+	DecidedDate   *platform.DateOnly  `json:"decidedDate"`
+	ConsultedDate *platform.DateOnly  `json:"consultedDate"`
+	Location      *geoJSONPoint       `json:"location"`
+	URL           *string             `json:"url"`
+	Link          *string             `json:"link"`
+	LastDifferent platform.DotNetTime `json:"lastDifferent"`
+}
+
+// NewSnapshotDocument projects a domain snapshot into the embedded shape.
+func NewSnapshotDocument(a PlanningApplication) SnapshotDocument {
+	return SnapshotDocument{
+		Name:          a.Name,
+		UID:           a.UID,
+		AreaName:      a.AreaName,
+		AreaID:        a.AreaID,
+		Address:       a.Address,
+		Postcode:      a.Postcode,
+		Description:   a.Description,
+		AppType:       a.AppType,
+		AppState:      a.AppState,
+		AppSize:       a.AppSize,
+		StartDate:     platform.DateOnlyPtr(a.StartDate),
+		DecidedDate:   platform.DateOnlyPtr(a.DecidedDate),
+		ConsultedDate: platform.DateOnlyPtr(a.ConsultedDate),
+		Location:      newGeoPoint(a.Longitude, a.Latitude),
+		URL:           a.URL,
+		Link:          a.Link,
+		LastDifferent: platform.DotNetTime(a.LastDifferent),
+	}
+}
+
+// ToDomain reconstitutes the embedded snapshot into a domain application.
+func (s SnapshotDocument) ToDomain() PlanningApplication {
+	lon, lat := coordsToLatLng(s.Location)
+	return PlanningApplication{
+		Name:          s.Name,
+		UID:           s.UID,
+		AreaName:      s.AreaName,
+		AreaID:        s.AreaID,
+		Address:       s.Address,
+		Postcode:      s.Postcode,
+		Description:   s.Description,
+		AppType:       s.AppType,
+		AppState:      s.AppState,
+		AppSize:       s.AppSize,
+		StartDate:     dateOnlyToTime(s.StartDate),
+		DecidedDate:   dateOnlyToTime(s.DecidedDate),
+		ConsultedDate: dateOnlyToTime(s.ConsultedDate),
+		Longitude:     lon,
+		Latitude:      lat,
+		URL:           s.URL,
+		Link:          s.Link,
+		LastDifferent: time.Time(s.LastDifferent),
+	}
+}

--- a/api-go/internal/applications/snapshot_test.go
+++ b/api-go/internal/applications/snapshot_test.go
@@ -1,0 +1,44 @@
+package applications
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSnapshotDocument_RoundTrip(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	got := NewSnapshotDocument(a).ToDomain()
+
+	if got.Name != a.Name || got.UID != a.UID || got.AreaID != a.AreaID {
+		t.Errorf("identity mismatch: %+v", got)
+	}
+	if !got.StartDate.Equal(*a.StartDate) || !got.LastDifferent.Equal(a.LastDifferent) {
+		t.Errorf("date mismatch: %+v", got)
+	}
+	if *got.Longitude != *a.Longitude || *got.Latitude != *a.Latitude {
+		t.Errorf("coords mismatch")
+	}
+}
+
+func TestSnapshotDocument_KeysOmitContainerIdentity(t *testing.T) {
+	t.Parallel()
+	raw, err := json.Marshal(NewSnapshotDocument(testApplication(t)))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(raw)
+	// The snapshot uses "name" and carries no master-doc identity keys.
+	if !strings.Contains(body, `"name":"24/0123/FUL"`) {
+		t.Errorf("missing name key: %s", body)
+	}
+	for _, absent := range []string{`"id":`, `"authorityCode":`, `"planitName":`} {
+		if strings.Contains(body, absent) {
+			t.Errorf("snapshot must not carry %s: %s", absent, body)
+		}
+	}
+	if !strings.Contains(body, `"type":"Point"`) {
+		t.Errorf("snapshot missing geojson location: %s", body)
+	}
+}

--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -1,0 +1,72 @@
+package applications
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// CosmosItems is the consumer-side slice of the Applications container the store
+// uses: a single-partition point read and an upsert. platform.CosmosContainer
+// satisfies it structurally.
+type CosmosItems interface {
+	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
+	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
+}
+
+// CosmosStore reads and writes planning applications in the Applications
+// container.
+//
+// Partition strategy: the container is partitioned by /authorityCode (the AreaID
+// as a string); the document id is the PlanIt case reference (Name). A lookup by
+// (authorityCode, name) is a ~1 RU point read; an upsert targets the
+// authorityCode partition.
+type CosmosStore struct {
+	items CosmosItems
+}
+
+// NewCosmosStore returns a store backed by the given Cosmos item accessor.
+func NewCosmosStore(items CosmosItems) *CosmosStore {
+	return &CosmosStore{items: items}
+}
+
+// Upsert writes the application document into its authorityCode partition.
+func (s *CosmosStore) Upsert(ctx context.Context, a PlanningApplication) error {
+	body, err := json.Marshal(newApplicationDocument(a))
+	if err != nil {
+		return fmt.Errorf("encode application %q: %w", a.Name, err)
+	}
+	if err := s.items.UpsertItem(ctx, strconv.Itoa(a.AreaID), body); err != nil {
+		return fmt.Errorf("upsert application %q: %w", a.Name, err)
+	}
+	return nil
+}
+
+// GetByAuthorityAndName point-reads the application identified by (authorityCode,
+// name). The boolean reports presence: a missing application is a normal 404 for
+// the caller, not an error. There is no PlanIt fallback (GH#395 Invariant 1).
+func (s *CosmosStore) GetByAuthorityAndName(ctx context.Context, authorityCode, name string) (PlanningApplication, bool, error) {
+	raw, err := s.items.ReadItem(ctx, authorityCode, name)
+	if err != nil {
+		if isNotFound(err) {
+			return PlanningApplication{}, false, nil
+		}
+		return PlanningApplication{}, false, fmt.Errorf("read application %q/%q: %w", authorityCode, name, err)
+	}
+	var doc applicationDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return PlanningApplication{}, false, fmt.Errorf("decode application %q/%q: %w", authorityCode, name, err)
+	}
+	return doc.toDomain(), true, nil
+}
+
+// isNotFound reports whether err is a Cosmos 404 response.
+func isNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -1,0 +1,98 @@
+package applications
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+type fakeItems struct {
+	stored       map[string][]byte // id -> bytes
+	readErr      error
+	upsertErr    error
+	lastUpsertPK string
+	lastUpsert   []byte
+	lastReadPK   string
+	lastReadID   string
+}
+
+func newFakeItems() *fakeItems { return &fakeItems{stored: map[string][]byte{}} }
+
+func (f *fakeItems) ReadItem(_ context.Context, partitionKey, id string) ([]byte, error) {
+	f.lastReadPK = partitionKey
+	f.lastReadID = id
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	b, ok := f.stored[id]
+	if !ok {
+		return nil, &azcore.ResponseError{StatusCode: http.StatusNotFound}
+	}
+	return b, nil
+}
+
+func (f *fakeItems) UpsertItem(_ context.Context, partitionKey string, item []byte) error {
+	f.lastUpsertPK = partitionKey
+	f.lastUpsert = item
+	return f.upsertErr
+}
+
+func TestCosmosStore_Upsert_TargetsAuthorityPartition(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if err := store.Upsert(context.Background(), a); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if items.lastUpsertPK != strconv.Itoa(a.AreaID) {
+		t.Errorf("upsert partition key: got %q, want %q", items.lastUpsertPK, strconv.Itoa(a.AreaID))
+	}
+	var doc applicationDocument
+	if err := json.Unmarshal(items.lastUpsert, &doc); err != nil {
+		t.Fatalf("decode upserted doc: %v", err)
+	}
+	if doc.ID != a.Name || doc.AuthorityCode != strconv.Itoa(a.AreaID) {
+		t.Errorf("upserted doc identity: got id=%q authorityCode=%q", doc.ID, doc.AuthorityCode)
+	}
+}
+
+func TestCosmosStore_GetByAuthorityAndName_PointRead(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	items := newFakeItems()
+	body, _ := json.Marshal(newApplicationDocument(a))
+	items.stored[a.Name] = body
+	store := NewCosmosStore(items)
+
+	got, found, err := store.GetByAuthorityAndName(context.Background(), strconv.Itoa(a.AreaID), a.Name)
+	if err != nil {
+		t.Fatalf("GetByAuthorityAndName: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found")
+	}
+	if got.Name != a.Name || got.UID != a.UID {
+		t.Errorf("got %+v", got)
+	}
+	if items.lastReadPK != strconv.Itoa(a.AreaID) || items.lastReadID != a.Name {
+		t.Errorf("point read keys: pk=%q id=%q", items.lastReadPK, items.lastReadID)
+	}
+}
+
+func TestCosmosStore_GetByAuthorityAndName_NotFound(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+	_, found, err := store.GetByAuthorityAndName(context.Background(), "471", "missing")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Error("expected not found")
+	}
+}

--- a/api-go/internal/authorities/lookup.go
+++ b/api-go/internal/authorities/lookup.go
@@ -1,0 +1,25 @@
+package authorities
+
+// Lookup is the exported, cross-package handle for resolving authority ids to
+// their display metadata. Features such as application-authorities depend on it
+// without reaching into the package's unexported static store.
+type Lookup struct {
+	store *staticStore
+}
+
+// NewLookup builds an authority lookup over the embedded static authority data.
+func NewLookup() *Lookup {
+	return &Lookup{store: newStaticStore()}
+}
+
+// ByID returns the authority with the given id, reporting whether it exists.
+func (l *Lookup) ByID(id int) (Authority, bool) {
+	return l.store.byID(id)
+}
+
+// CompareOrdinalIgnoreCase exposes the package's ordinal, case-insensitive name
+// comparator so callers building authority lists order them identically to the
+// /v1/authorities list and to .NET's StringComparer.OrdinalIgnoreCase.
+func CompareOrdinalIgnoreCase(a, b string) int {
+	return compareOrdinalIgnoreCase(a, b)
+}

--- a/api-go/internal/authorities/lookup_test.go
+++ b/api-go/internal/authorities/lookup_test.go
@@ -1,0 +1,31 @@
+package authorities
+
+import "testing"
+
+func TestLookup_ByID(t *testing.T) {
+	t.Parallel()
+	lookup := NewLookup()
+
+	// 471 is City of London, present in the embedded data.
+	a, ok := lookup.ByID(471)
+	if !ok {
+		t.Fatal("expected authority 471 to exist")
+	}
+	if a.ID != 471 || a.Name == "" || a.AreaType == "" {
+		t.Errorf("authority 471 incomplete: %+v", a)
+	}
+
+	if _, ok := lookup.ByID(-1); ok {
+		t.Error("expected authority -1 to be absent")
+	}
+}
+
+func TestCompareOrdinalIgnoreCase_Exported(t *testing.T) {
+	t.Parallel()
+	if CompareOrdinalIgnoreCase("apple", "Banana") >= 0 {
+		t.Error("apple should sort before Banana ignoring case")
+	}
+	if CompareOrdinalIgnoreCase("Zed", "zed") != 0 {
+		t.Error("case-only difference should compare equal")
+	}
+}

--- a/api-go/internal/platform/cosmos.go
+++ b/api-go/internal/platform/cosmos.go
@@ -103,6 +103,12 @@ const (
 	// CosmosWatchZonesContainer holds one document per watch zone; partition key
 	// /userId, document id == zoneId.
 	CosmosWatchZonesContainer = "WatchZones"
+	// CosmosApplicationsContainer holds the master planning-application records;
+	// partition key /authorityCode (the areaId as a string), document id == name.
+	CosmosApplicationsContainer = "Applications"
+	// CosmosSavedApplicationsContainer holds one document per saved application;
+	// partition key /userId, document id == "{userId}:{applicationUid}".
+	CosmosSavedApplicationsContainer = "SavedApplications"
 )
 
 // ReadItem point-reads the document with the given id from its partition.

--- a/api-go/internal/platform/dateonly.go
+++ b/api-go/internal/platform/dateonly.go
@@ -1,0 +1,59 @@
+package platform
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// dateOnlyLayout is the wire format of a .NET DateOnly: an ISO calendar date
+// with no time component, e.g. "2026-03-07".
+const dateOnlyLayout = "2006-01-02"
+
+// DateOnly marshals like System.Text.Json's DateOnly: a bare "yyyy-MM-dd" date,
+// never a full timestamp. Planning-application dates (start/decided/consulted)
+// carry .NET DateOnly values, so wire and stored documents must use this type to
+// stay byte-identical under the contract-diff harness.
+type DateOnly time.Time
+
+// String renders the calendar date in the .NET DateOnly wire format.
+func (d DateOnly) String() string {
+	return time.Time(d).Format(dateOnlyLayout)
+}
+
+// MarshalJSON renders the calendar date as a quoted "yyyy-MM-dd" string.
+func (d DateOnly) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + d.String() + `"`), nil
+}
+
+// UnmarshalJSON parses a bare "yyyy-MM-dd" date into the zero-time-of-day
+// instant in UTC.
+func (d *DateOnly) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	parsed, err := time.Parse(dateOnlyLayout, s)
+	if err != nil {
+		return fmt.Errorf("parse date-only %q: %w", s, err)
+	}
+	*d = DateOnly(parsed)
+	return nil
+}
+
+// TimePtr returns the date as a *time.Time (midnight UTC), the form the domain
+// model carries. Always non-nil.
+func (d DateOnly) TimePtr() *time.Time {
+	t := time.Time(d)
+	return &t
+}
+
+// DateOnlyPtr converts an optional date-bearing time, preserving nil so an absent
+// value serialises as null rather than a zero date.
+func DateOnlyPtr(t *time.Time) *DateOnly {
+	if t == nil {
+		return nil
+	}
+	d := DateOnly(*t)
+	return &d
+}

--- a/api-go/internal/platform/dateonly_test.go
+++ b/api-go/internal/platform/dateonly_test.go
@@ -1,0 +1,76 @@
+package platform
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestDateOnly_MarshalsAsYearMonthDay(t *testing.T) {
+	t.Parallel()
+	d := DateOnly(time.Date(2026, 3, 7, 0, 0, 0, 0, time.UTC))
+	raw, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(raw) != `"2026-03-07"` {
+		t.Errorf("got %s, want \"2026-03-07\"", raw)
+	}
+}
+
+func TestDateOnly_RoundTrip(t *testing.T) {
+	t.Parallel()
+	var d DateOnly
+	if err := json.Unmarshal([]byte(`"2026-12-31"`), &d); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := time.Time(d)
+	if got.Year() != 2026 || got.Month() != time.December || got.Day() != 31 {
+		t.Errorf("parsed wrong date: %v", got)
+	}
+}
+
+func TestDateOnlyPtr_NilPreserved(t *testing.T) {
+	t.Parallel()
+	if DateOnlyPtr(nil) != nil {
+		t.Error("nil time must map to nil DateOnly")
+	}
+	tm := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	d := DateOnlyPtr(&tm)
+	if d == nil {
+		t.Fatal("non-nil time must map to non-nil DateOnly")
+	}
+	raw, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(raw) != `"2026-01-02"` {
+		t.Errorf("got %s", raw)
+	}
+}
+
+func TestDateOnly_NilPointerMarshalsNull(t *testing.T) {
+	t.Parallel()
+	type holder struct {
+		D *DateOnly `json:"d"`
+	}
+	raw, err := json.Marshal(holder{})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(raw) != `{"d":null}` {
+		t.Errorf("got %s, want {\"d\":null}", raw)
+	}
+}
+
+func TestDateOnly_TimePtrRoundTrip(t *testing.T) {
+	t.Parallel()
+	var d DateOnly
+	if err := json.Unmarshal([]byte(`"2026-06-13"`), &d); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	tp := d.TimePtr()
+	if tp == nil || !tp.Equal(time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("TimePtr: got %v", tp)
+	}
+}

--- a/api-go/internal/savedapplications/document.go
+++ b/api-go/internal/savedapplications/document.go
@@ -1,0 +1,73 @@
+package savedapplications
+
+import (
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// savedApplicationDocument is the Cosmos persistence shape for a SavedApplication
+// in the SavedApplications container. JSON tags reproduce the camelCase keys the
+// .NET CosmosSavedApplicationRepository writes.
+//
+// Partition key: userId. Document id: "{userId}:{applicationUid}" — so a save is
+// an idempotent point upsert and a user's list is one single-partition query.
+type savedApplicationDocument struct {
+	ID             string                         `json:"id"`
+	UserID         string                         `json:"userId"`
+	ApplicationUID string                         `json:"applicationUid"`
+	AuthorityID    *int                           `json:"authorityId"`
+	SavedAt        platform.DotNetTime            `json:"savedAt"`
+	Application    *applications.SnapshotDocument `json:"application"`
+}
+
+// makeID builds the composite document id, matching .NET SavedApplicationDocument.MakeId.
+func makeID(userID, applicationUID string) string {
+	return userID + ":" + applicationUID
+}
+
+// newSavedApplicationDocument maps a domain record to its persistence shape.
+func newSavedApplicationDocument(s SavedApplication) savedApplicationDocument {
+	var snapshot *applications.SnapshotDocument
+	if s.Application != nil {
+		d := applications.NewSnapshotDocument(*s.Application)
+		snapshot = &d
+	}
+	authorityID := s.AuthorityID
+	return savedApplicationDocument{
+		ID:             makeID(s.UserID, s.ApplicationUID),
+		UserID:         s.UserID,
+		ApplicationUID: s.ApplicationUID,
+		AuthorityID:    &authorityID,
+		SavedAt:        platform.DotNetTime(s.SavedAt),
+		Application:    snapshot,
+	}
+}
+
+// toDomain reconstitutes a domain record, coalescing the projected authorityId
+// from the embedded snapshot for legacy rows persisted before that column
+// existed, exactly as .NET does.
+func (d savedApplicationDocument) toDomain() SavedApplication {
+	authorityID := 0
+	switch {
+	case d.AuthorityID != nil:
+		authorityID = *d.AuthorityID
+	case d.Application != nil:
+		authorityID = d.Application.AreaID
+	}
+
+	var app *applications.PlanningApplication
+	if d.Application != nil {
+		a := d.Application.ToDomain()
+		app = &a
+	}
+
+	return SavedApplication{
+		UserID:         d.UserID,
+		ApplicationUID: d.ApplicationUID,
+		AuthorityID:    authorityID,
+		SavedAt:        time.Time(d.SavedAt),
+		Application:    app,
+	}
+}

--- a/api-go/internal/savedapplications/document_test.go
+++ b/api-go/internal/savedapplications/document_test.go
@@ -1,0 +1,97 @@
+package savedapplications
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+func testApp(t *testing.T) applications.PlanningApplication {
+	t.Helper()
+	start := time.Date(2026, 1, 5, 0, 0, 0, 0, time.UTC)
+	lon := -0.0931
+	lat := 51.5155
+	return applications.PlanningApplication{
+		Name:          "24/0123/FUL",
+		UID:           "ABC-24-0123",
+		AreaName:      "City of London",
+		AreaID:        471,
+		Address:       "1 Test Street",
+		Description:   "Extension",
+		StartDate:     &start,
+		Longitude:     &lon,
+		Latitude:      &lat,
+		LastDifferent: time.Date(2026, 3, 2, 9, 30, 0, 0, time.UTC),
+	}
+}
+
+func TestNewSavedApplication_CanonicalKeyAndSnapshot(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC)
+	s := NewSavedApplication("auth0|u", testApp(t), now)
+
+	if s.ApplicationUID != "471/24/0123/FUL" {
+		t.Errorf("uid: got %q, want canonical 471/24/0123/FUL", s.ApplicationUID)
+	}
+	if s.AuthorityID != 471 {
+		t.Errorf("authorityId: got %d", s.AuthorityID)
+	}
+	if s.Application == nil || s.Application.Name != "24/0123/FUL" {
+		t.Errorf("snapshot not embedded: %+v", s.Application)
+	}
+	if !s.SavedAt.Equal(now) {
+		t.Errorf("savedAt: got %v", s.SavedAt)
+	}
+}
+
+func TestSavedApplicationDocument_RoundTrip(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC)
+	s := NewSavedApplication("auth0|u", testApp(t), now)
+	got := newSavedApplicationDocument(s).toDomain()
+
+	if got.UserID != s.UserID || got.ApplicationUID != s.ApplicationUID || got.AuthorityID != s.AuthorityID {
+		t.Errorf("identity mismatch: %+v", got)
+	}
+	if !got.SavedAt.Equal(s.SavedAt) {
+		t.Errorf("savedAt: got %v", got.SavedAt)
+	}
+	if got.Application == nil || got.Application.UID != s.Application.UID {
+		t.Errorf("snapshot lost: %+v", got.Application)
+	}
+}
+
+func TestSavedApplicationDocument_CamelCaseIdAndSavedAt(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC)
+	raw, err := json.Marshal(newSavedApplicationDocument(NewSavedApplication("auth0|u", testApp(t), now)))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(raw)
+	for _, key := range []string{
+		`"id":"auth0|u:471/24/0123/FUL"`, `"userId":"auth0|u"`, `"applicationUid":"471/24/0123/FUL"`,
+		`"authorityId":471`, `"savedAt":"2026-06-13T08:00:00+00:00"`, `"application":`,
+	} {
+		if !strings.Contains(body, key) {
+			t.Errorf("missing %s in %s", key, body)
+		}
+	}
+}
+
+func TestSavedApplicationDocument_AuthorityIdCoalescesFromSnapshot(t *testing.T) {
+	t.Parallel()
+	// Legacy row: authorityId column absent, but the embedded snapshot carries areaId.
+	raw := `{"id":"u:1/x","userId":"u","applicationUid":"1/x","savedAt":"2026-06-13T08:00:00+00:00","application":{"name":"x","uid":"u1","areaName":"a","areaId":42,"address":"addr","description":"d","lastDifferent":"2026-06-13T08:00:00+00:00"}}`
+	var doc savedApplicationDocument
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := doc.toDomain()
+	if got.AuthorityID != 42 {
+		t.Errorf("authorityId should coalesce from snapshot areaId: got %d", got.AuthorityID)
+	}
+}

--- a/api-go/internal/savedapplications/handler.go
+++ b/api-go/internal/savedapplications/handler.go
@@ -1,0 +1,242 @@
+package savedapplications
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+const maxBodyBytes = 1 << 20
+
+// invalidBodyMessage is the .NET ApiErrorResponse text when the save body lacks
+// the fields needed to build the canonical key and master record.
+const invalidBodyMessage = "Body must include a non-empty uid and name."
+
+// savedStore is the consumer-side saved-application store.
+type savedStore interface {
+	Save(ctx context.Context, sa SavedApplication) error
+	Exists(ctx context.Context, userID, applicationUID string) (bool, error)
+	Delete(ctx context.Context, userID, applicationUID string) error
+	GetByUserID(ctx context.Context, userID string) ([]SavedApplication, error)
+}
+
+// appUpserter writes the master planning-application record so a save always
+// points at a known application (the search path no longer upserts).
+type appUpserter interface {
+	Upsert(ctx context.Context, a applications.PlanningApplication) error
+}
+
+type handler struct {
+	store  savedStore
+	apps   appUpserter
+	now    func() time.Time
+	logger *slog.Logger
+}
+
+// Routes registers the saved-application endpoints. PUT/DELETE use a {**uid}
+// catch-all so a slash-bearing application uid is captured whole, mirroring the
+// .NET {**applicationUid} route.
+func Routes(mux *http.ServeMux, store savedStore, apps appUpserter, now func() time.Time, logger *slog.Logger) {
+	h := &handler{store: store, apps: apps, now: now, logger: logger}
+	mux.HandleFunc("PUT /v1/me/saved-applications/{applicationUid...}", h.save)
+	mux.HandleFunc("DELETE /v1/me/saved-applications/{applicationUid...}", h.delete)
+	mux.HandleFunc("GET /v1/me/saved-applications", h.list)
+}
+
+// saveRequest is the PUT body — the full planning-application payload. The path
+// uid is ignored; the saved record's identity is the canonical uid derived from
+// the body (areaId/name).
+type saveRequest struct {
+	Name          string              `json:"name"`
+	UID           string              `json:"uid"`
+	AreaName      string              `json:"areaName"`
+	AreaID        int                 `json:"areaId"`
+	Address       string              `json:"address"`
+	Postcode      *string             `json:"postcode"`
+	Description   string              `json:"description"`
+	AppType       *string             `json:"appType"`
+	AppState      *string             `json:"appState"`
+	AppSize       *string             `json:"appSize"`
+	StartDate     *platform.DateOnly  `json:"startDate"`
+	DecidedDate   *platform.DateOnly  `json:"decidedDate"`
+	ConsultedDate *platform.DateOnly  `json:"consultedDate"`
+	Longitude     *float64            `json:"longitude"`
+	Latitude      *float64            `json:"latitude"`
+	URL           *string             `json:"url"`
+	Link          *string             `json:"link"`
+	LastDifferent platform.DotNetTime `json:"lastDifferent"`
+}
+
+func (req saveRequest) toApplication() applications.PlanningApplication {
+	return applications.PlanningApplication{
+		Name:          req.Name,
+		UID:           req.UID,
+		AreaName:      req.AreaName,
+		AreaID:        req.AreaID,
+		Address:       req.Address,
+		Postcode:      req.Postcode,
+		Description:   req.Description,
+		AppType:       req.AppType,
+		AppState:      req.AppState,
+		AppSize:       req.AppSize,
+		StartDate:     dateToTime(req.StartDate),
+		DecidedDate:   dateToTime(req.DecidedDate),
+		ConsultedDate: dateToTime(req.ConsultedDate),
+		Longitude:     req.Longitude,
+		Latitude:      req.Latitude,
+		URL:           req.URL,
+		Link:          req.Link,
+		LastDifferent: time.Time(req.LastDifferent),
+	}
+}
+
+// save implements PUT /v1/me/saved-applications/{**uid}. The path uid is
+// ignored. The body must carry a non-blank uid and name; the master record is
+// upserted first, then the saved row is written keyed on the canonical uid
+// (skipped when one already exists — idempotent re-save).
+func (h *handler) save(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	var req saveRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if strings.TrimSpace(req.UID) == "" || strings.TrimSpace(req.Name) == "" {
+		h.writeError(w, r, http.StatusBadRequest, invalidBodyMessage)
+		return
+	}
+
+	app := req.toApplication()
+	if err := h.apps.Upsert(r.Context(), app); err != nil {
+		h.serverError(w, r, "upsert application", err)
+		return
+	}
+
+	canonicalUID := app.CanonicalUID()
+	exists, err := h.store.Exists(r.Context(), userID, canonicalUID)
+	if err != nil {
+		h.serverError(w, r, "check saved application", err)
+		return
+	}
+	if !exists {
+		if err := h.store.Save(r.Context(), NewSavedApplication(userID, app, h.now())); err != nil {
+			h.serverError(w, r, "save application", err)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// delete implements DELETE /v1/me/saved-applications/{**uid}. The delete is
+// idempotent — a missing record still returns 204.
+func (h *handler) delete(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+	applicationUID := r.PathValue("applicationUid")
+
+	if err := h.store.Delete(r.Context(), userID, applicationUID); err != nil {
+		h.serverError(w, r, "delete saved application", err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// savedEntry mirrors .NET SavedApplicationResult: { applicationUid, savedAt,
+// application }.
+type savedEntry struct {
+	ApplicationUID string              `json:"applicationUid"`
+	SavedAt        platform.DotNetTime `json:"savedAt"`
+	Application    applications.Result `json:"application"`
+}
+
+// list implements GET /v1/me/saved-applications, returning a JSON array of the
+// user's saved applications rendered from their embedded snapshots. Rows whose
+// snapshot is absent (legacy, pre-snapshot-column) are skipped here; the lazy
+// backfill / re-key / dedup machinery the .NET handler runs for them is deferred
+// to bead tc-wans.
+func (h *handler) list(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+
+	saved, err := h.store.GetByUserID(r.Context(), userID)
+	if err != nil {
+		h.serverError(w, r, "list saved applications", err)
+		return
+	}
+	entries := make([]savedEntry, 0, len(saved))
+	for _, s := range saved {
+		if s.Application == nil {
+			continue
+		}
+		entries = append(entries, savedEntry{
+			ApplicationUID: s.ApplicationUID,
+			SavedAt:        platform.DotNetTime(s.SavedAt),
+			Application:    applications.ResultOf(*s.Application),
+		})
+	}
+	h.writeJSON(w, r, entries)
+}
+
+func dateToTime(d *platform.DateOnly) *time.Time {
+	if d == nil {
+		return nil
+	}
+	return d.TimePtr()
+}
+
+// apiErrorResponse mirrors the .NET ApiErrorResponse: { error, message:null }.
+type apiErrorResponse struct {
+	Error   string  `json:"error"`
+	Message *string `json:"message"`
+}
+
+func (h *handler) writeJSON(w http.ResponseWriter, r *http.Request, v any) {
+	body, err := encodeJSON(v)
+	if err != nil {
+		h.serverError(w, r, "encode response", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		h.logger.ErrorContext(r.Context(), "write response", "error", err)
+	}
+}
+
+func (h *handler) writeError(w http.ResponseWriter, r *http.Request, status int, message string) {
+	body, err := encodeJSON(apiErrorResponse{Error: message})
+	if err != nil {
+		h.serverError(w, r, "encode error", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if _, err := w.Write(body); err != nil {
+		h.logger.ErrorContext(r.Context(), "write error body", "error", err)
+	}
+}
+
+func encodeJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+func (h *handler) serverError(w http.ResponseWriter, r *http.Request, op string, err error) {
+	h.logger.ErrorContext(r.Context(), "saved-application request failed", "op", op, "error", err)
+	w.WriteHeader(http.StatusInternalServerError)
+}

--- a/api-go/internal/savedapplications/handler_test.go
+++ b/api-go/internal/savedapplications/handler_test.go
@@ -1,0 +1,188 @@
+package savedapplications
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+)
+
+const user = "auth0|u"
+
+type fakeSavedStore struct {
+	rows       []SavedApplication
+	exists     bool
+	saved      []SavedApplication
+	deletedUID []string
+	listErr    error
+}
+
+func (f *fakeSavedStore) Save(_ context.Context, sa SavedApplication) error {
+	f.saved = append(f.saved, sa)
+	f.rows = append(f.rows, sa)
+	return nil
+}
+func (f *fakeSavedStore) Exists(_ context.Context, _, _ string) (bool, error) { return f.exists, nil }
+func (f *fakeSavedStore) Delete(_ context.Context, _, uid string) error {
+	f.deletedUID = append(f.deletedUID, uid)
+	return nil
+}
+func (f *fakeSavedStore) GetByUserID(_ context.Context, _ string) ([]SavedApplication, error) {
+	return f.rows, f.listErr
+}
+
+type fakeApps struct {
+	upserted []applications.PlanningApplication
+}
+
+func (f *fakeApps) Upsert(_ context.Context, a applications.PlanningApplication) error {
+	f.upserted = append(f.upserted, a)
+	return nil
+}
+
+func testMux(t *testing.T, store savedStore, apps appUpserter) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	now := func() time.Time { return time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC) }
+	Routes(mux, store, apps, now, slog.New(slog.DiscardHandler))
+	return mux
+}
+
+func doReq(t *testing.T, mux *http.ServeMux, method, path, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequestWithContext(auth.WithSubject(context.Background(), user), method, path, strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+const validSaveBody = `{"name":"24/0123/FUL","uid":"ABC-1","areaName":"City of London","areaId":471,"address":"1 St","description":"d","lastDifferent":"2026-03-02T09:30:00+00:00"}`
+
+func TestHandler_Save_DualWriteAndCanonicalKey(t *testing.T) {
+	t.Parallel()
+	store := &fakeSavedStore{exists: false}
+	apps := &fakeApps{}
+	rec := doReq(t, testMux(t, store, apps), http.MethodPut, "/v1/me/saved-applications/whatever-path-uid", validSaveBody)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status: got %d, want 204 (body %s)", rec.Code, rec.Body)
+	}
+	if len(apps.upserted) != 1 || apps.upserted[0].Name != "24/0123/FUL" {
+		t.Errorf("master record not upserted: %+v", apps.upserted)
+	}
+	if len(store.saved) != 1 || store.saved[0].ApplicationUID != "471/24/0123/FUL" {
+		t.Errorf("saved row not keyed on canonical uid: %+v", store.saved)
+	}
+}
+
+func TestHandler_Save_IdempotentWhenAlreadySaved(t *testing.T) {
+	t.Parallel()
+	store := &fakeSavedStore{exists: true}
+	apps := &fakeApps{}
+	rec := doReq(t, testMux(t, store, apps), http.MethodPut, "/v1/me/saved-applications/x", validSaveBody)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status: got %d", rec.Code)
+	}
+	// Master record still upserted, but no duplicate saved row written.
+	if len(apps.upserted) != 1 {
+		t.Errorf("master upsert should still run: %+v", apps.upserted)
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("must not re-save when already saved: %+v", store.saved)
+	}
+}
+
+func TestHandler_Save_MissingUidOrName(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"missing uid":  `{"name":"n","uid":"","areaId":1,"areaName":"a","address":"x","description":"d","lastDifferent":"2026-03-02T09:30:00+00:00"}`,
+		"missing name": `{"name":" ","uid":"u","areaId":1,"areaName":"a","address":"x","description":"d","lastDifferent":"2026-03-02T09:30:00+00:00"}`,
+	}
+	for name, body := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			store := &fakeSavedStore{}
+			rec := doReq(t, testMux(t, store, &fakeApps{}), http.MethodPut, "/v1/me/saved-applications/x", body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status: got %d, want 400", rec.Code)
+			}
+			var got map[string]any
+			if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if got["error"] != invalidBodyMessage {
+				t.Errorf("error: got %v", got["error"])
+			}
+			if v, ok := got["message"]; !ok || v != nil {
+				t.Errorf("message must be present and null: %v", v)
+			}
+			if len(store.saved) != 0 {
+				t.Error("invalid save must not persist")
+			}
+		})
+	}
+}
+
+func TestHandler_Delete(t *testing.T) {
+	t.Parallel()
+	store := &fakeSavedStore{}
+	// The catch-all captures a slash-bearing canonical uid whole.
+	rec := doReq(t, testMux(t, store, &fakeApps{}), http.MethodDelete, "/v1/me/saved-applications/471/24/0123/FUL", "")
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status: got %d, want 204", rec.Code)
+	}
+	if len(store.deletedUID) != 1 || store.deletedUID[0] != "471/24/0123/FUL" {
+		t.Errorf("deleted uid: %+v", store.deletedUID)
+	}
+}
+
+func TestHandler_List(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC)
+	store := &fakeSavedStore{rows: []SavedApplication{NewSavedApplication(user, testApp(t), now)}}
+	rec := doReq(t, testMux(t, store, &fakeApps{}), http.MethodGet, "/v1/me/saved-applications", "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d", rec.Code)
+	}
+	var got []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode (must be a JSON array): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+	if got[0]["applicationUid"] != "471/24/0123/FUL" {
+		t.Errorf("applicationUid: %v", got[0]["applicationUid"])
+	}
+	app, ok := got[0]["application"].(map[string]any)
+	if !ok || app["uid"] != "ABC-24-0123" {
+		t.Errorf("embedded application not rendered: %+v", got[0]["application"])
+	}
+}
+
+func TestHandler_List_EmptyArray(t *testing.T) {
+	t.Parallel()
+	rec := doReq(t, testMux(t, &fakeSavedStore{}, &fakeApps{}), http.MethodGet, "/v1/me/saved-applications", "")
+	if body := strings.TrimSpace(rec.Body.String()); body != `[]` {
+		t.Errorf("empty list must be [], got %s", body)
+	}
+}
+
+func TestHandler_List_SkipsNilSnapshotRows(t *testing.T) {
+	t.Parallel()
+	// A legacy row with no embedded snapshot is skipped (backfill deferred to tc-wans).
+	store := &fakeSavedStore{rows: []SavedApplication{{UserID: user, ApplicationUID: "legacy", AuthorityID: 1, Application: nil}}}
+	rec := doReq(t, testMux(t, store, &fakeApps{}), http.MethodGet, "/v1/me/saved-applications", "")
+	if body := strings.TrimSpace(rec.Body.String()); body != `[]` {
+		t.Errorf("nil-snapshot row must be skipped, got %s", body)
+	}
+}

--- a/api-go/internal/savedapplications/saved.go
+++ b/api-go/internal/savedapplications/saved.go
@@ -1,0 +1,45 @@
+// Package savedapplications owns the saved-application feature: the domain
+// record, the Cosmos store over the SavedApplications container, and the
+// /v1/me/saved-applications HTTP handlers. It mirrors the .NET
+// TownCrier.{Domain,Application,Infrastructure}.SavedApplications slices
+// (GH#418 iteration 6).
+//
+// Scope note: this ships the fresh-data path (a save always embeds the
+// snapshot and keys on the canonical uid). The legacy-row migration machinery
+// the .NET list handler runs — lazy snapshot backfill, legacy-uid re-keying and
+// dedup, plus refresh-on-tap — is deferred to bead tc-wans.
+package savedapplications
+
+import (
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+// SavedApplication is a user's bookmark of a planning application. Identity is
+// (UserID, ApplicationUID, AuthorityID): PlanIt uids are only unique within a
+// council. The embedded Application snapshot lets the list endpoint render with
+// one partitioned query rather than an N-fan-out hydration; it is nil only for
+// legacy rows persisted before the snapshot column existed.
+type SavedApplication struct {
+	UserID         string
+	ApplicationUID string
+	AuthorityID    int
+	SavedAt        time.Time
+	Application    *applications.PlanningApplication
+}
+
+// NewSavedApplication builds a saved record from a planning application, keyed on
+// the canonical {areaId}/{name} uid (not the raw client-supplied uid) so re-saves
+// of the same application are idempotent. The snapshot is embedded. Mirrors .NET
+// SavedApplication.Create(userId, application, now).
+func NewSavedApplication(userID string, app applications.PlanningApplication, now time.Time) SavedApplication {
+	snapshot := app
+	return SavedApplication{
+		UserID:         userID,
+		ApplicationUID: app.CanonicalUID(),
+		AuthorityID:    app.AreaID,
+		SavedAt:        now,
+		Application:    &snapshot,
+	}
+}

--- a/api-go/internal/savedapplications/store_cosmos.go
+++ b/api-go/internal/savedapplications/store_cosmos.go
@@ -1,0 +1,97 @@
+package savedapplications
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// CosmosItems is the consumer-side slice of the SavedApplications container the
+// store uses: point read/upsert/delete plus a single-partition list query.
+type CosmosItems interface {
+	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
+	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
+	DeleteItem(ctx context.Context, partitionKey, id string) error
+	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
+}
+
+// listByUserQuery lists a user's saved applications. Scoped to the userId
+// partition, so it never fans out cross-partition.
+const listByUserQuery = "SELECT * FROM c WHERE c.userId = @userId"
+
+// CosmosStore reads and writes saved applications in the SavedApplications
+// container.
+//
+// Partition strategy: partitioned by /userId; the document id is
+// "{userId}:{applicationUid}". A save/exists/delete is a point operation; a
+// user's list is one single-partition query.
+type CosmosStore struct {
+	items CosmosItems
+}
+
+// NewCosmosStore returns a store backed by the given Cosmos item accessor.
+func NewCosmosStore(items CosmosItems) *CosmosStore {
+	return &CosmosStore{items: items}
+}
+
+// Save upserts the saved-application document into the user's partition.
+func (s *CosmosStore) Save(ctx context.Context, sa SavedApplication) error {
+	body, err := json.Marshal(newSavedApplicationDocument(sa))
+	if err != nil {
+		return fmt.Errorf("encode saved application %q: %w", sa.ApplicationUID, err)
+	}
+	if err := s.items.UpsertItem(ctx, sa.UserID, body); err != nil {
+		return fmt.Errorf("upsert saved application %q: %w", sa.ApplicationUID, err)
+	}
+	return nil
+}
+
+// Exists reports whether the user has saved the application with the given
+// (canonical) uid.
+func (s *CosmosStore) Exists(ctx context.Context, userID, applicationUID string) (bool, error) {
+	_, err := s.items.ReadItem(ctx, userID, makeID(userID, applicationUID))
+	if err != nil {
+		if isNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read saved application %q: %w", applicationUID, err)
+	}
+	return true, nil
+}
+
+// Delete removes the saved-application document. A missing document is not an
+// error: the .NET REST delete is idempotent and the DELETE endpoint always
+// returns 204, so a 404 from Cosmos is swallowed.
+func (s *CosmosStore) Delete(ctx context.Context, userID, applicationUID string) error {
+	if err := s.items.DeleteItem(ctx, userID, makeID(userID, applicationUID)); err != nil && !isNotFound(err) {
+		return fmt.Errorf("delete saved application %q: %w", applicationUID, err)
+	}
+	return nil
+}
+
+// GetByUserID returns the user's saved applications via a single-partition query.
+func (s *CosmosStore) GetByUserID(ctx context.Context, userID string) ([]SavedApplication, error) {
+	raws, err := s.items.QueryItems(ctx, userID, listByUserQuery, map[string]any{"@userId": userID})
+	if err != nil {
+		return nil, fmt.Errorf("query saved applications for %q: %w", userID, err)
+	}
+	saved := make([]SavedApplication, 0, len(raws))
+	for _, raw := range raws {
+		var doc savedApplicationDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("decode saved application for %q: %w", userID, err)
+		}
+		saved = append(saved, doc.toDomain())
+	}
+	return saved, nil
+}
+
+// isNotFound reports whether err is a Cosmos 404 response.
+func isNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}

--- a/api-go/internal/savedapplications/store_cosmos_test.go
+++ b/api-go/internal/savedapplications/store_cosmos_test.go
@@ -1,0 +1,137 @@
+package savedapplications
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+type fakeItems struct {
+	stored       map[string][]byte
+	deleteErr    error
+	queryResult  [][]byte
+	lastUpsertPK string
+	lastDeleteID string
+	lastQueryPK  string
+	lastParams   map[string]any
+}
+
+func newFakeItems() *fakeItems { return &fakeItems{stored: map[string][]byte{}} }
+
+func (f *fakeItems) ReadItem(_ context.Context, _, id string) ([]byte, error) {
+	b, ok := f.stored[id]
+	if !ok {
+		return nil, &azcore.ResponseError{StatusCode: http.StatusNotFound}
+	}
+	return b, nil
+}
+
+func (f *fakeItems) UpsertItem(_ context.Context, partitionKey string, item []byte) error {
+	f.lastUpsertPK = partitionKey
+	var doc struct {
+		ID string `json:"id"`
+	}
+	_ = json.Unmarshal(item, &doc)
+	f.stored[doc.ID] = item
+	return nil
+}
+
+func (f *fakeItems) DeleteItem(_ context.Context, _, id string) error {
+	f.lastDeleteID = id
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	delete(f.stored, id)
+	return nil
+}
+
+func (f *fakeItems) QueryItems(_ context.Context, partitionKey, _ string, params map[string]any) ([][]byte, error) {
+	f.lastQueryPK = partitionKey
+	f.lastParams = params
+	return f.queryResult, nil
+}
+
+func savedFixture(t *testing.T) SavedApplication {
+	t.Helper()
+	return NewSavedApplication("auth0|u", testApp(t), time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+}
+
+func TestCosmosStore_Save_UpsertsToUserPartition(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+	s := savedFixture(t)
+
+	if err := store.Save(context.Background(), s); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if items.lastUpsertPK != "auth0|u" {
+		t.Errorf("upsert pk: got %q", items.lastUpsertPK)
+	}
+	if _, ok := items.stored["auth0|u:471/24/0123/FUL"]; !ok {
+		t.Errorf("doc not stored under composite id, have %v", keys(items.stored))
+	}
+}
+
+func TestCosmosStore_Exists(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+	s := savedFixture(t)
+	_ = store.Save(context.Background(), s)
+
+	ok, err := store.Exists(context.Background(), "auth0|u", "471/24/0123/FUL")
+	if err != nil || !ok {
+		t.Fatalf("Exists existing: ok=%v err=%v", ok, err)
+	}
+	ok, err = store.Exists(context.Background(), "auth0|u", "nope")
+	if err != nil || ok {
+		t.Fatalf("Exists missing: ok=%v err=%v", ok, err)
+	}
+}
+
+func TestCosmosStore_Delete_SwallowsNotFound(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	items.deleteErr = &azcore.ResponseError{StatusCode: http.StatusNotFound}
+	store := NewCosmosStore(items)
+
+	if err := store.Delete(context.Background(), "auth0|u", "missing"); err != nil {
+		t.Fatalf("Delete of missing must be a no-op, got %v", err)
+	}
+	if items.lastDeleteID != "auth0|u:missing" {
+		t.Errorf("delete id: got %q", items.lastDeleteID)
+	}
+}
+
+func TestCosmosStore_GetByUserID(t *testing.T) {
+	t.Parallel()
+	s := savedFixture(t)
+	body, _ := json.Marshal(newSavedApplicationDocument(s))
+	items := newFakeItems()
+	items.queryResult = [][]byte{body}
+	store := NewCosmosStore(items)
+
+	got, err := store.GetByUserID(context.Background(), "auth0|u")
+	if err != nil {
+		t.Fatalf("GetByUserID: %v", err)
+	}
+	if len(got) != 1 || got[0].ApplicationUID != "471/24/0123/FUL" {
+		t.Fatalf("got %+v", got)
+	}
+	if items.lastQueryPK != "auth0|u" || items.lastParams["@userId"] != "auth0|u" {
+		t.Errorf("query routing: pk=%q params=%v", items.lastQueryPK, items.lastParams)
+	}
+}
+
+func keys(m map[string][]byte) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/api-go/tests/e2e/contract_savedapps_test.go
+++ b/api-go/tests/e2e/contract_savedapps_test.go
@@ -1,0 +1,117 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// Valid-token contract scenarios for the iteration-6 saved + planning
+// application surface. A save is performed on the .NET side as un-diffed setup
+// (both APIs share one Cosmos database), then the read endpoints are diffed.
+// The saved-list diff is scoped to the entry this test creates so pre-existing
+// rows (and the deferred legacy-migration paths, tc-wans) never affect it.
+//
+// Quota-safe: the created saved row is always deleted on cleanup; the master
+// application record is shared reference data and is left in place.
+func TestContract_SavedApplications(t *testing.T) {
+	dotnetURL := baseURL(t, "DOTNET_BASE_URL")
+	goURL := baseURL(t, "GO_BASE_URL")
+	token := integrationToken(t)
+	client := &http.Client{Timeout: requestTimeout}
+
+	if setup := watchZoneRequest(t, client, dotnetURL, http.MethodPost, "/v1/me", token, ""); setup.status >= 500 {
+		t.Fatalf("setup POST /v1/me on .NET: %d %s", setup.status, setup.body)
+	}
+
+	suffix := newZoneSuffix(t)
+	name := "CONTRACT-" + suffix  // slash-free; canonical uid = "471/CONTRACT-..."
+	canonicalUID := "471/" + name // {areaId}/{name}
+	savePath := "/v1/me/saved-applications/" + canonicalUID
+	appPath := "/v1/applications/471/" + name
+	saveBody := fmt.Sprintf(`{
+		"name": %q, "uid": "ABC-%s", "areaName": "City of London", "areaId": 471,
+		"address": "1 Contract Street", "postcode": "EC2V 5AE", "description": "Contract test",
+		"appType": "Full", "appState": "Permitted", "appSize": "Small",
+		"startDate": "2026-01-05", "decidedDate": "2026-03-01", "consultedDate": "2026-01-20",
+		"longitude": -0.0931, "latitude": 51.5155,
+		"url": "https://planit.example/app", "link": "https://council.example/app",
+		"lastDifferent": "2026-03-02T09:30:00+00:00"
+	}`, name, suffix)
+
+	// Setup, not a diff: create the master record + saved row on .NET.
+	if created := watchZoneRequest(t, client, dotnetURL, http.MethodPut, savePath, token, saveBody); created.status != http.StatusNoContent {
+		t.Fatalf("setup save on .NET: status %d body %s", created.status, created.body)
+	}
+	t.Cleanup(func() {
+		_ = watchZoneRequest(t, client, dotnetURL, http.MethodDelete, savePath, token, "")
+	})
+
+	// Save is idempotent: re-saving on both APIs is a 204 on the shared state.
+	t.Run("PUT save (idempotent)", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodPut, savePath, token, saveBody)
+	})
+
+	// The created saved entry must be byte-identical between the two APIs.
+	t.Run("GET saved-applications entry", func(t *testing.T) {
+		want := findSavedEntry(t, watchZoneRequest(t, client, dotnetURL, http.MethodGet, "/v1/me/saved-applications", token, "").body, canonicalUID)
+		got := findSavedEntry(t, watchZoneRequest(t, client, goURL, http.MethodGet, "/v1/me/saved-applications", token, "").body, canonicalUID)
+		if want == nil || got == nil {
+			t.Fatalf("created entry missing: dotnet=%v go=%v", want != nil, got != nil)
+		}
+		if !jsonEqual(t, got, want) {
+			t.Errorf("saved entry: go=%s dotnet=%s", got, want)
+		}
+	})
+
+	// The master application point read.
+	t.Run("GET applications/{authority}/{name}", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodGet, appPath, token, "")
+	})
+
+	// The watch-zone-derived authority list.
+	t.Run("GET application-authorities", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodGet, "/v1/me/application-authorities", token, "")
+	})
+
+	// A body missing the uid is a 400 with the ApiErrorResponse envelope.
+	t.Run("PUT save invalid", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodPut, savePath, token,
+			`{"name":"x","uid":"","areaId":471,"areaName":"a","address":"b","description":"d","lastDifferent":"2026-03-02T09:30:00+00:00"}`)
+	})
+
+	// An application not in Cosmos is a bodyless 404 (no PlanIt fallback).
+	t.Run("GET application not found", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodGet, "/v1/applications/471/UNKNOWN-"+suffix, token, "")
+	})
+
+	// Deleting a non-existent saved row is an idempotent 204 on both.
+	t.Run("DELETE saved not found", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodDelete, "/v1/me/saved-applications/471/MISSING-"+suffix, token, "")
+	})
+}
+
+// findSavedEntry returns the saved-list entry with the given applicationUid, or
+// nil when absent — so the diff ignores any other rows the user may hold.
+func findSavedEntry(t *testing.T, body []byte, uid string) json.RawMessage {
+	t.Helper()
+	var arr []json.RawMessage
+	if err := json.Unmarshal(body, &arr); err != nil {
+		t.Fatalf("decode saved list %q: %v", body, err)
+	}
+	for _, entry := range arr {
+		var probe struct {
+			ApplicationUID string `json:"applicationUid"`
+		}
+		if err := json.Unmarshal(entry, &probe); err != nil {
+			t.Fatalf("decode saved entry: %v", err)
+		}
+		if probe.ApplicationUID == uid {
+			return entry
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Iteration 6 of the Go API migration (GH #418): ports the saved-application and master planning-application surface to `api-go/`.

## Scope shipped
- `PUT /v1/me/saved-applications/{**uid}` — save (path uid ignored; dual-writes the master record then the saved row keyed on the canonical `{areaId}/{name}` uid; idempotent re-save; `400` ApiErrorResponse when the body lacks uid/name)
- `DELETE /v1/me/saved-applications/{**uid}` — idempotent `204`
- `GET /v1/me/saved-applications` — JSON array of saved entries rendered from their embedded snapshots
- `GET /v1/me/application-authorities` — distinct authorities across the user's watch zones, resolved + sorted by name
- `GET /v1/applications/{authorityCode}/{**name}` — partitioned point read (`id=name`, `pk=authorityCode`); `404` with no PlanIt fallback (GH#395 Invariant 1)

## New building blocks
- `platform.DateOnly` — `yyyy-MM-dd` wire type for the planning-application dates
- `internal/applications` — `PlanningApplication` domain + canonical uid, Applications-container document (GeoJSON `location`, DateOnly/DotNetTime), point-read store, exported `Result`/`SnapshotDocument`
- `internal/savedapplications` — saved domain (canonical key + embedded snapshot), SavedApplications-container document, store, handlers
- `authorities.Lookup` + `CompareOrdinalIgnoreCase` exported for the authority resolution/sort

## Deferred (tc-wans, discovered-from)
The saved-list legacy-migration machinery — lazy snapshot backfill, legacy-uid→canonical re-keying, legacy+canonical dedup, and refresh-on-tap — only triggers on pre-PR#398 data and isn't reachable via a fresh contract flow. The Go core handles fresh rows identically to .NET; nil-snapshot legacy rows are skipped in the list.

## Tests
- Red/green TDD, hand fakes, table-driven; **328** unit tests pass with `-race`.
- e2e contract scenarios (`contract_savedapps_test.go`) diff the idempotent PUT, the created saved entry (matched by `applicationUid`, so pre-existing rows don't perturb it), the master point read, application-authorities, the `400` invalid body, the `404` unknown application, and the idempotent `204` delete — against the live .NET dev API over shared Cosmos. Quota-safe: only the created row is deleted on cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added planning applications endpoints: view applications by authority and list saved applications
  * Added ability to save and manage application bookmarks with save/delete/list operations
  * Added endpoint to view application authorities based on user's watch zones

<!-- end of auto-generated comment: release notes by coderabbit.ai -->