### PR TITLE
fix(api-go): saved-applications save looks up master record instead of upserting client body (#513)

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -153,8 +153,9 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 		demoaccount.Routes(mux, store, watchZoneStore, appStore, time.Now, logger)
 	}
 	if savedStore != nil && appStore != nil {
-		// The save path dual-writes: the master application record (appStore) then
-		// the saved row, so both stores are required to wire the endpoints.
+		// The save path looks up the master application record (appStore) to verify
+		// it exists, then writes only the per-user saved row. Both stores are
+		// required to wire the endpoints.
 		savedapplications.Routes(mux, savedStore, appStore, time.Now, logger)
 	}
 	if store != nil && offerStore != nil {

--- a/api-go/internal/savedapplications/handler.go
+++ b/api-go/internal/savedapplications/handler.go
@@ -62,9 +62,11 @@ func Routes(mux *http.ServeMux, store savedStore, apps appStore, now func() time
 	mux.HandleFunc("GET /v1/me/saved-applications", h.list)
 }
 
-// saveRequest is the PUT body — the full planning-application payload. The path
-// uid is ignored; the saved record's identity is the canonical uid derived from
-// the body (areaId/name).
+// saveRequest is the PUT body. Only Name, UID, and AreaID are used — they form
+// the key for the master-record look-up ((areaId, name) → canonical uid). The
+// remaining fields are decoded but not trusted as a source of truth; only the
+// data returned from the Applications container is written. The path uid is
+// ignored; identity is derived from the body's (areaId, name) pair.
 type saveRequest struct {
 	Name          string              `json:"name"`
 	UID           string              `json:"uid"`

--- a/api-go/internal/savedapplications/handler.go
+++ b/api-go/internal/savedapplications/handler.go
@@ -23,6 +23,11 @@ const maxBodyBytes = 1 << 20
 // the fields needed to build the canonical key and master record.
 const invalidBodyMessage = "Body must include a non-empty uid and name."
 
+// applicationNotFoundMessage is returned when the body's (areaId, name) does
+// not correspond to any master record in the Applications container. The save
+// path refuses to create master records — the poller is the source of truth.
+const applicationNotFoundMessage = "Application not found."
+
 // savedStore is the consumer-side saved-application store.
 type savedStore interface {
 	Save(ctx context.Context, sa SavedApplication) error
@@ -32,11 +37,11 @@ type savedStore interface {
 }
 
 // appStore is the consumer-side planning-application store the saved handler
-// needs: an upsert so a save always points at a known master record (the search
-// path no longer upserts), and a partition-scoped uid lookup used by the lazy
-// snapshot backfill for legacy rows.
+// needs: a point-read by (authorityCode, name) to verify a master record exists
+// before writing a user's bookmark, and a partition-scoped uid lookup used by
+// the lazy snapshot backfill for legacy rows.
 type appStore interface {
-	Upsert(ctx context.Context, a applications.PlanningApplication) error
+	GetByAuthorityAndName(ctx context.Context, authorityCode, name string) (applications.PlanningApplication, bool, error)
 	GetByUID(ctx context.Context, uid, authorityCode string) (applications.PlanningApplication, bool, error)
 }
 
@@ -81,33 +86,13 @@ type saveRequest struct {
 	LastDifferent platform.DotNetTime `json:"lastDifferent"`
 }
 
-func (req saveRequest) toApplication() applications.PlanningApplication {
-	return applications.PlanningApplication{
-		Name:          req.Name,
-		UID:           req.UID,
-		AreaName:      req.AreaName,
-		AreaID:        req.AreaID,
-		Address:       req.Address,
-		Postcode:      req.Postcode,
-		Description:   req.Description,
-		AppType:       req.AppType,
-		AppState:      req.AppState,
-		AppSize:       req.AppSize,
-		StartDate:     platform.DateOnlyPtrToTime(req.StartDate),
-		DecidedDate:   platform.DateOnlyPtrToTime(req.DecidedDate),
-		ConsultedDate: platform.DateOnlyPtrToTime(req.ConsultedDate),
-		Longitude:     req.Longitude,
-		Latitude:      req.Latitude,
-		URL:           req.URL,
-		Link:          req.Link,
-		LastDifferent: time.Time(req.LastDifferent),
-	}
-}
-
-// save implements PUT /v1/me/saved-applications/{**uid}. The path uid is
-// ignored. The body must carry a non-blank uid and name; the master record is
-// upserted first, then the saved row is written keyed on the canonical uid
-// (skipped when one already exists — idempotent re-save).
+// save implements PUT /v1/me/saved-applications/{**uid}. The body must carry a
+// non-blank uid and name. The handler looks up the canonical master record in
+// the Applications container by (areaId, name); if absent it returns 404 rather
+// than creating a record from untrusted client data — the poller is the sole
+// writer of the shared Applications container. When found, the per-user bookmark
+// is written against the canonical master record (idempotent: skipped when the
+// bookmark already exists).
 func (h *handler) save(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 
@@ -122,9 +107,16 @@ func (h *handler) save(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	app := req.toApplication()
-	if err := h.apps.Upsert(r.Context(), app); err != nil {
-		h.serverError(w, r, "upsert application", err)
+	// Look up the canonical master record — never trust the client body as a
+	// source of truth for the shared Applications container.
+	authorityCode := strconv.Itoa(req.AreaID)
+	app, found, err := h.apps.GetByAuthorityAndName(r.Context(), authorityCode, req.Name)
+	if err != nil {
+		h.serverError(w, r, "look up application", err)
+		return
+	}
+	if !found {
+		h.writeError(w, r, http.StatusNotFound, applicationNotFoundMessage)
 		return
 	}
 

--- a/api-go/internal/savedapplications/handler_test.go
+++ b/api-go/internal/savedapplications/handler_test.go
@@ -39,17 +39,23 @@ func (f *fakeSavedStore) GetByUserID(_ context.Context, _ string) ([]SavedApplic
 }
 
 type fakeApps struct {
-	upserted []applications.PlanningApplication
-	byUID    map[string]applications.PlanningApplication
-}
-
-func (f *fakeApps) Upsert(_ context.Context, a applications.PlanningApplication) error {
-	f.upserted = append(f.upserted, a)
-	return nil
+	// byUID supports the lazy-backfill GetByUID path used during list hydration.
+	byUID map[string]applications.PlanningApplication
+	// byAuthorityAndName supports the look-up path used by save.
+	byAuthorityAndName map[string]applications.PlanningApplication
+	// writeCount records how many write/upsert calls were made to the app store;
+	// tests assert this is zero to confirm no master-record mutation occurred.
+	writeCount int
 }
 
 func (f *fakeApps) GetByUID(_ context.Context, uid, _ string) (applications.PlanningApplication, bool, error) {
 	a, ok := f.byUID[uid]
+	return a, ok, nil
+}
+
+func (f *fakeApps) GetByAuthorityAndName(_ context.Context, authorityCode, name string) (applications.PlanningApplication, bool, error) {
+	key := authorityCode + "/" + name
+	a, ok := f.byAuthorityAndName[key]
 	return a, ok, nil
 }
 
@@ -71,18 +77,22 @@ func doReq(t *testing.T, mux *http.ServeMux, method, path, body string) *httptes
 
 const validSaveBody = `{"name":"24/0123/FUL","uid":"ABC-1","areaName":"City of London","areaId":471,"address":"1 St","description":"d","lastDifferent":"2026-03-02T09:30:00+00:00"}`
 
-func TestHandler_Save_DualWriteAndCanonicalKey(t *testing.T) {
+func TestHandler_Save_LooksUpMasterAndWritesBookmark(t *testing.T) {
 	t.Parallel()
 	store := &fakeSavedStore{exists: false}
-	apps := &fakeApps{}
+	app := testApp(t)
+	// The master record is present in the applications store.
+	apps := &fakeApps{byAuthorityAndName: map[string]applications.PlanningApplication{"471/24/0123/FUL": app}}
 	rec := doReq(t, testMux(t, store, apps), http.MethodPut, "/v1/me/saved-applications/whatever-path-uid", validSaveBody)
 
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("status: got %d, want 204 (body %s)", rec.Code, rec.Body)
 	}
-	if len(apps.upserted) != 1 || apps.upserted[0].Name != "24/0123/FUL" {
-		t.Errorf("master record not upserted: %+v", apps.upserted)
+	// No write to the shared Applications container.
+	if apps.writeCount != 0 {
+		t.Errorf("must not write to master Applications container: writeCount=%d", apps.writeCount)
 	}
+	// Per-user bookmark written with canonical uid from the master record.
 	if len(store.saved) != 1 || store.saved[0].ApplicationUID != "471/24/0123/FUL" {
 		t.Errorf("saved row not keyed on canonical uid: %+v", store.saved)
 	}
@@ -90,16 +100,17 @@ func TestHandler_Save_DualWriteAndCanonicalKey(t *testing.T) {
 
 func TestHandler_Save_IdempotentWhenAlreadySaved(t *testing.T) {
 	t.Parallel()
+	app := testApp(t)
 	store := &fakeSavedStore{exists: true}
-	apps := &fakeApps{}
+	apps := &fakeApps{byAuthorityAndName: map[string]applications.PlanningApplication{"471/24/0123/FUL": app}}
 	rec := doReq(t, testMux(t, store, apps), http.MethodPut, "/v1/me/saved-applications/x", validSaveBody)
 
 	if rec.Code != http.StatusNoContent {
 		t.Fatalf("status: got %d", rec.Code)
 	}
-	// Master record still upserted, but no duplicate saved row written.
-	if len(apps.upserted) != 1 {
-		t.Errorf("master upsert should still run: %+v", apps.upserted)
+	// No write to the shared Applications container.
+	if apps.writeCount != 0 {
+		t.Errorf("must not write to master Applications container: writeCount=%d", apps.writeCount)
 	}
 	if len(store.saved) != 0 {
 		t.Errorf("must not re-save when already saved: %+v", store.saved)
@@ -271,5 +282,82 @@ func TestHandler_List_DedupsLegacyAndCanonicalPair(t *testing.T) {
 	// Canonical already existed, so re-key only drops the legacy duplicate.
 	if len(store.deletedUID) != 1 || store.deletedUID[0] != "ABC-1" {
 		t.Errorf("legacy duplicate not dropped: %+v", store.deletedUID)
+	}
+}
+
+// TestSave_DoesNotWriteMasterRecordForUnknownApplication asserts that saving an
+// application whose uid/name does not correspond to any master record in the
+// Applications container returns 404 and writes nothing to that container.
+func TestSave_DoesNotWriteMasterRecordForUnknownApplication(t *testing.T) {
+	t.Parallel()
+	store := &fakeSavedStore{}
+	// The apps store has no record matching the body's (areaId, name).
+	apps := &fakeApps{}
+	rec := doReq(t, testMux(t, store, apps), http.MethodPut, "/v1/me/saved-applications/unknown", validSaveBody)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+	// No write to the Applications container.
+	if apps.writeCount != 0 {
+		t.Errorf("must not write to master Applications container: writeCount=%d", apps.writeCount)
+	}
+	// No per-user bookmark written.
+	if len(store.saved) != 0 {
+		t.Errorf("must not write bookmark for unknown application: %+v", store.saved)
+	}
+}
+
+// TestSave_PersistsBookmarkForKnownApplication asserts that saving an
+// application that exists in the Applications container writes the per-user
+// bookmark and returns 204, without touching the shared container.
+func TestSave_PersistsBookmarkForKnownApplication(t *testing.T) {
+	t.Parallel()
+	app := testApp(t)
+	apps := &fakeApps{byAuthorityAndName: map[string]applications.PlanningApplication{"471/24/0123/FUL": app}}
+	store := &fakeSavedStore{exists: false}
+	rec := doReq(t, testMux(t, store, apps), http.MethodPut, "/v1/me/saved-applications/x", validSaveBody)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status: got %d, want 204", rec.Code)
+	}
+	if apps.writeCount != 0 {
+		t.Errorf("must not write to master Applications container: writeCount=%d", apps.writeCount)
+	}
+	if len(store.saved) != 1 {
+		t.Fatalf("expected 1 bookmark saved, got %d", len(store.saved))
+	}
+	if store.saved[0].ApplicationUID != "471/24/0123/FUL" {
+		t.Errorf("bookmark uid: got %q, want %q", store.saved[0].ApplicationUID, "471/24/0123/FUL")
+	}
+	if store.saved[0].UserID != user {
+		t.Errorf("bookmark userID: got %q, want %q", store.saved[0].UserID, user)
+	}
+}
+
+// TestSave_RejectsForgedApplication asserts that a forged body for a
+// non-existent application causes no write to the Applications container and
+// returns a rejection (404). Regression: GET /v1/applications/{authorityCode}/{name}
+// must not be able to return attacker-supplied content via the save endpoint.
+func TestSave_RejectsForgedApplication(t *testing.T) {
+	t.Parallel()
+	// Forged body: attacker-chosen address, description, and coordinates for a
+	// record that does not exist in the master Applications container.
+	forgedBody := `{"name":"24/9999/FUL","uid":"forged-uid","areaName":"City of London","areaId":471,"address":"FORGED ADDRESS","description":"FORGED DESCRIPTION","latitude":51.5,"longitude":-0.12,"lastDifferent":"2026-03-02T09:30:00+00:00"}`
+	apps := &fakeApps{} // no master record for (471, "24/9999/FUL")
+	store := &fakeSavedStore{}
+
+	rec := doReq(t, testMux(t, store, apps), http.MethodPut, "/v1/me/saved-applications/forged", forgedBody)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404 — forged application must be rejected", rec.Code)
+	}
+	// The Applications container received no write calls.
+	if apps.writeCount != 0 {
+		t.Errorf("must not write forged data to Applications container: writeCount=%d", apps.writeCount)
+	}
+	// No per-user bookmark written either.
+	if len(store.saved) != 0 {
+		t.Errorf("must not write bookmark for forged application: %+v", store.saved)
 	}
 }


### PR DESCRIPTION
Security audit remediation — finding **F3** (#513), epic #522.

## Problem
`PUT /v1/me/saved-applications/{uid}` decoded the full client body and `Upsert`-ed it into the **shared master Applications container** (read by every user and the anonymous demo endpoint), validating only non-blank `uid`/`name`. Any authenticated user could forge or overwrite globally-served planning records (OWASP API3/API8).

## Fix — look-up (not trust-the-body)
Per the chosen approach (look-up, poller is sole source of truth):
- Removed `Upsert` from the `appStore` consumer-side interface and deleted `saveRequest.toApplication()` (the body→record mapper) — the attack surface is gone entirely, not just guarded.
- `save` now resolves the canonical record via `appStore.GetByAuthorityAndName(authorityCode, name)` (an existing Cosmos **point-read** — injection-safe).
  - **Not found** → `404 Application not found`, nothing written to the Applications container.
  - **Found** → the per-user bookmark is written via the existing `store.Save` path, built from the **canonical master record** (never the client body); idempotent via the existing `Exists` check; returns `204`.
- The per-user saved-row write (correctly `userID`-partitioned) is unchanged.

## Tests
- `TestSave_DoesNotWriteMasterRecordForUnknownApplication` — unknown app ⇒ 404, no write to Applications container
- `TestSave_PersistsBookmarkForKnownApplication` — known app ⇒ bookmark written, 204, app-store write count 0
- `TestSave_RejectsForgedApplication` — forged body ⇒ 404, nothing written
- Updated two existing tests to assert the app store receives no write (replacing the old dual-write assertions)

Gate: `golangci-lint run ./internal/savedapplications/...` = 0 issues, `go test ./...` (927 pass), `go test -race ./...`, `go vet`, `gofmt -l .`, `go build` all clean.

Epic: #522 · Bead: tc-ta40 · Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)