### PR TITLE
refactor(ios): drop dead ServerTierResolving protocol and stored serverTierResolver props (tc-3cij)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -37,7 +37,6 @@ public final class AppCoordinator: ObservableObject {
   let authService: AuthenticationService
   private let subscriptionService: SubscriptionService
   let userProfileRepository: UserProfileRepository
-  private let serverTierResolver: ServerTierResolving
   private let tierResolver: SubscriptionTierResolving
   private let onboardingRepository: OnboardingRepository
   let notificationService: NotificationService
@@ -70,7 +69,6 @@ public final class AppCoordinator: ObservableObject {
     authService: AuthenticationService,
     subscriptionService: SubscriptionService,
     userProfileRepository: UserProfileRepository,
-    serverTierResolver: ServerTierResolving? = nil,
     tierResolver: SubscriptionTierResolving? = nil,
     offlineRepository: OfflineAwareRepository? = nil,
     authorityRepository: ApplicationAuthorityRepository? = nil,
@@ -90,9 +88,7 @@ public final class AppCoordinator: ObservableObject {
     self.authService = authService
     self.subscriptionService = subscriptionService
     self.userProfileRepository = userProfileRepository
-    let server =
-      serverTierResolver ?? ServerTierResolver(userProfileRepository: userProfileRepository)
-    self.serverTierResolver = server
+    let server = ServerTierResolver(userProfileRepository: userProfileRepository)
     self.tierResolver =
       tierResolver
       ?? SubscriptionTierResolver(

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/ServerTierResolver.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/ServerTierResolver.swift
@@ -14,17 +14,7 @@ import os
 ///
 /// Shared by both ``AppCoordinator`` and ``SettingsViewModel`` so the two
 /// tier-resolution paths cannot drift apart again (tc-aza5).
-public protocol ServerTierResolving: Sendable {
-  /// Ensures the server profile exists and returns its tier.
-  ///
-  /// Returns `nil` when the call fails due to a network or server error,
-  /// so callers can distinguish "ensure failed" from "user is genuinely
-  /// on free tier" and apply the appropriate fallback (preserve cached
-  /// tier vs. fall back to JWT/StoreKit).
-  func ensureServerProfileTier() async -> SubscriptionTier?
-}
-
-public final class ServerTierResolver: ServerTierResolving {
+public final class ServerTierResolver: Sendable {
   private static let logger = Logger(
     subsystem: "uk.towncrierapp",
     category: "ServerTierResolver"
@@ -36,6 +26,12 @@ public final class ServerTierResolver: ServerTierResolving {
     self.userProfileRepository = userProfileRepository
   }
 
+  /// Ensures the server profile exists and returns its tier.
+  ///
+  /// Returns `nil` when the call fails due to a network or server error,
+  /// so callers can distinguish "ensure failed" from "user is genuinely
+  /// on free tier" and apply the appropriate fallback (preserve cached
+  /// tier vs. fall back to JWT/StoreKit).
   public func ensureServerProfileTier() async -> SubscriptionTier? {
     do {
       let profile = try await userProfileRepository.create()

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
@@ -26,7 +26,6 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
   private let authService: AuthenticationService
   private let subscriptionService: SubscriptionService
   private let userProfileRepository: UserProfileRepository
-  private let serverTierResolver: ServerTierResolving
   private let tierResolver: SubscriptionTierResolving
   private let appVersionProvider: AppVersionProvider
   private let notificationService: NotificationService
@@ -36,7 +35,6 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
     authService: AuthenticationService,
     subscriptionService: SubscriptionService,
     userProfileRepository: UserProfileRepository,
-    serverTierResolver: ServerTierResolving? = nil,
     tierResolver: SubscriptionTierResolving? = nil,
     appVersionProvider: AppVersionProvider,
     notificationService: NotificationService,
@@ -45,9 +43,7 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
     self.authService = authService
     self.subscriptionService = subscriptionService
     self.userProfileRepository = userProfileRepository
-    let server =
-      serverTierResolver ?? ServerTierResolver(userProfileRepository: userProfileRepository)
-    self.serverTierResolver = server
+    let server = ServerTierResolver(userProfileRepository: userProfileRepository)
     self.tierResolver =
       tierResolver
       ?? SubscriptionTierResolver(


### PR DESCRIPTION
## Summary
`ServerTierResolving` had a single conformer (concrete `ServerTierResolver`) and no test spy. `AppCoordinator` and `SettingsViewModel` stored a `serverTierResolver` property that was assigned in `init` but **never read afterward** (the default-construction closure captures a local `let server`, not the stored prop). Verified unused before removing — behaviour-preserving.

## Changes
- Removed the `serverTierResolver` stored property + init parameter + assignment from `AppCoordinator` and `SettingsViewModel` (construct `ServerTierResolver` inline as the local constant the closure already used).
- Deleted the single-conformer `ServerTierResolving` protocol; concrete `ServerTierResolver` now conforms to `Sendable` directly (still constructed in both inits and covered by `ServerTierResolverTests`).
- No call site passed `serverTierResolver:` explicitly, so zero callers broke.

## Test
`swift build` OK · `swift test` → 1252 tests / 154 suites passed · `swiftlint lint --strict` → 0 violations.

Bead: tc-3cij

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements to dependency management and class architecture. No user-facing changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->