### PR TITLE
feat(web): explicit AI/LLM crawler allow in robots.txt + add llms.txt

### DIFF
--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -1,0 +1,26 @@
+# Town Crier
+
+> Town Crier monitors UK local-authority planning applications and sends
+> residents, community groups, and property professionals push and email
+> alerts the moment an application is submitted or decided near them.
+
+The pages linked below are free, publicly accessible summaries of recent
+planning activity for individual UK local authorities and towns. Each page
+shows recent applications, a total count, a status breakdown, and a
+"last updated" date reflecting the most recent data snapshot. The underlying
+data comes from PlanIt (planit.org.uk) and is published under the Open
+Government Licence v3, so it may be freely used with attribution.
+
+## Planning pages
+
+- [All planning pages (sitemap)](https://towncrierapp.uk/sitemap.xml): machine-readable list of every authority and town page on the site.
+
+## About
+
+- [Town Crier](https://towncrierapp.uk/): what the app does, how alerts work, and how to get it.
+
+## Data and licensing
+
+- Source: PlanIt — https://planit.org.uk
+- Licence: Open Government Licence v3 — https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
+- Contact: https://towncrierapp.uk/

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,4 +1,59 @@
+# Town Crier robots policy.
+#
+# Everything served here is public, open-licensed UK planning data
+# (Open Government Licence v3) — not user data. We therefore deliberately
+# welcome AI / LLM crawlers (for both model training and live retrieval)
+# alongside classic search engines, so Town Crier can be discovered and
+# cited by AI answer engines.
+#
+# The blanket "User-agent: *  Allow: /" below already permits every bot.
+# The explicit per-crawler stanzas that follow are documentary: they
+# record the intent and guard against a future blanket change silently
+# locking these crawlers out. See web/public/llms.txt for an LLM-oriented
+# map of the site.
+
 User-agent: *
+Allow: /
+
+# --- AI / LLM crawlers: explicitly welcomed ---
+
+# OpenAI (ChatGPT)
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+# Google (Gemini / Vertex AI training — separate from Googlebot search)
+User-agent: Google-Extended
+Allow: /
+
+# Anthropic (Claude)
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+# Perplexity
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+# Common Crawl (feeds many open training corpora)
+User-agent: CCBot
+Allow: /
+
+# Apple Intelligence training
+User-agent: Applebot-Extended
 Allow: /
 
 Sitemap: https://towncrierapp.uk/sitemap.xml

--- a/web/src/__tests__/robots-sitemap.test.ts
+++ b/web/src/__tests__/robots-sitemap.test.ts
@@ -21,4 +21,38 @@ describe('robots.txt SEO additions', () => {
       'Sitemap: https://towncrierapp.uk/sitemap.xml',
     );
   });
+
+  it('explicitly welcomes the major AI/LLM crawlers', () => {
+    const content = robots();
+    const aiCrawlers = [
+      'GPTBot',
+      'OAI-SearchBot',
+      'ChatGPT-User',
+      'Google-Extended',
+      'ClaudeBot',
+      'Claude-User',
+      'anthropic-ai',
+      'PerplexityBot',
+      'Perplexity-User',
+      'CCBot',
+      'Applebot-Extended',
+    ];
+    for (const crawler of aiCrawlers) {
+      expect(content).toContain(`User-agent: ${crawler}`);
+    }
+  });
+});
+
+describe('llms.txt', () => {
+  function llms(): string {
+    return readFileSync(resolve(__dirname, '../../public/llms.txt'), 'utf-8');
+  }
+
+  it('is an llms.txt with the site name as the H1 title', () => {
+    expect(llms()).toContain('# Town Crier');
+  });
+
+  it('points LLMs at the sitemap of all planning pages', () => {
+    expect(llms()).toContain('https://towncrierapp.uk/sitemap.xml');
+  });
 });


### PR DESCRIPTION
## Changes
- **robots.txt** — keep the blanket `User-agent: * / Allow: /`, but add explicit, documentary allow stanzas for the major AI/LLM crawlers (GPTBot, OAI-SearchBot, ChatGPT-User, Google-Extended, ClaudeBot, Claude-User, anthropic-ai, PerplexityBot, Perplexity-User, CCBot, Applebot-Extended) plus a comment explaining the intent. Guards against a future blanket change silently locking AI crawlers out.
- **llms.txt** (new) — an [llmstxt.org](https://llmstxt.org)-format map pointing LLMs at the planning-pages sitemap, with source/licence (PlanIt, OGL v3).
- **robots-sitemap.test.ts** — assertions covering the new crawler stanzas and the new llms.txt.

All content is public, open-licensed UK planning data (OGL v3), not user data — so welcoming both training and retrieval crawlers is a clean, privacy-neutral decision. Goal: GEO / AI answer-engine discoverability.

(tc-ye8e)

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Created documentation for AI/LLM systems with app overview, planning data descriptions, and licensing information.
  * Updated crawling policy to explicitly welcome AI and LLM crawlers, including rules for major AI services.

* **Tests**
  * Added test coverage to verify AI/LLM crawler policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->