### PR TITLE
feat(web): add Scotland (NRS) settlements to the town gazetteer (tc-2avw.8)

### DIFF
--- a/web/scripts/generate-towns.mjs
+++ b/web/scripts/generate-towns.mjs
@@ -16,9 +16,11 @@
  * >= 20k selection later. Lowering the published threshold never needs a regen.
  *
  * Scope for THIS generator: England-ex-London + Wales (ONS Census 2021 BUA
- * file) PLUS London (tc-2avw.7), composed on top via a second population CSV.
- * Scotland settlements (tc-2avw.8) remain a separate source not yet wired —
- * see the EXTENSION SEAMS note at the foot of this file.
+ * file) PLUS London (tc-2avw.7), composed on top via a second population CSV,
+ * PLUS Scotland (tc-2avw.8) from NRS settlements via parseNrsRow/buildScotland
+ * — a different source schema with its OWN centroid CSV. See the "Scotland
+ * (NRS)" note (next to NRS_POPULATION_COLUMNS) and the EXTENSION SEAMS note at
+ * the foot of main().
  *
  * ── Data sources (TWO files, joined on BUA code) ────────────────────────────
  *
@@ -96,14 +98,24 @@
  *      pre-join supplies lad_name if the Census export lacks it). Build the
  *      separate London population CSV per the "London population" note above.
  *   2. Run:
- *        node scripts/generate-towns.mjs <ew-population.csv> <centroid.csv> [<london-population.csv>]
- *      It parses each population CSV, joins on bua_code against the shared
- *      centroid CSV, drops BUAs < 5,000, resolves lad_name -> authorityId
- *      against authority-mapping.json, skips+logs any BUA with no centroid or
- *      no resolvable authority, then de-duplicates the COMBINED E&W+London set
- *      by authorityId/slug, sorts, and overwrites web/src/data/towns.json.
- *   3. (When tc-2avw.8 lands) append the Scotland record set before writing —
- *      see EXTENSION SEAMS.
+ *        node scripts/generate-towns.mjs <ew-population.csv> <centroid.csv> \
+ *          [<london-population.csv>] [<scotland-population.csv> <scotland-centroids.csv>]
+ *      It parses each population CSV, joins on the settlement code against the
+ *      matching centroid CSV (the shared GB BUA file for E&W + London; the NRS
+ *      centroid file for Scotland), drops settlements < 5,000, resolves the LAD/
+ *      council name -> authorityId against authority-mapping.json, skips+logs
+ *      any settlement with no centroid or no resolvable authority, then
+ *      de-duplicates the COMBINED set by authorityId/slug, sorts, and overwrites
+ *      web/src/data/towns.json.
+ *   3. Scotland (tc-2avw.8): build the NRS population CSV from the "Population
+ *      estimates for settlements and localities in Scotland, mid-2020" workbook
+ *      (Table 2.1 settlement All-ages population, joined to Table 1.1 for the
+ *      council area); the ~6 settlements that straddle >1 council are resolved
+ *      to the single council containing the settlement centroid (point-in-
+ *      polygon against the ScotGov ScottishLocalAuthorities boundaries). Build
+ *      the NRS centroid CSV from the NRS:SettlementCentroids WFS layer. Both
+ *      key on the NRS settlement code (S2000....). Pass them as the last two
+ *      arguments. See the "Scotland (NRS)" note and EXTENSION SEAMS.
  *   4. Review the diff, run `npx vitest run`, and commit.
  *
  * ── Coordinate conversion (fallback) ────────────────────────────────────────
@@ -160,6 +172,55 @@ export const POPULATION_COLUMNS = {
 export const CENTROID_COLUMNS = {
   BUA_CODE: 0,
   BUA_NAME: 1,
+  LATITUDE: 2,
+  LONGITUDE: 3,
+  BNG_EASTING: 4,
+  BNG_NORTHING: 5,
+};
+
+// ── Scotland (NRS) extension ────────────────────────────────────────────────
+// Scotland is NOT a BUA region — it comes from National Records of Scotland
+// "settlements", a different source schema, so it gets its own parse/build path
+// (`parseNrsRow` + `buildScotland`) rather than reusing the BUA contracts above.
+// Once parsed, an NRS settlement emits the SAME gazetteer record shape and runs
+// through the SAME `joinBua` join/skip/dedupe/sort as the BUA regions.
+//
+// Sources (joined on the NRS settlement code, e.g. `S20001877`):
+//   1. POPULATION + COUNCIL — NRS "Population estimates for settlements and
+//      localities in Scotland, mid-2020", Table 2.1 (settlement populations,
+//      the All-ages row) joined to Table 1.1 (settlement -> council area). The
+//      6 settlements that straddle >1 council are resolved to the single council
+//      containing the settlement centroid (point-in-polygon against the ScotGov
+//      ScottishLocalAuthorities boundaries) before the CSV is produced — the
+//      generator never guesses; an unresolved council is left blank and skipped.
+//   2. CENTROID (lat/lng) — NRS Settlement Centroids (WFS `NRS:SettlementCentroids`),
+//      carrying the settlement code, a WGS84 lat/lng, and a BNG easting/northing.
+
+/**
+ * Zero-based column indices in the NRS POPULATION CSV. Expected header
+ * `settlement_code,settlement_name,council_area,population`. Distinct from the
+ * BUA population contract: the join key is an NRS settlement code (`S2000....`)
+ * and the authority column is a Scottish council-area name (matched verbatim
+ * against authority-mapping.json — all 32 councils are present).
+ * @type {Record<string, number>}
+ */
+export const NRS_POPULATION_COLUMNS = {
+  SETTLEMENT_CODE: 0,
+  SETTLEMENT_NAME: 1,
+  COUNCIL_AREA: 2,
+  POPULATION: 3,
+};
+
+/**
+ * Zero-based column indices in the NRS CENTROID CSV. Expected header
+ * `settlement_code,settlement_name,latitude,longitude,bng_easting,bng_northing`.
+ * The NRS WFS emits a WGS84 lat/lng directly; the BNG easting/northing remain a
+ * fallback (via `bngToLatLon`) for any grid-only export.
+ * @type {Record<string, number>}
+ */
+export const NRS_CENTROID_COLUMNS = {
+  SETTLEMENT_CODE: 0,
+  SETTLEMENT_NAME: 1,
   LATITUDE: 2,
   LONGITUDE: 3,
   BNG_EASTING: 4,
@@ -376,6 +437,109 @@ export function buildGazetteer(populationCsv, centroidCsv, mapping) {
 }
 
 /**
+ * Parse one NRS POPULATION CSV row into the same normalised shape `joinBua`
+ * consumes (`{ code, name, ladName, population }`), or null when the row is
+ * unusable (no settlement code, no name, or a non-finite population). The NRS
+ * `council_area` becomes `ladName` so it resolves against the SAME
+ * authority-mapping.json the BUA path uses; a blank council survives as an
+ * empty `ladName` and is skipped downstream as 'unmatched-authority' (the
+ * orchestrator leaves it blank only for the genuinely unresolved settlements).
+ *
+ * @param {string[]} fields CSV row split on commas
+ * @returns {{ code: string, name: string, ladName: string, population: number } | null}
+ */
+export function parseNrsRow(fields) {
+  const code = (fields[NRS_POPULATION_COLUMNS.SETTLEMENT_CODE] || '').trim();
+  if (!code) {
+    return null;
+  }
+  const name = (fields[NRS_POPULATION_COLUMNS.SETTLEMENT_NAME] || '').trim();
+  if (!name) {
+    return null;
+  }
+  const population = toNumberOrNull(fields[NRS_POPULATION_COLUMNS.POPULATION]);
+  if (population === null) {
+    return null;
+  }
+  const ladName = (fields[NRS_POPULATION_COLUMNS.COUNCIL_AREA] || '').trim();
+  return { code, name, ladName, population };
+}
+
+/**
+ * Parse one NRS CENTROID CSV row into `{ code, lat, lng }`, preferring the
+ * provided WGS84 lat/lng and falling back to BNG conversion when they are blank.
+ * Returns null when the settlement code is missing or no usable coordinate
+ * exists. Mirrors `parseCentroidRow` but reads the NRS column layout.
+ *
+ * @param {string[]} fields CSV row split on commas
+ * @returns {{ code: string, lat: number, lng: number } | null}
+ */
+export function parseNrsCentroidRow(fields) {
+  const code = (fields[NRS_CENTROID_COLUMNS.SETTLEMENT_CODE] || '').trim();
+  if (!code) {
+    return null;
+  }
+  const lat = toNumberOrNull(fields[NRS_CENTROID_COLUMNS.LATITUDE]);
+  const lng = toNumberOrNull(fields[NRS_CENTROID_COLUMNS.LONGITUDE]);
+  if (lat !== null && lng !== null) {
+    return { code, lat: round4(lat), lng: round4(lng) };
+  }
+  const easting = toNumberOrNull(fields[NRS_CENTROID_COLUMNS.BNG_EASTING]);
+  const northing = toNumberOrNull(fields[NRS_CENTROID_COLUMNS.BNG_NORTHING]);
+  if (easting !== null && northing !== null) {
+    const converted = bngToLatLon(easting, northing);
+    return { code, lat: converted.lat, lng: converted.lng };
+  }
+  return null;
+}
+
+/**
+ * End-to-end Scotland build: parse the NRS population + centroid CSV texts, drop
+ * settlements below the population floor, join on settlement code, and resolve
+ * each council-area name to an authority id — the SAME `joinBua` tail the BUA
+ * regions use, so the emitted record shape, skip reasons, dedupe, and sort are
+ * identical. Below-floor settlements are reported distinctly (as in
+ * `buildGazetteer`).
+ *
+ * @param {string} populationCsv raw NRS POPULATION CSV text (with header row)
+ * @param {string} centroidCsv   raw NRS CENTROID CSV text (with header row)
+ * @param {Record<string, number>} mapping council-name -> authority-id
+ * @returns {{
+ *   records: Array<{ slug: string, name: string, lat: number, lng: number, authorityId: number, population: number }>,
+ *   skipped: Array<{ code: string, name: string, reason: string }>
+ * }}
+ */
+export function buildScotland(populationCsv, centroidCsv, mapping) {
+  /** @type {Array<{ code: string, name: string, ladName: string, population: number }>} */
+  const populations = [];
+  /** @type {Array<{ code: string, name: string, reason: string }>} */
+  const belowFloor = [];
+  for (const fields of parseCsvRows(populationCsv)) {
+    const parsed = parseNrsRow(fields);
+    if (!parsed) {
+      continue;
+    }
+    if (parsed.population < POPULATION_FLOOR) {
+      belowFloor.push({ code: parsed.code, name: parsed.name, reason: 'below-floor' });
+      continue;
+    }
+    populations.push(parsed);
+  }
+
+  /** @type {Array<{ code: string, lat: number, lng: number }>} */
+  const centroids = [];
+  for (const fields of parseCsvRows(centroidCsv)) {
+    const parsed = parseNrsCentroidRow(fields);
+    if (parsed) {
+      centroids.push(parsed);
+    }
+  }
+
+  const { records, skipped } = joinBua(populations, centroids, mapping);
+  return { records, skipped: [...belowFloor, ...skipped] };
+}
+
+/**
  * Split CSV text into field arrays, dropping the header row and blank lines.
  * A handful of official ONS names carry embedded commas — both BUA names
  * (`Longfield, New Ash Green and Hartley`) and, more importantly, LAD names
@@ -575,21 +739,41 @@ function round4(v) {
 }
 
 /**
- * CLI entry: read the ONS CSVs, build the gazetteer (E&W + optional London),
- * write towns.json.
+ * CLI entry: read the source CSVs, build the gazetteer (E&W + optional London +
+ * optional Scotland), write towns.json.
  *
- * @param {string} populationFile      path to the E&W POPULATION CSV
- * @param {string} centroidFile        path to the GB-wide CENTROID CSV
+ * @param {string} populationFile      path to the E&W POPULATION CSV (BUA contract)
+ * @param {string} centroidFile        path to the GB-wide BUA CENTROID CSV
  * @param {string} [londonPopulationFile] optional path to the London POPULATION
  *   CSV (same `bua_code,bua_name,lad_name,population` contract). When supplied,
  *   its records are composed on top of E&W against the SAME centroid CSV.
+ * @param {string} [scotlandPopulationFile] optional path to the NRS Scotland
+ *   POPULATION CSV (`settlement_code,settlement_name,council_area,population`).
+ * @param {string} [scotlandCentroidFile] optional path to the NRS Scotland
+ *   CENTROID CSV (`settlement_code,settlement_name,latitude,longitude,
+ *   bng_easting,bng_northing`). Required when a Scotland population CSV is given
+ *   — Scotland centroids come from NRS, not the GB BUA centroid file.
  * @returns {Promise<void>}
  */
-async function main(populationFile, centroidFile, londonPopulationFile) {
+async function main(
+  populationFile,
+  centroidFile,
+  londonPopulationFile,
+  scotlandPopulationFile,
+  scotlandCentroidFile,
+) {
   if (!populationFile || !centroidFile) {
     console.error(
-      'usage: node scripts/generate-towns.mjs <ew-population.csv> <centroid.csv> [<london-population.csv>]\n' +
+      'usage: node scripts/generate-towns.mjs <ew-population.csv> <centroid.csv> ' +
+        '[<london-population.csv>] [<scotland-population.csv> <scotland-centroids.csv>]\n' +
         'See the script header for the full CSV contracts and regeneration steps.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  if (scotlandPopulationFile && !scotlandCentroidFile) {
+    console.error(
+      'A Scotland population CSV requires its NRS centroid CSV as the next argument.',
     );
     process.exitCode = 1;
     return;
@@ -608,15 +792,25 @@ async function main(populationFile, centroidFile, londonPopulationFile) {
   //     header note) joined against the same GB centroid CSV. London borough
   //     LADs are already in authority-mapping.json.
   //   * Scotland settlements (tc-2avw.8): NRS settlement population + NRS
-  //     settlement centroids. Different source schema — add a parseNrsRow /
-  //     buildScotland helper and concat its records here.
+  //     settlement centroids — a DIFFERENT source schema, so it goes through
+  //     parseNrsRow/buildScotland with its OWN centroid CSV (not the GB BUA
+  //     one). Council-area names resolve against the same mapping.
   // Each region must keep emitting { slug, name, lat, lng, authorityId,
-  // population } and resolve LAD->authorityId against the same mapping. Skipped
-  // BUAs stay skipped+logged, never guessed.
+  // population } and resolve LAD/council -> authorityId against the same
+  // mapping. Skipped rows stay skipped+logged, never guessed.
   const regions = [ew];
+  let london = null;
+  let scotland = null;
   if (londonPopulationFile) {
     const londonPopulationCsv = await readFile(londonPopulationFile, 'utf-8');
-    regions.push(buildGazetteer(londonPopulationCsv, centroidCsv, mapping));
+    london = buildGazetteer(londonPopulationCsv, centroidCsv, mapping);
+    regions.push(london);
+  }
+  if (scotlandPopulationFile) {
+    const scotlandPopulationCsv = await readFile(scotlandPopulationFile, 'utf-8');
+    const scotlandCentroidCsv = await readFile(scotlandCentroidFile, 'utf-8');
+    scotland = buildScotland(scotlandPopulationCsv, scotlandCentroidCsv, mapping);
+    regions.push(scotland);
   }
 
   // Combine across regions: concat, then re-apply the dedupe-by-authorityId/slug
@@ -634,11 +828,12 @@ async function main(populationFile, centroidFile, londonPopulationFile) {
   console.log(
     `[generate-towns] wrote ${records.length} town(s) to ${TOWNS_OUT}` +
       ` (E&W ${ew.records.length}` +
-      (londonPopulationFile ? `, London ${regions[1].records.length}` : '') +
+      (london ? `, London ${london.records.length}` : '') +
+      (scotland ? `, Scotland ${scotland.records.length}` : '') +
       ')',
   );
   console.log(
-    `[generate-towns] skipped ${skipped.length} BUA(s): ` +
+    `[generate-towns] skipped ${skipped.length} settlement(s): ` +
       Object.entries(byReason)
         .map(([reason, count]) => `${reason}=${count}`)
         .join(', '),
@@ -651,5 +846,11 @@ async function main(populationFile, centroidFile, londonPopulationFile) {
 
 // Run main() only when invoked directly, not when imported by tests.
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  await main(process.argv[2], process.argv[3], process.argv[4]);
+  await main(
+    process.argv[2],
+    process.argv[3],
+    process.argv[4],
+    process.argv[5],
+    process.argv[6],
+  );
 }

--- a/web/scripts/lib/__tests__/generate-towns.test.mjs
+++ b/web/scripts/lib/__tests__/generate-towns.test.mjs
@@ -9,11 +9,16 @@ import {
   parseCsvLine,
   parsePopulationRow,
   parseCentroidRow,
+  parseNrsRow,
+  parseNrsCentroidRow,
   joinBua,
   buildGazetteer,
+  buildScotland,
   combineRecords,
   POPULATION_COLUMNS,
   CENTROID_COLUMNS,
+  NRS_POPULATION_COLUMNS,
+  NRS_CENTROID_COLUMNS,
 } from '../../generate-towns.mjs';
 
 const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'fixtures');
@@ -551,5 +556,239 @@ describe('combineRecords (cross-region dedupe + stable sort)', () => {
     expect(combined).toHaveLength(1);
     // Last write wins, matching joinBua's Map-based dedupe.
     expect(combined[0]).toEqual(duplicateOfTruro);
+  });
+});
+
+describe('parseNrsRow (NRS Scotland settlement population file)', () => {
+  /** Build a synthetic NRS population CSV row in the documented column order. */
+  function row(values) {
+    const fields = [];
+    for (const [key, index] of Object.entries(NRS_POPULATION_COLUMNS)) {
+      fields[index] = values[key] ?? '';
+    }
+    return fields;
+  }
+
+  it('parses a well-formed row into {code, name, ladName, population}', () => {
+    const parsed = parseNrsRow(
+      row({
+        SETTLEMENT_CODE: 'S20001846',
+        SETTLEMENT_NAME: 'Inverness and Culloden',
+        COUNCIL_AREA: 'Highland',
+        POPULATION: '63730',
+      }),
+    );
+    // The council-area name lands in `ladName` so it resolves against the same
+    // authority mapping the BUA path uses.
+    expect(parsed).toEqual({
+      code: 'S20001846',
+      name: 'Inverness and Culloden',
+      ladName: 'Highland',
+      population: 63730,
+    });
+  });
+
+  it('keeps an NRS settlement name with embedded commas verbatim', () => {
+    const parsed = parseNrsRow(
+      row({
+        SETTLEMENT_CODE: 'S20001539',
+        SETTLEMENT_NAME: 'Aberdeen, Milltimber, and Peterculter',
+        COUNCIL_AREA: 'Aberdeen City',
+        POPULATION: '220690',
+      }),
+    );
+    expect(parsed.name).toBe('Aberdeen, Milltimber, and Peterculter');
+  });
+
+  it('returns null when the settlement code is missing', () => {
+    expect(
+      parseNrsRow(row({ SETTLEMENT_NAME: 'Nameless', COUNCIL_AREA: 'Fife', POPULATION: '9000' })),
+    ).toBeNull();
+  });
+
+  it('returns null when the population is not a finite number', () => {
+    expect(
+      parseNrsRow(
+        row({
+          SETTLEMENT_CODE: 'S20009999',
+          SETTLEMENT_NAME: 'Bad',
+          COUNCIL_AREA: 'Fife',
+          POPULATION: 'N/A',
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('preserves a blank council so it skips as unmatched downstream (never guessed)', () => {
+    // The orchestrator leaves council_area blank only for a genuinely unresolved
+    // settlement; parseNrsRow must keep it blank, not invent one.
+    const parsed = parseNrsRow(
+      row({
+        SETTLEMENT_CODE: 'S20008888',
+        SETTLEMENT_NAME: 'Ambiguous',
+        COUNCIL_AREA: '',
+        POPULATION: '6000',
+      }),
+    );
+    expect(parsed.ladName).toBe('');
+  });
+});
+
+describe('parseNrsCentroidRow (NRS Scotland settlement centroids)', () => {
+  /** Build a synthetic NRS centroid CSV row in the documented column order. */
+  function row(values) {
+    const fields = [];
+    for (const [key, index] of Object.entries(NRS_CENTROID_COLUMNS)) {
+      fields[index] = values[key] ?? '';
+    }
+    return fields;
+  }
+
+  it('parses a well-formed row, using the provided lat/lng directly', () => {
+    const parsed = parseNrsCentroidRow(
+      row({
+        SETTLEMENT_CODE: 'S20001846',
+        SETTLEMENT_NAME: 'Inverness and Culloden',
+        LATITUDE: '57.4700',
+        LONGITUDE: '-4.2080',
+        BNG_EASTING: '266500',
+        BNG_NORTHING: '845200',
+      }),
+    );
+    expect(parsed.code).toBe('S20001846');
+    expect(parsed.lat).toBeCloseTo(57.47, 4);
+    expect(parsed.lng).toBeCloseTo(-4.208, 4);
+  });
+
+  it('falls back to BNG conversion when lat/lng are absent (Edinburgh BNG)', () => {
+    // Edinburgh NT 25731 73721 -> easting 325731, northing 673721 -> ~55.95, -3.19.
+    const parsed = parseNrsCentroidRow(
+      row({
+        SETTLEMENT_CODE: 'S20001714',
+        SETTLEMENT_NAME: 'Edinburgh',
+        LATITUDE: '',
+        LONGITUDE: '',
+        BNG_EASTING: '325731',
+        BNG_NORTHING: '673721',
+      }),
+    );
+    expect(parsed.lat).toBeCloseTo(55.95, 1);
+    expect(parsed.lng).toBeCloseTo(-3.19, 1);
+  });
+
+  it('returns null when neither lat/lng nor BNG coordinates are usable', () => {
+    expect(
+      parseNrsCentroidRow(
+        row({ SETTLEMENT_CODE: 'S20000002', SETTLEMENT_NAME: 'Nowhere' }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null when the settlement code is missing', () => {
+    expect(
+      parseNrsCentroidRow(row({ SETTLEMENT_NAME: 'Perth', LATITUDE: '56.3990', LONGITUDE: '-3.4520' })),
+    ).toBeNull();
+  });
+});
+
+describe('buildScotland (NRS population x centroid on settlement code)', () => {
+  // All 32 Scottish council names match authority-mapping.json verbatim, so this
+  // mapping uses the real ids from that file.
+  const mapping = {
+    Highland: 372,
+    'City of Edinburgh': 387,
+    'Glasgow City': 395,
+    Fife: 371,
+    'Perth and Kinross': 378,
+  };
+
+  const populationCsv = [
+    'settlement_code,settlement_name,council_area,population',
+    'S20001846,Inverness and Culloden,Highland,63730',
+    'S20001714,Edinburgh,City of Edinburgh,530990',
+    // Greater Glasgow straddles >1 council; the orchestrator pre-resolves it to
+    // the council containing the settlement centroid (Glasgow City).
+    'S20001766,Greater Glasgow,Glasgow City,1028220',
+    // Below the 5,000 floor.
+    'S20009000,Tiny Clachan,Highland,4200',
+    // Genuinely unresolved council (left blank): must skip, never guessed.
+    'S20008888,Ambiguous,,6000',
+    // Has population but no matching centroid.
+    'S20007777,NoCentroid,Fife,9000',
+  ].join('\n');
+
+  const centroidCsv = [
+    'settlement_code,settlement_name,latitude,longitude,bng_easting,bng_northing',
+    'S20001846,Inverness and Culloden,57.4700,-4.2080,266500,845200',
+    'S20001714,Edinburgh,55.9420,-3.2020,325000,673000',
+    'S20001766,Greater Glasgow,55.8540,-4.2940,256447,664654',
+    'S20009000,Tiny Clachan,57.0000,-5.0000,200000,800000',
+    'S20008888,Ambiguous,56.5000,-3.0000,340000,730000',
+  ].join('\n');
+
+  it('emits a {slug,name,lat,lng,authorityId,population} record for a matched settlement', () => {
+    const { records } = buildScotland(populationCsv, centroidCsv, mapping);
+    const inverness = records.find((r) => r.slug === 'inverness-and-culloden');
+    expect(inverness).toEqual({
+      slug: 'inverness-and-culloden',
+      name: 'Inverness and Culloden',
+      lat: 57.47,
+      lng: -4.208,
+      authorityId: 372,
+      population: 63730,
+    });
+  });
+
+  it('joins population and centroid on the NRS settlement code (S2000....)', () => {
+    const { records } = buildScotland(populationCsv, centroidCsv, mapping);
+    const edinburgh = records.find((r) => r.slug === 'edinburgh');
+    expect(edinburgh.population).toBe(530990);
+    expect(edinburgh.authorityId).toBe(387);
+    expect(edinburgh.lat).toBeCloseTo(55.942, 3);
+    expect(edinburgh.lng).toBeCloseTo(-3.202, 3);
+  });
+
+  it('resolves a pre-disambiguated multi-council settlement to its single council', () => {
+    const { records } = buildScotland(populationCsv, centroidCsv, mapping);
+    const glasgow = records.find((r) => r.slug === 'greater-glasgow');
+    expect(glasgow.authorityId).toBe(395); // Glasgow City
+    expect(glasgow.population).toBe(1028220);
+  });
+
+  it('drops settlements below the 5,000 population floor', () => {
+    const { records } = buildScotland(populationCsv, centroidCsv, mapping);
+    expect(records.map((r) => r.slug)).not.toContain('tiny-clachan');
+  });
+
+  it('skips and logs a settlement whose council is blank/unresolved (never guessed)', () => {
+    const { records, skipped } = buildScotland(populationCsv, centroidCsv, mapping);
+    expect(records.map((r) => r.slug)).not.toContain('ambiguous');
+    const byCode = Object.fromEntries(skipped.map((s) => [s.code, s.reason]));
+    expect(byCode['S20008888']).toBe('unmatched-authority');
+  });
+
+  it('records the reason for every skipped settlement', () => {
+    const { skipped } = buildScotland(populationCsv, centroidCsv, mapping);
+    const byCode = Object.fromEntries(skipped.map((s) => [s.code, s.reason]));
+    expect(byCode['S20009000']).toBe('below-floor');
+    expect(byCode['S20008888']).toBe('unmatched-authority');
+    expect(byCode['S20007777']).toBe('no-centroid');
+  });
+
+  it('every emitted record carries a finite numeric population', () => {
+    const { records } = buildScotland(populationCsv, centroidCsv, mapping);
+    for (const r of records) {
+      expect(Number.isFinite(r.population)).toBe(true);
+    }
+  });
+
+  it('places every Scottish record inside the Scotland bounding box', () => {
+    const { records } = buildScotland(populationCsv, centroidCsv, mapping);
+    for (const r of records) {
+      expect(r.lat).toBeGreaterThan(54.5);
+      expect(r.lat).toBeLessThan(61.0);
+      expect(r.lng).toBeGreaterThan(-8.0);
+      expect(r.lng).toBeLessThan(-0.5);
+    }
   });
 });

--- a/web/src/data/towns.json
+++ b/web/src/data/towns.json
@@ -10208,6 +10208,982 @@
     "population": 50170
   },
   {
+    "slug": "alloa-and-sauchie",
+    "name": "Alloa and Sauchie",
+    "lat": 56.1209,
+    "lng": -3.7902,
+    "authorityId": 364,
+    "population": 20750
+  },
+  {
+    "slug": "tillicoultry",
+    "name": "Tillicoultry",
+    "lat": 56.1525,
+    "lng": -3.7387,
+    "authorityId": 364,
+    "population": 5910
+  },
+  {
+    "slug": "tullibody",
+    "name": "Tullibody",
+    "lat": 56.1347,
+    "lng": -3.8321,
+    "authorityId": 364,
+    "population": 9240
+  },
+  {
+    "slug": "annan",
+    "name": "Annan",
+    "lat": 54.9889,
+    "lng": -3.2542,
+    "authorityId": 365,
+    "population": 8760
+  },
+  {
+    "slug": "dumfries",
+    "name": "Dumfries",
+    "lat": 55.0701,
+    "lng": -3.6101,
+    "authorityId": 365,
+    "population": 34040
+  },
+  {
+    "slug": "locharbriggs",
+    "name": "Locharbriggs",
+    "lat": 55.0987,
+    "lng": -3.5788,
+    "authorityId": 365,
+    "population": 5610
+  },
+  {
+    "slug": "stranraer",
+    "name": "Stranraer",
+    "lat": 54.9018,
+    "lng": -5.0272,
+    "authorityId": 365,
+    "population": 10110
+  },
+  {
+    "slug": "cumnock",
+    "name": "Cumnock",
+    "lat": 55.4508,
+    "lng": -4.2574,
+    "authorityId": 366,
+    "population": 8700
+  },
+  {
+    "slug": "kilmarnock",
+    "name": "Kilmarnock",
+    "lat": 55.6095,
+    "lng": -4.4896,
+    "authorityId": 366,
+    "population": 51370
+  },
+  {
+    "slug": "stewarton",
+    "name": "Stewarton",
+    "lat": 55.6818,
+    "lng": -4.5153,
+    "authorityId": 366,
+    "population": 7770
+  },
+  {
+    "slug": "cockenzie",
+    "name": "Cockenzie",
+    "lat": 55.9688,
+    "lng": -2.9508,
+    "authorityId": 367,
+    "population": 5370
+  },
+  {
+    "slug": "dunbar",
+    "name": "Dunbar",
+    "lat": 55.9969,
+    "lng": -2.5181,
+    "authorityId": 367,
+    "population": 10270
+  },
+  {
+    "slug": "haddington",
+    "name": "Haddington",
+    "lat": 55.9558,
+    "lng": -2.7833,
+    "authorityId": 367,
+    "population": 10360
+  },
+  {
+    "slug": "north-berwick",
+    "name": "North Berwick",
+    "lat": 56.0545,
+    "lng": -2.7236,
+    "authorityId": 367,
+    "population": 7840
+  },
+  {
+    "slug": "prestonpans",
+    "name": "Prestonpans",
+    "lat": 55.9567,
+    "lng": -2.9782,
+    "authorityId": 367,
+    "population": 10460
+  },
+  {
+    "slug": "tranent",
+    "name": "Tranent",
+    "lat": 55.9414,
+    "lng": -2.9504,
+    "authorityId": 367,
+    "population": 11910
+  },
+  {
+    "slug": "neilston",
+    "name": "Neilston",
+    "lat": 55.7831,
+    "lng": -4.4274,
+    "authorityId": 368,
+    "population": 5170
+  },
+  {
+    "slug": "ste-rnabhagh-stornoway",
+    "name": "Steòrnabhagh (Stornoway)",
+    "lat": 58.2181,
+    "lng": -6.379,
+    "authorityId": 369,
+    "population": 7280
+  },
+  {
+    "slug": "boness",
+    "name": "Bo'ness",
+    "lat": 56.01,
+    "lng": -3.6044,
+    "authorityId": 370,
+    "population": 14840
+  },
+  {
+    "slug": "bonnybridge",
+    "name": "Bonnybridge",
+    "lat": 56.008,
+    "lng": -3.9081,
+    "authorityId": 370,
+    "population": 25710
+  },
+  {
+    "slug": "falkirk",
+    "name": "Falkirk",
+    "lat": 56.007,
+    "lng": -3.7684,
+    "authorityId": 370,
+    "population": 103380
+  },
+  {
+    "slug": "ballingry-lochore-and-crosshill",
+    "name": "Ballingry, Lochore and Crosshill",
+    "lat": 56.1601,
+    "lng": -3.3251,
+    "authorityId": 371,
+    "population": 5940
+  },
+  {
+    "slug": "burntisland",
+    "name": "Burntisland",
+    "lat": 56.0624,
+    "lng": -3.2329,
+    "authorityId": 371,
+    "population": 6630
+  },
+  {
+    "slug": "cardenden-and-auchterderran",
+    "name": "Cardenden and Auchterderran",
+    "lat": 56.144,
+    "lng": -3.2581,
+    "authorityId": 371,
+    "population": 5190
+  },
+  {
+    "slug": "cowdenbeath-lochgelly-and-lumphinnans",
+    "name": "Cowdenbeath, Lochgelly and Lumphinnans",
+    "lat": 56.1139,
+    "lng": -3.3388,
+    "authorityId": 371,
+    "population": 19330
+  },
+  {
+    "slug": "cupar",
+    "name": "Cupar",
+    "lat": 56.3182,
+    "lng": -3.0123,
+    "authorityId": 371,
+    "population": 8960
+  },
+  {
+    "slug": "dalgety-bay-and-hillend",
+    "name": "Dalgety Bay and Hillend",
+    "lat": 56.036,
+    "lng": -3.3575,
+    "authorityId": 371,
+    "population": 9710
+  },
+  {
+    "slug": "dunfermline",
+    "name": "Dunfermline",
+    "lat": 56.0618,
+    "lng": -3.4264,
+    "authorityId": 371,
+    "population": 76210
+  },
+  {
+    "slug": "glenrothes",
+    "name": "Glenrothes",
+    "lat": 56.197,
+    "lng": -3.1745,
+    "authorityId": 371,
+    "population": 44760
+  },
+  {
+    "slug": "kelty",
+    "name": "Kelty",
+    "lat": 56.136,
+    "lng": -3.3819,
+    "authorityId": 371,
+    "population": 6760
+  },
+  {
+    "slug": "kirkcaldy-and-dysart",
+    "name": "Kirkcaldy and Dysart",
+    "lat": 56.1241,
+    "lng": -3.1671,
+    "authorityId": 371,
+    "population": 50370
+  },
+  {
+    "slug": "methil-leven-and-buckhaven",
+    "name": "Methil, Leven and Buckhaven",
+    "lat": 56.1924,
+    "lng": -3.0254,
+    "authorityId": 371,
+    "population": 30730
+  },
+  {
+    "slug": "st-andrews",
+    "name": "St Andrews",
+    "lat": 56.335,
+    "lng": -2.8023,
+    "authorityId": 371,
+    "population": 18410
+  },
+  {
+    "slug": "alness",
+    "name": "Alness",
+    "lat": 57.6972,
+    "lng": -4.2538,
+    "authorityId": 372,
+    "population": 5950
+  },
+  {
+    "slug": "dingwall",
+    "name": "Dingwall",
+    "lat": 57.6017,
+    "lng": -4.4283,
+    "authorityId": 372,
+    "population": 5360
+  },
+  {
+    "slug": "fort-william",
+    "name": "Fort William",
+    "lat": 56.824,
+    "lng": -5.0989,
+    "authorityId": 372,
+    "population": 10260
+  },
+  {
+    "slug": "inverness-and-culloden",
+    "name": "Inverness and Culloden",
+    "lat": 57.4705,
+    "lng": -4.2082,
+    "authorityId": 372,
+    "population": 63730
+  },
+  {
+    "slug": "nairn",
+    "name": "Nairn",
+    "lat": 57.5829,
+    "lng": -3.869,
+    "authorityId": 372,
+    "population": 10190
+  },
+  {
+    "slug": "thurso",
+    "name": "Thurso",
+    "lat": 58.5934,
+    "lng": -3.5258,
+    "authorityId": 372,
+    "population": 7390
+  },
+  {
+    "slug": "wick",
+    "name": "Wick",
+    "lat": 58.4404,
+    "lng": -3.0856,
+    "authorityId": 372,
+    "population": 6870
+  },
+  {
+    "slug": "greenock",
+    "name": "Greenock",
+    "lat": 55.9424,
+    "lng": -4.7585,
+    "authorityId": 373,
+    "population": 65690
+  },
+  {
+    "slug": "bonnyrigg-dalkeith-mayfield-and-gorebridge",
+    "name": "Bonnyrigg, Dalkeith, Mayfield and Gorebridge",
+    "lat": 55.8709,
+    "lng": -3.0701,
+    "authorityId": 374,
+    "population": 54940
+  },
+  {
+    "slug": "loanhead-and-bilston",
+    "name": "Loanhead and Bilston",
+    "lat": 55.8771,
+    "lng": -3.1602,
+    "authorityId": 374,
+    "population": 8260
+  },
+  {
+    "slug": "penicuik",
+    "name": "Penicuik",
+    "lat": 55.8351,
+    "lng": -3.2193,
+    "authorityId": 374,
+    "population": 16150
+  },
+  {
+    "slug": "buckie",
+    "name": "Buckie",
+    "lat": 57.6738,
+    "lng": -2.9625,
+    "authorityId": 375,
+    "population": 9010
+  },
+  {
+    "slug": "elgin",
+    "name": "Elgin",
+    "lat": 57.6469,
+    "lng": -3.307,
+    "authorityId": 375,
+    "population": 25040
+  },
+  {
+    "slug": "forres",
+    "name": "Forres",
+    "lat": 57.6054,
+    "lng": -3.615,
+    "authorityId": 375,
+    "population": 9900
+  },
+  {
+    "slug": "lossiemouth",
+    "name": "Lossiemouth",
+    "lat": 57.7168,
+    "lng": -3.2911,
+    "authorityId": 375,
+    "population": 6840
+  },
+  {
+    "slug": "beith",
+    "name": "Beith",
+    "lat": 55.7501,
+    "lng": -4.6338,
+    "authorityId": 376,
+    "population": 5940
+  },
+  {
+    "slug": "dalry",
+    "name": "Dalry",
+    "lat": 55.7068,
+    "lng": -4.722,
+    "authorityId": 376,
+    "population": 5250
+  },
+  {
+    "slug": "irvine",
+    "name": "Irvine",
+    "lat": 55.6203,
+    "lng": -4.6474,
+    "authorityId": 376,
+    "population": 37580
+  },
+  {
+    "slug": "kilbirnie",
+    "name": "Kilbirnie",
+    "lat": 55.7531,
+    "lng": -4.6869,
+    "authorityId": 376,
+    "population": 7170
+  },
+  {
+    "slug": "kilwinning",
+    "name": "Kilwinning",
+    "lat": 55.6546,
+    "lng": -4.7046,
+    "authorityId": 376,
+    "population": 16100
+  },
+  {
+    "slug": "largs",
+    "name": "Largs",
+    "lat": 55.7969,
+    "lng": -4.8617,
+    "authorityId": 376,
+    "population": 11030
+  },
+  {
+    "slug": "saltcoats",
+    "name": "Saltcoats",
+    "lat": 55.6447,
+    "lng": -4.7815,
+    "authorityId": 376,
+    "population": 31800
+  },
+  {
+    "slug": "kirkwall",
+    "name": "Kirkwall",
+    "lat": 58.9796,
+    "lng": -2.9546,
+    "authorityId": 377,
+    "population": 7500
+  },
+  {
+    "slug": "auchterarder",
+    "name": "Auchterarder",
+    "lat": 56.2951,
+    "lng": -3.7097,
+    "authorityId": 378,
+    "population": 5840
+  },
+  {
+    "slug": "blairgowrie",
+    "name": "Blairgowrie",
+    "lat": 56.5883,
+    "lng": -3.3324,
+    "authorityId": 378,
+    "population": 9240
+  },
+  {
+    "slug": "crieff",
+    "name": "Crieff",
+    "lat": 56.3737,
+    "lng": -3.8378,
+    "authorityId": 378,
+    "population": 7280
+  },
+  {
+    "slug": "kinross",
+    "name": "Kinross",
+    "lat": 56.2102,
+    "lng": -3.4259,
+    "authorityId": 378,
+    "population": 5610
+  },
+  {
+    "slug": "perth",
+    "name": "Perth",
+    "lat": 56.3989,
+    "lng": -3.4519,
+    "authorityId": 378,
+    "population": 47350
+  },
+  {
+    "slug": "scone",
+    "name": "Scone",
+    "lat": 56.4201,
+    "lng": -3.4012,
+    "authorityId": 378,
+    "population": 5030
+  },
+  {
+    "slug": "galashiels",
+    "name": "Galashiels",
+    "lat": 55.6141,
+    "lng": -2.7951,
+    "authorityId": 379,
+    "population": 15490
+  },
+  {
+    "slug": "hawick",
+    "name": "Hawick",
+    "lat": 55.4271,
+    "lng": -2.7827,
+    "authorityId": 379,
+    "population": 13620
+  },
+  {
+    "slug": "kelso",
+    "name": "Kelso",
+    "lat": 55.6019,
+    "lng": -2.4306,
+    "authorityId": 379,
+    "population": 6870
+  },
+  {
+    "slug": "peebles",
+    "name": "Peebles",
+    "lat": 55.6501,
+    "lng": -3.1864,
+    "authorityId": 379,
+    "population": 9000
+  },
+  {
+    "slug": "selkirk",
+    "name": "Selkirk",
+    "lat": 55.5503,
+    "lng": -2.8394,
+    "authorityId": 379,
+    "population": 5380
+  },
+  {
+    "slug": "lerwick",
+    "name": "Lerwick",
+    "lat": 60.1514,
+    "lng": -1.1577,
+    "authorityId": 380,
+    "population": 6760
+  },
+  {
+    "slug": "ayr",
+    "name": "Ayr",
+    "lat": 55.4677,
+    "lng": -4.6141,
+    "authorityId": 381,
+    "population": 62270
+  },
+  {
+    "slug": "girvan",
+    "name": "Girvan",
+    "lat": 55.2373,
+    "lng": -4.8512,
+    "authorityId": 381,
+    "population": 6330
+  },
+  {
+    "slug": "troon",
+    "name": "Troon",
+    "lat": 55.5511,
+    "lng": -4.6476,
+    "authorityId": 381,
+    "population": 14950
+  },
+  {
+    "slug": "carluke",
+    "name": "Carluke",
+    "lat": 55.7317,
+    "lng": -3.832,
+    "authorityId": 382,
+    "population": 14400
+  },
+  {
+    "slug": "east-kilbride",
+    "name": "East Kilbride",
+    "lat": 55.759,
+    "lng": -4.1844,
+    "authorityId": 382,
+    "population": 75310
+  },
+  {
+    "slug": "hamilton",
+    "name": "Hamilton",
+    "lat": 55.7811,
+    "lng": -4.0682,
+    "authorityId": 382,
+    "population": 84450
+  },
+  {
+    "slug": "lanark-and-kirkfieldbank",
+    "name": "Lanark and Kirkfieldbank",
+    "lat": 55.675,
+    "lng": -3.7739,
+    "authorityId": 382,
+    "population": 9830
+  },
+  {
+    "slug": "larkhall",
+    "name": "Larkhall",
+    "lat": 55.7356,
+    "lng": -3.9652,
+    "authorityId": 382,
+    "population": 16400
+  },
+  {
+    "slug": "stonehouse",
+    "name": "Stonehouse",
+    "lat": 55.6933,
+    "lng": -3.9868,
+    "authorityId": 382,
+    "population": 5550
+  },
+  {
+    "slug": "strathaven",
+    "name": "Strathaven",
+    "lat": 55.6786,
+    "lng": -4.0659,
+    "authorityId": 382,
+    "population": 8090
+  },
+  {
+    "slug": "dunblane",
+    "name": "Dunblane",
+    "lat": 56.1903,
+    "lng": -3.9625,
+    "authorityId": 383,
+    "population": 9310
+  },
+  {
+    "slug": "stirling",
+    "name": "Stirling",
+    "lat": 56.1175,
+    "lng": -3.9353,
+    "authorityId": 383,
+    "population": 49950
+  },
+  {
+    "slug": "aberdeen-milltimber-and-peterculter",
+    "name": "Aberdeen, Milltimber, and Peterculter",
+    "lat": 57.1511,
+    "lng": -2.131,
+    "authorityId": 384,
+    "population": 220690
+  },
+  {
+    "slug": "banchory",
+    "name": "Banchory",
+    "lat": 57.0565,
+    "lng": -2.4887,
+    "authorityId": 385,
+    "population": 7440
+  },
+  {
+    "slug": "ellon",
+    "name": "Ellon",
+    "lat": 57.367,
+    "lng": -2.0775,
+    "authorityId": 385,
+    "population": 10070
+  },
+  {
+    "slug": "fraserburgh",
+    "name": "Fraserburgh",
+    "lat": 57.6865,
+    "lng": -2.018,
+    "authorityId": 385,
+    "population": 12570
+  },
+  {
+    "slug": "inverurie",
+    "name": "Inverurie",
+    "lat": 57.2873,
+    "lng": -2.3847,
+    "authorityId": 385,
+    "population": 14660
+  },
+  {
+    "slug": "peterhead",
+    "name": "Peterhead",
+    "lat": 57.5058,
+    "lng": -1.8012,
+    "authorityId": 385,
+    "population": 19060
+  },
+  {
+    "slug": "portlethen",
+    "name": "Portlethen",
+    "lat": 57.063,
+    "lng": -2.1341,
+    "authorityId": 385,
+    "population": 8940
+  },
+  {
+    "slug": "stonehaven",
+    "name": "Stonehaven",
+    "lat": 56.9662,
+    "lng": -2.2191,
+    "authorityId": 385,
+    "population": 11150
+  },
+  {
+    "slug": "westhill-aberdeenshire",
+    "name": "Westhill (Aberdeenshire)",
+    "lat": 57.1552,
+    "lng": -2.2934,
+    "authorityId": 385,
+    "population": 12110
+  },
+  {
+    "slug": "dunoon-and-sandbank",
+    "name": "Dunoon and Sandbank",
+    "lat": 55.9603,
+    "lng": -4.9254,
+    "authorityId": 386,
+    "population": 8980
+  },
+  {
+    "slug": "helensburgh",
+    "name": "Helensburgh",
+    "lat": 56.0083,
+    "lng": -4.7325,
+    "authorityId": 386,
+    "population": 15160
+  },
+  {
+    "slug": "oban",
+    "name": "Oban",
+    "lat": 56.4097,
+    "lng": -5.4695,
+    "authorityId": 386,
+    "population": 8140
+  },
+  {
+    "slug": "edinburgh",
+    "name": "Edinburgh",
+    "lat": 55.9423,
+    "lng": -3.2015,
+    "authorityId": 387,
+    "population": 530990
+  },
+  {
+    "slug": "kirkliston",
+    "name": "Kirkliston",
+    "lat": 55.9573,
+    "lng": -3.4048,
+    "authorityId": 387,
+    "population": 5280
+  },
+  {
+    "slug": "south-queensferry",
+    "name": "South Queensferry",
+    "lat": 55.9865,
+    "lng": -3.3967,
+    "authorityId": 387,
+    "population": 10400
+  },
+  {
+    "slug": "bishopton",
+    "name": "Bishopton",
+    "lat": 55.9071,
+    "lng": -4.5032,
+    "authorityId": 388,
+    "population": 7920
+  },
+  {
+    "slug": "erskine",
+    "name": "Erskine",
+    "lat": 55.8993,
+    "lng": -4.4489,
+    "authorityId": 388,
+    "population": 16830
+  },
+  {
+    "slug": "houston",
+    "name": "Houston",
+    "lat": 55.8619,
+    "lng": -4.5351,
+    "authorityId": 388,
+    "population": 6360
+  },
+  {
+    "slug": "dumbarton",
+    "name": "Dumbarton",
+    "lat": 55.9474,
+    "lng": -4.5604,
+    "authorityId": 389,
+    "population": 21030
+  },
+  {
+    "slug": "vale-of-leven",
+    "name": "Vale of Leven",
+    "lat": 55.9879,
+    "lng": -4.5721,
+    "authorityId": 389,
+    "population": 24130
+  },
+  {
+    "slug": "armadale",
+    "name": "Armadale",
+    "lat": 55.8958,
+    "lng": -3.6976,
+    "authorityId": 390,
+    "population": 12720
+  },
+  {
+    "slug": "bathgate",
+    "name": "Bathgate",
+    "lat": 55.8957,
+    "lng": -3.6287,
+    "authorityId": 390,
+    "population": 29330
+  },
+  {
+    "slug": "broxburn",
+    "name": "Broxburn",
+    "lat": 55.9331,
+    "lng": -3.4854,
+    "authorityId": 390,
+    "population": 15970
+  },
+  {
+    "slug": "east-calder",
+    "name": "East Calder",
+    "lat": 55.8931,
+    "lng": -3.4579,
+    "authorityId": 390,
+    "population": 6430
+  },
+  {
+    "slug": "linlithgow",
+    "name": "Linlithgow",
+    "lat": 55.9758,
+    "lng": -3.6029,
+    "authorityId": 390,
+    "population": 12840
+  },
+  {
+    "slug": "livingston",
+    "name": "Livingston",
+    "lat": 55.8895,
+    "lng": -3.5207,
+    "authorityId": 390,
+    "population": 65770
+  },
+  {
+    "slug": "whitburn",
+    "name": "Whitburn",
+    "lat": 55.8639,
+    "lng": -3.6842,
+    "authorityId": 390,
+    "population": 12730
+  },
+  {
+    "slug": "arbroath",
+    "name": "Arbroath",
+    "lat": 56.5643,
+    "lng": -2.5888,
+    "authorityId": 391,
+    "population": 23500
+  },
+  {
+    "slug": "brechin",
+    "name": "Brechin",
+    "lat": 56.7328,
+    "lng": -2.6543,
+    "authorityId": 391,
+    "population": 7230
+  },
+  {
+    "slug": "carnoustie",
+    "name": "Carnoustie",
+    "lat": 56.5023,
+    "lng": -2.7181,
+    "authorityId": 391,
+    "population": 11310
+  },
+  {
+    "slug": "forfar",
+    "name": "Forfar",
+    "lat": 56.6432,
+    "lng": -2.8853,
+    "authorityId": 391,
+    "population": 14120
+  },
+  {
+    "slug": "kirriemuir",
+    "name": "Kirriemuir",
+    "lat": 56.6755,
+    "lng": -3.0046,
+    "authorityId": 391,
+    "population": 6060
+  },
+  {
+    "slug": "montrose-ferryden-and-inchbraoch",
+    "name": "Montrose, Ferryden and Inchbraoch",
+    "lat": 56.7166,
+    "lng": -2.4648,
+    "authorityId": 391,
+    "population": 12950
+  },
+  {
+    "slug": "dundee",
+    "name": "Dundee",
+    "lat": 56.4764,
+    "lng": -2.9548,
+    "authorityId": 392,
+    "population": 158820
+  },
+  {
+    "slug": "coatbridge-airdrie-chapelhall-and-bargeddie",
+    "name": "Coatbridge, Airdrie, Chapelhall and Bargeddie",
+    "lat": 55.8593,
+    "lng": -4.0028,
+    "authorityId": 393,
+    "population": 90690
+  },
+  {
+    "slug": "cumbernauld-and-croy",
+    "name": "Cumbernauld and Croy",
+    "lat": 55.9494,
+    "lng": -3.9972,
+    "authorityId": 393,
+    "population": 52420
+  },
+  {
+    "slug": "kilsyth",
+    "name": "Kilsyth",
+    "lat": 55.9774,
+    "lng": -4.0565,
+    "authorityId": 393,
+    "population": 10380
+  },
+  {
+    "slug": "moodiesburn-and-chryston",
+    "name": "Moodiesburn and Chryston",
+    "lat": 55.9103,
+    "lng": -4.091,
+    "authorityId": 393,
+    "population": 11760
+  },
+  {
+    "slug": "motherwell-and-wishaw",
+    "name": "Motherwell and Wishaw",
+    "lat": 55.7971,
+    "lng": -3.9772,
+    "authorityId": 393,
+    "population": 125610
+  },
+  {
+    "slug": "shotts",
+    "name": "Shotts",
+    "lat": 55.82,
+    "lng": -3.7961,
+    "authorityId": 393,
+    "population": 8630
+  },
+  {
+    "slug": "kirkintilloch",
+    "name": "Kirkintilloch",
+    "lat": 55.9336,
+    "lng": -4.1416,
+    "authorityId": 394,
+    "population": 29960
+  },
+  {
+    "slug": "greater-glasgow",
+    "name": "Greater Glasgow",
+    "lat": 55.8537,
+    "lng": -4.2935,
+    "authorityId": 395,
+    "population": 1028220
+  },
+  {
     "slug": "holyhead",
     "name": "Holyhead",
     "lat": 53.3092,


### PR DESCRIPTION
## What

Adds Scotland to the committed town gazetteer (`web/src/data/towns.json`) from real National Records of Scotland (NRS) data, composed on top of the existing England-&-Wales + London gazetteer. Implements bead `tc-2avw.8` (epic `tc-2avw`, GH #585).

`web/scripts/generate-towns.mjs` gains a `parseNrsRow` / `parseNrsCentroidRow` / `buildScotland` path that consumes the NRS source schema and emits the SAME `{slug,name,lat,lng,authorityId,population}` record shape, reusing the existing `joinBua` (skip/log/dedupe/sort) and `combineRecords` (cross-region dedupe + stable sort). Wired into `main()` at the documented EXTENSION SEAM. **The E&W and London paths are untouched.**

## Provenance

**Sources (joined on the NRS settlement code, e.g. `S20001877`):**

- **Population + council area** — NRS *"Population estimates for settlements and localities in Scotland, mid-2020"* (`data-tables.xlsx`, https://www.nrscotland.gov.uk/media/wtwjdfuo/data-tables.xlsx):
  - **Table 2.1** "Population Estimates of Settlements by Sex and Broad Age Group" → settlement name, settlement code, and the **All-ages** population (one row per settlement).
  - **Table 1.1** "Settlements by Locality and Council Area" → settlement code → council-area name.
- **Centroids (lat/lng)** — NRS `SettlementCentroids` WFS layer (`https://maps.gov.scot/server/services/NRS/NRS/MapServer/WFSServer`, typeName `NRS:SettlementCentroids`), giving each settlement code a WGS84 lat/lng plus a BNG easting/northing (BNG fallback via `bngToLatLon`).

**Join key:** the NRS settlement code (`S2000....`), shared by all three sources. The centroid file joined 514/514 settlements with zero misses.

**Council → authorityId:** the NRS council-area name resolves against the existing `api-go/internal/geocoding/authority-mapping.json`. All **32** Scottish council names in Table 1.1 match the mapping spellings **verbatim** — no remapping needed.

**Multi-council settlements (6):** six settlements straddle more than one council (Dundee, Edinburgh, Greater Glasgow, Harthill, Kelty, Liff). Locality-population heuristics are unreliable for these (split localities are double-counted), so each was resolved to the single council **containing the settlement centroid** — a point-in-polygon query against the official ScotGov `ScottishLocalAuthorities` boundaries (`ScotGov/AdministrativeElectoral/MapServer/2`). Results: Dundee→Dundee City, Edinburgh→City of Edinburgh, Greater Glasgow→Glasgow City, Harthill→North Lanarkshire, Kelty→Fife, Liff→Dundee City. The generator itself never guesses — an unresolved council is left blank and skipped+logged.

## Counts

- 514 NRS settlements → **122** with population ≥ 5,000 (the gazetteer floor); **33** are ≥ 20,000 (the `SEO_TOWN_MIN_POPULATION` publish threshold).
- **Skip summary (Scotland):** 392 `below-floor` only. Zero `no-centroid`, zero `unmatched-authority`.
- **Total gazetteer:** 1,428 → **1,550** rows (+122 Scotland).

## The 1,428 prior rows are byte-preserved

Built ONLY the Scotland records from the NRS sources and `combineRecords([...existing, ...scotland])`. Verified: `git diff` is **976 insertions, 0 deletions**; every one of the 1,428 original E&W+London rows is byte-identical (0 missing, 0 changed). Scotland rows slot into authorityId-sorted position.

Spot-checks vs published NRS mid-2020 figures: Greater Glasgow 1,028,220 (Glasgow City); Edinburgh 530,990 (City of Edinburgh); Aberdeen, Milltimber, and Peterculter 220,690 (Aberdeen City); Dundee 158,820 (Dundee City); Inverness and Culloden 63,730 (Highland). All coordinates fall in Scotland (lat ~55.7–57.5, lng ~-2.1 to -4.3).

## Tests

Extended `web/scripts/lib/__tests__/generate-towns.test.mjs` with hand-written fixtures (no mocking libs) covering `parseNrsRow`, `parseNrsCentroidRow`, and `buildScotland`: matched settlement → record with right authorityId+population; name↔code join; multi-council pre-resolved settlement; below-5k skip; blank/unresolved council skip; no-centroid skip; BNG→WGS84 fallback; Scotland bounding-box.

- `npx vitest run` — **862 tests pass** (102 files), including the new 56 in the generator suite.
- `npm run build` — passes.
- `eslint` — clean.

Raw NRS downloads (XLSX/GeoJSON/CSV) were kept entirely out of git; only `towns.json` + the generator + tests are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013xL4oCpLWWGhqV6fmsfEXy