### PR TITLE
feat(profiles): enforce lazy subscription expiry on entitlement reads (tc-rlja.1)

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -112,7 +112,7 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 	var dispatch http.Handler = mux
 	if store != nil {
 		profiles.Routes(mux, store, auth0, proDomains, cascade, exportReaders, time.Now, logger)
-		dispatch = middleware.RateLimit(middleware.NewRateLimitStore(), profiles.NewTierLookup(store), logger)(
+		dispatch = middleware.RateLimit(middleware.NewRateLimitStore(), profiles.NewTierLookup(store, time.Now), logger)(
 			middleware.RecordActivity(profiles.NewActivityRecorder(store), time.Now, logger)(mux),
 		)
 	}

--- a/api-go/internal/digest/handler.go
+++ b/api-go/internal/digest/handler.go
@@ -130,7 +130,9 @@ func (h *Handler) RunWeekly(ctx context.Context) error {
 	}
 
 	for _, profile := range users {
-		wantsPush := profile.Tier.IsPaidPro() && profile.Preferences.PushEnabled
+		// The weekly push is Pro-only; a lapsed paid tier (EffectiveTier) reads as
+		// Free and gets the email but no push.
+		wantsPush := profile.EffectiveTier(now).IsPaidPro() && profile.Preferences.PushEnabled
 		wantsEmail := profile.Preferences.EmailDigestEnabled && profile.Email != nil && *profile.Email != ""
 		if !wantsPush && !wantsEmail {
 			continue
@@ -218,6 +220,7 @@ func (h *Handler) sendWeeklyPush(ctx context.Context, profile *profiles.UserProf
 // disabled) notifications are left unsent so the weekly digest can still pick them
 // up.
 func (h *Handler) RunHourly(ctx context.Context) error {
+	now := h.now()
 	userIDs, err := h.notifications.UserIDsWithUnsentEmails(ctx)
 	if err != nil {
 		return err
@@ -233,8 +236,9 @@ func (h *Handler) RunHourly(ctx context.Context) error {
 			continue
 		}
 		// Hourly digest emails are a paid entitlement (server-enforced) — Free tier
-		// is excluded even when email digests are enabled.
-		if !profile.Tier.HasHourlyDigestEntitlement() {
+		// is excluded even when email digests are enabled. A lapsed paid tier reads
+		// as Free via EffectiveTier and is excluded too.
+		if !profile.EffectiveTier(now).HasHourlyDigestEntitlement() {
 			continue
 		}
 		if profile.Email == nil || *profile.Email == "" {

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -320,6 +320,37 @@ func TestRunWeekly_ProTierGetsPushWithBadgeAndPrunesInvalidTokens(t *testing.T) 
 	}
 }
 
+func TestRunWeekly_ExpiredProTierGetsNoPush(t *testing.T) {
+	t.Parallel()
+	// A Pro tier whose subscription has lapsed (past expiry, no grace) reads as
+	// Free: the weekly digest PUSH is Pro-only, so no push fires even though push
+	// is enabled and there are notifications.
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = false
+	prefs.PushEnabled = true
+	p := mkProfile(t, profiles.TierPro, prefs)
+	past := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // before the harness clock (2026-02-04)
+	p.SubscriptionExpiry = &past
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
+		"user-1": {zoneNotif("uid-A", "zone-1")},
+	}}
+	devices := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
+		"user-1": {{UserID: "user-1", Token: "tok-1", Platform: devicetokens.PlatformIos}},
+	}}
+	email := &spyEmail{}
+	push := &spyPush{}
+	h := newHandler(fp, fn, &fakeZones{}, &fakeState{}, devices, email, push)
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+	if push.calls != 0 {
+		t.Errorf("lapsed Pro tier must NOT get a digest push: got %d push calls", push.calls)
+	}
+}
+
 func TestRunWeekly_SkipsUsersWithNoNotifications(t *testing.T) {
 	t.Parallel()
 	prefs := profiles.DefaultPreferences()
@@ -437,6 +468,38 @@ func TestRunHourly_FreeTierSkipped(t *testing.T) {
 	}
 	if len(fn.marked) != 0 {
 		t.Errorf("free tier skip must not mark anything sent: got %v", fn.marked)
+	}
+}
+
+func TestRunHourly_ExpiredPaidTierSkipped(t *testing.T) {
+	t.Parallel()
+	// A paid tier whose subscription has lapsed (past expiry, no grace) reads as
+	// Free, so it has no HourlyDigestEmails entitlement — hourly is paid-only.
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = true
+	p := mkProfile(t, profiles.TierPro, prefs)
+	past := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // before the harness clock (2026-02-04)
+	p.SubscriptionExpiry = &past
+
+	fp := &fakeProfiles{byID: map[string]*profiles.UserProfile{"user-1": p}}
+	fn := &fakeNotifications{
+		unsentUserIDs: []string{"user-1"},
+		unsentByUser:  map[string][]notifications.DigestNotification{"user-1": {zoneNotif("uid-A", "zone-1")}},
+	}
+	fz := &fakeZones{byUser: map[string][]watchzones.WatchZone{
+		"user-1": {mkZone(t, "zone-1", "Home", true)},
+	}}
+	email := &spyEmail{}
+	h := newHandler(fp, fn, fz, &fakeState{}, &fakeDevices{}, email, &spyPush{})
+
+	if err := h.RunHourly(context.Background()); err != nil {
+		t.Fatalf("RunHourly: %v", err)
+	}
+	if len(email.sent) != 0 {
+		t.Errorf("lapsed paid tier must NOT get an hourly email: got %d", len(email.sent))
+	}
+	if len(fn.marked) != 0 {
+		t.Errorf("lapsed paid tier skip must not mark anything sent: got %v", fn.marked)
 	}
 }
 

--- a/api-go/internal/notifydispatch/decision.go
+++ b/api-go/internal/notifydispatch/decision.go
@@ -190,7 +190,9 @@ func (d *DecisionDispatcher) dispatchForUser(ctx context.Context, app applicatio
 // canPush OR-merges the per-channel decision-push toggles across the matching
 // sources, gated on the paid tier and the global push preference.
 func (d *DecisionDispatcher) canPush(profile *profiles.UserProfile, m *userMatch) bool {
-	if !profile.Tier.IsPaid() || !profile.Preferences.PushEnabled {
+	// A paid tier whose subscription has lapsed (EffectiveTier) reads as Free and
+	// is not entitled to an instant push.
+	if !profile.EffectiveTier(d.now()).IsPaid() || !profile.Preferences.PushEnabled {
 		return false
 	}
 	zonePushOptIn := m.zone && m.watchZoneID != nil && profile.ZonePreferences[*m.watchZoneID].DecisionPush

--- a/api-go/internal/notifydispatch/decision_test.go
+++ b/api-go/internal/notifydispatch/decision_test.go
@@ -170,6 +170,30 @@ func TestDecisionDispatcher_FreeTier_RecordNoPush(t *testing.T) {
 	}
 }
 
+func TestDecisionDispatcher_ExpiredPaidTier_RecordNoPush(t *testing.T) {
+	t.Parallel()
+	// A Pro user opted into decision push, but whose subscription has lapsed (past
+	// expiry, no grace), reads as Free: the record is written but no push fires.
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	lapsed := proWithZonePrefs(t, true)
+	past := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC) // before the harness clock
+	lapsed.SubscriptionExpiry = &past
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": lapsed}}
+	d, notifs, push := newDecisionHarness(t, zones, &fakeSaved{}, profs)
+	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
+
+	if err := d.Dispatch(context.Background(), app); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Errorf("lapsed paid tier must still get the decision record, got %d", len(notifs.created))
+	}
+	if push.calls != 0 {
+		t.Errorf("lapsed paid tier must NOT push, got %d", push.calls)
+	}
+}
+
 func TestDecisionDispatcher_SavedOnly_NilZoneSourcesSaved(t *testing.T) {
 	t.Parallel()
 	zones := &fakeZones{}

--- a/api-go/internal/notifydispatch/enqueuer.go
+++ b/api-go/internal/notifydispatch/enqueuer.go
@@ -188,9 +188,10 @@ func (e *Enqueuer) Enqueue(ctx context.Context, app applications.PlanningApplica
 		now:         e.now().UTC(),
 	})
 
-	// Instant push is a paid-tier entitlement. Free-tier users still get the
+	// Instant push is a paid-tier entitlement. Free-tier users — including a paid
+	// tier whose subscription has lapsed (EffectiveTier) — still get the
 	// notification record (picked up by the weekly digest) but no push.
-	if profile.Tier.IsPaid() && profile.Preferences.PushEnabled {
+	if profile.EffectiveTier(e.now()).IsPaid() && profile.Preferences.PushEnabled {
 		n.PushSent = sendInstantPush(ctx, instantPushDeps{
 			devices: e.devices,
 			state:   e.state,

--- a/api-go/internal/notifydispatch/enqueuer_test.go
+++ b/api-go/internal/notifydispatch/enqueuer_test.go
@@ -312,6 +312,37 @@ func TestEnqueuer_FreeTier_CreatesRecordNoPush(t *testing.T) {
 	}
 }
 
+func TestEnqueuer_ExpiredPaidTier_CreatesRecordNoPush(t *testing.T) {
+	t.Parallel()
+	// A paid tier whose subscription has lapsed (past expiry, no grace) is treated
+	// as Free: the digest record is still written, but no instant push fires.
+	notifs := newFakeNotifications()
+	profile := profileWithTier(t, "auth0|alice", profiles.TierPro)
+	past := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC) // before the harness clock
+	profile.SubscriptionExpiry = &past
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{"auth0|alice": profile}}
+	devs := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
+		"auth0|alice": {{Token: "tok-1"}},
+	}}
+	push := &fakePush{}
+	enq := NewEnqueuer(notifs, &fakeZones{}, profs, devs, &fakeState{}, push,
+		func() string { return "n-1" },
+		func() time.Time { return time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC) },
+		testLogger(t))
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	if err := enq.Enqueue(context.Background(), app, zone); err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("lapsed paid tier must still create the digest record, got %d", len(notifs.created))
+	}
+	if push.calls != 0 {
+		t.Errorf("lapsed paid tier must NOT push, got %d calls", push.calls)
+	}
+}
+
 func TestEnqueuer_Dedup_SkipsWhenAlreadyNotified(t *testing.T) {
 	t.Parallel()
 	enq, notifs, push := newEnqueuerHarness(t, profiles.TierPro)

--- a/api-go/internal/profiles/handler.go
+++ b/api-go/internal/profiles/handler.go
@@ -113,7 +113,7 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 		h.writeJSON(w, r, createResult{
 			UserID:      existing.UserID,
 			PushEnabled: existing.Preferences.PushEnabled,
-			Tier:        existing.Tier.String(),
+			Tier:        existing.EffectiveTier(h.now()).String(),
 		})
 		return
 	case errors.Is(err, ErrNotFound):
@@ -139,7 +139,7 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(w, r, createResult{
 		UserID:      profile.UserID,
 		PushEnabled: profile.Preferences.PushEnabled,
-		Tier:        profile.Tier.String(),
+		Tier:        profile.EffectiveTier(h.now()).String(),
 	})
 }
 
@@ -156,7 +156,7 @@ func (h *handler) get(w http.ResponseWriter, r *http.Request) {
 		h.serverError(w, r, "load profile", err)
 		return
 	}
-	h.writeJSON(w, r, profileResultFrom(profile))
+	h.writeJSON(w, r, profileResultFrom(profile, h.now()))
 }
 
 // updateRequest is the PATCH /v1/me body. DigestDay accepts either the weekday
@@ -198,7 +198,7 @@ func (h *handler) patch(w http.ResponseWriter, r *http.Request) {
 		h.serverError(w, r, "save profile", err)
 		return
 	}
-	h.writeJSON(w, r, profileResultFrom(profile))
+	h.writeJSON(w, r, profileResultFrom(profile, h.now()))
 }
 
 // delete implements DELETE /v1/me as a complete UK GDPR Art. 17 erasure. It reads
@@ -289,7 +289,7 @@ func (h *handler) tryBackfillAuth0Tier(ctx context.Context, p *UserProfile, jwtT
 	}
 }
 
-func profileResultFrom(p *UserProfile) profileResult {
+func profileResultFrom(p *UserProfile, now time.Time) profileResult {
 	return profileResult{
 		UserID:             p.UserID,
 		PushEnabled:        p.Preferences.PushEnabled,
@@ -297,7 +297,7 @@ func profileResultFrom(p *UserProfile) profileResult {
 		EmailDigestEnabled: p.Preferences.EmailDigestEnabled,
 		SavedDecisionPush:  p.Preferences.SavedDecisionPush,
 		SavedDecisionEmail: p.Preferences.SavedDecisionEmail,
-		Tier:               p.Tier.String(),
+		Tier:               p.EffectiveTier(now).String(),
 	}
 }
 

--- a/api-go/internal/profiles/handler_test.go
+++ b/api-go/internal/profiles/handler_test.go
@@ -285,6 +285,61 @@ func TestHandler_GetProfile_OkAndNotFound(t *testing.T) {
 	}
 }
 
+func TestHandler_GetProfile_ReportsEffectiveTierForLapsedPaid(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	past := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC) // before the handler clock (2026-06-11)
+	store.byID["auth0|lapsed"] = &UserProfile{
+		UserID:             "auth0|lapsed",
+		Preferences:        DefaultPreferences(),
+		Tier:               TierPro,
+		SubscriptionExpiry: &past,
+		LastActiveAt:       time.Now(),
+	}
+	h := newTestHandler(store, newFakeAuth0(), "")
+
+	rec := httptest.NewRecorder()
+	h.get(rec, withSubject(http.MethodGet, "/v1/me", "auth0|lapsed", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// GET /v1/me must report the EFFECTIVE tier so the iOS app (which re-resolves
+	// tier from this endpoint) sees the lapsed Pro grant as Free.
+	if got["tier"] != "Free" {
+		t.Errorf("tier: got %v, want Free (lapsed Pro reads as effective Free)", got["tier"])
+	}
+}
+
+func TestHandler_CreateProfile_ReportsEffectiveTierForLapsedPaid(t *testing.T) {
+	t.Parallel()
+
+	store := newFakeStore()
+	past := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	existing, _ := NewProfile("auth0|lapsed", "user@example.com", time.Now())
+	existing.Tier = TierPro
+	existing.SubscriptionExpiry = &past
+	store.byID["auth0|lapsed"] = existing
+	h := newTestHandler(store, newFakeAuth0(), "")
+
+	rec := httptest.NewRecorder()
+	h.create(rec, withSubject(http.MethodPost, "/v1/me", "auth0|lapsed", ""))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if got["tier"] != "Free" {
+		t.Errorf("tier: got %v, want Free (lapsed Pro reads as effective Free)", got["tier"])
+	}
+}
+
 func TestHandler_PatchProfile_UpdatesAndDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/api-go/internal/profiles/middleware_adapter.go
+++ b/api-go/internal/profiles/middleware_adapter.go
@@ -42,18 +42,22 @@ func (r *ActivityRecorder) RecordActivity(ctx context.Context, userID string, no
 
 // TierLookup answers the rate-limiter's paid/free question from the Cosmos
 // profile tier — the authoritative entitlement source per ADR 0010, never the
-// JWT claim. A user with no profile is treated as free.
+// JWT claim. A user with no profile is treated as free. The injected clock lets
+// the lazy expiry check (EffectiveTier) collapse a lapsed paid tier to free.
 type TierLookup struct {
 	store profileStore
+	now   func() time.Time
 }
 
-// NewTierLookup builds the lookup over the given profile store.
-func NewTierLookup(store profileStore) *TierLookup {
-	return &TierLookup{store: store}
+// NewTierLookup builds the lookup over the given profile store and clock.
+func NewTierLookup(store profileStore, now func() time.Time) *TierLookup {
+	return &TierLookup{store: store, now: now}
 }
 
-// IsPaidUser reports whether the user's stored tier is paid (anything but Free).
-// A missing profile yields false (free) without error.
+// IsPaidUser reports whether the user's effective tier is paid (anything but
+// Free) at the current instant — a paid tier whose subscription has lapsed (with
+// no live grace period) reads as free. A missing profile yields false (free)
+// without error.
 func (l *TierLookup) IsPaidUser(ctx context.Context, userID string) (bool, error) {
 	profile, err := l.store.Get(ctx, userID)
 	if err != nil {
@@ -62,5 +66,5 @@ func (l *TierLookup) IsPaidUser(ctx context.Context, userID string) (bool, error
 		}
 		return false, err
 	}
-	return profile.Tier.IsPaid(), nil
+	return profile.EffectiveTier(l.now()).IsPaid(), nil
 }

--- a/api-go/internal/profiles/middleware_adapter_test.go
+++ b/api-go/internal/profiles/middleware_adapter_test.go
@@ -64,7 +64,7 @@ func TestTierLookup_PaidFromCosmosProfile(t *testing.T) {
 	pro.Tier = TierPro
 	store.byID["auth0|pro"] = pro
 
-	lookup := NewTierLookup(store)
+	lookup := NewTierLookup(store, time.Now)
 
 	paid, err := lookup.IsPaidUser(context.Background(), "auth0|pro")
 	if err != nil || !paid {
@@ -76,10 +76,43 @@ func TestTierLookup_PaidFromCosmosProfile(t *testing.T) {
 	}
 }
 
+func TestTierLookup_ExpiredPaidIsFree(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	store := newFakeStore()
+
+	// A paid tier whose subscription expiry has passed (no grace) is no longer
+	// entitled — the rate limiter must treat it as free.
+	expired, _ := NewProfile("auth0|lapsed", "", now)
+	expired.Tier = TierPro
+	past := now.Add(-time.Hour)
+	expired.SubscriptionExpiry = &past
+	store.byID["auth0|lapsed"] = expired
+
+	// A paid tier still within its window stays paid.
+	active, _ := NewProfile("auth0|active", "", now)
+	active.Tier = TierPersonal
+	future := now.Add(time.Hour)
+	active.SubscriptionExpiry = &future
+	store.byID["auth0|active"] = active
+
+	lookup := NewTierLookup(store, func() time.Time { return now })
+
+	paid, err := lookup.IsPaidUser(context.Background(), "auth0|lapsed")
+	if err != nil || paid {
+		t.Errorf("lapsed paid user: paid=%v err=%v, want paid=false", paid, err)
+	}
+	paid, err = lookup.IsPaidUser(context.Background(), "auth0|active")
+	if err != nil || !paid {
+		t.Errorf("active paid user: paid=%v err=%v, want paid=true", paid, err)
+	}
+}
+
 func TestTierLookup_MissingProfileIsFree(t *testing.T) {
 	t.Parallel()
 
-	lookup := NewTierLookup(newFakeStore())
+	lookup := NewTierLookup(newFakeStore(), time.Now)
 	paid, err := lookup.IsPaidUser(context.Background(), "auth0|missing")
 	// A user with no profile is treated as free, not an error — they simply have
 	// not registered yet, so the lower limit applies.

--- a/api-go/internal/profiles/profile.go
+++ b/api-go/internal/profiles/profile.go
@@ -189,6 +189,37 @@ func (p *UserProfile) UpdatePreferences(prefs NotificationPreferences) {
 	p.Preferences = prefs
 }
 
+// EffectiveTier returns the tier the user is actually entitled to at now,
+// applying ADR 0010's lazy expiry rule: a paid tier whose SubscriptionExpiry has
+// passed — with no grace period, or a grace period that has also passed —
+// collapses to Free regardless of the stored Tier. Free and any paid tier still
+// within its window (including a live grace period and the far-future pro-domain
+// auto-grant) are returned unchanged.
+//
+// Every entitlement gate reads this, never the raw stored Tier, so an offer-code
+// grant that has run out — or an App Store sub past expiry whose webhook never
+// arrived — is treated as Free everywhere without mutating the stored document
+// (the daily sweep, Phase 2, reverts the stored state separately).
+func (p *UserProfile) EffectiveTier(now time.Time) SubscriptionTier {
+	if p.Tier == TierFree {
+		return TierFree
+	}
+	if p.SubscriptionExpiry == nil {
+		// Invariant: every paid grant sets an expiry (ActivateSubscription /
+		// pro-domain auto-grant). A paid tier with no expiry is malformed; treat
+		// as still-entitled rather than silently downgrade (no proof of expiry).
+		return p.Tier
+	}
+	// "expired" mirrors the lapsed-txn filter on the verify path: expired when
+	// SubscriptionExpiry is NOT strictly after now (so expiry == now is expired).
+	if !p.SubscriptionExpiry.After(now) {
+		if p.GracePeriodExpiry == nil || !p.GracePeriodExpiry.After(now) {
+			return TierFree
+		}
+	}
+	return p.Tier
+}
+
 // ActivateSubscription moves the profile to a paid tier with the given expiry
 // and clears any grace period.
 func (p *UserProfile) ActivateSubscription(tier SubscriptionTier, expiry time.Time) {

--- a/api-go/internal/profiles/profile_test.go
+++ b/api-go/internal/profiles/profile_test.go
@@ -166,3 +166,70 @@ func TestSubscriptionTier_IsPaid(t *testing.T) {
 		t.Error("Personal and Pro should be paid")
 	}
 }
+
+func TestUserProfile_EffectiveTier(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	ptr := func(tm time.Time) *time.Time { return &tm }
+	past := now.Add(-time.Hour)
+	future := now.Add(time.Hour)
+	farFuture := time.Date(2099, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name   string
+		tier   SubscriptionTier
+		expiry *time.Time
+		grace  *time.Time
+		want   SubscriptionTier
+	}{
+		{
+			// Free always stays Free regardless of any stale expiry/grace fields.
+			name: "free", tier: TierFree, expiry: ptr(past), grace: ptr(past), want: TierFree,
+		},
+		{
+			// Paid tier still inside its window is returned unchanged.
+			name: "paid within window", tier: TierPro, expiry: ptr(future), grace: nil, want: TierPro,
+		},
+		{
+			// Lapsed paid tier with no grace collapses to Free (the offer-code gap).
+			name: "paid expired no grace", tier: TierPro, expiry: ptr(past), grace: nil, want: TierFree,
+		},
+		{
+			// Lapsed paid tier whose grace period is still live keeps the tier.
+			name: "paid expired grace live", tier: TierPersonal, expiry: ptr(past), grace: ptr(future), want: TierPersonal,
+		},
+		{
+			// Lapsed paid tier whose grace period has also passed collapses to Free.
+			name: "paid expired grace past", tier: TierPersonal, expiry: ptr(past), grace: ptr(past), want: TierFree,
+		},
+		{
+			// A paid tier with no expiry is malformed; treated as entitled rather
+			// than silently downgraded (no proof of expiry).
+			name: "nil expiry paid", tier: TierPro, expiry: nil, grace: nil, want: TierPro,
+		},
+		{
+			// Pro-domain auto-grants use a far-future expiry, so they are naturally
+			// exempt — no special-casing needed.
+			name: "far future pro-domain grant", tier: TierPro, expiry: ptr(farFuture), grace: nil, want: TierPro,
+		},
+		{
+			// Boundary: expiry exactly at now counts as expired (mirrors the
+			// lapsed-txn filter: expired when NOT strictly after now).
+			name: "boundary expiry equals now", tier: TierPro, expiry: ptr(now), grace: nil, want: TierFree,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := &UserProfile{
+				Tier:               tc.tier,
+				SubscriptionExpiry: tc.expiry,
+				GracePeriodExpiry:  tc.grace,
+			}
+			if got := p.EffectiveTier(now); got != tc.want {
+				t.Errorf("EffectiveTier() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/api-go/internal/subscriptions/handler.go
+++ b/api-go/internal/subscriptions/handler.go
@@ -276,11 +276,17 @@ func (h *handler) runVerify(ctx context.Context, userID string, signedTransactio
 		return verifyResponse{}, fmt.Errorf("sync auth0 tier %q: %w", userID, err)
 	}
 
+	// Report the effective tier so entitlements never outlive the subscription
+	// window. In the verify path the profile was just activated (future expiry) or
+	// expired in this same request, so this equals the stored tier today; routing
+	// it through EffectiveTier keeps the contract that no entitlement read trusts
+	// the raw stored Tier.
+	effective := profile.EffectiveTier(now)
 	return verifyResponse{
-		Tier:               profile.Tier.String(),
+		Tier:               effective.String(),
 		SubscriptionExpiry: platform.DotNetTimePtr(profile.SubscriptionExpiry),
-		Entitlements:       profile.Tier.Entitlements(),
-		WatchZoneLimit:     profile.Tier.WatchZoneLimit(),
+		Entitlements:       effective.Entitlements(),
+		WatchZoneLimit:     effective.WatchZoneLimit(),
 	}, nil
 }
 

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -187,7 +187,9 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 		h.serverError(w, r, "quota gate", errProfileCASNotWired)
 		return
 	}
-	ok, casErr := h.atomicQuotaIncrement(r.Context(), userID, profile.Tier.WatchZoneLimit())
+	// Quota is keyed on the effective tier: a lapsed paid subscription
+	// (EffectiveTier) falls back to the Free limit.
+	ok, casErr := h.atomicQuotaIncrement(r.Context(), userID, profile.EffectiveTier(h.now()).WatchZoneLimit())
 	if casErr != nil {
 		h.serverError(w, r, "atomic quota check", casErr)
 		return

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -261,6 +261,40 @@ func TestCreate_ProTierBypassesQuota(t *testing.T) {
 	}
 }
 
+func TestCreate_ExpiredProTierQuotaIs403(t *testing.T) {
+	t.Parallel()
+	// A Pro tier whose subscription has lapsed (past expiry, no grace) reads as
+	// Free via EffectiveTier, so the Free limit of 1 applies — a user already over
+	// that limit is forbidden a new zone.
+	lapsed := proProfile(t)
+	past := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC) // before nearbyNow (2026-06-14)
+	lapsed.SubscriptionExpiry = &past
+
+	manyZones := make([]WatchZone, 10)
+	for i := range manyZones {
+		manyZones[i] = authorityZone(t, 471)
+	}
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: manyZones},
+		profiles: &fakeProfileReader{profile: lapsed},
+		resolver: &fakeResolver{},
+		apps:     &fakeAppFinder{},
+		state:    &fakeWatermark{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	body := `{"name":"My Zone","latitude":51.5,"longitude":-0.12,"radiusMetres":1000,"authorityId":471}`
+	rec := doReq(t, mux, http.MethodPost, "/v1/me/watch-zones", body)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("lapsed Pro tier should fall back to the Free quota: got %d, want 403", rec.Code)
+	}
+	if d.store.saved != nil {
+		t.Error("must not save a zone when the effective quota is exceeded")
+	}
+}
+
 func TestCreate_InvalidPayloadIs400(t *testing.T) {
 	t.Parallel()
 	cases := map[string]string{


### PR DESCRIPTION
## What

Phase 1 of #608 — the mandatory read-path correctness fix. Adds `UserProfile.EffectiveTier(now)` and routes **every** entitlement read + `/v1/me` through it, so a paid tier whose `SubscriptionExpiry` has passed (no grace, or grace also passed) collapses to Free regardless of the stored `Tier`. Closes the offer-code "grants never revert" gap and backstops a dropped App Store webhook (ADR 0010's lazy-check, finally implemented).

## Call sites routed through `EffectiveTier(now)`
`TierLookup.IsPaidUser` (rate-limit; gains an injected clock), status-change push, decision push, weekly Pro push, hourly digest gate, watch-zone quota, subscriptions verify response, and `/v1/me` GET/POST. No entitlement gate reads the raw stored `Tier` for an allow/deny decision anymore.

## Locked decisions honoured
- Silent downgrade, no user notification.
- No grace period for offer codes (grace still honoured if set by the App Store path).
- Pro-domain far-future (2099) grants are naturally exempt via their far-future expiry — not special-cased.
- Clock injected (`now func() time.Time`), no ad-hoc `time.Now()` in domain code.

Deliberately left raw-`Tier` reads unchanged where they report/persist/sync stored state rather than gate (Cosmos/offercode persistence, GDPR export, admin views, Auth0 sync). Phase 2 (tc-rlja.2) reverts the stored doc.

## Tests
`EffectiveTier` unit tests (free, paid-within, expired-no-grace, expired-grace-live, expired-grace-past, nil-expiry-paid, far-future pro-domain, boundary expiry==now) + per-gate regression tests. Full suite green: `go build`/`vet`/`gofmt`/`go test -race ./...` (1083 pass) and `golangci-lint run ./...` clean.

## Out of scope
Phase 2 sweep worker (tc-rlja.2), any user-facing notification, iOS changes (client already re-resolves tier from `/v1/me`).

Closes part of #608 (Phase 1). Bead: tc-rlja.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription expiry dates are now properly enforced across push notifications, email digests, and watch zone quotas
  * Users with expired paid subscriptions are now correctly treated as free tier for feature entitlements
  * API responses now reflect the user's effective subscription tier, accounting for expiry and grace periods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->