### PR TITLE
fix(infra): align Applications index paths to real Go field names (tc-vj7c.4)

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -202,9 +202,9 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 				IndexingMode: cosmosdb.IndexingModeConsistent,
 				IncludedPaths: cosmosdb.IncludedPathArray{
 					&cosmosdb.IncludedPathArgs{Path: pulumi.String("/authorityCode/?")},
-					&cosmosdb.IncludedPathArgs{Path: pulumi.String("/status/?")},
-					&cosmosdb.IncludedPathArgs{Path: pulumi.String("/applicationType/?")},
-					&cosmosdb.IncludedPathArgs{Path: pulumi.String("/decisionDate/?")},
+					&cosmosdb.IncludedPathArgs{Path: pulumi.String("/appState/?")},
+					&cosmosdb.IncludedPathArgs{Path: pulumi.String("/appType/?")},
+					&cosmosdb.IncludedPathArgs{Path: pulumi.String("/decidedDate/?")},
 					&cosmosdb.IncludedPathArgs{Path: pulumi.String("/lastDifferent/?")},
 				},
 				ExcludedPaths: cosmosdb.ExcludedPathArray{


### PR DESCRIPTION
## What

Aligns the three dead `IncludedPaths` in the Applications Cosmos container indexing policy (`infra/environment.go`) to the field names the Go persistence shape actually writes:

| Before (indexes nothing) | After (real `json` field) |
|---|---|
| `/status/?` | `/appState/?` |
| `/applicationType/?` | `/appType/?` |
| `/decisionDate/?` | `/decidedDate/?` |

Confirmed against `api-go/internal/applications/document.go` — `applicationDocument` uses `appState`, `appType`, `decidedDate`.

## Why

The old paths matched no field in the wire shape, so they indexed nothing — wasted index-write RU on every upsert while `appState`/`decidedDate` went un-indexed. This unblocks cheap status-breakdown / date-sorted reads later.

## Unchanged (deliberately)

- Composite index `(authorityCode ASC, lastDifferent DESC)` — the SEO `ORDER BY` query rides this, so it must not change.
- `/authorityCode/?` and `/lastDifferent/?` included paths.
- All `ExcludedPaths` and the `/location` spatial index.

No other container or any other part of the file is touched.

## Verification

- `go build ./...` ✅
- `gofmt -l .` clean ✅
- `go vet ./...` ✅
- `pulumi preview` (dev) **not run in the worker env** — this worktree's `Pulumi.dev.yaml` lacks the `town-crier:adminApiKey` secret (`pulumi config get` → not found), so preview panics at config resolution. Pulumi auth/stack access is fine (program compiled, preview started). Orchestrator to confirm the preview shows **only** this Applications index-policy path change.

Changing an indexing policy triggers a background reindex on the container — expected.

> Note: `tc-hpsw` ("Applications indexing policy indexes phantom fields") was a duplicate, folded into this bead (`tc-vj7c.4`).

Closes bead tc-vj7c.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)