### PR TITLE
fix(infra): keep auto-grant-pro-domains secret defined to unblock cd-dev (tc-h79o)

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -135,6 +135,7 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 	adminAPIKey := conf.RequireSecret("adminApiKey")
 	// Build key the Go endpoint validates for the gated SEO prerender route (tc-nnte).
 	siteBuildKey := conf.RequireSecret("siteBuildKey")
+	autoGrantProDomains := conf.RequireSecret("autoGrantProDomains")
 	auth0M2mClientID := conf.RequireSecret("auth0M2mClientId")
 	auth0M2mClientSecret := conf.RequireSecret("auth0M2mClientSecret")
 
@@ -363,6 +364,11 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		Secrets: app.SecretArray{
 			&app.SecretArgs{Name: pulumi.String("auth0-m2m-client-id"), Value: auth0M2mClientID},
 			&app.SecretArgs{Name: pulumi.String("auth0-m2m-client-secret"), Value: auth0M2mClientSecret},
+			// Kept DEFINED but UNREFERENCED to unblock cd-dev: removing this secret 409s
+			// (ContainerAppSecretInUse) while active revisions still reference it. The env var
+			// that referenced it stays removed; a Phase-2 PR deletes the secret once those
+			// revisions are cleaned up (tc-h79o).
+			&app.SecretArgs{Name: pulumi.String("auto-grant-pro-domains"), Value: autoGrantProDomains},
 			// Admin key the Go X-Admin-Key gate validates for /v1/admin requests (tc-52t6).
 			&app.SecretArgs{Name: pulumi.String("admin-api-key"), Value: adminAPIKey},
 			// Build key the Go gate validates for the SEO prerender endpoint (tc-nnte).


### PR DESCRIPTION
## What
Unblocks cd-dev after #611. Re-adds **only** the `auto-grant-pro-domains` container-app secret definition (`RequireSecret` + `SecretArgs`); the `SUBSCRIPTION_AUTOGRANT_PRODOMAINS` env var stays removed.

## Why
#611's cd-dev `pulumi up` failed `Status=409 ContainerAppSecretInUse`: Azure won't delete a secret while active revisions still reference it, and dev's multi-active revisions (123–129) all bound `auto-grant-pro-domains` via the old env var. This is the phased-removal fix (Option A):
- Keeping the secret **defined** means `pulumi up` doesn't try to delete it → no 409.
- The new revision no longer **references** it (env var gone) → once the old revisions age out (weekly cleanup), a Phase-2 PR can delete the secret cleanly.

The auto-grant remains dead end-to-end: the api-go code and the env var are gone, so nothing reads the secret. It's a defined-but-unreferenced orphan until Phase 2.

## Verified
`go build`/`vet`/`gofmt` clean. CI still injects `autoGrantProDomains` (`setup-pulumi-secrets` + cd-dev/cd-prod), so `RequireSecret` resolves in cd — no missing-config panic. The actual 409 resolution is confirmed by watching cd-dev post-merge.

Bead: tc-h79o (fixes the deploy failure from #611). Phase-2 secret deletion tracked as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Configured automatic Pro domain assignment in infrastructure to prevent deployment conflicts during application updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->