### PR TITLE
refactor(api-go): remove dead planit Default* + platform.NewLogger constructors (tc-1sgm, tc-wa6z)

### DIFF
--- a/api-go/internal/planit/client.go
+++ b/api-go/internal/planit/client.go
@@ -80,21 +80,6 @@ type RetryOptions struct {
 	RateLimitBackoff time.Duration
 }
 
-// DefaultThrottleOptions returns the .NET default (2s between requests).
-func DefaultThrottleOptions() ThrottleOptions {
-	return ThrottleOptions{DelayBetweenRequests: 2 * time.Second}
-}
-
-// DefaultRetryOptions returns the .NET defaults (3 retries, 1s initial, 5s
-// rate-limit backoff base).
-func DefaultRetryOptions() RetryOptions {
-	return RetryOptions{
-		MaxRetries:       3,
-		InitialBackoff:   1 * time.Second,
-		RateLimitBackoff: 5 * time.Second,
-	}
-}
-
 // httpErrorRecorder is the consumer-side slice of the metrics registry the
 // client records towncrier.planit.http_errors on. *metrics.Registry satisfies
 // it; nil leaves the counter dark. The tag keys are owned by the recorder

--- a/api-go/internal/platform/logger.go
+++ b/api-go/internal/platform/logger.go
@@ -8,13 +8,6 @@ import (
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 )
 
-// NewLogger returns a JSON slog logger at the given level. Production wiring
-// passes os.Stdout; tests pass a buffer. Retained unchanged so unit tests that
-// want a plain JSON logger are unaffected by the OTel fan-out.
-func NewLogger(w io.Writer, level slog.Level) *slog.Logger {
-	return slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level}))
-}
-
 // NewOTelLogger returns a logger that fans every record out to BOTH a stdout
 // JSON handler (-> ContainerAppConsoleLogs) AND the otelslog bridge (-> OTel
 // logs -> App Insights AppTraces). tc-8x8g / ADR 0027: without the bridge the Go


### PR DESCRIPTION
## What

Deletes three dead exported constructors confirmed to have zero callers (deadcode + grep):

- **tc-1sgm** — `planit.DefaultThrottleOptions()` and `planit.DefaultRetryOptions()` (`internal/planit/client.go`). The worker wiring sets `ThrottleOptions`/`RetryOptions` values directly; these `.NET`-mirroring default constructors were never called. The `ThrottleOptions`/`RetryOptions` **types** are kept — still used by `Options`.
- **tc-wa6z** — `platform.NewLogger()` (`internal/platform/logger.go`). Zero callers; its doc comment falsely claimed tests used it. `NewOTelLogger` is the real constructor used everywhere. The `io` import stays (still used by `NewOTelLogger`).

22 lines removed, no behaviour change.

## Validation (local gate, all green)

`go build ./...`, `go vet ./...`, `go test ./...`, `gofmt -l .` (clean), `golangci-lint run ./...` (no issues).

Beads: tc-1sgm, tc-wa6z