### PR TITLE
feat(ios): surface Privacy Policy + Terms of Use links on paywall (tc-lg66)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionView.swift
@@ -23,6 +23,11 @@ public struct SubscriptionView: View {
           productsSection
           restoreSection
         }
+
+        // Always visible — App Store Guideline 3.1.2(c) requires functional
+        // Privacy Policy and Terms of Use links on the paywall itself, even
+        // when products fail to load.
+        legalLinksFooter
       }
       .padding(.horizontal, TCSpacing.medium)
       .padding(.top, TCSpacing.extraLarge)
@@ -30,6 +35,11 @@ public struct SubscriptionView: View {
     }
     .background(Color.tcBackground)
     .task { await viewModel.loadProducts() }
+    .sheet(item: $viewModel.presentedLegalDocument) { documentType in
+      NavigationStack {
+        LegalDocumentView(viewModel: LegalDocumentViewModel(documentType: documentType))
+      }
+    }
   }
 
   // MARK: - Header
@@ -152,6 +162,29 @@ public struct SubscriptionView: View {
     }
     .disabled(viewModel.isRestoring)
     .padding(.top, TCSpacing.small)
+  }
+
+  // MARK: - Legal
+
+  private var legalLinksFooter: some View {
+    HStack(spacing: TCSpacing.extraSmall) {
+      legalLink("Privacy Policy") { viewModel.showLegalDocument(.privacyPolicy) }
+
+      Text("·")
+        .font(TCTypography.caption)
+        .foregroundStyle(Color.tcTextTertiary)
+
+      legalLink("Terms of Use") { viewModel.showLegalDocument(.termsOfService) }
+    }
+    .frame(minHeight: 44)
+  }
+
+  private func legalLink(_ title: String, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+      Text(title)
+        .font(TCTypography.caption)
+        .foregroundStyle(Color.tcAmber)
+    }
   }
 
   // MARK: - Error

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionViewModel.swift
@@ -15,6 +15,12 @@ public final class SubscriptionViewModel: ObservableObject, ErrorHandlingViewMod
   @Published public internal(set) var error: DomainError?
   @Published public private(set) var currentEntitlement: SubscriptionEntitlement?
 
+  /// The legal document currently presented over the paywall, if any.
+  /// Drives a `.sheet(item:)` local to `SubscriptionView` so the Privacy Policy
+  /// and Terms of Use links required by App Store Guideline 3.1.2(c) open without
+  /// routing through the root coordinator (which already owns the paywall sheet).
+  @Published public var presentedLegalDocument: LegalDocumentType?
+
   private let subscriptionService: SubscriptionService
   private let authenticationService: AuthenticationService
 
@@ -77,6 +83,11 @@ public final class SubscriptionViewModel: ObservableObject, ErrorHandlingViewMod
       handleError(error) { .restoreFailed($0) }
     }
     isRestoring = false
+  }
+
+  /// Presents the given legal document (Privacy Policy or Terms of Use) over the paywall.
+  public func showLegalDocument(_ documentType: LegalDocumentType) {
+    presentedLegalDocument = documentType
   }
 
   // MARK: - Token refresh

--- a/mobile/ios/town-crier-tests/Sources/Features/SubscriptionViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SubscriptionViewModelTests.swift
@@ -215,6 +215,29 @@ struct SubscriptionViewModelTests {
     #expect(!disclosure.contains("free trial"))
   }
 
+  // MARK: - Legal documents
+
+  @Test func init_hasNoPresentedLegalDocument() {
+    let (sut, _, _) = makeSUT()
+    #expect(sut.presentedLegalDocument == nil)
+  }
+
+  @Test func showLegalDocument_presentsPrivacyPolicy() {
+    let (sut, _, _) = makeSUT()
+
+    sut.showLegalDocument(.privacyPolicy)
+
+    #expect(sut.presentedLegalDocument == .privacyPolicy)
+  }
+
+  @Test func showLegalDocument_presentsTermsOfService() {
+    let (sut, _, _) = makeSUT()
+
+    sut.showLegalDocument(.termsOfService)
+
+    #expect(sut.presentedLegalDocument == .termsOfService)
+  }
+
   // MARK: - Computed properties
 
   @Test func isSubscribed_returnsFalse_whenNoEntitlement() {

--- a/mobile/ios/town-crier-tests/Sources/Features/SubscriptionViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SubscriptionViewTests.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@Suite("SubscriptionView")
+@MainActor
+struct SubscriptionViewTests {
+  private func makeViewModel() -> SubscriptionViewModel {
+    SubscriptionViewModel(
+      subscriptionService: SpySubscriptionService(),
+      authenticationService: SpyAuthenticationService()
+    )
+  }
+
+  @Test func body_rendersWithoutCrashing() {
+    let sut = SubscriptionView(viewModel: makeViewModel())
+    _ = sut.body
+  }
+}


### PR DESCRIPTION
## Changes
- Add an always-visible legal links footer (Privacy Policy · Terms of Use) to the iOS subscription paywall (`SubscriptionView`), satisfying App Store Guideline 3.1.2(c). Submission v1.0 build 28 was rejected on 2026-06-17 because the paywall surfaced no legal links.
- Drive presentation from `SubscriptionViewModel.presentedLegalDocument` (`+ showLegalDocument(_:)`), opening the existing `LegalDocumentView` via a `.sheet(item:)` anchored to the paywall itself — not the root coordinator, which already owns the paywall sheet (avoids the root-anchor sheet conflict).
- Footer renders even when products fail to load, so the links are always reachable for review.
- Tests: 3 `SubscriptionViewModel` tests (nil default, presents privacy, presents terms) + a `SubscriptionView` body-render test. Full suite (1190) green; SwiftLint `--strict` clean; swift-format clean.

Scope is iOS code only. Sibling rejection items tracked separately: 4.8 Sign in with Apple (Auth0 config) and 3.1.2(c) ASC EULA metadata.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Legal links footer (Privacy Policy and Terms of Use) now always accessible on the subscription screen, even during loading or error states.
  * Users can view legal documents directly from the subscription screen via dedicated legal links.

* **Tests**
  * Added comprehensive test coverage for legal documents presentation.
  * Added test suite for subscription screen rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->