### PR TITLE
feat(go): it6 saved-app legacy migration + refresh-on-tap (tc-wans)

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -125,7 +125,15 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 		watchzones.AuthoritiesRoutes(mux, watchZoneStore, authorities.NewLookup(), logger)
 	}
 	if appStore != nil {
-		applications.Routes(mux, appStore, logger)
+		// Refresh-on-tap heals a saved row's snapshot when the user views an app
+		// they've saved; it needs the saved store. Pass a genuine nil interface
+		// (not a typed-nil pointer) when saving isn't wired, so the handler's
+		// nil-check disables the side effect cleanly.
+		if savedStore != nil {
+			applications.Routes(mux, appStore, savedapplications.NewSnapshotRefresher(savedStore, time.Now), logger)
+		} else {
+			applications.Routes(mux, appStore, nil, logger)
+		}
 	}
 	if store != nil && watchZoneStore != nil && appStore != nil && stateStore != nil && notifStore != nil {
 		// Watch-zone create (returns nearby applications) + the per-zone

--- a/api-go/internal/applications/handler.go
+++ b/api-go/internal/applications/handler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+
+	"github.com/AmyDe/town-crier/api-go/internal/auth"
 )
 
 // appStore is the consumer-side store the application read handler uses.
@@ -11,24 +13,34 @@ type appStore interface {
 	GetByAuthorityAndName(ctx context.Context, authorityCode, name string) (PlanningApplication, bool, error)
 }
 
+// snapshotRefresher is the consumer-side view of the saved-application
+// refresh-on-tap side effect. It is declared here, not imported from
+// savedapplications, because savedapplications already imports this package;
+// structural typing lets *savedapplications.SnapshotRefresher satisfy it without
+// an import cycle.
+type snapshotRefresher interface {
+	RefreshSnapshot(ctx context.Context, userID string, app PlanningApplication) error
+}
+
 // handler serves GET /v1/applications/{authorityCode}/{name}.
 type handler struct {
-	store  appStore
-	logger *slog.Logger
+	store     appStore
+	refresher snapshotRefresher
+	logger    *slog.Logger
 }
 
 // Routes registers the application read endpoint. The {name...} wildcard matches
 // the remainder of the path so a PlanIt case reference containing slashes (e.g.
-// "24/0123/FUL") is captured whole, mirroring the .NET {**name} catch-all.
-func Routes(mux *http.ServeMux, store appStore, logger *slog.Logger) {
-	h := &handler{store: store, logger: logger}
+// "24/0123/FUL") is captured whole, mirroring the .NET {**name} catch-all. The
+// refresher is optional (nil disables refresh-on-tap).
+func Routes(mux *http.ServeMux, store appStore, refresher snapshotRefresher, logger *slog.Logger) {
+	h := &handler{store: store, refresher: refresher, logger: logger}
 	mux.HandleFunc("GET /v1/applications/{authorityCode}/{name...}", h.getByAuthorityAndName)
 }
 
 // getByAuthorityAndName point-reads an application by (authorityCode, name) and
 // returns it, or a bodyless 404 when it is not in Cosmos — there is no PlanIt
-// fallback (GH#395 Invariant 1). Refresh-on-tap (the saved-snapshot heal side
-// effect) is deferred to bead tc-wans.
+// fallback (GH#395 Invariant 1).
 func (h *handler) getByAuthorityAndName(w http.ResponseWriter, r *http.Request) {
 	authorityCode := r.PathValue("authorityCode")
 	name := r.PathValue("name")
@@ -42,5 +54,17 @@ func (h *handler) getByAuthorityAndName(w http.ResponseWriter, r *http.Request) 
 		w.WriteHeader(http.StatusNotFound)
 		return
 	}
+
+	// Refresh-on-tap: if the requesting user has this application saved, heal
+	// their saved snapshot as a best-effort side effect. It must never fail the
+	// read, so errors are logged and swallowed (mirrors .NET TryRefreshSavedSnapshotAsync).
+	if h.refresher != nil {
+		if userID := auth.Subject(r.Context()); userID != "" {
+			if err := h.refresher.RefreshSnapshot(r.Context(), userID, app); err != nil {
+				h.logger.WarnContext(r.Context(), "refresh-on-tap failed", "user", userID, "uid", app.UID, "error", err)
+			}
+		}
+	}
+
 	writeJSON(w, r, h.logger, ResultOf(app))
 }

--- a/api-go/internal/applications/handler_test.go
+++ b/api-go/internal/applications/handler_test.go
@@ -26,11 +26,37 @@ func (f *fakeAppStore) GetByAuthorityAndName(_ context.Context, authorityCode, n
 	return f.app, f.found, f.err
 }
 
+type refreshCall struct {
+	userID string
+	app    PlanningApplication
+}
+
+type fakeRefresher struct {
+	calls []refreshCall
+	err   error
+}
+
+func (f *fakeRefresher) RefreshSnapshot(_ context.Context, userID string, app PlanningApplication) error {
+	f.calls = append(f.calls, refreshCall{userID: userID, app: app})
+	return f.err
+}
+
+// serveGet drives the read endpoint with a refresher absent (the nil-safe path)
+// and an authenticated subject.
 func serveGet(t *testing.T, store appStore, path string) *httptest.ResponseRecorder {
 	t.Helper()
+	return serveGetWith(t, store, nil, "auth0|u", path)
+}
+
+func serveGetWith(t *testing.T, store appStore, refresher snapshotRefresher, subject, path string) *httptest.ResponseRecorder {
+	t.Helper()
 	mux := http.NewServeMux()
-	Routes(mux, store, slog.New(slog.DiscardHandler))
-	req := httptest.NewRequestWithContext(auth.WithSubject(context.Background(), "auth0|u"), http.MethodGet, path, nil)
+	Routes(mux, store, refresher, slog.New(slog.DiscardHandler))
+	ctx := context.Background()
+	if subject != "" {
+		ctx = auth.WithSubject(ctx, subject)
+	}
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, path, nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	return rec
@@ -85,5 +111,63 @@ func TestHandler_GetByAuthorityAndName_StoreError(t *testing.T) {
 	rec := serveGet(t, &fakeAppStore{err: context.DeadlineExceeded}, "/v1/applications/471/x")
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("status: got %d, want 500", rec.Code)
+	}
+}
+
+func TestHandler_GetByAuthorityAndName_RefreshesOnTap(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	refresher := &fakeRefresher{}
+	rec := serveGetWith(t, &fakeAppStore{app: a, found: true}, refresher, "auth0|u", "/v1/applications/471/24/0123/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if len(refresher.calls) != 1 {
+		t.Fatalf("expected one refresh call, got %d", len(refresher.calls))
+	}
+	if refresher.calls[0].userID != "auth0|u" || refresher.calls[0].app.UID != a.UID {
+		t.Errorf("refresh call: %+v", refresher.calls[0])
+	}
+}
+
+func TestHandler_GetByAuthorityAndName_RefreshFailureDoesNotFailRead(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	refresher := &fakeRefresher{err: context.DeadlineExceeded}
+	rec := serveGetWith(t, &fakeAppStore{app: a, found: true}, refresher, "auth0|u", "/v1/applications/471/24/0123/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("refresh error must not fail the read: got %d, want 200", rec.Code)
+	}
+	if rec.Body.Len() == 0 {
+		t.Error("body must still be written on refresh failure")
+	}
+}
+
+func TestHandler_GetByAuthorityAndName_NoRefreshWhenNotFound(t *testing.T) {
+	t.Parallel()
+	refresher := &fakeRefresher{}
+	rec := serveGetWith(t, &fakeAppStore{found: false}, refresher, "auth0|u", "/v1/applications/471/missing")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+	if len(refresher.calls) != 0 {
+		t.Errorf("must not refresh a missing application: %+v", refresher.calls)
+	}
+}
+
+func TestHandler_GetByAuthorityAndName_NoRefreshWhenAnonymous(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	refresher := &fakeRefresher{}
+	rec := serveGetWith(t, &fakeAppStore{app: a, found: true}, refresher, "", "/v1/applications/471/24/0123/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if len(refresher.calls) != 0 {
+		t.Errorf("must not refresh without an authenticated subject: %+v", refresher.calls)
 	}
 }

--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -67,6 +67,27 @@ func (s *CosmosStore) GetByAuthorityAndName(ctx context.Context, authorityCode, 
 	return doc.toDomain(), true, nil
 }
 
+// GetByUID looks up an application by its raw PlanIt uid within the authorityCode
+// partition, via a single-partition query on the uid field. It mirrors .NET
+// GetByUidAsync(uid, authorityCode): used by the saved-application lazy snapshot
+// backfill, where a legacy row holds the bare uid and the authority is known.
+// The boolean reports presence; a miss is normal (the master record may be gone).
+func (s *CosmosStore) GetByUID(ctx context.Context, uid, authorityCode string) (PlanningApplication, bool, error) {
+	const query = "SELECT * FROM c WHERE c.uid = @uid"
+	raws, err := s.items.QueryItems(ctx, authorityCode, query, map[string]any{"@uid": uid})
+	if err != nil {
+		return PlanningApplication{}, false, fmt.Errorf("query application uid %q in %q: %w", uid, authorityCode, err)
+	}
+	if len(raws) == 0 {
+		return PlanningApplication{}, false, nil
+	}
+	var doc applicationDocument
+	if err := json.Unmarshal(raws[0], &doc); err != nil {
+		return PlanningApplication{}, false, fmt.Errorf("decode application uid %q: %w", uid, err)
+	}
+	return doc.toDomain(), true, nil
+}
+
 // FindNearby returns every application within radiusMetres of (latitude,
 // longitude) inside the authorityCode partition, via a single-partition
 // ST_DISTANCE spatial query against the GeoJSON location. It mirrors .NET

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -110,6 +110,46 @@ func TestCosmosStore_GetByAuthorityAndName_NotFound(t *testing.T) {
 	}
 }
 
+func TestCosmosStore_GetByUID_PartitionScopedQuery(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	body, _ := json.Marshal(newApplicationDocument(a))
+	items := newFakeItems()
+	items.queryResult = [][]byte{body}
+	store := NewCosmosStore(items)
+
+	got, found, err := store.GetByUID(context.Background(), a.UID, strconv.Itoa(a.AreaID))
+	if err != nil {
+		t.Fatalf("GetByUID: %v", err)
+	}
+	if !found {
+		t.Fatal("expected found")
+	}
+	if got.UID != a.UID || got.Name != a.Name {
+		t.Errorf("got %+v", got)
+	}
+	if items.lastQueryPK != strconv.Itoa(a.AreaID) {
+		t.Errorf("query partition key: got %q, want %q", items.lastQueryPK, strconv.Itoa(a.AreaID))
+	}
+	want := "SELECT * FROM c WHERE c.uid = @uid"
+	if items.lastQuery != want {
+		t.Errorf("uid query:\n got %q\nwant %q", items.lastQuery, want)
+	}
+}
+
+func TestCosmosStore_GetByUID_NotFound(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+
+	_, found, err := store.GetByUID(context.Background(), "missing-uid", "471")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if found {
+		t.Error("expected not found")
+	}
+}
+
 func TestCosmosStore_FindNearby_ScopesToAuthorityPartitionWithSpatialQuery(t *testing.T) {
 	t.Parallel()
 	a := testApplication(t)

--- a/api-go/internal/savedapplications/handler.go
+++ b/api-go/internal/savedapplications/handler.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,15 +31,18 @@ type savedStore interface {
 	GetByUserID(ctx context.Context, userID string) ([]SavedApplication, error)
 }
 
-// appUpserter writes the master planning-application record so a save always
-// points at a known application (the search path no longer upserts).
-type appUpserter interface {
+// appStore is the consumer-side planning-application store the saved handler
+// needs: an upsert so a save always points at a known master record (the search
+// path no longer upserts), and a partition-scoped uid lookup used by the lazy
+// snapshot backfill for legacy rows.
+type appStore interface {
 	Upsert(ctx context.Context, a applications.PlanningApplication) error
+	GetByUID(ctx context.Context, uid, authorityCode string) (applications.PlanningApplication, bool, error)
 }
 
 type handler struct {
 	store  savedStore
-	apps   appUpserter
+	apps   appStore
 	now    func() time.Time
 	logger *slog.Logger
 }
@@ -46,7 +50,7 @@ type handler struct {
 // Routes registers the saved-application endpoints. PUT/DELETE use a {**uid}
 // catch-all so a slash-bearing application uid is captured whole, mirroring the
 // .NET {**applicationUid} route.
-func Routes(mux *http.ServeMux, store savedStore, apps appUpserter, now func() time.Time, logger *slog.Logger) {
+func Routes(mux *http.ServeMux, store savedStore, apps appStore, now func() time.Time, logger *slog.Logger) {
 	h := &handler{store: store, apps: apps, now: now, logger: logger}
 	mux.HandleFunc("PUT /v1/me/saved-applications/{applicationUid...}", h.save)
 	mux.HandleFunc("DELETE /v1/me/saved-applications/{applicationUid...}", h.delete)
@@ -161,10 +165,12 @@ type savedEntry struct {
 }
 
 // list implements GET /v1/me/saved-applications, returning a JSON array of the
-// user's saved applications rendered from their embedded snapshots. Rows whose
-// snapshot is absent (legacy, pre-snapshot-column) are skipped here; the lazy
-// backfill / re-key / dedup machinery the .NET handler runs for them is deferred
-// to bead tc-wans.
+// user's saved applications rendered from their embedded snapshots. It runs the
+// lazy migration the .NET GetSavedApplicationsQueryHandler runs on every read,
+// reachable only by pre-PR#398 legacy data: (1) backfill the snapshot for rows
+// persisted before the snapshot column existed, (2) re-key legacy bare-ref uids
+// to the canonical {areaId}/{name} uid, (3) dedup a legacy+canonical pair for
+// the same application to a single row.
 func (h *handler) list(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 
@@ -173,18 +179,103 @@ func (h *handler) list(w http.ResponseWriter, r *http.Request) {
 		h.serverError(w, r, "list saved applications", err)
 		return
 	}
+
+	// Track the canonical uids already emitted this read so a legacy+canonical
+	// duplicate pair for the same app collapses to a single row.
+	emitted := make(map[string]struct{}, len(saved))
 	entries := make([]savedEntry, 0, len(saved))
-	for _, s := range saved {
-		if s.Application == nil {
+	for _, record := range saved {
+		hydrated, ok, err := h.hydrate(r.Context(), record)
+		if err != nil {
+			h.serverError(w, r, "hydrate saved application", err)
+			return
+		}
+		if !ok {
+			// Master record gone — exclude rather than failing the whole list.
 			continue
 		}
+
+		canonical := hydrated
+		if isLegacyKeyed(hydrated) {
+			canonical, err = h.reKeyToCanonical(r.Context(), hydrated)
+			if err != nil {
+				h.serverError(w, r, "re-key saved application", err)
+				return
+			}
+		}
+
+		if _, seen := emitted[canonical.ApplicationUID]; seen {
+			continue
+		}
+		emitted[canonical.ApplicationUID] = struct{}{}
 		entries = append(entries, savedEntry{
-			ApplicationUID: s.ApplicationUID,
-			SavedAt:        platform.DotNetTime(s.SavedAt),
-			Application:    applications.ResultOf(*s.Application),
+			ApplicationUID: canonical.ApplicationUID,
+			SavedAt:        platform.DotNetTime(canonical.SavedAt),
+			Application:    applications.ResultOf(*canonical.Application),
 		})
 	}
 	h.writeJSON(w, r, entries)
+}
+
+// isLegacyKeyed reports whether a row is keyed on a legacy bare-ref uid rather
+// than the canonical {areaId}/{name} uid. Only decidable once the snapshot is
+// embedded — the canonical uid is derived from the snapshot.
+func isLegacyKeyed(record SavedApplication) bool {
+	return record.Application != nil && record.ApplicationUID != record.Application.CanonicalUID()
+}
+
+// hydrate ensures the saved record carries an embedded snapshot. Rows persisted
+// before the snapshot column existed hold only the uid; they are backfilled once
+// via the partition-scoped planning lookup and rewritten in place so subsequent
+// reads are zero-hydration. The bool is false when the master planning
+// application is gone (the row is excluded). The row's existing ApplicationUID is
+// preserved — re-keying happens separately so the two steps stay independent.
+func (h *handler) hydrate(ctx context.Context, record SavedApplication) (SavedApplication, bool, error) {
+	if record.Application != nil {
+		return record, true, nil
+	}
+
+	authorityCode := strconv.Itoa(record.AuthorityID)
+	fetched, found, err := h.apps.GetByUID(ctx, record.ApplicationUID, authorityCode)
+	if err != nil {
+		return SavedApplication{}, false, err
+	}
+	if !found {
+		return SavedApplication{}, false, nil
+	}
+
+	refreshed := record.withEmbeddedSnapshot(fetched)
+	if err := h.store.Save(ctx, refreshed); err != nil {
+		return SavedApplication{}, false, err
+	}
+	return refreshed, true, nil
+}
+
+// reKeyToCanonical re-keys a legacy-format saved row to the canonical
+// {areaId}/{name} uid. Cosmos doc ids are immutable, so a re-key is a write of
+// the canonical doc plus a delete of the legacy doc. When a canonical doc already
+// exists for the same user+app (the confirmed legacy+canonical duplicate case)
+// the canonical doc is kept untouched and only the legacy doc is deleted.
+func (h *handler) reKeyToCanonical(ctx context.Context, legacy SavedApplication) (SavedApplication, error) {
+	canonical := NewSavedApplication(legacy.UserID, *legacy.Application, legacy.SavedAt)
+
+	exists, err := h.store.Exists(ctx, canonical.UserID, canonical.ApplicationUID)
+	if err != nil {
+		return SavedApplication{}, err
+	}
+	if !exists {
+		// Write the canonical doc before deleting the legacy one so an interrupted
+		// run leaves a recoverable duplicate, never a lost save.
+		if err := h.store.Save(ctx, canonical); err != nil {
+			return SavedApplication{}, err
+		}
+	}
+
+	// The canonical doc is the survivor — drop the legacy duplicate.
+	if err := h.store.Delete(ctx, legacy.UserID, legacy.ApplicationUID); err != nil {
+		return SavedApplication{}, err
+	}
+	return canonical, nil
 }
 
 func dateToTime(d *platform.DateOnly) *time.Time {

--- a/api-go/internal/savedapplications/handler_test.go
+++ b/api-go/internal/savedapplications/handler_test.go
@@ -40,6 +40,7 @@ func (f *fakeSavedStore) GetByUserID(_ context.Context, _ string) ([]SavedApplic
 
 type fakeApps struct {
 	upserted []applications.PlanningApplication
+	byUID    map[string]applications.PlanningApplication
 }
 
 func (f *fakeApps) Upsert(_ context.Context, a applications.PlanningApplication) error {
@@ -47,7 +48,12 @@ func (f *fakeApps) Upsert(_ context.Context, a applications.PlanningApplication)
 	return nil
 }
 
-func testMux(t *testing.T, store savedStore, apps appUpserter) *http.ServeMux {
+func (f *fakeApps) GetByUID(_ context.Context, uid, _ string) (applications.PlanningApplication, bool, error) {
+	a, ok := f.byUID[uid]
+	return a, ok, nil
+}
+
+func testMux(t *testing.T, store savedStore, apps appStore) *http.ServeMux {
 	t.Helper()
 	mux := http.NewServeMux()
 	now := func() time.Time { return time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC) }
@@ -177,12 +183,93 @@ func TestHandler_List_EmptyArray(t *testing.T) {
 	}
 }
 
-func TestHandler_List_SkipsNilSnapshotRows(t *testing.T) {
+func TestHandler_List_BackfillsNilSnapshotFromMaster(t *testing.T) {
 	t.Parallel()
-	// A legacy row with no embedded snapshot is skipped (backfill deferred to tc-wans).
-	store := &fakeSavedStore{rows: []SavedApplication{{UserID: user, ApplicationUID: "legacy", AuthorityID: 1, Application: nil}}}
+	now := time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC)
+	// A canonical-keyed legacy row with no embedded snapshot: hydrate fetches the
+	// master record, embeds it, and rewrites the row in place.
+	legacy := SavedApplication{UserID: user, ApplicationUID: "471/24/0123/FUL", AuthorityID: 471, SavedAt: now, Application: nil}
+	store := &fakeSavedStore{rows: []SavedApplication{legacy}}
+	apps := &fakeApps{byUID: map[string]applications.PlanningApplication{"471/24/0123/FUL": testApp(t)}}
+
+	rec := doReq(t, testMux(t, store, apps), http.MethodGet, "/v1/me/saved-applications", "")
+
+	var got []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 || got[0]["applicationUid"] != "471/24/0123/FUL" {
+		t.Fatalf("backfilled row not rendered: %+v", got)
+	}
+	app, ok := got[0]["application"].(map[string]any)
+	if !ok || app["uid"] != "ABC-24-0123" {
+		t.Errorf("snapshot not embedded after backfill: %+v", got[0]["application"])
+	}
+	// The backfilled snapshot is persisted so subsequent reads are zero-hydration.
+	if len(store.saved) != 1 || store.saved[0].Application == nil {
+		t.Errorf("backfilled row must be persisted: %+v", store.saved)
+	}
+}
+
+func TestHandler_List_SkipsRowWhenMasterGone(t *testing.T) {
+	t.Parallel()
+	// Nil-snapshot row whose master planning application no longer exists is
+	// excluded rather than failing the whole list.
+	legacy := SavedApplication{UserID: user, ApplicationUID: "gone", AuthorityID: 471, Application: nil}
+	store := &fakeSavedStore{rows: []SavedApplication{legacy}}
 	rec := doReq(t, testMux(t, store, &fakeApps{}), http.MethodGet, "/v1/me/saved-applications", "")
+
 	if body := strings.TrimSpace(rec.Body.String()); body != `[]` {
-		t.Errorf("nil-snapshot row must be skipped, got %s", body)
+		t.Errorf("row with missing master must be skipped, got %s", body)
+	}
+}
+
+func TestHandler_List_ReKeysLegacyUidToCanonical(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC)
+	app := testApp(t)
+	// Legacy row: snapshot present but keyed on the raw PlanIt bare ref.
+	legacy := SavedApplication{UserID: user, ApplicationUID: "ABC-1", AuthorityID: 471, SavedAt: now, Application: &app}
+	store := &fakeSavedStore{rows: []SavedApplication{legacy}, exists: false}
+
+	rec := doReq(t, testMux(t, store, &fakeApps{}), http.MethodGet, "/v1/me/saved-applications", "")
+
+	var got []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 || got[0]["applicationUid"] != "471/24/0123/FUL" {
+		t.Fatalf("legacy uid not re-keyed to canonical: %+v", got)
+	}
+	// Canonical doc written, legacy doc deleted.
+	if len(store.saved) != 1 || store.saved[0].ApplicationUID != "471/24/0123/FUL" {
+		t.Errorf("canonical doc not written: %+v", store.saved)
+	}
+	if len(store.deletedUID) != 1 || store.deletedUID[0] != "ABC-1" {
+		t.Errorf("legacy doc not deleted: %+v", store.deletedUID)
+	}
+}
+
+func TestHandler_List_DedupsLegacyAndCanonicalPair(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC)
+	app := testApp(t)
+	legacy := SavedApplication{UserID: user, ApplicationUID: "ABC-1", AuthorityID: 471, SavedAt: now, Application: &app}
+	canonical := NewSavedApplication(user, testApp(t), now)
+	// Both rows resolve to the same canonical uid; the canonical doc already exists.
+	store := &fakeSavedStore{rows: []SavedApplication{legacy, canonical}, exists: true}
+
+	rec := doReq(t, testMux(t, store, &fakeApps{}), http.MethodGet, "/v1/me/saved-applications", "")
+
+	var got []map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 || got[0]["applicationUid"] != "471/24/0123/FUL" {
+		t.Fatalf("legacy+canonical pair must collapse to one row: %+v", got)
+	}
+	// Canonical already existed, so re-key only drops the legacy duplicate.
+	if len(store.deletedUID) != 1 || store.deletedUID[0] != "ABC-1" {
+		t.Errorf("legacy duplicate not dropped: %+v", store.deletedUID)
 	}
 }

--- a/api-go/internal/savedapplications/refresher.go
+++ b/api-go/internal/savedapplications/refresher.go
@@ -1,0 +1,72 @@
+package savedapplications
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+// snapshotStore is the consumer-side slice of the saved-application store the
+// refresher needs: a presence check, the user's rows (to recover the original
+// SavedAt), and an upsert. *CosmosStore satisfies it structurally.
+type snapshotStore interface {
+	Exists(ctx context.Context, userID, applicationUID string) (bool, error)
+	GetByUserID(ctx context.Context, userID string) ([]SavedApplication, error)
+	Save(ctx context.Context, sa SavedApplication) error
+}
+
+// SnapshotRefresher implements refresh-on-tap: when a user views an application
+// they have already saved, re-embed the fresh snapshot into their saved row so
+// the saved list self-heals on the items they actually engage with. Mirrors the
+// .NET GetApplicationBy{Uid,AuthorityAndName}QueryHandler.TryRefreshSavedSnapshotAsync
+// (bd tc-udby, tc-o88i).
+type SnapshotRefresher struct {
+	store snapshotStore
+	now   func() time.Time
+}
+
+// NewSnapshotRefresher returns a refresher over the given saved-application store.
+func NewSnapshotRefresher(store snapshotStore, now func() time.Time) *SnapshotRefresher {
+	return &SnapshotRefresher{store: store, now: now}
+}
+
+// RefreshSnapshot re-saves the user's saved row for app with a fresh embedded
+// snapshot, keyed on the canonical {areaId}/{name} uid. It is a no-op when the
+// user has not saved the application. The original SavedAt is preserved by
+// reading the existing row; if that row has vanished mid-flight the current time
+// is used. Callers treat this as a best-effort side effect — an error here must
+// never fail the user's read.
+func (r *SnapshotRefresher) RefreshSnapshot(ctx context.Context, userID string, app applications.PlanningApplication) error {
+	// Saved rows are keyed on the canonical uid, not the master record's raw uid
+	// field. Aligning the presence check on CanonicalUID is what makes healing
+	// fire for stale-format saves (bd tc-o88i).
+	canonicalUID := app.CanonicalUID()
+	exists, err := r.store.Exists(ctx, userID, canonicalUID)
+	if err != nil {
+		return fmt.Errorf("check saved snapshot %q: %w", canonicalUID, err)
+	}
+	if !exists {
+		return nil
+	}
+
+	// Preserve the original SavedAt by reading the existing row; fall back to the
+	// current time when the row has vanished mid-flight.
+	savedAt := r.now()
+	rows, err := r.store.GetByUserID(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("load saved rows for refresh: %w", err)
+	}
+	for _, row := range rows {
+		if row.ApplicationUID == canonicalUID {
+			savedAt = row.SavedAt
+			break
+		}
+	}
+
+	if err := r.store.Save(ctx, NewSavedApplication(userID, app, savedAt)); err != nil {
+		return fmt.Errorf("save refreshed snapshot %q: %w", canonicalUID, err)
+	}
+	return nil
+}

--- a/api-go/internal/savedapplications/refresher_test.go
+++ b/api-go/internal/savedapplications/refresher_test.go
@@ -1,0 +1,125 @@
+package savedapplications
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeSnapshotStore struct {
+	existsResult bool
+	existsErr    error
+	rows         []SavedApplication
+	rowsErr      error
+	saved        []SavedApplication
+	saveErr      error
+}
+
+func (f *fakeSnapshotStore) Exists(_ context.Context, _, _ string) (bool, error) {
+	return f.existsResult, f.existsErr
+}
+
+func (f *fakeSnapshotStore) GetByUserID(_ context.Context, _ string) ([]SavedApplication, error) {
+	return f.rows, f.rowsErr
+}
+
+func (f *fakeSnapshotStore) Save(_ context.Context, sa SavedApplication) error {
+	if f.saveErr != nil {
+		return f.saveErr
+	}
+	f.saved = append(f.saved, sa)
+	return nil
+}
+
+func fixedNow() func() time.Time {
+	return func() time.Time { return time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC) }
+}
+
+func TestSnapshotRefresher_NoOpWhenNotSaved(t *testing.T) {
+	t.Parallel()
+	store := &fakeSnapshotStore{existsResult: false}
+	r := NewSnapshotRefresher(store, fixedNow())
+
+	if err := r.RefreshSnapshot(context.Background(), user, testApp(t)); err != nil {
+		t.Fatalf("RefreshSnapshot: %v", err)
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("must not save when application is not already saved: %+v", store.saved)
+	}
+}
+
+func TestSnapshotRefresher_PreservesSavedAtAndRefreshesSnapshot(t *testing.T) {
+	t.Parallel()
+	original := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	stale := testApp(t)
+	stale.Description = "stale description"
+	store := &fakeSnapshotStore{
+		existsResult: true,
+		rows:         []SavedApplication{NewSavedApplication(user, stale, original)},
+	}
+	r := NewSnapshotRefresher(store, fixedNow())
+
+	fresh := testApp(t)
+	fresh.Description = "fresh description"
+	if err := r.RefreshSnapshot(context.Background(), user, fresh); err != nil {
+		t.Fatalf("RefreshSnapshot: %v", err)
+	}
+	if len(store.saved) != 1 {
+		t.Fatalf("expected one refreshed save, got %+v", store.saved)
+	}
+	got := store.saved[0]
+	if !got.SavedAt.Equal(original) {
+		t.Errorf("savedAt: got %v, want preserved %v", got.SavedAt, original)
+	}
+	if got.ApplicationUID != fresh.CanonicalUID() {
+		t.Errorf("applicationUid: got %q, want canonical %q", got.ApplicationUID, fresh.CanonicalUID())
+	}
+	if got.Application == nil || got.Application.Description != "fresh description" {
+		t.Errorf("snapshot not refreshed: %+v", got.Application)
+	}
+}
+
+func TestSnapshotRefresher_FallsBackToNowWhenRowVanished(t *testing.T) {
+	t.Parallel()
+	// Row exists at the presence check but has vanished by the list read.
+	store := &fakeSnapshotStore{existsResult: true, rows: nil}
+	r := NewSnapshotRefresher(store, fixedNow())
+
+	if err := r.RefreshSnapshot(context.Background(), user, testApp(t)); err != nil {
+		t.Fatalf("RefreshSnapshot: %v", err)
+	}
+	if len(store.saved) != 1 {
+		t.Fatalf("expected one save, got %+v", store.saved)
+	}
+	if !store.saved[0].SavedAt.Equal(fixedNow()()) {
+		t.Errorf("savedAt: got %v, want now %v", store.saved[0].SavedAt, fixedNow()())
+	}
+}
+
+func TestSnapshotRefresher_PropagatesStoreErrors(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("boom")
+	tests := map[string]*fakeSnapshotStore{
+		"exists error": {existsErr: wantErr},
+		"list error":   {existsResult: true, rowsErr: wantErr},
+		"save error":   {existsResult: true, saveErr: wantErr},
+	}
+	for name, store := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			r := NewSnapshotRefresher(store, fixedNow())
+			err := r.RefreshSnapshot(context.Background(), user, testApp(t))
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("got err=%v, want wrapped %v", err, wantErr)
+			}
+			if name != "save error" && len(store.saved) != 0 {
+				t.Errorf("must not save on pre-save error: %+v", store.saved)
+			}
+		})
+	}
+}
+
+// Compile-time assertion that *CosmosStore satisfies the refresher's consumer
+// interface, so the production wiring in wiring.go stays valid.
+var _ snapshotStore = (*CosmosStore)(nil)

--- a/api-go/internal/savedapplications/saved.go
+++ b/api-go/internal/savedapplications/saved.go
@@ -43,3 +43,13 @@ func NewSavedApplication(userID string, app applications.PlanningApplication, no
 		Application:    &snapshot,
 	}
 }
+
+// withEmbeddedSnapshot returns a copy of the saved record with app embedded as
+// its snapshot, keeping the existing ApplicationUID and SavedAt. Re-keying to the
+// canonical uid is a separate step, so the lazy backfill and the re-key stay
+// independently testable. Mirrors .NET SavedApplication.WithEmbeddedSnapshot.
+func (s SavedApplication) withEmbeddedSnapshot(app applications.PlanningApplication) SavedApplication {
+	snapshot := app
+	s.Application = &snapshot
+	return s
+}


### PR DESCRIPTION
## What

Completes Go API iteration 6 parity (epic tc-7g3i / GH #418) by porting the saved-application migration behaviours the .NET `GetSavedApplicationsQueryHandler` runs on every saved-list read, plus the refresh-on-tap snapshot heal. These paths are reachable only by pre-PR#398 legacy data, so they were deferred from tc-7g3i.7 to keep it6 tractable (bead **tc-wans**).

## Changes

- **`applications.CosmosStore.GetByUID(uid, authorityCode)`** — partition-scoped uid query mirroring .NET `GetByUidAsync`, used by the lazy snapshot backfill.
- **`savedapplications.SnapshotRefresher`** — refresh-on-tap: re-saves a user's saved row with a fresh embedded snapshot when they view a saved app, preserving the original `SavedAt` (falls back to now when the row vanished mid-flight). Best-effort — never fails the read.
- **applications read handler** — wires refresh-on-tap via a consumer-side `snapshotRefresher` interface declared in `applications` (not imported from `savedapplications`) to avoid the import cycle. Nil-safe; skipped for anonymous callers and 404s.
- **savedapplications list handler** — now hydrates nil-snapshot rows from the master record, re-keys legacy bare-ref uids to the canonical `{areaId}/{name}` uid, and dedups a legacy+canonical pair to a single row (replacing the prior nil-snapshot skip). Master-gone rows are excluded rather than failing the whole list.
- **wiring** — passes a genuine nil interface (not a typed-nil pointer) when the saved store is absent, so the refresh-on-tap nil-check disables cleanly.

## Testing

Migration/refresh paths are unreachable by the contract suite (no legacy data in a fresh flow), so unit tests are the safety net: GetByUID (hit/miss), SnapshotRefresher (no-op/preserve-SavedAt/fallback-now/error-propagation), refresh-on-tap handler (fires/failure-tolerant/skip-on-404/skip-anonymous), and list migration (backfill/master-gone/re-key/dedup).

GATE: `gofmt`/`go vet`/`golangci-lint` clean, **558 tests pass under `-race`**, `go build -tags e2e` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)