### PR TITLE
fix(api-go): reclaim rate-limit map key on idle, no denied-path double-count (#518)

### DIFF
--- a/api-go/internal/middleware/ratelimit.go
+++ b/api-go/internal/middleware/ratelimit.go
@@ -131,12 +131,21 @@ func (s *rateLimitStore) checkAndIncrement(userID string, limit int) rateLimitRe
 		}
 	}
 
+	// Reclaim the map key once all in-window timestamps have aged out. This
+	// prevents the map from growing by one entry per distinct authenticated
+	// subject for the life of the replica (OWASP API4 / GH#518).
+	if len(kept) == 0 {
+		delete(s.requests, userID)
+	}
+
 	if len(kept) >= limit {
-		retryAfter := kept[0].Add(rateLimitWindow).Sub(now)
+		var retryAfter time.Duration
+		if len(kept) > 0 {
+			retryAfter = kept[0].Add(rateLimitWindow).Sub(now)
+		}
 		if retryAfter < time.Millisecond {
 			retryAfter = time.Millisecond
 		}
-		s.requests[userID] = kept
 		return rateLimitResult{allowed: false, remaining: 0, retryAfter: retryAfter}
 	}
 

--- a/api-go/internal/middleware/ratelimit.go
+++ b/api-go/internal/middleware/ratelimit.go
@@ -131,11 +131,18 @@ func (s *rateLimitStore) checkAndIncrement(userID string, limit int) rateLimitRe
 		}
 	}
 
-	// Reclaim the map key once all in-window timestamps have aged out. This
-	// prevents the map from growing by one entry per distinct authenticated
-	// subject for the life of the replica (OWASP API4 / GH#518).
+	// Persist the result of the in-place compaction. kept aliases the stored
+	// slice's backing array (kept := times[:0]); the map header is only updated
+	// when we reassign it. When everything aged out, reclaim the key (delete)
+	// rather than leaving an empty entry — this keeps the map sized to currently
+	// active users (OWASP API4 / GH#518). When some timestamps survive, write the
+	// compacted slice back so its length matches kept; otherwise the stored
+	// header would keep its old length with a stale tail and the next call would
+	// re-count those tail entries.
 	if len(kept) == 0 {
 		delete(s.requests, userID)
+	} else {
+		s.requests[userID] = kept
 	}
 
 	if len(kept) >= limit {

--- a/api-go/internal/middleware/ratelimit_test.go
+++ b/api-go/internal/middleware/ratelimit_test.go
@@ -179,3 +179,49 @@ func TestRateLimit_TierLookupFailureFailsOpenToFree(t *testing.T) {
 		t.Errorf("fallback limit: got %q, want 60 (free)", got)
 	}
 }
+
+// hasKey is a test-only accessor that reports whether the store map currently
+// holds an entry for userID. It must not be used in production paths.
+func (s *rateLimitStore) hasKey(userID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.requests[userID]
+	return ok
+}
+
+// TestRateLimitStore_EvictsIdleUserKey verifies that once all of a user's
+// in-window timestamps have aged out and the next checkAndIncrement call
+// evicts them, the store reclaims the map key (delete) rather than writing
+// back an empty slice.
+//
+// The denied path (limit=0) is used here because it is the only code path
+// that writes back without appending a new timestamp, making key deletion
+// observable in a single call. Active-user behaviour (limit>0, allowed path)
+// is covered by the existing window/limit tests above.
+func TestRateLimitStore_EvictsIdleUserKey(t *testing.T) {
+	t.Parallel()
+
+	const userID = "auth0|idle"
+
+	clock := &fixedClock{t: time.Unix(1000, 0)}
+	store := newRateLimitStore(clock.now)
+
+	// Seed one timestamp at t=0 so the user has a map entry.
+	store.checkAndIncrement(userID, freeTierLimit)
+	if !store.hasKey(userID) {
+		t.Fatal("setup: expected key to be present after first request")
+	}
+
+	// Advance past the window so the seeded timestamp is now expired.
+	clock.t = clock.t.Add(rateLimitWindow + time.Second)
+
+	// Use limit=0 to force the denied path: len(kept)==0 after eviction and
+	// 0>=0 is true, so we land on the denied branch without appending a new
+	// timestamp. The fix should delete the key instead of writing back an
+	// empty slice.
+	store.checkAndIncrement(userID, 0)
+
+	if store.hasKey(userID) {
+		t.Errorf("expected map key to be deleted after all timestamps aged out, but key is still present")
+	}
+}

--- a/api-go/internal/middleware/ratelimit_test.go
+++ b/api-go/internal/middleware/ratelimit_test.go
@@ -189,6 +189,14 @@ func (s *rateLimitStore) hasKey(userID string) bool {
 	return ok
 }
 
+// keyLen is a test-only accessor that reports the number of timestamps stored
+// for userID (0 if the key is absent). It must not be used in production paths.
+func (s *rateLimitStore) keyLen(userID string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.requests[userID])
+}
+
 // TestRateLimitStore_EvictsIdleUserKey verifies that once all of a user's
 // in-window timestamps have aged out and the next checkAndIncrement call
 // evicts them, the store reclaims the map key (delete) rather than writing
@@ -223,5 +231,61 @@ func TestRateLimitStore_EvictsIdleUserKey(t *testing.T) {
 
 	if store.hasKey(userID) {
 		t.Errorf("expected map key to be deleted after all timestamps aged out, but key is still present")
+	}
+}
+
+// TestRateLimitStore_DeniedDoesNotDoubleCountAcrossCalls guards against an
+// in-place compaction regression. checkAndIncrement filters surviving
+// timestamps into kept := times[:0], which aliases the stored slice's backing
+// array; the map header is only refreshed when kept is reassigned to
+// s.requests[userID]. On a real over-limit denial where the filter actually
+// drops an expired head entry, the compacted (shorter) slice MUST be persisted.
+// Otherwise the stored header keeps its old length with a stale duplicated tail,
+// and the next call re-reads — and re-counts — those tail entries, denying the
+// user for longer than the true window.
+func TestRateLimitStore_DeniedDoesNotDoubleCountAcrossCalls(t *testing.T) {
+	t.Parallel()
+
+	const userID = "auth0|busy"
+
+	clock := &fixedClock{t: time.Unix(1000, 0)}
+	store := newRateLimitStore(clock.now)
+
+	// Seed three timestamps with a generous limit so each is recorded. They are
+	// placed so that, after the window advance below, exactly the first one ages
+	// out and the latter two survive: stored slice = [t1000, t1030, t1031],
+	// len 3.
+	for _, sec := range []int64{1000, 1030, 1031} {
+		clock.t = time.Unix(sec, 0)
+		if got := store.checkAndIncrement(userID, 100); !got.allowed {
+			t.Fatalf("seed request at %d: expected allowed", sec)
+		}
+	}
+	if got := store.keyLen(userID); got != 3 {
+		t.Fatalf("after seeding: stored len = %d, want 3", got)
+	}
+
+	// Advance to t=1061. windowStart = 1061 - 60s = 1001, so only t1000 ages
+	// out; t1030 and t1031 stay in-window. Filtering will drop one entry ->
+	// kept has len 2.
+	clock.t = time.Unix(1061, 0)
+
+	// Over-limit denial (limit=1, two in-window entries survive). The filter
+	// drops the expired head, so the persisted slice must shrink to len 2. With
+	// the aliasing bug the header would stay len 3 with a duplicated tail.
+	if got := store.checkAndIncrement(userID, 1); got.allowed {
+		t.Fatal("first over-limit request: expected denial")
+	}
+	if got := store.keyLen(userID); got != 2 {
+		t.Fatalf("after first denial: stored len = %d, want 2 (expired head dropped; compacted slice must be persisted)", got)
+	}
+
+	// A second denial in the same window must not grow or re-count: still
+	// exactly the two genuine in-window timestamps.
+	if got := store.checkAndIncrement(userID, 1); got.allowed {
+		t.Fatal("second over-limit request: expected denial")
+	}
+	if got := store.keyLen(userID); got != 2 {
+		t.Fatalf("after second denial: stored len = %d, want 2 (double-count regression)", got)
 	}
 }


### PR DESCRIPTION
Security audit remediation — finding **F8** (#518), epic #522.

## Problem
The in-memory rate-limit store (`ratelimit.go` `checkAndIncrement`) filtered expired timestamps within each user's slice but never deleted the per-user map key, so the map grew by one entry per distinct authenticated subject for the life of the replica and never reclaimed memory (OWASP API4, slow leak).

## Fix
A single decision after the eviction filter loop:
- `len(kept) == 0` → `delete(s.requests, userID)` — reclaim the key once a user's window fully ages out (no janitor goroutine, per the issue's pre-resolved decision).
- non-empty → `s.requests[userID] = kept` — persist the compacted slice on **both** the denied and allowed paths.
- allowed → append `now` and persist.

### Subtle correctness point (caught in review)
`kept := times[:0]` compacts **in place** over the stored slice's backing array; the map header is only refreshed on reassignment. An intermediate version dropped the denied-path write-back, which left the stored header at its old length with a stale duplicated tail — causing a denied (over-limit) user to be **double-counted** on subsequent in-window calls. The final version persists the compacted slice in every non-empty path, so no stale tail. Also guards the `retryAfter` `kept[0]` access against `limit == 0` (a latent index-panic).

## Tests
- `TestRateLimitStore_EvictsIdleUserKey` — after a user's window ages out, their key is absent from the map
- `TestRateLimitStore_DeniedDoesNotDoubleCountAcrossCalls` — ages out the head entry so the stale-tail path is exercised; asserts the stored slice compacts and stays stable across a repeated in-window denial (verified Red→Green)
- `keyLen` test accessor added; existing window/limit tests unaffected (active users unchanged)

Gate: `golangci-lint run ./internal/middleware/...` = 0 issues, `go test -race ./...` (944 pass), `go vet`, `gofmt -l .`, `go build` all clean.

Epic: #522 · Bead: tc-c3h9 · Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)