### PR TITLE
fix(api-go): offer-code redemption CAS prevents multi-redeem race (#514)

### DIFF
--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -90,6 +90,27 @@ func (f *fakeItems) QueryItemsCrossPartition(_ context.Context, _ string, _ map[
 	return nil, nil
 }
 
+// ReadItemWithETag returns the item body and a synthetic etag, satisfying the
+// offercodes.cosmosItems CAS interface.
+func (f *fakeItems) ReadItemWithETag(_ context.Context, _, id string) ([]byte, string, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	raw, ok := f.items[id]
+	if !ok {
+		return nil, "", false, nil
+	}
+	return raw, "etag-" + id, true, nil
+}
+
+// ReplaceItemWithETag replaces the item unconditionally (no real etag enforcement
+// needed in wiring tests).
+func (f *fakeItems) ReplaceItemWithETag(_ context.Context, _ string, id string, item []byte, _ string) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.items[id] = item
+	return "etag-replaced-" + id, nil
+}
+
 func (f *fakeItems) QueryPageCrossPartition(_ context.Context, _ string, _ map[string]any, _ int, _ string) ([][]byte, string, error) {
 	return nil, "", nil
 }

--- a/api-go/internal/offercodes/handler.go
+++ b/api-go/internal/offercodes/handler.go
@@ -15,12 +15,22 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
 
+// maxCASRetries is the maximum number of etag-conditional replace attempts for
+// the redemption CAS loop. After this many ErrCASPreconditionFailed responses
+// the handler treats the code as already redeemed (the overwhelmingly likely
+// cause is a concurrent winner).
+const maxCASRetries = 3
+
 const maxBodyBytes = 1 << 20
 
 // codeStore is the consumer-side offer-code store the redeem handler needs.
 type codeStore interface {
 	Get(ctx context.Context, canonical string) (OfferCode, error)
 	Save(ctx context.Context, c OfferCode) error
+	// RedeemWithCAS atomically redeems the code using an etag-conditional replace.
+	// Returns ErrNotFound, ErrAlreadyRedeemed, or platform.ErrCASPreconditionFailed
+	// (etag mismatch — lost the CAS race to a concurrent writer).
+	RedeemWithCAS(ctx context.Context, canonical, userID string, now time.Time) error
 }
 
 // profileStore is the consumer-side profile store: the redeem path loads the
@@ -92,6 +102,9 @@ func (h *handler) redeem(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Verify the code exists and is not already redeemed before loading the
+	// profile. This is a fast-path check; the CAS loop below is the authoritative
+	// single-use enforcement.
 	code, err := h.codes.Get(r.Context(), canonical)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -121,17 +134,59 @@ func (h *handler) redeem(w http.ResponseWriter, r *http.Request) {
 	}
 
 	now := h.now()
-	if err := code.Redeem(userID, now); err != nil {
-		h.serverError(w, r, "redeem offer code", err)
+
+	// CAS retry loop: RedeemWithCAS does read→redeem-in-memory→etag-conditional
+	// replace, making the redemption atomic. On ErrCASPreconditionFailed (412 — a
+	// concurrent writer mutated the document first) we re-read to decide whether
+	// to retry or surface 409.
+	var redeemErr error
+	for range maxCASRetries {
+		redeemErr = h.codes.RedeemWithCAS(r.Context(), canonical, userID, now)
+		if redeemErr == nil {
+			break
+		}
+		if !errors.Is(redeemErr, platform.ErrCASPreconditionFailed) {
+			break
+		}
+		// Lost the CAS race. Re-read the code to determine its current state.
+		reread, rerr := h.codes.Get(r.Context(), canonical)
+		if rerr != nil {
+			h.serverError(w, r, "re-read offer code after CAS conflict", rerr)
+			return
+		}
+		if reread.IsRedeemed() {
+			// Another request won — treat as already redeemed.
+			h.writeError(r, w, http.StatusConflict, "code_already_redeemed", "Offer code '"+canonical+"' has already been redeemed.")
+			return
+		}
+		// Code still available after conflict (very rare); loop to retry.
+	}
+	switch {
+	case redeemErr == nil:
+		// success — fall through
+	case errors.Is(redeemErr, ErrAlreadyRedeemed):
+		h.writeError(r, w, http.StatusConflict, "code_already_redeemed", "Offer code '"+canonical+"' has already been redeemed.")
+		return
+	case errors.Is(redeemErr, platform.ErrCASPreconditionFailed):
+		// Exhausted retries without winning; treat conservatively as already redeemed.
+		h.writeError(r, w, http.StatusConflict, "code_already_redeemed", "Offer code '"+canonical+"' has already been redeemed.")
+		return
+	default:
+		h.serverError(w, r, "redeem offer code", redeemErr)
 		return
 	}
+
+	// RedeemWithCAS persisted the redeemed code atomically; re-read for the tier
+	// and duration so the profile grant is based on the authoritative stored state.
+	code, err = h.codes.Get(r.Context(), canonical)
+	if err != nil {
+		h.serverError(w, r, "reload offer code after redeem", err)
+		return
+	}
+
 	expiry := now.AddDate(0, 0, code.DurationDays)
 	profile.ActivateSubscription(code.Tier, expiry)
 
-	if err := h.codes.Save(r.Context(), code); err != nil {
-		h.serverError(w, r, "save offer code", err)
-		return
-	}
 	if err := h.profiles.Save(r.Context(), profile); err != nil {
 		h.serverError(w, r, "save profile", err)
 		return

--- a/api-go/internal/offercodes/handler_test.go
+++ b/api-go/internal/offercodes/handler_test.go
@@ -6,10 +6,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
 
@@ -17,9 +19,17 @@ type fakeCodeStore struct {
 	codes   map[string]OfferCode
 	saved   *OfferCode
 	saveErr error
+	// casConflictOnce, when true, causes the first RedeemWithCAS call to return
+	// ErrCASPreconditionFailed and then mark the code as already redeemed on
+	// subsequent Get calls — driving the "lost CAS race" path in the handler.
+	casConflictOnce  bool
+	casConflictFired bool
+	mu               sync.Mutex
 }
 
 func (f *fakeCodeStore) Get(_ context.Context, canonical string) (OfferCode, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	c, ok := f.codes[canonical]
 	if !ok {
 		return OfferCode{}, ErrNotFound
@@ -31,6 +41,40 @@ func (f *fakeCodeStore) Save(_ context.Context, c OfferCode) error {
 	if f.saveErr != nil {
 		return f.saveErr
 	}
+	cp := c
+	f.saved = &cp
+	return nil
+}
+
+// RedeemWithCAS is the CAS-aware redemption path. When casConflictOnce is set
+// and the conflict has not yet been fired, it returns ErrCASPreconditionFailed
+// and marks the code as redeemed so the handler's re-read observes the redeemed
+// state and returns 409. Otherwise it mutates the stored code and returns nil.
+func (f *fakeCodeStore) RedeemWithCAS(_ context.Context, canonical, userID string, now time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.casConflictOnce && !f.casConflictFired {
+		f.casConflictFired = true
+		// Mark the stored code as redeemed so a subsequent Get sees it redeemed.
+		if c, ok := f.codes[canonical]; ok {
+			uid := "auth0|someone-else"
+			c.Redeemed = true
+			c.RedeemedByUserID = &uid
+			f.codes[canonical] = c
+		}
+		return platform.ErrCASPreconditionFailed
+	}
+	c, ok := f.codes[canonical]
+	if !ok {
+		return ErrNotFound
+	}
+	if c.IsRedeemed() {
+		return ErrAlreadyRedeemed
+	}
+	if err := c.Redeem(userID, now); err != nil {
+		return err
+	}
+	f.codes[canonical] = c
 	cp := c
 	f.saved = &cp
 	return nil
@@ -203,4 +247,83 @@ func TestCosmosStore_SatisfiesProfileStore(t *testing.T) {
 	t.Parallel()
 	// The real profiles.CosmosStore must satisfy the redeem handler's profileStore.
 	var _ profileStore = profiles.NewCosmosStore(nil)
+}
+
+// TestRedeem_CASConflictReturns409 exercises the handler's CAS retry loop: the
+// fake store returns ErrCASPreconditionFailed on the first RedeemWithCAS call
+// (simulating a concurrent writer winning the race) and marks the code as
+// already-redeemed on the subsequent Get re-read, so the handler must surface
+// 409 code_already_redeemed.
+func TestRedeem_CASConflictReturns409(t *testing.T) {
+	t.Parallel()
+
+	codes := seededCode(t)
+	codes.casConflictOnce = true
+	profile := &fakeProfileStore{profile: freeProfile(t)}
+	auth0 := &fakeTierSync{}
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	rec := serveRedeem(t, codes, profile, auth0, now, `{"code":"abcd-efgh-jkmn"}`)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != `{"error":"code_already_redeemed","message":"Offer code 'ABCDEFGHJKMN' has already been redeemed."}` {
+		t.Errorf("body = %s", got)
+	}
+	// Auth0 must not be called when redemption fails.
+	if auth0.calls != 0 {
+		t.Errorf("auth0 should not be called on CAS conflict, got %d calls", auth0.calls)
+	}
+}
+
+// TestRedeem_ConcurrentRedemptionsYieldOneSuccess fires two concurrent redeem
+// requests against the same code. Because the fake store serialises RedeemWithCAS
+// under its mutex, exactly one caller wins; the loser observes the code as
+// already-redeemed on its re-read and receives 409.
+func TestRedeem_ConcurrentRedemptionsYieldOneSuccess(t *testing.T) {
+	t.Parallel()
+
+	// Build a store whose RedeemWithCAS is concurrency-safe: the first caller
+	// wins, the second sees the code already redeemed.
+	c, err := NewOfferCode("ABCDEFGHJKMN", profiles.TierPro, 30, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewOfferCode: %v", err)
+	}
+	codes := &fakeCodeStore{codes: map[string]OfferCode{"ABCDEFGHJKMN": c}}
+
+	profile1 := &fakeProfileStore{profile: freeProfile(t)}
+	profile2 := &fakeProfileStore{profile: freeProfile(t)}
+	auth0a := &fakeTierSync{}
+	auth0b := &fakeTierSync{}
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+	var wg sync.WaitGroup
+	results := make([]int, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		rec := serveRedeem(t, codes, profile1, auth0a, now, `{"code":"abcd-efgh-jkmn"}`)
+		results[0] = rec.Code
+	}()
+	go func() {
+		defer wg.Done()
+		rec := serveRedeem(t, codes, profile2, auth0b, now, `{"code":"abcd-efgh-jkmn"}`)
+		results[1] = rec.Code
+	}()
+	wg.Wait()
+
+	successes := 0
+	conflicts := 0
+	for _, code := range results {
+		switch code {
+		case http.StatusOK:
+			successes++
+		case http.StatusConflict:
+			conflicts++
+		}
+	}
+	if successes != 1 || conflicts != 1 {
+		t.Errorf("want 1 success + 1 conflict, got statuses %v", results)
+	}
 }

--- a/api-go/internal/offercodes/store_cosmos.go
+++ b/api-go/internal/offercodes/store_cosmos.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
@@ -14,14 +15,16 @@ import (
 var ErrNotFound = errors.New("offer code not found")
 
 // cosmosItems is the consumer-side slice of the Cosmos container the store
-// uses: single-partition point read/upsert keyed on the canonical code, plus a
-// cross-partition scan for the GDPR anonymise path (the container is keyed by
-// code, not by redeemer, so finding a user's redemptions must fan out across
-// partitions). The azcosmos-backed platform.CosmosContainer satisfies it
-// structurally.
+// uses: single-partition point read/upsert keyed on the canonical code, a
+// CAS-aware read+replace for atomic redemption, and a cross-partition scan for
+// the GDPR anonymise path (the container is keyed by code, not by redeemer, so
+// finding a user's redemptions must fan out across partitions). The
+// azcosmos-backed platform.CosmosContainer satisfies it structurally.
 type cosmosItems interface {
 	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
 	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
+	ReadItemWithETag(ctx context.Context, partitionKey, id string) (body []byte, etag string, found bool, err error)
+	ReplaceItemWithETag(ctx context.Context, partitionKey, id string, item []byte, etag string) (string, error)
 	QueryItemsCrossPartition(ctx context.Context, query string, params map[string]any) ([][]byte, error)
 }
 
@@ -61,6 +64,50 @@ func (s *CosmosStore) Save(ctx context.Context, c OfferCode) error {
 	}
 	if err := s.items.UpsertItem(ctx, c.Code, body); err != nil {
 		return fmt.Errorf("upsert offer code %q: %w", c.Code, err)
+	}
+	return nil
+}
+
+// RedeemWithCAS atomically redeems the code using a read+etag-conditional
+// replace so concurrent redeems of the same code yield at most one success.
+//
+// Returns:
+//   - nil on success (the code is now persisted as redeemed).
+//   - ErrNotFound if the code does not exist.
+//   - ErrAlreadyRedeemed if the code is already redeemed at read time.
+//   - platform.ErrCASPreconditionFailed if a concurrent writer mutated the
+//     document between the read and the replace (412 etag mismatch). The caller
+//     should re-read and retry, or treat it as code_already_redeemed.
+func (s *CosmosStore) RedeemWithCAS(ctx context.Context, canonical, userID string, now time.Time) error {
+	raw, etag, found, err := s.items.ReadItemWithETag(ctx, canonical, canonical)
+	if err != nil {
+		return fmt.Errorf("read offer code %q for CAS redeem: %w", canonical, err)
+	}
+	if !found {
+		return ErrNotFound
+	}
+	var doc offerCodeDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return fmt.Errorf("decode offer code %q: %w", canonical, err)
+	}
+	code, err := doc.toDomain()
+	if err != nil {
+		return fmt.Errorf("parse offer code %q: %w", canonical, err)
+	}
+	if code.IsRedeemed() {
+		return ErrAlreadyRedeemed
+	}
+	if err := code.Redeem(userID, now); err != nil {
+		return fmt.Errorf("redeem offer code %q: %w", canonical, err)
+	}
+	updated, err := json.Marshal(newOfferCodeDocument(code))
+	if err != nil {
+		return fmt.Errorf("encode redeemed offer code %q: %w", canonical, err)
+	}
+	if _, err := s.items.ReplaceItemWithETag(ctx, canonical, canonical, updated, etag); err != nil {
+		// ErrCASPreconditionFailed surfaces unwrapped so the handler can detect it
+		// with errors.Is and decide whether to retry or map to 409.
+		return fmt.Errorf("replace offer code %q: %w", canonical, err)
 	}
 	return nil
 }

--- a/api-go/internal/offercodes/store_cosmos_test.go
+++ b/api-go/internal/offercodes/store_cosmos_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
 
@@ -17,10 +18,20 @@ import (
 // without a real Cosmos.
 type fakeItems struct {
 	items    map[string][]byte
+	etags    map[string]string // simulated etags keyed by item id
 	queryErr error
+	// replaceConflictOnce, when true, causes the first ReplaceItemWithETag call to
+	// return ErrCASPreconditionFailed, simulating a concurrent write winning the race.
+	replaceConflictOnce  bool
+	replaceConflictFired bool
 }
 
-func newFakeItems() *fakeItems { return &fakeItems{items: map[string][]byte{}} }
+func newFakeItems() *fakeItems {
+	return &fakeItems{
+		items: map[string][]byte{},
+		etags: map[string]string{},
+	}
+}
 
 func (f *fakeItems) ReadItem(_ context.Context, _, id string) ([]byte, error) {
 	raw, ok := f.items[id]
@@ -32,7 +43,39 @@ func (f *fakeItems) ReadItem(_ context.Context, _, id string) ([]byte, error) {
 
 func (f *fakeItems) UpsertItem(_ context.Context, partitionKey string, item []byte) error {
 	f.items[partitionKey] = item
+	f.etags[partitionKey] = "etag-" + partitionKey
 	return nil
+}
+
+// ReadItemWithETag returns the item body and a synthetic etag.
+func (f *fakeItems) ReadItemWithETag(_ context.Context, _, id string) ([]byte, string, bool, error) {
+	raw, ok := f.items[id]
+	if !ok {
+		return nil, "", false, nil
+	}
+	etag := f.etags[id]
+	if etag == "" {
+		etag = "etag-" + id
+	}
+	return raw, etag, true, nil
+}
+
+// ReplaceItemWithETag replaces the item if the etag matches. When
+// replaceConflictOnce is set and the conflict has not yet been fired, it returns
+// ErrCASPreconditionFailed without modifying the store.
+func (f *fakeItems) ReplaceItemWithETag(_ context.Context, partitionKey, _ string, item []byte, etag string) (string, error) {
+	if f.replaceConflictOnce && !f.replaceConflictFired {
+		f.replaceConflictFired = true
+		return "", platform.ErrCASPreconditionFailed
+	}
+	current := f.etags[partitionKey]
+	if current != "" && current != etag {
+		return "", platform.ErrCASPreconditionFailed
+	}
+	newETag := "etag-replaced-" + partitionKey
+	f.items[partitionKey] = item
+	f.etags[partitionKey] = newETag
+	return newETag, nil
 }
 
 // QueryItemsCrossPartition implements the redeemed-by scan the anonymise path


### PR DESCRIPTION
Security audit remediation — finding **F4** (#514), epic #522.

## Problem
Offer-code redemption was a read-then-write race: `codes.Get` → `IsRedeemed()` check → `Redeem(userID)` → `codes.Save` (a plain last-writer-wins `UpsertItem`). N concurrent `POST /v1/offer-codes/redeem` for one single-use code all observed the unredeemed doc and each upgraded their own profile — single-use guarantee violated, revenue leakage (OWASP API6).

## Fix — compare-and-swap (reusing the proven primitive)
Reuses `internal/platform/cosmos_cas.go` (`ReadItemWithETag` + `ReplaceItemWithETag`), the same pattern the polling lease store uses:
- New `CosmosStore.RedeemWithCAS` does read → redeem-in-memory → **etag-conditional replace** atomically.
- The handler wraps it in a bounded retry loop (max 3): on `ErrCASPreconditionFailed` (412 — a concurrent writer won) it re-reads; if the code is now redeemed → `409 code_already_redeemed`; otherwise retries. Exhausted retries also map conservatively to `409`.
- On success, the code is re-read for authoritative tier/duration before granting the subscription.
- Existing contracts preserved: single redemption still succeeds and grants the tier; an already-redeemed code still returns `409`.

**Note:** the issue named `ErrCASConflict` generically, but the correct primitive for a conditional *replace* race is `ErrCASPreconditionFailed` (412); `ErrCASConflict` (409) is for create-conflicts. Implemented with the correct one.

## Tests
- `TestRedeem_ConcurrentRedemptionsYieldOneSuccess` — two concurrent redeems ⇒ exactly 1 success + 1 `409` (passes under `-race`)
- `TestRedeem_CASConflictReturns409` — injected `ErrCASPreconditionFailed` ⇒ `409`, Auth0 not called

Gate: `golangci-lint run ./internal/offercodes/...` = 0 issues, `go test -race ./...` (929 pass), `go vet`, `gofmt -l .`, `go build` all clean.

Epic: #522 · Bead: tc-2vun · Closes #514

🤖 Generated with [Claude Code](https://claude.com/claude-code)