### PR TITLE
feat(ios): "View full details" on map summary sheet opens full application card (tc-1q07)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Detail.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Detail.swift
@@ -1,0 +1,49 @@
+import Foundation
+import TownCrierDomain
+
+/// Application-detail presentation, split out of `AppCoordinator` to keep the
+/// root coordinator under the file-length limit (mirrors the
+/// `AppCoordinator+Onboarding` / `AppCoordinator+WatchZones` split).
+extension AppCoordinator {
+  /// Presents the detail sheet synchronously from a row payload — bypasses the
+  /// per-id fetch so the sheet appears instantly. The detail view model still
+  /// runs `refresh()` in `.task` to keep saved-row snapshots fresh on the
+  /// server (bd tc-sslz, tc-udby). Also used by the map summary sheet's
+  /// "View full details" button (tc-1q07), which already holds the full object.
+  func showApplicationDetail(_ application: PlanningApplication) {
+    detailApplication = application
+  }
+
+  func showApplicationDetail(_ id: PlanningApplicationId) {
+    // Cancel any in-flight detail load so rapid 4× taps from a digest
+    // email card collapse to a single presentation. Without this, multiple
+    // overlapping tasks could each mutate `detailApplication` after their
+    // `await` resumed, causing the sheet to flicker or fail to present
+    // (tc-dt3x).
+    pendingDetailLoad?.cancel()
+    pendingDetailLoad = Task { [weak self] in
+      guard let self else { return }
+      do {
+        let application = try await repository.fetchApplication(by: id)
+        // The cancellation above only cancels the prior `Task`, which has
+        // no effect on `try await` calls that don't check cooperatively.
+        // After the await resumes we must check `Task.isCancelled` so a
+        // superseded fetch does not stomp the latest tap's mutation.
+        guard !Task.isCancelled else { return }
+        detailApplication = application
+      } catch let domainError as DomainError {
+        guard !Task.isCancelled else { return }
+        deepLinkError = domainError
+      } catch {
+        guard !Task.isCancelled else { return }
+        deepLinkError = .unexpected(error.localizedDescription)
+      }
+    }
+  }
+
+  /// Test-only synchronisation: await the most recent
+  /// `showApplicationDetail` fetch. Replaces flaky `Task.sleep` waits.
+  public func waitForPendingDetailLoad() async {
+    await pendingDetailLoad?.value
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -45,7 +45,8 @@ public final class AppCoordinator: ObservableObject {
 
   private static let tierCacheKey = "cachedSubscriptionTier"
 
-  private let repository: PlanningApplicationRepository
+  // Internal (not private) so the AppCoordinator+Detail extension can read it.
+  let repository: PlanningApplicationRepository
   let authService: AuthenticationService
   private let subscriptionService: SubscriptionService
   let userProfileRepository: UserProfileRepository
@@ -162,11 +163,18 @@ public final class AppCoordinator: ObservableObject {
   }
 
   public func makeMapViewModel() -> MapViewModel {
-    MapViewModel(
+    let viewModel = MapViewModel(
       repository: repository,
       watchZoneRepository: watchZoneRepository,
       savedApplicationRepository: savedApplicationRepository
     )
+    // Open the full detail card from the summary sheet's "View full details"
+    // button. Uses the synchronous overload — we already hold the full
+    // `PlanningApplication`, so the sheet presents instantly with no re-fetch.
+    viewModel.onShowApplicationDetail = { [weak self] application in
+      self?.showApplicationDetail(application)
+    }
+    return viewModel
   }
 
   public func makeApplicationListViewModel(
@@ -355,46 +363,5 @@ public final class AppCoordinator: ObservableObject {
   /// UIKit-free; `TownCrierApp` observes the flag and opens the settings URL.
   public func showSystemNotificationSettings() {
     isOpeningSystemNotificationSettings = true
-  }
-
-  /// Presents the detail sheet synchronously from a row payload — bypasses the
-  /// per-id fetch so the sheet appears instantly. The detail view model still
-  /// runs `refresh()` in `.task` to keep saved-row snapshots fresh on the
-  /// server (bd tc-sslz, tc-udby).
-  func showApplicationDetail(_ application: PlanningApplication) {
-    detailApplication = application
-  }
-
-  func showApplicationDetail(_ id: PlanningApplicationId) {
-    // Cancel any in-flight detail load so rapid 4× taps from a digest
-    // email card collapse to a single presentation. Without this, multiple
-    // overlapping tasks could each mutate `detailApplication` after their
-    // `await` resumed, causing the sheet to flicker or fail to present
-    // (tc-dt3x).
-    pendingDetailLoad?.cancel()
-    pendingDetailLoad = Task { [weak self] in
-      guard let self else { return }
-      do {
-        let application = try await repository.fetchApplication(by: id)
-        // The cancellation above only cancels the prior `Task`, which has
-        // no effect on `try await` calls that don't check cooperatively.
-        // After the await resumes we must check `Task.isCancelled` so a
-        // superseded fetch does not stomp the latest tap's mutation.
-        guard !Task.isCancelled else { return }
-        detailApplication = application
-      } catch let domainError as DomainError {
-        guard !Task.isCancelled else { return }
-        deepLinkError = domainError
-      } catch {
-        guard !Task.isCancelled else { return }
-        deepLinkError = .unexpected(error.localizedDescription)
-      }
-    }
-  }
-
-  /// Test-only synchronisation: await the most recent
-  /// `showApplicationDetail` fetch. Replaces flaky `Task.sleep` waits.
-  public func waitForPendingDetailLoad() async {
-    await pendingDetailLoad?.value
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ApplicationSummarySheet.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ApplicationSummarySheet.swift
@@ -41,6 +41,16 @@ struct ApplicationSummarySheet: View {
       Text("Received \(application.receivedDate.formatted(date: .abbreviated, time: .omitted))")
         .font(.system(.caption))
         .foregroundStyle(Color.tcTextTertiary)
+
+      PrimaryButton {
+        viewModel.requestFullDetail()
+      } label: {
+        HStack {
+          Image(systemName: "doc.text.magnifyingglass")
+          Text("View full details")
+        }
+      }
+      .accessibilityLabel("View full details")
     }
     .padding(TCSpacing.medium)
     .frame(maxWidth: .infinity, alignment: .leading)

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
@@ -35,10 +35,12 @@ public struct MapView: View {
       item: Binding(
         get: { viewModel.selectedApplication },
         set: { _ in viewModel.clearSelection() }
-      )
-    ) { application in
-      ApplicationSummarySheet(application: application, viewModel: viewModel)
-    }
+      ),
+      onDismiss: { viewModel.presentPendingDetailIfNeeded() },
+      content: { application in
+        ApplicationSummarySheet(application: application, viewModel: viewModel)
+      }
+    )
   }
 
   @ViewBuilder

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
@@ -13,6 +13,12 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
   @Published private(set) var isLoading = false
   @Published var error: DomainError?
   @Published private(set) var selectedApplication: PlanningApplication?
+  /// The application whose full detail card should open once the summary
+  /// sheet has finished dismissing. Set by ``requestFullDetail()`` and
+  /// consumed by ``presentPendingDetailIfNeeded()`` from the sheet's
+  /// `onDismiss`, which serialises the dismiss-then-present transition and
+  /// avoids SwiftUI's two-sheets-at-once race.
+  @Published private(set) var pendingDetailApplication: PlanningApplication?
   @Published private(set) var hasLoaded = false
   @Published private(set) var zones: [WatchZone] = []
   @Published private(set) var selectedZone: WatchZone?
@@ -54,6 +60,12 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
   }
 
   var onApplicationSelected: ((PlanningApplicationId) -> Void)?
+
+  /// Fired when the user asks to open the full application detail card from the
+  /// summary sheet. The coordinator wires this to its synchronous
+  /// `showApplicationDetail(_ application:)` — we already hold the full
+  /// `PlanningApplication`, so there is no re-fetch.
+  var onShowApplicationDetail: ((PlanningApplication) -> Void)?
 
   public init(
     repository: PlanningApplicationRepository,
@@ -157,6 +169,28 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
 
   public func clearSelection() {
     selectedApplication = nil
+  }
+
+  /// Requests the full detail card for the currently selected application.
+  /// Stashes the selection as `pendingDetailApplication` and clears
+  /// `selectedApplication`, which dismisses the summary sheet. The MapView's
+  /// sheet `onDismiss` then calls ``presentPendingDetailIfNeeded()`` so the
+  /// detail card opens only after the summary has gone — never two sheets at
+  /// once. No-op when nothing is selected.
+  public func requestFullDetail() {
+    guard let selected = selectedApplication else { return }
+    pendingDetailApplication = selected
+    selectedApplication = nil
+  }
+
+  /// Presents any pending detail application via ``onShowApplicationDetail``,
+  /// clearing the pending slot first so it fires exactly once. Invoked from the
+  /// summary sheet's `onDismiss`. No-op when nothing is pending (e.g. the user
+  /// swiped the summary away instead of tapping "View full details").
+  public func presentPendingDetailIfNeeded() {
+    guard let pending = pendingDetailApplication else { return }
+    pendingDetailApplication = nil
+    onShowApplicationDetail?(pending)
   }
 
   /// Toggles the saved state of the currently selected application.

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewModelDetailTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewModelDetailTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+@Suite("MapViewModel Detail Navigation")
+@MainActor
+struct MapViewModelDetailTests {
+  private func makeSUT(
+    applications: [PlanningApplication] = [.pendingReview, .permitted],
+    watchZones: [WatchZone] = [.cambridge]
+  ) -> (MapViewModel, SpyPlanningApplicationRepository, SpyWatchZoneRepository) {
+    let spy = SpyPlanningApplicationRepository()
+    spy.fetchApplicationsResult = .success(applications)
+    let watchZoneSpy = SpyWatchZoneRepository()
+    watchZoneSpy.loadAllResult = .success(watchZones)
+    let vm = MapViewModel(repository: spy, watchZoneRepository: watchZoneSpy)
+    return (vm, spy, watchZoneSpy)
+  }
+
+  @Test func requestFullDetail_stashesSelectionAsPendingAndClearsSelection() async {
+    let (sut, _, _) = makeSUT()
+    await sut.loadApplications()
+    sut.selectApplication(PlanningApplication.pendingReview.id)
+
+    sut.requestFullDetail()
+
+    #expect(sut.pendingDetailApplication?.id == PlanningApplication.pendingReview.id)
+    #expect(sut.selectedApplication == nil)
+  }
+
+  @Test func presentPendingDetailIfNeeded_firesCallbackOnceWithPendingApplication() async {
+    let (sut, _, _) = makeSUT()
+    await sut.loadApplications()
+    sut.selectApplication(PlanningApplication.pendingReview.id)
+    sut.requestFullDetail()
+
+    var captured: [PlanningApplication] = []
+    sut.onShowApplicationDetail = { captured.append($0) }
+
+    sut.presentPendingDetailIfNeeded()
+    sut.presentPendingDetailIfNeeded()
+
+    #expect(captured.count == 1)
+    #expect(captured.first?.id == PlanningApplication.pendingReview.id)
+    #expect(sut.pendingDetailApplication == nil)
+  }
+
+  @Test func requestFullDetail_isNoOp_whenNothingSelected() async {
+    let (sut, _, _) = makeSUT()
+    await sut.loadApplications()
+
+    var captured: [PlanningApplication] = []
+    sut.onShowApplicationDetail = { captured.append($0) }
+
+    sut.requestFullDetail()
+    sut.presentPendingDetailIfNeeded()
+
+    #expect(sut.pendingDetailApplication == nil)
+    #expect(sut.selectedApplication == nil)
+    #expect(captured.isEmpty)
+  }
+}


### PR DESCRIPTION
## Changes

Fixes a navigation dead-end on the map: tapping a pin showed only a read-only summary sheet with no way to reach the full application detail card (and its **View on Council Portal** link). The full card was previously reachable only from list rows.

- **`ApplicationSummarySheet`** — adds a "View full details" `PrimaryButton` that calls `viewModel.requestFullDetail()`.
- **`MapView`** — the summary `.sheet` gains `onDismiss: { viewModel.presentPendingDetailIfNeeded() }`, serialising the dismiss-then-present transition so summary and detail never fight over the same presentation (avoids the SwiftUI two-sheets-at-once race).
- **`MapViewModel`** — new `onShowApplicationDetail` callback + `pendingDetailApplication` stash; `requestFullDetail()` dismisses the summary and stashes the selected app, `presentPendingDetailIfNeeded()` fires the callback once the sheet has dismissed. The dead `onApplicationSelected` is left untouched.
- **`AppCoordinator.makeMapViewModel()`** — wires `onShowApplicationDetail` to the synchronous `showApplicationDetail(_ application:)` (instant, no re-fetch — we already hold the full object), mirroring the list factory's wiring.
- **`AppCoordinator+Detail.swift`** — detail-presentation methods extracted into an extension to stay under the SwiftLint `file_length` limit (mirrors the existing `+Onboarding` / `+WatchZones` splits).

TDD: 3 new Swift Testing cases on `MapViewModel` (stash+clear, fire-once, no-op when nothing selected). Full suite 1354 tests green; SwiftLint `--strict` clean.

Closes tc-1q07.

---
*Auto-shipped via ship skill*