### PR TITLE
ci: cut cd-prod web build over to render-mode from Blob snapshot (tc-so05)

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -193,6 +193,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # azure-login MUST run before build-web: in render-mode, build-web
+      # downloads the weekly seo-snapshot.json from Azure Blob via `az storage
+      # blob download --auth-mode login`, which needs the OIDC session.
+      - uses: ./.github/actions/azure-login
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      # render-mode: build the SPA, download the weekly snapshot, render
+      # /planning/* + sitemap.xml offline — zero Go API / Cosmos calls.
+      # Fails loud if the snapshot blob is missing (no live-fetch fallback).
       - uses: ./.github/actions/build-web
         with:
           vite-api-base-url: ${{ vars.VITE_API_BASE_URL }}
@@ -200,14 +212,9 @@ jobs:
           vite-auth0-client-id: ${{ vars.VITE_AUTH0_CLIENT_ID }}
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
-          site-build-key: ${{ secrets.SITE_BUILD_KEY }}
           seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
-
-      - uses: ./.github/actions/azure-login
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          render-mode: 'true'
+          storage-account-name: sttowncrierprod
 
       - name: Get SWA deployment token
         id: swa-token


### PR DESCRIPTION
## What

Flips the **cd-prod** web build to render-mode, mirroring PR #604 (the dev flip) but pointing at `sttowncrierprod`:

- move `azure-login` **before** `build-web` (render-mode downloads the snapshot blob via the OIDC session)
- drop `site-build-key` (no more build-time Go API prerender)
- add `render-mode: 'true'` + `storage-account-name: sttowncrierprod`

## Why

Completes the prod half of epic **tc-w5w9 / #598** (ADR 0031). After this, cd-prod releases render `/planning/*` + `sitemap.xml` offline from the weekly Blob snapshot — **zero Go API / Cosmos calls per release** (previously ~1,900 serial gated API calls per prod tag). The weekly `seo-refresh` becomes the sole API reader for SEO.

## Bootstrap order (tc-so05's "seed before cutover" rule)

1. Prod storage `sttowncrierprod` + container + CI blob RBAC — created by the v0.15.33 release. ✅
2. Prod blob seeded — `seo-refresh environment=prod` dispatch (run 27979192309). ✅ (verified before merge)
3. This flip — takes effect on the **next prod release**; render-mode fails loud if the snapshot is missing, hence the seed must land first.

Closes tc-so05.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the production deployment workflow to optimize the build process. Changes include reordering authentication steps and adjusting build configuration parameters to improve artifact retrieval during deployment. These updates enhance the reliability of the production release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->