### PR TITLE
ci: swap worker jobs to town-crier-worker-go image (tc-hm20)

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -255,7 +255,7 @@ jobs:
   # ── Worker: deploy to dev ───────────────────────────────
   worker-deploy:
     name: "Worker: Deploy to dev"
-    needs: [worker-image, infra-dev]
+    needs: [worker-go-image, infra-dev]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: development

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -184,9 +184,9 @@ jobs:
           working-directory: api
 
   # ── Go Worker: build & push image ───────────────────────
-  # Builds the new Go worker image so it exists in ACR ahead of the
-  # image-swap (tc-hm20). Nothing deploys it yet — the worker jobs still
-  # run the .NET town-crier-worker image until the swap lands.
+  # Builds the Go worker image and pushes it to ACR. The worker jobs now
+  # deploy this image (worker-deploy below, image-swap tc-hm20). The .NET
+  # worker-image build above stays until Phase 3 (tc-tbyp) decommissions it.
   worker-go-image:
     name: "Go Worker: Build & push image"
     runs-on: ubuntu-latest
@@ -274,7 +274,7 @@ jobs:
           jobs: digest digest-hourly dormant-cleanup
           env-suffix: dev
           resource-group: rg-town-crier-dev
-          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:${{ github.sha }}
+          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker-go:${{ github.sha }}
 
   # ── Web: deploy to dev ──────────────────────────────
   web-deploy:

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -215,12 +215,12 @@ jobs:
           SHA="${{ steps.resolve.outputs.sha }}"
           if az acr manifest show \
             --registry "$ACR_NAME" \
-            --name "town-crier-worker:$SHA" 2>/dev/null; then
+            --name "town-crier-worker-go:$SHA" 2>/dev/null; then
             echo "Using exact image for SHA $SHA"
             echo "tag=$SHA" >> "$GITHUB_OUTPUT"
           elif az acr manifest show \
             --registry "$ACR_NAME" \
-            --name "town-crier-worker:latest" 2>/dev/null; then
+            --name "town-crier-worker-go:latest" 2>/dev/null; then
             echo "No image for SHA $SHA — falling back to latest"
             echo "tag=latest" >> "$GITHUB_OUTPUT"
           else
@@ -233,7 +233,7 @@ jobs:
           jobs: poll poll-bootstrap digest digest-hourly dormant-cleanup
           env-suffix: prod
           resource-group: ${{ needs.infra.outputs.resource-group }}
-          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker:${{ steps.check-image.outputs.tag }}
+          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker-go:${{ steps.check-image.outputs.tag }}
 
   # ── Web ───────────────────────────────────────────────
   web:


### PR DESCRIPTION
Phase 2 Go worker migration (epic tc-wad3) — **the cutover**. Flips the worker jobs from the .NET `town-crier-worker` image to the Go `town-crier-worker-go` image, in place (`deploy-worker-jobs` runs `az containerapp job update --image` on the existing jobs — no new jobs, no dual-run).

- **cd-dev.yml** `worker-deploy`: image → `town-crier-worker-go:$SHA`; and `needs:` changed `worker-image` → `worker-go-image` so the deploy waits for the Go image build (not the legacy .NET build) — otherwise it races and deploys a missing image.
- **cd-prod.yml** `worker` (deploy-only): `check-image` now resolves `town-crier-worker-go` by SHA→latest; `deploy-worker-jobs` image → `town-crier-worker-go`.

Left building (Phase 3 tc-tbyp removes): cd-dev `worker-image` .NET build. On merge, cd-dev swaps the 3 dev jobs (digest, digest-hourly, dormant-cleanup) to Go; the prod release then swaps all 5 prod jobs.

actionlint clean on both workflows.

Closes tc-hm20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)