### PR TITLE
feat(infra+ci): wire ADMIN_API_KEY onto Go dev app + contract job (tc-52t6)

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -469,6 +469,10 @@ jobs:
           INTEGRATION_TEST_AUTH0_AUDIENCE: ${{ vars.VITE_AUTH0_AUDIENCE }}
           INTEGRATION_TEST_USERNAME: ${{ secrets.INTEGRATION_TEST_USERNAME }}
           INTEGRATION_TEST_PASSWORD: ${{ secrets.INTEGRATION_TEST_PASSWORD }}
+          # Same shared admin key the .NET app is deployed with, so the
+          # offer-code/admin contract diffs can exercise the X-Admin-Key surface.
+          # Scenarios skip when this is unset locally.
+          ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
         run: go test -tags e2e -v ./tests/e2e/...
         working-directory: api-go
 

--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -414,6 +414,10 @@ public static class EnvironmentStack
                         new SecretArgs { Name = "auth0-m2m-client-id", Value = auth0M2mClientId },
                         new SecretArgs { Name = "auth0-m2m-client-secret", Value = auth0M2mClientSecret },
                         new SecretArgs { Name = "auto-grant-pro-domains", Value = autoGrantProDomains },
+                        // Same admin key as the .NET app so the Go X-Admin-Key gate
+                        // accepts identical requests — required by the offer-code/admin
+                        // contract diffs (tc-52t6).
+                        new SecretArgs { Name = "admin-api-key", Value = adminApiKey },
                     },
                 },
                 Identity = new Pulumi.AzureNative.App.Inputs.ManagedServiceIdentityArgs
@@ -453,6 +457,7 @@ public static class EnvironmentStack
                                 new EnvironmentVarArgs { Name = "AUTH0_M2M_CLIENT_ID", SecretRef = "auth0-m2m-client-id" },
                                 new EnvironmentVarArgs { Name = "AUTH0_M2M_CLIENT_SECRET", SecretRef = "auth0-m2m-client-secret" },
                                 new EnvironmentVarArgs { Name = "SUBSCRIPTION_AUTOGRANT_PRODOMAINS", SecretRef = "auto-grant-pro-domains" },
+                                new EnvironmentVarArgs { Name = "ADMIN_API_KEY", SecretRef = "admin-api-key" },
                             },
                         },
                     },


### PR DESCRIPTION
## What

First half of **tc-52t6** (epic tc-7g3i / GH #418): enable the offer-code/admin contract diffs by giving the Go dev app the same admin key the .NET app already carries, so the `X-Admin-Key` gate accepts identical requests.

- **infra** (`EnvironmentStack.cs`): add the `admin-api-key` secret (from the existing `adminApiKey` config) and the `ADMIN_API_KEY` env var to `ca-town-crier-api-go-dev`, mirroring the .NET app's `Admin__ApiKey` wiring.
- **ci** (`pr-gate.yml`): pass the existing `ADMIN_API_KEY` secret into the Go contract-test job env.

## Why split

The contract tests that exercise this surface need the *deployed* Go app to already carry the key — which only happens after `cd-dev` applies this Pulumi change on merge. A combined PR would fail its own gate (the staged revision wouldn't have the key yet). This mirrors the established infra-then-tests ordering (#423 → #424). The dependent tests land in a follow-up PR.

## Testing

`dotnet build` on `/infra` passes (0 errors). No Go code changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)