### PR TITLE
fix(go): detach Cosmos MI token fetch from per-try timeout (tc-u7mp)

### DIFF
--- a/api-go/internal/platform/cosmos.go
+++ b/api-go/internal/platform/cosmos.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
@@ -92,6 +93,30 @@ func cosmosRetryOptions() policy.RetryOptions {
 	}
 }
 
+// cosmosTokenAcquireTimeout bounds a managed-identity token fetch independently
+// of cosmosTryTimeout. The 1.5s per-Cosmos-try timeout (cosmosTryTimeout) wraps
+// the bearer-token auth policy, so it would otherwise cancel a COLD token fetch
+// on a short-lived Container Apps Job replica before azidentity can cache a
+// token — failing every retry (tc-u7mp). 30s comfortably covers a cold identity-
+// endpoint round trip; once cached the bearer policy reuses the token, so this
+// only affects the very first fetch.
+const cosmosTokenAcquireTimeout = 30 * time.Second
+
+// detachedTokenCredential decouples token acquisition from the caller's
+// (per-Cosmos-try) deadline. context.WithoutCancel keeps the trace/values but
+// drops the parent's cancellation + deadline; a fresh cosmosTokenAcquireTimeout
+// then bounds the fetch so it can't hang forever.
+type detachedTokenCredential struct {
+	inner   azcore.TokenCredential
+	timeout time.Duration
+}
+
+func (c detachedTokenCredential) GetToken(ctx context.Context, opts policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	tokenCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), c.timeout)
+	defer cancel()
+	return c.inner.GetToken(tokenCtx, opts)
+}
+
 // CosmosContainer is the azcosmos-backed implementation of the profile store's
 // item accessor. It performs single-partition point read/upsert/delete on the
 // Users container, keyed on the user id. SDK types never leak past its methods.
@@ -134,9 +159,14 @@ func NewCosmosContainerNamed(cfg Config, name string, logger *slog.Logger) (*Cos
 		return nil, fmt.Errorf("build managed-identity credential: %w", err)
 	}
 
+	// Wrap the MI credential so its token fetch runs under cosmosTokenAcquireTimeout
+	// detached from the per-Cosmos-try deadline, otherwise a cold token fetch on a
+	// short-lived job replica is strangled by cosmosTryTimeout (tc-u7mp).
+	detachedCred := detachedTokenCredential{inner: cred, timeout: cosmosTokenAcquireTimeout}
+
 	clientOpts := &azcosmos.ClientOptions{}
 	clientOpts.Retry = cosmosRetryOptions()
-	client, err := azcosmos.NewClient(cfg.CosmosEndpoint, cred, clientOpts)
+	client, err := azcosmos.NewClient(cfg.CosmosEndpoint, detachedCred, clientOpts)
 	if err != nil {
 		return nil, fmt.Errorf("build cosmos client: %w", err)
 	}

--- a/api-go/internal/platform/cosmos_token_test.go
+++ b/api-go/internal/platform/cosmos_token_test.go
@@ -1,0 +1,74 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+)
+
+// fakeTokenCredential stands in for a managed-identity credential. delay models
+// how long the identity endpoint round trip takes; the GetToken honours its
+// ctx deadline so a test can prove whether the wrapper detached from the
+// caller's per-try deadline.
+type fakeTokenCredential struct {
+	delay time.Duration
+	token string
+}
+
+func (f fakeTokenCredential) GetToken(ctx context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	select {
+	case <-time.After(f.delay):
+		return azcore.AccessToken{Token: f.token, ExpiresOn: time.Now().Add(time.Hour)}, nil
+	case <-ctx.Done():
+		return azcore.AccessToken{}, ctx.Err()
+	}
+}
+
+// TestDetachedTokenCredential_DetachesFromShortParentDeadline is the regression
+// guard for tc-u7mp: on a cold Container Apps Job replica the first MI token
+// fetch outlasts cosmosTryTimeout (the per-Cosmos-try deadline that wraps the
+// auth policy), so every Cosmos attempt is cancelled before a token caches. The
+// wrapper must run GetToken under its own generous timeout, detached from the
+// caller's short deadline, so the cold fetch completes and the token is returned.
+func TestDetachedTokenCredential_DetachesFromShortParentDeadline(t *testing.T) {
+	t.Parallel()
+
+	cred := detachedTokenCredential{
+		inner:   fakeTokenCredential{delay: 100 * time.Millisecond, token: "tok"},
+		timeout: 5 * time.Second,
+	}
+
+	// Parent deadline (10ms) is far shorter than the inner fetch (100ms). Without
+	// detaching this would return context.DeadlineExceeded.
+	parent, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	tok, err := cred.GetToken(parent, policy.TokenRequestOptions{})
+	if err != nil {
+		t.Fatalf("GetToken under short parent deadline: got err %v, want nil", err)
+	}
+	if tok.Token != "tok" {
+		t.Errorf("token: got %q, want %q", tok.Token, "tok")
+	}
+}
+
+// TestDetachedTokenCredential_BoundsAcquisition proves the detached fetch still
+// has an upper bound: when the inner credential outlasts the wrapper's own
+// timeout, GetToken returns a deadline-exceeded error rather than hanging forever.
+func TestDetachedTokenCredential_BoundsAcquisition(t *testing.T) {
+	t.Parallel()
+
+	cred := detachedTokenCredential{
+		inner:   fakeTokenCredential{delay: 200 * time.Millisecond, token: "tok"},
+		timeout: 20 * time.Millisecond,
+	}
+
+	_, err := cred.GetToken(context.Background(), policy.TokenRequestOptions{})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("GetToken with timeout shorter than inner delay: got err %v, want context.DeadlineExceeded", err)
+	}
+}


### PR DESCRIPTION
## Problem (tc-u7mp)

Every Go worker Container Apps Job run failed on its first Cosmos call:

```
query users with unsent emails: failed to retrieve account properties:
ManagedIdentityCredential: context deadline exceeded
```

The failing Cosmos dependency lasted **exactly 1500ms**.

## Root cause

`cosmosTryTimeout = 1500ms` is the azcore `RetryOptions.TryTimeout`. It bounds every Cosmos attempt — **including the bearer-token auth policy's `GetToken`**, which runs inside the per-try context. On a **cold, short-lived Container Apps Job replica** the first managed-identity token fetch takes longer than 1.5s, so every attempt is cancelled before a token is ever cached → all retries fail.

The long-running Go API **app** never hits this: its token cache is warm. A short-lived **job** starts cold every run. Identity wiring is identical to the working API app (`AZURE_CLIENT_ID=739d5a0a…` = `id-town-crier-cosmos-data`); the .NET worker reached Cosmos on the same job — so this is purely the token-fetch-vs-1.5s-timeout interaction.

## Fix

Wrap the managed-identity credential so `GetToken` runs under its own 30s timeout, **detached** from the per-Cosmos-try deadline (`context.WithoutCancel`, Go 1.26 — keeps trace/values, drops the parent deadline). azcore's existing retry then succeeds on the next attempt against the now-cached token. `cosmosTryTimeout` stays at 1.5s — it correctly bounds the actual Cosmos call; only the token fetch needed detaching. Shared platform code, so the API app benefits too with no downside.

## Tests (Red→Green, in-package, hand-written fake)

- `TestDetachedTokenCredential_DetachesFromShortParentDeadline` — regression guard: 10ms parent deadline, 100ms inner fetch, 5s wrapper timeout → token returned (without the fix: `context.DeadlineExceeded`).
- `TestDetachedTokenCredential_BoundsAcquisition` — 20ms wrapper timeout vs 200ms inner delay → `context.DeadlineExceeded`, proving the detached fetch still can't hang forever.

Gate green locally: gofmt clean, go vet clean, golangci-lint clean, `go test -race ./...` 812 passed, `go build ./...` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential connection failures by improving Cosmos database token acquisition reliability. Token fetch operations now complete independently from connection attempt timeouts, with proper timeout bounds.

* **Tests**
  * Added regression tests verifying token credential timeout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->