### PR TITLE
feat(go): it8 offer codes + admin endpoints (tc-7g3i.9)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/geocoding"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
@@ -96,6 +97,23 @@ func main() {
 		savedStore = savedapplications.NewCosmosStore(savedContainer)
 	}
 
+	offerCodesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosOfferCodesContainer, logger)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var offerStore *offercodes.CosmosStore
+	if offerCodesContainer != nil {
+		offerStore = offercodes.NewCosmosStore(offerCodesContainer)
+	}
+
+	// The admin grant/list operations query the Users container cross-partition
+	// (by email, and the full list), so the admin store reuses the same container
+	// as the profile store.
+	var adminStore *profiles.AdminStore
+	if cosmos != nil {
+		adminStore = profiles.NewAdminStore(cosmos)
+	}
+
 	// Real M2M client only when fully configured; otherwise the no-op fallback,
 	// matching .NET's conditional IAuth0ManagementClient registration.
 	var manager profiles.Auth0Manager = profiles.NoOpAuth0Client{}
@@ -113,7 +131,7 @@ func main() {
 	geocodeClient := geocoding.NewClient(cfg.PostcodesIoBaseURL, &http.Client{Timeout: 30 * time.Second})
 	designationClient := designations.NewClient(cfg.GovUkBaseURL, &http.Client{Timeout: 30 * time.Second})
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, deviceStore, stateStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, logger))
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, deviceStore, stateStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/AmyDe/town-crier/api-go/internal/admin"
 	"github.com/AmyDe/town-crier/api-go/internal/api"
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
@@ -16,6 +17,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/legal"
 	"github.com/AmyDe/town-crier/api-go/internal/middleware"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/versionconfig"
@@ -34,6 +36,12 @@ var anonymousPatterns = map[string]struct{}{
 	"GET /v1/authorities":          {},
 	"GET /v1/authorities/{$}":      {},
 	"GET /v1/authorities/{id}":     {},
+	// Admin routes are anonymous to Auth0 (no bearer token); they are
+	// authenticated solely by the X-Admin-Key gate inside the handlers, matching
+	// .NET's AllowAnonymous + AdminApiKeyFilter.
+	"PUT /v1/admin/subscriptions": {},
+	"GET /v1/admin/users":         {},
+	"POST /v1/admin/offer-codes":  {},
 }
 
 // dispatchMux satisfies auth.RequireAuth's routeMatcher: pattern matching comes
@@ -72,7 +80,7 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // nil-means-unwired convention. (The watch-zone preferences endpoints are
 // served by profiles.Routes off the profile store, so they come up with the
 // /v1/me routes, not the watch-zone store.)
-func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, logger *slog.Logger) http.Handler {
+func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)
@@ -111,6 +119,17 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 		// The save path dual-writes: the master application record (appStore) then
 		// the saved row, so both stores are required to wire the endpoints.
 		savedapplications.Routes(mux, savedStore, appStore, time.Now, logger)
+	}
+	if store != nil && offerStore != nil {
+		// Offer-code redeem is authed: it loads the caller's profile, grants the
+		// coded tier, and syncs Auth0. Needs both the profile and offer-code stores.
+		offercodes.Routes(mux, offerStore, store, auth0, time.Now, logger)
+	}
+	if adminStore != nil && offerStore != nil {
+		// Admin endpoints are anonymous to Auth0 and gated by the X-Admin-Key. The
+		// cross-partition admin store backs grant/list; the offer-code store backs
+		// generate.
+		admin.Routes(mux, adminKey, adminStore, auth0, offerStore, offercodes.NewRandomGenerator(), time.Now, logger)
 	}
 
 	authed := auth.RequireAuth(validator, &dispatchMux{ServeMux: mux, dispatch: dispatch}, anonymousPatterns)

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/designations"
 	"github.com/AmyDe/town-crier/api-go/internal/geocoding"
+	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
@@ -82,6 +83,16 @@ func (f *fakeItems) QueryItems(_ context.Context, _, _ string, _ map[string]any)
 	return nil, nil
 }
 
+// QueryItemsCrossPartition / QueryPageCrossPartition let fakeItems back a
+// profiles.AdminStore; the wiring tests only need the empty result path.
+func (f *fakeItems) QueryItemsCrossPartition(_ context.Context, _ string, _ map[string]any) ([][]byte, error) {
+	return nil, nil
+}
+
+func (f *fakeItems) QueryPageCrossPartition(_ context.Context, _ string, _ map[string]any, _ int, _ string) ([][]byte, string, error) {
+	return nil, "", nil
+}
+
 // notFoundErr mimics the azcore 404 the store's isNotFound detects.
 func notFoundErr() error {
 	return &azcore.ResponseError{StatusCode: http.StatusNotFound}
@@ -110,7 +121,7 @@ func testDesignationClient() *designations.Client {
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, nil, "", slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -163,6 +174,8 @@ func TestRouter_FallbackDeny(t *testing.T) {
 		// Geocode and designations are authed, not anonymous: no token -> 401.
 		{"geocode without token", http.MethodGet, "/v1/geocode/SW1A1AA"},
 		{"designations without token", http.MethodGet, "/v1/designations?latitude=55&longitude=2"},
+		// Offer-code redeem is authed: no token -> 401.
+		{"redeem without token", http.MethodPost, "/v1/offer-codes/redeem"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
@@ -213,7 +226,7 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	appStore := applications.NewCosmosStore(newFakeItems())
 	savedStore := savedapplications.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(), testDesignationClient(), logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(), testDesignationClient(), nil, nil, "", logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -296,7 +309,7 @@ func TestRouter_GeocodeAndDesignationsDispatch(t *testing.T) {
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
 	geocodeClient := geocoding.NewClient(upstream.URL, upstream.Client())
 	designationClient := designations.NewClient(upstream.URL, upstream.Client())
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, geocodeClient, designationClient, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", logger)
 
 	rec := serveReq(t, h, http.MethodGet, "/v1/geocode/SW1A%201AA", "", "Bearer tok")
 	if rec.Code != http.StatusOK {
@@ -313,6 +326,52 @@ func TestRouter_GeocodeAndDesignationsDispatch(t *testing.T) {
 	if got := rec.Body.String(); got != `{"isWithinConservationArea":false,"conservationAreaName":null,"isWithinListedBuildingCurtilage":false,"listedBuildingGrade":null,"isWithinArticle4Area":false}` {
 		t.Errorf("designations body = %s", got)
 	}
+}
+
+// TestRouter_AdminGate confirms the admin routes are wired, anonymous to Auth0,
+// and gated solely by the X-Admin-Key. A deny-all validator is used: if the
+// routes were behind the Auth0 fallback they would 401 with WWW-Authenticate:
+// Bearer; the admin gate's 401 carries no such header, and a correct key reaches
+// the handler.
+func TestRouter_AdminGate(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	offerStore := offercodes.NewCosmosStore(newFakeItems())
+	adminStore := profiles.NewAdminStore(newFakeItems())
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), offerStore, adminStore, "s3cret", logger)
+
+	// No key: the admin gate rejects with a bodyless 401 and NO WWW-Authenticate
+	// (distinguishing it from the Auth0 fallback-deny).
+	noKey := adminRequest(t, h, "")
+	if noKey.Code != http.StatusUnauthorized {
+		t.Fatalf("no key: status = %d, want 401", noKey.Code)
+	}
+	if got := noKey.Header().Get("WWW-Authenticate"); got != "" {
+		t.Errorf("no key: WWW-Authenticate = %q, want empty (admin gate, not Auth0)", got)
+	}
+
+	// Correct key: the request reaches the list handler and returns the empty page.
+	withKey := adminRequest(t, h, "s3cret")
+	if withKey.Code != http.StatusOK {
+		t.Fatalf("with key: status = %d body = %s", withKey.Code, withKey.Body.String())
+	}
+	if got := withKey.Body.String(); got != `{"items":[],"continuationToken":null}` {
+		t.Errorf("with key: body = %s", got)
+	}
+}
+
+func adminRequest(t *testing.T, h http.Handler, key string) *httptest.ResponseRecorder {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/v1/admin/users", nil)
+	if key != "" {
+		req.Header.Set("X-Admin-Key", key)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
 }
 
 func serveReq(t *testing.T, h http.Handler, method, path, origin, authz string) *httptest.ResponseRecorder {

--- a/api-go/internal/admin/handler.go
+++ b/api-go/internal/admin/handler.go
@@ -1,0 +1,89 @@
+package admin
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+const maxBodyBytes = 1 << 20
+
+// profileAdminStore is the cross-partition profile store the admin handlers use:
+// find-by-email and save (grant) plus the paged list. profiles.AdminStore
+// satisfies it.
+type profileAdminStore interface {
+	GetByEmail(ctx context.Context, email string) (*profiles.UserProfile, error)
+	Save(ctx context.Context, p *profiles.UserProfile) error
+	List(ctx context.Context, emailSearch string, pageSize int, continuationToken string) (profiles.Page, error)
+}
+
+// tierSync mirrors the .NET IAuth0ManagementClient subset: push the tier into
+// Auth0's app_metadata. profiles.Auth0Manager satisfies it.
+type tierSync interface {
+	UpdateSubscriptionTier(ctx context.Context, userID, tier string) error
+}
+
+// offerCodeStore is the offer-code writer the generate endpoint uses.
+// offercodes.CosmosStore satisfies it.
+type offerCodeStore interface {
+	Save(ctx context.Context, c offercodes.OfferCode) error
+}
+
+// codeGenerator mints fresh canonical codes. offercodes.RandomGenerator
+// satisfies it.
+type codeGenerator interface {
+	Generate() (string, error)
+}
+
+type handler struct {
+	profiles  profileAdminStore
+	auth0     tierSync
+	codes     offerCodeStore
+	generator codeGenerator
+	now       func() time.Time
+	logger    *slog.Logger
+}
+
+// Routes registers the admin endpoints on mux, each gated by the shared admin
+// key. The routes are anonymous to Auth0 (the caller carries no bearer token),
+// so the key gate is their only authentication.
+func Routes(mux *http.ServeMux, adminKey string, profileStore profileAdminStore, auth0 tierSync, codes offerCodeStore, generator codeGenerator, now func() time.Time, logger *slog.Logger) {
+	h := &handler{profiles: profileStore, auth0: auth0, codes: codes, generator: generator, now: now, logger: logger}
+	mux.HandleFunc("PUT /v1/admin/subscriptions", requireAdminKey(adminKey, h.grantSubscription))
+	mux.HandleFunc("GET /v1/admin/users", requireAdminKey(adminKey, h.listUsers))
+	mux.HandleFunc("POST /v1/admin/offer-codes", requireAdminKey(adminKey, h.generateOfferCodes))
+}
+
+func (h *handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {
+	body, err := encodeJSON(v)
+	if err != nil {
+		h.serverError(w, r, "encode response", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		h.logger.ErrorContext(r.Context(), "write admin response", "error", err)
+	}
+}
+
+func encodeJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+func (h *handler) serverError(w http.ResponseWriter, r *http.Request, op string, err error) {
+	h.logger.ErrorContext(r.Context(), "admin request failed", "op", op, "error", err)
+	w.WriteHeader(http.StatusInternalServerError)
+}

--- a/api-go/internal/admin/handler_test.go
+++ b/api-go/internal/admin/handler_test.go
@@ -1,0 +1,297 @@
+package admin
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+type fakeAdminStore struct {
+	byEmail map[string]*profiles.UserProfile
+	saved   *profiles.UserProfile
+	page    profiles.Page
+
+	gotSearch   string
+	gotPageSize int
+	gotToken    string
+}
+
+func (f *fakeAdminStore) GetByEmail(_ context.Context, email string) (*profiles.UserProfile, error) {
+	p, ok := f.byEmail[email]
+	if !ok {
+		return nil, profiles.ErrNotFound
+	}
+	return p, nil
+}
+
+func (f *fakeAdminStore) Save(_ context.Context, p *profiles.UserProfile) error {
+	f.saved = p
+	return nil
+}
+
+func (f *fakeAdminStore) List(_ context.Context, emailSearch string, pageSize int, continuationToken string) (profiles.Page, error) {
+	f.gotSearch = emailSearch
+	f.gotPageSize = pageSize
+	f.gotToken = continuationToken
+	return f.page, nil
+}
+
+type fakeTierSync struct {
+	gotTier string
+	calls   int
+}
+
+func (f *fakeTierSync) UpdateSubscriptionTier(_ context.Context, _, tier string) error {
+	f.calls++
+	f.gotTier = tier
+	return nil
+}
+
+type fakeOfferStore struct {
+	saved []offercodes.OfferCode
+}
+
+func (f *fakeOfferStore) Save(_ context.Context, c offercodes.OfferCode) error {
+	f.saved = append(f.saved, c)
+	return nil
+}
+
+type fakeGenerator struct {
+	codes []string
+	i     int
+}
+
+func (f *fakeGenerator) Generate() (string, error) {
+	c := f.codes[f.i]
+	f.i++
+	return c, nil
+}
+
+func newTestHandler(store profileAdminStore, auth0 tierSync, codes offerCodeStore, gen codeGenerator, now time.Time) *handler {
+	return &handler{
+		profiles:  store,
+		auth0:     auth0,
+		codes:     codes,
+		generator: gen,
+		now:       func() time.Time { return now },
+		logger:    slog.New(slog.DiscardHandler),
+	}
+}
+
+func serve(t *testing.T, hf http.HandlerFunc, method, target, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	var rdr *strings.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	} else {
+		rdr = strings.NewReader("")
+	}
+	req := httptest.NewRequestWithContext(context.Background(), method, target, rdr)
+	rec := httptest.NewRecorder()
+	hf(rec, req)
+	return rec
+}
+
+func freeProfile(t *testing.T) *profiles.UserProfile {
+	t.Helper()
+	p, err := profiles.NewProfile("auth0|u1", "u@example.com", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	return p
+}
+
+func TestGrant_ActivatesPaidTier(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeAdminStore{byEmail: map[string]*profiles.UserProfile{"u@example.com": freeProfile(t)}}
+	auth0 := &fakeTierSync{}
+	h := newTestHandler(store, auth0, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+
+	rec := serve(t, h.grantSubscription, http.MethodPut, "/v1/admin/subscriptions", `{"email":"u@example.com","tier":"Pro"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != `{"userId":"auth0|u1","email":"u@example.com","tier":"Pro"}` {
+		t.Errorf("body = %s", got)
+	}
+	if store.saved == nil || store.saved.Tier != profiles.TierPro || store.saved.SubscriptionExpiry == nil {
+		t.Errorf("profile not activated: %+v", store.saved)
+	}
+	if !store.saved.SubscriptionExpiry.Equal(farFutureExpiry) {
+		t.Errorf("expiry = %v, want far future", store.saved.SubscriptionExpiry)
+	}
+	if auth0.calls != 1 || auth0.gotTier != "Pro" {
+		t.Errorf("auth0 sync = %+v", auth0)
+	}
+}
+
+func TestGrant_FreeExpiresSubscription(t *testing.T) {
+	t.Parallel()
+
+	paid := freeProfile(t)
+	paid.ActivateSubscription(profiles.TierPro, time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC))
+	store := &fakeAdminStore{byEmail: map[string]*profiles.UserProfile{"u@example.com": paid}}
+	h := newTestHandler(store, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+
+	rec := serve(t, h.grantSubscription, http.MethodPut, "/v1/admin/subscriptions", `{"email":"u@example.com","tier":"Free"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"userId":"auth0|u1","email":"u@example.com","tier":"Free"}` {
+		t.Errorf("body = %s", got)
+	}
+	if store.saved.Tier != profiles.TierFree || store.saved.SubscriptionExpiry != nil {
+		t.Errorf("subscription not expired: %+v", store.saved)
+	}
+}
+
+func TestGrant_EmailNotFound(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeAdminStore{byEmail: map[string]*profiles.UserProfile{}}
+	h := newTestHandler(store, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+
+	rec := serve(t, h.grantSubscription, http.MethodPut, "/v1/admin/subscriptions", `{"email":"missing@example.com","tier":"Pro"}`)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("404 body = %q, want empty (backfilled downstream)", rec.Body.String())
+	}
+}
+
+func TestGrant_InvalidTier(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeAdminStore{byEmail: map[string]*profiles.UserProfile{"u@example.com": freeProfile(t)}}
+	h := newTestHandler(store, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+
+	rec := serve(t, h.grantSubscription, http.MethodPut, "/v1/admin/subscriptions", `{"email":"u@example.com","tier":"Bronze"}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestListUsers_ReturnsPage(t *testing.T) {
+	t.Parallel()
+
+	p1 := freeProfile(t)
+	p2, _ := profiles.NewProfile("auth0|u2", "b@example.com", time.Now())
+	p2.Tier = profiles.TierPro
+	store := &fakeAdminStore{page: profiles.Page{Profiles: []*profiles.UserProfile{p1, p2}, ContinuationToken: "next"}}
+	h := newTestHandler(store, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+
+	rec := serve(t, h.listUsers, http.MethodGet, "/v1/admin/users?search=example&pageSize=50", "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	want := `{"items":[{"userId":"auth0|u1","email":"u@example.com","tier":"Free"},{"userId":"auth0|u2","email":"b@example.com","tier":"Pro"}],"continuationToken":"next"}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body =\n  %s\nwant\n  %s", got, want)
+	}
+	if store.gotSearch != "example" || store.gotPageSize != 50 {
+		t.Errorf("forwarded search=%q pageSize=%d", store.gotSearch, store.gotPageSize)
+	}
+}
+
+func TestListUsers_DefaultsAndNullToken(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeAdminStore{page: profiles.Page{Profiles: nil, ContinuationToken: ""}}
+	h := newTestHandler(store, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+
+	rec := serve(t, h.listUsers, http.MethodGet, "/v1/admin/users", "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"items":[],"continuationToken":null}` {
+		t.Errorf("body = %s", got)
+	}
+	if store.gotPageSize != 20 {
+		t.Errorf("default pageSize = %d, want 20", store.gotPageSize)
+	}
+}
+
+func TestListUsers_InvalidPageSize(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(&fakeAdminStore{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	rec := serve(t, h.listUsers, http.MethodGet, "/v1/admin/users?pageSize=abc", "")
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestGenerate_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	offerStore := &fakeOfferStore{}
+	gen := &fakeGenerator{codes: []string{"ABCDEFGHJKMN", "NPQRSTVWXYZ0"}}
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	h := newTestHandler(&fakeAdminStore{}, &fakeTierSync{}, offerStore, gen, now)
+
+	rec := serve(t, h.generateOfferCodes, http.MethodPost, "/v1/admin/offer-codes", `{"count":2,"tier":"Pro","durationDays":30}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Errorf("content-type = %q", ct)
+	}
+	if got := rec.Body.String(); got != "ABCD-EFGH-JKMN\nNPQR-STVW-XYZ0\n" {
+		t.Errorf("body = %q", got)
+	}
+	// The stored codes are canonical (un-hyphenated) for the granted tier.
+	if len(offerStore.saved) != 2 || offerStore.saved[0].Code != "ABCDEFGHJKMN" || offerStore.saved[0].Tier != profiles.TierPro {
+		t.Errorf("saved = %+v", offerStore.saved)
+	}
+}
+
+func TestGenerate_ValidationErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"count too low", `{"count":0,"tier":"Pro","durationDays":30}`, `{"error":"Count must be between 1 and 1000. (Parameter 'command')\nActual value was 0.","message":null}`},
+		{"count too high", `{"count":2000,"tier":"Pro","durationDays":30}`, `{"error":"Count must be between 1 and 1000. (Parameter 'command')\nActual value was 2000.","message":null}`},
+		{"free tier", `{"count":1,"tier":"Free","durationDays":30}`, `{"error":"Offer codes cannot grant the Free tier. (Parameter 'command')","message":null}`},
+		{"duration too high", `{"count":1,"tier":"Pro","durationDays":400}`, `{"error":"DurationDays must be between 1 and 365. (Parameter 'command')\nActual value was 400.","message":null}`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h := newTestHandler(&fakeAdminStore{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+			rec := serve(t, h.generateOfferCodes, http.MethodPost, "/v1/admin/offer-codes", tc.body)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", rec.Code)
+			}
+			if got := rec.Body.String(); got != tc.want {
+				t.Errorf("body = %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStores_SatisfyInterfaces(t *testing.T) {
+	t.Parallel()
+	var _ profileAdminStore = profiles.NewAdminStore(nil)
+	var _ offerCodeStore = offercodes.NewCosmosStore(nil)
+	var _ codeGenerator = offercodes.NewRandomGenerator()
+}

--- a/api-go/internal/admin/middleware.go
+++ b/api-go/internal/admin/middleware.go
@@ -1,0 +1,33 @@
+// Package admin owns the admin surface: the X-Admin-Key gate and the
+// PUT /v1/admin/subscriptions, GET /v1/admin/users, POST /v1/admin/offer-codes
+// handlers. It mirrors the .NET TownCrier.Web AdminEndpoints + AdminApiKeyFilter
+// (GH#418 iteration 8). The admin routes are anonymous to Auth0 (absent from the
+// fallback-deny set) and authenticated solely by the shared admin key.
+package admin
+
+import (
+	"crypto/subtle"
+	"net/http"
+)
+
+// adminKeyHeader is the header carrying the shared admin key, matching the .NET
+// AdminApiKeyFilter.
+const adminKeyHeader = "X-Admin-Key"
+
+// requireAdminKey wraps next with the shared-key gate: a request lacking a
+// matching X-Admin-Key gets a bodyless 401 (the PascalCase envelope is
+// backfilled by middleware.ErrorBody, as in .NET's Results.Unauthorized()). An
+// empty configured key rejects every request, so an unconfigured deployment
+// cannot be reached. The compare is constant-time to avoid leaking the key by
+// timing; the accept/reject result matches .NET's ordinal comparison.
+func requireAdminKey(expectedKey string, next http.HandlerFunc) http.HandlerFunc {
+	expected := []byte(expectedKey)
+	return func(w http.ResponseWriter, r *http.Request) {
+		provided := []byte(r.Header.Get(adminKeyHeader))
+		if len(expected) == 0 || subtle.ConstantTimeCompare(provided, expected) != 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		next(w, r)
+	}
+}

--- a/api-go/internal/admin/middleware_test.go
+++ b/api-go/internal/admin/middleware_test.go
@@ -1,0 +1,55 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRequireAdminKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		expected   string
+		provided   string
+		setHeader  bool
+		wantStatus int
+		wantNext   bool
+	}{
+		{"matching key passes", "s3cret", "s3cret", true, http.StatusOK, true},
+		{"wrong key rejected", "s3cret", "nope", true, http.StatusUnauthorized, false},
+		{"missing header rejected", "s3cret", "", false, http.StatusUnauthorized, false},
+		{"empty configured key rejects all", "", "anything", true, http.StatusUnauthorized, false},
+		{"key prefix rejected (length-sensitive)", "s3cret", "s3cre", true, http.StatusUnauthorized, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			nextCalled := false
+			h := requireAdminKey(tc.expected, func(w http.ResponseWriter, _ *http.Request) {
+				nextCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/admin/users", nil)
+			if tc.setHeader {
+				req.Header.Set("X-Admin-Key", tc.provided)
+			}
+			rec := httptest.NewRecorder()
+			h(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+			if nextCalled != tc.wantNext {
+				t.Errorf("next called = %v, want %v", nextCalled, tc.wantNext)
+			}
+			if !tc.wantNext && rec.Body.Len() != 0 {
+				t.Errorf("rejected body = %q, want empty (backfilled downstream)", rec.Body.String())
+			}
+		})
+	}
+}

--- a/api-go/internal/admin/offercodes.go
+++ b/api-go/internal/admin/offercodes.go
@@ -1,0 +1,113 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// maxOfferCodeCount bounds a single generate request, mirroring the .NET
+// GenerateOfferCodesCommandHandler.MaxCount.
+const maxOfferCodeCount = 1000
+
+type generateRequest struct {
+	Count        int    `json:"count"`
+	Tier         string `json:"tier"`
+	DurationDays int    `json:"durationDays"`
+}
+
+// apiErrorResponse mirrors the .NET ApiErrorResponse { error, message:null } the
+// generate endpoint returns for validation failures.
+type apiErrorResponse struct {
+	Error   string  `json:"error"`
+	Message *string `json:"message"`
+}
+
+// generateOfferCodes implements POST /v1/admin/offer-codes: mint N codes for a
+// paid tier and return them, one display-formatted code per line, as text/plain.
+// Validation failures mirror the .NET handler's ArgumentException /
+// ArgumentOutOfRangeException messages byte-for-byte (including the runtime's
+// " (Parameter 'command')" and "Actual value was N." suffixes).
+func (h *handler) generateOfferCodes(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	var req generateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	tier, err := profiles.ParseSubscriptionTier(req.Tier)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	// Validation order matches the .NET handler: count, then tier, then duration.
+	if req.Count < 1 || req.Count > maxOfferCodeCount {
+		h.writeBadRequest(r, w, argOutOfRange("Count must be between 1 and 1000.", req.Count))
+		return
+	}
+	if tier == profiles.TierFree {
+		h.writeBadRequest(r, w, argException("Offer codes cannot grant the Free tier."))
+		return
+	}
+	if req.DurationDays < 1 || req.DurationDays > 365 {
+		h.writeBadRequest(r, w, argOutOfRange("DurationDays must be between 1 and 365.", req.DurationDays))
+		return
+	}
+
+	now := h.now()
+	formatted := make([]string, 0, req.Count)
+	for range req.Count {
+		canonical, err := h.generator.Generate()
+		if err != nil {
+			h.serverError(w, r, "generate offer code", err)
+			return
+		}
+		code, err := offercodes.NewOfferCode(canonical, tier, req.DurationDays, now)
+		if err != nil {
+			h.serverError(w, r, "build offer code", err)
+			return
+		}
+		if err := h.codes.Save(r.Context(), code); err != nil {
+			h.serverError(w, r, "save offer code", err)
+			return
+		}
+		formatted = append(formatted, offercodes.Format(canonical))
+	}
+
+	body := strings.Join(formatted, "\n") + "\n"
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write([]byte(body)); err != nil {
+		h.logger.ErrorContext(r.Context(), "write offer codes", "error", err)
+	}
+}
+
+func (h *handler) writeBadRequest(r *http.Request, w http.ResponseWriter, message string) {
+	body, err := encodeJSON(apiErrorResponse{Error: message, Message: nil})
+	if err != nil {
+		h.serverError(w, r, "encode error", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusBadRequest)
+	if _, err := w.Write(body); err != nil {
+		h.logger.ErrorContext(r.Context(), "write admin error body", "error", err)
+	}
+}
+
+// argOutOfRange reproduces .NET ArgumentOutOfRangeException.Message for
+// nameof(command): "{message} (Parameter 'command')\nActual value was {value}.".
+func argOutOfRange(message string, value int) string {
+	return message + " (Parameter 'command')\nActual value was " + strconv.Itoa(value) + "."
+}
+
+// argException reproduces .NET ArgumentException.Message for nameof(command):
+// "{message} (Parameter 'command')".
+func argException(message string) string {
+	return message + " (Parameter 'command')"
+}

--- a/api-go/internal/admin/subscriptions.go
+++ b/api-go/internal/admin/subscriptions.go
@@ -1,0 +1,72 @@
+package admin
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// farFutureExpiry is the sentinel expiry an admin grant assigns to a paid tier,
+// mirroring the .NET GrantSubscriptionCommandHandler.FarFutureExpiry
+// (2099-12-31T00:00:00+00:00).
+var farFutureExpiry = time.Date(2099, 12, 31, 0, 0, 0, 0, time.UTC)
+
+type grantRequest struct {
+	Email string `json:"email"`
+	Tier  string `json:"tier"`
+}
+
+// grantResult mirrors the .NET GrantSubscriptionResult: { userId, email, tier }.
+type grantResult struct {
+	UserID string  `json:"userId"`
+	Email  *string `json:"email"`
+	Tier   string  `json:"tier"`
+}
+
+// grantSubscription implements PUT /v1/admin/subscriptions: set a user's tier by
+// email. Granting Free expires the subscription; any paid tier activates it to
+// the far-future expiry. A missing profile is a bodyless 404, matching .NET's
+// Results.NotFound() on UserProfileNotFoundException.
+func (h *handler) grantSubscription(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	var req grantRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	tier, err := profiles.ParseSubscriptionTier(req.Tier)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	profile, err := h.profiles.GetByEmail(r.Context(), req.Email)
+	if err != nil {
+		if errors.Is(err, profiles.ErrNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		h.serverError(w, r, "load profile by email", err)
+		return
+	}
+
+	if tier == profiles.TierFree {
+		profile.ExpireSubscription()
+	} else {
+		profile.ActivateSubscription(tier, farFutureExpiry)
+	}
+
+	if err := h.profiles.Save(r.Context(), profile); err != nil {
+		h.serverError(w, r, "save profile", err)
+		return
+	}
+	if err := h.auth0.UpdateSubscriptionTier(r.Context(), profile.UserID, profile.Tier.String()); err != nil {
+		h.serverError(w, r, "sync auth0 tier", err)
+		return
+	}
+
+	h.writeJSON(r, w, grantResult{UserID: profile.UserID, Email: profile.Email, Tier: profile.Tier.String()})
+}

--- a/api-go/internal/admin/users.go
+++ b/api-go/internal/admin/users.go
@@ -1,0 +1,58 @@
+package admin
+
+import (
+	"net/http"
+	"strconv"
+)
+
+// defaultPageSize mirrors the .NET admin endpoint default (pageSize ?? 20).
+const defaultPageSize = 20
+
+type listItem struct {
+	UserID string  `json:"userId"`
+	Email  *string `json:"email"`
+	Tier   string  `json:"tier"`
+}
+
+// listResult mirrors the .NET ListUsersResult: { items, continuationToken }.
+// continuationToken is null when the query is exhausted.
+type listResult struct {
+	Items             []listItem `json:"items"`
+	ContinuationToken *string    `json:"continuationToken"`
+}
+
+// listUsers implements GET /v1/admin/users?search&pageSize&continuationToken: a
+// cross-partition page of profiles, optionally filtered by case-insensitive
+// email substring. An unparseable pageSize is a bodyless 400 (the .NET int?
+// binding failure).
+func (h *handler) listUsers(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	search := q.Get("search")
+	pageSize := defaultPageSize
+	if raw := q.Get("pageSize"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		pageSize = n
+	}
+	continuationToken := q.Get("continuationToken")
+
+	page, err := h.profiles.List(r.Context(), search, pageSize, continuationToken)
+	if err != nil {
+		h.serverError(w, r, "list users", err)
+		return
+	}
+
+	items := make([]listItem, 0, len(page.Profiles))
+	for _, p := range page.Profiles {
+		items = append(items, listItem{UserID: p.UserID, Email: p.Email, Tier: p.Tier.String()})
+	}
+	var token *string
+	if page.ContinuationToken != "" {
+		t := page.ContinuationToken
+		token = &t
+	}
+	h.writeJSON(r, w, listResult{Items: items, ContinuationToken: token})
+}

--- a/api-go/internal/offercodes/code.go
+++ b/api-go/internal/offercodes/code.go
@@ -1,0 +1,58 @@
+package offercodes
+
+import (
+	"errors"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// ErrAlreadyRedeemed is returned by Redeem when the code has already been
+// claimed. The redeem handler detects the already-redeemed state before calling
+// Redeem and builds the wire 409 message itself; this guards the invariant.
+var ErrAlreadyRedeemed = errors.New("offer code has already been redeemed")
+
+// OfferCode is a single redeemable code granting a paid tier for a fixed
+// duration, mirroring the .NET OfferCode aggregate. Fields are exported so the
+// store can rehydrate a stored document directly; NewOfferCode enforces the
+// invariants for freshly minted codes.
+type OfferCode struct {
+	Code             string
+	Tier             profiles.SubscriptionTier
+	DurationDays     int
+	CreatedAt        time.Time
+	RedeemedByUserID *string
+	RedeemedAt       *time.Time
+}
+
+// NewOfferCode mints a code, validating the canonical format, a non-Free tier,
+// and a 1..365 day duration — the same invariants the .NET OfferCode
+// constructor enforces.
+func NewOfferCode(code string, tier profiles.SubscriptionTier, durationDays int, createdAt time.Time) (OfferCode, error) {
+	if !IsValidCanonical(code) {
+		return OfferCode{}, errors.New("code is not a valid canonical offer code")
+	}
+	if tier == profiles.TierFree {
+		return OfferCode{}, errors.New("offer codes cannot grant the free tier")
+	}
+	if durationDays < 1 || durationDays > 365 {
+		return OfferCode{}, errors.New("duration must be between 1 and 365 days")
+	}
+	return OfferCode{Code: code, Tier: tier, DurationDays: durationDays, CreatedAt: createdAt}, nil
+}
+
+// IsRedeemed reports whether the code has been claimed.
+func (c *OfferCode) IsRedeemed() bool { return c.RedeemedByUserID != nil }
+
+// Redeem claims the code for userID at now. A second redemption is rejected with
+// ErrAlreadyRedeemed.
+func (c *OfferCode) Redeem(userID string, now time.Time) error {
+	if c.IsRedeemed() {
+		return ErrAlreadyRedeemed
+	}
+	uid := userID
+	at := now
+	c.RedeemedByUserID = &uid
+	c.RedeemedAt = &at
+	return nil
+}

--- a/api-go/internal/offercodes/code_test.go
+++ b/api-go/internal/offercodes/code_test.go
@@ -1,0 +1,75 @@
+package offercodes
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+func TestNewOfferCode_Validates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name     string
+		code     string
+		tier     profiles.SubscriptionTier
+		duration int
+		wantErr  bool
+	}{
+		{"valid", "ABCDEFGHJKMN", profiles.TierPro, 30, false},
+		{"non-canonical code", "ABC", profiles.TierPro, 30, true},
+		{"free tier rejected", "ABCDEFGHJKMN", profiles.TierFree, 30, true},
+		{"duration too low", "ABCDEFGHJKMN", profiles.TierPro, 0, true},
+		{"duration too high", "ABCDEFGHJKMN", profiles.TierPro, 366, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := NewOfferCode(tc.code, tc.tier, tc.duration, now)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("NewOfferCode err = %v, wantErr = %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestOfferCode_Redeem(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	code, err := NewOfferCode("ABCDEFGHJKMN", profiles.TierPro, 30, now)
+	if err != nil {
+		t.Fatalf("NewOfferCode: %v", err)
+	}
+	if code.IsRedeemed() {
+		t.Fatal("new code should not be redeemed")
+	}
+
+	if err := code.Redeem("auth0|u1", now); err != nil {
+		t.Fatalf("Redeem: %v", err)
+	}
+	if !code.IsRedeemed() {
+		t.Error("code should be redeemed after Redeem")
+	}
+	if code.RedeemedByUserID == nil || *code.RedeemedByUserID != "auth0|u1" {
+		t.Errorf("RedeemedByUserID = %v, want auth0|u1", code.RedeemedByUserID)
+	}
+	if code.RedeemedAt == nil || !code.RedeemedAt.Equal(now) {
+		t.Errorf("RedeemedAt = %v, want %v", code.RedeemedAt, now)
+	}
+}
+
+func TestOfferCode_Redeem_RejectsSecondRedemption(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	code, _ := NewOfferCode("ABCDEFGHJKMN", profiles.TierPro, 30, now)
+	_ = code.Redeem("auth0|u1", now)
+
+	if err := code.Redeem("auth0|u2", now); !errors.Is(err, ErrAlreadyRedeemed) {
+		t.Errorf("second Redeem err = %v, want ErrAlreadyRedeemed", err)
+	}
+}

--- a/api-go/internal/offercodes/document.go
+++ b/api-go/internal/offercodes/document.go
@@ -1,0 +1,56 @@
+package offercodes
+
+import (
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// offerCodeDocument is the Cosmos persistence shape, mirroring the .NET
+// OfferCodeDocument field-for-field (camelCase, .NET DateTimeOffset format for
+// the timestamps). id == code == partition key.
+type offerCodeDocument struct {
+	ID               string               `json:"id"`
+	Code             string               `json:"code"`
+	Tier             string               `json:"tier"`
+	DurationDays     int                  `json:"durationDays"`
+	CreatedAt        platform.DotNetTime  `json:"createdAt"`
+	RedeemedByUserID *string              `json:"redeemedByUserId"`
+	RedeemedAt       *platform.DotNetTime `json:"redeemedAt"`
+}
+
+func newOfferCodeDocument(c OfferCode) offerCodeDocument {
+	doc := offerCodeDocument{
+		ID:               c.Code,
+		Code:             c.Code,
+		Tier:             c.Tier.String(),
+		DurationDays:     c.DurationDays,
+		CreatedAt:        platform.DotNetTime(c.CreatedAt),
+		RedeemedByUserID: c.RedeemedByUserID,
+	}
+	if c.RedeemedAt != nil {
+		at := platform.DotNetTime(*c.RedeemedAt)
+		doc.RedeemedAt = &at
+	}
+	return doc
+}
+
+func (d offerCodeDocument) toDomain() (OfferCode, error) {
+	tier, err := profiles.ParseSubscriptionTier(d.Tier)
+	if err != nil {
+		return OfferCode{}, err
+	}
+	c := OfferCode{
+		Code:             d.Code,
+		Tier:             tier,
+		DurationDays:     d.DurationDays,
+		CreatedAt:        time.Time(d.CreatedAt),
+		RedeemedByUserID: d.RedeemedByUserID,
+	}
+	if d.RedeemedAt != nil {
+		at := time.Time(*d.RedeemedAt)
+		c.RedeemedAt = &at
+	}
+	return c, nil
+}

--- a/api-go/internal/offercodes/format.go
+++ b/api-go/internal/offercodes/format.go
@@ -1,0 +1,96 @@
+// Package offercodes owns the offer-code feature: code format/validation, the
+// domain model, the random generator, the Cosmos store, and the authed
+// POST /v1/offer-codes/redeem handler. It mirrors the .NET
+// TownCrier.{Domain,Application,Infrastructure}.OfferCodes slices (GH#418
+// iteration 8).
+package offercodes
+
+import (
+	"strconv"
+	"strings"
+)
+
+// canonicalLength is the number of characters in a canonical offer code.
+const canonicalLength = 12
+
+// alphabet is the Crockford base32 alphabet the codes are drawn from (excludes
+// I, L, O, U to avoid ambiguity), matching the .NET OfferCodeFormat.Alphabet.
+const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
+
+// InvalidFormatError signals a malformed offer code — the .NET
+// InvalidOfferCodeFormatException. Its message is surfaced verbatim in the 400
+// response body, so the text matches .NET exactly.
+type InvalidFormatError struct {
+	Message string
+}
+
+func (e *InvalidFormatError) Error() string { return e.Message }
+
+// Normalize strips separators and whitespace, upper-cases, and validates that
+// the remaining characters form a canonical 12-character Crockford code,
+// mirroring .NET OfferCodeFormat.Normalize. On failure it returns an
+// *InvalidFormatError whose message matches the .NET exception text.
+func Normalize(input string) (string, error) {
+	if strings.TrimSpace(input) == "" {
+		return "", &InvalidFormatError{Message: "Offer code is required."}
+	}
+
+	var b strings.Builder
+	b.Grow(len(input))
+	for _, c := range input {
+		if c == '-' || isWhitespace(c) {
+			continue
+		}
+		upper := toUpperASCII(c)
+		if !strings.ContainsRune(alphabet, upper) {
+			return "", &InvalidFormatError{Message: "Offer code contains invalid character '" + string(c) + "'."}
+		}
+		b.WriteRune(upper)
+	}
+
+	normalised := b.String()
+	if len(normalised) != canonicalLength {
+		return "", &InvalidFormatError{Message: "Offer code must be " + strconv.Itoa(canonicalLength) + " characters (got " + strconv.Itoa(len(normalised)) + ")."}
+	}
+	return normalised, nil
+}
+
+// Format renders a canonical code as the display form XXXX-XXXX-XXXX, mirroring
+// .NET OfferCodeFormat.Format. The input must already be canonical.
+func Format(canonical string) string {
+	return canonical[:4] + "-" + canonical[4:8] + "-" + canonical[8:]
+}
+
+// IsValidCanonical reports whether value is a canonical 12-character code drawn
+// entirely from the alphabet.
+func IsValidCanonical(value string) bool {
+	if len(value) != canonicalLength {
+		return false
+	}
+	for _, c := range value {
+		if !strings.ContainsRune(alphabet, c) {
+			return false
+		}
+	}
+	return true
+}
+
+// isWhitespace mirrors .NET char.IsWhiteSpace for the ASCII set that can appear
+// in user-entered codes (space, tab, newlines).
+func isWhitespace(c rune) bool {
+	switch c {
+	case ' ', '\t', '\n', '\v', '\f', '\r':
+		return true
+	default:
+		return false
+	}
+}
+
+// toUpperASCII upper-cases an ASCII letter, matching char.ToUpperInvariant for
+// the offer-code character set (ASCII letters/digits). Non-letters pass through.
+func toUpperASCII(c rune) rune {
+	if c >= 'a' && c <= 'z' {
+		return c - ('a' - 'A')
+	}
+	return c
+}

--- a/api-go/internal/offercodes/format_test.go
+++ b/api-go/internal/offercodes/format_test.go
@@ -1,0 +1,83 @@
+package offercodes
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNormalize_StripsSeparatorsAndUpperCases(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"ABCD-EFGH-JKMN":  "ABCDEFGHJKMN",
+		"abcd efgh jkmn":  "ABCDEFGHJKMN",
+		"abcdefghjkmn":    "ABCDEFGHJKMN",
+		"  ABCDEFGHJKMN ": "ABCDEFGHJKMN",
+	}
+	for in, want := range tests {
+		got, err := Normalize(in)
+		if err != nil {
+			t.Errorf("Normalize(%q): %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("Normalize(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestNormalize_RejectsWithDotNetMessages(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"blank", "   ", "Offer code is required."},
+		{"empty", "", "Offer code is required."},
+		{"invalid char", "ABCD-EFGH-JKM!", "Offer code contains invalid character '!'."},
+		{"ambiguous letter I", "ABCDEFGHJKMI", "Offer code contains invalid character 'I'."},
+		{"too short", "ABCDEFGH", "Offer code must be 12 characters (got 8)."},
+		{"too long", "ABCDEFGHJKMNPQ", "Offer code must be 12 characters (got 14)."},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := Normalize(tc.in)
+			var fe *InvalidFormatError
+			if !errors.As(err, &fe) {
+				t.Fatalf("Normalize(%q) error = %v, want *InvalidFormatError", tc.in, err)
+			}
+			if fe.Message != tc.want {
+				t.Errorf("message = %q, want %q", fe.Message, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormat_RendersDisplayForm(t *testing.T) {
+	t.Parallel()
+
+	if got := Format("ABCDEFGHJKMN"); got != "ABCD-EFGH-JKMN" {
+		t.Errorf("Format = %q, want ABCD-EFGH-JKMN", got)
+	}
+}
+
+func TestIsValidCanonical(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]bool{
+		"ABCDEFGHJKMN":   true,
+		"000000000000":   true,
+		"ABCDEFGHJKM":    false, // 11 chars
+		"ABCDEFGHJKMNP":  false, // 13 chars
+		"ABCD-EFGH-JKMN": false, // separators not canonical
+		"ABCDEFGHJKMI":   false, // I is not in the alphabet
+	}
+	for in, want := range tests {
+		if got := IsValidCanonical(in); got != want {
+			t.Errorf("IsValidCanonical(%q) = %v, want %v", in, got, want)
+		}
+	}
+}

--- a/api-go/internal/offercodes/generator.go
+++ b/api-go/internal/offercodes/generator.go
@@ -1,0 +1,32 @@
+package offercodes
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+)
+
+// RandomGenerator mints canonical offer codes from cryptographically secure
+// randomness: 60 bits (12 × 5) drawn from 8 random bytes, each 5-bit group
+// mapped through the Crockford alphabet — mirroring the .NET OfferCodeGenerator.
+type RandomGenerator struct{}
+
+// NewRandomGenerator returns a crypto/rand-backed generator.
+func NewRandomGenerator() RandomGenerator { return RandomGenerator{} }
+
+// Generate returns a fresh canonical 12-character code. It errors only if the
+// system CSPRNG is unavailable.
+func (RandomGenerator) Generate() (string, error) {
+	var b [8]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("read random bytes: %w", err)
+	}
+	value := binary.LittleEndian.Uint64(b[:])
+
+	var buf [canonicalLength]byte
+	for i := canonicalLength - 1; i >= 0; i-- {
+		buf[i] = alphabet[value&0x1F]
+		value >>= 5
+	}
+	return string(buf[:]), nil
+}

--- a/api-go/internal/offercodes/generator_test.go
+++ b/api-go/internal/offercodes/generator_test.go
@@ -1,0 +1,25 @@
+package offercodes
+
+import "testing"
+
+func TestRandomGenerator_ProducesCanonicalCodes(t *testing.T) {
+	t.Parallel()
+
+	g := NewRandomGenerator()
+	seen := make(map[string]struct{})
+	for range 200 {
+		code, err := g.Generate()
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if !IsValidCanonical(code) {
+			t.Fatalf("generated non-canonical code %q", code)
+		}
+		seen[code] = struct{}{}
+	}
+	// 60 bits of entropy: 200 draws colliding would be astronomically unlikely,
+	// so a near-full distinct set confirms the generator is actually random.
+	if len(seen) < 199 {
+		t.Errorf("only %d/200 codes were distinct — generator not random enough", len(seen))
+	}
+}

--- a/api-go/internal/offercodes/handler.go
+++ b/api-go/internal/offercodes/handler.go
@@ -1,0 +1,187 @@
+package offercodes
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+const maxBodyBytes = 1 << 20
+
+// codeStore is the consumer-side offer-code store the redeem handler needs.
+type codeStore interface {
+	Get(ctx context.Context, canonical string) (OfferCode, error)
+	Save(ctx context.Context, c OfferCode) error
+}
+
+// profileStore is the consumer-side profile store: the redeem path loads the
+// caller's profile, activates the granted tier, and saves it back.
+type profileStore interface {
+	Get(ctx context.Context, userID string) (*profiles.UserProfile, error)
+	Save(ctx context.Context, p *profiles.UserProfile) error
+}
+
+// tierSync mirrors the .NET IAuth0ManagementClient subset used here: push the
+// new tier into Auth0's app_metadata. profiles.Auth0Manager satisfies it.
+type tierSync interface {
+	UpdateSubscriptionTier(ctx context.Context, userID, tier string) error
+}
+
+type handler struct {
+	codes    codeStore
+	profiles profileStore
+	auth0    tierSync
+	now      func() time.Time
+	logger   *slog.Logger
+}
+
+// Routes registers the authed redeem endpoint on mux.
+func Routes(mux *http.ServeMux, codes codeStore, profileStore profileStore, auth0 tierSync, now func() time.Time, logger *slog.Logger) {
+	h := &handler{codes: codes, profiles: profileStore, auth0: auth0, now: now, logger: logger}
+	mux.HandleFunc("POST /v1/offer-codes/redeem", h.redeem)
+}
+
+type redeemRequest struct {
+	Code string `json:"code"`
+}
+
+// redeemResponse mirrors the .NET RedeemOfferCodeResponse: { tier, expiresAt }.
+type redeemResponse struct {
+	Tier      string              `json:"tier"`
+	ExpiresAt platform.DotNetTime `json:"expiresAt"`
+}
+
+// apiErrorResponse mirrors the .NET ApiErrorResponse { error, message }. Unlike
+// the bodyless-backfill paths, the offer-code errors carry a human message.
+type apiErrorResponse struct {
+	Error   string  `json:"error"`
+	Message *string `json:"message"`
+}
+
+// redeem implements POST /v1/offer-codes/redeem. It mirrors the .NET endpoint's
+// error contract exactly: malformed code -> 400 invalid_code_format, unknown
+// code -> 404 invalid_code, already-claimed -> 409 code_already_redeemed,
+// caller already paid -> 409 already_subscribed.
+func (h *handler) redeem(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	var req redeemRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil && !errors.Is(err, io.EOF) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	canonical, err := Normalize(req.Code)
+	if err != nil {
+		var fe *InvalidFormatError
+		if errors.As(err, &fe) {
+			h.writeError(r, w, http.StatusBadRequest, "invalid_code_format", fe.Message)
+			return
+		}
+		h.serverError(w, r, "normalize offer code", err)
+		return
+	}
+
+	code, err := h.codes.Get(r.Context(), canonical)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			h.writeError(r, w, http.StatusNotFound, "invalid_code", "Offer code '"+canonical+"' was not found.")
+			return
+		}
+		h.serverError(w, r, "load offer code", err)
+		return
+	}
+	if code.IsRedeemed() {
+		h.writeError(r, w, http.StatusConflict, "code_already_redeemed", "Offer code '"+canonical+"' has already been redeemed.")
+		return
+	}
+
+	// A missing profile for an authenticated caller is a server-side
+	// inconsistency: .NET throws UserProfileNotFoundException, which the endpoint
+	// does not catch, yielding a 500. Mirror that — any load failure is a 500.
+	profile, err := h.profiles.Get(r.Context(), userID)
+	if err != nil {
+		h.serverError(w, r, "load profile", err)
+		return
+	}
+	if profile.Tier != profiles.TierFree {
+		h.writeError(r, w, http.StatusConflict, "already_subscribed",
+			"User already has an active subscription; offer codes are only available to free-tier users.")
+		return
+	}
+
+	now := h.now()
+	if err := code.Redeem(userID, now); err != nil {
+		h.serverError(w, r, "redeem offer code", err)
+		return
+	}
+	expiry := now.AddDate(0, 0, code.DurationDays)
+	profile.ActivateSubscription(code.Tier, expiry)
+
+	if err := h.codes.Save(r.Context(), code); err != nil {
+		h.serverError(w, r, "save offer code", err)
+		return
+	}
+	if err := h.profiles.Save(r.Context(), profile); err != nil {
+		h.serverError(w, r, "save profile", err)
+		return
+	}
+	if err := h.auth0.UpdateSubscriptionTier(r.Context(), profile.UserID, profile.Tier.String()); err != nil {
+		h.serverError(w, r, "sync auth0 tier", err)
+		return
+	}
+
+	h.writeJSON(r, w, redeemResponse{Tier: profile.Tier.String(), ExpiresAt: platform.DotNetTime(*profile.SubscriptionExpiry)})
+}
+
+func (h *handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {
+	body, err := encodeJSON(v)
+	if err != nil {
+		h.serverError(w, r, "encode response", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(body); err != nil {
+		h.logger.ErrorContext(r.Context(), "write offer-code response", "error", err)
+	}
+}
+
+func (h *handler) writeError(r *http.Request, w http.ResponseWriter, status int, code, message string) {
+	msg := message
+	body, err := encodeJSON(apiErrorResponse{Error: code, Message: &msg})
+	if err != nil {
+		h.serverError(w, r, "encode error", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if _, err := w.Write(body); err != nil {
+		h.logger.ErrorContext(r.Context(), "write offer-code error body", "error", err)
+	}
+}
+
+func encodeJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}
+
+func (h *handler) serverError(w http.ResponseWriter, r *http.Request, op string, err error) {
+	h.logger.ErrorContext(r.Context(), "offer-code request failed", "op", op, "error", err)
+	w.WriteHeader(http.StatusInternalServerError)
+}

--- a/api-go/internal/offercodes/handler_test.go
+++ b/api-go/internal/offercodes/handler_test.go
@@ -1,0 +1,206 @@
+package offercodes
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+type fakeCodeStore struct {
+	codes   map[string]OfferCode
+	saved   *OfferCode
+	saveErr error
+}
+
+func (f *fakeCodeStore) Get(_ context.Context, canonical string) (OfferCode, error) {
+	c, ok := f.codes[canonical]
+	if !ok {
+		return OfferCode{}, ErrNotFound
+	}
+	return c, nil
+}
+
+func (f *fakeCodeStore) Save(_ context.Context, c OfferCode) error {
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	cp := c
+	f.saved = &cp
+	return nil
+}
+
+type fakeProfileStore struct {
+	profile *profiles.UserProfile
+	getErr  error
+	saved   *profiles.UserProfile
+}
+
+func (f *fakeProfileStore) Get(_ context.Context, _ string) (*profiles.UserProfile, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.profile, nil
+}
+
+func (f *fakeProfileStore) Save(_ context.Context, p *profiles.UserProfile) error {
+	f.saved = p
+	return nil
+}
+
+type fakeTierSync struct {
+	gotUserID string
+	gotTier   string
+	calls     int
+}
+
+func (f *fakeTierSync) UpdateSubscriptionTier(_ context.Context, userID, tier string) error {
+	f.calls++
+	f.gotUserID = userID
+	f.gotTier = tier
+	return nil
+}
+
+func freeProfile(t *testing.T) *profiles.UserProfile {
+	t.Helper()
+	p, err := profiles.NewProfile("auth0|u1", "u@example.com", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	return p
+}
+
+func serveRedeem(t *testing.T, codes codeStore, profileStore profileStore, auth0 tierSync, now time.Time, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	Routes(mux, codes, profileStore, auth0, func() time.Time { return now }, slog.New(slog.DiscardHandler))
+	req := httptest.NewRequestWithContext(auth.WithSubject(context.Background(), "auth0|u1"),
+		http.MethodPost, "/v1/offer-codes/redeem", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func seededCode(t *testing.T) *fakeCodeStore {
+	t.Helper()
+	c, err := NewOfferCode("ABCDEFGHJKMN", profiles.TierPro, 30, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewOfferCode: %v", err)
+	}
+	return &fakeCodeStore{codes: map[string]OfferCode{"ABCDEFGHJKMN": c}}
+}
+
+func TestRedeem_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	codes := seededCode(t)
+	profile := &fakeProfileStore{profile: freeProfile(t)}
+	auth0 := &fakeTierSync{}
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	// Mixed-case, hyphenated input normalises to the canonical code.
+	rec := serveRedeem(t, codes, profile, auth0, now, `{"code":"abcd-efgh-jkmn"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != `{"tier":"Pro","expiresAt":"2026-07-10T12:00:00+00:00"}` {
+		t.Errorf("body = %s", got)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("content-type = %q", ct)
+	}
+	// The code is persisted as redeemed by the caller.
+	if codes.saved == nil || !codes.saved.IsRedeemed() || *codes.saved.RedeemedByUserID != "auth0|u1" {
+		t.Errorf("code not saved redeemed: %+v", codes.saved)
+	}
+	// The profile is activated to the granted tier and persisted.
+	if profile.saved == nil || profile.saved.Tier != profiles.TierPro || profile.saved.SubscriptionExpiry == nil {
+		t.Errorf("profile not activated: %+v", profile.saved)
+	}
+	// Auth0 is told the new tier exactly once.
+	if auth0.calls != 1 || auth0.gotUserID != "auth0|u1" || auth0.gotTier != "Pro" {
+		t.Errorf("auth0 sync wrong: %+v", auth0)
+	}
+}
+
+func TestRedeem_InvalidFormat(t *testing.T) {
+	t.Parallel()
+
+	rec := serveRedeem(t, seededCode(t), &fakeProfileStore{profile: freeProfile(t)}, &fakeTierSync{},
+		time.Now(), `{"code":"ABCD"}`)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"error":"invalid_code_format","message":"Offer code must be 12 characters (got 4)."}` {
+		t.Errorf("body = %s", got)
+	}
+}
+
+func TestRedeem_NotFound(t *testing.T) {
+	t.Parallel()
+
+	codes := &fakeCodeStore{codes: map[string]OfferCode{}}
+	rec := serveRedeem(t, codes, &fakeProfileStore{profile: freeProfile(t)}, &fakeTierSync{},
+		time.Now(), `{"code":"ZZZZZZZZZZZZ"}`)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"error":"invalid_code","message":"Offer code 'ZZZZZZZZZZZZ' was not found."}` {
+		t.Errorf("body = %s", got)
+	}
+}
+
+func TestRedeem_AlreadyRedeemed(t *testing.T) {
+	t.Parallel()
+
+	c, _ := NewOfferCode("ABCDEFGHJKMN", profiles.TierPro, 30, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	_ = c.Redeem("auth0|someone", time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC))
+	codes := &fakeCodeStore{codes: map[string]OfferCode{"ABCDEFGHJKMN": c}}
+
+	rec := serveRedeem(t, codes, &fakeProfileStore{profile: freeProfile(t)}, &fakeTierSync{},
+		time.Now(), `{"code":"ABCDEFGHJKMN"}`)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"error":"code_already_redeemed","message":"Offer code 'ABCDEFGHJKMN' has already been redeemed."}` {
+		t.Errorf("body = %s", got)
+	}
+}
+
+func TestRedeem_AlreadySubscribed(t *testing.T) {
+	t.Parallel()
+
+	paid := freeProfile(t)
+	paid.ActivateSubscription(profiles.TierPersonal, time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	rec := serveRedeem(t, seededCode(t), &fakeProfileStore{profile: paid}, &fakeTierSync{},
+		time.Now(), `{"code":"ABCDEFGHJKMN"}`)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"error":"already_subscribed","message":"User already has an active subscription; offer codes are only available to free-tier users."}` {
+		t.Errorf("body = %s", got)
+	}
+}
+
+func TestCosmosStore_SatisfiesCodeStore(t *testing.T) {
+	t.Parallel()
+	var _ codeStore = NewCosmosStore(newFakeItems())
+}
+
+func TestCosmosStore_SatisfiesProfileStore(t *testing.T) {
+	t.Parallel()
+	// The real profiles.CosmosStore must satisfy the redeem handler's profileStore.
+	var _ profileStore = profiles.NewCosmosStore(nil)
+}

--- a/api-go/internal/offercodes/store_cosmos.go
+++ b/api-go/internal/offercodes/store_cosmos.go
@@ -1,0 +1,68 @@
+package offercodes
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// ErrNotFound signals that no offer code exists for the given canonical code.
+// The redeem handler translates it to the 404 "invalid_code" response.
+var ErrNotFound = errors.New("offer code not found")
+
+// cosmosItems is the consumer-side slice of the Cosmos container the store
+// uses: single-partition point read/upsert keyed on the canonical code. The
+// azcosmos-backed platform.CosmosContainer satisfies it structurally.
+type cosmosItems interface {
+	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
+	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
+}
+
+// CosmosStore reads and writes offer codes in the OfferCodes container.
+//
+// Partition strategy: the OfferCodes container is partitioned by /id == the
+// canonical code, so every operation is a single-partition point operation.
+type CosmosStore struct {
+	items cosmosItems
+}
+
+// NewCosmosStore returns a store backed by the given Cosmos item accessor.
+func NewCosmosStore(items cosmosItems) *CosmosStore { return &CosmosStore{items: items} }
+
+// Get point-reads the code; a 404 from Cosmos surfaces as ErrNotFound.
+func (s *CosmosStore) Get(ctx context.Context, canonical string) (OfferCode, error) {
+	raw, err := s.items.ReadItem(ctx, canonical, canonical)
+	if err != nil {
+		if isNotFound(err) {
+			return OfferCode{}, ErrNotFound
+		}
+		return OfferCode{}, fmt.Errorf("read offer code %q: %w", canonical, err)
+	}
+	var doc offerCodeDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return OfferCode{}, fmt.Errorf("decode offer code %q: %w", canonical, err)
+	}
+	return doc.toDomain()
+}
+
+// Save upserts the code document (id == code == partition key). The .NET
+// repository's CreateAsync is a best-effort upsert too, so Save covers both.
+func (s *CosmosStore) Save(ctx context.Context, c OfferCode) error {
+	body, err := json.Marshal(newOfferCodeDocument(c))
+	if err != nil {
+		return fmt.Errorf("encode offer code %q: %w", c.Code, err)
+	}
+	if err := s.items.UpsertItem(ctx, c.Code, body); err != nil {
+		return fmt.Errorf("upsert offer code %q: %w", c.Code, err)
+	}
+	return nil
+}
+
+func isNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}

--- a/api-go/internal/offercodes/store_cosmos_test.go
+++ b/api-go/internal/offercodes/store_cosmos_test.go
@@ -1,0 +1,97 @@
+package offercodes
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// fakeItems is an in-memory CosmosItems so the store's serialisation round-trips
+// without a real Cosmos.
+type fakeItems struct {
+	items map[string][]byte
+}
+
+func newFakeItems() *fakeItems { return &fakeItems{items: map[string][]byte{}} }
+
+func (f *fakeItems) ReadItem(_ context.Context, _, id string) ([]byte, error) {
+	raw, ok := f.items[id]
+	if !ok {
+		return nil, &azcore.ResponseError{StatusCode: http.StatusNotFound}
+	}
+	return raw, nil
+}
+
+func (f *fakeItems) UpsertItem(_ context.Context, partitionKey string, item []byte) error {
+	f.items[partitionKey] = item
+	return nil
+}
+
+func TestCosmosStore_SaveGetRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := NewCosmosStore(newFakeItems())
+	created := time.Date(2026, 6, 1, 9, 30, 0, 0, time.UTC)
+	code, err := NewOfferCode("ABCDEFGHJKMN", profiles.TierPro, 30, created)
+	if err != nil {
+		t.Fatalf("NewOfferCode: %v", err)
+	}
+
+	if err := store.Save(context.Background(), code); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := store.Get(context.Background(), "ABCDEFGHJKMN")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Code != "ABCDEFGHJKMN" || got.Tier != profiles.TierPro || got.DurationDays != 30 {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+	if !got.CreatedAt.Equal(created) {
+		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, created)
+	}
+	if got.IsRedeemed() {
+		t.Error("freshly stored code should not be redeemed")
+	}
+}
+
+func TestCosmosStore_RedeemedFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	store := NewCosmosStore(newFakeItems())
+	created := time.Date(2026, 6, 1, 9, 30, 0, 0, time.UTC)
+	redeemedAt := time.Date(2026, 6, 2, 10, 0, 0, 0, time.UTC)
+	code, _ := NewOfferCode("ABCDEFGHJKMN", profiles.TierPersonal, 14, created)
+	if err := code.Redeem("auth0|u1", redeemedAt); err != nil {
+		t.Fatalf("Redeem: %v", err)
+	}
+
+	if err := store.Save(context.Background(), code); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := store.Get(context.Background(), "ABCDEFGHJKMN")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.IsRedeemed() || got.RedeemedByUserID == nil || *got.RedeemedByUserID != "auth0|u1" {
+		t.Errorf("redeemed-by mismatch: %+v", got)
+	}
+	if got.RedeemedAt == nil || !got.RedeemedAt.Equal(redeemedAt) {
+		t.Errorf("RedeemedAt = %v, want %v", got.RedeemedAt, redeemedAt)
+	}
+}
+
+func TestCosmosStore_Get_NotFound(t *testing.T) {
+	t.Parallel()
+
+	store := NewCosmosStore(newFakeItems())
+	if _, err := store.Get(context.Background(), "ZZZZZZZZZZZZ"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get missing err = %v, want ErrNotFound", err)
+	}
+}

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -67,6 +67,11 @@ type Config struct {
 	// without any env wiring; an override points them at a stub.
 	PostcodesIoBaseURL string
 	GovUkBaseURL       string
+
+	// AdminAPIKey gates the /v1/admin/* endpoints (the X-Admin-Key header),
+	// mirroring .NET's Admin:ApiKey. Empty means the admin endpoints reject every
+	// request, so an unconfigured deployment exposes no admin surface.
+	AdminAPIKey string
 }
 
 // Auth0M2MConfigured reports whether the Auth0 Management (M2M) client can be
@@ -100,6 +105,8 @@ func LoadConfig() (Config, error) {
 
 		PostcodesIoBaseURL: getenv("POSTCODES_IO_BASE_URL", defaultPostcodesIoBaseURL),
 		GovUkBaseURL:       getenv("GOVUK_PLANNING_DATA_BASE_URL", defaultGovUkBaseURL),
+
+		AdminAPIKey: os.Getenv("ADMIN_API_KEY"),
 	}
 
 	if raw := os.Getenv("LOG_LEVEL"); raw != "" {

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -159,6 +159,30 @@ func TestLoadConfig_ProDomains(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_AdminAPIKey(t *testing.T) {
+	t.Run("set", func(t *testing.T) {
+		t.Setenv("ADMIN_API_KEY", "s3cret-admin-key")
+		cfg, err := LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.AdminAPIKey != "s3cret-admin-key" {
+			t.Errorf("AdminAPIKey: got %q", cfg.AdminAPIKey)
+		}
+	})
+
+	t.Run("absent defaults empty (admin surface disabled)", func(t *testing.T) {
+		t.Setenv("ADMIN_API_KEY", "")
+		cfg, err := LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.AdminAPIKey != "" {
+			t.Errorf("AdminAPIKey: got %q, want empty", cfg.AdminAPIKey)
+		}
+	})
+}
+
 func TestLoadConfig_OutboundBaseURLs(t *testing.T) {
 	t.Run("defaults to live UK services", func(t *testing.T) {
 		t.Setenv("POSTCODES_IO_BASE_URL", "")

--- a/api-go/internal/platform/cosmos.go
+++ b/api-go/internal/platform/cosmos.go
@@ -171,6 +171,64 @@ func (c *CosmosContainer) CountItems(ctx context.Context, partitionKey, query st
 	return count, nil
 }
 
+// QueryItemsCrossPartition runs a parametrised query across ALL partitions and
+// returns every matching document body, draining all gateway pages. The Gateway
+// API supports only simple projections/filters cross-partition, which is all the
+// admin find-by-email lookup needs. An empty partition key plus the SDK's
+// default cross-partition flag triggers the cross-partition path.
+func (c *CosmosContainer) QueryItemsCrossPartition(ctx context.Context, query string, params map[string]any) ([][]byte, error) {
+	opts := &azcosmos.QueryOptions{QueryParameters: queryParams(params)}
+	pager := c.container.NewQueryItemsPager(query, azcosmos.NewPartitionKey(), opts)
+	var items [][]byte
+	for pager.More() {
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, page.Items...)
+	}
+	return items, nil
+}
+
+// QueryPageCrossPartition runs a cross-partition query and returns a single
+// gateway page of up to pageSize documents plus the continuation token for the
+// next page (empty when the query is exhausted). A non-empty continuationToken
+// resumes a prior page. Mirrors the .NET CosmosRestClient.QueryPageAsync used by
+// the admin user list. The Gateway may return inconsistently sized or empty
+// pages with a non-nil token — an inherent property of cross-partition queries
+// shared by both APIs.
+func (c *CosmosContainer) QueryPageCrossPartition(ctx context.Context, query string, params map[string]any, pageSize int, continuationToken string) ([][]byte, string, error) {
+	opts := &azcosmos.QueryOptions{QueryParameters: queryParams(params)}
+	if pageSize > 0 {
+		opts.PageSizeHint = clampPageSize(pageSize)
+	}
+	if continuationToken != "" {
+		opts.ContinuationToken = &continuationToken
+	}
+	pager := c.container.NewQueryItemsPager(query, azcosmos.NewPartitionKey(), opts)
+	if !pager.More() {
+		return nil, "", nil
+	}
+	page, err := pager.NextPage(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	next := ""
+	if page.ContinuationToken != nil {
+		next = *page.ContinuationToken
+	}
+	return page.Items, next, nil
+}
+
+// clampPageSize bounds the page size to a safe int32 range for the SDK hint.
+func clampPageSize(pageSize int) int32 {
+	const maxPageSize = 1000
+	if pageSize > maxPageSize {
+		return maxPageSize
+	}
+	return int32(pageSize)
+}
+
 // queryParams converts a name/value map into the SDK's parameter slice. The
 // map's iteration order is irrelevant — Cosmos binds by @name, not position.
 func queryParams(params map[string]any) []azcosmos.QueryParameter {

--- a/api-go/internal/platform/cosmos.go
+++ b/api-go/internal/platform/cosmos.go
@@ -109,6 +109,9 @@ const (
 	// CosmosSavedApplicationsContainer holds one document per saved application;
 	// partition key /userId, document id == "{userId}:{applicationUid}".
 	CosmosSavedApplicationsContainer = "SavedApplications"
+	// CosmosOfferCodesContainer holds one document per offer code; partition key
+	// /id == the canonical code, document id == the canonical code.
+	CosmosOfferCodesContainer = "OfferCodes"
 )
 
 // ReadItem point-reads the document with the given id from its partition.

--- a/api-go/internal/profiles/admin_store.go
+++ b/api-go/internal/profiles/admin_store.go
@@ -1,0 +1,99 @@
+package profiles
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// adminItems is the consumer-side slice of the Cosmos container the admin store
+// needs: upsert (grant writes a profile back) plus cross-partition query and
+// paged query (the admin lookups span partitions — email and the full list are
+// not the partition key). platform.CosmosContainer satisfies it structurally.
+type adminItems interface {
+	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
+	QueryItemsCrossPartition(ctx context.Context, query string, params map[string]any) ([][]byte, error)
+	QueryPageCrossPartition(ctx context.Context, query string, params map[string]any, pageSize int, continuationToken string) ([][]byte, string, error)
+}
+
+// AdminStore serves the admin surface's cross-partition profile operations:
+// find-by-email (used by the grant endpoint) and the paged user list. It is
+// separate from CosmosStore because those operations span partitions, unlike the
+// single-partition /v1/me lifecycle.
+type AdminStore struct {
+	items adminItems
+}
+
+// NewAdminStore returns an admin store backed by the given accessor.
+func NewAdminStore(items adminItems) *AdminStore { return &AdminStore{items: items} }
+
+// Page is one page of the admin user list: the profiles on this page plus the
+// continuation token for the next page (empty when exhausted).
+type Page struct {
+	Profiles          []*UserProfile
+	ContinuationToken string
+}
+
+// GetByEmail returns the first profile whose email matches exactly, or
+// ErrNotFound. Mirrors the .NET GetByEmailCrossPartitionAsync.
+func (s *AdminStore) GetByEmail(ctx context.Context, email string) (*UserProfile, error) {
+	rows, err := s.items.QueryItemsCrossPartition(ctx,
+		"SELECT * FROM c WHERE c.email = @email",
+		map[string]any{"@email": email})
+	if err != nil {
+		return nil, fmt.Errorf("query profile by email: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil, ErrNotFound
+	}
+	var doc profileDocument
+	if err := json.Unmarshal(rows[0], &doc); err != nil {
+		return nil, fmt.Errorf("decode profile: %w", err)
+	}
+	return doc.toDomain()
+}
+
+// Save upserts the profile (id == user id == partition key).
+func (s *AdminStore) Save(ctx context.Context, p *UserProfile) error {
+	body, err := json.Marshal(newProfileDocument(p))
+	if err != nil {
+		return fmt.Errorf("encode profile %q: %w", p.UserID, err)
+	}
+	if err := s.items.UpsertItem(ctx, p.UserID, body); err != nil {
+		return fmt.Errorf("upsert profile %q: %w", p.UserID, err)
+	}
+	return nil
+}
+
+// List returns one page of profiles, optionally filtered by a case-insensitive
+// email substring, plus the continuation token for the next page. Mirrors the
+// .NET ListCrossPartitionAsync: CONTAINS(c.email, @search, true) when a search
+// is given, else an unfiltered scan. An empty search applies no filter (an empty
+// substring matches every email, so the result set is identical either way).
+func (s *AdminStore) List(ctx context.Context, emailSearch string, pageSize int, continuationToken string) (Page, error) {
+	query := "SELECT * FROM c"
+	var params map[string]any
+	if emailSearch != "" {
+		query = "SELECT * FROM c WHERE CONTAINS(c.email, @search, true)"
+		params = map[string]any{"@search": emailSearch}
+	}
+
+	rows, next, err := s.items.QueryPageCrossPartition(ctx, query, params, pageSize, continuationToken)
+	if err != nil {
+		return Page{}, fmt.Errorf("list profiles: %w", err)
+	}
+
+	page := Page{Profiles: make([]*UserProfile, 0, len(rows)), ContinuationToken: next}
+	for _, raw := range rows {
+		var doc profileDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return Page{}, fmt.Errorf("decode profile: %w", err)
+		}
+		p, err := doc.toDomain()
+		if err != nil {
+			return Page{}, fmt.Errorf("hydrate profile: %w", err)
+		}
+		page.Profiles = append(page.Profiles, p)
+	}
+	return page, nil
+}

--- a/api-go/internal/profiles/admin_store_test.go
+++ b/api-go/internal/profiles/admin_store_test.go
@@ -1,0 +1,153 @@
+package profiles
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeAdminItems is a hand-written adminItems: it stores upserted docs and
+// answers cross-partition queries from a fixed result set.
+type fakeAdminItems struct {
+	upserted     map[string][]byte
+	queryResult  [][]byte
+	queryErr     error
+	pageResult   [][]byte
+	pageNext     string
+	pageErr      error
+	gotQuery     string
+	gotPageSize  int
+	gotPageToken string
+}
+
+func newFakeAdminItems() *fakeAdminItems { return &fakeAdminItems{upserted: map[string][]byte{}} }
+
+func (f *fakeAdminItems) UpsertItem(_ context.Context, partitionKey string, item []byte) error {
+	f.upserted[partitionKey] = item
+	return nil
+}
+
+func (f *fakeAdminItems) QueryItemsCrossPartition(_ context.Context, query string, _ map[string]any) ([][]byte, error) {
+	f.gotQuery = query
+	return f.queryResult, f.queryErr
+}
+
+func (f *fakeAdminItems) QueryPageCrossPartition(_ context.Context, query string, _ map[string]any, pageSize int, continuationToken string) ([][]byte, string, error) {
+	f.gotQuery = query
+	f.gotPageSize = pageSize
+	f.gotPageToken = continuationToken
+	return f.pageResult, f.pageNext, f.pageErr
+}
+
+func profileDoc(t *testing.T, userID, email string, tier SubscriptionTier) []byte {
+	t.Helper()
+	p, err := NewProfile(userID, email, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	p.Tier = tier
+	raw, err := json.Marshal(newProfileDocument(p))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw
+}
+
+func TestAdminStore_GetByEmail(t *testing.T) {
+	t.Parallel()
+
+	items := newFakeAdminItems()
+	items.queryResult = [][]byte{profileDoc(t, "auth0|u1", "u@example.com", TierPro)}
+	store := NewAdminStore(items)
+
+	got, err := store.GetByEmail(context.Background(), "u@example.com")
+	if err != nil {
+		t.Fatalf("GetByEmail: %v", err)
+	}
+	if got.UserID != "auth0|u1" || got.Tier != TierPro {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestAdminStore_GetByEmail_NotFound(t *testing.T) {
+	t.Parallel()
+
+	store := NewAdminStore(newFakeAdminItems()) // empty result set
+	if _, err := store.GetByEmail(context.Background(), "missing@example.com"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestAdminStore_Save(t *testing.T) {
+	t.Parallel()
+
+	items := newFakeAdminItems()
+	store := NewAdminStore(items)
+	p, _ := NewProfile("auth0|u1", "u@example.com", time.Now())
+
+	if err := store.Save(context.Background(), p); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if _, ok := items.upserted["auth0|u1"]; !ok {
+		t.Error("profile not upserted under its user id")
+	}
+}
+
+func TestAdminStore_List_FiltersBySearch(t *testing.T) {
+	t.Parallel()
+
+	items := newFakeAdminItems()
+	items.pageResult = [][]byte{
+		profileDoc(t, "auth0|u1", "alice@example.com", TierFree),
+		profileDoc(t, "auth0|u2", "bob@example.com", TierPro),
+	}
+	items.pageNext = "next-token"
+	store := NewAdminStore(items)
+
+	page, err := store.List(context.Background(), "example", 20, "")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(page.Profiles) != 2 || page.ContinuationToken != "next-token" {
+		t.Errorf("page = %+v", page)
+	}
+	// A non-empty search uses the CONTAINS filter and forwards the page size.
+	if items.gotQuery != "SELECT * FROM c WHERE CONTAINS(c.email, @search, true)" {
+		t.Errorf("query = %q", items.gotQuery)
+	}
+	if items.gotPageSize != 20 {
+		t.Errorf("pageSize forwarded = %d, want 20", items.gotPageSize)
+	}
+}
+
+func TestAdminStore_List_NoSearchScansAll(t *testing.T) {
+	t.Parallel()
+
+	items := newFakeAdminItems()
+	store := NewAdminStore(items)
+
+	if _, err := store.List(context.Background(), "", 20, "tok"); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if items.gotQuery != "SELECT * FROM c" {
+		t.Errorf("query = %q, want unfiltered scan", items.gotQuery)
+	}
+	if items.gotPageToken != "tok" {
+		t.Errorf("continuation token forwarded = %q, want tok", items.gotPageToken)
+	}
+}
+
+func TestUserProfile_ExpireSubscription(t *testing.T) {
+	t.Parallel()
+
+	p, _ := NewProfile("auth0|u1", "u@example.com", time.Now())
+	p.ActivateSubscription(TierPro, time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	p.ExpireSubscription()
+
+	if p.Tier != TierFree || p.SubscriptionExpiry != nil || p.GracePeriodExpiry != nil {
+		t.Errorf("after expire: tier=%v expiry=%v grace=%v", p.Tier, p.SubscriptionExpiry, p.GracePeriodExpiry)
+	}
+}

--- a/api-go/internal/profiles/profile.go
+++ b/api-go/internal/profiles/profile.go
@@ -160,6 +160,15 @@ func (p *UserProfile) ActivateSubscription(tier SubscriptionTier, expiry time.Ti
 	p.GracePeriodExpiry = nil
 }
 
+// ExpireSubscription drops the profile back to the Free tier and clears the
+// subscription expiry and grace period, mirroring .NET ExpireSubscription. Used
+// by the admin grant endpoint when granting the Free tier (a downgrade).
+func (p *UserProfile) ExpireSubscription() {
+	p.Tier = TierFree
+	p.SubscriptionExpiry = nil
+	p.GracePeriodExpiry = nil
+}
+
 func normaliseEmail(email string) *string {
 	if strings.TrimSpace(email) == "" {
 		return nil

--- a/api-go/tests/e2e/contract_offercodes_admin_test.go
+++ b/api-go/tests/e2e/contract_offercodes_admin_test.go
@@ -1,0 +1,55 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net/http"
+	"testing"
+)
+
+// Contract scenarios for the iteration-8 offer-code and admin surface. Only the
+// deterministic, side-effect-free paths are diffed here:
+//
+//   - Redeem's invalid-format (400) and unknown-code (404) errors short-circuit
+//     before any Cosmos write and before the profile is loaded, so they are
+//     identical on both APIs regardless of the shared user's subscription state.
+//   - The admin surface's no-key 401 needs no shared secret.
+//
+// The stateful / secret-dependent diffs — redeem happy path (needs a seeded
+// code), already-redeemed / already-subscribed (need specific state), and the
+// admin-authenticated grant/list/generate bodies (need a shared ADMIN_API_KEY on
+// the Go app, plus opaque continuation tokens that differ across SDKs) — are
+// deferred to tc-52t6.
+
+func TestContract_OfferCodeRedeem_Errors(t *testing.T) {
+	dotnetURL := baseURL(t, "DOTNET_BASE_URL")
+	goURL := baseURL(t, "GO_BASE_URL")
+	token := integrationToken(t)
+	client := &http.Client{Timeout: requestTimeout}
+
+	// A malformed code is rejected at the boundary with the invalid_code_format
+	// envelope, before any lookup or write.
+	t.Run("invalid format", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodPost, "/v1/offer-codes/redeem", token, `{"code":"ABCD"}`)
+	})
+
+	// A well-formed code that does not exist is a 404 invalid_code. ZZZZZZZZZZZZ
+	// is a valid canonical code that is astronomically unlikely to have been
+	// minted (60-bit random space), so it is absent on both APIs' shared Cosmos.
+	t.Run("unknown code", func(t *testing.T) {
+		diffWatchZone(t, client, dotnetURL, goURL, http.MethodPost, "/v1/offer-codes/redeem", token, `{"code":"ZZZZZZZZZZZZ"}`)
+	})
+}
+
+func TestContract_AdminRequiresKey(t *testing.T) {
+	dotnetURL := baseURL(t, "DOTNET_BASE_URL")
+	goURL := baseURL(t, "GO_BASE_URL")
+	client := &http.Client{Timeout: requestTimeout}
+
+	// The admin endpoints are anonymous to Auth0 but gated by X-Admin-Key. With no
+	// key, GET /v1/admin/users returns a bodyless 401 (the PascalCase envelope
+	// backfilled) and — unlike the Auth0 fallback-deny — no WWW-Authenticate
+	// header. (Only the GET route is exercised here; the PUT/POST admin routes
+	// would method-mismatch under diffChallenge's GET.)
+	diffChallenge(t, client, dotnetURL, goURL, "/v1/admin/users")
+}


### PR DESCRIPTION
## Summary

Iteration 8 of the Go API migration (epic tc-7g3i / GH #418): ports the **offer-code redeem** and **admin** endpoints to `api-go/`.

- `POST /v1/offer-codes/redeem` — authed; full error contract
- `PUT /v1/admin/subscriptions` — grant a tier by email
- `GET /v1/admin/users` — cross-partition paged list (continuation token)
- `POST /v1/admin/offer-codes` — generate codes, `text/plain`

The admin group is **anonymous to Auth0** and authenticated solely by the `X-Admin-Key` gate (constant-time compare), mirroring .NET's `AllowAnonymous` + `AdminApiKeyFilter`. The redeem endpoint is authed and reuses the it3 profile store + Auth0 M2M client.

## What's inside

- **`internal/offercodes`**: Crockford base32 format/normalise (.NET-exact error messages), domain model + `Redeem`, crypto/rand generator, Cosmos store (new `OfferCodes` container), and the redeem handler.
- **`internal/admin`**: the `X-Admin-Key` middleware + grant/list/generate handlers.
- **`internal/profiles`**: a cross-partition `AdminStore` (`GetByEmail`, paged `List`) + `ExpireSubscription`; new `platform.CosmosContainer.QueryItemsCrossPartition` / `QueryPageCrossPartition` (azcosmos cross-partition + continuation tokens).
- Wiring + new `ADMIN_API_KEY` config.

## Parity details (vs .NET)

- Redeem error contract: `invalid_code_format` (400), `invalid_code` (404), `code_already_redeemed` (409), `already_subscribed` (409) — each with the .NET exception message verbatim.
- Generate validation reproduces the .NET `ArgumentException`/`ArgumentOutOfRangeException` `.Message` byte-for-byte (incl. `(Parameter 'command')` and `Actual value was N.`).
- Grant: Free → `ExpireSubscription`; paid → far-future expiry (`2099-12-31T00:00:00+00:00`); missing email → bodyless 404.

## Tests

- TDD per slice; hand fakes + `httptest`.
- e2e contract diffs (`contract_offercodes_admin_test.go`): redeem invalid-format (400), redeem unknown-code (404), admin no-key (401) — the deterministic, side-effect-free, secret-free paths.

## Deferred (tc-52t6)

Redeem happy path / already-redeemed / already-subscribed (need seeded state) and the admin-authenticated grant/list/generate diffs (need a shared `ADMIN_API_KEY` on the Go dev app + opaque continuation tokens that differ across SDKs) are deferred to **tc-52t6**, which blocks the it10 cutover (tc-7g3i.11).

## Gate

`gofmt`, `go vet` (+e2e), `golangci-lint` (+e2e), `go test -race ./...` (427 pass), `go build ./...` — all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now redeem offer codes to activate paid subscriptions with configurable duration.
  * Added admin API endpoints for managing user subscriptions, listing users, and generating offer codes (requires API key authentication).

* **Tests**
  * Added comprehensive test coverage for offer code redemption and admin operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->