### PR TITLE
refactor(ios): extract shared ZoneChipView from 2 duplicated zoneChip helpers (tc-fzpc)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ZoneChipView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ZoneChipView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// A compact, tappable capsule chip used in horizontal watch-zone picker rows.
+///
+/// Purely presentational: it renders a label in a capsule whose fill, text
+/// colour, and border reflect the `isSelected` flag, and forwards taps to
+/// `onTap`. The caller owns all selection logic — `ZoneChipView` never
+/// inspects a view model — so each call site can compute selection from its
+/// own state (e.g. `zone.id == viewModel.selectedZone?.id`) and run its own
+/// async tap action (e.g. `await viewModel.selectZone(zone)`) without
+/// changing the chip's appearance.
+///
+/// Visually identical to `FilterChipView`: `tcCaptionEmphasis` typography,
+/// `tcAmber` for the selected fill, `tcSurface` for the unselected fill, and
+/// a `tcBorder` outline that hides when selected.
+///
+/// Usage:
+/// ```swift
+/// ZoneChipView(
+///     label: zone.name,
+///     isSelected: zone.id == viewModel.selectedZone?.id
+/// ) {
+///     Task { await viewModel.selectZone(zone) }
+/// }
+/// ```
+public struct ZoneChipView: View {
+  private let label: String
+  private let isSelected: Bool
+  let onTap: () -> Void
+
+  public init(
+    label: String,
+    isSelected: Bool,
+    onTap: @escaping () -> Void
+  ) {
+    self.label = label
+    self.isSelected = isSelected
+    self.onTap = onTap
+  }
+
+  public var body: some View {
+    Text(label)
+      .font(TCTypography.captionEmphasis)
+      .foregroundStyle(isSelected ? Color.tcTextOnAccent : Color.tcTextPrimary)
+      .padding(.horizontal, TCSpacing.small)
+      .padding(.vertical, TCSpacing.extraSmall)
+      .background(isSelected ? Color.tcAmber : Color.tcSurface)
+      .clipShape(Capsule())
+      .overlay(
+        Capsule()
+          .stroke(Color.tcBorder, lineWidth: isSelected ? 0 : 1)
+      )
+      .contentShape(Capsule())
+      .onTapGesture {
+        onTap()
+      }
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
@@ -105,7 +105,14 @@ public struct ApplicationListView: View {
       ScrollView(.horizontal, showsIndicators: false) {
         HStack(spacing: TCSpacing.small) {
           ForEach(viewModel.zones) { zone in
-            zoneChip(zone: zone, isSelected: zone.id == viewModel.selectedZone?.id)
+            ZoneChipView(
+              label: zone.name,
+              isSelected: zone.id == viewModel.selectedZone?.id
+            ) {
+              Task {
+                await viewModel.selectZone(zone)
+              }
+            }
           }
         }
         .padding(.horizontal, TCSpacing.medium)
@@ -176,28 +183,6 @@ public struct ApplicationListView: View {
           }
       }
     }
-  }
-
-  // MARK: - Zone Chip
-
-  private func zoneChip(zone: WatchZone, isSelected: Bool) -> some View {
-    Text(zone.name)
-      .font(TCTypography.captionEmphasis)
-      .foregroundStyle(isSelected ? Color.tcTextOnAccent : Color.tcTextPrimary)
-      .padding(.horizontal, TCSpacing.small)
-      .padding(.vertical, TCSpacing.extraSmall)
-      .background(isSelected ? Color.tcAmber : Color.tcSurface)
-      .clipShape(Capsule())
-      .overlay(
-        Capsule()
-          .stroke(Color.tcBorder, lineWidth: isSelected ? 0 : 1)
-      )
-      .contentShape(Capsule())
-      .onTapGesture {
-        Task {
-          await viewModel.selectZone(zone)
-        }
-      }
   }
 
   // MARK: - Filter Chips

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
@@ -91,33 +91,20 @@ public struct MapView: View {
     ScrollView(.horizontal, showsIndicators: false) {
       HStack(spacing: TCSpacing.small) {
         ForEach(viewModel.zones) { zone in
-          zoneChip(zone: zone, isSelected: zone.id == viewModel.selectedZone?.id)
+          ZoneChipView(
+            label: zone.name,
+            isSelected: zone.id == viewModel.selectedZone?.id
+          ) {
+            Task {
+              await viewModel.selectZone(zone)
+            }
+          }
         }
       }
       .padding(.horizontal, TCSpacing.medium)
       .padding(.vertical, TCSpacing.small)
     }
     .background(Color.tcBackground)
-  }
-
-  private func zoneChip(zone: WatchZone, isSelected: Bool) -> some View {
-    Text(zone.name)
-      .font(TCTypography.captionEmphasis)
-      .foregroundStyle(isSelected ? Color.tcTextOnAccent : Color.tcTextPrimary)
-      .padding(.horizontal, TCSpacing.small)
-      .padding(.vertical, TCSpacing.extraSmall)
-      .background(isSelected ? Color.tcAmber : Color.tcSurface)
-      .clipShape(Capsule())
-      .overlay(
-        Capsule()
-          .stroke(Color.tcBorder, lineWidth: isSelected ? 0 : 1)
-      )
-      .contentShape(Capsule())
-      .onTapGesture {
-        Task {
-          await viewModel.selectZone(zone)
-        }
-      }
   }
 
   // MARK: - Filter Section

--- a/mobile/ios/town-crier-tests/Sources/Features/ZoneChipViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ZoneChipViewTests.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import Testing
+
+@testable import TownCrierPresentation
+
+@Suite("ZoneChipView")
+@MainActor
+struct ZoneChipViewTests {
+
+  @Test func init_selected_rendersWithoutCrashing() {
+    let sut = ZoneChipView(label: "Mill Road", isSelected: true) {}
+    _ = sut.body
+  }
+
+  @Test func init_unselected_rendersWithoutCrashing() {
+    let sut = ZoneChipView(label: "City Centre", isSelected: false) {}
+    _ = sut.body
+  }
+
+  @Test func onTap_invokesClosure() {
+    var tapped = false
+    let sut = ZoneChipView(label: "Trumpington", isSelected: false) { tapped = true }
+    sut.onTap()
+    #expect(tapped)
+  }
+}


### PR DESCRIPTION
## Summary
An identical `zoneChip(zone:isSelected:)` SwiftUI helper was duplicated in `ApplicationListView` and `MapView` (verified byte-identical visual output). Extracted one pure presentational `ZoneChipView` into the DesignSystem, mirroring the `FilterChipView` (#497) conventions + design-language tokens. The view-model-specific tap action (`selectZone`) is kept at each call site; the shared view takes `label`/`isSelected`/`onTap`.

## Test
`swift build` OK · `swift test` → 1217 tests / 152 suites passed (new `ZoneChipViewTests` included) · `swiftlint lint --strict` → 0 violations.

Bead: tc-fzpc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new zone selection chip component that provides visual feedback when zones are selected or unselected.

* **Tests**
  * Added comprehensive test coverage for the zone chip component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->