### PR TITLE
fix(api): boundary-agnostic watch-zone matching (notify + browse paths) (#637)

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -48,6 +48,7 @@ var anonymousPatterns = map[string]struct{}{
 	"GET /v1/admin/users":                         {},
 	"POST /v1/admin/offer-codes":                  {},
 	"POST /v1/admin/watchzones/backfill-location": {},
+	"POST /v1/admin/watchzones/backfill-bbox":     {},
 	// The App Store Server Notifications webhook is Apple -> API, not user-facing,
 	// so it is anonymous to Auth0; the signed JWS is its authentication. (The
 	// sibling POST /v1/subscriptions/verify is authed and absent here.)

--- a/api-go/internal/admin/handler.go
+++ b/api-go/internal/admin/handler.go
@@ -59,6 +59,7 @@ func Routes(mux *http.ServeMux, adminKey string, profileStore profileAdminStore,
 	mux.HandleFunc("GET /v1/admin/users", requireAdminKey(adminKey, h.listUsers))
 	mux.HandleFunc("POST /v1/admin/offer-codes", requireAdminKey(adminKey, h.generateOfferCodes))
 	mux.HandleFunc("POST /v1/admin/watchzones/backfill-location", requireAdminKey(adminKey, h.backfillWatchZoneLocation))
+	mux.HandleFunc("POST /v1/admin/watchzones/backfill-bbox", requireAdminKey(adminKey, h.backfillWatchZoneBoundingBox))
 }
 
 func (h *handler) writeJSON(r *http.Request, w http.ResponseWriter, v any) {

--- a/api-go/internal/admin/handler_test.go
+++ b/api-go/internal/admin/handler_test.go
@@ -80,6 +80,10 @@ type fakeBackfiller struct {
 	result watchzones.BackfillResult
 	err    error
 	calls  int
+
+	bboxResult watchzones.BackfillResult
+	bboxErr    error
+	bboxCalls  int
 }
 
 func (f *fakeBackfiller) BackfillLocation(_ context.Context) (watchzones.BackfillResult, error) {
@@ -88,6 +92,14 @@ func (f *fakeBackfiller) BackfillLocation(_ context.Context) (watchzones.Backfil
 		return watchzones.BackfillResult{}, f.err
 	}
 	return f.result, nil
+}
+
+func (f *fakeBackfiller) BackfillBoundingBox(_ context.Context) (watchzones.BackfillResult, error) {
+	f.bboxCalls++
+	if f.bboxErr != nil {
+		return watchzones.BackfillResult{}, f.bboxErr
+	}
+	return f.bboxResult, nil
 }
 
 func newTestHandler(store profileAdminStore, auth0 tierSync, codes offerCodeStore, gen codeGenerator, now time.Time) *handler {
@@ -358,6 +370,60 @@ func TestBackfillWatchZoneLocation_RequiresAdminKey(t *testing.T) {
 	}
 	if backfiller.calls != 0 {
 		t.Errorf("backfiller must not run for an unauthenticated request, calls = %d", backfiller.calls)
+	}
+}
+
+func TestBackfillWatchZoneBoundingBox_ReturnsReconciledCounts(t *testing.T) {
+	t.Parallel()
+
+	backfiller := &fakeBackfiller{bboxResult: watchzones.BackfillResult{Total: 5, Backfilled: 3, AlreadyHad: 2}}
+	h := newTestHandler(&fakeAdminStore{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	h.watchZones = backfiller
+
+	rec := serve(t, h.backfillWatchZoneBoundingBox, http.MethodPost, "/v1/admin/watchzones/backfill-bbox", "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); got != `{"total":5,"backfilled":3,"alreadyHad":2}` {
+		t.Errorf("body = %s", got)
+	}
+	if backfiller.bboxCalls != 1 {
+		t.Errorf("backfiller called %d times, want 1", backfiller.bboxCalls)
+	}
+}
+
+func TestBackfillWatchZoneBoundingBox_StoreErrorIs500(t *testing.T) {
+	t.Parallel()
+
+	h := newTestHandler(&fakeAdminStore{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	h.watchZones = &fakeBackfiller{bboxErr: errors.New("scan boom")}
+
+	rec := serve(t, h.backfillWatchZoneBoundingBox, http.MethodPost, "/v1/admin/watchzones/backfill-bbox", "")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+// TestBackfillWatchZoneBoundingBox_RequiresAdminKey locks the X-Admin-Key gate on
+// the route, mirroring the gate on the other admin endpoints: a request with no
+// key gets a bodyless 401 and never reaches the backfiller.
+func TestBackfillWatchZoneBoundingBox_RequiresAdminKey(t *testing.T) {
+	t.Parallel()
+
+	backfiller := &fakeBackfiller{}
+	h := newTestHandler(&fakeAdminStore{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	h.watchZones = backfiller
+	gated := requireAdminKey("secret", h.backfillWatchZoneBoundingBox)
+
+	rec := serve(t, gated, http.MethodPost, "/v1/admin/watchzones/backfill-bbox", "")
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401 with no admin key", rec.Code)
+	}
+	if backfiller.bboxCalls != 0 {
+		t.Errorf("backfiller must not run for an unauthenticated request, calls = %d", backfiller.bboxCalls)
 	}
 }
 

--- a/api-go/internal/admin/watchzones.go
+++ b/api-go/internal/admin/watchzones.go
@@ -8,10 +8,12 @@ import (
 )
 
 // watchZoneBackfiller is the consumer-side view of the watch-zone store the
-// backfill endpoint needs: a single one-shot rewrite of every document missing a
-// GeoJSON location. watchzones.CosmosStore satisfies it.
+// backfill endpoints need: one-shot rewrites of every document missing a derived
+// field — a GeoJSON location, or a bounding box. watchzones.CosmosStore satisfies
+// it.
 type watchZoneBackfiller interface {
 	BackfillLocation(ctx context.Context) (watchzones.BackfillResult, error)
+	BackfillBoundingBox(ctx context.Context) (watchzones.BackfillResult, error)
 }
 
 // backfillResponse is the response shape for the backfill endpoint:
@@ -31,6 +33,21 @@ func (h *handler) backfillWatchZoneLocation(w http.ResponseWriter, r *http.Reque
 	res, err := h.watchZones.BackfillLocation(r.Context())
 	if err != nil {
 		h.serverError(w, r, "backfill watch zone location", err)
+		return
+	}
+	h.writeJSON(r, w, backfillResponse{Total: res.Total, Backfilled: res.Backfilled, AlreadyHad: res.AlreadyHad})
+}
+
+// backfillWatchZoneBoundingBox implements POST /v1/admin/watchzones/backfill-bbox:
+// a guarded, idempotent one-shot that rewrites every WatchZone document predating
+// the bounding-box write path so it carries minLat/maxLat/minLon/maxLon (tc-b179 /
+// #637), recomputed from the zone's centre + radius. The request body is ignored;
+// the reconciled counts are returned as JSON. It runs independently of (and may
+// run after) the location backfill.
+func (h *handler) backfillWatchZoneBoundingBox(w http.ResponseWriter, r *http.Request) {
+	res, err := h.watchZones.BackfillBoundingBox(r.Context())
+	if err != nil {
+		h.serverError(w, r, "backfill watch zone bounding box", err)
 		return
 	}
 	h.writeJSON(r, w, backfillResponse{Total: res.Total, Backfilled: res.Backfilled, AlreadyHad: res.AlreadyHad})

--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -10,16 +10,19 @@ import (
 )
 
 // CosmosItems is the consumer-side slice of the Applications container the store
-// uses: a single-partition point read, an upsert, and single-partition queries.
-// QueryItems carries the tight 1.5s OLTP per-attempt budget for user-facing
-// reads; QueryItemsLongRead carries a longer per-attempt budget for the
-// latency-tolerant build-time SEO reads over a LARGE authority partition
-// (tc-9tov). platform.CosmosContainer satisfies it structurally.
+// uses: a single-partition point read, an upsert, single-partition queries, and
+// a cross-partition spatial fan-out. QueryItems carries the tight 1.5s OLTP
+// per-attempt budget for user-facing reads; QueryItemsLongRead carries a longer
+// per-attempt budget for the latency-tolerant build-time SEO reads over a LARGE
+// authority partition (tc-9tov); QueryItemsCrossPartition backs the
+// authority-agnostic nearby fan-out (tc-zldl). platform.CosmosContainer
+// satisfies it structurally.
 type CosmosItems interface {
 	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
 	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
 	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
 	QueryItemsLongRead(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
+	QueryItemsCrossPartition(ctx context.Context, query string, params map[string]any) ([][]byte, error)
 }
 
 // CosmosStore reads and writes planning applications in the Applications
@@ -183,35 +186,44 @@ func (s *CosmosStore) BreakdownByAuthority(ctx context.Context, authorityCode st
 	return out, nil
 }
 
-// findNearbyQuery is the single-partition ST_DISTANCE spatial query for nearby
-// applications. Coordinates and radius are bound as named parameters (mirroring
+// findNearbyQuery is the constant-radius ST_DISTANCE spatial query for nearby
+// applications. The radius is the query's constant, so the Applications
+// /location spatial index serves it directly — cross-partition included.
+// Coordinates and radius are bound as named parameters (mirroring
 // findZonesContainingQuery in the watchzones package) — no float literals are
 // concatenated into the query text.
 const findNearbyQuery = "SELECT * FROM c WHERE ST_DISTANCE(c.location, " +
 	`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres`
 
 // FindNearby returns every application within radiusMetres of (latitude,
-// longitude) inside the authorityCode partition, via a single-partition
-// ST_DISTANCE spatial query against the GeoJSON location. Coordinates and
-// radius are bound as named parameters (not string-concatenated) to eliminate
-// float-formatting edge cases and to mirror the parameterized style of the
-// sibling watchzones.FindZonesContaining query. The query is scoped to the
-// authorityCode logical partition, so it never fans out cross-partition.
-func (s *CosmosStore) FindNearby(ctx context.Context, authorityCode string, latitude, longitude, radiusMetres float64) ([]PlanningApplication, error) {
+// longitude) via a constant-radius ST_DISTANCE spatial query against the GeoJSON
+// location. Coordinates and radius are bound as named parameters (not
+// string-concatenated) to eliminate float-formatting edge cases and to mirror
+// the parameterized style of the sibling watchzones.FindZonesContaining query.
+//
+// This is a deliberate CROSS-PARTITION spatial fan-out: it is no longer scoped
+// to one authorityCode partition, so a watch zone whose circle crosses an
+// authority boundary surfaces in-circle applications on BOTH sides (tc-zldl /
+// tc-w11n). It is user-initiated and low-frequency (zone create / zone open),
+// strictly colder than the already-cross-partition notify path, so the fan-out
+// RU is acceptable at current scale. The constant radius lets the /location
+// spatial index serve the ST_DISTANCE residual exactly, so circle semantics
+// stay exact even across partitions.
+func (s *CosmosStore) FindNearby(ctx context.Context, latitude, longitude, radiusMetres float64) ([]PlanningApplication, error) {
 	params := map[string]any{
 		"@latitude":     latitude,
 		"@longitude":    longitude,
 		"@radiusMetres": radiusMetres,
 	}
-	raws, err := s.items.QueryItems(ctx, authorityCode, findNearbyQuery, params)
+	raws, err := s.items.QueryItemsCrossPartition(ctx, findNearbyQuery, params)
 	if err != nil {
-		return nil, fmt.Errorf("find applications near %q: %w", authorityCode, err)
+		return nil, fmt.Errorf("find applications near (%v, %v): %w", latitude, longitude, err)
 	}
 	apps := make([]PlanningApplication, 0, len(raws))
 	for _, raw := range raws {
 		var doc applicationDocument
 		if err := json.Unmarshal(raw, &doc); err != nil {
-			return nil, fmt.Errorf("decode nearby application in %q: %w", authorityCode, err)
+			return nil, fmt.Errorf("decode nearby application near (%v, %v): %w", latitude, longitude, err)
 		}
 		apps = append(apps, doc.toDomain())
 	}

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -940,11 +940,16 @@ func TestCosmosStore_FindNearby_KeepsOLTPBudget(t *testing.T) {
 	items := newFakeItems()
 	store := NewCosmosStore(items)
 
-	if _, err := store.FindNearby(context.Background(), "441", 51.4975, -0.1357, 2000); err != nil {
+	if _, err := store.FindNearby(context.Background(), 51.4975, -0.1357, 2000); err != nil {
 		t.Fatalf("FindNearby: %v", err)
 	}
+	// FindNearby is a user-facing read: it fans out cross-partition but must never
+	// route through the latency-tolerant build-time SEO budget (QueryItemsLongRead).
+	if items.lastCrossPartitionQuery == "" {
+		t.Error("FindNearby must run the cross-partition spatial query")
+	}
 	if items.lastQueryViaLongRead {
-		t.Error("FindNearby is a user-facing read and must keep the 1.5s OLTP QueryItems budget")
+		t.Error("FindNearby is a user-facing read and must not use the build-time long-read budget")
 	}
 }
 

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -29,6 +29,13 @@ type fakeItems struct {
 	// OLTP QueryItems. The build-time SEO reads must use the long-read path; the
 	// user-facing reads must not (tc-9tov).
 	lastQueryViaLongRead bool
+	// crossPartitionResult, lastCrossPartitionQuery, lastCrossPartitionParams and
+	// crossPartitionErr back QueryItemsCrossPartition, the authority-agnostic
+	// spatial fan-out FindNearby now uses (tc-zldl).
+	crossPartitionResult     [][]byte
+	lastCrossPartitionQuery  string
+	lastCrossPartitionParams map[string]any
+	crossPartitionErr        error
 }
 
 func newFakeItems() *fakeItems { return &fakeItems{stored: map[string][]byte{}} }
@@ -60,6 +67,15 @@ func (f *fakeItems) QueryItems(_ context.Context, partitionKey, query string, pa
 func (f *fakeItems) QueryItemsLongRead(_ context.Context, partitionKey, query string, params map[string]any) ([][]byte, error) {
 	f.lastQueryViaLongRead = true
 	return f.recordQuery(partitionKey, query, params)
+}
+
+func (f *fakeItems) QueryItemsCrossPartition(_ context.Context, query string, params map[string]any) ([][]byte, error) {
+	f.lastCrossPartitionQuery = query
+	f.lastCrossPartitionParams = params
+	if f.crossPartitionErr != nil {
+		return nil, f.crossPartitionErr
+	}
+	return f.crossPartitionResult, nil
 }
 
 func (f *fakeItems) recordQuery(partitionKey, query string, params map[string]any) ([][]byte, error) {
@@ -176,30 +192,46 @@ func TestCosmosStore_GetByUID_NotFound(t *testing.T) {
 	}
 }
 
-func TestCosmosStore_FindNearby_ScopesToAuthorityPartitionWithSpatialQuery(t *testing.T) {
+func TestCosmosStore_FindNearby_QueriesCrossPartitionAcrossAuthorities(t *testing.T) {
 	t.Parallel()
-	a := testApplication(t)
-	body, _ := json.Marshal(newApplicationDocument(a))
+	// A border-spanning circle: two in-radius applications tagged to different
+	// authority partitions (449 + 246). The cross-partition fan-out must surface
+	// BOTH, not just the home authority's side (tc-zldl / tc-w11n).
+	app449 := testApplication(t)
+	app449.AreaID = 449
+	app449.Name = "449/24/001"
+	app246 := testApplication(t)
+	app246.AreaID = 246
+	app246.Name = "246/24/002"
+	body449, _ := json.Marshal(newApplicationDocument(app449))
+	body246, _ := json.Marshal(newApplicationDocument(app246))
 	items := newFakeItems()
-	items.queryResult = [][]byte{body}
+	items.crossPartitionResult = [][]byte{body449, body246}
 	store := NewCosmosStore(items)
 
-	got, err := store.FindNearby(context.Background(), "441", 51.4975, -0.1357, 2000)
+	got, err := store.FindNearby(context.Background(), 51.4975, -0.1357, 2000)
 	if err != nil {
 		t.Fatalf("FindNearby: %v", err)
 	}
-	if len(got) != 1 || got[0].Name != a.Name {
-		t.Fatalf("FindNearby results: got %+v", got)
+	if len(got) != 2 {
+		t.Fatalf("FindNearby results: got %d, want 2 (both authorities); %+v", len(got), got)
 	}
-	if items.lastQueryPK != "441" {
-		t.Errorf("query partition key: got %q, want \"441\"", items.lastQueryPK)
+	gotAreas := map[int]bool{got[0].AreaID: true, got[1].AreaID: true}
+	if !gotAreas[449] || !gotAreas[246] {
+		t.Errorf("FindNearby must surface both authorities 449 and 246; got %+v", gotAreas)
 	}
-	// The GeoJSON point carries [longitude, latitude] (GeoJSON order) and the
-	// radius is a named parameter, mirroring findZonesContainingQuery style.
+	// The fan-out must run cross-partition, NOT through the partition-scoped
+	// QueryItems (which would re-impose single-authority scoping).
+	if items.lastQueryPK != "" {
+		t.Errorf("FindNearby must not run a partition-scoped query; got partition key %q", items.lastQueryPK)
+	}
+	// The constant-radius residual is preserved: ST_DISTANCE(...) <= @radiusMetres
+	// serves the exact circle, with the radius bound as the query's constant. The
+	// GeoJSON point carries [longitude, latitude] order.
 	want := "SELECT * FROM c WHERE ST_DISTANCE(c.location, " +
 		`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres`
-	if items.lastQuery != want {
-		t.Errorf("spatial query:\n got %q\nwant %q", items.lastQuery, want)
+	if items.lastCrossPartitionQuery != want {
+		t.Errorf("cross-partition spatial query:\n got %q\nwant %q", items.lastCrossPartitionQuery, want)
 	}
 }
 
@@ -208,16 +240,16 @@ func TestFindNearby_UsesParameterizedQuery(t *testing.T) {
 	items := newFakeItems()
 	store := NewCosmosStore(items)
 
-	_, _ = store.FindNearby(context.Background(), "441", 51.4975, -0.1357, 2000)
+	_, _ = store.FindNearby(context.Background(), 51.4975, -0.1357, 2000)
 
 	// The query text must not contain any float literal — values must be bound
 	// as named parameters, not string-concatenated.
-	if items.lastQuery == "" {
+	if items.lastCrossPartitionQuery == "" {
 		t.Fatal("no query was issued")
 	}
 	for _, literal := range []string{"51.4975", "-0.1357", "2000"} {
-		if strings.Contains(items.lastQuery, literal) {
-			t.Errorf("query contains float literal %q — should be a named parameter; query: %s", literal, items.lastQuery)
+		if strings.Contains(items.lastCrossPartitionQuery, literal) {
+			t.Errorf("query contains float literal %q — should be a named parameter; query: %s", literal, items.lastCrossPartitionQuery)
 		}
 	}
 	// Verify the three expected params are bound with correct values.
@@ -227,9 +259,9 @@ func TestFindNearby_UsesParameterizedQuery(t *testing.T) {
 		"@radiusMetres": 2000.0,
 	}
 	for k, wantVal := range wantParams {
-		gotVal, ok := items.lastQueryParams[k]
+		gotVal, ok := items.lastCrossPartitionParams[k]
 		if !ok {
-			t.Errorf("param %q not found in query params %v", k, items.lastQueryParams)
+			t.Errorf("param %q not found in query params %v", k, items.lastCrossPartitionParams)
 			continue
 		}
 		if gotVal != wantVal {
@@ -242,7 +274,7 @@ func TestCosmosStore_FindNearby_EmptyResultIsEmptySlice(t *testing.T) {
 	t.Parallel()
 	store := NewCosmosStore(newFakeItems())
 
-	got, err := store.FindNearby(context.Background(), "441", 51.4975, -0.1357, 2000)
+	got, err := store.FindNearby(context.Background(), 51.4975, -0.1357, 2000)
 	if err != nil {
 		t.Fatalf("FindNearby: %v", err)
 	}

--- a/api-go/internal/demoaccount/handler.go
+++ b/api-go/internal/demoaccount/handler.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
@@ -41,10 +40,10 @@ type zoneStore interface {
 }
 
 // appStore seeds the demo applications and runs the spatial lookup that backs
-// the response.
+// the response. FindNearby is authority-agnostic and cross-partition (tc-zldl).
 type appStore interface {
 	Upsert(ctx context.Context, a applications.PlanningApplication) error
-	FindNearby(ctx context.Context, authorityCode string, latitude, longitude, radiusMetres float64) ([]applications.PlanningApplication, error)
+	FindNearby(ctx context.Context, latitude, longitude, radiusMetres float64) ([]applications.PlanningApplication, error)
 }
 
 // handler serves GET /v1/demo-account.
@@ -82,8 +81,7 @@ func (h *handler) getDemoAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	authorityCode := strconv.Itoa(seedAuthorityID)
-	apps, err := h.apps.FindNearby(ctx, authorityCode, demoLatitude, demoLongitude, demoRadiusMetres)
+	apps, err := h.apps.FindNearby(ctx, demoLatitude, demoLongitude, demoRadiusMetres)
 	if err != nil {
 		serverError(w, r, h.logger, "find nearby demo applications", err)
 		return

--- a/api-go/internal/demoaccount/handler_test.go
+++ b/api-go/internal/demoaccount/handler_test.go
@@ -57,11 +57,11 @@ func (f *fakeZoneStore) Save(_ context.Context, z watchzones.WatchZone) error {
 }
 
 type fakeAppStore struct {
-	upserted  []applications.PlanningApplication
-	nearby    []applications.PlanningApplication
-	upsertErr error
-	findErr   error
-	findPK    string
+	upserted   []applications.PlanningApplication
+	nearby     []applications.PlanningApplication
+	upsertErr  error
+	findErr    error
+	findCalled bool
 }
 
 func (f *fakeAppStore) Upsert(_ context.Context, a applications.PlanningApplication) error {
@@ -72,8 +72,8 @@ func (f *fakeAppStore) Upsert(_ context.Context, a applications.PlanningApplicat
 	return nil
 }
 
-func (f *fakeAppStore) FindNearby(_ context.Context, authorityCode string, _, _, _ float64) ([]applications.PlanningApplication, error) {
-	f.findPK = authorityCode
+func (f *fakeAppStore) FindNearby(_ context.Context, _, _, _ float64) ([]applications.PlanningApplication, error) {
+	f.findCalled = true
 	if f.findErr != nil {
 		return nil, f.findErr
 	}
@@ -121,8 +121,10 @@ func TestGetDemoAccount_FirstCall_SeedsAndReturnsDemoAccount(t *testing.T) {
 	if len(a.upserted) != 5 {
 		t.Errorf("seeded applications: got %d, want 5", len(a.upserted))
 	}
-	if a.findPK != "441" {
-		t.Errorf("FindNearby authority partition: got %q, want \"441\"", a.findPK)
+	// FindNearby now runs cross-partition (no authority partition key), so we
+	// assert it ran and returned the seeded apps rather than a partition key.
+	if !a.findCalled {
+		t.Error("FindNearby must run to populate the demo applications")
 	}
 
 	var got demoAccountResult
@@ -173,8 +175,8 @@ func TestGetDemoAccount_SecondCall_DoesNotReseed(t *testing.T) {
 	if len(a.upserted) != 0 {
 		t.Errorf("expected no application re-seed, got %d", len(a.upserted))
 	}
-	if a.findPK != "441" {
-		t.Errorf("FindNearby still runs: authority got %q, want \"441\"", a.findPK)
+	if !a.findCalled {
+		t.Error("FindNearby must still run on a repeat call")
 	}
 }
 

--- a/api-go/internal/notifydispatch/decision.go
+++ b/api-go/internal/notifydispatch/decision.go
@@ -11,10 +11,12 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
-// zoneMatcher runs the cross-partition point-in-zone lookup, scoped to the
-// polled application's authority. *watchzones.CosmosStore satisfies it.
+// zoneMatcher runs the cross-partition point-in-zone lookup. It is purely
+// geographic — boundary-agnostic, with no authority scoping (tc-b179), so a zone
+// matches a containing application regardless of either's authority.
+// *watchzones.CosmosStore satisfies it.
 type zoneMatcher interface {
-	FindZonesContaining(ctx context.Context, authorityID int, latitude, longitude float64) ([]watchzones.WatchZone, error)
+	FindZonesContaining(ctx context.Context, latitude, longitude float64) ([]watchzones.WatchZone, error)
 }
 
 // savedMatcher runs the cross-partition saved-bookmark lookup.
@@ -96,7 +98,7 @@ func (d *DecisionDispatcher) Dispatch(ctx context.Context, app applications.Plan
 
 	// Zone matchers — only meaningful when the application has coordinates.
 	if app.Latitude != nil && app.Longitude != nil {
-		zones, err := d.zones.FindZonesContaining(ctx, app.AreaID, *app.Latitude, *app.Longitude)
+		zones, err := d.zones.FindZonesContaining(ctx, *app.Latitude, *app.Longitude)
 		if err != nil {
 			return err
 		}

--- a/api-go/internal/notifydispatch/decision_test.go
+++ b/api-go/internal/notifydispatch/decision_test.go
@@ -12,17 +12,17 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
-// fakeZones serves the cross-partition zone-containment lookup.
+// fakeZones serves the cross-partition zone-containment lookup. Matching is
+// purely geographic (tc-b179): the lookup no longer takes an authority, so the
+// fake returns its zones regardless of which authority the app is tagged with.
 type fakeZones struct {
-	zones           []watchzones.WatchZone
-	queryErr        error
-	lastAuthorityID int
-	lastLat         float64
-	lastLng         float64
+	zones    []watchzones.WatchZone
+	queryErr error
+	lastLat  float64
+	lastLng  float64
 }
 
-func (f *fakeZones) FindZonesContaining(_ context.Context, authorityID int, lat, lng float64) ([]watchzones.WatchZone, error) {
-	f.lastAuthorityID = authorityID
+func (f *fakeZones) FindZonesContaining(_ context.Context, lat, lng float64) ([]watchzones.WatchZone, error) {
 	f.lastLat = lat
 	f.lastLng = lng
 	if f.queryErr != nil {
@@ -130,21 +130,33 @@ func TestDecisionDispatcher_ZoneMatch_CreatesDecisionRecordAndPushes(t *testing.
 	}
 }
 
-func TestDecisionDispatcher_Dispatch_PassesApplicationAuthorityToZoneMatcher(t *testing.T) {
+func TestDecisionDispatcher_Dispatch_MatchesZoneRegardlessOfAuthority(t *testing.T) {
 	t.Parallel()
-	// The decision zone fan-out must scope to the polled application's authority,
-	// matching the saved-bookmark path's existing app.AreaID scoping. No zones or
-	// saved holders are configured, so this isolates the authority threading.
-	zones := &fakeZones{}
-	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{}}
-	d, _, _ := newDecisionHarness(t, zones, &fakeSaved{}, profs)
+	// Decision fan-out is now boundary-agnostic (tc-b179): the zone lookup is purely
+	// geographic, so a zone whose circle contains the application is matched even
+	// when the application is tagged a neighbouring authority. The fake returns the
+	// zone for the app's coordinates; the dispatcher must dispatch to its owner.
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	profs := &fakeProfiles{byID: map[string]*profiles.UserProfile{
+		"auth0|alice": proWithZonePrefs(t, true),
+	}}
+	d, notifs, _ := newDecisionHarness(t, zones, &fakeSaved{}, profs)
+	// App tagged a different authority (246) than the zone (99), inside the circle.
 	app := decisionApp(t, "Permitted", coord(51.5), coord(-0.1))
+	app.AreaID = 246
 
 	if err := d.Dispatch(context.Background(), app); err != nil {
 		t.Fatalf("Dispatch: %v", err)
 	}
-	if zones.lastAuthorityID != app.AreaID {
-		t.Errorf("zone matcher authority: got %d, want %d (app.AreaID)", zones.lastAuthorityID, app.AreaID)
+	if zones.lastLat != 51.5 || zones.lastLng != -0.1 {
+		t.Errorf("zone lookup point: got lat=%v lng=%v", zones.lastLat, zones.lastLng)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("cross-authority zone must still receive a decision record, got %d", len(notifs.created))
+	}
+	if notifs.created[0].WatchZoneID == nil || *notifs.created[0].WatchZoneID != "zone-1" {
+		t.Errorf("wrong zone fanned out: %+v", notifs.created[0].WatchZoneID)
 	}
 }
 

--- a/api-go/internal/notifydispatch/enqueuer.go
+++ b/api-go/internal/notifydispatch/enqueuer.go
@@ -139,7 +139,7 @@ func (e *Enqueuer) EnqueueForApplication(ctx context.Context, app applications.P
 	if app.Latitude == nil || app.Longitude == nil {
 		return nil
 	}
-	zones, err := e.zones.FindZonesContaining(ctx, app.AreaID, *app.Latitude, *app.Longitude)
+	zones, err := e.zones.FindZonesContaining(ctx, *app.Latitude, *app.Longitude)
 	if err != nil {
 		return err
 	}

--- a/api-go/internal/notifydispatch/enqueuer_test.go
+++ b/api-go/internal/notifydispatch/enqueuer_test.go
@@ -204,20 +204,64 @@ func TestEnqueuer_EnqueueForApplication_FansOutToContainingZones(t *testing.T) {
 	}
 }
 
-func TestEnqueuer_EnqueueForApplication_PassesApplicationAuthorityToZoneMatcher(t *testing.T) {
+func TestEnqueuer_EnqueueForApplication_MatchesCrossBorderNeighbourAuthorityZone(t *testing.T) {
 	t.Parallel()
-	// The new-application zone fan-out must scope to the polled application's
-	// authority: a WatchZone is authority-scoped, so the matcher is asked only for
-	// zones in the application's authority (app.AreaID), mirroring the
-	// saved-bookmark path's existing app.AreaID scoping.
-	enq, _, _, fz := newEnqueuerHarnessWithZones(t, profiles.TierPro, &fakeZones{})
-	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC))
+	// Boundary-agnostic matching (tc-b179 / tc-w11n): a zone pinned to authority 449
+	// (Adur & Worthing) must receive a NewApplication for an in-circle application
+	// tagged authority 246 (Arun) on the other side of the border. The store no
+	// longer scopes the lookup by authority, so the fake returns the 449 zone for
+	// the 246 app. The CreatedAt.After(LastDifferent) skip rule is UNCHANGED: a
+	// second 449 zone created after the application last changed is still skipped.
+	lastDifferent := time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC)
+	eligible, err := watchzones.NewWatchZone("zone-449", "auth0|alice", "Border", 50.81, -0.42, 2000, 449,
+		time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), true, true)
+	if err != nil {
+		t.Fatalf("NewWatchZone eligible: %v", err)
+	}
+	tooNew, err := watchzones.NewWatchZone("zone-449-new", "auth0|alice", "Border New", 50.81, -0.42, 2000, 449,
+		time.Date(2026, 6, 14, 0, 0, 0, 0, time.UTC), true, true)
+	if err != nil {
+		t.Fatalf("NewWatchZone tooNew: %v", err)
+	}
+	zones := &fakeZones{zones: []watchzones.WatchZone{eligible, tooNew}}
+	enq, notifs, _, fz := newEnqueuerHarnessWithZones(t, profiles.TierPro, zones)
+
+	// The application is tagged the NEIGHBOUR authority (246), not the zone's (449).
+	la, lo := 50.815, -0.41
+	state := "Pending"
+	app := applications.PlanningApplication{
+		Name: "AR/0007", UID: "AR/0007", AreaName: "Arun", AreaID: 246,
+		AppState: &state, Latitude: &la, Longitude: &lo, LastDifferent: lastDifferent,
+	}
 
 	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
 		t.Fatalf("EnqueueForApplication: %v", err)
 	}
-	if fz.lastAuthorityID != app.AreaID {
-		t.Errorf("zone matcher authority: got %d, want %d (app.AreaID)", fz.lastAuthorityID, app.AreaID)
+	if fz.lastLat != la || fz.lastLng != lo {
+		t.Errorf("zone lookup point: got lat=%v lng=%v, want %v %v", fz.lastLat, fz.lastLng, la, lo)
+	}
+	if len(notifs.created) != 1 {
+		t.Fatalf("border-spanning app must enqueue for the neighbour-authority zone exactly once, got %d", len(notifs.created))
+	}
+	if notifs.created[0].WatchZoneID == nil || *notifs.created[0].WatchZoneID != "zone-449" {
+		t.Errorf("wrong zone fanned out (the post-LastDifferent zone must be skipped): %+v", notifs.created[0].WatchZoneID)
+	}
+}
+
+func TestEnqueuer_EnqueueForApplication_NonBorderZoneMatchesUnchanged(t *testing.T) {
+	t.Parallel()
+	// Regression: a zone that does NOT cross a boundary (same authority as the app)
+	// still matches exactly as before the authority prune was removed — one record.
+	zone := testZoneAt(t, "zone-1", "auth0|alice", time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)) // authority 99
+	zones := &fakeZones{zones: []watchzones.WatchZone{zone}}
+	enq, notifs, _, _ := newEnqueuerHarnessWithZones(t, profiles.TierPro, zones)
+	app := testApplication(t, time.Date(2026, 6, 13, 8, 0, 0, 0, time.UTC)) // authority 99
+
+	if err := enq.EnqueueForApplication(context.Background(), app); err != nil {
+		t.Fatalf("EnqueueForApplication: %v", err)
+	}
+	if len(notifs.created) != 1 {
+		t.Errorf("same-authority zone must still match exactly once, got %d", len(notifs.created))
 	}
 }
 

--- a/api-go/internal/watchzones/document.go
+++ b/api-go/internal/watchzones/document.go
@@ -40,6 +40,23 @@ type watchZoneDocument struct {
 	// so an absent location stays nil rather than serialising an empty Point.
 	Location *geoJSONPoint `json:"location"`
 
+	// minLat/maxLat/minLon/maxLon are the axis-aligned bounding box of the zone's
+	// circle (centre offset by radius, longitude scaled by cos(latitude)). They are
+	// the index-served prune the notify-path containment query (store_cosmos.go)
+	// runs before the exact ST_DISTANCE residual, replacing the dropped authority
+	// equality so matching is boundary-agnostic (tc-b179 / tc-w11n). Like Location
+	// they are ADDITIVE and *float64: a legacy document written before this field
+	// decodes them as nil — that nil is the "needs backfill" signal the one-shot
+	// CLI backfill (slice 3) keys on, and the transitional query's
+	// NOT IS_DEFINED(c.minLat) fallback matches such zones via the residual alone
+	// until the backfill runs. toDomain does NOT read them (the domain recomputes
+	// the box); newWatchZoneDocument recomputes them wholesale on every write, so a
+	// radius/centre change is covered for free (Save always re-encodes here).
+	MinLat *float64 `json:"minLat"`
+	MaxLat *float64 `json:"maxLat"`
+	MinLon *float64 `json:"minLon"`
+	MaxLon *float64 `json:"maxLon"`
+
 	// createdAt must serialise with a numeric UTC offset ("+00:00"), never Go's
 	// RFC 3339 "Z" — platform.DotNetTime handles that. Nullable so a legacy
 	// document missing it hydrates to the zero instant (time.Time{}).
@@ -59,6 +76,7 @@ func newWatchZoneDocument(z WatchZone) watchZoneDocument {
 	createdAt := platform.DotNetTime(z.CreatedAt)
 	push := z.PushEnabled
 	email := z.EmailInstantEnabled
+	minLat, maxLat, minLon, maxLon := z.boundingBox()
 	return watchZoneDocument{
 		ID:                  z.ID,
 		UserID:              z.UserID,
@@ -68,6 +86,10 @@ func newWatchZoneDocument(z WatchZone) watchZoneDocument {
 		RadiusMetres:        z.RadiusMetres,
 		AuthorityID:         z.AuthorityID,
 		Location:            newGeoPoint(z.Longitude, z.Latitude),
+		MinLat:              &minLat,
+		MaxLat:              &maxLat,
+		MinLon:              &minLon,
+		MaxLon:              &maxLon,
 		CreatedAt:           &createdAt,
 		PushEnabled:         &push,
 		EmailInstantEnabled: &email,

--- a/api-go/internal/watchzones/document_test.go
+++ b/api-go/internal/watchzones/document_test.go
@@ -82,6 +82,72 @@ func TestWatchZoneDocument_WritesGeoJSONLocation(t *testing.T) {
 	}
 }
 
+func TestWatchZoneDocument_WritesBoundingBox(t *testing.T) {
+	t.Parallel()
+	z := testZone(t)
+
+	raw, err := json.Marshal(newWatchZoneDocument(z))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	body := string(raw)
+
+	for _, key := range []string{`"minLat":`, `"maxLat":`, `"minLon":`, `"maxLon":`} {
+		if !strings.Contains(body, key) {
+			t.Errorf("missing bounding-box key %s in %s", key, body)
+		}
+	}
+
+	// The persisted box must equal the domain-computed box: a freshly written zone
+	// always carries the bbox so the notify-path prune can use it without a backfill.
+	wantMinLat, wantMaxLat, wantMinLon, wantMaxLon := z.boundingBox()
+	var doc watchZoneDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	for _, c := range []struct {
+		name string
+		got  *float64
+		want float64
+	}{
+		{"minLat", doc.MinLat, wantMinLat},
+		{"maxLat", doc.MaxLat, wantMaxLat},
+		{"minLon", doc.MinLon, wantMinLon},
+		{"maxLon", doc.MaxLon, wantMaxLon},
+	} {
+		if c.got == nil {
+			t.Errorf("%s must be written, got nil", c.name)
+			continue
+		}
+		if *c.got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, *c.got, c.want)
+		}
+	}
+}
+
+func TestWatchZoneDocument_LegacyMissingBoundingBoxDecodesNil(t *testing.T) {
+	t.Parallel()
+	// A document written before the bounding box existed omits minLat/maxLat/
+	// minLon/maxLon. They are *float64 so they decode to nil rather than 0 — that
+	// nil is the "needs backfill" signal the slice-3 CLI backfill keys on, and the
+	// transitional query's NOT IS_DEFINED(c.minLat) fallback matches such zones via
+	// the ST_DISTANCE residual until the backfill runs.
+	raw := `{"id":"z1","userId":"u1","name":"Home","latitude":51.5074,"longitude":-0.1278,"radiusMetres":1000,"authorityId":471,"createdAt":"2026-06-01T09:00:00+00:00"}`
+	var doc watchZoneDocument
+	if err := json.Unmarshal([]byte(raw), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if doc.MinLat != nil || doc.MaxLat != nil || doc.MinLon != nil || doc.MaxLon != nil {
+		t.Errorf("legacy doc must decode the bounding box as nil: %+v %+v %+v %+v",
+			doc.MinLat, doc.MaxLat, doc.MinLon, doc.MaxLon)
+	}
+	// Hydration must still succeed — the bbox is not read by toDomain (the domain
+	// recomputes it from centre + radius).
+	if _, err := doc.toDomain(); err != nil {
+		t.Fatalf("toDomain on a legacy bbox-less doc: %v", err)
+	}
+}
+
 func TestWatchZoneDocument_HydratesWithAndWithoutLocation(t *testing.T) {
 	t.Parallel()
 	// location is additive: hydration reads the latitude/longitude float columns,

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -9,7 +9,6 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -47,10 +46,11 @@ type authorityResolver interface {
 }
 
 // appFinder runs the spatial lookup that backs both the create response's nearby
-// applications and the per-zone applications list. *applications.CosmosStore
-// satisfies it.
+// applications and the per-zone applications list. It is authority-agnostic and
+// cross-partition, so a border-spanning zone surfaces neighbour-authority apps
+// (tc-zldl). *applications.CosmosStore satisfies it.
 type appFinder interface {
-	FindNearby(ctx context.Context, authorityCode string, latitude, longitude, radiusMetres float64) ([]applications.PlanningApplication, error)
+	FindNearby(ctx context.Context, latitude, longitude, radiusMetres float64) ([]applications.PlanningApplication, error)
 }
 
 // watermarkReader reads the caller's notification read-watermark. A nil return
@@ -228,7 +228,7 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	nearby, err := h.apps.FindNearby(
-		r.Context(), strconv.Itoa(authorityID), req.Latitude, req.Longitude, req.RadiusMetres)
+		r.Context(), req.Latitude, req.Longitude, req.RadiusMetres)
 	if err != nil {
 		h.serverError(w, r, "find nearby applications", err)
 		return
@@ -269,7 +269,7 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 	}
 
 	apps, err := h.apps.FindNearby(
-		r.Context(), strconv.Itoa(zone.AuthorityID), zone.Latitude, zone.Longitude, zone.RadiusMetres)
+		r.Context(), zone.Latitude, zone.Longitude, zone.RadiusMetres)
 	if err != nil {
 		h.serverError(w, r, "find applications in zone", err)
 		return

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -42,11 +42,11 @@ func (f *fakeResolver) ResolveAuthority(_ context.Context, _, _ float64) (int, e
 type fakeAppFinder struct {
 	apps   []applications.PlanningApplication
 	err    error
-	lastPK string
+	called bool
 }
 
-func (f *fakeAppFinder) FindNearby(_ context.Context, authorityCode string, _, _, _ float64) ([]applications.PlanningApplication, error) {
-	f.lastPK = authorityCode
+func (f *fakeAppFinder) FindNearby(_ context.Context, _, _, _ float64) ([]applications.PlanningApplication, error) {
+	f.called = true
 	return f.apps, f.err
 }
 
@@ -129,15 +129,31 @@ func testApp(uid, name string) applications.PlanningApplication {
 	}
 }
 
+// testAppInAuthority builds a nearby application tagged to a specific authority,
+// for asserting the browse path surfaces neighbour-authority apps across a
+// border (tc-zldl).
+func testAppInAuthority(uid, name string, areaID int) applications.PlanningApplication {
+	a := testApp(uid, name)
+	a.AreaID = areaID
+	a.AreaName = fmt.Sprintf("Authority %d", areaID)
+	return a
+}
+
 func TestCreate_PersistsZoneAndReturnsNearbyApplications(t *testing.T) {
 	t.Parallel()
+	// A border-spanning zone (pinned to authority 471) whose circle also covers a
+	// neighbour authority (246). The browse path is now authority-agnostic, so the
+	// create response must surface the neighbour's app too (tc-zldl).
 	d := nearbyDeps{
 		store:    &fakeZoneStore{},
 		profiles: &fakeProfileReader{profile: proProfile(t)},
 		resolver: &fakeResolver{},
-		apps:     &fakeAppFinder{apps: []applications.PlanningApplication{testApp("uid-1", "24/001")}},
-		state:    &fakeWatermark{},
-		unread:   &fakeUnread{},
+		apps: &fakeAppFinder{apps: []applications.PlanningApplication{
+			testAppInAuthority("uid-1", "24/001", 471),
+			testAppInAuthority("uid-2", "24/002", 246),
+		}},
+		state:  &fakeWatermark{},
+		unread: &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
 
@@ -159,8 +175,8 @@ func TestCreate_PersistsZoneAndReturnsNearbyApplications(t *testing.T) {
 	if d.resolver.called {
 		t.Error("resolver must not run when authorityId is supplied")
 	}
-	if d.apps.lastPK != "471" {
-		t.Errorf("FindNearby authority partition: got %q", d.apps.lastPK)
+	if !d.apps.called {
+		t.Error("FindNearby must run to populate the create response")
 	}
 	var got struct {
 		NearbyApplications []struct {
@@ -171,8 +187,12 @@ func TestCreate_PersistsZoneAndReturnsNearbyApplications(t *testing.T) {
 	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
 		t.Fatalf("decode: %v; raw=%s", err, rec.Body.String())
 	}
-	if len(got.NearbyApplications) != 1 || got.NearbyApplications[0].UID != "uid-1" {
-		t.Fatalf("nearbyApplications: got %+v", got.NearbyApplications)
+	gotUIDs := map[string]bool{}
+	for _, a := range got.NearbyApplications {
+		gotUIDs[a.UID] = true
+	}
+	if len(got.NearbyApplications) != 2 || !gotUIDs["uid-1"] || !gotUIDs["uid-2"] {
+		t.Fatalf("nearbyApplications must surface both home and neighbour authority apps: got %+v", got.NearbyApplications)
 	}
 	// The create response carries the raw-domain shape — no latestUnreadEvent key.
 	if got.NearbyApplications[0].LatestUnreadEvent != nil {
@@ -402,6 +422,43 @@ func TestApplications_AugmentsUnreadAndNullsTheRest(t *testing.T) {
 	}
 	if rows[byUID["uid-2"]].LatestUnreadEvent != nil {
 		t.Errorf("uid-2 should have null latestUnreadEvent")
+	}
+}
+
+func TestApplications_SurfacesNeighbourAuthorityApps(t *testing.T) {
+	t.Parallel()
+	// A zone pinned to authority 471 whose circle crosses into authority 246. The
+	// applications list is now authority-agnostic, so both sides must appear
+	// (tc-zldl / tc-w11n).
+	d := nearbyDeps{
+		store: &fakeZoneStore{zones: []WatchZone{mustZone(t, "zone-1", 471)}},
+		apps: &fakeAppFinder{apps: []applications.PlanningApplication{
+			testAppInAuthority("uid-1", "24/001", 471),
+			testAppInAuthority("uid-2", "24/002", 246),
+		}},
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		state:    &fakeWatermark{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var rows []struct {
+		UID string `json:"uid"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("decode rows: %v; raw=%s", err, rec.Body.String())
+	}
+	gotUIDs := map[string]bool{}
+	for _, r := range rows {
+		gotUIDs[r.UID] = true
+	}
+	if len(rows) != 2 || !gotUIDs["uid-1"] || !gotUIDs["uid-2"] {
+		t.Fatalf("applications list must surface both home and neighbour authority apps: got %+v", rows)
 	}
 }
 

--- a/api-go/internal/watchzones/store_cosmos.go
+++ b/api-go/internal/watchzones/store_cosmos.go
@@ -172,52 +172,68 @@ func (s *CosmosStore) DistinctAuthorityIDs(ctx context.Context) ([]int, error) {
 	return ids, nil
 }
 
-// findZonesContainingQuery selects every watch zone scoped to the candidate
-// application's authority whose circle (centre + radius) contains the candidate
-// point, across all partitions. The authority equality predicate is evaluated by
-// Cosmos's default range index, pruning rows before the ST_DISTANCE test runs —
-// a WatchZone is authority-scoped (see zone.go), so a zone only ever matches
-// applications in its own authority, mirroring the saved-bookmark path's
-// app.AreaID scoping (notifydispatch/decision.go). The candidate authority and
-// point are bound as parameters.
+// findZonesContainingQuery selects every watch zone (across all users) whose
+// circle (centre + radius) contains the candidate point, across all partitions.
+// Matching is purely geographic — there is NO authority scoping (tc-b179 /
+// tc-w11n): a WatchZone's circle can straddle a local-authority boundary, so a
+// zone pinned to one authority must match an application tagged a neighbouring
+// authority when the application falls inside the circle. The dropped authority
+// equality (which silently lost the neighbour's side) is replaced by an
+// index-served bounding-box prune.
 //
-// The distance test is a single index-served clause: ST_DISTANCE(c.location,
-// @point) <= c.radiusMetres, served by the spatial index on the persisted GeoJSON
-// /location path (tc-quqe), so Cosmos fully uses the index rather than a full
-// scan. The legacy NOT IS_DEFINED(c.location) fallback — which distanced against
-// an inline [c.longitude, c.latitude] point for zones written before the location
-// backfill — was removed (tc-ltlw / Phase 2d) once both environments were fully
-// backfilled (tc-xj48) and the write path (#618) guaranteed every new zone
-// carries c.location, so no zone can lack it and the fallback was dead weight.
+// The candidate prune is the bounding-box BETWEEN test on minLat/maxLat,
+// minLon/maxLon — the axis-aligned box that circumscribes the circle, stored per
+// zone (document.go) and range-indexed for free under the WatchZones /* indexing
+// policy. It replaces the authority equality as the cheap predicate that thins
+// the candidate set before the spatial residual, so the per-app candidate set
+// stays as small as the authority prune kept it (no RU regression).
+//
+// The exact circle test stays as the ST_DISTANCE residual:
+// ST_DISTANCE(c.location, @point) <= c.radiusMetres, served by the spatial index
+// on the persisted GeoJSON /location path (tc-quqe). The bbox is only a coarse
+// prune (a box corner can lie outside the circle), so the residual, ANDed after
+// the prune, preserves exact circle semantics — a 2.0 km zone still excludes a
+// point at 2.1 km that slips inside a box corner.
+//
+// NOT IS_DEFINED(c.minLat) is a TRANSITIONAL fallback: a legacy zone written
+// before the bbox existed has no minLat, so the BETWEEN prune cannot match it.
+// Keeping such a zone in the candidate set lets the exact ST_DISTANCE residual
+// still match it, instead of silently dropping ALL its matches in the window
+// between this deploy and the slice-3 one-shot backfill. It mirrors how tc-qbq4
+// kept a NOT IS_DEFINED(c.location) fallback that tc-ltlw later removed; this
+// branch is likewise removable in a follow-up once both environments are
+// bbox-backfilled.
 //
 // All coordinates are GeoJSON order: [longitude, latitude], not [lat, lng].
 //
 // The projection is deliberate, not SELECT *: only the columns this hot path
 // needs are hydrated. id/userId/createdAt are consumed by the callers;
-// name/radiusMetres/authorityId are required by the NewWatchZone constructor so
-// the hydrated zone stays valid; pushEnabled/emailInstantEnabled are projected
-// (not dropped) because they are nullable *bool that coalesce to true when
-// absent, so omitting them would silently re-enable a user's disabled
-// notifications if a future caller read them. latitude/longitude are omitted from
-// the projection — no caller reads zone coordinates after the match, and the
-// distance test now reads only the indexed c.location, not the raw columns.
+// name/radiusMetres are required by the NewWatchZone constructor so the hydrated
+// zone stays valid; authorityId stays in the projection as metadata (the
+// constructor still reads it) even though it is gone from the WHERE clause;
+// pushEnabled/emailInstantEnabled are projected (not dropped) because they are
+// nullable *bool that coalesce to true when absent, so omitting them would
+// silently re-enable a user's disabled notifications if a future caller read
+// them. latitude/longitude are omitted — no caller reads zone coordinates after
+// the match, and the distance test reads only the indexed c.location.
 const findZonesContainingQuery = "SELECT c.id, c.userId, c.name, c.radiusMetres, c.authorityId, c.createdAt, c.pushEnabled, c.emailInstantEnabled " +
-	"FROM c WHERE c.authorityId = @authorityId AND " +
-	"ST_DISTANCE(c.location, {'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres"
+	"FROM c WHERE (NOT IS_DEFINED(c.minLat) " +
+	"OR (@latitude BETWEEN c.minLat AND c.maxLat AND @longitude BETWEEN c.minLon AND c.maxLon)) " +
+	"AND ST_DISTANCE(c.location, {'type': 'Point', 'coordinates': [@longitude, @latitude]}) <= c.radiusMetres"
 
-// FindZonesContaining returns every watch zone (across all users) scoped to the
-// given authority whose circle contains the point (latitude, longitude), via a
-// cross-partition query that pre-filters on the authority (index-served) before
-// the ST_DISTANCE test against each zone's centre and radius. It backs the
-// poll-path notification fan-out and decision-event dispatch (epic tc-wad3, bead
-// tc-uc2p); authorityID is the polled application's authority (app.AreaID). This
-// is a deliberate cross-partition scan — a polled application's coordinates must
-// be matched against every user's zones in that authority.
-func (s *CosmosStore) FindZonesContaining(ctx context.Context, authorityID int, latitude, longitude float64) ([]WatchZone, error) {
+// FindZonesContaining returns every watch zone (across all users) whose circle
+// contains the point (latitude, longitude), via a cross-partition query that
+// prunes candidates on the index-served bounding box before the exact
+// ST_DISTANCE test against each zone's centre and radius. It backs the poll-path
+// notification fan-out and decision-event dispatch (epic tc-wad3, bead tc-uc2p).
+// Matching is purely geographic across all partitions — it is NOT scoped to an
+// authority (tc-b179), so a polled application's coordinates are matched against
+// every user's zones regardless of which authority either is tagged with. This
+// is a deliberate cross-partition scan.
+func (s *CosmosStore) FindZonesContaining(ctx context.Context, latitude, longitude float64) ([]WatchZone, error) {
 	raws, err := s.items.QueryItemsCrossPartition(ctx, findZonesContainingQuery, map[string]any{
-		"@authorityId": authorityID,
-		"@latitude":    latitude,
-		"@longitude":   longitude,
+		"@latitude":  latitude,
+		"@longitude": longitude,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("find zones containing point: %w", err)

--- a/api-go/internal/watchzones/store_cosmos_backfill.go
+++ b/api-go/internal/watchzones/store_cosmos_backfill.go
@@ -63,3 +63,49 @@ func (s *CosmosStore) BackfillLocation(ctx context.Context) (BackfillResult, err
 	}
 	return res, nil
 }
+
+// BackfillBoundingBox rewrites every WatchZone document that predates the
+// bounding-box write path (tc-b179 / #637) so it carries minLat/maxLat/minLon/
+// maxLon, the index-served prune the notify-path containment query runs before
+// its exact ST_DISTANCE residual (replacing the dropped authority equality so
+// matching is boundary-agnostic). It is a guarded, idempotent one-shot: a
+// document that already has a bounding box is skipped, so a second run rewrites
+// nothing. The four bbox fields are written together by newWatchZoneDocument, so
+// checking minLat alone is sufficient to detect a backfilled document. The box is
+// never carried over — Save re-encodes the document via newWatchZoneDocument,
+// which recomputes the box from the zone's persisted centre + radius via
+// WatchZone.boundingBox.
+//
+// It runs independently of the location backfill (BackfillLocation): a document
+// may already carry a /location yet still lack a bounding box, so this can run
+// after, and is safe to run after, the location backfill.
+func (s *CosmosStore) BackfillBoundingBox(ctx context.Context) (BackfillResult, error) {
+	raws, err := s.items.QueryItemsCrossPartition(ctx, backfillScanQuery, nil)
+	if err != nil {
+		return BackfillResult{}, fmt.Errorf("scan watch zones for backfill: %w", err)
+	}
+
+	var res BackfillResult
+	for _, raw := range raws {
+		res.Total++
+
+		var doc watchZoneDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return BackfillResult{}, fmt.Errorf("decode watch zone for backfill: %w", err)
+		}
+		if doc.MinLat != nil {
+			res.AlreadyHad++
+			continue
+		}
+
+		zone, err := doc.toDomain()
+		if err != nil {
+			return BackfillResult{}, fmt.Errorf("hydrate watch zone %q for backfill: %w", doc.ID, err)
+		}
+		if err := s.Save(ctx, zone); err != nil {
+			return BackfillResult{}, fmt.Errorf("rewrite watch zone %q with bounding box: %w", doc.ID, err)
+		}
+		res.Backfilled++
+	}
+	return res, nil
+}

--- a/api-go/internal/watchzones/store_cosmos_backfill_test.go
+++ b/api-go/internal/watchzones/store_cosmos_backfill_test.go
@@ -1,0 +1,131 @@
+package watchzones
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+// legacyDocWithoutBoundingBox builds a document that predates the bounding-box
+// write path (tc-b179): it may already carry a GeoJSON location (a doc that was
+// only location-backfilled), but it has no minLat/maxLat/minLon/maxLon, which is
+// exactly the "needs bbox backfill" signal BackfillBoundingBox keys on.
+func legacyDocWithoutBoundingBox(id, userID string, lat, lon, radius float64, authorityID int) []byte {
+	return []byte(fmt.Sprintf(
+		`{"id":%q,"userId":%q,"name":"Legacy","latitude":%g,"longitude":%g,"radiusMetres":%g,"authorityId":%d,"location":{"type":"Point","coordinates":[%g,%g]},"createdAt":"2026-06-01T09:00:00+00:00","pushEnabled":true,"emailInstantEnabled":true}`,
+		id, userID, lat, lon, radius, authorityID, lon, lat))
+}
+
+func TestCosmosStore_BackfillBoundingBox_RewritesOnlyDocsMissingBoundingBox(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	// One legacy doc lacks a bounding box (location-only, predating tc-b179); two
+	// modern docs already carry it (written via newWatchZoneDocument, which always
+	// computes the bbox). The scan is cross-partition.
+	modernA := testZone(t)
+	modernA.ID, modernA.UserID = "modern-a", "auth0|a"
+	modernB := testZone(t)
+	modernB.ID, modernB.UserID = "modern-b", "auth0|b"
+	items.crossPartitionResult = [][]byte{
+		mustDocBytes(t, modernA),
+		legacyDocWithoutBoundingBox("legacy-1", "auth0|legacy", 53.4808, -2.2426, 750, 471),
+		mustDocBytes(t, modernB),
+	}
+	store := NewCosmosStore(items)
+
+	res, err := store.BackfillBoundingBox(context.Background())
+	if err != nil {
+		t.Fatalf("BackfillBoundingBox: %v", err)
+	}
+
+	if res.Total != 3 || res.AlreadyHad != 2 || res.Backfilled != 1 {
+		t.Fatalf("result = %+v, want {Total:3 Backfilled:1 AlreadyHad:2}", res)
+	}
+	// Exactly one upsert: the legacy doc only. The two modern docs are skipped.
+	if len(items.upserts) != 1 {
+		t.Fatalf("upserts = %d, want exactly 1 (the legacy doc)", len(items.upserts))
+	}
+	if items.lastUpsertPK != "auth0|legacy" {
+		t.Errorf("upsert partition key = %q, want auth0|legacy", items.lastUpsertPK)
+	}
+
+	var doc watchZoneDocument
+	if err := json.Unmarshal(items.upserts[0], &doc); err != nil {
+		t.Fatalf("unmarshal upserted doc: %v", err)
+	}
+	// The rewritten doc now carries a bounding box derived from its centre+radius,
+	// matching what boundingBox() computes for the same zone.
+	wantMinLat, wantMaxLat, wantMinLon, wantMaxLon := boundingBoxFor(t, 53.4808, -2.2426, 750, 471)
+	if doc.MinLat == nil || doc.MaxLat == nil || doc.MinLon == nil || doc.MaxLon == nil {
+		t.Fatalf("upserted doc must carry a bounding box, got %+v", doc)
+	}
+	if *doc.MinLat != wantMinLat || *doc.MaxLat != wantMaxLat || *doc.MinLon != wantMinLon || *doc.MaxLon != wantMaxLon {
+		t.Errorf("bbox = [%g,%g,%g,%g], want [%g,%g,%g,%g]",
+			*doc.MinLat, *doc.MaxLat, *doc.MinLon, *doc.MaxLon, wantMinLat, wantMaxLat, wantMinLon, wantMaxLon)
+	}
+	// The legacy doc's other fields survive the rewrite.
+	if doc.ID != "legacy-1" || doc.UserID != "auth0|legacy" || doc.RadiusMetres != 750 || doc.AuthorityID != 471 {
+		t.Errorf("legacy fields not preserved: %+v", doc)
+	}
+}
+
+func TestCosmosStore_BackfillBoundingBox_Idempotent(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	// Every doc already carries a bounding box (the steady state after a first run).
+	a := testZone(t)
+	a.ID, a.UserID = "z-a", "auth0|a"
+	b := testZone(t)
+	b.ID, b.UserID = "z-b", "auth0|b"
+	items.crossPartitionResult = [][]byte{mustDocBytes(t, a), mustDocBytes(t, b)}
+	store := NewCosmosStore(items)
+
+	res, err := store.BackfillBoundingBox(context.Background())
+	if err != nil {
+		t.Fatalf("BackfillBoundingBox: %v", err)
+	}
+	if res.Total != 2 || res.AlreadyHad != 2 || res.Backfilled != 0 {
+		t.Fatalf("result = %+v, want {Total:2 Backfilled:0 AlreadyHad:2}", res)
+	}
+	if len(items.upserts) != 0 {
+		t.Errorf("a re-run must write nothing, got %d upserts", len(items.upserts))
+	}
+}
+
+func TestCosmosStore_BackfillBoundingBox_QueryError(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	items.queryErr = errors.New("gateway boom")
+	store := NewCosmosStore(items)
+
+	if _, err := store.BackfillBoundingBox(context.Background()); err == nil {
+		t.Fatal("expected an error when the cross-partition scan fails")
+	}
+}
+
+func TestCosmosStore_BackfillBoundingBox_EmptyContainerIsZeroResult(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+	res, err := store.BackfillBoundingBox(context.Background())
+	if err != nil {
+		t.Fatalf("BackfillBoundingBox: %v", err)
+	}
+	if res.Total != 0 || res.Backfilled != 0 || res.AlreadyHad != 0 {
+		t.Errorf("result = %+v, want zero", res)
+	}
+}
+
+// boundingBoxFor computes the expected bounding box for a zone's centre+radius
+// via the same domain helper the write path uses, so the test asserts against
+// the production formula rather than a hand-copied literal.
+func boundingBoxFor(t *testing.T, lat, lon, radius float64, authorityID int) (minLat, maxLat, minLon, maxLon float64) {
+	t.Helper()
+	z, err := NewWatchZone("bbox", "u", "Box", lat, lon, radius, authorityID,
+		testZone(t).CreatedAt, true, true)
+	if err != nil {
+		t.Fatalf("NewWatchZone: %v", err)
+	}
+	return z.boundingBox()
+}

--- a/api-go/internal/watchzones/store_cosmos_test.go
+++ b/api-go/internal/watchzones/store_cosmos_test.go
@@ -309,15 +309,15 @@ func TestCosmosStore_FindZonesContaining_CrossPartitionSpatialQuery(t *testing.T
 	items.crossPartitionResult = [][]byte{mustDocBytes(t, z)}
 	store := NewCosmosStore(items)
 
-	zones, err := store.FindZonesContaining(context.Background(), z.AuthorityID, 51.5155, -0.0931)
+	zones, err := store.FindZonesContaining(context.Background(), 51.5155, -0.0931)
 	if err != nil {
 		t.Fatalf("FindZonesContaining: %v", err)
 	}
 	if len(zones) != 1 || zones[0].ID != z.ID {
 		t.Fatalf("zones: got %+v", zones)
 	}
-	// The point-in-circle predicate is an ST_DISTANCE against the zone radius,
-	// run cross-partition (every user's zones).
+	// The point-in-circle predicate keeps an exact ST_DISTANCE against the zone
+	// radius, run cross-partition (every user's zones) regardless of authority.
 	if !strings.Contains(items.lastQuery, "ST_DISTANCE") {
 		t.Errorf("query missing ST_DISTANCE: %q", items.lastQuery)
 	}
@@ -327,64 +327,80 @@ func TestCosmosStore_FindZonesContaining_CrossPartitionSpatialQuery(t *testing.T
 	if items.lastParams["@latitude"] != 51.5155 || items.lastParams["@longitude"] != -0.0931 {
 		t.Errorf("spatial params: got lat=%v lng=%v", items.lastParams["@latitude"], items.lastParams["@longitude"])
 	}
+	// Authority is no longer bound — matching is purely geographic (tc-b179).
+	if _, ok := items.lastParams["@authorityId"]; ok {
+		t.Errorf("authority must not be a query param any more: %v", items.lastParams)
+	}
 }
 
-func TestCosmosStore_FindZonesContaining_FiltersByAuthorityBeforeDistance(t *testing.T) {
+func TestCosmosStore_FindZonesContaining_DropsAuthorityScopeBboxPrunes(t *testing.T) {
 	t.Parallel()
 	items := newFakeItems()
 	store := NewCosmosStore(items)
 
-	// An application in authority 99 must match ONLY zones scoped to authority 99.
-	// The store sends Cosmos an equality predicate on c.authorityId bound to the
-	// application's authority alongside the ST_DISTANCE test, so a zone scoped to a
-	// different authority is never returned even when the application falls
-	// geographically within the zone's radius. This is the documented
-	// authority-scoped zone model (zone.go) and mirrors the saved-bookmark path's
-	// existing app.AreaID scoping. Cosmos evaluates the predicate; this test locks
-	// that the predicate is present and bound to the passed authority.
-	if _, err := store.FindZonesContaining(context.Background(), 99, 51.5, -0.1); err != nil {
+	// Matching is now boundary-agnostic (tc-b179 / tc-w11n): the authority equality
+	// prune is gone and replaced by an index-served bounding-box BETWEEN prune
+	// (minLat/maxLat, minLon/maxLon), so a zone pinned to authority B matches an app
+	// tagged authority A when the app falls inside the zone's circle. The bbox is
+	// range-indexed for free under the WatchZones /* indexing policy, so the
+	// candidate prune stays index-served — no full-container scan.
+	if _, err := store.FindZonesContaining(context.Background(), 51.5, -0.1); err != nil {
 		t.Fatalf("FindZonesContaining: %v", err)
 	}
-	if !strings.Contains(items.lastQuery, "c.authorityId = @authorityId") {
-		t.Errorf("query must filter on c.authorityId = @authorityId: %q", items.lastQuery)
+	if strings.Contains(items.lastQuery, "c.authorityId = @authorityId") {
+		t.Errorf("query must NOT scope by authority any more: %q", items.lastQuery)
 	}
-	if items.lastParams["@authorityId"] != 99 {
-		t.Errorf("@authorityId param: got %v, want 99", items.lastParams["@authorityId"])
-	}
-	// The authority equality must be ANDed with the distance test, not replace it.
-	if !strings.Contains(items.lastQuery, "ST_DISTANCE") || !strings.Contains(items.lastQuery, "c.radiusMetres") {
-		t.Errorf("query must keep the ST_DISTANCE radius test alongside the authority filter: %q", items.lastQuery)
+	for _, pred := range []string{
+		"@latitude BETWEEN c.minLat AND c.maxLat",
+		"@longitude BETWEEN c.minLon AND c.maxLon",
+	} {
+		if !strings.Contains(items.lastQuery, pred) {
+			t.Errorf("query missing bbox prune %q: %q", pred, items.lastQuery)
+		}
 	}
 }
 
-func TestCosmosStore_FindZonesContaining_PureIndexServedQuery(t *testing.T) {
+func TestCosmosStore_FindZonesContaining_TransitionalLegacyFallback(t *testing.T) {
 	t.Parallel()
 	items := newFakeItems()
 	store := NewCosmosStore(items)
 
-	if _, err := store.FindZonesContaining(context.Background(), 99, 51.5, -0.1); err != nil {
+	if _, err := store.FindZonesContaining(context.Background(), 51.5, -0.1); err != nil {
 		t.Fatalf("FindZonesContaining: %v", err)
 	}
-	// The distance test is now a single index-served clause: ST_DISTANCE against
-	// the persisted GeoJSON c.location path, served by the spatial index on
-	// /location (tc-quqe). This is the perf win — Cosmos fully uses the index.
+	// Transitional fallback: a legacy zone written before the bbox existed has no
+	// minLat, so the BETWEEN prune cannot match it. NOT IS_DEFINED(c.minLat) keeps
+	// such a zone in the candidate set so the exact ST_DISTANCE residual still
+	// matches it, instead of silently dropping ALL its matches in the window between
+	// deploy and the slice-3 backfill. Removable in a follow-up once both envs are
+	// bbox-backfilled — mirrors the tc-qbq4 → tc-ltlw NOT IS_DEFINED(c.location)
+	// fallback.
+	if !strings.Contains(items.lastQuery, "NOT IS_DEFINED(c.minLat)") {
+		t.Errorf("query must keep the transitional NOT IS_DEFINED(c.minLat) fallback: %q", items.lastQuery)
+	}
+}
+
+func TestCosmosStore_FindZonesContaining_KeepsExactDistanceResidual(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if _, err := store.FindZonesContaining(context.Background(), 51.5, -0.1); err != nil {
+		t.Fatalf("FindZonesContaining: %v", err)
+	}
+	// The bbox is only a coarse prune — a square circumscribing the circle, so a
+	// point in a box corner can be outside the circle. The exact ST_DISTANCE
+	// residual, ANDed after the prune, preserves precise circle semantics: a 2.0 km
+	// zone still excludes a point at 2.1 km that slips inside the box corner. The
+	// residual distances against the indexed c.location GeoJSON path (tc-quqe).
 	if !strings.Contains(items.lastQuery, "ST_DISTANCE(c.location,") {
 		t.Errorf("query must distance against the indexed c.location path: %q", items.lastQuery)
 	}
-	// The legacy fallback is gone (tc-ltlw / Phase 2d): both environments are fully
-	// backfilled (tc-xj48) and the write path (#618) guarantees every new zone
-	// carries c.location, so no zone can lack it. The NOT IS_DEFINED guard and the
-	// inline [c.longitude, c.latitude] read are removed so the query is pure and the
-	// index serves it without a residual full-scan clause.
-	if strings.Contains(items.lastQuery, "NOT IS_DEFINED") {
-		t.Errorf("query must not retain the removed NOT IS_DEFINED fallback: %q", items.lastQuery)
+	if !strings.Contains(items.lastQuery, "<= c.radiusMetres") {
+		t.Errorf("query must keep the exact radius residual: %q", items.lastQuery)
 	}
-	if strings.Contains(items.lastQuery, "[c.longitude, c.latitude]") {
-		t.Errorf("query must not retain the removed inline [c.longitude, c.latitude] legacy point: %q", items.lastQuery)
-	}
-	// The authority pre-filter (tc-8dud) survives the simplification.
-	if !strings.Contains(items.lastQuery, "c.authorityId = @authorityId") {
-		t.Errorf("query must keep the authority pre-filter: %q", items.lastQuery)
+	if !strings.Contains(items.lastQuery, "AND ST_DISTANCE") {
+		t.Errorf("residual must be ANDed after the bbox prune: %q", items.lastQuery)
 	}
 }
 
@@ -393,18 +409,19 @@ func TestCosmosStore_FindZonesContaining_ProjectsNeededFieldsNotSelectStar(t *te
 	items := newFakeItems()
 	store := NewCosmosStore(items)
 
-	if _, err := store.FindZonesContaining(context.Background(), 99, 51.5, -0.1); err != nil {
+	if _, err := store.FindZonesContaining(context.Background(), 51.5, -0.1); err != nil {
 		t.Fatalf("FindZonesContaining: %v", err)
 	}
 	// SELECT * hydrates whole docs on every cross-partition fan-out row. The query
 	// instead projects only the columns this path needs: id/userId/createdAt are
-	// consumed by the callers; name/radiusMetres/authorityId are required by the
-	// NewWatchZone constructor so the hydrated zone stays valid; pushEnabled and
+	// consumed by the callers; name/radiusMetres are required by the NewWatchZone
+	// constructor so the hydrated zone stays valid; pushEnabled and
 	// emailInstantEnabled are KEPT (not dropped) because they are nullable *bool
 	// that coalesce to true when absent — projecting them away would silently
 	// re-enable a user's disabled notifications if a future caller read them.
-	// latitude/longitude are dropped: no caller reads zone coordinates after the
-	// match (the distance test already ran server-side).
+	// authorityId STAYS in the projection as metadata (the constructor still reads
+	// it) even though it is gone from the WHERE clause. latitude/longitude are
+	// dropped: no caller reads zone coordinates after the match.
 	if strings.Contains(items.lastQuery, "SELECT *") {
 		t.Errorf("query must not SELECT * on the poll hot path: %q", items.lastQuery)
 	}
@@ -426,7 +443,7 @@ func TestCosmosStore_FindZonesContaining_HydratesProjectedDocument(t *testing.T)
 	items.crossPartitionResult = [][]byte{[]byte(`{"id":"zone-9","userId":"auth0|carol","name":"Z","radiusMetres":500,"authorityId":99,"createdAt":"2026-06-01T09:00:00+00:00","pushEnabled":false,"emailInstantEnabled":false}`)}
 	store := NewCosmosStore(items)
 
-	zones, err := store.FindZonesContaining(context.Background(), 99, 51.5, -0.1)
+	zones, err := store.FindZonesContaining(context.Background(), 51.5, -0.1)
 	if err != nil {
 		t.Fatalf("FindZonesContaining: %v", err)
 	}
@@ -448,7 +465,7 @@ func TestCosmosStore_FindZonesContaining_HydratesProjectedDocument(t *testing.T)
 func TestCosmosStore_FindZonesContaining_EmptyResultIsEmptySlice(t *testing.T) {
 	t.Parallel()
 	store := NewCosmosStore(newFakeItems())
-	zones, err := store.FindZonesContaining(context.Background(), 99, 51.5, -0.1)
+	zones, err := store.FindZonesContaining(context.Background(), 51.5, -0.1)
 	if err != nil {
 		t.Fatalf("FindZonesContaining: %v", err)
 	}

--- a/api-go/internal/watchzones/zone.go
+++ b/api-go/internal/watchzones/zone.go
@@ -12,6 +12,7 @@ package watchzones
 
 import (
 	"errors"
+	"math"
 	"strings"
 	"time"
 )
@@ -64,6 +65,25 @@ func NewWatchZone(id, userID, name string, latitude, longitude, radiusMetres flo
 		PushEnabled:         pushEnabled,
 		EmailInstantEnabled: emailInstantEnabled,
 	}, nil
+}
+
+// metresPerDegreeLat is the approximate number of metres in one degree of
+// latitude. It is treated as a constant: the meridional variation is sub-1% and
+// irrelevant to a coarse bounding-box prune. One degree of longitude shrinks by
+// cos(latitude), so the east-west offset is scaled by it.
+const metresPerDegreeLat = 111320
+
+// boundingBox returns the axis-aligned latitude/longitude box that circumscribes
+// the zone's circle, derived from the centre and radius. It is the index-served
+// prune for the notify-path containment query (store_cosmos.go): a candidate
+// point outside the box cannot be inside the circle, and the exact ST_DISTANCE
+// residual rejects the box corners that fall outside the circle. UK-only — no
+// antimeridian or pole wrap is needed.
+func (z WatchZone) boundingBox() (minLat, maxLat, minLon, maxLon float64) {
+	dLat := z.RadiusMetres / metresPerDegreeLat
+	latRadians := z.Latitude * math.Pi / 180
+	dLon := z.RadiusMetres / (metresPerDegreeLat * math.Cos(latRadians))
+	return z.Latitude - dLat, z.Latitude + dLat, z.Longitude - dLon, z.Longitude + dLon
 }
 
 // ZoneUpdate is a partial PATCH: a nil field leaves the existing value untouched.

--- a/api-go/internal/watchzones/zone_test.go
+++ b/api-go/internal/watchzones/zone_test.go
@@ -18,6 +18,46 @@ func testZone(t *testing.T) WatchZone {
 	return z
 }
 
+func TestWatchZone_BoundingBox(t *testing.T) {
+	t.Parallel()
+	// A 1 km zone centred on central London. The bounding box is the centre offset
+	// by the radius converted to degrees: latitude is a constant scale, longitude
+	// is scaled by cos(latitude), so at 51.5° the east-west span is wider than the
+	// north-south span. Expected values precomputed from the documented formula:
+	//   dLat = 1000 / 111320                      = 0.0089831
+	//   dLon = 1000 / (111320 * cos(51.5074°))    = 0.0144328
+	z, err := NewWatchZone("z1", "u1", "Home", 51.5074, -0.1278, 1000, 471,
+		time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC), true, true)
+	if err != nil {
+		t.Fatalf("NewWatchZone: %v", err)
+	}
+	minLat, maxLat, minLon, maxLon := z.boundingBox()
+
+	const tol = 1e-4
+	for _, c := range []struct {
+		name string
+		got  float64
+		want float64
+	}{
+		{"minLat", minLat, 51.4984169},
+		{"maxLat", maxLat, 51.5163831},
+		{"minLon", minLon, -0.1422328},
+		{"maxLon", maxLon, -0.1133672},
+	} {
+		if diff := c.got - c.want; diff > tol || diff < -tol {
+			t.Errorf("%s: got %v, want %v (±%v)", c.name, c.got, c.want, tol)
+		}
+	}
+	// The box must be symmetric about the centre and the longitude span wider than
+	// the latitude span at UK latitudes (cos(lat) < 1).
+	if maxLat-z.Latitude <= 0 || (maxLat-z.Latitude)-(z.Latitude-minLat) > tol {
+		t.Errorf("latitude box not symmetric about centre: [%v,%v] centre %v", minLat, maxLat, z.Latitude)
+	}
+	if (maxLon - minLon) <= (maxLat - minLat) {
+		t.Errorf("longitude span must exceed latitude span at UK latitudes: lon=%v lat=%v", maxLon-minLon, maxLat-minLat)
+	}
+}
+
 func TestNewWatchZone_Validation(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)

--- a/cli/internal/tc/app.go
+++ b/cli/internal/tc/app.go
@@ -18,6 +18,7 @@ Commands:
   grant-subscription          Grant or change a user's subscription tier
   list-users                  List users with email, ID, and subscription tier
   backfill-watchzone-location One-shot: add a GeoJSON location to legacy watch zones
+  backfill-watchzone-bbox     One-shot: add a bounding box to legacy watch zones
   help                        Show this help message
   version                     Print version
 
@@ -76,6 +77,8 @@ func Run(ctx context.Context, env Env, rawArgs []string) int {
 		return runListUsers(ctx, client, env, args)
 	case "backfill-watchzone-location":
 		return runBackfillWatchZoneLocation(ctx, client, env, args)
+	case "backfill-watchzone-bbox":
+		return runBackfillWatchZoneBoundingBox(ctx, client, env, args)
 	default:
 		fmt.Fprintf(env.Err, "Unknown command: %s\n", args.Command)
 		fmt.Fprintln(env.Err, "Run 'tc help' for a list of commands.")

--- a/cli/internal/tc/backfill.go
+++ b/cli/internal/tc/backfill.go
@@ -35,3 +35,33 @@ func runBackfillWatchZoneLocation(ctx context.Context, client *Client, env Env, 
 		result.Backfilled, result.Total, result.AlreadyHad)
 	return exitOK
 }
+
+// runBackfillWatchZoneBoundingBox implements `tc backfill-watchzone-bbox`: a
+// guarded, idempotent one-shot that POSTs to /v1/admin/watchzones/backfill-bbox
+// (no body) and prints the reconciled counts. The endpoint recomputes the bounding
+// box (minLat/maxLat/minLon/maxLon) on every legacy WatchZone document that lacks
+// one; re-running it is safe.
+func runBackfillWatchZoneBoundingBox(ctx context.Context, client *Client, env Env, _ *ParsedArgs) int {
+	resp, err := client.Post(ctx, "/v1/admin/watchzones/backfill-bbox", nil)
+	if err != nil {
+		fmt.Fprintf(env.Err, "API error: %s\n", err)
+		return exitRuntime
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
+		fmt.Fprintf(env.Err, "API error (%d): %s\n", resp.StatusCode, string(body))
+		return exitRuntime
+	}
+
+	var result backfillWatchZoneBoundingBoxResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxRespBytes)).Decode(&result); err != nil {
+		fmt.Fprintf(env.Err, "API error: %s\n", err)
+		return exitRuntime
+	}
+
+	fmt.Fprintf(env.Out, "Backfilled bounding box on %d of %d watch zones (%d already had it)\n",
+		result.Backfilled, result.Total, result.AlreadyHad)
+	return exitOK
+}

--- a/cli/internal/tc/backfill_test.go
+++ b/cli/internal/tc/backfill_test.go
@@ -60,3 +60,55 @@ func TestRunBackfillWatchZoneLocation_APIErrorReturns2(t *testing.T) {
 		t.Fatalf("stderr = %q, want API error (500)", errBuf.String())
 	}
 }
+
+func TestRunBackfillWatchZoneBoundingBox_SuccessReturns0(t *testing.T) {
+	t.Parallel()
+	var gotKey, gotPath, gotMethod string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get(apiKeyHeader)
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"total":10,"backfilled":3,"alreadyHad":7}`)
+	}))
+	defer server.Close()
+
+	env, out, errBuf := captureEnv()
+	code := runBackfillWatchZoneBoundingBox(context.Background(), clientFor(server), env, ParseArgs([]string{
+		"backfill-watchzone-bbox",
+	}))
+
+	if code != exitOK {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, errBuf.String())
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v1/admin/watchzones/backfill-bbox" {
+		t.Fatalf("request = %s %s, want POST /v1/admin/watchzones/backfill-bbox", gotMethod, gotPath)
+	}
+	if gotKey != "sk-test" {
+		t.Fatalf("X-Admin-Key = %q, want sk-test", gotKey)
+	}
+	if got := out.String(); !strings.Contains(got, "Backfilled bounding box on 3 of 10 watch zones (7 already had it)") {
+		t.Fatalf("stdout = %q, want reconciled summary", got)
+	}
+}
+
+func TestRunBackfillWatchZoneBoundingBox_APIErrorReturns2(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	}))
+	defer server.Close()
+
+	env, _, errBuf := captureEnv()
+	code := runBackfillWatchZoneBoundingBox(context.Background(), clientFor(server), env, ParseArgs([]string{
+		"backfill-watchzone-bbox",
+	}))
+
+	if code != exitRuntime {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "API error (500): boom") {
+		t.Fatalf("stderr = %q, want API error (500)", errBuf.String())
+	}
+}

--- a/cli/internal/tc/commands.go
+++ b/cli/internal/tc/commands.go
@@ -49,6 +49,13 @@ type backfillWatchZoneLocationResponse struct {
 	AlreadyHad int `json:"alreadyHad"`
 }
 
+// backfillWatchZoneBoundingBoxResponse is the POST
+// /v1/admin/watchzones/backfill-bbox response body. It is byte-identical to the
+// location backfill response ({total, backfilled, alreadyHad}), so it aliases that
+// type rather than redeclaring the shape — the alias keeps the bbox command's call
+// site self-documenting while staying DRY.
+type backfillWatchZoneBoundingBoxResponse = backfillWatchZoneLocationResponse
+
 // parseStrictInt parses s as a non-negative base-10 integer, accepting only
 // ASCII digits. It rejects signs, whitespace, and decimals. Overflow is
 // reported as invalid.


### PR DESCRIPTION
Fixes #637 (tc-w11n). Makes watch-zone matching purely geographic so a zone whose radius crosses a local-authority boundary matches in-circle applications on **both** sides, instead of silently dropping the neighbouring authority. Authority is demoted to pure metadata for matching.

## Changes

### Notify / ingest path (tc-b179)
- `WatchZone.boundingBox()` derives `minLat/maxLat/minLon/maxLon` from centre + radius; `watchZoneDocument` gains nullable `*float64` bbox fields, always written by `newWatchZoneDocument` (so create + any radius/centre change recompute wholesale).
- `findZonesContainingQuery` rewritten: drops the `c.authorityId` equality, prunes on the index-served bbox `BETWEEN` predicates, keeps the exact `ST_DISTANCE(c.location, …) <= c.radiusMetres` residual (so a 2.0 km zone still excludes a 2.1 km point). A transitional `NOT IS_DEFINED(c.minLat)` fallback keeps legacy un-backfilled zones matching via the residual until the backfill runs (mirrors tc-qbq4→tc-ltlw); removable in a follow-up once both envs are bbox-backfilled.
- `FindZonesContaining` drops its `authorityID` param; `notifydispatch` enqueuer **and** decision dispatcher (shared `zoneMatcher`) updated.

### Browse path (tc-zldl)
- `applications.FindNearby` goes **cross-partition** (`QueryItemsCrossPartition`) with the constant-radius `ST_DISTANCE` form (served by the existing `/location` spatial index), dropping the single-authority partition scoping and the `authorityCode` param. Callers updated: `watchzones/nearby.go` (create response + `GET /{zoneId}/applications`) and `demoaccount`. `RecentNearby`/`NearestNearby`/`Breakdown*` left single-partition (out of scope).

### CLI backfill (tc-fruu)
- `watchzones.BackfillBoundingBox` + admin `POST /v1/admin/watchzones/backfill-bbox` + `tc backfill-watchzone-bbox` one-shot to populate the bbox on existing zone docs (mirrors the tc-xj48 location backfill). To be run against dev then prod after merge.

## Notes
- No Pulumi/infra change: bbox is range-indexed automatically under WatchZones `/*`; the `/location` spatial index already exists.
- Backend/CLI-only — no `Release-Note:` trailer.
- All gates green in both modules: build, vet, gofmt, `go test` (api-go 1126, cli 50), golangci-lint.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new watch-zone bounding-box backfill command and admin endpoint.
  * Nearby application and zone matching now works across boundary lines, so results can include neighboring areas when appropriate.
  * Watch zones now store bounding-box data to improve geographic matching.

* **Bug Fixes**
  * Nearby lookups and notification dispatch now return cross-border matches more consistently.
  * Existing watch-zone data remains compatible during the transition to bounding-box-based matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->