### PR TITLE
docs(legal): disclose 12-month dormant-account deletion in privacy policy

### DIFF
--- a/api-go/internal/legal/resources/privacy.json
+++ b/api-go/internal/legal/resources/privacy.json
@@ -1,7 +1,7 @@
 {
   "documentType": "privacy",
   "title": "Privacy Policy",
-  "lastUpdated": "2026-05-17",
+  "lastUpdated": "2026-06-15",
   "sections": [
     {
       "heading": "Who We Are",
@@ -29,7 +29,7 @@
     },
     {
       "heading": "How Long We Keep It",
-      "body": "Your notifications and decision alerts are automatically deleted after 90 days. We remove iOS push tokens when Apple tells us they're no longer valid. Everything else (your account, watch zones, saved applications, preferences, and subscription status) is kept for as long as your account exists. You can delete your account at any time from the app settings, which removes your profile, preferences, watch zones, notifications, saved applications, and device registrations from our systems."
+      "body": "Your notifications and decision alerts are automatically deleted after 90 days. We remove iOS push tokens when Apple tells us they're no longer valid. Everything else (your account, watch zones, saved applications, preferences, and subscription status) is kept for as long as your account stays active. If you don't use Town Crier for 12 months, we automatically delete your whole account and everything in it, including your sign-in record, so we don't hold your data for longer than we need to (UK GDPR Article 5(1)(e)). You can also delete your account at any time from the app settings, which removes your profile, preferences, watch zones, notifications, saved applications, and device registrations from our systems."
     },
     {
       "heading": "Your Rights Under UK GDPR",

--- a/mobile/ios/packages/town-crier-presentation/Sources/Resources/legal/privacy.json
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Resources/legal/privacy.json
@@ -1,7 +1,7 @@
 {
   "documentType": "privacy",
   "title": "Privacy Policy",
-  "lastUpdated": "2026-05-17",
+  "lastUpdated": "2026-06-15",
   "sections": [
     {
       "heading": "Who We Are",
@@ -29,7 +29,7 @@
     },
     {
       "heading": "How Long We Keep It",
-      "body": "Your notifications and decision alerts are automatically deleted after 90 days. We remove iOS push tokens when Apple tells us they're no longer valid. Everything else (your account, watch zones, saved applications, preferences, and subscription status) is kept for as long as your account exists. You can delete your account at any time from the app settings, which removes your profile, preferences, watch zones, notifications, saved applications, and device registrations from our systems."
+      "body": "Your notifications and decision alerts are automatically deleted after 90 days. We remove iOS push tokens when Apple tells us they're no longer valid. Everything else (your account, watch zones, saved applications, preferences, and subscription status) is kept for as long as your account stays active. If you don't use Town Crier for 12 months, we automatically delete your whole account and everything in it, including your sign-in record, so we don't hold your data for longer than we need to (UK GDPR Article 5(1)(e)). You can also delete your account at any time from the app settings, which removes your profile, preferences, watch zones, notifications, saved applications, and device registrations from our systems."
     },
     {
       "heading": "Your Rights Under UK GDPR",


### PR DESCRIPTION
## Changes
- Privacy policy "How Long We Keep It" section now discloses that accounts inactive for 12 months are automatically erased (full GDPR Art. 17 cascade incl. Auth0 identity), enforced by the `dormant-cleanup` worker. Previously the policy said everything except notifications is kept "for as long as your account exists", omitting this.
- Cites UK GDPR Article 5(1)(e) (storage limitation); backed by ADR 0023.
- Bumped `lastUpdated` to 2026-06-15; iOS mirror synced via `scripts/sync-legal.sh` (drift check clean).

Closes tc-it6d. Found by `/legal` audit.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated privacy policy with new effective date (June 15, 2026)
  * Clarified data retention practices, specifying that account information and preferences are retained as long as your account remains active
  * Added automatic account deletion: accounts and associated data are automatically deleted after 12 months of inactivity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->