### PR TITLE
refactor(go): dedupe handler encodeJSON into shared httputil.EncodeJSON (tc-wlzc)

### DIFF
--- a/api-go/internal/admin/handler.go
+++ b/api-go/internal/admin/handler.go
@@ -1,13 +1,12 @@
 package admin
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"log/slog"
 	"net/http"
 	"time"
 
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
@@ -61,7 +60,7 @@ func Routes(mux *http.ServeMux, adminKey string, profileStore profileAdminStore,
 }
 
 func (h *handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {
-	body, err := encodeJSON(v)
+	body, err := httputil.EncodeJSON(v)
 	if err != nil {
 		h.serverError(w, r, "encode response", err)
 		return
@@ -71,16 +70,6 @@ func (h *handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {
 	if _, err := w.Write(body); err != nil {
 		h.logger.ErrorContext(r.Context(), "write admin response", "error", err)
 	}
-}
-
-func encodeJSON(v any) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(v); err != nil {
-		return nil, err
-	}
-	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }
 
 func (h *handler) serverError(w http.ResponseWriter, r *http.Request, op string, err error) {

--- a/api-go/internal/admin/offercodes.go
+++ b/api-go/internal/admin/offercodes.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
@@ -91,7 +92,7 @@ func (h *handler) generateOfferCodes(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) writeBadRequest(r *http.Request, w http.ResponseWriter, message string) {
-	body, err := encodeJSON(apiErrorResponse{Error: message, Message: nil})
+	body, err := httputil.EncodeJSON(apiErrorResponse{Error: message, Message: nil})
 	if err != nil {
 		h.serverError(w, r, "encode error", err)
 		return

--- a/api-go/internal/applications/respond.go
+++ b/api-go/internal/applications/respond.go
@@ -1,25 +1,23 @@
 package applications
 
 import (
-	"bytes"
-	"encoding/json"
 	"log/slog"
 	"net/http"
+
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 )
 
 // writeJSON encodes v as a 200 application/json; charset=utf-8 response with HTML
 // escaping off and no trailing newline, matching ASP.NET's Results.Ok byte output.
 func writeJSON(w http.ResponseWriter, r *http.Request, logger *slog.Logger, v any) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(v); err != nil {
+	body, err := httputil.EncodeJSON(v)
+	if err != nil {
 		serverError(w, r, logger, "encode response", err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(bytes.TrimRight(buf.Bytes(), "\n")); err != nil {
+	if _, err := w.Write(body); err != nil {
 		logger.ErrorContext(r.Context(), "write response", "error", err)
 	}
 }

--- a/api-go/internal/applications/respond.go
+++ b/api-go/internal/applications/respond.go
@@ -17,7 +17,9 @@ func writeJSON(w http.ResponseWriter, r *http.Request, logger *slog.Logger, v an
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(body); err != nil {
+	// gosec G705: body is JSON from httputil.EncodeJSON served as
+	// application/json, so it is never interpreted as HTML — no XSS surface.
+	if _, err := w.Write(body); err != nil { //nolint:gosec // JSON body, application/json content type
 		logger.ErrorContext(r.Context(), "write response", "error", err)
 	}
 }

--- a/api-go/internal/demoaccount/respond.go
+++ b/api-go/internal/demoaccount/respond.go
@@ -1,25 +1,23 @@
 package demoaccount
 
 import (
-	"bytes"
-	"encoding/json"
 	"log/slog"
 	"net/http"
+
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 )
 
 // writeJSON encodes v as a 200 application/json; charset=utf-8 response with HTML
 // escaping off and no trailing newline, matching ASP.NET's Results.Ok byte output.
 func writeJSON(w http.ResponseWriter, r *http.Request, logger *slog.Logger, v any) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(v); err != nil {
+	body, err := httputil.EncodeJSON(v)
+	if err != nil {
 		serverError(w, r, logger, "encode response", err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(http.StatusOK)
-	if _, err := w.Write(bytes.TrimRight(buf.Bytes(), "\n")); err != nil {
+	if _, err := w.Write(body); err != nil {
 		logger.ErrorContext(r.Context(), "write response", "error", err)
 	}
 }

--- a/api-go/internal/geocoding/handler.go
+++ b/api-go/internal/geocoding/handler.go
@@ -1,11 +1,11 @@
 package geocoding
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"log/slog"
 	"net/http"
+
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 )
 
 // geocoder is the consumer-side view the handler needs: resolve a normalised
@@ -71,7 +71,7 @@ func (h handler) geocode(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {
-	body, err := encodeJSON(v)
+	body, err := httputil.EncodeJSON(v)
 	if err != nil {
 		h.logger.ErrorContext(r.Context(), "encode geocode response", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -85,7 +85,7 @@ func (h handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {
 }
 
 func (h handler) writeError(r *http.Request, w http.ResponseWriter, status int, message string) {
-	body, err := encodeJSON(apiErrorResponse{Error: message})
+	body, err := httputil.EncodeJSON(apiErrorResponse{Error: message})
 	if err != nil {
 		h.logger.ErrorContext(r.Context(), "encode geocode error", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
@@ -96,16 +96,4 @@ func (h handler) writeError(r *http.Request, w http.ResponseWriter, status int, 
 	if _, err := w.Write(body); err != nil {
 		h.logger.ErrorContext(r.Context(), "write geocode error body", "error", err)
 	}
-}
-
-// encodeJSON renders v with HTML escaping off and the trailing newline trimmed,
-// so the wire bytes match the compact .NET response exactly.
-func encodeJSON(v any) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(v); err != nil {
-		return nil, err
-	}
-	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }

--- a/api-go/internal/httputil/json.go
+++ b/api-go/internal/httputil/json.go
@@ -1,0 +1,22 @@
+// Package httputil holds small, cross-cutting helpers shared by the HTTP
+// handlers. It deliberately carries no business logic.
+package httputil
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// EncodeJSON renders v as JSON with HTML escaping disabled and the trailing
+// newline that json.Encoder appends trimmed off. This matches the relaxed
+// (non-HTML-escaping) byte output of the .NET web serializer, so the wire bytes
+// stay identical across the handlers that emit JSON responses.
+func EncodeJSON(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buf.Bytes(), "\n"), nil
+}

--- a/api-go/internal/httputil/json_test.go
+++ b/api-go/internal/httputil/json_test.go
@@ -17,23 +17,16 @@ func TestEncodeJSON_DoesNotEscapeHTMLOrAppendNewline(t *testing.T) {
 		t.Fatalf("EncodeJSON returned error: %v", err)
 	}
 
-	s := string(got)
-
-	// HTML-significant characters must NOT be escaped (no <, >, &).
-	for _, escaped := range []string{`<`, `>`, `&`} {
-		if strings.Contains(s, escaped) {
-			t.Errorf("output %q contains escaped sequence %q; SetEscapeHTML(false) not applied", s, escaped)
-		}
-	}
-	for _, raw := range []string{"<", ">", "&"} {
-		if !strings.Contains(s, raw) {
-			t.Errorf("output %q is missing raw character %q", s, raw)
-		}
+	// With SetEscapeHTML(false) the <, > and & characters must appear raw (the
+	// default encoder would Unicode-escape them), and the trailing newline that
+	// json.Encoder writes must be trimmed. Asserting the exact bytes covers both
+	// behaviours at once.
+	if want := `{"q":"a < b && c > d"}`; string(got) != want {
+		t.Errorf("got %q, want %q", string(got), want)
 	}
 
-	// json.Encoder appends a trailing newline; EncodeJSON must trim it.
-	if strings.HasSuffix(s, "\n") {
-		t.Errorf("output %q has a trailing newline; it should be trimmed", s)
+	if strings.HasSuffix(string(got), "\n") {
+		t.Errorf("output %q has a trailing newline; it should be trimmed", string(got))
 	}
 }
 

--- a/api-go/internal/httputil/json_test.go
+++ b/api-go/internal/httputil/json_test.go
@@ -1,0 +1,61 @@
+package httputil_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
+)
+
+func TestEncodeJSON_DoesNotEscapeHTMLOrAppendNewline(t *testing.T) {
+	t.Parallel()
+
+	v := map[string]string{"q": "a < b && c > d"}
+
+	got, err := httputil.EncodeJSON(v)
+	if err != nil {
+		t.Fatalf("EncodeJSON returned error: %v", err)
+	}
+
+	s := string(got)
+
+	// HTML-significant characters must NOT be escaped (no <, >, &).
+	for _, escaped := range []string{`<`, `>`, `&`} {
+		if strings.Contains(s, escaped) {
+			t.Errorf("output %q contains escaped sequence %q; SetEscapeHTML(false) not applied", s, escaped)
+		}
+	}
+	for _, raw := range []string{"<", ">", "&"} {
+		if !strings.Contains(s, raw) {
+			t.Errorf("output %q is missing raw character %q", s, raw)
+		}
+	}
+
+	// json.Encoder appends a trailing newline; EncodeJSON must trim it.
+	if strings.HasSuffix(s, "\n") {
+		t.Errorf("output %q has a trailing newline; it should be trimmed", s)
+	}
+}
+
+func TestEncodeJSON_EncodesValue(t *testing.T) {
+	t.Parallel()
+
+	got, err := httputil.EncodeJSON(struct {
+		Name string `json:"name"`
+	}{Name: "GLA"})
+	if err != nil {
+		t.Fatalf("EncodeJSON returned error: %v", err)
+	}
+
+	if want := `{"name":"GLA"}`; string(got) != want {
+		t.Errorf("got %q, want %q", string(got), want)
+	}
+}
+
+func TestEncodeJSON_ReturnsErrorForUnencodableValue(t *testing.T) {
+	t.Parallel()
+
+	if _, err := httputil.EncodeJSON(make(chan int)); err == nil {
+		t.Fatal("expected an error encoding an unsupported type, got nil")
+	}
+}

--- a/api-go/internal/offercodes/handler.go
+++ b/api-go/internal/offercodes/handler.go
@@ -1,7 +1,6 @@
 package offercodes
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
@@ -145,7 +145,7 @@ func (h *handler) redeem(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {
-	body, err := encodeJSON(v)
+	body, err := httputil.EncodeJSON(v)
 	if err != nil {
 		h.serverError(w, r, "encode response", err)
 		return
@@ -159,7 +159,7 @@ func (h *handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {
 
 func (h *handler) writeError(r *http.Request, w http.ResponseWriter, status int, code, message string) {
 	msg := message
-	body, err := encodeJSON(apiErrorResponse{Error: code, Message: &msg})
+	body, err := httputil.EncodeJSON(apiErrorResponse{Error: code, Message: &msg})
 	if err != nil {
 		h.serverError(w, r, "encode error", err)
 		return
@@ -169,16 +169,6 @@ func (h *handler) writeError(r *http.Request, w http.ResponseWriter, status int,
 	if _, err := w.Write(body); err != nil {
 		h.logger.ErrorContext(r.Context(), "write offer-code error body", "error", err)
 	}
-}
-
-func encodeJSON(v any) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(v); err != nil {
-		return nil, err
-	}
-	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }
 
 func (h *handler) serverError(w http.ResponseWriter, r *http.Request, op string, err error) {

--- a/api-go/internal/savedapplications/handler.go
+++ b/api-go/internal/savedapplications/handler.go
@@ -1,7 +1,6 @@
 package savedapplications
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -14,6 +13,7 @@ import (
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
@@ -292,7 +292,7 @@ type apiErrorResponse struct {
 }
 
 func (h *handler) writeJSON(w http.ResponseWriter, r *http.Request, v any) {
-	body, err := encodeJSON(v)
+	body, err := httputil.EncodeJSON(v)
 	if err != nil {
 		h.serverError(w, r, "encode response", err)
 		return
@@ -305,7 +305,7 @@ func (h *handler) writeJSON(w http.ResponseWriter, r *http.Request, v any) {
 }
 
 func (h *handler) writeError(w http.ResponseWriter, r *http.Request, status int, message string) {
-	body, err := encodeJSON(apiErrorResponse{Error: message})
+	body, err := httputil.EncodeJSON(apiErrorResponse{Error: message})
 	if err != nil {
 		h.serverError(w, r, "encode error", err)
 		return
@@ -315,16 +315,6 @@ func (h *handler) writeError(w http.ResponseWriter, r *http.Request, status int,
 	if _, err := w.Write(body); err != nil {
 		h.logger.ErrorContext(r.Context(), "write error body", "error", err)
 	}
-}
-
-func encodeJSON(v any) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(v); err != nil {
-		return nil, err
-	}
-	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }
 
 func (h *handler) serverError(w http.ResponseWriter, r *http.Request, op string, err error) {

--- a/api-go/internal/subscriptions/handler.go
+++ b/api-go/internal/subscriptions/handler.go
@@ -1,7 +1,6 @@
 package subscriptions
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
@@ -397,7 +397,7 @@ type apiErrorResponse struct {
 }
 
 func (h *handler) writeJSON(r *http.Request, w http.ResponseWriter, status int, v any) {
-	body, err := encodeJSON(v)
+	body, err := httputil.EncodeJSON(v)
 	if err != nil {
 		h.serverError(r, w, "encode response", err)
 		return
@@ -411,7 +411,7 @@ func (h *handler) writeJSON(r *http.Request, w http.ResponseWriter, status int, 
 
 func (h *handler) writeError(r *http.Request, w http.ResponseWriter, status int, code, message string) {
 	msg := message
-	body, err := encodeJSON(apiErrorResponse{Error: code, Message: &msg})
+	body, err := httputil.EncodeJSON(apiErrorResponse{Error: code, Message: &msg})
 	if err != nil {
 		h.serverError(r, w, "encode error", err)
 		return
@@ -425,16 +425,6 @@ func (h *handler) writeError(r *http.Request, w http.ResponseWriter, status int,
 
 func (h *handler) malformedBody(r *http.Request, w http.ResponseWriter) {
 	h.writeError(r, w, http.StatusBadRequest, "malformed_request", "The request body is not valid JSON.")
-}
-
-func encodeJSON(v any) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(v); err != nil {
-		return nil, err
-	}
-	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }
 
 func (h *handler) serverError(r *http.Request, w http.ResponseWriter, op string, err error) {

--- a/api-go/internal/watchzones/applicationauthorities.go
+++ b/api-go/internal/watchzones/applicationauthorities.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/authorities"
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 )
 
 // zoneAuthorityLister yields the user's watch zones; the application-authorities
@@ -82,7 +83,7 @@ func (h *authoritiesHandler) list(w http.ResponseWriter, r *http.Request) {
 		return authorities.CompareOrdinalIgnoreCase(a.Name, b.Name)
 	})
 
-	body, err := encodeJSON(applicationAuthoritiesResult{Authorities: items, Count: len(items)})
+	body, err := httputil.EncodeJSON(applicationAuthoritiesResult{Authorities: items, Count: len(items)})
 	if err != nil {
 		h.logger.ErrorContext(r.Context(), "watch-zone request failed", "op", "encode authorities", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -1,7 +1,6 @@
 package watchzones
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -11,6 +10,7 @@ import (
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 )
 
 // maxBodyBytes caps the request body the PATCH handler reads.
@@ -246,7 +246,7 @@ type apiErrorResponse struct {
 // escaping off and no trailing newline, matching ASP.NET's Results.Ok byte
 // output (the same approach the profiles handler uses).
 func (h *handler) writeJSON(w http.ResponseWriter, r *http.Request, status int, v any) {
-	body, err := encodeJSON(v)
+	body, err := httputil.EncodeJSON(v)
 	if err != nil {
 		h.serverError(w, r, "encode response", err)
 		return
@@ -262,7 +262,7 @@ func (h *handler) writeJSON(w http.ResponseWriter, r *http.Request, status int, 
 // the same content type as a success body (Results.Json defaults to
 // application/json; charset=utf-8).
 func (h *handler) writeError(w http.ResponseWriter, r *http.Request, status int, message string) {
-	body, err := encodeJSON(apiErrorResponse{Error: message})
+	body, err := httputil.EncodeJSON(apiErrorResponse{Error: message})
 	if err != nil {
 		h.serverError(w, r, "encode error", err)
 		return
@@ -272,18 +272,6 @@ func (h *handler) writeError(w http.ResponseWriter, r *http.Request, status int,
 	if _, err := w.Write(body); err != nil {
 		h.logger.ErrorContext(r.Context(), "write error body", "error", err)
 	}
-}
-
-// encodeJSON renders v with HTML escaping disabled and the trailing newline
-// trimmed, matching the relaxed-encoder byte output of the .NET web serializer.
-func encodeJSON(v any) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	enc.SetEscapeHTML(false)
-	if err := enc.Encode(v); err != nil {
-		return nil, err
-	}
-	return bytes.TrimRight(buf.Bytes(), "\n"), nil
 }
 
 // serverError logs and emits a bodyless 500; the error envelope (with Detail) is

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
@@ -303,7 +304,7 @@ func boolOrTrue(p *bool) bool {
 // writeCreated emits a 201 Created with a Location header and the JSON body,
 // matching .NET Results.Created.
 func (h *handler) writeCreated(w http.ResponseWriter, r *http.Request, location string, v any) {
-	body, err := encodeJSON(v)
+	body, err := httputil.EncodeJSON(v)
 	if err != nil {
 		h.serverError(w, r, "encode response", err)
 		return


### PR DESCRIPTION
## Summary
The JSON-encoding helper (`json.Encoder` with `SetEscapeHTML(false)` + trailing-newline trim) was duplicated **byte-identical** across 6 handler files (savedapplications, admin, watchzones, geocoding, subscriptions, offercodes) plus inlined variants in `applications/respond.go` and `demoaccount/respond.go`. All 8 verified identical and consolidated.

## Changes
- New `internal/httputil` package with exported `EncodeJSON(v any) ([]byte, error)` + focused unit test (HTML chars not escaped, no trailing newline, error path).
- 11 call sites swapped to `httputil.EncodeJSON` (incl. 3 extra in-scope sites: `admin/offercodes.go`, `watchzones/nearby.go`, `watchzones/applicationauthorities.go`); dead local copies + unused imports removed. Net −66 lines.
- Suppressed a new gosec G705 false-positive on `applications/respond.go` `w.Write(body)` (JSON body served as `application/json`, no XSS surface) with an inline `//nolint:gosec` matching the codebase convention.

Behaviour-preserving — existing per-package `handler_test.go` coverage continues to pass.

## Test
`go build ./...` OK · `go test -race ./...` → 887 passed (35 packages) · `go vet` clean · `gofmt -l` empty · `golangci-lint` 0 issues in touched packages.

Bead: tc-wlzc