### PR TITLE
fix(web): point download CTAs at TestFlight until App Store launch

### DIFF
--- a/web/src/components/Footer/Footer.tsx
+++ b/web/src/components/Footer/Footer.tsx
@@ -1,3 +1,4 @@
+import { APP_DOWNLOAD_URL } from '../../config/links';
 import styles from './Footer.module.css';
 
 export function Footer() {
@@ -11,9 +12,11 @@ export function Footer() {
             Your neighbourhood is changing. Stay informed.
           </h2>
           <a
-            href="https://apps.apple.com/app/town-crier"
+            href={APP_DOWNLOAD_URL}
             className={styles.downloadButton}
             aria-label="Download on the App Store"
+            target="_blank"
+            rel="noopener noreferrer"
           >
             Download on the App Store
           </a>

--- a/web/src/components/Footer/__tests__/Footer.test.tsx
+++ b/web/src/components/Footer/__tests__/Footer.test.tsx
@@ -21,11 +21,17 @@ describe('Footer', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders an App Store download link styled as a button', () => {
+  it('renders a download link styled as a button pointing at TestFlight', () => {
     render(<Footer />);
 
     const link = screen.getByRole('link', { name: /download on the app store/i });
     expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      'href',
+      'https://testflight.apple.com/join/7fZTBZQN',
+    );
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('renders copyright with the current year', () => {

--- a/web/src/components/Hero/Hero.tsx
+++ b/web/src/components/Hero/Hero.tsx
@@ -1,3 +1,4 @@
+import { APP_DOWNLOAD_URL } from '../../config/links';
 import { useHeroCta } from './useHeroCta';
 import styles from './Hero.module.css';
 
@@ -16,7 +17,7 @@ export function Hero() {
       <div className={styles.ctaGroup}>
         <a
           className={styles.cta}
-          href="https://apps.apple.com/app/town-crier"
+          href={APP_DOWNLOAD_URL}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/web/src/components/Hero/__tests__/Hero.test.tsx
+++ b/web/src/components/Hero/__tests__/Hero.test.tsx
@@ -32,12 +32,17 @@ describe('Hero', () => {
     expect(screen.getByText(/417 local authorities/i)).toBeInTheDocument();
   });
 
-  it('renders an App Store CTA link', () => {
+  it('renders a download CTA link pointing at TestFlight', () => {
     renderHero();
 
     const cta = screen.getByRole('link', { name: /app store/i });
     expect(cta).toBeInTheDocument();
-    expect(cta).toHaveAttribute('href', expect.stringContaining('apps.apple.com'));
+    expect(cta).toHaveAttribute(
+      'href',
+      'https://testflight.apple.com/join/7fZTBZQN',
+    );
+    expect(cta).toHaveAttribute('target', '_blank');
+    expect(cta).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('renders a scroll indicator', () => {

--- a/web/src/components/Navbar/Navbar.tsx
+++ b/web/src/components/Navbar/Navbar.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { APP_DOWNLOAD_URL } from '../../config/links';
 import { useTheme } from '../../hooks/useTheme';
 import { useNavbarAuth } from './useNavbarAuth';
 import { ThemeToggle } from '../ThemeToggle/ThemeToggle';
@@ -54,7 +55,12 @@ export function Navbar() {
             </button>
           )}
 
-          <a href="#download" className={styles.cta}>
+          <a
+            href={APP_DOWNLOAD_URL}
+            className={styles.cta}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             Download
           </a>
 

--- a/web/src/components/Navbar/__tests__/Navbar.test.tsx
+++ b/web/src/components/Navbar/__tests__/Navbar.test.tsx
@@ -64,11 +64,17 @@ describe('Navbar', () => {
     expect(faq).toHaveAttribute('href', '#faq');
   });
 
-  it('renders Download CTA link', () => {
+  it('renders Download CTA link pointing at TestFlight', () => {
     renderNavbar();
 
     const cta = screen.getByRole('link', { name: /download/i });
     expect(cta).toBeInTheDocument();
+    expect(cta).toHaveAttribute(
+      'href',
+      'https://testflight.apple.com/join/7fZTBZQN',
+    );
+    expect(cta).toHaveAttribute('target', '_blank');
+    expect(cta).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('renders a ThemeToggle button', () => {

--- a/web/src/config/links.ts
+++ b/web/src/config/links.ts
@@ -1,0 +1,8 @@
+/**
+ * Public download link for the iOS app.
+ *
+ * Currently points at the TestFlight beta because Town Crier is not yet on the
+ * App Store. Swap this for the App Store URL (https://apps.apple.com/app/...)
+ * at GA — every download CTA reads from here, so it's a one-line change.
+ */
+export const APP_DOWNLOAD_URL = 'https://testflight.apple.com/join/7fZTBZQN';


### PR DESCRIPTION
## Changes
- Add `web/src/config/links.ts` exporting a single `APP_DOWNLOAD_URL` constant pointing at the TestFlight beta (`https://testflight.apple.com/join/7fZTBZQN`).
- Point the Hero, Footer, and Navbar "Download" CTAs at `APP_DOWNLOAD_URL`. Previously the Hero/Footer "Download on the App Store" buttons linked to a placeholder `apps.apple.com/app/town-crier` URL and the Navbar CTA linked to a non-existent `#download` anchor — all broken because Town Crier isn't on the App Store yet.
- External CTAs now open in a new tab with `rel="noopener noreferrer"`.
- Update Hero/Footer/Navbar tests to assert the TestFlight `href`, `target`, and `rel`.

Swapping for the real App Store URL at GA is now a one-line change in `links.ts`.

Bead: tc-gu4b

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * App download links throughout the website now open in a new browser tab, keeping your browsing context intact and allowing easy navigation between pages.
  * Download link destinations have been updated consistently across the entire site.
  * Improved security standards for handling external navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->