### PR TITLE
ci: fail-honest infra Pulumi preview in pr-gate (tc-60dx)

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -326,6 +326,24 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Select Pulumi stack
+        if: github.actor != 'dependabot[bot]'
+        working-directory: infra
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        run: pulumi stack select ${{ vars.PULUMI_STACK }}
+
+      - name: Set Pulumi secrets
+        if: github.actor != 'dependabot[bot]'
+        uses: ./.github/actions/setup-pulumi-secrets
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+        with:
+          admin-api-key: ${{ secrets.ADMIN_API_KEY }}
+          site-build-key: ${{ secrets.SITE_BUILD_KEY }}
+          auth0-m2m-client-id: ${{ secrets.AUTH0_M2M_CLIENT_ID }}
+          auth0-m2m-client-secret: ${{ secrets.AUTH0_M2M_CLIENT_SECRET }}
+
       - name: Pulumi preview
         if: github.actor != 'dependabot[bot]'
         working-directory: infra
@@ -336,11 +354,11 @@ jobs:
           ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         run: |
-          pulumi stack select ${{ vars.PULUMI_STACK }}
+          set -o pipefail
           pulumi preview --non-interactive 2>&1 | tee /tmp/pulumi-preview.txt
 
       - name: Comment preview on PR
-        if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+        if: always() && github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/infra/main.go
+++ b/infra/main.go
@@ -13,6 +13,12 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		conf := config.New(ctx, "town-crier")
+
+		// TC-60DX FAILURE-PATH TEST — DO NOT MERGE. Compiles & vets clean, but
+		// panics at preview time on a missing required config key, reproducing the
+		// kind of crash (#619 / tc-g9p6) that the old piped step silently swallowed.
+		conf.Require("tc60dxDeliberateCrash")
+
 		env := conf.Require("environment")
 
 		tags := pulumi.StringMap{

--- a/infra/main.go
+++ b/infra/main.go
@@ -13,12 +13,6 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		conf := config.New(ctx, "town-crier")
-
-		// TC-60DX FAILURE-PATH TEST — DO NOT MERGE. Compiles & vets clean, but
-		// panics at preview time on a missing required config key, reproducing the
-		// kind of crash (#619 / tc-g9p6) that the old piped step silently swallowed.
-		conf.Require("tc60dxDeliberateCrash")
-
 		env := conf.Require("environment")
 
 		tags := pulumi.StringMap{


### PR DESCRIPTION
## Problem (tc-60dx, P1)

The `infra-preview` job's Pulumi preview step ran:

```
pulumi preview --non-interactive 2>&1 | tee /tmp/pulumi-preview.txt
```

with no `set -o pipefail`. Under the default `bash -e {0}`, the pipe's exit code is `tee`'s (always 0), so **any pulumi crash or preview error was swallowed and the gate passed green.** On 2026-06-23 this let PR #619 (a Cosmos indexing-policy change) merge with NO real preview — the CI log showed `panic: Missing required configuration variable 'town-crier:adminApiKey'` and `1 errored`, yet the check was green. Historically it also let the tc-g9p6 null-CustomDomains crash through to main and break cd-dev (tc-6myy).

A second, compounding problem: the step never injected the Pulumi config secrets the program requires (`RequireSecret`), so simply adding `pipefail` would have crashed **every** infra PR on `Missing required configuration variable 'town-crier:adminApiKey'`. Both had to be fixed together.

## Fix

Restructured the `infra-preview` job to mirror cd-dev's ordering, keeping the existing `if: github.actor != 'dependabot[bot]'` guard on each new step:

1. **Select Pulumi stack** — standalone `pulumi stack select dev`.
2. **Set Pulumi secrets** — `uses: ./.github/actions/setup-pulumi-secrets`, injecting the 4 runtime secrets (`adminApiKey`, `siteBuildKey`, `auth0M2mClientId`, `auth0M2mClientSecret`). The 5th, `apnsAuthKey`, is already encrypted in committed `Pulumi.dev.yaml`.
3. **Pulumi preview** — now begins with `set -o pipefail` so a non-zero pulumi exit fails the step.

Also made **Comment preview on PR** run on `always()` so a failed preview still posts its crash output to the PR. No `environment:` added (the required secrets are repo-level, readable without it; avoids triggering PR approval gating).

The crash/revert commits cancel out — the **net diff of this PR is the `pr-gate.yml` change only**.

## Verification (red-then-green proven)

**✅ Acceptance 1 — normal preview runs real & green** ([run 28054185583](https://github.com/AmyDe/town-crier/actions/runs/28054185583))
`infra-preview` ran a real preview against the dev stack: `Select Pulumi stack` → `Set Pulumi secrets` → `Pulumi preview` all succeeded, config loaded with no missing-secret panic, output `Resources: 25 unchanged`, diff comment posted. No secret values leaked.

**✅ Acceptance 2 — failure path goes RED** ([run 28054449978](https://github.com/AmyDe/town-crier/actions/runs/28054449978))
Threw a deliberate missing-config crash into the infra program (commit `80d34241`, since reverted). `Build & vet` **passed** (proving it's a runtime crash, not a compile failure), then `Pulumi preview` **failed** and the whole gate went **RED** — exactly the class of crash (`panic: Missing required configuration variable …` → `1 errored`) that previously merged green. The `always()` comment step still posted the crash output to the PR for debugging.

**✅ Revert restores green** ([run 28054683123](https://github.com/AmyDe/town-crier/actions/runs/28054683123))
Reverting the crash (commit `6c36b474`) returned `infra-preview` and the full PR Gate to **green**.

**✅ Acceptance 3 — Dependabot path unchanged** — the new steps keep `if: github.actor != 'dependabot[bot]'`, so Dependabot still gets build + vet only (preview + secret steps skipped).

Fixes tc-60dx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)