### PR TITLE
docs: correct bd DB-maintenance guidance (CLAUDE.md + release skill)

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -111,6 +111,13 @@ After creation, report the release URL to the user.
 
 If there are any open beads that were completed by the released commits, offer to close them. Then run `bd dolt push` to sync beads state.
 
+**Bead DB cleanup (a release is a natural checkpoint).** Check size with `bd stats`. If **total issues exceed ~1000** (or `bd` commands feel sluggish), compact the DB before finishing:
+
+- **`bd flatten --force`** — squash Dolt commit history (server mode writes one commit per write via `dolt.auto-commit: on`). Main speed lever + reclaims disk + runs Dolt GC. Prefer over `bd compact`, whose commit-squash can fail with a Dolt constraint violation on a churned DB. After flatten, the next `bd dolt push` may need `--force` (rewritten history).
+- **`bd admin compact`** — semantic decay of old closed issues, run ~quarterly. Agent-driven, no API key: `bd compact --analyze --json` → write summaries → `bd compact --apply --id <id> --summary -`.
+
+The Dolt DB is the source of truth — never hand-edit `.beads/issues.jsonl` to "clean up"; `bd` regenerates it and the edits get clobbered.
+
 ### Step 7: Close resolved GitHub issues
 
 Sweep open GitHub issues whose linked beads are all closed, and close them with a pointer to the release. The `bead-created` label (added by the `triage-inbox` skill) marks issues that have been converted into beads; the linkage lives in a triage comment of the form `Triaged → bead **tc-xxxx**` (and optionally `, child tasks: tc-aaaa, tc-bbbb`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,7 +211,16 @@ A PreToolUse hook (`.claude/require-worktree.sh`) enforces this — Write/Edit o
 
 ### Cleanup Discipline
 
-Keep the working set under ~200 issues. Run `bd cleanup` regularly and compact closed issues with `bd compact`.
+Keep the working set (open + in-progress) under ~200 issues.
+
+**The Dolt DB is the source of truth.** `.beads/issues.jsonl` is a derived export for git/viewers — **never hand-edit it**; `bd` regenerates it from the DB and your edits get clobbered. Backups are `bd dolt push` / `bd backup`, not jsonl. (There is no `bd cleanup` command.)
+
+Server mode writes one Dolt commit per write (`dolt.auto-commit: on`), so history bloats over time. Maintenance:
+
+- **`bd flatten --force`** — squash Dolt commit history when `bd` commands get sluggish or the commit count is high. Main speed lever (took us 5405 commits → 1, ~3.5s → 0.15s per command). Prefer it over `bd compact`, whose commit-squash can fail with a Dolt constraint violation on a churned DB. Both run Dolt GC.
+- **`bd admin compact`** — semantic "memory decay" of old closed issues. Agent-driven, no API key: `bd compact --analyze --json` → write summaries → `bd compact --apply --id <id> --summary -`. Run ~quarterly at our size (≈900+ closed).
+
+Stay on **stable** bd releases (1.0.4); do not upgrade to pre-releases (1.0.5's schema migration corrupts this DB).
 
 ## CLI-First Policy
 


### PR DESCRIPTION
## Changes
- **CLAUDE.md → Cleanup Discipline**: drop the non-existent `bd cleanup` command. Document that the Dolt DB is the source of truth (never hand-edit `.beads/issues.jsonl`), the real maintenance commands (`bd flatten` for commit-history/speed, `bd admin compact` for semantic decay of old closed issues), and stable-release pinning (avoid the 1.0.5 pre-release).
- **release skill → Step 6 (Sync beads)**: add a bead-DB cleanup checkpoint — when `bd stats` total issues exceed ~1000, run `bd flatten --force` (+ quarterly `bd admin compact`), with the `bd dolt push --force` caveat after a flatten.

Both reflect upstream `gastownhall/beads` guidance (embedded vs server modes, jsonl-is-derived, semantic compaction cadence by size).

tc-hahg

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on system maintenance procedures and best practices for database health management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->