### PR TITLE
fix(go): tolerate PlanIt last_different no-TZ fractional timestamps (tc-8l96)

### DIFF
--- a/api-go/internal/planit/response.go
+++ b/api-go/internal/planit/response.go
@@ -43,7 +43,8 @@ type planItRecord struct {
 // toDomain maps a PlanIt record to the applications.PlanningApplication snapshot,
 // mirroring .NET PlanItClient.MapToDomain: location_x is longitude, location_y
 // latitude; app_type / app_state are carried as non-empty pointers; date-only
-// fields parse to *time.Time; last_different parses as an RFC3339 instant.
+// fields parse to *time.Time; last_different parses as a UTC instant, tolerating
+// the no-timezone fractional-second form PlanIt actually emits.
 func (r planItRecord) toDomain() (applications.PlanningApplication, error) {
 	startDate, err := parseDateOnly(r.StartDate)
 	if err != nil {
@@ -57,7 +58,7 @@ func (r planItRecord) toDomain() (applications.PlanningApplication, error) {
 	if err != nil {
 		return applications.PlanningApplication{}, fmt.Errorf("consulted_date: %w", err)
 	}
-	lastDifferent, err := time.Parse(time.RFC3339, r.LastDifferent)
+	lastDifferent, err := parsePlanItInstant(r.LastDifferent)
 	if err != nil {
 		return applications.PlanningApplication{}, fmt.Errorf("last_different %q: %w", r.LastDifferent, err)
 	}
@@ -83,8 +84,28 @@ func (r planItRecord) toDomain() (applications.PlanningApplication, error) {
 		Latitude:      r.LocationY,
 		URL:           r.URL,
 		Link:          r.Link,
-		LastDifferent: lastDifferent.UTC(),
+		LastDifferent: lastDifferent,
 	}, nil
+}
+
+// planItInstantLayouts are tried in order when parsing PlanIt's last_different.
+// PlanIt emits a naive UTC timestamp with variable fractional seconds and NO
+// timezone (e.g. "2026-06-13T00:06:34.112581"); RFC3339Nano is kept first so a
+// TZ-bearing value (should PlanIt ever send one) still parses. tc-8l96.
+var planItInstantLayouts = []string{
+	time.RFC3339Nano,             // TZ present, optional fractional seconds
+	"2006-01-02T15:04:05.999999", // no TZ, optional fractional seconds -> UTC
+}
+
+// parsePlanItInstant parses a PlanIt last_different timestamp as UTC, tolerating
+// the no-timezone fractional-second form PlanIt actually returns.
+func parsePlanItInstant(value string) (time.Time, error) {
+	for _, layout := range planItInstantLayouts {
+		if t, err := time.Parse(layout, value); err == nil {
+			return t.UTC(), nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("unrecognised timestamp %q", value)
 }
 
 // parseDateOnly parses an optional "yyyy-MM-dd" PlanIt date into a *time.Time,

--- a/api-go/internal/planit/response_test.go
+++ b/api-go/internal/planit/response_test.go
@@ -1,0 +1,99 @@
+package planit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParsePlanItInstant(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		value   string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			// PlanIt's real output: naive UTC, 6 fractional digits, no TZ.
+			name:  "no-TZ six fractional digits",
+			value: "2026-06-13T00:06:34.112581",
+			want:  time.Date(2026, 6, 13, 0, 6, 34, 112581000, time.UTC),
+		},
+		{
+			// PlanIt's real output: naive UTC, variable (4) fractional digits.
+			name:  "no-TZ four fractional digits",
+			value: "2026-06-13T01:33:50.2991",
+			want:  time.Date(2026, 6, 13, 1, 33, 50, 299100000, time.UTC),
+		},
+		{
+			name:  "no-TZ no fractional seconds",
+			value: "2026-06-13T01:33:50",
+			want:  time.Date(2026, 6, 13, 1, 33, 50, 0, time.UTC),
+		},
+		{
+			name:  "TZ Zulu",
+			value: "2026-06-13T00:06:34Z",
+			want:  time.Date(2026, 6, 13, 0, 6, 34, 0, time.UTC),
+		},
+		{
+			// A +01:00 offset must be normalised to the equivalent UTC instant.
+			name:  "TZ positive offset normalises to UTC",
+			value: "2026-06-13T00:06:34+01:00",
+			want:  time.Date(2026, 6, 12, 23, 6, 34, 0, time.UTC),
+		},
+		{
+			name:    "invalid value",
+			value:   "not-a-time",
+			wantErr: true,
+		},
+		{
+			name:    "empty value",
+			value:   "",
+			wantErr: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parsePlanItInstant(tc.value)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parsePlanItInstant(%q): got err=%v, wantErr=%v", tc.value, err, tc.wantErr)
+			}
+			if tc.wantErr {
+				return
+			}
+			if !got.Equal(tc.want) {
+				t.Errorf("parsePlanItInstant(%q): got %v, want %v", tc.value, got, tc.want)
+			}
+			if got.Location() != time.UTC {
+				t.Errorf("parsePlanItInstant(%q): location = %v, want UTC", tc.value, got.Location())
+			}
+		})
+	}
+}
+
+func TestToDomain_ParsesNoTimezoneFractionalLastDifferent(t *testing.T) {
+	t.Parallel()
+	rec := planItRecord{
+		Name:          "24/0001",
+		UID:           "24/0001/FUL",
+		AreaName:      "Test",
+		AreaID:        99,
+		Address:       "1 High St",
+		Description:   "A shed",
+		AppType:       "Full",
+		AppState:      "Undecided",
+		LastDifferent: "2026-06-13T00:06:34.112581",
+	}
+	app, err := rec.toDomain()
+	if err != nil {
+		t.Fatalf("toDomain: %v", err)
+	}
+	want := time.Date(2026, 6, 13, 0, 6, 34, 112581000, time.UTC)
+	if !app.LastDifferent.Equal(want) {
+		t.Errorf("LastDifferent: got %v, want %v", app.LastDifferent, want)
+	}
+	if app.LastDifferent.Location() != time.UTC {
+		t.Errorf("LastDifferent location = %v, want UTC", app.LastDifferent.Location())
+	}
+}


### PR DESCRIPTION
## Problem (tc-8l96, P0 — discovered verifying the tc-wad3 prod cutover)

After the worker cutover to Go, the poll-sb cycle runs end-to-end (receives trigger, acquires lease, re-enqueues) but ingests **0 applications** — every PlanIt record fails to map. Prod console log:

```
ERROR "error polling authority, skipping to next"
err: map planit record "ZG2026/0520/CPE": last_different "2026-06-13T00:06:34.112581":
parsing time "2026-06-13T00:06:34.112581" as "2006-01-02T15:04:05Z07:00": cannot parse
```

`response.go` parsed `last_different` with `time.RFC3339`, which **requires** a `Z`/offset. PlanIt actually sends a **naive UTC timestamp with no timezone and variable fractional seconds** (`2026-06-13T00:06:34.112581`, `2026-06-13T01:33:50.2991`). A single record's mapping error fails the whole authority, so every authority errored → nothing ingested.

## Fix

Parse `last_different` via a tolerant helper trying `time.RFC3339Nano` (TZ-bearing, for robustness) then `2006-01-02T15:04:05.999999` (no-TZ, variable fractional), returning UTC. `start_date`/`decided_date`/`consulted_date` are date-only and untouched.

## Tests

- `TestParsePlanItInstant` — no-TZ 6/4/0 fractional digits, Zulu, `+01:00` offset → UTC, invalid, empty; asserts `Location()==UTC`.
- `TestToDomain_ParsesNoTimezoneFractionalLastDifferent` — exercises the real PlanIt form through `toDomain`.

Gate green: gofmt/vet/golangci-lint clean, `go test -race ./...` 821 passed, build ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp parsing for planning application records. The system now reliably handles multiple timestamp formats, including UTC timestamps with variable fractional second precision and timezone offsets.

* **Tests**
  * Added comprehensive test coverage for timestamp parsing logic, validating correct handling of various timestamp formats and edge cases to ensure data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->