### PR TITLE
perf(watchzones): persist GeoJSON location on zone write path for spatial index (tc-x8w9)

### DIFF
--- a/api-go/internal/watchzones/document.go
+++ b/api-go/internal/watchzones/document.go
@@ -6,6 +6,15 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
+// geoJSONPoint is the Cosmos GeoJSON projection of a watch zone's centre: a
+// Point with [longitude, latitude] order (GeoJSON convention), matching what
+// Cosmos expects for ST_DISTANCE spatial queries and what a spatial index on
+// /location binds to. It mirrors the same shape in the applications package.
+type geoJSONPoint struct {
+	Type        string    `json:"type"`
+	Coordinates []float64 `json:"coordinates"`
+}
+
 // watchZoneDocument is the Cosmos persistence shape for a WatchZone. The JSON
 // tags use camelCase so a document written here is byte-compatible with the
 // existing WatchZones container and an existing document hydrates unchanged.
@@ -22,6 +31,14 @@ type watchZoneDocument struct {
 	Longitude    float64 `json:"longitude"`
 	RadiusMetres float64 `json:"radiusMetres"`
 	AuthorityID  int     `json:"authorityId"`
+
+	// location is the GeoJSON Point form of latitude/longitude, persisted purely
+	// so a spatial index (added later in the infra child tc-quqe) can serve
+	// FindZonesContaining. It is ADDITIVE: latitude/longitude remain the
+	// authoritative columns that toDomain hydrates from and the current query
+	// reads, so a legacy document without location hydrates unchanged. Pointer
+	// so an absent location stays nil rather than serialising an empty Point.
+	Location *geoJSONPoint `json:"location"`
 
 	// createdAt must serialise with a numeric UTC offset ("+00:00"), never Go's
 	// RFC 3339 "Z" — platform.DotNetTime handles that. Nullable so a legacy
@@ -50,10 +67,18 @@ func newWatchZoneDocument(z WatchZone) watchZoneDocument {
 		Longitude:           z.Longitude,
 		RadiusMetres:        z.RadiusMetres,
 		AuthorityID:         z.AuthorityID,
+		Location:            newGeoPoint(z.Longitude, z.Latitude),
 		CreatedAt:           &createdAt,
 		PushEnabled:         &push,
 		EmailInstantEnabled: &email,
 	}
+}
+
+// newGeoPoint builds the GeoJSON Point form of a zone centre. A WatchZone always
+// has coordinates (stored as plain floats), so a point is always written; the
+// [longitude, latitude] order is the GeoJSON convention Cosmos expects.
+func newGeoPoint(lon, lat float64) *geoJSONPoint {
+	return &geoJSONPoint{Type: "Point", Coordinates: []float64{lon, lat}}
 }
 
 // toDomain reconstitutes a domain zone from its stored document, coalescing the

--- a/api-go/internal/watchzones/document_test.go
+++ b/api-go/internal/watchzones/document_test.go
@@ -59,6 +59,65 @@ func TestWatchZoneDocument_CamelCaseAndDotNetTime(t *testing.T) {
 	}
 }
 
+func TestWatchZoneDocument_WritesGeoJSONLocation(t *testing.T) {
+	t.Parallel()
+	z := testZone(t) // latitude 51.5074, longitude -0.1278
+
+	raw, err := json.Marshal(newWatchZoneDocument(z))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(raw)
+
+	if !strings.Contains(body, `"location":`) {
+		t.Errorf("missing location key in %s", body)
+	}
+	if !strings.Contains(body, `"type":"Point"`) {
+		t.Errorf("location is not a GeoJSON Point in %s", body)
+	}
+	// GeoJSON coordinates are [longitude, latitude] — order matters and must
+	// match what a spatial index on /location expects (ST_DISTANCE).
+	if !strings.Contains(body, `"coordinates":[-0.1278,51.5074]`) {
+		t.Errorf("location coordinates not [lon,lat]: %s", body)
+	}
+}
+
+func TestWatchZoneDocument_HydratesWithAndWithoutLocation(t *testing.T) {
+	t.Parallel()
+	// location is additive: hydration reads the latitude/longitude float columns,
+	// so a legacy document predating location and a new document carrying it both
+	// hydrate to the same coordinates. Adding the field changes no read behaviour.
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "without location (legacy)",
+			raw:  `{"id":"z1","userId":"u1","name":"Home","latitude":51.5074,"longitude":-0.1278,"radiusMetres":1000,"authorityId":471,"createdAt":"2026-06-01T09:00:00+00:00"}`,
+		},
+		{
+			name: "with location",
+			raw:  `{"id":"z1","userId":"u1","name":"Home","latitude":51.5074,"longitude":-0.1278,"radiusMetres":1000,"authorityId":471,"createdAt":"2026-06-01T09:00:00+00:00","location":{"type":"Point","coordinates":[-0.1278,51.5074]}}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var doc watchZoneDocument
+			if err := json.Unmarshal([]byte(tc.raw), &doc); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			got, err := doc.toDomain()
+			if err != nil {
+				t.Fatalf("toDomain: %v", err)
+			}
+			if got.Latitude != 51.5074 || got.Longitude != -0.1278 {
+				t.Errorf("coords mismatch: got lat=%v lon=%v", got.Latitude, got.Longitude)
+			}
+		})
+	}
+}
+
 func TestWatchZoneDocument_LegacyNullFlagsCoalesceTrue(t *testing.T) {
 	t.Parallel()
 	// A document written before the per-zone flags existed omits them; absent


### PR DESCRIPTION
## What

Phase 2a of the WatchZones spatial-query optimisation (tc-x8w9, child of tc-8dud Cosmos audit). Persists a GeoJSON `Point` `location` on every WatchZone document's **write path**, mirroring `applications/document.go` exactly, so a spatial index (added later in the infra child **tc-quqe**) can bind to it.

Today `watchZoneDocument` stores `latitude`/`longitude` as separate floats and `FindZonesContaining` builds the point **inline** (`{'type':'Point','coordinates':[c.longitude,c.latitude]}`) — which no spatial index can serve.

## Changes (write sites)

- `api-go/internal/watchzones/document.go`
  - New `geoJSONPoint{ Type, Coordinates }` struct (`[longitude, latitude]` order — GeoJSON convention).
  - New `Location *geoJSONPoint` json:`location` field on `watchZoneDocument`.
  - New `newGeoPoint(lon, lat float64)` builder.
  - `newWatchZoneDocument` now writes `Location: newGeoPoint(z.Longitude, z.Latitude)`. Covers **all** write sites — `Save` (POST create + PATCH update) is the single mapping point.

## Additive / back-compat — read behaviour unchanged

- `latitude`/`longitude` float columns are **kept** and remain authoritative. `location` is purely additive.
- `toDomain` is **untouched**: it still hydrates lat/long from the float columns and never reads `location`. A legacy document without `location` (pointer → nil-safe) hydrates identically.
- `FindZonesContaining` is **not** switched to the indexed query here. That switch must wait until the index exists (tc-quqe) **and** every zone is backfilled — otherwise un-backfilled zones would silently stop matching.
- Deliberately did **not** port `coordsToLatLng` into watchzones: using it in `toDomain` would change the coordinate source (breaking back-compat), and an unused helper would fail the linter.

## Backfill

New/updated zones converge naturally (every `Save` writes `location`). A guaranteed one-shot backfill of existing untouched docs belongs in the `tc` admin CLI (`/cli`) — out of scope for this api-go bead, same routing precedent as tc-au3x. Filed as **tc-xj48** (discovered-from tc-x8w9). It MUST complete before tc-quqe switches the query to the index-served `c.location` form.

## TDD

- `red`: `TestWatchZoneDocument_WritesGeoJSONLocation` — asserts `location` is a `Point` with `coordinates:[-0.1278,51.5074]` (`[lon,lat]` order). Confirmed failing first.
- `green`: implement the field + builder + wiring.
- Back-compat guard: `TestWatchZoneDocument_HydratesWithAndWithoutLocation` (table: with/without stored location both hydrate from the float columns).

## Gates

`gofmt -l .` clean · `go vet` clean · `go build` ok · `golangci-lint run` clean · `go test -race ./...` 1104 pass.

Backend-only; no Release-Note trailer.