### PR TITLE
feat(go): poll-path notification fan-out + decision dispatch (tc-uc2p)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/AmyDe/town-crier/api-go/internal/acsemail"
 	"github.com/AmyDe/town-crier/api-go/internal/apns"
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
@@ -27,6 +29,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/dormant"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/notifydispatch"
 	"github.com/AmyDe/town-crier/api-go/internal/planit"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/polling"
@@ -222,6 +225,15 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, log
 		logger,
 	)
 
+	// Wire the poll-path notification fan-out: each upserted application drives a
+	// decision-event dispatch (on a non-decision -> decision transition) and a
+	// watch-zone notification fan-out, matching .NET PollPlanItCommandHandler.
+	// This is the CUTOVER-BLOCKER fan-out (bead tc-uc2p) — without it the
+	// Notifications container stays empty and every alert/digest breaks.
+	if err := wirePollFanOut(cfg, handler, zoneStore, logger); err != nil {
+		return nil, err
+	}
+
 	scheduler := polling.NewNextRunScheduler(polling.DefaultSchedulerOptions(), polling.NewRandomJitter())
 
 	// Lease TTL must exceed the handler's worst-case runtime so the lease cannot
@@ -249,6 +261,58 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, log
 	cycleBudget := time.Duration(maxInt(1, cfg.PollReplicaTimeoutSeconds-cfg.PollShutdownGraceSeconds)) * time.Second
 
 	return &pollOrchestratorAdapter{orchestrator: orchestrator, cycleBudget: cycleBudget}, nil
+}
+
+// wirePollFanOut builds the poll-path notification fan-out collaborators — the
+// decision-event dispatcher and the watch-zone enqueuer — and attaches them to
+// the ingestion handler. They share the WatchZones store with the poll's
+// authority provider (the same *watchzones.CosmosStore satisfies the
+// zone-containment lookup) and open their own Notifications / Users /
+// NotificationState / DeviceRegistrations / SavedApplications containers. The
+// APNs push sender is real when its credentials are present, NoOp otherwise so
+// the poll job boots even without APNs config (the record is still written, so
+// the digest pipeline keeps working). Mirrors .NET's per-app
+// decisionEventDispatcher + notificationEnqueuer wiring.
+func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zoneStore *watchzones.CosmosStore, logger *slog.Logger) error {
+	notifsContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationsContainer, logger)
+	if err != nil {
+		return err
+	}
+	usersContainer, err := platform.NewCosmosContainerNamed(cfg, "Users", logger)
+	if err != nil {
+		return err
+	}
+	stateContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationStateContainer, logger)
+	if err != nil {
+		return err
+	}
+	devicesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosDeviceRegistrationsContainer, logger)
+	if err != nil {
+		return err
+	}
+	savedContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosSavedApplicationsContainer, logger)
+	if err != nil {
+		return err
+	}
+
+	notifStore := notifications.NewDigestStore(notifsContainer)
+	profileStore := profiles.NewCosmosStore(usersContainer)
+	deviceStore := devicetokens.NewCosmosStore(devicesContainer)
+	statePushStore := notificationstate.NewCosmosStore(stateContainer, notifsContainer)
+	savedStore := savedapplications.NewCosmosStore(savedContainer)
+	pushSender := buildPushSender(cfg, logger)
+
+	enqueuer := notifydispatch.NewEnqueuer(
+		notifStore, zoneStore, profileStore, deviceStore, statePushStore, pushSender,
+		uuid.NewString, time.Now, logger,
+	)
+	dispatcher := notifydispatch.NewDecisionDispatcher(
+		notifStore, zoneStore, savedStore, profileStore, deviceStore, statePushStore, pushSender,
+		uuid.NewString, time.Now, logger,
+	)
+
+	handler.WithFanOut(dispatcher, enqueuer)
+	return nil
 }
 
 // pollOrchestratorAdapter flattens polling.OrchestratorRunResult into the

--- a/api-go/internal/notifications/digest_store_cosmos.go
+++ b/api-go/internal/notifications/digest_store_cosmos.go
@@ -92,6 +92,57 @@ func (s *DigestStore) UserIDsWithUnsentEmails(ctx context.Context) ([]string, er
 	return userIDs, nil
 }
 
+// Create writes a freshly dispatched notification into the user's partition. It
+// is the poll-path enqueuer's write primitive (epic tc-wad3, bead tc-uc2p): the
+// document it writes is the full digestDocument shape — camelCase keys, the
+// 90-day TTL, emailSent=false — so the digest worker's ByUserSince /
+// UnsentEmailsByUser reads hydrate it unchanged. Mirrors .NET
+// CosmosNotificationRepository.SaveAsync for a new notification.
+func (s *DigestStore) Create(ctx context.Context, n DigestNotification) error {
+	body, err := json.Marshal(newDigestDocument(n))
+	if err != nil {
+		return fmt.Errorf("encode notification %q: %w", n.ID, err)
+	}
+	if err := s.items.UpsertItem(ctx, n.UserID, body); err != nil {
+		return fmt.Errorf("upsert notification %q: %w", n.ID, err)
+	}
+	return nil
+}
+
+// getByUserAndApplicationQuery is the dedup lookup: the user's notification (if
+// any) for a given (applicationUid, authorityId, eventType). Authority is part
+// of the key because PlanIt uids collide across councils (tc-th98 / GH#384), so
+// a uid-only match would suppress a legitimate notification for a same-uid
+// application in a different authority. Mirrors .NET GetByUserAndApplicationAsync.
+const getByUserAndApplicationQuery = "SELECT * FROM c WHERE c.userId = @userId " +
+	"AND c.applicationUid = @applicationUid AND c.authorityId = @authorityId " +
+	"AND c.eventType = @eventType"
+
+// GetByUserAndApplication returns the user's existing notification for the
+// (applicationUid, authorityId, eventType) tuple, or nil when none exists — the
+// "not yet notified" signal the enqueuer and decision dispatcher branch on for
+// idempotency. The read is single-partition (scoped to userId), mirroring .NET.
+func (s *DigestStore) GetByUserAndApplication(ctx context.Context, userID, applicationUID string, authorityID int, eventType EventType) (*DigestNotification, error) {
+	raws, err := s.items.QueryItems(ctx, userID, getByUserAndApplicationQuery, map[string]any{
+		"@userId":         userID,
+		"@applicationUid": applicationUID,
+		"@authorityId":    authorityID,
+		"@eventType":      string(eventType),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query existing notification for %q: %w", userID, err)
+	}
+	if len(raws) == 0 {
+		return nil, nil //nolint:nilnil // absent notification is the "not yet notified" signal, not an error
+	}
+	var doc digestDocument
+	if err := json.Unmarshal(raws[0], &doc); err != nil {
+		return nil, fmt.Errorf("decode existing notification for %q: %w", userID, err)
+	}
+	n := doc.toDigest()
+	return &n, nil
+}
+
 // MarkEmailSent upserts the notification document (with EmailSent already set by
 // the caller) so it is excluded from the next hourly cycle, mirroring .NET's
 // MarkEmailSent + SaveAsync.

--- a/api-go/internal/notifications/digest_store_test.go
+++ b/api-go/internal/notifications/digest_store_test.go
@@ -176,6 +176,109 @@ func TestDigestStore_MarkEmailSentUpsertsDocument(t *testing.T) {
 	}
 }
 
+func TestDigestStore_Create_UpsertsDigestReadableDocument(t *testing.T) {
+	t.Parallel()
+	items := &fakeDigestItems{}
+	store := NewDigestStore(items)
+	zoneID := "zone-1"
+	n := DigestNotification{
+		ID:                     "n-1",
+		UserID:                 "user-1",
+		ApplicationUID:         "24/0001",
+		ApplicationName:        "24/0001",
+		WatchZoneID:            &zoneID,
+		ApplicationAddress:     "10 High St",
+		ApplicationDescription: "Loft conversion",
+		AuthorityID:            99,
+		EventType:              EventNewApplication,
+		Sources:                "Zone",
+		CreatedAt:              time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC),
+	}
+
+	if err := store.Create(context.Background(), n); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if items.upsertPK != "user-1" {
+		t.Errorf("upsert partition key: got %q, want user-1", items.upsertPK)
+	}
+	// The written document must be byte-compatible with what the digest reader
+	// hydrates (digestDocument): camelCase keys, the 90-day TTL, emailSent=false.
+	var back digestDocument
+	if err := json.Unmarshal(items.upsertBody, &back); err != nil {
+		t.Fatalf("unmarshal upserted body: %v", err)
+	}
+	if back.ID != "n-1" || back.UserID != "user-1" || back.AuthorityID != 99 {
+		t.Errorf("round-trip mismatch: %+v", back)
+	}
+	if back.EmailSent {
+		t.Error("a freshly created notification must be unsent (emailSent=false)")
+	}
+	if back.TTL != ninetyDaysSeconds {
+		t.Errorf("ttl: got %d, want %d", back.TTL, ninetyDaysSeconds)
+	}
+	// And it must hydrate cleanly through the digest read path.
+	got := back.toDigest()
+	if got.ApplicationUID != "24/0001" || got.WatchZoneID == nil || *got.WatchZoneID != "zone-1" {
+		t.Errorf("digest hydration mismatch: %+v", got)
+	}
+}
+
+func TestDigestStore_GetByUserAndApplication_DedupQuery(t *testing.T) {
+	t.Parallel()
+	decision := "Permitted"
+	doc := map[string]any{
+		"id":                     "n-1",
+		"userId":                 "user-1",
+		"applicationUid":         "24/0001",
+		"applicationName":        "24/0001",
+		"applicationAddress":     "addr",
+		"applicationDescription": "desc",
+		"authorityId":            99,
+		"eventType":              "DecisionUpdate",
+		"decision":               decision,
+		"createdAt":              "2026-06-13T08:00:00+00:00",
+	}
+	body, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	items := &fakeDigestItems{queryResult: [][]byte{body}}
+	store := NewDigestStore(items)
+
+	got, err := store.GetByUserAndApplication(context.Background(), "user-1", "24/0001", 99, EventDecisionUpdate)
+	if err != nil {
+		t.Fatalf("GetByUserAndApplication: %v", err)
+	}
+	if got == nil || got.ID != "n-1" {
+		t.Fatalf("expected the existing notification, got %+v", got)
+	}
+	if items.queryPK != "user-1" {
+		t.Errorf("partition key: got %q, want user-1", items.queryPK)
+	}
+	// Dedup key is (userId, applicationUid, authorityId, eventType) — authority
+	// is part of the key because PlanIt uids collide across councils (tc-th98).
+	for _, want := range []string{"c.userId", "c.applicationUid", "c.authorityId", "c.eventType"} {
+		if !strings.Contains(items.queryText, want) {
+			t.Errorf("dedup query missing %q: %s", want, items.queryText)
+		}
+	}
+	if items.queryParams["@applicationUid"] != "24/0001" || items.queryParams["@authorityId"] != 99 || items.queryParams["@eventType"] != "DecisionUpdate" {
+		t.Errorf("params: %v", items.queryParams)
+	}
+}
+
+func TestDigestStore_GetByUserAndApplication_NoMatchReturnsNil(t *testing.T) {
+	t.Parallel()
+	store := NewDigestStore(&fakeDigestItems{})
+	got, err := store.GetByUserAndApplication(context.Background(), "user-1", "24/0001", 99, EventNewApplication)
+	if err != nil {
+		t.Fatalf("GetByUserAndApplication: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for no match, got %+v", got)
+	}
+}
+
 func TestDigestStore_ByUserSinceWrapsError(t *testing.T) {
 	t.Parallel()
 	items := &fakeDigestItems{queryErr: errors.New("boom")}

--- a/api-go/internal/notifydispatch/decision.go
+++ b/api-go/internal/notifydispatch/decision.go
@@ -1,0 +1,198 @@
+package notifydispatch
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// zoneMatcher runs the cross-partition point-in-zone lookup.
+// *watchzones.CosmosStore satisfies it.
+type zoneMatcher interface {
+	FindZonesContaining(ctx context.Context, latitude, longitude float64) ([]watchzones.WatchZone, error)
+}
+
+// savedMatcher runs the cross-partition saved-bookmark lookup.
+// *savedapplications.CosmosStore satisfies it.
+type savedMatcher interface {
+	UserIDsForApplication(ctx context.Context, applicationUID string, authorityID int) ([]string, error)
+}
+
+// DecisionDispatcher ports .NET DispatchDecisionEventCommandHandler: when a
+// polled application transitions into a decision state, it computes the union of
+// users matched by a watch zone (geographic) and users who bookmarked the
+// application (saved), then dispatches exactly one DecisionUpdate notification
+// per user. Idempotent — at most one DecisionUpdate per (userId, applicationUid,
+// authorityId).
+type DecisionDispatcher struct {
+	notifications notificationWriter
+	zones         zoneMatcher
+	saved         savedMatcher
+	profiles      profileReader
+	devices       deviceReader
+	state         stateReader
+	push          pushSender
+	newID         func() string
+	now           func() time.Time
+	logger        *slog.Logger
+}
+
+// NewDecisionDispatcher wires the decision dispatcher. newID mints the
+// notification id; now stamps the record's creation time. Both are injected so
+// tests can pin them.
+func NewDecisionDispatcher(
+	notifs notificationWriter,
+	zones zoneMatcher,
+	saved savedMatcher,
+	profs profileReader,
+	devices deviceReader,
+	state stateReader,
+	push pushSender,
+	newID func() string,
+	now func() time.Time,
+	logger *slog.Logger,
+) *DecisionDispatcher {
+	return &DecisionDispatcher{
+		notifications: notifs,
+		zones:         zones,
+		saved:         saved,
+		profiles:      profs,
+		devices:       devices,
+		state:         state,
+		push:          push,
+		newID:         newID,
+		now:           now,
+		logger:        logger,
+	}
+}
+
+// userMatch accumulates which sources matched a user and the first zone id to
+// attribute the notification to (saved-only matches leave it nil).
+type userMatch struct {
+	zone        bool
+	saved       bool
+	watchZoneID *string
+}
+
+// Dispatch fans a decision event out to every matched user. It is idempotent per
+// (user, application, authority): a re-dispatch finds the existing DecisionUpdate
+// and skips.
+func (d *DecisionDispatcher) Dispatch(ctx context.Context, app applications.PlanningApplication) error {
+	matches := map[string]*userMatch{}
+
+	// Zone matchers — only meaningful when the application has coordinates.
+	if app.Latitude != nil && app.Longitude != nil {
+		zones, err := d.zones.FindZonesContaining(ctx, *app.Latitude, *app.Longitude)
+		if err != nil {
+			return err
+		}
+		for _, zone := range zones {
+			m := matches[zone.UserID]
+			if m == nil {
+				m = &userMatch{}
+				matches[zone.UserID] = m
+			}
+			m.zone = true
+			if m.watchZoneID == nil {
+				id := zone.ID
+				m.watchZoneID = &id
+			}
+		}
+	}
+
+	// Saved bookmark holders — scoped to the polled application's council, since
+	// PlanIt uids collide across councils (tc-th98 / GH#384).
+	savedUserIDs, err := d.saved.UserIDsForApplication(ctx, app.UID, app.AreaID)
+	if err != nil {
+		return err
+	}
+	for _, userID := range savedUserIDs {
+		m := matches[userID]
+		if m == nil {
+			m = &userMatch{}
+			matches[userID] = m
+		}
+		m.saved = true
+	}
+
+	for userID, m := range matches {
+		if err := d.dispatchForUser(ctx, app, userID, m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// dispatchForUser dispatches the decision event to one matched user, gated on
+// the per-user idempotency read. The push fires only when the user is on a paid
+// tier with push enabled AND opted into decision pushes on a matching source
+// (zone DecisionPush or saved SavedDecisionPush). The record is always written.
+func (d *DecisionDispatcher) dispatchForUser(ctx context.Context, app applications.PlanningApplication, userID string, m *userMatch) error {
+	existing, err := d.notifications.GetByUserAndApplication(ctx, userID, app.UID, app.AreaID, notifications.EventDecisionUpdate)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		return nil
+	}
+
+	profile, err := d.profiles.Get(ctx, userID)
+	if err != nil {
+		d.logger.WarnContext(ctx, "decision: profile unavailable, skipping", "user", userID, "error", err)
+		return nil //nolint:nilerr // a missing profile is a skip, not a fan-out failure
+	}
+	if profile == nil {
+		return nil
+	}
+
+	n := newRecord(recordInput{
+		id:          d.newID(),
+		userID:      userID,
+		app:         app,
+		watchZoneID: m.watchZoneID,
+		eventType:   notifications.EventDecisionUpdate,
+		sources:     mergeSources(m),
+		now:         d.now().UTC(),
+	})
+
+	if d.canPush(profile, m) {
+		n.PushSent = sendInstantPush(ctx, instantPushDeps{
+			devices: d.devices,
+			state:   d.state,
+			push:    d.push,
+			logger:  d.logger,
+		}, userID, n)
+	}
+
+	return d.notifications.Create(ctx, n)
+}
+
+// canPush OR-merges the per-channel decision-push toggles across the matching
+// sources, gated on the paid tier and the global push preference. Mirrors .NET's
+// zonePushOptIn || savedPushOptIn.
+func (d *DecisionDispatcher) canPush(profile *profiles.UserProfile, m *userMatch) bool {
+	if !profile.Tier.IsPaid() || !profile.Preferences.PushEnabled {
+		return false
+	}
+	zonePushOptIn := m.zone && m.watchZoneID != nil && profile.ZonePreferences[*m.watchZoneID].DecisionPush
+	savedPushOptIn := m.saved && profile.Preferences.SavedDecisionPush
+	return zonePushOptIn || savedPushOptIn
+}
+
+// mergeSources renders the .NET NotificationSources flag string for a match:
+// "Zone", "Saved", or "Zone,Saved" when both apply.
+func mergeSources(m *userMatch) string {
+	switch {
+	case m.zone && m.saved:
+		return sourceZone + "," + sourceSaved
+	case m.saved:
+		return sourceSaved
+	default:
+		return sourceZone
+	}
+}

--- a/api-go/internal/notifydispatch/decision_test.go
+++ b/api-go/internal/notifydispatch/decision_test.go
@@ -1,0 +1,273 @@
+package notifydispatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// fakeZones serves the cross-partition zone-containment lookup.
+type fakeZones struct {
+	zones    []watchzones.WatchZone
+	queryErr error
+	lastLat  float64
+	lastLng  float64
+}
+
+func (f *fakeZones) FindZonesContaining(_ context.Context, lat, lng float64) ([]watchzones.WatchZone, error) {
+	f.lastLat = lat
+	f.lastLng = lng
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return f.zones, nil
+}
+
+// fakeSaved serves the cross-partition saved-bookmark lookup.
+type fakeSaved struct {
+	userIDs  []string
+	queryErr error
+}
+
+func (f *fakeSaved) UserIDsForApplication(_ context.Context, _ string, _ int) ([]string, error) {
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return f.userIDs, nil
+}
+
+func decisionApp(t *testing.T, decision string, lat, lng *float64) applications.PlanningApplication {
+	t.Helper()
+	d := decision
+	app := applications.PlanningApplication{
+		Name:          "24/0001",
+		UID:           "24/0001",
+		AreaName:      "Kingston",
+		AreaID:        99,
+		Address:       "10 High St",
+		Description:   "Loft conversion",
+		AppState:      &d,
+		Latitude:      lat,
+		Longitude:     lng,
+		LastDifferent: time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC),
+	}
+	return app
+}
+
+func coord(v float64) *float64 { return &v }
+
+func proWithZonePrefs(t *testing.T, userID, zoneID string, decisionPush bool) *profiles.UserProfile {
+	t.Helper()
+	p := profileWithTier(t, userID, profiles.TierPro)
+	p.ZonePreferences[zoneID] = profiles.ZonePreferences{
+		NewApplicationPush: true,
+		DecisionPush:       decisionPush,
+	}
+	return p
+}
+
+func newDecisionHarness(
+	t *testing.T,
+	zones *fakeZones,
+	saved *fakeSaved,
+	profs *fakeProfiles,
+) (*DecisionDispatcher, *fakeNotifications, *fakePush, *fakeDevices) {
+	t.Helper()
+	notifs := newFakeNotifications()
+	devs := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
+		"auth0|alice": {{Token: "tok-1"}},
+		"auth0|bob":   {{Token: "tok-2"}},
+	}}
+	st := &fakeState{}
+	push := &fakePush{}
+	d := NewDecisionDispatcher(notifs, zones, saved, profs, devs, st, push,
+		func() string { return "n-fixed" },
+		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
+		testLogger(t))
+	return d, notifs, push, devs
+}
+
+func TestDecisionDispatcher_ZoneMatch_CreatesDecisionRecordAndPushes(t *testing.T) {
+	t.Parallel()
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	saved := &fakeSaved{}
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{
+		"auth0|alice": proWithZonePrefs(t, "auth0|alice", "zone-1", true),
+	}}
+	d, notifs, push, _ := newDecisionHarness(t, zones, saved, profs)
+	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
+
+	if err := d.Dispatch(context.Background(), app); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("expected 1 decision record, got %d", len(notifs.created))
+	}
+	rec := notifs.created[0]
+	if rec.EventType != notifications.EventDecisionUpdate {
+		t.Errorf("event type: got %q, want DecisionUpdate", rec.EventType)
+	}
+	if rec.Decision == nil || *rec.Decision != "Permitted" {
+		t.Errorf("decision: got %v", rec.Decision)
+	}
+	if rec.WatchZoneID == nil || *rec.WatchZoneID != "zone-1" {
+		t.Errorf("zone id: got %v", rec.WatchZoneID)
+	}
+	if rec.Sources != sourceZone {
+		t.Errorf("sources: got %q, want Zone", rec.Sources)
+	}
+	if push.calls != 1 {
+		t.Errorf("paid tier with decision push opted in should push, got %d", push.calls)
+	}
+}
+
+func TestDecisionDispatcher_ZoneMatch_DecisionPushOptedOut_RecordButNoPush(t *testing.T) {
+	t.Parallel()
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{
+		"auth0|alice": proWithZonePrefs(t, "auth0|alice", "zone-1", false),
+	}}
+	d, notifs, push, _ := newDecisionHarness(t, zones, &fakeSaved{}, profs)
+	app := decisionApp(t, "Rejected", coord(51.5), coord(-0.1))
+
+	if err := d.Dispatch(context.Background(), app); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Errorf("record must be written even when decision push is opted out, got %d", len(notifs.created))
+	}
+	if push.calls != 0 {
+		t.Errorf("decision-push opt-out must suppress the push, got %d", push.calls)
+	}
+}
+
+func TestDecisionDispatcher_FreeTier_RecordNoPush(t *testing.T) {
+	t.Parallel()
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	free := profileWithTier(t, "auth0|alice", profiles.TierFree)
+	free.ZonePreferences["zone-1"] = profiles.ZonePreferences{DecisionPush: true}
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": free}}
+	d, notifs, push, _ := newDecisionHarness(t, zones, &fakeSaved{}, profs)
+	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
+
+	if err := d.Dispatch(context.Background(), app); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Errorf("free tier must still get the decision record, got %d", len(notifs.created))
+	}
+	if push.calls != 0 {
+		t.Errorf("free tier must NOT push, got %d", push.calls)
+	}
+}
+
+func TestDecisionDispatcher_SavedOnly_NilZoneSourcesSaved(t *testing.T) {
+	t.Parallel()
+	zones := &fakeZones{}
+	saved := &fakeSaved{userIDs: []string{"auth0|bob"}}
+	bob := profileWithTier(t, "auth0|bob", profiles.TierPro)
+	bob.Preferences.SavedDecisionPush = true
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|bob": bob}}
+	d, notifs, push, _ := newDecisionHarness(t, zones, saved, profs)
+	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
+
+	if err := d.Dispatch(context.Background(), app); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("expected 1 saved-decision record, got %d", len(notifs.created))
+	}
+	rec := notifs.created[0]
+	if rec.WatchZoneID != nil {
+		t.Errorf("saved-only record must have nil zone id, got %v", *rec.WatchZoneID)
+	}
+	if rec.Sources != sourceSaved {
+		t.Errorf("sources: got %q, want Saved", rec.Sources)
+	}
+	if push.calls != 1 {
+		t.Errorf("saved-decision push opted in should push, got %d", push.calls)
+	}
+}
+
+func TestDecisionDispatcher_ZoneAndSaved_MergesSources(t *testing.T) {
+	t.Parallel()
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	saved := &fakeSaved{userIDs: []string{"auth0|alice"}}
+	alice := proWithZonePrefs(t, "auth0|alice", "zone-1", true)
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": alice}}
+	d, notifs, _, _ := newDecisionHarness(t, zones, saved, profs)
+	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
+
+	if err := d.Dispatch(context.Background(), app); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("a user matched by both zone and saved must get ONE merged record, got %d", len(notifs.created))
+	}
+	rec := notifs.created[0]
+	if rec.Sources != sourceZone+","+sourceSaved {
+		t.Errorf("merged sources: got %q, want %q", rec.Sources, sourceZone+","+sourceSaved)
+	}
+	if rec.WatchZoneID == nil || *rec.WatchZoneID != "zone-1" {
+		t.Errorf("merged record should attribute the zone id: %v", rec.WatchZoneID)
+	}
+}
+
+func TestDecisionDispatcher_Idempotent_SkipsExisting(t *testing.T) {
+	t.Parallel()
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{
+		"auth0|alice": proWithZonePrefs(t, "auth0|alice", "zone-1", true),
+	}}
+	d, notifs, push, _ := newDecisionHarness(t, zones, &fakeSaved{}, profs)
+	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
+
+	if err := d.Dispatch(context.Background(), app); err != nil {
+		t.Fatalf("first Dispatch: %v", err)
+	}
+	if err := d.Dispatch(context.Background(), app); err != nil {
+		t.Fatalf("second Dispatch: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Errorf("re-dispatch must not double-create, got %d records", len(notifs.created))
+	}
+	if push.calls != 1 {
+		t.Errorf("re-dispatch must not double-push, got %d", push.calls)
+	}
+}
+
+func TestDecisionDispatcher_NoCoords_OnlySavedFanOut(t *testing.T) {
+	t.Parallel()
+	zones := &fakeZones{zones: []watchzones.WatchZone{
+		testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)),
+	}}
+	saved := &fakeSaved{userIDs: []string{"auth0|bob"}}
+	bob := profileWithTier(t, "auth0|bob", profiles.TierPro)
+	bob.Preferences.SavedDecisionPush = true
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|bob": bob}}
+	d, notifs, _, _ := newDecisionHarness(t, zones, saved, profs)
+	app := decisionApp(t, "Permitted", nil, nil)
+
+	if err := d.Dispatch(context.Background(), app); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	// No coordinates means the zone lookup must be skipped entirely; only the
+	// saved bookmark holder is notified.
+	if zones.lastLat != 0 || zones.lastLng != 0 {
+		t.Errorf("zone lookup should not run without coordinates")
+	}
+	if len(notifs.created) != 1 || notifs.created[0].UserID != "auth0|bob" {
+		t.Errorf("expected only the saved holder notified, got %+v", notifs.created)
+	}
+}

--- a/api-go/internal/notifydispatch/decision_test.go
+++ b/api-go/internal/notifydispatch/decision_test.go
@@ -62,10 +62,10 @@ func decisionApp(t *testing.T, decision string, lat, lng *float64) applications.
 
 func coord(v float64) *float64 { return &v }
 
-func proWithZonePrefs(t *testing.T, userID, zoneID string, decisionPush bool) *profiles.UserProfile {
+func proWithZonePrefs(t *testing.T, decisionPush bool) *profiles.UserProfile {
 	t.Helper()
-	p := profileWithTier(t, userID, profiles.TierPro)
-	p.ZonePreferences[zoneID] = profiles.ZonePreferences{
+	p := profileWithTier(t, "auth0|alice", profiles.TierPro)
+	p.ZonePreferences["zone-1"] = profiles.ZonePreferences{
 		NewApplicationPush: true,
 		DecisionPush:       decisionPush,
 	}
@@ -77,7 +77,7 @@ func newDecisionHarness(
 	zones *fakeZones,
 	saved *fakeSaved,
 	profs *fakeProfiles,
-) (*DecisionDispatcher, *fakeNotifications, *fakePush, *fakeDevices) {
+) (*DecisionDispatcher, *fakeNotifications, *fakePush) {
 	t.Helper()
 	notifs := newFakeNotifications()
 	devs := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
@@ -90,7 +90,7 @@ func newDecisionHarness(
 		func() string { return "n-fixed" },
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))
-	return d, notifs, push, devs
+	return d, notifs, push
 }
 
 func TestDecisionDispatcher_ZoneMatch_CreatesDecisionRecordAndPushes(t *testing.T) {
@@ -99,9 +99,9 @@ func TestDecisionDispatcher_ZoneMatch_CreatesDecisionRecordAndPushes(t *testing.
 	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
 	saved := &fakeSaved{}
 	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{
-		"auth0|alice": proWithZonePrefs(t, "auth0|alice", "zone-1", true),
+		"auth0|alice": proWithZonePrefs(t, true),
 	}}
-	d, notifs, push, _ := newDecisionHarness(t, zones, saved, profs)
+	d, notifs, push := newDecisionHarness(t, zones, saved, profs)
 	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
 
 	if err := d.Dispatch(context.Background(), app); err != nil {
@@ -133,9 +133,9 @@ func TestDecisionDispatcher_ZoneMatch_DecisionPushOptedOut_RecordButNoPush(t *te
 	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
 	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{
-		"auth0|alice": proWithZonePrefs(t, "auth0|alice", "zone-1", false),
+		"auth0|alice": proWithZonePrefs(t, false),
 	}}
-	d, notifs, push, _ := newDecisionHarness(t, zones, &fakeSaved{}, profs)
+	d, notifs, push := newDecisionHarness(t, zones, &fakeSaved{}, profs)
 	app := decisionApp(t, "Rejected", coord(51.5), coord(-0.1))
 
 	if err := d.Dispatch(context.Background(), app); err != nil {
@@ -156,7 +156,7 @@ func TestDecisionDispatcher_FreeTier_RecordNoPush(t *testing.T) {
 	free := profileWithTier(t, "auth0|alice", profiles.TierFree)
 	free.ZonePreferences["zone-1"] = profiles.ZonePreferences{DecisionPush: true}
 	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": free}}
-	d, notifs, push, _ := newDecisionHarness(t, zones, &fakeSaved{}, profs)
+	d, notifs, push := newDecisionHarness(t, zones, &fakeSaved{}, profs)
 	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
 
 	if err := d.Dispatch(context.Background(), app); err != nil {
@@ -177,7 +177,7 @@ func TestDecisionDispatcher_SavedOnly_NilZoneSourcesSaved(t *testing.T) {
 	bob := profileWithTier(t, "auth0|bob", profiles.TierPro)
 	bob.Preferences.SavedDecisionPush = true
 	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|bob": bob}}
-	d, notifs, push, _ := newDecisionHarness(t, zones, saved, profs)
+	d, notifs, push := newDecisionHarness(t, zones, saved, profs)
 	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
 
 	if err := d.Dispatch(context.Background(), app); err != nil {
@@ -203,9 +203,9 @@ func TestDecisionDispatcher_ZoneAndSaved_MergesSources(t *testing.T) {
 	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
 	saved := &fakeSaved{userIDs: []string{"auth0|alice"}}
-	alice := proWithZonePrefs(t, "auth0|alice", "zone-1", true)
+	alice := proWithZonePrefs(t, true)
 	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": alice}}
-	d, notifs, _, _ := newDecisionHarness(t, zones, saved, profs)
+	d, notifs, _ := newDecisionHarness(t, zones, saved, profs)
 	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
 
 	if err := d.Dispatch(context.Background(), app); err != nil {
@@ -228,9 +228,9 @@ func TestDecisionDispatcher_Idempotent_SkipsExisting(t *testing.T) {
 	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
 	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{
-		"auth0|alice": proWithZonePrefs(t, "auth0|alice", "zone-1", true),
+		"auth0|alice": proWithZonePrefs(t, true),
 	}}
-	d, notifs, push, _ := newDecisionHarness(t, zones, &fakeSaved{}, profs)
+	d, notifs, push := newDecisionHarness(t, zones, &fakeSaved{}, profs)
 	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
 
 	if err := d.Dispatch(context.Background(), app); err != nil {
@@ -256,7 +256,7 @@ func TestDecisionDispatcher_NoCoords_OnlySavedFanOut(t *testing.T) {
 	bob := profileWithTier(t, "auth0|bob", profiles.TierPro)
 	bob.Preferences.SavedDecisionPush = true
 	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|bob": bob}}
-	d, notifs, _, _ := newDecisionHarness(t, zones, saved, profs)
+	d, notifs, _ := newDecisionHarness(t, zones, saved, profs)
 	app := decisionApp(t, "Permitted", nil, nil)
 
 	if err := d.Dispatch(context.Background(), app); err != nil {

--- a/api-go/internal/notifydispatch/digest_roundtrip_test.go
+++ b/api-go/internal/notifydispatch/digest_roundtrip_test.go
@@ -1,0 +1,98 @@
+package notifydispatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// recordingContainer is a hand-written stand-in for the Cosmos container the
+// real notifications.DigestStore writes through. It captures upserts keyed by
+// partition and replays them on the single-partition query the digest reader
+// (ByUserSince) issues — enough to prove a poll-path-written record round-trips
+// through the digest read path unchanged.
+type recordingContainer struct {
+	stored map[string][][]byte // partitionKey -> raw document bodies
+}
+
+func newRecordingContainer() *recordingContainer {
+	return &recordingContainer{stored: map[string][][]byte{}}
+}
+
+func (c *recordingContainer) UpsertItem(_ context.Context, partitionKey string, item []byte) error {
+	cp := make([]byte, len(item))
+	copy(cp, item)
+	c.stored[partitionKey] = append(c.stored[partitionKey], cp)
+	return nil
+}
+
+func (c *recordingContainer) QueryItems(_ context.Context, partitionKey, _ string, _ map[string]any) ([][]byte, error) {
+	return c.stored[partitionKey], nil
+}
+
+func (c *recordingContainer) QueryItemsCrossPartition(_ context.Context, _ string, _ map[string]any) ([][]byte, error) {
+	return nil, nil
+}
+
+// TestEnqueuer_CreatedRecordIsDigestReadable is the load-bearing cross-package
+// proof for bead tc-uc2p: a notification the poll-path enqueuer creates lands in
+// the Notifications container in the exact shape the digest worker reads. We wire
+// the real *notifications.DigestStore over a fake container, enqueue, then read
+// the same bytes back through the digest's ByUserSince — the path the weekly
+// digest uses — and assert the application surfaces with its fields intact.
+func TestEnqueuer_CreatedRecordIsDigestReadable(t *testing.T) {
+	t.Parallel()
+	container := newRecordingContainer()
+	store := notifications.NewDigestStore(container)
+
+	profile := profileWithTier(t, "auth0|alice", profiles.TierFree) // Free: record only, no push
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": profile}}
+	devs := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{}}
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+
+	enq := NewEnqueuer(store, zones, profs, devs, &fakeState{}, &fakePush{},
+		func() string { return "n-roundtrip" },
+		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
+		testLogger(t))
+
+	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
+		t.Fatalf("EnqueueForApplication: %v", err)
+	}
+
+	// Read it back exactly as the weekly digest does.
+	since := time.Date(2026, 6, 6, 0, 0, 0, 0, time.UTC)
+	got, err := store.ByUserSince(context.Background(), "auth0|alice", since)
+	if err != nil {
+		t.Fatalf("ByUserSince: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("digest must read back exactly one record, got %d", len(got))
+	}
+	n := got[0]
+	if n.ID != "n-roundtrip" {
+		t.Errorf("id round-trip: got %q", n.ID)
+	}
+	if n.UserID != "auth0|alice" || n.ApplicationUID != "24/0001" || n.AuthorityID != 99 {
+		t.Errorf("core fields lost in round-trip: %+v", n)
+	}
+	if n.ApplicationAddress != "10 High St" || n.ApplicationDescription != "Loft conversion" {
+		t.Errorf("display fields lost in round-trip: %+v", n)
+	}
+	if n.WatchZoneID == nil || *n.WatchZoneID != "zone-1" {
+		t.Errorf("zone attribution lost: %+v", n.WatchZoneID)
+	}
+	if n.EventType != notifications.EventNewApplication {
+		t.Errorf("event type lost: got %q", n.EventType)
+	}
+	if n.EmailSent {
+		t.Error("a freshly enqueued record must be unsent so the hourly/weekly digest picks it up")
+	}
+}

--- a/api-go/internal/notifydispatch/digest_roundtrip_test.go
+++ b/api-go/internal/notifydispatch/digest_roundtrip_test.go
@@ -61,7 +61,7 @@ func TestEnqueuer_CreatedRecordIsDigestReadable(t *testing.T) {
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))
 
-	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
 
 	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
 		t.Fatalf("EnqueueForApplication: %v", err)

--- a/api-go/internal/notifydispatch/enqueuer.go
+++ b/api-go/internal/notifydispatch/enqueuer.go
@@ -71,9 +71,11 @@ type pushSender interface {
 // Enqueuer ports .NET DispatchNotificationCommandHandler: for a new application
 // that matched a watch zone, it dedups, creates the notification record (which
 // feeds the digest pipeline), and — for paid tiers with devices — sends an
-// instant push, pruning any device tokens APNs reports invalid.
+// instant push, pruning any device tokens APNs reports invalid. The higher-level
+// EnqueueForApplication runs the per-app zone fan-out the poll handler calls.
 type Enqueuer struct {
 	notifications notificationWriter
+	zones         zoneMatcher
 	profiles      profileReader
 	devices       deviceReader
 	state         stateReader
@@ -88,6 +90,7 @@ type Enqueuer struct {
 // can pin them.
 func NewEnqueuer(
 	notifs notificationWriter,
+	zones zoneMatcher,
 	profs profileReader,
 	devices deviceReader,
 	state stateReader,
@@ -98,6 +101,7 @@ func NewEnqueuer(
 ) *Enqueuer {
 	return &Enqueuer{
 		notifications: notifs,
+		zones:         zones,
 		profiles:      profs,
 		devices:       devices,
 		state:         state,
@@ -106,6 +110,33 @@ func NewEnqueuer(
 		now:           now,
 		logger:        logger,
 	}
+}
+
+// EnqueueForApplication runs the new-application zone fan-out for one polled
+// application: it finds every watch zone whose circle contains the application's
+// coordinates (cross-partition) and enqueues a NewApplication notification for
+// each zone created on or before the application's LastDifferent timestamp. A
+// zone created after the application last changed is skipped — its owner only
+// subscribes to changes from creation onward, so a back-dated application is not
+// "new" to them. An application without coordinates fans out to nothing.
+// Mirrors the .NET PollPlanItCommandHandler zone-fan-out loop (L212-226).
+func (e *Enqueuer) EnqueueForApplication(ctx context.Context, app applications.PlanningApplication) error {
+	if app.Latitude == nil || app.Longitude == nil {
+		return nil
+	}
+	zones, err := e.zones.FindZonesContaining(ctx, *app.Latitude, *app.Longitude)
+	if err != nil {
+		return err
+	}
+	for _, zone := range zones {
+		if zone.CreatedAt.After(app.LastDifferent) {
+			continue
+		}
+		if err := e.Enqueue(ctx, app, zone); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Enqueue runs the per-(zone, application) fan-out for a NewApplication event.

--- a/api-go/internal/notifydispatch/enqueuer.go
+++ b/api-go/internal/notifydispatch/enqueuer.go
@@ -1,0 +1,215 @@
+// Package notifydispatch is the poll-path notification fan-out: the per-app
+// orchestration the Go poll-sb handler runs after upserting a changed planning
+// application. It ports the two .NET command handlers the .NET
+// PollPlanItCommandHandler invokes per app — DispatchNotificationCommandHandler
+// (new-application zone fan-out) as the Enqueuer, and
+// DispatchDecisionEventCommandHandler (non-decision -> decision transition) as
+// the DecisionDispatcher.
+//
+// It lives in its own package, not in notifications, to avoid an import cycle:
+// the watchzones package already imports notifications (for the latest-unread
+// projection), and the dispatchers depend on watchzones, profiles,
+// devicetokens, notificationstate, savedapplications and the notifications
+// store. Keeping notifications a leaf store package and composing here is the
+// idiomatic Go resolution.
+//
+// Idempotency is the load-bearing property: every dispatch is gated on a
+// (userId, applicationUid, authorityId, eventType) dedup read, so a re-poll of
+// an unchanged application never double-notifies. Free-tier users get the
+// notification record (which feeds the weekly digest) but no instant push —
+// matching the server-enforced tier entitlement.
+package notifydispatch
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// notificationWriter is the consumer-side slice of the Notifications store the
+// dispatchers need: a dedup read and a create. *notifications.DigestStore
+// satisfies it.
+type notificationWriter interface {
+	GetByUserAndApplication(ctx context.Context, userID, applicationUID string, authorityID int, eventType notifications.EventType) (*notifications.DigestNotification, error)
+	Create(ctx context.Context, n notifications.DigestNotification) error
+}
+
+// profileReader loads a user's profile to read the tier (instant push is
+// paid-only) and the push preference. *profiles.CosmosStore satisfies it.
+type profileReader interface {
+	Get(ctx context.Context, userID string) (*profiles.UserProfile, error)
+}
+
+// deviceReader lists a user's device tokens for a push and prunes the ones APNs
+// reports permanently invalid. *devicetokens.CosmosStore satisfies it.
+type deviceReader interface {
+	ListByUser(ctx context.Context, userID string) ([]devicetokens.DeviceRegistration, error)
+	Delete(ctx context.Context, userID, token string) error
+}
+
+// stateReader supplies the unread-badge inputs: the read watermark and the
+// strictly-after-watermark count. *notificationstate.CosmosStore satisfies it.
+type stateReader interface {
+	Get(ctx context.Context, userID string) (*notificationstate.State, error)
+	UnreadCount(ctx context.Context, userID string, lastReadAt time.Time) (int, error)
+}
+
+// pushSender is the consumer-side push contract; apns.PushSender (the real
+// Client or the NoOpSender) satisfies it structurally.
+type pushSender interface {
+	Send(ctx context.Context, tokens []string, payload json.RawMessage) ([]string, error)
+}
+
+// Enqueuer ports .NET DispatchNotificationCommandHandler: for a new application
+// that matched a watch zone, it dedups, creates the notification record (which
+// feeds the digest pipeline), and — for paid tiers with devices — sends an
+// instant push, pruning any device tokens APNs reports invalid.
+type Enqueuer struct {
+	notifications notificationWriter
+	profiles      profileReader
+	devices       deviceReader
+	state         stateReader
+	push          pushSender
+	newID         func() string
+	now           func() time.Time
+	logger        *slog.Logger
+}
+
+// NewEnqueuer wires the enqueuer. newID mints the notification id (a GUID in
+// production); now stamps the record's creation time. Both are injected so tests
+// can pin them.
+func NewEnqueuer(
+	notifs notificationWriter,
+	profs profileReader,
+	devices deviceReader,
+	state stateReader,
+	push pushSender,
+	newID func() string,
+	now func() time.Time,
+	logger *slog.Logger,
+) *Enqueuer {
+	return &Enqueuer{
+		notifications: notifs,
+		profiles:      profs,
+		devices:       devices,
+		state:         state,
+		push:          push,
+		newID:         newID,
+		now:           now,
+		logger:        logger,
+	}
+}
+
+// Enqueue runs the per-(zone, application) fan-out for a NewApplication event.
+// It is idempotent: a re-poll that finds an existing notification for
+// (user, application, authority, NewApplication) is a no-op.
+func (e *Enqueuer) Enqueue(ctx context.Context, app applications.PlanningApplication, zone watchzones.WatchZone) error {
+	existing, err := e.notifications.GetByUserAndApplication(ctx, zone.UserID, app.UID, app.AreaID, notifications.EventNewApplication)
+	if err != nil {
+		return err
+	}
+	if existing != nil {
+		return nil
+	}
+
+	profile, err := e.profiles.Get(ctx, zone.UserID)
+	if err != nil {
+		// A missing profile is not a fan-out failure — the user may have been
+		// deleted between zone creation and this poll. Skip them, matching .NET's
+		// null-profile early return.
+		e.logger.WarnContext(ctx, "enqueue: profile unavailable, skipping", "user", zone.UserID, "error", err)
+		return nil
+	}
+	if profile == nil {
+		return nil
+	}
+
+	zoneID := zone.ID
+	n := newRecord(recordInput{
+		id:          e.newID(),
+		userID:      zone.UserID,
+		app:         app,
+		watchZoneID: &zoneID,
+		eventType:   notifications.EventNewApplication,
+		sources:     sourceZone,
+		now:         e.now().UTC(),
+	})
+
+	// Instant push is a paid-tier entitlement. Free-tier users still get the
+	// notification record (picked up by the weekly digest) but no push.
+	if profile.Tier.IsPaid() && profile.Preferences.PushEnabled {
+		n.PushSent = e.sendInstantPush(ctx, zone.UserID, n)
+	}
+
+	return e.notifications.Create(ctx, n)
+}
+
+// sendInstantPush loads the user's devices, sends the alert payload, prunes any
+// tokens APNs reports invalid, and reports whether a push was actually sent. A
+// user with no devices is a no-op (returns false). Every failure is logged and
+// swallowed — a push failure must not abort the record write, mirroring .NET.
+func (e *Enqueuer) sendInstantPush(ctx context.Context, userID string, n notifications.DigestNotification) bool {
+	devices, err := e.devices.ListByUser(ctx, userID)
+	if err != nil {
+		e.logger.ErrorContext(ctx, "instant push: load devices failed", "user", userID, "error", err)
+		return false
+	}
+	if len(devices) == 0 {
+		return false
+	}
+
+	badge := e.unreadBadge(ctx, userID)
+	payload, err := buildAlertPayload(n, badge)
+	if err != nil {
+		e.logger.ErrorContext(ctx, "instant push: build payload failed", "user", userID, "error", err)
+		return false
+	}
+
+	tokens := make([]string, 0, len(devices))
+	for _, d := range devices {
+		tokens = append(tokens, d.Token)
+	}
+
+	invalid, err := e.push.Send(ctx, tokens, payload)
+	if err != nil {
+		e.logger.ErrorContext(ctx, "instant push: send failed", "user", userID, "error", err)
+		return false
+	}
+	for _, token := range invalid {
+		if err := e.devices.Delete(ctx, userID, token); err != nil {
+			e.logger.WarnContext(ctx, "instant push: prune invalid token failed", "user", userID, "error", err)
+		}
+	}
+	return true
+}
+
+// unreadBadge computes the app-icon badge: the count of notifications created
+// strictly after the read watermark, plus 1 for the just-created notification
+// (not yet persisted but unread by construction). A first-touch user (no
+// watermark) starts at the Unix epoch so every notification counts, matching
+// .NET's DateTimeOffset.MinValue fallback + 1.
+func (e *Enqueuer) unreadBadge(ctx context.Context, userID string) int {
+	lastReadAt := time.Unix(0, 0).UTC()
+	st, err := e.state.Get(ctx, userID)
+	if err != nil {
+		e.logger.ErrorContext(ctx, "instant push: load notification state failed", "user", userID, "error", err)
+		return 1
+	}
+	if st != nil {
+		lastReadAt = st.LastReadAt
+	}
+	count, err := e.state.UnreadCount(ctx, userID, lastReadAt)
+	if err != nil {
+		e.logger.ErrorContext(ctx, "instant push: unread count failed", "user", userID, "error", err)
+		return 1
+	}
+	return count + 1
+}

--- a/api-go/internal/notifydispatch/enqueuer.go
+++ b/api-go/internal/notifydispatch/enqueuer.go
@@ -146,70 +146,13 @@ func (e *Enqueuer) Enqueue(ctx context.Context, app applications.PlanningApplica
 	// Instant push is a paid-tier entitlement. Free-tier users still get the
 	// notification record (picked up by the weekly digest) but no push.
 	if profile.Tier.IsPaid() && profile.Preferences.PushEnabled {
-		n.PushSent = e.sendInstantPush(ctx, zone.UserID, n)
+		n.PushSent = sendInstantPush(ctx, instantPushDeps{
+			devices: e.devices,
+			state:   e.state,
+			push:    e.push,
+			logger:  e.logger,
+		}, zone.UserID, n)
 	}
 
 	return e.notifications.Create(ctx, n)
-}
-
-// sendInstantPush loads the user's devices, sends the alert payload, prunes any
-// tokens APNs reports invalid, and reports whether a push was actually sent. A
-// user with no devices is a no-op (returns false). Every failure is logged and
-// swallowed — a push failure must not abort the record write, mirroring .NET.
-func (e *Enqueuer) sendInstantPush(ctx context.Context, userID string, n notifications.DigestNotification) bool {
-	devices, err := e.devices.ListByUser(ctx, userID)
-	if err != nil {
-		e.logger.ErrorContext(ctx, "instant push: load devices failed", "user", userID, "error", err)
-		return false
-	}
-	if len(devices) == 0 {
-		return false
-	}
-
-	badge := e.unreadBadge(ctx, userID)
-	payload, err := buildAlertPayload(n, badge)
-	if err != nil {
-		e.logger.ErrorContext(ctx, "instant push: build payload failed", "user", userID, "error", err)
-		return false
-	}
-
-	tokens := make([]string, 0, len(devices))
-	for _, d := range devices {
-		tokens = append(tokens, d.Token)
-	}
-
-	invalid, err := e.push.Send(ctx, tokens, payload)
-	if err != nil {
-		e.logger.ErrorContext(ctx, "instant push: send failed", "user", userID, "error", err)
-		return false
-	}
-	for _, token := range invalid {
-		if err := e.devices.Delete(ctx, userID, token); err != nil {
-			e.logger.WarnContext(ctx, "instant push: prune invalid token failed", "user", userID, "error", err)
-		}
-	}
-	return true
-}
-
-// unreadBadge computes the app-icon badge: the count of notifications created
-// strictly after the read watermark, plus 1 for the just-created notification
-// (not yet persisted but unread by construction). A first-touch user (no
-// watermark) starts at the Unix epoch so every notification counts, matching
-// .NET's DateTimeOffset.MinValue fallback + 1.
-func (e *Enqueuer) unreadBadge(ctx context.Context, userID string) int {
-	lastReadAt := time.Unix(0, 0).UTC()
-	st, err := e.state.Get(ctx, userID)
-	if err != nil {
-		e.logger.ErrorContext(ctx, "instant push: load notification state failed", "user", userID, "error", err)
-		return 1
-	}
-	if st != nil {
-		lastReadAt = st.LastReadAt
-	}
-	count, err := e.state.UnreadCount(ctx, userID, lastReadAt)
-	if err != nil {
-		e.logger.ErrorContext(ctx, "instant push: unread count failed", "user", userID, "error", err)
-		return 1
-	}
-	return count + 1
 }

--- a/api-go/internal/notifydispatch/enqueuer_test.go
+++ b/api-go/internal/notifydispatch/enqueuer_test.go
@@ -3,7 +3,6 @@ package notifydispatch
 import (
 	"context"
 	"encoding/json"
-	"io"
 	"log/slog"
 	"strconv"
 	"testing"
@@ -19,7 +18,7 @@ import (
 
 func testLogger(t *testing.T) *slog.Logger {
 	t.Helper()
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+	return slog.New(slog.DiscardHandler)
 }
 
 // fakeNotifications records created notifications and serves dedup lookups from
@@ -121,15 +120,15 @@ func profileWithTier(t *testing.T, userID string, tier profiles.SubscriptionTier
 	return p
 }
 
-func testApplication(t *testing.T, areaID int, name string, lat, lng float64, lastDifferent time.Time) applications.PlanningApplication {
+func testApplication(t *testing.T, lastDifferent time.Time) applications.PlanningApplication {
 	t.Helper()
-	la, lo := lat, lng
+	la, lo := 51.5, -0.1
 	state := "Pending"
 	return applications.PlanningApplication{
-		Name:          name,
-		UID:           name,
+		Name:          "24/0001",
+		UID:           "24/0001",
 		AreaName:      "Kingston",
-		AreaID:        areaID,
+		AreaID:        99,
 		Address:       "10 High St",
 		Description:   "Loft conversion",
 		AppState:      &state,
@@ -192,7 +191,7 @@ func TestEnqueuer_EnqueueForApplication_FansOutToContainingZones(t *testing.T) {
 		func() string { return "n-fixed" },
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))
-	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
 
 	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
 		t.Fatalf("EnqueueForApplication: %v", err)
@@ -213,7 +212,7 @@ func TestEnqueuer_EnqueueForApplication_OneUserTwoZonesDedupsToOneRecord(t *test
 	z2 := testZoneAt(t, "zone-2", "auth0|alice", time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC))
 	zones := &fakeZones{zones: []watchzones.WatchZone{z1, z2}}
 	enq, notifs, _, _ := newEnqueuerHarnessWithZones(t, profiles.TierPro, zones)
-	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
 
 	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
 		t.Fatalf("EnqueueForApplication: %v", err)
@@ -231,7 +230,7 @@ func TestEnqueuer_EnqueueForApplication_SkipsZonesCreatedAfterLastDifferent(t *t
 	after := testZoneAt(t, "zone-new", "auth0|alice", time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC))
 	zones := &fakeZones{zones: []watchzones.WatchZone{before, after}}
 	enq, notifs, _, _ := newEnqueuerHarnessWithZones(t, profiles.TierPro, zones)
-	app := testApplication(t, 99, "24/0001", 51.5, -0.1, lastDifferent)
+	app := testApplication(t, lastDifferent)
 
 	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
 		t.Fatalf("EnqueueForApplication: %v", err)
@@ -269,7 +268,7 @@ func TestEnqueuer_EnqueueForApplication_NoCoordsSkipsLookup(t *testing.T) {
 func TestEnqueuer_PaidTier_CreatesRecordAndPushes(t *testing.T) {
 	t.Parallel()
 	enq, notifs, push := newEnqueuerHarness(t, profiles.TierPro)
-	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
 	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 
 	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
@@ -299,7 +298,7 @@ func TestEnqueuer_PaidTier_CreatesRecordAndPushes(t *testing.T) {
 func TestEnqueuer_FreeTier_CreatesRecordNoPush(t *testing.T) {
 	t.Parallel()
 	enq, notifs, push := newEnqueuerHarness(t, profiles.TierFree)
-	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
 	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 
 	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
@@ -316,7 +315,7 @@ func TestEnqueuer_FreeTier_CreatesRecordNoPush(t *testing.T) {
 func TestEnqueuer_Dedup_SkipsWhenAlreadyNotified(t *testing.T) {
 	t.Parallel()
 	enq, notifs, push := newEnqueuerHarness(t, profiles.TierPro)
-	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
 	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 
 	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
@@ -336,7 +335,7 @@ func TestEnqueuer_Dedup_SkipsWhenAlreadyNotified(t *testing.T) {
 func TestEnqueuer_UnknownProfile_NoRecord(t *testing.T) {
 	t.Parallel()
 	enq, notifs, push := newEnqueuerHarness(t, profiles.TierPro)
-	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
 	zone := testZoneAt(t, "zone-1", "auth0|stranger", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 
 	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
@@ -362,7 +361,7 @@ func TestEnqueuer_PaidTier_NoDevicesStillWritesRecord(t *testing.T) {
 		func() string { return "n-1" },
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))
-	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
 	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 
 	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
@@ -390,7 +389,7 @@ func TestEnqueuer_PrunesInvalidTokens(t *testing.T) {
 		func() string { return "n-1" },
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))
-	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
 	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
 
 	if err := enq.Enqueue(context.Background(), app, zone); err != nil {

--- a/api-go/internal/notifydispatch/enqueuer_test.go
+++ b/api-go/internal/notifydispatch/enqueuer_test.go
@@ -1,0 +1,301 @@
+package notifydispatch
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+func testLogger(t *testing.T) *slog.Logger {
+	t.Helper()
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// fakeNotifications records created notifications and serves dedup lookups from
+// an in-memory map keyed by (userId, uid, authorityId, eventType).
+type fakeNotifications struct {
+	created   []notifications.DigestNotification
+	existing  map[string]notifications.DigestNotification
+	createErr error
+}
+
+func newFakeNotifications() *fakeNotifications {
+	return &fakeNotifications{existing: map[string]notifications.DigestNotification{}}
+}
+
+func dedupKey(userID, uid string, authorityID int, eventType notifications.EventType) string {
+	return userID + "|" + uid + "|" + string(eventType) + "|" + strconv.Itoa(authorityID)
+}
+
+func (f *fakeNotifications) Create(_ context.Context, n notifications.DigestNotification) error {
+	if f.createErr != nil {
+		return f.createErr
+	}
+	f.created = append(f.created, n)
+	f.existing[dedupKey(n.UserID, n.ApplicationUID, n.AuthorityID, n.EventType)] = n
+	return nil
+}
+
+func (f *fakeNotifications) GetByUserAndApplication(_ context.Context, userID, uid string, authorityID int, eventType notifications.EventType) (*notifications.DigestNotification, error) {
+	if n, ok := f.existing[dedupKey(userID, uid, authorityID, eventType)]; ok {
+		return &n, nil
+	}
+	return nil, nil
+}
+
+// fakeProfiles serves user profiles by id.
+type fakeProfiles struct {
+	byID map[string]*profiles.UserProfile
+}
+
+func (f *fakeProfiles) Get(_ context.Context, userID string) (*profiles.UserProfile, error) {
+	if p, ok := f.byID[userID]; ok {
+		return p, nil
+	}
+	return nil, profiles.ErrNotFound
+}
+
+// fakeDevices serves device tokens and records pruned ones.
+type fakeDevices struct {
+	byUser  map[string][]devicetokens.DeviceRegistration
+	deleted []string
+}
+
+func (f *fakeDevices) ListByUser(_ context.Context, userID string) ([]devicetokens.DeviceRegistration, error) {
+	return f.byUser[userID], nil
+}
+
+func (f *fakeDevices) Delete(_ context.Context, _, token string) error {
+	f.deleted = append(f.deleted, token)
+	return nil
+}
+
+// fakeState serves the read-watermark and unread count.
+type fakeState struct {
+	state  *notificationstate.State
+	unread int
+}
+
+func (f *fakeState) Get(_ context.Context, _ string) (*notificationstate.State, error) {
+	return f.state, nil
+}
+
+func (f *fakeState) UnreadCount(_ context.Context, _ string, _ time.Time) (int, error) {
+	return f.unread, nil
+}
+
+// fakePush records the payloads it was asked to send and which devices it
+// returns as invalid.
+type fakePush struct {
+	calls    int
+	tokens   []string
+	payloads []json.RawMessage
+	invalid  []string
+}
+
+func (f *fakePush) Send(_ context.Context, tokens []string, payload json.RawMessage) ([]string, error) {
+	f.calls++
+	f.tokens = append(f.tokens, tokens...)
+	f.payloads = append(f.payloads, payload)
+	return f.invalid, nil
+}
+
+func profileWithTier(t *testing.T, userID string, tier profiles.SubscriptionTier) *profiles.UserProfile {
+	t.Helper()
+	p, err := profiles.NewProfile(userID, "", time.Now())
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	p.Tier = tier
+	return p
+}
+
+func testApplication(t *testing.T, areaID int, name string, lat, lng float64, lastDifferent time.Time) applications.PlanningApplication {
+	t.Helper()
+	la, lo := lat, lng
+	state := "Pending"
+	return applications.PlanningApplication{
+		Name:          name,
+		UID:           name,
+		AreaName:      "Kingston",
+		AreaID:        areaID,
+		Address:       "10 High St",
+		Description:   "Loft conversion",
+		AppState:      &state,
+		Latitude:      &la,
+		Longitude:     &lo,
+		LastDifferent: lastDifferent,
+	}
+}
+
+func testZoneAt(t *testing.T, id, userID string, createdAt time.Time) watchzones.WatchZone {
+	t.Helper()
+	z, err := watchzones.NewWatchZone(id, userID, "My Zone", 51.5, -0.1, 500, 99, createdAt, true, true)
+	if err != nil {
+		t.Fatalf("NewWatchZone: %v", err)
+	}
+	return z
+}
+
+func newEnqueuerHarness(t *testing.T, tier profiles.SubscriptionTier) (*Enqueuer, *fakeNotifications, *fakePush) {
+	t.Helper()
+	notifs := newFakeNotifications()
+	profile := profileWithTier(t, "auth0|alice", tier)
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": profile}}
+	devs := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
+		"auth0|alice": {{Token: "tok-1"}},
+	}}
+	st := &fakeState{unread: 2}
+	push := &fakePush{}
+	enq := NewEnqueuer(notifs, profs, devs, st, push,
+		func() string { return "n-fixed" },
+		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
+		testLogger(t))
+	return enq, notifs, push
+}
+
+func TestEnqueuer_PaidTier_CreatesRecordAndPushes(t *testing.T) {
+	t.Parallel()
+	enq, notifs, push := newEnqueuerHarness(t, profiles.TierPro)
+	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("expected 1 created record, got %d", len(notifs.created))
+	}
+	rec := notifs.created[0]
+	if rec.UserID != "auth0|alice" || rec.ApplicationUID != "24/0001" || rec.AuthorityID != 99 {
+		t.Errorf("record fields: %+v", rec)
+	}
+	if rec.WatchZoneID == nil || *rec.WatchZoneID != "zone-1" {
+		t.Errorf("record should carry the matching zone id: %+v", rec.WatchZoneID)
+	}
+	if rec.EventType != notifications.EventNewApplication {
+		t.Errorf("event type: got %q, want NewApplication", rec.EventType)
+	}
+	if push.calls != 1 {
+		t.Errorf("paid tier should push exactly once, got %d", push.calls)
+	}
+	if len(push.tokens) != 1 || push.tokens[0] != "tok-1" {
+		t.Errorf("push tokens: got %v", push.tokens)
+	}
+}
+
+func TestEnqueuer_FreeTier_CreatesRecordNoPush(t *testing.T) {
+	t.Parallel()
+	enq, notifs, push := newEnqueuerHarness(t, profiles.TierFree)
+	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("free tier must still create the digest record, got %d", len(notifs.created))
+	}
+	if push.calls != 0 {
+		t.Errorf("free tier must NOT push, got %d calls", push.calls)
+	}
+}
+
+func TestEnqueuer_Dedup_SkipsWhenAlreadyNotified(t *testing.T) {
+	t.Parallel()
+	enq, notifs, push := newEnqueuerHarness(t, profiles.TierPro)
+	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("first Enqueue: %v", err)
+	}
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("second Enqueue: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Errorf("re-enqueue must not double-create, got %d records", len(notifs.created))
+	}
+	if push.calls != 1 {
+		t.Errorf("re-enqueue must not double-push, got %d calls", push.calls)
+	}
+}
+
+func TestEnqueuer_UnknownProfile_NoRecord(t *testing.T) {
+	t.Parallel()
+	enq, notifs, push := newEnqueuerHarness(t, profiles.TierPro)
+	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	zone := testZoneAt(t, "zone-1", "auth0|stranger", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(notifs.created) != 0 {
+		t.Errorf("unknown profile must not create a record, got %d", len(notifs.created))
+	}
+	if push.calls != 0 {
+		t.Errorf("unknown profile must not push, got %d", push.calls)
+	}
+}
+
+func TestEnqueuer_PaidTier_NoDevicesStillWritesRecord(t *testing.T) {
+	t.Parallel()
+	notifs := newFakeNotifications()
+	profile := profileWithTier(t, "auth0|alice", profiles.TierPersonal)
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": profile}}
+	devs := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{}}
+	st := &fakeState{}
+	push := &fakePush{}
+	enq := NewEnqueuer(notifs, profs, devs, st, push,
+		func() string { return "n-1" },
+		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
+		testLogger(t))
+	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Errorf("record must be written even when there are no devices to push to, got %d", len(notifs.created))
+	}
+	if push.calls != 0 {
+		t.Errorf("no devices means no push call, got %d", push.calls)
+	}
+}
+
+func TestEnqueuer_PrunesInvalidTokens(t *testing.T) {
+	t.Parallel()
+	notifs := newFakeNotifications()
+	profile := profileWithTier(t, "auth0|alice", profiles.TierPro)
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": profile}}
+	devs := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
+		"auth0|alice": {{Token: "good"}, {Token: "stale"}},
+	}}
+	st := &fakeState{}
+	push := &fakePush{invalid: []string{"stale"}}
+	enq := NewEnqueuer(notifs, profs, devs, st, push,
+		func() string { return "n-1" },
+		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
+		testLogger(t))
+	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(devs.deleted) != 1 || devs.deleted[0] != "stale" {
+		t.Errorf("invalid token should be pruned: got %v", devs.deleted)
+	}
+}

--- a/api-go/internal/notifydispatch/enqueuer_test.go
+++ b/api-go/internal/notifydispatch/enqueuer_test.go
@@ -150,6 +150,12 @@ func testZoneAt(t *testing.T, id, userID string, createdAt time.Time) watchzones
 
 func newEnqueuerHarness(t *testing.T, tier profiles.SubscriptionTier) (*Enqueuer, *fakeNotifications, *fakePush) {
 	t.Helper()
+	enq, notifs, push, _ := newEnqueuerHarnessWithZones(t, tier, nil)
+	return enq, notifs, push
+}
+
+func newEnqueuerHarnessWithZones(t *testing.T, tier profiles.SubscriptionTier, zones *fakeZones) (*Enqueuer, *fakeNotifications, *fakePush, *fakeZones) {
+	t.Helper()
 	notifs := newFakeNotifications()
 	profile := profileWithTier(t, "auth0|alice", tier)
 	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": profile}}
@@ -158,11 +164,106 @@ func newEnqueuerHarness(t *testing.T, tier profiles.SubscriptionTier) (*Enqueuer
 	}}
 	st := &fakeState{unread: 2}
 	push := &fakePush{}
-	enq := NewEnqueuer(notifs, profs, devs, st, push,
+	if zones == nil {
+		zones = &fakeZones{}
+	}
+	enq := NewEnqueuer(notifs, zones, profs, devs, st, push,
 		func() string { return "n-fixed" },
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))
-	return enq, notifs, push
+	return enq, notifs, push, zones
+}
+
+func TestEnqueuer_EnqueueForApplication_FansOutToContainingZones(t *testing.T) {
+	t.Parallel()
+	// Two zones (different owners) contain the point; the enqueuer must fan out
+	// to both users.
+	z1 := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	z2 := testZoneAt(t, "zone-2", "auth0|bob", time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{z1, z2}}
+	notifs := newFakeNotifications()
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{
+		"auth0|alice": profileWithTier(t, "auth0|alice", profiles.TierPro),
+		"auth0|bob":   profileWithTier(t, "auth0|bob", profiles.TierPro),
+	}}
+	devs := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{}}
+	fz := zones
+	enq := NewEnqueuer(notifs, zones, profs, devs, &fakeState{}, &fakePush{},
+		func() string { return "n-fixed" },
+		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
+		testLogger(t))
+	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
+		t.Fatalf("EnqueueForApplication: %v", err)
+	}
+	if fz.lastLat != 51.5 || fz.lastLng != -0.1 {
+		t.Errorf("zone lookup point: got lat=%v lng=%v", fz.lastLat, fz.lastLng)
+	}
+	if len(notifs.created) != 2 {
+		t.Errorf("expected one record per containing zone owner, got %d", len(notifs.created))
+	}
+}
+
+func TestEnqueuer_EnqueueForApplication_OneUserTwoZonesDedupsToOneRecord(t *testing.T) {
+	t.Parallel()
+	// A single user with two containing zones must still get ONE NewApplication
+	// notification — dedup is per (user, application, authority), not per zone.
+	z1 := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	z2 := testZoneAt(t, "zone-2", "auth0|alice", time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{z1, z2}}
+	enq, notifs, _, _ := newEnqueuerHarnessWithZones(t, profiles.TierPro, zones)
+	app := testApplication(t, 99, "24/0001", 51.5, -0.1, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
+		t.Fatalf("EnqueueForApplication: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Errorf("one user with two zones must dedup to one record, got %d", len(notifs.created))
+	}
+}
+
+func TestEnqueuer_EnqueueForApplication_SkipsZonesCreatedAfterLastDifferent(t *testing.T) {
+	t.Parallel()
+	lastDifferent := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	// One zone created before the change (eligible), one created after (skip).
+	before := testZoneAt(t, "zone-old", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	after := testZoneAt(t, "zone-new", "auth0|alice", time.Date(2026, 6, 12, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{before, after}}
+	enq, notifs, _, _ := newEnqueuerHarnessWithZones(t, profiles.TierPro, zones)
+	app := testApplication(t, 99, "24/0001", 51.5, -0.1, lastDifferent)
+
+	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
+		t.Fatalf("EnqueueForApplication: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("only zones created on/before LastDifferent should fan out, got %d", len(notifs.created))
+	}
+	if notifs.created[0].WatchZoneID == nil || *notifs.created[0].WatchZoneID != "zone-old" {
+		t.Errorf("wrong zone fanned out: %+v", notifs.created[0].WatchZoneID)
+	}
+}
+
+func TestEnqueuer_EnqueueForApplication_NoCoordsSkipsLookup(t *testing.T) {
+	t.Parallel()
+	zones := &fakeZones{zones: []watchzones.WatchZone{
+		testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)),
+	}}
+	enq, notifs, _, fz := newEnqueuerHarnessWithZones(t, profiles.TierPro, zones)
+	app := applications.PlanningApplication{
+		Name: "24/0001", UID: "24/0001", AreaID: 99,
+		LastDifferent: time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC),
+	}
+
+	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
+		t.Fatalf("EnqueueForApplication: %v", err)
+	}
+	if fz.lastLat != 0 || fz.lastLng != 0 {
+		t.Errorf("zone lookup must be skipped when the application has no coordinates")
+	}
+	if len(notifs.created) != 0 {
+		t.Errorf("no coordinates means no fan-out, got %d", len(notifs.created))
+	}
 }
 
 func TestEnqueuer_PaidTier_CreatesRecordAndPushes(t *testing.T) {
@@ -257,7 +358,7 @@ func TestEnqueuer_PaidTier_NoDevicesStillWritesRecord(t *testing.T) {
 	devs := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{}}
 	st := &fakeState{}
 	push := &fakePush{}
-	enq := NewEnqueuer(notifs, profs, devs, st, push,
+	enq := NewEnqueuer(notifs, &fakeZones{}, profs, devs, st, push,
 		func() string { return "n-1" },
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))
@@ -285,7 +386,7 @@ func TestEnqueuer_PrunesInvalidTokens(t *testing.T) {
 	}}
 	st := &fakeState{}
 	push := &fakePush{invalid: []string{"stale"}}
-	enq := NewEnqueuer(notifs, profs, devs, st, push,
+	enq := NewEnqueuer(notifs, &fakeZones{}, profs, devs, st, push,
 		func() string { return "n-1" },
 		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
 		testLogger(t))

--- a/api-go/internal/notifydispatch/payload.go
+++ b/api-go/internal/notifydispatch/payload.go
@@ -1,0 +1,99 @@
+package notifydispatch
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// apnsAlertPayload is the APNs body for a single-notification (instant) push.
+// The JSON keys reproduce the .NET ApnsAlertPayload / ApnsAlertAps /
+// ApnsAlertContent shapes exactly so the iOS client receives an unchanged
+// payload across the cutover: the top-level notificationId / applicationRef /
+// authorityId / createdAt fields are the deep-link metadata iOS reads.
+type apnsAlertPayload struct {
+	Aps            apnsAlertAps        `json:"aps"`
+	NotificationID string              `json:"notificationId"`
+	ApplicationRef string              `json:"applicationRef"`
+	AuthorityID    int                 `json:"authorityId"`
+	CreatedAt      platform.DotNetTime `json:"createdAt"`
+}
+
+type apnsAlertAps struct {
+	Alert apnsAlertContent `json:"alert"`
+	Sound string           `json:"sound"`
+	Badge int              `json:"badge"`
+}
+
+type apnsAlertContent struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+// buildAlertPayload renders the instant-push body for a notification, mirroring
+// .NET ApnsPushNotificationSender.BuildAlertPayload: a zone-matched notification
+// is titled "Planning update near you", a saved-only one "Town Crier"; a decision
+// update body appends the UK display label, otherwise the body is the address.
+// totalUnreadCount is the app-icon badge.
+func buildAlertPayload(n notifications.DigestNotification, totalUnreadCount int) (json.RawMessage, error) {
+	title := "Town Crier"
+	if n.WatchZoneID != nil {
+		title = "Planning update near you"
+	}
+	body := n.ApplicationAddress
+	if n.EventType == notifications.EventDecisionUpdate {
+		body = buildDecisionBody(n)
+	}
+
+	raw, err := json.Marshal(apnsAlertPayload{
+		Aps: apnsAlertAps{
+			Alert: apnsAlertContent{Title: title, Body: body},
+			Sound: "default",
+			Badge: totalUnreadCount,
+		},
+		NotificationID: n.ID,
+		ApplicationRef: n.ApplicationName,
+		AuthorityID:    n.AuthorityID,
+		CreatedAt:      platform.DotNetTime(n.CreatedAt),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal alert payload: %w", err)
+	}
+	return raw, nil
+}
+
+// buildDecisionBody appends the UK display label to the address for a decision
+// update ("10 High St — Approved"), falling back to the bare address when the
+// decision string is empty or unrecognised. Mirrors .NET BuildDecisionBody.
+func buildDecisionBody(n notifications.DigestNotification) string {
+	label := ukDisplayString(n.Decision)
+	if label == "" {
+		return n.ApplicationAddress
+	}
+	return n.ApplicationAddress + " — " + label
+}
+
+// ukDisplayString maps a raw PlanIt app_state to the UK planning term residents
+// recognise, returning "" for a nil or unrecognised input. Port of .NET
+// UkPlanningVocabulary.GetDisplayString (matches the digest worker's copy).
+func ukDisplayString(planItAppState *string) string {
+	if planItAppState == nil {
+		return ""
+	}
+	state := strings.TrimSpace(*planItAppState)
+	switch {
+	case strings.EqualFold(state, "Permitted"):
+		return "Approved"
+	case strings.EqualFold(state, "Conditions"):
+		return "Approved with conditions"
+	case strings.EqualFold(state, "Rejected"):
+		return "Refused"
+	case strings.EqualFold(state, "Appealed"):
+		return "Refusal appealed"
+	default:
+		return ""
+	}
+}

--- a/api-go/internal/notifydispatch/push.go
+++ b/api-go/internal/notifydispatch/push.go
@@ -1,0 +1,80 @@
+package notifydispatch
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+)
+
+// instantPushDeps bundles the collaborators a single-notification push needs, so
+// the enqueuer and decision dispatcher share one push path rather than each
+// re-implementing device load + badge + send + prune.
+type instantPushDeps struct {
+	devices deviceReader
+	state   stateReader
+	push    pushSender
+	logger  *slog.Logger
+}
+
+// sendInstantPush loads the user's devices, builds the alert payload, sends it,
+// prunes any tokens APNs reports invalid, and reports whether a push was actually
+// sent. A user with no devices is a no-op (false). Every failure is logged and
+// swallowed — a push failure must not abort the record write, mirroring .NET.
+func sendInstantPush(ctx context.Context, deps instantPushDeps, userID string, n notifications.DigestNotification) bool {
+	devices, err := deps.devices.ListByUser(ctx, userID)
+	if err != nil {
+		deps.logger.ErrorContext(ctx, "instant push: load devices failed", "user", userID, "error", err)
+		return false
+	}
+	if len(devices) == 0 {
+		return false
+	}
+
+	badge := unreadBadge(ctx, deps.state, deps.logger, userID)
+	payload, err := buildAlertPayload(n, badge)
+	if err != nil {
+		deps.logger.ErrorContext(ctx, "instant push: build payload failed", "user", userID, "error", err)
+		return false
+	}
+
+	tokens := make([]string, 0, len(devices))
+	for _, d := range devices {
+		tokens = append(tokens, d.Token)
+	}
+
+	invalid, err := deps.push.Send(ctx, tokens, payload)
+	if err != nil {
+		deps.logger.ErrorContext(ctx, "instant push: send failed", "user", userID, "error", err)
+		return false
+	}
+	for _, token := range invalid {
+		if err := deps.devices.Delete(ctx, userID, token); err != nil {
+			deps.logger.WarnContext(ctx, "instant push: prune invalid token failed", "user", userID, "error", err)
+		}
+	}
+	return true
+}
+
+// unreadBadge computes the app-icon badge: notifications created strictly after
+// the read watermark plus 1 for the just-created notification (not yet persisted
+// but unread by construction). A first-touch user (no watermark) starts at the
+// Unix epoch so everything counts, matching .NET's MinValue + 1.
+func unreadBadge(ctx context.Context, state stateReader, logger *slog.Logger, userID string) int {
+	lastReadAt := time.Unix(0, 0).UTC()
+	st, err := state.Get(ctx, userID)
+	if err != nil {
+		logger.ErrorContext(ctx, "instant push: load notification state failed", "user", userID, "error", err)
+		return 1
+	}
+	if st != nil {
+		lastReadAt = st.LastReadAt
+	}
+	count, err := state.UnreadCount(ctx, userID, lastReadAt)
+	if err != nil {
+		logger.ErrorContext(ctx, "instant push: unread count failed", "user", userID, "error", err)
+		return 1
+	}
+	return count + 1
+}

--- a/api-go/internal/notifydispatch/record.go
+++ b/api-go/internal/notifydispatch/record.go
@@ -1,0 +1,55 @@
+package notifydispatch
+
+import (
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+)
+
+// NotificationSources values reproduce the .NET NotificationSources flag names
+// (comma-joined when both apply), preserved verbatim because the stored sources
+// string is read by the digest worker's HasSavedSource check and the web API.
+const (
+	sourceZone  = "Zone"
+	sourceSaved = "Saved"
+)
+
+// recordInput collects the fields needed to mint a notification record, so the
+// enqueuer and decision dispatcher build the digest-readable record the same way.
+type recordInput struct {
+	id          string
+	userID      string
+	app         applications.PlanningApplication
+	watchZoneID *string
+	eventType   notifications.EventType
+	sources     string
+	now         time.Time
+}
+
+// newRecord builds the notification record from a polled application. The result
+// is a notifications.DigestNotification — the exact shape the digest worker reads
+// (ByUserSince / UnsentEmailsByUser) and writes — so a record created here flows
+// into the weekly and hourly digests unchanged. It mirrors .NET
+// Notification.Create: a decision update carries the PlanIt app_state string, a
+// new application leaves Decision nil.
+func newRecord(in recordInput) notifications.DigestNotification {
+	n := notifications.DigestNotification{
+		ID:                     in.id,
+		UserID:                 in.userID,
+		ApplicationUID:         in.app.UID,
+		ApplicationName:        in.app.Name,
+		WatchZoneID:            in.watchZoneID,
+		ApplicationAddress:     in.app.Address,
+		ApplicationDescription: in.app.Description,
+		ApplicationType:        in.app.AppType,
+		AuthorityID:            in.app.AreaID,
+		EventType:              in.eventType,
+		Sources:                in.sources,
+		CreatedAt:              in.now,
+	}
+	if in.eventType == notifications.EventDecisionUpdate {
+		n.Decision = in.app.AppState
+	}
+	return n
+}

--- a/api-go/internal/polling/fanout_test.go
+++ b/api-go/internal/polling/fanout_test.go
@@ -1,0 +1,180 @@
+package polling
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+// fakeDecisionDispatcher records the applications it was asked to dispatch a
+// decision event for.
+type fakeDecisionDispatcher struct {
+	mu         sync.Mutex
+	dispatched []applications.PlanningApplication
+}
+
+func (f *fakeDecisionDispatcher) Dispatch(_ context.Context, app applications.PlanningApplication) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.dispatched = append(f.dispatched, app)
+	return nil
+}
+
+func (f *fakeDecisionDispatcher) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.dispatched)
+}
+
+// fakeEnqueuer records the applications it was asked to fan out to watch zones.
+type fakeEnqueuer struct {
+	mu       sync.Mutex
+	enqueued []applications.PlanningApplication
+}
+
+func (f *fakeEnqueuer) EnqueueForApplication(_ context.Context, app applications.PlanningApplication) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.enqueued = append(f.enqueued, app)
+	return nil
+}
+
+func (f *fakeEnqueuer) count() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.enqueued)
+}
+
+func decisionApp(name string, areaID int, appState string, lastDifferent time.Time) applications.PlanningApplication {
+	s := appState
+	return applications.PlanningApplication{
+		Name:          name,
+		UID:           name + "/FUL",
+		AreaName:      "Area",
+		AreaID:        areaID,
+		Address:       "1 St",
+		Description:   "d",
+		AppState:      &s,
+		LastDifferent: lastDifferent,
+	}
+}
+
+func TestHandler_FanOut_EnqueuesEveryUpsertedApplication(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	pi.pages[pageKey{99, 1}] = planitPage(decisionApp("24/0001", 99, "Undecided", ld))
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	disp := &fakeDecisionDispatcher{}
+	enq := &fakeEnqueuer{}
+	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts(), disp, enq)
+
+	if _, err := h.Handle(context.Background()); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if enq.count() != 1 {
+		t.Errorf("every upserted application must be enqueued for zone fan-out, got %d", enq.count())
+	}
+}
+
+func TestHandler_FanOut_DispatchesDecisionOnTransitionExactlyOnce(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	// Incoming app is in a decision state (Permitted).
+	pi.pages[pageKey{99, 1}] = planitPage(decisionApp("24/0001", 99, "Permitted", ld))
+	apps := newFakeApps()
+	// Existing record is NOT in a decision state — so this is a new-decision transition.
+	existing := decisionApp("24/0001", 99, "Undecided", ld.Add(-time.Hour))
+	apps.existing["24/0001/FUL"] = existing
+	state := newFakeStateStore()
+	disp := &fakeDecisionDispatcher{}
+	enq := &fakeEnqueuer{}
+	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts(), disp, enq)
+
+	if _, err := h.Handle(context.Background()); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if disp.count() != 1 {
+		t.Errorf("non-decision -> decision transition must dispatch exactly once, got %d", disp.count())
+	}
+}
+
+func TestHandler_FanOut_NoDecisionDispatchWhenAlreadyDecided(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	// Incoming app is Conditions (a decision state) but the existing record was
+	// ALREADY in a decision state (Permitted) — no transition, so no dispatch.
+	pi.pages[pageKey{99, 1}] = planitPage(decisionApp("24/0001", 99, "Conditions", ld))
+	apps := newFakeApps()
+	apps.existing["24/0001/FUL"] = decisionApp("24/0001", 99, "Permitted", ld.Add(-time.Hour))
+	state := newFakeStateStore()
+	disp := &fakeDecisionDispatcher{}
+	enq := &fakeEnqueuer{}
+	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts(), disp, enq)
+
+	if _, err := h.Handle(context.Background()); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if disp.count() != 0 {
+		t.Errorf("decision->decision change is not a new transition, got %d dispatches", disp.count())
+	}
+	// It is still a business-field change, so it is upserted and enqueued.
+	if enq.count() != 1 {
+		t.Errorf("the changed application should still be enqueued, got %d", enq.count())
+	}
+}
+
+func TestHandler_FanOut_FirstSeenDecidedAppCountsAsTransition(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	// First-time insert that arrives already decided (no existing record) counts
+	// as a transition, mirroring .NET (existing == null).
+	pi.pages[pageKey{99, 1}] = planitPage(decisionApp("24/0001", 99, "Rejected", ld))
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	disp := &fakeDecisionDispatcher{}
+	enq := &fakeEnqueuer{}
+	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts(), disp, enq)
+
+	if _, err := h.Handle(context.Background()); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if disp.count() != 1 {
+		t.Errorf("a first-seen already-decided app counts as a transition, got %d", disp.count())
+	}
+}
+
+func TestHandler_FanOut_SkipsUnchangedReindex(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	app := decisionApp("24/0001", 99, "Permitted", ld)
+	pi.pages[pageKey{99, 1}] = planitPage(app)
+	apps := newFakeApps()
+	// Identical business fields already stored (only LastDifferent differs) —
+	// the reindex-flood guard must skip both upsert AND fan-out.
+	existing := app
+	existing.LastDifferent = ld.Add(-time.Hour)
+	apps.existing["24/0001/FUL"] = existing
+	state := newFakeStateStore()
+	disp := &fakeDecisionDispatcher{}
+	enq := &fakeEnqueuer{}
+	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts(), disp, enq)
+
+	if _, err := h.Handle(context.Background()); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if len(apps.upserts) != 0 {
+		t.Errorf("unchanged reindex must not upsert, got %d", len(apps.upserts))
+	}
+	if disp.count() != 0 || enq.count() != 0 {
+		t.Errorf("unchanged reindex must not dispatch or enqueue: dispatch=%d enqueue=%d", disp.count(), enq.count())
+	}
+}

--- a/api-go/internal/polling/fanout_test.go
+++ b/api-go/internal/polling/fanout_test.go
@@ -48,13 +48,13 @@ func (f *fakeEnqueuer) count() int {
 	return len(f.enqueued)
 }
 
-func decisionApp(name string, areaID int, appState string, lastDifferent time.Time) applications.PlanningApplication {
+func decisionApp(appState string, lastDifferent time.Time) applications.PlanningApplication {
 	s := appState
 	return applications.PlanningApplication{
-		Name:          name,
-		UID:           name + "/FUL",
+		Name:          "24/0001",
+		UID:           "24/0001/FUL",
 		AreaName:      "Area",
-		AreaID:        areaID,
+		AreaID:        99,
 		Address:       "1 St",
 		Description:   "d",
 		AppState:      &s,
@@ -66,12 +66,12 @@ func TestHandler_FanOut_EnqueuesEveryUpsertedApplication(t *testing.T) {
 	t.Parallel()
 	pi := newFakePlanIt()
 	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
-	pi.pages[pageKey{99, 1}] = planitPage(decisionApp("24/0001", 99, "Undecided", ld))
+	pi.pages[pageKey{99, 1}] = planitPage(decisionApp("Undecided", ld))
 	apps := newFakeApps()
 	state := newFakeStateStore()
 	disp := &fakeDecisionDispatcher{}
 	enq := &fakeEnqueuer{}
-	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts(), disp, enq)
+	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, defaultHandlerOpts(), disp, enq)
 
 	if _, err := h.Handle(context.Background()); err != nil {
 		t.Fatalf("Handle: %v", err)
@@ -86,15 +86,15 @@ func TestHandler_FanOut_DispatchesDecisionOnTransitionExactlyOnce(t *testing.T) 
 	pi := newFakePlanIt()
 	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
 	// Incoming app is in a decision state (Permitted).
-	pi.pages[pageKey{99, 1}] = planitPage(decisionApp("24/0001", 99, "Permitted", ld))
+	pi.pages[pageKey{99, 1}] = planitPage(decisionApp("Permitted", ld))
 	apps := newFakeApps()
 	// Existing record is NOT in a decision state — so this is a new-decision transition.
-	existing := decisionApp("24/0001", 99, "Undecided", ld.Add(-time.Hour))
+	existing := decisionApp("Undecided", ld.Add(-time.Hour))
 	apps.existing["24/0001/FUL"] = existing
 	state := newFakeStateStore()
 	disp := &fakeDecisionDispatcher{}
 	enq := &fakeEnqueuer{}
-	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts(), disp, enq)
+	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, defaultHandlerOpts(), disp, enq)
 
 	if _, err := h.Handle(context.Background()); err != nil {
 		t.Fatalf("Handle: %v", err)
@@ -110,13 +110,13 @@ func TestHandler_FanOut_NoDecisionDispatchWhenAlreadyDecided(t *testing.T) {
 	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
 	// Incoming app is Conditions (a decision state) but the existing record was
 	// ALREADY in a decision state (Permitted) — no transition, so no dispatch.
-	pi.pages[pageKey{99, 1}] = planitPage(decisionApp("24/0001", 99, "Conditions", ld))
+	pi.pages[pageKey{99, 1}] = planitPage(decisionApp("Conditions", ld))
 	apps := newFakeApps()
-	apps.existing["24/0001/FUL"] = decisionApp("24/0001", 99, "Permitted", ld.Add(-time.Hour))
+	apps.existing["24/0001/FUL"] = decisionApp("Permitted", ld.Add(-time.Hour))
 	state := newFakeStateStore()
 	disp := &fakeDecisionDispatcher{}
 	enq := &fakeEnqueuer{}
-	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts(), disp, enq)
+	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, defaultHandlerOpts(), disp, enq)
 
 	if _, err := h.Handle(context.Background()); err != nil {
 		t.Fatalf("Handle: %v", err)
@@ -136,12 +136,12 @@ func TestHandler_FanOut_FirstSeenDecidedAppCountsAsTransition(t *testing.T) {
 	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
 	// First-time insert that arrives already decided (no existing record) counts
 	// as a transition, mirroring .NET (existing == null).
-	pi.pages[pageKey{99, 1}] = planitPage(decisionApp("24/0001", 99, "Rejected", ld))
+	pi.pages[pageKey{99, 1}] = planitPage(decisionApp("Rejected", ld))
 	apps := newFakeApps()
 	state := newFakeStateStore()
 	disp := &fakeDecisionDispatcher{}
 	enq := &fakeEnqueuer{}
-	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts(), disp, enq)
+	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, defaultHandlerOpts(), disp, enq)
 
 	if _, err := h.Handle(context.Background()); err != nil {
 		t.Fatalf("Handle: %v", err)
@@ -155,7 +155,7 @@ func TestHandler_FanOut_SkipsUnchangedReindex(t *testing.T) {
 	t.Parallel()
 	pi := newFakePlanIt()
 	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
-	app := decisionApp("24/0001", 99, "Permitted", ld)
+	app := decisionApp("Permitted", ld)
 	pi.pages[pageKey{99, 1}] = planitPage(app)
 	apps := newFakeApps()
 	// Identical business fields already stored (only LastDifferent differs) —
@@ -166,7 +166,7 @@ func TestHandler_FanOut_SkipsUnchangedReindex(t *testing.T) {
 	state := newFakeStateStore()
 	disp := &fakeDecisionDispatcher{}
 	enq := &fakeEnqueuer{}
-	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts(), disp, enq)
+	h := newHandlerWithFanOut(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, defaultHandlerOpts(), disp, enq)
 
 	if _, err := h.Handle(context.Background()); err != nil {
 		t.Fatalf("Handle: %v", err)

--- a/api-go/internal/polling/handler.go
+++ b/api-go/internal/polling/handler.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"log/slog"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
@@ -53,6 +54,21 @@ type pollStateAccess interface {
 // activeAuthorityProvider yields the authorities to walk this cycle.
 type activeAuthorityProvider interface {
 	ActiveAuthorityIDs(ctx context.Context) ([]int, error)
+}
+
+// DecisionDispatcher dispatches a decision-update event for a polled application
+// that has just transitioned into a decision state. *notifydispatch.DecisionDispatcher
+// satisfies it. It is exported because cmd/worker wires the concrete dispatcher
+// behind it.
+type DecisionDispatcher interface {
+	Dispatch(ctx context.Context, app applications.PlanningApplication) error
+}
+
+// NotificationEnqueuer fans a newly-changed application out to the watch zones
+// that contain it, enqueuing one notification per eligible zone.
+// *notifydispatch.Enqueuer satisfies it via EnqueueForApplication.
+type NotificationEnqueuer interface {
+	EnqueueForApplication(ctx context.Context, app applications.PlanningApplication) error
 }
 
 // HandlerOptions are the ingestion tunables. MaxPagesPerAuthorityPerCycle caps
@@ -94,6 +110,25 @@ type PollPlanItHandler struct {
 	opts        HandlerOptions
 	now         func() time.Time
 	logger      *slog.Logger
+
+	// decision and enqueuer are the optional poll-path notification fan-out
+	// collaborators wired via WithFanOut. When nil, the handler ingests only (the
+	// behaviour before bead tc-uc2p); when set, each upserted application drives a
+	// decision-event dispatch (on a non-decision -> decision transition) and a
+	// watch-zone notification fan-out, matching .NET PollPlanItCommandHandler.
+	decision DecisionDispatcher
+	enqueuer NotificationEnqueuer
+}
+
+// WithFanOut wires the notification fan-out collaborators the worker runs on the
+// poll path: the decision-event dispatcher and the watch-zone enqueuer. It is a
+// post-construction setter rather than a constructor parameter so the many
+// ingestion-only call sites and tests are unaffected; cmd/worker calls it once
+// after building the handler. Returns the handler for chaining.
+func (h *PollPlanItHandler) WithFanOut(decision DecisionDispatcher, enqueuer NotificationEnqueuer) *PollPlanItHandler {
+	h.decision = decision
+	h.enqueuer = enqueuer
+	return h
 }
 
 // NewPollPlanItHandler wires the handler. now is injected so tests pin the clock.
@@ -275,7 +310,7 @@ func (h *PollPlanItHandler) pollAuthority(ctx context.Context, authorityID int, 
 			if app.LastDifferent.After(highWaterMark) {
 				highWaterMark = app.LastDifferent
 			}
-			if err := h.upsertIfChanged(ctx, app); err != nil {
+			if err := h.processApplication(ctx, app); err != nil {
 				out.err = err
 				return h.finishAuthority(ctx, authorityID, now, out, highWaterMark, existingHWM, lastPageFetched, firstPageTotal, capHit, hadCursor)
 			}
@@ -305,10 +340,22 @@ func (h *PollPlanItHandler) pollAuthority(ctx context.Context, authorityID int, 
 	return h.finishAuthority(ctx, authorityID, now, out, highWaterMark, existingHWM, lastPageFetched, firstPageTotal, capHit, hadCursor)
 }
 
-// upsertIfChanged point-reads the persisted application by uid within its
-// authority partition and upserts only when a business field changed (the
-// reindex-flood guard). A first-time insert (no existing record) always upserts.
-func (h *PollPlanItHandler) upsertIfChanged(ctx context.Context, app applications.PlanningApplication) error {
+// processApplication point-reads the persisted application by uid within its
+// authority partition, and — when a business field changed (the reindex-flood
+// guard; a first-time insert always counts as changed) — upserts it, then runs
+// the poll-path notification fan-out: a decision-event dispatch when the app has
+// just transitioned into a decision state, and the watch-zone notification
+// fan-out. It is the Go port of .NET PollPlanItCommandHandler's per-app body
+// (L186-226).
+//
+// The new-decision check is computed BEFORE the upsert so it compares the
+// PERSISTED state, not the incoming one: a non-decision -> decision transition
+// (Permitted/Conditions/Rejected/Appealed), including a first-seen already-decided
+// application (existing is absent), dispatches exactly one decision event.
+// Downstream idempotency (one decision per user/app) makes a re-dispatch harmless,
+// but gating on the transition keeps the dispatch count honest. The fan-out
+// collaborators are skipped entirely when not wired (ingestion-only mode).
+func (h *PollPlanItHandler) processApplication(ctx context.Context, app applications.PlanningApplication) error {
 	authorityCode := strconv.Itoa(app.AreaID)
 	existing, found, err := h.apps.GetByUID(ctx, app.UID, authorityCode)
 	if err != nil {
@@ -317,7 +364,46 @@ func (h *PollPlanItHandler) upsertIfChanged(ctx context.Context, app application
 	if found && existing.HasSameBusinessFieldsAs(app) {
 		return nil
 	}
-	return h.apps.Upsert(ctx, app)
+
+	var existingState *string
+	if found {
+		existingState = existing.AppState
+	}
+	isNewDecision := isDecisionState(app.AppState) && !isDecisionState(existingState)
+
+	if err := h.apps.Upsert(ctx, app); err != nil {
+		return err
+	}
+
+	if isNewDecision && h.decision != nil {
+		if err := h.decision.Dispatch(ctx, app); err != nil {
+			return err
+		}
+	}
+	if h.enqueuer != nil {
+		if err := h.enqueuer.EnqueueForApplication(ctx, app); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isDecisionState reports whether a PlanIt app_state is a decision outcome
+// (Permitted, Conditions, Rejected, Appealed), case-insensitively. A nil/empty
+// state is not a decision. Mirrors .NET PollPlanItCommandHandler.IsDecisionState.
+func isDecisionState(appState *string) bool {
+	if appState == nil || *appState == "" {
+		return false
+	}
+	switch {
+	case strings.EqualFold(*appState, "Permitted"),
+		strings.EqualFold(*appState, "Conditions"),
+		strings.EqualFold(*appState, "Rejected"),
+		strings.EqualFold(*appState, "Appealed"):
+		return true
+	default:
+		return false
+	}
 }
 
 // finishAuthority persists the authority's advanced poll state. On a cap-hit or

--- a/api-go/internal/polling/handler_test.go
+++ b/api-go/internal/polling/handler_test.go
@@ -153,9 +153,9 @@ func newHandler(t *testing.T, pi *fakePlanIt, apps *fakeApps, state *fakeStateSt
 
 // newHandlerWithFanOut builds a handler wired with the per-app decision
 // dispatcher and zone enqueuer, used by the fan-out tests.
-func newHandlerWithFanOut(t *testing.T, pi *fakePlanIt, apps *fakeApps, state *fakeStateStore, auth fakeAuthorities, cycle CycleType, opts HandlerOptions, disp DecisionDispatcher, enq NotificationEnqueuer) *PollPlanItHandler {
+func newHandlerWithFanOut(t *testing.T, pi *fakePlanIt, apps *fakeApps, state *fakeStateStore, auth fakeAuthorities, opts HandlerOptions, disp DecisionDispatcher, enq NotificationEnqueuer) *PollPlanItHandler {
 	t.Helper()
-	h := newHandler(t, pi, apps, state, auth, cycle, opts)
+	h := newHandler(t, pi, apps, state, auth, CycleSeed, opts)
 	h.WithFanOut(disp, enq)
 	return h
 }

--- a/api-go/internal/polling/handler_test.go
+++ b/api-go/internal/polling/handler_test.go
@@ -151,6 +151,24 @@ func newHandler(t *testing.T, pi *fakePlanIt, apps *fakeApps, state *fakeStateSt
 	return NewPollPlanItHandler(pi, apps, state, auth, fakeCycle{cycle}, opts, clock, logger)
 }
 
+// newHandlerWithFanOut builds a handler wired with the per-app decision
+// dispatcher and zone enqueuer, used by the fan-out tests.
+func newHandlerWithFanOut(t *testing.T, pi *fakePlanIt, apps *fakeApps, state *fakeStateStore, auth fakeAuthorities, cycle CycleType, opts HandlerOptions, disp DecisionDispatcher, enq NotificationEnqueuer) *PollPlanItHandler {
+	t.Helper()
+	h := newHandler(t, pi, apps, state, auth, cycle, opts)
+	h.WithFanOut(disp, enq)
+	return h
+}
+
+// planitPage wraps a single application into a one-page, no-more-pages result.
+func planitPage(app applications.PlanningApplication) planit.FetchPageResult {
+	return planit.FetchPageResult{
+		Page:         1,
+		Applications: []applications.PlanningApplication{app},
+		HasMorePages: false,
+	}
+}
+
 type discard struct{}
 
 func (discard) Write(p []byte) (int, error) { return len(p), nil }

--- a/api-go/internal/savedapplications/store_cosmos.go
+++ b/api-go/internal/savedapplications/store_cosmos.go
@@ -11,12 +11,15 @@ import (
 )
 
 // CosmosItems is the consumer-side slice of the SavedApplications container the
-// store uses: point read/upsert/delete plus a single-partition list query.
+// store uses: point read/upsert/delete, a single-partition list query, and a
+// cross-partition scan for the poll-path decision fan-out (who saved a given
+// application). platform.CosmosContainer satisfies it structurally.
 type CosmosItems interface {
 	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
 	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
 	DeleteItem(ctx context.Context, partitionKey, id string) error
 	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
+	QueryItemsCrossPartition(ctx context.Context, query string, params map[string]any) ([][]byte, error)
 }
 
 // listByUserQuery lists a user's saved applications. Scoped to the userId
@@ -88,6 +91,40 @@ func (s *CosmosStore) GetByUserID(ctx context.Context, userID string) ([]SavedAp
 		saved = append(saved, doc.toDomain())
 	}
 	return saved, nil
+}
+
+// userIDsForApplicationQuery projects the distinct user ids that have saved the
+// (applicationUid, authorityId), across all partitions. The authority predicate
+// is load-bearing: PlanIt uids collide across councils (tc-th98 / GH#384), so a
+// uid-only match would falsely fan out a decision to bookmark holders in another
+// authority. Mirrors .NET GetUserIdsForApplicationCrossPartitionAsync. Legacy
+// rows persisted before the authorityId column was added fall through the filter
+// naturally — they won't match until backfilled.
+const userIDsForApplicationQuery = "SELECT VALUE c.userId FROM c " +
+	"WHERE c.applicationUid = @applicationUid AND c.authorityId = @authorityId"
+
+// UserIDsForApplication returns every user id that has saved the given
+// (applicationUid, authorityId), via a cross-partition scan. It backs the
+// poll-path decision-event fan-out to bookmark holders (epic tc-wad3, bead
+// tc-uc2p). This is a deliberate cross-partition scan — saved-app docs are
+// partitioned by userId, but a polled decision needs every user who saved it.
+func (s *CosmosStore) UserIDsForApplication(ctx context.Context, applicationUID string, authorityID int) ([]string, error) {
+	raws, err := s.items.QueryItemsCrossPartition(ctx, userIDsForApplicationQuery, map[string]any{
+		"@applicationUid": applicationUID,
+		"@authorityId":    authorityID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("query user ids for saved application %q: %w", applicationUID, err)
+	}
+	userIDs := make([]string, 0, len(raws))
+	for _, raw := range raws {
+		var id string
+		if err := json.Unmarshal(raw, &id); err != nil {
+			return nil, fmt.Errorf("decode saved-application user id: %w", err)
+		}
+		userIDs = append(userIDs, id)
+	}
+	return userIDs, nil
 }
 
 // idOnlyDocument captures just the id projected by the cascade-delete query

--- a/api-go/internal/savedapplications/store_cosmos_test.go
+++ b/api-go/internal/savedapplications/store_cosmos_test.go
@@ -11,16 +11,17 @@ import (
 )
 
 type fakeItems struct {
-	stored       map[string][]byte
-	deleteErr    error
-	queryResult  [][]byte
-	lastUpsertPK string
-	lastDeleteID string
-	lastDeletePK string
-	deletedIDs   []string
-	lastQueryPK  string
-	lastQuery    string
-	lastParams   map[string]any
+	stored               map[string][]byte
+	deleteErr            error
+	queryResult          [][]byte
+	crossPartitionResult [][]byte
+	lastUpsertPK         string
+	lastDeleteID         string
+	lastDeletePK         string
+	deletedIDs           []string
+	lastQueryPK          string
+	lastQuery            string
+	lastParams           map[string]any
 }
 
 func newFakeItems() *fakeItems { return &fakeItems{stored: map[string][]byte{}} }
@@ -59,6 +60,12 @@ func (f *fakeItems) QueryItems(_ context.Context, partitionKey, query string, pa
 	f.lastQuery = query
 	f.lastParams = params
 	return f.queryResult, nil
+}
+
+func (f *fakeItems) QueryItemsCrossPartition(_ context.Context, query string, params map[string]any) ([][]byte, error) {
+	f.lastQuery = query
+	f.lastParams = params
+	return f.crossPartitionResult, nil
 }
 
 func savedFixture(t *testing.T) SavedApplication {
@@ -155,6 +162,40 @@ func TestCosmosStore_DeleteAllByUserID_QueriesPartitionThenDeletesEachID(t *test
 	}
 	if items.lastDeletePK != userID {
 		t.Errorf("cascade delete pk: got %q, want %q", items.lastDeletePK, userID)
+	}
+}
+
+func TestCosmosStore_UserIDsForApplication_CrossPartitionScopedToAuthority(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	// SELECT VALUE c.userId yields bare JSON strings.
+	items.crossPartitionResult = [][]byte{[]byte(`"auth0|alice"`), []byte(`"auth0|bob"`)}
+	store := NewCosmosStore(items)
+
+	userIDs, err := store.UserIDsForApplication(context.Background(), "24/0001", 99)
+	if err != nil {
+		t.Fatalf("UserIDsForApplication: %v", err)
+	}
+	if len(userIDs) != 2 || userIDs[0] != "auth0|alice" || userIDs[1] != "auth0|bob" {
+		t.Fatalf("user ids: got %v", userIDs)
+	}
+	// Predicate must be scoped to the authority: PlanIt uids collide across
+	// councils (tc-th98), so a uid-only match would falsely notify a Bradford
+	// bookmark holder about a Kingston decision.
+	if items.lastParams["@applicationUid"] != "24/0001" || items.lastParams["@authorityId"] != 99 {
+		t.Errorf("params: got uid=%v authority=%v", items.lastParams["@applicationUid"], items.lastParams["@authorityId"])
+	}
+}
+
+func TestCosmosStore_UserIDsForApplication_EmptyResultIsEmptySlice(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+	userIDs, err := store.UserIDsForApplication(context.Background(), "24/0001", 99)
+	if err != nil {
+		t.Fatalf("UserIDsForApplication: %v", err)
+	}
+	if len(userIDs) != 0 {
+		t.Errorf("expected empty, got %v", userIDs)
 	}
 }
 

--- a/api-go/internal/watchzones/store_cosmos.go
+++ b/api-go/internal/watchzones/store_cosmos.go
@@ -165,6 +165,45 @@ func (s *CosmosStore) DistinctAuthorityIDs(ctx context.Context) ([]int, error) {
 	return ids, nil
 }
 
+// findZonesContainingQuery selects every watch zone whose circle (centre +
+// radius) contains the candidate point, across all partitions. The candidate
+// point is bound as parameters; the zone centre is read from each document's
+// latitude/longitude columns. Mirrors .NET
+// CosmosWatchZoneRepository.FindZonesContainingCrossPartitionAsync.
+const findZonesContainingQuery = "SELECT * FROM c WHERE ST_DISTANCE(" +
+	"{'type': 'Point', 'coordinates': [c.longitude, c.latitude]}, " +
+	"{'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres"
+
+// FindZonesContaining returns every watch zone (across all users) whose circle
+// contains the point (latitude, longitude), via a cross-partition ST_DISTANCE
+// query against each zone's centre and radius. It backs the poll-path
+// notification fan-out and decision-event dispatch (epic tc-wad3, bead tc-uc2p),
+// mirroring .NET FindZonesContainingCrossPartitionAsync. This is a deliberate
+// cross-partition scan — a polled application's coordinates must be matched
+// against every user's zones.
+func (s *CosmosStore) FindZonesContaining(ctx context.Context, latitude, longitude float64) ([]WatchZone, error) {
+	raws, err := s.items.QueryItemsCrossPartition(ctx, findZonesContainingQuery, map[string]any{
+		"@latitude":  latitude,
+		"@longitude": longitude,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("find zones containing point: %w", err)
+	}
+	zones := make([]WatchZone, 0, len(raws))
+	for _, raw := range raws {
+		var doc watchZoneDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("decode matched watch zone: %w", err)
+		}
+		zone, err := doc.toDomain()
+		if err != nil {
+			return nil, fmt.Errorf("hydrate matched watch zone: %w", err)
+		}
+		zones = append(zones, zone)
+	}
+	return zones, nil
+}
+
 // isNotFound reports whether err is a Cosmos 404 response.
 func isNotFound(err error) bool {
 	var respErr *azcore.ResponseError

--- a/api-go/internal/watchzones/store_cosmos_test.go
+++ b/api-go/internal/watchzones/store_cosmos_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -265,6 +266,46 @@ func TestCosmosStore_DistinctAuthorityIDs_CrossPartition(t *testing.T) {
 		if !got[want] {
 			t.Errorf("missing authority id %d in %v", want, ids)
 		}
+	}
+}
+
+func TestCosmosStore_FindZonesContaining_CrossPartitionSpatialQuery(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	items := newFakeItems()
+	items.crossPartitionResult = [][]byte{mustDocBytes(t, z)}
+	store := NewCosmosStore(items)
+
+	zones, err := store.FindZonesContaining(context.Background(), 51.5155, -0.0931)
+	if err != nil {
+		t.Fatalf("FindZonesContaining: %v", err)
+	}
+	if len(zones) != 1 || zones[0].ID != z.ID {
+		t.Fatalf("zones: got %+v", zones)
+	}
+	// The point-in-circle predicate is an ST_DISTANCE against the zone radius,
+	// run cross-partition (every user's zones), mirroring .NET
+	// FindZonesContainingCrossPartitionAsync.
+	if !strings.Contains(items.lastQuery, "ST_DISTANCE") {
+		t.Errorf("query missing ST_DISTANCE: %q", items.lastQuery)
+	}
+	if !strings.Contains(items.lastQuery, "c.radiusMetres") {
+		t.Errorf("query must compare against c.radiusMetres: %q", items.lastQuery)
+	}
+	if items.lastParams["@latitude"] != 51.5155 || items.lastParams["@longitude"] != -0.0931 {
+		t.Errorf("spatial params: got lat=%v lng=%v", items.lastParams["@latitude"], items.lastParams["@longitude"])
+	}
+}
+
+func TestCosmosStore_FindZonesContaining_EmptyResultIsEmptySlice(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+	zones, err := store.FindZonesContaining(context.Background(), 51.5, -0.1)
+	if err != nil {
+		t.Fatalf("FindZonesContaining: %v", err)
+	}
+	if len(zones) != 0 {
+		t.Errorf("expected empty, got %+v", zones)
 	}
 }
 


### PR DESCRIPTION
Phase 2 Go worker migration (epic tc-wad3) — **cutover blocker**. Ports the .NET `PollPlanItCommandHandler` L186-226 fan-out into the Go poll handler so ingestion feeds the notification/digest pipeline. Without this, the notifications container stays empty after cutover and all alerts + weekly/hourly digests break.

- `internal/notifydispatch` — `Enqueuer` (per-zone notification create + instant push, ports DispatchNotificationCommandHandler), `DecisionDispatcher` (decision-state-change alerts, zone+saved union, idempotent), shared push path + APNs payload + record builder.
- `internal/polling/handler.go` — `processApplication`: compute `isNewDecision` BEFORE upsert, dispatch AFTER, then zone fan-out; reindex guard still skips both. `WithFanOut(...)` nilable setter (ingestion-only call sites unaffected).
- `cmd/worker/main.go` — `wirePollFanOut` constructs dispatchers (real/NoOp APNs per config).
- New repo methods: `DigestStore.Create` + `GetByUserAndApplication` (dedup), `watchzones.FindZonesContaining` (cross-partition ST_DISTANCE), `savedapplications.UserIDsForApplication` (authority-scoped).

**Digest-readability proven:** `TestEnqueuer_CreatedRecordIsDigestReadable` enqueues via the real `DigestStore` then reads the bytes back through the weekly-digest `ByUserSince` path — fields round-trip, `emailSent=false`.

Tier gating: instant push paid-only (free = record only, picked up by weekly digest). No new env. Gate: gofmt/vet/golangci clean, `go test -race` 810 pass, build ok.

Closes tc-uc2p.

🤖 Generated with [Claude Code](https://claude.com/claude-code)