### PR TITLE
fix(ios): start weekly digest day picker on Monday (UK) (tc-v7tn)

### DIFF
--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/DayOfWeek.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/DayOfWeek.swift
@@ -10,6 +10,13 @@ public enum DayOfWeek: String, CaseIterable, Codable, Equatable, Hashable, Senda
   case friday = "Friday"
   case saturday = "Saturday"
 
+  /// Display order for UK-facing pickers: the week starts on Monday.
+  /// This is presentation-only — `allCases` and `rawValue` keep the API/wire
+  /// order (Sunday-first, mirroring System.DayOfWeek) untouched.
+  public static let weekOrderUK: [DayOfWeek] = [
+    .monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday,
+  ]
+
   /// Human-readable name for display in UI (e.g. picker labels). Currently
   /// equal to `rawValue` because the API uses English day names; kept as a
   /// distinct property so the UI doesn't depend on the wire format.

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/NotificationPreferences/NotificationPreferencesView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/NotificationPreferences/NotificationPreferencesView.swift
@@ -190,7 +190,7 @@ public struct NotificationPreferencesView: View {
           }
         )
       ) {
-        ForEach(DayOfWeek.allCases, id: \.self) { day in
+        ForEach(DayOfWeek.weekOrderUK, id: \.self) { day in
           Text(day.displayName).tag(day)
         }
       }

--- a/mobile/ios/town-crier-tests/Sources/Features/DayOfWeekTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DayOfWeekTests.swift
@@ -46,4 +46,37 @@ struct DayOfWeekTests {
     #expect(DayOfWeek.friday.displayName == "Friday")
     #expect(DayOfWeek.saturday.displayName == "Saturday")
   }
+
+  // MARK: - UK display order (Monday-first)
+
+  @Test("weekOrderUK starts on Monday and ends on Sunday")
+  func weekOrderUKIsMondayFirst() {
+    #expect(
+      DayOfWeek.weekOrderUK == [
+        .monday, .tuesday, .wednesday, .thursday, .friday, .saturday, .sunday,
+      ])
+    #expect(DayOfWeek.weekOrderUK.first == .monday)
+    #expect(DayOfWeek.weekOrderUK.last == .sunday)
+  }
+
+  @Test("weekOrderUK contains all seven days with no duplicates")
+  func weekOrderUKCoversEveryDayOnce() {
+    #expect(DayOfWeek.weekOrderUK.count == 7)
+    #expect(Set(DayOfWeek.weekOrderUK) == Set(DayOfWeek.allCases))
+  }
+
+  // MARK: - Wire-contract regression guards
+
+  @Test("allCases declaration order is unchanged (Sunday-first wire order)")
+  func allCasesStillSundayFirst() {
+    #expect(DayOfWeek.allCases.first == .sunday)
+    #expect(DayOfWeek.allCases.last == .saturday)
+  }
+
+  @Test("rawValue is the English day name for every case")
+  func rawValueIsEnglishDayName() {
+    #expect(DayOfWeek.monday.rawValue == "Monday")
+    #expect(DayOfWeek.sunday.rawValue == "Sunday")
+    #expect(DayOfWeek.saturday.rawValue == "Saturday")
+  }
 }


### PR DESCRIPTION
## What

The weekly-digest day picker started on **Sunday** because `DayOfWeek.allCases` mirrors the API / `System.DayOfWeek` wire order (Sunday-first). Town Crier is a British app, so the picker now starts on **Monday**.

## How

- Added a presentation-only `DayOfWeek.weekOrderUK` array (Monday..Sunday). The enum cases and every `rawValue` are untouched, so `allCases` and the wire contract stay Sunday-first and the selected day still round-trips to the API as e.g. "Monday".
- `NotificationPreferencesView` picker iterates `weekOrderUK` instead of `allCases` (one line); same `displayName` + selection binding.

## Tests

- `weekOrderUK` is exactly `[.monday … .sunday]`; `Set(weekOrderUK) == Set(allCases)` (all 7, no dupes).
- Regression guards: `allCases.first == .sunday` / `.last == .saturday`, and each `rawValue` is its English name — proves the wire order is unchanged.
- swift build / swift test (1264 pass) / swiftlint --strict (0) all green.

Bead: tc-v7tn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Email Digest day picker to display days of the week in Monday-first order.

* **Tests**
  * Added comprehensive test coverage for day-of-week ordering to ensure reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->