### PR TITLE
feat(web): header download CTA on SEO planning pages (tc-vj7c.3)

### DIFF
--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -118,6 +118,28 @@ describe('renderPlanningPage', () => {
     expect(html).toContain(APP_DOWNLOAD_URL);
   });
 
+  it('renders an above-the-fold download button in the site header', () => {
+    const html = renderPlanningPage(pageData());
+    const header = html.match(/<header class="siteHeader">[\s\S]*?<\/header>/);
+    expect(header).not.toBeNull();
+    const [headerHtml] = header;
+    expect(headerHtml).toContain('siteHeader__cta');
+    expect(headerHtml).toContain(`href="${APP_DOWNLOAD_URL}"`);
+    expect(headerHtml).toContain('Get the app');
+    // Match the bottom CTA's link safety exactly.
+    expect(headerHtml).toContain('rel="noopener"');
+    expect(headerHtml).toContain('target="_blank"');
+    // The brand link stays on the left.
+    expect(headerHtml).toContain('>Town Crier</a>');
+  });
+
+  it('keeps the rich bottom CTA block when the header CTA is present', () => {
+    const html = renderPlanningPage(pageData());
+    expect(html).toContain('<section class="cta">');
+    expect(html).toContain('class="cta__button"');
+    expect(html).toContain('Download on the App Store');
+  });
+
   it('carries the mandatory PlanIt + OGL + OS + OSM attribution', () => {
     const html = renderPlanningPage(pageData());
     expect(html).toContain('PlanIt');

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -120,6 +120,28 @@ describe('renderTownPage', () => {
     expect(html).toContain(APP_DOWNLOAD_URL);
   });
 
+  it('renders an above-the-fold download button in the site header', () => {
+    const html = renderTownPage(townData());
+    const header = html.match(/<header class="siteHeader">[\s\S]*?<\/header>/);
+    expect(header).not.toBeNull();
+    const [headerHtml] = header;
+    expect(headerHtml).toContain('siteHeader__cta');
+    expect(headerHtml).toContain(`href="${APP_DOWNLOAD_URL}"`);
+    expect(headerHtml).toContain('Get the app');
+    // Match the bottom CTA's link safety exactly.
+    expect(headerHtml).toContain('rel="noopener"');
+    expect(headerHtml).toContain('target="_blank"');
+    // The brand link stays on the left.
+    expect(headerHtml).toContain('>Town Crier</a>');
+  });
+
+  it('keeps the rich bottom CTA block when the header CTA is present', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain('<section class="cta">');
+    expect(html).toContain('class="cta__button"');
+    expect(html).toContain('Download on the App Store');
+  });
+
   it('carries the mandatory PlanIt + OGL + OS + OSM attribution', () => {
     const html = renderTownPage(townData());
     expect(html).toContain('PlanIt');

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -103,7 +103,10 @@ ${pageStyles()}
     <div class="wrap">
       <header class="siteHeader">
         <a href="/">Town Crier</a>
-        <a href="/">Home</a>
+        <nav class="siteHeader__nav">
+          <a href="/">Home</a>
+          <a class="siteHeader__cta" href="${APP_DOWNLOAD_URL}" rel="noopener" target="_blank">Get the app</a>
+        </nav>
       </header>
       <main>
         <h1>Planning applications in ${area}</h1>

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -205,10 +205,20 @@ export function pageStyles() {
       display: flex;
       align-items: center;
       justify-content: space-between;
+      flex-wrap: wrap;
+      gap: var(--tc-space-sm);
       padding: var(--tc-space-md) 0;
       border-bottom: 1px solid var(--tc-border);
     }
     .siteHeader a { color: var(--tc-text-primary); text-decoration: none; font-weight: 700; }
+    .siteHeader__nav { display: flex; align-items: center; gap: var(--tc-space-md); }
+    .siteHeader a.siteHeader__cta {
+      padding: var(--tc-space-sm) var(--tc-space-md);
+      background: var(--tc-amber);
+      color: var(--tc-text-on-accent);
+      border-radius: var(--tc-radius-md);
+    }
+    .siteHeader a.siteHeader__cta:hover { background: var(--tc-amber-hover); }
     .breadcrumb { margin: var(--tc-space-md) 0 0; font-size: 0.875rem; color: var(--tc-text-secondary); }
     .breadcrumb ol { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: var(--tc-space-sm); }
     .breadcrumb li::after { content: '/'; margin-left: var(--tc-space-sm); color: var(--tc-text-secondary); }

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -137,7 +137,10 @@ ${pageStyles()}
     <div class="wrap">
       <header class="siteHeader">
         <a href="/">Town Crier</a>
-        <a href="/">Home</a>
+        <nav class="siteHeader__nav">
+          <a href="/">Home</a>
+          <a class="siteHeader__cta" href="${APP_DOWNLOAD_URL}" rel="noopener" target="_blank">Get the app</a>
+        </nav>
       </header>
       <nav class="breadcrumb" aria-label="Breadcrumb">
         <ol>


### PR DESCRIPTION
## What

Adds a primary, above-the-fold **"Get the app"** download button to the `.siteHeader` on the static SEO planning pages (both authority and town renderers). This complements — and does **not** replace — the existing rich CTA block at the bottom of each page.

Pure build-time template + CSS change. No API dependency, ships independently of the other tc-vj7c.* beads.

## Changes

- **`web/scripts/lib/render-page.mjs`** & **`render-town-page.mjs`** — header now keeps the "Town Crier" brand link on the left and wraps the right-side items (`Home` link + new CTA) in a `.siteHeader__nav`. The CTA links to `APP_DOWNLOAD_URL` with `rel="noopener" target="_blank"`, matching the bottom CTA's link safety.
- **`web/scripts/lib/render-shared.mjs`** — new reusable `.siteHeader a.siteHeader__cta` style in `pageStyles()`. Compact header variant of the bottom `.cta__button`: reuses the same design-token vocabulary (`--tc-amber`, `--tc-text-on-accent`, `--tc-radius-md`, hover to `--tc-amber-hover`) with tighter padding (`--tc-space-sm`/`--tc-space-md`). `.siteHeader` gains `flex-wrap` + `gap` so the added button never overflows on narrow screens.

## Tests (TDD)

Extended `render-page.test.mjs` and `render-town-page.test.mjs` to assert the header contains a download button (`siteHeader__cta`, `APP_DOWNLOAD_URL` href, `rel=noopener`/`target=_blank`, brand link intact) and that the bottom `.cta` block still renders. The existing `APP_DOWNLOAD_URL` drift-guard is untouched.

## Gates

- `npx vitest run` — 772 pass
- `npx tsc --noEmit` — clean
- `npx eslint .` — clean

Note: kept the diff tight and localized to the header + its CSS so the follow-up web bead (tc-vj7c.2) can build on `render-shared.mjs` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)