### PR TITLE
feat(ios): expand wizard upsell chip to sell all paid benefits (tc-42gc)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/UnlockLargerZonesChip.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/UnlockLargerZonesChip.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 /// In-context upsell affordance surfaced beneath the radius slider when the
-/// user's tier caps their watch-zone radius below the 10 km maximum (tc-w3cb.3).
+/// user's tier caps their watch zones below the full set of paid benefits
+/// (tc-w3cb.3, tc-42gc).
 ///
 /// This is the "safe fallback" interaction from the design: a capped slider plus
 /// an explicit tappable chip, rather than a drag-past-the-cap gesture. Tapping it
@@ -9,9 +10,23 @@ import SwiftUI
 /// unlocks live. The richer "locked region on the track" gesture is an open
 /// question to be prototyped in TestFlight before release.
 ///
-/// Uses the brand amber at 15% opacity so it reads as an invitation, not an
-/// error — mirrors ``LargeRadiusWarningView``.
+/// The copy sells the whole upgrade, not just a bigger radius: bigger zones, more
+/// than one zone, and instant alerts by push and email (the free tier gets a
+/// weekly digest only). Uses the brand amber at 15% opacity so it reads as an
+/// invitation, not an error — mirrors ``LargeRadiusWarningView``.
 public struct UnlockLargerZonesChip: View {
+  /// User-facing copy, kept in one place so it can be unit-tested and reused.
+  enum Copy {
+    static let title = "Do more with a plan"
+    static let benefits =
+      "Bigger watch zones up to 10 km, more than one zone, and instant alerts by "
+      + "push and email. Free gives you a weekly digest."
+    static let accessibilityLabel =
+      "Do more with a plan. Bigger watch zones up to 10 kilometres, more than one "
+      + "watch zone, and instant alerts by push and email. Free gives you a weekly digest."
+    static let accessibilityHint = "Opens subscription plans"
+  }
+
   private let action: () -> Void
 
   public init(action: @escaping () -> Void) {
@@ -20,15 +35,22 @@ public struct UnlockLargerZonesChip: View {
 
   public var body: some View {
     Button(action: action) {
-      HStack(spacing: TCSpacing.small) {
+      HStack(alignment: .top, spacing: TCSpacing.small) {
         Image(systemName: "lock.fill")
           .font(.system(.caption))
           .foregroundStyle(Color.tcAmber)
           .accessibilityHidden(true)
 
-        Text("Unlock zones up to 10 km")
-          .font(TCTypography.bodyEmphasis)
-          .foregroundStyle(Color.tcTextPrimary)
+        VStack(alignment: .leading, spacing: TCSpacing.extraSmall) {
+          Text(Copy.title)
+            .font(TCTypography.bodyEmphasis)
+            .foregroundStyle(Color.tcTextPrimary)
+
+          Text(Copy.benefits)
+            .font(TCTypography.caption)
+            .foregroundStyle(Color.tcTextSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+        }
 
         Spacer(minLength: 0)
 
@@ -45,7 +67,7 @@ public struct UnlockLargerZonesChip: View {
       .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.small))
     }
     .buttonStyle(.plain)
-    .accessibilityLabel("Unlock larger watch zones, up to 10 kilometres")
-    .accessibilityHint("Opens subscription plans")
+    .accessibilityLabel(Copy.accessibilityLabel)
+    .accessibilityHint(Copy.accessibilityHint)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/UnlockLargerZonesChipTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/UnlockLargerZonesChipTests.swift
@@ -39,7 +39,7 @@ struct UnlockLargerZonesChipTests {
     #expect(
       UnlockLargerZonesChip.Copy.benefits
         == "Bigger watch zones up to 10 km, more than one zone, and instant alerts by "
-          + "push and email. Free gives you a weekly digest."
+        + "push and email. Free gives you a weekly digest."
     )
   }
 
@@ -49,7 +49,7 @@ struct UnlockLargerZonesChipTests {
     #expect(
       UnlockLargerZonesChip.Copy.accessibilityLabel
         == "Do more with a plan. Bigger watch zones up to 10 kilometres, more than one "
-          + "watch zone, and instant alerts by push and email. Free gives you a weekly digest."
+        + "watch zone, and instant alerts by push and email. Free gives you a weekly digest."
     )
   }
 
@@ -64,7 +64,7 @@ struct UnlockLargerZonesChipTests {
   // MARK: - View
 
   @Test func body_renders() {
-    let sut = UnlockLargerZonesChip(action: {})
+    let sut = UnlockLargerZonesChip {}
     _ = sut.body
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/UnlockLargerZonesChipTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/UnlockLargerZonesChipTests.swift
@@ -1,0 +1,70 @@
+import Testing
+
+@testable import TownCrierPresentation
+
+@MainActor
+@Suite("UnlockLargerZonesChip")
+struct UnlockLargerZonesChipTests {
+
+  // The chip sells the whole upgrade, not just a bigger radius (tc-42gc). Copy
+  // is exposed as constants so the value proposition lives in one place and can
+  // be asserted directly.
+
+  // MARK: - Title
+
+  @Test func title_invitesAnUpgrade() {
+    #expect(UnlockLargerZonesChip.Copy.title == "Do more with a plan")
+  }
+
+  // MARK: - Benefits line
+
+  @Test func benefits_coverBiggerZones() {
+    #expect(UnlockLargerZonesChip.Copy.benefits.contains("Bigger watch zones up to 10 km"))
+  }
+
+  @Test func benefits_coverMoreThanOneZone() {
+    #expect(UnlockLargerZonesChip.Copy.benefits.contains("more than one zone"))
+  }
+
+  @Test func benefits_phrasePushAndEmailAsOneAlert() {
+    // Push + email are two channels for the SAME alert, never two features.
+    #expect(UnlockLargerZonesChip.Copy.benefits.contains("instant alerts by push and email"))
+  }
+
+  @Test func benefits_clarifyTheFreeTier() {
+    #expect(UnlockLargerZonesChip.Copy.benefits.contains("Free gives you a weekly digest."))
+  }
+
+  @Test func benefits_exactWording() {
+    #expect(
+      UnlockLargerZonesChip.Copy.benefits
+        == "Bigger watch zones up to 10 km, more than one zone, and instant alerts by "
+          + "push and email. Free gives you a weekly digest."
+    )
+  }
+
+  // MARK: - Accessibility
+
+  @Test func accessibilityLabel_describesTheWholeUpgrade() {
+    #expect(
+      UnlockLargerZonesChip.Copy.accessibilityLabel
+        == "Do more with a plan. Bigger watch zones up to 10 kilometres, more than one "
+          + "watch zone, and instant alerts by push and email. Free gives you a weekly digest."
+    )
+  }
+
+  @Test func accessibilityLabel_spellsOutKilometres() {
+    #expect(UnlockLargerZonesChip.Copy.accessibilityLabel.contains("10 kilometres"))
+  }
+
+  @Test func accessibilityHint_opensPlans() {
+    #expect(UnlockLargerZonesChip.Copy.accessibilityHint == "Opens subscription plans")
+  }
+
+  // MARK: - View
+
+  @Test func body_renders() {
+    let sut = UnlockLargerZonesChip(action: {})
+    _ = sut.body
+  }
+}


### PR DESCRIPTION
## What

The onboarding wizard's upgrade chip (beneath the radius slider) read **"Unlock zones up to 10 km"**, which oversold radius as if it were the only paid benefit. Reworded and expanded so it conveys all three paid benefits:

- Bigger watch zones, up to 10 km
- More than one watch zone (free tier gets a single zone)
- Instant alerts by push and email (free tier = weekly digest only)

Push + email are framed as two channels for the **same** alert, never two features.

## Details

- Copy: title `Do more with a plan` + a benefits line, extracted into an internal `Copy` enum (mirrors `ApplicationStatus.displayLabel`) so it's unit-testable.
- Accessibility label updated to the broader value prop (km spelled out for VoiceOver); hint unchanged.
- Behaviour unchanged: still one tappable chip → same paywall `action`. Both call sites (`RadiusPickerStepView`, `WatchZoneEditorView`) untouched.
- Tokens only (TCSpacing/TCTypography/TCCornerRadius); brand amber muted background retained.

## Tests

- New `UnlockLargerZonesChipTests.swift` (10 tests): exact wording for title/benefits/a11y label, push+email-as-one-alert, free-tier clarifier, km-spelled-out, hint, body smoke render.
- swift build / swift test (1242 pass) / swiftlint --strict (0) / swift-format all green.

Bead: tc-42gc

🤖 Generated with [Claude Code](https://claude.com/claude-code)