### PR TITLE
feat(web): sitemap content-derived <lastmod> + town renderer (distance-display, ONS/NRS attribution) (tc-2avw.4)

### DIFF
--- a/web/scripts/lib/__tests__/prerender-towns.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-towns.test.mjs
@@ -124,6 +124,21 @@ describe('runPrerender — sitemap with authority and town pages', () => {
       '<loc>https://towncrierapp.uk/planning/cornwall/truro</loc>',
     );
   });
+
+  it('stamps the town sitemap <lastmod> with the max lastDifferent of its shown applications', async () => {
+    await runPrerender({
+      outDir,
+      townFixturePath: TOWN_FIXTURE,
+      logger: silentLogger,
+    });
+
+    const sitemap = await readFile(join(outDir, 'sitemap.xml'), 'utf-8');
+    // Truro's shown apps last-change on 14 Jun and 11 Jun 2026; the page's
+    // lastmod is the freshest of those (14 Jun), not the build clock.
+    expect(sitemap).toContain('<lastmod>2026-06-14</lastmod>');
+    expect(sitemap).not.toContain('<lastmod>2026-06-11</lastmod>');
+    expect(sitemap).not.toContain('<lastmod></lastmod>');
+  });
 });
 
 describe('runPrerender — town live mode', () => {
@@ -205,6 +220,131 @@ describe('runPrerender — town live mode', () => {
       'utf-8',
     );
     expect(html).toContain('<h1>Planning applications in Truro</h1>');
+  });
+
+  it('displays the distance-ordered set newest-first, regardless of the order the API returned', async () => {
+    // The build requests order=distance, so the API returns the nearest-N — NOT
+    // recency-ordered. Here the nearest app (CW-NEAR) is the OLDEST and a farther
+    // app (CW-FAR) is the NEWEST, so a recency display MUST reorder them.
+    const stub = new StubFetch((url) => {
+      if (url.includes('/v1/applications/near')) {
+        return {
+          ok: true,
+          status: 200,
+          body: {
+            authorityId: 52,
+            lat: 50.2632,
+            lng: -5.051,
+            radius: 5000,
+            applications: [
+              {
+                uid: 'CW-NEAR',
+                name: 'PA26/NEAR',
+                address: 'Nearest, Truro',
+                description: 'Closest by distance but oldest change',
+                appState: 'Permitted',
+                startDate: '2026-01-01',
+                lastDifferent: '2026-06-01T08:00:00+00:00',
+                link: 'https://planit.org.uk/planapplic/CW-NEAR',
+                url: null,
+              },
+              {
+                uid: 'CW-FAR',
+                name: 'PA26/FAR',
+                address: 'Farther, Truro',
+                description: 'Farther by distance but freshest change',
+                appState: 'Rejected',
+                startDate: '2026-02-02',
+                lastDifferent: '2026-06-20T09:00:00+00:00',
+                link: 'https://planit.org.uk/planapplic/CW-FAR',
+                url: null,
+              },
+            ],
+            total: 14,
+            statusBreakdown: [{ appState: 'Permitted', count: 14 }],
+          },
+        };
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+
+    await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => cornwallTowns,
+      logger: silentLogger,
+    });
+
+    const html = await readFile(
+      join(outDir, 'planning', 'cornwall', 'truro', 'index.html'),
+      'utf-8',
+    );
+    // The freshest card (20 Jun) appears BEFORE the oldest (1 Jun) — recency DESC,
+    // even though the API fed them distance-order (oldest first).
+    expect(html).toContain('Last updated 20 Jun 2026');
+    expect(html).toContain('Last updated 1 Jun 2026');
+    expect(html.indexOf('Last updated 20 Jun 2026')).toBeLessThan(
+      html.indexOf('Last updated 1 Jun 2026'),
+    );
+
+    // The page's sitemap lastmod is the freshest shown app (20 Jun), proving the
+    // lastmod is derived AFTER the recency sort and matches what the cards show.
+    const sitemap = await readFile(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain('<lastmod>2026-06-20</lastmod>');
+  });
+
+  it('omits the town sitemap <lastmod> when no shown application carries a lastDifferent date', async () => {
+    const stub = new StubFetch((url) => {
+      if (url.includes('/v1/applications/near')) {
+        return {
+          ok: true,
+          status: 200,
+          body: {
+            authorityId: 52,
+            lat: 50.2632,
+            lng: -5.051,
+            radius: 5000,
+            // 12 undated apps: clears the >=10 gate but has no date to stamp.
+            applications: Array.from({ length: 12 }, (_, i) => ({
+              uid: `U${i}`,
+              name: `PA26/${i}`,
+              address: `Addr ${i}, Truro`,
+              description: 'Undated',
+              appState: 'Permitted',
+              startDate: null,
+              lastDifferent: null,
+              link: null,
+              url: null,
+            })),
+            total: 12,
+            statusBreakdown: [{ appState: 'Permitted', count: 12 }],
+          },
+        };
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+
+    const result = await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => cornwallTowns,
+      logger: silentLogger,
+    });
+
+    // The page IS published (cleared the gate) ...
+    expect(result.publishedTowns).toEqual(['cornwall/truro']);
+    const sitemap = await readFile(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain(
+      '<loc>https://towncrierapp.uk/planning/cornwall/truro</loc>',
+    );
+    // ... but carries no lastmod — better than an invalid/empty one.
+    expect(sitemap).not.toContain('<lastmod>');
   });
 
   it('excludes a town that fails the coverage gate', async () => {

--- a/web/scripts/lib/__tests__/prerender.test.mjs
+++ b/web/scripts/lib/__tests__/prerender.test.mjs
@@ -98,6 +98,17 @@ describe('runPrerender — fixture mode', () => {
     );
     expect(sitemap).not.toContain('west-sussex');
   });
+
+  it('stamps the authority sitemap <lastmod> with the max lastDifferent of its shown applications', async () => {
+    await runPrerender({ outDir, fixturePath: FIXTURE, logger: silentLogger });
+    const sitemap = await readFile(join(outDir, 'sitemap.xml'), 'utf-8');
+    // Basingstoke's three shown apps last-change on 15/12/09 Jun 2026; the page's
+    // lastmod is the freshest of those (15 Jun), not the build clock.
+    expect(sitemap).toContain('<lastmod>2026-06-15</lastmod>');
+    // Never the older two dates and never an empty tag.
+    expect(sitemap).not.toContain('<lastmod>2026-06-12</lastmod>');
+    expect(sitemap).not.toContain('<lastmod></lastmod>');
+  });
 });
 
 describe('runPrerender — no key, no fixture', () => {

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -166,6 +166,14 @@ describe('renderPlanningPage', () => {
     expect(html).toContain('OpenStreetMap');
   });
 
+  it('does NOT carry the town-only ONS Built-Up-Area / NRS gazetteer credit', () => {
+    // Authority pages are not positioned from the BUA/NRS centroid gazetteer, so
+    // they keep the base attribution and must not pick up the town-only lines.
+    const html = renderPlanningPage(pageData());
+    expect(html).not.toContain('Built-Up Areas');
+    expect(html).not.toContain('National Records of Scotland');
+  });
+
   it('escapes HTML in application fields to prevent markup injection', () => {
     const html = renderPlanningPage(
       pageData({

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { renderApplicationsList } from '../render-shared.mjs';
+import {
+  renderApplicationsList,
+  renderAttributionList,
+} from '../render-shared.mjs';
+import { ATTRIBUTION_LINES } from '../constants.mjs';
 
 const PLANIT_CAPTION = 'View full record on PlanIt';
 const COUNCIL_CAPTION = 'View on the council website';
@@ -89,5 +93,26 @@ describe('renderApplicationsList per-application links', () => {
       expect(anchor).toContain('rel="nofollow noopener"');
       expect(anchor).toContain('target="_blank"');
     }
+  });
+});
+
+describe('renderAttributionList', () => {
+  it('defaults to the base ATTRIBUTION_LINES (one escaped <li> per line)', () => {
+    const html = renderAttributionList();
+    for (const line of ATTRIBUTION_LINES) {
+      expect(html).toContain(`<li>${line}</li>`);
+    }
+    expect((html.match(/<li>/g) ?? []).length).toBe(ATTRIBUTION_LINES.length);
+  });
+
+  it('renders a caller-supplied list of lines, so a page can extend the base set', () => {
+    const html = renderAttributionList([
+      'Line one',
+      'Line two & <b>bold</b>',
+    ]);
+    expect(html).toContain('<li>Line one</li>');
+    // HTML in a line is escaped so data can never inject markup.
+    expect(html).toContain('<li>Line two &amp; &lt;b&gt;bold&lt;/b&gt;</li>');
+    expect((html.match(/<li>/g) ?? []).length).toBe(2);
   });
 });

--- a/web/scripts/lib/__tests__/render-sitemap.test.mjs
+++ b/web/scripts/lib/__tests__/render-sitemap.test.mjs
@@ -1,10 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { renderSitemap } from '../render-sitemap.mjs';
+import { renderSitemap, sitemapLastmod } from '../render-sitemap.mjs';
 import { SITE_ORIGIN } from '../constants.mjs';
 
 describe('renderSitemap', () => {
   it('opens with the XML declaration and urlset envelope', () => {
-    const xml = renderSitemap(['adur']);
+    const xml = renderSitemap([{ path: 'adur' }]);
     expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
     expect(xml).toContain(
       '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
@@ -12,8 +12,11 @@ describe('renderSitemap', () => {
     expect(xml.trimEnd().endsWith('</urlset>')).toBe(true);
   });
 
-  it('emits one absolute canonical loc per slug', () => {
-    const xml = renderSitemap(['adur', 'basingstoke-and-deane']);
+  it('emits one absolute canonical loc per entry path', () => {
+    const xml = renderSitemap([
+      { path: 'adur' },
+      { path: 'basingstoke-and-deane' },
+    ]);
     expect(xml).toContain(`<loc>${SITE_ORIGIN}/planning/adur</loc>`);
     expect(xml).toContain(
       `<loc>${SITE_ORIGIN}/planning/basingstoke-and-deane</loc>`,
@@ -22,9 +25,57 @@ describe('renderSitemap', () => {
     expect(urlCount).toBe(2);
   });
 
-  it('produces a valid empty urlset for zero slugs', () => {
+  it('emits a content-derived <lastmod> as a W3C YYYY-MM-DD date', () => {
+    const xml = renderSitemap([
+      { path: 'adur', lastmod: '2026-06-15T10:00:00+00:00' },
+    ]);
+    // Only the date portion of the ISO lastDifferent — the cleanest valid
+    // W3C sitemap date.
+    expect(xml).toContain('<lastmod>2026-06-15</lastmod>');
+    // Never the full ISO datetime.
+    expect(xml).not.toContain('<lastmod>2026-06-15T10:00:00+00:00</lastmod>');
+  });
+
+  it('omits <lastmod> entirely for an entry with no lastmod', () => {
+    const xml = renderSitemap([{ path: 'adur' }]);
+    expect(xml).toContain(`<loc>${SITE_ORIGIN}/planning/adur</loc>`);
+    expect(xml).not.toContain('<lastmod>');
+  });
+
+  it('omits <lastmod> when the lastmod is an empty/invalid string rather than emitting an empty tag', () => {
+    const xml = renderSitemap([
+      { path: 'adur', lastmod: '' },
+      { path: 'truro', lastmod: 'not-a-date' },
+    ]);
+    expect(xml).not.toContain('<lastmod>');
+    expect(xml).not.toContain('<lastmod></lastmod>');
+  });
+
+  it('emits lastmod per-url independently — some dated, some not', () => {
+    const xml = renderSitemap([
+      { path: 'adur', lastmod: '2026-06-15T10:00:00+00:00' },
+      { path: 'truro' },
+    ]);
+    expect((xml.match(/<lastmod>/g) ?? []).length).toBe(1);
+    expect(xml).toContain('<lastmod>2026-06-15</lastmod>');
+  });
+
+  it('produces a valid empty urlset for zero entries', () => {
     const xml = renderSitemap([]);
     expect(xml).toContain('<urlset');
     expect((xml.match(/<url>/g) ?? []).length).toBe(0);
+  });
+});
+
+describe('sitemapLastmod', () => {
+  it('reduces an ISO datetime to its YYYY-MM-DD date portion', () => {
+    expect(sitemapLastmod('2026-06-15T10:00:00+00:00')).toBe('2026-06-15');
+  });
+
+  it('returns undefined for null, empty, or unparseable input', () => {
+    expect(sitemapLastmod(null)).toBeUndefined();
+    expect(sitemapLastmod(undefined)).toBeUndefined();
+    expect(sitemapLastmod('')).toBeUndefined();
+    expect(sitemapLastmod('not-a-date')).toBeUndefined();
   });
 });

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -173,6 +173,20 @@ describe('renderTownPage', () => {
     expect(html).toContain('OpenStreetMap');
   });
 
+  it('additionally credits the ONS Built-Up-Area and NRS Scotland gazetteers (the town centroid sources) under OGL', () => {
+    const html = renderTownPage(townData());
+    // Town positions come from the ONS Built-Up-Areas (2022) centroid gazetteer
+    // and (for Scotland) NRS settlements — both Open Government Licence sources —
+    // so town pages must credit them alongside the existing lines.
+    expect(html).toContain('Office for National Statistics');
+    expect(html).toContain('Built-Up Areas');
+    expect(html).toContain('National Records of Scotland');
+    // The four base lines are still present (not replaced).
+    expect(html).toContain('PlanIt');
+    expect(html).toContain('Ordnance Survey');
+    expect(html).toContain('OpenStreetMap');
+  });
+
   it('escapes HTML in application fields to prevent markup injection', () => {
     const html = renderTownPage(
       townData({

--- a/web/scripts/lib/constants.mjs
+++ b/web/scripts/lib/constants.mjs
@@ -26,3 +26,19 @@ export const ATTRIBUTION_LINES = [
   'Contains Ordnance Survey data © Crown Copyright and database right.',
   'Map data © OpenStreetMap contributors.',
 ];
+
+/**
+ * Attribution lines for TOWN pages only. Town pages are geolocated from the ONS
+ * Built-Up-Areas (2022) centroid gazetteer and (for Scotland) the NRS settlement
+ * gazetteer — both Open Government Licence sources that the authority pages do
+ * NOT use. So rather than widening the shared {@link ATTRIBUTION_LINES} (which
+ * would over-credit authority pages with sources they don't draw on), town pages
+ * extend the base list with these two extra credits. Both are OGL, mirroring the
+ * existing Crown Copyright line.
+ * @type {readonly string[]}
+ */
+export const TOWN_ATTRIBUTION_LINES = [
+  ...ATTRIBUTION_LINES,
+  'Town locations contain Built-Up Areas (2022) data from the Office for National Statistics, licensed under the Open Government Licence. Crown Copyright.',
+  'Scottish town locations contain data from National Records of Scotland, licensed under the Open Government Licence. Crown Copyright.',
+];

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -126,14 +126,17 @@ ${rows}
 
 /**
  * Render the mandatory data-attribution `<li>` items (ADR 0006). Required on
- * every public page — authority and town alike.
+ * every public page. Defaults to the base {@link ATTRIBUTION_LINES}; callers can
+ * supply an extended list (e.g. town pages add the ONS/NRS gazetteer credits)
+ * without the authority page picking up sources it doesn't use.
  *
+ * @param {readonly string[]} [lines]
  * @returns {string}
  */
-export function renderAttributionList() {
-  return ATTRIBUTION_LINES.map(
-    (line) => `        <li>${escapeHtml(line)}</li>`,
-  ).join('\n');
+export function renderAttributionList(lines = ATTRIBUTION_LINES) {
+  return lines
+    .map((line) => `        <li>${escapeHtml(line)}</li>`)
+    .join('\n');
 }
 
 /**

--- a/web/scripts/lib/render-sitemap.mjs
+++ b/web/scripts/lib/render-sitemap.mjs
@@ -1,22 +1,61 @@
 import { SITE_ORIGIN } from './constants.mjs';
 
 /**
- * Render a sitemap.xml listing every generated planning page as an absolute
- * canonical URL under the public origin.
+ * @typedef {Object} SitemapEntry
+ * @property {string} path        page path under /planning/, e.g. "adur" or
+ *                                "cornwall/truro"
+ * @property {string} [lastmod]   the page's content-derived freshness signal —
+ *                                the ISO `lastDifferent` of the most-recently
+ *                                changed application shown on the page. Reduced
+ *                                to a W3C `YYYY-MM-DD` date in the output;
+ *                                omitted from the `<url>` when absent/invalid.
+ */
+
+/**
+ * Reduce an ISO `lastDifferent` timestamp to the `YYYY-MM-DD` date the sitemap
+ * needs. A W3C sitemap `<lastmod>` accepts a bare calendar date, which is the
+ * cleanest honest signal here (the time-of-day adds noise Google ignores).
+ * Returns `undefined` for null/empty/unparseable input so the caller can omit
+ * the tag rather than emit an invalid/empty one.
  *
- * @param {readonly string[]} slugs published authority slugs
+ * @param {string | null | undefined} iso
+ * @returns {string | undefined} the `YYYY-MM-DD` date, or undefined
+ */
+export function sitemapLastmod(iso) {
+  if (iso === null || iso === undefined || iso === '') {
+    return undefined;
+  }
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+/**
+ * Render a sitemap.xml listing every generated planning page as an absolute
+ * canonical URL under the public origin, each carrying a content-derived
+ * `<lastmod>` (the date of the freshest application the page shows) when one is
+ * known. The `<lastmod>` is deliberately NOT the build clock — bumping it on
+ * every rebuild of an unchanged page teaches search engines to distrust it.
+ *
+ * @param {ReadonlyArray<SitemapEntry>} entries published page entries
  * @returns {string}
  */
-export function renderSitemap(slugs) {
-  const entries = slugs
-    .map(
-      (slug) =>
-        `  <url>\n    <loc>${SITE_ORIGIN}/planning/${slug}</loc>\n  </url>`,
-    )
+export function renderSitemap(entries) {
+  const urls = entries
+    .map((entry) => {
+      const loc = `    <loc>${SITE_ORIGIN}/planning/${entry.path}</loc>`;
+      const lastmod = sitemapLastmod(entry.lastmod);
+      const lines = lastmod
+        ? `${loc}\n    <lastmod>${lastmod}</lastmod>`
+        : loc;
+      return `  <url>\n${lines}\n  </url>`;
+    })
     .join('\n');
   return `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${entries}
+${urls}
 </urlset>
 `;
 }

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -13,7 +13,11 @@
  * build key never reaches this output.
  */
 
-import { SITE_ORIGIN, APP_DOWNLOAD_URL } from './constants.mjs';
+import {
+  SITE_ORIGIN,
+  APP_DOWNLOAD_URL,
+  TOWN_ATTRIBUTION_LINES,
+} from './constants.mjs';
 import { escapeHtml, leadLine } from './format.mjs';
 import {
   pageStyles,
@@ -111,7 +115,10 @@ export function renderTownPage(data) {
   const year = new Date().getFullYear();
 
   const applicationsList = renderApplicationsList(data.applications);
-  const attribution = renderAttributionList();
+  // Town pages credit the ONS Built-Up-Area + NRS gazetteers (their centroid
+  // sources) on top of the base PlanIt/OGL/OS/OSM lines; authority pages keep the
+  // base list since they don't use the gazetteer.
+  const attribution = renderAttributionList(TOWN_ATTRIBUTION_LINES);
 
   return `<!doctype html>
 <html lang="en">

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -36,6 +36,58 @@ import { renderSitemap } from './lib/render-sitemap.mjs';
 const DEFAULT_LIMIT = 30;
 
 /**
+ * Derive a page's content `lastmod` from the applications it actually shows: the
+ * maximum (freshest) `lastDifferent` of the rendered set. This is the honest
+ * freshness signal for the sitemap — NOT the build clock, which would falsely
+ * bump every unchanged page on every rebuild. Returns `undefined` when no shown
+ * application carries a parseable date, so the caller can omit `<lastmod>` rather
+ * than stamp an invalid/empty one.
+ *
+ * @param {ReadonlyArray<{ lastDifferent?: string | null }>} applications the
+ *   rendered (sliced) application set
+ * @returns {string | undefined} the max ISO `lastDifferent`, or undefined
+ */
+function maxLastmod(applications) {
+  let max;
+  let maxMs = -Infinity;
+  for (const app of applications) {
+    const iso = app?.lastDifferent;
+    if (typeof iso !== 'string' || iso === '') {
+      continue;
+    }
+    const ms = new Date(iso).getTime();
+    if (!Number.isNaN(ms) && ms > maxMs) {
+      maxMs = ms;
+      max = iso;
+    }
+  }
+  return max;
+}
+
+/**
+ * Sort applications by `lastDifferent` DESC (freshest first) for DISPLAY. Town
+ * nearby data arrives distance-ordered (the build requests `order=distance` to
+ * minimise overlap between adjacent town pages), so the renderer must re-sort it
+ * by recency to read newest-first and match the "Last updated" date order.
+ * Authority data already arrives recency-ordered, so this is only applied on the
+ * town path. Returns a new array; undated rows sort last, original order is kept
+ * among equal dates (stable).
+ *
+ * @param {ReadonlyArray<{ lastDifferent?: string | null }>} applications
+ * @returns {Array<{ lastDifferent?: string | null }>}
+ */
+function sortByRecencyDesc(applications) {
+  const keyed = applications.map((app, index) => {
+    const iso = app?.lastDifferent;
+    const ms =
+      typeof iso === 'string' && iso !== '' ? new Date(iso).getTime() : NaN;
+    return { app, index, ms: Number.isNaN(ms) ? -Infinity : ms };
+  });
+  keyed.sort((a, b) => b.ms - a.ms || a.index - b.index);
+  return keyed.map((k) => k.app);
+}
+
+/**
  * Default published-population threshold when `SEO_TOWN_MIN_POPULATION` is unset,
  * empty, or not a positive finite integer. A town ships only if its built-up-area
  * population is at least this value (the ≥10 in-radius coverage gate applies on
@@ -98,6 +150,10 @@ export const AUTHORITIES_FILE = join(
  * @type {string}
  */
 export const TOWNS_FILE = join(SCRIPT_DIR, '..', 'src', 'data', 'towns.json');
+
+/**
+ * @typedef {import('./lib/render-sitemap.mjs').SitemapEntry} SitemapEntry
+ */
 
 /**
  * @typedef {Object} PrerenderResult
@@ -299,6 +355,7 @@ async function writePage(outDir, data) {
  * @param {object[]} args.applications
  * @param {number} args.limit
  * @param {string[]} args.published
+ * @param {SitemapEntry[]} args.sitemapEntries           parallel { path, lastmod } records
  * @param {Array<{ name: string, reason: string }>} args.excluded
  * @param {Set<string>} args.seenSlugs
  * @param {{ warn: (msg: string) => void }} args.logger
@@ -315,6 +372,7 @@ async function considerAuthority(args) {
     areaName,
     limit,
     published,
+    sitemapEntries,
     excluded,
     seenSlugs,
     logger,
@@ -333,15 +391,19 @@ async function considerAuthority(args) {
   }
   seenSlugs.add(slug);
 
+  // Authority data already arrives recency-ordered (the bounded read sorts by
+  // lastDifferent DESC), so no re-sort here — only the town path needs that.
+  const shown = applications.slice(0, limit);
   await writePage(outDir, {
     slug,
     areaName: areaName || name,
     authorityId,
     total,
     statusBreakdown,
-    applications: applications.slice(0, limit),
+    applications: shown,
   });
   published.push(slug);
+  sitemapEntries.push({ path: slug, lastmod: maxLastmod(shown) });
 }
 
 /**
@@ -417,6 +479,7 @@ async function writeTownPage(outDir, data) {
  * @param {object[]} args.applications
  * @param {number} args.limit
  * @param {string[]} args.publishedTowns
+ * @param {SitemapEntry[]} args.sitemapEntries           parallel { path, lastmod } records
  * @param {Array<{ name: string, reason: string }>} args.excludedTowns
  * @param {Set<string>} args.seenPaths
  * @param {{ warn: (msg: string) => void }} args.logger
@@ -432,6 +495,7 @@ async function considerTown(args) {
     applications,
     limit,
     publishedTowns,
+    sitemapEntries,
     excludedTowns,
     seenPaths,
     logger,
@@ -454,6 +518,10 @@ async function considerTown(args) {
   }
   seenPaths.add(path);
 
+  // Town nearby data arrives distance-ordered (order=distance, tc-2avw.2). Re-sort
+  // by lastDifferent DESC for display so the cards read newest-first and the
+  // page's lastmod (derived below) is consistent with what is shown.
+  const shown = sortByRecencyDesc(applications).slice(0, limit);
   await writeTownPage(outDir, {
     townName: town.name,
     townSlug: town.slug,
@@ -462,9 +530,10 @@ async function considerTown(args) {
     authorityId: town.authorityId,
     total,
     statusBreakdown,
-    applications: applications.slice(0, limit),
+    applications: shown,
   });
   publishedTowns.push(path);
+  sitemapEntries.push({ path, lastmod: maxLastmod(shown) });
 }
 
 /**
@@ -479,13 +548,15 @@ async function considerTown(args) {
  * @param {(town: Town) => Promise<{ applications: object[], total: number, statusBreakdown: object[] }>} args.getGeo
  * @param {number} args.limit
  * @param {{ warn: (msg: string) => void }} args.logger
- * @returns {Promise<{ publishedTowns: string[], excludedTowns: Array<{ name: string, reason: string }> }>}
+ * @returns {Promise<{ publishedTowns: string[], townSitemapEntries: SitemapEntry[], excludedTowns: Array<{ name: string, reason: string }> }>}
  */
 async function renderTownPages(args) {
   const { outDir, towns, authorities, getGeo, limit, logger } = args;
 
   /** @type {string[]} */
   const publishedTowns = [];
+  /** @type {SitemapEntry[]} */
+  const townSitemapEntries = [];
   /** @type {Array<{ name: string, reason: string }>} */
   const excludedTowns = [];
   const seenPaths = new Set();
@@ -503,13 +574,14 @@ async function renderTownPages(args) {
       applications: Array.isArray(geo.applications) ? geo.applications : [],
       limit,
       publishedTowns,
+      sitemapEntries: townSitemapEntries,
       excludedTowns,
       seenPaths,
       logger,
     });
   }
 
-  return { publishedTowns, excludedTowns };
+  return { publishedTowns, townSitemapEntries, excludedTowns };
 }
 
 /**
@@ -528,6 +600,8 @@ async function runFixtureMode(args) {
 
   /** @type {string[]} */
   const published = [];
+  /** @type {SitemapEntry[]} */
+  const authoritySitemapEntries = [];
   /** @type {Array<{ name: string, reason: string }>} */
   const excluded = [];
   const seenSlugs = new Set();
@@ -558,6 +632,7 @@ async function runFixtureMode(args) {
           : [],
         limit,
         published,
+        sitemapEntries: authoritySitemapEntries,
         excluded,
         seenSlugs,
         logger,
@@ -567,6 +642,8 @@ async function runFixtureMode(args) {
 
   /** @type {string[]} */
   let publishedTowns = [];
+  /** @type {SitemapEntry[]} */
+  let townSitemapEntries = [];
   /** @type {Array<{ name: string, reason: string }>} */
   let excludedTowns = [];
 
@@ -579,25 +656,28 @@ async function runFixtureMode(args) {
       throw new Error(`town fixture ${townFixturePath} must be a JSON array`);
     }
     const authorities = await loadAuthorities();
-    ({ publishedTowns, excludedTowns } = await renderTownPages({
-      outDir,
-      towns: townEntries,
-      authorities,
-      getGeo: async (town) => ({
-        applications: Array.isArray(town.applications) ? town.applications : [],
-        total: town.total,
-        statusBreakdown: Array.isArray(town.statusBreakdown)
-          ? town.statusBreakdown
-          : [],
-      }),
-      limit,
-      logger,
-    }));
+    ({ publishedTowns, townSitemapEntries, excludedTowns } =
+      await renderTownPages({
+        outDir,
+        towns: townEntries,
+        authorities,
+        getGeo: async (town) => ({
+          applications: Array.isArray(town.applications)
+            ? town.applications
+            : [],
+          total: town.total,
+          statusBreakdown: Array.isArray(town.statusBreakdown)
+            ? town.statusBreakdown
+            : [],
+        }),
+        limit,
+        logger,
+      }));
   }
 
   await writeFile(
     join(outDir, 'sitemap.xml'),
-    renderSitemap([...published, ...publishedTowns]),
+    renderSitemap([...authoritySitemapEntries, ...townSitemapEntries]),
     'utf-8',
   );
   return { skipped: false, published, excluded, publishedTowns, excludedTowns };
@@ -633,6 +713,8 @@ async function runLiveMode(args) {
 
   /** @type {string[]} */
   const published = [];
+  /** @type {SitemapEntry[]} */
+  const authoritySitemapEntries = [];
   /** @type {Array<{ name: string, reason: string }>} */
   const excluded = [];
   const seenSlugs = new Set();
@@ -660,6 +742,7 @@ async function runLiveMode(args) {
       applications: recent.applications,
       limit,
       published,
+      sitemapEntries: authoritySitemapEntries,
       excluded,
       seenSlugs,
       logger,
@@ -687,19 +770,21 @@ async function runLiveMode(args) {
     }
   }
 
-  const { publishedTowns, excludedTowns } = await renderTownPages({
-    outDir,
-    towns: eligibleTowns,
-    authorities,
-    getGeo: (town) => fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl),
-    limit,
-    logger,
-  });
+  const { publishedTowns, townSitemapEntries, excludedTowns } =
+    await renderTownPages({
+      outDir,
+      towns: eligibleTowns,
+      authorities,
+      getGeo: (town) =>
+        fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl),
+      limit,
+      logger,
+    });
   excludedTowns.push(...populationExcludedTowns);
 
   await writeFile(
     join(outDir, 'sitemap.xml'),
-    renderSitemap([...published, ...publishedTowns]),
+    renderSitemap([...authoritySitemapEntries, ...townSitemapEntries]),
     'utf-8',
   );
   return { skipped: false, published, excluded, publishedTowns, excludedTowns };


### PR DESCRIPTION
Implements **tc-2avw.4** (GH #585, SEO Phase 2). Three things, all in `web/scripts/`. TDD, hand-written fakes only.

## A. Sitemap content-derived `<lastmod>`
- `renderSitemap` now takes `{ path, lastmod }` entries (was `string[]`) and emits a `<lastmod>` child per `<url>`, as a W3C `YYYY-MM-DD` date (the date portion of the ISO `lastDifferent` — cleanest valid form). New `sitemapLastmod` helper reduces ISO → date and returns `undefined` for null/empty/unparseable input, so an undated URL omits `<lastmod>` rather than emitting an invalid/empty tag.
- Each published page's `lastmod` is the **max `lastDifferent` of the page's shown (sliced) applications** (`maxLastmod` helper), never the build clock — for **both** authority pages (`considerAuthority`) and town pages (`considerTown`). Threaded through both call sites (live + fixture) via a parallel `SitemapEntry[]`.

## B. Recency display of the distance-selected town set
- Town nearby data arrives **distance-ordered** (`order=distance`, tc-2avw.2). `considerTown` now sorts by `lastDifferent` DESC (`sortByRecencyDesc`, stable, undated last) **before** slicing, so cards read newest-first and the page's `lastmod` is consistent with what's shown. Authority pages already arrive recency-ordered and are left untouched.

## C. ONS/NRS/OS attribution on town pages
- New `TOWN_ATTRIBUTION_LINES` in `constants.mjs` = base `ATTRIBUTION_LINES` + ONS Built-Up-Areas (OGL) + NRS Scotland (OGL). `renderAttributionList(lines = ATTRIBUTION_LINES)` is parametrised; the town renderer passes the town list.
- **Decision:** a town-specific list rather than widening the shared one — authority pages don't use the BUA/NRS gazetteer, so they keep the base attribution (no over-crediting). Justified in a code comment.
- Self-referential `<link rel="canonical">` on town pages confirmed intact (unchanged).

## Sitemap entry shape
```js
renderSitemap([{ path: 'cornwall/truro', lastmod: '2026-06-14T10:00:00+00:00' }])
// -> <url><loc>…/planning/cornwall/truro</loc><lastmod>2026-06-14</lastmod></url>
```

## Scope
Only `web/scripts/`. No changes to the population threshold filter, `generate-towns.mjs`, `seo-refresh.yml`, the Go API, or the `order=distance` request itself.

## Gates
`npx tsc --noEmit` clean · `npx eslint scripts/` clean · `npx vitest run` 834 pass · `npm run build` ok. End-to-end fixture smoke confirms per-page dated `<lastmod>` and the 6-line town attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xL4oCpLWWGhqV6fmsfEXy