### PR TITLE
fix(api-go): cheap webhook pre-check before JWS chain verify (#517)

### DIFF
--- a/api-go/internal/subscriptions/handler.go
+++ b/api-go/internal/subscriptions/handler.go
@@ -18,6 +18,16 @@ import (
 
 const maxBodyBytes = 1 << 20
 
+// maxWebhookPayloadBytes is the upper bound on the SignedPayload field of an
+// App Store Server Notification before JWS verification is attempted. A real
+// Apple notification outer JWS is roughly 2–4 KB (header + notification JSON +
+// three X.509 DER certificates base64url-encoded in the x5c header). 32 KB
+// gives a generous 8× headroom above the realistic maximum and is still cheap
+// enough to check in a single len() call, well below the 1 MiB body cap.
+// Anything larger cannot be a genuine Apple notification and is rejected before
+// the expensive X.509 chain verification runs.
+const maxWebhookPayloadBytes = 32 * 1024
+
 // jwsVerifier verifies and decodes an Apple StoreKit JWS. *JWSVerifier satisfies it.
 type jwsVerifier interface {
 	VerifyAndDecode(signedPayload string) (string, error)
@@ -70,6 +80,26 @@ type conflictError struct{}
 
 func (e *conflictError) Error() string {
 	return "Transaction is already claimed by another account."
+}
+
+// isCompactJWS reports whether s is a syntactically valid compact JWS:
+// exactly three non-empty segments separated by two dots
+// (header.payload.signature). It performs no base64url decoding or JSON
+// parsing — the intent is a cheap shape check before expensive crypto.
+func isCompactJWS(s string) bool {
+	first := strings.Index(s, ".")
+	if first <= 0 {
+		return false
+	}
+	rest := s[first+1:]
+	second := strings.Index(rest, ".")
+	if second <= 0 {
+		return false
+	}
+	// The third segment is everything after the second dot; it must be non-empty
+	// and must not contain another dot.
+	third := rest[second+1:]
+	return len(third) > 0 && !strings.Contains(third, ".")
 }
 
 // envAllowed reports whether env appears in the allowlist, comparing
@@ -267,6 +297,24 @@ func (h *handler) webhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if strings.TrimSpace(req.SignedPayload) == "" {
+		h.malformedBody(r, w)
+		return
+	}
+
+	// F7: cheap structural pre-checks — run BEFORE the expensive JWS X.509
+	// chain verification so an attacker cannot drive CPU cost with
+	// attacker-controlled input.
+	//
+	// 1. Size bound: reject payloads that exceed the realistic maximum for a
+	//    genuine Apple App Store Server Notification JWS. This is a secondary
+	//    guard; the 1 MiB MaxBytesReader on the body already exists.
+	if len(req.SignedPayload) > maxWebhookPayloadBytes {
+		h.malformedBody(r, w)
+		return
+	}
+	// 2. Compact JWS shape: a valid JWS is exactly header.payload.signature —
+	//    three non-empty segments separated by exactly two dots.
+	if !isCompactJWS(req.SignedPayload) {
 		h.malformedBody(r, w)
 		return
 	}

--- a/api-go/internal/subscriptions/handler_test.go
+++ b/api-go/internal/subscriptions/handler_test.go
@@ -340,10 +340,10 @@ func TestWebhook_SubscribedActivatesProfile(t *testing.T) {
 	t.Parallel()
 	d := newTestDeps()
 	d.byTxn.profile = freshProfile(t)
-	d.verifier.results["OUTER"] = notificationJSON("SUBSCRIBED", "uuid-1", "INNER")
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSON("SUBSCRIBED", "uuid-1", "INNER")
 	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
 
-	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"OUTER"}`, false)
+	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"hdr.OUTER.sig"}`, false)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
@@ -364,10 +364,10 @@ func TestWebhook_DuplicateIsNoOp(t *testing.T) {
 	d := newTestDeps()
 	d.byTxn.profile = freshProfile(t)
 	d.idempotency.processed["uuid-1"] = true
-	d.verifier.results["OUTER"] = notificationJSON("SUBSCRIBED", "uuid-1", "INNER")
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSON("SUBSCRIBED", "uuid-1", "INNER")
 	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs())
 
-	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"OUTER"}`, false)
+	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"hdr.OUTER.sig"}`, false)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d", rec.Code)
@@ -384,10 +384,10 @@ func TestWebhook_UnknownSubscriberStillMarksProcessed(t *testing.T) {
 	t.Parallel()
 	d := newTestDeps()
 	d.byTxn.profile = nil // no matching subscriber
-	d.verifier.results["OUTER"] = notificationJSON("DID_RENEW", "uuid-2", "INNER")
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSON("DID_RENEW", "uuid-2", "INNER")
 	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-x", futureExpiryMs())
 
-	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"OUTER"}`, false)
+	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"hdr.OUTER.sig"}`, false)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d", rec.Code)
@@ -413,18 +413,18 @@ func TestWebhook_ErrorContract(t *testing.T) {
 		{"empty payload", `{"signedPayload":""}`, nil, http.StatusBadRequest, "malformed_request"},
 		{
 			name: "jws failure",
-			body: `{"signedPayload":"BAD"}`,
+			body: `{"signedPayload":"hdr.BAD.sig"}`,
 			setup: func(d *testDeps) {
-				d.verifier.errs["BAD"] = &JWSVerificationError{Message: "bad chain"}
+				d.verifier.errs["hdr.BAD.sig"] = &JWSVerificationError{Message: "bad chain"}
 			},
 			wantStatus: http.StatusUnauthorized,
 			wantError:  "invalid_notification",
 		},
 		{
 			name: "malformed notification payload",
-			body: `{"signedPayload":"OUTER"}`,
+			body: `{"signedPayload":"hdr.OUTER.sig"}`,
 			setup: func(d *testDeps) {
-				d.verifier.results["OUTER"] = `{"notificationType":"SUBSCRIBED","notificationUUID":"u","data":{}}`
+				d.verifier.results["hdr.OUTER.sig"] = `{"notificationType":"SUBSCRIBED","notificationUUID":"u","data":{}}`
 			},
 			wantStatus: http.StatusBadRequest,
 			wantError:  "invalid_notification_payload",
@@ -587,10 +587,10 @@ func TestWebhook_IgnoresSandboxTransactionInProduction(t *testing.T) {
 	t.Parallel()
 	d := newTestDeps() // allowedEnvs = ["Production"]
 	d.byTxn.profile = freshProfile(t)
-	d.verifier.results["OUTER"] = notificationJSON("SUBSCRIBED", "uuid-env1", "INNER_SBX")
+	d.verifier.results["hdr.OUTER.sig"] = notificationJSON("SUBSCRIBED", "uuid-env1", "INNER_SBX")
 	d.verifier.results["INNER_SBX"] = txnJSONEnv(ProductProMonthly, testBundleID, "orig-1", futureExpiryMs(), "Sandbox")
 
-	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"OUTER"}`, false)
+	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"hdr.OUTER.sig"}`, false)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())

--- a/api-go/internal/subscriptions/handler_test.go
+++ b/api-go/internal/subscriptions/handler_test.go
@@ -732,7 +732,7 @@ func TestWebhook_RejectsOversizedPayloadBeforeVerify(t *testing.T) {
 	// Use a large MaxBytesReader so the outer body cap doesn't fire first.
 	// The serve helper applies the handler's own body limit; we bypass it here
 	// by posting a raw request directly to the mux.
-	req := httptest.NewRequest(http.MethodPost, "/v1/webhooks/appstore", strings.NewReader(body))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/v1/webhooks/appstore", strings.NewReader(body))
 	rec := httptest.NewRecorder()
 	d.mux.ServeHTTP(rec, req)
 

--- a/api-go/internal/subscriptions/handler_test.go
+++ b/api-go/internal/subscriptions/handler_test.go
@@ -28,11 +28,13 @@ func pastExpiryMs() int64   { return testNow.AddDate(0, -1, 0).UnixMilli() }
 // --- fakes ---
 
 type fakeVerifier struct {
-	results map[string]string
-	errs    map[string]error
+	results   map[string]string
+	errs      map[string]error
+	callCount int
 }
 
 func (f *fakeVerifier) VerifyAndDecode(signed string) (string, error) {
+	f.callCount++
 	if e, ok := f.errs[signed]; ok {
 		return "", e
 	}
@@ -670,5 +672,97 @@ func TestVerify_AllowsFirstTimeClaim(t *testing.T) {
 	}
 	if d.byUser.saved == nil || d.byUser.saved.Tier != profiles.TierPro {
 		t.Error("profile not saved as Pro on first claim")
+	}
+}
+
+// --- F7: webhook cheap pre-check tests ---
+
+// TestWebhook_RejectsMalformedPayloadBeforeVerify asserts that a SignedPayload
+// that is not a valid compact JWS (header.payload.signature) is rejected with
+// 400 malformed_request WITHOUT the JWS verifier being invoked at all. The
+// verifier call count proves the expensive crypto path is never entered.
+func TestWebhook_RejectsMalformedPayloadBeforeVerify(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		payload string
+	}{
+		{"no dots", "nodots"},
+		{"one dot", "a.b"},
+		{"three dots", "a.b.c.d"},
+		{"empty first segment", ".b.c"},
+		{"empty second segment", "a..c"},
+		{"empty third segment", "a.b."},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := newTestDeps()
+			body := `{"signedPayload":"` + tc.payload + `"}`
+			rec := d.serve(t, "/v1/webhooks/appstore", body, false)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400 (body=%s)", rec.Code, rec.Body.String())
+			}
+			if got := decodeError(t, rec).Error; got != "malformed_request" {
+				t.Errorf("error = %q, want malformed_request", got)
+			}
+			if d.verifier.callCount != 0 {
+				t.Errorf("verifier called %d time(s), want 0 — expensive crypto must not run on malformed input", d.verifier.callCount)
+			}
+		})
+	}
+}
+
+// TestWebhook_RejectsOversizedPayloadBeforeVerify asserts that a SignedPayload
+// exceeding maxWebhookPayloadBytes is rejected with 400 malformed_request
+// WITHOUT invoking the JWS verifier. The verifier call count proves the
+// expensive crypto path is never entered.
+func TestWebhook_RejectsOversizedPayloadBeforeVerify(t *testing.T) {
+	t.Parallel()
+	d := newTestDeps()
+
+	// Build a syntactically valid 3-segment JWS that is over the size bound.
+	// Each segment is a non-empty base64url-like string; the content does not
+	// need to be valid base64 — the size check must fire before decode.
+	bigSeg := strings.Repeat("A", maxWebhookPayloadBytes+1)
+	oversized := bigSeg + "." + bigSeg + "." + bigSeg
+
+	body := `{"signedPayload":"` + oversized + `"}`
+	// Use a large MaxBytesReader so the outer body cap doesn't fire first.
+	// The serve helper applies the handler's own body limit; we bypass it here
+	// by posting a raw request directly to the mux.
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhooks/appstore", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	d.mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if got := decodeError(t, rec).Error; got != "malformed_request" {
+		t.Errorf("error = %q, want malformed_request", got)
+	}
+	if d.verifier.callCount != 0 {
+		t.Errorf("verifier called %d time(s), want 0 — expensive crypto must not run on oversized input", d.verifier.callCount)
+	}
+}
+
+// TestWebhook_WellFormedPayloadReachesVerifier is a positive regression test:
+// a structurally valid 3-segment JWS within the size bound must still reach
+// the verifier (no regression on the happy path introduced by the pre-check).
+func TestWebhook_WellFormedPayloadReachesVerifier(t *testing.T) {
+	t.Parallel()
+	d := newTestDeps()
+	d.byTxn.profile = freshProfile(t)
+	d.verifier.results["hdr.pay.sig"] = notificationJSON("SUBSCRIBED", "uuid-wf1", "INNER")
+	d.verifier.results["INNER"] = txnJSON(ProductProMonthly, testBundleID, "orig-wf1", futureExpiryMs())
+
+	rec := d.serve(t, "/v1/webhooks/appstore", `{"signedPayload":"hdr.pay.sig"}`, false)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if d.verifier.callCount == 0 {
+		t.Error("verifier was not called — well-formed payload must reach the verifier")
 	}
 }


### PR DESCRIPTION
Security audit remediation — finding **F7** (#517), epic #522. **Code portion only.**

## Decision (owner)
The anonymous-route *rate-limiting* part of F7 is being handled at the **edge** (Cloudflare), not via an in-app IP-keyed limiter — tracked as infra bead **tc-sv58** (proxy prod through Cloudflare + CF rate-limit rule + lock ACA ingress to Cloudflare IPs, since prod is currently direct-to-ACA with no edge protection). This PR ships the part that belongs in code.

## Problem
`POST /v1/webhooks/appstore` ran full JWS signature + X.509 chain verification on attacker-controlled input before any cheap validation — unauthenticated CPU amplification (OWASP API4).

## Fix — cheap structural pre-check before the expensive verify
In the webhook handler, after the existing empty-`SignedPayload` check and **before** `runWebhook`/`VerifyAndDecode`:
- **Size bound:** reject `SignedPayload` > `maxWebhookPayloadBytes` (32 KiB — ~8× a realistic Apple outer JWS incl. the `x5c` cert chain).
- **Compact-JWS shape:** `isCompactJWS` requires exactly 3 non-empty dot-separated segments — a pure O(n) `strings` scan, no base64 decode.
- Rejections use the existing `malformedBody` (400 `malformed_request`) path; the JWS chain verify never runs for a rejected payload. Valid payloads are unchanged (incl. the F1 environment-allowlist swallow + "always mark processed" contract).

## Tests
- `TestWebhook_RejectsMalformedPayloadBeforeVerify` (6 subtests: wrong dot-count, empty segments) — each asserts the verifier fake's `callCount == 0`
- `TestWebhook_RejectsOversizedPayloadBeforeVerify` — over-bound payload, `callCount == 0`
- `TestWebhook_WellFormedPayloadReachesVerifier` — positive regression, `callCount > 0`

Gate: `golangci-lint run ./internal/subscriptions/...` = 0 issues, `go test -race ./...` (942 pass), `go vet`, `gofmt -l .`, `go build` all clean.

Epic: #522 · Bead: tc-doxe · edge follow-up: tc-sv58 · Refs #517

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced App Store webhook validation to reject malformed or oversized payloads with improved error handling.

* **Tests**
  * Added comprehensive test coverage for webhook payload validation edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->