### PR TITLE
fix(telemetry): map AppRequests ResultCode via legacy http.status_code attr (tc-oml9)

### DIFF
--- a/api-go/internal/middleware/routespan.go
+++ b/api-go/internal/middleware/routespan.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
@@ -73,7 +74,16 @@ func RouteSpan(matcher routeMatcher) func(http.Handler) http.Handler {
 			sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
 			next.ServeHTTP(sw, r)
 
-			span.SetAttributes(semconv.HTTPResponseStatusCode(sw.status))
+			// Set both the stable semconv key and the legacy http.status_code (pre-1.21
+		// semconv). Azure Monitor maps AppRequests.ResultCode from the LEGACY
+		// http.status_code, NOT the stable http.response.status_code, so without the
+		// legacy attribute ResultCode shows only the bare span StatusCode (0/2) and
+		// 4xx/5xx alerts keyed on ResultCode never fire (tc-oml9). Do not "clean up"
+		// this apparent duplication — both keys are load-bearing.
+		span.SetAttributes(
+			semconv.HTTPResponseStatusCode(sw.status),
+			attribute.Int("http.status_code", sw.status),
+		)
 			// Mirror semconv server semantics: a 5xx is a request error. ErrorBody
 			// also flags 5xx, but it does not run for the unmatched-route 404/anonymous
 			// paths that bypass it, so set it here too. SetStatus is idempotent and the

--- a/api-go/internal/middleware/routespan.go
+++ b/api-go/internal/middleware/routespan.go
@@ -75,15 +75,15 @@ func RouteSpan(matcher routeMatcher) func(http.Handler) http.Handler {
 			next.ServeHTTP(sw, r)
 
 			// Set both the stable semconv key and the legacy http.status_code (pre-1.21
-		// semconv). Azure Monitor maps AppRequests.ResultCode from the LEGACY
-		// http.status_code, NOT the stable http.response.status_code, so without the
-		// legacy attribute ResultCode shows only the bare span StatusCode (0/2) and
-		// 4xx/5xx alerts keyed on ResultCode never fire (tc-oml9). Do not "clean up"
-		// this apparent duplication — both keys are load-bearing.
-		span.SetAttributes(
-			semconv.HTTPResponseStatusCode(sw.status),
-			attribute.Int("http.status_code", sw.status),
-		)
+			// semconv). Azure Monitor maps AppRequests.ResultCode from the LEGACY
+			// http.status_code, NOT the stable http.response.status_code, so without the
+			// legacy attribute ResultCode shows only the bare span StatusCode (0/2) and
+			// 4xx/5xx alerts keyed on ResultCode never fire (tc-oml9). Do not "clean up"
+			// this apparent duplication — both keys are load-bearing.
+			span.SetAttributes(
+				semconv.HTTPResponseStatusCode(sw.status),
+				attribute.Int("http.status_code", sw.status),
+			)
 			// Mirror semconv server semantics: a 5xx is a request error. ErrorBody
 			// also flags 5xx, but it does not run for the unmatched-route 404/anonymous
 			// paths that bypass it, so set it here too. SetStatus is idempotent and the

--- a/api-go/internal/middleware/routespan_test.go
+++ b/api-go/internal/middleware/routespan_test.go
@@ -98,8 +98,11 @@ func TestRouteSpan_NamesSpanAfterMatchedRoute(t *testing.T) {
 }
 
 // TestRouteSpan_RecordsStatusCode confirms the real HTTP status is recorded onto
-// the span as http.response.status_code for both a 2xx and an error path, so
-// Azure Monitor's ResultCode reflects the HTTP status rather than the span code.
+// the span as both the stable http.response.status_code and the legacy
+// http.status_code, for both a 2xx and an error path. Azure Monitor maps
+// AppRequests.ResultCode from the LEGACY http.status_code (pre-1.21 semconv), not
+// the stable key, so the legacy attribute must carry the same numeric status for
+// status-keyed ResultCode dashboards and 4xx/5xx alerts to fire.
 func TestRouteSpan_RecordsStatusCode(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
@@ -118,6 +121,13 @@ func TestRouteSpan_RecordsStatusCode(t *testing.T) {
 			}
 			if int(got) != tc.status {
 				t.Errorf("http.response.status_code = %d, want %d", got, tc.status)
+			}
+			legacy, ok := attrInt(span, "http.status_code")
+			if !ok {
+				t.Fatalf("legacy http.status_code attribute missing")
+			}
+			if int(legacy) != tc.status {
+				t.Errorf("http.status_code = %d, want %d", legacy, tc.status)
 			}
 		})
 	}
@@ -139,5 +149,8 @@ func TestRouteSpan_UnmatchedRequestFallsBackGracefully(t *testing.T) {
 	}
 	if got, ok := attrInt(span, "http.response.status_code"); !ok || int(got) != http.StatusNotFound {
 		t.Errorf("http.response.status_code = %d (ok=%v), want 404", got, ok)
+	}
+	if got, ok := attrInt(span, "http.status_code"); !ok || int(got) != http.StatusNotFound {
+		t.Errorf("legacy http.status_code = %d (ok=%v), want 404", got, ok)
 	}
 }


### PR DESCRIPTION
## Changes
- RouteSpan middleware now sets the legacy `http.status_code` attribute alongside the stable `http.response.status_code`. Azure Monitor maps `AppRequests.ResultCode` from the **legacy** key, so without it ResultCode showed only the bare span StatusCode (0=Unset/2=Error) and 4xx/5xx alerts keyed on ResultCode never fired.
- Extended `TestRouteSpan_RecordsStatusCode` and `TestRouteSpan_UnmatchedRequestFallsBackGracefully` to assert the legacy attr is present and equals the numeric status (200/401/404/500 + the unmatched-404 fallback).

Closes tc-oml9. Follow-up to PR #475 (Go OTel restore). Verified via /loop post-deploy: ResultCode should read 200/4xx/5xx.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced telemetry and monitoring compatibility to ensure Azure Monitor properly tracks application requests and performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->