### PR TITLE
fix(go): dedupe cross-partition user/authority ids client-side; drop unsupported DISTINCT (tc-b7cm)

### DIFF
--- a/api-go/internal/notifications/digest_store_cosmos.go
+++ b/api-go/internal/notifications/digest_store_cosmos.go
@@ -11,7 +11,8 @@ import (
 
 // DigestItems is the consumer-side slice of the Notifications container the
 // digest store uses: a single-partition query (a user's recent / unsent rows), a
-// cross-partition DISTINCT projection (the users with unsent emails), and an
+// cross-partition projection with client-side dedup (the users with unsent
+// emails — azcosmos cannot serve a cross-partition DISTINCT, tc-b7cm), and an
 // upsert (writing back the emailSent flag). platform.CosmosContainer satisfies
 // it structurally.
 type DigestItems interface {
@@ -69,24 +70,36 @@ func (s *DigestStore) UnsentEmailsByUser(ctx context.Context, userID string) ([]
 	return decodeDigests(raws, userID)
 }
 
-// userIDsWithUnsentEmailsQuery projects the distinct user ids that have at least
-// one unsent-email notification, across all partitions. Mirrors .NET
+// userIDsWithUnsentEmailsQuery projects the user ids that have at least one
+// unsent-email notification, across all partitions. It is a cross-partition
+// projection with client-side dedup (azcosmos cannot serve a cross-partition
+// DISTINCT — the gateway returns 400 "can not be directly served by the
+// gateway"; tc-b7cm). The same row's userId repeats once per unsent
+// notification, so UserIDsWithUnsentEmails collapses them in Go. Mirrors .NET
 // GetUserIdsWithUnsentEmailsCrossPartitionAsync.
-const userIDsWithUnsentEmailsQuery = "SELECT DISTINCT VALUE c.userId FROM c WHERE c.emailSent = false OR NOT IS_DEFINED(c.emailSent)"
+const userIDsWithUnsentEmailsQuery = "SELECT VALUE c.userId FROM c WHERE c.emailSent = false OR NOT IS_DEFINED(c.emailSent)"
 
 // UserIDsWithUnsentEmails returns every user id with at least one unsent-email
 // notification — the hourly cycle's candidate set before per-user tier gating.
+// The cross-partition projection returns one row per unsent notification, so the
+// ids are de-duplicated here (a cross-partition DISTINCT 400s at the gateway,
+// tc-b7cm). First-seen order is preserved.
 func (s *DigestStore) UserIDsWithUnsentEmails(ctx context.Context) ([]string, error) {
 	raws, err := s.items.QueryItemsCrossPartition(ctx, userIDsWithUnsentEmailsQuery, nil)
 	if err != nil {
 		return nil, fmt.Errorf("query users with unsent emails: %w", err)
 	}
 	userIDs := make([]string, 0, len(raws))
+	seen := make(map[string]struct{}, len(raws))
 	for _, raw := range raws {
 		var id string
 		if err := json.Unmarshal(raw, &id); err != nil {
 			return nil, fmt.Errorf("decode user id: %w", err)
 		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
 		userIDs = append(userIDs, id)
 	}
 	return userIDs, nil

--- a/api-go/internal/notifications/digest_store_test.go
+++ b/api-go/internal/notifications/digest_store_test.go
@@ -126,9 +126,16 @@ func TestDigestStore_UnsentEmailsByUser(t *testing.T) {
 
 func TestDigestStore_UserIDsWithUnsentEmails(t *testing.T) {
 	t.Parallel()
+	// azcosmos cannot serve a cross-partition DISTINCT (the gateway 400s), so the
+	// query is a plain cross-partition projection and the store dedupes the rows
+	// client-side (tc-b7cm). The fake returns duplicate user ids out of order; the
+	// store must collapse them to one each in first-seen order.
 	items := &fakeDigestItems{crossResult: [][]byte{
-		[]byte(`"user-1"`),
-		[]byte(`"user-2"`),
+		[]byte(`"u1"`),
+		[]byte(`"u2"`),
+		[]byte(`"u1"`),
+		[]byte(`"u3"`),
+		[]byte(`"u2"`),
 	}}
 	store := NewDigestStore(items)
 
@@ -136,11 +143,19 @@ func TestDigestStore_UserIDsWithUnsentEmails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UserIDsWithUnsentEmails: %v", err)
 	}
-	if len(got) != 2 || got[0] != "user-1" || got[1] != "user-2" {
-		t.Fatalf("got %v", got)
+	want := []string{"u1", "u2", "u3"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
 	}
-	if !strings.Contains(items.crossText, "DISTINCT VALUE c.userId") {
-		t.Errorf("query missing distinct user id projection: %q", items.crossText)
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("dedup order mismatch: got %v, want %v", got, want)
+		}
+	}
+	// Guard the regression: a cross-partition DISTINCT 400s at the gateway, so the
+	// query the store sends must NOT contain DISTINCT.
+	if strings.Contains(items.crossText, "DISTINCT") {
+		t.Errorf("cross-partition query must not use DISTINCT (gateway 400): %q", items.crossText)
 	}
 }
 

--- a/api-go/internal/watchzones/store_cosmos.go
+++ b/api-go/internal/watchzones/store_cosmos.go
@@ -25,8 +25,9 @@ type CosmosItems interface {
 	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
 	DeleteItem(ctx context.Context, partitionKey, id string) error
 	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
-	// QueryItemsCrossPartition backs the polling authority provider's distinct
-	// authority-id scan; it is the only cross-partition read on this container.
+	// QueryItemsCrossPartition backs the polling authority provider's
+	// authority-id projection (deduped client-side, since azcosmos cannot serve a
+	// cross-partition DISTINCT — gateway 400, tc-b7cm) and the spatial fan-out.
 	QueryItemsCrossPartition(ctx context.Context, query string, params map[string]any) ([][]byte, error)
 }
 
@@ -145,21 +146,29 @@ func (s *CosmosStore) DeleteAllByUserID(ctx context.Context, userID string) erro
 }
 
 // DistinctAuthorityIDs returns the distinct authority ids across every user's
-// watch zones, via a cross-partition DISTINCT VALUE scan. It backs the polling
+// watch zones, via a cross-partition projection with client-side dedup (azcosmos
+// cannot serve a cross-partition DISTINCT — the gateway returns 400 "can not be
+// directly served by the gateway"; tc-b7cm). The VALUE projection returns bare
+// JSON integers, one per zone row, so the same authority id repeats once per
+// zone in it and is de-duplicated here in first-seen order. It backs the polling
 // watch-zone active-authority provider (poll-sb cycle), mirroring .NET
-// CosmosWatchZoneRepository.GetDistinctAuthorityIdsCrossPartitionAsync. The
-// VALUE projection returns bare JSON integers, one per result row.
+// CosmosWatchZoneRepository.GetDistinctAuthorityIdsCrossPartitionAsync.
 func (s *CosmosStore) DistinctAuthorityIDs(ctx context.Context) ([]int, error) {
-	raws, err := s.items.QueryItemsCrossPartition(ctx, "SELECT DISTINCT VALUE c.authorityId FROM c", nil)
+	raws, err := s.items.QueryItemsCrossPartition(ctx, "SELECT VALUE c.authorityId FROM c", nil)
 	if err != nil {
 		return nil, fmt.Errorf("query distinct authority ids: %w", err)
 	}
 	ids := make([]int, 0, len(raws))
+	seen := make(map[int]struct{}, len(raws))
 	for _, raw := range raws {
 		var id int
 		if err := json.Unmarshal(raw, &id); err != nil {
 			return nil, fmt.Errorf("decode authority id: %w", err)
 		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
 		ids = append(ids, id)
 	}
 	return ids, nil

--- a/api-go/internal/watchzones/store_cosmos_test.go
+++ b/api-go/internal/watchzones/store_cosmos_test.go
@@ -247,25 +247,31 @@ func TestCosmosStore_DeleteAllByUserID_NoZonesIsNoOp(t *testing.T) {
 func TestCosmosStore_DistinctAuthorityIDs_CrossPartition(t *testing.T) {
 	t.Parallel()
 	items := newFakeItems()
-	// SELECT DISTINCT VALUE c.authorityId FROM c yields bare JSON numbers.
-	items.crossPartitionResult = [][]byte{[]byte("99"), []byte("123"), []byte("7")}
+	// azcosmos cannot serve a cross-partition DISTINCT (the gateway 400s), so the
+	// query is a plain projection (SELECT VALUE c.authorityId FROM c, bare JSON
+	// numbers) and the store dedupes client-side (tc-b7cm). The fake returns the
+	// same authority id more than once, out of order; the store must collapse it
+	// to one each in first-seen order.
+	items.crossPartitionResult = [][]byte{[]byte("10"), []byte("20"), []byte("10"), []byte("30")}
 	store := NewCosmosStore(items)
 
 	ids, err := store.DistinctAuthorityIDs(context.Background())
 	if err != nil {
 		t.Fatalf("DistinctAuthorityIDs: %v", err)
 	}
-	if len(ids) != 3 {
-		t.Fatalf("ids: got %v, want 3 entries", ids)
+	want := []int{10, 20, 30}
+	if len(ids) != len(want) {
+		t.Fatalf("ids: got %v, want %v", ids, want)
 	}
-	got := map[int]bool{}
-	for _, id := range ids {
-		got[id] = true
-	}
-	for _, want := range []int{99, 123, 7} {
-		if !got[want] {
-			t.Errorf("missing authority id %d in %v", want, ids)
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("dedup order mismatch: got %v, want %v", ids, want)
 		}
+	}
+	// Guard the regression: a cross-partition DISTINCT 400s at the gateway, so the
+	// query the store sends must NOT contain DISTINCT.
+	if strings.Contains(items.lastQuery, "DISTINCT") {
+		t.Errorf("cross-partition query must not use DISTINCT (gateway 400): %q", items.lastQuery)
 	}
 }
 


### PR DESCRIPTION
## Problem (tc-b7cm, discovered-from tc-u7mp)

After the MI-token fix (#458) the Go worker's hourly-digest job got past auth but failed with:

```
400 BadRequest: The provided cross partition query can not be directly served by the gateway.
```

The Go `azcosmos` SDK does **not** support cross-partition queries with `DISTINCT` / aggregates / `GROUP BY` / `ORDER BY` (no query-plan pipeline) — only simple cross-partition scans (fan-out + concatenate). Two queries used `SELECT DISTINCT VALUE …` cross-partition and both fail:

1. `notifications/digest_store_cosmos.go` — `userIDsWithUnsentEmailsQuery` (hourly-digest).
2. `watchzones/store_cosmos.go` — `DistinctAuthorityIDs` (poll-sb, prod-only — would break the cutover).

## Fix

Drop `DISTINCT` from both queries (`SELECT VALUE c.userId …` / `SELECT VALUE c.authorityId FROM c`) and de-duplicate the returned values in Go with a set (append on first sight, stable order). Bounded result sets, logical result identical to the .NET `DISTINCT`. No change to `QueryItemsCrossPartition` or any of the other (simple) cross-partition scans.

## Tests

- `TestDigestStore_UserIDsWithUnsentEmails` — duplicate rows `["u1","u2","u1","u3","u2"]` → `["u1","u2","u3"]`; guard asserts the query contains no `DISTINCT`.
- `TestCosmosStore_DistinctAuthorityIDs_CrossPartition` — `[10,20,10,30]` → `[10,20,30]`; same no-`DISTINCT` guard.

Gate green locally: gofmt/vet/golangci-lint clean, `go test -race ./...` 812 passed, `go build ./...` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)