### PR TITLE
refactor(ios): remove unused PlanningApplication.markAsDecided + orphaned Decision enum (tc-3ref)

### DIFF
--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/Decision.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/Decision.swift
@@ -1,6 +1,0 @@
-/// The outcome of a planning decision, mirroring PlanIt's wire vocabulary.
-public enum Decision: Equatable, Sendable {
-  case permitted
-  case conditions
-  case rejected
-}

--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/PlanningApplication.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/PlanningApplication.swift
@@ -44,20 +44,4 @@ public struct PlanningApplication: Equatable, Identifiable, Sendable {
     self.statusHistory = statusHistory
     self.latestUnreadEvent = latestUnreadEvent
   }
-
-  public mutating func markAsDecided(_ decision: Decision, on decisionDate: Date) throws {
-    let decidedStatus: ApplicationStatus
-    switch decision {
-    case .permitted:
-      decidedStatus = .permitted
-    case .conditions:
-      decidedStatus = .conditions
-    case .rejected:
-      decidedStatus = .rejected
-    }
-    guard status == .undecided else {
-      throw DomainError.invalidStatusTransition(from: status, to: decidedStatus)
-    }
-    status = decidedStatus
-  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/PlanningApplicationTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/PlanningApplicationTests.swift
@@ -5,31 +5,6 @@ import Testing
 
 @Suite("PlanningApplication domain logic")
 struct PlanningApplicationTests {
-  @Test func markAsDecided_permitted_updatesStatus() throws {
-    var application = PlanningApplication.pendingReview
-    try application.markAsDecided(.permitted, on: Date())
-    #expect(application.status == .permitted)
-  }
-
-  @Test func markAsDecided_conditions_updatesStatus() throws {
-    var application = PlanningApplication.pendingReview
-    try application.markAsDecided(.conditions, on: Date())
-    #expect(application.status == .conditions)
-  }
-
-  @Test func markAsDecided_rejected_updatesStatus() throws {
-    var application = PlanningApplication.pendingReview
-    try application.markAsDecided(.rejected, on: Date())
-    #expect(application.status == .rejected)
-  }
-
-  @Test func markAsDecided_whenAlreadyPermitted_throwsError() {
-    var application = PlanningApplication.permitted
-    #expect(throws: DomainError.invalidStatusTransition(from: .permitted, to: .rejected)) {
-      try application.markAsDecided(.rejected, on: Date())
-    }
-  }
-
   // MARK: - latestUnreadEvent (tc-1nsa.8)
 
   @Test("latestUnreadEvent defaults to nil when not provided")


### PR DESCRIPTION
## Summary
`PlanningApplication.markAsDecided(_:on:)` was never called in production — only by its own tests. Removed the method and its 4 test cases (kept the 2 unrelated `latestUnreadEvent` tests).

## Scope note (expansion, verified safe)
With `markAsDecided` gone, the `Decision` enum (`Decision.swift`) became fully orphaned: a tree-wide check confirmed the `Decision` **type** was referenced only by its own definition and the deleted method parameter. The `.permitted`/`.conditions`/`.rejected` cases used elsewhere (filters, status pills, decision alerts) are `ApplicationStatus` cases, **not** `Decision` — so deleting `Decision` leaves that vocabulary fully intact. Removed `Decision.swift` too. The passing build is authoritative proof nothing else referenced it. (`DomainError.invalidStatusTransition` left in place — it's woven into exhaustive switches and is harmless.)

## Test
`swift build` OK · `swift test` → 1248 tests / 154 suites passed · `swiftlint lint --strict` → 0 violations. (Independently re-built + re-tested by the orchestrator before merge.)

Bead: tc-3ref