### PR TITLE
fix(web): mirror iOS postcode + privacy copy clarifications on web & legal (tc-n0u6, tc-l1di)

### DIFF
--- a/api-go/internal/legal/resources/privacy.json
+++ b/api-go/internal/legal/resources/privacy.json
@@ -1,7 +1,7 @@
 {
   "documentType": "privacy",
   "title": "Privacy Policy",
-  "lastUpdated": "2026-06-15",
+  "lastUpdated": "2026-06-18",
   "sections": [
     {
       "heading": "Who We Are",
@@ -9,7 +9,7 @@
     },
     {
       "heading": "What We Collect",
-      "body": "We keep the collection small. We store your email address (from sign-in), a unique user ID, and the notification preferences you choose. For each area you want to watch we store a label, coordinates, and a radius, not your exact address. We keep a short-lived history of the alerts we've sent you (new applications and decisions), and a list of the applications you've saved for later. If you subscribe we store an Apple App Store transaction ID so we know your tier; we never see your payment details. If you redeem an offer code, we record which code you redeemed and when. On iOS we store a push token so we can deliver notifications to your device."
+      "body": "We keep the collection small. We store a unique user ID and the notification preferences you choose. If your sign-in shares an email address, we store it so we can send you email alerts and digests. Sign in with Apple lets you hide your email; if you do, we never store your real email address. For each area you want to watch we store a label, coordinates, and a radius, not your exact address. We keep a short-lived history of the alerts we've sent you (new applications and decisions), and a list of the applications you've saved for later. If you subscribe we store an Apple App Store transaction ID so we know your tier; we never see your payment details. If you redeem an offer code, we record which code you redeemed and when. On iOS we store a push token so we can deliver notifications to your device."
     },
     {
       "heading": "Why We Collect It",

--- a/mobile/ios/packages/town-crier-presentation/Sources/Resources/legal/privacy.json
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Resources/legal/privacy.json
@@ -1,7 +1,7 @@
 {
   "documentType": "privacy",
   "title": "Privacy Policy",
-  "lastUpdated": "2026-06-15",
+  "lastUpdated": "2026-06-18",
   "sections": [
     {
       "heading": "Who We Are",
@@ -9,7 +9,7 @@
     },
     {
       "heading": "What We Collect",
-      "body": "We keep the collection small. We store your email address (from sign-in), a unique user ID, and the notification preferences you choose. For each area you want to watch we store a label, coordinates, and a radius, not your exact address. We keep a short-lived history of the alerts we've sent you (new applications and decisions), and a list of the applications you've saved for later. If you subscribe we store an Apple App Store transaction ID so we know your tier; we never see your payment details. If you redeem an offer code, we record which code you redeemed and when. On iOS we store a push token so we can deliver notifications to your device."
+      "body": "We keep the collection small. We store a unique user ID and the notification preferences you choose. If your sign-in shares an email address, we store it so we can send you email alerts and digests. Sign in with Apple lets you hide your email; if you do, we never store your real email address. For each area you want to watch we store a label, coordinates, and a radius, not your exact address. We keep a short-lived history of the alerts we've sent you (new applications and decisions), and a list of the applications you've saved for later. If you subscribe we store an Apple App Store transaction ID so we know your tier; we never see your payment details. If you redeem an offer code, we record which code you redeemed and when. On iOS we store a push token so we can deliver notifications to your device."
     },
     {
       "heading": "Why We Collect It",

--- a/web/src/components/HowItWorks/HowItWorks.tsx
+++ b/web/src/components/HowItWorks/HowItWorks.tsx
@@ -11,7 +11,7 @@ const STEPS: Step[] = [
     icon: '📍',
     title: 'Enter your postcode',
     description:
-      'Tell us where you live or work. We use your postcode to find the local authority that handles planning in your area.',
+      "Pick any postcode you care about. It doesn't have to be where you live or work, and we never use your phone's location. We use it to find the local authority that handles planning in that area.",
   },
   {
     icon: '🔭',


### PR DESCRIPTION
## What

Brings the **web** and **privacy-policy** copy in line with the postcode clarification already shipped on **iOS** (tc-rae0, live since v0.15.26). Two small, complete copy changes that were sitting unmerged:

- **`web/src/components/HowItWorks/HowItWorks.tsx`** (tc-n0u6) — the "Enter your postcode" step now says you can pick *any* postcode you care about (not just home/work) and that we never use the phone's location.
- **`privacy.json`** — api-go canonical + iOS mirror (tc-l1di) — "What We Collect" now states email is optional and that **Sign in with Apple lets you hide your email** (in which case we never store a real email). Bumps `lastUpdated` to 2026-06-18.

## Why

- The web "How it works" copy still implied the postcode had to be where you live/work — inconsistent with what iOS onboarding already tells users.
- The live privacy policy asserted *"We store your email address (from sign-in)"*, which is **inaccurate for Sign in with Apple users** (who often arrive with no email). This corrects it.

## Notes

- Both `privacy.json` copies updated identically — `scripts/check-legal-drift.sh` passes locally ("legal docs in sync").
- Web-only + legal copy; no iOS app-behaviour change, so no `Release-Note:` trailer (conventional titles satisfy the iOS PR guard).

Closes tc-n0u6, tc-l1di.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated privacy policy across all platforms to clarify data collection practices, specifying that the app stores email address, unique user ID, and notification preferences
  * Refreshed "How It Works" instructional text with improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->