### PR TITLE
feat(web): add 33 London BUAs to the town gazetteer (tc-2avw.7)

### DIFF
--- a/web/scripts/generate-towns.mjs
+++ b/web/scripts/generate-towns.mjs
@@ -16,9 +16,9 @@
  * >= 20k selection later. Lowering the published threshold never needs a regen.
  *
  * Scope for THIS generator: England-ex-London + Wales (ONS Census 2021 BUA
- * file). London BUAs (tc-2avw.7) and Scotland settlements (tc-2avw.8) are
- * separate sources composed on top — see the EXTENSION SEAMS note at the foot
- * of this file. They are deliberately NOT implemented here.
+ * file) PLUS London (tc-2avw.7), composed on top via a second population CSV.
+ * Scotland settlements (tc-2avw.8) remain a separate source not yet wired —
+ * see the EXTENSION SEAMS note at the foot of this file.
  *
  * ── Data sources (TWO files, joined on BUA code) ────────────────────────────
  *
@@ -74,18 +74,36 @@
  * source genuinely lacks codes, fall back to an exact name match and justify it
  * at the call site — do NOT silently fuzzy-match.
  *
+ * ── London population (tc-2avw.7) ───────────────────────────────────────────
+ * The Census 2021 BUA workbook (above) explicitly EXCLUDES London: in Greater
+ * London the BUA method follows borough boundaries rather than recognising
+ * individual settlements, so ONS removed the ~33 borough-shaped London BUAs
+ * from Tables 1c/1d. London therefore needs a SEPARATE population CSV, in the
+ * same `bua_code,bua_name,lad_name,population` contract, built from genuine ONS
+ * sources:
+ *   - usual residents per London BUA = SUM of Census 2021 TS001 OA usual
+ *     residents over the OAs the ONS OA21->BUA22->LAD22 lookup assigns to that
+ *     BUA (both sources cover London; sum on BUA22CD).
+ *   - lad_name = the London borough holding the plurality of the BUA's OA
+ *     population (>=98.9% for every one — the BUAs are borough-shaped), which
+ *     resolves the multi-LAD "Part" rows the BUA->LAD lookup carries.
+ * The centroid CSV is GB-wide (BUA_2022_GB already includes London), so the
+ * SAME centroid file feeds both the E&W and the London buildGazetteer calls.
+ *
  * ── How to regenerate (manual) ──────────────────────────────────────────────
  *   1. Download the two ONS files above and produce two CSVs that match the
  *      column contracts (you may need to rename/reorder columns; a spatial
- *      pre-join supplies lad_name if the Census export lacks it).
+ *      pre-join supplies lad_name if the Census export lacks it). Build the
+ *      separate London population CSV per the "London population" note above.
  *   2. Run:
- *        node scripts/generate-towns.mjs <population.csv> <centroid.csv>
- *      It parses both, joins on bua_code, drops BUAs < 5,000, resolves
- *      lad_name -> authorityId against authority-mapping.json, skips+logs any
- *      BUA with no centroid or no resolvable authority, de-duplicates by
- *      authorityId/slug, sorts, and overwrites web/src/data/towns.json.
- *   3. (When tc-2avw.7 / tc-2avw.8 land) append the London and Scotland record
- *      sets before writing — see EXTENSION SEAMS.
+ *        node scripts/generate-towns.mjs <ew-population.csv> <centroid.csv> [<london-population.csv>]
+ *      It parses each population CSV, joins on bua_code against the shared
+ *      centroid CSV, drops BUAs < 5,000, resolves lad_name -> authorityId
+ *      against authority-mapping.json, skips+logs any BUA with no centroid or
+ *      no resolvable authority, then de-duplicates the COMBINED E&W+London set
+ *      by authorityId/slug, sorts, and overwrites web/src/data/towns.json.
+ *   3. (When tc-2avw.8 lands) append the Scotland record set before writing —
+ *      see EXTENSION SEAMS.
  *   4. Review the diff, run `npx vitest run`, and commit.
  *
  * ── Coordinate conversion (fallback) ────────────────────────────────────────
@@ -290,6 +308,28 @@ export function joinBua(populations, centroids, mapping) {
   );
 
   return { records, skipped };
+}
+
+/**
+ * De-duplicate and stable-sort a COMBINED set of gazetteer records drawn from
+ * more than one region (E&W + London, later + Scotland). Each region's
+ * `buildGazetteer` already dedupes+sorts within itself, but concatenating two
+ * sets can reintroduce an `authorityId/slug` collision across regions, so the
+ * combine step re-applies the same last-wins dedupe and the same
+ * authorityId-then-slug stable sort `joinBua` uses. Identical key/sort keeps
+ * the committed diff stable regardless of the order regions are passed in.
+ *
+ * @param {Array<{ slug: string, name: string, lat: number, lng: number, authorityId: number, population: number }>} records
+ * @returns {Array<{ slug: string, name: string, lat: number, lng: number, authorityId: number, population: number }>}
+ */
+export function combineRecords(records) {
+  const byKey = new Map();
+  for (const r of records) {
+    byKey.set(`${r.authorityId}/${r.slug}`, r);
+  }
+  return [...byKey.values()].sort(
+    (x, y) => x.authorityId - y.authorityId || x.slug.localeCompare(y.slug),
+  );
 }
 
 /**
@@ -535,16 +575,20 @@ function round4(v) {
 }
 
 /**
- * CLI entry: read the two ONS CSVs, build the gazetteer, write towns.json.
+ * CLI entry: read the ONS CSVs, build the gazetteer (E&W + optional London),
+ * write towns.json.
  *
- * @param {string} populationFile path to the POPULATION CSV
- * @param {string} centroidFile   path to the CENTROID CSV
+ * @param {string} populationFile      path to the E&W POPULATION CSV
+ * @param {string} centroidFile        path to the GB-wide CENTROID CSV
+ * @param {string} [londonPopulationFile] optional path to the London POPULATION
+ *   CSV (same `bua_code,bua_name,lad_name,population` contract). When supplied,
+ *   its records are composed on top of E&W against the SAME centroid CSV.
  * @returns {Promise<void>}
  */
-async function main(populationFile, centroidFile) {
+async function main(populationFile, centroidFile, londonPopulationFile) {
   if (!populationFile || !centroidFile) {
     console.error(
-      'usage: node scripts/generate-towns.mjs <population.csv> <centroid.csv>\n' +
+      'usage: node scripts/generate-towns.mjs <ew-population.csv> <centroid.csv> [<london-population.csv>]\n' +
         'See the script header for the full CSV contracts and regeneration steps.',
     );
     process.exitCode = 1;
@@ -552,20 +596,34 @@ async function main(populationFile, centroidFile) {
   }
 
   const mapping = JSON.parse(await readFile(AUTHORITY_MAPPING_FILE, 'utf-8'));
-  const populationCsv = await readFile(populationFile, 'utf-8');
   const centroidCsv = await readFile(centroidFile, 'utf-8');
 
+  // England-excluding-London + Wales (ONS Census 2021 Tables 1c + 1d).
+  const ewPopulationCsv = await readFile(populationFile, 'utf-8');
+  const ew = buildGazetteer(ewPopulationCsv, centroidCsv, mapping);
+
   // EXTENSION SEAMS — compose other regions here before writing:
-  //   * London BUAs (tc-2avw.7): BUA-2022 geometry + a London BUA population
-  //     table. Produce records via buildGazetteer(londonPopCsv, centroidCsv,
-  //     mapping) and concat. London LADs are already in authority-mapping.json.
+  //   * London BUAs (tc-2avw.7): the Census 1c/1d tables EXCLUDE London, so
+  //     London arrives as its own population CSV (see the "London population"
+  //     header note) joined against the same GB centroid CSV. London borough
+  //     LADs are already in authority-mapping.json.
   //   * Scotland settlements (tc-2avw.8): NRS settlement population + NRS
   //     settlement centroids. Different source schema — add a parseNrsRow /
   //     buildScotland helper and concat its records here.
   // Each region must keep emitting { slug, name, lat, lng, authorityId,
   // population } and resolve LAD->authorityId against the same mapping. Skipped
   // BUAs stay skipped+logged, never guessed.
-  const { records, skipped } = buildGazetteer(populationCsv, centroidCsv, mapping);
+  const regions = [ew];
+  if (londonPopulationFile) {
+    const londonPopulationCsv = await readFile(londonPopulationFile, 'utf-8');
+    regions.push(buildGazetteer(londonPopulationCsv, centroidCsv, mapping));
+  }
+
+  // Combine across regions: concat, then re-apply the dedupe-by-authorityId/slug
+  // + stable sort across the whole set (an authorityId/slug can only collide
+  // within a region in practice, but combineRecords keeps the invariant honest).
+  const records = combineRecords(regions.flatMap((r) => r.records));
+  const skipped = regions.flatMap((r) => r.skipped);
 
   await writeFile(TOWNS_OUT, JSON.stringify(records, null, 2) + '\n', 'utf-8');
 
@@ -574,7 +632,10 @@ async function main(populationFile, centroidFile) {
     return acc;
   }, /** @type {Record<string, number>} */ ({}));
   console.log(
-    `[generate-towns] wrote ${records.length} town(s) to ${TOWNS_OUT}`,
+    `[generate-towns] wrote ${records.length} town(s) to ${TOWNS_OUT}` +
+      ` (E&W ${ew.records.length}` +
+      (londonPopulationFile ? `, London ${regions[1].records.length}` : '') +
+      ')',
   );
   console.log(
     `[generate-towns] skipped ${skipped.length} BUA(s): ` +
@@ -590,5 +651,5 @@ async function main(populationFile, centroidFile) {
 
 // Run main() only when invoked directly, not when imported by tests.
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  await main(process.argv[2], process.argv[3]);
+  await main(process.argv[2], process.argv[3], process.argv[4]);
 }

--- a/web/scripts/lib/__tests__/generate-towns.test.mjs
+++ b/web/scripts/lib/__tests__/generate-towns.test.mjs
@@ -11,6 +11,7 @@ import {
   parseCentroidRow,
   joinBua,
   buildGazetteer,
+  combineRecords,
   POPULATION_COLUMNS,
   CENTROID_COLUMNS,
 } from '../../generate-towns.mjs';
@@ -421,5 +422,134 @@ describe('buildGazetteer over the on-disk fixture CSVs (documented contract)', (
     expect(byCode['E63004000']).toBe('below-floor');
     expect(byCode['E63007777']).toBe('unmatched-authority');
     expect(byCode['E63009999']).toBe('no-centroid');
+  });
+});
+
+describe('London composition (tc-2avw.7)', () => {
+  // London arrives as a SEPARATE population CSV (the Census 1c/1d tables exclude
+  // London) joined against the SAME GB centroid CSV. These tests prove a
+  // London-borough BUA row flows through buildGazetteer to a record with the
+  // right authorityId + population, and an unmatched one skips — using the real
+  // London-borough spellings/ids from authority-mapping.json.
+  const mapping = { Camden: 300, 'City of London': 471, Westminster: 326 };
+
+  // A GB centroid CSV carries E&W *and* London BUAs (BUA_2022_GB is GB-wide).
+  const centroidCsv = [
+    'bua_code,bua_name,latitude,longitude,bng_easting,bng_northing',
+    'E63004858,Camden,51.5488,-0.1621,529000,183000',
+    'E63004906,City and County of the City of London,51.5154,-0.0899,532500,181200',
+    'E63004916,City of Westminster,51.5127,-0.1571,529300,180600',
+    // Hackney has a centroid in the shared GB file, so a missing authority
+    // mapping skips it as 'unmatched-authority' (not 'no-centroid').
+    'E63004850,Hackney,51.5513,-0.0656,534000,185000',
+    // An E&W centroid present in the same shared file, to prove the join keys on code.
+    'E63001234,Truro,50.2632,-5.0510,182500,44900',
+  ].join('\n');
+
+  it('flows a London-borough BUA to a record with the right authorityId and population', () => {
+    const londonPopCsv = [
+      'bua_code,bua_name,lad_name,population',
+      'E63004858,Camden,Camden,209342',
+    ].join('\n');
+
+    const { records, skipped } = buildGazetteer(londonPopCsv, centroidCsv, mapping);
+
+    expect(skipped).toEqual([]);
+    expect(records).toEqual([
+      {
+        slug: 'camden',
+        name: 'Camden',
+        lat: 51.5488,
+        lng: -0.1621,
+        authorityId: 300,
+        population: 209342,
+      },
+    ]);
+  });
+
+  it('keeps the ONS parenthetical/administrative BUA name verbatim (City of London)', () => {
+    const londonPopCsv = [
+      'bua_code,bua_name,lad_name,population',
+      'E63004906,City and County of the City of London,City of London,7820',
+    ].join('\n');
+
+    const { records } = buildGazetteer(londonPopCsv, centroidCsv, mapping);
+
+    expect(records).toHaveLength(1);
+    expect(records[0].name).toBe('City and County of the City of London');
+    expect(records[0].slug).toBe('city-and-county-of-the-city-of-london');
+    expect(records[0].authorityId).toBe(471);
+  });
+
+  it('skips and logs a London BUA whose borough is not in the mapping (never guessed)', () => {
+    const londonPopCsv = [
+      'bua_code,bua_name,lad_name,population',
+      'E63004858,Camden,Camden,209342',
+      // Hackney is a real London borough but absent from this test mapping.
+      'E63004850,Hackney,Hackney,258464',
+    ].join('\n');
+
+    const { records, skipped } = buildGazetteer(londonPopCsv, centroidCsv, mapping);
+
+    expect(records.map((r) => r.slug)).toEqual(['camden']);
+    expect(skipped).toEqual([
+      { code: 'E63004850', name: 'Hackney', reason: 'unmatched-authority' },
+    ]);
+  });
+});
+
+describe('combineRecords (cross-region dedupe + stable sort)', () => {
+  // The composed E&W + London set is concatenated then deduped+sorted by
+  // authorityId-then-slug. This mirrors the joinBua tail so the committed diff
+  // stays stable regardless of region order.
+  const ew = [
+    { slug: 'truro', name: 'Truro', lat: 50.2632, lng: -5.051, authorityId: 52, population: 18766 },
+  ];
+  const london = [
+    {
+      slug: 'camden',
+      name: 'Camden',
+      lat: 51.5488,
+      lng: -0.1621,
+      authorityId: 300,
+      population: 209342,
+    },
+    {
+      slug: 'barnet',
+      name: 'Barnet',
+      lat: 51.6152,
+      lng: -0.2091,
+      authorityId: 296,
+      population: 388572,
+    },
+  ];
+
+  it('orders the combined set by authorityId then slug regardless of input order', () => {
+    const combined = combineRecords([...london, ...ew]);
+    expect(combined.map((r) => `${r.authorityId}/${r.slug}`)).toEqual([
+      '52/truro',
+      '296/barnet',
+      '300/camden',
+    ]);
+  });
+
+  it('keeps every region record and adds nothing when keys do not collide', () => {
+    const combined = combineRecords([...ew, ...london]);
+    expect(combined).toHaveLength(ew.length + london.length);
+  });
+
+  it('de-duplicates an authorityId/slug collision across regions, keeping the last', () => {
+    const duplicateOfTruro = {
+      slug: 'truro',
+      name: 'Truro',
+      lat: 99,
+      lng: 99,
+      authorityId: 52,
+      population: 1,
+    };
+    const combined = combineRecords([...ew, duplicateOfTruro]);
+    expect(combined).toHaveLength(1);
+    // Last write wins, matching joinBua's Map-based dedupe.
+    expect(combined[0]).toEqual(duplicateOfTruro);
   });
 });

--- a/web/src/data/towns.json
+++ b/web/src/data/towns.json
@@ -9352,6 +9352,262 @@
     "population": 97870
   },
   {
+    "slug": "barking-and-dagenham",
+    "name": "Barking and Dagenham",
+    "lat": 51.542,
+    "lng": 0.127,
+    "authorityId": 295,
+    "population": 218236
+  },
+  {
+    "slug": "barnet",
+    "name": "Barnet",
+    "lat": 51.6152,
+    "lng": -0.2091,
+    "authorityId": 296,
+    "population": 388572
+  },
+  {
+    "slug": "bexley",
+    "name": "Bexley",
+    "lat": 51.4687,
+    "lng": 0.1474,
+    "authorityId": 297,
+    "population": 246074
+  },
+  {
+    "slug": "brent",
+    "name": "Brent",
+    "lat": 51.56,
+    "lng": -0.2779,
+    "authorityId": 298,
+    "population": 340611
+  },
+  {
+    "slug": "bromley",
+    "name": "Bromley",
+    "lat": 51.3802,
+    "lng": 0.0445,
+    "authorityId": 299,
+    "population": 325469
+  },
+  {
+    "slug": "camden",
+    "name": "Camden",
+    "lat": 51.5488,
+    "lng": -0.1621,
+    "authorityId": 300,
+    "population": 209342
+  },
+  {
+    "slug": "croydon",
+    "name": "Croydon",
+    "lat": 51.3507,
+    "lng": -0.083,
+    "authorityId": 301,
+    "population": 389242
+  },
+  {
+    "slug": "ealing",
+    "name": "Ealing",
+    "lat": 51.5245,
+    "lng": -0.3503,
+    "authorityId": 302,
+    "population": 367271
+  },
+  {
+    "slug": "enfield",
+    "name": "Enfield",
+    "lat": 51.6482,
+    "lng": -0.095,
+    "authorityId": 303,
+    "population": 329822
+  },
+  {
+    "slug": "greenwich",
+    "name": "Greenwich",
+    "lat": 51.4741,
+    "lng": 0.0472,
+    "authorityId": 304,
+    "population": 288117
+  },
+  {
+    "slug": "hackney",
+    "name": "Hackney",
+    "lat": 51.5513,
+    "lng": -0.0656,
+    "authorityId": 305,
+    "population": 258464
+  },
+  {
+    "slug": "hammersmith-and-fulham",
+    "name": "Hammersmith and Fulham",
+    "lat": 51.4973,
+    "lng": -0.2252,
+    "authorityId": 306,
+    "population": 182187
+  },
+  {
+    "slug": "haringey",
+    "name": "Haringey",
+    "lat": 51.5861,
+    "lng": -0.1031,
+    "authorityId": 307,
+    "population": 264069
+  },
+  {
+    "slug": "harrow",
+    "name": "Harrow",
+    "lat": 51.5944,
+    "lng": -0.3441,
+    "authorityId": 308,
+    "population": 260534
+  },
+  {
+    "slug": "havering",
+    "name": "Havering",
+    "lat": 51.5769,
+    "lng": 0.2164,
+    "authorityId": 309,
+    "population": 259401
+  },
+  {
+    "slug": "hillingdon",
+    "name": "Hillingdon",
+    "lat": 51.536,
+    "lng": -0.4454,
+    "authorityId": 310,
+    "population": 307089
+  },
+  {
+    "slug": "hounslow",
+    "name": "Hounslow",
+    "lat": 51.4679,
+    "lng": -0.3757,
+    "authorityId": 311,
+    "population": 286591
+  },
+  {
+    "slug": "islington",
+    "name": "Islington",
+    "lat": 51.5443,
+    "lng": -0.1035,
+    "authorityId": 312,
+    "population": 216309
+  },
+  {
+    "slug": "kensington-and-chelsea",
+    "name": "Kensington and Chelsea",
+    "lat": 51.4938,
+    "lng": -0.1773,
+    "authorityId": 313,
+    "population": 143348
+  },
+  {
+    "slug": "kingston-upon-thames",
+    "name": "Kingston upon Thames",
+    "lat": 51.3953,
+    "lng": -0.2796,
+    "authorityId": 314,
+    "population": 166333
+  },
+  {
+    "slug": "lambeth",
+    "name": "Lambeth",
+    "lat": 51.4355,
+    "lng": -0.1161,
+    "authorityId": 315,
+    "population": 317108
+  },
+  {
+    "slug": "lewisham",
+    "name": "Lewisham",
+    "lat": 51.4481,
+    "lng": -0.0217,
+    "authorityId": 316,
+    "population": 300764
+  },
+  {
+    "slug": "merton",
+    "name": "Merton",
+    "lat": 51.4113,
+    "lng": -0.2022,
+    "authorityId": 317,
+    "population": 214931
+  },
+  {
+    "slug": "newham",
+    "name": "Newham",
+    "lat": 51.5288,
+    "lng": 0.0376,
+    "authorityId": 318,
+    "population": 351065
+  },
+  {
+    "slug": "redbridge",
+    "name": "Redbridge",
+    "lat": 51.5842,
+    "lng": 0.0752,
+    "authorityId": 319,
+    "population": 309509
+  },
+  {
+    "slug": "richmond-upon-thames",
+    "name": "Richmond upon Thames",
+    "lat": 51.4346,
+    "lng": -0.3404,
+    "authorityId": 320,
+    "population": 192888
+  },
+  {
+    "slug": "southwark",
+    "name": "Southwark",
+    "lat": 51.4858,
+    "lng": -0.0723,
+    "authorityId": 321,
+    "population": 307076
+  },
+  {
+    "slug": "sutton-sutton",
+    "name": "Sutton (Sutton)",
+    "lat": 51.3588,
+    "lng": -0.1754,
+    "authorityId": 322,
+    "population": 208858
+  },
+  {
+    "slug": "tower-hamlets",
+    "name": "Tower Hamlets",
+    "lat": 51.5184,
+    "lng": -0.0375,
+    "authorityId": 323,
+    "population": 311072
+  },
+  {
+    "slug": "waltham-forest",
+    "name": "Waltham Forest",
+    "lat": 51.5808,
+    "lng": -0.0141,
+    "authorityId": 324,
+    "population": 278129
+  },
+  {
+    "slug": "wandsworth",
+    "name": "Wandsworth",
+    "lat": 51.4512,
+    "lng": -0.1773,
+    "authorityId": 325,
+    "population": 326725
+  },
+  {
+    "slug": "city-of-westminster",
+    "name": "City of Westminster",
+    "lat": 51.5127,
+    "lng": -0.1571,
+    "authorityId": 326,
+    "population": 203571
+  },
+  {
     "slug": "amersham",
     "name": "Amersham",
     "lat": 51.6777,
@@ -10790,6 +11046,14 @@
     "lng": -3.3087,
     "authorityId": 419,
     "population": 5045
+  },
+  {
+    "slug": "city-and-county-of-the-city-of-london",
+    "name": "City and County of the City of London",
+    "lat": 51.5154,
+    "lng": -0.0899,
+    "authorityId": 471,
+    "population": 7820
   },
   {
     "slug": "brandon-west-suffolk",


### PR DESCRIPTION
## What

Adds the **33 London Built-Up Areas** to the committed gazetteer `web/src/data/towns.json`, on top of the 1,395 England-ex-London + Wales rows shipped by `tc-2avw.5` (#595). Composes London at the documented EXTENSION SEAM in `generate-towns.mjs`. **towns.json: 1,395 → 1,428 rows.** Every row keeps the `{ slug, name, lat, lng, authorityId, population }` shape. **0 skipped.**

The diff to `towns.json` is **purely additive** (264 insertions, 0 deletions) — the existing 1,395 E&W rows are preserved byte-for-byte; London rows interleave at their sorted positions.

## Why a separate London population source

The ONS Census 2021 *"Towns and cities, characteristics of built-up areas, England and Wales"* workbook **explicitly excludes London**: in Greater London the BUA method follows borough boundaries rather than recognising individual settlements, so ONS removed the ~33 borough-shaped London BUAs from Tables 1c/1d. There is **no London table anywhere in that workbook** (every "individual BUA" table is "England (excluding London)" or "Wales"), and neither the ONS beta custom-dataset API nor Nomis exposes a `bua` geography for usual residents. London population therefore had to be derived from genuine ONS sources.

## Provenance (sources fetched 2026-06-21)

| Field | Source | Endpoint / file |
|---|---|---|
| London BUA population | **Census 2021 TS001** (usual residents) at Output-Area level, **summed by BUA** via the OA→BUA lookup | Nomis bulk `census2021-ts001-oa.csv` (188,880 OAs incl. London) + `OA21_BUA22_LAD22_RGN22_EW_LU` FeatureServer (`services1.arcgis.com/ESMARspQHYMw9BZ9/...`) |
| London BUA → borough (LAD) | plurality of each BUA's OA population (resolves the multi-LAD "Part" rows) | same OA→BUA→LAD lookup |
| Which BUAs are "London" | candidate = BUAs the `Built_Up_Area_to_Local_Authority_District_(December_2022)_Lookup_in_Great_Britain` lookup attaches to a London borough (`LAD22CD LIKE 'E09%'`), **minus** any already present in Census Table 1c/1d (those are surrounding-county edge towns already in the E&W set) | BUA→LAD lookup + workbook |
| Centroids (WGS84) | ONS Open Geography **BUA_2022_GB** (GB-wide, includes London), `LAT`/`LONG` direct | `services1.arcgis.com/ESMARspQHYMw9BZ9/.../BUA_2022_GB/FeatureServer/0` |

The centroid CSV is GB-wide, so the **same centroid file feeds both** the E&W and the London `buildGazetteer` calls.

## How the London set was built

1. Queried the BUA→LAD lookup for every BUA touching a London borough → **68 candidate BUA codes**.
2. Removed the **34** that also appear in Census Table 1c/1d — those are surrounding-county towns (Borehamwood, Bushey, Watford, Swanley, Banstead, Caterham, …) that only clip a London borough and are **already in the E&W set**; never re-added. Left **34 true London BUAs**.
3. Summed Census 2021 TS001 OA usual residents per BUA over the OA→BUA lookup. One candidate (`E63004765` "West Hyde") has **zero OAs** in the lookup → no population → correctly drops out. **33 BUAs** remain: the 32 boroughs + City of London.
4. Assigned each BUA to the borough holding the **plurality of its OA population** — **≥98.9% for every one** (the BUAs are borough-shaped), so every BUA maps cleanly to its eponymous borough. All 33 `lad_name`s match `authority-mapping.json` (verified — no unmatched, no guessing).
5. Took centroids from BUA_2022_GB and emitted a `bua_code,bua_name,lad_name,population` CSV, run through `buildGazetteer` exactly like E&W.

## Generator change (within the documented seam)

`main()` now takes an optional third arg (`<london-population.csv>`), builds London via a second `buildGazetteer(londonPopCsv, centroidCsv, mapping)` against the shared centroid CSV, and concatenates onto E&W. A new exported `combineRecords()` helper re-applies the `authorityId/slug` last-wins dedupe + `authorityId`-then-`slug` stable sort across the **combined** set (mirroring `joinBua`'s tail), so the committed diff is order-independent. The E&W path and the CSV parser are untouched.

## Counts

- **Total: 1,428 towns** (1,395 E&W + **33 London**), 0 skipped.
- London total population: **8,776,597** (≈ Greater London's Census 2021 ~8.8M — sanity check passes).
- Threshold breakdown (whole gazetteer): ≥5k=**1,428**, ≥10k=890, ≥20k=**506** (was 474; +32 London), ≥30k=341, ≥50k=209, ≥100k=101.
- **32 of 33** London BUAs are ≥20k (the default `SEO_TOWN_MIN_POPULATION`); only **City of London** (7,820) is below, but above the 5k gazetteer floor.
- Coordinates: all 33 inside Greater London (lat 51.35–51.65, lng −0.45…+0.22).

## Spot-checks vs published Census 2021 borough figures

BUA OA-sums land within ~0.3% of full-borough counts (a BUA's OA set differs from the LAD's by a few boundary OAs):

| Borough | BUA OA-sum | Published borough |
|---|---|---|
| Croydon | 389,242 | 390,506 |
| Barnet | 388,572 | 389,300 |
| Newham | 351,065 | 350,626 |
| City of London | 7,820 | ~8,600 |

## Skip summary

**0 skipped** in the London set (all 33 joined and resolved). `West Hyde` dropped pre-build (no OAs → no population). The 34 borough-clipping edge towns were excluded by construction (already E&W). E&W path unchanged: still 0 skipped, 1,395 rows.

## Verification

- `npx vitest run` — **845 passed** (was 839; +6 new London-composition / `combineRecords` tests).
- `npm run build` — passes (prerender correctly skips without `SITE_BUILD_KEY`).
- `tsc --noEmit` clean, `eslint` clean on the changed files.
- `towns.json` diff is purely additive; regeneration reproduces all 1,395 E&W rows byte-for-byte (verified against the committed file).

Raw ONS downloads (28 MB xlsx, OA CSVs, intermediate JSON) were kept **out of git** — only `towns.json` + the generator `main()` change + its tests are committed. Strictly scoped: no Scotland (tc-2avw.8), no prerender, no API, no CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xL4oCpLWWGhqV6fmsfEXy