### PR TITLE
infra: add /location spatial index to WatchZones container (tc-quqe)

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -231,8 +231,33 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		},
 		// Users — partitioned by id
 		{name: "Users", partitionKeyPath: "/id"},
-		// WatchZones — partitioned by userId, unique on (userId, name)
-		{name: "WatchZones", partitionKeyPath: "/userId", uniqueKeyPaths: [][]string{{"/userId", "/name"}}},
+		// WatchZones — partitioned by userId, unique on (userId, name).
+		// Keeps Cosmos default full indexing (IncludedPaths "/*") so the Phase 1
+		// authority pre-filter (WHERE c.authorityId = @authorityId, tc-8dud) stays
+		// index-served; ADDS a GeoJSON Point spatial index on /location so the
+		// Phase 2c index-served FindZonesContaining query (tc-qbq4) can bind to it.
+		// Inert until that query switches to reference c.location.
+		{
+			name:             "WatchZones",
+			partitionKeyPath: "/userId",
+			uniqueKeyPaths:   [][]string{{"/userId", "/name"}},
+			indexingPolicy: &cosmosdb.IndexingPolicyArgs{
+				Automatic:    pulumi.Bool(true),
+				IndexingMode: cosmosdb.IndexingModeConsistent,
+				IncludedPaths: cosmosdb.IncludedPathArray{
+					&cosmosdb.IncludedPathArgs{Path: pulumi.String("/*")},
+				},
+				ExcludedPaths: cosmosdb.ExcludedPathArray{
+					&cosmosdb.ExcludedPathArgs{Path: pulumi.String("/\"_etag\"/?")},
+				},
+				SpatialIndexes: cosmosdb.SpatialSpecArray{
+					&cosmosdb.SpatialSpecArgs{
+						Path:  pulumi.String("/location/?"),
+						Types: pulumi.StringArray{pulumi.String(string(cosmosdb.SpatialTypePoint))},
+					},
+				},
+			},
+		},
 		// Notifications — partitioned by userId, 90-day TTL
 		{name: "Notifications", partitionKeyPath: "/userId", defaultTTL: intPtr(90 * 24 * 60 * 60)},
 		// NotificationState — one watermark document per user (read-state cutoff)


### PR DESCRIPTION
## What

Adds an explicit indexing policy to the **WatchZones** Cosmos container (`infra/environment.go`) that:

- **Preserves Cosmos default full indexing** via `IncludedPaths: "/*"` (plus only the default `"/_etag/?"` exclusion) — so the Phase 1 authority pre-filter (`WHERE c.authorityId = @authorityId`, shipped in tc-8dud) **stays index-served**. It does **not** copy the Applications container's restrictive `ExcludedPaths: "/*"`, which would have silently de-indexed `authorityId` and reverted Phase 1 to a full scan.
- **Adds a GeoJSON `Point` spatial index on `/location`** so the Phase 2c index-served `FindZonesContaining` query (tc-qbq4) can bind to it.

No `CompositeIndexes` (authority equality and spatial are separate lookups). `partitionKeyPath` and `uniqueKeyPaths` are unchanged.

## Safety

- Changing a container's indexing policy is an **in-place update** — no recreate, no data loss. Cosmos reindexes in the background and queries keep working.
- The new spatial index is **inert** until tc-qbq4 switches `FindZonesContaining` to reference `c.location`; adding it now changes no query behaviour. That is expected.
- Phase 2a (tc-x8w9, persist GeoJSON `location` on zone docs) is already done, so the index has data to bind to.

## Validation

`go build ./...`, `go vet ./...`, and `gofmt -l .` are all clean. PR-only — applied by CI cd-dev on merge, never via direct `pulumi up`.

Bead: tc-quqe (Phase 2b of the WatchZones optimisation, discovered-from tc-8dud).