### PR TITLE
feat(seo): whole-partition status breakdown + honest per-application link captions (tc-4set, tc-wwm8)

### DIFF
--- a/api-go/internal/applications/recent.go
+++ b/api-go/internal/applications/recent.go
@@ -9,9 +9,11 @@ import (
 )
 
 // recentReadCap is the hard upper bound on documents read per authority in one
-// SEO build request. The query is bounded by it (SELECT TOP @cap), so the RU cost
-// and response size stay flat regardless of how busy the authority is. It also
-// bounds the denominator of the status breakdown.
+// SEO build request for the rendered list. The list query is bounded by it
+// (SELECT TOP @cap), so the RU cost and response size of the card list stay flat
+// regardless of how busy the authority is. It bounds only the rendered list, not
+// the status breakdown — that is an index-served GROUP BY over the whole
+// partition (BreakdownByAuthority).
 const recentReadCap = 200
 
 // recentDefaultLimit and recentMaxLimit bound how many applications the response
@@ -23,11 +25,12 @@ const (
 )
 
 // recentStore is the consumer-side store the SEO read handler needs: a bounded,
-// single-partition top-N read by authority plus an exact partition count. The
-// concrete *CosmosStore satisfies it structurally.
+// single-partition top-N read by authority plus a whole-partition per-appState
+// breakdown (whose buckets sum to the exact partition total). The concrete
+// *CosmosStore satisfies it structurally.
 type recentStore interface {
 	RecentByAuthority(ctx context.Context, authorityCode string, cap int) ([]PlanningApplication, error)
-	CountByAuthority(ctx context.Context, authorityCode string) (int, error)
+	BreakdownByAuthority(ctx context.Context, authorityCode string) ([]StateCount, error)
 }
 
 // recentHandler serves the build-time SEO endpoint.
@@ -66,13 +69,27 @@ func (h *recentHandler) recentByAuthority(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// total is the EXACT partition count (index-only COUNT), independent of the
-	// bounded read which saturates at recentReadCap. The render slice must clamp
-	// against the bounded read length, NOT total — total can dwarf len(apps).
-	total, err := h.store.CountByAuthority(r.Context(), authorityCode)
+	// breakdown is the per-appState distribution over the WHOLE partition (an
+	// index-served GROUP BY), independent of the bounded read which saturates at
+	// recentReadCap. The render slice must clamp against the bounded read length,
+	// NOT the breakdown total — the total can dwarf len(apps).
+	breakdown, err := h.store.BreakdownByAuthority(r.Context(), authorityCode)
 	if err != nil {
-		serverError(w, r, h.logger, "count applications by authority", err)
+		serverError(w, r, h.logger, "status breakdown by authority", err)
 		return
+	}
+
+	// StatusBreakdown is always a non-null array on the wire; an empty partition
+	// yields an empty (not nil) slice so it marshals to [] rather than null.
+	if breakdown == nil {
+		breakdown = []StateCount{}
+	}
+
+	// total is the EXACT whole-partition total: the sum of the breakdown buckets,
+	// so the rendered "tracking N applications" lead line equals the breakdown.
+	total := 0
+	for _, sc := range breakdown {
+		total += sc.Count
 	}
 
 	render := len(apps)
@@ -97,7 +114,7 @@ func (h *recentHandler) recentByAuthority(w http.ResponseWriter, r *http.Request
 		AreaName:        areaName,
 		Applications:    results,
 		Total:           total,
-		StatusBreakdown: breakdownByState(apps),
+		StatusBreakdown: breakdown,
 	})
 }
 

--- a/api-go/internal/applications/recent_test.go
+++ b/api-go/internal/applications/recent_test.go
@@ -12,19 +12,20 @@ import (
 
 // fakeRecentStore is a hand-written double for the recent-by-authority read. It
 // honours cap the way Cosmos TOP @cap does (so the handler's cap/limit logic is
-// exercised against realistic bounded results) and serves an exact partition
-// count independently, so a test can prove total comes from the count call rather
-// than the bounded read length.
+// exercised against realistic bounded results) and serves a whole-partition
+// status breakdown independently of the bounded read, so a test can prove the
+// rendered Total is the sum of those buckets — not the bounded read length nor
+// the rendered slice.
 type fakeRecentStore struct {
-	apps     []PlanningApplication
-	err      error
-	count    int
-	countErr error
+	apps         []PlanningApplication
+	err          error
+	breakdown    []StateCount
+	breakdownErr error
 
-	lastAuthorityCode      string
-	lastCap                int
-	countCalled            bool
-	lastCountAuthorityCode string
+	lastAuthorityCode          string
+	lastCap                    int
+	breakdownCalled            bool
+	lastBreakdownAuthorityCode string
 }
 
 func (f *fakeRecentStore) RecentByAuthority(_ context.Context, authorityCode string, cap int) ([]PlanningApplication, error) {
@@ -39,13 +40,21 @@ func (f *fakeRecentStore) RecentByAuthority(_ context.Context, authorityCode str
 	return f.apps, nil
 }
 
-func (f *fakeRecentStore) CountByAuthority(_ context.Context, authorityCode string) (int, error) {
-	f.countCalled = true
-	f.lastCountAuthorityCode = authorityCode
-	if f.countErr != nil {
-		return 0, f.countErr
+func (f *fakeRecentStore) BreakdownByAuthority(_ context.Context, authorityCode string) ([]StateCount, error) {
+	f.breakdownCalled = true
+	f.lastBreakdownAuthorityCode = authorityCode
+	if f.breakdownErr != nil {
+		return nil, f.breakdownErr
 	}
-	return f.count, nil
+	return f.breakdown, nil
+}
+
+// breakdownOf builds a []StateCount from raw appState/count pairs, for seeding the
+// fake's whole-partition breakdown.
+func breakdownOf(pairs ...StateCount) []StateCount {
+	out := make([]StateCount, 0, len(pairs))
+	out = append(out, pairs...)
+	return out
 }
 
 // recentApps builds n distinct planning applications for the handler tests.
@@ -108,9 +117,16 @@ func recentBody(t *testing.T, rec *httptest.ResponseRecorder) map[string]any {
 
 func TestRecentHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 	t.Parallel()
-	// count is deliberately distinct from len(apps) to prove total is the exact
-	// partition count, not the bounded read length.
-	store := &fakeRecentStore{apps: recentApps(t, 2), count: 1234}
+	// The whole-partition breakdown sums to 1234, deliberately distinct from
+	// len(apps) (2), to prove total is the sum of the breakdown buckets, not the
+	// bounded read length.
+	store := &fakeRecentStore{
+		apps: recentApps(t, 2),
+		breakdown: breakdownOf(
+			StateCount{AppState: strPtr("Permitted"), Count: 1000},
+			StateCount{AppState: strPtr("Rejected"), Count: 234},
+		),
+	}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications")
 
@@ -120,13 +136,13 @@ func TestRecentHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
 		t.Errorf("content-type: got %q", ct)
 	}
-	// The handler reads the bounded cap (200) and counts the partition, both scoped
-	// to the numeric id -> code.
+	// The handler reads the bounded cap (200) and computes the whole-partition
+	// breakdown, both scoped to the numeric id -> code.
 	if store.lastAuthorityCode != "471" || store.lastCap != 200 {
 		t.Errorf("store read call: authorityCode=%q cap=%d, want \"471\" 200", store.lastAuthorityCode, store.lastCap)
 	}
-	if !store.countCalled || store.lastCountAuthorityCode != "471" {
-		t.Errorf("count call: called=%v authorityCode=%q, want true \"471\"", store.countCalled, store.lastCountAuthorityCode)
+	if !store.breakdownCalled || store.lastBreakdownAuthorityCode != "471" {
+		t.Errorf("breakdown call: called=%v authorityCode=%q, want true \"471\"", store.breakdownCalled, store.lastBreakdownAuthorityCode)
 	}
 	got := recentBody(t, rec)
 	if got["authorityId"].(float64) != 471 {
@@ -143,7 +159,7 @@ func TestRecentHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 		t.Errorf("applications length: got %d, want 2", len(apps))
 	}
 	if got["total"].(float64) != 1234 {
-		t.Errorf("total: got %v, want 1234 (the exact count)", got["total"])
+		t.Errorf("total: got %v, want 1234 (sum of the breakdown buckets)", got["total"])
 	}
 	if _, present := got["totalCapped"]; present {
 		t.Errorf("totalCapped must be gone from the wire shape, got %v", got["totalCapped"])
@@ -166,7 +182,7 @@ func TestRecentHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 
 func TestRecentHandler_RejectsMissingKey(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 2), count: 2}
+	store := &fakeRecentStore{apps: recentApps(t, 2)}
 
 	rec := serveRecent(t, store, "buildkey", "", "/v1/authorities/471/applications")
 
@@ -176,28 +192,34 @@ func TestRecentHandler_RejectsMissingKey(t *testing.T) {
 	if rec.Body.Len() != 0 {
 		t.Errorf("401 must be bodyless (backfilled downstream), got %s", rec.Body)
 	}
-	if store.lastCap != 0 || store.countCalled {
+	if store.lastCap != 0 || store.breakdownCalled {
 		t.Errorf("store must not be hit when the key is missing")
 	}
 }
 
 func TestRecentHandler_EmptyConfiguredKeyRejectsAll(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 2), count: 2}
+	store := &fakeRecentStore{apps: recentApps(t, 2)}
 
 	rec := serveRecent(t, store, "", "anything", "/v1/authorities/471/applications")
 
 	if rec.Code != http.StatusUnauthorized {
 		t.Fatalf("empty configured key must reject all: got %d, want 401", rec.Code)
 	}
-	if store.lastCap != 0 || store.countCalled {
+	if store.lastCap != 0 || store.breakdownCalled {
 		t.Errorf("store must not be hit when the configured key is empty")
 	}
 }
 
 func TestRecentHandler_LimitsReturnedApplications(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 50), count: 73}
+	// Breakdown sums to 73, distinct from len(apps) (50) and the limit (10).
+	store := &fakeRecentStore{
+		apps: recentApps(t, 50),
+		breakdown: breakdownOf(
+			StateCount{AppState: strPtr("Permitted"), Count: 73},
+		),
+	}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications?limit=10")
 
@@ -209,15 +231,19 @@ func TestRecentHandler_LimitsReturnedApplications(t *testing.T) {
 	if len(apps) != 10 {
 		t.Errorf("applications length: got %d, want 10 (the limit)", len(apps))
 	}
-	// total is the exact partition count, not the rendered slice nor the bounded read.
+	// total is the sum of the whole-partition breakdown, not the rendered slice nor
+	// the bounded read.
 	if got["total"].(float64) != 73 {
-		t.Errorf("total: got %v, want 73 (exact count)", got["total"])
+		t.Errorf("total: got %v, want 73 (sum of breakdown buckets)", got["total"])
 	}
 }
 
 func TestRecentHandler_DefaultLimitIs30(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 50), count: 50}
+	store := &fakeRecentStore{
+		apps:      recentApps(t, 50),
+		breakdown: breakdownOf(StateCount{AppState: strPtr("Permitted"), Count: 50}),
+	}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications")
 
@@ -230,7 +256,10 @@ func TestRecentHandler_DefaultLimitIs30(t *testing.T) {
 
 func TestRecentHandler_LimitHardCappedAt100(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 150), count: 150}
+	store := &fakeRecentStore{
+		apps:      recentApps(t, 150),
+		breakdown: breakdownOf(StateCount{AppState: strPtr("Permitted"), Count: 150}),
+	}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications?limit=999")
 
@@ -243,27 +272,41 @@ func TestRecentHandler_LimitHardCappedAt100(t *testing.T) {
 
 func TestRecentHandler_ExactTotalIndependentOfSaturatedRead(t *testing.T) {
 	t.Parallel()
-	// The bounded read saturates at cap (200) but the exact count is far larger:
-	// total must be the count, and the render slice clamps to the limit, not the
-	// count (the bug the bounded-read clamp guards against).
-	store := &fakeRecentStore{apps: recentApps(t, 200), count: 8421}
+	// The bounded read saturates at cap (200) but the whole-partition breakdown
+	// sums to far more: total must be that sum, and the render slice clamps to the
+	// limit, not the total (the bug the bounded-read clamp guards against).
+	store := &fakeRecentStore{
+		apps: recentApps(t, 200),
+		breakdown: breakdownOf(
+			StateCount{AppState: strPtr("Permitted"), Count: 6000},
+			StateCount{AppState: strPtr("Rejected"), Count: 2421},
+		),
+	}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications")
 
 	got := recentBody(t, rec)
 	if got["total"].(float64) != 8421 {
-		t.Errorf("total: got %v, want 8421 (exact count)", got["total"])
+		t.Errorf("total: got %v, want 8421 (sum of breakdown buckets)", got["total"])
 	}
 	if apps := got["applications"].([]any); len(apps) != 30 {
-		t.Errorf("applications length: got %d, want 30 (default limit, NOT the count)", len(apps))
+		t.Errorf("applications length: got %d, want 30 (default limit, NOT the total)", len(apps))
 	}
 }
 
-func TestRecentHandler_StatusBreakdownSpansBoundedReadNotRenderedSlice(t *testing.T) {
+func TestRecentHandler_StatusBreakdownIsWholePartitionEchoedVerbatim(t *testing.T) {
 	t.Parallel()
-	// 40 in the bounded read (25 Permitted, 15 Rejected); only 30 are rendered, but
-	// the breakdown denominator is the whole bounded read.
-	store := &fakeRecentStore{apps: appsByState(t, 25, 15), count: 40}
+	// The store's whole-partition breakdown sums to 3771 — far beyond the bounded
+	// read (40 cards) and the rendered slice (30). The handler must echo the
+	// store's breakdown verbatim, order preserved, and set total to its sum.
+	store := &fakeRecentStore{
+		apps: appsByState(t, 25, 15),
+		breakdown: breakdownOf(
+			StateCount{AppState: strPtr("Permitted"), Count: 2100},
+			StateCount{AppState: strPtr("Rejected"), Count: 900},
+			StateCount{AppState: strPtr("Conditions"), Count: 771},
+		),
+	}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications")
 
@@ -272,22 +315,28 @@ func TestRecentHandler_StatusBreakdownSpansBoundedReadNotRenderedSlice(t *testin
 	if !ok {
 		t.Fatalf("statusBreakdown must be an array, got %T", got["statusBreakdown"])
 	}
-	if len(breakdown) != 2 {
-		t.Fatalf("statusBreakdown length: got %d, want 2 (%v)", len(breakdown), breakdown)
+	if len(breakdown) != 3 {
+		t.Fatalf("statusBreakdown length: got %d, want 3 (%v)", len(breakdown), breakdown)
 	}
-	first := breakdown[0].(map[string]any)
-	second := breakdown[1].(map[string]any)
-	if first["appState"] != "Permitted" || first["count"].(float64) != 25 {
-		t.Errorf("breakdown[0]: got %v, want Permitted/25", first)
+	// Echoed verbatim from the store, order preserved.
+	wantStates := []string{"Permitted", "Rejected", "Conditions"}
+	wantCounts := []float64{2100, 900, 771}
+	for i, row := range breakdown {
+		m := row.(map[string]any)
+		if m["appState"] != wantStates[i] || m["count"].(float64) != wantCounts[i] {
+			t.Errorf("breakdown[%d]: got %v, want %s/%v", i, m, wantStates[i], wantCounts[i])
+		}
 	}
-	if second["appState"] != "Rejected" || second["count"].(float64) != 15 {
-		t.Errorf("breakdown[1]: got %v, want Rejected/15", second)
+	// total is the sum of the breakdown buckets (2100+900+771), equal to the
+	// rendered "tracking N applications" lead line.
+	if got["total"].(float64) != 3771 {
+		t.Errorf("total: got %v, want 3771 (sum of breakdown buckets)", got["total"])
 	}
 }
 
 func TestRecentHandler_EmptyResultIsNonNullArray(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: nil, count: 0}
+	store := &fakeRecentStore{apps: nil, breakdown: nil}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications")
 
@@ -303,7 +352,7 @@ func TestRecentHandler_EmptyResultIsNonNullArray(t *testing.T) {
 		t.Errorf("applications length: got %d, want 0", len(apps))
 	}
 	if got["total"].(float64) != 0 {
-		t.Errorf("total: got %v, want 0", got["total"])
+		t.Errorf("total: got %v, want 0 (empty breakdown sums to 0)", got["total"])
 	}
 	if got["areaName"] != "" {
 		t.Errorf("areaName: got %v, want empty when no applications", got["areaName"])
@@ -319,14 +368,14 @@ func TestRecentHandler_EmptyResultIsNonNullArray(t *testing.T) {
 
 func TestRecentHandler_NonIntIdReturns400(t *testing.T) {
 	t.Parallel()
-	store := &fakeRecentStore{apps: recentApps(t, 2), count: 2}
+	store := &fakeRecentStore{apps: recentApps(t, 2)}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/abc/applications")
 
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("non-int id: got %d, want 400", rec.Code)
 	}
-	if store.lastCap != 0 || store.countCalled {
+	if store.lastCap != 0 || store.breakdownCalled {
 		t.Errorf("store must not be hit on a malformed id")
 	}
 }
@@ -342,14 +391,15 @@ func TestRecentHandler_StoreErrorReturns500(t *testing.T) {
 	}
 }
 
-func TestRecentHandler_CountErrorReturns500(t *testing.T) {
+func TestRecentHandler_BreakdownErrorReturns500(t *testing.T) {
 	t.Parallel()
-	// The bounded read succeeds but the exact count fails -> 500 (no partial total).
-	store := &fakeRecentStore{apps: recentApps(t, 2), countErr: context.DeadlineExceeded}
+	// The bounded read succeeds but the whole-partition breakdown fails -> 500 (no
+	// partial total).
+	store := &fakeRecentStore{apps: recentApps(t, 2), breakdownErr: context.DeadlineExceeded}
 
 	rec := serveRecent(t, store, "buildkey", "buildkey", "/v1/authorities/471/applications")
 
 	if rec.Code != http.StatusInternalServerError {
-		t.Fatalf("count error: got %d, want 500", rec.Code)
+		t.Fatalf("breakdown error: got %d, want 500", rec.Code)
 	}
 }

--- a/api-go/internal/applications/result.go
+++ b/api-go/internal/applications/result.go
@@ -84,10 +84,12 @@ type NearbyResult struct {
 
 // RecentByAuthorityResult is the wire shape of the build-time SEO endpoint
 // GET /v1/authorities/{id}/applications. Applications is always a non-null array
-// (at most the request's limit). Total is the EXACT count of applications in the
-// authority partition (a separate index-only COUNT, not the bounded read length).
-// StatusBreakdown is the per-appState distribution over the bounded read (its
-// denominator is that read, not the whole partition), always a non-null array.
+// (at most the request's limit). Total is the EXACT whole-partition total: the
+// sum of the StatusBreakdown buckets, so the rendered "tracking N applications"
+// lead line always equals the breakdown. StatusBreakdown is the per-appState
+// distribution over the WHOLE authority partition (its denominator is the whole
+// partition, not the bounded read), computed by an index-served GROUP BY, always
+// a non-null array.
 type RecentByAuthorityResult struct {
 	AuthorityID     int                 `json:"authorityId"`
 	AreaName        string              `json:"areaName"`
@@ -147,20 +149,18 @@ func RecentApplicationOf(a PlanningApplication) RecentApplication {
 }
 
 // StateCount is one row of an appState breakdown: a nullable raw appState and how
-// many applications in the bounded read carried it. The appState is the RAW
-// PlanIt value (nil when absent), not a resident-facing label — the web owns that
-// mapping.
+// many applications carried it. The appState is the RAW PlanIt value (nil when
+// absent), not a resident-facing label — the web owns that mapping.
 type StateCount struct {
 	AppState *string `json:"appState"`
 	Count    int     `json:"count"`
 }
 
-// breakdownByState computes the per-appState distribution over the given bounded
-// read of applications. The denominator is the bounded read (at most the handler
-// cap), NOT the whole partition — appState is not indexed, so an exact
-// over-everything breakdown is out of scope. Keys are the RAW appState values; a
-// nil appState is a distinct bucket. The order is deterministic: count DESC, then
-// appState ASC, with nil sorting last.
+// breakdownByState computes the per-appState distribution over the GIVEN slice of
+// applications: the denominator is exactly the slice it is handed (e.g. the town
+// page's bounded read), not the whole partition. Keys are the RAW appState
+// values; a nil appState is a distinct bucket. The order is deterministic: count
+// DESC, then appState ASC, with nil sorting last.
 func breakdownByState(apps []PlanningApplication) []StateCount {
 	counts := make(map[string]int)
 	nilCount := 0
@@ -181,6 +181,15 @@ func breakdownByState(apps []PlanningApplication) []StateCount {
 		out = append(out, StateCount{AppState: nil, Count: nilCount})
 	}
 
+	sortStateCounts(out)
+	return out
+}
+
+// sortStateCounts orders a breakdown deterministically in place: count DESC, then
+// raw appState ASC, with the nil-appState bucket sorting last on a count tie. It
+// is the single comparator shared by breakdownByState (over a bounded slice) and
+// CosmosStore.BreakdownByAuthority (over a whole-partition GROUP BY).
+func sortStateCounts(out []StateCount) {
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Count != out[j].Count {
 			return out[i].Count > out[j].Count // count DESC
@@ -194,7 +203,6 @@ func breakdownByState(apps []PlanningApplication) []StateCount {
 		}
 		return *out[i].AppState < *out[j].AppState // appState ASC
 	})
-	return out
 }
 
 // NearbyResultOf maps a domain snapshot to the raw-domain wire shape.

--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -122,33 +122,65 @@ func (s *CosmosStore) RecentByAuthority(ctx context.Context, authorityCode strin
 	return apps, nil
 }
 
-// countByAuthorityQuery is the exact, index-only count of every application in a
-// single authorityCode partition. SELECT VALUE COUNT(1) hydrates no documents, so
-// it stays cheap even for an authority holding tens of thousands of rows, and it
-// returns the EXACT partition total — unlike the TOP-@cap bounded read, which
-// saturates at the cap. Cosmos returns a single row that is a bare JSON number.
-const countByAuthorityQuery = "SELECT VALUE COUNT(1) FROM c"
+// breakdownByAuthorityQuery is the exact, index-served per-appState distribution
+// over a single authorityCode partition. The GROUP BY is served by the appState
+// index, so it hydrates no documents and stays cheap (≈3 RU flat, regardless of
+// partition size), and the buckets sum to the EXACT partition total — unlike the
+// TOP-@cap bounded read, which saturates at the cap. Each row is a projection
+// {"appState": "...", "count": N}; Cosmos OMITS the appState property entirely
+// when the value is undefined, so a missing-appState bucket arrives without that
+// key (decoded as a nil *string), distinct from an explicit JSON null.
+const breakdownByAuthorityQuery = "SELECT c.appState, COUNT(1) AS count FROM c GROUP BY c.appState"
 
-// CountByAuthority returns the exact number of applications in the authorityCode
-// partition. It backs the build-time SEO endpoint's total: RecentByAuthority
-// renders the bounded list, this counts the whole partition. It runs on the
+// BreakdownByAuthority returns the per-appState distribution over the WHOLE
+// authorityCode partition, ordered count DESC then appState ASC with nil last
+// (sortStateCounts, the same comparator breakdownByState uses). It backs the
+// build-time SEO endpoint's status breakdown and total: RecentByAuthority renders
+// the bounded list, this spans the whole partition, and the handler sums these
+// buckets for the exact Total. A row whose appState is absent (Cosmos omits an
+// undefined projection) OR explicit JSON null folds into the single nil-*string
+// bucket, matching breakdownByState's nil semantics. It runs on the
 // latency-tolerant build-read budget (QueryItemsLongRead), like the sibling SEO
 // reads, and reads only from Cosmos (GH#395 Invariant 1) — never PlanIt.
-func (s *CosmosStore) CountByAuthority(ctx context.Context, authorityCode string) (int, error) {
+func (s *CosmosStore) BreakdownByAuthority(ctx context.Context, authorityCode string) ([]StateCount, error) {
 	// Latency-tolerant build-time read: a LARGE authority partition legitimately
 	// exceeds the 1.5s OLTP budget, so use the longer per-attempt budget (tc-9tov).
-	raws, err := s.items.QueryItemsLongRead(ctx, authorityCode, countByAuthorityQuery, nil)
+	raws, err := s.items.QueryItemsLongRead(ctx, authorityCode, breakdownByAuthorityQuery, nil)
 	if err != nil {
-		return 0, fmt.Errorf("count applications for authority %q: %w", authorityCode, err)
+		return nil, fmt.Errorf("status breakdown for authority %q: %w", authorityCode, err)
 	}
-	if len(raws) == 0 {
-		return 0, nil
+	// breakdownRow decodes a GROUP BY projection. AppState is a *string so an
+	// absent property (Cosmos omits undefined projections) and an explicit JSON
+	// null both decode to nil — folded into the single nil bucket below.
+	type breakdownRow struct {
+		AppState *string `json:"appState"`
+		Count    int     `json:"count"`
 	}
-	var total int
-	if err := json.Unmarshal(raws[0], &total); err != nil {
-		return 0, fmt.Errorf("decode application count for authority %q: %w", authorityCode, err)
+	counts := make(map[string]int)
+	nilCount := 0
+	for _, raw := range raws {
+		var row breakdownRow
+		if err := json.Unmarshal(raw, &row); err != nil {
+			return nil, fmt.Errorf("decode status breakdown row for authority %q: %w", authorityCode, err)
+		}
+		if row.AppState == nil {
+			nilCount += row.Count
+			continue
+		}
+		counts[*row.AppState] += row.Count
 	}
-	return total, nil
+
+	out := make([]StateCount, 0, len(counts)+1)
+	for state, n := range counts {
+		s := state
+		out = append(out, StateCount{AppState: &s, Count: n})
+	}
+	if nilCount > 0 {
+		out = append(out, StateCount{AppState: nil, Count: nilCount})
+	}
+
+	sortStateCounts(out)
+	return out, nil
 }
 
 // findNearbyQuery is the single-partition ST_DISTANCE spatial query for nearby

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -440,71 +440,149 @@ func TestCosmosStore_RecentNearby_EmptyResultIsEmptySlice(t *testing.T) {
 	}
 }
 
-func TestCosmosStore_CountByAuthority_DecodesScalarScopedToPartition(t *testing.T) {
+// breakdownRow marshals a single GROUP BY projection row. A nil state omits the
+// appState property entirely (Cosmos omits an undefined projection), modelling
+// the "missing" case; a non-nil state emits an explicit string. The explicit
+// JSON-null case is built inline by the test that needs it.
+func breakdownRow(t *testing.T, state *string, count int) []byte {
+	t.Helper()
+	row := map[string]any{"count": count}
+	if state != nil {
+		row["appState"] = *state
+	}
+	body, err := json.Marshal(row)
+	if err != nil {
+		t.Fatalf("marshal breakdown row: %v", err)
+	}
+	return body
+}
+
+func TestCosmosStore_BreakdownByAuthority_DecodesGroupByScopedToPartition(t *testing.T) {
 	t.Parallel()
 	items := newFakeItems()
-	// SELECT VALUE COUNT(1) returns a single row that is a bare JSON number.
-	items.queryResult = [][]byte{[]byte("42")}
+	// GROUP BY returns one row per appState: {"appState": "...", "count": N}.
+	items.queryResult = [][]byte{
+		breakdownRow(t, strPtr("Permitted"), 2100),
+		breakdownRow(t, strPtr("Rejected"), 900),
+	}
 	store := NewCosmosStore(items)
 
-	got, err := store.CountByAuthority(context.Background(), "471")
+	got, err := store.BreakdownByAuthority(context.Background(), "471")
 	if err != nil {
-		t.Fatalf("CountByAuthority: %v", err)
+		t.Fatalf("BreakdownByAuthority: %v", err)
 	}
-	if got != 42 {
-		t.Errorf("count: got %d, want 42", got)
+	want := []StateCount{
+		{AppState: strPtr("Permitted"), Count: 2100},
+		{AppState: strPtr("Rejected"), Count: 900},
 	}
+	assertBreakdownEqual(t, got, want)
 	// Scoped to the authorityCode logical partition (never cross-partition).
 	if items.lastQueryPK != "471" {
 		t.Errorf("query partition key: got %q, want \"471\"", items.lastQueryPK)
 	}
-	// Index-only scalar count over the whole partition — no TOP @cap (that would
-	// saturate the total), no ordering.
-	want := "SELECT VALUE COUNT(1) FROM c"
-	if items.lastQuery != want {
-		t.Errorf("count query:\n got %q\nwant %q", items.lastQuery, want)
+	// Index-served GROUP BY over the whole partition — no TOP @cap (that would
+	// saturate the total).
+	wantQuery := "SELECT c.appState, COUNT(1) AS count FROM c GROUP BY c.appState"
+	if items.lastQuery != wantQuery {
+		t.Errorf("breakdown query:\n got %q\nwant %q", items.lastQuery, wantQuery)
 	}
 	if _, ok := items.lastQueryParams["@cap"]; ok {
-		t.Errorf("count query must not bind @cap (it counts the whole partition): %v", items.lastQueryParams)
+		t.Errorf("breakdown query must not bind @cap (it spans the whole partition): %v", items.lastQueryParams)
 	}
 }
 
-func TestCosmosStore_CountByAuthority_EmptyResultIsZero(t *testing.T) {
-	t.Parallel()
-	// No rows at all (defensive): an empty result set yields 0, not an error.
-	store := NewCosmosStore(newFakeItems())
-
-	got, err := store.CountByAuthority(context.Background(), "471")
-	if err != nil {
-		t.Fatalf("CountByAuthority: %v", err)
-	}
-	if got != 0 {
-		t.Errorf("count: got %d, want 0", got)
-	}
-}
-
-func TestCosmosStore_CountByAuthority_UsesLongReadBudget(t *testing.T) {
+func TestCosmosStore_BreakdownByAuthority_OrdersCountDescStateAscNilLast(t *testing.T) {
 	t.Parallel()
 	items := newFakeItems()
-	items.queryResult = [][]byte{[]byte("3")}
+	// Deliberately unsorted, with a tie (Permitted vs Rejected both 5) and a nil
+	// bucket tying on count too, to prove the deterministic ordering.
+	items.queryResult = [][]byte{
+		breakdownRow(t, strPtr("Rejected"), 5),
+		breakdownRow(t, nil, 5),
+		breakdownRow(t, strPtr("Conditions"), 9),
+		breakdownRow(t, strPtr("Permitted"), 5),
+	}
 	store := NewCosmosStore(items)
 
-	if _, err := store.CountByAuthority(context.Background(), "156"); err != nil {
-		t.Fatalf("CountByAuthority: %v", err)
+	got, err := store.BreakdownByAuthority(context.Background(), "471")
+	if err != nil {
+		t.Fatalf("BreakdownByAuthority: %v", err)
 	}
-	if !items.lastQueryViaLongRead {
-		t.Error("CountByAuthority must use the long-read budget (QueryItemsLongRead), not the 1.5s OLTP QueryItems")
+	// count DESC primary; on the 5-way tie, appState ASC then nil last.
+	want := []StateCount{
+		{AppState: strPtr("Conditions"), Count: 9},
+		{AppState: strPtr("Permitted"), Count: 5},
+		{AppState: strPtr("Rejected"), Count: 5},
+		{AppState: nil, Count: 5},
+	}
+	assertBreakdownEqual(t, got, want)
+}
+
+func TestCosmosStore_BreakdownByAuthority_MissingAndNullAppStateFoldIntoOneNilBucket(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	// One row omits appState (absent projection); a separate row carries explicit
+	// JSON null. Both must merge into the SINGLE nil bucket, matching
+	// breakdownByState's nil semantics.
+	items.queryResult = [][]byte{
+		breakdownRow(t, nil, 30),                  // appState absent
+		[]byte(`{"appState": null, "count": 12}`), // appState explicit null
+		breakdownRow(t, strPtr("Permitted"), 100),
+	}
+	store := NewCosmosStore(items)
+
+	got, err := store.BreakdownByAuthority(context.Background(), "471")
+	if err != nil {
+		t.Fatalf("BreakdownByAuthority: %v", err)
+	}
+	// 30 + 12 = 42 fold into one nil bucket; Permitted (100) outranks it.
+	want := []StateCount{
+		{AppState: strPtr("Permitted"), Count: 100},
+		{AppState: nil, Count: 42},
+	}
+	assertBreakdownEqual(t, got, want)
+}
+
+func TestCosmosStore_BreakdownByAuthority_EmptyPartitionIsEmptySlice(t *testing.T) {
+	t.Parallel()
+	// No rows at all (empty partition): an empty result set yields an empty
+	// non-nil slice, not an error.
+	store := NewCosmosStore(newFakeItems())
+
+	got, err := store.BreakdownByAuthority(context.Background(), "471")
+	if err != nil {
+		t.Fatalf("BreakdownByAuthority: %v", err)
+	}
+	if got == nil {
+		t.Fatal("BreakdownByAuthority: got nil slice, want empty non-nil slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("BreakdownByAuthority: got %d entries, want 0", len(got))
 	}
 }
 
-func TestCosmosStore_CountByAuthority_PropagatesQueryError(t *testing.T) {
+func TestCosmosStore_BreakdownByAuthority_UsesLongReadBudget(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	items.queryResult = [][]byte{breakdownRow(t, strPtr("Permitted"), 3)}
+	store := NewCosmosStore(items)
+
+	if _, err := store.BreakdownByAuthority(context.Background(), "156"); err != nil {
+		t.Fatalf("BreakdownByAuthority: %v", err)
+	}
+	if !items.lastQueryViaLongRead {
+		t.Error("BreakdownByAuthority must use the long-read budget (QueryItemsLongRead), not the 1.5s OLTP QueryItems")
+	}
+}
+
+func TestCosmosStore_BreakdownByAuthority_PropagatesQueryError(t *testing.T) {
 	t.Parallel()
 	items := newFakeItems()
 	items.queryErr = context.DeadlineExceeded
 	store := NewCosmosStore(items)
 
-	if _, err := store.CountByAuthority(context.Background(), "471"); err == nil {
-		t.Fatal("CountByAuthority: expected error, got nil")
+	if _, err := store.BreakdownByAuthority(context.Background(), "471"); err == nil {
+		t.Fatal("BreakdownByAuthority: expected error, got nil")
 	}
 }
 

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import { renderApplicationsList } from '../render-shared.mjs';
+
+const PLANIT_CAPTION = 'View full record on PlanIt';
+const COUNCIL_CAPTION = 'View on the council website';
+
+const PLANIT_HREF = 'https://planit.org.uk/planapplic/26-0001-FUL';
+const COUNCIL_HREF = 'https://www.basingstoke.gov.uk/planning/26-0001-FUL';
+
+/**
+ * @param {Partial<import('../render-shared.mjs').PlanningApplicationItem>} [overrides]
+ * @returns {import('../render-shared.mjs').PlanningApplicationItem}
+ */
+function application(overrides = {}) {
+  return {
+    uid: 'BDB/2026/0001',
+    name: '26/0001/FUL',
+    address: '12 Mill Road, Basingstoke, RG21 1AA',
+    description: 'Erection of two-storey rear extension',
+    appState: 'Permitted',
+    startDate: '2026-01-15',
+    lastDifferent: '2026-06-12T09:30:00+00:00',
+    link: PLANIT_HREF,
+    url: COUNCIL_HREF,
+    ...overrides,
+  };
+}
+
+/**
+ * Extract the caption (anchor text) for the `appLink` whose href matches `href`.
+ *
+ * @param {string} html
+ * @param {string} href
+ * @returns {string | null}
+ */
+function captionForHref(html, href) {
+  const escaped = href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = html.match(
+    new RegExp(`<a class="appLink" href="${escaped}"[^>]*>([^<]*)</a>`),
+  );
+  return match ? match[1] : null;
+}
+
+describe('renderApplicationsList per-application links', () => {
+  it('captions the PlanIt permalink and the council website honestly when both are present', () => {
+    const html = renderApplicationsList([application()]);
+
+    // The PlanIt permalink (app.link) is captioned for PlanIt.
+    expect(captionForHref(html, PLANIT_HREF)).toBe(PLANIT_CAPTION);
+    // The council website (app.url) is captioned for the council site.
+    expect(captionForHref(html, COUNCIL_HREF)).toBe(COUNCIL_CAPTION);
+
+    // And the now-retired dishonest captions are gone.
+    expect(html).not.toContain('View on the council portal');
+    expect(html).not.toContain('Application details');
+  });
+
+  it('emits only the PlanIt caption when only link is present', () => {
+    const html = renderApplicationsList([application({ url: null })]);
+
+    expect(html).toContain(PLANIT_CAPTION);
+    expect(captionForHref(html, PLANIT_HREF)).toBe(PLANIT_CAPTION);
+    expect(html).not.toContain(COUNCIL_CAPTION);
+  });
+
+  it('emits only the council caption when only url is present', () => {
+    const html = renderApplicationsList([application({ link: null })]);
+
+    expect(html).toContain(COUNCIL_CAPTION);
+    expect(captionForHref(html, COUNCIL_HREF)).toBe(COUNCIL_CAPTION);
+    expect(html).not.toContain(PLANIT_CAPTION);
+  });
+
+  it('emits no appLink anchors when neither link nor url is present', () => {
+    const html = renderApplicationsList([
+      application({ link: null, url: null }),
+    ]);
+
+    expect(html).not.toContain('class="appLink"');
+    expect(html).not.toContain(PLANIT_CAPTION);
+    expect(html).not.toContain(COUNCIL_CAPTION);
+  });
+
+  it('keeps the link safety attributes on each anchor', () => {
+    const html = renderApplicationsList([application()]);
+    const anchors = html.match(/<a class="appLink"[^>]*>/g) ?? [];
+    expect(anchors).toHaveLength(2);
+    for (const anchor of anchors) {
+      expect(anchor).toContain('rel="nofollow noopener"');
+      expect(anchor).toContain('target="_blank"');
+    }
+  });
+});

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -27,8 +27,8 @@ import {
  * @property {string | null} appState
  * @property {string | null} startDate      yyyy-MM-dd
  * @property {string} lastDifferent         ISO-8601 with offset; the DESC sort key
- * @property {string | null} link           council-portal deep link
- * @property {string | null} url            application detail link
+ * @property {string | null} link           PlanIt permalink (always a reliable per-application record)
+ * @property {string | null} url            council website (may be a generic portal page, not always a per-application deep link)
  */
 
 const MAX_DESCRIPTION_LENGTH = 160;
@@ -67,12 +67,12 @@ function renderApplication(app) {
   const links = [];
   if (app.link) {
     links.push(
-      `<a class="appLink" href="${escapeHtml(app.link)}" rel="nofollow noopener" target="_blank">View on the council portal</a>`,
+      `<a class="appLink" href="${escapeHtml(app.link)}" rel="nofollow noopener" target="_blank">View full record on PlanIt</a>`,
     );
   }
   if (app.url) {
     links.push(
-      `<a class="appLink" href="${escapeHtml(app.url)}" rel="nofollow noopener" target="_blank">Application details</a>`,
+      `<a class="appLink" href="${escapeHtml(app.url)}" rel="nofollow noopener" target="_blank">View on the council website</a>`,
     );
   }
 


### PR DESCRIPTION
## What

Two fixes to the programmatic SEO planning pages (authority + town), both Cosmos-only (no PlanIt — GH#395 Inv1), backend + static-prerender only.

### tc-4set — authority status breakdown spans the whole partition (Go)
The authority page lead line shows the exact whole-partition count (e.g. "tracking 3771 planning applications") but the "Status breakdown" only summed to ~200, because it was computed in-process from the bounded 200-doc read.

- `store_cosmos.go`: new `BreakdownByAuthority` running `SELECT c.appState, COUNT(1) AS count FROM c GROUP BY c.appState` on the long-read budget (index-served, ~3 RU flat — measured on dev, replaces the old ~3 RU COUNT, net-neutral). Absent + explicit-null `appState` fold into one nil bucket; deterministic order (count DESC, appState ASC, nil last) via a shared `sortStateCounts`. Deleted the now-unused `CountByAuthority` + its query.
- `recent.go`: `recentStore` swaps `CountByAuthority` for `BreakdownByAuthority`; the handler now sets `statusBreakdown` to the whole-partition distribution and `total` to the sum of those buckets.
- `result.go`: corrected the docs (removed the false "appState not indexed" claim); `breakdownByState` is retained for the town page (still bounded-read, pending tc-qmlo).

### tc-wwm8 — honest per-application link captions (web)
The two outbound links per application card had inverted, dishonest captions.

- `app.link` (the planit.org.uk permalink, always reliable) → **"View full record on PlanIt"** (was "View on the council portal").
- `app.url` (the council's own site, often a generic portal page) → **"View on the council website"** (was "Application details", which over-promised a per-app deep link).
- Both links kept (outbound citations to the authoritative source help SEO / avoid thin-doorway content); conditional per-field render and `rel="nofollow noopener"` unchanged. JSDoc refreshed.

## Testing
- Go: `go build`/`vet` clean, `gofmt` clean, `go test -race ./...` 1068 pass, `golangci-lint` 0 issues.
- Web: `tsc --noEmit` clean, `vitest` 785 pass (new `render-shared.test.mjs` covers all four conditional-render cases + caption→destination mapping).

## Not in this PR
- **tc-qmlo** (town/spatial `GROUP BY`) is deferred: its gate requires a dev Cosmos data-plane RU measurement that can't be obtained autonomously (managed-identity-only auth; local AAD data-plane 403s). Shipping an unmeasured spatial `GROUP BY` is exactly the risk the gate guards, so `near.go` is unchanged. See the bead for the exact dev-only Data Explorer measurement and conversion plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)