### PR TITLE
fix(ios): parse fractional-seconds DotNetTime timestamps (tc-1gbh)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/API/DotNetTimeParser.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/DotNetTimeParser.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Parses timestamp strings emitted by the Go backend's `platform.DotNetTime`
+/// format (`2006-01-02T15:04:05.9999999-07:00`).
+///
+/// Fractional seconds appear on the wire **only** when the sub-second part is
+/// non-zero, otherwise they are omitted entirely:
+///
+/// - `2026-07-20T14:23:45.6789123+00:00` — fractional (the common case, since
+///   expiries derive from `time.Now()`).
+/// - `2026-06-12T09:30:00+00:00` — whole second, no fractional part.
+/// - `2026-06-12T09:30:00Z` — `Z` zero-offset spelling.
+///
+/// A single `ISO8601DateFormatter` cannot cover all three: `.withFractionalSeconds`
+/// rejects whole-second strings, and the default `.withInternetDateTime` rejects
+/// fractional ones. So we try fractional first, then fall back to plain. Both
+/// option sets include `.withTimeZone`, which accepts the `Z` and `+hh:mm` forms.
+///
+/// Two `ISO8601DateFormatter` instances are cached. They are configured once and
+/// never mutated afterwards, so reusing them avoids per-call allocation. The type
+/// is not `Sendable`, but `ISO8601DateFormatter` is documented as safe for
+/// concurrent use of its parsing methods once configured, and `formatOptions` is
+/// never touched after init here — hence `nonisolated(unsafe)`.
+enum DotNetTimeParser {
+  private nonisolated(unsafe) static let fractional: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter
+  }()
+
+  private nonisolated(unsafe) static let plain: ISO8601DateFormatter = {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
+    return formatter
+  }()
+
+  /// Returns the parsed `Date`, or `nil` only if BOTH the fractional and the
+  /// plain parse fail (i.e. genuinely unparseable input).
+  static func date(from string: String) -> Date? {
+    fractional.date(from: string) ?? plain.date(from: string)
+  }
+}

--- a/mobile/ios/packages/town-crier-data/Sources/OfferCodes/HttpOfferCodeService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/OfferCodes/HttpOfferCodeService.swift
@@ -26,9 +26,7 @@ public final class HttpOfferCodeService: OfferCodeService, Sendable {
       guard let tier = SubscriptionTier(rawValue: dto.tier.lowercased()) else {
         throw OfferCodeError.network("Unknown tier: \(dto.tier)")
       }
-      let formatter = ISO8601DateFormatter()
-      formatter.formatOptions = [.withInternetDateTime]
-      guard let expiresAt = formatter.date(from: dto.expiresAt) else {
+      guard let expiresAt = DotNetTimeParser.date(from: dto.expiresAt) else {
         throw OfferCodeError.network("Unparseable expiresAt: \(dto.expiresAt)")
       }
       return OfferCodeRedemption(tier: tier, expiresAt: expiresAt)

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APINotificationStateRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APINotificationStateRepository.swift
@@ -64,9 +64,10 @@ struct NotificationStateDTO: Decodable, Sendable {
   let totalUnreadCount: Int
 
   func toDomain() -> NotificationState {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime]
-    let date = formatter.date(from: lastReadAt) ?? Date(timeIntervalSince1970: 0)
+    // The backend's DotNetTime format carries fractional seconds whenever the
+    // sub-second part is non-zero; parse robustly via the shared helper. The
+    // epoch fallback is retained only for genuinely unparseable input.
+    let date = DotNetTimeParser.date(from: lastReadAt) ?? Date(timeIntervalSince1970: 0)
     return NotificationState(
       lastReadAt: date,
       version: version,

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APISavedApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APISavedApplicationRepository.swift
@@ -137,9 +137,10 @@ struct SavedApplicationDTO: Decodable, Sendable {
   let application: PlanningApplicationDTO?
 
   func toDomain() -> SavedApplication {
-    let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime]
-    let date = formatter.date(from: savedAt) ?? Date()
+    // The backend's DotNetTime format carries fractional seconds whenever the
+    // sub-second part is non-zero; parse robustly via the shared helper. The
+    // "now" fallback is retained only for genuinely unparseable input.
+    let date = DotNetTimeParser.date(from: savedAt) ?? Date()
     return SavedApplication(
       applicationUid: applicationUid,
       savedAt: date,

--- a/mobile/ios/town-crier-tests/Sources/Features/APINotificationStateRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APINotificationStateRepositoryTests.swift
@@ -87,6 +87,34 @@ struct APINotificationStateRepositoryTests {
     #expect(state.lastReadAt == expected)
   }
 
+  @Test("fetchState parses a fractional-seconds lastReadAt (not 1970)")
+  func fetchState_fractionalSecondsLastReadAt_parsesCorrectly() async throws {
+    // The Go backend emits fractional seconds when the sub-second part is
+    // non-zero. A plain .withInternetDateTime parse returns nil and used to
+    // silently substitute Date(timeIntervalSince1970: 0) — the 1970 bug
+    // (tc-ubfm), which corrupts read/unread computation.
+    let json = """
+      {
+        "lastReadAt": "2026-04-10T14:30:00.5551234Z",
+        "version": 1,
+        "totalUnreadCount": 0
+      }
+      """
+    let (sut, _, _) = makeSUT(responses: [
+      (Data(json.utf8), httpResponse(statusCode: 200))
+    ])
+
+    let state = try await sut.fetchState()
+
+    // Must NOT fall back to the epoch.
+    #expect(state.lastReadAt != Date(timeIntervalSince1970: 0))
+    let wholeSecond = try #require(
+      DotNetTimeParser.date(from: "2026-04-10T14:30:00Z")
+    )
+    #expect(state.lastReadAt.timeIntervalSince(wholeSecond) > 0.5)
+    #expect(state.lastReadAt.timeIntervalSince(wholeSecond) < 0.6)
+  }
+
   @Test("fetchState maps zero unread count")
   func fetchState_zeroUnread_mapsCorrectly() async throws {
     let json = """

--- a/mobile/ios/town-crier-tests/Sources/Features/APISavedApplicationRepositoryTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APISavedApplicationRepositoryTests.swift
@@ -201,6 +201,37 @@ struct APISavedApplicationRepositoryTests {
     #expect(result[0].application?.address == "12 Mill Road, Cambridge, CB1 2AD")
   }
 
+  @Test("loadAll parses a fractional-seconds savedAt (not now)")
+  func loadAll_fractionalSecondsSavedAt_parsesCorrectly() async throws {
+    // The Go backend emits fractional seconds when the sub-second part is
+    // non-zero. A plain .withInternetDateTime parse returns nil and used to
+    // silently substitute Date() (now) — the tc-ephy bug, which corrupts the
+    // saved-application sort/display order.
+    let json = """
+      [
+        {
+          "applicationUid": "BK/2026/0042",
+          "savedAt": "2026-04-10T14:30:00.7654321Z",
+          "application": null
+        }
+      ]
+      """
+    let (sut, _, _) = makeSUT(responses: [
+      (Data(json.utf8), httpResponse(statusCode: 200))
+    ])
+
+    let result = try await sut.loadAll()
+
+    #expect(result.count == 1)
+    // Must NOT fall back to "now".
+    #expect(abs(result[0].savedAt.timeIntervalSinceNow) > 60)
+    let wholeSecond = try #require(
+      DotNetTimeParser.date(from: "2026-04-10T14:30:00Z")
+    )
+    #expect(result[0].savedAt.timeIntervalSince(wholeSecond) > 0.7)
+    #expect(result[0].savedAt.timeIntervalSince(wholeSecond) < 0.8)
+  }
+
   @Test("loadAll returns empty array for empty response")
   func loadAll_emptyResponse() async throws {
     let json = "[]"

--- a/mobile/ios/town-crier-tests/Sources/Features/DotNetTimeParserTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DotNetTimeParserTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+
+@testable import TownCrierData
+
+/// Tests for the shared `DotNetTimeParser` that decodes the Go backend's
+/// `platform.DotNetTime` wire format (`2006-01-02T15:04:05.9999999-07:00`).
+/// Fractional seconds appear only when the sub-second part is non-zero, so a
+/// robust parser must accept both fractional and whole-second strings, plus the
+/// `Z` zero-offset spelling.
+@Suite("DotNetTimeParser")
+struct DotNetTimeParserTests {
+
+  @Test("parses a fractional-seconds timestamp")
+  func parsesFractionalSeconds() throws {
+    let parsed = try #require(
+      DotNetTimeParser.date(from: "2026-07-20T14:23:45.6789123+00:00")
+    )
+    // Truncated to whole seconds plus the fractional remainder; assert the
+    // whole-second instant is correct and the fraction is carried.
+    let expectedWholeSecond = try #require(
+      DotNetTimeParser.date(from: "2026-07-20T14:23:45+00:00")
+    )
+    #expect(parsed.timeIntervalSince(expectedWholeSecond) > 0.6)
+    #expect(parsed.timeIntervalSince(expectedWholeSecond) < 0.7)
+  }
+
+  @Test("parses a whole-second timestamp with explicit offset")
+  func parsesWholeSecondWithOffset() throws {
+    let parsed = try #require(
+      DotNetTimeParser.date(from: "2026-06-12T09:30:00+00:00")
+    )
+    let reference = ISO8601DateFormatter()
+    reference.formatOptions = [.withInternetDateTime]
+    let expected = try #require(reference.date(from: "2026-06-12T09:30:00+00:00"))
+    #expect(parsed == expected)
+  }
+
+  @Test("parses a whole-second timestamp in Z form")
+  func parsesWholeSecondZForm() throws {
+    let parsed = try #require(
+      DotNetTimeParser.date(from: "2026-06-12T09:30:00Z")
+    )
+    let reference = ISO8601DateFormatter()
+    reference.formatOptions = [.withInternetDateTime]
+    let expected = try #require(reference.date(from: "2026-06-12T09:30:00Z"))
+    #expect(parsed == expected)
+  }
+
+  @Test("parses a fractional-seconds timestamp in Z form")
+  func parsesFractionalSecondsZForm() throws {
+    let parsed = try #require(
+      DotNetTimeParser.date(from: "2026-07-20T14:23:45.5Z")
+    )
+    let expectedWholeSecond = try #require(
+      DotNetTimeParser.date(from: "2026-07-20T14:23:45Z")
+    )
+    #expect(parsed.timeIntervalSince(expectedWholeSecond) > 0.4)
+    #expect(parsed.timeIntervalSince(expectedWholeSecond) < 0.6)
+  }
+
+  @Test("returns nil on genuine garbage")
+  func returnsNilOnGarbage() {
+    #expect(DotNetTimeParser.date(from: "not a date") == nil)
+    #expect(DotNetTimeParser.date(from: "") == nil)
+    #expect(DotNetTimeParser.date(from: "2026-13-45") == nil)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/HttpOfferCodeServiceTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/HttpOfferCodeServiceTests.swift
@@ -80,6 +80,53 @@ struct HttpOfferCodeServiceTests {
     #expect(redemption.expiresAt == expected)
   }
 
+  @Test("redeem succeeds when expiresAt has fractional seconds")
+  func redeem_fractionalSecondsExpiry_succeeds() async throws {
+    // The Go backend emits fractional seconds whenever the sub-second part is
+    // non-zero (expiry = time.Now().AddDate(...)). A plain .withInternetDateTime
+    // parse returns nil on this and used to throw .network — the user-reported
+    // "Something went wrong while redeeming that code" bug (tc-1gbh).
+    let body = """
+      {
+        "tier": "pro",
+        "expiresAt": "2026-07-20T14:23:45.6789123+00:00"
+      }
+      """
+    let (sut, _) = makeSUT(responses: [
+      (Data(body.utf8), httpResponse(statusCode: 200))
+    ])
+
+    let redemption = try await sut.redeem(code: "A7KMZQR3FNXP")
+
+    #expect(redemption.tier == .pro)
+    let wholeSecond = try #require(
+      DotNetTimeParser.date(from: "2026-07-20T14:23:45+00:00")
+    )
+    #expect(redemption.expiresAt.timeIntervalSince(wholeSecond) > 0.6)
+    #expect(redemption.expiresAt.timeIntervalSince(wholeSecond) < 0.7)
+  }
+
+  @Test("redeem succeeds when expiresAt has whole seconds (no regression)")
+  func redeem_wholeSecondExpiry_succeeds() async throws {
+    let body = """
+      {
+        "tier": "pro",
+        "expiresAt": "2026-06-12T09:30:00+00:00"
+      }
+      """
+    let (sut, _) = makeSUT(responses: [
+      (Data(body.utf8), httpResponse(statusCode: 200))
+    ])
+
+    let redemption = try await sut.redeem(code: "A7KMZQR3FNXP")
+
+    #expect(redemption.tier == .pro)
+    let expected = try #require(
+      DotNetTimeParser.date(from: "2026-06-12T09:30:00+00:00")
+    )
+    #expect(redemption.expiresAt == expected)
+  }
+
   @Test("redeem throws .network when tier rawValue is unknown")
   func redeem_unknownTier_throwsNetworkError() async throws {
     let body = """


### PR DESCRIPTION
## Problem

Redeeming an offer code in the iOS app showed **"Something went wrong while redeeming that code, please try again"** on the first (successful) attempt, then "That offer code has already been used" on the second, with pro features only appearing after an app restart.

App Insights confirmed the backend succeeded: `POST /v1/offer-codes/redeem` returned **200** on the first request and **409** on the retry. The bug was entirely client-side.

## Root cause

The Go backend serialises timestamps via `platform.DotNetTime`, which emits **fractional seconds whenever the sub-second part is non-zero** (e.g. `2026-07-20T14:23:45.6789123+00:00`). Offer-code expiry derives from `time.Now()`, so it's almost always fractional. Three iOS call sites parsed these with `ISO8601DateFormatter` using `[.withInternetDateTime]` only — no `.withFractionalSeconds` — so `date(from:)` returned `nil`:

- **`HttpOfferCodeService`** (`expiresAt`) → threw `.network` → "Something went wrong" *(the reported bug)*
- **`APINotificationStateRepository`** (`lastReadAt`) → silently fell back to **1970**
- **`APISavedApplicationRepository`** (`savedAt`) → silently fell back to **now**

## Changes

- Add shared `DotNetTimeParser` helper that tries `[.withInternetDateTime, .withFractionalSeconds]` then falls back to `[.withInternetDateTime]` (handles fractional, whole-second, `+00:00` and `Z` forms; cached formatters, no per-call allocation).
- Migrate all three broken call sites to it (tc-1gbh, tc-ubfm, tc-ephy). Existing error mappings and fallbacks for genuinely unparseable input preserved.
- Swift Testing red→green coverage for the helper and each call site, including a whole-second non-regression case.
- The two already-correct two-branch sites (`HttpSubscriptionVerificationService`, `APIPlanningApplicationRepository`) left untouched.

Validation: `swift build`, `swift test` (1281 tests), `swiftlint lint --strict` all pass.

Closes tc-1gbh, tc-ubfm, tc-ephy.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp parsing to correctly preserve fractional-second precision in notification last-read timestamps, saved application dates, and offer code expiration times when processing backend responses.

* **Tests**
  * Added comprehensive test coverage for timestamp parsing accuracy, including validation of fractional-second precision handling and edge cases for various timestamp formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->