### PR TITLE
fix(api-go): reject cross-host redirects on geocoding/designations clients (SSRF DiD) (#520)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -224,9 +224,16 @@ func main() {
 	}
 
 	// Geocode and designation clients call live UK services (the config defaults);
-	// each gets its own timeout-bounded HTTP client.
-	geocodeClient := geocoding.NewClient(cfg.PostcodesIoBaseURL, &http.Client{Timeout: 30 * time.Second})
-	designationClient := designations.NewClient(cfg.GovUkBaseURL, &http.Client{Timeout: 30 * time.Second})
+	// each gets its own timeout-bounded HTTP client. Construction can only fail
+	// with an unparseable base URL, which is a startup misconfiguration.
+	geocodeClient, err := geocoding.NewClient(cfg.PostcodesIoBaseURL, &http.Client{Timeout: 30 * time.Second})
+	if err != nil {
+		log.Fatalf("geocoding client: %v", err)
+	}
+	designationClient, err := designations.NewClient(cfg.GovUkBaseURL, &http.Client{Timeout: 30 * time.Second})
+	if err != nil {
+		log.Fatalf("designations client: %v", err)
+	}
 
 	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, cascade, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, cfg.AppleEnvironments, registry, logger))
 

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -133,17 +133,47 @@ func idFromDoc(raw []byte) string {
 // testGeocodeClient and testDesignationClient point at an unroutable address; the
 // deny-all wiring tests never reach the handlers, so the upstream is never
 // called.
-func testGeocodeClient() *geocoding.Client {
-	return geocoding.NewClient("http://127.0.0.1:0", http.DefaultClient)
+func testGeocodeClient(t *testing.T) *geocoding.Client {
+	t.Helper()
+	c, err := geocoding.NewClient("http://127.0.0.1:0", http.DefaultClient)
+	if err != nil {
+		t.Fatalf("geocoding.NewClient: %v", err)
+	}
+	return c
 }
 
-func testDesignationClient() *designations.Client {
-	return designations.NewClient("http://127.0.0.1:0", http.DefaultClient)
+func testDesignationClient(t *testing.T) *designations.Client {
+	t.Helper()
+	c, err := designations.NewClient("http://127.0.0.1:0", http.DefaultClient)
+	if err != nil {
+		t.Fatalf("designations.NewClient: %v", err)
+	}
+	return c
+}
+
+// testGeocodeClientWith and testDesignationClientWith build clients pointing at
+// a specific upstream (used in integration-style wiring tests).
+func testGeocodeClientWith(t *testing.T, baseURL string, httpClient *http.Client) *geocoding.Client {
+	t.Helper()
+	c, err := geocoding.NewClient(baseURL, httpClient)
+	if err != nil {
+		t.Fatalf("geocoding.NewClient(%q): %v", baseURL, err)
+	}
+	return c
+}
+
+func testDesignationClientWith(t *testing.T, baseURL string, httpClient *http.Client) *designations.Client {
+	t.Helper()
+	c, err := designations.NewClient(baseURL, httpClient)
+	if err != nil {
+		t.Fatalf("designations.NewClient(%q): %v", baseURL, err)
+	}
+	return c
 }
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", nil, nil, slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", nil, nil, "", nil, nil, slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -248,7 +278,7 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	appStore := applications.NewCosmosStore(newFakeItems())
 	savedStore := savedapplications.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(), testDesignationClient(), nil, nil, "", nil, nil, "", nil, nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", nil, nil, "", nil, nil, logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -329,8 +359,8 @@ func TestRouter_GeocodeAndDesignationsDispatch(t *testing.T) {
 
 	logger := slog.New(slog.DiscardHandler)
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	geocodeClient := geocoding.NewClient(upstream.URL, upstream.Client())
-	designationClient := designations.NewClient(upstream.URL, upstream.Client())
+	geocodeClient := testGeocodeClientWith(t, upstream.URL, upstream.Client())
+	designationClient := testDesignationClientWith(t, upstream.URL, upstream.Client())
 	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", nil, nil, "", nil, nil, logger)
 
 	rec := serveReq(t, h, http.MethodGet, "/v1/geocode/SW1A%201AA", "", "Bearer tok")
@@ -370,7 +400,7 @@ func TestRouter_SubscriptionsWired(t *testing.T) {
 		t.Fatalf("NewJWSVerifier: %v", err)
 	}
 
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), nil, adminStore, "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, adminStore, "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, logger)
 
 	// Webhook is anonymous: a malformed body reaches the handler -> 400 with the
 	// malformed_request envelope, not the WWW-Authenticate 401 fallback.
@@ -400,7 +430,7 @@ func TestRouter_AdminGate(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	offerStore := offercodes.NewCosmosStore(newFakeItems())
 	adminStore := profiles.NewAdminStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(), testDesignationClient(), offerStore, adminStore, "s3cret", nil, nil, "", nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", nil, nil, "", nil, nil, logger)
 
 	// No key: the admin gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).

--- a/api-go/internal/designations/client.go
+++ b/api-go/internal/designations/client.go
@@ -10,9 +10,14 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 )
+
+// errCrossHostRedirect is returned by CheckRedirect when a redirect target's
+// host differs from the configured base host.
+var errCrossHostRedirect = fmt.Errorf("designations: cross-host redirect refused")
 
 // datasets is the comma-separated dataset filter sent to the entity endpoint.
 // The commas are intentionally left unescaped to match the .NET client, which
@@ -42,7 +47,20 @@ type Client struct {
 }
 
 // NewClient builds a provider over the given base URL and shared HTTP client.
+// CheckRedirect is set on httpClient to refuse any redirect whose target host
+// differs from the configured base host (defense-in-depth SSRF hardening).
 func NewClient(baseURL string, httpClient *http.Client) *Client {
+	u, _ := url.Parse(strings.TrimRight(baseURL, "/"))
+	configuredHost := u.Host // host:port or bare host; must match exactly
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req.URL.Host != configuredHost {
+			return errCrossHostRedirect
+		}
+		if len(via) >= 10 {
+			return fmt.Errorf("designations: stopped after 10 redirects")
+		}
+		return nil
+	}
 	return &Client{baseURL: strings.TrimRight(baseURL, "/"), http: httpClient}
 }
 

--- a/api-go/internal/designations/client.go
+++ b/api-go/internal/designations/client.go
@@ -7,6 +7,7 @@ package designations
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,7 +18,7 @@ import (
 
 // errCrossHostRedirect is returned by CheckRedirect when a redirect target's
 // host differs from the configured base host.
-var errCrossHostRedirect = fmt.Errorf("designations: cross-host redirect refused")
+var errCrossHostRedirect = errors.New("designations: cross-host redirect refused")
 
 // datasets is the comma-separated dataset filter sent to the entity endpoint.
 // The commas are intentionally left unescaped to match the .NET client, which
@@ -47,21 +48,30 @@ type Client struct {
 }
 
 // NewClient builds a provider over the given base URL and shared HTTP client.
-// CheckRedirect is set on httpClient to refuse any redirect whose target host
+// A shallow copy of httpClient is taken so the caller's client is not mutated;
+// CheckRedirect is set on the copy to refuse any redirect whose target host
 // differs from the configured base host (defense-in-depth SSRF hardening).
-func NewClient(baseURL string, httpClient *http.Client) *Client {
-	u, _ := url.Parse(strings.TrimRight(baseURL, "/"))
+// Returns an error if baseURL cannot be parsed.
+func NewClient(baseURL string, httpClient *http.Client) (*Client, error) {
+	trimmed := strings.TrimRight(baseURL, "/")
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("designations: parse base URL: %w", err)
+	}
 	configuredHost := u.Host // host:port or bare host; must match exactly
-	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+	// Copy by value so we never mutate the caller's client (avoids data races
+	// when the same *http.Client is reused across multiple NewClient calls).
+	hc := *httpClient
+	hc.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if req.URL.Host != configuredHost {
 			return errCrossHostRedirect
 		}
 		if len(via) >= 10 {
-			return fmt.Errorf("designations: stopped after 10 redirects")
+			return errors.New("designations: stopped after 10 redirects")
 		}
 		return nil
 	}
-	return &Client{baseURL: strings.TrimRight(baseURL, "/"), http: httpClient}
+	return &Client{baseURL: trimmed, http: &hc}, nil
 }
 
 // entityResponse mirrors the GOV.UK entity.json envelope.

--- a/api-go/internal/designations/client_test.go
+++ b/api-go/internal/designations/client_test.go
@@ -7,6 +7,40 @@ import (
 	"testing"
 )
 
+// TestClient_DoesNotFollowCrossHostRedirect asserts that the designations
+// client refuses a 302 redirect whose target host differs from the configured
+// base host. The redirected body (from the second server) must not be returned.
+func TestClient_DoesNotFollowCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	// attackServer simulates a cross-host SSRF target; its body must never be
+	// read by the client.
+	attackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Return a valid entity response with a sentinel name that, if seen,
+		// proves the redirect was followed.
+		_, _ = w.Write([]byte(`{"entities":[{"dataset":"conservation-area","name":"SSRF-FOLLOWED","reference":"X1"}]}`))
+	}))
+	t.Cleanup(attackServer.Close)
+
+	// configuredServer redirects cross-host to attackServer.
+	configuredServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attackServer.URL+r.URL.RequestURI(), http.StatusFound)
+	}))
+	t.Cleanup(configuredServer.Close)
+
+	client := NewClient(configuredServer.URL, configuredServer.Client())
+
+	got, err := client.Get(context.Background(), 51.5, -0.14)
+
+	// The client must not follow the cross-host redirect. Either an error is
+	// returned, or the context is empty (redirect response, not the attack body).
+	// If the client followed the redirect the sentinel name would appear.
+	if err == nil && got.IsWithinConservationArea && got.ConservationAreaName != nil && *got.ConservationAreaName == "SSRF-FOLLOWED" {
+		t.Error("client followed cross-host redirect: got SSRF-FOLLOWED conservation area, want policy to block it")
+	}
+}
+
 // govUkServer is a hand-written fake planning.data.gov.uk entity endpoint. It
 // records the raw request URI and drives the status code and JSON body.
 type govUkServer struct {

--- a/api-go/internal/designations/client_test.go
+++ b/api-go/internal/designations/client_test.go
@@ -7,6 +7,17 @@ import (
 	"testing"
 )
 
+// mustNewClient calls NewClient and fatals the test on error. All test base
+// URLs are valid httptest addresses so this should never fail in practice.
+func mustNewClient(t *testing.T, baseURL string, httpClient *http.Client) *Client {
+	t.Helper()
+	c, err := NewClient(baseURL, httpClient)
+	if err != nil {
+		t.Fatalf("NewClient(%q): %v", baseURL, err)
+	}
+	return c
+}
+
 // TestClient_DoesNotFollowCrossHostRedirect asserts that the designations
 // client refuses a 302 redirect whose target host differs from the configured
 // base host. The redirected body (from the second server) must not be returned.
@@ -29,7 +40,7 @@ func TestClient_DoesNotFollowCrossHostRedirect(t *testing.T) {
 	}))
 	t.Cleanup(configuredServer.Close)
 
-	client := NewClient(configuredServer.URL, configuredServer.Client())
+	client := mustNewClient(t, configuredServer.URL, configuredServer.Client())
 
 	got, err := client.Get(context.Background(), 51.5, -0.14)
 
@@ -73,7 +84,7 @@ func TestClient_Get_MapsAllDatasets(t *testing.T) {
 		{"dataset":"article-4-direction-area","name":"A4 Zone","reference":"A41"}
 	]}`}
 	srv := newGovUkServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	got, err := client.Get(context.Background(), 51.5, -0.14)
 	if err != nil {
@@ -95,7 +106,7 @@ func TestClient_Get_EscapesPointLongitudeFirst(t *testing.T) {
 
 	fake := &govUkServer{status: http.StatusNotFound}
 	srv := newGovUkServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	if _, err := client.Get(context.Background(), 55, 2); err != nil {
 		t.Fatalf("Get: %v", err)
@@ -114,7 +125,7 @@ func TestClient_Get_NotFoundIsEmptyContext(t *testing.T) {
 	// 404 means the geometry intersects no entity — an empty context, not an error.
 	fake := &govUkServer{status: http.StatusNotFound}
 	srv := newGovUkServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	got, err := client.Get(context.Background(), 55, 2)
 	if err != nil {
@@ -130,7 +141,7 @@ func TestClient_Get_EmptyEntitiesIsEmptyContext(t *testing.T) {
 
 	fake := &govUkServer{body: `{"entities":[]}`}
 	srv := newGovUkServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	got, err := client.Get(context.Background(), 55, 2)
 	if err != nil {
@@ -148,7 +159,7 @@ func TestClient_Get_ErrorOnServerError(t *testing.T) {
 	// context), mirroring .NET's EnsureSuccessStatusCode throw.
 	fake := &govUkServer{status: http.StatusInternalServerError, body: `{}`}
 	srv := newGovUkServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	if _, err := client.Get(context.Background(), 55, 2); err == nil {
 		t.Error("Get on 500: want error, got nil")
@@ -160,7 +171,7 @@ func TestClient_Get_ErrorOnTransportFailure(t *testing.T) {
 
 	fake := &govUkServer{body: `{}`}
 	srv := newGovUkServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 	srv.Close()
 
 	if _, err := client.Get(context.Background(), 55, 2); err == nil {

--- a/api-go/internal/designations/handler_test.go
+++ b/api-go/internal/designations/handler_test.go
@@ -121,5 +121,6 @@ func TestHandler_Designations_ProviderErrorDegradesToEmpty(t *testing.T) {
 func TestClient_SatisfiesProviderInterface(t *testing.T) {
 	t.Parallel()
 
-	var _ provider = NewClient("https://www.planning.data.gov.uk", http.DefaultClient)
+	client := mustNewClient(t, "https://www.planning.data.gov.uk", http.DefaultClient)
+	var _ provider = client
 }

--- a/api-go/internal/geocoding/authority_test.go
+++ b/api-go/internal/geocoding/authority_test.go
@@ -38,7 +38,7 @@ func TestClient_ResolveAuthority_MapsAdminDistrictToAuthorityID(t *testing.T) {
 		body: `{"status":200,"result":[{"postcode":"YO1 7HH","admin_district":"York"}]}`,
 	}
 	srv := newReverseServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	id, err := client.ResolveAuthority(context.Background(), 53.9590, -1.0815)
 	if err != nil {
@@ -59,7 +59,7 @@ func TestClient_ResolveAuthority_NoAdminDistrictIsUnresolved(t *testing.T) {
 	t.Parallel()
 	fake := &reverseServer{body: `{"status":200,"result":[]}`}
 	srv := newReverseServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	_, err := client.ResolveAuthority(context.Background(), 0, 0)
 	if !errors.Is(err, ErrAuthorityUnresolved) {
@@ -73,7 +73,7 @@ func TestClient_ResolveAuthority_UnmappedDistrictIsUnresolved(t *testing.T) {
 		body: `{"status":200,"result":[{"admin_district":"Atlantis"}]}`,
 	}
 	srv := newReverseServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	_, err := client.ResolveAuthority(context.Background(), 51.5, -0.1)
 	if !errors.Is(err, ErrAuthorityUnresolved) {
@@ -85,7 +85,7 @@ func TestClient_ResolveAuthority_Non2xxIsUnresolved(t *testing.T) {
 	t.Parallel()
 	fake := &reverseServer{status: http.StatusInternalServerError, body: ""}
 	srv := newReverseServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	_, err := client.ResolveAuthority(context.Background(), 51.5, -0.1)
 	if !errors.Is(err, ErrAuthorityUnresolved) {

--- a/api-go/internal/geocoding/client.go
+++ b/api-go/internal/geocoding/client.go
@@ -3,6 +3,7 @@ package geocoding
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,7 +13,7 @@ import (
 
 // errCrossHostRedirect is returned by CheckRedirect when a redirect target's
 // host differs from the configured base host.
-var errCrossHostRedirect = fmt.Errorf("geocoding: cross-host redirect refused")
+var errCrossHostRedirect = errors.New("geocoding: cross-host redirect refused")
 
 // maxRespBytes bounds the postcodes.io response body read.
 const maxRespBytes = 1 << 20
@@ -32,21 +33,30 @@ type Client struct {
 }
 
 // NewClient builds a geocoder over the given base URL and shared HTTP client.
-// CheckRedirect is set on httpClient to refuse any redirect whose target host
+// A shallow copy of httpClient is taken so the caller's client is not mutated;
+// CheckRedirect is set on the copy to refuse any redirect whose target host
 // differs from the configured base host (defense-in-depth SSRF hardening).
-func NewClient(baseURL string, httpClient *http.Client) *Client {
-	u, _ := url.Parse(strings.TrimRight(baseURL, "/"))
+// Returns an error if baseURL cannot be parsed.
+func NewClient(baseURL string, httpClient *http.Client) (*Client, error) {
+	trimmed := strings.TrimRight(baseURL, "/")
+	u, err := url.Parse(trimmed)
+	if err != nil {
+		return nil, fmt.Errorf("geocoding: parse base URL: %w", err)
+	}
 	configuredHost := u.Host // host:port or bare host; must match exactly
-	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+	// Copy by value so we never mutate the caller's client (avoids data races
+	// when the same *http.Client is reused across multiple NewClient calls).
+	hc := *httpClient
+	hc.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if req.URL.Host != configuredHost {
 			return errCrossHostRedirect
 		}
 		if len(via) >= 10 {
-			return fmt.Errorf("geocoding: stopped after 10 redirects")
+			return errors.New("geocoding: stopped after 10 redirects")
 		}
 		return nil
 	}
-	return &Client{baseURL: strings.TrimRight(baseURL, "/"), http: httpClient}
+	return &Client{baseURL: trimmed, http: &hc}, nil
 }
 
 // postcodesIoResponse mirrors the postcodes.io envelope.

--- a/api-go/internal/geocoding/client.go
+++ b/api-go/internal/geocoding/client.go
@@ -10,6 +10,10 @@ import (
 	"strings"
 )
 
+// errCrossHostRedirect is returned by CheckRedirect when a redirect target's
+// host differs from the configured base host.
+var errCrossHostRedirect = fmt.Errorf("geocoding: cross-host redirect refused")
+
 // maxRespBytes bounds the postcodes.io response body read.
 const maxRespBytes = 1 << 20
 
@@ -28,7 +32,20 @@ type Client struct {
 }
 
 // NewClient builds a geocoder over the given base URL and shared HTTP client.
+// CheckRedirect is set on httpClient to refuse any redirect whose target host
+// differs from the configured base host (defense-in-depth SSRF hardening).
 func NewClient(baseURL string, httpClient *http.Client) *Client {
+	u, _ := url.Parse(strings.TrimRight(baseURL, "/"))
+	configuredHost := u.Host // host:port or bare host; must match exactly
+	httpClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		if req.URL.Host != configuredHost {
+			return errCrossHostRedirect
+		}
+		if len(via) >= 10 {
+			return fmt.Errorf("geocoding: stopped after 10 redirects")
+		}
+		return nil
+	}
 	return &Client{baseURL: strings.TrimRight(baseURL, "/"), http: httpClient}
 }
 

--- a/api-go/internal/geocoding/client_test.go
+++ b/api-go/internal/geocoding/client_test.go
@@ -7,6 +7,17 @@ import (
 	"testing"
 )
 
+// mustNewClient calls NewClient and fatals the test on error. All test base
+// URLs are valid httptest addresses so this should never fail in practice.
+func mustNewClient(t *testing.T, baseURL string, httpClient *http.Client) *Client {
+	t.Helper()
+	c, err := NewClient(baseURL, httpClient)
+	if err != nil {
+		t.Fatalf("NewClient(%q): %v", baseURL, err)
+	}
+	return c
+}
+
 // TestClient_DoesNotFollowCrossHostRedirect asserts that the geocoding client
 // refuses a 302 redirect whose target host differs from the configured base
 // host. The redirected body (from the second server) must not be returned; the
@@ -28,7 +39,7 @@ func TestClient_DoesNotFollowCrossHostRedirect(t *testing.T) {
 	}))
 	t.Cleanup(configuredServer.Close)
 
-	client := NewClient(configuredServer.URL, configuredServer.Client())
+	client := mustNewClient(t, configuredServer.URL, configuredServer.Client())
 
 	coords, found, err := client.Geocode(context.Background(), "SW1A 1AA")
 
@@ -71,7 +82,7 @@ func TestClient_Geocode_ReturnsCoordinates(t *testing.T) {
 		body: `{"status":200,"result":{"postcode":"SW1A 1AA","latitude":51.501009,"longitude":-0.141588,"admin_district":"Westminster"}}`,
 	}
 	srv := newPostcodesIoServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	coords, found, err := client.Geocode(context.Background(), "SW1A 1AA")
 	if err != nil {
@@ -90,7 +101,7 @@ func TestClient_Geocode_EscapesPostcodeInPath(t *testing.T) {
 
 	fake := &postcodesIoServer{body: `{"status":200,"result":{"latitude":1,"longitude":2}}`}
 	srv := newPostcodesIoServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	if _, _, err := client.Geocode(context.Background(), "SW1A 1AA"); err != nil {
 		t.Fatalf("Geocode: %v", err)
@@ -107,7 +118,7 @@ func TestClient_Geocode_NotFoundOnNon2xx(t *testing.T) {
 
 	fake := &postcodesIoServer{status: http.StatusNotFound, body: `{"status":404,"error":"Postcode not found"}`}
 	srv := newPostcodesIoServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	// A non-2xx response means not found (a 404 for the caller), not an error —
 	// mirroring .NET's null return on !IsSuccessStatusCode.
@@ -127,7 +138,7 @@ func TestClient_Geocode_NotFoundOnEnvelopeStatusNot200(t *testing.T) {
 	// matching .NET's body.Status != 200 short-circuit.
 	fake := &postcodesIoServer{body: `{"status":404,"result":null}`}
 	srv := newPostcodesIoServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	_, found, err := client.Geocode(context.Background(), "ZZ1 1ZZ")
 	if err != nil {
@@ -144,7 +155,7 @@ func TestClient_Geocode_NotFoundOnNilResult(t *testing.T) {
 	// status 200 but a null result is "not found", matching .NET's Result is null.
 	fake := &postcodesIoServer{body: `{"status":200,"result":null}`}
 	srv := newPostcodesIoServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 
 	_, found, err := client.Geocode(context.Background(), "ZZ1 1ZZ")
 	if err != nil {
@@ -163,7 +174,7 @@ func TestClient_Geocode_ErrorOnTransportFailure(t *testing.T) {
 	// capture its URL, then close it so the connection is refused.
 	fake := &postcodesIoServer{body: `{}`}
 	srv := newPostcodesIoServer(t, fake)
-	client := NewClient(srv.URL, srv.Client())
+	client := mustNewClient(t, srv.URL, srv.Client())
 	srv.Close()
 
 	if _, _, err := client.Geocode(context.Background(), "SW1A 1AA"); err == nil {

--- a/api-go/internal/geocoding/client_test.go
+++ b/api-go/internal/geocoding/client_test.go
@@ -7,6 +7,40 @@ import (
 	"testing"
 )
 
+// TestClient_DoesNotFollowCrossHostRedirect asserts that the geocoding client
+// refuses a 302 redirect whose target host differs from the configured base
+// host. The redirected body (from the second server) must not be returned; the
+// client must error or surface the redirect response, not the cross-host body.
+func TestClient_DoesNotFollowCrossHostRedirect(t *testing.T) {
+	t.Parallel()
+
+	// attackServer simulates a cross-host SSRF target; its body must never be
+	// read by the client.
+	attackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":200,"result":{"postcode":"SW1A 1AA","latitude":99.0,"longitude":99.0}}`))
+	}))
+	t.Cleanup(attackServer.Close)
+
+	// configuredServer redirects cross-host to attackServer.
+	configuredServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, attackServer.URL+r.URL.Path, http.StatusFound)
+	}))
+	t.Cleanup(configuredServer.Close)
+
+	client := NewClient(configuredServer.URL, configuredServer.Client())
+
+	coords, found, err := client.Geocode(context.Background(), "SW1A 1AA")
+
+	// The client must not follow the cross-host redirect. Either an error is
+	// returned, or found is false (redirect response, not the attack body).
+	// The attack server returns latitude=99.0; if the client followed the
+	// redirect we'd see that value — a definitive signal of a policy failure.
+	if err == nil && found && coords.Latitude == 99.0 {
+		t.Errorf("client followed cross-host redirect: got coords %+v, want policy to block it", coords)
+	}
+}
+
 // postcodesIoServer is a hand-written fake postcodes.io. It records the requested
 // path and lets a test drive the status code and raw JSON body the lookup
 // endpoint returns.

--- a/api-go/internal/geocoding/handler_test.go
+++ b/api-go/internal/geocoding/handler_test.go
@@ -131,5 +131,6 @@ func TestHandler_Geocode_ServerErrorOnTransportFailure(t *testing.T) {
 func TestClient_SatisfiesGeocoderInterface(t *testing.T) {
 	t.Parallel()
 
-	var _ geocoder = NewClient("https://api.postcodes.io", http.DefaultClient)
+	client := mustNewClient(t, "https://api.postcodes.io", http.DefaultClient)
+	var _ geocoder = client
 }


### PR DESCRIPTION
Security audit remediation — finding **F10** (#520, low / defense-in-depth), epic #522.

## Problem
The geocoding and designations outbound `http.Client`s were built with only a `Timeout`; Go's default client follows up to 10 redirects with no policy — a defense-in-depth SSRF gap (a trusted upstream could `30x` toward `169.254.169.254` / an RFC1918 host). Not request-triggerable today, but cheap to harden.

## Fix
`geocoding.NewClient` and `designations.NewClient` now set a `CheckRedirect` (on a **shallow copy** of the passed client, so a shared `http.DefaultClient` is never mutated — the race detector caught that) that **refuses any redirect whose target `host:port` differs from the configured base host**, and still caps same-host redirects at 10. Mirrors the PlanIt client's trust model. Both constructors now return `(*Client, error)` (for the base-URL parse); `main.go` fails fast on a bad base URL.

Implementation notes: compares `req.URL.Host` (host:port, not hostname) so a same-IP different-port redirect can't slip through; private-IP dial denial deemed unnecessary (kept the change small).

## Tests
- `TestClient_DoesNotFollowCrossHostRedirect` in both `internal/geocoding` and `internal/designations` — a server that 30x-redirects to a different host is not followed (request errors; cross-host body never fetched).
- Existing positive (non-redirect) tests still pass.

Gate: `golangci-lint run ./internal/geocoding/... ./internal/designations/... ./cmd/api/...` = 0 issues, `go test -race ./...` (962 pass), `go vet`, `gofmt -l .`, `go build` all clean.

Epic: #522 · Bead: tc-x9c3 · Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced client initialization with validation and improved error reporting when setup fails
  * Added Server-Side Request Forgery (SSRF) protection to block unsafe cross-host redirects
  * Enforced redirect limits (maximum 10 redirects per request)

* **Tests**
  * Added regression tests verifying SSRF protection functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->