### PR TITLE
fix(ios): bump MARKETING_VERSION to 1.0.3 (reopen TestFlight train) (tc-eg3h)

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.0.2"
+        MARKETING_VERSION: "1.0.3"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"


### PR DESCRIPTION
## Changes

- **fix(ios): bump MARKETING_VERSION 1.0.2 → 1.0.3** — The v0.15.38 iOS TestFlight upload failed: the 1.0.2 App Store train is closed for new build submissions (altool 90186 / 90062). The CD beta lane bumps only the build number, never `MARKETING_VERSION`. Bumping to 1.0.3 opens a fresh train so the next tag re-release uploads cleanly.

No code or test changes — single version-string bump in `mobile/ios/project.yml` (the Info.plist is generated from it by xcodegen).

---
*Auto-shipped via ship skill*