### PR TITLE
fix(telemetry): restore Go OTel pipeline (metrics, outbound deps, inbound route/status, prod/dev split)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -205,8 +205,15 @@ func main() {
 	// matching .NET's conditional IAuth0ManagementClient registration.
 	var manager profiles.Auth0Manager = profiles.NoOpAuth0Client{}
 	if cfg.Auth0M2MConfigured() {
-		manager = profiles.NewAuth0Client(
+		// Wrap the transport so Auth0 token/PATCH/DELETE calls emit OTel client
+		// spans (Type=HTTP in AppDependencies) named "Auth0 token"; the host lands
+		// in server.address.
+		auth0HTTP := platform.WrapHTTPClient(
 			&http.Client{Timeout: 30 * time.Second},
+			func(string, *http.Request) string { return "Auth0 token" },
+		)
+		manager = profiles.NewAuth0Client(
+			auth0HTTP,
 			"https://"+cfg.Auth0Domain,
 			cfg.Auth0M2MClientID,
 			cfg.Auth0M2MClientSecret,

--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/erasure"
 	"github.com/AmyDe/town-crier/api-go/internal/geocoding"
+	"github.com/AmyDe/town-crier/api-go/internal/metrics"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
@@ -27,6 +28,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/subscriptions"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+	"go.opentelemetry.io/otel"
 )
 
 func main() {
@@ -58,6 +60,13 @@ func main() {
 		}
 	}()
 
+	// The business-metric registry is built from the global MeterProvider that
+	// SetupTelemetry just installed (a no-op provider when telemetry is disabled,
+	// so the instruments record nothing locally). Every Cosmos container is wired
+	// to it below so towncrier.cosmos.request_charge_ru flows, and it is passed to
+	// newRouter for the watch-zone lifecycle counters (tc-21np).
+	registry := metrics.New(otel.Meter(metrics.MeterName))
+
 	validator, err := auth.NewAuth0Validator(cfg.Auth0Domain, cfg.Auth0Audience, logger)
 	if err != nil {
 		log.Fatal(err)
@@ -67,6 +76,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	cosmos.WithMetrics(registry)
 	var store *profiles.CosmosStore
 	if cosmos != nil {
 		store = profiles.NewCosmosStore(cosmos)
@@ -76,6 +86,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	devices.WithMetrics(registry)
 	var deviceStore *devicetokens.CosmosStore
 	if devices != nil {
 		deviceStore = devicetokens.NewCosmosStore(devices)
@@ -85,10 +96,12 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	stateContainer.WithMetrics(registry)
 	notificationsContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationsContainer, logger)
 	if err != nil {
 		log.Fatal(err)
 	}
+	notificationsContainer.WithMetrics(registry)
 	var stateStore *notificationstate.CosmosStore
 	if stateContainer != nil && notificationsContainer != nil {
 		stateStore = notificationstate.NewCosmosStore(stateContainer, notificationsContainer)
@@ -104,6 +117,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	watchZones.WithMetrics(registry)
 	var watchZoneStore *watchzones.CosmosStore
 	if watchZones != nil {
 		watchZoneStore = watchzones.NewCosmosStore(watchZones)
@@ -113,6 +127,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	appsContainer.WithMetrics(registry)
 	var appStore *applications.CosmosStore
 	if appsContainer != nil {
 		appStore = applications.NewCosmosStore(appsContainer)
@@ -122,6 +137,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	savedContainer.WithMetrics(registry)
 	var savedStore *savedapplications.CosmosStore
 	if savedContainer != nil {
 		savedStore = savedapplications.NewCosmosStore(savedContainer)
@@ -149,6 +165,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	offerCodesContainer.WithMetrics(registry)
 	var offerStore *offercodes.CosmosStore
 	if offerCodesContainer != nil {
 		offerStore = offercodes.NewCosmosStore(offerCodesContainer)
@@ -166,6 +183,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	appleNotificationsContainer.WithMetrics(registry)
 	var appleNotifStore *subscriptions.CosmosNotificationStore
 	if appleNotificationsContainer != nil {
 		appleNotifStore = subscriptions.NewCosmosNotificationStore(appleNotificationsContainer, time.Now)
@@ -200,7 +218,7 @@ func main() {
 	geocodeClient := geocoding.NewClient(cfg.PostcodesIoBaseURL, &http.Client{Timeout: 30 * time.Second})
 	designationClient := designations.NewClient(cfg.GovUkBaseURL, &http.Client{Timeout: 30 * time.Second})
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, cascade, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, logger))
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, cascade, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, registry, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -181,6 +181,13 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 			middleware.Recover(logger)(authed),
 		),
 	)
+	// RouteSpan names the request span after the matched route and records the
+	// HTTP status code on it (tc-r8eo). It must run inside the otelhttp span — so
+	// the span it decorates is the request span — yet outermost among our own
+	// middleware so it observes the final status. It resolves the pattern from the
+	// mux directly (the same lookup RequireAuth uses), which is why it takes mux
+	// rather than relying on r.Pattern (lost across the chain's context copies).
+	chain = middleware.RouteSpan(mux)(chain)
 	// otelhttp is the outermost wrapper so its span covers the whole request,
 	// including the CORS, error-envelope and panic-recovery middleware. When
 	// telemetry is disabled (no OTLP endpoint) the global no-op TracerProvider

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -16,6 +16,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/geocoding"
 	"github.com/AmyDe/town-crier/api-go/internal/health"
 	"github.com/AmyDe/town-crier/api-go/internal/legal"
+	"github.com/AmyDe/town-crier/api-go/internal/metrics"
 	"github.com/AmyDe/town-crier/api-go/internal/middleware"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
@@ -93,7 +94,7 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // nil-means-unwired convention. (The watch-zone preferences endpoints are
 // served by profiles.Routes off the profile store, so they come up with the
 // /v1/me routes, not the watch-zone store.)
-func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, cascade profiles.CascadeDeleters, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, logger *slog.Logger) http.Handler {
+func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, cascade profiles.CascadeDeleters, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, registry *metrics.Registry, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)
@@ -120,7 +121,7 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 		notificationstate.Routes(mux, stateStore, time.Now, logger)
 	}
 	if watchZoneStore != nil {
-		watchzones.Routes(mux, watchZoneStore, logger)
+		watchzones.Routes(mux, watchZoneStore, logger, watchzones.WithMetricsRecorder(registry))
 		// application-authorities derives from the user's watch zones plus the
 		// static authority data; it needs no Cosmos applications store.
 		watchzones.AuthoritiesRoutes(mux, watchZoneStore, authorities.NewLookup(), logger)
@@ -142,7 +143,7 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 		// profile store and resolves the authority from coordinates via the
 		// geocode client when the request omits one; the applications list
 		// augments each row with its latest unread notification.
-		watchzones.NearbyRoutes(mux, watchZoneStore, store, geocodeClient, appStore, stateStore, notifStore, uuid.NewString, time.Now, logger)
+		watchzones.NearbyRoutes(mux, watchZoneStore, store, geocodeClient, appStore, stateStore, notifStore, uuid.NewString, time.Now, logger, watchzones.WithMetricsRecorder(registry))
 	}
 	if store != nil && watchZoneStore != nil && appStore != nil {
 		// Demo account (anonymous): seeds a Pro profile, a Westminster watch zone,

--- a/api-go/cmd/api/wiring_telemetry_test.go
+++ b/api-go/cmd/api/wiring_telemetry_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"go.opentelemetry.io/otel"
+)
+
+// recordSpansFor drives method+path through the full newRouter chain (otelhttp
+// outermost) with a recording TracerProvider installed globally, and returns the
+// recorded request spans. The router runs deny-all + Cosmos-less, so it exercises
+// only routes that need no store.
+func recordSpansFor(t *testing.T, h http.Handler, method, path, authz string) []sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req := httptest.NewRequestWithContext(ctx, method, path, nil)
+	if authz != "" {
+		req.Header.Set("Authorization", authz)
+	}
+	h.ServeHTTP(httptest.NewRecorder(), req)
+	return rec.Ended()
+}
+
+// TestRouter_RequestSpanCarriesRouteAndStatus pins tc-r8eo end to end: a request
+// through the production chain produces a request span whose Name is the matched
+// route pattern and which carries http.route and http.response.status_code, so
+// Azure Monitor's AppRequests.Name and ResultCode are restored to .NET parity.
+func TestRouter_RequestSpanCarriesRouteAndStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		method       string
+		path         string
+		authz        string
+		wantRoute    string
+		wantStatus   int64
+		wantHasRoute bool
+	}{
+		// Anonymous matched route, 200.
+		{"health 200", http.MethodGet, "/v1/health", "", "GET /v1/health", http.StatusOK, true},
+		// Authed matched route with no token -> the fallback-deny 401. The route
+		// still matched (geocode is always wired, even Cosmos-less), so the span is
+		// named after it.
+		{"geocode 401", http.MethodGet, "/v1/geocode/SW1A1AA", "", "GET /v1/geocode/{postcode}", http.StatusUnauthorized, true},
+		// Unmatched path -> 401 fallback, no route, default span name preserved.
+		{"unmatched 401", http.MethodGet, "/v1/nope", "", "", http.StatusUnauthorized, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newTestHandler(t)
+			spans := recordSpansFor(t, h, tc.method, tc.path, tc.authz)
+
+			var req sdktrace.ReadOnlySpan
+			for _, s := range spans {
+				if s.SpanKind().String() == "server" {
+					req = s
+				}
+			}
+			if req == nil {
+				t.Fatalf("no server span recorded (got %d spans)", len(spans))
+			}
+
+			gotStatus, ok := attrInt64(req, "http.response.status_code")
+			if !ok {
+				t.Fatalf("http.response.status_code attribute missing")
+			}
+			if gotStatus != tc.wantStatus {
+				t.Errorf("http.response.status_code = %d, want %d", gotStatus, tc.wantStatus)
+			}
+
+			gotRoute := attrStr(req, "http.route")
+			if tc.wantHasRoute {
+				if gotRoute != tc.wantRoute {
+					t.Errorf("http.route = %q, want %q", gotRoute, tc.wantRoute)
+				}
+				if got := req.Name(); got != tc.wantRoute {
+					t.Errorf("span name = %q, want %q", got, tc.wantRoute)
+				}
+			} else if gotRoute != "" {
+				t.Errorf("http.route = %q, want empty for unmatched request", gotRoute)
+			}
+		})
+	}
+}
+
+func attrInt64(span sdktrace.ReadOnlySpan, key string) (int64, bool) {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsInt64(), true
+		}
+	}
+	return 0, false
+}
+
+func attrStr(span sdktrace.ReadOnlySpan, key string) string {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString()
+		}
+	}
+	return ""
+}

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -122,7 +122,7 @@ func testDesignationClient() *designations.Client {
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", nil, slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -227,7 +227,7 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	appStore := applications.NewCosmosStore(newFakeItems())
 	savedStore := savedapplications.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", nil, logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -310,7 +310,7 @@ func TestRouter_GeocodeAndDesignationsDispatch(t *testing.T) {
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
 	geocodeClient := geocoding.NewClient(upstream.URL, upstream.Client())
 	designationClient := designations.NewClient(upstream.URL, upstream.Client())
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", nil, nil, "", logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", nil, nil, "", nil, logger)
 
 	rec := serveReq(t, h, http.MethodGet, "/v1/geocode/SW1A%201AA", "", "Bearer tok")
 	if rec.Code != http.StatusOK {
@@ -349,7 +349,7 @@ func TestRouter_SubscriptionsWired(t *testing.T) {
 		t.Fatalf("NewJWSVerifier: %v", err)
 	}
 
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, adminStore, "", verifier, notifStore, "uk.towncrierapp.mobile", logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, adminStore, "", verifier, notifStore, "uk.towncrierapp.mobile", nil, logger)
 
 	// Webhook is anonymous: a malformed body reaches the handler -> 400 with the
 	// malformed_request envelope, not the WWW-Authenticate 401 fallback.
@@ -379,7 +379,7 @@ func TestRouter_AdminGate(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	offerStore := offercodes.NewCosmosStore(newFakeItems())
 	adminStore := profiles.NewAdminStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), offerStore, adminStore, "s3cret", nil, nil, "", logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), offerStore, adminStore, "s3cret", nil, nil, "", nil, logger)
 
 	// No key: the admin gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -582,8 +582,15 @@ func buildAuth0Deleter(cfg platform.Config, logger *slog.Logger) erasure.Auth0De
 		logger.Info("auth0 m2m unconfigured; dormant cleanup will skip Auth0 user deletion (NoOp)")
 		return profiles.NoOpAuth0Client{}
 	}
-	return profiles.NewAuth0Client(
+	// Wrap the transport so Auth0 token/DELETE calls emit OTel client spans
+	// (Type=HTTP in AppDependencies) named "Auth0 token"; the host lands in
+	// server.address.
+	auth0HTTP := platform.WrapHTTPClient(
 		&http.Client{Timeout: 30 * time.Second},
+		func(string, *http.Request) string { return "Auth0 token" },
+	)
+	return profiles.NewAuth0Client(
+		auth0HTTP,
 		"https://"+cfg.Auth0Domain,
 		cfg.Auth0M2MClientID,
 		cfg.Auth0M2MClientSecret,

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/digest"
 	"github.com/AmyDe/town-crier/api-go/internal/dormant"
 	"github.com/AmyDe/town-crier/api-go/internal/erasure"
+	"github.com/AmyDe/town-crier/api-go/internal/metrics"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/notifydispatch"
@@ -39,6 +40,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/servicebus"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 	"github.com/AmyDe/town-crier/api-go/internal/worker"
+	"go.opentelemetry.io/otel"
 )
 
 func main() {
@@ -87,6 +89,13 @@ func run() int {
 		}
 	}()
 
+	// The business-metric registry is built from the global MeterProvider
+	// SetupTelemetry just installed (a no-op provider when telemetry is disabled).
+	// It is threaded through the builders below so the poll handler / orchestrator,
+	// the PlanIt client, the notification dispatchers and every Cosmos container
+	// emit their towncrier.* metrics (tc-21np).
+	registry := metrics.New(otel.Meter(metrics.MeterName))
+
 	// The Service Bus client (and thus the bootstrapper and the poll-sb
 	// orchestrator) is built only when the job carries Service Bus config. Jobs
 	// that don't touch Service Bus (digest, hourly-digest, dormant-cleanup) leave
@@ -122,7 +131,7 @@ func run() int {
 	// the "no Cosmos" case leaves it nil — assigning a typed-nil *digest.Handler
 	// would make the interface non-nil and defeat worker.Run's nil guard.
 	var digester worker.DigestRunner
-	handler, err := buildDigester(cfg, logger)
+	handler, err := buildDigester(cfg, registry, logger)
 	if err != nil {
 		logger.Error("build digest handler", "error", err)
 		return 1
@@ -137,7 +146,7 @@ func run() int {
 	// worker.Run's nil guard). The Auth0 deleter falls back to a no-op when the M2M
 	// credentials are absent, so a Cosmos-only job still boots cleanly.
 	var dormantRunner worker.DormantRunner
-	dormantHandler, err := buildDormant(cfg, logger)
+	dormantHandler, err := buildDormant(cfg, registry, logger)
 	if err != nil {
 		logger.Error("build dormant cleanup handler", "error", err)
 		return 1
@@ -152,7 +161,7 @@ func run() int {
 	// run rather than crashing. Declared as the interface so the "unconfigured"
 	// case stays a nil interface value (a typed-nil adapter would defeat the guard).
 	var poller worker.PollOrchestrator
-	pollAdapter, err := buildPollOrchestrator(cfg, sbClient, logger)
+	pollAdapter, err := buildPollOrchestrator(cfg, sbClient, registry, logger)
 	if err != nil {
 		logger.Error("build poll-sb orchestrator", "error", err)
 		return 1
@@ -171,7 +180,7 @@ func run() int {
 // (nil, nil) when Service Bus or Cosmos config is absent, so poll-sb refuses to
 // run rather than nil-panicking. The cycle budget (replicaTimeout − grace) and
 // the handler/lease budgets all come from config.
-func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, logger *slog.Logger) (*pollOrchestratorAdapter, error) {
+func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, registry *metrics.Registry, logger *slog.Logger) (*pollOrchestratorAdapter, error) {
 	if sbClient == nil || cfg.CosmosEndpoint == "" {
 		return nil, nil //nolint:nilnil // absent SB/Cosmos config is a valid "no poller" state, not an error
 	}
@@ -186,6 +195,7 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, log
 			InitialBackoff:   secondsToDuration(cfg.PlanItInitialBackoffSeconds),
 			RateLimitBackoff: secondsToDuration(cfg.PlanItRateLimitBackoffSeconds),
 		},
+		Metrics: registry,
 	})
 	if err != nil {
 		return nil, err
@@ -195,18 +205,22 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, log
 	if err != nil {
 		return nil, err
 	}
+	appsContainer.WithMetrics(registry)
 	stateContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosPollStateContainer, logger)
 	if err != nil {
 		return nil, err
 	}
+	stateContainer.WithMetrics(registry)
 	leasesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosLeasesContainer, logger)
 	if err != nil {
 		return nil, err
 	}
+	leasesContainer.WithMetrics(registry)
 	zonesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosWatchZonesContainer, logger)
 	if err != nil {
 		return nil, err
 	}
+	zonesContainer.WithMetrics(registry)
 
 	stateStore := polling.NewPollStateStore(stateContainer)
 	leaseStore := polling.NewLeaseStore(leaseItemsAdapter{leasesContainer}, time.Now)
@@ -234,13 +248,15 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, log
 		time.Now,
 		logger,
 	)
+	// Record the towncrier.polling.* per-cycle / per-authority KPIs (tc-21np).
+	handler.WithMetrics(registry)
 
 	// Wire the poll-path notification fan-out: each upserted application drives a
 	// decision-event dispatch (on a non-decision -> decision transition) and a
 	// watch-zone notification fan-out, matching .NET PollPlanItCommandHandler.
 	// This is the CUTOVER-BLOCKER fan-out (bead tc-uc2p) — without it the
 	// Notifications container stays empty and every alert/digest breaks.
-	if err := wirePollFanOut(cfg, handler, zoneStore, logger); err != nil {
+	if err := wirePollFanOut(cfg, handler, zoneStore, registry, logger); err != nil {
 		return nil, err
 	}
 
@@ -264,6 +280,8 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, log
 		time.Now,
 		logger,
 	)
+	// Record towncrier.polling.lease.acquired with caller "orchestrator" (tc-21np).
+	orchestrator.WithLeaseMetrics(registry)
 
 	// The hard cycle budget is replicaTimeout − grace (mirrors the .NET worker);
 	// it bounds the whole RunOnce so the process exits cleanly before Container
@@ -283,27 +301,32 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, log
 // the poll job boots even without APNs config (the record is still written, so
 // the digest pipeline keeps working). Mirrors .NET's per-app
 // decisionEventDispatcher + notificationEnqueuer wiring.
-func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zoneStore *watchzones.CosmosStore, logger *slog.Logger) error {
+func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zoneStore *watchzones.CosmosStore, registry *metrics.Registry, logger *slog.Logger) error {
 	notifsContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationsContainer, logger)
 	if err != nil {
 		return err
 	}
+	notifsContainer.WithMetrics(registry)
 	usersContainer, err := platform.NewCosmosContainerNamed(cfg, "Users", logger)
 	if err != nil {
 		return err
 	}
+	usersContainer.WithMetrics(registry)
 	stateContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationStateContainer, logger)
 	if err != nil {
 		return err
 	}
+	stateContainer.WithMetrics(registry)
 	devicesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosDeviceRegistrationsContainer, logger)
 	if err != nil {
 		return err
 	}
+	devicesContainer.WithMetrics(registry)
 	savedContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosSavedApplicationsContainer, logger)
 	if err != nil {
 		return err
 	}
+	savedContainer.WithMetrics(registry)
 
 	notifStore := notifications.NewDigestStore(notifsContainer)
 	profileStore := profiles.NewCosmosStore(usersContainer)
@@ -312,14 +335,15 @@ func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zon
 	savedStore := savedapplications.NewCosmosStore(savedContainer)
 	pushSender := buildPushSender(cfg, logger)
 
+	// Record towncrier.notifications.created on each dispatcher (tc-21np).
 	enqueuer := notifydispatch.NewEnqueuer(
 		notifStore, zoneStore, profileStore, deviceStore, statePushStore, pushSender,
 		uuid.NewString, time.Now, logger,
-	)
+	).WithMetrics(registry)
 	dispatcher := notifydispatch.NewDecisionDispatcher(
 		notifStore, zoneStore, savedStore, profileStore, deviceStore, statePushStore, pushSender,
 		uuid.NewString, time.Now, logger,
-	)
+	).WithMetrics(registry)
 
 	handler.WithFanOut(dispatcher, enqueuer)
 	return nil
@@ -416,7 +440,7 @@ func maxInt(a, b int) int {
 // then refuse to run rather than nil-panicking. Returning the concrete
 // *digest.Handler lets worker.Run accept it via its unexported digestRunner
 // interface (structural satisfaction).
-func buildDigester(cfg platform.Config, logger *slog.Logger) (*digest.Handler, error) {
+func buildDigester(cfg platform.Config, registry *metrics.Registry, logger *slog.Logger) (*digest.Handler, error) {
 	if cfg.CosmosEndpoint == "" {
 		return nil, nil //nolint:nilnil // absent Cosmos config is a valid "no digester" state, not an error
 	}
@@ -425,22 +449,27 @@ func buildDigester(cfg platform.Config, logger *slog.Logger) (*digest.Handler, e
 	if err != nil {
 		return nil, err
 	}
+	users.WithMetrics(registry)
 	notifs, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationsContainer, logger)
 	if err != nil {
 		return nil, err
 	}
+	notifs.WithMetrics(registry)
 	zonesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosWatchZonesContainer, logger)
 	if err != nil {
 		return nil, err
 	}
+	zonesContainer.WithMetrics(registry)
 	stateContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationStateContainer, logger)
 	if err != nil {
 		return nil, err
 	}
+	stateContainer.WithMetrics(registry)
 	devicesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosDeviceRegistrationsContainer, logger)
 	if err != nil {
 		return nil, err
 	}
+	devicesContainer.WithMetrics(registry)
 
 	profileStore := digestProfiles{
 		admin: profiles.NewAdminStore(users),
@@ -491,7 +520,7 @@ func (p digestProfiles) Get(ctx context.Context, userID string) (*profiles.UserP
 // when Cosmos is unconfigured — the dormant-cleanup mode then refuses to run
 // rather than nil-panicking. Returning the concrete *dormant.Handler lets
 // worker.Run accept it via its exported DormantRunner interface.
-func buildDormant(cfg platform.Config, logger *slog.Logger) (*dormant.Handler, error) {
+func buildDormant(cfg platform.Config, registry *metrics.Registry, logger *slog.Logger) (*dormant.Handler, error) {
 	if cfg.CosmosEndpoint == "" {
 		return nil, nil //nolint:nilnil // absent Cosmos config is a valid "no dormant handler" state, not an error
 	}
@@ -500,26 +529,32 @@ func buildDormant(cfg platform.Config, logger *slog.Logger) (*dormant.Handler, e
 	if err != nil {
 		return nil, err
 	}
+	users.WithMetrics(registry)
 	notifs, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationsContainer, logger)
 	if err != nil {
 		return nil, err
 	}
+	notifs.WithMetrics(registry)
 	zonesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosWatchZonesContainer, logger)
 	if err != nil {
 		return nil, err
 	}
+	zonesContainer.WithMetrics(registry)
 	savedContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosSavedApplicationsContainer, logger)
 	if err != nil {
 		return nil, err
 	}
+	savedContainer.WithMetrics(registry)
 	devicesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosDeviceRegistrationsContainer, logger)
 	if err != nil {
 		return nil, err
 	}
+	devicesContainer.WithMetrics(registry)
 	stateContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationStateContainer, logger)
 	if err != nil {
 		return nil, err
 	}
+	stateContainer.WithMetrics(registry)
 
 	// The four DeleteAllByUserID stores satisfy erasure.ChildDeleter directly, the
 	// profile store's Delete satisfies erasure.ProfileDeleter directly, and the

--- a/api-go/go.mod
+++ b/api-go/go.mod
@@ -11,12 +11,16 @@ require (
 	github.com/google/uuid v1.6.0
 	go.opentelemetry.io/contrib/bridges/otelslog v0.19.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0
+	go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0
 	go.opentelemetry.io/otel/log v0.20.0
+	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/log v0.20.0
+	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/net v0.55.0
 )
@@ -48,7 +52,6 @@ require (
 	github.com/valyala/fastjson v1.6.7 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect
-	go.opentelemetry.io/otel/metric v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	golang.org/x/crypto v0.51.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect

--- a/api-go/go.sum
+++ b/api-go/go.sum
@@ -92,10 +92,14 @@ go.opentelemetry.io/contrib/bridges/otelslog v0.19.0 h1:5RgvxieNq9tS3ewrV1vnODvb
 go.opentelemetry.io/contrib/bridges/otelslog v0.19.0/go.mod h1:iTBIdNwx/xmUhfgJs6+84S4dIK059811cO1eUBjKcHY=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0 h1:8tvICD4vSTOOsNrsI4Ljf6C+6UKvpTEH5XY3JMoyPoo=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.69.0/go.mod h1:z9+yiacE0IHRqM4qFfkbt/JYlmYXgss8GY/jXoNuPJI=
+go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0 h1:MtkMsuRo3zEXTTMALfyrszwCDZTkB6wolyPjbwFAdq0=
+go.opentelemetry.io/contrib/instrumentation/runtime v0.69.0/go.mod h1:FYTxnpsm+UPD0erZNq20GvnM8T2YQHiHtT2vokdpoac=
 go.opentelemetry.io/otel v1.44.0 h1:JjwHmHpA4iZ3wBxluu2fbbE7j4kqlE8jXyAyPXH7HqU=
 go.opentelemetry.io/otel v1.44.0/go.mod h1:BMgjTHL9WPRlRjL2oZCBTL4whCGtXch2H4BhOPIAyYc=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0 h1:rydZ9sxbcFdm/oWrVyfLTjHIygMgv0bEeMd+3B/BvoM=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.20.0/go.mod h1:earQ25dooT0Hhspq59DZ8YCC50jWfOlFEeWoxy/P444=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0 h1:SUplec5dp06reu1zaXmOXdvqH398taqrDXqUl99jxSc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0/go.mod h1:ho2g4N+ane+swq5I/VBkKWnRDY4kUINH3FuqyZqX/Ug=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 h1:4YsVu3B8+3qtWYYrsUYgn0OG78pN0rnNPRGX4SbokQI=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0/go.mod h1:+wnlSn0mD1ADVMe3v9Z/WIaiz6q6gL2J/ejaAmdmv80=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.44.0 h1:qazEJlUOQzhCpzQpFETGby7EdqjI1wsd0W+6Gg1SCTU=
@@ -104,6 +108,8 @@ go.opentelemetry.io/otel/log v0.20.0 h1:/5i0vuHxCLWUfChWG41K9wkM0jafruPw9NU1/RCJ
 go.opentelemetry.io/otel/log v0.20.0/go.mod h1:wOcMcjsZpG8x7Bak7IhSi/lg8wscV2C1VdrKCLPlt0E=
 go.opentelemetry.io/otel/metric v1.44.0 h1:1w0gILTcHdr3YI+ixLyjemwrVnsMURbTZFrSYCdDdmc=
 go.opentelemetry.io/otel/metric v1.44.0/go.mod h1:8O7hanEPBNgEMmybD3s2VBKcgWOCsA6tzHBPODAiquo=
+go.opentelemetry.io/otel/metric/x v0.66.0 h1:YkCrx1zLOChi9ZcZ6euupOcsgzbVlec7D/xoEU1+cTA=
+go.opentelemetry.io/otel/metric/x v0.66.0/go.mod h1:d1+BDj9t96do0/1LoU1ayfCv79ZgNE41qbhBvnMOBZk=
 go.opentelemetry.io/otel/sdk v1.44.0 h1:nHYwb9lK+fJPU/dnT6s7W7Z8itMWyqrnVfbheVYrZ58=
 go.opentelemetry.io/otel/sdk v1.44.0/go.mod h1:Osuydd3Se74nqjAKxid74N5eC+jfEqfTegHRnq58oK0=
 go.opentelemetry.io/otel/sdk/log v0.20.0 h1:vM3xI7TQgKPiSghe6urZtAkyFY7SodrSpC83CffDFuY=

--- a/api-go/internal/acsemail/client.go
+++ b/api-go/internal/acsemail/client.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/url"
 	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
 const (
@@ -99,6 +101,11 @@ func NewClient(connectionString string, logger *slog.Logger, now func() time.Tim
 		return nil, err
 	}
 	httpClient := &http.Client{Timeout: requestTimeout}
+	// Wrap the transport so every ACS send/poll emits an OTel client span
+	// (Type=HTTP in AppDependencies) named "ACS email send". The ACS host lands
+	// in server.address; the static span name keeps cardinality low (no recipient
+	// or operation ID in the name).
+	httpClient = platform.WrapHTTPClient(httpClient, func(string, *http.Request) string { return "ACS email send" })
 	return newClientWithCreds(creds, httpClient, logger, now), nil
 }
 

--- a/api-go/internal/apns/client.go
+++ b/api-go/internal/apns/client.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"golang.org/x/net/http2"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
 const (
@@ -65,6 +67,11 @@ func NewClient(opts Options, logger *slog.Logger, now func() time.Time) (*Client
 		Transport: transport,
 		Timeout:   requestTimeout,
 	}
+	// Wrap the transport so every APNs push emits an OTel client span
+	// (Type=HTTP in AppDependencies) named "APNs push". api.push.apple.com lands
+	// in server.address; the static span name keeps cardinality low (no per-device
+	// token in the name).
+	httpClient = platform.WrapHTTPClient(httpClient, func(string, *http.Request) string { return "APNs push" })
 	return newClientWithBaseURL(opts, opts.baseURL(), httpClient, logger, now)
 }
 

--- a/api-go/internal/apns/span_test.go
+++ b/api-go/internal/apns/span_test.go
@@ -1,0 +1,91 @@
+package apns
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// recorderProvider returns an in-memory SDK TracerProvider for hermetic span
+// assertions; the wrapped transport emits into the recorder, not the global.
+func recorderProvider(t *testing.T) (*sdktrace.TracerProvider, *tracetest.SpanRecorder) {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return tp, rec
+}
+
+func spanAttr(attrs []attribute.KeyValue, key string) (attribute.Value, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+// TestSendOne_EmitsClientSpan asserts an APNs push produces a client span named
+// "APNs push" carrying the upstream host as server.address so it surfaces in
+// AppDependencies as a meaningful HTTP dependency. It exercises the same
+// platform.WrapHTTPClient wiring NewClient applies in production.
+func TestSendOne_EmitsClientSpan(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	tp, rec := recorderProvider(t)
+
+	pemBytes, _ := newTestKeyPEM(t)
+	opts := Options{
+		Enabled:  true,
+		AuthKey:  string(pemBytes),
+		KeyID:    "L2J5PQASN5",
+		TeamID:   "4574VQ7N2X",
+		BundleID: "uk.towncrierapp.mobile",
+	}
+	traced := platform.WrapHTTPClient(
+		srv.Client(),
+		func(string, *http.Request) string { return "APNs push" },
+		otelhttp.WithTracerProvider(tp),
+	)
+	client, err := newClientWithBaseURL(opts, srv.URL, traced, testLogger(), func() time.Time {
+		return time.Unix(1_700_000_000, 0).UTC()
+	})
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+
+	if _, err := client.Send(context.Background(), []string{"device-token-abc123"}, []byte(`{"aps":{}}`)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 client span, got %d", len(spans))
+	}
+	span := spans[0]
+
+	if span.Name() != "APNs push" {
+		t.Errorf("span name: got %q, want %q", span.Name(), "APNs push")
+	}
+	if span.SpanKind() != oteltrace.SpanKindClient {
+		t.Errorf("span kind: got %v, want client", span.SpanKind())
+	}
+	if _, ok := spanAttr(span.Attributes(), "server.address"); !ok {
+		t.Errorf("missing server.address attribute (Target source); attrs=%v", span.Attributes())
+	}
+}

--- a/api-go/internal/metrics/registry.go
+++ b/api-go/internal/metrics/registry.go
@@ -1,0 +1,375 @@
+// Package metrics holds the Town Crier business-metric registry: the
+// towncrier.* OpenTelemetry instruments the .NET worker/api emitted before the
+// Go cutover, re-registered against the global OTel MeterProvider (wired in
+// internal/platform/telemetry.go via the OTLP/gRPC metric exporter -> the ACA
+// managed-environment OTel agent -> App Insights AppMetrics). It restores the
+// polling-pipeline KPIs, PlanIt error rate, Cosmos RU consumption and watch-zone
+// counters the SRE team monitors on (bead tc-21np).
+//
+// The instrument NAMES and the tag keys (cycle.type, polling.authority_code,
+// never_polled, header_present, caller, ...) match the .NET implementation
+// exactly so the existing App Insights dashboards and alerts that key on them
+// keep working across the cutover.
+//
+// Registry exposes recording METHODS rather than raw instruments so every call
+// site stays trivial and the tag conventions live in one place. Recording
+// packages depend on a small consumer-side interface (the methods they use), not
+// on this concrete type, so *Registry satisfies them structurally. A nil
+// *Registry is a no-op on every method, so a call site can hold a nil registry
+// when telemetry is unconfigured without branching.
+package metrics
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+// MeterName is the instrumentation scope for the business metrics. The OTel
+// agent maps it to the App Insights AppMetrics SDK version tag; the towncrier.*
+// instrument names are what dashboards key on, so the scope name itself is not
+// load-bearing.
+const MeterName = "towncrier"
+
+// Registry holds the registered towncrier.* instruments. Build it once at boot
+// from otel.Meter(MeterName) (after platform.SetupTelemetry has installed the
+// global MeterProvider) and inject it through constructors. All instrument
+// construction errors are swallowed at build time — a failed instrument records
+// nothing rather than failing the boot, matching the OTel "metrics never break
+// the app" contract.
+type Registry struct {
+	authoritiesPolled  metric.Int64Counter
+	authoritiesSkipped metric.Int64Counter
+	applicationsIngest metric.Int64Counter
+	rateLimited        metric.Int64Counter
+	retryAfterSeconds  metric.Float64Histogram
+	authorityProcMs    metric.Float64Histogram
+	authorityTotal     metric.Int64Gauge
+	cyclesCompleted    metric.Int64Counter
+	cursorAdvanced     metric.Int64Counter
+	cursorCleared      metric.Int64Counter
+	leaseAcquired      metric.Int64Counter
+	oldestHwmAge       metric.Float64Gauge
+	neverPolledCount   metric.Int64Gauge
+
+	planitHTTPErrors metric.Int64Counter
+
+	notificationsCreated metric.Int64Counter
+
+	cosmosRequestCharge metric.Float64Histogram
+
+	watchZonesCreated metric.Int64Counter
+	watchZonesUpdated metric.Int64Counter
+	watchZonesDeleted metric.Int64Counter
+}
+
+// New builds the registry from a meter. Construction errors are deliberately
+// dropped: a missing instrument no-ops on record rather than aborting startup.
+func New(meter metric.Meter) *Registry {
+	r := &Registry{}
+
+	// counter / histogram / gauge drop the construction error deliberately: a
+	// failed instrument is left nil, and every recording method nil-checks it and
+	// no-ops, so a metric never aborts startup or a request. This is the OTel
+	// "metrics must not break the app" contract, and it keeps each registration
+	// below to one readable line while satisfying errcheck.
+	counter := func(name string, opts ...metric.Int64CounterOption) metric.Int64Counter {
+		inst, err := meter.Int64Counter(name, opts...)
+		if err != nil {
+			return nil
+		}
+		return inst
+	}
+	histogram := func(name string, opts ...metric.Float64HistogramOption) metric.Float64Histogram {
+		inst, err := meter.Float64Histogram(name, opts...)
+		if err != nil {
+			return nil
+		}
+		return inst
+	}
+	intGauge := func(name string, opts ...metric.Int64GaugeOption) metric.Int64Gauge {
+		inst, err := meter.Int64Gauge(name, opts...)
+		if err != nil {
+			return nil
+		}
+		return inst
+	}
+	floatGauge := func(name string, opts ...metric.Float64GaugeOption) metric.Float64Gauge {
+		inst, err := meter.Float64Gauge(name, opts...)
+		if err != nil {
+			return nil
+		}
+		return inst
+	}
+
+	r.authoritiesPolled = counter("towncrier.polling.authorities_polled")
+	r.authoritiesSkipped = counter("towncrier.polling.authorities_skipped")
+	r.applicationsIngest = counter("towncrier.polling.applications_ingested")
+	r.rateLimited = counter("towncrier.polling.rate_limited")
+	r.retryAfterSeconds = histogram(
+		"towncrier.polling.retry_after_seconds",
+		metric.WithUnit("s"),
+		metric.WithDescription("PlanIt-supplied Retry-After value (seconds) on 429 responses. Tagged by cycle.type, polling.authority_code, and header_present."),
+	)
+	r.authorityProcMs = histogram(
+		"towncrier.polling.authority_processing_ms",
+		metric.WithUnit("ms"),
+		metric.WithDescription("Total per-authority processing time (fetch + upsert + notifications)"),
+	)
+	r.authorityTotal = intGauge(
+		"towncrier.polling.authority_total",
+		metric.WithDescription("PlanIt-reported total matching applications for an authority at the start of a page-1 fetch. Tagged by cycle.type and polling.authority_code."),
+	)
+	r.cyclesCompleted = counter(
+		"towncrier.polling.cycles_completed",
+		metric.WithDescription("Finished poll cycles, tagged by cycle.type and termination."),
+	)
+	r.cursorAdvanced = counter(
+		"towncrier.polling.cursor_advanced",
+		metric.WithDescription("Incremented when the handler persists a non-null cursor (cap hit or 429 mid-pagination). Tagged by cycle.type."),
+	)
+	r.cursorCleared = counter(
+		"towncrier.polling.cursor_cleared",
+		metric.WithDescription("Incremented when the handler clears a previously-active cursor after reaching a natural end. Tagged by cycle.type."),
+	)
+	r.leaseAcquired = counter(
+		"towncrier.polling.lease.acquired",
+		metric.WithDescription("Incremented when the polling lease is successfully acquired. Tagged by caller."),
+	)
+	r.oldestHwmAge = floatGauge(
+		"towncrier.polling.oldest_hwm_age_seconds",
+		metric.WithUnit("s"),
+		metric.WithDescription("Age, in seconds, of the stalest authority's LastPollTime at the start of a cycle. Tagged by cycle.type, polling.authority_code, and never_polled."),
+	)
+	r.neverPolledCount = intGauge(
+		"towncrier.polling.never_polled_count",
+		metric.WithDescription("Count of authorities with no PollState document at the start of a cycle. Tagged by cycle.type."),
+	)
+
+	r.planitHTTPErrors = counter(
+		"towncrier.planit.http_errors",
+		metric.WithDescription("Non-2xx HTTP responses from PlanIt API"),
+	)
+
+	r.notificationsCreated = counter(
+		"towncrier.notifications.created",
+		metric.WithDescription("Notification records created (may or may not result in push)"),
+	)
+
+	r.cosmosRequestCharge = histogram(
+		"towncrier.cosmos.request_charge_ru",
+		metric.WithUnit("RU"),
+		metric.WithDescription("Cosmos RU consumption per operation"),
+	)
+
+	r.watchZonesCreated = counter("towncrier.watchzones.created")
+	r.watchZonesUpdated = counter("towncrier.watchzones.updated")
+	r.watchZonesDeleted = counter("towncrier.watchzones.deleted")
+
+	return r
+}
+
+// cycleTag builds the cycle.type attribute every polling instrument carries.
+func cycleTag(cycleType string) attribute.KeyValue {
+	return attribute.String("cycle.type", cycleType)
+}
+
+// AuthorityPolled counts an authority that produced work this cycle.
+func (r *Registry) AuthorityPolled(ctx context.Context, cycleType string) {
+	if r == nil || r.authoritiesPolled == nil {
+		return
+	}
+	r.authoritiesPolled.Add(ctx, 1, metric.WithAttributes(cycleTag(cycleType)))
+}
+
+// AuthoritySkipped counts an authority skipped this cycle (no work / error).
+func (r *Registry) AuthoritySkipped(ctx context.Context, cycleType string) {
+	if r == nil || r.authoritiesSkipped == nil {
+		return
+	}
+	r.authoritiesSkipped.Add(ctx, 1, metric.WithAttributes(cycleTag(cycleType)))
+}
+
+// ApplicationsIngested adds the count of applications ingested for an authority.
+func (r *Registry) ApplicationsIngested(ctx context.Context, n int, cycleType string) {
+	if r == nil || r.applicationsIngest == nil {
+		return
+	}
+	r.applicationsIngest.Add(ctx, int64(n), metric.WithAttributes(cycleTag(cycleType)))
+}
+
+// RateLimited counts a 429 from PlanIt during this cycle.
+func (r *Registry) RateLimited(ctx context.Context, cycleType string) {
+	if r == nil || r.rateLimited == nil {
+		return
+	}
+	r.rateLimited.Add(ctx, 1, metric.WithAttributes(cycleTag(cycleType)))
+}
+
+// RetryAfterSeconds records the parsed Retry-After value (seconds) on a 429,
+// tagged with cycle.type, polling.authority_code and header_present so
+// dashboards can distinguish "no header" (headerPresent=false, value 0) from a
+// genuine small backoff.
+func (r *Registry) RetryAfterSeconds(ctx context.Context, seconds float64, cycleType string, authorityID int, headerPresent bool) {
+	if r == nil || r.retryAfterSeconds == nil {
+		return
+	}
+	r.retryAfterSeconds.Record(ctx, seconds, metric.WithAttributes(
+		cycleTag(cycleType),
+		attribute.Int("polling.authority_code", authorityID),
+		attribute.String("header_present", boolStr(headerPresent)),
+	))
+}
+
+// AuthorityProcessingMillis records the total per-authority processing time.
+func (r *Registry) AuthorityProcessingMillis(ctx context.Context, ms float64, cycleType string) {
+	if r == nil || r.authorityProcMs == nil {
+		return
+	}
+	r.authorityProcMs.Record(ctx, ms, metric.WithAttributes(cycleTag(cycleType)))
+}
+
+// AuthorityTotal records PlanIt's reported total matching applications for an
+// authority at the start of a page-1 fetch.
+func (r *Registry) AuthorityTotal(ctx context.Context, total int, cycleType string, authorityID int) {
+	if r == nil || r.authorityTotal == nil {
+		return
+	}
+	r.authorityTotal.Record(ctx, int64(total), metric.WithAttributes(
+		cycleTag(cycleType),
+		attribute.Int("polling.authority_code", authorityID),
+	))
+}
+
+// CycleCompleted counts a finished poll cycle, tagged by cycle.type and the
+// termination reason.
+func (r *Registry) CycleCompleted(ctx context.Context, cycleType, termination string) {
+	if r == nil || r.cyclesCompleted == nil {
+		return
+	}
+	r.cyclesCompleted.Add(ctx, 1, metric.WithAttributes(
+		cycleTag(cycleType),
+		attribute.String("termination", termination),
+	))
+}
+
+// CursorAdvanced counts a non-null cursor persist (cap hit / 429 mid-pagination).
+func (r *Registry) CursorAdvanced(ctx context.Context, cycleType string) {
+	if r == nil || r.cursorAdvanced == nil {
+		return
+	}
+	r.cursorAdvanced.Add(ctx, 1, metric.WithAttributes(cycleTag(cycleType)))
+}
+
+// CursorCleared counts clearing a previously-active cursor at a natural end.
+func (r *Registry) CursorCleared(ctx context.Context, cycleType string) {
+	if r == nil || r.cursorCleared == nil {
+		return
+	}
+	r.cursorCleared.Add(ctx, 1, metric.WithAttributes(cycleTag(cycleType)))
+}
+
+// LeaseAcquired counts a successful polling-lease acquisition, tagged by caller
+// ("orchestrator" | "bootstrap").
+func (r *Registry) LeaseAcquired(ctx context.Context, caller string) {
+	if r == nil || r.leaseAcquired == nil {
+		return
+	}
+	r.leaseAcquired.Add(ctx, 1, metric.WithAttributes(attribute.String("caller", caller)))
+}
+
+// OldestHighWaterMarkAge records the age (seconds) of the stalest authority's
+// LastPollTime at cycle start, tagged with cycle.type, polling.authority_code
+// and never_polled.
+func (r *Registry) OldestHighWaterMarkAge(ctx context.Context, seconds float64, cycleType string, authorityID int, neverPolled bool) {
+	if r == nil || r.oldestHwmAge == nil {
+		return
+	}
+	r.oldestHwmAge.Record(ctx, seconds, metric.WithAttributes(
+		cycleTag(cycleType),
+		attribute.Int("polling.authority_code", authorityID),
+		attribute.String("never_polled", boolStr(neverPolled)),
+	))
+}
+
+// NeverPolledCount records the number of candidate authorities with no PollState
+// document at cycle start.
+func (r *Registry) NeverPolledCount(ctx context.Context, count int, cycleType string) {
+	if r == nil || r.neverPolledCount == nil {
+		return
+	}
+	r.neverPolledCount.Record(ctx, int64(count), metric.WithAttributes(cycleTag(cycleType)))
+}
+
+// PlanItHTTPError counts a non-2xx PlanIt response, tagged with the status code
+// and authority. The tag keys (http.response.status_code, planit.authority_code)
+// match the .NET PlanItClient instrumentation so existing App Insights queries
+// keep working.
+func (r *Registry) PlanItHTTPError(ctx context.Context, statusCode, authorityID int) {
+	if r == nil || r.planitHTTPErrors == nil {
+		return
+	}
+	r.planitHTTPErrors.Add(ctx, 1, metric.WithAttributes(
+		attribute.Int("http.response.status_code", statusCode),
+		attribute.Int("planit.authority_code", authorityID),
+	))
+}
+
+// NotificationCreated counts a notification record created, tagged by event_type
+// ("NewApplication" | "DecisionUpdate") and sources ("Zone" | "Saved" | both),
+// matching the .NET ApiMetrics.NotificationsCreated tags.
+func (r *Registry) NotificationCreated(ctx context.Context, eventType, sources string) {
+	if r == nil || r.notificationsCreated == nil {
+		return
+	}
+	r.notificationsCreated.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("event_type", eventType),
+		attribute.String("sources", sources),
+	))
+}
+
+// CosmosRequestCharge records the RU charge of a single Cosmos operation, tagged
+// with the operation and container.
+func (r *Registry) CosmosRequestCharge(ctx context.Context, ru float64, operation, container string) {
+	if r == nil || r.cosmosRequestCharge == nil {
+		return
+	}
+	r.cosmosRequestCharge.Record(ctx, ru, metric.WithAttributes(
+		attribute.String("operation", operation),
+		attribute.String("container", container),
+	))
+}
+
+// WatchZoneCreated counts a watch zone created.
+func (r *Registry) WatchZoneCreated(ctx context.Context) {
+	if r == nil || r.watchZonesCreated == nil {
+		return
+	}
+	r.watchZonesCreated.Add(ctx, 1)
+}
+
+// WatchZoneUpdated counts a watch zone updated.
+func (r *Registry) WatchZoneUpdated(ctx context.Context) {
+	if r == nil || r.watchZonesUpdated == nil {
+		return
+	}
+	r.watchZonesUpdated.Add(ctx, 1)
+}
+
+// WatchZoneDeleted counts a watch zone deleted.
+func (r *Registry) WatchZoneDeleted(ctx context.Context) {
+	if r == nil || r.watchZonesDeleted == nil {
+		return
+	}
+	r.watchZonesDeleted.Add(ctx, 1)
+}
+
+// boolStr renders a bool as the lowercase "true"/"false" string the .NET tags
+// used, so App Insights filters keep matching across the cutover.
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/api-go/internal/metrics/registry_test.go
+++ b/api-go/internal/metrics/registry_test.go
@@ -1,0 +1,159 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// newTestRegistry builds a Registry backed by an in-memory manual reader so a
+// test can collect the recorded measurements. It returns the registry and a
+// collect func that snapshots the current metrics.
+func newTestRegistry(t *testing.T) (*Registry, func() metricdata.ResourceMetrics) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() {
+		_ = mp.Shutdown(context.Background())
+	})
+	reg := New(mp.Meter("towncrier"))
+	collect := func() metricdata.ResourceMetrics {
+		var rm metricdata.ResourceMetrics
+		if err := reader.Collect(context.Background(), &rm); err != nil {
+			t.Fatalf("collect: %v", err)
+		}
+		return rm
+	}
+	return reg, collect
+}
+
+// metricNames flattens every instrument name present in the collected metrics.
+func metricNames(rm metricdata.ResourceMetrics) map[string]struct{} {
+	names := map[string]struct{}{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			names[m.Name] = struct{}{}
+		}
+	}
+	return names
+}
+
+func TestRegistry_RecordsAllInstrumentNames(t *testing.T) {
+	t.Parallel()
+	reg, collect := newTestRegistry(t)
+	ctx := context.Background()
+
+	// Drive every recording method once so each instrument emits at least one
+	// measurement and therefore appears in the collected metrics.
+	reg.AuthorityPolled(ctx, "Watched")
+	reg.AuthoritySkipped(ctx, "Watched")
+	reg.ApplicationsIngested(ctx, 3, "Watched")
+	reg.RateLimited(ctx, "Watched")
+	reg.RetryAfterSeconds(ctx, 12, "Watched", 7, true)
+	reg.AuthorityProcessingMillis(ctx, 42.0, "Watched")
+	reg.AuthorityTotal(ctx, 99, "Watched", 7)
+	reg.CycleCompleted(ctx, "Watched", "Natural")
+	reg.CursorAdvanced(ctx, "Watched")
+	reg.CursorCleared(ctx, "Watched")
+	reg.LeaseAcquired(ctx, "orchestrator")
+	reg.OldestHighWaterMarkAge(ctx, 3600, "Watched", 7, false)
+	reg.NeverPolledCount(ctx, 5, "Watched")
+	reg.PlanItHTTPError(ctx, 500, 99)
+	reg.NotificationCreated(ctx, "NewApplication", "Zone")
+	reg.CosmosRequestCharge(ctx, 2.5, "ReadItem", "WatchZones")
+	reg.WatchZoneCreated(ctx)
+	reg.WatchZoneUpdated(ctx)
+	reg.WatchZoneDeleted(ctx)
+
+	got := metricNames(collect())
+
+	want := []string{
+		"towncrier.polling.authorities_polled",
+		"towncrier.polling.authorities_skipped",
+		"towncrier.polling.applications_ingested",
+		"towncrier.polling.rate_limited",
+		"towncrier.polling.retry_after_seconds",
+		"towncrier.polling.authority_processing_ms",
+		"towncrier.polling.authority_total",
+		"towncrier.polling.cycles_completed",
+		"towncrier.polling.cursor_advanced",
+		"towncrier.polling.cursor_cleared",
+		"towncrier.polling.lease.acquired",
+		"towncrier.polling.oldest_hwm_age_seconds",
+		"towncrier.polling.never_polled_count",
+		"towncrier.planit.http_errors",
+		"towncrier.notifications.created",
+		"towncrier.cosmos.request_charge_ru",
+		"towncrier.watchzones.created",
+		"towncrier.watchzones.updated",
+		"towncrier.watchzones.deleted",
+	}
+	for _, name := range want {
+		if _, ok := got[name]; !ok {
+			t.Errorf("instrument %q not recorded; got %v", name, got)
+		}
+	}
+}
+
+func TestRegistry_NilIsNoOp(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	var reg *Registry // nil
+
+	// Every recording method must be safe to call on a nil registry so call sites
+	// can stay metric-agnostic when telemetry is unconfigured.
+	reg.AuthorityPolled(ctx, "Watched")
+	reg.AuthoritySkipped(ctx, "Watched")
+	reg.ApplicationsIngested(ctx, 1, "Watched")
+	reg.RateLimited(ctx, "Watched")
+	reg.RetryAfterSeconds(ctx, 1, "Watched", 1, false)
+	reg.AuthorityProcessingMillis(ctx, 1, "Watched")
+	reg.AuthorityTotal(ctx, 1, "Watched", 1)
+	reg.CycleCompleted(ctx, "Watched", "Natural")
+	reg.CursorAdvanced(ctx, "Watched")
+	reg.CursorCleared(ctx, "Watched")
+	reg.LeaseAcquired(ctx, "orchestrator")
+	reg.OldestHighWaterMarkAge(ctx, 1, "Watched", 1, false)
+	reg.NeverPolledCount(ctx, 1, "Watched")
+	reg.PlanItHTTPError(ctx, 500, 99)
+	reg.NotificationCreated(ctx, "NewApplication", "Zone")
+	reg.CosmosRequestCharge(ctx, 1, "ReadItem", "WatchZones")
+	reg.WatchZoneCreated(ctx)
+	reg.WatchZoneUpdated(ctx)
+	reg.WatchZoneDeleted(ctx)
+}
+
+func TestRegistry_RetryAfterTagsHeaderPresence(t *testing.T) {
+	t.Parallel()
+	reg, collect := newTestRegistry(t)
+	ctx := context.Background()
+
+	reg.RetryAfterSeconds(ctx, 0, "Seed", 7, false)
+
+	rm := collect()
+	var foundHeaderPresent bool
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "towncrier.polling.retry_after_seconds" {
+				continue
+			}
+			hist, ok := m.Data.(metricdata.Histogram[float64])
+			if !ok {
+				t.Fatalf("retry_after_seconds is not a float64 histogram: %T", m.Data)
+			}
+			for _, dp := range hist.DataPoints {
+				if v, ok := dp.Attributes.Value("header_present"); ok {
+					foundHeaderPresent = true
+					if v.AsString() != "false" {
+						t.Errorf("header_present = %q, want false", v.AsString())
+					}
+				}
+			}
+		}
+	}
+	if !foundHeaderPresent {
+		t.Error("retry_after_seconds missing header_present tag")
+	}
+}

--- a/api-go/internal/middleware/routespan.go
+++ b/api-go/internal/middleware/routespan.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// routeMatcher is the subset of *http.ServeMux RouteSpan needs to resolve the
+// pattern a request matches, mirroring auth.RequireAuth's matcher. Declared
+// here, consumer-side, so the middleware depends only on the two methods it
+// uses and *http.ServeMux satisfies it implicitly.
+type routeMatcher interface {
+	http.Handler
+	Handler(r *http.Request) (h http.Handler, pattern string)
+}
+
+// statusWriter captures the response status code so RouteSpan can record it on
+// the request span. It defaults to 200, matching net/http's behaviour when a
+// handler writes a body without an explicit WriteHeader.
+type statusWriter struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (s *statusWriter) WriteHeader(status int) {
+	if !s.wroteHeader {
+		s.status = status
+		s.wroteHeader = true
+	}
+	s.ResponseWriter.WriteHeader(status)
+}
+
+func (s *statusWriter) Write(p []byte) (int, error) {
+	if !s.wroteHeader {
+		s.status = http.StatusOK
+		s.wroteHeader = true
+	}
+	return s.ResponseWriter.Write(p)
+}
+
+// Unwrap lets http.ResponseController reach the underlying writer (Flush etc.).
+func (s *statusWriter) Unwrap() http.ResponseWriter { return s.ResponseWriter }
+
+// RouteSpan restores the request-telemetry parity the .NET API had (tc-r8eo):
+// it names the inbound request span after the matched ServeMux route (e.g.
+// "GET /v1/me") and records the real HTTP status code on the span. Azure Monitor
+// maps span Name -> AppRequests.Name and http.response.status_code ->
+// ResultCode, so without this every Go request row showed only the bare verb and
+// a span-status ResultCode (0/2), leaving status-keyed dashboards and 4xx/5xx
+// alerts blind.
+//
+// It resolves the pattern up front via the matcher (the same deterministic
+// lookup auth.RequireAuth uses) rather than reading r.Pattern, because the
+// request that the inner mux mutates is a context-copy that never propagates
+// back here. An unmatched request leaves the default span name and sets no
+// http.route, but still records its status code. Place it within the otelhttp
+// span — wrapping the rest of the chain — so the active span is the request span.
+func RouteSpan(matcher routeMatcher) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, pattern := matcher.Handler(r)
+
+			span := trace.SpanFromContext(r.Context())
+			if pattern != "" {
+				span.SetName(pattern)
+				span.SetAttributes(semconv.HTTPRoute(pattern))
+			}
+
+			sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+			next.ServeHTTP(sw, r)
+
+			span.SetAttributes(semconv.HTTPResponseStatusCode(sw.status))
+			// Mirror semconv server semantics: a 5xx is a request error. ErrorBody
+			// also flags 5xx, but it does not run for the unmatched-route 404/anonymous
+			// paths that bypass it, so set it here too. SetStatus is idempotent and the
+			// last Error wins, so re-flagging a panic-marked span is harmless.
+			if sw.status >= http.StatusInternalServerError {
+				span.SetStatus(codes.Error, http.StatusText(sw.status))
+			}
+		})
+	}
+}

--- a/api-go/internal/middleware/routespan_test.go
+++ b/api-go/internal/middleware/routespan_test.go
@@ -1,0 +1,143 @@
+package middleware
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// attrString returns the string value of the named attribute on the span, or ""
+// if the span carries no such attribute.
+func attrString(span sdktrace.ReadOnlySpan, key string) string {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsString()
+		}
+	}
+	return ""
+}
+
+// attrInt returns the int64 value of the named attribute on the span and whether
+// it was present.
+func attrInt(span sdktrace.ReadOnlySpan, key string) (int64, bool) {
+	for _, kv := range span.Attributes() {
+		if string(kv.Key) == key {
+			return kv.Value.AsInt64(), true
+		}
+	}
+	return 0, false
+}
+
+// serveRouteSpanChain drives a GET request for path through
+// spanStarter -> RouteSpan(mux) -> mux and returns the single recorded request
+// span. The mux registers a single GET pattern that responds with status.
+func serveRouteSpanChain(t *testing.T, pattern, path string, status int) sdktrace.ReadOnlySpan {
+	t.Helper()
+
+	prev := otel.GetTracerProvider()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+
+	mux := http.NewServeMux()
+	if pattern != "" {
+		mux.HandleFunc(pattern, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(status)
+		})
+	}
+
+	chain := spanStarter(RouteSpan(mux)(mux))
+	srv := httptest.NewServer(chain)
+	t.Cleanup(srv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+path, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	resp, err := srv.Client().Do(req)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	return spans[0]
+}
+
+// TestRouteSpan_NamesSpanAfterMatchedRoute pins tc-r8eo: a matched route makes
+// the request span Name the route pattern (e.g. "GET /v1/health") and carries
+// the http.route attribute, so Azure Monitor's AppRequests.Name shows the
+// endpoint rather than the bare verb.
+func TestRouteSpan_NamesSpanAfterMatchedRoute(t *testing.T) {
+	span := serveRouteSpanChain(t, "GET /v1/health", "/v1/health", http.StatusOK)
+
+	if got, want := span.Name(), "GET /v1/health"; got != want {
+		t.Errorf("span name = %q, want %q", got, want)
+	}
+	if got, want := attrString(span, string(attribute.Key("http.route"))), "GET /v1/health"; got != want {
+		t.Errorf("http.route = %q, want %q", got, want)
+	}
+}
+
+// TestRouteSpan_RecordsStatusCode confirms the real HTTP status is recorded onto
+// the span as http.response.status_code for both a 2xx and an error path, so
+// Azure Monitor's ResultCode reflects the HTTP status rather than the span code.
+func TestRouteSpan_RecordsStatusCode(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+	}{
+		{"ok", http.StatusOK},
+		{"unauthorized", http.StatusUnauthorized},
+		{"not found", http.StatusNotFound},
+		{"server error", http.StatusInternalServerError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			span := serveRouteSpanChain(t, "GET /v1/thing", "/v1/thing", tc.status)
+			got, ok := attrInt(span, "http.response.status_code")
+			if !ok {
+				t.Fatalf("http.response.status_code attribute missing")
+			}
+			if int(got) != tc.status {
+				t.Errorf("http.response.status_code = %d, want %d", got, tc.status)
+			}
+		})
+	}
+}
+
+// TestRouteSpan_UnmatchedRequestFallsBackGracefully confirms an unmatched
+// request neither panics nor renames the span to an empty string: the default
+// span name survives and no http.route attribute is set, while the status code
+// (the mux's own 404) is still recorded.
+func TestRouteSpan_UnmatchedRequestFallsBackGracefully(t *testing.T) {
+	// No pattern registered: every path is unmatched -> the mux's default 404.
+	span := serveRouteSpanChain(t, "", "/nope", http.StatusNotFound)
+
+	if got := span.Name(); got != "request" {
+		t.Errorf("span name = %q, want the default %q (unmatched must not rename)", got, "request")
+	}
+	if got := attrString(span, "http.route"); got != "" {
+		t.Errorf("http.route = %q, want empty for an unmatched request", got)
+	}
+	if got, ok := attrInt(span, "http.response.status_code"); !ok || int(got) != http.StatusNotFound {
+		t.Errorf("http.response.status_code = %d (ok=%v), want 404", got, ok)
+	}
+}

--- a/api-go/internal/notifydispatch/decision.go
+++ b/api-go/internal/notifydispatch/decision.go
@@ -40,6 +40,16 @@ type DecisionDispatcher struct {
 	newID         func() string
 	now           func() time.Time
 	logger        *slog.Logger
+	metrics       notificationMetricsRecorder
+}
+
+// WithMetrics wires the recorder the dispatcher records
+// towncrier.notifications.created on. A post-construction setter so the existing
+// dispatch call sites and tests are unaffected; cmd/worker calls it once after
+// building the dispatcher. Returns the dispatcher for chaining.
+func (d *DecisionDispatcher) WithMetrics(rec notificationMetricsRecorder) *DecisionDispatcher {
+	d.metrics = rec
+	return d
 }
 
 // NewDecisionDispatcher wires the decision dispatcher. newID mints the
@@ -169,7 +179,13 @@ func (d *DecisionDispatcher) dispatchForUser(ctx context.Context, app applicatio
 		}, userID, n)
 	}
 
-	return d.notifications.Create(ctx, n)
+	if err := d.notifications.Create(ctx, n); err != nil {
+		return err
+	}
+	if d.metrics != nil {
+		d.metrics.NotificationCreated(ctx, string(n.EventType), n.Sources)
+	}
+	return nil
 }
 
 // canPush OR-merges the per-channel decision-push toggles across the matching

--- a/api-go/internal/notifydispatch/enqueuer.go
+++ b/api-go/internal/notifydispatch/enqueuer.go
@@ -68,6 +68,14 @@ type pushSender interface {
 	Send(ctx context.Context, tokens []string, payload json.RawMessage) ([]string, error)
 }
 
+// notificationMetricsRecorder is the consumer-side slice of the metrics registry
+// the dispatchers record towncrier.notifications.created on, after a record is
+// successfully persisted. *metrics.Registry satisfies it; nil leaves the counter
+// dark (the default for the dispatch tests that don't assert on metrics).
+type notificationMetricsRecorder interface {
+	NotificationCreated(ctx context.Context, eventType, sources string)
+}
+
 // Enqueuer ports .NET DispatchNotificationCommandHandler: for a new application
 // that matched a watch zone, it dedups, creates the notification record (which
 // feeds the digest pipeline), and — for paid tiers with devices — sends an
@@ -83,6 +91,16 @@ type Enqueuer struct {
 	newID         func() string
 	now           func() time.Time
 	logger        *slog.Logger
+	metrics       notificationMetricsRecorder
+}
+
+// WithMetrics wires the recorder the enqueuer records
+// towncrier.notifications.created on. A post-construction setter so the existing
+// dispatch call sites and tests are unaffected; cmd/worker calls it once after
+// building the enqueuer. Returns the enqueuer for chaining.
+func (e *Enqueuer) WithMetrics(rec notificationMetricsRecorder) *Enqueuer {
+	e.metrics = rec
+	return e
 }
 
 // NewEnqueuer wires the enqueuer. newID mints the notification id (a GUID in
@@ -185,5 +203,11 @@ func (e *Enqueuer) Enqueue(ctx context.Context, app applications.PlanningApplica
 		}, zone.UserID, n)
 	}
 
-	return e.notifications.Create(ctx, n)
+	if err := e.notifications.Create(ctx, n); err != nil {
+		return err
+	}
+	if e.metrics != nil {
+		e.metrics.NotificationCreated(ctx, string(n.EventType), n.Sources)
+	}
+	return nil
 }

--- a/api-go/internal/notifydispatch/metrics_test.go
+++ b/api-go/internal/notifydispatch/metrics_test.go
@@ -1,0 +1,68 @@
+package notifydispatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// fakeNotifMetrics records the notification-created calls a dispatcher makes. It
+// satisfies the notifydispatch consumer-side notificationMetricsRecorder.
+type fakeNotifMetrics struct {
+	eventTypes []string
+	sources    []string
+}
+
+func (f *fakeNotifMetrics) NotificationCreated(_ context.Context, eventType, sources string) {
+	f.eventTypes = append(f.eventTypes, eventType)
+	f.sources = append(f.sources, sources)
+}
+
+func TestEnqueuer_RecordsNotificationCreated(t *testing.T) {
+	t.Parallel()
+	z := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{z}}
+	enq, _, _, _ := newEnqueuerHarnessWithZones(t, profiles.TierPro, zones)
+	rec := &fakeNotifMetrics{}
+	enq.WithMetrics(rec)
+
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
+		t.Fatalf("EnqueueForApplication: %v", err)
+	}
+
+	if len(rec.eventTypes) != 1 || rec.eventTypes[0] != "NewApplication" {
+		t.Errorf("NotificationCreated event types = %v, want [NewApplication]", rec.eventTypes)
+	}
+	if len(rec.sources) != 1 || rec.sources[0] != "Zone" {
+		t.Errorf("NotificationCreated sources = %v, want [Zone]", rec.sources)
+	}
+}
+
+func TestEnqueuer_DoesNotRecordOnDedup(t *testing.T) {
+	t.Parallel()
+	z := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{z}}
+	enq, notifs, _, _ := newEnqueuerHarnessWithZones(t, profiles.TierPro, zones)
+	rec := &fakeNotifMetrics{}
+	enq.WithMetrics(rec)
+
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
+		t.Fatalf("first EnqueueForApplication: %v", err)
+	}
+	// Second fan-out of the same application is a dedup no-op: no new record, no
+	// new metric.
+	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
+		t.Fatalf("second EnqueueForApplication: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("expected one record after dedup, got %d", len(notifs.created))
+	}
+	if len(rec.eventTypes) != 1 {
+		t.Errorf("NotificationCreated must fire once, got %d", len(rec.eventTypes))
+	}
+}

--- a/api-go/internal/planit/client.go
+++ b/api-go/internal/planit/client.go
@@ -92,6 +92,14 @@ func DefaultRetryOptions() RetryOptions {
 	}
 }
 
+// httpErrorRecorder is the consumer-side slice of the metrics registry the
+// client records towncrier.planit.http_errors on. *metrics.Registry satisfies
+// it; nil leaves the counter dark. The tag keys are owned by the recorder
+// (http.response.status_code, planit.authority_code) so they match .NET.
+type httpErrorRecorder interface {
+	PlanItHTTPError(ctx context.Context, statusCode, authorityID int)
+}
+
 // Options configures a Client. HTTPClient and Sleep default to a hardened
 // shared client and a context-aware time.Sleep when nil.
 type Options struct {
@@ -102,6 +110,9 @@ type Options struct {
 	// Sleep is injected so tests can pace deterministically without real waits.
 	// It must honour ctx cancellation. Defaults to a context-aware sleep.
 	Sleep func(ctx context.Context, d time.Duration) error
+	// Metrics records towncrier.planit.http_errors. nil leaves the counter dark
+	// (the default for the many client tests that don't assert on metrics).
+	Metrics httpErrorRecorder
 }
 
 // FetchPageResult is one page of a PlanIt fetch: the parsed applications, the
@@ -121,6 +132,7 @@ type Client struct {
 	throttle   ThrottleOptions
 	retry      RetryOptions
 	sleep      func(ctx context.Context, d time.Duration) error
+	metrics    httpErrorRecorder
 }
 
 // NewClient validates the base URL and wires the client. A non-HTTPS base URL is
@@ -153,6 +165,7 @@ func NewClient(opts Options) (*Client, error) {
 		throttle:   opts.Throttle,
 		retry:      opts.Retry,
 		sleep:      sleep,
+		metrics:    opts.Metrics,
 	}, nil
 }
 
@@ -162,7 +175,7 @@ func NewClient(opts Options) (*Client, error) {
 func (c *Client) FetchApplicationsPage(ctx context.Context, authorityID int, differentStart *time.Time, page int) (FetchPageResult, error) {
 	target := c.baseURL + buildPath(authorityID, differentStart, page)
 
-	resp, err := c.sendWithThrottle(ctx, target)
+	resp, err := c.sendWithThrottle(ctx, target, authorityID)
 	if err != nil {
 		return FetchPageResult{}, err
 	}
@@ -203,7 +216,7 @@ func (c *Client) FetchApplicationsPage(ctx context.Context, authorityID int, dif
 // transient (5xx/408) failures with exponential backoff. 429 and permanent 4xx
 // are returned to the caller without retry. The returned response (when err is
 // nil) has an un-read body the caller must classify and close.
-func (c *Client) sendWithThrottle(ctx context.Context, target string) (*http.Response, error) {
+func (c *Client) sendWithThrottle(ctx context.Context, target string, authorityID int) (*http.Response, error) {
 	maxAttempts := 1 + c.retry.MaxRetries
 	for attempt := range maxAttempts {
 		if c.throttle.DelayBetweenRequests > 0 {
@@ -232,6 +245,13 @@ func (c *Client) sendWithThrottle(ctx context.Context, target string) (*http.Res
 
 		if resp.StatusCode == http.StatusOK {
 			return resp, nil
+		}
+
+		// Every non-2xx response is an http error — count it on each attempt
+		// (including 429 and retried 5xx), tagged with status + authority, matching
+		// .NET PlanItClient's per-response HttpErrors.Add.
+		if c.metrics != nil {
+			c.metrics.PlanItHTTPError(ctx, resp.StatusCode, authorityID)
 		}
 
 		// 429 and permanent (non-retryable) statuses go straight back to the

--- a/api-go/internal/planit/client.go
+++ b/api-go/internal/planit/client.go
@@ -20,7 +20,10 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
 // defaultPageSize is PlanIt's page size; a full page (>= this many records) is
@@ -113,6 +116,10 @@ type Options struct {
 	// Metrics records towncrier.planit.http_errors. nil leaves the counter dark
 	// (the default for the many client tests that don't assert on metrics).
 	Metrics httpErrorRecorder
+	// TraceOptions are extra otelhttp options threaded into the wrapped transport
+	// (e.g. WithTracerProvider in hermetic tests). Production leaves this nil and
+	// relies on the global provider installed by SetupTelemetry.
+	TraceOptions []otelhttp.Option
 }
 
 // FetchPageResult is one page of a PlanIt fetch: the parsed applications, the
@@ -154,6 +161,10 @@ func NewClient(opts Options) (*Client, error) {
 	if hc == nil {
 		hc = &http.Client{Timeout: 30 * time.Second}
 	}
+	// Wrap the transport so every PlanIt GET emits an OTel client span
+	// (Type=HTTP in AppDependencies) named "PlanIt search". The host lands in
+	// server.address; the static span name keeps cardinality low.
+	hc = platform.WrapHTTPClient(hc, func(string, *http.Request) string { return "PlanIt search" }, opts.TraceOptions...)
 	sleep := opts.Sleep
 	if sleep == nil {
 		sleep = contextSleep

--- a/api-go/internal/planit/metrics_test.go
+++ b/api-go/internal/planit/metrics_test.go
@@ -1,0 +1,83 @@
+package planit
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// fakePlanItMetrics records the http-error calls the client makes. It satisfies
+// the planit package's consumer-side httpErrorRecorder interface.
+type fakePlanItMetrics struct {
+	statuses    []int
+	authorities []int
+}
+
+func (f *fakePlanItMetrics) PlanItHTTPError(_ context.Context, statusCode, authorityID int) {
+	f.statuses = append(f.statuses, statusCode)
+	f.authorities = append(f.authorities, authorityID)
+}
+
+func TestFetchApplicationsPage_RecordsHTTPErrorOnPermanent4xx(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	rec := &fakePlanItMetrics{}
+	clock := &fakeClock{}
+	c, err := NewClient(Options{
+		BaseURL:    srv.URL,
+		Throttle:   ThrottleOptions{DelayBetweenRequests: 0},
+		Retry:      RetryOptions{MaxRetries: 0, InitialBackoff: time.Second, RateLimitBackoff: 5 * time.Second},
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		Sleep:      clock.sleep,
+		Metrics:    rec,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if _, err := c.FetchApplicationsPage(context.Background(), 99, nil, 1); err == nil {
+		t.Fatal("expected an error for a 404")
+	}
+	if len(rec.statuses) != 1 || rec.statuses[0] != http.StatusNotFound {
+		t.Errorf("PlanItHTTPError statuses = %v, want [404]", rec.statuses)
+	}
+	if len(rec.authorities) != 1 || rec.authorities[0] != 99 {
+		t.Errorf("PlanItHTTPError authorities = %v, want [99]", rec.authorities)
+	}
+}
+
+func TestFetchApplicationsPage_DoesNotRecordHTTPErrorOnSuccess(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total":0,"records":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	rec := &fakePlanItMetrics{}
+	clock := &fakeClock{}
+	c, err := NewClient(Options{
+		BaseURL:    srv.URL,
+		Throttle:   ThrottleOptions{DelayBetweenRequests: 0},
+		Retry:      RetryOptions{MaxRetries: 0},
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		Sleep:      clock.sleep,
+		Metrics:    rec,
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if _, err := c.FetchApplicationsPage(context.Background(), 99, nil, 1); err != nil {
+		t.Fatalf("FetchApplicationsPage: %v", err)
+	}
+	if len(rec.statuses) != 0 {
+		t.Errorf("PlanItHTTPError must not fire on success: %v", rec.statuses)
+	}
+}

--- a/api-go/internal/planit/span_test.go
+++ b/api-go/internal/planit/span_test.go
@@ -1,0 +1,81 @@
+package planit
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// recorderProvider returns an in-memory SDK TracerProvider for hermetic span
+// assertions; the wrapped transport emits into the recorder, not the global.
+func recorderProvider(t *testing.T) (*sdktrace.TracerProvider, *tracetest.SpanRecorder) {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return tp, rec
+}
+
+func attr(attrs []attribute.KeyValue, key string) (attribute.Value, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+// TestFetchApplicationsPage_EmitsClientSpan asserts a PlanIt fetch produces a
+// client span named "PlanIt search" carrying the upstream host as server.address
+// so it surfaces in AppDependencies as a meaningful HTTP dependency.
+func TestFetchApplicationsPage_EmitsClientSpan(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"total":0,"pg_sz":100,"records":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	tp, rec := recorderProvider(t)
+
+	c, err := NewClient(Options{
+		BaseURL:      srv.URL,
+		Throttle:     ThrottleOptions{DelayBetweenRequests: 0},
+		Retry:        RetryOptions{MaxRetries: 0},
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		Sleep:        func(context.Context, time.Duration) error { return nil },
+		TraceOptions: []otelhttp.Option{otelhttp.WithTracerProvider(tp)},
+	})
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+
+	if _, err := c.FetchApplicationsPage(context.Background(), 99, nil, 1); err != nil {
+		t.Fatalf("FetchApplicationsPage: %v", err)
+	}
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 client span, got %d", len(spans))
+	}
+	span := spans[0]
+
+	if span.Name() != "PlanIt search" {
+		t.Errorf("span name: got %q, want %q", span.Name(), "PlanIt search")
+	}
+	if span.SpanKind() != oteltrace.SpanKindClient {
+		t.Errorf("span kind: got %v, want client", span.SpanKind())
+	}
+	if _, ok := attr(span.Attributes(), "server.address"); !ok {
+		t.Errorf("missing server.address attribute (Target source); attrs=%v", span.Attributes())
+	}
+}

--- a/api-go/internal/platform/cosmos.go
+++ b/api-go/internal/platform/cosmos.go
@@ -26,6 +26,14 @@ import (
 // invisible in App Insights.
 const cosmosTracerName = "github.com/AmyDe/town-crier/api-go/internal/platform"
 
+// cosmosMetricsRecorder is the consumer-side slice of the metrics registry the
+// Cosmos container records towncrier.cosmos.request_charge_ru on, once per
+// successful operation. *metrics.Registry satisfies it; nil leaves the histogram
+// dark (the default for tests and Cosmos-less boots).
+type cosmosMetricsRecorder interface {
+	CosmosRequestCharge(ctx context.Context, ru float64, operation, container string)
+}
+
 // traceCosmosOp wraps a single outbound azcosmos call in an OpenTelemetry client
 // span so it surfaces as an App Insights dependency. The span is a child of
 // whatever span rides on ctx (the incoming request span), and the ctx carrying
@@ -33,7 +41,13 @@ const cosmosTracerName = "github.com/AmyDe/town-crier/api-go/internal/platform"
 // follow the OTel DB semantic conventions so App Insights populates the
 // dependency Type/Target; on error the span records the error and is marked
 // Error. The span ends regardless of outcome.
-func traceCosmosOp(ctx context.Context, c *CosmosContainer, op string, fn func(context.Context) error) error {
+//
+// fn returns the operation's RU charge (read from the SDK ItemResponse /
+// QueryResponse); on success the charge is recorded as the
+// db.cosmosdb.request_charge span attribute and on the
+// towncrier.cosmos.request_charge_ru histogram (tc-21np), restoring the RU /
+// cost telemetry that went dark at the .NET->Go cutover.
+func traceCosmosOp(ctx context.Context, c *CosmosContainer, op string, fn func(context.Context) (float64, error)) error {
 	tracer := otel.Tracer(cosmosTracerName)
 	ctx, span := tracer.Start(ctx, "Cosmos "+op+" "+c.name,
 		trace.WithSpanKind(trace.SpanKindClient),
@@ -47,10 +61,15 @@ func traceCosmosOp(ctx context.Context, c *CosmosContainer, op string, fn func(c
 	)
 	defer span.End()
 
-	if err := fn(ctx); err != nil {
+	ru, err := fn(ctx)
+	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return err
+	}
+	span.SetAttributes(attribute.Float64("db.cosmosdb.request_charge", ru))
+	if c.metrics != nil {
+		c.metrics.CosmosRequestCharge(ctx, ru, op, c.name)
 	}
 	return nil
 }
@@ -127,6 +146,23 @@ type CosmosContainer struct {
 	// server.address (the dependency Target in App Insights).
 	name        string
 	accountHost string
+	// metrics records towncrier.cosmos.request_charge_ru per op, wired via
+	// WithMetrics. nil until wired, so the histogram stays dark in tests and
+	// Cosmos-less boots.
+	metrics cosmosMetricsRecorder
+}
+
+// WithMetrics wires the recorder the container records the per-op RU charge on.
+// A post-construction setter so the many NewCosmosContainerNamed call sites are
+// unaffected; cmd/api and cmd/worker call it once per container after building
+// it. Returns the container for chaining. A nil container (Cosmos unconfigured)
+// is a safe no-op so call sites can chain unconditionally.
+func (c *CosmosContainer) WithMetrics(rec cosmosMetricsRecorder) *CosmosContainer {
+	if c == nil {
+		return nil
+	}
+	c.metrics = rec
+	return c
 }
 
 // NewCosmosContainer builds a Cosmos client authenticated by the pinned
@@ -224,13 +260,13 @@ const (
 // ReadItem point-reads the document with the given id from its partition.
 func (c *CosmosContainer) ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error) {
 	var value []byte
-	err := traceCosmosOp(ctx, c, "ReadItem", func(ctx context.Context) error {
+	err := traceCosmosOp(ctx, c, "ReadItem", func(ctx context.Context) (float64, error) {
 		resp, err := c.container.ReadItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), id, nil)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		value = resp.Value
-		return nil
+		return float64(resp.RequestCharge), nil
 	})
 	if err != nil {
 		return nil, err
@@ -240,17 +276,23 @@ func (c *CosmosContainer) ReadItem(ctx context.Context, partitionKey, id string)
 
 // UpsertItem upserts the document into the given partition.
 func (c *CosmosContainer) UpsertItem(ctx context.Context, partitionKey string, item []byte) error {
-	return traceCosmosOp(ctx, c, "UpsertItem", func(ctx context.Context) error {
-		_, err := c.container.UpsertItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), item, nil)
-		return err
+	return traceCosmosOp(ctx, c, "UpsertItem", func(ctx context.Context) (float64, error) {
+		resp, err := c.container.UpsertItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), item, nil)
+		if err != nil {
+			return 0, err
+		}
+		return float64(resp.RequestCharge), nil
 	})
 }
 
 // DeleteItem deletes the document with the given id from its partition.
 func (c *CosmosContainer) DeleteItem(ctx context.Context, partitionKey, id string) error {
-	return traceCosmosOp(ctx, c, "DeleteItem", func(ctx context.Context) error {
-		_, err := c.container.DeleteItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), id, nil)
-		return err
+	return traceCosmosOp(ctx, c, "DeleteItem", func(ctx context.Context) (float64, error) {
+		resp, err := c.container.DeleteItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), id, nil)
+		if err != nil {
+			return 0, err
+		}
+		return float64(resp.RequestCharge), nil
 	})
 }
 
@@ -260,17 +302,19 @@ func (c *CosmosContainer) DeleteItem(ctx context.Context, partitionKey, id strin
 // binds @name placeholders.
 func (c *CosmosContainer) QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error) {
 	var items [][]byte
-	err := traceCosmosOp(ctx, c, "QueryItems", func(ctx context.Context) error {
+	err := traceCosmosOp(ctx, c, "QueryItems", func(ctx context.Context) (float64, error) {
 		opts := &azcosmos.QueryOptions{QueryParameters: queryParams(params)}
 		pager := c.container.NewQueryItemsPager(query, azcosmos.NewPartitionKeyString(partitionKey), opts)
+		var ru float64
 		for pager.More() {
 			page, err := pager.NextPage(ctx)
 			if err != nil {
-				return err
+				return 0, err
 			}
+			ru += float64(page.RequestCharge)
 			items = append(items, page.Items...)
 		}
-		return nil
+		return ru, nil
 	})
 	if err != nil {
 		return nil, err
@@ -303,17 +347,19 @@ func (c *CosmosContainer) CountItems(ctx context.Context, partitionKey, query st
 // default cross-partition flag triggers the cross-partition path.
 func (c *CosmosContainer) QueryItemsCrossPartition(ctx context.Context, query string, params map[string]any) ([][]byte, error) {
 	var items [][]byte
-	err := traceCosmosOp(ctx, c, "QueryItemsCrossPartition", func(ctx context.Context) error {
+	err := traceCosmosOp(ctx, c, "QueryItemsCrossPartition", func(ctx context.Context) (float64, error) {
 		opts := &azcosmos.QueryOptions{QueryParameters: queryParams(params)}
 		pager := c.container.NewQueryItemsPager(query, azcosmos.NewPartitionKey(), opts)
+		var ru float64
 		for pager.More() {
 			page, err := pager.NextPage(ctx)
 			if err != nil {
-				return err
+				return 0, err
 			}
+			ru += float64(page.RequestCharge)
 			items = append(items, page.Items...)
 		}
-		return nil
+		return ru, nil
 	})
 	if err != nil {
 		return nil, err
@@ -333,7 +379,7 @@ func (c *CosmosContainer) QueryPageCrossPartition(ctx context.Context, query str
 		items [][]byte
 		next  string
 	)
-	err := traceCosmosOp(ctx, c, "QueryPageCrossPartition", func(ctx context.Context) error {
+	err := traceCosmosOp(ctx, c, "QueryPageCrossPartition", func(ctx context.Context) (float64, error) {
 		opts := &azcosmos.QueryOptions{QueryParameters: queryParams(params)}
 		if pageSize > 0 {
 			opts.PageSizeHint = clampPageSize(pageSize)
@@ -343,17 +389,17 @@ func (c *CosmosContainer) QueryPageCrossPartition(ctx context.Context, query str
 		}
 		pager := c.container.NewQueryItemsPager(query, azcosmos.NewPartitionKey(), opts)
 		if !pager.More() {
-			return nil
+			return 0, nil
 		}
 		page, err := pager.NextPage(ctx)
 		if err != nil {
-			return err
+			return 0, err
 		}
 		items = page.Items
 		if page.ContinuationToken != nil {
 			next = *page.ContinuationToken
 		}
-		return nil
+		return float64(page.RequestCharge), nil
 	})
 	if err != nil {
 		return nil, "", err

--- a/api-go/internal/platform/cosmos_cas.go
+++ b/api-go/internal/platform/cosmos_cas.go
@@ -29,15 +29,15 @@ var (
 // lease store's "no lease yet" path. The etag is the opaque CAS token for a
 // subsequent conditional replace/delete.
 func (c *CosmosContainer) ReadItemWithETag(ctx context.Context, partitionKey, id string) (body []byte, etag string, found bool, err error) {
-	err = traceCosmosOp(ctx, c, "ReadItem", func(ctx context.Context) error {
+	err = traceCosmosOp(ctx, c, "ReadItem", func(ctx context.Context) (float64, error) {
 		resp, rerr := c.container.ReadItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), id, nil)
 		if rerr != nil {
-			return rerr
+			return 0, rerr
 		}
 		body = resp.Value
 		etag = string(resp.ETag)
 		found = true
-		return nil
+		return float64(resp.RequestCharge), nil
 	})
 	if err != nil {
 		if isCASNotFound(err) {
@@ -54,13 +54,13 @@ func (c *CosmosContainer) ReadItemWithETag(ctx context.Context, partitionKey, id
 // race" rather than a failure.
 func (c *CosmosContainer) CreateItemReturningETag(ctx context.Context, partitionKey string, item []byte) (string, error) {
 	var etag string
-	err := traceCosmosOp(ctx, c, "CreateItem", func(ctx context.Context) error {
+	err := traceCosmosOp(ctx, c, "CreateItem", func(ctx context.Context) (float64, error) {
 		resp, cerr := c.container.CreateItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), item, nil)
 		if cerr != nil {
-			return cerr
+			return 0, cerr
 		}
 		etag = string(resp.ETag)
-		return nil
+		return float64(resp.RequestCharge), nil
 	})
 	if err != nil {
 		if isCASStatus(err, http.StatusConflict) {
@@ -76,14 +76,14 @@ func (c *CosmosContainer) CreateItemReturningETag(ctx context.Context, partition
 // ErrCASPreconditionFailed so the caller can treat it as "lost the replace race".
 func (c *CosmosContainer) ReplaceItemWithETag(ctx context.Context, partitionKey, id string, item []byte, etag string) (string, error) {
 	var newETag string
-	err := traceCosmosOp(ctx, c, "ReplaceItem", func(ctx context.Context) error {
+	err := traceCosmosOp(ctx, c, "ReplaceItem", func(ctx context.Context) (float64, error) {
 		e := azcore.ETag(etag)
 		resp, rerr := c.container.ReplaceItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), id, item, &azcosmos.ItemOptions{IfMatchEtag: &e})
 		if rerr != nil {
-			return rerr
+			return 0, rerr
 		}
 		newETag = string(resp.ETag)
-		return nil
+		return float64(resp.RequestCharge), nil
 	})
 	if err != nil {
 		if isCASStatus(err, http.StatusPreconditionFailed) {
@@ -99,10 +99,13 @@ func (c *CosmosContainer) ReplaceItemWithETag(ctx context.Context, partitionKey,
 // ErrCASPreconditionFailed, so the lease store can distinguish "already gone"
 // from "lost the race".
 func (c *CosmosContainer) DeleteItemWithETag(ctx context.Context, partitionKey, id, etag string) error {
-	err := traceCosmosOp(ctx, c, "DeleteItem", func(ctx context.Context) error {
+	err := traceCosmosOp(ctx, c, "DeleteItem", func(ctx context.Context) (float64, error) {
 		e := azcore.ETag(etag)
-		_, derr := c.container.DeleteItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), id, &azcosmos.ItemOptions{IfMatchEtag: &e})
-		return derr
+		resp, derr := c.container.DeleteItem(ctx, azcosmos.NewPartitionKeyString(partitionKey), id, &azcosmos.ItemOptions{IfMatchEtag: &e})
+		if derr != nil {
+			return 0, derr
+		}
+		return float64(resp.RequestCharge), nil
 	})
 	switch {
 	case err == nil:

--- a/api-go/internal/platform/cosmos_ru_test.go
+++ b/api-go/internal/platform/cosmos_ru_test.go
@@ -1,0 +1,72 @@
+package platform
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeRUMetrics records the request-charge calls a Cosmos op makes. It satisfies
+// the platform consumer-side cosmosMetricsRecorder interface.
+type fakeRUMetrics struct {
+	charges    []float64
+	operations []string
+	containers []string
+}
+
+func (f *fakeRUMetrics) CosmosRequestCharge(_ context.Context, ru float64, operation, container string) {
+	f.charges = append(f.charges, ru)
+	f.operations = append(f.operations, operation)
+	f.containers = append(f.containers, container)
+}
+
+func TestTraceCosmosOp_RecordsRequestCharge(t *testing.T) {
+	t.Parallel()
+	rec := &fakeRUMetrics{}
+	c := &CosmosContainer{name: "Users", accountHost: "acct.documents.azure.com", metrics: rec}
+
+	err := traceCosmosOp(context.Background(), c, "ReadItem", func(context.Context) (float64, error) {
+		return 2.75, nil
+	})
+	if err != nil {
+		t.Fatalf("traceCosmosOp: %v", err)
+	}
+
+	if len(rec.charges) != 1 || rec.charges[0] != 2.75 {
+		t.Errorf("CosmosRequestCharge charges = %v, want [2.75]", rec.charges)
+	}
+	if len(rec.operations) != 1 || rec.operations[0] != "ReadItem" {
+		t.Errorf("operations = %v, want [ReadItem]", rec.operations)
+	}
+	if len(rec.containers) != 1 || rec.containers[0] != "Users" {
+		t.Errorf("containers = %v, want [Users]", rec.containers)
+	}
+}
+
+func TestTraceCosmosOp_DoesNotRecordChargeOnError(t *testing.T) {
+	t.Parallel()
+	rec := &fakeRUMetrics{}
+	c := &CosmosContainer{name: "Users", accountHost: "acct.documents.azure.com", metrics: rec}
+	sentinel := errors.New("cosmos boom")
+
+	err := traceCosmosOp(context.Background(), c, "ReadItem", func(context.Context) (float64, error) {
+		return 0, sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel, got %v", err)
+	}
+	if len(rec.charges) != 0 {
+		t.Errorf("must not record a charge on error: %v", rec.charges)
+	}
+}
+
+func TestTraceCosmosOp_NilMetricsRecorderIsNoOp(t *testing.T) {
+	t.Parallel()
+	c := &CosmosContainer{name: "Users", accountHost: "acct.documents.azure.com"}
+	err := traceCosmosOp(context.Background(), c, "ReadItem", func(context.Context) (float64, error) {
+		return 1.0, nil
+	})
+	if err != nil {
+		t.Fatalf("traceCosmosOp without recorder: %v", err)
+	}
+}

--- a/api-go/internal/platform/cosmos_span_test.go
+++ b/api-go/internal/platform/cosmos_span_test.go
@@ -47,9 +47,9 @@ func TestTraceCosmosOp_RecordsClientSpan(t *testing.T) {
 	c := &CosmosContainer{name: "Users", accountHost: "acct.documents.azure.com"}
 
 	called := false
-	err := traceCosmosOp(context.Background(), c, "ReadItem", func(context.Context) error {
+	err := traceCosmosOp(context.Background(), c, "ReadItem", func(context.Context) (float64, error) {
 		called = true
-		return nil
+		return 0, nil
 	})
 	if err != nil {
 		t.Fatalf("traceCosmosOp returned error: %v", err)
@@ -103,8 +103,8 @@ func TestTraceCosmosOp_RecordsError(t *testing.T) {
 	c := &CosmosContainer{name: "NotificationState", accountHost: "acct.documents.azure.com"}
 	sentinel := errors.New("cosmos timeout")
 
-	err := traceCosmosOp(context.Background(), c, "QueryItems", func(context.Context) error {
-		return sentinel
+	err := traceCosmosOp(context.Background(), c, "QueryItems", func(context.Context) (float64, error) {
+		return 0, sentinel
 	})
 	if !errors.Is(err, sentinel) {
 		t.Fatalf("traceCosmosOp must propagate the operation error: got %v", err)
@@ -146,9 +146,9 @@ func TestTraceCosmosOp_LinksChildSpan(t *testing.T) {
 	parentCtx, parent := tracer.Start(context.Background(), "request")
 
 	var childTraceID oteltrace.TraceID
-	err := traceCosmosOp(parentCtx, c, "UpsertItem", func(ctx context.Context) error {
+	err := traceCosmosOp(parentCtx, c, "UpsertItem", func(ctx context.Context) (float64, error) {
 		childTraceID = oteltrace.SpanContextFromContext(ctx).TraceID()
-		return nil
+		return 0, nil
 	})
 	if err != nil {
 		t.Fatalf("traceCosmosOp: %v", err)

--- a/api-go/internal/platform/otelhttp_client.go
+++ b/api-go/internal/platform/otelhttp_client.go
@@ -1,0 +1,36 @@
+package platform
+
+import (
+	"net/http"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// SpanNameFormatter names the client span for an outbound request. otelhttp's
+// default formatter uses the HTTP method ("GET"), which makes AppDependencies
+// rows indistinguishable across upstreams. Each outbound client supplies a
+// stable, low-cardinality formatter (e.g. "PlanIt search", "Auth0 token") so the
+// dependency Name plus the server.address Target identify the call. Formatters
+// MUST NOT embed per-request identifiers (application IDs, device tokens) — that
+// would explode span-name cardinality.
+type SpanNameFormatter = func(operation string, r *http.Request) string
+
+// WrapHTTPClient returns a copy of base whose transport is wrapped with
+// otelhttp.NewTransport, so every request it makes emits an OTel client span
+// (Type=HTTP in AppDependencies) and http.client.request.duration metrics
+// through the global tracer/meter providers (installed by SetupTelemetry).
+//
+// The existing Timeout is preserved. When base has no explicit Transport,
+// otelhttp wraps http.DefaultTransport (its documented fallback). The supplied
+// formatter names the span; callers may pass extra otelhttp.Options (e.g.
+// WithTracerProvider in hermetic tests).
+//
+// When telemetry is disabled (no OTLP endpoint) the global no-op providers make
+// the wrapped transport produce no-op spans at negligible cost, so call sites
+// wrap unconditionally.
+func WrapHTTPClient(base *http.Client, formatter SpanNameFormatter, opts ...otelhttp.Option) *http.Client {
+	wrapped := *base
+	allOpts := append([]otelhttp.Option{otelhttp.WithSpanNameFormatter(formatter)}, opts...)
+	wrapped.Transport = otelhttp.NewTransport(base.Transport, allOpts...)
+	return &wrapped
+}

--- a/api-go/internal/platform/otelhttp_test.go
+++ b/api-go/internal/platform/otelhttp_test.go
@@ -125,7 +125,7 @@ func TestWrapHTTPClient_NilTransportUsesDefault(t *testing.T) {
 func splitHostPortTest(rawURL string) (host, port string, ok bool) {
 	const prefix = "http://"
 	hp := rawURL[len(prefix):]
-	for i := 0; i < len(hp); i++ {
+	for i := range len(hp) {
 		if hp[i] == ':' {
 			return hp[:i], hp[i+1:], true
 		}

--- a/api-go/internal/platform/otelhttp_test.go
+++ b/api-go/internal/platform/otelhttp_test.go
@@ -1,0 +1,134 @@
+package platform
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+)
+
+// newRecorderProvider returns an in-memory SDK TracerProvider so transport tests
+// are hermetic: the wrapped client emits spans into the recorder, never the
+// global provider.
+func newRecorderProvider(t *testing.T) (*sdktrace.TracerProvider, *tracetest.SpanRecorder) {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return tp, rec
+}
+
+func attrLookupKV(attrs []attribute.KeyValue, key string) (attribute.Value, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+// TestWrapHTTPClient_EmitsNamedClientSpan asserts the wrapped client's transport
+// produces a client span whose name comes from the supplied formatter and whose
+// server.address attribute carries the upstream host, so AppDependencies renders
+// it as an HTTP dependency with a meaningful Target + Name.
+func TestWrapHTTPClient_EmitsNamedClientSpan(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	tp, rec := newRecorderProvider(t)
+
+	base := &http.Client{Timeout: 7 * time.Second}
+	formatter := func(string, *http.Request) string { return "TestService op" }
+	wrapped := WrapHTTPClient(base, formatter, otelhttp.WithTracerProvider(tp))
+
+	if wrapped.Timeout != 7*time.Second {
+		t.Fatalf("WrapHTTPClient must preserve Timeout: got %s, want 7s", wrapped.Timeout)
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := wrapped.Do(req)
+	if err != nil {
+		t.Fatalf("wrapped.Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	spans := rec.Ended()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 client span, got %d", len(spans))
+	}
+	span := spans[0]
+
+	if span.Name() != "TestService op" {
+		t.Errorf("span name: got %q, want %q", span.Name(), "TestService op")
+	}
+	if span.SpanKind() != oteltrace.SpanKindClient {
+		t.Errorf("span kind: got %v, want client", span.SpanKind())
+	}
+
+	wantHost, _, _ := splitHostPortTest(srv.URL)
+	got, ok := attrLookupKV(span.Attributes(), "server.address")
+	if !ok {
+		t.Fatalf("missing server.address attribute (Target source); attrs=%v", span.Attributes())
+	}
+	if got.AsString() != wantHost {
+		t.Errorf("server.address: got %q, want %q", got.AsString(), wantHost)
+	}
+}
+
+// TestWrapHTTPClient_NilTransportUsesDefault asserts a client with no explicit
+// transport is wrapped against http.DefaultTransport (otelhttp's documented
+// fallback), so the call still succeeds and produces a span.
+func TestWrapHTTPClient_NilTransportUsesDefault(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	tp, rec := newRecorderProvider(t)
+
+	base := &http.Client{} // no Transport set
+	wrapped := WrapHTTPClient(base, func(string, *http.Request) string { return "Default op" }, otelhttp.WithTracerProvider(tp))
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, http.NoBody)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	resp, err := wrapped.Do(req)
+	if err != nil {
+		t.Fatalf("wrapped.Do: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if got := len(rec.Ended()); got != 1 {
+		t.Fatalf("expected 1 span via DefaultTransport, got %d", got)
+	}
+}
+
+// splitHostPortTest pulls the host out of an httptest URL (http://127.0.0.1:NNNN)
+// for the server.address assertion.
+func splitHostPortTest(rawURL string) (host, port string, ok bool) {
+	const prefix = "http://"
+	hp := rawURL[len(prefix):]
+	for i := 0; i < len(hp); i++ {
+		if hp[i] == ':' {
+			return hp[:i], hp[i+1:], true
+		}
+	}
+	return hp, "", false
+}

--- a/api-go/internal/platform/telemetry.go
+++ b/api-go/internal/platform/telemetry.go
@@ -11,6 +11,15 @@
 // release line) bridge slog records to OTel logs so they land in App Insights
 // AppTraces. Without them the Go API emitted zero AppTraces and AppExceptions,
 // leaving 500s undiagnosable.
+//
+// tc-21np adds the metrics pipeline: an otlpmetricgrpc exporter behind an SDK
+// MeterProvider (PeriodicReader), installed as the global meter provider, plus
+// Go runtime metrics via contrib/instrumentation/runtime. This restores the
+// towncrier.* business metrics (defined in internal/metrics) and runtime /
+// http.client metrics that went dark at the .NET->Go cutover. There is NO direct
+// Azure Monitor exporter — like traces and logs, metrics export OTLP/gRPC to the
+// ACA managed-environment OTel agent, which forwards them to App Insights
+// AppMetrics.
 package platform
 
 import (
@@ -18,12 +27,15 @@ import (
 	"log/slog"
 	"os"
 
+	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/log/global"
 	"go.opentelemetry.io/otel/propagation"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -35,21 +47,23 @@ const defaultServiceName = "town-crier-api-go"
 // noopShutdown is returned when telemetry is disabled — there is nothing to flush.
 func noopShutdown(context.Context) error { return nil }
 
-// SetupTelemetry configures the global OpenTelemetry tracer and logger providers.
+// SetupTelemetry configures the global OpenTelemetry tracer, logger and meter
+// providers.
 //
 // When OTEL_EXPORTER_OTLP_ENDPOINT is unset or empty (local dev, tests, the
 // contract suite, or a Cosmos-less boot) it self-disables: no exporters are
-// built, the global no-op TracerProvider and LoggerProvider are left in place,
-// and a no-op shutdown is returned. This keeps every existing test green with no
-// infra-then-test split.
+// built, the global no-op TracerProvider, LoggerProvider and MeterProvider are
+// left in place, and a no-op shutdown is returned. This keeps every existing
+// test green with no infra-then-test split.
 //
 // When the endpoint is set (injected by the ACA OTel agent) it builds OTLP/gRPC
-// trace AND log exporters — otlptracegrpc.New / otlploggrpc.New read the
-// endpoint and related standard OTEL_* env vars themselves and dial lazily, so
-// this never blocks even if the collector is unreachable — installs SDK
-// TracerProvider and LoggerProvider as the global providers (sharing one
-// resource), sets a W3C TraceContext propagator, and returns a combined Shutdown
-// that flushes both providers.
+// trace, log AND metric exporters — otlptracegrpc.New / otlploggrpc.New /
+// otlpmetricgrpc.New read the endpoint and related standard OTEL_* env vars
+// themselves and dial lazily, so this never blocks even if the collector is
+// unreachable — installs SDK TracerProvider, LoggerProvider and MeterProvider as
+// the global providers (sharing one resource), sets a W3C TraceContext
+// propagator, starts Go runtime metrics against the new MeterProvider, and
+// returns a combined Shutdown that flushes all three providers.
 func SetupTelemetry(ctx context.Context, logger *slog.Logger) (func(context.Context) error, error) {
 	endpoint := os.Getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
 	if endpoint == "" {
@@ -93,16 +107,49 @@ func SetupTelemetry(ctx context.Context, logger *slog.Logger) (func(context.Cont
 	)
 	global.SetLoggerProvider(lp)
 
+	metricExporter, err := otlpmetricgrpc.New(ctx)
+	if err != nil {
+		// Tear the already-built providers down so a half-built pipeline doesn't
+		// leak, mirroring the tracer-teardown-on-log-failure path above.
+		if shutdownErr := tp.Shutdown(ctx); shutdownErr != nil {
+			logger.ErrorContext(ctx, "tracer shutdown after metric-exporter failure", "error", shutdownErr)
+		}
+		if shutdownErr := lp.Shutdown(ctx); shutdownErr != nil {
+			logger.ErrorContext(ctx, "logger shutdown after metric-exporter failure", "error", shutdownErr)
+		}
+		return nil, err
+	}
+	mp := sdkmetric.NewMeterProvider(
+		sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExporter)),
+		sdkmetric.WithResource(res),
+	)
+	otel.SetMeterProvider(mp)
+
+	// Start Go runtime metrics (GC, goroutines, memory) against the new provider.
+	// http.client metrics come from the otelhttp transport (tc-166z) using this
+	// same global MeterProvider; the towncrier.* business metrics come from
+	// internal/metrics built on otel.Meter("towncrier"). A runtime.Start failure
+	// is non-fatal — runtime metrics are a nice-to-have, not worth aborting the
+	// whole telemetry pipeline (and the rest of the metrics still flow).
+	if rerr := runtime.Start(runtime.WithMeterProvider(mp)); rerr != nil {
+		logger.ErrorContext(ctx, "runtime metrics start failed; continuing without them", "error", rerr)
+	}
+
 	logger.InfoContext(ctx, "telemetry enabled", "endpoint", endpoint, "service", serviceName)
 
-	// Combined shutdown flushes/shuts down both providers, returning the first
-	// error so neither flush is skipped.
+	// Combined shutdown flushes/shuts down all three providers, returning the
+	// first error so no flush is skipped.
 	return func(shutdownCtx context.Context) error {
 		errTrace := tp.Shutdown(shutdownCtx)
 		errLog := lp.Shutdown(shutdownCtx)
-		if errTrace != nil {
+		errMetric := mp.Shutdown(shutdownCtx)
+		switch {
+		case errTrace != nil:
 			return errTrace
+		case errLog != nil:
+			return errLog
+		default:
+			return errMetric
 		}
-		return errLog
 	}, nil
 }

--- a/api-go/internal/platform/telemetry.go
+++ b/api-go/internal/platform/telemetry.go
@@ -26,9 +26,11 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strings"
 
 	"go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -43,6 +45,47 @@ import (
 
 // defaultServiceName labels traces when OTEL_SERVICE_NAME is unset.
 const defaultServiceName = "town-crier-api-go"
+
+// cosmosDatabasePrefix is the shared prefix on the Cosmos database names
+// (town-crier-prod / town-crier-dev); the suffix is the deployment environment.
+const cosmosDatabasePrefix = "town-crier-"
+
+// deploymentEnvironment derives the deployment.environment resource attribute
+// value from the COSMOS_DATABASE name. "town-crier-prod" -> "prod",
+// "town-crier-dev" -> "dev". An empty database (local dev, tests) or any name
+// without the expected "town-crier-" prefix returns "" so the caller omits the
+// attribute rather than emitting deployment.environment="".
+func deploymentEnvironment(cosmosDB string) string {
+	if cosmosDB == "" {
+		return ""
+	}
+	env, ok := strings.CutPrefix(cosmosDB, cosmosDatabasePrefix)
+	if !ok {
+		return ""
+	}
+	return env
+}
+
+// newTelemetryResource builds the OTel resource shared by the trace, log and
+// metric providers. service.name is set explicitly (Azure Monitor maps it to
+// AppRoleName); it deliberately keeps the current town-crier-{api,worker}-go
+// role names so existing Go-role dashboards keep matching. deployment.environment
+// is added from the COSMOS_DATABASE name so prod and dev signal separate as a
+// dimension instead of commingling under one role (tc-yqyh); it is omitted
+// entirely when the environment can't be derived (local dev, tests). WithFromEnv
+// is applied last so an infra-injected OTEL_RESOURCE_ATTRIBUTES (e.g.
+// deployment.environment=prod) can override these explicit values without a code
+// change.
+func newTelemetryResource(ctx context.Context, serviceName, cosmosDB string) (*resource.Resource, error) {
+	attrs := []attribute.KeyValue{semconv.ServiceName(serviceName)}
+	if env := deploymentEnvironment(cosmosDB); env != "" {
+		attrs = append(attrs, semconv.DeploymentEnvironment(env))
+	}
+	return resource.New(ctx,
+		resource.WithAttributes(attrs...),
+		resource.WithFromEnv(),
+	)
+}
 
 // noopShutdown is returned when telemetry is disabled — there is nothing to flush.
 func noopShutdown(context.Context) error { return nil }
@@ -75,9 +118,7 @@ func SetupTelemetry(ctx context.Context, logger *slog.Logger) (func(context.Cont
 	if serviceName == "" {
 		serviceName = defaultServiceName
 	}
-	res, err := resource.New(ctx,
-		resource.WithAttributes(semconv.ServiceName(serviceName)),
-	)
+	res, err := newTelemetryResource(ctx, serviceName, os.Getenv("COSMOS_DATABASE"))
 	if err != nil {
 		return nil, err
 	}

--- a/api-go/internal/platform/telemetry_test.go
+++ b/api-go/internal/platform/telemetry_test.go
@@ -10,21 +10,25 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/log/global"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
 
-// restoreOTelGlobals captures the process-global TracerProvider, propagator and
-// LoggerProvider and reinstates them when the test ends, so a test that installs
-// a real SDK provider doesn't bleed into the rest of the suite.
+// restoreOTelGlobals captures the process-global TracerProvider, propagator,
+// LoggerProvider and MeterProvider and reinstates them when the test ends, so a
+// test that installs a real SDK provider doesn't bleed into the rest of the
+// suite.
 func restoreOTelGlobals(t *testing.T) {
 	t.Helper()
 	tp := otel.GetTracerProvider()
 	prop := otel.GetTextMapPropagator()
 	lp := global.GetLoggerProvider()
+	mp := otel.GetMeterProvider()
 	t.Cleanup(func() {
 		otel.SetTracerProvider(tp)
 		otel.SetTextMapPropagator(prop)
 		global.SetLoggerProvider(lp)
+		otel.SetMeterProvider(mp)
 	})
 }
 
@@ -57,6 +61,11 @@ func TestSetupTelemetry_DisabledWhenEndpointUnset(t *testing.T) {
 	// slog records are dropped (only stdout JSON appears).
 	if _, ok := global.GetLoggerProvider().(*sdklog.LoggerProvider); ok {
 		t.Error("an SDK LoggerProvider was installed while telemetry is disabled")
+	}
+	// The global MeterProvider must stay the no-op default so towncrier.*
+	// instruments record nothing locally (tc-21np).
+	if _, ok := otel.GetMeterProvider().(*sdkmetric.MeterProvider); ok {
+		t.Error("an SDK MeterProvider was installed while telemetry is disabled")
 	}
 
 	if err := shutdown(context.Background()); err != nil {
@@ -108,6 +117,12 @@ func TestSetupTelemetry_EnabledWhenEndpointSet(t *testing.T) {
 	// bridge to OTel logs (-> AppTraces) — tc-8x8g.
 	if _, ok := global.GetLoggerProvider().(*sdklog.LoggerProvider); !ok {
 		t.Errorf("expected an SDK LoggerProvider installed as global, got %T", global.GetLoggerProvider())
+	}
+	// SetupTelemetry must also install an SDK MeterProvider so towncrier.*
+	// instruments (and Go runtime + http.client metrics) flow to AppMetrics —
+	// tc-21np.
+	if _, ok := otel.GetMeterProvider().(*sdkmetric.MeterProvider); !ok {
+		t.Errorf("expected an SDK MeterProvider installed as global, got %T", otel.GetMeterProvider())
 	}
 
 	// Shutdown must be callable without hanging even though no collector exists.

--- a/api-go/internal/platform/telemetry_test.go
+++ b/api-go/internal/platform/telemetry_test.go
@@ -8,11 +8,37 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/log/global"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 )
+
+func TestDeploymentEnvironment(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		cosmosDB string
+		want     string
+	}{
+		{"prod database", "town-crier-prod", "prod"},
+		{"dev database", "town-crier-dev", "dev"},
+		{"empty database", "", ""},
+		{"unprefixed name omits environment", "somethingelse", ""},
+		{"prefix only yields empty env", "town-crier-", ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := deploymentEnvironment(tc.cosmosDB); got != tc.want {
+				t.Errorf("deploymentEnvironment(%q) = %q, want %q", tc.cosmosDB, got, tc.want)
+			}
+		})
+	}
+}
 
 // restoreOTelGlobals captures the process-global TracerProvider, propagator,
 // LoggerProvider and MeterProvider and reinstates them when the test ends, so a
@@ -30,6 +56,56 @@ func restoreOTelGlobals(t *testing.T) {
 		global.SetLoggerProvider(lp)
 		otel.SetMeterProvider(mp)
 	})
+}
+
+// resourceHasAttr reports whether the resource carries an attribute with the
+// given key, and returns its string value.
+func resourceHasAttr(res *resource.Resource, key attribute.Key) (string, bool) {
+	for _, kv := range res.Attributes() {
+		if kv.Key == key {
+			return kv.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func TestNewTelemetryResource_TagsDeploymentEnvironment(t *testing.T) {
+	res, err := newTelemetryResource(context.Background(), "town-crier-api-go", "town-crier-prod")
+	if err != nil {
+		t.Fatalf("newTelemetryResource: %v", err)
+	}
+
+	const envKey = attribute.Key("deployment.environment")
+	got, ok := resourceHasAttr(res, envKey)
+	if !ok {
+		t.Fatalf("resource missing %q attribute; attributes: %v", envKey, res.Attributes())
+	}
+	if got != "prod" {
+		t.Errorf("deployment.environment = %q, want %q", got, "prod")
+	}
+
+	// service.name must remain explicitly set and unchanged.
+	svc, ok := resourceHasAttr(res, semconv.ServiceNameKey)
+	if !ok || svc != "town-crier-api-go" {
+		t.Errorf("service.name = %q (present=%v), want %q", svc, ok, "town-crier-api-go")
+	}
+}
+
+func TestNewTelemetryResource_OmitsEnvironmentWhenCosmosDBUnset(t *testing.T) {
+	res, err := newTelemetryResource(context.Background(), "town-crier-api-go", "")
+	if err != nil {
+		t.Fatalf("newTelemetryResource: %v", err)
+	}
+
+	const envKey = attribute.Key("deployment.environment")
+	if got, ok := resourceHasAttr(res, envKey); ok {
+		t.Errorf("expected no deployment.environment attribute when COSMOS_DATABASE unset, got %q", got)
+	}
+
+	// service.name must still be present.
+	if svc, ok := resourceHasAttr(res, semconv.ServiceNameKey); !ok || svc != "town-crier-api-go" {
+		t.Errorf("service.name = %q (present=%v), want %q", svc, ok, "town-crier-api-go")
+	}
 }
 
 func TestSetupTelemetry_DisabledWhenEndpointUnset(t *testing.T) {

--- a/api-go/internal/polling/handler.go
+++ b/api-go/internal/polling/handler.go
@@ -71,6 +71,26 @@ type NotificationEnqueuer interface {
 	EnqueueForApplication(ctx context.Context, app applications.PlanningApplication) error
 }
 
+// metricsRecorder is the consumer-side slice of the metrics registry the handler
+// records the per-cycle / per-authority polling KPIs on. *metrics.Registry
+// satisfies it; a nil recorder no-ops every call, so the handler records nothing
+// until WithMetrics wires one (matching the WithFanOut pattern). cycleType is the
+// CycleType.TelemetryValue() string ("Watched" | "Seed") every instrument tags.
+type metricsRecorder interface {
+	AuthorityPolled(ctx context.Context, cycleType string)
+	AuthoritySkipped(ctx context.Context, cycleType string)
+	ApplicationsIngested(ctx context.Context, n int, cycleType string)
+	RateLimited(ctx context.Context, cycleType string)
+	RetryAfterSeconds(ctx context.Context, seconds float64, cycleType string, authorityID int, headerPresent bool)
+	AuthorityProcessingMillis(ctx context.Context, ms float64, cycleType string)
+	AuthorityTotal(ctx context.Context, total int, cycleType string, authorityID int)
+	CycleCompleted(ctx context.Context, cycleType, termination string)
+	CursorAdvanced(ctx context.Context, cycleType string)
+	CursorCleared(ctx context.Context, cycleType string)
+	OldestHighWaterMarkAge(ctx context.Context, seconds float64, cycleType string, authorityID int, neverPolled bool)
+	NeverPolledCount(ctx context.Context, count int, cycleType string)
+}
+
 // HandlerOptions are the ingestion tunables. MaxPagesPerAuthorityPerCycle caps
 // pagination per authority (nil = unbounded). HandlerBudget is the soft
 // wall-clock deadline; zero disables it. Mirrors the relevant .NET PollingOptions
@@ -118,6 +138,30 @@ type PollPlanItHandler struct {
 	// watch-zone notification fan-out, matching .NET PollPlanItCommandHandler.
 	decision DecisionDispatcher
 	enqueuer NotificationEnqueuer
+
+	// metrics records the towncrier.polling.* business KPIs, wired via WithMetrics.
+	// nil until wired (the no-metrics default), so the handler records nothing
+	// during the many ingestion-only tests and call sites that don't supply one.
+	metrics metricsRecorder
+}
+
+// WithMetrics wires the metrics recorder the handler records the per-cycle and
+// per-authority polling KPIs on. Like WithFanOut it is a post-construction setter
+// so the ingestion-only call sites and tests are unaffected; cmd/worker calls it
+// once after building the handler. Returns the handler for chaining.
+func (h *PollPlanItHandler) WithMetrics(rec metricsRecorder) *PollPlanItHandler {
+	h.metrics = rec
+	return h
+}
+
+// recorder returns a non-nil recorder so call sites can record unconditionally.
+// When no recorder is wired it returns a no-op so the per-call nil checks live in
+// one place rather than at every record site.
+func (h *PollPlanItHandler) recorder() metricsRecorder {
+	if h.metrics == nil {
+		return noopMetrics{}
+	}
+	return h.metrics
 }
 
 // WithFanOut wires the notification fan-out collaborators the worker runs on the
@@ -176,6 +220,9 @@ func (h *PollPlanItHandler) Handle(ctx context.Context) (PollPlanItResult, error
 		return hasDeadline && !h.now().UTC().Before(deadline)
 	}
 
+	cycleType := h.cycle.Current().TelemetryValue()
+	rec := h.recorder()
+
 	activeIDs, err := h.authorities.ActiveAuthorityIDs(ctx)
 	if err != nil {
 		return PollPlanItResult{}, err
@@ -184,6 +231,12 @@ func (h *PollPlanItHandler) Handle(ctx context.Context) (PollPlanItResult, error
 	if err != nil {
 		return PollPlanItResult{}, err
 	}
+
+	// Cycle-start gauges: the never-polled backlog and the staleness of the
+	// oldest authority's LastPollTime. These mirror .NET's per-cycle gauge
+	// records so the lag dashboards keep working.
+	rec.NeverPolledCount(ctx, lru.NeverPolledCount, cycleType)
+	h.recordOldestHWMAge(ctx, rec, lru, now, cycleType)
 
 	var (
 		count           int
@@ -203,11 +256,16 @@ func (h *PollPlanItHandler) Handle(ctx context.Context) (PollPlanItResult, error
 			break
 		}
 
-		outcome := h.pollAuthority(ctx, authorityID, now, budgetExhausted)
+		authorityStart := h.now()
+		outcome := h.pollAuthority(ctx, authorityID, now, budgetExhausted, cycleType)
+		rec.AuthorityProcessingMillis(ctx, h.now().Sub(authorityStart).Seconds()*1000, cycleType)
 		count += outcome.appCount
+
 		if outcome.rateLimited {
 			rateLimited = true
 			retryAfter = outcome.retryAfter
+			rec.RateLimited(ctx, cycleType)
+			h.recordRetryAfter(ctx, rec, outcome.retryAfter, cycleType, authorityID)
 		}
 		if outcome.timeBounded {
 			timeBounded = true
@@ -215,9 +273,16 @@ func (h *PollPlanItHandler) Handle(ctx context.Context) (PollPlanItResult, error
 		switch {
 		case outcome.err != nil:
 			authorityErrors++
+			rec.AuthoritySkipped(ctx, cycleType)
 			h.logger.ErrorContext(ctx, "error polling authority, skipping to next", "authorityCode", authorityID, "error", outcome.err)
 		case outcome.completed || outcome.appCount > 0:
 			authoritiesPoll++
+			rec.AuthorityPolled(ctx, cycleType)
+			rec.ApplicationsIngested(ctx, outcome.appCount, cycleType)
+		default:
+			// Polled but produced no work and did not error: counts as skipped,
+			// matching .NET's authorities_skipped on a quiet authority.
+			rec.AuthoritySkipped(ctx, cycleType)
 		}
 
 		// A 429 stops the whole cycle so the scheduler can back off via Retry-After.
@@ -233,6 +298,8 @@ func (h *PollPlanItHandler) Handle(ctx context.Context) (PollPlanItResult, error
 	case timeBounded:
 		reason = TerminationTimeBounded
 	}
+
+	rec.CycleCompleted(ctx, cycleType, reason.TelemetryValue())
 
 	return PollPlanItResult{
 		ApplicationCount:  count,
@@ -258,7 +325,7 @@ type authorityOutcome struct {
 // changed applications, and persists the advanced poll state (HWM + cursor). A
 // 429 is an expected outcome (not an error); a transport/5xx failure after
 // retries is an authority error that the caller counts and skips past.
-func (h *PollPlanItHandler) pollAuthority(ctx context.Context, authorityID int, now time.Time, budgetExhausted func() bool) authorityOutcome {
+func (h *PollPlanItHandler) pollAuthority(ctx context.Context, authorityID int, now time.Time, budgetExhausted func() bool, cycleType string) authorityOutcome {
 	existing, _, err := h.state.Get(ctx, authorityID)
 	existingHWM := now.AddDate(0, 0, -1)
 	hadCursor := false
@@ -303,6 +370,9 @@ func (h *PollPlanItHandler) pollAuthority(ctx context.Context, authorityID int, 
 
 		if pagesFetched == 0 {
 			firstPageTotal = res.Total
+			if res.Total != nil {
+				h.recorder().AuthorityTotal(ctx, *res.Total, cycleType, authorityID)
+			}
 		}
 
 		for _, app := range res.Applications {
@@ -312,7 +382,7 @@ func (h *PollPlanItHandler) pollAuthority(ctx context.Context, authorityID int, 
 			}
 			if err := h.processApplication(ctx, app); err != nil {
 				out.err = err
-				return h.finishAuthority(ctx, authorityID, now, out, highWaterMark, existingHWM, lastPageFetched, firstPageTotal, capHit, hadCursor)
+				return h.finishAuthority(ctx, authorityID, now, out, highWaterMark, existingHWM, lastPageFetched, firstPageTotal, capHit, hadCursor, cycleType)
 			}
 		}
 
@@ -337,7 +407,7 @@ func (h *PollPlanItHandler) pollAuthority(ctx context.Context, authorityID int, 
 	if out.err == nil && !out.rateLimited {
 		out.completed = true
 	}
-	return h.finishAuthority(ctx, authorityID, now, out, highWaterMark, existingHWM, lastPageFetched, firstPageTotal, capHit, hadCursor)
+	return h.finishAuthority(ctx, authorityID, now, out, highWaterMark, existingHWM, lastPageFetched, firstPageTotal, capHit, hadCursor, cycleType)
 }
 
 // processApplication point-reads the persisted application by uid within its
@@ -420,10 +490,13 @@ func (h *PollPlanItHandler) finishAuthority(
 	lastPageFetched int,
 	firstPageTotal *int,
 	capHit, hadCursor bool,
+	cycleType string,
 ) authorityOutcome {
 	if !out.completed && out.appCount == 0 {
 		return out
 	}
+
+	rec := h.recorder()
 
 	if capHit || (out.rateLimited && out.appCount > 0) {
 		// Freeze HWM, save a resumable cursor at the next unfetched page so the
@@ -438,6 +511,8 @@ func (h *PollPlanItHandler) finishAuthority(
 		if err := h.state.Save(ctx, authorityID, now, existingHWM, cursor); err != nil && out.err == nil {
 			out.err = err
 		}
+		// A persisted non-null cursor advances the resume point.
+		rec.CursorAdvanced(ctx, cycleType)
 		return out
 	}
 
@@ -450,8 +525,46 @@ func (h *PollPlanItHandler) finishAuthority(
 	if err := h.state.Save(ctx, authorityID, now, advancedHWM, nil); err != nil && out.err == nil {
 		out.err = err
 	}
-	_ = hadCursor // telemetry-only in .NET (cursor_cleared counter); omitted here
+	// Clearing a previously-active cursor at a natural end, matching .NET's
+	// cursor_cleared counter (recorded only when a cursor was actually present).
+	if hadCursor {
+		rec.CursorCleared(ctx, cycleType)
+	}
 	return out
+}
+
+// recordOldestHWMAge records the staleness of the oldest candidate authority's
+// LastPollTime at the start of a cycle. The LRU result orders never-polled-first
+// then ascending LastPollTime, so AuthorityIDs[0] is the stalest authority. A
+// never-polled authority (no PollState) reports its age from the Unix epoch and
+// is tagged never_polled=true so dashboards distinguish it from a genuinely stale
+// HWM, matching .NET. An empty candidate set records nothing.
+func (h *PollPlanItHandler) recordOldestHWMAge(ctx context.Context, rec metricsRecorder, lru LeastRecentlyPolledResult, now time.Time, cycleType string) {
+	if len(lru.AuthorityIDs) == 0 {
+		return
+	}
+	oldestID := lru.AuthorityIDs[0]
+	state, found, err := h.state.Get(ctx, oldestID)
+	neverPolled := err != nil || !found || state.LastPollTime.IsZero()
+
+	var ageSeconds float64
+	if neverPolled {
+		ageSeconds = now.Sub(time.Unix(0, 0).UTC()).Seconds()
+	} else {
+		ageSeconds = now.Sub(state.LastPollTime).Seconds()
+	}
+	rec.OldestHighWaterMarkAge(ctx, ageSeconds, cycleType, oldestID, neverPolled)
+}
+
+// recordRetryAfter records the parsed Retry-After value (seconds) for a 429,
+// tagging header_present so dashboards distinguish a PlanIt 429 with no
+// Retry-After header (value 0, header_present=false) from a real small backoff.
+func (h *PollPlanItHandler) recordRetryAfter(ctx context.Context, rec metricsRecorder, retryAfter *time.Duration, cycleType string, authorityID int) {
+	if retryAfter == nil {
+		rec.RetryAfterSeconds(ctx, 0, cycleType, authorityID, false)
+		return
+	}
+	rec.RetryAfterSeconds(ctx, retryAfter.Seconds(), cycleType, authorityID, true)
 }
 
 // sameDate reports whether two instants fall on the same UTC calendar day.
@@ -467,3 +580,20 @@ func truncateToDate(t time.Time) time.Time {
 	y, m, d := t.UTC().Date()
 	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
 }
+
+// noopMetrics is the recorder used when no metrics registry is wired: every
+// method is a no-op so the handler records nothing without per-site nil checks.
+type noopMetrics struct{}
+
+func (noopMetrics) AuthorityPolled(context.Context, string)                            {}
+func (noopMetrics) AuthoritySkipped(context.Context, string)                           {}
+func (noopMetrics) ApplicationsIngested(context.Context, int, string)                  {}
+func (noopMetrics) RateLimited(context.Context, string)                                {}
+func (noopMetrics) RetryAfterSeconds(context.Context, float64, string, int, bool)      {}
+func (noopMetrics) AuthorityProcessingMillis(context.Context, float64, string)         {}
+func (noopMetrics) AuthorityTotal(context.Context, int, string, int)                   {}
+func (noopMetrics) CycleCompleted(context.Context, string, string)                     {}
+func (noopMetrics) CursorAdvanced(context.Context, string)                             {}
+func (noopMetrics) CursorCleared(context.Context, string)                              {}
+func (noopMetrics) OldestHighWaterMarkAge(context.Context, float64, string, int, bool) {}
+func (noopMetrics) NeverPolledCount(context.Context, int, string)                      {}

--- a/api-go/internal/polling/metrics_test.go
+++ b/api-go/internal/polling/metrics_test.go
@@ -1,0 +1,213 @@
+package polling
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/planit"
+)
+
+// fakePollMetrics records every metrics call the handler makes so a test can
+// assert on the recorded business metrics without a real OTel pipeline. It
+// satisfies the polling package's consumer-side metricsRecorder interface.
+type fakePollMetrics struct {
+	authoritiesPolled  int
+	authoritiesSkipped int
+	applicationsIngest int
+	rateLimited        int
+	retryAfter         []float64
+	authorityProcMs    int
+	authorityTotals    []int
+	cyclesCompleted    []string // termination per completed cycle
+	cursorAdvanced     int
+	cursorCleared      int
+	oldestHwmCalls     int
+	neverPolledCalls   int
+}
+
+func (f *fakePollMetrics) AuthorityPolled(context.Context, string)  { f.authoritiesPolled++ }
+func (f *fakePollMetrics) AuthoritySkipped(context.Context, string) { f.authoritiesSkipped++ }
+func (f *fakePollMetrics) ApplicationsIngested(_ context.Context, n int, _ string) {
+	f.applicationsIngest += n
+}
+func (f *fakePollMetrics) RateLimited(context.Context, string) { f.rateLimited++ }
+func (f *fakePollMetrics) RetryAfterSeconds(_ context.Context, s float64, _ string, _ int, _ bool) {
+	f.retryAfter = append(f.retryAfter, s)
+}
+func (f *fakePollMetrics) AuthorityProcessingMillis(context.Context, float64, string) {
+	f.authorityProcMs++
+}
+func (f *fakePollMetrics) AuthorityTotal(_ context.Context, total int, _ string, _ int) {
+	f.authorityTotals = append(f.authorityTotals, total)
+}
+func (f *fakePollMetrics) CycleCompleted(_ context.Context, _ string, termination string) {
+	f.cyclesCompleted = append(f.cyclesCompleted, termination)
+}
+func (f *fakePollMetrics) CursorAdvanced(context.Context, string) { f.cursorAdvanced++ }
+func (f *fakePollMetrics) CursorCleared(context.Context, string)  { f.cursorCleared++ }
+func (f *fakePollMetrics) OldestHighWaterMarkAge(context.Context, float64, string, int, bool) {
+	f.oldestHwmCalls++
+}
+func (f *fakePollMetrics) NeverPolledCount(context.Context, int, string) { f.neverPolledCalls++ }
+
+func TestHandler_RecordsNaturalCycleMetrics(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	total := 2
+	pi.pages[pageKey{99, 1}] = planit.FetchPageResult{
+		Page:         1,
+		Total:        &total,
+		Applications: []applications.PlanningApplication{testApp("App", 99, time.Date(2026, 6, 14, 9, 0, 0, 0, time.UTC))},
+		HasMorePages: false,
+	}
+
+	rec := &fakePollMetrics{}
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+	h.WithMetrics(rec)
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if res.ApplicationCount != 1 {
+		t.Fatalf("ApplicationCount = %d, want 1", res.ApplicationCount)
+	}
+
+	if rec.authoritiesPolled != 1 {
+		t.Errorf("AuthorityPolled = %d, want 1", rec.authoritiesPolled)
+	}
+	if rec.applicationsIngest != 1 {
+		t.Errorf("ApplicationsIngested = %d, want 1", rec.applicationsIngest)
+	}
+	if rec.authorityProcMs != 1 {
+		t.Errorf("AuthorityProcessingMillis calls = %d, want 1", rec.authorityProcMs)
+	}
+	if len(rec.authorityTotals) != 1 || rec.authorityTotals[0] != 2 {
+		t.Errorf("AuthorityTotal = %v, want [2]", rec.authorityTotals)
+	}
+	if len(rec.cyclesCompleted) != 1 || rec.cyclesCompleted[0] != "Natural" {
+		t.Errorf("CycleCompleted = %v, want [Natural]", rec.cyclesCompleted)
+	}
+	if rec.oldestHwmCalls != 1 {
+		t.Errorf("OldestHighWaterMarkAge calls = %d, want 1", rec.oldestHwmCalls)
+	}
+	if rec.neverPolledCalls != 1 {
+		t.Errorf("NeverPolledCount calls = %d, want 1", rec.neverPolledCalls)
+	}
+}
+
+func TestHandler_RecordsRateLimitMetrics(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	retryAfter := 30 * time.Second
+	pi.errs[99] = &planit.RateLimitError{RetryAfter: &retryAfter}
+
+	rec := &fakePollMetrics{}
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleWatched, defaultHandlerOpts())
+	h.WithMetrics(rec)
+
+	res, err := h.Handle(context.Background())
+	if err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if !res.RateLimited {
+		t.Fatal("expected RateLimited result")
+	}
+	if rec.rateLimited != 1 {
+		t.Errorf("RateLimited = %d, want 1", rec.rateLimited)
+	}
+	if len(rec.retryAfter) != 1 || rec.retryAfter[0] != 30 {
+		t.Errorf("RetryAfterSeconds = %v, want [30]", rec.retryAfter)
+	}
+	if len(rec.cyclesCompleted) != 1 || rec.cyclesCompleted[0] != "RateLimited" {
+		t.Errorf("CycleCompleted = %v, want [RateLimited]", rec.cyclesCompleted)
+	}
+}
+
+func TestHandler_RecordsCursorAdvancedOnCapHit(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	// Two pages with more remaining, but a cap of 1 forces a cursor save.
+	pi.pages[pageKey{99, 1}] = planit.FetchPageResult{
+		Page:         1,
+		Applications: []applications.PlanningApplication{testApp("A", 99, time.Date(2026, 6, 14, 9, 0, 0, 0, time.UTC))},
+		HasMorePages: true,
+	}
+	one := 1
+	opts := HandlerOptions{MaxPagesPerAuthorityPerCycle: &one, HandlerBudget: 4 * time.Minute}
+
+	rec := &fakePollMetrics{}
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, opts)
+	h.WithMetrics(rec)
+
+	if _, err := h.Handle(context.Background()); err != nil {
+		t.Fatalf("Handle: %v", err)
+	}
+	if rec.cursorAdvanced != 1 {
+		t.Errorf("CursorAdvanced = %d, want 1", rec.cursorAdvanced)
+	}
+}
+
+// fakeLeaseMetrics records lease-acquired calls; it satisfies the orchestrator's
+// consumer-side leaseMetricsRecorder interface.
+type fakeLeaseMetrics struct {
+	acquiredCallers []string
+}
+
+func (f *fakeLeaseMetrics) LeaseAcquired(_ context.Context, caller string) {
+	f.acquiredCallers = append(f.acquiredCallers, caller)
+}
+
+func TestOrchestrator_RecordsLeaseAcquired(t *testing.T) {
+	t.Parallel()
+	_, lease, recv, pub, handler := newWiredFakes()
+	o := newOrchestrator(t, lease, recv, pub, handler)
+	rec := &fakeLeaseMetrics{}
+	o.WithLeaseMetrics(rec)
+
+	if _, err := o.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	if len(rec.acquiredCallers) != 1 || rec.acquiredCallers[0] != "orchestrator" {
+		t.Errorf("LeaseAcquired callers = %v, want [orchestrator]", rec.acquiredCallers)
+	}
+}
+
+func TestOrchestrator_DoesNotRecordLeaseAcquiredWhenHeld(t *testing.T) {
+	t.Parallel()
+	_, lease, recv, pub, handler := newWiredFakes()
+	lease.held = true
+	o := newOrchestrator(t, lease, recv, pub, handler)
+	rec := &fakeLeaseMetrics{}
+	o.WithLeaseMetrics(rec)
+
+	if _, err := o.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+	if len(rec.acquiredCallers) != 0 {
+		t.Errorf("LeaseAcquired must not fire when the lease is held: %v", rec.acquiredCallers)
+	}
+}
+
+func TestHandler_NilMetricsRecorderIsNoOp(t *testing.T) {
+	t.Parallel()
+	pi := newFakePlanIt()
+	apps := newFakeApps()
+	state := newFakeStateStore()
+	pi.pages[pageKey{99, 1}] = planitPage(testApp("App", 99, time.Date(2026, 6, 14, 9, 0, 0, 0, time.UTC)))
+
+	// No WithMetrics call: the handler must record nothing and not panic.
+	h := newHandler(t, pi, apps, state, fakeAuthorities{ids: []int{99}}, CycleSeed, defaultHandlerOpts())
+	if _, err := h.Handle(context.Background()); err != nil {
+		t.Fatalf("Handle without metrics recorder: %v", err)
+	}
+}

--- a/api-go/internal/polling/orchestrator.go
+++ b/api-go/internal/polling/orchestrator.go
@@ -38,6 +38,15 @@ type nextRunScheduler interface {
 	ComputeNextRun(reason TerminationReason, retryAfter *time.Duration, now time.Time) time.Time
 }
 
+// leaseMetricsRecorder is the consumer-side slice of the metrics registry the
+// orchestrator records the lease-acquired counter on. *metrics.Registry
+// satisfies it; nil no-ops, so the counter stays dark until WithLeaseMetrics
+// wires a recorder. caller is always "orchestrator" here (the bootstrap records
+// its own acquisitions with caller "bootstrap").
+type leaseMetricsRecorder interface {
+	LeaseAcquired(ctx context.Context, caller string)
+}
+
 // OrchestratorOptions tune the orchestrator's lease behaviour. LeaseTTL is the
 // TTL requested on acquire — it MUST exceed the handler's worst-case runtime so
 // the lease cannot expire mid-handler and let a peer start a duplicate cycle
@@ -78,6 +87,21 @@ type Orchestrator struct {
 	now       func() time.Time
 	sleep     func(ctx context.Context, d time.Duration) error
 	logger    *slog.Logger
+
+	// metrics records towncrier.polling.lease.acquired, wired via WithLeaseMetrics.
+	// nil until wired, so the counter stays dark in the lease-CAS tests that build
+	// an orchestrator without a registry.
+	metrics leaseMetricsRecorder
+}
+
+// WithLeaseMetrics wires the recorder the orchestrator records the
+// lease-acquired counter on. Like the handler's WithMetrics it is a
+// post-construction setter so the lease-CAS tests are unaffected; cmd/worker
+// calls it once after building the orchestrator. Returns the orchestrator for
+// chaining.
+func (o *Orchestrator) WithLeaseMetrics(rec leaseMetricsRecorder) *Orchestrator {
+	o.metrics = rec
+	return o
 }
 
 // NewOrchestrator wires the orchestrator. now and the internal sleep are injected
@@ -128,6 +152,10 @@ func (o *Orchestrator) RunOnce(ctx context.Context) (OrchestratorRunResult, erro
 		o.logger.WarnContext(ctx, "polling lease unavailable; exiting without polling",
 			"held", acquire.Held, "transient", acquire.TransientErr != nil)
 		return OrchestratorRunResult{LeaseUnavailable: true}, nil
+	}
+
+	if o.metrics != nil {
+		o.metrics.LeaseAcquired(ctx, "orchestrator")
 	}
 
 	// Release is deferred so the lease is always relinquished, but the next

--- a/api-go/internal/profiles/auth0_span_test.go
+++ b/api-go/internal/profiles/auth0_span_test.go
@@ -1,0 +1,74 @@
+package profiles
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// recorderProvider returns an in-memory SDK TracerProvider for hermetic span
+// assertions; the wrapped transport emits into the recorder, not the global.
+func recorderProvider(t *testing.T) (*sdktrace.TracerProvider, *tracetest.SpanRecorder) {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return tp, rec
+}
+
+func spanAttr(attrs []attribute.KeyValue, key string) (attribute.Value, bool) {
+	for _, a := range attrs {
+		if string(a.Key) == key {
+			return a.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+// TestAuth0Client_EmitsClientSpan asserts an Auth0 Management call produces
+// client spans named "Auth0 token" carrying the upstream host as server.address,
+// so token/PATCH/DELETE traffic surfaces in AppDependencies as a meaningful HTTP
+// dependency. It exercises the same platform.WrapHTTPClient wiring the api/worker
+// main() call sites apply in production. The static span name keeps cardinality
+// low (no per-user subject in the name).
+func TestAuth0Client_EmitsClientSpan(t *testing.T) {
+	t.Parallel()
+
+	_, srv := newAuth0Server(t)
+	tp, rec := recorderProvider(t)
+
+	traced := platform.WrapHTTPClient(
+		srv.Client(),
+		func(string, *http.Request) string { return "Auth0 token" },
+		otelhttp.WithTracerProvider(tp),
+	)
+	client := NewAuth0Client(traced, srv.URL, "client-id", platform.NewSecret("client-secret"))
+
+	if err := client.UpdateSubscriptionTier(context.Background(), "auth0|user-1", "premium"); err != nil {
+		t.Fatalf("UpdateSubscriptionTier: %v", err)
+	}
+
+	spans := rec.Ended()
+	if len(spans) == 0 {
+		t.Fatalf("expected at least 1 client span, got 0")
+	}
+	for _, span := range spans {
+		if span.Name() != "Auth0 token" {
+			t.Errorf("span name: got %q, want %q", span.Name(), "Auth0 token")
+		}
+		if span.SpanKind() != oteltrace.SpanKindClient {
+			t.Errorf("span kind: got %v, want client", span.SpanKind())
+		}
+		if _, ok := spanAttr(span.Attributes(), "server.address"); !ok {
+			t.Errorf("missing server.address attribute (Target source); attrs=%v", span.Attributes())
+		}
+	}
+}

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -29,6 +29,27 @@ type zoneStore interface {
 	Delete(ctx context.Context, userID, zoneID string) error
 }
 
+// MetricsRecorder is the consumer-side slice of the metrics registry the
+// watch-zone handlers record the lifecycle counters on. *metrics.Registry
+// satisfies it. It is exported because Routes / NearbyRoutes accept it as an
+// Option from cmd/api's wiring. A nil recorder no-ops every counter.
+type MetricsRecorder interface {
+	WatchZoneCreated(ctx context.Context)
+	WatchZoneUpdated(ctx context.Context)
+	WatchZoneDeleted(ctx context.Context)
+}
+
+// Option configures the watch-zone routes. WithMetricsRecorder is the only
+// option today; it is variadic so the many existing Routes/NearbyRoutes call
+// sites and tests compile unchanged.
+type Option func(*handler)
+
+// WithMetricsRecorder wires the metrics recorder the handlers record the
+// watch-zone lifecycle counters on.
+func WithMetricsRecorder(rec MetricsRecorder) Option {
+	return func(h *handler) { h.metrics = rec }
+}
+
 // handler serves the /v1/me/watch-zones surface. The auth middleware guarantees
 // a subject in context before these handlers run. The list/update/delete methods
 // use only store + logger; the create and applications methods (nearby.go) use
@@ -43,14 +64,18 @@ type handler struct {
 	newID    func() string
 	now      func() time.Time
 	logger   *slog.Logger
+	metrics  MetricsRecorder
 }
 
 // Routes registers the watch-zone list/update/delete endpoints on mux. POST
 // create and GET /{zoneId}/applications are registered separately by NearbyRoutes
 // (they need the profile, application, geocode, notification-state and
 // notification stores).
-func Routes(mux *http.ServeMux, store zoneStore, logger *slog.Logger) {
+func Routes(mux *http.ServeMux, store zoneStore, logger *slog.Logger, opts ...Option) {
 	h := &handler{store: store, logger: logger}
+	for _, opt := range opts {
+		opt(h)
+	}
 	mux.HandleFunc("GET /v1/me/watch-zones", h.list)
 	mux.HandleFunc("PATCH /v1/me/watch-zones/{zoneId}", h.patch)
 	mux.HandleFunc("DELETE /v1/me/watch-zones/{zoneId}", h.delete)
@@ -184,6 +209,9 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 		h.serverError(w, r, "save watch zone", err)
 		return
 	}
+	if h.metrics != nil {
+		h.metrics.WatchZoneUpdated(r.Context())
+	}
 	h.writeJSON(w, r, http.StatusOK, updateResult{Zone: summaryOf(updated)})
 }
 
@@ -200,6 +228,9 @@ func (h *handler) delete(w http.ResponseWriter, r *http.Request) {
 		}
 		h.serverError(w, r, "delete watch zone", err)
 		return
+	}
+	if h.metrics != nil {
+		h.metrics.WatchZoneDeleted(r.Context())
 	}
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/api-go/internal/watchzones/metrics_test.go
+++ b/api-go/internal/watchzones/metrics_test.go
@@ -1,0 +1,92 @@
+package watchzones
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"testing"
+)
+
+// fakeZoneMetrics records the watch-zone lifecycle calls the handlers make. It
+// satisfies the watchzones consumer-side MetricsRecorder.
+type fakeZoneMetrics struct {
+	created int
+	updated int
+	deleted int
+}
+
+func (f *fakeZoneMetrics) WatchZoneCreated(context.Context) { f.created++ }
+func (f *fakeZoneMetrics) WatchZoneUpdated(context.Context) { f.updated++ }
+func (f *fakeZoneMetrics) WatchZoneDeleted(context.Context) { f.deleted++ }
+
+func testMuxWithMetrics(t *testing.T, store zoneStore, rec MetricsRecorder) *http.ServeMux {
+	t.Helper()
+	mux := http.NewServeMux()
+	Routes(mux, store, slog.New(slog.DiscardHandler), WithMetricsRecorder(rec))
+	return mux
+}
+
+func TestHandler_Patch_RecordsWatchZoneUpdated(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	rec := &fakeZoneMetrics{}
+	mux := testMuxWithMetrics(t, store, rec)
+
+	resp := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/"+z.ID, `{"name":"Office"}`)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("status: got %d (body %s)", resp.Code, resp.Body)
+	}
+	if rec.updated != 1 {
+		t.Errorf("WatchZoneUpdated = %d, want 1", rec.updated)
+	}
+	if rec.created != 0 || rec.deleted != 0 {
+		t.Errorf("unexpected create/delete counters: created=%d deleted=%d", rec.created, rec.deleted)
+	}
+}
+
+func TestHandler_Patch_DoesNotRecordOnNotFound(t *testing.T) {
+	t.Parallel()
+	store := &fakeZoneStore{}
+	rec := &fakeZoneMetrics{}
+	mux := testMuxWithMetrics(t, store, rec)
+
+	resp := doReq(t, mux, http.MethodPatch, "/v1/me/watch-zones/missing", `{"name":"Office"}`)
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", resp.Code)
+	}
+	if rec.updated != 0 {
+		t.Errorf("WatchZoneUpdated must not fire on 404, got %d", rec.updated)
+	}
+}
+
+func TestHandler_Delete_RecordsWatchZoneDeleted(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+	store := &fakeZoneStore{zones: []WatchZone{z}}
+	rec := &fakeZoneMetrics{}
+	mux := testMuxWithMetrics(t, store, rec)
+
+	resp := doReq(t, mux, http.MethodDelete, "/v1/me/watch-zones/"+z.ID, "")
+	if resp.Code != http.StatusNoContent {
+		t.Fatalf("status: got %d, want 204", resp.Code)
+	}
+	if rec.deleted != 1 {
+		t.Errorf("WatchZoneDeleted = %d, want 1", rec.deleted)
+	}
+}
+
+func TestHandler_Delete_DoesNotRecordOnNotFound(t *testing.T) {
+	t.Parallel()
+	store := &fakeZoneStore{}
+	rec := &fakeZoneMetrics{}
+	mux := testMuxWithMetrics(t, store, rec)
+
+	resp := doReq(t, mux, http.MethodDelete, "/v1/me/watch-zones/missing", "")
+	if resp.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", resp.Code)
+	}
+	if rec.deleted != 0 {
+		t.Errorf("WatchZoneDeleted must not fire on 404, got %d", rec.deleted)
+	}
+}

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -72,6 +72,7 @@ func NearbyRoutes(
 	newID func() string,
 	now func() time.Time,
 	logger *slog.Logger,
+	opts ...Option,
 ) {
 	h := &handler{
 		store:    store,
@@ -83,6 +84,9 @@ func NearbyRoutes(
 		newID:    newID,
 		now:      now,
 		logger:   logger,
+	}
+	for _, opt := range opts {
+		opt(h)
 	}
 	mux.HandleFunc("POST /v1/me/watch-zones", h.create)
 	mux.HandleFunc("GET /v1/me/watch-zones/{zoneId}/applications", h.applications)
@@ -191,6 +195,9 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 	if err := h.store.Save(r.Context(), zone); err != nil {
 		h.serverError(w, r, "save watch zone", err)
 		return
+	}
+	if h.metrics != nil {
+		h.metrics.WatchZoneCreated(r.Context())
 	}
 
 	nearby, err := h.apps.FindNearby(


### PR DESCRIPTION
## Changes

Restores the Go backend OpenTelemetry pipeline that went dark at the .NET→Go cutover (2026-06-15). Closes the four observability beads from SRE runs tc-meml / tc-1542.

- **tc-21np** — Wire OTel `MeterProvider` + `otlpmetricgrpc` exporter (mirroring the existing trace/log OTLP→ACA-agent path) and register the `towncrier.*` instruments (polling KPIs, cosmos RU, planit http_errors, notifications, watchzones), recorded in the poll/digest/api handlers. Also starts Go runtime metrics; http.client metrics now flow via the global provider. Restores AppMetrics on both Go roles.
- **tc-166z** — Wrap the shared outbound `*http.Client` transports (PlanIt, Auth0, APNs, ACS) with `otelhttp.NewTransport` via a `platform.WrapHTTPClient` helper, with low-cardinality per-service span names ("PlanIt search", "Auth0 token", "APNs push", "ACS email send") so AppDependencies.Target is meaningful.
- **tc-r8eo** — New `RouteSpan` middleware records the matched route pattern as the inbound span Name (`GET /v1/me`) and the real `http.response.status_code` on the request span, so AppRequests.Name/ResultCode are populated again and 4xx/5xx alerts can fire.
- **tc-yqyh** — Tag the OTel resource with `deployment.environment` (derived from `COSMOS_DATABASE`) + `resource.WithFromEnv()` so prod/dev signal stops commingling under one AppRoleName. service.name left unchanged.
- **tc-9a10** — Trivial `intrange` lint fix in the new otelhttp test (keeps pr-gate golangci-lint green).

## Verification (local, from api-go/)
- `go build ./...` ✅
- `go test ./...` ✅ 875 passed in 34 packages (also clean under `-race`)
- `go vet ./...` ✅ no issues
- `gofmt -l .` ✅ clean
- `golangci-lint` (skill config) ✅ no issues

Telemetry proves out only after CD Production deploys; verified here on green gate + merge.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced system observability through OpenTelemetry metrics collection, including request tracing, route identification, and HTTP status tracking
  * Improved performance monitoring with runtime metrics and detailed request diagnostics
  * Better visibility into polling cycles, notification delivery, and infrastructure utilization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->