### PR TITLE
feat(go): it7 geocode + designations endpoints (tc-7g3i.8)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -15,7 +15,9 @@ import (
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/designations"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/geocoding"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
@@ -106,7 +108,12 @@ func main() {
 		)
 	}
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, deviceStore, stateStore, watchZoneStore, appStore, savedStore, logger))
+	// Geocode and designation clients call live UK services (the config defaults);
+	// each gets its own timeout-bounded HTTP client.
+	geocodeClient := geocoding.NewClient(cfg.PostcodesIoBaseURL, &http.Client{Timeout: 30 * time.Second})
+	designationClient := designations.NewClient(cfg.GovUkBaseURL, &http.Client{Timeout: 30 * time.Second})
+
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, deviceStore, stateStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -9,7 +9,9 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/authorities"
+	"github.com/AmyDe/town-crier/api-go/internal/designations"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/geocoding"
 	"github.com/AmyDe/town-crier/api-go/internal/health"
 	"github.com/AmyDe/town-crier/api-go/internal/legal"
 	"github.com/AmyDe/town-crier/api-go/internal/middleware"
@@ -70,13 +72,18 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // nil-means-unwired convention. (The watch-zone preferences endpoints are
 // served by profiles.Routes off the profile store, so they come up with the
 // /v1/me routes, not the watch-zone store.)
-func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, logger *slog.Logger) http.Handler {
+func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)
 	legal.Routes(mux, logger)
 	authorities.Routes(mux, logger)
 	api.Routes(mux, logger)
+	// Geocode and designations are authed (absent from anonymousPatterns) and
+	// have no Cosmos dependency — they call outbound UK services — so they are
+	// always wired, even on a Cosmos-less local boot.
+	geocoding.Routes(mux, geocodeClient, logger)
+	designations.Routes(mux, designationClient, logger)
 
 	var dispatch http.Handler = mux
 	if store != nil {

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/designations"
+	"github.com/AmyDe/town-crier/api-go/internal/geocoding"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
@@ -95,9 +97,20 @@ func idFromDoc(raw []byte) string {
 	return doc.ID
 }
 
+// testGeocodeClient and testDesignationClient point at an unroutable address; the
+// deny-all wiring tests never reach the handlers, so the upstream is never
+// called.
+func testGeocodeClient() *geocoding.Client {
+	return geocoding.NewClient("http://127.0.0.1:0", http.DefaultClient)
+}
+
+func testDesignationClient() *designations.Client {
+	return designations.NewClient("http://127.0.0.1:0", http.DefaultClient)
+}
+
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -147,6 +160,9 @@ func TestRouter_FallbackDeny(t *testing.T) {
 		{"unknown path", http.MethodGet, "/v1/nope"},
 		{"non-int authority id", http.MethodGet, "/v1/authorities/abc"},
 		{"wrong method on me", http.MethodPut, "/api/me"},
+		// Geocode and designations are authed, not anonymous: no token -> 401.
+		{"geocode without token", http.MethodGet, "/v1/geocode/SW1A1AA"},
+		{"designations without token", http.MethodGet, "/v1/designations?latitude=55&longitude=2"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -197,7 +213,7 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	appStore := applications.NewCosmosStore(newFakeItems())
 	savedStore := savedapplications.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", nil, nil, watchZoneStore, appStore, savedStore, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(), testDesignationClient(), logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -254,6 +270,48 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	}
 	if got := rec.Header().Get("X-RateLimit-Limit"); got != "" {
 		t.Errorf("anonymous route got rate-limit header %q", got)
+	}
+}
+
+// TestRouter_GeocodeAndDesignationsDispatch proves an authenticated request
+// reaches the geocode and designation handlers (not just the auth fallback). A
+// single stub upstream backs both outbound clients, routing by path.
+func TestRouter_GeocodeAndDesignationsDispatch(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/postcodes/"):
+			_, _ = w.Write([]byte(`{"status":200,"result":{"latitude":51.5,"longitude":-0.14}}`))
+		case r.URL.Path == "/api/v1/entity.json":
+			// No intersecting entity -> the none context.
+			w.WriteHeader(http.StatusNotFound)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(upstream.Close)
+
+	logger := slog.New(slog.DiscardHandler)
+	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
+	geocodeClient := geocoding.NewClient(upstream.URL, upstream.Client())
+	designationClient := designations.NewClient(upstream.URL, upstream.Client())
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, geocodeClient, designationClient, logger)
+
+	rec := serveReq(t, h, http.MethodGet, "/v1/geocode/SW1A%201AA", "", "Bearer tok")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/geocode status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != `{"coordinates":{"latitude":51.5,"longitude":-0.14}}` {
+		t.Errorf("geocode body = %s", got)
+	}
+
+	rec = serveReq(t, h, http.MethodGet, "/v1/designations?latitude=55&longitude=2", "", "Bearer tok")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/designations status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != `{"isWithinConservationArea":false,"conservationAreaName":null,"isWithinListedBuildingCurtilage":false,"listedBuildingGrade":null,"isWithinArticle4Area":false}` {
+		t.Errorf("designations body = %s", got)
 	}
 }
 

--- a/api-go/internal/designations/client.go
+++ b/api-go/internal/designations/client.go
@@ -69,12 +69,15 @@ func (c *Client) Get(ctx context.Context, latitude, longitude float64) (Context,
 	point := "POINT(" + strconv.FormatFloat(longitude, 'g', -1, 64) + " " + strconv.FormatFloat(latitude, 'g', -1, 64) + ")"
 	endpoint := c.baseURL + "/api/v1/entity.json?geometry_intersects=" + escapeDataString(point) + "&dataset=" + datasets
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	// gosec G704: the host is the trusted GovUkBaseURL config value; the query is
+	// built from parsed float coordinates and a fixed dataset list, so no
+	// attacker-controlled host can be reached — not an SSRF vector.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil) //nolint:gosec // trusted config host + numeric coordinates
 	if err != nil {
 		return Context{}, fmt.Errorf("build designations request: %w", err)
 	}
 
-	resp, err := c.http.Do(req)
+	resp, err := c.http.Do(req) //nolint:gosec // trusted config host, not user input
 	if err != nil {
 		return Context{}, fmt.Errorf("designations request: %w", err)
 	}
@@ -142,7 +145,7 @@ const upperHex = "0123456789ABCDEF"
 // wire — in particular a space becomes %20 (not "+", as url.QueryEscape would).
 func escapeDataString(s string) string {
 	var b strings.Builder
-	for i := 0; i < len(s); i++ {
+	for i := range len(s) {
 		c := s[i]
 		if isUnreserved(c) {
 			b.WriteByte(c)

--- a/api-go/internal/designations/client.go
+++ b/api-go/internal/designations/client.go
@@ -1,0 +1,167 @@
+// Package designations owns the planning-designation feature: the GOV.UK
+// planning.data.gov.uk outbound client and GET /v1/designations. It mirrors the
+// .NET TownCrier.{Domain,Application,Infrastructure} Designations slices
+// (GH#418 iteration 7).
+package designations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// datasets is the comma-separated dataset filter sent to the entity endpoint.
+// The commas are intentionally left unescaped to match the .NET client, which
+// concatenates this string straight into the query.
+const datasets = "conservation-area,listed-building-outline,article-4-direction-area"
+
+// maxRespBytes bounds the planning.data.gov.uk response body read.
+const maxRespBytes = 1 << 20
+
+// Context is the planning-designation context for a point, mirroring .NET
+// DesignationContext. The zero value is the "none" context (all false/nil) the
+// API returns when a point intersects no designated entity.
+type Context struct {
+	IsWithinConservationArea        bool
+	ConservationAreaName            *string
+	IsWithinListedBuildingCurtilage bool
+	ListedBuildingGrade             *string
+	IsWithinArticle4Area            bool
+}
+
+// Client is the planning.data.gov.uk outbound designation provider. The base URL
+// is config-supplied (default https://www.planning.data.gov.uk/), so no user
+// input reaches the scheme.
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+// NewClient builds a provider over the given base URL and shared HTTP client.
+func NewClient(baseURL string, httpClient *http.Client) *Client {
+	return &Client{baseURL: strings.TrimRight(baseURL, "/"), http: httpClient}
+}
+
+// entityResponse mirrors the GOV.UK entity.json envelope.
+type entityResponse struct {
+	Entities []entity `json:"entities"`
+}
+
+type entity struct {
+	Dataset             string  `json:"dataset"`
+	Name                string  `json:"name"`
+	Reference           string  `json:"reference"`
+	ListedBuildingGrade *string `json:"listed-building-grade"`
+}
+
+// Get resolves the designation context for a point. A 404 — the entity endpoint's
+// response when the geometry intersects nothing, which is most UK points —
+// yields the empty context with no error, mirroring .NET. Any other non-2xx, a
+// transport failure, or a malformed body returns an error; the handler maps that
+// to the empty context (mirroring .NET's catch of HttpRequestException).
+func (c *Client) Get(ctx context.Context, latitude, longitude float64) (Context, error) {
+	// WKT is "POINT(longitude latitude)" with invariant (shortest round-trip)
+	// formatting, escaped exactly as .NET's Uri.EscapeDataString does.
+	point := "POINT(" + strconv.FormatFloat(longitude, 'g', -1, 64) + " " + strconv.FormatFloat(latitude, 'g', -1, 64) + ")"
+	endpoint := c.baseURL + "/api/v1/entity.json?geometry_intersects=" + escapeDataString(point) + "&dataset=" + datasets
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return Context{}, fmt.Errorf("build designations request: %w", err)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return Context{}, fmt.Errorf("designations request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return Context{}, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Context{}, fmt.Errorf("designations request: unexpected status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
+	if err != nil {
+		return Context{}, fmt.Errorf("read designations response: %w", err)
+	}
+	var parsed entityResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return Context{}, fmt.Errorf("decode designations response: %w", err)
+	}
+	if len(parsed.Entities) == 0 {
+		return Context{}, nil
+	}
+	return mapContext(parsed.Entities), nil
+}
+
+// mapContext folds the matched entities into a designation context, picking the
+// first entity of each dataset, mirroring the .NET MapToDesignationContext.
+func mapContext(entities []entity) Context {
+	conservation := findDataset(entities, "conservation-area")
+	listed := findDataset(entities, "listed-building-outline")
+	article4 := findDataset(entities, "article-4-direction-area")
+
+	result := Context{
+		IsWithinConservationArea:        conservation != nil,
+		IsWithinListedBuildingCurtilage: listed != nil,
+		IsWithinArticle4Area:            article4 != nil,
+	}
+	if conservation != nil {
+		name := conservation.Name
+		result.ConservationAreaName = &name
+	}
+	if listed != nil {
+		result.ListedBuildingGrade = listed.ListedBuildingGrade
+	}
+	return result
+}
+
+// findDataset returns the first entity whose dataset matches (case-insensitively),
+// or nil, mirroring .NET's List.Find with OrdinalIgnoreCase.
+func findDataset(entities []entity, dataset string) *entity {
+	for i := range entities {
+		if strings.EqualFold(entities[i].Dataset, dataset) {
+			return &entities[i]
+		}
+	}
+	return nil
+}
+
+const upperHex = "0123456789ABCDEF"
+
+// escapeDataString percent-encodes everything outside the RFC 3986 unreserved
+// set (ALPHA / DIGIT / "-" / "." / "_" / "~"), reproducing .NET's
+// Uri.EscapeDataString so the geometry_intersects value is byte-identical on the
+// wire — in particular a space becomes %20 (not "+", as url.QueryEscape would).
+func escapeDataString(s string) string {
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if isUnreserved(c) {
+			b.WriteByte(c)
+			continue
+		}
+		b.WriteByte('%')
+		b.WriteByte(upperHex[c>>4])
+		b.WriteByte(upperHex[c&0x0f])
+	}
+	return b.String()
+}
+
+func isUnreserved(c byte) bool {
+	switch {
+	case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+		return true
+	case c == '-', c == '.', c == '_', c == '~':
+		return true
+	default:
+		return false
+	}
+}

--- a/api-go/internal/designations/client_test.go
+++ b/api-go/internal/designations/client_test.go
@@ -1,0 +1,150 @@
+package designations
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// govUkServer is a hand-written fake planning.data.gov.uk entity endpoint. It
+// records the raw request URI and drives the status code and JSON body.
+type govUkServer struct {
+	requestedURI string
+	status       int    // status for /api/v1/entity.json; 0 -> 200
+	body         string // raw JSON body on a 2xx
+}
+
+func newGovUkServer(t *testing.T, s *govUkServer) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// RequestURI is the unmodified request target, so the escaping assertion
+		// sees exactly what went on the wire.
+		s.requestedURI = r.RequestURI
+		if s.status != 0 {
+			w.WriteHeader(s.status)
+		}
+		_, _ = w.Write([]byte(s.body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestClient_Get_MapsAllDatasets(t *testing.T) {
+	t.Parallel()
+
+	fake := &govUkServer{body: `{"entities":[
+		{"dataset":"conservation-area","name":"Old Town CA","reference":"CA1"},
+		{"dataset":"listed-building-outline","name":"The Hall","reference":"LB1","listed-building-grade":"II*"},
+		{"dataset":"article-4-direction-area","name":"A4 Zone","reference":"A41"}
+	]}`}
+	srv := newGovUkServer(t, fake)
+	client := NewClient(srv.URL, srv.Client())
+
+	got, err := client.Get(context.Background(), 51.5, -0.14)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.IsWithinConservationArea || got.ConservationAreaName == nil || *got.ConservationAreaName != "Old Town CA" {
+		t.Errorf("conservation = %+v", got)
+	}
+	if !got.IsWithinListedBuildingCurtilage || got.ListedBuildingGrade == nil || *got.ListedBuildingGrade != "II*" {
+		t.Errorf("listed building = %+v", got)
+	}
+	if !got.IsWithinArticle4Area {
+		t.Errorf("article4 = %+v", got)
+	}
+}
+
+func TestClient_Get_EscapesPointLongitudeFirst(t *testing.T) {
+	t.Parallel()
+
+	fake := &govUkServer{status: http.StatusNotFound}
+	srv := newGovUkServer(t, fake)
+	client := NewClient(srv.URL, srv.Client())
+
+	if _, err := client.Get(context.Background(), 55, 2); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	// POINT(longitude latitude) with .NET-style escaping: "(" -> %28, " " -> %20,
+	// ")" -> %29; the dataset commas stay literal.
+	want := "/api/v1/entity.json?geometry_intersects=POINT%282%2055%29&dataset=conservation-area,listed-building-outline,article-4-direction-area"
+	if fake.requestedURI != want {
+		t.Errorf("request URI =\n  %q\nwant\n  %q", fake.requestedURI, want)
+	}
+}
+
+func TestClient_Get_NotFoundIsEmptyContext(t *testing.T) {
+	t.Parallel()
+
+	// 404 means the geometry intersects no entity — an empty context, not an error.
+	fake := &govUkServer{status: http.StatusNotFound}
+	srv := newGovUkServer(t, fake)
+	client := NewClient(srv.URL, srv.Client())
+
+	got, err := client.Get(context.Background(), 55, 2)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if (got != Context{}) {
+		t.Errorf("got %+v, want empty context", got)
+	}
+}
+
+func TestClient_Get_EmptyEntitiesIsEmptyContext(t *testing.T) {
+	t.Parallel()
+
+	fake := &govUkServer{body: `{"entities":[]}`}
+	srv := newGovUkServer(t, fake)
+	client := NewClient(srv.URL, srv.Client())
+
+	got, err := client.Get(context.Background(), 55, 2)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if (got != Context{}) {
+		t.Errorf("got %+v, want empty context", got)
+	}
+}
+
+func TestClient_Get_ErrorOnServerError(t *testing.T) {
+	t.Parallel()
+
+	// A non-404 error status is an error (the handler maps it to the empty
+	// context), mirroring .NET's EnsureSuccessStatusCode throw.
+	fake := &govUkServer{status: http.StatusInternalServerError, body: `{}`}
+	srv := newGovUkServer(t, fake)
+	client := NewClient(srv.URL, srv.Client())
+
+	if _, err := client.Get(context.Background(), 55, 2); err == nil {
+		t.Error("Get on 500: want error, got nil")
+	}
+}
+
+func TestClient_Get_ErrorOnTransportFailure(t *testing.T) {
+	t.Parallel()
+
+	fake := &govUkServer{body: `{}`}
+	srv := newGovUkServer(t, fake)
+	client := NewClient(srv.URL, srv.Client())
+	srv.Close()
+
+	if _, err := client.Get(context.Background(), 55, 2); err == nil {
+		t.Error("Get on dead upstream: want error, got nil")
+	}
+}
+
+func TestEscapeDataString_MatchesUriEscapeDataString(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"POINT(2 55)":       "POINT%282%2055%29",
+		"POINT(-0.14 51.5)": "POINT%28-0.14%2051.5%29",
+		"abc-_.~":           "abc-_.~",
+	}
+	for in, want := range tests {
+		if got := escapeDataString(in); got != want {
+			t.Errorf("escapeDataString(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/api-go/internal/designations/handler.go
+++ b/api-go/internal/designations/handler.go
@@ -59,13 +59,10 @@ func (h handler) designations(w http.ResponseWriter, r *http.Request) {
 		designation = Context{}
 	}
 
-	h.writeJSON(r, w, designationsResult{
-		IsWithinConservationArea:        designation.IsWithinConservationArea,
-		ConservationAreaName:            designation.ConservationAreaName,
-		IsWithinListedBuildingCurtilage: designation.IsWithinListedBuildingCurtilage,
-		ListedBuildingGrade:             designation.ListedBuildingGrade,
-		IsWithinArticle4Area:            designation.IsWithinArticle4Area,
-	})
+	// designationsResult mirrors Context field-for-field, differing only in JSON
+	// tags (ignored in a struct conversion), so the result is just the context in
+	// wire dress.
+	h.writeJSON(r, w, designationsResult(designation))
 }
 
 func (h handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {

--- a/api-go/internal/designations/handler.go
+++ b/api-go/internal/designations/handler.go
@@ -1,0 +1,84 @@
+package designations
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+)
+
+// provider is the consumer-side view the handler needs: resolve the designation
+// context for a point. The concrete *Client satisfies it structurally; the
+// handler test substitutes a hand fake.
+type provider interface {
+	Get(ctx context.Context, latitude, longitude float64) (Context, error)
+}
+
+type handler struct {
+	provider provider
+	logger   *slog.Logger
+}
+
+// Routes registers the designations endpoint on mux. The endpoint is authed (it
+// is not in the .NET AllowAnonymous set) and has no Cosmos dependency, so it is
+// always wired.
+func Routes(mux *http.ServeMux, p provider, logger *slog.Logger) {
+	h := handler{provider: p, logger: logger}
+	mux.HandleFunc("GET /v1/designations", h.designations)
+}
+
+// designationsResult mirrors the .NET GetDesignationContextResult record; field
+// order matches so the wire bytes are identical.
+type designationsResult struct {
+	IsWithinConservationArea        bool    `json:"isWithinConservationArea"`
+	ConservationAreaName            *string `json:"conservationAreaName"`
+	IsWithinListedBuildingCurtilage bool    `json:"isWithinListedBuildingCurtilage"`
+	ListedBuildingGrade             *string `json:"listedBuildingGrade"`
+	IsWithinArticle4Area            bool    `json:"isWithinArticle4Area"`
+}
+
+// designations implements GET /v1/designations?latitude=&longitude=. Missing or
+// unparseable coordinates are a bodyless 400 (mirroring .NET's value-type query
+// binding failure, whose PascalCase envelope middleware.ErrorBody backfills). A
+// provider failure degrades to the empty context, mirroring the .NET handler's
+// catch of HttpRequestException — the endpoint always answers 200 once the
+// coordinates parse.
+func (h handler) designations(w http.ResponseWriter, r *http.Request) {
+	latitude, latErr := strconv.ParseFloat(r.URL.Query().Get("latitude"), 64)
+	longitude, lngErr := strconv.ParseFloat(r.URL.Query().Get("longitude"), 64)
+	if latErr != nil || lngErr != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	designation, err := h.provider.Get(r.Context(), latitude, longitude)
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "resolve designations", "error", err)
+		designation = Context{}
+	}
+
+	h.writeJSON(r, w, designationsResult{
+		IsWithinConservationArea:        designation.IsWithinConservationArea,
+		ConservationAreaName:            designation.ConservationAreaName,
+		IsWithinListedBuildingCurtilage: designation.IsWithinListedBuildingCurtilage,
+		ListedBuildingGrade:             designation.ListedBuildingGrade,
+		IsWithinArticle4Area:            designation.IsWithinArticle4Area,
+	})
+}
+
+func (h handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		h.logger.ErrorContext(r.Context(), "encode designations response", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if _, err := w.Write(bytes.TrimRight(buf.Bytes(), "\n")); err != nil {
+		h.logger.ErrorContext(r.Context(), "write designations response", "error", err)
+	}
+}

--- a/api-go/internal/designations/handler_test.go
+++ b/api-go/internal/designations/handler_test.go
@@ -3,7 +3,6 @@ package designations
 import (
 	"context"
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -28,9 +27,9 @@ func (f *fakeProvider) Get(_ context.Context, latitude, longitude float64) (Cont
 func newDesignationsRequest(t *testing.T, p provider, query string) *httptest.ResponseRecorder {
 	t.Helper()
 	mux := http.NewServeMux()
-	Routes(mux, p, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	Routes(mux, p, slog.New(slog.DiscardHandler))
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/v1/designations"+query, nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/designations"+query, nil)
 	mux.ServeHTTP(rec, req)
 	return rec
 }

--- a/api-go/internal/designations/handler_test.go
+++ b/api-go/internal/designations/handler_test.go
@@ -1,0 +1,126 @@
+package designations
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeProvider is a hand-written designation provider double. It records the
+// coordinates it was asked about and returns a canned context / error.
+type fakeProvider struct {
+	gotLatitude  float64
+	gotLongitude float64
+	context      Context
+	err          error
+}
+
+func (f *fakeProvider) Get(_ context.Context, latitude, longitude float64) (Context, error) {
+	f.gotLatitude = latitude
+	f.gotLongitude = longitude
+	return f.context, f.err
+}
+
+func newDesignationsRequest(t *testing.T, p provider, query string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	Routes(mux, p, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/designations"+query, nil)
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func strPtr(s string) *string { return &s }
+
+func TestHandler_Designations_ReturnsContext(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeProvider{context: Context{
+		IsWithinConservationArea:        true,
+		ConservationAreaName:            strPtr("Old Town CA"),
+		IsWithinListedBuildingCurtilage: true,
+		ListedBuildingGrade:             strPtr("II*"),
+		IsWithinArticle4Area:            true,
+	}}
+	rec := newDesignationsRequest(t, fake, "?latitude=51.5&longitude=-0.14")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	want := `{"isWithinConservationArea":true,"conservationAreaName":"Old Town CA","isWithinListedBuildingCurtilage":true,"listedBuildingGrade":"II*","isWithinArticle4Area":true}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body =\n  %s\nwant\n  %s", got, want)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("content-type = %q", ct)
+	}
+}
+
+func TestHandler_Designations_PassesParsedCoordinates(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeProvider{}
+	newDesignationsRequest(t, fake, "?latitude=55&longitude=2")
+
+	if fake.gotLatitude != 55 || fake.gotLongitude != 2 {
+		t.Errorf("provider saw lat=%v lng=%v, want 55 / 2", fake.gotLatitude, fake.gotLongitude)
+	}
+}
+
+func TestHandler_Designations_EmptyContextSerializesNulls(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeProvider{} // zero Context -> all false / null
+	rec := newDesignationsRequest(t, fake, "?latitude=55&longitude=2")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	want := `{"isWithinConservationArea":false,"conservationAreaName":null,"isWithinListedBuildingCurtilage":false,"listedBuildingGrade":null,"isWithinArticle4Area":false}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body =\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+func TestHandler_Designations_BadRequestOnMissingCoordinates(t *testing.T) {
+	t.Parallel()
+
+	for _, query := range []string{"", "?latitude=51.5", "?longitude=-0.14", "?latitude=abc&longitude=2"} {
+		fake := &fakeProvider{}
+		rec := newDesignationsRequest(t, fake, query)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("query %q: status = %d, want 400", query, rec.Code)
+		}
+		if rec.Body.Len() != 0 {
+			t.Errorf("query %q: 400 body = %q, want empty (backfilled downstream)", query, rec.Body.String())
+		}
+	}
+}
+
+func TestHandler_Designations_ProviderErrorDegradesToEmpty(t *testing.T) {
+	t.Parallel()
+
+	// A provider failure must not fail the request: the handler answers 200 with
+	// the empty context, mirroring .NET's catch(HttpRequestException) -> None.
+	fake := &fakeProvider{err: errors.New("gov.uk down")}
+	rec := newDesignationsRequest(t, fake, "?latitude=55&longitude=2")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	want := `{"isWithinConservationArea":false,"conservationAreaName":null,"isWithinListedBuildingCurtilage":false,"listedBuildingGrade":null,"isWithinArticle4Area":false}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body =\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+func TestClient_SatisfiesProviderInterface(t *testing.T) {
+	t.Parallel()
+
+	var _ provider = NewClient("https://www.planning.data.gov.uk", http.DefaultClient)
+}

--- a/api-go/internal/geocoding/client.go
+++ b/api-go/internal/geocoding/client.go
@@ -1,0 +1,82 @@
+package geocoding
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// maxRespBytes bounds the postcodes.io response body read.
+const maxRespBytes = 1 << 20
+
+// Coordinates is the geocoded location, mirroring .NET Coordinates: { latitude,
+// longitude }.
+type Coordinates struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
+// Client is the postcodes.io outbound geocoder. The base URL is config-supplied
+// (default https://api.postcodes.io/), so no user input reaches the scheme.
+type Client struct {
+	baseURL string
+	http    *http.Client
+}
+
+// NewClient builds a geocoder over the given base URL and shared HTTP client.
+func NewClient(baseURL string, httpClient *http.Client) *Client {
+	return &Client{baseURL: strings.TrimRight(baseURL, "/"), http: httpClient}
+}
+
+// postcodesIoResponse mirrors the postcodes.io envelope.
+type postcodesIoResponse struct {
+	Status int                `json:"status"`
+	Result *postcodesIoResult `json:"result"`
+}
+
+type postcodesIoResult struct {
+	Postcode      string  `json:"postcode"`
+	Latitude      float64 `json:"latitude"`
+	Longitude     float64 `json:"longitude"`
+	AdminDistrict *string `json:"admin_district"`
+}
+
+// Geocode resolves a normalised UK postcode to coordinates. The boolean reports
+// whether the postcode was found: a non-2xx response or an envelope that is not
+// status 200 with a result yields found=false (a 404 for the caller), mirroring
+// .NET's null return. A transport failure returns an error (a 500 for the
+// caller), mirroring .NET's propagated HttpRequestException.
+func (c *Client) Geocode(ctx context.Context, postcode string) (Coordinates, bool, error) {
+	endpoint := c.baseURL + "/postcodes/" + url.PathEscape(postcode)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return Coordinates{}, false, fmt.Errorf("build geocode request: %w", err)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return Coordinates{}, false, fmt.Errorf("geocode request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Coordinates{}, false, nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
+	if err != nil {
+		return Coordinates{}, false, fmt.Errorf("read geocode response: %w", err)
+	}
+	var parsed postcodesIoResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return Coordinates{}, false, fmt.Errorf("decode geocode response: %w", err)
+	}
+	if parsed.Status != 200 || parsed.Result == nil {
+		return Coordinates{}, false, nil
+	}
+	return Coordinates{Latitude: parsed.Result.Latitude, Longitude: parsed.Result.Longitude}, true, nil
+}

--- a/api-go/internal/geocoding/client.go
+++ b/api-go/internal/geocoding/client.go
@@ -52,12 +52,15 @@ type postcodesIoResult struct {
 // caller), mirroring .NET's propagated HttpRequestException.
 func (c *Client) Geocode(ctx context.Context, postcode string) (Coordinates, bool, error) {
 	endpoint := c.baseURL + "/postcodes/" + url.PathEscape(postcode)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	// gosec G704: the host is the trusted PostcodesIoBaseURL config value; the
+	// postcode is regex-validated by normalisePostcode and path-escaped, so no
+	// attacker-controlled host can be reached — not an SSRF vector.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil) //nolint:gosec // trusted config host + validated, escaped postcode
 	if err != nil {
 		return Coordinates{}, false, fmt.Errorf("build geocode request: %w", err)
 	}
 
-	resp, err := c.http.Do(req)
+	resp, err := c.http.Do(req) //nolint:gosec // trusted config host, not user input
 	if err != nil {
 		return Coordinates{}, false, fmt.Errorf("geocode request: %w", err)
 	}

--- a/api-go/internal/geocoding/client_test.go
+++ b/api-go/internal/geocoding/client_test.go
@@ -1,0 +1,138 @@
+package geocoding
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// postcodesIoServer is a hand-written fake postcodes.io. It records the requested
+// path and lets a test drive the status code and raw JSON body the lookup
+// endpoint returns.
+type postcodesIoServer struct {
+	requestedPath string
+	status        int    // status returned by /postcodes/{postcode}; 0 -> 200
+	body          string // raw JSON body returned on a 2xx
+}
+
+func newPostcodesIoServer(t *testing.T, s *postcodesIoServer) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// EscapedPath preserves the on-the-wire %20 so the escaping assertion holds.
+		s.requestedPath = r.URL.EscapedPath()
+		if s.status != 0 {
+			w.WriteHeader(s.status)
+		}
+		_, _ = w.Write([]byte(s.body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestClient_Geocode_ReturnsCoordinates(t *testing.T) {
+	t.Parallel()
+
+	fake := &postcodesIoServer{
+		body: `{"status":200,"result":{"postcode":"SW1A 1AA","latitude":51.501009,"longitude":-0.141588,"admin_district":"Westminster"}}`,
+	}
+	srv := newPostcodesIoServer(t, fake)
+	client := NewClient(srv.URL, srv.Client())
+
+	coords, found, err := client.Geocode(context.Background(), "SW1A 1AA")
+	if err != nil {
+		t.Fatalf("Geocode: %v", err)
+	}
+	if !found {
+		t.Fatal("found = false, want true")
+	}
+	if coords.Latitude != 51.501009 || coords.Longitude != -0.141588 {
+		t.Errorf("coords = %+v, want {51.501009 -0.141588}", coords)
+	}
+}
+
+func TestClient_Geocode_EscapesPostcodeInPath(t *testing.T) {
+	t.Parallel()
+
+	fake := &postcodesIoServer{body: `{"status":200,"result":{"latitude":1,"longitude":2}}`}
+	srv := newPostcodesIoServer(t, fake)
+	client := NewClient(srv.URL, srv.Client())
+
+	if _, _, err := client.Geocode(context.Background(), "SW1A 1AA"); err != nil {
+		t.Fatalf("Geocode: %v", err)
+	}
+	// The space is percent-escaped as a single path segment, mirroring .NET's
+	// Uri.EscapeDataString.
+	if want := "/postcodes/SW1A%201AA"; fake.requestedPath != want {
+		t.Errorf("requested path = %q, want %q", fake.requestedPath, want)
+	}
+}
+
+func TestClient_Geocode_NotFoundOnNon2xx(t *testing.T) {
+	t.Parallel()
+
+	fake := &postcodesIoServer{status: http.StatusNotFound, body: `{"status":404,"error":"Postcode not found"}`}
+	srv := newPostcodesIoServer(t, fake)
+	client := NewClient(srv.URL, srv.Client())
+
+	// A non-2xx response means not found (a 404 for the caller), not an error —
+	// mirroring .NET's null return on !IsSuccessStatusCode.
+	coords, found, err := client.Geocode(context.Background(), "ZZ1 1ZZ")
+	if err != nil {
+		t.Fatalf("Geocode: %v", err)
+	}
+	if found {
+		t.Errorf("found = true, want false (got %+v)", coords)
+	}
+}
+
+func TestClient_Geocode_NotFoundOnEnvelopeStatusNot200(t *testing.T) {
+	t.Parallel()
+
+	// A 2xx wrapper whose envelope status is not 200 is still "not found",
+	// matching .NET's body.Status != 200 short-circuit.
+	fake := &postcodesIoServer{body: `{"status":404,"result":null}`}
+	srv := newPostcodesIoServer(t, fake)
+	client := NewClient(srv.URL, srv.Client())
+
+	_, found, err := client.Geocode(context.Background(), "ZZ1 1ZZ")
+	if err != nil {
+		t.Fatalf("Geocode: %v", err)
+	}
+	if found {
+		t.Error("found = true, want false")
+	}
+}
+
+func TestClient_Geocode_NotFoundOnNilResult(t *testing.T) {
+	t.Parallel()
+
+	// status 200 but a null result is "not found", matching .NET's Result is null.
+	fake := &postcodesIoServer{body: `{"status":200,"result":null}`}
+	srv := newPostcodesIoServer(t, fake)
+	client := NewClient(srv.URL, srv.Client())
+
+	_, found, err := client.Geocode(context.Background(), "ZZ1 1ZZ")
+	if err != nil {
+		t.Fatalf("Geocode: %v", err)
+	}
+	if found {
+		t.Error("found = true, want false")
+	}
+}
+
+func TestClient_Geocode_ErrorOnTransportFailure(t *testing.T) {
+	t.Parallel()
+
+	// A dead upstream is a transport failure: it returns an error (a 500 for the
+	// caller), mirroring .NET's propagated HttpRequestException. Build a server,
+	// capture its URL, then close it so the connection is refused.
+	fake := &postcodesIoServer{body: `{}`}
+	srv := newPostcodesIoServer(t, fake)
+	client := NewClient(srv.URL, srv.Client())
+	srv.Close()
+
+	if _, _, err := client.Geocode(context.Background(), "SW1A 1AA"); err == nil {
+		t.Error("Geocode on dead upstream: want error, got nil")
+	}
+}

--- a/api-go/internal/geocoding/handler.go
+++ b/api-go/internal/geocoding/handler.go
@@ -49,7 +49,10 @@ func (h handler) geocode(w http.ResponseWriter, r *http.Request) {
 
 	normalised, ok := normalisePostcode(raw)
 	if !ok {
-		h.writeError(r, w, http.StatusBadRequest, "'"+raw+"' is not a valid UK postcode.")
+		// .NET throws ArgumentException(msg, nameof(raw)); its Message — which the
+		// endpoint serializes — carries the " (Parameter 'raw')" suffix the
+		// runtime appends when a paramName is supplied. Reproduce it byte-for-byte.
+		h.writeError(r, w, http.StatusBadRequest, "'"+raw+"' is not a valid UK postcode. (Parameter 'raw')")
 		return
 	}
 

--- a/api-go/internal/geocoding/handler.go
+++ b/api-go/internal/geocoding/handler.go
@@ -1,0 +1,108 @@
+package geocoding
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// geocoder is the consumer-side view the handler needs: resolve a normalised
+// postcode to coordinates. The concrete *Client satisfies it structurally; the
+// handler test substitutes a hand fake.
+type geocoder interface {
+	Geocode(ctx context.Context, postcode string) (Coordinates, bool, error)
+}
+
+type handler struct {
+	geocoder geocoder
+	logger   *slog.Logger
+}
+
+// Routes registers the geocode endpoint on mux. The endpoint is authed (it is
+// not in the .NET AllowAnonymous set) and has no Cosmos dependency, so it is
+// always wired.
+func Routes(mux *http.ServeMux, g geocoder, logger *slog.Logger) {
+	h := handler{geocoder: g, logger: logger}
+	mux.HandleFunc("GET /v1/geocode/{postcode}", h.geocode)
+}
+
+// geocodeResult mirrors the .NET GeocodePostcodeResult record: { coordinates }.
+type geocodeResult struct {
+	Coordinates Coordinates `json:"coordinates"`
+}
+
+// apiErrorResponse mirrors the .NET ApiErrorResponse: { error, message:null }.
+type apiErrorResponse struct {
+	Error   string  `json:"error"`
+	Message *string `json:"message"`
+}
+
+// geocode implements GET /v1/geocode/{postcode}, mirroring the .NET endpoint's
+// three outcomes: a malformed postcode is a 400 (the .NET ArgumentException
+// path), an unresolvable one a 404 (the InvalidOperationException path), and a
+// transport failure a bodyless 500 (the propagated HttpRequestException, whose
+// PascalCase envelope middleware.ErrorBody backfills — as in .NET).
+func (h handler) geocode(w http.ResponseWriter, r *http.Request) {
+	raw := r.PathValue("postcode")
+
+	normalised, ok := normalisePostcode(raw)
+	if !ok {
+		h.writeError(r, w, http.StatusBadRequest, "'"+raw+"' is not a valid UK postcode.")
+		return
+	}
+
+	coords, found, err := h.geocoder.Geocode(r.Context(), normalised)
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "geocode postcode", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if !found {
+		h.writeError(r, w, http.StatusNotFound, "Postcode '"+raw+"' could not be geocoded.")
+		return
+	}
+
+	h.writeJSON(r, w, geocodeResult{Coordinates: coords})
+}
+
+func (h handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {
+	body, err := encodeJSON(v)
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "encode geocode response", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		h.logger.ErrorContext(r.Context(), "write geocode response", "error", err)
+	}
+}
+
+func (h handler) writeError(r *http.Request, w http.ResponseWriter, status int, message string) {
+	body, err := encodeJSON(apiErrorResponse{Error: message})
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "encode geocode error", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if _, err := w.Write(body); err != nil {
+		h.logger.ErrorContext(r.Context(), "write geocode error body", "error", err)
+	}
+}
+
+// encodeJSON renders v with HTML escaping off and the trailing newline trimmed,
+// so the wire bytes match the compact .NET response exactly.
+func encodeJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}

--- a/api-go/internal/geocoding/handler_test.go
+++ b/api-go/internal/geocoding/handler_test.go
@@ -1,0 +1,136 @@
+package geocoding
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeGeocoder is a hand-written geocoder double. It records the postcode it was
+// asked to resolve and returns canned coordinates / found / error values.
+type fakeGeocoder struct {
+	gotPostcode string
+	coords      Coordinates
+	found       bool
+	err         error
+}
+
+func (f *fakeGeocoder) Geocode(_ context.Context, postcode string) (Coordinates, bool, error) {
+	f.gotPostcode = postcode
+	return f.coords, f.found, f.err
+}
+
+func newGeocodeRequest(t *testing.T, g geocoder, rawPostcode string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	Routes(mux, g, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	rec := httptest.NewRecorder()
+	// The path segment is pre-escaped so the mux decodes it back to rawPostcode,
+	// matching how a real request arrives.
+	req := httptest.NewRequest(http.MethodGet, "/v1/geocode/"+escapeSegment(rawPostcode), nil)
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// escapeSegment percent-escapes a space so the raw postcode survives as one path
+// segment; the realistic inputs here contain only letters, digits and spaces.
+func escapeSegment(s string) string {
+	out := ""
+	for _, c := range s {
+		if c == ' ' {
+			out += "%20"
+			continue
+		}
+		out += string(c)
+	}
+	return out
+}
+
+func TestHandler_Geocode_ReturnsCoordinates(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeGeocoder{coords: Coordinates{Latitude: 51.501009, Longitude: -0.141588}, found: true}
+	rec := newGeocodeRequest(t, fake, "SW1A 1AA")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"coordinates":{"latitude":51.501009,"longitude":-0.141588}}` {
+		t.Errorf("body = %s", got)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("content-type = %q", ct)
+	}
+}
+
+func TestHandler_Geocode_NormalisesBeforeLookup(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeGeocoder{coords: Coordinates{Latitude: 1, Longitude: 2}, found: true}
+	newGeocodeRequest(t, fake, "sw1a 1aa")
+
+	// The geocoder is handed the trimmed, upper-cased postcode, never the raw input.
+	if fake.gotPostcode != "SW1A 1AA" {
+		t.Errorf("geocoder saw %q, want normalised SW1A 1AA", fake.gotPostcode)
+	}
+}
+
+func TestHandler_Geocode_BadRequestOnInvalidPostcode(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeGeocoder{}
+	rec := newGeocodeRequest(t, fake, "NOTAPOSTCODE")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"error":"'NOTAPOSTCODE' is not a valid UK postcode.","message":null}` {
+		t.Errorf("body = %s", got)
+	}
+	if fake.gotPostcode != "" {
+		t.Errorf("geocoder was called with %q; a malformed postcode must not reach it", fake.gotPostcode)
+	}
+}
+
+func TestHandler_Geocode_NotFoundWhenUnresolvable(t *testing.T) {
+	t.Parallel()
+
+	// A valid-format postcode the geocoder cannot resolve is a 404 carrying the
+	// raw input in the message, mirroring .NET's InvalidOperationException path.
+	fake := &fakeGeocoder{found: false}
+	rec := newGeocodeRequest(t, fake, "ZZ1 1ZZ")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"error":"Postcode 'ZZ1 1ZZ' could not be geocoded.","message":null}` {
+		t.Errorf("body = %s", got)
+	}
+}
+
+func TestHandler_Geocode_ServerErrorOnTransportFailure(t *testing.T) {
+	t.Parallel()
+
+	// A geocoder transport failure is a bodyless 500 (the PascalCase envelope is
+	// backfilled downstream by middleware.ErrorBody), matching .NET's propagated
+	// HttpRequestException.
+	fake := &fakeGeocoder{err: errors.New("upstream down")}
+	rec := newGeocodeRequest(t, fake, "SW1A 1AA")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("500 body = %q, want empty (backfilled downstream)", rec.Body.String())
+	}
+}
+
+func TestClient_SatisfiesGeocoderInterface(t *testing.T) {
+	t.Parallel()
+
+	var _ geocoder = NewClient("https://api.postcodes.io", http.DefaultClient)
+}

--- a/api-go/internal/geocoding/handler_test.go
+++ b/api-go/internal/geocoding/handler_test.go
@@ -3,7 +3,6 @@ package geocoding
 import (
 	"context"
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -27,11 +26,11 @@ func (f *fakeGeocoder) Geocode(_ context.Context, postcode string) (Coordinates,
 func newGeocodeRequest(t *testing.T, g geocoder, rawPostcode string) *httptest.ResponseRecorder {
 	t.Helper()
 	mux := http.NewServeMux()
-	Routes(mux, g, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	Routes(mux, g, slog.New(slog.DiscardHandler))
 	rec := httptest.NewRecorder()
 	// The path segment is pre-escaped so the mux decodes it back to rawPostcode,
 	// matching how a real request arrives.
-	req := httptest.NewRequest(http.MethodGet, "/v1/geocode/"+escapeSegment(rawPostcode), nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/geocode/"+escapeSegment(rawPostcode), nil)
 	mux.ServeHTTP(rec, req)
 	return rec
 }

--- a/api-go/internal/geocoding/handler_test.go
+++ b/api-go/internal/geocoding/handler_test.go
@@ -87,7 +87,7 @@ func TestHandler_Geocode_BadRequestOnInvalidPostcode(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", rec.Code)
 	}
-	if got := rec.Body.String(); got != `{"error":"'NOTAPOSTCODE' is not a valid UK postcode.","message":null}` {
+	if got := rec.Body.String(); got != `{"error":"'NOTAPOSTCODE' is not a valid UK postcode. (Parameter 'raw')","message":null}` {
 		t.Errorf("body = %s", got)
 	}
 	if fake.gotPostcode != "" {

--- a/api-go/internal/geocoding/postcode.go
+++ b/api-go/internal/geocoding/postcode.go
@@ -1,0 +1,25 @@
+// Package geocoding owns the postcode-geocoding feature: UK postcode validation,
+// the postcodes.io outbound client, and GET /v1/geocode/{postcode}. It mirrors
+// the .NET TownCrier.{Domain,Application,Infrastructure}.Geocoding slices
+// (GH#418 iteration 7).
+package geocoding
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ukPostcodeRegex matches a normalised (trimmed, upper-cased) UK postcode. It is
+// the exact pattern the .NET Postcode value object uses.
+var ukPostcodeRegex = regexp.MustCompile(`^[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}$`)
+
+// normalisePostcode trims and upper-cases a raw postcode and validates its
+// format, mirroring .NET Postcode.Create. The boolean reports validity; an
+// invalid (blank or malformed) postcode yields a 400 at the HTTP boundary.
+func normalisePostcode(raw string) (string, bool) {
+	normalised := strings.ToUpper(strings.TrimSpace(raw))
+	if normalised == "" || !ukPostcodeRegex.MatchString(normalised) {
+		return "", false
+	}
+	return normalised, true
+}

--- a/api-go/internal/geocoding/postcode_test.go
+++ b/api-go/internal/geocoding/postcode_test.go
@@ -1,0 +1,33 @@
+package geocoding
+
+import "testing"
+
+func TestNormalisePostcode(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		raw    string
+		want   string
+		wantOK bool
+	}{
+		{"valid with space", "sw1a 1aa", "SW1A 1AA", true},
+		{"valid no space", "ec2v5ae", "EC2V5AE", true},
+		{"valid lowercase trimmed", "  n1 9gu  ", "N1 9GU", true},
+		{"blank", "   ", "", false},
+		{"empty", "", "", false},
+		{"malformed letters", "NOTAPOSTCODE", "", false},
+		{"malformed digits", "12345", "", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := normalisePostcode(tc.raw)
+			if ok != tc.wantOK {
+				t.Fatalf("ok: got %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Errorf("normalised: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -11,6 +11,16 @@ import (
 // (Program.cs: ?? ["http://localhost:5173"]).
 const defaultCorsOrigin = "http://localhost:5173"
 
+// defaultPostcodesIoBaseURL and defaultGovUkBaseURL are the live UK services the
+// geocode and designation clients call, matching the .NET fallbacks for
+// PostcodesIo:BaseUrl and GovUkPlanningData:BaseUrl. The defaults are the real
+// endpoints, so the Go app geocodes against the same upstreams as .NET without
+// any infra wiring.
+const (
+	defaultPostcodesIoBaseURL = "https://api.postcodes.io/"
+	defaultGovUkBaseURL       = "https://www.planning.data.gov.uk/"
+)
+
 // Config holds process configuration loaded from environment variables.
 // Container Apps provides env vars; load them, validate them, fail fast at
 // startup.
@@ -50,6 +60,13 @@ type Config struct {
 	// auto-grant the Pro tier on a verified-email registration. Mirrors .NET's
 	// Subscription:AutoGrant:ProDomains. Empty disables auto-grant.
 	ProDomains string
+
+	// PostcodesIoBaseURL and GovUkBaseURL address the outbound geocode and
+	// designation upstreams. They default to the live UK services (matching
+	// .NET's PostcodesIo:BaseUrl / GovUkPlanningData:BaseUrl), so the clients work
+	// without any env wiring; an override points them at a stub.
+	PostcodesIoBaseURL string
+	GovUkBaseURL       string
 }
 
 // Auth0M2MConfigured reports whether the Auth0 Management (M2M) client can be
@@ -80,6 +97,9 @@ func LoadConfig() (Config, error) {
 		Auth0M2MClientSecret: NewSecret(os.Getenv("AUTH0_M2M_CLIENT_SECRET")),
 
 		ProDomains: os.Getenv("SUBSCRIPTION_AUTOGRANT_PRODOMAINS"),
+
+		PostcodesIoBaseURL: getenv("POSTCODES_IO_BASE_URL", defaultPostcodesIoBaseURL),
+		GovUkBaseURL:       getenv("GOVUK_PLANNING_DATA_BASE_URL", defaultGovUkBaseURL),
 	}
 
 	if raw := os.Getenv("LOG_LEVEL"); raw != "" {

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -159,6 +159,40 @@ func TestLoadConfig_ProDomains(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_OutboundBaseURLs(t *testing.T) {
+	t.Run("defaults to live UK services", func(t *testing.T) {
+		t.Setenv("POSTCODES_IO_BASE_URL", "")
+		t.Setenv("GOVUK_PLANNING_DATA_BASE_URL", "")
+
+		cfg, err := LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.PostcodesIoBaseURL != "https://api.postcodes.io/" {
+			t.Errorf("PostcodesIoBaseURL: got %q", cfg.PostcodesIoBaseURL)
+		}
+		if cfg.GovUkBaseURL != "https://www.planning.data.gov.uk/" {
+			t.Errorf("GovUkBaseURL: got %q", cfg.GovUkBaseURL)
+		}
+	})
+
+	t.Run("overrides honoured", func(t *testing.T) {
+		t.Setenv("POSTCODES_IO_BASE_URL", "http://localhost:9001/")
+		t.Setenv("GOVUK_PLANNING_DATA_BASE_URL", "http://localhost:9002/")
+
+		cfg, err := LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.PostcodesIoBaseURL != "http://localhost:9001/" {
+			t.Errorf("PostcodesIoBaseURL: got %q", cfg.PostcodesIoBaseURL)
+		}
+		if cfg.GovUkBaseURL != "http://localhost:9002/" {
+			t.Errorf("GovUkBaseURL: got %q", cfg.GovUkBaseURL)
+		}
+	})
+}
+
 func TestLoadConfig_CorsAllowedOrigins(t *testing.T) {
 	tests := []struct {
 		name string

--- a/api-go/tests/e2e/contract_geo_test.go
+++ b/api-go/tests/e2e/contract_geo_test.go
@@ -1,0 +1,53 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net/http"
+	"testing"
+)
+
+// Valid-token contract scenarios for the iteration-7 geocode and designation
+// surface. Both endpoints are authed and call live UK upstreams (postcodes.io
+// and planning.data.gov.uk). The .NET and Go APIs hit the same upstreams, so the
+// responses are deterministic and body-equal; the .NET response is the source of
+// truth. Scenarios reuse the authed watch-zone diff helper and skip when the
+// integration-token env is absent, so a plain local run stays green.
+
+func TestContract_Geocode(t *testing.T) {
+	dotnetURL := baseURL(t, "DOTNET_BASE_URL")
+	goURL := baseURL(t, "GO_BASE_URL")
+	token := integrationToken(t)
+	client := &http.Client{Timeout: requestTimeout}
+
+	// A real postcode resolves to deterministic coordinates from postcodes.io.
+	t.Run("valid postcode", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodGet, "/v1/geocode/SW1A%201AA", token, "")
+	})
+
+	// A malformed postcode is rejected at the boundary with the ApiErrorResponse
+	// envelope (400), before any upstream call.
+	t.Run("invalid postcode", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodGet, "/v1/geocode/NOTAPOSTCODE", token, "")
+	})
+
+	// A valid-format postcode that does not exist: postcodes.io 404s, so the
+	// endpoint returns 404 with the ApiErrorResponse envelope.
+	t.Run("valid format, nonexistent", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodGet, "/v1/geocode/ZZ1%201ZZ", token, "")
+	})
+}
+
+func TestContract_Designations(t *testing.T) {
+	dotnetURL := baseURL(t, "DOTNET_BASE_URL")
+	goURL := baseURL(t, "GO_BASE_URL")
+	token := integrationToken(t)
+	client := &http.Client{Timeout: requestTimeout}
+
+	// A North Sea point (lat 55, lng 2) intersects no designated entity, so
+	// planning.data.gov.uk 404s and both APIs return the empty designation
+	// context (all false / null).
+	t.Run("sea point yields none", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodGet, "/v1/designations?latitude=55&longitude=2", token, "")
+	})
+}

--- a/api-go/tests/e2e/contract_me_test.go
+++ b/api-go/tests/e2e/contract_me_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"sync"
 	"testing"
 )
@@ -221,10 +222,18 @@ func TestContract_GDPRExportProfileFields(t *testing.T) {
 		t.Fatalf("decode go export: %v", err)
 	}
 
-	for _, key := range []string{"userId", "email", "notificationPreferences", "subscription"} {
+	for _, key := range []string{"userId", "email", "subscription"} {
 		if !jsonEqual(t, gotDoc[key], wantDoc[key]) {
 			t.Errorf("%s: go=%s dotnet=%s", key, gotDoc[key], wantDoc[key])
 		}
+	}
+	// notificationPreferences carries the zonePreferences array, whose order is
+	// not a contract guarantee — neither API issues an ORDER BY, so the shared
+	// Cosmos returns the zones in an order that varies between requests. Sort by
+	// zoneId before diffing so the comparison is about content, not order
+	// (tc-zgnt).
+	if !jsonEqual(t, sortZonePreferences(t, gotDoc["notificationPreferences"]), sortZonePreferences(t, wantDoc["notificationPreferences"])) {
+		t.Errorf("notificationPreferences: go=%s dotnet=%s", gotDoc["notificationPreferences"], wantDoc["notificationPreferences"])
 	}
 	for _, key := range []string{"watchZones", "notifications", "savedApplications", "deviceRegistrations", "offerCodeRedemptions"} {
 		if raw, ok := gotDoc[key]; !ok || len(raw) == 0 || raw[0] != '[' {
@@ -234,6 +243,42 @@ func TestContract_GDPRExportProfileFields(t *testing.T) {
 			t.Errorf("dotnet export %q: missing or not an array (%s)", key, raw)
 		}
 	}
+}
+
+// sortZonePreferences returns the notificationPreferences object with its
+// zonePreferences array sorted by zoneId, so an order-undefined array can be
+// diffed for content. A payload without a zonePreferences array is returned
+// unchanged.
+func sortZonePreferences(t *testing.T, raw json.RawMessage) []byte {
+	t.Helper()
+	if len(raw) == 0 {
+		return raw
+	}
+	var prefs map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &prefs); err != nil {
+		t.Fatalf("decode notificationPreferences: %v", err)
+	}
+	zonesRaw, ok := prefs["zonePreferences"]
+	if !ok {
+		return raw
+	}
+	var zones []map[string]json.RawMessage
+	if err := json.Unmarshal(zonesRaw, &zones); err != nil {
+		t.Fatalf("decode zonePreferences: %v", err)
+	}
+	sort.Slice(zones, func(i, j int) bool {
+		return string(zones[i]["zoneId"]) < string(zones[j]["zoneId"])
+	})
+	sorted, err := json.Marshal(zones)
+	if err != nil {
+		t.Fatalf("marshal zonePreferences: %v", err)
+	}
+	prefs["zonePreferences"] = sorted
+	out, err := json.Marshal(prefs)
+	if err != nil {
+		t.Fatalf("marshal notificationPreferences: %v", err)
+	}
+	return out
 }
 
 // authedResponse is one authenticated exchange, including the rate-limit


### PR DESCRIPTION
## Summary

Iteration 7 of the Go API migration (epic tc-7g3i / GH #418): ports the **geocode** and **designations** endpoints to `api-go/`.

- `GET /v1/geocode/{postcode}` — UK postcode → coordinates via postcodes.io
- `GET /v1/designations?latitude=&longitude=` — planning designations (conservation area / listed building / Article 4) via GOV.UK planning.data.gov.uk

Both endpoints are **authed** (not anonymous) and have **no Cosmos dependency**, so they are always wired — even on a Cosmos-less local boot. Each calls a live UK upstream; the config base URLs default to the real services, so the Go API geocodes against the same upstreams as .NET with no infra change.

Scope note: the **demo-account** endpoint originally bundled in it7 is deferred to **tc-o2o3** (which blocks the cutover bead tc-7g3i.11).

## Parity details (vs .NET)

- **Geocode**: malformed postcode → 400 `ApiErrorResponse`; valid-format-but-unresolvable → 404; transport failure → bodyless 500 (PascalCase envelope backfilled by `middleware.ErrorBody`). Matches the .NET `ArgumentException`/`InvalidOperationException`/`HttpRequestException` outcomes.
- **Designations**: missing/unparseable coords → bodyless 400; a provider failure degrades to the empty context (mirroring .NET's `catch(HttpRequestException)` → `None`); the WKT point is `Uri.EscapeDataString`-escaped byte-for-byte (`%20`, not `+`).

## Tests

- TDD red/green per slice; hand-written fakes + `httptest` stubs.
- New e2e contract diffs (`tests/e2e/contract_geo_test.go`, `//go:build e2e`): valid postcode, invalid → 400, valid-format-nonexistent → 404, and a North-Sea designations point → none. These run in the **Go API: Contract tests vs .NET** job, diffing live .NET dev vs the staged Go revision over shared upstreams.

## Gate

`gofmt`, `go vet` (+`-tags e2e`), `golangci-lint` (+e2e), `go test -race ./...` (367 pass), `go build ./...` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `/v1/geocode` endpoint to resolve UK postcodes to latitude and longitude coordinates.
  * Added `/v1/designations` endpoint to retrieve planning designations (conservation areas, listed buildings, article 4 areas) for geographic coordinates.

* **Tests**
  * Added comprehensive unit, integration, and end-to-end contract tests for both geocoding and designations endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->