### PR TITLE
docs(offercodes): correct OfferCodes partition-key comments to /code (tc-aaqg)

### DIFF
--- a/api-go/internal/offercodes/document.go
+++ b/api-go/internal/offercodes/document.go
@@ -8,7 +8,7 @@ import (
 )
 
 // offerCodeDocument is the Cosmos persistence shape (camelCase keys, DateTimeOffset
-// "+00:00" format for timestamps). id == code == partition key.
+// "+00:00" format for timestamps). id == code, partition key /code.
 //
 // Redeemed is the consumed tombstone (GDPR Art. 17): it stays true after a
 // redeemer is scrubbed from RedeemedByUserId / RedeemedAt, so the code can never

--- a/api-go/internal/offercodes/store_cosmos.go
+++ b/api-go/internal/offercodes/store_cosmos.go
@@ -30,7 +30,7 @@ type cosmosItems interface {
 
 // CosmosStore reads and writes offer codes in the OfferCodes container.
 //
-// Partition strategy: the OfferCodes container is partitioned by /id == the
+// Partition strategy: the OfferCodes container is partitioned by /code == the
 // canonical code, so every operation is a single-partition point operation.
 type CosmosStore struct {
 	items cosmosItems
@@ -55,7 +55,7 @@ func (s *CosmosStore) Get(ctx context.Context, canonical string) (OfferCode, err
 	return doc.toDomain()
 }
 
-// Save upserts the code document (id == code == partition key), covering both
+// Save upserts the code document (id == code, partition key /code), covering both
 // create and update.
 func (s *CosmosStore) Save(ctx context.Context, c OfferCode) error {
 	body, err := json.Marshal(newOfferCodeDocument(c))
@@ -113,14 +113,14 @@ func (s *CosmosStore) RedeemWithCAS(ctx context.Context, canonical, userID strin
 }
 
 // redeemedByUserIDQuery selects every code a user redeemed. The OfferCodes
-// container is partitioned by /id == the canonical code, not by redeemer, so
+// container is partitioned by /code == the canonical code, not by redeemer, so
 // this is a deliberate cross-partition scan.
 const redeemedByUserIDQuery = "SELECT * FROM c WHERE c.redeemedByUserId = @userId"
 
 // RedeemedByUserID returns every code the user redeemed, hydrated to the domain
 // model, for the GDPR data export (GET /v1/me/data). It reuses the same
 // cross-partition redeemedByUserId scan as the anonymise path (the OfferCodes
-// container is partitioned by /id == the canonical code, not by redeemer, so
+// container is partitioned by /code == the canonical code, not by redeemer, so
 // finding a user's redemptions must fan out across partitions). The common case
 // (the user never redeemed a code) matches nothing and returns an empty, non-nil
 // slice. The export sorts the result, so no ORDER BY is needed here.

--- a/api-go/internal/platform/cosmos.go
+++ b/api-go/internal/platform/cosmos.go
@@ -265,7 +265,7 @@ const (
 	// partition key /userId, document id == "{userId}:{applicationUid}".
 	CosmosSavedApplicationsContainer = "SavedApplications"
 	// CosmosOfferCodesContainer holds one document per offer code; partition key
-	// /id == the canonical code, document id == the canonical code.
+	// /code == the canonical code, document id == the canonical code.
 	CosmosOfferCodesContainer = "OfferCodes"
 	// CosmosAppleNotificationsContainer holds one document per processed App Store
 	// Server Notification; partition key /id == the notificationUUID, document id


### PR DESCRIPTION
## What

The OfferCodes Cosmos container is provisioned with partition key **/code** (`infra/environment.go`), but several Go comments wrongly described it as `/id`. This corrects the drift found during the 2026-06-22 Cosmos audit (tc-aaqg).

Document values are written `id == code` (both set to the canonical code), so point reads resolve identically — this was comment rot, **not** a runtime bug.

## Changes (comment-only)

- `api-go/internal/platform/cosmos.go` — `CosmosOfferCodesContainer` doc: `/id` → `/code`
- `api-go/internal/offercodes/store_cosmos.go` — partition-strategy comment, `Save` comment, and two cross-partition-scan comments: `/id`/`partition key` → `/code`
- `api-go/internal/offercodes/document.go` — `id == code == partition key` → `id == code, partition key /code`

No behaviour change. The actual partition key and the load-bearing dual `ID == Code` write are untouched.

## Quality gates (all green)

- `go build ./...` ✅
- `go test -race ./...` ✅ (1092 passed, 38 packages)
- `go vet ./...` ✅
- `gofmt -l .` ✅ (empty)
- `golangci-lint run ./...` ✅ (no issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation to clarify system behavior and improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->