### PR TITLE
feat(web): prerender population threshold via SEO_TOWN_MIN_POPULATION (tc-2avw.3)

### DIFF
--- a/web/scripts/lib/__tests__/prerender-towns.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-towns.test.mjs
@@ -127,8 +127,17 @@ describe('runPrerender — sitemap with authority and town pages', () => {
 });
 
 describe('runPrerender — town live mode', () => {
+  // population well above the default 20000 threshold so these tests isolate the
+  // geo/coverage pipeline (tc-2avw.3's population gate is exercised separately).
   const cornwallTowns = [
-    { slug: 'truro', name: 'Truro', lat: 50.2632, lng: -5.051, authorityId: 52 },
+    {
+      slug: 'truro',
+      name: 'Truro',
+      lat: 50.2632,
+      lng: -5.051,
+      authorityId: 52,
+      population: 25000,
+    },
   ];
   // areaType is deliberately non-qualifying here so the authority pass is a
   // no-op and these tests isolate the TOWN pipeline. Slug resolution
@@ -626,6 +635,9 @@ describe('runPrerender — per-town integration spine (one authority, end to end
       apiBase: 'https://api-dev.towncrierapp.uk',
       buildKey: 'test-key',
       fetchImpl: stub.fetch,
+      // Admit the pop-18766 spine town past tc-2avw.3's population gate (default
+      // 20000) so this end-to-end test still exercises fetch -> gate -> write.
+      env: { SEO_TOWN_MIN_POPULATION: '5000' },
       loadAuthorities: async () => cornwallAuthorities,
       loadTowns: async () => towns,
       logger: silentLogger,

--- a/web/scripts/lib/__tests__/prerender-towns.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-towns.test.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 import {
   runPrerender,
   loadTownsFromFile,
+  resolveMinPopulation,
 } from '../../prerender-planning.mjs';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -307,6 +308,244 @@ describe('runPrerender — town live mode', () => {
         logger: silentLogger,
       }),
     ).rejects.toThrow();
+  });
+});
+
+// resolveMinPopulation (tc-2avw.3): the build-time published-population gate is a
+// config value read from SEO_TOWN_MIN_POPULATION, defaulting to 20000 when the
+// var is missing, empty, or not a positive finite integer.
+describe('resolveMinPopulation', () => {
+  it('defaults to 20000 when the env var is unset', () => {
+    expect(resolveMinPopulation({})).toBe(20000);
+  });
+
+  it('defaults to 20000 when the env var is an empty string', () => {
+    expect(resolveMinPopulation({ SEO_TOWN_MIN_POPULATION: '' })).toBe(20000);
+  });
+
+  it('defaults to 20000 when the env var is whitespace only', () => {
+    expect(resolveMinPopulation({ SEO_TOWN_MIN_POPULATION: '   ' })).toBe(20000);
+  });
+
+  it('defaults to 20000 when the env var is non-numeric', () => {
+    expect(resolveMinPopulation({ SEO_TOWN_MIN_POPULATION: 'lots' })).toBe(20000);
+  });
+
+  it('defaults to 20000 when the env var is zero or negative', () => {
+    expect(resolveMinPopulation({ SEO_TOWN_MIN_POPULATION: '0' })).toBe(20000);
+    expect(resolveMinPopulation({ SEO_TOWN_MIN_POPULATION: '-5000' })).toBe(20000);
+  });
+
+  it('reads a valid custom positive integer', () => {
+    expect(resolveMinPopulation({ SEO_TOWN_MIN_POPULATION: '5000' })).toBe(5000);
+  });
+
+  it('truncates a fractional value to its integer part', () => {
+    expect(resolveMinPopulation({ SEO_TOWN_MIN_POPULATION: '12345.9' })).toBe(
+      12345,
+    );
+  });
+});
+
+// Population threshold filter (tc-2avw.3): the live prerender publishes a town
+// only if its population >= the resolved threshold, applied BEFORE the per-town
+// geo fetch so below-threshold towns never hit the API. The >=10 coverage gate
+// still applies on top.
+describe('runPrerender — population threshold filter (live mode)', () => {
+  const cornwallAuthorities = [
+    { id: 52, name: 'Cornwall', areaType: 'English County' },
+  ];
+
+  /** A geo stub that always clears the >=10 coverage gate. */
+  function gatePassingStub() {
+    return new StubFetch((url) => {
+      if (url.includes('/v1/applications/near')) {
+        return {
+          ok: true,
+          status: 200,
+          body: {
+            authorityId: 52,
+            lat: 50.2632,
+            lng: -5.051,
+            radius: 5000,
+            applications: [
+              {
+                uid: 'CW1',
+                name: 'PA26/0001',
+                address: 'Lemon Quay, Truro',
+                description: 'Café conversion',
+                appState: 'Permitted',
+                startDate: '2026-01-12',
+                lastDifferent: '2026-06-12T10:00:00+00:00',
+                link: 'https://planit.org.uk/planapplic/CW1',
+                url: null,
+              },
+            ],
+            total: 14,
+            statusBreakdown: [{ appState: 'Permitted', count: 14 }],
+          },
+        };
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+  }
+
+  it('publishes a town above the default 20000 threshold', async () => {
+    const stub = gatePassingStub();
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      env: {},
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => [
+        {
+          slug: 'truro',
+          name: 'Truro',
+          lat: 50.2632,
+          lng: -5.051,
+          authorityId: 52,
+          population: 25000,
+        },
+      ],
+      logger: silentLogger,
+    });
+
+    expect(result.publishedTowns).toEqual(['cornwall/truro']);
+  });
+
+  it('publishes a town exactly at the threshold (>= is inclusive)', async () => {
+    const stub = gatePassingStub();
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      env: {},
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => [
+        {
+          slug: 'truro',
+          name: 'Truro',
+          lat: 50.2632,
+          lng: -5.051,
+          authorityId: 52,
+          population: 20000,
+        },
+      ],
+      logger: silentLogger,
+    });
+
+    expect(result.publishedTowns).toEqual(['cornwall/truro']);
+  });
+
+  it('excludes a below-threshold town with reason "population" and never fetches it', async () => {
+    const stub = new StubFetch(() => {
+      throw new Error('below-threshold town must not hit the geo endpoint');
+    });
+
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      env: {},
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => [
+        {
+          slug: 'truro',
+          name: 'Truro',
+          lat: 50.2632,
+          lng: -5.051,
+          authorityId: 52,
+          population: 18766,
+        },
+      ],
+      logger: silentLogger,
+    });
+
+    expect(result.publishedTowns).toEqual([]);
+    expect(result.excludedTowns).toContainEqual({
+      name: 'Truro',
+      reason: 'population',
+    });
+    expect(await exists(join(outDir, 'planning', 'cornwall', 'truro'))).toBe(
+      false,
+    );
+    // The whole point: no geo call is made for an excluded town.
+    expect(stub.calls).toHaveLength(0);
+  });
+
+  it('a custom SEO_TOWN_MIN_POPULATION changes the cut', async () => {
+    const stub = gatePassingStub();
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      env: { SEO_TOWN_MIN_POPULATION: '5000' },
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => [
+        {
+          slug: 'truro',
+          name: 'Truro',
+          lat: 50.2632,
+          lng: -5.051,
+          authorityId: 52,
+          // 18766 < default 20000 (would be excluded) but >= the custom 5000.
+          population: 18766,
+        },
+      ],
+      logger: silentLogger,
+    });
+
+    expect(result.publishedTowns).toEqual(['cornwall/truro']);
+  });
+
+  it('still excludes an above-threshold town that fails the coverage gate', async () => {
+    const stub = new StubFetch(() => ({
+      ok: true,
+      status: 200,
+      body: {
+        authorityId: 52,
+        lat: 50.2632,
+        lng: -5.051,
+        radius: 5000,
+        applications: [],
+        total: 3,
+        statusBreakdown: [],
+      },
+    }));
+
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      env: {},
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => [
+        {
+          slug: 'truro',
+          name: 'Truro',
+          lat: 50.2632,
+          lng: -5.051,
+          authorityId: 52,
+          population: 25000,
+        },
+      ],
+      logger: silentLogger,
+    });
+
+    expect(result.publishedTowns).toEqual([]);
+    // It passed the population gate (so it WAS fetched) but the coverage gate
+    // excluded it — reason "coverage", not "population".
+    expect(result.excludedTowns).toContainEqual({
+      name: 'Truro',
+      reason: 'coverage',
+    });
+    expect(stub.calls).toHaveLength(1);
   });
 });
 

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -35,8 +35,41 @@ import { renderSitemap } from './lib/render-sitemap.mjs';
 
 const DEFAULT_LIMIT = 30;
 
+/**
+ * Default published-population threshold when `SEO_TOWN_MIN_POPULATION` is unset,
+ * empty, or not a positive finite integer. A town ships only if its built-up-area
+ * population is at least this value (the ≥10 in-radius coverage gate applies on
+ * top). The threshold is a build-time config knob so coverage can be ramped by
+ * bumping the variable and rebuilding — no gazetteer regeneration.
+ *
+ * @type {number}
+ */
+export const DEFAULT_MIN_POPULATION = 20000;
+
 /** Directory containing this script (`web/scripts`), independent of cwd. */
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Resolve the build-time town population threshold from the environment.
+ * Reads `SEO_TOWN_MIN_POPULATION` and parses it to a positive finite integer,
+ * falling back to {@link DEFAULT_MIN_POPULATION} when the value is missing,
+ * empty/whitespace, non-numeric, or not strictly positive. A fractional value is
+ * truncated toward zero (so "12345.9" -> 12345).
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {number} the resolved minimum population (always a positive integer)
+ */
+export function resolveMinPopulation(env = {}) {
+  const raw = env.SEO_TOWN_MIN_POPULATION;
+  if (typeof raw !== 'string' || raw.trim().length === 0) {
+    return DEFAULT_MIN_POPULATION;
+  }
+  const parsed = Number.parseInt(raw.trim(), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_MIN_POPULATION;
+  }
+  return parsed;
+}
 
 /**
  * The authority list is static, public, committed data — read it from the repo
@@ -576,6 +609,7 @@ async function runFixtureMode(args) {
  * @param {string} args.apiBase
  * @param {string} args.buildKey
  * @param {number} args.limit
+ * @param {number} args.minPopulation
  * @param {typeof globalThis.fetch} args.fetchImpl
  * @param {() => Promise<Array<{ id: number, name: string, areaType: string }>>} args.loadAuthorities
  * @param {() => Promise<Town[]>} args.loadTowns
@@ -588,6 +622,7 @@ async function runLiveMode(args) {
     apiBase,
     buildKey,
     limit,
+    minPopulation,
     fetchImpl,
     loadAuthorities,
     loadTowns,
@@ -634,14 +669,33 @@ async function runLiveMode(args) {
   // Town pages: one bounded geo read per town, scoped to its authority partition
   // and centroid. Reuses the same authority list (no extra HTTP) to resolve slugs.
   const towns = await loadTowns();
+
+  // Population threshold gate, applied BEFORE the per-town geo fetch so that
+  // below-threshold towns never even hit the API. The threshold is a build-time
+  // config value (SEO_TOWN_MIN_POPULATION, default 20000); ramping coverage means
+  // bumping the variable and rebuilding — no gazetteer regeneration. The ≥10
+  // in-radius coverage gate (inside `considerTown`) still applies on top.
+  /** @type {Town[]} */
+  const eligibleTowns = [];
+  /** @type {Array<{ name: string, reason: string }>} */
+  const populationExcludedTowns = [];
+  for (const town of towns) {
+    if (town.population >= minPopulation) {
+      eligibleTowns.push(town);
+    } else {
+      populationExcludedTowns.push({ name: town.name, reason: 'population' });
+    }
+  }
+
   const { publishedTowns, excludedTowns } = await renderTownPages({
     outDir,
-    towns,
+    towns: eligibleTowns,
     authorities,
     getGeo: (town) => fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl),
     limit,
     logger,
   });
+  excludedTowns.push(...populationExcludedTowns);
 
   await writeFile(
     join(outDir, 'sitemap.xml'),
@@ -661,6 +715,7 @@ async function runLiveMode(args) {
  * @param {string} [options.fixturePath]           committed authority JSON fixture (fixture mode)
  * @param {string} [options.townFixturePath]       committed town JSON fixture (fixture mode)
  * @param {number} [options.limit]                 applications rendered per page
+ * @param {Record<string, string | undefined>} [options.env]  environment (for SEO_TOWN_MIN_POPULATION)
  * @param {typeof globalThis.fetch} [options.fetchImpl]
  * @param {() => Promise<Array<{ id: number, name: string, areaType: string }>>} [options.loadAuthorities]
  * @param {() => Promise<Town[]>} [options.loadTowns]
@@ -675,6 +730,7 @@ export async function runPrerender(options) {
     fixturePath,
     townFixturePath,
     limit = DEFAULT_LIMIT,
+    env = process.env,
     fetchImpl = globalThis.fetch,
     loadAuthorities = () => loadAuthoritiesFromFile(AUTHORITIES_FILE, readFile),
     loadTowns = () => loadTownsFromFile(TOWNS_FILE, readFile),
@@ -714,6 +770,7 @@ export async function runPrerender(options) {
     apiBase: trimTrailingSlash(apiBase),
     buildKey,
     limit,
+    minPopulation: resolveMinPopulation(env),
     fetchImpl,
     loadAuthorities,
     loadTowns,


### PR DESCRIPTION
## What

Adds a build-time population threshold to the per-town SEO prerender (`web/scripts/prerender-planning.mjs`). A town now publishes only if its built-up-area `population >= SEO_TOWN_MIN_POPULATION` **and** it still clears the existing ≥10 in-radius coverage gate. Both must pass.

Implements bead `tc-2avw.3` (part of SEO Phase 2 epic `tc-2avw`, GH #585).

## Changes

- **`resolveMinPopulation(env)`** — new exported helper. Reads `env.SEO_TOWN_MIN_POPULATION`, parses to a positive finite integer, and falls back to the default `20000` on missing / empty / whitespace / non-numeric / non-positive values. Fractional values truncate toward zero. Kept small and exported so it is unit-testable.
- **Population filter in `runLiveMode`** — applied to the loaded gazetteer **before** the per-town `near` fetch, so below-threshold towns never hit the API. A below-threshold town is recorded as `excludedTowns.push({ name, reason: 'population' })`, mirroring the existing coverage-gate exclusion pattern. The ≥10 `meetsCoverageGate` still runs on top inside `considerTown`.
- **`env` option on `runPrerender`** — defaults to `process.env`, so the CLI `main()` path reads the real environment; tests inject a fake `env`.

## Tests (Vitest, hand-written fakes only)

In `web/scripts/lib/__tests__/prerender-towns.test.mjs`:
- `resolveMinPopulation`: default when unset / empty / whitespace / non-numeric / zero-or-negative; valid custom integer; fractional truncation.
- Live-mode filter: above-threshold publishes; at threshold (`==`) publishes (`>=` is inclusive); below threshold is excluded with reason `population` **and is not fetched** (asserts zero geo calls); a custom `SEO_TOWN_MIN_POPULATION=5000` changes the cut; an above-threshold town still excluded by the coverage gate (reason `coverage`, and it *was* fetched).

## Scope

Only `web/scripts/prerender-planning.mjs` and its test changed. Does **not** touch `render-town-page.mjs`, `render-sitemap.mjs`, `generate-towns.mjs`, `towns.json`, or `seo-refresh.yml` (sibling beads tc-2avw.4/.5/.6). This bead only makes the prerender *read* the env var; CI wiring of the repo variable is tc-2avw.6.

## Gates

`npx tsc --noEmit` clean · `npm run build` succeeds (prerender skips cleanly with no build key) · `npx eslint .` clean · `npx vitest run` 796 passed (101 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xL4oCpLWWGhqV6fmsfEXy