### PR TITLE
feat(ios): add free-tier inline upsell card to Watch Zones (tc-t8hc)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneInlineUpsellCard.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneInlineUpsellCard.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+/// Richer inline upsell card shown beneath a free-tier user's single watch zone,
+/// filling the space they would otherwise see empty once they hit their one-zone
+/// limit (tc-t8hc).
+///
+/// It sells the whole plan, not just one feature: bigger zones, more than one
+/// zone, and instant alerts by push and email (the free tier gets a weekly digest
+/// only). Tapping "View Plans" opens the subscription paywall via the host's
+/// `onViewPlans` closure, which the list wires to
+/// ``WatchZoneListViewModel/viewPlans()``.
+///
+/// Visibility is gated by ``WatchZoneListViewModel/showsFreeTierUpsell`` so paid
+/// users (including a Personal user at their finite 3-zone cap) and below-cap free
+/// users never see it. Copy is shared verbatim with ``UnlockLargerZonesChip``
+/// (tc-42gc) so both surfaces speak in one voice.
+///
+/// Styling follows the design language: an elevated surface with a subtle border
+/// (cards drop the shadow in dark/OLED and use `tcBorder` instead), amber accents,
+/// and spacing/radius tokens.
+public struct WatchZoneInlineUpsellCard: View {
+  /// User-facing copy, kept in one place so it can be unit-tested and reused.
+  enum Copy {
+    static let title = "Do more with a plan"
+    static let biggerZones = "Bigger watch zones, up to 10 km"
+    static let moreThanOneZone = "More than one watch zone"
+    static let instantAlerts = "Instant alerts by push and email"
+    static let freeClarifier = "Free gives you a weekly digest."
+    static let viewPlans = "View Plans"
+    static let accessibilityLabel =
+      "Do more with a plan. Bigger watch zones, up to 10 kilometres. "
+      + "More than one watch zone. Instant alerts by push and email. "
+      + "Free gives you a weekly digest."
+    static let accessibilityHint = "Opens subscription plans"
+  }
+
+  private let onViewPlans: () -> Void
+
+  public init(onViewPlans: @escaping () -> Void) {
+    self.onViewPlans = onViewPlans
+  }
+
+  public var body: some View {
+    VStack(alignment: .leading, spacing: TCSpacing.medium) {
+      VStack(alignment: .leading, spacing: TCSpacing.small) {
+        Text(Copy.title)
+          .font(TCTypography.headline)
+          .foregroundStyle(Color.tcTextPrimary)
+
+        VStack(alignment: .leading, spacing: TCSpacing.small) {
+          benefitRow(icon: "arrow.up.left.and.arrow.down.right", text: Copy.biggerZones)
+          benefitRow(icon: "square.on.square", text: Copy.moreThanOneZone)
+          benefitRow(icon: "bell.badge", text: Copy.instantAlerts)
+        }
+
+        Text(Copy.freeClarifier)
+          .font(TCTypography.caption)
+          .foregroundStyle(Color.tcTextSecondary)
+      }
+      .accessibilityElement(children: .combine)
+      .accessibilityLabel(Copy.accessibilityLabel)
+
+      PrimaryButton(Copy.viewPlans, action: onViewPlans)
+        .accessibilityHint(Copy.accessibilityHint)
+    }
+    .padding(TCSpacing.medium)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .background(Color.tcSurfaceElevated)
+    .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+    .overlay(
+      RoundedRectangle(cornerRadius: TCCornerRadius.medium)
+        .strokeBorder(Color.tcBorder, lineWidth: 1)
+    )
+  }
+
+  private func benefitRow(icon: String, text: String) -> some View {
+    HStack(alignment: .firstTextBaseline, spacing: TCSpacing.small) {
+      Image(systemName: icon)
+        .font(.system(.body))
+        .foregroundStyle(Color.tcAmber)
+        .accessibilityHidden(true)
+      Text(text)
+        .font(TCTypography.body)
+        .foregroundStyle(Color.tcTextPrimary)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+  }
+
+  // MARK: - Test Helpers
+
+  /// Simulates tapping "View Plans" for unit testing.
+  func simulateViewPlansTap() {
+    onViewPlans()
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListView.swift
@@ -27,6 +27,22 @@ public struct WatchZoneListView: View {
           let zone = viewModel.zones[index]
           Task { await viewModel.deleteZone(zone) }
         }
+
+        if viewModel.showsFreeTierUpsell {
+          Section {
+            WatchZoneInlineUpsellCard { viewModel.viewPlans() }
+              .listRowInsets(
+                EdgeInsets(
+                  top: TCSpacing.medium,
+                  leading: TCSpacing.medium,
+                  bottom: TCSpacing.medium,
+                  trailing: TCSpacing.medium
+                )
+              )
+              .listRowBackground(Color.clear)
+              .listRowSeparator(.hidden)
+          }
+        }
       }
     }
     .navigationTitle("Watch Zones")

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneListViewModel.swift
@@ -44,6 +44,18 @@ public final class WatchZoneListViewModel: ObservableObject, ErrorHandlingViewMo
     featureGate.shouldShowUpgradeBadge(for: .watchZones, currentCount: zones.count)
   }
 
+  /// Whether to show the richer free-tier inline upsell card beneath the zone list.
+  ///
+  /// Single source of truth for that card. True only for a free-tier user who has
+  /// used their single allowed zone. Paid users never see it, including a Personal
+  /// user sitting at their finite 3-zone cap (where `showUpgradeBadge` is also true,
+  /// which is why the card must not piggyback on it). Below-cap free users see
+  /// nothing. Because tier-keyed views rebuild on `coordinator.subscriptionTier`,
+  /// the card disappears live after an in-app purchase with no extra work.
+  public var showsFreeTierUpsell: Bool {
+    featureGate.tier == .free && !canAddZone
+  }
+
   public func load() async {
     isLoading = true
     error = nil

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneInlineUpsellCardTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneInlineUpsellCardTests.swift
@@ -1,0 +1,94 @@
+import Testing
+
+@testable import TownCrierDomain
+@testable import TownCrierPresentation
+
+@MainActor
+@Suite("WatchZoneInlineUpsellCard")
+struct WatchZoneInlineUpsellCardTests {
+
+  // The inline card sells the whole upgrade beneath a free user's single zone.
+  // Copy is exposed as constants so the value proposition lives in one place and
+  // can be asserted directly, and reuses the tc-42gc wording so both surfaces
+  // speak in one voice.
+
+  // MARK: - Heading
+
+  @Test func title_invitesAnUpgrade() {
+    #expect(WatchZoneInlineUpsellCard.Copy.title == "Do more with a plan")
+  }
+
+  // MARK: - Benefit rows
+
+  @Test func benefit_biggerZones() {
+    #expect(WatchZoneInlineUpsellCard.Copy.biggerZones == "Bigger watch zones, up to 10 km")
+  }
+
+  @Test func benefit_moreThanOneZone() {
+    #expect(WatchZoneInlineUpsellCard.Copy.moreThanOneZone == "More than one watch zone")
+  }
+
+  @Test func benefit_instantAlertsAreOneAlertTwoChannels() {
+    // Push + email are two channels for the SAME alert, never two features.
+    #expect(WatchZoneInlineUpsellCard.Copy.instantAlerts == "Instant alerts by push and email")
+  }
+
+  @Test func freeClarifier_explainsTheFreeTier() {
+    #expect(WatchZoneInlineUpsellCard.Copy.freeClarifier == "Free gives you a weekly digest.")
+  }
+
+  // MARK: - CTA
+
+  @Test func viewPlans_ctaWording() {
+    #expect(WatchZoneInlineUpsellCard.Copy.viewPlans == "View Plans")
+  }
+
+  // MARK: - Accessibility
+
+  @Test func accessibilityHint_opensPlans() {
+    #expect(WatchZoneInlineUpsellCard.Copy.accessibilityHint == "Opens subscription plans")
+  }
+
+  @Test func accessibilityLabel_describesTheWholeUpgrade() {
+    let label = WatchZoneInlineUpsellCard.Copy.accessibilityLabel
+    #expect(label.contains("Do more with a plan"))
+    #expect(label.contains("Bigger watch zones, up to 10 kilometres"))
+    #expect(label.contains("More than one watch zone"))
+    #expect(label.contains("Instant alerts by push and email"))
+    #expect(label.contains("Free gives you a weekly digest."))
+  }
+
+  // MARK: - View
+
+  @Test func body_renders() {
+    let sut = WatchZoneInlineUpsellCard {}
+    _ = sut.body
+  }
+
+  // MARK: - Callback
+
+  @Test func onViewPlans_isCalled_whenViewPlansTapped() {
+    var called = false
+    let sut = WatchZoneInlineUpsellCard { called = true }
+
+    sut.simulateViewPlansTap()
+
+    #expect(called)
+  }
+
+  @Test func viewPlansTap_triggersViewModelViewPlans() async {
+    let spy = SpyWatchZoneRepository()
+    let viewModel = WatchZoneListViewModel(
+      repository: spy,
+      featureGate: FeatureGate(tier: .free)
+    )
+    var viewPlansCalled = false
+    viewModel.onViewPlans = { viewPlansCalled = true }
+    let sut = WatchZoneInlineUpsellCard { viewModel.viewPlans() }
+
+    sut.simulateViewPlansTap()
+
+    #expect(viewPlansCalled)
+    #expect(!viewModel.isUpgradePromptPresented)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewModelTests.swift
@@ -127,6 +127,73 @@ struct WatchZoneListViewModelTests {
     #expect(!sut.showUpgradeBadge)
   }
 
+  // MARK: - Free-tier inline upsell gating
+
+  // `showsFreeTierUpsell` is the single source of truth for the richer inline
+  // upsell card. It must be true ONLY for a free-tier user who has used their
+  // one allowed zone. Crucially it must NOT fire for a Personal user sitting at
+  // their finite 3-zone cap (where `showUpgradeBadge`/`!canAddZone` is also true).
+
+  @Test func showsFreeTierUpsell_freeBelowCap_returnsFalse() async {
+    let sut = WatchZoneListViewModel(
+      repository: spyRepository,
+      featureGate: FeatureGate(tier: .free)
+    )
+    spyRepository.loadAllResult = .success([])
+
+    await sut.load()
+
+    #expect(!sut.showsFreeTierUpsell)
+  }
+
+  @Test func showsFreeTierUpsell_freeAtCap_returnsTrue() async {
+    let sut = WatchZoneListViewModel(
+      repository: spyRepository,
+      featureGate: FeatureGate(tier: .free)
+    )
+    spyRepository.loadAllResult = .success([.cambridge])
+
+    await sut.load()
+
+    #expect(sut.showsFreeTierUpsell)
+  }
+
+  @Test func showsFreeTierUpsell_personalAtCap_returnsFalse() async {
+    let sut = WatchZoneListViewModel(
+      repository: spyRepository,
+      featureGate: FeatureGate(tier: .personal)
+    )
+    spyRepository.loadAllResult = .success([.cambridge, .london, .cambridge])
+
+    await sut.load()
+
+    #expect(!sut.showsFreeTierUpsell)
+  }
+
+  @Test func showsFreeTierUpsell_personalBelowCap_returnsFalse() async {
+    let sut = WatchZoneListViewModel(
+      repository: spyRepository,
+      featureGate: FeatureGate(tier: .personal)
+    )
+    spyRepository.loadAllResult = .success([.cambridge])
+
+    await sut.load()
+
+    #expect(!sut.showsFreeTierUpsell)
+  }
+
+  @Test func showsFreeTierUpsell_proWithManyZones_returnsFalse() async {
+    let sut = WatchZoneListViewModel(
+      repository: spyRepository,
+      featureGate: FeatureGate(tier: .pro)
+    )
+    spyRepository.loadAllResult = .success([.cambridge, .london])
+
+    await sut.load()
+
+    #expect(!sut.showsFreeTierUpsell)
+  }
+
   // MARK: - Feature gate exposure
 
   @Test func featureGate_exposesInjectedGate() {

--- a/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/WatchZoneListViewTests.swift
@@ -45,4 +45,29 @@ struct WatchZoneListViewTests {
     let sut = WatchZoneListView(viewModel: vm)
     _ = sut.body
   }
+
+  // Free tier at their one-zone cap: the richer inline upsell card fills the
+  // space beneath the single zone. The card itself is driven by
+  // `showsFreeTierUpsell`, asserted exhaustively in the ViewModel tests.
+  @Test func body_renders_whenFreeTierUpsellShown() async {
+    let (vm, spy) = makeViewModel(tier: .free)
+    spy.loadAllResult = .success([.cambridge])
+    await vm.load()
+
+    #expect(vm.showsFreeTierUpsell)
+
+    let sut = WatchZoneListView(viewModel: vm)
+    _ = sut.body
+  }
+
+  @Test func body_renders_whenPersonalAtCap_noFreeTierUpsell() async {
+    let (vm, spy) = makeViewModel(tier: .personal)
+    spy.loadAllResult = .success([.cambridge, .london, .cambridge])
+    await vm.load()
+
+    #expect(!vm.showsFreeTierUpsell)
+
+    let sut = WatchZoneListView(viewModel: vm)
+    _ = sut.body
+  }
 }


### PR DESCRIPTION
## What

On free tier, the Watch Zones screen showed one zone and a lot of empty space below it. This fills that space with a richer inline upsell card (more than the small add-button badge) that sells the paid benefits, with a **View Plans** CTA that opens the paywall.

## When it shows (gating)

New single-source-of-truth property `WatchZoneListViewModel.showsFreeTierUpsell`:

```swift
featureGate.tier == .free && !canAddZone
```

- free + below cap → hidden
- free + at cap (1 zone used) → **shown**
- personal at its 3-zone cap → **hidden** (regression guard: `showUpgradeBadge`/`!canAddZone` alone is true here because Personal has a finite cap, which would wrongly target a paying user)
- pro → hidden

Tier-keyed views rebuild on `coordinator.subscriptionTier`, so the card disappears live after an in-app purchase.

## Copy & styling

- Reuses the tc-42gc chip wording verbatim (one voice across both surfaces): heading "Do more with a plan"; rows "Bigger watch zones, up to 10 km" / "More than one watch zone" / "Instant alerts by push and email"; clarifier "Free gives you a weekly digest."
- Push + email framed as one alert across two channels, never two features.
- New `WatchZoneInlineUpsellCard` view; design-language card styling (tcSurfaceElevated + tcBorder, amber accents, tokens). Combined VoiceOver label + "Opens subscription plans" hint.

## Tests

- Gating (exhaustive): free+0→false, free+1→true, personal+3→false, personal below→false, pro→false.
- Card copy-string assertions + "View Plans triggers viewPlans()".
- swift build / swift test (1260 pass) / swiftlint --strict (0) all green.

Bead: tc-t8hc

🤖 Generated with [Claude Code](https://claude.com/claude-code)