### PR TITLE
fix(ci): give infra its own global.json after api/ deletion (tc-g9xs)

### DIFF
--- a/.github/actions/setup-dotnet-infra/action.yml
+++ b/.github/actions/setup-dotnet-infra/action.yml
@@ -9,7 +9,7 @@ runs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v5
       with:
-        global-json-file: api/global.json
+        global-json-file: infra/global.json
 
     - name: Install Pulumi CLI
       shell: bash

--- a/infra/global.json
+++ b/infra/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
The `setup-dotnet-infra` composite action pinned the .NET SDK via `api/global.json`, which was deleted in #466 (tc-tbyp.3). This broke every infra build/deploy — **cd-prod v0.15.4 failed** with `The specified global.json file 'api/global.json' does not exist`.

Fix: add `infra/global.json` (same `10.0.100` / `latestFeature` pin the api copy used) and repoint the action at it, so infra no longer depends on the removed .NET API directory. The action is used by cd-dev, cd-prod, and pr-gate infra-preview.

`cd infra && dotnet build` → 0 errors.

Discovered-from tc-tbyp.3. After merge, a fresh release (v0.15.5) re-runs cd-prod to complete the prod .NET ContainerApp teardown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)