### PR TITLE
fix(ios): gate watch-zone instant-alert toggles for free tier (tc-bd6i)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
@@ -32,6 +32,9 @@ public struct WatchZoneEditorView: View {
       #if os(iOS)
         .navigationBarTitleDisplayMode(.inline)
       #endif
+      .entitlementGateSheet(entitlement: $viewModel.entitlementGate) {
+        viewModel.viewPlans()
+      }
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
           Button("Cancel") { dismiss() }
@@ -131,17 +134,37 @@ public struct WatchZoneEditorView: View {
 
   private var notificationsSection: some View {
     Section {
-      Toggle("Send push notifications", isOn: $viewModel.pushEnabled)
-        .tint(Color.tcAmber)
-      Toggle("Send instant emails", isOn: $viewModel.emailInstantEnabled)
-        .tint(Color.tcAmber)
+      GatedToggle(
+        label: "Send push notifications",
+        isOn: $viewModel.pushEnabled,
+        entitlement: viewModel.instantAlertEntitlement,
+        featureGate: viewModel.featureGate
+      ) {
+        viewModel.requestInstantAlertUpgrade()
+      }
+      GatedToggle(
+        label: "Send instant emails",
+        isOn: $viewModel.emailInstantEnabled,
+        entitlement: viewModel.instantAlertEntitlement,
+        featureGate: viewModel.featureGate
+      ) {
+        viewModel.requestInstantAlertUpgrade()
+      }
     } header: {
       Text("Notifications")
     } footer: {
-      Text("Choose how this zone alerts you when new applications match.")
+      Text(notificationsFooterText)
         .font(.system(.caption))
         .foregroundStyle(Color.tcTextSecondary)
     }
+  }
+
+  private var notificationsFooterText: String {
+    if viewModel.featureGate.hasEntitlement(viewModel.instantAlertEntitlement) {
+      return "Choose how this zone alerts you when new applications match."
+    }
+    return "Instant push and email alerts are available on Personal and Pro. "
+      + "Free accounts receive a weekly email digest."
   }
 
   @ViewBuilder

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
@@ -4,7 +4,7 @@ import TownCrierDomain
 
 /// Drives create/edit of a single watch zone with postcode geocoding and tier-based radius limits.
 @MainActor
-public final class WatchZoneEditorViewModel: ObservableObject, ErrorHandlingViewModel {
+public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGatingViewModel {
   @Published public var nameInput: String = ""
   @Published public var postcodeInput: String = ""
   @Published public var selectedRadiusMetres: Double = 1000
@@ -13,6 +13,10 @@ public final class WatchZoneEditorViewModel: ObservableObject, ErrorHandlingView
   @Published public private(set) var geocodedCoordinate: Coordinate?
   @Published public private(set) var isLoading = false
   @Published public internal(set) var error: DomainError?
+
+  /// Drives the in-editor subscription upsell sheet. Non-nil while the gate is
+  /// presented for the given entitlement; cleared when the sheet dismisses.
+  @Published public var entitlementGate: Entitlement?
 
   var onSave: ((WatchZone) -> Void)?
 
@@ -63,12 +67,40 @@ public final class WatchZoneEditorViewModel: ObservableObject, ErrorHandlingView
     limits.maxRadiusMetres
   }
 
-  /// Per-zone notification toggles are gated to Personal/Pro tiers only (tc-kh1s).
+  /// Proactive UI gate exposing the session's tier to entitlement-aware controls
+  /// (e.g. ``GatedToggle``) without a network round-trip.
+  public var featureGate: FeatureGate {
+    FeatureGate(tier: tier)
+  }
+
+  /// The entitlement that the per-zone instant push/email toggles are gated behind.
   ///
-  /// Free users do not see these controls — the polling fan-out skips push and
-  /// instant email for them regardless of any flag values.
+  /// Instant alerts (push and instant email) are paid-only; free accounts receive
+  /// the weekly digest only and the server never delivers instant alerts to them
+  /// (tc-bd6i). All paid entitlements travel together in ``EntitlementMap``, so any
+  /// paid-only entitlement correctly distinguishes free (locked) from paid (open).
+  public var instantAlertEntitlement: Entitlement {
+    .statusChangeAlerts
+  }
+
+  /// The notifications section is always shown. For free accounts the instant
+  /// push/email toggles render locked with an upgrade prompt via ``GatedToggle``;
+  /// for Personal/Pro they are fully interactive (tc-bd6i).
   public var areNotificationTogglesVisible: Bool {
-    tier != .free
+    true
+  }
+
+  /// Surfaces the in-editor subscription upsell when a free-tier user taps a locked
+  /// instant-alert toggle. Routes through the entitlement gate so the editor stays
+  /// open and the user can dismiss without losing their work.
+  public func requestInstantAlertUpgrade() {
+    entitlementGate = instantAlertEntitlement
+  }
+
+  /// Invoked when the user taps "View Plans" in the upsell sheet — hands off to the
+  /// coordinator (via ``onUpgradeRequired``) to present the subscription screen.
+  public func viewPlans() {
+    onUpgradeRequired?()
   }
 
   /// Whether to surface the "this zone may produce lots of notifications" callout

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelGatingTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelGatingTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+
+@testable import TownCrierDomain
+@testable import TownCrierPresentation
+
+/// The instant push/email toggles in the watch-zone editor are paid-only (tc-bd6i).
+/// Free-tier users see them locked with an upsell rather than as functioning controls,
+/// because the server never delivers instant alerts to free accounts.
+@MainActor
+@Suite("WatchZoneEditorViewModel — instant-alert gating")
+struct WatchZoneEditorViewModelGatingTests {
+  private var spyGeocoder: SpyPostcodeGeocoder!
+  private var spyRepository: SpyWatchZoneRepository!
+
+  init() {
+    spyGeocoder = SpyPostcodeGeocoder()
+    spyRepository = SpyWatchZoneRepository()
+  }
+
+  private func makeViewModel(tier: SubscriptionTier) -> WatchZoneEditorViewModel {
+    WatchZoneEditorViewModel(
+      geocoder: spyGeocoder,
+      repository: spyRepository,
+      tier: tier
+    )
+  }
+
+  // MARK: - featureGate reflects the tier
+
+  @Test func featureGate_carriesTheTier_free() {
+    #expect(makeViewModel(tier: .free).featureGate.tier == .free)
+  }
+
+  @Test func featureGate_carriesTheTier_personal() {
+    #expect(makeViewModel(tier: .personal).featureGate.tier == .personal)
+  }
+
+  @Test func featureGate_carriesTheTier_pro() {
+    #expect(makeViewModel(tier: .pro).featureGate.tier == .pro)
+  }
+
+  // MARK: - instant-alert entitlement gates the toggles
+
+  @Test func freeTier_doesNotGrantInstantAlertEntitlement() {
+    let sut = makeViewModel(tier: .free)
+    #expect(!sut.featureGate.hasEntitlement(sut.instantAlertEntitlement))
+  }
+
+  @Test func personalTier_grantsInstantAlertEntitlement() {
+    let sut = makeViewModel(tier: .personal)
+    #expect(sut.featureGate.hasEntitlement(sut.instantAlertEntitlement))
+  }
+
+  @Test func proTier_grantsInstantAlertEntitlement() {
+    let sut = makeViewModel(tier: .pro)
+    #expect(sut.featureGate.hasEntitlement(sut.instantAlertEntitlement))
+  }
+
+  // MARK: - The notifications section is always present now
+
+  @Test func notificationsSection_alwaysVisible_free() {
+    #expect(makeViewModel(tier: .free).areNotificationTogglesVisible)
+  }
+
+  @Test func notificationsSection_alwaysVisible_personal() {
+    #expect(makeViewModel(tier: .personal).areNotificationTogglesVisible)
+  }
+
+  // MARK: - Requesting an upgrade surfaces the in-editor upsell gate
+
+  @Test func requestInstantAlertUpgrade_setsEntitlementGate() {
+    let sut = makeViewModel(tier: .free)
+
+    sut.requestInstantAlertUpgrade()
+
+    #expect(sut.entitlementGate == sut.instantAlertEntitlement)
+  }
+
+  @Test func requestInstantAlertUpgrade_doesNotSetInlineError() {
+    let sut = makeViewModel(tier: .free)
+
+    sut.requestInstantAlertUpgrade()
+
+    #expect(sut.error == nil)
+  }
+
+  // MARK: - The upsell's "View Plans" routes to the subscription screen
+
+  @Test func viewPlans_invokesOnUpgradeRequired() {
+    let sut = makeViewModel(tier: .free)
+    var upgradeRequested = false
+    sut.onUpgradeRequired = { upgradeRequested = true }
+
+    sut.viewPlans()
+
+    #expect(upgradeRequested)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelTests.swift
@@ -205,13 +205,15 @@ struct WatchZoneEditorCreateTests {
     #expect(sut.emailInstantEnabled)
   }
 
-  @Test func areNotificationTogglesVisible_freeTier_isFalse() {
+  @Test func areNotificationTogglesVisible_freeTier_isTrue() {
+    // The notifications section is now always shown; for free tier the instant
+    // toggles render locked with an upsell rather than being hidden (tc-bd6i).
     let freeSut = WatchZoneEditorViewModel(
       geocoder: spyGeocoder,
       repository: spyRepository,
       tier: .free
     )
-    #expect(!freeSut.areNotificationTogglesVisible)
+    #expect(freeSut.areNotificationTogglesVisible)
   }
 
   @Test func areNotificationTogglesVisible_personalTier_isTrue() {

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewTests.swift
@@ -116,4 +116,37 @@ struct WatchZoneEditorViewTests {
     let sut = WatchZoneEditorView(viewModel: vm)
     _ = sut.body
   }
+
+  // MARK: - Instant-alert gating in the View (tc-bd6i)
+
+  /// Free-tier create mode now shows the notifications section with locked
+  /// ``GatedToggle`` rows + upsell instead of hiding it; the View must render.
+  @Test func body_renders_inCreateMode_freeTier_withGatedToggles() {
+    let vm = makeViewModel(tier: .free)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  /// The notifications section is now shown for every tier in create mode.
+  @Test func body_renders_inCreateMode_personalTier_withInteractiveToggles() {
+    let vm = makeViewModel(tier: .personal)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  /// Free-tier edit mode renders the gated toggles + upsell without crashing.
+  @Test func body_renders_inEditMode_freeTier_withGatedToggles() {
+    let vm = makeViewModel(tier: .free, editing: .cambridge)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
+
+  /// While the in-editor upsell gate is active, the View still renders.
+  @Test func body_renders_whenEntitlementGateActive() {
+    let vm = makeViewModel(tier: .free)
+    vm.requestInstantAlertUpgrade()
+    #expect(vm.entitlementGate == vm.instantAlertEntitlement)
+    let sut = WatchZoneEditorView(viewModel: vm)
+    _ = sut.body
+  }
 }


### PR DESCRIPTION
## Summary
Free-tier accounts were shown the "Send push notifications" / "Send instant emails" toggles in the watch-zone editor even though the server never delivers instant alerts to free tier (misleading — free = weekly digest only). Per the resolved product decision, the Notifications section is now always shown, but for free tier the instant toggles render **locked with an upsell** instead of being interactive or hidden.

## Changes
- `WatchZoneEditorViewModel` now conforms to `EntitlementGatingViewModel` (`featureGate`, `instantAlertEntitlement` = `.statusChangeAlerts`, `@Published entitlementGate`, `requestInstantAlertUpgrade()`, `viewPlans()`). `areNotificationTogglesVisible` is always `true`.
- `WatchZoneEditorView` replaces plain `Toggle`s with `GatedToggle`, attaches `.entitlementGateSheet(...)`, and shows tier-aware footer copy. "View Plans" routes via the existing `onUpgradeRequired` coordinator callback.
- Tests: new gating tests (free → locked, Personal/Pro → interactive) + updated the prior "hidden for free" test + view render tests.

## Reused existing (previously unwired) gating infra
Now wired into production: **GatedToggle**, **EntitlementGatingViewModel**, **entitlementGateSheet/View+EntitlementGate** (transitively SubscriptionUpsellSheet, UpgradeBadgeView). Still unused: **GatedButton** (only its own tests reference it).

## Test
`swift build` OK · `swift test` → 1248 tests / 152 suites passed · `swiftlint lint --strict` → 0 violations.

Bead: tc-bd6i