### PR TITLE
ci: rewire seo-refresh to write SEO snapshot to Blob (fetch→upload→render→deploy) (tc-w5w9.8)

### DIFF
--- a/.github/workflows/seo-refresh.yml
+++ b/.github/workflows/seo-refresh.yml
@@ -1,22 +1,33 @@
-# Weekly refresh of the baked SEO pages for BOTH dev and prod web.
+# Weekly refresh of the SEO snapshot for BOTH dev and prod web.
 #
-# The programmatic SEO pages (authority-level AND per-town) are statically
-# prerendered at build time (the prerender step is wired into `npm run build`
-# via build-web, pulling fresh applications from the gated API using
-# SITE_BUILD_KEY). A normal CD deploy only happens on push (dev) or tag (prod),
-# so without this job the baked data would go stale. This workflow redeploys the
-# web as a *data-only* refresh — no code change — for both environments.
+# This job is the SOLE caller of the gated Go API for the programmatic SEO pages
+# (authority-level AND per-town), plus sitemap.xml (epic tc-w5w9 / GH #598). It
+# decouples *data fetching* (weekly, against the API) from *page rendering*
+# (every build, offline) so that normal CD releases (cd-dev on push, cd-prod on
+# tag) make ZERO Go API / Cosmos calls. The per-build render reads the snapshot
+# this job produces.
 #
-# Cadence is a WEEKLY FULL rebuild — every run builds the complete set of
-# authority AND town pages together, emits one combined sitemap, and ships it as
-# a full-replace SWA deploy (owner decision, GH #585, tc-2avw.6). We deliberately
-# do NOT run a more frequent authority-only refresh: a full-replace deploy with a
-# single combined sitemap would silently drop all town pages if only authorities
-# were rebuilt. Building everything together every week keeps the sitemap ≡ the
-# live page set by construction. The build cost is negligible (~£0.10/run, see
-# GH #585), so there is no benefit to sharding. A normal code deploy (cd-dev on
-# push, cd-prod on tag) still rebuilds everything immediately. Accepted trade-off:
-# authority-page data refreshes weekly rather than nightly.
+# Per environment, each job runs the following flow:
+#   1. Build the SPA only (build-web with an EMPTY site-build-key, so the
+#      build-time prerender step skips — produces an SPA-only web/dist).
+#   2. Azure OIDC login.
+#   3. FETCH: `prerender-planning.mjs --fetch` calls the gated Go API for all
+#      authorities + population-eligible towns and writes web/seo-snapshot.json.
+#      This is the ONLY Go API call in the whole pipeline.
+#   4. UPLOAD: push seo-snapshot.json to the environment's Azure Blob container
+#      (seo-snapshot/seo-snapshot.json). The storage account has shared-key
+#      access DISABLED, so blob I/O uses `--auth-mode login` (AAD/RBAC); the CI
+#      OIDC identity holds Storage Blob Data Contributor.
+#   5. RENDER: `prerender-planning.mjs --render` reads seo-snapshot.json and
+#      writes /planning/* + sitemap.xml into web/dist with ZERO network calls.
+#   6. DEPLOY: full-replace SWA upload of web/dist.
+#
+# Cadence is a WEEKLY FULL rebuild — every run fetches the complete authority AND
+# town set, emits one combined sitemap, and ships it as a full-replace SWA deploy
+# (owner decision, GH #585, tc-2avw.6). Building everything together every week
+# keeps the sitemap ≡ the live page set by construction. The snapshot it writes
+# is then re-used (rendered offline) by every CD release until the next weekly
+# run, so page data is at most ~1 week stale — acceptable for SEO pages.
 #
 # Deploying prod on a schedule is a deliberate exception to the tag-triggered
 # prod convention (see GH #570, tc-nnte.6), accepted so prod SEO pages stay fresh.
@@ -25,12 +36,13 @@
 #   AZURE_CLIENT_ID        — OIDC federated credential for Azure login
 #   AZURE_TENANT_ID        — Azure AD tenant
 #   AZURE_SUBSCRIPTION_ID  — Azure subscription
-#   SITE_BUILD_KEY         — build-key that gates the recent-applications API used by the prerender
+#   SITE_BUILD_KEY         — build-key that gates the recent-applications API used by --fetch
 #   GITHUB_TOKEN           — provided automatically; used by static-web-apps-deploy
 #
 # Requires per-environment GitHub variables (vars.*):
 #   VITE_API_BASE_URL, VITE_AUTH0_DOMAIN, VITE_AUTH0_CLIENT_ID,
-#   VITE_AUTH0_AUDIENCE, VITE_APPLICATIONINSIGHTS_CONNECTION_STRING
+#   VITE_AUTH0_AUDIENCE, VITE_APPLICATIONINSIGHTS_CONNECTION_STRING,
+#   SEO_TOWN_MIN_POPULATION (optional; defaults to 20000)
 #
 # Requires GitHub Environments:
 #   development, production  — each with an OIDC federated credential. The
@@ -59,15 +71,15 @@ jobs:
   web-dev:
     name: "Web: Weekly refresh dev"
     runs-on: ubuntu-latest
-    # 30 min: a full rebuild prerenders the complete authority + town set, and the
-    # prerender fetches serially (~410 authorities + several hundred towns, two
-    # bounded Cosmos reads each), so the build runs much longer than the old
-    # authority-only refresh.
+    # 30 min: --fetch gathers the complete authority + town set serially (~410
+    # authorities + several hundred towns, two bounded Cosmos reads each), so this
+    # is the long pole; the offline --render is fast.
     timeout-minutes: 30
     environment: development
     steps:
       - uses: actions/checkout@v6
 
+      # SPA only — empty site-build-key skips the build-time prerender.
       - uses: ./.github/actions/build-web
         with:
           vite-api-base-url: ${{ vars.VITE_API_BASE_URL }}
@@ -75,7 +87,7 @@ jobs:
           vite-auth0-client-id: ${{ vars.VITE_AUTH0_CLIENT_ID }}
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
-          site-build-key: ${{ secrets.SITE_BUILD_KEY }}
+          site-build-key: ""
           seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
 
       - uses: ./.github/actions/azure-login
@@ -83,6 +95,31 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # The ONLY Go API call in the pipeline: write web/seo-snapshot.json.
+      - name: Fetch SEO snapshot from the API
+        working-directory: web
+        run: node scripts/prerender-planning.mjs --fetch
+        env:
+          SITE_BUILD_KEY: ${{ secrets.SITE_BUILD_KEY }}
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+          SEO_TOWN_MIN_POPULATION: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
+
+      # Shared-key access is disabled on the account, so --auth-mode login (AAD).
+      - name: Upload snapshot to Azure Blob
+        run: |
+          az storage blob upload \
+            --auth-mode login \
+            --account-name sttowncrierdev \
+            --container-name seo-snapshot \
+            --name seo-snapshot.json \
+            --file web/seo-snapshot.json \
+            --overwrite
+
+      # Offline render of /planning/* + sitemap.xml into web/dist (zero network).
+      - name: Render SEO pages from the snapshot
+        working-directory: web
+        run: node scripts/prerender-planning.mjs --render
 
       - name: Get SWA deployment token
         id: swa-token
@@ -101,17 +138,19 @@ jobs:
           skip_api_build: true
 
   # ── Web: weekly full refresh prod ───────────────────────
-  # No infra job here, so swa-name is hardcoded (cd-prod reads it from a
-  # Pulumi output; this data-only refresh has no Pulumi step).
+  # No infra job here, so swa-name and the storage account name are hardcoded
+  # (cd-prod reads these from Pulumi outputs; this data-only refresh has no
+  # Pulumi step). Names match infra/environment.go.
   web-prod:
     name: "Web: Weekly refresh prod"
     runs-on: ubuntu-latest
-    # 30 min: full authority + town rebuild (see web-dev for the rationale).
+    # 30 min: full authority + town --fetch (see web-dev for the rationale).
     timeout-minutes: 30
     environment: production
     steps:
       - uses: actions/checkout@v6
 
+      # SPA only — empty site-build-key skips the build-time prerender.
       - uses: ./.github/actions/build-web
         with:
           vite-api-base-url: ${{ vars.VITE_API_BASE_URL }}
@@ -119,7 +158,7 @@ jobs:
           vite-auth0-client-id: ${{ vars.VITE_AUTH0_CLIENT_ID }}
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
-          site-build-key: ${{ secrets.SITE_BUILD_KEY }}
+          site-build-key: ""
           seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
 
       - uses: ./.github/actions/azure-login
@@ -127,6 +166,31 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # The ONLY Go API call in the pipeline: write web/seo-snapshot.json.
+      - name: Fetch SEO snapshot from the API
+        working-directory: web
+        run: node scripts/prerender-planning.mjs --fetch
+        env:
+          SITE_BUILD_KEY: ${{ secrets.SITE_BUILD_KEY }}
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+          SEO_TOWN_MIN_POPULATION: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
+
+      # Shared-key access is disabled on the account, so --auth-mode login (AAD).
+      - name: Upload snapshot to Azure Blob
+        run: |
+          az storage blob upload \
+            --auth-mode login \
+            --account-name sttowncrierprod \
+            --container-name seo-snapshot \
+            --name seo-snapshot.json \
+            --file web/seo-snapshot.json \
+            --overwrite
+
+      # Offline render of /planning/* + sitemap.xml into web/dist (zero network).
+      - name: Render SEO pages from the snapshot
+        working-directory: web
+        run: node scripts/prerender-planning.mjs --render
 
       - name: Get SWA deployment token
         id: swa-token


### PR DESCRIPTION
Part of epic **tc-w5w9** / GH #598 (Phase 3 — weekly job writes the snapshot).

## What
Rewires both jobs in `seo-refresh.yml` (weekly, dev + prod) from "live-prerender at build time" to the blob-snapshot flow. Each job now:
1. Builds the **SPA only** (`build-web` with an empty `site-build-key`, so the build-time prerender skips).
2. Azure OIDC login.
3. **`--fetch`** — `node scripts/prerender-planning.mjs --fetch` calls the gated Go API for all authorities + eligible towns and writes `web/seo-snapshot.json`. **This is the sole Go API caller.**
4. **Upload** — `az storage blob upload --auth-mode login` to `seo-snapshot/seo-snapshot.json` (shared-key access is disabled on the account → AAD/RBAC only; CI SP holds Storage Blob Data Contributor from #599). Account hardcoded per-env (`sttowncrierdev`/`sttowncrierprod`) matching infra + the existing `swa-name` hardcoding convention.
5. **`--render`** — offline render of `/planning/*` + `sitemap.xml` into `web/dist`, zero network.
6. Deploy to SWA (unchanged).

The snapshot it writes is re-used (rendered offline) by every CD release until the next weekly run, so page data is ≤1 week stale.

## Preserved
Schedule (Mon 04:00 UTC) + `workflow_dispatch`, concurrency group, `id-token: write`, per-job `environment:`, the 30-min timeout. Header comment rewritten to describe the new flow.

## Validation
`actionlint` clean; YAML parses. Only `.github/workflows/seo-refresh.yml` changed.

## Note
This new flow is only exercised on dispatch/schedule (not on the PR). After merge — once the storage account exists (cd-dev/#599) — I'll dispatch `seo-refresh` (dev) to seed the blob and validate end-to-end before the `.10` cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)