### PR TITLE
fix(api-go): bound watch-zone radius (<=10km), reject non-finite, parameterize FindNearby (#519)

### DIFF
--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -86,22 +86,27 @@ func (s *CosmosStore) GetByUID(ctx context.Context, uid, authorityCode string) (
 	return doc.toDomain(), true, nil
 }
 
+// findNearbyQuery is the single-partition ST_DISTANCE spatial query for nearby
+// applications. Coordinates and radius are bound as named parameters (mirroring
+// findZonesContainingQuery in the watchzones package) — no float literals are
+// concatenated into the query text.
+const findNearbyQuery = "SELECT * FROM c WHERE ST_DISTANCE(c.location, " +
+	`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres`
+
 // FindNearby returns every application within radiusMetres of (latitude,
 // longitude) inside the authorityCode partition, via a single-partition
-// ST_DISTANCE spatial query against the GeoJSON location. It mirrors .NET
-// CosmosPlanningApplicationRepository.FindNearbyAsync: the GeoJSON point and
-// radius are formatted into the query with InvariantCulture-equivalent
-// (strconv) decimals — they are float64 values, never user-supplied strings, so
-// there is no injection surface. The query is scoped to the authorityCode
-// logical partition, so it never fans out cross-partition.
+// ST_DISTANCE spatial query against the GeoJSON location. Coordinates and
+// radius are bound as named parameters (not string-concatenated) to eliminate
+// float-formatting edge cases and to mirror the parameterized style of the
+// sibling watchzones.FindZonesContaining query. The query is scoped to the
+// authorityCode logical partition, so it never fans out cross-partition.
 func (s *CosmosStore) FindNearby(ctx context.Context, authorityCode string, latitude, longitude, radiusMetres float64) ([]PlanningApplication, error) {
-	lng := strconv.FormatFloat(longitude, 'g', -1, 64)
-	lat := strconv.FormatFloat(latitude, 'g', -1, 64)
-	rad := strconv.FormatFloat(radiusMetres, 'g', -1, 64)
-	query := `SELECT * FROM c WHERE ST_DISTANCE(c.location, ` +
-		`{"type": "Point", "coordinates": [` + lng + `, ` + lat + `]}) <= ` + rad
-
-	raws, err := s.items.QueryItems(ctx, authorityCode, query, nil)
+	params := map[string]any{
+		"@latitude":     latitude,
+		"@longitude":    longitude,
+		"@radiusMetres": radiusMetres,
+	}
+	raws, err := s.items.QueryItems(ctx, authorityCode, findNearbyQuery, params)
 	if err != nil {
 		return nil, fmt.Errorf("find applications near %q: %w", authorityCode, err)
 	}

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -12,17 +12,17 @@ import (
 )
 
 type fakeItems struct {
-	stored        map[string][]byte // id -> bytes
-	readErr       error
-	upsertErr     error
-	queryErr      error
-	queryResult   [][]byte
-	lastUpsertPK  string
-	lastUpsert    []byte
-	lastReadPK    string
-	lastReadID    string
-	lastQueryPK   string
-	lastQuery     string
+	stored          map[string][]byte // id -> bytes
+	readErr         error
+	upsertErr       error
+	queryErr        error
+	queryResult     [][]byte
+	lastUpsertPK    string
+	lastUpsert      []byte
+	lastReadPK      string
+	lastReadID      string
+	lastQueryPK     string
+	lastQuery       string
 	lastQueryParams map[string]any
 }
 

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -5,23 +5,25 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 )
 
 type fakeItems struct {
-	stored       map[string][]byte // id -> bytes
-	readErr      error
-	upsertErr    error
-	queryErr     error
-	queryResult  [][]byte
-	lastUpsertPK string
-	lastUpsert   []byte
-	lastReadPK   string
-	lastReadID   string
-	lastQueryPK  string
-	lastQuery    string
+	stored        map[string][]byte // id -> bytes
+	readErr       error
+	upsertErr     error
+	queryErr      error
+	queryResult   [][]byte
+	lastUpsertPK  string
+	lastUpsert    []byte
+	lastReadPK    string
+	lastReadID    string
+	lastQueryPK   string
+	lastQuery     string
+	lastQueryParams map[string]any
 }
 
 func newFakeItems() *fakeItems { return &fakeItems{stored: map[string][]byte{}} }
@@ -45,9 +47,10 @@ func (f *fakeItems) UpsertItem(_ context.Context, partitionKey string, item []by
 	return f.upsertErr
 }
 
-func (f *fakeItems) QueryItems(_ context.Context, partitionKey, query string, _ map[string]any) ([][]byte, error) {
+func (f *fakeItems) QueryItems(_ context.Context, partitionKey, query string, params map[string]any) ([][]byte, error) {
 	f.lastQueryPK = partitionKey
 	f.lastQuery = query
+	f.lastQueryParams = params
 	if f.queryErr != nil {
 		return nil, f.queryErr
 	}
@@ -169,10 +172,46 @@ func TestCosmosStore_FindNearby_ScopesToAuthorityPartitionWithSpatialQuery(t *te
 		t.Errorf("query partition key: got %q, want \"441\"", items.lastQueryPK)
 	}
 	// The GeoJSON point carries [longitude, latitude] (GeoJSON order) and the
-	// radius is the bare metres value, mirroring .NET's interpolated ST_DISTANCE.
-	want := `SELECT * FROM c WHERE ST_DISTANCE(c.location, {"type": "Point", "coordinates": [-0.1357, 51.4975]}) <= 2000`
+	// radius is a named parameter, mirroring findZonesContainingQuery style.
+	want := "SELECT * FROM c WHERE ST_DISTANCE(c.location, " +
+		`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres`
 	if items.lastQuery != want {
 		t.Errorf("spatial query:\n got %q\nwant %q", items.lastQuery, want)
+	}
+}
+
+func TestFindNearby_UsesParameterizedQuery(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	_, _ = store.FindNearby(context.Background(), "441", 51.4975, -0.1357, 2000)
+
+	// The query text must not contain any float literal — values must be bound
+	// as named parameters, not string-concatenated.
+	if items.lastQuery == "" {
+		t.Fatal("no query was issued")
+	}
+	for _, literal := range []string{"51.4975", "-0.1357", "2000"} {
+		if strings.Contains(items.lastQuery, literal) {
+			t.Errorf("query contains float literal %q — should be a named parameter; query: %s", literal, items.lastQuery)
+		}
+	}
+	// Verify the three expected params are bound with correct values.
+	wantParams := map[string]any{
+		"@latitude":     51.4975,
+		"@longitude":    -0.1357,
+		"@radiusMetres": 2000.0,
+	}
+	for k, wantVal := range wantParams {
+		gotVal, ok := items.lastQueryParams[k]
+		if !ok {
+			t.Errorf("param %q not found in query params %v", k, items.lastQueryParams)
+			continue
+		}
+		if gotVal != wantVal {
+			t.Errorf("param %q: got %v, want %v", k, gotVal, wantVal)
+		}
 	}
 }
 

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"math"
 	"net/http"
 	"time"
 
@@ -174,13 +175,16 @@ type patchRequest struct {
 // checked. Name is deliberately not checked here — like .NET, that is enforced
 // by the domain merge (and a blank name there is a 500, not a 400).
 func (req patchRequest) rangeValid() bool {
-	if req.Latitude != nil && (*req.Latitude < -90 || *req.Latitude > 90) {
+	if req.Latitude != nil && (math.IsNaN(*req.Latitude) || math.IsInf(*req.Latitude, 0) ||
+		*req.Latitude < -90 || *req.Latitude > 90) {
 		return false
 	}
-	if req.Longitude != nil && (*req.Longitude < -180 || *req.Longitude > 180) {
+	if req.Longitude != nil && (math.IsNaN(*req.Longitude) || math.IsInf(*req.Longitude, 0) ||
+		*req.Longitude < -180 || *req.Longitude > 180) {
 		return false
 	}
-	if req.RadiusMetres != nil && *req.RadiusMetres <= 0 {
+	if req.RadiusMetres != nil && (math.IsNaN(*req.RadiusMetres) || math.IsInf(*req.RadiusMetres, 0) ||
+		*req.RadiusMetres <= 0 || *req.RadiusMetres > maxRadiusMetres) {
 		return false
 	}
 	if req.AuthorityID != nil && *req.AuthorityID <= 0 {

--- a/api-go/internal/watchzones/handler_test.go
+++ b/api-go/internal/watchzones/handler_test.go
@@ -3,6 +3,7 @@ package watchzones
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -220,6 +221,31 @@ func TestHandler_Delete(t *testing.T) {
 	}
 	if len(store.deleted) != 1 || store.deleted[0] != z.ID {
 		t.Errorf("zone not deleted: %+v", store.deleted)
+	}
+}
+
+func TestPatch_RejectsOversizedRadius(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		radiusMetres float64
+		wantStatus   int
+	}{
+		{"exactly at limit is valid", 10000, http.StatusOK},
+		{"just above limit is 400", 10001, http.StatusBadRequest},
+		{"far above limit is 400", 1e308, http.StatusBadRequest},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			z := testZone(t)
+			store := &fakeZoneStore{zones: []WatchZone{z}}
+			body := fmt.Sprintf(`{"radiusMetres":%v}`, tc.radiusMetres)
+			rec := doReq(t, testMux(t, store), http.MethodPatch, "/v1/me/watch-zones/"+z.ID, body)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("radiusMetres=%v: got status %d, want %d", tc.radiusMetres, rec.Code, tc.wantStatus)
+			}
+		})
 	}
 }
 

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -113,14 +113,28 @@ type createRequest struct {
 	EmailInstantEnabled *bool   `json:"emailInstantEnabled"`
 }
 
+// maxRadiusMetres is the server-side ceiling for a watch-zone radius. It matches
+// the top-tier iOS UI ceiling (10 km). If a larger radius tier is ever offered,
+// bump this value server-side first before shipping the iOS change.
+const maxRadiusMetres = 10_000
+
 // valid mirrors the .NET create endpoint's pre-handler guard: non-blank name,
-// positive radius, in-range coordinates, and a positive authority id when one is
-// supplied.
+// positive radius within the server ceiling, in-range non-finite coordinates,
+// and a positive authority id when one is supplied.
 func (req createRequest) valid() bool {
 	if strings.TrimSpace(req.Name) == "" {
 		return false
 	}
-	if req.RadiusMetres <= 0 {
+	if math.IsNaN(req.Latitude) || math.IsInf(req.Latitude, 0) {
+		return false
+	}
+	if math.IsNaN(req.Longitude) || math.IsInf(req.Longitude, 0) {
+		return false
+	}
+	if math.IsNaN(req.RadiusMetres) || math.IsInf(req.RadiusMetres, 0) {
+		return false
+	}
+	if req.RadiusMetres <= 0 || req.RadiusMetres > maxRadiusMetres {
 		return false
 	}
 	if req.Latitude < -90 || req.Latitude > 90 {

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"testing"
 	"time"
@@ -426,6 +428,61 @@ func TestApplications_EmptyZoneReturnsEmptyArray(t *testing.T) {
 	}
 	if got := rec.Body.String(); got != "[]" {
 		t.Errorf("empty applications: got %s, want []", got)
+	}
+}
+
+func TestCreate_RejectsOversizedRadius(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		radiusMetres float64
+		wantStatus   int
+	}{
+		{"exactly at limit is valid", 10000, http.StatusCreated},
+		{"just above limit is 400", 10001, http.StatusBadRequest},
+		{"far above limit is 400", 1e308, http.StatusBadRequest},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := nearbyDeps{
+				store:    &fakeZoneStore{},
+				profiles: &fakeProfileReader{profile: proProfile(t)},
+				resolver: &fakeResolver{},
+				apps:     &fakeAppFinder{},
+				state:    &fakeWatermark{},
+				unread:   &fakeUnread{},
+			}
+			mux := newNearbyMux(t, d)
+			body := fmt.Sprintf(`{"name":"Z","latitude":51.5,"longitude":-0.12,"radiusMetres":%v,"authorityId":471}`, tc.radiusMetres)
+			rec := doReq(t, mux, http.MethodPost, "/v1/me/watch-zones", body)
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("radiusMetres=%v: got status %d, want %d", tc.radiusMetres, rec.Code, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestValid_RejectsNonFiniteCoordinates(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		req  createRequest
+	}{
+		{"NaN latitude", createRequest{Name: "Z", Latitude: math.NaN(), Longitude: 0, RadiusMetres: 1000}},
+		{"Inf latitude", createRequest{Name: "Z", Latitude: math.Inf(1), Longitude: 0, RadiusMetres: 1000}},
+		{"NaN longitude", createRequest{Name: "Z", Latitude: 51.5, Longitude: math.NaN(), RadiusMetres: 1000}},
+		{"Inf longitude", createRequest{Name: "Z", Latitude: 51.5, Longitude: math.Inf(-1), RadiusMetres: 1000}},
+		{"NaN radius", createRequest{Name: "Z", Latitude: 51.5, Longitude: -0.12, RadiusMetres: math.NaN()}},
+		{"Inf radius", createRequest{Name: "Z", Latitude: 51.5, Longitude: -0.12, RadiusMetres: math.Inf(1)}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.req.valid() {
+				t.Errorf("%s: valid() returned true, want false", tc.name)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Security audit remediation — finding **F9** (#519), epic #522.

## Problem
`FindNearby` built its Cosmos `ST_DISTANCE` spatial query by string-concatenating `strconv.FormatFloat` of lat/lng/radius — the only non-parameterized query in the codebase. The watch-zone guards validated `radiusMetres > 0` only (no upper bound, so `1e308` matched every row in the authority partition → RU/scan amplification) and used NaN-unsafe `<`/`>` comparisons (OWASP API8).

## Fix
1. **Radius upper bound:** `const maxRadiusMetres = 10_000` — reject `radiusMetres > 10000` in both `createRequest.valid()` and `patchRequest.rangeValid()` (`0 < radius <= 10000` valid). Owner chose 10 km to match the top-tier iOS UI ceiling. **Note:** couples the server cap to the current UI max — bump it server-side first if a larger radius tier is ever offered.
2. **Non-finite rejection:** `math.IsNaN`/`math.IsInf` on latitude, longitude, and radius in both guards (defense-in-depth).
3. **Parameterize `FindNearby`:** lat/lng/radius bound as `@latitude`/`@longitude`/`@radiusMetres` (mirroring `findZonesContainingQuery`); the only string-concatenated query is gone. Identical results for valid inputs.

## Tests
- `TestCreate_RejectsOversizedRadius` (boundary: 10000 -> 201, 10001 -> 400, 1e308 -> 400)
- `TestPatch_RejectsOversizedRadius`
- `TestValid_RejectsNonFiniteCoordinates`
- `TestFindNearby_UsesParameterizedQuery`

Gate: `golangci-lint run ./internal/watchzones/... ./internal/applications/...` = 0 issues, `go test -race ./...` (960 pass), `go vet`, `gofmt -l .`, `go build` all clean.

Epic: #522 · Bead: tc-e9tj · Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)