### PR TITLE
fix(email): only mark hourly digest email-sent when ACS send succeeds (tc-qvds)

### DIFF
--- a/api-go/internal/digest/handler.go
+++ b/api-go/internal/digest/handler.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -150,7 +151,10 @@ func (h *Handler) RunWeekly(ctx context.Context) error {
 			h.sendWeeklyPush(ctx, profile, len(notifs))
 		}
 		if wantsEmail {
-			h.sendDigestEmail(ctx, profile.UserID, *profile.Email, notifs)
+			// The weekly cycle does not track emailSent (it re-derives the digest from
+			// the look-back window each run), so a failed send is logged inside
+			// sendDigestEmail and we simply move on to the next user.
+			_ = h.sendDigestEmail(ctx, profile.UserID, *profile.Email, notifs)
 		}
 	}
 	return nil
@@ -260,7 +264,13 @@ func (h *Handler) RunHourly(ctx context.Context) error {
 			continue
 		}
 
-		h.sendDigestEmail(ctx, userID, *profile.Email, included)
+		// Only flip emailSent when the ACS send actually succeeded — one email
+		// batches every included notification for this user, so a failed send must
+		// leave the whole batch unmarked for the next cycle to retry. Marking on a
+		// swallowed send error is silent data loss (tc-qvds).
+		if err := h.sendDigestEmail(ctx, userID, *profile.Email, included); err != nil {
+			continue
+		}
 
 		for _, n := range included {
 			if err := h.notifications.MarkEmailSent(ctx, markSent(n)); err != nil {
@@ -303,14 +313,17 @@ func markSent(n notifications.DigestNotification) notifications.DigestNotificati
 
 // sendDigestEmail groups the notifications by watch zone (with a saved-only
 // section for zone-less notifications), renders the email body, and hands it to
-// the transport-only email sender. A send failure is logged, not propagated — one
-// failed email must not abort the rest of the cycle, mirroring .NET's
-// catch-and-continue in AcsEmailSender.
-func (h *Handler) sendDigestEmail(ctx context.Context, userID, email string, notifs []notifications.DigestNotification) {
+// the transport-only email sender. It logs and returns any failure so the caller
+// can decide whether to proceed: the hourly cycle must NOT flip emailSent when the
+// send fails (otherwise the email is silently lost and never retried — tc-qvds),
+// while the weekly cycle simply moves on to the next user. A failed email never
+// aborts the rest of the cycle either way, mirroring .NET's catch-and-continue in
+// AcsEmailSender.
+func (h *Handler) sendDigestEmail(ctx context.Context, userID, email string, notifs []notifications.DigestNotification) error {
 	zones, err := h.zones.GetByUserID(ctx, userID)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "digest email: load zones failed", "user", userID, "error", err)
-		return
+		return fmt.Errorf("load zones for %s: %w", userID, err)
 	}
 	zoneName := make(map[string]string, len(zones))
 	for _, z := range zones {
@@ -327,7 +340,9 @@ func (h *Handler) sendDigestEmail(ctx context.Context, userID, email string, not
 	}
 	if err := h.email.Send(ctx, msg); err != nil {
 		h.logger.ErrorContext(ctx, "digest email: send failed", "user", userID, "error", err)
+		return fmt.Errorf("send digest email to %s: %w", userID, err)
 	}
+	return nil
 }
 
 // groupByZone partitions notifications into per-zone sections (preserving zone

--- a/api-go/internal/digest/handler.go
+++ b/api-go/internal/digest/handler.go
@@ -152,9 +152,11 @@ func (h *Handler) RunWeekly(ctx context.Context) error {
 		}
 		if wantsEmail {
 			// The weekly cycle does not track emailSent (it re-derives the digest from
-			// the look-back window each run), so a failed send is logged inside
-			// sendDigestEmail and we simply move on to the next user.
-			_ = h.sendDigestEmail(ctx, profile.UserID, *profile.Email, notifs)
+			// the look-back window each run), so a failed send is already logged inside
+			// sendDigestEmail; we just move on to the next user.
+			if err := h.sendDigestEmail(ctx, profile.UserID, *profile.Email, notifs); err != nil {
+				continue
+			}
 		}
 	}
 	return nil

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"strings"
 	"testing"
@@ -105,12 +106,13 @@ func (f *fakeDevices) Delete(_ context.Context, _ string, token string) error {
 }
 
 type spyEmail struct {
-	sent []acsemail.Message
+	sent    []acsemail.Message
+	sendErr error // returned (after recording the attempt) when set
 }
 
 func (s *spyEmail) Send(_ context.Context, msg acsemail.Message) error {
 	s.sent = append(s.sent, msg)
-	return nil
+	return s.sendErr
 }
 
 type spyPush struct {
@@ -369,6 +371,43 @@ func TestRunHourly_PaidTierSendsAndMarksEmailSent(t *testing.T) {
 	// Both included notifications marked email-sent for dedup.
 	if len(fn.marked) != 2 {
 		t.Errorf("marked email-sent: got %v, want 2", fn.marked)
+	}
+}
+
+func TestRunHourly_EmailSendFailureDoesNotMarkSent(t *testing.T) {
+	t.Parallel()
+	// If the ACS send fails, the notifications must NOT be flipped emailSent — the
+	// next cycle must retry. A swallowed send error that marks sent anyway is silent
+	// data loss (tc-qvds).
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	p := mkProfile(t, profiles.TierPro, prefs)
+
+	n1 := zoneNotif("uid-A", "zone-1")
+	n2 := zoneNotif("uid-B", "")
+	n2.WatchZoneID = nil
+
+	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
+	fn := &fakeNotifications{
+		unsentUserIDs: []string{"user-1"},
+		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {n1, n2}},
+	}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
+	}}
+	email := &spyEmail{sendErr: errors.New("acs send boom")}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+	if err := h.RunHourly(context.Background()); err != nil {
+		t.Fatalf("RunHourly: %v", err)
+	}
+	// Send was attempted...
+	if len(email.sent) != 1 {
+		t.Fatalf("emails attempted: got %d, want 1", len(email.sent))
+	}
+	// ...but the failure must leave EVERY batched notification unmarked so it is retried.
+	if len(fn.marked) != 0 {
+		t.Errorf("failed send must not mark anything email-sent: got %v", fn.marked)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes silent data loss in the hourly digest: `sendDigestEmail` swallowed the ACS send error and `RunHourly` then called `MarkEmailSent` unconditionally, flipping `emailSent=true` even on a failed send. The user never got the email and it was never retried.

## Changes
- `sendDigestEmail` now returns its error (wrapped with `%w`).
- `RunHourly` only calls `MarkEmailSent` when the send succeeds; a failed send leaves the whole user batch unmarked so the next cycle retries.
- `RunWeekly` audited — it never calls `MarkEmailSent` (re-derives from the 7-day window each run) so it has no data-loss bug; error is still threaded through for a consistent contract.

## Test
- TDD red→green: `TestRunHourly_EmailSendFailureDoesNotMarkSent` (fake ACS sender returns an error; asserts send attempted but nothing marked).
- Full suite: `go test ./...` → 876 passed.

Bead: tc-qvds