### PR TITLE
infra: cut api-dev to Go app + MinReplicas policy (tc-fdml)

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -383,10 +383,11 @@ public static class EnvironmentStack
                 },
                 Scale = new ScaleArgs
                 {
-                    // Prod keeps one warm instance so first requests (e.g. App Store
-                    // review) skip the ~15s ACA scale-from-zero cold start. Dev stays
-                    // scale-to-zero to avoid idle cost.
-                    MinReplicas = env == "prod" ? 1 : 0,
+                    // The .NET app is a cold standby in all environments after the Go
+                    // cutover (tc-fdml): prod api traffic moved to the Go app (tc-t56q),
+                    // dev follows here. Keep it scale-to-zero everywhere to avoid idle
+                    // cost; the Go app carries the warm-replica budget where needed.
+                    MinReplicas = 0,
                     MaxReplicas = 1,
                 },
             },
@@ -504,12 +505,11 @@ public static class EnvironmentStack
                     },
                     Scale = new ScaleArgs
                     {
-                        // Keep one warm replica when the Go app is the active backend
-                        // (apiBackend=="go", i.e. prod post-cutover) so live api traffic
-                        // skips the ~15s ACA scale-from-zero cold start, mirroring the
-                        // .NET prod app. Otherwise (dev, or before cutover) stay
-                        // scale-to-zero to avoid idle cost.
-                        MinReplicas = apiBackend == "go" ? 1 : 0,
+                        // Keep one warm replica only for the PROD Go app once it is the
+                        // active backend (apiBackend=="go") so live api traffic skips the
+                        // ~15s ACA scale-from-zero cold start. Dev — even though it is now
+                        // go-backed after tc-fdml — stays scale-to-zero to avoid idle cost.
+                        MinReplicas = (env == "prod" && apiBackend == "go") ? 1 : 0,
                         MaxReplicas = 1,
                     },
                 },

--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -5,6 +5,11 @@ config:
   town-crier:apiDomain: api-dev.towncrierapp.uk
   town-crier:auth0Domain: towncrierapp.uk.auth0.com
   town-crier:auth0Audience: https://api-dev.towncrierapp.uk
+  # api-dev.towncrierapp.uk is served by the Go app (ca-town-crier-api-go-dev) after the
+  # tc-fdml cutover (mirrors prod tc-t56q). This moves the hostname-to-app binding from
+  # the .NET app to the Go app and binds the existing env-level cert-api-dev. Unlike prod,
+  # Go dev stays scale-to-zero (MinReplicas=0) to avoid idle cost — only Go prod is warm.
+  town-crier:apiBackend: "go"
   town-crier:apnsKeyId: L2J5PQASN5
   town-crier:apnsTeamId: 4574VQ7N2X
   town-crier:apnsAuthKey:


### PR DESCRIPTION
Mirrors the prod cutover (tc-t56q) for **dev** and adjusts the warm-replica policy per owner request (2026-06-14): **prod Go=1, all .NET apps=0, dev stays scale-to-zero**.

## Changes
- **`Pulumi.dev.yaml`**: set `apiBackend: "go"` so cd-dev's `pulumi up` moves the `api-dev.towncrierapp.uk` custom-domain binding from `ca-town-crier-api-dev` → `ca-town-crier-api-go-dev`, binding the existing env-level `cert-api-dev`.
- **`EnvironmentStack.cs` .NET app**: `MinReplicas = 0` in all envs — the .NET app is a cold standby everywhere after the Go cutover.
- **`EnvironmentStack.cs` Go app**: `MinReplicas = (env == "prod" && apiBackend == "go") ? 1 : 0` — only the prod Go app stays warm; dev Go stays scale-to-zero despite now being go-backed.

`CustomDomains` stays `Array.Empty` (never `null`) for the non-owning app to avoid the `InputList` `ArgumentNullException` regression (tc-6myy, #444).

## Validation
`pulumi preview --stack dev` (local, with throwaway secrets): **2 apps update** — the `api-dev` SNI binding moves .NET → Go, **no replica diff for dev** (both stay 0). The prod replica changes (NET prod 1→0, Go prod 0→1) activate only on the next prod release (tracked in tc-83cy).

## Cutover sequencing (operational, post-merge)
1. ✅ `asuid.api-dev` TXT added to Cloudflare before merge (subscription-scoped verification ID).
2. Merge → cd-dev `pulumi up` moves the binding + binds `cert-api-dev`.
3. Flip Cloudflare CNAME `api-dev` → `ca-town-crier-api-go-dev` FQDN.
4. Verify `https://api-dev.towncrierapp.uk/health` = 200 (Go).

Closes tc-fdml.