### PR TITLE
fix(ios): guard application detail/list loads against re-entrant fetches (tc-eum5)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
@@ -78,6 +78,14 @@ public final class ApplicationDetailViewModel: ObservableObject {
   private let savedApplicationRepository: SavedApplicationRepository?
   private let planningApplicationRepository: PlanningApplicationRepository?
 
+  /// Re-entrancy guard for ``refresh()``. The detail sheet's `.task` can fire
+  /// repeatedly for a single open — alongside scenePhase changes or a
+  /// re-appear — and each unguarded call previously spawned a duplicate
+  /// per-id fetch. SRE telemetry caught `GET /v1/applications/{ref}` firing up
+  /// to 6 times within seconds, all cancelled (HTTP 499). While one refresh is
+  /// in flight, further calls short-circuit (bd tc-eum5).
+  private var isRefreshInFlight = false
+
   private var applicationId: PlanningApplicationId { application.id }
 
   public init(
@@ -120,6 +128,14 @@ public final class ApplicationDetailViewModel: ObservableObject {
   /// No-op if no `PlanningApplicationRepository` was injected.
   public func refresh() async {
     guard let repository = planningApplicationRepository else { return }
+    // Drop re-entrant calls while a refresh is already running so a single
+    // detail open issues at most one per-id fetch (bd tc-eum5). The flag is
+    // read and set synchronously before any `await`, so a second call
+    // scheduled on the same actor sees it set and returns immediately.
+    guard !isRefreshInFlight else { return }
+    isRefreshInFlight = true
+    defer { isRefreshInFlight = false }
+
     do {
       let fresh = try await repository.fetchApplication(by: applicationId)
       if fresh != application {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -56,6 +56,13 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   private let watchZoneRepository: WatchZoneRepository?
   private let notificationStateRepository: NotificationStateRepository?
   private var zone: WatchZone?
+  /// Re-entrancy guard for ``loadApplications()``. A single user action can
+  /// trigger the load repeatedly — `.task` firing alongside `.refreshable`, a
+  /// scenePhase change, or the view re-appearing — and each unguarded call
+  /// previously spawned a duplicate fetch. SRE telemetry caught the same
+  /// request firing 3-6 times within seconds, all cancelled (HTTP 499). While
+  /// one load is in flight, further calls short-circuit (bd tc-eum5).
+  private var isLoadInFlight = false
   private let userDefaults: UserDefaults
   private let zoneSelectionKey: String
   private let sortKey: String
@@ -191,6 +198,14 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   }
 
   public func loadApplications() async {
+    // Drop re-entrant calls while a load is already running so a single user
+    // action issues at most one fetch for the active zone (bd tc-eum5). The
+    // flag is read and set synchronously before any `await`, so a second call
+    // scheduled on the same actor sees it set and returns immediately.
+    guard !isLoadInFlight else { return }
+    isLoadInFlight = true
+    defer { isLoadInFlight = false }
+
     isLoading = true
     error = nil
     do {

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailViewModelConcurrentRefreshTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailViewModelConcurrentRefreshTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Guards against the client-side retry storm in bd tc-eum5: a single detail
+/// open (`.task` firing alongside scenePhase changes or a re-appear) must issue
+/// at most ONE in-flight `GET /v1/applications/{ref}` fetch. Without the guard
+/// the same request fired up to 6 times within seconds, all cancelled
+/// (HTTP 499).
+@Suite("ApplicationDetailViewModel — concurrent refresh guard")
+@MainActor
+struct ApplicationDetailViewModelConcurrentRefreshTests {
+
+  @Test func refresh_whileRefreshInFlight_doesNotIssueSecondFetch() async {
+    let repo = SpyPlanningApplicationRepository()
+    repo.fetchApplicationResult = .success(.permitted)
+    repo.enableGate()
+    let sut = ApplicationDetailViewModel(
+      application: .pendingReview,
+      planningApplicationRepository: repo
+    )
+
+    // First refresh parks inside the gated fetch (fetch call #1 recorded).
+    let first = Task { await sut.refresh() }
+    await Task.yield()
+
+    // Second concurrent refresh must short-circuit synchronously — its
+    // re-entrancy guard runs before any `await`, so it never reaches the
+    // repository. Issued as a Task so it can't deadlock the test if the guard
+    // is missing.
+    let second = Task { await sut.refresh() }
+    await Task.yield()
+    await Task.yield()
+
+    #expect(repo.fetchApplicationCalls.count == 1)
+
+    repo.releaseGate()
+    await first.value
+    await second.value
+
+    #expect(repo.fetchApplicationCalls.count == 1)
+  }
+
+  @Test func refresh_afterPriorRefreshCompletes_fetchesAgain() async {
+    let repo = SpyPlanningApplicationRepository()
+    repo.fetchApplicationResult = .success(.pendingReview)
+    let sut = ApplicationDetailViewModel(
+      application: .pendingReview,
+      planningApplicationRepository: repo
+    )
+
+    await sut.refresh()
+    await sut.refresh()
+
+    // Sequential refreshes still fire — each detail open must revalidate.
+    #expect(repo.fetchApplicationCalls.count == 2)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelConcurrentLoadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelConcurrentLoadTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Guards against the client-side retry storm in bd tc-eum5: a single user
+/// action (`.task` firing alongside `.refreshable`, scenePhase changes, or a
+/// view re-appearing) must issue at most ONE in-flight repository fetch for the
+/// watch-zone applications list. Without the guard the same
+/// `GET /v1/me/watch-zones/{id}/applications` request fired 3-6 times within
+/// seconds, all cancelled (HTTP 499).
+@Suite("ApplicationListViewModel — concurrent load guard")
+@MainActor
+struct ApplicationListViewModelConcurrentLoadTests {
+
+  @Test func loadApplications_whileLoadInFlight_doesNotIssueSecondFetch() async {
+    let spy = SpyPlanningApplicationRepository()
+    spy.fetchApplicationsResult = .success([.pendingReview])
+    spy.enableGate()
+    let sut = ApplicationListViewModel(repository: spy, zone: .cambridge)
+
+    // First load parks inside the gated fetch (fetch call #1 recorded).
+    let first = Task { await sut.loadApplications() }
+    await Task.yield()
+    #expect(sut.isLoading)
+
+    // Second concurrent call must short-circuit synchronously — its
+    // re-entrancy guard runs before any `await`, so it never reaches the
+    // repository. Issued as a Task so it can't deadlock the test if the guard
+    // is missing.
+    let second = Task { await sut.loadApplications() }
+    await Task.yield()
+    await Task.yield()
+
+    // The guard means the in-flight fetch count is still exactly 1.
+    #expect(spy.fetchApplicationsCalls.count == 1)
+
+    spy.releaseGate()
+    await first.value
+    await second.value
+
+    #expect(spy.fetchApplicationsCalls.count == 1)
+  }
+
+  @Test func loadApplications_afterPriorLoadCompletes_fetchesAgain() async {
+    let spy = SpyPlanningApplicationRepository()
+    spy.fetchApplicationsResult = .success([.pendingReview])
+    let sut = ApplicationListViewModel(repository: spy, zone: .cambridge)
+
+    await sut.loadApplications()
+    await sut.loadApplications()
+
+    // Sequential (non-overlapping) loads are still allowed — pull-to-refresh
+    // after the first load completes must hit the network.
+    #expect(spy.fetchApplicationsCalls.count == 2)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyPlanningApplicationRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyPlanningApplicationRepository.swift
@@ -10,8 +10,33 @@ final class SpyPlanningApplicationRepository: PlanningApplicationRepository, @un
   /// Zone IDs that should throw an error when fetched.
   var fetchApplicationsFailureZones: Set<String> = []
 
+  /// Optional gate that holds every fetch open until ``releaseGate()`` is
+  /// called. Lets a test start a fetch, observe the in-flight load, issue a
+  /// second concurrent call, then release both — proving (or disproving) the
+  /// ViewModel's re-entrancy guard (bd tc-eum5).
+  ///
+  /// Implemented as a cooperatively-polled flag rather than a continuation so
+  /// it can never leak or double-resume a `CheckedContinuation` when a test
+  /// holds multiple fetches open at once.
+  private var isGateClosed = false
+
+  func enableGate() {
+    isGateClosed = true
+  }
+
+  func releaseGate() {
+    isGateClosed = false
+  }
+
+  private func waitForGateIfNeeded() async {
+    while isGateClosed {
+      await Task.yield()
+    }
+  }
+
   func fetchApplications(for zone: WatchZone) async throws -> [PlanningApplication] {
     fetchApplicationsCalls.append(zone)
+    await waitForGateIfNeeded()
     if fetchApplicationsFailureZones.contains(zone.id.value) {
       throw DomainError.unexpected("Simulated failure for \(zone.id.value)")
     }
@@ -26,6 +51,7 @@ final class SpyPlanningApplicationRepository: PlanningApplicationRepository, @un
 
   func fetchApplication(by id: PlanningApplicationId) async throws -> PlanningApplication {
     fetchApplicationCalls.append(id)
+    await waitForGateIfNeeded()
     return try fetchApplicationResult.get()
   }
 }


### PR DESCRIPTION
## Summary
SRE telemetry showed the iOS client firing the same request 3-6× within 3-5s for one user action, all ending HTTP 499 (client-cancelled), on `GET /v1/applications/{ref}` and `GET /v1/me/watch-zones/{id}/applications`. Root cause: the two list/detail ViewModels had no re-entrancy guard, so repeated triggers (`.task` + `.refreshable` + re-appear + scenePhase) each issued a fetch; under transient slowness these overlapped, got cancelled and refired.

The original telemetry window coincided with a transient post-deploy server latency spike, and the backend is now Go — so the durable fix is client-side: one user action ⇒ at most one in-flight request per resource.

## Changes
- `ApplicationListViewModel.loadApplications()` → `isLoadInFlight` guard (set synchronously before the first `await`).
- `ApplicationDetailViewModel.refresh()` → `isRefreshInFlight` guard.
- Sequential loads (pull-to-refresh after completion, error-retry) still fetch; only overlapping/re-entrant calls are dropped. `selectZone()` / `markAllRead()` left unguarded as distinct actions.
- Test spy gains a `Task.yield`-polled gate to hold a fetch open and observe in-flight behaviour; 4 new tests.

## Test
`swift build` OK · `swift test` → 1237 tests / 153 suites passed · `swiftlint lint --strict` → 0 violations.

Bead: tc-eum5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented duplicate application fetch requests that could occur during rapid UI transitions or concurrent refresh operations.
  * Improved performance by ensuring only one fetch executes at a time during view lifecycle changes.

* **Tests**
  * Added comprehensive test coverage for concurrent refresh and load operations to verify request deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->