### PR TITLE
iOS onboarding wizard: wire in + tier-aware radius upsell (tc-w3cb)

### DIFF
--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZoneLimits.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/WatchZoneLimits.swift
@@ -29,10 +29,4 @@ public struct WatchZoneLimits: Equatable, Sendable {
   public func clampRadius(_ radius: Double) -> Double {
     min(radius, maxRadiusMetres)
   }
-
-  /// Predefined radius options available for this tier.
-  public var availableRadiusOptions: [Double] {
-    let allOptions: [Double] = [500, 1000, 1500, 2000, 3000, 5000, 7500, 10000]
-    return allOptions.filter { $0 <= maxRadiusMetres }
-  }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Onboarding.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Onboarding.swift
@@ -42,6 +42,15 @@ extension AppCoordinator {
     viewModel.onComplete = { [weak self] _ in
       self?.completeOnboarding()
     }
+    // In-wizard radius upsell (tc-w3cb.3): build the paywall and, on dismiss,
+    // re-resolve the tier so the larger radius unlocks live. resolveSubscriptionTier
+    // pushes the new tier back into this same VM instance.
+    viewModel.makeUpsellViewModel = { [weak self] in
+      self?.makeSubscriptionViewModel()
+    }
+    viewModel.onUpgradeFlowCompleted = { [weak self] in
+      await self?.resolveSubscriptionTier()
+    }
     onboardingViewModel = viewModel
     return viewModel
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Onboarding.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Onboarding.swift
@@ -1,0 +1,78 @@
+import TownCrierDomain
+
+/// Whether the first-run onboarding wizard should be presented for the
+/// authenticated user.
+///
+/// The gate is account-state driven (does the user have zero watch zones?)
+/// rather than a device-local latch, so it survives reinstall and works across
+/// devices. ``AppCoordinator/determineOnboarding()`` resolves this after
+/// profile-ensure completes; the third `undetermined` case keeps the wizard
+/// from flashing while watch zones are still loading (tc-w3cb.1).
+public enum OnboardingPresentation: Equatable, Sendable {
+  /// Still resolving — show a neutral loading screen, never the wizard.
+  case undetermined
+  /// The user has no watch zones — guide them through creating their first.
+  case required
+  /// The user already has at least one zone — go straight to the app.
+  case notRequired
+}
+
+extension AppCoordinator {
+  /// Factory for the first-run onboarding wizard. Mirrors
+  /// ``makeWatchZoneEditorViewModel(editing:)`` in guarding the optional
+  /// `geocoder`, and returns a retained instance so the live subscription tier
+  /// can be pushed into it (see ``resolveSubscriptionTier()``).
+  public func makeOnboardingViewModel() -> OnboardingViewModel {
+    guard let geocoder else {
+      fatalError("PostcodeGeocoder must be injected to create OnboardingViewModel")
+    }
+    if let cached = onboardingViewModel {
+      // Re-renders re-evaluate this factory; keep the tier current but reuse
+      // the live instance so wizard state (postcode, geocode) is preserved.
+      cached.subscriptionTier = subscriptionTier
+      return cached
+    }
+    let viewModel = OnboardingViewModel(
+      geocoder: geocoder,
+      watchZoneRepository: watchZoneRepository,
+      onboardingRepository: onboardingRepository,
+      notificationService: notificationService,
+      subscriptionTier: subscriptionTier
+    )
+    viewModel.onComplete = { [weak self] _ in
+      self?.completeOnboarding()
+    }
+    onboardingViewModel = viewModel
+    return viewModel
+  }
+
+  /// Resolves whether to show the onboarding wizard for the authenticated user.
+  ///
+  /// MUST run after profile-ensure (`POST /v1/me`, performed by
+  /// ``resolveSubscriptionTier()``) so the wizard's first watch-zone save has a
+  /// server profile to attach to — otherwise that save 500s on its quota check
+  /// (the GA bug fixed in tc-k9fk).
+  ///
+  /// The gate is the user's watch-zone count: zero zones means show the wizard.
+  /// We only drop back to `.undetermined` (the loading screen) when the device
+  /// has no completion latch, so returning users never see a launch flash; a
+  /// failed load falls through to the app rather than trapping the user.
+  public func determineOnboarding() async {
+    if !onboardingRepository.isOnboardingComplete {
+      onboardingPresentation = .undetermined
+    }
+    do {
+      let zones = try await watchZoneRepository.loadAll()
+      onboardingPresentation = zones.isEmpty ? .required : .notRequired
+    } catch {
+      onboardingPresentation = .notRequired
+    }
+  }
+
+  /// Invoked when the wizard saves the user's first zone. Flips the gate so the
+  /// root view falls through to the main app and releases the wizard VM.
+  func completeOnboarding() {
+    onboardingPresentation = .notRequired
+    onboardingViewModel = nil
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+WatchZones.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+WatchZones.swift
@@ -1,0 +1,79 @@
+import TownCrierDomain
+
+extension AppCoordinator {
+  // MARK: - Watch Zone Factories
+
+  public func makeWatchZoneListViewModel() -> WatchZoneListViewModel {
+    // Reuse the cached VM only while its gate still reflects the current tier.
+    // The tier resolves from the default `.free` to a paid tier *after* the VM
+    // is first built (resolveSubscriptionTier runs asynchronously at launch),
+    // and the list is keyed `.id(subscriptionTier)` so the view rebuilds on the
+    // change. Returning a stale `.free` gate kept the upgrade badge on the +
+    // button once the 1-zone free limit was hit, blocking paid users below
+    // their actual limit (tc-ujct). Rebuild with a fresh gate when the tier
+    // differs; same-tier calls still return a stable instance so the editor's
+    // post-save reload path converges on the retained VM.
+    if let cached = watchZoneListViewModel, cached.featureGate.tier == subscriptionTier {
+      return cached
+    }
+    let viewModel = WatchZoneListViewModel(
+      repository: watchZoneRepository,
+      featureGate: FeatureGate(tier: subscriptionTier)
+    )
+    viewModel.onAddZone = { [weak self] in
+      self?.isAddingWatchZone = true
+    }
+    viewModel.onEditZone = { [weak self] zone in
+      self?.editingWatchZone = zone
+    }
+    viewModel.onViewPlans = { [weak self] in
+      self?.isSubscriptionPresented = true
+    }
+    watchZoneListViewModel = viewModel
+    return viewModel
+  }
+
+  public func makeWatchZoneEditorViewModel(
+    editing zone: WatchZone? = nil
+  ) -> WatchZoneEditorViewModel {
+    guard let geocoder else {
+      fatalError("PostcodeGeocoder must be injected to create WatchZoneEditorViewModel")
+    }
+    let viewModel = WatchZoneEditorViewModel(
+      geocoder: geocoder,
+      repository: watchZoneRepository,
+      tier: subscriptionTier,
+      editing: zone
+    )
+    let isEditing = zone != nil
+    viewModel.onUpgradeRequired = { [weak self] in
+      // Quota breach on save (tc-gpjk): close the editor sheet and present the
+      // subscription paywall instead of showing an inline error.
+      self?.isAddingWatchZone = false
+      self?.editingWatchZone = nil
+      self?.isSubscriptionPresented = true
+    }
+    viewModel.onSave = { [weak self] saved in
+      self?.isAddingWatchZone = false
+      self?.editingWatchZone = nil
+      self?.pendingWatchZoneRefresh = Task { [weak self] in
+        // Invalidate the per-zone applications cache before reloading so a
+        // radius/centre change does not serve a stale cache hit on the
+        // Apps view for up to the cache TTL (tc-9vid).
+        if isEditing, let offlineRepository = self?.offlineRepository {
+          await offlineRepository.invalidateCache(for: saved.id)
+        }
+        await self?.watchZoneListViewModel?.load()
+      }
+    }
+    return viewModel
+  }
+
+  /// Test-only synchronisation: await the most recently kicked-off post-save
+  /// watch-zone reload so assertions happen after the list view-model has
+  /// been refreshed against the latest repository state. Replaces flaky
+  /// `Task.sleep(...)` waits in tests.
+  public func waitForPendingWatchZoneRefresh() async {
+    await pendingWatchZoneRefresh?.value
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -26,6 +26,12 @@ public final class AppCoordinator: ObservableObject {
   /// Settings sheet — bound to the gear-icon toolbar action installed on each tab.
   @Published public var isSettingsPresented = false
   @Published public private(set) var subscriptionTier: SubscriptionTier = .free
+  /// Drives the root view's choice between the onboarding wizard, a loading
+  /// screen, and the main tab view (tc-w3cb.1). Seeded from the device-local
+  /// completion latch as a fast path so returning users skip the loading
+  /// screen, then confirmed authoritatively against account state by
+  /// ``determineOnboarding()``.
+  @Published public internal(set) var onboardingPresentation: OnboardingPresentation = .undetermined
 
   public var isOnboardingComplete: Bool {
     onboardingRepository.isOnboardingComplete
@@ -38,12 +44,15 @@ public final class AppCoordinator: ObservableObject {
   private let subscriptionService: SubscriptionService
   let userProfileRepository: UserProfileRepository
   private let tierResolver: SubscriptionTierResolving
-  private let onboardingRepository: OnboardingRepository
+  // Internal (not private) so the AppCoordinator+Onboarding extension can read it.
+  let onboardingRepository: OnboardingRepository
   let notificationService: NotificationService
-  private let offlineRepository: OfflineAwareRepository?
+  // Internal (not private) so the AppCoordinator+WatchZones extension can read it.
+  let offlineRepository: OfflineAwareRepository?
   let authorityRepository: ApplicationAuthorityRepository?
   let watchZoneRepository: WatchZoneRepository
-  private let geocoder: PostcodeGeocoder?
+  // Internal (not private) so the AppCoordinator+Onboarding extension can read it.
+  let geocoder: PostcodeGeocoder?
   private let appVersionProvider: AppVersionProvider
   private let versionConfigService: VersionConfigService
   private let savedApplicationRepository: SavedApplicationRepository?
@@ -53,10 +62,17 @@ public final class AppCoordinator: ObservableObject {
   let badgeSetter: BadgeSetting?
   // Cached strongly so SwiftUI's factory re-evaluation doesn't leave the
   // coordinator with a dangling reference; editor `onSave` needs a live VM.
-  private var watchZoneListViewModel: WatchZoneListViewModel?
+  // Internal (not private) so the AppCoordinator+WatchZones extension owns it.
+  var watchZoneListViewModel: WatchZoneListViewModel?
+  // Retained so the live subscription tier can be pushed into the wizard in
+  // place (rather than rebuilding it and losing in-progress postcode/geocode),
+  // and so SwiftUI's StateObject and the coordinator converge on one instance.
+  // Internal (not private) so the AppCoordinator+Onboarding extension owns it.
+  var onboardingViewModel: OnboardingViewModel?
   // In-flight tasks tests can await deterministically (no `Task.sleep`).
   var pendingOfferCodeRefresh: Task<Void, Never>?
-  private var pendingWatchZoneRefresh: Task<Void, Never>?
+  // Internal (not private) so the AppCoordinator+WatchZones extension can drive it.
+  var pendingWatchZoneRefresh: Task<Void, Never>?
   var pendingDetailLoad: Task<Void, Never>?
   // Push-tap watermark advance — fire-and-forget but stored so tests can
   // await deterministically (tc-1nsa.9).
@@ -116,6 +132,14 @@ public final class AppCoordinator: ObservableObject {
     if let cached = self.tierCache.string(forKey: Self.tierCacheKey),
       let tier = SubscriptionTier(rawValue: cached) {
       subscriptionTier = tier
+    }
+
+    // Fast path: a returning user who already completed onboarding on this
+    // device skips the loading screen and lands straight in the app. Account
+    // state stays authoritative — `determineOnboarding()` reconfirms against
+    // the server and can still surface the wizard for a zero-zone account.
+    if onboardingRepository.isOnboardingComplete {
+      onboardingPresentation = .notRequired
     }
   }
 
@@ -248,82 +272,10 @@ public final class AppCoordinator: ObservableObject {
     )
     subscriptionTier = result.tier
     tierCache.set(result.tier.rawValue, forKey: Self.tierCacheKey)
-  }
-
-  // MARK: - Watch Zone Factories
-
-  public func makeWatchZoneListViewModel() -> WatchZoneListViewModel {
-    // Reuse the cached VM only while its gate still reflects the current tier.
-    // The tier resolves from the default `.free` to a paid tier *after* the VM
-    // is first built (resolveSubscriptionTier runs asynchronously at launch),
-    // and the list is keyed `.id(subscriptionTier)` so the view rebuilds on the
-    // change. Returning a stale `.free` gate kept the upgrade badge on the +
-    // button once the 1-zone free limit was hit, blocking paid users below
-    // their actual limit (tc-ujct). Rebuild with a fresh gate when the tier
-    // differs; same-tier calls still return a stable instance so the editor's
-    // post-save reload path converges on the retained VM.
-    if let cached = watchZoneListViewModel, cached.featureGate.tier == subscriptionTier {
-      return cached
-    }
-    let viewModel = WatchZoneListViewModel(
-      repository: watchZoneRepository,
-      featureGate: FeatureGate(tier: subscriptionTier)
-    )
-    viewModel.onAddZone = { [weak self] in
-      self?.isAddingWatchZone = true
-    }
-    viewModel.onEditZone = { [weak self] zone in
-      self?.editingWatchZone = zone
-    }
-    viewModel.onViewPlans = { [weak self] in
-      self?.isSubscriptionPresented = true
-    }
-    watchZoneListViewModel = viewModel
-    return viewModel
-  }
-
-  public func makeWatchZoneEditorViewModel(
-    editing zone: WatchZone? = nil
-  ) -> WatchZoneEditorViewModel {
-    guard let geocoder else {
-      fatalError("PostcodeGeocoder must be injected to create WatchZoneEditorViewModel")
-    }
-    let viewModel = WatchZoneEditorViewModel(
-      geocoder: geocoder,
-      repository: watchZoneRepository,
-      tier: subscriptionTier,
-      editing: zone
-    )
-    let isEditing = zone != nil
-    viewModel.onUpgradeRequired = { [weak self] in
-      // Quota breach on save (tc-gpjk): close the editor sheet and present the
-      // subscription paywall instead of showing an inline error.
-      self?.isAddingWatchZone = false
-      self?.editingWatchZone = nil
-      self?.isSubscriptionPresented = true
-    }
-    viewModel.onSave = { [weak self] saved in
-      self?.isAddingWatchZone = false
-      self?.editingWatchZone = nil
-      self?.pendingWatchZoneRefresh = Task { [weak self] in
-        // Invalidate the per-zone applications cache before reloading so a
-        // radius/centre change does not serve a stale cache hit on the
-        // Apps view for up to the cache TTL (tc-9vid).
-        if isEditing, let offlineRepository = self?.offlineRepository {
-          await offlineRepository.invalidateCache(for: saved.id)
-        }
-        await self?.watchZoneListViewModel?.load()
-      }
-    }
-    return viewModel
-  }
-
-  /// Test-only synchronisation: await the most recently kicked-off post-save
-  /// watch-zone reload so assertions happen after the list view-model has
-  /// been refreshed against the latest repository state. Replaces flaky
-  /// `Task.sleep(...)` waits in tests.
-  public func waitForPendingWatchZoneRefresh() async {
-    await pendingWatchZoneRefresh?.value
+    // Keep an in-flight onboarding wizard's tier live so the radius step can
+    // unlock the paid range the moment a purchase resolves, without rebuilding
+    // the wizard and losing the user's in-progress postcode (tc-w3cb.1/.3).
+    onboardingViewModel?.subscriptionTier = result.tier
   }
 
   // MARK: - Settings Navigation

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/UnlockLargerZonesChip.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/UnlockLargerZonesChip.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// In-context upsell affordance surfaced beneath the radius slider when the
+/// user's tier caps their watch-zone radius below the 10 km maximum (tc-w3cb.3).
+///
+/// This is the "safe fallback" interaction from the design: a capped slider plus
+/// an explicit tappable chip, rather than a drag-past-the-cap gesture. Tapping it
+/// opens the subscription paywall; on a successful upgrade the radius range
+/// unlocks live. The richer "locked region on the track" gesture is an open
+/// question to be prototyped in TestFlight before release.
+///
+/// Uses the brand amber at 15% opacity so it reads as an invitation, not an
+/// error — mirrors ``LargeRadiusWarningView``.
+public struct UnlockLargerZonesChip: View {
+  private let action: () -> Void
+
+  public init(action: @escaping () -> Void) {
+    self.action = action
+  }
+
+  public var body: some View {
+    Button(action: action) {
+      HStack(spacing: TCSpacing.small) {
+        Image(systemName: "lock.fill")
+          .font(.system(.caption))
+          .foregroundStyle(Color.tcAmber)
+          .accessibilityHidden(true)
+
+        Text("Unlock zones up to 10 km")
+          .font(TCTypography.bodyEmphasis)
+          .foregroundStyle(Color.tcTextPrimary)
+
+        Spacer(minLength: 0)
+
+        Image(systemName: "chevron.right")
+          .font(.system(.caption))
+          .foregroundStyle(Color.tcTextSecondary)
+          .accessibilityHidden(true)
+      }
+      .padding(.horizontal, TCSpacing.medium)
+      .padding(.vertical, TCSpacing.small)
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .frame(minHeight: 44)
+      .background(Color.tcAmberMuted)
+      .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.small))
+    }
+    .buttonStyle(.plain)
+    .accessibilityLabel("Unlock larger watch zones, up to 10 kilometres")
+    .accessibilityHint("Opens subscription plans")
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingView.swift
@@ -42,6 +42,21 @@ public struct OnboardingView: View {
         Spacer()
       }
     }
+    // In-wizard radius upsell (tc-w3cb.3): presented as a sheet *over* the
+    // wizard so the StateObject — and the in-progress postcode/geocode — survive
+    // the purchase round-trip. On dismiss we re-resolve the tier so a successful
+    // upgrade unlocks the larger radius range live, without rebuilding the wizard.
+    .sheet(
+      isPresented: $viewModel.isRadiusUpsellPresented,
+      onDismiss: { Task { await viewModel.reconcileTierAfterUpgrade() } },
+      content: {
+        if let upsellViewModel = viewModel.makeUpsellViewModel?() {
+          NavigationStack {
+            SubscriptionView(viewModel: upsellViewModel)
+          }
+        }
+      }
+    )
   }
 
   private var stepIndicator: some View {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
@@ -30,7 +30,21 @@ public final class OnboardingViewModel: ObservableObject, ErrorHandlingViewModel
   /// postcode/geocode, which must survive the upgrade round-trip (tc-w3cb.3).
   @Published public internal(set) var subscriptionTier: SubscriptionTier
 
+  /// Drives the in-wizard subscription paywall (tc-w3cb.3). Presented as a sheet
+  /// *over* the wizard so the StateObject — and the in-progress postcode/geocode
+  /// — survives the purchase round-trip.
+  @Published public var isRadiusUpsellPresented = false
+
   var onComplete: ((WatchZone) -> Void)?
+
+  /// Builds the paywall view-model for the in-wizard upsell sheet. Injected by
+  /// ``AppCoordinator`` so the wizard stays decoupled from the composition root.
+  /// Optional return so the view degrades gracefully if the factory is unset.
+  var makeUpsellViewModel: (() -> SubscriptionViewModel?)?
+
+  /// Invoked when the upsell sheet dismisses, so the coordinator can re-resolve
+  /// the subscription tier and unlock the larger radius range live.
+  var onUpgradeFlowCompleted: (() async -> Void)?
 
   private let geocoder: PostcodeGeocoder
   private let watchZoneRepository: WatchZoneRepository
@@ -109,6 +123,24 @@ public final class OnboardingViewModel: ObservableObject, ErrorHandlingViewModel
   /// ``WatchZoneLimits`` (tc-w3cb.2).
   public var maxRadiusMetres: Double {
     WatchZoneLimits(tier: subscriptionTier).maxRadiusMetres
+  }
+
+  /// Whether the user's tier still has radius headroom to unlock — true for any
+  /// tier below the top (Pro, 10 km). Drives the "Unlock larger zones" chip.
+  public var canUnlockLargerRadius: Bool {
+    subscriptionTier < .pro
+  }
+
+  /// Surfaces the in-wizard paywall when the user taps the unlock chip.
+  public func requestLargerRadiusUpgrade() {
+    isRadiusUpsellPresented = true
+  }
+
+  /// Called when the paywall sheet dismisses. Re-resolves the tier so a
+  /// successful upgrade opens the larger radius range without rebuilding the
+  /// wizard (which would discard the in-progress postcode/geocode).
+  public func reconcileTierAfterUpgrade() async {
+    await onUpgradeFlowCompleted?()
   }
 
   /// Whether to surface the "this zone may produce lots of notifications" callout

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
@@ -131,6 +131,14 @@ public final class OnboardingViewModel: ObservableObject, ErrorHandlingViewModel
     subscriptionTier < .pro
   }
 
+  /// Whether the user's tier delivers instant alerts (push and instant email).
+  /// Free accounts receive only the weekly email digest, so the notification
+  /// step adapts its copy — and shows a light upgrade nudge — accordingly
+  /// (tc-w3cb.4). Same entitlement the editor's instant-alert toggles gate on.
+  public var deliversInstantAlerts: Bool {
+    EntitlementMap.hasEntitlement(.statusChangeAlerts, for: subscriptionTier)
+  }
+
   /// Surfaces the in-wizard paywall when the user taps the unlock chip.
   public func requestLargerRadiusUpgrade() {
     isRadiusUpsellPresented = true

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
@@ -22,6 +22,14 @@ public final class OnboardingViewModel: ObservableObject, ErrorHandlingViewModel
   private var createdWatchZone: WatchZone?
   @Published public private(set) var isComplete = false
 
+  /// The user's current subscription tier, injected at construction and kept
+  /// fresh by ``AppCoordinator`` (it updates this in place when the live tier
+  /// resolves, e.g. after an in-wizard purchase). It is `@Published` so the
+  /// radius step can unlock the larger paid range reactively *without* the
+  /// wizard being rebuilt — a `.id(tier)` rebuild would discard the in-progress
+  /// postcode/geocode, which must survive the upgrade round-trip (tc-w3cb.3).
+  @Published public internal(set) var subscriptionTier: SubscriptionTier
+
   var onComplete: ((WatchZone) -> Void)?
 
   private let geocoder: PostcodeGeocoder
@@ -33,12 +41,14 @@ public final class OnboardingViewModel: ObservableObject, ErrorHandlingViewModel
     geocoder: PostcodeGeocoder,
     watchZoneRepository: WatchZoneRepository,
     onboardingRepository: OnboardingRepository,
-    notificationService: NotificationService
+    notificationService: NotificationService,
+    subscriptionTier: SubscriptionTier = .free
   ) {
     self.geocoder = geocoder
     self.watchZoneRepository = watchZoneRepository
     self.onboardingRepository = onboardingRepository
     self.notificationService = notificationService
+    self.subscriptionTier = subscriptionTier
   }
 
   public func advance() {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
@@ -102,6 +102,15 @@ public final class OnboardingViewModel: ObservableObject, ErrorHandlingViewModel
     isLoading = false
   }
 
+  /// The maximum radius the user's tier permits, in metres. The radius slider
+  /// is bounded at this so a free user cannot pick a zone larger than their
+  /// tier allows — replacing the old discrete picker that wrongly offered 5 km
+  /// to free accounts (cap 2 km). Shared source of truth with the editor via
+  /// ``WatchZoneLimits`` (tc-w3cb.2).
+  public var maxRadiusMetres: Double {
+    WatchZoneLimits(tier: subscriptionTier).maxRadiusMetres
+  }
+
   /// Whether to surface the "this zone may produce lots of notifications" callout
   /// (tc-1zb7). Triggered at or above 2 km, the upper edge of the recommended
   /// "small zone" range — see `LargeRadiusWarningView`.

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/NotificationPermissionStepView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/NotificationPermissionStepView.swift
@@ -1,34 +1,21 @@
 import SwiftUI
 
-/// Notification permission step — asks user to enable push notifications.
+/// Final onboarding step. Tier-aware and honest about what the user's plan
+/// actually delivers (tc-w3cb.4):
+///
+/// - Paid tiers get instant alerts, so this asks to enable notifications.
+/// - Free accounts get a weekly email digest only (no instant push), so the
+///   copy says exactly that and shows a *light* upgrade nudge — no second full
+///   paywall (the radius step already carries the in-context upsell).
 struct NotificationPermissionStepView: View {
   @ObservedObject var viewModel: OnboardingViewModel
 
   var body: some View {
     VStack(spacing: TCSpacing.large) {
-      Image(systemName: "bell.badge")
-        .font(.system(.largeTitle))
-        .foregroundStyle(Color.tcAmber)
-
-      Text("Stay Updated")
-        .font(TCTypography.displaySmall)
-        .foregroundStyle(Color.tcTextPrimary)
-
-      Text("Get notified when new planning applications appear near you.")
-        .font(TCTypography.body)
-        .foregroundStyle(Color.tcTextSecondary)
-        .multilineTextAlignment(.center)
-
-      PrimaryButton("Enable Notifications") {
-        Task { await viewModel.requestNotificationPermission() }
-      }
-
-      Button {
-        Task { await viewModel.skipNotifications() }
-      } label: {
-        Text("Skip for Now")
-          .font(TCTypography.body)
-          .foregroundStyle(Color.tcTextSecondary)
+      if viewModel.deliversInstantAlerts {
+        instantAlertsContent
+      } else {
+        weeklyDigestContent
       }
 
       Button("Back") {
@@ -38,5 +25,61 @@ struct NotificationPermissionStepView: View {
       .foregroundStyle(Color.tcTextSecondary)
     }
     .padding(TCSpacing.extraLarge)
+  }
+
+  /// Paid tiers: instant alerts are delivered, so offer to enable notifications.
+  @ViewBuilder
+  private var instantAlertsContent: some View {
+    Image(systemName: "bell.badge")
+      .font(.system(.largeTitle))
+      .foregroundStyle(Color.tcAmber)
+
+    Text("Stay updated")
+      .font(TCTypography.displaySmall)
+      .foregroundStyle(Color.tcTextPrimary)
+
+    Text("Get an alert the moment a planning application in your watch zone changes.")
+      .font(TCTypography.body)
+      .foregroundStyle(Color.tcTextSecondary)
+      .multilineTextAlignment(.center)
+
+    PrimaryButton("Enable notifications") {
+      Task { await viewModel.requestNotificationPermission() }
+    }
+
+    Button {
+      Task { await viewModel.skipNotifications() }
+    } label: {
+      Text("Skip for now")
+        .font(TCTypography.body)
+        .foregroundStyle(Color.tcTextSecondary)
+    }
+  }
+
+  /// Free tier: weekly email digest only. No instant push to promise, so no
+  /// permission request — just an honest summary and a light upgrade nudge.
+  @ViewBuilder
+  private var weeklyDigestContent: some View {
+    Image(systemName: "envelope")
+      .font(.system(.largeTitle))
+      .foregroundStyle(Color.tcAmber)
+
+    Text("Stay updated")
+      .font(TCTypography.displaySmall)
+      .foregroundStyle(Color.tcTextPrimary)
+
+    Text("Your free plan sends a weekly email digest of new planning applications near you.")
+      .font(TCTypography.body)
+      .foregroundStyle(Color.tcTextSecondary)
+      .multilineTextAlignment(.center)
+
+    Text("Want to know the moment something changes? Instant alerts come with Personal and Pro.")
+      .font(TCTypography.caption)
+      .foregroundStyle(Color.tcTextSecondary)
+      .multilineTextAlignment(.center)
+
+    PrimaryButton("Finish") {
+      Task { await viewModel.skipNotifications() }
+    }
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/RadiusPickerStepView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/RadiusPickerStepView.swift
@@ -21,6 +21,12 @@ struct RadiusPickerStepView: View {
 
       radiusControl
 
+      if viewModel.canUnlockLargerRadius {
+        UnlockLargerZonesChip {
+          viewModel.requestLargerRadiusUpgrade()
+        }
+      }
+
       if viewModel.showsLargeRadiusWarning {
         LargeRadiusWarningView()
       }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/RadiusPickerStepView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/RadiusPickerStepView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
 /// Radius selection step — user picks how far around their postcode to monitor.
+///
+/// Uses the same `Slider` paradigm as `WatchZoneEditorView`, bounded at the
+/// tier's maximum radius so a free user cannot exceed their 2 km cap by
+/// construction (tc-w3cb.2).
 struct RadiusPickerStepView: View {
   @ObservedObject var viewModel: OnboardingViewModel
-
-  private let radiusOptions: [Double] = [500, 1000, 2000, 5000]
 
   var body: some View {
     VStack(spacing: TCSpacing.large) {
@@ -17,36 +19,7 @@ struct RadiusPickerStepView: View {
         .foregroundStyle(Color.tcTextSecondary)
         .multilineTextAlignment(.center)
 
-      VStack(spacing: TCSpacing.small) {
-        ForEach(radiusOptions, id: \.self) { radius in
-          Button {
-            viewModel.selectedRadiusMetres = radius
-          } label: {
-            HStack {
-              Text(formatRadius(radius))
-                .font(TCTypography.bodyEmphasis)
-              Spacer()
-              if viewModel.selectedRadiusMetres == radius {
-                Image(systemName: "checkmark.circle.fill")
-                  .foregroundStyle(Color.tcAmber)
-              }
-            }
-            .padding(TCSpacing.medium)
-            .background(Color.tcSurface)
-            .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
-            .overlay(
-              RoundedRectangle(cornerRadius: TCCornerRadius.medium)
-                .stroke(
-                  viewModel.selectedRadiusMetres == radius
-                    ? Color.tcAmber : Color.tcBorder,
-                  lineWidth: 1
-                )
-            )
-          }
-          .buttonStyle(.plain)
-          .foregroundStyle(Color.tcTextPrimary)
-        }
-      }
+      radiusControl
 
       if viewModel.showsLargeRadiusWarning {
         LargeRadiusWarningView()
@@ -63,6 +36,32 @@ struct RadiusPickerStepView: View {
       .foregroundStyle(Color.tcTextSecondary)
     }
     .padding(TCSpacing.extraLarge)
+  }
+
+  private var radiusControl: some View {
+    VStack(alignment: .leading, spacing: TCSpacing.small) {
+      Text(formatRadius(viewModel.selectedRadiusMetres))
+        .font(TCTypography.bodyEmphasis)
+        .foregroundStyle(Color.tcTextPrimary)
+        .frame(maxWidth: .infinity, alignment: .center)
+
+      Slider(
+        value: $viewModel.selectedRadiusMetres,
+        in: 100...viewModel.maxRadiusMetres,
+        step: 100
+      )
+      .tint(Color.tcAmber)
+      .accessibilityLabel("Radius")
+      .accessibilityValue(formatRadius(viewModel.selectedRadiusMetres))
+
+      HStack {
+        Text(formatRadius(100))
+        Spacer()
+        Text(formatRadius(viewModel.maxRadiusMetres))
+      }
+      .font(TCTypography.caption)
+      .foregroundStyle(Color.tcTextSecondary)
+    }
   }
 
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorView.swift
@@ -124,6 +124,17 @@ public struct WatchZoneEditorView: View {
         .font(TCTypography.caption)
         .foregroundStyle(Color.tcTextSecondary)
 
+        if viewModel.canUnlockLargerRadius {
+          // Radius upsell (tc-w3cb.3). Routes through viewPlans()/onUpgradeRequired
+          // like the instant-alert upsell: the editor closes and the paywall
+          // opens. After purchase the list rebuilds on the new tier (.id), so a
+          // reopened editor offers the larger range.
+          UnlockLargerZonesChip {
+            viewModel.viewPlans()
+          }
+          .padding(.top, TCSpacing.small)
+        }
+
         if viewModel.showsLargeRadiusWarning {
           LargeRadiusWarningView()
             .padding(.top, TCSpacing.small)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
@@ -55,10 +55,6 @@ public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGating
     }
   }
 
-  public var availableRadiusOptions: [Double] {
-    limits.availableRadiusOptions
-  }
-
   public var isPostcodeFieldVisible: Bool {
     !isEditing
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
@@ -67,6 +67,13 @@ public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGating
     limits.maxRadiusMetres
   }
 
+  /// Whether the user's tier still has radius headroom to unlock — true for any
+  /// tier below the top (Pro, 10 km). Drives the "Unlock larger zones" chip
+  /// shown beneath the radius slider, mirroring the onboarding wizard (tc-w3cb.3).
+  public var canUnlockLargerRadius: Bool {
+    tier < .pro
+  }
+
   /// Proactive UI gate exposing the session's tier to entitlement-aware controls
   /// (e.g. ``GatedToggle``) without a network round-trip.
   public var featureGate: FeatureGate {

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -298,11 +298,18 @@ struct TownCrierApp: App {
     // Subscription paywall — presented when an upsell (e.g. "View Plans" in
     // the watch-zone quota banner) sets `isSubscriptionPresented`. Hoisted to
     // the TabView so the paywall reaches the user regardless of active tab.
-    .sheet(isPresented: $coordinator.isSubscriptionPresented) {
-      NavigationStack {
-        SubscriptionView(viewModel: coordinator.makeSubscriptionViewModel())
+    // On dismiss, re-resolve the tier so a successful purchase unlocks gated
+    // features (e.g. the larger watch-zone radius) live, without an app
+    // relaunch — the tier-keyed views rebuild on the change (tc-w3cb.3).
+    .sheet(
+      isPresented: $coordinator.isSubscriptionPresented,
+      onDismiss: { Task { await coordinator.resolveSubscriptionTier() } },
+      content: {
+        NavigationStack {
+          SubscriptionView(viewModel: coordinator.makeSubscriptionViewModel())
+        }
       }
-    }
+    )
   }
 
   /// Settings sheet — presented from the gear icon installed on every tab.

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -127,7 +127,7 @@ struct TownCrierApp: App {
             appStoreURL: URL(string: "https://apps.apple.com/app/town-crier/id000000000")
           )
         } else if loginViewModel.isAuthenticated {
-          mainTabView
+          authenticatedRootView
         } else {
           LoginView(viewModel: loginViewModel)
         }
@@ -152,6 +152,13 @@ struct TownCrierApp: App {
       // it here is harmless (tc-k9fk).
       .task(id: loginViewModel.isAuthenticated) {
         await coordinator.resolveSubscriptionTier()
+        // Resolve onboarding only once authenticated, and strictly after
+        // resolveSubscriptionTier() has ensured the server profile above — the
+        // wizard's first watch-zone save needs that profile or it 500s
+        // (tc-k9fk / tc-w3cb.1).
+        if loginViewModel.isAuthenticated {
+          await coordinator.determineOnboarding()
+        }
         await forceUpdateViewModel.checkVersion()
       }
       .onChange(of: scenePhase) { _, newPhase in
@@ -192,6 +199,33 @@ struct TownCrierApp: App {
           )
         }
       }
+    }
+  }
+
+  /// Routes the authenticated user to the first-run onboarding wizard, a
+  /// neutral loading screen, or the main app — depending on whether the
+  /// coordinator has determined onboarding is needed (tc-w3cb.1). The wizard
+  /// presents only once profile-ensure has run, so its first watch-zone save
+  /// cannot 500.
+  @ViewBuilder
+  private var authenticatedRootView: some View {
+    switch coordinator.onboardingPresentation {
+    case .required:
+      OnboardingView(viewModel: coordinator.makeOnboardingViewModel())
+    case .notRequired:
+      mainTabView
+    case .undetermined:
+      onboardingLoadingView
+    }
+  }
+
+  /// Branded loading screen shown while onboarding need is still resolving.
+  /// Keeps the wizard from flashing before the watch-zone load completes.
+  private var onboardingLoadingView: some View {
+    ZStack {
+      Color.tcBackground.ignoresSafeArea()
+      ProgressView()
+        .tint(Color.tcAmber)
     }
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorOnboardingTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorOnboardingTests.swift
@@ -125,4 +125,32 @@ struct AppCoordinatorOnboardingTests {
     // in-progress postcode/geocode survives the tier change.
     #expect(vm.subscriptionTier == .pro)
   }
+
+  // MARK: - In-wizard radius upsell (tc-w3cb.3)
+
+  @Test func makeOnboardingViewModel_wiresUpsellPaywallFactory() {
+    let sut = makeSUT()
+    let vm = sut.makeOnboardingViewModel()
+
+    // The coordinator injects the paywall factory so the wizard can present
+    // the subscription sheet over itself.
+    #expect(vm.makeUpsellViewModel?() != nil)
+  }
+
+  @Test func reconcileTierAfterUpgrade_reResolvesTier_unlockingLargerRadiusLive() async {
+    let resolver = FakeSubscriptionTierResolver()
+    resolver.resolveResult = (.pro, false)
+    let sut = makeSUT(tierResolver: resolver)
+    let vm = sut.makeOnboardingViewModel()
+    #expect(vm.canUnlockLargerRadius)
+    #expect(vm.maxRadiusMetres == 2000)
+
+    // Simulates the paywall dismissing after a successful purchase.
+    await vm.reconcileTierAfterUpgrade()
+
+    // Live unlock: the same wizard instance now reflects the upgraded tier.
+    #expect(vm.subscriptionTier == .pro)
+    #expect(vm.maxRadiusMetres == 10000)
+    #expect(!vm.canUnlockLargerRadius)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorOnboardingTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorOnboardingTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@Suite("AppCoordinator -- Onboarding Gating")
+@MainActor
+struct AppCoordinatorOnboardingTests {
+  private func makeSUT(
+    onboardingRepository: SpyOnboardingRepository = SpyOnboardingRepository(),
+    watchZoneRepository: SpyWatchZoneRepository = SpyWatchZoneRepository(),
+    tierResolver: SubscriptionTierResolving? = nil
+  ) -> AppCoordinator {
+    // Isolated tier cache so a leftover `cachedSubscriptionTier` from another
+    // test can't seed a non-free tier at init.
+    let defaults = UserDefaults(suiteName: UUID().uuidString)
+    return AppCoordinator(
+      repository: SpyPlanningApplicationRepository(),
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: SpyUserProfileRepository(),
+      tierResolver: tierResolver,
+      watchZoneRepository: watchZoneRepository,
+      geocoder: SpyPostcodeGeocoder(),
+      onboardingRepository: onboardingRepository,
+      notificationService: SpyNotificationService(),
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService(),
+      tierCache: defaults
+    )
+  }
+
+  // MARK: - Initial presentation state
+
+  @Test func onboardingPresentation_defaultsToUndetermined_whenNotPreviouslyComplete() {
+    let sut = makeSUT()
+
+    #expect(sut.onboardingPresentation == .undetermined)
+  }
+
+  @Test func onboardingPresentation_seedsNotRequired_whenAlreadyCompletedOnDevice() {
+    let onboardingRepo = SpyOnboardingRepository()
+    onboardingRepo.isOnboardingComplete = true
+
+    let sut = makeSUT(onboardingRepository: onboardingRepo)
+
+    #expect(sut.onboardingPresentation == .notRequired)
+  }
+
+  // MARK: - determineOnboarding (account-state gate)
+
+  @Test func determineOnboarding_withNoWatchZones_requiresOnboarding() async {
+    let watchZones = SpyWatchZoneRepository()
+    watchZones.loadAllResult = .success([])
+    let sut = makeSUT(watchZoneRepository: watchZones)
+
+    await sut.determineOnboarding()
+
+    #expect(sut.onboardingPresentation == .required)
+  }
+
+  @Test func determineOnboarding_withExistingWatchZones_skipsOnboarding() async {
+    let watchZones = SpyWatchZoneRepository()
+    watchZones.loadAllResult = .success([.cambridge])
+    let sut = makeSUT(watchZoneRepository: watchZones)
+
+    await sut.determineOnboarding()
+
+    #expect(sut.onboardingPresentation == .notRequired)
+  }
+
+  @Test func determineOnboarding_whenLoadFails_fallsThroughToApp() async {
+    let watchZones = SpyWatchZoneRepository()
+    watchZones.loadAllResult = .failure(DomainError.networkUnavailable)
+    let sut = makeSUT(watchZoneRepository: watchZones)
+
+    await sut.determineOnboarding()
+
+    // A failed determination must not trap the user behind a loading screen
+    // or in the wizard — fall through to the app.
+    #expect(sut.onboardingPresentation == .notRequired)
+  }
+
+  // MARK: - Wizard factory
+
+  @Test func makeOnboardingViewModel_injectsCurrentTier() {
+    let sut = makeSUT()
+
+    let vm = sut.makeOnboardingViewModel()
+
+    #expect(vm.subscriptionTier == .free)
+  }
+
+  @Test func makeOnboardingViewModel_returnsStableInstanceAcrossCalls() {
+    let sut = makeSUT()
+
+    let first = sut.makeOnboardingViewModel()
+    let second = sut.makeOnboardingViewModel()
+
+    #expect(first === second)
+  }
+
+  @Test func makeOnboardingViewModel_onComplete_marksOnboardingNotRequired() {
+    let sut = makeSUT()
+    let vm = sut.makeOnboardingViewModel()
+
+    vm.onComplete?(.cambridge)
+
+    #expect(sut.onboardingPresentation == .notRequired)
+  }
+
+  // MARK: - Live tier observation (tc-w3cb.1 / .3)
+
+  @Test func resolveSubscriptionTier_pushesResolvedTierIntoLiveWizard() async {
+    let resolver = FakeSubscriptionTierResolver()
+    resolver.resolveResult = (.pro, false)
+    let sut = makeSUT(tierResolver: resolver)
+    let vm = sut.makeOnboardingViewModel()
+    #expect(vm.subscriptionTier == .free)
+
+    await sut.resolveSubscriptionTier()
+
+    // The wizard observes the change in place — it is not rebuilt, so any
+    // in-progress postcode/geocode survives the tier change.
+    #expect(vm.subscriptionTier == .pro)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTierResolutionTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTierResolutionTests.swift
@@ -181,7 +181,7 @@ struct AppCoordinatorTierResolutionTests {
     await sut.resolveSubscriptionTier()
     let vm = sut.makeWatchZoneEditorViewModel()
 
-    #expect(vm.availableRadiusOptions == WatchZoneLimits(tier: .personal).availableRadiusOptions)
+    #expect(vm.maxRadiusMetres == WatchZoneLimits(tier: .personal).maxRadiusMetres)
   }
 
   // MARK: - Tier preservation when all sources fail

--- a/mobile/ios/town-crier-tests/Sources/Features/NotificationPermissionStepViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/NotificationPermissionStepViewTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@MainActor
+@Suite("NotificationPermissionStepView")
+struct NotificationPermissionStepViewTests {
+
+  // The step renders one of two tier-aware variants. These smoke tests verify
+  // both construct and evaluate their body (tc-w3cb.4).
+
+  private func makeViewModel(tier: SubscriptionTier) -> OnboardingViewModel {
+    OnboardingViewModel(
+      geocoder: SpyPostcodeGeocoder(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      subscriptionTier: tier
+    )
+  }
+
+  @Test func body_renders_freeTier_weeklyDigestVariant() {
+    let vm = makeViewModel(tier: .free)
+    #expect(!vm.deliversInstantAlerts)
+
+    let sut = NotificationPermissionStepView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_paidTier_instantAlertsVariant() {
+    let vm = makeViewModel(tier: .personal)
+    #expect(vm.deliversInstantAlerts)
+
+    let sut = NotificationPermissionStepView(viewModel: vm)
+    _ = sut.body
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/OnboardingViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/OnboardingViewModelTests.swift
@@ -231,4 +231,28 @@ struct OnboardingViewModelTests {
     #expect(completedZone != nil)
     #expect(completedZone?.radiusMetres == 1000)
   }
+
+  // MARK: - Tier-bounded radius (tc-w3cb.2)
+
+  private func makeViewModel(tier: SubscriptionTier) -> OnboardingViewModel {
+    OnboardingViewModel(
+      geocoder: SpyPostcodeGeocoder(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      subscriptionTier: tier
+    )
+  }
+
+  @Test func maxRadiusMetres_freeTier_capsAt2km() {
+    #expect(makeViewModel(tier: .free).maxRadiusMetres == 2000)
+  }
+
+  @Test func maxRadiusMetres_personalTier_capsAt5km() {
+    #expect(makeViewModel(tier: .personal).maxRadiusMetres == 5000)
+  }
+
+  @Test func maxRadiusMetres_proTier_capsAt10km() {
+    #expect(makeViewModel(tier: .pro).maxRadiusMetres == 10000)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/OnboardingViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/OnboardingViewModelTests.swift
@@ -275,4 +275,15 @@ struct OnboardingViewModelTests {
 
     #expect(sut.isRadiusUpsellPresented)
   }
+
+  // MARK: - Tier-aware notification copy (tc-w3cb.4)
+
+  @Test func deliversInstantAlerts_isFalseForFree() {
+    #expect(!makeViewModel(tier: .free).deliversInstantAlerts)
+  }
+
+  @Test func deliversInstantAlerts_isTrueForPaidTiers() {
+    #expect(makeViewModel(tier: .personal).deliversInstantAlerts)
+    #expect(makeViewModel(tier: .pro).deliversInstantAlerts)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/OnboardingViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/OnboardingViewModelTests.swift
@@ -255,4 +255,24 @@ struct OnboardingViewModelTests {
   @Test func maxRadiusMetres_proTier_capsAt10km() {
     #expect(makeViewModel(tier: .pro).maxRadiusMetres == 10000)
   }
+
+  // MARK: - Radius upsell (tc-w3cb.3)
+
+  @Test func canUnlockLargerRadius_isTrueBelowPro() {
+    #expect(makeViewModel(tier: .free).canUnlockLargerRadius)
+    #expect(makeViewModel(tier: .personal).canUnlockLargerRadius)
+  }
+
+  @Test func canUnlockLargerRadius_isFalseAtTopTier() {
+    #expect(!makeViewModel(tier: .pro).canUnlockLargerRadius)
+  }
+
+  @Test func requestLargerRadiusUpgrade_presentsUpsellSheet() {
+    let sut = makeViewModel(tier: .free)
+    #expect(!sut.isRadiusUpsellPresented)
+
+    sut.requestLargerRadiusUpgrade()
+
+    #expect(sut.isRadiusUpsellPresented)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/OnboardingViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/OnboardingViewTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@MainActor
+@Suite("OnboardingView")
+struct OnboardingViewTests {
+
+  // Smoke tests: the wizard container is a passive renderer. Verify it
+  // constructs and its body evaluates, including the in-wizard radius upsell
+  // sheet path (tc-w3cb.3).
+
+  private func makeViewModel(tier: SubscriptionTier = .free) -> OnboardingViewModel {
+    OnboardingViewModel(
+      geocoder: SpyPostcodeGeocoder(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      subscriptionTier: tier
+    )
+  }
+
+  @Test func body_renders() {
+    let sut = OnboardingView(viewModel: makeViewModel())
+    _ = sut.body
+  }
+
+  @Test func body_renders_whenRadiusUpsellPresented() {
+    let vm = makeViewModel(tier: .free)
+    vm.makeUpsellViewModel = {
+      SubscriptionViewModel(
+        subscriptionService: SpySubscriptionService(),
+        authenticationService: SpyAuthenticationService()
+      )
+    }
+    vm.requestLargerRadiusUpgrade()
+    #expect(vm.isRadiusUpsellPresented)
+
+    let sut = OnboardingView(viewModel: vm)
+    _ = sut.body
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/RadiusPickerStepViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/RadiusPickerStepViewTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@MainActor
+@Suite("RadiusPickerStepView")
+struct RadiusPickerStepViewTests {
+
+  // The step is a passive renderer of OnboardingViewModel state. These tests
+  // verify the slider-based step constructs and its body evaluates across the
+  // tier range it must support (tc-w3cb.2).
+
+  private func makeViewModel(tier: SubscriptionTier) -> OnboardingViewModel {
+    OnboardingViewModel(
+      geocoder: SpyPostcodeGeocoder(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      subscriptionTier: tier
+    )
+  }
+
+  @Test func body_renders_forFreeTier() {
+    let sut = RadiusPickerStepView(viewModel: makeViewModel(tier: .free))
+    _ = sut.body
+  }
+
+  @Test func body_renders_forPersonalTier() {
+    let sut = RadiusPickerStepView(viewModel: makeViewModel(tier: .personal))
+    _ = sut.body
+  }
+
+  @Test func body_renders_forProTier() {
+    let sut = RadiusPickerStepView(viewModel: makeViewModel(tier: .pro))
+    _ = sut.body
+  }
+
+  @Test func body_renders_whenLargeRadiusWarningShown() {
+    let vm = makeViewModel(tier: .pro)
+    vm.selectedRadiusMetres = 3000  // at/above the 2 km large-radius threshold
+    #expect(vm.showsLargeRadiusWarning)
+
+    let sut = RadiusPickerStepView(viewModel: vm)
+    _ = sut.body
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewModelTests.swift
@@ -58,21 +58,6 @@ struct WatchZoneEditorCreateTests {
     #expect(sut.error == .geocodingFailed("not found"))
   }
 
-  @Test func radiusOptions_reflectTierLimits() {
-    let limits = WatchZoneLimits(tier: .personal)
-    #expect(sut.availableRadiusOptions == limits.availableRadiusOptions)
-  }
-
-  @Test func radiusOptions_freeTier_capped() {
-    let freeSut = WatchZoneEditorViewModel(
-      geocoder: spyGeocoder,
-      repository: spyRepository,
-      tier: .free
-    )
-    let limits = WatchZoneLimits(tier: .free)
-    #expect(freeSut.availableRadiusOptions == limits.availableRadiusOptions)
-  }
-
   @Test func isPostcodeFieldVisible_inCreateMode_isTrue() {
     #expect(sut.isPostcodeFieldVisible)
   }

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneEditorViewTests.swift
@@ -83,6 +83,17 @@ struct WatchZoneEditorViewTests {
     #expect(vm.maxRadiusMetres == 10000)
   }
 
+  // MARK: - Radius upsell chip (tc-w3cb.3)
+
+  @Test func canUnlockLargerRadius_belowTopTier() {
+    #expect(makeViewModel(tier: .free).canUnlockLargerRadius)
+    #expect(makeViewModel(tier: .personal).canUnlockLargerRadius)
+  }
+
+  @Test func canUnlockLargerRadius_falseAtProTier() {
+    #expect(!makeViewModel(tier: .pro).canUnlockLargerRadius)
+  }
+
   @Test func liveLabelFormatsCurrentRadius() {
     let vm = makeViewModel()
     vm.selectedRadiusMetres = 1500

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneLimitsTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneLimitsTests.swift
@@ -59,16 +59,4 @@ struct WatchZoneLimitsTests {
     #expect(limits.clampRadius(8000) == 5000)
   }
 
-  @Test func availableRadiusOptions_freeTier() {
-    let limits = WatchZoneLimits(tier: .free)
-    let options = limits.availableRadiusOptions
-    #expect(options.allSatisfy { $0 <= 2000 })
-    #expect(!options.isEmpty)
-  }
-
-  @Test func availableRadiusOptions_proTier_includesLargeRadii() {
-    let limits = WatchZoneLimits(tier: .pro)
-    let options = limits.availableRadiusOptions
-    #expect(options.contains(10000))
-  }
 }


### PR DESCRIPTION
Closes the **tc-w3cb** epic ([#551](https://github.com/AmyDe/town-crier/issues/551)). The onboarding wizard already existed but was never wired in; this wires it in and modernises it for the freemium model. Native iOS (Swift/SwiftUI, MVVM-C).

## Changes
- **Phase 1 (tc-w3cb.1)** — Wire the wizard into `TownCrierApp`. `AppCoordinator.makeOnboardingViewModel()` (guards the optional geocoder, retains the VM so the live tier can be pushed in). Presentation is **account-state driven** (0 watch zones ⇒ wizard), not the device-local `isOnboardingComplete` latch, so it survives reinstall and multi-device. Runs **after** profile-ensure (`POST /v1/me`, tc-k9fk) so the first zone save can't 500. A neutral loading screen avoids flashing the wizard while zones load. Coordinator factories split into `+Onboarding`/`+WatchZones` extensions to stay under the 400-line `file_length` limit.
- **Phase 2 (tc-w3cb.2)** — Replace the wizard's discrete radius buttons with the editor's `Slider`, bounded at the tier cap. Fixes the free-tier 5 km bug by construction; both screens now share one radius paradigm.
- **Phase 3 (tc-w3cb.3)** — In-context radius upsell. A tier-aware "Unlock larger zones" chip sits beneath the slider (wizard + editor). In the wizard the paywall presents as a sheet **over** the wizard so the in-progress postcode/geocode survives the purchase; on dismiss the tier re-resolves and the range unlocks **live** in the same instance. The paywall sheet now re-resolves the tier on dismiss generally, so any IAP unlocks gated features without a relaunch.
- **Phase 4 (tc-w3cb.4)** — Honest, tier-aware notification step: paid tiers get "Enable notifications"; free gets a truthful weekly-email-digest summary, no push prompt, and a *light* upgrade nudge (no second paywall, no double-upsell).
- **Phase 5 (tc-w3cb.5)** — Retire the now-dead `availableRadiusOptions` (VM + domain) and its tests.

## Note for the owner (TestFlight)
This ships the **documented safe fallback** for the radius interaction: a capped slider plus an explicit "Unlock larger zones" chip. The richer locked-region-on-the-track gesture (hard-clamp + tap-to-unlock vs. drag-triggers-sheet) is the open question to **prototype in TestFlight** before release. `Release-Note:` trailers are on the user-facing commits.

## Validation
`swift build`, `swift test` (1229 passing), `swiftlint --strict` (0 violations), and `xcodebuild -scheme TownCrierApp` all green locally.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding wizard with subscription tier-aware features
  * Radius picker now uses an interactive slider control
  * "Unlock larger zones" upsells during onboarding and zone editing
  * Tier-based notification settings (instant alerts for paid tiers, weekly digest for free)

* **Tests**
  * Added comprehensive test coverage for onboarding flow and zone management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->