### PR TITLE
ci: pin SwiftLint to 0.63.2 in iOS CD + PR gate (tc-6kdu)

### DIFF
--- a/.github/workflows/cd-ios-testflight.yml
+++ b/.github/workflows/cd-ios-testflight.yml
@@ -95,8 +95,15 @@ jobs:
           restore-keys: |
             spm-test-
 
-      - name: Install swiftlint
-        run: brew install swiftlint
+      - name: Install SwiftLint 0.63.2 (pinned — avoids latest-ruleset drift, tc-6kdu)
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/swiftlint.zip" \
+            https://github.com/realm/SwiftLint/releases/download/0.63.2/portable_swiftlint.zip
+          unzip -o "$RUNNER_TEMP/swiftlint.zip" -d "$RUNNER_TEMP/swiftlint"
+          echo "$RUNNER_TEMP/swiftlint" >> "$GITHUB_PATH"
+
+      - name: Verify SwiftLint version
+        run: swiftlint version
 
       - name: SwiftLint (strict)
         working-directory: mobile/ios

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -588,8 +588,14 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
-      - run: brew install swiftlint
-      - run: swiftlint lint
+      - name: Install SwiftLint 0.63.2 (pinned — avoids latest-ruleset drift, tc-6kdu)
+        run: |
+          curl -fsSL -o "$RUNNER_TEMP/swiftlint.zip" \
+            https://github.com/realm/SwiftLint/releases/download/0.63.2/portable_swiftlint.zip
+          unzip -o "$RUNNER_TEMP/swiftlint.zip" -d "$RUNNER_TEMP/swiftlint"
+          echo "$RUNNER_TEMP/swiftlint" >> "$GITHUB_PATH"
+      - run: swiftlint version
+      - run: swiftlint lint --strict
         working-directory: mobile/ios
 
   ios-build-test:


### PR DESCRIPTION
## Problem
The iOS TestFlight CD (`cd-ios-testflight.yml`) and PR gate both `brew install swiftlint` (always latest). Latest SwiftLint keeps adding rules, so `swiftlint lint --strict` fails at **release time** — v0.13.23's TestFlight build failed on 63 strict violations — while local SwiftLint **0.63.2** reports **0** and the non-strict PR gate passes. Recurring (v0.13.22 was "clear 21 swiftlint --strict violations blocking CD TestFlight").

## Fix
- **Pin SwiftLint to 0.63.2** in both workflows via the `portable_swiftlint.zip` release artifact instead of `brew install` — stops the latest-ruleset drift permanently and aligns CI with the version developers run.
- **Make the PR gate strict** (`swiftlint lint --strict`) so strict failures surface at PR time, not release time. Safe because 0.63.2 reports 0 strict violations on current code.

## Notes
- Both jobs run on macOS runners; `portable_swiftlint.zip` is the correct macOS asset (confirmed present on the 0.63.2 release).
- No code changes — pure CI version pin. Unblocks the TestFlight build with zero churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the iOS lint checks to use a pinned SwiftLint version for more consistent results across CI runs.
  * Added a version verification step before linting to help catch setup issues early.
  * Updated the lint command to run in strict mode, improving code quality enforcement during checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->