### PR TITLE
fix(api): bound watch-zone nearby browse to a single 500-app page (tc-fm8f)

### DIFF
--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -23,7 +23,6 @@ type CosmosItems interface {
 	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
 	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
 	QueryItemsLongRead(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
-	QueryItemsCrossPartition(ctx context.Context, query string, params map[string]any) ([][]byte, error)
 	QueryPageCrossPartition(ctx context.Context, query string, params map[string]any, pageSize int, continuationToken string) ([][]byte, string, error)
 }
 
@@ -193,44 +192,11 @@ func (s *CosmosStore) BreakdownByAuthority(ctx context.Context, authorityCode st
 // /location spatial index serves it directly — cross-partition included.
 // Coordinates and radius are bound as named parameters (mirroring
 // findZonesContainingQuery in the watchzones package) — no float literals are
-// concatenated into the query text.
+// concatenated into the query text. There is deliberately NO ORDER BY: the
+// Cosmos Gateway rejects cross-partition ordering/aggregates, so the paged
+// result is in arbitrary (partition) order.
 const findNearbyQuery = "SELECT * FROM c WHERE ST_DISTANCE(c.location, " +
 	`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres`
-
-// FindNearby returns every application within radiusMetres of (latitude,
-// longitude) via a constant-radius ST_DISTANCE spatial query against the GeoJSON
-// location. Coordinates and radius are bound as named parameters (not
-// string-concatenated) to eliminate float-formatting edge cases and to mirror
-// the parameterized style of the sibling watchzones.FindZonesContaining query.
-//
-// This is a deliberate CROSS-PARTITION spatial fan-out: it is no longer scoped
-// to one authorityCode partition, so a watch zone whose circle crosses an
-// authority boundary surfaces in-circle applications on BOTH sides (tc-zldl /
-// tc-w11n). It is user-initiated and low-frequency (zone create / zone open),
-// strictly colder than the already-cross-partition notify path, so the fan-out
-// RU is acceptable at current scale. The constant radius lets the /location
-// spatial index serve the ST_DISTANCE residual exactly, so circle semantics
-// stay exact even across partitions.
-func (s *CosmosStore) FindNearby(ctx context.Context, latitude, longitude, radiusMetres float64) ([]PlanningApplication, error) {
-	params := map[string]any{
-		"@latitude":     latitude,
-		"@longitude":    longitude,
-		"@radiusMetres": radiusMetres,
-	}
-	raws, err := s.items.QueryItemsCrossPartition(ctx, findNearbyQuery, params)
-	if err != nil {
-		return nil, fmt.Errorf("find applications near (%v, %v): %w", latitude, longitude, err)
-	}
-	apps := make([]PlanningApplication, 0, len(raws))
-	for _, raw := range raws {
-		var doc applicationDocument
-		if err := json.Unmarshal(raw, &doc); err != nil {
-			return nil, fmt.Errorf("decode nearby application near (%v, %v): %w", latitude, longitude, err)
-		}
-		apps = append(apps, doc.toDomain())
-	}
-	return apps, nil
-}
 
 // FindNearbyPage returns ONE bounded page of up to limit applications within
 // radiusMetres of (latitude, longitude), plus an opaque continuation token for

--- a/api-go/internal/applications/store_cosmos.go
+++ b/api-go/internal/applications/store_cosmos.go
@@ -11,18 +11,20 @@ import (
 
 // CosmosItems is the consumer-side slice of the Applications container the store
 // uses: a single-partition point read, an upsert, single-partition queries, and
-// a cross-partition spatial fan-out. QueryItems carries the tight 1.5s OLTP
-// per-attempt budget for user-facing reads; QueryItemsLongRead carries a longer
-// per-attempt budget for the latency-tolerant build-time SEO reads over a LARGE
-// authority partition (tc-9tov); QueryItemsCrossPartition backs the
-// authority-agnostic nearby fan-out (tc-zldl). platform.CosmosContainer
-// satisfies it structurally.
+// a bounded cross-partition spatial fan-out. QueryItems carries the tight 1.5s
+// OLTP per-attempt budget for user-facing reads; QueryItemsLongRead carries a
+// longer per-attempt budget for the latency-tolerant build-time SEO reads over a
+// LARGE authority partition (tc-9tov); QueryPageCrossPartition backs the bounded,
+// cursor-paged authority-agnostic nearby fan-out (tc-fm8f, replacing the
+// unbounded drain from tc-zldl). platform.CosmosContainer satisfies it
+// structurally.
 type CosmosItems interface {
 	ReadItem(ctx context.Context, partitionKey, id string) ([]byte, error)
 	UpsertItem(ctx context.Context, partitionKey string, item []byte) error
 	QueryItems(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
 	QueryItemsLongRead(ctx context.Context, partitionKey, query string, params map[string]any) ([][]byte, error)
 	QueryItemsCrossPartition(ctx context.Context, query string, params map[string]any) ([][]byte, error)
+	QueryPageCrossPartition(ctx context.Context, query string, params map[string]any, pageSize int, continuationToken string) ([][]byte, string, error)
 }
 
 // CosmosStore reads and writes planning applications in the Applications
@@ -228,6 +230,43 @@ func (s *CosmosStore) FindNearby(ctx context.Context, latitude, longitude, radiu
 		apps = append(apps, doc.toDomain())
 	}
 	return apps, nil
+}
+
+// FindNearbyPage returns ONE bounded page of up to limit applications within
+// radiusMetres of (latitude, longitude), plus an opaque continuation token for
+// the next page (empty when the query is exhausted). It runs the same
+// constant-radius ST_DISTANCE spatial query as FindNearby, served by the
+// /location spatial index, and fans out cross-partition so a circle that crosses
+// an authority boundary surfaces in-circle applications on BOTH sides (tc-zldl /
+// tc-w11n). There is NO ORDER BY: the Cosmos Gateway rejects cross-partition
+// ordering/aggregates, so a paged cross-partition result is in arbitrary
+// (partition) order.
+//
+// The cap is applied AT THE QUERY LAYER via the page-size hint, so this issues
+// exactly one gateway round-trip and never drains all pages — the fix for the
+// unbounded fan-out that blew the server write timeout on dense urban zones
+// (tc-fm8f). cursor resumes a prior page; "" starts at the first page.
+// Coordinates and radius are bound as named parameters (not string-concatenated),
+// mirroring the parameterized style of watchzones.FindZonesContaining.
+func (s *CosmosStore) FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error) {
+	params := map[string]any{
+		"@latitude":     latitude,
+		"@longitude":    longitude,
+		"@radiusMetres": radiusMetres,
+	}
+	raws, next, err := s.items.QueryPageCrossPartition(ctx, findNearbyQuery, params, limit, cursor)
+	if err != nil {
+		return nil, "", fmt.Errorf("find applications near (%v, %v): %w", latitude, longitude, err)
+	}
+	apps := make([]PlanningApplication, 0, len(raws))
+	for _, raw := range raws {
+		var doc applicationDocument
+		if err := json.Unmarshal(raw, &doc); err != nil {
+			return nil, "", fmt.Errorf("decode nearby application near (%v, %v): %w", latitude, longitude, err)
+		}
+		apps = append(apps, doc.toDomain())
+	}
+	return apps, next, nil
 }
 
 // breakdownNearbyQuery is the exact, index-served per-appState distribution over

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -30,13 +30,6 @@ type fakeItems struct {
 	// OLTP QueryItems. The build-time SEO reads must use the long-read path; the
 	// user-facing reads must not (tc-9tov).
 	lastQueryViaLongRead bool
-	// crossPartitionResult, lastCrossPartitionQuery, lastCrossPartitionParams and
-	// crossPartitionErr back QueryItemsCrossPartition, the authority-agnostic
-	// spatial fan-out FindNearby now uses (tc-zldl).
-	crossPartitionResult     [][]byte
-	lastCrossPartitionQuery  string
-	lastCrossPartitionParams map[string]any
-	crossPartitionErr        error
 	// pageResult, pageNext, pageErr and the lastPage* fields back
 	// QueryPageCrossPartition, the bounded single-page fan-out FindNearbyPage uses
 	// (tc-fm8f). A non-empty pageNext models "more pages remain".
@@ -78,15 +71,6 @@ func (f *fakeItems) QueryItems(_ context.Context, partitionKey, query string, pa
 func (f *fakeItems) QueryItemsLongRead(_ context.Context, partitionKey, query string, params map[string]any) ([][]byte, error) {
 	f.lastQueryViaLongRead = true
 	return f.recordQuery(partitionKey, query, params)
-}
-
-func (f *fakeItems) QueryItemsCrossPartition(_ context.Context, query string, params map[string]any) ([][]byte, error) {
-	f.lastCrossPartitionQuery = query
-	f.lastCrossPartitionParams = params
-	if f.crossPartitionErr != nil {
-		return nil, f.crossPartitionErr
-	}
-	return f.crossPartitionResult, nil
 }
 
 func (f *fakeItems) QueryPageCrossPartition(_ context.Context, query string, params map[string]any, pageSize int, continuationToken string) ([][]byte, string, error) {
@@ -214,100 +198,6 @@ func TestCosmosStore_GetByUID_NotFound(t *testing.T) {
 	}
 }
 
-func TestCosmosStore_FindNearby_QueriesCrossPartitionAcrossAuthorities(t *testing.T) {
-	t.Parallel()
-	// A border-spanning circle: two in-radius applications tagged to different
-	// authority partitions (449 + 246). The cross-partition fan-out must surface
-	// BOTH, not just the home authority's side (tc-zldl / tc-w11n).
-	app449 := testApplication(t)
-	app449.AreaID = 449
-	app449.Name = "449/24/001"
-	app246 := testApplication(t)
-	app246.AreaID = 246
-	app246.Name = "246/24/002"
-	body449, _ := json.Marshal(newApplicationDocument(app449))
-	body246, _ := json.Marshal(newApplicationDocument(app246))
-	items := newFakeItems()
-	items.crossPartitionResult = [][]byte{body449, body246}
-	store := NewCosmosStore(items)
-
-	got, err := store.FindNearby(context.Background(), 51.4975, -0.1357, 2000)
-	if err != nil {
-		t.Fatalf("FindNearby: %v", err)
-	}
-	if len(got) != 2 {
-		t.Fatalf("FindNearby results: got %d, want 2 (both authorities); %+v", len(got), got)
-	}
-	gotAreas := map[int]bool{got[0].AreaID: true, got[1].AreaID: true}
-	if !gotAreas[449] || !gotAreas[246] {
-		t.Errorf("FindNearby must surface both authorities 449 and 246; got %+v", gotAreas)
-	}
-	// The fan-out must run cross-partition, NOT through the partition-scoped
-	// QueryItems (which would re-impose single-authority scoping).
-	if items.lastQueryPK != "" {
-		t.Errorf("FindNearby must not run a partition-scoped query; got partition key %q", items.lastQueryPK)
-	}
-	// The constant-radius residual is preserved: ST_DISTANCE(...) <= @radiusMetres
-	// serves the exact circle, with the radius bound as the query's constant. The
-	// GeoJSON point carries [longitude, latitude] order.
-	want := "SELECT * FROM c WHERE ST_DISTANCE(c.location, " +
-		`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres`
-	if items.lastCrossPartitionQuery != want {
-		t.Errorf("cross-partition spatial query:\n got %q\nwant %q", items.lastCrossPartitionQuery, want)
-	}
-}
-
-func TestFindNearby_UsesParameterizedQuery(t *testing.T) {
-	t.Parallel()
-	items := newFakeItems()
-	store := NewCosmosStore(items)
-
-	_, _ = store.FindNearby(context.Background(), 51.4975, -0.1357, 2000)
-
-	// The query text must not contain any float literal — values must be bound
-	// as named parameters, not string-concatenated.
-	if items.lastCrossPartitionQuery == "" {
-		t.Fatal("no query was issued")
-	}
-	for _, literal := range []string{"51.4975", "-0.1357", "2000"} {
-		if strings.Contains(items.lastCrossPartitionQuery, literal) {
-			t.Errorf("query contains float literal %q — should be a named parameter; query: %s", literal, items.lastCrossPartitionQuery)
-		}
-	}
-	// Verify the three expected params are bound with correct values.
-	wantParams := map[string]any{
-		"@latitude":     51.4975,
-		"@longitude":    -0.1357,
-		"@radiusMetres": 2000.0,
-	}
-	for k, wantVal := range wantParams {
-		gotVal, ok := items.lastCrossPartitionParams[k]
-		if !ok {
-			t.Errorf("param %q not found in query params %v", k, items.lastCrossPartitionParams)
-			continue
-		}
-		if gotVal != wantVal {
-			t.Errorf("param %q: got %v, want %v", k, gotVal, wantVal)
-		}
-	}
-}
-
-func TestCosmosStore_FindNearby_EmptyResultIsEmptySlice(t *testing.T) {
-	t.Parallel()
-	store := NewCosmosStore(newFakeItems())
-
-	got, err := store.FindNearby(context.Background(), 51.4975, -0.1357, 2000)
-	if err != nil {
-		t.Fatalf("FindNearby: %v", err)
-	}
-	if got == nil {
-		t.Fatal("FindNearby: got nil slice, want empty non-nil slice")
-	}
-	if len(got) != 0 {
-		t.Errorf("FindNearby: got %d results, want 0", len(got))
-	}
-}
-
 func TestCosmosStore_FindNearbyPage_FetchesOneBoundedPageWithCursor(t *testing.T) {
 	t.Parallel()
 	// A border-spanning circle: two in-radius applications tagged to different
@@ -350,10 +240,6 @@ func TestCosmosStore_FindNearbyPage_FetchesOneBoundedPageWithCursor(t *testing.T
 	// First page: no continuation token sent in.
 	if items.lastPageContinuation != "" {
 		t.Errorf("first page must not send a continuation token; got %q", items.lastPageContinuation)
-	}
-	// It must use the single-page method, never the unbounded drain.
-	if items.lastCrossPartitionQuery != "" {
-		t.Error("FindNearbyPage must not call the unbounded QueryItemsCrossPartition drain")
 	}
 	// The constant-radius residual is preserved (same query as the unbounded form):
 	// ST_DISTANCE(...) <= @radiusMetres, GeoJSON [longitude, latitude] order. No
@@ -1095,21 +981,22 @@ func TestCosmosStore_RecentNearby_UsesLongReadBudget(t *testing.T) {
 // The user-facing reads must keep the tight OLTP budget — only the build-time SEO
 // reads get the longer one, so widening must never leak onto the OLTP path.
 
-func TestCosmosStore_FindNearby_KeepsOLTPBudget(t *testing.T) {
+func TestCosmosStore_FindNearbyPage_KeepsOLTPBudget(t *testing.T) {
 	t.Parallel()
 	items := newFakeItems()
 	store := NewCosmosStore(items)
 
-	if _, err := store.FindNearby(context.Background(), 51.4975, -0.1357, 2000); err != nil {
-		t.Fatalf("FindNearby: %v", err)
+	if _, _, err := store.FindNearbyPage(context.Background(), 51.4975, -0.1357, 2000, 500, ""); err != nil {
+		t.Fatalf("FindNearbyPage: %v", err)
 	}
-	// FindNearby is a user-facing read: it fans out cross-partition but must never
-	// route through the latency-tolerant build-time SEO budget (QueryItemsLongRead).
-	if items.lastCrossPartitionQuery == "" {
-		t.Error("FindNearby must run the cross-partition spatial query")
+	// FindNearbyPage is a user-facing read: it fans out cross-partition but must
+	// never route through the latency-tolerant build-time SEO budget
+	// (QueryItemsLongRead).
+	if items.lastPageQuery == "" {
+		t.Error("FindNearbyPage must run the bounded cross-partition spatial query")
 	}
 	if items.lastQueryViaLongRead {
-		t.Error("FindNearby is a user-facing read and must not use the build-time long-read budget")
+		t.Error("FindNearbyPage is a user-facing read and must not use the build-time long-read budget")
 	}
 }
 

--- a/api-go/internal/applications/store_cosmos_test.go
+++ b/api-go/internal/applications/store_cosmos_test.go
@@ -3,6 +3,7 @@ package applications
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -36,6 +37,16 @@ type fakeItems struct {
 	lastCrossPartitionQuery  string
 	lastCrossPartitionParams map[string]any
 	crossPartitionErr        error
+	// pageResult, pageNext, pageErr and the lastPage* fields back
+	// QueryPageCrossPartition, the bounded single-page fan-out FindNearbyPage uses
+	// (tc-fm8f). A non-empty pageNext models "more pages remain".
+	pageResult           [][]byte
+	pageNext             string
+	pageErr              error
+	lastPageQuery        string
+	lastPageParams       map[string]any
+	lastPageSize         int
+	lastPageContinuation string
 }
 
 func newFakeItems() *fakeItems { return &fakeItems{stored: map[string][]byte{}} }
@@ -76,6 +87,17 @@ func (f *fakeItems) QueryItemsCrossPartition(_ context.Context, query string, pa
 		return nil, f.crossPartitionErr
 	}
 	return f.crossPartitionResult, nil
+}
+
+func (f *fakeItems) QueryPageCrossPartition(_ context.Context, query string, params map[string]any, pageSize int, continuationToken string) ([][]byte, string, error) {
+	f.lastPageQuery = query
+	f.lastPageParams = params
+	f.lastPageSize = pageSize
+	f.lastPageContinuation = continuationToken
+	if f.pageErr != nil {
+		return nil, "", f.pageErr
+	}
+	return f.pageResult, f.pageNext, nil
 }
 
 func (f *fakeItems) recordQuery(partitionKey, query string, params map[string]any) ([][]byte, error) {
@@ -283,6 +305,144 @@ func TestCosmosStore_FindNearby_EmptyResultIsEmptySlice(t *testing.T) {
 	}
 	if len(got) != 0 {
 		t.Errorf("FindNearby: got %d results, want 0", len(got))
+	}
+}
+
+func TestCosmosStore_FindNearbyPage_FetchesOneBoundedPageWithCursor(t *testing.T) {
+	t.Parallel()
+	// A border-spanning circle: two in-radius applications tagged to different
+	// authority partitions (449 + 246). The bounded fan-out must surface BOTH and
+	// must run via the single-page QueryPageCrossPartition, NOT the unbounded
+	// QueryItemsCrossPartition drain (tc-fm8f).
+	app449 := testApplication(t)
+	app449.AreaID = 449
+	app449.Name = "449/24/001"
+	app246 := testApplication(t)
+	app246.AreaID = 246
+	app246.Name = "246/24/002"
+	body449, _ := json.Marshal(newApplicationDocument(app449))
+	body246, _ := json.Marshal(newApplicationDocument(app246))
+	items := newFakeItems()
+	items.pageResult = [][]byte{body449, body246}
+	items.pageNext = "continuation-token-xyz"
+	store := NewCosmosStore(items)
+
+	got, next, err := store.FindNearbyPage(context.Background(), 51.4975, -0.1357, 2000, 500, "")
+	if err != nil {
+		t.Fatalf("FindNearbyPage: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("FindNearbyPage results: got %d, want 2 (both authorities); %+v", len(got), got)
+	}
+	gotAreas := map[int]bool{got[0].AreaID: true, got[1].AreaID: true}
+	if !gotAreas[449] || !gotAreas[246] {
+		t.Errorf("FindNearbyPage must surface both authorities 449 and 246; got %+v", gotAreas)
+	}
+	// The continuation token is passed straight back to the caller.
+	if next != "continuation-token-xyz" {
+		t.Errorf("next cursor: got %q, want %q", next, "continuation-token-xyz")
+	}
+	// The page size hint must be the requested limit so Cosmos caps the page at the
+	// query layer — never an unbounded drain.
+	if items.lastPageSize != 500 {
+		t.Errorf("page size: got %d, want 500", items.lastPageSize)
+	}
+	// First page: no continuation token sent in.
+	if items.lastPageContinuation != "" {
+		t.Errorf("first page must not send a continuation token; got %q", items.lastPageContinuation)
+	}
+	// It must use the single-page method, never the unbounded drain.
+	if items.lastCrossPartitionQuery != "" {
+		t.Error("FindNearbyPage must not call the unbounded QueryItemsCrossPartition drain")
+	}
+	// The constant-radius residual is preserved (same query as the unbounded form):
+	// ST_DISTANCE(...) <= @radiusMetres, GeoJSON [longitude, latitude] order. No
+	// ORDER BY — the Gateway rejects cross-partition ordering.
+	want := "SELECT * FROM c WHERE ST_DISTANCE(c.location, " +
+		`{"type": "Point", "coordinates": [@longitude, @latitude]}) <= @radiusMetres`
+	if items.lastPageQuery != want {
+		t.Errorf("bounded spatial query:\n got %q\nwant %q", items.lastPageQuery, want)
+	}
+}
+
+func TestCosmosStore_FindNearbyPage_ResumesFromCursor(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	if _, _, err := store.FindNearbyPage(context.Background(), 51.4975, -0.1357, 2000, 250, "resume-here"); err != nil {
+		t.Fatalf("FindNearbyPage: %v", err)
+	}
+	if items.lastPageContinuation != "resume-here" {
+		t.Errorf("continuation token: got %q, want %q", items.lastPageContinuation, "resume-here")
+	}
+	if items.lastPageSize != 250 {
+		t.Errorf("page size: got %d, want 250", items.lastPageSize)
+	}
+}
+
+func TestCosmosStore_FindNearbyPage_UsesParameterizedQuery(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	store := NewCosmosStore(items)
+
+	_, _, _ = store.FindNearbyPage(context.Background(), 51.4975, -0.1357, 2000, 500, "")
+
+	if items.lastPageQuery == "" {
+		t.Fatal("no query was issued")
+	}
+	// The query text must not contain any float literal — values must be bound as
+	// named parameters, not string-concatenated.
+	for _, literal := range []string{"51.4975", "-0.1357", "2000"} {
+		if strings.Contains(items.lastPageQuery, literal) {
+			t.Errorf("query contains float literal %q — should be a named parameter; query: %s", literal, items.lastPageQuery)
+		}
+	}
+	wantParams := map[string]any{
+		"@latitude":     51.4975,
+		"@longitude":    -0.1357,
+		"@radiusMetres": 2000.0,
+	}
+	for k, wantVal := range wantParams {
+		gotVal, ok := items.lastPageParams[k]
+		if !ok {
+			t.Errorf("param %q not found in query params %v", k, items.lastPageParams)
+			continue
+		}
+		if gotVal != wantVal {
+			t.Errorf("param %q: got %v, want %v", k, gotVal, wantVal)
+		}
+	}
+}
+
+func TestCosmosStore_FindNearbyPage_EmptyResultIsEmptySlice(t *testing.T) {
+	t.Parallel()
+	store := NewCosmosStore(newFakeItems())
+
+	got, next, err := store.FindNearbyPage(context.Background(), 51.4975, -0.1357, 2000, 500, "")
+	if err != nil {
+		t.Fatalf("FindNearbyPage: %v", err)
+	}
+	if got == nil {
+		t.Fatal("FindNearbyPage: got nil slice, want empty non-nil slice")
+	}
+	if len(got) != 0 {
+		t.Errorf("FindNearbyPage: got %d results, want 0", len(got))
+	}
+	if next != "" {
+		t.Errorf("exhausted query must return an empty cursor; got %q", next)
+	}
+}
+
+func TestCosmosStore_FindNearbyPage_PropagatesError(t *testing.T) {
+	t.Parallel()
+	items := newFakeItems()
+	items.pageErr = errors.New("gateway boom")
+	store := NewCosmosStore(items)
+
+	_, _, err := store.FindNearbyPage(context.Background(), 51.4975, -0.1357, 2000, 500, "")
+	if err == nil {
+		t.Fatal("FindNearbyPage: want error, got nil")
 	}
 }
 

--- a/api-go/internal/demoaccount/handler.go
+++ b/api-go/internal/demoaccount/handler.go
@@ -25,6 +25,10 @@ const (
 	// demoSubscriptionYears is how far ahead the demo Pro subscription is set to
 	// expire (10 years from the seed call time).
 	demoSubscriptionYears = 10
+	// demoNearbyLimit bounds the demo applications page. The demo zone holds five
+	// seeded apps, well under the cap; the bound just keeps the demo on the same
+	// bounded fetch as the real browse path (tc-fm8f).
+	demoNearbyLimit = 500
 )
 
 // profileStore is the consumer-side slice of the profile store the demo handler
@@ -40,10 +44,11 @@ type zoneStore interface {
 }
 
 // appStore seeds the demo applications and runs the spatial lookup that backs
-// the response. FindNearby is authority-agnostic and cross-partition (tc-zldl).
+// the response. FindNearbyPage is authority-agnostic and cross-partition
+// (tc-zldl), and bounded to a single page (tc-fm8f).
 type appStore interface {
 	Upsert(ctx context.Context, a applications.PlanningApplication) error
-	FindNearby(ctx context.Context, latitude, longitude, radiusMetres float64) ([]applications.PlanningApplication, error)
+	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]applications.PlanningApplication, string, error)
 }
 
 // handler serves GET /v1/demo-account.
@@ -81,7 +86,9 @@ func (h *handler) getDemoAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apps, err := h.apps.FindNearby(ctx, demoLatitude, demoLongitude, demoRadiusMetres)
+	// Page one of the bounded fetch; the demo never needs "load more", so the
+	// continuation token is discarded (tc-fm8f).
+	apps, _, err := h.apps.FindNearbyPage(ctx, demoLatitude, demoLongitude, demoRadiusMetres, demoNearbyLimit, "")
 	if err != nil {
 		serverError(w, r, h.logger, "find nearby demo applications", err)
 		return

--- a/api-go/internal/demoaccount/handler_test.go
+++ b/api-go/internal/demoaccount/handler_test.go
@@ -62,6 +62,8 @@ type fakeAppStore struct {
 	upsertErr  error
 	findErr    error
 	findCalled bool
+	lastLimit  int
+	lastCursor string
 }
 
 func (f *fakeAppStore) Upsert(_ context.Context, a applications.PlanningApplication) error {
@@ -72,12 +74,14 @@ func (f *fakeAppStore) Upsert(_ context.Context, a applications.PlanningApplicat
 	return nil
 }
 
-func (f *fakeAppStore) FindNearby(_ context.Context, _, _, _ float64) ([]applications.PlanningApplication, error) {
+func (f *fakeAppStore) FindNearbyPage(_ context.Context, _, _, _ float64, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
 	f.findCalled = true
+	f.lastLimit = limit
+	f.lastCursor = cursor
 	if f.findErr != nil {
-		return nil, f.findErr
+		return nil, "", f.findErr
 	}
-	return f.nearby, nil
+	return f.nearby, "", nil
 }
 
 // serve wires the route and issues GET /v1/demo-account, returning the recorder.
@@ -177,6 +181,26 @@ func TestGetDemoAccount_SecondCall_DoesNotReseed(t *testing.T) {
 	}
 	if !a.findCalled {
 		t.Error("FindNearby must still run on a repeat call")
+	}
+}
+
+func TestGetDemoAccount_UsesBoundedFetch(t *testing.T) {
+	t.Parallel()
+	p := &fakeProfileStore{}
+	a := &fakeAppStore{nearby: seedApplications(fixedNow)}
+
+	rec := serve(t, p, &fakeZoneStore{}, a)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	// The demo path must use the bounded page-one fetch (limit 500, no cursor),
+	// never the removed unbounded drain (tc-fm8f).
+	if a.lastLimit != 500 {
+		t.Errorf("demo fetch limit: got %d, want 500", a.lastLimit)
+	}
+	if a.lastCursor != "" {
+		t.Errorf("demo fetch cursor: got %q, want empty (page one)", a.lastCursor)
 	}
 }
 

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -323,7 +323,12 @@ func (h *handler) writeJSON(w http.ResponseWriter, r *http.Request, status int, 
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(status)
-	if _, err := w.Write(body); err != nil {
+	// G705 (gosec taint analysis) flags this since the nearby browse handler reads
+	// ?limit=/?cursor= query params, but reflected XSS is not applicable: writeJSON
+	// always emits application/json and body is server-encoded JSON of structured
+	// data — the query params never reach the body (the cursor returns via a
+	// base64url-encoded response header, not here).
+	if _, err := w.Write(body); err != nil { //nolint:gosec // G705 false positive: JSON-only response, query params never reach the body
 		h.logger.ErrorContext(r.Context(), "write response", "error", err)
 	}
 }

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -2,6 +2,7 @@ package watchzones
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -48,9 +50,11 @@ type authorityResolver interface {
 // appFinder runs the spatial lookup that backs both the create response's nearby
 // applications and the per-zone applications list. It is authority-agnostic and
 // cross-partition, so a border-spanning zone surfaces neighbour-authority apps
-// (tc-zldl). *applications.CosmosStore satisfies it.
+// (tc-zldl). The fetch is bounded: it returns at most `limit` rows for the given
+// cursor plus an opaque continuation token for the next page (tc-fm8f).
+// *applications.CosmosStore satisfies it.
 type appFinder interface {
-	FindNearby(ctx context.Context, latitude, longitude, radiusMetres float64) ([]applications.PlanningApplication, error)
+	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]applications.PlanningApplication, string, error)
 }
 
 // watermarkReader reads the caller's notification read-watermark. A nil return
@@ -116,6 +120,20 @@ type createRequest struct {
 // the top-tier iOS UI ceiling (10 km). If a larger radius tier is ever offered,
 // bump this value server-side first before shipping the iOS change.
 const maxRadiusMetres = 10_000
+
+// defaultNearbyLimit and maxNearbyLimit bound the per-request page of nearby
+// applications. The browse path fetches a SINGLE bounded page so a dense urban
+// zone can no longer drain tens of thousands of documents and blow the server
+// write timeout (tc-fm8f). Default and max are equal at 500: ~0.5 MB of full
+// Result rows, sub-second, low RU. The create + demo paths fetch page one only.
+const (
+	defaultNearbyLimit = 500
+	maxNearbyLimit     = 500
+)
+
+// invalidCursorMessage is the 400 body when ?cursor= is not a valid base64url
+// continuation token previously handed out via the X-Next-Cursor header.
+const invalidCursorMessage = "Invalid cursor."
 
 // valid reports whether the create request passes the pre-handler guard:
 // non-blank name, positive radius within the server ceiling, in-range
@@ -227,8 +245,10 @@ func (h *handler) create(w http.ResponseWriter, r *http.Request) {
 		h.metrics.WatchZoneCreated(r.Context())
 	}
 
-	nearby, err := h.apps.FindNearby(
-		r.Context(), req.Latitude, req.Longitude, req.RadiusMetres)
+	// The create response carries page one of the bounded fetch; the continuation
+	// token is irrelevant here (no "load more" on create), so it is discarded.
+	nearby, _, err := h.apps.FindNearbyPage(
+		r.Context(), req.Latitude, req.Longitude, req.RadiusMetres, maxNearbyLimit, "")
 	if err != nil {
 		h.serverError(w, r, "find nearby applications", err)
 		return
@@ -268,8 +288,15 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apps, err := h.apps.FindNearby(
-		r.Context(), zone.Latitude, zone.Longitude, zone.RadiusMetres)
+	limit := parseNearbyLimit(r.URL.Query().Get("limit"))
+	cursor, ok := decodeCursor(r.URL.Query().Get("cursor"))
+	if !ok {
+		h.writeError(w, r, http.StatusBadRequest, invalidCursorMessage)
+		return
+	}
+
+	apps, nextCursor, err := h.apps.FindNearbyPage(
+		r.Context(), zone.Latitude, zone.Longitude, zone.RadiusMetres, limit, cursor)
 	if err != nil {
 		h.serverError(w, r, "find applications in zone", err)
 		return
@@ -314,7 +341,52 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 		}
 		results = append(results, row)
 	}
+	// Hand the opaque continuation token back via the response header (not the
+	// body, which stays a bare []Result so existing clients are untouched). Set it
+	// before writeJSON, which calls WriteHeader. Omitted when the page is the last.
+	if nextCursor != "" {
+		w.Header().Set("X-Next-Cursor", encodeCursor(nextCursor))
+	}
 	h.writeJSON(w, r, http.StatusOK, results)
+}
+
+// parseNearbyLimit resolves ?limit= to a bounded page size: absent, non-numeric,
+// or non-positive falls back to the default; anything above the max clamps down.
+// It never rejects — an existing client that omits or fat-fingers the parameter
+// still gets a sane bounded page.
+func parseNearbyLimit(raw string) int {
+	if raw == "" {
+		return defaultNearbyLimit
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return defaultNearbyLimit
+	}
+	if n > maxNearbyLimit {
+		return maxNearbyLimit
+	}
+	return n
+}
+
+// decodeCursor base64url-decodes an opaque ?cursor= value into the raw Cosmos
+// continuation token. An empty value means the first page (ok). A malformed value
+// is rejected (ok == false) so a garbage cursor is a clean 400, not a silent
+// reset to the first page.
+func decodeCursor(raw string) (string, bool) {
+	if raw == "" {
+		return "", true
+	}
+	b, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return "", false
+	}
+	return string(b), true
+}
+
+// encodeCursor base64url-encodes a raw Cosmos continuation token for the
+// X-Next-Cursor response header — header- and URL-safe, unpadded.
+func encodeCursor(token string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(token))
 }
 
 // atomicQuotaIncrement tries to atomically claim one slot in the user's

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -2,12 +2,14 @@ package watchzones
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"math"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 
@@ -40,14 +42,30 @@ func (f *fakeResolver) ResolveAuthority(_ context.Context, _, _ float64) (int, e
 }
 
 type fakeAppFinder struct {
-	apps   []applications.PlanningApplication
-	err    error
-	called bool
+	apps       []applications.PlanningApplication
+	next       string
+	err        error
+	called     bool
+	lastLimit  int
+	lastCursor string
 }
 
-func (f *fakeAppFinder) FindNearby(_ context.Context, _, _, _ float64) ([]applications.PlanningApplication, error) {
+func (f *fakeAppFinder) FindNearbyPage(_ context.Context, _, _, _ float64, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
 	f.called = true
-	return f.apps, f.err
+	f.lastLimit = limit
+	f.lastCursor = cursor
+	if f.err != nil {
+		return nil, "", f.err
+	}
+	// Mirror the bounded store contract: never hand back more than `limit` rows.
+	// The production store caps at the query layer (the page-size hint); the fake
+	// caps here so handler tests can prove the downstream unread lookup receives a
+	// bounded UID set (tc-fm8f).
+	apps := f.apps
+	if limit > 0 && len(apps) > limit {
+		apps = apps[:limit]
+	}
+	return apps, f.next, nil
 }
 
 type fakeWatermark struct {
@@ -60,13 +78,15 @@ func (f *fakeWatermark) Get(_ context.Context, _ string) (*notificationstate.Sta
 }
 
 type fakeUnread struct {
-	result map[string]notifications.LatestUnread
-	err    error
-	called bool
+	result   map[string]notifications.LatestUnread
+	err      error
+	called   bool
+	lastUIDs []string
 }
 
-func (f *fakeUnread) GetLatestUnreadByApplications(_ context.Context, _ string, _ []string, _ time.Time) (map[string]notifications.LatestUnread, error) {
+func (f *fakeUnread) GetLatestUnreadByApplications(_ context.Context, _ string, uids []string, _ time.Time) (map[string]notifications.LatestUnread, error) {
 	f.called = true
+	f.lastUIDs = uids
 	return f.result, f.err
 }
 
@@ -425,6 +445,182 @@ func TestApplications_AugmentsUnreadAndNullsTheRest(t *testing.T) {
 	}
 }
 
+func TestApplications_DefaultsLimitTo500(t *testing.T) {
+	t.Parallel()
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{mustZone(t, "zone-1", 471)}},
+		apps:     &fakeAppFinder{},
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		state:    &fakeWatermark{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if d.apps.lastLimit != 500 {
+		t.Errorf("default limit: got %d, want 500", d.apps.lastLimit)
+	}
+}
+
+func TestApplications_LimitParsing(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		query     string
+		wantLimit int
+	}{
+		{"valid below max", "?limit=50", 50},
+		{"exactly max", "?limit=500", 500},
+		{"above max clamps down", "?limit=10000", 500},
+		{"zero falls back to default", "?limit=0", 500},
+		{"negative falls back to default", "?limit=-5", 500},
+		{"non-numeric falls back to default", "?limit=abc", 500},
+		{"absent falls back to default", "", 500},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			d := nearbyDeps{
+				store:    &fakeZoneStore{zones: []WatchZone{mustZone(t, "zone-1", 471)}},
+				apps:     &fakeAppFinder{},
+				profiles: &fakeProfileReader{},
+				resolver: &fakeResolver{},
+				state:    &fakeWatermark{},
+				unread:   &fakeUnread{},
+			}
+			mux := newNearbyMux(t, d)
+			rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications"+tc.query, "")
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status: got %d, want 200", rec.Code)
+			}
+			if d.apps.lastLimit != tc.wantLimit {
+				t.Errorf("limit: got %d, want %d", d.apps.lastLimit, tc.wantLimit)
+			}
+		})
+	}
+}
+
+func TestApplications_SetsNextCursorHeaderWhenMorePagesExist(t *testing.T) {
+	t.Parallel()
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{mustZone(t, "zone-1", 471)}},
+		apps:     &fakeAppFinder{apps: []applications.PlanningApplication{testApp("uid-1", "24/001")}, next: "raw-token-123"},
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		state:    &fakeWatermark{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	got := rec.Header().Get("X-Next-Cursor")
+	want := base64.RawURLEncoding.EncodeToString([]byte("raw-token-123"))
+	if got != want {
+		t.Errorf("X-Next-Cursor: got %q, want %q (base64url of the raw token)", got, want)
+	}
+}
+
+func TestApplications_OmitsNextCursorHeaderWhenExhausted(t *testing.T) {
+	t.Parallel()
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{mustZone(t, "zone-1", 471)}},
+		apps:     &fakeAppFinder{apps: []applications.PlanningApplication{testApp("uid-1", "24/001")}}, // next == ""
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		state:    &fakeWatermark{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("X-Next-Cursor"); got != "" {
+		t.Errorf("X-Next-Cursor must be absent when the query is exhausted; got %q", got)
+	}
+}
+
+func TestApplications_ResumesFromCursorParam(t *testing.T) {
+	t.Parallel()
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{mustZone(t, "zone-1", 471)}},
+		apps:     &fakeAppFinder{},
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		state:    &fakeWatermark{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	cursor := base64.RawURLEncoding.EncodeToString([]byte("resume-token-9"))
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?cursor="+cursor, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	// The handler must base64url-decode the cursor before handing it to the store.
+	if d.apps.lastCursor != "resume-token-9" {
+		t.Errorf("decoded cursor: got %q, want %q", d.apps.lastCursor, "resume-token-9")
+	}
+}
+
+func TestApplications_RejectsUndecodableCursorWith400(t *testing.T) {
+	t.Parallel()
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{mustZone(t, "zone-1", 471)}},
+		apps:     &fakeAppFinder{},
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		state:    &fakeWatermark{},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	// "!!!" is not valid base64url — a garbage cursor must be a clean 400, not a
+	// silent reset to the first page.
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?cursor=%21%21%21", "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", rec.Code)
+	}
+	if d.apps.called {
+		t.Error("must not run the spatial query when the cursor is malformed")
+	}
+}
+
+func TestApplications_BoundsUnreadLookupToReturnedPage(t *testing.T) {
+	t.Parallel()
+	// The finder has more than a page worth of apps available; the bounded fetch
+	// returns only `limit` (default 500), so the unread lookup must receive a
+	// bounded UID set — never every app in a dense zone (tc-fm8f).
+	d := nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{mustZone(t, "zone-1", 471)}},
+		apps:     &fakeAppFinder{apps: manyApps(600)},
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		state:    &fakeWatermark{state: &notificationstate.State{UserID: testUser, LastReadAt: time.Unix(0, 0), Version: 1}},
+		unread:   &fakeUnread{},
+	}
+	mux := newNearbyMux(t, d)
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !d.unread.called {
+		t.Fatal("unread lookup must run when the user has a watermark")
+	}
+	if got := len(d.unread.lastUIDs); got != 500 {
+		t.Errorf("unread lookup UID set: got %d, want 500 (bounded to the returned page)", got)
+	}
+}
+
 func TestApplications_SurfacesNeighbourAuthorityApps(t *testing.T) {
 	t.Parallel()
 	// A zone pinned to authority 471 whose circle crosses into authority 246. The
@@ -575,6 +771,17 @@ func TestValid_RejectsNonFiniteCoordinates(t *testing.T) {
 			}
 		})
 	}
+}
+
+// manyApps builds n distinct nearby applications, for asserting the bounded page
+// caps the downstream unread UID set.
+func manyApps(n int) []applications.PlanningApplication {
+	apps := make([]applications.PlanningApplication, n)
+	for i := range apps {
+		id := strconv.Itoa(i)
+		apps[i] = testApp("uid-"+id, "24/"+id)
+	}
+	return apps
 }
 
 func mustZone(t *testing.T, id string, authorityID int) WatchZone {


### PR DESCRIPTION
Fixes #641 (tc-fm8f). Regression from #640 (tc-zldl/tc-w11n).

## Problem

Selecting a large watch zone on the map view spun indefinitely. #640 correctly made `applications.FindNearby` an authority-agnostic cross-partition `SELECT *`, but that made it **unbounded**. Measured against live prod for a real **10 km London zone**: 22,220 docs / 24.3 MB / 1,640 RU over 23 gateway pages (~7.4 s) — past the 15 s server write timeout, so the connection was cut and iOS retried (the "spinning"). The handler then also fed all 22 k UIDs into the unread lookup's `ARRAY_CONTAINS`.

## Fix — bounded single-page fetch at the query layer

`FindNearby` → **`FindNearbyPage(…, limit, cursor)`**: one `QueryPageCrossPartition` call with `pageSize = limit`, so the cap is applied **at the query**, never by draining-then-trimming. Same constant-radius `ST_DISTANCE` (no `ORDER BY` — the Gateway rejects cross-partition ordering, so order is arbitrary, which is acceptable here). The unbounded `FindNearby` and `QueryItemsCrossPartition` are removed from the package so the footgun can't return.

Because the handler's unread `uids` and response rows are both built from the `apps` slice, bounding the fetch **auto-bounds the unread lookup** to ≤ 500 UIDs (covered by a test).

### Same live zone, after
| | Before | After (1 page) |
|---|---|---|
| Docs | 22,220 | **500** |
| RU | 1,640 | **33** |
| Payload | 24.3 MB | **0.55 MB** |
| Time | ~7.4 s | **0.26 s** |

## API contract (backward compatible)

- `GET /v1/me/watch-zones/{zoneId}/applications?limit=&cursor=` — `limit` defaults to **500** and clamps to a 500 max (absent/garbage → default, never 400s on limit). `cursor` is an opaque base64url continuation token; a malformed cursor is a clean 400.
- **Body shape unchanged** (bare `[]Result`). The next-page token returns via the **`X-Next-Cursor`** response header, set only when more pages exist. Existing iOS/web clients get a bounded first page with zero changes; a future "load more" just reads the header and sends `?cursor=`.
- **No projection** — full `Result` retained so tapping a pin opens the detail card from already-fetched data (no iOS re-fetch).
- `create` and `demoaccount` use the bounded fetch (page one, token discarded); their response shapes are unchanged.

## Tests
Store: one-page bound, cursor resume, parameterized query, empty/error, OLTP budget. Browse: default/clamp/garbage limit table, `X-Next-Cursor` set/omitted, cursor resume, malformed-cursor 400, and **unread lookup bounded to 500 when 600 apps are available**. demoaccount: bounded fetch. Hand-written fakes only.

## Gates
`gofmt` clean · `go vet` clean · `go build` ok · `go test ./...` 1143 pass · `golangci-lint` 0 issues on touched packages.

## Out of scope (Phase 2, follow-ups filed)
Viewport-bounded loading, nearest-first ordering + accurate in-zone counts (partition-prune-and-merge), iOS pin clustering. `tc-q5yc`: expose `X-Next-Cursor` via CORS if a browser load-more client ever needs it.

Backend-only — no `Release-Note:` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nearby application results are now returned in pages, with support for `limit` and continuation cursors.
  * Watch-zone applications can now be browsed page by page, with a next-cursor indicator when more results are available.
  * Demo account nearby results are now fetched as a bounded page.

* **Bug Fixes**
  * Invalid cursors are now rejected with a clear error.
  * Empty nearby-result responses now return an empty list consistently.
  * Related unread counts now stay aligned with the returned page of applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->