### PR TITLE
perf(watchzones): simplify FindZonesContaining to pure index-served ST_DISTANCE (tc-ltlw)

### DIFF
--- a/api-go/internal/watchzones/store_cosmos.go
+++ b/api-go/internal/watchzones/store_cosmos.go
@@ -181,18 +181,14 @@ func (s *CosmosStore) DistinctAuthorityIDs(ctx context.Context) ([]int, error) {
 // app.AreaID scoping (notifydispatch/decision.go). The candidate authority and
 // point are bound as parameters.
 //
-// The distance test is a hybrid of two clauses, ORed inside the authority filter:
-//   - Primary: ST_DISTANCE(c.location, @point) is served by the spatial index on
-//     the persisted GeoJSON /location path (tc-quqe), so the common (backfilled)
-//     case is index-accelerated rather than a full scan.
-//   - Fallback: any zone written before the location backfill (tc-xj48) has no
-//     c.location field, so the index-served clause cannot match it. The NOT
-//     IS_DEFINED(c.location) guard restores those legacy zones via the inline
-//     [c.longitude, c.latitude] point, computed from the document's latitude /
-//     longitude columns. The guard means the two clauses are mutually exclusive
-//     (a doc either has c.location or it doesn't), so nothing double-counts and
-//     the switch is correct regardless of backfill state — mirroring the
-//     dormant-sweep NOT IS_DEFINED guard (profiles/admin_store.go dormantQuery).
+// The distance test is a single index-served clause: ST_DISTANCE(c.location,
+// @point) <= c.radiusMetres, served by the spatial index on the persisted GeoJSON
+// /location path (tc-quqe), so Cosmos fully uses the index rather than a full
+// scan. The legacy NOT IS_DEFINED(c.location) fallback — which distanced against
+// an inline [c.longitude, c.latitude] point for zones written before the location
+// backfill — was removed (tc-ltlw / Phase 2d) once both environments were fully
+// backfilled (tc-xj48) and the write path (#618) guaranteed every new zone
+// carries c.location, so no zone can lack it and the fallback was dead weight.
 //
 // All coordinates are GeoJSON order: [longitude, latitude], not [lat, lng].
 //
@@ -203,14 +199,11 @@ func (s *CosmosStore) DistinctAuthorityIDs(ctx context.Context) ([]int, error) {
 // (not dropped) because they are nullable *bool that coalesce to true when
 // absent, so omitting them would silently re-enable a user's disabled
 // notifications if a future caller read them. latitude/longitude are omitted from
-// the projection — no caller reads zone coordinates after the match (the fallback
-// clause reads them server-side during the distance test, not in the result).
+// the projection — no caller reads zone coordinates after the match, and the
+// distance test now reads only the indexed c.location, not the raw columns.
 const findZonesContainingQuery = "SELECT c.id, c.userId, c.name, c.radiusMetres, c.authorityId, c.createdAt, c.pushEnabled, c.emailInstantEnabled " +
-	"FROM c WHERE c.authorityId = @authorityId AND (" +
-	"ST_DISTANCE(c.location, {'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres " +
-	"OR (NOT IS_DEFINED(c.location) AND ST_DISTANCE(" +
-	"{'type': 'Point', 'coordinates': [c.longitude, c.latitude]}, " +
-	"{'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres))"
+	"FROM c WHERE c.authorityId = @authorityId AND " +
+	"ST_DISTANCE(c.location, {'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres"
 
 // FindZonesContaining returns every watch zone (across all users) scoped to the
 // given authority whose circle contains the point (latitude, longitude), via a

--- a/api-go/internal/watchzones/store_cosmos_test.go
+++ b/api-go/internal/watchzones/store_cosmos_test.go
@@ -357,7 +357,7 @@ func TestCosmosStore_FindZonesContaining_FiltersByAuthorityBeforeDistance(t *tes
 	}
 }
 
-func TestCosmosStore_FindZonesContaining_HybridIndexServedWithLegacyFallback(t *testing.T) {
+func TestCosmosStore_FindZonesContaining_PureIndexServedQuery(t *testing.T) {
 	t.Parallel()
 	items := newFakeItems()
 	store := NewCosmosStore(items)
@@ -365,25 +365,26 @@ func TestCosmosStore_FindZonesContaining_HybridIndexServedWithLegacyFallback(t *
 	if _, err := store.FindZonesContaining(context.Background(), 99, 51.5, -0.1); err != nil {
 		t.Fatalf("FindZonesContaining: %v", err)
 	}
-	// The primary clause distances against the persisted GeoJSON c.location path so
-	// the spatial index on /location (tc-quqe) serves it — this is the perf win.
+	// The distance test is now a single index-served clause: ST_DISTANCE against
+	// the persisted GeoJSON c.location path, served by the spatial index on
+	// /location (tc-quqe). This is the perf win — Cosmos fully uses the index.
 	if !strings.Contains(items.lastQuery, "ST_DISTANCE(c.location,") {
 		t.Errorf("query must distance against the indexed c.location path: %q", items.lastQuery)
 	}
-	// Any zone written before the location backfill (tc-xj48) has no c.location, so
-	// the index-served clause cannot match it. The legacy fallback keeps it matching
-	// via the inline [c.longitude, c.latitude] point, guarded by NOT IS_DEFINED so
-	// the two clauses never double-count and the switch is correct regardless of
-	// backfill state (mirrors the dormant-sweep guard, profiles/admin_store.go).
-	if !strings.Contains(items.lastQuery, "NOT IS_DEFINED(c.location)") {
-		t.Errorf("query must guard the legacy fallback with NOT IS_DEFINED(c.location): %q", items.lastQuery)
+	// The legacy fallback is gone (tc-ltlw / Phase 2d): both environments are fully
+	// backfilled (tc-xj48) and the write path (#618) guarantees every new zone
+	// carries c.location, so no zone can lack it. The NOT IS_DEFINED guard and the
+	// inline [c.longitude, c.latitude] read are removed so the query is pure and the
+	// index serves it without a residual full-scan clause.
+	if strings.Contains(items.lastQuery, "NOT IS_DEFINED") {
+		t.Errorf("query must not retain the removed NOT IS_DEFINED fallback: %q", items.lastQuery)
 	}
-	if !strings.Contains(items.lastQuery, "[c.longitude, c.latitude]") {
-		t.Errorf("legacy fallback must distance against the inline [c.longitude, c.latitude] point: %q", items.lastQuery)
+	if strings.Contains(items.lastQuery, "[c.longitude, c.latitude]") {
+		t.Errorf("query must not retain the removed inline [c.longitude, c.latitude] legacy point: %q", items.lastQuery)
 	}
-	// The authority pre-filter (tc-8dud) survives the hybrid rewrite.
+	// The authority pre-filter (tc-8dud) survives the simplification.
 	if !strings.Contains(items.lastQuery, "c.authorityId = @authorityId") {
-		t.Errorf("hybrid query must keep the authority pre-filter: %q", items.lastQuery)
+		t.Errorf("query must keep the authority pre-filter: %q", items.lastQuery)
 	}
 }
 


### PR DESCRIPTION
Phase 2d cleanup — drops the hybrid fallback now that both environments are fully backfilled.

`findZonesContainingQuery` is now a single index-served distance test:
```
c.authorityId = @authorityId AND ST_DISTANCE(c.location, @point) <= c.radiusMetres
```
The legacy `OR (NOT IS_DEFINED(c.location) AND ST_DISTANCE([c.longitude, c.latitude], @point) …)` fallback is removed, so Cosmos fully uses the `/location` spatial index with no residual full-scan branch.

## Why this is safe now
- **Dev**: 17/17 zones backfilled (idempotent re-run → 0 to do).
- **Prod**: 19/19 zones backfilled (idempotent re-run → 0 to do).
- The `/location` spatial index is live on both `town-crier-dev` and `town-crier-prod` WatchZones.
- The write path (#618) populates `location` on every new/updated zone, so no future zone can lack it.

The authority pre-filter, projection, and cross-partition `/userId` fan-out are unchanged.

## Gates
api-go: build / test (`-race`, 1112 pass) / vet / gofmt / golangci-lint — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)