### PR TITLE
feat(go): digest + hourly-digest worker modes (tc-34y5)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -12,11 +12,20 @@ package main
 import (
 	"context"
 	"log"
+	"log/slog"
 	"os"
 	"time"
 
+	"github.com/AmyDe/town-crier/api-go/internal/acsemail"
+	"github.com/AmyDe/town-crier/api-go/internal/apns"
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/digest"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/servicebus"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 	"github.com/AmyDe/town-crier/api-go/internal/worker"
 )
 
@@ -78,5 +87,137 @@ func run() int {
 		bootstrapper = worker.NewBootstrapper(sbClient, logger, time.Now)
 	}
 
-	return worker.Run(context.Background(), mode, bootstrapper, logger)
+	// The digest handler (and thus the digest / hourly-digest modes) is built
+	// only when the job carries Cosmos config. Jobs that don't touch Cosmos leave
+	// the digester a genuinely nil interface; the digest modes then refuse to run
+	// rather than crashing. The email and push senders fall back to NoOp when
+	// their credentials are absent, so a Cosmos-only job still boots cleanly.
+	//
+	// digester is declared as the interface (not the concrete *digest.Handler) so
+	// the "no Cosmos" case leaves it nil — assigning a typed-nil *digest.Handler
+	// would make the interface non-nil and defeat worker.Run's nil guard.
+	var digester worker.DigestRunner
+	handler, err := buildDigester(cfg, logger)
+	if err != nil {
+		logger.Error("build digest handler", "error", err)
+		return 1
+	}
+	if handler != nil {
+		digester = handler
+	}
+
+	return worker.Run(context.Background(), mode, bootstrapper, digester, logger)
+}
+
+// buildDigester constructs the digest handler when Cosmos is configured, wiring
+// the per-container stores and the email/push senders (real when their
+// credentials are present, NoOp otherwise so a job without ACS/APNs boots
+// cleanly). It returns (nil, nil) when Cosmos is unconfigured — the digest modes
+// then refuse to run rather than nil-panicking. Returning the concrete
+// *digest.Handler lets worker.Run accept it via its unexported digestRunner
+// interface (structural satisfaction).
+func buildDigester(cfg platform.Config, logger *slog.Logger) (*digest.Handler, error) {
+	if cfg.CosmosEndpoint == "" {
+		return nil, nil //nolint:nilnil // absent Cosmos config is a valid "no digester" state, not an error
+	}
+
+	users, err := platform.NewCosmosContainerNamed(cfg, "Users", logger)
+	if err != nil {
+		return nil, err
+	}
+	notifs, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationsContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+	zonesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosWatchZonesContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+	stateContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationStateContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+	devicesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosDeviceRegistrationsContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	profileStore := digestProfiles{
+		admin: profiles.NewAdminStore(users),
+		point: profiles.NewCosmosStore(users),
+	}
+	notificationStore := notifications.NewDigestStore(notifs)
+	zoneStore := watchzones.NewCosmosStore(zonesContainer)
+	stateStore := notificationstate.NewCosmosStore(stateContainer, notifs)
+	deviceStore := devicetokens.NewCosmosStore(devicesContainer)
+
+	emailSender := buildEmailSender(cfg, logger)
+	pushSender := buildPushSender(cfg, logger)
+
+	return digest.NewHandler(
+		profileStore,
+		notificationStore,
+		zoneStore,
+		stateStore,
+		deviceStore,
+		emailSender,
+		pushSender,
+		logger,
+		time.Now,
+	), nil
+}
+
+// digestProfiles adapts the two profile stores the digest handler needs — the
+// cross-partition digest-day selector (AdminStore) and the per-user point read
+// (CosmosStore) — into the single consumer-side profile interface the handler
+// depends on.
+type digestProfiles struct {
+	admin *profiles.AdminStore
+	point *profiles.CosmosStore
+}
+
+func (p digestProfiles) ByDigestDay(ctx context.Context, day time.Weekday) ([]*profiles.UserProfile, error) {
+	return p.admin.ByDigestDay(ctx, day)
+}
+
+func (p digestProfiles) Get(ctx context.Context, userID string) (*profiles.UserProfile, error) {
+	return p.point.Get(ctx, userID)
+}
+
+// buildEmailSender returns the real ACS email sender when a connection string is
+// configured, else a NoOp so a job without ACS credentials boots cleanly.
+func buildEmailSender(cfg platform.Config, logger *slog.Logger) acsemail.EmailSender {
+	conn := cfg.ACSConnectionString.Expose()
+	if conn == "" {
+		logger.Info("acs connection string unset; digest emails disabled (NoOp sender)")
+		return acsemail.NewNoOpSender()
+	}
+	client, err := acsemail.NewClient(conn, logger, time.Now)
+	if err != nil {
+		logger.Error("build acs email client; falling back to NoOp sender", "error", err)
+		return acsemail.NewNoOpSender()
+	}
+	return client
+}
+
+// buildPushSender returns the real APNs sender when APNs is enabled, else a NoOp
+// so a job without a .p8 auth key boots cleanly.
+func buildPushSender(cfg platform.Config, logger *slog.Logger) apns.PushSender {
+	if !cfg.APNsEnabled {
+		logger.Info("apns disabled; digest pushes disabled (NoOp sender)")
+		return apns.NewNoOpSender()
+	}
+	client, err := apns.NewClient(apns.Options{
+		Enabled:    cfg.APNsEnabled,
+		AuthKey:    cfg.APNsAuthKey.Expose(),
+		KeyID:      cfg.APNsKeyID,
+		TeamID:     cfg.APNsTeamID,
+		BundleID:   cfg.APNsBundleID,
+		UseSandbox: cfg.APNsUseSandbox,
+	}, logger, time.Now)
+	if err != nil {
+		logger.Error("build apns client; falling back to NoOp sender", "error", err)
+		return apns.NewNoOpSender()
+	}
+	return client
 }

--- a/api-go/internal/digest/email.go
+++ b/api-go/internal/digest/email.go
@@ -1,0 +1,161 @@
+package digest
+
+import (
+	"fmt"
+	"html"
+	"net/url"
+	"strings"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+)
+
+// senderAddress is the verified ACS sender the digest emails are sent from,
+// matching the .NET AcsEmailSender.SenderAddress constant.
+const senderAddress = "hello@towncrierapp.uk"
+
+// watchZoneDigest groups a watch zone's display name with the notifications that
+// fell inside it. It is the Go analogue of the .NET WatchZoneDigest record.
+type watchZoneDigest struct {
+	name          string
+	notifications []notifications.DigestNotification
+}
+
+// buildDigestSubject renders the digest email subject line, mirroring .NET
+// AcsEmailSender.BuildDigestSubject.
+func buildDigestSubject(totalCount int) string {
+	return fmt.Sprintf("Planning update — %d new applications near you", totalCount)
+}
+
+// buildDigestHTML renders the full digest email body: a header, one block per
+// watch zone (each with its application cards), an optional Saved Applications
+// section, a CTA button, and a footer. It is a faithful port of .NET
+// AcsEmailSender.BuildDigestHtml so the rendered email is unchanged across the
+// cutover. All user-supplied content is HTML-encoded.
+func buildDigestHTML(zoneSections []watchZoneDigest, savedApplications []notifications.DigestNotification, totalCount int) string {
+	var zoneBlocks strings.Builder
+	for _, section := range zoneSections {
+		var cards strings.Builder
+		for _, n := range section.notifications {
+			cards.WriteString(buildNotificationCard(n))
+		}
+		zoneBlocks.WriteString(fmt.Sprintf(
+			`<tr><td style="padding:16px 0 8px 0;font-size:14px;color:#666;text-transform:uppercase;letter-spacing:0.5px;">
+  📍 %s
+</td></tr>
+%s`, htmlEncode(section.name), cards.String()))
+	}
+
+	if len(savedApplications) > 0 {
+		var savedCards strings.Builder
+		for _, n := range savedApplications {
+			savedCards.WriteString(buildNotificationCard(n))
+		}
+		zoneBlocks.WriteString(fmt.Sprintf(
+			`<tr><td style="padding:16px 0 8px 0;font-size:14px;color:#666;text-transform:uppercase;letter-spacing:0.5px;">
+  ★ Saved Applications
+</td></tr>
+%s`, savedCards.String()))
+	}
+
+	plural := "s"
+	if totalCount == 1 {
+		plural = ""
+	}
+
+	return fmt.Sprintf(`<!DOCTYPE html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"></head>
+<body style="margin:0;padding:0;background:#f0f0f0;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table width="100%%" cellpadding="0" cellspacing="0"><tr><td align="center" style="padding:24px;">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:8px;overflow:hidden;">
+  <tr><td style="background:#1a1a2e;padding:24px;text-align:center;">
+    <div style="font-size:20px;font-weight:700;color:#ffffff;">Town Crier</div>
+    <div style="color:#888;font-size:13px;margin-top:4px;">Live Planning Update</div>
+  </td></tr>
+  <tr><td style="padding:24px;">
+    <table width="100%%" cellpadding="0" cellspacing="0">
+      %s
+    </table>
+    <table width="100%%" cellpadding="0" cellspacing="0" style="margin-top:24px;">
+      <tr><td align="center">
+        <a href="https://towncrierapp.uk/applications" style="display:inline-block;background:#4a6cf7;color:#ffffff;padding:12px 32px;border-radius:6px;text-decoration:none;font-weight:600;">View All in App</a>
+      </td></tr>
+    </table>
+  </td></tr>
+  <tr><td style="padding:16px 24px;text-align:center;color:#999;font-size:12px;border-top:1px solid #eee;">
+    %d new application%s · <a href="https://towncrierapp.uk/settings" style="color:#999;">Unsubscribe</a>
+  </td></tr>
+</table>
+</td></tr></table>
+</body></html>`, zoneBlocks.String(), totalCount, plural)
+}
+
+// buildNotificationCard renders one application card for the digest body. A
+// decision update prepends the UK display-label badge; a zone notification that
+// is also saved appends a "★ saved" indicator. Each card line links to the
+// application detail page so iOS Universal Links open the app. Ports .NET
+// AcsEmailSender.BuildNotificationCard.
+func buildNotificationCard(n notifications.DigestNotification) string {
+	addressLine := htmlEncode(n.ApplicationAddress)
+	if n.EventType == notifications.EventDecisionUpdate {
+		if label := ukDisplayString(n.Decision); label != "" {
+			addressLine = fmt.Sprintf(
+				`<span style="display:inline-block;background:#eef1ff;color:#1a1a2e;font-size:11px;font-weight:700;letter-spacing:0.5px;padding:2px 6px;border-radius:4px;margin-right:6px;">[%s]</span>%s`,
+				htmlEncode(label), addressLine)
+		}
+	}
+
+	savedIndicator := ""
+	if n.WatchZoneID != nil && n.HasSavedSource() {
+		savedIndicator = `<span data-saved-indicator style="display:inline-block;background:#fff3cd;color:#664d03;font-size:11px;font-weight:600;letter-spacing:0.3px;padding:2px 6px;border-radius:4px;margin-left:6px;">★ saved</span>`
+	}
+
+	appURL := buildApplicationDetailURL(n.ApplicationUID)
+	openLink := fmt.Sprintf(`<a href="%s" style="text-decoration:none;color:inherit;">`, appURL)
+	const closeLink = "</a>"
+
+	appType := "Planning Application"
+	if n.ApplicationType != nil && *n.ApplicationType != "" {
+		appType = *n.ApplicationType
+	}
+
+	return fmt.Sprintf(`<tr><td style="padding:0 0 8px 0;">
+  <table width="100%%" cellpadding="0" cellspacing="0" style="background:#f8f9fa;border-radius:6px;">
+    <tr><td style="padding:12px;">
+      %s<div style="font-weight:600;color:#1a1a2e;">%s%s</div>%s
+      %s<div style="color:#4a6cf7;font-size:13px;">%s</div>%s
+      %s<div style="color:#666;font-size:13px;margin-top:4px;">%s</div>%s
+    </td></tr>
+  </table>
+</td></tr>`,
+		openLink, addressLine, savedIndicator, closeLink,
+		openLink, htmlEncode(appType), closeLink,
+		openLink, htmlEncode(truncate(n.ApplicationDescription, 120)), closeLink)
+}
+
+// buildApplicationDetailURL builds the application detail URL, keeping the
+// slashes in a PlanIt uid (e.g. "19/00123/FUL") as path separators while
+// percent-encoding every other reserved character per segment. Ports .NET
+// AcsEmailSender.BuildApplicationDetailUrl.
+func buildApplicationDetailURL(applicationUID string) string {
+	segments := strings.Split(applicationUID, "/")
+	for i, seg := range segments {
+		segments[i] = url.PathEscape(seg)
+	}
+	return "https://towncrierapp.uk/applications/" + strings.Join(segments, "/")
+}
+
+// htmlEncode HTML-encodes user-supplied text for safe inclusion in the email
+// body, matching .NET's WebUtility.HtmlEncode.
+func htmlEncode(text string) string {
+	return html.EscapeString(text)
+}
+
+// truncate caps text at maxLength, replacing the tail with an ellipsis when it
+// overflows, matching .NET AcsEmailSender.Truncate.
+func truncate(text string, maxLength int) string {
+	if len([]rune(text)) <= maxLength {
+		return text
+	}
+	runes := []rune(text)
+	return string(runes[:maxLength-1]) + "…"
+}

--- a/api-go/internal/digest/email.go
+++ b/api-go/internal/digest/email.go
@@ -38,11 +38,11 @@ func buildDigestHTML(zoneSections []watchZoneDigest, savedApplications []notific
 		for _, n := range section.notifications {
 			cards.WriteString(buildNotificationCard(n))
 		}
-		zoneBlocks.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&zoneBlocks,
 			`<tr><td style="padding:16px 0 8px 0;font-size:14px;color:#666;text-transform:uppercase;letter-spacing:0.5px;">
   📍 %s
 </td></tr>
-%s`, htmlEncode(section.name), cards.String()))
+%s`, htmlEncode(section.name), cards.String())
 	}
 
 	if len(savedApplications) > 0 {
@@ -50,11 +50,11 @@ func buildDigestHTML(zoneSections []watchZoneDigest, savedApplications []notific
 		for _, n := range savedApplications {
 			savedCards.WriteString(buildNotificationCard(n))
 		}
-		zoneBlocks.WriteString(fmt.Sprintf(
+		fmt.Fprintf(&zoneBlocks,
 			`<tr><td style="padding:16px 0 8px 0;font-size:14px;color:#666;text-transform:uppercase;letter-spacing:0.5px;">
   ★ Saved Applications
 </td></tr>
-%s`, savedCards.String()))
+%s`, savedCards.String())
 	}
 
 	plural := "s"

--- a/api-go/internal/digest/email_test.go
+++ b/api-go/internal/digest/email_test.go
@@ -1,0 +1,141 @@
+package digest
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+)
+
+func strptr(s string) *string { return &s }
+
+func testNotification(uid, zoneID, address, appType, desc string) notifications.DigestNotification {
+	n := notifications.DigestNotification{
+		ID:                     "n-" + uid,
+		UserID:                 "user-1",
+		ApplicationUID:         uid,
+		ApplicationName:        uid,
+		ApplicationAddress:     address,
+		ApplicationDescription: desc,
+		EventType:              notifications.EventNewApplication,
+		AuthorityID:            1,
+		CreatedAt:              time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if zoneID != "" {
+		n.WatchZoneID = strptr(zoneID)
+	}
+	if appType != "" {
+		n.ApplicationType = strptr(appType)
+	}
+	return n
+}
+
+func TestBuildDigestSubject(t *testing.T) {
+	t.Parallel()
+	got := buildDigestSubject(3)
+	want := "Planning update — 3 new applications near you"
+	if got != want {
+		t.Errorf("subject: got %q, want %q", got, want)
+	}
+}
+
+func TestBuildDigestHTML_RendersZoneAndSavedSections(t *testing.T) {
+	t.Parallel()
+	zones := []watchZoneDigest{
+		{name: "Home", notifications: []notifications.DigestNotification{
+			testNotification("19/00123/FUL", "zone-1", "10 High St", "Householder", "Rear extension"),
+		}},
+	}
+	saved := []notifications.DigestNotification{
+		testNotification("20/00045/FUL", "", "5 Mill Ln", "Full", "New dwelling"),
+	}
+
+	html := buildDigestHTML(zones, saved, 2)
+
+	for _, want := range []string{
+		"Town Crier",
+		"Home",                  // zone section header
+		"Saved Applications",    // saved section header
+		"10 High St",            // zone card address
+		"5 Mill Ln",             // saved card address
+		"Householder",           // zone card type
+		"Rear extension",        // zone card description
+		"2 new applications",    // footer count (plural)
+		"towncrierapp.uk/applications/19/00123/FUL", // slash-preserving detail URL
+	} {
+		if !strings.Contains(html, want) {
+			t.Errorf("digest HTML missing %q\n%s", want, html)
+		}
+	}
+}
+
+func TestBuildDigestHTML_DecisionLabelBadge(t *testing.T) {
+	t.Parallel()
+	// A decision-update notification renders the UK display label badge, not the
+	// raw PlanIt app_state.
+	n := testNotification("19/0009", "zone-1", "9 Oak Ave", "Householder", "Loft")
+	n.EventType = notifications.EventDecisionUpdate
+	n.Decision = strptr("Permitted")
+	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
+
+	html := buildDigestHTML(zones, nil, 1)
+
+	if !strings.Contains(html, "[Approved]") {
+		t.Errorf("decision badge should show UK label [Approved], got:\n%s", html)
+	}
+	if strings.Contains(html, "[Permitted]") {
+		t.Errorf("decision badge should not show raw PlanIt state Permitted")
+	}
+	// Singular footer copy.
+	if !strings.Contains(html, "1 new application ") {
+		t.Errorf("footer should use singular for count 1, got:\n%s", html)
+	}
+}
+
+func TestBuildDigestHTML_SavedIndicatorOnZoneCard(t *testing.T) {
+	t.Parallel()
+	// A zone notification that also has the Saved source renders the "★ saved"
+	// indicator on its zone card.
+	n := testNotification("19/0010", "zone-1", "1 Elm Rd", "Householder", "Garage")
+	n.Sources = "Zone, Saved"
+	zones := []watchZoneDigest{{name: "Home", notifications: []notifications.DigestNotification{n}}}
+
+	html := buildDigestHTML(zones, nil, 1)
+
+	if !strings.Contains(html, "★ saved") {
+		t.Errorf("expected saved indicator on zone card, got:\n%s", html)
+	}
+}
+
+func TestBuildDigestHTML_EscapesUserContent(t *testing.T) {
+	t.Parallel()
+	// Application fields are HTML-encoded to prevent injection into the email body.
+	n := testNotification("19/0011", "zone-1", "<script>alert(1)</script>", "Householder", "x & y")
+	zones := []watchZoneDigest{{name: "Home & Garden", notifications: []notifications.DigestNotification{n}}}
+
+	html := buildDigestHTML(zones, nil, 1)
+
+	if strings.Contains(html, "<script>alert(1)</script>") {
+		t.Errorf("address must be HTML-encoded, got:\n%s", html)
+	}
+	if !strings.Contains(html, "Home &amp; Garden") {
+		t.Errorf("zone name must be HTML-encoded, got:\n%s", html)
+	}
+}
+
+func TestBuildApplicationDetailURL_PreservesSlashesEncodesSegments(t *testing.T) {
+	t.Parallel()
+	// Slash-containing PlanIt uids keep their slashes as path separators while
+	// other reserved characters in a segment are percent-encoded.
+	got := buildApplicationDetailURL("19/00123/FUL")
+	want := "https://towncrierapp.uk/applications/19/00123/FUL"
+	if got != want {
+		t.Errorf("detail URL: got %q, want %q", got, want)
+	}
+
+	gotSpace := buildApplicationDetailURL("19/00 1")
+	if !strings.Contains(gotSpace, "/applications/19/00%201") {
+		t.Errorf("space in segment must be percent-encoded, got %q", gotSpace)
+	}
+}

--- a/api-go/internal/digest/email_test.go
+++ b/api-go/internal/digest/email_test.go
@@ -55,13 +55,13 @@ func TestBuildDigestHTML_RendersZoneAndSavedSections(t *testing.T) {
 
 	for _, want := range []string{
 		"Town Crier",
-		"Home",                  // zone section header
-		"Saved Applications",    // saved section header
-		"10 High St",            // zone card address
-		"5 Mill Ln",             // saved card address
-		"Householder",           // zone card type
-		"Rear extension",        // zone card description
-		"2 new applications",    // footer count (plural)
+		"Home",               // zone section header
+		"Saved Applications", // saved section header
+		"10 High St",         // zone card address
+		"5 Mill Ln",          // saved card address
+		"Householder",        // zone card type
+		"Rear extension",     // zone card description
+		"2 new applications", // footer count (plural)
 		"towncrierapp.uk/applications/19/00123/FUL", // slash-preserving detail URL
 	} {
 		if !strings.Contains(html, want) {

--- a/api-go/internal/digest/handler.go
+++ b/api-go/internal/digest/handler.go
@@ -1,0 +1,359 @@
+// Package digest holds the Town Crier digest-generation worker modes: the weekly
+// digest (WORKER_MODE=digest) and the hourly digest (WORKER_MODE=hourly-digest).
+// Each cycle reads dispatched notifications from Cosmos, applies tier and
+// per-user preference gating, groups the matching applications per watch zone,
+// renders an email HTML body and (weekly, Pro tier only) an APNs push payload,
+// hands them to the transport-only acsemail / apns senders, and records dedup
+// state (the hourly cycle flips emailSent; the weekly push prunes invalid device
+// tokens). It ports the .NET GenerateWeeklyDigests / GenerateHourlyDigests
+// command handlers (epic tc-wad3) following idiomatic Go: consumer-side
+// interfaces, hand-written test fakes, business logic in the package.
+package digest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/acsemail"
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// digestWindow is the look-back the weekly digest gathers notifications over,
+// matching .NET's now.AddDays(-7).
+const digestWindow = 7 * 24 * time.Hour
+
+// profileReader is the consumer-side slice of the profile stores the digest
+// worker needs: the weekly cycle selects by digest day (cross-partition) and the
+// hourly cycle point-reads each candidate user. profiles.AdminStore satisfies
+// ByDigestDay; profiles.CosmosStore satisfies Get.
+type profileReader interface {
+	ByDigestDay(ctx context.Context, day time.Weekday) ([]*profiles.UserProfile, error)
+	Get(ctx context.Context, userID string) (*profiles.UserProfile, error)
+}
+
+// notificationReader is the consumer-side slice of the Notifications store the
+// digest worker reads and writes. notifications.DigestStore satisfies it.
+type notificationReader interface {
+	ByUserSince(ctx context.Context, userID string, since time.Time) ([]notifications.DigestNotification, error)
+	UnsentEmailsByUser(ctx context.Context, userID string) ([]notifications.DigestNotification, error)
+	UserIDsWithUnsentEmails(ctx context.Context) ([]string, error)
+	MarkEmailSent(ctx context.Context, n notifications.DigestNotification) error
+}
+
+// zoneReader returns a user's watch zones for grouping and per-zone gating.
+// watchzones.CosmosStore satisfies it.
+type zoneReader interface {
+	GetByUserID(ctx context.Context, userID string) ([]watchzones.WatchZone, error)
+}
+
+// stateReader supplies the unread-count badge inputs for the weekly push:
+// the watermark and the strictly-after-watermark count. notificationstate.CosmosStore
+// satisfies it.
+type stateReader interface {
+	Get(ctx context.Context, userID string) (*notificationstate.State, error)
+	UnreadCount(ctx context.Context, userID string, lastReadAt time.Time) (int, error)
+}
+
+// deviceReader lists a user's device tokens for a push and prunes the ones APNs
+// reports permanently invalid. devicetokens.CosmosStore satisfies it.
+type deviceReader interface {
+	ListByUser(ctx context.Context, userID string) ([]devicetokens.DeviceRegistration, error)
+	Delete(ctx context.Context, userID, token string) error
+}
+
+// pushSender is the consumer-side push contract; apns.PushSender (the real Client
+// or the NoOpSender) satisfies it. It is declared locally so the handler test can
+// substitute a spy without importing apns.
+type pushSender interface {
+	Send(ctx context.Context, tokens []string, payload json.RawMessage) ([]string, error)
+}
+
+// Handler runs the weekly and hourly digest cycles. It holds the stores and the
+// transport-only senders, and renders the email/push bodies itself.
+type Handler struct {
+	profiles      profileReader
+	notifications notificationReader
+	zones         zoneReader
+	state         stateReader
+	devices       deviceReader
+	email         acsemail.EmailSender
+	push          pushSender
+	logger        *slog.Logger
+	now           func() time.Time
+}
+
+// NewHandler wires the digest handler. now is injected so tests can pin the
+// current day (which drives the weekly digest-day selection); production passes
+// time.Now.
+func NewHandler(
+	profiles profileReader,
+	notifications notificationReader,
+	zones zoneReader,
+	state stateReader,
+	devices deviceReader,
+	email acsemail.EmailSender,
+	push pushSender,
+	logger *slog.Logger,
+	now func() time.Time,
+) *Handler {
+	return &Handler{
+		profiles:      profiles,
+		notifications: notifications,
+		zones:         zones,
+		state:         state,
+		devices:       devices,
+		email:         email,
+		push:          push,
+		logger:        logger,
+		now:           now,
+	}
+}
+
+// RunWeekly generates the weekly digest for every user whose configured digest
+// day is today. For each user it sends a digest email (when email is enabled and
+// the user has an address) and a digest push (Pro tier only, when push is
+// enabled). It ports .NET GenerateWeeklyDigestsCommandHandler.
+func (h *Handler) RunWeekly(ctx context.Context) error {
+	now := h.now().UTC()
+	today := now.Weekday()
+	since := now.Add(-digestWindow)
+
+	users, err := h.profiles.ByDigestDay(ctx, today)
+	if err != nil {
+		return err
+	}
+
+	for _, profile := range users {
+		wantsPush := profile.Tier.IsPaidPro() && profile.Preferences.PushEnabled
+		wantsEmail := profile.Preferences.EmailDigestEnabled && profile.Email != nil && *profile.Email != ""
+		if !wantsPush && !wantsEmail {
+			continue
+		}
+
+		notifs, err := h.notifications.ByUserSince(ctx, profile.UserID, since)
+		if err != nil {
+			h.logger.ErrorContext(ctx, "weekly digest: load notifications failed", "user", profile.UserID, "error", err)
+			continue
+		}
+		if len(notifs) == 0 {
+			continue
+		}
+
+		if wantsPush {
+			h.sendWeeklyPush(ctx, profile, len(notifs))
+		}
+		if wantsEmail {
+			h.sendDigestEmail(ctx, profile.UserID, *profile.Email, notifs)
+		}
+	}
+	return nil
+}
+
+// sendWeeklyPush builds and sends the weekly digest push, then prunes any device
+// tokens APNs reports invalid. A user with no devices is a no-op. The badge is
+// the total unread count derived from the watermark (first-touch users start at
+// the zero instant), distinct from the digest application count.
+func (h *Handler) sendWeeklyPush(ctx context.Context, profile *profiles.UserProfile, applicationCount int) {
+	devices, err := h.devices.ListByUser(ctx, profile.UserID)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "weekly digest: load devices failed", "user", profile.UserID, "error", err)
+		return
+	}
+	if len(devices) == 0 {
+		return
+	}
+
+	lastReadAt := time.Unix(0, 0).UTC()
+	st, err := h.state.Get(ctx, profile.UserID)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "weekly digest: load notification state failed", "user", profile.UserID, "error", err)
+		return
+	}
+	if st != nil {
+		lastReadAt = st.LastReadAt
+	}
+	totalUnread, err := h.state.UnreadCount(ctx, profile.UserID, lastReadAt)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "weekly digest: unread count failed", "user", profile.UserID, "error", err)
+		return
+	}
+
+	payload, err := buildDigestPayload(applicationCount, totalUnread)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "weekly digest: build payload failed", "user", profile.UserID, "error", err)
+		return
+	}
+
+	tokens := make([]string, 0, len(devices))
+	for _, d := range devices {
+		tokens = append(tokens, d.Token)
+	}
+
+	invalid, err := h.push.Send(ctx, tokens, payload)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "weekly digest: push send failed", "user", profile.UserID, "error", err)
+		return
+	}
+	for _, token := range invalid {
+		if err := h.devices.Delete(ctx, profile.UserID, token); err != nil {
+			h.logger.WarnContext(ctx, "weekly digest: prune invalid token failed", "user", profile.UserID, "error", err)
+		}
+	}
+}
+
+// RunHourly generates the hourly digest email for every paid user with unsent-email
+// notifications, honouring per-zone instant-email gating. It marks the included
+// notifications email-sent so the next cycle excludes them; excluded (per-zone
+// disabled) notifications are left unsent so the weekly digest can still pick them
+// up. It ports .NET GenerateHourlyDigestsCommandHandler.
+func (h *Handler) RunHourly(ctx context.Context) error {
+	userIDs, err := h.notifications.UserIDsWithUnsentEmails(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, userID := range userIDs {
+		profile, err := h.profiles.Get(ctx, userID)
+		if err != nil {
+			if errors.Is(err, profiles.ErrNotFound) {
+				continue
+			}
+			h.logger.ErrorContext(ctx, "hourly digest: load profile failed", "user", userID, "error", err)
+			continue
+		}
+		// Hourly digest emails are a paid entitlement (server-enforced) — Free tier
+		// is excluded even when email digests are enabled.
+		if !profile.Tier.HasHourlyDigestEntitlement() {
+			continue
+		}
+		if profile.Email == nil || *profile.Email == "" {
+			continue
+		}
+		if !profile.Preferences.EmailDigestEnabled {
+			continue
+		}
+
+		notifs, err := h.notifications.UnsentEmailsByUser(ctx, userID)
+		if err != nil {
+			h.logger.ErrorContext(ctx, "hourly digest: load unsent emails failed", "user", userID, "error", err)
+			continue
+		}
+		if len(notifs) == 0 {
+			continue
+		}
+
+		zones, err := h.zones.GetByUserID(ctx, userID)
+		if err != nil {
+			h.logger.ErrorContext(ctx, "hourly digest: load zones failed", "user", userID, "error", err)
+			continue
+		}
+
+		included := filterByInstantGate(notifs, zones)
+		if len(included) == 0 {
+			continue
+		}
+
+		h.sendDigestEmail(ctx, userID, *profile.Email, included)
+
+		for _, n := range included {
+			if err := h.notifications.MarkEmailSent(ctx, markSent(n)); err != nil {
+				h.logger.ErrorContext(ctx, "hourly digest: mark email sent failed", "user", userID, "notification", n.ID, "error", err)
+			}
+		}
+	}
+	return nil
+}
+
+// filterByInstantGate keeps notifications whose watch zone has instant email
+// enabled, plus all saved-only notifications (no zone — driven by the saved
+// bookmark contract, which bypasses the per-zone gate). Mirrors .NET's
+// instantEnabledZones filter.
+func filterByInstantGate(notifs []notifications.DigestNotification, zones []watchzones.WatchZone) []notifications.DigestNotification {
+	instantEnabled := make(map[string]struct{}, len(zones))
+	for _, z := range zones {
+		if z.EmailInstantEnabled {
+			instantEnabled[z.ID] = struct{}{}
+		}
+	}
+	included := make([]notifications.DigestNotification, 0, len(notifs))
+	for _, n := range notifs {
+		if n.WatchZoneID == nil {
+			included = append(included, n)
+			continue
+		}
+		if _, ok := instantEnabled[*n.WatchZoneID]; ok {
+			included = append(included, n)
+		}
+	}
+	return included
+}
+
+// markSent returns a copy of n with EmailSent set, ready to upsert.
+func markSent(n notifications.DigestNotification) notifications.DigestNotification {
+	n.MarkEmailSent()
+	return n
+}
+
+// sendDigestEmail groups the notifications by watch zone (with a saved-only
+// section for zone-less notifications), renders the email body, and hands it to
+// the transport-only email sender. A send failure is logged, not propagated — one
+// failed email must not abort the rest of the cycle, mirroring .NET's
+// catch-and-continue in AcsEmailSender.
+func (h *Handler) sendDigestEmail(ctx context.Context, userID, email string, notifs []notifications.DigestNotification) {
+	zones, err := h.zones.GetByUserID(ctx, userID)
+	if err != nil {
+		h.logger.ErrorContext(ctx, "digest email: load zones failed", "user", userID, "error", err)
+		return
+	}
+	zoneName := make(map[string]string, len(zones))
+	for _, z := range zones {
+		zoneName[z.ID] = z.Name
+	}
+
+	sections, saved, total := groupByZone(notifs, zoneName)
+
+	msg := acsemail.Message{
+		Sender:    senderAddress,
+		Recipient: email,
+		Subject:   buildDigestSubject(total),
+		HTMLBody:  buildDigestHTML(sections, saved, total),
+	}
+	if err := h.email.Send(ctx, msg); err != nil {
+		h.logger.ErrorContext(ctx, "digest email: send failed", "user", userID, "error", err)
+	}
+}
+
+// groupByZone partitions notifications into per-zone sections (preserving zone
+// order by first appearance) plus a saved-only slice for zone-less notifications,
+// returning the total count. An unknown zone id renders as "Unknown Zone",
+// mirroring .NET's zoneLookup.GetValueOrDefault fallback.
+func groupByZone(notifs []notifications.DigestNotification, zoneName map[string]string) (sections []watchZoneDigest, saved []notifications.DigestNotification, total int) {
+	index := map[string]int{}
+	for _, n := range notifs {
+		total++
+		if n.WatchZoneID == nil {
+			saved = append(saved, n)
+			continue
+		}
+		zoneID := *n.WatchZoneID
+		pos, ok := index[zoneID]
+		if !ok {
+			name := "Unknown Zone"
+			if display, found := zoneName[zoneID]; found {
+				name = display
+			}
+			sections = append(sections, watchZoneDigest{name: name})
+			pos = len(sections) - 1
+			index[zoneID] = pos
+		}
+		sections[pos].notifications = append(sections[pos].notifications, n)
+	}
+	return sections, saved, total
+}

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -1,0 +1,495 @@
+package digest
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/acsemail"
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// ---- hand-written fakes ----
+
+type fakeProfiles struct {
+	byDay   map[time.Weekday][]*profiles.UserProfile
+	byID    map[string]*profiles.UserProfile
+	byDayErr error
+}
+
+func (f *fakeProfiles) ByDigestDay(_ context.Context, day time.Weekday) ([]*profiles.UserProfile, error) {
+	if f.byDayErr != nil {
+		return nil, f.byDayErr
+	}
+	return f.byDay[day], nil
+}
+
+func (f *fakeProfiles) Get(_ context.Context, userID string) (*profiles.UserProfile, error) {
+	p, ok := f.byID[userID]
+	if !ok {
+		return nil, profiles.ErrNotFound
+	}
+	return p, nil
+}
+
+type fakeNotifications struct {
+	sinceByUser  map[string][]notifications.DigestNotification
+	unsentByUser map[string][]notifications.DigestNotification
+	unsentUserIDs []string
+	marked       []string // notification IDs marked email-sent
+}
+
+func (f *fakeNotifications) ByUserSince(_ context.Context, userID string, _ time.Time) ([]notifications.DigestNotification, error) {
+	return f.sinceByUser[userID], nil
+}
+
+func (f *fakeNotifications) UnsentEmailsByUser(_ context.Context, userID string) ([]notifications.DigestNotification, error) {
+	return f.unsentByUser[userID], nil
+}
+
+func (f *fakeNotifications) UserIDsWithUnsentEmails(_ context.Context) ([]string, error) {
+	return f.unsentUserIDs, nil
+}
+
+func (f *fakeNotifications) MarkEmailSent(_ context.Context, n notifications.DigestNotification) error {
+	f.marked = append(f.marked, n.ID)
+	return nil
+}
+
+type fakeZones struct {
+	byUser map[string][]watchzones.WatchZone
+}
+
+func (f *fakeZones) GetByUserID(_ context.Context, userID string) ([]watchzones.WatchZone, error) {
+	return f.byUser[userID], nil
+}
+
+type fakeState struct {
+	byUser map[string]*notificationstate.State
+	unread map[string]int
+}
+
+func (f *fakeState) Get(_ context.Context, userID string) (*notificationstate.State, error) {
+	return f.byUser[userID], nil
+}
+
+func (f *fakeState) UnreadCount(_ context.Context, userID string, _ time.Time) (int, error) {
+	return f.unread[userID], nil
+}
+
+type fakeDevices struct {
+	byUser  map[string][]devicetokens.DeviceRegistration
+	deleted []string // tokens deleted
+}
+
+func (f *fakeDevices) ListByUser(_ context.Context, userID string) ([]devicetokens.DeviceRegistration, error) {
+	return f.byUser[userID], nil
+}
+
+func (f *fakeDevices) Delete(_ context.Context, _ string, token string) error {
+	f.deleted = append(f.deleted, token)
+	return nil
+}
+
+type spyEmail struct {
+	sent []acsemail.Message
+}
+
+func (s *spyEmail) Send(_ context.Context, msg acsemail.Message) error {
+	s.sent = append(s.sent, msg)
+	return nil
+}
+
+type spyPush struct {
+	calls   int
+	tokens  []string
+	payload json.RawMessage
+	invalid []string // tokens to report invalid on the next Send
+}
+
+func (s *spyPush) Send(_ context.Context, tokens []string, payload json.RawMessage) ([]string, error) {
+	s.calls++
+	s.tokens = tokens
+	s.payload = payload
+	return s.invalid, nil
+}
+
+// ---- helpers ----
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+}
+
+func mkProfile(t *testing.T, userID, email string, tier profiles.SubscriptionTier, prefs profiles.NotificationPreferences) *profiles.UserProfile {
+	t.Helper()
+	p, err := profiles.NewProfile(userID, email, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	p.Tier = tier
+	p.Preferences = prefs
+	return p
+}
+
+func mkZone(t *testing.T, id, userID, name string, emailInstant bool) watchzones.WatchZone {
+	t.Helper()
+	z, err := watchzones.NewWatchZone(id, userID, name, 51.5, -0.1, 500, 1, time.Now(), true, emailInstant)
+	if err != nil {
+		t.Fatalf("NewWatchZone: %v", err)
+	}
+	return z
+}
+
+func zoneNotif(userID, uid, zoneID string) notifications.DigestNotification {
+	z := zoneID
+	return notifications.DigestNotification{
+		ID:                     "n-" + uid,
+		UserID:                 userID,
+		ApplicationUID:         uid,
+		ApplicationName:        uid,
+		WatchZoneID:            &z,
+		ApplicationAddress:     "addr " + uid,
+		ApplicationDescription: "desc",
+		EventType:              notifications.EventNewApplication,
+		AuthorityID:            1,
+		CreatedAt:              time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+	}
+}
+
+func newHandler(p *fakeProfiles, n *fakeNotifications, z *fakeZones, st *fakeState, d *fakeDevices, email acsemail.EmailSender, push interface {
+	Send(context.Context, []string, json.RawMessage) ([]string, error)
+}) *Handler {
+	return NewHandler(p, n, z, st, d, email, push, testLogger(), func() time.Time {
+		// Pin "now" to a Wednesday so weekly tests select the Wednesday digest day.
+		return time.Date(2026, 2, 4, 9, 0, 0, 0, time.UTC) // 2026-02-04 is a Wednesday
+	})
+}
+
+// ---- weekly tests ----
+
+func TestRunWeekly_EmailGroupsByZoneAndSavedSection(t *testing.T) {
+	t.Parallel()
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	prefs.PushEnabled = false
+	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierFree, prefs)
+
+	zoneN := zoneNotif("user-1", "uid-A", "zone-1")
+	savedN := zoneNotif("user-1", "uid-B", "")
+	savedN.WatchZoneID = nil // saved-only (no zone)
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
+		"user-1": {zoneN, savedN},
+	}}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "user-1", "Home", true)},
+	}}
+	email := &spyEmail{}
+	push := &spyPush{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, push)
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+
+	if len(email.sent) != 1 {
+		t.Fatalf("emails sent: got %d, want 1", len(email.sent))
+	}
+	msg := email.sent[0]
+	if msg.Recipient != "u1@example.com" || msg.Sender != senderAddress {
+		t.Errorf("recipient/sender: got %q / %q", msg.Recipient, msg.Sender)
+	}
+	if !contains(msg.HTMLBody, "Home") || !contains(msg.HTMLBody, "Saved Applications") {
+		t.Errorf("body missing zone or saved section:\n%s", msg.HTMLBody)
+	}
+	if !contains(msg.HTMLBody, "addr uid-A") || !contains(msg.HTMLBody, "addr uid-B") {
+		t.Errorf("body missing notification addresses:\n%s", msg.HTMLBody)
+	}
+	// Email-only profile: no push.
+	if push.calls != 0 {
+		t.Errorf("push calls: got %d, want 0 (email-only profile)", push.calls)
+	}
+}
+
+func TestRunWeekly_FreeTierGetsEmailButNoPush(t *testing.T) {
+	t.Parallel()
+	// Free tier: weekly digest EMAIL is allowed; the digest PUSH is Pro-only.
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	prefs.PushEnabled = true // push is on, but tier is Free -> no push
+	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierFree, prefs)
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
+		"user-1": {zoneNotif("user-1", "uid-A", "zone-1")},
+	}}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "user-1", "Home", true)},
+	}}
+	devices := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
+		"user-1": {{UserID: "user-1", Token: "tok-1", Platform: devicetokens.PlatformIos}},
+	}}
+	email := &spyEmail{}
+	push := &spyPush{}
+	h := newHandler(fp, fn, fz, &fakeState{}, devices, email, push)
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+	if len(email.sent) != 1 {
+		t.Errorf("free tier should still get the weekly email: got %d", len(email.sent))
+	}
+	if push.calls != 0 {
+		t.Errorf("free tier must NOT get a digest push: got %d push calls", push.calls)
+	}
+}
+
+func TestRunWeekly_ProTierGetsPushWithBadgeAndPrunesInvalidTokens(t *testing.T) {
+	t.Parallel()
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = false
+	prefs.PushEnabled = true
+	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierPro, prefs)
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
+		"user-1": {zoneNotif("user-1", "uid-A", "zone-1"), zoneNotif("user-1", "uid-B", "zone-1")},
+	}}
+	state := &fakeState{
+		byUser: map[string]*notificationstate.State{
+			"user-1": {UserID: "user-1", LastReadAt: time.Unix(0, 0), Version: 1},
+		},
+		unread: map[string]int{"user-1": 5},
+	}
+	devices := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
+		"user-1": {
+			{UserID: "user-1", Token: "good-token", Platform: devicetokens.PlatformIos},
+			{UserID: "user-1", Token: "dead-token", Platform: devicetokens.PlatformIos},
+		},
+	}}
+	email := &spyEmail{}
+	push := &spyPush{invalid: []string{"dead-token"}}
+	h := newHandler(fp, fn, &fakeZones{}, state, devices, email, push)
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+	if push.calls != 1 {
+		t.Fatalf("push calls: got %d, want 1", push.calls)
+	}
+	if len(push.tokens) != 2 {
+		t.Errorf("push tokens: got %v, want 2", push.tokens)
+	}
+	// Badge = total unread count (5), body = 2 applications this week.
+	var parsed struct {
+		Aps struct {
+			Alert struct {
+				Body string `json:"body"`
+			} `json:"alert"`
+			Badge int `json:"badge"`
+		} `json:"aps"`
+	}
+	if err := json.Unmarshal(push.payload, &parsed); err != nil {
+		t.Fatalf("payload unmarshal: %v", err)
+	}
+	if parsed.Aps.Badge != 5 {
+		t.Errorf("badge: got %d, want 5 (total unread)", parsed.Aps.Badge)
+	}
+	if parsed.Aps.Alert.Body != "2 new applications this week" {
+		t.Errorf("body: got %q", parsed.Aps.Alert.Body)
+	}
+	// Invalid token pruned.
+	if len(devices.deleted) != 1 || devices.deleted[0] != "dead-token" {
+		t.Errorf("pruned tokens: got %v, want [dead-token]", devices.deleted)
+	}
+}
+
+func TestRunWeekly_SkipsUsersWithNoNotifications(t *testing.T) {
+	t.Parallel()
+	prefs := profiles.DefaultPreferences()
+	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierPro, prefs)
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{} // no notifications for anyone
+	email := &spyEmail{}
+	push := &spyPush{}
+	h := newHandler(fp, fn, &fakeZones{}, &fakeState{}, &fakeDevices{}, email, push)
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+	if len(email.sent) != 0 || push.calls != 0 {
+		t.Errorf("no-notification user should be skipped: emails=%d pushes=%d", len(email.sent), push.calls)
+	}
+}
+
+// ---- hourly tests ----
+
+func TestRunHourly_PaidTierSendsAndMarksEmailSent(t *testing.T) {
+	t.Parallel()
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierPro, prefs)
+
+	n1 := zoneNotif("user-1", "uid-A", "zone-1")
+	n2 := zoneNotif("user-1", "uid-B", "") // saved-only bypasses per-zone gate
+	n2.WatchZoneID = nil
+
+	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
+	fn := &fakeNotifications{
+		unsentUserIDs: []string{"user-1"},
+		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {n1, n2}},
+	}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "user-1", "Home", true)}, // instant enabled
+	}}
+	email := &spyEmail{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+	if err := h.RunHourly(context.Background()); err != nil {
+		t.Fatalf("RunHourly: %v", err)
+	}
+	if len(email.sent) != 1 {
+		t.Fatalf("emails sent: got %d, want 1", len(email.sent))
+	}
+	// Both included notifications marked email-sent for dedup.
+	if len(fn.marked) != 2 {
+		t.Errorf("marked email-sent: got %v, want 2", fn.marked)
+	}
+}
+
+func TestRunHourly_FreeTierSkipped(t *testing.T) {
+	t.Parallel()
+	// Free tier has no HourlyDigestEmails entitlement; hourly is paid-only.
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierFree, prefs)
+
+	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
+	fn := &fakeNotifications{
+		unsentUserIDs: []string{"user-1"},
+		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {zoneNotif("user-1", "uid-A", "zone-1")}},
+	}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "user-1", "Home", true)},
+	}}
+	email := &spyEmail{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+	if err := h.RunHourly(context.Background()); err != nil {
+		t.Fatalf("RunHourly: %v", err)
+	}
+	if len(email.sent) != 0 {
+		t.Errorf("free tier must NOT get an hourly email: got %d", len(email.sent))
+	}
+	if len(fn.marked) != 0 {
+		t.Errorf("free tier skip must not mark anything sent: got %v", fn.marked)
+	}
+}
+
+func TestRunHourly_PerZoneInstantGatingExcludesDisabledZone(t *testing.T) {
+	t.Parallel()
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierPro, prefs)
+
+	inZone := zoneNotif("user-1", "uid-IN", "zone-on")
+	offZone := zoneNotif("user-1", "uid-OFF", "zone-off")
+
+	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
+	fn := &fakeNotifications{
+		unsentUserIDs: []string{"user-1"},
+		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {inZone, offZone}},
+	}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {
+			mkZone(t, "zone-on", "user-1", "On", true),
+			mkZone(t, "zone-off", "user-1", "Off", false), // instant disabled
+		},
+	}}
+	email := &spyEmail{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+	if err := h.RunHourly(context.Background()); err != nil {
+		t.Fatalf("RunHourly: %v", err)
+	}
+	if len(email.sent) != 1 {
+		t.Fatalf("emails sent: got %d, want 1", len(email.sent))
+	}
+	body := email.sent[0].HTMLBody
+	if !contains(body, "addr uid-IN") {
+		t.Errorf("instant-enabled zone notification should be included:\n%s", body)
+	}
+	if contains(body, "addr uid-OFF") {
+		t.Errorf("instant-disabled zone notification must be excluded:\n%s", body)
+	}
+	// Only the included notification is marked sent; the excluded one stays unsent
+	// so the weekly digest can still pick it up.
+	if len(fn.marked) != 1 || fn.marked[0] != "n-uid-IN" {
+		t.Errorf("marked: got %v, want [n-uid-IN]", fn.marked)
+	}
+}
+
+func TestRunHourly_AllZonesDisabledSendsNothing(t *testing.T) {
+	t.Parallel()
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierPro, prefs)
+
+	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
+	fn := &fakeNotifications{
+		unsentUserIDs: []string{"user-1"},
+		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {zoneNotif("user-1", "uid-OFF", "zone-off")}},
+	}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-off", "user-1", "Off", false)},
+	}}
+	email := &spyEmail{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+	if err := h.RunHourly(context.Background()); err != nil {
+		t.Fatalf("RunHourly: %v", err)
+	}
+	if len(email.sent) != 0 || len(fn.marked) != 0 {
+		t.Errorf("all-zones-disabled: emails=%d marked=%v, want 0 / none", len(email.sent), fn.marked)
+	}
+}
+
+func TestRunHourly_NoOpSenderDropsEmailButStillMarksSent(t *testing.T) {
+	t.Parallel()
+	// With a NoOp email sender wired (senders disabled), the cycle still runs and
+	// marks notifications sent — the NoOp returns nil, so dedup proceeds.
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierPro, prefs)
+
+	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
+	fn := &fakeNotifications{
+		unsentUserIDs: []string{"user-1"},
+		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {zoneNotif("user-1", "uid-A", "zone-1")}},
+	}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "user-1", "Home", true)},
+	}}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, acsemail.NewNoOpSender(), &spyPush{})
+
+	if err := h.RunHourly(context.Background()); err != nil {
+		t.Fatalf("RunHourly: %v", err)
+	}
+	if len(fn.marked) != 1 {
+		t.Errorf("NoOp path should still mark sent: got %v", fn.marked)
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return strings.Contains(haystack, needle)
+}

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -17,11 +17,16 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
+const (
+	testUser  = "user-1"
+	testEmail = "u1@example.com"
+)
+
 // ---- hand-written fakes ----
 
 type fakeProfiles struct {
-	byDay   map[time.Weekday][]*profiles.UserProfile
-	byID    map[string]*profiles.UserProfile
+	byDay    map[time.Weekday][]*profiles.UserProfile
+	byID     map[string]*profiles.UserProfile
 	byDayErr error
 }
 
@@ -41,10 +46,10 @@ func (f *fakeProfiles) Get(_ context.Context, userID string) (*profiles.UserProf
 }
 
 type fakeNotifications struct {
-	sinceByUser  map[string][]notifications.DigestNotification
-	unsentByUser map[string][]notifications.DigestNotification
+	sinceByUser   map[string][]notifications.DigestNotification
+	unsentByUser  map[string][]notifications.DigestNotification
 	unsentUserIDs []string
-	marked       []string // notification IDs marked email-sent
+	marked        []string // notification IDs marked email-sent
 }
 
 func (f *fakeNotifications) ByUserSince(_ context.Context, userID string, _ time.Time) ([]notifications.DigestNotification, error) {
@@ -128,9 +133,9 @@ func testLogger() *slog.Logger {
 	return slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 }
 
-func mkProfile(t *testing.T, userID, email string, tier profiles.SubscriptionTier, prefs profiles.NotificationPreferences) *profiles.UserProfile {
+func mkProfile(t *testing.T, tier profiles.SubscriptionTier, prefs profiles.NotificationPreferences) *profiles.UserProfile {
 	t.Helper()
-	p, err := profiles.NewProfile(userID, email, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	p, err := profiles.NewProfile(testUser, testEmail, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	if err != nil {
 		t.Fatalf("NewProfile: %v", err)
 	}
@@ -139,20 +144,20 @@ func mkProfile(t *testing.T, userID, email string, tier profiles.SubscriptionTie
 	return p
 }
 
-func mkZone(t *testing.T, id, userID, name string, emailInstant bool) watchzones.WatchZone {
+func mkZone(t *testing.T, id, name string, emailInstant bool) watchzones.WatchZone {
 	t.Helper()
-	z, err := watchzones.NewWatchZone(id, userID, name, 51.5, -0.1, 500, 1, time.Now(), true, emailInstant)
+	z, err := watchzones.NewWatchZone(id, testUser, name, 51.5, -0.1, 500, 1, time.Now(), true, emailInstant)
 	if err != nil {
 		t.Fatalf("NewWatchZone: %v", err)
 	}
 	return z
 }
 
-func zoneNotif(userID, uid, zoneID string) notifications.DigestNotification {
+func zoneNotif(uid, zoneID string) notifications.DigestNotification {
 	z := zoneID
 	return notifications.DigestNotification{
 		ID:                     "n-" + uid,
-		UserID:                 userID,
+		UserID:                 testUser,
 		ApplicationUID:         uid,
 		ApplicationName:        uid,
 		WatchZoneID:            &z,
@@ -180,10 +185,10 @@ func TestRunWeekly_EmailGroupsByZoneAndSavedSection(t *testing.T) {
 	prefs := profiles.DefaultPreferences()
 	prefs.EmailDigestEnabled = true
 	prefs.PushEnabled = false
-	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierFree, prefs)
+	p := mkProfile(t, profiles.TierFree, prefs)
 
-	zoneN := zoneNotif("user-1", "uid-A", "zone-1")
-	savedN := zoneNotif("user-1", "uid-B", "")
+	zoneN := zoneNotif("uid-A", "zone-1")
+	savedN := zoneNotif("uid-B", "")
 	savedN.WatchZoneID = nil // saved-only (no zone)
 
 	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
@@ -191,7 +196,7 @@ func TestRunWeekly_EmailGroupsByZoneAndSavedSection(t *testing.T) {
 		"user-1": {zoneN, savedN},
 	}}
 	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
-		"user-1": {mkZone(t, "zone-1", "user-1", "Home", true)},
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
 	}}
 	email := &spyEmail{}
 	push := &spyPush{}
@@ -226,14 +231,14 @@ func TestRunWeekly_FreeTierGetsEmailButNoPush(t *testing.T) {
 	prefs := profiles.DefaultPreferences()
 	prefs.EmailDigestEnabled = true
 	prefs.PushEnabled = true // push is on, but tier is Free -> no push
-	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierFree, prefs)
+	p := mkProfile(t, profiles.TierFree, prefs)
 
 	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
 	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
-		"user-1": {zoneNotif("user-1", "uid-A", "zone-1")},
+		"user-1": {zoneNotif("uid-A", "zone-1")},
 	}}
 	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
-		"user-1": {mkZone(t, "zone-1", "user-1", "Home", true)},
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
 	}}
 	devices := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
 		"user-1": {{UserID: "user-1", Token: "tok-1", Platform: devicetokens.PlatformIos}},
@@ -258,11 +263,11 @@ func TestRunWeekly_ProTierGetsPushWithBadgeAndPrunesInvalidTokens(t *testing.T) 
 	prefs := profiles.DefaultPreferences()
 	prefs.EmailDigestEnabled = false
 	prefs.PushEnabled = true
-	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierPro, prefs)
+	p := mkProfile(t, profiles.TierPro, prefs)
 
 	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
 	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
-		"user-1": {zoneNotif("user-1", "uid-A", "zone-1"), zoneNotif("user-1", "uid-B", "zone-1")},
+		"user-1": {zoneNotif("uid-A", "zone-1"), zoneNotif("uid-B", "zone-1")},
 	}}
 	state := &fakeState{
 		byUser: map[string]*notificationstate.State{
@@ -316,7 +321,7 @@ func TestRunWeekly_ProTierGetsPushWithBadgeAndPrunesInvalidTokens(t *testing.T) 
 func TestRunWeekly_SkipsUsersWithNoNotifications(t *testing.T) {
 	t.Parallel()
 	prefs := profiles.DefaultPreferences()
-	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierPro, prefs)
+	p := mkProfile(t, profiles.TierPro, prefs)
 
 	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
 	fn := &fakeNotifications{} // no notifications for anyone
@@ -338,10 +343,10 @@ func TestRunHourly_PaidTierSendsAndMarksEmailSent(t *testing.T) {
 	t.Parallel()
 	prefs := profiles.DefaultPreferences()
 	prefs.EmailDigestEnabled = true
-	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierPro, prefs)
+	p := mkProfile(t, profiles.TierPro, prefs)
 
-	n1 := zoneNotif("user-1", "uid-A", "zone-1")
-	n2 := zoneNotif("user-1", "uid-B", "") // saved-only bypasses per-zone gate
+	n1 := zoneNotif("uid-A", "zone-1")
+	n2 := zoneNotif("uid-B", "") // saved-only bypasses per-zone gate
 	n2.WatchZoneID = nil
 
 	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
@@ -350,7 +355,7 @@ func TestRunHourly_PaidTierSendsAndMarksEmailSent(t *testing.T) {
 		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {n1, n2}},
 	}
 	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
-		"user-1": {mkZone(t, "zone-1", "user-1", "Home", true)}, // instant enabled
+		"user-1": {mkZone(t, "zone-1", "Home", true)}, // instant enabled
 	}}
 	email := &spyEmail{}
 	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
@@ -372,15 +377,15 @@ func TestRunHourly_FreeTierSkipped(t *testing.T) {
 	// Free tier has no HourlyDigestEmails entitlement; hourly is paid-only.
 	prefs := profiles.DefaultPreferences()
 	prefs.EmailDigestEnabled = true
-	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierFree, prefs)
+	p := mkProfile(t, profiles.TierFree, prefs)
 
 	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
 	fn := &fakeNotifications{
 		unsentUserIDs: []string{"user-1"},
-		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {zoneNotif("user-1", "uid-A", "zone-1")}},
+		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {zoneNotif("uid-A", "zone-1")}},
 	}
 	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
-		"user-1": {mkZone(t, "zone-1", "user-1", "Home", true)},
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
 	}}
 	email := &spyEmail{}
 	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
@@ -400,10 +405,10 @@ func TestRunHourly_PerZoneInstantGatingExcludesDisabledZone(t *testing.T) {
 	t.Parallel()
 	prefs := profiles.DefaultPreferences()
 	prefs.EmailDigestEnabled = true
-	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierPro, prefs)
+	p := mkProfile(t, profiles.TierPro, prefs)
 
-	inZone := zoneNotif("user-1", "uid-IN", "zone-on")
-	offZone := zoneNotif("user-1", "uid-OFF", "zone-off")
+	inZone := zoneNotif("uid-IN", "zone-on")
+	offZone := zoneNotif("uid-OFF", "zone-off")
 
 	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
 	fn := &fakeNotifications{
@@ -412,8 +417,8 @@ func TestRunHourly_PerZoneInstantGatingExcludesDisabledZone(t *testing.T) {
 	}
 	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
 		"user-1": {
-			mkZone(t, "zone-on", "user-1", "On", true),
-			mkZone(t, "zone-off", "user-1", "Off", false), // instant disabled
+			mkZone(t, "zone-on", "On", true),
+			mkZone(t, "zone-off", "Off", false), // instant disabled
 		},
 	}}
 	email := &spyEmail{}
@@ -443,15 +448,15 @@ func TestRunHourly_AllZonesDisabledSendsNothing(t *testing.T) {
 	t.Parallel()
 	prefs := profiles.DefaultPreferences()
 	prefs.EmailDigestEnabled = true
-	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierPro, prefs)
+	p := mkProfile(t, profiles.TierPro, prefs)
 
 	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
 	fn := &fakeNotifications{
 		unsentUserIDs: []string{"user-1"},
-		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {zoneNotif("user-1", "uid-OFF", "zone-off")}},
+		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {zoneNotif("uid-OFF", "zone-off")}},
 	}
 	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
-		"user-1": {mkZone(t, "zone-off", "user-1", "Off", false)},
+		"user-1": {mkZone(t, "zone-off", "Off", false)},
 	}}
 	email := &spyEmail{}
 	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
@@ -470,15 +475,15 @@ func TestRunHourly_NoOpSenderDropsEmailButStillMarksSent(t *testing.T) {
 	// marks notifications sent — the NoOp returns nil, so dedup proceeds.
 	prefs := profiles.DefaultPreferences()
 	prefs.EmailDigestEnabled = true
-	p := mkProfile(t, "user-1", "u1@example.com", profiles.TierPro, prefs)
+	p := mkProfile(t, profiles.TierPro, prefs)
 
 	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
 	fn := &fakeNotifications{
 		unsentUserIDs: []string{"user-1"},
-		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {zoneNotif("user-1", "uid-A", "zone-1")}},
+		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {zoneNotif("uid-A", "zone-1")}},
 	}
 	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
-		"user-1": {mkZone(t, "zone-1", "user-1", "Home", true)},
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
 	}}
 	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, acsemail.NewNoOpSender(), &spyPush{})
 

--- a/api-go/internal/digest/payload.go
+++ b/api-go/internal/digest/payload.go
@@ -1,0 +1,48 @@
+package digest
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// apnsDigestPayload is the APNs body for a digest push: {"aps":{...}}. The JSON
+// keys match the .NET ApnsDigestPayload / ApnsDigestAps / ApnsAlertContent shapes
+// exactly so the iOS client receives an unchanged payload across the cutover.
+type apnsDigestPayload struct {
+	Aps apnsDigestAps `json:"aps"`
+}
+
+type apnsDigestAps struct {
+	Alert apnsAlertContent `json:"alert"`
+	Sound string           `json:"sound"`
+	Badge int              `json:"badge"`
+}
+
+type apnsAlertContent struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+// buildDigestPayload renders the APNs digest push body. applicationCount is the
+// number of applications in the digest window (rendered in the body copy);
+// totalUnreadCount is the user's total unread tally surfaced as the app icon
+// badge — the two are deliberately distinct, matching .NET BuildDigestPayload.
+func buildDigestPayload(applicationCount, totalUnreadCount int) (json.RawMessage, error) {
+	plural := "s"
+	if applicationCount == 1 {
+		plural = ""
+	}
+	body := fmt.Sprintf("%d new application%s this week", applicationCount, plural)
+
+	raw, err := json.Marshal(apnsDigestPayload{
+		Aps: apnsDigestAps{
+			Alert: apnsAlertContent{Title: "Town Crier", Body: body},
+			Sound: "default",
+			Badge: totalUnreadCount,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal digest payload: %w", err)
+	}
+	return raw, nil
+}

--- a/api-go/internal/digest/payload_test.go
+++ b/api-go/internal/digest/payload_test.go
@@ -1,0 +1,64 @@
+package digest
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBuildDigestPayload_Shape(t *testing.T) {
+	t.Parallel()
+	raw, err := buildDigestPayload(3, 7)
+	if err != nil {
+		t.Fatalf("buildDigestPayload: %v", err)
+	}
+
+	var parsed struct {
+		Aps struct {
+			Alert struct {
+				Title string `json:"title"`
+				Body  string `json:"body"`
+			} `json:"alert"`
+			Sound string `json:"sound"`
+			Badge int    `json:"badge"`
+		} `json:"aps"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+
+	if parsed.Aps.Alert.Title != "Town Crier" {
+		t.Errorf("title: got %q, want Town Crier", parsed.Aps.Alert.Title)
+	}
+	if parsed.Aps.Alert.Body != "3 new applications this week" {
+		t.Errorf("body: got %q", parsed.Aps.Alert.Body)
+	}
+	if parsed.Aps.Sound != "default" {
+		t.Errorf("sound: got %q, want default", parsed.Aps.Sound)
+	}
+	// The badge is the total unread count, distinct from the digest application
+	// count.
+	if parsed.Aps.Badge != 7 {
+		t.Errorf("badge: got %d, want 7", parsed.Aps.Badge)
+	}
+}
+
+func TestBuildDigestPayload_SingularBody(t *testing.T) {
+	t.Parallel()
+	raw, err := buildDigestPayload(1, 1)
+	if err != nil {
+		t.Fatalf("buildDigestPayload: %v", err)
+	}
+	var parsed struct {
+		Aps struct {
+			Alert struct {
+				Body string `json:"body"`
+			} `json:"alert"`
+		} `json:"aps"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if parsed.Aps.Alert.Body != "1 new application this week" {
+		t.Errorf("singular body: got %q", parsed.Aps.Alert.Body)
+	}
+}

--- a/api-go/internal/digest/vocabulary.go
+++ b/api-go/internal/digest/vocabulary.go
@@ -1,0 +1,27 @@
+package digest
+
+import "strings"
+
+// ukDisplayString maps a raw PlanIt app_state ("Permitted", "Conditions",
+// "Rejected", "Appealed") to the UK planning term residents recognise
+// ("Approved", "Approved with conditions", "Refused", "Refusal appealed"),
+// returning "" for a nil or unrecognised input. Matching is case-insensitive to
+// tolerate upstream casing drift. Port of .NET UkPlanningVocabulary.GetDisplayString.
+func ukDisplayString(planItAppState *string) string {
+	if planItAppState == nil {
+		return ""
+	}
+	state := strings.TrimSpace(*planItAppState)
+	switch {
+	case strings.EqualFold(state, "Permitted"):
+		return "Approved"
+	case strings.EqualFold(state, "Conditions"):
+		return "Approved with conditions"
+	case strings.EqualFold(state, "Rejected"):
+		return "Refused"
+	case strings.EqualFold(state, "Appealed"):
+		return "Refusal appealed"
+	default:
+		return ""
+	}
+}

--- a/api-go/internal/notifications/digest.go
+++ b/api-go/internal/notifications/digest.go
@@ -1,0 +1,141 @@
+package notifications
+
+import (
+	"strings"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// ninetyDaysSeconds is the TTL the .NET NotificationDocument writes so dispatched
+// notifications expire after 90 days. Preserved here so a Go-written document
+// matches the .NET retention.
+const ninetyDaysSeconds = 90 * 24 * 60 * 60
+
+// DigestNotification is the full read/write model the digest worker needs — the
+// complete Notifications-container document, not the latest-unread projection
+// used by the web API. It carries every field the digest email body and APNs
+// payload render, plus the EmailSent flag the hourly cycle flips after a
+// successful send. It mirrors the .NET Notification aggregate.
+type DigestNotification struct {
+	ID                     string
+	UserID                 string
+	ApplicationUID         string
+	ApplicationName        string
+	WatchZoneID            *string
+	ApplicationAddress     string
+	ApplicationDescription string
+	ApplicationType        *string
+	AuthorityID            int
+	Decision               *string
+	EventType              EventType
+	Sources                string
+	PushSent               bool
+	EmailSent              bool
+	CreatedAt              time.Time
+}
+
+// HasSavedSource reports whether the notification was produced (in part) by the
+// user's Saved list. It mirrors .NET's NotificationSources.HasFlag(Saved), used
+// to render the "★ saved" indicator on a zone card.
+func (n DigestNotification) HasSavedSource() bool {
+	for _, part := range strings.Split(n.Sources, ",") {
+		if strings.EqualFold(strings.TrimSpace(part), "Saved") {
+			return true
+		}
+	}
+	return false
+}
+
+// MarkEmailSent flips EmailSent so the persisted document is excluded from the
+// next hourly cycle's unsent-emails query, mirroring .NET Notification.MarkEmailSent.
+func (n *DigestNotification) MarkEmailSent() {
+	n.EmailSent = true
+}
+
+// digestDocument is the full Cosmos persistence shape of a Notifications-container
+// document. The JSON keys reproduce the .NET NotificationDocument camelCase so a
+// Go-written document is byte-compatible with the existing container. Nullable
+// pointer fields hydrate legacy rows (predating eventType/sources/applicationUid)
+// with the backfill defaults, matching .NET's lazy coalesce on read.
+type digestDocument struct {
+	ID                     string              `json:"id"`
+	UserID                 string              `json:"userId"`
+	ApplicationUID         *string             `json:"applicationUid"`
+	ApplicationName        string              `json:"applicationName"`
+	WatchZoneID            *string             `json:"watchZoneId"`
+	ApplicationAddress     string              `json:"applicationAddress"`
+	ApplicationDescription string              `json:"applicationDescription"`
+	ApplicationType        *string             `json:"applicationType"`
+	AuthorityID            int                 `json:"authorityId"`
+	Decision               *string             `json:"decision"`
+	EventType              *string             `json:"eventType"`
+	Sources                *string             `json:"sources"`
+	PushSent               bool                `json:"pushSent"`
+	EmailSent              bool                `json:"emailSent"`
+	CreatedAt              platform.DotNetTime `json:"createdAt"`
+	TTL                    int                 `json:"ttl"`
+}
+
+// toDigest hydrates the full digest model from a stored document, coalescing the
+// legacy nulls: a null eventType becomes NewApplication, a null applicationUid
+// falls back to applicationName, and an absent sources stays empty (only the
+// Saved check reads it, and a legacy Zone-only row has no Saved indicator).
+func (d digestDocument) toDigest() DigestNotification {
+	eventType := EventNewApplication
+	if d.EventType != nil && *d.EventType != "" {
+		eventType = EventType(*d.EventType)
+	}
+	uid := d.ApplicationName
+	if d.ApplicationUID != nil && *d.ApplicationUID != "" {
+		uid = *d.ApplicationUID
+	}
+	sources := ""
+	if d.Sources != nil {
+		sources = *d.Sources
+	}
+	return DigestNotification{
+		ID:                     d.ID,
+		UserID:                 d.UserID,
+		ApplicationUID:         uid,
+		ApplicationName:        d.ApplicationName,
+		WatchZoneID:            d.WatchZoneID,
+		ApplicationAddress:     d.ApplicationAddress,
+		ApplicationDescription: d.ApplicationDescription,
+		ApplicationType:        d.ApplicationType,
+		AuthorityID:            d.AuthorityID,
+		Decision:               d.Decision,
+		EventType:              eventType,
+		Sources:                sources,
+		PushSent:               d.PushSent,
+		EmailSent:              d.EmailSent,
+		CreatedAt:              time.Time(d.CreatedAt),
+	}
+}
+
+// newDigestDocument maps the digest model back to its persistence shape for the
+// MarkEmailSent upsert. It always writes the 90-day TTL so re-saved documents
+// keep the .NET retention.
+func newDigestDocument(n DigestNotification) digestDocument {
+	eventType := string(n.EventType)
+	sources := n.Sources
+	uid := n.ApplicationUID
+	return digestDocument{
+		ID:                     n.ID,
+		UserID:                 n.UserID,
+		ApplicationUID:         &uid,
+		ApplicationName:        n.ApplicationName,
+		WatchZoneID:            n.WatchZoneID,
+		ApplicationAddress:     n.ApplicationAddress,
+		ApplicationDescription: n.ApplicationDescription,
+		ApplicationType:        n.ApplicationType,
+		AuthorityID:            n.AuthorityID,
+		Decision:               n.Decision,
+		EventType:              &eventType,
+		Sources:                &sources,
+		PushSent:               n.PushSent,
+		EmailSent:              n.EmailSent,
+		CreatedAt:              platform.DotNetTime(n.CreatedAt),
+		TTL:                    ninetyDaysSeconds,
+	}
+}

--- a/api-go/internal/notifications/digest_store_cosmos.go
+++ b/api-go/internal/notifications/digest_store_cosmos.go
@@ -1,0 +1,120 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// DigestItems is the consumer-side slice of the Notifications container the
+// digest store uses: a single-partition query (a user's recent / unsent rows), a
+// cross-partition DISTINCT projection (the users with unsent emails), and an
+// upsert (writing back the emailSent flag). platform.CosmosContainer satisfies
+// it structurally.
+type DigestItems interface {
+	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
+	QueryItemsCrossPartition(ctx context.Context, query string, params map[string]any) ([][]byte, error)
+	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
+}
+
+// DigestStore reads and writes the full Notifications-container documents the
+// digest worker needs. It is separate from CosmosStore (the web API's
+// latest-unread projection) because it hydrates the complete document and writes
+// the emailSent flag back.
+//
+// Partition strategy: the container is partitioned by /userId. The per-user
+// reads target one partition; the unsent-email user list is the only
+// cross-partition scan, mirroring .NET's GetUserIdsWithUnsentEmailsCrossPartition.
+type DigestStore struct {
+	items DigestItems
+}
+
+// NewDigestStore returns a digest store backed by the given Cosmos item accessor.
+func NewDigestStore(items DigestItems) *DigestStore {
+	return &DigestStore{items: items}
+}
+
+// byUserSinceQuery selects a user's notifications created at or after a cutoff,
+// newest first — the weekly-digest window. Mirrors .NET GetByUserSinceAsync.
+const byUserSinceQuery = "SELECT * FROM c WHERE c.userId = @userId AND c.createdAt >= @since ORDER BY c.createdAt DESC"
+
+// ByUserSince returns the user's notifications created at or after since, used by
+// the weekly digest to gather the past week's activity.
+func (s *DigestStore) ByUserSince(ctx context.Context, userID string, since time.Time) ([]DigestNotification, error) {
+	raws, err := s.items.QueryItems(ctx, userID, byUserSinceQuery, map[string]any{
+		"@userId": userID,
+		"@since":  platform.DotNetTime(since).String(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query notifications since for %q: %w", userID, err)
+	}
+	return decodeDigests(raws, userID)
+}
+
+// unsentEmailsQuery selects a user's notifications whose email has not yet been
+// sent, oldest first. The OR-NOT-IS_DEFINED clause includes legacy rows written
+// before the emailSent field existed. Mirrors .NET GetUnsentEmailsByUserAsync.
+const unsentEmailsQuery = "SELECT * FROM c WHERE c.userId = @userId AND (c.emailSent = false OR NOT IS_DEFINED(c.emailSent)) ORDER BY c.createdAt ASC"
+
+// UnsentEmailsByUser returns the user's notifications awaiting an email, used by
+// the hourly digest to gather the rows to render and then mark sent.
+func (s *DigestStore) UnsentEmailsByUser(ctx context.Context, userID string) ([]DigestNotification, error) {
+	raws, err := s.items.QueryItems(ctx, userID, unsentEmailsQuery, map[string]any{"@userId": userID})
+	if err != nil {
+		return nil, fmt.Errorf("query unsent emails for %q: %w", userID, err)
+	}
+	return decodeDigests(raws, userID)
+}
+
+// userIDsWithUnsentEmailsQuery projects the distinct user ids that have at least
+// one unsent-email notification, across all partitions. Mirrors .NET
+// GetUserIdsWithUnsentEmailsCrossPartitionAsync.
+const userIDsWithUnsentEmailsQuery = "SELECT DISTINCT VALUE c.userId FROM c WHERE c.emailSent = false OR NOT IS_DEFINED(c.emailSent)"
+
+// UserIDsWithUnsentEmails returns every user id with at least one unsent-email
+// notification — the hourly cycle's candidate set before per-user tier gating.
+func (s *DigestStore) UserIDsWithUnsentEmails(ctx context.Context) ([]string, error) {
+	raws, err := s.items.QueryItemsCrossPartition(ctx, userIDsWithUnsentEmailsQuery, nil)
+	if err != nil {
+		return nil, fmt.Errorf("query users with unsent emails: %w", err)
+	}
+	userIDs := make([]string, 0, len(raws))
+	for _, raw := range raws {
+		var id string
+		if err := json.Unmarshal(raw, &id); err != nil {
+			return nil, fmt.Errorf("decode user id: %w", err)
+		}
+		userIDs = append(userIDs, id)
+	}
+	return userIDs, nil
+}
+
+// MarkEmailSent upserts the notification document (with EmailSent already set by
+// the caller) so it is excluded from the next hourly cycle, mirroring .NET's
+// MarkEmailSent + SaveAsync.
+func (s *DigestStore) MarkEmailSent(ctx context.Context, n DigestNotification) error {
+	body, err := json.Marshal(newDigestDocument(n))
+	if err != nil {
+		return fmt.Errorf("encode notification %q: %w", n.ID, err)
+	}
+	if err := s.items.UpsertItem(ctx, n.UserID, body); err != nil {
+		return fmt.Errorf("upsert notification %q: %w", n.ID, err)
+	}
+	return nil
+}
+
+// decodeDigests hydrates a batch of stored documents into the digest model.
+func decodeDigests(raws [][]byte, userID string) ([]DigestNotification, error) {
+	out := make([]DigestNotification, 0, len(raws))
+	for _, raw := range raws {
+		var doc digestDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("decode notification for %q: %w", userID, err)
+		}
+		out = append(out, doc.toDigest())
+	}
+	return out, nil
+}

--- a/api-go/internal/notifications/digest_store_test.go
+++ b/api-go/internal/notifications/digest_store_test.go
@@ -1,0 +1,191 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeDigestItems is a hand-written double for the digest store's consumer-side
+// container interface: single-partition query, cross-partition query, and upsert.
+type fakeDigestItems struct {
+	queryResult [][]byte
+	queryErr    error
+	queryPK     string
+	queryText   string
+	queryParams map[string]any
+
+	crossResult [][]byte
+	crossErr    error
+	crossText   string
+
+	upsertErr  error
+	upsertPK   string
+	upsertBody []byte
+}
+
+func (f *fakeDigestItems) QueryItems(_ context.Context, pk, query string, params map[string]any) ([][]byte, error) {
+	f.queryPK = pk
+	f.queryText = query
+	f.queryParams = params
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return f.queryResult, nil
+}
+
+func (f *fakeDigestItems) QueryItemsCrossPartition(_ context.Context, query string, _ map[string]any) ([][]byte, error) {
+	f.crossText = query
+	if f.crossErr != nil {
+		return nil, f.crossErr
+	}
+	return f.crossResult, nil
+}
+
+func (f *fakeDigestItems) UpsertItem(_ context.Context, pk string, body []byte) error {
+	f.upsertPK = pk
+	f.upsertBody = body
+	return f.upsertErr
+}
+
+func fullDocJSON(t *testing.T, id, userID, uid, watchZoneID, createdAt string, emailSent bool) []byte {
+	t.Helper()
+	m := map[string]any{
+		"id":                     id,
+		"userId":                 userID,
+		"applicationUid":         uid,
+		"applicationName":        uid,
+		"applicationAddress":     "addr",
+		"applicationDescription": "desc",
+		"authorityId":            1,
+		"eventType":              "NewApplication",
+		"createdAt":              createdAt,
+		"emailSent":              emailSent,
+	}
+	if watchZoneID != "" {
+		m["watchZoneId"] = watchZoneID
+	}
+	b, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func TestDigestStore_ByUserSince(t *testing.T) {
+	t.Parallel()
+	items := &fakeDigestItems{queryResult: [][]byte{
+		fullDocJSON(t, "n-1", "user-1", "uid-A", "zone-1", "2026-02-02T00:00:00+00:00", false),
+		fullDocJSON(t, "n-2", "user-1", "uid-B", "", "2026-02-01T00:00:00+00:00", false),
+	}}
+	store := NewDigestStore(items)
+	since := time.Date(2026, 1, 26, 0, 0, 0, 0, time.UTC)
+
+	got, err := store.ByUserSince(context.Background(), "user-1", since)
+	if err != nil {
+		t.Fatalf("ByUserSince: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("count: got %d, want 2", len(got))
+	}
+	if items.queryPK != "user-1" {
+		t.Errorf("partition key: got %q, want user-1", items.queryPK)
+	}
+	if !strings.Contains(items.queryText, "c.createdAt >= @since") {
+		t.Errorf("query missing since clause: %q", items.queryText)
+	}
+	if _, ok := items.queryParams["@since"].(string); !ok {
+		t.Errorf("@since must be the .NET string form, got %v", items.queryParams["@since"])
+	}
+}
+
+func TestDigestStore_UnsentEmailsByUser(t *testing.T) {
+	t.Parallel()
+	items := &fakeDigestItems{queryResult: [][]byte{
+		fullDocJSON(t, "n-1", "user-1", "uid-A", "zone-1", "2026-02-01T00:00:00+00:00", false),
+	}}
+	store := NewDigestStore(items)
+
+	got, err := store.UnsentEmailsByUser(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("UnsentEmailsByUser: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "n-1" {
+		t.Fatalf("got %+v", got)
+	}
+	if items.queryPK != "user-1" {
+		t.Errorf("partition key: got %q, want user-1", items.queryPK)
+	}
+	if !strings.Contains(items.queryText, "emailSent") {
+		t.Errorf("query missing emailSent filter: %q", items.queryText)
+	}
+}
+
+func TestDigestStore_UserIDsWithUnsentEmails(t *testing.T) {
+	t.Parallel()
+	items := &fakeDigestItems{crossResult: [][]byte{
+		[]byte(`"user-1"`),
+		[]byte(`"user-2"`),
+	}}
+	store := NewDigestStore(items)
+
+	got, err := store.UserIDsWithUnsentEmails(context.Background())
+	if err != nil {
+		t.Fatalf("UserIDsWithUnsentEmails: %v", err)
+	}
+	if len(got) != 2 || got[0] != "user-1" || got[1] != "user-2" {
+		t.Fatalf("got %v", got)
+	}
+	if !strings.Contains(items.crossText, "DISTINCT VALUE c.userId") {
+		t.Errorf("query missing distinct user id projection: %q", items.crossText)
+	}
+}
+
+func TestDigestStore_MarkEmailSentUpsertsDocument(t *testing.T) {
+	t.Parallel()
+	items := &fakeDigestItems{}
+	store := NewDigestStore(items)
+	n := DigestNotification{
+		ID:                     "n-1",
+		UserID:                 "user-1",
+		ApplicationUID:         "uid-A",
+		ApplicationName:        "uid-A",
+		ApplicationAddress:     "addr",
+		ApplicationDescription: "desc",
+		AuthorityID:            1,
+		EventType:              EventNewApplication,
+		CreatedAt:              time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC),
+		EmailSent:              true,
+	}
+
+	if err := store.MarkEmailSent(context.Background(), n); err != nil {
+		t.Fatalf("MarkEmailSent: %v", err)
+	}
+	if items.upsertPK != "user-1" {
+		t.Errorf("upsert partition key: got %q, want user-1", items.upsertPK)
+	}
+	var back digestDocument
+	if err := json.Unmarshal(items.upsertBody, &back); err != nil {
+		t.Fatalf("unmarshal upserted body: %v", err)
+	}
+	if !back.EmailSent {
+		t.Error("upserted document should have emailSent true")
+	}
+}
+
+func TestDigestStore_ByUserSinceWrapsError(t *testing.T) {
+	t.Parallel()
+	items := &fakeDigestItems{queryErr: errors.New("boom")}
+	store := NewDigestStore(items)
+
+	_, err := store.ByUserSince(context.Background(), "user-1", time.Now())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "user-1") {
+		t.Errorf("error should name the user: %v", err)
+	}
+}

--- a/api-go/internal/notifications/digest_test.go
+++ b/api-go/internal/notifications/digest_test.go
@@ -1,0 +1,146 @@
+package notifications
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestDigestNotificationDocument_RoundTrips(t *testing.T) {
+	t.Parallel()
+	// A full Notifications-container document hydrates into a DigestNotification
+	// carrying every field the digest email body and APNs payload need. The
+	// camelCase JSON keys match the .NET NotificationDocument exactly.
+	raw := []byte(`{
+		"id": "n-1",
+		"userId": "user-1",
+		"applicationUid": "19/00123/FUL",
+		"applicationName": "19/00123/FUL",
+		"watchZoneId": "zone-1",
+		"applicationAddress": "10 High St",
+		"applicationDescription": "Single storey rear extension",
+		"applicationType": "Householder",
+		"authorityId": 42,
+		"decision": "Permitted",
+		"eventType": "DecisionUpdate",
+		"sources": "Zone, Saved",
+		"pushSent": true,
+		"emailSent": false,
+		"createdAt": "2026-02-01T10:00:00+00:00"
+	}`)
+
+	var doc digestDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	n := doc.toDigest()
+
+	if n.ID != "n-1" || n.UserID != "user-1" {
+		t.Errorf("ids: got id=%q userId=%q", n.ID, n.UserID)
+	}
+	if n.ApplicationUID != "19/00123/FUL" || n.ApplicationName != "19/00123/FUL" {
+		t.Errorf("application uid/name: got %q / %q", n.ApplicationUID, n.ApplicationName)
+	}
+	if n.WatchZoneID == nil || *n.WatchZoneID != "zone-1" {
+		t.Errorf("watchZoneId: got %v", n.WatchZoneID)
+	}
+	if n.ApplicationAddress != "10 High St" {
+		t.Errorf("address: got %q", n.ApplicationAddress)
+	}
+	if n.ApplicationDescription != "Single storey rear extension" {
+		t.Errorf("description: got %q", n.ApplicationDescription)
+	}
+	if n.ApplicationType == nil || *n.ApplicationType != "Householder" {
+		t.Errorf("type: got %v", n.ApplicationType)
+	}
+	if n.Decision == nil || *n.Decision != "Permitted" {
+		t.Errorf("decision: got %v", n.Decision)
+	}
+	if n.EventType != EventDecisionUpdate {
+		t.Errorf("eventType: got %q", n.EventType)
+	}
+	if !n.HasSavedSource() {
+		t.Error("sources should include Saved")
+	}
+	wantCreated := time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC)
+	if !n.CreatedAt.Equal(wantCreated) {
+		t.Errorf("createdAt: got %v, want %v", n.CreatedAt, wantCreated)
+	}
+}
+
+func TestDigestNotificationDocument_LegacyNullsCoalesce(t *testing.T) {
+	t.Parallel()
+	// Legacy rows predating eventType/sources/applicationUid hydrate with the
+	// backfill defaults: NewApplication event, no Saved source, applicationUid
+	// falls back to applicationName.
+	raw := []byte(`{
+		"id": "n-2",
+		"userId": "user-2",
+		"applicationName": "20/00045/FUL",
+		"applicationAddress": "5 Mill Ln",
+		"applicationDescription": "New dwelling",
+		"authorityId": 7,
+		"pushSent": false,
+		"createdAt": "2026-01-01T00:00:00+00:00"
+	}`)
+
+	var doc digestDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	n := doc.toDigest()
+
+	if n.EventType != EventNewApplication {
+		t.Errorf("legacy eventType: got %q, want NewApplication", n.EventType)
+	}
+	if n.HasSavedSource() {
+		t.Error("legacy row should not have Saved source")
+	}
+	if n.ApplicationUID != "20/00045/FUL" {
+		t.Errorf("legacy applicationUid fallback: got %q", n.ApplicationUID)
+	}
+	if n.WatchZoneID != nil {
+		t.Errorf("absent watchZoneId should be nil, got %v", n.WatchZoneID)
+	}
+	if n.ApplicationType != nil {
+		t.Errorf("absent applicationType should be nil, got %v", n.ApplicationType)
+	}
+}
+
+func TestDigestNotification_MarkEmailSentRoundTripsDocument(t *testing.T) {
+	t.Parallel()
+	// MarkEmailSent flips emailSent so the persisted document excludes the row
+	// from the next hourly cycle's GetUnsentEmailsByUser query.
+	n := DigestNotification{
+		ID:                     "n-3",
+		UserID:                 "user-3",
+		ApplicationUID:         "21/0001",
+		ApplicationName:        "21/0001",
+		ApplicationAddress:     "1 Test Rd",
+		ApplicationDescription: "desc",
+		AuthorityID:            1,
+		EventType:              EventNewApplication,
+		CreatedAt:              time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		EmailSent:              false,
+	}
+	n.MarkEmailSent()
+	if !n.EmailSent {
+		t.Fatal("MarkEmailSent should set EmailSent true")
+	}
+
+	body, err := json.Marshal(newDigestDocument(n))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back digestDocument
+	if err := json.Unmarshal(body, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.toDigest().EmailSent != true {
+		t.Error("emailSent should survive the document round trip")
+	}
+	// The 90-day TTL must be written so digest rows expire like .NET's.
+	if back.TTL <= 0 {
+		t.Errorf("ttl should be a positive value, got %d", back.TTL)
+	}
+}

--- a/api-go/internal/profiles/admin_store.go
+++ b/api-go/internal/profiles/admin_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 )
 
 // adminItems is the consumer-side slice of the Cosmos container the admin store
@@ -72,6 +73,33 @@ func (s *AdminStore) GetByOriginalTransactionID(ctx context.Context, originalTra
 		return nil, fmt.Errorf("decode profile: %w", err)
 	}
 	return doc.toDomain()
+}
+
+// ByDigestDay returns every profile whose configured digest day matches day —
+// the weekly-digest candidate set, before per-user tier and preference gating.
+// The digest day is bound as the int DayOfWeek value (Sunday=0 … Saturday=6),
+// matching .NET's GetAllByDigestDayCrossPartitionAsync (which casts the enum to
+// int) and the int stored by the profile document's digestDay field.
+func (s *AdminStore) ByDigestDay(ctx context.Context, day time.Weekday) ([]*UserProfile, error) {
+	rows, err := s.items.QueryItemsCrossPartition(ctx,
+		"SELECT * FROM c WHERE c.digestDay = @digestDay",
+		map[string]any{"@digestDay": int(day)})
+	if err != nil {
+		return nil, fmt.Errorf("query profiles by digest day: %w", err)
+	}
+	profiles := make([]*UserProfile, 0, len(rows))
+	for _, raw := range rows {
+		var doc profileDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("decode profile: %w", err)
+		}
+		p, err := doc.toDomain()
+		if err != nil {
+			return nil, fmt.Errorf("hydrate profile: %w", err)
+		}
+		profiles = append(profiles, p)
+	}
+	return profiles, nil
 }
 
 // Save upserts the profile (id == user id == partition key).

--- a/api-go/internal/profiles/admin_store_test.go
+++ b/api-go/internal/profiles/admin_store_test.go
@@ -18,6 +18,7 @@ type fakeAdminItems struct {
 	pageNext     string
 	pageErr      error
 	gotQuery     string
+	gotParams    map[string]any
 	gotPageSize  int
 	gotPageToken string
 }
@@ -29,8 +30,9 @@ func (f *fakeAdminItems) UpsertItem(_ context.Context, partitionKey string, item
 	return nil
 }
 
-func (f *fakeAdminItems) QueryItemsCrossPartition(_ context.Context, query string, _ map[string]any) ([][]byte, error) {
+func (f *fakeAdminItems) QueryItemsCrossPartition(_ context.Context, query string, params map[string]any) ([][]byte, error) {
 	f.gotQuery = query
+	f.gotParams = params
 	return f.queryResult, f.queryErr
 }
 
@@ -177,5 +179,44 @@ func TestUserProfile_ExpireSubscription(t *testing.T) {
 
 	if p.Tier != TierFree || p.SubscriptionExpiry != nil || p.GracePeriodExpiry != nil {
 		t.Errorf("after expire: tier=%v expiry=%v grace=%v", p.Tier, p.SubscriptionExpiry, p.GracePeriodExpiry)
+	}
+}
+
+func TestAdminStore_ByDigestDay(t *testing.T) {
+	t.Parallel()
+
+	items := newFakeAdminItems()
+	items.queryResult = [][]byte{
+		profileDoc(t, "auth0|u1", "u1@example.com", TierPro),
+		profileDoc(t, "auth0|u2", "u2@example.com", TierFree),
+	}
+	store := NewAdminStore(items)
+
+	got, err := store.ByDigestDay(context.Background(), time.Wednesday)
+	if err != nil {
+		t.Fatalf("ByDigestDay: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("count: got %d, want 2", len(got))
+	}
+	if items.gotQuery != "SELECT * FROM c WHERE c.digestDay = @digestDay" {
+		t.Errorf("query = %q", items.gotQuery)
+	}
+	// .NET binds the digest day as the int DayOfWeek value; Go's time.Weekday
+	// numbering matches (Sunday=0 … Saturday=6), so Wednesday must bind as 3.
+	if day, ok := items.gotParams["@digestDay"].(int); !ok || day != int(time.Wednesday) {
+		t.Errorf("@digestDay = %v, want int %d", items.gotParams["@digestDay"], int(time.Wednesday))
+	}
+}
+
+func TestAdminStore_ByDigestDayWrapsError(t *testing.T) {
+	t.Parallel()
+
+	items := newFakeAdminItems()
+	items.queryErr = errors.New("boom")
+	store := NewAdminStore(items)
+
+	if _, err := store.ByDigestDay(context.Background(), time.Monday); err == nil {
+		t.Fatal("expected error")
 	}
 }

--- a/api-go/internal/profiles/profile.go
+++ b/api-go/internal/profiles/profile.go
@@ -44,6 +44,16 @@ func (t SubscriptionTier) String() string {
 // IsPaid reports whether the tier grants paid entitlements (anything but Free).
 func (t SubscriptionTier) IsPaid() bool { return t != TierFree }
 
+// IsPaidPro reports whether the tier is specifically Pro. The weekly digest PUSH
+// is Pro-only (.NET gates on Tier == SubscriptionTier.Pro), distinct from the
+// hourly-digest entitlement which Personal also holds.
+func (t SubscriptionTier) IsPaidPro() bool { return t == TierPro }
+
+// HasHourlyDigestEntitlement reports whether the tier grants the
+// HourlyDigestEmails entitlement (Personal and Pro, never Free), mirroring .NET
+// EntitlementMap — hourly digest emails are a paid, server-enforced entitlement.
+func (t SubscriptionTier) HasHourlyDigestEntitlement() bool { return t.IsPaid() }
+
 // unlimitedWatchZones is the Pro-tier watch-zone limit: .NET's int.MaxValue,
 // the sentinel the iOS app reads as "no limit". Preserved exactly so the
 // /v1/subscriptions/verify response is byte-identical to .NET's.

--- a/api-go/internal/profiles/subscription_test.go
+++ b/api-go/internal/profiles/subscription_test.go
@@ -74,6 +74,48 @@ func TestSubscriptionTier_Entitlements(t *testing.T) {
 	}
 }
 
+func TestSubscriptionTier_IsPaidPro(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		tier SubscriptionTier
+		want bool
+	}{
+		{TierFree, false},
+		{TierPersonal, false},
+		{TierPro, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.tier.String(), func(t *testing.T) {
+			t.Parallel()
+			if got := tc.tier.IsPaidPro(); got != tc.want {
+				t.Errorf("IsPaidPro() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSubscriptionTier_HasHourlyDigestEntitlement(t *testing.T) {
+	t.Parallel()
+	// Hourly digest emails are a paid entitlement granted to Personal and Pro,
+	// never Free — mirroring .NET EntitlementMap (HourlyDigestEmails in PaidEntitlements).
+	tests := []struct {
+		tier SubscriptionTier
+		want bool
+	}{
+		{TierFree, false},
+		{TierPersonal, true},
+		{TierPro, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.tier.String(), func(t *testing.T) {
+			t.Parallel()
+			if got := tc.tier.HasHourlyDigestEntitlement(); got != tc.want {
+				t.Errorf("HasHourlyDigestEntitlement() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSubscriptionTier_WatchZoneLimit(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -7,6 +7,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 // tracerName labels the worker's OpenTelemetry spans.
@@ -18,20 +19,36 @@ const tracerName = "github.com/AmyDe/town-crier/api-go/internal/worker"
 // the soft ceiling that lets the process exit cleanly and flush telemetry.
 const bootstrapBudget = 60 * time.Second
 
+// digestBudget is the soft self-cancel for a single digest / hourly-digest run.
+// A digest cycle fans out across many users' Cosmos reads and email/push sends;
+// 10 minutes is generous while still bounded well under the Container Apps
+// replicaTimeout so the process exits cleanly and flushes telemetry.
+const digestBudget = 10 * time.Minute
+
+// digestRunner is the consumer-side slice of the digest handler the dispatcher
+// invokes. *digest.Handler satisfies it; the worker depends only on these two
+// methods so it need not know the handler's internals.
+type digestRunner interface {
+	RunWeekly(ctx context.Context) error
+	RunHourly(ctx context.Context) error
+}
+
 // Run dispatches on WORKER_MODE and returns the process exit code. It is the
 // testable core of cmd/worker/main.go — main() only loads config, wires the
 // Service Bus client + bootstrapper, sets up telemetry, and propagates this
 // code.
 //
-// Only poll-bootstrap is implemented in this skeleton. The other four modes
-// (poll-sb, digest, hourly-digest, dormant-cleanup) are loud stubs that exit 1;
-// the Go worker image is not deployed to any job until the final cutover bead,
-// so a stub can never run in production. An unset or unknown mode is a
+// poll-bootstrap, digest, and hourly-digest are implemented; the remaining modes
+// (poll-sb, dormant-cleanup) are loud stubs that exit 1 until their own beads
+// land. The Go worker image is not deployed to any job until the final cutover
+// bead, so a stub can never run in production. An unset or unknown mode is a
 // deployment accident and also fails fast.
 //
 // bootstrapper may be nil when the job has no Service Bus config; poll-bootstrap
-// then refuses to run rather than nil-panicking.
-func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, logger *slog.Logger) int {
+// then refuses to run rather than nil-panicking. Likewise digester may be nil
+// when the job has no Cosmos / ACS / APNs config; the digest modes then refuse
+// to run rather than nil-panicking.
+func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester digestRunner, logger *slog.Logger) int {
 	switch mode {
 	case "":
 		// WORKER_MODE is always set by infra; an unset value is a deployment
@@ -42,7 +59,13 @@ func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, logger *s
 	case "poll-bootstrap":
 		return runPollBootstrap(ctx, bootstrapper, logger)
 
-	case "poll-sb", "digest", "hourly-digest", "dormant-cleanup":
+	case "digest":
+		return runDigest(ctx, "Digest Cycle", digester, digestRunner.RunWeekly, logger)
+
+	case "hourly-digest":
+		return runDigest(ctx, "Hourly Digest Cycle", digester, digestRunner.RunHourly, logger)
+
+	case "poll-sb", "dormant-cleanup":
 		// Loud, safe stub: the image is not deployed until the final cutover, so
 		// this exit-1 can never strand a real job. Each mode lands in its own bead.
 		logger.ErrorContext(ctx, "WORKER_MODE not yet implemented in Go worker", "mode", mode)
@@ -52,6 +75,33 @@ func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, logger *s
 		logger.ErrorContext(ctx, "unknown WORKER_MODE; refusing to run", "mode", mode)
 		return 1
 	}
+}
+
+// runDigest executes one digest cycle (weekly or hourly) under a soft self-cancel
+// budget, inside a telemetry span whose name mirrors the .NET worker ("Digest
+// Cycle" / "Hourly Digest Cycle") so existing App Insights queries keep working.
+// A nil digester (job missing Cosmos/ACS config) is an exit-1 condition; a cycle
+// error is recorded on the span and also exits 1 so the job surfaces the failure.
+func runDigest(ctx context.Context, spanName string, digester digestRunner, run func(digestRunner, context.Context) error, logger *slog.Logger) int {
+	tracer := otel.Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, spanName)
+	defer span.End()
+
+	if digester == nil {
+		logger.ErrorContext(ctx, "digest mode requires Cosmos + ACS/APNs config (COSMOS_ENDPOINT et al.); refusing to run", "span", spanName)
+		return 1
+	}
+
+	cycleCtx, cancel := context.WithTimeout(ctx, digestBudget)
+	defer cancel()
+
+	if err := run(digester, cycleCtx); err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		logger.ErrorContext(ctx, "digest cycle failed", "span", spanName, "error", err)
+		return 1
+	}
+	return 0
 }
 
 // runPollBootstrap executes one bootstrap cycle under a soft self-cancel budget,

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -25,10 +25,12 @@ const bootstrapBudget = 60 * time.Second
 // replicaTimeout so the process exits cleanly and flushes telemetry.
 const digestBudget = 10 * time.Minute
 
-// digestRunner is the consumer-side slice of the digest handler the dispatcher
+// DigestRunner is the consumer-side slice of the digest handler the dispatcher
 // invokes. *digest.Handler satisfies it; the worker depends only on these two
-// methods so it need not know the handler's internals.
-type digestRunner interface {
+// methods so it need not know the handler's internals. It is exported so main()
+// can hold a genuinely nil interface value when the job has no digest config —
+// passing a typed-nil *digest.Handler would defeat the nil guard below.
+type DigestRunner interface {
 	RunWeekly(ctx context.Context) error
 	RunHourly(ctx context.Context) error
 }
@@ -48,7 +50,7 @@ type digestRunner interface {
 // then refuses to run rather than nil-panicking. Likewise digester may be nil
 // when the job has no Cosmos / ACS / APNs config; the digest modes then refuse
 // to run rather than nil-panicking.
-func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester digestRunner, logger *slog.Logger) int {
+func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, logger *slog.Logger) int {
 	switch mode {
 	case "":
 		// WORKER_MODE is always set by infra; an unset value is a deployment
@@ -60,10 +62,10 @@ func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester 
 		return runPollBootstrap(ctx, bootstrapper, logger)
 
 	case "digest":
-		return runDigest(ctx, "Digest Cycle", digester, digestRunner.RunWeekly, logger)
+		return runDigest(ctx, "Digest Cycle", digester, DigestRunner.RunWeekly, logger)
 
 	case "hourly-digest":
-		return runDigest(ctx, "Hourly Digest Cycle", digester, digestRunner.RunHourly, logger)
+		return runDigest(ctx, "Hourly Digest Cycle", digester, DigestRunner.RunHourly, logger)
 
 	case "poll-sb", "dormant-cleanup":
 		// Loud, safe stub: the image is not deployed until the final cutover, so
@@ -82,7 +84,7 @@ func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester 
 // Cycle" / "Hourly Digest Cycle") so existing App Insights queries keep working.
 // A nil digester (job missing Cosmos/ACS config) is an exit-1 condition; a cycle
 // error is recorded on the span and also exits 1 so the job surfaces the failure.
-func runDigest(ctx context.Context, spanName string, digester digestRunner, run func(digestRunner, context.Context) error, logger *slog.Logger) int {
+func runDigest(ctx context.Context, spanName string, digester DigestRunner, run func(DigestRunner, context.Context) error, logger *slog.Logger) int {
 	tracer := otel.Tracer(tracerName)
 	ctx, span := tracer.Start(ctx, spanName)
 	defer span.End()

--- a/api-go/internal/worker/dispatch_test.go
+++ b/api-go/internal/worker/dispatch_test.go
@@ -11,12 +11,31 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/servicebus"
 )
 
+// fakeDigester is a hand-written double for the digestRunner the dispatcher
+// invokes. It records which cycle ran and can be primed with an error.
+type fakeDigester struct {
+	weeklyCalls int
+	hourlyCalls int
+	weeklyErr   error
+	hourlyErr   error
+}
+
+func (f *fakeDigester) RunWeekly(context.Context) error {
+	f.weeklyCalls++
+	return f.weeklyErr
+}
+
+func (f *fakeDigester) RunHourly(context.Context) error {
+	f.hourlyCalls++
+	return f.hourlyErr
+}
+
 func TestRun_UnsetModeFailsFast(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "", nil, logger)
+	code := Run(context.Background(), "", nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unset mode", code)
@@ -26,19 +45,75 @@ func TestRun_UnsetModeFailsFast(t *testing.T) {
 	}
 }
 
+func TestRun_DigestModeRunsWeeklyAndExitsZero(t *testing.T) {
+	t.Parallel()
+	d := &fakeDigester{}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "digest", nil, d, logger)
+
+	if code != 0 {
+		t.Errorf("exit code: got %d, want 0", code)
+	}
+	if d.weeklyCalls != 1 || d.hourlyCalls != 0 {
+		t.Errorf("calls: weekly=%d hourly=%d, want 1/0", d.weeklyCalls, d.hourlyCalls)
+	}
+}
+
+func TestRun_HourlyDigestModeRunsHourlyAndExitsZero(t *testing.T) {
+	t.Parallel()
+	d := &fakeDigester{}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "hourly-digest", nil, d, logger)
+
+	if code != 0 {
+		t.Errorf("exit code: got %d, want 0", code)
+	}
+	if d.hourlyCalls != 1 || d.weeklyCalls != 0 {
+		t.Errorf("calls: weekly=%d hourly=%d, want 0/1", d.weeklyCalls, d.hourlyCalls)
+	}
+}
+
+func TestRun_DigestModeWithoutHandlerExitsOne(t *testing.T) {
+	t.Parallel()
+	// A job missing Cosmos/ACS config leaves the digester nil; the mode must
+	// refuse to run rather than nil-panic.
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	code := Run(context.Background(), "digest", nil, nil, logger)
+
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1 when digest handler is unconfigured", code)
+	}
+}
+
+func TestRun_DigestCycleErrorExitsOne(t *testing.T) {
+	t.Parallel()
+	d := &fakeDigester{weeklyErr: errors.New("cosmos down")}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "digest", nil, d, logger)
+
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1 on digest cycle error", code)
+	}
+}
+
 func TestRun_UnimplementedModesExitOne(t *testing.T) {
 	t.Parallel()
-	// Every non-bootstrap mode is a stub until its own bead lands. The image is
-	// not deployed until the final cutover, so failing fast (exit 1) is safe and
-	// loud.
-	modes := []string{"poll-sb", "digest", "hourly-digest", "dormant-cleanup"}
+	// The remaining non-digest modes are stubs until their own beads land. The
+	// image is not deployed until the final cutover, so failing fast (exit 1) is
+	// safe and loud.
+	modes := []string{"poll-sb", "dormant-cleanup"}
 	for _, mode := range modes {
 		t.Run(mode, func(t *testing.T) {
 			t.Parallel()
 			var buf bytes.Buffer
 			logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-			code := Run(context.Background(), mode, nil, logger)
+			code := Run(context.Background(), mode, nil, nil, logger)
 
 			if code != 1 {
 				t.Errorf("exit code: got %d, want 1 for unimplemented mode %q", code, mode)
@@ -59,7 +134,7 @@ func TestRun_UnknownModeExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "banana", nil, logger)
+	code := Run(context.Background(), "banana", nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unknown mode", code)
@@ -72,7 +147,7 @@ func TestRun_PollBootstrapSeedsAndExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful bootstrap)", code)
@@ -89,7 +164,7 @@ func TestRun_PollBootstrapWithoutQueueExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when Service Bus is unconfigured", code)
@@ -104,7 +179,7 @@ func TestRun_PollBootstrapProbeFailureStillExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (absorbed probe failure is not a job failure)", code)


### PR DESCRIPTION
Phase 2 Go worker migration (epic tc-wad3). Ports `GenerateWeeklyDigestsCommandHandler` / `GenerateHourlyDigestsCommandHandler` to Go.

- `internal/digest` — handler (`RunWeekly`/`RunHourly`): Cosmos reads → tier gating (free = weekly email only; hourly + push are Pro) → per-zone instant gating with saved-only bypass → zone grouping → email HTML + APNs payload rendering → send via `acsemail`/`apns` enablers → notification-state dedup + invalid-token pruning. Badge = total unread.
- `internal/notifications` — full `DigestNotification` model + `DigestStore` (the prior store was a read-only projection).
- `internal/worker/dispatch.go` — real `digest`/`hourly-digest` handlers under telemetry spans; `poll-sb` and `dormant-cleanup` remain exit-1 stubs (land in tc-yng2 / tc-dwcq).
- `cmd/worker/main.go` — wires Cosmos repos + email/push senders (NoOp when unconfigured; avoids the typed-nil interface trap).
- Repo read-methods added: `DigestStore.{ByUserSince,UnsentEmailsByUser,UserIDsWithUnsentEmails,MarkEmailSent}`, `profiles.AdminStore.ByDigestDay`, tier helpers `IsPaidPro`/`HasHourlyDigestEntitlement`.

No new env keys (reuses APNS_*/ACS_/COSMOS_*). Gate: gofmt/vet/golangci clean, `go test -race` 678 pass, build ok.

Closes tc-34y5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weekly digest emails grouped by watch zones and saved applications.
  * Added weekly push notifications for Pro-tier users with unread badge counts.
  * Added hourly digest emails for paid-tier users with per-zone instant gating control.
  * Implemented notification email tracking to prevent duplicate digests.
  * Digest emails now include decision status badges and saved-item indicators.

* **Tests**
  * Added comprehensive test coverage for digest email rendering, push payload formatting, and multi-tier notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->