### PR TITLE
fix(ios): raise large-radius warning threshold to 2.1km so free users never see it

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/LargeRadiusWarningView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/DesignSystem/Components/LargeRadiusWarningView.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 
 /// Threshold (in metres) at or above which `LargeRadiusWarningView` is shown.
-/// The bead (tc-1zb7) recommends "100–500 m in cities, under 2 km elsewhere",
-/// so any selection at or above 2 km warrants the heads-up.
+/// The bead (tc-1zb7) recommends "100–500 m in cities, under 2 km elsewhere".
+/// Set just above the free tier's 2 km radius cap (see ``WatchZoneLimits``) so a
+/// free user pinned at their maximum never trips the warning — only paid tiers,
+/// which can exceed 2 km, see it (tc-3ygm).
 public enum LargeRadiusWarning {
-  public static let thresholdMetres: Double = 2000
+  public static let thresholdMetres: Double = 2100
 }
 
 /// Callout warning that a watch zone with a large radius may generate a high

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Onboarding/OnboardingViewModel.swift
@@ -152,8 +152,8 @@ public final class OnboardingViewModel: ObservableObject, ErrorHandlingViewModel
   }
 
   /// Whether to surface the "this zone may produce lots of notifications" callout
-  /// (tc-1zb7). Triggered at or above 2 km, the upper edge of the recommended
-  /// "small zone" range — see `LargeRadiusWarningView`.
+  /// (tc-1zb7). Triggered just above the free tier's 2 km cap so only paid tiers
+  /// see it — see `LargeRadiusWarningView` for the threshold rationale.
   public var showsLargeRadiusWarning: Bool {
     selectedRadiusMetres >= LargeRadiusWarning.thresholdMetres
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/WatchZones/WatchZoneEditorViewModel.swift
@@ -107,8 +107,8 @@ public final class WatchZoneEditorViewModel: ObservableObject, EntitlementGating
   }
 
   /// Whether to surface the "this zone may produce lots of notifications" callout
-  /// (tc-1zb7). Triggered at or above 2 km, the upper edge of the recommended
-  /// "small zone" range — see `LargeRadiusWarningView`.
+  /// (tc-1zb7). Triggered just above the free tier's 2 km cap so only paid tiers
+  /// see it — see `LargeRadiusWarningView` for the threshold rationale.
   public var showsLargeRadiusWarning: Bool {
     selectedRadiusMetres >= LargeRadiusWarning.thresholdMetres
   }

--- a/mobile/ios/town-crier-tests/Sources/Features/LargeRadiusWarningTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/LargeRadiusWarningTests.swift
@@ -21,9 +21,18 @@ struct LargeRadiusWarningTests {
 
   @Test func warningIsShown_atThreshold_inEditor() {
     let vm = makeEditorViewModel()
-    vm.selectedRadiusMetres = 2000
+    vm.selectedRadiusMetres = 2100
 
     #expect(vm.showsLargeRadiusWarning == true)
+  }
+
+  @Test func warningIsHidden_atFreeTierMaxRadius_inEditor() {
+    // The free tier caps the radius at 2 km. The threshold sits just above that
+    // cap so a free user pinned at their maximum never sees the warning (tc-3ygm).
+    let vm = makeEditorViewModel(tier: .free)
+    vm.selectedRadiusMetres = 2000
+
+    #expect(vm.showsLargeRadiusWarning == false)
   }
 
   @Test func warningIsShown_aboveThreshold_inEditor() {
@@ -50,9 +59,18 @@ struct LargeRadiusWarningTests {
 
   @Test func warningIsShown_atThreshold_inOnboarding() {
     let vm = makeOnboardingViewModel()
-    vm.selectedRadiusMetres = 2000
+    vm.selectedRadiusMetres = 2100
 
     #expect(vm.showsLargeRadiusWarning == true)
+  }
+
+  @Test func warningIsHidden_atFreeTierMaxRadius_inOnboarding() {
+    // Onboarding defaults to the free tier, whose slider caps at 2 km — so a free
+    // user pinned at their maximum never sees the warning (tc-3ygm).
+    let vm = makeOnboardingViewModel()
+    vm.selectedRadiusMetres = 2000
+
+    #expect(vm.showsLargeRadiusWarning == false)
   }
 
   @Test func warningIsShown_atLargestOnboardingOption_inOnboarding() {

--- a/mobile/ios/town-crier-tests/Sources/Features/RadiusPickerStepViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/RadiusPickerStepViewTests.swift
@@ -39,7 +39,7 @@ struct RadiusPickerStepViewTests {
 
   @Test func body_renders_whenLargeRadiusWarningShown() {
     let vm = makeViewModel(tier: .pro)
-    vm.selectedRadiusMetres = 3000  // at/above the 2 km large-radius threshold
+    vm.selectedRadiusMetres = 3000  // above the 2.1 km large-radius threshold
     #expect(vm.showsLargeRadiusWarning)
 
     let sut = RadiusPickerStepView(viewModel: vm)


### PR DESCRIPTION
## Changes
- Raise `LargeRadiusWarning.thresholdMetres` from 2000m to 2100m so free-tier users (capped at a 2 km radius) never trip the "large zones get noisy" heads-up; paid tiers above 2.1 km still see it (tc-3ygm).
- Update threshold tests to the new 2100m boundary and add a free-tier-at-max case (editor + onboarding) that locks in the fix.
- Refresh now-stale "2 km" doc comments on the editor/onboarding view models and the radius-picker test.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the large-radius warning so it no longer appears at the free tier’s 2 km limit, while still showing for larger paid-tier zones.
  * Improved consistency across onboarding and zone editing so the warning matches the expected radius behavior.

* **Tests**
  * Updated and expanded coverage for free-tier and higher-radius warning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->