### PR TITLE
feat: daily subscription-sweep worker to downgrade lapsed paid tiers (tc-rlja.2)

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -2,10 +2,10 @@
 // Container Apps Jobs. One process per job: WORKER_MODE selects the mode,
 // the process runs it once, flushes telemetry, and exits with a status code.
 //
-// poll-bootstrap, digest, hourly-digest, and dormant-cleanup are implemented;
-// poll-sb remains a loud stub that exits 1 until its own bead (tc-yng2) lands.
-// The Go image is not deployed to any job until the final cutover, so a stub can
-// never strand a real job.
+// poll-bootstrap, digest, hourly-digest, dormant-cleanup, and subscription-sweep
+// are implemented; poll-sb remains a loud stub that exits 1 until its own bead
+// (tc-yng2) lands. The Go image is not deployed to any job until the final
+// cutover, so a stub can never strand a real job.
 package main
 
 import (
@@ -38,6 +38,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/servicebus"
+	"github.com/AmyDe/town-crier/api-go/internal/subscriptionsweep"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 	"github.com/AmyDe/town-crier/api-go/internal/worker"
 	"go.opentelemetry.io/otel"
@@ -170,7 +171,23 @@ func run() int {
 		poller = pollAdapter
 	}
 
-	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, nil, logger)
+	// The subscription-sweep handler is built only when the job carries Cosmos
+	// config. Like dormantRunner it is declared as the interface so the "no Cosmos"
+	// case leaves it a genuinely nil interface value (a typed-nil
+	// *subscriptionsweep.Handler would defeat worker.Run's nil guard). The Auth0
+	// syncer falls back to a no-op when the M2M credentials are absent, so a
+	// Cosmos-only job still boots cleanly.
+	var sweepRunner worker.SweepRunner
+	sweepHandler, err := buildSweep(cfg, registry, logger)
+	if err != nil {
+		logger.Error("build subscription sweep handler", "error", err)
+		return 1
+	}
+	if sweepHandler != nil {
+		sweepRunner = sweepHandler
+	}
+
+	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, sweepRunner, logger)
 }
 
 // buildPollOrchestrator wires the poll-sb orchestrator: the PlanIt client, the
@@ -590,6 +607,57 @@ func buildAuth0Deleter(cfg platform.Config, logger *slog.Logger) erasure.Auth0De
 		return profiles.NoOpAuth0Client{}
 	}
 	// Wrap the transport so Auth0 token/DELETE calls emit OTel client spans
+	// (Type=HTTP in AppDependencies) named "Auth0 token"; the host lands in
+	// server.address.
+	auth0HTTP := platform.WrapHTTPClient(
+		&http.Client{Timeout: 30 * time.Second},
+		func(string, *http.Request) string { return "Auth0 token" },
+	)
+	return profiles.NewAuth0Client(
+		auth0HTTP,
+		"https://"+cfg.Auth0Domain,
+		cfg.Auth0M2MClientID,
+		cfg.Auth0M2MClientSecret,
+	)
+}
+
+// buildSweep constructs the subscription-sweep handler when Cosmos is configured,
+// wiring the lapsed-paid finder and profile saver (both the AdminStore over the
+// Users container) and the Auth0 M2M syncer (real when its credentials are
+// present, NoOp otherwise so a job without Auth0 M2M config still reverts the
+// stored Cosmos tier). It returns (nil, nil) when Cosmos is unconfigured — the
+// subscription-sweep mode then refuses to run rather than nil-panicking.
+// Returning the concrete *subscriptionsweep.Handler lets worker.Run accept it via
+// its exported SweepRunner interface.
+func buildSweep(cfg platform.Config, registry *metrics.Registry, logger *slog.Logger) (*subscriptionsweep.Handler, error) {
+	if cfg.CosmosEndpoint == "" {
+		return nil, nil //nolint:nilnil // absent Cosmos config is a valid "no sweep handler" state, not an error
+	}
+
+	users, err := platform.NewCosmosContainerNamed(cfg, "Users", logger)
+	if err != nil {
+		return nil, err
+	}
+	users.WithMetrics(registry)
+
+	// The AdminStore satisfies both the sweep's Finder (LapsedPaid) and Saver
+	// (Save) — the lapsed scan and the downgrade upsert both span / key on the
+	// Users container, so one store serves both roles.
+	store := profiles.NewAdminStore(users)
+	return subscriptionsweep.New(store, store, buildAuth0Syncer(cfg, logger), logger, time.Now), nil
+}
+
+// buildAuth0Syncer returns the real Auth0 Management (M2M) client when the M2M
+// credentials are configured, else a no-op so a job without Auth0 M2M config still
+// reverts the stored Cosmos tier. The read path (EffectiveTier) already treats a
+// lapsed user as Free everywhere, so the Auth0 subscription_tier metadata the
+// sweep keeps in step is informational, not load-bearing.
+func buildAuth0Syncer(cfg platform.Config, logger *slog.Logger) subscriptionsweep.Auth0Syncer {
+	if !cfg.Auth0M2MConfigured() {
+		logger.Info("auth0 m2m unconfigured; subscription sweep will skip Auth0 tier sync (NoOp)")
+		return profiles.NoOpAuth0Client{}
+	}
+	// Wrap the transport so Auth0 token/PATCH calls emit OTel client spans
 	// (Type=HTTP in AppDependencies) named "Auth0 token"; the host lands in
 	// server.address.
 	auth0HTTP := platform.WrapHTTPClient(

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -170,7 +170,7 @@ func run() int {
 		poller = pollAdapter
 	}
 
-	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, logger)
+	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, nil, logger)
 }
 
 // buildPollOrchestrator wires the poll-sb orchestrator: the PlanIt client, the

--- a/api-go/internal/profiles/admin_store.go
+++ b/api-go/internal/profiles/admin_store.go
@@ -131,6 +131,39 @@ func (s *AdminStore) Dormant(ctx context.Context, cutoff time.Time) ([]*UserProf
 	return dormant, nil
 }
 
+// LapsedPaid returns every profile whose stored tier is paid but whose
+// entitlement has lapsed at now — i.e. EffectiveTier(now) has collapsed to Free.
+// These are the profiles the daily subscription sweep (WORKER_MODE=subscription-
+// sweep) reverts to the Free tier in Cosmos and syncs to Auth0. Like Dormant it
+// does a full cross-partition scan and filters in Go: the lapsed test is the
+// domain EffectiveTier rule (expiry-vs-grace comparison, across the two
+// production timestamp wire formats), not a Cosmos predicate, and the scan is a
+// once-a-day batch over a small user base. Far-future paid grants (pro-domain
+// auto-grants, admin 2099 grants) keep their stored tier under EffectiveTier and
+// are never selected; Free profiles and paid profiles still within their window
+// (including a live grace period) are likewise skipped.
+func (s *AdminStore) LapsedPaid(ctx context.Context, now time.Time) ([]*UserProfile, error) {
+	rows, err := s.items.QueryItemsCrossPartition(ctx, "SELECT * FROM c", nil)
+	if err != nil {
+		return nil, fmt.Errorf("query lapsed paid profiles: %w", err)
+	}
+	lapsed := make([]*UserProfile, 0)
+	for _, raw := range rows {
+		var doc profileDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, fmt.Errorf("decode profile: %w", err)
+		}
+		p, err := doc.toDomain()
+		if err != nil {
+			return nil, fmt.Errorf("hydrate profile: %w", err)
+		}
+		if p.Tier.IsPaid() && p.EffectiveTier(now) == TierFree {
+			lapsed = append(lapsed, p)
+		}
+	}
+	return lapsed, nil
+}
+
 // Save upserts the profile (id == user id == partition key).
 func (s *AdminStore) Save(ctx context.Context, p *UserProfile) error {
 	body, err := json.Marshal(newProfileDocument(p))

--- a/api-go/internal/profiles/admin_store_test.go
+++ b/api-go/internal/profiles/admin_store_test.go
@@ -283,3 +283,81 @@ func TestAdminStore_Dormant_WrapsQueryError(t *testing.T) {
 		t.Fatal("expected error when the dormant scan fails")
 	}
 }
+
+// paidProfileDoc builds a stored profile document with a specific tier, expiry,
+// and grace period so the lapsed-paid scan's Go-side EffectiveTier filter can be
+// exercised across the window/grace/far-future combinations.
+func paidProfileDoc(t *testing.T, userID string, tier SubscriptionTier, expiry, grace *time.Time) []byte {
+	t.Helper()
+	p, err := NewProfile(userID, "", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	p.Tier = tier
+	p.SubscriptionExpiry = expiry
+	p.GracePeriodExpiry = grace
+	raw, err := json.Marshal(newProfileDocument(p))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw
+}
+
+func TestAdminStore_LapsedPaid_SelectsExpiredPaidProfiles(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	past := now.AddDate(0, 0, -1)
+	future := now.AddDate(0, 0, 1)
+	farFuture := time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	items := newFakeAdminItems()
+	items.queryResult = [][]byte{
+		paidProfileDoc(t, "lapsed-personal", TierPersonal, &past, nil),        // selected: expired, no grace
+		paidProfileDoc(t, "lapsed-pro", TierPro, &past, nil),                  // selected: expired, no grace
+		paidProfileDoc(t, "expired-grace-past", TierPersonal, &past, &past),   // selected: expired, grace also past
+		paidProfileDoc(t, "within-window", TierPro, &future, nil),             // kept: still within window
+		paidProfileDoc(t, "expired-grace-live", TierPersonal, &past, &future), // kept: live grace period
+		paidProfileDoc(t, "far-future-pro", TierPro, &farFuture, nil),         // kept: 2099 pro-domain/admin grant
+		paidProfileDoc(t, "nil-expiry-paid", TierPro, nil, nil),               // kept: malformed paid, treated as entitled
+		profileDoc(t, "free-user", "f@example.com", TierFree),                 // kept: free is never paid
+	}
+	store := NewAdminStore(items)
+
+	got, err := store.LapsedPaid(context.Background(), now)
+	if err != nil {
+		t.Fatalf("LapsedPaid: %v", err)
+	}
+
+	selected := map[string]bool{}
+	for _, p := range got {
+		selected[p.UserID] = true
+	}
+	for _, id := range []string{"lapsed-personal", "lapsed-pro", "expired-grace-past"} {
+		if !selected[id] {
+			t.Errorf("%s should be selected as lapsed-paid", id)
+		}
+	}
+	for _, id := range []string{"within-window", "expired-grace-live", "far-future-pro", "nil-expiry-paid", "free-user"} {
+		if selected[id] {
+			t.Errorf("%s must NOT be selected (still entitled or free)", id)
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("lapsed count: got %d, want 3", len(got))
+	}
+	// A full cross-partition scan, filtered in Go — mirrors Dormant's RU profile.
+	if items.gotQuery != "SELECT * FROM c" {
+		t.Errorf("query = %q, want full scan", items.gotQuery)
+	}
+}
+
+func TestAdminStore_LapsedPaid_WrapsQueryError(t *testing.T) {
+	t.Parallel()
+	items := newFakeAdminItems()
+	items.queryErr = errors.New("cosmos down")
+	store := NewAdminStore(items)
+
+	if _, err := store.LapsedPaid(context.Background(), time.Now()); err == nil {
+		t.Fatal("expected error when the lapsed-paid scan fails")
+	}
+}

--- a/api-go/internal/subscriptionsweep/handler.go
+++ b/api-go/internal/subscriptionsweep/handler.go
@@ -1,0 +1,105 @@
+// Package subscriptionsweep holds the subscription-sweep worker mode
+// (WORKER_MODE=subscription-sweep): once a day it finds paid profiles whose
+// entitlement has lapsed — offer-code grants past their duration, or App Store
+// subscriptions past expiry whose webhook never arrived — and reverts their
+// stored Cosmos tier to Free, then syncs Auth0's subscription_tier metadata to
+// match.
+//
+// It is the stored-state reconciliation half of GH #608 (Option B). The lazy
+// read-path check (UserProfile.EffectiveTier, Phase 1) already makes those users
+// Free on every entitlement gate the moment they lapse; this sweep is hygiene
+// that keeps the persisted Cosmos document and the Auth0 metadata clean. Because
+// the read path is already correct, a transient Auth0 sync failure here is benign
+// — entitlements gate on Cosmos + EffectiveTier, never on the Auth0 metadata.
+//
+// It mirrors internal/dormant: consumer-side interfaces declared here, concrete
+// stores injected from main(), hand-written test fakes, an injected now for a
+// pinned clock, and per-item failure isolation so one bad profile never aborts
+// the cycle.
+package subscriptionsweep
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// Finder returns the lapsed-paid set: every profile whose stored tier is paid but
+// whose EffectiveTier(now) has collapsed to Free. profiles.AdminStore satisfies
+// it via LapsedPaid.
+type Finder interface {
+	LapsedPaid(ctx context.Context, now time.Time) ([]*profiles.UserProfile, error)
+}
+
+// Saver persists a downgraded profile back to Cosmos. profiles.AdminStore
+// satisfies it via Save (an upsert keyed on the user id / partition key).
+type Saver interface {
+	Save(ctx context.Context, p *profiles.UserProfile) error
+}
+
+// Auth0Syncer keeps Auth0's app_metadata.subscription_tier in step with the
+// downgrade. profiles.Auth0Client (and the NoOpAuth0Client fallback) satisfy it
+// via UpdateSubscriptionTier — the same call the redemption and verify paths use.
+type Auth0Syncer interface {
+	UpdateSubscriptionTier(ctx context.Context, userID, tier string) error
+}
+
+// Handler runs one subscription-sweep cycle.
+type Handler struct {
+	finder Finder
+	saver  Saver
+	auth0  Auth0Syncer
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// New builds a subscription-sweep handler. now is injected so tests pin the
+// lapsed cutoff; production passes time.Now.
+func New(finder Finder, saver Saver, auth0 Auth0Syncer, logger *slog.Logger, now func() time.Time) *Handler {
+	return &Handler{finder: finder, saver: saver, auth0: auth0, logger: logger, now: now}
+}
+
+// Run executes one sweep cycle and returns the number of profiles fully
+// downgraded. It scans for lapsed paid profiles, then for each reverts the stored
+// tier to Free, saves, and syncs Auth0. A scan failure is fatal to the cycle; a
+// per-profile Save or Auth0 failure is logged and skipped (the profile is not
+// counted and the next daily run retries it) and the cycle continues — mirroring
+// dormant.Handler.Run.
+func (h *Handler) Run(ctx context.Context) (int, error) {
+	now := h.now()
+	lapsed, err := h.finder.LapsedPaid(ctx, now)
+	if err != nil {
+		return 0, fmt.Errorf("find lapsed paid profiles: %w", err)
+	}
+
+	downgraded := 0
+	for _, p := range lapsed {
+		if err := h.downgrade(ctx, p); err != nil {
+			h.logger.ErrorContext(ctx, "subscription downgrade failed; will retry next cycle", "user", p.UserID, "error", err)
+			continue
+		}
+		downgraded++
+	}
+	h.logger.InfoContext(ctx, "subscription sweep cycle complete", "scanned", len(lapsed), "downgraded", downgraded)
+	return downgraded, nil
+}
+
+// downgrade reverts one lapsed profile to the Free tier: ExpireSubscription
+// clears the stored tier/expiry/grace, Save persists it, then the Auth0 metadata
+// is synced. Cosmos is written before Auth0 (mirroring the erasure cascade): if
+// Save fails the stored state is untouched and the next cycle retries; if Auth0
+// fails after a successful Save the stored tier is already Free, so the read path
+// is correct and only the informational Auth0 metadata is momentarily stale.
+func (h *Handler) downgrade(ctx context.Context, p *profiles.UserProfile) error {
+	p.ExpireSubscription()
+	if err := h.saver.Save(ctx, p); err != nil {
+		return fmt.Errorf("save downgraded profile %q: %w", p.UserID, err)
+	}
+	if err := h.auth0.UpdateSubscriptionTier(ctx, p.UserID, profiles.TierFree.String()); err != nil {
+		return fmt.Errorf("sync auth0 tier for %q: %w", p.UserID, err)
+	}
+	return nil
+}

--- a/api-go/internal/subscriptionsweep/handler_test.go
+++ b/api-go/internal/subscriptionsweep/handler_test.go
@@ -1,0 +1,200 @@
+package subscriptionsweep
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// --- hand-written fakes -----------------------------------------------------
+
+type fakeFinder struct {
+	lapsed []*profiles.UserProfile
+	err    error
+	gotNow time.Time
+}
+
+func (f *fakeFinder) LapsedPaid(_ context.Context, now time.Time) ([]*profiles.UserProfile, error) {
+	f.gotNow = now
+	return f.lapsed, f.err
+}
+
+// fakeSaver records the profiles upserted back to Cosmos and can be primed with a
+// per-user save error, so the test can isolate a single profile's failure.
+type fakeSaver struct {
+	saved   map[string]profiles.SubscriptionTier // tier at the moment of Save
+	saveErr map[string]error                     // keyed by user id
+}
+
+func newFakeSaver() *fakeSaver {
+	return &fakeSaver{saved: map[string]profiles.SubscriptionTier{}, saveErr: map[string]error{}}
+}
+
+func (s *fakeSaver) Save(_ context.Context, p *profiles.UserProfile) error {
+	if err := s.saveErr[p.UserID]; err != nil {
+		return err
+	}
+	s.saved[p.UserID] = p.Tier
+	return nil
+}
+
+// fakeAuth0 records the tier synced to Auth0 per user and can be primed with a
+// per-user error.
+type fakeAuth0 struct {
+	synced  map[string]string // user id -> tier string
+	syncErr map[string]error
+}
+
+func newFakeAuth0() *fakeAuth0 {
+	return &fakeAuth0{synced: map[string]string{}, syncErr: map[string]error{}}
+}
+
+func (a *fakeAuth0) UpdateSubscriptionTier(_ context.Context, userID, tier string) error {
+	if err := a.syncErr[userID]; err != nil {
+		return err
+	}
+	a.synced[userID] = tier
+	return nil
+}
+
+func lapsedProfile(t *testing.T, userID string) *profiles.UserProfile {
+	t.Helper()
+	p, err := profiles.NewProfile(userID, "", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	// A paid grant that has already lapsed; the finder is responsible for the
+	// EffectiveTier filtering, so the handler just downgrades whatever it returns.
+	p.ActivateSubscription(profiles.TierPro, time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	return p
+}
+
+func newHandler(finder Finder, saver Saver, auth0 Auth0Syncer, now time.Time) *Handler {
+	return New(finder, saver, auth0, slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil)), func() time.Time { return now })
+}
+
+// --- tests ------------------------------------------------------------------
+
+func TestHandler_Run_PassesNowToFinder(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC)
+	finder := &fakeFinder{}
+	h := newHandler(finder, newFakeSaver(), newFakeAuth0(), now)
+
+	if _, err := h.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !finder.gotNow.Equal(now) {
+		t.Errorf("now passed to finder: got %v, want %v", finder.gotNow, now)
+	}
+}
+
+func TestHandler_Run_DowngradesEachLapsedProfileAndSyncsAuth0(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 6, 23, 9, 0, 0, 0, time.UTC)
+	finder := &fakeFinder{lapsed: []*profiles.UserProfile{lapsedProfile(t, "auth0|a"), lapsedProfile(t, "auth0|b")}}
+	saver := newFakeSaver()
+	auth0 := newFakeAuth0()
+	h := newHandler(finder, saver, auth0, now)
+
+	downgraded, err := h.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if downgraded != 2 {
+		t.Errorf("downgraded count: got %d, want 2", downgraded)
+	}
+
+	for _, id := range []string{"auth0|a", "auth0|b"} {
+		// Each lapsed profile is reverted to Free in Cosmos before being saved.
+		if tier, ok := saver.saved[id]; !ok || tier != profiles.TierFree {
+			t.Errorf("%s saved tier: got %v (saved=%v), want Free", id, tier, ok)
+		}
+		// And Auth0 metadata is synced to the canonical "Free" string.
+		if auth0.synced[id] != "Free" {
+			t.Errorf("%s auth0 tier: got %q, want Free", id, auth0.synced[id])
+		}
+	}
+}
+
+func TestHandler_Run_NoLapsedProfilesDoesNothing(t *testing.T) {
+	t.Parallel()
+	saver := newFakeSaver()
+	auth0 := newFakeAuth0()
+	h := newHandler(&fakeFinder{}, saver, auth0, time.Now())
+
+	downgraded, err := h.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if downgraded != 0 {
+		t.Errorf("downgraded count: got %d, want 0", downgraded)
+	}
+	if len(saver.saved) != 0 || len(auth0.synced) != 0 {
+		t.Errorf("nothing should be saved or synced: saved=%v synced=%v", saver.saved, auth0.synced)
+	}
+}
+
+func TestHandler_Run_FinderErrorPropagates(t *testing.T) {
+	t.Parallel()
+	finder := &fakeFinder{err: errors.New("cosmos down")}
+	h := newHandler(finder, newFakeSaver(), newFakeAuth0(), time.Now())
+
+	if _, err := h.Run(context.Background()); err == nil {
+		t.Fatal("expected error when the lapsed-paid scan fails")
+	}
+}
+
+func TestHandler_Run_SaveFailureIsolatedAndContinues(t *testing.T) {
+	t.Parallel()
+	// The first profile's Save fails; its Auth0 sync must be skipped and it must
+	// not be counted, but the cycle must continue to downgrade the second profile.
+	finder := &fakeFinder{lapsed: []*profiles.UserProfile{lapsedProfile(t, "auth0|fails"), lapsedProfile(t, "auth0|ok")}}
+	saver := newFakeSaver()
+	saver.saveErr["auth0|fails"] = errors.New("upsert conflict")
+	auth0 := newFakeAuth0()
+	h := newHandler(finder, saver, auth0, time.Now())
+
+	downgraded, err := h.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if downgraded != 1 {
+		t.Errorf("downgraded count: got %d, want 1 (the failing profile is skipped)", downgraded)
+	}
+	// A failed Save must not reach Auth0 for that profile.
+	if _, synced := auth0.synced["auth0|fails"]; synced {
+		t.Error("auth0 must not be synced when the Cosmos save failed")
+	}
+	// The healthy profile still gets downgraded and synced.
+	if saver.saved["auth0|ok"] != profiles.TierFree || auth0.synced["auth0|ok"] != "Free" {
+		t.Errorf("healthy profile not fully downgraded: saved=%v synced=%v", saver.saved["auth0|ok"], auth0.synced["auth0|ok"])
+	}
+}
+
+func TestHandler_Run_Auth0FailureIsolatedAndContinues(t *testing.T) {
+	t.Parallel()
+	// The first profile's Auth0 sync fails after its Cosmos save succeeded; it is
+	// not counted, but the cycle continues to the second profile.
+	finder := &fakeFinder{lapsed: []*profiles.UserProfile{lapsedProfile(t, "auth0|a0fail"), lapsedProfile(t, "auth0|ok")}}
+	saver := newFakeSaver()
+	auth0 := newFakeAuth0()
+	auth0.syncErr["auth0|a0fail"] = errors.New("auth0 5xx")
+	h := newHandler(finder, saver, auth0, time.Now())
+
+	downgraded, err := h.Run(context.Background())
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if downgraded != 1 {
+		t.Errorf("downgraded count: got %d, want 1 (the auth0-failing profile is skipped)", downgraded)
+	}
+	if saver.saved["auth0|ok"] != profiles.TierFree || auth0.synced["auth0|ok"] != "Free" {
+		t.Errorf("healthy profile not fully downgraded: saved=%v synced=%v", saver.saved["auth0|ok"], auth0.synced["auth0|ok"])
+	}
+}

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -32,6 +32,13 @@ const digestBudget = 10 * time.Minute
 // flushes telemetry.
 const dormantBudget = 10 * time.Minute
 
+// sweepBudget is the soft self-cancel for a single subscription-sweep run. The
+// cycle scans all profiles cross-partition then downgrades the (small) lapsed-paid
+// set with a Cosmos upsert and an Auth0 PATCH each; 10 minutes is generous while
+// still bounded well under the Container Apps replicaTimeout so the process exits
+// cleanly and flushes telemetry.
+const sweepBudget = 10 * time.Minute
+
 // DigestRunner is the consumer-side slice of the digest handler the dispatcher
 // invokes. *digest.Handler satisfies it; the worker depends only on these two
 // methods so it need not know the handler's internals. It is exported so main()
@@ -90,11 +97,11 @@ type PollOrchestrator interface {
 // Service Bus client + bootstrapper, sets up telemetry, and propagates this
 // code.
 //
-// poll-bootstrap, digest, hourly-digest, and dormant-cleanup are implemented;
-// poll-sb remains a loud stub that exits 1 until its own bead (tc-yng2) lands.
-// The Go worker image is not deployed to any job until the final cutover bead, so
-// a stub can never run in production. An unset or unknown mode is a deployment
-// accident and also fails fast.
+// poll-bootstrap, digest, hourly-digest, dormant-cleanup, and subscription-sweep
+// are implemented; poll-sb remains a loud stub that exits 1 until its own bead
+// (tc-yng2) lands. The Go worker image is not deployed to any job until the final
+// cutover bead, so a stub can never run in production. An unset or unknown mode is
+// a deployment accident and also fails fast.
 //
 // bootstrapper may be nil when the job has no Service Bus config; poll-bootstrap
 // then refuses to run rather than nil-panicking. Likewise digester / dormant may
@@ -119,6 +126,9 @@ func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester 
 
 	case "dormant-cleanup":
 		return runDormant(ctx, dormant, logger)
+
+	case "subscription-sweep":
+		return runSweep(ctx, sweeper, logger)
 
 	case "poll-sb":
 		return runPollSB(ctx, poller, logger)
@@ -233,6 +243,35 @@ func runDormant(ctx context.Context, runner DormantRunner, logger *slog.Logger) 
 		return 1
 	}
 	span.SetAttributes(attribute.Int("dormant_cleanup.deleted_count", deleted))
+	return 0
+}
+
+// runSweep executes one subscription-sweep cycle under a soft self-cancel budget,
+// inside a telemetry span named "Subscription Sweep Cycle". It records the number
+// of downgraded profiles as the subscription_sweep.downgraded_count tag. A nil
+// runner (job missing Cosmos config) is an exit-1 condition; a cycle error is
+// recorded on the span and also exits 1 so the job surfaces the failure.
+func runSweep(ctx context.Context, runner SweepRunner, logger *slog.Logger) int {
+	tracer := otel.Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, "Subscription Sweep Cycle")
+	defer span.End()
+
+	if runner == nil {
+		logger.ErrorContext(ctx, "subscription-sweep requires Cosmos config (COSMOS_ENDPOINT et al.); refusing to run")
+		return 1
+	}
+
+	cycleCtx, cancel := context.WithTimeout(ctx, sweepBudget)
+	defer cancel()
+
+	downgraded, err := runner.Run(cycleCtx)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		logger.ErrorContext(ctx, "subscription sweep cycle failed", "error", err)
+		return 1
+	}
+	span.SetAttributes(attribute.Int("subscription_sweep.downgraded_count", downgraded))
 	return 0
 }
 

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -51,6 +51,16 @@ type DormantRunner interface {
 	Run(ctx context.Context) (int, error)
 }
 
+// SweepRunner is the consumer-side slice of the subscription-sweep handler the
+// dispatcher invokes. *subscriptionsweep.Handler satisfies it; Run returns the
+// number of profiles downgraded so the dispatcher can record it as a telemetry
+// tag. It is exported so main() can hold a genuinely nil interface value when the
+// job has no Cosmos config — passing a typed-nil *subscriptionsweep.Handler would
+// defeat the nil guard.
+type SweepRunner interface {
+	Run(ctx context.Context) (int, error)
+}
+
 // PollRunResult is the dispatcher-facing summary of one poll-sb cycle. It mirrors
 // the orchestrator's run result plus the ingestion counts the dispatch span tags
 // and the exit-code logic need, decoupling the worker package from the polling
@@ -90,7 +100,7 @@ type PollOrchestrator interface {
 // then refuses to run rather than nil-panicking. Likewise digester / dormant may
 // be nil when the job has no Cosmos config; those modes then refuse to run rather
 // than nil-panicking.
-func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, dormant DormantRunner, poller PollOrchestrator, logger *slog.Logger) int {
+func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, dormant DormantRunner, poller PollOrchestrator, sweeper SweepRunner, logger *slog.Logger) int {
 	switch mode {
 	case "":
 		// WORKER_MODE is always set by infra; an unset value is a deployment

--- a/api-go/internal/worker/dispatch_test.go
+++ b/api-go/internal/worker/dispatch_test.go
@@ -43,12 +43,25 @@ func (f *fakeDormant) Run(context.Context) (int, error) {
 	return f.deleted, f.err
 }
 
+// fakeSweep is a hand-written double for the SweepRunner the dispatcher invokes.
+// It records the call and can be primed with a downgraded count or error.
+type fakeSweep struct {
+	calls      int
+	downgraded int
+	err        error
+}
+
+func (f *fakeSweep) Run(context.Context) (int, error) {
+	f.calls++
+	return f.downgraded, f.err
+}
+
 func TestRun_UnsetModeFailsFast(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "", nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "", nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unset mode", code)
@@ -63,7 +76,7 @@ func TestRun_DigestModeRunsWeeklyAndExitsZero(t *testing.T) {
 	d := &fakeDigester{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "digest", nil, d, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0", code)
@@ -78,7 +91,7 @@ func TestRun_HourlyDigestModeRunsHourlyAndExitsZero(t *testing.T) {
 	d := &fakeDigester{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "hourly-digest", nil, d, nil, nil, logger)
+	code := Run(context.Background(), "hourly-digest", nil, d, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0", code)
@@ -95,7 +108,7 @@ func TestRun_DigestModeWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "digest", nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when digest handler is unconfigured", code)
@@ -107,7 +120,7 @@ func TestRun_DigestCycleErrorExitsOne(t *testing.T) {
 	d := &fakeDigester{weeklyErr: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "digest", nil, d, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on digest cycle error", code)
@@ -138,7 +151,7 @@ func TestRun_PollSBRunsOrchestratorAndExitsZeroOnSuccess(t *testing.T) {
 	}}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 for a successful poll cycle", code)
@@ -155,7 +168,7 @@ func TestRun_PollSBWithoutOrchestratorExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when poll-sb is unconfigured", code)
@@ -195,7 +208,7 @@ func TestRun_PollSBExitsOneOnlyWhenNoAppsAndAuthorityErrors(t *testing.T) {
 			t.Parallel()
 			o := &fakePollOrchestrator{result: tc.result}
 			logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
-			code := Run(context.Background(), "poll-sb", nil, nil, nil, o, logger)
+			code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, logger)
 			if code != tc.wantExit {
 				t.Errorf("exit code: got %d, want %d", code, tc.wantExit)
 			}
@@ -208,7 +221,7 @@ func TestRun_PollSBExitsOneOnOrchestratorError(t *testing.T) {
 	o := &fakePollOrchestrator{err: errors.New("orchestrator blew up")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on orchestrator error", code)
@@ -220,7 +233,7 @@ func TestRun_DormantCleanupRunsAndExitsZero(t *testing.T) {
 	d := &fakeDormant{deleted: 3}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful dormant cleanup)", code)
@@ -237,7 +250,7 @@ func TestRun_DormantCleanupWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when dormant handler is unconfigured", code)
@@ -249,10 +262,51 @@ func TestRun_DormantCleanupCycleErrorExitsOne(t *testing.T) {
 	d := &fakeDormant{err: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on dormant cleanup error", code)
+	}
+}
+
+func TestRun_SubscriptionSweepRunsAndExitsZero(t *testing.T) {
+	t.Parallel()
+	s := &fakeSweep{downgraded: 4}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, logger)
+
+	if code != 0 {
+		t.Errorf("exit code: got %d, want 0 (successful subscription sweep)", code)
+	}
+	if s.calls != 1 {
+		t.Errorf("sweep Run calls: got %d, want 1", s.calls)
+	}
+}
+
+func TestRun_SubscriptionSweepWithoutHandlerExitsOne(t *testing.T) {
+	t.Parallel()
+	// A job missing Cosmos config leaves the sweep runner nil; the mode must
+	// refuse to run rather than nil-panic.
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, nil, logger)
+
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1 when sweep handler is unconfigured", code)
+	}
+}
+
+func TestRun_SubscriptionSweepCycleErrorExitsOne(t *testing.T) {
+	t.Parallel()
+	s := &fakeSweep{err: errors.New("cosmos down")}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, logger)
+
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1 on subscription sweep error", code)
 	}
 }
 
@@ -261,7 +315,7 @@ func TestRun_UnknownModeExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "banana", nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "banana", nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unknown mode", code)
@@ -274,7 +328,7 @@ func TestRun_PollBootstrapSeedsAndExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful bootstrap)", code)
@@ -291,7 +345,7 @@ func TestRun_PollBootstrapWithoutQueueExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when Service Bus is unconfigured", code)
@@ -306,7 +360,7 @@ func TestRun_PollBootstrapProbeFailureStillExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (absorbed probe failure is not a job failure)", code)

--- a/docs/adr/0010-subscription-entitlement-flow.md
+++ b/docs/adr/0010-subscription-entitlement-flow.md
@@ -56,7 +56,7 @@ Stored on the User document:
 }
 ```
 
-**Tier enforcement:** API checks `subscriptionTier` and `subscriptionExpiry` on every tier-gated request. If `subscriptionExpiry` is in the past and `gracePeriodExpiry` is null or also past, the user is treated as `free` regardless of the stored tier.
+**Tier enforcement:** API checks `subscriptionTier` and `subscriptionExpiry` on every tier-gated request. If `subscriptionExpiry` is in the past and `gracePeriodExpiry` is null or also past, the user is treated as `free` regardless of the stored tier. This lazy rule is implemented as `UserProfile.EffectiveTier(now)`, through which every entitlement gate (and `/v1/me`) reads — see Implementation Notes.
 
 ### Grace Period Handling
 
@@ -73,13 +73,23 @@ iOS calls `Transaction.currentEntitlements` to retrieve all active transactions,
 ### Not Supported Initially
 
 - **Family Sharing**: not enabled. Simplifies the entitlement model — one transaction per user.
-- **Offer codes / promotional offers**: deferred to a future phase.
+- **Offer codes / promotional offers**: deferred to a future phase. *(Subsequently shipped: offer codes grant a fixed-duration paid tier and now participate in expiry enforcement via the lazy `EffectiveTier` check and the daily sweep — see Implementation Notes.)*
 - **Android / web subscriptions**: iOS only at launch.
 
 ## Consequences
 
 - **No Apple API dependency at purchase time.** The JWS verification is purely cryptographic (local certificate validation), so purchases succeed even if Apple's server API is temporarily unavailable. Faster user experience.
-- **Server Notifications v2 are the backbone of lifecycle management.** If notifications are missed (Apple outage, endpoint downtime), subscription state could drift. Mitigation: periodic reconciliation job that calls Apple's App Store Server API to verify active subscriptions — added as a future enhancement if needed.
+- **Server Notifications v2 are the backbone of lifecycle management.** If notifications are missed (Apple outage, endpoint downtime), subscription state could drift. Mitigation: a daily `subscription-sweep` worker now reconciles the stored state by collapsing any lapsed paid tier to Free in Cosmos and Auth0 — see Implementation Notes. (It does not call Apple's App Store Server API; it relies on the locally-stored `subscriptionExpiry`. Active-subscription re-verification against Apple's Server API remains a possible future enhancement.)
 - **Silent grace period** means some users may have access beyond their paid period during billing retry. This is by design — Apple retries billing for up to 60 days, and most billing issues resolve automatically.
 - **7-day trial** adds no code complexity — it's an App Store Connect configuration. The API sees it as a normal subscription with an offer type in the JWS payload.
 - **Cosmos DB is the single source of truth for entitlements.** The API never calls Apple during request processing. This keeps tier-gated endpoints fast and eliminates an external dependency from the hot path.
+
+## Implementation Notes
+
+Date: 2026-06-23 (GH [#608](https://github.com/AmyDe/town-crier/issues/608), epic tc-rlja)
+
+The lazy expiry rule and its stored-state reconciliation are now both built. Offer-code grants (which store an absolute `subscriptionExpiry` at redemption) previously never reverted because every gate read the raw stored `subscriptionTier`; both pieces below close that gap and also backstop a dropped App Store webhook.
+
+- **Phase 1 — lazy read-path check (tc-rlja.1).** `UserProfile.EffectiveTier(now)` centralises the rule: a paid tier whose `subscriptionExpiry` has passed (with no grace period, or a grace period that has also passed) collapses to `Free`; Free, paid-within-window, a live grace period, and far-future grants (the pro-domain / admin 2099 grants) are returned unchanged. Every entitlement gate and `/v1/me` reads through it rather than the raw stored `Tier`, so a lapsed user is treated as Free everywhere the instant they expire. Boundary: `expiry == now` counts as expired.
+- **Phase 2 — daily reconciliation sweep (tc-rlja.2).** A `WORKER_MODE=subscription-sweep` Container Apps Job runs once a day (`internal/subscriptionsweep`). It scans all profiles cross-partition, filters in Go for `Tier.IsPaid() && EffectiveTier(now) == Free`, and for each reverts the stored Cosmos tier to Free (`ExpireSubscription` + upsert) then syncs Auth0's `subscription_tier` metadata. Per-profile failures are logged and skipped; the cycle continues. Because the read path is already correct, this is stored-state hygiene — a transient Auth0 sync failure is benign.
+- **Downgrades are silent** (no user notification), mirroring how App Store `EXPIRED` already behaves. **No grace period is set for offer codes** — grace is an Apple billing-retry concept; the lazy check still honours a grace period if the App Store path ever sets one.

--- a/infra/environment.go
+++ b/infra/environment.go
@@ -462,6 +462,12 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 	if err = createWorkerJob(ctx, ec, "dormant-cleanup", "30 3 * * *", 600, "dormant-cleanup", nil); err != nil {
 		return err
 	}
+	// Subscription sweep — daily at 04:30 UTC (offset an hour from dormant-cleanup so the two
+	// full-scan jobs don't contend). Reverts lapsed offer-code/App Store paid tiers to Free in
+	// Cosmos and syncs Auth0 metadata (ADR 0010 reconciliation; epic tc-rlja / GH #608).
+	if err = createWorkerJob(ctx, ec, "subscription-sweep", "30 4 * * *", 600, "subscription-sweep", nil); err != nil {
+		return err
+	}
 
 	// Static Web App (Landing Page)
 	staticWebApp, err := web.NewStaticSite(ctx, fmt.Sprintf("swa-town-crier-%s", env), &web.StaticSiteArgs{
@@ -534,12 +540,12 @@ func createWorkerJob(ctx *pulumi.Context, ec envContext, nameSuffix, cronExpress
 	}
 
 	// The acs-connection-string and apns-auth-key secrets exist on every job; dormant-cleanup
-	// also needs the Auth0 Management (M2M) credentials.
+	// and subscription-sweep also need the Auth0 Management (M2M) credentials.
 	secrets := app.SecretArray{
 		&app.SecretArgs{Name: pulumi.String("acs-connection-string"), Value: ec.acsConnectionString},
 		&app.SecretArgs{Name: pulumi.String("apns-auth-key"), Value: ec.apnsAuthKey},
 	}
-	if workerMode == "dormant-cleanup" {
+	if workerMode == "dormant-cleanup" || workerMode == "subscription-sweep" {
 		secrets = append(secrets,
 			&app.SecretArgs{Name: pulumi.String("auth0-m2m-client-id"), Value: ec.auth0M2mClientID},
 			&app.SecretArgs{Name: pulumi.String("auth0-m2m-client-secret"), Value: ec.auth0M2mClientSecret},
@@ -667,7 +673,8 @@ func addGoWorkerEnv(envVars app.EnvironmentVarArray, ec envContext, workerMode s
 	}
 
 	// dormant-cleanup: Auth0 Management (M2M) for the Auth0 user delete in the cascade.
-	if workerMode == "dormant-cleanup" {
+	// subscription-sweep: same Auth0 M2M creds to sync subscription_tier back to Free.
+	if workerMode == "dormant-cleanup" || workerMode == "subscription-sweep" {
 		envVars = append(envVars,
 			app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_DOMAIN"), Value: pulumi.String(ec.auth0Domain)},
 			app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_ID"), SecretRef: pulumi.String("auth0-m2m-client-id")},


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until tc-h79o is resolved
cd-dev is currently wedged on a `ContainerAppSecretInUse` 409 from #611's secret removal (tracked in **tc-h79o**). Merging this PR would re-trigger the same failed deploy. Hold until cd-dev is healthy, then merge. Auto-merge is intentionally disabled.

## What
Phase 2 of #608 — the daily reconciliation sweep that reverts stored state for lapsed paid tiers (the hygiene complement to #610's read-path `EffectiveTier` enforcement). Offer-code grants past their duration now get their stored Cosmos tier reverted to Free and Auth0 synced, within one sweep cycle.

## Changes
**api-go:**
- `AdminStore.LapsedPaid(ctx, now)` — cross-partition `SELECT * FROM c`, filtered in Go for `Tier.IsPaid() && EffectiveTier(now) == TierFree` (mirrors `Dormant`'s scan profile).
- New `subscriptionsweep` package: `Handler.Run` downgrades each lapsed profile (`ExpireSubscription` + `Save`) then `auth0.UpdateSubscriptionTier(…, "Free")`; per-profile failures are logged and skipped (mirrors `dormant.Handler`); injected clock.
- `WORKER_MODE=subscription-sweep` wired in worker dispatch + `cmd/worker/main.go` (NoOp Auth0 fallback when M2M unconfigured).
- ADR 0010 updated: Phase 1 + Phase 2 now implemented; offer codes participate in expiry enforcement.

**infra:**
- New `job-tc-subscription-sweep-{env}` Container Apps Job, cron `30 4 * * *` (offset 1h from dormant-cleanup), reusing the dormant-cleanup image/resources/identities + Auth0 M2M secrets. **No new secret or env var.**

## Locked decisions honoured
Silent downgrade, no notification; far-future (2099) pro-domain/admin grants exempt naturally via `EffectiveTier` (no sentinel special-case); Cosmos-before-Auth0 ordering.

## Verification
`gofmt`/`build`/`vet`/`golangci-lint` clean; `go test -race ./...` 1092+ pass. Infra `go build`/`vet` clean; shared `pulumi preview` 32 unchanged. (dev/prod local preview hits the pre-existing `adminApiKey` panic — secrets injected only by CI; verified in cd, not locally.)

Closes #608 (Phase 2). Bead: tc-rlja.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)