### PR TITLE
ci: weekly-full SEO refresh + SEO_TOWN_MIN_POPULATION through build-web (tc-2avw.6)

### DIFF
--- a/.github/actions/build-web/action.yml
+++ b/.github/actions/build-web/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: SITE_BUILD_KEY — build key for the gated SEO prerender endpoint (empty = SPA-only, prerender skips)
     required: false
     default: ""
+  seo-town-min-population:
+    description: SEO_TOWN_MIN_POPULATION — population floor for published town SEO pages (towns below this are not published)
+    required: false
+    default: "20000"
 
 runs:
   using: composite
@@ -51,3 +55,4 @@ runs:
         VITE_AUTH0_AUDIENCE: ${{ inputs.vite-auth0-audience }}
         VITE_APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ inputs.vite-applicationinsights-connection-string }}
         SITE_BUILD_KEY: ${{ inputs.site-build-key }}
+        SEO_TOWN_MIN_POPULATION: ${{ inputs.seo-town-min-population }}

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -225,6 +225,7 @@ jobs:
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
           site-build-key: ${{ secrets.SITE_BUILD_KEY }}
+          seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
 
       - uses: ./.github/actions/azure-login
         with:

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -201,6 +201,7 @@ jobs:
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
           site-build-key: ${{ secrets.SITE_BUILD_KEY }}
+          seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
 
       - uses: ./.github/actions/azure-login
         with:

--- a/.github/workflows/seo-refresh.yml
+++ b/.github/workflows/seo-refresh.yml
@@ -1,11 +1,22 @@
-# Nightly refresh of the baked SEO pages for BOTH dev and prod web.
+# Weekly refresh of the baked SEO pages for BOTH dev and prod web.
 #
-# The programmatic authority-level SEO pages are statically prerendered at build
-# time (the prerender step is wired into `npm run build` via build-web, pulling
-# fresh applications from the gated API using SITE_BUILD_KEY). A normal CD deploy
-# only happens on push (dev) or tag (prod), so without this job the baked data
-# would go stale. This workflow redeploys the web as a *data-only* refresh — no
-# code change — for both environments.
+# The programmatic SEO pages (authority-level AND per-town) are statically
+# prerendered at build time (the prerender step is wired into `npm run build`
+# via build-web, pulling fresh applications from the gated API using
+# SITE_BUILD_KEY). A normal CD deploy only happens on push (dev) or tag (prod),
+# so without this job the baked data would go stale. This workflow redeploys the
+# web as a *data-only* refresh — no code change — for both environments.
+#
+# Cadence is a WEEKLY FULL rebuild — every run builds the complete set of
+# authority AND town pages together, emits one combined sitemap, and ships it as
+# a full-replace SWA deploy (owner decision, GH #585, tc-2avw.6). We deliberately
+# do NOT run a more frequent authority-only refresh: a full-replace deploy with a
+# single combined sitemap would silently drop all town pages if only authorities
+# were rebuilt. Building everything together every week keeps the sitemap ≡ the
+# live page set by construction. The build cost is negligible (~£0.10/run, see
+# GH #585), so there is no benefit to sharding. A normal code deploy (cd-dev on
+# push, cd-prod on tag) still rebuilds everything immediately. Accepted trade-off:
+# authority-page data refreshes weekly rather than nightly.
 #
 # Deploying prod on a schedule is a deliberate exception to the tag-triggered
 # prod convention (see GH #570, tc-nnte.6), accepted so prod SEO pages stay fresh.
@@ -30,8 +41,9 @@ name: SEO Refresh
 
 on:
   schedule:
-    # 04:00 UTC daily — low UK traffic window.
-    - cron: '0 4 * * *'
+    # 04:00 UTC every Monday — low UK traffic window. Weekly full rebuild of the
+    # complete authority + town SEO page set (see header for why weekly-full).
+    - cron: '0 4 * * 1'
   workflow_dispatch:
 
 concurrency:
@@ -43,11 +55,15 @@ permissions:
   id-token: write
 
 jobs:
-  # ── Web: refresh dev ────────────────────────────────────
+  # ── Web: weekly full refresh dev ────────────────────────
   web-dev:
-    name: "Web: Refresh dev"
+    name: "Web: Weekly refresh dev"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 30 min: a full rebuild prerenders the complete authority + town set, and the
+    # prerender fetches serially (~410 authorities + several hundred towns, two
+    # bounded Cosmos reads each), so the build runs much longer than the old
+    # authority-only refresh.
+    timeout-minutes: 30
     environment: development
     steps:
       - uses: actions/checkout@v6
@@ -60,6 +76,7 @@ jobs:
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
           site-build-key: ${{ secrets.SITE_BUILD_KEY }}
+          seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
 
       - uses: ./.github/actions/azure-login
         with:
@@ -83,13 +100,14 @@ jobs:
           skip_app_build: true
           skip_api_build: true
 
-  # ── Web: refresh prod ───────────────────────────────────
+  # ── Web: weekly full refresh prod ───────────────────────
   # No infra job here, so swa-name is hardcoded (cd-prod reads it from a
   # Pulumi output; this data-only refresh has no Pulumi step).
   web-prod:
-    name: "Web: Refresh prod"
+    name: "Web: Weekly refresh prod"
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # 30 min: full authority + town rebuild (see web-dev for the rationale).
+    timeout-minutes: 30
     environment: production
     steps:
       - uses: actions/checkout@v6
@@ -102,6 +120,7 @@ jobs:
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
           site-build-key: ${{ secrets.SITE_BUILD_KEY }}
+          seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
 
       - uses: ./.github/actions/azure-login
         with:


### PR DESCRIPTION
## What

Implements **tc-2avw.6** (GH #585): move the SEO page refresh to a single **weekly full rebuild** and thread the `SEO_TOWN_MIN_POPULATION` population floor through the shared `build-web` action so every build honours the town-page ramp consistently.

## Changes (all under `.github/`)

- **`seo-refresh.yml`**
  - Schedule daily → **weekly**: `cron: '0 4 * * 1'` (Monday 04:00 UTC, the existing low-traffic window). `workflow_dispatch` retained.
  - `timeout-minutes` on both `web-dev` and `web-prod`: `10` → **30** (a full authority + town rebuild fetches serially — ~410 authorities + several hundred towns, two bounded Cosmos reads each).
  - Header comment, `name`, and job names reworded "Nightly" → "Weekly", explaining why weekly-full: under full-replace SWA deploys with a single combined sitemap, an authority-only refresh would silently drop all town pages; building everything together keeps the sitemap ≡ live page set by construction. Build cost is negligible.
  - Both `build-web` callers now pass `seo-town-min-population`.
- **`actions/build-web/action.yml`** — new input `seo-town-min-population` (`required: false`, `default: "20000"`), threaded into `SEO_TOWN_MIN_POPULATION` in the Build step `env`.
- **`cd-dev.yml` / `cd-prod.yml`** — their `build-web` step now passes `seo-town-min-population` too, so a normal code deploy honours the same ramp.

All callers use `${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}` so an unset repo variable falls back to the action default instead of shadowing it with an empty string.

## Repo variable

Created the non-sensitive Actions variable `SEO_TOWN_MIN_POPULATION=20000` (`gh variable set`), confirmed in `gh variable list`.

## Validation

- All four YAML files parse (`python3 -c "import yaml ..."`); cron is a valid 5-field weekly expression.
- `actionlint` clean on all three workflows.
- Scope check: diff is `.github/`-only.
- Every `build-web` caller still passes all required `vite-*` inputs.

## Decision

Cadence is **weekly-full only** per owner decision (GH #585) — no nightly authority-only refresh. The town-page filtering itself lands with the prerender work (tc-2avw.3); this PR is a no-op for town pages until that ships, but the wiring is ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xL4oCpLWWGhqV6fmsfEXy