### PR TITLE
feat(go): it7 demo-account endpoint + applications.FindNearby geo query (tc-o2o3)

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/authorities"
+	"github.com/AmyDe/town-crier/api-go/internal/demoaccount"
 	"github.com/AmyDe/town-crier/api-go/internal/designations"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/geocoding"
@@ -37,6 +38,10 @@ var anonymousPatterns = map[string]struct{}{
 	"GET /v1/authorities":          {},
 	"GET /v1/authorities/{$}":      {},
 	"GET /v1/authorities/{id}":     {},
+	// The demo-account endpoint is anonymous so Apple's App Store reviewer can
+	// reach a fully-provisioned Pro account without a token, matching .NET's
+	// AllowAnonymous.
+	"GET /v1/demo-account": {},
 	// Admin routes are anonymous to Auth0 (no bearer token); they are
 	// authenticated solely by the X-Admin-Key gate inside the handlers, matching
 	// .NET's AllowAnonymous + AdminApiKeyFilter.
@@ -119,6 +124,13 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 	}
 	if appStore != nil {
 		applications.Routes(mux, appStore, logger)
+	}
+	if store != nil && watchZoneStore != nil && appStore != nil {
+		// Demo account (anonymous): seeds a Pro profile, a Westminster watch zone,
+		// and five fixed applications on first call, then returns the zone plus
+		// its nearby applications. Needs the profile, watch-zone and application
+		// stores; the spatial lookup hits the applications store's FindNearby.
+		demoaccount.Routes(mux, store, watchZoneStore, appStore, time.Now, logger)
 	}
 	if savedStore != nil && appStore != nil {
 		// The save path dual-writes: the master application record (appStore) then

--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -12,11 +12,13 @@ import (
 )
 
 // CosmosItems is the consumer-side slice of the Applications container the store
-// uses: a single-partition point read and an upsert. platform.CosmosContainer
-// satisfies it structurally.
+// uses: a single-partition point read, an upsert, and a single-partition
+// spatial query for the nearby lookup. platform.CosmosContainer satisfies it
+// structurally.
 type CosmosItems interface {
 	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
 	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
+	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
 }
 
 // CosmosStore reads and writes planning applications in the Applications
@@ -63,6 +65,36 @@ func (s *CosmosStore) GetByAuthorityAndName(ctx context.Context, authorityCode, 
 		return PlanningApplication{}, false, fmt.Errorf("decode application %q/%q: %w", authorityCode, name, err)
 	}
 	return doc.toDomain(), true, nil
+}
+
+// FindNearby returns every application within radiusMetres of (latitude,
+// longitude) inside the authorityCode partition, via a single-partition
+// ST_DISTANCE spatial query against the GeoJSON location. It mirrors .NET
+// CosmosPlanningApplicationRepository.FindNearbyAsync: the GeoJSON point and
+// radius are formatted into the query with InvariantCulture-equivalent
+// (strconv) decimals — they are float64 values, never user-supplied strings, so
+// there is no injection surface. The query is scoped to the authorityCode
+// logical partition, so it never fans out cross-partition.
+func (s *CosmosStore) FindNearby(ctx context.Context, authorityCode string, latitude, longitude, radiusMetres float64) ([]PlanningApplication, error) {
+	lng := strconv.FormatFloat(longitude, 'g', -1, 64)
+	lat := strconv.FormatFloat(latitude, 'g', -1, 64)
+	rad := strconv.FormatFloat(radiusMetres, 'g', -1, 64)
+	query := `SELECT * FROM c WHERE ST_DISTANCE(c.location, ` +
+		`{"type": "Point", "coordinates": [` + lng + `, ` + lat + `]}) <= ` + rad
+
+	raws, err := s.items.QueryItems(ctx, authorityCode, query, nil)
+	if err != nil {
+		return nil, fmt.Errorf("find applications near %q: %w", authorityCode, err)
+	}
+	apps := make([]PlanningApplication, 0, len(raws))
+	for _, raw := range raws {
+		var doc applicationDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("decode nearby application in %q: %w", authorityCode, err)
+		}
+		apps = append(apps, doc.toDomain())
+	}
+	return apps, nil
 }
 
 // isNotFound reports whether err is a Cosmos 404 response.

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -14,10 +14,14 @@ type fakeItems struct {
 	stored       map[string][]byte // id -> bytes
 	readErr      error
 	upsertErr    error
+	queryErr     error
+	queryResult  [][]byte
 	lastUpsertPK string
 	lastUpsert   []byte
 	lastReadPK   string
 	lastReadID   string
+	lastQueryPK  string
+	lastQuery    string
 }
 
 func newFakeItems() *fakeItems { return &fakeItems{stored: map[string][]byte{}} }
@@ -39,6 +43,15 @@ func (f *fakeItems) UpsertItem(_ context.Context, partitionKey string, item []by
 	f.lastUpsertPK = partitionKey
 	f.lastUpsert = item
 	return f.upsertErr
+}
+
+func (f *fakeItems) QueryItems(_ context.Context, partitionKey, query string, _ map[string]any) ([][]byte, error) {
+	f.lastQueryPK = partitionKey
+	f.lastQuery = query
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return f.queryResult, nil
 }
 
 func TestCosmosStore_Upsert_TargetsAuthorityPartition(t *testing.T) {
@@ -94,5 +107,47 @@ func TestCosmosStore_GetByAuthorityAndName_NotFound(t *testing.T) {
 	}
 	if found {
 		t.Error("expected not found")
+	}
+}
+
+func TestCosmosStore_FindNearby_ScopesToAuthorityPartitionWithSpatialQuery(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	body, _ := json.Marshal(newApplicationDocument(a))
+	items := newFakeItems()
+	items.queryResult = [][]byte{body}
+	store := NewCosmosStore(items)
+
+	got, err := store.FindNearby(context.Background(), "441", 51.4975, -0.1357, 2000)
+	if err != nil {
+		t.Fatalf("FindNearby: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != a.Name {
+		t.Fatalf("FindNearby results: got %+v", got)
+	}
+	if items.lastQueryPK != "441" {
+		t.Errorf("query partition key: got %q, want \"441\"", items.lastQueryPK)
+	}
+	// The GeoJSON point carries [longitude, latitude] (GeoJSON order) and the
+	// radius is the bare metres value, mirroring .NET's interpolated ST_DISTANCE.
+	want := `SELECT * FROM c WHERE ST_DISTANCE(c.location, {"type": "Point", "coordinates": [-0.1357, 51.4975]}) <= 2000`
+	if items.lastQuery != want {
+		t.Errorf("spatial query:\n got %q\nwant %q", items.lastQuery, want)
+	}
+}
+
+func TestCosmosStore_FindNearby_EmptyResultIsEmptySlice(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+
+	got, err := store.FindNearby(context.Background(), "441", 51.4975, -0.1357, 2000)
+	if err != nil {
+		t.Fatalf("FindNearby: %v", err)
+	}
+	if got == nil {
+		t.Fatal("FindNearby: got nil slice, want empty non-nil slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("FindNearby: got %d results, want 0", len(got))
 	}
 }

--- a/api-go/internal/demoaccount/handler.go
+++ b/api-go/internal/demoaccount/handler.go
@@ -1,0 +1,148 @@
+package demoaccount
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// The fixed demo identity and zone geometry, mirroring .NET
+// GetDemoAccountQueryHandler. The reviewer account is keyed on a synthetic Auth0
+// subject; the zone centres on Westminster with a 2 km radius.
+const (
+	demoUserID       = "demo|apple-reviewer"
+	demoZoneID       = "demo-zone"
+	demoZoneName     = "Westminster Demo Zone"
+	demoLatitude     = 51.4975
+	demoLongitude    = -0.1357
+	demoRadiusMetres = 2000
+	// demoSubscriptionYears is how far ahead the demo Pro subscription is set to
+	// expire, matching .NET's DateTimeOffset.UtcNow.AddYears(10).
+	demoSubscriptionYears = 10
+)
+
+// profileStore is the consumer-side slice of the profile store the demo handler
+// needs: load the demo profile and persist a freshly seeded one.
+type profileStore interface {
+	Get(ctx context.Context, userID string) (*profiles.UserProfile, error)
+	Save(ctx context.Context, p *profiles.UserProfile) error
+}
+
+// zoneStore persists the seeded demo watch zone.
+type zoneStore interface {
+	Save(ctx context.Context, z watchzones.WatchZone) error
+}
+
+// appStore seeds the demo applications and runs the spatial lookup that backs
+// the response.
+type appStore interface {
+	Upsert(ctx context.Context, a applications.PlanningApplication) error
+	FindNearby(ctx context.Context, authorityCode string, latitude, longitude, radiusMetres float64) ([]applications.PlanningApplication, error)
+}
+
+// handler serves GET /v1/demo-account.
+type handler struct {
+	profiles profileStore
+	zones    zoneStore
+	apps     appStore
+	now      func() time.Time
+	logger   *slog.Logger
+}
+
+// Routes registers the anonymous demo-account endpoint. The route is added to
+// the wiring's anonymousPatterns so it bypasses the Auth0 bearer requirement,
+// matching .NET's AllowAnonymous.
+func Routes(mux *http.ServeMux, profiles profileStore, zones zoneStore, apps appStore, now func() time.Time, logger *slog.Logger) {
+	h := &handler{profiles: profiles, zones: zones, apps: apps, now: now, logger: logger}
+	mux.HandleFunc("GET /v1/demo-account", h.getDemoAccount)
+}
+
+// getDemoAccount returns the demo account, seeding Cosmos on first call. The
+// seed is gated on the profile's absence, so repeated calls are idempotent —
+// they skip straight to the spatial lookup. Mirrors .NET
+// GetDemoAccountQueryHandler.HandleAsync.
+func (h *handler) getDemoAccount(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	profile, err := h.profiles.Get(ctx, demoUserID)
+	switch {
+	case errors.Is(err, profiles.ErrNotFound):
+		profile, err = h.seed(ctx)
+		if err != nil {
+			serverError(w, r, h.logger, "seed demo account", err)
+			return
+		}
+	case err != nil:
+		serverError(w, r, h.logger, "load demo profile", err)
+		return
+	}
+
+	authorityCode := strconv.Itoa(seedAuthorityID)
+	apps, err := h.apps.FindNearby(ctx, authorityCode, demoLatitude, demoLongitude, demoRadiusMetres)
+	if err != nil {
+		serverError(w, r, h.logger, "find nearby demo applications", err)
+		return
+	}
+
+	appResults := make([]demoApplicationResult, 0, len(apps))
+	for _, a := range apps {
+		appResults = append(appResults, applicationResultOf(a))
+	}
+
+	writeJSON(w, r, h.logger, demoAccountResult{
+		UserID: demoUserID,
+		Tier:   profile.Tier.String(),
+		WatchZone: demoWatchZoneResult{
+			ZoneID:        demoZoneID,
+			AuthorityName: seedAuthorityName,
+			Latitude:      demoLatitude,
+			Longitude:     demoLongitude,
+			RadiusMetres:  demoRadiusMetres,
+		},
+		Applications: appResults,
+	})
+}
+
+// seed provisions the demo profile (Pro, 10-year expiry), the Westminster watch
+// zone, and the five fixed applications, returning the saved profile. It runs
+// only when the profile is absent. Mirrors .NET's seed branch; the watch zone is
+// created with DateTimeOffset.MinValue (Go's zero time) as its CreatedAt.
+func (h *handler) seed(ctx context.Context) (*profiles.UserProfile, error) {
+	now := h.now()
+
+	profile, err := profiles.NewProfile(demoUserID, "", now)
+	if err != nil {
+		return nil, fmt.Errorf("register demo profile: %w", err)
+	}
+	profile.ActivateSubscription(profiles.TierPro, now.AddDate(demoSubscriptionYears, 0, 0))
+	if err := h.profiles.Save(ctx, profile); err != nil {
+		return nil, fmt.Errorf("save demo profile: %w", err)
+	}
+
+	zone, err := watchzones.NewWatchZone(
+		demoZoneID, demoUserID, demoZoneName,
+		demoLatitude, demoLongitude, demoRadiusMetres,
+		seedAuthorityID, time.Time{}, true, true)
+	if err != nil {
+		return nil, fmt.Errorf("build demo watch zone: %w", err)
+	}
+	if err := h.zones.Save(ctx, zone); err != nil {
+		return nil, fmt.Errorf("save demo watch zone: %w", err)
+	}
+
+	for _, a := range seedApplications(now) {
+		if err := h.apps.Upsert(ctx, a); err != nil {
+			return nil, fmt.Errorf("seed demo application %q: %w", a.Name, err)
+		}
+	}
+
+	return profile, nil
+}

--- a/api-go/internal/demoaccount/handler_test.go
+++ b/api-go/internal/demoaccount/handler_test.go
@@ -1,0 +1,231 @@
+package demoaccount
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+var fixedNow = time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+
+type fakeProfileStore struct {
+	profile *profiles.UserProfile
+	getErr  error
+	saved   *profiles.UserProfile
+	saveErr error
+}
+
+func (f *fakeProfileStore) Get(_ context.Context, _ string) (*profiles.UserProfile, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if f.profile == nil {
+		return nil, profiles.ErrNotFound
+	}
+	return f.profile, nil
+}
+
+func (f *fakeProfileStore) Save(_ context.Context, p *profiles.UserProfile) error {
+	f.saved = p
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	f.profile = p
+	return nil
+}
+
+type fakeZoneStore struct {
+	saved   []watchzones.WatchZone
+	saveErr error
+}
+
+func (f *fakeZoneStore) Save(_ context.Context, z watchzones.WatchZone) error {
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	f.saved = append(f.saved, z)
+	return nil
+}
+
+type fakeAppStore struct {
+	upserted  []applications.PlanningApplication
+	nearby    []applications.PlanningApplication
+	upsertErr error
+	findErr   error
+	findPK    string
+}
+
+func (f *fakeAppStore) Upsert(_ context.Context, a applications.PlanningApplication) error {
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	f.upserted = append(f.upserted, a)
+	return nil
+}
+
+func (f *fakeAppStore) FindNearby(_ context.Context, authorityCode string, _, _, _ float64) ([]applications.PlanningApplication, error) {
+	f.findPK = authorityCode
+	if f.findErr != nil {
+		return nil, f.findErr
+	}
+	return f.nearby, nil
+}
+
+// serve wires the route and issues GET /v1/demo-account, returning the recorder.
+func serve(t *testing.T, p profileStore, z zoneStore, a appStore) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	Routes(mux, p, z, a, func() time.Time { return fixedNow }, slog.New(slog.DiscardHandler))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/v1/demo-account", nil)
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestGetDemoAccount_FirstCall_SeedsAndReturnsDemoAccount(t *testing.T) {
+	t.Parallel()
+	p := &fakeProfileStore{}
+	z := &fakeZoneStore{}
+	a := &fakeAppStore{nearby: seedApplications(fixedNow)}
+
+	rec := serve(t, p, z, a)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Seed side effects: a Pro profile, one watch zone, and the five fixed apps.
+	if p.saved == nil || p.saved.Tier != profiles.TierPro {
+		t.Errorf("seeded profile: got %+v, want Pro tier", p.saved)
+	}
+	if p.saved != nil && p.saved.SubscriptionExpiry != nil {
+		if got := *p.saved.SubscriptionExpiry; !got.Equal(fixedNow.AddDate(demoSubscriptionYears, 0, 0)) {
+			t.Errorf("subscription expiry: got %v, want +10y", got)
+		}
+	}
+	if len(z.saved) != 1 {
+		t.Fatalf("watch zones saved: got %d, want 1", len(z.saved))
+	}
+	if zone := z.saved[0]; zone.ID != demoZoneID || zone.AuthorityID != seedAuthorityID || !zone.CreatedAt.IsZero() {
+		t.Errorf("seeded zone: got %+v", zone)
+	}
+	if len(a.upserted) != 5 {
+		t.Errorf("seeded applications: got %d, want 5", len(a.upserted))
+	}
+	if a.findPK != "441" {
+		t.Errorf("FindNearby authority partition: got %q, want \"441\"", a.findPK)
+	}
+
+	var got demoAccountResult
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode body: %v; raw=%s", err, rec.Body.String())
+	}
+	if got.UserID != demoUserID {
+		t.Errorf("userId: got %q, want %q", got.UserID, demoUserID)
+	}
+	if got.Tier != "Pro" {
+		t.Errorf("tier: got %q, want \"Pro\"", got.Tier)
+	}
+	wantZone := demoWatchZoneResult{ZoneID: demoZoneID, AuthorityName: seedAuthorityName, Latitude: demoLatitude, Longitude: demoLongitude, RadiusMetres: demoRadiusMetres}
+	if got.WatchZone != wantZone {
+		t.Errorf("watchZone: got %+v, want %+v", got.WatchZone, wantZone)
+	}
+	if len(got.Applications) != 5 {
+		t.Fatalf("applications: got %d, want 5", len(got.Applications))
+	}
+	first := got.Applications[0]
+	if first.UID != "demo-app-001" || first.Name != "24/05678/FULL" || first.AppType == nil || *first.AppType != "Full" {
+		t.Errorf("first application: got %+v", first)
+	}
+}
+
+func TestGetDemoAccount_SecondCall_DoesNotReseed(t *testing.T) {
+	t.Parallel()
+	existing, err := profiles.NewProfile(demoUserID, "", fixedNow)
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	existing.ActivateSubscription(profiles.TierPro, fixedNow.AddDate(demoSubscriptionYears, 0, 0))
+	p := &fakeProfileStore{profile: existing}
+	z := &fakeZoneStore{}
+	a := &fakeAppStore{nearby: seedApplications(fixedNow)}
+
+	rec := serve(t, p, z, a)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if p.saved != nil {
+		t.Error("expected no profile re-save on second call")
+	}
+	if len(z.saved) != 0 {
+		t.Errorf("expected no zone re-seed, got %d", len(z.saved))
+	}
+	if len(a.upserted) != 0 {
+		t.Errorf("expected no application re-seed, got %d", len(a.upserted))
+	}
+	if a.findPK != "441" {
+		t.Errorf("FindNearby still runs: authority got %q, want \"441\"", a.findPK)
+	}
+}
+
+func TestGetDemoAccount_EmptyNearby_SerialisesEmptyArray(t *testing.T) {
+	t.Parallel()
+	p := &fakeProfileStore{}
+	rec := serve(t, p, &fakeZoneStore{}, &fakeAppStore{})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	// The applications array must serialise as [] (not null) when empty, matching
+	// .NET's List<DemoApplicationResult>.
+	var raw struct {
+		Applications json.RawMessage `json:"applications"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if string(raw.Applications) != "[]" {
+		t.Errorf("applications: got %s, want []", raw.Applications)
+	}
+}
+
+func TestGetDemoAccount_ProfileLoadError_Returns500(t *testing.T) {
+	t.Parallel()
+	p := &fakeProfileStore{getErr: errors.New("cosmos unavailable")}
+	rec := serve(t, p, &fakeZoneStore{}, &fakeAppStore{})
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500", rec.Code)
+	}
+}
+
+func TestGetDemoAccount_FindNearbyError_Returns500(t *testing.T) {
+	t.Parallel()
+	p := &fakeProfileStore{}
+	a := &fakeAppStore{findErr: errors.New("query failed")}
+	rec := serve(t, p, &fakeZoneStore{}, a)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500", rec.Code)
+	}
+}
+
+func TestGetDemoAccount_SeedSaveError_Returns500(t *testing.T) {
+	t.Parallel()
+	p := &fakeProfileStore{saveErr: errors.New("save failed")}
+	rec := serve(t, p, &fakeZoneStore{}, &fakeAppStore{})
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500", rec.Code)
+	}
+}

--- a/api-go/internal/demoaccount/respond.go
+++ b/api-go/internal/demoaccount/respond.go
@@ -1,0 +1,32 @@
+package demoaccount
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// writeJSON encodes v as a 200 application/json; charset=utf-8 response with HTML
+// escaping off and no trailing newline, matching ASP.NET's Results.Ok byte output.
+func writeJSON(w http.ResponseWriter, r *http.Request, logger *slog.Logger, v any) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		serverError(w, r, logger, "encode response", err)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	if _, err := w.Write(bytes.TrimRight(buf.Bytes(), "\n")); err != nil {
+		logger.ErrorContext(r.Context(), "write response", "error", err)
+	}
+}
+
+// serverError logs and emits a bodyless 500; the error envelope is backfilled by
+// middleware.ErrorBody.
+func serverError(w http.ResponseWriter, r *http.Request, logger *slog.Logger, op string, err error) {
+	logger.ErrorContext(r.Context(), "demo-account request failed", "op", op, "error", err)
+	w.WriteHeader(http.StatusInternalServerError)
+}

--- a/api-go/internal/demoaccount/result.go
+++ b/api-go/internal/demoaccount/result.go
@@ -1,0 +1,50 @@
+package demoaccount
+
+import "github.com/AmyDe/town-crier/api-go/internal/applications"
+
+// demoAccountResult is the wire shape of GET /v1/demo-account, mirroring .NET
+// GetDemoAccountResult. JSON keys are the camelCase forms ASP.NET emits; tier is
+// the SubscriptionTier string ("Pro").
+type demoAccountResult struct {
+	UserID       string                  `json:"userId"`
+	Tier         string                  `json:"tier"`
+	WatchZone    demoWatchZoneResult     `json:"watchZone"`
+	Applications []demoApplicationResult `json:"applications"`
+}
+
+// demoWatchZoneResult mirrors .NET DemoWatchZoneResult. authorityName is the
+// council display name (not the stored zone name).
+type demoWatchZoneResult struct {
+	ZoneID        string  `json:"zoneId"`
+	AuthorityName string  `json:"authorityName"`
+	Latitude      float64 `json:"latitude"`
+	Longitude     float64 `json:"longitude"`
+	RadiusMetres  float64 `json:"radiusMetres"`
+}
+
+// demoApplicationResult mirrors .NET DemoApplicationResult — the trimmed
+// application projection the demo endpoint returns (no coordinates, dates, or
+// unread-event data). appType and appState are nullable, marshalling to null
+// when absent.
+type demoApplicationResult struct {
+	UID         string  `json:"uid"`
+	Name        string  `json:"name"`
+	Address     string  `json:"address"`
+	Description string  `json:"description"`
+	AppType     *string `json:"appType"`
+	AppState    *string `json:"appState"`
+}
+
+// applicationResultOf maps a domain snapshot to its demo wire projection,
+// mirroring .NET's new DemoApplicationResult(a.Uid, a.Name, a.Address,
+// a.Description, a.AppType, a.AppState).
+func applicationResultOf(a applications.PlanningApplication) demoApplicationResult {
+	return demoApplicationResult{
+		UID:         a.UID,
+		Name:        a.Name,
+		Address:     a.Address,
+		Description: a.Description,
+		AppType:     a.AppType,
+		AppState:    a.AppState,
+	}
+}

--- a/api-go/internal/demoaccount/seed.go
+++ b/api-go/internal/demoaccount/seed.go
@@ -1,0 +1,127 @@
+// Package demoaccount owns the App Store reviewer demo endpoint:
+// GET /v1/demo-account (anonymous). On first call for the fixed demo identity it
+// idempotently seeds Cosmos — a Pro-tier profile, a Westminster watch zone, and
+// five fixed Westminster planning applications — then returns the zone plus the
+// applications found within the zone via a spatial lookup. It mirrors the .NET
+// TownCrier.Application.DemoAccount slice (GH#418 iteration 7).
+//
+// The seed is a deliberate write side effect of a GET: it provisions a stable,
+// data-rich account so Apple's reviewer can exercise the paid experience without
+// a subscription. Subsequent calls find the profile already present and skip the
+// seed, so the endpoint is idempotent.
+package demoaccount
+
+import (
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+// Demo authority: every seeded application and the demo watch zone belong to
+// Westminster City Council, so the spatial lookup is scoped to its partition.
+const (
+	seedAuthorityName = "Westminster City Council"
+	seedAuthorityID   = 441
+)
+
+// strptr / dateptr return pointers to fixed seed values; the domain snapshot
+// carries nullable fields as pointers.
+func strptr(s string) *string { return &s }
+
+func dateptr(year int, month time.Month, day int) *time.Time {
+	d := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	return &d
+}
+
+func floatptr(f float64) *float64 { return &f }
+
+// seedApplications builds the five fixed Westminster demo applications, mirroring
+// .NET DemoSeedData.CreateApplications. lastDifferent is stamped with now (the
+// value is not part of the response, but is persisted for fidelity). Coordinates
+// place all five within the 2 km demo zone so the spatial lookup returns them.
+func seedApplications(now time.Time) []applications.PlanningApplication {
+	return []applications.PlanningApplication{
+		{
+			Name:          "24/05678/FULL",
+			UID:           "demo-app-001",
+			AreaName:      seedAuthorityName,
+			AreaID:        seedAuthorityID,
+			Address:       "10 Downing Street, London SW1A 2AA",
+			Postcode:      strptr("SW1A 2AA"),
+			Description:   "Replacement of entrance door and associated security improvements",
+			AppType:       strptr("Full"),
+			AppState:      strptr("Under consideration"),
+			StartDate:     dateptr(2026, time.January, 15),
+			ConsultedDate: dateptr(2026, time.February, 1),
+			Longitude:     floatptr(-0.1276),
+			Latitude:      floatptr(51.5034),
+			LastDifferent: now,
+		},
+		{
+			Name:          "24/05679/FULL",
+			UID:           "demo-app-002",
+			AreaName:      seedAuthorityName,
+			AreaID:        seedAuthorityID,
+			Address:       "Westminster Abbey, 20 Deans Yd, London SW1P 3PA",
+			Postcode:      strptr("SW1P 3PA"),
+			Description:   "Installation of new lighting system in the nave and restoration of stonework",
+			AppType:       strptr("Listed Building"),
+			AppState:      strptr("Permitted"),
+			StartDate:     dateptr(2025, time.November, 1),
+			DecidedDate:   dateptr(2026, time.February, 20),
+			ConsultedDate: dateptr(2025, time.December, 1),
+			Longitude:     floatptr(-0.1273),
+			Latitude:      floatptr(51.4993),
+			LastDifferent: now,
+		},
+		{
+			Name:          "24/05680/FULL",
+			UID:           "demo-app-003",
+			AreaName:      seedAuthorityName,
+			AreaID:        seedAuthorityID,
+			Address:       "Buckingham Palace, London SW1A 1AA",
+			Postcode:      strptr("SW1A 1AA"),
+			Description:   "Erection of temporary scaffolding for facade cleaning and minor repairs to roof drainage",
+			AppType:       strptr("Full"),
+			AppState:      strptr("Undecided"),
+			StartDate:     dateptr(2026, time.February, 10),
+			Longitude:     floatptr(-0.1419),
+			Latitude:      floatptr(51.5014),
+			LastDifferent: now,
+		},
+		{
+			Name:          "24/05681/FULL",
+			UID:           "demo-app-004",
+			AreaName:      seedAuthorityName,
+			AreaID:        seedAuthorityID,
+			Address:       "St James's Park, London SW1A 2BJ",
+			Postcode:      strptr("SW1A 2BJ"),
+			Description:   "Construction of new accessible footpath and installation of park benches",
+			AppType:       strptr("Full"),
+			AppState:      strptr("Rejected"),
+			StartDate:     dateptr(2025, time.October, 5),
+			DecidedDate:   dateptr(2026, time.January, 30),
+			ConsultedDate: dateptr(2025, time.November, 1),
+			Longitude:     floatptr(-0.1340),
+			Latitude:      floatptr(51.5025),
+			LastDifferent: now,
+		},
+		{
+			Name:          "24/05682/FULL",
+			UID:           "demo-app-005",
+			AreaName:      seedAuthorityName,
+			AreaID:        seedAuthorityID,
+			Address:       "Trafalgar Square, London WC2N 5DN",
+			Postcode:      strptr("WC2N 5DN"),
+			Description:   "Replacement of paving stones around the central fountain with conditions on materials and working hours",
+			AppType:       strptr("Full"),
+			AppState:      strptr("Conditions"),
+			StartDate:     dateptr(2025, time.September, 12),
+			DecidedDate:   dateptr(2026, time.January, 18),
+			ConsultedDate: dateptr(2025, time.October, 10),
+			Longitude:     floatptr(-0.1281),
+			Latitude:      floatptr(51.5080),
+			LastDifferent: now,
+		},
+	}
+}

--- a/api-go/internal/demoaccount/seed_test.go
+++ b/api-go/internal/demoaccount/seed_test.go
@@ -1,0 +1,48 @@
+package demoaccount
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestSeedApplications_AllInWestminsterAuthority(t *testing.T) {
+	t.Parallel()
+	apps := seedApplications(time.Now())
+	if len(apps) != 5 {
+		t.Fatalf("seed count: got %d, want 5", len(apps))
+	}
+	for _, a := range apps {
+		if a.AreaID != seedAuthorityID || a.AreaName != seedAuthorityName {
+			t.Errorf("%s: authority got id=%d name=%q", a.Name, a.AreaID, a.AreaName)
+		}
+		if a.Longitude == nil || a.Latitude == nil {
+			t.Errorf("%s: missing coordinates", a.Name)
+		}
+	}
+}
+
+// TestSeedApplications_WithinDemoRadius guards the contract the production
+// ST_DISTANCE query depends on: every seeded application must lie inside the
+// demo zone, or FindNearby would return fewer than five rows in prod (where the
+// fake here can't catch it). Distance is haversine, mirroring the in-memory
+// .NET repository's metric.
+func TestSeedApplications_WithinDemoRadius(t *testing.T) {
+	t.Parallel()
+	for _, a := range seedApplications(time.Now()) {
+		d := haversineMetres(demoLatitude, demoLongitude, *a.Latitude, *a.Longitude)
+		if d > demoRadiusMetres {
+			t.Errorf("%s is %.0fm from demo centre, outside the %dm radius", a.Name, d, demoRadiusMetres)
+		}
+	}
+}
+
+func haversineMetres(lat1, lon1, lat2, lon2 float64) float64 {
+	const earthRadiusMetres = 6_371_000
+	rad := func(d float64) float64 { return d * math.Pi / 180 }
+	dLat := rad(lat2 - lat1)
+	dLon := rad(lon2 - lon1)
+	h := math.Sin(dLat/2)*math.Sin(dLat/2) +
+		math.Cos(rad(lat1))*math.Cos(rad(lat2))*math.Sin(dLon/2)*math.Sin(dLon/2)
+	return earthRadiusMetres * 2 * math.Asin(math.Sqrt(h))
+}

--- a/api-go/tests/e2e/contract_demo_test.go
+++ b/api-go/tests/e2e/contract_demo_test.go
@@ -1,0 +1,31 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestContract_DemoAccount diffs GET /v1/demo-account between the deployed .NET
+// and Go APIs. The endpoint is anonymous (Apple's reviewer reaches it without a
+// token) and writes to Cosmos as a side effect: on first call it seeds the demo
+// Pro profile, the Westminster watch zone, and five fixed applications. Both
+// APIs share the same Cosmos account and the seed is gated on the profile's
+// absence, so the call is idempotent — whichever API runs first provisions the
+// data and both then observe the identical account. The .NET response is the
+// source of truth.
+func TestContract_DemoAccount(t *testing.T) {
+	dotnetURL := baseURL(t, "DOTNET_BASE_URL")
+	goURL := baseURL(t, "GO_BASE_URL")
+	client := &http.Client{Timeout: requestTimeout}
+
+	// Prime both APIs once so the (one-time) seed write completes before the
+	// diff: the first caller may seed while the second reads, and a freshly
+	// seeded vs already-seeded response is identical, so a single warm-up call to
+	// each removes any first-call seeding race from the comparison.
+	get(t, client, dotnetURL+"/v1/demo-account")
+	get(t, client, goURL+"/v1/demo-account")
+
+	diffPath(t, client, dotnetURL, goURL, "/v1/demo-account")
+}


### PR DESCRIPTION
## Summary

Ports `GET /v1/demo-account` (anonymous) from the .NET `DemoAccount` slice to the Go API (epic tc-7g3i / #418, iteration 7). On first call for the fixed App Store reviewer identity (`demo|apple-reviewer`), it idempotently seeds Cosmos — a Pro-tier profile (10y expiry), a Westminster watch zone, and five fixed Westminster planning applications — then returns the zone plus the applications found within it via a spatial lookup. The seed is gated on the profile's absence, so repeat calls skip straight to the lookup.

Also adds the `applications.FindNearby` store method (a single-partition `ST_DISTANCE` query scoped to the `authorityCode` partition), mirroring .NET `CosmosPlanningApplicationRepository.FindNearbyAsync`. **tc-5847** (watch-zone nearby POST + `GET /{zoneId}/applications`) reuses this method.

## Changes

- **`internal/demoaccount/`** (new package): handler + consumer-side store interfaces, seed data (5 fixtures), wire result shapes, respond helpers, unit tests.
- **`internal/applications/`**: `FindNearby` method + `QueryItems` on the consumer-side `CosmosItems` interface.
- **`cmd/api/wiring.go`**: route wired when the profile + watch-zone + application stores are all present; `/v1/demo-account` added to `anonymousPatterns`.
- **`tests/e2e/contract_demo_test.go`**: anonymous `GET` contract diff against deployed .NET (source of truth); shared Cosmos, idempotent seed.

## Notes

- The `ST_DISTANCE` query interpolates the GeoJSON point + radius as `float64` decimals (`strconv`), exactly as the production-proven .NET repository does — there is no injection surface (values are never user-supplied strings).
- A `seed_test` haversine check proves all five fixtures fall inside the 2 km demo zone, so the prod `ST_DISTANCE` query returns them — the unit fake can't catch a fixture drifting out of range.

## Verification

- `gofmt -l .` clean, `go vet ./...` clean, `golangci-lint run ./...` clean.
- `go test -race ./...` — 518 passed across 21 packages.
- `go build -tags e2e ./tests/...` + `go vet -tags e2e` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)