### PR TITLE
fix(ios): create server profile on sign-in, not only at launch (tc-k9fk)

### DIFF
--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -141,7 +141,16 @@ struct TownCrierApp: App {
         else { return }
         coordinator.handleDeepLink(deepLink)
       }
-      .task {
+      // Keyed on auth state (not a bare `.task`) so profile-ensure RE-RUNS on
+      // the unauthenticated->authenticated transition. On a fresh install the
+      // launch-time task fires while still signed out (no token -> the
+      // idempotent POST /v1/me can't create the Cosmos UserProfile); without an
+      // `id:` it never re-runs when the user signs in, so the profile is missing
+      // for the whole session and the first watch-zone POST 500s on its quota
+      // check (Cosmos 404). Re-running on the transition ensures the profile the
+      // moment a session exists. `checkVersion()` is idempotent, so re-running
+      // it here is harmless (tc-k9fk).
+      .task(id: loginViewModel.isAuthenticated) {
         await coordinator.resolveSubscriptionTier()
         await forceUpdateViewModel.checkVersion()
       }

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTierResolutionTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTierResolutionTests.swift
@@ -73,6 +73,45 @@ struct AppCoordinatorTierResolutionTests {
     #expect(profileSpy.createCallCount >= 1)
   }
 
+  @Test
+  func resolveSubscriptionTier_reEnsuresServerProfile_afterSignIn() async {
+    // Regression for tc-k9fk (GA-breaking first-run watch-zone 500). On a fresh
+    // install the launch-time tier resolve runs while the user is still
+    // UNauthenticated, so POST /v1/me cannot create a Cosmos UserProfile (no
+    // token -> the request 401s and ServerTierResolver swallows it). The user
+    // then signs in. The fix keys the launch
+    // `.task(id: loginViewModel.isAuthenticated)` so resolveSubscriptionTier()
+    // RE-RUNS on the unauthenticated->authenticated transition, ensuring the
+    // profile on the post-auth path -- not only at launch. Without the re-run
+    // the profile never exists this session and the first watch-zone POST 500s
+    // (its quota check loads the profile and hits a Cosmos 404).
+    //
+    // The view wiring (`.task(id:)`) lives in the non-testable app target, so
+    // this locks the coordinator-side invariant the fix depends on: a resolve
+    // AFTER sign-in re-invokes create() and applies the ensured tier.
+    let (sut, authSpy, _, profileSpy) = makeSUT()
+
+    // Phase 1 -- first launch while UNauthenticated. The unauthenticated
+    // POST /v1/me 401s server-side, so create() fails and no profile is
+    // established this pass.
+    authSpy.currentSessionResult = nil
+    profileSpy.createResult = .failure(DomainError.networkUnavailable)
+    await sut.resolveSubscriptionTier()
+    let createCallsBeforeSignIn = profileSpy.createCallCount
+
+    // Phase 2 -- the user signs in; a session (and token) is now available, so
+    // the idempotent POST /v1/me succeeds and backfills the server profile.
+    authSpy.currentSessionResult = .valid
+    profileSpy.createResult = .success(makeServerProfile(tier: .personal))
+    await sut.resolveSubscriptionTier()
+
+    // The post-auth re-run must ensure the profile (create invoked again) and
+    // apply its tier -- proving the profile is established on sign-in, not just
+    // attempted and dropped at launch.
+    #expect(profileSpy.createCallCount > createCallsBeforeSignIn)
+    #expect(sut.subscriptionTier == .personal)
+  }
+
   @Test func resolveSubscriptionTier_picksHighestFromAllSources() async {
     let (sut, _, _, _) = makeSUT(
       authSession: .pro,


### PR DESCRIPTION
## Changes

GA-breaking first-run fix. Every new user who signed up and created a watch zone in their first session got *"The server encountered an error."* (confirmed in prod telemetry 2026-06-19, 6+ users, both `auth0|` and `apple|` connections).

**Root cause:** the idempotent `POST /v1/me` (server profile create) only fired via `AppCoordinator.resolveSubscriptionTier()`, called from a launch-time `.task` attached to the root `Group` with **no `id:`**. It ran once at launch while the user was still signed out (no token → no profile created), the user signed in, the task never re-fired, so the profile was missing for the whole session. The first `POST /v1/me/watch-zones` then 500'd because its quota check loads the profile and hit a Cosmos 404.

- **fix:** key the launch task to auth state — `.task(id: loginViewModel.isAuthenticated)` — so profile-ensure re-runs on the unauthenticated→authenticated transition (and on logout→login). `checkVersion()` is idempotent, so re-running is harmless. Only the `.task` line changed in `TownCrierApp.swift`, plus an explanatory comment.
- **test:** `resolveSubscriptionTier_reEnsuresServerProfile_afterSignIn` in `AppCoordinatorTierResolutionTests` — locks the coordinator-side invariant: a resolve after sign-in re-invokes `create()` and applies the ensured tier (models pre-auth 401 → post-auth success).

Gates (local): `swift build` OK · `swift test` 1204 pass (incl. new test) · `swiftlint lint --strict` 0 violations.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where user profile information and subscription tier weren't properly refreshed upon sign-in, ensuring the app correctly loads the latest account data after authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->