### PR TITLE
chore: remove legacy pro-domain Pro auto-grant (tc-rlja.3)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -254,7 +254,7 @@ func main() {
 		log.Fatalf("designations client: %v", err)
 	}
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cfg.ProDomains, cascade, exportReaders, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, cfg.SiteBuildKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, cfg.AppleEnvironments, registry, logger))
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cascade, exportReaders, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, cfg.SiteBuildKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, cfg.AppleEnvironments, registry, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -96,7 +96,7 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // nil-means-unwired convention. (The watch-zone preferences endpoints are
 // served by profiles.Routes off the profile store, so they come up with the
 // /v1/me routes, not the watch-zone store.)
-func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, proDomains string, cascade profiles.CascadeDeleters, exportReaders profiles.ExportReaders, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, siteBuildKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, appleEnvironments []string, registry *metrics.Registry, logger *slog.Logger) http.Handler {
+func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, cascade profiles.CascadeDeleters, exportReaders profiles.ExportReaders, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, siteBuildKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, appleEnvironments []string, registry *metrics.Registry, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)
@@ -111,7 +111,7 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 
 	var dispatch http.Handler = mux
 	if store != nil {
-		profiles.Routes(mux, store, auth0, proDomains, cascade, exportReaders, time.Now, logger)
+		profiles.Routes(mux, store, auth0, cascade, exportReaders, time.Now, logger)
 		dispatch = middleware.RateLimit(middleware.NewRateLimitStore(), profiles.NewTierLookup(store), logger)(
 			middleware.RecordActivity(profiles.NewActivityRecorder(store), time.Now, logger)(mux),
 		)

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -180,7 +180,7 @@ func testDesignationClientWith(t *testing.T, baseURL string, httpClient *http.Cl
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -285,7 +285,7 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	appStore := applications.NewCosmosStore(newFakeItems())
 	savedStore := savedapplications.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -383,7 +383,7 @@ func TestRouter_GeocodeAndDesignationsDispatch(t *testing.T) {
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
 	geocodeClient := testGeocodeClientWith(t, upstream.URL, upstream.Client())
 	designationClient := testDesignationClientWith(t, upstream.URL, upstream.Client())
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", "", nil, nil, "", nil, nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", "", nil, nil, "", nil, nil, logger)
 
 	rec := serveReq(t, h, http.MethodGet, "/v1/geocode/SW1A%201AA", "", "Bearer tok")
 	if rec.Code != http.StatusOK {
@@ -422,7 +422,7 @@ func TestRouter_SubscriptionsWired(t *testing.T) {
 		t.Fatalf("NewJWSVerifier: %v", err)
 	}
 
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, adminStore, "", "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, adminStore, "", "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, logger)
 
 	// Webhook is anonymous: a malformed body reaches the handler -> 400 with the
 	// malformed_request envelope, not the WWW-Authenticate 401 fallback.
@@ -452,7 +452,7 @@ func TestRouter_AdminGate(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	offerStore := offercodes.NewCosmosStore(newFakeItems())
 	adminStore := profiles.NewAdminStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, logger)
 
 	// No key: the admin gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).
@@ -484,7 +484,7 @@ func TestRouter_RecentApplicationsBuildKeyGate(t *testing.T) {
 
 	logger := slog.New(slog.DiscardHandler)
 	appStore := applications.NewCosmosStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, logger)
 
 	// No key: the build gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).
@@ -530,7 +530,7 @@ func TestRouter_NearApplicationsBuildKeyGate(t *testing.T) {
 
 	logger := slog.New(slog.DiscardHandler)
 	appStore := applications.NewCosmosStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, "", profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, logger)
 
 	noKey := nearRequest(t, h, "")
 	if noKey.Code != http.StatusUnauthorized {

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -65,11 +65,6 @@ type Config struct {
 	ServiceBusNamespace string
 	ServiceBusQueueName string
 
-	// ProDomains is the comma-separated allow-list of email domains that
-	// auto-grant the Pro tier on a verified-email registration. Empty disables
-	// auto-grant.
-	ProDomains string
-
 	// PostcodesIoBaseURL and GovUkBaseURL address the outbound geocode and
 	// designation upstreams. They default to the live UK services, so the clients
 	// work without any env wiring; an override points them at a stub.
@@ -197,8 +192,6 @@ func LoadConfig() (Config, error) {
 
 		Auth0M2MClientID:     os.Getenv("AUTH0_M2M_CLIENT_ID"),
 		Auth0M2MClientSecret: NewSecret(os.Getenv("AUTH0_M2M_CLIENT_SECRET")),
-
-		ProDomains: os.Getenv("SUBSCRIPTION_AUTOGRANT_PRODOMAINS"),
 
 		PostcodesIoBaseURL: getenv("POSTCODES_IO_BASE_URL", defaultPostcodesIoBaseURL),
 		GovUkBaseURL:       getenv("GOVUK_PLANNING_DATA_BASE_URL", defaultGovUkBaseURL),

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -266,18 +266,6 @@ func TestLoadConfig_ACSConnectionString(t *testing.T) {
 	})
 }
 
-func TestLoadConfig_ProDomains(t *testing.T) {
-	t.Setenv("SUBSCRIPTION_AUTOGRANT_PRODOMAINS", "towncrier.test, example.org")
-
-	cfg, err := LoadConfig()
-	if err != nil {
-		t.Fatalf("LoadConfig: %v", err)
-	}
-	if cfg.ProDomains != "towncrier.test, example.org" {
-		t.Errorf("ProDomains: got %q", cfg.ProDomains)
-	}
-}
-
 func TestLoadConfig_AdminAPIKey(t *testing.T) {
 	t.Run("set", func(t *testing.T) {
 		t.Setenv("ADMIN_API_KEY", "s3cret-admin-key")

--- a/api-go/internal/profiles/handler.go
+++ b/api-go/internal/profiles/handler.go
@@ -19,9 +19,6 @@ import (
 // maxBodyBytes caps the request body the /v1/me write handlers read.
 const maxBodyBytes = 1 << 20
 
-// farFutureExpiry is the auto-grant subscription expiry (2099-12-31).
-var farFutureExpiry = time.Date(2099, 12, 31, 0, 0, 0, 0, time.UTC)
-
 // profileStore is the consumer-side store the handlers use. *CosmosStore
 // satisfies it; tests substitute a hand-written fake.
 type profileStore interface {
@@ -32,26 +29,24 @@ type profileStore interface {
 
 // handler serves the /v1/me lifecycle. It depends on the profile store, the
 // Auth0 management client (real or no-op), the per-container cascade deleters
-// account erasure runs, the per-collection readers GET /v1/me/data exports, the
-// auto-grant pro-domain list, a clock, and a logger — all injected, no globals.
+// account erasure runs, the per-collection readers GET /v1/me/data exports, a
+// clock, and a logger — all injected, no globals.
 type handler struct {
 	store         profileStore
 	auth0         Auth0Manager
 	cascade       CascadeDeleters
 	exportReaders ExportReaders
-	proDomains    proDomainSet
 	now           func() time.Time
 	logger        *slog.Logger
 }
 
 // newHandler builds the /v1/me handler.
-func newHandler(store profileStore, auth0 Auth0Manager, proDomains string, cascade CascadeDeleters, exportReaders ExportReaders, now func() time.Time, logger *slog.Logger) *handler {
+func newHandler(store profileStore, auth0 Auth0Manager, cascade CascadeDeleters, exportReaders ExportReaders, now func() time.Time, logger *slog.Logger) *handler {
 	return &handler{
 		store:         store,
 		auth0:         auth0,
 		cascade:       cascade,
 		exportReaders: exportReaders,
-		proDomains:    newProDomainSet(proDomains),
 		now:           now,
 		logger:        logger,
 	}
@@ -59,8 +54,8 @@ func newHandler(store profileStore, auth0 Auth0Manager, proDomains string, casca
 
 // Routes registers the /v1/me endpoints on mux. All are authenticated: the auth
 // middleware guarantees a subject in context before these handlers run.
-func Routes(mux *http.ServeMux, store profileStore, auth0 Auth0Manager, proDomains string, cascade CascadeDeleters, exportReaders ExportReaders, now func() time.Time, logger *slog.Logger) {
-	h := newHandler(store, auth0, proDomains, cascade, exportReaders, now, logger)
+func Routes(mux *http.ServeMux, store profileStore, auth0 Auth0Manager, cascade CascadeDeleters, exportReaders ExportReaders, now func() time.Time, logger *slog.Logger) {
+	h := newHandler(store, auth0, cascade, exportReaders, now, logger)
 	mux.HandleFunc("POST /v1/me", h.create)
 	mux.HandleFunc("GET /v1/me", h.get)
 	mux.HandleFunc("PATCH /v1/me", h.patch)
@@ -94,8 +89,8 @@ type profileResult struct {
 
 // create implements POST /v1/me. It is idempotent: an existing profile is
 // returned unchanged (with an email backfill when newly available), and a fresh
-// profile is registered with the Free tier — or Pro when a verified pro-domain
-// email auto-grants. Auth0 tier drift is backfilled best-effort.
+// profile is registered with the Free tier. Auth0 tier drift is backfilled
+// best-effort.
 func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 	claims := auth.ClaimsFrom(r.Context())
 
@@ -127,9 +122,6 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		h.serverError(w, r, "register profile", err)
 		return
-	}
-	if claims.EmailVerified && h.proDomains.contains(claims.Email) {
-		profile.ActivateSubscription(TierPro, farFutureExpiry)
 	}
 	if err := h.store.Save(r.Context(), profile); err != nil {
 		h.serverError(w, r, "save profile", err)
@@ -325,30 +317,6 @@ func (h *handler) writeJSON(w http.ResponseWriter, r *http.Request, v any) {
 func (h *handler) serverError(w http.ResponseWriter, r *http.Request, op string, err error) {
 	h.logger.ErrorContext(r.Context(), "profile request failed", "op", op, "error", err)
 	w.WriteHeader(http.StatusInternalServerError)
-}
-
-// proDomainSet is the parsed, case-insensitive set of auto-grant pro domains.
-type proDomainSet map[string]struct{}
-
-func newProDomainSet(raw string) proDomainSet {
-	set := proDomainSet{}
-	for _, part := range strings.Split(raw, ",") {
-		if d := strings.TrimSpace(part); d != "" {
-			set[strings.ToLower(d)] = struct{}{}
-		}
-	}
-	return set
-}
-
-// contains reports whether the email's domain is an auto-grant pro domain
-// (case-insensitive domain match).
-func (s proDomainSet) contains(email string) bool {
-	at := strings.LastIndex(email, "@")
-	if at < 0 || at == len(email)-1 {
-		return false
-	}
-	_, ok := s[strings.ToLower(email[at+1:])]
-	return ok
 }
 
 // weekdayName serialises a time.Weekday as its English name (e.g. "Wednesday"),

--- a/api-go/internal/profiles/handler_test.go
+++ b/api-go/internal/profiles/handler_test.go
@@ -128,20 +128,20 @@ func recordingCascade(calls *[]string) CascadeDeleters {
 	}
 }
 
-func newTestHandler(store profileStore, a0 Auth0Manager, proDomains string) *handler {
-	return newTestHandlerCascade(store, a0, proDomains, recordingCascade(nil))
+func newTestHandler(store profileStore, a0 Auth0Manager) *handler {
+	return newTestHandlerCascade(store, a0, recordingCascade(nil))
 }
 
-func newTestHandlerCascade(store profileStore, a0 Auth0Manager, proDomains string, cascade CascadeDeleters) *handler {
+func newTestHandlerCascade(store profileStore, a0 Auth0Manager, cascade CascadeDeleters) *handler {
 	now := func() time.Time { return time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC) }
-	return newHandler(store, a0, proDomains, cascade, ExportReaders{}, now, slog.New(slog.DiscardHandler))
+	return newHandler(store, a0, cascade, ExportReaders{}, now, slog.New(slog.DiscardHandler))
 }
 
 // newTestHandlerExport builds a handler with the export readers wired, for the
 // GDPR-export tests.
 func newTestHandlerExport(store profileStore, a0 Auth0Manager, readers ExportReaders) *handler {
 	now := func() time.Time { return time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC) }
-	return newHandler(store, a0, "", CascadeDeleters{}, readers, now, slog.New(slog.DiscardHandler))
+	return newHandler(store, a0, CascadeDeleters{}, readers, now, slog.New(slog.DiscardHandler))
 }
 
 // withSubject builds a request carrying an authenticated subject in context, as
@@ -159,7 +159,7 @@ func TestHandler_CreateProfile_ReturnsOkCamelCase(t *testing.T) {
 	t.Parallel()
 
 	store := newFakeStore()
-	h := newTestHandler(store, newFakeAuth0(), "")
+	h := newTestHandler(store, newFakeAuth0())
 
 	rec := httptest.NewRecorder()
 	h.create(rec, withSubject(http.MethodPost, "/v1/me", "auth0|new", ""))
@@ -196,7 +196,7 @@ func TestHandler_CreateProfile_Idempotent(t *testing.T) {
 	store := newFakeStore()
 	existing, _ := NewProfile("auth0|abc", "user@example.com", time.Now())
 	store.byID["auth0|abc"] = existing
-	h := newTestHandler(store, newFakeAuth0(), "")
+	h := newTestHandler(store, newFakeAuth0())
 
 	rec := httptest.NewRecorder()
 	h.create(rec, withSubject(http.MethodPost, "/v1/me", "auth0|abc", ""))
@@ -214,35 +214,6 @@ func TestHandler_CreateProfile_Idempotent(t *testing.T) {
 	}
 }
 
-func TestHandler_CreateProfile_AutoGrantsProForVerifiedProDomain(t *testing.T) {
-	t.Parallel()
-
-	store := newFakeStore()
-	h := newTestHandler(store, newFakeAuth0(), "towncrier.test")
-
-	r := withSubject(http.MethodPost, "/v1/me", "auth0|staff", "")
-	r.Header.Set("X-Test-Email", "person@towncrier.test")
-	r.Header.Set("X-Test-Email-Verified", "true")
-	// Emails arrive via JWT claims, threaded through context by the auth layer.
-	r = r.WithContext(auth.WithClaims(r.Context(), auth.Claims{
-		Subject:       "auth0|staff",
-		Email:         "person@towncrier.test",
-		EmailVerified: true,
-	}))
-
-	rec := httptest.NewRecorder()
-	h.create(rec, r)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d, want 200", rec.Code)
-	}
-	var got map[string]any
-	_ = json.Unmarshal(rec.Body.Bytes(), &got)
-	if got["tier"] != "Pro" {
-		t.Errorf("tier: got %v, want Pro (auto-grant)", got["tier"])
-	}
-}
-
 func TestHandler_GetProfile_OkAndNotFound(t *testing.T) {
 	t.Parallel()
 
@@ -254,7 +225,7 @@ func TestHandler_GetProfile_OkAndNotFound(t *testing.T) {
 		LastActiveAt: time.Now(),
 	}
 	store.byID["auth0|abc"] = p
-	h := newTestHandler(store, newFakeAuth0(), "")
+	h := newTestHandler(store, newFakeAuth0())
 
 	rec := httptest.NewRecorder()
 	h.get(rec, withSubject(http.MethodGet, "/v1/me", "auth0|abc", ""))
@@ -291,7 +262,7 @@ func TestHandler_PatchProfile_UpdatesAndDefaults(t *testing.T) {
 	store := newFakeStore()
 	existing, _ := NewProfile("auth0|abc", "", time.Now())
 	store.byID["auth0|abc"] = existing
-	h := newTestHandler(store, newFakeAuth0(), "")
+	h := newTestHandler(store, newFakeAuth0())
 
 	// iOS-style body: omits digestDay and emailDigestEnabled, which must take the
 	// command defaults (Monday / true).
@@ -324,7 +295,7 @@ func TestHandler_PatchProfile_AcceptsDigestDayAsString(t *testing.T) {
 	store := newFakeStore()
 	existing, _ := NewProfile("auth0|abc", "", time.Now())
 	store.byID["auth0|abc"] = existing
-	h := newTestHandler(store, newFakeAuth0(), "")
+	h := newTestHandler(store, newFakeAuth0())
 
 	body := `{"pushEnabled":true,"digestDay":"Wednesday","emailDigestEnabled":true,"savedDecisionPush":true,"savedDecisionEmail":true}`
 	rec := httptest.NewRecorder()
@@ -346,7 +317,7 @@ func TestHandler_PatchProfile_AcceptsDigestDayAsInt(t *testing.T) {
 	store := newFakeStore()
 	existing, _ := NewProfile("auth0|abc", "", time.Now())
 	store.byID["auth0|abc"] = existing
-	h := newTestHandler(store, newFakeAuth0(), "")
+	h := newTestHandler(store, newFakeAuth0())
 
 	// The API accepts digestDay as an integer in addition to the weekday name;
 	// the handler must accept both.
@@ -367,7 +338,7 @@ func TestHandler_PatchProfile_AcceptsDigestDayAsInt(t *testing.T) {
 func TestHandler_PatchProfile_NotFound(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(newFakeStore(), newFakeAuth0(), "")
+	h := newTestHandler(newFakeStore(), newFakeAuth0())
 	rec := httptest.NewRecorder()
 	h.patch(rec, withSubject(http.MethodPatch, "/v1/me", "auth0|missing", `{"pushEnabled":true}`))
 	if rec.Code != http.StatusNotFound {
@@ -383,7 +354,7 @@ func TestHandler_DeleteProfile_CascadesEveryContainerThenProfileThenAuth0(t *tes
 	store.byID["auth0|abc"] = existing
 	a0 := newFakeAuth0()
 	var calls []string
-	h := newTestHandlerCascade(store, a0, "", recordingCascade(&calls))
+	h := newTestHandlerCascade(store, a0, recordingCascade(&calls))
 
 	rec := httptest.NewRecorder()
 	h.delete(rec, withSubject(http.MethodDelete, "/v1/me", "auth0|abc", ""))
@@ -427,7 +398,7 @@ func TestHandler_DeleteProfile_ChildCascadeFailureLeavesProfileAndAuth0Intact(t 
 	a0 := newFakeAuth0()
 	cascade := recordingCascade(nil)
 	cascade.WatchZones = fakeChildDeleter{label: "watchZones", err: errors.New("cosmos down")}
-	h := newTestHandlerCascade(store, a0, "", cascade)
+	h := newTestHandlerCascade(store, a0, cascade)
 
 	rec := httptest.NewRecorder()
 	h.delete(rec, withSubject(http.MethodDelete, "/v1/me", "auth0|abc", ""))
@@ -455,7 +426,7 @@ func TestHandler_DeleteProfile_OfferCodeAnonymiseFailureLeavesProfileAndAuth0Int
 	a0 := newFakeAuth0()
 	cascade := recordingCascade(nil)
 	cascade.OfferCodes = fakeRedemptionAnonymiser{err: errors.New("cosmos down")}
-	h := newTestHandlerCascade(store, a0, "", cascade)
+	h := newTestHandlerCascade(store, a0, cascade)
 
 	rec := httptest.NewRecorder()
 	h.delete(rec, withSubject(http.MethodDelete, "/v1/me", "auth0|abc", ""))
@@ -483,7 +454,7 @@ func TestHandler_DeleteProfile_Auth0DeletedAfterAllCosmosData(t *testing.T) {
 	a0 := newFakeAuth0()
 	a0.deleteErr = errors.New("auth0 m2m down")
 	var calls []string
-	h := newTestHandlerCascade(store, a0, "", recordingCascade(&calls))
+	h := newTestHandlerCascade(store, a0, recordingCascade(&calls))
 
 	rec := httptest.NewRecorder()
 	h.delete(rec, withSubject(http.MethodDelete, "/v1/me", "auth0|abc", ""))
@@ -504,7 +475,7 @@ func TestHandler_DeleteProfile_NotFound(t *testing.T) {
 
 	a0 := newFakeAuth0()
 	var calls []string
-	h := newTestHandlerCascade(newFakeStore(), a0, "", recordingCascade(&calls))
+	h := newTestHandlerCascade(newFakeStore(), a0, recordingCascade(&calls))
 	rec := httptest.NewRecorder()
 	h.delete(rec, withSubject(http.MethodDelete, "/v1/me", "auth0|missing", ""))
 	if rec.Code != http.StatusNotFound {
@@ -535,7 +506,7 @@ func TestHandler_ExportData_NestedContract(t *testing.T) {
 		LastActiveAt:       time.Now(),
 	}
 	store.byID["auth0|abc"] = p
-	h := newTestHandler(store, newFakeAuth0(), "")
+	h := newTestHandler(store, newFakeAuth0())
 
 	rec := httptest.NewRecorder()
 	h.exportData(rec, withSubject(http.MethodGet, "/v1/me/data", "auth0|abc", ""))
@@ -632,7 +603,7 @@ func TestHandler_ExportData_PopulatedChildCollections(t *testing.T) {
 func TestHandler_ExportData_NotFound(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(newFakeStore(), newFakeAuth0(), "")
+	h := newTestHandler(newFakeStore(), newFakeAuth0())
 	rec := httptest.NewRecorder()
 	h.exportData(rec, withSubject(http.MethodGet, "/v1/me/data", "auth0|missing", ""))
 	if rec.Code != http.StatusNotFound {

--- a/api-go/internal/profiles/profile.go
+++ b/api-go/internal/profiles/profile.go
@@ -193,8 +193,8 @@ func (p *UserProfile) UpdatePreferences(prefs NotificationPreferences) {
 // applying ADR 0010's lazy expiry rule: a paid tier whose SubscriptionExpiry has
 // passed — with no grace period, or a grace period that has also passed —
 // collapses to Free regardless of the stored Tier. Free and any paid tier still
-// within its window (including a live grace period and the far-future pro-domain
-// auto-grant) are returned unchanged.
+// within its window (including a live grace period and the far-future admin
+// grant) are returned unchanged.
 //
 // Every entitlement gate reads this, never the raw stored Tier, so an offer-code
 // grant that has run out — or an App Store sub past expiry whose webhook never
@@ -206,7 +206,7 @@ func (p *UserProfile) EffectiveTier(now time.Time) SubscriptionTier {
 	}
 	if p.SubscriptionExpiry == nil {
 		// Invariant: every paid grant sets an expiry (ActivateSubscription /
-		// pro-domain auto-grant). A paid tier with no expiry is malformed; treat
+		// admin grant). A paid tier with no expiry is malformed; treat
 		// as still-entitled rather than silently downgrade (no proof of expiry).
 		return p.Tier
 	}

--- a/api-go/internal/profiles/profile.go
+++ b/api-go/internal/profiles/profile.go
@@ -22,7 +22,7 @@ const (
 	TierFree SubscriptionTier = iota
 	// TierPersonal is the £1.99/mo tier.
 	TierPersonal
-	// TierPro is the £5.99/mo tier (also the auto-grant target for pro domains).
+	// TierPro is the £5.99/mo tier.
 	TierPro
 )
 

--- a/api-go/internal/profiles/zonepreferences_handler_test.go
+++ b/api-go/internal/profiles/zonepreferences_handler_test.go
@@ -36,7 +36,7 @@ func TestHandler_GetZonePreferences_DefaultsForNewZone(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
 	seededProfile(t, store)
-	h := newTestHandler(store, newFakeAuth0(), "")
+	h := newTestHandler(store, newFakeAuth0())
 
 	rec := httptest.NewRecorder()
 	h.getZonePreferences(rec, withZonePath(http.MethodGet, prefsUser, ""))
@@ -66,7 +66,7 @@ func TestHandler_GetZonePreferences_ReflectsStored(t *testing.T) {
 	store := newFakeStore()
 	p := seededProfile(t, store)
 	p.SetZonePreferences("z1", ZonePreferences{NewApplicationPush: false, NewApplicationEmail: true, DecisionPush: false, DecisionEmail: true})
-	h := newTestHandler(store, newFakeAuth0(), "")
+	h := newTestHandler(store, newFakeAuth0())
 
 	rec := httptest.NewRecorder()
 	h.getZonePreferences(rec, withZonePath(http.MethodGet, prefsUser, ""))
@@ -85,7 +85,7 @@ func TestHandler_GetZonePreferences_ReflectsStored(t *testing.T) {
 
 func TestHandler_GetZonePreferences_ProfileNotFound(t *testing.T) {
 	t.Parallel()
-	h := newTestHandler(newFakeStore(), newFakeAuth0(), "")
+	h := newTestHandler(newFakeStore(), newFakeAuth0())
 	rec := httptest.NewRecorder()
 	h.getZonePreferences(rec, withZonePath(http.MethodGet, "auth0|missing", ""))
 	if rec.Code != http.StatusNotFound {
@@ -100,7 +100,7 @@ func TestHandler_PutZonePreferences_PersistsAndReturns(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
 	seededProfile(t, store)
-	h := newTestHandler(store, newFakeAuth0(), "")
+	h := newTestHandler(store, newFakeAuth0())
 
 	body := `{"newApplicationPush":false,"newApplicationEmail":true,"decisionPush":false,"decisionEmail":true}`
 	rec := httptest.NewRecorder()
@@ -130,7 +130,7 @@ func TestHandler_PutZonePreferences_MissingFieldsDefaultFalse(t *testing.T) {
 	t.Parallel()
 	store := newFakeStore()
 	seededProfile(t, store)
-	h := newTestHandler(store, newFakeAuth0(), "")
+	h := newTestHandler(store, newFakeAuth0())
 
 	// Only one field present; the rest default to false (JSON zero-value
 	// decoding for non-nullable bool fields).
@@ -153,7 +153,7 @@ func TestHandler_PutZonePreferences_MissingFieldsDefaultFalse(t *testing.T) {
 
 func TestHandler_PutZonePreferences_ProfileNotFound(t *testing.T) {
 	t.Parallel()
-	h := newTestHandler(newFakeStore(), newFakeAuth0(), "")
+	h := newTestHandler(newFakeStore(), newFakeAuth0())
 	rec := httptest.NewRecorder()
 	h.putZonePreferences(rec, withZonePath(http.MethodPut, "auth0|missing", `{"decisionPush":true}`))
 	if rec.Code != http.StatusNotFound {

--- a/infra/environment.go
+++ b/infra/environment.go
@@ -135,7 +135,6 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 	adminAPIKey := conf.RequireSecret("adminApiKey")
 	// Build key the Go endpoint validates for the gated SEO prerender route (tc-nnte).
 	siteBuildKey := conf.RequireSecret("siteBuildKey")
-	autoGrantProDomains := conf.RequireSecret("autoGrantProDomains")
 	auth0M2mClientID := conf.RequireSecret("auth0M2mClientId")
 	auth0M2mClientSecret := conf.RequireSecret("auth0M2mClientSecret")
 
@@ -364,7 +363,6 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		Secrets: app.SecretArray{
 			&app.SecretArgs{Name: pulumi.String("auth0-m2m-client-id"), Value: auth0M2mClientID},
 			&app.SecretArgs{Name: pulumi.String("auth0-m2m-client-secret"), Value: auth0M2mClientSecret},
-			&app.SecretArgs{Name: pulumi.String("auto-grant-pro-domains"), Value: autoGrantProDomains},
 			// Admin key the Go X-Admin-Key gate validates for /v1/admin requests (tc-52t6).
 			&app.SecretArgs{Name: pulumi.String("admin-api-key"), Value: adminAPIKey},
 			// Build key the Go gate validates for the SEO prerender endpoint (tc-nnte).
@@ -414,7 +412,6 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 						app.EnvironmentVarArgs{Name: pulumi.String("CORS_ALLOWED_ORIGINS"), Value: pulumi.String(fmt.Sprintf("https://%s", frontendDomain))},
 						app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_ID"), SecretRef: pulumi.String("auth0-m2m-client-id")},
 						app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_SECRET"), SecretRef: pulumi.String("auth0-m2m-client-secret")},
-						app.EnvironmentVarArgs{Name: pulumi.String("SUBSCRIPTION_AUTOGRANT_PRODOMAINS"), SecretRef: pulumi.String("auto-grant-pro-domains")},
 						app.EnvironmentVarArgs{Name: pulumi.String("ADMIN_API_KEY"), SecretRef: pulumi.String("admin-api-key")},
 						app.EnvironmentVarArgs{Name: pulumi.String("SITE_BUILD_KEY"), SecretRef: pulumi.String("site-build-key")},
 					},


### PR DESCRIPTION
## What

Removes the legacy pro-domain Pro auto-grant end to end (#609). It predates the offer-code system and was the only path minting a **permanent** Pro entitlement on self-registration (far-future 2099 expiry), which would exempt those profiles from the expiry enforcement in #608. After this, `POST /v1/me` always registers at the Free tier; paid access comes only from offer codes, App Store subscriptions, or an explicit admin grant.

It is already **dormant**: the `autoGrantProDomains` secret is empty in all stacks, so no Go-era user was ever auto-granted — clean code + infra removal, no data migration.

## Changes
**api-go** (`36d4965`): auto-grant block, `proDomains` field + constructor/Routes params, `proDomainSet`/`newProDomainSet`/`contains`, the local `farFutureExpiry` (admin grants keep their own in `internal/admin/subscriptions.go`), the `ProDomains` config field + `SUBSCRIPTION_AUTOGRANT_PRODOMAINS` env read, doc-comment fixes, and all associated tests.

**infra** (`b6d34b7`): `infra/environment.go` drops the `autoGrantProDomains` `RequireSecret`, the `auto-grant-pro-domains` `SecretArgs`, and the `SUBSCRIPTION_AUTOGRANT_PRODOMAINS` container-app env var.

## Verification
- api-go: `gofmt`/`build`/`vet` clean, `go test -race ./...` 1064 pass, `golangci-lint` clean. Admin-grant path confirmed untouched.
- infra: `gofmt`/`build`/`vet` clean; `pulumi preview` on **shared** clean (32 unchanged, 0 changes). dev/prod local preview panics on the pre-existing `adminApiKey` secret (injected only by CI's `setup-pulumi-secrets`, not committed) — the intended container-app diff is verified by CI's infra-preview. Removing an empty, unused secret + env var cannot break CD (unread config is harmless to `pulumi up`).

## Follow-up (separate bead, NOT in this PR)
The `autoGrantProDomains` value is injected by CI, not committed in any `Pulumi.*.yaml` (so #609's "remove from stack YAMLs" had nothing to remove). The real orphan — `setup-pulumi-secrets` input, `cd-dev`/`cd-prod` workflow inputs, and the `AUTO_GRANT_PRO_DOMAINS` repo secret — is tracked in **tc-bi9z** (discovered-from tc-rlja.3) for a github-actions-worker. It's harmless until then (unread config doesn't error).

Closes #609. Bead: tc-rlja.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)