### PR TITLE
feat(ios): "Rate the App" Settings row → App Store write-review (tc-gq0p)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+RateApp.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+RateApp.swift
@@ -10,4 +10,11 @@ extension AppCoordinator {
   /// silently suppress (that path belongs to the automatic prompt, GH #628).
   public static let appStoreWriteReviewURLString =
     "https://apps.apple.com/app/id6764095657?action=write-review"
+
+  /// Requests the App Store write-review composer from the "Rate the App" row
+  /// in Settings. Coordinator stays UIKit-free; `TownCrierApp` observes
+  /// ``isOpeningAppStoreReview`` and opens ``appStoreWriteReviewURLString``.
+  public func rateApp() {
+    isOpeningAppStoreReview = true
+  }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+RateApp.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+RateApp.swift
@@ -1,0 +1,13 @@
+extension AppCoordinator {
+  /// Deep-link URL string for the "Rate the App" row in Settings (GH #629).
+  /// The `?action=write-review` query opens the App Store straight on Town
+  /// Crier's review composer, rather than the listing page.
+  ///
+  /// Apple ID `6764095657` is Town Crier's stable, published App Store
+  /// identifier (also used by the web download CTAs). A manual tap must always
+  /// do something, so this row uses the App Store URL rather than
+  /// `SKStoreReviewController.requestReview`, which Apple throttles and may
+  /// silently suppress (that path belongs to the automatic prompt, GH #628).
+  public static let appStoreWriteReviewURLString =
+    "https://apps.apple.com/app/id6764095657?action=write-review"
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -16,6 +16,10 @@ public final class AppCoordinator: ObservableObject {
   /// Set to `true` from the in-app preferences screen footer; the view layer
   /// opens ``AppCoordinator/systemNotificationSettingsURLString`` and resets it.
   @Published public var isOpeningSystemNotificationSettings = false
+  /// Set to `true` by the "Rate the App" row in Settings; the view layer opens
+  /// ``AppCoordinator/appStoreWriteReviewURLString`` and resets it (GH #629,
+  /// mirroring ``isOpeningSystemNotificationSettings``).
+  @Published public var isOpeningAppStoreReview = false
   /// In-app preferences: `true` pushes `NotificationPreferencesView` via `.navigationDestination`.
   @Published public var isNotificationPreferencesPresented = false
   /// Set to `true` by the review-prompt requester at an engagement peak; the app
@@ -354,6 +358,13 @@ public final class AppCoordinator: ObservableObject {
   /// UIKit-free; `TownCrierApp` observes the flag and opens the settings URL.
   public func showSystemNotificationSettings() {
     isOpeningSystemNotificationSettings = true
+  }
+
+  /// Requests the App Store write-review composer from the "Rate the App" row
+  /// in Settings. Coordinator stays UIKit-free; `TownCrierApp` observes the
+  /// flag and opens ``appStoreWriteReviewURLString`` (GH #629).
+  public func rateApp() {
+    isOpeningAppStoreReview = true
   }
 
   /// Presents the detail sheet synchronously from a row payload — bypasses the

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -16,10 +16,7 @@ public final class AppCoordinator: ObservableObject {
   /// Set to `true` from the in-app preferences screen footer; the view layer
   /// opens ``AppCoordinator/systemNotificationSettingsURLString`` and resets it.
   @Published public var isOpeningSystemNotificationSettings = false
-  /// Set to `true` by the "Rate the App" row in Settings; the view layer opens
-  /// ``AppCoordinator/appStoreWriteReviewURLString`` and resets it (GH #629,
-  /// mirroring ``isOpeningSystemNotificationSettings``).
-  @Published public var isOpeningAppStoreReview = false
+  @Published public var isOpeningAppStoreReview = false  // see rateApp() (GH #629)
   /// In-app preferences: `true` pushes `NotificationPreferencesView` via `.navigationDestination`.
   @Published public var isNotificationPreferencesPresented = false
   /// Set to `true` by the review-prompt requester at an engagement peak; the app
@@ -358,13 +355,6 @@ public final class AppCoordinator: ObservableObject {
   /// UIKit-free; `TownCrierApp` observes the flag and opens the settings URL.
   public func showSystemNotificationSettings() {
     isOpeningSystemNotificationSettings = true
-  }
-
-  /// Requests the App Store write-review composer from the "Rate the App" row
-  /// in Settings. Coordinator stays UIKit-free; `TownCrierApp` observes the
-  /// flag and opens ``appStoreWriteReviewURLString`` (GH #629).
-  public func rateApp() {
-    isOpeningAppStoreReview = true
   }
 
   /// Presents the detail sheet synchronously from a row payload — bypasses the

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Settings/SettingsView.swift
@@ -9,6 +9,7 @@ public struct SettingsView: View {
   private var onPrivacyPolicy: (() -> Void)?
   private var onTermsOfService: (() -> Void)?
   private var onRedeemOfferCode: (() -> Void)?
+  private var onRateApp: (() -> Void)?
 
   public init(
     viewModel: SettingsViewModel,
@@ -16,7 +17,8 @@ public struct SettingsView: View {
     onManageSubscription: (() -> Void)? = nil,
     onPrivacyPolicy: (() -> Void)? = nil,
     onTermsOfService: (() -> Void)? = nil,
-    onRedeemOfferCode: (() -> Void)? = nil
+    onRedeemOfferCode: (() -> Void)? = nil,
+    onRateApp: (() -> Void)? = nil
   ) {
     _viewModel = StateObject(wrappedValue: viewModel)
     self.onNotificationPreferences = onNotificationPreferences
@@ -24,6 +26,7 @@ public struct SettingsView: View {
     self.onPrivacyPolicy = onPrivacyPolicy
     self.onTermsOfService = onTermsOfService
     self.onRedeemOfferCode = onRedeemOfferCode
+    self.onRateApp = onRateApp
   }
 
   /// Test-only seam: invoke the redeem-offer-code callback as if the user had
@@ -46,6 +49,13 @@ public struct SettingsView: View {
   /// verifiable without UI-level automation.
   public func requestExportData() async {
     await viewModel.exportData()
+  }
+
+  /// Test-only seam: invoke the rate-app callback as if the user had tapped the
+  /// "Rate the App" row in Settings. Mirrors `requestRedeemOfferCode` so the
+  /// wiring is verifiable without UI-level automation (GH #629).
+  public func requestRateApp() {
+    onRateApp?()
   }
 
   public var body: some View {
@@ -321,11 +331,18 @@ public struct SettingsView: View {
 
   private var appInfoSection: some View {
     Section {
+      navigationRow("Rate the App", systemImage: "star") {
+        onRateApp?()
+      }
+
       HStack {
         settingLabel("Version")
         Spacer()
         settingCaption(viewModel.appVersion)
       }
+    } header: {
+      Text("About")
+        .font(TCTypography.captionEmphasis)
     }
   }
 }

--- a/mobile/ios/town-crier-app/Sources/CoordinatorURLModifiers.swift
+++ b/mobile/ios/town-crier-app/Sources/CoordinatorURLModifiers.swift
@@ -1,0 +1,52 @@
+import Foundation
+import SwiftUI
+import TownCrierPresentation
+
+extension View {
+  /// Opens the iOS system Settings notifications subpage when the coordinator
+  /// raises ``AppCoordinator/isOpeningSystemNotificationSettings``, then resets
+  /// the flag. Keeps the coordinator UIKit-free.
+  func openingSystemNotificationSettings(when coordinator: AppCoordinator) -> some View {
+    modifier(
+      OpenURLOnFlagModifier(
+        coordinator: coordinator,
+        flag: \.isOpeningSystemNotificationSettings,
+        urlString: AppCoordinator.systemNotificationSettingsURLString
+      )
+    )
+  }
+
+  /// Opens the App Store write-review composer when the coordinator raises
+  /// ``AppCoordinator/isOpeningAppStoreReview`` (the "Rate the App" row), then
+  /// resets the flag (GH #629).
+  func openingAppStoreReview(when coordinator: AppCoordinator) -> some View {
+    modifier(
+      OpenURLOnFlagModifier(
+        coordinator: coordinator,
+        flag: \.isOpeningAppStoreReview,
+        urlString: AppCoordinator.appStoreWriteReviewURLString
+      )
+    )
+  }
+}
+
+/// Bridges a coordinator `Bool` flag to SwiftUI's environment `openURL` action:
+/// when the flag flips to `true` the app opens `urlString` and resets the flag.
+/// The coordinator only raises the flag; the un-testable `openURL` side effect
+/// lives here, mirroring `ReviewPromptRequestModifier`.
+private struct OpenURLOnFlagModifier: ViewModifier {
+  @Environment(\.openURL) private var openURL
+  @ObservedObject var coordinator: AppCoordinator
+  let flag: ReferenceWritableKeyPath<AppCoordinator, Bool>
+  let urlString: String
+
+  func body(content: Content) -> some View {
+    content.onChange(of: coordinator[keyPath: flag]) { _, requested in
+      guard requested else { return }
+      if let url = URL(string: urlString) {
+        openURL(url)
+      }
+      coordinator[keyPath: flag] = false
+    }
+  }
+}

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -9,7 +9,6 @@ import UserNotifications
 @main
 struct TownCrierApp: App {
   @UIApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-  @Environment(\.openURL) private var openURL
   @Environment(\.scenePhase) private var scenePhase
   @StateObject private var coordinator: AppCoordinator
   @StateObject private var loginViewModel: LoginViewModel
@@ -354,7 +353,7 @@ struct TownCrierApp: App {
         onRedeemOfferCode: coordinator.isOfferCodeRedemptionAvailable
           ? { coordinator.showRedeemOfferCode() }
           : nil,
-        onRateApp: { coordinator.rateApp() }
+        onRateApp: coordinator.rateApp
       )
       .navigationDestination(isPresented: $coordinator.isNotificationPreferencesPresented) {
         NotificationPreferencesView(
@@ -390,21 +389,10 @@ struct TownCrierApp: App {
         isPresented: $coordinator.isManageSubscriptionPresented.dispatchingSetOnMain()
       )
     #endif
-    .onChange(of: coordinator.isOpeningSystemNotificationSettings) { _, requested in
-      guard requested else { return }
-      if let url = URL(string: AppCoordinator.systemNotificationSettingsURLString) {
-        openURL(url)
-      }
-      coordinator.isOpeningSystemNotificationSettings = false
-    }
-    // "Rate the App" row (GH #629): open the App Store write-review composer
-    // then reset the flag, mirroring the system-settings handler above.
-    .onChange(of: coordinator.isOpeningAppStoreReview) { _, requested in
-      guard requested else { return }
-      if let url = URL(string: AppCoordinator.appStoreWriteReviewURLString) {
-        openURL(url)
-      }
-      coordinator.isOpeningAppStoreReview = false
-    }
+    // App-layer edge for coordinator-driven deep links: open the URL and reset
+    // the flag. Extracted into a shared modifier (mirrors ReviewPromptRequest-
+    // Modifier) so the file stays UIKit-free and within length limits.
+    .openingSystemNotificationSettings(when: coordinator)
+    .openingAppStoreReview(when: coordinator)
   }
 }

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -353,7 +353,8 @@ struct TownCrierApp: App {
         // was injected — SettingsView hides the row when this callback is nil.
         onRedeemOfferCode: coordinator.isOfferCodeRedemptionAvailable
           ? { coordinator.showRedeemOfferCode() }
-          : nil
+          : nil,
+        onRateApp: { coordinator.rateApp() }
       )
       .navigationDestination(isPresented: $coordinator.isNotificationPreferencesPresented) {
         NotificationPreferencesView(
@@ -395,6 +396,15 @@ struct TownCrierApp: App {
         openURL(url)
       }
       coordinator.isOpeningSystemNotificationSettings = false
+    }
+    // "Rate the App" row (GH #629): open the App Store write-review composer
+    // then reset the flag, mirroring the system-settings handler above.
+    .onChange(of: coordinator.isOpeningAppStoreReview) { _, requested in
+      guard requested else { return }
+      if let url = URL(string: AppCoordinator.appStoreWriteReviewURLString) {
+        openURL(url)
+      }
+      coordinator.isOpeningAppStoreReview = false
     }
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -360,14 +360,9 @@ struct AppCoordinatorTests {
 
   // MARK: - Settings Navigation (App Store Review)
 
-  @Test func isOpeningAppStoreReview_isFalseByDefault() {
+  @Test func rateApp_flipsFlagFromFalseToTrue() {
     let (sut, _) = makeSUT()
-
     #expect(!sut.isOpeningAppStoreReview)
-  }
-
-  @Test func rateApp_setsFlagToTrue() {
-    let (sut, _) = makeSUT()
 
     sut.rateApp()
 

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -358,6 +358,31 @@ struct AppCoordinatorTests {
     #expect(AppCoordinator.systemNotificationSettingsURLString == "app-settings:notification")
   }
 
+  // MARK: - Settings Navigation (App Store Review)
+
+  @Test func isOpeningAppStoreReview_isFalseByDefault() {
+    let (sut, _) = makeSUT()
+
+    #expect(!sut.isOpeningAppStoreReview)
+  }
+
+  @Test func rateApp_setsFlagToTrue() {
+    let (sut, _) = makeSUT()
+
+    sut.rateApp()
+
+    #expect(sut.isOpeningAppStoreReview)
+  }
+
+  /// The "Rate the App" row opens the App Store straight on Town Crier's
+  /// write-review composer via the `?action=write-review` deep link (GH #629).
+  @Test func appStoreWriteReviewURLString_deepLinksToWriteReviewComposer() {
+    #expect(
+      AppCoordinator.appStoreWriteReviewURLString
+        == "https://apps.apple.com/app/id6764095657?action=write-review"
+    )
+  }
+
   // MARK: - Deterministic detail-load synchronisation
 
   /// Regression guard for tc-nsrh (CI flakes on `Task.sleep(...)` waits in

--- a/mobile/ios/town-crier-tests/Sources/Features/SettingsViewTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/SettingsViewTests.swift
@@ -66,6 +66,18 @@ struct SettingsViewTests {
     #expect(tapped)
   }
 
+  @Test("SettingsView forwards the rate-app tap to the callback")
+  func rateAppCallback_isInvokedOnRequest() {
+    let vm = makeViewModel()
+    var tapped = false
+    let handler: () -> Void = { tapped = true }
+    let view = SettingsView(viewModel: vm, onRateApp: handler)
+
+    view.requestRateApp()
+
+    #expect(tapped)
+  }
+
   @Test("SettingsView export-data tap drives the ViewModel export flow")
   func exportDataTap_invokesViewModelExport() async {
     let profileSpy = SpyUserProfileRepository()


### PR DESCRIPTION
## Changes

Implements GitHub issue #629 — a manual "Rate the App" row in Settings that opens the App Store write-review composer. The always-available complement to the automatic engagement-score prompt (#628). No telemetry, no `SKStoreReviewController`.

- `AppCoordinator+RateApp.swift` — `appStoreWriteReviewURLString = "https://apps.apple.com/app/id6764095657?action=write-review"` + `rateApp()`.
- `AppCoordinator.swift` — `@Published var isOpeningAppStoreReview`.
- `SettingsView.swift` — `onRateApp` callback (init param + stored var), `requestRateApp()` test seam, and a "Rate the App" star row (in the "About" section).
- `TownCrierApp.swift` — passes `onRateApp: coordinator.rateApp`; opens the URL at the app-layer edge via `openURL`, then resets the flag (mirrors the `isOpeningSystemNotificationSettings` pattern).
- Refactor: both the new App Store handler and the existing system-notification-settings handler are consolidated into a shared, behavior-preserving `OpenURLOnFlagModifier` (mirrors `ReviewPromptRequestModifier`) to keep files under the SwiftLint 400-line `file_length` cap. The system-settings deep link is unchanged.
- New tests: `rateApp()` flips the flag false→true, the URL string value, and the SettingsView `requestRateApp()` seam invokes `onRateApp`. 1351 total tests pass; SwiftLint --strict clean.

Closes #629.

---
*Auto-shipped via ship skill*

Release-Note: You can now rate Town Crier any time from a new Rate the App row in Settings.