### PR TITLE
fix(api-go): subscription verify Apple env allowlist + transaction single-owner (#511, #512)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -228,7 +228,7 @@ func main() {
 	geocodeClient := geocoding.NewClient(cfg.PostcodesIoBaseURL, &http.Client{Timeout: 30 * time.Second})
 	designationClient := designations.NewClient(cfg.GovUkBaseURL, &http.Client{Timeout: 30 * time.Second})
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, cascade, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, registry, logger))
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, cascade, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, cfg.AppleEnvironments, registry, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -94,7 +94,7 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // nil-means-unwired convention. (The watch-zone preferences endpoints are
 // served by profiles.Routes off the profile store, so they come up with the
 // /v1/me routes, not the watch-zone store.)
-func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, cascade profiles.CascadeDeleters, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, registry *metrics.Registry, logger *slog.Logger) http.Handler {
+func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, cascade profiles.CascadeDeleters, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, appleEnvironments []string, registry *metrics.Registry, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)
@@ -172,7 +172,7 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 		// Subscriptions: verify (authed, by user id via the profile store) and the
 		// App Store webhook (anonymous, by original transaction id via the admin
 		// store, deduped through the AppleNotifications idempotency store).
-		subscriptions.Routes(mux, jwsVerifier, store, adminStore, auth0, appleNotifStore, appleBundleID, time.Now, logger)
+		subscriptions.Routes(mux, jwsVerifier, store, adminStore, auth0, appleNotifStore, appleBundleID, appleEnvironments, time.Now, logger)
 	}
 
 	authed := auth.RequireAuth(validator, &dispatchMux{ServeMux: mux, dispatch: dispatch}, anonymousPatterns)

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -122,7 +122,7 @@ func testDesignationClient() *designations.Client {
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", nil, slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", nil, nil, slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -227,7 +227,7 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	appStore := applications.NewCosmosStore(newFakeItems())
 	savedStore := savedapplications.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", nil, nil, logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -310,7 +310,7 @@ func TestRouter_GeocodeAndDesignationsDispatch(t *testing.T) {
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
 	geocodeClient := geocoding.NewClient(upstream.URL, upstream.Client())
 	designationClient := designations.NewClient(upstream.URL, upstream.Client())
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", nil, nil, "", nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", nil, nil, "", nil, nil, logger)
 
 	rec := serveReq(t, h, http.MethodGet, "/v1/geocode/SW1A%201AA", "", "Bearer tok")
 	if rec.Code != http.StatusOK {
@@ -349,7 +349,7 @@ func TestRouter_SubscriptionsWired(t *testing.T) {
 		t.Fatalf("NewJWSVerifier: %v", err)
 	}
 
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, adminStore, "", verifier, notifStore, "uk.towncrierapp.mobile", nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, adminStore, "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, logger)
 
 	// Webhook is anonymous: a malformed body reaches the handler -> 400 with the
 	// malformed_request envelope, not the WWW-Authenticate 401 fallback.
@@ -379,7 +379,7 @@ func TestRouter_AdminGate(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	offerStore := offercodes.NewCosmosStore(newFakeItems())
 	adminStore := profiles.NewAdminStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), offerStore, adminStore, "s3cret", nil, nil, "", nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), offerStore, adminStore, "s3cret", nil, nil, "", nil, nil, logger)
 
 	// No key: the admin gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -95,6 +95,16 @@ type Config struct {
 	// (tc-7g3i.12).
 	AppleBundleID string
 
+	// AppleEnvironments is the allowlist of StoreKit transaction environments
+	// (e.g. "Production", "Sandbox") that the subscription-verify and webhook
+	// paths accept. Loaded from APPLE_ENVIRONMENT (comma-separated, whitespace-
+	// tolerant). Defaults to ["Production"] — fail-safe so an unconfigured
+	// production deployment never accepts a free sandbox transaction. A dev/
+	// TestFlight deployment sets APPLE_ENVIRONMENT=Sandbox,Production so both
+	// real-money (Production) and TestFlight (Sandbox) purchases work during the
+	// testing phase. Matching is case-insensitive at use-time.
+	AppleEnvironments []string
+
 	// APNs* configure the direct APNs HTTP/2 push client the digest worker modes
 	// use to deliver instant and digest alerts (epic tc-wad3, enabler tc-qlqn).
 	// APNsEnabled gates whether the real sender is constructed; when false the
@@ -199,7 +209,8 @@ func LoadConfig() (Config, error) {
 
 		AdminAPIKey: os.Getenv("ADMIN_API_KEY"),
 
-		AppleBundleID: getenv("APPLE_BUNDLE_ID", defaultAppleBundleID),
+		AppleBundleID:     getenv("APPLE_BUNDLE_ID", defaultAppleBundleID),
+		AppleEnvironments: parseAppleEnvironments(os.Getenv("APPLE_ENVIRONMENT")),
 
 		APNsEnabled:    getenvBool("APNS_ENABLED"),
 		APNsAuthKey:    NewSecret(os.Getenv("APNS_AUTH_KEY")),
@@ -247,6 +258,29 @@ func parseOrigins(raw string) []string {
 		return []string{defaultCorsOrigin}
 	}
 	return origins
+}
+
+// defaultAppleEnvironment is the production environment value. A deployment
+// that does not configure APPLE_ENVIRONMENT rejects sandbox transactions,
+// which is the safe default for production.
+const defaultAppleEnvironment = "Production"
+
+// parseAppleEnvironments splits a comma-separated list of Apple StoreKit
+// environment names, trims whitespace, and drops empty entries. An empty or
+// all-empty input returns [defaultAppleEnvironment], so an unconfigured
+// production deployment rejects sandbox transactions by default.
+// Values are stored as-is; callers compare case-insensitively.
+func parseAppleEnvironments(raw string) []string {
+	envs := make([]string, 0, 1)
+	for _, part := range strings.Split(raw, ",") {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			envs = append(envs, trimmed)
+		}
+	}
+	if len(envs) == 0 {
+		return []string{defaultAppleEnvironment}
+	}
+	return envs
 }
 
 func getenv(key, fallback string) string {

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -403,6 +403,33 @@ func TestLoadConfig_PollingDefaults(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_AppleEnvironments(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want []string
+	}{
+		{"default is Production when unset", "", []string{"Production"}},
+		{"single override", "Sandbox", []string{"Sandbox"}},
+		{"comma list with whitespace", " Sandbox , Production ", []string{"Sandbox", "Production"}},
+		{"empty entries dropped", "Production,,", []string{"Production"}},
+		{"case preserved in value", "sandbox", []string{"sandbox"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("APPLE_ENVIRONMENT", tc.env)
+
+			cfg, err := LoadConfig()
+			if err != nil {
+				t.Fatalf("LoadConfig: %v", err)
+			}
+			if !reflect.DeepEqual(cfg.AppleEnvironments, tc.want) {
+				t.Errorf("AppleEnvironments: got %v, want %v", cfg.AppleEnvironments, tc.want)
+			}
+		})
+	}
+}
+
 func TestLoadConfig_PollingOverrides(t *testing.T) {
 	t.Setenv("PLANIT_BASE_URL", "https://stub.planit.test/")
 	t.Setenv("POLLING_MAX_PAGES_PER_AUTHORITY_PER_CYCLE", "5")

--- a/api-go/internal/subscriptions/handler.go
+++ b/api-go/internal/subscriptions/handler.go
@@ -52,29 +52,54 @@ type idempotencyStore interface {
 }
 
 type handler struct {
-	verifier       jwsVerifier
-	profilesByUser profileByUser
-	profilesByTxn  profileByTxn
-	auth0          tierSync
-	idempotency    idempotencyStore
-	bundleID       string
-	now            func() time.Time
-	logger         *slog.Logger
+	verifier            jwsVerifier
+	profilesByUser      profileByUser
+	profilesByTxn       profileByTxn
+	auth0               tierSync
+	idempotency         idempotencyStore
+	bundleID            string
+	allowedEnvironments []string
+	now                 func() time.Time
+	logger              *slog.Logger
+}
+
+// conflictError signals that the transaction's originalTransactionId is already
+// owned by a different user's profile. The verify endpoint maps it to
+// 409 transaction_already_claimed.
+type conflictError struct{}
+
+func (e *conflictError) Error() string {
+	return "Transaction is already claimed by another account."
+}
+
+// envAllowed reports whether env appears in the allowlist, comparing
+// case-insensitively and after trimming whitespace.
+func envAllowed(env string, allowed []string) bool {
+	env = strings.TrimSpace(env)
+	for _, a := range allowed {
+		if strings.EqualFold(env, strings.TrimSpace(a)) {
+			return true
+		}
+	}
+	return false
 }
 
 // Routes registers the authed verify endpoint and the anonymous App Store
 // webhook on mux. The webhook is authenticated by the signed JWS itself
 // (Apple -> API), so it is added to the wiring's anonymousPatterns.
-func Routes(mux *http.ServeMux, verifier jwsVerifier, profilesByUser profileByUser, profilesByTxn profileByTxn, auth0 tierSync, idempotency idempotencyStore, bundleID string, now func() time.Time, logger *slog.Logger) {
+// allowedEnvironments is the set of Apple StoreKit environments the handler
+// accepts (e.g. ["Production"] for prod, ["Sandbox","Production"] for dev).
+func Routes(mux *http.ServeMux, verifier jwsVerifier, profilesByUser profileByUser, profilesByTxn profileByTxn, auth0 tierSync, idempotency idempotencyStore, bundleID string, allowedEnvironments []string, now func() time.Time, logger *slog.Logger) {
 	h := &handler{
-		verifier:       verifier,
-		profilesByUser: profilesByUser,
-		profilesByTxn:  profilesByTxn,
-		auth0:          auth0,
-		idempotency:    idempotency,
-		bundleID:       bundleID,
-		now:            now,
-		logger:         logger,
+		verifier:            verifier,
+		profilesByUser:      profilesByUser,
+		profilesByTxn:       profilesByTxn,
+		auth0:               auth0,
+		idempotency:         idempotency,
+		bundleID:            bundleID,
+		allowedEnvironments: allowedEnvironments,
+		now:                 now,
+		logger:              logger,
 	}
 	mux.HandleFunc("POST /v1/subscriptions/verify", h.verify)
 	mux.HandleFunc("POST /v1/webhooks/appstore", h.webhook)
@@ -177,6 +202,10 @@ func (h *handler) runVerify(ctx context.Context, userID string, signedTransactio
 		if txn.BundleID != h.bundleID {
 			return verifyResponse{}, &PayloadError{Message: fmt.Sprintf("Bundle ID mismatch: expected '%s', got '%s'.", h.bundleID, txn.BundleID)}
 		}
+		// F1: reject transactions from environments not in the allowlist.
+		if !envAllowed(txn.Environment, h.allowedEnvironments) {
+			return verifyResponse{}, &PayloadError{Message: fmt.Sprintf("Transaction environment '%s' is not accepted.", txn.Environment)}
+		}
 		// A restore may legitimately include lapsed transactions — skip them.
 		if !txn.ExpiresDate.After(now) {
 			continue
@@ -195,6 +224,18 @@ func (h *handler) runVerify(ctx context.Context, userID string, signedTransactio
 	if highestTier == profiles.TierFree {
 		profile.ExpireSubscription()
 	} else {
+		// F2: enforce single-owner on the original transaction id. A transaction
+		// signed by Apple proves nothing about which account made the purchase; we
+		// reject cross-user linking to prevent one JWS from granting Pro on
+		// unlimited accounts. Same user (idempotent re-verify) or ErrNotFound
+		// (first-time claim) both proceed.
+		existing, err := h.profilesByTxn.GetByOriginalTransactionID(ctx, highestOriginalTxn)
+		switch {
+		case err != nil && !errors.Is(err, profiles.ErrNotFound):
+			return verifyResponse{}, fmt.Errorf("look up transaction owner %q: %w", highestOriginalTxn, err)
+		case err == nil && existing.UserID != userID:
+			return verifyResponse{}, &conflictError{}
+		}
 		profile.LinkOriginalTransactionID(highestOriginalTxn)
 		profile.ActivateSubscription(highestTier, highestExpiry)
 	}
@@ -276,7 +317,11 @@ func (h *handler) runWebhook(ctx context.Context, signedPayload string) error {
 		return fmt.Errorf("locate subscriber: %w", err)
 	}
 
-	if profile != nil {
+	// F1: on the webhook, an environment mismatch is swallowed — the notification
+	// is still marked processed so Apple does not retry, but the profile is not
+	// mutated. This mirrors the "mark processed, no state change" contract of
+	// unknown-subscriber and no-change events already in this path.
+	if profile != nil && envAllowed(txn.Environment, h.allowedEnvironments) {
 		changed, err := applyNotification(profile, notification, txn)
 		if err != nil {
 			return err
@@ -357,6 +402,11 @@ func (h *handler) writeVerifyError(r *http.Request, w http.ResponseWriter, err e
 	var notFound *userNotFoundError
 	if errors.As(err, &notFound) {
 		h.writeError(r, w, http.StatusNotFound, "user_not_found", notFound.Error())
+		return
+	}
+	var conflict *conflictError
+	if errors.As(err, &conflict) {
+		h.writeError(r, w, http.StatusConflict, "transaction_already_claimed", conflict.Error())
 		return
 	}
 	h.serverError(r, w, "verify subscription", err)

--- a/api-go/internal/subscriptions/handler_test.go
+++ b/api-go/internal/subscriptions/handler_test.go
@@ -329,20 +329,16 @@ func TestVerify_ErrorContract(t *testing.T) {
 
 // --- webhook tests ---
 
-func notificationJSON(notifType, subtype, uuid, signedTxn string) string {
-	sub := ""
-	if subtype != "" {
-		sub = fmt.Sprintf(`"subtype":%q,`, subtype)
-	}
-	return fmt.Sprintf(`{"notificationType":%q,%s"notificationUUID":%q,"data":{"signedTransactionInfo":%q}}`,
-		notifType, sub, uuid, signedTxn)
+func notificationJSON(notifType, uuid, signedTxn string) string {
+	return fmt.Sprintf(`{"notificationType":%q,"notificationUUID":%q,"data":{"signedTransactionInfo":%q}}`,
+		notifType, uuid, signedTxn)
 }
 
 func TestWebhook_SubscribedActivatesProfile(t *testing.T) {
 	t.Parallel()
 	d := newTestDeps()
 	d.byTxn.profile = freshProfile(t)
-	d.verifier.results["OUTER"] = notificationJSON("SUBSCRIBED", "", "uuid-1", "INNER")
+	d.verifier.results["OUTER"] = notificationJSON("SUBSCRIBED", "uuid-1", "INNER")
 	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
 
 	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"OUTER"}`, false)
@@ -366,7 +362,7 @@ func TestWebhook_DuplicateIsNoOp(t *testing.T) {
 	d := newTestDeps()
 	d.byTxn.profile = freshProfile(t)
 	d.idempotency.processed["uuid-1"] = true
-	d.verifier.results["OUTER"] = notificationJSON("SUBSCRIBED", "", "uuid-1", "INNER")
+	d.verifier.results["OUTER"] = notificationJSON("SUBSCRIBED", "uuid-1", "INNER")
 	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
 
 	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"OUTER"}`, false)
@@ -386,7 +382,7 @@ func TestWebhook_UnknownSubscriberStillMarksProcessed(t *testing.T) {
 	t.Parallel()
 	d := newTestDeps()
 	d.byTxn.profile = nil // no matching subscriber
-	d.verifier.results["OUTER"] = notificationJSON("DID_RENEW", "", "uuid-2", "INNER")
+	d.verifier.results["OUTER"] = notificationJSON("DID_RENEW", "uuid-2", "INNER")
 	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-x", futureExpiryMs())
 
 	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"OUTER"}`, false)
@@ -589,7 +585,7 @@ func TestWebhook_IgnoresSandboxTransactionInProduction(t *testing.T) {
 	t.Parallel()
 	d := newTestDeps() // allowedEnvs = ["Production"]
 	d.byTxn.profile = freshProfile(t)
-	d.verifier.results["OUTER"] = notificationJSON("SUBSCRIBED", "", "uuid-env1", "INNER_SBX")
+	d.verifier.results["OUTER"] = notificationJSON("SUBSCRIBED", "uuid-env1", "INNER_SBX")
 	d.verifier.results["INNER_SBX"] = txnJSONEnv(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs(), "Sandbox")
 
 	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"OUTER"}`, false)

--- a/api-go/internal/subscriptions/handler_test.go
+++ b/api-go/internal/subscriptions/handler_test.go
@@ -61,11 +61,21 @@ func (f *fakeProfileByUser) Save(_ context.Context, p *profiles.UserProfile) err
 }
 
 type fakeProfileByTxn struct {
+	// profile is returned for all txn lookups when profilesByTxnID is nil.
 	profile *profiles.UserProfile
-	saved   *profiles.UserProfile
+	// profilesByTxnID maps originalTransactionID to a profile, supporting F2
+	// conflict tests where different txn ids resolve to different profiles.
+	profilesByTxnID map[string]*profiles.UserProfile
+	saved           *profiles.UserProfile
 }
 
-func (f *fakeProfileByTxn) GetByOriginalTransactionID(context.Context, string) (*profiles.UserProfile, error) {
+func (f *fakeProfileByTxn) GetByOriginalTransactionID(_ context.Context, txnID string) (*profiles.UserProfile, error) {
+	if f.profilesByTxnID != nil {
+		if p, ok := f.profilesByTxnID[txnID]; ok {
+			return p, nil
+		}
+		return nil, profiles.ErrNotFound
+	}
 	if f.profile == nil {
 		return nil, profiles.ErrNotFound
 	}
@@ -113,7 +123,15 @@ type testDeps struct {
 	mux         *http.ServeMux
 }
 
+// testAllowedEnvs is the default allowlist used by newTestDeps. It mirrors a
+// production config that only accepts Production-environment transactions.
+var testAllowedEnvs = []string{"Production"}
+
 func newTestDeps() *testDeps {
+	return newTestDepsWithEnvs(testAllowedEnvs)
+}
+
+func newTestDepsWithEnvs(allowedEnvs []string) *testDeps {
 	d := &testDeps{
 		verifier:    &fakeVerifier{results: map[string]string{}, errs: map[string]error{}},
 		byUser:      &fakeProfileByUser{},
@@ -122,7 +140,7 @@ func newTestDeps() *testDeps {
 		idempotency: newFakeIdempotency(),
 		mux:         http.NewServeMux(),
 	}
-	Routes(d.mux, d.verifier, d.byUser, d.byTxn, d.auth0, d.idempotency, testBundleID,
+	Routes(d.mux, d.verifier, d.byUser, d.byTxn, d.auth0, d.idempotency, testBundleID, allowedEnvs,
 		func() time.Time { return testNow }, slog.New(slog.DiscardHandler))
 	return d
 }
@@ -149,8 +167,12 @@ func freshProfile(t *testing.T) *profiles.UserProfile {
 }
 
 func txnJSON(productID, bundleID, origTxn string, expiresMs int64) string {
-	return fmt.Sprintf(`{"transactionId":"t1","originalTransactionId":%q,"productId":%q,"bundleId":%q,"purchaseDate":1,"expiresDate":%d,"environment":"Production"}`,
-		origTxn, productID, bundleID, expiresMs)
+	return txnJSONEnv(productID, bundleID, origTxn, expiresMs, "Production")
+}
+
+func txnJSONEnv(productID, bundleID, origTxn string, expiresMs int64, environment string) string {
+	return fmt.Sprintf(`{"transactionId":"t1","originalTransactionId":%q,"productId":%q,"bundleId":%q,"purchaseDate":1,"expiresDate":%d,"environment":%q}`,
+		origTxn, productID, bundleID, expiresMs, environment)
 }
 
 func decodeError(t *testing.T, rec *httptest.ResponseRecorder) apiErrorResponse {
@@ -475,5 +497,182 @@ func TestApplyNotification(t *testing.T) {
 				t.Errorf("grace set = %v, want %v", p.GracePeriodExpiry != nil, tc.wantGrace)
 			}
 		})
+	}
+}
+
+// --- F1: environment allowlist tests ---
+
+func TestVerify_RejectsSandboxTransactionInProduction(t *testing.T) {
+	t.Parallel()
+	d := newTestDeps() // allowedEnvs = ["Production"]
+	d.byUser.profile = freshProfile(t)
+	d.verifier.results["JWS_SANDBOX"] = txnJSONEnv(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs(), "Sandbox")
+
+	rec := d.serve(t, "/v1/subscriptions/verify", `{"signedTransaction":"JWS_SANDBOX"}`, true)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := decodeError(t, rec).Error; got != "invalid_transaction_payload" {
+		t.Errorf("error = %q, want invalid_transaction_payload", got)
+	}
+	if d.byUser.saved != nil {
+		t.Error("profile must not be saved on environment mismatch")
+	}
+	if len(d.auth0.tiers) != 0 {
+		t.Error("auth0 must not be synced on environment mismatch")
+	}
+}
+
+func TestVerify_AcceptsProductionTransaction(t *testing.T) {
+	t.Parallel()
+	d := newTestDeps() // allowedEnvs = ["Production"]
+	d.byUser.profile = freshProfile(t)
+	d.verifier.results["JWS_PROD"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
+
+	rec := d.serve(t, "/v1/subscriptions/verify", `{"signedTransaction":"JWS_PROD"}`, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if d.byUser.saved == nil || d.byUser.saved.Tier != profiles.TierPro {
+		t.Error("profile not saved as Pro")
+	}
+}
+
+func TestVerify_AcceptsSandboxWhenConfiguredForSandbox(t *testing.T) {
+	t.Parallel()
+	d := newTestDepsWithEnvs([]string{"Sandbox"})
+	d.byUser.profile = freshProfile(t)
+	d.verifier.results["JWS_SANDBOX"] = txnJSONEnv(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs(), "Sandbox")
+
+	rec := d.serve(t, "/v1/subscriptions/verify", `{"signedTransaction":"JWS_SANDBOX"}`, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if d.byUser.saved == nil || d.byUser.saved.Tier != profiles.TierPro {
+		t.Error("profile not saved as Pro")
+	}
+}
+
+func TestVerify_AcceptsBothEnvironmentsWhenAllowlistHasTwo(t *testing.T) {
+	t.Parallel()
+	allowBoth := []string{"Sandbox", "Production"}
+
+	t.Run("accepts Production", func(t *testing.T) {
+		t.Parallel()
+		d := newTestDepsWithEnvs(allowBoth)
+		d.byUser.profile = freshProfile(t)
+		d.verifier.results["JWS_PROD"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
+
+		rec := d.serve(t, "/v1/subscriptions/verify", `{"signedTransaction":"JWS_PROD"}`, true)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("Production status = %d, body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("accepts Sandbox", func(t *testing.T) {
+		t.Parallel()
+		d := newTestDepsWithEnvs(allowBoth)
+		d.byUser.profile = freshProfile(t)
+		d.verifier.results["JWS_SBX"] = txnJSONEnv(ProductProMonthly, testBundleID, "orig-2", futureExpiryMs(), "Sandbox")
+
+		rec := d.serve(t, "/v1/subscriptions/verify", `{"signedTransaction":"JWS_SBX"}`, true)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("Sandbox status = %d, body=%s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+func TestWebhook_IgnoresSandboxTransactionInProduction(t *testing.T) {
+	t.Parallel()
+	d := newTestDeps() // allowedEnvs = ["Production"]
+	d.byTxn.profile = freshProfile(t)
+	d.verifier.results["OUTER"] = notificationJSON("SUBSCRIBED", "", "uuid-env1", "INNER_SBX")
+	d.verifier.results["INNER_SBX"] = txnJSONEnv(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs(), "Sandbox")
+
+	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"OUTER"}`, false)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if d.byTxn.saved != nil {
+		t.Error("profile must not be mutated when webhook environment mismatches")
+	}
+	if len(d.auth0.tiers) != 0 {
+		t.Error("auth0 must not be synced when webhook environment mismatches")
+	}
+	// Notification must still be marked processed (Apple should not retry).
+	if len(d.idempotency.marked) != 1 || d.idempotency.marked[0] != "uuid-env1" {
+		t.Errorf("should still mark processed, got %v", d.idempotency.marked)
+	}
+}
+
+// --- F2: transaction ownership tests ---
+
+func TestVerify_RejectsTransactionOwnedByAnotherUser(t *testing.T) {
+	t.Parallel()
+	d := newTestDeps()
+	d.byUser.profile = freshProfile(t)
+
+	// Another user already owns "orig-claimed".
+	otherUser, err := profiles.NewProfile("auth0|other", "other@example.com", testNow)
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	d.byTxn.profilesByTxnID = map[string]*profiles.UserProfile{
+		"orig-claimed": otherUser,
+	}
+	d.verifier.results["JWS_CONFLICT"] = txnJSON(ProductProMonthly, testBundleID, "orig-claimed", futureExpiryMs())
+
+	rec := d.serve(t, "/v1/subscriptions/verify", `{"signedTransaction":"JWS_CONFLICT"}`, true)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := decodeError(t, rec).Error; got != "transaction_already_claimed" {
+		t.Errorf("error = %q, want transaction_already_claimed", got)
+	}
+	if d.byUser.saved != nil {
+		t.Error("caller profile must not be saved on conflict")
+	}
+	if len(d.auth0.tiers) != 0 {
+		t.Error("auth0 must not be synced on conflict")
+	}
+}
+
+func TestVerify_AllowsReVerifyBySameOwner(t *testing.T) {
+	t.Parallel()
+	d := newTestDeps()
+	p := freshProfile(t) // UserID = testUserID = "auth0|u1"
+	d.byUser.profile = p
+	// Same user already owns the tx id — idempotent re-verify should succeed.
+	d.byTxn.profilesByTxnID = map[string]*profiles.UserProfile{
+		"orig-1": p,
+	}
+	d.verifier.results["JWS_REVERIFY"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
+
+	rec := d.serve(t, "/v1/subscriptions/verify", `{"signedTransaction":"JWS_REVERIFY"}`, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestVerify_AllowsFirstTimeClaim(t *testing.T) {
+	t.Parallel()
+	d := newTestDeps()
+	d.byUser.profile = freshProfile(t)
+	// byTxn returns ErrNotFound for unknown ids (default fakeProfileByTxn behaviour).
+	d.verifier.results["JWS_FIRST"] = txnJSON(ProductProMonthly, testBundleID, "orig-new", futureExpiryMs())
+
+	rec := d.serve(t, "/v1/subscriptions/verify", `{"signedTransaction":"JWS_FIRST"}`, true)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if d.byUser.saved == nil || d.byUser.saved.Tier != profiles.TierPro {
+		t.Error("profile not saved as Pro on first claim")
 	}
 }


### PR DESCRIPTION
Security audit remediation — findings **F1** (#511) and **F2** (#512). Both modify `runVerify`, shipped together per the epic sequencing (#522).

## F1 — Apple StoreKit environment allowlist (Critical, #511)
`runVerify` / the App Store webhook never checked whether a signed StoreKit transaction came from Sandbox or Production, so a free sandbox/TestFlight purchase could grant a paid tier.

**Design note (diverges from the issue's pre-resolved single-value design — per human decision):** TestFlight purchases are Apple-stamped `environment:"Sandbox"` and hit the **production** API alongside real `Production` purchases, so a single-value check would break TestFlight. Implemented instead as a **comma-separated allowlist** via `APPLE_ENVIRONMENT` (default `"Production"`, fail-safe; matching is case-insensitive + whitespace-tolerant). Prod will be configured `Sandbox,Production` during the TestFlight phase and flipped to `Production`-only at App Store GA.

- `verify`: rejects a transaction whose environment is not allowlisted → `400 invalid_transaction_payload`, no profile/Auth0 mutation.
- `webhook`: swallows an environment mismatch (marks the notification processed, no profile change, no Apple retry).

## F2 — Transaction single-owner (High, #512)
A verified JWS proves Apple signed the transaction, not that it belongs to the caller. `runVerify` now looks up `originalTransactionId` before linking: if it's already owned by a **different** user → `409 transaction_already_claimed` (caller profile untouched). Same user (idempotent re-verify) or first-time claim both proceed.

## Tests
- `TestLoadConfig_AppleEnvironments` (default / override / comma+whitespace / drop-empty / case)
- `TestVerify_RejectsSandboxTransactionInProduction`, `TestVerify_AcceptsProductionTransaction`, `TestVerify_AcceptsSandboxWhenConfiguredForSandbox`, `TestVerify_AcceptsBothEnvironmentsWhenAllowlistHasTwo`, `TestWebhook_IgnoresSandboxTransactionInProduction`
- `TestVerify_RejectsTransactionOwnedByAnotherUser`, `TestVerify_AllowsReVerifyBySameOwner`, `TestVerify_AllowsFirstTimeClaim`

`go test ./...`, `go test -race ./...`, `go vet ./...`, `gofmt -l .`, `go build ./...` all clean.

## Follow-ups filed
- **tc-tryt** (infra): set `APPLE_ENVIRONMENT` on the container apps (prod `Sandbox,Production`; dev permissive). **Must deploy before/with this code** or prod's default `Production` rejects current TestFlight Sandbox purchases.
- **tc-xbcc** (GA launch gate): flip prod `APPLE_ENVIRONMENT` to `Production`-only when the external TestFlight link is decommissioned.

Epic: #522 · Beads: tc-tij8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable Apple StoreKit environment support for subscription transactions
  * Added transaction ownership verification to prevent duplicate subscription claims across accounts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->