### PR TITLE
chore(ios): add App Store en-GB release notes for v0.15.29

### DIFF
--- a/mobile/ios/fastlane/metadata/en-GB/release_notes.txt
+++ b/mobile/ios/fastlane/metadata/en-GB/release_notes.txt
@@ -1,0 +1,5 @@
+Offer codes now work the first time you enter them.
+
+It's also clearer what Pro includes, both while you set up the app and when you reach the free limit on Watch Zones.
+
+Two smaller fixes: setup now makes clear you can enter any UK postcode, not just your own, and the weekly digest day picker starts the week on Monday.


### PR DESCRIPTION
## Changes
- Add `mobile/ios/fastlane/metadata/en-GB/release_notes.txt` with the App Store "What's New" copy for the build shipping after live build 35 (v0.15.25).

Copy authored via the `ios-whats-new` + `voice` skills. Covers: offer codes working first time, clearer Pro framing during setup and at the free Watch Zone limit, the onboarding postcode wording fix, and the Monday-first weekly digest day picker.

The `deliver` lane that will consume this path isn't wired up yet (tc-3eim) — this is prep. The copy was pasted into App Store Connect manually for this submission.

Closes tc-7zu2.

---
*Auto-shipped via ship skill*