### PR TITLE
infra: dedupe OTEL_SERVICE_NAME + AZURE_CLIENT_ID on worker jobs (tc-fsn6)

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -699,7 +699,11 @@ public static class EnvironmentStack
         // feature flag the API/worker DI both read.
         var envVars = new List<EnvironmentVarArgs>
         {
-            new() { Name = "OTEL_SERVICE_NAME", Value = "town-crier-worker" },
+            // Single OTEL_SERVICE_NAME for the job: the Go worker reads it (→ AppRoleName
+            // town-crier-worker-go); the legacy .NET worker ignores it (it hardcodes
+            // AddService("town-crier-worker") in Program.cs), so flipping it here ahead of the
+            // image swap is safe and avoids a duplicate-named env var. See tc-fsn6.
+            new() { Name = "OTEL_SERVICE_NAME", Value = "town-crier-worker-go" },
             new() { Name = "Cosmos__AccountEndpoint", Value = cosmosAccountEndpoint },
             new() { Name = "Cosmos__DatabaseName", Value = cosmosDatabaseName },
             new() { Name = "AZURE_CLIENT_ID", Value = cosmosDataIdentityClientId },
@@ -735,7 +739,7 @@ public static class EnvironmentStack
         // from the SAME Pulumi config/secret/output as its .NET counterpart, and the
         // per-mode split mirrors the .NET env composition above.
         AddGoWorkerEnv(envVars, workerMode, cosmosAccountEndpoint, cosmosDatabaseName,
-            cosmosDataIdentityClientId, auth0Domain, apnsUseSandbox, pollingBus);
+            auth0Domain, apnsUseSandbox, pollingBus);
 
         var useEventTrigger = cronExpression is null;
         if (useEventTrigger && pollingBus is null)
@@ -878,17 +882,16 @@ public static class EnvironmentStack
         string? workerMode,
         Output<string> cosmosAccountEndpoint,
         Output<string> cosmosDatabaseName,
-        Output<string> cosmosDataIdentityClientId,
         string auth0Domain,
         string apnsUseSandbox,
         ServiceBusPollingInfra? pollingBus)
     {
-        // All modes: telemetry service name + Cosmos + managed identity. The Go worker
-        // resolves a Cosmos client and DefaultAzureCredential in every mode.
-        envVars.Add(new EnvironmentVarArgs { Name = "OTEL_SERVICE_NAME", Value = "town-crier-worker-go" });
+        // All modes: Go-named Cosmos endpoint/database. OTEL_SERVICE_NAME and AZURE_CLIENT_ID
+        // are already on the shared base env block (single entries) — re-adding them here would
+        // create duplicate-named env vars on the job. The Go worker resolves a Cosmos client and
+        // DefaultAzureCredential in every mode from those base vars. See tc-fsn6.
         envVars.Add(new EnvironmentVarArgs { Name = "COSMOS_ENDPOINT", Value = cosmosAccountEndpoint });
         envVars.Add(new EnvironmentVarArgs { Name = "COSMOS_DATABASE", Value = cosmosDatabaseName });
-        envVars.Add(new EnvironmentVarArgs { Name = "AZURE_CLIENT_ID", Value = cosmosDataIdentityClientId });
 
         // poll / poll-bootstrap: Service Bus (mirrors .NET ServiceBus__Namespace/QueueName).
         if (pollingBus is not null)


### PR DESCRIPTION
Follow-up to tc-uzm1 (#454). That bead added Go-named env additively, but `OTEL_SERVICE_NAME` and `AZURE_CLIENT_ID` already existed in the shared base worker env, so each job ended up with **duplicate-named env vars** (confirmed on `job-tc-digest-dev`: two `OTEL_SERVICE_NAME`, two `AZURE_CLIENT_ID`).

A duplicate `OTEL_SERVICE_NAME` with conflicting values (`town-crier-worker` vs `town-crier-worker-go`) is ambiguous at runtime and would jeopardise the `AppRoleName==town-crier-worker-go` cutover success criterion.

Fix:
- Set a single `OTEL_SERVICE_NAME=town-crier-worker-go` on the base worker env. The legacy .NET worker hardcodes `AddService("town-crier-worker")` (Program.cs L55) and ignores the env var, so flipping it ahead of the image swap is safe and produces no duplicate.
- Drop the duplicate `OTEL_SERVICE_NAME` and `AZURE_CLIENT_ID` adds from `AddGoWorkerEnv` (both are on the base env already) and remove its now-unused `cosmosDataIdentityClientId` parameter.

`dotnet build` clean (0 errors), `dotnet format` clean. Blocks the image-swap (tc-hm20).

Closes tc-fsn6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)