### PR TITLE
fix(web): correct coverage claims — drop unverifiable '417 authorities', cover whole UK

### DIFF
--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -68,7 +68,7 @@ describe('LandingPage (formerly App)', () => {
 
     const main = screen.getByRole('main');
 
-    expect(within(main).getByText('417')).toBeInTheDocument();
+    expect(within(main).getByText('UK-wide')).toBeInTheDocument();
     expect(within(main).getByText('How It Works')).toBeInTheDocument();
     expect(within(main).getByText('Pricing')).toBeInTheDocument();
     expect(within(main).getByText('Frequently Asked Questions')).toBeInTheDocument();

--- a/web/src/components/Faq/Faq.tsx
+++ b/web/src/components/Faq/Faq.tsx
@@ -14,7 +14,7 @@ const FAQ_ITEMS: FaqItem[] = [
   {
     question: 'Which areas do you cover?',
     answer:
-      'We cover local planning authorities across England, Scotland, and Wales. Coverage is expanding. If your area isn\u2019t listed yet, let us know and we\u2019ll prioritise it.',
+      'We cover local planning authorities across the whole UK \u2014 England, Scotland, Wales, and Northern Ireland. If your area isn\u2019t listed yet, let us know and we\u2019ll prioritise it.',
   },
   {
     question: 'Is there a free tier?',

--- a/web/src/components/Faq/__tests__/Faq.test.tsx
+++ b/web/src/components/Faq/__tests__/Faq.test.tsx
@@ -37,6 +37,17 @@ describe('Faq', () => {
     expect(screen.getByText(/which areas do you cover/i)).toBeInTheDocument();
   });
 
+  it('coverage answer names the whole UK including Northern Ireland', () => {
+    render(<Faq />);
+
+    const coverageAnswer = screen
+      .getByText(/which areas do you cover/i)
+      .closest('details')!
+      .querySelector('p')!;
+    expect(coverageAnswer.textContent).toMatch(/Northern Ireland/i);
+    expect(coverageAnswer.textContent).not.toMatch(/\b417\b/);
+  });
+
   it('renders question about free tier', () => {
     render(<Faq />);
 

--- a/web/src/components/Hero/Hero.tsx
+++ b/web/src/components/Hero/Hero.tsx
@@ -11,8 +11,8 @@ export function Hero() {
         Stay informed about what&apos;s being built in your neighbourhood
       </h1>
       <p className={styles.subheading}>
-        Monitoring planning applications across 417 local authorities in England
-        and Wales, so you don&apos;t have to.
+        Monitoring planning applications across the UK, so you don&apos;t have
+        to.
       </p>
       <div className={styles.ctaGroup}>
         <a

--- a/web/src/components/Hero/__tests__/Hero.test.tsx
+++ b/web/src/components/Hero/__tests__/Hero.test.tsx
@@ -26,10 +26,12 @@ describe('Hero', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the subheading about 417 authorities', () => {
+  it('renders the subheading about UK-wide coverage', () => {
     renderHero();
 
-    expect(screen.getByText(/417 local authorities/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/planning applications across the UK/i),
+    ).toBeInTheDocument();
   });
 
   it('renders a download CTA link pointing at TestFlight', () => {

--- a/web/src/components/StatsBar/StatsBar.tsx
+++ b/web/src/components/StatsBar/StatsBar.tsx
@@ -6,7 +6,7 @@ interface Stat {
 }
 
 const STATS: Stat[] = [
-  { value: '417', label: 'Local Authorities' },
+  { value: 'UK-wide', label: 'Coverage' },
   { value: 'Free', label: 'To Get Started' },
   { value: 'Real-time', label: 'Push Alerts' },
 ];

--- a/web/src/components/StatsBar/__tests__/StatsBar.test.tsx
+++ b/web/src/components/StatsBar/__tests__/StatsBar.test.tsx
@@ -10,11 +10,11 @@ describe('StatsBar', () => {
     expect(statItems).toHaveLength(3);
   });
 
-  it('renders "417" value with "Local Authorities" label', () => {
+  it('renders "UK-wide" value with "Coverage" label', () => {
     render(<StatsBar />);
 
-    expect(screen.getByText('417')).toBeInTheDocument();
-    expect(screen.getByText('Local Authorities')).toBeInTheDocument();
+    expect(screen.getByText('UK-wide')).toBeInTheDocument();
+    expect(screen.getByText('Coverage')).toBeInTheDocument();
   });
 
   it('renders "Free" value with "To Get Started" label', () => {
@@ -34,14 +34,14 @@ describe('StatsBar', () => {
   it('renders values with amber styling class', () => {
     render(<StatsBar />);
 
-    const value = screen.getByText('417');
+    const value = screen.getByText('UK-wide');
     expect(value.className).toMatch(/value/);
   });
 
   it('renders labels with secondary text styling class', () => {
     render(<StatsBar />);
 
-    const label = screen.getByText('Local Authorities');
+    const label = screen.getByText('Coverage');
     expect(label.className).toMatch(/label/);
   });
 


### PR DESCRIPTION
## Changes

Verified against PlanIt's live API (`planit.org.uk/api/areas/json`) on 2026-06-18: **420 active planning areas** (485 total), not 417 — and they overlap heavily (22 English counties duplicate their 152 districts, 15 national parks sit inside other LAs, 7 combined authorities overlap members, 4 Crown Dependencies + NSIP entities aren't councils). PlanIt also covers **Northern Ireland** (11 NI districts) and the Crown Dependencies, i.e. the whole UK.

- **StatsBar:** replace the unverifiable `417 / Local Authorities` tile with `UK-wide / Coverage`.
- **Hero:** "across 417 local authorities in England and Wales" → "across the UK".
- **FAQ:** "across England, Scotland, and Wales" → "across the whole UK — England, Scotland, Wales, and Northern Ireland" (drops the now-contradictory "coverage is expanding").
- **Tests:** update StatsBar/Hero/App assertions; add a FAQ regression test asserting the coverage answer names Northern Ireland and no longer says 417.

Gates run locally in the worktree: `tsc --noEmit` clean, `eslint` clean, **644 tests pass**, production build OK.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refreshed service coverage messaging to reflect UK-wide availability across the platform.
  * Updated hero section and FAQ components to clarify current geographic coverage scope.
  * Enhanced test validations to ensure messaging consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->