### PR TITLE
feat(ios): prompt paid users to enable push after upgrade + home banner (tc-afub)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+PushNudge.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+PushNudge.swift
@@ -13,10 +13,9 @@ extension AppCoordinator {
   public func makePushNudgeViewModel() -> PushNudgeViewModel {
     PushNudgeViewModel(
       tier: subscriptionTier,
-      notificationService: notificationService,
-      onOpenSettings: { [weak self] in
-        self?.showSystemNotificationSettings()
-      }
-    )
+      notificationService: notificationService
+    ) { [weak self] in
+      self?.showSystemNotificationSettings()
+    }
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+PushNudge.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+PushNudge.swift
@@ -1,0 +1,22 @@
+import Foundation
+import TownCrierDomain
+
+extension AppCoordinator {
+  /// Factory for the home-tab push-permission nudge ViewModel (issue #624,
+  /// Prong 2). Injects the current resolved tier and the shared notification
+  /// service, and wires the `.denied` action to the existing iOS-Settings deep
+  /// link (``showSystemNotificationSettings()``) rather than duplicating it.
+  ///
+  /// The Applications-tab `NavigationStack` is keyed on `subscriptionTier`, so
+  /// the banner (and this freshly built ViewModel) rebuilds with the current
+  /// tier whenever a purchase resolves.
+  public func makePushNudgeViewModel() -> PushNudgeViewModel {
+    PushNudgeViewModel(
+      tier: subscriptionTier,
+      notificationService: notificationService,
+      onOpenSettings: { [weak self] in
+        self?.showSystemNotificationSettings()
+      }
+    )
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -79,6 +79,9 @@ public final class AppCoordinator: ObservableObject {
   var pendingWatermarkAdvance: Task<Void, Never>?
   // Foreground badge sync (tc-1nsa.9).
   var pendingBadgeSync: Task<Void, Never>?
+  // Post-purchase push-permission prompt — fire-and-forget but stored so
+  // tests can await deterministically (issue #624, Prong 1).
+  var pendingPostPurchasePermissionPrompt: Task<Void, Never>?
 
   public init(
     repository: PlanningApplicationRepository,
@@ -276,6 +279,27 @@ public final class AppCoordinator: ObservableObject {
     // unlock the paid range the moment a purchase resolves, without rebuilding
     // the wizard and losing the user's in-progress postcode (tc-w3cb.1/.3).
     onboardingViewModel?.subscriptionTier = result.tier
+
+    // Post-purchase push prompt (issue #624, Prong 1): a freshly upgraded user
+    // is now paying for instant alerts. If they have never been asked
+    // (`.notDetermined`), trigger the system prompt at this peak-intent moment.
+    // The `.notDetermined` gate self-limits this to one prompt — once the user
+    // responds, the status leaves `.notDetermined` and never returns. A
+    // `.denied` user is intentionally NOT re-prompted (iOS cannot re-show the
+    // dialog); Prong 2's home banner deep-links them to iOS Settings instead.
+    // Fired into a stored `Task` so tests can await it deterministically.
+    if result.tier > .free,
+      await notificationService.authorizationStatus() == .notDetermined {
+      pendingPostPurchasePermissionPrompt = Task { [weak self] in
+        _ = try? await self?.notificationService.requestPermission()
+      }
+    }
+  }
+
+  /// Test-only synchronisation: await the most recent post-purchase
+  /// push-permission prompt. Replaces flaky `Task.sleep` waits.
+  public func waitForPendingPostPurchasePrompt() async {
+    await pendingPostPurchasePermissionPrompt?.value
   }
 
   // MARK: - Settings Navigation

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/PushNudge/PushNudgeBanner.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/PushNudge/PushNudgeBanner.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+import TownCrierDomain
+
+/// Home-tab push-permission nudge banner (issue #624, Prong 2).
+///
+/// A passive view: all logic lives in ``PushNudgeViewModel``. Rendered above
+/// the Applications list, it appears only when the user is on a paid tier and
+/// notifications are not authorized. The single button branches on status —
+/// "Turn on" requests the system prompt when `.notDetermined`, "Open Settings"
+/// deep-links to iOS Settings when `.denied`.
+///
+/// Status is loaded on appear and re-read on `scenePhase == .active` so the
+/// banner disappears once the user enables notifications in iOS Settings and
+/// returns.
+public struct PushNudgeBanner: View {
+  @StateObject private var viewModel: PushNudgeViewModel
+  @Environment(\.scenePhase) private var scenePhase
+
+  public init(viewModel: PushNudgeViewModel) {
+    _viewModel = StateObject(wrappedValue: viewModel)
+  }
+
+  public var body: some View {
+    Group {
+      if viewModel.isVisible {
+        banner
+      }
+    }
+    .task { await viewModel.load() }
+    .onChange(of: scenePhase) { _, newPhase in
+      guard newPhase == .active else { return }
+      Task { await viewModel.refresh() }
+    }
+  }
+
+  private var banner: some View {
+    HStack(alignment: .top, spacing: TCSpacing.medium) {
+      Image(systemName: "bell.badge")
+        .font(.system(.title3))
+        .foregroundStyle(Color.tcAmber)
+        .accessibilityHidden(true)
+
+      VStack(alignment: .leading, spacing: TCSpacing.small) {
+        Text(viewModel.bodyText)
+          .font(TCTypography.body)
+          .foregroundStyle(Color.tcTextPrimary)
+          .fixedSize(horizontal: false, vertical: true)
+
+        Button {
+          Task { await viewModel.primaryAction() }
+        } label: {
+          Text(viewModel.buttonTitle)
+            .font(TCTypography.bodyEmphasis)
+            .foregroundStyle(Color.tcAmber)
+        }
+        .accessibilityLabel(viewModel.buttonTitle)
+      }
+
+      Spacer(minLength: 0)
+    }
+    .padding(TCSpacing.medium)
+    .background(Color.tcAmberMuted)
+    .clipShape(RoundedRectangle(cornerRadius: TCCornerRadius.medium))
+    .padding(.horizontal, TCSpacing.medium)
+    .padding(.top, TCSpacing.small)
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/PushNudge/PushNudgeViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/PushNudge/PushNudgeViewModel.swift
@@ -1,0 +1,92 @@
+import Foundation
+import TownCrierDomain
+
+/// ViewModel for the home-tab push-permission nudge banner (issue #624).
+///
+/// A paid user who never granted notification permission is paying for instant
+/// alerts they will never receive. This banner is the persistent safety net: it
+/// shows on the Applications tab whenever the user is on a paid tier and
+/// notifications are not authorized, and its primary action branches on the
+/// system authorization status (mirroring `NotificationPreferencesViewModel`):
+///
+/// - `.notDetermined` → request the system prompt, then re-read the status.
+/// - `.denied` → invoke `onOpenSettings` (the system prompt can never be
+///   re-shown once denied; the only recovery is the iOS Settings deep link).
+///
+/// `authorizationStatus` is `nil` until the first ``load()`` completes; the
+/// banner stays hidden in that window to avoid a flash before the status
+/// resolves.
+@MainActor
+public final class PushNudgeViewModel: ObservableObject {
+  /// Reflects the system notification permission. `nil` until the first
+  /// ``load()`` completes — the view treats `nil` as "hidden, no flash".
+  @Published public private(set) var authorizationStatus: NotificationAuthorizationStatus?
+
+  private let tier: SubscriptionTier
+  private let notificationService: NotificationService
+  private let onOpenSettings: () -> Void
+
+  public init(
+    tier: SubscriptionTier,
+    notificationService: NotificationService,
+    onOpenSettings: @escaping () -> Void
+  ) {
+    self.tier = tier
+    self.notificationService = notificationService
+    self.onOpenSettings = onOpenSettings
+  }
+
+  /// `true` only for a paid tier whose resolved authorization is not yet
+  /// `.authorized`. Hidden while the status is still loading (`nil`) and for
+  /// any free-tier user.
+  public var isVisible: Bool {
+    guard tier > .free, let authorizationStatus else { return false }
+    return authorizationStatus != .authorized
+  }
+
+  /// Banner body copy, status-appropriate.
+  public var bodyText: String {
+    switch authorizationStatus {
+    case .denied:
+      return "Notifications are switched off in iOS Settings. Tap to turn them back on."
+    default:
+      return "Notifications are off. Turn them on to get the instant alerts you're paying for."
+    }
+  }
+
+  /// Primary-action button title, status-appropriate.
+  public var buttonTitle: String {
+    switch authorizationStatus {
+    case .denied:
+      return "Open Settings"
+    default:
+      return "Turn on"
+    }
+  }
+
+  /// Reads the current authorization status on appear.
+  public func load() async {
+    authorizationStatus = await notificationService.authorizationStatus()
+  }
+
+  /// Re-reads the authorization status without prompting. Called from the view
+  /// on `scenePhase == .active` so the banner disappears once the user enables
+  /// notifications in iOS Settings and returns.
+  public func refresh() async {
+    authorizationStatus = await notificationService.authorizationStatus()
+  }
+
+  /// Acts on the current status: `.notDetermined` requests the system prompt
+  /// and re-reads the resulting status; `.denied` deep-links to iOS Settings.
+  public func primaryAction() async {
+    switch authorizationStatus {
+    case .notDetermined:
+      _ = try? await notificationService.requestPermission()
+      authorizationStatus = await notificationService.authorizationStatus()
+    case .denied:
+      onOpenSettings()
+    case .authorized, .none:
+      break
+    }
+  }
+}

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -233,9 +233,17 @@ struct TownCrierApp: App {
     TabView(selection: $coordinator.selectedTab) {
       // 1. Applications
       NavigationStack {
-        ApplicationListView(viewModel: coordinator.makeApplicationListViewModel())
-          .id(coordinator.subscriptionTier)
-          .settingsToolbar { coordinator.showSettings() }
+        VStack(spacing: 0) {
+          // Paid-user push-permission nudge (issue #624, Prong 2). Hidden
+          // unless the user is on a paid tier and notifications are not
+          // authorized. The `.id` is hoisted onto the VStack so both the
+          // banner and the list rebuild when the resolved tier changes (e.g.
+          // straight after a purchase).
+          PushNudgeBanner(viewModel: coordinator.makePushNudgeViewModel())
+          ApplicationListView(viewModel: coordinator.makeApplicationListViewModel())
+        }
+        .id(coordinator.subscriptionTier)
+        .settingsToolbar { coordinator.showSettings() }
       }
       .tabItem {
         Label("Applications", systemImage: "doc.text.magnifyingglass")

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorPostPurchaseNotificationTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorPostPurchaseNotificationTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Post-purchase notification prompt (issue #624, Prong 1).
+///
+/// After a purchase resolves to a paid tier and notifications have never been
+/// requested (`.notDetermined`), `resolveSubscriptionTier()` triggers the
+/// system permission prompt — the highest-intent moment to ask. Gating on
+/// `.notDetermined` self-limits the prompt to once: a `.denied` user is never
+/// re-prompted (iOS won't re-show the dialog anyway), and a `.free` user is
+/// never prompted regardless of status. The prompt is fired into a stored
+/// `Task` so tests can await it deterministically.
+@Suite("AppCoordinator — post-purchase notification prompt")
+@MainActor
+struct AppCoordinatorPostPurchaseNotificationTests {
+
+  private func makeSUT(
+    resolvedTier: SubscriptionTier,
+    authorizationStatus: NotificationAuthorizationStatus
+  ) -> (AppCoordinator, SpyNotificationService) {
+    let notificationSpy = SpyNotificationService()
+    notificationSpy.nextAuthorizationStatus = authorizationStatus
+    let tierResolver = FakeSubscriptionTierResolver()
+    tierResolver.resolveResult = (resolvedTier, false)
+    let coordinator = AppCoordinator(
+      repository: SpyPlanningApplicationRepository(),
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: SpyUserProfileRepository(),
+      tierResolver: tierResolver,
+      watchZoneRepository: SpyWatchZoneRepository(),
+      geocoder: SpyPostcodeGeocoder(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: notificationSpy,
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService(),
+      tierCache: UserDefaults(suiteName: UUID().uuidString) ?? .standard
+    )
+    return (coordinator, notificationSpy)
+  }
+
+  @Test func paidTier_notDetermined_requestsPermission() async {
+    let (sut, notificationSpy) = makeSUT(
+      resolvedTier: .personal,
+      authorizationStatus: .notDetermined
+    )
+
+    await sut.resolveSubscriptionTier()
+    await sut.waitForPendingPostPurchasePrompt()
+
+    #expect(notificationSpy.requestPermissionCallCount == 1)
+  }
+
+  @Test func proTier_notDetermined_requestsPermission() async {
+    let (sut, notificationSpy) = makeSUT(
+      resolvedTier: .pro,
+      authorizationStatus: .notDetermined
+    )
+
+    await sut.resolveSubscriptionTier()
+    await sut.waitForPendingPostPurchasePrompt()
+
+    #expect(notificationSpy.requestPermissionCallCount == 1)
+  }
+
+  @Test func paidTier_authorized_doesNotRequest() async {
+    let (sut, notificationSpy) = makeSUT(
+      resolvedTier: .personal,
+      authorizationStatus: .authorized
+    )
+
+    await sut.resolveSubscriptionTier()
+    await sut.waitForPendingPostPurchasePrompt()
+
+    #expect(notificationSpy.requestPermissionCallCount == 0)
+  }
+
+  @Test func paidTier_denied_doesNotRequest() async {
+    let (sut, notificationSpy) = makeSUT(
+      resolvedTier: .personal,
+      authorizationStatus: .denied
+    )
+
+    await sut.resolveSubscriptionTier()
+    await sut.waitForPendingPostPurchasePrompt()
+
+    #expect(notificationSpy.requestPermissionCallCount == 0)
+  }
+
+  @Test func freeTier_notDetermined_doesNotRequest() async {
+    let (sut, notificationSpy) = makeSUT(
+      resolvedTier: .free,
+      authorizationStatus: .notDetermined
+    )
+
+    await sut.resolveSubscriptionTier()
+    await sut.waitForPendingPostPurchasePrompt()
+
+    #expect(notificationSpy.requestPermissionCallCount == 0)
+  }
+
+  // MARK: - Banner factory wiring
+
+  @Test func makePushNudgeViewModel_usesResolvedTier_andDeniedActionOpensSettings() async {
+    let (sut, notificationSpy) = makeSUT(
+      resolvedTier: .personal,
+      authorizationStatus: .denied
+    )
+    await sut.resolveSubscriptionTier()
+
+    let viewModel = sut.makePushNudgeViewModel()
+    await viewModel.load()
+    #expect(viewModel.isVisible == true)
+
+    await viewModel.primaryAction()
+
+    #expect(sut.isOpeningSystemNotificationSettings == true)
+    #expect(notificationSpy.requestPermissionCallCount == 0)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/PushNudgeViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/PushNudgeViewModelTests.swift
@@ -32,9 +32,8 @@ struct PushNudgeViewModelTests {
     let openSettings = OpenSettingsSpy()
     let sut = PushNudgeViewModel(
       tier: tier,
-      notificationService: notificationSpy,
-      onOpenSettings: { openSettings.record() }
-    )
+      notificationService: notificationSpy
+    ) { openSettings.record() }
     return (sut, notificationSpy, openSettings)
   }
 
@@ -49,7 +48,10 @@ struct PushNudgeViewModelTests {
   @Test(
     "isVisible matrix: paid + unauthorized shows; authorized or free hides",
     arguments: [
-      (tier: SubscriptionTier.personal, status: NotificationAuthorizationStatus.notDetermined, expected: true),
+      (
+        tier: SubscriptionTier.personal, status: NotificationAuthorizationStatus.notDetermined,
+        expected: true
+      ),
       (tier: .personal, status: .denied, expected: true),
       (tier: .personal, status: .authorized, expected: false),
       (tier: .pro, status: .notDetermined, expected: true),

--- a/mobile/ios/town-crier-tests/Sources/Features/PushNudgeViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/PushNudgeViewModelTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Tests for the home-tab push-permission nudge ViewModel (issue #624).
+///
+/// The banner is shown only when the user is on a paid tier and notifications
+/// are not authorized. Its primary action branches on the system authorization
+/// status: `.notDetermined` triggers the system prompt (then re-reads status),
+/// `.denied` deep-links to iOS Settings (the prompt can never be re-shown once
+/// denied). Status is refreshed on `scenePhase == .active` so the banner
+/// disappears after the user enables notifications in iOS Settings and returns.
+@Suite("PushNudgeViewModel")
+@MainActor
+struct PushNudgeViewModelTests {
+
+  /// Records invocations of the injected `onOpenSettings` callback so tests can
+  /// assert the `.denied` action deep-links rather than re-prompting.
+  private final class OpenSettingsSpy {
+    private(set) var callCount = 0
+    func record() { callCount += 1 }
+  }
+
+  private func makeSUT(
+    tier: SubscriptionTier = .personal,
+    status: NotificationAuthorizationStatus = .notDetermined
+  ) -> (PushNudgeViewModel, SpyNotificationService, OpenSettingsSpy) {
+    let notificationSpy = SpyNotificationService()
+    notificationSpy.nextAuthorizationStatus = status
+    let openSettings = OpenSettingsSpy()
+    let sut = PushNudgeViewModel(
+      tier: tier,
+      notificationService: notificationSpy,
+      onOpenSettings: { openSettings.record() }
+    )
+    return (sut, notificationSpy, openSettings)
+  }
+
+  // MARK: - Visibility
+
+  @Test func isNotVisibleBeforeLoad() {
+    let (sut, _, _) = makeSUT(tier: .personal, status: .notDetermined)
+
+    #expect(sut.isVisible == false)
+  }
+
+  @Test(
+    "isVisible matrix: paid + unauthorized shows; authorized or free hides",
+    arguments: [
+      (tier: SubscriptionTier.personal, status: NotificationAuthorizationStatus.notDetermined, expected: true),
+      (tier: .personal, status: .denied, expected: true),
+      (tier: .personal, status: .authorized, expected: false),
+      (tier: .pro, status: .notDetermined, expected: true),
+      (tier: .pro, status: .denied, expected: true),
+      (tier: .pro, status: .authorized, expected: false),
+      (tier: .free, status: .notDetermined, expected: false),
+      (tier: .free, status: .denied, expected: false),
+      (tier: .free, status: .authorized, expected: false),
+    ]
+  )
+  func isVisibleMatrix(
+    _ testCase: (tier: SubscriptionTier, status: NotificationAuthorizationStatus, expected: Bool)
+  ) async {
+    let (sut, _, _) = makeSUT(tier: testCase.tier, status: testCase.status)
+
+    await sut.load()
+
+    #expect(sut.isVisible == testCase.expected)
+  }
+
+  // MARK: - Copy
+
+  @Test func notDeterminedCopyAsksToTurnOn() async {
+    let (sut, _, _) = makeSUT(tier: .personal, status: .notDetermined)
+
+    await sut.load()
+
+    #expect(
+      sut.bodyText
+        == "Notifications are off. Turn them on to get the instant alerts you're paying for."
+    )
+    #expect(sut.buttonTitle == "Turn on")
+  }
+
+  @Test func deniedCopyPointsToSettings() async {
+    let (sut, _, _) = makeSUT(tier: .personal, status: .denied)
+
+    await sut.load()
+
+    #expect(
+      sut.bodyText
+        == "Notifications are switched off in iOS Settings. Tap to turn them back on."
+    )
+    #expect(sut.buttonTitle == "Open Settings")
+  }
+
+  // MARK: - Primary action
+
+  @Test func notDeterminedActionRequestsPermissionThenReReadsStatus() async {
+    let (sut, notificationSpy, openSettings) = makeSUT(
+      tier: .personal,
+      status: .notDetermined
+    )
+    await sut.load()
+    notificationSpy.nextAuthorizationStatus = .authorized
+
+    await sut.primaryAction()
+
+    #expect(notificationSpy.requestPermissionCallCount == 1)
+    #expect(openSettings.callCount == 0)
+    #expect(sut.authorizationStatus == .authorized)
+    #expect(sut.isVisible == false)
+  }
+
+  @Test func deniedActionOpensSettingsAndDoesNotRequestPermission() async {
+    let (sut, notificationSpy, openSettings) = makeSUT(
+      tier: .personal,
+      status: .denied
+    )
+    await sut.load()
+
+    await sut.primaryAction()
+
+    #expect(openSettings.callCount == 1)
+    #expect(notificationSpy.requestPermissionCallCount == 0)
+  }
+
+  // MARK: - Foreground refresh
+
+  @Test func refreshHidesBannerWhenStatusBecomesAuthorized() async {
+    let (sut, notificationSpy, _) = makeSUT(tier: .personal, status: .denied)
+    await sut.load()
+    #expect(sut.isVisible == true)
+    notificationSpy.nextAuthorizationStatus = .authorized
+
+    await sut.refresh()
+
+    #expect(sut.authorizationStatus == .authorized)
+    #expect(sut.isVisible == false)
+  }
+}


### PR DESCRIPTION
## Changes

Implements GitHub issue #624 — give upgraded (paid-tier) iOS users an obvious path to enable push notifications. Two prongs only; nothing broader.

**Prong 1 — post-purchase prompt (coordinator).** `AppCoordinator.resolveSubscriptionTier()` now fires the system notification permission prompt when a purchase resolves to a paid tier (`tier > .free`) and status is `.notDetermined`. Fired into a stored `Task` (`pendingPostPurchasePermissionPrompt`) for test determinism; the `.notDetermined` gate self-limits it to one prompt. `.denied`/`.authorized` users are not re-prompted.

**Prong 2 — persistent home banner (Applications tab only).** New `PushNudgeBanner` above `ApplicationListView`, shown only when a paid user has not authorized notifications. Branches on status: "Turn on" requests the system prompt when `.notDetermined`; "Open Settings" reuses the existing `showSystemNotificationSettings()` deep link when `.denied`. Re-reads status on `scenePhase == .active` so it disappears once the user enables notifications and returns.

### Files
- NEW `PushNudgeViewModel.swift` — visibility (`tier > .free && status != .authorized`), status-branched `primaryAction`, load/refresh.
- NEW `PushNudgeBanner.swift` — amber-tinted banner using design-language tokens.
- NEW `AppCoordinator+PushNudge.swift` — `makePushNudgeViewModel()` factory; `onOpenSettings` → existing deep link.
- MODIFIED `AppCoordinator.swift` — Prong 1 prompt + `waitForPendingPostPurchasePrompt()` test seam.
- MODIFIED `TownCrierApp.swift` — banner above the Applications list (that tab only).
- NEW tests: `PushNudgeViewModelTests.swift` (visibility matrix + actions + scenePhase refresh), `AppCoordinatorPostPurchaseNotificationTests.swift` (post-purchase request matrix).

### Validation
- `swift build` ✓ · `swiftlint lint --strict` ✓ (0 violations / 379 files) · `swift test` ✓ (1294 tests / 162 suites)

### Out of scope (per issue)
No `SubscriptionViewModel`/StoreKit changes, no onboarding/`NotificationPermissionStepView` changes, no other-tab banners, no backend/`/v1/me/device-token` changes.

Closes #624

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a home-tab push permission nudge banner for eligible paid users.
  * The banner updates its message and button based on notification status, and can open iOS notification settings when permission is denied.
  * Notification prompts may now appear after subscription changes, and the banner refreshes when the app returns to the foreground.

* **Bug Fixes**
  * Prevented the banner from briefly flashing before notification status is loaded.
  * Ensured the banner and application list refresh together when subscription tier changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->