### PR TITLE
ci: run pr-gate on merge_group events to enable a merge queue (tc-laia)

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,9 +1,10 @@
-# Monorepo change detection for push and pull_request events.
+# Monorepo change detection for push, pull_request, and merge_group events.
 # Outputs boolean flags for each component category that changed.
 #
 # Modes:
-#   push — compares HEAD~1..HEAD (squash-merge assumed)
-#   pr   — compares origin/<base-ref>...HEAD
+#   push        — compares HEAD~1..HEAD (squash-merge assumed)
+#   pr          — compares origin/<base-ref>...HEAD
+#   merge_group — compares <base-ref>...HEAD against a raw base SHA (no origin/ prefix)
 #
 # Trigger files:
 #   Workflow files (e.g., cd-dev.yml, pr-gate.yml) can force categories
@@ -14,10 +15,10 @@ description: Monorepo change detection with push/pr modes
 
 inputs:
   mode:
-    description: "Detection mode: 'push' (HEAD~1..HEAD) or 'pr' (origin/base...HEAD)"
+    description: "Detection mode: 'push' (HEAD~1..HEAD), 'pr' (origin/base...HEAD), or 'merge_group' (base-sha...HEAD)"
     required: true
   base-ref:
-    description: "Base branch for PR mode (e.g., github.base_ref). Ignored in push mode."
+    description: "Base ref for PR mode (e.g., github.base_ref) or raw base SHA for merge_group mode. Ignored in push mode."
     required: false
     default: ""
   categories:
@@ -65,8 +66,10 @@ runs:
           CHANGED=$(git diff --name-only HEAD~1 HEAD)
         elif [[ "${{ inputs.mode }}" == "pr" ]]; then
           CHANGED=$(git diff --name-only origin/${{ inputs.base-ref }}...HEAD)
+        elif [[ "${{ inputs.mode }}" == "merge_group" ]]; then
+          CHANGED=$(git diff --name-only "${{ inputs.base-ref }}...HEAD")
         else
-          echo "::error::Unknown mode '${{ inputs.mode }}'. Use 'push' or 'pr'."
+          echo "::error::Unknown mode '${{ inputs.mode }}'. Use 'push', 'pr', or 'merge_group'."
           exit 1
         fi
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -18,6 +18,7 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, closed]
+  merge_group:
 
 concurrency:
   group: pr-gate-${{ github.ref }}
@@ -34,7 +35,7 @@ env:
 jobs:
   changes:
     name: Detect changes
-    if: github.event.action != 'closed'
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     outputs:
@@ -51,8 +52,8 @@ jobs:
         id: detect
         uses: ./.github/actions/detect-changes
         with:
-          mode: pr
-          base-ref: ${{ github.base_ref }}
+          mode: ${{ github.event_name == 'merge_group' && 'merge_group' || 'pr' }}
+          base-ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.base_ref }}
           categories: cli,ios,web,infra,go
           trigger-files: |
             .github/workflows/pr-gate.yml:cli,ios,web,infra,go
@@ -278,6 +279,7 @@ jobs:
           pulumi preview --non-interactive 2>&1 | tee /tmp/pulumi-preview.txt
 
       - name: Comment preview on PR
+        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -290,7 +292,7 @@ jobs:
   gate:
     name: PR Gate
     needs: [go-lint, go-test, cli-format, cli-build-test, ios-lint, ios-build-test, web-lint, web-build-test, infra-preview]
-    if: always() && github.event.action != 'closed'
+    if: always() && (github.event_name != 'pull_request' || github.event.action != 'closed')
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:


### PR DESCRIPTION
## Summary
Prereq for enabling a GitHub **merge queue** on `main`: CI must report the required `PR Gate` check on `merge_group` events, or the queue stalls forever. This teaches `pr-gate.yml` + the `detect-changes` action to handle `merge_group`.

## Changes (`.github/` only)
- `detect-changes/action.yml`: new `merge_group` mode → `git diff --name-only <base-sha>...HEAD` (raw SHA, no `origin/` prefix). `push`/`pr` unchanged.
- `pr-gate.yml`:
  - add `merge_group:` trigger
  - `changes` job: detect-changes inputs conditional — `mode`/`base-ref` use `github.event.merge_group.base_sha` on merge_group, else PR base
  - guard `infra-preview` "Comment preview on PR" step with `if: github.event_name == 'pull_request'` (no PR number on merge_group)
  - make `changes`/`gate` `if:` robust (`github.event.action` is unset on merge_group)

## Safety
- **Dormant until the queue is enabled** — no `merge_group` events fire without a queue.
- The `pull_request` path is behaviorally identical (the `if:` rewrites collapse to the originals for PR events; verified).
- Required check name `PR Gate` left byte-identical so branch protection keeps matching.
- `actionlint` clean (one pre-existing SC2016 info note, unchanged).

Follow-up (orchestrator, after merge): add the `merge_queue` rule to ruleset 14462306 + smoke-test, revert the rule if merges stall.

Bead: tc-laia

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended CI/CD workflows to support GitHub merge queue event handling alongside pull request workflows.
  * Enhanced change detection mechanisms to accurately identify file modifications during merge queue operations.
  * Refined automated workflow gating logic for proper status check evaluation across merge queue and pull request environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->