### PR TITLE
chore: final removal of auto-grant-pro-domains secret + CI injection (tc-f1fj, tc-bi9z)

### DIFF
--- a/.github/actions/setup-pulumi-secrets/action.yml
+++ b/.github/actions/setup-pulumi-secrets/action.yml
@@ -13,9 +13,6 @@ inputs:
   site-build-key:
     description: Build key for the gated SEO prerender endpoint
     required: true
-  auto-grant-pro-domains:
-    description: Comma-separated email domains for automatic Pro tier
-    required: true
   auth0-m2m-client-id:
     description: Auth0 machine-to-machine client ID
     required: true
@@ -36,6 +33,5 @@ runs:
       run: |
         pulumi config set --secret adminApiKey "${{ inputs.admin-api-key }}"
         pulumi config set --secret siteBuildKey "${{ inputs.site-build-key }}"
-        pulumi config set --secret autoGrantProDomains "${{ inputs.auto-grant-pro-domains }}"
         pulumi config set --secret auth0M2mClientId "${{ inputs.auth0-m2m-client-id }}"
         pulumi config set --secret auth0M2mClientSecret "${{ inputs.auth0-m2m-client-secret }}"

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -12,7 +12,6 @@
 #   ACR_LOGIN_SERVER       — Azure Container Registry login server
 #   PULUMI_ACCESS_TOKEN    — Pulumi Cloud access token
 #   ADMIN_API_KEY          — API key for admin endpoints
-#   AUTO_GRANT_PRO_DOMAINS — Comma-separated email domains for automatic Pro tier
 #
 # Requires GitHub Environment:
 #   development            — with OIDC federated credential (environment:development)
@@ -102,7 +101,6 @@ jobs:
         with:
           admin-api-key: ${{ secrets.ADMIN_API_KEY }}
           site-build-key: ${{ secrets.SITE_BUILD_KEY }}
-          auto-grant-pro-domains: ${{ secrets.AUTO_GRANT_PRO_DOMAINS }}
           auth0-m2m-client-id: ${{ secrets.AUTH0_M2M_CLIENT_ID }}
           auth0-m2m-client-secret: ${{ secrets.AUTH0_M2M_CLIENT_SECRET }}
 

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -7,7 +7,6 @@
 #   AZURE_SUBSCRIPTION_ID  — Azure subscription
 #   PULUMI_ACCESS_TOKEN    — Pulumi Cloud access token
 #   ADMIN_API_KEY          — API key for admin endpoints
-#   AUTO_GRANT_PRO_DOMAINS — Comma-separated email domains for automatic Pro tier
 #
 # Requires GitHub Environment:
 #   production             — with OIDC federated credential (environment:production)
@@ -61,7 +60,6 @@ jobs:
         with:
           admin-api-key: ${{ secrets.ADMIN_API_KEY }}
           site-build-key: ${{ secrets.SITE_BUILD_KEY }}
-          auto-grant-pro-domains: ${{ secrets.AUTO_GRANT_PRO_DOMAINS }}
           auth0-m2m-client-id: ${{ secrets.AUTH0_M2M_CLIENT_ID }}
           auth0-m2m-client-secret: ${{ secrets.AUTH0_M2M_CLIENT_SECRET }}
 

--- a/infra/environment.go
+++ b/infra/environment.go
@@ -135,7 +135,6 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 	adminAPIKey := conf.RequireSecret("adminApiKey")
 	// Build key the Go endpoint validates for the gated SEO prerender route (tc-nnte).
 	siteBuildKey := conf.RequireSecret("siteBuildKey")
-	autoGrantProDomains := conf.RequireSecret("autoGrantProDomains")
 	auth0M2mClientID := conf.RequireSecret("auth0M2mClientId")
 	auth0M2mClientSecret := conf.RequireSecret("auth0M2mClientSecret")
 
@@ -364,11 +363,6 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		Secrets: app.SecretArray{
 			&app.SecretArgs{Name: pulumi.String("auth0-m2m-client-id"), Value: auth0M2mClientID},
 			&app.SecretArgs{Name: pulumi.String("auth0-m2m-client-secret"), Value: auth0M2mClientSecret},
-			// Kept DEFINED but UNREFERENCED to unblock cd-dev: removing this secret 409s
-			// (ContainerAppSecretInUse) while active revisions still reference it. The env var
-			// that referenced it stays removed; a Phase-2 PR deletes the secret once those
-			// revisions are cleaned up (tc-h79o).
-			&app.SecretArgs{Name: pulumi.String("auto-grant-pro-domains"), Value: autoGrantProDomains},
 			// Admin key the Go X-Admin-Key gate validates for /v1/admin requests (tc-52t6).
 			&app.SecretArgs{Name: pulumi.String("admin-api-key"), Value: adminAPIKey},
 			// Build key the Go gate validates for the SEO prerender endpoint (tc-nnte).


### PR DESCRIPTION
## What
Phase-2 completion of the pro-domain auto-grant removal. Deletes the `auto-grant-pro-domains` secret end-to-end now that no active container-app revision references it.

**These two beads ship together by necessity:** infra must stop *requiring* the secret in the same change CI stops *setting* it, otherwise `pulumi up` would panic on missing config.

- **tc-f1fj** (`infra/environment.go`): removed `RequireSecret("autoGrantProDomains")` + the `auto-grant-pro-domains` `SecretArgs` (the defined-but-unreferenced orphan left by #613's phased fix).
- **tc-bi9z** (`.github/`): removed the orphaned injection — the `auto-grant-pro-domains` input in `setup-pulumi-secrets`, the `pulumi config set` line, and the `AUTO_GRANT_PRO_DOMAINS` inputs/comments in `cd-dev.yml` / `cd-prod.yml`.

## Why it's safe now
The 7 old dev revisions referencing the secret were deactivated, and prod's old revision auto-cleared in Single mode on the v0.15.34 deploy. So `pulumi up` can now delete the secret with no `ContainerAppSecretInUse` 409 (the failure that blocked #611).

## Verified
- `grep` for `autoGrantProDomains` / `AUTO_GRANT_PRO_DOMAINS` / `auto-grant-pro-domains` across `infra/` + `.github/` → empty.
- infra `go build`/`vet`/`gofmt` clean; all 3 workflow/action YAMLs parse; `actionlint` clean.
- Clean `pulumi up` (secret deletion, no 409) confirmed by the author at cd-dev post-merge.

## Follow-up (operational, post-merge)
The `AUTO_GRANT_PRO_DOMAINS` repository secret is deleted via `gh secret delete` after merge (unused once these land).

Closes the pro-domain removal. Beads: tc-f1fj, tc-bi9z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions and deployment workflows to remove `auto-grant-pro-domains` secret handling.
  * Added new required `site-build-key` input to deployment configuration setup.
  * Updated infrastructure environment code to remove related secret provisioning from container configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->