### PR TITLE
fix(api): longer per-attempt Cosmos budget for build-time SEO reads (tc-9tov)

### DIFF
--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -84,6 +84,13 @@ func (f *fakeItems) QueryItems(_ context.Context, _, _ string, _ map[string]any)
 	return nil, nil
 }
 
+// QueryItemsLongRead lets fakeItems satisfy applications.CosmosItems, whose
+// build-time SEO reads run on the longer per-attempt budget (tc-9tov). The
+// wiring tests only need the empty-list path.
+func (f *fakeItems) QueryItemsLongRead(_ context.Context, _, _ string, _ map[string]any) ([][]byte, error) {
+	return nil, nil
+}
+
 // QueryItemsCrossPartition / QueryPageCrossPartition let fakeItems back a
 // profiles.AdminStore; the wiring tests only need the empty result path.
 func (f *fakeItems) QueryItemsCrossPartition(_ context.Context, _ string, _ map[string]any) ([][]byte, error) {

--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -10,13 +10,16 @@ import (
 )
 
 // CosmosItems is the consumer-side slice of the Applications container the store
-// uses: a single-partition point read, an upsert, and a single-partition
-// spatial query for the nearby lookup. platform.CosmosContainer satisfies it
-// structurally.
+// uses: a single-partition point read, an upsert, and single-partition queries.
+// QueryItems carries the tight 1.5s OLTP per-attempt budget for user-facing
+// reads; QueryItemsLongRead carries a longer per-attempt budget for the
+// latency-tolerant build-time SEO reads over a LARGE authority partition
+// (tc-9tov). platform.CosmosContainer satisfies it structurally.
 type CosmosItems interface {
 	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
 	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
 	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
+	QueryItemsLongRead(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
 }
 
 // CosmosStore reads and writes planning applications in the Applications

--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -105,7 +105,9 @@ const recentByAuthorityQuery = "SELECT TOP @cap * FROM c ORDER BY c.lastDifferen
 // fallback (GH#395 Invariant 1) — it reads only from Cosmos.
 func (s *CosmosStore) RecentByAuthority(ctx context.Context, authorityCode string, cap int) ([]PlanningApplication, error) {
 	params := map[string]any{"@cap": cap}
-	raws, err := s.items.QueryItems(ctx, authorityCode, recentByAuthorityQuery, params)
+	// Latency-tolerant build-time read: a LARGE authority partition legitimately
+	// exceeds the 1.5s OLTP budget, so use the longer per-attempt budget (tc-9tov).
+	raws, err := s.items.QueryItemsLongRead(ctx, authorityCode, recentByAuthorityQuery, params)
 	if err != nil {
 		return nil, fmt.Errorf("recent applications for authority %q: %w", authorityCode, err)
 	}
@@ -183,7 +185,9 @@ func (s *CosmosStore) RecentNearby(ctx context.Context, authorityCode string, la
 		"@radiusMetres": radiusMetres,
 		"@cap":          cap,
 	}
-	raws, err := s.items.QueryItems(ctx, authorityCode, recentNearbyQuery, params)
+	// Latency-tolerant build-time read: a LARGE authority partition legitimately
+	// exceeds the 1.5s OLTP budget, so use the longer per-attempt budget (tc-9tov).
+	raws, err := s.items.QueryItemsLongRead(ctx, authorityCode, recentNearbyQuery, params)
 	if err != nil {
 		return nil, fmt.Errorf("recent applications near %q: %w", authorityCode, err)
 	}

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -24,6 +24,11 @@ type fakeItems struct {
 	lastQueryPK     string
 	lastQuery       string
 	lastQueryParams map[string]any
+	// lastQueryViaLongRead records whether the most recent query went through the
+	// longer-budget build-read accessor (QueryItemsLongRead) rather than the tight
+	// OLTP QueryItems. The build-time SEO reads must use the long-read path; the
+	// user-facing reads must not (tc-9tov).
+	lastQueryViaLongRead bool
 }
 
 func newFakeItems() *fakeItems { return &fakeItems{stored: map[string][]byte{}} }
@@ -48,6 +53,16 @@ func (f *fakeItems) UpsertItem(_ context.Context, partitionKey string, item []by
 }
 
 func (f *fakeItems) QueryItems(_ context.Context, partitionKey, query string, params map[string]any) ([][]byte, error) {
+	f.lastQueryViaLongRead = false
+	return f.recordQuery(partitionKey, query, params)
+}
+
+func (f *fakeItems) QueryItemsLongRead(_ context.Context, partitionKey, query string, params map[string]any) ([][]byte, error) {
+	f.lastQueryViaLongRead = true
+	return f.recordQuery(partitionKey, query, params)
+}
+
+func (f *fakeItems) recordQuery(partitionKey, query string, params map[string]any) ([][]byte, error) {
 	f.lastQueryPK = partitionKey
 	f.lastQuery = query
 	f.lastQueryParams = params
@@ -422,5 +437,67 @@ func TestCosmosStore_RecentNearby_EmptyResultIsEmptySlice(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("RecentNearby: got %d results, want 0", len(got))
+	}
+}
+
+// The build-time SEO reads run over a LARGE authority partition and legitimately
+// exceed the tight 1.5s OLTP budget, so they must route through the longer-budget
+// QueryItemsLongRead accessor — never the OLTP QueryItems (tc-9tov).
+
+func TestCosmosStore_RecentByAuthority_UsesLongReadBudget(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if _, err := store.RecentByAuthority(context.Background(), "156", 200); err != nil {
+		t.Fatalf("RecentByAuthority: %v", err)
+	}
+	if !items.lastQueryViaLongRead {
+		t.Error("RecentByAuthority must use the long-read budget (QueryItemsLongRead), not the 1.5s OLTP QueryItems")
+	}
+}
+
+func TestCosmosStore_RecentNearby_UsesLongReadBudget(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if _, err := store.RecentNearby(context.Background(), "156", 51.5, -0.1, 5000, 200); err != nil {
+		t.Fatalf("RecentNearby: %v", err)
+	}
+	if !items.lastQueryViaLongRead {
+		t.Error("RecentNearby must use the long-read budget (QueryItemsLongRead), not the 1.5s OLTP QueryItems")
+	}
+}
+
+// The user-facing reads must keep the tight OLTP budget — only the build-time SEO
+// reads get the longer one, so widening must never leak onto the OLTP path.
+
+func TestCosmosStore_FindNearby_KeepsOLTPBudget(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if _, err := store.FindNearby(context.Background(), "441", 51.4975, -0.1357, 2000); err != nil {
+		t.Fatalf("FindNearby: %v", err)
+	}
+	if items.lastQueryViaLongRead {
+		t.Error("FindNearby is a user-facing read and must keep the 1.5s OLTP QueryItems budget")
+	}
+}
+
+func TestCosmosStore_GetByUID_KeepsOLTPBudget(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	body, _ := json.Marshal(newApplicationDocument(a))
+	items := newFakeItems()
+	items.queryResult = [][]byte{body}
+	store := NewCosmosStore(items)
+
+	if _, _, err := store.GetByUID(context.Background(), a.UID, strconv.Itoa(a.AreaID)); err != nil {
+		t.Fatalf("GetByUID: %v", err)
+	}
+	if items.lastQueryViaLongRead {
+		t.Error("GetByUID is a user-facing read and must keep the 1.5s OLTP QueryItems budget")
 	}
 }

--- a/api-go/internal/platform/cosmos.go
+++ b/api-go/internal/platform/cosmos.go
@@ -110,6 +110,32 @@ func cosmosRetryOptions() policy.RetryOptions {
 	}
 }
 
+// cosmosBuildReadTryTimeout bounds one attempt of a latency-tolerant build-time
+// read. The SEO prerender's bounded top-N queries (RecentByAuthority /
+// RecentNearby, up to ~200 full documents) legitimately exceed the 1.5s OLTP
+// cosmosTryTimeout on a LARGE authority partition (e.g. a big-city authority),
+// so under that tight budget every retry times out and the request 500s
+// (tc-9tov). 9s gives a single generous attempt that covers the slow
+// large-partition read while staying comfortably under the 15s server
+// WriteTimeout (NewServer in server.go). Only the build-key-gated SEO reads opt
+// in, via QueryItemsLongRead — user-facing OLTP endpoints keep the 1.5s budget.
+const cosmosBuildReadTryTimeout = 9 * time.Second
+
+// cosmosBuildReadRetryOptions returns the per-call retry override for
+// latency-tolerant build-time reads: a single generous attempt, no retries.
+// MaxRetries is -1 because azcore's setDefaults normalises 0 to its default of 3
+// retries; -1 normalises to 0, i.e. one attempt. A second attempt at the 9s
+// per-try budget would risk ~18s total and breach the 15s server WriteTimeout,
+// so a retry is deliberately omitted — and a retry does not cure a
+// consistently-slow large-partition read anyway (the root cause is the
+// per-attempt budget, not transient failure).
+func cosmosBuildReadRetryOptions() policy.RetryOptions {
+	return policy.RetryOptions{
+		MaxRetries: -1, // -1 => 0 retries (single attempt); 0 would mean azcore's default of 3
+		TryTimeout: cosmosBuildReadTryTimeout,
+	}
+}
+
 // cosmosTokenAcquireTimeout bounds a managed-identity token fetch independently
 // of cosmosTryTimeout. The 1.5s per-Cosmos-try timeout (cosmosTryTimeout) wraps
 // the bearer-token auth policy, so it would otherwise cancel a COLD token fetch
@@ -317,6 +343,19 @@ func (c *CosmosContainer) QueryItems(ctx context.Context, partitionKey, query st
 		return nil, err
 	}
 	return items, nil
+}
+
+// QueryItemsLongRead is QueryItems with a longer per-attempt Cosmos budget for
+// latency-tolerant build-time reads (the SEO prerender's bounded top-N queries
+// over a LARGE authority partition). It overrides the tight 1.5s OLTP TryTimeout
+// for this single call only — via policy.WithRetryOptions on the request
+// context, which the azcore retry policy reads per call (req.Raw().Context()) —
+// so the user-facing endpoints sharing this client keep their 1.5s budget. The
+// override flows through traceCosmosOp's span context into the SDK pager. See
+// cosmosBuildReadRetryOptions for the budget and tc-9tov for the motivation.
+func (c *CosmosContainer) QueryItemsLongRead(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error) {
+	ctx = policy.WithRetryOptions(ctx, cosmosBuildReadRetryOptions())
+	return c.QueryItems(ctx, partitionKey, query, params)
 }
 
 // CountItems runs a SELECT VALUE COUNT(1) scalar query in a single partition and

--- a/api-go/internal/platform/cosmos_test.go
+++ b/api-go/internal/platform/cosmos_test.go
@@ -26,6 +26,40 @@ func TestCosmosRetryOptions_MatchesBoundedBudget(t *testing.T) {
 	}
 }
 
+func TestCosmosBuildReadRetryOptions_LongerSingleAttemptBudgetThanOLTP(t *testing.T) {
+	t.Parallel()
+
+	oltp := cosmosRetryOptions()
+	build := cosmosBuildReadRetryOptions()
+
+	// The build-time SEO reads (RecentByAuthority / RecentNearby) load up to ~200
+	// full documents from a LARGE authority partition, which legitimately exceeds
+	// the tight 1.5s OLTP per-try budget — so under the OLTP budget every retry
+	// times out and the request 500s (tc-9tov). The build path must get a strictly
+	// longer per-attempt budget.
+	if build.TryTimeout <= oltp.TryTimeout {
+		t.Errorf("build TryTimeout %v must exceed OLTP TryTimeout %v", build.TryTimeout, oltp.TryTimeout)
+	}
+	// Target the ~8–10s band: long enough for the slow large-partition read,
+	// short enough to stay clear of the 15s server WriteTimeout.
+	if build.TryTimeout < 8*time.Second || build.TryTimeout > 10*time.Second {
+		t.Errorf("build TryTimeout: got %v, want within [8s, 10s]", build.TryTimeout)
+	}
+	// A single generous attempt. A second attempt at this per-try budget would
+	// risk ~18s total and breach the 15s WriteTimeout, and a retry does not cure a
+	// consistently-slow large-partition read anyway. MaxRetries < 0 is azcore's
+	// spelling of "no retries": setDefaults normalises 0 to the default of 3.
+	if build.MaxRetries >= 0 {
+		t.Errorf("build MaxRetries: got %d, want < 0 (single attempt; 0 would mean azcore's default of 3 retries)", build.MaxRetries)
+	}
+	// Worst case (single attempt) must stay comfortably under the 15s HTTP
+	// WriteTimeout (platform.NewServer), or the SEO response can't be written.
+	const serverWriteTimeout = 15 * time.Second
+	if build.TryTimeout >= serverWriteTimeout {
+		t.Errorf("build TryTimeout %v must stay under the %v server WriteTimeout", build.TryTimeout, serverWriteTimeout)
+	}
+}
+
 func TestNewCosmosContainer_RequiresConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Changes

Fixes a production 500 that blocked the programmatic-SEO prod publish (epic tc-nnte). The prerender failed on `GET /v1/authorities/156/applications` with a Cosmos `context deadline exceeded`.

**Root cause:** the shared Cosmos client's per-attempt `TryTimeout` is 1.5s (tuned for fast OLTP point reads). The build-time SEO reads (`RecentByAuthority` / `RecentNearby`, `SELECT TOP 200 *` loading up to 200 docs) legitimately exceed 1.5s on a **large** authority partition, so every retry times out → 500. The composite index is present on prod; it's purely a timeout-budget mismatch. Dev never reproduces it (tiny partitions).

**Fix:**
- `platform.CosmosContainer.QueryItemsLongRead` — overrides retry options per-call via `policy.WithRetryOptions(ctx, …)`: a single 9s attempt (`MaxRetries=-1`), well under the 15s server `WriteTimeout`.
- `RecentByAuthority` + `RecentNearby` route through it; `FindNearby` + `GetByUID` keep the 1.5s OLTP budget. Global `cosmosRetryOptions()` is unchanged, so user-facing endpoints are unaffected.
- Tests: platform budget-helper test (9s, single attempt, > OLTP, < WriteTimeout) + store routing tests (build reads use long-read; OLTP reads unchanged).

Gates green locally: gofmt, go build, go vet, full `go test`, golangci-lint (0 issues). Changes confined to `api-go/`.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Extended timeout budgets for batch read operations to reliably process large data sets.
  * User-facing queries maintain optimized response times with OLTP performance tuning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->