### PR TITLE
fix(go): worker uses NewOTelLogger so logs reach App Insights (tc-1x8j)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -54,16 +54,25 @@ func run() int {
 		return 1
 	}
 
-	logger := platform.NewLogger(os.Stdout, cfg.LogLevel)
+	// NewOTelLogger fans every record out to stdout JSON (ContainerAppConsoleLogs)
+	// AND the otelslog bridge -> the global OTel LoggerProvider -> App Insights
+	// AppTraces. The bridge targets the GLOBAL LoggerProvider, which is the no-op
+	// provider until SetupTelemetry (called next) installs an SDK one; the global
+	// provider's delegation upgrades this logger in place, so building it before
+	// SetupTelemetry is correct (tc-1x8j / tc-8x8g / ADR 0027). Without it the
+	// worker's slog records (e.g. digest "send failed") never reach telemetry —
+	// worker spans arrive but logs do not, leaving ACS send failures invisible.
+	logger := platform.NewOTelLogger(os.Stdout, cfg.LogLevel)
 
 	mode := os.Getenv("WORKER_MODE")
 
 	// SetupTelemetry self-disables when OTEL_EXPORTER_OTLP_ENDPOINT is unset, so
-	// local/dev boots leave the no-op TracerProvider in place. OTEL_SERVICE_NAME
-	// (set to town-crier-worker-go by infra) drives the service name on exported
-	// spans. The deferred shutdown force-flushes the final batch before this
-	// short-lived process exits — without it the worker can terminate before its
-	// spans reach the collector (mirrors the .NET worker's ForceFlush).
+	// local/dev boots leave the no-op Tracer and Logger providers in place.
+	// OTEL_SERVICE_NAME (set to town-crier-worker-go by infra) drives the service
+	// name on exported spans and logs. The deferred shutdown force-flushes the
+	// final batch before this short-lived process exits — without it the worker
+	// can terminate before its spans and logs reach the collector (mirrors the
+	// .NET worker's ForceFlush).
 	shutdownTelemetry, err := platform.SetupTelemetry(context.Background(), logger)
 	if err != nil {
 		log.Print(err)


### PR DESCRIPTION
## What

Swap the Go worker's logger from `platform.NewLogger` (stdout JSON only) to `platform.NewOTelLogger` — matching `cmd/api/main.go:42`.

## Why

`api-go/cmd/worker/main.go` built its logger with `platform.NewLogger`, so worker `slog` records never reached the `otelslog` bridge → global OTel `LoggerProvider` → App Insights `AppTraces`. Worker **spans** arrived (the ACA OTel agent injects `OTEL_EXPORTER_OTLP_ENDPOINT`), but **logs did not** — leaving us blind to why Go email sends silently fail (the critical `digest email: send failed` line in `internal/digest/handler.go` is logged via `slog` and was invisible).

Confirmed broken in prod: christy@salter.uk received **0** email from the Go hourly digest (manual run `job-tc-digest-hourly-prod-9yjubq2` at 21:00Z 2026-06-14, latest notification flipped to `emailSent=false`), while .NET digests delivered fine the day before.

## How

`NewOTelLogger` is built **before** `SetupTelemetry` so the global `LoggerProvider` upgrade applies in place (ADR 0027 / tc-8x8g). The deferred telemetry shutdown already force-flushes the final batch on this short-lived job — that now covers logs as well as spans.

## Deadline

Must land + cd-prod deploy **before the 07:00Z daily digest** (`job-tc-digest-prod`) tomorrow so that first Go-image run is diagnosable.

## Verify (post-deploy)

Trigger `job-tc-digest-hourly-prod`, then the AppTraces search should return worker lines for AppRoleName `cae-town-crier-shared.town-crier-worker-go` (returns 0 today).

Closes tc-1x8j.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated worker logging to utilize OpenTelemetry logger, with logs now output as JSON to stdout and integrated with the global telemetry provider for unified trace and log export.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->