### PR TITLE
refactor(ios): remove dead error-state computed props on 3 list ViewModels (tc-qhps)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -110,19 +110,6 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     filteredApplications.isEmpty && error == nil && !isLoading
   }
 
-  public var isNetworkError: Bool {
-    error == .networkUnavailable
-  }
-
-  public var isServerError: Bool {
-    if case .serverError = error { return true }
-    return false
-  }
-
-  public var isSessionExpired: Bool {
-    error == .sessionExpired
-  }
-
   public init(
     repository: PlanningApplicationRepository,
     zone: WatchZone,

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
@@ -53,19 +53,6 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
     zones.count > 1
   }
 
-  public var isNetworkError: Bool {
-    error == .networkUnavailable
-  }
-
-  public var isServerError: Bool {
-    if case .serverError = error { return true }
-    return false
-  }
-
-  public var isSessionExpired: Bool {
-    error == .sessionExpired
-  }
-
   var onApplicationSelected: ((PlanningApplicationId) -> Void)?
 
   public init(

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/SavedApplicationList/SavedApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/SavedApplicationList/SavedApplicationListViewModel.swift
@@ -40,19 +40,6 @@ public final class SavedApplicationListViewModel: ObservableObject, ErrorHandlin
     filteredApplications.isEmpty && error == nil && !isLoading
   }
 
-  public var isNetworkError: Bool {
-    error == .networkUnavailable
-  }
-
-  public var isServerError: Bool {
-    if case .serverError = error { return true }
-    return false
-  }
-
-  public var isSessionExpired: Bool {
-    error == .sessionExpired
-  }
-
   public init(savedApplicationRepository: SavedApplicationRepository) {
     self.savedApplicationRepository = savedApplicationRepository
   }

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTests.swift
@@ -121,66 +121,6 @@ struct ApplicationListViewModelTests {
     #expect(sut.filteredApplications.isEmpty)
   }
 
-  @Test func isServerError_trueForServerError() async throws {
-    let (sut, spy) = try makeSUT()
-    spy.fetchApplicationsResult = .failure(
-      DomainError.serverError(statusCode: 500, message: nil)
-    )
-
-    await sut.loadApplications()
-
-    #expect(sut.isServerError)
-    #expect(!sut.isNetworkError)
-  }
-
-  @Test func isServerError_falseForNetworkError() async throws {
-    let (sut, spy) = try makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
-
-    await sut.loadApplications()
-
-    #expect(!sut.isServerError)
-    #expect(sut.isNetworkError)
-  }
-
-  // MARK: - Error Classification
-
-  @Test func isNetworkError_trueForNetworkUnavailable() async throws {
-    let (sut, spy) = try makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
-
-    await sut.loadApplications()
-
-    #expect(sut.isNetworkError)
-  }
-
-  @Test func isNetworkError_falseForOtherErrors() async throws {
-    let (sut, spy) = try makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.unexpected("Server error"))
-
-    await sut.loadApplications()
-
-    #expect(!sut.isNetworkError)
-  }
-
-  @Test func isSessionExpired_trueForSessionExpired() async throws {
-    let (sut, spy) = try makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.sessionExpired)
-
-    await sut.loadApplications()
-
-    #expect(sut.isSessionExpired)
-  }
-
-  @Test func isSessionExpired_falseForOtherErrors() async throws {
-    let (sut, spy) = try makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
-
-    await sut.loadApplications()
-
-    #expect(!sut.isSessionExpired)
-  }
-
   // MARK: - Zone Resolution
 
   @Test func loadApplications_withWatchZoneRepository_resolvesFirstZoneAndFetches() async throws {

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
@@ -180,66 +180,6 @@ struct MapViewModelTests {
     #expect(!sut.isEmpty)
   }
 
-  // MARK: - Error Classification
-
-  @Test func isNetworkError_trueForNetworkUnavailable() async {
-    let (sut, spy, _) = makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
-
-    await sut.loadApplications()
-
-    #expect(sut.isNetworkError)
-  }
-
-  @Test func isNetworkError_falseForOtherErrors() async {
-    let (sut, spy, _) = makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.unexpected("Server error"))
-
-    await sut.loadApplications()
-
-    #expect(!sut.isNetworkError)
-  }
-
-  @Test func isServerError_trueForServerError() async {
-    let (sut, spy, _) = makeSUT()
-    spy.fetchApplicationsResult = .failure(
-      DomainError.serverError(statusCode: 500, message: nil)
-    )
-
-    await sut.loadApplications()
-
-    #expect(sut.isServerError)
-    #expect(!sut.isNetworkError)
-  }
-
-  @Test func isServerError_falseForNetworkError() async {
-    let (sut, spy, _) = makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
-
-    await sut.loadApplications()
-
-    #expect(!sut.isServerError)
-    #expect(sut.isNetworkError)
-  }
-
-  @Test func isSessionExpired_trueForSessionExpired() async {
-    let (sut, spy, _) = makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.sessionExpired)
-
-    await sut.loadApplications()
-
-    #expect(sut.isSessionExpired)
-  }
-
-  @Test func isSessionExpired_falseForOtherErrors() async {
-    let (sut, spy, _) = makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
-
-    await sut.loadApplications()
-
-    #expect(!sut.isSessionExpired)
-  }
-
   // MARK: - Zone-based loading
 
   @Test func loadApplications_fetchesBySelectedZone() async throws {


### PR DESCRIPTION
## Summary
`isNetworkError` / `isServerError` / `isSessionExpired` were computed from `error` on `ApplicationListViewModel`, `MapViewModel`, and `SavedApplicationListViewModel` but never read by any View (the Views inspect `viewModel.error` directly). Verified all three unread across the source tree (remaining grep hits are the vendored Auth0 SDK's unrelated `isNetworkError`). Deleted the 9 props + 12 orphaned tests; the underlying `error` stored property is untouched.

## Test
`swift build` OK · `swift test` → 1211 tests passed (−12 deleted) · `swiftlint lint --strict` → 0 violations.

Bead: tc-qhps