### PR TITLE
feat(web): point app download CTAs at live App Store listing

### DIFF
--- a/web/src/components/Footer/__tests__/Footer.test.tsx
+++ b/web/src/components/Footer/__tests__/Footer.test.tsx
@@ -21,14 +21,14 @@ describe('Footer', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders a download link styled as a button pointing at TestFlight', () => {
+  it('renders a download link styled as a button pointing at the App Store', () => {
     render(<Footer />);
 
     const link = screen.getByRole('link', { name: /download on the app store/i });
     expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute(
       'href',
-      'https://testflight.apple.com/join/7fZTBZQN',
+      'https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657',
     );
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');

--- a/web/src/components/Hero/__tests__/Hero.test.tsx
+++ b/web/src/components/Hero/__tests__/Hero.test.tsx
@@ -34,14 +34,14 @@ describe('Hero', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders a download CTA link pointing at TestFlight', () => {
+  it('renders a download CTA link pointing at the App Store', () => {
     renderHero();
 
     const cta = screen.getByRole('link', { name: /app store/i });
     expect(cta).toBeInTheDocument();
     expect(cta).toHaveAttribute(
       'href',
-      'https://testflight.apple.com/join/7fZTBZQN',
+      'https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657',
     );
     expect(cta).toHaveAttribute('target', '_blank');
     expect(cta).toHaveAttribute('rel', 'noopener noreferrer');

--- a/web/src/components/Navbar/__tests__/Navbar.test.tsx
+++ b/web/src/components/Navbar/__tests__/Navbar.test.tsx
@@ -64,14 +64,14 @@ describe('Navbar', () => {
     expect(faq).toHaveAttribute('href', '#faq');
   });
 
-  it('renders Download CTA link pointing at TestFlight', () => {
+  it('renders Download CTA link pointing at the App Store', () => {
     renderNavbar();
 
     const cta = screen.getByRole('link', { name: /download/i });
     expect(cta).toBeInTheDocument();
     expect(cta).toHaveAttribute(
       'href',
-      'https://testflight.apple.com/join/7fZTBZQN',
+      'https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657',
     );
     expect(cta).toHaveAttribute('target', '_blank');
     expect(cta).toHaveAttribute('rel', 'noopener noreferrer');

--- a/web/src/config/links.ts
+++ b/web/src/config/links.ts
@@ -1,8 +1,8 @@
 /**
  * Public download link for the iOS app.
  *
- * Currently points at the TestFlight beta because Town Crier is not yet on the
- * App Store. Swap this for the App Store URL (https://apps.apple.com/app/...)
- * at GA — every download CTA reads from here, so it's a one-line change.
+ * Points at the live App Store listing. Every download CTA reads from here,
+ * so swapping this single value updates them all.
  */
-export const APP_DOWNLOAD_URL = 'https://testflight.apple.com/join/7fZTBZQN';
+export const APP_DOWNLOAD_URL =
+  'https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657';


### PR DESCRIPTION
## Changes
- Town Crier was approved on the App Store. Swap `APP_DOWNLOAD_URL` in `web/src/config/links.ts` from the TestFlight beta link to the live App Store listing (`apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657`). Every Hero/Navbar/Footer download CTA reads from this single constant.
- Update the three CTA tests (Hero/Navbar/Footer) that asserted the old TestFlight href.

Closes tc-5lp5.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated app download link to point to the official App Store instead of the beta testing platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->