### PR TITLE
fix(profiles): deterministic GDPR export zonePreferences order (tc-zgnt)

### DIFF
--- a/api-go/internal/profiles/export.go
+++ b/api-go/internal/profiles/export.go
@@ -1,6 +1,10 @@
 package profiles
 
-import "time"
+import (
+	"cmp"
+	"slices"
+	"time"
+)
 
 // dotnetTime marshals like System.Text.Json's DateTimeOffset: ISO 8601 with a
 // numeric UTC offset ("2099-12-31T00:00:00+00:00"), never Go's RFC 3339 "Z"
@@ -126,6 +130,13 @@ func newExportUserData(p *UserProfile) exportUserData {
 			DecisionEmail:       z.DecisionEmail,
 		})
 	}
+	// Sort by zoneId so the export is deterministic: ZonePreferences is a Go map,
+	// whose iteration order is randomised, which made the array order flake
+	// request-to-request (tc-zgnt). A stable order keeps successive exports
+	// byte-identical.
+	slices.SortFunc(zones, func(a, b exportedZonePreference) int {
+		return cmp.Compare(a.ZoneID, b.ZoneID)
+	})
 	return exportUserData{
 		UserID: p.UserID,
 		Email:  p.Email,

--- a/api-go/internal/profiles/export_test.go
+++ b/api-go/internal/profiles/export_test.go
@@ -1,0 +1,46 @@
+package profiles
+
+import (
+	"testing"
+	"time"
+)
+
+// TestNewExportUserData_ZonePreferencesSortedByZoneID pins the fix for tc-zgnt:
+// the GDPR export builds zonePreferences by ranging a Go map, whose iteration
+// order is randomised, so without an explicit sort the array order flaked
+// request-to-request. The export must emit the per-zone preferences in a stable
+// order — sorted by zoneId — so two successive exports of the same profile are
+// byte-identical. Building the map in reverse-sorted insertion order, and
+// asserting the exported slice is forward-sorted, fails reliably until the sort
+// lands (Go randomises map ranging, so an unsorted build matches the sorted
+// expectation only by chance).
+func TestNewExportUserData_ZonePreferencesSortedByZoneID(t *testing.T) {
+	t.Parallel()
+
+	p := &UserProfile{
+		UserID:       "auth0|abc",
+		Preferences:  DefaultPreferences(),
+		LastActiveAt: time.Now(),
+		ZonePreferences: map[string]ZonePreferences{
+			"cb5224db": DefaultZonePreferences(),
+			"eb39413d": DefaultZonePreferences(),
+			"4abf25b2": DefaultZonePreferences(),
+		},
+	}
+
+	want := []string{"4abf25b2", "cb5224db", "eb39413d"}
+	export := newExportUserData(p)
+	got := make([]string, 0, len(export.NotificationPreferences.ZonePreferences))
+	for _, z := range export.NotificationPreferences.ZonePreferences {
+		got = append(got, z.ZoneID)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("zonePreferences length: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("zonePreferences not sorted by zoneId: got %v, want %v", got, want)
+		}
+	}
+}

--- a/api-go/internal/watchzones/store_cosmos.go
+++ b/api-go/internal/watchzones/store_cosmos.go
@@ -32,8 +32,11 @@ type CosmosItems interface {
 }
 
 // listByUserQuery lists a user's zones. It is scoped to the userId partition, so
-// it never fans out cross-partition — matching .NET's CosmosWatchZoneRepository.
-const listByUserQuery = "SELECT * FROM c WHERE c.userId = @userId"
+// it never fans out cross-partition. The ORDER BY c.id makes the result
+// deterministic: without it Cosmos returns the zones in an arbitrary order per
+// request, which flaked the GDPR export's zonePreferences array order (tc-zgnt).
+// The document id equals the zone id, so this orders by zone id.
+const listByUserQuery = "SELECT * FROM c WHERE c.userId = @userId ORDER BY c.id"
 
 // CosmosStore reads and writes watch zones in the WatchZones container. It holds
 // only the consumer-side item interface, so no SDK type leaks past it.

--- a/api-go/internal/watchzones/store_cosmos_test.go
+++ b/api-go/internal/watchzones/store_cosmos_test.go
@@ -119,6 +119,23 @@ func TestCosmosStore_GetByUserID_SinglePartitionQuery(t *testing.T) {
 	}
 }
 
+func TestCosmosStore_GetByUserID_OrdersByZoneIDForDeterminism(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if _, err := store.GetByUserID(context.Background(), "auth0|user"); err != nil {
+		t.Fatalf("GetByUserID: %v", err)
+	}
+	// Without an ORDER BY, Cosmos returns a user's zones in an arbitrary,
+	// non-deterministic order each request, which made the GDPR export's
+	// zonePreferences array flake on order (tc-zgnt). The list query must order by
+	// the zone id (the document id) so successive list calls are stable.
+	if !strings.Contains(items.lastQuery, "ORDER BY c.id") {
+		t.Errorf("list query must ORDER BY c.id for deterministic order: %q", items.lastQuery)
+	}
+}
+
 func TestCosmosStore_GetByUserID_EmptyWhenNoZones(t *testing.T) {
 	t.Parallel()
 	store := NewCosmosStore(newFakeItems())


### PR DESCRIPTION
## Summary
Fixes the flaky `zonePreferences` ordering in the GDPR profile export. Root cause: `newExportUserData` built the `zonePreferences` array by ranging a Go map (`UserProfile.ZonePreferences`), whose iteration order is randomised — so `GET /v1/me/data` returned the same zone ids in a different order each call.

Note: the e2e contract test the bead referenced (`api-go/tests/e2e/contract_me_test.go`) no longer exists — the whole `tests/e2e/` dir was removed in #464 during the .NET decommission. So there is no contract assertion to adjust and no .NET parity to match; this is the true source-side fix.

## Changes
- `internal/profiles/export.go` — sort `zonePreferences` by `zoneId` (`slices.SortFunc`) after building the slice from the map → deterministic export.
- `internal/watchzones/store_cosmos.go` — `listByUserQuery` now ends `ORDER BY c.id` (doc id == zone id) so per-user zone lists are deterministic end-to-end (belt-and-braces for when the export sources watch zones).
- Tests added for both.

## Test
`go test -race ./...` → 883 passed, 34 packages, no races.

Bead: tc-zgnt