### PR TITLE
fix(ios): route watch-zone quota breach to paywall instead of silent no-op (tc-gpjk)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIWatchZoneRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIWatchZoneRepository.swift
@@ -28,9 +28,25 @@ public final class APIWatchZoneRepository: WatchZoneRepository, Sendable {
     do {
       let _: EmptyResponse = try await apiClient.request(.post("/v1/me/watch-zones", body: body))
     } catch let domainError as DomainError {
-      throw domainError
+      throw Self.normalisingCreateQuota(domainError)
     } catch {
-      throw error.toDomainError()
+      throw Self.normalisingCreateQuota(error.toDomainError())
+    }
+  }
+
+  /// The create endpoint's only 403 is "quota exceeded", so a 403 on save means
+  /// the user has hit their tier's watch-zone limit (tc-gpjk). Normalise it to
+  /// `.insufficientEntitlement` — which carries the "Upgrade Required" UX — so
+  /// the UI routes to the paywall rather than showing a generic "Server Error".
+  /// An already-mapped `.insufficientEntitlement` (entitlement-shaped body) is
+  /// passed through unchanged. The API does not return the required tier here,
+  /// so we surface the next tier up.
+  private static func normalisingCreateQuota(_ error: DomainError) -> DomainError {
+    switch error {
+    case .serverError(statusCode: 403, _):
+      return .insufficientEntitlement(required: "personal")
+    default:
+      return error
     }
   }
 

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -290,6 +290,13 @@ public final class AppCoordinator: ObservableObject {
       editing: zone
     )
     let isEditing = zone != nil
+    viewModel.onUpgradeRequired = { [weak self] in
+      // Quota breach on save (tc-gpjk): close the editor sheet and present the
+      // subscription paywall instead of showing an inline error.
+      self?.isAddingWatchZone = false
+      self?.editingWatchZone = nil
+      self?.isSubscriptionPresented = true
+    }
     viewModel.onSave = { [weak self] saved in
       self?.isAddingWatchZone = false
       self?.editingWatchZone = nil

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
@@ -39,8 +39,12 @@ public struct WatchZoneEditorView: View {
         ToolbarItem(placement: .confirmationAction) {
           Button("Save") {
             Task {
-              await viewModel.save()
-              dismiss()
+              // Dismiss only on success. On a quota breach the coordinator
+              // closes the sheet and opens the paywall (tc-gpjk); on any other
+              // failure the editor stays open and shows the inline error.
+              if await viewModel.save() {
+                dismiss()
+              }
             }
           }
           .disabled(

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
@@ -16,6 +16,11 @@ public final class WatchZoneEditorViewModel: ObservableObject, ErrorHandlingView
 
   var onSave: ((WatchZone) -> Void)?
 
+  /// Invoked when a save fails because the user has hit their tier's watch-zone
+  /// quota (tc-gpjk). The coordinator dismisses the editor and presents the
+  /// subscription paywall — no inline error is shown for this case.
+  public var onUpgradeRequired: (() -> Void)?
+
   public let isEditing: Bool
 
   private let geocoder: PostcodeGeocoder
@@ -98,8 +103,16 @@ public final class WatchZoneEditorViewModel: ObservableObject, ErrorHandlingView
     isLoading = false
   }
 
-  public func save() async {
-    guard let coordinate = geocodedCoordinate else { return }
+  /// Persists the zone. Returns `true` on success so the View dismisses only
+  /// when the save actually succeeded.
+  ///
+  /// On a quota breach (`DomainError.insufficientEntitlement`) the editor routes
+  /// to the subscription paywall via `onUpgradeRequired` and leaves `error`
+  /// unset — the coordinator closes the sheet. All other failures set `error`
+  /// so the inline error section is shown and the editor stays open.
+  @discardableResult
+  public func save() async -> Bool {
+    guard let coordinate = geocodedCoordinate else { return false }
     error = nil
 
     let clampedRadius = limits.clampRadius(selectedRadiusMetres)
@@ -119,8 +132,13 @@ public final class WatchZoneEditorViewModel: ObservableObject, ErrorHandlingView
         try await repository.save(zone)
       }
       onSave?(zone)
+      return true
+    } catch DomainError.insufficientEntitlement {
+      onUpgradeRequired?()
+      return false
     } catch {
       handleError(error)
+      return false
     }
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryQuotaTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIWatchZoneRepositoryQuotaTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+/// Watch-zone quota (tc-gpjk): the create endpoint's only 403 is
+/// "quota exceeded", so the repository normalises a create 403 to
+/// `DomainError.insufficientEntitlement(required:)` — giving the UI the
+/// "Upgrade Required" path instead of a generic "Server Error". This covers
+/// BOTH forms the client may surface: a plain quota 403 (which the client maps
+/// to `serverError(statusCode: 403, _)`) and an entitlement-shaped 403 body
+/// (already mapped to `.insufficientEntitlement`). `update` (PATCH) is left
+/// unchanged because quota only applies to create.
+@Suite("APIWatchZoneRepository — create quota 403")
+struct APIWatchZoneRepositoryQuotaTests {
+
+  // swiftlint:disable:next force_unwrapping
+  private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
+
+  private func makeSUT(
+    responses: [(Data, URLResponse)]
+  ) -> APIWatchZoneRepository {
+    let authService = SpyAuthenticationService()
+    authService.currentSessionResult = .valid
+    let transport = StubHTTPTransport()
+    transport.responses = responses
+    let apiClient = URLSessionAPIClient(
+      baseURL: baseURL,
+      authService: authService,
+      transport: transport
+    )
+    return APIWatchZoneRepository(apiClient: apiClient)
+  }
+
+  // swiftlint:disable force_unwrapping
+  private func httpResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: baseURL,
+      statusCode: statusCode,
+      httpVersion: nil,
+      headerFields: nil
+    )!
+  }
+  // swiftlint:enable force_unwrapping
+
+  @Test("save maps a plain quota 403 to insufficientEntitlement(required: personal)")
+  func save_quota403_mapsToInsufficientEntitlement() async {
+    let body = "Watch zone quota exceeded. Upgrade your subscription for more zones."
+    let sut = makeSUT(responses: [
+      (Data(body.utf8), httpResponse(statusCode: 403))
+    ])
+
+    await #expect(throws: DomainError.insufficientEntitlement(required: "personal")) {
+      try await sut.save(.cambridge)
+    }
+  }
+
+  @Test("save passes through an entitlement-shaped 403 as insufficientEntitlement")
+  func save_entitlement403_passesThrough() async {
+    let body = #"{"error":"insufficient_entitlement","required":"pro"}"#
+    let sut = makeSUT(responses: [
+      (Data(body.utf8), httpResponse(statusCode: 403))
+    ])
+
+    await #expect(throws: DomainError.insufficientEntitlement(required: "pro")) {
+      try await sut.save(.cambridge)
+    }
+  }
+
+  @Test("update with a 403 is left unchanged — quota only applies to create")
+  func update_403_throwsServerError() async {
+    let body = "Forbidden"
+    let sut = makeSUT(responses: [
+      (Data(body.utf8), httpResponse(statusCode: 403))
+    ])
+
+    await #expect(throws: DomainError.serverError(statusCode: 403, message: body)) {
+      try await sut.update(.cambridge)
+    }
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorWatchZoneTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorWatchZoneTests.swift
@@ -302,6 +302,32 @@ struct AppCoordinatorWatchZoneTests {
     #expect(listVM.zones == [renamed])
   }
 
+  // MARK: - Watch Zone Editor Quota Upsell (tc-gpjk)
+
+  @Test func makeWatchZoneEditorViewModel_onUpgradeRequired_dismissesEditorAndPresentsPaywall() {
+    let sut = makeSUT()
+    sut.isAddingWatchZone = true
+    let vm = sut.makeWatchZoneEditorViewModel()
+
+    vm.onUpgradeRequired?()
+
+    #expect(!sut.isAddingWatchZone)
+    #expect(sut.editingWatchZone == nil)
+    #expect(sut.isSubscriptionPresented)
+  }
+
+  @Test func makeWatchZoneEditorViewModel_forEdit_onUpgradeRequired_dismissesAndPresentsPaywall() {
+    let sut = makeSUT()
+    sut.editingWatchZone = .cambridge
+    let vm = sut.makeWatchZoneEditorViewModel(editing: .cambridge)
+
+    vm.onUpgradeRequired?()
+
+    #expect(sut.editingWatchZone == nil)
+    #expect(!sut.isAddingWatchZone)
+    #expect(sut.isSubscriptionPresented)
+  }
+
   // MARK: - Watch Zone Upsell
 
   @Test func makeWatchZoneListViewModel_onViewPlans_setsIsSubscriptionPresented() {

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelSaveOutcomeTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelSaveOutcomeTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+@testable import TownCrierDomain
+@testable import TownCrierPresentation
+
+/// Save outcome + quota routing (tc-gpjk). `save()` reports success so the View
+/// can dismiss only on success. When the repository reports the watch-zone
+/// quota is exceeded (`.insufficientEntitlement`), the editor routes to the
+/// upgrade paywall via `onUpgradeRequired` and leaves `error` unset (the inline
+/// error section is for other, retryable-ish failures only).
+@MainActor
+@Suite("WatchZoneEditorViewModel — save outcome")
+struct WatchZoneEditorSaveOutcomeTests {
+  private var spyGeocoder: SpyPostcodeGeocoder!
+  private var spyRepository: SpyWatchZoneRepository!
+  private var sut: WatchZoneEditorViewModel!
+
+  init() {
+    spyGeocoder = SpyPostcodeGeocoder()
+    spyRepository = SpyWatchZoneRepository()
+    sut = WatchZoneEditorViewModel(
+      geocoder: spyGeocoder,
+      repository: spyRepository,
+      tier: .free
+    )
+  }
+
+  private func geocode() async {
+    sut.postcodeInput = "CB1 2AD"
+    spyGeocoder.geocodeResult = .success(.cambridge)
+    await sut.submitPostcode()
+  }
+
+  @Test func save_onSuccess_returnsTrueAndFiresOnSave() async {
+    await geocode()
+    var savedZone: WatchZone?
+    sut.onSave = { savedZone = $0 }
+
+    let didSave = await sut.save()
+
+    #expect(didSave)
+    #expect(savedZone != nil)
+    #expect(sut.error == nil)
+  }
+
+  @Test func save_quotaExceeded_routesToUpgrade_withoutSettingError() async {
+    await geocode()
+    spyRepository.saveResult = .failure(
+      DomainError.insufficientEntitlement(required: "personal"))
+    var upgradeRequested = false
+    sut.onUpgradeRequired = { upgradeRequested = true }
+
+    let didSave = await sut.save()
+
+    #expect(!didSave)
+    #expect(upgradeRequested)
+    #expect(sut.error == nil)
+  }
+
+  @Test func save_otherFailure_setsError_andDoesNotRouteToUpgrade() async {
+    await geocode()
+    spyRepository.saveResult = .failure(DomainError.networkUnavailable)
+    var upgradeRequested = false
+    sut.onUpgradeRequired = { upgradeRequested = true }
+
+    let didSave = await sut.save()
+
+    #expect(!didSave)
+    #expect(!upgradeRequested)
+    #expect(sut.error == .networkUnavailable)
+  }
+
+  @Test func save_withoutGeocoding_returnsFalse() async {
+    let didSave = await sut.save()
+
+    #expect(!didSave)
+    #expect(spyRepository.saveCalls.isEmpty)
+  }
+}


### PR DESCRIPTION
## Problem (tc-gpjk, P1)

Adding a watch zone past the tier limit silently did nothing — no zone, no error, no upsell. Root cause: the editor's Save button called `await viewModel.save()` then `dismiss()` **unconditionally**, so the backend's `403 "quota exceeded"` rejection was swallowed before the error could render. Separately, the quota `403` only degraded to a generic `serverError` because iOS's `mapForbidden` didn't recognise the create endpoint's quota body.

## Changes
- **Repository** (`APIWatchZoneRepository.save`): normalise a create-`403` to `DomainError.insufficientEntitlement` (the create endpoint's only 403 is quota-exceeded), giving it the "Upgrade Required" semantics. PATCH/update left unchanged.
- **Editor VM** (`WatchZoneEditorViewModel`): `save()` is now `@discardableResult -> Bool`; added `onUpgradeRequired`. A quota breach fires `onUpgradeRequired` (no inline error); other failures set `error`; success returns `true`.
- **Editor View**: Save dismisses **only** on success.
- **Coordinator**: wires `onUpgradeRequired` to close the editor sheet and present the existing `SubscriptionView` paywall.

## Behaviour now
- Free user hits the 1-zone limit on save → editor closes, **paywall opens** (the "View Plans" upsell path).
- Any other save failure → editor stays open, inline error shown.

## Tests (Swift Testing, TDD red→green)
- `APIWatchZoneRepositoryQuotaTests` — 403→insufficientEntitlement, entitlement-403 pass-through, PATCH 403 unchanged.
- `WatchZoneEditorViewModelSaveOutcomeTests` — success/quota/other-failure/no-geocode outcomes.
- `AppCoordinatorWatchZoneTests` — onUpgradeRequired dismisses editor + presents paywall (add & edit).

## Verification
swift build clean · 1232 tests pass · swiftlint --strict 0 violations · scope: all under `mobile/ios/`.

## Follow-up
Filed **tc-79y4**: the Go API has no POST/quota for watch-zones — must be ported before cutover or all creates will 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)