### PR TITLE
feat(ios): automatic engagement-score App Store review prompt (tc-iq7o)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/ReviewPrompt/UserDefaultsReviewPromptStore.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/ReviewPrompt/UserDefaultsReviewPromptStore.swift
@@ -1,0 +1,79 @@
+import Foundation
+import TownCrierDomain
+
+/// Persists ``ReviewPromptState`` to `UserDefaults` (GH #628).
+///
+/// Every field is device-local; nothing here is sent to a server or used for
+/// analytics. Dates are stored as `Double` Unix timestamps and the rolling
+/// prompt-timestamp list as a `[Double]` array. Mirrors
+/// ``UserDefaultsOnboardingRepository``.
+public final class UserDefaultsReviewPromptStore: ReviewPromptStore, @unchecked Sendable {
+  private enum Key {
+    static let firstLaunchDate = "reviewPrompt.firstLaunchDate"
+    static let engagementScore = "reviewPrompt.engagementScore"
+    static let saveCount = "reviewPrompt.saveCount"
+    static let lastActiveDayKey = "reviewPrompt.lastActiveDayKey"
+    static let distinctActiveDays = "reviewPrompt.distinctActiveDays"
+    static let lastPromptDate = "reviewPrompt.lastPromptDate"
+    static let promptTimestamps = "reviewPrompt.promptTimestamps"
+    static let hasRecordedUpgrade = "reviewPrompt.hasRecordedUpgrade"
+  }
+
+  private let defaults: UserDefaults
+
+  public init(defaults: UserDefaults = .standard) {
+    self.defaults = defaults
+  }
+
+  public func load() -> ReviewPromptState {
+    ReviewPromptState(
+      firstLaunchDate: date(forKey: Key.firstLaunchDate),
+      engagementScore: defaults.integer(forKey: Key.engagementScore),
+      saveCount: defaults.integer(forKey: Key.saveCount),
+      lastActiveDayKey: defaults.string(forKey: Key.lastActiveDayKey),
+      distinctActiveDays: defaults.integer(forKey: Key.distinctActiveDays),
+      lastPromptDate: date(forKey: Key.lastPromptDate),
+      promptTimestamps: timestamps(forKey: Key.promptTimestamps),
+      hasRecordedUpgrade: defaults.bool(forKey: Key.hasRecordedUpgrade)
+    )
+  }
+
+  public func save(_ state: ReviewPromptState) {
+    setDate(state.firstLaunchDate, forKey: Key.firstLaunchDate)
+    defaults.set(state.engagementScore, forKey: Key.engagementScore)
+    defaults.set(state.saveCount, forKey: Key.saveCount)
+    setOptionalString(state.lastActiveDayKey, forKey: Key.lastActiveDayKey)
+    defaults.set(state.distinctActiveDays, forKey: Key.distinctActiveDays)
+    setDate(state.lastPromptDate, forKey: Key.lastPromptDate)
+    defaults.set(state.promptTimestamps.map(\.timeIntervalSince1970), forKey: Key.promptTimestamps)
+    defaults.set(state.hasRecordedUpgrade, forKey: Key.hasRecordedUpgrade)
+  }
+
+  // MARK: - Helpers
+
+  private func date(forKey key: String) -> Date? {
+    guard let seconds = defaults.object(forKey: key) as? Double else { return nil }
+    return Date(timeIntervalSince1970: seconds)
+  }
+
+  private func setDate(_ date: Date?, forKey key: String) {
+    if let date {
+      defaults.set(date.timeIntervalSince1970, forKey: key)
+    } else {
+      defaults.removeObject(forKey: key)
+    }
+  }
+
+  private func setOptionalString(_ value: String?, forKey key: String) {
+    if let value {
+      defaults.set(value, forKey: key)
+    } else {
+      defaults.removeObject(forKey: key)
+    }
+  }
+
+  private func timestamps(forKey key: String) -> [Date] {
+    let seconds = defaults.array(forKey: key) as? [Double] ?? []
+    return seconds.map { Date(timeIntervalSince1970: $0) }
+  }
+}

--- a/mobile/ios/packages/town-crier-domain/Sources/ReviewPrompt/ReviewPromptPolicy.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ReviewPrompt/ReviewPromptPolicy.swift
@@ -1,0 +1,173 @@
+import Foundation
+
+/// The outcome of a single review-prompt evaluation: whether to ask, plus the
+/// state to persist afterwards.
+public enum ReviewPromptDecision: Equatable, Sendable {
+  /// Present Apple's native review dialog now.
+  case fire
+  /// Do not present the dialog.
+  case hold
+}
+
+/// The result of ``ReviewPromptPolicy/evaluate(signal:state:sessionSuppressed:isReactivation:)``:
+/// the decision and the updated state the caller should persist.
+public struct ReviewPromptOutcome: Equatable, Sendable {
+  public let decision: ReviewPromptDecision
+  public let state: ReviewPromptState
+
+  public init(decision: ReviewPromptDecision, state: ReviewPromptState) {
+    self.decision = decision
+    self.state = state
+  }
+}
+
+/// Pure, deterministic decision engine for the App Store review prompt (GH #628).
+///
+/// Given an incoming ``ReviewSignal``, the persisted ``ReviewPromptState``, a
+/// transient session-suppression flag, and whether the current app foreground is
+/// a background→active re-entry, it applies the signal's weight, enforces every
+/// guard, and returns a ``ReviewPromptOutcome``. It performs no I/O and never
+/// touches StoreKit, so it can be exhaustively unit-tested.
+///
+/// The scarce resource is Apple's ~3-prompts-per-year quota, so the policy only
+/// fires at a genuine engagement peak (the score has reached the threshold *at*
+/// a fire-eligible signal) and never after friction.
+public struct ReviewPromptPolicy: Sendable {
+  // MARK: - Tunable constants (the `upgradeWeight < engagementThreshold`
+  // invariant must be preserved).
+
+  /// The score at or above which a fire-eligible signal may fire.
+  public static let engagementThreshold = 6
+  public static let portalWeight = 3
+  public static let savedApplicationWeight = 2
+  public static let openedAlertWeight = 2
+  public static let activeDayWeight = 1
+  public static let upgradeWeight = 2
+
+  /// Minimum account age before the first prompt (7 days).
+  public static let minimumAccountAge: TimeInterval = 7 * 86_400
+  /// Minimum gap between two prompts (120 days).
+  public static let promptCooldown: TimeInterval = 120 * 86_400
+  /// Rolling window for the belt-and-braces annual cap (365 days).
+  public static let annualCapWindow: TimeInterval = 365 * 86_400
+  /// Maximum prompt attempts allowed within ``annualCapWindow``.
+  public static let annualCapLimit = 3
+  /// Distinct active days required before a loyalty day becomes fire-eligible.
+  public static let loyaltyDistinctDayThreshold = 3
+
+  private let now: @Sendable () -> Date
+  private let calendar: Calendar
+
+  public init(now: @escaping @Sendable () -> Date = Date.init, calendar: Calendar = .current) {
+    self.now = now
+    self.calendar = calendar
+  }
+
+  /// Applies `signal` to `state`, enforces the guards, and returns the decision
+  /// plus the state to persist. The signal's weight is always applied (so score
+  /// accrues even when a guard holds the prompt); the score is reset only on a
+  /// successful fire.
+  public func evaluate(
+    signal: ReviewSignal,
+    state: ReviewPromptState,
+    sessionSuppressed: Bool,
+    isReactivation: Bool
+  ) -> ReviewPromptOutcome {
+    var newState = state
+    let fireEligible = apply(signal, to: &newState, isReactivation: isReactivation)
+
+    guard fireEligible, passesGuards(newState, sessionSuppressed: sessionSuppressed) else {
+      return ReviewPromptOutcome(decision: .hold, state: newState)
+    }
+
+    let firedAt = now()
+    newState.engagementScore = 0
+    newState.lastPromptDate = firedAt
+    newState.promptTimestamps.append(firedAt)
+    return ReviewPromptOutcome(decision: .fire, state: newState)
+  }
+
+  // MARK: - Scoring
+
+  /// Mutates `state` for the signal and returns whether the signal is a
+  /// fire-eligible peak (a candidate for the guard checks).
+  private func apply(
+    _ signal: ReviewSignal,
+    to state: inout ReviewPromptState,
+    isReactivation: Bool
+  ) -> Bool {
+    switch signal {
+    case .tappedPortal:
+      state.engagementScore += Self.portalWeight
+      return true
+
+    case .openedAlert:
+      state.engagementScore += Self.openedAlertWeight
+      return true
+
+    case .savedApplication:
+      state.saveCount += 1
+      // The first save is not counted; only the 2nd and later saves contribute.
+      guard state.saveCount >= 2 else { return false }
+      state.engagementScore += Self.savedApplicationWeight
+      return true
+
+    case .activeDay:
+      let key = dayKey(for: now())
+      // Never double-count the same calendar day.
+      guard key != state.lastActiveDayKey else { return false }
+      state.lastActiveDayKey = key
+      state.distinctActiveDays += 1
+      state.engagementScore += Self.activeDayWeight
+      // Loyalty only becomes a fire moment once enough distinct days have
+      // accrued, and only on a background→active re-entry (never a cold launch).
+      return isReactivation && state.distinctActiveDays >= Self.loyaltyDistinctDayThreshold
+
+    case .upgraded:
+      // Latched: contributes at most once across the app's lifetime, and is
+      // never itself a fire moment.
+      if !state.hasRecordedUpgrade {
+        state.engagementScore += Self.upgradeWeight
+        state.hasRecordedUpgrade = true
+      }
+      return false
+    }
+  }
+
+  // MARK: - Guards
+
+  private func passesGuards(_ state: ReviewPromptState, sessionSuppressed: Bool) -> Bool {
+    guard !sessionSuppressed else { return false }
+    guard state.engagementScore >= Self.engagementThreshold else { return false }
+
+    let current = now()
+
+    // Account age.
+    guard let firstLaunch = state.firstLaunchDate,
+      current.timeIntervalSince(firstLaunch) >= Self.minimumAccountAge
+    else { return false }
+
+    // Cooldown. A backward clock (current < lastPromptDate) yields a negative
+    // elapsed interval, which is < the cooldown, so it correctly holds.
+    if let lastPrompt = state.lastPromptDate {
+      guard current.timeIntervalSince(lastPrompt) >= Self.promptCooldown else { return false }
+    }
+
+    // Belt-and-braces annual cap.
+    let windowStart = current.addingTimeInterval(-Self.annualCapWindow)
+    let recentPrompts = state.promptTimestamps.filter { $0 >= windowStart }
+    guard recentPrompts.count < Self.annualCapLimit else { return false }
+
+    return true
+  }
+
+  // MARK: - Day key
+
+  /// Derives a calendar-day key (`yyyy-M-d`) in the policy's calendar so distinct
+  /// days are counted on day boundaries, never on time deltas — robust to
+  /// timezone and backward-clock changes.
+  private func dayKey(for date: Date) -> String {
+    let components = calendar.dateComponents([.year, .month, .day], from: date)
+    return "\(components.year ?? 0)-\(components.month ?? 0)-\(components.day ?? 0)"
+  }
+}

--- a/mobile/ios/packages/town-crier-domain/Sources/ReviewPrompt/ReviewPromptStore.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ReviewPrompt/ReviewPromptStore.swift
@@ -1,0 +1,13 @@
+/// Persists the local ``ReviewPromptState`` for the App Store review-prompt
+/// feature (GH #628).
+///
+/// The contract is a whole-state load/save: the store reconstructs the full
+/// value on ``load()`` and writes it back on ``save(_:)``. All storage is
+/// device-local — there is no server, network, or PII involved. Mirrors the
+/// ``OnboardingRepository`` persistence shape.
+public protocol ReviewPromptStore: Sendable {
+  /// Returns the persisted state, or a default-initialised state on first run.
+  func load() -> ReviewPromptState
+  /// Persists the supplied state.
+  func save(_ state: ReviewPromptState)
+}

--- a/mobile/ios/packages/town-crier-domain/Sources/ReviewPrompt/ReviewSignal.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ReviewPrompt/ReviewSignal.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// A positive in-app engagement signal that feeds the App Store review-prompt
+/// policy (GH #628).
+///
+/// Signals are deliberately scoped to *value* moments inside the app — a review
+/// ask is never delivered by push. Most signals can trigger a fire evaluation;
+/// ``upgraded`` is a pure score contributor that nudges a borderline user toward
+/// a prompt but can never, on its own, be the moment that triggers the ask.
+public enum ReviewSignal: Equatable, Sendable {
+  /// The user tapped through to the council planning portal.
+  case tappedPortal
+  /// The user saved/bookmarked an application. Only the 2nd and later saves are
+  /// fire-eligible; the first save is usually setup rather than delight.
+  case savedApplication
+  /// The user opened an instant alert via its push/deep-link detail path. This
+  /// is the alert-payoff moment and is distinct from browsing the list.
+  case openedAlert
+  /// The app was foregrounded on a new distinct calendar day (loyalty).
+  case activeDay
+  /// The user upgraded to a paid tier. Contributes score but is never a fire
+  /// moment and is latched so it counts at most once.
+  case upgraded
+
+  /// Whether this signal can ever be the moment that triggers a review ask.
+  ///
+  /// ``upgraded`` is excluded outright; the remaining signals are *candidate*
+  /// fire moments whose final eligibility is further qualified by the policy
+  /// (e.g. a save is only eligible on the 2nd+ occurrence, a loyalty day only
+  /// once enough distinct days have accrued and only on a re-entry).
+  public var canTriggerFire: Bool {
+    switch self {
+    case .upgraded:
+      return false
+    case .tappedPortal, .savedApplication, .openedAlert, .activeDay:
+      return true
+    }
+  }
+}
+
+/// The locally-persisted state the review-prompt policy reads and updates.
+///
+/// Every field is device-local: there is no server telemetry, analytics, or PII
+/// involved in deciding when to ask for a rating.
+public struct ReviewPromptState: Equatable, Sendable {
+  /// When this device first ran the app with the review feature — the anchor for
+  /// the account-age guard. `nil` until the tracker establishes it on first run.
+  public var firstLaunchDate: Date?
+  /// The accumulated engagement score, reset to 0 after a fire.
+  public var engagementScore: Int
+  /// How many applications the user has saved (gates the first-save exclusion).
+  public var saveCount: Int
+  /// The `yyyy-M-d` key of the most recent active day, so the same calendar day
+  /// is never double-counted.
+  public var lastActiveDayKey: String?
+  /// The number of distinct calendar days the app has been foregrounded on.
+  public var distinctActiveDays: Int
+  /// When the last review prompt was attempted, anchoring the cooldown guard.
+  public var lastPromptDate: Date?
+  /// Timestamps of past prompt attempts, used for the rolling annual cap.
+  public var promptTimestamps: [Date]
+  /// Whether the upgrade score contribution has already been latched.
+  public var hasRecordedUpgrade: Bool
+
+  public init(
+    firstLaunchDate: Date? = nil,
+    engagementScore: Int = 0,
+    saveCount: Int = 0,
+    lastActiveDayKey: String? = nil,
+    distinctActiveDays: Int = 0,
+    lastPromptDate: Date? = nil,
+    promptTimestamps: [Date] = [],
+    hasRecordedUpgrade: Bool = false
+  ) {
+    self.firstLaunchDate = firstLaunchDate
+    self.engagementScore = engagementScore
+    self.saveCount = saveCount
+    self.lastActiveDayKey = lastActiveDayKey
+    self.distinctActiveDays = distinctActiveDays
+    self.lastPromptDate = lastPromptDate
+    self.promptTimestamps = promptTimestamps
+    self.hasRecordedUpgrade = hasRecordedUpgrade
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+DeepLink.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+DeepLink.swift
@@ -15,6 +15,10 @@ extension AppCoordinator {
       // the app on the previous tab and the sheet would never present
       // (tc-dt3x).
       selectedTab = .applications
+      // Opening an application from a push/deep link is the instant-alert payoff
+      // moment — a fire-eligible review signal (GH #628). This is deliberately
+      // distinct from browsing the in-app list.
+      reviewPromptTracker?.record(.openedAlert)
       showApplicationDetail(id)
     case .applicationsList:
       selectedTab = .applications

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Onboarding.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Onboarding.swift
@@ -73,6 +73,10 @@ extension AppCoordinator {
     do {
       let zones = try await watchZoneRepository.loadAll()
       onboardingPresentation = zones.isEmpty ? .required : .notRequired
+      // Never ask for a review during a first-run onboarding session (GH #628).
+      if zones.isEmpty {
+        reviewPromptTracker?.suppressThisSession()
+      }
     } catch {
       onboardingPresentation = .notRequired
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+ReviewPrompt.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+ReviewPrompt.swift
@@ -1,0 +1,10 @@
+import TownCrierDomain
+
+extension AppCoordinator {
+  /// Records that the app was foregrounded, feeding the review-prompt loyalty
+  /// signal (GH #628). `isReactivation` is `true` only for a background→active
+  /// re-entry, never the cold-launch render.
+  public func recordAppForegrounded(isReactivation: Bool) {
+    reviewPromptTracker?.recordAppForegrounded(isReactivation: isReactivation)
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+WatchZones.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+WatchZones.swift
@@ -52,6 +52,9 @@ extension AppCoordinator {
       self?.isAddingWatchZone = false
       self?.editingWatchZone = nil
       self?.isSubscriptionPresented = true
+      // Hitting a quota wall is a friction moment — never ask for a review in
+      // the same session (GH #628).
+      self?.reviewPromptTracker?.suppressThisSession()
     }
     viewModel.onSave = { [weak self] saved in
       self?.isAddingWatchZone = false

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -296,10 +296,8 @@ public final class AppCoordinator: ObservableObject {
     subscriptionTier = result.tier
     tierCache.set(result.tier.rawValue, forKey: Self.tierCacheKey)
 
-    // Review-prompt upgrade signal (GH #628): record a free→paid transition so
-    // upgrading nudges a borderline user toward a prompt. The tracker latches
-    // it, and the weight sits strictly below the threshold, so the act of
-    // paying can never on its own trigger the ask.
+    // Review-prompt upgrade signal (GH #628): a latched free→paid nudge weighted
+    // below the threshold, so paying alone can never trigger the ask.
     if previousTier == .free, result.tier > .free {
       reviewPromptTracker?.record(.upgraded)
     }
@@ -318,20 +316,12 @@ public final class AppCoordinator: ObservableObject {
     // Fired into a stored `Task` so tests can await it deterministically.
     if result.tier > .free,
       await notificationService.authorizationStatus() == .notDetermined {
-      // The review prompt must never stack with the post-purchase push prompt
-      // nor appear right after a purchase (value isn't delivered yet) — suppress
-      // it for the rest of this session (GH #628).
+      // Never stack the review prompt on the post-purchase push prompt (GH #628).
       reviewPromptTracker?.suppressThisSession()
       pendingPostPurchasePermissionPrompt = Task { [weak self] in
         _ = try? await self?.notificationService.requestPermission()
       }
     }
-  }
-
-  /// Records that the app was foregrounded, feeding the review-prompt loyalty
-  /// signal. `isReactivation` is `true` only for a background→active re-entry.
-  public func recordAppForegrounded(isReactivation: Bool) {
-    reviewPromptTracker?.recordAppForegrounded(isReactivation: isReactivation)
   }
 
   /// Test-only synchronisation: await the most recent post-purchase

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -65,6 +65,9 @@ public final class AppCoordinator: ObservableObject {
   private let tierCache: UserDefaults
   let notificationStateRepository: NotificationStateRepository?
   let badgeSetter: BadgeSetting?
+  // Drives the App Store review prompt at engagement peaks (GH #628). Optional
+  // so existing call sites and tests that don't exercise it inject nothing.
+  let reviewPromptTracker: ReviewPromptTracker?
   // Cached strongly so SwiftUI's factory re-evaluation doesn't leave the
   // coordinator with a dangling reference; editor `onSave` needs a live VM.
   // Internal (not private) so the AppCoordinator+WatchZones extension owns it.
@@ -106,7 +109,8 @@ public final class AppCoordinator: ObservableObject {
     offerCodeService: OfferCodeService? = nil,
     tierCache: UserDefaults? = nil,
     notificationStateRepository: NotificationStateRepository? = nil,
-    badgeSetter: BadgeSetting? = nil
+    badgeSetter: BadgeSetting? = nil,
+    reviewPromptTracker: ReviewPromptTracker? = nil
   ) {
     self.repository = repository
     self.authService = authService
@@ -133,6 +137,7 @@ public final class AppCoordinator: ObservableObject {
     self.tierCache = tierCache ?? .standard
     self.notificationStateRepository = notificationStateRepository
     self.badgeSetter = badgeSetter
+    self.reviewPromptTracker = reviewPromptTracker
 
     // Restore the last successfully resolved tier so that paying users
     // retain feature access immediately, even before the live resolution
@@ -263,6 +268,15 @@ public final class AppCoordinator: ObservableObject {
     viewModel.onDismiss = { [weak self] in
       self?.detailApplication = nil
     }
+    // Review-prompt value moments (GH #628): a portal tap-through and a save are
+    // both genuine engagement peaks. The save callback fires only on a
+    // successful false→true save (the view model guarantees this).
+    viewModel.onOpenPortal = { [weak self] _ in
+      self?.reviewPromptTracker?.record(.tappedPortal)
+    }
+    viewModel.onSaved = { [weak self] in
+      self?.reviewPromptTracker?.record(.savedApplication)
+    }
     return viewModel
   }
 
@@ -273,6 +287,7 @@ public final class AppCoordinator: ObservableObject {
   /// (third recurrence after tc-aza5; original bug tc-exg6).
   public func resolveSubscriptionTier() async {
     let session = await authService.currentSession()
+    let previousTier = subscriptionTier
     let result = await tierResolver.resolve(
       jwtTier: session?.subscriptionTier ?? .free,
       previousTier: subscriptionTier,
@@ -280,6 +295,14 @@ public final class AppCoordinator: ObservableObject {
     )
     subscriptionTier = result.tier
     tierCache.set(result.tier.rawValue, forKey: Self.tierCacheKey)
+
+    // Review-prompt upgrade signal (GH #628): record a free→paid transition so
+    // upgrading nudges a borderline user toward a prompt. The tracker latches
+    // it, and the weight sits strictly below the threshold, so the act of
+    // paying can never on its own trigger the ask.
+    if previousTier == .free, result.tier > .free {
+      reviewPromptTracker?.record(.upgraded)
+    }
     // Keep an in-flight onboarding wizard's tier live so the radius step can
     // unlock the paid range the moment a purchase resolves, without rebuilding
     // the wizard and losing the user's in-progress postcode (tc-w3cb.1/.3).
@@ -295,10 +318,20 @@ public final class AppCoordinator: ObservableObject {
     // Fired into a stored `Task` so tests can await it deterministically.
     if result.tier > .free,
       await notificationService.authorizationStatus() == .notDetermined {
+      // The review prompt must never stack with the post-purchase push prompt
+      // nor appear right after a purchase (value isn't delivered yet) — suppress
+      // it for the rest of this session (GH #628).
+      reviewPromptTracker?.suppressThisSession()
       pendingPostPurchasePermissionPrompt = Task { [weak self] in
         _ = try? await self?.notificationService.requestPermission()
       }
     }
+  }
+
+  /// Records that the app was foregrounded, feeding the review-prompt loyalty
+  /// signal. `isReactivation` is `true` only for a background→active re-entry.
+  public func recordAppForegrounded(isReactivation: Bool) {
+    reviewPromptTracker?.recordAppForegrounded(isReactivation: isReactivation)
   }
 
   /// Test-only synchronisation: await the most recent post-purchase

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -18,6 +18,11 @@ public final class AppCoordinator: ObservableObject {
   @Published public var isOpeningSystemNotificationSettings = false
   /// In-app preferences: `true` pushes `NotificationPreferencesView` via `.navigationDestination`.
   @Published public var isNotificationPreferencesPresented = false
+  /// Set to `true` by the review-prompt requester at an engagement peak; the app
+  /// layer observes it, calls SwiftUI's `requestReview`, then resets it
+  /// (mirroring ``isOpeningSystemNotificationSettings``). The OS call is never
+  /// guaranteed to show — Apple caps and may silently suppress it (GH #628).
+  @Published public var isRequestingReview = false
   /// Selected main tab; bound to the root `TabView` for coordinator-driven tab switches.
   @Published public var selectedTab: MainTab = .applications
   @Published public var isAddingWatchZone = false

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/ReviewPromptTracker.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/ReviewPromptTracker.swift
@@ -1,0 +1,95 @@
+import Foundation
+import TownCrierDomain
+
+/// Performs the real App Store review request. Abstracted behind a protocol so
+/// the decision flow stays unit-testable (the OS call sits at the app-layer
+/// edge — see ``CoordinatorReviewRequester``).
+@MainActor
+public protocol ReviewRequesting {
+  func requestReview()
+}
+
+/// Production ``ReviewRequesting`` that flips ``AppCoordinator/isRequestingReview``.
+///
+/// An app-layer `.onChange(of:)` observes that flag, performs the real
+/// `requestReview` via the SwiftUI environment, then resets it — mirroring the
+/// established `isOpeningSystemNotificationSettings` → `openURL` pattern. The
+/// coordinator reference is weak to avoid a retain cycle (the coordinator owns
+/// the tracker, which owns this requester).
+@MainActor
+public final class CoordinatorReviewRequester: ReviewRequesting {
+  public weak var coordinator: AppCoordinator?
+
+  public init(coordinator: AppCoordinator? = nil) {
+    self.coordinator = coordinator
+  }
+
+  public func requestReview() {
+    coordinator?.isRequestingReview = true
+  }
+}
+
+/// The @MainActor service the app talks to for the App Store review prompt
+/// (GH #628).
+///
+/// It owns the only mutable session flag (``suppressThisSession()``), reads and
+/// writes the persisted state via the injected ``ReviewPromptStore``, runs the
+/// pure ``ReviewPromptPolicy`` on each signal, and — on a `.fire` decision —
+/// asks the injected ``ReviewRequesting`` to present the dialog. Being
+/// `@MainActor`, back-to-back signals are serialized, so each is evaluated once.
+@MainActor
+public final class ReviewPromptTracker {
+  private let store: ReviewPromptStore
+  private let policy: ReviewPromptPolicy
+  private let requester: any ReviewRequesting
+  private let now: @Sendable () -> Date
+  private var isSessionSuppressed = false
+
+  public init(
+    store: ReviewPromptStore,
+    requester: any ReviewRequesting,
+    now: @escaping @Sendable () -> Date = Date.init,
+    policy: ReviewPromptPolicy? = nil
+  ) {
+    self.store = store
+    self.requester = requester
+    self.now = now
+    self.policy = policy ?? ReviewPromptPolicy(now: now)
+    establishFirstLaunchDateIfNeeded()
+  }
+
+  /// Suppresses any review prompt for the rest of this session. Called during
+  /// onboarding, when the post-purchase push prompt fires, and on friction.
+  public func suppressThisSession() {
+    isSessionSuppressed = true
+  }
+
+  /// Records an engagement signal: updates the persisted state via the policy
+  /// and, on a `.fire`, requests the native review dialog.
+  public func record(_ signal: ReviewSignal, isReactivation: Bool = false) {
+    let outcome = policy.evaluate(
+      signal: signal,
+      state: store.load(),
+      sessionSuppressed: isSessionSuppressed,
+      isReactivation: isReactivation
+    )
+    store.save(outcome.state)
+    if outcome.decision == .fire {
+      requester.requestReview()
+    }
+  }
+
+  /// Records a loyalty active-day signal on app foreground. `isReactivation` is
+  /// `true` only for a background→active re-entry (never the cold-launch render).
+  public func recordAppForegrounded(isReactivation: Bool) {
+    record(.activeDay, isReactivation: isReactivation)
+  }
+
+  /// Anchors the account-age guard the first time the tracker runs on a device.
+  private func establishFirstLaunchDateIfNeeded() {
+    var state = store.load()
+    guard state.firstLaunchDate == nil else { return }
+    state.firstLaunchDate = now()
+    store.save(state)
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
@@ -114,6 +114,9 @@ public struct ApplicationDetailView: View {
 
   private var portalButton: some View {
     PrimaryButton {
+      // Notify the view model so the coordinator can record the portal-tap
+      // review signal (GH #628); the in-app Safari sheet still presents below.
+      viewModel.openPortal()
       showingSafari = true
     } label: {
       HStack {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
@@ -61,6 +61,9 @@ public final class ApplicationDetailViewModel: ObservableObject {
 
   public var onOpenPortal: ((URL) -> Void)?
   public var onDismiss: (() -> Void)?
+  /// Fired only on a successful false→true save (never on unsave or failure).
+  /// Drives the review-prompt `savedApplication` signal (GH #628).
+  public var onSaved: (() -> Void)?
 
   /// Whether the save/unsave action is available (repository was provided).
   public var canSave: Bool {
@@ -171,6 +174,7 @@ public final class ApplicationDetailViewModel: ObservableObject {
       do {
         try await repository.save(application: application)
         isSaved = true
+        onSaved?()
       } catch {
         // Preserve current state on failure
       }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Subscription/SubscriptionViewModel.swift
@@ -21,6 +21,10 @@ public final class SubscriptionViewModel: ObservableObject, ErrorHandlingViewMod
   /// routing through the root coordinator (which already owns the paywall sheet).
   @Published public var presentedLegalDocument: LegalDocumentType?
 
+  /// Fired when a purchase fails (not when cancelled or successful). A failed
+  /// purchase is a friction moment that suppresses the review prompt (GH #628).
+  public var onPurchaseFailed: (() -> Void)?
+
   private let subscriptionService: SubscriptionService
   private let authenticationService: AuthenticationService
 
@@ -63,6 +67,7 @@ public final class SubscriptionViewModel: ObservableObject, ErrorHandlingViewMod
       // User cancelled — not an error
     } catch {
       handleError(error) { .purchaseFailed($0) }
+      onPurchaseFailed?()
     }
     isPurchasing = false
   }

--- a/mobile/ios/town-crier-app/Sources/ReviewPromptRequestModifier.swift
+++ b/mobile/ios/town-crier-app/Sources/ReviewPromptRequestModifier.swift
@@ -1,0 +1,32 @@
+import StoreKit
+import SwiftUI
+import TownCrierPresentation
+
+extension View {
+  /// Performs the real `requestReview` OS call when the coordinator flags an
+  /// engagement peak, then resets the flag (GH #628).
+  ///
+  /// This is the app-layer edge for the review prompt: the decision logic lives
+  /// in the testable `ReviewPromptTracker`/`ReviewPromptPolicy`, and only the
+  /// un-testable StoreKit call sits here — mirroring the established
+  /// `isOpeningSystemNotificationSettings` → `openURL` pattern.
+  func requestingReview(when coordinator: AppCoordinator) -> some View {
+    modifier(ReviewPromptRequestModifier(coordinator: coordinator))
+  }
+}
+
+/// Bridges ``AppCoordinator/isRequestingReview`` to SwiftUI's environment
+/// `requestReview` action. Apple caps prompts (~3/year) and may show nothing;
+/// we cannot detect display, so the flag is simply reset after the attempt.
+private struct ReviewPromptRequestModifier: ViewModifier {
+  @Environment(\.requestReview) private var requestReview
+  @ObservedObject var coordinator: AppCoordinator
+
+  func body(content: Content) -> some View {
+    content.onChange(of: coordinator.isRequestingReview) { _, requested in
+      guard requested else { return }
+      requestReview()
+      coordinator.isRequestingReview = false
+    }
+  }
+}

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -61,6 +61,12 @@ struct TownCrierApp: App {
     // Injecting the service unhides the "Redeem Offer Code" row in Settings.
     let offerCodeService = HttpOfferCodeService(apiClient: apiClient)
 
+    // App Store review prompt (GH #628): device-local gating only, no server/PII.
+    let reviewRequester = CoordinatorReviewRequester()
+    let reviewPromptTracker = ReviewPromptTracker(
+      store: UserDefaultsReviewPromptStore(),
+      requester: reviewRequester
+    )
     let appCoordinator = AppCoordinator(
       repository: repository,
       authService: authService,
@@ -77,8 +83,10 @@ struct TownCrierApp: App {
       savedApplicationRepository: savedApplicationRepository,
       offerCodeService: offerCodeService,
       notificationStateRepository: notificationStateRepository,
-      badgeSetter: UIApplicationBadgeSetter()
+      badgeSetter: UIApplicationBadgeSetter(),
+      reviewPromptTracker: reviewPromptTracker
     )
+    reviewRequester.coordinator = appCoordinator  // weak; coordinator owns the tracker
     _coordinator = StateObject(wrappedValue: appCoordinator)
 
     let registrar = PushNotificationRegistrar(
@@ -161,16 +169,17 @@ struct TownCrierApp: App {
         }
         await forceUpdateViewModel.checkVersion()
       }
-      .onChange(of: scenePhase) { _, newPhase in
-        // Reconcile the app icon badge with the server-side unread watermark
-        // whenever the scene becomes active — both on first launch and on
-        // every foreground entry. We deliberately pull rather than rely on
-        // silent push so cross-device read-state changes propagate without
-        // server-side push fan-out (spec
-        // docs/specs/notifications-unread-watermark.md#ios-badge-foreground-push).
+      .onChange(of: scenePhase) { oldPhase, newPhase in
+        // Reconcile the app icon badge with the server-side unread watermark on
+        // every foreground entry — we pull rather than rely on silent push so
+        // cross-device read-state changes propagate without server-side fan-out
+        // (docs/specs/notifications-unread-watermark.md#ios-badge-foreground-push).
         guard newPhase == .active else { return }
+        // Loyalty review signal: only a background→active re-entry counts (#628).
+        coordinator.recordAppForegrounded(isReactivation: oldPhase == .background)
         Task { await coordinator.syncBadge() }
       }
+      .requestingReview(when: coordinator)
       .preferredColorScheme(settingsViewModel.appearanceMode.preferredColorScheme)
       .alert(
         coordinator.deepLinkError?.userTitle ?? "Error",

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorReviewPromptTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorReviewPromptTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Integration tests for how ``AppCoordinator`` and its extensions feed the
+/// review-prompt tracker (GH #628): the upgrade signal is latched to a free→paid
+/// transition, friction/onboarding/post-purchase moments suppress the session,
+/// and the value moments (deep-link alert open, portal tap, save) record their
+/// signals.
+@Suite("AppCoordinator — review prompt wiring")
+@MainActor
+struct AppCoordinatorReviewPromptTests {
+  private let reference = Date(timeIntervalSince1970: 1_700_000_000)
+  private let day: TimeInterval = 86_400
+
+  private func eligibleState(
+    engagementScore: Int = 0,
+    saveCount: Int = 0
+  ) -> ReviewPromptState {
+    ReviewPromptState(
+      firstLaunchDate: reference.addingTimeInterval(-30 * day),
+      engagementScore: engagementScore,
+      saveCount: saveCount
+    )
+  }
+
+  private func makeSUT(
+    storeState: ReviewPromptState,
+    resolvedTier: SubscriptionTier = .personal,
+    authorizationStatus: NotificationAuthorizationStatus = .authorized,
+    savedApplicationRepository: SavedApplicationRepository? = nil,
+    watchZones: [WatchZone] = []
+  ) -> (AppCoordinator, FakeReviewPromptStore, SpyReviewRequester) {
+    let store = FakeReviewPromptStore(state: storeState)
+    let requester = SpyReviewRequester()
+    let now = reference
+    let tracker = ReviewPromptTracker(store: store, requester: requester) { now }
+
+    let notificationSpy = SpyNotificationService()
+    notificationSpy.nextAuthorizationStatus = authorizationStatus
+    let tierResolver = FakeSubscriptionTierResolver()
+    tierResolver.resolveResult = (resolvedTier, false)
+    let watchZoneRepository = SpyWatchZoneRepository()
+    watchZoneRepository.loadAllResult = .success(watchZones)
+
+    let coordinator = AppCoordinator(
+      repository: SpyPlanningApplicationRepository(),
+      authService: SpyAuthenticationService(),
+      subscriptionService: SpySubscriptionService(),
+      userProfileRepository: SpyUserProfileRepository(),
+      tierResolver: tierResolver,
+      watchZoneRepository: watchZoneRepository,
+      geocoder: SpyPostcodeGeocoder(),
+      onboardingRepository: SpyOnboardingRepository(),
+      notificationService: notificationSpy,
+      appVersionProvider: SpyAppVersionProvider(),
+      versionConfigService: SpyVersionConfigService(),
+      savedApplicationRepository: savedApplicationRepository,
+      tierCache: UserDefaults(suiteName: UUID().uuidString) ?? .standard,
+      reviewPromptTracker: tracker
+    )
+    return (coordinator, store, requester)
+  }
+
+  // MARK: - Upgrade
+
+  @Test("a free→paid transition records the upgrade once and never fires")
+  func upgradeRecordedOnceOnTransition() async {
+    let (sut, store, requester) = makeSUT(storeState: eligibleState(engagementScore: 0))
+
+    await sut.resolveSubscriptionTier()
+    #expect(store.load().engagementScore == 2)
+    #expect(store.load().hasRecordedUpgrade)
+
+    // A second resolve (now paid→paid) must not re-record the upgrade.
+    await sut.resolveSubscriptionTier()
+    #expect(store.load().engagementScore == 2)
+    #expect(requester.requestReviewCallCount == 0)
+  }
+
+  // MARK: - Suppression
+
+  @Test("the post-purchase push prompt suppresses the review session")
+  func postPurchasePushPromptSuppresses() async {
+    let (sut, _, requester) = makeSUT(
+      storeState: eligibleState(engagementScore: 4),
+      authorizationStatus: .notDetermined
+    )
+
+    await sut.resolveSubscriptionTier()
+    await sut.waitForPendingPostPurchasePrompt()
+    sut.reviewPromptTracker?.record(.openedAlert)  // would reach the threshold
+
+    #expect(requester.requestReviewCallCount == 0)
+  }
+
+  @Test("without the post-purchase prompt a value moment can still fire")
+  func noPushPromptAllowsFire() async {
+    let (sut, _, requester) = makeSUT(
+      storeState: eligibleState(engagementScore: 4),
+      authorizationStatus: .authorized
+    )
+
+    await sut.resolveSubscriptionTier()
+    sut.reviewPromptTracker?.record(.openedAlert)
+
+    #expect(requester.requestReviewCallCount == 1)
+  }
+
+  @Test("an onboarding-required session is suppressed")
+  func onboardingRequiredSuppresses() async {
+    let (sut, _, requester) = makeSUT(
+      storeState: eligibleState(engagementScore: 4),
+      watchZones: []
+    )
+
+    await sut.determineOnboarding()
+    sut.reviewPromptTracker?.record(.openedAlert)
+
+    #expect(requester.requestReviewCallCount == 0)
+  }
+
+  @Test("a returning user with zones is not suppressed by onboarding")
+  func onboardingNotRequiredDoesNotSuppress() async {
+    let (sut, _, requester) = makeSUT(
+      storeState: eligibleState(engagementScore: 4),
+      watchZones: [.cambridge]
+    )
+
+    await sut.determineOnboarding()
+    sut.reviewPromptTracker?.record(.openedAlert)
+
+    #expect(requester.requestReviewCallCount == 1)
+  }
+
+  // MARK: - Value moments
+
+  @Test("opening an application via a deep link records the alert signal")
+  func deepLinkRecordsOpenedAlert() async {
+    let (sut, _, requester) = makeSUT(storeState: eligibleState(engagementScore: 4))
+
+    sut.handleDeepLink(.applicationDetail(PlanningApplicationId(authority: "CAM", name: "2026/0042")))
+    await sut.waitForPendingDetailLoad()
+
+    #expect(requester.requestReviewCallCount == 1)
+  }
+
+  @Test("tapping through to the portal records the portal signal")
+  func portalTapRecordsTappedPortal() {
+    let (sut, _, requester) = makeSUT(storeState: eligibleState(engagementScore: 3))
+
+    let viewModel = sut.makeApplicationDetailViewModel(application: .withPortalUrl)
+    viewModel.openPortal()
+
+    #expect(requester.requestReviewCallCount == 1)
+  }
+
+  @Test("a successful save records the saved-application signal")
+  func saveRecordsSavedApplication() async {
+    let (sut, _, requester) = makeSUT(
+      storeState: eligibleState(engagementScore: 4, saveCount: 1),
+      savedApplicationRepository: SpySavedApplicationRepository()
+    )
+
+    let viewModel = sut.makeApplicationDetailViewModel(application: .withPortalUrl)
+    await viewModel.toggleSave()  // 2nd save -> +2 -> 6
+
+    #expect(requester.requestReviewCallCount == 1)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailViewModelOnSavedTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailViewModelOnSavedTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Verifies the `onSaved` callback added for the review-prompt feature (GH #628)
+/// fires only on a successful false→true save — never on unsave or failure.
+@Suite("ApplicationDetailViewModel — onSaved")
+@MainActor
+struct ApplicationDetailViewModelOnSavedTests {
+  private func makeSUT(
+    isSaved: Bool,
+    saveResult: Result<Void, Error> = .success(())
+  ) -> (ApplicationDetailViewModel, SpySavedApplicationRepository) {
+    let repository = SpySavedApplicationRepository()
+    repository.saveResult = saveResult
+    let viewModel = ApplicationDetailViewModel(
+      application: .withPortalUrl,
+      savedApplicationRepository: repository,
+      isSaved: isSaved
+    )
+    return (viewModel, repository)
+  }
+
+  @Test("a successful first-time save fires onSaved")
+  func successfulSaveFiresCallback() async {
+    let (sut, _) = makeSUT(isSaved: false)
+    var savedCallCount = 0
+    sut.onSaved = { savedCallCount += 1 }
+
+    await sut.toggleSave()
+
+    #expect(savedCallCount == 1)
+  }
+
+  @Test("unsaving does not fire onSaved")
+  func unsaveDoesNotFireCallback() async {
+    let (sut, _) = makeSUT(isSaved: true)
+    var savedCallCount = 0
+    sut.onSaved = { savedCallCount += 1 }
+
+    await sut.toggleSave()
+
+    #expect(savedCallCount == 0)
+  }
+
+  @Test("a failed save does not fire onSaved")
+  func failedSaveDoesNotFireCallback() async {
+    let (sut, _) = makeSUT(isSaved: false, saveResult: .failure(DomainError.networkUnavailable))
+    var savedCallCount = 0
+    sut.onSaved = { savedCallCount += 1 }
+
+    await sut.toggleSave()
+
+    #expect(savedCallCount == 0)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/ReviewPromptPolicyTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ReviewPromptPolicyTests.swift
@@ -1,0 +1,398 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+/// Exhaustive unit tests for the pure ``ReviewPromptPolicy`` decision engine
+/// (GH #628). Every weight, the threshold, and every guard is covered here with
+/// a deterministic injected clock and a fixed-timezone calendar so distinct-day
+/// counting is reproducible regardless of the host machine's locale.
+@Suite("ReviewPromptPolicy")
+struct ReviewPromptPolicyTests {
+  // 2023-11-14 22:13:20 UTC — a fixed anchor for all time-dependent assertions.
+  private let reference = Date(timeIntervalSince1970: 1_700_000_000)
+  private let day: TimeInterval = 86_400
+
+  private var utcCalendar: Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+    return calendar
+  }
+
+  private func makePolicy(now: Date) -> ReviewPromptPolicy {
+    ReviewPromptPolicy(now: { now }, calendar: utcCalendar)
+  }
+
+  /// A state whose account is comfortably older than the 7-day age guard and
+  /// that has never been prompted, so only the assertion under test gates a fire.
+  private func eligibleState(
+    engagementScore: Int = 0,
+    saveCount: Int = 0,
+    lastActiveDayKey: String? = nil,
+    distinctActiveDays: Int = 0,
+    lastPromptDate: Date? = nil,
+    promptTimestamps: [Date] = [],
+    hasRecordedUpgrade: Bool = false
+  ) -> ReviewPromptState {
+    ReviewPromptState(
+      firstLaunchDate: reference.addingTimeInterval(-30 * day),
+      engagementScore: engagementScore,
+      saveCount: saveCount,
+      lastActiveDayKey: lastActiveDayKey,
+      distinctActiveDays: distinctActiveDays,
+      lastPromptDate: lastPromptDate,
+      promptTimestamps: promptTimestamps,
+      hasRecordedUpgrade: hasRecordedUpgrade
+    )
+  }
+
+  private func evaluate(
+    _ signal: ReviewSignal,
+    state: ReviewPromptState,
+    now: Date? = nil,
+    sessionSuppressed: Bool = false,
+    isReactivation: Bool = false
+  ) -> ReviewPromptOutcome {
+    makePolicy(now: now ?? reference).evaluate(
+      signal: signal,
+      state: state,
+      sessionSuppressed: sessionSuppressed,
+      isReactivation: isReactivation
+    )
+  }
+
+  // MARK: - Threshold
+
+  @Test("holds when the accumulated score stays below the threshold")
+  func holdsBelowThreshold() {
+    let outcome = evaluate(.tappedPortal, state: eligibleState(engagementScore: 0))
+
+    #expect(outcome.decision == .hold)
+    #expect(outcome.state.engagementScore == 3)
+  }
+
+  @Test("fires when a fire-eligible signal lifts the score to exactly the threshold")
+  func firesAtThreshold() {
+    let outcome = evaluate(.tappedPortal, state: eligibleState(engagementScore: 3))
+
+    #expect(outcome.decision == .fire)
+  }
+
+  // MARK: - Weights
+
+  @Test("tapping through to the portal contributes +3")
+  func portalWeight() {
+    let outcome = evaluate(.tappedPortal, state: eligibleState(engagementScore: 0))
+    #expect(outcome.state.engagementScore == ReviewPromptPolicy.portalWeight)
+    #expect(ReviewPromptPolicy.portalWeight == 3)
+  }
+
+  @Test("opening an instant alert contributes +2")
+  func openedAlertWeight() {
+    let outcome = evaluate(.openedAlert, state: eligibleState(engagementScore: 0))
+    #expect(outcome.state.engagementScore == ReviewPromptPolicy.openedAlertWeight)
+    #expect(ReviewPromptPolicy.openedAlertWeight == 2)
+  }
+
+  @Test("a loyalty active day contributes +1")
+  func activeDayWeight() {
+    let outcome = evaluate(
+      .activeDay,
+      state: eligibleState(engagementScore: 0, lastActiveDayKey: nil),
+      isReactivation: true
+    )
+    #expect(outcome.state.engagementScore == ReviewPromptPolicy.activeDayWeight)
+    #expect(ReviewPromptPolicy.activeDayWeight == 1)
+  }
+
+  @Test("portal (+3), a 2nd save (+2) and a loyalty day (+1) reach 6 and fire")
+  func combinedSignalsReachThreshold() {
+    // Pre-load portal (3) + 2nd save (2) = 5 with two prior distinct days, then
+    // the third distinct day's loyalty point (+1) crosses the threshold.
+    let state = eligibleState(
+      engagementScore: 5,
+      saveCount: 2,
+      lastActiveDayKey: "2023-11-14",
+      distinctActiveDays: 2
+    )
+
+    let outcome = evaluate(
+      .activeDay,
+      state: state,
+      now: reference.addingTimeInterval(day),
+      isReactivation: true
+    )
+
+    #expect(outcome.decision == .fire)
+  }
+
+  // MARK: - Upgrade — score contributor only, latched
+
+  @Test("upgrading contributes +2 but never fires (weight < threshold invariant)")
+  func upgradeNeverFires() {
+    #expect(ReviewPromptPolicy.upgradeWeight < ReviewPromptPolicy.engagementThreshold)
+
+    let outcome = evaluate(.upgraded, state: eligibleState(engagementScore: 0))
+
+    #expect(outcome.decision == .hold)
+    #expect(outcome.state.engagementScore == 2)
+  }
+
+  @Test("upgrade is latched — recording it twice still only adds +2 once")
+  func upgradeIsLatched() {
+    let first = evaluate(.upgraded, state: eligibleState(engagementScore: 0))
+    #expect(first.state.engagementScore == 2)
+    #expect(first.state.hasRecordedUpgrade)
+
+    let second = evaluate(.upgraded, state: first.state)
+    #expect(second.decision == .hold)
+    #expect(second.state.engagementScore == 2)
+  }
+
+  // MARK: - Saves — first save not counted
+
+  @Test("the first save increments the count but contributes no score and never fires")
+  func firstSaveNotCounted() {
+    let outcome = evaluate(.savedApplication, state: eligibleState(engagementScore: 5, saveCount: 0))
+
+    #expect(outcome.decision == .hold)
+    #expect(outcome.state.saveCount == 1)
+    #expect(outcome.state.engagementScore == 5)
+  }
+
+  @Test("the second save contributes +2 and is fire-eligible")
+  func secondSaveCountsAndCanFire() {
+    let outcome = evaluate(.savedApplication, state: eligibleState(engagementScore: 4, saveCount: 1))
+
+    #expect(outcome.decision == .fire)
+    #expect(outcome.state.saveCount == 2)
+  }
+
+  // MARK: - Account-age guard
+
+  @Test("never fires before the account is 7 days old, regardless of score")
+  func accountAgeGuardBlocks() {
+    let state = ReviewPromptState(
+      firstLaunchDate: reference.addingTimeInterval(-6 * day),
+      engagementScore: 3
+    )
+
+    let outcome = evaluate(.tappedPortal, state: state)
+
+    #expect(outcome.decision == .hold)
+    #expect(outcome.state.engagementScore == 6)  // score still accrues
+  }
+
+  @Test("fires once the account reaches 7 days old")
+  func accountAgeGuardPasses() {
+    let state = ReviewPromptState(
+      firstLaunchDate: reference.addingTimeInterval(-7 * day),
+      engagementScore: 3
+    )
+
+    let outcome = evaluate(.tappedPortal, state: state)
+
+    #expect(outcome.decision == .fire)
+  }
+
+  @Test("never fires when the first-launch date is unknown")
+  func accountAgeGuardBlocksWhenUnknown() {
+    let state = ReviewPromptState(firstLaunchDate: nil, engagementScore: 3)
+
+    let outcome = evaluate(.tappedPortal, state: state)
+
+    #expect(outcome.decision == .hold)
+  }
+
+  // MARK: - Cooldown guard
+
+  @Test("never fires within 120 days of the last prompt")
+  func cooldownGuardBlocks() {
+    let state = eligibleState(
+      engagementScore: 3,
+      lastPromptDate: reference.addingTimeInterval(-119 * day)
+    )
+
+    let outcome = evaluate(.tappedPortal, state: state)
+
+    #expect(outcome.decision == .hold)
+  }
+
+  @Test("fires once 120 days have elapsed since the last prompt")
+  func cooldownGuardPasses() {
+    let state = eligibleState(
+      engagementScore: 3,
+      lastPromptDate: reference.addingTimeInterval(-120 * day)
+    )
+
+    let outcome = evaluate(.tappedPortal, state: state)
+
+    #expect(outcome.decision == .fire)
+  }
+
+  @Test("holds when the clock has moved backwards past the last prompt date")
+  func cooldownGuardHoldsOnBackwardClock() {
+    let state = eligibleState(
+      engagementScore: 3,
+      lastPromptDate: reference.addingTimeInterval(10 * day)  // in the future
+    )
+
+    let outcome = evaluate(.tappedPortal, state: state)
+
+    #expect(outcome.decision == .hold)
+  }
+
+  // MARK: - Annual cap guard
+
+  @Test("never fires when 3 prompts already fall within the trailing 365 days")
+  func annualCapGuardBlocks() {
+    let state = eligibleState(
+      engagementScore: 3,
+      lastPromptDate: reference.addingTimeInterval(-200 * day),
+      promptTimestamps: [
+        reference.addingTimeInterval(-300 * day),
+        reference.addingTimeInterval(-200 * day),
+        reference.addingTimeInterval(-130 * day),
+      ]
+    )
+
+    let outcome = evaluate(.tappedPortal, state: state)
+
+    #expect(outcome.decision == .hold)
+  }
+
+  @Test("fires once the oldest of three prompts ages out past 365 days")
+  func annualCapGuardUnblocksAsOldestAgesOut() {
+    let state = eligibleState(
+      engagementScore: 3,
+      lastPromptDate: reference.addingTimeInterval(-200 * day),
+      promptTimestamps: [
+        reference.addingTimeInterval(-366 * day),  // aged out
+        reference.addingTimeInterval(-300 * day),
+        reference.addingTimeInterval(-200 * day),
+      ]
+    )
+
+    let outcome = evaluate(.tappedPortal, state: state)
+
+    #expect(outcome.decision == .fire)
+  }
+
+  // MARK: - Session suppression guard
+
+  @Test("never fires while the session is suppressed")
+  func sessionSuppressionGuardBlocks() {
+    let outcome = evaluate(
+      .tappedPortal,
+      state: eligibleState(engagementScore: 3),
+      sessionSuppressed: true
+    )
+
+    #expect(outcome.decision == .hold)
+    #expect(outcome.state.engagementScore == 6)  // suppression does not stop accrual
+  }
+
+  // MARK: - Reset after fire
+
+  @Test("after a fire the score resets and the prompt is timestamped")
+  func resetsAfterFire() {
+    let state = eligibleState(engagementScore: 3, promptTimestamps: [])
+
+    let outcome = evaluate(.tappedPortal, state: state)
+
+    #expect(outcome.decision == .fire)
+    #expect(outcome.state.engagementScore == 0)
+    #expect(outcome.state.lastPromptDate == reference)
+    #expect(outcome.state.promptTimestamps == [reference])
+  }
+
+  // MARK: - Loyalty active-day eligibility
+
+  @Test("loyalty is not fire-eligible before 3 distinct active days")
+  func loyaltyNotEligibleBelowThreeDays() {
+    let state = eligibleState(
+      engagementScore: 8,  // already past the threshold
+      lastActiveDayKey: "2023-11-14",
+      distinctActiveDays: 1
+    )
+
+    let outcome = evaluate(
+      .activeDay,
+      state: state,
+      now: reference.addingTimeInterval(day),
+      isReactivation: true
+    )
+
+    #expect(outcome.decision == .hold)
+    #expect(outcome.state.distinctActiveDays == 2)
+  }
+
+  @Test("loyalty is fire-eligible on the 3rd distinct day during a re-entry")
+  func loyaltyEligibleAtThreeDaysOnReactivation() {
+    let state = eligibleState(
+      engagementScore: 5,
+      lastActiveDayKey: "2023-11-14",
+      distinctActiveDays: 2
+    )
+
+    let outcome = evaluate(
+      .activeDay,
+      state: state,
+      now: reference.addingTimeInterval(day),
+      isReactivation: true
+    )
+
+    #expect(outcome.decision == .fire)
+    #expect(outcome.state.distinctActiveDays == 3)
+  }
+
+  @Test("loyalty never fires on a cold launch even at 3 distinct days")
+  func loyaltyNotEligibleOnColdLaunch() {
+    let state = eligibleState(
+      engagementScore: 5,
+      lastActiveDayKey: "2023-11-14",
+      distinctActiveDays: 2
+    )
+
+    let outcome = evaluate(
+      .activeDay,
+      state: state,
+      now: reference.addingTimeInterval(day),
+      isReactivation: false
+    )
+
+    #expect(outcome.decision == .hold)
+    #expect(outcome.state.distinctActiveDays == 3)
+    #expect(outcome.state.engagementScore == 6)
+  }
+
+  @Test("the same calendar day is never counted twice")
+  func sameDayNotDoubleCounted() {
+    let state = eligibleState(
+      engagementScore: 4,
+      lastActiveDayKey: "2023-11-14",
+      distinctActiveDays: 2
+    )
+
+    let outcome = evaluate(.activeDay, state: state, now: reference, isReactivation: true)
+
+    #expect(outcome.decision == .hold)
+    #expect(outcome.state.distinctActiveDays == 2)
+    #expect(outcome.state.engagementScore == 4)
+  }
+
+  @Test("a backward clock change counts a new day without corrupting state")
+  func backwardClockDoesNotCorruptDayCount() {
+    let state = eligibleState(
+      engagementScore: 0,
+      lastActiveDayKey: "2023-11-15",
+      distinctActiveDays: 3
+    )
+
+    // now is a day earlier than the last recorded key.
+    let outcome = evaluate(.activeDay, state: state, now: reference, isReactivation: true)
+
+    #expect(outcome.state.distinctActiveDays == 4)
+    #expect(outcome.state.engagementScore == 1)
+    #expect(outcome.state.lastActiveDayKey == "2023-11-14")
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/ReviewPromptTrackerTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ReviewPromptTrackerTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Tests the thin @MainActor ``ReviewPromptTracker`` service that the app talks
+/// to (GH #628): it updates the store, evaluates the policy, requests a review
+/// on a fire, and honours session suppression.
+@Suite("ReviewPromptTracker")
+@MainActor
+struct ReviewPromptTrackerTests {
+  private let reference = Date(timeIntervalSince1970: 1_700_000_000)
+  private let day: TimeInterval = 86_400
+
+  /// A store seeded so the account is older than the age guard and only the
+  /// behaviour under test gates a fire.
+  private func makeStore(
+    engagementScore: Int = 0,
+    saveCount: Int = 0,
+    distinctActiveDays: Int = 0,
+    lastActiveDayKey: String? = nil
+  ) -> FakeReviewPromptStore {
+    FakeReviewPromptStore(
+      state: ReviewPromptState(
+        firstLaunchDate: reference.addingTimeInterval(-30 * day),
+        engagementScore: engagementScore,
+        saveCount: saveCount,
+        lastActiveDayKey: lastActiveDayKey,
+        distinctActiveDays: distinctActiveDays
+      )
+    )
+  }
+
+  private func makeTracker(
+    store: FakeReviewPromptStore,
+    requester: SpyReviewRequester
+  ) -> ReviewPromptTracker {
+    let now = reference
+    return ReviewPromptTracker(store: store, requester: requester) { now }
+  }
+
+  @Test("record applies the signal weight and persists it")
+  func recordUpdatesStore() {
+    let store = makeStore(engagementScore: 0)
+    let tracker = makeTracker(store: store, requester: SpyReviewRequester())
+
+    tracker.record(.tappedPortal)
+
+    #expect(store.load().engagementScore == 3)
+  }
+
+  @Test("a fire-eligible signal that crosses the threshold requests a review and resets")
+  func fireRequestsReviewAndResets() {
+    let store = makeStore(engagementScore: 4)
+    let requester = SpyReviewRequester()
+    let tracker = makeTracker(store: store, requester: requester)
+
+    tracker.record(.openedAlert)  // +2 -> 6
+
+    #expect(requester.requestReviewCallCount == 1)
+    #expect(store.load().engagementScore == 0)
+  }
+
+  @Test("a below-threshold signal does not request a review")
+  func belowThresholdDoesNotRequest() {
+    let store = makeStore(engagementScore: 0)
+    let requester = SpyReviewRequester()
+    let tracker = makeTracker(store: store, requester: requester)
+
+    tracker.record(.tappedPortal)  // +3 -> 3
+
+    #expect(requester.requestReviewCallCount == 0)
+  }
+
+  @Test("upgrading never requests a review even when repeated")
+  func upgradeNeverRequests() {
+    let store = makeStore(engagementScore: 5)
+    let requester = SpyReviewRequester()
+    let tracker = makeTracker(store: store, requester: requester)
+
+    tracker.record(.upgraded)  // +2 -> 7 but not fire-eligible
+    tracker.record(.upgraded)  // latched, no change
+
+    #expect(requester.requestReviewCallCount == 0)
+    #expect(store.load().engagementScore == 7)
+  }
+
+  @Test("suppressThisSession holds a subsequent fire-eligible signal")
+  func suppressHoldsFire() {
+    let store = makeStore(engagementScore: 4)
+    let requester = SpyReviewRequester()
+    let tracker = makeTracker(store: store, requester: requester)
+
+    tracker.suppressThisSession()
+    tracker.record(.openedAlert)  // would reach 6 but session is suppressed
+
+    #expect(requester.requestReviewCallCount == 0)
+    #expect(store.load().engagementScore == 6)  // accrual still happens
+  }
+
+  @Test("recordAppForegrounded records a loyalty active day")
+  func foregroundRecordsActiveDay() {
+    let store = makeStore(distinctActiveDays: 0, lastActiveDayKey: nil)
+    let tracker = makeTracker(store: store, requester: SpyReviewRequester())
+
+    tracker.recordAppForegrounded(isReactivation: true)
+
+    #expect(store.load().distinctActiveDays == 1)
+    #expect(store.load().lastActiveDayKey != nil)
+  }
+
+  @Test("the first-launch date is established on init when absent")
+  func firstLaunchEstablishedOnInit() {
+    let store = FakeReviewPromptStore(state: ReviewPromptState(firstLaunchDate: nil))
+    let requester = SpyReviewRequester()
+    let now = reference
+
+    _ = ReviewPromptTracker(store: store, requester: requester) { now }
+
+    #expect(store.load().firstLaunchDate == reference)
+  }
+
+  @Test("an existing first-launch date is not overwritten on init")
+  func firstLaunchNotOverwritten() {
+    let original = reference.addingTimeInterval(-100 * day)
+    let store = FakeReviewPromptStore(state: ReviewPromptState(firstLaunchDate: original))
+    let now = reference
+
+    _ = ReviewPromptTracker(store: store, requester: SpyReviewRequester()) { now }
+
+    #expect(store.load().firstLaunchDate == original)
+  }
+
+  @Test("back-to-back signals each accrue, firing exactly once on the crossing")
+  func backToBackSignalsEvaluatedSerially() {
+    let store = makeStore(engagementScore: 0)
+    let requester = SpyReviewRequester()
+    let tracker = makeTracker(store: store, requester: requester)
+
+    tracker.record(.openedAlert)  // 2
+    tracker.record(.openedAlert)  // 4
+    tracker.record(.openedAlert)  // 6 -> fire, reset to 0
+
+    #expect(requester.requestReviewCallCount == 1)
+    #expect(store.load().engagementScore == 0)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/SubscriptionViewModelFrictionTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SubscriptionViewModelFrictionTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Verifies the `onPurchaseFailed` friction callback added for the review-prompt
+/// feature (GH #628): a failed purchase is a friction moment and must suppress
+/// the review session. A cancelled or successful purchase must not.
+@Suite("SubscriptionViewModel — purchase friction")
+@MainActor
+struct SubscriptionViewModelFrictionTests {
+  private func makeSUT(
+    purchaseResult: Result<SubscriptionEntitlement, Error>
+  ) -> SubscriptionViewModel {
+    let service = SpySubscriptionService()
+    service.purchaseResult = purchaseResult
+    return SubscriptionViewModel(
+      subscriptionService: service,
+      authenticationService: SpyAuthenticationService()
+    )
+  }
+
+  @Test("a failed purchase fires onPurchaseFailed")
+  func failedPurchaseFiresFriction() async {
+    let sut = makeSUT(purchaseResult: .failure(DomainError.networkUnavailable))
+    var frictionCount = 0
+    sut.onPurchaseFailed = { frictionCount += 1 }
+
+    await sut.purchase(productId: "premium")
+
+    #expect(frictionCount == 1)
+  }
+
+  @Test("a cancelled purchase does not fire onPurchaseFailed")
+  func cancelledPurchaseDoesNotFireFriction() async {
+    let sut = makeSUT(purchaseResult: .failure(DomainError.purchaseCancelled))
+    var frictionCount = 0
+    sut.onPurchaseFailed = { frictionCount += 1 }
+
+    await sut.purchase(productId: "premium")
+
+    #expect(frictionCount == 0)
+  }
+
+  @Test("a successful purchase does not fire onPurchaseFailed")
+  func successfulPurchaseDoesNotFireFriction() async {
+    let sut = makeSUT(purchaseResult: .success(.personalActive))
+    var frictionCount = 0
+    sut.onPurchaseFailed = { frictionCount += 1 }
+
+    await sut.purchase(productId: "premium")
+
+    #expect(frictionCount == 0)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/UserDefaultsReviewPromptStoreTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/UserDefaultsReviewPromptStoreTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+import TownCrierData
+import TownCrierDomain
+
+/// Verifies the `UserDefaults`-backed review-prompt store round-trips the full
+/// state locally (GH #628). Mirrors `UserDefaultsOnboardingRepositoryTests`.
+@Suite("UserDefaultsReviewPromptStore")
+struct UserDefaultsReviewPromptStoreTests {
+  private func makeSUT() throws -> (UserDefaultsReviewPromptStore, UserDefaults) {
+    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
+    return (UserDefaultsReviewPromptStore(defaults: defaults), defaults)
+  }
+
+  @Test("load returns a default-initialised state on first run")
+  func loadsDefaultStateOnFirstRun() throws {
+    let (sut, _) = try makeSUT()
+
+    let state = sut.load()
+
+    #expect(state == ReviewPromptState())
+    #expect(state.firstLaunchDate == nil)
+    #expect(state.engagementScore == 0)
+    #expect(state.promptTimestamps.isEmpty)
+    #expect(!state.hasRecordedUpgrade)
+  }
+
+  @Test("save then load round-trips the full state")
+  func roundTripsFullState() throws {
+    let (sut, _) = try makeSUT()
+    let saved = ReviewPromptState(
+      firstLaunchDate: Date(timeIntervalSince1970: 1_700_000_000),
+      engagementScore: 5,
+      saveCount: 3,
+      lastActiveDayKey: "2023-11-14",
+      distinctActiveDays: 4,
+      lastPromptDate: Date(timeIntervalSince1970: 1_700_100_000),
+      promptTimestamps: [
+        Date(timeIntervalSince1970: 1_600_000_000),
+        Date(timeIntervalSince1970: 1_700_100_000),
+      ],
+      hasRecordedUpgrade: true
+    )
+
+    sut.save(saved)
+
+    #expect(sut.load() == saved)
+  }
+
+  @Test("state persists across store instances sharing the same defaults")
+  func persistsAcrossInstances() throws {
+    let (sut, defaults) = try makeSUT()
+    let saved = ReviewPromptState(
+      firstLaunchDate: Date(timeIntervalSince1970: 1_700_000_000),
+      engagementScore: 6,
+      hasRecordedUpgrade: true
+    )
+
+    sut.save(saved)
+    let reopened = UserDefaultsReviewPromptStore(defaults: defaults)
+
+    #expect(reopened.load() == saved)
+  }
+
+  @Test("optional dates persist as nil when unset")
+  func optionalDatesNilWhenUnset() throws {
+    let (sut, _) = try makeSUT()
+
+    sut.save(ReviewPromptState(engagementScore: 2))
+
+    let loaded = sut.load()
+    #expect(loaded.firstLaunchDate == nil)
+    #expect(loaded.lastPromptDate == nil)
+    #expect(loaded.lastActiveDayKey == nil)
+    #expect(loaded.engagementScore == 2)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Spies/FakeReviewPromptStore.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/FakeReviewPromptStore.swift
@@ -1,0 +1,22 @@
+import Foundation
+import TownCrierDomain
+
+/// In-memory ``ReviewPromptStore`` for tests — holds the state in a field and
+/// counts saves.
+final class FakeReviewPromptStore: ReviewPromptStore, @unchecked Sendable {
+  var state: ReviewPromptState
+  private(set) var saveCallCount = 0
+
+  init(state: ReviewPromptState = ReviewPromptState()) {
+    self.state = state
+  }
+
+  func load() -> ReviewPromptState {
+    state
+  }
+
+  func save(_ state: ReviewPromptState) {
+    self.state = state
+    saveCallCount += 1
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyReviewRequester.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyReviewRequester.swift
@@ -1,0 +1,12 @@
+import TownCrierPresentation
+
+/// Records whether a review request was made, in place of the real
+/// `requestReview` OS call.
+@MainActor
+final class SpyReviewRequester: ReviewRequesting {
+  private(set) var requestReviewCallCount = 0
+
+  func requestReview() {
+    requestReviewCallCount += 1
+  }
+}


### PR DESCRIPTION
## Changes

Implements GitHub issue #628 — prompt users to rate the app at genuine in-app engagement peaks, gated by a local deterministic engagement-score policy. No push, no telemetry, all state in local `UserDefaults`.

- `ReviewPromptPolicy` — pure decision engine (weights, threshold=6, guards: 7-day account age, 120-day cooldown, rolling 365-day annual cap ≤3, session suppression), injected `now: () -> Date`, no I/O, no StoreKit.
- `ReviewPromptStore` protocol + `UserDefaultsReviewPromptStore` impl — local-only persistence, no PII, no server.
- `ReviewPromptTracker` (@MainActor) — `record(_:)`, `recordAppForegrounded(isReactivation:)`, `suppressThisSession()`.
- `ReviewRequesting` protocol + `CoordinatorReviewRequester` — flips `AppCoordinator.isRequestingReview`; app-layer `.onChange` performs the real `requestReview` at the OS edge (mirrors the `isOpeningSystemNotificationSettings` pattern).
- Signal wiring: `.tappedPortal` (+3), 2nd+ `.savedApplication` (+2), `.openedAlert` deep-link only (+2), loyalty `.activeDay` (+1, gated on distinctActiveDays≥3 + re-entry), `.upgraded` (+2, latched, never fire-eligible). Suppression on onboarding, post-purchase push prompt (#625), quota-block, and failed-purchase friction.
- 52 new Swift Testing cases (1348 total pass); SwiftLint --strict clean.

Closes #628.

---
*Auto-shipped via ship skill*

Release-Note: Town Crier now asks you to rate the app after a good run of using it, never by notification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a smarter App Store review prompt flow that tracks engagement moments, applies timing rules, and requests reviews only when appropriate.
  * Review state is now saved locally so prompting behavior persists across app launches.

* **Bug Fixes**
  * Prevents review prompts from appearing during onboarding, after quota-related upgrade screens, and alongside post-purchase permission prompts.
  * Improves handling of foreground re-entry, deep-link opens, and successful saves as review-worthy moments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->