### PR TITLE
feat(ci): run SEO prerender with SITE_BUILD_KEY in build-web + both CD web-deploys (tc-nnte.4)

### DIFF
--- a/.github/actions/build-web/action.yml
+++ b/.github/actions/build-web/action.yml
@@ -21,6 +21,10 @@ inputs:
   vite-applicationinsights-connection-string:
     description: VITE_APPLICATIONINSIGHTS_CONNECTION_STRING — App Insights connection string
     required: true
+  site-build-key:
+    description: SITE_BUILD_KEY — build key for the gated SEO prerender endpoint (empty = SPA-only, prerender skips)
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -46,3 +50,4 @@ runs:
         VITE_AUTH0_CLIENT_ID: ${{ inputs.vite-auth0-client-id }}
         VITE_AUTH0_AUDIENCE: ${{ inputs.vite-auth0-audience }}
         VITE_APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ inputs.vite-applicationinsights-connection-string }}
+        SITE_BUILD_KEY: ${{ inputs.site-build-key }}

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -224,6 +224,7 @@ jobs:
           vite-auth0-client-id: ${{ vars.VITE_AUTH0_CLIENT_ID }}
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
+          site-build-key: ${{ secrets.SITE_BUILD_KEY }}
 
       - uses: ./.github/actions/azure-login
         with:

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -200,6 +200,7 @@ jobs:
           vite-auth0-client-id: ${{ vars.VITE_AUTH0_CLIENT_ID }}
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
+          site-build-key: ${{ secrets.SITE_BUILD_KEY }}
 
       - uses: ./.github/actions/azure-login
         with:


### PR DESCRIPTION
Part of epic #570 (programmatic authority-level SEO pages), bead tc-nnte.4.

Wires the build key into the web build so the static prerender (tc-nnte.3) runs against the live gated endpoint during CD:

- `.github/actions/build-web`: new `site-build-key` input (optional, default `""`) + `SITE_BUILD_KEY` env on the Build step. The build already exports `VITE_API_BASE_URL`, which the prerender uses as the API base.
- `cd-dev.yml` (web-deploy) + `cd-prod.yml` (web): pass `secrets.SITE_BUILD_KEY` to build-web.

With the key set, `npm run build`'s prerender fetches the live endpoint and fails the build loudly on any API error (zero qualifying authorities is valid). With it unset, the prerender skips (SPA-only, exit 0) — safe even if the secret were ever empty.

After merge, cd-dev's web-deploy runs the prerender against the live dev endpoint — the definitive valid-key → 200 → real-pages end-to-end.

Validation: `actionlint` clean on both workflows; all three YAMLs well-formed; scope = `.github/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)