### PR TITLE
fix(ios): watch-zone upgrade badge no longer shows below tier limit (tc-ujct)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -257,7 +257,16 @@ public final class AppCoordinator: ObservableObject {
   // MARK: - Watch Zone Factories
 
   public func makeWatchZoneListViewModel() -> WatchZoneListViewModel {
-    if let cached = watchZoneListViewModel {
+    // Reuse the cached VM only while its gate still reflects the current tier.
+    // The tier resolves from the default `.free` to a paid tier *after* the VM
+    // is first built (resolveSubscriptionTier runs asynchronously at launch),
+    // and the list is keyed `.id(subscriptionTier)` so the view rebuilds on the
+    // change. Returning a stale `.free` gate kept the upgrade badge on the +
+    // button once the 1-zone free limit was hit, blocking paid users below
+    // their actual limit (tc-ujct). Rebuild with a fresh gate when the tier
+    // differs; same-tier calls still return a stable instance so the editor's
+    // post-save reload path converges on the retained VM.
+    if let cached = watchZoneListViewModel, cached.featureGate.tier == subscriptionTier {
       return cached
     }
     let viewModel = WatchZoneListViewModel(

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorWatchZoneTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorWatchZoneTests.swift
@@ -328,6 +328,45 @@ struct AppCoordinatorWatchZoneTests {
     #expect(sut.isSubscriptionPresented)
   }
 
+  // MARK: - Watch Zone List Gate Tracks Tier Changes (tc-ujct)
+
+  /// Regression for tc-ujct: the list VM is cached and its ``FeatureGate``
+  /// froze ``AppCoordinator/subscriptionTier`` at first build. At launch the
+  /// tier defaults to `.free` (1-zone limit) until `resolveSubscriptionTier()`
+  /// runs asynchronously; the list view is keyed `.id(subscriptionTier)` so it
+  /// rebuilds on tier change, but the factory returned the stale cached VM —
+  /// wrongly showing the upgrade badge for paid users below their limit. The
+  /// gate must reflect the live tier.
+  @Test func makeWatchZoneListViewModel_rebuildsGate_whenTierChanges() async throws {
+    let resolver = FakeSubscriptionTierResolver()
+    resolver.resolveResult = (.pro, false)
+    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
+    let sut = AppCoordinator(
+      repository: SpyPlanningApplicationRepository(),
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: SpyUserProfileRepository(),
+      tierResolver: resolver,
+      watchZoneRepository: SpyWatchZoneRepository(),
+      geocoder: SpyPostcodeGeocoder(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService(),
+      tierCache: defaults
+    )
+
+    // First build happens before the live tier resolves: defaults to `.free`.
+    let freeVM = sut.makeWatchZoneListViewModel()
+    #expect(freeVM.featureGate.tier == .free)
+
+    // Tier resolves to a paid tier after the VM was first built.
+    await sut.resolveSubscriptionTier()
+
+    let paidVM = sut.makeWatchZoneListViewModel()
+    #expect(paidVM.featureGate.tier == .pro)
+  }
+
   // MARK: - Watch Zone Upsell
 
   @Test func makeWatchZoneListViewModel_onViewPlans_setsIsSubscriptionPresented() {


### PR DESCRIPTION
## Changes
- Fix the Zones tab replacing the **+** button with the **Upgrade** badge even when the user is below their tier's watch-zone limit.
- Root cause: `makeWatchZoneListViewModel()` caches the list VM, whose `FeatureGate` froze `subscriptionTier` at first build. At launch the tier defaults to `.free` (1-zone limit) until `resolveSubscriptionTier()` runs async; the list is keyed `.id(subscriptionTier)` and rebuilds on tier change, but the factory returned the cached VM with the stale `.free` gate — so paid users saw the upgrade badge after their first zone.
- Fix: reuse the cached VM only while its `featureGate.tier` matches the current `subscriptionTier`; otherwise rebuild with a fresh gate. Same-tier calls still return a stable instance, preserving the editor's post-save reload path.
- Upgrade badge now appears only when `currentCount >= ` the tier's maximum.
- Added regression test `makeWatchZoneListViewModel_rebuildsGate_whenTierChanges`; full iOS suite (1233 tests) and SwiftLint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
*Auto-shipped via ship skill*