### PR TITLE
feat(go): poll-sb adaptive poll mode — receive-and-delete orchestrator (tc-yng2)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -11,6 +11,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"log"
 	"log/slog"
 	"net/http"
@@ -19,12 +20,16 @@ import (
 
 	"github.com/AmyDe/town-crier/api-go/internal/acsemail"
 	"github.com/AmyDe/town-crier/api-go/internal/apns"
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/authorities"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/digest"
 	"github.com/AmyDe/town-crier/api-go/internal/dormant"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/planit"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/polling"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/servicebus"
@@ -69,13 +74,17 @@ func run() int {
 		}
 	}()
 
-	// The Service Bus client (and thus the bootstrapper) is built only when the
-	// job carries Service Bus config. Jobs that don't touch Service Bus (digest,
-	// hourly-digest, dormant-cleanup) leave the bootstrapper nil; poll-bootstrap
-	// then refuses to run rather than crashing.
-	var bootstrapper *worker.Bootstrapper
+	// The Service Bus client (and thus the bootstrapper and the poll-sb
+	// orchestrator) is built only when the job carries Service Bus config. Jobs
+	// that don't touch Service Bus (digest, hourly-digest, dormant-cleanup) leave
+	// the bootstrapper nil; poll-bootstrap then refuses to run rather than
+	// crashing.
+	var (
+		bootstrapper *worker.Bootstrapper
+		sbClient     *servicebus.Client
+	)
 	if cfg.ServiceBusNamespace != "" && cfg.ServiceBusQueueName != "" {
-		sbClient, err := servicebus.NewClient(cfg.ServiceBusNamespace, cfg.ServiceBusQueueName, cfg.AzureClientID)
+		sbClient, err = servicebus.NewClient(cfg.ServiceBusNamespace, cfg.ServiceBusQueueName, cfg.AzureClientID)
 		if err != nil {
 			logger.Error("build service bus client", "error", err)
 			return 1
@@ -124,7 +133,206 @@ func run() int {
 		dormantRunner = dormantHandler
 	}
 
-	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, logger)
+	// The poll-sb orchestrator is built only when the job carries BOTH Service Bus
+	// (trigger queue) and Cosmos (lease + poll state + applications) config. A job
+	// missing either leaves it a genuinely nil interface; poll-sb then refuses to
+	// run rather than crashing. Declared as the interface so the "unconfigured"
+	// case stays a nil interface value (a typed-nil adapter would defeat the guard).
+	var poller worker.PollOrchestrator
+	pollAdapter, err := buildPollOrchestrator(cfg, sbClient, logger)
+	if err != nil {
+		logger.Error("build poll-sb orchestrator", "error", err)
+		return 1
+	}
+	if pollAdapter != nil {
+		poller = pollAdapter
+	}
+
+	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, logger)
+}
+
+// buildPollOrchestrator wires the poll-sb orchestrator: the PlanIt client, the
+// Cosmos poll-state and etag-CAS lease stores, the cycle-alternating authority
+// provider, the ingestion handler, and the next-run scheduler — bridged to the
+// receive/publish operations of the shared Service Bus client. It returns
+// (nil, nil) when Service Bus or Cosmos config is absent, so poll-sb refuses to
+// run rather than nil-panicking. The cycle budget (replicaTimeout − grace) and
+// the handler/lease budgets all come from config.
+func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, logger *slog.Logger) (*pollOrchestratorAdapter, error) {
+	if sbClient == nil || cfg.CosmosEndpoint == "" {
+		return nil, nil //nolint:nilnil // absent SB/Cosmos config is a valid "no poller" state, not an error
+	}
+
+	planItClient, err := planit.NewClient(planit.Options{
+		BaseURL: cfg.PlanItBaseURL,
+		Throttle: planit.ThrottleOptions{
+			DelayBetweenRequests: secondsToDuration(cfg.PlanItThrottleDelaySeconds),
+		},
+		Retry: planit.RetryOptions{
+			MaxRetries:       cfg.PlanItMaxRetries,
+			InitialBackoff:   secondsToDuration(cfg.PlanItInitialBackoffSeconds),
+			RateLimitBackoff: secondsToDuration(cfg.PlanItRateLimitBackoffSeconds),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	appsContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosApplicationsContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+	stateContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosPollStateContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+	leasesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosLeasesContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+	zonesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosWatchZonesContainer, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	stateStore := polling.NewPollStateStore(stateContainer)
+	leaseStore := polling.NewLeaseStore(leaseItemsAdapter{leasesContainer}, time.Now)
+	appStore := applications.NewCosmosStore(appsContainer)
+	zoneStore := watchzones.NewCosmosStore(zonesContainer)
+
+	cycleSelector := polling.NewMinuteCycleSelector(time.Now)
+	authorityProvider := polling.NewCycleAlternatingProvider(
+		polling.NewWatchZoneAuthorityProvider(zoneStore),
+		polling.NewAllAuthorityProvider(authorities.NewLookup()),
+		cycleSelector,
+	)
+
+	maxPages := cfg.PollingMaxPagesPerAuthorityPerCycle
+	handler := polling.NewPollPlanItHandler(
+		planItClient,
+		appStore,
+		stateStore,
+		authorityProvider,
+		cycleSelector,
+		polling.HandlerOptions{
+			MaxPagesPerAuthorityPerCycle: &maxPages,
+			HandlerBudget:                secondsToDuration(float64(cfg.PollingHandlerBudgetSeconds)),
+		},
+		time.Now,
+		logger,
+	)
+
+	scheduler := polling.NewNextRunScheduler(polling.DefaultSchedulerOptions(), polling.NewRandomJitter())
+
+	// Lease TTL must exceed the handler's worst-case runtime so the lease cannot
+	// expire mid-handler (which would let a peer start a duplicate cycle). Size it
+	// at the handler budget plus a 30s margin, matching .NET's 4.5m-vs-4m gap.
+	leaseTTL := secondsToDuration(float64(cfg.PollingHandlerBudgetSeconds)) + 30*time.Second
+
+	orchestrator := polling.NewOrchestrator(
+		handler,
+		sbClient,
+		sbClient,
+		leaseStore,
+		scheduler,
+		polling.OrchestratorOptions{
+			LeaseTTL:               leaseTTL,
+			LeaseAcquireRetryDelay: 1 * time.Second,
+		},
+		time.Now,
+		logger,
+	)
+
+	// The hard cycle budget is replicaTimeout − grace (mirrors the .NET worker);
+	// it bounds the whole RunOnce so the process exits cleanly before Container
+	// Apps SIGTERMs the replica.
+	cycleBudget := time.Duration(maxInt(1, cfg.PollReplicaTimeoutSeconds-cfg.PollShutdownGraceSeconds)) * time.Second
+
+	return &pollOrchestratorAdapter{orchestrator: orchestrator, cycleBudget: cycleBudget}, nil
+}
+
+// pollOrchestratorAdapter flattens polling.OrchestratorRunResult into the
+// worker.PollRunResult the dispatcher tags and exit-codes on, and applies the
+// hard cycle-budget timeout around the orchestrator's single run. It satisfies
+// worker.PollOrchestrator.
+type pollOrchestratorAdapter struct {
+	orchestrator *polling.Orchestrator
+	cycleBudget  time.Duration
+}
+
+func (a *pollOrchestratorAdapter) RunOnce(ctx context.Context) (worker.PollRunResult, error) {
+	cycleCtx, cancel := context.WithTimeout(ctx, a.cycleBudget)
+	defer cancel()
+
+	res, err := a.orchestrator.RunOnce(cycleCtx)
+	if err != nil {
+		return worker.PollRunResult{MessageReceived: res.MessageReceived}, err
+	}
+
+	out := worker.PollRunResult{
+		MessageReceived:  res.MessageReceived,
+		PublishedNext:    res.PublishedNext,
+		LeaseUnavailable: res.LeaseUnavailable,
+	}
+	if res.PollResult != nil {
+		out.ApplicationCount = res.PollResult.ApplicationCount
+		out.AuthoritiesPolled = res.PollResult.AuthoritiesPolled
+		out.AuthorityErrors = res.PollResult.AuthorityErrors
+		out.Termination = res.PollResult.TerminationReason.TelemetryValue()
+	}
+	return out, nil
+}
+
+// leaseItemsAdapter bridges *platform.CosmosContainer's etag-CAS methods to the
+// polling lease store's consumer interface, translating the platform CAS
+// sentinel errors into the polling sentinels the store branches on.
+type leaseItemsAdapter struct {
+	c *platform.CosmosContainer
+}
+
+func (a leaseItemsAdapter) ReadLeaseWithETag(ctx context.Context, id string) ([]byte, string, bool, error) {
+	return a.c.ReadItemWithETag(ctx, id, id)
+}
+
+func (a leaseItemsAdapter) CreateLease(ctx context.Context, id string, item []byte) (string, error) {
+	etag, err := a.c.CreateItemReturningETag(ctx, id, item)
+	if errors.Is(err, platform.ErrCASConflict) {
+		return "", polling.ErrLeaseConflict
+	}
+	return etag, err
+}
+
+func (a leaseItemsAdapter) ReplaceLeaseWithETag(ctx context.Context, id string, item []byte, etag string) (string, error) {
+	newETag, err := a.c.ReplaceItemWithETag(ctx, id, id, item, etag)
+	if errors.Is(err, platform.ErrCASPreconditionFailed) {
+		return "", polling.ErrLeasePreconditionFailed
+	}
+	return newETag, err
+}
+
+func (a leaseItemsAdapter) DeleteLeaseWithETag(ctx context.Context, id, etag string) error {
+	err := a.c.DeleteItemWithETag(ctx, id, id, etag)
+	switch {
+	case errors.Is(err, platform.ErrCASNotFound):
+		return polling.ErrLeaseNotFound
+	case errors.Is(err, platform.ErrCASPreconditionFailed):
+		return polling.ErrLeasePreconditionFailed
+	default:
+		return err
+	}
+}
+
+// secondsToDuration converts a fractional-seconds config value to a Duration.
+func secondsToDuration(s float64) time.Duration {
+	return time.Duration(s * float64(time.Second))
+}
+
+// maxInt returns the larger of a and b.
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 // buildDigester constructs the digest handler when Cosmos is configured, wiring

--- a/api-go/internal/applications/application.go
+++ b/api-go/internal/applications/application.go
@@ -49,3 +49,54 @@ type PlanningApplication struct {
 func (a PlanningApplication) CanonicalUID() string {
 	return strconv.Itoa(a.AreaID) + "/" + a.Name
 }
+
+// HasSameBusinessFieldsAs reports whether every business-material field matches
+// other, ignoring LastDifferent. The poll cycle uses it to skip a redundant
+// upsert when PlanIt re-emits an application with only a bumped LastDifferent
+// timestamp — the load-bearing reindex-flood guard. Mirrors .NET
+// PlanningApplication.HasSameBusinessFieldsAs.
+func (a PlanningApplication) HasSameBusinessFieldsAs(other PlanningApplication) bool {
+	return a.Name == other.Name &&
+		a.UID == other.UID &&
+		a.AreaName == other.AreaName &&
+		a.AreaID == other.AreaID &&
+		a.Address == other.Address &&
+		eqStrPtr(a.Postcode, other.Postcode) &&
+		a.Description == other.Description &&
+		eqStrPtr(a.AppType, other.AppType) &&
+		eqStrPtr(a.AppState, other.AppState) &&
+		eqStrPtr(a.AppSize, other.AppSize) &&
+		eqTimePtr(a.StartDate, other.StartDate) &&
+		eqTimePtr(a.DecidedDate, other.DecidedDate) &&
+		eqTimePtr(a.ConsultedDate, other.ConsultedDate) &&
+		eqFloatPtr(a.Longitude, other.Longitude) &&
+		eqFloatPtr(a.Latitude, other.Latitude) &&
+		eqStrPtr(a.URL, other.URL) &&
+		eqStrPtr(a.Link, other.Link)
+}
+
+// eqStrPtr reports whether two optional strings are equal (both nil, or both
+// set to the same value).
+func eqStrPtr(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+// eqFloatPtr reports whether two optional floats are equal, mirroring .NET
+// Nullable.Equals.
+func eqFloatPtr(a, b *float64) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+// eqTimePtr reports whether two optional date values are equal.
+func eqTimePtr(a, b *time.Time) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Equal(*b)
+}

--- a/api-go/internal/applications/application_test.go
+++ b/api-go/internal/applications/application_test.go
@@ -57,3 +57,39 @@ func TestPlanningApplication_CanonicalUID_PreservesNameWithSlashes(t *testing.T)
 		t.Errorf("CanonicalUID: got %q", got)
 	}
 }
+
+func TestPlanningApplication_HasSameBusinessFieldsAs(t *testing.T) {
+	t.Parallel()
+	base := testApplication(t)
+
+	// Same business fields, only LastDifferent bumped -> still equal (the
+	// reindex-flood skip case the poll handler depends on).
+	bumped := base
+	bumped.LastDifferent = base.LastDifferent.Add(48 * time.Hour)
+	if !base.HasSameBusinessFieldsAs(bumped) {
+		t.Error("a bumped LastDifferent alone must compare equal")
+	}
+
+	// A changed business field (AppState) -> not equal.
+	other := "Rejected"
+	changed := base
+	changed.AppState = &other
+	if base.HasSameBusinessFieldsAs(changed) {
+		t.Error("a changed AppState must compare not-equal")
+	}
+
+	// A changed coordinate -> not equal.
+	newLon := *base.Longitude + 1
+	movedLon := base
+	movedLon.Longitude = &newLon
+	if base.HasSameBusinessFieldsAs(movedLon) {
+		t.Error("a changed longitude must compare not-equal")
+	}
+
+	// nil vs set pointer -> not equal.
+	nilState := base
+	nilState.AppState = nil
+	if base.HasSameBusinessFieldsAs(nilState) {
+		t.Error("nil vs set AppState must compare not-equal")
+	}
+}

--- a/api-go/internal/authorities/lookup.go
+++ b/api-go/internal/authorities/lookup.go
@@ -17,6 +17,12 @@ func (l *Lookup) ByID(id int) (Authority, bool) {
 	return l.store.byID(id)
 }
 
+// All returns every authority in the static list, sorted by name. The polling
+// all-authority provider filters this set down to the pollable area types.
+func (l *Lookup) All() []Authority {
+	return l.store.all()
+}
+
 // CompareOrdinalIgnoreCase exposes the package's ordinal, case-insensitive name
 // comparator so callers building authority lists order them identically to the
 // /v1/authorities list and to .NET's StringComparer.OrdinalIgnoreCase.

--- a/api-go/internal/planit/client.go
+++ b/api-go/internal/planit/client.go
@@ -205,7 +205,7 @@ func (c *Client) FetchApplicationsPage(ctx context.Context, authorityID int, dif
 // nil) has an un-read body the caller must classify and close.
 func (c *Client) sendWithThrottle(ctx context.Context, target string) (*http.Response, error) {
 	maxAttempts := 1 + c.retry.MaxRetries
-	for attempt := 0; attempt < maxAttempts; attempt++ {
+	for attempt := range maxAttempts {
 		if c.throttle.DelayBetweenRequests > 0 {
 			if err := c.sleep(ctx, c.throttle.DelayBetweenRequests); err != nil {
 				return nil, err

--- a/api-go/internal/planit/client.go
+++ b/api-go/internal/planit/client.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
-	"github.com/AmyDe/town-crier/api-go/internal/polling"
 )
 
 // defaultPageSize is PlanIt's page size; a full page (>= this many records) is
@@ -264,7 +263,7 @@ func classify(resp *http.Response) error {
 	}
 	if resp.StatusCode == http.StatusTooManyRequests {
 		var retryAfter *time.Duration
-		if d, ok := polling.ParseRetryAfter(resp.Header.Get("Retry-After"), time.Now()); ok {
+		if d, ok := ParseRetryAfter(resp.Header.Get("Retry-After"), time.Now()); ok {
 			retryAfter = &d
 		}
 		return &RateLimitError{RetryAfter: retryAfter}

--- a/api-go/internal/planit/client.go
+++ b/api-go/internal/planit/client.go
@@ -1,0 +1,318 @@
+// Package planit is the Go port of TownCrier.Infrastructure.PlanIt.PlanItClient:
+// a rate-limited HTTP client for the PlanIt applications API. It throttles
+// requests, retries idempotent GETs on transient 5xx/408 with exponential
+// backoff, and surfaces HTTP 429 as a typed RateLimitError carrying the parsed
+// Retry-After hint (429 is deliberately NOT retried — the poll scheduler uses
+// Retry-After to choose the next cycle, and internal retries would burn the
+// handler's wall-clock budget). Returned applications reuse the
+// applications.PlanningApplication domain snapshot so the poll handler upserts
+// them through the existing Applications store unchanged.
+package planit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/polling"
+)
+
+// defaultPageSize is PlanIt's page size; a full page (>= this many records) is
+// the page-fill heuristic for "more pages may follow", matching .NET.
+const defaultPageSize = 100
+
+// maxResponseBytes bounds a PlanIt JSON body so a hostile or broken upstream
+// cannot exhaust memory. A 100-record page is well under this.
+const maxResponseBytes = 10 << 20 // 10 MiB
+
+// Sentinel errors for construction-time validation.
+var (
+	// ErrMissingBaseURL is returned when the PlanIt base URL is empty.
+	ErrMissingBaseURL = errors.New("planit base URL is required")
+	// ErrInsecureBaseURL is returned for a non-HTTPS base URL other than localhost.
+	ErrInsecureBaseURL = errors.New("planit base URL must be https (except localhost)")
+)
+
+// RateLimitError is returned when PlanIt responds 429. RetryAfter carries the
+// parsed Retry-After hint, or nil when the header was absent or malformed. The
+// poll handler treats this as an expected, handled outcome (not an unhandled
+// exception) and the scheduler consumes RetryAfter to pick the next cycle.
+type RateLimitError struct {
+	RetryAfter *time.Duration
+}
+
+func (e *RateLimitError) Error() string {
+	if e.RetryAfter != nil {
+		return fmt.Sprintf("planit rate limited (retry-after %s)", *e.RetryAfter)
+	}
+	return "planit rate limited (no retry-after)"
+}
+
+// httpError is a non-429, non-2xx response from PlanIt that the client gave up
+// on (either permanent 4xx or a 5xx that exhausted retries).
+type httpError struct {
+	StatusCode int
+}
+
+func (e *httpError) Error() string {
+	return fmt.Sprintf("planit http error: status %d", e.StatusCode)
+}
+
+// ThrottleOptions paces outbound requests. Mirrors .NET PlanItThrottleOptions.
+type ThrottleOptions struct {
+	DelayBetweenRequests time.Duration
+}
+
+// RetryOptions tune the exponential-backoff retry on transient failures. Mirrors
+// .NET PlanItRetryOptions.
+type RetryOptions struct {
+	MaxRetries       int
+	InitialBackoff   time.Duration
+	RateLimitBackoff time.Duration
+}
+
+// DefaultThrottleOptions returns the .NET default (2s between requests).
+func DefaultThrottleOptions() ThrottleOptions {
+	return ThrottleOptions{DelayBetweenRequests: 2 * time.Second}
+}
+
+// DefaultRetryOptions returns the .NET defaults (3 retries, 1s initial, 5s
+// rate-limit backoff base).
+func DefaultRetryOptions() RetryOptions {
+	return RetryOptions{
+		MaxRetries:       3,
+		InitialBackoff:   1 * time.Second,
+		RateLimitBackoff: 5 * time.Second,
+	}
+}
+
+// Options configures a Client. HTTPClient and Sleep default to a hardened
+// shared client and a context-aware time.Sleep when nil.
+type Options struct {
+	BaseURL    string
+	Throttle   ThrottleOptions
+	Retry      RetryOptions
+	HTTPClient *http.Client
+	// Sleep is injected so tests can pace deterministically without real waits.
+	// It must honour ctx cancellation. Defaults to a context-aware sleep.
+	Sleep func(ctx context.Context, d time.Duration) error
+}
+
+// FetchPageResult is one page of a PlanIt fetch: the parsed applications, the
+// reported total (nil when PlanIt omitted it), and whether more pages may follow
+// (the page-fill heuristic). Mirrors .NET FetchPageResult.
+type FetchPageResult struct {
+	Page         int
+	Applications []applications.PlanningApplication
+	Total        *int
+	HasMorePages bool
+}
+
+// Client is the rate-limited PlanIt HTTP client.
+type Client struct {
+	httpClient *http.Client
+	baseURL    string
+	throttle   ThrottleOptions
+	retry      RetryOptions
+	sleep      func(ctx context.Context, d time.Duration) error
+}
+
+// NewClient validates the base URL and wires the client. A non-HTTPS base URL is
+// rejected unless it targets localhost (for tests). HTTPClient and Sleep fall
+// back to hardened defaults when nil.
+func NewClient(opts Options) (*Client, error) {
+	if opts.BaseURL == "" {
+		return nil, ErrMissingBaseURL
+	}
+	u, err := url.Parse(opts.BaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse planit base URL: %w", err)
+	}
+	if u.Scheme != "https" && !isLocalhost(u.Hostname()) {
+		return nil, ErrInsecureBaseURL
+	}
+
+	hc := opts.HTTPClient
+	if hc == nil {
+		hc = &http.Client{Timeout: 30 * time.Second}
+	}
+	sleep := opts.Sleep
+	if sleep == nil {
+		sleep = contextSleep
+	}
+
+	return &Client{
+		httpClient: hc,
+		baseURL:    strings.TrimRight(opts.BaseURL, "/"),
+		throttle:   opts.Throttle,
+		retry:      opts.Retry,
+		sleep:      sleep,
+	}, nil
+}
+
+// FetchApplicationsPage fetches one page of applications for authorityID, scoped
+// to records changed on or after differentStart (nil for an unbounded fetch).
+// It throttles, retries transient failures, and surfaces 429 as *RateLimitError.
+func (c *Client) FetchApplicationsPage(ctx context.Context, authorityID int, differentStart *time.Time, page int) (FetchPageResult, error) {
+	target := c.baseURL + buildPath(authorityID, differentStart, page)
+
+	resp, err := c.sendWithThrottle(ctx, target)
+	if err != nil {
+		return FetchPageResult{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if err := classify(resp); err != nil {
+		return FetchPageResult{}, err
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return FetchPageResult{}, fmt.Errorf("read planit page %d body: %w", page, err)
+	}
+
+	var parsed planItResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return FetchPageResult{}, fmt.Errorf("decode planit page %d: %w", page, err)
+	}
+
+	apps := make([]applications.PlanningApplication, 0, len(parsed.Records))
+	for _, rec := range parsed.Records {
+		app, err := rec.toDomain()
+		if err != nil {
+			return FetchPageResult{}, fmt.Errorf("map planit record %q: %w", rec.UID, err)
+		}
+		apps = append(apps, app)
+	}
+
+	return FetchPageResult{
+		Page:         page,
+		Applications: apps,
+		Total:        parsed.Total,
+		HasMorePages: len(apps) >= defaultPageSize,
+	}, nil
+}
+
+// sendWiththrottle applies the inter-request delay, sends the GET, and retries
+// transient (5xx/408) failures with exponential backoff. 429 and permanent 4xx
+// are returned to the caller without retry. The returned response (when err is
+// nil) has an un-read body the caller must classify and close.
+func (c *Client) sendWithThrottle(ctx context.Context, target string) (*http.Response, error) {
+	maxAttempts := 1 + c.retry.MaxRetries
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if c.throttle.DelayBetweenRequests > 0 {
+			if err := c.sleep(ctx, c.throttle.DelayBetweenRequests); err != nil {
+				return nil, err
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, http.NoBody)
+		if err != nil {
+			return nil, fmt.Errorf("build planit request: %w", err)
+		}
+		req.Header.Set("Accept", "application/json")
+
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			// Transport-level failure: retry like a transient server error.
+			if attempt >= maxAttempts-1 {
+				return nil, fmt.Errorf("planit request failed: %w", err)
+			}
+			if berr := c.sleep(ctx, c.backoff(c.retry.InitialBackoff, attempt)); berr != nil {
+				return nil, berr
+			}
+			continue
+		}
+
+		if resp.StatusCode == http.StatusOK {
+			return resp, nil
+		}
+
+		// 429 and permanent (non-retryable) statuses go straight back to the
+		// caller; classify() turns them into the right typed error.
+		if resp.StatusCode == http.StatusTooManyRequests || !isRetryable(resp.StatusCode) {
+			return resp, nil
+		}
+
+		isLast := attempt >= maxAttempts-1
+		if isLast {
+			return resp, nil
+		}
+
+		_ = resp.Body.Close()
+		if err := c.sleep(ctx, c.backoff(c.retry.InitialBackoff, attempt)); err != nil {
+			return nil, err
+		}
+	}
+	// Unreachable: the loop always returns inside the body.
+	return nil, errors.New("planit retry loop exited unexpectedly")
+}
+
+// classify maps a non-2xx response to a typed error, leaving 2xx as nil. A 429
+// becomes *RateLimitError with the parsed Retry-After; any other non-2xx becomes
+// *httpError.
+func classify(resp *http.Response) error {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		var retryAfter *time.Duration
+		if d, ok := polling.ParseRetryAfter(resp.Header.Get("Retry-After"), time.Now()); ok {
+			retryAfter = &d
+		}
+		return &RateLimitError{RetryAfter: retryAfter}
+	}
+	return &httpError{StatusCode: resp.StatusCode}
+}
+
+// backoff computes exponential backoff: base * 2^attempt.
+func (c *Client) backoff(base time.Duration, attempt int) time.Duration {
+	return base << attempt //nolint:gosec // attempt is a small bounded loop index
+}
+
+// isRetryable reports whether a status code is a transient server error worth
+// retrying. 429 is intentionally excluded (handled via Retry-After).
+func isRetryable(status int) bool {
+	switch status {
+	case http.StatusGatewayTimeout, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusRequestTimeout:
+		return true
+	default:
+		return false
+	}
+}
+
+// buildPath builds the PlanIt applications query path, mirroring .NET BuildUrl:
+// pg_sz, sort=last_different, page, auth, and optional different_start (date).
+func buildPath(authorityID int, differentStart *time.Time, page int) string {
+	path := fmt.Sprintf("/api/applics/json?pg_sz=%d&sort=last_different&page=%d&auth=%d", defaultPageSize, page, authorityID)
+	if differentStart != nil {
+		path += "&different_start=" + differentStart.UTC().Format("2006-01-02")
+	}
+	return path
+}
+
+// isLocalhost reports whether host is a loopback name, so http is permitted in
+// tests without weakening production HTTPS enforcement.
+func isLocalhost(host string) bool {
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
+}
+
+// contextSleep is the default Sleep: it waits d but returns early with the
+// context error if ctx is cancelled first.
+func contextSleep(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/api-go/internal/planit/client_test.go
+++ b/api-go/internal/planit/client_test.go
@@ -1,0 +1,286 @@
+package planit
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock records the durations it is asked to sleep so tests can assert
+// throttle/backoff behaviour without real wall-clock waits. It honours ctx
+// cancellation like the real delay would.
+type fakeClock struct {
+	mu     sync.Mutex
+	sleeps []time.Duration
+}
+
+func (c *fakeClock) sleep(ctx context.Context, d time.Duration) error {
+	c.mu.Lock()
+	c.sleeps = append(c.sleeps, d)
+	c.mu.Unlock()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *fakeClock) total() time.Duration {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var sum time.Duration
+	for _, d := range c.sleeps {
+		sum += d
+	}
+	return sum
+}
+
+func newTestClient(t *testing.T, baseURL string, clock *fakeClock) *Client {
+	t.Helper()
+	c, err := NewClient(Options{
+		BaseURL:    baseURL,
+		Throttle:   ThrottleOptions{DelayBetweenRequests: 0},
+		Retry:      RetryOptions{MaxRetries: 3, InitialBackoff: time.Second, RateLimitBackoff: 5 * time.Second},
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		Sleep:      clock.sleep,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	return c
+}
+
+func TestFetchApplicationsPage_ParsesRecordsAndTotal(t *testing.T) {
+	t.Parallel()
+	body := `{"total":42,"pg_sz":100,"records":[
+		{"name":"24/0001","uid":"24/0001/FUL","area_name":"Test","area_id":99,"address":"1 High St","postcode":"AB1 2CD","description":"A shed","app_type":"Full","app_state":"Undecided","app_size":"Small","start_date":"2026-06-01","location_x":-0.1,"location_y":51.5,"url":"http://x","link":"http://y","last_different":"2026-06-10T09:00:00Z"}
+	]}`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify the query the .NET client builds: pg_sz, sort, page, auth, different_start.
+		q := r.URL.Query()
+		if q.Get("auth") != "99" || q.Get("page") != "1" || q.Get("different_start") != "2026-06-09" {
+			t.Errorf("unexpected query: %s", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	clock := &fakeClock{}
+	c := newTestClient(t, srv.URL, clock)
+
+	ds := time.Date(2026, 6, 9, 0, 0, 0, 0, time.UTC)
+	res, err := c.FetchApplicationsPage(context.Background(), 99, &ds, 1)
+	if err != nil {
+		t.Fatalf("FetchApplicationsPage: %v", err)
+	}
+	if res.Total == nil || *res.Total != 42 {
+		t.Errorf("total: got %v, want 42", res.Total)
+	}
+	if len(res.Applications) != 1 {
+		t.Fatalf("applications: got %d, want 1", len(res.Applications))
+	}
+	app := res.Applications[0]
+	if app.Name != "24/0001" || app.AreaID != 99 || app.UID != "24/0001/FUL" {
+		t.Errorf("mapped app fields wrong: %+v", app)
+	}
+	if app.Latitude == nil || *app.Latitude != 51.5 || app.Longitude == nil || *app.Longitude != -0.1 {
+		t.Errorf("coords: lat=%v lng=%v", app.Latitude, app.Longitude)
+	}
+	if !app.LastDifferent.Equal(time.Date(2026, 6, 10, 9, 0, 0, 0, time.UTC)) {
+		t.Errorf("lastDifferent: got %v", app.LastDifferent)
+	}
+	// A short (< page size) record set means no more pages.
+	if res.HasMorePages {
+		t.Error("HasMorePages should be false for a partial page")
+	}
+}
+
+func TestFetchApplicationsPage_FullPageMeansMorePages(t *testing.T) {
+	t.Parallel()
+	var sb strings.Builder
+	sb.WriteString(`{"total":250,"records":[`)
+	for i := range 100 {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(`{"name":"r","uid":"u","area_name":"a","area_id":1,"address":"x","description":"d","app_type":"t","app_state":"s","last_different":"2026-06-10T09:00:00Z"}`)
+	}
+	sb.WriteString(`]}`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(sb.String()))
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL, &fakeClock{})
+	res, err := c.FetchApplicationsPage(context.Background(), 1, nil, 1)
+	if err != nil {
+		t.Fatalf("FetchApplicationsPage: %v", err)
+	}
+	if !res.HasMorePages {
+		t.Error("HasMorePages should be true for a full page")
+	}
+}
+
+func TestFetchApplicationsPage_429SurfacesRateLimitWithRetryAfterAndIsNotRetried(t *testing.T) {
+	t.Parallel()
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.Header().Set("Retry-After", "120")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL, &fakeClock{})
+	_, err := c.FetchApplicationsPage(context.Background(), 1, nil, 1)
+
+	var rl *RateLimitError
+	if !errors.As(err, &rl) {
+		t.Fatalf("expected RateLimitError, got %v", err)
+	}
+	if rl.RetryAfter == nil || *rl.RetryAfter != 120*time.Second {
+		t.Errorf("RetryAfter: got %v, want 120s", rl.RetryAfter)
+	}
+	// 429 must NOT be retried (the scheduler uses Retry-After to pick next run).
+	if calls != 1 {
+		t.Errorf("429 should not be retried: got %d calls, want 1", calls)
+	}
+}
+
+func TestFetchApplicationsPage_429WithoutHeaderHasNilRetryAfter(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL, &fakeClock{})
+	_, err := c.FetchApplicationsPage(context.Background(), 1, nil, 1)
+
+	var rl *RateLimitError
+	if !errors.As(err, &rl) {
+		t.Fatalf("expected RateLimitError, got %v", err)
+	}
+	if rl.RetryAfter != nil {
+		t.Errorf("RetryAfter should be nil when header absent, got %v", rl.RetryAfter)
+	}
+}
+
+func TestFetchApplicationsPage_RetriesOn503ThenSucceeds(t *testing.T) {
+	t.Parallel()
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"total":0,"records":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	clock := &fakeClock{}
+	c := newTestClient(t, srv.URL, clock)
+	res, err := c.FetchApplicationsPage(context.Background(), 1, nil, 1)
+	if err != nil {
+		t.Fatalf("FetchApplicationsPage: %v", err)
+	}
+	if len(res.Applications) != 0 {
+		t.Errorf("applications: got %d, want 0", len(res.Applications))
+	}
+	if calls != 3 {
+		t.Errorf("calls: got %d, want 3 (two retries)", calls)
+	}
+	// Exponential backoff from InitialBackoff (1s): first retry 1s, second 2s.
+	if got := clock.total(); got != 3*time.Second {
+		t.Errorf("backoff total: got %v, want 3s (1s + 2s)", got)
+	}
+}
+
+func TestFetchApplicationsPage_GivesUpAfterMaxRetries(t *testing.T) {
+	t.Parallel()
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL, &fakeClock{})
+	_, err := c.FetchApplicationsPage(context.Background(), 1, nil, 1)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	// 1 initial + 3 retries = 4 attempts.
+	if calls != 4 {
+		t.Errorf("calls: got %d, want 4 (1 + MaxRetries)", calls)
+	}
+}
+
+func TestFetchApplicationsPage_4xxIsPermanentAndNotRetried(t *testing.T) {
+	t.Parallel()
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+
+	c := newTestClient(t, srv.URL, &fakeClock{})
+	_, err := c.FetchApplicationsPage(context.Background(), 1, nil, 1)
+	if err == nil {
+		t.Fatal("expected error for 400")
+	}
+	var rl *RateLimitError
+	if errors.As(err, &rl) {
+		t.Error("400 must not be a RateLimitError")
+	}
+	if calls != 1 {
+		t.Errorf("4xx should not be retried: got %d calls, want 1", calls)
+	}
+}
+
+func TestFetchApplicationsPage_AppliesThrottleDelayBeforeRequest(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"records":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	clock := &fakeClock{}
+	c, err := NewClient(Options{
+		BaseURL:    srv.URL,
+		Throttle:   ThrottleOptions{DelayBetweenRequests: 2 * time.Second},
+		Retry:      RetryOptions{MaxRetries: 0},
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		Sleep:      clock.sleep,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	if _, err := c.FetchApplicationsPage(context.Background(), 1, nil, 1); err != nil {
+		t.Fatalf("FetchApplicationsPage: %v", err)
+	}
+	if got := clock.total(); got != 2*time.Second {
+		t.Errorf("throttle delay: got %v, want 2s", got)
+	}
+}
+
+func TestNewClient_RejectsNonHTTPSAndEmptyBaseURL(t *testing.T) {
+	t.Parallel()
+	if _, err := NewClient(Options{BaseURL: ""}); err == nil {
+		t.Error("empty base URL should error")
+	}
+	if _, err := NewClient(Options{BaseURL: "http://planit.example.com"}); err == nil {
+		t.Error("non-HTTPS, non-localhost base URL should error")
+	}
+	// Localhost http is permitted for tests.
+	if _, err := NewClient(Options{BaseURL: "http://127.0.0.1:8080"}); err != nil {
+		t.Errorf("localhost http should be permitted: %v", err)
+	}
+}

--- a/api-go/internal/planit/response.go
+++ b/api-go/internal/planit/response.go
@@ -1,0 +1,110 @@
+package planit
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+// planItResponse is the PlanIt list-endpoint envelope. JSON tags mirror the
+// snake_case keys PlanIt returns and the .NET PlanItResponse.
+type planItResponse struct {
+	Records []planItRecord `json:"records"`
+	PageSiz *int           `json:"pg_sz"`
+	From    *int           `json:"from"`
+	Total   *int           `json:"total"`
+}
+
+// planItRecord is one PlanIt application record. JSON tags mirror .NET
+// PlanItApplicationRecord. Nullable upstream fields are pointers so an absent
+// value maps to a nil domain pointer.
+type planItRecord struct {
+	Name          string   `json:"name"`
+	UID           string   `json:"uid"`
+	AreaName      string   `json:"area_name"`
+	AreaID        int      `json:"area_id"`
+	Address       string   `json:"address"`
+	Postcode      *string  `json:"postcode"`
+	Description   string   `json:"description"`
+	AppType       string   `json:"app_type"`
+	AppState      string   `json:"app_state"`
+	AppSize       *string  `json:"app_size"`
+	StartDate     *string  `json:"start_date"`
+	DecidedDate   *string  `json:"decided_date"`
+	ConsultedDate *string  `json:"consulted_date"`
+	LocationX     *float64 `json:"location_x"`
+	LocationY     *float64 `json:"location_y"`
+	URL           *string  `json:"url"`
+	Link          *string  `json:"link"`
+	LastDifferent string   `json:"last_different"`
+}
+
+// toDomain maps a PlanIt record to the applications.PlanningApplication snapshot,
+// mirroring .NET PlanItClient.MapToDomain: location_x is longitude, location_y
+// latitude; app_type / app_state are carried as non-empty pointers; date-only
+// fields parse to *time.Time; last_different parses as an RFC3339 instant.
+func (r planItRecord) toDomain() (applications.PlanningApplication, error) {
+	startDate, err := parseDateOnly(r.StartDate)
+	if err != nil {
+		return applications.PlanningApplication{}, fmt.Errorf("start_date: %w", err)
+	}
+	decidedDate, err := parseDateOnly(r.DecidedDate)
+	if err != nil {
+		return applications.PlanningApplication{}, fmt.Errorf("decided_date: %w", err)
+	}
+	consultedDate, err := parseDateOnly(r.ConsultedDate)
+	if err != nil {
+		return applications.PlanningApplication{}, fmt.Errorf("consulted_date: %w", err)
+	}
+	lastDifferent, err := time.Parse(time.RFC3339, r.LastDifferent)
+	if err != nil {
+		return applications.PlanningApplication{}, fmt.Errorf("last_different %q: %w", r.LastDifferent, err)
+	}
+
+	appType := nonEmptyPtr(r.AppType)
+	appState := nonEmptyPtr(r.AppState)
+
+	return applications.PlanningApplication{
+		Name:          r.Name,
+		UID:           r.UID,
+		AreaName:      r.AreaName,
+		AreaID:        r.AreaID,
+		Address:       r.Address,
+		Postcode:      r.Postcode,
+		Description:   r.Description,
+		AppType:       appType,
+		AppState:      appState,
+		AppSize:       r.AppSize,
+		StartDate:     startDate,
+		DecidedDate:   decidedDate,
+		ConsultedDate: consultedDate,
+		Longitude:     r.LocationX,
+		Latitude:      r.LocationY,
+		URL:           r.URL,
+		Link:          r.Link,
+		LastDifferent: lastDifferent.UTC(),
+	}, nil
+}
+
+// parseDateOnly parses an optional "yyyy-MM-dd" PlanIt date into a *time.Time,
+// returning nil for an absent or empty value (matching .NET ParseDate).
+func parseDateOnly(value *string) (*time.Time, error) {
+	if value == nil || *value == "" {
+		return nil, nil //nolint:nilnil // absent optional date is a valid nil, not an error
+	}
+	t, err := time.Parse("2006-01-02", *value)
+	if err != nil {
+		return nil, fmt.Errorf("parse date %q: %w", *value, err)
+	}
+	return &t, nil
+}
+
+// nonEmptyPtr returns a pointer to s, or nil when s is empty, so an empty
+// upstream string maps to a JSON-null domain field.
+func nonEmptyPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/api-go/internal/planit/retryafter.go
+++ b/api-go/internal/planit/retryafter.go
@@ -1,16 +1,4 @@
-// Package polling is the Go port of the .NET TownCrier.Application.Polling and
-// TownCrier.Infrastructure.Polling slices: the Service-Bus-triggered adaptive
-// PlanIt poll (WORKER_MODE=poll-sb). It owns the trigger orchestrator, the
-// PlanIt ingestion handler, the next-run scheduler, the Cosmos etag-CAS lease
-// and poll-state stores, and the cycle-alternating authority providers.
-//
-// The crash-safety model is receive-and-delete + publish-after-consume per
-// ADR 0024 (2026-04-22 amendment): the orchestrator acquires a Cosmos lease,
-// destructively receives one trigger, runs the handler, publishes the next
-// scheduled trigger, then releases the lease. There is no Service Bus
-// Complete/Abandon — the safety-net bootstrap (internal/worker) is the sole
-// recovery path when anything fails between receive and publish.
-package polling
+package planit
 
 import (
 	"strconv"

--- a/api-go/internal/planit/retryafter_test.go
+++ b/api-go/internal/planit/retryafter_test.go
@@ -1,4 +1,4 @@
-package polling
+package planit
 
 import (
 	"testing"

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -118,7 +118,37 @@ type Config struct {
 	// wires a NoOp email sender. The infra bead tc-uzm1 wires the
 	// acs-connection-string secret to this env var.
 	ACSConnectionString SecretString
+
+	// PlanIt* configure the rate-limited PlanIt HTTP client the poll-sb worker
+	// mode uses to fetch planning applications (epic tc-wad3, bead tc-yng2).
+	// PlanItBaseURL defaults to the live PlanIt service (matching .NET's
+	// PlanIt:BaseUrl fallback). The throttle/retry knobs mirror .NET's
+	// PlanItThrottleOptions / PlanItRetryOptions defaults. The infra bead tc-uzm1
+	// wires these env vars additively onto the prod poll job.
+	PlanItBaseURL                 string
+	PlanItThrottleDelaySeconds    float64
+	PlanItMaxRetries              int
+	PlanItInitialBackoffSeconds   float64
+	PlanItRateLimitBackoffSeconds float64
+
+	// Polling* configure the poll-sb ingestion cycle (bead tc-yng2).
+	// PollingMaxPagesPerAuthorityPerCycle caps PlanIt pagination per authority
+	// (default 3, matching .NET Polling:MaxPagesPerAuthorityPerCycle).
+	// PollingHandlerBudgetSeconds is the soft per-cycle wall-clock budget (default
+	// 240); under ADR 0024's receive-and-delete model it is a safety cap, not a
+	// Service-Bus-lock bound — the Cosmos lease TTL (> handler budget) prevents
+	// concurrent runs. PollReplicaTimeoutSeconds and PollShutdownGraceSeconds size
+	// the hard cycle budget (replicaTimeout − grace), matching the .NET worker's
+	// POLL_REPLICA_TIMEOUT_SECONDS / POLL_SHUTDOWN_GRACE_SECONDS.
+	PollingMaxPagesPerAuthorityPerCycle int
+	PollingHandlerBudgetSeconds         int
+	PollReplicaTimeoutSeconds           int
+	PollShutdownGraceSeconds            int
 }
+
+// defaultPlanItBaseURL is the live PlanIt applications API, matching .NET's
+// PlanIt:BaseUrl fallback.
+const defaultPlanItBaseURL = "https://www.planit.org.uk/"
 
 // defaultAPNsKeyID and defaultAPNsTeamID are the identifiers Apple issued for
 // the Town Crier app's .p8 auth key (epic tc-wad3 notes). Defaulting them keeps
@@ -179,6 +209,17 @@ func LoadConfig() (Config, error) {
 		APNsUseSandbox: getenvBool("APNS_USE_SANDBOX"),
 
 		ACSConnectionString: NewSecret(os.Getenv("ACS_CONNECTION_STRING")),
+
+		PlanItBaseURL:                 getenv("PLANIT_BASE_URL", defaultPlanItBaseURL),
+		PlanItThrottleDelaySeconds:    getenvFloat("PLANIT_THROTTLE_DELAY_SECONDS", 2),
+		PlanItMaxRetries:              getenvInt("PLANIT_RETRY_MAX_RETRIES", 3),
+		PlanItInitialBackoffSeconds:   getenvFloat("PLANIT_RETRY_INITIAL_BACKOFF_SECONDS", 1),
+		PlanItRateLimitBackoffSeconds: getenvFloat("PLANIT_RETRY_RATE_LIMIT_BACKOFF_SECONDS", 5),
+
+		PollingMaxPagesPerAuthorityPerCycle: getenvInt("POLLING_MAX_PAGES_PER_AUTHORITY_PER_CYCLE", 3),
+		PollingHandlerBudgetSeconds:         getenvInt("POLLING_HANDLER_BUDGET_SECONDS", 240),
+		PollReplicaTimeoutSeconds:           getenvInt("POLL_REPLICA_TIMEOUT_SECONDS", 600),
+		PollShutdownGraceSeconds:            getenvInt("POLL_SHUTDOWN_GRACE_SECONDS", 30),
 	}
 
 	if raw := os.Getenv("LOG_LEVEL"); raw != "" {
@@ -222,6 +263,26 @@ func getenvBool(key string) bool {
 	v, err := strconv.ParseBool(strings.TrimSpace(os.Getenv(key)))
 	if err != nil {
 		return false
+	}
+	return v
+}
+
+// getenvInt returns the named env var parsed as an int, or fallback when unset,
+// empty, or unparseable — so a misconfigured value fails safe to the default.
+func getenvInt(key string, fallback int) int {
+	v, err := strconv.Atoi(strings.TrimSpace(os.Getenv(key)))
+	if err != nil {
+		return fallback
+	}
+	return v
+}
+
+// getenvFloat returns the named env var parsed as a float64, or fallback when
+// unset, empty, or unparseable.
+func getenvFloat(key string, fallback float64) float64 {
+	v, err := strconv.ParseFloat(strings.TrimSpace(os.Getenv(key)), 64)
+	if err != nil {
+		return fallback
 	}
 	return v
 }

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -366,3 +366,64 @@ func TestLoadConfig_CorsAllowedOrigins(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadConfig_PollingDefaults(t *testing.T) {
+	// Clear any inherited overrides so the defaults are exercised.
+	for _, k := range []string{
+		"PLANIT_BASE_URL", "PLANIT_THROTTLE_DELAY_SECONDS",
+		"PLANIT_RETRY_MAX_RETRIES", "PLANIT_RETRY_INITIAL_BACKOFF_SECONDS",
+		"PLANIT_RETRY_RATE_LIMIT_BACKOFF_SECONDS",
+		"POLLING_MAX_PAGES_PER_AUTHORITY_PER_CYCLE", "POLLING_HANDLER_BUDGET_SECONDS",
+		"POLL_REPLICA_TIMEOUT_SECONDS", "POLL_SHUTDOWN_GRACE_SECONDS",
+	} {
+		t.Setenv(k, "")
+	}
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.PlanItBaseURL != "https://www.planit.org.uk/" {
+		t.Errorf("PlanItBaseURL default: got %q", cfg.PlanItBaseURL)
+	}
+	if cfg.PlanItThrottleDelaySeconds != 2 {
+		t.Errorf("throttle default: got %v, want 2", cfg.PlanItThrottleDelaySeconds)
+	}
+	if cfg.PlanItMaxRetries != 3 || cfg.PlanItInitialBackoffSeconds != 1 || cfg.PlanItRateLimitBackoffSeconds != 5 {
+		t.Errorf("retry defaults: %d/%v/%v", cfg.PlanItMaxRetries, cfg.PlanItInitialBackoffSeconds, cfg.PlanItRateLimitBackoffSeconds)
+	}
+	if cfg.PollingMaxPagesPerAuthorityPerCycle != 3 {
+		t.Errorf("max pages default: got %d, want 3", cfg.PollingMaxPagesPerAuthorityPerCycle)
+	}
+	if cfg.PollingHandlerBudgetSeconds != 240 {
+		t.Errorf("handler budget default: got %d, want 240", cfg.PollingHandlerBudgetSeconds)
+	}
+	if cfg.PollReplicaTimeoutSeconds != 600 || cfg.PollShutdownGraceSeconds != 30 {
+		t.Errorf("cycle budget defaults: %d/%d", cfg.PollReplicaTimeoutSeconds, cfg.PollShutdownGraceSeconds)
+	}
+}
+
+func TestLoadConfig_PollingOverrides(t *testing.T) {
+	t.Setenv("PLANIT_BASE_URL", "https://stub.planit.test/")
+	t.Setenv("POLLING_MAX_PAGES_PER_AUTHORITY_PER_CYCLE", "5")
+	t.Setenv("POLLING_HANDLER_BUDGET_SECONDS", "120")
+	t.Setenv("POLL_REPLICA_TIMEOUT_SECONDS", "300")
+	t.Setenv("POLL_SHUTDOWN_GRACE_SECONDS", "15")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.PlanItBaseURL != "https://stub.planit.test/" {
+		t.Errorf("PlanItBaseURL override: got %q", cfg.PlanItBaseURL)
+	}
+	if cfg.PollingMaxPagesPerAuthorityPerCycle != 5 {
+		t.Errorf("max pages override: got %d, want 5", cfg.PollingMaxPagesPerAuthorityPerCycle)
+	}
+	if cfg.PollingHandlerBudgetSeconds != 120 {
+		t.Errorf("handler budget override: got %d, want 120", cfg.PollingHandlerBudgetSeconds)
+	}
+	if cfg.PollReplicaTimeoutSeconds != 300 || cfg.PollShutdownGraceSeconds != 15 {
+		t.Errorf("cycle budget override: %d/%d", cfg.PollReplicaTimeoutSeconds, cfg.PollShutdownGraceSeconds)
+	}
+}

--- a/api-go/internal/platform/cosmos.go
+++ b/api-go/internal/platform/cosmos.go
@@ -182,6 +182,13 @@ const (
 	// Server Notification; partition key /id == the notificationUUID, document id
 	// == the notificationUUID. Backs webhook idempotency.
 	CosmosAppleNotificationsContainer = "AppleNotifications"
+	// CosmosPollStateContainer holds one document per authority's poll state;
+	// partition key /id == "poll-state-{authorityId}", document id == same. The
+	// poll-sb cycle reads/writes per-authority high-water marks and cursors here.
+	CosmosPollStateContainer = "PollState"
+	// CosmosLeasesContainer holds the single "polling" lease document gating
+	// concurrent poll cycles; partition key /id == the lease id. CAS via etag.
+	CosmosLeasesContainer = "Leases"
 )
 
 // ReadItem point-reads the document with the given id from its partition.

--- a/api-go/internal/platform/cosmos_cas.go
+++ b/api-go/internal/platform/cosmos_cas.go
@@ -1,0 +1,127 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+)
+
+// CAS sentinel errors returned by the etag-conditional operations. They classify
+// the Cosmos precondition responses the polling lease store needs to distinguish
+// expected races from genuine failures. The lease store adapter maps these onto
+// its own outcome types.
+var (
+	// ErrCASConflict is a 409 from a create — the document already exists.
+	ErrCASConflict = errors.New("cosmos create conflict")
+	// ErrCASPreconditionFailed is a 412 from a conditional replace/delete — the
+	// etag did not match.
+	ErrCASPreconditionFailed = errors.New("cosmos precondition failed")
+	// ErrCASNotFound is a 404 from a conditional delete — the document was absent.
+	ErrCASNotFound = errors.New("cosmos item not found")
+)
+
+// ReadItemWithETag point-reads a document and returns its body and current etag.
+// found is false (no error) when the document is absent (404), matching the
+// lease store's "no lease yet" path. The etag is the opaque CAS token for a
+// subsequent conditional replace/delete.
+func (c *CosmosContainer) ReadItemWithETag(ctx context.Context, partitionKey, id string) (body []byte, etag string, found bool, err error) {
+	err = traceCosmosOp(ctx, c, "ReadItem", func(ctx context.Context) error {
+		resp, rerr := c.container.ReadItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), id, nil)
+		if rerr != nil {
+			return rerr
+		}
+		body = resp.Value
+		etag = string(resp.ETag)
+		found = true
+		return nil
+	})
+	if err != nil {
+		if isCASNotFound(err) {
+			return nil, "", false, nil
+		}
+		return nil, "", false, fmt.Errorf("read item %q: %w", id, err)
+	}
+	return body, etag, found, nil
+}
+
+// CreateItemReturningETag creates a document only if it does not already exist,
+// returning the server-assigned etag. A 409 (the document already exists)
+// surfaces as ErrCASConflict so the caller can treat it as "lost the create
+// race" rather than a failure.
+func (c *CosmosContainer) CreateItemReturningETag(ctx context.Context, partitionKey string, item []byte) (string, error) {
+	var etag string
+	err := traceCosmosOp(ctx, c, "CreateItem", func(ctx context.Context) error {
+		resp, cerr := c.container.CreateItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), item, nil)
+		if cerr != nil {
+			return cerr
+		}
+		etag = string(resp.ETag)
+		return nil
+	})
+	if err != nil {
+		if isCASStatus(err, http.StatusConflict) {
+			return "", ErrCASConflict
+		}
+		return "", fmt.Errorf("create item: %w", err)
+	}
+	return etag, nil
+}
+
+// ReplaceItemWithETag replaces a document only if its current etag matches,
+// returning the new etag. A 412 (etag mismatch) surfaces as
+// ErrCASPreconditionFailed so the caller can treat it as "lost the replace race".
+func (c *CosmosContainer) ReplaceItemWithETag(ctx context.Context, partitionKey, id string, item []byte, etag string) (string, error) {
+	var newETag string
+	err := traceCosmosOp(ctx, c, "ReplaceItem", func(ctx context.Context) error {
+		e := azcore.ETag(etag)
+		resp, rerr := c.container.ReplaceItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), id, item, &azcosmos.ItemOptions{IfMatchEtag: &e})
+		if rerr != nil {
+			return rerr
+		}
+		newETag = string(resp.ETag)
+		return nil
+	})
+	if err != nil {
+		if isCASStatus(err, http.StatusPreconditionFailed) {
+			return "", ErrCASPreconditionFailed
+		}
+		return "", fmt.Errorf("replace item %q: %w", id, err)
+	}
+	return newETag, nil
+}
+
+// DeleteItemWithETag deletes a document only if its current etag matches. A 404
+// (absent) surfaces as ErrCASNotFound and a 412 (etag mismatch) as
+// ErrCASPreconditionFailed, so the lease store can distinguish "already gone"
+// from "lost the race".
+func (c *CosmosContainer) DeleteItemWithETag(ctx context.Context, partitionKey, id, etag string) error {
+	err := traceCosmosOp(ctx, c, "DeleteItem", func(ctx context.Context) error {
+		e := azcore.ETag(etag)
+		_, derr := c.container.DeleteItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), id, &azcosmos.ItemOptions{IfMatchEtag: &e})
+		return derr
+	})
+	switch {
+	case err == nil:
+		return nil
+	case isCASNotFound(err):
+		return ErrCASNotFound
+	case isCASStatus(err, http.StatusPreconditionFailed):
+		return ErrCASPreconditionFailed
+	default:
+		return fmt.Errorf("delete item %q: %w", id, err)
+	}
+}
+
+// isCASNotFound reports whether err is a Cosmos 404.
+func isCASNotFound(err error) bool { return isCASStatus(err, http.StatusNotFound) }
+
+// isCASStatus reports whether err is a Cosmos ResponseError with the given HTTP
+// status code.
+func isCASStatus(err error, status int) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == status
+}

--- a/api-go/internal/platform/cosmos_cas_test.go
+++ b/api-go/internal/platform/cosmos_cas_test.go
@@ -1,0 +1,46 @@
+package platform
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+func TestIsCASStatus_MatchesWrappedResponseError(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		err    error
+		status int
+		want   bool
+	}{
+		{"conflict matches", &azcore.ResponseError{StatusCode: http.StatusConflict}, http.StatusConflict, true},
+		{"wrapped conflict matches", fmt.Errorf("create: %w", &azcore.ResponseError{StatusCode: http.StatusConflict}), http.StatusConflict, true},
+		{"precondition matches", &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed}, http.StatusPreconditionFailed, true},
+		{"not-found matches", &azcore.ResponseError{StatusCode: http.StatusNotFound}, http.StatusNotFound, true},
+		{"wrong status does not match", &azcore.ResponseError{StatusCode: http.StatusConflict}, http.StatusNotFound, false},
+		{"plain error does not match", errors.New("network blip"), http.StatusConflict, false},
+		{"nil does not match", nil, http.StatusConflict, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isCASStatus(tc.err, tc.status); got != tc.want {
+				t.Errorf("isCASStatus: got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsCASNotFound_OnlyMatches404(t *testing.T) {
+	t.Parallel()
+	if !isCASNotFound(&azcore.ResponseError{StatusCode: http.StatusNotFound}) {
+		t.Error("404 should be CAS not-found")
+	}
+	if isCASNotFound(&azcore.ResponseError{StatusCode: http.StatusConflict}) {
+		t.Error("409 must not be CAS not-found")
+	}
+}

--- a/api-go/internal/polling/authorities.go
+++ b/api-go/internal/polling/authorities.go
@@ -1,0 +1,151 @@
+package polling
+
+import (
+	"context"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/authorities"
+)
+
+// CycleType selects which authority set a poll cycle walks. Mirrors .NET
+// CycleType.
+type CycleType int
+
+const (
+	// CycleWatched polls only authorities a user is watching (the responsive
+	// cycle).
+	CycleWatched CycleType = iota
+	// CycleSeed polls every pollable authority (the backfill cycle).
+	CycleSeed
+)
+
+// TelemetryValue returns the span-tag string for this cycle type, matching .NET
+// CycleType.ToTelemetryValue().
+func (c CycleType) TelemetryValue() string {
+	if c == CycleSeed {
+		return "Seed"
+	}
+	return "Watched"
+}
+
+// MinuteCycleSelector alternates between Watched and Seed cycles on a 15-minute
+// boundary within each half hour, matching .NET MinuteBasedCycleSelector:
+// minute%30 < 15 → Watched, else Seed.
+type MinuteCycleSelector struct {
+	now func() time.Time
+}
+
+// NewMinuteCycleSelector wires the selector with an injected clock.
+func NewMinuteCycleSelector(now func() time.Time) *MinuteCycleSelector {
+	return &MinuteCycleSelector{now: now}
+}
+
+// Current returns the cycle type for the current minute.
+func (s *MinuteCycleSelector) Current() CycleType {
+	if s.now().Minute()%30 < 15 {
+		return CycleWatched
+	}
+	return CycleSeed
+}
+
+// zoneAuthoritySource yields the distinct authority ids across all watch zones.
+// *watchzones.CosmosStore satisfies it via DistinctAuthorityIDs.
+type zoneAuthoritySource interface {
+	DistinctAuthorityIDs(ctx context.Context) ([]int, error)
+}
+
+// WatchZoneAuthorityProvider returns the authorities that at least one user is
+// watching. Mirrors .NET WatchZoneActiveAuthorityProvider.
+type WatchZoneAuthorityProvider struct {
+	source zoneAuthoritySource
+}
+
+// NewWatchZoneAuthorityProvider wires the provider over a zone authority source.
+func NewWatchZoneAuthorityProvider(source zoneAuthoritySource) *WatchZoneAuthorityProvider {
+	return &WatchZoneAuthorityProvider{source: source}
+}
+
+// ActiveAuthorityIDs returns the distinct watch-zone authority ids.
+func (p *WatchZoneAuthorityProvider) ActiveAuthorityIDs(ctx context.Context) ([]int, error) {
+	return p.source.DistinctAuthorityIDs(ctx)
+}
+
+// nonPollableAreaTypes are the regional aggregates and non-LPA containers PlanIt
+// exposes but which never return planning applications. Polling them wastes RUs
+// and skews diagnostics. Mirrors .NET AllAuthorityIdProvider.NonPollableAreaTypes
+// — note "Crown Dependencies" (plural, the aggregate) is excluded while the
+// singular "Crown Dependency" records remain pollable.
+var nonPollableAreaTypes = map[string]struct{}{
+	"English Region":      {},
+	"UK Nation":           {},
+	"Cross Border Area":   {},
+	"Metropolitan County": {},
+	"Crown Dependencies":  {},
+}
+
+// allAuthorityLister yields the full static authority list. authorities.Lookup
+// satisfies it via All().
+type allAuthorityLister interface {
+	All() []authorities.Authority
+}
+
+// AllAuthorityProvider returns every pollable authority id from the static
+// authority list, filtering out the non-pollable area-type aggregates. Mirrors
+// .NET AllAuthorityIdProvider.
+type AllAuthorityProvider struct {
+	lister allAuthorityLister
+}
+
+// NewAllAuthorityProvider wires the provider over a static authority list.
+func NewAllAuthorityProvider(lister allAuthorityLister) *AllAuthorityProvider {
+	return &AllAuthorityProvider{lister: lister}
+}
+
+// ActiveAuthorityIDs returns the ids of all pollable authorities, preserving the
+// lister's order.
+func (p *AllAuthorityProvider) ActiveAuthorityIDs(_ context.Context) ([]int, error) {
+	all := p.lister.All()
+	ids := make([]int, 0, len(all))
+	for _, a := range all {
+		if _, nonPollable := nonPollableAreaTypes[a.AreaType]; nonPollable {
+			continue
+		}
+		ids = append(ids, a.ID)
+	}
+	return ids, nil
+}
+
+// authorityProvider is the common contract the cycle-alternating provider
+// dispatches to.
+type authorityProvider interface {
+	ActiveAuthorityIDs(ctx context.Context) ([]int, error)
+}
+
+// cycleSelector reports the current cycle type.
+type cycleSelector interface {
+	Current() CycleType
+}
+
+// CycleAlternatingProvider chooses the authority set per cycle: the Seed cycle
+// walks all pollable authorities; every other cycle walks the watch-zone set.
+// Mirrors .NET CycleAlternatingAuthorityProvider.
+type CycleAlternatingProvider struct {
+	watched  authorityProvider
+	all      authorityProvider
+	selector cycleSelector
+}
+
+// NewCycleAlternatingProvider wires the provider with the watched/all providers
+// and the cycle selector.
+func NewCycleAlternatingProvider(watched, all authorityProvider, selector cycleSelector) *CycleAlternatingProvider {
+	return &CycleAlternatingProvider{watched: watched, all: all, selector: selector}
+}
+
+// ActiveAuthorityIDs dispatches to the all-authority provider on a Seed cycle and
+// the watch-zone provider otherwise.
+func (p *CycleAlternatingProvider) ActiveAuthorityIDs(ctx context.Context) ([]int, error) {
+	if p.selector.Current() == CycleSeed {
+		return p.all.ActiveAuthorityIDs(ctx)
+	}
+	return p.watched.ActiveAuthorityIDs(ctx)
+}

--- a/api-go/internal/polling/authorities_test.go
+++ b/api-go/internal/polling/authorities_test.go
@@ -1,0 +1,119 @@
+package polling
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/authorities"
+)
+
+func TestMinuteCycleSelector_AlternatesEvery15Minutes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		minute int
+		want   CycleType
+	}{
+		{0, CycleWatched},
+		{14, CycleWatched},
+		{15, CycleSeed},
+		{29, CycleSeed},
+		{30, CycleWatched},
+		{44, CycleWatched},
+		{45, CycleSeed},
+		{59, CycleSeed},
+	}
+	for _, tc := range tests {
+		now := func() time.Time {
+			return time.Date(2026, 6, 14, 10, tc.minute, 0, 0, time.UTC)
+		}
+		sel := NewMinuteCycleSelector(now)
+		if got := sel.Current(); got != tc.want {
+			t.Errorf("minute %d: got %v, want %v", tc.minute, got, tc.want)
+		}
+	}
+}
+
+// fakeZoneAuthorities is a hand-written double for the watch-zone authority
+// source the watch-zone provider depends on.
+type fakeZoneAuthorities struct {
+	ids []int
+	err error
+}
+
+func (f fakeZoneAuthorities) DistinctAuthorityIDs(context.Context) ([]int, error) {
+	return f.ids, f.err
+}
+
+func TestWatchZoneAuthorityProvider_ReturnsDistinctZoneAuthorities(t *testing.T) {
+	t.Parallel()
+	p := NewWatchZoneAuthorityProvider(fakeZoneAuthorities{ids: []int{5, 9, 5}})
+	ids, err := p.ActiveAuthorityIDs(context.Background())
+	if err != nil {
+		t.Fatalf("ActiveAuthorityIDs: %v", err)
+	}
+	if !slices.Equal(ids, []int{5, 9, 5}) {
+		t.Errorf("ids: got %v, want passthrough [5 9 5]", ids)
+	}
+}
+
+func TestAllAuthorityProvider_FiltersNonPollableAreaTypes(t *testing.T) {
+	t.Parallel()
+	all := []authorities.Authority{
+		{ID: 1, Name: "Real LPA", AreaType: "District"},
+		{ID: 2, Name: "England", AreaType: "UK Nation"},
+		{ID: 3, Name: "South East", AreaType: "English Region"},
+		{ID: 4, Name: "Greater London", AreaType: "Metropolitan County"},
+		{ID: 5, Name: "Cross Border", AreaType: "Cross Border Area"},
+		{ID: 6, Name: "Channel Islands", AreaType: "Crown Dependencies"},
+		{ID: 7, Name: "Jersey", AreaType: "Crown Dependency"}, // singular IS pollable
+	}
+	p := NewAllAuthorityProvider(staticAuthorities(all))
+	ids, err := p.ActiveAuthorityIDs(context.Background())
+	if err != nil {
+		t.Fatalf("ActiveAuthorityIDs: %v", err)
+	}
+	// Only the real LPA (1) and the singular Crown Dependency (7) are pollable.
+	want := []int{1, 7}
+	if !slices.Equal(ids, want) {
+		t.Errorf("pollable ids: got %v, want %v", ids, want)
+	}
+}
+
+func TestCycleAlternatingProvider_UsesAllAuthoritiesOnSeedAndWatchedOnWatched(t *testing.T) {
+	t.Parallel()
+	all := NewAllAuthorityProvider(staticAuthorities([]authorities.Authority{
+		{ID: 100, Name: "All A", AreaType: "District"},
+		{ID: 200, Name: "All B", AreaType: "District"},
+	}))
+	watched := NewWatchZoneAuthorityProvider(fakeZoneAuthorities{ids: []int{200}})
+
+	// Seed cycle (minute 15-29) -> all authorities.
+	seedClock := func() time.Time { return time.Date(2026, 6, 14, 10, 20, 0, 0, time.UTC) }
+	seedProvider := NewCycleAlternatingProvider(watched, all, NewMinuteCycleSelector(seedClock))
+	seedIDs, err := seedProvider.ActiveAuthorityIDs(context.Background())
+	if err != nil {
+		t.Fatalf("seed ActiveAuthorityIDs: %v", err)
+	}
+	if !slices.Equal(seedIDs, []int{100, 200}) {
+		t.Errorf("seed cycle: got %v, want all [100 200]", seedIDs)
+	}
+
+	// Watched cycle (minute 0-14) -> watch-zone authorities.
+	watchedClock := func() time.Time { return time.Date(2026, 6, 14, 10, 5, 0, 0, time.UTC) }
+	watchedProvider := NewCycleAlternatingProvider(watched, all, NewMinuteCycleSelector(watchedClock))
+	watchedIDs, err := watchedProvider.ActiveAuthorityIDs(context.Background())
+	if err != nil {
+		t.Fatalf("watched ActiveAuthorityIDs: %v", err)
+	}
+	if !slices.Equal(watchedIDs, []int{200}) {
+		t.Errorf("watched cycle: got %v, want watch-zone [200]", watchedIDs)
+	}
+}
+
+// staticAuthorities adapts a slice into the allAuthorityLister the
+// all-authority provider depends on.
+type staticAuthorities []authorities.Authority
+
+func (s staticAuthorities) All() []authorities.Authority { return s }

--- a/api-go/internal/polling/handler.go
+++ b/api-go/internal/polling/handler.go
@@ -180,7 +180,7 @@ func (h *PollPlanItHandler) Handle(ctx context.Context) (PollPlanItResult, error
 		switch {
 		case outcome.err != nil:
 			authorityErrors++
-			h.logger.ErrorContext(ctx, "error polling authority, skipping to next", "polling.authority_code", authorityID, "error", outcome.err)
+			h.logger.ErrorContext(ctx, "error polling authority, skipping to next", "authorityCode", authorityID, "error", outcome.err)
 		case outcome.completed || outcome.appCount > 0:
 			authoritiesPoll++
 		}

--- a/api-go/internal/polling/handler.go
+++ b/api-go/internal/polling/handler.go
@@ -1,0 +1,383 @@
+// Package polling is the Go port of the .NET TownCrier.Application.Polling and
+// TownCrier.Infrastructure.Polling slices: the Service-Bus-triggered adaptive
+// PlanIt poll (WORKER_MODE=poll-sb). It owns the trigger orchestrator, the
+// PlanIt ingestion handler, the next-run scheduler, the Cosmos etag-CAS lease
+// and poll-state stores, and the cycle-alternating authority providers.
+//
+// The crash-safety model is receive-and-delete + publish-after-consume per
+// ADR 0024 (2026-04-22 amendment): the orchestrator acquires a Cosmos lease,
+// destructively receives one trigger, runs the handler, publishes the next
+// scheduled trigger, then releases the lease. There is no Service Bus
+// Complete/Abandon — the safety-net bootstrap (internal/worker) is the sole
+// recovery path when anything fails between receive and publish.
+package polling
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/planit"
+)
+
+// resumeOverlap is the one-page overlap applied when resuming from a saved
+// cursor (start at max(1, NextPage-1)) to tolerate PlanIt page-shift between
+// cycles, matching .NET's resumable-cursor logic.
+const resumeOverlap = 1
+
+// planItFetcher is the consumer-side slice of the PlanIt client the handler
+// needs: fetch one page for an authority. *planit.Client satisfies it.
+type planItFetcher interface {
+	FetchApplicationsPage(ctx context.Context, authorityID int, differentStart *time.Time, page int) (planit.FetchPageResult, error)
+}
+
+// applicationStore is the consumer-side slice of the Applications store: a
+// partition-scoped existence read and an upsert. *applications.CosmosStore
+// satisfies it.
+type applicationStore interface {
+	GetByUID(ctx context.Context, uid, authorityCode string) (applications.PlanningApplication, bool, error)
+	Upsert(ctx context.Context, a applications.PlanningApplication) error
+}
+
+// pollStateAccess is the consumer-side slice of the poll-state store the handler
+// needs. *PollStateStore satisfies it.
+type pollStateAccess interface {
+	Get(ctx context.Context, authorityID int) (PollState, bool, error)
+	Save(ctx context.Context, authorityID int, lastPollTime, highWaterMark time.Time, cursor *PollCursor) error
+	GetLeastRecentlyPolled(ctx context.Context, candidateAuthorityIDs []int) (LeastRecentlyPolledResult, error)
+}
+
+// activeAuthorityProvider yields the authorities to walk this cycle.
+type activeAuthorityProvider interface {
+	ActiveAuthorityIDs(ctx context.Context) ([]int, error)
+}
+
+// HandlerOptions are the ingestion tunables. MaxPagesPerAuthorityPerCycle caps
+// pagination per authority (nil = unbounded). HandlerBudget is the soft
+// wall-clock deadline; zero disables it. Mirrors the relevant .NET PollingOptions
+// fields.
+type HandlerOptions struct {
+	MaxPagesPerAuthorityPerCycle *int
+	HandlerBudget                time.Duration
+}
+
+// PollPlanItResult is the outcome of one ingestion cycle. Mirrors .NET
+// PollPlanItResult and drives the worker's exit code (exit 1 only when
+// ApplicationCount==0 AND AuthorityErrors>0) and the next-run cadence.
+type PollPlanItResult struct {
+	ApplicationCount  int
+	AuthoritiesPolled int
+	RateLimited       bool
+	TerminationReason TerminationReason
+	AuthorityErrors   int
+	// RetryAfter is the Retry-After hint bubbled up from a 429, consumed by the
+	// scheduler to time the next trigger. nil when not rate-limited or absent.
+	RetryAfter *time.Duration
+}
+
+// PollPlanItHandler runs one adaptive PlanIt poll cycle: select the active
+// authorities for the current cycle type, walk them least-recently-polled first,
+// page each up to the cap, upsert changed applications, and advance per-authority
+// poll state (high-water mark + resumable cursor). It is the Go port of .NET
+// PollPlanItCommandHandler, scoped to ingestion (zone fan-out and decision-event
+// dispatch are the notification pipeline's concern and not wired into the worker
+// poll path — see bd follow-up).
+type PollPlanItHandler struct {
+	planIt      planItFetcher
+	apps        applicationStore
+	state       pollStateAccess
+	authorities activeAuthorityProvider
+	cycle       cycleSelector
+	opts        HandlerOptions
+	now         func() time.Time
+	logger      *slog.Logger
+}
+
+// NewPollPlanItHandler wires the handler. now is injected so tests pin the clock.
+func NewPollPlanItHandler(
+	planIt planItFetcher,
+	apps applicationStore,
+	state pollStateAccess,
+	authorities activeAuthorityProvider,
+	cycle cycleSelector,
+	opts HandlerOptions,
+	now func() time.Time,
+	logger *slog.Logger,
+) *PollPlanItHandler {
+	return &PollPlanItHandler{
+		planIt:      planIt,
+		apps:        apps,
+		state:       state,
+		authorities: authorities,
+		cycle:       cycle,
+		opts:        opts,
+		now:         now,
+		logger:      logger,
+	}
+}
+
+// CurrentCycle reports the cycle type the next Handle call will run, so the
+// dispatch layer can tag the telemetry span with cycle.type before invoking it.
+func (h *PollPlanItHandler) CurrentCycle() CycleType {
+	return h.cycle.Current()
+}
+
+// Handle runs one ingestion cycle and returns its result. It never returns an
+// error for an empty active set or per-authority failures (those are counted and
+// the cycle continues); it returns an error only when the candidate selection
+// itself fails (e.g. the cross-partition LRU query errored).
+func (h *PollPlanItHandler) Handle(ctx context.Context) (PollPlanItResult, error) {
+	now := h.now().UTC()
+
+	var deadline time.Time
+	hasDeadline := h.opts.HandlerBudget > 0
+	if hasDeadline {
+		deadline = now.Add(h.opts.HandlerBudget)
+	}
+	budgetExhausted := func() bool {
+		return hasDeadline && !h.now().UTC().Before(deadline)
+	}
+
+	activeIDs, err := h.authorities.ActiveAuthorityIDs(ctx)
+	if err != nil {
+		return PollPlanItResult{}, err
+	}
+	lru, err := h.state.GetLeastRecentlyPolled(ctx, activeIDs)
+	if err != nil {
+		return PollPlanItResult{}, err
+	}
+
+	var (
+		count           int
+		authoritiesPoll int
+		authorityErrors int
+		rateLimited     bool
+		timeBounded     bool
+		retryAfter      *time.Duration
+	)
+
+	for _, authorityID := range lru.AuthorityIDs {
+		// Graceful timeout: stop before starting a new authority when the outer
+		// context is cancelled or the soft budget is spent, returning the partial
+		// result cleanly.
+		if ctx.Err() != nil || budgetExhausted() {
+			timeBounded = true
+			break
+		}
+
+		outcome := h.pollAuthority(ctx, authorityID, now, budgetExhausted)
+		count += outcome.appCount
+		if outcome.rateLimited {
+			rateLimited = true
+			retryAfter = outcome.retryAfter
+		}
+		if outcome.timeBounded {
+			timeBounded = true
+		}
+		switch {
+		case outcome.err != nil:
+			authorityErrors++
+			h.logger.ErrorContext(ctx, "error polling authority, skipping to next", "polling.authority_code", authorityID, "error", outcome.err)
+		case outcome.completed || outcome.appCount > 0:
+			authoritiesPoll++
+		}
+
+		// A 429 stops the whole cycle so the scheduler can back off via Retry-After.
+		if outcome.rateLimited {
+			break
+		}
+	}
+
+	reason := TerminationNatural
+	switch {
+	case rateLimited:
+		reason = TerminationRateLimited
+	case timeBounded:
+		reason = TerminationTimeBounded
+	}
+
+	return PollPlanItResult{
+		ApplicationCount:  count,
+		AuthoritiesPolled: authoritiesPoll,
+		RateLimited:       rateLimited,
+		TerminationReason: reason,
+		AuthorityErrors:   authorityErrors,
+		RetryAfter:        retryAfter,
+	}, nil
+}
+
+// authorityOutcome captures one authority's processing result.
+type authorityOutcome struct {
+	appCount    int
+	completed   bool
+	rateLimited bool
+	timeBounded bool
+	retryAfter  *time.Duration
+	err         error
+}
+
+// pollAuthority pages one authority from its resume point up to the cap, upserts
+// changed applications, and persists the advanced poll state (HWM + cursor). A
+// 429 is an expected outcome (not an error); a transport/5xx failure after
+// retries is an authority error that the caller counts and skips past.
+func (h *PollPlanItHandler) pollAuthority(ctx context.Context, authorityID int, now time.Time, budgetExhausted func() bool) authorityOutcome {
+	existing, _, err := h.state.Get(ctx, authorityID)
+	existingHWM := now.AddDate(0, 0, -1)
+	hadCursor := false
+	if err == nil {
+		if !existing.HighWaterMark.IsZero() {
+			existingHWM = existing.HighWaterMark
+		}
+		hadCursor = existing.Cursor != nil
+	}
+
+	// Resume from a saved cursor only when it still anchors the current HWM date,
+	// overlapping by one page to tolerate PlanIt page-shift. Otherwise start at 1.
+	startPage := 1
+	if existing.Cursor != nil && sameDate(existing.Cursor.DifferentStart, existingHWM) {
+		startPage = max(1, existing.Cursor.NextPage-resumeOverlap)
+	}
+
+	maxPages := h.opts.MaxPagesPerAuthorityPerCycle
+	var (
+		out             authorityOutcome
+		highWaterMark   time.Time
+		lastPageFetched int
+		firstPageTotal  *int
+		capHit          bool
+		pagesFetched    int
+		page            = startPage
+	)
+
+	ds := existingHWM
+	for {
+		res, fetchErr := h.planIt.FetchApplicationsPage(ctx, authorityID, &ds, page)
+		if fetchErr != nil {
+			var rl *planit.RateLimitError
+			if errors.As(fetchErr, &rl) {
+				out.rateLimited = true
+				out.retryAfter = rl.RetryAfter
+				break
+			}
+			out.err = fetchErr
+			break
+		}
+
+		if pagesFetched == 0 {
+			firstPageTotal = res.Total
+		}
+
+		for _, app := range res.Applications {
+			out.appCount++
+			if app.LastDifferent.After(highWaterMark) {
+				highWaterMark = app.LastDifferent
+			}
+			if err := h.upsertIfChanged(ctx, app); err != nil {
+				out.err = err
+				return h.finishAuthority(ctx, authorityID, now, out, highWaterMark, existingHWM, lastPageFetched, firstPageTotal, capHit, hadCursor)
+			}
+		}
+
+		pagesFetched++
+		lastPageFetched = page
+
+		if !res.HasMorePages {
+			break
+		}
+		if maxPages != nil && pagesFetched >= *maxPages {
+			capHit = true
+			break
+		}
+		if ctx.Err() != nil || budgetExhausted() {
+			capHit = true
+			out.timeBounded = true
+			break
+		}
+		page++
+	}
+
+	if out.err == nil && !out.rateLimited {
+		out.completed = true
+	}
+	return h.finishAuthority(ctx, authorityID, now, out, highWaterMark, existingHWM, lastPageFetched, firstPageTotal, capHit, hadCursor)
+}
+
+// upsertIfChanged point-reads the persisted application by uid within its
+// authority partition and upserts only when a business field changed (the
+// reindex-flood guard). A first-time insert (no existing record) always upserts.
+func (h *PollPlanItHandler) upsertIfChanged(ctx context.Context, app applications.PlanningApplication) error {
+	authorityCode := strconv.Itoa(app.AreaID)
+	existing, found, err := h.apps.GetByUID(ctx, app.UID, authorityCode)
+	if err != nil {
+		return err
+	}
+	if found && existing.HasSameBusinessFieldsAs(app) {
+		return nil
+	}
+	return h.apps.Upsert(ctx, app)
+}
+
+// finishAuthority persists the authority's advanced poll state. On a cap-hit or
+// mid-pagination 429 it freezes the HWM and saves a resumable cursor at the next
+// unfetched page; on a natural end it advances the HWM to the max LastDifferent
+// observed and clears any cursor. State is only written when the authority
+// produced work (completed or saw applications), matching .NET.
+func (h *PollPlanItHandler) finishAuthority(
+	ctx context.Context,
+	authorityID int,
+	now time.Time,
+	out authorityOutcome,
+	highWaterMark, existingHWM time.Time,
+	lastPageFetched int,
+	firstPageTotal *int,
+	capHit, hadCursor bool,
+) authorityOutcome {
+	if !out.completed && out.appCount == 0 {
+		return out
+	}
+
+	if capHit || (out.rateLimited && out.appCount > 0) {
+		// Freeze HWM, save a resumable cursor at the next unfetched page so the
+		// following cycle resumes there. LastPollTime still advances so the
+		// scheduler rotates off this authority.
+		nextPage := lastPageFetched + 1
+		cursor := &PollCursor{
+			DifferentStart: truncateToDate(existingHWM),
+			NextPage:       nextPage,
+			KnownTotal:     firstPageTotal,
+		}
+		if err := h.state.Save(ctx, authorityID, now, existingHWM, cursor); err != nil && out.err == nil {
+			out.err = err
+		}
+		return out
+	}
+
+	// Natural end: advance HWM to the max LastDifferent observed, falling back to
+	// the existing HWM when the authority was quiet. Clear any active cursor.
+	advancedHWM := existingHWM
+	if !highWaterMark.IsZero() {
+		advancedHWM = highWaterMark
+	}
+	if err := h.state.Save(ctx, authorityID, now, advancedHWM, nil); err != nil && out.err == nil {
+		out.err = err
+	}
+	_ = hadCursor // telemetry-only in .NET (cursor_cleared counter); omitted here
+	return out
+}
+
+// sameDate reports whether two instants fall on the same UTC calendar day.
+func sameDate(a, b time.Time) bool {
+	ay, am, ad := a.UTC().Date()
+	by, bm, bd := b.UTC().Date()
+	return ay == by && am == bm && ad == bd
+}
+
+// truncateToDate returns the UTC midnight of t's calendar day — the cursor's
+// different_start anchor.
+func truncateToDate(t time.Time) time.Time {
+	y, m, d := t.UTC().Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}

--- a/api-go/internal/polling/handler_test.go
+++ b/api-go/internal/polling/handler_test.go
@@ -1,0 +1,378 @@
+package polling
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/planit"
+)
+
+// --- hand-written fakes for the handler's dependencies ---
+
+// fakePlanIt serves pre-canned pages keyed by (authorityID, page) and can be
+// primed with a rate-limit or transient error per authority.
+type fakePlanIt struct {
+	pages   map[pageKey]planit.FetchPageResult
+	errs    map[int]error // authorityID -> error returned on every page fetch
+	fetched []pageKey
+	mu      sync.Mutex
+}
+
+type pageKey struct {
+	authority int
+	page      int
+}
+
+func newFakePlanIt() *fakePlanIt {
+	return &fakePlanIt{pages: map[pageKey]planit.FetchPageResult{}, errs: map[int]error{}}
+}
+
+func (f *fakePlanIt) FetchApplicationsPage(_ context.Context, authorityID int, _ *time.Time, page int) (planit.FetchPageResult, error) {
+	f.mu.Lock()
+	f.fetched = append(f.fetched, pageKey{authorityID, page})
+	f.mu.Unlock()
+	if err := f.errs[authorityID]; err != nil {
+		return planit.FetchPageResult{}, err
+	}
+	res, ok := f.pages[pageKey{authorityID, page}]
+	if !ok {
+		return planit.FetchPageResult{Page: page, Applications: nil, HasMorePages: false}, nil
+	}
+	return res, nil
+}
+
+func (f *fakePlanIt) fetchCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.fetched)
+}
+
+// fakeApps records upserts and answers existence point reads.
+type fakeApps struct {
+	existing  map[string]applications.PlanningApplication // uid -> existing record
+	upserts   []applications.PlanningApplication
+	upsertErr error
+}
+
+func newFakeApps() *fakeApps {
+	return &fakeApps{existing: map[string]applications.PlanningApplication{}}
+}
+
+func (f *fakeApps) GetByUID(_ context.Context, uid, _ string) (applications.PlanningApplication, bool, error) {
+	a, ok := f.existing[uid]
+	return a, ok, nil
+}
+
+func (f *fakeApps) Upsert(_ context.Context, a applications.PlanningApplication) error {
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	f.upserts = append(f.upserts, a)
+	return nil
+}
+
+// fakeStateStore records saves and answers gets / LRU ordering.
+type fakeStateStore struct {
+	states   map[int]PollState
+	saves    []savedState
+	lruOrder []int
+	lruErr   error
+}
+
+type savedState struct {
+	authorityID   int
+	lastPollTime  time.Time
+	highWaterMark time.Time
+	cursor        *PollCursor
+}
+
+func newFakeStateStore() *fakeStateStore {
+	return &fakeStateStore{states: map[int]PollState{}}
+}
+
+func (f *fakeStateStore) Get(_ context.Context, authorityID int) (PollState, bool, error) {
+	s, ok := f.states[authorityID]
+	return s, ok, nil
+}
+
+func (f *fakeStateStore) Save(_ context.Context, authorityID int, lastPollTime, highWaterMark time.Time, cursor *PollCursor) error {
+	f.saves = append(f.saves, savedState{authorityID, lastPollTime, highWaterMark, cursor})
+	f.states[authorityID] = PollState{LastPollTime: lastPollTime, HighWaterMark: highWaterMark, Cursor: cursor}
+	return nil
+}
+
+func (f *fakeStateStore) GetLeastRecentlyPolled(_ context.Context, candidates []int) (LeastRecentlyPolledResult, error) {
+	if f.lruErr != nil {
+		return LeastRecentlyPolledResult{}, f.lruErr
+	}
+	order := f.lruOrder
+	if order == nil {
+		order = candidates
+	}
+	return LeastRecentlyPolledResult{AuthorityIDs: order, NeverPolledCount: 0}, nil
+}
+
+// fakeAuthorities returns a fixed active set.
+type fakeAuthorities struct {
+	ids []int
+	err error
+}
+
+func (f fakeAuthorities) ActiveAuthorityIDs(context.Context) ([]int, error) { return f.ids, f.err }
+
+// fakeCycle reports a fixed cycle type.
+type fakeCycle struct{ cycle CycleType }
+
+func (f fakeCycle) Current() CycleType { return f.cycle }
+
+func testApp(name string, areaID int, lastDifferent time.Time) applications.PlanningApplication {
+	state := "Undecided"
+	return applications.PlanningApplication{
+		Name:          name,
+		UID:           name + "/FUL",
+		AreaName:      "Area",
+		AreaID:        areaID,
+		Address:       "1 St",
+		Description:   "d",
+		AppState:      &state,
+		LastDifferent: lastDifferent,
+	}
+}
+
+func newHandler(t *testing.T, pi *fakePlanIt, apps *fakeApps, state *fakeStateStore, auth fakeAuthorities, cycle CycleType, opts HandlerOptions) *PollPlanItHandler {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC) }
+	return NewPollPlanItHandler(pi, apps, state, auth, fakeCycle{cycle}, opts, clock, logger)
+}
+
+type discard struct{}
+
+func (discard) Write(p []byte) (int, error) { return len(p), nil }
+
+func defaultHandlerOpts() HandlerOptions {
+	max := 3
+	return HandlerOptions{MaxPagesPerAuthorityPerCycle: &max, HandlerBudget: 4 * time.Minute}
+}
+
+// --- tests ---
+
+func TestHandler_IngestsAndUpsertsNewApplications(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	pi.pages[pageKey{99, 1}] = planit.FetchPageResult{
+		Page:         1,
+		Applications: []applications.PlanningApplication{testApp("24/0001", 99, ld)},
+		HasMorePages: false,
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.ApplicationCount != 1 || res.AuthoritiesPolled != 1 {
+		t.Errorf("counts: apps=%d authorities=%d", res.ApplicationCount, res.AuthoritiesPolled)
+	}
+	if len(apps.upserts) != 1 {
+		t.Errorf("upserts: got %d, want 1", len(apps.upserts))
+	}
+	if res.TerminationReason != TerminationNatural {
+		t.Errorf("termination: got %v, want Natural", res.TerminationReason)
+	}
+	// Natural end advances HWM to the max LastDifferent observed and clears cursor.
+	if len(state.saves) != 1 || !state.saves[0].highWaterMark.Equal(ld) || state.saves[0].cursor != nil {
+		t.Errorf("state save: %+v", state.saves)
+	}
+}
+
+func TestHandler_SkipsUpsertWhenBusinessFieldsUnchanged(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	app := testApp("24/0001", 99, ld)
+	pi.pages[pageKey{99, 1}] = planit.FetchPageResult{Page: 1, Applications: []applications.PlanningApplication{app}}
+	apps := newFakeApps()
+	// An identical record already exists (only LastDifferent would differ).
+	existing := app
+	existing.LastDifferent = ld.Add(-time.Hour)
+	apps.existing[app.UID] = existing
+	state := newFakeStateStore()
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(apps.upserts) != 0 {
+		t.Errorf("unchanged business fields must skip upsert, got %d upserts", len(apps.upserts))
+	}
+	// The application was still seen, so it counts toward the cycle's app count.
+	if res.ApplicationCount != 1 {
+		t.Errorf("application count: got %d, want 1 (seen but not upserted)", res.ApplicationCount)
+	}
+}
+
+func TestHandler_CapsPagesAndSavesResumableCursor(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	// Every page is full (HasMorePages true) so only the MaxPages cap stops it.
+	full := make([]applications.PlanningApplication, 100)
+	for i := range full {
+		full[i] = testApp("app", 99, ld)
+	}
+	for p := 1; p <= 5; p++ {
+		pi.pages[pageKey{99, p}] = planit.FetchPageResult{Page: p, Applications: full, HasMorePages: true, Total: ptr(500)}
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	// MaxPages = 3, so exactly 3 pages fetched.
+	if pi.fetchCount() != 3 {
+		t.Errorf("pages fetched: got %d, want 3 (MaxPages cap)", pi.fetchCount())
+	}
+	if res.TerminationReason != TerminationNatural {
+		t.Errorf("cap-hit on a single authority is a natural cycle end: got %v", res.TerminationReason)
+	}
+	// Cap hit saves a resumable cursor at next unfetched page (4) and freezes HWM.
+	if len(state.saves) != 1 {
+		t.Fatalf("state saves: got %d, want 1", len(state.saves))
+	}
+	cur := state.saves[0].cursor
+	if cur == nil || cur.NextPage != 4 {
+		t.Errorf("cursor: %+v, want NextPage=4", cur)
+	}
+}
+
+func TestHandler_ResumesFromSavedCursor(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	hwm := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	for p := 1; p <= 5; p++ {
+		pi.pages[pageKey{99, p}] = planit.FetchPageResult{Page: p, Applications: []applications.PlanningApplication{testApp("a", 99, hwm)}, HasMorePages: false}
+	}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	// Existing state: HWM at 2026-06-13, cursor pointing at page 4 against that date.
+	state.states[99] = PollState{
+		LastPollTime:  hwm,
+		HighWaterMark: hwm,
+		Cursor:        &PollCursor{DifferentStart: hwm, NextPage: 4, KnownTotal: ptr(500)},
+	}
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+
+	if _, err := h.Handle(context.Background()); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	// Resume overlaps by one page: start at max(1, NextPage-1) = 3.
+	if len(pi.fetched) == 0 || pi.fetched[0].page != 3 {
+		t.Errorf("first fetched page: got %+v, want page 3 (resume with -1 overlap)", pi.fetched)
+	}
+}
+
+func TestHandler_RateLimitStopsCycleAndCarriesRetryAfter(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	ra := 90 * time.Second
+	pi.errs[99] = &planit.RateLimitError{RetryAfter: &ra}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	// Two authorities; the first 429s and the cycle must stop before the second.
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99, 200}}, CycleSeed, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.TerminationReason != TerminationRateLimited || !res.RateLimited {
+		t.Errorf("termination: got %v rateLimited=%v, want RateLimited", res.TerminationReason, res.RateLimited)
+	}
+	if res.RetryAfter == nil || *res.RetryAfter != ra {
+		t.Errorf("retry-after: got %v, want %v", res.RetryAfter, ra)
+	}
+	// The second authority (200) must NOT be fetched after the 429.
+	for _, k := range pi.fetched {
+		if k.authority == 200 {
+			t.Errorf("authority 200 should not be polled after a 429: %+v", pi.fetched)
+		}
+	}
+}
+
+func TestHandler_AuthorityErrorIsCountedAndCycleContinues(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	pi.errs[99] = errors.New("planit 500 exhausted")
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	pi.pages[pageKey{200, 1}] = planit.FetchPageResult{Page: 1, Applications: []applications.PlanningApplication{testApp("ok", 200, ld)}}
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99, 200}}, CycleSeed, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.AuthorityErrors != 1 {
+		t.Errorf("authority errors: got %d, want 1", res.AuthorityErrors)
+	}
+	// The cycle continues past the erroring authority and ingests the second.
+	if res.ApplicationCount != 1 {
+		t.Errorf("application count: got %d, want 1 (second authority succeeded)", res.ApplicationCount)
+	}
+	if res.TerminationReason != TerminationNatural {
+		t.Errorf("termination: got %v, want Natural", res.TerminationReason)
+	}
+}
+
+func TestHandler_NoActiveAuthoritiesIsCleanEmptyCycle(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	h := newHandler(t, pi, newFakeApps(), newFakeStateStore(), fakeAuthorities{ids: []int{}}, CycleWatched, defaultHandlerOpts())
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.ApplicationCount != 0 || res.AuthorityErrors != 0 || res.TerminationReason != TerminationNatural {
+		t.Errorf("empty cycle: %+v", res)
+	}
+	if pi.fetchCount() != 0 {
+		t.Errorf("no authorities means no PlanIt calls, got %d", pi.fetchCount())
+	}
+}
+
+func TestHandler_CancelledContextTerminatesTimeBounded(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99, 200}}, CycleSeed, defaultHandlerOpts())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before the loop starts
+
+	res, err := h.Handle(ctx)
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.TerminationReason != TerminationTimeBounded {
+		t.Errorf("termination: got %v, want TimeBounded for a cancelled context", res.TerminationReason)
+	}
+	if pi.fetchCount() != 0 {
+		t.Errorf("cancelled context must not fetch any pages, got %d", pi.fetchCount())
+	}
+}

--- a/api-go/internal/polling/holderid.go
+++ b/api-go/internal/polling/holderid.go
@@ -1,0 +1,19 @@
+package polling
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+)
+
+// newHolderID returns a fresh random hex id for this process's lease writes. It
+// is diagnostic metadata only (acquisition decisions compare expiry + etag), but
+// crypto/rand is used so two concurrent pollers never collide on holder identity.
+func newHolderID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand.Read never fails on supported platforms; fall back to a
+		// constant rather than panicking in library code — the id is diagnostic.
+		return "unknown-holder"
+	}
+	return hex.EncodeToString(b[:])
+}

--- a/api-go/internal/polling/jitter.go
+++ b/api-go/internal/polling/jitter.go
@@ -1,0 +1,24 @@
+package polling
+
+import (
+	mathrand "math/rand/v2"
+	"time"
+)
+
+// RandomJitter is the production Jitter: a symmetric offset uniformly drawn from
+// [-bound, +bound]. The jitter de-synchronises re-enqueues across cycles, so it
+// is operational rather than security-sensitive — math/rand/v2 is the correct
+// tool (gosec G404 is a false positive here), matching internal/worker bootstrap.
+type RandomJitter struct{}
+
+// NewRandomJitter returns the production jitter source.
+func NewRandomJitter() RandomJitter { return RandomJitter{} }
+
+// NextOffset returns a value in [-bound, +bound]. A non-positive bound yields 0.
+func (RandomJitter) NextOffset(bound time.Duration) time.Duration {
+	if bound <= 0 {
+		return 0
+	}
+	// Int64N(2*bound+1) yields [0, 2*bound]; subtracting bound centres it on zero.
+	return time.Duration(mathrand.Int64N(int64(2*bound)+1)) - bound //nolint:gosec // non-security operational jitter
+}

--- a/api-go/internal/polling/jitter_test.go
+++ b/api-go/internal/polling/jitter_test.go
@@ -1,0 +1,29 @@
+package polling
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRandomJitter_NextOffsetWithinBound(t *testing.T) {
+	t.Parallel()
+	j := NewRandomJitter()
+	bound := 10 * time.Second
+	for range 1000 {
+		off := j.NextOffset(bound)
+		if off < -bound || off > bound {
+			t.Fatalf("offset %v out of [-%v, +%v]", off, bound, bound)
+		}
+	}
+}
+
+func TestRandomJitter_NonPositiveBoundIsZero(t *testing.T) {
+	t.Parallel()
+	j := NewRandomJitter()
+	if got := j.NextOffset(0); got != 0 {
+		t.Errorf("zero bound: got %v, want 0", got)
+	}
+	if got := j.NextOffset(-5 * time.Second); got != 0 {
+		t.Errorf("negative bound: got %v, want 0", got)
+	}
+}

--- a/api-go/internal/polling/leasestore.go
+++ b/api-go/internal/polling/leasestore.go
@@ -1,0 +1,193 @@
+package polling
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// leaseDocumentID is the single lease document gating concurrent poll cycles.
+// The Leases container is partitioned by /id, so this lease lives in its own
+// logical partition. Mirrors .NET CosmosPollingLeaseStore.LeaseDocumentId.
+const leaseDocumentID = "polling"
+
+// Lease-store sentinel errors. The CAS-aware Cosmos accessor returns these to
+// distinguish the expected race outcomes from genuine transient failures. The
+// store maps create/replace conflicts to Held and never lets them escape as
+// errors, matching .NET's result-type contract.
+var (
+	// ErrLeaseConflict is returned by CreateLease when the document already exists
+	// (Cosmos 409) — a peer created the lease first.
+	ErrLeaseConflict = errors.New("lease already exists")
+	// ErrLeasePreconditionFailed is returned by a CAS replace/delete when the etag
+	// did not match (Cosmos 412) — a peer mutated the document first.
+	ErrLeasePreconditionFailed = errors.New("lease precondition failed")
+	// ErrLeaseNotFound is returned by DeleteLeaseWithETag when the document was
+	// absent (Cosmos 404) — the lease had already expired or been released.
+	ErrLeaseNotFound = errors.New("lease not found")
+)
+
+// leaseItems is the consumer-side slice of the Leases container the lease store
+// needs: a CAS-aware read (returns the etag), a create-if-absent, an
+// etag-conditional replace, and an etag-conditional delete. platform's CAS-aware
+// container accessor satisfies it structurally.
+type leaseItems interface {
+	ReadLeaseWithETag(ctx context.Context, id string) (body []byte, etag string, found bool, err error)
+	CreateLease(ctx context.Context, id string, item []byte) (etag string, err error)
+	ReplaceLeaseWithETag(ctx context.Context, id string, item []byte, etag string) (newETag string, err error)
+	DeleteLeaseWithETag(ctx context.Context, id, etag string) error
+}
+
+// LeaseHandle carries the etag of the winning write so Release can perform a
+// conditional delete. Mirrors .NET LeaseHandle.
+type LeaseHandle struct {
+	ETag string
+}
+
+// LeaseAcquireResult is the outcome of a TryAcquire. Exactly one of Acquired,
+// Held, or TransientErr-set is true. Mirrors .NET LeaseAcquireResult.
+type LeaseAcquireResult struct {
+	// Acquired reports whether this caller now holds the lease; Handle is valid
+	// only when Acquired.
+	Acquired bool
+	Handle   LeaseHandle
+	// Held reports that a peer holds the lease (lost a create/replace race or the
+	// existing lease is still live).
+	Held bool
+	// TransientErr is set when a network/5xx failure prevented a decision; the
+	// caller should treat it as "could not acquire" and rely on the next trigger.
+	TransientErr error
+}
+
+// LeaseReleaseOutcome is the outcome of a Release. Mirrors .NET
+// LeaseReleaseOutcome.
+type LeaseReleaseOutcome int
+
+const (
+	// LeaseReleased means the lease document was deleted successfully.
+	LeaseReleased LeaseReleaseOutcome = iota
+	// LeaseAlreadyGone means the document was not found (already expired/released).
+	LeaseAlreadyGone
+	// LeasePreconditionFailed means the conditional delete failed (etag mismatch).
+	LeasePreconditionFailed
+	// LeaseTransientError means a network/5xx failure occurred; TTL is the backstop.
+	LeaseTransientError
+)
+
+// leaseDocument is the Cosmos persistence shape for the polling lease. JSON tags
+// reproduce the camelCase keys the .NET CosmosPollingLeaseStore writes, so the
+// Go and .NET workers contend on a byte-compatible document during cutover.
+// expiresAtUtc is the only field acquisition decisions consult; holderId and
+// acquiredAtUtc are diagnostic. Times use the .NET "O" round-trip layout.
+type leaseDocument struct {
+	ID            string `json:"id"`
+	HolderID      string `json:"holderId"`
+	AcquiredAtUTC string `json:"acquiredAtUtc"`
+	ExpiresAtUTC  string `json:"expiresAtUtc"`
+}
+
+// LeaseStore is the etag-CAS-backed polling lease over the Cosmos Leases
+// container. It is the Go port of .NET CosmosPollingLeaseStore: a missing
+// document is created with create-if-absent; an expired document is replaced
+// with an If-Match etag; a live document or a lost race yields Held. The lease
+// prevents the orchestrator and the safety-net bootstrap from running a poll
+// cycle concurrently.
+type LeaseStore struct {
+	items    leaseItems
+	now      func() time.Time
+	holderID string
+}
+
+// NewLeaseStore wires the lease store. now is injected so tests pin the clock;
+// production passes time.Now. The holder id is a fresh random id per process,
+// written as diagnostic metadata only — acquisition compares ExpiresAtUtc + etag.
+func NewLeaseStore(items leaseItems, now func() time.Time) *LeaseStore {
+	return &LeaseStore{
+		items:    items,
+		now:      now,
+		holderID: newHolderID(),
+	}
+}
+
+// TryAcquire attempts to acquire the polling lease with the given TTL. It never
+// returns an error for the expected race outcomes (held by peer, raced on
+// create/replace); those surface via the result. A transient failure is carried
+// on TransientErr.
+func (s *LeaseStore) TryAcquire(ctx context.Context, ttl time.Duration) (LeaseAcquireResult, error) {
+	now := s.now().UTC()
+	body, etag, found, err := s.items.ReadLeaseWithETag(ctx, leaseDocumentID)
+	if err != nil {
+		return LeaseAcquireResult{TransientErr: fmt.Errorf("read lease: %w", err)}, nil
+	}
+
+	desired, err := json.Marshal(leaseDocument{
+		ID:            leaseDocumentID,
+		HolderID:      s.holderID,
+		AcquiredAtUTC: now.Format(dotNetRoundTrip),
+		ExpiresAtUTC:  now.Add(ttl).Format(dotNetRoundTrip),
+	})
+	if err != nil {
+		return LeaseAcquireResult{TransientErr: fmt.Errorf("encode lease: %w", err)}, nil
+	}
+
+	if !found {
+		newETag, createErr := s.items.CreateLease(ctx, leaseDocumentID, desired)
+		switch {
+		case errors.Is(createErr, ErrLeaseConflict):
+			return LeaseAcquireResult{Held: true}, nil
+		case createErr != nil:
+			return LeaseAcquireResult{TransientErr: fmt.Errorf("create lease: %w", createErr)}, nil
+		default:
+			return LeaseAcquireResult{Acquired: true, Handle: LeaseHandle{ETag: newETag}}, nil
+		}
+	}
+
+	// A live (unexpired) lease is held by a peer; do not attempt to replace it.
+	if expiresAt, perr := parseLeaseExpiry(body); perr == nil && expiresAt.After(now) {
+		return LeaseAcquireResult{Held: true}, nil
+	}
+
+	// Expired (or unparseable expiry): replace under the read etag. A 412 means a
+	// peer won the race.
+	newETag, replaceErr := s.items.ReplaceLeaseWithETag(ctx, leaseDocumentID, desired, etag)
+	switch {
+	case errors.Is(replaceErr, ErrLeasePreconditionFailed):
+		return LeaseAcquireResult{Held: true}, nil
+	case replaceErr != nil:
+		return LeaseAcquireResult{TransientErr: fmt.Errorf("replace lease: %w", replaceErr)}, nil
+	default:
+		return LeaseAcquireResult{Acquired: true, Handle: LeaseHandle{ETag: newETag}}, nil
+	}
+}
+
+// Release performs a conditional delete using the handle's etag. It never throws
+// — failures are surfaced as an outcome, and the lease TTL is the backstop for
+// any non-Released outcome. Mirrors .NET ReleaseAsync.
+func (s *LeaseStore) Release(ctx context.Context, handle LeaseHandle) LeaseReleaseOutcome {
+	err := s.items.DeleteLeaseWithETag(ctx, leaseDocumentID, handle.ETag)
+	switch {
+	case err == nil:
+		return LeaseReleased
+	case errors.Is(err, ErrLeaseNotFound):
+		return LeaseAlreadyGone
+	case errors.Is(err, ErrLeasePreconditionFailed):
+		return LeasePreconditionFailed
+	default:
+		return LeaseTransientError
+	}
+}
+
+// parseLeaseExpiry extracts the expiresAtUtc instant from a stored lease body.
+func parseLeaseExpiry(body []byte) (time.Time, error) {
+	var doc leaseDocument
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return time.Time{}, fmt.Errorf("decode lease: %w", err)
+	}
+	t, err := time.Parse(time.RFC3339Nano, doc.ExpiresAtUTC)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse lease expiry %q: %w", doc.ExpiresAtUTC, err)
+	}
+	return t.UTC(), nil
+}

--- a/api-go/internal/polling/leasestore_test.go
+++ b/api-go/internal/polling/leasestore_test.go
@@ -1,0 +1,245 @@
+package polling
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+// mustLeaseDoc builds a marshalled lease document expiring at the given instant,
+// for priming the fake's stored document in acquire-race tests.
+func mustLeaseDoc(t *testing.T, expiresAt time.Time) []byte {
+	t.Helper()
+	body, err := json.Marshal(leaseDocument{
+		ID:            leaseDocumentID,
+		HolderID:      "peer",
+		AcquiredAtUTC: expiresAt.Add(-time.Minute).UTC().Format(dotNetRoundTrip),
+		ExpiresAtUTC:  expiresAt.UTC().Format(dotNetRoundTrip),
+	})
+	if err != nil {
+		t.Fatalf("marshal lease doc: %v", err)
+	}
+	return body
+}
+
+// fakeLeaseItems is a hand-written double for the lease store's CAS-aware Cosmos
+// accessor. It simulates a single lease document with an etag, and can be primed
+// to force conflicts on create/replace/delete so the tests can exercise the
+// "held by peer" and "precondition failed" branches without a live Cosmos.
+type fakeLeaseItems struct {
+	doc  []byte
+	etag string
+
+	createConflict  bool // CreateItem returns ErrConflict (a peer created first)
+	replaceMismatch bool // ReplaceItemWithETag returns ErrPreconditionFailed
+	deleteMismatch  bool // DeleteItemWithETag returns ErrPreconditionFailed
+	deleteNotFound  bool // DeleteItemWithETag returns ErrLeaseNotFound
+	createErr       error
+	nextETag        int
+	deleteCalls     int
+	createCalls     int
+	replaceCalls    int
+}
+
+func newFakeLeaseItems() *fakeLeaseItems { return &fakeLeaseItems{} }
+
+func (f *fakeLeaseItems) bump() string {
+	f.nextETag++
+	return "etag-" + time.Duration(f.nextETag).String()
+}
+
+func (f *fakeLeaseItems) ReadLeaseWithETag(_ context.Context, _ string) ([]byte, string, bool, error) {
+	if f.doc == nil {
+		return nil, "", false, nil
+	}
+	return f.doc, f.etag, true, nil
+}
+
+func (f *fakeLeaseItems) CreateLease(_ context.Context, _ string, item []byte) (string, error) {
+	f.createCalls++
+	if f.createErr != nil {
+		return "", f.createErr
+	}
+	if f.createConflict {
+		return "", ErrLeaseConflict
+	}
+	f.doc = item
+	f.etag = f.bump()
+	return f.etag, nil
+}
+
+func (f *fakeLeaseItems) ReplaceLeaseWithETag(_ context.Context, _ string, item []byte, _ string) (string, error) {
+	f.replaceCalls++
+	if f.replaceMismatch {
+		return "", ErrLeasePreconditionFailed
+	}
+	f.doc = item
+	f.etag = f.bump()
+	return f.etag, nil
+}
+
+func (f *fakeLeaseItems) DeleteLeaseWithETag(_ context.Context, _, _ string) error {
+	f.deleteCalls++
+	if f.deleteNotFound {
+		return ErrLeaseNotFound
+	}
+	if f.deleteMismatch {
+		return ErrLeasePreconditionFailed
+	}
+	f.doc = nil
+	return nil
+}
+
+func newLeaseStore(items leaseItems) *LeaseStore {
+	clock := func() time.Time { return time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC) }
+	return NewLeaseStore(items, clock)
+}
+
+func TestLeaseStore_AcquireCreatesWhenAbsent(t *testing.T) {
+	t.Parallel()
+	items := newFakeLeaseItems()
+	store := newLeaseStore(items)
+
+	res, err := store.TryAcquire(context.Background(), 4*time.Minute)
+	if err != nil {
+		t.Fatalf("TryAcquire: %v", err)
+	}
+	if !res.Acquired {
+		t.Fatalf("expected acquired, got %+v", res)
+	}
+	if res.Handle.ETag == "" {
+		t.Error("expected a non-empty handle etag")
+	}
+	if items.createCalls != 1 {
+		t.Errorf("create calls: got %d, want 1", items.createCalls)
+	}
+}
+
+func TestLeaseStore_AcquireHeldWhenCreateConflicts(t *testing.T) {
+	t.Parallel()
+	// A peer created the lease first → CreateItem 409 → Held (not acquired).
+	items := newFakeLeaseItems()
+	items.createConflict = true
+	store := newLeaseStore(items)
+
+	res, err := store.TryAcquire(context.Background(), 4*time.Minute)
+	if err != nil {
+		t.Fatalf("TryAcquire: %v", err)
+	}
+	if res.Acquired {
+		t.Error("expected not acquired (peer holds the lease)")
+	}
+	if !res.Held {
+		t.Error("expected Held=true")
+	}
+}
+
+func TestLeaseStore_AcquireHeldWhenLiveLeaseExists(t *testing.T) {
+	t.Parallel()
+	// An unexpired lease held by a peer → not acquired, no replace attempted.
+	items := newFakeLeaseItems()
+	store := newLeaseStore(items)
+	// Lease expires 1 minute in the future relative to the fixed clock.
+	items.doc = mustLeaseDoc(t, time.Date(2026, 6, 14, 12, 1, 0, 0, time.UTC))
+	items.etag = "live"
+
+	res, err := store.TryAcquire(context.Background(), 4*time.Minute)
+	if err != nil {
+		t.Fatalf("TryAcquire: %v", err)
+	}
+	if res.Acquired {
+		t.Error("expected not acquired (live lease held by peer)")
+	}
+	if !res.Held {
+		t.Error("expected Held=true")
+	}
+	if items.replaceCalls != 0 {
+		t.Errorf("must not attempt replace on a live lease: replace calls=%d", items.replaceCalls)
+	}
+}
+
+func TestLeaseStore_AcquireReplacesExpiredLease(t *testing.T) {
+	t.Parallel()
+	// An expired lease → replace with If-Match etag → acquired.
+	items := newFakeLeaseItems()
+	store := newLeaseStore(items)
+	items.doc = mustLeaseDoc(t, time.Date(2026, 6, 14, 11, 59, 0, 0, time.UTC)) // expired
+	items.etag = "stale"
+
+	res, err := store.TryAcquire(context.Background(), 4*time.Minute)
+	if err != nil {
+		t.Fatalf("TryAcquire: %v", err)
+	}
+	if !res.Acquired {
+		t.Errorf("expected acquired (expired lease replaced), got %+v", res)
+	}
+	if items.replaceCalls != 1 {
+		t.Errorf("replace calls: got %d, want 1", items.replaceCalls)
+	}
+}
+
+func TestLeaseStore_AcquireHeldWhenReplaceRacesLost(t *testing.T) {
+	t.Parallel()
+	// Expired lease, but a peer replaced it first → If-Match 412 → Held.
+	items := newFakeLeaseItems()
+	store := newLeaseStore(items)
+	items.doc = mustLeaseDoc(t, time.Date(2026, 6, 14, 11, 59, 0, 0, time.UTC))
+	items.etag = "stale"
+	items.replaceMismatch = true
+
+	res, err := store.TryAcquire(context.Background(), 4*time.Minute)
+	if err != nil {
+		t.Fatalf("TryAcquire: %v", err)
+	}
+	if res.Acquired {
+		t.Error("expected not acquired (lost the replace race)")
+	}
+	if !res.Held {
+		t.Error("expected Held=true")
+	}
+}
+
+func TestLeaseStore_AcquireTransientErrorSurfacesAsResult(t *testing.T) {
+	t.Parallel()
+	items := newFakeLeaseItems()
+	items.createErr = errors.New("network blip")
+	store := newLeaseStore(items)
+
+	res, err := store.TryAcquire(context.Background(), 4*time.Minute)
+	if err != nil {
+		t.Fatalf("TryAcquire must not return an error for a transient: %v", err)
+	}
+	if res.Acquired || res.Held {
+		t.Errorf("transient should be neither acquired nor held: %+v", res)
+	}
+	if res.TransientErr == nil {
+		t.Error("expected TransientErr to be set")
+	}
+}
+
+func TestLeaseStore_ReleaseOutcomes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		setup func(*fakeLeaseItems)
+		want  LeaseReleaseOutcome
+	}{
+		{"released", func(*fakeLeaseItems) {}, LeaseReleased},
+		{"already gone", func(f *fakeLeaseItems) { f.deleteNotFound = true }, LeaseAlreadyGone},
+		{"precondition failed", func(f *fakeLeaseItems) { f.deleteMismatch = true }, LeasePreconditionFailed},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			items := newFakeLeaseItems()
+			tc.setup(items)
+			store := newLeaseStore(items)
+			got := store.Release(context.Background(), LeaseHandle{ETag: "etag-x"})
+			if got != tc.want {
+				t.Errorf("Release outcome: got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/api-go/internal/polling/orchestrator.go
+++ b/api-go/internal/polling/orchestrator.go
@@ -1,0 +1,199 @@
+package polling
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+)
+
+// triggerReceiver destructively receives one poll trigger in receive-and-delete
+// mode. ReceiveTrigger reports whether a message was consumed; there is no
+// settle (Complete/Abandon) — the message is gone on receive (ADR 0024).
+type triggerReceiver interface {
+	ReceiveTrigger(ctx context.Context) (received bool, err error)
+}
+
+// triggerPublisher publishes the next trigger with a server-side scheduled
+// enqueue time. *servicebus.Client satisfies it via PublishAt.
+type triggerPublisher interface {
+	PublishAt(ctx context.Context, scheduledEnqueueTime time.Time, body []byte) error
+}
+
+// leaseStore is the consumer-side slice of the polling lease the orchestrator
+// needs. *LeaseStore satisfies it.
+type leaseStore interface {
+	TryAcquire(ctx context.Context, ttl time.Duration) (LeaseAcquireResult, error)
+	Release(ctx context.Context, handle LeaseHandle) LeaseReleaseOutcome
+}
+
+// cycleHandler runs one ingestion cycle. *PollPlanItHandler satisfies it.
+type cycleHandler interface {
+	Handle(ctx context.Context) (PollPlanItResult, error)
+}
+
+// nextRunScheduler computes the next trigger's enqueue time. *NextRunScheduler
+// satisfies it.
+type nextRunScheduler interface {
+	ComputeNextRun(reason TerminationReason, retryAfter *time.Duration, now time.Time) time.Time
+}
+
+// OrchestratorOptions tune the orchestrator's lease behaviour. LeaseTTL is the
+// TTL requested on acquire — it MUST exceed the handler's worst-case runtime so
+// the lease cannot expire mid-handler and let a peer start a duplicate cycle
+// (default 4.5m vs the 4m handler budget). LeaseAcquireRetryDelay is the single
+// retry pause when the lease is briefly held (e.g. by the bootstrap); zero skips
+// the pause.
+type OrchestratorOptions struct {
+	LeaseTTL               time.Duration
+	LeaseAcquireRetryDelay time.Duration
+}
+
+// OrchestratorRunResult is the outcome of one orchestrator run. PollResult is
+// non-nil only when a trigger was received and the handler ran. Mirrors .NET
+// PollTriggerOrchestratorRunResult.
+type OrchestratorRunResult struct {
+	MessageReceived  bool
+	PublishedNext    bool
+	LeaseUnavailable bool
+	PollResult       *PollPlanItResult
+}
+
+// Orchestrator glues the Service Bus trigger queue to the ingestion handler under
+// the receive-and-delete + publish-after-consume model (ADR 0024 amendment). The
+// ordering is acquire lease → receive → handler → publish → release: the lease is
+// acquired before the destructive receive so no other actor mutates the queue
+// during the critical section, and the next trigger is published before the lease
+// is released so a single in-flight trigger is preserved. There is no Service Bus
+// settle — a crash anywhere between receive and publish pauses the chain until
+// the safety-net bootstrap re-seeds. This is the faithful port of .NET
+// PollTriggerOrchestrator.RunOnceAsync.
+type Orchestrator struct {
+	handler   cycleHandler
+	receiver  triggerReceiver
+	publisher triggerPublisher
+	lease     leaseStore
+	scheduler nextRunScheduler
+	opts      OrchestratorOptions
+	now       func() time.Time
+	sleep     func(ctx context.Context, d time.Duration) error
+	logger    *slog.Logger
+}
+
+// NewOrchestrator wires the orchestrator. now and the internal sleep are injected
+// for deterministic tests; production passes time.Now and a context-aware sleep.
+func NewOrchestrator(
+	handler cycleHandler,
+	receiver triggerReceiver,
+	publisher triggerPublisher,
+	lease leaseStore,
+	scheduler nextRunScheduler,
+	opts OrchestratorOptions,
+	now func() time.Time,
+	logger *slog.Logger,
+) *Orchestrator {
+	return &Orchestrator{
+		handler:   handler,
+		receiver:  receiver,
+		publisher: publisher,
+		lease:     lease,
+		scheduler: scheduler,
+		opts:      opts,
+		now:       now,
+		sleep:     sleepUntil,
+		logger:    logger,
+	}
+}
+
+// triggerPayload is the next-trigger body. It carries only a diagnostic
+// timestamp — the message is a "run once" tick — matching .NET's
+// PollTriggerPayload (publishedAtUtc).
+type triggerPayload struct {
+	PublishedAtUTC string `json:"publishedAtUtc"`
+}
+
+// RunOnce performs one orchestrated poll cycle and returns its outcome. It
+// returns an error only when the ingestion handler itself errors; expected
+// states (lease held, empty queue) surface via the result.
+func (o *Orchestrator) RunOnce(ctx context.Context) (OrchestratorRunResult, error) {
+	acquire, err := o.acquireWithRetry(ctx)
+	if err != nil {
+		return OrchestratorRunResult{}, err
+	}
+	if !acquire.Acquired {
+		// Held by a peer or a transient acquire failure: exit cleanly without
+		// touching the queue. KEDA / the next trigger re-runs when the peer
+		// releases. This is the no-dual-run guarantee — only the lease holder
+		// polls PlanIt.
+		o.logger.WarnContext(ctx, "polling lease unavailable; exiting without polling",
+			"held", acquire.Held, "transient", acquire.TransientErr != nil)
+		return OrchestratorRunResult{LeaseUnavailable: true}, nil
+	}
+
+	// Release is deferred so the lease is always relinquished, but the next
+	// trigger is still published before this returns (publish happens inside the
+	// body, release in the defer) — preserving publish-before-release ordering.
+	defer func() {
+		if outcome := o.lease.Release(ctx, acquire.Handle); outcome == LeasePreconditionFailed {
+			o.logger.WarnContext(ctx, "polling lease release returned precondition-failed; TTL is the backstop")
+		}
+	}()
+
+	received, err := o.receiver.ReceiveTrigger(ctx)
+	if err != nil {
+		return OrchestratorRunResult{}, err
+	}
+	if !received {
+		o.logger.InfoContext(ctx, "poll trigger queue empty; exiting cleanly (bootstrap will re-seed)")
+		return OrchestratorRunResult{}, nil
+	}
+
+	result, err := o.handler.Handle(ctx)
+	if err != nil {
+		// The trigger is already destructively consumed and the cycle failed; do
+		// NOT publish a next trigger from a failed cycle — the safety-net bootstrap
+		// recovers the chain. Surface the error for the worker's exit code.
+		return OrchestratorRunResult{MessageReceived: true}, err
+	}
+
+	nextRun := o.scheduler.ComputeNextRun(result.TerminationReason, result.RetryAfter, o.now().UTC())
+	body, _ := json.Marshal(triggerPayload{PublishedAtUTC: o.now().UTC().Format(time.RFC3339Nano)})
+	if err := o.publisher.PublishAt(ctx, nextRun, body); err != nil {
+		return OrchestratorRunResult{MessageReceived: true, PollResult: &result}, err
+	}
+
+	return OrchestratorRunResult{
+		MessageReceived: true,
+		PublishedNext:   true,
+		PollResult:      &result,
+	}, nil
+}
+
+// acquireWithRetry attempts to acquire the lease, retrying once after a short
+// pause to absorb the common case where the bootstrap briefly holds it. Mirrors
+// .NET's single-retry path.
+func (o *Orchestrator) acquireWithRetry(ctx context.Context) (LeaseAcquireResult, error) {
+	res, _ := o.lease.TryAcquire(ctx, o.opts.LeaseTTL)
+	if res.Acquired {
+		return res, nil
+	}
+	if o.opts.LeaseAcquireRetryDelay > 0 {
+		if err := o.sleep(ctx, o.opts.LeaseAcquireRetryDelay); err != nil {
+			return LeaseAcquireResult{}, err
+		}
+	}
+	res, _ = o.lease.TryAcquire(ctx, o.opts.LeaseTTL)
+	return res, nil
+}
+
+// sleepUntil waits d, returning early with the context error if cancelled.
+func sleepUntil(ctx context.Context, d time.Duration) error {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/api-go/internal/polling/orchestrator.go
+++ b/api-go/internal/polling/orchestrator.go
@@ -157,7 +157,13 @@ func (o *Orchestrator) RunOnce(ctx context.Context) (OrchestratorRunResult, erro
 	}
 
 	nextRun := o.scheduler.ComputeNextRun(result.TerminationReason, result.RetryAfter, o.now().UTC())
-	body, _ := json.Marshal(triggerPayload{PublishedAtUTC: o.now().UTC().Format(time.RFC3339Nano)})
+	body, err := json.Marshal(triggerPayload{PublishedAtUTC: o.now().UTC().Format(time.RFC3339Nano)})
+	if err != nil {
+		// json.Marshal of a fixed struct cannot realistically fail; surface it as
+		// a run error so the worker exit-codes on it rather than publishing a
+		// malformed trigger.
+		return OrchestratorRunResult{MessageReceived: true, PollResult: &result}, err
+	}
 	if err := o.publisher.PublishAt(ctx, nextRun, body); err != nil {
 		return OrchestratorRunResult{MessageReceived: true, PollResult: &result}, err
 	}
@@ -173,16 +179,22 @@ func (o *Orchestrator) RunOnce(ctx context.Context) (OrchestratorRunResult, erro
 // pause to absorb the common case where the bootstrap briefly holds it. Mirrors
 // .NET's single-retry path.
 func (o *Orchestrator) acquireWithRetry(ctx context.Context) (LeaseAcquireResult, error) {
-	res, _ := o.lease.TryAcquire(ctx, o.opts.LeaseTTL)
+	res, err := o.lease.TryAcquire(ctx, o.opts.LeaseTTL)
+	if err != nil {
+		return LeaseAcquireResult{}, err
+	}
 	if res.Acquired {
 		return res, nil
 	}
 	if o.opts.LeaseAcquireRetryDelay > 0 {
-		if err := o.sleep(ctx, o.opts.LeaseAcquireRetryDelay); err != nil {
-			return LeaseAcquireResult{}, err
+		if serr := o.sleep(ctx, o.opts.LeaseAcquireRetryDelay); serr != nil {
+			return LeaseAcquireResult{}, serr
 		}
 	}
-	res, _ = o.lease.TryAcquire(ctx, o.opts.LeaseTTL)
+	res, err = o.lease.TryAcquire(ctx, o.opts.LeaseTTL)
+	if err != nil {
+		return LeaseAcquireResult{}, err
+	}
 	return res, nil
 }
 

--- a/api-go/internal/polling/orchestrator_test.go
+++ b/api-go/internal/polling/orchestrator_test.go
@@ -1,0 +1,297 @@
+package polling
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+// --- hand-written fakes for the orchestrator's dependencies ---
+
+// fakeLease records acquire/release calls and can be primed to be held by a peer
+// or to fail transiently. It also records the ORDER of lease vs publish calls via
+// a shared call log so tests can assert publish-after-consume + release-last.
+type fakeLease struct {
+	log       *callLog
+	held      bool
+	transient bool
+	acquireCt int
+	releaseCt int
+	released  bool
+}
+
+func (f *fakeLease) TryAcquire(_ context.Context, _ time.Duration) (LeaseAcquireResult, error) {
+	f.acquireCt++
+	if f.transient {
+		return LeaseAcquireResult{TransientErr: errors.New("cosmos blip")}, nil
+	}
+	if f.held {
+		return LeaseAcquireResult{Held: true}, nil
+	}
+	f.log.add("acquire")
+	return LeaseAcquireResult{Acquired: true, Handle: LeaseHandle{ETag: "e1"}}, nil
+}
+
+func (f *fakeLease) Release(_ context.Context, _ LeaseHandle) LeaseReleaseOutcome {
+	f.releaseCt++
+	f.released = true
+	f.log.add("release")
+	return LeaseReleased
+}
+
+// fakeReceiver hands out one trigger (or none) in receive-and-delete mode. There
+// is no settle method — the message is destructively consumed on receive.
+type fakeReceiver struct {
+	log       *callLog
+	hasMsg    bool
+	receiveCt int
+	err       error
+}
+
+func (f *fakeReceiver) ReceiveTrigger(_ context.Context) (bool, error) {
+	f.receiveCt++
+	if f.err != nil {
+		return false, f.err
+	}
+	if !f.hasMsg {
+		return false, nil
+	}
+	f.log.add("receive")
+	return true, nil
+}
+
+// fakePublisher records the scheduled enqueue time of the next trigger.
+type fakePublisher struct {
+	log         *callLog
+	publishCt   int
+	publishedAt time.Time
+	err         error
+}
+
+func (f *fakePublisher) PublishAt(_ context.Context, at time.Time, _ []byte) error {
+	f.publishCt++
+	if f.err != nil {
+		return f.err
+	}
+	f.publishedAt = at
+	f.log.add("publish")
+	return nil
+}
+
+// fakeCycleHandler stands in for the ingestion handler.
+type fakeCycleHandler struct {
+	log    *callLog
+	result PollPlanItResult
+	err    error
+}
+
+func (f *fakeCycleHandler) Handle(_ context.Context) (PollPlanItResult, error) {
+	f.log.add("handle")
+	return f.result, f.err
+}
+
+// callLog records the order of side-effecting calls across fakes.
+type callLog struct{ events []string }
+
+func (c *callLog) add(e string) { c.events = append(c.events, e) }
+
+func newOrchestrator(t *testing.T, lease *fakeLease, recv *fakeReceiver, pub *fakePublisher, handler *fakeCycleHandler) *Orchestrator {
+	t.Helper()
+	logger := slog.New(slog.NewTextHandler(discard{}, nil))
+	clock := func() time.Time { return time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC) }
+	scheduler := NewNextRunScheduler(DefaultSchedulerOptions(), zeroJitter{})
+	return NewOrchestrator(handler, recv, pub, lease, scheduler, OrchestratorOptions{LeaseTTL: 4*time.Minute + 30*time.Second}, clock, logger)
+}
+
+func newWiredFakes() (*callLog, *fakeLease, *fakeReceiver, *fakePublisher, *fakeCycleHandler) {
+	log := &callLog{}
+	return log,
+		&fakeLease{log: log},
+		&fakeReceiver{log: log, hasMsg: true},
+		&fakePublisher{log: log},
+		&fakeCycleHandler{log: log, result: PollPlanItResult{ApplicationCount: 5, TerminationReason: TerminationNatural}}
+}
+
+// --- tests ---
+
+func TestOrchestrator_HappyPath_AcquireReceiveHandlePublishRelease(t *testing.T) {
+	t.Parallel()
+	log, lease, recv, pub, handler := newWiredFakes()
+	o := newOrchestrator(t, lease, recv, pub, handler)
+
+	res, err := o.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if !res.MessageReceived || !res.PublishedNext {
+		t.Errorf("result: %+v", res)
+	}
+	// Ordering MUST be acquire -> receive -> handle -> publish -> release.
+	want := []string{"acquire", "receive", "handle", "publish", "release"}
+	if got := log.events; !equalStrings(got, want) {
+		t.Errorf("call order: got %v, want %v", got, want)
+	}
+}
+
+func TestOrchestrator_PublishHappensBeforeRelease(t *testing.T) {
+	t.Parallel()
+	// Crash-safety per ADR 0024: publish-after-consume, and the lease is released
+	// only after the next trigger is published. Assert publish precedes release.
+	log, lease, recv, pub, handler := newWiredFakes()
+	o := newOrchestrator(t, lease, recv, pub, handler)
+
+	if _, err := o.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	pubIdx, relIdx := indexOf(log.events, "publish"), indexOf(log.events, "release")
+	if pubIdx == -1 || relIdx == -1 || pubIdx > relIdx {
+		t.Errorf("publish must precede release: events=%v", log.events)
+	}
+}
+
+func TestOrchestrator_LeaseUnavailableExitsWithoutReceiveOrPublish(t *testing.T) {
+	t.Parallel()
+	// A peer holds the lease (after the in-method retry) → exit cleanly without
+	// touching the queue. This is what prevents two pollers double-polling PlanIt.
+	log, lease, recv, pub, handler := newWiredFakes()
+	lease.held = true
+	o := newOrchestrator(t, lease, recv, pub, handler)
+
+	res, err := o.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if !res.LeaseUnavailable {
+		t.Error("expected LeaseUnavailable=true")
+	}
+	if res.MessageReceived || res.PublishedNext {
+		t.Errorf("must not receive/publish when lease unavailable: %+v", res)
+	}
+	if recv.receiveCt != 0 || pub.publishCt != 0 {
+		t.Errorf("no queue ops when lease unavailable: receive=%d publish=%d", recv.receiveCt, pub.publishCt)
+	}
+	if len(log.events) != 0 {
+		t.Errorf("no side effects when lease unavailable: %v", log.events)
+	}
+}
+
+func TestOrchestrator_EmptyQueueExitsCleanlyAndReleasesLease(t *testing.T) {
+	t.Parallel()
+	// No trigger message → run nothing, publish nothing, but still release the
+	// lease (bootstrap will re-seed).
+	log, lease, recv, pub, handler := newWiredFakes()
+	recv.hasMsg = false
+	o := newOrchestrator(t, lease, recv, pub, handler)
+
+	res, err := o.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if res.MessageReceived || res.PublishedNext {
+		t.Errorf("empty queue should not receive/publish: %+v", res)
+	}
+	if handler.log != nil && indexOf(log.events, "handle") != -1 {
+		t.Error("handler must not run on an empty queue")
+	}
+	if !lease.released {
+		t.Error("lease must be released even on an empty queue")
+	}
+}
+
+func TestOrchestrator_RateLimitedResultDrivesScheduledEnqueue(t *testing.T) {
+	t.Parallel()
+	log, lease, recv, pub, _ := newWiredFakes()
+	ra := 90 * time.Second
+	handler := &fakeCycleHandler{
+		log:    log,
+		result: PollPlanItResult{ApplicationCount: 2, RateLimited: true, TerminationReason: TerminationRateLimited, RetryAfter: &ra},
+	}
+	o := newOrchestrator(t, lease, recv, pub, handler)
+
+	if _, err := o.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	// Next enqueue = now + retryAfter (zero jitter): 12:00:00 + 90s = 12:01:30.
+	want := time.Date(2026, 6, 14, 12, 1, 30, 0, time.UTC)
+	if !pub.publishedAt.Equal(want) {
+		t.Errorf("scheduled enqueue: got %v, want %v", pub.publishedAt, want)
+	}
+}
+
+func TestOrchestrator_NaturalResultUsesNaturalCadence(t *testing.T) {
+	t.Parallel()
+	_, lease, recv, pub, handler := newWiredFakes()
+	o := newOrchestrator(t, lease, recv, pub, handler)
+
+	if _, err := o.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	// Natural cadence (5m): 12:00:00 + 5m = 12:05:00.
+	want := time.Date(2026, 6, 14, 12, 5, 0, 0, time.UTC)
+	if !pub.publishedAt.Equal(want) {
+		t.Errorf("scheduled enqueue: got %v, want %v", pub.publishedAt, want)
+	}
+}
+
+func TestOrchestrator_ReleasesLeaseEvenWhenHandlerFails(t *testing.T) {
+	t.Parallel()
+	log, lease, recv, pub, _ := newWiredFakes()
+	handler := &fakeCycleHandler{log: log, err: errors.New("ingestion blew up")}
+	o := newOrchestrator(t, lease, recv, pub, handler)
+
+	_, err := o.RunOnce(context.Background())
+	if err == nil {
+		t.Fatal("expected handler error to surface")
+	}
+	if !lease.released {
+		t.Error("lease must be released even when the handler errors")
+	}
+	// A handler failure must NOT publish a next trigger (no scheduled enqueue from
+	// a failed cycle) — the bootstrap recovers the chain.
+	if pub.publishCt != 0 {
+		t.Errorf("must not publish after a handler failure: publish=%d", pub.publishCt)
+	}
+}
+
+func TestOrchestrator_LeaseTransientErrorExitsCleanly(t *testing.T) {
+	t.Parallel()
+	_, lease, recv, pub, handler := newWiredFakes()
+	lease.transient = true
+	o := newOrchestrator(t, lease, recv, pub, handler)
+
+	res, err := o.RunOnce(context.Background())
+	if err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if res.MessageReceived || res.PublishedNext {
+		t.Errorf("transient lease error must not touch the queue: %+v", res)
+	}
+	if recv.receiveCt != 0 {
+		t.Errorf("no receive on transient lease error: %d", recv.receiveCt)
+	}
+}
+
+// --- helpers ---
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func indexOf(s []string, v string) int {
+	for i, e := range s {
+		if e == v {
+			return i
+		}
+	}
+	return -1
+}

--- a/api-go/internal/polling/retryafter.go
+++ b/api-go/internal/polling/retryafter.go
@@ -1,0 +1,64 @@
+// Package polling is the Go port of the .NET TownCrier.Application.Polling and
+// TownCrier.Infrastructure.Polling slices: the Service-Bus-triggered adaptive
+// PlanIt poll (WORKER_MODE=poll-sb). It owns the trigger orchestrator, the
+// PlanIt ingestion handler, the next-run scheduler, the Cosmos etag-CAS lease
+// and poll-state stores, and the cycle-alternating authority providers.
+//
+// The crash-safety model is receive-and-delete + publish-after-consume per
+// ADR 0024 (2026-04-22 amendment): the orchestrator acquires a Cosmos lease,
+// destructively receives one trigger, runs the handler, publishes the next
+// scheduled trigger, then releases the lease. There is no Service Bus
+// Complete/Abandon — the safety-net bootstrap (internal/worker) is the sole
+// recovery path when anything fails between receive and publish.
+package polling
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ParseRetryAfter parses an HTTP Retry-After header value, supporting both the
+// delta-seconds form ("120") and the HTTP-date form
+// ("Wed, 21 Oct 2015 07:28:00 GMT"). It mirrors .NET RetryAfterParser.Parse:
+// malformed, negative, or absent values report ok=false so callers fall back to
+// a default policy; a past HTTP-date clamps to zero. now anchors the HTTP-date
+// delta computation.
+func ParseRetryAfter(header string, now time.Time) (time.Duration, bool) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return 0, false
+	}
+
+	if seconds, err := strconv.Atoi(header); err == nil {
+		if seconds < 0 {
+			return 0, false
+		}
+		return time.Duration(seconds) * time.Second, true
+	}
+
+	if target, err := http1123(header); err == nil {
+		delta := target.Sub(now)
+		if delta < 0 {
+			return 0, true
+		}
+		return delta, true
+	}
+
+	return 0, false
+}
+
+// http1123 parses an HTTP-date in the three formats RFC 7231 permits, in the
+// order browsers and the Go net/http stack try them. The result is in UTC so
+// the delta against an absolute now is computed in a single timezone.
+func http1123(value string) (time.Time, error) {
+	for _, layout := range []string{time.RFC1123, time.RFC1123Z, time.RFC850, time.ANSIC} {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	// time.RFC1123 expects "GMT"; some servers send "UTC" or an offset. Fall
+	// back to RFC3339 for robustness, then give up.
+	t, err := time.Parse(time.RFC3339, value)
+	return t.UTC(), err
+}

--- a/api-go/internal/polling/retryafter_test.go
+++ b/api-go/internal/polling/retryafter_test.go
@@ -1,0 +1,38 @@
+package polling
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name   string
+		header string
+		want   time.Duration
+		wantOK bool
+	}{
+		{"empty", "", 0, false},
+		{"whitespace", "   ", 0, false},
+		{"delta seconds", "120", 120 * time.Second, true},
+		{"zero seconds", "0", 0, true},
+		{"negative seconds", "-5", 0, false},
+		{"non-numeric garbage", "soon", 0, false},
+		{"http-date future", "Wed, 14 Jun 2026 12:02:00 GMT", 2 * time.Minute, true},
+		{"http-date past clamps to zero", "Wed, 14 Jun 2026 11:58:00 GMT", 0, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, ok := ParseRetryAfter(tc.header, now)
+			if ok != tc.wantOK {
+				t.Fatalf("ParseRetryAfter(%q): ok=%v, want %v", tc.header, ok, tc.wantOK)
+			}
+			if ok && got != tc.want {
+				t.Errorf("ParseRetryAfter(%q): got %v, want %v", tc.header, got, tc.want)
+			}
+		})
+	}
+}

--- a/api-go/internal/polling/scheduler.go
+++ b/api-go/internal/polling/scheduler.go
@@ -1,0 +1,74 @@
+package polling
+
+import "time"
+
+// Jitter yields a symmetric random offset in [-bound, +bound]. It is injected so
+// scheduler tests stay deterministic; production uses a math/rand/v2-backed
+// implementation (operational de-synchronisation, not security-sensitive).
+type Jitter interface {
+	NextOffset(bound time.Duration) time.Duration
+}
+
+// SchedulerOptions are the next-run scheduler tunables. Defaults mirror .NET
+// PollNextRunSchedulerOptions: 5m natural cadence, 1m resume after a time-bounded
+// cut-off, 3h cap on a Retry-After hint, 5m rate-limit default, 10s jitter bound.
+type SchedulerOptions struct {
+	NaturalCadence     time.Duration
+	TimeBoundedCadence time.Duration
+	RetryAfterCap      time.Duration
+	RateLimitDefault   time.Duration
+	JitterBound        time.Duration
+}
+
+// DefaultSchedulerOptions returns the .NET-default tunables.
+func DefaultSchedulerOptions() SchedulerOptions {
+	return SchedulerOptions{
+		NaturalCadence:     5 * time.Minute,
+		TimeBoundedCadence: 1 * time.Minute,
+		RetryAfterCap:      3 * time.Hour,
+		RateLimitDefault:   5 * time.Minute,
+		JitterBound:        10 * time.Second,
+	}
+}
+
+// NextRunScheduler computes when the next poll trigger should be enqueued, given
+// how the previous cycle ended. It is the Go port of .NET PollNextRunScheduler.
+type NextRunScheduler struct {
+	opts   SchedulerOptions
+	jitter Jitter
+}
+
+// NewNextRunScheduler wires the scheduler with its options and jitter source.
+func NewNextRunScheduler(opts SchedulerOptions, jitter Jitter) *NextRunScheduler {
+	return &NextRunScheduler{opts: opts, jitter: jitter}
+}
+
+// ComputeNextRun returns the absolute time the next trigger should enqueue.
+// retryAfter is the optional Retry-After hint from a 429 (nil when absent). Only
+// the rate-limited path consults retryAfter and applies jitter, matching .NET.
+func (s *NextRunScheduler) ComputeNextRun(reason TerminationReason, retryAfter *time.Duration, now time.Time) time.Time {
+	switch reason {
+	case TerminationRateLimited:
+		return now.Add(s.rateLimitedDelay(retryAfter))
+	case TerminationTimeBounded:
+		return now.Add(s.opts.TimeBoundedCadence)
+	case TerminationNatural:
+		return now.Add(s.opts.NaturalCadence)
+	default:
+		return now.Add(s.opts.NaturalCadence)
+	}
+}
+
+// rateLimitedDelay caps the Retry-After hint at RetryAfterCap (falling back to
+// RateLimitDefault when absent) and adds a symmetric jitter, mirroring .NET
+// ComputeRateLimitedDelay.
+func (s *NextRunScheduler) rateLimitedDelay(retryAfter *time.Duration) time.Duration {
+	base := s.opts.RateLimitDefault
+	if retryAfter != nil {
+		base = *retryAfter
+		if base > s.opts.RetryAfterCap {
+			base = s.opts.RetryAfterCap
+		}
+	}
+	return base + s.jitter.NextOffset(s.opts.JitterBound)
+}

--- a/api-go/internal/polling/scheduler_test.go
+++ b/api-go/internal/polling/scheduler_test.go
@@ -1,0 +1,102 @@
+package polling
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNextRunScheduler_ComputeNextRun(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	opts := DefaultSchedulerOptions()
+
+	tests := []struct {
+		name       string
+		reason     TerminationReason
+		retryAfter time.Duration
+		hasRetry   bool
+		want       time.Time
+	}{
+		{
+			name: "natural uses natural cadence",
+			// 5m natural cadence, no jitter (jitter is zero in this test).
+			reason: TerminationNatural,
+			want:   now.Add(5 * time.Minute),
+		},
+		{
+			name:   "time-bounded uses short resume cadence",
+			reason: TerminationTimeBounded,
+			want:   now.Add(1 * time.Minute),
+		},
+		{
+			name:       "rate-limited honours retry-after",
+			reason:     TerminationRateLimited,
+			retryAfter: 90 * time.Second,
+			hasRetry:   true,
+			want:       now.Add(90 * time.Second),
+		},
+		{
+			name:       "rate-limited caps an oversized retry-after",
+			reason:     TerminationRateLimited,
+			retryAfter: 10 * time.Hour, // > 3h cap
+			hasRetry:   true,
+			want:       now.Add(3 * time.Hour),
+		},
+		{
+			name:   "rate-limited without retry-after uses default",
+			reason: TerminationRateLimited,
+			// no retry-after -> RateLimitDefault (5m)
+			want: now.Add(5 * time.Minute),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// Zero jitter makes the result deterministic; jitter coverage is a
+			// separate test below.
+			s := NewNextRunScheduler(opts, zeroJitter{})
+			var retry *time.Duration
+			if tc.hasRetry {
+				ra := tc.retryAfter
+				retry = &ra
+			}
+			got := s.ComputeNextRun(tc.reason, retry, now)
+			if !got.Equal(tc.want) {
+				t.Errorf("ComputeNextRun(%v): got %v, want %v", tc.reason, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNextRunScheduler_RateLimitedAppliesJitter(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	opts := DefaultSchedulerOptions()
+	// A fixed +7s jitter must be added on top of the (capped) base delay only on
+	// the rate-limited path, matching .NET's ComputeRateLimitedDelay.
+	s := NewNextRunScheduler(opts, fixedJitter{offset: 7 * time.Second})
+
+	ra := 90 * time.Second
+	got := s.ComputeNextRun(TerminationRateLimited, &ra, now)
+	want := now.Add(90*time.Second + 7*time.Second)
+	if !got.Equal(want) {
+		t.Errorf("rate-limited jittered next run: got %v, want %v", got, want)
+	}
+
+	// Natural cadence does NOT apply jitter (only the rate-limited branch does in
+	// .NET PollNextRunScheduler).
+	gotNatural := s.ComputeNextRun(TerminationNatural, nil, now)
+	if !gotNatural.Equal(now.Add(5 * time.Minute)) {
+		t.Errorf("natural cadence should not jitter: got %v, want %v", gotNatural, now.Add(5*time.Minute))
+	}
+}
+
+// zeroJitter and fixedJitter are hand-written jitter doubles for deterministic
+// scheduler tests.
+type zeroJitter struct{}
+
+func (zeroJitter) NextOffset(time.Duration) time.Duration { return 0 }
+
+type fixedJitter struct{ offset time.Duration }
+
+func (f fixedJitter) NextOffset(time.Duration) time.Duration { return f.offset }

--- a/api-go/internal/polling/state.go
+++ b/api-go/internal/polling/state.go
@@ -1,0 +1,44 @@
+package polling
+
+import "time"
+
+// PollCursor is a resumable PlanIt pagination cursor: where a previous cycle
+// stopped mid-pagination so the next cycle resumes from the same different_start
+// date and page. All three fields move as a set. Mirrors .NET PollCursor.
+type PollCursor struct {
+	// DifferentStart is the PlanIt different_start date the cursor was recorded
+	// against. The cursor is valid only while the authority's high-water mark
+	// still matches this date; once the HWM advances the cursor is stale.
+	DifferentStart time.Time
+	// NextPage is the next unfetched page number (1-based).
+	NextPage int
+	// KnownTotal is the total PlanIt reported on the first page of the cycle that
+	// recorded the cursor, if known. Telemetry only. nil when unknown.
+	KnownTotal *int
+}
+
+// PollState is the combined poll-state snapshot for one authority: when it was
+// last polled (scheduling clock), its PlanIt high-water mark (cursoring), and an
+// optional resumable pagination cursor. Mirrors .NET PollState.
+type PollState struct {
+	// LastPollTime is the wall-clock time of the last poll attempt. Drives the
+	// least-recently-polled ordering so quiet authorities drop to the back of the
+	// queue immediately, independent of whether PlanIt returned anything new.
+	LastPollTime time.Time
+	// HighWaterMark is the latest LastDifferent observed for this authority, used
+	// as the PlanIt different_start cursor on the next fetch.
+	HighWaterMark time.Time
+	// Cursor is the active pagination cursor, or nil when no cycle is
+	// mid-pagination against the current HighWaterMark date.
+	Cursor *PollCursor
+}
+
+// LeastRecentlyPolledResult is the LRU-sorted candidate authority ids the cycle
+// should walk, plus the count of never-polled candidates (no PollState doc).
+// Mirrors .NET LeastRecentlyPolledResult.
+type LeastRecentlyPolledResult struct {
+	// AuthorityIDs are ordered never-polled-first, then ascending LastPollTime.
+	AuthorityIDs []int
+	// NeverPolledCount is the number of candidates with no PollState document.
+	NeverPolledCount int
+}

--- a/api-go/internal/polling/statestore.go
+++ b/api-go/internal/polling/statestore.go
@@ -1,0 +1,216 @@
+package polling
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// pollStateCrossPartitionQuery selects every poll-state document for the
+// least-recently-polled scan. The PollState container is partitioned by /id, so
+// the LRU ordering needs a cross-partition read, matching .NET's
+// "SELECT * FROM c WHERE STARTSWITH(c.id, 'poll-state-')".
+const pollStateCrossPartitionQuery = "SELECT * FROM c WHERE STARTSWITH(c.id, 'poll-state-')"
+
+// stateItems is the consumer-side slice of the PollState container the store
+// uses: a point read/upsert keyed on the per-authority document id, and a
+// cross-partition scan for the LRU ordering. platform.CosmosContainer satisfies
+// it structurally.
+type stateItems interface {
+	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
+	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
+	QueryItemsCrossPartition(ctx context.Context, query string, params map[string]any) ([][]byte, error)
+}
+
+// pollStateDocument is the Cosmos persistence shape for a PollState. JSON tags
+// reproduce the camelCase keys the .NET CosmosPollStateStore writes (its
+// serializer context uses CamelCase), so a Go-written document is byte-compatible
+// with the existing PollState container and a .NET-written document hydrates here
+// unchanged. Times use the .NET "O" round-trip layout; the cursor date uses
+// yyyy-MM-dd. The container is partitioned by /id.
+type pollStateDocument struct {
+	ID            string  `json:"id"`
+	LastPollTime  string  `json:"lastPollTime"`
+	AuthorityID   int     `json:"authorityId"`
+	HighWaterMark *string `json:"highWaterMark"`
+
+	CursorDifferentStart *string `json:"cursorDifferentStart"`
+	CursorNextPage       *int    `json:"cursorNextPage"`
+	CursorKnownTotal     *int    `json:"cursorKnownTotal"`
+}
+
+// dotNetRoundTrip is Go's equivalent of .NET DateTimeOffset.ToString("O"): a
+// 7-digit fractional second and a numeric UTC offset.
+const dotNetRoundTrip = "2006-01-02T15:04:05.0000000-07:00"
+
+// PollStateStore reads and writes per-authority poll state in the PollState
+// container. It is the Go port of .NET CosmosPollStateStore.
+type PollStateStore struct {
+	items stateItems
+}
+
+// NewPollStateStore returns a store backed by the given Cosmos item accessor.
+func NewPollStateStore(items stateItems) *PollStateStore {
+	return &PollStateStore{items: items}
+}
+
+// Get point-reads the poll state for authorityID. The boolean reports presence:
+// a missing document is a normal "never polled" state, not an error.
+func (s *PollStateStore) Get(ctx context.Context, authorityID int) (PollState, bool, error) {
+	id := documentID(authorityID)
+	raw, err := s.items.ReadItem(ctx, id, id)
+	if err != nil {
+		if isNotFound(err) {
+			return PollState{}, false, nil
+		}
+		return PollState{}, false, fmt.Errorf("read poll state %d: %w", authorityID, err)
+	}
+	var doc pollStateDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return PollState{}, false, fmt.Errorf("decode poll state %d: %w", authorityID, err)
+	}
+	state, err := doc.toState()
+	if err != nil {
+		return PollState{}, false, fmt.Errorf("hydrate poll state %d: %w", authorityID, err)
+	}
+	return state, true, nil
+}
+
+// Save upserts the poll state for authorityID. A nil cursor clears any active
+// cursor. The three poll-state fields are written together as a set.
+func (s *PollStateStore) Save(ctx context.Context, authorityID int, lastPollTime, highWaterMark time.Time, cursor *PollCursor) error {
+	id := documentID(authorityID)
+	hwm := highWaterMark.UTC().Format(dotNetRoundTrip)
+	doc := pollStateDocument{
+		ID:            id,
+		LastPollTime:  lastPollTime.UTC().Format(dotNetRoundTrip),
+		AuthorityID:   authorityID,
+		HighWaterMark: &hwm,
+	}
+	if cursor != nil {
+		ds := cursor.DifferentStart.UTC().Format("2006-01-02")
+		doc.CursorDifferentStart = &ds
+		np := cursor.NextPage
+		doc.CursorNextPage = &np
+		doc.CursorKnownTotal = cursor.KnownTotal
+	}
+	body, err := json.Marshal(doc)
+	if err != nil {
+		return fmt.Errorf("encode poll state %d: %w", authorityID, err)
+	}
+	if err := s.items.UpsertItem(ctx, id, body); err != nil {
+		return fmt.Errorf("upsert poll state %d: %w", authorityID, err)
+	}
+	return nil
+}
+
+// GetLeastRecentlyPolled returns the candidate authority ids ordered
+// never-polled-first then ascending LastPollTime, plus the never-polled count.
+// It mirrors .NET GetLeastRecentlyPolledAsync: one cross-partition scan over all
+// poll-state docs, then an in-memory sort of the candidate set.
+func (s *PollStateStore) GetLeastRecentlyPolled(ctx context.Context, candidateAuthorityIDs []int) (LeastRecentlyPolledResult, error) {
+	if len(candidateAuthorityIDs) == 0 {
+		return LeastRecentlyPolledResult{AuthorityIDs: []int{}, NeverPolledCount: 0}, nil
+	}
+
+	raws, err := s.items.QueryItemsCrossPartition(ctx, pollStateCrossPartitionQuery, nil)
+	if err != nil {
+		return LeastRecentlyPolledResult{}, fmt.Errorf("query poll state: %w", err)
+	}
+
+	lastPollByAuthority := make(map[int]time.Time, len(raws))
+	for _, raw := range raws {
+		var doc pollStateDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return LeastRecentlyPolledResult{}, fmt.Errorf("decode poll state row: %w", err)
+		}
+		lpt, err := time.Parse(time.RFC3339Nano, doc.LastPollTime)
+		if err != nil {
+			return LeastRecentlyPolledResult{}, fmt.Errorf("parse lastPollTime %q: %w", doc.LastPollTime, err)
+		}
+		lastPollByAuthority[doc.AuthorityID] = lpt
+	}
+
+	sorted := make([]int, len(candidateAuthorityIDs))
+	copy(sorted, candidateAuthorityIDs)
+	// Stable sort: never-polled (rank 0) before polled (rank 1), then by oldest
+	// LastPollTime ascending. Matches .NET OrderBy(rank).ThenBy(lastPollTime).
+	sort.SliceStable(sorted, func(i, j int) bool {
+		ai, aj := sorted[i], sorted[j]
+		ti, polledI := lastPollByAuthority[ai]
+		tj, polledJ := lastPollByAuthority[aj]
+		if polledI != polledJ {
+			// never-polled (false) sorts first
+			return !polledI
+		}
+		if !polledI {
+			return false // both never-polled: stable, keep input order
+		}
+		return ti.Before(tj)
+	})
+
+	neverPolled := 0
+	for _, id := range candidateAuthorityIDs {
+		if _, ok := lastPollByAuthority[id]; !ok {
+			neverPolled++
+		}
+	}
+
+	return LeastRecentlyPolledResult{AuthorityIDs: sorted, NeverPolledCount: neverPolled}, nil
+}
+
+// toState hydrates a stored document into a PollState. A legacy document missing
+// highWaterMark falls back to lastPollTime, matching .NET's backward-compat path.
+func (d pollStateDocument) toState() (PollState, error) {
+	lpt, err := time.Parse(time.RFC3339Nano, d.LastPollTime)
+	if err != nil {
+		return PollState{}, fmt.Errorf("parse lastPollTime %q: %w", d.LastPollTime, err)
+	}
+	hwm := lpt
+	if d.HighWaterMark != nil {
+		hwm, err = time.Parse(time.RFC3339Nano, *d.HighWaterMark)
+		if err != nil {
+			return PollState{}, fmt.Errorf("parse highWaterMark %q: %w", *d.HighWaterMark, err)
+		}
+	}
+	cursor, err := d.readCursor()
+	if err != nil {
+		return PollState{}, err
+	}
+	return PollState{LastPollTime: lpt, HighWaterMark: hwm, Cursor: cursor}, nil
+}
+
+// readCursor reconstitutes the cursor; all three fields move as a set, so an
+// absent date or page means there is no active cursor.
+func (d pollStateDocument) readCursor() (*PollCursor, error) {
+	if d.CursorDifferentStart == nil || d.CursorNextPage == nil {
+		return nil, nil //nolint:nilnil // absence of a cursor is a valid nil, not an error
+	}
+	ds, err := time.Parse("2006-01-02", *d.CursorDifferentStart)
+	if err != nil {
+		return nil, fmt.Errorf("parse cursorDifferentStart %q: %w", *d.CursorDifferentStart, err)
+	}
+	return &PollCursor{DifferentStart: ds, NextPage: *d.CursorNextPage, KnownTotal: d.CursorKnownTotal}, nil
+}
+
+// documentID formats the per-authority PollState document id (== partition key),
+// matching .NET FormatDocumentId.
+func documentID(authorityID int) string {
+	return "poll-state-" + strconv.Itoa(authorityID)
+}
+
+// isNotFound reports whether err is a Cosmos 404 response.
+func isNotFound(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
+}
+
+// ptr returns a pointer to v. Used by tests and the store for optional fields.
+func ptr[T any](v T) *T { return &v }

--- a/api-go/internal/polling/statestore_test.go
+++ b/api-go/internal/polling/statestore_test.go
@@ -1,0 +1,180 @@
+package polling
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+// fakeStateItems is a hand-written double for the poll-state store's Cosmos
+// accessor. It keeps documents in a map keyed by id and supports a
+// cross-partition "all poll-state docs" query.
+type fakeStateItems struct {
+	docs        map[string][]byte
+	readErr     error
+	upsertErr   error
+	queryErr    error
+	upsertCalls int
+}
+
+func newFakeStateItems() *fakeStateItems {
+	return &fakeStateItems{docs: map[string][]byte{}}
+}
+
+func (f *fakeStateItems) ReadItem(_ context.Context, _, id string) ([]byte, error) {
+	if f.readErr != nil {
+		return nil, f.readErr
+	}
+	body, ok := f.docs[id]
+	if !ok {
+		return nil, &azcore.ResponseError{StatusCode: http.StatusNotFound}
+	}
+	return body, nil
+}
+
+func (f *fakeStateItems) UpsertItem(_ context.Context, _ string, item []byte) error {
+	f.upsertCalls++
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	var doc pollStateDocument
+	if err := json.Unmarshal(item, &doc); err != nil {
+		return err
+	}
+	f.docs[doc.ID] = item
+	return nil
+}
+
+func (f *fakeStateItems) QueryItemsCrossPartition(_ context.Context, _ string, _ map[string]any) ([][]byte, error) {
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	out := make([][]byte, 0, len(f.docs))
+	for _, body := range f.docs {
+		out = append(out, body)
+	}
+	return out, nil
+}
+
+func TestPollStateStore_SaveThenGetRoundTrips(t *testing.T) {
+	t.Parallel()
+	items := newFakeStateItems()
+	store := NewPollStateStore(items)
+	ctx := context.Background()
+
+	lastPoll := time.Date(2026, 6, 14, 12, 0, 0, 0, time.UTC)
+	hwm := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	cursor := &PollCursor{DifferentStart: time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC), NextPage: 3, KnownTotal: ptr(250)}
+
+	if err := store.Save(ctx, 99, lastPoll, hwm, cursor); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, ok, err := store.Get(ctx, 99)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !ok {
+		t.Fatal("Get: expected state to exist")
+	}
+	if !got.LastPollTime.Equal(lastPoll) || !got.HighWaterMark.Equal(hwm) {
+		t.Errorf("times: lastPoll=%v hwm=%v", got.LastPollTime, got.HighWaterMark)
+	}
+	if got.Cursor == nil || got.Cursor.NextPage != 3 || got.Cursor.KnownTotal == nil || *got.Cursor.KnownTotal != 250 {
+		t.Errorf("cursor: %+v", got.Cursor)
+	}
+	if !got.Cursor.DifferentStart.Equal(cursor.DifferentStart) {
+		t.Errorf("cursor different_start: got %v, want %v", got.Cursor.DifferentStart, cursor.DifferentStart)
+	}
+}
+
+func TestPollStateStore_GetMissingReturnsNotOK(t *testing.T) {
+	t.Parallel()
+	store := NewPollStateStore(newFakeStateItems())
+	_, ok, err := store.Get(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if ok {
+		t.Error("expected ok=false for missing state")
+	}
+}
+
+func TestPollStateStore_SaveWithoutCursorClearsIt(t *testing.T) {
+	t.Parallel()
+	items := newFakeStateItems()
+	store := NewPollStateStore(items)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Save with a cursor, then save again without one — the second read must show
+	// no active cursor.
+	_ = store.Save(ctx, 5, now, now, &PollCursor{DifferentStart: now, NextPage: 2})
+	if err := store.Save(ctx, 5, now, now, nil); err != nil {
+		t.Fatalf("Save (clear cursor): %v", err)
+	}
+	got, _, err := store.Get(ctx, 5)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.Cursor != nil {
+		t.Errorf("cursor should be cleared, got %+v", got.Cursor)
+	}
+}
+
+func TestPollStateStore_GetLeastRecentlyPolledOrdersNeverPolledFirstThenByLastPollTime(t *testing.T) {
+	t.Parallel()
+	items := newFakeStateItems()
+	store := NewPollStateStore(items)
+	ctx := context.Background()
+
+	t0 := time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC)
+	// 100 polled most recently, 200 polled longest ago. 300 is never-polled.
+	_ = store.Save(ctx, 100, t0.Add(2*time.Hour), t0, nil)
+	_ = store.Save(ctx, 200, t0, t0, nil)
+
+	res, err := store.GetLeastRecentlyPolled(ctx, []int{100, 200, 300})
+	if err != nil {
+		t.Fatalf("GetLeastRecentlyPolled: %v", err)
+	}
+	// Never-polled (300) first, then oldest-polled (200), then newest (100).
+	want := []int{300, 200, 100}
+	if len(res.AuthorityIDs) != len(want) {
+		t.Fatalf("ids: got %v, want %v", res.AuthorityIDs, want)
+	}
+	for i := range want {
+		if res.AuthorityIDs[i] != want[i] {
+			t.Errorf("order[%d]: got %d, want %d (full=%v)", i, res.AuthorityIDs[i], want[i], res.AuthorityIDs)
+		}
+	}
+	if res.NeverPolledCount != 1 {
+		t.Errorf("never-polled count: got %d, want 1", res.NeverPolledCount)
+	}
+}
+
+func TestPollStateStore_GetLeastRecentlyPolledEmptyCandidates(t *testing.T) {
+	t.Parallel()
+	store := NewPollStateStore(newFakeStateItems())
+	res, err := store.GetLeastRecentlyPolled(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("GetLeastRecentlyPolled: %v", err)
+	}
+	if len(res.AuthorityIDs) != 0 || res.NeverPolledCount != 0 {
+		t.Errorf("empty candidates should yield empty result, got %+v", res)
+	}
+}
+
+func TestPollStateStore_GetSurfacesNonNotFoundError(t *testing.T) {
+	t.Parallel()
+	items := newFakeStateItems()
+	items.readErr = errors.New("cosmos down")
+	store := NewPollStateStore(items)
+	if _, _, err := store.Get(context.Background(), 1); err == nil {
+		t.Error("expected error from underlying read failure")
+	}
+}

--- a/api-go/internal/polling/termination.go
+++ b/api-go/internal/polling/termination.go
@@ -1,0 +1,35 @@
+package polling
+
+// TerminationReason records how a poll cycle ended. It mirrors .NET
+// PollTerminationReason and drives both the next-run cadence and the worker's
+// exit code. The telemetry value strings match .NET's
+// PollTerminationReason.ToTelemetryValue() so existing App Insights queries keep
+// working across the cutover.
+type TerminationReason int
+
+const (
+	// TerminationNatural means every active authority was processed before the
+	// cycle ended.
+	TerminationNatural TerminationReason = iota
+	// TerminationTimeBounded means the cycle was cut short by the cycle budget or
+	// the soft handler budget.
+	TerminationTimeBounded
+	// TerminationRateLimited means the cycle stopped early because PlanIt returned
+	// HTTP 429.
+	TerminationRateLimited
+)
+
+// TelemetryValue returns the span-tag string for this reason, matching .NET's
+// PollTerminationReason.ToTelemetryValue().
+func (r TerminationReason) TelemetryValue() string {
+	switch r {
+	case TerminationTimeBounded:
+		return "TimeBounded"
+	case TerminationRateLimited:
+		return "RateLimited"
+	case TerminationNatural:
+		return "Natural"
+	default:
+		return "Natural"
+	}
+}

--- a/api-go/internal/servicebus/client.go
+++ b/api-go/internal/servicebus/client.go
@@ -143,6 +143,53 @@ func (c *Client) PublishAt(ctx context.Context, scheduledEnqueueTime time.Time, 
 	return nil
 }
 
+// receiveWaitTimeout bounds a single receive-and-delete attempt so an empty
+// queue returns promptly rather than blocking until a message arrives. It
+// mirrors .NET ServiceBusPollTriggerQueue's 5s receive timeout.
+const receiveWaitTimeout = 5 * time.Second
+
+// ReceiveTrigger destructively receives one poll-trigger message in
+// receive-and-delete mode (ADR 0024 amendment): the message is removed from the
+// queue the instant it is received — there is no lock, no Complete, no Abandon.
+// It reports whether a message was consumed (false when the queue is empty
+// within the receive window). The body is discarded: the trigger is a "run once"
+// tick, so its presence is all the orchestrator needs.
+//
+// A receiver is opened per call and closed after; the orchestrator runs once per
+// process so there is no hot-path receiver to pool. The wait is bounded by
+// receiveWaitTimeout so an empty queue does not block the cycle.
+func (c *Client) ReceiveTrigger(ctx context.Context) (received bool, err error) {
+	receiver, err := c.sbClient.NewReceiverForQueue(c.queueName, &azservicebus.ReceiverOptions{
+		ReceiveMode: azservicebus.ReceiveModeReceiveAndDelete,
+	})
+	if err != nil {
+		return false, fmt.Errorf("build receiver: %w", err)
+	}
+	defer func() {
+		if closeErr := receiver.Close(ctx); closeErr != nil && err == nil {
+			err = fmt.Errorf("close receiver: %w", closeErr)
+		}
+	}()
+
+	waitCtx, cancel := context.WithTimeout(ctx, receiveWaitTimeout)
+	defer cancel()
+
+	msgs, err := receiver.ReceiveMessages(waitCtx, 1, nil)
+	if err != nil {
+		// A timeout waiting for a message means an empty queue, not a failure: the
+		// deadline-exceeded is scoped to waitCtx. A caller-cancelled parent ctx is
+		// a genuine error — distinguish the two via the parent ctx.
+		if ctx.Err() != nil {
+			return false, ctx.Err()
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return false, nil
+		}
+		return false, fmt.Errorf("receive poll trigger: %w", err)
+	}
+	return len(msgs) > 0, nil
+}
+
 // Close releases the underlying SDK clients.
 func (c *Client) Close(ctx context.Context) error {
 	if c.sbClient == nil {

--- a/api-go/internal/watchzones/store_cosmos.go
+++ b/api-go/internal/watchzones/store_cosmos.go
@@ -25,6 +25,9 @@ type CosmosItems interface {
 	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
 	DeleteItem(ctx context.Context, partitionKey, id string) error
 	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
+	// QueryItemsCrossPartition backs the polling authority provider's distinct
+	// authority-id scan; it is the only cross-partition read on this container.
+	QueryItemsCrossPartition(ctx context.Context, query string, params map[string]any) ([][]byte, error)
 }
 
 // listByUserQuery lists a user's zones. It is scoped to the userId partition, so
@@ -139,6 +142,27 @@ func (s *CosmosStore) DeleteAllByUserID(ctx context.Context, userID string) erro
 		}
 	}
 	return nil
+}
+
+// DistinctAuthorityIDs returns the distinct authority ids across every user's
+// watch zones, via a cross-partition DISTINCT VALUE scan. It backs the polling
+// watch-zone active-authority provider (poll-sb cycle), mirroring .NET
+// CosmosWatchZoneRepository.GetDistinctAuthorityIdsCrossPartitionAsync. The
+// VALUE projection returns bare JSON integers, one per result row.
+func (s *CosmosStore) DistinctAuthorityIDs(ctx context.Context) ([]int, error) {
+	raws, err := s.items.QueryItemsCrossPartition(ctx, "SELECT DISTINCT VALUE c.authorityId FROM c", nil)
+	if err != nil {
+		return nil, fmt.Errorf("query distinct authority ids: %w", err)
+	}
+	ids := make([]int, 0, len(raws))
+	for _, raw := range raws {
+		var id int
+		if err := json.Unmarshal(raw, &id); err != nil {
+			return nil, fmt.Errorf("decode authority id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
 }
 
 // isNotFound reports whether err is a Cosmos 404 response.

--- a/api-go/internal/watchzones/store_cosmos_test.go
+++ b/api-go/internal/watchzones/store_cosmos_test.go
@@ -30,6 +30,8 @@ type fakeItems struct {
 	lastQueryPK  string
 	lastQuery    string
 	lastParams   map[string]any
+
+	crossPartitionResult [][]byte // QueryItemsCrossPartition source
 }
 
 func newFakeItems() *fakeItems {
@@ -74,6 +76,15 @@ func (f *fakeItems) QueryItems(_ context.Context, partitionKey, query string, pa
 		return nil, f.queryErr
 	}
 	return f.queryResult, nil
+}
+
+func (f *fakeItems) QueryItemsCrossPartition(_ context.Context, query string, params map[string]any) ([][]byte, error) {
+	f.lastQuery = query
+	f.lastParams = params
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return f.crossPartitionResult, nil
 }
 
 func mustDocBytes(t *testing.T, z WatchZone) []byte {
@@ -229,5 +240,43 @@ func TestCosmosStore_DeleteAllByUserID_NoZonesIsNoOp(t *testing.T) {
 	}
 	if len(items.deletedIDs) != 0 {
 		t.Errorf("expected no deletes, got %v", items.deletedIDs)
+	}
+}
+
+func TestCosmosStore_DistinctAuthorityIDs_CrossPartition(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	// SELECT DISTINCT VALUE c.authorityId FROM c yields bare JSON numbers.
+	items.crossPartitionResult = [][]byte{[]byte("99"), []byte("123"), []byte("7")}
+	store := NewCosmosStore(items)
+
+	ids, err := store.DistinctAuthorityIDs(context.Background())
+	if err != nil {
+		t.Fatalf("DistinctAuthorityIDs: %v", err)
+	}
+	if len(ids) != 3 {
+		t.Fatalf("ids: got %v, want 3 entries", ids)
+	}
+	got := map[int]bool{}
+	for _, id := range ids {
+		got[id] = true
+	}
+	for _, want := range []int{99, 123, 7} {
+		if !got[want] {
+			t.Errorf("missing authority id %d in %v", want, ids)
+		}
+	}
+}
+
+func TestCosmosStore_DistinctAuthorityIDs_EmptyQueryYieldsEmpty(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+	ids, err := store.DistinctAuthorityIDs(context.Background())
+	if err != nil {
+		t.Fatalf("DistinctAuthorityIDs: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected empty, got %v", ids)
 	}
 }

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -51,6 +51,30 @@ type DormantRunner interface {
 	Run(ctx context.Context) (int, error)
 }
 
+// PollRunResult is the dispatcher-facing summary of one poll-sb cycle. It mirrors
+// the orchestrator's run result plus the ingestion counts the dispatch span tags
+// and the exit-code logic need, decoupling the worker package from the polling
+// package's concrete result types. The cmd/worker adapter flattens
+// polling.OrchestratorRunResult into this shape.
+type PollRunResult struct {
+	MessageReceived   bool
+	PublishedNext     bool
+	LeaseUnavailable  bool
+	ApplicationCount  int
+	AuthoritiesPolled int
+	AuthorityErrors   int
+	Termination       string
+}
+
+// PollOrchestrator is the consumer-side slice of the poll-sb orchestrator the
+// dispatcher invokes. The cmd/worker adapter over *polling.Orchestrator satisfies
+// it. It is exported so main() can hold a genuinely nil interface value when the
+// job has no Service Bus / Cosmos config — poll-sb then refuses to run rather
+// than nil-panicking.
+type PollOrchestrator interface {
+	RunOnce(ctx context.Context) (PollRunResult, error)
+}
+
 // Run dispatches on WORKER_MODE and returns the process exit code. It is the
 // testable core of cmd/worker/main.go — main() only loads config, wires the
 // Service Bus client + bootstrapper, sets up telemetry, and propagates this
@@ -66,7 +90,7 @@ type DormantRunner interface {
 // then refuses to run rather than nil-panicking. Likewise digester / dormant may
 // be nil when the job has no Cosmos config; those modes then refuse to run rather
 // than nil-panicking.
-func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, dormant DormantRunner, logger *slog.Logger) int {
+func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, dormant DormantRunner, poller PollOrchestrator, logger *slog.Logger) int {
 	switch mode {
 	case "":
 		// WORKER_MODE is always set by infra; an unset value is a deployment
@@ -87,15 +111,64 @@ func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester 
 		return runDormant(ctx, dormant, logger)
 
 	case "poll-sb":
-		// Loud, safe stub: the image is not deployed until the final cutover, so
-		// this exit-1 can never strand a real job. poll-sb lands in bead tc-yng2.
-		logger.ErrorContext(ctx, "WORKER_MODE not yet implemented in Go worker", "mode", mode)
-		return 1
+		return runPollSB(ctx, poller, logger)
 
 	default:
 		logger.ErrorContext(ctx, "unknown WORKER_MODE; refusing to run", "mode", mode)
 		return 1
 	}
+}
+
+// runPollSB executes one Service-Bus-triggered adaptive poll cycle inside a
+// telemetry span named "Polling Cycle (SB)" (mirroring the .NET worker so
+// existing App Insights queries keep working). It tags the span with the same
+// keys .NET emits (polling.sb.message_received / published_next /
+// authorities_polled / applications_ingested / termination / authority_errors)
+// and applies the .NET exit-code rule: exit 1 only when the run did NO useful
+// work AND hit authority errors. A nil orchestrator (job missing Service Bus /
+// Cosmos config) is an exit-1 condition; an orchestrator error is recorded on the
+// span and also exits 1.
+func runPollSB(ctx context.Context, poller PollOrchestrator, logger *slog.Logger) int {
+	tracer := otel.Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, "Polling Cycle (SB)")
+	defer span.End()
+
+	if poller == nil {
+		logger.ErrorContext(ctx, "poll-sb requires Service Bus + Cosmos config (SERVICE_BUS_* / COSMOS_*); refusing to run")
+		return 1
+	}
+
+	res, err := poller.RunOnce(ctx)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		logger.ErrorContext(ctx, "poll-sb cycle failed", "error", err)
+		return 1
+	}
+
+	span.SetAttributes(
+		attribute.Bool("polling.sb.message_received", res.MessageReceived),
+		attribute.Bool("polling.sb.published_next", res.PublishedNext),
+		attribute.Int("polling.authorities_polled", res.AuthoritiesPolled),
+		attribute.Int("polling.applications_ingested", res.ApplicationCount),
+		attribute.Int("polling.authority_errors", res.AuthorityErrors),
+		attribute.String("polling.termination", res.Termination),
+	)
+
+	logger.InfoContext(ctx, "poll-sb cycle completed",
+		"applications_ingested", res.ApplicationCount,
+		"authorities_polled", res.AuthoritiesPolled,
+		"authority_errors", res.AuthorityErrors,
+		"lease_unavailable", res.LeaseUnavailable)
+
+	// Same exit-code semantics as the .NET poll-sb branch: only exit 1 when the
+	// run did no useful work AND hit authority errors. A quiet cycle (0 apps, 0
+	// errors), a lease-unavailable exit, and any cycle that ingested apps all
+	// exit 0.
+	if res.ApplicationCount == 0 && res.AuthorityErrors > 0 {
+		return 1
+	}
+	return 0
 }
 
 // runDigest executes one digest cycle (weekly or hourly) under a soft self-cancel

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -156,10 +156,10 @@ func runPollSB(ctx context.Context, poller PollOrchestrator, logger *slog.Logger
 	)
 
 	logger.InfoContext(ctx, "poll-sb cycle completed",
-		"applications_ingested", res.ApplicationCount,
-		"authorities_polled", res.AuthoritiesPolled,
-		"authority_errors", res.AuthorityErrors,
-		"lease_unavailable", res.LeaseUnavailable)
+		"applicationsIngested", res.ApplicationCount,
+		"authoritiesPolled", res.AuthoritiesPolled,
+		"authorityErrors", res.AuthorityErrors,
+		"leaseUnavailable", res.LeaseUnavailable)
 
 	// Same exit-code semantics as the .NET poll-sb branch: only exit 1 when the
 	// run did no useful work AND hit authority errors. A quiet cycle (0 apps, 0

--- a/api-go/internal/worker/dispatch_test.go
+++ b/api-go/internal/worker/dispatch_test.go
@@ -48,7 +48,7 @@ func TestRun_UnsetModeFailsFast(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "", nil, nil, nil, logger)
+	code := Run(context.Background(), "", nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unset mode", code)
@@ -63,7 +63,7 @@ func TestRun_DigestModeRunsWeeklyAndExitsZero(t *testing.T) {
 	d := &fakeDigester{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "digest", nil, d, nil, logger)
+	code := Run(context.Background(), "digest", nil, d, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0", code)
@@ -78,7 +78,7 @@ func TestRun_HourlyDigestModeRunsHourlyAndExitsZero(t *testing.T) {
 	d := &fakeDigester{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "hourly-digest", nil, d, nil, logger)
+	code := Run(context.Background(), "hourly-digest", nil, d, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0", code)
@@ -95,7 +95,7 @@ func TestRun_DigestModeWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "digest", nil, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when digest handler is unconfigured", code)
@@ -107,31 +107,111 @@ func TestRun_DigestCycleErrorExitsOne(t *testing.T) {
 	d := &fakeDigester{weeklyErr: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "digest", nil, d, nil, logger)
+	code := Run(context.Background(), "digest", nil, d, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on digest cycle error", code)
 	}
 }
 
-func TestRun_PollSBStillStubsExitOne(t *testing.T) {
+// fakePollOrchestrator is a hand-written double for the poll-sb orchestrator the
+// dispatcher invokes. It records the call and can be primed with a run result or
+// error.
+type fakePollOrchestrator struct {
+	calls  int
+	result PollRunResult
+	err    error
+}
+
+func (f *fakePollOrchestrator) RunOnce(context.Context) (PollRunResult, error) {
+	f.calls++
+	return f.result, f.err
+}
+
+func TestRun_PollSBRunsOrchestratorAndExitsZeroOnSuccess(t *testing.T) {
 	t.Parallel()
-	// poll-sb remains a loud stub until its own bead (tc-yng2) lands. The image is
-	// not deployed until the final cutover, so failing fast (exit 1) is safe.
+	o := &fakePollOrchestrator{result: PollRunResult{
+		MessageReceived:   true,
+		PublishedNext:     true,
+		ApplicationCount:  5,
+		AuthoritiesPolled: 2,
+	}}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, logger)
+
+	if code != 0 {
+		t.Errorf("exit code: got %d, want 0 for a successful poll cycle", code)
+	}
+	if o.calls != 1 {
+		t.Errorf("orchestrator calls: got %d, want 1", o.calls)
+	}
+}
+
+func TestRun_PollSBWithoutOrchestratorExitsOne(t *testing.T) {
+	t.Parallel()
+	// A job missing Service Bus / Cosmos config leaves the orchestrator nil; the
+	// mode must refuse to run rather than nil-panic.
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, nil, logger)
 
 	if code != 1 {
-		t.Errorf("exit code: got %d, want 1 for unimplemented poll-sb", code)
+		t.Errorf("exit code: got %d, want 1 when poll-sb is unconfigured", code)
 	}
-	out := buf.String()
-	if !strings.Contains(out, "not yet implemented in Go worker") {
-		t.Errorf("log should report unimplemented mode, got: %s", out)
+}
+
+func TestRun_PollSBExitsOneOnlyWhenNoAppsAndAuthorityErrors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		result   PollRunResult
+		wantExit int
+	}{
+		{
+			name:     "no apps and authority errors -> exit 1",
+			result:   PollRunResult{MessageReceived: true, ApplicationCount: 0, AuthorityErrors: 2},
+			wantExit: 1,
+		},
+		{
+			name:     "no apps but no authority errors -> exit 0 (quiet cycle)",
+			result:   PollRunResult{MessageReceived: true, ApplicationCount: 0, AuthorityErrors: 0},
+			wantExit: 0,
+		},
+		{
+			name:     "apps ingested despite some authority errors -> exit 0",
+			result:   PollRunResult{MessageReceived: true, ApplicationCount: 10, AuthorityErrors: 1},
+			wantExit: 0,
+		},
+		{
+			name:     "lease unavailable -> exit 0 (peer is polling)",
+			result:   PollRunResult{LeaseUnavailable: true},
+			wantExit: 0,
+		},
 	}
-	if !strings.Contains(out, "poll-sb") {
-		t.Errorf("log should name poll-sb, got: %s", out)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			o := &fakePollOrchestrator{result: tc.result}
+			logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+			code := Run(context.Background(), "poll-sb", nil, nil, nil, o, logger)
+			if code != tc.wantExit {
+				t.Errorf("exit code: got %d, want %d", code, tc.wantExit)
+			}
+		})
+	}
+}
+
+func TestRun_PollSBExitsOneOnOrchestratorError(t *testing.T) {
+	t.Parallel()
+	o := &fakePollOrchestrator{err: errors.New("orchestrator blew up")}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, logger)
+
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1 on orchestrator error", code)
 	}
 }
 
@@ -140,7 +220,7 @@ func TestRun_DormantCleanupRunsAndExitsZero(t *testing.T) {
 	d := &fakeDormant{deleted: 3}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful dormant cleanup)", code)
@@ -157,7 +237,7 @@ func TestRun_DormantCleanupWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when dormant handler is unconfigured", code)
@@ -169,7 +249,7 @@ func TestRun_DormantCleanupCycleErrorExitsOne(t *testing.T) {
 	d := &fakeDormant{err: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on dormant cleanup error", code)
@@ -181,7 +261,7 @@ func TestRun_UnknownModeExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "banana", nil, nil, nil, logger)
+	code := Run(context.Background(), "banana", nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unknown mode", code)
@@ -194,7 +274,7 @@ func TestRun_PollBootstrapSeedsAndExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful bootstrap)", code)
@@ -211,7 +291,7 @@ func TestRun_PollBootstrapWithoutQueueExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when Service Bus is unconfigured", code)
@@ -226,7 +306,7 @@ func TestRun_PollBootstrapProbeFailureStillExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (absorbed probe failure is not a job failure)", code)


### PR DESCRIPTION
Phase 2 Go worker migration (epic tc-wad3). The `poll-sb` mode — faithful port of the **deployed** ADR 0024 design (receive-and-delete + publish-after-consume; NOT the pre-amendment peek-lock/publish-before-ack, which caused a prod incident).

- `internal/planit` — rate-limited HTTP client (throttle, retry on 5xx/408, 429→Retry-After backoff, pagination).
- `internal/polling` — etag-CAS lease store + poll-state store, next-run scheduler (Retry-After + cadence), cycle-alternating authority provider (minute-based), `PollPlanItHandler` (ingest up to MaxPagesPerAuthorityPerCycle, resumable cursor, termination reasons), `Orchestrator` (acquire lease → receive [receive-and-delete] → handle → publish scheduled next → release).
- `internal/platform/cosmos_cas.go` — etag-CAS container ops.
- `dispatch.go` — real poll-sb under span "Polling Cycle (SB)" with the .NET tags; exit-1 only when no apps AND authority errors. `cmd/worker/main.go` wires it (cycle budget = POLL_REPLICA_TIMEOUT_SECONDS − grace).
- Verified the merged poll-bootstrap probe already sums active+scheduled (ADR 0024 §78) — no double-seed.

**Scope note:** this bead is ingestion + re-enqueue only. Notification fan-out (per-zone enqueue + decision-event dispatch) is **tc-uc2p**, a REQUIRED follow-up before cutover — the digest pipeline reads poll-enqueued notification records.

Env for infra (tc-uzm1): `PLANIT_BASE_URL`, `PLANIT_THROTTLE_DELAY_SECONDS`, `PLANIT_RETRY_*`, `POLLING_MAX_PAGES_PER_AUTHORITY_PER_CYCLE`, `POLLING_HANDLER_BUDGET_SECONDS`, `POLL_REPLICA_TIMEOUT_SECONDS`, `POLL_SHUTDOWN_GRACE_SECONDS` + existing SERVICE_BUS_*/COSMOS_*/AZURE_CLIENT_ID.

Gate: gofmt/vet/golangci clean, `go test -race` 780 pass, build ok.

Closes tc-yng2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a polling system that monitors PlanIt applications on a cycle-based schedule with Service Bus triggering.
  * Integrated rate limiting and exponential backoff retry logic for external API calls.
  * Added adaptive authority selection for polling with support for seed and watched cycles.
  * Introduced distributed lease coordination for polling across replicas using Cosmos storage.

* **Tests**
  * Added comprehensive test coverage for polling orchestration, scheduling, and state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->