### PR TITLE
chore(ios): bump MARKETING_VERSION to 1.0.2 to reopen TestFlight train

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.0.1"
+        MARKETING_VERSION: "1.0.2"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"


### PR DESCRIPTION
## Changes
- Bump `mobile/ios/project.yml` `MARKETING_VERSION` from `1.0.1` to `1.0.2`.

## Why
CD iOS TestFlight run [27862979304](https://github.com/AmyDe/town-crier/actions/runs/27862979304) failed at altool upload with a 409:
- `Invalid Pre-Release Train. The train version '1.0.1' is closed for new build submissions`
- `CFBundleShortVersionString [1.0.1] must contain a higher version than the previously approved version [1.0.1]`

App Store `1.0.1` is approved/released, which closes the `1.0.1` pre-release train. The CD beta lane bumps only the build number (now 36), so every TestFlight upload kept landing on the closed `1.0.1` train. Bumping the marketing version opens the `1.0.2` train so builds flow again. Recurring per-App-Store-version gotcha (tc-xap5).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application version from 1.0.1 to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->