### PR TITLE
fix(ios): correct Pro fixture displayPrice to £4.99 (tc-wc5m)

### DIFF
--- a/mobile/ios/town-crier-tests/Sources/Fixtures/SubscriptionProduct+Fixtures.swift
+++ b/mobile/ios/town-crier-tests/Sources/Fixtures/SubscriptionProduct+Fixtures.swift
@@ -14,7 +14,7 @@ extension SubscriptionProduct {
   static let pro = SubscriptionProduct(
     id: "uk.towncrierapp.pro.monthly",
     displayName: "Pro",
-    displayPrice: "£5.99",
+    displayPrice: "£4.99",
     tier: .pro
   )
 }


### PR DESCRIPTION
## Changes
- Fix the Pro subscription test fixture `displayPrice` from `£5.99` to `£4.99`, matching `TownCrier.storekit` and the App Store Connect Pro Monthly price.

Test-only display string; no behaviour change. Discovered during tc-ipov.

Closes tc-wc5m.

---
*Auto-shipped via ship skill*