### PR TITLE
fix(api-go): add X-Content-Type-Options: nosniff security header middleware (#521)

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -191,8 +191,10 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 
 	authed := auth.RequireAuth(validator, &dispatchMux{ServeMux: mux, dispatch: dispatch}, anonymousPatterns)
 	chain := middleware.CORS(corsOrigins)(
-		middleware.ErrorBody(logger)(
-			middleware.Recover(logger)(authed),
+		middleware.SecurityHeaders(
+			middleware.ErrorBody(logger)(
+				middleware.Recover(logger)(authed),
+			),
 		),
 	)
 	// RouteSpan names the request span after the matched route and records the

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -76,10 +76,13 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // middleware chain. Ordering, from outermost to innermost, mirrors the .NET
 // pipeline (WebApplicationExtensions.UseMiddlewarePipeline):
 //
-//		CORS -> ErrorBody -> Recover -> RequireAuth -> RateLimit -> RecordActivity -> mux
+//		CORS -> SecurityHeaders -> ErrorBody -> Recover -> RequireAuth -> RateLimit -> RecordActivity -> mux
 //
 //	  - CORS runs first so its headers are present on every response, including
 //	    the 401s and 500s produced further in.
+//	  - SecurityHeaders sits just inside CORS so X-Content-Type-Options: nosniff
+//	    is set on every response, including the error-body envelopes and
+//	    panic-recovery 500s produced further in (GH#521).
 //	  - ErrorBody backfills the PascalCase envelope onto any bodyless >= 400.
 //	  - Recover converts a handler panic into a 500 + Detail, which ErrorBody
 //	    then renders — the Go equivalent of ErrorResponseMiddleware's try/catch.

--- a/api-go/internal/middleware/securityheaders.go
+++ b/api-go/internal/middleware/securityheaders.go
@@ -1,0 +1,14 @@
+package middleware
+
+import "net/http"
+
+// SecurityHeaders sets the X-Content-Type-Options header on every response,
+// before the next handler writes, so it applies to both success and error
+// responses. Only nosniff is set: CSP, X-Frame-Options, and HSTS are
+// out-of-scope for this cookieless JSON API behind TLS ingress (GH#521).
+func SecurityHeaders(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		next.ServeHTTP(w, r)
+	})
+}

--- a/api-go/internal/middleware/securityheaders_test.go
+++ b/api-go/internal/middleware/securityheaders_test.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSecurityHeaders_SetsNoSniff(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		innerCode  int
+		wantStatus int
+	}{
+		{"200 success response", http.StatusOK, http.StatusOK},
+		{"500 error response", http.StatusInternalServerError, http.StatusInternalServerError},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.innerCode)
+			})
+			h := SecurityHeaders(inner)
+
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+
+			h.ServeHTTP(rec, req)
+
+			if got := rec.Header().Get("X-Content-Type-Options"); got != "nosniff" {
+				t.Errorf("X-Content-Type-Options = %q, want %q", got, "nosniff")
+			}
+			if rec.Code != tc.wantStatus {
+				t.Errorf("status = %d, want %d", rec.Code, tc.wantStatus)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Security audit remediation — finding **F11** (#521, low / defense-in-depth), epic #522. **Final finding.**

## Problem
No security response headers were set anywhere. For this cookieless JSON API behind TLS ingress most are irrelevant, but `X-Content-Type-Options: nosniff` is cheap correct hardening — notably for `GET /v1/legal/{documentType}`, which serves document bodies.

## Fix
New `internal/middleware/securityheaders.go`: `SecurityHeaders` sets `X-Content-Type-Options: nosniff` before calling the next handler, so it applies to success AND error responses. Inserted into the chain just inside CORS: `CORS → SecurityHeaders → ErrorBody → Recover → …`, so the header is present on every response including the PascalCase error envelope and panic-recovery 500s.

Only `nosniff` is set — CSP/X-Frame-Options/HSTS are intentionally omitted (HTML concerns / HSTS belongs at ingress; no cargo-culting).

## Tests
- `TestSecurityHeaders_SetsNoSniff` — asserts the header equals `nosniff` on both a 200 and a 500 response.

Gate: `golangci-lint run ./internal/middleware/... ./cmd/api/...` = 0 issues, `go test ./...` (965 pass), `go vet`, `gofmt -l .`, `go build` all clean.

Epic: #522 · Bead: tc-l240 · Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)