### PR TITLE
fix(ios): polish paywall + upgrade prompts (truncation, plan features)

### DIFF
--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/SubscriptionTier+Features.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/SubscriptionTier+Features.swift
@@ -1,0 +1,39 @@
+extension SubscriptionTier {
+  /// Concise, user-facing feature highlights for this tier, shown on the paywall.
+  ///
+  /// Derived from ``WatchZoneLimits`` and ``EntitlementMap`` so the copy stays in
+  /// sync with the zone limits and entitlements the app actually enforces. Order
+  /// runs from quotas (zones, radius) to alerting.
+  ///
+  /// Push and email are framed as two channels for the same alerts rather than
+  /// separate features, so the paid tiers collapse to a single alerts line.
+  public var featureHighlights: [String] {
+    let limits = WatchZoneLimits(tier: self)
+    var highlights = [
+      Self.zoneCountHighlight(maxZones: limits.maxZones),
+      Self.radiusHighlight(maxRadiusMetres: limits.maxRadiusMetres),
+    ]
+    if EntitlementMap.hasEntitlement(.statusChangeAlerts, for: self) {
+      highlights.append("Status & decision alerts by push and email")
+    } else {
+      highlights.append("Weekly email summary")
+    }
+    return highlights
+  }
+
+  private static func zoneCountHighlight(maxZones: Int) -> String {
+    switch maxZones {
+    case Int.max:
+      return "Unlimited watch zones"
+    case 1:
+      return "1 watch zone"
+    default:
+      return "\(maxZones) watch zones"
+    }
+  }
+
+  private static func radiusHighlight(maxRadiusMetres: Double) -> String {
+    let kilometres = Int(maxRadiusMetres / 1000)
+    return "Zones up to \(kilometres) km radius"
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Modifiers/SelfSizingSheet.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Modifiers/SelfSizingSheet.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Sizes the enclosing sheet to its content's natural height.
+///
+/// A fixed `.presentationDetents([.medium])` clips short, text-heavy sheets: when
+/// the content's intrinsic height exceeds the medium detent the body text is
+/// compressed and truncates (worse at larger Dynamic Type sizes). This modifier
+/// measures the content at its ideal height and makes that the sole detent, so
+/// the copy is always shown in full.
+private struct SelfSizingSheetModifier: ViewModifier {
+  @State private var contentHeight: CGFloat?
+
+  func body(content: Content) -> some View {
+    content
+      // Force the ideal vertical height so text wraps fully instead of truncating,
+      // then measure that height to drive the detent.
+      .fixedSize(horizontal: false, vertical: true)
+      .background {
+        GeometryReader { proxy in
+          Color.clear
+            .onAppear { contentHeight = proxy.size.height }
+            .onChange(of: proxy.size.height) { _, newValue in
+              contentHeight = newValue
+            }
+        }
+      }
+      // Fall back to `.large` until measured so the first frame never truncates.
+      .presentationDetents(contentHeight.map { measured in [.height(measured)] } ?? [.large])
+      .presentationDragIndicator(.visible)
+  }
+}
+
+extension View {
+  /// Presents this view in a sheet sized to its own content height.
+  ///
+  /// Use in place of `.presentationDetents([.medium])` for short, text-heavy
+  /// sheets where a fixed detent would clip and truncate the copy.
+  func selfSizingSheet() -> some View {
+    modifier(SelfSizingSheetModifier())
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionView.swift
@@ -91,6 +91,10 @@ public struct SubscriptionView: View {
         }
       }
 
+      featureList(for: product)
+        .padding(.top, TCSpacing.extraSmall)
+        .padding(.bottom, TCSpacing.small)
+
       if isCurrentTier(product) {
         currentPlanLabel
       } else {
@@ -104,6 +108,24 @@ public struct SubscriptionView: View {
     .padding(TCSpacing.medium)
     .background(Color.tcSurface)
     .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+  }
+
+  private func featureList(for product: SubscriptionProduct) -> some View {
+    VStack(alignment: .leading, spacing: TCSpacing.small) {
+      ForEach(product.tier.featureHighlights, id: \.self) { feature in
+        Label {
+          Text(feature)
+            .font(TCTypography.body)
+            .foregroundStyle(Color.tcTextPrimary)
+            .fixedSize(horizontal: false, vertical: true)
+        } icon: {
+          Image(systemName: "checkmark.circle.fill")
+            .font(TCTypography.body)
+            .foregroundStyle(Color.tcAmber)
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
   }
 
   private func trialBadge(days: Int) -> some View {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/View+EntitlementGate.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/View+EntitlementGate.swift
@@ -29,8 +29,7 @@ extension View {
           entitlement.wrappedValue = nil
         }
       )
-      .presentationDetents([.medium])
-      .presentationDragIndicator(.visible)
+      .selfSizingSheet()
     }
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -61,8 +61,7 @@ public struct WatchZoneListView: View {
         onViewPlans: { viewModel.viewPlans() },
         onDismiss: { viewModel.dismissUpgradePrompt() }
       )
-      .presentationDetents([.medium])
-      .presentationDragIndicator(.visible)
+      .selfSizingSheet()
     }
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/SubscriptionTierFeatureHighlightsTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SubscriptionTierFeatureHighlightsTests.swift
@@ -1,0 +1,38 @@
+import Testing
+import TownCrierDomain
+
+@Suite("SubscriptionTier — featureHighlights")
+struct SubscriptionTierFeatureHighlightsTests {
+  @Test("free tier: 1 zone, 2 km radius, weekly email summary, no instant alerts")
+  func free() {
+    #expect(
+      SubscriptionTier.free.featureHighlights == [
+        "1 watch zone",
+        "Zones up to 2 km radius",
+        "Weekly email summary",
+      ]
+    )
+  }
+
+  @Test("personal tier: 3 zones, 5 km radius, alerts by push and email")
+  func personal() {
+    #expect(
+      SubscriptionTier.personal.featureHighlights == [
+        "3 watch zones",
+        "Zones up to 5 km radius",
+        "Status & decision alerts by push and email",
+      ]
+    )
+  }
+
+  @Test("pro tier: unlimited zones, 10 km radius, alerts by push and email")
+  func pro() {
+    #expect(
+      SubscriptionTier.pro.featureHighlights == [
+        "Unlimited watch zones",
+        "Zones up to 10 km radius",
+        "Status & decision alerts by push and email",
+      ]
+    )
+  }
+}


### PR DESCRIPTION
## Changes

User feedback on the iOS paywall and upgrade prompts.

- **Upgrade sheets no longer truncate (tc-ahqn).** The "Add more watch zones" and entitlement-gated upsell sheets used a fixed `.presentationDetents([.medium])`, which compressed and cut off the body copy (e.g. "...never miss a..."), worse at larger Dynamic Type. New reusable `.selfSizingSheet()` modifier measures the content and sizes the sheet to fit, applied to both sheets.
- **Paywall now says what each plan includes (tc-ya72).** Each plan card gains a feature checklist (watch zones, radius, alerts) between price and Subscribe. Copy is derived from `WatchZoneLimits` + `EntitlementMap` via a new `SubscriptionTier.featureHighlights`, so it can't drift from the limits the app enforces. Push and email are framed as two channels for the same alerts ("Status & decision alerts by push and email").

Tests: 3 new domain tests for `featureHighlights`; full suite (1232) green. SwiftLint strict clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)