### PR TITLE
refactor(go): drop profiles-local dups of erasure.ChildDeleter and platform.DotNetTime (tc-hg65)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -157,7 +157,7 @@ func main() {
 	// GDPR erasure (bead tc-qkf2). It is populated only when Cosmos is configured —
 	// the same condition under which profiles.Routes is wired — so the handler's
 	// deleters are never nil when the route is reachable. The four DeleteAllByUserID
-	// stores satisfy profiles.ChildDeleter directly; notification-state is bridged by
+	// stores satisfy erasure.ChildDeleter directly; notification-state is bridged by
 	// erasure.NotificationStateChild (its store method is DeleteByUserID), shared with
 	// the dormant-cleanup worker (bead tc-gf0g). The offer-code anonymiser scrubs the
 	// redeemer back-reference (redeemedByUserId + redeemedAt) without deleting the

--- a/api-go/internal/profiles/cascade.go
+++ b/api-go/internal/profiles/cascade.go
@@ -1,26 +1,6 @@
 package profiles
 
-import "context"
-
-// ChildDeleter erases every document a single per-user container holds for the
-// account being deleted. The per-container cascade stores expose this exact
-// method, so notifications.DeleteStore and the watchzones / savedapplications /
-// devicetokens CosmosStores satisfy it directly; the notification-state store is
-// bridged by a one-line adapter in the api wiring, since its method is
-// DeleteByUserID. Each store tolerates a 404 on an individual delete internally,
-// so any error returned here is real and must abort the cascade.
-type ChildDeleter interface {
-	DeleteAllByUserID(ctx context.Context, userID string) error
-}
-
-// RedemptionAnonymiser scrubs the offer-code redemption back-reference
-// (redeemedByUserId + redeemedAt) for the account being deleted, without
-// deleting the code document — the code is an admin campaign artifact whose
-// consumed state must survive so it can't be re-redeemed (bead tc-5jyh). The
-// offercodes.CosmosStore satisfies it directly.
-type RedemptionAnonymiser interface {
-	AnonymiseRedemptionsByUserID(ctx context.Context, userID string) error
-}
+import "github.com/AmyDe/town-crier/api-go/internal/erasure"
 
 // CascadeDeleters bundles the per-container erasure steps DELETE /v1/me runs — in
 // the fixed order the handler invokes them — before deleting the profile document
@@ -30,11 +10,17 @@ type RedemptionAnonymiser interface {
 // profile and the Auth0 user, leaving watch zones, saved applications,
 // notifications, device registrations and the notification-state watermark
 // orphaned in Cosmos.
+//
+// The per-container and offer-code step contracts are the shared erasure
+// interfaces (erasure.ChildDeleter, erasure.RedemptionAnonymiser) — the same
+// types the dormant-cleanup worker's cascade uses — so the handler can pass these
+// deleters straight into erasure.Deleters with no per-package interface drift
+// (bead tc-hg65).
 type CascadeDeleters struct {
-	Notifications       ChildDeleter
-	WatchZones          ChildDeleter
-	SavedApplications   ChildDeleter
-	DeviceRegistrations ChildDeleter
-	NotificationState   ChildDeleter
-	OfferCodes          RedemptionAnonymiser
+	Notifications       erasure.ChildDeleter
+	WatchZones          erasure.ChildDeleter
+	SavedApplications   erasure.ChildDeleter
+	DeviceRegistrations erasure.ChildDeleter
+	NotificationState   erasure.ChildDeleter
+	OfferCodes          erasure.RedemptionAnonymiser
 }

--- a/api-go/internal/profiles/export.go
+++ b/api-go/internal/profiles/export.go
@@ -3,29 +3,9 @@ package profiles
 import (
 	"cmp"
 	"slices"
-	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
-
-// dotnetTime marshals like System.Text.Json's DateTimeOffset: ISO 8601 with a
-// numeric UTC offset ("2099-12-31T00:00:00+00:00"), never Go's RFC 3339 "Z"
-// suffix; fractional seconds appear only when non-zero, trailing zeros
-// trimmed — the same trimming STJ applies. Every .NET Exported* timestamp is a
-// DateTimeOffset, so every export wire timestamp must use this type.
-type dotnetTime time.Time
-
-func (t dotnetTime) MarshalJSON() ([]byte, error) {
-	return []byte(`"` + time.Time(t).Format("2006-01-02T15:04:05.9999999-07:00") + `"`), nil
-}
-
-// dotnetTimePtr converts an optional time for the export shapes, preserving
-// nil so absent values serialise as null.
-func dotnetTimePtr(t *time.Time) *dotnetTime {
-	if t == nil {
-		return nil
-	}
-	dt := dotnetTime(*t)
-	return &dt
-}
 
 // exportUserData is the GDPR data-export contract returned by GET /v1/me/data.
 // It mirrors .NET's ExportUserDataResult, including the nested
@@ -65,10 +45,10 @@ type exportedZonePreference struct {
 }
 
 type exportedSubscription struct {
-	Tier                  string      `json:"tier"`
-	ExpiresAt             *dotnetTime `json:"expiresAt"`
-	OriginalTransactionID *string     `json:"originalTransactionId"`
-	GracePeriodExpiresAt  *dotnetTime `json:"gracePeriodExpiresAt"`
+	Tier                  string               `json:"tier"`
+	ExpiresAt             *platform.DotNetTime `json:"expiresAt"`
+	OriginalTransactionID *string              `json:"originalTransactionId"`
+	GracePeriodExpiresAt  *platform.DotNetTime `json:"gracePeriodExpiresAt"`
 }
 
 // The following child-record shapes match .NET's Exported* records. They have no
@@ -76,45 +56,45 @@ type exportedSubscription struct {
 // renders them as empty arrays; the structs pin the contract for when the
 // sources arrive.
 type exportedWatchZone struct {
-	ID           string     `json:"id"`
-	Name         string     `json:"name"`
-	Latitude     float64    `json:"latitude"`
-	Longitude    float64    `json:"longitude"`
-	RadiusMetres float64    `json:"radiusMetres"`
-	AuthorityID  int        `json:"authorityId"`
-	CreatedAt    dotnetTime `json:"createdAt"`
+	ID           string              `json:"id"`
+	Name         string              `json:"name"`
+	Latitude     float64             `json:"latitude"`
+	Longitude    float64             `json:"longitude"`
+	RadiusMetres float64             `json:"radiusMetres"`
+	AuthorityID  int                 `json:"authorityId"`
+	CreatedAt    platform.DotNetTime `json:"createdAt"`
 }
 
 type exportedNotification struct {
-	ID                     string     `json:"id"`
-	ApplicationName        string     `json:"applicationName"`
-	WatchZoneID            *string    `json:"watchZoneId"`
-	ApplicationAddress     string     `json:"applicationAddress"`
-	ApplicationDescription string     `json:"applicationDescription"`
-	ApplicationType        *string    `json:"applicationType"`
-	AuthorityID            int        `json:"authorityId"`
-	Decision               *string    `json:"decision"`
-	PushSent               bool       `json:"pushSent"`
-	EmailSent              bool       `json:"emailSent"`
-	CreatedAt              dotnetTime `json:"createdAt"`
+	ID                     string              `json:"id"`
+	ApplicationName        string              `json:"applicationName"`
+	WatchZoneID            *string             `json:"watchZoneId"`
+	ApplicationAddress     string              `json:"applicationAddress"`
+	ApplicationDescription string              `json:"applicationDescription"`
+	ApplicationType        *string             `json:"applicationType"`
+	AuthorityID            int                 `json:"authorityId"`
+	Decision               *string             `json:"decision"`
+	PushSent               bool                `json:"pushSent"`
+	EmailSent              bool                `json:"emailSent"`
+	CreatedAt              platform.DotNetTime `json:"createdAt"`
 }
 
 type exportedSavedApplication struct {
-	ApplicationUID string     `json:"applicationUid"`
-	SavedAt        dotnetTime `json:"savedAt"`
+	ApplicationUID string              `json:"applicationUid"`
+	SavedAt        platform.DotNetTime `json:"savedAt"`
 }
 
 type exportedDeviceRegistration struct {
-	Token        string     `json:"token"`
-	Platform     string     `json:"platform"`
-	RegisteredAt dotnetTime `json:"registeredAt"`
+	Token        string              `json:"token"`
+	Platform     string              `json:"platform"`
+	RegisteredAt platform.DotNetTime `json:"registeredAt"`
 }
 
 type exportedOfferCodeRedemption struct {
-	Code         string     `json:"code"`
-	Tier         string     `json:"tier"`
-	DurationDays int        `json:"durationDays"`
-	RedeemedAt   dotnetTime `json:"redeemedAt"`
+	Code         string              `json:"code"`
+	Tier         string              `json:"tier"`
+	DurationDays int                 `json:"durationDays"`
+	RedeemedAt   platform.DotNetTime `json:"redeemedAt"`
 }
 
 // newExportUserData builds the export contract for a profile, with child
@@ -150,9 +130,9 @@ func newExportUserData(p *UserProfile) exportUserData {
 		},
 		Subscription: exportedSubscription{
 			Tier:                  p.Tier.String(),
-			ExpiresAt:             dotnetTimePtr(p.SubscriptionExpiry),
+			ExpiresAt:             platform.DotNetTimePtr(p.SubscriptionExpiry),
 			OriginalTransactionID: p.OriginalTransactionID,
-			GracePeriodExpiresAt:  dotnetTimePtr(p.GracePeriodExpiry),
+			GracePeriodExpiresAt:  platform.DotNetTimePtr(p.GracePeriodExpiry),
 		},
 		WatchZones:           []exportedWatchZone{},
 		Notifications:        []exportedNotification{},


### PR DESCRIPTION
## Summary
`internal/profiles` carried local duplicates of types that already live in shared packages. Collapsed, behaviour-preserving:
- `profiles/cascade.go` local `ChildDeleter` + `RedemptionAnonymiser` interfaces removed; `CascadeDeleters` now uses `erasure.ChildDeleter` / `erasure.RedemptionAnonymiser` (identical method sets).
- `profiles/export.go` local `dotnetTime`/`dotnetTimePtr` removed; export now uses `platform.DotNetTime` / `platform.DotNetTimePtr` (byte-identical `.NET` wire format `2006-01-02T15:04:05.9999999-07:00`).
- `cmd/api/main.go` stale comment updated.

No import cycle (`profiles` already imports `erasure`/`platform`; `erasure` is stdlib-only). Hand-written fakes in `handler_test.go` satisfy the shared interfaces structurally — no test changes needed.

## Test
`go build ./...` OK · `go test -race ./...` → 903 passed (36 packages) · `go vet` clean · `gofmt -l` empty · `golangci-lint` clean.

Bead: tc-hg65