### PR TITLE
fix(api-go): require Auth0 auth on /v1/authorities endpoints (tc-u2cf)

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -39,9 +39,6 @@ var anonymousPatterns = map[string]struct{}{
 	"GET /v1/health":               {},
 	"GET /v1/version-config":       {},
 	"GET /v1/legal/{documentType}": {},
-	"GET /v1/authorities":          {},
-	"GET /v1/authorities/{$}":      {},
-	"GET /v1/authorities/{id}":     {},
 	// The demo-account endpoint is anonymous so Apple's App Store reviewer can
 	// reach a fully-provisioned Pro account without a token, matching .NET's
 	// AllowAnonymous.

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -191,9 +191,6 @@ func TestRouter_AnonymousRoutesServedWithoutToken(t *testing.T) {
 		{"/v1/version-config", http.StatusOK},
 		{"/v1/legal/privacy", http.StatusOK},
 		{"/v1/legal/unknown", http.StatusNotFound}, // anonymous route, bodyless 404 backfilled
-		{"/v1/authorities", http.StatusOK},
-		{"/v1/authorities/384", http.StatusOK},
-		{"/v1/authorities/99999999", http.StatusNotFound},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
 			t.Parallel()
@@ -221,6 +218,9 @@ func TestRouter_FallbackDeny(t *testing.T) {
 		{"me without token", http.MethodGet, "/v1/me"},
 		{"root", http.MethodGet, "/"},
 		{"unknown path", http.MethodGet, "/v1/nope"},
+		// Authorities routes are authed (GH#418): no token -> 401.
+		{"authorities list without token", http.MethodGet, "/v1/authorities"},
+		{"authority by id without token", http.MethodGet, "/v1/authorities/384"},
 		{"non-int authority id", http.MethodGet, "/v1/authorities/abc"},
 		{"wrong method on me", http.MethodPut, "/api/me"},
 		// Geocode and designations are authed, not anonymous: no token -> 401.
@@ -326,6 +326,21 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	}
 	if got := strings.TrimSpace(rec.Body.String()); got != `{"authorities":[],"count":0}` {
 		t.Errorf("GET /v1/me/application-authorities body = %s", got)
+	}
+
+	// Authorities routes are authed (GH#418): a valid token reaches the handlers,
+	// which are backed by embedded reference data (independent of the stores).
+	rec = serveReq(t, h, http.MethodGet, "/v1/authorities", "", "Bearer tok")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/authorities status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	rec = serveReq(t, h, http.MethodGet, "/v1/authorities/384", "", "Bearer tok")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/authorities/384 status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	rec = serveReq(t, h, http.MethodGet, "/v1/authorities/99999999", "", "Bearer tok")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /v1/authorities/99999999 status = %d body = %s", rec.Code, rec.Body.String())
 	}
 
 	// Anonymous routes stay unmetered even on the store-wired router.


### PR DESCRIPTION
## Changes
- Remove the three `GET /v1/authorities…` patterns (`/v1/authorities`, `/v1/authorities/{$}`, `/v1/authorities/{id}`) from `anonymousPatterns` in `api-go/cmd/api/wiring.go`, so all three now require a valid Auth0 bearer token via the fallback-deny policy.
- These were anonymous only as inherited .NET cruft (GH#418). iOS never calls them; the sole web caller is dead/unwired and the web ApiClient always sends a Bearer token anyway. No client relied on anonymous access, so requiring auth breaks zero clients.
- Tests (`wiring_test.go`): authorities rows removed from `TestRouter_AnonymousRoutesServedWithoutToken`; added to `TestRouter_FallbackDeny` (401 without a token, `WWW-Authenticate: Bearer`); added authed assertions to `TestRouter_AuthenticatedPipeline` (200 list, 200 by-id, 404 unknown-id with a valid token).
- No other route's auth posture changed.

Backend-only — no `Release-Note:` trailer.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authority endpoints (`/v1/authorities`) now properly require authentication instead of being publicly accessible.

* **Security**
  * Admin endpoints now authenticate via API key instead of bearer token.
  * App Store webhook endpoint uses signed payload authentication.
  * Demo account endpoint is now publicly accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->