### PR TITLE
feat(api): order=distance variant on /v1/applications/near (tc-2avw.1)

### DIFF
--- a/api-go/internal/applications/near.go
+++ b/api-go/internal/applications/near.go
@@ -31,13 +31,24 @@ const (
 	maxLongitude = 180
 )
 
-// nearStore is the consumer-side store the recent-nearby SEO handler needs: a
-// bounded, single-partition spatial top-N read plus an exact in-radius count. The
-// concrete *CosmosStore satisfies it structurally.
+// nearStore is the consumer-side store the recent-nearby SEO handler needs: two
+// bounded, single-partition spatial top-N reads (recency-ordered and
+// distance-ordered) plus an exact in-radius count. The concrete *CosmosStore
+// satisfies it structurally.
 type nearStore interface {
 	RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
+	NearestNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
 	CountNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) (int, error)
 }
+
+// near ordering modes for the optional order query param. recency (the default,
+// also selected by an absent param) orders by lastDifferent DESC via
+// RecentNearby; distance orders by ST_DISTANCE ASC (nearest first) via
+// NearestNearby. Any other value is a 400.
+const (
+	orderRecency  = "recency"
+	orderDistance = "distance"
+)
 
 // nearHandler serves the build-time town-level SEO endpoint.
 type nearHandler struct {
@@ -55,12 +66,15 @@ func NearRoutes(mux *http.ServeMux, store nearStore, buildKey string, logger *sl
 	mux.HandleFunc("GET /v1/applications/near", requireBuildKey(buildKey, h.recentNearby))
 }
 
-// recentNearby returns up to limit most-recently-active applications within a
-// bounded radius of (lat, lng), scoped to the required authorityId's single
-// Cosmos partition, drawn from one bounded read of at most nearReadCap documents.
-// authorityId scopes the partition; a missing/invalid id, a non-finite or
-// out-of-range coordinate, or a non-finite/non-positive radius is a bodyless 400
-// (the build key was already validated by the gate). There is no PlanIt fallback.
+// recentNearby returns up to limit applications within a bounded radius of (lat,
+// lng), scoped to the required authorityId's single Cosmos partition, drawn from
+// one bounded read of at most nearReadCap documents. The optional order param
+// selects the ordering: recency (default, also when absent) is most-recently-
+// active first; distance is nearest-first (for overlap reduction between adjacent
+// town pages). authorityId scopes the partition; a missing/invalid id, a
+// non-finite or out-of-range coordinate, a non-finite/non-positive radius, or an
+// unknown order value is a bodyless 400 (the build key was already validated by
+// the gate). There is no PlanIt fallback.
 func (h *nearHandler) recentNearby(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
@@ -88,10 +102,18 @@ func (h *nearHandler) recentNearby(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// nearby selects the ordering: distance -> NearestNearby (nearest first),
+	// recency or absent -> RecentNearby (lastDifferent DESC, unchanged default).
+	nearby, ok := selectNearbyRead(h.store, q.Get("order"))
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	limit := parseLimit(q.Get("limit"))
 	authorityCode := strconv.Itoa(id)
 
-	apps, err := h.store.RecentNearby(r.Context(), authorityCode, lat, lng, radius, nearReadCap)
+	apps, err := nearby(r.Context(), authorityCode, lat, lng, radius, nearReadCap)
 	if err != nil {
 		serverError(w, r, h.logger, "recent applications near point", err)
 		return
@@ -135,6 +157,23 @@ func parseCoordinate(raw string, minVal, maxVal float64) (float64, bool) {
 		return 0, false
 	}
 	return v, true
+}
+
+// selectNearbyRead maps the optional order query param to the bounded
+// single-partition read it selects: an empty or "recency" value picks the
+// recency-ordered RecentNearby (the unchanged default), "distance" picks the
+// distance-ordered NearestNearby (nearest first). The bool reports validity; the
+// caller turns false into a 400. Both reads share the same signature, so the
+// handler calls the result without branching further.
+func selectNearbyRead(store nearStore, order string) (func(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error), bool) {
+	switch strings.TrimSpace(order) {
+	case "", orderRecency:
+		return store.RecentNearby, true
+	case orderDistance:
+		return store.NearestNearby, true
+	default:
+		return nil, false
+	}
 }
 
 // parseRadius parses the optional radius in metres: it defaults to

--- a/api-go/internal/applications/near_test.go
+++ b/api-go/internal/applications/near_test.go
@@ -25,6 +25,10 @@ type fakeNearStore struct {
 	lastRadius        float64
 	lastCap           int
 
+	// nearestCalled records whether the distance-ordered read path was taken
+	// (order=distance) instead of the recency-ordered RecentNearby default.
+	nearestCalled bool
+
 	countCalled       bool
 	lastCountAuthCode string
 	lastCountLat      float64
@@ -34,6 +38,23 @@ type fakeNearStore struct {
 
 func (f *fakeNearStore) RecentNearby(_ context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error) {
 	f.called = true
+	f.lastAuthorityCode = authorityCode
+	f.lastLat = lat
+	f.lastLng = lng
+	f.lastRadius = radiusMetres
+	f.lastCap = cap
+	if f.err != nil {
+		return nil, f.err
+	}
+	if cap >= 0 && cap < len(f.apps) {
+		return f.apps[:cap], nil
+	}
+	return f.apps, nil
+}
+
+func (f *fakeNearStore) NearestNearby(_ context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error) {
+	f.called = true
+	f.nearestCalled = true
 	f.lastAuthorityCode = authorityCode
 	f.lastLat = lat
 	f.lastLng = lng
@@ -460,5 +481,109 @@ func TestNearHandler_CountErrorReturns500(t *testing.T) {
 
 	if rec.Code != http.StatusInternalServerError {
 		t.Fatalf("count error: got %d, want 500", rec.Code)
+	}
+}
+
+func TestNearHandler_DefaultOrderRoutesToRecentNearby(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 5}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	// Absent order param -> recency-ordered RecentNearby (the unchanged default).
+	if !store.called || store.nearestCalled {
+		t.Errorf("default order must route to RecentNearby, not NearestNearby (called=%v nearest=%v)", store.called, store.nearestCalled)
+	}
+}
+
+func TestNearHandler_OrderRecencyRoutesToRecentNearby(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 5}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&order=recency")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	// Explicit order=recency must behave exactly like the default.
+	if !store.called || store.nearestCalled {
+		t.Errorf("order=recency must route to RecentNearby, not NearestNearby (called=%v nearest=%v)", store.called, store.nearestCalled)
+	}
+}
+
+func TestNearHandler_OrderDistanceRoutesToNearestNearby(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 5}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5155&lng=-0.0931&radius=4000&order=distance")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	// order=distance must route to the distance-ordered NearestNearby read.
+	if !store.nearestCalled {
+		t.Fatalf("order=distance must route to NearestNearby")
+	}
+	// Same scoping/clamping/cap and geo args reach the distance-ordered read.
+	if store.lastAuthorityCode != "471" || store.lastCap != 200 {
+		t.Errorf("nearest read call: authorityCode=%q cap=%d, want \"471\" 200", store.lastAuthorityCode, store.lastCap)
+	}
+	if store.lastLat != 51.5155 || store.lastLng != -0.0931 || store.lastRadius != 4000 {
+		t.Errorf("nearest geo args: lat=%v lng=%v radius=%v, want 51.5155 -0.0931 4000", store.lastLat, store.lastLng, store.lastRadius)
+	}
+	// The exact count is still taken over the same scoped, clamped geo window.
+	if !store.countCalled || store.lastCountAuthCode != "471" {
+		t.Errorf("count call: called=%v auth=%q, want true \"471\"", store.countCalled, store.lastCountAuthCode)
+	}
+}
+
+func TestNearHandler_UnknownOrderReturns400(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 5}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&order=banana")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("unknown order: got %d, want 400", rec.Code)
+	}
+	if store.called || store.countCalled {
+		t.Errorf("store must not be hit on an unknown order value")
+	}
+}
+
+func TestNearHandler_OrderDistanceStillRejectsOutOfRangeCoord(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 5}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=91&lng=-0.1&order=distance")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("out-of-range lat with order=distance: got %d, want 400", rec.Code)
+	}
+	if store.called || store.countCalled {
+		t.Errorf("store must not be hit on an out-of-range coord, even with order=distance")
+	}
+}
+
+func TestNearHandler_OrderDistanceStillRejectsNonPositiveRadius(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2), count: 5}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&radius=0&order=distance")
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("non-positive radius with order=distance: got %d, want 400", rec.Code)
+	}
+	if store.called || store.countCalled {
+		t.Errorf("store must not be hit on a non-positive radius, even with order=distance")
 	}
 }

--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -268,3 +268,52 @@ func (s *CosmosStore) RecentNearby(ctx context.Context, authorityCode string, la
 	}
 	return apps, nil
 }
+
+// nearestNearbyQuery is the bounded, single-partition spatial top-N query behind
+// the build-time town-level SEO endpoint's distance-ordered variant: the @cap
+// applications NEAREST to a point, inside one authorityCode partition. It marries
+// the recentNearbyQuery ST_DISTANCE filter (GeoJSON [longitude, latitude] order,
+// all values bound as named parameters) with a SELECT TOP @cap ... ORDER BY
+// ST_DISTANCE ASC ordering — so the read stays bounded by @cap and returns the
+// nearest-first set, minimising overlap between adjacent town pages in
+// conurbations. The ORDER BY repeats the same parameterized ST_DISTANCE
+// expression as the WHERE filter; no coordinate is concatenated into the text.
+// This is a sibling of recentNearbyQuery: that path (ordered by lastDifferent
+// DESC) is the default and is deliberately left unchanged.
+const nearestNearbyQuery = "SELECT TOP @cap * FROM c WHERE ST_DISTANCE(c.location, " +
+	`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres ` +
+	"ORDER BY ST_DISTANCE(c.location, " +
+	`{"type": "Point", "coordinates": [@longitude, @latitude]})`
+
+// NearestNearby returns up to cap applications NEAREST to (lat, lng) within
+// radiusMetres inside the authorityCode partition, ordered by ST_DISTANCE ASC
+// (nearest first). It backs the distance-ordered variant of the build-time
+// town-level SEO endpoint: a single bounded single-partition spatial query, never
+// a cross-partition fan-out and never an unbounded scan. Coordinates, radius, and
+// cap are bound as named parameters (not string-concatenated). It runs on the
+// latency-tolerant build-read budget (QueryItemsLongRead), like its RecentNearby
+// sibling. There is no PlanIt fallback (GH#395 Invariant 1) — it reads only from
+// Cosmos.
+func (s *CosmosStore) NearestNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error) {
+	params := map[string]any{
+		"@latitude":     lat,
+		"@longitude":    lng,
+		"@radiusMetres": radiusMetres,
+		"@cap":          cap,
+	}
+	// Latency-tolerant build-time read: a LARGE authority partition legitimately
+	// exceeds the 1.5s OLTP budget, so use the longer per-attempt budget (tc-9tov).
+	raws, err := s.items.QueryItemsLongRead(ctx, authorityCode, nearestNearbyQuery, params)
+	if err != nil {
+		return nil, fmt.Errorf("nearest applications near %q: %w", authorityCode, err)
+	}
+	apps := make([]PlanningApplication, 0, len(raws))
+	for _, raw := range raws {
+		var doc applicationDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("decode nearest nearby application in %q: %w", authorityCode, err)
+		}
+		apps = append(apps, doc.toDomain())
+	}
+	return apps, nil
+}

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -440,6 +440,123 @@ func TestCosmosStore_RecentNearby_EmptyResultIsEmptySlice(t *testing.T) {
 	}
 }
 
+func TestCosmosStore_NearestNearby_BoundedSpatialDistanceOrderedScopedToPartition(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	body, _ := json.Marshal(newApplicationDocument(a))
+	items := newFakeItems()
+	items.queryResult = [][]byte{body}
+	store := NewCosmosStore(items)
+
+	got, err := store.NearestNearby(context.Background(), "441", 51.4975, -0.1357, 5000, 200)
+	if err != nil {
+		t.Fatalf("NearestNearby: %v", err)
+	}
+	if len(got) != 1 || got[0].Name != a.Name {
+		t.Fatalf("NearestNearby results: got %+v", got)
+	}
+	// Scoped to the authorityCode logical partition (never cross-partition).
+	if items.lastQueryPK != "441" {
+		t.Errorf("query partition key: got %q, want \"441\"", items.lastQueryPK)
+	}
+	// Bounded TOP @cap, single-partition spatial filter, ordered by ST_DISTANCE
+	// ASC (nearest first) — NOT by lastDifferent. The GeoJSON point carries
+	// [longitude, latitude] (GeoJSON order), mirroring recentNearbyQuery. The
+	// ORDER BY repeats the same parameterized ST_DISTANCE expression as the
+	// WHERE filter.
+	want := "SELECT TOP @cap * FROM c WHERE ST_DISTANCE(c.location, " +
+		`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres ` +
+		"ORDER BY ST_DISTANCE(c.location, " +
+		`{"type": "Point", "coordinates": [@longitude, @latitude]})`
+	if items.lastQuery != want {
+		t.Errorf("nearest nearby query:\n got %q\nwant %q", items.lastQuery, want)
+	}
+	if strings.Contains(items.lastQuery, "lastDifferent") {
+		t.Errorf("distance-ordered query must not order by lastDifferent: %s", items.lastQuery)
+	}
+}
+
+func TestCosmosStore_NearestNearby_UsesParameterizedQuery(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	_, _ = store.NearestNearby(context.Background(), "441", 51.4975, -0.1357, 5000, 200)
+
+	// No coordinate, radius, or cap value may be string-concatenated into the
+	// query text — they must all be bound as named parameters.
+	if items.lastQuery == "" {
+		t.Fatal("no query was issued")
+	}
+	for _, literal := range []string{"51.4975", "-0.1357", "5000", "200"} {
+		if strings.Contains(items.lastQuery, literal) {
+			t.Errorf("query contains literal %q — should be a named parameter; query: %s", literal, items.lastQuery)
+		}
+	}
+	wantParams := map[string]any{
+		"@latitude":     51.4975,
+		"@longitude":    -0.1357,
+		"@radiusMetres": 5000.0,
+		"@cap":          200,
+	}
+	for k, wantVal := range wantParams {
+		gotVal, ok := items.lastQueryParams[k]
+		if !ok {
+			t.Errorf("param %q not found in query params %v", k, items.lastQueryParams)
+			continue
+		}
+		if gotVal != wantVal {
+			t.Errorf("param %q: got %v, want %v", k, gotVal, wantVal)
+		}
+	}
+}
+
+func TestCosmosStore_NearestNearby_CapsAtCap(t *testing.T) {
+	t.Parallel()
+	const wantCap = 5
+	items := newFakeItems()
+	// A busy authority with more than wantCap documents within the radius.
+	items.queryResult = recentDocs(t, wantCap+8)
+	store := NewCosmosStore(items)
+
+	got, err := store.NearestNearby(context.Background(), "471", 51.5, -0.1, 5000, wantCap)
+	if err != nil {
+		t.Fatalf("NearestNearby: %v", err)
+	}
+	if len(got) != wantCap {
+		t.Errorf("busy authority: got %d results, want exactly cap=%d", len(got), wantCap)
+	}
+}
+
+func TestCosmosStore_NearestNearby_EmptyResultIsEmptySlice(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+
+	got, err := store.NearestNearby(context.Background(), "471", 51.5, -0.1, 5000, 200)
+	if err != nil {
+		t.Fatalf("NearestNearby: %v", err)
+	}
+	if got == nil {
+		t.Fatal("NearestNearby: got nil slice, want empty non-nil slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("NearestNearby: got %d results, want 0", len(got))
+	}
+}
+
+func TestCosmosStore_NearestNearby_UsesLongReadBudget(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if _, err := store.NearestNearby(context.Background(), "156", 51.5, -0.1, 5000, 200); err != nil {
+		t.Fatalf("NearestNearby: %v", err)
+	}
+	if !items.lastQueryViaLongRead {
+		t.Error("NearestNearby must use the long-read budget (QueryItemsLongRead), not the 1.5s OLTP QueryItems")
+	}
+}
+
 func TestCosmosStore_CountByAuthority_DecodesScalarScopedToPartition(t *testing.T) {
 	t.Parallel()
 	items := newFakeItems()


### PR DESCRIPTION
## What

Adds a **distance-ordered** nearby query variant to `GET /v1/applications/near`, exposed via a new optional `order` query param, feeding the SEO Phase 2 town-page pipeline (epic `tc-2avw`, GH #585). Backend-only.

- `store_cosmos.go`: new `nearestNearbyQuery` (`SELECT TOP @cap * ... WHERE ST_DISTANCE(...) <= @radiusMetres ORDER BY ST_DISTANCE(...)`) + `NearestNearby` store method. Coordinates/radius/cap are bound as named parameters (no float string-concatenation), GeoJSON `[longitude, latitude]` order, same `QueryItemsLongRead` build-read budget as its `RecentNearby` sibling. Never PlanIt (GH#395 Invariant 1), single-partition, bounded by `@cap`.
- `near.go`: `NearestNearby` added to the `nearStore` interface; the handler parses an optional `order` param:
  - absent or `order=recency` -> `RecentNearby` (**unchanged default**, ordered by `lastDifferent` DESC)
  - `order=distance` -> `NearestNearby` (nearest first)
  - any other value -> `400` (consistent with the handler's strict validation)
- Existing truncate-to-`limit` logic is unchanged: for distance order the store returns nearest-first, so truncating keeps the nearest-N. JSON response shape is unchanged.

The web renderer re-sorts the returned set by recency for display (sibling bead) — the API's job for `order=distance` is only to **select** the nearest-N, so no display sorting was added in Go.

## Tests (TDD, hand-written fakes only)

- **Store** (`store_cosmos_test.go`): distance-ordered query shape + partition scoping; named-parameter binding (no literals); caps at `@cap`; empty result is empty slice; uses the long-read budget.
- **Handler** (`near_test.go`): `order=distance` routes to `NearestNearby`; default and `order=recency` route to `RecentNearby` (unchanged); unknown `order` -> 400; out-of-range coord / non-positive radius still -> 400 with `order=distance`. The fake `nearStore` records which method was called and with what args.

## Quality gates (all pass)

- `gofmt -l .` empty
- `go vet ./...` clean
- `go build ./...` clean
- `go test -race ./...` — 1066 pass
- `golangci-lint run ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xL4oCpLWWGhqV6fmsfEXy