### PR TITLE
feat(api): build-key-gated bounded geo applications-near endpoint (tc-nnte.7)

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -51,10 +51,12 @@ var anonymousPatterns = map[string]struct{}{
 	// so it is anonymous to Auth0; the signed JWS is its authentication. (The
 	// sibling POST /v1/subscriptions/verify is authed and absent here.)
 	"POST /v1/webhooks/appstore": {},
-	// The build-time SEO endpoint is anonymous to Auth0 (no bearer token); it is
-	// authenticated solely by the X-Build-Key gate inside the handler, mirroring
-	// the admin routes. It reads only public planning data from Cosmos.
+	// The build-time SEO endpoints are anonymous to Auth0 (no bearer token); they
+	// are authenticated solely by the X-Build-Key gate inside the handler, mirroring
+	// the admin routes. They read only public planning data from Cosmos. The first
+	// feeds authority pages; the second feeds town pages (bounded geo query).
 	"GET /v1/authorities/{id}/applications": {},
+	"GET /v1/applications/near":             {},
 }
 
 // dispatchMux satisfies auth.RequireAuth's routeMatcher: pattern matching comes
@@ -146,11 +148,14 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 		} else {
 			applications.Routes(mux, appStore, nil, logger)
 		}
-		// The build-time SEO endpoint (anonymous to Auth0, gated by the dedicated
-		// X-Build-Key) reads recent applications by authority from the same store.
-		// It is registered here because it needs the applications store; the route
-		// is absent on a Cosmos-less local boot, where it falls to the 401 fallback.
+		// The build-time SEO endpoints (anonymous to Auth0, gated by the dedicated
+		// X-Build-Key) read recent applications from the same store: RecentRoutes by
+		// authority (authority pages) and NearRoutes by a bounded geo point (town
+		// pages). Both are registered here because they need the applications store;
+		// the routes are absent on a Cosmos-less local boot, where they fall to the
+		// 401 fallback.
 		applications.RecentRoutes(mux, appStore, siteBuildKey, logger)
+		applications.NearRoutes(mux, appStore, siteBuildKey, logger)
 	}
 	if store != nil && watchZoneStore != nil && appStore != nil && stateStore != nil && notifStore != nil {
 		// Watch-zone create (returns nearby applications) + the per-zone

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -513,6 +513,48 @@ func recentRequest(t *testing.T, h http.Handler, key string) *httptest.ResponseR
 	return rec
 }
 
+// TestRouter_NearApplicationsBuildKeyGate confirms the build-time town-level SEO
+// endpoint (GET /v1/applications/near) is wired, anonymous to Auth0, and gated
+// solely by the X-Build-Key. The deny-all validator distinguishes the gates: the
+// Auth0 fallback would 401 with WWW-Authenticate: Bearer, whereas the build gate's
+// 401 carries no such header, and a correct key reaches the handler.
+func TestRouter_NearApplicationsBuildKeyGate(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	appStore := applications.NewCosmosStore(newFakeItems())
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, logger)
+
+	noKey := nearRequest(t, h, "")
+	if noKey.Code != http.StatusUnauthorized {
+		t.Fatalf("no key: status = %d, want 401", noKey.Code)
+	}
+	if got := noKey.Header().Get("WWW-Authenticate"); got != "" {
+		t.Errorf("no key: WWW-Authenticate = %q, want empty (build gate, not Auth0)", got)
+	}
+
+	withKey := nearRequest(t, h, "buildsecret")
+	if withKey.Code != http.StatusOK {
+		t.Fatalf("with key: status = %d body = %s", withKey.Code, withKey.Body.String())
+	}
+	if got := withKey.Body.String(); !strings.Contains(got, `"applications":[]`) {
+		t.Errorf("with key: body = %s, want a non-null applications array", got)
+	}
+}
+
+func nearRequest(t *testing.T, h http.Handler, key string) *httptest.ResponseRecorder {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1", nil)
+	if key != "" {
+		req.Header.Set("X-Build-Key", key)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
 func adminRequest(t *testing.T, h http.Handler, key string) *httptest.ResponseRecorder {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/api-go/internal/applications/near.go
+++ b/api-go/internal/applications/near.go
@@ -1,0 +1,148 @@
+package applications
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// nearReadCap is the hard upper bound on documents read per town request in one
+// SEO build call. The query is bounded by it (SELECT TOP @cap), so the RU cost
+// and response size stay flat regardless of how busy the authority partition is.
+const nearReadCap = 200
+
+// nearDefaultRadiusMetres and nearMaxRadiusMetres bound the spatial search radius.
+// radius defaults to nearDefaultRadiusMetres (a town-centroid catchment) when
+// unset and is hard-clamped to nearMaxRadiusMetres, so a build request can never
+// widen the single-partition scan beyond the intended town footprint.
+const (
+	nearDefaultRadiusMetres = 5000
+	nearMaxRadiusMetres     = 10000
+)
+
+// Coordinate validity ranges for WGS84 latitude/longitude.
+const (
+	minLatitude  = -90
+	maxLatitude  = 90
+	minLongitude = -180
+	maxLongitude = 180
+)
+
+// nearStore is the consumer-side store the recent-nearby SEO handler needs: a
+// single bounded, single-partition spatial top-N read. The concrete *CosmosStore
+// satisfies it structurally.
+type nearStore interface {
+	RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
+}
+
+// nearHandler serves the build-time town-level SEO endpoint.
+type nearHandler struct {
+	store  nearStore
+	logger *slog.Logger
+}
+
+// NearRoutes registers the build-key-gated recent-applications-near-a-point
+// endpoint that feeds town-level SEO pages. The route is anonymous to Auth0 (kept
+// out of the fallback-deny set in wiring) and authenticated solely by the
+// X-Build-Key gate, mirroring the sibling authority endpoint. It reads only public
+// planning data from Cosmos (GH#395 Invariant 1 — never PlanIt).
+func NearRoutes(mux *http.ServeMux, store nearStore, buildKey string, logger *slog.Logger) {
+	h := &nearHandler{store: store, logger: logger}
+	mux.HandleFunc("GET /v1/applications/near", requireBuildKey(buildKey, h.recentNearby))
+}
+
+// recentNearby returns up to limit most-recently-active applications within a
+// bounded radius of (lat, lng), scoped to the required authorityId's single
+// Cosmos partition, drawn from one bounded read of at most nearReadCap documents.
+// authorityId scopes the partition; a missing/invalid id, a non-finite or
+// out-of-range coordinate, or a non-finite/non-positive radius is a bodyless 400
+// (the build key was already validated by the gate). There is no PlanIt fallback.
+func (h *nearHandler) recentNearby(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	// authorityId is required: it scopes the single-partition spatial query to one
+	// authorityCode (the AreaID as a string), exactly as the authority endpoint does.
+	id, err := strconv.Atoi(strings.TrimSpace(q.Get("authorityId")))
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	lat, ok := parseCoordinate(q.Get("lat"), minLatitude, maxLatitude)
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	lng, ok := parseCoordinate(q.Get("lng"), minLongitude, maxLongitude)
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	radius, ok := parseRadius(q.Get("radius"))
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	limit := parseLimit(q.Get("limit"))
+	authorityCode := strconv.Itoa(id)
+
+	apps, err := h.store.RecentNearby(r.Context(), authorityCode, lat, lng, radius, nearReadCap)
+	if err != nil {
+		serverError(w, r, h.logger, "recent applications near point", err)
+		return
+	}
+
+	total := len(apps)
+	render := total
+	if render > limit {
+		render = limit
+	}
+	results := make([]RecentApplication, 0, render)
+	for i := range render {
+		results = append(results, RecentApplicationOf(apps[i]))
+	}
+
+	writeJSON(w, r, h.logger, RecentNearbyResult{
+		AuthorityID:  id,
+		Lat:          lat,
+		Lng:          lng,
+		Radius:       radius,
+		Applications: results,
+		Total:        total,
+		TotalCapped:  total >= nearReadCap,
+	})
+}
+
+// parseCoordinate parses a required WGS84 coordinate, rejecting an empty,
+// non-numeric, non-finite (NaN/±Inf), or out-of-[min,max] value. The bool reports
+// validity; the caller turns false into a 400.
+func parseCoordinate(raw string, minVal, maxVal float64) (float64, bool) {
+	v, err := strconv.ParseFloat(strings.TrimSpace(raw), 64)
+	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) || v < minVal || v > maxVal {
+		return 0, false
+	}
+	return v, true
+}
+
+// parseRadius parses the optional radius in metres: it defaults to
+// nearDefaultRadiusMetres when unset/empty, rejects a non-numeric, non-finite, or
+// non-positive value (false -> 400), and clamps anything above nearMaxRadiusMetres
+// down to the hard maximum so the spatial scan stays bounded.
+func parseRadius(raw string) (float64, bool) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nearDefaultRadiusMetres, true
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) || v <= 0 {
+		return 0, false
+	}
+	if v > nearMaxRadiusMetres {
+		return nearMaxRadiusMetres, true
+	}
+	return v, true
+}

--- a/api-go/internal/applications/near_test.go
+++ b/api-go/internal/applications/near_test.go
@@ -1,0 +1,395 @@
+package applications
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeNearStore is a hand-written double for the recent-nearby read. It records
+// the arguments the handler passed (so clamping/defaulting is asserted at the
+// store boundary) and honours cap the way Cosmos TOP @cap does.
+type fakeNearStore struct {
+	apps []PlanningApplication
+	err  error
+
+	called            bool
+	lastAuthorityCode string
+	lastLat           float64
+	lastLng           float64
+	lastRadius        float64
+	lastCap           int
+}
+
+func (f *fakeNearStore) RecentNearby(_ context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error) {
+	f.called = true
+	f.lastAuthorityCode = authorityCode
+	f.lastLat = lat
+	f.lastLng = lng
+	f.lastRadius = radiusMetres
+	f.lastCap = cap
+	if f.err != nil {
+		return nil, f.err
+	}
+	if cap >= 0 && cap < len(f.apps) {
+		return f.apps[:cap], nil
+	}
+	return f.apps, nil
+}
+
+func serveNear(t *testing.T, store nearStore, buildKey, providedKey, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	NearRoutes(mux, store, buildKey, slog.New(slog.DiscardHandler))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+	if providedKey != "" {
+		req.Header.Set("X-Build-Key", providedKey)
+	}
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestNearHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5155&lng=-0.0931&radius=4000")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("content-type: got %q", ct)
+	}
+	// The handler scopes to the numeric authority id -> partition code, reads the
+	// bounded cap (200), and passes the parsed point + radius through verbatim.
+	if store.lastAuthorityCode != "471" || store.lastCap != 200 {
+		t.Errorf("store call: authorityCode=%q cap=%d, want \"471\" 200", store.lastAuthorityCode, store.lastCap)
+	}
+	if store.lastLat != 51.5155 || store.lastLng != -0.0931 || store.lastRadius != 4000 {
+		t.Errorf("store geo args: lat=%v lng=%v radius=%v, want 51.5155 -0.0931 4000", store.lastLat, store.lastLng, store.lastRadius)
+	}
+	got := recentBody(t, rec)
+	if got["authorityId"].(float64) != 471 {
+		t.Errorf("authorityId: got %v, want 471", got["authorityId"])
+	}
+	if got["lat"].(float64) != 51.5155 || got["lng"].(float64) != -0.0931 || got["radius"].(float64) != 4000 {
+		t.Errorf("echoed geo: lat=%v lng=%v radius=%v", got["lat"], got["lng"], got["radius"])
+	}
+	apps, ok := got["applications"].([]any)
+	if !ok {
+		t.Fatalf("applications must be a non-null array, got %T (%v)", got["applications"], got["applications"])
+	}
+	if len(apps) != 2 {
+		t.Errorf("applications length: got %d, want 2", len(apps))
+	}
+	if got["total"].(float64) != 2 {
+		t.Errorf("total: got %v, want 2", got["total"])
+	}
+	if got["totalCapped"].(bool) {
+		t.Errorf("totalCapped: got true, want false")
+	}
+	first := apps[0].(map[string]any)
+	for _, key := range []string{"uid", "name", "address", "description", "appState", "startDate", "link", "url"} {
+		if _, present := first[key]; !present {
+			t.Errorf("application missing field %q: %v", key, first)
+		}
+	}
+}
+
+func TestNearHandler_RejectsMissingKey(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status: got %d, want 401", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("401 must be bodyless (backfilled downstream), got %s", rec.Body)
+	}
+	if store.called {
+		t.Errorf("store must not be hit when the key is missing")
+	}
+}
+
+func TestNearHandler_EmptyConfiguredKeyRejectsAll(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "", "anything",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("empty configured key must reject all: got %d, want 401", rec.Code)
+	}
+	if store.called {
+		t.Errorf("store must not be hit when the configured key is empty")
+	}
+}
+
+func TestNearHandler_MissingAuthorityIdReturns400(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?lat=51.5&lng=-0.1")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing authorityId: got %d, want 400", rec.Code)
+	}
+	if store.called {
+		t.Errorf("store must not be hit without a valid authorityId")
+	}
+}
+
+func TestNearHandler_NonIntAuthorityIdReturns400(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=abc&lat=51.5&lng=-0.1")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("non-int authorityId: got %d, want 400", rec.Code)
+	}
+	if store.called {
+		t.Errorf("store must not be hit on a malformed authorityId")
+	}
+}
+
+func TestNearHandler_RejectsNonFiniteLat(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=NaN&lng=-0.1")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("NaN lat: got %d, want 400", rec.Code)
+	}
+	if store.called {
+		t.Errorf("store must not be hit on a non-finite lat")
+	}
+}
+
+func TestNearHandler_RejectsNonFiniteLng(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=Inf")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("Inf lng: got %d, want 400", rec.Code)
+	}
+	if store.called {
+		t.Errorf("store must not be hit on a non-finite lng")
+	}
+}
+
+func TestNearHandler_RejectsOutOfRangeLat(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=91&lng=-0.1")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("out-of-range lat: got %d, want 400", rec.Code)
+	}
+	if store.called {
+		t.Errorf("store must not be hit on an out-of-range lat")
+	}
+}
+
+func TestNearHandler_RejectsOutOfRangeLng(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=200")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("out-of-range lng: got %d, want 400", rec.Code)
+	}
+	if store.called {
+		t.Errorf("store must not be hit on an out-of-range lng")
+	}
+}
+
+func TestNearHandler_RejectsMissingLat(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lng=-0.1")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("missing lat: got %d, want 400", rec.Code)
+	}
+	if store.called {
+		t.Errorf("store must not be hit without a lat")
+	}
+}
+
+func TestNearHandler_RejectsNonFiniteRadius(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&radius=Inf")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("non-finite radius: got %d, want 400", rec.Code)
+	}
+	if store.called {
+		t.Errorf("store must not be hit on a non-finite radius")
+	}
+}
+
+func TestNearHandler_RejectsNonPositiveRadius(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&radius=0")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("non-positive radius: got %d, want 400", rec.Code)
+	}
+	if store.called {
+		t.Errorf("store must not be hit on a non-positive radius")
+	}
+}
+
+func TestNearHandler_ClampsRadiusToMax(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&radius=99999")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	// The clamped 10km radius is what reaches the store and what the response echoes.
+	if store.lastRadius != 10000 {
+		t.Errorf("store radius: got %v, want 10000 (clamped to 10km)", store.lastRadius)
+	}
+	got := recentBody(t, rec)
+	if got["radius"].(float64) != 10000 {
+		t.Errorf("echoed radius: got %v, want 10000", got["radius"])
+	}
+}
+
+func TestNearHandler_DefaultRadiusWhenUnset(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if store.lastRadius != 5000 {
+		t.Errorf("store radius: got %v, want 5000 (default when unset)", store.lastRadius)
+	}
+	got := recentBody(t, rec)
+	if got["radius"].(float64) != 5000 {
+		t.Errorf("echoed radius: got %v, want 5000", got["radius"])
+	}
+}
+
+func TestNearHandler_DefaultLimitIs30(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 50)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
+
+	got := recentBody(t, rec)
+	apps := got["applications"].([]any)
+	if len(apps) != 30 {
+		t.Errorf("applications length: got %d, want 30 (default limit)", len(apps))
+	}
+	if got["total"].(float64) != 50 {
+		t.Errorf("total: got %v, want 50 (full bounded read)", got["total"])
+	}
+}
+
+func TestNearHandler_LimitHardCappedAt100(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 150)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&limit=999")
+
+	got := recentBody(t, rec)
+	apps := got["applications"].([]any)
+	if len(apps) != 100 {
+		t.Errorf("applications length: got %d, want 100 (hard max limit)", len(apps))
+	}
+}
+
+func TestNearHandler_TotalCappedWhenReadHitsCap(t *testing.T) {
+	t.Parallel()
+	// Exactly cap (200) documents available -> the bounded read returns cap.
+	store := &fakeNearStore{apps: recentApps(t, 200)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
+
+	got := recentBody(t, rec)
+	if got["total"].(float64) != 200 {
+		t.Errorf("total: got %v, want 200", got["total"])
+	}
+	if !got["totalCapped"].(bool) {
+		t.Errorf("totalCapped: got false, want true when the read hits cap")
+	}
+	if apps := got["applications"].([]any); len(apps) != 30 {
+		t.Errorf("applications length: got %d, want 30", len(apps))
+	}
+}
+
+func TestNearHandler_EmptyResultIsNonNullArray(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: nil}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	got := recentBody(t, rec)
+	apps, ok := got["applications"].([]any)
+	if !ok {
+		t.Fatalf("applications must be a non-null array even when empty, got %T", got["applications"])
+	}
+	if len(apps) != 0 {
+		t.Errorf("applications length: got %d, want 0", len(apps))
+	}
+	if got["total"].(float64) != 0 {
+		t.Errorf("total: got %v, want 0", got["total"])
+	}
+}
+
+func TestNearHandler_StoreErrorReturns500(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{err: context.DeadlineExceeded}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("store error: got %d, want 500", rec.Code)
+	}
+}

--- a/api-go/internal/applications/result.go
+++ b/api-go/internal/applications/result.go
@@ -93,6 +93,22 @@ type RecentByAuthorityResult struct {
 	TotalCapped  bool                `json:"totalCapped"`
 }
 
+// RecentNearbyResult is the wire shape of the build-time town-level SEO endpoint
+// GET /v1/applications/near. It mirrors RecentByAuthorityResult but echoes the
+// effective (post-clamp) query point and radius instead of an area name, so the
+// town prerender can label and cache the page by its centroid. Applications is
+// always a non-null array (at most the request's limit); Total is the count from
+// the single bounded read; TotalCapped reports that the read hit cap.
+type RecentNearbyResult struct {
+	AuthorityID  int                 `json:"authorityId"`
+	Lat          float64             `json:"lat"`
+	Lng          float64             `json:"lng"`
+	Radius       float64             `json:"radius"`
+	Applications []RecentApplication `json:"applications"`
+	Total        int                 `json:"total"`
+	TotalCapped  bool                `json:"totalCapped"`
+}
+
 // RecentApplication is the slim, render-only projection of a planning application
 // for an SEO page: just the fields the static page needs. Coordinates, area
 // identity, and the unread-event projection are deliberately omitted.

--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -151,3 +151,46 @@ func (s *CosmosStore) FindNearby(ctx context.Context, authorityCode string, lati
 	}
 	return apps, nil
 }
+
+// recentNearbyQuery is the bounded, single-partition spatial top-N query behind
+// the build-time town-level SEO endpoint: the most recently active applications
+// within radiusMetres of a point, inside one authorityCode partition. It marries
+// the findNearbyQuery ST_DISTANCE filter (GeoJSON [longitude, latitude] order,
+// all values bound as named parameters) with the recentByAuthorityQuery
+// SELECT TOP @cap ... ORDER BY c.lastDifferent DESC discipline, so the read stays
+// bounded by @cap and ordered by the index-backed lastDifferent field. Ordering
+// is NOT by startDate: it is excluded from the indexing policy, so ordering by it
+// would force a full-partition scan. This is a distinct query from FindNearby —
+// the authed nearby path is deliberately left unchanged.
+const recentNearbyQuery = "SELECT TOP @cap * FROM c WHERE ST_DISTANCE(c.location, " +
+	`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres ` +
+	"ORDER BY c.lastDifferent DESC"
+
+// RecentNearby returns up to cap most-recently-active applications within
+// radiusMetres of (lat, lng) inside the authorityCode partition, ordered by
+// lastDifferent DESC. It backs the build-time town-level SEO endpoint: a single
+// bounded single-partition spatial query, never a cross-partition fan-out and
+// never an unbounded scan. Coordinates, radius, and cap are bound as named
+// parameters (not string-concatenated). There is no PlanIt fallback (GH#395
+// Invariant 1) — it reads only from Cosmos.
+func (s *CosmosStore) RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error) {
+	params := map[string]any{
+		"@latitude":     lat,
+		"@longitude":    lng,
+		"@radiusMetres": radiusMetres,
+		"@cap":          cap,
+	}
+	raws, err := s.items.QueryItems(ctx, authorityCode, recentNearbyQuery, params)
+	if err != nil {
+		return nil, fmt.Errorf("recent applications near %q: %w", authorityCode, err)
+	}
+	apps := make([]PlanningApplication, 0, len(raws))
+	for _, raw := range raws {
+		var doc applicationDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("decode recent nearby application in %q: %w", authorityCode, err)
+		}
+		apps = append(apps, doc.toDomain())
+	}
+	return apps, nil
+}

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -322,3 +322,105 @@ func TestCosmosStore_RecentByAuthority_EmptyResultIsEmptySlice(t *testing.T) {
 		t.Errorf("RecentByAuthority: got %d results, want 0", len(got))
 	}
 }
+
+func TestCosmosStore_RecentNearby_BoundedSpatialOrderedScopedToPartition(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	body, _ := json.Marshal(newApplicationDocument(a))
+	items := newFakeItems()
+	items.queryResult = [][]byte{body}
+	store := NewCosmosStore(items)
+
+	got, err := store.RecentNearby(context.Background(), "441", 51.4975, -0.1357, 5000, 200)
+	if err != nil {
+		t.Fatalf("RecentNearby: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != a.Name {
+		t.Fatalf("RecentNearby results: got %+v", got)
+	}
+	// Scoped to the authorityCode logical partition (never cross-partition).
+	if items.lastQueryPK != "441" {
+		t.Errorf("query partition key: got %q, want \"441\"", items.lastQueryPK)
+	}
+	// Bounded TOP @cap, single-partition spatial filter, ordered by the
+	// index-backed lastDifferent field DESC. The GeoJSON point carries
+	// [longitude, latitude] (GeoJSON order), mirroring findNearbyQuery. Must NOT
+	// order by startDate (unindexed -> full-partition scan).
+	want := "SELECT TOP @cap * FROM c WHERE ST_DISTANCE(c.location, " +
+		`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres ` +
+		"ORDER BY c.lastDifferent DESC"
+	if items.lastQuery != want {
+		t.Errorf("recent nearby query:\n got %q\nwant %q", items.lastQuery, want)
+	}
+	if strings.Contains(items.lastQuery, "startDate") {
+		t.Errorf("query must not order by startDate (unindexed): %s", items.lastQuery)
+	}
+}
+
+func TestCosmosStore_RecentNearby_UsesParameterizedQuery(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	_, _ = store.RecentNearby(context.Background(), "441", 51.4975, -0.1357, 5000, 200)
+
+	// No coordinate, radius, or cap value may be string-concatenated into the
+	// query text — they must all be bound as named parameters.
+	if items.lastQuery == "" {
+		t.Fatal("no query was issued")
+	}
+	for _, literal := range []string{"51.4975", "-0.1357", "5000", "200"} {
+		if strings.Contains(items.lastQuery, literal) {
+			t.Errorf("query contains literal %q — should be a named parameter; query: %s", literal, items.lastQuery)
+		}
+	}
+	wantParams := map[string]any{
+		"@latitude":     51.4975,
+		"@longitude":    -0.1357,
+		"@radiusMetres": 5000.0,
+		"@cap":          200,
+	}
+	for k, wantVal := range wantParams {
+		gotVal, ok := items.lastQueryParams[k]
+		if !ok {
+			t.Errorf("param %q not found in query params %v", k, items.lastQueryParams)
+			continue
+		}
+		if gotVal != wantVal {
+			t.Errorf("param %q: got %v, want %v", k, gotVal, wantVal)
+		}
+	}
+}
+
+func TestCosmosStore_RecentNearby_CapsAtCap(t *testing.T) {
+	t.Parallel()
+	const wantCap = 5
+	items := newFakeItems()
+	// A busy authority with more than wantCap documents within the radius.
+	items.queryResult = recentDocs(t, wantCap+8)
+	store := NewCosmosStore(items)
+
+	got, err := store.RecentNearby(context.Background(), "471", 51.5, -0.1, 5000, wantCap)
+	if err != nil {
+		t.Fatalf("RecentNearby: %v", err)
+	}
+	if len(got) != wantCap {
+		t.Errorf("busy authority: got %d results, want exactly cap=%d", len(got), wantCap)
+	}
+}
+
+func TestCosmosStore_RecentNearby_EmptyResultIsEmptySlice(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+
+	got, err := store.RecentNearby(context.Background(), "471", 51.5, -0.1, 5000, 200)
+	if err != nil {
+		t.Fatalf("RecentNearby: %v", err)
+	}
+	if got == nil {
+		t.Fatal("RecentNearby: got nil slice, want empty non-nil slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("RecentNearby: got %d results, want 0", len(got))
+	}
+}


### PR DESCRIPTION
First sub-step of epic #570 bead tc-nnte.7 (town-level SEO pages): the data endpoint town pages will consume.

New route **`GET /v1/applications/near?authorityId=&lat=&lng=&radius=&limit=`** — anonymous to Auth0, gated by the existing `X-Build-Key`. Reads only Cosmos; no PlanIt.

- `applications/near.go`: handler. `authorityId` required (scopes the single partition) → 400 if missing/invalid; lat/lng required, finite + WGS84 range else 400; radius default 5000m, clamped to 10000m max, non-finite/non-positive → 400 (mirrors the tc-e9tj hardening intent); limit default 30 / max 100. Response echoes the effective (post-clamp) lat/lng/radius + applications + total + totalCapped.
- `store_cosmos.go`: `RecentNearby` — bounded `SELECT TOP @cap * FROM c WHERE ST_DISTANCE(...) <= @radiusMetres ORDER BY c.lastDifferent DESC` (cap=200), single-partition, named params, rides the `(/authorityCode, /lastDifferent)` composite index. The existing authed `FindNearby` is left untouched.
- `cmd/api/wiring.go`: route added to `anonymousPatterns` + registered via `NearRoutes` under the Cosmos-store guard.

Validation (api-go/): `gofmt -l .` clean, `go vet`, `golangci-lint run ./...` clean; `go test -race ./...` → 1032 passed / 37 pkgs (18 handler + 4 store + 1 wiring-gate new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)