### PR TITLE
fix: make iOS release notes robust to missing trailers/prefixes (tc-0557)

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -201,6 +201,50 @@ jobs:
       - run: swift test
         working-directory: mobile/ios
 
+  ios-release-note-guard:
+    name: "iOS: Release-note guard"
+    needs: changes
+    if: needs.changes.outputs.ios == 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Ensure iOS changes carry a user-note signal
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          # A user-facing iOS change must surface in the App Store / TestFlight
+          # changelog. scripts/ios-release-notes.sh derives that changelog from
+          # (1) Release-Note: trailers, then (2) cleaned mobile/ios subjects. A PR
+          # whose squash subject (the PR title) has no recognised conventional
+          # type AND no Release-Note: trailer falls through to the stock line —
+          # which is how v0.15.23's onboarding-wizard launch shipped with no real
+          # notes (tc-0557). Block that class of PR here.
+
+          # Signal 1: any Release-Note: trailer in the PR's commits.
+          if git log --format='%B' "origin/${BASE_REF}..HEAD" | grep -qiE '^Release-Note:'; then
+            echo "✓ Release-Note: trailer present — App Store note authored verbatim."
+            exit 0
+          fi
+
+          # Signal 2: PR title carries a recognised conventional-commit type.
+          #   feat/fix   → generates a cleaned user note (Tier 2)
+          #   chore/ci/… → explicit, intentional opt-out (no note, by design)
+          if printf '%s' "$PR_TITLE" \
+              | grep -qiE '^(feat|fix|chore|ci|docs|test|build|style|refactor|perf)(\([^)]*\))?!?:'; then
+            echo "✓ PR title has a conventional-commit type prefix: $PR_TITLE"
+            exit 0
+          fi
+
+          echo "::error::iOS-touching PR has no Release-Note: trailer and the PR title has no conventional-commit type prefix: '$PR_TITLE'"
+          echo "::error::The App Store / TestFlight changelog would silently fall back to the generic stock line."
+          echo "::error::Fix one of: add a 'Release-Note: <plain-English user-facing change>' git trailer; OR retitle the PR with a type prefix — feat(ios):/fix(ios): for user-facing changes, or chore(ios):/test(ios): etc. to opt out."
+          exit 1
+
   # ── Web ──────────────────────────────────────────────
 
   web-lint:
@@ -304,7 +348,7 @@ jobs:
 
   gate:
     name: PR Gate
-    needs: [go-lint, go-test, cli-format, cli-build-test, ios-lint, ios-build-test, web-lint, web-build-test, infra-preview]
+    needs: [go-lint, go-test, cli-format, cli-build-test, ios-lint, ios-build-test, ios-release-note-guard, web-lint, web-build-test, infra-preview]
     if: always() && (github.event_name != 'pull_request' || github.event.action != 'closed')
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -318,6 +362,7 @@ jobs:
             "${{ needs.cli-build-test.result }}"
             "${{ needs.ios-lint.result }}"
             "${{ needs.ios-build-test.result }}"
+            "${{ needs.ios-release-note-guard.result }}"
             "${{ needs.web-lint.result }}"
             "${{ needs.web-build-test.result }}"
             "${{ needs.infra-preview.result }}"

--- a/scripts/ios-release-notes.sh
+++ b/scripts/ios-release-notes.sh
@@ -7,15 +7,21 @@
 # user-centric notes deterministically, with no LLM or human in the loop, so it
 # can run unattended in CD.
 #
-# Resolution order (first tier that yields any line wins):
-#   1. `Release-Note:` commit trailers in the range. Authored, plain-English,
-#      shipped verbatim. This is the way to get polished copy: when you make a
-#      user-facing iOS change, add a trailer, e.g.
+# Each user-facing change contributes one note; the two sources are MERGED, not
+# ranked (an early "first tier wins" design let a single trailer suppress every
+# sibling commit's note — that is how a multi-PR range silently dropped the
+# onboarding-wizard launch, tc-0557). Per change, in commit order:
+#   1. If the commit carries `Release-Note:` trailer(s), use them verbatim.
+#      Authored, plain-English copy — the way to get polished notes:
 #          Release-Note: Saved searches now refresh the moment an application changes.
-#   2. mobile/ios/ feat & fix commit subjects, with the conventional-commit
-#      `type(scope):` prefix, `(#NN)` PR refs and `(tc-xxxx)` bead IDs stripped.
-#      No backend, no infra, no chores, no internal IDs.
-#   3. A stock catch-all line.
+#   2. Otherwise, if it is a user-facing mobile/ios/ commit, use its subject with
+#      the conventional-commit `type(scope):` prefix, `(#NN)` PR refs and
+#      `(tc-xxxx)` bead IDs stripped. Explicitly non-user-facing types
+#      (chore/ci/docs/test/build/style/refactor/perf) and version-bump plumbing
+#      are excluded. This also catches subjects that LOST their feat/fix prefix
+#      during squash-merge (e.g. a plain "iOS onboarding wizard: ..." title).
+#   3. If nothing qualifies, a stock catch-all line.
+# A commit's own subject is never emitted alongside its trailer (no duplicates).
 #
 # Usage: ios-release-notes.sh <previous-tag> <current-ref>
 #   <previous-tag> may be empty (first release / workflow_dispatch) — the range
@@ -38,27 +44,45 @@ fi
 
 STOCK="Bug fixes and performance improvements."
 
-# --- Tier 1: Release-Note: trailers (authored, verbatim) ---------------------
+# --- Source 1: authored Release-Note: trailers (verbatim, any commit) --------
 # `|| true` guards against grep exiting 1 (no match) tripping pipefail.
-notes="$(
+trailer_notes="$(
   git log --format='%B' "$RANGE" 2>/dev/null \
     | grep -iE '^Release-Note:' \
-    | sed -E 's/^[Rr]elease-[Nn]ote:[[:space:]]*//' \
-    | awk 'NF && !seen[$0]++' || true
+    | sed -E 's/^[Rr]elease-[Nn]ote:[[:space:]]*//' || true
 )"
 
-# --- Tier 2: mobile/ios feat/fix subjects (cleaned) --------------------------
-if [ -z "$notes" ]; then
-  notes="$(
-    git log --no-merges --format='%s' "$RANGE" -- mobile/ios/ 2>/dev/null \
-      | grep -E '^(feat|fix)(\([^)]*\))?!?:' \
-      | sed -E 's/^(feat|fix)(\([^)]*\))?!?:[[:space:]]*//' \
-      | sed -E 's/[[:space:]]*\(#[0-9]+\)//g; s/[[:space:]]*\(tc-[a-z0-9]+\)//g; s/[[:space:]]+$//' \
-      | awk 'NF && !seen[$0]++ { print toupper(substr($0,1,1)) substr($0,2) }' || true
-  )"
-fi
+# --- Source 2: cleaned mobile/ios subjects for commits WITHOUT a trailer -----
+# Skipping trailer-carrying commits is what keeps the two sources from either
+# duplicating a change (subject + its own trailer) or — the bug this replaces —
+# letting one source suppress the other. Non-user-facing types and version-bump
+# plumbing are excluded so they can never leak to App Store users.
+subject_notes="$(
+  while IFS= read -r h; do
+    [ -z "$h" ] && continue
+    if git show -s --format='%B' "$h" 2>/dev/null | grep -qiE '^Release-Note:'; then
+      continue   # its trailer already covers it (Source 1)
+    fi
+    git show -s --format='%s' "$h" 2>/dev/null
+  done < <(git log --no-merges --format='%H' "$RANGE" -- mobile/ios/ 2>/dev/null) \
+    | grep -viE '^(chore|ci|docs|test|build|style|refactor|perf)(\([^)]*\))?!?:' \
+    | sed -E 's/^(feat|fix)(\([^)]*\))?!?:[[:space:]]*//' \
+    | sed -E 's/[[:space:]]*\(#[0-9]+\)//g; s/[[:space:]]*\(tc-[a-z0-9]+\)//g; s/[[:space:]]+$//' \
+    | grep -viE 'bump.*version|marketing version|version bump' || true
+)"
 
-# --- Tier 3: stock catch-all -------------------------------------------------
+# --- Merge, dedupe, tidy -----------------------------------------------------
+notes="$(
+  printf '%s\n%s\n' "$trailer_notes" "$subject_notes" \
+    | awk 'NF && !seen[$0]++ {
+        first = substr($0, 1, 1); second = substr($0, 2, 1)
+        # Capitalise the lead char, but leave "iOS"/"macOS"-style words alone.
+        if (first ~ /[a-z]/ && second !~ /[A-Z]/) $0 = toupper(first) substr($0, 2)
+        print
+      }'
+)"
+
+# --- Stock catch-all ---------------------------------------------------------
 if [ -z "$notes" ]; then
   printf '%s\n' "$STOCK"
   exit 0


### PR DESCRIPTION
## Changes
Fixes the silent-drop bug that shipped the v0.15.23 onboarding-wizard launch with the generic stock note ("Bug fixes and performance improvements.").

- **Generator (`scripts/ios-release-notes.sh`):** trailers and cleaned `mobile/ios` subjects are now **merged per-commit**, not ranked. The old "first tier wins" let a single `Release-Note:` trailer suppress every sibling commit's note. Each change yields one note (trailer preferred, subject otherwise), a commit's subject is never emitted beside its own trailer, subjects that lost their `feat/fix` prefix in squash are captured, and non-user types + version-bump plumbing are filtered so they can't leak.
- **PR gate (`pr-gate.yml`):** new `ios-release-note-guard` job (wired into the required `gate`) fails any iOS-touching PR that has neither a `Release-Note:` trailer nor a conventional-commit title, so this class of silent drop can't reach a release again.

Verified locally against the real release ranges: v0.15.23 now lists the onboarding wizard; the multi-PR GA→now range lists all three changes (export + onboarding + sign-in fix) with no duplication; version-bump-only ranges fall to stock without leaking.

App Store 1.0.1 "What's New" backfilled separately (manual paste, deliver lane is tc-3eim).

---
*Auto-shipped via ship skill*