### PR TITLE
feat(infra): inject APPLICATIONINSIGHTS_CONNECTION_STRING into Go API apps (tc-yl6w)

### DIFF
--- a/infra/EnvironmentStack.cs
+++ b/infra/EnvironmentStack.cs
@@ -333,6 +333,10 @@ public static class EnvironmentStack
                             Env = new[]
                             {
                                 new EnvironmentVarArgs { Name = "OTEL_SERVICE_NAME", Value = "town-crier-api-go" },
+                                // Read by the in-process Azure Monitor metrics exporter (tc-0rt1):
+                                // the ACA managed OTel agent forwards only logs+traces to App Insights,
+                                // not metrics, so the API exports metrics directly via this conn string.
+                                new EnvironmentVarArgs { Name = "APPLICATIONINSIGHTS_CONNECTION_STRING", Value = appInsightsConnectionString },
                                 new EnvironmentVarArgs { Name = "COSMOS_ENDPOINT", Value = cosmosAccountEndpoint },
                                 new EnvironmentVarArgs { Name = "COSMOS_DATABASE", Value = cosmosDatabase.Name },
                                 new EnvironmentVarArgs { Name = "AZURE_CLIENT_ID", Value = cosmosDataIdentityClientId },


### PR DESCRIPTION
## Changes
- Add `APPLICATIONINSIGHTS_CONNECTION_STRING` to the Go API container apps' env (`ca-town-crier-api-go-{dev,prod}`). The worker jobs already receive it; the API apps only had `OTEL_SERVICE_NAME` (verified via `az containerapp show`).
- Prerequisite for tc-0rt1: the in-process Azure Monitor metrics exporter reads this conn string, because the ACA managed OTel agent forwards only logs+traces to App Insights — not metrics.

**Deploy-ordering:** this must merge and deploy before the tc-0rt1 Go metrics-exporter image lands.

Closes tc-yl6w (discovered-from tc-0rt1).

---
*Auto-shipped via ship skill*