### PR TITLE
feat(web): SEO/conversion plumbing for planning pages (Smart App Banner, App Store ct token, authority→town links) (tc-r0q7)

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,6 +8,10 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Apple Smart App Banner: prompts iOS Safari visitors to install the app.
+         The id is the source-of-truth APPLE_APP_ID in src/config/links.ts (kept
+         in lockstep with scripts/lib/constants.mjs by the drift-guard test). -->
+    <meta name="apple-itunes-app" content="app-id=6764095657" />
     <title>Town Crier — Planning Application Alerts for Your Area</title>
     <meta name="description" content="Monitor UK local authority planning applications and get push notifications for your neighbourhood. Stay informed about developments that matter to you." />
 

--- a/web/scripts/lib/__tests__/prerender-snapshot.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-snapshot.test.mjs
@@ -386,6 +386,89 @@ describe('runRender — offline mode', () => {
     expect(sitemap).toContain('<lastmod>2026-06-14</lastmod>');
   });
 
+  it('links an authority page down to its published town children, sorted by name', async () => {
+    const { writeFile } = await import('node:fs/promises');
+    const snapshotPath = join(outDir, 'wiring-snapshot.json');
+    const app = (uid) => ({
+      uid,
+      name: uid,
+      address: `${uid} address`,
+      description: 'desc',
+      appState: 'Permitted',
+      startDate: '2026-01-10',
+      lastDifferent: '2026-06-10T10:00:00+00:00',
+      link: null,
+      url: null,
+    });
+    await writeFile(
+      snapshotPath,
+      JSON.stringify({
+        version: 1,
+        generatedAt: '2026-06-25T00:00:00.000Z',
+        minPopulation: 20000,
+        limit: 30,
+        authorities: [{ id: 1, name: 'Adur' }],
+        authorityPages: [
+          {
+            id: 1,
+            name: 'Adur',
+            areaType: 'English District',
+            areaName: 'Adur',
+            total: 12,
+            statusBreakdown: [{ appState: 'Permitted', count: 12 }],
+            applications: [app('A1')],
+          },
+        ],
+        townPages: [
+          {
+            slug: 'shoreham-by-sea',
+            name: 'Shoreham-by-Sea',
+            lat: 50.83,
+            lng: -0.27,
+            authorityId: 1,
+            population: 25000,
+            total: 14,
+            statusBreakdown: [{ appState: 'Permitted', count: 14 }],
+            applications: [app('S1')],
+          },
+          {
+            slug: 'lancing',
+            name: 'Lancing',
+            lat: 50.83,
+            lng: -0.32,
+            authorityId: 1,
+            population: 30000,
+            total: 11,
+            statusBreakdown: [{ appState: 'Permitted', count: 11 }],
+            applications: [app('L1')],
+          },
+        ],
+      }),
+      'utf-8',
+    );
+
+    const result = await runRender({
+      outDir,
+      snapshotPath,
+      logger: silentLogger,
+    });
+
+    expect(result.published).toEqual(['adur']);
+
+    const html = await readFile(
+      join(outDir, 'planning', 'adur', 'index.html'),
+      'utf-8',
+    );
+    expect(html).toContain('<section class="townLinks">');
+    expect(html).toContain('<a href="/planning/adur/lancing">Lancing</a>');
+    expect(html).toContain(
+      '<a href="/planning/adur/shoreham-by-sea">Shoreham-by-Sea</a>',
+    );
+    expect(html.indexOf('>Lancing<')).toBeLessThan(
+      html.indexOf('>Shoreham-by-Sea<'),
+    );
+  });
+
   it('fails loud when the snapshot file is missing', async () => {
     await expect(
       runRender({

--- a/web/scripts/lib/__tests__/prerender.test.mjs
+++ b/web/scripts/lib/__tests__/prerender.test.mjs
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, readFile, access } from 'node:fs/promises';
+import { mkdtemp, rm, readFile, writeFile, access } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -305,6 +305,169 @@ describe('runPrerender — live mode', () => {
         logger: silentLogger,
       }),
     ).rejects.toThrow();
+  });
+});
+
+describe('runPrerender — authority links down to its published towns', () => {
+  /**
+   * One qualifying authority (Adur, id 1) plus three of its towns: two clear the
+   * coverage gate, one is gated out. Written to temp fixtures so the test is
+   * self-contained.
+   */
+  async function writeWiringFixtures() {
+    const authorityFixture = join(outDir, 'authorities-fixture.json');
+    const townFixture = join(outDir, 'towns-fixture.json');
+
+    const app = (uid) => ({
+      uid,
+      name: uid,
+      address: `${uid} address`,
+      description: 'desc',
+      appState: 'Permitted',
+      startDate: '2026-01-10',
+      lastDifferent: '2026-06-10T10:00:00+00:00',
+      link: null,
+      url: null,
+    });
+
+    await writeFile(
+      authorityFixture,
+      JSON.stringify([
+        {
+          id: 1,
+          name: 'Adur',
+          areaType: 'English District',
+          areaName: 'Adur',
+          total: 12,
+          statusBreakdown: [{ appState: 'Permitted', count: 12 }],
+          applications: [app('A1')],
+        },
+      ]),
+      'utf-8',
+    );
+
+    await writeFile(
+      townFixture,
+      JSON.stringify([
+        {
+          slug: 'shoreham-by-sea',
+          name: 'Shoreham-by-Sea',
+          lat: 50.83,
+          lng: -0.27,
+          authorityId: 1,
+          total: 14,
+          statusBreakdown: [{ appState: 'Permitted', count: 14 }],
+          applications: [app('S1')],
+        },
+        {
+          slug: 'lancing',
+          name: 'Lancing',
+          lat: 50.83,
+          lng: -0.32,
+          authorityId: 1,
+          total: 11,
+          statusBreakdown: [{ appState: 'Permitted', count: 11 }],
+          applications: [app('L1')],
+        },
+        {
+          slug: 'tiny',
+          name: 'Tiny',
+          lat: 50.8,
+          lng: -0.3,
+          authorityId: 1,
+          total: 4, // below the coverage gate -> gated out, must never be linked
+          statusBreakdown: [{ appState: 'Permitted', count: 4 }],
+          applications: [],
+        },
+      ]),
+      'utf-8',
+    );
+
+    return { authorityFixture, townFixture };
+  }
+
+  it('renders a .townLinks section linking only to its published (gated-in) towns, sorted by name', async () => {
+    const { authorityFixture, townFixture } = await writeWiringFixtures();
+
+    const result = await runPrerender({
+      outDir,
+      fixturePath: authorityFixture,
+      townFixturePath: townFixture,
+      loadAuthorities: async () => [{ id: 1, name: 'Adur' }],
+      logger: silentLogger,
+    });
+
+    expect(result.published).toEqual(['adur']);
+    expect(result.publishedTowns.sort()).toEqual([
+      'adur/lancing',
+      'adur/shoreham-by-sea',
+    ]);
+
+    const html = await readFile(
+      join(outDir, 'planning', 'adur', 'index.html'),
+      'utf-8',
+    );
+
+    expect(html).toContain('<section class="townLinks">');
+    // Links to both published towns, at the canonical nested path.
+    expect(html).toContain('<a href="/planning/adur/lancing">Lancing</a>');
+    expect(html).toContain(
+      '<a href="/planning/adur/shoreham-by-sea">Shoreham-by-Sea</a>',
+    );
+    // Sorted by name.localeCompare: Lancing before Shoreham-by-Sea.
+    expect(html.indexOf('>Lancing<')).toBeLessThan(
+      html.indexOf('>Shoreham-by-Sea<'),
+    );
+    // The gated-out town is NEVER linked (would be a link to a 404).
+    expect(html).not.toContain('/planning/adur/tiny');
+    expect(html).not.toContain('>Tiny<');
+  });
+
+  it('omits the town-links section for an authority with no published towns', async () => {
+    // Authority fixture only (no town fixture) -> no towns map -> no section.
+    const authorityFixture = join(outDir, 'authorities-only.json');
+    await writeFile(
+      authorityFixture,
+      JSON.stringify([
+        {
+          id: 1,
+          name: 'Adur',
+          areaType: 'English District',
+          areaName: 'Adur',
+          total: 12,
+          statusBreakdown: [{ appState: 'Permitted', count: 12 }],
+          applications: [
+            {
+              uid: 'A1',
+              name: 'A1',
+              address: 'x',
+              description: 'd',
+              appState: 'Permitted',
+              startDate: null,
+              lastDifferent: '2026-06-10T10:00:00+00:00',
+              link: null,
+              url: null,
+            },
+          ],
+        },
+      ]),
+      'utf-8',
+    );
+
+    await runPrerender({
+      outDir,
+      fixturePath: authorityFixture,
+      loadAuthorities: async () => [{ id: 1, name: 'Adur' }],
+      logger: silentLogger,
+    });
+
+    const html = await readFile(
+      join(outDir, 'planning', 'adur', 'index.html'),
+      'utf-8',
+    );
+    // The stylesheet always carries the .townLinks rules, so assert on the
+    // section element, not the bare substring.
+    expect(html).not.toContain('<section class="townLinks">');
   });
 });
 

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -276,11 +276,15 @@ describe('renderPlanningPage', () => {
     });
 
     it('omits the section entirely when there are no published towns', () => {
+      // The stylesheet always carries the .townLinks rules, so assert on the
+      // section element, not the bare substring.
       expect(renderPlanningPage(pageData({ towns: [] }))).not.toContain(
-        'townLinks',
+        '<section class="townLinks">',
       );
       // Undefined towns (the default) also omit the section — backwards compatible.
-      expect(renderPlanningPage(pageData())).not.toContain('townLinks');
+      expect(renderPlanningPage(pageData())).not.toContain(
+        '<section class="townLinks">',
+      );
     });
 
     it('HTML-escapes town names in the link list', () => {

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { renderPlanningPage } from '../render-page.mjs';
-import { APP_DOWNLOAD_URL, SITE_ORIGIN } from '../constants.mjs';
+import {
+  APP_DOWNLOAD_URL,
+  APPLE_APP_ID,
+  SITE_ORIGIN,
+  appStoreUrl,
+} from '../constants.mjs';
 
 /**
  * @param {Partial<import('../render-page.mjs').PlanningPageData>} [overrides]
@@ -130,6 +135,32 @@ describe('renderPlanningPage', () => {
     );
   });
 
+  it('emits the Apple Smart App Banner meta tag in <head> after the viewport meta', () => {
+    const html = renderPlanningPage(pageData());
+    const head = html.match(/<head>[\s\S]*?<\/head>/);
+    expect(head).not.toBeNull();
+    const [headHtml] = head;
+    expect(headHtml).toContain(
+      `<meta name="apple-itunes-app" content="app-id=${APPLE_APP_ID}" />`,
+    );
+    expect(headHtml).toContain('app-id=6764095657');
+    // Sits immediately after the viewport meta.
+    expect(headHtml.indexOf('name="viewport"')).toBeLessThan(
+      headHtml.indexOf('name="apple-itunes-app"'),
+    );
+  });
+
+  it('tags every download CTA with the ct=seo-lpa campaign token', () => {
+    const html = renderPlanningPage(pageData());
+    const tagged = appStoreUrl('seo-lpa');
+    // Both CTAs (header "Get the app" + bottom "Download on the App Store").
+    const occurrences = html.split(`href="${tagged}"`).length - 1;
+    expect(occurrences).toBe(2);
+    expect(html).toContain('ct=seo-lpa');
+    // Never the bare, campaign-free URL in a CTA href.
+    expect(html).not.toContain(`href="${APP_DOWNLOAD_URL}"`);
+  });
+
   it('includes a CTA to the App Store for the area', () => {
     const html = renderPlanningPage(pageData());
     expect(html).toContain('Get push alerts for Basingstoke and Deane');
@@ -142,7 +173,7 @@ describe('renderPlanningPage', () => {
     expect(header).not.toBeNull();
     const [headerHtml] = header;
     expect(headerHtml).toContain('siteHeader__cta');
-    expect(headerHtml).toContain(`href="${APP_DOWNLOAD_URL}"`);
+    expect(headerHtml).toContain(`href="${appStoreUrl('seo-lpa')}"`);
     expect(headerHtml).toContain('Get the app');
     // Match the bottom CTA's link safety exactly.
     expect(headerHtml).toContain('rel="noopener"');

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -227,4 +227,70 @@ describe('renderPlanningPage', () => {
     expect(html).not.toContain('<script>alert(1)</script>');
     expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
   });
+
+  describe('town links section', () => {
+    it('renders a .townLinks section when the authority has published towns', () => {
+      const html = renderPlanningPage(
+        pageData({
+          towns: [
+            { name: 'Basingstoke', slug: 'basingstoke' },
+            { name: 'Tadley', slug: 'tadley' },
+          ],
+        }),
+      );
+      expect(html).toContain('<section class="townLinks">');
+      expect(html).toContain(
+        '<h2>Planning applications by town in Basingstoke and Deane</h2>',
+      );
+      expect(html).toContain('<ul class="townLinks__list">');
+    });
+
+    it('links to the canonical nested /planning/<authority>/<town> path for each town', () => {
+      const html = renderPlanningPage(
+        pageData({
+          towns: [
+            { name: 'Basingstoke', slug: 'basingstoke' },
+            { name: 'Tadley', slug: 'tadley' },
+          ],
+        }),
+      );
+      expect(html).toContain(
+        '<a href="/planning/basingstoke-and-deane/basingstoke">Basingstoke</a>',
+      );
+      expect(html).toContain(
+        '<a href="/planning/basingstoke-and-deane/tadley">Tadley</a>',
+      );
+    });
+
+    it('places the town-links section immediately after the Recent applications list', () => {
+      const html = renderPlanningPage(
+        pageData({ towns: [{ name: 'Basingstoke', slug: 'basingstoke' }] }),
+      );
+      // After the recent-applications <ul>, before the how-to-comment explainer.
+      expect(html.indexOf('class="appList"')).toBeLessThan(
+        html.indexOf('class="townLinks"'),
+      );
+      expect(html.indexOf('class="townLinks"')).toBeLessThan(
+        html.indexOf('class="explainer"'),
+      );
+    });
+
+    it('omits the section entirely when there are no published towns', () => {
+      expect(renderPlanningPage(pageData({ towns: [] }))).not.toContain(
+        'townLinks',
+      );
+      // Undefined towns (the default) also omit the section — backwards compatible.
+      expect(renderPlanningPage(pageData())).not.toContain('townLinks');
+    });
+
+    it('HTML-escapes town names in the link list', () => {
+      const html = renderPlanningPage(
+        pageData({
+          towns: [{ name: 'Stoke & <b>Bramley</b>', slug: 'stoke-bramley' }],
+        }),
+      );
+      expect(html).not.toContain('<b>Bramley</b>');
+      expect(html).toContain('Stoke &amp; &lt;b&gt;Bramley&lt;/b&gt;');
+    });
+  });
 });

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   renderApplicationsList,
   renderAttributionList,
+  pageStyles,
 } from '../render-shared.mjs';
 import { ATTRIBUTION_LINES } from '../constants.mjs';
 
@@ -114,5 +115,15 @@ describe('renderAttributionList', () => {
     // HTML in a line is escaped so data can never inject markup.
     expect(html).toContain('<li>Line two &amp; &lt;b&gt;bold&lt;/b&gt;</li>');
     expect((html.match(/<li>/g) ?? []).length).toBe(2);
+  });
+});
+
+describe('pageStyles townLinks', () => {
+  it('styles the .townLinks__list and its anchors with design tokens', () => {
+    const css = pageStyles();
+    expect(css).toContain('.townLinks__list');
+    expect(css).toContain('.townLinks__list a');
+    // Uses design tokens (var(--tc-*)), never hard-coded colours/spacing.
+    expect(css).toMatch(/\.townLinks__list a \{[^}]*var\(--tc-/);
   });
 });

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { renderTownPage } from '../render-town-page.mjs';
-import { APP_DOWNLOAD_URL, SITE_ORIGIN } from '../constants.mjs';
+import {
+  APP_DOWNLOAD_URL,
+  APPLE_APP_ID,
+  SITE_ORIGIN,
+  appStoreUrl,
+} from '../constants.mjs';
 
 /**
  * @param {Partial<import('../render-town-page.mjs').TownPageData>} [overrides]
@@ -137,6 +142,32 @@ describe('renderTownPage', () => {
     );
   });
 
+  it('emits the Apple Smart App Banner meta tag in <head> after the viewport meta', () => {
+    const html = renderTownPage(townData());
+    const head = html.match(/<head>[\s\S]*?<\/head>/);
+    expect(head).not.toBeNull();
+    const [headHtml] = head;
+    expect(headHtml).toContain(
+      `<meta name="apple-itunes-app" content="app-id=${APPLE_APP_ID}" />`,
+    );
+    expect(headHtml).toContain('app-id=6764095657');
+    // Sits immediately after the viewport meta.
+    expect(headHtml.indexOf('name="viewport"')).toBeLessThan(
+      headHtml.indexOf('name="apple-itunes-app"'),
+    );
+  });
+
+  it('tags every download CTA with the ct=seo-town campaign token', () => {
+    const html = renderTownPage(townData());
+    const tagged = appStoreUrl('seo-town');
+    // Both CTAs (header "Get the app" + bottom "Download on the App Store").
+    const occurrences = html.split(`href="${tagged}"`).length - 1;
+    expect(occurrences).toBe(2);
+    expect(html).toContain('ct=seo-town');
+    // Never the bare, campaign-free URL in a CTA href.
+    expect(html).not.toContain(`href="${APP_DOWNLOAD_URL}"`);
+  });
+
   it('includes a CTA to the App Store for the town', () => {
     const html = renderTownPage(townData());
     expect(html).toContain('Get push alerts for Truro');
@@ -149,7 +180,7 @@ describe('renderTownPage', () => {
     expect(header).not.toBeNull();
     const [headerHtml] = header;
     expect(headerHtml).toContain('siteHeader__cta');
-    expect(headerHtml).toContain(`href="${APP_DOWNLOAD_URL}"`);
+    expect(headerHtml).toContain(`href="${appStoreUrl('seo-town')}"`);
     expect(headerHtml).toContain('Get the app');
     // Match the bottom CTA's link safety exactly.
     expect(headerHtml).toContain('rel="noopener"');

--- a/web/scripts/lib/constants.mjs
+++ b/web/scripts/lib/constants.mjs
@@ -16,6 +16,32 @@ export const APP_DOWNLOAD_URL =
   'https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657';
 
 /**
+ * Numeric App Store id for the iOS app — the tail of {@link APP_DOWNLOAD_URL}.
+ * Sourced once here (and mirrored in `src/config/links.ts`, kept in lockstep by
+ * the drift-guard test) so the Apple Smart App Banner meta tag never hardcodes
+ * it per template.
+ * @type {string}
+ */
+export const APPLE_APP_ID = '6764095657';
+
+/**
+ * Build a campaign-tagged App Store link from the campaign-free
+ * {@link APP_DOWNLOAD_URL}. The `ct` token surfaces under App Store Connect →
+ * App Analytics → Acquisition so installs can be attributed to the surface that
+ * sent them (e.g. `seo-lpa`, `seo-town`, `web-home`); `mt=8` is Apple's
+ * software-app media type. Cookieless and aggregate — sets nothing on-device.
+ *
+ * `APP_DOWNLOAD_URL` is deliberately left campaign-free so the byte-equal
+ * lockstep guard between this file and `src/config/links.ts` still holds.
+ *
+ * @param {string} campaign
+ * @returns {string}
+ */
+export function appStoreUrl(campaign) {
+  return `${APP_DOWNLOAD_URL}?ct=${encodeURIComponent(campaign)}&mt=8`;
+}
+
+/**
  * Mandatory data attribution lines (ADR 0006). Byte-for-byte the same copy the
  * app shows on its Settings → Attribution panel. Required on every public page.
  * @type {readonly string[]}

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -1,5 +1,6 @@
 import { SITE_ORIGIN, APPLE_APP_ID, appStoreUrl } from './constants.mjs';
 import { escapeHtml, leadLine } from './format.mjs';
+import { townPagePath } from './town-path.mjs';
 import {
   pageStyles,
   renderApplicationsList,
@@ -12,6 +13,12 @@ import {
  */
 
 /**
+ * @typedef {Object} TownLink
+ * @property {string} name display name of the published town
+ * @property {string} slug the town's URL slug (joined under this authority)
+ */
+
+/**
  * @typedef {Object} PlanningPageData
  * @property {string} slug
  * @property {string} areaName
@@ -19,7 +26,40 @@ import {
  * @property {number} total
  * @property {Array<{ appState: string | null, count: number }>} statusBreakdown
  * @property {PlanningApplicationItem[]} applications
+ * @property {TownLink[]} [towns] published town children, for the internal link
+ *   list. Omitted/empty for authorities with no published towns.
  */
+
+/**
+ * Render the internal link list down to this authority's published town pages.
+ * Only published (coverage-gated) towns are passed in, so these links never
+ * point at a 404. Returns '' when there are no towns, so the section is omitted
+ * entirely. Town display names are HTML-escaped; slugs are already URL-safe.
+ *
+ * @param {PlanningPageData} data
+ * @returns {string}
+ */
+function renderTownLinks(data) {
+  if (!Array.isArray(data.towns) || data.towns.length === 0) {
+    return '';
+  }
+  const area = escapeHtml(data.areaName);
+  const items = data.towns
+    .map(
+      (town) =>
+        `          <li><a href="/planning/${townPagePath(data.slug, town.slug)}">${escapeHtml(town.name)}</a></li>`,
+    )
+    .join('\n');
+  return `
+        <section class="townLinks">
+          <h2>Planning applications by town in ${area}</h2>
+          <p>Browse recent applications for individual towns and villages in ${area}.</p>
+          <ul class="townLinks__list">
+${items}
+          </ul>
+        </section>
+`;
+}
 
 /**
  * @param {PlanningPageData} data
@@ -77,6 +117,7 @@ export function renderPlanningPage(data) {
   const year = new Date().getFullYear();
 
   const applicationsList = renderApplicationsList(data.applications);
+  const townLinks = renderTownLinks(data);
   const attribution = renderAttributionList();
 
   return `<!doctype html>
@@ -119,7 +160,7 @@ ${renderStats(data.statusBreakdown)}
         <ul class="appList">
 ${applicationsList}
         </ul>
-
+${townLinks}
         <section class="explainer">
           <h2>How to comment on a planning application in ${area}</h2>
           <p>

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -1,4 +1,4 @@
-import { SITE_ORIGIN, APP_DOWNLOAD_URL } from './constants.mjs';
+import { SITE_ORIGIN, APPLE_APP_ID, appStoreUrl } from './constants.mjs';
 import { escapeHtml, leadLine } from './format.mjs';
 import {
   pageStyles,
@@ -84,6 +84,7 @@ export function renderPlanningPage(data) {
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="apple-itunes-app" content="app-id=${APPLE_APP_ID}" />
     <title>${title}</title>
     <meta name="description" content="${metaDescription}" />
     <meta name="robots" content="index,follow" />
@@ -105,7 +106,7 @@ ${pageStyles()}
         <a href="/">Town Crier</a>
         <nav class="siteHeader__nav">
           <a href="/">Home</a>
-          <a class="siteHeader__cta" href="${APP_DOWNLOAD_URL}" rel="noopener" target="_blank">Get the app</a>
+          <a class="siteHeader__cta" href="${appStoreUrl('seo-lpa')}" rel="noopener" target="_blank">Get the app</a>
         </nav>
       </header>
       <main>
@@ -142,7 +143,7 @@ ${applicationsList}
             Draw a circle on the map and Town Crier will notify you the moment a new
             planning application is submitted or decided inside it.
           </p>
-          <a class="cta__button" href="${APP_DOWNLOAD_URL}" rel="noopener" target="_blank">Download on the App Store</a>
+          <a class="cta__button" href="${appStoreUrl('seo-lpa')}" rel="noopener" target="_blank">Download on the App Store</a>
         </section>
       </main>
 

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -272,6 +272,18 @@ export function pageStyles() {
     .status--appealed { color: var(--tc-status-appealed); }
     .statRow { display: flex; justify-content: space-between; background: var(--tc-surface); border: 1px solid var(--tc-border); border-radius: var(--tc-radius-md); padding: var(--tc-space-sm) var(--tc-space-md); }
     .statRow__count { font-weight: 700; }
+    .townLinks__list { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: var(--tc-space-sm); }
+    .townLinks__list a {
+      display: inline-block;
+      padding: var(--tc-space-sm) var(--tc-space-md);
+      background: var(--tc-surface);
+      border: 1px solid var(--tc-border);
+      border-radius: var(--tc-radius-full);
+      color: var(--tc-amber);
+      text-decoration: none;
+      font-weight: 600;
+    }
+    .townLinks__list a:hover { color: var(--tc-amber-hover); border-color: var(--tc-amber); }
     .explainer p { color: var(--tc-text-secondary); }
     .cta {
       margin: var(--tc-space-xl) 0;

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -15,7 +15,8 @@
 
 import {
   SITE_ORIGIN,
-  APP_DOWNLOAD_URL,
+  APPLE_APP_ID,
+  appStoreUrl,
   TOWN_ATTRIBUTION_LINES,
 } from './constants.mjs';
 import { escapeHtml, leadLine } from './format.mjs';
@@ -125,6 +126,7 @@ export function renderTownPage(data) {
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="apple-itunes-app" content="app-id=${APPLE_APP_ID}" />
     <title>${title}</title>
     <meta name="description" content="${metaDescription}" />
     <meta name="robots" content="index,follow" />
@@ -146,7 +148,7 @@ ${pageStyles()}
         <a href="/">Town Crier</a>
         <nav class="siteHeader__nav">
           <a href="/">Home</a>
-          <a class="siteHeader__cta" href="${APP_DOWNLOAD_URL}" rel="noopener" target="_blank">Get the app</a>
+          <a class="siteHeader__cta" href="${appStoreUrl('seo-town')}" rel="noopener" target="_blank">Get the app</a>
         </nav>
       </header>
       <nav class="breadcrumb" aria-label="Breadcrumb">
@@ -191,7 +193,7 @@ ${applicationsList}
             Draw a circle on the map and Town Crier will notify you the moment a new
             planning application is submitted or decided inside it.
           </p>
-          <a class="cta__button" href="${APP_DOWNLOAD_URL}" rel="noopener" target="_blank">Download on the App Store</a>
+          <a class="cta__button" href="${appStoreUrl('seo-town')}" rel="noopener" target="_blank">Download on the App Store</a>
         </section>
       </main>
 

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -378,6 +378,9 @@ async function writePage(outDir, data) {
  * @param {SitemapEntry[]} args.sitemapEntries           parallel { path, lastmod } records
  * @param {Array<{ name: string, reason: string }>} args.excluded
  * @param {Set<string>} args.seenSlugs
+ * @param {Map<number, Array<{ name: string, slug: string }>>} args.townsByAuthority
+ *   published towns keyed by parent authorityId, accumulated by the (earlier)
+ *   town pass; the authority page links down to its own entry (sorted by name).
  * @param {{ warn: (msg: string) => void }} args.logger
  * @returns {Promise<void>}
  */
@@ -395,6 +398,7 @@ async function considerAuthority(args) {
     sitemapEntries,
     excluded,
     seenSlugs,
+    townsByAuthority,
     logger,
   } = args;
 
@@ -414,6 +418,11 @@ async function considerAuthority(args) {
   // Authority data already arrives recency-ordered (the bounded read sorts by
   // lastDifferent DESC), so no re-sort here — only the town path needs that.
   const shown = applications.slice(0, limit);
+  // Only this authority's PUBLISHED towns (gated-in by the earlier town pass) are
+  // linked, sorted by display name, so the page never links to a 404.
+  const towns = [...(townsByAuthority?.get(authorityId) ?? [])].sort((a, b) =>
+    a.name.localeCompare(b.name),
+  );
   await writePage(outDir, {
     slug,
     areaName: areaName || name,
@@ -421,6 +430,7 @@ async function considerAuthority(args) {
     total,
     statusBreakdown,
     applications: shown,
+    towns,
   });
   published.push(slug);
   sitemapEntries.push({ path: slug, lastmod: maxLastmod(shown) });
@@ -502,6 +512,9 @@ async function writeTownPage(outDir, data) {
  * @param {SitemapEntry[]} args.sitemapEntries           parallel { path, lastmod } records
  * @param {Array<{ name: string, reason: string }>} args.excludedTowns
  * @param {Set<string>} args.seenPaths
+ * @param {Map<number, Array<{ name: string, slug: string }>>} args.townsByAuthority
+ *   accumulates each published town under its parent authorityId so the (later)
+ *   authority pass can link down to its town children.
  * @param {{ warn: (msg: string) => void }} args.logger
  * @returns {Promise<void>}
  */
@@ -518,6 +531,7 @@ async function considerTown(args) {
     sitemapEntries,
     excludedTowns,
     seenPaths,
+    townsByAuthority,
     logger,
   } = args;
 
@@ -554,6 +568,19 @@ async function considerTown(args) {
   });
   publishedTowns.push(path);
   sitemapEntries.push({ path, lastmod: maxLastmod(shown) });
+  // Record this published town under its parent authority so the authority page
+  // can link down to it. Only reached after the coverage gate + dedup pass, so a
+  // gated-out or duplicate town is never linked.
+  if (townsByAuthority) {
+    const siblings = townsByAuthority.get(town.authorityId);
+    if (siblings) {
+      siblings.push({ name: town.name, slug: town.slug });
+    } else {
+      townsByAuthority.set(town.authorityId, [
+        { name: town.name, slug: town.slug },
+      ]);
+    }
+  }
 }
 
 /**
@@ -568,7 +595,7 @@ async function considerTown(args) {
  * @param {(town: Town) => Promise<{ applications: object[], total: number, statusBreakdown: object[] }>} args.getGeo
  * @param {number} args.limit
  * @param {{ warn: (msg: string) => void }} args.logger
- * @returns {Promise<{ publishedTowns: string[], townSitemapEntries: SitemapEntry[], excludedTowns: Array<{ name: string, reason: string }> }>}
+ * @returns {Promise<{ publishedTowns: string[], townSitemapEntries: SitemapEntry[], excludedTowns: Array<{ name: string, reason: string }>, townsByAuthority: Map<number, Array<{ name: string, slug: string }>> }>}
  */
 async function renderTownPages(args) {
   const { outDir, towns, authorities, getGeo, limit, logger } = args;
@@ -580,6 +607,10 @@ async function renderTownPages(args) {
   /** @type {Array<{ name: string, reason: string }>} */
   const excludedTowns = [];
   const seenPaths = new Set();
+  // Published towns keyed by parent authorityId — handed to the authority pass so
+  // each authority page can link down to its own (gated-in) town children.
+  /** @type {Map<number, Array<{ name: string, slug: string }>>} */
+  const townsByAuthority = new Map();
 
   for (const town of towns) {
     const geo = await getGeo(town);
@@ -597,11 +628,12 @@ async function renderTownPages(args) {
       sitemapEntries: townSitemapEntries,
       excludedTowns,
       seenPaths,
+      townsByAuthority,
       logger,
     });
   }
 
-  return { publishedTowns, townSitemapEntries, excludedTowns };
+  return { publishedTowns, townSitemapEntries, excludedTowns, townsByAuthority };
 }
 
 /**
@@ -626,6 +658,28 @@ async function renderTownPages(args) {
 async function renderEntries(args) {
   const { outDir, authorityEntries, townEntries, authorities, limit, logger } =
     args;
+
+  // Town pass FIRST: an authority page must link only to towns that actually
+  // published (cleared the coverage gate), so the per-authority town map has to
+  // be built before authority pages render. Both passes are independent; sitemap
+  // order is immaterial. Town entries carry the geo projection inline, so
+  // `getGeo` is a pure lookup — no network. With zero town entries the loop is a
+  // no-op and `authorities` is never consulted.
+  const { publishedTowns, townSitemapEntries, excludedTowns, townsByAuthority } =
+    await renderTownPages({
+      outDir,
+      towns: townEntries,
+      authorities,
+      getGeo: async (town) => ({
+        applications: Array.isArray(town.applications) ? town.applications : [],
+        total: town.total,
+        statusBreakdown: Array.isArray(town.statusBreakdown)
+          ? town.statusBreakdown
+          : [],
+      }),
+      limit,
+      logger,
+    });
 
   /** @type {string[]} */
   const published = [];
@@ -656,28 +710,10 @@ async function renderEntries(args) {
       sitemapEntries: authoritySitemapEntries,
       excluded,
       seenSlugs,
+      townsByAuthority,
       logger,
     });
   }
-
-  // Town entries carry the geo projection inline (total/statusBreakdown/
-  // applications), so `getGeo` is a pure lookup — no network. With zero town
-  // entries the loop is a no-op and `authorities` is never consulted.
-  const { publishedTowns, townSitemapEntries, excludedTowns } =
-    await renderTownPages({
-      outDir,
-      towns: townEntries,
-      authorities,
-      getGeo: async (town) => ({
-        applications: Array.isArray(town.applications) ? town.applications : [],
-        total: town.total,
-        statusBreakdown: Array.isArray(town.statusBreakdown)
-          ? town.statusBreakdown
-          : [],
-      }),
-      limit,
-      logger,
-    });
 
   await writeFile(
     join(outDir, 'sitemap.xml'),
@@ -764,6 +800,41 @@ async function runLiveMode(args) {
 
   const authorities = await loadAuthorities();
 
+  // Town pass FIRST: the authority pages link down to their PUBLISHED towns, so
+  // the per-authority town map must be built before authority pages render.
+  // One bounded geo read per town, scoped to its authority partition and
+  // centroid. Reuses the same authority list (no extra HTTP) to resolve slugs.
+  const towns = await loadTowns();
+
+  // Population threshold gate, applied BEFORE the per-town geo fetch so that
+  // below-threshold towns never even hit the API. The threshold is a build-time
+  // config value (SEO_TOWN_MIN_POPULATION, default 20000); ramping coverage means
+  // bumping the variable and rebuilding — no gazetteer regeneration. The ≥10
+  // in-radius coverage gate (inside `considerTown`) still applies on top.
+  /** @type {Town[]} */
+  const eligibleTowns = [];
+  /** @type {Array<{ name: string, reason: string }>} */
+  const populationExcludedTowns = [];
+  for (const town of towns) {
+    if (town.population >= minPopulation) {
+      eligibleTowns.push(town);
+    } else {
+      populationExcludedTowns.push({ name: town.name, reason: 'population' });
+    }
+  }
+
+  const { publishedTowns, townSitemapEntries, excludedTowns, townsByAuthority } =
+    await renderTownPages({
+      outDir,
+      towns: eligibleTowns,
+      authorities,
+      getGeo: (town) =>
+        fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl),
+      limit,
+      logger,
+    });
+  excludedTowns.push(...populationExcludedTowns);
+
   /** @type {string[]} */
   const published = [];
   /** @type {SitemapEntry[]} */
@@ -798,42 +869,10 @@ async function runLiveMode(args) {
       sitemapEntries: authoritySitemapEntries,
       excluded,
       seenSlugs,
+      townsByAuthority,
       logger,
     });
   }
-
-  // Town pages: one bounded geo read per town, scoped to its authority partition
-  // and centroid. Reuses the same authority list (no extra HTTP) to resolve slugs.
-  const towns = await loadTowns();
-
-  // Population threshold gate, applied BEFORE the per-town geo fetch so that
-  // below-threshold towns never even hit the API. The threshold is a build-time
-  // config value (SEO_TOWN_MIN_POPULATION, default 20000); ramping coverage means
-  // bumping the variable and rebuilding — no gazetteer regeneration. The ≥10
-  // in-radius coverage gate (inside `considerTown`) still applies on top.
-  /** @type {Town[]} */
-  const eligibleTowns = [];
-  /** @type {Array<{ name: string, reason: string }>} */
-  const populationExcludedTowns = [];
-  for (const town of towns) {
-    if (town.population >= minPopulation) {
-      eligibleTowns.push(town);
-    } else {
-      populationExcludedTowns.push({ name: town.name, reason: 'population' });
-    }
-  }
-
-  const { publishedTowns, townSitemapEntries, excludedTowns } =
-    await renderTownPages({
-      outDir,
-      towns: eligibleTowns,
-      authorities,
-      getGeo: (town) =>
-        fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl),
-      limit,
-      logger,
-    });
-  excludedTowns.push(...populationExcludedTowns);
 
   await writeFile(
     join(outDir, 'sitemap.xml'),

--- a/web/src/__tests__/planning-cta-link.test.ts
+++ b/web/src/__tests__/planning-cta-link.test.ts
@@ -1,12 +1,39 @@
 import { describe, it, expect } from 'vitest';
-import { APP_DOWNLOAD_URL } from '../config/links';
+import { APP_DOWNLOAD_URL, APPLE_APP_ID, appStoreUrl } from '../config/links';
 // The prerender build script is plain ESM (`.mjs`) and cannot import the app's
-// TypeScript modules at runtime, so it keeps its own copy of the App Store URL.
-// This guard fails the build the moment the two drift apart.
-import { APP_DOWNLOAD_URL as PRERENDER_APP_DOWNLOAD_URL } from '../../scripts/lib/constants.mjs';
+// TypeScript modules at runtime, so it keeps its own copy of the App Store URL,
+// the numeric App Store id, and the campaign-tagging helper. These guards fail
+// the build the moment the two drift apart.
+import {
+  APP_DOWNLOAD_URL as PRERENDER_APP_DOWNLOAD_URL,
+  APPLE_APP_ID as PRERENDER_APPLE_APP_ID,
+  appStoreUrl as prerenderAppStoreUrl,
+} from '../../scripts/lib/constants.mjs';
 
 describe('planning page CTA link', () => {
   it('keeps the prerender App Store URL in lockstep with config/links.ts', () => {
     expect(PRERENDER_APP_DOWNLOAD_URL).toBe(APP_DOWNLOAD_URL);
+  });
+
+  it('keeps the prerender App Store id in lockstep with config/links.ts', () => {
+    expect(PRERENDER_APPLE_APP_ID).toBe(APPLE_APP_ID);
+    // The id is the numeric tail of the download URL, never an independent value.
+    expect(APP_DOWNLOAD_URL).toContain(APPLE_APP_ID);
+  });
+
+  it('keeps appStoreUrl() byte-identical between the two copies for the same campaign', () => {
+    for (const campaign of ['seo-lpa', 'seo-town', 'web-home']) {
+      expect(prerenderAppStoreUrl(campaign)).toBe(appStoreUrl(campaign));
+    }
+  });
+
+  it('appStoreUrl() appends the campaign token and mt=8 to the campaign-free base', () => {
+    expect(appStoreUrl('web-home')).toBe(`${APP_DOWNLOAD_URL}?ct=web-home&mt=8`);
+    // The base constant itself stays campaign-free so the lockstep guard holds.
+    expect(APP_DOWNLOAD_URL).not.toContain('ct=');
+  });
+
+  it('appStoreUrl() URL-encodes the campaign value', () => {
+    expect(appStoreUrl('a b&c')).toBe(`${APP_DOWNLOAD_URL}?ct=a%20b%26c&mt=8`);
   });
 });

--- a/web/src/__tests__/smart-app-banner.test.ts
+++ b/web/src/__tests__/smart-app-banner.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { APPLE_APP_ID } from '../config/links';
+
+const indexHtmlPath = resolve(__dirname, '../../index.html');
+const html = readFileSync(indexHtmlPath, 'utf-8');
+
+describe('Apple Smart App Banner (SPA shell)', () => {
+  it('emits the apple-itunes-app meta tag in index.html', () => {
+    expect(html).toContain(
+      `<meta name="apple-itunes-app" content="app-id=${APPLE_APP_ID}" />`,
+    );
+    expect(html).toContain('app-id=6764095657');
+  });
+
+  it('places the banner meta inside <head>', () => {
+    const head = html.match(/<head>[\s\S]*?<\/head>/)?.[0] ?? '';
+    expect(head).toContain('name="apple-itunes-app"');
+  });
+
+  it('points at config/links.ts as the source of truth for the id', () => {
+    // A comment keeps the static value honest against APPLE_APP_ID, which the
+    // lockstep guard pins to constants.mjs. There is no banner without the note.
+    expect(html).toContain('src/config/links.ts');
+  });
+
+  it('does not bake a campaign token into the banner (app-id only, no app-argument)', () => {
+    expect(html).not.toContain('app-argument');
+  });
+});

--- a/web/src/components/Footer/Footer.tsx
+++ b/web/src/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { APP_DOWNLOAD_URL } from '../../config/links';
+import { appStoreUrl } from '../../config/links';
 import styles from './Footer.module.css';
 
 export function Footer() {
@@ -12,7 +12,7 @@ export function Footer() {
             Your neighbourhood is changing. Stay informed.
           </h2>
           <a
-            href={APP_DOWNLOAD_URL}
+            href={appStoreUrl('web-home')}
             className={styles.downloadButton}
             aria-label="Download on the App Store"
             target="_blank"

--- a/web/src/components/Footer/__tests__/Footer.test.tsx
+++ b/web/src/components/Footer/__tests__/Footer.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, within } from '@testing-library/react';
 import { describe, it, expect } from 'vitest';
+import { appStoreUrl } from '../../../config/links';
 import { Footer } from '../Footer';
 
 describe('Footer', () => {
@@ -26,10 +27,7 @@ describe('Footer', () => {
 
     const link = screen.getByRole('link', { name: /download on the app store/i });
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute(
-      'href',
-      'https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657',
-    );
+    expect(link).toHaveAttribute('href', appStoreUrl('web-home'));
     expect(link).toHaveAttribute('target', '_blank');
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });

--- a/web/src/components/Hero/Hero.tsx
+++ b/web/src/components/Hero/Hero.tsx
@@ -1,4 +1,4 @@
-import { APP_DOWNLOAD_URL } from '../../config/links';
+import { appStoreUrl } from '../../config/links';
 import { useHeroCta } from './useHeroCta';
 import styles from './Hero.module.css';
 
@@ -17,7 +17,7 @@ export function Hero() {
       <div className={styles.ctaGroup}>
         <a
           className={styles.cta}
-          href={APP_DOWNLOAD_URL}
+          href={appStoreUrl('web-home')}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/web/src/components/Hero/__tests__/Hero.test.tsx
+++ b/web/src/components/Hero/__tests__/Hero.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect } from 'vitest';
+import { appStoreUrl } from '../../../config/links';
 import { AuthProvider } from '../../../auth/auth-context';
 import { SpyAuthPort } from '../../../auth/__tests__/spies/spy-auth-port';
 import { Hero } from '../Hero';
@@ -39,10 +40,7 @@ describe('Hero', () => {
 
     const cta = screen.getByRole('link', { name: /app store/i });
     expect(cta).toBeInTheDocument();
-    expect(cta).toHaveAttribute(
-      'href',
-      'https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657',
-    );
+    expect(cta).toHaveAttribute('href', appStoreUrl('web-home'));
     expect(cta).toHaveAttribute('target', '_blank');
     expect(cta).toHaveAttribute('rel', 'noopener noreferrer');
   });

--- a/web/src/components/Navbar/Navbar.tsx
+++ b/web/src/components/Navbar/Navbar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { APP_DOWNLOAD_URL } from '../../config/links';
+import { appStoreUrl } from '../../config/links';
 import { useTheme } from '../../hooks/useTheme';
 import { useNavbarAuth } from './useNavbarAuth';
 import { ThemeToggle } from '../ThemeToggle/ThemeToggle';
@@ -56,7 +56,7 @@ export function Navbar() {
           )}
 
           <a
-            href={APP_DOWNLOAD_URL}
+            href={appStoreUrl('web-home')}
             className={styles.cta}
             target="_blank"
             rel="noopener noreferrer"

--- a/web/src/components/Navbar/__tests__/Navbar.test.tsx
+++ b/web/src/components/Navbar/__tests__/Navbar.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, beforeEach } from 'vitest';
+import { appStoreUrl } from '../../../config/links';
 import { AuthProvider } from '../../../auth/auth-context';
 import { SpyAuthPort } from '../../../auth/__tests__/spies/spy-auth-port';
 import { Navbar } from '../Navbar';
@@ -69,10 +70,7 @@ describe('Navbar', () => {
 
     const cta = screen.getByRole('link', { name: /download/i });
     expect(cta).toBeInTheDocument();
-    expect(cta).toHaveAttribute(
-      'href',
-      'https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657',
-    );
+    expect(cta).toHaveAttribute('href', appStoreUrl('web-home'));
     expect(cta).toHaveAttribute('target', '_blank');
     expect(cta).toHaveAttribute('rel', 'noopener noreferrer');
   });

--- a/web/src/config/links.ts
+++ b/web/src/config/links.ts
@@ -6,3 +6,25 @@
  */
 export const APP_DOWNLOAD_URL =
   'https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657';
+
+/**
+ * Numeric App Store id for the iOS app — the tail of {@link APP_DOWNLOAD_URL}.
+ * Mirrors `scripts/lib/constants.mjs` (the `.mjs` prerender scripts cannot import
+ * this TS at runtime); the two are kept in lockstep by the drift-guard test in
+ * `src/__tests__/planning-cta-link.test.ts`. Feeds the Apple Smart App Banner
+ * meta tag in `index.html` so the id is never hardcoded there.
+ */
+export const APPLE_APP_ID = '6764095657';
+
+/**
+ * Build a campaign-tagged App Store link from the campaign-free
+ * {@link APP_DOWNLOAD_URL}. The `ct` token lets App Store Connect attribute
+ * installs to the surface that sent them (e.g. `web-home` for the SPA CTAs);
+ * `mt=8` is Apple's software-app media type. Cookieless and aggregate.
+ *
+ * `APP_DOWNLOAD_URL` stays campaign-free so the byte-equal lockstep guard with
+ * `scripts/lib/constants.mjs` still holds.
+ */
+export function appStoreUrl(campaign: string): string {
+  return `${APP_DOWNLOAD_URL}?ct=${encodeURIComponent(campaign)}&mt=8`;
+}


### PR DESCRIPTION
## Changes

Implements GitHub issue #633 — three zero-cost web changes to convert and measure the planning-page SEO traffic. All under `web/`.

**Change 1 — Apple Smart App Banner**
- `APPLE_APP_ID` constant added to `scripts/lib/constants.mjs` and mirrored in `src/config/links.ts`.
- `<meta name="apple-itunes-app" content="app-id=6764095657">` emitted in `<head>` (after viewport) on `render-page.mjs`, `render-town-page.mjs`, and statically in `index.html` (with a source-of-truth comment).

**Change 2 — App Store campaign attribution token (`ct`)**
- `appStoreUrl(campaign)` helper added to both `constants.mjs` and `src/config/links.ts`; `APP_DOWNLOAD_URL` kept campaign-free so the byte-equal lockstep guard holds.
- Authority CTAs → `ct=seo-lpa`; town CTAs → `ct=seo-town`; SPA CTAs (Hero, Navbar, Footer) → `ct=web-home`.

**Change 3 — Authority → town internal links**
- `prerender-planning.mjs` now runs the town pass before the authority pass (both `renderEntries` and `runLiveMode`), accumulating a `Map<authorityId, [{name, slug}]>` of published towns inside `considerTown` after the coverage gate.
- Authority pages render a `.townLinks` section (only when ≥1 published town), sorted by name, HTML-escaped, linking the canonical `/planning/<authority>/<town>` path. Section omitted entirely when there are 0 published towns, so no links to coverage-gated 404s.
- `.townLinks` styles added to `pageStyles()` in `render-shared.mjs`.

**Tests** — extended lockstep guard (`APPLE_APP_ID` + `appStoreUrl()` parity), new `smart-app-banner.test.ts`, and updated render/prerender/snapshot + component tests.

Validation (all green): `npx tsc --noEmit`, `npx eslint .`, `npx vitest run` (894 passed), `npm run build`.

Out of scope (per issue): privacy-policy/legal note (separate api-go change), sibling town↔town links, `app-argument` deep-linking, IndexNow, GSC resubmit.

Closes #633.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple Smart App Banner support across app pages.
  * Planning pages now show links to published towns, making related local pages easier to find.
  * App Store links now include campaign tracking for better destination consistency.

* **Bug Fixes**
  * Planning pages no longer surface links to unavailable towns.
  * Town links are ordered consistently and only appear when relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->