### PR TITLE
perf(profiles): filter dormant sweep server-side via lastActiveAtEpoch (tc-b9yj)

### DIFF
--- a/api-go/internal/profiles/admin_store.go
+++ b/api-go/internal/profiles/admin_store.go
@@ -101,16 +101,27 @@ func (s *AdminStore) ByDigestDay(ctx context.Context, day time.Weekday) ([]*User
 	return profiles, nil
 }
 
+// dormantQuery selects the dormant candidate set server-side on the numeric
+// lastActiveAtEpoch mirror (Unix millis), which sorts unambiguously — unlike the
+// lastActiveAt string, persisted in two wire formats ("+00:00" and RFC 3339 "Z")
+// that do not sort lexicographically. The NOT IS_DEFINED clause also returns any
+// legacy doc written before the mirror existed, so no dormant account is silently
+// dropped during rollout; those un-backfilled docs (and only those) are then
+// classified by the Go-side cutoff gate below. The cross-partition fan-out is
+// inherent ("find dormant users across all partitions") and kept; only the full
+// client-side hydration is removed.
+const dormantQuery = "SELECT * FROM c WHERE c.lastActiveAtEpoch < @cutoffEpoch OR NOT IS_DEFINED(c.lastActiveAtEpoch)"
+
 // Dormant returns every profile last active strictly before cutoff — the
 // dormant-account set the cleanup worker erases (UK GDPR Art. 5(1)(e), ADR 0023).
-// The cutoff comparison is done in Go on the parsed LastActiveAt rather than as a
-// Cosmos string comparison: production documents carry lastActiveAt in two wire
-// formats ("+00:00" and RFC 3339 "Z"), and "Z" sorts after "+", so a
-// lexicographic SQL "<" would silently miss "Z"-stored dormant accounts. The
-// scan is a once-a-day batch over a small user base, so hydrating all profiles
-// and filtering in Go is both correct and cheap.
+// The server-side filter (see dormantQuery) shrinks the hydrated set from "all
+// users" to "dormant users plus any not-yet-backfilled legacy docs". The Go-side
+// LastActiveAt.Before(cutoff) check below remains the final authority: it is what
+// keeps a legacy (epoch-less) doc belonging to an active user from being erased,
+// and it preserves the strictly-before semantics the deletion path depends on.
 func (s *AdminStore) Dormant(ctx context.Context, cutoff time.Time) ([]*UserProfile, error) {
-	rows, err := s.items.QueryItemsCrossPartition(ctx, "SELECT * FROM c", nil)
+	rows, err := s.items.QueryItemsCrossPartition(ctx, dormantQuery,
+		map[string]any{"@cutoffEpoch": cutoff.UnixMilli()})
 	if err != nil {
 		return nil, fmt.Errorf("query dormant profiles: %w", err)
 	}

--- a/api-go/internal/profiles/admin_store_test.go
+++ b/api-go/internal/profiles/admin_store_test.go
@@ -273,6 +273,90 @@ func TestAdminStore_Dormant_KeepsAccountsActiveAtOrAfterCutoff(t *testing.T) {
 	}
 }
 
+// legacyProfileDocAt builds a stored profile document WITHOUT the
+// lastActiveAtEpoch field, simulating an un-backfilled document written before
+// the numeric mirror existed. Such docs are returned by the server-side
+// NOT IS_DEFINED fallback and must still be classified correctly by the Go gate.
+func legacyProfileDocAt(t *testing.T, userID string, lastActive time.Time) []byte {
+	t.Helper()
+	p, err := NewProfile(userID, "", lastActive)
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	p.LastActiveAt = lastActive
+	var doc map[string]any
+	if err := json.Unmarshal(profileDocAt(t, userID, lastActive), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	delete(doc, "lastActiveAtEpoch")
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return raw
+}
+
+func TestAdminStore_Dormant_FiltersServerSide(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2025, 6, 14, 0, 0, 0, 0, time.UTC)
+
+	items := newFakeAdminItems()
+	store := NewAdminStore(items)
+
+	if _, err := store.Dormant(context.Background(), cutoff); err != nil {
+		t.Fatalf("Dormant: %v", err)
+	}
+
+	// The scan filters server-side on the numeric epoch mirror, shrinking the
+	// hydrated set from "all users" to "dormant users" — while the NOT IS_DEFINED
+	// fallback keeps any un-backfilled (legacy) doc in the result set so it is
+	// never silently dropped during rollout.
+	const want = "SELECT * FROM c WHERE c.lastActiveAtEpoch < @cutoffEpoch OR NOT IS_DEFINED(c.lastActiveAtEpoch)"
+	if items.gotQuery != want {
+		t.Errorf("query = %q, want %q", items.gotQuery, want)
+	}
+	// The cutoff binds as epoch milliseconds so it sorts against the numeric field.
+	if epoch, ok := items.gotParams["@cutoffEpoch"].(int64); !ok || epoch != cutoff.UnixMilli() {
+		t.Errorf("@cutoffEpoch = %v, want int64 %d", items.gotParams["@cutoffEpoch"], cutoff.UnixMilli())
+	}
+}
+
+func TestAdminStore_Dormant_ClassifiesLegacyDocsInGo(t *testing.T) {
+	t.Parallel()
+	cutoff := time.Date(2025, 6, 14, 0, 0, 0, 0, time.UTC)
+
+	// Legacy docs lack lastActiveAtEpoch, so the server returns them via the
+	// NOT IS_DEFINED fallback regardless of activity. The Go-side cutoff gate is
+	// the final authority: a legacy-but-active account must NOT be erased, and a
+	// legacy-and-dormant account must still be caught.
+	items := newFakeAdminItems()
+	items.queryResult = [][]byte{
+		legacyProfileDocAt(t, "legacy-dormant", cutoff.AddDate(0, -1, 0)), // before cutoff -> dormant
+		legacyProfileDocAt(t, "legacy-active", cutoff.AddDate(0, 1, 0)),   // after cutoff -> kept
+		profileDocAt(t, "backfilled-dormant", cutoff.AddDate(-1, 0, 0)),   // backfilled, dormant
+	}
+	store := NewAdminStore(items)
+
+	got, err := store.Dormant(context.Background(), cutoff)
+	if err != nil {
+		t.Fatalf("Dormant: %v", err)
+	}
+
+	ids := map[string]bool{}
+	for _, p := range got {
+		ids[p.UserID] = true
+	}
+	if !ids["legacy-dormant"] || !ids["backfilled-dormant"] {
+		t.Errorf("dormant accounts missing from result: %v", ids)
+	}
+	if ids["legacy-active"] {
+		t.Error("a legacy doc active after the cutoff must not be erased (Go gate is the final authority)")
+	}
+	if len(got) != 2 {
+		t.Errorf("dormant count: got %d, want 2", len(got))
+	}
+}
+
 func TestAdminStore_Dormant_WrapsQueryError(t *testing.T) {
 	t.Parallel()
 	items := newFakeAdminItems()

--- a/api-go/internal/profiles/document.go
+++ b/api-go/internal/profiles/document.go
@@ -33,6 +33,16 @@ type profileDocument struct {
 	OriginalTransactionID *string    `json:"originalTransactionId"`
 	GracePeriodExpiry     *time.Time `json:"gracePeriodExpiry"`
 	LastActiveAt          time.Time  `json:"lastActiveAt"`
+	// LastActiveAtEpoch is LastActiveAt as Unix epoch milliseconds — a numeric
+	// mirror written on every upsert so the dormant scan filters server-side on a
+	// value that sorts unambiguously. lastActiveAt itself is persisted in two wire
+	// formats ("+00:00" and "Z") that do not sort lexicographically, so a SQL
+	// string comparison on it would silently miss "Z"-stored accounts. It is a
+	// derived query-acceleration field: LastActiveAt remains the source of truth,
+	// so toDomain reads the timestamp, not this mirror. No omitempty — the key must
+	// always be present so a server-side IS_DEFINED check can tell a freshly
+	// written doc from a legacy, un-backfilled one.
+	LastActiveAtEpoch int64 `json:"lastActiveAtEpoch"`
 	// watchZoneCount is the CAS quota counter. omitempty so legacy documents
 	// (written before this field existed) remain unchanged on re-read.
 	WatchZoneCount *int `json:"watchZoneCount,omitempty"`
@@ -71,6 +81,7 @@ func newProfileDocument(p *UserProfile) profileDocument {
 		OriginalTransactionID: p.OriginalTransactionID,
 		GracePeriodExpiry:     p.GracePeriodExpiry,
 		LastActiveAt:          p.LastActiveAt,
+		LastActiveAtEpoch:     p.LastActiveAt.UnixMilli(),
 		WatchZoneCount:        p.WatchZoneCount,
 	}
 }

--- a/api-go/internal/profiles/document_test.go
+++ b/api-go/internal/profiles/document_test.go
@@ -78,6 +78,45 @@ func TestProfileDocument_JSONShapeMatchesNET(t *testing.T) {
 	}
 }
 
+func TestProfileDocument_EmitsLastActiveAtEpoch(t *testing.T) {
+	t.Parallel()
+
+	// lastActiveAtEpoch is a numeric (epoch-millis) mirror of lastActiveAt,
+	// written on every profile upsert so the dormant scan can filter server-side
+	// on a value that sorts unambiguously (lastActiveAt itself is persisted in two
+	// wire formats, "+00:00" and "Z", that do not sort lexicographically).
+	now := time.Date(2026, 6, 11, 9, 30, 0, 0, time.UTC)
+	p, err := NewProfile("auth0|abc", "", now)
+	if err != nil {
+		t.Fatalf("NewProfile: %v", err)
+	}
+	p.LastActiveAt = now
+
+	b, err := json.Marshal(newProfileDocument(p))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	// The numeric mirror must be present and equal to LastActiveAt.UnixMilli().
+	var doc profileDocument
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if doc.LastActiveAtEpoch != now.UnixMilli() {
+		t.Errorf("lastActiveAtEpoch = %d, want %d", doc.LastActiveAtEpoch, now.UnixMilli())
+	}
+
+	// The JSON key must actually be present so a server-side IS_DEFINED check
+	// distinguishes a freshly written doc from a legacy un-backfilled one.
+	var raw map[string]any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	if _, present := raw["lastActiveAtEpoch"]; !present {
+		t.Error("lastActiveAtEpoch key should be present on every written document")
+	}
+}
+
 func TestProfileDocument_RoundTrip(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

The dormant-cleanup sweep (`WORKER_MODE=dormant-cleanup`, cron 03:30 daily) ran `SELECT * FROM c` against the Users container and filtered `LastActiveAt < cutoff` in Go — hydrating **every** profile each run. A server-side `WHERE c.lastActiveAt < @cutoff` was impossible because `lastActiveAt` is persisted in two wire formats (`+00:00` and `Z`) that do not sort lexicographically, so a SQL string `<` would silently miss `Z`-stored dormant accounts.

This moves the cutoff filter **server-side**, shrinking the hydrated result set from "all users" to "dormant users" (plus, transiently, any not-yet-backfilled legacy docs). The cross-partition fan-out is kept — it is inherent to "find dormant users across all partitions"; only the full client-side hydration was the waste.

## How (Option B — numeric epoch field)

- Added `profileDocument.LastActiveAtEpoch` (`int64`, Unix millis, `json:"lastActiveAtEpoch"`, no `omitempty`), written via `newProfileDocument` — the single mapping point, so **every** write site is covered automatically.
- `Dormant()` now queries:
  ```sql
  SELECT * FROM c WHERE c.lastActiveAtEpoch < @cutoffEpoch OR NOT IS_DEFINED(c.lastActiveAtEpoch)
  ```
  with `@cutoffEpoch = cutoff.UnixMilli()`. The epoch sorts unambiguously, sidestepping the two-format string-sort risk without changing the `lastActiveAt` string (no other reader depends on its format — all consumers parse to `time.Time`).
- The Go-side `LastActiveAt.Before(cutoff)` gate is **kept as the final authority**. This is essential: it stops a legacy (epoch-less) doc belonging to an *active* user — returned by the `NOT IS_DEFINED` fallback — from being erased, and it preserves strictly-before semantics.

## Backfill safety

Existing docs lack the field. The `OR NOT IS_DEFINED(...)` fallback (same idiom already used in `notifications/digest_store_cosmos.go`) ensures legacy docs are still returned and Go-classified, so **no dormant account is silently dropped** during rollout. Every profile write now backfills the field, so the set converges naturally.

An optional one-shot backfill to realise the full RU saving sooner belongs in a `tc` admin CLI command (in `/cli`, out of scope here) — split to **tc-au3x** (`discovered-from` tc-b9yj).

## Out of scope / unchanged

- Cutoff value and deletion semantics are **unchanged** — only *where* the filter executes.
- No `/cli`, `/infra`, web, iOS, or `.claude` changes.

## Tests (TDD, red→green)

- `TestProfileDocument_EmitsLastActiveAtEpoch` — epoch mirror written and key present.
- `TestAdminStore_Dormant_FiltersServerSide` — query string + `@cutoffEpoch` binding.
- `TestAdminStore_Dormant_ClassifiesLegacyDocsInGo` — legacy (epoch-less) active doc not erased; legacy + backfilled dormant docs caught.
- Existing dormant behaviour tests retained.

Gates: `gofmt`/`go vet`/`go build`/`golangci-lint` clean; `go test -race ./...` 1095 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)