### PR TITLE
fix(ios): clarify onboarding postcode can be any UK postcode (tc-rae0)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/PostcodeEntryStepView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/Steps/PostcodeEntryStepView.swift
@@ -1,21 +1,31 @@
 import SwiftUI
 
-/// Postcode entry step — user enters their postcode to set up a watch zone.
+/// Postcode entry step. The user enters any UK postcode they want to watch, not
+/// only their home address (tc-rae0).
 struct PostcodeEntryStepView: View {
+  /// User-facing copy, kept in one place so it can be unit-tested.
+  enum Copy {
+    static let title = "Pick a postcode to watch"
+    static let helper =
+      "Any UK postcode works. Your home, your work, a relative's street, or a "
+      + "site you're keeping an eye on. We'll find planning applications nearby."
+    static let placeholder = "e.g. CB1 2AD"
+  }
+
   @ObservedObject var viewModel: OnboardingViewModel
 
   var body: some View {
     VStack(spacing: TCSpacing.large) {
-      Text("Where do you live?")
+      Text(Copy.title)
         .font(TCTypography.displaySmall)
         .foregroundStyle(Color.tcTextPrimary)
 
-      Text("Enter your postcode so we can find planning applications near you.")
+      Text(Copy.helper)
         .font(TCTypography.body)
         .foregroundStyle(Color.tcTextSecondary)
         .multilineTextAlignment(.center)
 
-      TextField("e.g. CB1 2AD", text: $viewModel.postcodeInput)
+      TextField(Copy.placeholder, text: $viewModel.postcodeInput)
         .textFieldStyle(.roundedBorder)
         .autocorrectionDisabled()
         #if os(iOS)

--- a/mobile/ios/town-crier-tests/Sources/Features/PostcodeEntryStepViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/PostcodeEntryStepViewTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@MainActor
+@Suite("PostcodeEntryStepView")
+struct PostcodeEntryStepViewTests {
+
+  // The step lets the user watch ANY UK postcode, not just their home address
+  // (tc-rae0). Copy is exposed as constants so the wording lives in one place and
+  // can be asserted directly.
+
+  private func makeViewModel(tier: SubscriptionTier = .free) -> OnboardingViewModel {
+    OnboardingViewModel(
+      geocoder: SpyPostcodeGeocoder(),
+      watchZoneRepository: SpyWatchZoneRepository(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: SpyNotificationService(),
+      subscriptionTier: tier
+    )
+  }
+
+  // MARK: - Title
+
+  @Test func title_doesNotImplyHomeOnly() {
+    // The old title ("Where do you live?") implied the postcode had to be home.
+    #expect(PostcodeEntryStepView.Copy.title != "Where do you live?")
+    #expect(!PostcodeEntryStepView.Copy.title.lowercased().contains("live"))
+  }
+
+  @Test func title_exactWording() {
+    #expect(PostcodeEntryStepView.Copy.title == "Pick a postcode to watch")
+  }
+
+  // MARK: - Helper
+
+  @Test func helper_statesAnyPostcodeWorks() {
+    #expect(PostcodeEntryStepView.Copy.helper.contains("Any UK postcode"))
+  }
+
+  @Test func helper_givesConcreteExamples() {
+    let helper = PostcodeEntryStepView.Copy.helper
+    #expect(helper.contains("home"))
+    #expect(helper.contains("work"))
+    #expect(helper.contains("relative's street"))
+    #expect(helper.contains("keeping an eye on"))
+  }
+
+  @Test func helper_doesNotImplyHomeOnly() {
+    #expect(
+      PostcodeEntryStepView.Copy.helper
+        != "Enter your postcode so we can find planning applications near you."
+    )
+  }
+
+  @Test func helper_exactWording() {
+    #expect(
+      PostcodeEntryStepView.Copy.helper
+        == "Any UK postcode works. Your home, your work, a relative's street, or a "
+        + "site you're keeping an eye on. We'll find planning applications nearby."
+    )
+  }
+
+  // MARK: - Placeholder
+
+  @Test func placeholder_showsValidExamplePostcode() {
+    #expect(PostcodeEntryStepView.Copy.placeholder == "e.g. CB1 2AD")
+  }
+
+  // MARK: - View
+
+  @Test func body_renders() {
+    let sut = PostcodeEntryStepView(viewModel: makeViewModel())
+    _ = sut.body
+  }
+}


### PR DESCRIPTION
## What

The onboarding postcode step read **"Where do you live?"** with helper "Enter your postcode so we can find planning applications near you." That implied the postcode had to be the user's home. It doesn't — any UK postcode works.

## Copy

- **Title:** `Pick a postcode to watch`
- **Helper:** `Any UK postcode works. Your home, your work, a relative's street, or a site you're keeping an eye on. We'll find planning applications nearby.`
- **Placeholder:** `e.g. CB1 2AD` (unchanged)

Plain British English, concrete examples, no em dashes, no AI-tell. Only copy changed — TextField, validation, buttons, and view structure untouched. Strings extracted into a testable internal `Copy` enum (matches `UnlockLargerZonesChip` / `WatchZoneInlineUpsellCard`).

## Tests

- New `PostcodeEntryStepViewTests.swift` (8 tests): asserts the new title/helper, that neither implies home-only, and the placeholder example is unchanged.
- swift build / swift test (1272 pass) / swiftlint --strict (0) all green.

Bead: tc-rae0

🤖 Generated with [Claude Code](https://claude.com/claude-code)