### PR TITLE
docs: repoint stale .NET references to Go after Phase 3 decommission (tc-tbyp.5)

### DIFF
--- a/.claude/commands/verify-polling.md
+++ b/.claude/commands/verify-polling.md
@@ -12,7 +12,7 @@ Verify the Town Crier prod polling pipeline is healthy. Report concisely (green/
   - **⚠️ Do NOT use `az monitor app-insights query` for windows > ~1h.** This workspace only surfaces a partial/recent slice of data through the classic API. Longer windows will look like a telemetry gap that does not exist. This is a known false-positive source that has triggered incorrect "9-hour gap" findings in multiple past sessions.
 - **Service Bus**: namespace `sb-town-crier-prod` in `rg-town-crier-prod`, queue `poll`. Use `az servicebus queue show ... --query countDetails` — `az monitor metrics list` does NOT work for `Microsoft.ServiceBus/namespaces/queues`.
 - **Jobs**: `job-tc-poll-prod` (orchestrator, KEDA ~30s cadence), `job-tc-poll-bootstrap-prod` (cron `*/30 * * * *`). Both in `rg-town-crier-prod`.
-- **Worker role name** in telemetry: `town-crier-worker`.
+- **Worker role name** in telemetry: `town-crier-worker-go` (the Go worker; set via `OTEL_SERVICE_NAME` in `infra/EnvironmentStack.cs`).
 - **Lease counter names** (from PR #291 T17): `towncrier.polling.lease.acquired`, `towncrier.polling.lease.held_by_peer`, `towncrier.polling.lease.released_412`.
 
 ## Checks to run (in parallel where possible)
@@ -27,7 +27,7 @@ Confirm latest `CD Production` run is `completed / success` and newer than the m
 ### 2. Poll job not aborting
 ```bash
 az monitor app-insights query --app appi-town-crier-shared -g rg-town-crier-shared \
-  --analytics-query "traces | where timestamp > ago(1h) | where cloud_RoleName == 'town-crier-worker' | where message contains 'HandlerBudget' or message contains 'Aborting' | summarize count() by bin(timestamp, 5m) | order by timestamp asc"
+  --analytics-query "traces | where timestamp > ago(1h) | where cloud_RoleName == 'town-crier-worker-go' | where message contains 'HandlerBudget' or message contains 'Aborting' | summarize count() by bin(timestamp, 5m) | order by timestamp asc"
 az containerapp job execution list --name job-tc-poll-prod -g rg-town-crier-prod \
   --query "[].{start:properties.startTime, status:properties.status, name:name}" -o table | head -20
 ```
@@ -50,10 +50,10 @@ Expect non-zero `applications_ingested`, `authorities_polled`, `cycles_completed
 
 ```bash
 az monitor app-insights query --app appi-town-crier-shared -g rg-town-crier-shared \
-  --analytics-query "dependencies | where timestamp > ago(1h) | where target contains 'planit' and cloud_RoleName == 'town-crier-worker' | summarize arg_min(timestamp, resultCode) by cloud_RoleInstance | extend first_response_429 = (resultCode == '429') | summarize total_cycles = count(), cycles_with_first_429 = countif(first_response_429)"
+  --analytics-query "dependencies | where timestamp > ago(1h) | where target contains 'planit' and cloud_RoleName == 'town-crier-worker-go' | summarize arg_min(timestamp, resultCode) by cloud_RoleInstance | extend first_response_429 = (resultCode == '429') | summarize total_cycles = count(), cycles_with_first_429 = countif(first_response_429)"
 ```
 
-`cycles_with_first_429` **MUST be 0**. If non-zero, that's the symptom — point at `PlanItClient.cs` / the retry-after handling in the orchestrator's next-message scheduler.
+`cycles_with_first_429` **MUST be 0**. If non-zero, that's the symptom — point at `api-go/internal/planit/client.go` / the retry-after handling in the next-run scheduler (`api-go/internal/polling/scheduler.go`).
 
 For context only (not a pass/fail signal), you can also report the 429 distribution, but state it as expected cadence not a concern:
 
@@ -64,7 +64,7 @@ az monitor app-insights query --app appi-town-crier-shared -g rg-town-crier-shar
 
 `failures` (excluding 429) must be near 0. `rate429` being non-zero is fine — that's the cycle termination marker.
 
-**Retry-After value distribution** — what is PlanIt actually asking us to wait? The worker emits `towncrier.polling.retry_after_seconds` (histogram) on every 429 with the parsed `Retry-After` header value, tagged `header_present=true|false`. Use this to confirm whether the configured `RetryAfterCap` (currently 3h, [PollNextRunSchedulerOptions.cs:14](api/src/town-crier.application/Polling/PollNextRunSchedulerOptions.cs)) is large enough for the values PlanIt is sending:
+**Retry-After value distribution** — what is PlanIt actually asking us to wait? The worker emits `towncrier.polling.retry_after_seconds` (histogram) on every 429 with the parsed `Retry-After` header value, tagged `header_present=true|false`. Use this to confirm whether the configured `RetryAfterCap` (currently 3h, default in [scheduler.go](api-go/internal/polling/scheduler.go) → `SchedulerOptions.RetryAfterCap`) is large enough for the values PlanIt is sending:
 
 ```bash
 az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
@@ -78,7 +78,7 @@ az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 
   --analytics-query "AppMetrics | where TimeGenerated > ago(6h) | where Name == 'towncrier.polling.retry_after_seconds' | extend header_present = tostring(Properties['header_present']), authority = tostring(Properties['polling.authority_code']) | summarize samples=count() by header_present, authority | order by samples desc | take 10"
 ```
 
-A high `header_present='false'` count means PlanIt isn't sending `Retry-After` at all, and we're falling back to the configured default — point at `PollNextRunScheduler.cs` retry-after parsing if `cycles_with_first_429` is also non-zero.
+A high `header_present='false'` count means PlanIt isn't sending `Retry-After` at all, and we're falling back to the configured default — point at the retry-after parsing in `api-go/internal/planit/retryafter.go` / the next-run scheduler (`api-go/internal/polling/scheduler.go`) if `cycles_with_first_429` is also non-zero.
 
 **3c. Only 1 thread at a time (lease CAS)**
 ```bash
@@ -101,7 +101,7 @@ Steady state: `active + scheduled ∈ {0, 1}`. `{a:0, s:1}` is healthy (next pol
 
 **3e. Keeping up with the authority backlog (oldest LastPollTime age)**
 
-> **Naming note:** the metric is `towncrier.polling.oldest_hwm_age_seconds` for legacy reasons (PR #298 / tc-m6fx split LastPollTime from HighWaterMark but kept the metric name). The value is the **LastPollTime age**, not the HighWaterMark age — see the description in [PollingMetrics.cs](api/src/town-crier.application/Observability/PollingMetrics.cs).
+> **Naming note:** the metric is `towncrier.polling.oldest_hwm_age_seconds` for legacy reasons (PR #298 / tc-m6fx split LastPollTime from HighWaterMark but kept the metric name). The value is the **LastPollTime age**, not the HighWaterMark age — the metric is emitted from the polling worker (`api-go/internal/polling`).
 
 This check focuses on **polled** authorities (`never_polled='false'`). The never-polled cohort is covered by 3g — they always report `(now − UnixEpoch)` which is huge by design and would otherwise dominate this signal.
 
@@ -136,7 +136,7 @@ Pass conditions:
 - Latest `count_` equals the count of authorities added in the most recent CD deploy and the deploy was within the last 6h (fresh-deploy transient).
 
 Fail conditions:
-- Latest `count_` is non-zero AND has been flat or rising for ≥6h after a deploy that's been live ≥6h. Point at `CycleAlternatingAuthorityProvider`, `CosmosPollStateStore.GetLeastRecentlyPolledAsync`, and `PollPlanItCommandHandler`'s natural-end branch (lines 296-308) — that's the drain path.
+- Latest `count_` is non-zero AND has been flat or rising for ≥6h after a deploy that's been live ≥6h. Point at `CycleAlternatingProvider` (`api-go/internal/polling/authorities.go`), `PollStateStore.GetLeastRecentlyPolled` (`api-go/internal/polling/statestore.go`), and the natural-end branch of the poll handler (`api-go/internal/polling/handler.go`) — that's the drain path.
 - Metric is missing from telemetry. Confirm the worker image is post-tc-ifdl deploy.
 
 The Watched cycle reports its own `never_polled_count` (count of watch-zone authorities with no state — usually 0). Filter on `cycle.type == 'seed'` for the canonical drain signal; report Watched separately only if non-zero.
@@ -144,7 +144,7 @@ The Watched cycle reports its own `never_polled_count` (count of watch-zone auth
 ### 4. Exceptions sanity check
 ```bash
 az monitor app-insights query --app appi-town-crier-shared -g rg-town-crier-shared \
-  --analytics-query "exceptions | where timestamp > ago(1h) | where cloud_RoleName == 'town-crier-worker' | summarize count() by type, outerMessage | top 10 by count_"
+  --analytics-query "exceptions | where timestamp > ago(1h) | where cloud_RoleName == 'town-crier-worker-go' | summarize count() by type, outerMessage | top 10 by count_"
 ```
 Should be empty or known-benign. `PlanItRateLimitException` is expected (see 3b) and is not a concern in any volume — do not flag it.
 
@@ -165,7 +165,7 @@ az containerapp job execution list --name job-tc-poll-bootstrap-prod -g rg-town-
 
 # Per-instance counters since deploy — each AppRoleInstance is one job execution
 az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
-  --analytics-query "AppMetrics | where TimeGenerated > datetime('$DEPLOY_TS') | where AppRoleName == 'town-crier-worker' | where Name in ('towncrier.polling.applications_ingested','towncrier.polling.authorities_polled','towncrier.polling.authorities_skipped','towncrier.polling.cycles_completed','towncrier.polling.cursor_advanced','towncrier.polling.rate_limited','towncrier.polling.lease.acquired','towncrier.polling.lease.held_by_peer','towncrier.polling.lease.released_412') | summarize total=sum(Sum) by AppRoleInstance, Name | order by AppRoleInstance asc, Name asc"
+  --analytics-query "AppMetrics | where TimeGenerated > datetime('$DEPLOY_TS') | where AppRoleName == 'town-crier-worker-go' | where Name in ('towncrier.polling.applications_ingested','towncrier.polling.authorities_polled','towncrier.polling.authorities_skipped','towncrier.polling.cycles_completed','towncrier.polling.cursor_advanced','towncrier.polling.rate_limited','towncrier.polling.lease.acquired','towncrier.polling.lease.held_by_peer','towncrier.polling.lease.released_412') | summarize total=sum(Sum) by AppRoleInstance, Name | order by AppRoleInstance asc, Name asc"
 
 # Oldest-LastPollTime age per cycle since deploy — one emission per cycle at cycle start
 az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
@@ -177,7 +177,7 @@ az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 
 
 # Map AppRoleInstance -> execution by first-seen timestamp (matches execution startTime within a few seconds)
 az monitor log-analytics query --workspace 842645cf-1439-4a2b-80e8-54bd02e326f9 \
-  --analytics-query "union AppMetrics, AppTraces | where TimeGenerated > datetime('$DEPLOY_TS') | where AppRoleName == 'town-crier-worker' | summarize firstSeen=min(TimeGenerated), lastSeen=max(TimeGenerated) by AppRoleInstance | order by firstSeen asc"
+  --analytics-query "union AppMetrics, AppTraces | where TimeGenerated > datetime('$DEPLOY_TS') | where AppRoleName == 'town-crier-worker-go' | summarize firstSeen=min(TimeGenerated), lastSeen=max(TimeGenerated) by AppRoleInstance | order by firstSeen asc"
 ```
 
 Match each `cloud_RoleInstance` to an execution by taking the execution whose `startTime` is within ~30s before `firstSeen`. Short-lived instances (~6s lifetime, `lease.acquired=1` only) are bootstrap ticks — label them as such.

--- a/.claude/skills/legal/SKILL.md
+++ b/.claude/skills/legal/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: legal
-description: "Autonomous UK GDPR auditor for Town Crier — scans the codebase to inventory personal data collected, third-party processors, cross-border data flows, and cookies, then compares against the live Terms of Service and Privacy Policy (served from `GetLegalDocumentQueryHandler.cs`). Produces a gap report, files a bead, updates the copy, and files separate beads for any code-level compliance gaps found. MUST use this skill whenever the user says 'legal audit', 'privacy audit', 'privacy review', 'GDPR check', 'compliance check', 'update terms', 'update privacy policy', 'data audit', 'check data processors', 'privacy policy is stale', 'terms are stale', '/legal', or any variation of wanting to ensure the Terms of Service and Privacy Policy accurately reflect the codebase and meet UK GDPR transparency requirements. Also trigger proactively whenever a new third-party integration, new personal data field, or new data flow is added to the codebase."
+description: "Autonomous UK GDPR auditor for Town Crier — scans the codebase to inventory personal data collected, third-party processors, cross-border data flows, and cookies, then compares against the live Terms of Service and Privacy Policy (served from `api-go/internal/legal/handler.go`). Produces a gap report, files a bead, updates the copy, and files separate beads for any code-level compliance gaps found. MUST use this skill whenever the user says 'legal audit', 'privacy audit', 'privacy review', 'GDPR check', 'compliance check', 'update terms', 'update privacy policy', 'data audit', 'check data processors', 'privacy policy is stale', 'terms are stale', '/legal', or any variation of wanting to ensure the Terms of Service and Privacy Policy accurately reflect the codebase and meet UK GDPR transparency requirements. Also trigger proactively whenever a new third-party integration, new personal data field, or new data flow is added to the codebase."
 ---
 
 # Legal Audit
@@ -17,22 +17,23 @@ App Store and Play Store policy compliance is in scope only where it directly af
 
 This skill produces **three things**:
 1. A gap report in the conversation (what drifts, what's missing)
-2. Updates to `api/src/town-crier.application/Legal/GetLegalDocumentQueryHandler.cs` and the associated tests, committed via PR through a single bead that is created and closed in one pass
+2. Updates to `api-go/internal/legal/handler.go` and the associated tests, committed via PR through a single bead that is created and closed in one pass
 3. **Separate** beads for any finding that requires a code change beyond the legal copy (e.g., "add a cookie banner", "implement account deletion endpoint", "add data export endpoint"). Leave these beads open for later work.
 
 If no drift is found, report `Legal audit: no drift detected` and exit. Do nothing.
 
 ## Where the Legal Copy Lives
 
-The Terms of Service and Privacy Policy are **not** static files. They are served from a .NET handler:
+The Terms of Service and Privacy Policy are **not** static files. They are served from the Go API:
 
-- **File:** `api/src/town-crier.application/Legal/GetLegalDocumentQueryHandler.cs`
-- **Served by:** `api/src/town-crier.web/Endpoints/LegalEndpoints.cs` at `GET /legal/{documentType}` where documentType is `privacy` or `terms`
+- **File:** `api-go/internal/legal/handler.go` (loads and serves the embedded copy)
+- **Served by:** the same file — `legal.Routes` registers `GET /v1/legal/{documentType}` (wired in `api-go/cmd/api/wiring.go`) where documentType is `privacy` or `terms`
+- **Canonical copy:** the JSON source lives at `api-go/internal/legal/resources/{privacy,terms}.json` (embedded at build time)
 - **Rendered by:** iOS (`mobile/ios/packages/town-crier-presentation/Sources/Features/Legal/`) and web (`web/src/features/legal/`)
-- **Tests:** `api/tests/town-crier.application.tests/Legal/GetLegalDocumentQueryHandlerTests.cs`
+- **Tests:** `api-go/internal/legal/handler_test.go`
 
-All edits go in the handler file. Remember to:
-- Update the `LastUpdated` date to today (the current session date, not hardcoded).
+The legal copy itself lives in the `resources/{privacy,terms}.json` files; the handler embeds and serves them. Edit the JSON, then update tests that assert on section content — don't leave them stale. Remember to:
+- Update the `lastUpdated` date to today (the current session date, not hardcoded).
 - Update tests that assert on section content — don't leave them stale.
 
 ## Execution Flow
@@ -43,7 +44,7 @@ Read legal docs → Parallel scan (data, processors, flows, cookies) → Gap ana
 
 ## Phase 1: Read Existing Legal Copy
 
-Read `api/src/town-crier.application/Legal/GetLegalDocumentQueryHandler.cs` and extract:
+Read `api-go/internal/legal/resources/{privacy,terms}.json` (served by `api-go/internal/legal/handler.go`) and extract:
 - Every section heading and the verbatim body text for both Privacy Policy and Terms of Service
 - The `LastUpdated` date (staleness signal)
 - Which named third parties are already disclosed (e.g., "Microsoft Azure", "PlanIt", "Apple Push Notification Service")
@@ -54,13 +55,13 @@ Build a mental inventory: "The policy currently names X, Y, Z as processors; cla
 
 Run these scans in parallel using subagents. Each subagent reports facts, not opinions.
 
-### 2a. Personal Data Inventory — `/api`
+### 2a. Personal Data Inventory — `/api-go`
 
-What personal data does the system collect, store, or process? Look at:
+The Go API is feature-sliced under `api-go/internal/<feature>/`. Each feature typically holds its domain type (`<name>.go`), HTTP request/response models + handler (`handler.go`), Cosmos document shape (`document.go`), and persistence (`store_cosmos.go`). What personal data does the system collect, store, or process? Look at:
 
-- **Domain entities** (`api/src/town-crier.domain/`) — user profiles, saved locations, notification preferences, devices. Record every field that could identify a person (name, email, device ID, IP, coordinates, postcode, phone).
-- **DTOs and request models** in `api/src/town-crier.web/` — what do the API endpoints accept from clients?
-- **Cosmos documents** in `api/src/town-crier.infrastructure/` — what shape is the data actually persisted in?
+- **Domain entities & user data** (`api-go/internal/profiles/`, `api-go/internal/watchzones/`, `api-go/internal/devicetokens/`, `api-go/internal/savedapplications/`) — user profiles, saved locations, notification preferences, devices. Record every field that could identify a person (name, email, device ID, IP, coordinates, postcode, phone).
+- **DTOs and request models** in each feature's `handler.go` (e.g. `api-go/internal/profiles/handler.go`) — what do the API endpoints accept from clients?
+- **Cosmos documents** in each feature's `document.go` / `store_cosmos.go` — what shape is the data actually persisted in?
 - **Observability** — are request bodies, user IDs, IP addresses, or user-agents logged? (App Insights, OpenTelemetry spans). If PII is in logs, that's a processing activity.
 - **Auth0 claims** — what does the identity token carry? (email, sub, name, maybe more)
 
@@ -88,10 +89,10 @@ For each data category, record:
 
 A processor is any third party that handles personal data on our behalf. Scan for:
 
-- **`package.json` / `Package.swift` / `.csproj`** — identify SDKs that integrate with remote services (auth, email, push, analytics, payments, maps, storage)
+- **`package.json` / `Package.swift` / `go.mod` / `.csproj`** — identify SDKs that integrate with remote services (auth, email, push, analytics, payments, maps, storage)
 - **Environment variables and Pulumi config** (`infra/`) — API keys, connection strings, endpoints reveal which services are actually wired up in prod
 - **Infra stack** (`infra/EnvironmentStack.cs` and siblings) — what Azure resources are provisioned? What region?
-- **`Program.cs`** in `api/src/town-crier.web/` and `api/src/town-crier.worker/` — what external clients are registered with DI?
+- **DI/main wiring** in `api-go/cmd/api/wiring.go` (+ `api-go/cmd/api/main.go`) and `api-go/cmd/worker/main.go` — what external clients are constructed and injected at startup?
 
 For each processor, record:
 - **Name** (e.g., "Auth0", "Azure Communication Services")
@@ -151,7 +152,7 @@ Show the user a concise report before making any changes:
 1. [Gap] — [what UK GDPR requires] — [will file bead]
 2. ...
 
-## Proposed edits to GetLegalDocumentQueryHandler.cs
+## Proposed edits to resources/{privacy,terms}.json
 [diff-style before/after for each affected section]
 
 Proceed? [y/n]
@@ -176,17 +177,18 @@ On approval:
    EnterWorktree with a name like "legal-audit-<date>"
    ```
 
-3. **Apply the edits** to `GetLegalDocumentQueryHandler.cs`:
+3. **Apply the edits** to `api-go/internal/legal/resources/{privacy,terms}.json`:
    - Update affected sections
-   - Update `LastUpdated` to today
+   - Update `lastUpdated` to today
    - Preserve the existing plain-English style — no legalese. Shorter is better.
    - Match the voice of the current copy (first person plural, "we")
+   - Run `scripts/sync-legal.sh` afterwards if the iOS mirror needs refreshing (CI's `check-legal-drift.sh` enforces parity)
 
-4. **Update tests** in `GetLegalDocumentQueryHandlerTests.cs` that assert on specific section content. Don't add tests for every sentence — the existing tests are structural (count of sections, headings, non-empty body). Update them to match new structure, not to pin down every word.
+4. **Update tests** in `api-go/internal/legal/handler_test.go` that assert on specific section content. Don't add tests for every sentence — the existing tests are structural (count of sections, headings, non-empty body). Update them to match new structure, not to pin down every word.
 
 5. **Run the tests**:
    ```bash
-   cd api && dotnet test --filter "FullyQualifiedName~Legal"
+   cd api-go && go test ./internal/legal/...
    ```
    If they fail, fix the assertions. Don't ship broken tests.
 

--- a/.claude/skills/sre-observatory/SKILL.md
+++ b/.claude/skills/sre-observatory/SKILL.md
@@ -61,16 +61,16 @@ Notes on data flow:
 
 ## Service Identity
 
-`AppRoleName` is set by `ResourceBuilder.AddService(...)` in each project's `Program.cs`, which **overrides** any `OTEL_SERVICE_NAME` env var. Trust the values in `AppRoleName`, not env vars or container app names.
+`AppRoleName` comes from the `OTEL_SERVICE_NAME` env var set on each Container App in `infra/EnvironmentStack.cs`. The Go API/worker read it at startup (`api-go/internal/platform/telemetry.go` → `semconv.ServiceName`); there is no hardcoded `AddService(...)` override anymore. Trust the values in `AppRoleName`, not container app names.
 
-Town Crier's roles as of 2026-04-25:
+Town Crier's roles (Go backend, Phase 3 onward):
 
 | AppRoleName | What it is |
 |---|---|
-| `town-crier-api` | The API (project lives at `api/src/town-crier.web/`, hardcoded `AddService("town-crier-api")` in `Program.cs:27`, container is `ca-town-crier-api-prod`) |
-| `town-crier-worker` | Background polling/digest jobs (Container App Jobs, event- or schedule-driven) |
+| `town-crier-api-go` | The Go HTTP API (`api-go/cmd/api/`, container is `ca-town-crier-api-go-prod`; `OTEL_SERVICE_NAME=town-crier-api-go` set in `infra/EnvironmentStack.cs`) |
+| `town-crier-worker-go` | The Go background worker — polling/digest/dormant-cleanup (Container App Job, schedule-driven; `OTEL_SERVICE_NAME=town-crier-worker-go`) |
 
-There is no role called `town-crier-api` — the env var on the API container says that, but the code overrides it. If you see `unknown_service:` as a prefix on any role, that IS a finding (means `AddService` was not called).
+If you see `unknown_service:` as a prefix on any role, that IS a finding (means `OTEL_SERVICE_NAME` was unset and the binary fell back to its default service name).
 
 If you suspect a service is silent, run a controlled probe before filing:
 
@@ -332,7 +332,7 @@ union AppRequests, AppMetrics, AppPerformanceCounters, AppDependencies, AppExcep
 | order by count_ desc
 ```
 
-Expected roles: `town-crier-api` (API), `town-crier-worker` (jobs). If any `AppRoleName` starts with `unknown_service:`, that's a bead — it means `ResourceBuilder.AddService(...)` is missing from the corresponding project's `Program.cs`. If a role you expect is missing entirely, run a probe before filing — see the "Service Identity" section.
+Expected roles: `town-crier-api-go` (API), `town-crier-worker-go` (jobs). If any `AppRoleName` starts with `unknown_service:`, that's a bead — it means `OTEL_SERVICE_NAME` is unset on the corresponding Container App in `infra/EnvironmentStack.cs`. If a role you expect is missing entirely, run a probe before filing — see the "Service Identity" section.
 
 ### Phase 5: User Frustration Signals
 
@@ -450,7 +450,7 @@ Now that you have the full picture and have reconciled prior findings, decide wh
 | Dependency failure rate > 5% | P1-P2 | Cosmos 429s, PlanIt timeouts |
 | New exception type not seen in baseline | P2 | New HttpRequestException pattern |
 | CLR exception counter > 0 with empty AppExceptions table AND failed dependencies exist | P2 | OTel exception pipeline not wired (verify failed deps/non-200s exist that should produce exception records — CLR counter alone is not sufficient, as it includes first-chance runtime exceptions) |
-| Service reports as `unknown_service:` prefix | P2 | `ResourceBuilder.AddService(...)` missing from Program.cs |
+| Service reports as `unknown_service:` prefix | P2 | `OTEL_SERVICE_NAME` missing from the Container App in `infra/EnvironmentStack.cs` |
 | Polling skip ratio > 50% | P2 | Most authorities skipped due to rate limiting |
 | Cosmos RU consumption spiking or throttling (429) | P2 | 60k RU consumed in 3 minutes |
 | Warning/error log pattern with > 10 occurrences | P2-P3 | Repeated auth token refresh failures |

--- a/.claude/skills/test-consolidation-sweep/references/dotnet.md
+++ b/.claude/skills/test-consolidation-sweep/references/dotnet.md
@@ -1,14 +1,12 @@
 # .NET test consolidation (TUnit + Stryker.NET)
 
+> **Scope note (Phase 3 onward):** the .NET API and worker were migrated to Go and deleted. The Go tests live in `api-go/` and are covered by Go tooling (`go test`), not this reference. The **only** remaining .NET test suite is the CLI's, so that is the sole .NET consolidation target now.
+
 ## Where tests live
 
-- `api/tests/town-crier.domain.tests/` — domain entity / value-object tests
-- `api/tests/town-crier.application.tests/` — command/query handler tests (the main consolidation target)
-- `api/tests/town-crier.infrastructure.tests/` — adapter tests
-- `api/tests/town-crier.web.tests/` — minimal API / web layer tests
-- `api/tests/town-crier.integration-tests/` — flow tests (silver-bullet layer)
+- `cli/tests/tc.tests/` — the self-contained .NET CLI's tests (the only remaining .NET test project; TUnit)
 
-Handler tests are where most coverage lives and where the greatest consolidation wins are.
+The CLI is small, so consolidation wins are modest — but the TUnit idioms, mutation-testing gate, and naming conventions below still apply to any .NET test work.
 
 ## Test framework idioms
 
@@ -25,7 +23,7 @@ Handler tests are where most coverage lives and where the greatest consolidation
 
 3. **Tiny single-assertion tests.** Tests whose Act is the same as the neighbouring test but assert only one field of the result. Signal: classes with >3 tests averaging <2 asserts each. Target: one verbose test with all the asserts for that Act.
 
-4. **Flow tests asserting handler-level detail.** Tests under `integration-tests/` asserting repository contents for a single entity — that's handler-level coverage that has leaked upward. Signal: `integration-tests` referencing specific repository state that no happy-path user would observe. Target: trim the assertion from the flow test, confirm an equivalent exists at handler level, add it at handler level if missing.
+4. **Over-asserted command tests.** A command test asserting many incidental side effects that a single observable outcome already covers. Signal: tests pinning internal state no caller of the CLI command would observe. Target: trim the redundant assertion, confirm the behaviour is still covered by a focused test, add one if missing.
 
 ## Mutation testing — Stryker.NET
 
@@ -35,7 +33,7 @@ If not installed:
 dotnet tool install -g dotnet-stryker
 ```
 
-Baseline run for a consolidation candidate (run from `api/`):
+Baseline run for a consolidation candidate (run from `cli/`):
 
 ```bash
 dotnet stryker \
@@ -50,6 +48,8 @@ Workflow in the bead:
 3. Re-run. The new score must be **≥** baseline. **A drop is a failure, not a negotiation** — revert and report.
 
 ## Naming target
+
+> The example below is illustrative of the consolidation *pattern* — the `SaveApplication*` types it names belonged to the now-deleted .NET API and no longer exist. Apply the same shape to the CLI's TUnit tests.
 
 Bad (over-granular):
 

--- a/.github/workflows/dev-container-app-cleanup.yml
+++ b/.github/workflows/dev-container-app-cleanup.yml
@@ -15,7 +15,7 @@
 #
 # "Keep newest active" rather than "keep latestRevisionName": Azure's
 # latestRevisionName on the container app can point to a now-inactive PR
-# staging revision (e.g. ca-town-crier-api-dev--pr5b26a9b), making the
+# staging revision (e.g. ca-town-crier-api-go-dev--pr5b26a9b), making the
 # latestRevisionName approach silently keep nothing useful. Anchoring on the
 # newest active revision is correct regardless of what Azure considers
 # "latest" at the app level.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,8 @@ Town Crier is a mobile-first app for monitoring UK local authority planning appl
 ## Monorepo Structure
 
 ```
-/api          # .NET 10 backend (Hexagonal / Ports & Adapters)
+/api-go       # Go backend (HTTP API + background worker)
+/cli          # .NET CLI (self-contained)
 /mobile/ios   # Native iOS app (Clean Architecture / MVVM-C)
 /web          # React/TypeScript frontend
 /infra        # Pulumi IaC (.NET 10 / C#)
@@ -20,12 +21,12 @@ Town Crier is a mobile-first app for monitoring UK local authority planning appl
 
 | Component | Technology |
 |-----------|-----------|
-| Backend API | .NET 10 (ASP.NET Core), Native AOT, Azure Container Apps |
+| Backend API | Go (net/http, log/slog), Azure Container Apps |
 | Database | Azure Cosmos DB (Serverless) via Cosmos DB SDK (no ORM) |
 | iOS App | Swift, SwiftUI, SwiftData, SPM |
 | Infrastructure | Pulumi (C#/.NET 10) |
 | CI/CD | GitHub Actions |
-| Testing | TUnit (.NET), XCTest (iOS) |
+| Testing | go test (Go), XCTest/Swift Testing (iOS), Vitest (web), TUnit (.NET CLI/infra) |
 
 ## Data Sources
 
@@ -52,14 +53,14 @@ When fixing CI failures, always check for ALL root causes before declaring the f
 
 ## Development Commands
 
-### .NET API (`/api`)
+### Go API (`/api-go`)
 
 ```bash
-dotnet build                        # Build
-dotnet test                         # Run all tests
-dotnet test --filter "TestName"     # Run a single test
-dotnet format --verify-no-changes   # Check formatting
-dotnet format                       # Auto-fix formatting
+# Run from api-go/
+go build ./...                      # Build
+go test ./...                       # Run all tests
+go vet ./...                        # Static analysis
+gofmt -l .                          # List files needing formatting (empty = clean)
 ```
 
 ### iOS (`/mobile/ios`)
@@ -86,7 +87,7 @@ When a bead targets a given tech stack, use the matching skill and worker agent.
 
 | Tech stack          | Path             | Skill                     | Worker agent           |
 |---------------------|------------------|---------------------------|------------------------|
-| .NET / C#           | `/api`           | `dotnet-coding-standards` | `dotnet-tdd-worker`    |
+| .NET / C#           | `/cli`           | `dotnet-coding-standards` | `dotnet-tdd-worker`    |
 | Go                  | `/api-go`        | `go-coding-standards`     | `go-tdd-worker`        |
 | iOS / Swift         | `/mobile/ios`    | `ios-coding-standards`    | `ios-tdd-worker`       |
 | Web / React / TS    | `/web`           | `react-coding-standards`  | `react-tdd-worker`     |


### PR DESCRIPTION
Phase 3e (epic tc-tbyp) — fix documentation that pointed at the deleted .NET API/worker source so it doesn't misdirect future agents.

- **CLAUDE.md**: Monorepo Structure (`/api-go` Go backend + `/cli`), Tech Stack (Backend API → Go; Testing → go test/XCTest/Vitest/TUnit), Development Commands (Go API section), Coding Standards table (.NET/C# row Path `/api` → `/cli`).
- **.claude/skills/legal/SKILL.md**: legal handler/endpoint/test/data-inventory paths repointed to `api-go/internal/legal/*` and the feature slices.
- **.claude/skills/sre-observatory/SKILL.md**: AppRoleNames `town-crier-api-go`/`town-crier-worker-go`, sourced from `OTEL_SERVICE_NAME` (no hardcoded `AddService`).
- **.claude/skills/test-consolidation-sweep/references/dotnet.md**: .NET tests now only `cli/tests/tc.tests`.
- **.claude/commands/verify-polling.md**: polling `.cs` pointers → `api-go/internal/polling`/`planit`; worker role `town-crier-worker-go`; metric names kept.
- **.github/workflows/dev-container-app-cleanup.yml**: example revision → Go app (comment only).
- **docs/adr/0027**: left unchanged (historical ADR context — ADRs are immutable records).

No dead *current* .NET path pointers remain. (Two `.claude/handoffs/*` session archives still reference old paths but are frozen historical snapshots, intentionally left.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)