### PR TITLE
docs(memo): graduate memo 0007 → Superseded by ADR 0028

### DIFF
--- a/docs/memo/0007-backend-language-choice-revisit.md
+++ b/docs/memo/0007-backend-language-choice-revisit.md
@@ -4,7 +4,9 @@ Date: 2026-05-17
 
 ## Status
 
-Open
+Superseded by ADR [0028](../adr/0028-migrate-backend-from-dotnet-to-go.md)
+
+> Resolved 2026-06-15. The exploration below recommended Option C — pilot Go on the polling worker, then consider the API. That played out in full: the worker pilot succeeded (Phase 2), the API was migrated (Phase 1), and the .NET runtime was decommissioned (Phase 3, epic tc-tbyp). The decision and outcome are recorded in [ADR 0028](../adr/0028-migrate-backend-from-dotnet-to-go.md); the observability slice is in [ADR 0027](../adr/0027-go-api-observability-via-aca-otel-agent.md). This memo is retained as the rationale trail (the .NET-AOT-vs-Go-vs-Rust analysis ADR 0028 deliberately does not repeat). Rust was considered and rejected here, as 0028 reflects.
 
 ## Question
 


### PR DESCRIPTION
## Changes

Follow-up to the ADR audit (#470). Memo 0007 (*Revisiting the Backend Language Choice*) recommended piloting Go on the worker then migrating the API — now complete end-to-end (Phases 1–3, epic `tc-tbyp`) and recorded in ADR 0028.

- **memo 0007** — status `Open` → `Superseded by ADR 0028`, with a short resolution note. Kept (not deleted), mirroring how memo 0002 graduated to ADR 0020 — preserves the .NET-AOT-vs-Go-vs-Rust analysis as the rationale trail.

The other open memos (0001 own-scraper Cosmos scaling, 0003 Ultra tier, 0004 web billing, 0005 admin web app, 0006 v2 API versioning) remain genuinely unimplemented and stay Open.

Bead: tc-vgsu.

---
*Auto-shipped via ship skill*