### PR TITLE
feat(web): town-level SEO pages — nested /planning/[authority]/[town] prerender (tc-nnte.7)

### DIFF
--- a/web/scripts/fixtures/sample-towns.json
+++ b/web/scripts/fixtures/sample-towns.json
@@ -1,0 +1,54 @@
+[
+  {
+    "slug": "truro",
+    "name": "Truro",
+    "lat": 50.2632,
+    "lng": -5.051,
+    "authorityId": 52,
+    "total": 18,
+    "totalCapped": false,
+    "applications": [
+      {
+        "uid": "CW/2026/0001",
+        "name": "PA26/00001",
+        "address": "Lemon Quay, Truro, TR1 2LW",
+        "description": "Change of use of ground floor from retail (Class E) to a café with associated shopfront alterations.",
+        "appState": "Permitted",
+        "startDate": "2026-01-12",
+        "link": "https://planit.org.uk/planapplic/PA26-00001",
+        "url": "https://planning.cornwall.gov.uk/online-applications/PA26-00001"
+      },
+      {
+        "uid": "CW/2026/0002",
+        "name": "PA26/00002",
+        "address": "Boscawen Street, Truro, TR1 2QU",
+        "description": "Listed building consent for internal alterations and a two-storey rear extension.",
+        "appState": "Rejected",
+        "startDate": "2026-02-01",
+        "link": "https://planit.org.uk/planapplic/PA26-00002",
+        "url": null
+      }
+    ]
+  },
+  {
+    "slug": "sparse-village",
+    "name": "Sparse Village",
+    "lat": 50.1,
+    "lng": -5.1,
+    "authorityId": 52,
+    "total": 4,
+    "totalCapped": false,
+    "applications": [
+      {
+        "uid": "CW/2026/0099",
+        "name": "PA26/00099",
+        "address": "1 The Green, Sparse Village",
+        "description": "Single dwelling.",
+        "appState": "Undecided",
+        "startDate": "2026-01-03",
+        "link": "https://planit.org.uk/planapplic/PA26-00099",
+        "url": null
+      }
+    ]
+  }
+]

--- a/web/scripts/generate-towns.mjs
+++ b/web/scripts/generate-towns.mjs
@@ -1,0 +1,359 @@
+/**
+ * generate-towns.mjs — one-time / occasional generator for the committed town
+ * gazetteer `web/src/data/towns.json` (`[{ slug, name, lat, lng, authorityId }]`).
+ *
+ * THIS SCRIPT IS NOT PART OF THE BUILD. It is run by a human, by hand, when the
+ * gazetteer needs (re)generating. The build (`prerender-planning.mjs`) only ever
+ * READS the committed JSON — it never downloads OS data.
+ *
+ * ── Data source ────────────────────────────────────────────────────────────
+ * OS Open Names (Ordnance Survey OpenData, Open Government Licence v3, no API
+ * key). It lists every named place in GB with a settlement classification
+ * (`LOCAL_TYPE`) and a British National Grid coordinate.
+ *
+ *   https://osdatahub.os.uk/downloads/open/OpenNames
+ *
+ * We keep only `LOCAL_TYPE in (City, Town)` — villages and hamlets are dropped
+ * to control page count and thin-content risk (issue #570 Phase 2 addendum).
+ *
+ * ── How to regenerate (manual) ─────────────────────────────────────────────
+ *   1. Download "OS Open Names" (CSV) and unzip it. The payload is a `DATA/`
+ *      directory of grid-square CSV files (no header row) plus a
+ *      `DOC/OS_Open_Names_Header.csv` listing the column order.
+ *   2. Cross-check `OS_OPEN_NAMES_COLUMNS` below against that header file — OS
+ *      occasionally revises the schema. The indices here follow the long-stable
+ *      Open Names CSV layout.
+ *   3. Run:
+ *        node scripts/generate-towns.mjs /path/to/OS_Open_Names/DATA
+ *      It filters to City/Town, converts each BNG easting/northing to WGS84
+ *      lat/lng, resolves the parent LPA from the OS DISTRICT_BOROUGH /
+ *      COUNTY_UNITARY name against `api-go/internal/geocoding/authority-mapping.json`,
+ *      de-duplicates, sorts, and overwrites `web/src/data/towns.json`.
+ *   4. Review the diff, run `npx vitest run`, and commit.
+ *
+ * ── Town → LPA resolution ──────────────────────────────────────────────────
+ * Primary path: the OS DISTRICT_BOROUGH (metropolitan/London/two-tier districts)
+ * or COUNTY_UNITARY (unitary authorities) name, looked up in the committed
+ * district-name → authority-id map. Towns whose OS administrative name does not
+ * match an authority in our list are skipped (logged), never guessed.
+ *
+ * Fallback (not automated here): for stubborn unmatched towns, reverse-geocode
+ * the OS POSTCODE_DISTRICT via postcodes.io `/outcodes/{outcode}` — it returns
+ * `admin_district` and a WGS84 centroid directly — then map that district name
+ * the same way. Left as a manual step because it makes one network call per
+ * town and must never run in CI.
+ *
+ * ── Coordinate conversion ──────────────────────────────────────────────────
+ * OS Open Names coordinates are British National Grid (OSGB36, EPSG:27700)
+ * eastings/northings. `bngToLatLon` does the standard inverse Transverse
+ * Mercator (Airy 1830) plus a Helmert datum shift to WGS84 — accurate to a few
+ * metres, far finer than the 4-dp (~11 m) coordinates we store.
+ */
+
+import { readFile, readdir, writeFile } from 'node:fs/promises';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { slugify } from './lib/slug.mjs';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+
+/** Output gazetteer path (the file the build reads). */
+const TOWNS_OUT = join(SCRIPT_DIR, '..', 'src', 'data', 'towns.json');
+
+/** District-name → authority-id map, the same one the Go geocoder uses. */
+const AUTHORITY_MAPPING_FILE = join(
+  SCRIPT_DIR,
+  '..',
+  '..',
+  'api-go',
+  'internal',
+  'geocoding',
+  'authority-mapping.json',
+);
+
+/**
+ * Zero-based column indices in the OS Open Names CSV (DATA rows have no header;
+ * this mirrors DOC/OS_Open_Names_Header.csv). Re-verify against the shipped
+ * header file when regenerating — see the script header.
+ * @type {Record<string, number>}
+ */
+export const OS_OPEN_NAMES_COLUMNS = {
+  NAME1: 2,
+  LOCAL_TYPE: 7,
+  GEOMETRY_X: 8,
+  GEOMETRY_Y: 9,
+  DISTRICT_BOROUGH: 21,
+  COUNTY_UNITARY: 24,
+};
+
+/** OS Open Names settlement classes we publish a page for. */
+const QUALIFYING_LOCAL_TYPES = new Set(['City', 'Town']);
+
+/**
+ * @param {string} localType OS `LOCAL_TYPE` value
+ * @returns {boolean} whether the place is a City or Town
+ */
+export function localTypeQualifies(localType) {
+  return QUALIFYING_LOCAL_TYPES.has(localType);
+}
+
+/**
+ * Resolve an OS administrative name to one of our authority ids. Prefers the
+ * district/borough name (covers metropolitan, London and two-tier districts);
+ * falls back to the county/unitary name (covers unitary authorities). Returns
+ * null when neither matches — the caller then skips the town.
+ *
+ * @param {string} districtBorough OS `DISTRICT_BOROUGH`
+ * @param {string} countyUnitary   OS `COUNTY_UNITARY`
+ * @param {Record<string, number>} mapping district-name -> authority-id
+ * @returns {number | null}
+ */
+export function resolveAuthorityId(districtBorough, countyUnitary, mapping) {
+  const district = (districtBorough || '').trim();
+  if (district && Object.prototype.hasOwnProperty.call(mapping, district)) {
+    return mapping[district];
+  }
+  const county = (countyUnitary || '').trim();
+  if (county && Object.prototype.hasOwnProperty.call(mapping, county)) {
+    return mapping[county];
+  }
+  return null;
+}
+
+// ── OSGB36 British National Grid -> WGS84 ──────────────────────────────────
+// Standard inverse Transverse Mercator on the Airy 1830 ellipsoid, then a
+// Helmert transformation from the OSGB36 datum to WGS84. Constants are the
+// published OS / EPSG values.
+
+const DEG = 180 / Math.PI;
+
+/**
+ * Convert a British National Grid easting/northing (OSGB36, metres) to a WGS84
+ * latitude/longitude in decimal degrees, rounded to 4 dp.
+ *
+ * @param {number} easting
+ * @param {number} northing
+ * @returns {{ lat: number, lng: number }}
+ */
+export function bngToLatLon(easting, northing) {
+  // Airy 1830 ellipsoid (the OSGB36 figure of the Earth).
+  const a = 6377563.396;
+  const b = 6356256.909;
+  const F0 = 0.9996012717; // central meridian scale factor
+  const lat0 = (49 * Math.PI) / 180; // true origin latitude
+  const lon0 = (-2 * Math.PI) / 180; // true origin longitude
+  const N0 = -100000;
+  const E0 = 400000;
+  const e2 = 1 - (b * b) / (a * a);
+  const n = (a - b) / (a + b);
+  const n2 = n * n;
+  const n3 = n * n * n;
+
+  // Iteratively solve for the footpoint latitude.
+  let lat = lat0;
+  let M = 0;
+  do {
+    lat = (northing - N0 - M) / (a * F0) + lat;
+    const Ma = (1 + n + (5 / 4) * n2 + (5 / 4) * n3) * (lat - lat0);
+    const Mb =
+      (3 * n + 3 * n2 + (21 / 8) * n3) *
+      Math.sin(lat - lat0) *
+      Math.cos(lat + lat0);
+    const Mc =
+      ((15 / 8) * n2 + (15 / 8) * n3) *
+      Math.sin(2 * (lat - lat0)) *
+      Math.cos(2 * (lat + lat0));
+    const Md = (35 / 24) * n3 * Math.sin(3 * (lat - lat0)) * Math.cos(3 * (lat + lat0));
+    M = b * F0 * (Ma - Mb + Mc - Md);
+  } while (Math.abs(northing - N0 - M) >= 0.00001);
+
+  const sinLat = Math.sin(lat);
+  const cosLat = Math.cos(lat);
+  const tanLat = Math.tan(lat);
+  const nu = (a * F0) / Math.sqrt(1 - e2 * sinLat * sinLat);
+  const rho = (a * F0 * (1 - e2)) / Math.pow(1 - e2 * sinLat * sinLat, 1.5);
+  const eta2 = nu / rho - 1;
+
+  const tan2 = tanLat * tanLat;
+  const tan4 = tan2 * tan2;
+  const sec = 1 / cosLat;
+
+  const VII = tanLat / (2 * rho * nu);
+  const VIII = (tanLat / (24 * rho * Math.pow(nu, 3))) * (5 + 3 * tan2 + eta2 - 9 * tan2 * eta2);
+  const IX = (tanLat / (720 * rho * Math.pow(nu, 5))) * (61 + 90 * tan2 + 45 * tan4);
+  const X = sec / nu;
+  const XI = (sec / (6 * Math.pow(nu, 3))) * (nu / rho + 2 * tan2);
+  const XII = (sec / (120 * Math.pow(nu, 5))) * (5 + 28 * tan2 + 24 * tan4);
+  const XIIA =
+    (sec / (5040 * Math.pow(nu, 7))) * (61 + 662 * tan2 + 1320 * tan4 + 720 * tan4 * tan2);
+
+  const dE = easting - E0;
+  const dE2 = dE * dE;
+  const latAiry = lat - VII * dE2 + VIII * dE2 * dE2 - IX * dE2 * dE2 * dE2;
+  const lonAiry =
+    lon0 + X * dE - XI * dE * dE2 + XII * dE * dE2 * dE2 - XIIA * dE * dE2 * dE2 * dE2;
+
+  return helmertAiryToWgs84(latAiry, lonAiry, a, b);
+}
+
+/**
+ * Helmert datum shift: OSGB36 (Airy) lat/lon -> WGS84 lat/lon. Goes via
+ * geocentric cartesian coordinates.
+ *
+ * @param {number} lat OSGB36 latitude (radians)
+ * @param {number} lon OSGB36 longitude (radians)
+ * @param {number} a   Airy semi-major axis
+ * @param {number} b   Airy semi-minor axis
+ * @returns {{ lat: number, lng: number }} WGS84 lat/lng in degrees, 4 dp
+ */
+function helmertAiryToWgs84(lat, lon, a, b) {
+  const e2 = 1 - (b * b) / (a * a);
+  const sinLat = Math.sin(lat);
+  const cosLat = Math.cos(lat);
+  const sinLon = Math.sin(lon);
+  const cosLon = Math.cos(lon);
+  const nu = a / Math.sqrt(1 - e2 * sinLat * sinLat);
+  const H = 0; // settlement points carry no height
+
+  const x1 = (nu + H) * cosLat * cosLon;
+  const y1 = (nu + H) * cosLat * sinLon;
+  const z1 = ((1 - e2) * nu + H) * sinLat;
+
+  // OSGB36 -> WGS84 Helmert parameters (negated WGS84 -> OSGB36 set).
+  const tx = 446.448;
+  const ty = -125.157;
+  const tz = 542.06;
+  const s = 20.4894e-6;
+  const rx = (0.1502 / 3600) * (Math.PI / 180);
+  const ry = (0.247 / 3600) * (Math.PI / 180);
+  const rz = (0.8421 / 3600) * (Math.PI / 180);
+
+  const x2 = tx + (1 + s) * x1 - rz * y1 + ry * z1;
+  const y2 = ty + rz * x1 + (1 + s) * y1 - rx * z1;
+  const z2 = tz - ry * x1 + rx * y1 + (1 + s) * z1;
+
+  // WGS84 ellipsoid.
+  const aW = 6378137.0;
+  const bW = 6356752.3142;
+  const e2W = 1 - (bW * bW) / (aW * aW);
+  const p = Math.sqrt(x2 * x2 + y2 * y2);
+  let latW = Math.atan2(z2, p * (1 - e2W));
+  let latPrev;
+  let nuW;
+  do {
+    latPrev = latW;
+    nuW = aW / Math.sqrt(1 - e2W * Math.sin(latW) * Math.sin(latW));
+    latW = Math.atan2(z2 + e2W * nuW * Math.sin(latW), p);
+  } while (Math.abs(latW - latPrev) >= 1e-12);
+  const lonW = Math.atan2(y2, x2);
+
+  return {
+    lat: round4(latW * DEG),
+    lng: round4(lonW * DEG),
+  };
+}
+
+/**
+ * @param {number} v
+ * @returns {number} v rounded to 4 decimal places
+ */
+function round4(v) {
+  return Math.round(v * 1e4) / 1e4;
+}
+
+/**
+ * Build a gazetteer record from one parsed OS Open Names CSV row, or null when
+ * the place is not a City/Town or its authority can't be resolved.
+ *
+ * @param {string[]} fields  CSV row split on commas
+ * @param {Record<string, number>} mapping district-name -> authority-id
+ * @returns {{ slug: string, name: string, lat: number, lng: number, authorityId: number } | null}
+ */
+export function townRecordFromRow(fields, mapping) {
+  const localType = fields[OS_OPEN_NAMES_COLUMNS.LOCAL_TYPE];
+  if (!localTypeQualifies(localType)) {
+    return null;
+  }
+  const name = (fields[OS_OPEN_NAMES_COLUMNS.NAME1] || '').trim();
+  if (!name) {
+    return null;
+  }
+  const authorityId = resolveAuthorityId(
+    fields[OS_OPEN_NAMES_COLUMNS.DISTRICT_BOROUGH],
+    fields[OS_OPEN_NAMES_COLUMNS.COUNTY_UNITARY],
+    mapping,
+  );
+  if (authorityId === null) {
+    return null;
+  }
+  const easting = Number(fields[OS_OPEN_NAMES_COLUMNS.GEOMETRY_X]);
+  const northing = Number(fields[OS_OPEN_NAMES_COLUMNS.GEOMETRY_Y]);
+  if (!Number.isFinite(easting) || !Number.isFinite(northing)) {
+    return null;
+  }
+  const { lat, lng } = bngToLatLon(easting, northing);
+  return { slug: slugify(name), name, lat, lng, authorityId };
+}
+
+/**
+ * Split a CSV line on commas, stripping a single layer of double quotes. OS Open
+ * Names place fields do not contain embedded commas, so a full RFC-4180 parser
+ * is unnecessary.
+ *
+ * @param {string} line
+ * @returns {string[]}
+ */
+function splitCsvLine(line) {
+  return line.split(',').map((f) => f.replace(/^"|"$/g, ''));
+}
+
+/**
+ * CLI entry: read every CSV under `dataDir`, build the gazetteer, write
+ * towns.json. Deduplicates by `authorityId/slug` and sorts for a stable diff.
+ *
+ * @param {string} dataDir OS Open Names DATA directory
+ * @returns {Promise<void>}
+ */
+async function main(dataDir) {
+  if (!dataDir) {
+    console.error(
+      'usage: node scripts/generate-towns.mjs <OS_Open_Names_DATA_dir>\n' +
+        'See the script header for the full manual regeneration steps.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const mapping = JSON.parse(await readFile(AUTHORITY_MAPPING_FILE, 'utf-8'));
+  const files = (await readdir(dataDir)).filter((f) => f.toLowerCase().endsWith('.csv'));
+
+  /** @type {Map<string, { slug: string, name: string, lat: number, lng: number, authorityId: number }>} */
+  const byKey = new Map();
+  for (const file of files) {
+    const text = await readFile(join(dataDir, file), 'utf-8');
+    for (const line of text.split(/\r?\n/)) {
+      if (!line) continue;
+      const record = townRecordFromRow(splitCsvLine(line), mapping);
+      if (record) {
+        byKey.set(`${record.authorityId}/${record.slug}`, record);
+      }
+    }
+  }
+
+  const towns = [...byKey.values()].sort(
+    (x, y) =>
+      x.authorityId - y.authorityId || x.slug.localeCompare(y.slug),
+  );
+
+  await writeFile(TOWNS_OUT, JSON.stringify(towns, null, 2) + '\n', 'utf-8');
+  console.log(
+    `[generate-towns] wrote ${towns.length} town(s) to ${TOWNS_OUT} ` +
+      `from ${files.length} OS Open Names file(s)`,
+  );
+}
+
+// Run main() only when invoked directly, not when imported by tests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main(process.argv[2]);
+}

--- a/web/scripts/lib/__tests__/generate-towns.test.mjs
+++ b/web/scripts/lib/__tests__/generate-towns.test.mjs
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  bngToLatLon,
+  localTypeQualifies,
+  resolveAuthorityId,
+  townRecordFromRow,
+  OS_OPEN_NAMES_COLUMNS,
+} from '../../generate-towns.mjs';
+
+describe('bngToLatLon (OSGB36 British National Grid -> WGS84)', () => {
+  it('converts a known central-London point to within ~100m', () => {
+    // Trafalgar Square ~ TQ 30034 80381 -> WGS84 ~ 51.5080, -0.1281.
+    const { lat, lng } = bngToLatLon(530034, 180381);
+    expect(lat).toBeCloseTo(51.508, 2);
+    expect(lng).toBeCloseTo(-0.128, 2);
+  });
+
+  it('returns coordinates inside the UK bounding box for a northern point', () => {
+    // Edinburgh ~ NT 25731 73721 -> easting 325731, northing 673721.
+    const { lat, lng } = bngToLatLon(325731, 673721);
+    expect(lat).toBeGreaterThan(55.8);
+    expect(lat).toBeLessThan(56.1);
+    expect(lng).toBeGreaterThan(-3.3);
+    expect(lng).toBeLessThan(-3.0);
+  });
+});
+
+describe('localTypeQualifies', () => {
+  it('accepts only City and Town LOCAL_TYPE values', () => {
+    expect(localTypeQualifies('City')).toBe(true);
+    expect(localTypeQualifies('Town')).toBe(true);
+    expect(localTypeQualifies('Village')).toBe(false);
+    expect(localTypeQualifies('Hamlet')).toBe(false);
+    expect(localTypeQualifies('Other Settlement')).toBe(false);
+    expect(localTypeQualifies('Suburban Area')).toBe(false);
+  });
+});
+
+describe('resolveAuthorityId', () => {
+  const mapping = { Cornwall: 52, Croydon: 301, Brent: 298 };
+
+  it('resolves via the district/borough name', () => {
+    expect(resolveAuthorityId('Croydon', '', mapping)).toBe(301);
+  });
+
+  it('falls back to the county/unitary name when no district match', () => {
+    expect(resolveAuthorityId('', 'Cornwall', mapping)).toBe(52);
+  });
+
+  it('returns null when neither name is in the authority mapping', () => {
+    expect(resolveAuthorityId('Nowhere', 'Neverland', mapping)).toBeNull();
+  });
+});
+
+describe('townRecordFromRow', () => {
+  const mapping = { Croydon: 301 };
+
+  /** Build a synthetic OS Open Names field array from a partial map. */
+  function row(values) {
+    const fields = [];
+    for (const [name, index] of Object.entries(OS_OPEN_NAMES_COLUMNS)) {
+      fields[index] = values[name] ?? '';
+    }
+    return fields;
+  }
+
+  it('builds a {slug,name,lat,lng,authorityId} record for a qualifying town', () => {
+    const fields = row({
+      NAME1: 'Croydon',
+      LOCAL_TYPE: 'Town',
+      GEOMETRY_X: '532504',
+      GEOMETRY_Y: '165522',
+      DISTRICT_BOROUGH: 'Croydon',
+    });
+    const record = townRecordFromRow(fields, mapping);
+    expect(record).not.toBeNull();
+    expect(record.slug).toBe('croydon');
+    expect(record.name).toBe('Croydon');
+    expect(record.authorityId).toBe(301);
+    expect(Number.isFinite(record.lat)).toBe(true);
+    expect(Number.isFinite(record.lng)).toBe(true);
+    // coordinates are rounded to 4 decimal places
+    expect(String(record.lat).split('.')[1]?.length ?? 0).toBeLessThanOrEqual(4);
+  });
+
+  it('skips a non-qualifying LOCAL_TYPE', () => {
+    const fields = row({
+      NAME1: 'Tiny',
+      LOCAL_TYPE: 'Village',
+      GEOMETRY_X: '530000',
+      GEOMETRY_Y: '180000',
+      DISTRICT_BOROUGH: 'Croydon',
+    });
+    expect(townRecordFromRow(fields, mapping)).toBeNull();
+  });
+
+  it('skips a town whose authority cannot be resolved', () => {
+    const fields = row({
+      NAME1: 'Orphan',
+      LOCAL_TYPE: 'Town',
+      GEOMETRY_X: '530000',
+      GEOMETRY_Y: '180000',
+      DISTRICT_BOROUGH: 'Unmapped District',
+    });
+    expect(townRecordFromRow(fields, mapping)).toBeNull();
+  });
+});

--- a/web/scripts/lib/__tests__/prerender-towns.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-towns.test.mjs
@@ -1,0 +1,275 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runPrerender } from '../../prerender-planning.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const AUTHORITY_FIXTURE = join(
+  here,
+  '..',
+  '..',
+  'fixtures',
+  'sample-authorities.json',
+);
+const TOWN_FIXTURE = join(here, '..', '..', 'fixtures', 'sample-towns.json');
+
+/** Hand-written fetch stub — no vi.fn / vi.mock. */
+class StubFetch {
+  /** @param {(url: string, init?: object) => { ok: boolean, status: number, body: unknown }} handler */
+  constructor(handler) {
+    this.calls = [];
+    this.handler = handler;
+  }
+
+  fetch = async (url, init) => {
+    this.calls.push({ url: String(url), init });
+    const { ok, status, body } = this.handler(String(url), init);
+    return { ok, status, json: async () => body };
+  };
+}
+
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+let outDir;
+
+beforeEach(async () => {
+  outDir = await mkdtemp(join(tmpdir(), 'prerender-towns-'));
+});
+
+afterEach(async () => {
+  await rm(outDir, { recursive: true, force: true });
+});
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('runPrerender — town fixture mode', () => {
+  it('emits a nested /planning/<authority>/<town>/index.html for a gated town', async () => {
+    const result = await runPrerender({
+      outDir,
+      townFixturePath: TOWN_FIXTURE,
+      logger: silentLogger,
+    });
+
+    expect(result.publishedTowns).toEqual(['cornwall/truro']);
+
+    const html = await readFile(
+      join(outDir, 'planning', 'cornwall', 'truro', 'index.html'),
+      'utf-8',
+    );
+    expect(html).toContain('<h1>Planning applications in Truro</h1>');
+    expect(html).toContain('PlanIt');
+    expect(html).toContain('Get push alerts for Truro');
+    expect(html).toContain(
+      '<link rel="canonical" href="https://towncrierapp.uk/planning/cornwall/truro"',
+    );
+  });
+
+  it('excludes a town below the coverage gate', async () => {
+    const result = await runPrerender({
+      outDir,
+      townFixturePath: TOWN_FIXTURE,
+      logger: silentLogger,
+    });
+
+    expect(
+      await exists(join(outDir, 'planning', 'cornwall', 'sparse-village')),
+    ).toBe(false);
+    expect(result.excludedTowns.map((e) => e.name)).toContain('Sparse Village');
+  });
+
+  it('the town page does not collide with the bare authority page path', async () => {
+    await runPrerender({
+      outDir,
+      townFixturePath: TOWN_FIXTURE,
+      logger: silentLogger,
+    });
+    // Town page is nested two levels deep; an authority page would be a sibling
+    // index.html directly under planning/cornwall (not emitted in town-only mode).
+    expect(
+      await exists(join(outDir, 'planning', 'cornwall', 'truro', 'index.html')),
+    ).toBe(true);
+    expect(await exists(join(outDir, 'planning', 'cornwall', 'index.html'))).toBe(
+      false,
+    );
+  });
+});
+
+describe('runPrerender — sitemap with authority and town pages', () => {
+  it('lists both authority pages and nested town pages', async () => {
+    await runPrerender({
+      outDir,
+      fixturePath: AUTHORITY_FIXTURE,
+      townFixturePath: TOWN_FIXTURE,
+      logger: silentLogger,
+    });
+
+    const sitemap = await readFile(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain(
+      '<loc>https://towncrierapp.uk/planning/basingstoke-and-deane</loc>',
+    );
+    expect(sitemap).toContain(
+      '<loc>https://towncrierapp.uk/planning/cornwall/truro</loc>',
+    );
+  });
+});
+
+describe('runPrerender — town live mode', () => {
+  const cornwallTowns = [
+    { slug: 'truro', name: 'Truro', lat: 50.2632, lng: -5.051, authorityId: 52 },
+  ];
+  const cornwallAuthorities = [
+    { id: 52, name: 'Cornwall', areaType: 'English Unitary Authority' },
+  ];
+
+  it('calls the geo endpoint with authorityId+lat+lng and X-Build-Key, then emits the nested page', async () => {
+    const stub = new StubFetch((url) => {
+      if (url.includes('/v1/applications/near')) {
+        return {
+          ok: true,
+          status: 200,
+          body: {
+            authorityId: 52,
+            lat: 50.2632,
+            lng: -5.051,
+            radius: 5000,
+            applications: [
+              {
+                uid: 'CW1',
+                name: 'PA26/0001',
+                address: 'Lemon Quay, Truro',
+                description: 'Café conversion',
+                appState: 'Permitted',
+                startDate: '2026-01-12',
+                link: 'https://planit.org.uk/planapplic/CW1',
+                url: null,
+              },
+            ],
+            total: 14,
+            totalCapped: false,
+          },
+        };
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => cornwallTowns,
+      logger: silentLogger,
+    });
+
+    expect(result.publishedTowns).toEqual(['cornwall/truro']);
+
+    const nearCalls = stub.calls.filter((c) => c.url.includes('/v1/applications/near'));
+    expect(nearCalls).toHaveLength(1);
+    expect(nearCalls[0].url).toContain('authorityId=52');
+    expect(nearCalls[0].url).toContain('lat=50.2632');
+    expect(nearCalls[0].url).toContain('lng=-5.051');
+    expect(nearCalls[0].url).toContain('limit=30');
+    expect(nearCalls[0].init.headers['X-Build-Key']).toBe('test-key');
+
+    const html = await readFile(
+      join(outDir, 'planning', 'cornwall', 'truro', 'index.html'),
+      'utf-8',
+    );
+    expect(html).toContain('<h1>Planning applications in Truro</h1>');
+  });
+
+  it('excludes a town that fails the coverage gate', async () => {
+    const stub = new StubFetch(() => ({
+      ok: true,
+      status: 200,
+      body: {
+        authorityId: 52,
+        lat: 50.2632,
+        lng: -5.051,
+        radius: 5000,
+        applications: [],
+        total: 3,
+        totalCapped: false,
+      },
+    }));
+
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => cornwallTowns,
+      logger: silentLogger,
+    });
+
+    expect(result.publishedTowns).toEqual([]);
+    expect(await exists(join(outDir, 'planning', 'cornwall', 'truro'))).toBe(false);
+  });
+
+  it('treats zero towns as a valid (non-error) build with no geo calls', async () => {
+    const stub = new StubFetch(() => {
+      throw new Error('geo endpoint must not be called');
+    });
+
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => [],
+      logger: silentLogger,
+    });
+
+    expect(result.skipped).toBe(false);
+    expect(result.publishedTowns).toEqual([]);
+    expect(stub.calls).toHaveLength(0);
+  });
+
+  it('fails loud when the geo endpoint returns an unexpected shape', async () => {
+    const stub = new StubFetch(() => ({
+      ok: true,
+      status: 200,
+      body: { not: 'what we expect' },
+    }));
+
+    await expect(
+      runPrerender({
+        outDir,
+        apiBase: 'https://api-dev.towncrierapp.uk',
+        buildKey: 'test-key',
+        fetchImpl: stub.fetch,
+        loadAuthorities: async () => cornwallAuthorities,
+        loadTowns: async () => cornwallTowns,
+        logger: silentLogger,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('fails loud when the geo endpoint returns a non-OK status', async () => {
+    const stub = new StubFetch(() => ({ ok: false, status: 503, body: null }));
+
+    await expect(
+      runPrerender({
+        outDir,
+        apiBase: 'https://api-dev.towncrierapp.uk',
+        buildKey: 'test-key',
+        fetchImpl: stub.fetch,
+        loadAuthorities: async () => cornwallAuthorities,
+        loadTowns: async () => cornwallTowns,
+        logger: silentLogger,
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/web/scripts/lib/__tests__/prerender-towns.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-towns.test.mjs
@@ -126,8 +126,11 @@ describe('runPrerender — town live mode', () => {
   const cornwallTowns = [
     { slug: 'truro', name: 'Truro', lat: 50.2632, lng: -5.051, authorityId: 52 },
   ];
+  // areaType is deliberately non-qualifying here so the authority pass is a
+  // no-op and these tests isolate the TOWN pipeline. Slug resolution
+  // (authorityId 52 -> "Cornwall" -> "cornwall") ignores areaType.
   const cornwallAuthorities = [
-    { id: 52, name: 'Cornwall', areaType: 'English Unitary Authority' },
+    { id: 52, name: 'Cornwall', areaType: 'English County' },
   ];
 
   it('calls the geo endpoint with authorityId+lat+lng and X-Build-Key, then emits the nested page', async () => {

--- a/web/scripts/lib/__tests__/prerender.test.mjs
+++ b/web/scripts/lib/__tests__/prerender.test.mjs
@@ -153,6 +153,7 @@ describe('runPrerender — live mode', () => {
       buildKey: 'test-key',
       fetchImpl: stub.fetch,
       loadAuthorities: async () => adurAndWestSussex,
+      loadTowns: async () => [],
       logger: silentLogger,
     });
 
@@ -197,6 +198,7 @@ describe('runPrerender — live mode', () => {
       loadAuthorities: async () => [
         { id: 1, name: 'Adur', areaType: 'English District' },
       ],
+      loadTowns: async () => [],
       logger: silentLogger,
     });
 
@@ -217,6 +219,7 @@ describe('runPrerender — live mode', () => {
       loadAuthorities: async () => [
         { id: 9, name: 'Surrey', areaType: 'English County' },
       ],
+      loadTowns: async () => [],
       logger: silentLogger,
     });
 

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { renderTownPage } from '../render-town-page.mjs';
+import { APP_DOWNLOAD_URL, SITE_ORIGIN } from '../constants.mjs';
+
+/**
+ * @param {Partial<import('../render-town-page.mjs').TownPageData>} [overrides]
+ * @returns {import('../render-town-page.mjs').TownPageData}
+ */
+function townData(overrides = {}) {
+  return {
+    townName: 'Truro',
+    townSlug: 'truro',
+    authorityName: 'Cornwall',
+    authoritySlug: 'cornwall',
+    authorityId: 52,
+    total: 18,
+    totalCapped: false,
+    applications: [
+      {
+        uid: 'CW/2026/0001',
+        name: '26/0001',
+        address: 'Lemon Quay, Truro, TR1 2LW',
+        description: 'Change of use of ground floor from retail to café',
+        appState: 'Permitted',
+        startDate: '2026-01-12',
+        link: 'https://planit.org.uk/planapplic/CW-26-0001',
+        url: 'https://planning.cornwall.gov.uk/26-0001',
+      },
+      {
+        uid: 'CW/2026/0002',
+        name: '26/0002',
+        address: 'Boscawen Street, Truro, TR1 2QU',
+        description: 'Two-storey rear extension to a listed building',
+        appState: 'Rejected',
+        startDate: '2026-02-01',
+        link: 'https://planit.org.uk/planapplic/CW-26-0002',
+        url: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('renderTownPage', () => {
+  it('is a complete HTML document with the lang attribute', () => {
+    const html = renderTownPage(townData());
+    expect(html.startsWith('<!doctype html>')).toBe(true);
+    expect(html).toContain('<html lang="en">');
+  });
+
+  it('renders the town H1 (not the authority)', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain('<h1>Planning applications in Truro</h1>');
+  });
+
+  it('canonicalises to the NESTED /planning/<authority>/<town> URL', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain(
+      `<link rel="canonical" href="${SITE_ORIGIN}/planning/cornwall/truro"`,
+    );
+  });
+
+  it('sets the OG url to the nested town URL', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain(
+      `property="og:url" content="${SITE_ORIGIN}/planning/cornwall/truro"`,
+    );
+    expect(html).toContain('property="og:title"');
+    expect(html).toContain('property="og:type"');
+  });
+
+  it('embeds schema.org ItemList and BreadcrumbList JSON-LD', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain('application/ld+json');
+    expect(html).toContain('"@type":"ItemList"');
+    expect(html).toContain('"@type":"BreadcrumbList"');
+  });
+
+  it('renders a breadcrumb linking up to the authority page', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain('class="breadcrumb"');
+    expect(html).toContain(`href="${SITE_ORIGIN}/planning/cornwall"`);
+    // The breadcrumb names the parent authority.
+    expect(html).toMatch(/breadcrumb[\s\S]*?Cornwall/);
+  });
+
+  it('renders each application address, status label, date and links', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain('Lemon Quay, Truro, TR1 2LW');
+    expect(html).toContain('Change of use of ground floor from retail to café');
+    expect(html).toContain('Granted'); // Permitted -> Granted
+    expect(html).toContain('Refused'); // Rejected -> Refused
+    expect(html).toContain('12 Jan 2026');
+    expect(html).toContain('https://planning.cornwall.gov.uk/26-0001');
+    expect(html).toContain('https://planit.org.uk/planapplic/CW-26-0001');
+  });
+
+  it('shows the exact total in the lead line when not capped', () => {
+    const html = renderTownPage(townData({ total: 18, totalCapped: false }));
+    expect(html).toContain('18');
+    expect(html).toContain('Truro');
+  });
+
+  it('shows a capped count as "200+" when the read hit the cap', () => {
+    const html = renderTownPage(townData({ total: 200, totalCapped: true }));
+    expect(html).toContain('200+');
+  });
+
+  it('includes the evergreen how-to-comment explainer naming the town and its authority', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain('How to comment on a planning application in Truro');
+    expect(html).toContain(
+      'Cornwall is the local planning authority responsible',
+    );
+  });
+
+  it('includes a CTA to the App Store for the town', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain('Get push alerts for Truro');
+    expect(html).toContain(APP_DOWNLOAD_URL);
+  });
+
+  it('carries the mandatory PlanIt + OGL + OS + OSM attribution', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain('PlanIt');
+    expect(html).toContain('Open Government Licence');
+    expect(html).toContain('Ordnance Survey');
+    expect(html).toContain('OpenStreetMap');
+  });
+
+  it('escapes HTML in application fields to prevent markup injection', () => {
+    const html = renderTownPage(
+      townData({
+        applications: [
+          {
+            uid: 'x',
+            name: 'x',
+            address: '<script>alert(1)</script>',
+            description: 'safe',
+            appState: 'Permitted',
+            startDate: null,
+            link: null,
+            url: null,
+          },
+        ],
+      }),
+    );
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+});

--- a/web/scripts/lib/__tests__/town-path.test.mjs
+++ b/web/scripts/lib/__tests__/town-path.test.mjs
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAuthority, townPagePath } from '../town-path.mjs';
+import { slugify } from '../slug.mjs';
+
+const AUTHORITIES = [
+  { id: 52, name: 'Cornwall', areaType: 'English Unitary Authority' },
+  { id: 301, name: 'Croydon', areaType: 'London Borough' },
+  { id: 298, name: 'Brent', areaType: 'London Borough' },
+];
+
+describe('resolveAuthority', () => {
+  it('maps an authorityId to its name and lowercase-hyphenated slug', () => {
+    expect(resolveAuthority(52, AUTHORITIES)).toEqual({
+      name: 'Cornwall',
+      slug: 'cornwall',
+    });
+    expect(resolveAuthority(298, AUTHORITIES)).toEqual({
+      name: 'Brent',
+      slug: 'brent',
+    });
+  });
+
+  it('throws loudly when the authorityId is not in the list (drift guard)', () => {
+    expect(() => resolveAuthority(99999, AUTHORITIES)).toThrow();
+  });
+});
+
+describe('townPagePath', () => {
+  it('builds a nested <authority-slug>/<town-slug> path', () => {
+    const { slug } = resolveAuthority(52, AUTHORITIES);
+    expect(townPagePath(slug, 'truro')).toBe('cornwall/truro');
+  });
+
+  it('never collides with a bare authority page path (two segments, not one)', () => {
+    // The authority page lives at /planning/<authority-slug>; a town page lives
+    // one level deeper at /planning/<authority-slug>/<town-slug>. The nested path
+    // must always carry a slash and split into exactly two segments, so it can
+    // never equal the single-segment authority slug.
+    const authoritySlug = slugify('Croydon'); // 'croydon'
+    const townSlug = slugify('Croydon'); // a town also called Croydon
+    const path = townPagePath(authoritySlug, townSlug);
+
+    expect(path).toBe('croydon/croydon');
+    expect(path).not.toBe(authoritySlug);
+    expect(path.split('/')).toHaveLength(2);
+  });
+});

--- a/web/scripts/lib/__tests__/towns-data.test.mjs
+++ b/web/scripts/lib/__tests__/towns-data.test.mjs
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import {
+  loadTownsFromFile,
+  TOWNS_FILE,
+  loadAuthoritiesFromFile,
+  AUTHORITIES_FILE,
+} from '../../prerender-planning.mjs';
+
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+describe('loadTownsFromFile', () => {
+  const FAKE_PATH = '/fake/towns.json';
+
+  it('loads and validates a well-formed gazetteer', async () => {
+    const readImpl = async () =>
+      JSON.stringify([
+        { slug: 'truro', name: 'Truro', lat: 50.2632, lng: -5.051, authorityId: 52 },
+      ]);
+    const towns = await loadTownsFromFile(FAKE_PATH, readImpl);
+    expect(towns).toHaveLength(1);
+    expect(towns[0]).toEqual({
+      slug: 'truro',
+      name: 'Truro',
+      lat: 50.2632,
+      lng: -5.051,
+      authorityId: 52,
+    });
+  });
+
+  it('throws when the file is missing', async () => {
+    const readImpl = async () => {
+      throw new Error('ENOENT: no such file or directory');
+    };
+    await expect(loadTownsFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
+  });
+
+  it('throws on invalid JSON', async () => {
+    const readImpl = async () => 'not json';
+    await expect(loadTownsFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
+  });
+
+  it('throws on a non-array payload', async () => {
+    const readImpl = async () => JSON.stringify({ towns: [] });
+    await expect(loadTownsFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
+  });
+
+  it('throws on a malformed town row (non-numeric coordinate)', async () => {
+    const readImpl = async () =>
+      JSON.stringify([
+        { slug: 'x', name: 'X', lat: 'nope', lng: 0, authorityId: 1 },
+      ]);
+    await expect(loadTownsFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
+  });
+
+  it('throws on a malformed town row (missing authorityId)', async () => {
+    const readImpl = async () =>
+      JSON.stringify([{ slug: 'x', name: 'X', lat: 0, lng: 0 }]);
+    await expect(loadTownsFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
+  });
+});
+
+describe('committed towns.json gazetteer', () => {
+  it('parses, is an array, and every row has slug/name/numeric lat-lng/authorityId', async () => {
+    const towns = await loadTownsFromFile(TOWNS_FILE, readFile);
+    expect(Array.isArray(towns)).toBe(true);
+    for (const t of towns) {
+      expect(t.slug).toMatch(SLUG_PATTERN);
+      expect(typeof t.name).toBe('string');
+      expect(t.name.length).toBeGreaterThan(0);
+      expect(Number.isFinite(t.lat)).toBe(true);
+      expect(Number.isFinite(t.lng)).toBe(true);
+      expect(Number.isFinite(t.authorityId)).toBe(true);
+    }
+  });
+
+  it('has unique slugs within each authority (no nested-path collisions)', async () => {
+    const towns = await loadTownsFromFile(TOWNS_FILE, readFile);
+    const seen = new Set();
+    for (const t of towns) {
+      const key = `${t.authorityId}/${t.slug}`;
+      expect(seen.has(key)).toBe(false);
+      seen.add(key);
+    }
+  });
+
+  it('every town authorityId exists in the committed authority list (drift guard)', async () => {
+    const towns = await loadTownsFromFile(TOWNS_FILE, readFile);
+    const authorities = await loadAuthoritiesFromFile(AUTHORITIES_FILE, readFile);
+    const ids = new Set(authorities.map((a) => a.id));
+    for (const t of towns) {
+      expect(ids.has(t.authorityId)).toBe(true);
+    }
+  });
+});

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -1,27 +1,14 @@
+import { SITE_ORIGIN, APP_DOWNLOAD_URL } from './constants.mjs';
+import { escapeHtml, leadLine } from './format.mjs';
 import {
-  SITE_ORIGIN,
-  APP_DOWNLOAD_URL,
-  ATTRIBUTION_LINES,
-} from './constants.mjs';
-import {
-  escapeHtml,
-  truncate,
-  formatDate,
-  statusDisplayLabel,
-  countByState,
-  leadLine,
-} from './format.mjs';
+  pageStyles,
+  renderApplicationsList,
+  renderStats,
+  renderAttributionList,
+} from './render-shared.mjs';
 
 /**
- * @typedef {Object} PlanningApplicationItem
- * @property {string} uid
- * @property {string} name
- * @property {string} address
- * @property {string} description
- * @property {string | null} appState
- * @property {string | null} startDate  yyyy-MM-dd
- * @property {string | null} link       council-portal deep link
- * @property {string | null} url        application detail link
+ * @typedef {import('./render-shared.mjs').PlanningApplicationItem} PlanningApplicationItem
  */
 
 /**
@@ -33,82 +20,6 @@ import {
  * @property {boolean} totalCapped
  * @property {PlanningApplicationItem[]} applications
  */
-
-const MAX_DESCRIPTION_LENGTH = 160;
-
-const STATUS_MODIFIER = {
-  Permitted: 'permitted',
-  Conditions: 'conditions',
-  Rejected: 'rejected',
-  Withdrawn: 'withdrawn',
-  Appealed: 'appealed',
-};
-
-/**
- * @param {string | null} appState
- * @returns {string}
- */
-function statusModifier(appState) {
-  if (appState === null || appState === undefined) {
-    return 'default';
-  }
-  return STATUS_MODIFIER[appState] ?? 'default';
-}
-
-/**
- * @param {PlanningApplicationItem} app
- * @returns {string}
- */
-function renderApplication(app) {
-  const label = escapeHtml(statusDisplayLabel(app.appState));
-  const modifier = statusModifier(app.appState);
-  const date = formatDate(app.startDate);
-  const description = escapeHtml(truncate(app.description, MAX_DESCRIPTION_LENGTH));
-
-  const links = [];
-  if (app.link) {
-    links.push(
-      `<a class="appLink" href="${escapeHtml(app.link)}" rel="nofollow noopener" target="_blank">View on the council portal</a>`,
-    );
-  }
-  if (app.url) {
-    links.push(
-      `<a class="appLink" href="${escapeHtml(app.url)}" rel="nofollow noopener" target="_blank">Application details</a>`,
-    );
-  }
-
-  return `      <li class="appCard">
-        <div class="appCard__head">
-          <h3 class="appCard__ref">${escapeHtml(app.name)}</h3>
-          <span class="status status--${modifier}">${label}</span>
-        </div>
-        <p class="appCard__address">${escapeHtml(app.address)}</p>
-        <p class="appCard__desc">${description}</p>
-        <div class="appCard__meta">
-          ${date ? `<span class="appCard__date">${escapeHtml(date)}</span>` : ''}
-          ${links.join('\n          ')}
-        </div>
-      </li>`;
-}
-
-/**
- * @param {PlanningApplicationItem[]} applications
- * @returns {string}
- */
-function renderStats(applications) {
-  const rows = countByState(applications)
-    .map(
-      (s) =>
-        `        <li class="statRow"><span class="statRow__label">${escapeHtml(s.label)}</span><span class="statRow__count">${s.count}</span></li>`,
-    )
-    .join('\n');
-  return `    <section class="stats" aria-label="Application status breakdown">
-      <h2 class="stats__heading">Status breakdown</h2>
-      <ul class="statList">
-${rows}
-      </ul>
-    </section>`;
-}
 
 /**
  * @param {PlanningPageData} data
@@ -149,147 +60,6 @@ function buildJsonLd(data, canonical) {
 }
 
 /**
- * Inline stylesheet for the standalone static page. Self-contained (no external
- * CSS request) for first-byte readability and strong Core Web Vitals. Uses the
- * Town Crier design tokens — dark by default, light via prefers-color-scheme —
- * mirroring `src/styles/tokens.css`.
- *
- * @returns {string}
- */
-function pageStyles() {
-  return `    :root {
-      --tc-amber: #E9A620;
-      --tc-amber-hover: #F0B83A;
-      --tc-background: #1A1A1E;
-      --tc-surface: #242428;
-      --tc-text-primary: #F1EFE9;
-      --tc-text-secondary: #9B9590;
-      --tc-text-on-accent: #1C1917;
-      --tc-status-permitted: #34C759;
-      --tc-status-conditions: #FF9500;
-      --tc-status-rejected: #FF453A;
-      --tc-status-withdrawn: #8E8A85;
-      --tc-status-appealed: #A78BFA;
-      --tc-status-default: #9B9590;
-      --tc-border: #3A3A3F;
-      --tc-radius-md: 12px;
-      --tc-radius-full: 9999px;
-      --tc-space-sm: 8px;
-      --tc-space-md: 16px;
-      --tc-space-lg: 24px;
-      --tc-space-xl: 32px;
-      --tc-space-xxl: 48px;
-      --tc-font-family: 'Inter', system-ui, -apple-system, sans-serif;
-      --tc-content-max-width: 760px;
-    }
-    @media (prefers-color-scheme: light) {
-      :root {
-        --tc-amber: #D4910A;
-        --tc-amber-hover: #B87A08;
-        --tc-background: #FAF8F5;
-        --tc-surface: #FFFFFF;
-        --tc-text-primary: #1C1917;
-        --tc-text-secondary: #6B6560;
-        --tc-text-on-accent: #FFFFFF;
-        --tc-status-permitted: #1A7D37;
-        --tc-status-conditions: #A85A0A;
-        --tc-status-rejected: #C42B2B;
-        --tc-status-withdrawn: #7A7570;
-        --tc-status-appealed: #7C3AED;
-        --tc-status-default: #6B6560;
-        --tc-border: #E8E4DF;
-      }
-    }
-    @font-face {
-      font-family: 'Inter';
-      font-style: normal;
-      font-weight: 400 700;
-      font-display: swap;
-      src: url('/fonts/inter-latin.woff2') format('woff2');
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      font-family: var(--tc-font-family);
-      background: var(--tc-background);
-      color: var(--tc-text-primary);
-      line-height: 1.4;
-      -webkit-font-smoothing: antialiased;
-    }
-    .wrap {
-      max-width: var(--tc-content-max-width);
-      margin: 0 auto;
-      padding: var(--tc-space-md);
-    }
-    .siteHeader {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      padding: var(--tc-space-md) 0;
-      border-bottom: 1px solid var(--tc-border);
-    }
-    .siteHeader a { color: var(--tc-text-primary); text-decoration: none; font-weight: 700; }
-    h1 { font-size: 2rem; line-height: 1.2; margin: var(--tc-space-xl) 0 var(--tc-space-sm); }
-    h2 { font-size: 1.5rem; margin: var(--tc-space-xl) 0 var(--tc-space-md); }
-    h3 { font-size: 1.125rem; margin: 0; }
-    .lead { font-size: 1.125rem; color: var(--tc-text-secondary); margin: 0 0 var(--tc-space-lg); }
-    .appList, .statList { list-style: none; margin: 0; padding: 0; display: grid; gap: var(--tc-space-md); }
-    .appCard {
-      background: var(--tc-surface);
-      border: 1px solid var(--tc-border);
-      border-radius: var(--tc-radius-md);
-      padding: var(--tc-space-md);
-    }
-    .appCard__head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--tc-space-sm); }
-    .appCard__address { margin: var(--tc-space-sm) 0 var(--tc-space-sm); font-weight: 600; }
-    .appCard__desc { margin: 0 0 var(--tc-space-sm); color: var(--tc-text-secondary); }
-    .appCard__meta { display: flex; flex-wrap: wrap; gap: var(--tc-space-md); align-items: center; font-size: 0.875rem; }
-    .appCard__date { color: var(--tc-text-secondary); }
-    .appLink { color: var(--tc-amber); text-decoration: none; font-weight: 600; }
-    .appLink:hover { color: var(--tc-amber-hover); text-decoration: underline; }
-    .status {
-      display: inline-flex;
-      align-items: center;
-      border-radius: var(--tc-radius-full);
-      padding: 2px var(--tc-space-sm);
-      font-size: 0.8125rem;
-      font-weight: 600;
-      white-space: nowrap;
-      color: var(--tc-status-default);
-      border: 1px solid currentColor;
-    }
-    .status--permitted { color: var(--tc-status-permitted); }
-    .status--conditions { color: var(--tc-status-conditions); }
-    .status--rejected { color: var(--tc-status-rejected); }
-    .status--withdrawn { color: var(--tc-status-withdrawn); }
-    .status--appealed { color: var(--tc-status-appealed); }
-    .statRow { display: flex; justify-content: space-between; background: var(--tc-surface); border: 1px solid var(--tc-border); border-radius: var(--tc-radius-md); padding: var(--tc-space-sm) var(--tc-space-md); }
-    .statRow__count { font-weight: 700; }
-    .explainer p { color: var(--tc-text-secondary); }
-    .cta {
-      margin: var(--tc-space-xl) 0;
-      padding: var(--tc-space-lg);
-      background: var(--tc-surface);
-      border: 1px solid var(--tc-border);
-      border-radius: var(--tc-radius-md);
-      text-align: center;
-    }
-    .cta__button {
-      display: inline-block;
-      margin-top: var(--tc-space-md);
-      padding: var(--tc-space-sm) var(--tc-space-lg);
-      background: var(--tc-amber);
-      color: var(--tc-text-on-accent);
-      border-radius: var(--tc-radius-md);
-      text-decoration: none;
-      font-weight: 700;
-    }
-    .siteFooter { margin-top: var(--tc-space-xxl); padding: var(--tc-space-lg) 0; border-top: 1px solid var(--tc-border); color: var(--tc-text-secondary); font-size: 0.875rem; }
-    .attribution { list-style: none; margin: 0 0 var(--tc-space-md); padding: 0; display: grid; gap: var(--tc-space-sm); }
-    .siteFooter a { color: var(--tc-text-secondary); }`;
-}
-
-/**
  * Render a complete, hydration-free static HTML page for one authority.
  *
  * @param {PlanningPageData} data
@@ -306,10 +76,8 @@ export function renderPlanningPage(data) {
   const jsonLd = buildJsonLd(data, canonical);
   const year = new Date().getFullYear();
 
-  const applicationsList = data.applications.map(renderApplication).join('\n');
-  const attribution = ATTRIBUTION_LINES.map(
-    (line) => `        <li>${escapeHtml(line)}</li>`,
-  ).join('\n');
+  const applicationsList = renderApplicationsList(data.applications);
+  const attribution = renderAttributionList();
 
   return `<!doctype html>
 <html lang="en">

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -1,0 +1,276 @@
+/**
+ * Building blocks shared by the authority-page renderer (`render-page.mjs`) and
+ * the town-page renderer (`render-town-page.mjs`). Both pages are the same
+ * hydration-free static template — only the title, canonical URL, breadcrumb and
+ * a little evergreen copy differ — so the application cards, status stats,
+ * attribution footer and the inline stylesheet live here once.
+ *
+ * Everything emitted here is destined for raw HTML, so data-derived strings are
+ * passed through `escapeHtml` before interpolation.
+ */
+
+import { ATTRIBUTION_LINES } from './constants.mjs';
+import {
+  escapeHtml,
+  truncate,
+  formatDate,
+  statusDisplayLabel,
+  countByState,
+} from './format.mjs';
+
+/**
+ * @typedef {Object} PlanningApplicationItem
+ * @property {string} uid
+ * @property {string} name
+ * @property {string} address
+ * @property {string} description
+ * @property {string | null} appState
+ * @property {string | null} startDate  yyyy-MM-dd
+ * @property {string | null} link       council-portal deep link
+ * @property {string | null} url        application detail link
+ */
+
+const MAX_DESCRIPTION_LENGTH = 160;
+
+const STATUS_MODIFIER = {
+  Permitted: 'permitted',
+  Conditions: 'conditions',
+  Rejected: 'rejected',
+  Withdrawn: 'withdrawn',
+  Appealed: 'appealed',
+};
+
+/**
+ * @param {string | null} appState
+ * @returns {string}
+ */
+function statusModifier(appState) {
+  if (appState === null || appState === undefined) {
+    return 'default';
+  }
+  return STATUS_MODIFIER[appState] ?? 'default';
+}
+
+/**
+ * @param {PlanningApplicationItem} app
+ * @returns {string}
+ */
+function renderApplication(app) {
+  const label = escapeHtml(statusDisplayLabel(app.appState));
+  const modifier = statusModifier(app.appState);
+  const date = formatDate(app.startDate);
+  const description = escapeHtml(truncate(app.description, MAX_DESCRIPTION_LENGTH));
+
+  const links = [];
+  if (app.link) {
+    links.push(
+      `<a class="appLink" href="${escapeHtml(app.link)}" rel="nofollow noopener" target="_blank">View on the council portal</a>`,
+    );
+  }
+  if (app.url) {
+    links.push(
+      `<a class="appLink" href="${escapeHtml(app.url)}" rel="nofollow noopener" target="_blank">Application details</a>`,
+    );
+  }
+
+  return `      <li class="appCard">
+        <div class="appCard__head">
+          <h3 class="appCard__ref">${escapeHtml(app.name)}</h3>
+          <span class="status status--${modifier}">${label}</span>
+        </div>
+        <p class="appCard__address">${escapeHtml(app.address)}</p>
+        <p class="appCard__desc">${description}</p>
+        <div class="appCard__meta">
+          ${date ? `<span class="appCard__date">${escapeHtml(date)}</span>` : ''}
+          ${links.join('\n          ')}
+        </div>
+      </li>`;
+}
+
+/**
+ * Render the recent-applications list body (the `<li>` cards joined by newlines).
+ *
+ * @param {PlanningApplicationItem[]} applications
+ * @returns {string}
+ */
+export function renderApplicationsList(applications) {
+  return applications.map(renderApplication).join('\n');
+}
+
+/**
+ * @param {PlanningApplicationItem[]} applications
+ * @returns {string}
+ */
+export function renderStats(applications) {
+  const rows = countByState(applications)
+    .map(
+      (s) =>
+        `        <li class="statRow"><span class="statRow__label">${escapeHtml(s.label)}</span><span class="statRow__count">${s.count}</span></li>`,
+    )
+    .join('\n');
+  return `    <section class="stats" aria-label="Application status breakdown">
+      <h2 class="stats__heading">Status breakdown</h2>
+      <ul class="statList">
+${rows}
+      </ul>
+    </section>`;
+}
+
+/**
+ * Render the mandatory data-attribution `<li>` items (ADR 0006). Required on
+ * every public page — authority and town alike.
+ *
+ * @returns {string}
+ */
+export function renderAttributionList() {
+  return ATTRIBUTION_LINES.map(
+    (line) => `        <li>${escapeHtml(line)}</li>`,
+  ).join('\n');
+}
+
+/**
+ * Inline stylesheet for the standalone static pages. Self-contained (no external
+ * CSS request) for first-byte readability and strong Core Web Vitals. Uses the
+ * Town Crier design tokens — dark by default, light via prefers-color-scheme —
+ * mirroring `src/styles/tokens.css`.
+ *
+ * @returns {string}
+ */
+export function pageStyles() {
+  return `    :root {
+      --tc-amber: #E9A620;
+      --tc-amber-hover: #F0B83A;
+      --tc-background: #1A1A1E;
+      --tc-surface: #242428;
+      --tc-text-primary: #F1EFE9;
+      --tc-text-secondary: #9B9590;
+      --tc-text-on-accent: #1C1917;
+      --tc-status-permitted: #34C759;
+      --tc-status-conditions: #FF9500;
+      --tc-status-rejected: #FF453A;
+      --tc-status-withdrawn: #8E8A85;
+      --tc-status-appealed: #A78BFA;
+      --tc-status-default: #9B9590;
+      --tc-border: #3A3A3F;
+      --tc-radius-md: 12px;
+      --tc-radius-full: 9999px;
+      --tc-space-sm: 8px;
+      --tc-space-md: 16px;
+      --tc-space-lg: 24px;
+      --tc-space-xl: 32px;
+      --tc-space-xxl: 48px;
+      --tc-font-family: 'Inter', system-ui, -apple-system, sans-serif;
+      --tc-content-max-width: 760px;
+    }
+    @media (prefers-color-scheme: light) {
+      :root {
+        --tc-amber: #D4910A;
+        --tc-amber-hover: #B87A08;
+        --tc-background: #FAF8F5;
+        --tc-surface: #FFFFFF;
+        --tc-text-primary: #1C1917;
+        --tc-text-secondary: #6B6560;
+        --tc-text-on-accent: #FFFFFF;
+        --tc-status-permitted: #1A7D37;
+        --tc-status-conditions: #A85A0A;
+        --tc-status-rejected: #C42B2B;
+        --tc-status-withdrawn: #7A7570;
+        --tc-status-appealed: #7C3AED;
+        --tc-status-default: #6B6560;
+        --tc-border: #E8E4DF;
+      }
+    }
+    @font-face {
+      font-family: 'Inter';
+      font-style: normal;
+      font-weight: 400 700;
+      font-display: swap;
+      src: url('/fonts/inter-latin.woff2') format('woff2');
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: var(--tc-font-family);
+      background: var(--tc-background);
+      color: var(--tc-text-primary);
+      line-height: 1.4;
+      -webkit-font-smoothing: antialiased;
+    }
+    .wrap {
+      max-width: var(--tc-content-max-width);
+      margin: 0 auto;
+      padding: var(--tc-space-md);
+    }
+    .siteHeader {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: var(--tc-space-md) 0;
+      border-bottom: 1px solid var(--tc-border);
+    }
+    .siteHeader a { color: var(--tc-text-primary); text-decoration: none; font-weight: 700; }
+    .breadcrumb { margin: var(--tc-space-md) 0 0; font-size: 0.875rem; color: var(--tc-text-secondary); }
+    .breadcrumb ol { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: var(--tc-space-sm); }
+    .breadcrumb li::after { content: '/'; margin-left: var(--tc-space-sm); color: var(--tc-text-secondary); }
+    .breadcrumb li:last-child::after { content: ''; margin: 0; }
+    .breadcrumb a { color: var(--tc-text-secondary); text-decoration: none; }
+    .breadcrumb a:hover { color: var(--tc-amber); text-decoration: underline; }
+    h1 { font-size: 2rem; line-height: 1.2; margin: var(--tc-space-xl) 0 var(--tc-space-sm); }
+    h2 { font-size: 1.5rem; margin: var(--tc-space-xl) 0 var(--tc-space-md); }
+    h3 { font-size: 1.125rem; margin: 0; }
+    .lead { font-size: 1.125rem; color: var(--tc-text-secondary); margin: 0 0 var(--tc-space-lg); }
+    .appList, .statList { list-style: none; margin: 0; padding: 0; display: grid; gap: var(--tc-space-md); }
+    .appCard {
+      background: var(--tc-surface);
+      border: 1px solid var(--tc-border);
+      border-radius: var(--tc-radius-md);
+      padding: var(--tc-space-md);
+    }
+    .appCard__head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--tc-space-sm); }
+    .appCard__address { margin: var(--tc-space-sm) 0 var(--tc-space-sm); font-weight: 600; }
+    .appCard__desc { margin: 0 0 var(--tc-space-sm); color: var(--tc-text-secondary); }
+    .appCard__meta { display: flex; flex-wrap: wrap; gap: var(--tc-space-md); align-items: center; font-size: 0.875rem; }
+    .appCard__date { color: var(--tc-text-secondary); }
+    .appLink { color: var(--tc-amber); text-decoration: none; font-weight: 600; }
+    .appLink:hover { color: var(--tc-amber-hover); text-decoration: underline; }
+    .status {
+      display: inline-flex;
+      align-items: center;
+      border-radius: var(--tc-radius-full);
+      padding: 2px var(--tc-space-sm);
+      font-size: 0.8125rem;
+      font-weight: 600;
+      white-space: nowrap;
+      color: var(--tc-status-default);
+      border: 1px solid currentColor;
+    }
+    .status--permitted { color: var(--tc-status-permitted); }
+    .status--conditions { color: var(--tc-status-conditions); }
+    .status--rejected { color: var(--tc-status-rejected); }
+    .status--withdrawn { color: var(--tc-status-withdrawn); }
+    .status--appealed { color: var(--tc-status-appealed); }
+    .statRow { display: flex; justify-content: space-between; background: var(--tc-surface); border: 1px solid var(--tc-border); border-radius: var(--tc-radius-md); padding: var(--tc-space-sm) var(--tc-space-md); }
+    .statRow__count { font-weight: 700; }
+    .explainer p { color: var(--tc-text-secondary); }
+    .cta {
+      margin: var(--tc-space-xl) 0;
+      padding: var(--tc-space-lg);
+      background: var(--tc-surface);
+      border: 1px solid var(--tc-border);
+      border-radius: var(--tc-radius-md);
+      text-align: center;
+    }
+    .cta__button {
+      display: inline-block;
+      margin-top: var(--tc-space-md);
+      padding: var(--tc-space-sm) var(--tc-space-lg);
+      background: var(--tc-amber);
+      color: var(--tc-text-on-accent);
+      border-radius: var(--tc-radius-md);
+      text-decoration: none;
+      font-weight: 700;
+    }
+    .siteFooter { margin-top: var(--tc-space-xxl); padding: var(--tc-space-lg) 0; border-top: 1px solid var(--tc-border); color: var(--tc-text-secondary); font-size: 0.875rem; }
+    .attribution { list-style: none; margin: 0 0 var(--tc-space-md); padding: 0; display: grid; gap: var(--tc-space-sm); }
+    .siteFooter a { color: var(--tc-text-secondary); }`;
+}

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -1,0 +1,199 @@
+/**
+ * Static renderer for a town-level SEO page (`/planning/<authority>/<town>`).
+ * It is the same hydration-free template as the authority page (shared cards,
+ * stats, attribution and stylesheet from `render-shared.mjs`), retitled to the
+ * town and nested one level deeper:
+ *
+ *   - H1 + lead + CTA + explainer name the TOWN
+ *   - a breadcrumb climbs back up to the parent authority page
+ *   - the canonical / OG url / sitemap entry are the nested town URL
+ *   - schema.org carries an ItemList, a Dataset and a BreadcrumbList
+ *
+ * Data comes only from our own geo endpoint (Cosmos-backed) — never PlanIt. The
+ * build key never reaches this output.
+ */
+
+import { SITE_ORIGIN, APP_DOWNLOAD_URL } from './constants.mjs';
+import { escapeHtml, leadLine } from './format.mjs';
+import {
+  pageStyles,
+  renderApplicationsList,
+  renderStats,
+  renderAttributionList,
+} from './render-shared.mjs';
+
+/**
+ * @typedef {Object} TownPageData
+ * @property {string} townName        display name, e.g. "Truro"
+ * @property {string} townSlug        lowercase-hyphenated, e.g. "truro"
+ * @property {string} authorityName   parent authority display name
+ * @property {string} authoritySlug   parent authority slug, e.g. "cornwall"
+ * @property {number} authorityId
+ * @property {number} total
+ * @property {boolean} totalCapped
+ * @property {import('./render-shared.mjs').PlanningApplicationItem[]} applications
+ */
+
+/**
+ * Build the schema.org JSON-LD for a town page: an ItemList of the rendered
+ * applications, a Dataset describing the page, and a BreadcrumbList that mirrors
+ * the visible Home › Authority › Town trail. Safe to embed inside a <script>.
+ *
+ * @param {TownPageData} data
+ * @param {string} canonical            absolute town-page URL
+ * @param {string} authorityCanonical   absolute parent authority-page URL
+ * @returns {string}
+ */
+function buildTownJsonLd(data, canonical, authorityCanonical) {
+  const itemList = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: `Planning applications in ${data.townName}`,
+    url: canonical,
+    numberOfItems: data.applications.length,
+    itemListElement: data.applications.map((app, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: [app.name, app.address].filter(Boolean).join(' — '),
+      url: app.url || app.link || canonical,
+    })),
+  };
+  const dataset = {
+    '@context': 'https://schema.org',
+    '@type': 'Dataset',
+    name: `Recent planning applications in ${data.townName}`,
+    description: `Recent local planning applications in and around ${data.townName}, ${data.authorityName}, drawn from Town Crier's planning-application snapshot.`,
+    url: canonical,
+    isAccessibleForFree: true,
+    creator: {
+      '@type': 'Organization',
+      name: 'PlanIt',
+      url: 'https://planit.org.uk',
+    },
+    license:
+      'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/',
+  };
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Town Crier', item: `${SITE_ORIGIN}/` },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: data.authorityName,
+        item: authorityCanonical,
+      },
+      { '@type': 'ListItem', position: 3, name: data.townName, item: canonical },
+    ],
+  };
+  // Escape "<" so a malicious data value can never close the <script> element.
+  return JSON.stringify([itemList, dataset, breadcrumb]).replace(/</g, '\\u003c');
+}
+
+/**
+ * Render a complete, hydration-free static HTML page for one town.
+ *
+ * @param {TownPageData} data
+ * @returns {string}
+ */
+export function renderTownPage(data) {
+  const town = escapeHtml(data.townName);
+  const authority = escapeHtml(data.authorityName);
+  const canonical = `${SITE_ORIGIN}/planning/${data.authoritySlug}/${data.townSlug}`;
+  const authorityCanonical = `${SITE_ORIGIN}/planning/${data.authoritySlug}`;
+  const lead = escapeHtml(leadLine(data.townName, data.total, data.totalCapped));
+  const title = `Planning applications in ${town} | Town Crier`;
+  const metaDescription = escapeHtml(
+    `Recent planning applications in ${data.townName}, ${data.authorityName}. See what is being built nearby and get push alerts the moment an application is submitted or decided near you.`,
+  );
+  const jsonLd = buildTownJsonLd(data, canonical, authorityCanonical);
+  const year = new Date().getFullYear();
+
+  const applicationsList = renderApplicationsList(data.applications);
+  const attribution = renderAttributionList();
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${title}</title>
+    <meta name="description" content="${metaDescription}" />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="${canonical}" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <meta property="og:title" content="Planning applications in ${town}" />
+    <meta property="og:description" content="${metaDescription}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="${canonical}" />
+    <meta property="og:site_name" content="Town Crier" />
+    <script type="application/ld+json">${jsonLd}</script>
+    <style>
+${pageStyles()}
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <header class="siteHeader">
+        <a href="/">Town Crier</a>
+        <a href="/">Home</a>
+      </header>
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <ol>
+          <li><a href="/">Town Crier</a></li>
+          <li><a href="${authorityCanonical}">${authority}</a></li>
+          <li>${town}</li>
+        </ol>
+      </nav>
+      <main>
+        <h1>Planning applications in ${town}</h1>
+        <p class="lead">${lead}</p>
+
+${renderStats(data.applications)}
+
+        <h2>Recent applications</h2>
+        <ul class="appList">
+${applicationsList}
+        </ul>
+
+        <section class="explainer">
+          <h2>How to comment on a planning application in ${town}</h2>
+          <p>
+            Anyone can have their say on a planning application in ${town}. Find the
+            application on the ${authority} planning authority's public-access portal
+            using the reference number above, then submit a comment before the
+            consultation deadline. Comments are usually limited to planning matters
+            such as overlooking, loss of light, traffic, noise and the character of
+            the area.
+          </p>
+          <p>
+            ${authority} is the local planning authority responsible for deciding
+            applications in ${town}. Town Crier mirrors the public record so you can
+            keep track of what is happening near you, but the council remains the
+            authoritative source and the place to submit formal comments.
+          </p>
+        </section>
+
+        <section class="cta">
+          <h2>Get push alerts for ${town}</h2>
+          <p>
+            Draw a circle on the map and Town Crier will notify you the moment a new
+            planning application is submitted or decided inside it.
+          </p>
+          <a class="cta__button" href="${APP_DOWNLOAD_URL}" rel="noopener" target="_blank">Download on the App Store</a>
+        </section>
+      </main>
+
+      <footer class="siteFooter">
+        <ul class="attribution">
+${attribution}
+        </ul>
+        <p>© ${year} Town Crier · Ivo and the Bea Ltd</p>
+        <p><a href="/legal/privacy">Privacy Policy</a> · <a href="/legal/terms">Terms of Service</a></p>
+      </footer>
+    </div>
+  </body>
+</html>
+`;
+}

--- a/web/scripts/lib/town-path.mjs
+++ b/web/scripts/lib/town-path.mjs
@@ -1,0 +1,53 @@
+/**
+ * Town-page URL helpers. Town pages live one level below their authority page in
+ * a nested hierarchy:
+ *
+ *   /planning/<authority-slug>              <- authority page (Phase 1)
+ *   /planning/<authority-slug>/<town-slug>  <- town page (Phase 2)
+ *
+ * The nesting is what keeps town pages from colliding with authority pages and
+ * gives crawlers a clean breadcrumb trail. The authority slug for a town is
+ * resolved from its `authorityId` against the committed authority list — never
+ * stored in the gazetteer, so the two can never drift.
+ */
+
+import { slugify } from './slug.mjs';
+
+/**
+ * @typedef {Object} ResolvedAuthority
+ * @property {string} name display name (the PlanIt area name)
+ * @property {string} slug lowercase-hyphenated URL slug
+ */
+
+/**
+ * Resolve a town's `authorityId` to its parent authority's display name and URL
+ * slug, using the committed authority list as the single source of truth.
+ * Throws loudly when the id is absent — a malformed gazetteer must fail the
+ * build, never silently emit an orphan page.
+ *
+ * @param {number} authorityId
+ * @param {ReadonlyArray<{ id: number, name: string }>} authorities
+ * @returns {ResolvedAuthority}
+ */
+export function resolveAuthority(authorityId, authorities) {
+  const match = authorities.find((a) => a.id === authorityId);
+  if (!match) {
+    throw new Error(
+      `no authority with id ${authorityId} in the authority list`,
+    );
+  }
+  return { name: match.name, slug: slugify(match.name) };
+}
+
+/**
+ * Build the path of a town page relative to `/planning`: the parent authority
+ * slug joined to the town slug. Always two segments, so it can never equal the
+ * single-segment authority page path.
+ *
+ * @param {string} authoritySlug
+ * @param {string} townSlug
+ * @returns {string} e.g. "cornwall/truro"
+ */
+export function townPagePath(authoritySlug, townSlug) {
+  return `${authoritySlug}/${townSlug}`;
+}

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -29,6 +29,8 @@ import { slugify } from './lib/slug.mjs';
 import { isQualifyingAreaType } from './lib/area-types.mjs';
 import { meetsCoverageGate } from './lib/coverage-gate.mjs';
 import { renderPlanningPage } from './lib/render-page.mjs';
+import { renderTownPage } from './lib/render-town-page.mjs';
+import { resolveAuthority, townPagePath } from './lib/town-path.mjs';
 import { renderSitemap } from './lib/render-sitemap.mjs';
 
 const DEFAULT_LIMIT = 30;
@@ -68,8 +70,10 @@ export const TOWNS_FILE = join(SCRIPT_DIR, '..', 'src', 'data', 'towns.json');
  * @typedef {Object} PrerenderResult
  * @property {boolean} skipped
  * @property {string} [reason]
- * @property {string[]} published                       slugs written
+ * @property {string[]} published                       authority slugs written
  * @property {Array<{ name: string, reason: string }>} excluded
+ * @property {string[]} publishedTowns                  town paths written (<authority>/<town>)
+ * @property {Array<{ name: string, reason: string }>} excludedTowns
  */
 
 /**
@@ -306,18 +310,180 @@ async function considerAuthority(args) {
 }
 
 /**
- * @param {string} outDir
- * @param {string} fixturePath
+ * Fetch the bounded recent-applications-near-a-point projection for one town via
+ * the build-key-gated geo endpoint. Scopes the spatial query to the town's
+ * authority partition (authorityId) and centroid (lat/lng); the server defaults
+ * and clamps the radius. Throws on any non-OK status or unexpected shape.
+ *
+ * @param {string} apiBase
+ * @param {Town} town
+ * @param {string} buildKey
  * @param {number} limit
- * @param {{ warn: (msg: string) => void }} logger
+ * @param {typeof globalThis.fetch} fetchImpl
+ * @returns {Promise<{ applications: object[], total: number, totalCapped: boolean }>}
+ */
+async function fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl) {
+  const url =
+    `${apiBase}/v1/applications/near?authorityId=${town.authorityId}` +
+    `&lat=${town.lat}&lng=${town.lng}&limit=${limit}`;
+  const res = await fetchImpl(url, { headers: { 'X-Build-Key': buildKey } });
+  if (!res.ok) {
+    throw new Error(
+      `GET /v1/applications/near (authority ${town.authorityId}, ${town.name}) ` +
+        `failed: HTTP ${res.status}`,
+    );
+  }
+  const body = await res.json();
+  if (
+    !body ||
+    !Array.isArray(body.applications) ||
+    typeof body.total !== 'number' ||
+    typeof body.totalCapped !== 'boolean'
+  ) {
+    throw new Error(
+      `GET /v1/applications/near (authority ${town.authorityId}, ${town.name}) ` +
+        `returned an unexpected shape`,
+    );
+  }
+  return {
+    applications: body.applications,
+    total: body.total,
+    totalCapped: body.totalCapped,
+  };
+}
+
+/**
+ * Write one town's page to <outDir>/planning/<authority-slug>/<town-slug>/index.html.
+ *
+ * @param {string} outDir
+ * @param {import('./lib/render-town-page.mjs').TownPageData} data
+ * @returns {Promise<void>}
+ */
+async function writeTownPage(outDir, data) {
+  const dir = join(outDir, 'planning', data.authoritySlug, data.townSlug);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'index.html'), renderTownPage(data), 'utf-8');
+}
+
+/**
+ * Render and write a town page if it clears the coverage gate, after resolving
+ * its parent authority slug. Mutates `publishedTowns`/`excludedTowns`/`seenPaths`.
+ *
+ * @param {Object} args
+ * @param {string} args.outDir
+ * @param {Town} args.town
+ * @param {ReadonlyArray<{ id: number, name: string }>} args.authorities
+ * @param {number} args.total
+ * @param {boolean} args.totalCapped
+ * @param {object[]} args.applications
+ * @param {number} args.limit
+ * @param {string[]} args.publishedTowns
+ * @param {Array<{ name: string, reason: string }>} args.excludedTowns
+ * @param {Set<string>} args.seenPaths
+ * @param {{ warn: (msg: string) => void }} args.logger
+ * @returns {Promise<void>}
+ */
+async function considerTown(args) {
+  const {
+    outDir,
+    town,
+    authorities,
+    total,
+    totalCapped,
+    applications,
+    limit,
+    publishedTowns,
+    excludedTowns,
+    seenPaths,
+    logger,
+  } = args;
+
+  if (!meetsCoverageGate(total)) {
+    excludedTowns.push({ name: town.name, reason: 'coverage' });
+    return;
+  }
+
+  const { name: authorityName, slug: authoritySlug } = resolveAuthority(
+    town.authorityId,
+    authorities,
+  );
+  const path = townPagePath(authoritySlug, town.slug);
+  if (seenPaths.has(path)) {
+    logger.warn(`[prerender] duplicate town path "${path}" — skipped`);
+    excludedTowns.push({ name: town.name, reason: 'duplicate-path' });
+    return;
+  }
+  seenPaths.add(path);
+
+  await writeTownPage(outDir, {
+    townName: town.name,
+    townSlug: town.slug,
+    authorityName,
+    authoritySlug,
+    authorityId: town.authorityId,
+    total,
+    totalCapped,
+    applications: applications.slice(0, limit),
+  });
+  publishedTowns.push(path);
+}
+
+/**
+ * Render every town that clears the coverage gate. `getGeo` resolves a town to
+ * its bounded recent-nearby projection (a live geo fetch, or inline fixture
+ * data). The parent authority slug is resolved from `authorities`.
+ *
+ * @param {Object} args
+ * @param {string} args.outDir
+ * @param {Town[]} args.towns
+ * @param {ReadonlyArray<{ id: number, name: string }>} args.authorities
+ * @param {(town: Town) => Promise<{ applications: object[], total: number, totalCapped: boolean }>} args.getGeo
+ * @param {number} args.limit
+ * @param {{ warn: (msg: string) => void }} args.logger
+ * @returns {Promise<{ publishedTowns: string[], excludedTowns: Array<{ name: string, reason: string }> }>}
+ */
+async function renderTownPages(args) {
+  const { outDir, towns, authorities, getGeo, limit, logger } = args;
+
+  /** @type {string[]} */
+  const publishedTowns = [];
+  /** @type {Array<{ name: string, reason: string }>} */
+  const excludedTowns = [];
+  const seenPaths = new Set();
+
+  for (const town of towns) {
+    const geo = await getGeo(town);
+    await considerTown({
+      outDir,
+      town,
+      authorities,
+      total: geo.total,
+      totalCapped: geo.totalCapped,
+      applications: Array.isArray(geo.applications) ? geo.applications : [],
+      limit,
+      publishedTowns,
+      excludedTowns,
+      seenPaths,
+      logger,
+    });
+  }
+
+  return { publishedTowns, excludedTowns };
+}
+
+/**
+ * @param {Object} args
+ * @param {string} args.outDir
+ * @param {string} args.fixturePath               authority fixture (optional)
+ * @param {string} [args.townFixturePath]         town fixture (optional)
+ * @param {number} args.limit
+ * @param {() => Promise<Array<{ id: number, name: string, areaType: string }>>} args.loadAuthorities
+ * @param {{ warn: (msg: string) => void }} args.logger
  * @returns {Promise<PrerenderResult>}
  */
-async function runFixtureMode(outDir, fixturePath, limit, logger) {
-  const raw = await readFile(fixturePath, 'utf-8');
-  const entries = JSON.parse(raw);
-  if (!Array.isArray(entries)) {
-    throw new Error(`fixture ${fixturePath} must be a JSON array`);
-  }
+async function runFixtureMode(args) {
+  const { outDir, fixturePath, townFixturePath, limit, loadAuthorities, logger } =
+    args;
 
   /** @type {string[]} */
   const published = [];
@@ -325,30 +491,71 @@ async function runFixtureMode(outDir, fixturePath, limit, logger) {
   const excluded = [];
   const seenSlugs = new Set();
 
-  for (const entry of entries) {
-    if (!isQualifyingAreaType(entry.areaType)) {
-      excluded.push({ name: entry.name, reason: 'areaType' });
-      continue;
+  if (fixturePath) {
+    const raw = await readFile(fixturePath, 'utf-8');
+    const entries = JSON.parse(raw);
+    if (!Array.isArray(entries)) {
+      throw new Error(`fixture ${fixturePath} must be a JSON array`);
     }
-    await considerAuthority({
-      outDir,
-      authorityId: entry.id,
-      name: entry.name,
-      areaType: entry.areaType,
-      areaName: entry.areaName ?? entry.name,
-      total: entry.total,
-      totalCapped: Boolean(entry.totalCapped),
-      applications: Array.isArray(entry.applications) ? entry.applications : [],
-      limit,
-      published,
-      excluded,
-      seenSlugs,
-      logger,
-    });
+    for (const entry of entries) {
+      if (!isQualifyingAreaType(entry.areaType)) {
+        excluded.push({ name: entry.name, reason: 'areaType' });
+        continue;
+      }
+      await considerAuthority({
+        outDir,
+        authorityId: entry.id,
+        name: entry.name,
+        areaType: entry.areaType,
+        areaName: entry.areaName ?? entry.name,
+        total: entry.total,
+        totalCapped: Boolean(entry.totalCapped),
+        applications: Array.isArray(entry.applications)
+          ? entry.applications
+          : [],
+        limit,
+        published,
+        excluded,
+        seenSlugs,
+        logger,
+      });
+    }
   }
 
-  await writeFile(join(outDir, 'sitemap.xml'), renderSitemap(published), 'utf-8');
-  return { skipped: false, published, excluded };
+  /** @type {string[]} */
+  let publishedTowns = [];
+  /** @type {Array<{ name: string, reason: string }>} */
+  let excludedTowns = [];
+
+  // Town fixture rows carry the geo projection inline (total/totalCapped/
+  // applications), so `getGeo` is a pure lookup — no network in fixture mode.
+  if (townFixturePath) {
+    const rawTowns = await readFile(townFixturePath, 'utf-8');
+    const townEntries = JSON.parse(rawTowns);
+    if (!Array.isArray(townEntries)) {
+      throw new Error(`town fixture ${townFixturePath} must be a JSON array`);
+    }
+    const authorities = await loadAuthorities();
+    ({ publishedTowns, excludedTowns } = await renderTownPages({
+      outDir,
+      towns: townEntries,
+      authorities,
+      getGeo: async (town) => ({
+        applications: Array.isArray(town.applications) ? town.applications : [],
+        total: town.total,
+        totalCapped: Boolean(town.totalCapped),
+      }),
+      limit,
+      logger,
+    }));
+  }
+
+  await writeFile(
+    join(outDir, 'sitemap.xml'),
+    renderSitemap([...published, ...publishedTowns]),
+    'utf-8',
+  );
+  return { skipped: false, published, excluded, publishedTowns, excludedTowns };
 }
 
 /**
@@ -359,12 +566,21 @@ async function runFixtureMode(outDir, fixturePath, limit, logger) {
  * @param {number} args.limit
  * @param {typeof globalThis.fetch} args.fetchImpl
  * @param {() => Promise<Array<{ id: number, name: string, areaType: string }>>} args.loadAuthorities
+ * @param {() => Promise<Town[]>} args.loadTowns
  * @param {{ warn: (msg: string) => void }} args.logger
  * @returns {Promise<PrerenderResult>}
  */
 async function runLiveMode(args) {
-  const { outDir, apiBase, buildKey, limit, fetchImpl, loadAuthorities, logger } =
-    args;
+  const {
+    outDir,
+    apiBase,
+    buildKey,
+    limit,
+    fetchImpl,
+    loadAuthorities,
+    loadTowns,
+    logger,
+  } = args;
 
   const authorities = await loadAuthorities();
 
@@ -403,8 +619,24 @@ async function runLiveMode(args) {
     });
   }
 
-  await writeFile(join(outDir, 'sitemap.xml'), renderSitemap(published), 'utf-8');
-  return { skipped: false, published, excluded };
+  // Town pages: one bounded geo read per town, scoped to its authority partition
+  // and centroid. Reuses the same authority list (no extra HTTP) to resolve slugs.
+  const towns = await loadTowns();
+  const { publishedTowns, excludedTowns } = await renderTownPages({
+    outDir,
+    towns,
+    authorities,
+    getGeo: (town) => fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl),
+    limit,
+    logger,
+  });
+
+  await writeFile(
+    join(outDir, 'sitemap.xml'),
+    renderSitemap([...published, ...publishedTowns]),
+    'utf-8',
+  );
+  return { skipped: false, published, excluded, publishedTowns, excludedTowns };
 }
 
 /**
@@ -414,10 +646,12 @@ async function runLiveMode(args) {
  * @param {string} options.outDir                  directory to emit into (web/dist)
  * @param {string} [options.apiBase]               API base URL (live mode)
  * @param {string} [options.buildKey]              SITE_BUILD_KEY (live mode)
- * @param {string} [options.fixturePath]           committed JSON fixture (fixture mode)
+ * @param {string} [options.fixturePath]           committed authority JSON fixture (fixture mode)
+ * @param {string} [options.townFixturePath]       committed town JSON fixture (fixture mode)
  * @param {number} [options.limit]                 applications rendered per page
  * @param {typeof globalThis.fetch} [options.fetchImpl]
  * @param {() => Promise<Array<{ id: number, name: string, areaType: string }>>} [options.loadAuthorities]
+ * @param {() => Promise<Town[]>} [options.loadTowns]
  * @param {{ log: Function, warn: Function, error: Function }} [options.logger]
  * @returns {Promise<PrerenderResult>}
  */
@@ -427,14 +661,23 @@ export async function runPrerender(options) {
     apiBase,
     buildKey,
     fixturePath,
+    townFixturePath,
     limit = DEFAULT_LIMIT,
     fetchImpl = globalThis.fetch,
     loadAuthorities = () => loadAuthoritiesFromFile(AUTHORITIES_FILE, readFile),
+    loadTowns = () => loadTownsFromFile(TOWNS_FILE, readFile),
     logger = console,
   } = options;
 
-  if (fixturePath) {
-    return runFixtureMode(outDir, fixturePath, limit, logger);
+  if (fixturePath || townFixturePath) {
+    return runFixtureMode({
+      outDir,
+      fixturePath,
+      townFixturePath,
+      limit,
+      loadAuthorities,
+      logger,
+    });
   }
 
   if (!buildKey) {
@@ -443,6 +686,8 @@ export async function runPrerender(options) {
       reason: 'SITE_BUILD_KEY not set',
       published: [],
       excluded: [],
+      publishedTowns: [],
+      excludedTowns: [],
     };
   }
 
@@ -459,6 +704,7 @@ export async function runPrerender(options) {
     limit,
     fetchImpl,
     loadAuthorities,
+    loadTowns,
     logger,
   });
 }
@@ -475,6 +721,7 @@ async function main() {
     process.env.PRERENDER_API_BASE || process.env.VITE_API_BASE_URL;
   const buildKey = process.env.SITE_BUILD_KEY;
   const fixturePath = process.env.PRERENDER_FIXTURE;
+  const townFixturePath = process.env.PRERENDER_TOWN_FIXTURE;
 
   try {
     const result = await runPrerender({
@@ -482,14 +729,17 @@ async function main() {
       apiBase,
       buildKey,
       fixturePath,
+      townFixturePath,
     });
     if (result.skipped) {
       console.log(`[prerender] skipped — ${result.reason} (SPA build only)`);
       return;
     }
     console.log(
-      `[prerender] wrote ${result.published.length} planning page(s); ` +
-        `excluded ${result.excluded.length} authority/-ies`,
+      `[prerender] wrote ${result.published.length} authority page(s) and ` +
+        `${result.publishedTowns.length} town page(s); excluded ` +
+        `${result.excluded.length} authority/-ies and ` +
+        `${result.excludedTowns.length} town(s)`,
     );
   } catch (err) {
     console.error(

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -56,6 +56,15 @@ export const AUTHORITIES_FILE = join(
 );
 
 /**
+ * The town gazetteer is a slim, committed JSON file in the web app's source
+ * tree (`web/src/data/towns.json`). It is regenerated occasionally by
+ * `scripts/generate-towns.mjs` from OS Open Names — never downloaded at build
+ * time. Each row is `{ slug, name, lat, lng, authorityId }`.
+ * @type {string}
+ */
+export const TOWNS_FILE = join(SCRIPT_DIR, '..', 'src', 'data', 'towns.json');
+
+/**
  * @typedef {Object} PrerenderResult
  * @property {boolean} skipped
  * @property {string} [reason]
@@ -115,6 +124,65 @@ export async function loadAuthoritiesFromFile(filePath, readFileImpl) {
       throw new Error(
         `authority list at ${filePath} has a malformed authority row`,
       );
+    }
+  }
+  return list;
+}
+
+/**
+ * @typedef {Object} Town
+ * @property {string} slug          lowercase-hyphenated, e.g. "truro"
+ * @property {string} name          display name, e.g. "Truro"
+ * @property {number} lat           WGS84 latitude (centroid)
+ * @property {number} lng           WGS84 longitude (centroid)
+ * @property {number} authorityId   parent authority id (resolves to its slug)
+ */
+
+/**
+ * Load and validate the slim committed town gazetteer. An empty array is valid
+ * (sparse data -> zero town pages is a legitimate build), but the file must be
+ * present, parse as JSON, be an array, and every row must be well-formed —
+ * never a silent malformed gazetteer.
+ *
+ * @param {string} filePath
+ * @param {(path: string, encoding: string) => Promise<string>} readFileImpl
+ * @returns {Promise<Town[]>}
+ */
+export async function loadTownsFromFile(filePath, readFileImpl) {
+  let raw;
+  try {
+    raw = await readFileImpl(filePath, 'utf-8');
+  } catch (err) {
+    throw new Error(
+      `town gazetteer not found at ${filePath}: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  let list;
+  try {
+    list = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `town gazetteer at ${filePath} is not valid JSON: ` +
+        `${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!Array.isArray(list)) {
+    throw new Error(`town gazetteer at ${filePath} must be a JSON array`);
+  }
+  for (const t of list) {
+    if (
+      typeof t?.slug !== 'string' ||
+      t.slug.length === 0 ||
+      typeof t?.name !== 'string' ||
+      t.name.length === 0 ||
+      !Number.isFinite(t?.lat) ||
+      !Number.isFinite(t?.lng) ||
+      !Number.isFinite(t?.authorityId)
+    ) {
+      throw new Error(`town gazetteer at ${filePath} has a malformed town row`);
     }
   }
   return list;

--- a/web/src/data/towns.json
+++ b/web/src/data/towns.json
@@ -1,0 +1,14 @@
+[
+  { "slug": "croydon", "name": "Croydon", "lat": 51.3762, "lng": -0.0982, "authorityId": 301 },
+  { "slug": "truro", "name": "Truro", "lat": 50.2632, "lng": -5.0510, "authorityId": 52 },
+  { "slug": "newquay", "name": "Newquay", "lat": 50.4156, "lng": -5.0739, "authorityId": 52 },
+  { "slug": "cambridge", "name": "Cambridge", "lat": 52.2053, "lng": 0.1218, "authorityId": 61 },
+  { "slug": "wembley", "name": "Wembley", "lat": 51.5530, "lng": -0.2963, "authorityId": 298 },
+  { "slug": "ealing", "name": "Ealing", "lat": 51.5130, "lng": -0.3089, "authorityId": 302 },
+  { "slug": "greenwich", "name": "Greenwich", "lat": 51.4826, "lng": -0.0077, "authorityId": 304 },
+  { "slug": "woolwich", "name": "Woolwich", "lat": 51.4920, "lng": 0.0640, "authorityId": 304 },
+  { "slug": "bexleyheath", "name": "Bexleyheath", "lat": 51.4549, "lng": 0.1505, "authorityId": 297 },
+  { "slug": "hackney", "name": "Hackney", "lat": 51.5450, "lng": -0.0553, "authorityId": 305 },
+  { "slug": "islington", "name": "Islington", "lat": 51.5362, "lng": -0.1033, "authorityId": 312 },
+  { "slug": "finchley", "name": "Finchley", "lat": 51.5990, "lng": -0.1870, "authorityId": 296 }
+]


### PR DESCRIPTION
Second sub-step of epic #570 bead tc-nnte.7 (Phase 2 town-level SEO pages), built on the deployed geo endpoint.

- `web/src/data/towns.json` — slim committed gazetteer (TRACER: 12 well-known towns inside dev-published authorities; every `authorityId` cross-checked against authorities.json).
- `web/scripts/generate-towns.mjs` — one-time OS Open Names → towns.json generator (OGL v3; `LOCAL_TYPE in (City,Town)`; BNG→WGS84). NOT run in CI/build; documented manual/occasional regeneration. Full OS ingest is the one remaining follow-up.
- Prerender extended: for each town, resolve authority-slug, call `GET /v1/applications/near?authorityId&lat&lng` with `X-Build-Key`, apply the `total>=10` gate, emit static `web/dist/planning/<authority-slug>/<town-slug>/index.html`. Live mode fails loud; zero town pages on sparse data is valid. Sitemap now lists authority + town pages.
- Town template reuses a shared render module (authority page output is byte-stable, guarded by existing tests): H1, recent apps, stats, how-to-comment, "Get push alerts for {Town}" CTA, PlanIt/OGL/OS/OSM attribution, nested canonical, OG, schema.org ItemList+Dataset+BreadcrumbList, breadcrumb up to the authority page.

Nested URLs don't collide with authority pages (`/planning/cornwall` vs `/planning/cornwall/truro`).

Validation (web/): `tsc --noEmit` clean, `eslint` clean, vitest **768/768 (101 files)**, `npm run build` ok. Fixture proof: `planning/cornwall/truro/index.html` has the H1, nested canonical, CTA, attribution, breadcrumb, and JSON-LD; below-gate town excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)