### PR TITLE
perf: authority pre-filter + projection on WatchZones.FindZonesContaining (tc-8dud)

### DIFF
--- a/api-go/internal/notifydispatch/decision.go
+++ b/api-go/internal/notifydispatch/decision.go
@@ -11,10 +11,10 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
-// zoneMatcher runs the cross-partition point-in-zone lookup.
-// *watchzones.CosmosStore satisfies it.
+// zoneMatcher runs the cross-partition point-in-zone lookup, scoped to the
+// polled application's authority. *watchzones.CosmosStore satisfies it.
 type zoneMatcher interface {
-	FindZonesContaining(ctx context.Context, latitude, longitude float64) ([]watchzones.WatchZone, error)
+	FindZonesContaining(ctx context.Context, authorityID int, latitude, longitude float64) ([]watchzones.WatchZone, error)
 }
 
 // savedMatcher runs the cross-partition saved-bookmark lookup.
@@ -96,7 +96,7 @@ func (d *DecisionDispatcher) Dispatch(ctx context.Context, app applications.Plan
 
 	// Zone matchers — only meaningful when the application has coordinates.
 	if app.Latitude != nil && app.Longitude != nil {
-		zones, err := d.zones.FindZonesContaining(ctx, *app.Latitude, *app.Longitude)
+		zones, err := d.zones.FindZonesContaining(ctx, app.AreaID, *app.Latitude, *app.Longitude)
 		if err != nil {
 			return err
 		}

--- a/api-go/internal/notifydispatch/decision_test.go
+++ b/api-go/internal/notifydispatch/decision_test.go
@@ -14,13 +14,15 @@ import (
 
 // fakeZones serves the cross-partition zone-containment lookup.
 type fakeZones struct {
-	zones    []watchzones.WatchZone
-	queryErr error
-	lastLat  float64
-	lastLng  float64
+	zones           []watchzones.WatchZone
+	queryErr        error
+	lastAuthorityID int
+	lastLat         float64
+	lastLng         float64
 }
 
-func (f *fakeZones) FindZonesContaining(_ context.Context, lat, lng float64) ([]watchzones.WatchZone, error) {
+func (f *fakeZones) FindZonesContaining(_ context.Context, authorityID int, lat, lng float64) ([]watchzones.WatchZone, error) {
+	f.lastAuthorityID = authorityID
 	f.lastLat = lat
 	f.lastLng = lng
 	if f.queryErr != nil {
@@ -125,6 +127,24 @@ func TestDecisionDispatcher_ZoneMatch_CreatesDecisionRecordAndPushes(t *testing.
 	}
 	if push.calls != 1 {
 		t.Errorf("paid tier with decision push opted in should push, got %d", push.calls)
+	}
+}
+
+func TestDecisionDispatcher_Dispatch_PassesApplicationAuthorityToZoneMatcher(t *testing.T) {
+	t.Parallel()
+	// The decision zone fan-out must scope to the polled application's authority,
+	// matching the saved-bookmark path's existing app.AreaID scoping. No zones or
+	// saved holders are configured, so this isolates the authority threading.
+	zones := &fakeZones{}
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{}}
+	d, _, _ := newDecisionHarness(t, zones, &fakeSaved{}, profs)
+	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
+
+	if err := d.Dispatch(context.Background(), app); err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if zones.lastAuthorityID != app.AreaID {
+		t.Errorf("zone matcher authority: got %d, want %d (app.AreaID)", zones.lastAuthorityID, app.AreaID)
 	}
 }
 

--- a/api-go/internal/notifydispatch/enqueuer.go
+++ b/api-go/internal/notifydispatch/enqueuer.go
@@ -139,7 +139,7 @@ func (e *Enqueuer) EnqueueForApplication(ctx context.Context, app applications.P
 	if app.Latitude == nil || app.Longitude == nil {
 		return nil
 	}
-	zones, err := e.zones.FindZonesContaining(ctx, *app.Latitude, *app.Longitude)
+	zones, err := e.zones.FindZonesContaining(ctx, app.AreaID, *app.Latitude, *app.Longitude)
 	if err != nil {
 		return err
 	}

--- a/api-go/internal/notifydispatch/enqueuer_test.go
+++ b/api-go/internal/notifydispatch/enqueuer_test.go
@@ -204,6 +204,23 @@ func TestEnqueuer_EnqueueForApplication_FansOutToContainingZones(t *testing.T) {
 	}
 }
 
+func TestEnqueuer_EnqueueForApplication_PassesApplicationAuthorityToZoneMatcher(t *testing.T) {
+	t.Parallel()
+	// The new-application zone fan-out must scope to the polled application's
+	// authority: a WatchZone is authority-scoped, so the matcher is asked only for
+	// zones in the application's authority (app.AreaID), mirroring the
+	// saved-bookmark path's existing app.AreaID scoping.
+	enq, _, _, fz := newEnqueuerHarnessWithZones(t, profiles.TierPro, &fakeZones{})
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+
+	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
+		t.Fatalf("EnqueueForApplication: %v", err)
+	}
+	if fz.lastAuthorityID != app.AreaID {
+		t.Errorf("zone matcher authority: got %d, want %d (app.AreaID)", fz.lastAuthorityID, app.AreaID)
+	}
+}
+
 func TestEnqueuer_EnqueueForApplication_OneUserTwoZonesDedupsToOneRecord(t *testing.T) {
 	t.Parallel()
 	// A single user with two containing zones must still get ONE NewApplication

--- a/api-go/internal/watchzones/store_cosmos.go
+++ b/api-go/internal/watchzones/store_cosmos.go
@@ -172,24 +172,42 @@ func (s *CosmosStore) DistinctAuthorityIDs(ctx context.Context) ([]int, error) {
 	return ids, nil
 }
 
-// findZonesContainingQuery selects every watch zone whose circle (centre +
-// radius) contains the candidate point, across all partitions. The candidate
-// point is bound as parameters; the zone centre is read from each document's
+// findZonesContainingQuery selects every watch zone scoped to the candidate
+// application's authority whose circle (centre + radius) contains the candidate
+// point, across all partitions. The authority equality predicate is evaluated by
+// Cosmos's default range index, pruning rows before the unindexed ST_DISTANCE
+// test runs — a WatchZone is authority-scoped (see zone.go), so a zone only ever
+// matches applications in its own authority, mirroring the saved-bookmark path's
+// app.AreaID scoping (notifydispatch/decision.go). The candidate authority and
+// point are bound as parameters; the zone centre is read from each document's
 // latitude/longitude columns.
-const findZonesContainingQuery = "SELECT * FROM c WHERE ST_DISTANCE(" +
+//
+// The projection is deliberate, not SELECT *: only the columns this hot path
+// needs are hydrated. id/userId/createdAt are consumed by the callers;
+// name/radiusMetres/authorityId are required by the NewWatchZone constructor so
+// the hydrated zone stays valid; pushEnabled/emailInstantEnabled are projected
+// (not dropped) because they are nullable *bool that coalesce to true when
+// absent, so omitting them would silently re-enable a user's disabled
+// notifications if a future caller read them. latitude/longitude are omitted —
+// no caller reads zone coordinates after the match.
+const findZonesContainingQuery = "SELECT c.id, c.userId, c.name, c.radiusMetres, c.authorityId, c.createdAt, c.pushEnabled, c.emailInstantEnabled " +
+	"FROM c WHERE c.authorityId = @authorityId AND ST_DISTANCE(" +
 	"{'type': 'Point', 'coordinates': [c.longitude, c.latitude]}, " +
 	"{'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres"
 
-// FindZonesContaining returns every watch zone (across all users) whose circle
-// contains the point (latitude, longitude), via a cross-partition ST_DISTANCE
-// query against each zone's centre and radius. It backs the poll-path
-// notification fan-out and decision-event dispatch (epic tc-wad3, bead tc-uc2p).
-// This is a deliberate cross-partition scan — a polled application's coordinates
-// must be matched against every user's zones.
-func (s *CosmosStore) FindZonesContaining(ctx context.Context, latitude, longitude float64) ([]WatchZone, error) {
+// FindZonesContaining returns every watch zone (across all users) scoped to the
+// given authority whose circle contains the point (latitude, longitude), via a
+// cross-partition query that pre-filters on the authority (index-served) before
+// the ST_DISTANCE test against each zone's centre and radius. It backs the
+// poll-path notification fan-out and decision-event dispatch (epic tc-wad3, bead
+// tc-uc2p); authorityID is the polled application's authority (app.AreaID). This
+// is a deliberate cross-partition scan — a polled application's coordinates must
+// be matched against every user's zones in that authority.
+func (s *CosmosStore) FindZonesContaining(ctx context.Context, authorityID int, latitude, longitude float64) ([]WatchZone, error) {
 	raws, err := s.items.QueryItemsCrossPartition(ctx, findZonesContainingQuery, map[string]any{
-		"@latitude":  latitude,
-		"@longitude": longitude,
+		"@authorityId": authorityID,
+		"@latitude":    latitude,
+		"@longitude":   longitude,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("find zones containing point: %w", err)

--- a/api-go/internal/watchzones/store_cosmos_test.go
+++ b/api-go/internal/watchzones/store_cosmos_test.go
@@ -299,7 +299,7 @@ func TestCosmosStore_FindZonesContaining_CrossPartitionSpatialQuery(t *testing.T
 	items.crossPartitionResult = [][]byte{mustDocBytes(t, z)}
 	store := NewCosmosStore(items)
 
-	zones, err := store.FindZonesContaining(context.Background(), 51.5155, -0.0931)
+	zones, err := store.FindZonesContaining(context.Background(), z.AuthorityID, 51.5155, -0.0931)
 	if err != nil {
 		t.Fatalf("FindZonesContaining: %v", err)
 	}
@@ -319,10 +319,95 @@ func TestCosmosStore_FindZonesContaining_CrossPartitionSpatialQuery(t *testing.T
 	}
 }
 
+func TestCosmosStore_FindZonesContaining_FiltersByAuthorityBeforeDistance(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	// An application in authority 99 must match ONLY zones scoped to authority 99.
+	// The store sends Cosmos an equality predicate on c.authorityId bound to the
+	// application's authority alongside the ST_DISTANCE test, so a zone scoped to a
+	// different authority is never returned even when the application falls
+	// geographically within the zone's radius. This is the documented
+	// authority-scoped zone model (zone.go) and mirrors the saved-bookmark path's
+	// existing app.AreaID scoping. Cosmos evaluates the predicate; this test locks
+	// that the predicate is present and bound to the passed authority.
+	if _, err := store.FindZonesContaining(context.Background(), 99, 51.5, -0.1); err != nil {
+		t.Fatalf("FindZonesContaining: %v", err)
+	}
+	if !strings.Contains(items.lastQuery, "c.authorityId = @authorityId") {
+		t.Errorf("query must filter on c.authorityId = @authorityId: %q", items.lastQuery)
+	}
+	if items.lastParams["@authorityId"] != 99 {
+		t.Errorf("@authorityId param: got %v, want 99", items.lastParams["@authorityId"])
+	}
+	// The authority equality must be ANDed with the distance test, not replace it.
+	if !strings.Contains(items.lastQuery, "ST_DISTANCE") || !strings.Contains(items.lastQuery, "c.radiusMetres") {
+		t.Errorf("query must keep the ST_DISTANCE radius test alongside the authority filter: %q", items.lastQuery)
+	}
+}
+
+func TestCosmosStore_FindZonesContaining_ProjectsNeededFieldsNotSelectStar(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if _, err := store.FindZonesContaining(context.Background(), 99, 51.5, -0.1); err != nil {
+		t.Fatalf("FindZonesContaining: %v", err)
+	}
+	// SELECT * hydrates whole docs on every cross-partition fan-out row. The query
+	// instead projects only the columns this path needs: id/userId/createdAt are
+	// consumed by the callers; name/radiusMetres/authorityId are required by the
+	// NewWatchZone constructor so the hydrated zone stays valid; pushEnabled and
+	// emailInstantEnabled are KEPT (not dropped) because they are nullable *bool
+	// that coalesce to true when absent — projecting them away would silently
+	// re-enable a user's disabled notifications if a future caller read them.
+	// latitude/longitude are dropped: no caller reads zone coordinates after the
+	// match (the distance test already ran server-side).
+	if strings.Contains(items.lastQuery, "SELECT *") {
+		t.Errorf("query must not SELECT * on the poll hot path: %q", items.lastQuery)
+	}
+	for _, field := range []string{"c.id", "c.userId", "c.name", "c.radiusMetres", "c.authorityId", "c.createdAt", "c.pushEnabled", "c.emailInstantEnabled"} {
+		if !strings.Contains(items.lastQuery, field) {
+			t.Errorf("projection missing %q: %q", field, items.lastQuery)
+		}
+	}
+}
+
+func TestCosmosStore_FindZonesContaining_HydratesProjectedDocument(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	// A projected row carries no latitude/longitude (those columns are dropped from
+	// the projection). The store must still hydrate it: coordinates coalesce to the
+	// zero value (unused post-match) while the validated fields and the consumed
+	// fields (id, userId, createdAt) survive intact, and the stored push/email
+	// flags are preserved rather than coalescing to true.
+	items.crossPartitionResult = [][]byte{[]byte(`{"id":"zone-9","userId":"auth0|carol","name":"Z","radiusMetres":500,"authorityId":99,"createdAt":"2026-06-01T09:00:00+00:00","pushEnabled":false,"emailInstantEnabled":false}`)}
+	store := NewCosmosStore(items)
+
+	zones, err := store.FindZonesContaining(context.Background(), 99, 51.5, -0.1)
+	if err != nil {
+		t.Fatalf("FindZonesContaining: %v", err)
+	}
+	if len(zones) != 1 {
+		t.Fatalf("zones: got %d, want 1", len(zones))
+	}
+	got := zones[0]
+	if got.ID != "zone-9" || got.UserID != "auth0|carol" {
+		t.Errorf("identity: got id=%q user=%q", got.ID, got.UserID)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Error("createdAt must hydrate from the projection, got zero")
+	}
+	if got.PushEnabled || got.EmailInstantEnabled {
+		t.Errorf("stored-false flags must survive the projection: push=%v email=%v", got.PushEnabled, got.EmailInstantEnabled)
+	}
+}
+
 func TestCosmosStore_FindZonesContaining_EmptyResultIsEmptySlice(t *testing.T) {
 	t.Parallel()
 	store := NewCosmosStore(newFakeItems())
-	zones, err := store.FindZonesContaining(context.Background(), 51.5, -0.1)
+	zones, err := store.FindZonesContaining(context.Background(), 99, 51.5, -0.1)
 	if err != nil {
 		t.Fatalf("FindZonesContaining: %v", err)
 	}


### PR DESCRIPTION
## What

Phase 1 (Go-only) optimisation of `WatchZones.FindZonesContaining` — the one hot-path cross-partition + unindexed spatial scan in the Cosmos surface, run once per changed application in the poll loop (callers `notifydispatch/enqueuer.go` and `notifydispatch/decision.go`).

Two changes, both inside `api-go/`:

1. **Authority pre-filter.** The query now runs `WHERE c.authorityId = @authorityId AND ST_DISTANCE(...) <= c.radiusMetres`. The authority equality is served by Cosmos's default range index, pruning rows before the unindexed `ST_DISTANCE` test. `authorityID` is the polled application's authority (`app.AreaID`), threaded through `FindZonesContaining(ctx, authorityID int, lat, lng)` and the `zoneMatcher` consumer interface; both call sites pass `app.AreaID`. The cross-partition fan-out on `/userId` is **kept** — it is inherent.
2. **Projection instead of `SELECT *`.** Projects only `c.id, c.userId, c.name, c.radiusMetres, c.authorityId, c.createdAt, c.pushEnabled, c.emailInstantEnabled`, so the fan-out no longer hydrates whole documents.

## Behaviour change (the bug fix this is)

A zone now matches **only applications from its own authority**. This fixes cross-authority over-notification near council boundaries, consistent with the documented authority-scoped zone model (`zone.go`: a WatchZone is "scoped to one planning authority") and with the saved-bookmark path, which already scopes on `app.AreaID`.

Concretely: a wide-radius zone scoped to authority A whose circle geographically overlaps into authority B previously matched a B-authority application (geo-only match) and notified the user; it no longer does. This is a deliberate boundary-case behaviour change, not a pure no-op — framed as the bug fix it is. The `ST_DISTANCE` radius semantics are otherwise unchanged.

## Projection trap — flags kept on purpose

`pushEnabled`/`emailInstantEnabled` are nullable `*bool` that **coalesce to `true` when absent** (`document.go`, legacy opt-in default). They are projected (not dropped) so a stored `false` survives — dropping them would silently re-enable a user's disabled notifications if a future caller read those fields. Trace confirmed no current caller of `FindZonesContaining` reads zone flags or coordinates; `latitude`/`longitude` are dropped (coords are unused after the match). `name`/`radiusMetres`/`authorityId` are projected to satisfy the `NewWatchZone` constructor so the hydrated zone stays valid.

## Tests

- Store: authority predicate present + bound to the passed authority; projection (no `SELECT *`, exact field set); a projected document (no lat/long) still hydrates with stored flags preserved.
- Call sites: `EnqueueForApplication` and `Dispatch` forward `app.AreaID` to the zone matcher.

Gates: `gofmt` clean, `go vet` clean, `golangci-lint` 0 issues, `go test -race ./...` 37 ok / 0 fail, `go build ./...` clean.

## Out of scope (Phase 2, separate beads)

- tc-x8w9 — persist a GeoJSON location point on zone docs (write path + backfill).
- tc-quqe — add a spatial index on `/location` to the WatchZones container (infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)