### PR TITLE
feat(ios): Export your data action in Settings (tc-gczo)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
@@ -80,7 +80,52 @@ public final class URLSessionAPIClient: Sendable {
     }
   }
 
+  /// Performs a request and returns the raw response body bytes without
+  /// decoding. Used for opaque payloads (e.g. the GDPR data export) that must
+  /// be preserved byte-for-byte as the server produced them. Auth, token
+  /// refresh on 401, and HTTP status mapping are identical to `request(_:)`.
+  public func requestData(_ endpoint: APIEndpoint) async throws -> Data {
+    guard let session = await authService.currentSession() else {
+      throw DomainError.sessionExpired
+    }
+
+    do {
+      return try await executeRequestData(endpoint, accessToken: session.accessToken)
+    } catch APIError.unauthorized {
+      let refreshed: AuthSession
+      do {
+        refreshed = try await authService.refreshSession()
+      } catch is URLError {
+        throw DomainError.networkUnavailable
+      } catch {
+        throw DomainError.sessionExpired
+      }
+      do {
+        return try await executeRequestData(endpoint, accessToken: refreshed.accessToken)
+      } catch is URLError {
+        throw DomainError.networkUnavailable
+      }
+    } catch is URLError {
+      throw DomainError.networkUnavailable
+    }
+  }
+
   // MARK: - Private
+
+  private func executeRequestData(
+    _ endpoint: APIEndpoint,
+    accessToken: String
+  ) async throws -> Data {
+    let urlRequest = try buildRequest(endpoint, accessToken: accessToken)
+    let (data, response) = try await transport.data(for: urlRequest)
+
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw APIError.serverError(statusCode: 0, message: "Invalid response")
+    }
+
+    try mapHTTPStatus(httpResponse.statusCode, data: data)
+    return data
+  }
 
   private func executeRequest<T: Decodable>(
     _ endpoint: APIEndpoint,

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIUserProfileRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIUserProfileRepository.swift
@@ -68,6 +68,18 @@ public final class APIUserProfileRepository: UserProfileRepository, Sendable {
       throw error.toDomainError()
     }
   }
+
+  public func exportData() async throws -> Data {
+    do {
+      // Raw bytes, no decode: the GDPR export is opaque to the client and must
+      // stay byte-stable with what the server produced (GET /v1/me/data).
+      return try await apiClient.requestData(.get("/v1/me/data"))
+    } catch let domainError as DomainError {
+      throw domainError
+    } catch {
+      throw error.toDomainError()
+    }
+  }
 }
 
 // MARK: - DTOs

--- a/mobile/ios/packages/town-crier-domain/Sources/Protocols/UserProfileRepository.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Protocols/UserProfileRepository.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Port for managing the user's server-side profile.
 ///
 /// Maps to the `/v1/me` API endpoints:
@@ -5,6 +7,7 @@
 /// - `fetch()` -> `GET /v1/me`
 /// - `update(...)` -> `PATCH /v1/me`
 /// - `delete()` -> `DELETE /v1/me`
+/// - `exportData()` -> `GET /v1/me/data`
 public protocol UserProfileRepository: Sendable {
   /// Creates the user profile on the server. The API reads identity from the JWT.
   func create() async throws -> ServerProfile
@@ -27,4 +30,12 @@ public protocol UserProfileRepository: Sendable {
 
   /// Deletes the user profile and cascades (removes all user data server-side).
   func delete() async throws
+
+  /// Fetches the full GDPR data export as raw JSON bytes.
+  ///
+  /// The export is opaque to the client: the server bytes are returned as-is so
+  /// the user can save or share a machine-readable copy of all their data. The
+  /// caller must not decode or re-encode the payload, to keep the export
+  /// byte-stable with what the server produced.
+  func exportData() async throws -> Data
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ShareSheet.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/ShareSheet.swift
@@ -1,0 +1,25 @@
+#if os(iOS)
+  import SwiftUI
+  import UIKit
+
+  /// Thin SwiftUI wrapper around `UIActivityViewController` so a file (or any
+  /// activity item) can be shared via the standard iOS share sheet — Save to
+  /// Files, AirDrop, Mail, and so on. Used to hand the GDPR data-export `.json`
+  /// file to the user from Settings.
+  public struct ShareSheet: UIViewControllerRepresentable {
+    private let activityItems: [Any]
+
+    public init(activityItems: [Any]) {
+      self.activityItems = activityItems
+    }
+
+    public func makeUIViewController(context: Context) -> UIActivityViewController {
+      UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    public func updateUIViewController(
+      _ uiViewController: UIActivityViewController,
+      context: Context
+    ) {}
+  }
+#endif

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsView.swift
@@ -41,7 +41,34 @@ public struct SettingsView: View {
     onNotificationPreferences?()
   }
 
+  /// Test-only seam: trigger the data-export flow as if the user had tapped the
+  /// "Export your data" row. Mirrors the other seams so the wiring is
+  /// verifiable without UI-level automation.
+  public func requestExportData() async {
+    await viewModel.exportData()
+  }
+
   public var body: some View {
+    listContent
+      .background(Color.tcBackground)
+      .scrollContentBackground(.hidden)
+      .navigationTitle("Settings")
+      .task { await viewModel.load() }
+      .modifier(ExportShareSheetModifier(viewModel: viewModel))
+      .alert(
+        "Export Failed",
+        isPresented: Binding(
+          get: { viewModel.exportErrorMessage != nil },
+          set: { if !$0 { viewModel.dismissExportError() } }
+        )
+      ) {
+        Button("OK", role: .cancel) { viewModel.dismissExportError() }
+      } message: {
+        Text(viewModel.exportErrorMessage ?? "")
+      }
+  }
+
+  private var listContent: some View {
     List {
       accountSection
       appearanceSection
@@ -52,10 +79,6 @@ public struct SettingsView: View {
       dangerZoneSection
       appInfoSection
     }
-    .background(Color.tcBackground)
-    .scrollContentBackground(.hidden)
-    .navigationTitle("Settings")
-    .task { await viewModel.load() }
     .alert("Delete Account", isPresented: $viewModel.isShowingDeleteConfirmation) {
       Button("Delete", role: .destructive) {
         Task { await viewModel.confirmDeleteAccount() }
@@ -240,10 +263,34 @@ public struct SettingsView: View {
       navigationRow("Terms of Service", systemImage: "doc.text") {
         onTermsOfService?()
       }
+
+      exportDataRow
     } header: {
       Text("Legal")
         .font(TCTypography.captionEmphasis)
     }
+  }
+
+  /// "Export your data" row: triggers the GDPR data export. Shows a spinner and
+  /// disables while the export is in flight; the resulting file is handed to
+  /// the iOS share sheet by the body's `.sheet` modifier.
+  private var exportDataRow: some View {
+    Button {
+      Task { await viewModel.exportData() }
+    } label: {
+      HStack {
+        Label("Export your data", systemImage: "square.and.arrow.up")
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextPrimary)
+        Spacer()
+        if viewModel.isExporting {
+          ProgressView()
+        } else {
+          settingChevron
+        }
+      }
+    }
+    .disabled(viewModel.isExporting)
   }
 
   // MARK: - Danger Zone
@@ -280,5 +327,30 @@ public struct SettingsView: View {
         settingCaption(viewModel.appVersion)
       }
     }
+  }
+}
+
+/// Presents the data-export share sheet over Settings when the ViewModel has a
+/// finished export file ready. The `UIActivityViewController` is iOS-only, so
+/// the modifier is a no-op on other platforms (keeping the View buildable for
+/// macOS unit tests).
+private struct ExportShareSheetModifier: ViewModifier {
+  @ObservedObject var viewModel: SettingsViewModel
+
+  func body(content: Content) -> some View {
+    #if os(iOS)
+      content.sheet(
+        isPresented: Binding(
+          get: { viewModel.exportFileURL != nil },
+          set: { if !$0 { viewModel.dismissExportShare() } }
+        )
+      ) {
+        if let url = viewModel.exportFileURL {
+          ShareSheet(activityItems: [url])
+        }
+      }
+    #else
+      content
+    #endif
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
@@ -13,6 +13,15 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
   @Published public private(set) var isLoading = false
   @Published public internal(set) var error: DomainError?
   @Published public var isShowingDeleteConfirmation = false
+
+  /// True while the data export request is in flight. The View disables the
+  /// row and shows a spinner so the user can't trigger a second export.
+  @Published public private(set) var isExporting = false
+
+  /// The temp file URL of a completed export, ready to hand to the iOS share
+  /// sheet. `nil` until an export succeeds, and reset once the sheet is
+  /// dismissed. Setting this is what triggers the View to present the sheet.
+  @Published public var exportFileURL: URL?
   @Published public var appearanceMode: AppearanceMode {
     didSet {
       defaults.set(appearanceMode.rawValue, forKey: Self.appearanceModeKey)
@@ -30,6 +39,7 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
   private let appVersionProvider: AppVersionProvider
   private let notificationService: NotificationService
   private let defaults: UserDefaults
+  private let exportFileWriter: (Data) throws -> URL
 
   public init(
     authService: AuthenticationService,
@@ -38,7 +48,8 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
     tierResolver: SubscriptionTierResolving? = nil,
     appVersionProvider: AppVersionProvider,
     notificationService: NotificationService,
-    defaults: UserDefaults = .standard
+    defaults: UserDefaults = .standard,
+    exportFileWriter: @escaping (Data) throws -> URL = SettingsViewModel.writeExportToTempFile
   ) {
     self.authService = authService
     self.subscriptionService = subscriptionService
@@ -54,6 +65,7 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
     self.appVersionProvider = appVersionProvider
     self.notificationService = notificationService
     self.defaults = defaults
+    self.exportFileWriter = exportFileWriter
 
     let storedRaw = defaults.string(forKey: Self.appearanceModeKey) ?? ""
     self.appearanceMode = AppearanceMode(rawValue: storedRaw) ?? .system
@@ -146,6 +158,41 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
     } catch {
       handleError(error)
     }
+  }
+
+  /// Fetches the full GDPR data export (GET /v1/me/data), writes the opaque
+  /// server bytes to a temp `.json` file, and publishes the file URL so the
+  /// View can present the iOS share sheet. On failure, sets a user-facing
+  /// error and produces no artifact.
+  public func exportData() async {
+    guard !isExporting else { return }
+    isExporting = true
+    error = nil
+    exportFileURL = nil
+    do {
+      let bytes = try await userProfileRepository.exportData()
+      exportFileURL = try exportFileWriter(bytes)
+    } catch {
+      handleError(error)
+    }
+    isExporting = false
+  }
+
+  /// Clears the shareable artifact once the share sheet has been dismissed.
+  public func dismissExportShare() {
+    exportFileURL = nil
+  }
+
+  /// Default writer: persists the export bytes verbatim to a `.json` file in
+  /// the temporary directory and returns its URL. Overwrites any prior export
+  /// so the temp directory doesn't accumulate stale copies. `nonisolated`
+  /// because it touches no actor-isolated state and is used as a default
+  /// argument to the `@MainActor` initialiser.
+  public nonisolated static func writeExportToTempFile(_ data: Data) throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+      .appendingPathComponent("towncrier-data-export.json")
+    try data.write(to: url, options: .atomic)
+    return url
   }
 
   private func clearSession() {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsViewModel.swift
@@ -22,6 +22,10 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
   /// sheet. `nil` until an export succeeds, and reset once the sheet is
   /// dismissed. Setting this is what triggers the View to present the sheet.
   @Published public var exportFileURL: URL?
+
+  /// User-facing message shown when an export fails. `nil` when there is no
+  /// export error to display; the View presents an alert while it is non-nil.
+  @Published public private(set) var exportErrorMessage: String?
   @Published public var appearanceMode: AppearanceMode {
     didSet {
       defaults.set(appearanceMode.rawValue, forKey: Self.appearanceModeKey)
@@ -168,12 +172,16 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
     guard !isExporting else { return }
     isExporting = true
     error = nil
+    exportErrorMessage = nil
     exportFileURL = nil
     do {
       let bytes = try await userProfileRepository.exportData()
       exportFileURL = try exportFileWriter(bytes)
     } catch {
       handleError(error)
+      exportErrorMessage =
+        (error as? DomainError)?.userMessage
+        ?? "We couldn't export your data. Please try again."
     }
     isExporting = false
   }
@@ -181,6 +189,11 @@ public final class SettingsViewModel: ObservableObject, ErrorHandlingViewModel {
   /// Clears the shareable artifact once the share sheet has been dismissed.
   public func dismissExportShare() {
     exportFileURL = nil
+  }
+
+  /// Clears the export error once its alert has been dismissed.
+  public func dismissExportError() {
+    exportErrorMessage = nil
   }
 
   /// Default writer: persists the export bytes verbatim to a `.json` file in

--- a/mobile/ios/town-crier-tests/Sources/Features/APIUserProfileRepositoryExportTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIUserProfileRepositoryExportTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+@Suite("APIUserProfileRepository data export")
+struct APIUserProfileRepositoryExportTests {
+
+  // swiftlint:disable:next force_unwrapping
+  private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
+
+  private func makeSUT(
+    responses: [(Data, URLResponse)]
+  ) -> (APIUserProfileRepository, StubHTTPTransport) {
+    let authService = SpyAuthenticationService()
+    authService.currentSessionResult = .valid
+    let transport = StubHTTPTransport()
+    transport.responses = responses
+    let apiClient = URLSessionAPIClient(
+      baseURL: baseURL,
+      authService: authService,
+      transport: transport
+    )
+    let sut = APIUserProfileRepository(apiClient: apiClient)
+    return (sut, transport)
+  }
+
+  // swiftlint:disable force_unwrapping
+  private func httpResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(url: baseURL, statusCode: statusCode, httpVersion: nil, headerFields: nil)!
+  }
+  // swiftlint:enable force_unwrapping
+
+  @Test("exportData sends GET /v1/me/data and returns the raw bytes verbatim")
+  func exportData_returnsRawBytes() async throws {
+    let json = #"{"profile":{"id":"abc"},"watchZones":[{"id":"z1"}],"notifications":[]}"#
+    let bytes = Data(json.utf8)
+    let (sut, transport) = makeSUT(responses: [
+      (bytes, httpResponse(statusCode: 200))
+    ])
+
+    let exported = try await sut.exportData()
+
+    #expect(transport.requests.count == 1)
+    let request = transport.requests[0]
+    #expect(request.httpMethod == "GET")
+    #expect(request.url?.path().contains("/v1/me/data") == true)
+    #expect(exported == bytes, "the response bytes must be preserved exactly, with no re-encoding")
+  }
+
+  @Test("exportData with network error throws networkUnavailable")
+  func exportData_networkError_throwsNetworkUnavailable() async {
+    let authService = SpyAuthenticationService()
+    authService.currentSessionResult = .valid
+    let transport = StubHTTPTransport()
+    transport.error = URLError(.notConnectedToInternet)
+    let apiClient = URLSessionAPIClient(
+      baseURL: baseURL,
+      authService: authService,
+      transport: transport
+    )
+    let sut = APIUserProfileRepository(apiClient: apiClient)
+
+    await #expect(throws: DomainError.networkUnavailable) {
+      _ = try await sut.exportData()
+    }
+  }
+
+  @Test("exportData with server error throws serverError")
+  func exportData_serverError_throwsServerError() async {
+    let (sut, _) = makeSUT(responses: [
+      (Data("Internal Server Error".utf8), httpResponse(statusCode: 500))
+    ])
+
+    await #expect(
+      throws: DomainError.serverError(statusCode: 500, message: "Internal Server Error")
+    ) {
+      _ = try await sut.exportData()
+    }
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/SettingsViewModelDataExportTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SettingsViewModelDataExportTests.swift
@@ -90,6 +90,32 @@ struct SettingsViewModelDataExportTests {
     #expect(!sut.isExporting)
   }
 
+  @Test func exportData_failure_setsUserFacingExportErrorMessage() async {
+    let (sut, _) = makeSUT(exportResult: .failure(DomainError.networkUnavailable))
+
+    await sut.exportData()
+
+    #expect(sut.exportErrorMessage == DomainError.networkUnavailable.userMessage)
+  }
+
+  @Test func exportData_success_leavesExportErrorMessageNil() async {
+    let (sut, _) = makeSUT()
+
+    await sut.exportData()
+
+    #expect(sut.exportErrorMessage == nil)
+  }
+
+  @Test func dismissExportError_clearsMessage() async {
+    let (sut, _) = makeSUT(exportResult: .failure(DomainError.networkUnavailable))
+    await sut.exportData()
+    #expect(sut.exportErrorMessage != nil)
+
+    sut.dismissExportError()
+
+    #expect(sut.exportErrorMessage == nil)
+  }
+
   @Test func exportData_writerThrows_setsErrorAndNoArtifact() async {
     struct WriteFailure: Error {}
     let (sut, _) = makeSUT { _ in throw WriteFailure() }

--- a/mobile/ios/town-crier-tests/Sources/Features/SettingsViewModelDataExportTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SettingsViewModelDataExportTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Tests for the self-service GDPR data export flow in `SettingsViewModel`.
+///
+/// Tapping "Export your data" calls `UserProfileRepository.exportData()`
+/// (GET /v1/me/data), writes the opaque server bytes to a temp `.json` file,
+/// and exposes the file URL so the View can present the iOS share sheet.
+/// Loading and error states are handled in the ViewModel; the View only renders.
+@Suite("SettingsViewModel data export")
+@MainActor
+struct SettingsViewModelDataExportTests {
+  private func makeSUT(
+    exportResult: Result<Data, Error> = .success(Data(#"{"profile":{}}"#.utf8)),
+    writer: ((Data) throws -> URL)? = nil
+  ) -> (SettingsViewModel, SpyUserProfileRepository) {
+    let authSpy = SpyAuthenticationService()
+    authSpy.currentSessionResult = .valid
+    let subscriptionSpy = SpySubscriptionService()
+    let profileSpy = SpyUserProfileRepository()
+    profileSpy.exportDataResult = exportResult
+    let versionProvider = SpyAppVersionProvider()
+    let notificationSpy = SpyNotificationService()
+    let defaults = UserDefaults(suiteName: "SettingsVMExportTests.\(UUID().uuidString)")
+    let vm = SettingsViewModel(
+      authService: authSpy,
+      subscriptionService: subscriptionSpy,
+      userProfileRepository: profileSpy,
+      appVersionProvider: versionProvider,
+      notificationService: notificationSpy,
+      defaults: defaults ?? .standard,
+      exportFileWriter: writer ?? { data in
+        let url = FileManager.default.temporaryDirectory
+          .appendingPathComponent("export-test-\(UUID().uuidString).json")
+        try data.write(to: url)
+        return url
+      }
+    )
+    return (vm, profileSpy)
+  }
+
+  // MARK: - Success
+
+  @Test func exportData_callsRepositoryExport() async {
+    let (sut, profileSpy) = makeSUT()
+
+    await sut.exportData()
+
+    #expect(profileSpy.exportDataCallCount == 1)
+  }
+
+  @Test func exportData_success_writesServerBytesVerbatimAndSetsFileURL() async {
+    let bytes = Data(#"{"profile":{"id":"abc"},"watchZones":[]}"#.utf8)
+    var written: Data?
+    let stagedURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent("staged-export.json")
+    let (sut, _) = makeSUT(exportResult: .success(bytes)) { data in
+      written = data
+      return stagedURL
+    }
+
+    await sut.exportData()
+
+    #expect(written == bytes, "the server bytes must be preserved as-is")
+    #expect(sut.exportFileURL == stagedURL)
+    #expect(sut.error == nil)
+    #expect(!sut.isExporting)
+  }
+
+  @Test func exportData_clearsExportingFlagAfterSuccess() async {
+    let (sut, _) = makeSUT()
+
+    await sut.exportData()
+
+    #expect(!sut.isExporting)
+  }
+
+  // MARK: - Failure
+
+  @Test func exportData_failure_setsErrorAndProducesNoArtifact() async {
+    let (sut, _) = makeSUT(exportResult: .failure(DomainError.networkUnavailable))
+
+    await sut.exportData()
+
+    #expect(sut.error == .networkUnavailable)
+    #expect(sut.exportFileURL == nil, "no shareable artifact on failure")
+    #expect(!sut.isExporting)
+  }
+
+  @Test func exportData_writerThrows_setsErrorAndNoArtifact() async {
+    struct WriteFailure: Error {}
+    let (sut, _) = makeSUT { _ in throw WriteFailure() }
+
+    await sut.exportData()
+
+    #expect(sut.error != nil)
+    #expect(sut.exportFileURL == nil)
+    #expect(!sut.isExporting)
+  }
+
+  // MARK: - Share-sheet lifecycle
+
+  @Test func dismissExportShare_clearsFileURL() async {
+    let (sut, _) = makeSUT()
+    await sut.exportData()
+    #expect(sut.exportFileURL != nil)
+
+    sut.dismissExportShare()
+
+    #expect(sut.exportFileURL == nil)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/SettingsViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SettingsViewTests.swift
@@ -65,4 +65,22 @@ struct SettingsViewTests {
 
     #expect(tapped)
   }
+
+  @Test("SettingsView export-data tap drives the ViewModel export flow")
+  func exportDataTap_invokesViewModelExport() async {
+    let profileSpy = SpyUserProfileRepository()
+    let vm = SettingsViewModel(
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: profileSpy,
+      appVersionProvider: SpyAppVersionProvider(),
+      notificationService: SpyNotificationService(),
+      defaults: UserDefaults(suiteName: UUID().uuidString) ?? .standard
+    )
+    let view = SettingsView(viewModel: vm)
+
+    await view.requestExportData()
+
+    #expect(profileSpy.exportDataCallCount == 1)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyUserProfileRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyUserProfileRepository.swift
@@ -1,3 +1,4 @@
+import Foundation
 import TownCrierDomain
 
 final class SpyUserProfileRepository: UserProfileRepository, @unchecked Sendable {
@@ -70,5 +71,13 @@ final class SpyUserProfileRepository: UserProfileRepository, @unchecked Sendable
     deleteCallCount += 1
     onDelete?()
     try deleteResult.get()
+  }
+
+  private(set) var exportDataCallCount = 0
+  var exportDataResult: Result<Data, Error> = .success(Data("{}".utf8))
+
+  func exportData() async throws -> Data {
+    exportDataCallCount += 1
+    return try exportDataResult.get()
   }
 }


### PR DESCRIPTION
## What

Adds a self-service "Export your data" action to the iOS Settings screen, matching the Privacy Policy claim and the web app's existing export button. Pairs with the completed backend export (#539, tc-lllv) so an iOS user can download a full copy of their data (profile, preferences, watch zones, notifications, decision alerts, saved applications, device registrations, subscription, offer codes).

## How

- **Repository**: `UserProfileRepository.exportData() async throws -> Data` (port), implemented in `APIUserProfileRepository` via a new `URLSessionAPIClient.requestData(_:)` that reuses the existing auth / 401-refresh / status-mapping path but returns the raw body **without decoding**, so the export stays byte-stable with the server output.
- **ViewModel** (`SettingsViewModel`): export flow with `isExporting` and error state; writes the server bytes verbatim to a temp `towncrier-data-export.json`, publishes `exportFileURL`.
- **View** (`SettingsView`): the row (styled per design-language), an error alert, and an `#if os(iOS)` share-sheet modifier presenting `UIActivityViewController` (new `ShareSheet` wrapper) on the file URL — Files / AirDrop / etc. No networking in the View.

## Tests (Swift Testing)

`SettingsViewModelDataExportTests` (success writes verbatim bytes + sets file URL, clears `isExporting`, failure sets error + produces no artifact, dismiss handlers) and `APIUserProfileRepositoryExportTests` (raw bytes preserved, network/server error mapping). Full suite: 1203 tests pass.

## Gates (local)

`swift build` ok · `swift test` 1203 passed · `swiftlint lint --strict` 0 violations · `swift-format` clean.

Release-Note: Download a copy of all your data from Settings.

Closes tc-gczo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)