### PR TITLE
feat(web): regenerate towns.json from real ONS BUA data — 1,395 E&W towns (tc-2avw.5)

### DIFF
--- a/web/scripts/generate-towns.mjs
+++ b/web/scripts/generate-towns.mjs
@@ -337,8 +337,13 @@ export function buildGazetteer(populationCsv, centroidCsv, mapping) {
 
 /**
  * Split CSV text into field arrays, dropping the header row and blank lines.
- * ONS BUA names do not contain embedded commas, so a full RFC-4180 parser is
- * unnecessary; we strip a single layer of surrounding double quotes per field.
+ * A handful of official ONS names carry embedded commas — both BUA names
+ * (`Longfield, New Ash Green and Hartley`) and, more importantly, LAD names
+ * that must match `authority-mapping.json` verbatim (`Bristol, City of`,
+ * `Kingston upon Hull, City of`, `Herefordshire, County of`, `Bournemouth,
+ * Christchurch and Poole`). Those fields are double-quoted in the source CSVs,
+ * so we honour RFC-4180 quoting: a comma inside a quoted field is part of the
+ * value, and a doubled `""` is a literal quote.
  *
  * @param {string} text raw CSV text (first non-blank line is the header)
  * @returns {string[][]}
@@ -346,7 +351,45 @@ export function buildGazetteer(populationCsv, centroidCsv, mapping) {
 function parseCsvRows(text) {
   const lines = text.split(/\r?\n/).filter((line) => line.trim() !== '');
   // Drop the header row.
-  return lines.slice(1).map((line) => line.split(',').map((f) => f.replace(/^"|"$/g, '')));
+  return lines.slice(1).map((line) => parseCsvLine(line));
+}
+
+/**
+ * Split a single CSV line into fields, respecting RFC-4180 double-quoting so a
+ * comma inside a quoted field is not treated as a delimiter. A doubled quote
+ * (`""`) inside a quoted field is an escaped literal quote.
+ *
+ * @param {string} line one CSV record (no trailing newline)
+ * @returns {string[]} the parsed fields, with surrounding quotes removed
+ */
+export function parseCsvLine(line) {
+  const fields = [];
+  let field = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (line[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      fields.push(field);
+      field = '';
+    } else {
+      field += ch;
+    }
+  }
+  fields.push(field);
+  return fields;
 }
 
 // ── OSGB36 British National Grid -> WGS84 ──────────────────────────────────

--- a/web/scripts/lib/__tests__/generate-towns.test.mjs
+++ b/web/scripts/lib/__tests__/generate-towns.test.mjs
@@ -6,6 +6,7 @@ import { describe, it, expect } from 'vitest';
 import {
   bngToLatLon,
   resolveAuthorityId,
+  parseCsvLine,
   parsePopulationRow,
   parseCentroidRow,
   joinBua,
@@ -272,6 +273,45 @@ describe('joinBua (population x centroid on BUA code)', () => {
   });
 });
 
+describe('parseCsvLine (RFC-4180 quoting)', () => {
+  it('splits an unquoted line on every comma', () => {
+    expect(parseCsvLine('E63001234,Truro,Cornwall,18766')).toEqual([
+      'E63001234',
+      'Truro',
+      'Cornwall',
+      '18766',
+    ]);
+  });
+
+  it('keeps a comma inside a quoted field (official LAD name)', () => {
+    // ONS names "Bristol, City of" / "Kingston upon Hull, City of" carry a comma
+    // that must survive so lad_name matches authority-mapping.json verbatim.
+    expect(parseCsvLine('E63005057,Bristol,"Bristol, City of",425215')).toEqual([
+      'E63005057',
+      'Bristol',
+      'Bristol, City of',
+      '425215',
+    ]);
+  });
+
+  it('handles a quoted comma in both the BUA name and the LAD name', () => {
+    expect(
+      parseCsvLine(
+        'E63006696,"Christchurch (Bournemouth, Christchurch and Poole)","Bournemouth, Christchurch and Poole",48985',
+      ),
+    ).toEqual([
+      'E63006696',
+      'Christchurch (Bournemouth, Christchurch and Poole)',
+      'Bournemouth, Christchurch and Poole',
+      '48985',
+    ]);
+  });
+
+  it('unescapes a doubled quote inside a quoted field', () => {
+    expect(parseCsvLine('A,"say ""hi""",B')).toEqual(['A', 'say "hi"', 'B']);
+  });
+});
+
 describe('buildGazetteer (end-to-end CSV text -> records)', () => {
   const mapping = { Cornwall: 52, Stockport: 320 };
 
@@ -318,6 +358,27 @@ describe('buildGazetteer (end-to-end CSV text -> records)', () => {
     for (const r of records) {
       expect(Number.isFinite(r.population)).toBe(true);
     }
+  });
+
+  it('resolves a BUA whose official LAD name contains a comma', () => {
+    // Regression: "Bristol, City of" must round-trip through the quoted CSV and
+    // match the authority mapping, otherwise Bristol is silently dropped.
+    const popCsv = [
+      'bua_code,bua_name,lad_name,population',
+      'E63005057,Bristol,"Bristol, City of",425215',
+    ].join('\n');
+    const cenCsv = [
+      'bua_code,bua_name,latitude,longitude,bng_easting,bng_northing',
+      'E63005057,Bristol,51.4518,-2.5898,358000,173000',
+    ].join('\n');
+    const { records } = buildGazetteer(popCsv, cenCsv, { 'Bristol, City of': 23 });
+    expect(records).toHaveLength(1);
+    expect(records[0]).toMatchObject({
+      slug: 'bristol',
+      name: 'Bristol',
+      authorityId: 23,
+      population: 425215,
+    });
   });
 });
 

--- a/web/src/data/towns.json
+++ b/web/src/data/towns.json
@@ -1,14 +1,11162 @@
 [
-  { "slug": "croydon", "name": "Croydon", "lat": 51.3762, "lng": -0.0982, "authorityId": 301, "population": 192064 },
-  { "slug": "truro", "name": "Truro", "lat": 50.2632, "lng": -5.0510, "authorityId": 52, "population": 18766 },
-  { "slug": "newquay", "name": "Newquay", "lat": 50.4156, "lng": -5.0739, "authorityId": 52, "population": 20342 },
-  { "slug": "cambridge", "name": "Cambridge", "lat": 52.2053, "lng": 0.1218, "authorityId": 61, "population": 145674 },
-  { "slug": "wembley", "name": "Wembley", "lat": 51.5530, "lng": -0.2963, "authorityId": 298, "population": 102856 },
-  { "slug": "ealing", "name": "Ealing", "lat": 51.5130, "lng": -0.3089, "authorityId": 302, "population": 85014 },
-  { "slug": "greenwich", "name": "Greenwich", "lat": 51.4826, "lng": -0.0077, "authorityId": 304, "population": 52783 },
-  { "slug": "woolwich", "name": "Woolwich", "lat": 51.4920, "lng": 0.0640, "authorityId": 304, "population": 84959 },
-  { "slug": "bexleyheath", "name": "Bexleyheath", "lat": 51.4549, "lng": 0.1505, "authorityId": 297, "population": 31929 },
-  { "slug": "hackney", "name": "Hackney", "lat": 51.5450, "lng": -0.0553, "authorityId": 305, "population": 281120 },
-  { "slug": "islington", "name": "Islington", "lat": 51.5362, "lng": -0.1033, "authorityId": 312, "population": 215667 },
-  { "slug": "finchley", "name": "Finchley", "lat": 51.5990, "lng": -0.1870, "authorityId": 296, "population": 65812 }
+  {
+    "slug": "hartlepool",
+    "name": "Hartlepool",
+    "lat": 54.6846,
+    "lng": -1.2163,
+    "authorityId": 1,
+    "population": 87995
+  },
+  {
+    "slug": "middlesbrough",
+    "name": "Middlesbrough",
+    "lat": 54.5498,
+    "lng": -1.2146,
+    "authorityId": 2,
+    "population": 148215
+  },
+  {
+    "slug": "brotton",
+    "name": "Brotton",
+    "lat": 54.5691,
+    "lng": -0.9407,
+    "authorityId": 3,
+    "population": 5400
+  },
+  {
+    "slug": "eston",
+    "name": "Eston",
+    "lat": 54.5656,
+    "lng": -1.1539,
+    "authorityId": 3,
+    "population": 29635
+  },
+  {
+    "slug": "guisborough",
+    "name": "Guisborough",
+    "lat": 54.5323,
+    "lng": -1.0569,
+    "authorityId": 3,
+    "population": 18095
+  },
+  {
+    "slug": "marske-by-the-sea",
+    "name": "Marske-by-the-Sea",
+    "lat": 54.5932,
+    "lng": -1.024,
+    "authorityId": 3,
+    "population": 7580
+  },
+  {
+    "slug": "redcar",
+    "name": "Redcar",
+    "lat": 54.6067,
+    "lng": -1.0773,
+    "authorityId": 3,
+    "population": 37660
+  },
+  {
+    "slug": "saltburn-by-the-sea",
+    "name": "Saltburn-by-the-Sea",
+    "lat": 54.5796,
+    "lng": -0.982,
+    "authorityId": 3,
+    "population": 5875
+  },
+  {
+    "slug": "skelton-redcar-and-cleveland",
+    "name": "Skelton (Redcar and Cleveland)",
+    "lat": 54.5618,
+    "lng": -0.9769,
+    "authorityId": 3,
+    "population": 6895
+  },
+  {
+    "slug": "billingham",
+    "name": "Billingham",
+    "lat": 54.5988,
+    "lng": -1.2714,
+    "authorityId": 4,
+    "population": 33920
+  },
+  {
+    "slug": "egglescliffe",
+    "name": "Egglescliffe",
+    "lat": 54.523,
+    "lng": -1.3563,
+    "authorityId": 4,
+    "population": 10250
+  },
+  {
+    "slug": "ingleby-barwick",
+    "name": "Ingleby Barwick",
+    "lat": 54.5167,
+    "lng": -1.3157,
+    "authorityId": 4,
+    "population": 23380
+  },
+  {
+    "slug": "stockton-on-tees",
+    "name": "Stockton-on-Tees",
+    "lat": 54.573,
+    "lng": -1.3267,
+    "authorityId": 4,
+    "population": 84815
+  },
+  {
+    "slug": "thornaby-on-tees",
+    "name": "Thornaby-on-Tees",
+    "lat": 54.5524,
+    "lng": -1.2913,
+    "authorityId": 4,
+    "population": 23350
+  },
+  {
+    "slug": "yarm",
+    "name": "Yarm",
+    "lat": 54.5006,
+    "lng": -1.3478,
+    "authorityId": 4,
+    "population": 9600
+  },
+  {
+    "slug": "darlington",
+    "name": "Darlington",
+    "lat": 54.528,
+    "lng": -1.5546,
+    "authorityId": 5,
+    "population": 93015
+  },
+  {
+    "slug": "runcorn",
+    "name": "Runcorn",
+    "lat": 53.3294,
+    "lng": -2.6869,
+    "authorityId": 6,
+    "population": 61645
+  },
+  {
+    "slug": "widnes",
+    "name": "Widnes",
+    "lat": 53.3715,
+    "lng": -2.7334,
+    "authorityId": 6,
+    "population": 59935
+  },
+  {
+    "slug": "culcheth",
+    "name": "Culcheth",
+    "lat": 53.4558,
+    "lng": -2.5234,
+    "authorityId": 7,
+    "population": 6720
+  },
+  {
+    "slug": "lymm",
+    "name": "Lymm",
+    "lat": 53.3777,
+    "lng": -2.4821,
+    "authorityId": 7,
+    "population": 11545
+  },
+  {
+    "slug": "warrington",
+    "name": "Warrington",
+    "lat": 53.3895,
+    "lng": -2.5843,
+    "authorityId": 7,
+    "population": 174970
+  },
+  {
+    "slug": "blackburn-blackburn-with-darwen",
+    "name": "Blackburn (Blackburn with Darwen)",
+    "lat": 53.7465,
+    "lng": -2.4841,
+    "authorityId": 8,
+    "population": 124955
+  },
+  {
+    "slug": "darwen",
+    "name": "Darwen",
+    "lat": 53.6975,
+    "lng": -2.4666,
+    "authorityId": 8,
+    "population": 27900
+  },
+  {
+    "slug": "blackpool",
+    "name": "Blackpool",
+    "lat": 53.7968,
+    "lng": -3.0169,
+    "authorityId": 9,
+    "population": 149070
+  },
+  {
+    "slug": "kingston-upon-hull",
+    "name": "Kingston upon Hull",
+    "lat": 53.765,
+    "lng": -0.3338,
+    "authorityId": 10,
+    "population": 270810
+  },
+  {
+    "slug": "beverley",
+    "name": "Beverley",
+    "lat": 53.843,
+    "lng": -0.4282,
+    "authorityId": 11,
+    "population": 30930
+  },
+  {
+    "slug": "bridlington",
+    "name": "Bridlington",
+    "lat": 54.0895,
+    "lng": -0.2031,
+    "authorityId": 11,
+    "population": 34845
+  },
+  {
+    "slug": "brough-east-riding-of-yorkshire",
+    "name": "Brough (East Riding of Yorkshire)",
+    "lat": 53.7248,
+    "lng": -0.5532,
+    "authorityId": 11,
+    "population": 13320
+  },
+  {
+    "slug": "cottingham",
+    "name": "Cottingham",
+    "lat": 53.7846,
+    "lng": -0.4146,
+    "authorityId": 11,
+    "population": 14425
+  },
+  {
+    "slug": "driffield",
+    "name": "Driffield",
+    "lat": 54.0062,
+    "lng": -0.4361,
+    "authorityId": 11,
+    "population": 13215
+  },
+  {
+    "slug": "goole",
+    "name": "Goole",
+    "lat": 53.7048,
+    "lng": -0.8778,
+    "authorityId": 11,
+    "population": 20175
+  },
+  {
+    "slug": "hedon",
+    "name": "Hedon",
+    "lat": 53.7408,
+    "lng": -0.1955,
+    "authorityId": 11,
+    "population": 8120
+  },
+  {
+    "slug": "hessle",
+    "name": "Hessle",
+    "lat": 53.7248,
+    "lng": -0.4463,
+    "authorityId": 11,
+    "population": 15485
+  },
+  {
+    "slug": "hornsea",
+    "name": "Hornsea",
+    "lat": 53.9113,
+    "lng": -0.1726,
+    "authorityId": 11,
+    "population": 8790
+  },
+  {
+    "slug": "market-weighton",
+    "name": "Market Weighton",
+    "lat": 53.8644,
+    "lng": -0.6669,
+    "authorityId": 11,
+    "population": 7460
+  },
+  {
+    "slug": "pocklington",
+    "name": "Pocklington",
+    "lat": 53.9297,
+    "lng": -0.7811,
+    "authorityId": 11,
+    "population": 10120
+  },
+  {
+    "slug": "willerby-and-anlaby",
+    "name": "Willerby and Anlaby",
+    "lat": 53.7521,
+    "lng": -0.4454,
+    "authorityId": 11,
+    "population": 19260
+  },
+  {
+    "slug": "withernsea",
+    "name": "Withernsea",
+    "lat": 53.7308,
+    "lng": 0.026,
+    "authorityId": 11,
+    "population": 5765
+  },
+  {
+    "slug": "cleethorpes",
+    "name": "Cleethorpes",
+    "lat": 53.5497,
+    "lng": -0.0346,
+    "authorityId": 12,
+    "population": 29670
+  },
+  {
+    "slug": "grimsby",
+    "name": "Grimsby",
+    "lat": 53.5631,
+    "lng": -0.0961,
+    "authorityId": 12,
+    "population": 85925
+  },
+  {
+    "slug": "humberston-and-new-waltham",
+    "name": "Humberston and New Waltham",
+    "lat": 53.53,
+    "lng": -0.0307,
+    "authorityId": 12,
+    "population": 14860
+  },
+  {
+    "slug": "immingham",
+    "name": "Immingham",
+    "lat": 53.6203,
+    "lng": -0.2004,
+    "authorityId": 12,
+    "population": 9770
+  },
+  {
+    "slug": "waltham",
+    "name": "Waltham",
+    "lat": 53.5133,
+    "lng": -0.1028,
+    "authorityId": 12,
+    "population": 6200
+  },
+  {
+    "slug": "barton-upon-humber",
+    "name": "Barton-upon-Humber",
+    "lat": 53.685,
+    "lng": -0.4377,
+    "authorityId": 13,
+    "population": 11920
+  },
+  {
+    "slug": "brigg",
+    "name": "Brigg",
+    "lat": 53.5542,
+    "lng": -0.4878,
+    "authorityId": 13,
+    "population": 5635
+  },
+  {
+    "slug": "scunthorpe",
+    "name": "Scunthorpe",
+    "lat": 53.5815,
+    "lng": -0.6475,
+    "authorityId": 13,
+    "population": 81265
+  },
+  {
+    "slug": "haxby",
+    "name": "Haxby",
+    "lat": 54.0142,
+    "lng": -1.0744,
+    "authorityId": 14,
+    "population": 10180
+  },
+  {
+    "slug": "huntington-york",
+    "name": "Huntington (York)",
+    "lat": 53.99,
+    "lng": -1.0616,
+    "authorityId": 14,
+    "population": 12420
+  },
+  {
+    "slug": "strensall",
+    "name": "Strensall",
+    "lat": 54.0366,
+    "lng": -1.0352,
+    "authorityId": 14,
+    "population": 6055
+  },
+  {
+    "slug": "york",
+    "name": "York",
+    "lat": 53.9572,
+    "lng": -1.0895,
+    "authorityId": 14,
+    "population": 141685
+  },
+  {
+    "slug": "derby",
+    "name": "Derby",
+    "lat": 52.9124,
+    "lng": -1.4668,
+    "authorityId": 15,
+    "population": 275575
+  },
+  {
+    "slug": "leicester",
+    "name": "Leicester",
+    "lat": 52.6322,
+    "lng": -1.14,
+    "authorityId": 16,
+    "population": 406580
+  },
+  {
+    "slug": "oakham",
+    "name": "Oakham",
+    "lat": 52.6724,
+    "lng": -0.7307,
+    "authorityId": 17,
+    "population": 12160
+  },
+  {
+    "slug": "clifton-nottingham",
+    "name": "Clifton (Nottingham)",
+    "lat": 52.9024,
+    "lng": -1.1836,
+    "authorityId": 18,
+    "population": 22935
+  },
+  {
+    "slug": "nottingham",
+    "name": "Nottingham",
+    "lat": 52.9667,
+    "lng": -1.1792,
+    "authorityId": 18,
+    "population": 299790
+  },
+  {
+    "slug": "hereford",
+    "name": "Hereford",
+    "lat": 52.0554,
+    "lng": -2.7185,
+    "authorityId": 19,
+    "population": 60480
+  },
+  {
+    "slug": "ledbury",
+    "name": "Ledbury",
+    "lat": 52.0329,
+    "lng": -2.4286,
+    "authorityId": 19,
+    "population": 8345
+  },
+  {
+    "slug": "leominster",
+    "name": "Leominster",
+    "lat": 52.2255,
+    "lng": -2.7451,
+    "authorityId": 19,
+    "population": 11205
+  },
+  {
+    "slug": "ross-on-wye",
+    "name": "Ross-on-Wye",
+    "lat": 51.9155,
+    "lng": -2.5782,
+    "authorityId": 19,
+    "population": 10990
+  },
+  {
+    "slug": "newport-telford-and-wrekin",
+    "name": "Newport (Telford and Wrekin)",
+    "lat": 52.7681,
+    "lng": -2.3746,
+    "authorityId": 20,
+    "population": 14190
+  },
+  {
+    "slug": "telford",
+    "name": "Telford",
+    "lat": 52.6876,
+    "lng": -2.4752,
+    "authorityId": 20,
+    "population": 156910
+  },
+  {
+    "slug": "stoke-on-trent",
+    "name": "Stoke-on-Trent",
+    "lat": 52.9885,
+    "lng": -2.1506,
+    "authorityId": 21,
+    "population": 260560
+  },
+  {
+    "slug": "bath",
+    "name": "Bath",
+    "lat": 51.3816,
+    "lng": -2.366,
+    "authorityId": 22,
+    "population": 94080
+  },
+  {
+    "slug": "keynsham",
+    "name": "Keynsham",
+    "lat": 51.4109,
+    "lng": -2.4977,
+    "authorityId": 22,
+    "population": 19255
+  },
+  {
+    "slug": "midsomer-norton",
+    "name": "Midsomer Norton",
+    "lat": 51.2855,
+    "lng": -2.4846,
+    "authorityId": 22,
+    "population": 13745
+  },
+  {
+    "slug": "paulton",
+    "name": "Paulton",
+    "lat": 51.3063,
+    "lng": -2.5003,
+    "authorityId": 22,
+    "population": 6505
+  },
+  {
+    "slug": "peasedown-st-john",
+    "name": "Peasedown St John",
+    "lat": 51.3168,
+    "lng": -2.4296,
+    "authorityId": 22,
+    "population": 6670
+  },
+  {
+    "slug": "radstock",
+    "name": "Radstock",
+    "lat": 51.291,
+    "lng": -2.4519,
+    "authorityId": 22,
+    "population": 9980
+  },
+  {
+    "slug": "bristol",
+    "name": "Bristol",
+    "lat": 51.4518,
+    "lng": -2.5898,
+    "authorityId": 23,
+    "population": 425215
+  },
+  {
+    "slug": "clevedon",
+    "name": "Clevedon",
+    "lat": 51.4314,
+    "lng": -2.857,
+    "authorityId": 24,
+    "population": 21085
+  },
+  {
+    "slug": "long-ashton",
+    "name": "Long Ashton",
+    "lat": 51.4309,
+    "lng": -2.6626,
+    "authorityId": 24,
+    "population": 5180
+  },
+  {
+    "slug": "nailsea",
+    "name": "Nailsea",
+    "lat": 51.43,
+    "lng": -2.763,
+    "authorityId": 24,
+    "population": 15925
+  },
+  {
+    "slug": "portishead",
+    "name": "Portishead",
+    "lat": 51.4826,
+    "lng": -2.7701,
+    "authorityId": 24,
+    "population": 26355
+  },
+  {
+    "slug": "weston-super-mare",
+    "name": "Weston-super-Mare",
+    "lat": 51.3443,
+    "lng": -2.958,
+    "authorityId": 24,
+    "population": 84605
+  },
+  {
+    "slug": "yatton",
+    "name": "Yatton",
+    "lat": 51.3916,
+    "lng": -2.8215,
+    "authorityId": 24,
+    "population": 7705
+  },
+  {
+    "slug": "bradley-stoke",
+    "name": "Bradley Stoke",
+    "lat": 51.5302,
+    "lng": -2.5489,
+    "authorityId": 25,
+    "population": 25200
+  },
+  {
+    "slug": "chipping-sodbury",
+    "name": "Chipping Sodbury",
+    "lat": 51.5372,
+    "lng": -2.3916,
+    "authorityId": 25,
+    "population": 8025
+  },
+  {
+    "slug": "filton",
+    "name": "Filton",
+    "lat": 51.5143,
+    "lng": -2.5773,
+    "authorityId": 25,
+    "population": 10960
+  },
+  {
+    "slug": "frampton-cotterell-and-winterbourne",
+    "name": "Frampton Cotterell and Winterbourne",
+    "lat": 51.5284,
+    "lng": -2.4841,
+    "authorityId": 25,
+    "population": 14970
+  },
+  {
+    "slug": "kingswood-and-fishponds",
+    "name": "Kingswood and Fishponds",
+    "lat": 51.4759,
+    "lng": -2.5018,
+    "authorityId": 25,
+    "population": 160270
+  },
+  {
+    "slug": "patchway",
+    "name": "Patchway",
+    "lat": 51.532,
+    "lng": -2.5789,
+    "authorityId": 25,
+    "population": 16520
+  },
+  {
+    "slug": "stoke-gifford",
+    "name": "Stoke Gifford",
+    "lat": 51.5071,
+    "lng": -2.5449,
+    "authorityId": 25,
+    "population": 13470
+  },
+  {
+    "slug": "thornbury",
+    "name": "Thornbury",
+    "lat": 51.609,
+    "lng": -2.5157,
+    "authorityId": 25,
+    "population": 14485
+  },
+  {
+    "slug": "yate",
+    "name": "Yate",
+    "lat": 51.5446,
+    "lng": -2.4246,
+    "authorityId": 25,
+    "population": 28350
+  },
+  {
+    "slug": "plymouth",
+    "name": "Plymouth",
+    "lat": 50.3965,
+    "lng": -4.1257,
+    "authorityId": 26,
+    "population": 266955
+  },
+  {
+    "slug": "brixham",
+    "name": "Brixham",
+    "lat": 50.3903,
+    "lng": -3.5303,
+    "authorityId": 27,
+    "population": 17840
+  },
+  {
+    "slug": "paignton",
+    "name": "Paignton",
+    "lat": 50.4261,
+    "lng": -3.5739,
+    "authorityId": 27,
+    "population": 67520
+  },
+  {
+    "slug": "torquay",
+    "name": "Torquay",
+    "lat": 50.4884,
+    "lng": -3.532,
+    "authorityId": 27,
+    "population": 52035
+  },
+  {
+    "slug": "bournemouth",
+    "name": "Bournemouth",
+    "lat": 50.7409,
+    "lng": -1.8749,
+    "authorityId": 28,
+    "population": 196455
+  },
+  {
+    "slug": "christchurch-bournemouth-christchurch-and-poole",
+    "name": "Christchurch (Bournemouth, Christchurch and Poole)",
+    "lat": 50.7415,
+    "lng": -1.7455,
+    "authorityId": 28,
+    "population": 48985
+  },
+  {
+    "slug": "merley",
+    "name": "Merley",
+    "lat": 50.7804,
+    "lng": -1.9687,
+    "authorityId": 28,
+    "population": 5490
+  },
+  {
+    "slug": "poole",
+    "name": "Poole",
+    "lat": 50.7257,
+    "lng": -1.9542,
+    "authorityId": 28,
+    "population": 141005
+  },
+  {
+    "slug": "broad-blunsdon",
+    "name": "Broad Blunsdon",
+    "lat": 51.6103,
+    "lng": -1.79,
+    "authorityId": 30,
+    "population": 6505
+  },
+  {
+    "slug": "highworth",
+    "name": "Highworth",
+    "lat": 51.6307,
+    "lng": -1.7116,
+    "authorityId": 30,
+    "population": 7930
+  },
+  {
+    "slug": "stratton-st-margaret",
+    "name": "Stratton St Margaret",
+    "lat": 51.5854,
+    "lng": -1.7456,
+    "authorityId": 30,
+    "population": 20690
+  },
+  {
+    "slug": "swindon-swindon",
+    "name": "Swindon (Swindon)",
+    "lat": 51.5689,
+    "lng": -1.7974,
+    "authorityId": 30,
+    "population": 183680
+  },
+  {
+    "slug": "wroughton",
+    "name": "Wroughton",
+    "lat": 51.5256,
+    "lng": -1.791,
+    "authorityId": 30,
+    "population": 7280
+  },
+  {
+    "slug": "eye-peterborough",
+    "name": "Eye (Peterborough)",
+    "lat": 52.6117,
+    "lng": -0.1891,
+    "authorityId": 31,
+    "population": 5415
+  },
+  {
+    "slug": "peterborough",
+    "name": "Peterborough",
+    "lat": 52.5706,
+    "lng": -0.2588,
+    "authorityId": 31,
+    "population": 190605
+  },
+  {
+    "slug": "luton",
+    "name": "Luton",
+    "lat": 51.8944,
+    "lng": -0.4249,
+    "authorityId": 32,
+    "population": 233525
+  },
+  {
+    "slug": "southend-on-sea",
+    "name": "Southend-on-Sea",
+    "lat": 51.5554,
+    "lng": 0.6954,
+    "authorityId": 33,
+    "population": 182305
+  },
+  {
+    "slug": "aveley",
+    "name": "Aveley",
+    "lat": 51.5021,
+    "lng": 0.251,
+    "authorityId": 34,
+    "population": 9360
+  },
+  {
+    "slug": "chadwell-st-mary",
+    "name": "Chadwell St Mary",
+    "lat": 51.4824,
+    "lng": 0.3706,
+    "authorityId": 34,
+    "population": 10685
+  },
+  {
+    "slug": "chafford-hundred-and-west-thurrock",
+    "name": "Chafford Hundred and West Thurrock",
+    "lat": 51.4821,
+    "lng": 0.2838,
+    "authorityId": 34,
+    "population": 23585
+  },
+  {
+    "slug": "east-tilbury",
+    "name": "East Tilbury",
+    "lat": 51.4822,
+    "lng": 0.4173,
+    "authorityId": 34,
+    "population": 5750
+  },
+  {
+    "slug": "grays",
+    "name": "Grays",
+    "lat": 51.4836,
+    "lng": 0.332,
+    "authorityId": 34,
+    "population": 44345
+  },
+  {
+    "slug": "purfleet-on-thames",
+    "name": "Purfleet-on-Thames",
+    "lat": 51.4744,
+    "lng": 0.2553,
+    "authorityId": 34,
+    "population": 5880
+  },
+  {
+    "slug": "south-ockendon",
+    "name": "South Ockendon",
+    "lat": 51.5127,
+    "lng": 0.2936,
+    "authorityId": 34,
+    "population": 22440
+  },
+  {
+    "slug": "stanford-le-hope",
+    "name": "Stanford-le-Hope",
+    "lat": 51.5198,
+    "lng": 0.448,
+    "authorityId": 34,
+    "population": 29525
+  },
+  {
+    "slug": "tilbury",
+    "name": "Tilbury",
+    "lat": 51.4621,
+    "lng": 0.361,
+    "authorityId": 34,
+    "population": 14185
+  },
+  {
+    "slug": "chatham",
+    "name": "Chatham",
+    "lat": 51.3615,
+    "lng": 0.5344,
+    "authorityId": 35,
+    "population": 76955
+  },
+  {
+    "slug": "gillingham-medway",
+    "name": "Gillingham (Medway)",
+    "lat": 51.3628,
+    "lng": 0.5836,
+    "authorityId": 35,
+    "population": 108480
+  },
+  {
+    "slug": "hoo-st-werburgh",
+    "name": "Hoo St Werburgh",
+    "lat": 51.4207,
+    "lng": 0.5599,
+    "authorityId": 35,
+    "population": 8760
+  },
+  {
+    "slug": "rochester",
+    "name": "Rochester",
+    "lat": 51.3928,
+    "lng": 0.492,
+    "authorityId": 35,
+    "population": 67285
+  },
+  {
+    "slug": "bracknell",
+    "name": "Bracknell",
+    "lat": 51.4083,
+    "lng": -0.7565,
+    "authorityId": 36,
+    "population": 78675
+  },
+  {
+    "slug": "sandhurst-bracknell-forest",
+    "name": "Sandhurst (Bracknell Forest)",
+    "lat": 51.3483,
+    "lng": -0.7817,
+    "authorityId": 36,
+    "population": 20215
+  },
+  {
+    "slug": "burghfield-common",
+    "name": "Burghfield Common",
+    "lat": 51.3971,
+    "lng": -1.0672,
+    "authorityId": 37,
+    "population": 6215
+  },
+  {
+    "slug": "hungerford",
+    "name": "Hungerford",
+    "lat": 51.4134,
+    "lng": -1.5187,
+    "authorityId": 37,
+    "population": 5185
+  },
+  {
+    "slug": "newbury",
+    "name": "Newbury",
+    "lat": 51.4035,
+    "lng": -1.3201,
+    "authorityId": 37,
+    "population": 42260
+  },
+  {
+    "slug": "thatcham",
+    "name": "Thatcham",
+    "lat": 51.3988,
+    "lng": -1.2528,
+    "authorityId": 37,
+    "population": 25550
+  },
+  {
+    "slug": "caversham",
+    "name": "Caversham",
+    "lat": 51.478,
+    "lng": -0.9667,
+    "authorityId": 38,
+    "population": 33040
+  },
+  {
+    "slug": "reading",
+    "name": "Reading",
+    "lat": 51.4416,
+    "lng": -0.9631,
+    "authorityId": 38,
+    "population": 203795
+  },
+  {
+    "slug": "slough",
+    "name": "Slough",
+    "lat": 51.5178,
+    "lng": -0.591,
+    "authorityId": 39,
+    "population": 166855
+  },
+  {
+    "slug": "ascot",
+    "name": "Ascot",
+    "lat": 51.4021,
+    "lng": -0.6595,
+    "authorityId": 40,
+    "population": 23995
+  },
+  {
+    "slug": "cookham",
+    "name": "Cookham",
+    "lat": 51.5588,
+    "lng": -0.7322,
+    "authorityId": 40,
+    "population": 5215
+  },
+  {
+    "slug": "maidenhead",
+    "name": "Maidenhead",
+    "lat": 51.5181,
+    "lng": -0.7276,
+    "authorityId": 40,
+    "population": 67375
+  },
+  {
+    "slug": "old-windsor-and-wraysbury",
+    "name": "Old Windsor and Wraysbury",
+    "lat": 51.4607,
+    "lng": -0.5703,
+    "authorityId": 40,
+    "population": 7690
+  },
+  {
+    "slug": "windsor",
+    "name": "Windsor",
+    "lat": 51.4755,
+    "lng": -0.6409,
+    "authorityId": 40,
+    "population": 31560
+  },
+  {
+    "slug": "crowthorne",
+    "name": "Crowthorne",
+    "lat": 51.3733,
+    "lng": -0.7927,
+    "authorityId": 41,
+    "population": 15190
+  },
+  {
+    "slug": "shinfield",
+    "name": "Shinfield",
+    "lat": 51.4082,
+    "lng": -0.9481,
+    "authorityId": 41,
+    "population": 5420
+  },
+  {
+    "slug": "spencers-wood-and-three-mile-cross",
+    "name": "Spencers Wood and Three Mile Cross",
+    "lat": 51.3957,
+    "lng": -0.968,
+    "authorityId": 41,
+    "population": 7610
+  },
+  {
+    "slug": "twyford-wokingham",
+    "name": "Twyford (Wokingham)",
+    "lat": 51.4787,
+    "lng": -0.8589,
+    "authorityId": 41,
+    "population": 8070
+  },
+  {
+    "slug": "winnersh",
+    "name": "Winnersh",
+    "lat": 51.4333,
+    "lng": -0.8786,
+    "authorityId": 41,
+    "population": 8905
+  },
+  {
+    "slug": "wokingham",
+    "name": "Wokingham",
+    "lat": 51.395,
+    "lng": -0.8466,
+    "authorityId": 41,
+    "population": 50325
+  },
+  {
+    "slug": "woodley",
+    "name": "Woodley",
+    "lat": 51.4517,
+    "lng": -0.9022,
+    "authorityId": 41,
+    "population": 28025
+  },
+  {
+    "slug": "bletchley",
+    "name": "Bletchley",
+    "lat": 51.9927,
+    "lng": -0.7375,
+    "authorityId": 42,
+    "population": 45010
+  },
+  {
+    "slug": "milton-keynes",
+    "name": "Milton Keynes",
+    "lat": 52.0371,
+    "lng": -0.7632,
+    "authorityId": 42,
+    "population": 197340
+  },
+  {
+    "slug": "newport-pagnell",
+    "name": "Newport Pagnell",
+    "lat": 52.0824,
+    "lng": -0.7272,
+    "authorityId": 42,
+    "population": 15250
+  },
+  {
+    "slug": "olney",
+    "name": "Olney",
+    "lat": 52.1571,
+    "lng": -0.7063,
+    "authorityId": 42,
+    "population": 6600
+  },
+  {
+    "slug": "brighton-and-hove",
+    "name": "Brighton and Hove",
+    "lat": 50.8411,
+    "lng": -0.1073,
+    "authorityId": 43,
+    "population": 277105
+  },
+  {
+    "slug": "portsmouth",
+    "name": "Portsmouth",
+    "lat": 50.8234,
+    "lng": -1.0753,
+    "authorityId": 44,
+    "population": 223305
+  },
+  {
+    "slug": "southampton",
+    "name": "Southampton",
+    "lat": 50.9216,
+    "lng": -1.3876,
+    "authorityId": 45,
+    "population": 249620
+  },
+  {
+    "slug": "cowes",
+    "name": "Cowes",
+    "lat": 50.7513,
+    "lng": -1.3125,
+    "authorityId": 46,
+    "population": 14365
+  },
+  {
+    "slug": "east-cowes",
+    "name": "East Cowes",
+    "lat": 50.752,
+    "lng": -1.2809,
+    "authorityId": 46,
+    "population": 8430
+  },
+  {
+    "slug": "freshwater-and-totland",
+    "name": "Freshwater and Totland",
+    "lat": 50.6815,
+    "lng": -1.5256,
+    "authorityId": 46,
+    "population": 7520
+  },
+  {
+    "slug": "newport-isle-of-wight",
+    "name": "Newport (Isle of Wight)",
+    "lat": 50.7016,
+    "lng": -1.2988,
+    "authorityId": 46,
+    "population": 25405
+  },
+  {
+    "slug": "ryde",
+    "name": "Ryde",
+    "lat": 50.7226,
+    "lng": -1.1606,
+    "authorityId": 46,
+    "population": 24105
+  },
+  {
+    "slug": "sandown",
+    "name": "Sandown",
+    "lat": 50.6502,
+    "lng": -1.173,
+    "authorityId": 46,
+    "population": 11655
+  },
+  {
+    "slug": "shanklin",
+    "name": "Shanklin",
+    "lat": 50.6295,
+    "lng": -1.1842,
+    "authorityId": 46,
+    "population": 9120
+  },
+  {
+    "slug": "ventnor",
+    "name": "Ventnor",
+    "lat": 50.5965,
+    "lng": -1.2155,
+    "authorityId": 46,
+    "population": 5565
+  },
+  {
+    "slug": "annfield-plain",
+    "name": "Annfield Plain",
+    "lat": 54.8608,
+    "lng": -1.7386,
+    "authorityId": 47,
+    "population": 7785
+  },
+  {
+    "slug": "barnard-castle",
+    "name": "Barnard Castle",
+    "lat": 54.5476,
+    "lng": -1.9151,
+    "authorityId": 47,
+    "population": 5785
+  },
+  {
+    "slug": "bishop-auckland",
+    "name": "Bishop Auckland",
+    "lat": 54.65,
+    "lng": -1.6929,
+    "authorityId": 47,
+    "population": 23355
+  },
+  {
+    "slug": "brandon-county-durham",
+    "name": "Brandon (County Durham)",
+    "lat": 54.7525,
+    "lng": -1.6211,
+    "authorityId": 47,
+    "population": 9505
+  },
+  {
+    "slug": "chester-le-street",
+    "name": "Chester-le-Street",
+    "lat": 54.8559,
+    "lng": -1.5785,
+    "authorityId": 47,
+    "population": 23560
+  },
+  {
+    "slug": "consett",
+    "name": "Consett",
+    "lat": 54.8504,
+    "lng": -1.8413,
+    "authorityId": 47,
+    "population": 29885
+  },
+  {
+    "slug": "crook",
+    "name": "Crook",
+    "lat": 54.7127,
+    "lng": -1.749,
+    "authorityId": 47,
+    "population": 9715
+  },
+  {
+    "slug": "durham",
+    "name": "Durham",
+    "lat": 54.7832,
+    "lng": -1.5728,
+    "authorityId": 47,
+    "population": 50510
+  },
+  {
+    "slug": "easington-county-durham",
+    "name": "Easington (County Durham)",
+    "lat": 54.7873,
+    "lng": -1.3327,
+    "authorityId": 47,
+    "population": 6965
+  },
+  {
+    "slug": "ferryhill",
+    "name": "Ferryhill",
+    "lat": 54.6847,
+    "lng": -1.5497,
+    "authorityId": 47,
+    "population": 8860
+  },
+  {
+    "slug": "horden",
+    "name": "Horden",
+    "lat": 54.7648,
+    "lng": -1.3167,
+    "authorityId": 47,
+    "population": 6805
+  },
+  {
+    "slug": "murton-county-durham",
+    "name": "Murton (County Durham)",
+    "lat": 54.8168,
+    "lng": -1.3817,
+    "authorityId": 47,
+    "population": 7240
+  },
+  {
+    "slug": "newton-aycliffe",
+    "name": "Newton Aycliffe",
+    "lat": 54.6196,
+    "lng": -1.5798,
+    "authorityId": 47,
+    "population": 25765
+  },
+  {
+    "slug": "pelton-and-ouston",
+    "name": "Pelton and Ouston",
+    "lat": 54.8777,
+    "lng": -1.6053,
+    "authorityId": 47,
+    "population": 7305
+  },
+  {
+    "slug": "peterlee",
+    "name": "Peterlee",
+    "lat": 54.7596,
+    "lng": -1.3492,
+    "authorityId": 47,
+    "population": 19750
+  },
+  {
+    "slug": "sacriston",
+    "name": "Sacriston",
+    "lat": 54.8193,
+    "lng": -1.6262,
+    "authorityId": 47,
+    "population": 5190
+  },
+  {
+    "slug": "seaham",
+    "name": "Seaham",
+    "lat": 54.8365,
+    "lng": -1.3521,
+    "authorityId": 47,
+    "population": 21665
+  },
+  {
+    "slug": "shildon",
+    "name": "Shildon",
+    "lat": 54.6302,
+    "lng": -1.6439,
+    "authorityId": 47,
+    "population": 9645
+  },
+  {
+    "slug": "spennymoor",
+    "name": "Spennymoor",
+    "lat": 54.7059,
+    "lng": -1.5913,
+    "authorityId": 47,
+    "population": 20410
+  },
+  {
+    "slug": "stanley-county-durham",
+    "name": "Stanley (County Durham)",
+    "lat": 54.8649,
+    "lng": -1.6923,
+    "authorityId": 47,
+    "population": 19415
+  },
+  {
+    "slug": "ushaw-moor-and-bearpark",
+    "name": "Ushaw Moor and Bearpark",
+    "lat": 54.7801,
+    "lng": -1.6358,
+    "authorityId": 47,
+    "population": 6480
+  },
+  {
+    "slug": "willington-county-durham",
+    "name": "Willington (County Durham)",
+    "lat": 54.7094,
+    "lng": -1.6904,
+    "authorityId": 47,
+    "population": 5685
+  },
+  {
+    "slug": "wingate",
+    "name": "Wingate",
+    "lat": 54.7306,
+    "lng": -1.3738,
+    "authorityId": 47,
+    "population": 5035
+  },
+  {
+    "slug": "alnwick",
+    "name": "Alnwick",
+    "lat": 55.4066,
+    "lng": -1.701,
+    "authorityId": 48,
+    "population": 8435
+  },
+  {
+    "slug": "amble",
+    "name": "Amble",
+    "lat": 55.3307,
+    "lng": -1.5774,
+    "authorityId": 48,
+    "population": 5860
+  },
+  {
+    "slug": "ashington-northumberland",
+    "name": "Ashington (Northumberland)",
+    "lat": 55.1777,
+    "lng": -1.5579,
+    "authorityId": 48,
+    "population": 28280
+  },
+  {
+    "slug": "bedlington",
+    "name": "Bedlington",
+    "lat": 55.134,
+    "lng": -1.5956,
+    "authorityId": 48,
+    "population": 16185
+  },
+  {
+    "slug": "berwick-upon-tweed",
+    "name": "Berwick-upon-Tweed",
+    "lat": 55.7635,
+    "lng": -2.0134,
+    "authorityId": 48,
+    "population": 13175
+  },
+  {
+    "slug": "blyth-northumberland",
+    "name": "Blyth (Northumberland)",
+    "lat": 55.1211,
+    "lng": -1.5253,
+    "authorityId": 48,
+    "population": 39730
+  },
+  {
+    "slug": "cramlington",
+    "name": "Cramlington",
+    "lat": 55.0878,
+    "lng": -1.5928,
+    "authorityId": 48,
+    "population": 28845
+  },
+  {
+    "slug": "hexham",
+    "name": "Hexham",
+    "lat": 54.9704,
+    "lng": -2.1023,
+    "authorityId": 48,
+    "population": 10945
+  },
+  {
+    "slug": "morpeth",
+    "name": "Morpeth",
+    "lat": 55.1659,
+    "lng": -1.6917,
+    "authorityId": 48,
+    "population": 14420
+  },
+  {
+    "slug": "newbiggin-by-the-sea",
+    "name": "Newbiggin-by-the-Sea",
+    "lat": 55.1856,
+    "lng": -1.5161,
+    "authorityId": 48,
+    "population": 5950
+  },
+  {
+    "slug": "ponteland",
+    "name": "Ponteland",
+    "lat": 55.0417,
+    "lng": -1.7593,
+    "authorityId": 48,
+    "population": 10150
+  },
+  {
+    "slug": "prudhoe",
+    "name": "Prudhoe",
+    "lat": 54.96,
+    "lng": -1.8479,
+    "authorityId": 48,
+    "population": 10280
+  },
+  {
+    "slug": "seaton-delaval",
+    "name": "Seaton Delaval",
+    "lat": 55.0688,
+    "lng": -1.5197,
+    "authorityId": 48,
+    "population": 8010
+  },
+  {
+    "slug": "stakeford",
+    "name": "Stakeford",
+    "lat": 55.1624,
+    "lng": -1.5904,
+    "authorityId": 48,
+    "population": 8190
+  },
+  {
+    "slug": "alsager",
+    "name": "Alsager",
+    "lat": 53.0957,
+    "lng": -2.2984,
+    "authorityId": 49,
+    "population": 15505
+  },
+  {
+    "slug": "bollington",
+    "name": "Bollington",
+    "lat": 53.2928,
+    "lng": -2.1109,
+    "authorityId": 49,
+    "population": 7235
+  },
+  {
+    "slug": "congleton",
+    "name": "Congleton",
+    "lat": 53.1663,
+    "lng": -2.2129,
+    "authorityId": 49,
+    "population": 30005
+  },
+  {
+    "slug": "crewe",
+    "name": "Crewe",
+    "lat": 53.0939,
+    "lng": -2.4495,
+    "authorityId": 49,
+    "population": 74120
+  },
+  {
+    "slug": "elworth",
+    "name": "Elworth",
+    "lat": 53.1455,
+    "lng": -2.3945,
+    "authorityId": 49,
+    "population": 7645
+  },
+  {
+    "slug": "haslington",
+    "name": "Haslington",
+    "lat": 53.1001,
+    "lng": -2.3952,
+    "authorityId": 49,
+    "population": 5040
+  },
+  {
+    "slug": "holmes-chapel",
+    "name": "Holmes Chapel",
+    "lat": 53.1997,
+    "lng": -2.3564,
+    "authorityId": 49,
+    "population": 6670
+  },
+  {
+    "slug": "knutsford",
+    "name": "Knutsford",
+    "lat": 53.3034,
+    "lng": -2.3701,
+    "authorityId": 49,
+    "population": 13255
+  },
+  {
+    "slug": "macclesfield",
+    "name": "Macclesfield",
+    "lat": 53.2612,
+    "lng": -2.1324,
+    "authorityId": 49,
+    "population": 54345
+  },
+  {
+    "slug": "middlewich",
+    "name": "Middlewich",
+    "lat": 53.1889,
+    "lng": -2.4414,
+    "authorityId": 49,
+    "population": 14425
+  },
+  {
+    "slug": "nantwich",
+    "name": "Nantwich",
+    "lat": 53.0655,
+    "lng": -2.5169,
+    "authorityId": 49,
+    "population": 18740
+  },
+  {
+    "slug": "poynton",
+    "name": "Poynton",
+    "lat": 53.3483,
+    "lng": -2.1182,
+    "authorityId": 49,
+    "population": 13010
+  },
+  {
+    "slug": "sandbach",
+    "name": "Sandbach",
+    "lat": 53.1432,
+    "lng": -2.3662,
+    "authorityId": 49,
+    "population": 11290
+  },
+  {
+    "slug": "wilmslow",
+    "name": "Wilmslow",
+    "lat": 53.3265,
+    "lng": -2.2283,
+    "authorityId": 49,
+    "population": 25725
+  },
+  {
+    "slug": "barnton",
+    "name": "Barnton",
+    "lat": 53.2733,
+    "lng": -2.5468,
+    "authorityId": 50,
+    "population": 6255
+  },
+  {
+    "slug": "cuddington-cheshire-west-and-chester",
+    "name": "Cuddington (Cheshire West and Chester)",
+    "lat": 53.2387,
+    "lng": -2.6058,
+    "authorityId": 50,
+    "population": 5860
+  },
+  {
+    "slug": "davenham",
+    "name": "Davenham",
+    "lat": 53.2367,
+    "lng": -2.5141,
+    "authorityId": 50,
+    "population": 13835
+  },
+  {
+    "slug": "ellesmere-port",
+    "name": "Ellesmere Port",
+    "lat": 53.2761,
+    "lng": -2.9132,
+    "authorityId": 50,
+    "population": 65430
+  },
+  {
+    "slug": "frodsham",
+    "name": "Frodsham",
+    "lat": 53.2908,
+    "lng": -2.719,
+    "authorityId": 50,
+    "population": 9100
+  },
+  {
+    "slug": "hartford",
+    "name": "Hartford",
+    "lat": 53.2454,
+    "lng": -2.5507,
+    "authorityId": 50,
+    "population": 6695
+  },
+  {
+    "slug": "helsby",
+    "name": "Helsby",
+    "lat": 53.2696,
+    "lng": -2.7644,
+    "authorityId": 50,
+    "population": 5275
+  },
+  {
+    "slug": "neston-cheshire-west-and-chester",
+    "name": "Neston (Cheshire West and Chester)",
+    "lat": 53.2964,
+    "lng": -3.0607,
+    "authorityId": 50,
+    "population": 14960
+  },
+  {
+    "slug": "northwich",
+    "name": "Northwich",
+    "lat": 53.26,
+    "lng": -2.5234,
+    "authorityId": 50,
+    "population": 18640
+  },
+  {
+    "slug": "weaverham",
+    "name": "Weaverham",
+    "lat": 53.2605,
+    "lng": -2.5719,
+    "authorityId": 50,
+    "population": 6265
+  },
+  {
+    "slug": "winsford",
+    "name": "Winsford",
+    "lat": 53.189,
+    "lng": -2.525,
+    "authorityId": 50,
+    "population": 32530
+  },
+  {
+    "slug": "albrighton",
+    "name": "Albrighton",
+    "lat": 52.6395,
+    "lng": -2.2883,
+    "authorityId": 51,
+    "population": 6985
+  },
+  {
+    "slug": "bayston-hill",
+    "name": "Bayston Hill",
+    "lat": 52.6746,
+    "lng": -2.7752,
+    "authorityId": 51,
+    "population": 5220
+  },
+  {
+    "slug": "bridgnorth",
+    "name": "Bridgnorth",
+    "lat": 52.5358,
+    "lng": -2.4216,
+    "authorityId": 51,
+    "population": 12175
+  },
+  {
+    "slug": "broseley",
+    "name": "Broseley",
+    "lat": 52.6176,
+    "lng": -2.4859,
+    "authorityId": 51,
+    "population": 5595
+  },
+  {
+    "slug": "ludlow",
+    "name": "Ludlow",
+    "lat": 52.3698,
+    "lng": -2.7121,
+    "authorityId": 51,
+    "population": 10040
+  },
+  {
+    "slug": "market-drayton",
+    "name": "Market Drayton",
+    "lat": 52.9066,
+    "lng": -2.4865,
+    "authorityId": 51,
+    "population": 12060
+  },
+  {
+    "slug": "oswestry",
+    "name": "Oswestry",
+    "lat": 52.8562,
+    "lng": -3.0486,
+    "authorityId": 51,
+    "population": 17510
+  },
+  {
+    "slug": "shifnal",
+    "name": "Shifnal",
+    "lat": 52.6685,
+    "lng": -2.3693,
+    "authorityId": 51,
+    "population": 8980
+  },
+  {
+    "slug": "shrewsbury",
+    "name": "Shrewsbury",
+    "lat": 52.7112,
+    "lng": -2.7532,
+    "authorityId": 51,
+    "population": 76015
+  },
+  {
+    "slug": "wem",
+    "name": "Wem",
+    "lat": 52.8571,
+    "lng": -2.7218,
+    "authorityId": 51,
+    "population": 6280
+  },
+  {
+    "slug": "whitchurch-shropshire",
+    "name": "Whitchurch (Shropshire)",
+    "lat": 52.9692,
+    "lng": -2.688,
+    "authorityId": 51,
+    "population": 9855
+  },
+  {
+    "slug": "bodmin",
+    "name": "Bodmin",
+    "lat": 50.4673,
+    "lng": -4.7156,
+    "authorityId": 52,
+    "population": 16910
+  },
+  {
+    "slug": "bude",
+    "name": "Bude",
+    "lat": 50.827,
+    "lng": -4.539,
+    "authorityId": 52,
+    "population": 7350
+  },
+  {
+    "slug": "camborne",
+    "name": "Camborne",
+    "lat": 50.2149,
+    "lng": -5.2959,
+    "authorityId": 52,
+    "population": 20450
+  },
+  {
+    "slug": "falmouth",
+    "name": "Falmouth",
+    "lat": 50.1503,
+    "lng": -5.082,
+    "authorityId": 52,
+    "population": 24070
+  },
+  {
+    "slug": "hayle",
+    "name": "Hayle",
+    "lat": 50.1914,
+    "lng": -5.4096,
+    "authorityId": 52,
+    "population": 9040
+  },
+  {
+    "slug": "helston",
+    "name": "Helston",
+    "lat": 50.1016,
+    "lng": -5.2699,
+    "authorityId": 52,
+    "population": 11360
+  },
+  {
+    "slug": "launceston",
+    "name": "Launceston",
+    "lat": 50.6342,
+    "lng": -4.3655,
+    "authorityId": 52,
+    "population": 8425
+  },
+  {
+    "slug": "liskeard",
+    "name": "Liskeard",
+    "lat": 50.4545,
+    "lng": -4.462,
+    "authorityId": 52,
+    "population": 10900
+  },
+  {
+    "slug": "looe",
+    "name": "Looe",
+    "lat": 50.3551,
+    "lng": -4.4548,
+    "authorityId": 52,
+    "population": 5310
+  },
+  {
+    "slug": "newquay",
+    "name": "Newquay",
+    "lat": 50.413,
+    "lng": -5.0594,
+    "authorityId": 52,
+    "population": 24545
+  },
+  {
+    "slug": "penryn",
+    "name": "Penryn",
+    "lat": 50.1685,
+    "lng": -5.113,
+    "authorityId": 52,
+    "population": 11195
+  },
+  {
+    "slug": "penzance",
+    "name": "Penzance",
+    "lat": 50.1207,
+    "lng": -5.5442,
+    "authorityId": 52,
+    "population": 14960
+  },
+  {
+    "slug": "pool-and-illogan",
+    "name": "Pool and Illogan",
+    "lat": 50.2396,
+    "lng": -5.2649,
+    "authorityId": 52,
+    "population": 8585
+  },
+  {
+    "slug": "redruth",
+    "name": "Redruth",
+    "lat": 50.2345,
+    "lng": -5.2244,
+    "authorityId": 52,
+    "population": 15455
+  },
+  {
+    "slug": "saltash",
+    "name": "Saltash",
+    "lat": 50.4098,
+    "lng": -4.2257,
+    "authorityId": 52,
+    "population": 15435
+  },
+  {
+    "slug": "st-austell",
+    "name": "St Austell",
+    "lat": 50.3436,
+    "lng": -4.783,
+    "authorityId": 52,
+    "population": 24360
+  },
+  {
+    "slug": "st-blazey",
+    "name": "St Blazey",
+    "lat": 50.3522,
+    "lng": -4.7208,
+    "authorityId": 52,
+    "population": 6575
+  },
+  {
+    "slug": "st-ives-cornwall",
+    "name": "St Ives (Cornwall)",
+    "lat": 50.2094,
+    "lng": -5.4848,
+    "authorityId": 52,
+    "population": 5410
+  },
+  {
+    "slug": "torpoint",
+    "name": "Torpoint",
+    "lat": 50.3773,
+    "lng": -4.2059,
+    "authorityId": 52,
+    "population": 7160
+  },
+  {
+    "slug": "truro",
+    "name": "Truro",
+    "lat": 50.2636,
+    "lng": -5.0524,
+    "authorityId": 52,
+    "population": 23060
+  },
+  {
+    "slug": "wadebridge",
+    "name": "Wadebridge",
+    "lat": 50.5177,
+    "lng": -4.837,
+    "authorityId": 52,
+    "population": 5625
+  },
+  {
+    "slug": "amesbury",
+    "name": "Amesbury",
+    "lat": 51.158,
+    "lng": -1.7538,
+    "authorityId": 54,
+    "population": 12680
+  },
+  {
+    "slug": "bradford-on-avon",
+    "name": "Bradford-on-Avon",
+    "lat": 51.3444,
+    "lng": -2.2482,
+    "authorityId": 54,
+    "population": 9865
+  },
+  {
+    "slug": "calne",
+    "name": "Calne",
+    "lat": 51.4366,
+    "lng": -1.9935,
+    "authorityId": 54,
+    "population": 19725
+  },
+  {
+    "slug": "chippenham-wiltshire",
+    "name": "Chippenham (Wiltshire)",
+    "lat": 51.4584,
+    "lng": -2.124,
+    "authorityId": 54,
+    "population": 36090
+  },
+  {
+    "slug": "corsham",
+    "name": "Corsham",
+    "lat": 51.4304,
+    "lng": -2.1916,
+    "authorityId": 54,
+    "population": 10890
+  },
+  {
+    "slug": "devizes",
+    "name": "Devizes",
+    "lat": 51.3508,
+    "lng": -1.9859,
+    "authorityId": 54,
+    "population": 19490
+  },
+  {
+    "slug": "durrington",
+    "name": "Durrington",
+    "lat": 51.1991,
+    "lng": -1.7743,
+    "authorityId": 54,
+    "population": 5720
+  },
+  {
+    "slug": "ludgershall-wiltshire",
+    "name": "Ludgershall (Wiltshire)",
+    "lat": 51.2536,
+    "lng": -1.6093,
+    "authorityId": 54,
+    "population": 5395
+  },
+  {
+    "slug": "malmesbury",
+    "name": "Malmesbury",
+    "lat": 51.5863,
+    "lng": -2.1011,
+    "authorityId": 54,
+    "population": 7180
+  },
+  {
+    "slug": "marlborough",
+    "name": "Marlborough",
+    "lat": 51.4208,
+    "lng": -1.7314,
+    "authorityId": 54,
+    "population": 8830
+  },
+  {
+    "slug": "melksham",
+    "name": "Melksham",
+    "lat": 51.3762,
+    "lng": -2.1311,
+    "authorityId": 54,
+    "population": 18280
+  },
+  {
+    "slug": "royal-wootton-bassett",
+    "name": "Royal Wootton Bassett",
+    "lat": 51.5421,
+    "lng": -1.8977,
+    "authorityId": 54,
+    "population": 13005
+  },
+  {
+    "slug": "salisbury",
+    "name": "Salisbury",
+    "lat": 51.0747,
+    "lng": -1.7988,
+    "authorityId": 54,
+    "population": 47690
+  },
+  {
+    "slug": "tidworth",
+    "name": "Tidworth",
+    "lat": 51.2357,
+    "lng": -1.6703,
+    "authorityId": 54,
+    "population": 10690
+  },
+  {
+    "slug": "trowbridge",
+    "name": "Trowbridge",
+    "lat": 51.3252,
+    "lng": -2.1993,
+    "authorityId": 54,
+    "population": 43750
+  },
+  {
+    "slug": "warminster",
+    "name": "Warminster",
+    "lat": 51.2039,
+    "lng": -2.1741,
+    "authorityId": 54,
+    "population": 18020
+  },
+  {
+    "slug": "westbury-wiltshire",
+    "name": "Westbury (Wiltshire)",
+    "lat": 51.2634,
+    "lng": -2.1924,
+    "authorityId": 54,
+    "population": 16395
+  },
+  {
+    "slug": "bedford",
+    "name": "Bedford",
+    "lat": 52.1393,
+    "lng": -0.4595,
+    "authorityId": 55,
+    "population": 97235
+  },
+  {
+    "slug": "kempston",
+    "name": "Kempston",
+    "lat": 52.1149,
+    "lng": -0.4944,
+    "authorityId": 55,
+    "population": 22785
+  },
+  {
+    "slug": "wootton-bedford",
+    "name": "Wootton (Bedford)",
+    "lat": 52.0928,
+    "lng": -0.5289,
+    "authorityId": 55,
+    "population": 7565
+  },
+  {
+    "slug": "ampthill",
+    "name": "Ampthill",
+    "lat": 52.0249,
+    "lng": -0.4972,
+    "authorityId": 56,
+    "population": 8825
+  },
+  {
+    "slug": "arlesey",
+    "name": "Arlesey",
+    "lat": 52.015,
+    "lng": -0.266,
+    "authorityId": 56,
+    "population": 6025
+  },
+  {
+    "slug": "biggleswade",
+    "name": "Biggleswade",
+    "lat": 52.0841,
+    "lng": -0.2527,
+    "authorityId": 56,
+    "population": 21950
+  },
+  {
+    "slug": "cranfield",
+    "name": "Cranfield",
+    "lat": 52.0706,
+    "lng": -0.6135,
+    "authorityId": 56,
+    "population": 7050
+  },
+  {
+    "slug": "dunstable",
+    "name": "Dunstable",
+    "lat": 51.8855,
+    "lng": -0.5314,
+    "authorityId": 56,
+    "population": 34500
+  },
+  {
+    "slug": "flitwick",
+    "name": "Flitwick",
+    "lat": 52.0049,
+    "lng": -0.4973,
+    "authorityId": 56,
+    "population": 13660
+  },
+  {
+    "slug": "houghton-regis",
+    "name": "Houghton Regis",
+    "lat": 51.9075,
+    "lng": -0.5225,
+    "authorityId": 56,
+    "population": 18820
+  },
+  {
+    "slug": "leighton-buzzard",
+    "name": "Leighton Buzzard",
+    "lat": 51.9206,
+    "lng": -0.6623,
+    "authorityId": 56,
+    "population": 42735
+  },
+  {
+    "slug": "marston-moretaine",
+    "name": "Marston Moretaine",
+    "lat": 52.067,
+    "lng": -0.5477,
+    "authorityId": 56,
+    "population": 6350
+  },
+  {
+    "slug": "potton",
+    "name": "Potton",
+    "lat": 52.128,
+    "lng": -0.215,
+    "authorityId": 56,
+    "population": 5230
+  },
+  {
+    "slug": "sandy",
+    "name": "Sandy",
+    "lat": 52.1366,
+    "lng": -0.2928,
+    "authorityId": 56,
+    "population": 11375
+  },
+  {
+    "slug": "shefford",
+    "name": "Shefford",
+    "lat": 52.0372,
+    "lng": -0.3313,
+    "authorityId": 56,
+    "population": 7310
+  },
+  {
+    "slug": "stotfold",
+    "name": "Stotfold",
+    "lat": 52.0146,
+    "lng": -0.2348,
+    "authorityId": 56,
+    "population": 12310
+  },
+  {
+    "slug": "wixams",
+    "name": "Wixams",
+    "lat": 52.0874,
+    "lng": -0.4726,
+    "authorityId": 56,
+    "population": 6050
+  },
+  {
+    "slug": "cambridge-cambridge",
+    "name": "Cambridge (Cambridge)",
+    "lat": 52.2039,
+    "lng": 0.1363,
+    "authorityId": 61,
+    "population": 152740
+  },
+  {
+    "slug": "burwell",
+    "name": "Burwell",
+    "lat": 52.2776,
+    "lng": 0.3266,
+    "authorityId": 62,
+    "population": 5915
+  },
+  {
+    "slug": "ely",
+    "name": "Ely",
+    "lat": 52.3994,
+    "lng": 0.2592,
+    "authorityId": 62,
+    "population": 19185
+  },
+  {
+    "slug": "littleport",
+    "name": "Littleport",
+    "lat": 52.4559,
+    "lng": 0.3014,
+    "authorityId": 62,
+    "population": 9165
+  },
+  {
+    "slug": "soham",
+    "name": "Soham",
+    "lat": 52.3337,
+    "lng": 0.3385,
+    "authorityId": 62,
+    "population": 10615
+  },
+  {
+    "slug": "chatteris",
+    "name": "Chatteris",
+    "lat": 52.4548,
+    "lng": 0.0477,
+    "authorityId": 63,
+    "population": 11015
+  },
+  {
+    "slug": "march",
+    "name": "March",
+    "lat": 52.554,
+    "lng": 0.0867,
+    "authorityId": 63,
+    "population": 21345
+  },
+  {
+    "slug": "whittlesey",
+    "name": "Whittlesey",
+    "lat": 52.5568,
+    "lng": -0.1204,
+    "authorityId": 63,
+    "population": 13830
+  },
+  {
+    "slug": "wisbech",
+    "name": "Wisbech",
+    "lat": 52.6668,
+    "lng": 0.1626,
+    "authorityId": 63,
+    "population": 26795
+  },
+  {
+    "slug": "brampton-huntingdonshire",
+    "name": "Brampton (Huntingdonshire)",
+    "lat": 52.3215,
+    "lng": -0.2345,
+    "authorityId": 64,
+    "population": 6585
+  },
+  {
+    "slug": "godmanchester",
+    "name": "Godmanchester",
+    "lat": 52.314,
+    "lng": -0.1658,
+    "authorityId": 64,
+    "population": 7715
+  },
+  {
+    "slug": "huntingdon",
+    "name": "Huntingdon",
+    "lat": 52.3392,
+    "lng": -0.1827,
+    "authorityId": 64,
+    "population": 25600
+  },
+  {
+    "slug": "ramsey",
+    "name": "Ramsey",
+    "lat": 52.4488,
+    "lng": -0.1102,
+    "authorityId": 64,
+    "population": 5730
+  },
+  {
+    "slug": "sawtry",
+    "name": "Sawtry",
+    "lat": 52.437,
+    "lng": -0.2841,
+    "authorityId": 64,
+    "population": 5875
+  },
+  {
+    "slug": "st-ives-huntingdonshire",
+    "name": "St Ives (Huntingdonshire)",
+    "lat": 52.3334,
+    "lng": -0.0758,
+    "authorityId": 64,
+    "population": 16820
+  },
+  {
+    "slug": "st-neots",
+    "name": "St Neots",
+    "lat": 52.2236,
+    "lng": -0.2684,
+    "authorityId": 64,
+    "population": 33265
+  },
+  {
+    "slug": "yaxley-huntingdonshire",
+    "name": "Yaxley (Huntingdonshire)",
+    "lat": 52.516,
+    "lng": -0.259,
+    "authorityId": 64,
+    "population": 9405
+  },
+  {
+    "slug": "cambourne",
+    "name": "Cambourne",
+    "lat": 52.2171,
+    "lng": -0.0701,
+    "authorityId": 65,
+    "population": 11075
+  },
+  {
+    "slug": "cottenham",
+    "name": "Cottenham",
+    "lat": 52.2846,
+    "lng": 0.1215,
+    "authorityId": 65,
+    "population": 6155
+  },
+  {
+    "slug": "great-shelford-and-stapleford",
+    "name": "Great Shelford and Stapleford",
+    "lat": 52.1502,
+    "lng": 0.1386,
+    "authorityId": 65,
+    "population": 6160
+  },
+  {
+    "slug": "histon-and-impington",
+    "name": "Histon and Impington",
+    "lat": 52.2507,
+    "lng": 0.1104,
+    "authorityId": 65,
+    "population": 7780
+  },
+  {
+    "slug": "longstanton-and-northstowe",
+    "name": "Longstanton and Northstowe",
+    "lat": 52.2793,
+    "lng": 0.0592,
+    "authorityId": 65,
+    "population": 5275
+  },
+  {
+    "slug": "sawston",
+    "name": "Sawston",
+    "lat": 52.1229,
+    "lng": 0.1693,
+    "authorityId": 65,
+    "population": 7270
+  },
+  {
+    "slug": "waterbeach",
+    "name": "Waterbeach",
+    "lat": 52.2725,
+    "lng": 0.1853,
+    "authorityId": 65,
+    "population": 5375
+  },
+  {
+    "slug": "alfreton",
+    "name": "Alfreton",
+    "lat": 53.0966,
+    "lng": -1.3822,
+    "authorityId": 72,
+    "population": 8795
+  },
+  {
+    "slug": "belper",
+    "name": "Belper",
+    "lat": 53.0253,
+    "lng": -1.474,
+    "authorityId": 72,
+    "population": 19075
+  },
+  {
+    "slug": "heanor",
+    "name": "Heanor",
+    "lat": 53.0153,
+    "lng": -1.3443,
+    "authorityId": 72,
+    "population": 24260
+  },
+  {
+    "slug": "ripley-amber-valley",
+    "name": "Ripley (Amber Valley)",
+    "lat": 53.0428,
+    "lng": -1.3976,
+    "authorityId": 72,
+    "population": 20180
+  },
+  {
+    "slug": "somercotes-and-swanwick",
+    "name": "Somercotes and Swanwick",
+    "lat": 53.0769,
+    "lng": -1.3755,
+    "authorityId": 72,
+    "population": 15100
+  },
+  {
+    "slug": "bolsover",
+    "name": "Bolsover",
+    "lat": 53.2316,
+    "lng": -1.2955,
+    "authorityId": 73,
+    "population": 11225
+  },
+  {
+    "slug": "clowne",
+    "name": "Clowne",
+    "lat": 53.2745,
+    "lng": -1.2618,
+    "authorityId": 73,
+    "population": 7760
+  },
+  {
+    "slug": "creswell",
+    "name": "Creswell",
+    "lat": 53.2625,
+    "lng": -1.2199,
+    "authorityId": 73,
+    "population": 5795
+  },
+  {
+    "slug": "shirebrook",
+    "name": "Shirebrook",
+    "lat": 53.2016,
+    "lng": -1.2174,
+    "authorityId": 73,
+    "population": 11575
+  },
+  {
+    "slug": "south-normanton-and-pinxton",
+    "name": "South Normanton and Pinxton",
+    "lat": 53.0989,
+    "lng": -1.3307,
+    "authorityId": 73,
+    "population": 16025
+  },
+  {
+    "slug": "brimington",
+    "name": "Brimington",
+    "lat": 53.2556,
+    "lng": -1.3972,
+    "authorityId": 74,
+    "population": 11075
+  },
+  {
+    "slug": "chesterfield",
+    "name": "Chesterfield",
+    "lat": 53.2407,
+    "lng": -1.4388,
+    "authorityId": 74,
+    "population": 76420
+  },
+  {
+    "slug": "staveley-chesterfield",
+    "name": "Staveley (Chesterfield)",
+    "lat": 53.2612,
+    "lng": -1.3642,
+    "authorityId": 74,
+    "population": 15145
+  },
+  {
+    "slug": "ashbourne",
+    "name": "Ashbourne",
+    "lat": 53.0136,
+    "lng": -1.7285,
+    "authorityId": 75,
+    "population": 8855
+  },
+  {
+    "slug": "matlock",
+    "name": "Matlock",
+    "lat": 53.1422,
+    "lng": -1.549,
+    "authorityId": 75,
+    "population": 11990
+  },
+  {
+    "slug": "borrowash",
+    "name": "Borrowash",
+    "lat": 52.9092,
+    "lng": -1.3758,
+    "authorityId": 76,
+    "population": 7165
+  },
+  {
+    "slug": "breaston-and-draycott",
+    "name": "Breaston and Draycott",
+    "lat": 52.8995,
+    "lng": -1.3094,
+    "authorityId": 76,
+    "population": 7395
+  },
+  {
+    "slug": "ilkeston",
+    "name": "Ilkeston",
+    "lat": 52.9644,
+    "lng": -1.3102,
+    "authorityId": 76,
+    "population": 38725
+  },
+  {
+    "slug": "long-eaton",
+    "name": "Long Eaton",
+    "lat": 52.892,
+    "lng": -1.2888,
+    "authorityId": 76,
+    "population": 37820
+  },
+  {
+    "slug": "sandiacre",
+    "name": "Sandiacre",
+    "lat": 52.9221,
+    "lng": -1.2953,
+    "authorityId": 76,
+    "population": 9370
+  },
+  {
+    "slug": "west-hallam",
+    "name": "West Hallam",
+    "lat": 52.9692,
+    "lng": -1.356,
+    "authorityId": 76,
+    "population": 5910
+  },
+  {
+    "slug": "buxton-high-peak",
+    "name": "Buxton (High Peak)",
+    "lat": 53.2538,
+    "lng": -1.9128,
+    "authorityId": 77,
+    "population": 20050
+  },
+  {
+    "slug": "chapel-en-le-frith",
+    "name": "Chapel-en-le-Frith",
+    "lat": 53.3231,
+    "lng": -1.9204,
+    "authorityId": 77,
+    "population": 7240
+  },
+  {
+    "slug": "glossop",
+    "name": "Glossop",
+    "lat": 53.4429,
+    "lng": -1.9461,
+    "authorityId": 77,
+    "population": 17820
+  },
+  {
+    "slug": "hadfield",
+    "name": "Hadfield",
+    "lat": 53.4575,
+    "lng": -1.987,
+    "authorityId": 77,
+    "population": 16275
+  },
+  {
+    "slug": "new-mills",
+    "name": "New Mills",
+    "lat": 53.3668,
+    "lng": -2.0001,
+    "authorityId": 77,
+    "population": 9200
+  },
+  {
+    "slug": "clay-cross",
+    "name": "Clay Cross",
+    "lat": 53.167,
+    "lng": -1.4123,
+    "authorityId": 78,
+    "population": 8920
+  },
+  {
+    "slug": "dronfield",
+    "name": "Dronfield",
+    "lat": 53.3029,
+    "lng": -1.4673,
+    "authorityId": 78,
+    "population": 21160
+  },
+  {
+    "slug": "eckington-north-east-derbyshire",
+    "name": "Eckington (North East Derbyshire)",
+    "lat": 53.3063,
+    "lng": -1.3698,
+    "authorityId": 78,
+    "population": 7435
+  },
+  {
+    "slug": "killamarsh",
+    "name": "Killamarsh",
+    "lat": 53.3216,
+    "lng": -1.3149,
+    "authorityId": 78,
+    "population": 9080
+  },
+  {
+    "slug": "north-wingfield-and-holmewood",
+    "name": "North Wingfield and Holmewood",
+    "lat": 53.1882,
+    "lng": -1.3659,
+    "authorityId": 78,
+    "population": 9540
+  },
+  {
+    "slug": "wingerworth",
+    "name": "Wingerworth",
+    "lat": 53.2025,
+    "lng": -1.429,
+    "authorityId": 78,
+    "population": 6400
+  },
+  {
+    "slug": "hilton-south-derbyshire",
+    "name": "Hilton (South Derbyshire)",
+    "lat": 52.8707,
+    "lng": -1.6303,
+    "authorityId": 79,
+    "population": 8275
+  },
+  {
+    "slug": "overseal-and-castle-gresley",
+    "name": "Overseal and Castle Gresley",
+    "lat": 52.7382,
+    "lng": -1.5652,
+    "authorityId": 79,
+    "population": 5055
+  },
+  {
+    "slug": "swadlincote",
+    "name": "Swadlincote",
+    "lat": 52.7756,
+    "lng": -1.5646,
+    "authorityId": 79,
+    "population": 34565
+  },
+  {
+    "slug": "woodville",
+    "name": "Woodville",
+    "lat": 52.7698,
+    "lng": -1.5285,
+    "authorityId": 79,
+    "population": 7255
+  },
+  {
+    "slug": "axminster",
+    "name": "Axminster",
+    "lat": 50.7811,
+    "lng": -2.9945,
+    "authorityId": 80,
+    "population": 6095
+  },
+  {
+    "slug": "budleigh-salterton",
+    "name": "Budleigh Salterton",
+    "lat": 50.6326,
+    "lng": -3.3364,
+    "authorityId": 80,
+    "population": 5235
+  },
+  {
+    "slug": "exmouth",
+    "name": "Exmouth",
+    "lat": 50.6269,
+    "lng": -3.3948,
+    "authorityId": 80,
+    "population": 35500
+  },
+  {
+    "slug": "honiton",
+    "name": "Honiton",
+    "lat": 50.7952,
+    "lng": -3.1965,
+    "authorityId": 80,
+    "population": 12155
+  },
+  {
+    "slug": "ottery-st-mary",
+    "name": "Ottery St Mary",
+    "lat": 50.7522,
+    "lng": -3.2779,
+    "authorityId": 80,
+    "population": 6045
+  },
+  {
+    "slug": "seaton-east-devon",
+    "name": "Seaton (East Devon)",
+    "lat": 50.7093,
+    "lng": -3.0747,
+    "authorityId": 80,
+    "population": 7435
+  },
+  {
+    "slug": "sidmouth",
+    "name": "Sidmouth",
+    "lat": 50.6925,
+    "lng": -3.2401,
+    "authorityId": 80,
+    "population": 13265
+  },
+  {
+    "slug": "exeter",
+    "name": "Exeter",
+    "lat": 50.7174,
+    "lng": -3.5124,
+    "authorityId": 81,
+    "population": 126175
+  },
+  {
+    "slug": "crediton",
+    "name": "Crediton",
+    "lat": 50.7874,
+    "lng": -3.6494,
+    "authorityId": 82,
+    "population": 7975
+  },
+  {
+    "slug": "cullompton",
+    "name": "Cullompton",
+    "lat": 50.8565,
+    "lng": -3.3966,
+    "authorityId": 82,
+    "population": 8895
+  },
+  {
+    "slug": "tiverton",
+    "name": "Tiverton",
+    "lat": 50.9034,
+    "lng": -3.4858,
+    "authorityId": 82,
+    "population": 19710
+  },
+  {
+    "slug": "barnstaple",
+    "name": "Barnstaple",
+    "lat": 51.0773,
+    "lng": -4.0564,
+    "authorityId": 83,
+    "population": 31275
+  },
+  {
+    "slug": "braunton",
+    "name": "Braunton",
+    "lat": 51.1084,
+    "lng": -4.1596,
+    "authorityId": 83,
+    "population": 6610
+  },
+  {
+    "slug": "fremington",
+    "name": "Fremington",
+    "lat": 51.0673,
+    "lng": -4.1503,
+    "authorityId": 83,
+    "population": 5230
+  },
+  {
+    "slug": "ilfracombe",
+    "name": "Ilfracombe",
+    "lat": 51.2034,
+    "lng": -4.1217,
+    "authorityId": 83,
+    "population": 9200
+  },
+  {
+    "slug": "south-molton",
+    "name": "South Molton",
+    "lat": 51.0187,
+    "lng": -3.8339,
+    "authorityId": 83,
+    "population": 6225
+  },
+  {
+    "slug": "dartmouth",
+    "name": "Dartmouth",
+    "lat": 50.3495,
+    "lng": -3.5874,
+    "authorityId": 84,
+    "population": 5260
+  },
+  {
+    "slug": "ivybridge",
+    "name": "Ivybridge",
+    "lat": 50.3899,
+    "lng": -3.9237,
+    "authorityId": 84,
+    "population": 12490
+  },
+  {
+    "slug": "kingsbridge",
+    "name": "Kingsbridge",
+    "lat": 50.284,
+    "lng": -3.7729,
+    "authorityId": 84,
+    "population": 5680
+  },
+  {
+    "slug": "totnes",
+    "name": "Totnes",
+    "lat": 50.4319,
+    "lng": -3.6873,
+    "authorityId": 84,
+    "population": 9215
+  },
+  {
+    "slug": "bovey-tracey",
+    "name": "Bovey Tracey",
+    "lat": 50.5892,
+    "lng": -3.6785,
+    "authorityId": 85,
+    "population": 6240
+  },
+  {
+    "slug": "dawlish",
+    "name": "Dawlish",
+    "lat": 50.5895,
+    "lng": -3.4678,
+    "authorityId": 85,
+    "population": 11800
+  },
+  {
+    "slug": "kingsteignton",
+    "name": "Kingsteignton",
+    "lat": 50.5494,
+    "lng": -3.5944,
+    "authorityId": 85,
+    "population": 11940
+  },
+  {
+    "slug": "newton-abbot",
+    "name": "Newton Abbot",
+    "lat": 50.5272,
+    "lng": -3.6169,
+    "authorityId": 85,
+    "population": 29650
+  },
+  {
+    "slug": "teignmouth",
+    "name": "Teignmouth",
+    "lat": 50.5568,
+    "lng": -3.5003,
+    "authorityId": 85,
+    "population": 15315
+  },
+  {
+    "slug": "bideford",
+    "name": "Bideford",
+    "lat": 51.0181,
+    "lng": -4.2121,
+    "authorityId": 86,
+    "population": 19490
+  },
+  {
+    "slug": "great-torrington",
+    "name": "Great Torrington",
+    "lat": 50.9522,
+    "lng": -4.1456,
+    "authorityId": 86,
+    "population": 5955
+  },
+  {
+    "slug": "northam",
+    "name": "Northam",
+    "lat": 51.0392,
+    "lng": -4.214,
+    "authorityId": 86,
+    "population": 5190
+  },
+  {
+    "slug": "okehampton",
+    "name": "Okehampton",
+    "lat": 50.7417,
+    "lng": -3.995,
+    "authorityId": 87,
+    "population": 9110
+  },
+  {
+    "slug": "tavistock",
+    "name": "Tavistock",
+    "lat": 50.5457,
+    "lng": -4.1441,
+    "authorityId": 87,
+    "population": 12670
+  },
+  {
+    "slug": "eastbourne",
+    "name": "Eastbourne",
+    "lat": 50.7919,
+    "lng": 0.2841,
+    "authorityId": 94,
+    "population": 99180
+  },
+  {
+    "slug": "hastings",
+    "name": "Hastings",
+    "lat": 50.8745,
+    "lng": 0.5636,
+    "authorityId": 95,
+    "population": 91490
+  },
+  {
+    "slug": "lewes",
+    "name": "Lewes",
+    "lat": 50.8744,
+    "lng": 0.0025,
+    "authorityId": 96,
+    "population": 16060
+  },
+  {
+    "slug": "newhaven",
+    "name": "Newhaven",
+    "lat": 50.7908,
+    "lng": 0.0491,
+    "authorityId": 96,
+    "population": 12850
+  },
+  {
+    "slug": "peacehaven",
+    "name": "Peacehaven",
+    "lat": 50.797,
+    "lng": 0.0069,
+    "authorityId": 96,
+    "population": 15700
+  },
+  {
+    "slug": "seaford",
+    "name": "Seaford",
+    "lat": 50.776,
+    "lng": 0.1144,
+    "authorityId": 96,
+    "population": 23865
+  },
+  {
+    "slug": "battle",
+    "name": "Battle",
+    "lat": 50.9226,
+    "lng": 0.4842,
+    "authorityId": 97,
+    "population": 5330
+  },
+  {
+    "slug": "bexhill-on-sea",
+    "name": "Bexhill-on-Sea",
+    "lat": 50.8487,
+    "lng": 0.4472,
+    "authorityId": 97,
+    "population": 43755
+  },
+  {
+    "slug": "crowborough",
+    "name": "Crowborough",
+    "lat": 51.0528,
+    "lng": 0.1635,
+    "authorityId": 98,
+    "population": 21990
+  },
+  {
+    "slug": "hailsham",
+    "name": "Hailsham",
+    "lat": 50.866,
+    "lng": 0.257,
+    "authorityId": 98,
+    "population": 22550
+  },
+  {
+    "slug": "heathfield-wealden",
+    "name": "Heathfield (Wealden)",
+    "lat": 50.9668,
+    "lng": 0.2552,
+    "authorityId": 98,
+    "population": 7670
+  },
+  {
+    "slug": "lower-willingdon",
+    "name": "Lower Willingdon",
+    "lat": 50.807,
+    "lng": 0.2506,
+    "authorityId": 98,
+    "population": 6130
+  },
+  {
+    "slug": "polegate",
+    "name": "Polegate",
+    "lat": 50.821,
+    "lng": 0.2459,
+    "authorityId": 98,
+    "population": 10065
+  },
+  {
+    "slug": "stone-cross",
+    "name": "Stone Cross",
+    "lat": 50.8167,
+    "lng": 0.2981,
+    "authorityId": 98,
+    "population": 5035
+  },
+  {
+    "slug": "uckfield",
+    "name": "Uckfield",
+    "lat": 50.9694,
+    "lng": 0.0975,
+    "authorityId": 98,
+    "population": 15035
+  },
+  {
+    "slug": "basildon",
+    "name": "Basildon",
+    "lat": 51.5712,
+    "lng": 0.438,
+    "authorityId": 99,
+    "population": 115955
+  },
+  {
+    "slug": "billericay",
+    "name": "Billericay",
+    "lat": 51.6287,
+    "lng": 0.4236,
+    "authorityId": 99,
+    "population": 34075
+  },
+  {
+    "slug": "wickford",
+    "name": "Wickford",
+    "lat": 51.6096,
+    "lng": 0.5162,
+    "authorityId": 99,
+    "population": 27535
+  },
+  {
+    "slug": "braintree",
+    "name": "Braintree",
+    "lat": 51.8825,
+    "lng": 0.5551,
+    "authorityId": 100,
+    "population": 43190
+  },
+  {
+    "slug": "great-notley",
+    "name": "Great Notley",
+    "lat": 51.8624,
+    "lng": 0.5272,
+    "authorityId": 100,
+    "population": 7660
+  },
+  {
+    "slug": "halstead-braintree",
+    "name": "Halstead (Braintree)",
+    "lat": 51.9443,
+    "lng": 0.6369,
+    "authorityId": 100,
+    "population": 13900
+  },
+  {
+    "slug": "witham",
+    "name": "Witham",
+    "lat": 51.8043,
+    "lng": 0.6354,
+    "authorityId": 100,
+    "population": 27395
+  },
+  {
+    "slug": "brentwood",
+    "name": "Brentwood",
+    "lat": 51.625,
+    "lng": 0.2996,
+    "authorityId": 101,
+    "population": 55340
+  },
+  {
+    "slug": "ingatestone",
+    "name": "Ingatestone",
+    "lat": 51.6698,
+    "lng": 0.3786,
+    "authorityId": 101,
+    "population": 5410
+  },
+  {
+    "slug": "canvey-island",
+    "name": "Canvey Island",
+    "lat": 51.5211,
+    "lng": 0.5771,
+    "authorityId": 102,
+    "population": 38010
+  },
+  {
+    "slug": "thundersley-and-south-benfleet",
+    "name": "Thundersley and South Benfleet",
+    "lat": 51.5635,
+    "lng": 0.5723,
+    "authorityId": 102,
+    "population": 49885
+  },
+  {
+    "slug": "chelmsford",
+    "name": "Chelmsford",
+    "lat": 51.7393,
+    "lng": 0.4822,
+    "authorityId": 103,
+    "population": 110625
+  },
+  {
+    "slug": "danbury",
+    "name": "Danbury",
+    "lat": 51.7201,
+    "lng": 0.5812,
+    "authorityId": 103,
+    "population": 6195
+  },
+  {
+    "slug": "galleywood",
+    "name": "Galleywood",
+    "lat": 51.6979,
+    "lng": 0.4758,
+    "authorityId": 103,
+    "population": 6410
+  },
+  {
+    "slug": "runwell",
+    "name": "Runwell",
+    "lat": 51.6257,
+    "lng": 0.5243,
+    "authorityId": 103,
+    "population": 8085
+  },
+  {
+    "slug": "south-woodham-ferrers",
+    "name": "South Woodham Ferrers",
+    "lat": 51.6445,
+    "lng": 0.6087,
+    "authorityId": 103,
+    "population": 16025
+  },
+  {
+    "slug": "berechurch",
+    "name": "Berechurch",
+    "lat": 51.8628,
+    "lng": 0.9026,
+    "authorityId": 104,
+    "population": 7705
+  },
+  {
+    "slug": "colchester",
+    "name": "Colchester",
+    "lat": 51.8924,
+    "lng": 0.904,
+    "authorityId": 104,
+    "population": 130245
+  },
+  {
+    "slug": "tiptree",
+    "name": "Tiptree",
+    "lat": 51.8129,
+    "lng": 0.7444,
+    "authorityId": 104,
+    "population": 9300
+  },
+  {
+    "slug": "west-mersea",
+    "name": "West Mersea",
+    "lat": 51.7793,
+    "lng": 0.9246,
+    "authorityId": 104,
+    "population": 7065
+  },
+  {
+    "slug": "wivenhoe",
+    "name": "Wivenhoe",
+    "lat": 51.8632,
+    "lng": 0.9631,
+    "authorityId": 104,
+    "population": 7350
+  },
+  {
+    "slug": "buckhurst-hill",
+    "name": "Buckhurst Hill",
+    "lat": 51.6281,
+    "lng": 0.041,
+    "authorityId": 105,
+    "population": 11750
+  },
+  {
+    "slug": "chigwell",
+    "name": "Chigwell",
+    "lat": 51.6153,
+    "lng": 0.0777,
+    "authorityId": 105,
+    "population": 12250
+  },
+  {
+    "slug": "epping",
+    "name": "Epping",
+    "lat": 51.6943,
+    "lng": 0.108,
+    "authorityId": 105,
+    "population": 10695
+  },
+  {
+    "slug": "loughton",
+    "name": "Loughton",
+    "lat": 51.6516,
+    "lng": 0.0737,
+    "authorityId": 105,
+    "population": 33345
+  },
+  {
+    "slug": "waltham-abbey",
+    "name": "Waltham Abbey",
+    "lat": 51.6872,
+    "lng": 0.0062,
+    "authorityId": 105,
+    "population": 18645
+  },
+  {
+    "slug": "harlow",
+    "name": "Harlow",
+    "lat": 51.7681,
+    "lng": 0.1167,
+    "authorityId": 106,
+    "population": 93580
+  },
+  {
+    "slug": "burnham-on-crouch",
+    "name": "Burnham-on-Crouch",
+    "lat": 51.6332,
+    "lng": 0.8133,
+    "authorityId": 107,
+    "population": 7805
+  },
+  {
+    "slug": "maldon",
+    "name": "Maldon",
+    "lat": 51.7344,
+    "lng": 0.6931,
+    "authorityId": 107,
+    "population": 23380
+  },
+  {
+    "slug": "ashingdon",
+    "name": "Ashingdon",
+    "lat": 51.6098,
+    "lng": 0.6876,
+    "authorityId": 108,
+    "population": 6485
+  },
+  {
+    "slug": "great-wakering",
+    "name": "Great Wakering",
+    "lat": 51.554,
+    "lng": 0.7989,
+    "authorityId": 108,
+    "population": 6775
+  },
+  {
+    "slug": "hockley-and-hawkwell",
+    "name": "Hockley and Hawkwell",
+    "lat": 51.6051,
+    "lng": 0.6553,
+    "authorityId": 108,
+    "population": 15425
+  },
+  {
+    "slug": "hullbridge",
+    "name": "Hullbridge",
+    "lat": 51.6219,
+    "lng": 0.6152,
+    "authorityId": 108,
+    "population": 5710
+  },
+  {
+    "slug": "rayleigh",
+    "name": "Rayleigh",
+    "lat": 51.5928,
+    "lng": 0.5961,
+    "authorityId": 108,
+    "population": 32380
+  },
+  {
+    "slug": "rochford",
+    "name": "Rochford",
+    "lat": 51.5869,
+    "lng": 0.7018,
+    "authorityId": 108,
+    "population": 12615
+  },
+  {
+    "slug": "brightlingsea",
+    "name": "Brightlingsea",
+    "lat": 51.813,
+    "lng": 1.0257,
+    "authorityId": 109,
+    "population": 8680
+  },
+  {
+    "slug": "clacton-on-sea",
+    "name": "Clacton-on-Sea",
+    "lat": 51.7994,
+    "lng": 1.1455,
+    "authorityId": 109,
+    "population": 53200
+  },
+  {
+    "slug": "harwich",
+    "name": "Harwich",
+    "lat": 51.9312,
+    "lng": 1.2604,
+    "authorityId": 109,
+    "population": 20215
+  },
+  {
+    "slug": "jaywick",
+    "name": "Jaywick",
+    "lat": 51.7799,
+    "lng": 1.1133,
+    "authorityId": 109,
+    "population": 5085
+  },
+  {
+    "slug": "kirby-cross",
+    "name": "Kirby Cross",
+    "lat": 51.8437,
+    "lng": 1.2245,
+    "authorityId": 109,
+    "population": 6035
+  },
+  {
+    "slug": "walton-on-the-naze",
+    "name": "Walton-on-the-Naze",
+    "lat": 51.8475,
+    "lng": 1.2616,
+    "authorityId": 109,
+    "population": 6990
+  },
+  {
+    "slug": "great-dunmow",
+    "name": "Great Dunmow",
+    "lat": 51.8747,
+    "lng": 0.3556,
+    "authorityId": 110,
+    "population": 10395
+  },
+  {
+    "slug": "saffron-walden",
+    "name": "Saffron Walden",
+    "lat": 52.0196,
+    "lng": 0.2463,
+    "authorityId": 110,
+    "population": 16610
+  },
+  {
+    "slug": "stansted-mountfitchet",
+    "name": "Stansted Mountfitchet",
+    "lat": 51.8995,
+    "lng": 0.1997,
+    "authorityId": 110,
+    "population": 8625
+  },
+  {
+    "slug": "takeley-and-little-canfield",
+    "name": "Takeley and Little Canfield",
+    "lat": 51.868,
+    "lng": 0.2749,
+    "authorityId": 110,
+    "population": 5550
+  },
+  {
+    "slug": "cheltenham",
+    "name": "Cheltenham",
+    "lat": 51.8961,
+    "lng": -2.0829,
+    "authorityId": 111,
+    "population": 115940
+  },
+  {
+    "slug": "cirencester",
+    "name": "Cirencester",
+    "lat": 51.7105,
+    "lng": -1.9679,
+    "authorityId": 112,
+    "population": 17715
+  },
+  {
+    "slug": "moreton-in-marsh",
+    "name": "Moreton-in-Marsh",
+    "lat": 51.9903,
+    "lng": -1.6907,
+    "authorityId": 112,
+    "population": 5010
+  },
+  {
+    "slug": "tetbury",
+    "name": "Tetbury",
+    "lat": 51.6404,
+    "lng": -2.1579,
+    "authorityId": 112,
+    "population": 6455
+  },
+  {
+    "slug": "cinderford",
+    "name": "Cinderford",
+    "lat": 51.8253,
+    "lng": -2.5004,
+    "authorityId": 113,
+    "population": 8775
+  },
+  {
+    "slug": "coleford-forest-of-dean",
+    "name": "Coleford (Forest of Dean)",
+    "lat": 51.7943,
+    "lng": -2.6165,
+    "authorityId": 113,
+    "population": 5020
+  },
+  {
+    "slug": "lydney",
+    "name": "Lydney",
+    "lat": 51.7234,
+    "lng": -2.5268,
+    "authorityId": 113,
+    "population": 9660
+  },
+  {
+    "slug": "newent",
+    "name": "Newent",
+    "lat": 51.9305,
+    "lng": -2.4059,
+    "authorityId": 113,
+    "population": 5360
+  },
+  {
+    "slug": "gloucester",
+    "name": "Gloucester",
+    "lat": 51.8548,
+    "lng": -2.2245,
+    "authorityId": 114,
+    "population": 118555
+  },
+  {
+    "slug": "quedgeley-and-hardwicke",
+    "name": "Quedgeley and Hardwicke",
+    "lat": 51.8201,
+    "lng": -2.2815,
+    "authorityId": 114,
+    "population": 21125
+  },
+  {
+    "slug": "cam",
+    "name": "Cam",
+    "lat": 51.6997,
+    "lng": -2.3666,
+    "authorityId": 115,
+    "population": 7730
+  },
+  {
+    "slug": "chalford",
+    "name": "Chalford",
+    "lat": 51.7262,
+    "lng": -2.1552,
+    "authorityId": 115,
+    "population": 6660
+  },
+  {
+    "slug": "dursley",
+    "name": "Dursley",
+    "lat": 51.6784,
+    "lng": -2.3472,
+    "authorityId": 115,
+    "population": 7935
+  },
+  {
+    "slug": "nailsworth",
+    "name": "Nailsworth",
+    "lat": 51.6954,
+    "lng": -2.224,
+    "authorityId": 115,
+    "population": 5660
+  },
+  {
+    "slug": "stonehouse-stroud",
+    "name": "Stonehouse (Stroud)",
+    "lat": 51.7502,
+    "lng": -2.2964,
+    "authorityId": 115,
+    "population": 8300
+  },
+  {
+    "slug": "stroud",
+    "name": "Stroud",
+    "lat": 51.7432,
+    "lng": -2.2263,
+    "authorityId": 115,
+    "population": 26080
+  },
+  {
+    "slug": "bishops-cleeve",
+    "name": "Bishop's Cleeve",
+    "lat": 51.9456,
+    "lng": -2.0634,
+    "authorityId": 116,
+    "population": 16325
+  },
+  {
+    "slug": "brockworth",
+    "name": "Brockworth",
+    "lat": 51.8467,
+    "lng": -2.1616,
+    "authorityId": 116,
+    "population": 12005
+  },
+  {
+    "slug": "churchdown",
+    "name": "Churchdown",
+    "lat": 51.8884,
+    "lng": -2.1946,
+    "authorityId": 116,
+    "population": 13480
+  },
+  {
+    "slug": "tewkesbury",
+    "name": "Tewkesbury",
+    "lat": 51.99,
+    "lng": -2.1461,
+    "authorityId": 116,
+    "population": 14390
+  },
+  {
+    "slug": "basingstoke",
+    "name": "Basingstoke",
+    "lat": 51.2658,
+    "lng": -1.1031,
+    "authorityId": 117,
+    "population": 117210
+  },
+  {
+    "slug": "oakley-basingstoke-and-deane",
+    "name": "Oakley (Basingstoke and Deane)",
+    "lat": 51.2499,
+    "lng": -1.176,
+    "authorityId": 117,
+    "population": 5265
+  },
+  {
+    "slug": "tadley",
+    "name": "Tadley",
+    "lat": 51.3593,
+    "lng": -1.1469,
+    "authorityId": 117,
+    "population": 14760
+  },
+  {
+    "slug": "whitchurch-basingstoke-and-deane",
+    "name": "Whitchurch (Basingstoke and Deane)",
+    "lat": 51.2291,
+    "lng": -1.3353,
+    "authorityId": 117,
+    "population": 5290
+  },
+  {
+    "slug": "alton-east-hampshire",
+    "name": "Alton (East Hampshire)",
+    "lat": 51.154,
+    "lng": -0.9729,
+    "authorityId": 118,
+    "population": 17880
+  },
+  {
+    "slug": "bordon",
+    "name": "Bordon",
+    "lat": 51.1151,
+    "lng": -0.8621,
+    "authorityId": 118,
+    "population": 9350
+  },
+  {
+    "slug": "four-marks",
+    "name": "Four Marks",
+    "lat": 51.1093,
+    "lng": -1.0463,
+    "authorityId": 118,
+    "population": 5615
+  },
+  {
+    "slug": "hindhead",
+    "name": "Hindhead",
+    "lat": 51.112,
+    "lng": -0.7463,
+    "authorityId": 118,
+    "population": 6445
+  },
+  {
+    "slug": "horndean",
+    "name": "Horndean",
+    "lat": 50.9123,
+    "lng": -1.0172,
+    "authorityId": 118,
+    "population": 34050
+  },
+  {
+    "slug": "liphook",
+    "name": "Liphook",
+    "lat": 51.075,
+    "lng": -0.7988,
+    "authorityId": 118,
+    "population": 7130
+  },
+  {
+    "slug": "petersfield",
+    "name": "Petersfield",
+    "lat": 51.0061,
+    "lng": -0.9348,
+    "authorityId": 118,
+    "population": 14995
+  },
+  {
+    "slug": "whitehill-east-hampshire",
+    "name": "Whitehill (East Hampshire)",
+    "lat": 51.1023,
+    "lng": -0.8758,
+    "authorityId": 118,
+    "population": 5175
+  },
+  {
+    "slug": "botley",
+    "name": "Botley",
+    "lat": 50.916,
+    "lng": -1.2789,
+    "authorityId": 119,
+    "population": 5900
+  },
+  {
+    "slug": "bursledon",
+    "name": "Bursledon",
+    "lat": 50.8873,
+    "lng": -1.3149,
+    "authorityId": 119,
+    "population": 8070
+  },
+  {
+    "slug": "chandlers-ford",
+    "name": "Chandler's Ford",
+    "lat": 50.9898,
+    "lng": -1.3863,
+    "authorityId": 119,
+    "population": 31975
+  },
+  {
+    "slug": "eastleigh",
+    "name": "Eastleigh",
+    "lat": 50.9721,
+    "lng": -1.3396,
+    "authorityId": 119,
+    "population": 48360
+  },
+  {
+    "slug": "hedge-end",
+    "name": "Hedge End",
+    "lat": 50.9198,
+    "lng": -1.2999,
+    "authorityId": 119,
+    "population": 23190
+  },
+  {
+    "slug": "netley",
+    "name": "Netley",
+    "lat": 50.8753,
+    "lng": -1.3445,
+    "authorityId": 119,
+    "population": 6305
+  },
+  {
+    "slug": "west-end-eastleigh",
+    "name": "West End (Eastleigh)",
+    "lat": 50.9293,
+    "lng": -1.3317,
+    "authorityId": 119,
+    "population": 10870
+  },
+  {
+    "slug": "fareham",
+    "name": "Fareham",
+    "lat": 50.8512,
+    "lng": -1.1978,
+    "authorityId": 120,
+    "population": 42625
+  },
+  {
+    "slug": "lee-on-the-solent",
+    "name": "Lee-on-the-Solent",
+    "lat": 50.8212,
+    "lng": -1.2157,
+    "authorityId": 120,
+    "population": 24315
+  },
+  {
+    "slug": "locks-heath",
+    "name": "Locks Heath",
+    "lat": 50.8605,
+    "lng": -1.2758,
+    "authorityId": 120,
+    "population": 35755
+  },
+  {
+    "slug": "whiteley",
+    "name": "Whiteley",
+    "lat": 50.8851,
+    "lng": -1.2596,
+    "authorityId": 120,
+    "population": 9350
+  },
+  {
+    "slug": "gosport",
+    "name": "Gosport",
+    "lat": 50.7996,
+    "lng": -1.151,
+    "authorityId": 121,
+    "population": 70110
+  },
+  {
+    "slug": "blackwater-hart",
+    "name": "Blackwater (Hart)",
+    "lat": 51.3341,
+    "lng": -0.7925,
+    "authorityId": 122,
+    "population": 7170
+  },
+  {
+    "slug": "fleet",
+    "name": "Fleet",
+    "lat": 51.2759,
+    "lng": -0.8388,
+    "authorityId": 122,
+    "population": 37790
+  },
+  {
+    "slug": "hook-hart",
+    "name": "Hook (Hart)",
+    "lat": 51.2845,
+    "lng": -0.9555,
+    "authorityId": 122,
+    "population": 9065
+  },
+  {
+    "slug": "odiham",
+    "name": "Odiham",
+    "lat": 51.2526,
+    "lng": -0.9434,
+    "authorityId": 122,
+    "population": 5090
+  },
+  {
+    "slug": "yateley",
+    "name": "Yateley",
+    "lat": 51.3367,
+    "lng": -0.8346,
+    "authorityId": 122,
+    "population": 14685
+  },
+  {
+    "slug": "emsworth",
+    "name": "Emsworth",
+    "lat": 50.8527,
+    "lng": -0.9404,
+    "authorityId": 123,
+    "population": 11505
+  },
+  {
+    "slug": "havant",
+    "name": "Havant",
+    "lat": 50.8593,
+    "lng": -0.9883,
+    "authorityId": 123,
+    "population": 46960
+  },
+  {
+    "slug": "south-hayling",
+    "name": "South Hayling",
+    "lat": 50.7914,
+    "lng": -0.9747,
+    "authorityId": 123,
+    "population": 15305
+  },
+  {
+    "slug": "waterlooville",
+    "name": "Waterlooville",
+    "lat": 50.879,
+    "lng": -1.0328,
+    "authorityId": 123,
+    "population": 34775
+  },
+  {
+    "slug": "ashley-new-forest",
+    "name": "Ashley (New Forest)",
+    "lat": 50.7597,
+    "lng": -1.6348,
+    "authorityId": 124,
+    "population": 7725
+  },
+  {
+    "slug": "barton-on-sea",
+    "name": "Barton on Sea",
+    "lat": 50.7412,
+    "lng": -1.6573,
+    "authorityId": 124,
+    "population": 6760
+  },
+  {
+    "slug": "blackfield-and-langley",
+    "name": "Blackfield and Langley",
+    "lat": 50.8146,
+    "lng": -1.3733,
+    "authorityId": 124,
+    "population": 5845
+  },
+  {
+    "slug": "holbury",
+    "name": "Holbury",
+    "lat": 50.8338,
+    "lng": -1.3797,
+    "authorityId": 124,
+    "population": 7335
+  },
+  {
+    "slug": "hythe-and-dibden-purlieu",
+    "name": "Hythe and Dibden Purlieu",
+    "lat": 50.862,
+    "lng": -1.408,
+    "authorityId": 124,
+    "population": 19855
+  },
+  {
+    "slug": "lymington",
+    "name": "Lymington",
+    "lat": 50.7601,
+    "lng": -1.555,
+    "authorityId": 124,
+    "population": 14865
+  },
+  {
+    "slug": "marchwood",
+    "name": "Marchwood",
+    "lat": 50.893,
+    "lng": -1.4441,
+    "authorityId": 124,
+    "population": 5775
+  },
+  {
+    "slug": "new-milton",
+    "name": "New Milton",
+    "lat": 50.7554,
+    "lng": -1.6589,
+    "authorityId": 124,
+    "population": 11870
+  },
+  {
+    "slug": "ringwood",
+    "name": "Ringwood",
+    "lat": 50.8514,
+    "lng": -1.778,
+    "authorityId": 124,
+    "population": 12785
+  },
+  {
+    "slug": "totton",
+    "name": "Totton",
+    "lat": 50.9203,
+    "lng": -1.5064,
+    "authorityId": 124,
+    "population": 28090
+  },
+  {
+    "slug": "aldershot",
+    "name": "Aldershot",
+    "lat": 51.2487,
+    "lng": -0.7552,
+    "authorityId": 125,
+    "population": 39825
+  },
+  {
+    "slug": "farnborough",
+    "name": "Farnborough",
+    "lat": 51.2853,
+    "lng": -0.7692,
+    "authorityId": 125,
+    "population": 60655
+  },
+  {
+    "slug": "andover",
+    "name": "Andover",
+    "lat": 51.2133,
+    "lng": -1.4757,
+    "authorityId": 126,
+    "population": 48480
+  },
+  {
+    "slug": "north-baddesley",
+    "name": "North Baddesley",
+    "lat": 50.9776,
+    "lng": -1.4451,
+    "authorityId": 126,
+    "population": 7000
+  },
+  {
+    "slug": "romsey",
+    "name": "Romsey",
+    "lat": 50.9946,
+    "lng": -1.477,
+    "authorityId": 126,
+    "population": 19920
+  },
+  {
+    "slug": "bishops-waltham",
+    "name": "Bishop's Waltham",
+    "lat": 50.9587,
+    "lng": -1.2146,
+    "authorityId": 127,
+    "population": 6955
+  },
+  {
+    "slug": "denmead",
+    "name": "Denmead",
+    "lat": 50.903,
+    "lng": -1.0689,
+    "authorityId": 127,
+    "population": 6505
+  },
+  {
+    "slug": "new-alresford",
+    "name": "New Alresford",
+    "lat": 51.0862,
+    "lng": -1.1665,
+    "authorityId": 127,
+    "population": 5340
+  },
+  {
+    "slug": "winchester",
+    "name": "Winchester",
+    "lat": 51.0629,
+    "lng": -1.3193,
+    "authorityId": 127,
+    "population": 48480
+  },
+  {
+    "slug": "cheshunt",
+    "name": "Cheshunt",
+    "lat": 51.7074,
+    "lng": -0.0441,
+    "authorityId": 128,
+    "population": 43680
+  },
+  {
+    "slug": "hoddesdon",
+    "name": "Hoddesdon",
+    "lat": 51.7582,
+    "lng": -0.0103,
+    "authorityId": 128,
+    "population": 40615
+  },
+  {
+    "slug": "waltham-cross",
+    "name": "Waltham Cross",
+    "lat": 51.6886,
+    "lng": -0.0277,
+    "authorityId": 128,
+    "population": 11940
+  },
+  {
+    "slug": "berkhamsted",
+    "name": "Berkhamsted",
+    "lat": 51.7618,
+    "lng": -0.5727,
+    "authorityId": 129,
+    "population": 21240
+  },
+  {
+    "slug": "bovingdon",
+    "name": "Bovingdon",
+    "lat": 51.7228,
+    "lng": -0.5355,
+    "authorityId": 129,
+    "population": 5310
+  },
+  {
+    "slug": "hemel-hempstead",
+    "name": "Hemel Hempstead",
+    "lat": 51.7514,
+    "lng": -0.4646,
+    "authorityId": 129,
+    "population": 95985
+  },
+  {
+    "slug": "tring",
+    "name": "Tring",
+    "lat": 51.7986,
+    "lng": -0.6601,
+    "authorityId": 129,
+    "population": 11960
+  },
+  {
+    "slug": "bishops-stortford",
+    "name": "Bishop's Stortford",
+    "lat": 51.8691,
+    "lng": 0.1621,
+    "authorityId": 130,
+    "population": 40915
+  },
+  {
+    "slug": "buntingford",
+    "name": "Buntingford",
+    "lat": 51.9495,
+    "lng": -0.023,
+    "authorityId": 130,
+    "population": 7875
+  },
+  {
+    "slug": "hertford",
+    "name": "Hertford",
+    "lat": 51.7973,
+    "lng": -0.085,
+    "authorityId": 130,
+    "population": 28800
+  },
+  {
+    "slug": "sawbridgeworth",
+    "name": "Sawbridgeworth",
+    "lat": 51.8106,
+    "lng": 0.1475,
+    "authorityId": 130,
+    "population": 10475
+  },
+  {
+    "slug": "ware",
+    "name": "Ware",
+    "lat": 51.8126,
+    "lng": -0.0315,
+    "authorityId": 130,
+    "population": 19625
+  },
+  {
+    "slug": "borehamwood",
+    "name": "Borehamwood",
+    "lat": 51.6597,
+    "lng": -0.2756,
+    "authorityId": 131,
+    "population": 39765
+  },
+  {
+    "slug": "bushey",
+    "name": "Bushey",
+    "lat": 51.6525,
+    "lng": -0.3591,
+    "authorityId": 131,
+    "population": 28425
+  },
+  {
+    "slug": "potters-bar",
+    "name": "Potters Bar",
+    "lat": 51.6981,
+    "lng": -0.1836,
+    "authorityId": 131,
+    "population": 23400
+  },
+  {
+    "slug": "radlett",
+    "name": "Radlett",
+    "lat": 51.6841,
+    "lng": -0.3199,
+    "authorityId": 131,
+    "population": 8185
+  },
+  {
+    "slug": "baldock",
+    "name": "Baldock",
+    "lat": 51.9863,
+    "lng": -0.1873,
+    "authorityId": 132,
+    "population": 10615
+  },
+  {
+    "slug": "hitchin",
+    "name": "Hitchin",
+    "lat": 51.9526,
+    "lng": -0.271,
+    "authorityId": 132,
+    "population": 35220
+  },
+  {
+    "slug": "letchworth",
+    "name": "Letchworth",
+    "lat": 51.9793,
+    "lng": -0.2244,
+    "authorityId": 132,
+    "population": 33990
+  },
+  {
+    "slug": "royston-north-hertfordshire",
+    "name": "Royston (North Hertfordshire)",
+    "lat": 52.0512,
+    "lng": -0.0225,
+    "authorityId": 132,
+    "population": 17445
+  },
+  {
+    "slug": "chiswell-green",
+    "name": "Chiswell Green",
+    "lat": 51.7215,
+    "lng": -0.356,
+    "authorityId": 133,
+    "population": 6680
+  },
+  {
+    "slug": "harpenden",
+    "name": "Harpenden",
+    "lat": 51.815,
+    "lng": -0.3486,
+    "authorityId": 133,
+    "population": 30965
+  },
+  {
+    "slug": "london-colney",
+    "name": "London Colney",
+    "lat": 51.7177,
+    "lng": -0.2949,
+    "authorityId": 133,
+    "population": 7930
+  },
+  {
+    "slug": "redbourn",
+    "name": "Redbourn",
+    "lat": 51.7998,
+    "lng": -0.4,
+    "authorityId": 133,
+    "population": 5185
+  },
+  {
+    "slug": "st-albans",
+    "name": "St Albans",
+    "lat": 51.754,
+    "lng": -0.3207,
+    "authorityId": 133,
+    "population": 75540
+  },
+  {
+    "slug": "stevenage",
+    "name": "Stevenage",
+    "lat": 51.9096,
+    "lng": -0.1898,
+    "authorityId": 134,
+    "population": 94470
+  },
+  {
+    "slug": "abbots-langley-and-kings-langley",
+    "name": "Abbots Langley and Kings Langley",
+    "lat": 51.7078,
+    "lng": -0.4382,
+    "authorityId": 135,
+    "population": 18205
+  },
+  {
+    "slug": "chorleywood",
+    "name": "Chorleywood",
+    "lat": 51.6507,
+    "lng": -0.5092,
+    "authorityId": 135,
+    "population": 12630
+  },
+  {
+    "slug": "moor-park",
+    "name": "Moor Park",
+    "lat": 51.6266,
+    "lng": -0.4316,
+    "authorityId": 135,
+    "population": 5850
+  },
+  {
+    "slug": "rickmansworth",
+    "name": "Rickmansworth",
+    "lat": 51.6395,
+    "lng": -0.4658,
+    "authorityId": 135,
+    "population": 26290
+  },
+  {
+    "slug": "watford-watford",
+    "name": "Watford (Watford)",
+    "lat": 51.6479,
+    "lng": -0.4063,
+    "authorityId": 136,
+    "population": 131325
+  },
+  {
+    "slug": "hatfield",
+    "name": "Hatfield",
+    "lat": 51.7645,
+    "lng": -0.2325,
+    "authorityId": 137,
+    "population": 41560
+  },
+  {
+    "slug": "welwyn-garden-city",
+    "name": "Welwyn Garden City",
+    "lat": 51.8024,
+    "lng": -0.1936,
+    "authorityId": 137,
+    "population": 51505
+  },
+  {
+    "slug": "ashford-ashford",
+    "name": "Ashford (Ashford)",
+    "lat": 51.1413,
+    "lng": 0.8751,
+    "authorityId": 138,
+    "population": 82140
+  },
+  {
+    "slug": "tenterden",
+    "name": "Tenterden",
+    "lat": 51.075,
+    "lng": 0.692,
+    "authorityId": 138,
+    "population": 7775
+  },
+  {
+    "slug": "canterbury",
+    "name": "Canterbury",
+    "lat": 51.2786,
+    "lng": 1.081,
+    "authorityId": 139,
+    "population": 55090
+  },
+  {
+    "slug": "herne",
+    "name": "Herne",
+    "lat": 51.3532,
+    "lng": 1.1282,
+    "authorityId": 139,
+    "population": 14875
+  },
+  {
+    "slug": "herne-bay",
+    "name": "Herne Bay",
+    "lat": 51.3676,
+    "lng": 1.1459,
+    "authorityId": 139,
+    "population": 24870
+  },
+  {
+    "slug": "whitstable",
+    "name": "Whitstable",
+    "lat": 51.3512,
+    "lng": 1.0332,
+    "authorityId": 139,
+    "population": 32195
+  },
+  {
+    "slug": "dartford",
+    "name": "Dartford",
+    "lat": 51.446,
+    "lng": 0.2361,
+    "authorityId": 140,
+    "population": 69130
+  },
+  {
+    "slug": "stone-dartford",
+    "name": "Stone (Dartford)",
+    "lat": 51.4447,
+    "lng": 0.2665,
+    "authorityId": 140,
+    "population": 6440
+  },
+  {
+    "slug": "swanscombe",
+    "name": "Swanscombe",
+    "lat": 51.4476,
+    "lng": 0.3021,
+    "authorityId": 140,
+    "population": 15460
+  },
+  {
+    "slug": "aylesham",
+    "name": "Aylesham",
+    "lat": 51.2275,
+    "lng": 1.2013,
+    "authorityId": 141,
+    "population": 5785
+  },
+  {
+    "slug": "deal",
+    "name": "Deal",
+    "lat": 51.2156,
+    "lng": 1.3884,
+    "authorityId": 141,
+    "population": 28985
+  },
+  {
+    "slug": "dover",
+    "name": "Dover",
+    "lat": 51.1278,
+    "lng": 1.3037,
+    "authorityId": 141,
+    "population": 36360
+  },
+  {
+    "slug": "whitfield-dover",
+    "name": "Whitfield (Dover)",
+    "lat": 51.1565,
+    "lng": 1.2946,
+    "authorityId": 141,
+    "population": 6510
+  },
+  {
+    "slug": "gravesend",
+    "name": "Gravesend",
+    "lat": 51.4285,
+    "lng": 0.3826,
+    "authorityId": 142,
+    "population": 58105
+  },
+  {
+    "slug": "northfleet",
+    "name": "Northfleet",
+    "lat": 51.4381,
+    "lng": 0.3394,
+    "authorityId": 142,
+    "population": 29900
+  },
+  {
+    "slug": "bearsted",
+    "name": "Bearsted",
+    "lat": 51.2693,
+    "lng": 0.5744,
+    "authorityId": 143,
+    "population": 8350
+  },
+  {
+    "slug": "coxheath",
+    "name": "Coxheath",
+    "lat": 51.2347,
+    "lng": 0.5166,
+    "authorityId": 143,
+    "population": 8455
+  },
+  {
+    "slug": "maidstone",
+    "name": "Maidstone",
+    "lat": 51.2702,
+    "lng": 0.5215,
+    "authorityId": 143,
+    "population": 109490
+  },
+  {
+    "slug": "staplehurst",
+    "name": "Staplehurst",
+    "lat": 51.1679,
+    "lng": 0.5502,
+    "authorityId": 143,
+    "population": 6180
+  },
+  {
+    "slug": "edenbridge",
+    "name": "Edenbridge",
+    "lat": 51.2011,
+    "lng": 0.0619,
+    "authorityId": 144,
+    "population": 7900
+  },
+  {
+    "slug": "longfield-new-ash-green-and-hartley",
+    "name": "Longfield, New Ash Green and Hartley",
+    "lat": 51.3884,
+    "lng": 0.3152,
+    "authorityId": 144,
+    "population": 16075
+  },
+  {
+    "slug": "otford-and-kemsing",
+    "name": "Otford and Kemsing",
+    "lat": 51.3137,
+    "lng": 0.1913,
+    "authorityId": 144,
+    "population": 7335
+  },
+  {
+    "slug": "sevenoaks",
+    "name": "Sevenoaks",
+    "lat": 51.2784,
+    "lng": 0.1851,
+    "authorityId": 144,
+    "population": 26475
+  },
+  {
+    "slug": "swanley",
+    "name": "Swanley",
+    "lat": 51.3985,
+    "lng": 0.1704,
+    "authorityId": 144,
+    "population": 17210
+  },
+  {
+    "slug": "folkestone",
+    "name": "Folkestone",
+    "lat": 51.0858,
+    "lng": 1.1336,
+    "authorityId": 145,
+    "population": 51995
+  },
+  {
+    "slug": "hawkinge",
+    "name": "Hawkinge",
+    "lat": 51.1132,
+    "lng": 1.163,
+    "authorityId": 145,
+    "population": 8500
+  },
+  {
+    "slug": "hythe",
+    "name": "Hythe",
+    "lat": 51.0711,
+    "lng": 1.0744,
+    "authorityId": 145,
+    "population": 14620
+  },
+  {
+    "slug": "littlestone-on-sea",
+    "name": "Littlestone-on-Sea",
+    "lat": 50.9752,
+    "lng": 0.9623,
+    "authorityId": 145,
+    "population": 5270
+  },
+  {
+    "slug": "faversham",
+    "name": "Faversham",
+    "lat": 51.3129,
+    "lng": 0.8874,
+    "authorityId": 146,
+    "population": 20940
+  },
+  {
+    "slug": "minster-swale",
+    "name": "Minster (Swale)",
+    "lat": 51.4212,
+    "lng": 0.8042,
+    "authorityId": 146,
+    "population": 16740
+  },
+  {
+    "slug": "sheerness",
+    "name": "Sheerness",
+    "lat": 51.4357,
+    "lng": 0.7555,
+    "authorityId": 146,
+    "population": 13250
+  },
+  {
+    "slug": "sittingbourne",
+    "name": "Sittingbourne",
+    "lat": 51.3463,
+    "lng": 0.7396,
+    "authorityId": 146,
+    "population": 54390
+  },
+  {
+    "slug": "broadstairs",
+    "name": "Broadstairs",
+    "lat": 51.3639,
+    "lng": 1.4237,
+    "authorityId": 147,
+    "population": 25775
+  },
+  {
+    "slug": "margate",
+    "name": "Margate",
+    "lat": 51.3752,
+    "lng": 1.3753,
+    "authorityId": 147,
+    "population": 63320
+  },
+  {
+    "slug": "ramsgate",
+    "name": "Ramsgate",
+    "lat": 51.3391,
+    "lng": 1.4062,
+    "authorityId": 147,
+    "population": 42030
+  },
+  {
+    "slug": "kings-hill",
+    "name": "Kings Hill",
+    "lat": 51.2715,
+    "lng": 0.4105,
+    "authorityId": 148,
+    "population": 9970
+  },
+  {
+    "slug": "larkfield",
+    "name": "Larkfield",
+    "lat": 51.2992,
+    "lng": 0.447,
+    "authorityId": 148,
+    "population": 26150
+  },
+  {
+    "slug": "snodland",
+    "name": "Snodland",
+    "lat": 51.3298,
+    "lng": 0.4429,
+    "authorityId": 148,
+    "population": 11830
+  },
+  {
+    "slug": "tonbridge",
+    "name": "Tonbridge",
+    "lat": 51.1958,
+    "lng": 0.2822,
+    "authorityId": 148,
+    "population": 36125
+  },
+  {
+    "slug": "paddock-wood",
+    "name": "Paddock Wood",
+    "lat": 51.1796,
+    "lng": 0.3908,
+    "authorityId": 149,
+    "population": 7610
+  },
+  {
+    "slug": "pembury",
+    "name": "Pembury",
+    "lat": 51.1498,
+    "lng": 0.3279,
+    "authorityId": 149,
+    "population": 5785
+  },
+  {
+    "slug": "royal-tunbridge-wells",
+    "name": "Royal Tunbridge Wells",
+    "lat": 51.1333,
+    "lng": 0.2679,
+    "authorityId": 149,
+    "population": 51220
+  },
+  {
+    "slug": "rusthall-and-langton-green",
+    "name": "Rusthall and Langton Green",
+    "lat": 51.1317,
+    "lng": 0.2168,
+    "authorityId": 149,
+    "population": 7780
+  },
+  {
+    "slug": "southborough",
+    "name": "Southborough",
+    "lat": 51.1593,
+    "lng": 0.2579,
+    "authorityId": 149,
+    "population": 9630
+  },
+  {
+    "slug": "burnley",
+    "name": "Burnley",
+    "lat": 53.7937,
+    "lng": -2.234,
+    "authorityId": 150,
+    "population": 78255
+  },
+  {
+    "slug": "padiham",
+    "name": "Padiham",
+    "lat": 53.7999,
+    "lng": -2.3111,
+    "authorityId": 150,
+    "population": 10125
+  },
+  {
+    "slug": "adlington-chorley",
+    "name": "Adlington (Chorley)",
+    "lat": 53.6172,
+    "lng": -2.6044,
+    "authorityId": 151,
+    "population": 8780
+  },
+  {
+    "slug": "chorley",
+    "name": "Chorley",
+    "lat": 53.6529,
+    "lng": -2.633,
+    "authorityId": 151,
+    "population": 39535
+  },
+  {
+    "slug": "coppull",
+    "name": "Coppull",
+    "lat": 53.619,
+    "lng": -2.6628,
+    "authorityId": 151,
+    "population": 8300
+  },
+  {
+    "slug": "euxton",
+    "name": "Euxton",
+    "lat": 53.6743,
+    "lng": -2.6625,
+    "authorityId": 151,
+    "population": 17520
+  },
+  {
+    "slug": "kirkham",
+    "name": "Kirkham",
+    "lat": 53.7772,
+    "lng": -2.8708,
+    "authorityId": 152,
+    "population": 8935
+  },
+  {
+    "slug": "lytham-st-annes",
+    "name": "Lytham St Anne's",
+    "lat": 53.7507,
+    "lng": -2.9989,
+    "authorityId": 152,
+    "population": 42695
+  },
+  {
+    "slug": "accrington",
+    "name": "Accrington",
+    "lat": 53.7498,
+    "lng": -2.3608,
+    "authorityId": 153,
+    "population": 34895
+  },
+  {
+    "slug": "church",
+    "name": "Church",
+    "lat": 53.7551,
+    "lng": -2.3896,
+    "authorityId": 153,
+    "population": 5030
+  },
+  {
+    "slug": "clayton-le-moors",
+    "name": "Clayton-le-Moors",
+    "lat": 53.7761,
+    "lng": -2.3812,
+    "authorityId": 153,
+    "population": 7970
+  },
+  {
+    "slug": "great-harwood",
+    "name": "Great Harwood",
+    "lat": 53.787,
+    "lng": -2.4065,
+    "authorityId": 153,
+    "population": 11015
+  },
+  {
+    "slug": "oswaldtwistle",
+    "name": "Oswaldtwistle",
+    "lat": 53.7424,
+    "lng": -2.4002,
+    "authorityId": 153,
+    "population": 10810
+  },
+  {
+    "slug": "rishton",
+    "name": "Rishton",
+    "lat": 53.7679,
+    "lng": -2.4168,
+    "authorityId": 153,
+    "population": 6655
+  },
+  {
+    "slug": "bolton-le-sands",
+    "name": "Bolton-le-Sands",
+    "lat": 54.0895,
+    "lng": -2.8072,
+    "authorityId": 154,
+    "population": 6725
+  },
+  {
+    "slug": "carnforth",
+    "name": "Carnforth",
+    "lat": 54.1281,
+    "lng": -2.7676,
+    "authorityId": 154,
+    "population": 5855
+  },
+  {
+    "slug": "heysham",
+    "name": "Heysham",
+    "lat": 54.0547,
+    "lng": -2.882,
+    "authorityId": 154,
+    "population": 16585
+  },
+  {
+    "slug": "lancaster",
+    "name": "Lancaster",
+    "lat": 54.0518,
+    "lng": -2.7976,
+    "authorityId": 154,
+    "population": 52655
+  },
+  {
+    "slug": "morecambe",
+    "name": "Morecambe",
+    "lat": 54.0671,
+    "lng": -2.8476,
+    "authorityId": 154,
+    "population": 32750
+  },
+  {
+    "slug": "barnoldswick",
+    "name": "Barnoldswick",
+    "lat": 53.9192,
+    "lng": -2.1853,
+    "authorityId": 155,
+    "population": 10915
+  },
+  {
+    "slug": "barrowford",
+    "name": "Barrowford",
+    "lat": 53.8532,
+    "lng": -2.2229,
+    "authorityId": 155,
+    "population": 5885
+  },
+  {
+    "slug": "brierfield",
+    "name": "Brierfield",
+    "lat": 53.8242,
+    "lng": -2.2291,
+    "authorityId": 155,
+    "population": 10720
+  },
+  {
+    "slug": "colne",
+    "name": "Colne",
+    "lat": 53.8582,
+    "lng": -2.1699,
+    "authorityId": 155,
+    "population": 18910
+  },
+  {
+    "slug": "nelson-pendle",
+    "name": "Nelson (Pendle)",
+    "lat": 53.8366,
+    "lng": -2.2066,
+    "authorityId": 155,
+    "population": 33805
+  },
+  {
+    "slug": "cottam-preston",
+    "name": "Cottam (Preston)",
+    "lat": 53.7835,
+    "lng": -2.775,
+    "authorityId": 156,
+    "population": 5505
+  },
+  {
+    "slug": "fulwood",
+    "name": "Fulwood",
+    "lat": 53.788,
+    "lng": -2.7245,
+    "authorityId": 156,
+    "population": 34690
+  },
+  {
+    "slug": "preston-preston",
+    "name": "Preston (Preston)",
+    "lat": 53.7714,
+    "lng": -2.7008,
+    "authorityId": 156,
+    "population": 94490
+  },
+  {
+    "slug": "clitheroe",
+    "name": "Clitheroe",
+    "lat": 53.871,
+    "lng": -2.3915,
+    "authorityId": 157,
+    "population": 16630
+  },
+  {
+    "slug": "longridge-ribble-valley",
+    "name": "Longridge (Ribble Valley)",
+    "lat": 53.8296,
+    "lng": -2.6066,
+    "authorityId": 157,
+    "population": 8740
+  },
+  {
+    "slug": "bacup",
+    "name": "Bacup",
+    "lat": 53.6967,
+    "lng": -2.1995,
+    "authorityId": 158,
+    "population": 13560
+  },
+  {
+    "slug": "haslingden",
+    "name": "Haslingden",
+    "lat": 53.6926,
+    "lng": -2.3261,
+    "authorityId": 158,
+    "population": 16005
+  },
+  {
+    "slug": "rawtenstall",
+    "name": "Rawtenstall",
+    "lat": 53.7045,
+    "lng": -2.274,
+    "authorityId": 158,
+    "population": 23680
+  },
+  {
+    "slug": "whitworth",
+    "name": "Whitworth",
+    "lat": 53.6561,
+    "lng": -2.1782,
+    "authorityId": 158,
+    "population": 6715
+  },
+  {
+    "slug": "bamber-bridge",
+    "name": "Bamber Bridge",
+    "lat": 53.7306,
+    "lng": -2.6703,
+    "authorityId": 159,
+    "population": 40360
+  },
+  {
+    "slug": "leyland",
+    "name": "Leyland",
+    "lat": 53.6951,
+    "lng": -2.6997,
+    "authorityId": 159,
+    "population": 39295
+  },
+  {
+    "slug": "longton",
+    "name": "Longton",
+    "lat": 53.7151,
+    "lng": -2.7877,
+    "authorityId": 159,
+    "population": 10910
+  },
+  {
+    "slug": "penwortham",
+    "name": "Penwortham",
+    "lat": 53.7428,
+    "lng": -2.7296,
+    "authorityId": 159,
+    "population": 20485
+  },
+  {
+    "slug": "appley-bridge",
+    "name": "Appley Bridge",
+    "lat": 53.5815,
+    "lng": -2.7153,
+    "authorityId": 160,
+    "population": 5130
+  },
+  {
+    "slug": "burscough",
+    "name": "Burscough",
+    "lat": 53.6006,
+    "lng": -2.8523,
+    "authorityId": 160,
+    "population": 8770
+  },
+  {
+    "slug": "ormskirk",
+    "name": "Ormskirk",
+    "lat": 53.5616,
+    "lng": -2.8835,
+    "authorityId": 160,
+    "population": 27715
+  },
+  {
+    "slug": "skelmersdale",
+    "name": "Skelmersdale",
+    "lat": 53.5517,
+    "lng": -2.7834,
+    "authorityId": 160,
+    "population": 34915
+  },
+  {
+    "slug": "tarleton-and-hesketh-bank",
+    "name": "Tarleton and Hesketh Bank",
+    "lat": 53.6938,
+    "lng": -2.8476,
+    "authorityId": 160,
+    "population": 8755
+  },
+  {
+    "slug": "cleveleys",
+    "name": "Cleveleys",
+    "lat": 53.8824,
+    "lng": -3.0352,
+    "authorityId": 161,
+    "population": 11120
+  },
+  {
+    "slug": "fleetwood",
+    "name": "Fleetwood",
+    "lat": 53.9125,
+    "lng": -3.0292,
+    "authorityId": 161,
+    "population": 26225
+  },
+  {
+    "slug": "garstang",
+    "name": "Garstang",
+    "lat": 53.9052,
+    "lng": -2.7795,
+    "authorityId": 161,
+    "population": 5805
+  },
+  {
+    "slug": "poulton-le-fylde",
+    "name": "Poulton-le-Fylde",
+    "lat": 53.8501,
+    "lng": -2.9796,
+    "authorityId": 161,
+    "population": 12795
+  },
+  {
+    "slug": "thornton-wyre",
+    "name": "Thornton (Wyre)",
+    "lat": 53.8763,
+    "lng": -3.002,
+    "authorityId": 161,
+    "population": 19270
+  },
+  {
+    "slug": "blaby-and-whetstone",
+    "name": "Blaby and Whetstone",
+    "lat": 52.5692,
+    "lng": -1.1717,
+    "authorityId": 162,
+    "population": 14080
+  },
+  {
+    "slug": "countesthorpe",
+    "name": "Countesthorpe",
+    "lat": 52.554,
+    "lng": -1.152,
+    "authorityId": 162,
+    "population": 7670
+  },
+  {
+    "slug": "enderby-and-narborough",
+    "name": "Enderby and Narborough",
+    "lat": 52.5858,
+    "lng": -1.2062,
+    "authorityId": 162,
+    "population": 13180
+  },
+  {
+    "slug": "leicester-forest-east-and-kirby-muxloe",
+    "name": "Leicester Forest East and Kirby Muxloe",
+    "lat": 52.624,
+    "lng": -1.2216,
+    "authorityId": 162,
+    "population": 13850
+  },
+  {
+    "slug": "anstey",
+    "name": "Anstey",
+    "lat": 52.6746,
+    "lng": -1.1923,
+    "authorityId": 163,
+    "population": 7045
+  },
+  {
+    "slug": "barrow-upon-soar",
+    "name": "Barrow upon Soar",
+    "lat": 52.7518,
+    "lng": -1.146,
+    "authorityId": 163,
+    "population": 6820
+  },
+  {
+    "slug": "birstall",
+    "name": "Birstall",
+    "lat": 52.6817,
+    "lng": -1.1251,
+    "authorityId": 163,
+    "population": 14315
+  },
+  {
+    "slug": "loughborough",
+    "name": "Loughborough",
+    "lat": 52.7676,
+    "lng": -1.2248,
+    "authorityId": 163,
+    "population": 64860
+  },
+  {
+    "slug": "mountsorrel",
+    "name": "Mountsorrel",
+    "lat": 52.7227,
+    "lng": -1.1431,
+    "authorityId": 163,
+    "population": 12885
+  },
+  {
+    "slug": "quorndon",
+    "name": "Quorndon",
+    "lat": 52.7443,
+    "lng": -1.1745,
+    "authorityId": 163,
+    "population": 5575
+  },
+  {
+    "slug": "shepshed",
+    "name": "Shepshed",
+    "lat": 52.7642,
+    "lng": -1.2937,
+    "authorityId": 163,
+    "population": 14870
+  },
+  {
+    "slug": "sileby",
+    "name": "Sileby",
+    "lat": 52.7318,
+    "lng": -1.103,
+    "authorityId": 163,
+    "population": 8955
+  },
+  {
+    "slug": "syston",
+    "name": "Syston",
+    "lat": 52.6975,
+    "lng": -1.0736,
+    "authorityId": 163,
+    "population": 13620
+  },
+  {
+    "slug": "thurmaston",
+    "name": "Thurmaston",
+    "lat": 52.6775,
+    "lng": -1.0933,
+    "authorityId": 163,
+    "population": 9505
+  },
+  {
+    "slug": "broughton-astley",
+    "name": "Broughton Astley",
+    "lat": 52.5308,
+    "lng": -1.2231,
+    "authorityId": 164,
+    "population": 9650
+  },
+  {
+    "slug": "kibworth-beauchamp-and-kibworth-harcourt",
+    "name": "Kibworth Beauchamp and Kibworth Harcourt",
+    "lat": 52.5407,
+    "lng": -0.9998,
+    "authorityId": 164,
+    "population": 7330
+  },
+  {
+    "slug": "lutterworth",
+    "name": "Lutterworth",
+    "lat": 52.46,
+    "lng": -1.2418,
+    "authorityId": 164,
+    "population": 10520
+  },
+  {
+    "slug": "market-harborough",
+    "name": "Market Harborough",
+    "lat": 52.478,
+    "lng": -0.9244,
+    "authorityId": 164,
+    "population": 24165
+  },
+  {
+    "slug": "barwell",
+    "name": "Barwell",
+    "lat": 52.5703,
+    "lng": -1.3426,
+    "authorityId": 165,
+    "population": 9150
+  },
+  {
+    "slug": "earl-shilton",
+    "name": "Earl Shilton",
+    "lat": 52.5731,
+    "lng": -1.3194,
+    "authorityId": 165,
+    "population": 10885
+  },
+  {
+    "slug": "groby",
+    "name": "Groby",
+    "lat": 52.6607,
+    "lng": -1.228,
+    "authorityId": 165,
+    "population": 6560
+  },
+  {
+    "slug": "hinckley",
+    "name": "Hinckley",
+    "lat": 52.5409,
+    "lng": -1.3755,
+    "authorityId": 165,
+    "population": 50725
+  },
+  {
+    "slug": "melton-mowbray",
+    "name": "Melton Mowbray",
+    "lat": 52.77,
+    "lng": -0.8864,
+    "authorityId": 166,
+    "population": 27450
+  },
+  {
+    "slug": "ashby-de-la-zouch",
+    "name": "Ashby-de-la-Zouch",
+    "lat": 52.7477,
+    "lng": -1.4708,
+    "authorityId": 167,
+    "population": 15120
+  },
+  {
+    "slug": "castle-donington",
+    "name": "Castle Donington",
+    "lat": 52.845,
+    "lng": -1.3457,
+    "authorityId": 167,
+    "population": 7345
+  },
+  {
+    "slug": "coalville",
+    "name": "Coalville",
+    "lat": 52.7258,
+    "lng": -1.3687,
+    "authorityId": 167,
+    "population": 21980
+  },
+  {
+    "slug": "ibstock",
+    "name": "Ibstock",
+    "lat": 52.6922,
+    "lng": -1.3974,
+    "authorityId": 167,
+    "population": 6810
+  },
+  {
+    "slug": "measham",
+    "name": "Measham",
+    "lat": 52.7036,
+    "lng": -1.5096,
+    "authorityId": 167,
+    "population": 5370
+  },
+  {
+    "slug": "whitwick",
+    "name": "Whitwick",
+    "lat": 52.7378,
+    "lng": -1.3559,
+    "authorityId": 167,
+    "population": 10455
+  },
+  {
+    "slug": "oadby",
+    "name": "Oadby",
+    "lat": 52.5999,
+    "lng": -1.0762,
+    "authorityId": 168,
+    "population": 24030
+  },
+  {
+    "slug": "wigston",
+    "name": "Wigston",
+    "lat": 52.5851,
+    "lng": -1.1149,
+    "authorityId": 168,
+    "population": 34730
+  },
+  {
+    "slug": "boston",
+    "name": "Boston",
+    "lat": 52.9739,
+    "lng": -0.0211,
+    "authorityId": 169,
+    "population": 45340
+  },
+  {
+    "slug": "kirton-boston",
+    "name": "Kirton (Boston)",
+    "lat": 52.9304,
+    "lng": -0.0582,
+    "authorityId": 169,
+    "population": 5570
+  },
+  {
+    "slug": "coningsby-and-tattershall",
+    "name": "Coningsby and Tattershall",
+    "lat": 53.0978,
+    "lng": -0.1711,
+    "authorityId": 170,
+    "population": 5515
+  },
+  {
+    "slug": "horncastle",
+    "name": "Horncastle",
+    "lat": 53.21,
+    "lng": -0.1174,
+    "authorityId": 170,
+    "population": 7295
+  },
+  {
+    "slug": "louth",
+    "name": "Louth",
+    "lat": 53.3673,
+    "lng": 0.0026,
+    "authorityId": 170,
+    "population": 17420
+  },
+  {
+    "slug": "mablethorpe",
+    "name": "Mablethorpe",
+    "lat": 53.3408,
+    "lng": 0.2533,
+    "authorityId": 170,
+    "population": 7630
+  },
+  {
+    "slug": "skegness",
+    "name": "Skegness",
+    "lat": 53.1428,
+    "lng": 0.3205,
+    "authorityId": 170,
+    "population": 20700
+  },
+  {
+    "slug": "sutton-on-sea-and-trusthorpe",
+    "name": "Sutton on Sea and Trusthorpe",
+    "lat": 53.3009,
+    "lng": 0.2839,
+    "authorityId": 170,
+    "population": 5040
+  },
+  {
+    "slug": "lincoln",
+    "name": "Lincoln",
+    "lat": 53.2111,
+    "lng": -0.5716,
+    "authorityId": 171,
+    "population": 104555
+  },
+  {
+    "slug": "bracebridge-heath",
+    "name": "Bracebridge Heath",
+    "lat": 53.1953,
+    "lng": -0.5318,
+    "authorityId": 172,
+    "population": 5790
+  },
+  {
+    "slug": "north-hykeham",
+    "name": "North Hykeham",
+    "lat": 53.1884,
+    "lng": -0.5938,
+    "authorityId": 172,
+    "population": 16845
+  },
+  {
+    "slug": "ruskington",
+    "name": "Ruskington",
+    "lat": 53.0444,
+    "lng": -0.3842,
+    "authorityId": 172,
+    "population": 5650
+  },
+  {
+    "slug": "sleaford",
+    "name": "Sleaford",
+    "lat": 52.9997,
+    "lng": -0.4109,
+    "authorityId": 172,
+    "population": 18030
+  },
+  {
+    "slug": "waddington-north-kesteven",
+    "name": "Waddington (North Kesteven)",
+    "lat": 53.1694,
+    "lng": -0.5305,
+    "authorityId": 172,
+    "population": 6830
+  },
+  {
+    "slug": "washingborough-and-heighington",
+    "name": "Washingborough and Heighington",
+    "lat": 53.2153,
+    "lng": -0.4628,
+    "authorityId": 172,
+    "population": 6385
+  },
+  {
+    "slug": "holbeach",
+    "name": "Holbeach",
+    "lat": 52.806,
+    "lng": 0.01,
+    "authorityId": 173,
+    "population": 8755
+  },
+  {
+    "slug": "long-sutton-south-holland",
+    "name": "Long Sutton (South Holland)",
+    "lat": 52.7839,
+    "lng": 0.1217,
+    "authorityId": 173,
+    "population": 5375
+  },
+  {
+    "slug": "spalding",
+    "name": "Spalding",
+    "lat": 52.7795,
+    "lng": -0.1576,
+    "authorityId": 173,
+    "population": 30550
+  },
+  {
+    "slug": "bourne",
+    "name": "Bourne",
+    "lat": 52.7674,
+    "lng": -0.3751,
+    "authorityId": 174,
+    "population": 17495
+  },
+  {
+    "slug": "deeping-st-james",
+    "name": "Deeping St James",
+    "lat": 52.6736,
+    "lng": -0.2883,
+    "authorityId": 174,
+    "population": 7255
+  },
+  {
+    "slug": "grantham",
+    "name": "Grantham",
+    "lat": 52.9106,
+    "lng": -0.6376,
+    "authorityId": 174,
+    "population": 44905
+  },
+  {
+    "slug": "market-deeping",
+    "name": "Market Deeping",
+    "lat": 52.6806,
+    "lng": -0.3179,
+    "authorityId": 174,
+    "population": 6535
+  },
+  {
+    "slug": "stamford",
+    "name": "Stamford",
+    "lat": 52.6569,
+    "lng": -0.4822,
+    "authorityId": 174,
+    "population": 20750
+  },
+  {
+    "slug": "gainsborough",
+    "name": "Gainsborough",
+    "lat": 53.3986,
+    "lng": -0.7618,
+    "authorityId": 175,
+    "population": 21910
+  },
+  {
+    "slug": "attleborough",
+    "name": "Attleborough",
+    "lat": 52.513,
+    "lng": 1.017,
+    "authorityId": 176,
+    "population": 11235
+  },
+  {
+    "slug": "dereham",
+    "name": "Dereham",
+    "lat": 52.6767,
+    "lng": 0.9435,
+    "authorityId": 176,
+    "population": 20785
+  },
+  {
+    "slug": "swaffham",
+    "name": "Swaffham",
+    "lat": 52.646,
+    "lng": 0.6905,
+    "authorityId": 176,
+    "population": 8430
+  },
+  {
+    "slug": "thetford",
+    "name": "Thetford",
+    "lat": 52.4138,
+    "lng": 0.7442,
+    "authorityId": 176,
+    "population": 25510
+  },
+  {
+    "slug": "watton",
+    "name": "Watton",
+    "lat": 52.5704,
+    "lng": 0.8301,
+    "authorityId": 176,
+    "population": 11545
+  },
+  {
+    "slug": "aylsham",
+    "name": "Aylsham",
+    "lat": 52.7931,
+    "lng": 1.2522,
+    "authorityId": 177,
+    "population": 7185
+  },
+  {
+    "slug": "taverham-and-drayton",
+    "name": "Taverham and Drayton",
+    "lat": 52.6831,
+    "lng": 1.2115,
+    "authorityId": 177,
+    "population": 14985
+  },
+  {
+    "slug": "bradwell-great-yarmouth",
+    "name": "Bradwell (Great Yarmouth)",
+    "lat": 52.578,
+    "lng": 1.6973,
+    "authorityId": 178,
+    "population": 11630
+  },
+  {
+    "slug": "caister-on-sea",
+    "name": "Caister-on-Sea",
+    "lat": 52.6467,
+    "lng": 1.7239,
+    "authorityId": 178,
+    "population": 9095
+  },
+  {
+    "slug": "gorleston-on-sea",
+    "name": "Gorleston-on-Sea",
+    "lat": 52.5692,
+    "lng": 1.7206,
+    "authorityId": 178,
+    "population": 24470
+  },
+  {
+    "slug": "great-yarmouth",
+    "name": "Great Yarmouth",
+    "lat": 52.5998,
+    "lng": 1.7257,
+    "authorityId": 178,
+    "population": 28985
+  },
+  {
+    "slug": "hemsby",
+    "name": "Hemsby",
+    "lat": 52.6996,
+    "lng": 1.6899,
+    "authorityId": 178,
+    "population": 5720
+  },
+  {
+    "slug": "downham-market",
+    "name": "Downham Market",
+    "lat": 52.6042,
+    "lng": 0.3788,
+    "authorityId": 179,
+    "population": 11350
+  },
+  {
+    "slug": "kings-lynn",
+    "name": "King's Lynn",
+    "lat": 52.7614,
+    "lng": 0.4163,
+    "authorityId": 179,
+    "population": 47615
+  },
+  {
+    "slug": "cromer",
+    "name": "Cromer",
+    "lat": 52.9229,
+    "lng": 1.2988,
+    "authorityId": 180,
+    "population": 7525
+  },
+  {
+    "slug": "fakenham",
+    "name": "Fakenham",
+    "lat": 52.8338,
+    "lng": 0.8515,
+    "authorityId": 180,
+    "population": 8390
+  },
+  {
+    "slug": "north-walsham",
+    "name": "North Walsham",
+    "lat": 52.8214,
+    "lng": 1.3872,
+    "authorityId": 180,
+    "population": 12825
+  },
+  {
+    "slug": "sheringham",
+    "name": "Sheringham",
+    "lat": 52.9368,
+    "lng": 1.2116,
+    "authorityId": 180,
+    "population": 7090
+  },
+  {
+    "slug": "norwich",
+    "name": "Norwich",
+    "lat": 52.642,
+    "lng": 1.2816,
+    "authorityId": 181,
+    "population": 200770
+  },
+  {
+    "slug": "diss",
+    "name": "Diss",
+    "lat": 52.3771,
+    "lng": 1.1098,
+    "authorityId": 182,
+    "population": 9600
+  },
+  {
+    "slug": "harleston",
+    "name": "Harleston",
+    "lat": 52.4003,
+    "lng": 1.2992,
+    "authorityId": 182,
+    "population": 5075
+  },
+  {
+    "slug": "hethersett",
+    "name": "Hethersett",
+    "lat": 52.6031,
+    "lng": 1.1828,
+    "authorityId": 182,
+    "population": 7020
+  },
+  {
+    "slug": "long-stratton",
+    "name": "Long Stratton",
+    "lat": 52.4895,
+    "lng": 1.2285,
+    "authorityId": 182,
+    "population": 5220
+  },
+  {
+    "slug": "poringland",
+    "name": "Poringland",
+    "lat": 52.5745,
+    "lng": 1.3346,
+    "authorityId": 182,
+    "population": 7105
+  },
+  {
+    "slug": "wymondham-south-norfolk",
+    "name": "Wymondham (South Norfolk)",
+    "lat": 52.5717,
+    "lng": 1.1157,
+    "authorityId": 182,
+    "population": 16330
+  },
+  {
+    "slug": "annesley-woodhouse",
+    "name": "Annesley Woodhouse",
+    "lat": 53.0771,
+    "lng": -1.2537,
+    "authorityId": 197,
+    "population": 6160
+  },
+  {
+    "slug": "hucknall",
+    "name": "Hucknall",
+    "lat": 53.033,
+    "lng": -1.2081,
+    "authorityId": 197,
+    "population": 35840
+  },
+  {
+    "slug": "huthwaite",
+    "name": "Huthwaite",
+    "lat": 53.1262,
+    "lng": -1.3039,
+    "authorityId": 197,
+    "population": 5065
+  },
+  {
+    "slug": "kirkby-in-ashfield",
+    "name": "Kirkby-in-Ashfield",
+    "lat": 53.0996,
+    "lng": -1.2505,
+    "authorityId": 197,
+    "population": 21270
+  },
+  {
+    "slug": "selston",
+    "name": "Selston",
+    "lat": 53.0734,
+    "lng": -1.3055,
+    "authorityId": 197,
+    "population": 6275
+  },
+  {
+    "slug": "sutton-in-ashfield",
+    "name": "Sutton in Ashfield",
+    "lat": 53.1278,
+    "lng": -1.2567,
+    "authorityId": 197,
+    "population": 36425
+  },
+  {
+    "slug": "carlton-in-lindrick",
+    "name": "Carlton in Lindrick",
+    "lat": 53.3569,
+    "lng": -1.1215,
+    "authorityId": 198,
+    "population": 5460
+  },
+  {
+    "slug": "harworth-and-bircotes",
+    "name": "Harworth and Bircotes",
+    "lat": 53.4206,
+    "lng": -1.06,
+    "authorityId": 198,
+    "population": 8885
+  },
+  {
+    "slug": "retford",
+    "name": "Retford",
+    "lat": 53.3227,
+    "lng": -0.9436,
+    "authorityId": 198,
+    "population": 23740
+  },
+  {
+    "slug": "worksop",
+    "name": "Worksop",
+    "lat": 53.3108,
+    "lng": -1.1209,
+    "authorityId": 198,
+    "population": 43440
+  },
+  {
+    "slug": "beeston-broxtowe",
+    "name": "Beeston (Broxtowe)",
+    "lat": 52.9234,
+    "lng": -1.2353,
+    "authorityId": 199,
+    "population": 52355
+  },
+  {
+    "slug": "eastwood",
+    "name": "Eastwood",
+    "lat": 53.0153,
+    "lng": -1.2927,
+    "authorityId": 199,
+    "population": 18890
+  },
+  {
+    "slug": "nuthall-and-watnall",
+    "name": "Nuthall and Watnall",
+    "lat": 52.9881,
+    "lng": -1.2271,
+    "authorityId": 199,
+    "population": 9585
+  },
+  {
+    "slug": "stapleford",
+    "name": "Stapleford",
+    "lat": 52.9316,
+    "lng": -1.2699,
+    "authorityId": 199,
+    "population": 15045
+  },
+  {
+    "slug": "arnold",
+    "name": "Arnold",
+    "lat": 53.0002,
+    "lng": -1.122,
+    "authorityId": 200,
+    "population": 40010
+  },
+  {
+    "slug": "calverton",
+    "name": "Calverton",
+    "lat": 53.0412,
+    "lng": -1.087,
+    "authorityId": 200,
+    "population": 7320
+  },
+  {
+    "slug": "carlton-gedling",
+    "name": "Carlton (Gedling)",
+    "lat": 52.9717,
+    "lng": -1.0786,
+    "authorityId": 200,
+    "population": 53555
+  },
+  {
+    "slug": "ravenshead",
+    "name": "Ravenshead",
+    "lat": 53.0851,
+    "lng": -1.1642,
+    "authorityId": 200,
+    "population": 5370
+  },
+  {
+    "slug": "forest-town",
+    "name": "Forest Town",
+    "lat": 53.1559,
+    "lng": -1.1513,
+    "authorityId": 201,
+    "population": 19010
+  },
+  {
+    "slug": "mansfield",
+    "name": "Mansfield",
+    "lat": 53.1403,
+    "lng": -1.1973,
+    "authorityId": 201,
+    "population": 63445
+  },
+  {
+    "slug": "mansfield-woodhouse",
+    "name": "Mansfield Woodhouse",
+    "lat": 53.1681,
+    "lng": -1.1893,
+    "authorityId": 201,
+    "population": 19520
+  },
+  {
+    "slug": "market-warsop",
+    "name": "Market Warsop",
+    "lat": 53.2026,
+    "lng": -1.1522,
+    "authorityId": 201,
+    "population": 6975
+  },
+  {
+    "slug": "balderton",
+    "name": "Balderton",
+    "lat": 53.0552,
+    "lng": -0.7812,
+    "authorityId": 202,
+    "population": 12875
+  },
+  {
+    "slug": "edwinstowe",
+    "name": "Edwinstowe",
+    "lat": 53.1891,
+    "lng": -1.062,
+    "authorityId": 202,
+    "population": 5325
+  },
+  {
+    "slug": "new-ollerton-and-ollerton",
+    "name": "New Ollerton and Ollerton",
+    "lat": 53.2015,
+    "lng": -1.0084,
+    "authorityId": 202,
+    "population": 10870
+  },
+  {
+    "slug": "newark-on-trent",
+    "name": "Newark-on-Trent",
+    "lat": 53.0762,
+    "lng": -0.8009,
+    "authorityId": 202,
+    "population": 29755
+  },
+  {
+    "slug": "rainworth",
+    "name": "Rainworth",
+    "lat": 53.1202,
+    "lng": -1.1145,
+    "authorityId": 202,
+    "population": 7985
+  },
+  {
+    "slug": "southwell-newark-and-sherwood",
+    "name": "Southwell (Newark and Sherwood)",
+    "lat": 53.0744,
+    "lng": -0.9589,
+    "authorityId": 202,
+    "population": 7410
+  },
+  {
+    "slug": "bingham",
+    "name": "Bingham",
+    "lat": 52.9532,
+    "lng": -0.9578,
+    "authorityId": 203,
+    "population": 10110
+  },
+  {
+    "slug": "cotgrave",
+    "name": "Cotgrave",
+    "lat": 52.9104,
+    "lng": -1.0374,
+    "authorityId": 203,
+    "population": 7795
+  },
+  {
+    "slug": "east-leake",
+    "name": "East Leake",
+    "lat": 52.8304,
+    "lng": -1.1811,
+    "authorityId": 203,
+    "population": 8555
+  },
+  {
+    "slug": "keyworth",
+    "name": "Keyworth",
+    "lat": 52.8742,
+    "lng": -1.084,
+    "authorityId": 203,
+    "population": 6820
+  },
+  {
+    "slug": "radcliffe-on-trent",
+    "name": "Radcliffe on Trent",
+    "lat": 52.9477,
+    "lng": -1.0304,
+    "authorityId": 203,
+    "population": 7205
+  },
+  {
+    "slug": "ruddington",
+    "name": "Ruddington",
+    "lat": 52.893,
+    "lng": -1.1502,
+    "authorityId": 203,
+    "population": 7490
+  },
+  {
+    "slug": "west-bridgford",
+    "name": "West Bridgford",
+    "lat": 52.9261,
+    "lng": -1.126,
+    "authorityId": 203,
+    "population": 36490
+  },
+  {
+    "slug": "banbury",
+    "name": "Banbury",
+    "lat": 52.0623,
+    "lng": -1.3388,
+    "authorityId": 204,
+    "population": 52045
+  },
+  {
+    "slug": "bicester",
+    "name": "Bicester",
+    "lat": 51.8992,
+    "lng": -1.1541,
+    "authorityId": 204,
+    "population": 37755
+  },
+  {
+    "slug": "kidlington",
+    "name": "Kidlington",
+    "lat": 51.8229,
+    "lng": -1.2892,
+    "authorityId": 204,
+    "population": 14640
+  },
+  {
+    "slug": "oxford",
+    "name": "Oxford",
+    "lat": 51.7563,
+    "lng": -1.2589,
+    "authorityId": 205,
+    "population": 170805
+  },
+  {
+    "slug": "benson",
+    "name": "Benson",
+    "lat": 51.6182,
+    "lng": -1.0995,
+    "authorityId": 206,
+    "population": 5240
+  },
+  {
+    "slug": "chinnor",
+    "name": "Chinnor",
+    "lat": 51.7011,
+    "lng": -0.9117,
+    "authorityId": 206,
+    "population": 7265
+  },
+  {
+    "slug": "didcot",
+    "name": "Didcot",
+    "lat": 51.6112,
+    "lng": -1.2481,
+    "authorityId": 206,
+    "population": 34600
+  },
+  {
+    "slug": "henley-on-thames",
+    "name": "Henley-on-Thames",
+    "lat": 51.5324,
+    "lng": -0.9093,
+    "authorityId": 206,
+    "population": 11780
+  },
+  {
+    "slug": "sonning-common",
+    "name": "Sonning Common",
+    "lat": 51.5189,
+    "lng": -0.9834,
+    "authorityId": 206,
+    "population": 5265
+  },
+  {
+    "slug": "thame",
+    "name": "Thame",
+    "lat": 51.7468,
+    "lng": -0.9778,
+    "authorityId": 206,
+    "population": 12945
+  },
+  {
+    "slug": "wallingford",
+    "name": "Wallingford",
+    "lat": 51.6015,
+    "lng": -1.133,
+    "authorityId": 206,
+    "population": 8455
+  },
+  {
+    "slug": "abingdon-on-thames",
+    "name": "Abingdon-on-Thames",
+    "lat": 51.678,
+    "lng": -1.2769,
+    "authorityId": 207,
+    "population": 33175
+  },
+  {
+    "slug": "faringdon",
+    "name": "Faringdon",
+    "lat": 51.6535,
+    "lng": -1.5862,
+    "authorityId": 207,
+    "population": 8625
+  },
+  {
+    "slug": "grove-vale-of-white-horse",
+    "name": "Grove (Vale of White Horse)",
+    "lat": 51.6067,
+    "lng": -1.4261,
+    "authorityId": 207,
+    "population": 7945
+  },
+  {
+    "slug": "shrivenham-and-watchfield",
+    "name": "Shrivenham and Watchfield",
+    "lat": 51.6055,
+    "lng": -1.6434,
+    "authorityId": 207,
+    "population": 5350
+  },
+  {
+    "slug": "wantage",
+    "name": "Wantage",
+    "lat": 51.5903,
+    "lng": -1.4258,
+    "authorityId": 207,
+    "population": 13105
+  },
+  {
+    "slug": "carterton",
+    "name": "Carterton",
+    "lat": 51.7567,
+    "lng": -1.5849,
+    "authorityId": 208,
+    "population": 17950
+  },
+  {
+    "slug": "chipping-norton",
+    "name": "Chipping Norton",
+    "lat": 51.9388,
+    "lng": -1.5484,
+    "authorityId": 208,
+    "population": 6985
+  },
+  {
+    "slug": "eynsham",
+    "name": "Eynsham",
+    "lat": 51.7817,
+    "lng": -1.3764,
+    "authorityId": 208,
+    "population": 5325
+  },
+  {
+    "slug": "witney",
+    "name": "Witney",
+    "lat": 51.7874,
+    "lng": -1.4846,
+    "authorityId": 208,
+    "population": 30165
+  },
+  {
+    "slug": "cannock",
+    "name": "Cannock",
+    "lat": 52.6986,
+    "lng": -2.0104,
+    "authorityId": 214,
+    "population": 63065
+  },
+  {
+    "slug": "norton-canes",
+    "name": "Norton Canes",
+    "lat": 52.6702,
+    "lng": -1.9713,
+    "authorityId": 214,
+    "population": 8150
+  },
+  {
+    "slug": "rugeley",
+    "name": "Rugeley",
+    "lat": 52.7608,
+    "lng": -1.9425,
+    "authorityId": 214,
+    "population": 26145
+  },
+  {
+    "slug": "burton-upon-trent",
+    "name": "Burton upon Trent",
+    "lat": 52.8021,
+    "lng": -1.647,
+    "authorityId": 215,
+    "population": 76255
+  },
+  {
+    "slug": "uttoxeter",
+    "name": "Uttoxeter",
+    "lat": 52.8993,
+    "lng": -1.871,
+    "authorityId": 215,
+    "population": 14020
+  },
+  {
+    "slug": "burntwood",
+    "name": "Burntwood",
+    "lat": 52.6793,
+    "lng": -1.9242,
+    "authorityId": 216,
+    "population": 27900
+  },
+  {
+    "slug": "fazeley",
+    "name": "Fazeley",
+    "lat": 52.6148,
+    "lng": -1.7114,
+    "authorityId": 216,
+    "population": 7570
+  },
+  {
+    "slug": "lichfield",
+    "name": "Lichfield",
+    "lat": 52.6823,
+    "lng": -1.826,
+    "authorityId": 216,
+    "population": 32580
+  },
+  {
+    "slug": "kidsgrove",
+    "name": "Kidsgrove",
+    "lat": 53.0865,
+    "lng": -2.2427,
+    "authorityId": 217,
+    "population": 15595
+  },
+  {
+    "slug": "newcastle-under-lyme",
+    "name": "Newcastle-under-Lyme",
+    "lat": 53.0217,
+    "lng": -2.2448,
+    "authorityId": 217,
+    "population": 76505
+  },
+  {
+    "slug": "codsall",
+    "name": "Codsall",
+    "lat": 52.6268,
+    "lng": -2.1921,
+    "authorityId": 218,
+    "population": 11865
+  },
+  {
+    "slug": "featherstone-south-staffordshire",
+    "name": "Featherstone (South Staffordshire)",
+    "lat": 52.6473,
+    "lng": -2.1065,
+    "authorityId": 218,
+    "population": 7095
+  },
+  {
+    "slug": "great-wyrley-and-cheslyn-hay",
+    "name": "Great Wyrley and Cheslyn Hay",
+    "lat": 52.6591,
+    "lng": -2.0236,
+    "authorityId": 218,
+    "population": 17640
+  },
+  {
+    "slug": "penkridge",
+    "name": "Penkridge",
+    "lat": 52.7218,
+    "lng": -2.1096,
+    "authorityId": 218,
+    "population": 8370
+  },
+  {
+    "slug": "perton",
+    "name": "Perton",
+    "lat": 52.5959,
+    "lng": -2.2028,
+    "authorityId": 218,
+    "population": 9300
+  },
+  {
+    "slug": "wombourne",
+    "name": "Wombourne",
+    "lat": 52.5341,
+    "lng": -2.1976,
+    "authorityId": 218,
+    "population": 12815
+  },
+  {
+    "slug": "stafford",
+    "name": "Stafford",
+    "lat": 52.8006,
+    "lng": -2.1072,
+    "authorityId": 219,
+    "population": 71690
+  },
+  {
+    "slug": "stone-stafford",
+    "name": "Stone (Stafford)",
+    "lat": 52.8963,
+    "lng": -2.1437,
+    "authorityId": 219,
+    "population": 17280
+  },
+  {
+    "slug": "biddulph",
+    "name": "Biddulph",
+    "lat": 53.1114,
+    "lng": -2.1707,
+    "authorityId": 220,
+    "population": 17495
+  },
+  {
+    "slug": "blythe-bridge-and-forsbrook",
+    "name": "Blythe Bridge and Forsbrook",
+    "lat": 52.9666,
+    "lng": -2.0667,
+    "authorityId": 220,
+    "population": 6805
+  },
+  {
+    "slug": "cheadle-staffordshire-moorlands",
+    "name": "Cheadle (Staffordshire Moorlands)",
+    "lat": 52.9846,
+    "lng": -1.9924,
+    "authorityId": 220,
+    "population": 11400
+  },
+  {
+    "slug": "leek",
+    "name": "Leek",
+    "lat": 53.1031,
+    "lng": -2.0337,
+    "authorityId": 220,
+    "population": 19385
+  },
+  {
+    "slug": "werrington",
+    "name": "Werrington",
+    "lat": 53.0253,
+    "lng": -2.0942,
+    "authorityId": 220,
+    "population": 6010
+  },
+  {
+    "slug": "tamworth",
+    "name": "Tamworth",
+    "lat": 52.624,
+    "lng": -1.6747,
+    "authorityId": 221,
+    "population": 76090
+  },
+  {
+    "slug": "hadleigh",
+    "name": "Hadleigh",
+    "lat": 52.0464,
+    "lng": 0.9609,
+    "authorityId": 222,
+    "population": 8640
+  },
+  {
+    "slug": "sudbury",
+    "name": "Sudbury",
+    "lat": 52.0393,
+    "lng": 0.7368,
+    "authorityId": 222,
+    "population": 23920
+  },
+  {
+    "slug": "ipswich",
+    "name": "Ipswich",
+    "lat": 52.0565,
+    "lng": 1.1464,
+    "authorityId": 224,
+    "population": 151565
+  },
+  {
+    "slug": "needham-market",
+    "name": "Needham Market",
+    "lat": 52.1573,
+    "lng": 1.051,
+    "authorityId": 225,
+    "population": 5050
+  },
+  {
+    "slug": "stowmarket",
+    "name": "Stowmarket",
+    "lat": 52.1856,
+    "lng": 0.9958,
+    "authorityId": 225,
+    "population": 21535
+  },
+  {
+    "slug": "byfleet",
+    "name": "Byfleet",
+    "lat": 51.3482,
+    "lng": -0.4556,
+    "authorityId": 229,
+    "population": 14190
+  },
+  {
+    "slug": "cobham-elmbridge",
+    "name": "Cobham (Elmbridge)",
+    "lat": 51.3335,
+    "lng": -0.3856,
+    "authorityId": 229,
+    "population": 17505
+  },
+  {
+    "slug": "esher",
+    "name": "Esher",
+    "lat": 51.3663,
+    "lng": -0.3687,
+    "authorityId": 229,
+    "population": 9485
+  },
+  {
+    "slug": "hersham",
+    "name": "Hersham",
+    "lat": 51.3671,
+    "lng": -0.4022,
+    "authorityId": 229,
+    "population": 12625
+  },
+  {
+    "slug": "walton-on-thames",
+    "name": "Walton-on-Thames",
+    "lat": 51.386,
+    "lng": -0.4061,
+    "authorityId": 229,
+    "population": 27020
+  },
+  {
+    "slug": "west-molesey",
+    "name": "West Molesey",
+    "lat": 51.3803,
+    "lng": -0.3381,
+    "authorityId": 229,
+    "population": 47150
+  },
+  {
+    "slug": "weybridge",
+    "name": "Weybridge",
+    "lat": 51.3748,
+    "lng": -0.4518,
+    "authorityId": 229,
+    "population": 15915
+  },
+  {
+    "slug": "epsom",
+    "name": "Epsom",
+    "lat": 51.3322,
+    "lng": -0.272,
+    "authorityId": 230,
+    "population": 35850
+  },
+  {
+    "slug": "ewell",
+    "name": "Ewell",
+    "lat": 51.3461,
+    "lng": -0.2436,
+    "authorityId": 230,
+    "population": 27515
+  },
+  {
+    "slug": "worcester-park-and-stoneleigh",
+    "name": "Worcester Park and Stoneleigh",
+    "lat": 51.3719,
+    "lng": -0.2534,
+    "authorityId": 230,
+    "population": 15850
+  },
+  {
+    "slug": "ash-and-ash-vale",
+    "name": "Ash and Ash Vale",
+    "lat": 51.2511,
+    "lng": -0.7224,
+    "authorityId": 231,
+    "population": 24285
+  },
+  {
+    "slug": "east-horsley",
+    "name": "East Horsley",
+    "lat": 51.2794,
+    "lng": -0.4361,
+    "authorityId": 231,
+    "population": 5840
+  },
+  {
+    "slug": "guildford",
+    "name": "Guildford",
+    "lat": 51.2448,
+    "lng": -0.5705,
+    "authorityId": 231,
+    "population": 77880
+  },
+  {
+    "slug": "ashtead",
+    "name": "Ashtead",
+    "lat": 51.3095,
+    "lng": -0.3028,
+    "authorityId": 232,
+    "population": 14830
+  },
+  {
+    "slug": "dorking",
+    "name": "Dorking",
+    "lat": 51.2292,
+    "lng": -0.3292,
+    "authorityId": 232,
+    "population": 17465
+  },
+  {
+    "slug": "great-bookham-and-fetcham",
+    "name": "Great Bookham and Fetcham",
+    "lat": 51.2814,
+    "lng": -0.3762,
+    "authorityId": 232,
+    "population": 21655
+  },
+  {
+    "slug": "leatherhead",
+    "name": "Leatherhead",
+    "lat": 51.287,
+    "lng": -0.3144,
+    "authorityId": 232,
+    "population": 11485
+  },
+  {
+    "slug": "banstead",
+    "name": "Banstead",
+    "lat": 51.3231,
+    "lng": -0.1986,
+    "authorityId": 233,
+    "population": 8925
+  },
+  {
+    "slug": "horley-reigate-and-banstead",
+    "name": "Horley (Reigate and Banstead)",
+    "lat": 51.1744,
+    "lng": -0.1608,
+    "authorityId": 233,
+    "population": 27070
+  },
+  {
+    "slug": "redhill-reigate-and-banstead",
+    "name": "Redhill (Reigate and Banstead)",
+    "lat": 51.23,
+    "lng": -0.1742,
+    "authorityId": 233,
+    "population": 32525
+  },
+  {
+    "slug": "reigate",
+    "name": "Reigate",
+    "lat": 51.2384,
+    "lng": -0.2043,
+    "authorityId": 233,
+    "population": 23780
+  },
+  {
+    "slug": "south-merstham",
+    "name": "South Merstham",
+    "lat": 51.2585,
+    "lng": -0.1479,
+    "authorityId": 233,
+    "population": 9955
+  },
+  {
+    "slug": "tadworth-and-epsom-downs",
+    "name": "Tadworth and Epsom Downs",
+    "lat": 51.3127,
+    "lng": -0.2302,
+    "authorityId": 233,
+    "population": 27095
+  },
+  {
+    "slug": "addlestone",
+    "name": "Addlestone",
+    "lat": 51.3725,
+    "lng": -0.4888,
+    "authorityId": 234,
+    "population": 13745
+  },
+  {
+    "slug": "chertsey",
+    "name": "Chertsey",
+    "lat": 51.3861,
+    "lng": -0.5154,
+    "authorityId": 234,
+    "population": 14560
+  },
+  {
+    "slug": "egham",
+    "name": "Egham",
+    "lat": 51.4268,
+    "lng": -0.5634,
+    "authorityId": 234,
+    "population": 28000
+  },
+  {
+    "slug": "new-haw-west-byfleet-and-sheerwater",
+    "name": "New Haw, West Byfleet and Sheerwater",
+    "lat": 51.3479,
+    "lng": -0.5142,
+    "authorityId": 234,
+    "population": 33035
+  },
+  {
+    "slug": "virginia-water",
+    "name": "Virginia Water",
+    "lat": 51.4012,
+    "lng": -0.5754,
+    "authorityId": 234,
+    "population": 5185
+  },
+  {
+    "slug": "ashford-common",
+    "name": "Ashford Common",
+    "lat": 51.4215,
+    "lng": -0.4425,
+    "authorityId": 235,
+    "population": 8335
+  },
+  {
+    "slug": "ashford-spelthorne",
+    "name": "Ashford (Spelthorne)",
+    "lat": 51.4348,
+    "lng": -0.4679,
+    "authorityId": 235,
+    "population": 22825
+  },
+  {
+    "slug": "shepperton",
+    "name": "Shepperton",
+    "lat": 51.3918,
+    "lng": -0.4444,
+    "authorityId": 235,
+    "population": 5915
+  },
+  {
+    "slug": "staines-upon-thames",
+    "name": "Staines-upon-Thames",
+    "lat": 51.4233,
+    "lng": -0.504,
+    "authorityId": 235,
+    "population": 21325
+  },
+  {
+    "slug": "stanwell",
+    "name": "Stanwell",
+    "lat": 51.4527,
+    "lng": -0.4732,
+    "authorityId": 235,
+    "population": 11720
+  },
+  {
+    "slug": "sunbury-on-thames",
+    "name": "Sunbury-on-Thames",
+    "lat": 51.4097,
+    "lng": -0.4124,
+    "authorityId": 235,
+    "population": 21475
+  },
+  {
+    "slug": "bagshot",
+    "name": "Bagshot",
+    "lat": 51.3592,
+    "lng": -0.6924,
+    "authorityId": 236,
+    "population": 5930
+  },
+  {
+    "slug": "camberley",
+    "name": "Camberley",
+    "lat": 51.336,
+    "lng": -0.7294,
+    "authorityId": 236,
+    "population": 36785
+  },
+  {
+    "slug": "frimley",
+    "name": "Frimley",
+    "lat": 51.315,
+    "lng": -0.7344,
+    "authorityId": 236,
+    "population": 15100
+  },
+  {
+    "slug": "lightwater",
+    "name": "Lightwater",
+    "lat": 51.3493,
+    "lng": -0.6742,
+    "authorityId": 236,
+    "population": 6535
+  },
+  {
+    "slug": "west-end-and-chobham",
+    "name": "West End and Chobham",
+    "lat": 51.3472,
+    "lng": -0.6156,
+    "authorityId": 236,
+    "population": 8875
+  },
+  {
+    "slug": "caterham",
+    "name": "Caterham",
+    "lat": 51.2874,
+    "lng": -0.0895,
+    "authorityId": 237,
+    "population": 22755
+  },
+  {
+    "slug": "oxted",
+    "name": "Oxted",
+    "lat": 51.2465,
+    "lng": -0.0022,
+    "authorityId": 237,
+    "population": 11490
+  },
+  {
+    "slug": "warlingham",
+    "name": "Warlingham",
+    "lat": 51.3095,
+    "lng": -0.0603,
+    "authorityId": 237,
+    "population": 8920
+  },
+  {
+    "slug": "cranleigh",
+    "name": "Cranleigh",
+    "lat": 51.1429,
+    "lng": -0.4826,
+    "authorityId": 238,
+    "population": 10425
+  },
+  {
+    "slug": "farncombe",
+    "name": "Farncombe",
+    "lat": 51.1985,
+    "lng": -0.6176,
+    "authorityId": 238,
+    "population": 13250
+  },
+  {
+    "slug": "farnham",
+    "name": "Farnham",
+    "lat": 51.2089,
+    "lng": -0.793,
+    "authorityId": 238,
+    "population": 20500
+  },
+  {
+    "slug": "godalming",
+    "name": "Godalming",
+    "lat": 51.1808,
+    "lng": -0.6199,
+    "authorityId": 238,
+    "population": 10450
+  },
+  {
+    "slug": "haslemere",
+    "name": "Haslemere",
+    "lat": 51.0877,
+    "lng": -0.7183,
+    "authorityId": 238,
+    "population": 11900
+  },
+  {
+    "slug": "milford-and-witley",
+    "name": "Milford and Witley",
+    "lat": 51.1609,
+    "lng": -0.6524,
+    "authorityId": 238,
+    "population": 6485
+  },
+  {
+    "slug": "weybourne-waverley",
+    "name": "Weybourne (Waverley)",
+    "lat": 51.2329,
+    "lng": -0.7886,
+    "authorityId": 238,
+    "population": 11240
+  },
+  {
+    "slug": "wrecclesham",
+    "name": "Wrecclesham",
+    "lat": 51.1891,
+    "lng": -0.8162,
+    "authorityId": 238,
+    "population": 7315
+  },
+  {
+    "slug": "woking",
+    "name": "Woking",
+    "lat": 51.3097,
+    "lng": -0.5868,
+    "authorityId": 239,
+    "population": 75660
+  },
+  {
+    "slug": "atherstone",
+    "name": "Atherstone",
+    "lat": 52.5776,
+    "lng": -1.5426,
+    "authorityId": 240,
+    "population": 8665
+  },
+  {
+    "slug": "coleshill-north-warwickshire",
+    "name": "Coleshill (North Warwickshire)",
+    "lat": 52.5261,
+    "lng": -1.7075,
+    "authorityId": 240,
+    "population": 6745
+  },
+  {
+    "slug": "polesworth-and-dordon",
+    "name": "Polesworth and Dordon",
+    "lat": 52.5992,
+    "lng": -1.6183,
+    "authorityId": 240,
+    "population": 7555
+  },
+  {
+    "slug": "bedworth",
+    "name": "Bedworth",
+    "lat": 52.4732,
+    "lng": -1.4871,
+    "authorityId": 241,
+    "population": 31090
+  },
+  {
+    "slug": "bulkington",
+    "name": "Bulkington",
+    "lat": 52.4793,
+    "lng": -1.4272,
+    "authorityId": 241,
+    "population": 5670
+  },
+  {
+    "slug": "nuneaton",
+    "name": "Nuneaton",
+    "lat": 52.5248,
+    "lng": -1.456,
+    "authorityId": 241,
+    "population": 88815
+  },
+  {
+    "slug": "cawston-rugby",
+    "name": "Cawston (Rugby)",
+    "lat": 52.3568,
+    "lng": -1.3067,
+    "authorityId": 242,
+    "population": 6470
+  },
+  {
+    "slug": "rugby",
+    "name": "Rugby",
+    "lat": 52.3764,
+    "lng": -1.2469,
+    "authorityId": 242,
+    "population": 78120
+  },
+  {
+    "slug": "alcester",
+    "name": "Alcester",
+    "lat": 52.2195,
+    "lng": -1.8698,
+    "authorityId": 243,
+    "population": 6425
+  },
+  {
+    "slug": "bidford-on-avon",
+    "name": "Bidford-on-Avon",
+    "lat": 52.169,
+    "lng": -1.8564,
+    "authorityId": 243,
+    "population": 5825
+  },
+  {
+    "slug": "shipston-on-stour",
+    "name": "Shipston-on-Stour",
+    "lat": 52.0627,
+    "lng": -1.628,
+    "authorityId": 243,
+    "population": 5850
+  },
+  {
+    "slug": "southam-stratford-on-avon",
+    "name": "Southam (Stratford-on-Avon)",
+    "lat": 52.2516,
+    "lng": -1.3912,
+    "authorityId": 243,
+    "population": 8110
+  },
+  {
+    "slug": "stratford-upon-avon",
+    "name": "Stratford-upon-Avon",
+    "lat": 52.1927,
+    "lng": -1.7216,
+    "authorityId": 243,
+    "population": 28120
+  },
+  {
+    "slug": "studley",
+    "name": "Studley",
+    "lat": 52.2703,
+    "lng": -1.8998,
+    "authorityId": 243,
+    "population": 6040
+  },
+  {
+    "slug": "wellesbourne",
+    "name": "Wellesbourne",
+    "lat": 52.1945,
+    "lng": -1.6033,
+    "authorityId": 243,
+    "population": 7020
+  },
+  {
+    "slug": "kenilworth",
+    "name": "Kenilworth",
+    "lat": 52.3454,
+    "lng": -1.5732,
+    "authorityId": 244,
+    "population": 22235
+  },
+  {
+    "slug": "royal-leamington-spa",
+    "name": "Royal Leamington Spa",
+    "lat": 52.2928,
+    "lng": -1.5331,
+    "authorityId": 244,
+    "population": 51310
+  },
+  {
+    "slug": "warwick",
+    "name": "Warwick",
+    "lat": 52.2782,
+    "lng": -1.5826,
+    "authorityId": 244,
+    "population": 36680
+  },
+  {
+    "slug": "whitnash",
+    "name": "Whitnash",
+    "lat": 52.264,
+    "lng": -1.5252,
+    "authorityId": 244,
+    "population": 8915
+  },
+  {
+    "slug": "lancing-and-sompting",
+    "name": "Lancing and Sompting",
+    "lat": 50.8323,
+    "lng": -0.3268,
+    "authorityId": 245,
+    "population": 27930
+  },
+  {
+    "slug": "shoreham-by-sea",
+    "name": "Shoreham-by-Sea",
+    "lat": 50.8354,
+    "lng": -0.2696,
+    "authorityId": 245,
+    "population": 23660
+  },
+  {
+    "slug": "southwick-adur",
+    "name": "Southwick (Adur)",
+    "lat": 50.8352,
+    "lng": -0.2351,
+    "authorityId": 245,
+    "population": 12240
+  },
+  {
+    "slug": "barnham-arun",
+    "name": "Barnham (Arun)",
+    "lat": 50.8397,
+    "lng": -0.6477,
+    "authorityId": 246,
+    "population": 10145
+  },
+  {
+    "slug": "bognor-regis",
+    "name": "Bognor Regis",
+    "lat": 50.7928,
+    "lng": -0.6868,
+    "authorityId": 246,
+    "population": 68435
+  },
+  {
+    "slug": "littlehampton",
+    "name": "Littlehampton",
+    "lat": 50.8119,
+    "lng": -0.5332,
+    "authorityId": 246,
+    "population": 19065
+  },
+  {
+    "slug": "rustington",
+    "name": "Rustington",
+    "lat": 50.8193,
+    "lng": -0.4794,
+    "authorityId": 246,
+    "population": 33885
+  },
+  {
+    "slug": "wick-arun",
+    "name": "Wick (Arun)",
+    "lat": 50.8228,
+    "lng": -0.545,
+    "authorityId": 246,
+    "population": 13225
+  },
+  {
+    "slug": "yapton",
+    "name": "Yapton",
+    "lat": 50.8194,
+    "lng": -0.6033,
+    "authorityId": 246,
+    "population": 6340
+  },
+  {
+    "slug": "chichester",
+    "name": "Chichester",
+    "lat": 50.8398,
+    "lng": -0.7761,
+    "authorityId": 247,
+    "population": 31710
+  },
+  {
+    "slug": "east-wittering",
+    "name": "East Wittering",
+    "lat": 50.7676,
+    "lng": -0.8547,
+    "authorityId": 247,
+    "population": 6060
+  },
+  {
+    "slug": "midhurst",
+    "name": "Midhurst",
+    "lat": 50.9844,
+    "lng": -0.7435,
+    "authorityId": 247,
+    "population": 5370
+  },
+  {
+    "slug": "selsey",
+    "name": "Selsey",
+    "lat": 50.7345,
+    "lng": -0.7906,
+    "authorityId": 247,
+    "population": 10735
+  },
+  {
+    "slug": "crawley-crawley",
+    "name": "Crawley (Crawley)",
+    "lat": 51.1158,
+    "lng": -0.1798,
+    "authorityId": 248,
+    "population": 120550
+  },
+  {
+    "slug": "billingshurst",
+    "name": "Billingshurst",
+    "lat": 51.0152,
+    "lng": -0.4509,
+    "authorityId": 249,
+    "population": 9120
+  },
+  {
+    "slug": "broadbridge-heath",
+    "name": "Broadbridge Heath",
+    "lat": 51.0678,
+    "lng": -0.3645,
+    "authorityId": 249,
+    "population": 6355
+  },
+  {
+    "slug": "henfield",
+    "name": "Henfield",
+    "lat": 50.9311,
+    "lng": -0.2762,
+    "authorityId": 249,
+    "population": 5635
+  },
+  {
+    "slug": "horsham",
+    "name": "Horsham",
+    "lat": 51.0679,
+    "lng": -0.3186,
+    "authorityId": 249,
+    "population": 50215
+  },
+  {
+    "slug": "southwater",
+    "name": "Southwater",
+    "lat": 51.0333,
+    "lng": -0.3525,
+    "authorityId": 249,
+    "population": 11205
+  },
+  {
+    "slug": "steyning",
+    "name": "Steyning",
+    "lat": 50.8867,
+    "lng": -0.329,
+    "authorityId": 249,
+    "population": 5510
+  },
+  {
+    "slug": "storrington",
+    "name": "Storrington",
+    "lat": 50.919,
+    "lng": -0.4259,
+    "authorityId": 249,
+    "population": 8710
+  },
+  {
+    "slug": "burgess-hill",
+    "name": "Burgess Hill",
+    "lat": 50.9573,
+    "lng": -0.1311,
+    "authorityId": 250,
+    "population": 33355
+  },
+  {
+    "slug": "crawley-down",
+    "name": "Crawley Down",
+    "lat": 51.121,
+    "lng": -0.078,
+    "authorityId": 250,
+    "population": 5775
+  },
+  {
+    "slug": "east-grinstead",
+    "name": "East Grinstead",
+    "lat": 51.1276,
+    "lng": -0.0129,
+    "authorityId": 250,
+    "population": 26350
+  },
+  {
+    "slug": "hassocks-and-hurstpierpoint",
+    "name": "Hassocks and Hurstpierpoint",
+    "lat": 50.9358,
+    "lng": -0.165,
+    "authorityId": 250,
+    "population": 14215
+  },
+  {
+    "slug": "haywards-heath",
+    "name": "Haywards Heath",
+    "lat": 51.0007,
+    "lng": -0.0943,
+    "authorityId": 250,
+    "population": 40185
+  },
+  {
+    "slug": "worthing",
+    "name": "Worthing",
+    "lat": 50.829,
+    "lng": -0.4018,
+    "authorityId": 251,
+    "population": 111620
+  },
+  {
+    "slug": "bromsgrove",
+    "name": "Bromsgrove",
+    "lat": 52.3309,
+    "lng": -2.0571,
+    "authorityId": 252,
+    "population": 34755
+  },
+  {
+    "slug": "catshill",
+    "name": "Catshill",
+    "lat": 52.3615,
+    "lng": -2.0486,
+    "authorityId": 252,
+    "population": 10170
+  },
+  {
+    "slug": "hagley",
+    "name": "Hagley",
+    "lat": 52.4187,
+    "lng": -2.1473,
+    "authorityId": 252,
+    "population": 7010
+  },
+  {
+    "slug": "hollywood",
+    "name": "Hollywood",
+    "lat": 52.3898,
+    "lng": -1.8838,
+    "authorityId": 252,
+    "population": 6945
+  },
+  {
+    "slug": "great-malvern",
+    "name": "Great Malvern",
+    "lat": 52.1117,
+    "lng": -2.3211,
+    "authorityId": 253,
+    "population": 33185
+  },
+  {
+    "slug": "redditch",
+    "name": "Redditch",
+    "lat": 52.2976,
+    "lng": -1.9355,
+    "authorityId": 254,
+    "population": 81635
+  },
+  {
+    "slug": "worcester",
+    "name": "Worcester",
+    "lat": 52.197,
+    "lng": -2.212,
+    "authorityId": 255,
+    "population": 105465
+  },
+  {
+    "slug": "droitwich-spa",
+    "name": "Droitwich Spa",
+    "lat": 52.2625,
+    "lng": -2.1551,
+    "authorityId": 256,
+    "population": 26420
+  },
+  {
+    "slug": "evesham",
+    "name": "Evesham",
+    "lat": 52.0859,
+    "lng": -1.9465,
+    "authorityId": 256,
+    "population": 28250
+  },
+  {
+    "slug": "pershore",
+    "name": "Pershore",
+    "lat": 52.1115,
+    "lng": -2.0825,
+    "authorityId": 256,
+    "population": 8210
+  },
+  {
+    "slug": "bewdley",
+    "name": "Bewdley",
+    "lat": 52.3774,
+    "lng": -2.3113,
+    "authorityId": 257,
+    "population": 8280
+  },
+  {
+    "slug": "kidderminster",
+    "name": "Kidderminster",
+    "lat": 52.3874,
+    "lng": -2.2509,
+    "authorityId": 257,
+    "population": 57560
+  },
+  {
+    "slug": "stourport-on-severn",
+    "name": "Stourport-on-Severn",
+    "lat": 52.3439,
+    "lng": -2.2793,
+    "authorityId": 257,
+    "population": 20305
+  },
+  {
+    "slug": "blackrod",
+    "name": "Blackrod",
+    "lat": 53.5897,
+    "lng": -2.5837,
+    "authorityId": 258,
+    "population": 5340
+  },
+  {
+    "slug": "bolton-bolton",
+    "name": "Bolton (Bolton)",
+    "lat": 53.5892,
+    "lng": -2.4338,
+    "authorityId": 258,
+    "population": 184090
+  },
+  {
+    "slug": "farnworth",
+    "name": "Farnworth",
+    "lat": 53.5487,
+    "lng": -2.4037,
+    "authorityId": 258,
+    "population": 28760
+  },
+  {
+    "slug": "horwich",
+    "name": "Horwich",
+    "lat": 53.5947,
+    "lng": -2.5435,
+    "authorityId": 258,
+    "population": 20700
+  },
+  {
+    "slug": "kearsley",
+    "name": "Kearsley",
+    "lat": 53.5421,
+    "lng": -2.3752,
+    "authorityId": 258,
+    "population": 11115
+  },
+  {
+    "slug": "little-lever",
+    "name": "Little Lever",
+    "lat": 53.5639,
+    "lng": -2.3703,
+    "authorityId": 258,
+    "population": 12525
+  },
+  {
+    "slug": "westhoughton",
+    "name": "Westhoughton",
+    "lat": 53.5453,
+    "lng": -2.5206,
+    "authorityId": 258,
+    "population": 21960
+  },
+  {
+    "slug": "bury-bury",
+    "name": "Bury (Bury)",
+    "lat": 53.5949,
+    "lng": -2.2939,
+    "authorityId": 259,
+    "population": 81095
+  },
+  {
+    "slug": "prestwich",
+    "name": "Prestwich",
+    "lat": 53.5289,
+    "lng": -2.2751,
+    "authorityId": 259,
+    "population": 31495
+  },
+  {
+    "slug": "radcliffe",
+    "name": "Radcliffe",
+    "lat": 53.5646,
+    "lng": -2.3224,
+    "authorityId": 259,
+    "population": 31115
+  },
+  {
+    "slug": "ramsbottom",
+    "name": "Ramsbottom",
+    "lat": 53.6339,
+    "lng": -2.3268,
+    "authorityId": 259,
+    "population": 17075
+  },
+  {
+    "slug": "whitefield",
+    "name": "Whitefield",
+    "lat": 53.5491,
+    "lng": -2.2892,
+    "authorityId": 259,
+    "population": 22185
+  },
+  {
+    "slug": "manchester",
+    "name": "Manchester",
+    "lat": 53.4747,
+    "lng": -2.2123,
+    "authorityId": 260,
+    "population": 470405
+  },
+  {
+    "slug": "wythenshawe",
+    "name": "Wythenshawe",
+    "lat": 53.3949,
+    "lng": -2.2738,
+    "authorityId": 260,
+    "population": 97660
+  },
+  {
+    "slug": "chadderton",
+    "name": "Chadderton",
+    "lat": 53.5342,
+    "lng": -2.1563,
+    "authorityId": 261,
+    "population": 37610
+  },
+  {
+    "slug": "failsworth",
+    "name": "Failsworth",
+    "lat": 53.5046,
+    "lng": -2.1595,
+    "authorityId": 261,
+    "population": 19960
+  },
+  {
+    "slug": "lees",
+    "name": "Lees",
+    "lat": 53.5395,
+    "lng": -2.0626,
+    "authorityId": 261,
+    "population": 12630
+  },
+  {
+    "slug": "oldham",
+    "name": "Oldham",
+    "lat": 53.5403,
+    "lng": -2.1021,
+    "authorityId": 261,
+    "population": 110720
+  },
+  {
+    "slug": "royton",
+    "name": "Royton",
+    "lat": 53.5676,
+    "lng": -2.125,
+    "authorityId": 261,
+    "population": 22990
+  },
+  {
+    "slug": "shaw-oldham",
+    "name": "Shaw (Oldham)",
+    "lat": 53.5813,
+    "lng": -2.0957,
+    "authorityId": 261,
+    "population": 18240
+  },
+  {
+    "slug": "uppermill",
+    "name": "Uppermill",
+    "lat": 53.5456,
+    "lng": -2.0107,
+    "authorityId": 261,
+    "population": 11200
+  },
+  {
+    "slug": "heywood",
+    "name": "Heywood",
+    "lat": 53.5863,
+    "lng": -2.2253,
+    "authorityId": 262,
+    "population": 29725
+  },
+  {
+    "slug": "littleborough",
+    "name": "Littleborough",
+    "lat": 53.6437,
+    "lng": -2.1017,
+    "authorityId": 262,
+    "population": 12160
+  },
+  {
+    "slug": "middleton-rochdale",
+    "name": "Middleton (Rochdale)",
+    "lat": 53.554,
+    "lng": -2.1979,
+    "authorityId": 262,
+    "population": 46630
+  },
+  {
+    "slug": "milnrow",
+    "name": "Milnrow",
+    "lat": 53.6106,
+    "lng": -2.1107,
+    "authorityId": 262,
+    "population": 9235
+  },
+  {
+    "slug": "rochdale",
+    "name": "Rochdale",
+    "lat": 53.6146,
+    "lng": -2.1638,
+    "authorityId": 262,
+    "population": 111255
+  },
+  {
+    "slug": "clifton-salford",
+    "name": "Clifton (Salford)",
+    "lat": 53.5187,
+    "lng": -2.3226,
+    "authorityId": 263,
+    "population": 17750
+  },
+  {
+    "slug": "eccles-salford",
+    "name": "Eccles (Salford)",
+    "lat": 53.4846,
+    "lng": -2.3635,
+    "authorityId": 263,
+    "population": 41125
+  },
+  {
+    "slug": "irlam",
+    "name": "Irlam",
+    "lat": 53.445,
+    "lng": -2.4185,
+    "authorityId": 263,
+    "population": 19715
+  },
+  {
+    "slug": "little-hulton",
+    "name": "Little Hulton",
+    "lat": 53.5289,
+    "lng": -2.4179,
+    "authorityId": 263,
+    "population": 25825
+  },
+  {
+    "slug": "salford",
+    "name": "Salford",
+    "lat": 53.4919,
+    "lng": -2.286,
+    "authorityId": 263,
+    "population": 108410
+  },
+  {
+    "slug": "swinton-salford",
+    "name": "Swinton (Salford)",
+    "lat": 53.5093,
+    "lng": -2.3487,
+    "authorityId": 263,
+    "population": 22885
+  },
+  {
+    "slug": "walkden",
+    "name": "Walkden",
+    "lat": 53.5205,
+    "lng": -2.3936,
+    "authorityId": 263,
+    "population": 18690
+  },
+  {
+    "slug": "worsley",
+    "name": "Worsley",
+    "lat": 53.5035,
+    "lng": -2.3851,
+    "authorityId": 263,
+    "population": 11950
+  },
+  {
+    "slug": "bramhall",
+    "name": "Bramhall",
+    "lat": 53.3652,
+    "lng": -2.1614,
+    "authorityId": 264,
+    "population": 17195
+  },
+  {
+    "slug": "bredbury-and-woodley",
+    "name": "Bredbury and Woodley",
+    "lat": 53.4254,
+    "lng": -2.1111,
+    "authorityId": 264,
+    "population": 17040
+  },
+  {
+    "slug": "cheadle-hulme",
+    "name": "Cheadle Hulme",
+    "lat": 53.3709,
+    "lng": -2.1918,
+    "authorityId": 264,
+    "population": 24785
+  },
+  {
+    "slug": "cheadle-stockport",
+    "name": "Cheadle (Stockport)",
+    "lat": 53.3891,
+    "lng": -2.2084,
+    "authorityId": 264,
+    "population": 14435
+  },
+  {
+    "slug": "gatley",
+    "name": "Gatley",
+    "lat": 53.3894,
+    "lng": -2.2349,
+    "authorityId": 264,
+    "population": 9150
+  },
+  {
+    "slug": "hazel-grove",
+    "name": "Hazel Grove",
+    "lat": 53.3755,
+    "lng": -2.1173,
+    "authorityId": 264,
+    "population": 20170
+  },
+  {
+    "slug": "marple",
+    "name": "Marple",
+    "lat": 53.3955,
+    "lng": -2.0704,
+    "authorityId": 264,
+    "population": 12970
+  },
+  {
+    "slug": "reddish",
+    "name": "Reddish",
+    "lat": 53.4425,
+    "lng": -2.1576,
+    "authorityId": 264,
+    "population": 22200
+  },
+  {
+    "slug": "romiley",
+    "name": "Romiley",
+    "lat": 53.4166,
+    "lng": -2.0807,
+    "authorityId": 264,
+    "population": 10900
+  },
+  {
+    "slug": "stockport",
+    "name": "Stockport",
+    "lat": 53.4105,
+    "lng": -2.1605,
+    "authorityId": 264,
+    "population": 117935
+  },
+  {
+    "slug": "ashton-under-lyne",
+    "name": "Ashton-under-Lyne",
+    "lat": 53.4955,
+    "lng": -2.093,
+    "authorityId": 265,
+    "population": 48600
+  },
+  {
+    "slug": "audenshaw",
+    "name": "Audenshaw",
+    "lat": 53.4734,
+    "lng": -2.1303,
+    "authorityId": 265,
+    "population": 13395
+  },
+  {
+    "slug": "denton-tameside",
+    "name": "Denton (Tameside)",
+    "lat": 53.4516,
+    "lng": -2.1184,
+    "authorityId": 265,
+    "population": 35995
+  },
+  {
+    "slug": "droylsden",
+    "name": "Droylsden",
+    "lat": 53.4836,
+    "lng": -2.1515,
+    "authorityId": 265,
+    "population": 23915
+  },
+  {
+    "slug": "dukinfield",
+    "name": "Dukinfield",
+    "lat": 53.4746,
+    "lng": -2.0863,
+    "authorityId": 265,
+    "population": 21155
+  },
+  {
+    "slug": "hattersley",
+    "name": "Hattersley",
+    "lat": 53.4493,
+    "lng": -2.0317,
+    "authorityId": 265,
+    "population": 6960
+  },
+  {
+    "slug": "hyde-tameside",
+    "name": "Hyde (Tameside)",
+    "lat": 53.4527,
+    "lng": -2.0715,
+    "authorityId": 265,
+    "population": 35895
+  },
+  {
+    "slug": "mossley",
+    "name": "Mossley",
+    "lat": 53.52,
+    "lng": -2.0369,
+    "authorityId": 265,
+    "population": 11410
+  },
+  {
+    "slug": "stalybridge",
+    "name": "Stalybridge",
+    "lat": 53.4867,
+    "lng": -2.0422,
+    "authorityId": 265,
+    "population": 26830
+  },
+  {
+    "slug": "altrincham",
+    "name": "Altrincham",
+    "lat": 53.3942,
+    "lng": -2.3476,
+    "authorityId": 266,
+    "population": 49680
+  },
+  {
+    "slug": "bowdon",
+    "name": "Bowdon",
+    "lat": 53.3756,
+    "lng": -2.3673,
+    "authorityId": 266,
+    "population": 6105
+  },
+  {
+    "slug": "hale-trafford",
+    "name": "Hale (Trafford)",
+    "lat": 53.3598,
+    "lng": -2.3051,
+    "authorityId": 266,
+    "population": 16715
+  },
+  {
+    "slug": "old-trafford",
+    "name": "Old Trafford",
+    "lat": 53.4655,
+    "lng": -2.3128,
+    "authorityId": 266,
+    "population": 21445
+  },
+  {
+    "slug": "partington",
+    "name": "Partington",
+    "lat": 53.421,
+    "lng": -2.419,
+    "authorityId": 266,
+    "population": 7710
+  },
+  {
+    "slug": "sale",
+    "name": "Sale",
+    "lat": 53.4213,
+    "lng": -2.3217,
+    "authorityId": 266,
+    "population": 62550
+  },
+  {
+    "slug": "stretford",
+    "name": "Stretford",
+    "lat": 53.4499,
+    "lng": -2.3106,
+    "authorityId": 266,
+    "population": 28015
+  },
+  {
+    "slug": "urmston",
+    "name": "Urmston",
+    "lat": 53.452,
+    "lng": -2.3686,
+    "authorityId": 266,
+    "population": 41740
+  },
+  {
+    "slug": "ashton-in-makerfield",
+    "name": "Ashton-in-Makerfield",
+    "lat": 53.4931,
+    "lng": -2.6383,
+    "authorityId": 267,
+    "population": 26375
+  },
+  {
+    "slug": "atherton",
+    "name": "Atherton",
+    "lat": 53.5276,
+    "lng": -2.487,
+    "authorityId": 267,
+    "population": 27575
+  },
+  {
+    "slug": "golborne",
+    "name": "Golborne",
+    "lat": 53.4742,
+    "lng": -2.5769,
+    "authorityId": 267,
+    "population": 25555
+  },
+  {
+    "slug": "hindley",
+    "name": "Hindley",
+    "lat": 53.5352,
+    "lng": -2.5735,
+    "authorityId": 267,
+    "population": 24490
+  },
+  {
+    "slug": "ince-in-makerfield",
+    "name": "Ince-in-Makerfield",
+    "lat": 53.5371,
+    "lng": -2.6096,
+    "authorityId": 267,
+    "population": 12185
+  },
+  {
+    "slug": "leigh-wigan",
+    "name": "Leigh (Wigan)",
+    "lat": 53.5014,
+    "lng": -2.5333,
+    "authorityId": 267,
+    "population": 45495
+  },
+  {
+    "slug": "orrell",
+    "name": "Orrell",
+    "lat": 53.5342,
+    "lng": -2.7145,
+    "authorityId": 267,
+    "population": 23410
+  },
+  {
+    "slug": "platt-bridge-and-abram",
+    "name": "Platt Bridge and Abram",
+    "lat": 53.5189,
+    "lng": -2.5973,
+    "authorityId": 267,
+    "population": 10590
+  },
+  {
+    "slug": "shevington",
+    "name": "Shevington",
+    "lat": 53.5709,
+    "lng": -2.6926,
+    "authorityId": 267,
+    "population": 5320
+  },
+  {
+    "slug": "standish",
+    "name": "Standish",
+    "lat": 53.5865,
+    "lng": -2.6539,
+    "authorityId": 267,
+    "population": 12940
+  },
+  {
+    "slug": "tyldesley",
+    "name": "Tyldesley",
+    "lat": 53.5103,
+    "lng": -2.4606,
+    "authorityId": 267,
+    "population": 16205
+  },
+  {
+    "slug": "wigan",
+    "name": "Wigan",
+    "lat": 53.5466,
+    "lng": -2.6506,
+    "authorityId": 267,
+    "population": 81580
+  },
+  {
+    "slug": "huyton-with-roby",
+    "name": "Huyton with Roby",
+    "lat": 53.4168,
+    "lng": -2.8536,
+    "authorityId": 268,
+    "population": 59845
+  },
+  {
+    "slug": "kirkby",
+    "name": "Kirkby",
+    "lat": 53.4813,
+    "lng": -2.88,
+    "authorityId": 268,
+    "population": 45560
+  },
+  {
+    "slug": "prescot",
+    "name": "Prescot",
+    "lat": 53.4182,
+    "lng": -2.7876,
+    "authorityId": 268,
+    "population": 39225
+  },
+  {
+    "slug": "liverpool",
+    "name": "Liverpool",
+    "lat": 53.4106,
+    "lng": -2.9208,
+    "authorityId": 269,
+    "population": 506565
+  },
+  {
+    "slug": "haydock",
+    "name": "Haydock",
+    "lat": 53.4701,
+    "lng": -2.6705,
+    "authorityId": 270,
+    "population": 16140
+  },
+  {
+    "slug": "newton-le-willows",
+    "name": "Newton-le-Willows",
+    "lat": 53.4528,
+    "lng": -2.6297,
+    "authorityId": 270,
+    "population": 24650
+  },
+  {
+    "slug": "rainford",
+    "name": "Rainford",
+    "lat": 53.5044,
+    "lng": -2.7861,
+    "authorityId": 270,
+    "population": 5575
+  },
+  {
+    "slug": "st-helens-st-helens",
+    "name": "St Helens (St. Helens)",
+    "lat": 53.448,
+    "lng": -2.7367,
+    "authorityId": 270,
+    "population": 107680
+  },
+  {
+    "slug": "aintree",
+    "name": "Aintree",
+    "lat": 53.4812,
+    "lng": -2.9425,
+    "authorityId": 271,
+    "population": 6215
+  },
+  {
+    "slug": "bootle-sefton",
+    "name": "Bootle (Sefton)",
+    "lat": 53.4565,
+    "lng": -2.9959,
+    "authorityId": 271,
+    "population": 53720
+  },
+  {
+    "slug": "crosby-sefton",
+    "name": "Crosby (Sefton)",
+    "lat": 53.4885,
+    "lng": -3.0229,
+    "authorityId": 271,
+    "population": 50215
+  },
+  {
+    "slug": "formby",
+    "name": "Formby",
+    "lat": 53.5582,
+    "lng": -3.0623,
+    "authorityId": 271,
+    "population": 22890
+  },
+  {
+    "slug": "litherland",
+    "name": "Litherland",
+    "lat": 53.4749,
+    "lng": -2.9948,
+    "authorityId": 271,
+    "population": 18750
+  },
+  {
+    "slug": "lydiate",
+    "name": "Lydiate",
+    "lat": 53.5255,
+    "lng": -2.941,
+    "authorityId": 271,
+    "population": 6515
+  },
+  {
+    "slug": "maghull",
+    "name": "Maghull",
+    "lat": 53.5113,
+    "lng": -2.9395,
+    "authorityId": 271,
+    "population": 20370
+  },
+  {
+    "slug": "southport",
+    "name": "Southport",
+    "lat": 53.6356,
+    "lng": -2.9919,
+    "authorityId": 271,
+    "population": 94440
+  },
+  {
+    "slug": "bebington",
+    "name": "Bebington",
+    "lat": 53.341,
+    "lng": -2.9997,
+    "authorityId": 272,
+    "population": 57600
+  },
+  {
+    "slug": "birkenhead",
+    "name": "Birkenhead",
+    "lat": 53.3848,
+    "lng": -3.0581,
+    "authorityId": 272,
+    "population": 109835
+  },
+  {
+    "slug": "greasby",
+    "name": "Greasby",
+    "lat": 53.3739,
+    "lng": -3.1226,
+    "authorityId": 272,
+    "population": 9180
+  },
+  {
+    "slug": "heswall",
+    "name": "Heswall",
+    "lat": 53.3355,
+    "lng": -3.1007,
+    "authorityId": 272,
+    "population": 29075
+  },
+  {
+    "slug": "hoylake",
+    "name": "Hoylake",
+    "lat": 53.3871,
+    "lng": -3.1857,
+    "authorityId": 272,
+    "population": 5315
+  },
+  {
+    "slug": "meols",
+    "name": "Meols",
+    "lat": 53.3997,
+    "lng": -3.1555,
+    "authorityId": 272,
+    "population": 5020
+  },
+  {
+    "slug": "wallasey",
+    "name": "Wallasey",
+    "lat": 53.4172,
+    "lng": -3.0571,
+    "authorityId": 272,
+    "population": 85610
+  },
+  {
+    "slug": "west-kirby",
+    "name": "West Kirby",
+    "lat": 53.3702,
+    "lng": -3.1687,
+    "authorityId": 272,
+    "population": 13380
+  },
+  {
+    "slug": "barnsley",
+    "name": "Barnsley",
+    "lat": 53.5597,
+    "lng": -1.467,
+    "authorityId": 273,
+    "population": 71405
+  },
+  {
+    "slug": "barugh-green-and-redbrook",
+    "name": "Barugh Green and Redbrook",
+    "lat": 53.5657,
+    "lng": -1.5192,
+    "authorityId": 273,
+    "population": 7550
+  },
+  {
+    "slug": "bolton-upon-dearne",
+    "name": "Bolton upon Dearne",
+    "lat": 53.5193,
+    "lng": -1.3197,
+    "authorityId": 273,
+    "population": 7445
+  },
+  {
+    "slug": "cudworth-and-shafton",
+    "name": "Cudworth and Shafton",
+    "lat": 53.5853,
+    "lng": -1.4145,
+    "authorityId": 273,
+    "population": 12470
+  },
+  {
+    "slug": "darfield",
+    "name": "Darfield",
+    "lat": 53.5361,
+    "lng": -1.3806,
+    "authorityId": 273,
+    "population": 7210
+  },
+  {
+    "slug": "darton",
+    "name": "Darton",
+    "lat": 53.5886,
+    "lng": -1.5159,
+    "authorityId": 273,
+    "population": 15025
+  },
+  {
+    "slug": "dodworth",
+    "name": "Dodworth",
+    "lat": 53.545,
+    "lng": -1.5257,
+    "authorityId": 273,
+    "population": 5975
+  },
+  {
+    "slug": "goldthorpe",
+    "name": "Goldthorpe",
+    "lat": 53.5304,
+    "lng": -1.3112,
+    "authorityId": 273,
+    "population": 7490
+  },
+  {
+    "slug": "grimethorpe",
+    "name": "Grimethorpe",
+    "lat": 53.5754,
+    "lng": -1.3807,
+    "authorityId": 273,
+    "population": 5065
+  },
+  {
+    "slug": "hoyland",
+    "name": "Hoyland",
+    "lat": 53.5018,
+    "lng": -1.4432,
+    "authorityId": 273,
+    "population": 15535
+  },
+  {
+    "slug": "penistone",
+    "name": "Penistone",
+    "lat": 53.5237,
+    "lng": -1.6269,
+    "authorityId": 273,
+    "population": 8540
+  },
+  {
+    "slug": "royston-barnsley",
+    "name": "Royston (Barnsley)",
+    "lat": 53.5992,
+    "lng": -1.4537,
+    "authorityId": 273,
+    "population": 10755
+  },
+  {
+    "slug": "thurnscoe",
+    "name": "Thurnscoe",
+    "lat": 53.5454,
+    "lng": -1.3108,
+    "authorityId": 273,
+    "population": 9135
+  },
+  {
+    "slug": "wombwell",
+    "name": "Wombwell",
+    "lat": 53.5226,
+    "lng": -1.405,
+    "authorityId": 273,
+    "population": 16765
+  },
+  {
+    "slug": "worsbrough",
+    "name": "Worsbrough",
+    "lat": 53.532,
+    "lng": -1.4672,
+    "authorityId": 273,
+    "population": 8835
+  },
+  {
+    "slug": "adwick-le-street",
+    "name": "Adwick le Street",
+    "lat": 53.5736,
+    "lng": -1.1928,
+    "authorityId": 274,
+    "population": 18325
+  },
+  {
+    "slug": "armthorpe",
+    "name": "Armthorpe",
+    "lat": 53.5371,
+    "lng": -1.0495,
+    "authorityId": 274,
+    "population": 14160
+  },
+  {
+    "slug": "askern",
+    "name": "Askern",
+    "lat": 53.6151,
+    "lng": -1.1523,
+    "authorityId": 274,
+    "population": 5435
+  },
+  {
+    "slug": "bentley-doncaster",
+    "name": "Bentley (Doncaster)",
+    "lat": 53.538,
+    "lng": -1.1487,
+    "authorityId": 274,
+    "population": 12045
+  },
+  {
+    "slug": "conisbrough",
+    "name": "Conisbrough",
+    "lat": 53.4822,
+    "lng": -1.2305,
+    "authorityId": 274,
+    "population": 11465
+  },
+  {
+    "slug": "doncaster",
+    "name": "Doncaster",
+    "lat": 53.5144,
+    "lng": -1.1069,
+    "authorityId": 274,
+    "population": 87455
+  },
+  {
+    "slug": "dunscroft-and-hatfield",
+    "name": "Dunscroft and Hatfield",
+    "lat": 53.5739,
+    "lng": -1.0117,
+    "authorityId": 274,
+    "population": 14000
+  },
+  {
+    "slug": "finningley",
+    "name": "Finningley",
+    "lat": 53.4823,
+    "lng": -1.0071,
+    "authorityId": 274,
+    "population": 5920
+  },
+  {
+    "slug": "kirk-sandall-and-edenthorpe",
+    "name": "Kirk Sandall and Edenthorpe",
+    "lat": 53.5593,
+    "lng": -1.0719,
+    "authorityId": 274,
+    "population": 13085
+  },
+  {
+    "slug": "mexborough",
+    "name": "Mexborough",
+    "lat": 53.4977,
+    "lng": -1.2865,
+    "authorityId": 274,
+    "population": 15555
+  },
+  {
+    "slug": "moorends",
+    "name": "Moorends",
+    "lat": 53.631,
+    "lng": -0.9475,
+    "authorityId": 274,
+    "population": 5195
+  },
+  {
+    "slug": "new-rossington-and-rossington",
+    "name": "New Rossington and Rossington",
+    "lat": 53.4703,
+    "lng": -1.0793,
+    "authorityId": 274,
+    "population": 13910
+  },
+  {
+    "slug": "scawthorpe-and-cusworth",
+    "name": "Scawthorpe and Cusworth",
+    "lat": 53.5416,
+    "lng": -1.1732,
+    "authorityId": 274,
+    "population": 13015
+  },
+  {
+    "slug": "sprotbrough",
+    "name": "Sprotbrough",
+    "lat": 53.515,
+    "lng": -1.1876,
+    "authorityId": 274,
+    "population": 7550
+  },
+  {
+    "slug": "stainforth",
+    "name": "Stainforth",
+    "lat": 53.5963,
+    "lng": -1.0251,
+    "authorityId": 274,
+    "population": 6000
+  },
+  {
+    "slug": "thorne",
+    "name": "Thorne",
+    "lat": 53.6131,
+    "lng": -0.9644,
+    "authorityId": 274,
+    "population": 12305
+  },
+  {
+    "slug": "warmsworth",
+    "name": "Warmsworth",
+    "lat": 53.4801,
+    "lng": -1.1897,
+    "authorityId": 274,
+    "population": 11315
+  },
+  {
+    "slug": "brinsworth",
+    "name": "Brinsworth",
+    "lat": 53.4033,
+    "lng": -1.37,
+    "authorityId": 275,
+    "population": 8760
+  },
+  {
+    "slug": "dinnington-rotherham",
+    "name": "Dinnington (Rotherham)",
+    "lat": 53.371,
+    "lng": -1.2117,
+    "authorityId": 275,
+    "population": 10960
+  },
+  {
+    "slug": "kiveton-park",
+    "name": "Kiveton Park",
+    "lat": 53.3413,
+    "lng": -1.2572,
+    "authorityId": 275,
+    "population": 7100
+  },
+  {
+    "slug": "maltby",
+    "name": "Maltby",
+    "lat": 53.4235,
+    "lng": -1.1903,
+    "authorityId": 275,
+    "population": 16310
+  },
+  {
+    "slug": "north-anston",
+    "name": "North Anston",
+    "lat": 53.3584,
+    "lng": -1.2205,
+    "authorityId": 275,
+    "population": 6605
+  },
+  {
+    "slug": "rawmarsh",
+    "name": "Rawmarsh",
+    "lat": 53.4621,
+    "lng": -1.3448,
+    "authorityId": 275,
+    "population": 18895
+  },
+  {
+    "slug": "rotherham",
+    "name": "Rotherham",
+    "lat": 53.4303,
+    "lng": -1.3508,
+    "authorityId": 275,
+    "population": 71535
+  },
+  {
+    "slug": "swallownest-and-aston",
+    "name": "Swallownest and Aston",
+    "lat": 53.3643,
+    "lng": -1.3175,
+    "authorityId": 275,
+    "population": 14910
+  },
+  {
+    "slug": "swinton-rotherham",
+    "name": "Swinton (Rotherham)",
+    "lat": 53.484,
+    "lng": -1.313,
+    "authorityId": 275,
+    "population": 15910
+  },
+  {
+    "slug": "thrybergh-and-dalton",
+    "name": "Thrybergh and Dalton",
+    "lat": 53.4494,
+    "lng": -1.2959,
+    "authorityId": 275,
+    "population": 5860
+  },
+  {
+    "slug": "thurcroft",
+    "name": "Thurcroft",
+    "lat": 53.3949,
+    "lng": -1.2581,
+    "authorityId": 275,
+    "population": 6100
+  },
+  {
+    "slug": "wath-upon-dearne",
+    "name": "Wath upon Dearne",
+    "lat": 53.5015,
+    "lng": -1.3394,
+    "authorityId": 275,
+    "population": 16960
+  },
+  {
+    "slug": "waverley-and-catcliffe",
+    "name": "Waverley and Catcliffe",
+    "lat": 53.387,
+    "lng": -1.3707,
+    "authorityId": 275,
+    "population": 5340
+  },
+  {
+    "slug": "wickersley-and-bramley",
+    "name": "Wickersley and Bramley",
+    "lat": 53.4256,
+    "lng": -1.279,
+    "authorityId": 275,
+    "population": 24655
+  },
+  {
+    "slug": "chapeltown-and-high-green",
+    "name": "Chapeltown and High Green",
+    "lat": 53.4644,
+    "lng": -1.4797,
+    "authorityId": 276,
+    "population": 22180
+  },
+  {
+    "slug": "deepcar",
+    "name": "Deepcar",
+    "lat": 53.4761,
+    "lng": -1.5782,
+    "authorityId": 276,
+    "population": 5645
+  },
+  {
+    "slug": "ecclesfield-and-grenoside",
+    "name": "Ecclesfield and Grenoside",
+    "lat": 53.4431,
+    "lng": -1.4654,
+    "authorityId": 276,
+    "population": 8190
+  },
+  {
+    "slug": "sheffield",
+    "name": "Sheffield",
+    "lat": 53.3739,
+    "lng": -1.4605,
+    "authorityId": 276,
+    "population": 500535
+  },
+  {
+    "slug": "stocksbridge",
+    "name": "Stocksbridge",
+    "lat": 53.4793,
+    "lng": -1.597,
+    "authorityId": 276,
+    "population": 7265
+  },
+  {
+    "slug": "birtley",
+    "name": "Birtley",
+    "lat": 54.8991,
+    "lng": -1.5792,
+    "authorityId": 277,
+    "population": 13835
+  },
+  {
+    "slug": "blaydon",
+    "name": "Blaydon",
+    "lat": 54.9597,
+    "lng": -1.7042,
+    "authorityId": 277,
+    "population": 14240
+  },
+  {
+    "slug": "crawcrook-and-greenside",
+    "name": "Crawcrook and Greenside",
+    "lat": 54.9595,
+    "lng": -1.7845,
+    "authorityId": 277,
+    "population": 7545
+  },
+  {
+    "slug": "gateshead",
+    "name": "Gateshead",
+    "lat": 54.9402,
+    "lng": -1.5797,
+    "authorityId": 277,
+    "population": 115280
+  },
+  {
+    "slug": "rowlands-gill",
+    "name": "Rowlands Gill",
+    "lat": 54.9205,
+    "lng": -1.7552,
+    "authorityId": 277,
+    "population": 5255
+  },
+  {
+    "slug": "ryton",
+    "name": "Ryton",
+    "lat": 54.9719,
+    "lng": -1.7502,
+    "authorityId": 277,
+    "population": 8805
+  },
+  {
+    "slug": "whickham",
+    "name": "Whickham",
+    "lat": 54.9451,
+    "lng": -1.6807,
+    "authorityId": 277,
+    "population": 15685
+  },
+  {
+    "slug": "newcastle-upon-tyne",
+    "name": "Newcastle upon Tyne",
+    "lat": 54.9987,
+    "lng": -1.6418,
+    "authorityId": 278,
+    "population": 286445
+  },
+  {
+    "slug": "throckley",
+    "name": "Throckley",
+    "lat": 54.9958,
+    "lng": -1.7586,
+    "authorityId": 278,
+    "population": 6210
+  },
+  {
+    "slug": "killingworth",
+    "name": "Killingworth",
+    "lat": 55.0396,
+    "lng": -1.5743,
+    "authorityId": 279,
+    "population": 12180
+  },
+  {
+    "slug": "longbenton",
+    "name": "Longbenton",
+    "lat": 55.0225,
+    "lng": -1.5726,
+    "authorityId": 279,
+    "population": 26880
+  },
+  {
+    "slug": "shiremoor",
+    "name": "Shiremoor",
+    "lat": 55.0349,
+    "lng": -1.5082,
+    "authorityId": 279,
+    "population": 6955
+  },
+  {
+    "slug": "tynemouth",
+    "name": "Tynemouth",
+    "lat": 55.0142,
+    "lng": -1.4657,
+    "authorityId": 279,
+    "population": 60605
+  },
+  {
+    "slug": "wallsend",
+    "name": "Wallsend",
+    "lat": 55.0012,
+    "lng": -1.5187,
+    "authorityId": 279,
+    "population": 45355
+  },
+  {
+    "slug": "whitley-bay",
+    "name": "Whitley Bay",
+    "lat": 55.0464,
+    "lng": -1.4672,
+    "authorityId": 279,
+    "population": 36880
+  },
+  {
+    "slug": "wideopen",
+    "name": "Wideopen",
+    "lat": 55.0457,
+    "lng": -1.629,
+    "authorityId": 279,
+    "population": 9145
+  },
+  {
+    "slug": "boldon-colliery",
+    "name": "Boldon Colliery",
+    "lat": 54.9504,
+    "lng": -1.4619,
+    "authorityId": 280,
+    "population": 6070
+  },
+  {
+    "slug": "east-boldon-and-west-boldon",
+    "name": "East Boldon and West Boldon",
+    "lat": 54.9463,
+    "lng": -1.4391,
+    "authorityId": 280,
+    "population": 6795
+  },
+  {
+    "slug": "hebburn",
+    "name": "Hebburn",
+    "lat": 54.9744,
+    "lng": -1.5144,
+    "authorityId": 280,
+    "population": 21345
+  },
+  {
+    "slug": "jarrow",
+    "name": "Jarrow",
+    "lat": 54.9703,
+    "lng": -1.478,
+    "authorityId": 280,
+    "population": 29470
+  },
+  {
+    "slug": "south-shields",
+    "name": "South Shields",
+    "lat": 54.9783,
+    "lng": -1.424,
+    "authorityId": 280,
+    "population": 73345
+  },
+  {
+    "slug": "whitburn-south-tyneside",
+    "name": "Whitburn (South Tyneside)",
+    "lat": 54.9515,
+    "lng": -1.367,
+    "authorityId": 280,
+    "population": 5090
+  },
+  {
+    "slug": "fence-houses",
+    "name": "Fence Houses",
+    "lat": 54.8439,
+    "lng": -1.5013,
+    "authorityId": 281,
+    "population": 6945
+  },
+  {
+    "slug": "hetton-le-hole",
+    "name": "Hetton-le-Hole",
+    "lat": 54.8182,
+    "lng": -1.4547,
+    "authorityId": 281,
+    "population": 8970
+  },
+  {
+    "slug": "houghton-le-spring",
+    "name": "Houghton-le-Spring",
+    "lat": 54.8397,
+    "lng": -1.4754,
+    "authorityId": 281,
+    "population": 12555
+  },
+  {
+    "slug": "shiney-row-and-penshaw",
+    "name": "Shiney Row and Penshaw",
+    "lat": 54.8665,
+    "lng": -1.4865,
+    "authorityId": 281,
+    "population": 16900
+  },
+  {
+    "slug": "sunderland",
+    "name": "Sunderland",
+    "lat": 54.9038,
+    "lng": -1.41,
+    "authorityId": 281,
+    "population": 168315
+  },
+  {
+    "slug": "washington",
+    "name": "Washington",
+    "lat": 54.9048,
+    "lng": -1.5163,
+    "authorityId": 281,
+    "population": 51320
+  },
+  {
+    "slug": "birmingham",
+    "name": "Birmingham",
+    "lat": 52.4805,
+    "lng": -1.8617,
+    "authorityId": 282,
+    "population": 1121375
+  },
+  {
+    "slug": "royal-sutton-coldfield",
+    "name": "Royal Sutton Coldfield",
+    "lat": 52.5694,
+    "lng": -1.8285,
+    "authorityId": 282,
+    "population": 93375
+  },
+  {
+    "slug": "coventry",
+    "name": "Coventry",
+    "lat": 52.4091,
+    "lng": -1.5128,
+    "authorityId": 283,
+    "population": 344285
+  },
+  {
+    "slug": "brierley-hill",
+    "name": "Brierley Hill",
+    "lat": 52.4754,
+    "lng": -2.12,
+    "authorityId": 284,
+    "population": 32305
+  },
+  {
+    "slug": "coseley",
+    "name": "Coseley",
+    "lat": 52.5358,
+    "lng": -2.0948,
+    "authorityId": 284,
+    "population": 25205
+  },
+  {
+    "slug": "dudley-dudley",
+    "name": "Dudley (Dudley)",
+    "lat": 52.5047,
+    "lng": -2.0917,
+    "authorityId": 284,
+    "population": 64270
+  },
+  {
+    "slug": "halesowen",
+    "name": "Halesowen",
+    "lat": 52.4542,
+    "lng": -2.0696,
+    "authorityId": 284,
+    "population": 60110
+  },
+  {
+    "slug": "kingswinford",
+    "name": "Kingswinford",
+    "lat": 52.4947,
+    "lng": -2.1565,
+    "authorityId": 284,
+    "population": 51910
+  },
+  {
+    "slug": "sedgley",
+    "name": "Sedgley",
+    "lat": 52.5267,
+    "lng": -2.1281,
+    "authorityId": 284,
+    "population": 31990
+  },
+  {
+    "slug": "stourbridge",
+    "name": "Stourbridge",
+    "lat": 52.4519,
+    "lng": -2.143,
+    "authorityId": 284,
+    "population": 56950
+  },
+  {
+    "slug": "blackheath",
+    "name": "Blackheath",
+    "lat": 52.4782,
+    "lng": -2.0411,
+    "authorityId": 285,
+    "population": 6950
+  },
+  {
+    "slug": "cradley-heath",
+    "name": "Cradley Heath",
+    "lat": 52.4725,
+    "lng": -2.0659,
+    "authorityId": 285,
+    "population": 18820
+  },
+  {
+    "slug": "oldbury-sandwell",
+    "name": "Oldbury (Sandwell)",
+    "lat": 52.4965,
+    "lng": -2.0159,
+    "authorityId": 285,
+    "population": 45180
+  },
+  {
+    "slug": "rowley-regis",
+    "name": "Rowley Regis",
+    "lat": 52.4921,
+    "lng": -2.0454,
+    "authorityId": 285,
+    "population": 39050
+  },
+  {
+    "slug": "smethwick",
+    "name": "Smethwick",
+    "lat": 52.4918,
+    "lng": -1.9719,
+    "authorityId": 285,
+    "population": 56340
+  },
+  {
+    "slug": "tipton",
+    "name": "Tipton",
+    "lat": 52.5381,
+    "lng": -2.0551,
+    "authorityId": 285,
+    "population": 47200
+  },
+  {
+    "slug": "wednesbury",
+    "name": "Wednesbury",
+    "lat": 52.5561,
+    "lng": -2.015,
+    "authorityId": 285,
+    "population": 20315
+  },
+  {
+    "slug": "west-bromwich",
+    "name": "West Bromwich",
+    "lat": 52.53,
+    "lng": -1.9894,
+    "authorityId": 285,
+    "population": 103110
+  },
+  {
+    "slug": "balsall-common",
+    "name": "Balsall Common",
+    "lat": 52.3941,
+    "lng": -1.6552,
+    "authorityId": 286,
+    "population": 7095
+  },
+  {
+    "slug": "knowle-and-dorridge",
+    "name": "Knowle and Dorridge",
+    "lat": 52.377,
+    "lng": -1.7471,
+    "authorityId": 286,
+    "population": 19320
+  },
+  {
+    "slug": "solihull",
+    "name": "Solihull",
+    "lat": 52.4086,
+    "lng": -1.8084,
+    "authorityId": 286,
+    "population": 107735
+  },
+  {
+    "slug": "aldridge",
+    "name": "Aldridge",
+    "lat": 52.6056,
+    "lng": -1.9248,
+    "authorityId": 287,
+    "population": 15835
+  },
+  {
+    "slug": "bloxwich",
+    "name": "Bloxwich",
+    "lat": 52.6113,
+    "lng": -1.998,
+    "authorityId": 287,
+    "population": 51875
+  },
+  {
+    "slug": "brownhills",
+    "name": "Brownhills",
+    "lat": 52.6455,
+    "lng": -1.9323,
+    "authorityId": 287,
+    "population": 21240
+  },
+  {
+    "slug": "darlaston",
+    "name": "Darlaston",
+    "lat": 52.5699,
+    "lng": -2.0343,
+    "authorityId": 287,
+    "population": 21540
+  },
+  {
+    "slug": "pelsall",
+    "name": "Pelsall",
+    "lat": 52.6309,
+    "lng": -1.9711,
+    "authorityId": 287,
+    "population": 10455
+  },
+  {
+    "slug": "pheasey",
+    "name": "Pheasey",
+    "lat": 52.5584,
+    "lng": -1.9102,
+    "authorityId": 287,
+    "population": 9495
+  },
+  {
+    "slug": "rushall-and-shelfield",
+    "name": "Rushall and Shelfield",
+    "lat": 52.6102,
+    "lng": -1.9542,
+    "authorityId": 287,
+    "population": 12845
+  },
+  {
+    "slug": "streetly",
+    "name": "Streetly",
+    "lat": 52.5804,
+    "lng": -1.8879,
+    "authorityId": 287,
+    "population": 16785
+  },
+  {
+    "slug": "walsall",
+    "name": "Walsall",
+    "lat": 52.5784,
+    "lng": -1.9746,
+    "authorityId": 287,
+    "population": 70775
+  },
+  {
+    "slug": "willenhall",
+    "name": "Willenhall",
+    "lat": 52.5916,
+    "lng": -2.0425,
+    "authorityId": 287,
+    "population": 49580
+  },
+  {
+    "slug": "bilston-wolverhampton",
+    "name": "Bilston (Wolverhampton)",
+    "lat": 52.5633,
+    "lng": -2.0736,
+    "authorityId": 288,
+    "population": 34640
+  },
+  {
+    "slug": "wolverhampton",
+    "name": "Wolverhampton",
+    "lat": 52.5879,
+    "lng": -2.1305,
+    "authorityId": 288,
+    "population": 234025
+  },
+  {
+    "slug": "baildon",
+    "name": "Baildon",
+    "lat": 53.847,
+    "lng": -1.7753,
+    "authorityId": 289,
+    "population": 17050
+  },
+  {
+    "slug": "bingley",
+    "name": "Bingley",
+    "lat": 53.853,
+    "lng": -1.829,
+    "authorityId": 289,
+    "population": 21330
+  },
+  {
+    "slug": "bradford",
+    "name": "Bradford",
+    "lat": 53.7928,
+    "lng": -1.7637,
+    "authorityId": 289,
+    "population": 333950
+  },
+  {
+    "slug": "burley-in-wharfedale",
+    "name": "Burley in Wharfedale",
+    "lat": 53.9092,
+    "lng": -1.7517,
+    "authorityId": 289,
+    "population": 6805
+  },
+  {
+    "slug": "haworth",
+    "name": "Haworth",
+    "lat": 53.8336,
+    "lng": -1.9459,
+    "authorityId": 289,
+    "population": 5680
+  },
+  {
+    "slug": "ilkley",
+    "name": "Ilkley",
+    "lat": 53.9268,
+    "lng": -1.8324,
+    "authorityId": 289,
+    "population": 14845
+  },
+  {
+    "slug": "keighley",
+    "name": "Keighley",
+    "lat": 53.8674,
+    "lng": -1.9121,
+    "authorityId": 289,
+    "population": 48750
+  },
+  {
+    "slug": "menston",
+    "name": "Menston",
+    "lat": 53.8915,
+    "lng": -1.7374,
+    "authorityId": 289,
+    "population": 5905
+  },
+  {
+    "slug": "queensbury",
+    "name": "Queensbury",
+    "lat": 53.7653,
+    "lng": -1.8522,
+    "authorityId": 289,
+    "population": 9705
+  },
+  {
+    "slug": "shipley-bradford",
+    "name": "Shipley (Bradford)",
+    "lat": 53.831,
+    "lng": -1.7667,
+    "authorityId": 289,
+    "population": 29225
+  },
+  {
+    "slug": "silsden",
+    "name": "Silsden",
+    "lat": 53.9121,
+    "lng": -1.9373,
+    "authorityId": 289,
+    "population": 8395
+  },
+  {
+    "slug": "steeton",
+    "name": "Steeton",
+    "lat": 53.8969,
+    "lng": -1.9542,
+    "authorityId": 289,
+    "population": 5020
+  },
+  {
+    "slug": "thornton-bradford",
+    "name": "Thornton (Bradford)",
+    "lat": 53.791,
+    "lng": -1.8449,
+    "authorityId": 289,
+    "population": 5410
+  },
+  {
+    "slug": "brighouse",
+    "name": "Brighouse",
+    "lat": 53.7044,
+    "lng": -1.787,
+    "authorityId": 290,
+    "population": 33160
+  },
+  {
+    "slug": "elland",
+    "name": "Elland",
+    "lat": 53.6861,
+    "lng": -1.8346,
+    "authorityId": 290,
+    "population": 15785
+  },
+  {
+    "slug": "halifax",
+    "name": "Halifax",
+    "lat": 53.7281,
+    "lng": -1.8854,
+    "authorityId": 290,
+    "population": 88115
+  },
+  {
+    "slug": "hebden-bridge",
+    "name": "Hebden Bridge",
+    "lat": 53.7447,
+    "lng": -2.0136,
+    "authorityId": 290,
+    "population": 5225
+  },
+  {
+    "slug": "shelf-and-northowram",
+    "name": "Shelf and Northowram",
+    "lat": 53.7418,
+    "lng": -1.8277,
+    "authorityId": 290,
+    "population": 9195
+  },
+  {
+    "slug": "todmorden",
+    "name": "Todmorden",
+    "lat": 53.7122,
+    "lng": -2.1031,
+    "authorityId": 290,
+    "population": 12970
+  },
+  {
+    "slug": "batley",
+    "name": "Batley",
+    "lat": 53.7188,
+    "lng": -1.6392,
+    "authorityId": 291,
+    "population": 44500
+  },
+  {
+    "slug": "cleckheaton",
+    "name": "Cleckheaton",
+    "lat": 53.725,
+    "lng": -1.7173,
+    "authorityId": 291,
+    "population": 11605
+  },
+  {
+    "slug": "dewsbury",
+    "name": "Dewsbury",
+    "lat": 53.6849,
+    "lng": -1.6334,
+    "authorityId": 291,
+    "population": 63720
+  },
+  {
+    "slug": "gomersal-and-birkenshaw",
+    "name": "Gomersal and Birkenshaw",
+    "lat": 53.7535,
+    "lng": -1.6939,
+    "authorityId": 291,
+    "population": 13955
+  },
+  {
+    "slug": "heckmondwike",
+    "name": "Heckmondwike",
+    "lat": 53.7117,
+    "lng": -1.6717,
+    "authorityId": 291,
+    "population": 13370
+  },
+  {
+    "slug": "honley",
+    "name": "Honley",
+    "lat": 53.5864,
+    "lng": -1.7769,
+    "authorityId": 291,
+    "population": 14395
+  },
+  {
+    "slug": "huddersfield",
+    "name": "Huddersfield",
+    "lat": 53.6474,
+    "lng": -1.7916,
+    "authorityId": 291,
+    "population": 141675
+  },
+  {
+    "slug": "linthwaite-and-slaithwaite",
+    "name": "Linthwaite and Slaithwaite",
+    "lat": 53.6231,
+    "lng": -1.8632,
+    "authorityId": 291,
+    "population": 9245
+  },
+  {
+    "slug": "liversedge",
+    "name": "Liversedge",
+    "lat": 53.7072,
+    "lng": -1.7017,
+    "authorityId": 291,
+    "population": 17525
+  },
+  {
+    "slug": "meltham",
+    "name": "Meltham",
+    "lat": 53.5938,
+    "lng": -1.8467,
+    "authorityId": 291,
+    "population": 8325
+  },
+  {
+    "slug": "mirfield",
+    "name": "Mirfield",
+    "lat": 53.6793,
+    "lng": -1.6982,
+    "authorityId": 291,
+    "population": 19610
+  },
+  {
+    "slug": "allerton-bywater",
+    "name": "Allerton Bywater",
+    "lat": 53.7561,
+    "lng": -1.3874,
+    "authorityId": 292,
+    "population": 6960
+  },
+  {
+    "slug": "boston-spa",
+    "name": "Boston Spa",
+    "lat": 53.8995,
+    "lng": -1.3499,
+    "authorityId": 292,
+    "population": 6360
+  },
+  {
+    "slug": "drighlington",
+    "name": "Drighlington",
+    "lat": 53.7548,
+    "lng": -1.6598,
+    "authorityId": 292,
+    "population": 5280
+  },
+  {
+    "slug": "east-ardsley",
+    "name": "East Ardsley",
+    "lat": 53.7255,
+    "lng": -1.5512,
+    "authorityId": 292,
+    "population": 15245
+  },
+  {
+    "slug": "garforth",
+    "name": "Garforth",
+    "lat": 53.7918,
+    "lng": -1.381,
+    "authorityId": 292,
+    "population": 15155
+  },
+  {
+    "slug": "gildersome",
+    "name": "Gildersome",
+    "lat": 53.7552,
+    "lng": -1.6312,
+    "authorityId": 292,
+    "population": 6275
+  },
+  {
+    "slug": "guiseley",
+    "name": "Guiseley",
+    "lat": 53.8754,
+    "lng": -1.7121,
+    "authorityId": 292,
+    "population": 12460
+  },
+  {
+    "slug": "kippax",
+    "name": "Kippax",
+    "lat": 53.7688,
+    "lng": -1.3723,
+    "authorityId": 292,
+    "population": 10300
+  },
+  {
+    "slug": "leeds",
+    "name": "Leeds",
+    "lat": 53.8067,
+    "lng": -1.5535,
+    "authorityId": 292,
+    "population": 536280
+  },
+  {
+    "slug": "morley-leeds",
+    "name": "Morley (Leeds)",
+    "lat": 53.7448,
+    "lng": -1.5986,
+    "authorityId": 292,
+    "population": 32550
+  },
+  {
+    "slug": "otley-leeds",
+    "name": "Otley (Leeds)",
+    "lat": 53.9073,
+    "lng": -1.6957,
+    "authorityId": 292,
+    "population": 14540
+  },
+  {
+    "slug": "pudsey",
+    "name": "Pudsey",
+    "lat": 53.8029,
+    "lng": -1.6759,
+    "authorityId": 292,
+    "population": 34850
+  },
+  {
+    "slug": "rawdon",
+    "name": "Rawdon",
+    "lat": 53.8478,
+    "lng": -1.675,
+    "authorityId": 292,
+    "population": 6740
+  },
+  {
+    "slug": "rothwell-leeds",
+    "name": "Rothwell (Leeds)",
+    "lat": 53.7526,
+    "lng": -1.4906,
+    "authorityId": 292,
+    "population": 20965
+  },
+  {
+    "slug": "wetherby",
+    "name": "Wetherby",
+    "lat": 53.9337,
+    "lng": -1.3889,
+    "authorityId": 292,
+    "population": 11710
+  },
+  {
+    "slug": "yeadon",
+    "name": "Yeadon",
+    "lat": 53.8684,
+    "lng": -1.6683,
+    "authorityId": 292,
+    "population": 14270
+  },
+  {
+    "slug": "ackworth-moor-top",
+    "name": "Ackworth Moor Top",
+    "lat": 53.6411,
+    "lng": -1.3393,
+    "authorityId": 293,
+    "population": 6280
+  },
+  {
+    "slug": "castleford",
+    "name": "Castleford",
+    "lat": 53.722,
+    "lng": -1.3367,
+    "authorityId": 293,
+    "population": 45355
+  },
+  {
+    "slug": "crigglestone-and-durkar",
+    "name": "Crigglestone and Durkar",
+    "lat": 53.6435,
+    "lng": -1.5323,
+    "authorityId": 293,
+    "population": 6675
+  },
+  {
+    "slug": "crofton",
+    "name": "Crofton",
+    "lat": 53.6607,
+    "lng": -1.432,
+    "authorityId": 293,
+    "population": 6125
+  },
+  {
+    "slug": "featherstone-wakefield",
+    "name": "Featherstone (Wakefield)",
+    "lat": 53.6801,
+    "lng": -1.3602,
+    "authorityId": 293,
+    "population": 11655
+  },
+  {
+    "slug": "havercroft-and-ryhill",
+    "name": "Havercroft and Ryhill",
+    "lat": 53.6237,
+    "lng": -1.4126,
+    "authorityId": 293,
+    "population": 5205
+  },
+  {
+    "slug": "hemsworth",
+    "name": "Hemsworth",
+    "lat": 53.6125,
+    "lng": -1.3514,
+    "authorityId": 293,
+    "population": 9180
+  },
+  {
+    "slug": "horbury",
+    "name": "Horbury",
+    "lat": 53.6599,
+    "lng": -1.552,
+    "authorityId": 293,
+    "population": 9865
+  },
+  {
+    "slug": "knottingley",
+    "name": "Knottingley",
+    "lat": 53.7015,
+    "lng": -1.252,
+    "authorityId": 293,
+    "population": 9510
+  },
+  {
+    "slug": "normanton-wakefield",
+    "name": "Normanton (Wakefield)",
+    "lat": 53.7044,
+    "lng": -1.4109,
+    "authorityId": 293,
+    "population": 21980
+  },
+  {
+    "slug": "ossett",
+    "name": "Ossett",
+    "lat": 53.6795,
+    "lng": -1.5745,
+    "authorityId": 293,
+    "population": 21855
+  },
+  {
+    "slug": "pontefract",
+    "name": "Pontefract",
+    "lat": 53.6921,
+    "lng": -1.3089,
+    "authorityId": 293,
+    "population": 32975
+  },
+  {
+    "slug": "south-elmsall",
+    "name": "South Elmsall",
+    "lat": 53.5977,
+    "lng": -1.2816,
+    "authorityId": 293,
+    "population": 11185
+  },
+  {
+    "slug": "south-kirkby",
+    "name": "South Kirkby",
+    "lat": 53.5938,
+    "lng": -1.3216,
+    "authorityId": 293,
+    "population": 8885
+  },
+  {
+    "slug": "upton-wakefield",
+    "name": "Upton (Wakefield)",
+    "lat": 53.6163,
+    "lng": -1.2827,
+    "authorityId": 293,
+    "population": 6330
+  },
+  {
+    "slug": "wakefield",
+    "name": "Wakefield",
+    "lat": 53.684,
+    "lng": -1.5045,
+    "authorityId": 293,
+    "population": 97870
+  },
+  {
+    "slug": "amersham",
+    "name": "Amersham",
+    "lat": 51.6777,
+    "lng": -0.6045,
+    "authorityId": 327,
+    "population": 17380
+  },
+  {
+    "slug": "aston-clinton",
+    "name": "Aston Clinton",
+    "lat": 51.8041,
+    "lng": -0.727,
+    "authorityId": 327,
+    "population": 5510
+  },
+  {
+    "slug": "aylesbury",
+    "name": "Aylesbury",
+    "lat": 51.8118,
+    "lng": -0.8057,
+    "authorityId": 327,
+    "population": 87950
+  },
+  {
+    "slug": "beaconsfield",
+    "name": "Beaconsfield",
+    "lat": 51.6073,
+    "lng": -0.6494,
+    "authorityId": 327,
+    "population": 14145
+  },
+  {
+    "slug": "bourne-end",
+    "name": "Bourne End",
+    "lat": 51.5785,
+    "lng": -0.7057,
+    "authorityId": 327,
+    "population": 7170
+  },
+  {
+    "slug": "buckingham",
+    "name": "Buckingham",
+    "lat": 51.997,
+    "lng": -0.9851,
+    "authorityId": 327,
+    "population": 14295
+  },
+  {
+    "slug": "chalfont-st-peter",
+    "name": "Chalfont St Peter",
+    "lat": 51.6046,
+    "lng": -0.559,
+    "authorityId": 327,
+    "population": 13650
+  },
+  {
+    "slug": "chesham",
+    "name": "Chesham",
+    "lat": 51.7157,
+    "lng": -0.612,
+    "authorityId": 327,
+    "population": 23695
+  },
+  {
+    "slug": "farnham-common-and-farnham-royal",
+    "name": "Farnham Common and Farnham Royal",
+    "lat": 51.5489,
+    "lng": -0.6178,
+    "authorityId": 327,
+    "population": 6715
+  },
+  {
+    "slug": "flackwell-heath-and-wooburn-green",
+    "name": "Flackwell Heath and Wooburn Green",
+    "lat": 51.6029,
+    "lng": -0.7039,
+    "authorityId": 327,
+    "population": 12435
+  },
+  {
+    "slug": "gerrards-cross",
+    "name": "Gerrards Cross",
+    "lat": 51.5814,
+    "lng": -0.5562,
+    "authorityId": 327,
+    "population": 8115
+  },
+  {
+    "slug": "haddenham-buckinghamshire",
+    "name": "Haddenham (Buckinghamshire)",
+    "lat": 51.772,
+    "lng": -0.9278,
+    "authorityId": 327,
+    "population": 5605
+  },
+  {
+    "slug": "hazlemere",
+    "name": "Hazlemere",
+    "lat": 51.6519,
+    "lng": -0.7037,
+    "authorityId": 327,
+    "population": 20005
+  },
+  {
+    "slug": "high-wycombe",
+    "name": "High Wycombe",
+    "lat": 51.6295,
+    "lng": -0.7423,
+    "authorityId": 327,
+    "population": 83535
+  },
+  {
+    "slug": "iver-heath",
+    "name": "Iver Heath",
+    "lat": 51.5312,
+    "lng": -0.524,
+    "authorityId": 327,
+    "population": 5150
+  },
+  {
+    "slug": "little-chalfont",
+    "name": "Little Chalfont",
+    "lat": 51.664,
+    "lng": -0.5626,
+    "authorityId": 327,
+    "population": 6505
+  },
+  {
+    "slug": "marlow",
+    "name": "Marlow",
+    "lat": 51.5735,
+    "lng": -0.7738,
+    "authorityId": 327,
+    "population": 14645
+  },
+  {
+    "slug": "prestwood-and-great-missenden",
+    "name": "Prestwood and Great Missenden",
+    "lat": 51.6959,
+    "lng": -0.7332,
+    "authorityId": 327,
+    "population": 7595
+  },
+  {
+    "slug": "princes-risborough",
+    "name": "Princes Risborough",
+    "lat": 51.7221,
+    "lng": -0.8356,
+    "authorityId": 327,
+    "population": 7530
+  },
+  {
+    "slug": "wendover",
+    "name": "Wendover",
+    "lat": 51.7685,
+    "lng": -0.7386,
+    "authorityId": 327,
+    "population": 8730
+  },
+  {
+    "slug": "winslow",
+    "name": "Winslow",
+    "lat": 51.9449,
+    "lng": -0.8823,
+    "authorityId": 327,
+    "population": 5235
+  },
+  {
+    "slug": "ashley-heath",
+    "name": "Ashley Heath",
+    "lat": 50.8306,
+    "lng": -1.8311,
+    "authorityId": 332,
+    "population": 7150
+  },
+  {
+    "slug": "blandford-forum",
+    "name": "Blandford Forum",
+    "lat": 50.8606,
+    "lng": -2.1615,
+    "authorityId": 332,
+    "population": 11800
+  },
+  {
+    "slug": "bridport",
+    "name": "Bridport",
+    "lat": 50.7327,
+    "lng": -2.7577,
+    "authorityId": 332,
+    "population": 12295
+  },
+  {
+    "slug": "corfe-mullen",
+    "name": "Corfe Mullen",
+    "lat": 50.7639,
+    "lng": -2.0218,
+    "authorityId": 332,
+    "population": 10035
+  },
+  {
+    "slug": "dorchester-dorset",
+    "name": "Dorchester (Dorset)",
+    "lat": 50.7096,
+    "lng": -2.4439,
+    "authorityId": 332,
+    "population": 21360
+  },
+  {
+    "slug": "ferndown",
+    "name": "Ferndown",
+    "lat": 50.804,
+    "lng": -1.8994,
+    "authorityId": 332,
+    "population": 13265
+  },
+  {
+    "slug": "gillingham-dorset",
+    "name": "Gillingham (Dorset)",
+    "lat": 51.0383,
+    "lng": -2.278,
+    "authorityId": 332,
+    "population": 11010
+  },
+  {
+    "slug": "shaftesbury",
+    "name": "Shaftesbury",
+    "lat": 51.0077,
+    "lng": -2.1927,
+    "authorityId": 332,
+    "population": 9160
+  },
+  {
+    "slug": "sherborne",
+    "name": "Sherborne",
+    "lat": 50.9498,
+    "lng": -2.5194,
+    "authorityId": 332,
+    "population": 10360
+  },
+  {
+    "slug": "swanage",
+    "name": "Swanage",
+    "lat": 50.6135,
+    "lng": -1.9668,
+    "authorityId": 332,
+    "population": 9110
+  },
+  {
+    "slug": "upton-dorset",
+    "name": "Upton (Dorset)",
+    "lat": 50.7363,
+    "lng": -2.0275,
+    "authorityId": 332,
+    "population": 8400
+  },
+  {
+    "slug": "verwood",
+    "name": "Verwood",
+    "lat": 50.8784,
+    "lng": -1.8789,
+    "authorityId": 332,
+    "population": 13710
+  },
+  {
+    "slug": "wareham",
+    "name": "Wareham",
+    "lat": 50.6906,
+    "lng": -2.1134,
+    "authorityId": 332,
+    "population": 5880
+  },
+  {
+    "slug": "west-moors",
+    "name": "West Moors",
+    "lat": 50.8257,
+    "lng": -1.8819,
+    "authorityId": 332,
+    "population": 10425
+  },
+  {
+    "slug": "weston-dorset",
+    "name": "Weston (Dorset)",
+    "lat": 50.5436,
+    "lng": -2.4401,
+    "authorityId": 332,
+    "population": 5210
+  },
+  {
+    "slug": "weymouth",
+    "name": "Weymouth",
+    "lat": 50.6324,
+    "lng": -2.4572,
+    "authorityId": 332,
+    "population": 55535
+  },
+  {
+    "slug": "wimborne-minster",
+    "name": "Wimborne Minster",
+    "lat": 50.8044,
+    "lng": -1.9649,
+    "authorityId": 332,
+    "population": 16630
+  },
+  {
+    "slug": "wool",
+    "name": "Wool",
+    "lat": 50.6933,
+    "lng": -2.2419,
+    "authorityId": 332,
+    "population": 5040
+  },
+  {
+    "slug": "catterick-garrison",
+    "name": "Catterick Garrison",
+    "lat": 54.3722,
+    "lng": -1.7163,
+    "authorityId": 344,
+    "population": 14210
+  },
+  {
+    "slug": "easingwold",
+    "name": "Easingwold",
+    "lat": 54.122,
+    "lng": -1.1933,
+    "authorityId": 344,
+    "population": 5035
+  },
+  {
+    "slug": "filey",
+    "name": "Filey",
+    "lat": 54.2107,
+    "lng": -0.2944,
+    "authorityId": 344,
+    "population": 6665
+  },
+  {
+    "slug": "harrogate",
+    "name": "Harrogate",
+    "lat": 53.9908,
+    "lng": -1.5412,
+    "authorityId": 344,
+    "population": 75515
+  },
+  {
+    "slug": "knaresborough",
+    "name": "Knaresborough",
+    "lat": 54.0084,
+    "lng": -1.4661,
+    "authorityId": 344,
+    "population": 15785
+  },
+  {
+    "slug": "malton",
+    "name": "Malton",
+    "lat": 54.1382,
+    "lng": -0.7978,
+    "authorityId": 344,
+    "population": 6320
+  },
+  {
+    "slug": "northallerton",
+    "name": "Northallerton",
+    "lat": 54.3438,
+    "lng": -1.4335,
+    "authorityId": 344,
+    "population": 13310
+  },
+  {
+    "slug": "norton-on-derwent",
+    "name": "Norton-on-Derwent",
+    "lat": 54.1278,
+    "lng": -0.7861,
+    "authorityId": 344,
+    "population": 7905
+  },
+  {
+    "slug": "pickering",
+    "name": "Pickering",
+    "lat": 54.2448,
+    "lng": -0.7789,
+    "authorityId": 344,
+    "population": 7255
+  },
+  {
+    "slug": "richmond",
+    "name": "Richmond",
+    "lat": 54.4057,
+    "lng": -1.7398,
+    "authorityId": 344,
+    "population": 8075
+  },
+  {
+    "slug": "ripon",
+    "name": "Ripon",
+    "lat": 54.1414,
+    "lng": -1.5297,
+    "authorityId": 344,
+    "population": 16590
+  },
+  {
+    "slug": "scarborough",
+    "name": "Scarborough",
+    "lat": 54.2576,
+    "lng": -0.4045,
+    "authorityId": 344,
+    "population": 59505
+  },
+  {
+    "slug": "selby",
+    "name": "Selby",
+    "lat": 53.7809,
+    "lng": -1.0688,
+    "authorityId": 344,
+    "population": 19475
+  },
+  {
+    "slug": "sherburn-in-elmet",
+    "name": "Sherburn in Elmet",
+    "lat": 53.7891,
+    "lng": -1.2179,
+    "authorityId": 344,
+    "population": 8570
+  },
+  {
+    "slug": "skipton",
+    "name": "Skipton",
+    "lat": 53.9586,
+    "lng": -2.0174,
+    "authorityId": 344,
+    "population": 15050
+  },
+  {
+    "slug": "tadcaster",
+    "name": "Tadcaster",
+    "lat": 53.8807,
+    "lng": -1.2757,
+    "authorityId": 344,
+    "population": 6340
+  },
+  {
+    "slug": "thirsk",
+    "name": "Thirsk",
+    "lat": 54.232,
+    "lng": -1.3404,
+    "authorityId": 344,
+    "population": 5890
+  },
+  {
+    "slug": "whitby",
+    "name": "Whitby",
+    "lat": 54.4788,
+    "lng": -0.6212,
+    "authorityId": 344,
+    "population": 12595
+  },
+  {
+    "slug": "bridgwater",
+    "name": "Bridgwater",
+    "lat": 51.1244,
+    "lng": -3.0038,
+    "authorityId": 347,
+    "population": 47860
+  },
+  {
+    "slug": "burnham-on-sea",
+    "name": "Burnham-on-Sea",
+    "lat": 51.2414,
+    "lng": -2.9914,
+    "authorityId": 347,
+    "population": 16320
+  },
+  {
+    "slug": "chard",
+    "name": "Chard",
+    "lat": 50.8758,
+    "lng": -2.9597,
+    "authorityId": 347,
+    "population": 14290
+  },
+  {
+    "slug": "cheddar",
+    "name": "Cheddar",
+    "lat": 51.2784,
+    "lng": -2.7789,
+    "authorityId": 347,
+    "population": 5840
+  },
+  {
+    "slug": "crewkerne",
+    "name": "Crewkerne",
+    "lat": 50.883,
+    "lng": -2.7926,
+    "authorityId": 347,
+    "population": 7065
+  },
+  {
+    "slug": "frome",
+    "name": "Frome",
+    "lat": 51.2314,
+    "lng": -2.3198,
+    "authorityId": 347,
+    "population": 27905
+  },
+  {
+    "slug": "glastonbury",
+    "name": "Glastonbury",
+    "lat": 51.149,
+    "lng": -2.7107,
+    "authorityId": 347,
+    "population": 8300
+  },
+  {
+    "slug": "highbridge",
+    "name": "Highbridge",
+    "lat": 51.2209,
+    "lng": -2.972,
+    "authorityId": 347,
+    "population": 5365
+  },
+  {
+    "slug": "ilminster",
+    "name": "Ilminster",
+    "lat": 50.926,
+    "lng": -2.9114,
+    "authorityId": 347,
+    "population": 5965
+  },
+  {
+    "slug": "minehead",
+    "name": "Minehead",
+    "lat": 51.205,
+    "lng": -3.4797,
+    "authorityId": 347,
+    "population": 11750
+  },
+  {
+    "slug": "shepton-mallet",
+    "name": "Shepton Mallet",
+    "lat": 51.1888,
+    "lng": -2.5467,
+    "authorityId": 347,
+    "population": 9645
+  },
+  {
+    "slug": "somerton",
+    "name": "Somerton",
+    "lat": 51.0546,
+    "lng": -2.7398,
+    "authorityId": 347,
+    "population": 5100
+  },
+  {
+    "slug": "street",
+    "name": "Street",
+    "lat": 51.1235,
+    "lng": -2.7405,
+    "authorityId": 347,
+    "population": 12710
+  },
+  {
+    "slug": "taunton",
+    "name": "Taunton",
+    "lat": 51.0185,
+    "lng": -3.1022,
+    "authorityId": 347,
+    "population": 61665
+  },
+  {
+    "slug": "wellington-somerset-west-and-taunton",
+    "name": "Wellington (Somerset West and Taunton)",
+    "lat": 50.9793,
+    "lng": -3.2269,
+    "authorityId": 347,
+    "population": 13815
+  },
+  {
+    "slug": "wells",
+    "name": "Wells",
+    "lat": 51.2096,
+    "lng": -2.6536,
+    "authorityId": 347,
+    "population": 12105
+  },
+  {
+    "slug": "wincanton",
+    "name": "Wincanton",
+    "lat": 51.0541,
+    "lng": -2.4133,
+    "authorityId": 347,
+    "population": 6745
+  },
+  {
+    "slug": "yeovil",
+    "name": "Yeovil",
+    "lat": 50.9415,
+    "lng": -2.6513,
+    "authorityId": 347,
+    "population": 50170
+  },
+  {
+    "slug": "holyhead",
+    "name": "Holyhead",
+    "lat": 53.3092,
+    "lng": -4.629,
+    "authorityId": 398,
+    "population": 11755
+  },
+  {
+    "slug": "llangefni",
+    "name": "Llangefni",
+    "lat": 53.2548,
+    "lng": -4.3064,
+    "authorityId": 398,
+    "population": 5260
+  },
+  {
+    "slug": "bangor",
+    "name": "Bangor",
+    "lat": 53.2199,
+    "lng": -4.1402,
+    "authorityId": 399,
+    "population": 16990
+  },
+  {
+    "slug": "caernarfon",
+    "name": "Caernarfon",
+    "lat": 53.1432,
+    "lng": -4.2583,
+    "authorityId": 399,
+    "population": 9835
+  },
+  {
+    "slug": "abergele",
+    "name": "Abergele",
+    "lat": 53.2838,
+    "lng": -3.5861,
+    "authorityId": 400,
+    "population": 8535
+  },
+  {
+    "slug": "colwyn-bay",
+    "name": "Colwyn Bay",
+    "lat": 53.2967,
+    "lng": -3.7417,
+    "authorityId": 400,
+    "population": 29275
+  },
+  {
+    "slug": "conwy",
+    "name": "Conwy",
+    "lat": 53.2906,
+    "lng": -3.8239,
+    "authorityId": 400,
+    "population": 15715
+  },
+  {
+    "slug": "kinmel-bay",
+    "name": "Kinmel Bay",
+    "lat": 53.3029,
+    "lng": -3.5207,
+    "authorityId": 400,
+    "population": 9020
+  },
+  {
+    "slug": "llandudno",
+    "name": "Llandudno",
+    "lat": 53.32,
+    "lng": -3.8282,
+    "authorityId": 400,
+    "population": 14710
+  },
+  {
+    "slug": "denbigh",
+    "name": "Denbigh",
+    "lat": 53.1875,
+    "lng": -3.4126,
+    "authorityId": 401,
+    "population": 8075
+  },
+  {
+    "slug": "prestatyn",
+    "name": "Prestatyn",
+    "lat": 53.3318,
+    "lng": -3.4089,
+    "authorityId": 401,
+    "population": 16675
+  },
+  {
+    "slug": "rhyl",
+    "name": "Rhyl",
+    "lat": 53.3155,
+    "lng": -3.4759,
+    "authorityId": 401,
+    "population": 26990
+  },
+  {
+    "slug": "ruthin",
+    "name": "Ruthin",
+    "lat": 53.1153,
+    "lng": -3.318,
+    "authorityId": 401,
+    "population": 5700
+  },
+  {
+    "slug": "bagillt",
+    "name": "Bagillt",
+    "lat": 53.2874,
+    "lng": -3.2087,
+    "authorityId": 402,
+    "population": 5945
+  },
+  {
+    "slug": "broughton-flintshire",
+    "name": "Broughton (Flintshire)",
+    "lat": 53.1745,
+    "lng": -2.9798,
+    "authorityId": 402,
+    "population": 6530
+  },
+  {
+    "slug": "buckley",
+    "name": "Buckley",
+    "lat": 53.1701,
+    "lng": -3.0786,
+    "authorityId": 402,
+    "population": 13560
+  },
+  {
+    "slug": "connahs-quay",
+    "name": "Connah's Quay",
+    "lat": 53.2221,
+    "lng": -3.0633,
+    "authorityId": 402,
+    "population": 16770
+  },
+  {
+    "slug": "flint",
+    "name": "Flint",
+    "lat": 53.2454,
+    "lng": -3.1369,
+    "authorityId": 402,
+    "population": 12780
+  },
+  {
+    "slug": "hawarden",
+    "name": "Hawarden",
+    "lat": 53.1966,
+    "lng": -3.019,
+    "authorityId": 402,
+    "population": 14280
+  },
+  {
+    "slug": "holywell-flintshire",
+    "name": "Holywell (Flintshire)",
+    "lat": 53.2746,
+    "lng": -3.2196,
+    "authorityId": 402,
+    "population": 7735
+  },
+  {
+    "slug": "mold",
+    "name": "Mold",
+    "lat": 53.1659,
+    "lng": -3.1424,
+    "authorityId": 402,
+    "population": 9890
+  },
+  {
+    "slug": "shotton",
+    "name": "Shotton",
+    "lat": 53.2076,
+    "lng": -3.038,
+    "authorityId": 402,
+    "population": 6500
+  },
+  {
+    "slug": "acrefair-and-cefn-mawr",
+    "name": "Acrefair and Cefn-mawr",
+    "lat": 52.9769,
+    "lng": -3.0703,
+    "authorityId": 403,
+    "population": 6905
+  },
+  {
+    "slug": "brynteg-wrexham",
+    "name": "Brynteg (Wrexham)",
+    "lat": 53.0736,
+    "lng": -3.045,
+    "authorityId": 403,
+    "population": 9225
+  },
+  {
+    "slug": "gwersyllt",
+    "name": "Gwersyllt",
+    "lat": 53.071,
+    "lng": -3.0186,
+    "authorityId": 403,
+    "population": 7110
+  },
+  {
+    "slug": "rhosllannerchrugog",
+    "name": "Rhosllannerchrugog",
+    "lat": 53.0066,
+    "lng": -3.0527,
+    "authorityId": 403,
+    "population": 12785
+  },
+  {
+    "slug": "wrexham",
+    "name": "Wrexham",
+    "lat": 53.051,
+    "lng": -2.9846,
+    "authorityId": 403,
+    "population": 44785
+  },
+  {
+    "slug": "aberystwyth",
+    "name": "Aberystwyth",
+    "lat": 52.4109,
+    "lng": -4.0697,
+    "authorityId": 404,
+    "population": 14640
+  },
+  {
+    "slug": "haverfordwest",
+    "name": "Haverfordwest",
+    "lat": 51.8086,
+    "lng": -4.9717,
+    "authorityId": 405,
+    "population": 12085
+  },
+  {
+    "slug": "milford-haven",
+    "name": "Milford Haven",
+    "lat": 51.7078,
+    "lng": -5.0419,
+    "authorityId": 405,
+    "population": 14250
+  },
+  {
+    "slug": "pembroke",
+    "name": "Pembroke",
+    "lat": 51.6769,
+    "lng": -4.9211,
+    "authorityId": 405,
+    "population": 7965
+  },
+  {
+    "slug": "pembroke-dock",
+    "name": "Pembroke Dock",
+    "lat": 51.6907,
+    "lng": -4.9483,
+    "authorityId": 405,
+    "population": 9655
+  },
+  {
+    "slug": "ammanford",
+    "name": "Ammanford",
+    "lat": 51.7929,
+    "lng": -3.9847,
+    "authorityId": 406,
+    "population": 8285
+  },
+  {
+    "slug": "carmarthen",
+    "name": "Carmarthen",
+    "lat": 51.8564,
+    "lng": -4.3107,
+    "authorityId": 406,
+    "population": 16455
+  },
+  {
+    "slug": "cross-hands-and-pen-y-groes",
+    "name": "Cross Hands and Pen-y-groes",
+    "lat": 51.8006,
+    "lng": -4.0736,
+    "authorityId": 406,
+    "population": 6340
+  },
+  {
+    "slug": "llanelli",
+    "name": "Llanelli",
+    "lat": 51.6842,
+    "lng": -4.1432,
+    "authorityId": 406,
+    "population": 42155
+  },
+  {
+    "slug": "clydach-swansea",
+    "name": "Clydach (Swansea)",
+    "lat": 51.6997,
+    "lng": -3.8923,
+    "authorityId": 407,
+    "population": 8445
+  },
+  {
+    "slug": "gorseinon",
+    "name": "Gorseinon",
+    "lat": 51.6672,
+    "lng": -4.0423,
+    "authorityId": 407,
+    "population": 14110
+  },
+  {
+    "slug": "gowerton",
+    "name": "Gowerton",
+    "lat": 51.6435,
+    "lng": -4.0246,
+    "authorityId": 407,
+    "population": 7445
+  },
+  {
+    "slug": "pontarddulais",
+    "name": "Pontarddulais",
+    "lat": 51.7153,
+    "lng": -4.0348,
+    "authorityId": 407,
+    "population": 6515
+  },
+  {
+    "slug": "swansea",
+    "name": "Swansea",
+    "lat": 51.6441,
+    "lng": -3.93,
+    "authorityId": 407,
+    "population": 170085
+  },
+  {
+    "slug": "baglan",
+    "name": "Baglan",
+    "lat": 51.6309,
+    "lng": -3.8188,
+    "authorityId": 408,
+    "population": 10510
+  },
+  {
+    "slug": "neath",
+    "name": "Neath",
+    "lat": 51.6636,
+    "lng": -3.8133,
+    "authorityId": 408,
+    "population": 40730
+  },
+  {
+    "slug": "pontardawe",
+    "name": "Pontardawe",
+    "lat": 51.7272,
+    "lng": -3.8512,
+    "authorityId": 408,
+    "population": 5540
+  },
+  {
+    "slug": "port-talbot",
+    "name": "Port Talbot",
+    "lat": 51.5926,
+    "lng": -3.7899,
+    "authorityId": 408,
+    "population": 31555
+  },
+  {
+    "slug": "ystalyfera",
+    "name": "Ystalyfera",
+    "lat": 51.7684,
+    "lng": -3.7879,
+    "authorityId": 408,
+    "population": 7830
+  },
+  {
+    "slug": "bridgend",
+    "name": "Bridgend",
+    "lat": 51.5096,
+    "lng": -3.5656,
+    "authorityId": 409,
+    "population": 51760
+  },
+  {
+    "slug": "maesteg",
+    "name": "Maesteg",
+    "lat": 51.6104,
+    "lng": -3.6537,
+    "authorityId": 409,
+    "population": 18335
+  },
+  {
+    "slug": "pencoed",
+    "name": "Pencoed",
+    "lat": 51.5225,
+    "lng": -3.5018,
+    "authorityId": 409,
+    "population": 9115
+  },
+  {
+    "slug": "porthcawl",
+    "name": "Porthcawl",
+    "lat": 51.4853,
+    "lng": -3.6949,
+    "authorityId": 409,
+    "population": 15795
+  },
+  {
+    "slug": "pyle",
+    "name": "Pyle",
+    "lat": 51.5295,
+    "lng": -3.6833,
+    "authorityId": 409,
+    "population": 14075
+  },
+  {
+    "slug": "sarn",
+    "name": "Sarn",
+    "lat": 51.5444,
+    "lng": -3.5877,
+    "authorityId": 409,
+    "population": 11870
+  },
+  {
+    "slug": "barry-vale-of-glamorgan",
+    "name": "Barry (Vale of Glamorgan)",
+    "lat": 51.4085,
+    "lng": -3.2648,
+    "authorityId": 410,
+    "population": 56605
+  },
+  {
+    "slug": "dinas-powis",
+    "name": "Dinas Powis",
+    "lat": 51.434,
+    "lng": -3.2145,
+    "authorityId": 410,
+    "population": 7890
+  },
+  {
+    "slug": "llantwit-major",
+    "name": "Llantwit Major",
+    "lat": 51.4093,
+    "lng": -3.4823,
+    "authorityId": 410,
+    "population": 5345
+  },
+  {
+    "slug": "penarth",
+    "name": "Penarth",
+    "lat": 51.4427,
+    "lng": -3.1847,
+    "authorityId": 410,
+    "population": 28395
+  },
+  {
+    "slug": "rhoose",
+    "name": "Rhoose",
+    "lat": 51.3952,
+    "lng": -3.3496,
+    "authorityId": 410,
+    "population": 6780
+  },
+  {
+    "slug": "cardiff",
+    "name": "Cardiff",
+    "lat": 51.4998,
+    "lng": -3.1884,
+    "authorityId": 411,
+    "population": 348535
+  },
+  {
+    "slug": "abercynon",
+    "name": "Abercynon",
+    "lat": 51.6488,
+    "lng": -3.3302,
+    "authorityId": 412,
+    "population": 6375
+  },
+  {
+    "slug": "aberdare",
+    "name": "Aberdare",
+    "lat": 51.7093,
+    "lng": -3.4445,
+    "authorityId": 412,
+    "population": 37675
+  },
+  {
+    "slug": "beddau",
+    "name": "Beddau",
+    "lat": 51.5567,
+    "lng": -3.3534,
+    "authorityId": 412,
+    "population": 7350
+  },
+  {
+    "slug": "church-village",
+    "name": "Church Village",
+    "lat": 51.5638,
+    "lng": -3.3242,
+    "authorityId": 412,
+    "population": 14155
+  },
+  {
+    "slug": "llanharan-and-brynna",
+    "name": "Llanharan and Brynna",
+    "lat": 51.5359,
+    "lng": -3.4523,
+    "authorityId": 412,
+    "population": 8105
+  },
+  {
+    "slug": "mountain-ash",
+    "name": "Mountain Ash",
+    "lat": 51.6848,
+    "lng": -3.3892,
+    "authorityId": 412,
+    "population": 13000
+  },
+  {
+    "slug": "pontyclun",
+    "name": "Pontyclun",
+    "lat": 51.5252,
+    "lng": -3.3897,
+    "authorityId": 412,
+    "population": 5800
+  },
+  {
+    "slug": "pontypridd",
+    "name": "Pontypridd",
+    "lat": 51.6054,
+    "lng": -3.3334,
+    "authorityId": 412,
+    "population": 31900
+  },
+  {
+    "slug": "porth",
+    "name": "Porth",
+    "lat": 51.6126,
+    "lng": -3.4068,
+    "authorityId": 412,
+    "population": 13350
+  },
+  {
+    "slug": "rhondda",
+    "name": "Rhondda",
+    "lat": 51.643,
+    "lng": -3.4747,
+    "authorityId": 412,
+    "population": 13265
+  },
+  {
+    "slug": "tonypandy",
+    "name": "Tonypandy",
+    "lat": 51.6218,
+    "lng": -3.4553,
+    "authorityId": 412,
+    "population": 17210
+  },
+  {
+    "slug": "tonyrefail",
+    "name": "Tonyrefail",
+    "lat": 51.5796,
+    "lng": -3.4307,
+    "authorityId": 412,
+    "population": 11440
+  },
+  {
+    "slug": "treherbert",
+    "name": "Treherbert",
+    "lat": 51.6818,
+    "lng": -3.5491,
+    "authorityId": 412,
+    "population": 5425
+  },
+  {
+    "slug": "treorchy",
+    "name": "Treorchy",
+    "lat": 51.6586,
+    "lng": -3.5119,
+    "authorityId": 412,
+    "population": 7650
+  },
+  {
+    "slug": "abercarn",
+    "name": "Abercarn",
+    "lat": 51.6478,
+    "lng": -3.1306,
+    "authorityId": 413,
+    "population": 5125
+  },
+  {
+    "slug": "abertridwr-and-senghenydd",
+    "name": "Abertridwr and Senghenydd",
+    "lat": 51.5981,
+    "lng": -3.2717,
+    "authorityId": 413,
+    "population": 5640
+  },
+  {
+    "slug": "bargod",
+    "name": "Bargod",
+    "lat": 51.6886,
+    "lng": -3.236,
+    "authorityId": 413,
+    "population": 8035
+  },
+  {
+    "slug": "bedwas",
+    "name": "Bedwas",
+    "lat": 51.5917,
+    "lng": -3.1921,
+    "authorityId": 413,
+    "population": 6460
+  },
+  {
+    "slug": "blackwood",
+    "name": "Blackwood",
+    "lat": 51.6678,
+    "lng": -3.2001,
+    "authorityId": 413,
+    "population": 12620
+  },
+  {
+    "slug": "caerphilly",
+    "name": "Caerphilly",
+    "lat": 51.5774,
+    "lng": -3.2271,
+    "authorityId": 413,
+    "population": 33105
+  },
+  {
+    "slug": "newbridge",
+    "name": "Newbridge",
+    "lat": 51.6723,
+    "lng": -3.1429,
+    "authorityId": 413,
+    "population": 7585
+  },
+  {
+    "slug": "oakdale",
+    "name": "Oakdale",
+    "lat": 51.6806,
+    "lng": -3.1677,
+    "authorityId": 413,
+    "population": 6130
+  },
+  {
+    "slug": "pontllanfraith",
+    "name": "Pontllanfraith",
+    "lat": 51.6531,
+    "lng": -3.1935,
+    "authorityId": 413,
+    "population": 9360
+  },
+  {
+    "slug": "risca",
+    "name": "Risca",
+    "lat": 51.6182,
+    "lng": -3.1247,
+    "authorityId": 413,
+    "population": 15195
+  },
+  {
+    "slug": "ystrad-mynach",
+    "name": "Ystrad Mynach",
+    "lat": 51.6471,
+    "lng": -3.238,
+    "authorityId": 413,
+    "population": 11855
+  },
+  {
+    "slug": "abertillery",
+    "name": "Abertillery",
+    "lat": 51.7379,
+    "lng": -3.1369,
+    "authorityId": 414,
+    "population": 10245
+  },
+  {
+    "slug": "brynmawr",
+    "name": "Brynmawr",
+    "lat": 51.7995,
+    "lng": -3.173,
+    "authorityId": 414,
+    "population": 5250
+  },
+  {
+    "slug": "ebbw-vale",
+    "name": "Ebbw Vale",
+    "lat": 51.7932,
+    "lng": -3.2147,
+    "authorityId": 414,
+    "population": 19630
+  },
+  {
+    "slug": "tredegar",
+    "name": "Tredegar",
+    "lat": 51.7799,
+    "lng": -3.2455,
+    "authorityId": 414,
+    "population": 14530
+  },
+  {
+    "slug": "abersychan",
+    "name": "Abersychan",
+    "lat": 51.7329,
+    "lng": -3.0668,
+    "authorityId": 415,
+    "population": 7495
+  },
+  {
+    "slug": "blaenavon",
+    "name": "Blaenavon",
+    "lat": 51.7738,
+    "lng": -3.0844,
+    "authorityId": 415,
+    "population": 5640
+  },
+  {
+    "slug": "cwmbr-n",
+    "name": "Cwmbrân",
+    "lat": 51.6488,
+    "lng": -3.0286,
+    "authorityId": 415,
+    "population": 47090
+  },
+  {
+    "slug": "pontypool",
+    "name": "Pontypool",
+    "lat": 51.6912,
+    "lng": -3.0262,
+    "authorityId": 415,
+    "population": 29070
+  },
+  {
+    "slug": "abergavenny",
+    "name": "Abergavenny",
+    "lat": 51.8269,
+    "lng": -3.0199,
+    "authorityId": 416,
+    "population": 13695
+  },
+  {
+    "slug": "caldicot",
+    "name": "Caldicot",
+    "lat": 51.5925,
+    "lng": -2.752,
+    "authorityId": 416,
+    "population": 9815
+  },
+  {
+    "slug": "chepstow",
+    "name": "Chepstow",
+    "lat": 51.6391,
+    "lng": -2.6821,
+    "authorityId": 416,
+    "population": 11935
+  },
+  {
+    "slug": "monmouth",
+    "name": "Monmouth",
+    "lat": 51.8128,
+    "lng": -2.7171,
+    "authorityId": 416,
+    "population": 10325
+  },
+  {
+    "slug": "undy-and-magor",
+    "name": "Undy and Magor",
+    "lat": 51.5796,
+    "lng": -2.8197,
+    "authorityId": 416,
+    "population": 5740
+  },
+  {
+    "slug": "caerleon",
+    "name": "Caerleon",
+    "lat": 51.6152,
+    "lng": -2.9643,
+    "authorityId": 417,
+    "population": 7330
+  },
+  {
+    "slug": "newport-newport",
+    "name": "Newport (Newport)",
+    "lat": 51.5823,
+    "lng": -3.0025,
+    "authorityId": 417,
+    "population": 130890
+  },
+  {
+    "slug": "rogerstone",
+    "name": "Rogerstone",
+    "lat": 51.5936,
+    "lng": -3.0537,
+    "authorityId": 417,
+    "population": 7550
+  },
+  {
+    "slug": "brecon",
+    "name": "Brecon",
+    "lat": 51.9492,
+    "lng": -3.3895,
+    "authorityId": 418,
+    "population": 8255
+  },
+  {
+    "slug": "llandrindod-wells",
+    "name": "Llandrindod Wells",
+    "lat": 52.2433,
+    "lng": -3.3747,
+    "authorityId": 418,
+    "population": 5430
+  },
+  {
+    "slug": "newtown-powys",
+    "name": "Newtown (Powys)",
+    "lat": 52.5085,
+    "lng": -3.3209,
+    "authorityId": 418,
+    "population": 10885
+  },
+  {
+    "slug": "welshpool",
+    "name": "Welshpool",
+    "lat": 52.6613,
+    "lng": -3.1444,
+    "authorityId": 418,
+    "population": 5455
+  },
+  {
+    "slug": "merthyr-tydfil",
+    "name": "Merthyr Tydfil",
+    "lat": 51.7536,
+    "lng": -3.3792,
+    "authorityId": 419,
+    "population": 39535
+  },
+  {
+    "slug": "treharris",
+    "name": "Treharris",
+    "lat": 51.6623,
+    "lng": -3.3087,
+    "authorityId": 419,
+    "population": 5045
+  },
+  {
+    "slug": "brandon-west-suffolk",
+    "name": "Brandon (West Suffolk)",
+    "lat": 52.448,
+    "lng": 0.6228,
+    "authorityId": 497,
+    "population": 9225
+  },
+  {
+    "slug": "bury-st-edmunds",
+    "name": "Bury St Edmunds",
+    "lat": 52.2467,
+    "lng": 0.711,
+    "authorityId": 497,
+    "population": 41280
+  },
+  {
+    "slug": "haverhill",
+    "name": "Haverhill",
+    "lat": 52.0831,
+    "lng": 0.444,
+    "authorityId": 497,
+    "population": 26705
+  },
+  {
+    "slug": "mildenhall-west-suffolk",
+    "name": "Mildenhall (West Suffolk)",
+    "lat": 52.3481,
+    "lng": 0.5062,
+    "authorityId": 497,
+    "population": 9685
+  },
+  {
+    "slug": "newmarket",
+    "name": "Newmarket",
+    "lat": 52.2482,
+    "lng": 0.4076,
+    "authorityId": 497,
+    "population": 18855
+  },
+  {
+    "slug": "red-lodge",
+    "name": "Red Lodge",
+    "lat": 52.3032,
+    "lng": 0.4911,
+    "authorityId": 497,
+    "population": 5775
+  },
+  {
+    "slug": "beccles",
+    "name": "Beccles",
+    "lat": 52.4506,
+    "lng": 1.5676,
+    "authorityId": 509,
+    "population": 9810
+  },
+  {
+    "slug": "bungay",
+    "name": "Bungay",
+    "lat": 52.4507,
+    "lng": 1.4411,
+    "authorityId": 509,
+    "population": 5010
+  },
+  {
+    "slug": "felixstowe",
+    "name": "Felixstowe",
+    "lat": 51.9601,
+    "lng": 1.3236,
+    "authorityId": 509,
+    "population": 24220
+  },
+  {
+    "slug": "kesgrave",
+    "name": "Kesgrave",
+    "lat": 52.0624,
+    "lng": 1.2365,
+    "authorityId": 509,
+    "population": 14950
+  },
+  {
+    "slug": "leiston",
+    "name": "Leiston",
+    "lat": 52.2063,
+    "lng": 1.5773,
+    "authorityId": 509,
+    "population": 5920
+  },
+  {
+    "slug": "lowestoft",
+    "name": "Lowestoft",
+    "lat": 52.4724,
+    "lng": 1.7214,
+    "authorityId": 509,
+    "population": 71315
+  },
+  {
+    "slug": "woodbridge",
+    "name": "Woodbridge",
+    "lat": 52.0941,
+    "lng": 1.308,
+    "authorityId": 509,
+    "population": 10145
+  },
+  {
+    "slug": "burton-latimer",
+    "name": "Burton Latimer",
+    "lat": 52.3646,
+    "lng": -0.6821,
+    "authorityId": 518,
+    "population": 10445
+  },
+  {
+    "slug": "corby",
+    "name": "Corby",
+    "lat": 52.4912,
+    "lng": -0.6911,
+    "authorityId": 518,
+    "population": 68160
+  },
+  {
+    "slug": "desborough",
+    "name": "Desborough",
+    "lat": 52.4436,
+    "lng": -0.823,
+    "authorityId": 518,
+    "population": 11900
+  },
+  {
+    "slug": "earls-barton",
+    "name": "Earls Barton",
+    "lat": 52.2665,
+    "lng": -0.7492,
+    "authorityId": 518,
+    "population": 6065
+  },
+  {
+    "slug": "higham-ferrers",
+    "name": "Higham Ferrers",
+    "lat": 52.3094,
+    "lng": -0.593,
+    "authorityId": 518,
+    "population": 8825
+  },
+  {
+    "slug": "irthlingborough",
+    "name": "Irthlingborough",
+    "lat": 52.3279,
+    "lng": -0.6125,
+    "authorityId": 518,
+    "population": 9310
+  },
+  {
+    "slug": "kettering",
+    "name": "Kettering",
+    "lat": 52.3983,
+    "lng": -0.7239,
+    "authorityId": 518,
+    "population": 63150
+  },
+  {
+    "slug": "oundle",
+    "name": "Oundle",
+    "lat": 52.4861,
+    "lng": -0.475,
+    "authorityId": 518,
+    "population": 6255
+  },
+  {
+    "slug": "raunds",
+    "name": "Raunds",
+    "lat": 52.3444,
+    "lng": -0.5427,
+    "authorityId": 518,
+    "population": 10230
+  },
+  {
+    "slug": "rothwell-north-northamptonshire",
+    "name": "Rothwell (North Northamptonshire)",
+    "lat": 52.4223,
+    "lng": -0.8089,
+    "authorityId": 518,
+    "population": 8620
+  },
+  {
+    "slug": "rushden",
+    "name": "Rushden",
+    "lat": 52.2893,
+    "lng": -0.5971,
+    "authorityId": 518,
+    "population": 31685
+  },
+  {
+    "slug": "thrapston",
+    "name": "Thrapston",
+    "lat": 52.3966,
+    "lng": -0.5276,
+    "authorityId": 518,
+    "population": 7245
+  },
+  {
+    "slug": "wellingborough",
+    "name": "Wellingborough",
+    "lat": 52.3051,
+    "lng": -0.7014,
+    "authorityId": 518,
+    "population": 54425
+  },
+  {
+    "slug": "brackley",
+    "name": "Brackley",
+    "lat": 52.0323,
+    "lng": -1.1485,
+    "authorityId": 519,
+    "population": 16190
+  },
+  {
+    "slug": "brixworth",
+    "name": "Brixworth",
+    "lat": 52.3257,
+    "lng": -0.9043,
+    "authorityId": 519,
+    "population": 5770
+  },
+  {
+    "slug": "daventry",
+    "name": "Daventry",
+    "lat": 52.263,
+    "lng": -1.1674,
+    "authorityId": 519,
+    "population": 27790
+  },
+  {
+    "slug": "northampton",
+    "name": "Northampton",
+    "lat": 52.2381,
+    "lng": -0.8952,
+    "authorityId": 519,
+    "population": 243520
+  },
+  {
+    "slug": "towcester",
+    "name": "Towcester",
+    "lat": 52.1286,
+    "lng": -0.9867,
+    "authorityId": 519,
+    "population": 11330
+  },
+  {
+    "slug": "carlisle",
+    "name": "Carlisle",
+    "lat": 54.8925,
+    "lng": -2.9435,
+    "authorityId": 522,
+    "population": 77730
+  },
+  {
+    "slug": "cleator-moor",
+    "name": "Cleator Moor",
+    "lat": 54.5195,
+    "lng": -3.5191,
+    "authorityId": 522,
+    "population": 6670
+  },
+  {
+    "slug": "cockermouth",
+    "name": "Cockermouth",
+    "lat": 54.6617,
+    "lng": -3.3588,
+    "authorityId": 522,
+    "population": 8860
+  },
+  {
+    "slug": "egremont",
+    "name": "Egremont",
+    "lat": 54.4823,
+    "lng": -3.5315,
+    "authorityId": 522,
+    "population": 5795
+  },
+  {
+    "slug": "maryport",
+    "name": "Maryport",
+    "lat": 54.7127,
+    "lng": -3.491,
+    "authorityId": 522,
+    "population": 8525
+  },
+  {
+    "slug": "millom",
+    "name": "Millom",
+    "lat": 54.2104,
+    "lng": -3.2684,
+    "authorityId": 522,
+    "population": 5690
+  },
+  {
+    "slug": "seaton-allerdale",
+    "name": "Seaton (Allerdale)",
+    "lat": 54.6605,
+    "lng": -3.5264,
+    "authorityId": 522,
+    "population": 5050
+  },
+  {
+    "slug": "whitehaven",
+    "name": "Whitehaven",
+    "lat": 54.5395,
+    "lng": -3.5757,
+    "authorityId": 522,
+    "population": 22945
+  },
+  {
+    "slug": "wigton",
+    "name": "Wigton",
+    "lat": 54.8241,
+    "lng": -3.1591,
+    "authorityId": 522,
+    "population": 5395
+  },
+  {
+    "slug": "workington",
+    "name": "Workington",
+    "lat": 54.6396,
+    "lng": -3.5525,
+    "authorityId": 522,
+    "population": 21275
+  },
+  {
+    "slug": "barrow-in-furness",
+    "name": "Barrow-in-Furness",
+    "lat": 54.1166,
+    "lng": -3.225,
+    "authorityId": 523,
+    "population": 55255
+  },
+  {
+    "slug": "dalton-in-furness",
+    "name": "Dalton-in-Furness",
+    "lat": 54.1556,
+    "lng": -3.18,
+    "authorityId": 523,
+    "population": 7555
+  },
+  {
+    "slug": "kendal",
+    "name": "Kendal",
+    "lat": 54.327,
+    "lng": -2.7414,
+    "authorityId": 523,
+    "population": 28940
+  },
+  {
+    "slug": "penrith",
+    "name": "Penrith",
+    "lat": 54.665,
+    "lng": -2.7539,
+    "authorityId": 523,
+    "population": 16700
+  },
+  {
+    "slug": "ulverston",
+    "name": "Ulverston",
+    "lat": 54.1905,
+    "lng": -3.0881,
+    "authorityId": 523,
+    "population": 11220
+  }
 ]


### PR DESCRIPTION
## What

Regenerates `web/src/data/towns.json` from authoritative ONS sources, replacing the 12-town tracer with **1,395 Built-Up Areas (BUAs) ≥5,000** across **England (excluding London) and Wales**. This is the data half of `tc-2avw.5` (the generator code merged in #591).

Every row: `{ slug, name, lat, lng, authorityId, population }`. **0 BUAs skipped** — all 1,395 joined and resolved; every row has a finite numeric population and a valid `authorityId`.

## Provenance (sources fetched 2026-06-21)

| Field | Source | Endpoint / file | Mapped fields |
|---|---|---|---|
| Population + name | ONS Census 2021 "Towns and cities, characteristics of built-up areas, England and Wales" (released 2 Aug 2023) | [xlsx](https://www.ons.gov.uk/file?uri=/peoplepopulationandcommunity/housing/datasets/townsandcitiescharacteristicsofbuiltupareasenglandandwalescensus2021/2021/townsandcitiescharacteristicsofbuiltupareasenglandandwalescensus2021.xlsx) — **Table 1c** (England ex-London) + **Table 1d** (Wales) | `BUA code`→`bua_code`, `BUA name`→`bua_name`, `Counts`→`population` |
| Centroids (WGS84) | ONS Open Geography "Built Up Areas (2022) GB BGG" | `services1.arcgis.com/ESMARspQHYMw9BZ9/.../BUA_2022_GB/FeatureServer/0` | `BUA22CD`, `BUA22NM`, `LAT`→`latitude`, `LONG`→`longitude`, `BNG_E`/`BNG_N` fallback |
| BUA → LAD | ONS "Built Up Area to Local Authority District (December 2022) Lookup in GB" | `services1.arcgis.com/ESMARspQHYMw9BZ9/.../Built_Up_Area_to_Local_Authority_District_(December_2022)_Lookup_in_Great_Britain/FeatureServer/0` | `LAD22NM`→`lad_name` |
| Multi-LAD split resolution | ONS "Local Authority Districts (December 2022) UK BFC V2" boundaries | `services1.arcgis.com/ESMARspQHYMw9BZ9/.../Local_Authority_Districts_December_2022_UK_BFC_V2/FeatureServer/0` | point-in-polygon of the BUA centroid |

All three primary sources key on **`BUA22CD`** (the join key the generator expects).

## How the join was built

1. Parsed Census Tables 1c + 1d → 6,975 individual BUAs; kept the **1,395 with population ≥5,000**.
2. Pulled WGS84 centroids for every E&W BUA from `BUA_2022_GB` (used `LAT`/`LONG` directly; every ≥5k BUA had a centroid).
3. Resolved one LAD per BUA from the BUA→LAD lookup:
   - **902** BUAs map to a single LAD ("Whole") → used directly.
   - **493** BUAs span multiple LADs ("Part") → resolved by **point-in-polygon** of the genuine ONS centroid against the Dec-2022 LAD boundaries. All 493 landed inside one of their candidate LADs (0 fallbacks).
4. Mapped **17 abolished districts** to their **1 April 2023 LGR successor unitaries** so `lad_name` matches `authority-mapping.json`: Cumbria's Allerdale/Carlisle/Copeland → **Cumberland**, Barrow-in-Furness/Eden/South Lakeland → **Westmorland and Furness**; North Yorkshire's Craven/Hambleton/Harrogate/Richmondshire/Ryedale/Scarborough/Selby → **North Yorkshire**; Somerset's Mendip/Sedgemoor/Somerset West and Taunton/South Somerset → **Somerset**.

## How London was excluded

By construction: the Census 1c/1d population tables are **"England (excluding London)"** + Wales — London BUAs are simply not in the population source, so no row is emitted for them. London is `tc-2avw.7`.

## Generator parser fix (same bead)

`parseCsvRows` split on **every** comma, so the 12 BUAs whose official name or LAD name contains a comma were **silently dropped** — losing **Bristol** (425k), **Kingston upon Hull** (271k), **Bournemouth** (196k) and **Poole** (141k), plus Hereford/Christchurch/Leominster/Ledbury/Merley/Ross-on-Wye and two "X, Y and Z" BUAs. The dropped rows weren't even logged as skips (the comma shifted `population` out of its column → row parsed as `null`). Replaced with an RFC-4180 quote-aware `parseCsvLine` (honours quoted fields + doubled-quote escapes, which the generator's own comment already assumed) and added 5 regression tests.

## Counts

- Total emitted: **1,395** towns (0 skipped)
- Threshold breakdown: ≥5k=**1,395**, ≥10k=858, ≥20k=**474**, ≥30k=309, ≥50k=177, ≥100k=69
- Top 5 by population: Birmingham (1,121,375), Leeds (536,280), Liverpool (506,565), Sheffield (500,535), Manchester (470,405)
- Spot-checks vs published ONS Census 2021 BUA figures: Truro 23,060 · Newquay 24,545 · Cambridge ("Cambridge (Cambridge)") 152,740 · Bristol 425,215 · Hull 270,810 (all coordinates land inside the UK box). Note: the BUA-2022 boundaries are larger than the older built-up-area definitions, so Truro/Newquay read higher than the brief's ~18–19k/~20k hints — these are the genuine current ONS figures.

## Verification

- `npx vitest run` — **839 passed** (102 files), including the 5 new comma-handling tests
- `npm run build` — passes (loads + validates the new towns.json; prerender correctly skips without SITE_BUILD_KEY)
- `tsc --noEmit` clean, `eslint` clean

Raw ONS downloads (28 MB xlsx, intermediate CSVs) were kept **out of git** — only `towns.json` + the parser fix + its tests are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xL4oCpLWWGhqV6fmsfEXy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved CSV data parsing to correctly handle location names containing commas, ensuring geographic records with commas in their official names are now properly processed and matched.

* **Tests**
  * Added test coverage for RFC-4180–compliant CSV parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->