### PR TITLE
feat(web): SEO pages — exact count, Last updated date, server status breakdown (tc-vj7c.2)

### DIFF
--- a/web/scripts/fixtures/sample-authorities.json
+++ b/web/scripts/fixtures/sample-authorities.json
@@ -5,7 +5,12 @@
     "areaType": "English District",
     "areaName": "Basingstoke and Deane",
     "total": 42,
-    "totalCapped": false,
+    "statusBreakdown": [
+      { "appState": "Permitted", "count": 20 },
+      { "appState": "Rejected", "count": 12 },
+      { "appState": "Undecided", "count": 8 },
+      { "appState": null, "count": 2 }
+    ],
     "applications": [
       {
         "uid": "BDB/2026/0001",
@@ -14,6 +19,7 @@
         "description": "Erection of a two-storey rear extension and associated landscaping works to an existing dwelling house.",
         "appState": "Permitted",
         "startDate": "2026-01-15",
+        "lastDifferent": "2026-06-15T10:00:00+00:00",
         "link": "https://planit.org.uk/planapplic/26-00001-FUL",
         "url": "https://planning.basingstoke.gov.uk/online-applications/26-00001-FUL"
       },
@@ -24,6 +30,7 @@
         "description": "Single-storey side extension, replacement boundary wall and new vehicular access.",
         "appState": "Rejected",
         "startDate": "2026-02-03",
+        "lastDifferent": "2026-06-12T09:00:00+00:00",
         "link": "https://planit.org.uk/planapplic/26-00002-HSE",
         "url": null
       },
@@ -34,6 +41,7 @@
         "description": "Listed building consent for internal alterations and the installation of accessible facilities.",
         "appState": "Undecided",
         "startDate": "2026-02-20",
+        "lastDifferent": "2026-06-09T08:00:00+00:00",
         "link": "https://planit.org.uk/planapplic/26-00003-LBC",
         "url": "https://planning.basingstoke.gov.uk/online-applications/26-00003-LBC"
       }
@@ -45,7 +53,7 @@
     "areaType": "English County",
     "areaName": "West Sussex",
     "total": 88,
-    "totalCapped": false,
+    "statusBreakdown": [],
     "applications": []
   },
   {
@@ -54,7 +62,7 @@
     "areaType": "English District",
     "areaName": "Sparse Parish",
     "total": 4,
-    "totalCapped": false,
+    "statusBreakdown": [{ "appState": "Undecided", "count": 4 }],
     "applications": [
       {
         "uid": "SP/2026/0001",
@@ -63,6 +71,7 @@
         "description": "Single dwelling.",
         "appState": "Undecided",
         "startDate": "2026-01-01",
+        "lastDifferent": "2026-06-01T08:00:00+00:00",
         "link": "https://planit.org.uk/planapplic/SP-26-0001",
         "url": null
       }

--- a/web/scripts/fixtures/sample-towns.json
+++ b/web/scripts/fixtures/sample-towns.json
@@ -6,7 +6,11 @@
     "lng": -5.051,
     "authorityId": 52,
     "total": 18,
-    "totalCapped": false,
+    "statusBreakdown": [
+      { "appState": "Permitted", "count": 10 },
+      { "appState": "Rejected", "count": 6 },
+      { "appState": null, "count": 2 }
+    ],
     "applications": [
       {
         "uid": "CW/2026/0001",
@@ -15,6 +19,7 @@
         "description": "Change of use of ground floor from retail (Class E) to a café with associated shopfront alterations.",
         "appState": "Permitted",
         "startDate": "2026-01-12",
+        "lastDifferent": "2026-06-14T10:00:00+00:00",
         "link": "https://planit.org.uk/planapplic/PA26-00001",
         "url": "https://planning.cornwall.gov.uk/online-applications/PA26-00001"
       },
@@ -25,6 +30,7 @@
         "description": "Listed building consent for internal alterations and a two-storey rear extension.",
         "appState": "Rejected",
         "startDate": "2026-02-01",
+        "lastDifferent": "2026-06-11T09:00:00+00:00",
         "link": "https://planit.org.uk/planapplic/PA26-00002",
         "url": null
       }
@@ -37,7 +43,7 @@
     "lng": -5.1,
     "authorityId": 52,
     "total": 4,
-    "totalCapped": false,
+    "statusBreakdown": [{ "appState": "Undecided", "count": 4 }],
     "applications": [
       {
         "uid": "CW/2026/0099",
@@ -46,6 +52,7 @@
         "description": "Single dwelling.",
         "appState": "Undecided",
         "startDate": "2026-01-03",
+        "lastDifferent": "2026-06-03T08:00:00+00:00",
         "link": "https://planit.org.uk/planapplic/PA26-00099",
         "url": null
       }

--- a/web/scripts/lib/__tests__/format.test.mjs
+++ b/web/scripts/lib/__tests__/format.test.mjs
@@ -4,7 +4,7 @@ import {
   truncate,
   formatDate,
   statusDisplayLabel,
-  countByState,
+  aggregateBreakdown,
   leadLine,
 } from '../format.mjs';
 
@@ -64,34 +64,58 @@ describe('statusDisplayLabel', () => {
   });
 });
 
-describe('countByState', () => {
-  it('counts applications by display label, most common first', () => {
-    const apps = [
-      { appState: 'Permitted' },
-      { appState: 'Permitted' },
-      { appState: 'Rejected' },
-      { appState: null },
+describe('aggregateBreakdown', () => {
+  it('maps each raw appState to its resident label and re-aggregates by label', () => {
+    const breakdown = [
+      { appState: 'Permitted', count: 5 },
+      { appState: 'Conditions', count: 2 },
+      { appState: 'Rejected', count: 3 },
+      { appState: null, count: 1 },
+      { appState: '', count: 1 },
+      { appState: 'Unknown', count: 2 },
     ];
 
-    expect(countByState(apps)).toEqual([
-      { label: 'Granted', count: 2 },
-      { label: 'Refused', count: 1 },
-      { label: 'Unknown', count: 1 },
+    // null, '' and a literal "Unknown" all collapse to the "Unknown" label and
+    // their counts sum (1 + 1 + 2 = 4). Sorted by count DESC, then label ASC.
+    expect(aggregateBreakdown(breakdown)).toEqual([
+      { label: 'Granted', count: 5 },
+      { label: 'Unknown', count: 4 },
+      { label: 'Refused', count: 3 },
+      { label: 'Granted with conditions', count: 2 },
     ]);
+  });
+
+  it('breaks count ties alphabetically by label', () => {
+    const breakdown = [
+      { appState: 'Rejected', count: 2 },
+      { appState: 'Permitted', count: 2 },
+    ];
+
+    expect(aggregateBreakdown(breakdown)).toEqual([
+      { label: 'Granted', count: 2 },
+      { label: 'Refused', count: 2 },
+    ]);
+  });
+
+  it('returns an empty array for an empty breakdown', () => {
+    expect(aggregateBreakdown([])).toEqual([]);
   });
 });
 
 describe('leadLine', () => {
-  it('shows the exact total when the read was not capped', () => {
-    expect(leadLine('Adur', 42, false)).toContain('42');
-    expect(leadLine('Adur', 42, false)).toContain('Adur');
-  });
-
-  it('shows a capped count as "<total>+" when the read hit the cap', () => {
-    expect(leadLine('Leeds', 200, true)).toContain('200+');
+  it('shows the exact total and the area name', () => {
+    expect(leadLine('Adur', 42)).toBe(
+      'Town Crier is tracking 42 planning applications in Adur.',
+    );
   });
 
   it('uses the singular noun for a single application', () => {
-    expect(leadLine('Tiny', 1, false)).toContain('1 recent planning application ');
+    expect(leadLine('Tiny', 1)).toBe(
+      'Town Crier is tracking 1 planning application in Tiny.',
+    );
+  });
+
+  it('does not describe the count as "recent"', () => {
+    expect(leadLine('Adur', 42)).not.toContain('recent');
   });
 });

--- a/web/scripts/lib/__tests__/prerender-towns.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-towns.test.mjs
@@ -152,12 +152,13 @@ describe('runPrerender — town live mode', () => {
                 description: 'Café conversion',
                 appState: 'Permitted',
                 startDate: '2026-01-12',
+                lastDifferent: '2026-06-12T10:00:00+00:00',
                 link: 'https://planit.org.uk/planapplic/CW1',
                 url: null,
               },
             ],
             total: 14,
-            totalCapped: false,
+            statusBreakdown: [{ appState: 'Permitted', count: 14 }],
           },
         };
       }
@@ -202,7 +203,7 @@ describe('runPrerender — town live mode', () => {
         radius: 5000,
         applications: [],
         total: 3,
-        totalCapped: false,
+        statusBreakdown: [],
       },
     }));
 
@@ -245,6 +246,33 @@ describe('runPrerender — town live mode', () => {
       ok: true,
       status: 200,
       body: { not: 'what we expect' },
+    }));
+
+    await expect(
+      runPrerender({
+        outDir,
+        apiBase: 'https://api-dev.towncrierapp.uk',
+        buildKey: 'test-key',
+        fetchImpl: stub.fetch,
+        loadAuthorities: async () => cornwallAuthorities,
+        loadTowns: async () => cornwallTowns,
+        logger: silentLogger,
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('fails loud when the geo endpoint omits statusBreakdown', async () => {
+    const stub = new StubFetch(() => ({
+      ok: true,
+      status: 200,
+      body: {
+        authorityId: 52,
+        lat: 50.2632,
+        lng: -5.051,
+        radius: 5000,
+        applications: [],
+        total: 14,
+      },
     }));
 
     await expect(

--- a/web/scripts/lib/__tests__/prerender.test.mjs
+++ b/web/scripts/lib/__tests__/prerender.test.mjs
@@ -68,6 +68,11 @@ describe('runPrerender — fixture mode', () => {
     );
     expect(html).toContain('PlanIt');
     expect(html).toContain('Get push alerts for Basingstoke and Deane');
+    // The lastDifferent date threads through to a "Last updated" card label.
+    expect(html).toContain('Last updated 15 Jun 2026');
+    // The server breakdown (20 Granted) is threaded through and exceeds the three
+    // cards rendered — proving the stats are server-driven, not card-counted.
+    expect(html).toMatch(/Granted[\s\S]*?20/);
   });
 
   it('excludes a non-qualifying areaType (English County) and a below-gate authority', async () => {
@@ -135,12 +140,13 @@ describe('runPrerender — live mode', () => {
                 description: 'Extension',
                 appState: 'Permitted',
                 startDate: '2026-01-10',
+                lastDifferent: '2026-06-10T10:00:00+00:00',
                 link: 'https://planit.org.uk/planapplic/A1',
                 url: null,
               },
             ],
             total: 12,
-            totalCapped: false,
+            statusBreakdown: [{ appState: 'Permitted', count: 12 }],
           },
         };
       }
@@ -186,7 +192,7 @@ describe('runPrerender — live mode', () => {
         areaName: 'Adur',
         applications: [],
         total: 5,
-        totalCapped: false,
+        statusBreakdown: [],
       },
     }));
 
@@ -204,6 +210,33 @@ describe('runPrerender — live mode', () => {
 
     expect(result.published).toEqual([]);
     expect(await exists(join(outDir, 'planning', 'adur'))).toBe(false);
+  });
+
+  it('fails loud when the applications endpoint omits statusBreakdown', async () => {
+    const stub = new StubFetch(() => ({
+      ok: true,
+      status: 200,
+      body: {
+        authorityId: 1,
+        areaName: 'Adur',
+        applications: [],
+        total: 12,
+      },
+    }));
+
+    await expect(
+      runPrerender({
+        outDir,
+        apiBase: 'https://api-dev.towncrierapp.uk',
+        buildKey: 'test-key',
+        fetchImpl: stub.fetch,
+        loadAuthorities: async () => [
+          { id: 1, name: 'Adur', areaType: 'English District' },
+        ],
+        loadTowns: async () => [],
+        logger: silentLogger,
+      }),
+    ).rejects.toThrow();
   });
 
   it('treats zero qualifying authorities as a valid (non-error) build', async () => {

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -12,7 +12,14 @@ function pageData(overrides = {}) {
     areaName: 'Basingstoke and Deane',
     authorityId: 100,
     total: 42,
-    totalCapped: false,
+    // Server-provided distribution over the bounded ~200-doc read: deliberately
+    // sums to more than the two cards rendered below, proving the stats block
+    // uses the breakdown rather than counting the visible cards.
+    statusBreakdown: [
+      { appState: 'Permitted', count: 30 },
+      { appState: 'Rejected', count: 8 },
+      { appState: null, count: 4 },
+    ],
     applications: [
       {
         uid: 'BDB/2026/0001',
@@ -21,6 +28,7 @@ function pageData(overrides = {}) {
         description: 'Erection of two-storey rear extension',
         appState: 'Permitted',
         startDate: '2026-01-15',
+        lastDifferent: '2026-06-12T09:30:00+00:00',
         link: 'https://planit.org.uk/planapplic/26-0001-FUL',
         url: 'https://www.basingstoke.gov.uk/planning/26-0001-FUL',
       },
@@ -31,6 +39,7 @@ function pageData(overrides = {}) {
         description: 'Single-storey side extension and new boundary wall',
         appState: 'Rejected',
         startDate: '2026-02-03',
+        lastDifferent: '2026-06-10T08:00:00+00:00',
         link: 'https://planit.org.uk/planapplic/26-0002-HSE',
         url: null,
       },
@@ -75,34 +84,43 @@ describe('renderPlanningPage', () => {
     expect(html).toContain('"@type":"ItemList"');
   });
 
-  it('renders each application address, status label, date and links', () => {
+  it('renders each application address, status label, Last updated date and links', () => {
     const html = renderPlanningPage(pageData());
     expect(html).toContain('12 Mill Road, Basingstoke, RG21 1AA');
     expect(html).toContain('Erection of two-storey rear extension');
     expect(html).toContain('Granted'); // Permitted -> Granted
     expect(html).toContain('Refused'); // Rejected -> Refused
-    expect(html).toContain('15 Jan 2026');
+    // The visible card date is the lastDifferent date, labelled "Last updated".
+    expect(html).toContain('Last updated 12 Jun 2026');
     expect(html).toContain(
       'https://www.basingstoke.gov.uk/planning/26-0001-FUL',
     );
     expect(html).toContain('https://planit.org.uk/planapplic/26-0001-FUL');
   });
 
-  it('shows the exact total in the lead line when not capped', () => {
-    const html = renderPlanningPage(pageData({ total: 42, totalCapped: false }));
-    expect(html).toContain('42');
-  });
-
-  it('shows a capped count as "200+" when the read hit the cap', () => {
-    const html = renderPlanningPage(
-      pageData({ total: 200, totalCapped: true }),
-    );
-    expect(html).toContain('200+');
-  });
-
-  it('renders a stats block with counts by status', () => {
+  it('orders the visible Last updated dates to match the lastDifferent DESC sort', () => {
     const html = renderPlanningPage(pageData());
-    expect(html).toMatch(/Granted[\s\S]*?1/);
+    expect(html).toContain('Last updated 12 Jun 2026');
+    expect(html).toContain('Last updated 10 Jun 2026');
+    expect(html.indexOf('Last updated 12 Jun 2026')).toBeLessThan(
+      html.indexOf('Last updated 10 Jun 2026'),
+    );
+  });
+
+  it('shows the exact total in the lead line', () => {
+    const html = renderPlanningPage(pageData({ total: 42 }));
+    expect(html).toContain(
+      'Town Crier is tracking 42 planning applications in Basingstoke and Deane.',
+    );
+  });
+
+  it('renders a stats block from the server breakdown, not the visible cards', () => {
+    const html = renderPlanningPage(pageData());
+    // 30 Granted comes from the server breakdown over the bounded read; only two
+    // cards are rendered, so a count of 30 proves the stats are server-driven.
+    expect(html).toMatch(/Granted[\s\S]*?30/);
+    expect(html).toMatch(/Refused[\s\S]*?8/);
+    expect(html).toMatch(/Unknown[\s\S]*?4/);
   });
 
   it('includes the evergreen how-to-comment explainer for the area', () => {
@@ -159,6 +177,7 @@ describe('renderPlanningPage', () => {
             description: 'safe',
             appState: 'Permitted',
             startDate: null,
+            lastDifferent: '2026-06-12T09:30:00+00:00',
             link: null,
             url: null,
           },

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -14,7 +14,13 @@ function townData(overrides = {}) {
     authoritySlug: 'cornwall',
     authorityId: 52,
     total: 18,
-    totalCapped: false,
+    // Server-provided distribution over the bounded read: deliberately sums to
+    // more than the two cards below, proving the stats use the breakdown.
+    statusBreakdown: [
+      { appState: 'Permitted', count: 12 },
+      { appState: 'Rejected', count: 4 },
+      { appState: null, count: 2 },
+    ],
     applications: [
       {
         uid: 'CW/2026/0001',
@@ -23,6 +29,7 @@ function townData(overrides = {}) {
         description: 'Change of use of ground floor from retail to café',
         appState: 'Permitted',
         startDate: '2026-01-12',
+        lastDifferent: '2026-06-12T09:30:00+00:00',
         link: 'https://planit.org.uk/planapplic/CW-26-0001',
         url: 'https://planning.cornwall.gov.uk/26-0001',
       },
@@ -33,6 +40,7 @@ function townData(overrides = {}) {
         description: 'Two-storey rear extension to a listed building',
         appState: 'Rejected',
         startDate: '2026-02-01',
+        lastDifferent: '2026-06-10T08:00:00+00:00',
         link: 'https://planit.org.uk/planapplic/CW-26-0002',
         url: null,
       },
@@ -84,26 +92,41 @@ describe('renderTownPage', () => {
     expect(html).toMatch(/breadcrumb[\s\S]*?Cornwall/);
   });
 
-  it('renders each application address, status label, date and links', () => {
+  it('renders each application address, status label, Last updated date and links', () => {
     const html = renderTownPage(townData());
     expect(html).toContain('Lemon Quay, Truro, TR1 2LW');
     expect(html).toContain('Change of use of ground floor from retail to café');
     expect(html).toContain('Granted'); // Permitted -> Granted
     expect(html).toContain('Refused'); // Rejected -> Refused
-    expect(html).toContain('12 Jan 2026');
+    // The visible card date is the lastDifferent date, labelled "Last updated".
+    expect(html).toContain('Last updated 12 Jun 2026');
     expect(html).toContain('https://planning.cornwall.gov.uk/26-0001');
     expect(html).toContain('https://planit.org.uk/planapplic/CW-26-0001');
   });
 
-  it('shows the exact total in the lead line when not capped', () => {
-    const html = renderTownPage(townData({ total: 18, totalCapped: false }));
-    expect(html).toContain('18');
-    expect(html).toContain('Truro');
+  it('orders the visible Last updated dates to match the lastDifferent DESC sort', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain('Last updated 12 Jun 2026');
+    expect(html).toContain('Last updated 10 Jun 2026');
+    expect(html.indexOf('Last updated 12 Jun 2026')).toBeLessThan(
+      html.indexOf('Last updated 10 Jun 2026'),
+    );
   });
 
-  it('shows a capped count as "200+" when the read hit the cap', () => {
-    const html = renderTownPage(townData({ total: 200, totalCapped: true }));
-    expect(html).toContain('200+');
+  it('shows the exact total in the lead line', () => {
+    const html = renderTownPage(townData({ total: 18 }));
+    expect(html).toContain(
+      'Town Crier is tracking 18 planning applications in Truro.',
+    );
+  });
+
+  it('renders a stats block from the server breakdown, not the visible cards', () => {
+    const html = renderTownPage(townData());
+    // 12 Granted comes from the server breakdown over the bounded read; only two
+    // cards are rendered, so a count of 12 proves the stats are server-driven.
+    expect(html).toMatch(/Granted[\s\S]*?12/);
+    expect(html).toMatch(/Refused[\s\S]*?4/);
+    expect(html).toMatch(/Unknown[\s\S]*?2/);
   });
 
   it('includes the evergreen how-to-comment explainer naming the town and its authority', () => {
@@ -161,6 +184,7 @@ describe('renderTownPage', () => {
             description: 'safe',
             appState: 'Permitted',
             startDate: null,
+            lastDifferent: '2026-06-12T09:30:00+00:00',
             link: null,
             url: null,
           },

--- a/web/scripts/lib/format.mjs
+++ b/web/scripts/lib/format.mjs
@@ -86,22 +86,28 @@ export function statusDisplayLabel(appState) {
 }
 
 /**
- * @typedef {{ label: string, count: number }} StateCount
+ * @typedef {{ label: string, count: number }} LabelCount
  */
 
 /**
- * Count applications by resident-facing status label, most common first then
- * alphabetical for a stable order.
+ * Collapse the server's raw per-`appState` distribution into resident-facing
+ * labels. Each wire `appState` is translated via `statusDisplayLabel` and then
+ * RE-AGGREGATED by that label, so null, "" and a literal "Unknown" all fold into
+ * a single "Unknown" row whose count is the sum. Sorted most common first, then
+ * alphabetically by label for a stable order.
  *
- * @param {ReadonlyArray<{ appState: string | null | undefined }>} applications
- * @returns {StateCount[]}
+ * The breakdown is computed server-side over the bounded read (~200 docs), so it
+ * can legitimately total more than the handful of cards rendered on the page.
+ *
+ * @param {ReadonlyArray<{ appState: string | null | undefined, count: number }>} statusBreakdown
+ * @returns {LabelCount[]}
  */
-export function countByState(applications) {
+export function aggregateBreakdown(statusBreakdown) {
   /** @type {Map<string, number>} */
   const counts = new Map();
-  for (const app of applications) {
-    const label = statusDisplayLabel(app.appState);
-    counts.set(label, (counts.get(label) ?? 0) + 1);
+  for (const { appState, count } of statusBreakdown) {
+    const label = statusDisplayLabel(appState);
+    counts.set(label, (counts.get(label) ?? 0) + count);
   }
   return [...counts.entries()]
     .map(([label, count]) => ({ label, count }))
@@ -109,19 +115,14 @@ export function countByState(applications) {
 }
 
 /**
- * Build the data-filled lead sentence under the H1. Uses "<total>+" when the
- * bounded read hit its cap, otherwise the exact total with the right plural.
+ * Build the data-filled lead sentence under the H1: the exact whole-partition
+ * total with the right plural.
  *
  * @param {string} areaName
  * @param {number} total
- * @param {boolean} totalCapped
  * @returns {string}
  */
-export function leadLine(areaName, total, totalCapped) {
-  const countPhrase = totalCapped ? `${total}+` : `${total}`;
-  const noun =
-    !totalCapped && total === 1
-      ? 'recent planning application'
-      : 'recent planning applications';
-  return `Town Crier is tracking ${countPhrase} ${noun} in ${areaName}.`;
+export function leadLine(areaName, total) {
+  const noun = total === 1 ? 'planning application' : 'planning applications';
+  return `Town Crier is tracking ${total} ${noun} in ${areaName}.`;
 }

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -17,7 +17,7 @@ import {
  * @property {string} areaName
  * @property {number} authorityId
  * @property {number} total
- * @property {boolean} totalCapped
+ * @property {Array<{ appState: string | null, count: number }>} statusBreakdown
  * @property {PlanningApplicationItem[]} applications
  */
 
@@ -68,7 +68,7 @@ function buildJsonLd(data, canonical) {
 export function renderPlanningPage(data) {
   const area = escapeHtml(data.areaName);
   const canonical = `${SITE_ORIGIN}/planning/${data.slug}`;
-  const lead = escapeHtml(leadLine(data.areaName, data.total, data.totalCapped));
+  const lead = escapeHtml(leadLine(data.areaName, data.total));
   const title = `Planning applications in ${area} | Town Crier`;
   const metaDescription = escapeHtml(
     `Recent planning applications in ${data.areaName}. See what is being built nearby and get push alerts the moment an application is submitted or decided in your area.`,
@@ -112,7 +112,7 @@ ${pageStyles()}
         <h1>Planning applications in ${area}</h1>
         <p class="lead">${lead}</p>
 
-${renderStats(data.applications)}
+${renderStats(data.statusBreakdown)}
 
         <h2>Recent applications</h2>
         <ul class="appList">

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -15,7 +15,7 @@ import {
   truncate,
   formatDate,
   statusDisplayLabel,
-  countByState,
+  aggregateBreakdown,
 } from './format.mjs';
 
 /**
@@ -25,9 +25,10 @@ import {
  * @property {string} address
  * @property {string} description
  * @property {string | null} appState
- * @property {string | null} startDate  yyyy-MM-dd
- * @property {string | null} link       council-portal deep link
- * @property {string | null} url        application detail link
+ * @property {string | null} startDate      yyyy-MM-dd
+ * @property {string} lastDifferent         ISO-8601 with offset; the DESC sort key
+ * @property {string | null} link           council-portal deep link
+ * @property {string | null} url            application detail link
  */
 
 const MAX_DESCRIPTION_LENGTH = 160;
@@ -58,7 +59,9 @@ function statusModifier(appState) {
 function renderApplication(app) {
   const label = escapeHtml(statusDisplayLabel(app.appState));
   const modifier = statusModifier(app.appState);
-  const date = formatDate(app.startDate);
+  // The visible date is lastDifferent (the bounded read's DESC sort key), so the
+  // dates read top-to-bottom in the same order the cards are listed.
+  const date = formatDate(app.lastDifferent);
   const description = escapeHtml(truncate(app.description, MAX_DESCRIPTION_LENGTH));
 
   const links = [];
@@ -81,7 +84,7 @@ function renderApplication(app) {
         <p class="appCard__address">${escapeHtml(app.address)}</p>
         <p class="appCard__desc">${description}</p>
         <div class="appCard__meta">
-          ${date ? `<span class="appCard__date">${escapeHtml(date)}</span>` : ''}
+          ${date ? `<span class="appCard__date">Last updated ${escapeHtml(date)}</span>` : ''}
           ${links.join('\n          ')}
         </div>
       </li>`;
@@ -98,11 +101,16 @@ export function renderApplicationsList(applications) {
 }
 
 /**
- * @param {PlanningApplicationItem[]} applications
+ * Render the status-breakdown block from the server-provided per-`appState`
+ * distribution (computed over the bounded read), folded into resident-facing
+ * labels. This is intentionally NOT derived from the handful of cards rendered
+ * on the page, so the counts reflect the wider bounded set.
+ *
+ * @param {ReadonlyArray<{ appState: string | null, count: number }>} statusBreakdown
  * @returns {string}
  */
-export function renderStats(applications) {
-  const rows = countByState(applications)
+export function renderStats(statusBreakdown) {
+  const rows = aggregateBreakdown(statusBreakdown)
     .map(
       (s) =>
         `        <li class="statRow"><span class="statRow__label">${escapeHtml(s.label)}</span><span class="statRow__count">${s.count}</span></li>`,

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -30,7 +30,7 @@ import {
  * @property {string} authoritySlug   parent authority slug, e.g. "cornwall"
  * @property {number} authorityId
  * @property {number} total
- * @property {boolean} totalCapped
+ * @property {Array<{ appState: string | null, count: number }>} statusBreakdown
  * @property {import('./render-shared.mjs').PlanningApplicationItem[]} applications
  */
 
@@ -102,7 +102,7 @@ export function renderTownPage(data) {
   const authority = escapeHtml(data.authorityName);
   const canonical = `${SITE_ORIGIN}/planning/${data.authoritySlug}/${data.townSlug}`;
   const authorityCanonical = `${SITE_ORIGIN}/planning/${data.authoritySlug}`;
-  const lead = escapeHtml(leadLine(data.townName, data.total, data.totalCapped));
+  const lead = escapeHtml(leadLine(data.townName, data.total));
   const title = `Planning applications in ${town} | Town Crier`;
   const metaDescription = escapeHtml(
     `Recent planning applications in ${data.townName}, ${data.authorityName}. See what is being built nearby and get push alerts the moment an application is submitted or decided near you.`,
@@ -153,7 +153,7 @@ ${pageStyles()}
         <h1>Planning applications in ${town}</h1>
         <p class="lead">${lead}</p>
 
-${renderStats(data.applications)}
+${renderStats(data.statusBreakdown)}
 
         <h2>Recent applications</h2>
         <ul class="appList">

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -201,7 +201,7 @@ export async function loadTownsFromFile(filePath, readFileImpl) {
  * @param {string} buildKey
  * @param {number} limit
  * @param {typeof globalThis.fetch} fetchImpl
- * @returns {Promise<{ areaName: string, applications: object[], total: number, totalCapped: boolean }>}
+ * @returns {Promise<{ areaName: string, applications: object[], total: number, statusBreakdown: object[] }>}
  */
 async function fetchRecentApplications(
   apiBase,
@@ -222,7 +222,7 @@ async function fetchRecentApplications(
     !body ||
     !Array.isArray(body.applications) ||
     typeof body.total !== 'number' ||
-    typeof body.totalCapped !== 'boolean'
+    !Array.isArray(body.statusBreakdown)
   ) {
     throw new Error(
       `GET /v1/authorities/${authorityId}/applications returned an unexpected shape`,
@@ -232,7 +232,7 @@ async function fetchRecentApplications(
     areaName: typeof body.areaName === 'string' ? body.areaName : '',
     applications: body.applications,
     total: body.total,
-    totalCapped: body.totalCapped,
+    statusBreakdown: body.statusBreakdown,
   };
 }
 
@@ -260,7 +260,7 @@ async function writePage(outDir, data) {
  * @param {string} args.areaType
  * @param {string} args.areaName
  * @param {number} args.total
- * @param {boolean} args.totalCapped
+ * @param {object[]} args.statusBreakdown
  * @param {object[]} args.applications
  * @param {number} args.limit
  * @param {string[]} args.published
@@ -275,7 +275,7 @@ async function considerAuthority(args) {
     authorityId,
     name,
     total,
-    totalCapped,
+    statusBreakdown,
     applications,
     areaName,
     limit,
@@ -303,7 +303,7 @@ async function considerAuthority(args) {
     areaName: areaName || name,
     authorityId,
     total,
-    totalCapped,
+    statusBreakdown,
     applications: applications.slice(0, limit),
   });
   published.push(slug);
@@ -320,7 +320,7 @@ async function considerAuthority(args) {
  * @param {string} buildKey
  * @param {number} limit
  * @param {typeof globalThis.fetch} fetchImpl
- * @returns {Promise<{ applications: object[], total: number, totalCapped: boolean }>}
+ * @returns {Promise<{ applications: object[], total: number, statusBreakdown: object[] }>}
  */
 async function fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl) {
   const url =
@@ -338,7 +338,7 @@ async function fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl) {
     !body ||
     !Array.isArray(body.applications) ||
     typeof body.total !== 'number' ||
-    typeof body.totalCapped !== 'boolean'
+    !Array.isArray(body.statusBreakdown)
   ) {
     throw new Error(
       `GET /v1/applications/near (authority ${town.authorityId}, ${town.name}) ` +
@@ -348,7 +348,7 @@ async function fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl) {
   return {
     applications: body.applications,
     total: body.total,
-    totalCapped: body.totalCapped,
+    statusBreakdown: body.statusBreakdown,
   };
 }
 
@@ -374,7 +374,7 @@ async function writeTownPage(outDir, data) {
  * @param {Town} args.town
  * @param {ReadonlyArray<{ id: number, name: string }>} args.authorities
  * @param {number} args.total
- * @param {boolean} args.totalCapped
+ * @param {object[]} args.statusBreakdown
  * @param {object[]} args.applications
  * @param {number} args.limit
  * @param {string[]} args.publishedTowns
@@ -389,7 +389,7 @@ async function considerTown(args) {
     town,
     authorities,
     total,
-    totalCapped,
+    statusBreakdown,
     applications,
     limit,
     publishedTowns,
@@ -422,7 +422,7 @@ async function considerTown(args) {
     authoritySlug,
     authorityId: town.authorityId,
     total,
-    totalCapped,
+    statusBreakdown,
     applications: applications.slice(0, limit),
   });
   publishedTowns.push(path);
@@ -437,7 +437,7 @@ async function considerTown(args) {
  * @param {string} args.outDir
  * @param {Town[]} args.towns
  * @param {ReadonlyArray<{ id: number, name: string }>} args.authorities
- * @param {(town: Town) => Promise<{ applications: object[], total: number, totalCapped: boolean }>} args.getGeo
+ * @param {(town: Town) => Promise<{ applications: object[], total: number, statusBreakdown: object[] }>} args.getGeo
  * @param {number} args.limit
  * @param {{ warn: (msg: string) => void }} args.logger
  * @returns {Promise<{ publishedTowns: string[], excludedTowns: Array<{ name: string, reason: string }> }>}
@@ -458,7 +458,9 @@ async function renderTownPages(args) {
       town,
       authorities,
       total: geo.total,
-      totalCapped: geo.totalCapped,
+      statusBreakdown: Array.isArray(geo.statusBreakdown)
+        ? geo.statusBreakdown
+        : [],
       applications: Array.isArray(geo.applications) ? geo.applications : [],
       limit,
       publishedTowns,
@@ -509,7 +511,9 @@ async function runFixtureMode(args) {
         areaType: entry.areaType,
         areaName: entry.areaName ?? entry.name,
         total: entry.total,
-        totalCapped: Boolean(entry.totalCapped),
+        statusBreakdown: Array.isArray(entry.statusBreakdown)
+          ? entry.statusBreakdown
+          : [],
         applications: Array.isArray(entry.applications)
           ? entry.applications
           : [],
@@ -527,7 +531,7 @@ async function runFixtureMode(args) {
   /** @type {Array<{ name: string, reason: string }>} */
   let excludedTowns = [];
 
-  // Town fixture rows carry the geo projection inline (total/totalCapped/
+  // Town fixture rows carry the geo projection inline (total/statusBreakdown/
   // applications), so `getGeo` is a pure lookup — no network in fixture mode.
   if (townFixturePath) {
     const rawTowns = await readFile(townFixturePath, 'utf-8');
@@ -543,7 +547,9 @@ async function runFixtureMode(args) {
       getGeo: async (town) => ({
         applications: Array.isArray(town.applications) ? town.applications : [],
         total: town.total,
-        totalCapped: Boolean(town.totalCapped),
+        statusBreakdown: Array.isArray(town.statusBreakdown)
+          ? town.statusBreakdown
+          : [],
       }),
       limit,
       logger,
@@ -609,7 +615,7 @@ async function runLiveMode(args) {
       areaType: authority.areaType,
       areaName: recent.areaName || authority.name,
       total: recent.total,
-      totalCapped: recent.totalCapped,
+      statusBreakdown: recent.statusBreakdown,
       applications: recent.applications,
       limit,
       published,


### PR DESCRIPTION
## What

Consumes the new build-key-gated SEO API fields landed in tc-vj7c.1 (#583) across the shared static prerenderers, so both authority pages (`render-page.mjs`) and town pages (`render-town-page.mjs`) update together.

1. **Exact count** — `leadLine(areaName, total)` now renders the EXACT whole-partition total: `Town Crier is tracking N planning application(s) in X.` Dropped the `totalCapped` `<total>+` logic and the word "recent" from the count line.
2. **Last updated** — application cards now show `formatDate(lastDifferent)` labelled **Last updated** (the bounded read's DESC sort key), replacing the bare `startDate`, so the visible dates read in the same order the cards are listed — fixing the "cards look unsorted" feedback.
3. **Server status breakdown** — new `aggregateBreakdown()` folds the server's RAW per-`appState` distribution into resident-facing labels (null/`""`/`Unknown` collapse into one **Unknown** row), re-aggregates, and sorts count DESC then label ASC. `renderStats(statusBreakdown)` renders this SERVER-side breakdown over the bounded ~200-doc read instead of counting the ~30 rendered cards.
4. **Threading** — `prerender-planning.mjs` now validates `Array.isArray(statusBreakdown)` (and no longer requires `totalCapped`), threads `statusBreakdown` through `considerAuthority`/`considerTown`/`writePage`/`writeTownPage`/`runFixtureMode`/`runLiveMode`, and the page-data typedefs drop `totalCapped` / gain `statusBreakdown`. `countByState` removed (no remaining callers). Fixtures rebaked with `statusBreakdown` arrays and per-application `lastDifferent`.

## Tests

TDD red→green throughout. Updated `format`, `render-page`, `render-town-page`, `prerender`, and `prerender-towns` suites: shape validation now requires `statusBreakdown` and ignores `totalCapped`; new assertions prove a card shows **Last updated** with the `lastDifferent` date (in DESC order) and that the stats reflect a server count exceeding the rendered cards.

Gates clean from `web/`: `npx vitest run` (777 passed), `npx tsc --noEmit`, `npx eslint .`, `npm run build`.

Closes tc-vj7c.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)