### PR TITLE
perf(watchzones): activate spatial index — hybrid FindZonesContaining + location backfill (tc-qbq4) (tc-xj48)

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -44,9 +44,10 @@ var anonymousPatterns = map[string]struct{}{
 	"GET /v1/demo-account": {},
 	// Admin routes are anonymous to Auth0 (no bearer token); they are
 	// authenticated solely by the X-Admin-Key gate inside the handlers.
-	"PUT /v1/admin/subscriptions": {},
-	"GET /v1/admin/users":         {},
-	"POST /v1/admin/offer-codes":  {},
+	"PUT /v1/admin/subscriptions":                 {},
+	"GET /v1/admin/users":                         {},
+	"POST /v1/admin/offer-codes":                  {},
+	"POST /v1/admin/watchzones/backfill-location": {},
 	// The App Store Server Notifications webhook is Apple -> API, not user-facing,
 	// so it is anonymous to Auth0; the signed JWS is its authentication. (The
 	// sibling POST /v1/subscriptions/verify is authed and absent here.)
@@ -186,11 +187,13 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 		// coded tier, and syncs Auth0. Needs both the profile and offer-code stores.
 		offercodes.Routes(mux, offerStore, store, auth0, time.Now, logger)
 	}
-	if adminStore != nil && offerStore != nil {
+	if adminStore != nil && offerStore != nil && watchZoneStore != nil {
 		// Admin endpoints are anonymous to Auth0 and gated by the X-Admin-Key. The
 		// cross-partition admin store backs grant/list; the offer-code store backs
-		// generate.
-		admin.Routes(mux, adminKey, adminStore, auth0, offerStore, offercodes.NewRandomGenerator(), time.Now, logger)
+		// generate; the watch-zone store backs the one-shot location backfill. All
+		// three are Cosmos-gated, so the added guard never disables admin in a real
+		// deployment (Cosmos configures every store together).
+		admin.Routes(mux, adminKey, adminStore, auth0, offerStore, offercodes.NewRandomGenerator(), watchZoneStore, time.Now, logger)
 	}
 	if store != nil && adminStore != nil && jwsVerifier != nil && appleNotifStore != nil {
 		// Subscriptions: verify (authed, by user id via the profile store) and the

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -452,7 +452,11 @@ func TestRouter_AdminGate(t *testing.T) {
 	logger := slog.New(slog.DiscardHandler)
 	offerStore := offercodes.NewCosmosStore(newFakeItems())
 	adminStore := profiles.NewAdminStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, logger)
+	// The admin block now also requires the watch-zone store (it backs the
+	// location-backfill endpoint), so supply one — all admin stores are Cosmos-gated
+	// together in a real deployment.
+	watchZoneStore := watchzones.NewCosmosStore(newFakeItems())
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, watchZoneStore, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, logger)
 
 	// No key: the admin gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).

--- a/api-go/internal/admin/handler.go
+++ b/api-go/internal/admin/handler.go
@@ -41,22 +41,24 @@ type codeGenerator interface {
 }
 
 type handler struct {
-	profiles  profileAdminStore
-	auth0     tierSync
-	codes     offerCodeStore
-	generator codeGenerator
-	now       func() time.Time
-	logger    *slog.Logger
+	profiles   profileAdminStore
+	auth0      tierSync
+	codes      offerCodeStore
+	generator  codeGenerator
+	watchZones watchZoneBackfiller
+	now        func() time.Time
+	logger     *slog.Logger
 }
 
 // Routes registers the admin endpoints on mux, each gated by the shared admin
 // key. The routes are anonymous to Auth0 (the caller carries no bearer token),
 // so the key gate is their only authentication.
-func Routes(mux *http.ServeMux, adminKey string, profileStore profileAdminStore, auth0 tierSync, codes offerCodeStore, generator codeGenerator, now func() time.Time, logger *slog.Logger) {
-	h := &handler{profiles: profileStore, auth0: auth0, codes: codes, generator: generator, now: now, logger: logger}
+func Routes(mux *http.ServeMux, adminKey string, profileStore profileAdminStore, auth0 tierSync, codes offerCodeStore, generator codeGenerator, watchZones watchZoneBackfiller, now func() time.Time, logger *slog.Logger) {
+	h := &handler{profiles: profileStore, auth0: auth0, codes: codes, generator: generator, watchZones: watchZones, now: now, logger: logger}
 	mux.HandleFunc("PUT /v1/admin/subscriptions", requireAdminKey(adminKey, h.grantSubscription))
 	mux.HandleFunc("GET /v1/admin/users", requireAdminKey(adminKey, h.listUsers))
 	mux.HandleFunc("POST /v1/admin/offer-codes", requireAdminKey(adminKey, h.generateOfferCodes))
+	mux.HandleFunc("POST /v1/admin/watchzones/backfill-location", requireAdminKey(adminKey, h.backfillWatchZoneLocation))
 }
 
 func (h *handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {

--- a/api-go/internal/admin/handler_test.go
+++ b/api-go/internal/admin/handler_test.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
 type fakeAdminStore struct {
@@ -74,14 +76,29 @@ func (f *fakeGenerator) Generate() (string, error) {
 	return c, nil
 }
 
+type fakeBackfiller struct {
+	result watchzones.BackfillResult
+	err    error
+	calls  int
+}
+
+func (f *fakeBackfiller) BackfillLocation(_ context.Context) (watchzones.BackfillResult, error) {
+	f.calls++
+	if f.err != nil {
+		return watchzones.BackfillResult{}, f.err
+	}
+	return f.result, nil
+}
+
 func newTestHandler(store profileAdminStore, auth0 tierSync, codes offerCodeStore, gen codeGenerator, now time.Time) *handler {
 	return &handler{
-		profiles:  store,
-		auth0:     auth0,
-		codes:     codes,
-		generator: gen,
-		now:       func() time.Time { return now },
-		logger:    slog.New(slog.DiscardHandler),
+		profiles:   store,
+		auth0:      auth0,
+		codes:      codes,
+		generator:  gen,
+		watchZones: &fakeBackfiller{},
+		now:        func() time.Time { return now },
+		logger:     slog.New(slog.DiscardHandler),
 	}
 }
 
@@ -289,9 +306,65 @@ func TestGenerate_ValidationErrors(t *testing.T) {
 	}
 }
 
+func TestBackfillWatchZoneLocation_ReturnsReconciledCounts(t *testing.T) {
+	t.Parallel()
+
+	backfiller := &fakeBackfiller{result: watchzones.BackfillResult{Total: 5, Backfilled: 3, AlreadyHad: 2}}
+	h := newTestHandler(&fakeAdminStore{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	h.watchZones = backfiller
+
+	rec := serve(t, h.backfillWatchZoneLocation, http.MethodPost, "/v1/admin/watchzones/backfill-location", "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != `{"total":5,"backfilled":3,"alreadyHad":2}` {
+		t.Errorf("body = %s", got)
+	}
+	if backfiller.calls != 1 {
+		t.Errorf("backfiller called %d times, want 1", backfiller.calls)
+	}
+}
+
+func TestBackfillWatchZoneLocation_StoreErrorIs500(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(&fakeAdminStore{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	h.watchZones = &fakeBackfiller{err: errors.New("scan boom")}
+
+	rec := serve(t, h.backfillWatchZoneLocation, http.MethodPost, "/v1/admin/watchzones/backfill-location", "")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+// TestBackfillWatchZoneLocation_RequiresAdminKey locks the X-Admin-Key gate on
+// the route, mirroring the gate on the other admin endpoints: a request with no
+// key (or an empty configured key) gets a bodyless 401 and never reaches the
+// backfiller.
+func TestBackfillWatchZoneLocation_RequiresAdminKey(t *testing.T) {
+	t.Parallel()
+
+	backfiller := &fakeBackfiller{}
+	h := newTestHandler(&fakeAdminStore{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	h.watchZones = backfiller
+	gated := requireAdminKey("secret", h.backfillWatchZoneLocation)
+
+	rec := serve(t, gated, http.MethodPost, "/v1/admin/watchzones/backfill-location", "")
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 with no admin key", rec.Code)
+	}
+	if backfiller.calls != 0 {
+		t.Errorf("backfiller must not run for an unauthenticated request, calls = %d", backfiller.calls)
+	}
+}
+
 func TestStores_SatisfyInterfaces(t *testing.T) {
 	t.Parallel()
 	var _ profileAdminStore = profiles.NewAdminStore(nil)
 	var _ offerCodeStore = offercodes.NewCosmosStore(nil)
 	var _ codeGenerator = offercodes.NewRandomGenerator()
+	var _ watchZoneBackfiller = watchzones.NewCosmosStore(nil)
 }

--- a/api-go/internal/admin/middleware.go
+++ b/api-go/internal/admin/middleware.go
@@ -1,7 +1,8 @@
 // Package admin owns the admin surface: the X-Admin-Key gate and the
 // PUT /v1/admin/subscriptions, GET /v1/admin/users, POST /v1/admin/offer-codes
-// handlers. The admin routes are anonymous to Auth0 (absent from the
-// fallback-deny set) and authenticated solely by the shared admin key.
+// and POST /v1/admin/watchzones/backfill-location handlers. The admin routes are
+// anonymous to Auth0 (absent from the fallback-deny set) and authenticated
+// solely by the shared admin key.
 package admin
 
 import (

--- a/api-go/internal/admin/watchzones.go
+++ b/api-go/internal/admin/watchzones.go
@@ -1,0 +1,37 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// watchZoneBackfiller is the consumer-side view of the watch-zone store the
+// backfill endpoint needs: a single one-shot rewrite of every document missing a
+// GeoJSON location. watchzones.CosmosStore satisfies it.
+type watchZoneBackfiller interface {
+	BackfillLocation(ctx context.Context) (watchzones.BackfillResult, error)
+}
+
+// backfillResponse is the response shape for the backfill endpoint:
+// { total, backfilled, alreadyHad }, all camelCase.
+type backfillResponse struct {
+	Total      int `json:"total"`
+	Backfilled int `json:"backfilled"`
+	AlreadyHad int `json:"alreadyHad"`
+}
+
+// backfillWatchZoneLocation implements POST /v1/admin/watchzones/backfill-location:
+// a guarded, idempotent one-shot that rewrites every WatchZone document predating
+// the GeoJSON write path so it carries a /location field (tc-xj48). The request
+// body is ignored; the reconciled counts are returned as JSON. This must run
+// before FindZonesContaining switches to the index-served c.location query.
+func (h *handler) backfillWatchZoneLocation(w http.ResponseWriter, r *http.Request) {
+	res, err := h.watchZones.BackfillLocation(r.Context())
+	if err != nil {
+		h.serverError(w, r, "backfill watch zone location", err)
+		return
+	}
+	h.writeJSON(r, w, backfillResponse{Total: res.Total, Backfilled: res.Backfilled, AlreadyHad: res.AlreadyHad})
+}

--- a/api-go/internal/watchzones/store_cosmos.go
+++ b/api-go/internal/watchzones/store_cosmos.go
@@ -175,12 +175,26 @@ func (s *CosmosStore) DistinctAuthorityIDs(ctx context.Context) ([]int, error) {
 // findZonesContainingQuery selects every watch zone scoped to the candidate
 // application's authority whose circle (centre + radius) contains the candidate
 // point, across all partitions. The authority equality predicate is evaluated by
-// Cosmos's default range index, pruning rows before the unindexed ST_DISTANCE
-// test runs — a WatchZone is authority-scoped (see zone.go), so a zone only ever
-// matches applications in its own authority, mirroring the saved-bookmark path's
+// Cosmos's default range index, pruning rows before the ST_DISTANCE test runs —
+// a WatchZone is authority-scoped (see zone.go), so a zone only ever matches
+// applications in its own authority, mirroring the saved-bookmark path's
 // app.AreaID scoping (notifydispatch/decision.go). The candidate authority and
-// point are bound as parameters; the zone centre is read from each document's
-// latitude/longitude columns.
+// point are bound as parameters.
+//
+// The distance test is a hybrid of two clauses, ORed inside the authority filter:
+//   - Primary: ST_DISTANCE(c.location, @point) is served by the spatial index on
+//     the persisted GeoJSON /location path (tc-quqe), so the common (backfilled)
+//     case is index-accelerated rather than a full scan.
+//   - Fallback: any zone written before the location backfill (tc-xj48) has no
+//     c.location field, so the index-served clause cannot match it. The NOT
+//     IS_DEFINED(c.location) guard restores those legacy zones via the inline
+//     [c.longitude, c.latitude] point, computed from the document's latitude /
+//     longitude columns. The guard means the two clauses are mutually exclusive
+//     (a doc either has c.location or it doesn't), so nothing double-counts and
+//     the switch is correct regardless of backfill state — mirroring the
+//     dormant-sweep NOT IS_DEFINED guard (profiles/admin_store.go dormantQuery).
+//
+// All coordinates are GeoJSON order: [longitude, latitude], not [lat, lng].
 //
 // The projection is deliberate, not SELECT *: only the columns this hot path
 // needs are hydrated. id/userId/createdAt are consumed by the callers;
@@ -188,12 +202,15 @@ func (s *CosmosStore) DistinctAuthorityIDs(ctx context.Context) ([]int, error) {
 // the hydrated zone stays valid; pushEnabled/emailInstantEnabled are projected
 // (not dropped) because they are nullable *bool that coalesce to true when
 // absent, so omitting them would silently re-enable a user's disabled
-// notifications if a future caller read them. latitude/longitude are omitted —
-// no caller reads zone coordinates after the match.
+// notifications if a future caller read them. latitude/longitude are omitted from
+// the projection — no caller reads zone coordinates after the match (the fallback
+// clause reads them server-side during the distance test, not in the result).
 const findZonesContainingQuery = "SELECT c.id, c.userId, c.name, c.radiusMetres, c.authorityId, c.createdAt, c.pushEnabled, c.emailInstantEnabled " +
-	"FROM c WHERE c.authorityId = @authorityId AND ST_DISTANCE(" +
+	"FROM c WHERE c.authorityId = @authorityId AND (" +
+	"ST_DISTANCE(c.location, {'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres " +
+	"OR (NOT IS_DEFINED(c.location) AND ST_DISTANCE(" +
 	"{'type': 'Point', 'coordinates': [c.longitude, c.latitude]}, " +
-	"{'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres"
+	"{'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres))"
 
 // FindZonesContaining returns every watch zone (across all users) scoped to the
 // given authority whose circle contains the point (latitude, longitude), via a

--- a/api-go/internal/watchzones/store_cosmos_backfill.go
+++ b/api-go/internal/watchzones/store_cosmos_backfill.go
@@ -1,0 +1,65 @@
+package watchzones
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// BackfillResult reports the outcome of a one-shot location backfill: how many
+// documents were scanned, how many were rewritten with a derived GeoJSON
+// location, and how many already carried one (and so were left untouched).
+type BackfillResult struct {
+	Total      int
+	Backfilled int
+	AlreadyHad int
+}
+
+// backfillScanQuery selects every watch zone document across all partitions. The
+// backfill is a deliberate full cross-partition scan: it is a one-shot
+// maintenance task, not a hot path, and must visit every document regardless of
+// its partition (/userId).
+const backfillScanQuery = "SELECT * FROM c"
+
+// BackfillLocation rewrites every WatchZone document that predates the GeoJSON
+// write path (tc-x8w9) so it carries a "location" field, derived from the
+// document's authoritative latitude / longitude floats. It is a guarded,
+// idempotent one-shot: a document that already has a location is skipped, so a
+// second run rewrites nothing. The derived point is never recomputed — Save
+// re-encodes the document via newWatchZoneDocument, which builds the GeoJSON
+// Point from the same persisted latitude / longitude that toDomain hydrated.
+//
+// This must run before FindZonesContaining switches to the index-served
+// c.location query (tc-qbq4); until then the write path is additive and the
+// hybrid query falls back to the inline point for un-backfilled zones, so
+// nothing breaks in the meantime.
+func (s *CosmosStore) BackfillLocation(ctx context.Context) (BackfillResult, error) {
+	raws, err := s.items.QueryItemsCrossPartition(ctx, backfillScanQuery, nil)
+	if err != nil {
+		return BackfillResult{}, fmt.Errorf("scan watch zones for backfill: %w", err)
+	}
+
+	var res BackfillResult
+	for _, raw := range raws {
+		res.Total++
+
+		var doc watchZoneDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return BackfillResult{}, fmt.Errorf("decode watch zone for backfill: %w", err)
+		}
+		if doc.Location != nil {
+			res.AlreadyHad++
+			continue
+		}
+
+		zone, err := doc.toDomain()
+		if err != nil {
+			return BackfillResult{}, fmt.Errorf("hydrate watch zone %q for backfill: %w", doc.ID, err)
+		}
+		if err := s.Save(ctx, zone); err != nil {
+			return BackfillResult{}, fmt.Errorf("rewrite watch zone %q with location: %w", doc.ID, err)
+		}
+		res.Backfilled++
+	}
+	return res, nil
+}

--- a/api-go/internal/watchzones/store_cosmos_test.go
+++ b/api-go/internal/watchzones/store_cosmos_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -25,6 +26,7 @@ type fakeItems struct {
 	lastReadID   string
 	lastUpsertPK string
 	lastUpsert   []byte
+	upserts      [][]byte // every upserted document body, in call order, for backfill assertions
 	lastDeletePK string
 	lastDeleteID string
 	deletedIDs   []string // every (pk,id) deleted, in call order, for cascade assertions
@@ -55,7 +57,15 @@ func (f *fakeItems) ReadItem(_ context.Context, partitionKey, id string) ([]byte
 func (f *fakeItems) UpsertItem(_ context.Context, partitionKey string, item []byte) error {
 	f.lastUpsertPK = partitionKey
 	f.lastUpsert = item
-	return f.upsertErr
+	if f.upsertErr != nil {
+		return f.upsertErr
+	}
+	// Copy the body: azcosmos owns the slice after the call, and the store reuses
+	// no buffer, but copying keeps each recorded upsert independent regardless.
+	saved := make([]byte, len(item))
+	copy(saved, item)
+	f.upserts = append(f.upserts, saved)
+	return nil
 }
 
 func (f *fakeItems) DeleteItem(_ context.Context, partitionKey, id string) error {
@@ -456,5 +466,113 @@ func TestCosmosStore_DistinctAuthorityIDs_EmptyQueryYieldsEmpty(t *testing.T) {
 	}
 	if len(ids) != 0 {
 		t.Errorf("expected empty, got %v", ids)
+	}
+}
+
+// legacyDocWithoutLocation is a raw WatchZones document written before the
+// GeoJSON write path (tc-x8w9) existed: it carries the authoritative latitude /
+// longitude floats and every other field, but no "location" field at all (so
+// watchZoneDocument.Location unmarshals to nil). The backfill must rewrite it
+// with a derived location while preserving every other column.
+func legacyDocWithoutLocation(id, userID string, lat, lon float64, radius float64, authorityID int) []byte {
+	return []byte(fmt.Sprintf(
+		`{"id":%q,"userId":%q,"name":"Legacy","latitude":%g,"longitude":%g,"radiusMetres":%g,"authorityId":%d,"createdAt":"2026-06-01T09:00:00+00:00","pushEnabled":true,"emailInstantEnabled":true}`,
+		id, userID, lat, lon, radius, authorityID))
+}
+
+func TestCosmosStore_BackfillLocation_RewritesOnlyDocsMissingLocation(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	// One legacy doc lacks location; two modern docs already carry it (written via
+	// newWatchZoneDocument, which always sets location). The scan is cross-partition.
+	modernA := testZone(t)
+	modernA.ID, modernA.UserID = "modern-a", "auth0|a"
+	modernB := testZone(t)
+	modernB.ID, modernB.UserID = "modern-b", "auth0|b"
+	items.crossPartitionResult = [][]byte{
+		mustDocBytes(t, modernA),
+		legacyDocWithoutLocation("legacy-1", "auth0|legacy", 53.4808, -2.2426, 750, 471),
+		mustDocBytes(t, modernB),
+	}
+	store := NewCosmosStore(items)
+
+	res, err := store.BackfillLocation(context.Background())
+	if err != nil {
+		t.Fatalf("BackfillLocation: %v", err)
+	}
+
+	if res.Total != 3 || res.AlreadyHad != 2 || res.Backfilled != 1 {
+		t.Fatalf("result = %+v, want {Total:3 Backfilled:1 AlreadyHad:2}", res)
+	}
+	// Exactly one upsert: the legacy doc only. The two modern docs are skipped.
+	if len(items.upserts) != 1 {
+		t.Fatalf("upserts = %d, want exactly 1 (the legacy doc)", len(items.upserts))
+	}
+	if items.lastUpsertPK != "auth0|legacy" {
+		t.Errorf("upsert partition key = %q, want auth0|legacy", items.lastUpsertPK)
+	}
+
+	var doc watchZoneDocument
+	if err := json.Unmarshal(items.upserts[0], &doc); err != nil {
+		t.Fatalf("unmarshal upserted doc: %v", err)
+	}
+	// The rewritten doc now carries a GeoJSON location derived from the floats, in
+	// [longitude, latitude] order, never recomputed.
+	if doc.Location == nil {
+		t.Fatal("upserted doc must carry a location")
+	}
+	if doc.Location.Type != "Point" || len(doc.Location.Coordinates) != 2 ||
+		doc.Location.Coordinates[0] != -2.2426 || doc.Location.Coordinates[1] != 53.4808 {
+		t.Errorf("location = %+v, want Point[-2.2426, 53.4808]", doc.Location)
+	}
+	// The legacy doc's other fields survive the rewrite.
+	if doc.ID != "legacy-1" || doc.UserID != "auth0|legacy" || doc.RadiusMetres != 750 || doc.AuthorityID != 471 {
+		t.Errorf("legacy fields not preserved: %+v", doc)
+	}
+}
+
+func TestCosmosStore_BackfillLocation_Idempotent(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	// Every doc already carries a location (the steady state after a first run).
+	a := testZone(t)
+	a.ID, a.UserID = "z-a", "auth0|a"
+	b := testZone(t)
+	b.ID, b.UserID = "z-b", "auth0|b"
+	items.crossPartitionResult = [][]byte{mustDocBytes(t, a), mustDocBytes(t, b)}
+	store := NewCosmosStore(items)
+
+	res, err := store.BackfillLocation(context.Background())
+	if err != nil {
+		t.Fatalf("BackfillLocation: %v", err)
+	}
+	if res.Total != 2 || res.AlreadyHad != 2 || res.Backfilled != 0 {
+		t.Fatalf("result = %+v, want {Total:2 Backfilled:0 AlreadyHad:2}", res)
+	}
+	if len(items.upserts) != 0 {
+		t.Errorf("a re-run must write nothing, got %d upserts", len(items.upserts))
+	}
+}
+
+func TestCosmosStore_BackfillLocation_QueryError(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	items.queryErr = errors.New("gateway boom")
+	store := NewCosmosStore(items)
+
+	if _, err := store.BackfillLocation(context.Background()); err == nil {
+		t.Fatal("expected an error when the cross-partition scan fails")
+	}
+}
+
+func TestCosmosStore_BackfillLocation_EmptyContainerIsZeroResult(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+	res, err := store.BackfillLocation(context.Background())
+	if err != nil {
+		t.Fatalf("BackfillLocation: %v", err)
+	}
+	if res.Total != 0 || res.Backfilled != 0 || res.AlreadyHad != 0 {
+		t.Errorf("result = %+v, want zero", res)
 	}
 }

--- a/api-go/internal/watchzones/store_cosmos_test.go
+++ b/api-go/internal/watchzones/store_cosmos_test.go
@@ -347,6 +347,36 @@ func TestCosmosStore_FindZonesContaining_FiltersByAuthorityBeforeDistance(t *tes
 	}
 }
 
+func TestCosmosStore_FindZonesContaining_HybridIndexServedWithLegacyFallback(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if _, err := store.FindZonesContaining(context.Background(), 99, 51.5, -0.1); err != nil {
+		t.Fatalf("FindZonesContaining: %v", err)
+	}
+	// The primary clause distances against the persisted GeoJSON c.location path so
+	// the spatial index on /location (tc-quqe) serves it — this is the perf win.
+	if !strings.Contains(items.lastQuery, "ST_DISTANCE(c.location,") {
+		t.Errorf("query must distance against the indexed c.location path: %q", items.lastQuery)
+	}
+	// Any zone written before the location backfill (tc-xj48) has no c.location, so
+	// the index-served clause cannot match it. The legacy fallback keeps it matching
+	// via the inline [c.longitude, c.latitude] point, guarded by NOT IS_DEFINED so
+	// the two clauses never double-count and the switch is correct regardless of
+	// backfill state (mirrors the dormant-sweep guard, profiles/admin_store.go).
+	if !strings.Contains(items.lastQuery, "NOT IS_DEFINED(c.location)") {
+		t.Errorf("query must guard the legacy fallback with NOT IS_DEFINED(c.location): %q", items.lastQuery)
+	}
+	if !strings.Contains(items.lastQuery, "[c.longitude, c.latitude]") {
+		t.Errorf("legacy fallback must distance against the inline [c.longitude, c.latitude] point: %q", items.lastQuery)
+	}
+	// The authority pre-filter (tc-8dud) survives the hybrid rewrite.
+	if !strings.Contains(items.lastQuery, "c.authorityId = @authorityId") {
+		t.Errorf("hybrid query must keep the authority pre-filter: %q", items.lastQuery)
+	}
+}
+
 func TestCosmosStore_FindZonesContaining_ProjectsNeededFieldsNotSelectStar(t *testing.T) {
 	t.Parallel()
 	items := newFakeItems()

--- a/cli/internal/tc/app.go
+++ b/cli/internal/tc/app.go
@@ -14,11 +14,12 @@ const helpText = `tc — Town Crier admin CLI
 Usage: tc <command> [options]
 
 Commands:
-  generate-offer-codes Bulk-generate single-use offer codes
-  grant-subscription   Grant or change a user's subscription tier
-  list-users           List users with email, ID, and subscription tier
-  help                 Show this help message
-  version              Print version
+  generate-offer-codes        Bulk-generate single-use offer codes
+  grant-subscription          Grant or change a user's subscription tier
+  list-users                  List users with email, ID, and subscription tier
+  backfill-watchzone-location One-shot: add a GeoJSON location to legacy watch zones
+  help                        Show this help message
+  version                     Print version
 
 generate-offer-codes options:
   --count <n>           Number of codes to generate (1-1000, required)
@@ -73,6 +74,8 @@ func Run(ctx context.Context, env Env, rawArgs []string) int {
 		return runGrantSubscription(ctx, client, env, args)
 	case "list-users":
 		return runListUsers(ctx, client, env, args)
+	case "backfill-watchzone-location":
+		return runBackfillWatchZoneLocation(ctx, client, env, args)
 	default:
 		fmt.Fprintf(env.Err, "Unknown command: %s\n", args.Command)
 		fmt.Fprintln(env.Err, "Run 'tc help' for a list of commands.")

--- a/cli/internal/tc/backfill.go
+++ b/cli/internal/tc/backfill.go
@@ -1,0 +1,37 @@
+package tc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// runBackfillWatchZoneLocation implements `tc backfill-watchzone-location`: a
+// guarded, idempotent one-shot that POSTs to /v1/admin/watchzones/backfill-location
+// (no body) and prints the reconciled counts. The endpoint rewrites every legacy
+// WatchZone document with a derived GeoJSON location; re-running it is safe.
+func runBackfillWatchZoneLocation(ctx context.Context, client *Client, env Env, _ *ParsedArgs) int {
+	resp, err := client.Post(ctx, "/v1/admin/watchzones/backfill-location", nil)
+	if err != nil {
+		fmt.Fprintf(env.Err, "API error: %s\n", err)
+		return exitRuntime
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
+		fmt.Fprintf(env.Err, "API error (%d): %s\n", resp.StatusCode, string(body))
+		return exitRuntime
+	}
+
+	var result backfillWatchZoneLocationResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxRespBytes)).Decode(&result); err != nil {
+		fmt.Fprintf(env.Err, "API error: %s\n", err)
+		return exitRuntime
+	}
+
+	fmt.Fprintf(env.Out, "Backfilled location on %d of %d watch zones (%d already had it)\n",
+		result.Backfilled, result.Total, result.AlreadyHad)
+	return exitOK
+}

--- a/cli/internal/tc/backfill_test.go
+++ b/cli/internal/tc/backfill_test.go
@@ -1,0 +1,62 @@
+package tc
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRunBackfillWatchZoneLocation_SuccessReturns0(t *testing.T) {
+	t.Parallel()
+	var gotKey, gotPath, gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get(apiKeyHeader)
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"total":10,"backfilled":3,"alreadyHad":7}`)
+	}))
+	defer server.Close()
+
+	env, out, errBuf := captureEnv()
+	code := runBackfillWatchZoneLocation(context.Background(), clientFor(server), env, ParseArgs([]string{
+		"backfill-watchzone-location",
+	}))
+
+	if code != exitOK {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, errBuf.String())
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v1/admin/watchzones/backfill-location" {
+		t.Fatalf("request = %s %s, want POST /v1/admin/watchzones/backfill-location", gotMethod, gotPath)
+	}
+	if gotKey != "sk-test" {
+		t.Fatalf("X-Admin-Key = %q, want sk-test", gotKey)
+	}
+	if got := out.String(); !strings.Contains(got, "Backfilled location on 3 of 10 watch zones (7 already had it)") {
+		t.Fatalf("stdout = %q, want reconciled summary", got)
+	}
+}
+
+func TestRunBackfillWatchZoneLocation_APIErrorReturns2(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	}))
+	defer server.Close()
+
+	env, _, errBuf := captureEnv()
+	code := runBackfillWatchZoneLocation(context.Background(), clientFor(server), env, ParseArgs([]string{
+		"backfill-watchzone-location",
+	}))
+
+	if code != exitRuntime {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "API error (500): boom") {
+		t.Fatalf("stderr = %q, want API error (500)", errBuf.String())
+	}
+}

--- a/cli/internal/tc/commands.go
+++ b/cli/internal/tc/commands.go
@@ -40,6 +40,15 @@ type listUsersItem struct {
 	Tier   string  `json:"tier"`
 }
 
+// backfillWatchZoneLocationResponse is the POST
+// /v1/admin/watchzones/backfill-location response body: how many documents were
+// scanned, rewritten with a derived GeoJSON location, and already had one.
+type backfillWatchZoneLocationResponse struct {
+	Total      int `json:"total"`
+	Backfilled int `json:"backfilled"`
+	AlreadyHad int `json:"alreadyHad"`
+}
+
 // parseStrictInt parses s as a non-negative base-10 integer, accepting only
 // ASCII digits. It rejects signs, whitespace, and decimals. Overflow is
 // reported as invalid.


### PR DESCRIPTION
Activates the WatchZones `/location` spatial index (added in #619, live on dev) on the read path, with a safe, idempotent backfill for pre-existing zones.

## tc-qbq4 — hybrid index-served query
`findZonesContainingQuery` (api-go/internal/watchzones/store_cosmos.go) now ORs two clauses inside the authority pre-filter:
- **Primary:** `ST_DISTANCE(c.location, @point) <= c.radiusMetres` — served by the spatial index on the persisted GeoJSON `/location` path.
- **Fallback:** `NOT IS_DEFINED(c.location) AND ST_DISTANCE({'type':'Point','coordinates':[c.longitude,c.latitude]}, @point) <= c.radiusMetres` — keeps any zone written before the location backfill matching via its lat/lon columns.

The `NOT IS_DEFINED` guard makes the two clauses mutually exclusive, mirroring the dormant-sweep pattern (#616). This removes the ordering risk: the switch is correct **regardless** of backfill state, so an un-backfilled zone never silently stops matching and no owner misses alerts. Authority pre-filter, cross-partition `/userId` fan-out, and the deliberate projection are unchanged.

## tc-xj48 — one-shot location backfill
- `CosmosStore.BackfillLocation(ctx)` — cross-partition scans every zone; re-Saves only docs missing `location` (idempotent), deriving the point from the persisted lat/lon floats (never recomputed). Returns `{total, backfilled, alreadyHad}`.
- `POST /v1/admin/watchzones/backfill-location` — X-Admin-Key gated, anonymous to Auth0, mirrors the existing `/v1/admin` handlers.
- `tc backfill-watchzone-location` — CLI command hitting the endpoint via X-Admin-Key.

## Rollout
Both ship together so a single cd-dev deploy carries index + write-path (#618) + hybrid query + backfill endpoint. Dev backfill + verification follow this merge; prod gets it via the next tagged release. A later cleanup PR will simplify the query to pure `ST_DISTANCE(c.location, …)` once both envs are 100% backfilled.

## Gates
api-go: build / test (`-race`, 1112 pass) / vet / gofmt / golangci-lint — all green.
cli: build / test (`-race`, 48 pass) / vet / gofmt / golangci-lint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)