### PR TITLE
feat(api): exact SEO total, lastDifferent, status breakdown (tc-vj7c.1)

### DIFF
--- a/api-go/internal/applications/near.go
+++ b/api-go/internal/applications/near.go
@@ -32,10 +32,11 @@ const (
 )
 
 // nearStore is the consumer-side store the recent-nearby SEO handler needs: a
-// single bounded, single-partition spatial top-N read. The concrete *CosmosStore
-// satisfies it structurally.
+// bounded, single-partition spatial top-N read plus an exact in-radius count. The
+// concrete *CosmosStore satisfies it structurally.
 type nearStore interface {
 	RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
+	CountNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) (int, error)
 }
 
 // nearHandler serves the build-time town-level SEO endpoint.
@@ -96,8 +97,16 @@ func (h *nearHandler) recentNearby(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	total := len(apps)
-	render := total
+	// total is the EXACT in-radius count (a separate COUNT over the same scoped,
+	// clamped geo window), independent of the bounded read which saturates at
+	// nearReadCap. The render slice must clamp against the bounded read length.
+	total, err := h.store.CountNearby(r.Context(), authorityCode, lat, lng, radius)
+	if err != nil {
+		serverError(w, r, h.logger, "count applications near point", err)
+		return
+	}
+
+	render := len(apps)
 	if render > limit {
 		render = limit
 	}
@@ -107,13 +116,13 @@ func (h *nearHandler) recentNearby(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, r, h.logger, RecentNearbyResult{
-		AuthorityID:  id,
-		Lat:          lat,
-		Lng:          lng,
-		Radius:       radius,
-		Applications: results,
-		Total:        total,
-		TotalCapped:  total >= nearReadCap,
+		AuthorityID:     id,
+		Lat:             lat,
+		Lng:             lng,
+		Radius:          radius,
+		Applications:    results,
+		Total:           total,
+		StatusBreakdown: breakdownByState(apps),
 	})
 }
 

--- a/api-go/internal/applications/near_test.go
+++ b/api-go/internal/applications/near_test.go
@@ -10,10 +10,13 @@ import (
 
 // fakeNearStore is a hand-written double for the recent-nearby read. It records
 // the arguments the handler passed (so clamping/defaulting is asserted at the
-// store boundary) and honours cap the way Cosmos TOP @cap does.
+// store boundary), honours cap the way Cosmos TOP @cap does, and serves an exact
+// in-radius count independently of the bounded read.
 type fakeNearStore struct {
-	apps []PlanningApplication
-	err  error
+	apps     []PlanningApplication
+	err      error
+	count    int
+	countErr error
 
 	called            bool
 	lastAuthorityCode string
@@ -21,6 +24,12 @@ type fakeNearStore struct {
 	lastLng           float64
 	lastRadius        float64
 	lastCap           int
+
+	countCalled       bool
+	lastCountAuthCode string
+	lastCountLat      float64
+	lastCountLng      float64
+	lastCountRadius   float64
 }
 
 func (f *fakeNearStore) RecentNearby(_ context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error) {
@@ -39,6 +48,18 @@ func (f *fakeNearStore) RecentNearby(_ context.Context, authorityCode string, la
 	return f.apps, nil
 }
 
+func (f *fakeNearStore) CountNearby(_ context.Context, authorityCode string, lat, lng, radiusMetres float64) (int, error) {
+	f.countCalled = true
+	f.lastCountAuthCode = authorityCode
+	f.lastCountLat = lat
+	f.lastCountLng = lng
+	f.lastCountRadius = radiusMetres
+	if f.countErr != nil {
+		return 0, f.countErr
+	}
+	return f.count, nil
+}
+
 func serveNear(t *testing.T, store nearStore, buildKey, providedKey, path string) *httptest.ResponseRecorder {
 	t.Helper()
 	mux := http.NewServeMux()
@@ -54,7 +75,7 @@ func serveNear(t *testing.T, store nearStore, buildKey, providedKey, path string
 
 func TestNearHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 1234}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=51.5155&lng=-0.0931&radius=4000")
@@ -68,10 +89,16 @@ func TestNearHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 	// The handler scopes to the numeric authority id -> partition code, reads the
 	// bounded cap (200), and passes the parsed point + radius through verbatim.
 	if store.lastAuthorityCode != "471" || store.lastCap != 200 {
-		t.Errorf("store call: authorityCode=%q cap=%d, want \"471\" 200", store.lastAuthorityCode, store.lastCap)
+		t.Errorf("store read call: authorityCode=%q cap=%d, want \"471\" 200", store.lastAuthorityCode, store.lastCap)
 	}
 	if store.lastLat != 51.5155 || store.lastLng != -0.0931 || store.lastRadius != 4000 {
 		t.Errorf("store geo args: lat=%v lng=%v radius=%v, want 51.5155 -0.0931 4000", store.lastLat, store.lastLng, store.lastRadius)
+	}
+	// The exact count is taken over the same scoped, clamped geo window.
+	if !store.countCalled || store.lastCountAuthCode != "471" ||
+		store.lastCountLat != 51.5155 || store.lastCountLng != -0.0931 || store.lastCountRadius != 4000 {
+		t.Errorf("count call: called=%v auth=%q lat=%v lng=%v radius=%v, want true \"471\" 51.5155 -0.0931 4000",
+			store.countCalled, store.lastCountAuthCode, store.lastCountLat, store.lastCountLng, store.lastCountRadius)
 	}
 	got := recentBody(t, rec)
 	if got["authorityId"].(float64) != 471 {
@@ -87,14 +114,17 @@ func TestNearHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 	if len(apps) != 2 {
 		t.Errorf("applications length: got %d, want 2", len(apps))
 	}
-	if got["total"].(float64) != 2 {
-		t.Errorf("total: got %v, want 2", got["total"])
+	if got["total"].(float64) != 1234 {
+		t.Errorf("total: got %v, want 1234 (the exact count)", got["total"])
 	}
-	if got["totalCapped"].(bool) {
-		t.Errorf("totalCapped: got true, want false")
+	if _, present := got["totalCapped"]; present {
+		t.Errorf("totalCapped must be gone from the wire shape, got %v", got["totalCapped"])
+	}
+	if _, present := got["statusBreakdown"]; !present {
+		t.Errorf("statusBreakdown must be present: %v", got)
 	}
 	first := apps[0].(map[string]any)
-	for _, key := range []string{"uid", "name", "address", "description", "appState", "startDate", "link", "url"} {
+	for _, key := range []string{"uid", "name", "address", "description", "appState", "startDate", "lastDifferent", "link", "url"} {
 		if _, present := first[key]; !present {
 			t.Errorf("application missing field %q: %v", key, first)
 		}
@@ -103,7 +133,7 @@ func TestNearHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 
 func TestNearHandler_RejectsMissingKey(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "buildkey", "",
 		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
@@ -114,14 +144,14 @@ func TestNearHandler_RejectsMissingKey(t *testing.T) {
 	if rec.Body.Len() != 0 {
 		t.Errorf("401 must be bodyless (backfilled downstream), got %s", rec.Body)
 	}
-	if store.called {
+	if store.called || store.countCalled {
 		t.Errorf("store must not be hit when the key is missing")
 	}
 }
 
 func TestNearHandler_EmptyConfiguredKeyRejectsAll(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "", "anything",
 		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
@@ -129,14 +159,14 @@ func TestNearHandler_EmptyConfiguredKeyRejectsAll(t *testing.T) {
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("empty configured key must reject all: got %d, want 401", rec.Code)
 	}
-	if store.called {
+	if store.called || store.countCalled {
 		t.Errorf("store must not be hit when the configured key is empty")
 	}
 }
 
 func TestNearHandler_MissingAuthorityIdReturns400(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?lat=51.5&lng=-0.1")
@@ -144,14 +174,14 @@ func TestNearHandler_MissingAuthorityIdReturns400(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("missing authorityId: got %d, want 400", rec.Code)
 	}
-	if store.called {
+	if store.called || store.countCalled {
 		t.Errorf("store must not be hit without a valid authorityId")
 	}
 }
 
 func TestNearHandler_NonIntAuthorityIdReturns400(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=abc&lat=51.5&lng=-0.1")
@@ -159,14 +189,14 @@ func TestNearHandler_NonIntAuthorityIdReturns400(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("non-int authorityId: got %d, want 400", rec.Code)
 	}
-	if store.called {
+	if store.called || store.countCalled {
 		t.Errorf("store must not be hit on a malformed authorityId")
 	}
 }
 
 func TestNearHandler_RejectsNonFiniteLat(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=NaN&lng=-0.1")
@@ -174,14 +204,14 @@ func TestNearHandler_RejectsNonFiniteLat(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("NaN lat: got %d, want 400", rec.Code)
 	}
-	if store.called {
+	if store.called || store.countCalled {
 		t.Errorf("store must not be hit on a non-finite lat")
 	}
 }
 
 func TestNearHandler_RejectsNonFiniteLng(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=51.5&lng=Inf")
@@ -189,14 +219,14 @@ func TestNearHandler_RejectsNonFiniteLng(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("Inf lng: got %d, want 400", rec.Code)
 	}
-	if store.called {
+	if store.called || store.countCalled {
 		t.Errorf("store must not be hit on a non-finite lng")
 	}
 }
 
 func TestNearHandler_RejectsOutOfRangeLat(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=91&lng=-0.1")
@@ -204,14 +234,14 @@ func TestNearHandler_RejectsOutOfRangeLat(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("out-of-range lat: got %d, want 400", rec.Code)
 	}
-	if store.called {
+	if store.called || store.countCalled {
 		t.Errorf("store must not be hit on an out-of-range lat")
 	}
 }
 
 func TestNearHandler_RejectsOutOfRangeLng(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=51.5&lng=200")
@@ -219,14 +249,14 @@ func TestNearHandler_RejectsOutOfRangeLng(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("out-of-range lng: got %d, want 400", rec.Code)
 	}
-	if store.called {
+	if store.called || store.countCalled {
 		t.Errorf("store must not be hit on an out-of-range lng")
 	}
 }
 
 func TestNearHandler_RejectsMissingLat(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lng=-0.1")
@@ -234,14 +264,14 @@ func TestNearHandler_RejectsMissingLat(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("missing lat: got %d, want 400", rec.Code)
 	}
-	if store.called {
+	if store.called || store.countCalled {
 		t.Errorf("store must not be hit without a lat")
 	}
 }
 
 func TestNearHandler_RejectsNonFiniteRadius(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&radius=Inf")
@@ -249,14 +279,14 @@ func TestNearHandler_RejectsNonFiniteRadius(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("non-finite radius: got %d, want 400", rec.Code)
 	}
-	if store.called {
+	if store.called || store.countCalled {
 		t.Errorf("store must not be hit on a non-finite radius")
 	}
 }
 
 func TestNearHandler_RejectsNonPositiveRadius(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&radius=0")
@@ -264,14 +294,14 @@ func TestNearHandler_RejectsNonPositiveRadius(t *testing.T) {
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("non-positive radius: got %d, want 400", rec.Code)
 	}
-	if store.called {
+	if store.called || store.countCalled {
 		t.Errorf("store must not be hit on a non-positive radius")
 	}
 }
 
 func TestNearHandler_ClampsRadiusToMax(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&radius=99999")
@@ -279,9 +309,10 @@ func TestNearHandler_ClampsRadiusToMax(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200", rec.Code)
 	}
-	// The clamped 10km radius is what reaches the store and what the response echoes.
-	if store.lastRadius != 10000 {
-		t.Errorf("store radius: got %v, want 10000 (clamped to 10km)", store.lastRadius)
+	// The clamped 10km radius is what reaches both the read and the count, and what
+	// the response echoes.
+	if store.lastRadius != 10000 || store.lastCountRadius != 10000 {
+		t.Errorf("store radius: read=%v count=%v, want 10000 (clamped to 10km)", store.lastRadius, store.lastCountRadius)
 	}
 	got := recentBody(t, rec)
 	if got["radius"].(float64) != 10000 {
@@ -291,7 +322,7 @@ func TestNearHandler_ClampsRadiusToMax(t *testing.T) {
 
 func TestNearHandler_DefaultRadiusWhenUnset(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
@@ -299,8 +330,8 @@ func TestNearHandler_DefaultRadiusWhenUnset(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200", rec.Code)
 	}
-	if store.lastRadius != 5000 {
-		t.Errorf("store radius: got %v, want 5000 (default when unset)", store.lastRadius)
+	if store.lastRadius != 5000 || store.lastCountRadius != 5000 {
+		t.Errorf("store radius: read=%v count=%v, want 5000 (default when unset)", store.lastRadius, store.lastCountRadius)
 	}
 	got := recentBody(t, rec)
 	if got["radius"].(float64) != 5000 {
@@ -310,7 +341,7 @@ func TestNearHandler_DefaultRadiusWhenUnset(t *testing.T) {
 
 func TestNearHandler_DefaultLimitIs30(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 50)}
+	store := &fakeNearStore{apps: recentApps(t, 50), count: 73}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
@@ -320,14 +351,14 @@ func TestNearHandler_DefaultLimitIs30(t *testing.T) {
 	if len(apps) != 30 {
 		t.Errorf("applications length: got %d, want 30 (default limit)", len(apps))
 	}
-	if got["total"].(float64) != 50 {
-		t.Errorf("total: got %v, want 50 (full bounded read)", got["total"])
+	if got["total"].(float64) != 73 {
+		t.Errorf("total: got %v, want 73 (exact count)", got["total"])
 	}
 }
 
 func TestNearHandler_LimitHardCappedAt100(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 150)}
+	store := &fakeNearStore{apps: recentApps(t, 150), count: 150}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&limit=999")
@@ -339,29 +370,48 @@ func TestNearHandler_LimitHardCappedAt100(t *testing.T) {
 	}
 }
 
-func TestNearHandler_TotalCappedWhenReadHitsCap(t *testing.T) {
+func TestNearHandler_ExactTotalIndependentOfSaturatedRead(t *testing.T) {
 	t.Parallel()
-	// Exactly cap (200) documents available -> the bounded read returns cap.
-	store := &fakeNearStore{apps: recentApps(t, 200)}
+	// The bounded read saturates at cap (200) but the exact count is far larger:
+	// total must be the count, and the render slice clamps to the limit.
+	store := &fakeNearStore{apps: recentApps(t, 200), count: 6502}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
 
 	got := recentBody(t, rec)
-	if got["total"].(float64) != 200 {
-		t.Errorf("total: got %v, want 200", got["total"])
-	}
-	if !got["totalCapped"].(bool) {
-		t.Errorf("totalCapped: got false, want true when the read hits cap")
+	if got["total"].(float64) != 6502 {
+		t.Errorf("total: got %v, want 6502 (exact count)", got["total"])
 	}
 	if apps := got["applications"].([]any); len(apps) != 30 {
-		t.Errorf("applications length: got %d, want 30", len(apps))
+		t.Errorf("applications length: got %d, want 30 (default limit, NOT the count)", len(apps))
+	}
+}
+
+func TestNearHandler_StatusBreakdownSpansBoundedReadNotRenderedSlice(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: appsByState(t, 25, 15), count: 40}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
+
+	got := recentBody(t, rec)
+	breakdown, ok := got["statusBreakdown"].([]any)
+	if !ok {
+		t.Fatalf("statusBreakdown must be an array, got %T", got["statusBreakdown"])
+	}
+	if len(breakdown) != 2 {
+		t.Fatalf("statusBreakdown length: got %d, want 2 (%v)", len(breakdown), breakdown)
+	}
+	first := breakdown[0].(map[string]any)
+	if first["appState"] != "Permitted" || first["count"].(float64) != 25 {
+		t.Errorf("breakdown[0]: got %v, want Permitted/25", first)
 	}
 }
 
 func TestNearHandler_EmptyResultIsNonNullArray(t *testing.T) {
 	t.Parallel()
-	store := &fakeNearStore{apps: nil}
+	store := &fakeNearStore{apps: nil, count: 0}
 
 	rec := serveNear(t, store, "buildkey", "buildkey",
 		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
@@ -380,6 +430,13 @@ func TestNearHandler_EmptyResultIsNonNullArray(t *testing.T) {
 	if got["total"].(float64) != 0 {
 		t.Errorf("total: got %v, want 0", got["total"])
 	}
+	breakdown, ok := got["statusBreakdown"].([]any)
+	if !ok {
+		t.Fatalf("statusBreakdown must be a non-null array even when empty, got %T", got["statusBreakdown"])
+	}
+	if len(breakdown) != 0 {
+		t.Errorf("statusBreakdown length: got %d, want 0", len(breakdown))
+	}
 }
 
 func TestNearHandler_StoreErrorReturns500(t *testing.T) {
@@ -391,5 +448,17 @@ func TestNearHandler_StoreErrorReturns500(t *testing.T) {
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("store error: got %d, want 500", rec.Code)
+	}
+}
+
+func TestNearHandler_CountErrorReturns500(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2), countErr: context.DeadlineExceeded}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("count error: got %d, want 500", rec.Code)
 	}
 }

--- a/api-go/internal/applications/recent.go
+++ b/api-go/internal/applications/recent.go
@@ -10,22 +10,24 @@ import (
 
 // recentReadCap is the hard upper bound on documents read per authority in one
 // SEO build request. The query is bounded by it (SELECT TOP @cap), so the RU cost
-// and response size stay flat regardless of how busy the authority is.
+// and response size stay flat regardless of how busy the authority is. It also
+// bounds the denominator of the status breakdown.
 const recentReadCap = 200
 
 // recentDefaultLimit and recentMaxLimit bound how many applications the response
 // renders. limit defaults to recentDefaultLimit and is hard-capped at
-// recentMaxLimit; the full bounded read still backs total/totalCapped.
+// recentMaxLimit; the rendered slice is clamped against the bounded read.
 const (
 	recentDefaultLimit = 30
 	recentMaxLimit     = 100
 )
 
-// recentStore is the consumer-side store the SEO read handler needs: a single
-// bounded, single-partition top-N read by authority. The concrete *CosmosStore
-// satisfies it structurally.
+// recentStore is the consumer-side store the SEO read handler needs: a bounded,
+// single-partition top-N read by authority plus an exact partition count. The
+// concrete *CosmosStore satisfies it structurally.
 type recentStore interface {
 	RecentByAuthority(ctx context.Context, authorityCode string, cap int) ([]PlanningApplication, error)
+	CountByAuthority(ctx context.Context, authorityCode string) (int, error)
 }
 
 // recentHandler serves the build-time SEO endpoint.
@@ -64,8 +66,16 @@ func (h *recentHandler) recentByAuthority(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	total := len(apps)
-	render := total
+	// total is the EXACT partition count (index-only COUNT), independent of the
+	// bounded read which saturates at recentReadCap. The render slice must clamp
+	// against the bounded read length, NOT total — total can dwarf len(apps).
+	total, err := h.store.CountByAuthority(r.Context(), authorityCode)
+	if err != nil {
+		serverError(w, r, h.logger, "count applications by authority", err)
+		return
+	}
+
+	render := len(apps)
 	if render > limit {
 		render = limit
 	}
@@ -78,16 +88,16 @@ func (h *recentHandler) recentByAuthority(w http.ResponseWriter, r *http.Request
 	// present. With zero applications it is empty (the prerender gate skips such
 	// authorities, so an empty page title never ships).
 	areaName := ""
-	if total > 0 {
+	if len(apps) > 0 {
 		areaName = apps[0].AreaName
 	}
 
 	writeJSON(w, r, h.logger, RecentByAuthorityResult{
-		AuthorityID:  id,
-		AreaName:     areaName,
-		Applications: results,
-		Total:        total,
-		TotalCapped:  total >= recentReadCap,
+		AuthorityID:     id,
+		AreaName:        areaName,
+		Applications:    results,
+		Total:           total,
+		StatusBreakdown: breakdownByState(apps),
 	})
 }
 

--- a/api-go/internal/applications/recent_test.go
+++ b/api-go/internal/applications/recent_test.go
@@ -11,14 +11,20 @@ import (
 )
 
 // fakeRecentStore is a hand-written double for the recent-by-authority read. It
-// honours cap the way Cosmos TOP @cap does, so the handler's cap/limit logic is
-// exercised against realistic bounded results.
+// honours cap the way Cosmos TOP @cap does (so the handler's cap/limit logic is
+// exercised against realistic bounded results) and serves an exact partition
+// count independently, so a test can prove total comes from the count call rather
+// than the bounded read length.
 type fakeRecentStore struct {
-	apps []PlanningApplication
-	err  error
+	apps     []PlanningApplication
+	err      error
+	count    int
+	countErr error
 
-	lastAuthorityCode string
-	lastCap           int
+	lastAuthorityCode      string
+	lastCap                int
+	countCalled            bool
+	lastCountAuthorityCode string
 }
 
 func (f *fakeRecentStore) RecentByAuthority(_ context.Context, authorityCode string, cap int) ([]PlanningApplication, error) {
@@ -33,6 +39,15 @@ func (f *fakeRecentStore) RecentByAuthority(_ context.Context, authorityCode str
 	return f.apps, nil
 }
 
+func (f *fakeRecentStore) CountByAuthority(_ context.Context, authorityCode string) (int, error) {
+	f.countCalled = true
+	f.lastCountAuthorityCode = authorityCode
+	if f.countErr != nil {
+		return 0, f.countErr
+	}
+	return f.count, nil
+}
+
 // recentApps builds n distinct planning applications for the handler tests.
 func recentApps(t *testing.T, n int) []PlanningApplication {
 	t.Helper()
@@ -43,6 +58,28 @@ func recentApps(t *testing.T, n int) []PlanningApplication {
 		a.Name = "24/" + strconv.Itoa(i) + "/FUL"
 		apps = append(apps, a)
 	}
+	return apps
+}
+
+// appsByState builds permitted+rejected distinct applications with the named raw
+// appStates, for asserting the status breakdown spans the bounded read.
+func appsByState(t *testing.T, permitted, rejected int) []PlanningApplication {
+	t.Helper()
+	base := testApplication(t)
+	apps := make([]PlanningApplication, 0, permitted+rejected)
+	i := 0
+	add := func(state string, n int) {
+		for range n {
+			a := base
+			a.Name = "24/" + strconv.Itoa(i) + "/FUL"
+			st := state
+			a.AppState = &st
+			apps = append(apps, a)
+			i++
+		}
+	}
+	add("Permitted", permitted)
+	add("Rejected", rejected)
 	return apps
 }
 
@@ -71,7 +108,9 @@ func recentBody(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
 
 func TestRecentHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 2)}
+	// count is deliberately distinct from len(apps) to prove total is the exact
+	// partition count, not the bounded read length.
+	store := &fakeRecentStore{apps: recentApps(t, 2), count: 1234}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications")
 
@@ -81,9 +120,13 @@ func TestRecentHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
 		t.Errorf("content-type: got %q", ct)
 	}
-	// The handler reads the bounded cap (200), scoped to the numeric id -> code.
+	// The handler reads the bounded cap (200) and counts the partition, both scoped
+	// to the numeric id -> code.
 	if store.lastAuthorityCode != "471" || store.lastCap != 200 {
-		t.Errorf("store call: authorityCode=%q cap=%d, want \"471\" 200", store.lastAuthorityCode, store.lastCap)
+		t.Errorf("store read call: authorityCode=%q cap=%d, want \"471\" 200", store.lastAuthorityCode, store.lastCap)
+	}
+	if !store.countCalled || store.lastCountAuthorityCode != "471" {
+		t.Errorf("count call: called=%v authorityCode=%q, want true \"471\"", store.countCalled, store.lastCountAuthorityCode)
 	}
 	got := recentBody(t, rec)
 	if got["authorityId"].(float64) != 471 {
@@ -99,24 +142,31 @@ func TestRecentHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 	if len(apps) != 2 {
 		t.Errorf("applications length: got %d, want 2", len(apps))
 	}
-	if got["total"].(float64) != 2 {
-		t.Errorf("total: got %v, want 2", got["total"])
+	if got["total"].(float64) != 1234 {
+		t.Errorf("total: got %v, want 1234 (the exact count)", got["total"])
 	}
-	if got["totalCapped"].(bool) {
-		t.Errorf("totalCapped: got true, want false")
+	if _, present := got["totalCapped"]; present {
+		t.Errorf("totalCapped must be gone from the wire shape, got %v", got["totalCapped"])
 	}
-	// The wire shape of an application carries the SEO-relevant fields.
+	if _, present := got["statusBreakdown"]; !present {
+		t.Errorf("statusBreakdown must be present: %v", got)
+	}
+	// The wire shape of an application carries the SEO-relevant fields, now
+	// including lastDifferent (the list's DESC sort key, for the "Last updated" card).
 	first := apps[0].(map[string]any)
-	for _, key := range []string{"uid", "name", "address", "description", "appState", "startDate", "link", "url"} {
+	for _, key := range []string{"uid", "name", "address", "description", "appState", "startDate", "lastDifferent", "link", "url"} {
 		if _, present := first[key]; !present {
 			t.Errorf("application missing field %q: %v", key, first)
 		}
+	}
+	if first["lastDifferent"] != "2026-03-02T09:30:00+00:00" {
+		t.Errorf("lastDifferent: got %v, want 2026-03-02T09:30:00+00:00", first["lastDifferent"])
 	}
 }
 
 func TestRecentHandler_RejectsMissingKey(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 2)}
+	store := &fakeRecentStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveRecent(t, store, "buildkey", "", "/v1/authorities/471/applications")
 
@@ -126,28 +176,28 @@ func TestRecentHandler_RejectsMissingKey(t *testing.T) {
 	if rec.Body.Len() != 0 {
 		t.Errorf("401 must be bodyless (backfilled downstream), got %s", rec.Body)
 	}
-	if store.lastCap != 0 {
+	if store.lastCap != 0 || store.countCalled {
 		t.Errorf("store must not be hit when the key is missing")
 	}
 }
 
 func TestRecentHandler_EmptyConfiguredKeyRejectsAll(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 2)}
+	store := &fakeRecentStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveRecent(t, store, "", "anything", "/v1/authorities/471/applications")
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("empty configured key must reject all: got %d, want 401", rec.Code)
 	}
-	if store.lastCap != 0 {
+	if store.lastCap != 0 || store.countCalled {
 		t.Errorf("store must not be hit when the configured key is empty")
 	}
 }
 
 func TestRecentHandler_LimitsReturnedApplications(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 50)}
+	store := &fakeRecentStore{apps: recentApps(t, 50), count: 73}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications?limit=10")
 
@@ -159,15 +209,15 @@ func TestRecentHandler_LimitsReturnedApplications(t *testing.T) {
 	if len(apps) != 10 {
 		t.Errorf("applications length: got %d, want 10 (the limit)", len(apps))
 	}
-	// total reflects the full bounded read, not the rendered slice.
-	if got["total"].(float64) != 50 {
-		t.Errorf("total: got %v, want 50", got["total"])
+	// total is the exact partition count, not the rendered slice nor the bounded read.
+	if got["total"].(float64) != 73 {
+		t.Errorf("total: got %v, want 73 (exact count)", got["total"])
 	}
 }
 
 func TestRecentHandler_DefaultLimitIs30(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 50)}
+	store := &fakeRecentStore{apps: recentApps(t, 50), count: 50}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications")
 
@@ -180,7 +230,7 @@ func TestRecentHandler_DefaultLimitIs30(t *testing.T) {
 
 func TestRecentHandler_LimitHardCappedAt100(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 150)}
+	store := &fakeRecentStore{apps: recentApps(t, 150), count: 150}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications?limit=999")
 
@@ -191,29 +241,53 @@ func TestRecentHandler_LimitHardCappedAt100(t *testing.T) {
 	}
 }
 
-func TestRecentHandler_TotalCappedWhenReadHitsCap(t *testing.T) {
+func TestRecentHandler_ExactTotalIndependentOfSaturatedRead(t *testing.T) {
 	t.Parallel()
-	// Exactly cap (200) documents available -> the bounded read returns cap.
-	store := &fakeRecentStore{apps: recentApps(t, 200)}
+	// The bounded read saturates at cap (200) but the exact count is far larger:
+	// total must be the count, and the render slice clamps to the limit, not the
+	// count (the bug the bounded-read clamp guards against).
+	store := &fakeRecentStore{apps: recentApps(t, 200), count: 8421}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications")
 
 	got := recentBody(t, rec)
-	if got["total"].(float64) != 200 {
-		t.Errorf("total: got %v, want 200", got["total"])
+	if got["total"].(float64) != 8421 {
+		t.Errorf("total: got %v, want 8421 (exact count)", got["total"])
 	}
-	if !got["totalCapped"].(bool) {
-		t.Errorf("totalCapped: got false, want true when the read hits cap")
-	}
-	// Still renders only the default limit.
 	if apps := got["applications"].([]any); len(apps) != 30 {
-		t.Errorf("applications length: got %d, want 30", len(apps))
+		t.Errorf("applications length: got %d, want 30 (default limit, NOT the count)", len(apps))
+	}
+}
+
+func TestRecentHandler_StatusBreakdownSpansBoundedReadNotRenderedSlice(t *testing.T) {
+	t.Parallel()
+	// 40 in the bounded read (25 Permitted, 15 Rejected); only 30 are rendered, but
+	// the breakdown denominator is the whole bounded read.
+	store := &fakeRecentStore{apps: appsByState(t, 25, 15), count: 40}
+
+	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications")
+
+	got := recentBody(t, rec)
+	breakdown, ok := got["statusBreakdown"].([]any)
+	if !ok {
+		t.Fatalf("statusBreakdown must be an array, got %T", got["statusBreakdown"])
+	}
+	if len(breakdown) != 2 {
+		t.Fatalf("statusBreakdown length: got %d, want 2 (%v)", len(breakdown), breakdown)
+	}
+	first := breakdown[0].(map[string]any)
+	second := breakdown[1].(map[string]any)
+	if first["appState"] != "Permitted" || first["count"].(float64) != 25 {
+		t.Errorf("breakdown[0]: got %v, want Permitted/25", first)
+	}
+	if second["appState"] != "Rejected" || second["count"].(float64) != 15 {
+		t.Errorf("breakdown[1]: got %v, want Rejected/15", second)
 	}
 }
 
 func TestRecentHandler_EmptyResultIsNonNullArray(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: nil}
+	store := &fakeRecentStore{apps: nil, count: 0}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications")
 
@@ -234,18 +308,25 @@ func TestRecentHandler_EmptyResultIsNonNullArray(t *testing.T) {
 	if got["areaName"] != "" {
 		t.Errorf("areaName: got %v, want empty when no applications", got["areaName"])
 	}
+	breakdown, ok := got["statusBreakdown"].([]any)
+	if !ok {
+		t.Fatalf("statusBreakdown must be a non-null array even when empty, got %T", got["statusBreakdown"])
+	}
+	if len(breakdown) != 0 {
+		t.Errorf("statusBreakdown length: got %d, want 0", len(breakdown))
+	}
 }
 
 func TestRecentHandler_NonIntIdReturns400(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 2)}
+	store := &fakeRecentStore{apps: recentApps(t, 2), count: 2}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/abc/applications")
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("non-int id: got %d, want 400", rec.Code)
 	}
-	if store.lastCap != 0 {
+	if store.lastCap != 0 || store.countCalled {
 		t.Errorf("store must not be hit on a malformed id")
 	}
 }
@@ -258,5 +339,17 @@ func TestRecentHandler_StoreErrorReturns500(t *testing.T) {
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("store error: got %d, want 500", rec.Code)
+	}
+}
+
+func TestRecentHandler_CountErrorReturns500(t *testing.T) {
+	t.Parallel()
+	// The bounded read succeeds but the exact count fails -> 500 (no partial total).
+	store := &fakeRecentStore{apps: recentApps(t, 2), countErr: context.DeadlineExceeded}
+
+	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("count error: got %d, want 500", rec.Code)
 	}
 }

--- a/api-go/internal/applications/result.go
+++ b/api-go/internal/applications/result.go
@@ -2,6 +2,7 @@ package applications
 
 import (
 	"encoding/json"
+	"sort"
 
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
@@ -112,29 +113,85 @@ type RecentNearbyResult struct {
 // RecentApplication is the slim, render-only projection of a planning application
 // for an SEO page: just the fields the static page needs. Coordinates, area
 // identity, and the unread-event projection are deliberately omitted.
+// lastDifferent is the DESC sort key of the bounded read, carried so the web card
+// can show a "Last updated" date that matches the list order; it is non-pointer
+// because the domain always carries it.
 type RecentApplication struct {
-	UID         string             `json:"uid"`
-	Name        string             `json:"name"`
-	Address     string             `json:"address"`
-	Description string             `json:"description"`
-	AppState    *string            `json:"appState"`
-	StartDate   *platform.DateOnly `json:"startDate"`
-	Link        *string            `json:"link"`
-	URL         *string            `json:"url"`
+	UID           string              `json:"uid"`
+	Name          string              `json:"name"`
+	Address       string              `json:"address"`
+	Description   string              `json:"description"`
+	AppState      *string             `json:"appState"`
+	StartDate     *platform.DateOnly  `json:"startDate"`
+	LastDifferent platform.DotNetTime `json:"lastDifferent"`
+	Link          *string             `json:"link"`
+	URL           *string             `json:"url"`
 }
 
 // RecentApplicationOf maps a domain snapshot to its slim SEO wire shape.
 func RecentApplicationOf(a PlanningApplication) RecentApplication {
 	return RecentApplication{
-		UID:         a.UID,
-		Name:        a.Name,
-		Address:     a.Address,
-		Description: a.Description,
-		AppState:    a.AppState,
-		StartDate:   platform.DateOnlyPtr(a.StartDate),
-		Link:        a.Link,
-		URL:         a.URL,
+		UID:           a.UID,
+		Name:          a.Name,
+		Address:       a.Address,
+		Description:   a.Description,
+		AppState:      a.AppState,
+		StartDate:     platform.DateOnlyPtr(a.StartDate),
+		LastDifferent: platform.DotNetTime(a.LastDifferent),
+		Link:          a.Link,
+		URL:           a.URL,
 	}
+}
+
+// StateCount is one row of an appState breakdown: a nullable raw appState and how
+// many applications in the bounded read carried it. The appState is the RAW
+// PlanIt value (nil when absent), not a resident-facing label — the web owns that
+// mapping.
+type StateCount struct {
+	AppState *string `json:"appState"`
+	Count    int     `json:"count"`
+}
+
+// breakdownByState computes the per-appState distribution over the given bounded
+// read of applications. The denominator is the bounded read (at most the handler
+// cap), NOT the whole partition — appState is not indexed, so an exact
+// over-everything breakdown is out of scope. Keys are the RAW appState values; a
+// nil appState is a distinct bucket. The order is deterministic: count DESC, then
+// appState ASC, with nil sorting last.
+func breakdownByState(apps []PlanningApplication) []StateCount {
+	counts := make(map[string]int)
+	nilCount := 0
+	for _, a := range apps {
+		if a.AppState == nil {
+			nilCount++
+			continue
+		}
+		counts[*a.AppState]++
+	}
+
+	out := make([]StateCount, 0, len(counts)+1)
+	for state, n := range counts {
+		s := state
+		out = append(out, StateCount{AppState: &s, Count: n})
+	}
+	if nilCount > 0 {
+		out = append(out, StateCount{AppState: nil, Count: nilCount})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count // count DESC
+		}
+		// nil sorts last on a count tie.
+		if out[i].AppState == nil {
+			return false
+		}
+		if out[j].AppState == nil {
+			return true
+		}
+		return *out[i].AppState < *out[j].AppState // appState ASC
+	})
+	return out
 }
 
 // NearbyResultOf maps a domain snapshot to the raw-domain wire shape.

--- a/api-go/internal/applications/result.go
+++ b/api-go/internal/applications/result.go
@@ -84,30 +84,33 @@ type NearbyResult struct {
 
 // RecentByAuthorityResult is the wire shape of the build-time SEO endpoint
 // GET /v1/authorities/{id}/applications. Applications is always a non-null array
-// (at most the request's limit). Total is the count from the single bounded read;
-// TotalCapped reports that the read hit cap (so the prerender can render "200+").
+// (at most the request's limit). Total is the EXACT count of applications in the
+// authority partition (a separate index-only COUNT, not the bounded read length).
+// StatusBreakdown is the per-appState distribution over the bounded read (its
+// denominator is that read, not the whole partition), always a non-null array.
 type RecentByAuthorityResult struct {
-	AuthorityID  int                 `json:"authorityId"`
-	AreaName     string              `json:"areaName"`
-	Applications []RecentApplication `json:"applications"`
-	Total        int                 `json:"total"`
-	TotalCapped  bool                `json:"totalCapped"`
+	AuthorityID     int                 `json:"authorityId"`
+	AreaName        string              `json:"areaName"`
+	Applications    []RecentApplication `json:"applications"`
+	Total           int                 `json:"total"`
+	StatusBreakdown []StateCount        `json:"statusBreakdown"`
 }
 
 // RecentNearbyResult is the wire shape of the build-time town-level SEO endpoint
 // GET /v1/applications/near. It mirrors RecentByAuthorityResult but echoes the
 // effective (post-clamp) query point and radius instead of an area name, so the
 // town prerender can label and cache the page by its centroid. Applications is
-// always a non-null array (at most the request's limit); Total is the count from
-// the single bounded read; TotalCapped reports that the read hit cap.
+// always a non-null array (at most the request's limit); Total is the EXACT
+// in-radius count (a separate COUNT, not the bounded read length); StatusBreakdown
+// is the per-appState distribution over the bounded read, always a non-null array.
 type RecentNearbyResult struct {
-	AuthorityID  int                 `json:"authorityId"`
-	Lat          float64             `json:"lat"`
-	Lng          float64             `json:"lng"`
-	Radius       float64             `json:"radius"`
-	Applications []RecentApplication `json:"applications"`
-	Total        int                 `json:"total"`
-	TotalCapped  bool                `json:"totalCapped"`
+	AuthorityID     int                 `json:"authorityId"`
+	Lat             float64             `json:"lat"`
+	Lng             float64             `json:"lng"`
+	Radius          float64             `json:"radius"`
+	Applications    []RecentApplication `json:"applications"`
+	Total           int                 `json:"total"`
+	StatusBreakdown []StateCount        `json:"statusBreakdown"`
 }
 
 // RecentApplication is the slim, render-only projection of a planning application

--- a/api-go/internal/applications/result_test.go
+++ b/api-go/internal/applications/result_test.go
@@ -71,7 +71,26 @@ func TestBreakdownByState_OrdersByCountDescThenStateAsc(t *testing.T) {
 	assertBreakdownEqual(t, got, want)
 }
 
-func TestBreakdownByState_NilStateSortsLast(t *testing.T) {
+func TestBreakdownByState_NilStateSortsLastOnCountTie(t *testing.T) {
+	t.Parallel()
+	apps := []PlanningApplication{
+		appWithState(t, nil),
+		appWithState(t, nil),
+		appWithState(t, strPtr("Permitted")),
+		appWithState(t, strPtr("Permitted")),
+	}
+
+	got := breakdownByState(apps)
+
+	// nil is a distinct bucket; on a count tie the deterministic rule sorts it last.
+	want := []StateCount{
+		{AppState: strPtr("Permitted"), Count: 2},
+		{AppState: nil, Count: 2},
+	}
+	assertBreakdownEqual(t, got, want)
+}
+
+func TestBreakdownByState_NilStateRanksByCountDesc(t *testing.T) {
 	t.Parallel()
 	apps := []PlanningApplication{
 		appWithState(t, nil),
@@ -82,11 +101,10 @@ func TestBreakdownByState_NilStateSortsLast(t *testing.T) {
 
 	got := breakdownByState(apps)
 
-	// A nil appState is a distinct bucket and, despite the higher count, sorts last
-	// by the deterministic tie-break rule.
+	// count DESC is the primary key: nil's higher count outranks Permitted here.
 	want := []StateCount{
-		{AppState: strPtr("Permitted"), Count: 1},
 		{AppState: nil, Count: 3},
+		{AppState: strPtr("Permitted"), Count: 1},
 	}
 	assertBreakdownEqual(t, got, want)
 }

--- a/api-go/internal/applications/result_test.go
+++ b/api-go/internal/applications/result_test.go
@@ -1,0 +1,125 @@
+package applications
+
+import (
+	"testing"
+	"time"
+)
+
+// strPtr is a local helper for building *string appState keys in the breakdown
+// tests.
+func strPtr(s string) *string { return &s }
+
+func TestRecentApplicationOf_IncludesLastDifferent(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+
+	got := RecentApplicationOf(a)
+
+	// The slim SEO projection carries lastDifferent (the DESC sort key) so the web
+	// card can show a "Last updated" date that matches the list order.
+	if !time.Time(got.LastDifferent).Equal(a.LastDifferent) {
+		t.Errorf("LastDifferent: got %v, want %v", time.Time(got.LastDifferent), a.LastDifferent)
+	}
+}
+
+func appWithState(t *testing.T, state *string) PlanningApplication {
+	t.Helper()
+	a := testApplication(t)
+	a.AppState = state
+	return a
+}
+
+func TestBreakdownByState_CountsRawStatesOverBoundedRead(t *testing.T) {
+	t.Parallel()
+	apps := []PlanningApplication{
+		appWithState(t, strPtr("Permitted")),
+		appWithState(t, strPtr("Rejected")),
+		appWithState(t, strPtr("Permitted")),
+		appWithState(t, strPtr("Permitted")),
+		appWithState(t, strPtr("Rejected")),
+	}
+
+	got := breakdownByState(apps)
+
+	// Raw appState keys are returned verbatim (the web owns label mapping); the
+	// denominator is the bounded read, not the whole partition.
+	want := []StateCount{
+		{AppState: strPtr("Permitted"), Count: 3},
+		{AppState: strPtr("Rejected"), Count: 2},
+	}
+	assertBreakdownEqual(t, got, want)
+}
+
+func TestBreakdownByState_OrdersByCountDescThenStateAsc(t *testing.T) {
+	t.Parallel()
+	apps := []PlanningApplication{
+		appWithState(t, strPtr("Conditions")),
+		appWithState(t, strPtr("Permitted")),
+		appWithState(t, strPtr("Permitted")),
+		appWithState(t, strPtr("Rejected")),
+		appWithState(t, strPtr("Rejected")),
+	}
+
+	got := breakdownByState(apps)
+
+	// Permitted and Rejected tie on 2 -> alphabetical asc; Conditions trails on 1.
+	want := []StateCount{
+		{AppState: strPtr("Permitted"), Count: 2},
+		{AppState: strPtr("Rejected"), Count: 2},
+		{AppState: strPtr("Conditions"), Count: 1},
+	}
+	assertBreakdownEqual(t, got, want)
+}
+
+func TestBreakdownByState_NilStateSortsLast(t *testing.T) {
+	t.Parallel()
+	apps := []PlanningApplication{
+		appWithState(t, nil),
+		appWithState(t, nil),
+		appWithState(t, nil),
+		appWithState(t, strPtr("Permitted")),
+	}
+
+	got := breakdownByState(apps)
+
+	// A nil appState is a distinct bucket and, despite the higher count, sorts last
+	// by the deterministic tie-break rule.
+	want := []StateCount{
+		{AppState: strPtr("Permitted"), Count: 1},
+		{AppState: nil, Count: 3},
+	}
+	assertBreakdownEqual(t, got, want)
+}
+
+func TestBreakdownByState_EmptyInputIsNonNilEmptySlice(t *testing.T) {
+	t.Parallel()
+	got := breakdownByState(nil)
+	if got == nil {
+		t.Fatal("breakdownByState(nil): got nil slice, want empty non-nil slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("breakdownByState(nil): got %d entries, want 0", len(got))
+	}
+}
+
+// assertBreakdownEqual compares two breakdown slices positionally, including the
+// nullable AppState pointer values.
+func assertBreakdownEqual(t *testing.T, got, want []StateCount) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("breakdown length: got %d, want %d (%+v)", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Count != want[i].Count {
+			t.Errorf("entry %d count: got %d, want %d", i, got[i].Count, want[i].Count)
+		}
+		switch {
+		case want[i].AppState == nil && got[i].AppState != nil:
+			t.Errorf("entry %d appState: got %q, want nil", i, *got[i].AppState)
+		case want[i].AppState != nil && got[i].AppState == nil:
+			t.Errorf("entry %d appState: got nil, want %q", i, *want[i].AppState)
+		case want[i].AppState != nil && got[i].AppState != nil && *got[i].AppState != *want[i].AppState:
+			t.Errorf("entry %d appState: got %q, want %q", i, *got[i].AppState, *want[i].AppState)
+		}
+	}
+}

--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -122,6 +122,35 @@ func (s *CosmosStore) RecentByAuthority(ctx context.Context, authorityCode strin
 	return apps, nil
 }
 
+// countByAuthorityQuery is the exact, index-only count of every application in a
+// single authorityCode partition. SELECT VALUE COUNT(1) hydrates no documents, so
+// it stays cheap even for an authority holding tens of thousands of rows, and it
+// returns the EXACT partition total — unlike the TOP-@cap bounded read, which
+// saturates at the cap. Cosmos returns a single row that is a bare JSON number.
+const countByAuthorityQuery = "SELECT VALUE COUNT(1) FROM c"
+
+// CountByAuthority returns the exact number of applications in the authorityCode
+// partition. It backs the build-time SEO endpoint's total: RecentByAuthority
+// renders the bounded list, this counts the whole partition. It runs on the
+// latency-tolerant build-read budget (QueryItemsLongRead), like the sibling SEO
+// reads, and reads only from Cosmos (GH#395 Invariant 1) — never PlanIt.
+func (s *CosmosStore) CountByAuthority(ctx context.Context, authorityCode string) (int, error) {
+	// Latency-tolerant build-time read: a LARGE authority partition legitimately
+	// exceeds the 1.5s OLTP budget, so use the longer per-attempt budget (tc-9tov).
+	raws, err := s.items.QueryItemsLongRead(ctx, authorityCode, countByAuthorityQuery, nil)
+	if err != nil {
+		return 0, fmt.Errorf("count applications for authority %q: %w", authorityCode, err)
+	}
+	if len(raws) == 0 {
+		return 0, nil
+	}
+	var total int
+	if err := json.Unmarshal(raws[0], &total); err != nil {
+		return 0, fmt.Errorf("decode application count for authority %q: %w", authorityCode, err)
+	}
+	return total, nil
+}
+
 // findNearbyQuery is the single-partition ST_DISTANCE spatial query for nearby
 // applications. Coordinates and radius are bound as named parameters (mirroring
 // findZonesContainingQuery in the watchzones package) — no float literals are
@@ -155,6 +184,44 @@ func (s *CosmosStore) FindNearby(ctx context.Context, authorityCode string, lati
 		apps = append(apps, doc.toDomain())
 	}
 	return apps, nil
+}
+
+// countNearbyQuery is the exact, single-partition count of applications within
+// radiusMetres of a point. It marries the recentNearbyQuery ST_DISTANCE filter
+// (GeoJSON [longitude, latitude] order, all values bound as named parameters)
+// with a SELECT VALUE COUNT(1) scalar instead of a bounded TOP @cap read, so it
+// returns the EXACT in-radius total for the town SEO page. Cosmos returns a
+// single row that is a bare JSON number.
+const countNearbyQuery = "SELECT VALUE COUNT(1) FROM c WHERE ST_DISTANCE(c.location, " +
+	`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres`
+
+// CountNearby returns the exact number of applications within radiusMetres of
+// (lat, lng) inside the authorityCode partition. It backs the build-time
+// town-level SEO endpoint's total: RecentNearby renders the bounded list, this
+// counts everything in radius. Coordinates and radius are bound as named
+// parameters (not string-concatenated). It runs on the latency-tolerant
+// build-read budget (QueryItemsLongRead) and reads only from Cosmos (GH#395
+// Invariant 1) — never PlanIt.
+func (s *CosmosStore) CountNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) (int, error) {
+	params := map[string]any{
+		"@latitude":     lat,
+		"@longitude":    lng,
+		"@radiusMetres": radiusMetres,
+	}
+	// Latency-tolerant build-time read: a LARGE authority partition legitimately
+	// exceeds the 1.5s OLTP budget, so use the longer per-attempt budget (tc-9tov).
+	raws, err := s.items.QueryItemsLongRead(ctx, authorityCode, countNearbyQuery, params)
+	if err != nil {
+		return 0, fmt.Errorf("count applications near %q: %w", authorityCode, err)
+	}
+	if len(raws) == 0 {
+		return 0, nil
+	}
+	var total int
+	if err := json.Unmarshal(raws[0], &total); err != nil {
+		return 0, fmt.Errorf("decode nearby application count for %q: %w", authorityCode, err)
+	}
+	return total, nil
 }
 
 // recentNearbyQuery is the bounded, single-partition spatial top-N query behind

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -440,6 +440,163 @@ func TestCosmosStore_RecentNearby_EmptyResultIsEmptySlice(t *testing.T) {
 	}
 }
 
+func TestCosmosStore_CountByAuthority_DecodesScalarScopedToPartition(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	// SELECT VALUE COUNT(1) returns a single row that is a bare JSON number.
+	items.queryResult = [][]byte{[]byte("42")}
+	store := NewCosmosStore(items)
+
+	got, err := store.CountByAuthority(context.Background(), "471")
+	if err != nil {
+		t.Fatalf("CountByAuthority: %v", err)
+	}
+	if got != 42 {
+		t.Errorf("count: got %d, want 42", got)
+	}
+	// Scoped to the authorityCode logical partition (never cross-partition).
+	if items.lastQueryPK != "471" {
+		t.Errorf("query partition key: got %q, want \"471\"", items.lastQueryPK)
+	}
+	// Index-only scalar count over the whole partition — no TOP @cap (that would
+	// saturate the total), no ordering.
+	want := "SELECT VALUE COUNT(1) FROM c"
+	if items.lastQuery != want {
+		t.Errorf("count query:\n got %q\nwant %q", items.lastQuery, want)
+	}
+	if _, ok := items.lastQueryParams["@cap"]; ok {
+		t.Errorf("count query must not bind @cap (it counts the whole partition): %v", items.lastQueryParams)
+	}
+}
+
+func TestCosmosStore_CountByAuthority_EmptyResultIsZero(t *testing.T) {
+	t.Parallel()
+	// No rows at all (defensive): an empty result set yields 0, not an error.
+	store := NewCosmosStore(newFakeItems())
+
+	got, err := store.CountByAuthority(context.Background(), "471")
+	if err != nil {
+		t.Fatalf("CountByAuthority: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("count: got %d, want 0", got)
+	}
+}
+
+func TestCosmosStore_CountByAuthority_UsesLongReadBudget(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	items.queryResult = [][]byte{[]byte("3")}
+	store := NewCosmosStore(items)
+
+	if _, err := store.CountByAuthority(context.Background(), "156"); err != nil {
+		t.Fatalf("CountByAuthority: %v", err)
+	}
+	if !items.lastQueryViaLongRead {
+		t.Error("CountByAuthority must use the long-read budget (QueryItemsLongRead), not the 1.5s OLTP QueryItems")
+	}
+}
+
+func TestCosmosStore_CountByAuthority_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	items.queryErr = context.DeadlineExceeded
+	store := NewCosmosStore(items)
+
+	if _, err := store.CountByAuthority(context.Background(), "471"); err == nil {
+		t.Fatal("CountByAuthority: expected error, got nil")
+	}
+}
+
+func TestCosmosStore_CountNearby_DecodesScalarWithSpatialFilterScopedToPartition(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	items.queryResult = [][]byte{[]byte("17")}
+	store := NewCosmosStore(items)
+
+	got, err := store.CountNearby(context.Background(), "441", 51.4975, -0.1357, 5000)
+	if err != nil {
+		t.Fatalf("CountNearby: %v", err)
+	}
+	if got != 17 {
+		t.Errorf("count: got %d, want 17", got)
+	}
+	if items.lastQueryPK != "441" {
+		t.Errorf("query partition key: got %q, want \"441\"", items.lastQueryPK)
+	}
+	// Same single-partition ST_DISTANCE filter and named-param style as
+	// recentNearbyQuery, but a scalar COUNT instead of a bounded TOP @cap.
+	want := "SELECT VALUE COUNT(1) FROM c WHERE ST_DISTANCE(c.location, " +
+		`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres`
+	if items.lastQuery != want {
+		t.Errorf("count nearby query:\n got %q\nwant %q", items.lastQuery, want)
+	}
+	if _, ok := items.lastQueryParams["@cap"]; ok {
+		t.Errorf("count query must not bind @cap: %v", items.lastQueryParams)
+	}
+}
+
+func TestCosmosStore_CountNearby_UsesParameterizedQuery(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	_, _ = store.CountNearby(context.Background(), "441", 51.4975, -0.1357, 5000)
+
+	// No coordinate or radius value may be string-concatenated into the query —
+	// they must all be bound as named parameters.
+	if items.lastQuery == "" {
+		t.Fatal("no query was issued")
+	}
+	for _, literal := range []string{"51.4975", "-0.1357", "5000"} {
+		if strings.Contains(items.lastQuery, literal) {
+			t.Errorf("query contains literal %q — should be a named parameter; query: %s", literal, items.lastQuery)
+		}
+	}
+	wantParams := map[string]any{
+		"@latitude":     51.4975,
+		"@longitude":    -0.1357,
+		"@radiusMetres": 5000.0,
+	}
+	for k, wantVal := range wantParams {
+		gotVal, ok := items.lastQueryParams[k]
+		if !ok {
+			t.Errorf("param %q not found in query params %v", k, items.lastQueryParams)
+			continue
+		}
+		if gotVal != wantVal {
+			t.Errorf("param %q: got %v, want %v", k, gotVal, wantVal)
+		}
+	}
+}
+
+func TestCosmosStore_CountNearby_EmptyResultIsZero(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+
+	got, err := store.CountNearby(context.Background(), "471", 51.5, -0.1, 5000)
+	if err != nil {
+		t.Fatalf("CountNearby: %v", err)
+	}
+	if got != 0 {
+		t.Errorf("count: got %d, want 0", got)
+	}
+}
+
+func TestCosmosStore_CountNearby_UsesLongReadBudget(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	items.queryResult = [][]byte{[]byte("9")}
+	store := NewCosmosStore(items)
+
+	if _, err := store.CountNearby(context.Background(), "156", 51.5, -0.1, 5000); err != nil {
+		t.Fatalf("CountNearby: %v", err)
+	}
+	if !items.lastQueryViaLongRead {
+		t.Error("CountNearby must use the long-read budget (QueryItemsLongRead), not the 1.5s OLTP QueryItems")
+	}
+}
+
 // The build-time SEO reads run over a LARGE authority partition and legitimately
 // exceed the tight 1.5s OLTP budget, so they must route through the longer-budget
 // QueryItemsLongRead accessor — never the OLTP QueryItems (tc-9tov).


### PR DESCRIPTION
Implements tc-vj7c.1 — three changes to the build-key-gated SEO read endpoints (`GET /v1/authorities/{id}/applications` and `GET /v1/applications/near`). All changes are confined to `api-go/internal/applications/`. The authed `FindNearby` path is untouched; reads stay Cosmos-only (no PlanIt fallback).

## 1. Exact total (replaces the TOP-200-saturated total; `TotalCapped` removed)
- New store methods on `*CosmosStore`:
  - `CountByAuthority` → `SELECT VALUE COUNT(1) FROM c` (index-only, exact partition total).
  - `CountNearby` → same `ST_DISTANCE` filter / named-param style as `recentNearbyQuery`, with a scalar `COUNT(1)`.
  - Both run on `QueryItemsLongRead` (build-time, latency-tolerant), decode `raws[0]` as a bare JSON number, and treat `len(raws)==0` as `0`.
- Added `CountByAuthority`/`CountNearby` to the `recentStore`/`nearStore` consumer interfaces.
- Handlers set `total` from the exact count after the bounded read succeeds. The render slice now clamps against the **bounded read length** (`render := len(apps); if render > limit ...`) rather than `total`, since an exact whole-partition total can dwarf the 200-cap read. `areaName` guard switched from `total > 0` to `len(apps) > 0`.
- `TotalCapped` field dropped from `RecentByAuthorityResult` and `RecentNearbyResult` and every reference/assertion; doc comments updated (no more "200+").

## 2. `lastDifferent` in the slim projection
- Added `LastDifferent platform.DotNetTime` (non-pointer, json `lastDifferent`) to `RecentApplication`, set in `RecentApplicationOf`. Lets the web card show a "Last updated" date matching the `lastDifferent` DESC sort.

## 3. Status breakdown over the bounded read
- `StatusBreakdown []StateCount` (json `statusBreakdown`) added to both result structs, where `StateCount{ AppState *string; Count int }`.
- Pure helper `breakdownByState(apps)` computes per-RAW-appState counts over the bounded `apps` slice (zero extra query). Returns raw nullable appState keys (the web owns resident-facing label mapping). Deterministic order: count DESC, then appState ASC, nil last on a tie. Denominator is the bounded read, not the whole partition.

## Testing
- Strict Red-Green-Refactor with hand-written fakes (extended `fakeItems`, `fakeRecentStore`, `fakeNearStore`). No mocking libraries.
- Gates clean from `api-go/`: `go test -race ./...`, `go vet ./...`, `gofmt -l .` (empty), `golangci-lint run ./...`.

Unblocks tc-vj7c.2 (web rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applications list endpoints now include a status breakdown showing count of applications by state.
  * Total application count is now exact and independent of result limits.

* **Bug Fixes**
  * Fixed inaccurate total count reporting when results were bounded by pagination limits.

* **Tests**
  * Added comprehensive test coverage for count and status breakdown functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->