### PR TITLE
docs(go): record why subscription happy-path has no live contract diff (tc-dpfn)

### DIFF
--- a/api-go/tests/e2e/contract_subscriptions_test.go
+++ b/api-go/tests/e2e/contract_subscriptions_test.go
@@ -22,8 +22,20 @@ import (
 // class of end-to-end bug as the .NET product-ID typo (tc-7g3i.12). Go binds the
 // camelCase body (encoding/json is case-insensitive) and is the first correct
 // implementation, so its JWS-failure path (401) diverges from .NET's bugged 400
-// by design. That path is unit-tested in internal/subscriptions; the happy path
-// (a real Apple-signed payload) is deferred to tc-dpfn (blocks the it10 cutover).
+// by design. That path is unit-tested in internal/subscriptions.
+//
+// The verify/webhook HAPPY paths are not diffed live either (tc-dpfn, resolved):
+//   1. There is no diff target — .NET 400s on every camelCase body, so it never
+//      reaches the activation logic to compare against.
+//   2. A captured sandbox transaction's expiresDate is in the past by the time a
+//      stored CI artifact runs, and verify skips lapsed transactions
+//      (handler.go: "if !txn.ExpiresDate.After(now) { continue }"), so a replayed
+//      artifact returns Free — it cannot demonstrate paid activation.
+// The only way to get a live happy-path check would be a dev-only test-root seam
+// on both deployed apps; the activation + webhook lifecycle + JWS chain/signature
+// are instead covered by unit tests (TestVerify_PurchaseActivatesPro,
+// TestWebhook_SubscribedActivatesProfile, TestWebhook_DuplicateIsNoOp,
+// TestJWSVerifier_ValidChainAndSignature, ...).
 //
 // The two APIs share one Cosmos account, so the error scenarios below return the
 // same result whatever the shared user's profile state.


### PR DESCRIPTION
## What

Resolves **tc-dpfn** (epic tc-7g3i / GH #418). Per owner decision, the subscription verify/webhook **happy path stays unit-test-covered** rather than gaining a live contract diff, because a live diff is infeasible. This PR records *why* in the `contract_subscriptions_test.go` header comment so the next reader doesn't re-attempt it.

### Why a live happy-path diff can't work
1. **No diff target** — the deployed .NET API 400s on every camelCase body (its PascalCase binding bug; the very thing this migration fixes, tc-n7f8), so it never reaches the activation logic to compare against.
2. **Captured artifacts expire** — a sandbox transaction's `expiresDate` is in the past by the time a stored CI artifact runs, and verify skips lapsed transactions (`if !txn.ExpiresDate.After(now) { continue }`), so a replay returns `Free` — it can't demonstrate paid activation.

The only way to get a live happy-path check would be a dev-only test-root seam on both deployed apps (declined). The activation + webhook lifecycle + JWS chain/signature are already covered by unit tests: `TestVerify_PurchaseActivatesPro`, `TestWebhook_SubscribedActivatesProfile`, `TestWebhook_DuplicateIsNoOp`, `TestJWSVerifier_ValidChainAndSignature`.

## Testing

Comment-only change — no behaviour change. `go build -tags e2e` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)