### PR TITLE
feat(infra): wire site-build-key secret + SITE_BUILD_KEY env var (tc-nnte.2)

### DIFF
--- a/.github/actions/setup-pulumi-secrets/action.yml
+++ b/.github/actions/setup-pulumi-secrets/action.yml
@@ -10,6 +10,9 @@ inputs:
   admin-api-key:
     description: API key for admin endpoints
     required: true
+  site-build-key:
+    description: Build key for the gated SEO prerender endpoint
+    required: true
   auto-grant-pro-domains:
     description: Comma-separated email domains for automatic Pro tier
     required: true
@@ -32,6 +35,7 @@ runs:
       working-directory: ${{ inputs.working-directory }}
       run: |
         pulumi config set --secret adminApiKey "${{ inputs.admin-api-key }}"
+        pulumi config set --secret siteBuildKey "${{ inputs.site-build-key }}"
         pulumi config set --secret autoGrantProDomains "${{ inputs.auto-grant-pro-domains }}"
         pulumi config set --secret auth0M2mClientId "${{ inputs.auth0-m2m-client-id }}"
         pulumi config set --secret auth0M2mClientSecret "${{ inputs.auth0-m2m-client-secret }}"

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -101,6 +101,7 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
         with:
           admin-api-key: ${{ secrets.ADMIN_API_KEY }}
+          site-build-key: ${{ secrets.SITE_BUILD_KEY }}
           auto-grant-pro-domains: ${{ secrets.AUTO_GRANT_PRO_DOMAINS }}
           auth0-m2m-client-id: ${{ secrets.AUTH0_M2M_CLIENT_ID }}
           auth0-m2m-client-secret: ${{ secrets.AUTH0_M2M_CLIENT_SECRET }}

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -60,6 +60,7 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
         with:
           admin-api-key: ${{ secrets.ADMIN_API_KEY }}
+          site-build-key: ${{ secrets.SITE_BUILD_KEY }}
           auto-grant-pro-domains: ${{ secrets.AUTO_GRANT_PRO_DOMAINS }}
           auth0-m2m-client-id: ${{ secrets.AUTH0_M2M_CLIENT_ID }}
           auth0-m2m-client-secret: ${{ secrets.AUTH0_M2M_CLIENT_SECRET }}

--- a/infra/environment.go
+++ b/infra/environment.go
@@ -128,6 +128,8 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		customDomainPhase = v
 	}
 	adminAPIKey := conf.RequireSecret("adminApiKey")
+	// Build key the Go endpoint validates for the gated SEO prerender route (tc-nnte).
+	siteBuildKey := conf.RequireSecret("siteBuildKey")
 	autoGrantProDomains := conf.RequireSecret("autoGrantProDomains")
 	auth0M2mClientID := conf.RequireSecret("auth0M2mClientId")
 	auth0M2mClientSecret := conf.RequireSecret("auth0M2mClientSecret")
@@ -360,6 +362,8 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 			&app.SecretArgs{Name: pulumi.String("auto-grant-pro-domains"), Value: autoGrantProDomains},
 			// Admin key the Go X-Admin-Key gate validates for /v1/admin requests (tc-52t6).
 			&app.SecretArgs{Name: pulumi.String("admin-api-key"), Value: adminAPIKey},
+			// Build key the Go gate validates for the SEO prerender endpoint (tc-nnte).
+			&app.SecretArgs{Name: pulumi.String("site-build-key"), Value: siteBuildKey},
 		},
 	}
 	minReplicas := 0
@@ -407,6 +411,7 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 						app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_SECRET"), SecretRef: pulumi.String("auth0-m2m-client-secret")},
 						app.EnvironmentVarArgs{Name: pulumi.String("SUBSCRIPTION_AUTOGRANT_PRODOMAINS"), SecretRef: pulumi.String("auto-grant-pro-domains")},
 						app.EnvironmentVarArgs{Name: pulumi.String("ADMIN_API_KEY"), SecretRef: pulumi.String("admin-api-key")},
+						app.EnvironmentVarArgs{Name: pulumi.String("SITE_BUILD_KEY"), SecretRef: pulumi.String("site-build-key")},
 					},
 				},
 			},


### PR DESCRIPTION
Part of epic #570 (programmatic authority-level SEO pages), bead tc-nnte.2.

Wires a **dedicated** build key (separate from the admin key, least privilege) so the gated SEO prerender endpoint can be reached at build time:

- `infra/environment.go`: `conf.RequireSecret("siteBuildKey")` → container secret `site-build-key` → `SITE_BUILD_KEY` env var on the api-go container, mirroring `adminApiKey` exactly.
- `.github/actions/setup-pulumi-secrets`: new `site-build-key` input + `pulumi config set --secret siteBuildKey`.
- `cd-dev.yml` + `cd-prod.yml`: pass `secrets.SITE_BUILD_KEY` to the infra deploy's setup-pulumi-secrets step.

The `SITE_BUILD_KEY` GH Actions secret is already provisioned. Secret value never committed (set at CI time, identical to `adminApiKey`).

Validation: `go build ./... && go vet ./...` (infra) clean; `gofmt -l .` clean; `actionlint` clean on both workflows.

Note: pr-gate's infra Pulumi preview masks failures (tc-60dx), so the real validation is the cd-dev deploy after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new `site-build-key` secret configuration to deployment pipelines for both development and production environments, making it available as an application secret and environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->