### PR TITLE
fix(api-go): complete GDPR data export — populate child collections in GET /v1/me/data (tc-lllv)

### DIFF
--- a/api-go/cmd/api/export_adapters.go
+++ b/api-go/cmd/api/export_adapters.go
@@ -75,7 +75,9 @@ func (r notificationExportReader) NotificationsByUser(ctx context.Context, userI
 
 // savedApplicationExportReader adapts the saved-application store to
 // profiles.SavedApplicationReader.
-type savedApplicationExportReader struct{ store *savedapplications.CosmosStore }
+type savedApplicationExportReader struct {
+	store *savedapplications.CosmosStore
+}
 
 func (r savedApplicationExportReader) SavedApplicationsByUser(ctx context.Context, userID string) ([]profiles.ExportedSavedApplication, error) {
 	saved, err := r.store.GetByUserID(ctx, userID)

--- a/api-go/cmd/api/export_adapters.go
+++ b/api-go/cmd/api/export_adapters.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// The GDPR export (GET /v1/me/data) sources its child collections from the
+// per-feature stores. profiles must not import those packages (offercodes already
+// imports profiles, so a back-import would close a cycle — see
+// profiles/export_readers.go), so the store -> export-row mapping lives here, in
+// cmd/api, as thin adapters that satisfy the consumer-side profiles reader
+// interfaces. This mirrors the cascade adapters built in main.go (the
+// erasure.ChildDeleter wiring): the wiring layer is the one place that depends on
+// both the stores and the profiles row types.
+
+// watchZoneExportReader adapts the watch-zone store to profiles.WatchZoneReader.
+type watchZoneExportReader struct{ store *watchzones.CosmosStore }
+
+func (r watchZoneExportReader) WatchZonesByUser(ctx context.Context, userID string) ([]profiles.ExportedWatchZone, error) {
+	zones, err := r.store.GetByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]profiles.ExportedWatchZone, 0, len(zones))
+	for _, z := range zones {
+		rows = append(rows, profiles.ExportedWatchZone{
+			ID:           z.ID,
+			Name:         z.Name,
+			Latitude:     z.Latitude,
+			Longitude:    z.Longitude,
+			RadiusMetres: z.RadiusMetres,
+			AuthorityID:  z.AuthorityID,
+			CreatedAt:    platform.DotNetTime(z.CreatedAt),
+		})
+	}
+	return rows, nil
+}
+
+// notificationExportReader adapts the notifications digest store to
+// profiles.NotificationReader. It reads the full Notifications-container document
+// (AllByUser) so every exported field is carried.
+type notificationExportReader struct{ store *notifications.DigestStore }
+
+func (r notificationExportReader) NotificationsByUser(ctx context.Context, userID string) ([]profiles.ExportedNotification, error) {
+	notifs, err := r.store.AllByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]profiles.ExportedNotification, 0, len(notifs))
+	for _, n := range notifs {
+		rows = append(rows, profiles.ExportedNotification{
+			ID:                     n.ID,
+			ApplicationName:        n.ApplicationName,
+			WatchZoneID:            n.WatchZoneID,
+			ApplicationAddress:     n.ApplicationAddress,
+			ApplicationDescription: n.ApplicationDescription,
+			ApplicationType:        n.ApplicationType,
+			AuthorityID:            n.AuthorityID,
+			Decision:               n.Decision,
+			PushSent:               n.PushSent,
+			EmailSent:              n.EmailSent,
+			CreatedAt:              platform.DotNetTime(n.CreatedAt),
+		})
+	}
+	return rows, nil
+}
+
+// savedApplicationExportReader adapts the saved-application store to
+// profiles.SavedApplicationReader.
+type savedApplicationExportReader struct{ store *savedapplications.CosmosStore }
+
+func (r savedApplicationExportReader) SavedApplicationsByUser(ctx context.Context, userID string) ([]profiles.ExportedSavedApplication, error) {
+	saved, err := r.store.GetByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]profiles.ExportedSavedApplication, 0, len(saved))
+	for _, s := range saved {
+		rows = append(rows, profiles.ExportedSavedApplication{
+			ApplicationUID: s.ApplicationUID,
+			SavedAt:        platform.DotNetTime(s.SavedAt),
+		})
+	}
+	return rows, nil
+}
+
+// deviceRegistrationExportReader adapts the device-token store to
+// profiles.DeviceRegistrationReader.
+type deviceRegistrationExportReader struct{ store *devicetokens.CosmosStore }
+
+func (r deviceRegistrationExportReader) DeviceRegistrationsByUser(ctx context.Context, userID string) ([]profiles.ExportedDeviceRegistration, error) {
+	regs, err := r.store.ListByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]profiles.ExportedDeviceRegistration, 0, len(regs))
+	for _, d := range regs {
+		rows = append(rows, profiles.ExportedDeviceRegistration{
+			Token:        d.Token,
+			Platform:     d.Platform.String(),
+			RegisteredAt: platform.DotNetTime(d.RegisteredAt),
+		})
+	}
+	return rows, nil
+}
+
+// offerCodeExportReader adapts the offer-code store to
+// profiles.OfferCodeRedemptionReader. A redeemed-by-user code always has a
+// RedeemedAt set, but a nil is guarded (it serialises as the zero instant) so a
+// malformed document can never panic the export.
+type offerCodeExportReader struct{ store *offercodes.CosmosStore }
+
+func (r offerCodeExportReader) OfferCodeRedemptionsByUser(ctx context.Context, userID string) ([]profiles.ExportedOfferCodeRedemption, error) {
+	codes, err := r.store.RedeemedByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	rows := make([]profiles.ExportedOfferCodeRedemption, 0, len(codes))
+	for _, c := range codes {
+		var redeemedAt platform.DotNetTime
+		if c.RedeemedAt != nil {
+			redeemedAt = platform.DotNetTime(*c.RedeemedAt)
+		}
+		rows = append(rows, profiles.ExportedOfferCodeRedemption{
+			Code:         c.Code,
+			Tier:         c.Tier.String(),
+			DurationDays: c.DurationDays,
+			RedeemedAt:   redeemedAt,
+		})
+	}
+	return rows, nil
+}

--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -174,6 +174,28 @@ func main() {
 		}
 	}
 
+	// exportReaders bundles the per-collection readers GET /v1/me/data uses to
+	// source the GDPR export's child collections (bead tc-lllv). Like cascade it is
+	// populated only when Cosmos is configured — the same condition under which
+	// profiles.Routes is wired — so the export's readers are never nil when the
+	// route is reachable; on a Cosmos-less local boot the readers stay nil and the
+	// export renders every collection as [] (never null). The adapters
+	// (export_adapters.go) map each store's records to the profiles-local export
+	// row types, keeping the store -> row mapping out of profiles (which must not
+	// import the feature packages — offercodes already imports profiles). The
+	// notifications reader uses the digest store's full-document AllByUser read so
+	// every exported field is carried, not the latest-unread projection.
+	var exportReaders profiles.ExportReaders
+	if notificationsContainer != nil && watchZones != nil && savedContainer != nil && devices != nil && offerStore != nil {
+		exportReaders = profiles.ExportReaders{
+			WatchZones:           watchZoneExportReader{store: watchZoneStore},
+			Notifications:        notificationExportReader{store: notifications.NewDigestStore(notificationsContainer)},
+			SavedApplications:    savedApplicationExportReader{store: savedStore},
+			DeviceRegistrations:  deviceRegistrationExportReader{store: deviceStore},
+			OfferCodeRedemptions: offerCodeExportReader{store: offerStore},
+		}
+	}
+
 	// The admin grant/list operations query the Users container cross-partition
 	// (by email, and the full list), so the admin store reuses the same container
 	// as the profile store.
@@ -235,7 +257,7 @@ func main() {
 		log.Fatalf("designations client: %v", err)
 	}
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, cascade, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, cfg.AppleEnvironments, registry, logger))
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, cascade, exportReaders, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, cfg.AppleEnvironments, registry, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -94,7 +94,7 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // nil-means-unwired convention. (The watch-zone preferences endpoints are
 // served by profiles.Routes off the profile store, so they come up with the
 // /v1/me routes, not the watch-zone store.)
-func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, cascade profiles.CascadeDeleters, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, appleEnvironments []string, registry *metrics.Registry, logger *slog.Logger) http.Handler {
+func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, cascade profiles.CascadeDeleters, exportReaders profiles.ExportReaders, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, appleEnvironments []string, registry *metrics.Registry, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)
@@ -109,7 +109,7 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 
 	var dispatch http.Handler = mux
 	if store != nil {
-		profiles.Routes(mux, store, auth0, proDomains, cascade, time.Now, logger)
+		profiles.Routes(mux, store, auth0, proDomains, cascade, exportReaders, time.Now, logger)
 		dispatch = middleware.RateLimit(middleware.NewRateLimitStore(), profiles.NewTierLookup(store), logger)(
 			middleware.RecordActivity(profiles.NewActivityRecorder(store), time.Now, logger)(mux),
 		)

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -173,7 +173,7 @@ func testDesignationClientWith(t *testing.T, baseURL string, httpClient *http.Cl
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", nil, nil, "", nil, nil, slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{},nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", nil, nil, "", nil, nil, slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -278,7 +278,7 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	appStore := applications.NewCosmosStore(newFakeItems())
 	savedStore := savedapplications.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", nil, nil, "", nil, nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{},nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", nil, nil, "", nil, nil, logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -361,7 +361,7 @@ func TestRouter_GeocodeAndDesignationsDispatch(t *testing.T) {
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
 	geocodeClient := testGeocodeClientWith(t, upstream.URL, upstream.Client())
 	designationClient := testDesignationClientWith(t, upstream.URL, upstream.Client())
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", nil, nil, "", nil, nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{},nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", nil, nil, "", nil, nil, logger)
 
 	rec := serveReq(t, h, http.MethodGet, "/v1/geocode/SW1A%201AA", "", "Bearer tok")
 	if rec.Code != http.StatusOK {
@@ -400,7 +400,7 @@ func TestRouter_SubscriptionsWired(t *testing.T) {
 		t.Fatalf("NewJWSVerifier: %v", err)
 	}
 
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, adminStore, "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{},nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, adminStore, "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, logger)
 
 	// Webhook is anonymous: a malformed body reaches the handler -> 400 with the
 	// malformed_request envelope, not the WWW-Authenticate 401 fallback.
@@ -430,7 +430,7 @@ func TestRouter_AdminGate(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	offerStore := offercodes.NewCosmosStore(newFakeItems())
 	adminStore := profiles.NewAdminStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", nil, nil, "", nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{},nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", nil, nil, "", nil, nil, logger)
 
 	// No key: the admin gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -173,7 +173,7 @@ func testDesignationClientWith(t *testing.T, baseURL string, httpClient *http.Cl
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{},nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", nil, nil, "", nil, nil, slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", nil, nil, "", nil, nil, slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -278,7 +278,7 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	appStore := applications.NewCosmosStore(newFakeItems())
 	savedStore := savedapplications.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{},nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", nil, nil, "", nil, nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", nil, nil, "", nil, nil, logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -361,7 +361,7 @@ func TestRouter_GeocodeAndDesignationsDispatch(t *testing.T) {
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
 	geocodeClient := testGeocodeClientWith(t, upstream.URL, upstream.Client())
 	designationClient := testDesignationClientWith(t, upstream.URL, upstream.Client())
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{},nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", nil, nil, "", nil, nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", nil, nil, "", nil, nil, logger)
 
 	rec := serveReq(t, h, http.MethodGet, "/v1/geocode/SW1A%201AA", "", "Bearer tok")
 	if rec.Code != http.StatusOK {
@@ -400,7 +400,7 @@ func TestRouter_SubscriptionsWired(t *testing.T) {
 		t.Fatalf("NewJWSVerifier: %v", err)
 	}
 
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{},nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, adminStore, "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, adminStore, "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, logger)
 
 	// Webhook is anonymous: a malformed body reaches the handler -> 400 with the
 	// malformed_request envelope, not the WWW-Authenticate 401 fallback.
@@ -430,7 +430,7 @@ func TestRouter_AdminGate(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	offerStore := offercodes.NewCosmosStore(newFakeItems())
 	adminStore := profiles.NewAdminStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{},nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", nil, nil, "", nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", nil, nil, "", nil, nil, logger)
 
 	// No key: the admin gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).

--- a/api-go/internal/notifications/digest_store_cosmos.go
+++ b/api-go/internal/notifications/digest_store_cosmos.go
@@ -55,6 +55,25 @@ func (s *DigestStore) ByUserSince(ctx context.Context, userID string, since time
 	return decodeDigests(raws, userID)
 }
 
+// allByUserQuery selects every notification in a user's partition, oldest first,
+// with no since-floor — the GDPR-export read. It is single-partition (scoped to
+// userId) so it never fans out cross-partition; the Notifications container's
+// 90-day TTL naturally bounds the row count. The ORDER BY makes the export's
+// notifications array deterministic so successive exports stay byte-stable.
+const allByUserQuery = "SELECT * FROM c WHERE c.userId = @userId ORDER BY c.createdAt ASC"
+
+// AllByUser returns every notification in the user's partition, hydrated to the
+// full DigestNotification, for the GDPR data export (GET /v1/me/data). Unlike
+// ByUserSince it applies no time window — the export covers the user's whole
+// (TTL-bounded) notification history. Single-partition, never cross-partition.
+func (s *DigestStore) AllByUser(ctx context.Context, userID string) ([]DigestNotification, error) {
+	raws, err := s.items.QueryItems(ctx, userID, allByUserQuery, map[string]any{"@userId": userID})
+	if err != nil {
+		return nil, fmt.Errorf("query all notifications for %q: %w", userID, err)
+	}
+	return decodeDigests(raws, userID)
+}
+
 // unsentEmailsQuery selects a user's notifications whose email has not yet been
 // sent, oldest first. The OR-NOT-IS_DEFINED clause includes legacy rows written
 // before the emailSent field existed. Mirrors .NET GetUnsentEmailsByUserAsync.

--- a/api-go/internal/notifications/digest_store_test.go
+++ b/api-go/internal/notifications/digest_store_test.go
@@ -102,6 +102,40 @@ func TestDigestStore_ByUserSince(t *testing.T) {
 	}
 }
 
+func TestDigestStore_AllByUser(t *testing.T) {
+	t.Parallel()
+	// AllByUser is the GDPR-export read: every notification in the user's
+	// partition, with no since-floor, hydrated to the full DigestNotification so
+	// the export carries each field. It is single-partition (scoped to userId) and
+	// must never fan out cross-partition.
+	items := &fakeDigestItems{queryResult: [][]byte{
+		fullDocJSON(t, "n-1", "user-1", "uid-A", "zone-1", "2026-02-02T00:00:00+00:00", true),
+		fullDocJSON(t, "n-2", "user-1", "uid-B", "", "2026-02-01T00:00:00+00:00", false),
+	}}
+	store := NewDigestStore(items)
+
+	got, err := store.AllByUser(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("AllByUser: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("count: got %d, want 2", len(got))
+	}
+	if got[0].ID != "n-1" || got[1].ID != "n-2" {
+		t.Errorf("hydrated ids wrong: %+v", got)
+	}
+	if items.queryPK != "user-1" {
+		t.Errorf("partition key: got %q, want user-1", items.queryPK)
+	}
+	// No since-floor: the export covers the user's whole (TTL-bounded) history.
+	if strings.Contains(items.queryText, "@since") || strings.Contains(items.queryText, "createdAt >=") {
+		t.Errorf("AllByUser must not apply a since-floor: %q", items.queryText)
+	}
+	if !strings.Contains(items.queryText, "c.userId = @userId") {
+		t.Errorf("query must be scoped to the user partition: %q", items.queryText)
+	}
+}
+
 func TestDigestStore_UnsentEmailsByUser(t *testing.T) {
 	t.Parallel()
 	items := &fakeDigestItems{queryResult: [][]byte{

--- a/api-go/internal/notifications/digest_store_test.go
+++ b/api-go/internal/notifications/digest_store_test.go
@@ -109,12 +109,12 @@ func TestDigestStore_AllByUser(t *testing.T) {
 	// the export carries each field. It is single-partition (scoped to userId) and
 	// must never fan out cross-partition.
 	items := &fakeDigestItems{queryResult: [][]byte{
-		fullDocJSON(t, "n-1", "user-1", "uid-A", "zone-1", "2026-02-02T00:00:00+00:00", true),
-		fullDocJSON(t, "n-2", "user-1", "uid-B", "", "2026-02-01T00:00:00+00:00", false),
+		fullDocJSON(t, "n-1", "user-2", "uid-A", "zone-1", "2026-02-02T00:00:00+00:00", true),
+		fullDocJSON(t, "n-2", "user-2", "uid-B", "", "2026-02-01T00:00:00+00:00", false),
 	}}
 	store := NewDigestStore(items)
 
-	got, err := store.AllByUser(context.Background(), "user-1")
+	got, err := store.AllByUser(context.Background(), "user-2")
 	if err != nil {
 		t.Fatalf("AllByUser: %v", err)
 	}
@@ -124,8 +124,10 @@ func TestDigestStore_AllByUser(t *testing.T) {
 	if got[0].ID != "n-1" || got[1].ID != "n-2" {
 		t.Errorf("hydrated ids wrong: %+v", got)
 	}
-	if items.queryPK != "user-1" {
-		t.Errorf("partition key: got %q, want user-1", items.queryPK)
+	// Scoped to the caller's partition (here a distinct user id), so the read never
+	// fans out cross-partition.
+	if items.queryPK != "user-2" {
+		t.Errorf("partition key: got %q, want user-2", items.queryPK)
 	}
 	// No since-floor: the export covers the user's whole (TTL-bounded) history.
 	if strings.Contains(items.queryText, "@since") || strings.Contains(items.queryText, "createdAt >=") {

--- a/api-go/internal/offercodes/store_cosmos.go
+++ b/api-go/internal/offercodes/store_cosmos.go
@@ -117,6 +117,33 @@ func (s *CosmosStore) RedeemWithCAS(ctx context.Context, canonical, userID strin
 // this is a deliberate cross-partition scan.
 const redeemedByUserIDQuery = "SELECT * FROM c WHERE c.redeemedByUserId = @userId"
 
+// RedeemedByUserID returns every code the user redeemed, hydrated to the domain
+// model, for the GDPR data export (GET /v1/me/data). It reuses the same
+// cross-partition redeemedByUserId scan as the anonymise path (the OfferCodes
+// container is partitioned by /id == the canonical code, not by redeemer, so
+// finding a user's redemptions must fan out across partitions). The common case
+// (the user never redeemed a code) matches nothing and returns an empty, non-nil
+// slice. The export sorts the result, so no ORDER BY is needed here.
+func (s *CosmosStore) RedeemedByUserID(ctx context.Context, userID string) ([]OfferCode, error) {
+	raws, err := s.items.QueryItemsCrossPartition(ctx, redeemedByUserIDQuery, map[string]any{"@userId": userID})
+	if err != nil {
+		return nil, fmt.Errorf("query redemptions for user %q: %w", userID, err)
+	}
+	codes := make([]OfferCode, 0, len(raws))
+	for _, raw := range raws {
+		var doc offerCodeDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("decode redeemed offer code for user %q: %w", userID, err)
+		}
+		code, err := doc.toDomain()
+		if err != nil {
+			return nil, fmt.Errorf("hydrate redeemed offer code for user %q: %w", userID, err)
+		}
+		codes = append(codes, code)
+	}
+	return codes, nil
+}
+
 // AnonymiseRedemptionsByUserID scrubs the redeemer back-reference
 // (redeemedByUserId + redeemedAt) from every code the user redeemed, for UK
 // GDPR Art. 17 account erasure. It does NOT delete the code document (the code

--- a/api-go/internal/offercodes/store_cosmos_test.go
+++ b/api-go/internal/offercodes/store_cosmos_test.go
@@ -163,6 +163,70 @@ func TestCosmosStore_Get_NotFound(t *testing.T) {
 	}
 }
 
+// RedeemedByUserID is the GDPR-export read: every code the user redeemed,
+// hydrated to the domain model, reusing the same cross-partition redeemedByUserId
+// scan the anonymise path uses (the container is keyed by code, not redeemer). It
+// must return only the caller's redemptions, not other users' or unredeemed codes.
+func TestCosmosStore_RedeemedByUserID(t *testing.T) {
+	t.Parallel()
+
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+	ctx := context.Background()
+	created := time.Date(2026, 6, 1, 9, 30, 0, 0, time.UTC)
+	redeemedAt := time.Date(2026, 6, 2, 10, 0, 0, 0, time.UTC)
+
+	mine, _ := NewOfferCode("AAAAAAAAAAAA", profiles.TierPro, 30, created)
+	if err := mine.Redeem("auth0|target", redeemedAt); err != nil {
+		t.Fatalf("Redeem mine: %v", err)
+	}
+	theirs, _ := NewOfferCode("BBBBBBBBBBBB", profiles.TierPersonal, 14, created)
+	if err := theirs.Redeem("auth0|other", redeemedAt); err != nil {
+		t.Fatalf("Redeem theirs: %v", err)
+	}
+	fresh, _ := NewOfferCode("CCCCCCCCCCCC", profiles.TierPro, 7, created)
+	for _, c := range []OfferCode{mine, theirs, fresh} {
+		if err := store.Save(ctx, c); err != nil {
+			t.Fatalf("Save %s: %v", c.Code, err)
+		}
+	}
+
+	got, err := store.RedeemedByUserID(ctx, "auth0|target")
+	if err != nil {
+		t.Fatalf("RedeemedByUserID: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("count: got %d, want 1 (only the target's redemption)", len(got))
+	}
+	c := got[0]
+	if c.Code != "AAAAAAAAAAAA" || c.Tier != profiles.TierPro || c.DurationDays != 30 {
+		t.Errorf("hydrated code mismatch: %+v", c)
+	}
+	if c.RedeemedByUserID == nil || *c.RedeemedByUserID != "auth0|target" {
+		t.Errorf("redeemer mismatch: %+v", c)
+	}
+	if c.RedeemedAt == nil || !c.RedeemedAt.Equal(redeemedAt) {
+		t.Errorf("RedeemedAt = %v, want %v", c.RedeemedAt, redeemedAt)
+	}
+}
+
+// A user who never redeemed a code yields an empty, non-nil slice.
+func TestCosmosStore_RedeemedByUserID_NoMatches(t *testing.T) {
+	t.Parallel()
+
+	store := NewCosmosStore(newFakeItems())
+	got, err := store.RedeemedByUserID(context.Background(), "auth0|never")
+	if err != nil {
+		t.Fatalf("RedeemedByUserID: %v", err)
+	}
+	if got == nil {
+		t.Error("must return a non-nil empty slice, not nil")
+	}
+	if len(got) != 0 {
+		t.Errorf("count: got %d, want 0", len(got))
+	}
+}
+
 // AnonymiseRedemptionsByUserID scrubs the PII (redeemedByUserId / redeemedAt)
 // from every code the user redeemed while keeping the consumed tombstone, and
 // must leave codes redeemed by other users — and never-redeemed codes —

--- a/api-go/internal/profiles/export.go
+++ b/api-go/internal/profiles/export.go
@@ -2,6 +2,8 @@ package profiles
 
 import (
 	"cmp"
+	"context"
+	"fmt"
 	"slices"
 
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
@@ -12,19 +14,21 @@ import (
 // notificationPreferences (with the per-zone array) and subscription blocks.
 // JSON keys are camelCase to match the web serializer; the tier enum renders as
 // its string name. Child collections (watch zones, notifications, saved
-// applications, device registrations, offer-code redemptions) are sourced by
-// stores that arrive in later iterations; until then they serialise as empty
-// arrays — never null — to match .NET's IReadOnlyList<>.ToList() empty result.
+// applications, device registrations, offer-code redemptions) are sourced by the
+// per-feature stores via the consumer-side ExportReaders (export_readers.go);
+// each is sorted deterministically so successive exports are byte-stable, and an
+// absent reader (Cosmos-less local boot) yields an empty array — never null — to
+// match .NET's IReadOnlyList<>.ToList() empty result.
 type exportUserData struct {
 	UserID                  string                        `json:"userId"`
 	Email                   *string                       `json:"email"`
 	NotificationPreferences exportedNotificationPrefs     `json:"notificationPreferences"`
 	Subscription            exportedSubscription          `json:"subscription"`
-	WatchZones              []exportedWatchZone           `json:"watchZones"`
-	Notifications           []exportedNotification        `json:"notifications"`
-	SavedApplications       []exportedSavedApplication    `json:"savedApplications"`
-	DeviceRegistrations     []exportedDeviceRegistration  `json:"deviceRegistrations"`
-	OfferCodeRedemptions    []exportedOfferCodeRedemption `json:"offerCodeRedemptions"`
+	WatchZones              []ExportedWatchZone           `json:"watchZones"`
+	Notifications           []ExportedNotification        `json:"notifications"`
+	SavedApplications       []ExportedSavedApplication    `json:"savedApplications"`
+	DeviceRegistrations     []ExportedDeviceRegistration  `json:"deviceRegistrations"`
+	OfferCodeRedemptions    []ExportedOfferCodeRedemption `json:"offerCodeRedemptions"`
 }
 
 type exportedNotificationPrefs struct {
@@ -51,11 +55,12 @@ type exportedSubscription struct {
 	GracePeriodExpiresAt  *platform.DotNetTime `json:"gracePeriodExpiresAt"`
 }
 
-// The following child-record shapes match .NET's Exported* records. They have no
-// data source in iteration 3 (their stores land later), so the export always
-// renders them as empty arrays; the structs pin the contract for when the
-// sources arrive.
-type exportedWatchZone struct {
+// The following child-record shapes match .NET's Exported* records. They are the
+// neutral return types of the consumer-side ExportReaders (export_readers.go), so
+// they are exported: cmd/api's store adapters build them directly, keeping the
+// store -> row mapping out of profiles (which must not import the feature
+// packages — see the import-cycle note in export_readers.go).
+type ExportedWatchZone struct {
 	ID           string              `json:"id"`
 	Name         string              `json:"name"`
 	Latitude     float64             `json:"latitude"`
@@ -65,7 +70,7 @@ type exportedWatchZone struct {
 	CreatedAt    platform.DotNetTime `json:"createdAt"`
 }
 
-type exportedNotification struct {
+type ExportedNotification struct {
 	ID                     string              `json:"id"`
 	ApplicationName        string              `json:"applicationName"`
 	WatchZoneID            *string             `json:"watchZoneId"`
@@ -79,27 +84,31 @@ type exportedNotification struct {
 	CreatedAt              platform.DotNetTime `json:"createdAt"`
 }
 
-type exportedSavedApplication struct {
+type ExportedSavedApplication struct {
 	ApplicationUID string              `json:"applicationUid"`
 	SavedAt        platform.DotNetTime `json:"savedAt"`
 }
 
-type exportedDeviceRegistration struct {
+type ExportedDeviceRegistration struct {
 	Token        string              `json:"token"`
 	Platform     string              `json:"platform"`
 	RegisteredAt platform.DotNetTime `json:"registeredAt"`
 }
 
-type exportedOfferCodeRedemption struct {
+type ExportedOfferCodeRedemption struct {
 	Code         string              `json:"code"`
 	Tier         string              `json:"tier"`
 	DurationDays int                 `json:"durationDays"`
 	RedeemedAt   platform.DotNetTime `json:"redeemedAt"`
 }
 
-// newExportUserData builds the export contract for a profile, with child
-// collections initialised as empty (non-nil) slices so they serialise as [].
-func newExportUserData(p *UserProfile) exportUserData {
+// newExportUserData builds the export contract for a profile, sourcing each child
+// collection from its reader and sorting it deterministically so two successive
+// exports of the same data are byte-identical (the iOS share fetches the export
+// repeatedly). A nil reader (Cosmos-less local boot) leaves that collection as an
+// empty, non-nil slice so it serialises as [] rather than null. A reader failure
+// is returned so the handler renders a 500 rather than a silently-empty section.
+func newExportUserData(ctx context.Context, p *UserProfile, readers ExportReaders) (exportUserData, error) {
 	zones := make([]exportedZonePreference, 0, len(p.ZonePreferences))
 	for id, z := range p.ZonePreferences {
 		zones = append(zones, exportedZonePreference{
@@ -117,6 +126,57 @@ func newExportUserData(p *UserProfile) exportUserData {
 	slices.SortFunc(zones, func(a, b exportedZonePreference) int {
 		return cmp.Compare(a.ZoneID, b.ZoneID)
 	})
+
+	watchZones := []ExportedWatchZone{}
+	if readers.WatchZones != nil {
+		rows, err := readers.WatchZones.WatchZonesByUser(ctx, p.UserID)
+		if err != nil {
+			return exportUserData{}, fmt.Errorf("export watch zones: %w", err)
+		}
+		watchZones = rows
+	}
+	slices.SortFunc(watchZones, func(a, b ExportedWatchZone) int { return cmp.Compare(a.ID, b.ID) })
+
+	notifs := []ExportedNotification{}
+	if readers.Notifications != nil {
+		rows, err := readers.Notifications.NotificationsByUser(ctx, p.UserID)
+		if err != nil {
+			return exportUserData{}, fmt.Errorf("export notifications: %w", err)
+		}
+		notifs = rows
+	}
+	slices.SortFunc(notifs, func(a, b ExportedNotification) int { return cmp.Compare(a.ID, b.ID) })
+
+	saved := []ExportedSavedApplication{}
+	if readers.SavedApplications != nil {
+		rows, err := readers.SavedApplications.SavedApplicationsByUser(ctx, p.UserID)
+		if err != nil {
+			return exportUserData{}, fmt.Errorf("export saved applications: %w", err)
+		}
+		saved = rows
+	}
+	slices.SortFunc(saved, func(a, b ExportedSavedApplication) int { return cmp.Compare(a.ApplicationUID, b.ApplicationUID) })
+
+	devices := []ExportedDeviceRegistration{}
+	if readers.DeviceRegistrations != nil {
+		rows, err := readers.DeviceRegistrations.DeviceRegistrationsByUser(ctx, p.UserID)
+		if err != nil {
+			return exportUserData{}, fmt.Errorf("export device registrations: %w", err)
+		}
+		devices = rows
+	}
+	slices.SortFunc(devices, func(a, b ExportedDeviceRegistration) int { return cmp.Compare(a.Token, b.Token) })
+
+	codes := []ExportedOfferCodeRedemption{}
+	if readers.OfferCodeRedemptions != nil {
+		rows, err := readers.OfferCodeRedemptions.OfferCodeRedemptionsByUser(ctx, p.UserID)
+		if err != nil {
+			return exportUserData{}, fmt.Errorf("export offer-code redemptions: %w", err)
+		}
+		codes = rows
+	}
+	slices.SortFunc(codes, func(a, b ExportedOfferCodeRedemption) int { return cmp.Compare(a.Code, b.Code) })
+
 	return exportUserData{
 		UserID: p.UserID,
 		Email:  p.Email,
@@ -134,10 +194,10 @@ func newExportUserData(p *UserProfile) exportUserData {
 			OriginalTransactionID: p.OriginalTransactionID,
 			GracePeriodExpiresAt:  platform.DotNetTimePtr(p.GracePeriodExpiry),
 		},
-		WatchZones:           []exportedWatchZone{},
-		Notifications:        []exportedNotification{},
-		SavedApplications:    []exportedSavedApplication{},
-		DeviceRegistrations:  []exportedDeviceRegistration{},
-		OfferCodeRedemptions: []exportedOfferCodeRedemption{},
-	}
+		WatchZones:           watchZones,
+		Notifications:        notifs,
+		SavedApplications:    saved,
+		DeviceRegistrations:  devices,
+		OfferCodeRedemptions: codes,
+	}, nil
 }

--- a/api-go/internal/profiles/export_readers.go
+++ b/api-go/internal/profiles/export_readers.go
@@ -1,0 +1,55 @@
+package profiles
+
+import "context"
+
+// The GDPR export (GET /v1/me/data) populates its child collections from the
+// per-feature stores. Those stores live in packages that cannot be imported here
+// without a cycle: package offercodes already imports profiles
+// (profiles.ParseSubscriptionTier), so profiles importing offercodes (or, by the
+// same DI symmetry, watchzones / notifications / savedapplications / devicetokens)
+// would close a loop. The readers below are therefore consumer-side interfaces,
+// declared where they are used, returning profiles-local row structs (the
+// Exported* types in export.go). cmd/api supplies thin adapters that map each
+// store's records to those row types, mirroring the CascadeDeleters pattern
+// (cascade.go + cmd/api/main.go) exactly.
+//
+// Each reader is single-method and returns the already-shaped export rows so the
+// export does no per-store mapping itself.
+
+// WatchZoneReader reads a user's watch zones for the export.
+type WatchZoneReader interface {
+	WatchZonesByUser(ctx context.Context, userID string) ([]ExportedWatchZone, error)
+}
+
+// NotificationReader reads a user's dispatched notifications for the export.
+type NotificationReader interface {
+	NotificationsByUser(ctx context.Context, userID string) ([]ExportedNotification, error)
+}
+
+// SavedApplicationReader reads a user's saved applications for the export.
+type SavedApplicationReader interface {
+	SavedApplicationsByUser(ctx context.Context, userID string) ([]ExportedSavedApplication, error)
+}
+
+// DeviceRegistrationReader reads a user's device registrations for the export.
+type DeviceRegistrationReader interface {
+	DeviceRegistrationsByUser(ctx context.Context, userID string) ([]ExportedDeviceRegistration, error)
+}
+
+// OfferCodeRedemptionReader reads the offer codes a user redeemed for the export.
+type OfferCodeRedemptionReader interface {
+	OfferCodeRedemptionsByUser(ctx context.Context, userID string) ([]ExportedOfferCodeRedemption, error)
+}
+
+// ExportReaders bundles the per-collection readers GET /v1/me/data uses to source
+// the export's child collections, mirroring CascadeDeleters. It is populated in
+// cmd/api under the same Cosmos-configured guard as profiles.Routes; on a
+// Cosmos-less local boot the fields are nil and the export renders every
+// collection as [] (never null) — newExportUserData skips a nil reader.
+type ExportReaders struct {
+	WatchZones           WatchZoneReader
+	Notifications        NotificationReader
+	SavedApplications    SavedApplicationReader
+	DeviceRegistrations  DeviceRegistrationReader
+	OfferCodeRedemptions OfferCodeRedemptionReader
+}

--- a/api-go/internal/profiles/export_test.go
+++ b/api-go/internal/profiles/export_test.go
@@ -308,7 +308,10 @@ func TestNewExportUserData_ZonePreferencesSortedByZoneID(t *testing.T) {
 	}
 
 	want := []string{"4abf25b2", "cb5224db", "eb39413d"}
-	export := newExportUserData(p)
+	export, err := newExportUserData(context.Background(), p, ExportReaders{})
+	if err != nil {
+		t.Fatalf("newExportUserData: %v", err)
+	}
 	got := make([]string, 0, len(export.NotificationPreferences.ZonePreferences))
 	for _, z := range export.NotificationPreferences.ZonePreferences {
 		got = append(got, z.ZoneID)

--- a/api-go/internal/profiles/export_test.go
+++ b/api-go/internal/profiles/export_test.go
@@ -1,9 +1,288 @@
 package profiles
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
+
+// The export readers are hand-written per-collection doubles; each returns the
+// profiles-local row slice the matching reader yields (the readers already return
+// profiles-local row structs, so the export maps nothing further). They are
+// defined below the constructor that assembles them into an ExportReaders bundle.
+
+func dnt(t *testing.T, s string) platform.DotNetTime {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse time %q: %v", s, err)
+	}
+	return platform.DotNetTime(parsed)
+}
+
+func populatedReaders(t *testing.T) ExportReaders {
+	t.Helper()
+	at := func(s string) platform.DotNetTime { return dnt(t, s) }
+	wzID := "zone-a"
+	appType := "Full"
+	decision := "Permitted"
+	return ExportReaders{
+		WatchZones: fakeWatchZonesReader{rows: []ExportedWatchZone{
+			{ID: "zone-b", Name: "Bravo", Latitude: 51.5, Longitude: -0.1, RadiusMetres: 500, AuthorityID: 22, CreatedAt: at("2026-02-02T00:00:00Z")},
+			{ID: "zone-a", Name: "Alpha", Latitude: 52.5, Longitude: -1.1, RadiusMetres: 1000, AuthorityID: 11, CreatedAt: at("2026-02-01T00:00:00Z")},
+		}},
+		Notifications: fakeNotificationsReader{rows: []ExportedNotification{
+			{ID: "n-2", ApplicationName: "App Two", WatchZoneID: &wzID, ApplicationAddress: "2 St", ApplicationDescription: "two", ApplicationType: &appType, AuthorityID: 22, Decision: &decision, PushSent: true, EmailSent: false, CreatedAt: at("2026-03-02T00:00:00Z")},
+			{ID: "n-1", ApplicationName: "App One", ApplicationAddress: "1 St", ApplicationDescription: "one", AuthorityID: 11, PushSent: true, EmailSent: true, CreatedAt: at("2026-03-01T00:00:00Z")},
+		}},
+		SavedApplications: fakeSavedReader{rows: []ExportedSavedApplication{
+			{ApplicationUID: "22/0002", SavedAt: at("2026-04-02T00:00:00Z")},
+			{ApplicationUID: "11/0001", SavedAt: at("2026-04-01T00:00:00Z")},
+		}},
+		DeviceRegistrations: fakeDevicesReader{rows: []ExportedDeviceRegistration{
+			{Token: "tok-z", Platform: "Android", RegisteredAt: at("2026-05-02T00:00:00Z")},
+			{Token: "tok-a", Platform: "Ios", RegisteredAt: at("2026-05-01T00:00:00Z")},
+		}},
+		OfferCodeRedemptions: fakeCodesReader{rows: []ExportedOfferCodeRedemption{
+			{Code: "ZZZZ", Tier: "Pro", DurationDays: 30, RedeemedAt: at("2026-06-02T00:00:00Z")},
+			{Code: "AAAA", Tier: "Personal", DurationDays: 14, RedeemedAt: at("2026-06-01T00:00:00Z")},
+		}},
+	}
+}
+
+type fakeWatchZonesReader struct {
+	rows []ExportedWatchZone
+	err  error
+}
+
+func (f fakeWatchZonesReader) WatchZonesByUser(_ context.Context, _ string) ([]ExportedWatchZone, error) {
+	return f.rows, f.err
+}
+
+type fakeNotificationsReader struct{ rows []ExportedNotification }
+
+func (f fakeNotificationsReader) NotificationsByUser(_ context.Context, _ string) ([]ExportedNotification, error) {
+	return f.rows, nil
+}
+
+type fakeSavedReader struct{ rows []ExportedSavedApplication }
+
+func (f fakeSavedReader) SavedApplicationsByUser(_ context.Context, _ string) ([]ExportedSavedApplication, error) {
+	return f.rows, nil
+}
+
+type fakeDevicesReader struct{ rows []ExportedDeviceRegistration }
+
+func (f fakeDevicesReader) DeviceRegistrationsByUser(_ context.Context, _ string) ([]ExportedDeviceRegistration, error) {
+	return f.rows, nil
+}
+
+type fakeCodesReader struct{ rows []ExportedOfferCodeRedemption }
+
+func (f fakeCodesReader) OfferCodeRedemptionsByUser(_ context.Context, _ string) ([]ExportedOfferCodeRedemption, error) {
+	return f.rows, nil
+}
+
+func testExportProfile() *UserProfile {
+	return &UserProfile{
+		UserID:       "auth0|abc",
+		Preferences:  DefaultPreferences(),
+		LastActiveAt: time.Now(),
+	}
+}
+
+// TestNewExportUserData_PopulatedFromReaders pins the GDPR export populating every
+// child collection from the readers, each sorted deterministically so successive
+// exports are byte-stable, with the shapes the Privacy Policy promises.
+func TestNewExportUserData_PopulatedFromReaders(t *testing.T) {
+	t.Parallel()
+
+	export, err := newExportUserData(context.Background(), testExportProfile(), populatedReaders(t))
+	if err != nil {
+		t.Fatalf("newExportUserData: %v", err)
+	}
+
+	if got := zoneIDs(export.WatchZones); !equalStrings(got, []string{"zone-a", "zone-b"}) {
+		t.Errorf("watchZones not sorted by id: %v", got)
+	}
+	if got := notifIDs(export.Notifications); !equalStrings(got, []string{"n-1", "n-2"}) {
+		t.Errorf("notifications not sorted by id: %v", got)
+	}
+	if got := savedUIDs(export.SavedApplications); !equalStrings(got, []string{"11/0001", "22/0002"}) {
+		t.Errorf("savedApplications not sorted by applicationUid: %v", got)
+	}
+	if got := deviceTokens(export.DeviceRegistrations); !equalStrings(got, []string{"tok-a", "tok-z"}) {
+		t.Errorf("deviceRegistrations not sorted by token: %v", got)
+	}
+	if got := codeStrings(export.OfferCodeRedemptions); !equalStrings(got, []string{"AAAA", "ZZZZ"}) {
+		t.Errorf("offerCodeRedemptions not sorted by code: %v", got)
+	}
+
+	// Byte-stability: marshalling the same export twice (and re-running the build)
+	// must yield identical bytes — the export is read repeatedly per the iOS share.
+	first := mustMarshal(t, export)
+	again, err := newExportUserData(context.Background(), testExportProfile(), populatedReaders(t))
+	if err != nil {
+		t.Fatalf("newExportUserData (repeat): %v", err)
+	}
+	if second := mustMarshal(t, again); first != second {
+		t.Errorf("export not byte-stable across calls:\n first=%s\nsecond=%s", first, second)
+	}
+}
+
+// TestNewExportUserData_PopulatedShapes asserts the wire shape (camelCase keys,
+// .NET timestamp format, nested optional fields) of one fully-shaped row per
+// collection so the contract the Privacy Policy promises is exact.
+func TestNewExportUserData_PopulatedShapes(t *testing.T) {
+	t.Parallel()
+
+	export, err := newExportUserData(context.Background(), testExportProfile(), populatedReaders(t))
+	if err != nil {
+		t.Fatalf("newExportUserData: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(mustMarshal(t, export)), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	wz := got["watchZones"].([]any)[0].(map[string]any) // sorted: zone-a first
+	if wz["id"] != "zone-a" || wz["name"] != "Alpha" || wz["radiusMetres"] != 1000.0 || wz["authorityId"] != 11.0 {
+		t.Errorf("watchZone shape wrong: %v", wz)
+	}
+	if wz["createdAt"] != "2026-02-01T00:00:00+00:00" {
+		t.Errorf("watchZone createdAt wire format: got %v", wz["createdAt"])
+	}
+
+	n := got["notifications"].([]any)[1].(map[string]any) // sorted: n-1, n-2 -> index 1 is n-2 (has the optionals)
+	if n["id"] != "n-2" || n["watchZoneId"] != "zone-a" || n["applicationType"] != "Full" || n["decision"] != "Permitted" {
+		t.Errorf("notification shape wrong: %v", n)
+	}
+	if n["pushSent"] != true || n["emailSent"] != false {
+		t.Errorf("notification flags wrong: %v", n)
+	}
+
+	sa := got["savedApplications"].([]any)[0].(map[string]any)
+	if sa["applicationUid"] != "11/0001" || sa["savedAt"] != "2026-04-01T00:00:00+00:00" {
+		t.Errorf("savedApplication shape wrong: %v", sa)
+	}
+
+	dr := got["deviceRegistrations"].([]any)[0].(map[string]any)
+	if dr["token"] != "tok-a" || dr["platform"] != "Ios" || dr["registeredAt"] != "2026-05-01T00:00:00+00:00" {
+		t.Errorf("deviceRegistration shape wrong: %v", dr)
+	}
+
+	oc := got["offerCodeRedemptions"].([]any)[0].(map[string]any)
+	if oc["code"] != "AAAA" || oc["tier"] != "Personal" || oc["durationDays"] != 14.0 || oc["redeemedAt"] != "2026-06-01T00:00:00+00:00" {
+		t.Errorf("offerCodeRedemption shape wrong: %v", oc)
+	}
+}
+
+// TestNewExportUserData_NilReadersYieldEmptyArrays guards the Cosmos-less local
+// boot: when the readers are absent (zero-valued bundle) every child collection
+// must still render as [] — never null.
+func TestNewExportUserData_NilReadersYieldEmptyArrays(t *testing.T) {
+	t.Parallel()
+
+	export, err := newExportUserData(context.Background(), testExportProfile(), ExportReaders{})
+	if err != nil {
+		t.Fatalf("newExportUserData: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(mustMarshal(t, export)), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"watchZones", "notifications", "savedApplications", "deviceRegistrations", "offerCodeRedemptions"} {
+		arr, ok := got[k].([]any)
+		if !ok {
+			t.Errorf("%s must be [] (array), got %v (%T)", k, got[k], got[k])
+			continue
+		}
+		if len(arr) != 0 {
+			t.Errorf("%s must be empty with nil readers, got %v", k, arr)
+		}
+	}
+}
+
+// TestNewExportUserData_ReaderErrorPropagates ensures a store failure surfaces as
+// an error (the handler maps it to a 500) rather than a silent empty collection.
+func TestNewExportUserData_ReaderErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	readers := ExportReaders{WatchZones: fakeWatchZonesReader{err: errBoom}}
+	if _, err := newExportUserData(context.Background(), testExportProfile(), readers); err == nil {
+		t.Fatal("expected an error when a reader fails, got nil")
+	}
+}
+
+var errBoom = &boomError{}
+
+type boomError struct{}
+
+func (*boomError) Error() string { return "boom" }
+
+func mustMarshal(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+func zoneIDs(zs []ExportedWatchZone) []string {
+	out := make([]string, len(zs))
+	for i, z := range zs {
+		out[i] = z.ID
+	}
+	return out
+}
+
+func notifIDs(ns []ExportedNotification) []string {
+	out := make([]string, len(ns))
+	for i, n := range ns {
+		out[i] = n.ID
+	}
+	return out
+}
+
+func savedUIDs(ss []ExportedSavedApplication) []string {
+	out := make([]string, len(ss))
+	for i, s := range ss {
+		out[i] = s.ApplicationUID
+	}
+	return out
+}
+
+func deviceTokens(ds []ExportedDeviceRegistration) []string {
+	out := make([]string, len(ds))
+	for i, d := range ds {
+		out[i] = d.Token
+	}
+	return out
+}
+
+func codeStrings(cs []ExportedOfferCodeRedemption) []string {
+	out := make([]string, len(cs))
+	for i, c := range cs {
+		out[i] = c.Code
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
 
 // TestNewExportUserData_ZonePreferencesSortedByZoneID pins the fix for tc-zgnt:
 // the GDPR export builds zonePreferences by ranging a Go map, whose iteration

--- a/api-go/internal/profiles/handler.go
+++ b/api-go/internal/profiles/handler.go
@@ -33,33 +33,35 @@ type profileStore interface {
 
 // handler serves the /v1/me lifecycle. It depends on the profile store, the
 // Auth0 management client (real or no-op), the per-container cascade deleters
-// account erasure runs, the auto-grant pro-domain list, a clock, and a logger —
-// all injected, no globals.
+// account erasure runs, the per-collection readers GET /v1/me/data exports, the
+// auto-grant pro-domain list, a clock, and a logger — all injected, no globals.
 type handler struct {
-	store      profileStore
-	auth0      Auth0Manager
-	cascade    CascadeDeleters
-	proDomains proDomainSet
-	now        func() time.Time
-	logger     *slog.Logger
+	store         profileStore
+	auth0         Auth0Manager
+	cascade       CascadeDeleters
+	exportReaders ExportReaders
+	proDomains    proDomainSet
+	now           func() time.Time
+	logger        *slog.Logger
 }
 
 // newHandler builds the /v1/me handler.
-func newHandler(store profileStore, auth0 Auth0Manager, proDomains string, cascade CascadeDeleters, now func() time.Time, logger *slog.Logger) *handler {
+func newHandler(store profileStore, auth0 Auth0Manager, proDomains string, cascade CascadeDeleters, exportReaders ExportReaders, now func() time.Time, logger *slog.Logger) *handler {
 	return &handler{
-		store:      store,
-		auth0:      auth0,
-		cascade:    cascade,
-		proDomains: newProDomainSet(proDomains),
-		now:        now,
-		logger:     logger,
+		store:         store,
+		auth0:         auth0,
+		cascade:       cascade,
+		exportReaders: exportReaders,
+		proDomains:    newProDomainSet(proDomains),
+		now:           now,
+		logger:        logger,
 	}
 }
 
 // Routes registers the /v1/me endpoints on mux. All are authenticated: the auth
 // middleware guarantees a subject in context before these handlers run.
-func Routes(mux *http.ServeMux, store profileStore, auth0 Auth0Manager, proDomains string, cascade CascadeDeleters, now func() time.Time, logger *slog.Logger) {
-	h := newHandler(store, auth0, proDomains, cascade, now, logger)
+func Routes(mux *http.ServeMux, store profileStore, auth0 Auth0Manager, proDomains string, cascade CascadeDeleters, exportReaders ExportReaders, now func() time.Time, logger *slog.Logger) {
+	h := newHandler(store, auth0, proDomains, cascade, exportReaders, now, logger)
 	mux.HandleFunc("POST /v1/me", h.create)
 	mux.HandleFunc("GET /v1/me", h.get)
 	mux.HandleFunc("PATCH /v1/me", h.patch)
@@ -265,7 +267,12 @@ func (h *handler) exportData(w http.ResponseWriter, r *http.Request) {
 		h.serverError(w, r, "load profile", err)
 		return
 	}
-	h.writeJSON(w, r, newExportUserData(profile))
+	export, err := newExportUserData(r.Context(), profile, h.exportReaders)
+	if err != nil {
+		h.serverError(w, r, "build export", err)
+		return
+	}
+	h.writeJSON(w, r, export)
 }
 
 // tryBackfillAuth0Tier syncs Auth0's subscription_tier to the Cosmos tier when

--- a/api-go/internal/profiles/handler_test.go
+++ b/api-go/internal/profiles/handler_test.go
@@ -134,7 +134,14 @@ func newTestHandler(store profileStore, a0 Auth0Manager, proDomains string) *han
 
 func newTestHandlerCascade(store profileStore, a0 Auth0Manager, proDomains string, cascade CascadeDeleters) *handler {
 	now := func() time.Time { return time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC) }
-	return newHandler(store, a0, proDomains, cascade, now, slog.New(slog.DiscardHandler))
+	return newHandler(store, a0, proDomains, cascade, ExportReaders{}, now, slog.New(slog.DiscardHandler))
+}
+
+// newTestHandlerExport builds a handler with the export readers wired, for the
+// GDPR-export tests.
+func newTestHandlerExport(store profileStore, a0 Auth0Manager, readers ExportReaders) *handler {
+	now := func() time.Time { return time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC) }
+	return newHandler(store, a0, "", CascadeDeleters{}, readers, now, slog.New(slog.DiscardHandler))
 }
 
 // withSubject builds a request carrying an authenticated subject in context, as
@@ -571,7 +578,9 @@ func TestHandler_ExportData_NestedContract(t *testing.T) {
 	if sub["gracePeriodExpiresAt"] != nil {
 		t.Errorf("gracePeriodExpiresAt: got %v, want null", sub["gracePeriodExpiresAt"])
 	}
-	// Child collections not yet sourced in this iteration: present as empty arrays.
+	// This handler is built with no export readers (newTestHandler passes a
+	// zero ExportReaders), so the child collections must still render as empty
+	// arrays — never null.
 	for _, k := range []string{"watchZones", "notifications", "savedApplications", "deviceRegistrations", "offerCodeRedemptions"} {
 		arr, ok := got[k].([]any)
 		if !ok {
@@ -579,7 +588,43 @@ func TestHandler_ExportData_NestedContract(t *testing.T) {
 			continue
 		}
 		if len(arr) != 0 {
-			t.Errorf("%s should be empty in it3, got %v", k, arr)
+			t.Errorf("%s should be empty with no readers, got %v", k, arr)
+		}
+	}
+}
+
+// TestHandler_ExportData_PopulatedChildCollections drives the export end-to-end
+// through the handler with the readers wired: every child collection is present,
+// non-empty, and correctly shaped in the HTTP response body.
+func TestHandler_ExportData_PopulatedChildCollections(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	store.byID["auth0|abc"] = &UserProfile{
+		UserID:       "auth0|abc",
+		Preferences:  DefaultPreferences(),
+		Tier:         TierPro,
+		LastActiveAt: time.Now(),
+	}
+	h := newTestHandlerExport(store, newFakeAuth0(), populatedReaders(t))
+
+	rec := httptest.NewRecorder()
+	h.exportData(rec, withSubject(http.MethodGet, "/v1/me/data", "auth0|abc", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("export status: got %d, want 200", rec.Code)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, k := range []string{"watchZones", "notifications", "savedApplications", "deviceRegistrations", "offerCodeRedemptions"} {
+		arr, ok := got[k].([]any)
+		if !ok {
+			t.Errorf("%s should be an array, got %v", k, got[k])
+			continue
+		}
+		if len(arr) == 0 {
+			t.Errorf("%s should be populated, got empty", k)
 		}
 	}
 }


### PR DESCRIPTION
## What

`GET /v1/me/data` (the GDPR self-service export) previously hardcoded WatchZones, Notifications, SavedApplications, DeviceRegistrations and OfferCodeRedemptions to empty arrays (`export.go:137-141`), while the Privacy Policy promises a machine-readable export covering all of them. This populates every child collection from the real stores.

## How

- **Consumer-side readers in `profiles`** — a new `ExportReaders` bundle of reader interfaces returning profiles-local `Exported*` row structs. Store→row mapping lives in thin adapters in `cmd/api/export_adapters.go`, wired in `main.go` under the same Cosmos-configured guard as `CascadeDeleters`. This keeps `profiles` from importing the feature packages (necessary: `offercodes` imports `profiles`).
- **Two new store reads**:
  - `notifications.DigestStore.AllByUser` — single-partition full-document read (carries every exported field; 90-day TTL bounds it).
  - `offercodes.CosmosStore.RedeemedByUserID` — reuses the existing `redeemedByUserIDQuery` cross-partition scan.
- Every collection is sorted deterministically so successive exports are **byte-stable** (same property already held for `ZonePreferences`).
- A store read failure now **propagates → 500**; a nil reader (Cosmos-less boot) renders `[]`, never null.

## Tests

Store-method unit tests + `export_test.go`/`handler_test.go` cover a fully populated account (every collection non-empty, correctly shaped, sorted, byte-stable across repeated calls), an empty account (`[]` not null), nil readers, and reader-error propagation.

## Gates (local)

`gofmt -l .` clean · `go vet` clean · `go build` ok · `go test ./...` 970 passed · `golangci-lint run ./...` 0 issues.

Closes tc-lllv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced the GDPR data export endpoint (`/v1/me/data`) to include watch zones, notifications, saved applications, device registrations, and offer code redemptions alongside existing profile data.

* **Tests**
  * Added comprehensive test coverage validating the expanded export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->