### PR TITLE
fix(copy): voice-align user-facing copy across web and iOS

### DIFF
--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/DomainError.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/DomainError.swift
@@ -70,7 +70,7 @@ public enum DomainError: Error, Equatable, Sendable {
     case .purchaseFailed, .purchaseCancelled, .restoreFailed, .productNotFound:
       return "There was a problem with your purchase. Please try again."
     case .insufficientEntitlement:
-      return "This feature requires a higher subscription tier. Upgrade to unlock it."
+      return "This feature is on a higher plan. Upgrade to use it."
     case .invalidPostcode(let raw):
       return "The postcode '\(raw)' doesn't look right. Please enter a valid UK postcode."
     case .geocodingFailed:

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/LargeRadiusWarningView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/LargeRadiusWarningView.swift
@@ -32,7 +32,7 @@ public struct LargeRadiusWarningView: View {
         Text(
           """
           A wide watch zone can produce hundreds of notifications a day, \
-          especially in cities. We recommend 100–500 m in built-up areas, \
+          especially in cities. We recommend 100-500 m in built-up areas, \
           and under 2 km everywhere else.
           """
         )

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionUpsellSheet.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionUpsellSheet.swift
@@ -4,7 +4,7 @@ import TownCrierDomain
 /// A reusable sheet presented when a user attempts an action above their subscription tier.
 ///
 /// Design (from spec 2.5):
-/// - Title: "Upgrade to unlock"
+/// - Title: "Upgrade to use this"
 /// - Body: describes the specific feature (parameterised by entitlement)
 /// - CTA: "View Plans" -- navigates to existing `SubscriptionView`
 /// - Secondary: "Not now" -- dismisses
@@ -37,7 +37,7 @@ public struct SubscriptionUpsellSheet: View {
         .foregroundStyle(Color.tcAmber)
 
       // Title
-      Text("Upgrade to unlock")
+      Text("Upgrade to use this")
         .font(TCTypography.displaySmall)
         .foregroundStyle(Color.tcTextPrimary)
 

--- a/mobile/ios/town-crier-tests/Sources/Features/DomainErrorMessageTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DomainErrorMessageTests.swift
@@ -54,7 +54,7 @@ struct DomainErrorMessageTests {
     let error = DomainError.insufficientEntitlement(required: "statusChangeAlerts")
     #expect(
       error.userMessage
-        == "This feature requires a higher subscription tier. Upgrade to unlock it."
+        == "This feature is on a higher plan. Upgrade to use it."
     )
   }
 

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -22,8 +22,8 @@ export class ErrorBoundary extends Component<Props, State> {
         <div className={styles.container}>
           <h1 className={styles.title}>Something went wrong</h1>
           <p className={styles.message}>
-            The application encountered an unexpected error. Please try
-            refreshing the page.
+            That&apos;s on our end, not yours. Refreshing the page usually fixes
+            it.
           </p>
           <button
             className={styles.button}

--- a/web/src/components/Faq/Faq.tsx
+++ b/web/src/components/Faq/Faq.tsx
@@ -9,27 +9,27 @@ const FAQ_ITEMS: FaqItem[] = [
   {
     question: 'Where does the data come from?',
     answer:
-      'Town Crier sources its data from PlanIt (planit.org.uk), the UK\u2019s leading aggregator of planning application data. We poll local authority feeds regularly so you see new applications shortly after they\u2019re published.',
+      'Town Crier gets its data from PlanIt (planit.org.uk), which aggregates planning applications from local authorities across the UK. We poll those feeds regularly, so you see new applications shortly after they\u2019re published.',
   },
   {
     question: 'Which areas do you cover?',
     answer:
-      'We cover local planning authorities across the whole UK \u2014 England, Scotland, Wales, and Northern Ireland. If your area isn\u2019t listed yet, let us know and we\u2019ll prioritise it.',
+      'We cover local planning authorities across the whole UK: England, Scotland, Wales and Northern Ireland. If something looks missing for your area, let us know and we\u2019ll look into it.',
   },
   {
     question: 'Is there a free tier?',
     answer:
-      'Yes. The Free plan lets you monitor one watch zone with weekly email digests at no cost, forever. Upgrade any time if you need more zones, wider radii, or instant push notifications.',
+      'Yes. The Free plan monitors one watch zone and sends a weekly email digest, free forever. Upgrade any time for more zones, a wider radius, and instant alerts as applications land: push notifications on iOS and instant emails. The weekly digest stays available on every plan.',
   },
   {
     question: 'Can communities use Town Crier?',
     answer:
-      'Absolutely. Neighbourhood forums, civic societies, and residents\u2019 associations use Town Crier to stay on top of planning activity in their area. The Pro plan supports multiple watch zones for broader coverage.',
+      'Yes. Neighbourhood forums, civic societies and residents\u2019 associations use Town Crier to keep track of planning activity in their area. The Pro plan adds more watch zones for wider coverage.',
   },
   {
     question: 'How quickly will I be notified?',
     answer:
-      'Most applications appear within hours of being published by the local authority. Paid plans receive instant push notifications; the Free plan delivers a weekly digest email.',
+      'Most applications appear within hours of being published by the local authority. Paid plans get instant push notifications. The Free plan sends a weekly digest email.',
   },
 ];
 

--- a/web/src/components/Hero/Hero.tsx
+++ b/web/src/components/Hero/Hero.tsx
@@ -11,8 +11,8 @@ export function Hero() {
         Stay informed about what&apos;s being built in your neighbourhood
       </h1>
       <p className={styles.subheading}>
-        Monitoring planning applications across the UK, so you don&apos;t have
-        to.
+        We watch planning applications across the UK and tell you when
+        something&apos;s proposed near you.
       </p>
       <div className={styles.ctaGroup}>
         <a

--- a/web/src/components/LargeRadiusWarning/LargeRadiusWarning.tsx
+++ b/web/src/components/LargeRadiusWarning/LargeRadiusWarning.tsx
@@ -26,7 +26,7 @@ export function LargeRadiusWarning({ radiusMetres }: Props) {
         <p className={styles.title}>Heads up: large zones get noisy</p>
         <p className={styles.body}>
           A wide watch zone can produce hundreds of notifications a day, especially in
-          cities. We recommend 100–500m in built-up areas, and under 2km everywhere
+          cities. We recommend 100-500m in built-up areas, and under 2km everywhere
           else.
         </p>
       </div>

--- a/web/src/components/Pricing/Pricing.tsx
+++ b/web/src/components/Pricing/Pricing.tsx
@@ -12,7 +12,7 @@ const FEATURES: Feature[] = [
   { label: 'Radius', free: '500m', personal: '2km', pro: '5km' },
   { label: 'Notifications', free: 'Weekly digest', personal: 'Instant', pro: 'Instant' },
   { label: 'Search', free: 'Basic', personal: 'Advanced', pro: 'Advanced + Filters' },
-  { label: 'Historical Data', free: '—', personal: '6 months', pro: '5 years' },
+  { label: 'Historical Data', free: 'None', personal: '6 months', pro: '5 years' },
 ];
 
 interface Tier {

--- a/web/src/components/ProGate/ProGate.tsx
+++ b/web/src/components/ProGate/ProGate.tsx
@@ -11,7 +11,7 @@ export function ProGate({ featureName }: Props) {
       <h2 className={styles.title}>Pro Feature</h2>
       <p className={styles.message}>
         <span className={styles.highlight}>{featureName}</span> is available on
-        the Pro plan. Upgrade in the iOS app to unlock this feature.
+        the Pro plan. Upgrade in the iOS app to turn it on.
       </p>
     </div>
   );


### PR DESCRIPTION
## Changes

Copy review grounded in the user's voice (bead tc-if6u). Pure string changes, no behaviour change.

- **Web**
  - Hero subheading: concrete rewrite ("We watch planning applications across the UK and tell you when something's proposed near you")
  - FAQ: removed em dash, dropped unverifiable "leading aggregator", and the free-tier answer now spells out that paid plans get instant iOS push + instant emails while the weekly digest stays on every plan
  - Pricing: Historical Data (Free) `—` → `None`
  - LargeRadiusWarning: en dash → hyphen in "100-500m"
  - ProGate: dropped banned "unlock" ("turn it on")
  - ErrorBoundary: plainer, situation-blaming message
- **iOS**
  - SubscriptionUpsellSheet title: "Upgrade to unlock" → "Upgrade to use this"
  - DomainError insufficientEntitlement message: dropped "unlock" (+ matching test)
  - LargeRadiusWarningView: en dash → hyphen

Left untouched on purpose: the "Download on the App Store" CTA (deliberately points at TestFlight pre-launch, tested) and legal docs (compliance).

Affected web tests pass (65) and `tsc` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Copy Updates**
  * Clarified subscription upgrade prompts to specify "upgrade to use" messaging across app and web
  * Updated error messages for insufficient entitlements and system errors
  * Improved FAQ answers addressing data sources and coverage areas
  * Refined hero section and warning message text for clarity
  * Updated pricing display to show "None" instead of dash for free tier features

* **Tests**
  * Updated error message tests to reflect new copy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->