### PR TITLE
fix(ios): bump marketing version to 1.0.1 (tc-xap5)

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.0.0"
+        MARKETING_VERSION: "1.0.1"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"


### PR DESCRIPTION
## Changes

The v0.15.21 **CD iOS TestFlight** upload failed altool validation with 409s:
- *Invalid Pre-Release Train — train version '1.0.0' is closed for new build submissions*
- *CFBundleShortVersionString [1.0.0] must contain a higher version than the previously approved version [1.0.0]*

GA shipped `1.0.0` to the App Store today, which closes the 1.0.0 train. The CD beta lane auto-bumps the **build number** (`CURRENT_PROJECT_VERSION`) but not the **marketing version**, which was hardcoded `MARKETING_VERSION: "1.0.0"` in `mobile/ios/project.yml`.

- **fix(ios): bump marketing version to 1.0.1** (tc-xap5) — `TownCrier.xcodeproj` is generated in CI via `xcodegen`, so editing `project.yml` is sufficient. This rebuild is the first TestFlight build to actually carry the tc-k9fk first-run watch-zone fix (its v0.15.21 build never uploaded).

Filed as tc-xap5 (discovered-from tc-k9fk).

---
*Auto-shipped via ship skill*