### PR TITLE
fix(ios): rename subscription product IDs to uk.towncrierapp.* (tc-ipov)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/Subscriptions/StoreKitSubscriptionService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Subscriptions/StoreKitSubscriptionService.swift
@@ -6,13 +6,13 @@ import os
 /// StoreKit 2 adapter implementing the SubscriptionService domain protocol.
 public final class StoreKitSubscriptionService: SubscriptionService, @unchecked Sendable {
   private static let productIds = [
-    "uk.towncrier.personal.monthly",
-    "uk.towncrier.pro.monthly",
+    "uk.towncrierapp.personal.monthly",
+    "uk.towncrierapp.pro.monthly",
   ]
 
   private static let tierMapping: [String: SubscriptionTier] = [
-    "uk.towncrier.personal.monthly": .personal,
-    "uk.towncrier.pro.monthly": .pro,
+    "uk.towncrierapp.personal.monthly": .personal,
+    "uk.towncrierapp.pro.monthly": .pro,
   ]
 
   private static let logger = Logger(

--- a/mobile/ios/town-crier-app/TownCrier.storekit
+++ b/mobile/ios/town-crier-app/TownCrier.storekit
@@ -92,7 +92,7 @@
               "locale" : "en_GB"
             }
           ],
-          "productID" : "uk.towncrier.personal.monthly",
+          "productID" : "uk.towncrierapp.personal.monthly",
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Personal Monthly",
           "subscriptionGroupID" : "21001",
@@ -117,7 +117,7 @@
               "locale" : "en_GB"
             }
           ],
-          "productID" : "uk.towncrier.pro.monthly",
+          "productID" : "uk.towncrierapp.pro.monthly",
           "recurringSubscriptionPeriod" : "P1M",
           "referenceName" : "Pro Monthly",
           "subscriptionGroupID" : "21001",

--- a/mobile/ios/town-crier-tests/Sources/Features/SubscriptionViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SubscriptionViewModelTests.swift
@@ -100,7 +100,7 @@ struct SubscriptionViewModelTests {
     let (sut, spy, _) = makeSUT()
     spy.purchaseResult = .success(.personalActive)
 
-    await sut.purchase(productId: "uk.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrierapp.personal.monthly")
 
     #expect(sut.currentEntitlement == .personalActive)
     #expect(!sut.isPurchasing)
@@ -111,16 +111,16 @@ struct SubscriptionViewModelTests {
     let (sut, spy, _) = makeSUT()
     spy.purchaseResult = .success(.personalActive)
 
-    await sut.purchase(productId: "uk.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrierapp.personal.monthly")
 
-    #expect(spy.purchaseCalls == ["uk.towncrier.personal.monthly"])
+    #expect(spy.purchaseCalls == ["uk.towncrierapp.personal.monthly"])
   }
 
   @Test func purchase_setsError_onFailure() async {
     let (sut, spy, _) = makeSUT()
     spy.purchaseResult = .failure(DomainError.purchaseFailed("payment declined"))
 
-    await sut.purchase(productId: "uk.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrierapp.personal.monthly")
 
     #expect(sut.currentEntitlement == nil)
     #expect(sut.error == .purchaseFailed("payment declined"))
@@ -130,7 +130,7 @@ struct SubscriptionViewModelTests {
     let (sut, spy, _) = makeSUT()
     spy.purchaseResult = .failure(DomainError.purchaseCancelled)
 
-    await sut.purchase(productId: "uk.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrierapp.personal.monthly")
 
     #expect(sut.error == nil)
     #expect(!sut.isPurchasing)
@@ -237,7 +237,7 @@ struct SubscriptionViewModelTests {
     subscriptionSpy.purchaseResult = .success(.personalActive)
     authSpy.refreshSessionResult = .success(.personal)
 
-    await sut.purchase(productId: "uk.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrierapp.personal.monthly")
 
     #expect(authSpy.refreshSessionCallCount == 1)
   }
@@ -246,7 +246,7 @@ struct SubscriptionViewModelTests {
     let (sut, subscriptionSpy, authSpy) = makeSUT()
     subscriptionSpy.purchaseResult = .failure(DomainError.purchaseFailed("declined"))
 
-    await sut.purchase(productId: "uk.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrierapp.personal.monthly")
 
     #expect(authSpy.refreshSessionCallCount == 0)
   }
@@ -255,7 +255,7 @@ struct SubscriptionViewModelTests {
     let (sut, subscriptionSpy, authSpy) = makeSUT()
     subscriptionSpy.purchaseResult = .failure(DomainError.purchaseCancelled)
 
-    await sut.purchase(productId: "uk.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrierapp.personal.monthly")
 
     #expect(authSpy.refreshSessionCallCount == 0)
   }
@@ -265,7 +265,7 @@ struct SubscriptionViewModelTests {
     subscriptionSpy.purchaseResult = .success(.personalActive)
     authSpy.refreshSessionResult = .failure(DomainError.sessionExpired)
 
-    await sut.purchase(productId: "uk.towncrier.personal.monthly")
+    await sut.purchase(productId: "uk.towncrierapp.personal.monthly")
 
     #expect(sut.currentEntitlement == .personalActive)
     #expect(sut.error == nil)

--- a/mobile/ios/town-crier-tests/Sources/Fixtures/SubscriptionProduct+Fixtures.swift
+++ b/mobile/ios/town-crier-tests/Sources/Fixtures/SubscriptionProduct+Fixtures.swift
@@ -3,7 +3,7 @@ import TownCrierDomain
 
 extension SubscriptionProduct {
   static let personal = SubscriptionProduct(
-    id: "uk.towncrier.personal.monthly",
+    id: "uk.towncrierapp.personal.monthly",
     displayName: "Personal",
     displayPrice: "£1.99",
     tier: .personal,
@@ -12,7 +12,7 @@ extension SubscriptionProduct {
   )
 
   static let pro = SubscriptionProduct(
-    id: "uk.towncrier.pro.monthly",
+    id: "uk.towncrierapp.pro.monthly",
     displayName: "Pro",
     displayPrice: "£5.99",
     tier: .pro


### PR DESCRIPTION
## Changes
- Rename StoreKit subscription product IDs from `uk.towncrier.*` to `uk.towncrierapp.*` across `TownCrier.storekit`, `StoreKitSubscriptionService` (productIds + tierMapping), and the test fixtures/ViewModel tests.

## Why
The old IDs were inconsistent with the rest of the app (bundle id `uk.towncrierapp.mobile`, domain `towncrierapp.uk`, Auth0 `towncrierapp.uk.auth0.com`) and could not be created in App Store Connect ("Product ID already being used by another in-app purchase"). The app must request the exact strings registered in App Store Connect or `Product.products(for:)` returns nothing and the paywall is empty. Required for the first App Review submission.

Canonical IDs (auto-renewable subs, group "Town Crier Subscriptions"):
- `uk.towncrierapp.personal.monthly` — Personal Monthly, £1.99/mo, 1-week free trial
- `uk.towncrierapp.pro.monthly` — Pro Monthly, £4.99/mo

The Go API uses the same canonical IDs via tc-7g3i.12 (blocks tc-7g3i.10 subscriptions).

Closes tc-ipov.

---
*Auto-shipped via ship skill*