### PR TITLE
feat(web): per-town SEO tracer — population field + order=distance wired end-to-end (tc-2avw.2)

### DIFF
--- a/web/scripts/lib/__tests__/prerender-towns.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-towns.test.mjs
@@ -183,6 +183,8 @@ describe('runPrerender — town live mode', () => {
     expect(nearCalls[0].url).toContain('lat=50.2632');
     expect(nearCalls[0].url).toContain('lng=-5.051');
     expect(nearCalls[0].url).toContain('limit=30');
+    // Selects the nearest-N by distance (the order=distance variant from tc-2avw.1).
+    expect(nearCalls[0].url).toContain('order=distance');
     expect(nearCalls[0].init.headers['X-Build-Key']).toBe('test-key');
 
     const html = await readFile(

--- a/web/scripts/lib/__tests__/prerender-towns.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-towns.test.mjs
@@ -3,7 +3,10 @@ import { mkdtemp, rm, readFile, access } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { runPrerender } from '../../prerender-planning.mjs';
+import {
+  runPrerender,
+  loadTownsFromFile,
+} from '../../prerender-planning.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const AUTHORITY_FIXTURE = join(
@@ -304,5 +307,113 @@ describe('runPrerender — town live mode', () => {
         logger: silentLogger,
       }),
     ).rejects.toThrow();
+  });
+});
+
+// The integration spine for the per-town SEO pipeline (tc-2avw.2): drives ONE
+// authority end-to-end through the two NEW pieces wired in this bead — the
+// `population` field in the gazetteer schema and the `order=distance` near param —
+// from gazetteer load → near fetch → coverage gate → page write → sitemap.
+describe('runPrerender — per-town integration spine (one authority, end to end)', () => {
+  const cornwallAuthorities = [
+    { id: 52, name: 'Cornwall', areaType: 'English County' },
+  ];
+
+  it('refuses a gazetteer whose town row has a malformed population', async () => {
+    const readImpl = async () =>
+      JSON.stringify([
+        {
+          slug: 'truro',
+          name: 'Truro',
+          lat: 50.2632,
+          lng: -5.051,
+          authorityId: 52,
+          population: 'lots',
+        },
+      ]);
+    await expect(loadTownsFromFile('/fake/towns.json', readImpl)).rejects.toThrow();
+  });
+
+  it('loads a population-bearing gazetteer, requests order=distance, gates, writes the page, and lists it in the sitemap', async () => {
+    // 1) Gazetteer load: a real loadTownsFromFile round-trip carrying `population`.
+    const gazetteer = async () =>
+      JSON.stringify([
+        {
+          slug: 'truro',
+          name: 'Truro',
+          lat: 50.2632,
+          lng: -5.051,
+          authorityId: 52,
+          population: 18766,
+        },
+      ]);
+    const towns = await loadTownsFromFile('/fake/towns.json', gazetteer);
+    expect(towns[0].population).toBe(18766);
+
+    // 2) Near fetch: hand-written fake fetch, total=14 (clears the >=10 gate).
+    const stub = new StubFetch((url) => {
+      if (url.includes('/v1/applications/near')) {
+        return {
+          ok: true,
+          status: 200,
+          body: {
+            authorityId: 52,
+            lat: 50.2632,
+            lng: -5.051,
+            radius: 5000,
+            applications: [
+              {
+                uid: 'CW1',
+                name: 'PA26/0001',
+                address: 'Lemon Quay, Truro',
+                description: 'Café conversion',
+                appState: 'Permitted',
+                startDate: '2026-01-12',
+                lastDifferent: '2026-06-12T10:00:00+00:00',
+                link: 'https://planit.org.uk/planapplic/CW1',
+                url: null,
+              },
+            ],
+            total: 14,
+            statusBreakdown: [{ appState: 'Permitted', count: 14 }],
+          },
+        };
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => towns,
+      logger: silentLogger,
+    });
+
+    // 3) order=distance: the near request consumes the tc-2avw.1 param.
+    const nearCalls = stub.calls.filter((c) =>
+      c.url.includes('/v1/applications/near'),
+    );
+    expect(nearCalls).toHaveLength(1);
+    expect(nearCalls[0].url).toContain('order=distance');
+
+    // No PlanIt at build time — only our own build-key-gated API.
+    expect(stub.calls.every((c) => !c.url.includes('planit.org.uk'))).toBe(true);
+
+    // 4) Coverage gate cleared -> the nested town page is published and written.
+    expect(result.publishedTowns).toEqual(['cornwall/truro']);
+    const html = await readFile(
+      join(outDir, 'planning', 'cornwall', 'truro', 'index.html'),
+      'utf-8',
+    );
+    expect(html).toContain('<h1>Planning applications in Truro</h1>');
+
+    // 5) Sitemap carries the published town path.
+    const sitemap = await readFile(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain(
+      '<loc>https://towncrierapp.uk/planning/cornwall/truro</loc>',
+    );
   });
 });

--- a/web/scripts/lib/__tests__/towns-data.test.mjs
+++ b/web/scripts/lib/__tests__/towns-data.test.mjs
@@ -15,7 +15,14 @@ describe('loadTownsFromFile', () => {
   it('loads and validates a well-formed gazetteer', async () => {
     const readImpl = async () =>
       JSON.stringify([
-        { slug: 'truro', name: 'Truro', lat: 50.2632, lng: -5.051, authorityId: 52 },
+        {
+          slug: 'truro',
+          name: 'Truro',
+          lat: 50.2632,
+          lng: -5.051,
+          authorityId: 52,
+          population: 19000,
+        },
       ]);
     const towns = await loadTownsFromFile(FAKE_PATH, readImpl);
     expect(towns).toHaveLength(1);
@@ -25,6 +32,7 @@ describe('loadTownsFromFile', () => {
       lat: 50.2632,
       lng: -5.051,
       authorityId: 52,
+      population: 19000,
     });
   });
 
@@ -55,7 +63,30 @@ describe('loadTownsFromFile', () => {
 
   it('throws on a malformed town row (missing authorityId)', async () => {
     const readImpl = async () =>
-      JSON.stringify([{ slug: 'x', name: 'X', lat: 0, lng: 0 }]);
+      JSON.stringify([{ slug: 'x', name: 'X', lat: 0, lng: 0, population: 5000 }]);
+    await expect(loadTownsFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
+  });
+
+  it('throws on a malformed town row (missing population)', async () => {
+    const readImpl = async () =>
+      JSON.stringify([
+        { slug: 'x', name: 'X', lat: 0, lng: 0, authorityId: 1 },
+      ]);
+    await expect(loadTownsFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
+  });
+
+  it('throws on a malformed town row (non-numeric population)', async () => {
+    const readImpl = async () =>
+      JSON.stringify([
+        {
+          slug: 'x',
+          name: 'X',
+          lat: 0,
+          lng: 0,
+          authorityId: 1,
+          population: 'lots',
+        },
+      ]);
     await expect(loadTownsFromFile(FAKE_PATH, readImpl)).rejects.toThrow();
   });
 });
@@ -71,6 +102,7 @@ describe('committed towns.json gazetteer', () => {
       expect(Number.isFinite(t.lat)).toBe(true);
       expect(Number.isFinite(t.lng)).toBe(true);
       expect(Number.isFinite(t.authorityId)).toBe(true);
+      expect(Number.isFinite(t.population)).toBe(true);
     }
   });
 

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -140,6 +140,7 @@ export async function loadAuthoritiesFromFile(filePath, readFileImpl) {
  * @property {number} lat           WGS84 latitude (centroid)
  * @property {number} lng           WGS84 longitude (centroid)
  * @property {number} authorityId   parent authority id (resolves to its slug)
+ * @property {number} population    built-up-area population (gates which towns ship)
  */
 
 /**
@@ -184,7 +185,8 @@ export async function loadTownsFromFile(filePath, readFileImpl) {
       t.name.length === 0 ||
       !Number.isFinite(t?.lat) ||
       !Number.isFinite(t?.lng) ||
-      !Number.isFinite(t?.authorityId)
+      !Number.isFinite(t?.authorityId) ||
+      !Number.isFinite(t?.population)
     ) {
       throw new Error(`town gazetteer at ${filePath} has a malformed town row`);
     }

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -61,7 +61,7 @@ export const AUTHORITIES_FILE = join(
  * The town gazetteer is a slim, committed JSON file in the web app's source
  * tree (`web/src/data/towns.json`). It is regenerated occasionally by
  * `scripts/generate-towns.mjs` from OS Open Names — never downloaded at build
- * time. Each row is `{ slug, name, lat, lng, authorityId }`.
+ * time. Each row is `{ slug, name, lat, lng, authorityId, population }`.
  * @type {string}
  */
 export const TOWNS_FILE = join(SCRIPT_DIR, '..', 'src', 'data', 'towns.json');

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -325,9 +325,13 @@ async function considerAuthority(args) {
  * @returns {Promise<{ applications: object[], total: number, statusBreakdown: object[] }>}
  */
 async function fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl) {
+  // `order=distance` (tc-2avw.1) makes the server return the nearest-N in the
+  // radius by ST_DISTANCE, so adjacent town pages in a conurbation overlap less.
+  // The returned set is left in the API's order here; recency-display re-sorting
+  // is the renderer's job.
   const url =
     `${apiBase}/v1/applications/near?authorityId=${town.authorityId}` +
-    `&lat=${town.lat}&lng=${town.lng}&limit=${limit}`;
+    `&lat=${town.lat}&lng=${town.lng}&limit=${limit}&order=distance`;
   const res = await fetchImpl(url, { headers: { 'X-Build-Key': buildKey } });
   if (!res.ok) {
     throw new Error(

--- a/web/src/data/towns.json
+++ b/web/src/data/towns.json
@@ -1,14 +1,14 @@
 [
-  { "slug": "croydon", "name": "Croydon", "lat": 51.3762, "lng": -0.0982, "authorityId": 301 },
-  { "slug": "truro", "name": "Truro", "lat": 50.2632, "lng": -5.0510, "authorityId": 52 },
-  { "slug": "newquay", "name": "Newquay", "lat": 50.4156, "lng": -5.0739, "authorityId": 52 },
-  { "slug": "cambridge", "name": "Cambridge", "lat": 52.2053, "lng": 0.1218, "authorityId": 61 },
-  { "slug": "wembley", "name": "Wembley", "lat": 51.5530, "lng": -0.2963, "authorityId": 298 },
-  { "slug": "ealing", "name": "Ealing", "lat": 51.5130, "lng": -0.3089, "authorityId": 302 },
-  { "slug": "greenwich", "name": "Greenwich", "lat": 51.4826, "lng": -0.0077, "authorityId": 304 },
-  { "slug": "woolwich", "name": "Woolwich", "lat": 51.4920, "lng": 0.0640, "authorityId": 304 },
-  { "slug": "bexleyheath", "name": "Bexleyheath", "lat": 51.4549, "lng": 0.1505, "authorityId": 297 },
-  { "slug": "hackney", "name": "Hackney", "lat": 51.5450, "lng": -0.0553, "authorityId": 305 },
-  { "slug": "islington", "name": "Islington", "lat": 51.5362, "lng": -0.1033, "authorityId": 312 },
-  { "slug": "finchley", "name": "Finchley", "lat": 51.5990, "lng": -0.1870, "authorityId": 296 }
+  { "slug": "croydon", "name": "Croydon", "lat": 51.3762, "lng": -0.0982, "authorityId": 301, "population": 192064 },
+  { "slug": "truro", "name": "Truro", "lat": 50.2632, "lng": -5.0510, "authorityId": 52, "population": 18766 },
+  { "slug": "newquay", "name": "Newquay", "lat": 50.4156, "lng": -5.0739, "authorityId": 52, "population": 20342 },
+  { "slug": "cambridge", "name": "Cambridge", "lat": 52.2053, "lng": 0.1218, "authorityId": 61, "population": 145674 },
+  { "slug": "wembley", "name": "Wembley", "lat": 51.5530, "lng": -0.2963, "authorityId": 298, "population": 102856 },
+  { "slug": "ealing", "name": "Ealing", "lat": 51.5130, "lng": -0.3089, "authorityId": 302, "population": 85014 },
+  { "slug": "greenwich", "name": "Greenwich", "lat": 51.4826, "lng": -0.0077, "authorityId": 304, "population": 52783 },
+  { "slug": "woolwich", "name": "Woolwich", "lat": 51.4920, "lng": 0.0640, "authorityId": 304, "population": 84959 },
+  { "slug": "bexleyheath", "name": "Bexleyheath", "lat": 51.4549, "lng": 0.1505, "authorityId": 297, "population": 31929 },
+  { "slug": "hackney", "name": "Hackney", "lat": 51.5450, "lng": -0.0553, "authorityId": 305, "population": 281120 },
+  { "slug": "islington", "name": "Islington", "lat": 51.5362, "lng": -0.1033, "authorityId": 312, "population": 215667 },
+  { "slug": "finchley", "name": "Finchley", "lat": 51.5990, "lng": -0.1870, "authorityId": 296, "population": 65812 }
 ]


### PR DESCRIPTION
## What

The integration spine (tracer bullet) for the per-town SEO pipeline (epic tc-2avw, GH #585). Proves the per-town path works end-to-end for ONE authority with the two NEW pieces wired in minimally. Deliberately thin — sibling beads tc-2avw.3/.4/.5 own the polish.

### Changes (all under `web/`)

1. **`web/scripts/prerender-planning.mjs` — `loadTownsFromFile` + `Town` typedef:** added a `population` field. The validation guard now requires a finite numeric `population` on every row (`Number.isFinite`); a missing or malformed population is a build error, consistent with the existing malformed-row throw. Added `@property {number} population` to the typedef and updated the `TOWNS_FILE` row-shape doc comment.

2. **`web/src/data/towns.json`:** added a `"population"` field to each of the 12 tracer rows so the gazetteer satisfies the new validation. These rows are tracer scaffolding; sibling bead tc-2avw.5 regenerates the whole file from the real ONS source. Values are approximate ONS Census 2021 Built-Up-Area-scale figures used only to satisfy the schema — no population-threshold filter is wired in this bead (that is tc-2avw.3), so the exact values are not load-bearing here and are not presented as authoritative.

3. **`web/scripts/prerender-planning.mjs` — `fetchRecentNearby`:** appended `&order=distance` to the `/v1/applications/near` request URL, consuming the new API param shipped in sibling bead tc-2avw.1. The returned applications are left in the API's order — the recency-display re-sort is tc-2avw.4's job. Response-shape validation unchanged.

4. **Vitest (the real deliverable):**
   - `web/scripts/lib/__tests__/prerender-towns.test.mjs` — a focused integration-spine test drives ONE authority (Cornwall/Truro) end-to-end with a hand-written fake fetch: `loadTownsFromFile` round-trips `population` (and a malformed-population row throws) → town near fetch (asserts the request URL contains `order=distance`, and no PlanIt) → coverage gate → nested town page written → sitemap contains the town path. Also added an `order=distance` assertion to the existing live-mode town test.
   - `web/scripts/lib/__tests__/towns-data.test.mjs` — added missing-population and non-numeric-population throw cases, asserted `population` round-trips, and added a numeric-`population` assertion on the committed gazetteer.

### Strictly out of scope (sibling beads, untouched)
- tc-2avw.3 (SEO_TOWN_MIN_POPULATION threshold read + `population >= threshold` filter)
- tc-2avw.4 (sitemap `<lastmod>`, recency-display sort, town copy, ONS/NRS/OS attribution)
- tc-2avw.5 (`generate-towns.mjs` rewrite + full GB `towns.json` regen)

### TDD
Red→Green→Refactor throughout. The integration spine was verified to genuinely guard the new behaviour by toggling `order=distance` off (RED) then on (GREEN).

### Quality gates (all pass)
- `npx tsc --noEmit` — no errors
- `npx eslint` (edited files) — no issues
- `npx vitest run` — 784/784 passed (101 files)
- `npm run build` — clean (prerender skips without SITE_BUILD_KEY, as designed)
- scope — only `web/` files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xL4oCpLWWGhqV6fmsfEXy