### PR TITLE
docs: adr-audit README pass + reconcile README/ADR 0001 with Go consolidation

### DIFF
--- a/.claude/skills/adr-audit/SKILL.md
+++ b/.claude/skills/adr-audit/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: adr-audit
-description: "Autonomous ADR auditor — scans the entire codebase (API, iOS, web, infra, CI/CD) and compares what's actually built against what's documented in /docs/adr/. Amends stale ADRs and drafts new ones for undocumented decisions. It also audits technical memos in /docs/memo, graduating any whose recommendation has now shipped to 'Superseded by ADR NNNN' (never deleting them). Then commits the changes. Designed for `/loop` — runs idempotently and only writes when there's genuine drift. MUST use this skill whenever the user says 'audit ADRs', 'check ADRs', 'are my ADRs up to date', 'review architecture decisions', 'ADR sweep', 'documentation audit', 'audit memos', 'check memos', 'graduate memos', 'memo sweep', or any variation of wanting to ensure architecture decision records (and memos) match the codebase. Also trigger when used via `/loop` with this skill."
+description: "Autonomous ADR auditor — scans the entire codebase (API, iOS, web, infra, CI/CD) and compares what's actually built against what's documented in /docs/adr/. Amends stale ADRs and drafts new ones for undocumented decisions. It also audits technical memos in /docs/memo, graduating any whose recommendation has now shipped to 'Superseded by ADR NNNN' (never deleting them). On the same scan it verifies the root README.md still matches reality — tech stack, repository layout, build commands, and architecture summary — and corrects any drift. Then commits the changes. Designed for `/loop` — runs idempotently and only writes when there's genuine drift. MUST use this skill whenever the user says 'audit ADRs', 'check ADRs', 'are my ADRs up to date', 'review architecture decisions', 'ADR sweep', 'documentation audit', 'audit memos', 'check memos', 'graduate memos', 'memo sweep', 'check the readme', 'is the readme up to date', 'fix the readme', or any variation of wanting to ensure architecture decision records, memos, and the README match the codebase. Also trigger when used via `/loop` with this skill."
 ---
 
 # ADR Audit
 
-You are an autonomous architecture auditor. Your job: scan the entire Town Crier codebase, compare what's actually built against what's documented in `/docs/adr/`, and fix any drift — amending stale ADRs and creating new ones for undocumented decisions. Then audit the technical memos in `/docs/memo/` and graduate any whose recommendation has now shipped. Then commit and push.
+You are an autonomous architecture auditor. Your job: scan the entire Town Crier codebase, compare what's actually built against what's documented in `/docs/adr/`, and fix any drift — amending stale ADRs and creating new ones for undocumented decisions. Then audit the technical memos in `/docs/memo/` and graduate any whose recommendation has now shipped. Then verify the root `README.md` is accurate against the same scan and correct any drift. Then commit and push.
 
-This skill is designed for unattended `/loop` execution. Be idempotent — if ADRs and memos are already up to date, do nothing and return quickly.
+This skill is designed for unattended `/loop` execution. Be idempotent — if the ADRs, memos, and README are already up to date, do nothing and return quickly.
 
 ## Execution Flow
 
 ```
-Read ADRs → Scan codebase → Identify drift → Audit memos → Write changes → Commit & push
+Read ADRs → Scan codebase → Identify drift → Audit memos → Audit README → Write changes → Commit & push
 ```
 
 ## Phase 1: Read Existing ADRs
@@ -134,7 +134,7 @@ Categorise each `Open` memo:
 
 - **Graduate to Superseded** — the recommendation shipped **and** an ADR records the decision. Set the status to `Superseded by ADR [NNNN](../adr/NNNN-title.md)` and add a one-line resolution note (date · what shipped · which ADR). **Never delete the memo** — it holds the trade-off analysis the ADR deliberately doesn't repeat (the rationale trail). This mirrors how memo 0002 graduated to ADR 0020 and memo 0007 to ADR 0028.
 - **Resolved (no action)** — the question was settled by explicitly deciding *not* to act (the explored path was rejected and won't be built). Set status to `Resolved (no action)` with a one-line note on why.
-- **Implemented but no ADR yet** — the recommendation is built but no ADR captures it. This is also a Phase 3 "new ADR needed" finding: **create the ADR first** (in Phase 5), then graduate the memo to point at it. A significant decision that shipped should have an ADR, not just a memo.
+- **Implemented but no ADR yet** — the recommendation is built but no ADR captures it. This is also a Phase 3 "new ADR needed" finding: **create the ADR first** (in Phase 6), then graduate the memo to point at it. A significant decision that shipped should have an ADR, not just a memo.
 - **Still Open** — neither built nor decided. Leave it untouched. This is the common case; most memos are forward-looking and stay Open for a long time.
 
 **Judgement calls:**
@@ -142,9 +142,28 @@ Categorise each `Open` memo:
 - Don't graduate on a partial implementation. If only part of the recommendation shipped, leave it Open (optionally note the gap).
 - **Never delete a memo.** Graduation is a status change. Preserving the analysis is the entire point of a memo.
 
-## Phase 5: Write Changes
+## Phase 5: Audit the README
 
-If Phase 3 and Phase 4 found nothing, report "ADRs and memos are up to date" and stop. Do not make changes for the sake of it.
+The root `README.md` is the project's front door — the first thing a new contributor (or a future you) reads. It drifts the same way ADRs do, only faster, because nobody re-reads it after the first week. Reuse the Phase 2 codebase scan you already have; don't scan the tree again.
+
+Read `README.md` and check each section against codebase reality:
+
+- **Tech Stack table** — does every row still match what's built? Backend language and framework, database, iOS stack, infrastructure language and platform, CI/CD, and the testing frameworks per component. This is where the worst drift hides: a migrated backend or infra language, a major framework version jump, or a tool that was swapped out. Cross-check against the Phase 1 ADR inventory and the actual project files (`go.mod`, `*.csproj`, `package.json`, `Package.swift`).
+- **Repository Structure** — does every listed directory still exist, and is its one-line description accurate? Catch renamed (`/api` → `/api-go`), removed, or newly-significant top-level directories. A directory the README lists that no longer exists is a hard error; a significant directory that exists but isn't listed is an omission.
+- **Getting Started / build commands** — do the documented build and test commands still work for each component? A `cd api && dotnet build` pointing at a deleted directory, or an `npm`/`swift` command that's been renamed, is actively misleading. Cross-check against the "Development Commands" in CLAUDE.md.
+- **Architecture summary** — does the prose paragraph still describe the real architecture? The patterns named (hexagonal, CQRS, MVVM-C), libraries called out (Leaflet, Auth0, React Query), and the data-ingestion model should all match the code and the ADRs.
+- **Links** — do referenced paths resolve? `docs/adr/`, `LICENSE`, external URLs.
+
+Collect any README drift as a Phase 6 write — don't edit it here. That keeps every doc change in one place so it all commits together.
+
+**Judgement calls:**
+- The README is a summary, not an inventory. It should name architectural choices, not list every dependency. Don't pad it.
+- Keep the README's existing structure, headings, and voice. Correct the facts; don't restructure or expand scope.
+- If the README and an ADR you're about to write or amend disagree, the **codebase is the tie-breaker** — fix both to match reality, not each other.
+
+## Phase 6: Write Changes
+
+If Phase 3, Phase 4, and Phase 5 found nothing, report "ADRs, memos, and README are up to date" and stop. Do not make changes for the sake of it.
 
 If there is drift:
 
@@ -203,19 +222,28 @@ When Phase 4 found a memo to graduate:
 - Leave the rest of the memo (Question, Analysis, Options Considered, Recommendation) **exactly as written** — that is the rationale trail. Do not rewrite or trim it.
 - Never rename or delete the file. The sequence number stays.
 
+### Correcting the README
+
+When Phase 5 found README drift:
+
+- Edit `README.md` in place. Change only the facts that drifted — the stale tech-stack row, the renamed directory line, the broken command, the inaccurate architecture sentence.
+- Preserve the existing headings, table shape, and tone. Resist the urge to expand a summary into an inventory.
+- Keep it consistent with any ADR you amended or created in this same run — they should tell the same story.
+
 ### Naming convention
 
 Files: `NNNN-kebab-case-title.md` (zero-padded to 4 digits). Memos and ADRs each have their own independent sequence under `docs/memo/` and `docs/adr/`.
 
-## Phase 6: Commit and Push
+## Phase 7: Commit and Push
 
 If changes were made:
 
-1. Stage only the doc files you touched: `git add docs/adr/ docs/memo/`
+1. Stage only the doc files you touched: `git add docs/adr/ docs/memo/ README.md`
 2. Commit with a descriptive message:
    - For ADR amendments: `docs(adr): update ADR NNNN with [what changed]`
    - For new ADRs: `docs(adr): add ADR NNNN [title]`
    - For memo graduation: `docs(memo): graduate memo NNNN → Superseded by ADR MMMM`
+   - For README corrections: `docs(readme): correct [what drifted]`
    - For multiple changes: `docs: audit — [summary of all changes]`
 3. Use the `/ship` skill to push via PR if available, otherwise `git push` directly
 
@@ -226,6 +254,7 @@ This skill will be called repeatedly via `/loop`. To avoid churn:
 - **Don't re-amend what you just amended.** If an ADR already has an Amendments section with today's date covering the same topic, skip it.
 - **Don't create duplicate ADRs.** Before creating a new ADR, check that no existing ADR (including any you might have created on a previous loop iteration) already covers the topic.
 - **Don't re-graduate memos.** A memo whose status is already `Superseded by ADR NNNN` or `Resolved (no action)` is done — skip it. Only `Open` memos are candidates.
+- **Don't re-correct the README.** If the README already matches the codebase, leave it untouched. Only edit a specific line when a specific fact is wrong — never reflow or rewrite prose that's already accurate.
 - **Don't commit empty changes.** If `git diff --cached` is empty after staging, skip the commit.
 - **Quick exit.** If the scan finds no drift, return a one-line status message and stop. The common case on `/loop` should take under a minute.
 
@@ -233,4 +262,4 @@ This skill will be called repeatedly via `/loop`. To avoid churn:
 
 Keep output terse — this runs unattended. Report:
 - `ADR audit: no drift detected` (happy path), or
-- `ADR audit: amended 0011 (added React Query, Leaflet); created 0014 (offline-first iOS); graduated memo 0007 → ADR 0028` (changes made)
+- `ADR audit: amended 0011 (added React Query, Leaflet); created 0014 (offline-first iOS); graduated memo 0007 → ADR 0028; corrected README (backend now Go)` (changes made)

--- a/README.md
+++ b/README.md
@@ -6,21 +6,22 @@ Town Crier is a mobile-first app for monitoring UK local authority planning appl
 
 | Component | Technology |
 |-----------|-----------|
-| Backend API | .NET 10, ASP.NET Core, Native AOT |
+| Backend API | Go (`net/http`, `log/slog`), Azure Container Apps |
 | Web Frontend | React 19, TypeScript, Vite |
 | Database | Azure Cosmos DB (Serverless) |
 | iOS App | Swift, SwiftUI, SwiftData |
-| Infrastructure | Pulumi (C# / .NET 10), Azure Container Apps |
+| Infrastructure | Pulumi (Go), Azure Container Apps |
 | CI/CD | GitHub Actions |
-| Testing | TUnit (.NET), Vitest (Web), XCTest (iOS) |
+| Testing | go test (Go), Vitest (Web), XCTest / Swift Testing (iOS) |
 
 ## Repository Structure
 
 ```plaintext
-/api          — .NET backend (Hexagonal Architecture / Ports & Adapters)
+/api-go       — Go backend: HTTP API + background worker
+/cli          — Go admin CLI (`tc`)
 /web          — React frontend (Vite, Leaflet maps, Auth0)
 /mobile/ios   — Native iOS app (MVVM-C)
-/infra        — Pulumi Infrastructure as Code
+/infra        — Pulumi Infrastructure as Code (Go)
 /docs/adr     — Architecture Decision Records
 ```
 
@@ -28,17 +29,24 @@ Town Crier is a mobile-first app for monitoring UK local authority planning appl
 
 ### Prerequisites
 
-- [.NET 10 SDK](https://dotnet.microsoft.com/download)
+- [Go 1.26](https://go.dev/dl/) (backend, CLI, and infrastructure)
 - [Node.js](https://nodejs.org/) (for web development)
 - [Xcode](https://developer.apple.com/xcode/) (for iOS development)
-- [Docker](https://www.docker.com/) (for running integration tests)
 
-### API
+### Backend API
 
 ```bash
-cd api
-dotnet build
-dotnet test
+cd api-go
+go build ./...
+go test ./...
+```
+
+### Admin CLI
+
+```bash
+cd cli
+go build ./...
+go test ./...
 ```
 
 ### Web
@@ -61,10 +69,12 @@ swift test
 
 ## Architecture
 
-Town Crier follows a **hexagonal architecture** (ports and adapters) on the backend with **CQRS** for command/query separation and **Domain-Driven Design** with rich domain models. The web frontend uses **React** with **Leaflet** for interactive maps, **Auth0** for authentication, and **React Query** for server state. The iOS app uses **MVVM-C** (Model-View-ViewModel-Coordinator) with Swift Concurrency.
+The backend is a **Go** service — an HTTP API plus a background worker — with a flat, feature-sliced layout under `internal/`, built on the standard library (`net/http`, `log/slog`) and the official Azure SDKs for Cosmos DB and Service Bus. The web frontend uses **React** with **Leaflet** for interactive maps, **Auth0** for authentication, and **React Query** for server state. The iOS app uses **MVVM-C** (Model-View-ViewModel-Coordinator) with Swift Concurrency. Infrastructure is defined with **Pulumi** in Go.
 
 Data is ingested from [PlanIt](https://www.planit.org.uk/) via a polling-based model. See the [Architecture Decision Records](docs/adr/) for detailed design rationale.
 
 ## License
 
 See [LICENSE](LICENSE) for details.
+</content>
+</invoke>

--- a/docs/adr/0001-initial-tech-stack.md
+++ b/docs/adr/0001-initial-tech-stack.md
@@ -3,7 +3,7 @@
 Date: 2026-03-16
 
 ## Status
-Accepted — backend technology choice (item 2) reversed by [ADR 0028](0028-migrate-backend-from-dotnet-to-go.md); all other choices stand.
+Accepted — the backend (item 2) and IaC (item 7) technology choices have since been reversed by [ADR 0028](0028-migrate-backend-from-dotnet-to-go.md) and [ADR 0029](0029-migrate-infrastructure-from-dotnet-to-go.md), and the admin CLI (added after this ADR, originally .NET) was migrated by [ADR 0030](0030-migrate-admin-cli-from-dotnet-to-go.md); **.NET is no longer used anywhere in the repository.** All non-.NET choices stand: iOS (Swift), Azure hosting, Cosmos DB (Serverless), the Cosmos-SDK / no-ORM data-access pattern, and GitHub Actions.
 
 ## Context
 The project "town-crier" requires a mobile application and a supporting backend API. The primary mobile platform is iOS, and the backend needs to be hosted in a cloud environment with strong enterprise support and scalability.
@@ -51,3 +51,7 @@ We will use the following technology stack for the initial prototype and develop
 ### 2026-06-18
 - Reversed (item 7, IaC): the **Pulumi infrastructure program was ported from C#/.NET to Go** (zero-diff, no resource changes). See [ADR 0029](0029-migrate-infrastructure-from-dotnet-to-go.md). The 2026-06-15 amendment above said `/infra` "remains on .NET" — that is no longer true. Pulumi is still the IaC tool, with the same stacks and Azure-native provider version (3.16.0); only the program language changed (`runtime: go`, `infra/go.mod`, no `infra/global.json`).
 - Unchanged: **`/cli` remains on .NET** and is now the only .NET component in the repo. iOS (Swift), Azure hosting, Cosmos DB (Serverless), and GitHub Actions still stand.
+
+### 2026-06-19
+- Reversed (CLI): the admin CLI (`/cli`, originally C#/.NET 10 Native AOT — added after this ADR) was **rebuilt in Go**, feature-identical. See [ADR 0030](0030-migrate-admin-cli-from-dotnet-to-go.md). The 2026-06-18 amendment's closing line — "`/cli` remains on .NET and is now the only .NET component in the repo" — no longer holds.
+- Current state: **.NET is fully removed from the repository.** The server-side stack is Go (backend, infrastructure, and CLI), with iOS (Swift) and web (TypeScript) as the only other ecosystems. No `setup-dotnet`, NuGet cache, or .NET SDK pin remains anywhere in CI or the repo. This closes the language consolidation begun by [ADR 0028](0028-migrate-backend-from-dotnet-to-go.md) and [ADR 0029](0029-migrate-infrastructure-from-dotnet-to-go.md).


### PR DESCRIPTION
## Changes

- **adr-audit skill (tc-z7gs):** Adds a Phase 5 "Audit the README" step (renumbering Write Changes → 6, Commit & Push → 7) so every sweep verifies `README.md` — tech-stack table, repo layout, build commands, architecture summary — against the codebase and corrects drift, alongside the existing ADR and memo passes. Reuses the Phase 2 scan, collects README writes with the ADR/memo writes, stages `README.md` in the commit phase, and adds a "don't re-correct an accurate README" idempotency guard.
- **README + ADR 0001 (tc-e3t2):** First run of the upgraded skill. Reconciles the stale README with the full Go consolidation (ADR 0028 backend→Go, 0029 infra→Go, 0030 cli→Go): updates the tech-stack table, repo structure (`/api-go`, `/cli`, infra=Go), prerequisites (Go 1.26), and build commands; drops the stale Docker prerequisite (Go tests use in-memory fakes, no compose); rewrites the architecture paragraph (Go backend is flat feature-sliced `internal/`, not hexagonal/CQRS/DDD). Also amends ADR 0001 — fixes its Status line ("all other choices stand" was false after 0029 reversed IaC) and adds a 2026-06-19 amendment recording cli→Go and .NET fully removed from the repo.

---
*Auto-shipped via ship skill*