### PR TITLE
fix(go): cascade DELETE /v1/me to all per-user containers for complete GDPR erasure (tc-qkf2)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -126,6 +126,23 @@ func main() {
 		savedStore = savedapplications.NewCosmosStore(savedContainer)
 	}
 
+	// cascade bundles the per-container deleters DELETE /v1/me runs for a complete
+	// GDPR erasure (bead tc-qkf2). It is populated only when Cosmos is configured —
+	// the same condition under which profiles.Routes is wired — so the handler's
+	// deleters are never nil when the route is reachable. The four DeleteAllByUserID
+	// stores satisfy profiles.ChildDeleter directly; notification-state is bridged by
+	// the notificationStateDeleter adapter (its store method is DeleteByUserID).
+	var cascade profiles.CascadeDeleters
+	if notificationsContainer != nil && watchZones != nil && savedContainer != nil && devices != nil && stateContainer != nil {
+		cascade = profiles.CascadeDeleters{
+			Notifications:       notifications.NewDeleteStore(notificationsContainer),
+			WatchZones:          watchZoneStore,
+			SavedApplications:   savedStore,
+			DeviceRegistrations: deviceStore,
+			NotificationState:   notificationStateDeleter{stateStore},
+		}
+	}
+
 	offerCodesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosOfferCodesContainer, logger)
 	if err != nil {
 		log.Fatal(err)
@@ -181,7 +198,7 @@ func main() {
 	geocodeClient := geocoding.NewClient(cfg.PostcodesIoBaseURL, &http.Client{Timeout: 30 * time.Second})
 	designationClient := designations.NewClient(cfg.GovUkBaseURL, &http.Client{Timeout: 30 * time.Second})
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, logger))
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, cascade, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"time"
@@ -71,6 +72,18 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	d.dispatch.ServeHTTP(w, r)
 }
 
+// notificationStateDeleter bridges the notification-state store's DeleteByUserID
+// (one watermark document per user) to the profiles cascade's ChildDeleter
+// contract (DeleteAllByUserID). The other four cascade stores already expose
+// DeleteAllByUserID and satisfy the interface directly.
+type notificationStateDeleter struct {
+	s *notificationstate.CosmosStore
+}
+
+func (d notificationStateDeleter) DeleteAllByUserID(ctx context.Context, userID string) error {
+	return d.s.DeleteByUserID(ctx, userID)
+}
+
 // newRouter wires the feature routes onto a mux and wraps it in the production
 // middleware chain. Ordering, from outermost to innermost, mirrors the .NET
 // pipeline (WebApplicationExtensions.UseMiddlewarePipeline):
@@ -93,7 +106,7 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // nil-means-unwired convention. (The watch-zone preferences endpoints are
 // served by profiles.Routes off the profile store, so they come up with the
 // /v1/me routes, not the watch-zone store.)
-func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, logger *slog.Logger) http.Handler {
+func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, cascade profiles.CascadeDeleters, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)
@@ -108,7 +121,7 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 
 	var dispatch http.Handler = mux
 	if store != nil {
-		profiles.Routes(mux, store, auth0, proDomains, time.Now, logger)
+		profiles.Routes(mux, store, auth0, proDomains, cascade, time.Now, logger)
 		dispatch = middleware.RateLimit(middleware.NewRateLimitStore(), profiles.NewTierLookup(store), logger)(
 			middleware.RecordActivity(profiles.NewActivityRecorder(store), time.Now, logger)(mux),
 		)

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -122,7 +122,7 @@ func testDesignationClient() *designations.Client {
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -227,7 +227,7 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	appStore := applications.NewCosmosStore(newFakeItems())
 	savedStore := savedapplications.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -310,7 +310,7 @@ func TestRouter_GeocodeAndDesignationsDispatch(t *testing.T) {
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
 	geocodeClient := geocoding.NewClient(upstream.URL, upstream.Client())
 	designationClient := designations.NewClient(upstream.URL, upstream.Client())
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", nil, nil, "", logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", nil, nil, "", logger)
 
 	rec := serveReq(t, h, http.MethodGet, "/v1/geocode/SW1A%201AA", "", "Bearer tok")
 	if rec.Code != http.StatusOK {
@@ -349,7 +349,7 @@ func TestRouter_SubscriptionsWired(t *testing.T) {
 		t.Fatalf("NewJWSVerifier: %v", err)
 	}
 
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, adminStore, "", verifier, notifStore, "uk.towncrierapp.mobile", logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, adminStore, "", verifier, notifStore, "uk.towncrierapp.mobile", logger)
 
 	// Webhook is anonymous: a malformed body reaches the handler -> 400 with the
 	// malformed_request envelope, not the WWW-Authenticate 401 fallback.
@@ -379,7 +379,7 @@ func TestRouter_AdminGate(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	offerStore := offercodes.NewCosmosStore(newFakeItems())
 	adminStore := profiles.NewAdminStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), offerStore, adminStore, "s3cret", nil, nil, "", logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), offerStore, adminStore, "s3cret", nil, nil, "", logger)
 
 	// No key: the admin gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).

--- a/api-go/internal/profiles/cascade.go
+++ b/api-go/internal/profiles/cascade.go
@@ -1,0 +1,30 @@
+package profiles
+
+import "context"
+
+// ChildDeleter erases every document a single per-user container holds for the
+// account being deleted. The per-container cascade stores expose this exact
+// method, so notifications.DeleteStore and the watchzones / savedapplications /
+// devicetokens CosmosStores satisfy it directly; the notification-state store is
+// bridged by a one-line adapter in the api wiring, since its method is
+// DeleteByUserID. Each store tolerates a 404 on an individual delete internally,
+// so any error returned here is real and must abort the cascade.
+type ChildDeleter interface {
+	DeleteAllByUserID(ctx context.Context, userID string) error
+}
+
+// CascadeDeleters bundles the per-container erasure steps DELETE /v1/me runs — in
+// the fixed order the handler invokes them — before deleting the profile document
+// and, last, the Auth0 user. It mirrors the dormant-cleanup worker's cascade so
+// account deletion is a complete UK GDPR Art. 17 erasure from either entry point
+// (bead tc-qkf2): the Go DELETE /v1/me handler previously deleted only the
+// profile and the Auth0 user, leaving watch zones, saved applications,
+// notifications, device registrations and the notification-state watermark
+// orphaned in Cosmos.
+type CascadeDeleters struct {
+	Notifications       ChildDeleter
+	WatchZones          ChildDeleter
+	SavedApplications   ChildDeleter
+	DeviceRegistrations ChildDeleter
+	NotificationState   ChildDeleter
+}

--- a/api-go/internal/profiles/handler.go
+++ b/api-go/internal/profiles/handler.go
@@ -31,21 +31,24 @@ type profileStore interface {
 }
 
 // handler serves the /v1/me lifecycle. It depends on the profile store, the
-// Auth0 management client (real or no-op), the auto-grant pro-domain list, a
-// clock, and a logger — all injected, no globals.
+// Auth0 management client (real or no-op), the per-container cascade deleters
+// account erasure runs, the auto-grant pro-domain list, a clock, and a logger —
+// all injected, no globals.
 type handler struct {
 	store      profileStore
 	auth0      Auth0Manager
+	cascade    CascadeDeleters
 	proDomains proDomainSet
 	now        func() time.Time
 	logger     *slog.Logger
 }
 
 // newHandler builds the /v1/me handler.
-func newHandler(store profileStore, auth0 Auth0Manager, proDomains string, now func() time.Time, logger *slog.Logger) *handler {
+func newHandler(store profileStore, auth0 Auth0Manager, proDomains string, cascade CascadeDeleters, now func() time.Time, logger *slog.Logger) *handler {
 	return &handler{
 		store:      store,
 		auth0:      auth0,
+		cascade:    cascade,
 		proDomains: newProDomainSet(proDomains),
 		now:        now,
 		logger:     logger,
@@ -54,8 +57,8 @@ func newHandler(store profileStore, auth0 Auth0Manager, proDomains string, now f
 
 // Routes registers the /v1/me endpoints on mux. All are authenticated: the auth
 // middleware guarantees a subject in context before these handlers run.
-func Routes(mux *http.ServeMux, store profileStore, auth0 Auth0Manager, proDomains string, now func() time.Time, logger *slog.Logger) {
-	h := newHandler(store, auth0, proDomains, now, logger)
+func Routes(mux *http.ServeMux, store profileStore, auth0 Auth0Manager, proDomains string, cascade CascadeDeleters, now func() time.Time, logger *slog.Logger) {
+	h := newHandler(store, auth0, proDomains, cascade, now, logger)
 	mux.HandleFunc("POST /v1/me", h.create)
 	mux.HandleFunc("GET /v1/me", h.get)
 	mux.HandleFunc("PATCH /v1/me", h.patch)
@@ -198,10 +201,21 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(w, r, profileResultFrom(profile))
 }
 
-// delete implements DELETE /v1/me. It reads first so a missing profile is a 404
-// before any cascade, then removes the profile from Cosmos and the user from
-// Auth0 (the Auth0 delete tolerates 404 internally). Child-record cascades land
-// with their stores in later iterations.
+// delete implements DELETE /v1/me as a complete UK GDPR Art. 17 erasure. It reads
+// first so a missing profile is a 404 before any cascade, then erases the user's
+// data from every per-user container, then the profile document, then — last —
+// the Auth0 user.
+//
+// Ordering is the safety contract: child records are removed before the profile,
+// so a mid-cascade failure leaves the profile present (GET still 200s) and the
+// account retryable by a repeat DELETE rather than half-erased; the Auth0 user is
+// deleted last so an Auth0 Management-API failure can never strand un-erased
+// Cosmos data. Each cascade store tolerates a 404 on an individual document
+// internally, and the Auth0 delete tolerates a 404, so the whole flow is
+// idempotent. This mirrors the dormant-cleanup worker's cascade (bead tc-qkf2):
+// the earlier Go handler deleted only the profile and the Auth0 user, orphaning
+// watch zones, saved applications, notifications, device registrations and the
+// notification-state watermark.
 func (h *handler) delete(w http.ResponseWriter, r *http.Request) {
 	subject := auth.Subject(r.Context())
 
@@ -211,6 +225,27 @@ func (h *handler) delete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		h.serverError(w, r, "load profile", err)
+		return
+	}
+
+	if err := h.cascade.Notifications.DeleteAllByUserID(r.Context(), subject); err != nil {
+		h.serverError(w, r, "delete notifications", err)
+		return
+	}
+	if err := h.cascade.WatchZones.DeleteAllByUserID(r.Context(), subject); err != nil {
+		h.serverError(w, r, "delete watch zones", err)
+		return
+	}
+	if err := h.cascade.SavedApplications.DeleteAllByUserID(r.Context(), subject); err != nil {
+		h.serverError(w, r, "delete saved applications", err)
+		return
+	}
+	if err := h.cascade.DeviceRegistrations.DeleteAllByUserID(r.Context(), subject); err != nil {
+		h.serverError(w, r, "delete device registrations", err)
+		return
+	}
+	if err := h.cascade.NotificationState.DeleteAllByUserID(r.Context(), subject); err != nil {
+		h.serverError(w, r, "delete notification state", err)
 		return
 	}
 

--- a/api-go/internal/profiles/handler_test.go
+++ b/api-go/internal/profiles/handler_test.go
@@ -3,10 +3,12 @@ package profiles
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -81,9 +83,42 @@ func (f *fakeAuth0) DeleteUser(_ context.Context, userID string) error {
 	return nil
 }
 
+// fakeChildDeleter is a hand-written per-container cascade deleter. When calls is
+// non-nil it appends "<label>:<userID>" on each invocation, so a test can assert
+// both coverage (which containers were erased) and order across a shared log.
+type fakeChildDeleter struct {
+	label string
+	calls *[]string
+	err   error
+}
+
+func (f fakeChildDeleter) DeleteAllByUserID(_ context.Context, userID string) error {
+	if f.calls != nil {
+		*f.calls = append(*f.calls, f.label+":"+userID)
+	}
+	return f.err
+}
+
+// recordingCascade builds a CascadeDeleters whose five deleters all append to the
+// shared calls log (pass nil for a no-op cascade). Individual deleters can be
+// overwritten by a test to inject a failure in one container.
+func recordingCascade(calls *[]string) CascadeDeleters {
+	return CascadeDeleters{
+		Notifications:       fakeChildDeleter{label: "notifications", calls: calls},
+		WatchZones:          fakeChildDeleter{label: "watchZones", calls: calls},
+		SavedApplications:   fakeChildDeleter{label: "savedApplications", calls: calls},
+		DeviceRegistrations: fakeChildDeleter{label: "deviceRegistrations", calls: calls},
+		NotificationState:   fakeChildDeleter{label: "notificationState", calls: calls},
+	}
+}
+
 func newTestHandler(store profileStore, a0 Auth0Manager, proDomains string) *handler {
+	return newTestHandlerCascade(store, a0, proDomains, recordingCascade(nil))
+}
+
+func newTestHandlerCascade(store profileStore, a0 Auth0Manager, proDomains string, cascade CascadeDeleters) *handler {
 	now := func() time.Time { return time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC) }
-	return newHandler(store, a0, proDomains, now, slog.New(slog.DiscardHandler))
+	return newHandler(store, a0, proDomains, cascade, now, slog.New(slog.DiscardHandler))
 }
 
 // withSubject builds a request carrying an authenticated subject in context, as
@@ -317,14 +352,15 @@ func TestHandler_PatchProfile_NotFound(t *testing.T) {
 	}
 }
 
-func TestHandler_DeleteProfile_NoContentAndCascades(t *testing.T) {
+func TestHandler_DeleteProfile_CascadesEveryContainerThenProfileThenAuth0(t *testing.T) {
 	t.Parallel()
 
 	store := newFakeStore()
 	existing, _ := NewProfile("auth0|abc", "", time.Now())
 	store.byID["auth0|abc"] = existing
 	a0 := newFakeAuth0()
-	h := newTestHandler(store, a0, "")
+	var calls []string
+	h := newTestHandlerCascade(store, a0, "", recordingCascade(&calls))
 
 	rec := httptest.NewRecorder()
 	h.delete(rec, withSubject(http.MethodDelete, "/v1/me", "auth0|abc", ""))
@@ -335,6 +371,18 @@ func TestHandler_DeleteProfile_NoContentAndCascades(t *testing.T) {
 	if rec.Body.Len() != 0 {
 		t.Errorf("204 should be bodyless, got %q", rec.Body.String())
 	}
+	// Complete UK GDPR Art. 17 erasure: every per-user container is cleared, in a
+	// fixed order, before the profile document is removed.
+	want := []string{
+		"notifications:auth0|abc",
+		"watchZones:auth0|abc",
+		"savedApplications:auth0|abc",
+		"deviceRegistrations:auth0|abc",
+		"notificationState:auth0|abc",
+	}
+	if !slices.Equal(calls, want) {
+		t.Errorf("cascade coverage/order: got %v, want %v", calls, want)
+	}
 	if len(store.deleted) != 1 || store.deleted[0] != "auth0|abc" {
 		t.Errorf("profile not deleted from store: %v", store.deleted)
 	}
@@ -343,17 +391,77 @@ func TestHandler_DeleteProfile_NoContentAndCascades(t *testing.T) {
 	}
 }
 
+// A child-container erasure failure must abort the cascade before the profile and
+// the Auth0 user are touched, so the account stays intact and a repeat DELETE can
+// retry the erasure (no partial, irrecoverable deletion).
+func TestHandler_DeleteProfile_ChildCascadeFailureLeavesProfileAndAuth0Intact(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	existing, _ := NewProfile("auth0|abc", "", time.Now())
+	store.byID["auth0|abc"] = existing
+	a0 := newFakeAuth0()
+	cascade := recordingCascade(nil)
+	cascade.WatchZones = fakeChildDeleter{label: "watchZones", err: errors.New("cosmos down")}
+	h := newTestHandlerCascade(store, a0, "", cascade)
+
+	rec := httptest.NewRecorder()
+	h.delete(rec, withSubject(http.MethodDelete, "/v1/me", "auth0|abc", ""))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("delete status: got %d, want 500", rec.Code)
+	}
+	if len(store.deleted) != 0 {
+		t.Errorf("profile must survive a child-cascade failure, got deleted %v", store.deleted)
+	}
+	if len(a0.deletedUsers) != 0 {
+		t.Errorf("auth0 user must survive a child-cascade failure, got deleted %v", a0.deletedUsers)
+	}
+}
+
+// Auth0 is deleted last: an Auth0 Management-API failure must not strand
+// un-erased Cosmos data, so by the time it runs every container and the profile
+// document are already gone.
+func TestHandler_DeleteProfile_Auth0DeletedAfterAllCosmosData(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	existing, _ := NewProfile("auth0|abc", "", time.Now())
+	store.byID["auth0|abc"] = existing
+	a0 := newFakeAuth0()
+	a0.deleteErr = errors.New("auth0 m2m down")
+	var calls []string
+	h := newTestHandlerCascade(store, a0, "", recordingCascade(&calls))
+
+	rec := httptest.NewRecorder()
+	h.delete(rec, withSubject(http.MethodDelete, "/v1/me", "auth0|abc", ""))
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("delete status: got %d, want 500", rec.Code)
+	}
+	if len(calls) != 5 {
+		t.Errorf("all child containers must be erased before the auth0 step, got %v", calls)
+	}
+	if len(store.deleted) != 1 {
+		t.Errorf("profile must be erased before the auth0 step, got %v", store.deleted)
+	}
+}
+
 func TestHandler_DeleteProfile_NotFound(t *testing.T) {
 	t.Parallel()
 
 	a0 := newFakeAuth0()
-	h := newTestHandler(newFakeStore(), a0, "")
+	var calls []string
+	h := newTestHandlerCascade(newFakeStore(), a0, "", recordingCascade(&calls))
 	rec := httptest.NewRecorder()
 	h.delete(rec, withSubject(http.MethodDelete, "/v1/me", "auth0|missing", ""))
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("delete missing: got %d, want 404", rec.Code)
 	}
-	// No Auth0 deletion when the profile did not exist.
+	// No cascade and no Auth0 deletion when the profile did not exist.
+	if len(calls) != 0 {
+		t.Errorf("cascade should not run for a missing profile: %v", calls)
+	}
 	if len(a0.deletedUsers) != 0 {
 		t.Errorf("auth0 delete should not run for a missing profile: %v", a0.deletedUsers)
 	}


### PR DESCRIPTION
## Changes

Fixes **tc-qkf2** (go-live blocker). The Go `DELETE /v1/me` handler deleted only the Users profile document and the Auth0 user, leaving the caller's **watch zones, saved applications, notifications, device registrations, and notification-state watermark** orphaned in Cosmos — an incomplete UK GDPR Art. 17 erasure and a regression from the retired .NET handler (which cascaded). Confirmed live on prod Cosmos.

- New `profiles.CascadeDeleters` bundle (`internal/profiles/cascade.go`) — the five per-container `DeleteAllByUserID` deleters.
- `handler.delete()` runs the full cascade **before** deleting the profile, with the **Auth0 user deleted last** so an Auth0 Management-API failure can never strand un-erased Cosmos data. A mid-cascade failure leaves the account intact and retryable; each store tolerates a per-doc 404, so the flow is idempotent.
- The delete-all stores already existed and were proven by the dormant-cleanup worker (`dormant.erase`) — the HTTP handler simply was never wired to them. `cmd/api` now builds the cascade (`notifications.NewDeleteStore` + four existing stores + a one-line `notificationStateDeleter` adapter) and threads it through `newRouter` → `profiles.Routes`.
- Tests (TDD): cascade covers all five containers in order; a child failure aborts before the profile/Auth0 are touched; Auth0 runs only after all Cosmos data is gone; a missing profile still 404s with no cascade.

**Scope:** Go only — the .NET handler is untouched (being retired). Data remediation for pre-fix orphans was already done (tc-ui6k; prod 0 orphans).

**Discovered-from follow-ups filed:** tc-5jyh (offer-code `redeemedByUserId` back-reference still left behind by *both* erasure paths — P2, decide block-vs-fast-follow) and tc-gf0g (unify the dormant + `DELETE /v1/me` cascades into one shared impl to prevent future drift — P3).

Gates: `go test -race ./...` 823 pass · gofmt clean · go vet clean · golangci-lint clean.

---
*Auto-shipped via ship skill*