### PR TITLE
chore(ios): bump MARKETING_VERSION to 1.2.3 (unblock App Store build selection) (tc-ddyk)

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.0.4"
+        MARKETING_VERSION: "1.2.3"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"


### PR DESCRIPTION
## What

Bump iOS `MARKETING_VERSION` `1.0.4` → `1.2.3` in `mobile/ios/project.yml`.

## Why

App Store version 1.2.2 (live) is backed by build 41, whose binary version (`CFBundleShortVersionString`) is **1.0.4**. Build 42 was also stamped **1.0.4**, so App Store Connect treats it as belonging to the already-published 1.0.4 train and **won't offer it** as a build for the new App Store version 1.2.3 (empty build picker / "Upload your builds using one of several tools").

Every prior store release bumped `MARKETING_VERSION` (1.0.1 → 1.0.2 → 1.0.3 → 1.0.4) precisely to give each store-bound build a unique binary version. This cycle the bump was missed, so build 42 collided. Bumping to **1.2.3** gives the next build (43) a fresh, unique binary version *and* realigns the binary version with the store version, ending the confusing 1.0.x-vs-1.2.x divergence.

## Deploy safety

- iOS-only change. `cd-dev.yml` path-ignores `mobile/ios/**`, so merging this **deploys nothing**.
- Build 43 will be produced via **`cd-ios-testflight` `workflow_dispatch` against main** — **not** a `v*` tag — so `cd-prod` does **not** fire. (An untested dev change must not reach prod yet.)

Closes tc-ddyk.