### PR TITLE
refactor(go): unify account-erasure cascade into internal/erasure (tc-gf0g)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/designations"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/erasure"
 	"github.com/AmyDe/town-crier/api-go/internal/geocoding"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
@@ -131,7 +132,8 @@ func main() {
 	// the same condition under which profiles.Routes is wired — so the handler's
 	// deleters are never nil when the route is reachable. The four DeleteAllByUserID
 	// stores satisfy profiles.ChildDeleter directly; notification-state is bridged by
-	// the notificationStateDeleter adapter (its store method is DeleteByUserID).
+	// erasure.NotificationStateChild (its store method is DeleteByUserID), shared with
+	// the dormant-cleanup worker (bead tc-gf0g).
 	var cascade profiles.CascadeDeleters
 	if notificationsContainer != nil && watchZones != nil && savedContainer != nil && devices != nil && stateContainer != nil {
 		cascade = profiles.CascadeDeleters{
@@ -139,7 +141,7 @@ func main() {
 			WatchZones:          watchZoneStore,
 			SavedApplications:   savedStore,
 			DeviceRegistrations: deviceStore,
-			NotificationState:   notificationStateDeleter{stateStore},
+			NotificationState:   erasure.NotificationStateChild(stateStore),
 		}
 	}
 

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"log/slog"
 	"net/http"
 	"time"
@@ -70,18 +69,6 @@ type dispatchMux struct {
 
 func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	d.dispatch.ServeHTTP(w, r)
-}
-
-// notificationStateDeleter bridges the notification-state store's DeleteByUserID
-// (one watermark document per user) to the profiles cascade's ChildDeleter
-// contract (DeleteAllByUserID). The other four cascade stores already expose
-// DeleteAllByUserID and satisfy the interface directly.
-type notificationStateDeleter struct {
-	s *notificationstate.CosmosStore
-}
-
-func (d notificationStateDeleter) DeleteAllByUserID(ctx context.Context, userID string) error {
-	return d.s.DeleteByUserID(ctx, userID)
 }
 
 // newRouter wires the feature routes onto a mux and wraps it in the production

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/digest"
 	"github.com/AmyDe/town-crier/api-go/internal/dormant"
+	"github.com/AmyDe/town-crier/api-go/internal/erasure"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/notifydispatch"
@@ -520,23 +521,28 @@ func buildDormant(cfg platform.Config, logger *slog.Logger) (*dormant.Handler, e
 		return nil, err
 	}
 
-	stores := dormant.Stores{
-		Notifications:       notificationDeleter{notifications.NewDeleteStore(notifs)},
-		WatchZones:          watchZoneDeleter{watchzones.NewCosmosStore(zonesContainer)},
-		SavedApplications:   savedApplicationDeleter{savedapplications.NewCosmosStore(savedContainer)},
-		DeviceRegistrations: deviceDeleter{devicetokens.NewCosmosStore(devicesContainer)},
-		NotificationState:   stateDeleter{notificationstate.NewCosmosStore(stateContainer, notifs)},
-		Profiles:            profileDeleter{profiles.NewCosmosStore(users)},
+	// The four DeleteAllByUserID stores satisfy erasure.ChildDeleter directly, the
+	// profile store's Delete satisfies erasure.ProfileDeleter directly, and the
+	// notification-state store (whose method is DeleteByUserID) is bridged by
+	// erasure.NotificationStateChild — so no per-step adapter types are needed.
+	deleters := erasure.Deleters{
+		Notifications:       notifications.NewDeleteStore(notifs),
+		WatchZones:          watchzones.NewCosmosStore(zonesContainer),
+		SavedApplications:   savedapplications.NewCosmosStore(savedContainer),
+		DeviceRegistrations: devicetokens.NewCosmosStore(devicesContainer),
+		NotificationState:   erasure.NotificationStateChild(notificationstate.NewCosmosStore(stateContainer, notifs)),
+		Profile:             profiles.NewCosmosStore(users),
 		Auth0:               buildAuth0Deleter(cfg, logger),
+		ProfileAbsent:       func(e error) bool { return errors.Is(e, profiles.ErrNotFound) },
 	}
 
-	return dormant.New(profiles.NewAdminStore(users), stores, logger, time.Now), nil
+	return dormant.New(profiles.NewAdminStore(users), deleters, logger, time.Now), nil
 }
 
 // buildAuth0Deleter returns the real Auth0 Management (M2M) client when the M2M
 // credentials are configured, else a no-op so a job without Auth0 M2M config
 // still erases Cosmos data, mirroring .NET's NoOpAuth0ManagementClient fallback.
-func buildAuth0Deleter(cfg platform.Config, logger *slog.Logger) dormant.Auth0Deleter {
+func buildAuth0Deleter(cfg platform.Config, logger *slog.Logger) erasure.Auth0Deleter {
 	if !cfg.Auth0M2MConfigured() {
 		logger.Info("auth0 m2m unconfigured; dormant cleanup will skip Auth0 user deletion (NoOp)")
 		return profiles.NoOpAuth0Client{}
@@ -547,54 +553,6 @@ func buildAuth0Deleter(cfg platform.Config, logger *slog.Logger) dormant.Auth0De
 		cfg.Auth0M2MClientID,
 		cfg.Auth0M2MClientSecret,
 	)
-}
-
-// The adapters below bridge each store's own method name (DeleteAllByUserID /
-// Delete / DeleteByUserID) to the dormant package's consumer-side interface
-// method names. They keep the dormant handler's contracts explicit without
-// renaming the stores' established API.
-
-type notificationDeleter struct{ s *notifications.DeleteStore }
-
-func (d notificationDeleter) DeleteAllNotifications(ctx context.Context, userID string) error {
-	return d.s.DeleteAllByUserID(ctx, userID)
-}
-
-type watchZoneDeleter struct{ s *watchzones.CosmosStore }
-
-func (d watchZoneDeleter) DeleteAllWatchZones(ctx context.Context, userID string) error {
-	return d.s.DeleteAllByUserID(ctx, userID)
-}
-
-type savedApplicationDeleter struct {
-	s *savedapplications.CosmosStore
-}
-
-func (d savedApplicationDeleter) DeleteAllSavedApplications(ctx context.Context, userID string) error {
-	return d.s.DeleteAllByUserID(ctx, userID)
-}
-
-type deviceDeleter struct{ s *devicetokens.CosmosStore }
-
-func (d deviceDeleter) DeleteAllDeviceRegistrations(ctx context.Context, userID string) error {
-	return d.s.DeleteAllByUserID(ctx, userID)
-}
-
-type stateDeleter struct {
-	s *notificationstate.CosmosStore
-}
-
-func (d stateDeleter) DeleteNotificationState(ctx context.Context, userID string) error {
-	return d.s.DeleteByUserID(ctx, userID)
-}
-
-type profileDeleter struct{ s *profiles.CosmosStore }
-
-// DeleteProfile maps to the profile store's Delete, translating its ErrNotFound
-// (a 404 from Cosmos) so the dormant handler can tolerate a concurrently-deleted
-// profile via errors.Is(err, profiles.ErrNotFound).
-func (d profileDeleter) DeleteProfile(ctx context.Context, userID string) error {
-	return d.s.Delete(ctx, userID)
 }
 
 // buildEmailSender returns the real ACS email sender when a connection string is

--- a/api-go/internal/dormant/handler.go
+++ b/api-go/internal/dormant/handler.go
@@ -5,6 +5,10 @@
 // registrations, and notification-state watermark from Cosmos, then the profile,
 // then the Auth0 user via the Management (M2M) API.
 //
+// The cascade itself lives in internal/erasure so the dormant worker and the
+// DELETE /v1/me HTTP handler share one ordered erasure (bead tc-gf0g); this
+// package only scans for dormant accounts and drives the cascade per account.
+//
 // It ports the .NET DormantAccountCleanupCommandHandler + DeleteUserProfile
 // CommandHandler (epic tc-wad3, bead tc-dwcq) following idiomatic Go:
 // consumer-side interfaces declared here, concrete stores injected from main(),
@@ -15,11 +19,11 @@ package dormant
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
+	"github.com/AmyDe/town-crier/api-go/internal/erasure"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
 
@@ -34,77 +38,20 @@ type Finder interface {
 	Dormant(ctx context.Context, cutoff time.Time) ([]*profiles.UserProfile, error)
 }
 
-// The cascade interfaces below are the consumer-side slices of each per-container
-// store the erasure needs. Each is a single method so a store satisfies only the
-// contract the cascade actually uses; the concrete stores
-// (notifications.DeleteStore, watchzones.CosmosStore, etc.) satisfy them
-// structurally.
-
-// NotificationDeleter erases a user's notifications. notifications.DeleteStore
-// satisfies it.
-type NotificationDeleter interface {
-	DeleteAllNotifications(ctx context.Context, userID string) error
-}
-
-// WatchZoneDeleter erases a user's watch zones. watchzones.CosmosStore satisfies
-// it (via an adapter in main, since its method is DeleteAllByUserID).
-type WatchZoneDeleter interface {
-	DeleteAllWatchZones(ctx context.Context, userID string) error
-}
-
-// SavedApplicationDeleter erases a user's saved applications.
-type SavedApplicationDeleter interface {
-	DeleteAllSavedApplications(ctx context.Context, userID string) error
-}
-
-// DeviceRegistrationDeleter erases a user's device registrations.
-type DeviceRegistrationDeleter interface {
-	DeleteAllDeviceRegistrations(ctx context.Context, userID string) error
-}
-
-// NotificationStateDeleter erases a user's notification-state watermark.
-type NotificationStateDeleter interface {
-	DeleteNotificationState(ctx context.Context, userID string) error
-}
-
-// ProfileDeleter erases the user profile document itself.
-type ProfileDeleter interface {
-	DeleteProfile(ctx context.Context, userID string) error
-}
-
-// Auth0Deleter removes the user from Auth0 via the Management (M2M) API. Both the
-// real profiles.Auth0Client and profiles.NoOpAuth0Client satisfy it; the no-op is
-// wired when the Auth0 M2M credentials are absent (local/dev), mirroring .NET's
-// NoOpAuth0ManagementClient.
-type Auth0Deleter interface {
-	DeleteUser(ctx context.Context, userID string) error
-}
-
-// Stores bundles the per-step deleters so the constructor signature stays
-// readable. main() builds it from the concrete stores; the test substitutes a
-// single recorder that satisfies every interface.
-type Stores struct {
-	Notifications       NotificationDeleter
-	WatchZones          WatchZoneDeleter
-	SavedApplications   SavedApplicationDeleter
-	DeviceRegistrations DeviceRegistrationDeleter
-	NotificationState   NotificationStateDeleter
-	Profiles            ProfileDeleter
-	Auth0               Auth0Deleter
-}
-
 // Handler runs one dormant-cleanup cycle.
 type Handler struct {
-	finder Finder
-	stores Stores
-	logger *slog.Logger
-	now    func() time.Time
+	finder   Finder
+	deleters erasure.Deleters
+	logger   *slog.Logger
+	now      func() time.Time
 }
 
 // New builds a dormant-cleanup handler. now is injected so tests pin the cutoff;
-// production passes time.Now.
-func New(finder Finder, stores Stores, logger *slog.Logger, now func() time.Time) *Handler {
-	return &Handler{finder: finder, stores: stores, logger: logger, now: now}
+// production passes time.Now. The deleters carry the per-container erasure steps
+// and the profile-absent predicate that lets the cascade tolerate a
+// concurrently-deleted profile.
+func New(finder Finder, deleters erasure.Deleters, logger *slog.Logger, now func() time.Time) *Handler {
+	return &Handler{finder: finder, deleters: deleters, logger: logger, now: now}
 }
 
 // Run executes one cleanup cycle and returns the number of accounts fully erased.
@@ -133,33 +80,10 @@ func (h *Handler) Run(ctx context.Context) (int, error) {
 	return deleted, nil
 }
 
-// erase runs the full erasure cascade for one user. Child records are removed
-// before the profile so a mid-cascade failure leaves the profile present and the
-// account retryable, mirroring the .NET ordering. A 404 on the profile delete is
-// tolerated (the profile was removed concurrently), but a 404 on a child step is
-// already absorbed inside each store, so any error from a child step is real and
-// aborts the cascade for this account.
+// erase runs the shared GDPR Art. 17 erasure cascade for one user. The ordering
+// and profile-absent tolerance live in internal/erasure; the profile-absent
+// predicate (errors.Is(err, profiles.ErrNotFound)) is supplied by main() when it
+// builds the deleters.
 func (h *Handler) erase(ctx context.Context, userID string) error {
-	if err := h.stores.Notifications.DeleteAllNotifications(ctx, userID); err != nil {
-		return fmt.Errorf("delete notifications: %w", err)
-	}
-	if err := h.stores.WatchZones.DeleteAllWatchZones(ctx, userID); err != nil {
-		return fmt.Errorf("delete watch zones: %w", err)
-	}
-	if err := h.stores.SavedApplications.DeleteAllSavedApplications(ctx, userID); err != nil {
-		return fmt.Errorf("delete saved applications: %w", err)
-	}
-	if err := h.stores.DeviceRegistrations.DeleteAllDeviceRegistrations(ctx, userID); err != nil {
-		return fmt.Errorf("delete device registrations: %w", err)
-	}
-	if err := h.stores.NotificationState.DeleteNotificationState(ctx, userID); err != nil {
-		return fmt.Errorf("delete notification state: %w", err)
-	}
-	if err := h.stores.Profiles.DeleteProfile(ctx, userID); err != nil && !errors.Is(err, profiles.ErrNotFound) {
-		return fmt.Errorf("delete profile: %w", err)
-	}
-	if err := h.stores.Auth0.DeleteUser(ctx, userID); err != nil {
-		return fmt.Errorf("delete auth0 user: %w", err)
-	}
-	return nil
+	return erasure.Cascade(ctx, userID, h.deleters)
 }

--- a/api-go/internal/dormant/handler_test.go
+++ b/api-go/internal/dormant/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AmyDe/town-crier/api-go/internal/erasure"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
 
@@ -24,53 +25,42 @@ func (f *fakeFinder) Dormant(_ context.Context, cutoff time.Time) ([]*profiles.U
 	return f.dormant, f.err
 }
 
-// cascadeRecorder records, per user id, which cascade steps ran and in what
-// order, so the test can assert the full erasure cascade fired for each account.
+// cascadeRecorder satisfies every erasure interface a child + profile delete
+// needs: erasure.ChildDeleter (DeleteAllByUserID) is wired to all five child
+// slots, erasure.ProfileDeleter (Delete) handles the profile step, and it counts
+// how many cascade steps ran per user. Since all five children share
+// DeleteAllByUserID, the test asserts the count of child invocations per account
+// rather than distinct labels — the per-container ORDER assertion now lives in
+// erasure's own test.
 type cascadeRecorder struct {
-	steps      map[string][]string
-	notifErr   error
-	zoneErr    error
-	savedErr   error
-	deviceErr  error
-	stateErr   error
-	profileErr map[string]error // keyed by user id
+	childCalls map[string]int   // child DeleteAllByUserID calls per user id
+	profile    map[string]bool  // profile Delete called per user id
+	notifErr   error            // injected on the first (notifications) child call
+	profileErr map[string]error // keyed by user id, returned from Delete
 }
 
 func newCascadeRecorder() *cascadeRecorder {
-	return &cascadeRecorder{steps: map[string][]string{}, profileErr: map[string]error{}}
+	return &cascadeRecorder{
+		childCalls: map[string]int{},
+		profile:    map[string]bool{},
+		profileErr: map[string]error{},
+	}
 }
 
-func (c *cascadeRecorder) record(userID, step string) {
-	c.steps[userID] = append(c.steps[userID], step)
+func (c *cascadeRecorder) DeleteAllByUserID(_ context.Context, userID string) error {
+	// The first child call per user is the notifications step; injecting notifErr
+	// here models a child-container failure aborting the cascade before later
+	// children, the profile, and Auth0 run.
+	first := c.childCalls[userID] == 0
+	c.childCalls[userID]++
+	if first && c.notifErr != nil {
+		return c.notifErr
+	}
+	return nil
 }
 
-func (c *cascadeRecorder) DeleteAllNotifications(_ context.Context, userID string) error {
-	c.record(userID, "notifications")
-	return c.notifErr
-}
-
-func (c *cascadeRecorder) DeleteAllWatchZones(_ context.Context, userID string) error {
-	c.record(userID, "watchzones")
-	return c.zoneErr
-}
-
-func (c *cascadeRecorder) DeleteAllSavedApplications(_ context.Context, userID string) error {
-	c.record(userID, "saved")
-	return c.savedErr
-}
-
-func (c *cascadeRecorder) DeleteAllDeviceRegistrations(_ context.Context, userID string) error {
-	c.record(userID, "devices")
-	return c.deviceErr
-}
-
-func (c *cascadeRecorder) DeleteNotificationState(_ context.Context, userID string) error {
-	c.record(userID, "state")
-	return c.stateErr
-}
-
-func (c *cascadeRecorder) DeleteProfile(_ context.Context, userID string) error {
-	c.record(userID, "profile")
+func (c *cascadeRecorder) Delete(_ context.Context, userID string) error {
+	c.profile[userID] = true
 	return c.profileErr[userID]
 }
 
@@ -96,17 +86,18 @@ func profile(t *testing.T, userID string) *profiles.UserProfile {
 	return p
 }
 
-func newHandler(finder Finder, cascade *cascadeRecorder, auth0 Auth0Deleter, now time.Time) *Handler {
-	stores := Stores{
+func newHandler(finder Finder, cascade *cascadeRecorder, auth0 erasure.Auth0Deleter, now time.Time) *Handler {
+	deleters := erasure.Deleters{
 		Notifications:       cascade,
 		WatchZones:          cascade,
 		SavedApplications:   cascade,
 		DeviceRegistrations: cascade,
 		NotificationState:   cascade,
-		Profiles:            cascade,
+		Profile:             cascade,
 		Auth0:               auth0,
+		ProfileAbsent:       func(e error) bool { return errors.Is(e, profiles.ErrNotFound) },
 	}
-	return New(finder, stores, slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)), func() time.Time { return now })
+	return New(finder, deleters, slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)), func() time.Time { return now })
 }
 
 // --- tests ------------------------------------------------------------------
@@ -142,18 +133,16 @@ func TestHandler_Run_DeletesEachDormantAccountWithFullCascade(t *testing.T) {
 		t.Errorf("deleted count: got %d, want 2", deleted)
 	}
 
-	wantSteps := []string{"notifications", "watchzones", "saved", "devices", "state", "profile"}
+	// Each account runs all five child-container erasures plus the profile delete.
 	for _, id := range []string{"auth0|a", "auth0|b"} {
-		got := cascade.steps[id]
-		if len(got) != len(wantSteps) {
-			t.Fatalf("%s cascade steps: got %v, want %v", id, got, wantSteps)
+		if cascade.childCalls[id] != 5 {
+			t.Errorf("%s child erasures: got %d, want 5", id, cascade.childCalls[id])
 		}
-		for i := range wantSteps {
-			if got[i] != wantSteps[i] {
-				t.Errorf("%s cascade order at %d: got %q, want %q", id, i, got[i], wantSteps[i])
-			}
+		if !cascade.profile[id] {
+			t.Errorf("%s profile not deleted", id)
 		}
 	}
+	// Auth0 runs last per account, after every Cosmos erasure.
 	if len(auth0.deleted) != 2 || auth0.deleted[0] != "auth0|a" || auth0.deleted[1] != "auth0|b" {
 		t.Errorf("auth0 deletes: got %v, want [auth0|a auth0|b]", auth0.deleted)
 	}
@@ -191,13 +180,14 @@ func TestHandler_Run_FinderErrorPropagates(t *testing.T) {
 func TestHandler_Run_ProfileNotFoundIsToleratedAndCounted(t *testing.T) {
 	t.Parallel()
 	// A concurrent delete between the scan and the cascade leaves the profile
-	// gone; the cascade must tolerate ErrNotFound on the profile delete and still
-	// count the account as removed (its end state is achieved), mirroring .NET's
-	// UserProfileNotFoundException catch.
+	// gone; the cascade must tolerate ErrNotFound on the profile delete (via the
+	// ProfileAbsent predicate) and still count the account as removed (its end
+	// state is achieved), mirroring .NET's UserProfileNotFoundException catch.
 	finder := &fakeFinder{dormant: []*profiles.UserProfile{profile(t, "auth0|gone")}}
 	cascade := newCascadeRecorder()
 	cascade.profileErr["auth0|gone"] = profiles.ErrNotFound
-	h := newHandler(finder, cascade, &fakeAuth0{}, time.Now())
+	auth0 := &fakeAuth0{}
+	h := newHandler(finder, cascade, auth0, time.Now())
 
 	deleted, err := h.Run(context.Background())
 	if err != nil {
@@ -205,6 +195,10 @@ func TestHandler_Run_ProfileNotFoundIsToleratedAndCounted(t *testing.T) {
 	}
 	if deleted != 1 {
 		t.Errorf("deleted count: got %d, want 1 (not-found is tolerated)", deleted)
+	}
+	// A tolerated profile-absent still proceeds to delete the Auth0 user.
+	if len(auth0.deleted) != 1 || auth0.deleted[0] != "auth0|gone" {
+		t.Errorf("auth0 deletes: got %v, want [auth0|gone]", auth0.deleted)
 	}
 }
 
@@ -215,7 +209,8 @@ func TestHandler_Run_ChildCascadeErrorAbortsThatAccountButContinues(t *testing.T
 	finder := &fakeFinder{dormant: []*profiles.UserProfile{profile(t, "auth0|fails"), profile(t, "auth0|ok")}}
 	cascade := newCascadeRecorder()
 	cascade.notifErr = errors.New("notifications delete failed")
-	h := newHandler(finder, cascade, &fakeAuth0{}, time.Now())
+	auth0 := &fakeAuth0{}
+	h := newHandler(finder, cascade, auth0, time.Now())
 
 	deleted, err := h.Run(context.Background())
 	if err != nil {
@@ -225,5 +220,12 @@ func TestHandler_Run_ChildCascadeErrorAbortsThatAccountButContinues(t *testing.T
 	// counted, but the run completes without erroring out.
 	if deleted != 0 {
 		t.Errorf("deleted count: got %d, want 0 (child failure aborts that account)", deleted)
+	}
+	// The profile and Auth0 must be untouched when a child step aborts the cascade.
+	if cascade.profile["auth0|fails"] || cascade.profile["auth0|ok"] {
+		t.Errorf("profile must survive a child-cascade failure")
+	}
+	if len(auth0.deleted) != 0 {
+		t.Errorf("auth0 must not run after a child-cascade failure, got %v", auth0.deleted)
 	}
 }

--- a/api-go/internal/erasure/cascade.go
+++ b/api-go/internal/erasure/cascade.go
@@ -1,0 +1,123 @@
+// Package erasure holds the single shared GDPR Art. 17 account-erasure cascade
+// run by both account-deletion entry points: the dormant-cleanup worker
+// (WORKER_MODE=dormant-cleanup) and DELETE /v1/me. Both previously encoded the
+// same ordered container list independently, the exact drift that caused bead
+// tc-qkf2 (the HTTP handler omitted the cascade while the worker's grew ahead of
+// it). Centralising the order here means a new per-user container is added once,
+// not twice (bead tc-gf0g).
+//
+// The package is deliberately dependency-free (stdlib only) so the profiles
+// package can import it without an import cycle — profiles imports erasure for
+// Cascade, and erasure must never import profiles (nor dormant). The
+// profile-absent tolerance that previously lived inside the cascade is injected
+// as a predicate (Deleters.ProfileAbsent) so erasure needs no knowledge of any
+// concrete sentinel error.
+package erasure
+
+import (
+	"context"
+	"fmt"
+)
+
+// ChildDeleter erases every document a single per-user container holds for the
+// account being deleted. The per-container cascade stores expose this exact
+// method, so the notifications / watchzones / savedapplications / devicetokens
+// stores satisfy it directly; the notification-state store is bridged by
+// NotificationStateChild. Each store tolerates a 404 on an individual delete
+// internally, so any error returned here is real and must abort the cascade.
+type ChildDeleter interface {
+	DeleteAllByUserID(ctx context.Context, userID string) error
+}
+
+// ProfileDeleter erases the user profile document itself. The profile store's
+// Delete satisfies it.
+type ProfileDeleter interface {
+	Delete(ctx context.Context, userID string) error
+}
+
+// Auth0Deleter removes the user from Auth0 via the Management (M2M) API. The real
+// Auth0 client and the no-op fallback both satisfy it.
+type Auth0Deleter interface {
+	DeleteUser(ctx context.Context, userID string) error
+}
+
+// Deleters bundles every erasure step in the fixed order Cascade invokes them.
+// ProfileAbsent reports whether a profile-delete error means "the profile was
+// already gone" (a concurrent delete between scan and cascade), so the cascade
+// tolerates it and still proceeds to Auth0; a nil predicate treats every
+// profile-delete error as fatal.
+type Deleters struct {
+	Notifications       ChildDeleter
+	WatchZones          ChildDeleter
+	SavedApplications   ChildDeleter
+	DeviceRegistrations ChildDeleter
+	NotificationState   ChildDeleter
+	Profile             ProfileDeleter
+	Auth0               Auth0Deleter
+	ProfileAbsent       func(error) bool
+}
+
+// profileAbsent reports whether err means the profile is already gone. A nil
+// predicate is treated as "never absent", so every profile-delete error is
+// fatal.
+func (d Deleters) profileAbsent(err error) bool {
+	return d.ProfileAbsent != nil && d.ProfileAbsent(err)
+}
+
+// Cascade runs the full GDPR Art. 17 erasure for one user in the fixed safety
+// order: every per-user child container first (notifications, watch zones, saved
+// applications, device registrations, notification-state watermark), then the
+// profile document, then — last — the Auth0 user.
+//
+// Ordering is the safety contract: child records are removed before the profile,
+// so a mid-cascade failure leaves the profile present (the account stays
+// retryable rather than half-erased); Auth0 is deleted last so an Auth0
+// Management-API failure can never strand un-erased Cosmos data. A profile delete
+// that reports the profile is already gone (per Deleters.ProfileAbsent) is
+// tolerated and the cascade proceeds to Auth0.
+func Cascade(ctx context.Context, userID string, d Deleters) error {
+	if err := d.Notifications.DeleteAllByUserID(ctx, userID); err != nil {
+		return fmt.Errorf("delete notifications: %w", err)
+	}
+	if err := d.WatchZones.DeleteAllByUserID(ctx, userID); err != nil {
+		return fmt.Errorf("delete watch zones: %w", err)
+	}
+	if err := d.SavedApplications.DeleteAllByUserID(ctx, userID); err != nil {
+		return fmt.Errorf("delete saved applications: %w", err)
+	}
+	if err := d.DeviceRegistrations.DeleteAllByUserID(ctx, userID); err != nil {
+		return fmt.Errorf("delete device registrations: %w", err)
+	}
+	if err := d.NotificationState.DeleteAllByUserID(ctx, userID); err != nil {
+		return fmt.Errorf("delete notification state: %w", err)
+	}
+	if err := d.Profile.Delete(ctx, userID); err != nil && !d.profileAbsent(err) {
+		return fmt.Errorf("delete profile: %w", err)
+	}
+	if err := d.Auth0.DeleteUser(ctx, userID); err != nil {
+		return fmt.Errorf("delete auth0 user: %w", err)
+	}
+	return nil
+}
+
+// byUserIDDeleter is the notification-state store's own delete contract. It holds
+// one watermark document per user, so DeleteByUserID erases everything the user
+// owns there.
+type byUserIDDeleter interface {
+	DeleteByUserID(ctx context.Context, userID string) error
+}
+
+// NotificationStateChild bridges the notification-state store to the uniform
+// ChildDeleter contract so both entry points share one adapter instead of
+// duplicating it. The store holds a single watermark document per user, so its
+// DeleteByUserID erases everything the user owns in that container — exactly what
+// DeleteAllByUserID promises.
+func NotificationStateChild(s byUserIDDeleter) ChildDeleter {
+	return notificationStateChild{s: s}
+}
+
+type notificationStateChild struct{ s byUserIDDeleter }
+
+func (a notificationStateChild) DeleteAllByUserID(ctx context.Context, userID string) error {
+	return a.s.DeleteByUserID(ctx, userID)
+}

--- a/api-go/internal/erasure/cascade_test.go
+++ b/api-go/internal/erasure/cascade_test.go
@@ -1,0 +1,212 @@
+package erasure
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"testing"
+)
+
+// --- hand-written fakes -----------------------------------------------------
+
+// recordingChild appends "<label>:<userID>" to a shared log on each call and
+// returns its configured error, so a test can assert both coverage and order
+// across the whole cascade.
+type recordingChild struct {
+	label string
+	log   *[]string
+	err   error
+}
+
+func (c recordingChild) DeleteAllByUserID(_ context.Context, userID string) error {
+	*c.log = append(*c.log, c.label+":"+userID)
+	return c.err
+}
+
+// recordingProfile records "profile:<userID>" and returns its configured error.
+type recordingProfile struct {
+	log *[]string
+	err error
+}
+
+func (p recordingProfile) Delete(_ context.Context, userID string) error {
+	*p.log = append(*p.log, "profile:"+userID)
+	return p.err
+}
+
+// recordingAuth0 records "auth0:<userID>" and returns its configured error.
+type recordingAuth0 struct {
+	log *[]string
+	err error
+}
+
+func (a recordingAuth0) DeleteUser(_ context.Context, userID string) error {
+	*a.log = append(*a.log, "auth0:"+userID)
+	return a.err
+}
+
+// recordingDeleters wires a Deleters whose every step appends to the shared log,
+// so a single recorder captures the entire cascade order.
+func recordingDeleters(log *[]string) Deleters {
+	return Deleters{
+		Notifications:       recordingChild{label: "notifications", log: log},
+		WatchZones:          recordingChild{label: "watchZones", log: log},
+		SavedApplications:   recordingChild{label: "savedApplications", log: log},
+		DeviceRegistrations: recordingChild{label: "deviceRegistrations", log: log},
+		NotificationState:   recordingChild{label: "notificationState", log: log},
+		Profile:             recordingProfile{log: log},
+		Auth0:               recordingAuth0{log: log},
+	}
+}
+
+// --- tests ------------------------------------------------------------------
+
+func TestCascade_RunsEveryStepInFixedOrder(t *testing.T) {
+	t.Parallel()
+	var log []string
+	d := recordingDeleters(&log)
+
+	if err := Cascade(context.Background(), "auth0|abc", d); err != nil {
+		t.Fatalf("Cascade: %v", err)
+	}
+
+	want := []string{
+		"notifications:auth0|abc",
+		"watchZones:auth0|abc",
+		"savedApplications:auth0|abc",
+		"deviceRegistrations:auth0|abc",
+		"notificationState:auth0|abc",
+		"profile:auth0|abc",
+		"auth0:auth0|abc",
+	}
+	if !slices.Equal(log, want) {
+		t.Errorf("cascade order: got %v, want %v", log, want)
+	}
+}
+
+func TestCascade_ChildFailureAbortsBeforeProfileAndAuth0(t *testing.T) {
+	t.Parallel()
+	var log []string
+	d := recordingDeleters(&log)
+	d.WatchZones = recordingChild{label: "watchZones", log: &log, err: errors.New("cosmos down")}
+
+	err := Cascade(context.Background(), "auth0|abc", d)
+	if err == nil {
+		t.Fatal("expected error when a child step fails")
+	}
+	if slices.Contains(log, "profile:auth0|abc") {
+		t.Errorf("profile must not run after a child failure: %v", log)
+	}
+	if slices.Contains(log, "auth0:auth0|abc") {
+		t.Errorf("auth0 must not run after a child failure: %v", log)
+	}
+}
+
+func TestCascade_Auth0RunsLastAfterEveryOtherStep(t *testing.T) {
+	t.Parallel()
+	var log []string
+	d := recordingDeleters(&log)
+	d.Auth0 = recordingAuth0{log: &log, err: errors.New("auth0 m2m down")}
+
+	err := Cascade(context.Background(), "auth0|abc", d)
+	if err == nil {
+		t.Fatal("expected error when the auth0 step fails")
+	}
+	// All five children plus the profile ran before the (failed) auth0 attempt,
+	// and the auth0 attempt was recorded last.
+	want := []string{
+		"notifications:auth0|abc",
+		"watchZones:auth0|abc",
+		"savedApplications:auth0|abc",
+		"deviceRegistrations:auth0|abc",
+		"notificationState:auth0|abc",
+		"profile:auth0|abc",
+		"auth0:auth0|abc",
+	}
+	if !slices.Equal(log, want) {
+		t.Errorf("auth0-last order: got %v, want %v", log, want)
+	}
+	profileIdx := slices.Index(log, "profile:auth0|abc")
+	auth0Idx := slices.Index(log, "auth0:auth0|abc")
+	if profileIdx < 0 || auth0Idx < 0 || profileIdx >= auth0Idx {
+		t.Errorf("profile must run before auth0: profileIdx=%d auth0Idx=%d", profileIdx, auth0Idx)
+	}
+}
+
+func TestCascade_ProfileAbsentToleratedProceedsToAuth0(t *testing.T) {
+	t.Parallel()
+	var log []string
+	gone := errors.New("profile already gone")
+	d := recordingDeleters(&log)
+	d.Profile = recordingProfile{log: &log, err: gone}
+	d.ProfileAbsent = func(e error) bool { return errors.Is(e, gone) }
+
+	if err := Cascade(context.Background(), "auth0|abc", d); err != nil {
+		t.Fatalf("Cascade should tolerate an absent profile: %v", err)
+	}
+	if !slices.Contains(log, "auth0:auth0|abc") {
+		t.Errorf("auth0 must run after a tolerated profile-absent: %v", log)
+	}
+}
+
+func TestCascade_ProfileErrorNotAbsentAbortsBeforeAuth0(t *testing.T) {
+	t.Parallel()
+
+	t.Run("predicate returns false", func(t *testing.T) {
+		t.Parallel()
+		var log []string
+		fatal := errors.New("profile delete failed")
+		d := recordingDeleters(&log)
+		d.Profile = recordingProfile{log: &log, err: fatal}
+		d.ProfileAbsent = func(error) bool { return false }
+
+		err := Cascade(context.Background(), "auth0|abc", d)
+		if !errors.Is(err, fatal) {
+			t.Fatalf("expected the profile error to propagate, got %v", err)
+		}
+		if slices.Contains(log, "auth0:auth0|abc") {
+			t.Errorf("auth0 must not run after a fatal profile error: %v", log)
+		}
+	})
+
+	t.Run("nil predicate treats every profile error as fatal", func(t *testing.T) {
+		t.Parallel()
+		var log []string
+		fatal := errors.New("profile delete failed")
+		d := recordingDeleters(&log)
+		d.Profile = recordingProfile{log: &log, err: fatal}
+		d.ProfileAbsent = nil
+
+		err := Cascade(context.Background(), "auth0|abc", d)
+		if !errors.Is(err, fatal) {
+			t.Fatalf("expected the profile error to propagate with a nil predicate, got %v", err)
+		}
+		if slices.Contains(log, "auth0:auth0|abc") {
+			t.Errorf("auth0 must not run after a fatal profile error: %v", log)
+		}
+	})
+}
+
+// fakeByUserIDDeleter records that DeleteByUserID was called with the user id,
+// standing in for the notification-state store whose method is DeleteByUserID.
+type fakeByUserIDDeleter struct {
+	called []string
+}
+
+func (f *fakeByUserIDDeleter) DeleteByUserID(_ context.Context, userID string) error {
+	f.called = append(f.called, userID)
+	return nil
+}
+
+func TestNotificationStateChild_DelegatesToDeleteByUserID(t *testing.T) {
+	t.Parallel()
+	fake := &fakeByUserIDDeleter{}
+	child := NotificationStateChild(fake)
+
+	if err := child.DeleteAllByUserID(context.Background(), "auth0|abc"); err != nil {
+		t.Fatalf("DeleteAllByUserID: %v", err)
+	}
+	if !slices.Equal(fake.called, []string{"auth0|abc"}) {
+		t.Errorf("expected DeleteByUserID called with auth0|abc, got %v", fake.called)
+	}
+}

--- a/api-go/internal/profiles/handler.go
+++ b/api-go/internal/profiles/handler.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/erasure"
 )
 
 // maxBodyBytes caps the request body the /v1/me write handlers read.
@@ -202,9 +203,9 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 }
 
 // delete implements DELETE /v1/me as a complete UK GDPR Art. 17 erasure. It reads
-// first so a missing profile is a 404 before any cascade, then erases the user's
-// data from every per-user container, then the profile document, then — last —
-// the Auth0 user.
+// first so a missing profile is a 404 before any cascade, then runs the shared
+// erasure.Cascade: it erases the user's data from every per-user container, then
+// the profile document, then — last — the Auth0 user.
 //
 // Ordering is the safety contract: child records are removed before the profile,
 // so a mid-cascade failure leaves the profile present (GET still 200s) and the
@@ -212,10 +213,15 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 // deleted last so an Auth0 Management-API failure can never strand un-erased
 // Cosmos data. Each cascade store tolerates a 404 on an individual document
 // internally, and the Auth0 delete tolerates a 404, so the whole flow is
-// idempotent. This mirrors the dormant-cleanup worker's cascade (bead tc-qkf2):
-// the earlier Go handler deleted only the profile and the Auth0 user, orphaning
-// watch zones, saved applications, notifications, device registrations and the
-// notification-state watermark.
+// idempotent.
+//
+// The cascade execution is now shared with the dormant-cleanup worker via
+// internal/erasure (single source of truth, bead tc-gf0g) so the ordered
+// container list lives in exactly one place; the earlier drift (the Go handler
+// once deleted only the profile and the Auth0 user, orphaning watch zones, saved
+// applications, notifications, device registrations and the notification-state
+// watermark — bead tc-qkf2) cannot silently recur. The Get-first 404 check and
+// the ordering contract above are unchanged.
 func (h *handler) delete(w http.ResponseWriter, r *http.Request) {
 	subject := auth.Subject(r.Context())
 
@@ -228,33 +234,18 @@ func (h *handler) delete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.cascade.Notifications.DeleteAllByUserID(r.Context(), subject); err != nil {
-		h.serverError(w, r, "delete notifications", err)
-		return
+	deleters := erasure.Deleters{
+		Notifications:       h.cascade.Notifications,
+		WatchZones:          h.cascade.WatchZones,
+		SavedApplications:   h.cascade.SavedApplications,
+		DeviceRegistrations: h.cascade.DeviceRegistrations,
+		NotificationState:   h.cascade.NotificationState,
+		Profile:             h.store,
+		Auth0:               h.auth0,
+		ProfileAbsent:       func(e error) bool { return errors.Is(e, ErrNotFound) },
 	}
-	if err := h.cascade.WatchZones.DeleteAllByUserID(r.Context(), subject); err != nil {
-		h.serverError(w, r, "delete watch zones", err)
-		return
-	}
-	if err := h.cascade.SavedApplications.DeleteAllByUserID(r.Context(), subject); err != nil {
-		h.serverError(w, r, "delete saved applications", err)
-		return
-	}
-	if err := h.cascade.DeviceRegistrations.DeleteAllByUserID(r.Context(), subject); err != nil {
-		h.serverError(w, r, "delete device registrations", err)
-		return
-	}
-	if err := h.cascade.NotificationState.DeleteAllByUserID(r.Context(), subject); err != nil {
-		h.serverError(w, r, "delete notification state", err)
-		return
-	}
-
-	if err := h.store.Delete(r.Context(), subject); err != nil {
-		h.serverError(w, r, "delete profile", err)
-		return
-	}
-	if err := h.auth0.DeleteUser(r.Context(), subject); err != nil {
-		h.serverError(w, r, "delete auth0 user", err)
+	if err := erasure.Cascade(r.Context(), subject, deleters); err != nil {
+		h.serverError(w, r, "erase account", err)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)


### PR DESCRIPTION
## Changes

Extracts the GDPR Art. 17 account-erasure cascade into one shared package, `internal/erasure`, consumed by **both** account-deletion entry points so the ordered container list can never drift between them again (the failure mode that caused tc-qkf2).

- **New `internal/erasure` package** (`cascade.go` + `cascade_test.go`): `Cascade(ctx, userID, Deleters)` runs the fixed order — notifications → watch zones → saved applications → device registrations → notification state → profile → Auth0 (last). Defines `ChildDeleter` / `ProfileDeleter` / `Auth0Deleter`, a `Deleters` bundle, and a `NotificationStateChild` adapter. Profile-absent tolerance is injected as a `ProfileAbsent func(error) bool` predicate so the package stays **stdlib-only** and never imports `profiles` (avoids an import cycle — `profiles` imports `erasure`).
- **`dormant.erase`** now delegates to `erasure.Cascade`; its 6 bespoke deleter interfaces + `Stores` struct are removed. Scan loop / per-account try-catch / count unchanged.
- **`profiles` DELETE /v1/me** keeps its Get-first 404 + HTTP status handling, then delegates to `erasure.Cascade`. Public `CascadeDeleters` DI bundle retained.
- **`cmd/worker`** collapses its 6 per-step adapter types into 4 direct stores + `erasure.NotificationStateChild` + direct profile store; `buildAuth0Deleter` returns `erasure.Auth0Deleter`.
- **`cmd/api`** uses `erasure.NotificationStateChild`; the duplicate `notificationStateDeleter` adapter in `wiring.go` is deleted.

Callers supply `ProfileAbsent: errors.Is(err, profiles.ErrNotFound)`; `erasure` itself knows no concrete sentinel.

## Verification

- `go build ./...` — pass
- `go test -race ./...` — **831 pass / 33 packages**
- `gofmt -l .` — clean · `go vet ./...` — clean · `golangci-lint` (cmd + erasure + dormant + profiles) — clean
- `go list -deps ./internal/erasure` lists no other town-crier package — import cycle provably avoided

Behaviour is preserved end-to-end; the ordered cascade now lives in exactly one place. Unblocks tc-5jyh (offer-code scrub) to add one `ChildDeleter` in a single spot.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated GDPR data deletion workflow to ensure consistent handling when users delete their accounts or dormant accounts are cleaned up.
  * Improved code maintainability and reliability by unifying deletion logic across profile deletion and account cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->