### PR TITLE
refactor(infra): simplify dashboard tiles, dead guard, stale comments

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -279,93 +279,90 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		tags:                        tags,
 	}
 
-	// Container App (Go API) — created for BOTH dev and prod. The placeholder quickstart
-	// image listens on 80, so the first revision stays unhealthy until CD pushes the real
-	// town-crier-api-go image.
-	if env == "dev" || env == "prod" {
-		configuration := &app.ConfigurationArgs{
-			// Single in prod; Multiple in dev (pr-gate stages per-PR revisions).
-			ActiveRevisionsMode: pulumi.String(string(app.ActiveRevisionsModeMultiple)),
-			Ingress: &app.IngressArgs{
-				External:      pulumi.Bool(true),
-				TargetPort:    pulumi.Int(8080),
-				Transport:     pulumi.String(string(app.IngressTransportMethodHttp)),
-				CustomDomains: goApiCustomDomains,
+	// Container App (Go API), created for both dev and prod — the only environment stacks
+	// (shared is handled separately). The placeholder quickstart image listens on 80, so the
+	// first revision stays unhealthy until CD pushes the real town-crier-api-go image.
+	configuration := &app.ConfigurationArgs{
+		// Single in prod; Multiple in dev (pr-gate stages per-PR revisions).
+		ActiveRevisionsMode: pulumi.String(string(app.ActiveRevisionsModeMultiple)),
+		Ingress: &app.IngressArgs{
+			External:      pulumi.Bool(true),
+			TargetPort:    pulumi.Int(8080),
+			Transport:     pulumi.String(string(app.IngressTransportMethodHttp)),
+			CustomDomains: goApiCustomDomains,
+		},
+		Registries: app.RegistryCredentialsArray{
+			&app.RegistryCredentialsArgs{
+				Server:   acrLoginServer,
+				Identity: acrPullIdentityID,
 			},
-			Registries: app.RegistryCredentialsArray{
-				&app.RegistryCredentialsArgs{
-					Server:   acrLoginServer,
-					Identity: acrPullIdentityID,
-				},
-			},
-			Secrets: app.SecretArray{
-				&app.SecretArgs{Name: pulumi.String("auth0-m2m-client-id"), Value: auth0M2mClientID},
-				&app.SecretArgs{Name: pulumi.String("auth0-m2m-client-secret"), Value: auth0M2mClientSecret},
-				&app.SecretArgs{Name: pulumi.String("auto-grant-pro-domains"), Value: autoGrantProDomains},
-				// Same admin key as the .NET app so the Go X-Admin-Key gate accepts
-				// identical requests (tc-52t6).
-				&app.SecretArgs{Name: pulumi.String("admin-api-key"), Value: adminAPIKey},
-			},
-		}
-		minReplicas := 0
-		if env == "prod" {
-			configuration.ActiveRevisionsMode = pulumi.String(string(app.ActiveRevisionsModeSingle))
-			minReplicas = 1
-		} else {
-			// MaxInactiveRevisions only applies to Multiple mode (caps ACR storage growth
-			// from staged PR revisions); omit it under Single.
-			configuration.MaxInactiveRevisions = pulumi.Int(5)
-		}
+		},
+		Secrets: app.SecretArray{
+			&app.SecretArgs{Name: pulumi.String("auth0-m2m-client-id"), Value: auth0M2mClientID},
+			&app.SecretArgs{Name: pulumi.String("auth0-m2m-client-secret"), Value: auth0M2mClientSecret},
+			&app.SecretArgs{Name: pulumi.String("auto-grant-pro-domains"), Value: autoGrantProDomains},
+			// Admin key the Go X-Admin-Key gate validates for /v1/admin requests (tc-52t6).
+			&app.SecretArgs{Name: pulumi.String("admin-api-key"), Value: adminAPIKey},
+		},
+	}
+	minReplicas := 0
+	if env == "prod" {
+		configuration.ActiveRevisionsMode = pulumi.String(string(app.ActiveRevisionsModeSingle))
+		minReplicas = 1
+	} else {
+		// MaxInactiveRevisions only applies to Multiple mode (caps ACR storage growth
+		// from staged PR revisions); omit it under Single.
+		configuration.MaxInactiveRevisions = pulumi.Int(5)
+	}
 
-		_, err = app.NewContainerApp(ctx, fmt.Sprintf("ca-town-crier-api-go-%s", env), &app.ContainerAppArgs{
-			ContainerAppName:     pulumi.String(fmt.Sprintf("ca-town-crier-api-go-%s", env)),
-			ResourceGroupName:    resourceGroup.Name,
-			ManagedEnvironmentId: containerAppsEnvironmentID,
-			Configuration:        configuration,
-			Identity: &app.ManagedServiceIdentityArgs{
-				Type: pulumi.String(string(app.ManagedServiceIdentityTypeUserAssigned)),
-				UserAssignedIdentities: pulumi.StringArray{
-					acrPullIdentityID,
-					cosmosDataIdentityID,
-				},
+	_, err = app.NewContainerApp(ctx, fmt.Sprintf("ca-town-crier-api-go-%s", env), &app.ContainerAppArgs{
+		ContainerAppName:     pulumi.String(fmt.Sprintf("ca-town-crier-api-go-%s", env)),
+		ResourceGroupName:    resourceGroup.Name,
+		ManagedEnvironmentId: containerAppsEnvironmentID,
+		Configuration:        configuration,
+		Identity: &app.ManagedServiceIdentityArgs{
+			Type: pulumi.String(string(app.ManagedServiceIdentityTypeUserAssigned)),
+			UserAssignedIdentities: pulumi.StringArray{
+				acrPullIdentityID,
+				cosmosDataIdentityID,
 			},
-			Template: &app.TemplateArgs{
-				Containers: app.ContainerArray{
-					&app.ContainerArgs{
-						Name:  pulumi.String("api-go"),
-						Image: pulumi.String("mcr.microsoft.com/k8se/quickstart:latest"),
-						Resources: &app.ContainerResourcesArgs{
-							Cpu:    pulumi.Float64(containerCpu),
-							Memory: pulumi.String(containerMemory),
-						},
-						Env: app.EnvironmentVarArray{
-							app.EnvironmentVarArgs{Name: pulumi.String("OTEL_SERVICE_NAME"), Value: pulumi.String("town-crier-api-go")},
-							// Read by the in-process Azure Monitor metrics exporter (tc-0rt1).
-							app.EnvironmentVarArgs{Name: pulumi.String("APPLICATIONINSIGHTS_CONNECTION_STRING"), Value: appInsightsConnectionString},
-							app.EnvironmentVarArgs{Name: pulumi.String("COSMOS_ENDPOINT"), Value: cosmosAccountEndpoint},
-							app.EnvironmentVarArgs{Name: pulumi.String("COSMOS_DATABASE"), Value: cosmosDatabase.Name},
-							app.EnvironmentVarArgs{Name: pulumi.String("AZURE_CLIENT_ID"), Value: cosmosDataIdentityClientID},
-							app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_DOMAIN"), Value: pulumi.String(auth0Domain)},
-							app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_AUDIENCE"), Value: pulumi.String(auth0Audience)},
-							app.EnvironmentVarArgs{Name: pulumi.String("CORS_ALLOWED_ORIGINS"), Value: pulumi.String(fmt.Sprintf("https://%s", frontendDomain))},
-							app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_ID"), SecretRef: pulumi.String("auth0-m2m-client-id")},
-							app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_SECRET"), SecretRef: pulumi.String("auth0-m2m-client-secret")},
-							app.EnvironmentVarArgs{Name: pulumi.String("SUBSCRIPTION_AUTOGRANT_PRODOMAINS"), SecretRef: pulumi.String("auto-grant-pro-domains")},
-							app.EnvironmentVarArgs{Name: pulumi.String("ADMIN_API_KEY"), SecretRef: pulumi.String("admin-api-key")},
-						},
+		},
+		Template: &app.TemplateArgs{
+			Containers: app.ContainerArray{
+				&app.ContainerArgs{
+					Name:  pulumi.String("api-go"),
+					Image: pulumi.String("mcr.microsoft.com/k8se/quickstart:latest"),
+					Resources: &app.ContainerResourcesArgs{
+						Cpu:    pulumi.Float64(containerCpu),
+						Memory: pulumi.String(containerMemory),
+					},
+					Env: app.EnvironmentVarArray{
+						app.EnvironmentVarArgs{Name: pulumi.String("OTEL_SERVICE_NAME"), Value: pulumi.String("town-crier-api-go")},
+						// Read by the in-process Azure Monitor metrics exporter (tc-0rt1).
+						app.EnvironmentVarArgs{Name: pulumi.String("APPLICATIONINSIGHTS_CONNECTION_STRING"), Value: appInsightsConnectionString},
+						app.EnvironmentVarArgs{Name: pulumi.String("COSMOS_ENDPOINT"), Value: cosmosAccountEndpoint},
+						app.EnvironmentVarArgs{Name: pulumi.String("COSMOS_DATABASE"), Value: cosmosDatabase.Name},
+						app.EnvironmentVarArgs{Name: pulumi.String("AZURE_CLIENT_ID"), Value: cosmosDataIdentityClientID},
+						app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_DOMAIN"), Value: pulumi.String(auth0Domain)},
+						app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_AUDIENCE"), Value: pulumi.String(auth0Audience)},
+						app.EnvironmentVarArgs{Name: pulumi.String("CORS_ALLOWED_ORIGINS"), Value: pulumi.String(fmt.Sprintf("https://%s", frontendDomain))},
+						app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_ID"), SecretRef: pulumi.String("auth0-m2m-client-id")},
+						app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_SECRET"), SecretRef: pulumi.String("auth0-m2m-client-secret")},
+						app.EnvironmentVarArgs{Name: pulumi.String("SUBSCRIPTION_AUTOGRANT_PRODOMAINS"), SecretRef: pulumi.String("auto-grant-pro-domains")},
+						app.EnvironmentVarArgs{Name: pulumi.String("ADMIN_API_KEY"), SecretRef: pulumi.String("admin-api-key")},
 					},
 				},
-				Scale: &app.ScaleArgs{
-					// Keep one warm replica only for PROD to skip the ~15s ACA cold start.
-					MinReplicas: pulumi.Int(minReplicas),
-					MaxReplicas: pulumi.Int(1),
-				},
 			},
-			Tags: tags,
-		}, pulumi.IgnoreChanges([]string{"template.containers[0].image", "configuration.ingress.traffic"}))
-		if err != nil {
-			return err
-		}
+			Scale: &app.ScaleArgs{
+				// Keep one warm replica only for PROD to skip the ~15s ACA cold start.
+				MinReplicas: pulumi.Int(minReplicas),
+				MaxReplicas: pulumi.Int(1),
+			},
+		},
+		Tags: tags,
+	}, pulumi.IgnoreChanges([]string{"template.containers[0].image", "configuration.ingress.traffic"}))
+	if err != nil {
+		return err
 	}
 
 	// Service Bus — adaptive polling trigger (prod only). The worker identity gets Data
@@ -448,7 +445,7 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 // + non-nil pollingBus produces an Event-triggered job; otherwise a Schedule-triggered cron
 // job.
 func createWorkerJob(ctx *pulumi.Context, ec envContext, nameSuffix, cronExpression string, replicaTimeout int, workerMode string, pollingBus *serviceBusPollingInfra) error {
-	// Base env. WORKER_MODE is inserted after OTEL_SERVICE_NAME (matches the C# List.Insert(1)).
+	// Base env shared by every worker job.
 	envVars := app.EnvironmentVarArray{
 		app.EnvironmentVarArgs{Name: pulumi.String("OTEL_SERVICE_NAME"), Value: pulumi.String("town-crier-worker-go")},
 		app.EnvironmentVarArgs{Name: pulumi.String("WORKER_MODE"), Value: pulumi.String(workerMode)},
@@ -550,8 +547,8 @@ func createWorkerJob(ctx *pulumi.Context, ec envContext, nameSuffix, cronExpress
 	return err
 }
 
-// addGoWorkerEnv appends the Go worker's env vars (SINGLE-underscore names) in the same
-// order as the original C# AddGoWorkerEnv. The consumer is api-go/internal/platform/config.go.
+// addGoWorkerEnv appends the Go worker's env vars (SINGLE-underscore names). The consumer
+// is api-go/internal/platform/config.go.
 func addGoWorkerEnv(envVars app.EnvironmentVarArray, ec envContext, workerMode string, pollingBus *serviceBusPollingInfra) app.EnvironmentVarArray {
 	// All modes: Go-named Cosmos endpoint/database.
 	envVars = append(envVars,
@@ -567,7 +564,7 @@ func addGoWorkerEnv(envVars app.EnvironmentVarArray, ec envContext, workerMode s
 		)
 	}
 
-	// poll only: PlanIt client + polling-cycle budgets (the .NET defaults made explicit).
+	// poll only: PlanIt client + polling-cycle budgets (defaults made explicit).
 	if workerMode == "poll-sb" {
 		envVars = append(envVars,
 			app.EnvironmentVarArgs{Name: pulumi.String("PLANIT_BASE_URL"), Value: pulumi.String("https://www.planit.org.uk/")},

--- a/infra/shared.go
+++ b/infra/shared.go
@@ -174,42 +174,37 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		return err
 	}
 
-	// ImportId must be a plain string (not an Output) because the Pulumi engine needs it
-	// at planning time. We read the subscription from ARM_SUBSCRIPTION_ID that CI (and
-	// local `pulumi up`) sets via the Azure login step; RG and workspace names are static.
+	// ARM_SUBSCRIPTION_ID is set by CI (and local `pulumi up`) via the Azure login step; it
+	// feeds the subscription-wide budget scope below.
 	armSubscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
 	if armSubscriptionID == "" {
-		return fmt.Errorf("ARM_SUBSCRIPTION_ID must be set to import the ContainerAppConsoleLogs table")
+		return fmt.Errorf("ARM_SUBSCRIPTION_ID must be set for the subscription budget scope")
 	}
 
-	// Set the native ContainerAppConsoleLogs table to the Basic plan (import-then-patch).
-	tableImportID := fmt.Sprintf(
-		"/subscriptions/%s/resourceGroups/rg-town-crier-shared/providers/Microsoft.OperationalInsights/workspaces/log-town-crier-shared/tables/ContainerAppConsoleLogs", armSubscriptionID)
+	// Set the native ContainerAppConsoleLogs table to the Basic plan.
 	_, err = operationalinsights.NewTable(ctx, "table-containerappconsolelogs-basic", &operationalinsights.TableArgs{
 		ResourceGroupName: resourceGroup.Name,
 		WorkspaceName:     logAnalytics.Name,
 		TableName:         pulumi.String("ContainerAppConsoleLogs"),
 		Plan:              operationalinsights.TablePlanEnumBasic,
-	}, pulumi.Import(pulumi.ID(tableImportID)))
+	})
 	if err != nil {
 		return err
 	}
 
-	// Move the AppTraces table to the Basic Logs plan (import-then-patch). See tc-9ggc.
-	appTracesTableImportID := fmt.Sprintf(
-		"/subscriptions/%s/resourceGroups/rg-town-crier-shared/providers/Microsoft.OperationalInsights/workspaces/log-town-crier-shared/tables/AppTraces", armSubscriptionID)
+	// Move the AppTraces table to the Basic Logs plan. See tc-9ggc.
 	_, err = operationalinsights.NewTable(ctx, "table-apptraces-basic", &operationalinsights.TableArgs{
 		ResourceGroupName: resourceGroup.Name,
 		WorkspaceName:     logAnalytics.Name,
 		TableName:         pulumi.String("AppTraces"),
 		Plan:              operationalinsights.TablePlanEnumBasic,
-	}, pulumi.Import(pulumi.ID(appTracesTableImportID)))
+	})
 	if err != nil {
 		return err
 	}
 
-	// Cap the workspace-based App* tables at the workspace's 30-day retention
-	// (import-then-patch). See tc-23yb. AppTraces is omitted (already on Basic = 8 days).
+	// Cap the workspace-based App* tables at the workspace's 30-day retention. See tc-23yb.
+	// AppTraces is omitted (already on Basic = 8 days).
 	appTablesToCapAt30Days := []string{
 		"AppRequests",
 		"AppDependencies",
@@ -223,15 +218,13 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		"AppSystemEvents",
 	}
 	for _, tableName := range appTablesToCapAt30Days {
-		importID := fmt.Sprintf(
-			"/subscriptions/%s/resourceGroups/rg-town-crier-shared/providers/Microsoft.OperationalInsights/workspaces/log-town-crier-shared/tables/%s", armSubscriptionID, tableName)
 		_, err = operationalinsights.NewTable(ctx, fmt.Sprintf("table-%s-30day", strings.ToLower(tableName)), &operationalinsights.TableArgs{
 			ResourceGroupName:    resourceGroup.Name,
 			WorkspaceName:        logAnalytics.Name,
 			TableName:            pulumi.String(tableName),
 			RetentionInDays:      pulumi.Int(30),
 			TotalRetentionInDays: pulumi.Int(30),
-		}, pulumi.Import(pulumi.ID(importID)))
+		})
 		if err != nil {
 			return err
 		}
@@ -430,10 +423,9 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 						dashboardPart(4, 4, 4, 4, metricTile(appInsightsID, "towncrier.watchzones.deleted", "Watch Zones Deleted")),
 						dashboardPart(8, 4, 4, 4, metricTile(appInsightsID, "towncrier.notifications.sent", "Notifications Sent")),
 						// Row 3: Sync & Infrastructure Health
-						dashboardPart(0, 8, 3, 4, stackedMetricTile(appInsightsID,
-							"towncrier.polling.authorities_polled", "Successes",
-							"towncrier.polling.failures", "Failures",
-							"Sync Success vs Failure")),
+						dashboardPart(0, 8, 3, 4, metricChartTile(appInsightsID, "Sync Success vs Failure",
+							metricSpec{name: "towncrier.polling.authorities_polled", label: "Successes"},
+							metricSpec{name: "towncrier.polling.failures", label: "Failures"})),
 						dashboardPart(3, 8, 3, 4, metricTile(appInsightsID, "towncrier.polling.applications_ingested", "Applications Ingested")),
 						dashboardPart(6, 8, 3, 4, metricTile(appInsightsID, "towncrier.cosmos.request_charge_ru", "Cosmos RU Consumption")),
 						dashboardPart(9, 8, 3, 4, metricTile(appInsightsID, "towncrier.api.errors", "API Errors")),
@@ -490,66 +482,31 @@ func dashboardPart(x, y, colSpan, rowSpan int, metadata portal.DashboardPartMeta
 	}
 }
 
-// metricTile renders a single App Insights custom metric as a MonitorChartPart.
-func metricTile(appInsightsID pulumi.StringOutput, metricName, title string) portal.DashboardPartMetadataArgs {
-	return portal.DashboardPartMetadataArgs{
-		Type: pulumi.String("Extension/HubsExtension/PartType/MonitorChartPart"),
-		Settings: pulumi.Map{
-			"content": pulumi.Map{
-				"options": pulumi.Map{
-					"chart": pulumi.Map{
-						"metrics": pulumi.Array{
-							pulumi.Map{
-								"resourceMetadata": pulumi.Map{"id": appInsightsID},
-								"name":             pulumi.String(metricName),
-								"aggregationType":  pulumi.Int(1),
-								"namespace":        pulumi.String("azure.applicationinsights"),
-								"metricVisualization": pulumi.Map{
-									"displayName": pulumi.String(title),
-								},
-							},
-						},
-						"title":     pulumi.String(title),
-						"titleKind": pulumi.Int(1),
-						"visualization": pulumi.Map{
-							"chartType": pulumi.Int(2),
-						},
-						"timespan": pulumi.Map{
-							"relative": pulumi.Map{
-								"duration": pulumi.Int(dashboardTimespan24HoursMs),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+// metricSpec is one App Insights custom metric series within a chart tile.
+type metricSpec struct {
+	name  string // custom metric name, e.g. "towncrier.users.registered"
+	label string // series display name shown in the chart legend
 }
 
-// stackedMetricTile renders two App Insights custom metrics stacked in one chart.
-func stackedMetricTile(appInsightsID pulumi.StringOutput, metric1, label1, metric2, label2, title string) portal.DashboardPartMetadataArgs {
+// metricChartTile renders one or more App Insights custom metrics as a MonitorChartPart.
+func metricChartTile(appInsightsID pulumi.StringOutput, title string, metrics ...metricSpec) portal.DashboardPartMetadataArgs {
+	series := make(pulumi.Array, len(metrics))
+	for i, m := range metrics {
+		series[i] = pulumi.Map{
+			"resourceMetadata":    pulumi.Map{"id": appInsightsID},
+			"name":                pulumi.String(m.name),
+			"aggregationType":     pulumi.Int(1),
+			"namespace":           pulumi.String("azure.applicationinsights"),
+			"metricVisualization": pulumi.Map{"displayName": pulumi.String(m.label)},
+		}
+	}
 	return portal.DashboardPartMetadataArgs{
 		Type: pulumi.String("Extension/HubsExtension/PartType/MonitorChartPart"),
 		Settings: pulumi.Map{
 			"content": pulumi.Map{
 				"options": pulumi.Map{
 					"chart": pulumi.Map{
-						"metrics": pulumi.Array{
-							pulumi.Map{
-								"resourceMetadata":    pulumi.Map{"id": appInsightsID},
-								"name":                pulumi.String(metric1),
-								"aggregationType":     pulumi.Int(1),
-								"namespace":           pulumi.String("azure.applicationinsights"),
-								"metricVisualization": pulumi.Map{"displayName": pulumi.String(label1)},
-							},
-							pulumi.Map{
-								"resourceMetadata":    pulumi.Map{"id": appInsightsID},
-								"name":                pulumi.String(metric2),
-								"aggregationType":     pulumi.Int(1),
-								"namespace":           pulumi.String("azure.applicationinsights"),
-								"metricVisualization": pulumi.Map{"displayName": pulumi.String(label2)},
-							},
-						},
+						"metrics":       series,
 						"title":         pulumi.String(title),
 						"titleKind":     pulumi.Int(1),
 						"visualization": pulumi.Map{"chartType": pulumi.Int(2)},
@@ -561,6 +518,11 @@ func stackedMetricTile(appInsightsID pulumi.StringOutput, metric1, label1, metri
 			},
 		},
 	}
+}
+
+// metricTile renders a single custom metric whose series label matches the chart title.
+func metricTile(appInsightsID pulumi.StringOutput, metricName, title string) portal.DashboardPartMetadataArgs {
+	return metricChartTile(appInsightsID, title, metricSpec{name: metricName, label: title})
 }
 
 // kqlTile renders an Analytics (KQL query) dashboard part bound to the App Insights component.


### PR DESCRIPTION
## Changes

Simplify-sweep findings on the Go-ported `/infra` Pulumi program:

- **tc-mdbj** — Unify `metricTile` + `stackedMetricTile` into one variadic `metricChartTile` builder taking `metricSpec{name,label}`; `metricTile` is now a thin single-metric adapter. Collapses ~70 lines of duplicated `MonitorChartPart` scaffolding to one.
- **tc-vuvd** — Drop the always-true `if env == "dev" || env == "prod"` guard around the Go ContainerApp; `runEnvironmentStack` only ever runs for dev/prod, so the ContainerApp is now created unconditionally (same as the worker jobs below it).
- **tc-q3dd** — Refresh stale `.NET`-era comments that survived the C#→Go port (`C# List.Insert(1)`, "original C# AddGoWorkerEnv", ".NET app" admin key, ".NET defaults").
- **tc-29wf** — Remove leftover `pulumi.Import` directives + import-ID strings on the log-table resources (one-time imports, already in state); keep `armSubscriptionID` for the subscription budget scope.

## Verification

- `pulumi preview` on the **shared** stack reports **32 unchanged** — zero diff confirms the unified dashboard JSON and the log tables (import removal) are byte-identical.
- `go build ./...`, `go vet ./...`, `gofmt -l .` all clean.
- dev/prod ContainerApp preview is a provably-equivalent refactor (always-true guard removed); local preview is blocked by CI-injected secrets, so it is validated by the CI pr-gate infra preview.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Container App configuration flexibility across environments
  * Streamlined operational dashboard and logging metrics generation
  
* **Chores**
  * Updated infrastructure provisioning and subscription budget configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->