### PR TITLE
refactor(go): dedupe Cosmos isNotFound 404 check into platform.IsCosmosNotFound (tc-25ka)

### DIFF
--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -3,12 +3,10 @@ package applications
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"strconv"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
 // CosmosItems is the consumer-side slice of the Applications container the store
@@ -55,7 +53,7 @@ func (s *CosmosStore) Upsert(ctx context.Context, a PlanningApplication) error {
 func (s *CosmosStore) GetByAuthorityAndName(ctx context.Context, authorityCode, name string) (PlanningApplication, bool, error) {
 	raw, err := s.items.ReadItem(ctx, authorityCode, name)
 	if err != nil {
-		if isNotFound(err) {
+		if platform.IsCosmosNotFound(err) {
 			return PlanningApplication{}, false, nil
 		}
 		return PlanningApplication{}, false, fmt.Errorf("read application %q/%q: %w", authorityCode, name, err)
@@ -116,10 +114,4 @@ func (s *CosmosStore) FindNearby(ctx context.Context, authorityCode string, lati
 		apps = append(apps, doc.toDomain())
 	}
 	return apps, nil
-}
-
-// isNotFound reports whether err is a Cosmos 404 response.
-func isNotFound(err error) bool {
-	var respErr *azcore.ResponseError
-	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }

--- a/api-go/internal/devicetokens/store_cosmos.go
+++ b/api-go/internal/devicetokens/store_cosmos.go
@@ -3,11 +3,9 @@ package devicetokens
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
 // CosmosItems is the consumer-side slice of the DeviceRegistrations container
@@ -46,7 +44,7 @@ func NewCosmosStore(items CosmosItems) *CosmosStore {
 func (s *CosmosStore) GetByToken(ctx context.Context, userID, token string) (*DeviceRegistration, error) {
 	raw, err := s.items.ReadItem(ctx, userID, token)
 	if err != nil {
-		if isNotFound(err) {
+		if platform.IsCosmosNotFound(err) {
 			return nil, nil //nolint:nilnil // absent registration is a valid "not found" signal, not an error
 		}
 		return nil, fmt.Errorf("read device token %q: %w", token, err)
@@ -79,7 +77,7 @@ func (s *CosmosStore) Save(ctx context.Context, reg DeviceRegistration) error {
 // matching .NET DeleteByTokenAsync.
 func (s *CosmosStore) Delete(ctx context.Context, userID, token string) error {
 	if err := s.items.DeleteItem(ctx, userID, token); err != nil {
-		if isNotFound(err) {
+		if platform.IsCosmosNotFound(err) {
 			return nil
 		}
 		return fmt.Errorf("delete device token %q: %w", token, err)
@@ -133,15 +131,9 @@ func (s *CosmosStore) DeleteAllByUserID(ctx context.Context, userID string) erro
 		if err := json.Unmarshal(raw, &doc); err != nil {
 			return fmt.Errorf("decode device token id for %q: %w", userID, err)
 		}
-		if err := s.items.DeleteItem(ctx, userID, doc.ID); err != nil && !isNotFound(err) {
+		if err := s.items.DeleteItem(ctx, userID, doc.ID); err != nil && !platform.IsCosmosNotFound(err) {
 			return fmt.Errorf("delete device token %q for %q: %w", doc.ID, userID, err)
 		}
 	}
 	return nil
-}
-
-// isNotFound reports whether err is a Cosmos 404 response.
-func isNotFound(err error) bool {
-	var respErr *azcore.ResponseError
-	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }

--- a/api-go/internal/notifications/delete_store_cosmos.go
+++ b/api-go/internal/notifications/delete_store_cosmos.go
@@ -3,11 +3,9 @@ package notifications
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
 // DeleteItems is the consumer-side slice of the Notifications container the
@@ -56,15 +54,9 @@ func (s *DeleteStore) DeleteAllByUserID(ctx context.Context, userID string) erro
 		if err := json.Unmarshal(raw, &doc); err != nil {
 			return fmt.Errorf("decode notification id for %q: %w", userID, err)
 		}
-		if err := s.items.DeleteItem(ctx, userID, doc.ID); err != nil && !isDeleteNotFound(err) {
+		if err := s.items.DeleteItem(ctx, userID, doc.ID); err != nil && !platform.IsCosmosNotFound(err) {
 			return fmt.Errorf("delete notification %q for %q: %w", doc.ID, userID, err)
 		}
 	}
 	return nil
-}
-
-// isDeleteNotFound reports whether err is a Cosmos 404 response.
-func isDeleteNotFound(err error) bool {
-	var respErr *azcore.ResponseError
-	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }

--- a/api-go/internal/notificationstate/store_cosmos.go
+++ b/api-go/internal/notificationstate/store_cosmos.go
@@ -3,12 +3,8 @@ package notificationstate
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"time"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
@@ -45,7 +41,7 @@ func NewCosmosStore(state CosmosItems, notifications CosmosCounter) *CosmosStore
 func (s *CosmosStore) Get(ctx context.Context, userID string) (*State, error) {
 	raw, err := s.state.ReadItem(ctx, userID, userID)
 	if err != nil {
-		if isNotFound(err) {
+		if platform.IsCosmosNotFound(err) {
 			return nil, nil //nolint:nilnil // absent watermark is the first-touch signal, not an error
 		}
 		return nil, fmt.Errorf("read notification state %q: %w", userID, err)
@@ -97,14 +93,8 @@ func (s *CosmosStore) UnreadCount(ctx context.Context, userID string, lastReadAt
 // deletion. The Go cascade deletes it (epic tc-wad3, bead tc-dwcq) for complete
 // GDPR erasure.
 func (s *CosmosStore) DeleteByUserID(ctx context.Context, userID string) error {
-	if err := s.state.DeleteItem(ctx, userID, userID); err != nil && !isNotFound(err) {
+	if err := s.state.DeleteItem(ctx, userID, userID); err != nil && !platform.IsCosmosNotFound(err) {
 		return fmt.Errorf("delete notification state %q: %w", userID, err)
 	}
 	return nil
-}
-
-// isNotFound reports whether err is a Cosmos 404 response.
-func isNotFound(err error) bool {
-	var respErr *azcore.ResponseError
-	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }

--- a/api-go/internal/offercodes/store_cosmos.go
+++ b/api-go/internal/offercodes/store_cosmos.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
 // ErrNotFound signals that no offer code exists for the given canonical code.
@@ -41,7 +40,7 @@ func NewCosmosStore(items cosmosItems) *CosmosStore { return &CosmosStore{items:
 func (s *CosmosStore) Get(ctx context.Context, canonical string) (OfferCode, error) {
 	raw, err := s.items.ReadItem(ctx, canonical, canonical)
 	if err != nil {
-		if isNotFound(err) {
+		if platform.IsCosmosNotFound(err) {
 			return OfferCode{}, ErrNotFound
 		}
 		return OfferCode{}, fmt.Errorf("read offer code %q: %w", canonical, err)
@@ -104,9 +103,4 @@ func (s *CosmosStore) AnonymiseRedemptionsByUserID(ctx context.Context, userID s
 		}
 	}
 	return nil
-}
-
-func isNotFound(err error) bool {
-	var respErr *azcore.ResponseError
-	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }

--- a/api-go/internal/platform/cosmos_notfound.go
+++ b/api-go/internal/platform/cosmos_notfound.go
@@ -1,0 +1,12 @@
+package platform
+
+import "net/http"
+
+// IsCosmosNotFound reports whether err is (or wraps) a Cosmos 404 response.
+// Store implementations use it to treat an absent document as a "not found"
+// outcome rather than a failure. It mirrors the unexported isCASNotFound used
+// by the etag-conditional operations but is exported for reuse across the
+// per-feature Cosmos stores.
+func IsCosmosNotFound(err error) bool {
+	return isCASStatus(err, http.StatusNotFound)
+}

--- a/api-go/internal/platform/cosmos_notfound_test.go
+++ b/api-go/internal/platform/cosmos_notfound_test.go
@@ -1,0 +1,33 @@
+package platform
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+func TestIsCosmosNotFound(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"404 response error", &azcore.ResponseError{StatusCode: http.StatusNotFound}, true},
+		{"wrapped 404 response error", fmt.Errorf("read item: %w", &azcore.ResponseError{StatusCode: http.StatusNotFound}), true},
+		{"409 response error", &azcore.ResponseError{StatusCode: http.StatusConflict}, false},
+		{"plain error", errors.New("network blip"), false},
+		{"nil error", nil, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsCosmosNotFound(tc.err); got != tc.want {
+				t.Errorf("IsCosmosNotFound(%v): got %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}

--- a/api-go/internal/polling/statestore.go
+++ b/api-go/internal/polling/statestore.go
@@ -3,14 +3,12 @@ package polling
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"sort"
 	"strconv"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
 // pollStateCrossPartitionQuery selects every poll-state document for the
@@ -67,7 +65,7 @@ func (s *PollStateStore) Get(ctx context.Context, authorityID int) (PollState, b
 	id := documentID(authorityID)
 	raw, err := s.items.ReadItem(ctx, id, id)
 	if err != nil {
-		if isNotFound(err) {
+		if platform.IsCosmosNotFound(err) {
 			return PollState{}, false, nil
 		}
 		return PollState{}, false, fmt.Errorf("read poll state %d: %w", authorityID, err)
@@ -204,12 +202,6 @@ func (d pollStateDocument) readCursor() (*PollCursor, error) {
 // matching .NET FormatDocumentId.
 func documentID(authorityID int) string {
 	return "poll-state-" + strconv.Itoa(authorityID)
-}
-
-// isNotFound reports whether err is a Cosmos 404 response.
-func isNotFound(err error) bool {
-	var respErr *azcore.ResponseError
-	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }
 
 // ptr returns a pointer to v. Used by tests and the store for optional fields.

--- a/api-go/internal/profiles/store_cosmos.go
+++ b/api-go/internal/profiles/store_cosmos.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
 // ErrNotFound signals that no profile exists for the given user id. Callers use
@@ -47,7 +46,7 @@ func NewCosmosStore(items CosmosItems) *CosmosStore {
 func (s *CosmosStore) Get(ctx context.Context, userID string) (*UserProfile, error) {
 	raw, err := s.items.ReadItem(ctx, userID, userID)
 	if err != nil {
-		if isNotFound(err) {
+		if platform.IsCosmosNotFound(err) {
 			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("read profile %q: %w", userID, err)
@@ -80,16 +79,10 @@ func (s *CosmosStore) Save(ctx context.Context, p *UserProfile) error {
 // reads first) or tolerable.
 func (s *CosmosStore) Delete(ctx context.Context, userID string) error {
 	if err := s.items.DeleteItem(ctx, userID, userID); err != nil {
-		if isNotFound(err) {
+		if platform.IsCosmosNotFound(err) {
 			return ErrNotFound
 		}
 		return fmt.Errorf("delete profile %q: %w", userID, err)
 	}
 	return nil
-}
-
-// isNotFound reports whether err is a Cosmos 404 response.
-func isNotFound(err error) bool {
-	var respErr *azcore.ResponseError
-	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }

--- a/api-go/internal/savedapplications/store_cosmos.go
+++ b/api-go/internal/savedapplications/store_cosmos.go
@@ -3,11 +3,9 @@ package savedapplications
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
 // CosmosItems is the consumer-side slice of the SavedApplications container the
@@ -58,7 +56,7 @@ func (s *CosmosStore) Save(ctx context.Context, sa SavedApplication) error {
 func (s *CosmosStore) Exists(ctx context.Context, userID, applicationUID string) (bool, error) {
 	_, err := s.items.ReadItem(ctx, userID, makeID(userID, applicationUID))
 	if err != nil {
-		if isNotFound(err) {
+		if platform.IsCosmosNotFound(err) {
 			return false, nil
 		}
 		return false, fmt.Errorf("read saved application %q: %w", applicationUID, err)
@@ -70,7 +68,7 @@ func (s *CosmosStore) Exists(ctx context.Context, userID, applicationUID string)
 // error: the .NET REST delete is idempotent and the DELETE endpoint always
 // returns 204, so a 404 from Cosmos is swallowed.
 func (s *CosmosStore) Delete(ctx context.Context, userID, applicationUID string) error {
-	if err := s.items.DeleteItem(ctx, userID, makeID(userID, applicationUID)); err != nil && !isNotFound(err) {
+	if err := s.items.DeleteItem(ctx, userID, makeID(userID, applicationUID)); err != nil && !platform.IsCosmosNotFound(err) {
 		return fmt.Errorf("delete saved application %q: %w", applicationUID, err)
 	}
 	return nil
@@ -148,15 +146,9 @@ func (s *CosmosStore) DeleteAllByUserID(ctx context.Context, userID string) erro
 		if err := json.Unmarshal(raw, &doc); err != nil {
 			return fmt.Errorf("decode saved application id for %q: %w", userID, err)
 		}
-		if err := s.items.DeleteItem(ctx, userID, doc.ID); err != nil && !isNotFound(err) {
+		if err := s.items.DeleteItem(ctx, userID, doc.ID); err != nil && !platform.IsCosmosNotFound(err) {
 			return fmt.Errorf("delete saved application %q for %q: %w", doc.ID, userID, err)
 		}
 	}
 	return nil
-}
-
-// isNotFound reports whether err is a Cosmos 404 response.
-func isNotFound(err error) bool {
-	var respErr *azcore.ResponseError
-	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }

--- a/api-go/internal/subscriptions/store_cosmos.go
+++ b/api-go/internal/subscriptions/store_cosmos.go
@@ -3,12 +3,8 @@ package subscriptions
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
-	"net/http"
 	"time"
-
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
@@ -50,7 +46,7 @@ func NewCosmosNotificationStore(items notificationItems, now func() time.Time) *
 func (s *CosmosNotificationStore) IsProcessed(ctx context.Context, notificationUUID string) (bool, error) {
 	_, err := s.items.ReadItem(ctx, notificationUUID, notificationUUID)
 	if err != nil {
-		if isNotFound(err) {
+		if platform.IsCosmosNotFound(err) {
 			return false, nil
 		}
 		return false, fmt.Errorf("read processed notification %q: %w", notificationUUID, err)
@@ -74,9 +70,4 @@ func (s *CosmosNotificationStore) MarkProcessed(ctx context.Context, notificatio
 		return fmt.Errorf("upsert processed notification %q: %w", notificationUUID, err)
 	}
 	return nil
-}
-
-func isNotFound(err error) bool {
-	var respErr *azcore.ResponseError
-	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }

--- a/api-go/internal/watchzones/store_cosmos.go
+++ b/api-go/internal/watchzones/store_cosmos.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
 // ErrNotFound signals that no watch zone exists for the given (user, zone) pair.
@@ -78,7 +77,7 @@ func (s *CosmosStore) GetByUserID(ctx context.Context, userID string) ([]WatchZo
 func (s *CosmosStore) Get(ctx context.Context, userID, zoneID string) (WatchZone, error) {
 	raw, err := s.items.ReadItem(ctx, userID, zoneID)
 	if err != nil {
-		if isNotFound(err) {
+		if platform.IsCosmosNotFound(err) {
 			return WatchZone{}, ErrNotFound
 		}
 		return WatchZone{}, fmt.Errorf("read watch zone %q: %w", zoneID, err)
@@ -112,7 +111,7 @@ func (s *CosmosStore) Save(ctx context.Context, z WatchZone) error {
 // the .NET REST client.)
 func (s *CosmosStore) Delete(ctx context.Context, userID, zoneID string) error {
 	if err := s.items.DeleteItem(ctx, userID, zoneID); err != nil {
-		if isNotFound(err) {
+		if platform.IsCosmosNotFound(err) {
 			return ErrNotFound
 		}
 		return fmt.Errorf("delete watch zone %q: %w", zoneID, err)
@@ -141,7 +140,7 @@ func (s *CosmosStore) DeleteAllByUserID(ctx context.Context, userID string) erro
 		if err := json.Unmarshal(raw, &doc); err != nil {
 			return fmt.Errorf("decode watch zone id for %q: %w", userID, err)
 		}
-		if err := s.items.DeleteItem(ctx, userID, doc.ID); err != nil && !isNotFound(err) {
+		if err := s.items.DeleteItem(ctx, userID, doc.ID); err != nil && !platform.IsCosmosNotFound(err) {
 			return fmt.Errorf("delete watch zone %q for %q: %w", doc.ID, userID, err)
 		}
 	}
@@ -214,10 +213,4 @@ func (s *CosmosStore) FindZonesContaining(ctx context.Context, latitude, longitu
 		zones = append(zones, zone)
 	}
 	return zones, nil
-}
-
-// isNotFound reports whether err is a Cosmos 404 response.
-func isNotFound(err error) bool {
-	var respErr *azcore.ResponseError
-	return errors.As(err, &respErr) && respErr.StatusCode == http.StatusNotFound
 }


### PR DESCRIPTION
## Summary
The Cosmos 404 check `func isNotFound(err) bool` was duplicated **byte-identical** across 9 `internal/*/store_cosmos.go` files (profiles, polling, notificationstate, devicetokens, savedapplications, watchzones, subscriptions, applications, offercodes), plus the `isDeleteNotFound` variant in `notifications/delete_store_cosmos.go` (same check). All collapsed into one exported helper.

## Changes
- New `platform.IsCosmosNotFound(err error) bool` (`internal/platform/cosmos_notfound.go`), reusing the existing `isCASStatus` style alongside `isCASNotFound`, with a focused unit test.
- 10 store files updated to call it; dead local copies deleted; unused imports (`errors`/`net/http`/`azcore`) cleaned. Net −105/+26 across the store files.

Behaviour-preserving — verified all 9 bodies identical before consolidating; existing per-package `store_cosmos_test.go` 404-path tests continue to pass.

## Test
`go build ./...` OK · `go test -race ./...` → 890 passed (34 packages) · `go vet` clean · `gofmt -l` empty · `golangci-lint` clean.

Bead: tc-25ka