### PR TITLE
refactor(ios): extract shared FilterChipView from 3 duplicated filterChip helpers (tc-jc4z)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/FilterChipView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/FilterChipView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+/// A compact, tappable capsule chip used in horizontal filter rows.
+///
+/// Purely presentational: it renders a label in a capsule whose fill, text
+/// colour, and border reflect the `isSelected` flag, and forwards taps to
+/// `onTap`. The caller owns all selection logic — `FilterChipView` never
+/// inspects a view model — so the same chip can express different selection
+/// rules at each call site (e.g. the application list ANDs in an
+/// "unread filter inactive" guard) without changing its appearance.
+///
+/// Follows the design language: `tcCaptionEmphasis` typography, `tcAmber`
+/// for the selected fill, `tcSurface` for the unselected fill, and a
+/// `tcBorder` outline that hides when selected.
+///
+/// Usage:
+/// ```swift
+/// FilterChipView(
+///     label: "Pending",
+///     isSelected: viewModel.selectedStatusFilter == .undecided
+/// ) {
+///     viewModel.selectedStatusFilter = .undecided
+/// }
+/// ```
+public struct FilterChipView: View {
+  private let label: String
+  private let isSelected: Bool
+  let onTap: () -> Void
+
+  public init(
+    label: String,
+    isSelected: Bool,
+    onTap: @escaping () -> Void
+  ) {
+    self.label = label
+    self.isSelected = isSelected
+    self.onTap = onTap
+  }
+
+  public var body: some View {
+    Text(label)
+      .font(TCTypography.captionEmphasis)
+      .foregroundStyle(isSelected ? Color.tcTextOnAccent : Color.tcTextPrimary)
+      .padding(.horizontal, TCSpacing.small)
+      .padding(.vertical, TCSpacing.extraSmall)
+      .background(isSelected ? Color.tcAmber : Color.tcSurface)
+      .clipShape(Capsule())
+      .overlay(
+        Capsule()
+          .stroke(Color.tcBorder, lineWidth: isSelected ? 0 : 1)
+      )
+      .contentShape(Capsule())
+      .onTapGesture {
+        onTap()
+      }
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
@@ -203,22 +203,13 @@ public struct ApplicationListView: View {
   // MARK: - Filter Chips
 
   private func filterChip(label: String, status: ApplicationStatus?) -> some View {
+    // The extra `!unreadOnly` guard stays here, not in the shared
+    // `FilterChipView`: when the Unread chip is active, every status chip
+    // must read as unselected even if `selectedStatusFilter` still matches.
     let isSelected = !viewModel.unreadOnly && viewModel.selectedStatusFilter == status
-    return Text(label)
-      .font(TCTypography.captionEmphasis)
-      .foregroundStyle(isSelected ? Color.tcTextOnAccent : Color.tcTextPrimary)
-      .padding(.horizontal, TCSpacing.small)
-      .padding(.vertical, TCSpacing.extraSmall)
-      .background(isSelected ? Color.tcAmber : Color.tcSurface)
-      .clipShape(Capsule())
-      .overlay(
-        Capsule()
-          .stroke(Color.tcBorder, lineWidth: isSelected ? 0 : 1)
-      )
-      .contentShape(Capsule())
-      .onTapGesture {
-        viewModel.selectedStatusFilter = status
-      }
+    return FilterChipView(label: label, isSelected: isSelected) {
+      viewModel.selectedStatusFilter = status
+    }
   }
 
   /// The Unread chip lives at the head of the chip group. Selecting it

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
@@ -140,22 +140,9 @@ public struct MapView: View {
   }
 
   private func filterChip(label: String, status: ApplicationStatus?) -> some View {
-    let isSelected = viewModel.selectedStatusFilter == status
-    return Text(label)
-      .font(TCTypography.captionEmphasis)
-      .foregroundStyle(isSelected ? Color.tcTextOnAccent : Color.tcTextPrimary)
-      .padding(.horizontal, TCSpacing.small)
-      .padding(.vertical, TCSpacing.extraSmall)
-      .background(isSelected ? Color.tcAmber : Color.tcSurface)
-      .clipShape(Capsule())
-      .overlay(
-        Capsule()
-          .stroke(Color.tcBorder, lineWidth: isSelected ? 0 : 1)
-      )
-      .contentShape(Capsule())
-      .onTapGesture {
-        viewModel.selectedStatusFilter = status
-      }
+    FilterChipView(label: label, isSelected: viewModel.selectedStatusFilter == status) {
+      viewModel.selectedStatusFilter = status
+    }
   }
 
   // MARK: - Map Body

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/SavedApplicationList/SavedApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/SavedApplicationList/SavedApplicationListView.swift
@@ -56,22 +56,9 @@ public struct SavedApplicationListView: View {
   }
 
   private func filterChip(label: String, status: ApplicationStatus?) -> some View {
-    let isSelected = viewModel.selectedStatusFilter == status
-    return Text(label)
-      .font(TCTypography.captionEmphasis)
-      .foregroundStyle(isSelected ? Color.tcTextOnAccent : Color.tcTextPrimary)
-      .padding(.horizontal, TCSpacing.small)
-      .padding(.vertical, TCSpacing.extraSmall)
-      .background(isSelected ? Color.tcAmber : Color.tcSurface)
-      .clipShape(Capsule())
-      .overlay(
-        Capsule()
-          .stroke(Color.tcBorder, lineWidth: isSelected ? 0 : 1)
-      )
-      .contentShape(Capsule())
-      .onTapGesture {
-        viewModel.selectedStatusFilter = status
-      }
+    FilterChipView(label: label, isSelected: viewModel.selectedStatusFilter == status) {
+      viewModel.selectedStatusFilter = status
+    }
   }
 
   // MARK: - Content Rows

--- a/mobile/ios/town-crier-tests/Sources/Features/FilterChipViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/FilterChipViewTests.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import Testing
+
+@testable import TownCrierPresentation
+
+@Suite("FilterChipView")
+@MainActor
+struct FilterChipViewTests {
+
+  @Test func init_selected_rendersWithoutCrashing() {
+    let sut = FilterChipView(label: "All", isSelected: true) {}
+    _ = sut.body
+  }
+
+  @Test func init_unselected_rendersWithoutCrashing() {
+    let sut = FilterChipView(label: "Pending", isSelected: false) {}
+    _ = sut.body
+  }
+
+  @Test func onTap_invokesClosure() {
+    var tapped = false
+    let sut = FilterChipView(label: "Refused", isSelected: false) { tapped = true }
+    sut.onTap()
+    #expect(tapped)
+  }
+}


### PR DESCRIPTION
## Summary
An identical `filterChip(label:status:)` SwiftUI helper was duplicated in `MapView`, `SavedApplicationListView`, and `ApplicationListView`. Extracted one pure presentational `FilterChipView` into the DesignSystem (matching `UpgradeBadgeView` conventions + design-language tokens). Visual output is byte-identical.

- `MapView` / `SavedApplicationListView` copies were byte-identical.
- `ApplicationListView` differs only by an extra `!unreadOnly` guard in its `isSelected` expression — kept at the **call site** (folded into the `isSelected` arg), so the shared view stays purely presentational and the unread-filter interaction is unchanged.
- Each screen keeps a thin private wrapper delegating to the shared view, keeping per-screen selection logic local. ~35 lines of duplication removed.

## Test
`swift build` OK · `swift test` → 1214 tests / 151 suites passed (new `FilterChipView` render tests included) · `swiftlint lint --strict` → 0 violations. (Independently re-built + re-tested by the orchestrator.)

Bead: tc-jc4z