### PR TITLE
feat(api): Postgres+PostGIS store ports for Applications + WatchZones (tc-kgqw)

### DIFF
--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -1,0 +1,407 @@
+package applications
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// querier is the consumer-side slice of *pgxpool.Pool the store uses: parameterised
+// exec/query/query-row. Defining it here (not importing pgxpool) keeps the store
+// decoupled from the concrete pool and lets a pgx.Tx stand in. Both *pgxpool.Pool
+// and pgx.Tx satisfy it structurally.
+type querier interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// storeSurface is the full method set the Applications store exposes to its
+// consumers across packages (handler's appStore, recent.go's recentStore,
+// near.go's nearStore, watchzones.appFinder's FindNearbyPage, the savedapplications
+// snapshot backfill's GetByUID, and the poll Upsert). It exists only as a
+// compile-time parity check: both *CosmosStore and *PostgresStore must satisfy it,
+// so a Postgres port can never silently diverge from the Cosmos surface.
+type storeSurface interface {
+	Upsert(ctx context.Context, a PlanningApplication) error
+	GetByAuthorityAndName(ctx context.Context, authorityCode, name string) (PlanningApplication, bool, error)
+	GetByUID(ctx context.Context, uid, authorityCode string) (PlanningApplication, bool, error)
+	RecentByAuthority(ctx context.Context, authorityCode string, cap int) ([]PlanningApplication, error)
+	BreakdownByAuthority(ctx context.Context, authorityCode string) ([]StateCount, error)
+	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error)
+	RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
+	NearestNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
+	BreakdownNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) ([]StateCount, error)
+}
+
+// Compile-time parity: the Postgres store satisfies the same consumer-side
+// interfaces the Cosmos store does, and both satisfy the full storeSurface.
+var (
+	_ appStore     = (*PostgresStore)(nil)
+	_ recentStore  = (*PostgresStore)(nil)
+	_ nearStore    = (*PostgresStore)(nil)
+	_ storeSurface = (*PostgresStore)(nil)
+	_ storeSurface = (*CosmosStore)(nil)
+)
+
+// PostgresStore reads and writes planning applications in the Postgres
+// `applications` table (Cosmos -> Postgres + PostGIS migration; memo 0010, epic
+// #645). It is a parallel implementation: Cosmos remains the wired datastore, so
+// nothing here is on a live path yet.
+//
+// Key design vs the Cosmos store:
+//   - The natural key is the COMPOSITE (authority_code, planit_name) — a PlanIt
+//     case reference is only unique within an authority — so Upsert is
+//     INSERT ... ON CONFLICT (authority_code, planit_name) DO UPDATE.
+//   - location is a geography(Point,4326) served by one GiST index, so the radius
+//     reads use ST_DWithin and the nearest-first read uses the KNN <-> operator —
+//     the true nearest-N ordering the Cosmos Gateway refuses cross-partition.
+type PostgresStore struct {
+	db querier
+}
+
+// NewPostgresStore returns a store over the given pgx pool (or any querier).
+func NewPostgresStore(db querier) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+// appColumns is the read projection. Its order MUST match appScanDest. ST_Y is the
+// latitude and ST_X the longitude of the geography point (NULL when location is
+// absent); the geometry cast is required for the accessor functions.
+const appColumns = "planit_name, uid, area_name, area_id, address, postcode, " +
+	"description, app_type, app_state, app_size, start_date, decided_date, " +
+	"consulted_date, ST_Y(location::geometry), ST_X(location::geometry), url, link, last_different"
+
+// appScanDest returns the scan destinations for appColumns, in order. The
+// nullable text/float/date columns scan into pointer fields (NULL -> nil).
+func appScanDest(a *PlanningApplication) []any {
+	return []any{
+		&a.Name, &a.UID, &a.AreaName, &a.AreaID, &a.Address, &a.Postcode,
+		&a.Description, &a.AppType, &a.AppState, &a.AppSize,
+		&a.StartDate, &a.DecidedDate, &a.ConsultedDate,
+		&a.Latitude, &a.Longitude, &a.URL, &a.Link, &a.LastDifferent,
+	}
+}
+
+// scanApp hydrates one application from a single-row read (QueryRow).
+func scanApp(row pgx.Row) (PlanningApplication, error) {
+	var a PlanningApplication
+	if err := row.Scan(appScanDest(&a)...); err != nil {
+		return PlanningApplication{}, err
+	}
+	return a, nil
+}
+
+// scanAppRow adapts scanApp to pgx.CollectRows over a multi-row result.
+func scanAppRow(row pgx.CollectableRow) (PlanningApplication, error) {
+	return scanApp(row)
+}
+
+// upsertQuery writes the application keyed on the composite (authority_code,
+// planit_name). location is built from longitude ($15) and latitude ($16): when
+// either is NULL, ST_MakePoint yields NULL, so a coordinate-less application stores
+// a NULL location — matching the Cosmos newGeoPoint both-or-nothing rule.
+const upsertQuery = `
+INSERT INTO applications (
+	planit_name, authority_code, uid, area_name, area_id, address, postcode,
+	description, app_type, app_state, app_size, start_date, decided_date,
+	consulted_date, location, url, link, last_different
+) VALUES (
+	$1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+	ST_SetSRID(ST_MakePoint($15::double precision, $16::double precision), 4326)::geography,
+	$17, $18, $19
+)
+ON CONFLICT (authority_code, planit_name) DO UPDATE SET
+	uid = EXCLUDED.uid,
+	area_name = EXCLUDED.area_name,
+	area_id = EXCLUDED.area_id,
+	address = EXCLUDED.address,
+	postcode = EXCLUDED.postcode,
+	description = EXCLUDED.description,
+	app_type = EXCLUDED.app_type,
+	app_state = EXCLUDED.app_state,
+	app_size = EXCLUDED.app_size,
+	start_date = EXCLUDED.start_date,
+	decided_date = EXCLUDED.decided_date,
+	consulted_date = EXCLUDED.consulted_date,
+	location = EXCLUDED.location,
+	url = EXCLUDED.url,
+	link = EXCLUDED.link,
+	last_different = EXCLUDED.last_different`
+
+// Upsert inserts or updates the application. authority_code is the stringified
+// AreaID, matching the Cosmos partition key.
+func (s *PostgresStore) Upsert(ctx context.Context, a PlanningApplication) error {
+	_, err := s.db.Exec(ctx, upsertQuery,
+		a.Name, strconv.Itoa(a.AreaID), a.UID, a.AreaName, a.AreaID, a.Address,
+		a.Postcode, a.Description, a.AppType, a.AppState, a.AppSize,
+		a.StartDate, a.DecidedDate, a.ConsultedDate,
+		a.Longitude, a.Latitude, a.URL, a.Link, a.LastDifferent,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert application %q: %w", a.Name, err)
+	}
+	return nil
+}
+
+const getByAuthorityAndNameQuery = "SELECT " + appColumns +
+	" FROM applications WHERE authority_code = $1 AND planit_name = $2"
+
+// GetByAuthorityAndName point-reads by (authority_code, planit_name). The boolean
+// reports presence; a miss is a normal 404 for the caller, not an error.
+func (s *PostgresStore) GetByAuthorityAndName(ctx context.Context, authorityCode, name string) (PlanningApplication, bool, error) {
+	a, err := scanApp(s.db.QueryRow(ctx, getByAuthorityAndNameQuery, authorityCode, name))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return PlanningApplication{}, false, nil
+	}
+	if err != nil {
+		return PlanningApplication{}, false, fmt.Errorf("read application %q/%q: %w", authorityCode, name, err)
+	}
+	return a, true, nil
+}
+
+const getByUIDQuery = "SELECT " + appColumns +
+	" FROM applications WHERE authority_code = $1 AND uid = $2 ORDER BY planit_name LIMIT 1"
+
+// GetByUID looks up an application by its raw PlanIt uid within an authority,
+// for the saved-application lazy snapshot backfill. The boolean reports presence.
+func (s *PostgresStore) GetByUID(ctx context.Context, uid, authorityCode string) (PlanningApplication, bool, error) {
+	a, err := scanApp(s.db.QueryRow(ctx, getByUIDQuery, authorityCode, uid))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return PlanningApplication{}, false, nil
+	}
+	if err != nil {
+		return PlanningApplication{}, false, fmt.Errorf("read application uid %q in %q: %w", uid, authorityCode, err)
+	}
+	return a, true, nil
+}
+
+const pgRecentByAuthorityQuery = "SELECT " + appColumns +
+	" FROM applications WHERE authority_code = $1 ORDER BY last_different DESC LIMIT $2"
+
+// RecentByAuthority returns up to cap most-recently-active applications in the
+// authority, ordered by last_different DESC. It backs the build-time SEO endpoint.
+func (s *PostgresStore) RecentByAuthority(ctx context.Context, authorityCode string, cap int) ([]PlanningApplication, error) {
+	rows, err := s.db.Query(ctx, pgRecentByAuthorityQuery, authorityCode, cap)
+	if err != nil {
+		return nil, fmt.Errorf("recent applications for authority %q: %w", authorityCode, err)
+	}
+	apps, err := pgx.CollectRows(rows, scanAppRow)
+	if err != nil {
+		return nil, fmt.Errorf("recent applications for authority %q: %w", authorityCode, err)
+	}
+	return apps, nil
+}
+
+const pgBreakdownByAuthorityQuery = "SELECT app_state, count(*) FROM applications " +
+	"WHERE authority_code = $1 GROUP BY app_state"
+
+// BreakdownByAuthority returns the per-app_state distribution over the whole
+// authority, ordered by sortStateCounts (count DESC, then app_state ASC, nil last).
+// A NULL app_state is its own GROUP BY bucket and folds into the single nil bucket.
+func (s *PostgresStore) BreakdownByAuthority(ctx context.Context, authorityCode string) ([]StateCount, error) {
+	rows, err := s.db.Query(ctx, pgBreakdownByAuthorityQuery, authorityCode)
+	if err != nil {
+		return nil, fmt.Errorf("status breakdown for authority %q: %w", authorityCode, err)
+	}
+	out, err := collectBreakdown(rows)
+	if err != nil {
+		return nil, fmt.Errorf("status breakdown for authority %q: %w", authorityCode, err)
+	}
+	return out, nil
+}
+
+// nearbyPoint is the GeoJSON-equivalent query point for the authority-agnostic
+// browse reads, built from $1 (longitude) and $2 (latitude).
+const nearbyPoint = "ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography"
+
+// findNearbyFirstPageQuery returns the nearest `limit` in-radius applications,
+// ordered by the KNN <-> distance then planit_name (the keyset tie-break).
+const findNearbyFirstPageQuery = "SELECT " + appColumns + ", location <-> " + nearbyPoint + " AS distance " +
+	"FROM applications WHERE ST_DWithin(location, " + nearbyPoint + ", $3) " +
+	"ORDER BY location <-> " + nearbyPoint + ", planit_name LIMIT $4"
+
+// findNearbyKeysetQuery resumes after the cursor's (distance, planit_name): rows
+// strictly farther, or at the same distance with a greater name. This is the
+// stable keyset predicate matching the ORDER BY, so pages never overlap or gap.
+const findNearbyKeysetQuery = "SELECT " + appColumns + ", location <-> " + nearbyPoint + " AS distance " +
+	"FROM applications WHERE ST_DWithin(location, " + nearbyPoint + ", $3) " +
+	"AND (location <-> " + nearbyPoint + " > $5 " +
+	"OR (location <-> " + nearbyPoint + " = $5 AND planit_name > $6)) " +
+	"ORDER BY location <-> " + nearbyPoint + ", planit_name LIMIT $4"
+
+// nearbyRow carries a hydrated application plus its computed distance, so the last
+// row of a full page can be encoded into the next-page cursor.
+type nearbyRow struct {
+	app  PlanningApplication
+	dist float64
+}
+
+func scanNearbyRow(row pgx.CollectableRow) (nearbyRow, error) {
+	var nr nearbyRow
+	dest := append(appScanDest(&nr.app), &nr.dist)
+	if err := row.Scan(dest...); err != nil {
+		return nearbyRow{}, err
+	}
+	return nr, nil
+}
+
+// FindNearbyPage returns one nearest-first page of up to limit applications within
+// radiusMetres of (latitude, longitude), plus an opaque cursor for the next page
+// (empty when exhausted). This is the new, correct nearest-first behaviour memo
+// 0010 calls for — true KNN ordering with stable keyset pagination, which the
+// Cosmos Gateway cannot serve cross-partition. It is authority-agnostic.
+func (s *PostgresStore) FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error) {
+	var (
+		rows pgx.Rows
+		err  error
+	)
+	if cursor == "" {
+		rows, err = s.db.Query(ctx, findNearbyFirstPageQuery, longitude, latitude, radiusMetres, limit)
+	} else {
+		dist, name, decodeErr := decodeNearbyCursor(cursor)
+		if decodeErr != nil {
+			return nil, "", fmt.Errorf("decode nearby cursor: %w", decodeErr)
+		}
+		rows, err = s.db.Query(ctx, findNearbyKeysetQuery, longitude, latitude, radiusMetres, limit, dist, name)
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("find applications near (%v, %v): %w", latitude, longitude, err)
+	}
+
+	collected, err := pgx.CollectRows(rows, scanNearbyRow)
+	if err != nil {
+		return nil, "", fmt.Errorf("find applications near (%v, %v): %w", latitude, longitude, err)
+	}
+
+	apps := make([]PlanningApplication, len(collected))
+	for i := range collected {
+		apps[i] = collected[i].app
+	}
+
+	next := ""
+	if limit > 0 && len(collected) == limit {
+		last := collected[len(collected)-1]
+		next, err = encodeNearbyCursor(last.dist, last.app.Name)
+		if err != nil {
+			return nil, "", fmt.Errorf("encode nearby cursor: %w", err)
+		}
+	}
+	return apps, next, nil
+}
+
+// seoNearbyPoint is the query point for the authority-scoped SEO spatial reads,
+// built from $2 (longitude) and $3 (latitude); $1 is the authority_code.
+const seoNearbyPoint = "ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography"
+
+const pgRecentNearbyQuery = "SELECT " + appColumns +
+	" FROM applications WHERE authority_code = $1 AND ST_DWithin(location, " + seoNearbyPoint + ", $4) " +
+	"ORDER BY last_different DESC LIMIT $5"
+
+// RecentNearby returns up to cap most-recently-active applications within
+// radiusMetres of (lat, lng) inside the authority, ordered by last_different DESC.
+// The authority scope is kept for parity with the Cosmos read (memo 0010 notes a
+// later phase may relax it; not relaxed here).
+func (s *PostgresStore) RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error) {
+	rows, err := s.db.Query(ctx, pgRecentNearbyQuery, authorityCode, lng, lat, radiusMetres, cap)
+	if err != nil {
+		return nil, fmt.Errorf("recent applications near %q: %w", authorityCode, err)
+	}
+	apps, err := pgx.CollectRows(rows, scanAppRow)
+	if err != nil {
+		return nil, fmt.Errorf("recent applications near %q: %w", authorityCode, err)
+	}
+	return apps, nil
+}
+
+const pgNearestNearbyQuery = "SELECT " + appColumns +
+	" FROM applications WHERE authority_code = $1 AND ST_DWithin(location, " + seoNearbyPoint + ", $4) " +
+	"ORDER BY location <-> " + seoNearbyPoint + " LIMIT $5"
+
+// NearestNearby returns up to cap applications nearest to (lat, lng) within
+// radiusMetres inside the authority, ordered by the KNN <-> distance ASC.
+func (s *PostgresStore) NearestNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error) {
+	rows, err := s.db.Query(ctx, pgNearestNearbyQuery, authorityCode, lng, lat, radiusMetres, cap)
+	if err != nil {
+		return nil, fmt.Errorf("nearest applications near %q: %w", authorityCode, err)
+	}
+	apps, err := pgx.CollectRows(rows, scanAppRow)
+	if err != nil {
+		return nil, fmt.Errorf("nearest applications near %q: %w", authorityCode, err)
+	}
+	return apps, nil
+}
+
+const pgBreakdownNearbyQuery = "SELECT app_state, count(*) FROM applications " +
+	"WHERE authority_code = $1 AND ST_DWithin(location, " + seoNearbyPoint + ", $4) GROUP BY app_state"
+
+// BreakdownNearby returns the per-app_state distribution over the in-radius,
+// authority-scoped set, ordered by sortStateCounts. The NULL bucket folds into nil.
+func (s *PostgresStore) BreakdownNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) ([]StateCount, error) {
+	rows, err := s.db.Query(ctx, pgBreakdownNearbyQuery, authorityCode, lng, lat, radiusMetres)
+	if err != nil {
+		return nil, fmt.Errorf("status breakdown near %q: %w", authorityCode, err)
+	}
+	out, err := collectBreakdown(rows)
+	if err != nil {
+		return nil, fmt.Errorf("status breakdown near %q: %w", authorityCode, err)
+	}
+	return out, nil
+}
+
+// collectBreakdown scans (app_state, count) rows into StateCounts (NULL app_state
+// -> nil bucket) and applies the shared sortStateCounts ordering.
+func collectBreakdown(rows pgx.Rows) ([]StateCount, error) {
+	out, err := pgx.CollectRows(rows, func(row pgx.CollectableRow) (StateCount, error) {
+		var sc StateCount
+		if err := row.Scan(&sc.AppState, &sc.Count); err != nil {
+			return StateCount{}, err
+		}
+		return sc, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sortStateCounts(out)
+	return out, nil
+}
+
+// nearbyCursor is the opaque keyset cursor: the last row's distance (as a
+// round-trippable decimal string) and planit_name. It is base64url-encoded JSON.
+type nearbyCursor struct {
+	D string `json:"d"`
+	N string `json:"n"`
+}
+
+// encodeNearbyCursor serialises the keyset position. The distance is formatted
+// with shortest round-trippable precision so the next page's predicate compares
+// against the exact float the database produced.
+func encodeNearbyCursor(dist float64, name string) (string, error) {
+	b, err := json.Marshal(nearbyCursor{D: strconv.FormatFloat(dist, 'g', -1, 64), N: name})
+	if err != nil {
+		return "", fmt.Errorf("marshal cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+func decodeNearbyCursor(cursor string) (dist float64, name string, err error) {
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, "", fmt.Errorf("base64 decode: %w", err)
+	}
+	var c nearbyCursor
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return 0, "", fmt.Errorf("unmarshal cursor: %w", err)
+	}
+	dist, err = strconv.ParseFloat(c.D, 64)
+	if err != nil {
+		return 0, "", fmt.Errorf("parse cursor distance: %w", err)
+	}
+	return dist, c.N, nil
+}

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -1,0 +1,530 @@
+//go:build integration
+
+package applications
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// Deterministic fixture geometry, mirroring the Phase 0 spatial proof
+// (internal/platform/postgres/spatial_integration_test.go): a fixed London
+// centre with applications offset due north by a known number of metres, so
+// PostGIS's spheroidal distances are exact to within a metre.
+const (
+	pgCentreLon    = -0.1278
+	pgCentreLat    = 51.5074
+	pgMetresPerLat = 111_320.0
+)
+
+func pgLatNorth(metres float64) float64 { return pgCentreLat + metres/pgMetresPerLat }
+
+// pgPtr returns a pointer to v. Used to populate the nullable pointer fields of
+// PlanningApplication in test fixtures.
+func pgPtr[T any](v T) *T { return &v }
+
+// newAppPGStore returns a Postgres-backed applications store over a truncated
+// database. Integration tests are NOT run in parallel: they share the single
+// docker-compose database and TRUNCATE it per test for isolation.
+func newAppPGStore(t *testing.T) (*PostgresStore, *pgxpool.Pool) {
+	t.Helper()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "applications", "watch_zones")
+	return NewPostgresStore(pool), pool
+}
+
+// pgApp builds a baseline application in the given authority with all nullable
+// fields left nil and no coordinates. Tests set the fields they exercise.
+func pgApp(name string, areaID int) PlanningApplication {
+	return PlanningApplication{
+		Name:          name,
+		UID:           "uid-" + name,
+		AreaName:      "Testshire",
+		AreaID:        areaID,
+		Address:       "1 Test Street",
+		Description:   "a planning application",
+		LastDifferent: time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+// at places the application's centre `metres` due north of the fixture centre.
+func at(a PlanningApplication, metres float64) PlanningApplication {
+	a.Longitude = pgPtr(pgCentreLon)
+	a.Latitude = pgPtr(pgLatNorth(metres))
+	return a
+}
+
+func assertTimePtrEqual(t *testing.T, field string, got, want *time.Time) {
+	t.Helper()
+	if (got == nil) != (want == nil) {
+		t.Errorf("%s nil mismatch: got %v, want %v", field, got, want)
+		return
+	}
+	if got != nil && !got.Equal(*want) {
+		t.Errorf("%s: got %v, want %v", field, *got, *want)
+	}
+}
+
+// assertAppEqual compares two snapshots, using time.Equal for the temporal
+// fields (a timestamptz/date round-trip can change the time.Time location while
+// preserving the instant) and reflect.DeepEqual for everything else.
+func assertAppEqual(t *testing.T, got, want PlanningApplication) {
+	t.Helper()
+	if !got.LastDifferent.Equal(want.LastDifferent) {
+		t.Errorf("LastDifferent: got %v, want %v", got.LastDifferent, want.LastDifferent)
+	}
+	assertTimePtrEqual(t, "StartDate", got.StartDate, want.StartDate)
+	assertTimePtrEqual(t, "DecidedDate", got.DecidedDate, want.DecidedDate)
+	assertTimePtrEqual(t, "ConsultedDate", got.ConsultedDate, want.ConsultedDate)
+
+	g, w := got, want
+	g.LastDifferent, w.LastDifferent = time.Time{}, time.Time{}
+	g.StartDate, w.StartDate = nil, nil
+	g.DecidedDate, w.DecidedDate = nil, nil
+	g.ConsultedDate, w.ConsultedDate = nil, nil
+	if !reflect.DeepEqual(g, w) {
+		t.Errorf("application mismatch:\n got = %+v\nwant = %+v", g, w)
+	}
+}
+
+func appNames(apps []PlanningApplication) []string {
+	names := make([]string, len(apps))
+	for i, a := range apps {
+		names[i] = a.Name
+	}
+	return names
+}
+
+func assertNames(t *testing.T, got, want []string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("names = %v, want %v", got, want)
+	}
+}
+
+// TestPostgresStore_Upsert_RoundTripFull writes a fully-populated application —
+// every nullable field set, coordinates present — and reads it back unchanged.
+func TestPostgresStore_Upsert_RoundTripFull(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newAppPGStore(t)
+
+	start := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	decided := time.Date(2026, 3, 4, 0, 0, 0, 0, time.UTC)
+	consulted := time.Date(2026, 2, 3, 0, 0, 0, 0, time.UTC)
+	want := PlanningApplication{
+		Name:          "24/0001/FUL",
+		UID:           "raw-uid-1",
+		AreaName:      "Testshire",
+		AreaID:        100,
+		Address:       "1 Test Street",
+		Postcode:      pgPtr("TE1 1ST"),
+		Description:   "Single storey rear extension",
+		AppType:       pgPtr("Full"),
+		AppState:      pgPtr("Permitted"),
+		AppSize:       pgPtr("Small"),
+		StartDate:     &start,
+		DecidedDate:   &decided,
+		ConsultedDate: &consulted,
+		Longitude:     pgPtr(pgCentreLon),
+		Latitude:      pgPtr(pgLatNorth(100)),
+		URL:           pgPtr("https://example.test/app/1"),
+		Link:          pgPtr("https://example.test/link/1"),
+		LastDifferent: time.Date(2026, 6, 26, 9, 30, 0, 0, time.UTC),
+	}
+
+	if err := store.Upsert(ctx, want); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	got, found, err := store.GetByAuthorityAndName(ctx, "100", "24/0001/FUL")
+	if err != nil {
+		t.Fatalf("GetByAuthorityAndName: %v", err)
+	}
+	if !found {
+		t.Fatal("expected application to be found")
+	}
+	assertAppEqual(t, got, want)
+}
+
+// TestPostgresStore_Upsert_RoundTripNullable writes an application with every
+// nullable field absent and no coordinates, and reads back the same nils — the
+// NULL-location case PostGIS must preserve.
+func TestPostgresStore_Upsert_RoundTripNullable(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newAppPGStore(t)
+
+	want := pgApp("24/0002/FUL", 100) // all pointers nil, no coords
+	if err := store.Upsert(ctx, want); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	got, found, err := store.GetByAuthorityAndName(ctx, "100", "24/0002/FUL")
+	if err != nil {
+		t.Fatalf("GetByAuthorityAndName: %v", err)
+	}
+	if !found {
+		t.Fatal("expected application to be found")
+	}
+	assertAppEqual(t, got, want)
+	if got.Latitude != nil || got.Longitude != nil {
+		t.Errorf("expected nil coordinates, got lat=%v lon=%v", got.Latitude, got.Longitude)
+	}
+}
+
+// TestPostgresStore_Upsert_UpdatesInPlace proves ON CONFLICT (authority_code,
+// planit_name) updates the existing row rather than inserting a second.
+func TestPostgresStore_Upsert_UpdatesInPlace(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newAppPGStore(t)
+
+	first := pgApp("24/0003/FUL", 100)
+	first.AppState = pgPtr("Pending")
+	first.Address = "old address"
+	if err := store.Upsert(ctx, first); err != nil {
+		t.Fatalf("Upsert first: %v", err)
+	}
+
+	second := pgApp("24/0003/FUL", 100)
+	second.AppState = pgPtr("Permitted")
+	second.Address = "new address"
+	if err := store.Upsert(ctx, second); err != nil {
+		t.Fatalf("Upsert second: %v", err)
+	}
+
+	got, found, err := store.GetByAuthorityAndName(ctx, "100", "24/0003/FUL")
+	if err != nil || !found {
+		t.Fatalf("GetByAuthorityAndName: found=%v err=%v", found, err)
+	}
+	if got.Address != "new address" || got.AppState == nil || *got.AppState != "Permitted" {
+		t.Errorf("expected updated row, got address=%q appState=%v", got.Address, got.AppState)
+	}
+	// Exactly one row for the authority.
+	all, err := store.RecentByAuthority(ctx, "100", 10)
+	if err != nil {
+		t.Fatalf("RecentByAuthority: %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("expected 1 row after in-place update, got %d", len(all))
+	}
+}
+
+// TestPostgresStore_Upsert_CompositeKeyAllowsSameNameAcrossAuthorities is the
+// schema-correction proof: a PlanIt case reference is only unique within an
+// authority, so two authorities sharing the same planit_name must coexist as two
+// distinct rows. A global planit_name PRIMARY KEY would silently overwrite one.
+func TestPostgresStore_Upsert_CompositeKeyAllowsSameNameAcrossAuthorities(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newAppPGStore(t)
+
+	a := pgApp("24/SAME/FUL", 100)
+	a.UID = "uid-authority-100"
+	a.AreaName = "Northshire"
+	b := pgApp("24/SAME/FUL", 200)
+	b.UID = "uid-authority-200"
+	b.AreaName = "Southshire"
+
+	if err := store.Upsert(ctx, a); err != nil {
+		t.Fatalf("Upsert a: %v", err)
+	}
+	if err := store.Upsert(ctx, b); err != nil {
+		t.Fatalf("Upsert b: %v", err)
+	}
+
+	gotA, foundA, err := store.GetByAuthorityAndName(ctx, "100", "24/SAME/FUL")
+	if err != nil || !foundA {
+		t.Fatalf("get a: found=%v err=%v", foundA, err)
+	}
+	gotB, foundB, err := store.GetByAuthorityAndName(ctx, "200", "24/SAME/FUL")
+	if err != nil || !foundB {
+		t.Fatalf("get b: found=%v err=%v", foundB, err)
+	}
+	if gotA.UID != "uid-authority-100" || gotA.AreaName != "Northshire" {
+		t.Errorf("authority 100 row clobbered: %+v", gotA)
+	}
+	if gotB.UID != "uid-authority-200" || gotB.AreaName != "Southshire" {
+		t.Errorf("authority 200 row clobbered: %+v", gotB)
+	}
+}
+
+// TestPostgresStore_GetByAuthorityAndName_Miss returns found=false, no error.
+func TestPostgresStore_GetByAuthorityAndName_Miss(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newAppPGStore(t)
+
+	_, found, err := store.GetByAuthorityAndName(ctx, "100", "does-not-exist")
+	if err != nil {
+		t.Fatalf("expected nil error on miss, got %v", err)
+	}
+	if found {
+		t.Fatal("expected found=false on miss")
+	}
+}
+
+// TestPostgresStore_GetByUID covers the saved-application backfill lookup: by raw
+// uid within an authority, with a miss (and a wrong-authority miss) returning
+// found=false and no error.
+func TestPostgresStore_GetByUID(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newAppPGStore(t)
+
+	a := pgApp("24/0004/FUL", 100)
+	a.UID = "the-uid"
+	if err := store.Upsert(ctx, a); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	got, found, err := store.GetByUID(ctx, "the-uid", "100")
+	if err != nil || !found {
+		t.Fatalf("GetByUID hit: found=%v err=%v", found, err)
+	}
+	if got.Name != "24/0004/FUL" {
+		t.Errorf("GetByUID returned wrong app: %+v", got)
+	}
+
+	if _, found, err := store.GetByUID(ctx, "no-such-uid", "100"); err != nil || found {
+		t.Errorf("GetByUID miss: found=%v err=%v", found, err)
+	}
+	if _, found, err := store.GetByUID(ctx, "the-uid", "200"); err != nil || found {
+		t.Errorf("GetByUID wrong-authority: found=%v err=%v", found, err)
+	}
+}
+
+// TestPostgresStore_RecentByAuthority orders by last_different DESC, bounds by
+// cap, and scopes to the authority.
+func TestPostgresStore_RecentByAuthority(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newAppPGStore(t)
+
+	older := pgApp("OLD", 100)
+	older.LastDifferent = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mid := pgApp("MID", 100)
+	mid.LastDifferent = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	newer := pgApp("NEW", 100)
+	newer.LastDifferent = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	other := pgApp("OTHER-AUTH", 200) // must not appear for authority 100
+	for _, a := range []PlanningApplication{older, mid, newer, other} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	got, err := store.RecentByAuthority(ctx, "100", 10)
+	if err != nil {
+		t.Fatalf("RecentByAuthority: %v", err)
+	}
+	assertNames(t, appNames(got), []string{"NEW", "MID", "OLD"})
+
+	capped, err := store.RecentByAuthority(ctx, "100", 2)
+	if err != nil {
+		t.Fatalf("RecentByAuthority capped: %v", err)
+	}
+	assertNames(t, appNames(capped), []string{"NEW", "MID"})
+}
+
+// TestPostgresStore_BreakdownByAuthority returns exact per-app_state counts
+// including the NULL-app_state bucket, sorted by sortStateCounts, scoped to the
+// authority and summing to the true total.
+func TestPostgresStore_BreakdownByAuthority(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newAppPGStore(t)
+
+	apps := []PlanningApplication{
+		withState(pgApp("P1", 100), pgPtr("Permitted")),
+		withState(pgApp("P2", 100), pgPtr("Permitted")),
+		withState(pgApp("R1", 100), pgPtr("Rejected")),
+		withState(pgApp("N1", 100), nil), // NULL app_state
+		withState(pgApp("OTHER", 200), pgPtr("Permitted")),
+	}
+	for _, a := range apps {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	got, err := store.BreakdownByAuthority(ctx, "100")
+	if err != nil {
+		t.Fatalf("BreakdownByAuthority: %v", err)
+	}
+	want := []StateCount{
+		{AppState: pgPtr("Permitted"), Count: 2},
+		{AppState: pgPtr("Rejected"), Count: 1},
+		{AppState: nil, Count: 1},
+	}
+	assertBreakdown(t, got, want)
+}
+
+func withState(a PlanningApplication, state *string) PlanningApplication {
+	a.AppState = state
+	return a
+}
+
+func assertBreakdown(t *testing.T, got, want []StateCount) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("breakdown length = %d, want %d (%+v)", len(got), len(want), got)
+	}
+	total := 0
+	for i := range want {
+		if (got[i].AppState == nil) != (want[i].AppState == nil) {
+			t.Fatalf("bucket %d appState nil mismatch: got %v want %v", i, got[i].AppState, want[i].AppState)
+		}
+		if got[i].AppState != nil && *got[i].AppState != *want[i].AppState {
+			t.Fatalf("bucket %d appState: got %q want %q", i, *got[i].AppState, *want[i].AppState)
+		}
+		if got[i].Count != want[i].Count {
+			t.Fatalf("bucket %d count: got %d want %d", i, got[i].Count, want[i].Count)
+		}
+		total += got[i].Count
+	}
+	wantTotal := 0
+	for _, w := range want {
+		wantTotal += w.Count
+	}
+	if total != wantTotal {
+		t.Fatalf("breakdown total = %d, want %d", total, wantTotal)
+	}
+}
+
+// TestPostgresStore_FindNearbyPage proves nearest-first ordering, the radius
+// filter, and keyset pagination across pages with no overlap or gap and an empty
+// next-cursor at exhaustion.
+func TestPostgresStore_FindNearbyPage(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newAppPGStore(t)
+
+	for _, a := range []PlanningApplication{
+		at(pgApp("APP-100", 100), 100),
+		at(pgApp("APP-500", 100), 500),
+		at(pgApp("APP-5000", 100), 5000),
+		at(pgApp("APP-FAR", 100), 50000), // outside any test radius
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	// Radius filter + nearest-first ordering, first page.
+	page1, cursor1, err := store.FindNearbyPage(ctx, pgCentreLat, pgCentreLon, 6000, 2, "")
+	if err != nil {
+		t.Fatalf("FindNearbyPage page1: %v", err)
+	}
+	assertNames(t, appNames(page1), []string{"APP-100", "APP-500"})
+	if cursor1 == "" {
+		t.Fatal("expected a continuation cursor after a full page")
+	}
+
+	page2, cursor2, err := store.FindNearbyPage(ctx, pgCentreLat, pgCentreLon, 6000, 2, cursor1)
+	if err != nil {
+		t.Fatalf("FindNearbyPage page2: %v", err)
+	}
+	assertNames(t, appNames(page2), []string{"APP-5000"})
+	if cursor2 != "" {
+		t.Fatalf("expected empty cursor at exhaustion, got %q", cursor2)
+	}
+	// APP-FAR (50 km) is excluded by the 6 km radius.
+}
+
+// TestPostgresStore_FindNearbyPage_TieBreak proves the planit_name tie-break
+// keeps keyset pagination correct when two applications share an exact distance.
+func TestPostgresStore_FindNearbyPage_TieBreak(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newAppPGStore(t)
+
+	for _, a := range []PlanningApplication{
+		at(pgApp("APP-1-100", 100), 100),
+		at(pgApp("APP-2-200A", 100), 200),
+		at(pgApp("APP-3-200B", 100), 200), // identical distance to 200A
+		at(pgApp("APP-4-500", 100), 500),
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	var collected []string
+	cursor := ""
+	for range 10 { // safety bound
+		page, next, err := store.FindNearbyPage(ctx, pgCentreLat, pgCentreLon, 1000, 1, cursor)
+		if err != nil {
+			t.Fatalf("FindNearbyPage: %v", err)
+		}
+		collected = append(collected, appNames(page)...)
+		if next == "" {
+			break
+		}
+		cursor = next
+	}
+	assertNames(t, collected, []string{"APP-1-100", "APP-2-200A", "APP-3-200B", "APP-4-500"})
+}
+
+// TestPostgresStore_RecentNearby_And_NearestNearby distinguishes recency ordering
+// (last_different DESC) from distance ordering (nearest first), and proves the
+// radius filter and authority scope.
+func TestPostgresStore_RecentNearby_And_NearestNearby(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newAppPGStore(t)
+
+	near := at(pgApp("NEAR", 100), 100)
+	near.LastDifferent = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // oldest
+	far := at(pgApp("FAR", 100), 500)
+	far.LastDifferent = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC) // newest
+	outside := at(pgApp("OUTSIDE", 100), 5000)                      // beyond 1 km
+	otherAuth := at(pgApp("OTHER-AUTH", 200), 100)                  // wrong authority
+	for _, a := range []PlanningApplication{near, far, outside, otherAuth} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	recent, err := store.RecentNearby(ctx, "100", pgCentreLat, pgCentreLon, 1000, 10)
+	if err != nil {
+		t.Fatalf("RecentNearby: %v", err)
+	}
+	assertNames(t, appNames(recent), []string{"FAR", "NEAR"}) // recency DESC
+
+	nearest, err := store.NearestNearby(ctx, "100", pgCentreLat, pgCentreLon, 1000, 10)
+	if err != nil {
+		t.Fatalf("NearestNearby: %v", err)
+	}
+	assertNames(t, appNames(nearest), []string{"NEAR", "FAR"}) // distance ASC
+
+	capped, err := store.NearestNearby(ctx, "100", pgCentreLat, pgCentreLon, 1000, 1)
+	if err != nil {
+		t.Fatalf("NearestNearby capped: %v", err)
+	}
+	assertNames(t, appNames(capped), []string{"NEAR"})
+}
+
+// TestPostgresStore_BreakdownNearby returns the exact per-app_state counts over
+// the in-radius, authority-scoped set, including the NULL bucket.
+func TestPostgresStore_BreakdownNearby(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newAppPGStore(t)
+
+	apps := []PlanningApplication{
+		withState(at(pgApp("P1", 100), 100), pgPtr("Permitted")),
+		withState(at(pgApp("P2", 100), 500), pgPtr("Permitted")),
+		withState(at(pgApp("N1", 100), 300), nil),                   // NULL state, in radius
+		withState(at(pgApp("OUT", 100), 5000), pgPtr("Permitted")),  // out of radius
+		withState(at(pgApp("OTHER", 200), 100), pgPtr("Permitted")), // wrong authority
+	}
+	for _, a := range apps {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	got, err := store.BreakdownNearby(ctx, "100", pgCentreLat, pgCentreLon, 1000)
+	if err != nil {
+		t.Fatalf("BreakdownNearby: %v", err)
+	}
+	want := []StateCount{
+		{AppState: pgPtr("Permitted"), Count: 2},
+		{AppState: nil, Count: 1},
+	}
+	assertBreakdown(t, got, want)
+}

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
 )
 
@@ -32,11 +30,11 @@ func pgPtr[T any](v T) *T { return &v }
 // newAppPGStore returns a Postgres-backed applications store over a truncated
 // database. Integration tests are NOT run in parallel: they share the single
 // docker-compose database and TRUNCATE it per test for isolation.
-func newAppPGStore(t *testing.T) (*PostgresStore, *pgxpool.Pool) {
+func newAppPGStore(t *testing.T) *PostgresStore {
 	t.Helper()
 	pool := pgtest.New(t)
 	pgtest.Truncate(t, pool, "applications", "watch_zones")
-	return NewPostgresStore(pool), pool
+	return NewPostgresStore(pool)
 }
 
 // pgApp builds a baseline application in the given authority with all nullable
@@ -112,7 +110,7 @@ func assertNames(t *testing.T, got, want []string) {
 // every nullable field set, coordinates present — and reads it back unchanged.
 func TestPostgresStore_Upsert_RoundTripFull(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newAppPGStore(t)
+	store := newAppPGStore(t)
 
 	start := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
 	decided := time.Date(2026, 3, 4, 0, 0, 0, 0, time.UTC)
@@ -156,7 +154,7 @@ func TestPostgresStore_Upsert_RoundTripFull(t *testing.T) {
 // NULL-location case PostGIS must preserve.
 func TestPostgresStore_Upsert_RoundTripNullable(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newAppPGStore(t)
+	store := newAppPGStore(t)
 
 	want := pgApp("24/0002/FUL", 100) // all pointers nil, no coords
 	if err := store.Upsert(ctx, want); err != nil {
@@ -179,7 +177,7 @@ func TestPostgresStore_Upsert_RoundTripNullable(t *testing.T) {
 // planit_name) updates the existing row rather than inserting a second.
 func TestPostgresStore_Upsert_UpdatesInPlace(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newAppPGStore(t)
+	store := newAppPGStore(t)
 
 	first := pgApp("24/0003/FUL", 100)
 	first.AppState = pgPtr("Pending")
@@ -218,7 +216,7 @@ func TestPostgresStore_Upsert_UpdatesInPlace(t *testing.T) {
 // distinct rows. A global planit_name PRIMARY KEY would silently overwrite one.
 func TestPostgresStore_Upsert_CompositeKeyAllowsSameNameAcrossAuthorities(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newAppPGStore(t)
+	store := newAppPGStore(t)
 
 	a := pgApp("24/SAME/FUL", 100)
 	a.UID = "uid-authority-100"
@@ -253,7 +251,7 @@ func TestPostgresStore_Upsert_CompositeKeyAllowsSameNameAcrossAuthorities(t *tes
 // TestPostgresStore_GetByAuthorityAndName_Miss returns found=false, no error.
 func TestPostgresStore_GetByAuthorityAndName_Miss(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newAppPGStore(t)
+	store := newAppPGStore(t)
 
 	_, found, err := store.GetByAuthorityAndName(ctx, "100", "does-not-exist")
 	if err != nil {
@@ -269,7 +267,7 @@ func TestPostgresStore_GetByAuthorityAndName_Miss(t *testing.T) {
 // found=false and no error.
 func TestPostgresStore_GetByUID(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newAppPGStore(t)
+	store := newAppPGStore(t)
 
 	a := pgApp("24/0004/FUL", 100)
 	a.UID = "the-uid"
@@ -297,7 +295,7 @@ func TestPostgresStore_GetByUID(t *testing.T) {
 // cap, and scopes to the authority.
 func TestPostgresStore_RecentByAuthority(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newAppPGStore(t)
+	store := newAppPGStore(t)
 
 	older := pgApp("OLD", 100)
 	older.LastDifferent = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -330,7 +328,7 @@ func TestPostgresStore_RecentByAuthority(t *testing.T) {
 // authority and summing to the true total.
 func TestPostgresStore_BreakdownByAuthority(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newAppPGStore(t)
+	store := newAppPGStore(t)
 
 	apps := []PlanningApplication{
 		withState(pgApp("P1", 100), pgPtr("Permitted")),
@@ -394,7 +392,7 @@ func assertBreakdown(t *testing.T, got, want []StateCount) {
 // next-cursor at exhaustion.
 func TestPostgresStore_FindNearbyPage(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newAppPGStore(t)
+	store := newAppPGStore(t)
 
 	for _, a := range []PlanningApplication{
 		at(pgApp("APP-100", 100), 100),
@@ -432,7 +430,7 @@ func TestPostgresStore_FindNearbyPage(t *testing.T) {
 // keeps keyset pagination correct when two applications share an exact distance.
 func TestPostgresStore_FindNearbyPage_TieBreak(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newAppPGStore(t)
+	store := newAppPGStore(t)
 
 	for _, a := range []PlanningApplication{
 		at(pgApp("APP-1-100", 100), 100),
@@ -466,7 +464,7 @@ func TestPostgresStore_FindNearbyPage_TieBreak(t *testing.T) {
 // radius filter and authority scope.
 func TestPostgresStore_RecentNearby_And_NearestNearby(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newAppPGStore(t)
+	store := newAppPGStore(t)
 
 	near := at(pgApp("NEAR", 100), 100)
 	near.LastDifferent = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // oldest
@@ -503,7 +501,7 @@ func TestPostgresStore_RecentNearby_And_NearestNearby(t *testing.T) {
 // the in-radius, authority-scoped set, including the NULL bucket.
 func TestPostgresStore_BreakdownNearby(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newAppPGStore(t)
+	store := newAppPGStore(t)
 
 	apps := []PlanningApplication{
 		withState(at(pgApp("P1", 100), 100), pgPtr("Permitted")),

--- a/api-go/internal/platform/postgres/migrations/0002_applications_composite_key.sql
+++ b/api-go/internal/platform/postgres/migrations/0002_applications_composite_key.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+
+-- Migration 0001 made planit_name a GLOBAL primary key, which is wrong: a PlanIt
+-- case reference is only unique WITHIN an authority (see PlanningApplication.
+-- CanonicalUID and the Cosmos model — partition key authorityCode, doc id Name).
+-- Two authorities can legitimately share a planit_name; a global PK would let one
+-- silently overwrite the other, and the memo 0010 Upsert
+-- (INSERT ... ON CONFLICT (authority_code, planit_name)) cannot run without a
+-- matching unique constraint. Replace the single-column PK with the composite
+-- (authority_code, planit_name). The GiST, authority_recent and app_state indexes
+-- are unaffected.
+ALTER TABLE applications DROP CONSTRAINT applications_pkey;
+ALTER TABLE applications ADD CONSTRAINT applications_pkey PRIMARY KEY (authority_code, planit_name);
+
+-- +goose Down
+
+ALTER TABLE applications DROP CONSTRAINT applications_pkey;
+ALTER TABLE applications ADD CONSTRAINT applications_pkey PRIMARY KEY (planit_name);

--- a/api-go/internal/platform/postgres/pgtest/pgtest.go
+++ b/api-go/internal/platform/postgres/pgtest/pgtest.go
@@ -19,11 +19,26 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
 )
 
+// serializeLockKey is the fixed key for the cross-process advisory lock New
+// acquires. Its only purpose is to make every test that touches the shared
+// database mutually exclusive; the value is arbitrary.
+const serializeLockKey int64 = 0x70_67_74_65_73_74 // "pgtest"
+
 // New returns a migrated connection pool for the test database. It reads the DSN
 // from TEST_DATABASE_URL (or the docker-compose default), pings to confirm
 // reachability, and applies all pending migrations. If the database is
 // unreachable the test is skipped with instructions to bring the stack up. The
 // pool is closed automatically via t.Cleanup.
+//
+// New also holds a session-level advisory lock for the test's whole duration, so
+// all tests that use this harness run one at a time — even across packages.
+// `go test ./...` runs each package's test binary in parallel, and they all share
+// this single database, so without that lock one package's TRUNCATE wipes another
+// package's freshly-seeded fixtures mid-test. Non-DB packages never call New, so
+// they stay parallel. A test that calls New must therefore NOT also call
+// t.Parallel: the lock is released in t.Cleanup, which for a parallel test runs
+// only after the whole parallel group finishes, so two parallel New callers would
+// deadlock.
 func New(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 
@@ -47,8 +62,33 @@ func New(t *testing.T) *pgxpool.Pool {
 		t.Fatalf("migrate test database: %v", err)
 	}
 
+	// Registered before the lock cleanup so it runs LAST (cleanups are LIFO): the
+	// lock is released and its connection returned before the pool is closed.
 	t.Cleanup(pool.Close)
+	acquireSerializeLock(t, pool)
+
 	return pool
+}
+
+// acquireSerializeLock takes the global advisory lock on a dedicated pooled
+// connection and registers a cleanup that releases it. See New for why.
+func acquireSerializeLock(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+
+	conn, err := pool.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("acquire advisory-lock connection: %v", err)
+	}
+	if _, err := conn.Exec(context.Background(), "SELECT pg_advisory_lock($1)", serializeLockKey); err != nil {
+		conn.Release()
+		t.Fatalf("acquire advisory lock: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := conn.Exec(context.Background(), "SELECT pg_advisory_unlock($1)", serializeLockKey); err != nil {
+			t.Logf("release advisory lock: %v", err)
+		}
+		conn.Release()
+	})
 }
 
 // Truncate empties the named tables (RESTART IDENTITY CASCADE) so each test

--- a/api-go/internal/watchzones/store_postgres.go
+++ b/api-go/internal/watchzones/store_postgres.go
@@ -1,0 +1,211 @@
+package watchzones
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// querier is the consumer-side slice of *pgxpool.Pool the store uses. Defining it
+// here keeps the store decoupled from the concrete pool; both *pgxpool.Pool and
+// pgx.Tx satisfy it structurally.
+type querier interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// storeSurface is the full watch-zone store method set its consumers rely on. It
+// exists only as a compile-time parity check: both *CosmosStore and *PostgresStore
+// must satisfy it, so the Postgres port can never silently diverge.
+type storeSurface interface {
+	GetByUserID(ctx context.Context, userID string) ([]WatchZone, error)
+	Get(ctx context.Context, userID, zoneID string) (WatchZone, error)
+	Save(ctx context.Context, z WatchZone) error
+	Delete(ctx context.Context, userID, zoneID string) error
+	DeleteAllByUserID(ctx context.Context, userID string) error
+	DistinctAuthorityIDs(ctx context.Context) ([]int, error)
+	FindZonesContaining(ctx context.Context, latitude, longitude float64) ([]WatchZone, error)
+}
+
+var (
+	_ storeSurface = (*PostgresStore)(nil)
+	_ storeSurface = (*CosmosStore)(nil)
+)
+
+// PostgresStore reads and writes watch zones in the Postgres `watch_zones` table
+// (Cosmos -> Postgres + PostGIS migration; memo 0010, epic #645). It is a parallel
+// implementation: Cosmos remains wired, so nothing here is on a live path yet.
+//
+// The notify hot path, FindZonesContaining, becomes a single ST_DWithin against
+// one GiST index across every user's zones — authority-agnostic by construction,
+// with no bounding-box prune or cross-partition fan-out.
+type PostgresStore struct {
+	db querier
+}
+
+// NewPostgresStore returns a store over the given pgx pool (or any querier).
+func NewPostgresStore(db querier) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+// pgZoneColumns is the read projection. id is rendered as text; ST_Y is the
+// latitude and ST_X the longitude of the (NOT NULL) geography point. The order
+// MUST match scanZone.
+const pgZoneColumns = "id::text, user_id, name, ST_Y(location::geometry), " +
+	"ST_X(location::geometry), radius_metres, authority_id, created_at, " +
+	"push_enabled, email_instant_enabled"
+
+// scanZone hydrates one zone through NewWatchZone, so the same invariants the
+// domain enforces (positive radius and authority id, non-blank id/user/name) gate
+// a row read from the database.
+func scanZone(row pgx.Row) (WatchZone, error) {
+	var (
+		id, userID, name       string
+		latitude, longitude    float64
+		radiusMetres           float64
+		authorityID            int
+		createdAt              time.Time
+		pushEnabled, emailFlag bool
+	)
+	if err := row.Scan(&id, &userID, &name, &latitude, &longitude, &radiusMetres,
+		&authorityID, &createdAt, &pushEnabled, &emailFlag); err != nil {
+		return WatchZone{}, err
+	}
+	return NewWatchZone(id, userID, name, latitude, longitude, radiusMetres,
+		authorityID, createdAt, pushEnabled, emailFlag)
+}
+
+// scanZoneRow adapts scanZone to pgx.CollectRows over a multi-row result.
+func scanZoneRow(row pgx.CollectableRow) (WatchZone, error) {
+	return scanZone(row)
+}
+
+const pgGetByUserIDQuery = "SELECT " + pgZoneColumns +
+	" FROM watch_zones WHERE user_id = $1 ORDER BY id"
+
+// GetByUserID returns all of the user's zones, ordered by id for determinism.
+func (s *PostgresStore) GetByUserID(ctx context.Context, userID string) ([]WatchZone, error) {
+	rows, err := s.db.Query(ctx, pgGetByUserIDQuery, userID)
+	if err != nil {
+		return nil, fmt.Errorf("query watch zones for %q: %w", userID, err)
+	}
+	zones, err := pgx.CollectRows(rows, scanZoneRow)
+	if err != nil {
+		return nil, fmt.Errorf("query watch zones for %q: %w", userID, err)
+	}
+	return zones, nil
+}
+
+const pgGetZoneQuery = "SELECT " + pgZoneColumns +
+	" FROM watch_zones WHERE user_id = $1 AND id = $2::uuid"
+
+// Get point-reads a single zone. A miss surfaces as ErrNotFound.
+func (s *PostgresStore) Get(ctx context.Context, userID, zoneID string) (WatchZone, error) {
+	z, err := scanZone(s.db.QueryRow(ctx, pgGetZoneQuery, userID, zoneID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return WatchZone{}, ErrNotFound
+	}
+	if err != nil {
+		return WatchZone{}, fmt.Errorf("read watch zone %q: %w", zoneID, err)
+	}
+	return z, nil
+}
+
+const pgSaveZoneQuery = `
+INSERT INTO watch_zones (
+	id, user_id, name, location, radius_metres, authority_id,
+	push_enabled, email_instant_enabled, created_at
+) VALUES (
+	$1::uuid, $2, $3, ST_SetSRID(ST_MakePoint($4, $5), 4326)::geography,
+	$6, $7, $8, $9, $10
+)
+ON CONFLICT (id) DO UPDATE SET
+	user_id = EXCLUDED.user_id,
+	name = EXCLUDED.name,
+	location = EXCLUDED.location,
+	radius_metres = EXCLUDED.radius_metres,
+	authority_id = EXCLUDED.authority_id,
+	push_enabled = EXCLUDED.push_enabled,
+	email_instant_enabled = EXCLUDED.email_instant_enabled,
+	created_at = EXCLUDED.created_at`
+
+// Save upserts the zone keyed on its uuid id.
+func (s *PostgresStore) Save(ctx context.Context, z WatchZone) error {
+	_, err := s.db.Exec(ctx, pgSaveZoneQuery,
+		z.ID, z.UserID, z.Name, z.Longitude, z.Latitude, z.RadiusMetres,
+		z.AuthorityID, z.PushEnabled, z.EmailInstantEnabled, z.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert watch zone %q: %w", z.ID, err)
+	}
+	return nil
+}
+
+const pgDeleteZoneQuery = "DELETE FROM watch_zones WHERE user_id = $1 AND id = $2::uuid"
+
+// Delete removes a zone. A miss surfaces as ErrNotFound.
+func (s *PostgresStore) Delete(ctx context.Context, userID, zoneID string) error {
+	tag, err := s.db.Exec(ctx, pgDeleteZoneQuery, userID, zoneID)
+	if err != nil {
+		return fmt.Errorf("delete watch zone %q: %w", zoneID, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+const pgDeleteAllByUserIDQuery = "DELETE FROM watch_zones WHERE user_id = $1"
+
+// DeleteAllByUserID removes every watch zone owned by the user (account-deletion
+// cascade). Deleting zero rows is not an error.
+func (s *PostgresStore) DeleteAllByUserID(ctx context.Context, userID string) error {
+	if _, err := s.db.Exec(ctx, pgDeleteAllByUserIDQuery, userID); err != nil {
+		return fmt.Errorf("delete all watch zones for %q: %w", userID, err)
+	}
+	return nil
+}
+
+// pgDistinctAuthorityIDsQuery serves the distinct set natively — unlike the Cosmos
+// gateway, which cannot run a cross-partition DISTINCT and forces a client-side dedup.
+const pgDistinctAuthorityIDsQuery = "SELECT DISTINCT authority_id FROM watch_zones " +
+	"WHERE authority_id IS NOT NULL ORDER BY authority_id"
+
+// DistinctAuthorityIDs returns the distinct authority ids across every user's
+// zones, ascending. It backs the polling watch-zone active-authority provider.
+func (s *PostgresStore) DistinctAuthorityIDs(ctx context.Context) ([]int, error) {
+	rows, err := s.db.Query(ctx, pgDistinctAuthorityIDsQuery)
+	if err != nil {
+		return nil, fmt.Errorf("query distinct authority ids: %w", err)
+	}
+	ids, err := pgx.CollectRows(rows, pgx.RowTo[int])
+	if err != nil {
+		return nil, fmt.Errorf("query distinct authority ids: %w", err)
+	}
+	return ids, nil
+}
+
+const pgFindZonesContainingQuery = "SELECT " + pgZoneColumns +
+	" FROM watch_zones WHERE ST_DWithin(location, " +
+	"ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography, radius_metres) ORDER BY id"
+
+// FindZonesContaining returns every watch zone (across all users, all authorities)
+// whose circle contains the point (latitude, longitude). Matching is purely
+// geographic via one GiST-served ST_DWithin against each zone's centre and radius —
+// the notify hot path. Zones are hydrated through NewWatchZone.
+func (s *PostgresStore) FindZonesContaining(ctx context.Context, latitude, longitude float64) ([]WatchZone, error) {
+	rows, err := s.db.Query(ctx, pgFindZonesContainingQuery, longitude, latitude)
+	if err != nil {
+		return nil, fmt.Errorf("find zones containing point: %w", err)
+	}
+	zones, err := pgx.CollectRows(rows, scanZoneRow)
+	if err != nil {
+		return nil, fmt.Errorf("find zones containing point: %w", err)
+	}
+	return zones, nil
+}

--- a/api-go/internal/watchzones/store_postgres_test.go
+++ b/api-go/internal/watchzones/store_postgres_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-
 	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
 )
 
@@ -32,11 +30,11 @@ func uuidN(n int) string {
 
 // newZonePGStore returns a Postgres-backed watch-zone store over a truncated
 // database. Integration tests are NOT parallel: they share the docker-compose DB.
-func newZonePGStore(t *testing.T) (*PostgresStore, *pgxpool.Pool) {
+func newZonePGStore(t *testing.T) *PostgresStore {
 	t.Helper()
 	pool := pgtest.New(t)
 	pgtest.Truncate(t, pool, "applications", "watch_zones")
-	return NewPostgresStore(pool), pool
+	return NewPostgresStore(pool)
 }
 
 // pgZone constructs a validated watch zone. authorityID must be positive so
@@ -82,7 +80,7 @@ func assertStrings(t *testing.T, got, want []string) {
 // reads it back unchanged via both Get and GetByUserID.
 func TestWatchZonePostgresStore_SaveGetRoundTrip(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newZonePGStore(t)
+	store := newZonePGStore(t)
 
 	want := pgZone(t, uuidN(1), "user-1", "Home", 51.5, -0.12, 500, 33)
 	want.PushEnabled = true
@@ -111,7 +109,7 @@ func TestWatchZonePostgresStore_SaveGetRoundTrip(t *testing.T) {
 // TestWatchZonePostgresStore_Get_Miss returns the ErrNotFound sentinel.
 func TestWatchZonePostgresStore_Get_Miss(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newZonePGStore(t)
+	store := newZonePGStore(t)
 
 	_, err := store.Get(ctx, "user-1", uuidN(404))
 	if !errors.Is(err, ErrNotFound) {
@@ -123,7 +121,7 @@ func TestWatchZonePostgresStore_Get_Miss(t *testing.T) {
 // same id is saved again, rather than inserting a second.
 func TestWatchZonePostgresStore_Save_UpsertOnID(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newZonePGStore(t)
+	store := newZonePGStore(t)
 
 	first := pgZone(t, uuidN(1), "user-1", "Old name", 51.5, -0.12, 500, 10)
 	if err := store.Save(ctx, first); err != nil {
@@ -153,7 +151,7 @@ func TestWatchZonePostgresStore_Save_UpsertOnID(t *testing.T) {
 // id order and excludes other users' zones.
 func TestWatchZonePostgresStore_GetByUserID_OrderedAndScoped(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newZonePGStore(t)
+	store := newZonePGStore(t)
 
 	for _, z := range []WatchZone{
 		pgZone(t, uuidN(3), "user-1", "third", 51.5, -0.12, 500, 10),
@@ -176,7 +174,7 @@ func TestWatchZonePostgresStore_GetByUserID_OrderedAndScoped(t *testing.T) {
 // TestWatchZonePostgresStore_Delete removes a zone; a miss returns ErrNotFound.
 func TestWatchZonePostgresStore_Delete(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newZonePGStore(t)
+	store := newZonePGStore(t)
 
 	z := pgZone(t, uuidN(1), "user-1", "Home", 51.5, -0.12, 500, 10)
 	if err := store.Save(ctx, z); err != nil {
@@ -197,7 +195,7 @@ func TestWatchZonePostgresStore_Delete(t *testing.T) {
 // other users untouched.
 func TestWatchZonePostgresStore_DeleteAllByUserID(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newZonePGStore(t)
+	store := newZonePGStore(t)
 
 	for _, z := range []WatchZone{
 		pgZone(t, uuidN(1), "user-1", "a", 51.5, -0.12, 500, 10),
@@ -232,7 +230,7 @@ func TestWatchZonePostgresStore_DeleteAllByUserID(t *testing.T) {
 // authority ids across every user's zones.
 func TestWatchZonePostgresStore_DistinctAuthorityIDs(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newZonePGStore(t)
+	store := newZonePGStore(t)
 
 	for _, z := range []WatchZone{
 		pgZone(t, uuidN(1), "user-1", "a", 51.5, -0.12, 500, 10),
@@ -260,7 +258,7 @@ func TestWatchZonePostgresStore_DistinctAuthorityIDs(t *testing.T) {
 // authorities (one GiST index, authority-agnostic).
 func TestWatchZonePostgresStore_FindZonesContaining(t *testing.T) {
 	ctx := context.Background()
-	store, _ := newZonePGStore(t)
+	store := newZonePGStore(t)
 
 	// Two zones centred 2 km north of the query point: the wide one's 3 km radius
 	// reaches back to the point, the narrow one's 1 km does not.

--- a/api-go/internal/watchzones/store_postgres_test.go
+++ b/api-go/internal/watchzones/store_postgres_test.go
@@ -1,0 +1,289 @@
+//go:build integration
+
+package watchzones
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// Deterministic fixture geometry, mirroring the Phase 0 spatial proof: a fixed
+// London centre with zone centres offset due north by a known number of metres.
+const (
+	wzCentreLon    = -0.1278
+	wzCentreLat    = 51.5074
+	wzMetresPerLat = 111_320.0
+)
+
+func wzLatNorth(metres float64) float64 { return wzCentreLat + metres/wzMetresPerLat }
+
+// uuidN builds a deterministic, ordered UUID so ORDER BY id assertions are stable.
+func uuidN(n int) string {
+	return fmt.Sprintf("%08d-0000-0000-0000-000000000000", n)
+}
+
+// newZonePGStore returns a Postgres-backed watch-zone store over a truncated
+// database. Integration tests are NOT parallel: they share the docker-compose DB.
+func newZonePGStore(t *testing.T) (*PostgresStore, *pgxpool.Pool) {
+	t.Helper()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "applications", "watch_zones")
+	return NewPostgresStore(pool), pool
+}
+
+// pgZone constructs a validated watch zone. authorityID must be positive so
+// NewWatchZone (and therefore FindZonesContaining hydration) accepts it.
+func pgZone(t *testing.T, id, userID, name string, lat, lon, radius float64, authorityID int) WatchZone {
+	t.Helper()
+	z, err := NewWatchZone(id, userID, name, lat, lon, radius, authorityID,
+		time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC), true, false)
+	if err != nil {
+		t.Fatalf("NewWatchZone(%s): %v", name, err)
+	}
+	return z
+}
+
+func assertZoneEqual(t *testing.T, got, want WatchZone) {
+	t.Helper()
+	if !got.CreatedAt.Equal(want.CreatedAt) {
+		t.Errorf("CreatedAt: got %v, want %v", got.CreatedAt, want.CreatedAt)
+	}
+	g, w := got, want
+	g.CreatedAt, w.CreatedAt = time.Time{}, time.Time{}
+	if !reflect.DeepEqual(g, w) {
+		t.Errorf("watch zone mismatch:\n got = %+v\nwant = %+v", g, w)
+	}
+}
+
+func zoneNames(zones []WatchZone) []string {
+	names := make([]string, len(zones))
+	for i, z := range zones {
+		names[i] = z.Name
+	}
+	return names
+}
+
+func assertStrings(t *testing.T, got, want []string) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+// TestWatchZonePostgresStore_SaveGetRoundTrip persists a fully-specified zone and
+// reads it back unchanged via both Get and GetByUserID.
+func TestWatchZonePostgresStore_SaveGetRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newZonePGStore(t)
+
+	want := pgZone(t, uuidN(1), "user-1", "Home", 51.5, -0.12, 500, 33)
+	want.PushEnabled = true
+	want.EmailInstantEnabled = true
+
+	if err := store.Save(ctx, want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.Get(ctx, "user-1", uuidN(1))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	assertZoneEqual(t, got, want)
+
+	list, err := store.GetByUserID(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("GetByUserID: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("GetByUserID len = %d, want 1", len(list))
+	}
+	assertZoneEqual(t, list[0], want)
+}
+
+// TestWatchZonePostgresStore_Get_Miss returns the ErrNotFound sentinel.
+func TestWatchZonePostgresStore_Get_Miss(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newZonePGStore(t)
+
+	_, err := store.Get(ctx, "user-1", uuidN(404))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get miss: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestWatchZonePostgresStore_Save_UpsertOnID updates the existing row when the
+// same id is saved again, rather than inserting a second.
+func TestWatchZonePostgresStore_Save_UpsertOnID(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newZonePGStore(t)
+
+	first := pgZone(t, uuidN(1), "user-1", "Old name", 51.5, -0.12, 500, 10)
+	if err := store.Save(ctx, first); err != nil {
+		t.Fatalf("Save first: %v", err)
+	}
+	second := pgZone(t, uuidN(1), "user-1", "New name", 52.0, -1.0, 750, 20)
+	if err := store.Save(ctx, second); err != nil {
+		t.Fatalf("Save second: %v", err)
+	}
+
+	got, err := store.Get(ctx, "user-1", uuidN(1))
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	assertZoneEqual(t, got, second)
+
+	list, err := store.GetByUserID(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("GetByUserID: %v", err)
+	}
+	if len(list) != 1 {
+		t.Errorf("expected 1 zone after upsert, got %d", len(list))
+	}
+}
+
+// TestWatchZonePostgresStore_GetByUserID_OrderedAndScoped lists a user's zones in
+// id order and excludes other users' zones.
+func TestWatchZonePostgresStore_GetByUserID_OrderedAndScoped(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newZonePGStore(t)
+
+	for _, z := range []WatchZone{
+		pgZone(t, uuidN(3), "user-1", "third", 51.5, -0.12, 500, 10),
+		pgZone(t, uuidN(1), "user-1", "first", 51.5, -0.12, 500, 10),
+		pgZone(t, uuidN(2), "user-1", "second", 51.5, -0.12, 500, 10),
+		pgZone(t, uuidN(9), "user-2", "other", 51.5, -0.12, 500, 10),
+	} {
+		if err := store.Save(ctx, z); err != nil {
+			t.Fatalf("Save %s: %v", z.Name, err)
+		}
+	}
+
+	list, err := store.GetByUserID(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("GetByUserID: %v", err)
+	}
+	assertStrings(t, zoneNames(list), []string{"first", "second", "third"})
+}
+
+// TestWatchZonePostgresStore_Delete removes a zone; a miss returns ErrNotFound.
+func TestWatchZonePostgresStore_Delete(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newZonePGStore(t)
+
+	z := pgZone(t, uuidN(1), "user-1", "Home", 51.5, -0.12, 500, 10)
+	if err := store.Save(ctx, z); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := store.Delete(ctx, "user-1", uuidN(1)); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.Get(ctx, "user-1", uuidN(1)); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get after delete: got %v, want ErrNotFound", err)
+	}
+	if err := store.Delete(ctx, "user-1", uuidN(1)); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Delete miss: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestWatchZonePostgresStore_DeleteAllByUserID clears one user's zones and leaves
+// other users untouched.
+func TestWatchZonePostgresStore_DeleteAllByUserID(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newZonePGStore(t)
+
+	for _, z := range []WatchZone{
+		pgZone(t, uuidN(1), "user-1", "a", 51.5, -0.12, 500, 10),
+		pgZone(t, uuidN(2), "user-1", "b", 51.5, -0.12, 500, 10),
+		pgZone(t, uuidN(3), "user-2", "keep", 51.5, -0.12, 500, 10),
+	} {
+		if err := store.Save(ctx, z); err != nil {
+			t.Fatalf("Save %s: %v", z.Name, err)
+		}
+	}
+
+	if err := store.DeleteAllByUserID(ctx, "user-1"); err != nil {
+		t.Fatalf("DeleteAllByUserID: %v", err)
+	}
+	left, err := store.GetByUserID(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("GetByUserID user-1: %v", err)
+	}
+	if len(left) != 0 {
+		t.Errorf("expected 0 zones for user-1, got %d", len(left))
+	}
+	other, err := store.GetByUserID(ctx, "user-2")
+	if err != nil {
+		t.Fatalf("GetByUserID user-2: %v", err)
+	}
+	if len(other) != 1 {
+		t.Errorf("expected user-2's zone untouched, got %d", len(other))
+	}
+}
+
+// TestWatchZonePostgresStore_DistinctAuthorityIDs returns the deduplicated set of
+// authority ids across every user's zones.
+func TestWatchZonePostgresStore_DistinctAuthorityIDs(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newZonePGStore(t)
+
+	for _, z := range []WatchZone{
+		pgZone(t, uuidN(1), "user-1", "a", 51.5, -0.12, 500, 10),
+		pgZone(t, uuidN(2), "user-1", "b", 51.5, -0.12, 500, 10), // dup authority 10
+		pgZone(t, uuidN(3), "user-2", "c", 51.5, -0.12, 500, 20),
+		pgZone(t, uuidN(4), "user-3", "d", 51.5, -0.12, 500, 99),
+	} {
+		if err := store.Save(ctx, z); err != nil {
+			t.Fatalf("Save %s: %v", z.Name, err)
+		}
+	}
+
+	ids, err := store.DistinctAuthorityIDs(ctx)
+	if err != nil {
+		t.Fatalf("DistinctAuthorityIDs: %v", err)
+	}
+	if !reflect.DeepEqual(ids, []int{10, 20, 99}) {
+		t.Fatalf("DistinctAuthorityIDs = %v, want [10 20 99]", ids)
+	}
+}
+
+// TestWatchZonePostgresStore_FindZonesContaining proves the notify hot path:
+// a zone whose circle contains the point matches; a same-centre narrower zone
+// does not (radius-driven, not centre proximity); and matching crosses users and
+// authorities (one GiST index, authority-agnostic).
+func TestWatchZonePostgresStore_FindZonesContaining(t *testing.T) {
+	ctx := context.Background()
+	store, _ := newZonePGStore(t)
+
+	// Two zones centred 2 km north of the query point: the wide one's 3 km radius
+	// reaches back to the point, the narrow one's 1 km does not.
+	wide := pgZone(t, uuidN(1), "user-1", "zone-wide", wzLatNorth(2000), wzCentreLon, 3000, 10)
+	narrow := pgZone(t, uuidN(2), "user-1", "zone-narrow", wzLatNorth(2000), wzCentreLon, 1000, 10)
+	// A different user, different authority, centred on the point itself.
+	other := pgZone(t, uuidN(3), "user-2", "zone-other", wzCentreLat, wzCentreLon, 500, 99)
+	for _, z := range []WatchZone{wide, narrow, other} {
+		if err := store.Save(ctx, z); err != nil {
+			t.Fatalf("Save %s: %v", z.Name, err)
+		}
+	}
+
+	matched, err := store.FindZonesContaining(ctx, wzCentreLat, wzCentreLon)
+	if err != nil {
+		t.Fatalf("FindZonesContaining: %v", err)
+	}
+	assertStrings(t, zoneNames(matched), []string{"zone-wide", "zone-other"})
+
+	// The hydrated zones are valid (positive authority id) and carry their owner.
+	for _, z := range matched {
+		if z.AuthorityID <= 0 || z.UserID == "" {
+			t.Errorf("hydrated zone invalid: %+v", z)
+		}
+	}
+}


### PR DESCRIPTION
## What

Phase 1b of the Cosmos → Postgres + PostGIS migration (memo 0010 / epic #645, bead tc-kgqw). Adds **parallel** Postgres store ports for Applications + WatchZones behind the **existing repository interfaces**. No cutover: Cosmos stays fully wired, `cmd/api/wiring.go` and both `store_cosmos.go` are untouched. Nothing in the live system changes.

## Changes
- `internal/applications/store_postgres.go` — new `PostgresStore`: `Upsert`, `GetByAuthorityAndName`, `GetByUID`, `RecentByAuthority`, `BreakdownByAuthority`, `FindNearbyPage`, `RecentNearby`, `NearestNearby`, `BreakdownNearby`.
- `internal/watchzones/store_postgres.go` — new `PostgresStore`: `GetByUserID`, `Get`, `Save`, `Delete`, `DeleteAllByUserID`, `DistinctAuthorityIDs`, `FindZonesContaining`.
- `internal/platform/postgres/migrations/0002_applications_composite_key.sql` — **schema correction** (see below).
- `internal/{applications,watchzones}/store_postgres_test.go` — `//go:build integration` pgtest suites covering every op in the memo-0010 query-shape table.
- `internal/platform/postgres/pgtest/pgtest.go` — cross-package test serialization (see below).

Each package declares a compile-time `storeSurface` interface satisfied by **both** `*CosmosStore` and `*PostgresStore` (plus the real consumer interfaces), so parity is enforced by the compiler.

## ⚠️ Schema correction (migration 0002)
Migration 0001 made `planit_name` a **global** PRIMARY KEY. That is wrong: a PlanIt case reference is only unique **within an authority** (`PlanningApplication.CanonicalUID`; the Cosmos model partitions by `authorityCode`, doc id `Name`). Two authorities can legitimately share a `planit_name` — a global PK would let one silently overwrite the other, and the memo's `ON CONFLICT (authority_code, planit_name)` Upsert can't run without a matching constraint. 0002 drops the single-column PK and adds composite PK `(authority_code, planit_name)`, keeping the GiST / authority-recent / app_state indexes. Proven by a test where two authorities share `24/SAME/FUL` and coexist as two rows.

## Notes
- **`FindNearbyPage`** is the new correct nearest-first behaviour: `ST_DWithin` radius filter + KNN `ORDER BY location <-> point, planit_name`, opaque base64url keyset cursor encoding `(distance, planit_name)`. Tested across pages including an equal-distance tie-break. Fine because it is unwired.
- **`pgtest.New` now holds a session-level `pg_advisory_lock`** for each DB test's duration. `go test -tags=integration ./...` (the bare command CI runs) executes package test binaries in parallel against the one shared Docker DB; with three DB-touching packages, concurrent `TRUNCATE`s wiped each other's fixtures (a real flake caught under `-race`). The lock serialises DB tests across packages; non-DB packages stay parallel. Constraint documented: a test using `pgtest.New` must not call `t.Parallel`.
- The three nearby SEO reads keep the `authority_code` scope for behaviour parity; the memo shows the pure-spatial form as the eventual target (a later phase), not relaxed here.

## Validation
- `gofmt -l .` empty · `go vet ./...` clean · `go build ./...` ok
- `go test ./...` (default, fakes) — **1146 passed, 39 pkgs, Docker-free**
- `make test-integration` green; new spatial suites confirmed **running** (not skipped), including composite-key and keyset tie-break cases
- `golangci-lint run ./...` — **0 issues** (default + `--build-tags=integration`)
- Scope: `wiring.go` / `store_cosmos.go` / `.claude/` untouched; all 5 commits GPG-signed

---
*Auto-shipped via ship skill*