### PR TITLE
fix(infra): empty CustomDomains list not null — fixes cd-dev crash (tc-6myy)

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -248,9 +248,12 @@ public static class EnvironmentStack
         // moves to the Go app (below) and the .NET app must NOT claim it, or the bind
         // collides. The phase>=2 SniEnabled binding reuses apiManagedCert; phase 1 uses a
         // Disabled placeholder so Azure can validate the hostname before the cert exists.
-        CustomDomainArgs[]? dotnetApiCustomDomains =
+        // Empty (not null) for the non-owning app: Pulumi's InputList<CustomDomainArgs>
+        // implicit operator runs .Select over the array and throws ArgumentNullException
+        // on null, so an empty list is the correct "no custom domains" value.
+        CustomDomainArgs[] dotnetApiCustomDomains =
             apiBackend == "go"
-                ? null
+                ? Array.Empty<CustomDomainArgs>()
                 : customDomainPhase >= 2
                     ? new[]
                     {
@@ -271,7 +274,7 @@ public static class EnvironmentStack
                     };
 
         // Mirror binding for the Go app: it owns the api domain when apiBackend=="go".
-        CustomDomainArgs[]? goApiCustomDomains =
+        CustomDomainArgs[] goApiCustomDomains =
             apiBackend == "go" && customDomainPhase >= 2
                 ? new[]
                 {
@@ -282,7 +285,7 @@ public static class EnvironmentStack
                         BindingType = BindingType.SniEnabled,
                     },
                 }
-                : null;
+                : Array.Empty<CustomDomainArgs>();
 
         // Container App (API) — placeholder image until CI/CD pushes real builds
         var containerApp = new ContainerApp($"ca-town-crier-api-{env}", new ContainerAppArgs


### PR DESCRIPTION
## Changes
Fixes the `ArgumentNullException` that broke **CD Dev** (run 27493535775) after #443.

- Assigning `null` to `IngressArgs.CustomDomains` (`InputList<CustomDomainArgs>`) throws — the implicit `CustomDomainArgs[] → InputList` operator runs `.Select` over the array. This crashed the Pulumi program during evaluation for the app that isn't the active backend (`goApiCustomDomains` null in dev).
- Use `Array.Empty<CustomDomainArgs>()` instead of `null` — an empty list is the correct "no custom domains" value.
- The crash happened **before any resource op**, so nothing was applied to dev; **prod was untouched** (cd-prod runs only on `v*` tags) and verified healthy throughout.

Validated with a local dev `pulumi preview` (with throwaway secrets): evaluates cleanly — `~2 to update, 20 unchanged`, no replaces, no exception.

Follow-up filed (tc-60dx): the pr-gate `Infra: Pulumi preview` step masks pulumi failures via `| tee` (no `pipefail`), which is why this crash passed the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)