### PR TITLE
feat(web): static prerender pipeline + per-authority SEO page template (tc-nnte.3)

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -20,4 +20,14 @@ export default defineConfig([
       globals: globals.browser,
     },
   },
+  {
+    // Build-time prerender scripts are plain Node ESM, not part of the app bundle.
+    files: ['scripts/**/*.mjs'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'module',
+      globals: { ...globals.node },
+    },
+  },
 ])

--- a/web/package.json
+++ b/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && node scripts/prerender-planning.mjs",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://towncrierapp.uk/sitemap.xml

--- a/web/scripts/fixtures/sample-authorities.json
+++ b/web/scripts/fixtures/sample-authorities.json
@@ -1,0 +1,71 @@
+[
+  {
+    "id": 100,
+    "name": "Basingstoke and Deane",
+    "areaType": "English District",
+    "areaName": "Basingstoke and Deane",
+    "total": 42,
+    "totalCapped": false,
+    "applications": [
+      {
+        "uid": "BDB/2026/0001",
+        "name": "26/00001/FUL",
+        "address": "12 Mill Road, Basingstoke, RG21 1AA",
+        "description": "Erection of a two-storey rear extension and associated landscaping works to an existing dwelling house.",
+        "appState": "Permitted",
+        "startDate": "2026-01-15",
+        "link": "https://planit.org.uk/planapplic/26-00001-FUL",
+        "url": "https://planning.basingstoke.gov.uk/online-applications/26-00001-FUL"
+      },
+      {
+        "uid": "BDB/2026/0002",
+        "name": "26/00002/HSE",
+        "address": "5 High Street, Basingstoke, RG21 7QN",
+        "description": "Single-storey side extension, replacement boundary wall and new vehicular access.",
+        "appState": "Rejected",
+        "startDate": "2026-02-03",
+        "link": "https://planit.org.uk/planapplic/26-00002-HSE",
+        "url": null
+      },
+      {
+        "uid": "BDB/2026/0003",
+        "name": "26/00003/LBC",
+        "address": "Old Town Hall, Market Place, Basingstoke, RG21 7PA",
+        "description": "Listed building consent for internal alterations and the installation of accessible facilities.",
+        "appState": "Undecided",
+        "startDate": "2026-02-20",
+        "link": "https://planit.org.uk/planapplic/26-00003-LBC",
+        "url": "https://planning.basingstoke.gov.uk/online-applications/26-00003-LBC"
+      }
+    ]
+  },
+  {
+    "id": 200,
+    "name": "West Sussex",
+    "areaType": "English County",
+    "areaName": "West Sussex",
+    "total": 88,
+    "totalCapped": false,
+    "applications": []
+  },
+  {
+    "id": 300,
+    "name": "Sparse Parish",
+    "areaType": "English District",
+    "areaName": "Sparse Parish",
+    "total": 4,
+    "totalCapped": false,
+    "applications": [
+      {
+        "uid": "SP/2026/0001",
+        "name": "26/0001",
+        "address": "1 The Green, Sparse Parish",
+        "description": "Single dwelling.",
+        "appState": "Undecided",
+        "startDate": "2026-01-01",
+        "link": "https://planit.org.uk/planapplic/SP-26-0001",
+        "url": null
+      }
+    ]
+  }
+]

--- a/web/scripts/lib/__tests__/area-types.test.mjs
+++ b/web/scripts/lib/__tests__/area-types.test.mjs
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  QUALIFYING_AREA_TYPES,
+  isQualifyingAreaType,
+  filterQualifyingAuthorities,
+} from '../area-types.mjs';
+
+describe('QUALIFYING_AREA_TYPES', () => {
+  it('contains exactly the nine local-planning-authority area types', () => {
+    expect([...QUALIFYING_AREA_TYPES].sort()).toEqual(
+      [
+        'Council District',
+        'English District',
+        'English Unitary Authority',
+        'London Borough',
+        'Metropolitan Borough',
+        'National Park',
+        'Northern Ireland District',
+        'Scottish Council',
+        'Welsh Principal Area',
+      ].sort(),
+    );
+  });
+});
+
+describe('isQualifyingAreaType', () => {
+  it.each([
+    'English District',
+    'English Unitary Authority',
+    'Council District',
+    'Metropolitan Borough',
+    'London Borough',
+    'Scottish Council',
+    'Welsh Principal Area',
+    'National Park',
+    'Northern Ireland District',
+  ])('includes %s', (areaType) => {
+    expect(isQualifyingAreaType(areaType)).toBe(true);
+  });
+
+  it.each([
+    'English Region',
+    'UK Nation',
+    'English County',
+    'Metropolitan County',
+    'Cross Border Area',
+    'Other Planning Entity',
+    'Crown Dependency',
+    'Crown Dependencies',
+    'Combined Planning Authority',
+  ])('excludes %s', (areaType) => {
+    expect(isQualifyingAreaType(areaType)).toBe(false);
+  });
+});
+
+describe('filterQualifyingAuthorities', () => {
+  it('keeps only authorities whose areaType qualifies', () => {
+    const input = [
+      { id: 1, name: 'Adur', areaType: 'English District' },
+      { id: 2, name: 'West Sussex', areaType: 'English County' },
+      { id: 3, name: 'Cardiff', areaType: 'Welsh Principal Area' },
+      { id: 4, name: 'Greater London', areaType: 'English Region' },
+    ];
+
+    expect(filterQualifyingAuthorities(input)).toEqual([
+      { id: 1, name: 'Adur', areaType: 'English District' },
+      { id: 3, name: 'Cardiff', areaType: 'Welsh Principal Area' },
+    ]);
+  });
+});

--- a/web/scripts/lib/__tests__/coverage-gate.test.mjs
+++ b/web/scripts/lib/__tests__/coverage-gate.test.mjs
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { COVERAGE_THRESHOLD, meetsCoverageGate } from '../coverage-gate.mjs';
+
+describe('coverage gate', () => {
+  it('publishes when total meets the threshold', () => {
+    expect(meetsCoverageGate(COVERAGE_THRESHOLD)).toBe(true);
+  });
+
+  it('publishes when total exceeds the threshold', () => {
+    expect(meetsCoverageGate(200)).toBe(true);
+  });
+
+  it('skips when total is one below the threshold', () => {
+    expect(meetsCoverageGate(COVERAGE_THRESHOLD - 1)).toBe(false);
+  });
+
+  it('skips an authority with no applications', () => {
+    expect(meetsCoverageGate(0)).toBe(false);
+  });
+
+  it('uses a threshold of ten', () => {
+    expect(COVERAGE_THRESHOLD).toBe(10);
+  });
+});

--- a/web/scripts/lib/__tests__/format.test.mjs
+++ b/web/scripts/lib/__tests__/format.test.mjs
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import {
+  escapeHtml,
+  truncate,
+  formatDate,
+  statusDisplayLabel,
+  countByState,
+  leadLine,
+} from '../format.mjs';
+
+describe('escapeHtml', () => {
+  it('escapes the characters that would break out of HTML/attribute context', () => {
+    expect(escapeHtml(`<script>"a" & 'b'`)).toBe(
+      '&lt;script&gt;&quot;a&quot; &amp; &#39;b&#39;',
+    );
+  });
+
+  it('coerces null and undefined to an empty string', () => {
+    expect(escapeHtml(null)).toBe('');
+    expect(escapeHtml(undefined)).toBe('');
+  });
+});
+
+describe('truncate', () => {
+  it('returns short text unchanged', () => {
+    expect(truncate('short', 160)).toBe('short');
+  });
+
+  it('cuts long text and appends an ellipsis', () => {
+    const long = 'a'.repeat(200);
+    const result = truncate(long, 160);
+    expect(result.length).toBe(161);
+    expect(result.endsWith('…')).toBe(true);
+  });
+
+  it('treats null as empty', () => {
+    expect(truncate(null, 160)).toBe('');
+  });
+});
+
+describe('formatDate', () => {
+  it('renders a yyyy-MM-dd date in en-GB short form', () => {
+    expect(formatDate('2026-01-15')).toBe('15 Jan 2026');
+  });
+
+  it('returns empty for a null date', () => {
+    expect(formatDate(null)).toBe('');
+  });
+});
+
+describe('statusDisplayLabel', () => {
+  it('translates PlanIt wire states to resident-facing labels', () => {
+    expect(statusDisplayLabel('Permitted')).toBe('Granted');
+    expect(statusDisplayLabel('Conditions')).toBe('Granted with conditions');
+    expect(statusDisplayLabel('Rejected')).toBe('Refused');
+  });
+
+  it('passes unknown states through unchanged', () => {
+    expect(statusDisplayLabel('Undecided')).toBe('Undecided');
+  });
+
+  it('labels a null state as Unknown', () => {
+    expect(statusDisplayLabel(null)).toBe('Unknown');
+  });
+});
+
+describe('countByState', () => {
+  it('counts applications by display label, most common first', () => {
+    const apps = [
+      { appState: 'Permitted' },
+      { appState: 'Permitted' },
+      { appState: 'Rejected' },
+      { appState: null },
+    ];
+
+    expect(countByState(apps)).toEqual([
+      { label: 'Granted', count: 2 },
+      { label: 'Refused', count: 1 },
+      { label: 'Unknown', count: 1 },
+    ]);
+  });
+});
+
+describe('leadLine', () => {
+  it('shows the exact total when the read was not capped', () => {
+    expect(leadLine('Adur', 42, false)).toContain('42');
+    expect(leadLine('Adur', 42, false)).toContain('Adur');
+  });
+
+  it('shows a capped count as "<total>+" when the read hit the cap', () => {
+    expect(leadLine('Leeds', 200, true)).toContain('200+');
+  });
+
+  it('uses the singular noun for a single application', () => {
+    expect(leadLine('Tiny', 1, false)).toContain('1 recent planning application ');
+  });
+});

--- a/web/scripts/lib/__tests__/prerender.test.mjs
+++ b/web/scripts/lib/__tests__/prerender.test.mjs
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runPrerender } from '../../prerender-planning.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = join(here, '..', '..', 'fixtures', 'sample-authorities.json');
+
+/** Hand-written fetch stub — no vi.fn / vi.mock. */
+class StubFetch {
+  /** @param {(url: string, init?: object) => { ok: boolean, status: number, body: unknown }} handler */
+  constructor(handler) {
+    this.calls = [];
+    this.handler = handler;
+  }
+
+  fetch = async (url, init) => {
+    this.calls.push({ url: String(url), init });
+    const { ok, status, body } = this.handler(String(url), init);
+    return { ok, status, json: async () => body };
+  };
+}
+
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+let outDir;
+
+beforeEach(async () => {
+  outDir = await mkdtemp(join(tmpdir(), 'prerender-'));
+});
+
+afterEach(async () => {
+  await rm(outDir, { recursive: true, force: true });
+});
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('runPrerender — fixture mode', () => {
+  it('publishes only qualifying, gated authorities and writes their index.html', async () => {
+    const result = await runPrerender({
+      outDir,
+      fixturePath: FIXTURE,
+      logger: silentLogger,
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.published).toEqual(['basingstoke-and-deane']);
+
+    const html = await readFile(
+      join(outDir, 'planning', 'basingstoke-and-deane', 'index.html'),
+      'utf-8',
+    );
+    expect(html).toContain(
+      '<h1>Planning applications in Basingstoke and Deane</h1>',
+    );
+    expect(html).toContain('PlanIt');
+    expect(html).toContain('Get push alerts for Basingstoke and Deane');
+  });
+
+  it('excludes a non-qualifying areaType (English County) and a below-gate authority', async () => {
+    const result = await runPrerender({
+      outDir,
+      fixturePath: FIXTURE,
+      logger: silentLogger,
+    });
+
+    expect(await exists(join(outDir, 'planning', 'west-sussex'))).toBe(false);
+    expect(await exists(join(outDir, 'planning', 'sparse-parish'))).toBe(false);
+    expect(result.excluded.map((e) => e.name).sort()).toEqual([
+      'Sparse Parish',
+      'West Sussex',
+    ]);
+  });
+
+  it('writes a sitemap.xml listing the published pages', async () => {
+    await runPrerender({ outDir, fixturePath: FIXTURE, logger: silentLogger });
+    const sitemap = await readFile(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain(
+      '<loc>https://towncrierapp.uk/planning/basingstoke-and-deane</loc>',
+    );
+    expect(sitemap).not.toContain('west-sussex');
+  });
+});
+
+describe('runPrerender — no key, no fixture', () => {
+  it('skips gracefully and writes nothing', async () => {
+    const result = await runPrerender({
+      outDir,
+      apiBase: undefined,
+      buildKey: undefined,
+      fixturePath: undefined,
+      logger: silentLogger,
+    });
+
+    expect(result.skipped).toBe(true);
+    expect(result.published).toEqual([]);
+    expect(await exists(join(outDir, 'planning'))).toBe(false);
+    expect(await exists(join(outDir, 'sitemap.xml'))).toBe(false);
+  });
+});
+
+describe('runPrerender — live mode', () => {
+  function authoritiesBody(items) {
+    return { authorities: items, total: items.length };
+  }
+
+  it('fetches the gated endpoint with X-Build-Key and publishes gated authorities only', async () => {
+    const stub = new StubFetch((url) => {
+      if (url.endsWith('/v1/authorities')) {
+        return {
+          ok: true,
+          status: 200,
+          body: authoritiesBody([
+            { id: 1, name: 'Adur', areaType: 'English District' },
+            { id: 2, name: 'West Sussex', areaType: 'English County' },
+          ]),
+        };
+      }
+      if (url.includes('/v1/authorities/1/applications')) {
+        return {
+          ok: true,
+          status: 200,
+          body: {
+            authorityId: 1,
+            areaName: 'Adur',
+            applications: [
+              {
+                uid: 'A1',
+                name: '26/0001',
+                address: '1 Sea Road',
+                description: 'Extension',
+                appState: 'Permitted',
+                startDate: '2026-01-10',
+                link: 'https://planit.org.uk/planapplic/A1',
+                url: null,
+              },
+            ],
+            total: 12,
+            totalCapped: false,
+          },
+        };
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      logger: silentLogger,
+    });
+
+    expect(result.published).toEqual(['adur']);
+
+    // West Sussex (English County) must never trigger an applications fetch.
+    const appsCalls = stub.calls.filter((c) =>
+      c.url.includes('/applications'),
+    );
+    expect(appsCalls).toHaveLength(1);
+    expect(appsCalls[0].url).toContain('/v1/authorities/1/applications');
+    expect(appsCalls[0].url).toContain('limit=30');
+    expect(appsCalls[0].init.headers['X-Build-Key']).toBe('test-key');
+
+    const html = await readFile(
+      join(outDir, 'planning', 'adur', 'index.html'),
+      'utf-8',
+    );
+    expect(html).toContain('<h1>Planning applications in Adur</h1>');
+  });
+
+  it('excludes a qualifying authority that fails the coverage gate', async () => {
+    const stub = new StubFetch((url) => {
+      if (url.endsWith('/v1/authorities')) {
+        return {
+          ok: true,
+          status: 200,
+          body: authoritiesBody([
+            { id: 1, name: 'Adur', areaType: 'English District' },
+          ]),
+        };
+      }
+      return {
+        ok: true,
+        status: 200,
+        body: {
+          authorityId: 1,
+          areaName: 'Adur',
+          applications: [],
+          total: 5,
+          totalCapped: false,
+        },
+      };
+    });
+
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      logger: silentLogger,
+    });
+
+    expect(result.published).toEqual([]);
+    expect(await exists(join(outDir, 'planning', 'adur'))).toBe(false);
+  });
+
+  it('treats zero qualifying authorities as a valid (non-error) build', async () => {
+    const stub = new StubFetch(() => ({
+      ok: true,
+      status: 200,
+      body: authoritiesBody([
+        { id: 9, name: 'Surrey', areaType: 'English County' },
+      ]),
+    }));
+
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      logger: silentLogger,
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.published).toEqual([]);
+  });
+
+  it('fails loud when the authorities endpoint returns a non-OK status', async () => {
+    const stub = new StubFetch(() => ({ ok: false, status: 500, body: {} }));
+    await expect(
+      runPrerender({
+        outDir,
+        apiBase: 'https://api-dev.towncrierapp.uk',
+        buildKey: 'test-key',
+        fetchImpl: stub.fetch,
+        logger: silentLogger,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('fails loud when the applications endpoint returns an unexpected shape', async () => {
+    const stub = new StubFetch((url) => {
+      if (url.endsWith('/v1/authorities')) {
+        return {
+          ok: true,
+          status: 200,
+          body: authoritiesBody([
+            { id: 1, name: 'Adur', areaType: 'English District' },
+          ]),
+        };
+      }
+      return { ok: true, status: 200, body: { not: 'what we expect' } };
+    });
+
+    await expect(
+      runPrerender({
+        outDir,
+        apiBase: 'https://api-dev.towncrierapp.uk',
+        buildKey: 'test-key',
+        fetchImpl: stub.fetch,
+        logger: silentLogger,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('fails loud when a build key is set but no API base is configured', async () => {
+    await expect(
+      runPrerender({
+        outDir,
+        apiBase: undefined,
+        buildKey: 'test-key',
+        logger: silentLogger,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { renderPlanningPage } from '../render-page.mjs';
+import { APP_DOWNLOAD_URL, SITE_ORIGIN } from '../constants.mjs';
+
+/**
+ * @param {Partial<import('../render-page.mjs').PlanningPageData>} [overrides]
+ * @returns {import('../render-page.mjs').PlanningPageData}
+ */
+function pageData(overrides = {}) {
+  return {
+    slug: 'basingstoke-and-deane',
+    areaName: 'Basingstoke and Deane',
+    authorityId: 100,
+    total: 42,
+    totalCapped: false,
+    applications: [
+      {
+        uid: 'BDB/2026/0001',
+        name: '26/0001/FUL',
+        address: '12 Mill Road, Basingstoke, RG21 1AA',
+        description: 'Erection of two-storey rear extension',
+        appState: 'Permitted',
+        startDate: '2026-01-15',
+        link: 'https://planit.org.uk/planapplic/26-0001-FUL',
+        url: 'https://www.basingstoke.gov.uk/planning/26-0001-FUL',
+      },
+      {
+        uid: 'BDB/2026/0002',
+        name: '26/0002/HSE',
+        address: '5 High Street, Basingstoke, RG21 7QN',
+        description: 'Single-storey side extension and new boundary wall',
+        appState: 'Rejected',
+        startDate: '2026-02-03',
+        link: 'https://planit.org.uk/planapplic/26-0002-HSE',
+        url: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('renderPlanningPage', () => {
+  it('is a complete HTML document with the lang attribute', () => {
+    const html = renderPlanningPage(pageData());
+    expect(html.startsWith('<!doctype html>')).toBe(true);
+    expect(html).toContain('<html lang="en">');
+  });
+
+  it('renders the area H1', () => {
+    const html = renderPlanningPage(pageData());
+    expect(html).toContain(
+      '<h1>Planning applications in Basingstoke and Deane</h1>',
+    );
+  });
+
+  it('includes a canonical link to the towncrierapp.uk slug', () => {
+    const html = renderPlanningPage(pageData());
+    expect(html).toContain(
+      `<link rel="canonical" href="${SITE_ORIGIN}/planning/basingstoke-and-deane"`,
+    );
+  });
+
+  it('includes Open Graph tags', () => {
+    const html = renderPlanningPage(pageData());
+    expect(html).toContain('property="og:title"');
+    expect(html).toContain('property="og:type"');
+    expect(html).toContain(
+      `property="og:url" content="${SITE_ORIGIN}/planning/basingstoke-and-deane"`,
+    );
+  });
+
+  it('embeds schema.org ItemList JSON-LD', () => {
+    const html = renderPlanningPage(pageData());
+    expect(html).toContain('application/ld+json');
+    expect(html).toContain('"@type":"ItemList"');
+  });
+
+  it('renders each application address, status label, date and links', () => {
+    const html = renderPlanningPage(pageData());
+    expect(html).toContain('12 Mill Road, Basingstoke, RG21 1AA');
+    expect(html).toContain('Erection of two-storey rear extension');
+    expect(html).toContain('Granted'); // Permitted -> Granted
+    expect(html).toContain('Refused'); // Rejected -> Refused
+    expect(html).toContain('15 Jan 2026');
+    expect(html).toContain(
+      'https://www.basingstoke.gov.uk/planning/26-0001-FUL',
+    );
+    expect(html).toContain('https://planit.org.uk/planapplic/26-0001-FUL');
+  });
+
+  it('shows the exact total in the lead line when not capped', () => {
+    const html = renderPlanningPage(pageData({ total: 42, totalCapped: false }));
+    expect(html).toContain('42');
+  });
+
+  it('shows a capped count as "200+" when the read hit the cap', () => {
+    const html = renderPlanningPage(
+      pageData({ total: 200, totalCapped: true }),
+    );
+    expect(html).toContain('200+');
+  });
+
+  it('renders a stats block with counts by status', () => {
+    const html = renderPlanningPage(pageData());
+    expect(html).toMatch(/Granted[\s\S]*?1/);
+  });
+
+  it('includes the evergreen how-to-comment explainer for the area', () => {
+    const html = renderPlanningPage(pageData());
+    expect(html).toContain(
+      'How to comment on a planning application in Basingstoke and Deane',
+    );
+  });
+
+  it('includes a CTA to the App Store for the area', () => {
+    const html = renderPlanningPage(pageData());
+    expect(html).toContain('Get push alerts for Basingstoke and Deane');
+    expect(html).toContain(APP_DOWNLOAD_URL);
+  });
+
+  it('carries the mandatory PlanIt + OGL + OS + OSM attribution', () => {
+    const html = renderPlanningPage(pageData());
+    expect(html).toContain('PlanIt');
+    expect(html).toContain('Open Government Licence');
+    expect(html).toContain('Ordnance Survey');
+    expect(html).toContain('OpenStreetMap');
+  });
+
+  it('escapes HTML in application fields to prevent markup injection', () => {
+    const html = renderPlanningPage(
+      pageData({
+        applications: [
+          {
+            uid: 'x',
+            name: 'x',
+            address: '<script>alert(1)</script>',
+            description: 'safe',
+            appState: 'Permitted',
+            startDate: null,
+            link: null,
+            url: null,
+          },
+        ],
+        total: 12,
+      }),
+    );
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+});

--- a/web/scripts/lib/__tests__/render-sitemap.test.mjs
+++ b/web/scripts/lib/__tests__/render-sitemap.test.mjs
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { renderSitemap } from '../render-sitemap.mjs';
+import { SITE_ORIGIN } from '../constants.mjs';
+
+describe('renderSitemap', () => {
+  it('opens with the XML declaration and urlset envelope', () => {
+    const xml = renderSitemap(['adur']);
+    expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+    expect(xml).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    );
+    expect(xml.trimEnd().endsWith('</urlset>')).toBe(true);
+  });
+
+  it('emits one absolute canonical loc per slug', () => {
+    const xml = renderSitemap(['adur', 'basingstoke-and-deane']);
+    expect(xml).toContain(`<loc>${SITE_ORIGIN}/planning/adur</loc>`);
+    expect(xml).toContain(
+      `<loc>${SITE_ORIGIN}/planning/basingstoke-and-deane</loc>`,
+    );
+    const urlCount = (xml.match(/<url>/g) ?? []).length;
+    expect(urlCount).toBe(2);
+  });
+
+  it('produces a valid empty urlset for zero slugs', () => {
+    const xml = renderSitemap([]);
+    expect(xml).toContain('<urlset');
+    expect((xml.match(/<url>/g) ?? []).length).toBe(0);
+  });
+});

--- a/web/scripts/lib/__tests__/slug.test.mjs
+++ b/web/scripts/lib/__tests__/slug.test.mjs
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { slugify } from '../slug.mjs';
+
+describe('slugify', () => {
+  it('lowercases and hyphenates a multi-word authority name', () => {
+    expect(slugify('Basingstoke and Deane')).toBe('basingstoke-and-deane');
+  });
+
+  it('drops commas and other punctuation', () => {
+    expect(slugify('Bristol, City of')).toBe('bristol-city-of');
+  });
+
+  it('strips apostrophes rather than turning them into hyphens', () => {
+    expect(slugify("King's Lynn and West Norfolk")).toBe(
+      'kings-lynn-and-west-norfolk',
+    );
+  });
+
+  it('expands ampersands to "and"', () => {
+    expect(slugify('Hammersmith & Fulham')).toBe('hammersmith-and-fulham');
+  });
+
+  it('collapses runs of whitespace and trims edges', () => {
+    expect(slugify('  Test   Name  ')).toBe('test-name');
+  });
+
+  it('collapses a slash in a bilingual name to a single hyphen', () => {
+    expect(slugify('Bro Morgannwg / Vale of Glamorgan')).toBe(
+      'bro-morgannwg-vale-of-glamorgan',
+    );
+  });
+});

--- a/web/scripts/lib/area-types.mjs
+++ b/web/scripts/lib/area-types.mjs
@@ -1,0 +1,38 @@
+/**
+ * The PlanIt `areaType` values that map 1:1 to a UK local planning authority
+ * and therefore qualify for an SEO page. The excluded set (English County,
+ * English Region, Metropolitan County, UK Nation, Combined Planning Authority,
+ * Cross Border Area, Other Planning Entity, Crown Dependency/Dependencies) are
+ * aggregates or overlap their constituent districts and would create
+ * duplicate/competing pages. See issue #570 "Pre-Resolved Design Decisions".
+ *
+ * @type {ReadonlySet<string>}
+ */
+export const QUALIFYING_AREA_TYPES = new Set([
+  'English District',
+  'English Unitary Authority',
+  'Council District',
+  'Metropolitan Borough',
+  'London Borough',
+  'Scottish Council',
+  'Welsh Principal Area',
+  'National Park',
+  'Northern Ireland District',
+]);
+
+/**
+ * @param {string} areaType
+ * @returns {boolean}
+ */
+export function isQualifyingAreaType(areaType) {
+  return QUALIFYING_AREA_TYPES.has(areaType);
+}
+
+/**
+ * @template {{ areaType: string }} T
+ * @param {readonly T[]} authorities
+ * @returns {T[]}
+ */
+export function filterQualifyingAuthorities(authorities) {
+  return authorities.filter((a) => isQualifyingAreaType(a.areaType));
+}

--- a/web/scripts/lib/constants.mjs
+++ b/web/scripts/lib/constants.mjs
@@ -1,0 +1,28 @@
+/**
+ * Canonical origin for the public marketing/SEO site. Every generated page,
+ * canonical link, OG url and sitemap entry is anchored here.
+ * @type {string}
+ */
+export const SITE_ORIGIN = 'https://towncrierapp.uk';
+
+/**
+ * Public App Store listing for the iOS app. Mirrors `src/config/links.ts`
+ * (`APP_DOWNLOAD_URL`) — kept in lockstep by the drift-guard test in
+ * `src/__tests__/planning-cta-link.test.ts`, because this build-time `.mjs`
+ * script cannot import the app's TypeScript modules at runtime.
+ * @type {string}
+ */
+export const APP_DOWNLOAD_URL =
+  'https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657';
+
+/**
+ * Mandatory data attribution lines (ADR 0006). Byte-for-byte the same copy the
+ * app shows on its Settings → Attribution panel. Required on every public page.
+ * @type {readonly string[]}
+ */
+export const ATTRIBUTION_LINES = [
+  'Planning data provided by PlanIt (planit.org.uk)',
+  'Contains public sector information licensed under the Open Government Licence. Crown Copyright.',
+  'Contains Ordnance Survey data © Crown Copyright and database right.',
+  'Map data © OpenStreetMap contributors.',
+];

--- a/web/scripts/lib/coverage-gate.mjs
+++ b/web/scripts/lib/coverage-gate.mjs
@@ -1,0 +1,22 @@
+/**
+ * Minimum number of recent applications an authority must have before we
+ * publish a page for it. Guards against thin, auto-generated content that
+ * Google's helpful-content system penalises.
+ *
+ * This is the implementable realisation of issue #570's "≥10 in the last
+ * 90 days" intent: the slim SEO DTO does not expose `lastDifferent`, so the
+ * `total` from the bounded most-recently-active read is the faithful proxy.
+ * Strict 90-day windowing would need `lastDifferent` added to the DTO — a
+ * future tweak, deliberately not built here.
+ *
+ * @type {number}
+ */
+export const COVERAGE_THRESHOLD = 10;
+
+/**
+ * @param {number} total count from the bounded recent-applications read
+ * @returns {boolean} whether the authority clears the coverage gate
+ */
+export function meetsCoverageGate(total) {
+  return total >= COVERAGE_THRESHOLD;
+}

--- a/web/scripts/lib/format.mjs
+++ b/web/scripts/lib/format.mjs
@@ -1,0 +1,127 @@
+/**
+ * Formatting helpers shared by the planning-page renderer. All output is
+ * destined for raw HTML, so callers MUST pass user/data-derived strings through
+ * `escapeHtml` before interpolating them into markup.
+ */
+
+/**
+ * Escape the five characters that can break out of HTML element or
+ * double-quoted attribute context. Null/undefined coerce to an empty string.
+ *
+ * @param {string | null | undefined} value
+ * @returns {string}
+ */
+export function escapeHtml(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Truncate text to `maxLength` characters, appending a single ellipsis when
+ * cut. Null/undefined coerce to an empty string.
+ *
+ * @param {string | null | undefined} text
+ * @param {number} maxLength
+ * @returns {string}
+ */
+export function truncate(text, maxLength) {
+  if (text === null || text === undefined) {
+    return '';
+  }
+  if (text.length <= maxLength) {
+    return text;
+  }
+  return text.slice(0, maxLength) + '…';
+}
+
+/**
+ * Render a `yyyy-MM-dd` calendar date as en-GB short form ("15 Jan 2026").
+ * Null/undefined or unparseable input yields an empty string.
+ *
+ * @param {string | null | undefined} isoDate
+ * @returns {string}
+ */
+export function formatDate(isoDate) {
+  if (isoDate === null || isoDate === undefined || isoDate === '') {
+    return '';
+  }
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return date.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC',
+  });
+}
+
+const STATUS_DISPLAY_LABEL_MAP = {
+  Permitted: 'Granted',
+  Conditions: 'Granted with conditions',
+  Rejected: 'Refused',
+};
+
+/**
+ * Translate a PlanIt `app_state` wire string into the resident-facing label.
+ * Mirrors `src/utils/formatting.ts`. Null maps to "Unknown"; unknown states
+ * pass through unchanged.
+ *
+ * @param {string | null | undefined} appState
+ * @returns {string}
+ */
+export function statusDisplayLabel(appState) {
+  if (appState === null || appState === undefined || appState === '') {
+    return 'Unknown';
+  }
+  return STATUS_DISPLAY_LABEL_MAP[appState] ?? appState;
+}
+
+/**
+ * @typedef {{ label: string, count: number }} StateCount
+ */
+
+/**
+ * Count applications by resident-facing status label, most common first then
+ * alphabetical for a stable order.
+ *
+ * @param {ReadonlyArray<{ appState: string | null | undefined }>} applications
+ * @returns {StateCount[]}
+ */
+export function countByState(applications) {
+  /** @type {Map<string, number>} */
+  const counts = new Map();
+  for (const app of applications) {
+    const label = statusDisplayLabel(app.appState);
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+}
+
+/**
+ * Build the data-filled lead sentence under the H1. Uses "<total>+" when the
+ * bounded read hit its cap, otherwise the exact total with the right plural.
+ *
+ * @param {string} areaName
+ * @param {number} total
+ * @param {boolean} totalCapped
+ * @returns {string}
+ */
+export function leadLine(areaName, total, totalCapped) {
+  const countPhrase = totalCapped ? `${total}+` : `${total}`;
+  const noun =
+    !totalCapped && total === 1
+      ? 'recent planning application'
+      : 'recent planning applications';
+  return `Town Crier is tracking ${countPhrase} ${noun} in ${areaName}.`;
+}

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -1,0 +1,389 @@
+import {
+  SITE_ORIGIN,
+  APP_DOWNLOAD_URL,
+  ATTRIBUTION_LINES,
+} from './constants.mjs';
+import {
+  escapeHtml,
+  truncate,
+  formatDate,
+  statusDisplayLabel,
+  countByState,
+  leadLine,
+} from './format.mjs';
+
+/**
+ * @typedef {Object} PlanningApplicationItem
+ * @property {string} uid
+ * @property {string} name
+ * @property {string} address
+ * @property {string} description
+ * @property {string | null} appState
+ * @property {string | null} startDate  yyyy-MM-dd
+ * @property {string | null} link       council-portal deep link
+ * @property {string | null} url        application detail link
+ */
+
+/**
+ * @typedef {Object} PlanningPageData
+ * @property {string} slug
+ * @property {string} areaName
+ * @property {number} authorityId
+ * @property {number} total
+ * @property {boolean} totalCapped
+ * @property {PlanningApplicationItem[]} applications
+ */
+
+const MAX_DESCRIPTION_LENGTH = 160;
+
+const STATUS_MODIFIER = {
+  Permitted: 'permitted',
+  Conditions: 'conditions',
+  Rejected: 'rejected',
+  Withdrawn: 'withdrawn',
+  Appealed: 'appealed',
+};
+
+/**
+ * @param {string | null} appState
+ * @returns {string}
+ */
+function statusModifier(appState) {
+  if (appState === null || appState === undefined) {
+    return 'default';
+  }
+  return STATUS_MODIFIER[appState] ?? 'default';
+}
+
+/**
+ * @param {PlanningApplicationItem} app
+ * @returns {string}
+ */
+function renderApplication(app) {
+  const label = escapeHtml(statusDisplayLabel(app.appState));
+  const modifier = statusModifier(app.appState);
+  const date = formatDate(app.startDate);
+  const description = escapeHtml(truncate(app.description, MAX_DESCRIPTION_LENGTH));
+
+  const links = [];
+  if (app.link) {
+    links.push(
+      `<a class="appLink" href="${escapeHtml(app.link)}" rel="nofollow noopener" target="_blank">View on the council portal</a>`,
+    );
+  }
+  if (app.url) {
+    links.push(
+      `<a class="appLink" href="${escapeHtml(app.url)}" rel="nofollow noopener" target="_blank">Application details</a>`,
+    );
+  }
+
+  return `      <li class="appCard">
+        <div class="appCard__head">
+          <h3 class="appCard__ref">${escapeHtml(app.name)}</h3>
+          <span class="status status--${modifier}">${label}</span>
+        </div>
+        <p class="appCard__address">${escapeHtml(app.address)}</p>
+        <p class="appCard__desc">${description}</p>
+        <div class="appCard__meta">
+          ${date ? `<span class="appCard__date">${escapeHtml(date)}</span>` : ''}
+          ${links.join('\n          ')}
+        </div>
+      </li>`;
+}
+
+/**
+ * @param {PlanningApplicationItem[]} applications
+ * @returns {string}
+ */
+function renderStats(applications) {
+  const rows = countByState(applications)
+    .map(
+      (s) =>
+        `        <li class="statRow"><span class="statRow__label">${escapeHtml(s.label)}</span><span class="statRow__count">${s.count}</span></li>`,
+    )
+    .join('\n');
+  return `    <section class="stats" aria-label="Application status breakdown">
+      <h2 class="stats__heading">Status breakdown</h2>
+      <ul class="statList">
+${rows}
+      </ul>
+    </section>`;
+}
+
+/**
+ * @param {PlanningPageData} data
+ * @param {string} canonical
+ * @returns {string} JSON-LD, safe to embed inside a <script> element
+ */
+function buildJsonLd(data, canonical) {
+  const itemList = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: `Planning applications in ${data.areaName}`,
+    url: canonical,
+    numberOfItems: data.applications.length,
+    itemListElement: data.applications.map((app, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: [app.name, app.address].filter(Boolean).join(' — '),
+      url: app.url || app.link || canonical,
+    })),
+  };
+  const dataset = {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    name: `Recent planning applications in ${data.areaName}`,
+    description: `Recent local planning applications in ${data.areaName}, drawn from Town Crier's planning-application snapshot.`,
+    url: canonical,
+    isAccessibleForFree: true,
+    creator: {
+      '@type': 'Organization',
+      name: 'PlanIt',
+      url: 'https://planit.org.uk',
+    },
+    license:
+      'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/',
+  };
+  // Escape "<" so a malicious data value can never close the <script> element.
+  return JSON.stringify([itemList, dataset]).replace(/</g, '\\u003c');
+}
+
+/**
+ * Inline stylesheet for the standalone static page. Self-contained (no external
+ * CSS request) for first-byte readability and strong Core Web Vitals. Uses the
+ * Town Crier design tokens — dark by default, light via prefers-color-scheme —
+ * mirroring `src/styles/tokens.css`.
+ *
+ * @returns {string}
+ */
+function pageStyles() {
+  return `    :root {
+      --tc-amber: #E9A620;
+      --tc-amber-hover: #F0B83A;
+      --tc-background: #1A1A1E;
+      --tc-surface: #242428;
+      --tc-text-primary: #F1EFE9;
+      --tc-text-secondary: #9B9590;
+      --tc-text-on-accent: #1C1917;
+      --tc-status-permitted: #34C759;
+      --tc-status-conditions: #FF9500;
+      --tc-status-rejected: #FF453A;
+      --tc-status-withdrawn: #8E8A85;
+      --tc-status-appealed: #A78BFA;
+      --tc-status-default: #9B9590;
+      --tc-border: #3A3A3F;
+      --tc-radius-md: 12px;
+      --tc-radius-full: 9999px;
+      --tc-space-sm: 8px;
+      --tc-space-md: 16px;
+      --tc-space-lg: 24px;
+      --tc-space-xl: 32px;
+      --tc-space-xxl: 48px;
+      --tc-font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      --tc-content-max-width: 760px;
+    }
+    @media (prefers-color-scheme: light) {
+      :root {
+        --tc-amber: #D4910A;
+        --tc-amber-hover: #B87A08;
+        --tc-background: #FAF8F5;
+        --tc-surface: #FFFFFF;
+        --tc-text-primary: #1C1917;
+        --tc-text-secondary: #6B6560;
+        --tc-text-on-accent: #FFFFFF;
+        --tc-status-permitted: #1A7D37;
+        --tc-status-conditions: #A85A0A;
+        --tc-status-rejected: #C42B2B;
+        --tc-status-withdrawn: #7A7570;
+        --tc-status-appealed: #7C3AED;
+        --tc-status-default: #6B6560;
+        --tc-border: #E8E4DF;
+      }
+    }
+    @font-face {
+      font-family: 'Inter';
+      font-style: normal;
+      font-weight: 400 700;
+      font-display: swap;
+      src: url('/fonts/inter-latin.woff2') format('woff2');
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: var(--tc-font-family);
+      background: var(--tc-background);
+      color: var(--tc-text-primary);
+      line-height: 1.4;
+      -webkit-font-smoothing: antialiased;
+    }
+    .wrap {
+      max-width: var(--tc-content-max-width);
+      margin: 0 auto;
+      padding: var(--tc-space-md);
+    }
+    .siteHeader {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--tc-space-md) 0;
+      border-bottom: 1px solid var(--tc-border);
+    }
+    .siteHeader a { color: var(--tc-text-primary); text-decoration: none; font-weight: 700; }
+    h1 { font-size: 2rem; line-height: 1.2; margin: var(--tc-space-xl) 0 var(--tc-space-sm); }
+    h2 { font-size: 1.5rem; margin: var(--tc-space-xl) 0 var(--tc-space-md); }
+    h3 { font-size: 1.125rem; margin: 0; }
+    .lead { font-size: 1.125rem; color: var(--tc-text-secondary); margin: 0 0 var(--tc-space-lg); }
+    .appList, .statList { list-style: none; margin: 0; padding: 0; display: grid; gap: var(--tc-space-md); }
+    .appCard {
+      background: var(--tc-surface);
+      border: 1px solid var(--tc-border);
+      border-radius: var(--tc-radius-md);
+      padding: var(--tc-space-md);
+    }
+    .appCard__head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--tc-space-sm); }
+    .appCard__address { margin: var(--tc-space-sm) 0 var(--tc-space-sm); font-weight: 600; }
+    .appCard__desc { margin: 0 0 var(--tc-space-sm); color: var(--tc-text-secondary); }
+    .appCard__meta { display: flex; flex-wrap: wrap; gap: var(--tc-space-md); align-items: center; font-size: 0.875rem; }
+    .appCard__date { color: var(--tc-text-secondary); }
+    .appLink { color: var(--tc-amber); text-decoration: none; font-weight: 600; }
+    .appLink:hover { color: var(--tc-amber-hover); text-decoration: underline; }
+    .status {
+      display: inline-flex;
+      align-items: center;
+      border-radius: var(--tc-radius-full);
+      padding: 2px var(--tc-space-sm);
+      font-size: 0.8125rem;
+      font-weight: 600;
+      white-space: nowrap;
+      color: var(--tc-status-default);
+      border: 1px solid currentColor;
+    }
+    .status--permitted { color: var(--tc-status-permitted); }
+    .status--conditions { color: var(--tc-status-conditions); }
+    .status--rejected { color: var(--tc-status-rejected); }
+    .status--withdrawn { color: var(--tc-status-withdrawn); }
+    .status--appealed { color: var(--tc-status-appealed); }
+    .statRow { display: flex; justify-content: space-between; background: var(--tc-surface); border: 1px solid var(--tc-border); border-radius: var(--tc-radius-md); padding: var(--tc-space-sm) var(--tc-space-md); }
+    .statRow__count { font-weight: 700; }
+    .explainer p { color: var(--tc-text-secondary); }
+    .cta {
+      margin: var(--tc-space-xl) 0;
+      padding: var(--tc-space-lg);
+      background: var(--tc-surface);
+      border: 1px solid var(--tc-border);
+      border-radius: var(--tc-radius-md);
+      text-align: center;
+    }
+    .cta__button {
+      display: inline-block;
+      margin-top: var(--tc-space-md);
+      padding: var(--tc-space-sm) var(--tc-space-lg);
+      background: var(--tc-amber);
+      color: var(--tc-text-on-accent);
+      border-radius: var(--tc-radius-md);
+      text-decoration: none;
+      font-weight: 700;
+    }
+    .siteFooter { margin-top: var(--tc-space-xxl); padding: var(--tc-space-lg) 0; border-top: 1px solid var(--tc-border); color: var(--tc-text-secondary); font-size: 0.875rem; }
+    .attribution { list-style: none; margin: 0 0 var(--tc-space-md); padding: 0; display: grid; gap: var(--tc-space-sm); }
+    .siteFooter a { color: var(--tc-text-secondary); }`;
+}
+
+/**
+ * Render a complete, hydration-free static HTML page for one authority.
+ *
+ * @param {PlanningPageData} data
+ * @returns {string}
+ */
+export function renderPlanningPage(data) {
+  const area = escapeHtml(data.areaName);
+  const canonical = `${SITE_ORIGIN}/planning/${data.slug}`;
+  const lead = escapeHtml(leadLine(data.areaName, data.total, data.totalCapped));
+  const title = `Planning applications in ${area} | Town Crier`;
+  const metaDescription = escapeHtml(
+    `Recent planning applications in ${data.areaName}. See what is being built nearby and get push alerts the moment an application is submitted or decided in your area.`,
+  );
+  const jsonLd = buildJsonLd(data, canonical);
+  const year = new Date().getFullYear();
+
+  const applicationsList = data.applications.map(renderApplication).join('\n');
+  const attribution = ATTRIBUTION_LINES.map(
+    (line) => `        <li>${escapeHtml(line)}</li>`,
+  ).join('\n');
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${title}</title>
+    <meta name="description" content="${metaDescription}" />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="${canonical}" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <meta property="og:title" content="Planning applications in ${area}" />
+    <meta property="og:description" content="${metaDescription}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="${canonical}" />
+    <meta property="og:site_name" content="Town Crier" />
+    <script type="application/ld+json">${jsonLd}</script>
+    <style>
+${pageStyles()}
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <header class="siteHeader">
+        <a href="/">Town Crier</a>
+        <a href="/">Home</a>
+      </header>
+      <main>
+        <h1>Planning applications in ${area}</h1>
+        <p class="lead">${lead}</p>
+
+${renderStats(data.applications)}
+
+        <h2>Recent applications</h2>
+        <ul class="appList">
+${applicationsList}
+        </ul>
+
+        <section class="explainer">
+          <h2>How to comment on a planning application in ${area}</h2>
+          <p>
+            Anyone can have their say on a planning application in ${area}. Find the
+            application on the ${area} planning authority's public-access portal using
+            the reference number above, then submit a comment before the consultation
+            deadline. Comments are usually limited to planning matters such as overlooking,
+            loss of light, traffic, noise and the character of the area.
+          </p>
+          <p>
+            ${area} is the local planning authority responsible for deciding these
+            applications. Town Crier mirrors the public record so you can keep track of
+            what is happening near you, but the council remains the authoritative source
+            and the place to submit formal comments.
+          </p>
+        </section>
+
+        <section class="cta">
+          <h2>Get push alerts for ${area}</h2>
+          <p>
+            Draw a circle on the map and Town Crier will notify you the moment a new
+            planning application is submitted or decided inside it.
+          </p>
+          <a class="cta__button" href="${APP_DOWNLOAD_URL}" rel="noopener" target="_blank">Download on the App Store</a>
+        </section>
+      </main>
+
+      <footer class="siteFooter">
+        <ul class="attribution">
+${attribution}
+        </ul>
+        <p>© ${year} Town Crier · Ivo and the Bea Ltd</p>
+        <p><a href="/legal/privacy">Privacy Policy</a> · <a href="/legal/terms">Terms of Service</a></p>
+      </footer>
+    </div>
+  </body>
+</html>
+`;
+}

--- a/web/scripts/lib/render-sitemap.mjs
+++ b/web/scripts/lib/render-sitemap.mjs
@@ -1,0 +1,22 @@
+import { SITE_ORIGIN } from './constants.mjs';
+
+/**
+ * Render a sitemap.xml listing every generated planning page as an absolute
+ * canonical URL under the public origin.
+ *
+ * @param {readonly string[]} slugs published authority slugs
+ * @returns {string}
+ */
+export function renderSitemap(slugs) {
+  const entries = slugs
+    .map(
+      (slug) =>
+        `  <url>\n    <loc>${SITE_ORIGIN}/planning/${slug}</loc>\n  </url>`,
+    )
+    .join('\n');
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${entries}
+</urlset>
+`;
+}

--- a/web/scripts/lib/slug.mjs
+++ b/web/scripts/lib/slug.mjs
@@ -1,0 +1,23 @@
+/**
+ * Convert a PlanIt authority name into a lowercase-hyphenated URL slug.
+ *
+ *   "Basingstoke and Deane"  -> "basingstoke-and-deane"
+ *   "Bristol, City of"       -> "bristol-city-of"
+ *   "King's Lynn and ..."    -> "kings-lynn-and-..."
+ *   "Hammersmith & Fulham"   -> "hammersmith-and-fulham"
+ *
+ * Ampersands expand to "and"; apostrophes are stripped (so they do not become
+ * hyphens); every other run of non-alphanumeric characters collapses to a
+ * single hyphen, with leading/trailing hyphens trimmed.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+export function slugify(name) {
+  return name
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/['’]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -1,0 +1,396 @@
+/**
+ * Static prerender for the programmatic authority-level SEO pages
+ * (`/planning/<slug>`). Runs AFTER `vite build`, emitting fully static,
+ * hydration-free HTML into `web/dist/planning/<slug>/index.html` plus a
+ * `web/dist/sitemap.xml`.
+ *
+ * Three run modes, selected by environment:
+ *   - SITE_BUILD_KEY set        -> live: fetch our gated API, fail LOUD on any
+ *                                  transport/shape error (never empty pages).
+ *   - PRERENDER_FIXTURE=<path>  -> fixture: render from a committed JSON file,
+ *                                  no network (used by the tracer + tests).
+ *   - neither set               -> skip: leave the SPA build untouched so
+ *                                  `npm run build` still succeeds without a key.
+ *
+ * The build key is server-side only and is NEVER written into any page or the
+ * client bundle. We read ONLY our own API — never PlanIt (ADR 0006).
+ */
+
+import { mkdir, writeFile, readFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { slugify } from './lib/slug.mjs';
+import { isQualifyingAreaType } from './lib/area-types.mjs';
+import { meetsCoverageGate } from './lib/coverage-gate.mjs';
+import { renderPlanningPage } from './lib/render-page.mjs';
+import { renderSitemap } from './lib/render-sitemap.mjs';
+
+const DEFAULT_LIMIT = 30;
+
+/**
+ * @typedef {Object} PrerenderResult
+ * @property {boolean} skipped
+ * @property {string} [reason]
+ * @property {string[]} published                       slugs written
+ * @property {Array<{ name: string, reason: string }>} excluded
+ */
+
+/**
+ * @param {string} base
+ * @returns {string} base URL with any trailing slash removed
+ */
+function trimTrailingSlash(base) {
+  return base.replace(/\/+$/, '');
+}
+
+/**
+ * Fetch the full authority list (anonymous, no key). Throws on any non-OK
+ * status or unexpected shape so a broken upstream fails the build loudly.
+ *
+ * @param {string} apiBase
+ * @param {typeof globalThis.fetch} fetchImpl
+ * @returns {Promise<Array<{ id: number, name: string, areaType: string }>>}
+ */
+async function fetchAuthorities(apiBase, fetchImpl) {
+  const url = `${apiBase}/v1/authorities`;
+  const res = await fetchImpl(url);
+  if (!res.ok) {
+    throw new Error(`GET /v1/authorities failed: HTTP ${res.status}`);
+  }
+  const body = await res.json();
+  // The Go handler returns { authorities: [...], total }. Accept a bare array
+  // defensively too.
+  const list = Array.isArray(body) ? body : body?.authorities;
+  if (!Array.isArray(list)) {
+    throw new Error(
+      'GET /v1/authorities returned an unexpected shape (no authorities array)',
+    );
+  }
+  for (const a of list) {
+    if (
+      typeof a?.id !== 'number' ||
+      typeof a?.name !== 'string' ||
+      typeof a?.areaType !== 'string'
+    ) {
+      throw new Error('GET /v1/authorities returned a malformed authority row');
+    }
+  }
+  return list;
+}
+
+/**
+ * Fetch the bounded recent-applications projection for one authority via the
+ * build-key-gated endpoint. Throws on any non-OK status or unexpected shape.
+ *
+ * @param {string} apiBase
+ * @param {number} authorityId
+ * @param {string} buildKey
+ * @param {number} limit
+ * @param {typeof globalThis.fetch} fetchImpl
+ * @returns {Promise<{ areaName: string, applications: object[], total: number, totalCapped: boolean }>}
+ */
+async function fetchRecentApplications(
+  apiBase,
+  authorityId,
+  buildKey,
+  limit,
+  fetchImpl,
+) {
+  const url = `${apiBase}/v1/authorities/${authorityId}/applications?limit=${limit}`;
+  const res = await fetchImpl(url, { headers: { 'X-Build-Key': buildKey } });
+  if (!res.ok) {
+    throw new Error(
+      `GET /v1/authorities/${authorityId}/applications failed: HTTP ${res.status}`,
+    );
+  }
+  const body = await res.json();
+  if (
+    !body ||
+    !Array.isArray(body.applications) ||
+    typeof body.total !== 'number' ||
+    typeof body.totalCapped !== 'boolean'
+  ) {
+    throw new Error(
+      `GET /v1/authorities/${authorityId}/applications returned an unexpected shape`,
+    );
+  }
+  return {
+    areaName: typeof body.areaName === 'string' ? body.areaName : '',
+    applications: body.applications,
+    total: body.total,
+    totalCapped: body.totalCapped,
+  };
+}
+
+/**
+ * Write one authority's page to <outDir>/planning/<slug>/index.html.
+ *
+ * @param {string} outDir
+ * @param {import('./lib/render-page.mjs').PlanningPageData} data
+ * @returns {Promise<void>}
+ */
+async function writePage(outDir, data) {
+  const dir = join(outDir, 'planning', data.slug);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'index.html'), renderPlanningPage(data), 'utf-8');
+}
+
+/**
+ * Render and write a page if the authority qualifies and clears the gate.
+ * Mutates `published`/`excluded`/`seenSlugs` and returns nothing.
+ *
+ * @param {Object} args
+ * @param {string} args.outDir
+ * @param {number} args.authorityId
+ * @param {string} args.name
+ * @param {string} args.areaType
+ * @param {string} args.areaName
+ * @param {number} args.total
+ * @param {boolean} args.totalCapped
+ * @param {object[]} args.applications
+ * @param {number} args.limit
+ * @param {string[]} args.published
+ * @param {Array<{ name: string, reason: string }>} args.excluded
+ * @param {Set<string>} args.seenSlugs
+ * @param {{ warn: (msg: string) => void }} args.logger
+ * @returns {Promise<void>}
+ */
+async function considerAuthority(args) {
+  const {
+    outDir,
+    authorityId,
+    name,
+    total,
+    totalCapped,
+    applications,
+    areaName,
+    limit,
+    published,
+    excluded,
+    seenSlugs,
+    logger,
+  } = args;
+
+  if (!meetsCoverageGate(total)) {
+    excluded.push({ name, reason: 'coverage' });
+    return;
+  }
+
+  const slug = slugify(name);
+  if (seenSlugs.has(slug)) {
+    logger.warn(`[prerender] duplicate slug "${slug}" for "${name}" — skipped`);
+    excluded.push({ name, reason: 'duplicate-slug' });
+    return;
+  }
+  seenSlugs.add(slug);
+
+  await writePage(outDir, {
+    slug,
+    areaName: areaName || name,
+    authorityId,
+    total,
+    totalCapped,
+    applications: applications.slice(0, limit),
+  });
+  published.push(slug);
+}
+
+/**
+ * @param {string} outDir
+ * @param {string} fixturePath
+ * @param {number} limit
+ * @param {{ warn: (msg: string) => void }} logger
+ * @returns {Promise<PrerenderResult>}
+ */
+async function runFixtureMode(outDir, fixturePath, limit, logger) {
+  const raw = await readFile(fixturePath, 'utf-8');
+  const entries = JSON.parse(raw);
+  if (!Array.isArray(entries)) {
+    throw new Error(`fixture ${fixturePath} must be a JSON array`);
+  }
+
+  /** @type {string[]} */
+  const published = [];
+  /** @type {Array<{ name: string, reason: string }>} */
+  const excluded = [];
+  const seenSlugs = new Set();
+
+  for (const entry of entries) {
+    if (!isQualifyingAreaType(entry.areaType)) {
+      excluded.push({ name: entry.name, reason: 'areaType' });
+      continue;
+    }
+    await considerAuthority({
+      outDir,
+      authorityId: entry.id,
+      name: entry.name,
+      areaType: entry.areaType,
+      areaName: entry.areaName ?? entry.name,
+      total: entry.total,
+      totalCapped: Boolean(entry.totalCapped),
+      applications: Array.isArray(entry.applications) ? entry.applications : [],
+      limit,
+      published,
+      excluded,
+      seenSlugs,
+      logger,
+    });
+  }
+
+  await writeFile(join(outDir, 'sitemap.xml'), renderSitemap(published), 'utf-8');
+  return { skipped: false, published, excluded };
+}
+
+/**
+ * @param {Object} args
+ * @param {string} args.outDir
+ * @param {string} args.apiBase
+ * @param {string} args.buildKey
+ * @param {number} args.limit
+ * @param {typeof globalThis.fetch} args.fetchImpl
+ * @param {{ warn: (msg: string) => void }} args.logger
+ * @returns {Promise<PrerenderResult>}
+ */
+async function runLiveMode(args) {
+  const { outDir, apiBase, buildKey, limit, fetchImpl, logger } = args;
+
+  const authorities = await fetchAuthorities(apiBase, fetchImpl);
+
+  /** @type {string[]} */
+  const published = [];
+  /** @type {Array<{ name: string, reason: string }>} */
+  const excluded = [];
+  const seenSlugs = new Set();
+
+  for (const authority of authorities) {
+    if (!isQualifyingAreaType(authority.areaType)) {
+      excluded.push({ name: authority.name, reason: 'areaType' });
+      continue;
+    }
+    const recent = await fetchRecentApplications(
+      apiBase,
+      authority.id,
+      buildKey,
+      limit,
+      fetchImpl,
+    );
+    await considerAuthority({
+      outDir,
+      authorityId: authority.id,
+      name: authority.name,
+      areaType: authority.areaType,
+      areaName: recent.areaName || authority.name,
+      total: recent.total,
+      totalCapped: recent.totalCapped,
+      applications: recent.applications,
+      limit,
+      published,
+      excluded,
+      seenSlugs,
+      logger,
+    });
+  }
+
+  await writeFile(join(outDir, 'sitemap.xml'), renderSitemap(published), 'utf-8');
+  return { skipped: false, published, excluded };
+}
+
+/**
+ * Orchestrate the prerender. Dependency-injected for testing.
+ *
+ * @param {Object} options
+ * @param {string} options.outDir                  directory to emit into (web/dist)
+ * @param {string} [options.apiBase]               API base URL (live mode)
+ * @param {string} [options.buildKey]              SITE_BUILD_KEY (live mode)
+ * @param {string} [options.fixturePath]           committed JSON fixture (fixture mode)
+ * @param {number} [options.limit]                 applications rendered per page
+ * @param {typeof globalThis.fetch} [options.fetchImpl]
+ * @param {{ log: Function, warn: Function, error: Function }} [options.logger]
+ * @returns {Promise<PrerenderResult>}
+ */
+export async function runPrerender(options) {
+  const {
+    outDir,
+    apiBase,
+    buildKey,
+    fixturePath,
+    limit = DEFAULT_LIMIT,
+    fetchImpl = globalThis.fetch,
+    logger = console,
+  } = options;
+
+  if (fixturePath) {
+    return runFixtureMode(outDir, fixturePath, limit, logger);
+  }
+
+  if (!buildKey) {
+    return {
+      skipped: true,
+      reason: 'SITE_BUILD_KEY not set',
+      published: [],
+      excluded: [],
+    };
+  }
+
+  if (!apiBase) {
+    throw new Error(
+      'SITE_BUILD_KEY is set but no API base URL is configured (PRERENDER_API_BASE / VITE_API_BASE_URL)',
+    );
+  }
+
+  return runLiveMode({
+    outDir,
+    apiBase: trimTrailingSlash(apiBase),
+    buildKey,
+    limit,
+    fetchImpl,
+    logger,
+  });
+}
+
+/**
+ * CLI entry point. Reads configuration from the environment and writes into
+ * web/dist (resolved relative to this script, independent of cwd).
+ *
+ * @returns {Promise<void>}
+ */
+async function main() {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const outDir = process.env.PRERENDER_OUT_DIR || join(scriptDir, '..', 'dist');
+  const apiBase =
+    process.env.PRERENDER_API_BASE || process.env.VITE_API_BASE_URL;
+  const buildKey = process.env.SITE_BUILD_KEY;
+  const fixturePath = process.env.PRERENDER_FIXTURE;
+
+  try {
+    const result = await runPrerender({
+      outDir,
+      apiBase,
+      buildKey,
+      fixturePath,
+    });
+    if (result.skipped) {
+      console.log(`[prerender] skipped — ${result.reason} (SPA build only)`);
+      return;
+    }
+    console.log(
+      `[prerender] wrote ${result.published.length} planning page(s); ` +
+        `excluded ${result.excluded.length} authority/-ies`,
+    );
+  } catch (err) {
+    console.error(
+      `[prerender] FAILED: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+// Run main() only when invoked directly (`node scripts/prerender-planning.mjs`),
+// not when imported by tests.
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main();
+}

--- a/web/src/__tests__/planning-cta-link.test.ts
+++ b/web/src/__tests__/planning-cta-link.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { APP_DOWNLOAD_URL } from '../config/links';
+// The prerender build script is plain ESM (`.mjs`) and cannot import the app's
+// TypeScript modules at runtime, so it keeps its own copy of the App Store URL.
+// This guard fails the build the moment the two drift apart.
+import { APP_DOWNLOAD_URL as PRERENDER_APP_DOWNLOAD_URL } from '../../scripts/lib/constants.mjs';
+
+describe('planning page CTA link', () => {
+  it('keeps the prerender App Store URL in lockstep with config/links.ts', () => {
+    expect(PRERENDER_APP_DOWNLOAD_URL).toBe(APP_DOWNLOAD_URL);
+  });
+});

--- a/web/src/__tests__/robots-sitemap.test.ts
+++ b/web/src/__tests__/robots-sitemap.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('robots.txt SEO additions', () => {
+  function robots(): string {
+    return readFileSync(
+      resolve(__dirname, '../../public/robots.txt'),
+      'utf-8',
+    );
+  }
+
+  it('still allows all crawlers', () => {
+    const content = robots();
+    expect(content).toContain('User-agent: *');
+    expect(content).toContain('Allow: /');
+  });
+
+  it('references the absolute sitemap URL', () => {
+    expect(robots()).toContain(
+      'Sitemap: https://towncrierapp.uk/sitemap.xml',
+    );
+  });
+});


### PR DESCRIPTION
Part of epic #570 (programmatic authority-level SEO pages), bead tc-nnte.3.

Standalone Node-ESM prerender run after `vite build`, emitting fully static, hydration-free HTML to `web/dist/planning/<slug>/index.html` + `web/dist/sitemap.xml`. The build key is server-side only and never enters the browser bundle.

**Three modes:** live (`SITE_BUILD_KEY` set → fetch the gated API, **fail loud** non-zero on any transport/non-OK/bad-shape error, zero qualifying authorities is valid); fixture (`PRERENDER_FIXTURE` → render from committed JSON, no network); skip (no key → logs + exits 0 so the SPA still builds).

- `web/scripts/prerender-planning.mjs` + `web/scripts/lib/*` — slugify, qualifying-areaType filter (9 types = 418 LPAs), coverage gate (`total >= 10`), page render (H1, data-filled lead incl. "200+" on `totalCapped`, ≤30 recent apps with portal `link`+app `url`, stats-by-status, evergreen how-to-comment, "Get push alerts" CTA → App Store, PlanIt/OGL/OS/OSM attribution, `<link rel=canonical>`, OG, schema.org ItemList+Dataset), sitemap render.
- `web/public/robots.txt` — added `Sitemap:` line (kept `Allow: /`).
- `web/package.json` build → `tsc -b && vite build && node scripts/prerender-planning.mjs`.
- Drift guard test pins the .mjs App Store URL to `config/links.ts`.

Validation (web/): `tsc --noEmit`, `eslint .`, `vitest run` (718 pass, 56 new specs), `npm run build` (SPA builds; prerender skips without a key) — all clean. Fixture-mode tracer emits a real `planning/basingstoke-and-deane/index.html` with the H1, attribution, CTA, canonical, OG, and JSON-LD.

**For tc-nnte.4 / dev deploy:** confirm `/planning/*` static pages aren't swallowed by the SWA SPA `navigationFallback`; add an explicit route only if the deploy shows they are. The coverage gate uses `total>=10` from the bounded read (DTO lacks `lastDifferent`; strict 90-day windowing is a future DTO tweak).

🤖 Generated with [Claude Code](https://claude.com/claude-code)