### PR TITLE
ci: remove dead .NET api category from detect-changes action (tc-ifwk)

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -22,22 +22,19 @@ inputs:
     required: false
     default: ""
   categories:
-    description: "Comma-separated list of categories to detect (e.g., api,web,infra,ios)"
+    description: "Comma-separated list of categories to detect (e.g., go,web,infra,ios)"
     required: true
   trigger-files:
     description: |
       Newline-separated list of workflow files that force categories when changed.
       Format: "path:cat1,cat2,..." per line.
       Example:
-        .github/workflows/pr-gate.yml:api,ios,web,infra
-        .github/workflows/cd-dev.yml:api,web,infra
+        .github/workflows/pr-gate.yml:ios,web,infra
+        .github/workflows/cd-dev.yml:web,infra
     required: false
     default: ""
 
 outputs:
-  api:
-    description: "true if api/ changed"
-    value: ${{ steps.detect.outputs.api }}
   cli:
     description: "true if cli/ changed"
     value: ${{ steps.detect.outputs.cli }}
@@ -105,7 +102,6 @@ runs:
         while IFS= read -r file; do
           [[ -z "$file" ]] && continue
           case "$file" in
-            api/*) [[ -v "flags[api]" ]] && flags[api]=true ;;
             api-go/*) [[ -v "flags[go]" ]] && flags[go]=true ;;
             cli/*) [[ -v "flags[cli]" ]] && flags[cli]=true ;;
             mobile/ios/*) [[ -v "flags[ios]" ]] && flags[ios]=true ;;


### PR DESCRIPTION
## What

Removes the dead `.NET api` category from the `detect-changes` composite action. The `api/` directory was deleted in the .NET decommission (Phase 3); `api-go/` is the `go` category now.

Three dead references removed from `.github/actions/detect-changes/action.yml`:
- the `api:` output block
- the `api/*` path→category case branch
- stale `api,` in the trigger-files example doc

Plus a doc-only fix to the `categories` input example (`api,…` → `go,…`) so it no longer suggests a category that always resolves false.

## Why it's safe

- No workflow consumes `outputs.api` (`grep -rn "outputs\.api\b" .github/` → empty).
- `pr-gate.yml` `categories` (`cli,ios,web,infra,go`) already excludes `api`.
- Self-contained: composite action only, no behaviour change for any live category.

## Validation

- YAML parses (`yaml.safe_load`).
- `actionlint` clean of new findings (one pre-existing unrelated SC2016 info on `pr-gate.yml:350`, present on `main`).

Bead: tc-ifwk