### PR TITLE
feat(go): dormant-cleanup worker mode + delete-cascade (tc-dwcq)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -3,10 +3,10 @@
 // Phase 2, epic tc-wad3). One process per job: WORKER_MODE selects the mode,
 // the process runs it once, flushes telemetry, and exits with a status code.
 //
-// This skeleton implements only poll-bootstrap (the Service-Bus-only tracer
-// bullet); the other four modes are loud stubs that exit 1 until their own beads
-// land. The Go image is not deployed to any job until the final cutover, so a
-// stub can never strand a real job.
+// poll-bootstrap, digest, hourly-digest, and dormant-cleanup are implemented;
+// poll-sb remains a loud stub that exits 1 until its own bead (tc-yng2) lands.
+// The Go image is not deployed to any job until the final cutover, so a stub can
+// never strand a real job.
 package main
 
 import (
@@ -285,7 +285,9 @@ func (d watchZoneDeleter) DeleteAllWatchZones(ctx context.Context, userID string
 	return d.s.DeleteAllByUserID(ctx, userID)
 }
 
-type savedApplicationDeleter struct{ s *savedapplications.CosmosStore }
+type savedApplicationDeleter struct {
+	s *savedapplications.CosmosStore
+}
 
 func (d savedApplicationDeleter) DeleteAllSavedApplications(ctx context.Context, userID string) error {
 	return d.s.DeleteAllByUserID(ctx, userID)
@@ -297,7 +299,9 @@ func (d deviceDeleter) DeleteAllDeviceRegistrations(ctx context.Context, userID 
 	return d.s.DeleteAllByUserID(ctx, userID)
 }
 
-type stateDeleter struct{ s *notificationstate.CosmosStore }
+type stateDeleter struct {
+	s *notificationstate.CosmosStore
+}
 
 func (d stateDeleter) DeleteNotificationState(ctx context.Context, userID string) error {
 	return d.s.DeleteByUserID(ctx, userID)

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"log"
 	"log/slog"
+	"net/http"
 	"os"
 	"time"
 
@@ -20,10 +21,12 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/apns"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/digest"
+	"github.com/AmyDe/town-crier/api-go/internal/dormant"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/servicebus"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 	"github.com/AmyDe/town-crier/api-go/internal/worker"
@@ -106,7 +109,22 @@ func run() int {
 		digester = handler
 	}
 
-	return worker.Run(context.Background(), mode, bootstrapper, digester, logger)
+	// The dormant-cleanup handler is built only when the job carries Cosmos config.
+	// Like digester, it is declared as the interface so the "no Cosmos" case leaves
+	// it a genuinely nil interface value (a typed-nil *dormant.Handler would defeat
+	// worker.Run's nil guard). The Auth0 deleter falls back to a no-op when the M2M
+	// credentials are absent, so a Cosmos-only job still boots cleanly.
+	var dormantRunner worker.DormantRunner
+	dormantHandler, err := buildDormant(cfg, logger)
+	if err != nil {
+		logger.Error("build dormant cleanup handler", "error", err)
+		return 1
+	}
+	if dormantHandler != nil {
+		dormantRunner = dormantHandler
+	}
+
+	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, logger)
 }
 
 // buildDigester constructs the digest handler when Cosmos is configured, wiring
@@ -182,6 +200,116 @@ func (p digestProfiles) ByDigestDay(ctx context.Context, day time.Weekday) ([]*p
 
 func (p digestProfiles) Get(ctx context.Context, userID string) (*profiles.UserProfile, error) {
 	return p.point.Get(ctx, userID)
+}
+
+// buildDormant constructs the dormant-cleanup handler when Cosmos is configured,
+// wiring the dormant-account finder, the per-container erasure stores, and the
+// Auth0 M2M deleter (real when its credentials are present, NoOp otherwise so a
+// job without Auth0 M2M config still erases Cosmos data). It returns (nil, nil)
+// when Cosmos is unconfigured — the dormant-cleanup mode then refuses to run
+// rather than nil-panicking. Returning the concrete *dormant.Handler lets
+// worker.Run accept it via its exported DormantRunner interface.
+func buildDormant(cfg platform.Config, logger *slog.Logger) (*dormant.Handler, error) {
+	if cfg.CosmosEndpoint == "" {
+		return nil, nil //nolint:nilnil // absent Cosmos config is a valid "no dormant handler" state, not an error
+	}
+
+	users, err := platform.NewCosmosContainerNamed(cfg, "Users", logger)
+	if err != nil {
+		return nil, err
+	}
+	notifs, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationsContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+	zonesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosWatchZonesContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+	savedContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosSavedApplicationsContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+	devicesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosDeviceRegistrationsContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+	stateContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationStateContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	stores := dormant.Stores{
+		Notifications:       notificationDeleter{notifications.NewDeleteStore(notifs)},
+		WatchZones:          watchZoneDeleter{watchzones.NewCosmosStore(zonesContainer)},
+		SavedApplications:   savedApplicationDeleter{savedapplications.NewCosmosStore(savedContainer)},
+		DeviceRegistrations: deviceDeleter{devicetokens.NewCosmosStore(devicesContainer)},
+		NotificationState:   stateDeleter{notificationstate.NewCosmosStore(stateContainer, notifs)},
+		Profiles:            profileDeleter{profiles.NewCosmosStore(users)},
+		Auth0:               buildAuth0Deleter(cfg, logger),
+	}
+
+	return dormant.New(profiles.NewAdminStore(users), stores, logger, time.Now), nil
+}
+
+// buildAuth0Deleter returns the real Auth0 Management (M2M) client when the M2M
+// credentials are configured, else a no-op so a job without Auth0 M2M config
+// still erases Cosmos data, mirroring .NET's NoOpAuth0ManagementClient fallback.
+func buildAuth0Deleter(cfg platform.Config, logger *slog.Logger) dormant.Auth0Deleter {
+	if !cfg.Auth0M2MConfigured() {
+		logger.Info("auth0 m2m unconfigured; dormant cleanup will skip Auth0 user deletion (NoOp)")
+		return profiles.NoOpAuth0Client{}
+	}
+	return profiles.NewAuth0Client(
+		&http.Client{Timeout: 30 * time.Second},
+		"https://"+cfg.Auth0Domain,
+		cfg.Auth0M2MClientID,
+		cfg.Auth0M2MClientSecret,
+	)
+}
+
+// The adapters below bridge each store's own method name (DeleteAllByUserID /
+// Delete / DeleteByUserID) to the dormant package's consumer-side interface
+// method names. They keep the dormant handler's contracts explicit without
+// renaming the stores' established API.
+
+type notificationDeleter struct{ s *notifications.DeleteStore }
+
+func (d notificationDeleter) DeleteAllNotifications(ctx context.Context, userID string) error {
+	return d.s.DeleteAllByUserID(ctx, userID)
+}
+
+type watchZoneDeleter struct{ s *watchzones.CosmosStore }
+
+func (d watchZoneDeleter) DeleteAllWatchZones(ctx context.Context, userID string) error {
+	return d.s.DeleteAllByUserID(ctx, userID)
+}
+
+type savedApplicationDeleter struct{ s *savedapplications.CosmosStore }
+
+func (d savedApplicationDeleter) DeleteAllSavedApplications(ctx context.Context, userID string) error {
+	return d.s.DeleteAllByUserID(ctx, userID)
+}
+
+type deviceDeleter struct{ s *devicetokens.CosmosStore }
+
+func (d deviceDeleter) DeleteAllDeviceRegistrations(ctx context.Context, userID string) error {
+	return d.s.DeleteAllByUserID(ctx, userID)
+}
+
+type stateDeleter struct{ s *notificationstate.CosmosStore }
+
+func (d stateDeleter) DeleteNotificationState(ctx context.Context, userID string) error {
+	return d.s.DeleteByUserID(ctx, userID)
+}
+
+type profileDeleter struct{ s *profiles.CosmosStore }
+
+// DeleteProfile maps to the profile store's Delete, translating its ErrNotFound
+// (a 404 from Cosmos) so the dormant handler can tolerate a concurrently-deleted
+// profile via errors.Is(err, profiles.ErrNotFound).
+func (d profileDeleter) DeleteProfile(ctx context.Context, userID string) error {
+	return d.s.Delete(ctx, userID)
 }
 
 // buildEmailSender returns the real ACS email sender when a connection string is

--- a/api-go/internal/devicetokens/store_cosmos.go
+++ b/api-go/internal/devicetokens/store_cosmos.go
@@ -111,6 +111,35 @@ func (s *CosmosStore) ListByUser(ctx context.Context, userID string) ([]DeviceRe
 	return regs, nil
 }
 
+// idOnlyDocument captures just the id projected by the cascade-delete query
+// (SELECT c.id FROM c ...), so the cascade need not hydrate full documents.
+type idOnlyDocument struct {
+	ID string `json:"id"`
+}
+
+// DeleteAllByUserID removes every device registration in the user's partition: it
+// queries the partition for the document ids, then point-deletes each. Used by
+// the account-deletion cascade (dormant cleanup and DELETE /v1/me), mirroring
+// .NET CosmosDeviceRegistrationRepository.DeleteAllByUserIdAsync. All operations
+// are single-partition; a 404 on an individual delete is tolerated (idempotent).
+func (s *CosmosStore) DeleteAllByUserID(ctx context.Context, userID string) error {
+	const query = "SELECT c.id FROM c WHERE c.userId = @userId"
+	raws, err := s.items.QueryItems(ctx, userID, query, map[string]any{"@userId": userID})
+	if err != nil {
+		return fmt.Errorf("query device token ids for %q: %w", userID, err)
+	}
+	for _, raw := range raws {
+		var doc idOnlyDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return fmt.Errorf("decode device token id for %q: %w", userID, err)
+		}
+		if err := s.items.DeleteItem(ctx, userID, doc.ID); err != nil && !isNotFound(err) {
+			return fmt.Errorf("delete device token %q for %q: %w", doc.ID, userID, err)
+		}
+	}
+	return nil
+}
+
 // isNotFound reports whether err is a Cosmos 404 response.
 func isNotFound(err error) bool {
 	var respErr *azcore.ResponseError

--- a/api-go/internal/devicetokens/store_cosmos_test.go
+++ b/api-go/internal/devicetokens/store_cosmos_test.go
@@ -14,13 +14,17 @@ import (
 // fakeItems is an in-memory CosmosItems keyed by (partitionKey, id). It records
 // the last upsert partition key so tests can assert single-partition scoping.
 type fakeItems struct {
-	docs        map[string][]byte // key: partitionKey + "\x00" + id
-	upsertPart  string
-	upsertErr   error
-	deleteErr   error
-	readErr     error
-	queryErr    error
-	deleteCalls int
+	docs         map[string][]byte // key: partitionKey + "\x00" + id
+	upsertPart   string
+	upsertErr    error
+	deleteErr    error
+	readErr      error
+	queryErr     error
+	queryResult  [][]byte // when set, returned verbatim by QueryItems
+	deleteCalls  int
+	lastQueryPK  string
+	lastDeletePK string
+	deletedIDs   []string
 }
 
 func newFakeItems() *fakeItems { return &fakeItems{docs: map[string][]byte{}} }
@@ -53,16 +57,22 @@ func (f *fakeItems) UpsertItem(_ context.Context, pk string, item []byte) error 
 
 func (f *fakeItems) DeleteItem(_ context.Context, pk, id string) error {
 	f.deleteCalls++
+	f.lastDeletePK = pk
 	if f.deleteErr != nil {
 		return f.deleteErr
 	}
+	f.deletedIDs = append(f.deletedIDs, id)
 	delete(f.docs, key(pk, id))
 	return nil
 }
 
 func (f *fakeItems) QueryItems(_ context.Context, pk, _ string, _ map[string]any) ([][]byte, error) {
+	f.lastQueryPK = pk
 	if f.queryErr != nil {
 		return nil, f.queryErr
+	}
+	if f.queryResult != nil {
+		return f.queryResult, nil
 	}
 	var out [][]byte
 	prefix := pk + "\x00"
@@ -175,5 +185,29 @@ func TestCosmosStore_ListByUser(t *testing.T) {
 	}
 	if len(got) != 2 {
 		t.Errorf("ListByUser returned %d registrations, want 2", len(got))
+	}
+}
+
+func TestCosmosStore_DeleteAllByUserID_QueriesPartitionThenDeletesEachID(t *testing.T) {
+	t.Parallel()
+	const userID = "auth0|u"
+	items := newFakeItems()
+	items.queryResult = [][]byte{
+		[]byte(`{"id":"token-a"}`),
+		[]byte(`{"id":"token-b"}`),
+	}
+	store := NewCosmosStore(items)
+
+	if err := store.DeleteAllByUserID(context.Background(), userID); err != nil {
+		t.Fatalf("DeleteAllByUserID: %v", err)
+	}
+	if items.lastQueryPK != userID {
+		t.Errorf("cascade query pk: got %q, want %q", items.lastQueryPK, userID)
+	}
+	if len(items.deletedIDs) != 2 || items.deletedIDs[0] != "token-a" || items.deletedIDs[1] != "token-b" {
+		t.Errorf("deleted ids: got %v", items.deletedIDs)
+	}
+	if items.lastDeletePK != userID {
+		t.Errorf("cascade delete pk: got %q, want %q", items.lastDeletePK, userID)
 	}
 }

--- a/api-go/internal/dormant/handler.go
+++ b/api-go/internal/dormant/handler.go
@@ -1,0 +1,165 @@
+// Package dormant holds the dormant-account cleanup worker mode
+// (WORKER_MODE=dormant-cleanup): once a day it finds user accounts inactive for
+// the retention window and runs the full GDPR erasure cascade for each — deleting
+// the user's notifications, watch zones, saved applications, device
+// registrations, and notification-state watermark from Cosmos, then the profile,
+// then the Auth0 user via the Management (M2M) API.
+//
+// It ports the .NET DormantAccountCleanupCommandHandler + DeleteUserProfile
+// CommandHandler (epic tc-wad3, bead tc-dwcq) following idiomatic Go:
+// consumer-side interfaces declared here, concrete stores injected from main(),
+// and hand-written test fakes. The 12-month retention window is a code constant
+// (not config) so the privacy policy's "12 months of inactivity" promise is
+// enforced uniformly (UK GDPR Art. 5(1)(e), ADR 0023).
+package dormant
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// retentionMonths is the inactivity window after which an account is erased. It
+// is a constant, not configuration, so the retention promise is enforced
+// uniformly in code, mirroring .NET's DormantAccountCleanupCommandHandler.
+const retentionMonths = 12
+
+// Finder returns the dormant-account set: every profile last active strictly
+// before the cutoff. profiles.AdminStore satisfies it via Dormant.
+type Finder interface {
+	Dormant(ctx context.Context, cutoff time.Time) ([]*profiles.UserProfile, error)
+}
+
+// The cascade interfaces below are the consumer-side slices of each per-container
+// store the erasure needs. Each is a single method so a store satisfies only the
+// contract the cascade actually uses; the concrete stores
+// (notifications.DeleteStore, watchzones.CosmosStore, etc.) satisfy them
+// structurally.
+
+// NotificationDeleter erases a user's notifications. notifications.DeleteStore
+// satisfies it.
+type NotificationDeleter interface {
+	DeleteAllNotifications(ctx context.Context, userID string) error
+}
+
+// WatchZoneDeleter erases a user's watch zones. watchzones.CosmosStore satisfies
+// it (via an adapter in main, since its method is DeleteAllByUserID).
+type WatchZoneDeleter interface {
+	DeleteAllWatchZones(ctx context.Context, userID string) error
+}
+
+// SavedApplicationDeleter erases a user's saved applications.
+type SavedApplicationDeleter interface {
+	DeleteAllSavedApplications(ctx context.Context, userID string) error
+}
+
+// DeviceRegistrationDeleter erases a user's device registrations.
+type DeviceRegistrationDeleter interface {
+	DeleteAllDeviceRegistrations(ctx context.Context, userID string) error
+}
+
+// NotificationStateDeleter erases a user's notification-state watermark.
+type NotificationStateDeleter interface {
+	DeleteNotificationState(ctx context.Context, userID string) error
+}
+
+// ProfileDeleter erases the user profile document itself.
+type ProfileDeleter interface {
+	DeleteProfile(ctx context.Context, userID string) error
+}
+
+// Auth0Deleter removes the user from Auth0 via the Management (M2M) API. Both the
+// real profiles.Auth0Client and profiles.NoOpAuth0Client satisfy it; the no-op is
+// wired when the Auth0 M2M credentials are absent (local/dev), mirroring .NET's
+// NoOpAuth0ManagementClient.
+type Auth0Deleter interface {
+	DeleteUser(ctx context.Context, userID string) error
+}
+
+// Stores bundles the per-step deleters so the constructor signature stays
+// readable. main() builds it from the concrete stores; the test substitutes a
+// single recorder that satisfies every interface.
+type Stores struct {
+	Notifications       NotificationDeleter
+	WatchZones          WatchZoneDeleter
+	SavedApplications   SavedApplicationDeleter
+	DeviceRegistrations DeviceRegistrationDeleter
+	NotificationState   NotificationStateDeleter
+	Profiles            ProfileDeleter
+	Auth0               Auth0Deleter
+}
+
+// Handler runs one dormant-cleanup cycle.
+type Handler struct {
+	finder Finder
+	stores Stores
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// New builds a dormant-cleanup handler. now is injected so tests pin the cutoff;
+// production passes time.Now.
+func New(finder Finder, stores Stores, logger *slog.Logger, now func() time.Time) *Handler {
+	return &Handler{finder: finder, stores: stores, logger: logger, now: now}
+}
+
+// Run executes one cleanup cycle and returns the number of accounts fully erased.
+// It scans for dormant accounts, then runs the erasure cascade for each. A child
+// step that fails leaves the profile intact (so the next daily run retries) and
+// the account is not counted; a profile that has already been deleted by a
+// concurrent caller is tolerated and still counted (its end state is achieved).
+// A scan failure is fatal to the cycle; per-account failures are logged and the
+// run continues, mirroring .NET's per-account try/catch.
+func (h *Handler) Run(ctx context.Context) (int, error) {
+	cutoff := h.now().AddDate(0, -retentionMonths, 0)
+	dormant, err := h.finder.Dormant(ctx, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("find dormant accounts: %w", err)
+	}
+
+	deleted := 0
+	for _, p := range dormant {
+		if err := h.erase(ctx, p.UserID); err != nil {
+			h.logger.ErrorContext(ctx, "dormant account erasure failed; will retry next cycle", "user", p.UserID, "error", err)
+			continue
+		}
+		deleted++
+	}
+	h.logger.InfoContext(ctx, "dormant cleanup cycle complete", "scanned", len(dormant), "deleted", deleted)
+	return deleted, nil
+}
+
+// erase runs the full erasure cascade for one user. Child records are removed
+// before the profile so a mid-cascade failure leaves the profile present and the
+// account retryable, mirroring the .NET ordering. A 404 on the profile delete is
+// tolerated (the profile was removed concurrently), but a 404 on a child step is
+// already absorbed inside each store, so any error from a child step is real and
+// aborts the cascade for this account.
+func (h *Handler) erase(ctx context.Context, userID string) error {
+	if err := h.stores.Notifications.DeleteAllNotifications(ctx, userID); err != nil {
+		return fmt.Errorf("delete notifications: %w", err)
+	}
+	if err := h.stores.WatchZones.DeleteAllWatchZones(ctx, userID); err != nil {
+		return fmt.Errorf("delete watch zones: %w", err)
+	}
+	if err := h.stores.SavedApplications.DeleteAllSavedApplications(ctx, userID); err != nil {
+		return fmt.Errorf("delete saved applications: %w", err)
+	}
+	if err := h.stores.DeviceRegistrations.DeleteAllDeviceRegistrations(ctx, userID); err != nil {
+		return fmt.Errorf("delete device registrations: %w", err)
+	}
+	if err := h.stores.NotificationState.DeleteNotificationState(ctx, userID); err != nil {
+		return fmt.Errorf("delete notification state: %w", err)
+	}
+	if err := h.stores.Profiles.DeleteProfile(ctx, userID); err != nil && !errors.Is(err, profiles.ErrNotFound) {
+		return fmt.Errorf("delete profile: %w", err)
+	}
+	if err := h.stores.Auth0.DeleteUser(ctx, userID); err != nil {
+		return fmt.Errorf("delete auth0 user: %w", err)
+	}
+	return nil
+}

--- a/api-go/internal/dormant/handler_test.go
+++ b/api-go/internal/dormant/handler_test.go
@@ -1,9 +1,9 @@
 package dormant
 
 import (
+	"bytes"
 	"context"
 	"errors"
-	"io"
 	"log/slog"
 	"testing"
 	"time"
@@ -106,7 +106,7 @@ func newHandler(finder Finder, cascade *cascadeRecorder, auth0 Auth0Deleter, now
 		Profiles:            cascade,
 		Auth0:               auth0,
 	}
-	return New(finder, stores, slog.New(slog.NewTextHandler(io.Discard, nil)), func() time.Time { return now })
+	return New(finder, stores, slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)), func() time.Time { return now })
 }
 
 // --- tests ------------------------------------------------------------------

--- a/api-go/internal/dormant/handler_test.go
+++ b/api-go/internal/dormant/handler_test.go
@@ -1,0 +1,229 @@
+package dormant
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// --- hand-written fakes -----------------------------------------------------
+
+type fakeFinder struct {
+	dormant   []*profiles.UserProfile
+	err       error
+	gotCutoff time.Time
+}
+
+func (f *fakeFinder) Dormant(_ context.Context, cutoff time.Time) ([]*profiles.UserProfile, error) {
+	f.gotCutoff = cutoff
+	return f.dormant, f.err
+}
+
+// cascadeRecorder records, per user id, which cascade steps ran and in what
+// order, so the test can assert the full erasure cascade fired for each account.
+type cascadeRecorder struct {
+	steps      map[string][]string
+	notifErr   error
+	zoneErr    error
+	savedErr   error
+	deviceErr  error
+	stateErr   error
+	profileErr map[string]error // keyed by user id
+}
+
+func newCascadeRecorder() *cascadeRecorder {
+	return &cascadeRecorder{steps: map[string][]string{}, profileErr: map[string]error{}}
+}
+
+func (c *cascadeRecorder) record(userID, step string) {
+	c.steps[userID] = append(c.steps[userID], step)
+}
+
+func (c *cascadeRecorder) DeleteAllNotifications(_ context.Context, userID string) error {
+	c.record(userID, "notifications")
+	return c.notifErr
+}
+
+func (c *cascadeRecorder) DeleteAllWatchZones(_ context.Context, userID string) error {
+	c.record(userID, "watchzones")
+	return c.zoneErr
+}
+
+func (c *cascadeRecorder) DeleteAllSavedApplications(_ context.Context, userID string) error {
+	c.record(userID, "saved")
+	return c.savedErr
+}
+
+func (c *cascadeRecorder) DeleteAllDeviceRegistrations(_ context.Context, userID string) error {
+	c.record(userID, "devices")
+	return c.deviceErr
+}
+
+func (c *cascadeRecorder) DeleteNotificationState(_ context.Context, userID string) error {
+	c.record(userID, "state")
+	return c.stateErr
+}
+
+func (c *cascadeRecorder) DeleteProfile(_ context.Context, userID string) error {
+	c.record(userID, "profile")
+	return c.profileErr[userID]
+}
+
+type fakeAuth0 struct {
+	deleted   []string
+	deleteErr error
+}
+
+func (a *fakeAuth0) DeleteUser(_ context.Context, userID string) error {
+	if a.deleteErr != nil {
+		return a.deleteErr
+	}
+	a.deleted = append(a.deleted, userID)
+	return nil
+}
+
+func profile(t *testing.T, userID string) *profiles.UserProfile {
+	t.Helper()
+	p, err := profiles.NewProfile(userID, "", time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	return p
+}
+
+func newHandler(finder Finder, cascade *cascadeRecorder, auth0 Auth0Deleter, now time.Time) *Handler {
+	stores := Stores{
+		Notifications:       cascade,
+		WatchZones:          cascade,
+		SavedApplications:   cascade,
+		DeviceRegistrations: cascade,
+		NotificationState:   cascade,
+		Profiles:            cascade,
+		Auth0:               auth0,
+	}
+	return New(finder, stores, slog.New(slog.NewTextHandler(io.Discard, nil)), func() time.Time { return now })
+}
+
+// --- tests ------------------------------------------------------------------
+
+func TestHandler_Run_CutoffIs12MonthsBeforeNow(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+	finder := &fakeFinder{}
+	h := newHandler(finder, newCascadeRecorder(), &fakeAuth0{}, now)
+
+	if _, err := h.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := now.AddDate(0, -12, 0)
+	if !finder.gotCutoff.Equal(want) {
+		t.Errorf("cutoff: got %v, want %v (12 months before now)", finder.gotCutoff, want)
+	}
+}
+
+func TestHandler_Run_DeletesEachDormantAccountWithFullCascade(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC)
+	finder := &fakeFinder{dormant: []*profiles.UserProfile{profile(t, "auth0|a"), profile(t, "auth0|b")}}
+	cascade := newCascadeRecorder()
+	auth0 := &fakeAuth0{}
+	h := newHandler(finder, cascade, auth0, now)
+
+	deleted, err := h.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("deleted count: got %d, want 2", deleted)
+	}
+
+	wantSteps := []string{"notifications", "watchzones", "saved", "devices", "state", "profile"}
+	for _, id := range []string{"auth0|a", "auth0|b"} {
+		got := cascade.steps[id]
+		if len(got) != len(wantSteps) {
+			t.Fatalf("%s cascade steps: got %v, want %v", id, got, wantSteps)
+		}
+		for i := range wantSteps {
+			if got[i] != wantSteps[i] {
+				t.Errorf("%s cascade order at %d: got %q, want %q", id, i, got[i], wantSteps[i])
+			}
+		}
+	}
+	if len(auth0.deleted) != 2 || auth0.deleted[0] != "auth0|a" || auth0.deleted[1] != "auth0|b" {
+		t.Errorf("auth0 deletes: got %v, want [auth0|a auth0|b]", auth0.deleted)
+	}
+}
+
+func TestHandler_Run_NoDormantAccountsDeletesNothing(t *testing.T) {
+	t.Parallel()
+	finder := &fakeFinder{}
+	cascade := newCascadeRecorder()
+	auth0 := &fakeAuth0{}
+	h := newHandler(finder, cascade, auth0, time.Now())
+
+	deleted, err := h.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("deleted count: got %d, want 0", deleted)
+	}
+	if len(auth0.deleted) != 0 {
+		t.Errorf("auth0 deletes: got %v, want none", auth0.deleted)
+	}
+}
+
+func TestHandler_Run_FinderErrorPropagates(t *testing.T) {
+	t.Parallel()
+	finder := &fakeFinder{err: errors.New("cosmos down")}
+	h := newHandler(finder, newCascadeRecorder(), &fakeAuth0{}, time.Now())
+
+	if _, err := h.Run(context.Background()); err == nil {
+		t.Fatal("expected error when the dormant scan fails")
+	}
+}
+
+func TestHandler_Run_ProfileNotFoundIsToleratedAndCounted(t *testing.T) {
+	t.Parallel()
+	// A concurrent delete between the scan and the cascade leaves the profile
+	// gone; the cascade must tolerate ErrNotFound on the profile delete and still
+	// count the account as removed (its end state is achieved), mirroring .NET's
+	// UserProfileNotFoundException catch.
+	finder := &fakeFinder{dormant: []*profiles.UserProfile{profile(t, "auth0|gone")}}
+	cascade := newCascadeRecorder()
+	cascade.profileErr["auth0|gone"] = profiles.ErrNotFound
+	h := newHandler(finder, cascade, &fakeAuth0{}, time.Now())
+
+	deleted, err := h.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted count: got %d, want 1 (not-found is tolerated)", deleted)
+	}
+}
+
+func TestHandler_Run_ChildCascadeErrorAbortsThatAccountButContinues(t *testing.T) {
+	t.Parallel()
+	// A child-step failure leaves the profile intact so the next run retries; the
+	// account is NOT counted as deleted, and the run continues to the next account.
+	finder := &fakeFinder{dormant: []*profiles.UserProfile{profile(t, "auth0|fails"), profile(t, "auth0|ok")}}
+	cascade := newCascadeRecorder()
+	cascade.notifErr = errors.New("notifications delete failed")
+	h := newHandler(finder, cascade, &fakeAuth0{}, time.Now())
+
+	deleted, err := h.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Both accounts hit the notifications step first; both fail it, so none are
+	// counted, but the run completes without erroring out.
+	if deleted != 0 {
+		t.Errorf("deleted count: got %d, want 0 (child failure aborts that account)", deleted)
+	}
+}

--- a/api-go/internal/notifications/delete_store_cosmos.go
+++ b/api-go/internal/notifications/delete_store_cosmos.go
@@ -1,0 +1,70 @@
+package notifications
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// DeleteItems is the consumer-side slice of the Notifications container the
+// cascade-delete store uses: a single-partition id projection plus a
+// single-partition point delete. platform.CosmosContainer satisfies it
+// structurally. It is separate from CosmosItems / DigestItems because account
+// erasure needs delete, which the read-only projection store does not expose.
+type DeleteItems interface {
+	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
+	DeleteItem(ctx context.Context, partitionKey, id string) error
+}
+
+// DeleteStore removes a user's notifications for the account-erasure cascade
+// (dormant cleanup and DELETE /v1/me).
+//
+// Partition strategy: the Notifications container is partitioned by /userId, so
+// both the id projection and the point deletes target the single user partition
+// and never fan out cross-partition.
+type DeleteStore struct {
+	items DeleteItems
+}
+
+// NewDeleteStore returns a cascade-delete store backed by the given accessor.
+func NewDeleteStore(items DeleteItems) *DeleteStore {
+	return &DeleteStore{items: items}
+}
+
+// deleteIDOnlyDocument captures just the id projected by the cascade-delete query
+// (SELECT c.id FROM c ...).
+type deleteIDOnlyDocument struct {
+	ID string `json:"id"`
+}
+
+// DeleteAllByUserID removes every notification in the user's partition: it
+// queries the partition for the document ids, then point-deletes each, mirroring
+// .NET CosmosNotificationRepository.DeleteAllByUserIdAsync. A 404 on an
+// individual delete is tolerated so a concurrent delete does not fail the cascade.
+func (s *DeleteStore) DeleteAllByUserID(ctx context.Context, userID string) error {
+	const query = "SELECT c.id FROM c WHERE c.userId = @userId"
+	raws, err := s.items.QueryItems(ctx, userID, query, map[string]any{"@userId": userID})
+	if err != nil {
+		return fmt.Errorf("query notification ids for %q: %w", userID, err)
+	}
+	for _, raw := range raws {
+		var doc deleteIDOnlyDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return fmt.Errorf("decode notification id for %q: %w", userID, err)
+		}
+		if err := s.items.DeleteItem(ctx, userID, doc.ID); err != nil && !isDeleteNotFound(err) {
+			return fmt.Errorf("delete notification %q for %q: %w", doc.ID, userID, err)
+		}
+	}
+	return nil
+}
+
+// isDeleteNotFound reports whether err is a Cosmos 404 response.
+func isDeleteNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}

--- a/api-go/internal/notifications/delete_store_cosmos_test.go
+++ b/api-go/internal/notifications/delete_store_cosmos_test.go
@@ -1,0 +1,84 @@
+package notifications
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeDeleteItems is a hand-written stand-in for the query+delete slice of the
+// Notifications container the DeleteStore depends on. It records the partition
+// key for the cascade query and every deleted id, and can inject errors.
+type fakeDeleteItems struct {
+	queryResult  [][]byte
+	queryErr     error
+	deleteErr    error
+	lastQueryPK  string
+	lastQuery    string
+	lastDeletePK string
+	deletedIDs   []string
+}
+
+func (f *fakeDeleteItems) QueryItems(_ context.Context, partitionKey, query string, _ map[string]any) ([][]byte, error) {
+	f.lastQueryPK = partitionKey
+	f.lastQuery = query
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return f.queryResult, nil
+}
+
+func (f *fakeDeleteItems) DeleteItem(_ context.Context, partitionKey, id string) error {
+	f.lastDeletePK = partitionKey
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	f.deletedIDs = append(f.deletedIDs, id)
+	return nil
+}
+
+func TestDeleteStore_DeleteAllByUserID_QueriesPartitionThenDeletesEachID(t *testing.T) {
+	t.Parallel()
+	const userID = "auth0|u"
+	items := &fakeDeleteItems{queryResult: [][]byte{
+		[]byte(`{"id":"notif-a"}`),
+		[]byte(`{"id":"notif-b"}`),
+	}}
+	store := NewDeleteStore(items)
+
+	if err := store.DeleteAllByUserID(context.Background(), userID); err != nil {
+		t.Fatalf("DeleteAllByUserID: %v", err)
+	}
+	if items.lastQueryPK != userID {
+		t.Errorf("cascade query pk: got %q, want %q", items.lastQueryPK, userID)
+	}
+	if len(items.deletedIDs) != 2 || items.deletedIDs[0] != "notif-a" || items.deletedIDs[1] != "notif-b" {
+		t.Errorf("deleted ids: got %v", items.deletedIDs)
+	}
+	if items.lastDeletePK != userID {
+		t.Errorf("cascade delete pk: got %q, want %q", items.lastDeletePK, userID)
+	}
+}
+
+func TestDeleteStore_DeleteAllByUserID_QueryErrorPropagates(t *testing.T) {
+	t.Parallel()
+	items := &fakeDeleteItems{queryErr: errors.New("cosmos down")}
+	store := NewDeleteStore(items)
+
+	if err := store.DeleteAllByUserID(context.Background(), "auth0|u"); err == nil {
+		t.Fatal("expected error when the cascade query fails")
+	}
+}
+
+func TestDeleteStore_DeleteAllByUserID_NoneIsNoOp(t *testing.T) {
+	t.Parallel()
+	items := &fakeDeleteItems{}
+	store := NewDeleteStore(items)
+
+	if err := store.DeleteAllByUserID(context.Background(), "auth0|nobody"); err != nil {
+		t.Fatalf("DeleteAllByUserID: %v", err)
+	}
+	if len(items.deletedIDs) != 0 {
+		t.Errorf("expected no deletes, got %v", items.deletedIDs)
+	}
+}

--- a/api-go/internal/notificationstate/store_cosmos.go
+++ b/api-go/internal/notificationstate/store_cosmos.go
@@ -14,11 +14,12 @@ import (
 )
 
 // CosmosItems is the consumer-side slice of the NotificationState container the
-// store uses: point read/upsert keyed on the user id (one document per user,
-// id == partition key). platform.CosmosContainer satisfies it structurally.
+// store uses: point read/upsert/delete keyed on the user id (one document per
+// user, id == partition key). platform.CosmosContainer satisfies it structurally.
 type CosmosItems interface {
 	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
 	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
+	DeleteItem(ctx context.Context, partitionKey, id string) error
 }
 
 // CosmosCounter is the consumer-side slice of the Notifications container the
@@ -84,6 +85,22 @@ func (s *CosmosStore) UnreadCount(ctx context.Context, userID string, lastReadAt
 		return 0, fmt.Errorf("count unread for %q: %w", userID, err)
 	}
 	return count, nil
+}
+
+// DeleteByUserID removes the user's watermark document for the account-erasure
+// cascade (dormant cleanup and DELETE /v1/me). The container holds one document
+// per user (id == userId == partition key), so this is a single point delete; a
+// 404 is tolerated so an account with no watermark yet is not a cascade failure.
+//
+// Note: the retired .NET DeleteUserProfileCommandHandler did not erase the
+// notification-state watermark, leaving an orphaned document after account
+// deletion. The Go cascade deletes it (epic tc-wad3, bead tc-dwcq) for complete
+// GDPR erasure.
+func (s *CosmosStore) DeleteByUserID(ctx context.Context, userID string) error {
+	if err := s.state.DeleteItem(ctx, userID, userID); err != nil && !isNotFound(err) {
+		return fmt.Errorf("delete notification state %q: %w", userID, err)
+	}
+	return nil
 }
 
 // isNotFound reports whether err is a Cosmos 404 response.

--- a/api-go/internal/notificationstate/store_cosmos_test.go
+++ b/api-go/internal/notificationstate/store_cosmos_test.go
@@ -11,7 +11,10 @@ import (
 )
 
 type fakeItems struct {
-	docs map[string][]byte
+	docs         map[string][]byte
+	deleteErr    error
+	lastDeletePK string
+	lastDeleteID string
 }
 
 func (f *fakeItems) ReadItem(_ context.Context, _, id string) ([]byte, error) {
@@ -27,6 +30,16 @@ func (f *fakeItems) UpsertItem(_ context.Context, _ string, item []byte) error {
 		f.docs = map[string][]byte{}
 	}
 	f.docs[idOf(item)] = item
+	return nil
+}
+
+func (f *fakeItems) DeleteItem(_ context.Context, partitionKey, id string) error {
+	f.lastDeletePK = partitionKey
+	f.lastDeleteID = id
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	delete(f.docs, id)
 	return nil
 }
 
@@ -93,5 +106,32 @@ func TestCosmosStore_UnreadCount_CutoffFormat(t *testing.T) {
 	// lexicographic comparison against .NET-written createdAt values holds.
 	if cutoff := counter.params["@lastReadAt"]; cutoff != "2026-06-12T09:00:00+00:00" {
 		t.Errorf("cutoff param = %v, want +00:00 form", cutoff)
+	}
+}
+
+func TestCosmosStore_DeleteByUserID_PointDeletesUserDocument(t *testing.T) {
+	t.Parallel()
+	const userID = "auth0|s1"
+	items := &fakeItems{docs: map[string][]byte{userID: []byte(`{"id":"auth0|s1"}`)}}
+	store := NewCosmosStore(items, &fakeCounter{})
+
+	if err := store.DeleteByUserID(context.Background(), userID); err != nil {
+		t.Fatalf("DeleteByUserID: %v", err)
+	}
+	if items.lastDeletePK != userID || items.lastDeleteID != userID {
+		t.Errorf("delete keys: pk=%q id=%q, want both %q", items.lastDeletePK, items.lastDeleteID, userID)
+	}
+	if _, ok := items.docs[userID]; ok {
+		t.Error("document still present after DeleteByUserID")
+	}
+}
+
+func TestCosmosStore_DeleteByUserID_MissingIsNoError(t *testing.T) {
+	t.Parallel()
+	items := &fakeItems{deleteErr: &azcore.ResponseError{StatusCode: http.StatusNotFound}}
+	store := NewCosmosStore(items, &fakeCounter{})
+
+	if err := store.DeleteByUserID(context.Background(), "auth0|gone"); err != nil {
+		t.Errorf("DeleteByUserID on absent watermark: got %v, want nil (idempotent)", err)
 	}
 }

--- a/api-go/internal/profiles/admin_store.go
+++ b/api-go/internal/profiles/admin_store.go
@@ -102,6 +102,37 @@ func (s *AdminStore) ByDigestDay(ctx context.Context, day time.Weekday) ([]*User
 	return profiles, nil
 }
 
+// Dormant returns every profile last active strictly before cutoff — the
+// dormant-account set the cleanup worker erases (UK GDPR Art. 5(1)(e), ADR 0023).
+// Mirrors .NET GetDormantCrossPartitionAsync, with one deliberate hardening: the
+// cutoff comparison is done in Go on the parsed LastActiveAt rather than as a
+// Cosmos string comparison. Production documents carry lastActiveAt in two wire
+// formats — .NET's DateTimeOffset "+00:00" form and the Go store's RFC 3339 "Z"
+// form — and "Z" sorts after "+", so a lexicographic SQL "<" would silently miss
+// "Z"-stored dormant accounts. The scan is a once-a-day batch over a small user
+// base, so hydrating all profiles and filtering in Go is both correct and cheap.
+func (s *AdminStore) Dormant(ctx context.Context, cutoff time.Time) ([]*UserProfile, error) {
+	rows, err := s.items.QueryItemsCrossPartition(ctx, "SELECT * FROM c", nil)
+	if err != nil {
+		return nil, fmt.Errorf("query dormant profiles: %w", err)
+	}
+	dormant := make([]*UserProfile, 0)
+	for _, raw := range rows {
+		var doc profileDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("decode profile: %w", err)
+		}
+		p, err := doc.toDomain()
+		if err != nil {
+			return nil, fmt.Errorf("hydrate profile: %w", err)
+		}
+		if p.LastActiveAt.Before(cutoff) {
+			dormant = append(dormant, p)
+		}
+	}
+	return dormant, nil
+}
+
 // Save upserts the profile (id == user id == partition key).
 func (s *AdminStore) Save(ctx context.Context, p *UserProfile) error {
 	body, err := json.Marshal(newProfileDocument(p))

--- a/api-go/internal/profiles/admin_store_test.go
+++ b/api-go/internal/profiles/admin_store_test.go
@@ -220,3 +220,66 @@ func TestAdminStore_ByDigestDayWrapsError(t *testing.T) {
 		t.Fatal("expected error")
 	}
 }
+
+// profileDocAt builds a stored profile document with a specific LastActiveAt so
+// the dormant scan's Go-side cutoff comparison can be exercised.
+func profileDocAt(t *testing.T, userID string, lastActive time.Time) []byte {
+	t.Helper()
+	p, err := NewProfile(userID, "", lastActive)
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	p.LastActiveAt = lastActive
+	raw, err := json.Marshal(newProfileDocument(p))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw
+}
+
+func TestAdminStore_Dormant_KeepsAccountsActiveAtOrAfterCutoff(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2025, 6, 14, 0, 0, 0, 0, time.UTC)
+
+	items := newFakeAdminItems()
+	items.queryResult = [][]byte{
+		profileDocAt(t, "dormant-13mo", cutoff.AddDate(0, -1, 0)),  // before cutoff -> dormant
+		profileDocAt(t, "active-11mo", cutoff.AddDate(0, 1, 0)),    // after cutoff -> kept
+		profileDocAt(t, "exactly-12mo", cutoff),                    // == cutoff -> kept (not strictly before)
+		profileDocAt(t, "dormant-old", cutoff.AddDate(-1, 0, 0)),   // well before -> dormant
+	}
+	store := NewAdminStore(items)
+
+	got, err := store.Dormant(context.Background(), cutoff)
+	if err != nil {
+		t.Fatalf("Dormant: %v", err)
+	}
+
+	ids := map[string]bool{}
+	for _, p := range got {
+		ids[p.UserID] = true
+	}
+	if !ids["dormant-13mo"] || !ids["dormant-old"] {
+		t.Errorf("dormant accounts missing from result: %v", ids)
+	}
+	if ids["active-11mo"] {
+		t.Error("an account active after the cutoff must not be dormant")
+	}
+	if ids["exactly-12mo"] {
+		t.Error("an account active exactly at the cutoff must be kept (strictly-before semantics)")
+	}
+	if len(got) != 2 {
+		t.Errorf("dormant count: got %d, want 2", len(got))
+	}
+}
+
+func TestAdminStore_Dormant_WrapsQueryError(t *testing.T) {
+	t.Parallel()
+	items := newFakeAdminItems()
+	items.queryErr = errors.New("cosmos down")
+	store := NewAdminStore(items)
+
+	if _, err := store.Dormant(context.Background(), time.Now()); err == nil {
+		t.Fatal("expected error when the dormant scan fails")
+	}
+}

--- a/api-go/internal/profiles/admin_store_test.go
+++ b/api-go/internal/profiles/admin_store_test.go
@@ -243,10 +243,10 @@ func TestAdminStore_Dormant_KeepsAccountsActiveAtOrAfterCutoff(t *testing.T) {
 
 	items := newFakeAdminItems()
 	items.queryResult = [][]byte{
-		profileDocAt(t, "dormant-13mo", cutoff.AddDate(0, -1, 0)),  // before cutoff -> dormant
-		profileDocAt(t, "active-11mo", cutoff.AddDate(0, 1, 0)),    // after cutoff -> kept
-		profileDocAt(t, "exactly-12mo", cutoff),                    // == cutoff -> kept (not strictly before)
-		profileDocAt(t, "dormant-old", cutoff.AddDate(-1, 0, 0)),   // well before -> dormant
+		profileDocAt(t, "dormant-13mo", cutoff.AddDate(0, -1, 0)), // before cutoff -> dormant
+		profileDocAt(t, "active-11mo", cutoff.AddDate(0, 1, 0)),   // after cutoff -> kept
+		profileDocAt(t, "exactly-12mo", cutoff),                   // == cutoff -> kept (not strictly before)
+		profileDocAt(t, "dormant-old", cutoff.AddDate(-1, 0, 0)),  // well before -> dormant
 	}
 	store := NewAdminStore(items)
 

--- a/api-go/internal/savedapplications/store_cosmos.go
+++ b/api-go/internal/savedapplications/store_cosmos.go
@@ -90,6 +90,34 @@ func (s *CosmosStore) GetByUserID(ctx context.Context, userID string) ([]SavedAp
 	return saved, nil
 }
 
+// idOnlyDocument captures just the id projected by the cascade-delete query
+// (SELECT c.id FROM c ...), so the cascade need not hydrate full documents.
+type idOnlyDocument struct {
+	ID string `json:"id"`
+}
+
+// DeleteAllByUserID removes every saved application in the user's partition: it
+// queries the partition for the document ids, then point-deletes each. Used by
+// the account-deletion cascade (dormant cleanup and DELETE /v1/me), mirroring
+// .NET CosmosSavedApplicationRepository.DeleteAllByUserIdAsync. All operations
+// are single-partition.
+func (s *CosmosStore) DeleteAllByUserID(ctx context.Context, userID string) error {
+	raws, err := s.items.QueryItems(ctx, userID, "SELECT c.id FROM c WHERE c.userId = @userId", map[string]any{"@userId": userID})
+	if err != nil {
+		return fmt.Errorf("query saved application ids for %q: %w", userID, err)
+	}
+	for _, raw := range raws {
+		var doc idOnlyDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return fmt.Errorf("decode saved application id for %q: %w", userID, err)
+		}
+		if err := s.items.DeleteItem(ctx, userID, doc.ID); err != nil && !isNotFound(err) {
+			return fmt.Errorf("delete saved application %q for %q: %w", doc.ID, userID, err)
+		}
+	}
+	return nil
+}
+
 // isNotFound reports whether err is a Cosmos 404 response.
 func isNotFound(err error) bool {
 	var respErr *azcore.ResponseError

--- a/api-go/internal/savedapplications/store_cosmos_test.go
+++ b/api-go/internal/savedapplications/store_cosmos_test.go
@@ -16,7 +16,10 @@ type fakeItems struct {
 	queryResult  [][]byte
 	lastUpsertPK string
 	lastDeleteID string
+	lastDeletePK string
+	deletedIDs   []string
 	lastQueryPK  string
+	lastQuery    string
 	lastParams   map[string]any
 }
 
@@ -40,17 +43,20 @@ func (f *fakeItems) UpsertItem(_ context.Context, partitionKey string, item []by
 	return nil
 }
 
-func (f *fakeItems) DeleteItem(_ context.Context, _, id string) error {
+func (f *fakeItems) DeleteItem(_ context.Context, partitionKey, id string) error {
 	f.lastDeleteID = id
+	f.lastDeletePK = partitionKey
 	if f.deleteErr != nil {
 		return f.deleteErr
 	}
+	f.deletedIDs = append(f.deletedIDs, id)
 	delete(f.stored, id)
 	return nil
 }
 
-func (f *fakeItems) QueryItems(_ context.Context, partitionKey, _ string, params map[string]any) ([][]byte, error) {
+func (f *fakeItems) QueryItems(_ context.Context, partitionKey, query string, params map[string]any) ([][]byte, error) {
 	f.lastQueryPK = partitionKey
+	f.lastQuery = query
 	f.lastParams = params
 	return f.queryResult, nil
 }
@@ -125,6 +131,30 @@ func TestCosmosStore_GetByUserID(t *testing.T) {
 	}
 	if items.lastQueryPK != "auth0|u" || items.lastParams["@userId"] != "auth0|u" {
 		t.Errorf("query routing: pk=%q params=%v", items.lastQueryPK, items.lastParams)
+	}
+}
+
+func TestCosmosStore_DeleteAllByUserID_QueriesPartitionThenDeletesEachID(t *testing.T) {
+	t.Parallel()
+	const userID = "auth0|u"
+	items := newFakeItems()
+	items.queryResult = [][]byte{
+		[]byte(`{"id":"auth0|u:app-a"}`),
+		[]byte(`{"id":"auth0|u:app-b"}`),
+	}
+	store := NewCosmosStore(items)
+
+	if err := store.DeleteAllByUserID(context.Background(), userID); err != nil {
+		t.Fatalf("DeleteAllByUserID: %v", err)
+	}
+	if items.lastQueryPK != userID {
+		t.Errorf("cascade query pk: got %q, want %q", items.lastQueryPK, userID)
+	}
+	if len(items.deletedIDs) != 2 || items.deletedIDs[0] != "auth0|u:app-a" || items.deletedIDs[1] != "auth0|u:app-b" {
+		t.Errorf("deleted ids: got %v", items.deletedIDs)
+	}
+	if items.lastDeletePK != userID {
+		t.Errorf("cascade delete pk: got %q, want %q", items.lastDeletePK, userID)
 	}
 }
 

--- a/api-go/internal/watchzones/store_cosmos.go
+++ b/api-go/internal/watchzones/store_cosmos.go
@@ -113,6 +113,34 @@ func (s *CosmosStore) Delete(ctx context.Context, userID, zoneID string) error {
 	return nil
 }
 
+// idOnlyDocument captures just the id projected by the cascade-delete query
+// (SELECT c.id FROM c ...), so the cascade need not hydrate full documents.
+type idOnlyDocument struct {
+	ID string `json:"id"`
+}
+
+// DeleteAllByUserID removes every watch zone in the user's partition: it queries
+// the partition for the document ids, then point-deletes each. Used by the
+// account-deletion cascade (dormant cleanup and DELETE /v1/me), mirroring .NET
+// CosmosWatchZoneRepository.DeleteAllByUserIdAsync. The scan and the deletes are
+// all single-partition, so they never fan out cross-partition.
+func (s *CosmosStore) DeleteAllByUserID(ctx context.Context, userID string) error {
+	raws, err := s.items.QueryItems(ctx, userID, "SELECT c.id FROM c WHERE c.userId = @userId", map[string]any{"@userId": userID})
+	if err != nil {
+		return fmt.Errorf("query watch zone ids for %q: %w", userID, err)
+	}
+	for _, raw := range raws {
+		var doc idOnlyDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return fmt.Errorf("decode watch zone id for %q: %w", userID, err)
+		}
+		if err := s.items.DeleteItem(ctx, userID, doc.ID); err != nil && !isNotFound(err) {
+			return fmt.Errorf("delete watch zone %q for %q: %w", doc.ID, userID, err)
+		}
+	}
+	return nil
+}
+
 // isNotFound reports whether err is a Cosmos 404 response.
 func isNotFound(err error) bool {
 	var respErr *azcore.ResponseError

--- a/api-go/internal/watchzones/store_cosmos_test.go
+++ b/api-go/internal/watchzones/store_cosmos_test.go
@@ -26,6 +26,7 @@ type fakeItems struct {
 	lastUpsert   []byte
 	lastDeletePK string
 	lastDeleteID string
+	deletedIDs   []string // every (pk,id) deleted, in call order, for cascade assertions
 	lastQueryPK  string
 	lastQuery    string
 	lastParams   map[string]any
@@ -57,7 +58,12 @@ func (f *fakeItems) UpsertItem(_ context.Context, partitionKey string, item []by
 func (f *fakeItems) DeleteItem(_ context.Context, partitionKey, id string) error {
 	f.lastDeletePK = partitionKey
 	f.lastDeleteID = id
-	return f.deleteErr
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	f.deletedIDs = append(f.deletedIDs, id)
+	delete(f.stored, id)
+	return nil
 }
 
 func (f *fakeItems) QueryItems(_ context.Context, partitionKey, query string, params map[string]any) ([][]byte, error) {
@@ -185,5 +191,43 @@ func TestCosmosStore_Delete_NotFound(t *testing.T) {
 	err := store.Delete(context.Background(), "auth0|user", "missing")
 	if !errors.Is(err, ErrNotFound) {
 		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+}
+
+func TestCosmosStore_DeleteAllByUserID_QueriesPartitionThenDeletesEachID(t *testing.T) {
+	t.Parallel()
+	const userID = "auth0|user"
+	items := newFakeItems()
+	items.queryResult = [][]byte{
+		[]byte(`{"id":"zone-a"}`),
+		[]byte(`{"id":"zone-b"}`),
+	}
+	store := NewCosmosStore(items)
+
+	if err := store.DeleteAllByUserID(context.Background(), userID); err != nil {
+		t.Fatalf("DeleteAllByUserID: %v", err)
+	}
+
+	if items.lastQueryPK != userID {
+		t.Errorf("cascade query partition key: got %q, want %q", items.lastQueryPK, userID)
+	}
+	if len(items.deletedIDs) != 2 || items.deletedIDs[0] != "zone-a" || items.deletedIDs[1] != "zone-b" {
+		t.Errorf("deleted ids: got %v, want [zone-a zone-b]", items.deletedIDs)
+	}
+	if items.lastDeletePK != userID {
+		t.Errorf("cascade delete partition key: got %q, want %q", items.lastDeletePK, userID)
+	}
+}
+
+func TestCosmosStore_DeleteAllByUserID_NoZonesIsNoOp(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if err := store.DeleteAllByUserID(context.Background(), "auth0|nobody"); err != nil {
+		t.Fatalf("DeleteAllByUserID: %v", err)
+	}
+	if len(items.deletedIDs) != 0 {
+		t.Errorf("expected no deletes, got %v", items.deletedIDs)
 	}
 }

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -25,6 +25,13 @@ const bootstrapBudget = 60 * time.Second
 // replicaTimeout so the process exits cleanly and flushes telemetry.
 const digestBudget = 10 * time.Minute
 
+// dormantBudget is the soft self-cancel for a single dormant-cleanup run. The
+// cycle scans all profiles cross-partition then runs a per-account erasure
+// cascade for the (small) dormant set; 10 minutes is generous while still bounded
+// well under the Container Apps replicaTimeout so the process exits cleanly and
+// flushes telemetry.
+const dormantBudget = 10 * time.Minute
+
 // DigestRunner is the consumer-side slice of the digest handler the dispatcher
 // invokes. *digest.Handler satisfies it; the worker depends only on these two
 // methods so it need not know the handler's internals. It is exported so main()
@@ -35,22 +42,31 @@ type DigestRunner interface {
 	RunHourly(ctx context.Context) error
 }
 
+// DormantRunner is the consumer-side slice of the dormant-cleanup handler the
+// dispatcher invokes. *dormant.Handler satisfies it; Run returns the number of
+// accounts erased so the dispatcher can record it as a telemetry tag. It is
+// exported so main() can hold a genuinely nil interface value when the job has no
+// Cosmos config — passing a typed-nil *dormant.Handler would defeat the nil guard.
+type DormantRunner interface {
+	Run(ctx context.Context) (int, error)
+}
+
 // Run dispatches on WORKER_MODE and returns the process exit code. It is the
 // testable core of cmd/worker/main.go — main() only loads config, wires the
 // Service Bus client + bootstrapper, sets up telemetry, and propagates this
 // code.
 //
-// poll-bootstrap, digest, and hourly-digest are implemented; the remaining modes
-// (poll-sb, dormant-cleanup) are loud stubs that exit 1 until their own beads
-// land. The Go worker image is not deployed to any job until the final cutover
-// bead, so a stub can never run in production. An unset or unknown mode is a
-// deployment accident and also fails fast.
+// poll-bootstrap, digest, hourly-digest, and dormant-cleanup are implemented;
+// poll-sb remains a loud stub that exits 1 until its own bead (tc-yng2) lands.
+// The Go worker image is not deployed to any job until the final cutover bead, so
+// a stub can never run in production. An unset or unknown mode is a deployment
+// accident and also fails fast.
 //
 // bootstrapper may be nil when the job has no Service Bus config; poll-bootstrap
-// then refuses to run rather than nil-panicking. Likewise digester may be nil
-// when the job has no Cosmos / ACS / APNs config; the digest modes then refuse
-// to run rather than nil-panicking.
-func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, logger *slog.Logger) int {
+// then refuses to run rather than nil-panicking. Likewise digester / dormant may
+// be nil when the job has no Cosmos config; those modes then refuse to run rather
+// than nil-panicking.
+func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, dormant DormantRunner, logger *slog.Logger) int {
 	switch mode {
 	case "":
 		// WORKER_MODE is always set by infra; an unset value is a deployment
@@ -67,9 +83,12 @@ func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester 
 	case "hourly-digest":
 		return runDigest(ctx, "Hourly Digest Cycle", digester, DigestRunner.RunHourly, logger)
 
-	case "poll-sb", "dormant-cleanup":
+	case "dormant-cleanup":
+		return runDormant(ctx, dormant, logger)
+
+	case "poll-sb":
 		// Loud, safe stub: the image is not deployed until the final cutover, so
-		// this exit-1 can never strand a real job. Each mode lands in its own bead.
+		// this exit-1 can never strand a real job. poll-sb lands in bead tc-yng2.
 		logger.ErrorContext(ctx, "WORKER_MODE not yet implemented in Go worker", "mode", mode)
 		return 1
 
@@ -103,6 +122,36 @@ func runDigest(ctx context.Context, spanName string, digester DigestRunner, run 
 		logger.ErrorContext(ctx, "digest cycle failed", "span", spanName, "error", err)
 		return 1
 	}
+	return 0
+}
+
+// runDormant executes one dormant-cleanup cycle under a soft self-cancel budget,
+// inside a telemetry span named "Dormant Cleanup Cycle" (mirroring the .NET
+// worker so existing App Insights queries keep working). It records the number of
+// erased accounts as the dormant_cleanup.deleted_count tag. A nil runner (job
+// missing Cosmos config) is an exit-1 condition; a cycle error is recorded on the
+// span and also exits 1 so the job surfaces the failure.
+func runDormant(ctx context.Context, runner DormantRunner, logger *slog.Logger) int {
+	tracer := otel.Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, "Dormant Cleanup Cycle")
+	defer span.End()
+
+	if runner == nil {
+		logger.ErrorContext(ctx, "dormant-cleanup requires Cosmos config (COSMOS_ENDPOINT et al.); refusing to run")
+		return 1
+	}
+
+	cycleCtx, cancel := context.WithTimeout(ctx, dormantBudget)
+	defer cancel()
+
+	deleted, err := runner.Run(cycleCtx)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		logger.ErrorContext(ctx, "dormant cleanup cycle failed", "error", err)
+		return 1
+	}
+	span.SetAttributes(attribute.Int("dormant_cleanup.deleted_count", deleted))
 	return 0
 }
 

--- a/api-go/internal/worker/dispatch_test.go
+++ b/api-go/internal/worker/dispatch_test.go
@@ -30,12 +30,25 @@ func (f *fakeDigester) RunHourly(context.Context) error {
 	return f.hourlyErr
 }
 
+// fakeDormant is a hand-written double for the DormantRunner the dispatcher
+// invokes. It records the call and can be primed with a deleted count or error.
+type fakeDormant struct {
+	calls   int
+	deleted int
+	err     error
+}
+
+func (f *fakeDormant) Run(context.Context) (int, error) {
+	f.calls++
+	return f.deleted, f.err
+}
+
 func TestRun_UnsetModeFailsFast(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "", nil, nil, logger)
+	code := Run(context.Background(), "", nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unset mode", code)
@@ -50,7 +63,7 @@ func TestRun_DigestModeRunsWeeklyAndExitsZero(t *testing.T) {
 	d := &fakeDigester{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "digest", nil, d, logger)
+	code := Run(context.Background(), "digest", nil, d, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0", code)
@@ -65,7 +78,7 @@ func TestRun_HourlyDigestModeRunsHourlyAndExitsZero(t *testing.T) {
 	d := &fakeDigester{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "hourly-digest", nil, d, logger)
+	code := Run(context.Background(), "hourly-digest", nil, d, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0", code)
@@ -82,7 +95,7 @@ func TestRun_DigestModeWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "digest", nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when digest handler is unconfigured", code)
@@ -94,38 +107,72 @@ func TestRun_DigestCycleErrorExitsOne(t *testing.T) {
 	d := &fakeDigester{weeklyErr: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "digest", nil, d, logger)
+	code := Run(context.Background(), "digest", nil, d, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on digest cycle error", code)
 	}
 }
 
-func TestRun_UnimplementedModesExitOne(t *testing.T) {
+func TestRun_PollSBStillStubsExitOne(t *testing.T) {
 	t.Parallel()
-	// The remaining non-digest modes are stubs until their own beads land. The
-	// image is not deployed until the final cutover, so failing fast (exit 1) is
-	// safe and loud.
-	modes := []string{"poll-sb", "dormant-cleanup"}
-	for _, mode := range modes {
-		t.Run(mode, func(t *testing.T) {
-			t.Parallel()
-			var buf bytes.Buffer
-			logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	// poll-sb remains a loud stub until its own bead (tc-yng2) lands. The image is
+	// not deployed until the final cutover, so failing fast (exit 1) is safe.
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-			code := Run(context.Background(), mode, nil, nil, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, logger)
 
-			if code != 1 {
-				t.Errorf("exit code: got %d, want 1 for unimplemented mode %q", code, mode)
-			}
-			out := buf.String()
-			if !strings.Contains(out, "not yet implemented in Go worker") {
-				t.Errorf("log should report unimplemented mode, got: %s", out)
-			}
-			if !strings.Contains(out, mode) {
-				t.Errorf("log should name the mode %q, got: %s", mode, out)
-			}
-		})
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1 for unimplemented poll-sb", code)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "not yet implemented in Go worker") {
+		t.Errorf("log should report unimplemented mode, got: %s", out)
+	}
+	if !strings.Contains(out, "poll-sb") {
+		t.Errorf("log should name poll-sb, got: %s", out)
+	}
+}
+
+func TestRun_DormantCleanupRunsAndExitsZero(t *testing.T) {
+	t.Parallel()
+	d := &fakeDormant{deleted: 3}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, logger)
+
+	if code != 0 {
+		t.Errorf("exit code: got %d, want 0 (successful dormant cleanup)", code)
+	}
+	if d.calls != 1 {
+		t.Errorf("dormant Run calls: got %d, want 1", d.calls)
+	}
+}
+
+func TestRun_DormantCleanupWithoutHandlerExitsOne(t *testing.T) {
+	t.Parallel()
+	// A job missing Cosmos config leaves the dormant runner nil; the mode must
+	// refuse to run rather than nil-panic.
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, nil, logger)
+
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1 when dormant handler is unconfigured", code)
+	}
+}
+
+func TestRun_DormantCleanupCycleErrorExitsOne(t *testing.T) {
+	t.Parallel()
+	d := &fakeDormant{err: errors.New("cosmos down")}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, logger)
+
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1 on dormant cleanup error", code)
 	}
 }
 
@@ -134,7 +181,7 @@ func TestRun_UnknownModeExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "banana", nil, nil, logger)
+	code := Run(context.Background(), "banana", nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unknown mode", code)
@@ -147,7 +194,7 @@ func TestRun_PollBootstrapSeedsAndExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful bootstrap)", code)
@@ -164,7 +211,7 @@ func TestRun_PollBootstrapWithoutQueueExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when Service Bus is unconfigured", code)
@@ -179,7 +226,7 @@ func TestRun_PollBootstrapProbeFailureStillExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (absorbed probe failure is not a job failure)", code)


### PR DESCRIPTION
Phase 2 Go worker migration (epic tc-wad3). Ports `DormantAccountCleanupCommandHandler` + the GDPR delete-cascade.

- `internal/dormant` — `Handler.Run`: cutoff = now−12mo (UK GDPR Art 5(1)(e), ADR 0023), finds dormant accounts, runs per-account erasure cascade, returns deleted count.
- Per-container cascade delete methods (single-partition `SELECT id WHERE userId` → point-delete, tolerating 404s): `notifications.DeleteStore.DeleteAllByUserID`, `watchzones`/`savedapplications`/`devicetokens`.`DeleteAllByUserID`, `notificationstate.DeleteByUserID`, `profiles.AdminStore.Dormant`. Cascade order: notifications → watchzones → savedApplications → deviceRegistrations → notificationState → profile → Auth0.
- Auth0 M2M delete reuses the existing `profiles.Auth0Client`/`NoOpAuth0Client` (token cache + `DELETE /api/v2/users/{id}`); NoOp when M2M unconfigured.
- `dispatch.go` — real `dormant-cleanup` handler under span "Dormant Cleanup Cycle" (tag `dormant_cleanup.deleted_count`); **poll-sb remains the exit-1 stub** (next bead tc-yng2). `cmd/worker/main.go` wires the cascade.

Two deliberate divergences from .NET (in bead notes): (1) dormancy filter parsed in Go not SQL string-compare — prod stores `lastActiveAt` in two formats (`+00:00` vs `Z`) and `Z` sorts after `+`, so a SQL compare would miss `Z` accounts; (2) notification-state IS deleted (complete erasure) where the retired .NET handler left an orphan watermark.

Env for infra (tc-uzm1): `AUTH0_DOMAIN`, `AUTH0_M2M_CLIENT_ID`, `AUTH0_M2M_CLIENT_SECRET` (reuse .NET Auth0 secret values) + existing COSMOS_*/AZURE_CLIENT_ID.

Gate: gofmt/vet/golangci clean, `go test -race` 696 pass, build ok.

Closes tc-dwcq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)