### PR TITLE
chore(ios): bump MARKETING_VERSION to 1.0.4 (reopen TestFlight train) (tc-6z22)

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.0.3"
+        MARKETING_VERSION: "1.0.4"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"


### PR DESCRIPTION
## Changes

The `v0.15.41` CD iOS TestFlight upload failed with an altool **409**: the App Store pre-release train **1.0.3** is closed for new build submissions (`CFBundleShortVersionString` must exceed the previously approved `1.0.3`).

- Bump `MARKETING_VERSION` `1.0.3` → `1.0.4` in `mobile/ios/project.yml` so the next CD beta upload opens a fresh train.

Release plumbing only — no user-facing behaviour change (hence `chore(ios):`, no `Release-Note:` trailer). After merge, a fresh release tag re-triggers CD: iOS builds against the open `1.0.4` train, and the Go API deploy retries past its transient Azure 429.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the app version to **1.0.4** for the iOS release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->