### PR TITLE
fix(web): source SEO prerender authority list from committed authorities.json (tc-a0qm)

### DIFF
--- a/web/scripts/lib/__tests__/prerender.test.mjs
+++ b/web/scripts/lib/__tests__/prerender.test.mjs
@@ -3,7 +3,11 @@ import { mkdtemp, rm, readFile, access } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { runPrerender } from '../../prerender-planning.mjs';
+import {
+  runPrerender,
+  loadAuthoritiesFromFile,
+  AUTHORITIES_FILE,
+} from '../../prerender-planning.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const FIXTURE = join(here, '..', '..', 'fixtures', 'sample-authorities.json');
@@ -109,22 +113,13 @@ describe('runPrerender — no key, no fixture', () => {
 });
 
 describe('runPrerender — live mode', () => {
-  function authoritiesBody(items) {
-    return { authorities: items, total: items.length };
-  }
+  const adurAndWestSussex = [
+    { id: 1, name: 'Adur', areaType: 'English District' },
+    { id: 2, name: 'West Sussex', areaType: 'English County' },
+  ];
 
-  it('fetches the gated endpoint with X-Build-Key and publishes gated authorities only', async () => {
+  it('reads the committed authority list (no HTTP) and fetches only the gated applications endpoint with X-Build-Key', async () => {
     const stub = new StubFetch((url) => {
-      if (url.endsWith('/v1/authorities')) {
-        return {
-          ok: true,
-          status: 200,
-          body: authoritiesBody([
-            { id: 1, name: 'Adur', areaType: 'English District' },
-            { id: 2, name: 'West Sussex', areaType: 'English County' },
-          ]),
-        };
-      }
       if (url.includes('/v1/authorities/1/applications')) {
         return {
           ok: true,
@@ -157,15 +152,18 @@ describe('runPrerender — live mode', () => {
       apiBase: 'https://api-dev.towncrierapp.uk',
       buildKey: 'test-key',
       fetchImpl: stub.fetch,
+      loadAuthorities: async () => adurAndWestSussex,
       logger: silentLogger,
     });
 
     expect(result.published).toEqual(['adur']);
 
+    // The authority list must NEVER be fetched over HTTP — only the per-authority
+    // gated applications endpoint is called.
+    expect(stub.calls.every((c) => c.url.includes('/applications'))).toBe(true);
+
     // West Sussex (English County) must never trigger an applications fetch.
-    const appsCalls = stub.calls.filter((c) =>
-      c.url.includes('/applications'),
-    );
+    const appsCalls = stub.calls.filter((c) => c.url.includes('/applications'));
     expect(appsCalls).toHaveLength(1);
     expect(appsCalls[0].url).toContain('/v1/authorities/1/applications');
     expect(appsCalls[0].url).toContain('limit=30');
@@ -179,34 +177,26 @@ describe('runPrerender — live mode', () => {
   });
 
   it('excludes a qualifying authority that fails the coverage gate', async () => {
-    const stub = new StubFetch((url) => {
-      if (url.endsWith('/v1/authorities')) {
-        return {
-          ok: true,
-          status: 200,
-          body: authoritiesBody([
-            { id: 1, name: 'Adur', areaType: 'English District' },
-          ]),
-        };
-      }
-      return {
-        ok: true,
-        status: 200,
-        body: {
-          authorityId: 1,
-          areaName: 'Adur',
-          applications: [],
-          total: 5,
-          totalCapped: false,
-        },
-      };
-    });
+    const stub = new StubFetch(() => ({
+      ok: true,
+      status: 200,
+      body: {
+        authorityId: 1,
+        areaName: 'Adur',
+        applications: [],
+        total: 5,
+        totalCapped: false,
+      },
+    }));
 
     const result = await runPrerender({
       outDir,
       apiBase: 'https://api-dev.towncrierapp.uk',
       buildKey: 'test-key',
       fetchImpl: stub.fetch,
+      loadAuthorities: async () => [
+        { id: 1, name: 'Adur', areaType: 'English District' },
+      ],
       logger: silentLogger,
     });
 
@@ -215,52 +205,32 @@ describe('runPrerender — live mode', () => {
   });
 
   it('treats zero qualifying authorities as a valid (non-error) build', async () => {
-    const stub = new StubFetch(() => ({
-      ok: true,
-      status: 200,
-      body: authoritiesBody([
-        { id: 9, name: 'Surrey', areaType: 'English County' },
-      ]),
-    }));
+    const stub = new StubFetch(() => {
+      throw new Error('applications endpoint must not be called');
+    });
 
     const result = await runPrerender({
       outDir,
       apiBase: 'https://api-dev.towncrierapp.uk',
       buildKey: 'test-key',
       fetchImpl: stub.fetch,
+      loadAuthorities: async () => [
+        { id: 9, name: 'Surrey', areaType: 'English County' },
+      ],
       logger: silentLogger,
     });
 
     expect(result.skipped).toBe(false);
     expect(result.published).toEqual([]);
-  });
-
-  it('fails loud when the authorities endpoint returns a non-OK status', async () => {
-    const stub = new StubFetch(() => ({ ok: false, status: 500, body: {} }));
-    await expect(
-      runPrerender({
-        outDir,
-        apiBase: 'https://api-dev.towncrierapp.uk',
-        buildKey: 'test-key',
-        fetchImpl: stub.fetch,
-        logger: silentLogger,
-      }),
-    ).rejects.toThrow();
+    expect(stub.calls).toHaveLength(0);
   });
 
   it('fails loud when the applications endpoint returns an unexpected shape', async () => {
-    const stub = new StubFetch((url) => {
-      if (url.endsWith('/v1/authorities')) {
-        return {
-          ok: true,
-          status: 200,
-          body: authoritiesBody([
-            { id: 1, name: 'Adur', areaType: 'English District' },
-          ]),
-        };
-      }
-      return { ok: true, status: 200, body: { not: 'what we expect' } };
-    });
+    const stub = new StubFetch(() => ({
+      ok: true,
+      status: 200,
+      body: { not: 'what we expect' },
+    }));
 
     await expect(
       runPrerender({
@@ -268,6 +238,9 @@ describe('runPrerender — live mode', () => {
         apiBase: 'https://api-dev.towncrierapp.uk',
         buildKey: 'test-key',
         fetchImpl: stub.fetch,
+        loadAuthorities: async () => [
+          { id: 1, name: 'Adur', areaType: 'English District' },
+        ],
         logger: silentLogger,
       }),
     ).rejects.toThrow();
@@ -279,8 +252,71 @@ describe('runPrerender — live mode', () => {
         outDir,
         apiBase: undefined,
         buildKey: 'test-key',
+        loadAuthorities: async () => [
+          { id: 1, name: 'Adur', areaType: 'English District' },
+        ],
         logger: silentLogger,
       }),
     ).rejects.toThrow();
+  });
+});
+
+describe('loadAuthoritiesFromFile', () => {
+  const FAKE_PATH = '/fake/authorities.json';
+
+  it('loads and validates a well-formed authority list', async () => {
+    const readImpl = async () =>
+      JSON.stringify([
+        { id: 1, name: 'Adur', areaType: 'English District' },
+        { id: 2, name: 'Aberdeen', areaType: 'Scottish Council' },
+      ]);
+    const list = await loadAuthoritiesFromFile(FAKE_PATH, readImpl);
+    expect(list).toHaveLength(2);
+    expect(list[0]).toEqual({
+      id: 1,
+      name: 'Adur',
+      areaType: 'English District',
+    });
+  });
+
+  it('throws when the file is missing', async () => {
+    const readImpl = async () => {
+      throw new Error('ENOENT: no such file or directory');
+    };
+    await expect(loadAuthoritiesFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
+  });
+
+  it('throws on invalid JSON', async () => {
+    const readImpl = async () => 'not json at all';
+    await expect(loadAuthoritiesFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
+  });
+
+  it('throws on a non-array payload', async () => {
+    const readImpl = async () => JSON.stringify({ authorities: [] });
+    await expect(loadAuthoritiesFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
+  });
+
+  it('throws on an empty array (never a silent empty list)', async () => {
+    const readImpl = async () => JSON.stringify([]);
+    await expect(loadAuthoritiesFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
+  });
+
+  it('throws on a malformed authority row', async () => {
+    const readImpl = async () =>
+      JSON.stringify([{ id: 'not-a-number', name: 'X', areaType: 'Y' }]);
+    await expect(loadAuthoritiesFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
+  });
+});
+
+describe('authorities.json drift guard', () => {
+  it('the committed authority list loads, is a non-empty array, and every row is well-formed', async () => {
+    const list = await loadAuthoritiesFromFile(AUTHORITIES_FILE, readFile);
+    expect(Array.isArray(list)).toBe(true);
+    expect(list.length).toBeGreaterThan(0);
+    for (const a of list) {
+      expect(typeof a.id).toBe('number');
+      expect(typeof a.name).toBe('string');
+      expect(typeof a.areaType).toBe('string');
+    }
   });
 });

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -5,15 +5,20 @@
  * `web/dist/sitemap.xml`.
  *
  * Three run modes, selected by environment:
- *   - SITE_BUILD_KEY set        -> live: fetch our gated API, fail LOUD on any
- *                                  transport/shape error (never empty pages).
+ *   - SITE_BUILD_KEY set        -> live: read the committed authority list from
+ *                                  the repo, then fetch each authority's recent
+ *                                  applications from our build-key-gated API.
+ *                                  Fail LOUD on any transport/shape error
+ *                                  (never empty pages).
  *   - PRERENDER_FIXTURE=<path>  -> fixture: render from a committed JSON file,
  *                                  no network (used by the tracer + tests).
  *   - neither set               -> skip: leave the SPA build untouched so
  *                                  `npm run build` still succeeds without a key.
  *
- * The build key is server-side only and is NEVER written into any page or the
- * client bundle. We read ONLY our own API — never PlanIt (ADR 0006).
+ * The authority list itself is static, public, committed data (read from disk,
+ * not over HTTP — the live `/v1/authorities` endpoint needs an Auth0 token). The
+ * build key is server-side only and is NEVER written into any page or the client
+ * bundle. We read ONLY our own API — never PlanIt (ADR 0006).
  */
 
 import { mkdir, writeFile, readFile } from 'node:fs/promises';
@@ -27,6 +32,28 @@ import { renderPlanningPage } from './lib/render-page.mjs';
 import { renderSitemap } from './lib/render-sitemap.mjs';
 
 const DEFAULT_LIMIT = 30;
+
+/** Directory containing this script (`web/scripts`), independent of cwd. */
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The authority list is static, public, committed data — read it from the repo
+ * rather than over HTTP. The live `GET /v1/authorities` endpoint requires an
+ * Auth0 bearer token (401 anonymously), and only the per-authority applications
+ * endpoint is build-key-anonymous. The whole monorepo is checked out in CI, so
+ * this file is always present two directories up from `web/scripts`.
+ * @type {string}
+ */
+export const AUTHORITIES_FILE = join(
+  SCRIPT_DIR,
+  '..',
+  '..',
+  'api-go',
+  'internal',
+  'authorities',
+  'resources',
+  'authorities.json',
+);
 
 /**
  * @typedef {Object} PrerenderResult
@@ -45,26 +72,38 @@ function trimTrailingSlash(base) {
 }
 
 /**
- * Fetch the full authority list (anonymous, no key). Throws on any non-OK
- * status or unexpected shape so a broken upstream fails the build loudly.
+ * Load and validate the full authority list from the committed JSON file.
+ * Throws loudly if the file is missing, is not valid JSON, is not a non-empty
+ * array, or has a malformed row — never a silent empty list.
  *
- * @param {string} apiBase
- * @param {typeof globalThis.fetch} fetchImpl
+ * @param {string} filePath
+ * @param {(path: string, encoding: string) => Promise<string>} readFileImpl
  * @returns {Promise<Array<{ id: number, name: string, areaType: string }>>}
  */
-async function fetchAuthorities(apiBase, fetchImpl) {
-  const url = `${apiBase}/v1/authorities`;
-  const res = await fetchImpl(url);
-  if (!res.ok) {
-    throw new Error(`GET /v1/authorities failed: HTTP ${res.status}`);
-  }
-  const body = await res.json();
-  // The Go handler returns { authorities: [...], total }. Accept a bare array
-  // defensively too.
-  const list = Array.isArray(body) ? body : body?.authorities;
-  if (!Array.isArray(list)) {
+export async function loadAuthoritiesFromFile(filePath, readFileImpl) {
+  let raw;
+  try {
+    raw = await readFileImpl(filePath, 'utf-8');
+  } catch (err) {
     throw new Error(
-      'GET /v1/authorities returned an unexpected shape (no authorities array)',
+      `authority list not found at ${filePath}: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  let list;
+  try {
+    list = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `authority list at ${filePath} is not valid JSON: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!Array.isArray(list) || list.length === 0) {
+    throw new Error(
+      `authority list at ${filePath} must be a non-empty JSON array`,
     );
   }
   for (const a of list) {
@@ -73,7 +112,9 @@ async function fetchAuthorities(apiBase, fetchImpl) {
       typeof a?.name !== 'string' ||
       typeof a?.areaType !== 'string'
     ) {
-      throw new Error('GET /v1/authorities returned a malformed authority row');
+      throw new Error(
+        `authority list at ${filePath} has a malformed authority row`,
+      );
     }
   }
   return list;
@@ -249,13 +290,15 @@ async function runFixtureMode(outDir, fixturePath, limit, logger) {
  * @param {string} args.buildKey
  * @param {number} args.limit
  * @param {typeof globalThis.fetch} args.fetchImpl
+ * @param {() => Promise<Array<{ id: number, name: string, areaType: string }>>} args.loadAuthorities
  * @param {{ warn: (msg: string) => void }} args.logger
  * @returns {Promise<PrerenderResult>}
  */
 async function runLiveMode(args) {
-  const { outDir, apiBase, buildKey, limit, fetchImpl, logger } = args;
+  const { outDir, apiBase, buildKey, limit, fetchImpl, loadAuthorities, logger } =
+    args;
 
-  const authorities = await fetchAuthorities(apiBase, fetchImpl);
+  const authorities = await loadAuthorities();
 
   /** @type {string[]} */
   const published = [];
@@ -306,6 +349,7 @@ async function runLiveMode(args) {
  * @param {string} [options.fixturePath]           committed JSON fixture (fixture mode)
  * @param {number} [options.limit]                 applications rendered per page
  * @param {typeof globalThis.fetch} [options.fetchImpl]
+ * @param {() => Promise<Array<{ id: number, name: string, areaType: string }>>} [options.loadAuthorities]
  * @param {{ log: Function, warn: Function, error: Function }} [options.logger]
  * @returns {Promise<PrerenderResult>}
  */
@@ -317,6 +361,7 @@ export async function runPrerender(options) {
     fixturePath,
     limit = DEFAULT_LIMIT,
     fetchImpl = globalThis.fetch,
+    loadAuthorities = () => loadAuthoritiesFromFile(AUTHORITIES_FILE, readFile),
     logger = console,
   } = options;
 
@@ -345,6 +390,7 @@ export async function runPrerender(options) {
     buildKey,
     limit,
     fetchImpl,
+    loadAuthorities,
     logger,
   });
 }
@@ -356,8 +402,7 @@ export async function runPrerender(options) {
  * @returns {Promise<void>}
  */
 async function main() {
-  const scriptDir = dirname(fileURLToPath(import.meta.url));
-  const outDir = process.env.PRERENDER_OUT_DIR || join(scriptDir, '..', 'dist');
+  const outDir = process.env.PRERENDER_OUT_DIR || join(SCRIPT_DIR, '..', 'dist');
   const apiBase =
     process.env.PRERENDER_API_BASE || process.env.VITE_API_BASE_URL;
   const buildKey = process.env.SITE_BUILD_KEY;


### PR DESCRIPTION
Fixes the cd-dev web-deploy failure introduced when tc-nnte.4 turned the prerender key on: the prerender fetched `GET /v1/authorities`, which requires an Auth0 bearer in the deployed API (401 anonymously) — only `/v1/authorities/{id}/applications` is build-key-anonymous.

Fix (no endpoint auth change — Scope Discipline): the static, public authority list is now read from the committed `api-go/internal/authorities/resources/authorities.json` (single source of truth, no network round-trip) via a new injectable `loadAuthoritiesFromFile`. The per-authority build-key applications calls are unchanged.

- Drift-guard test loads the real JSON and validates shape.
- Live-mode tests assert the list is never fetched over HTTP.

Validation (web/): `tsc --noEmit` clean, `eslint` clean, vitest **724 pass / 96 files**, `npm run build` OK. Loader proof: 485 loaded, 418 qualifying, zero network during load.

Discovered-from tc-nnte.3. After merge, cd-dev web-deploy runs the prerender end-to-end against the live endpoint with the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved prerendering reliability by switching the authority list source from live HTTP fetching to a committed file, enabling faster and more consistent builds
  * Enhanced validation and error handling for authority list integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->