### PR TITLE
feat(infra): Entra auth + admin on shared Postgres, retire password secret (tc-megp)

### DIFF
--- a/infra/Pulumi.shared.yaml
+++ b/infra/Pulumi.shared.yaml
@@ -3,3 +3,6 @@ config:
   town-crier:environment: shared
   town-crier:ciServicePrincipalId: 8efcb7cf-f17e-4a93-aab5-df7bc3c2c2cc
   town-crier:alertEmail: christy@salter.uk
+  town-crier:azureTenantId: 947ab4d8-734a-4d97-8bd7-b5ddf3caa5ab
+  town-crier:postgresAadAdminObjectId: 397680e0-c5f9-40a9-b667-0659f64cad00
+  town-crier:postgresAadAdminPrincipalName: amy_salter.uk#EXT#@amysalter.onmicrosoft.com

--- a/infra/environment.go
+++ b/infra/environment.go
@@ -365,18 +365,12 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		tags:                        tags,
 	}
 
-	// Dev-only: the Postgres database + a connection-string secret on the dev Container App.
-	// First step of the Cosmos → Postgres + PostGIS migration (memo 0010, epic tc-hpd2 / GH
-	// #645). The shared stack owns the Flexible Server; the per-env database lives on it. The
-	// prod database/role and the wiring.go swap that actually consumes this secret are deferred
-	// to later phases — here the secret only needs to exist on ca-town-crier-api-go-dev.
-	var postgresConnectionStringSecret pulumi.StringOutput
-	hasPostgresSecret := false
+	// Dev-only: Postgres database for town_crier_dev on the shared Flexible Server.
+	// Part of the Cosmos → Postgres + PostGIS migration (memo 0010, epic tc-hpd2 / GH #645).
+	// The password-based connection-string secret is retired; the dev API authenticates via
+	// Entra managed identity using a runtime token (no stored password). See GH #653.
 	if env == "dev" {
 		postgresServerName := shared.GetStringOutput(pulumi.String("postgresServerName"))
-		postgresServerFqdn := shared.GetStringOutput(pulumi.String("postgresServerFqdn"))
-		postgresAdminLogin := shared.GetStringOutput(pulumi.String("postgresAdminLogin"))
-		postgresAdminPassword := shared.GetStringOutput(pulumi.String("postgresAdminPassword"))
 
 		_, err = dbforpostgresql.NewDatabase(ctx, fmt.Sprintf("psql-db-town-crier-%s", env), &dbforpostgresql.DatabaseArgs{
 			DatabaseName:      pulumi.String("town_crier_dev"),
@@ -388,14 +382,6 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		if err != nil {
 			return err
 		}
-
-		// sslmode=require — the Flexible Server enforces TLS. The admin password is already a
-		// secret output; ToSecret makes the whole connection string secret explicitly.
-		postgresConnectionStringSecret = pulumi.ToSecret(pulumi.Sprintf(
-			"postgres://%s:%s@%s:5432/town_crier_dev?sslmode=require",
-			postgresAdminLogin, postgresAdminPassword, postgresServerFqdn,
-		)).(pulumi.StringOutput)
-		hasPostgresSecret = true
 	}
 
 	secrets := app.SecretArray{
@@ -406,14 +392,33 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		// Build key the Go gate validates for the SEO prerender endpoint (tc-nnte).
 		&app.SecretArgs{Name: pulumi.String("site-build-key"), Value: siteBuildKey},
 	}
-	// Dev-only: attach the Postgres connection-string secret. No Env/SecretRef yet — the app
-	// does not consume it until the wiring swap in a later migration phase; the secret just
-	// needs to exist on the dev Container App. Prod's secret set is unchanged.
-	if hasPostgresSecret {
-		secrets = append(secrets, &app.SecretArgs{
-			Name:  pulumi.String("postgres-connection-string"),
-			Value: postgresConnectionStringSecret,
-		})
+
+	// Build the API container env-var array. Postgres connection vars are dev-only: the dev
+	// API authenticates to town_crier_dev via Entra managed identity (GH #653). AZURE_CLIENT_ID
+	// is already present and reused for the token fetch — no duplication.
+	apiEnvVars := app.EnvironmentVarArray{
+		app.EnvironmentVarArgs{Name: pulumi.String("OTEL_SERVICE_NAME"), Value: pulumi.String("town-crier-api-go")},
+		// Read by the in-process Azure Monitor metrics exporter (tc-0rt1).
+		app.EnvironmentVarArgs{Name: pulumi.String("APPLICATIONINSIGHTS_CONNECTION_STRING"), Value: appInsightsConnectionString},
+		app.EnvironmentVarArgs{Name: pulumi.String("COSMOS_ENDPOINT"), Value: cosmosAccountEndpoint},
+		app.EnvironmentVarArgs{Name: pulumi.String("COSMOS_DATABASE"), Value: cosmosDatabase.Name},
+		app.EnvironmentVarArgs{Name: pulumi.String("AZURE_CLIENT_ID"), Value: cosmosDataIdentityClientID},
+		app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_DOMAIN"), Value: pulumi.String(auth0Domain)},
+		app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_AUDIENCE"), Value: pulumi.String(auth0Audience)},
+		app.EnvironmentVarArgs{Name: pulumi.String("CORS_ALLOWED_ORIGINS"), Value: pulumi.String(fmt.Sprintf("https://%s", frontendDomain))},
+		app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_ID"), SecretRef: pulumi.String("auth0-m2m-client-id")},
+		app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_SECRET"), SecretRef: pulumi.String("auth0-m2m-client-secret")},
+		app.EnvironmentVarArgs{Name: pulumi.String("ADMIN_API_KEY"), SecretRef: pulumi.String("admin-api-key")},
+		app.EnvironmentVarArgs{Name: pulumi.String("SITE_BUILD_KEY"), SecretRef: pulumi.String("site-build-key")},
+	}
+	if env == "dev" {
+		apiEnvVars = append(apiEnvVars,
+			app.EnvironmentVarArgs{Name: pulumi.String("POSTGRES_HOST"), Value: shared.GetStringOutput(pulumi.String("postgresServerFqdn"))},
+			app.EnvironmentVarArgs{Name: pulumi.String("POSTGRES_DB"), Value: pulumi.String("town_crier_dev")},
+			app.EnvironmentVarArgs{Name: pulumi.String("POSTGRES_USER"), Value: pulumi.String("towncrier_api")},
+			app.EnvironmentVarArgs{Name: pulumi.String("POSTGRES_SSLMODE"), Value: pulumi.String("require")},
+			app.EnvironmentVarArgs{Name: pulumi.String("POSTGRES_AUTH"), Value: pulumi.String("azure-managed-identity")},
+		)
 	}
 
 	// Container App (Go API), created for both dev and prod — the only environment stacks
@@ -470,21 +475,7 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 						Cpu:    pulumi.Float64(containerCpu),
 						Memory: pulumi.String(containerMemory),
 					},
-					Env: app.EnvironmentVarArray{
-						app.EnvironmentVarArgs{Name: pulumi.String("OTEL_SERVICE_NAME"), Value: pulumi.String("town-crier-api-go")},
-						// Read by the in-process Azure Monitor metrics exporter (tc-0rt1).
-						app.EnvironmentVarArgs{Name: pulumi.String("APPLICATIONINSIGHTS_CONNECTION_STRING"), Value: appInsightsConnectionString},
-						app.EnvironmentVarArgs{Name: pulumi.String("COSMOS_ENDPOINT"), Value: cosmosAccountEndpoint},
-						app.EnvironmentVarArgs{Name: pulumi.String("COSMOS_DATABASE"), Value: cosmosDatabase.Name},
-						app.EnvironmentVarArgs{Name: pulumi.String("AZURE_CLIENT_ID"), Value: cosmosDataIdentityClientID},
-						app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_DOMAIN"), Value: pulumi.String(auth0Domain)},
-						app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_AUDIENCE"), Value: pulumi.String(auth0Audience)},
-						app.EnvironmentVarArgs{Name: pulumi.String("CORS_ALLOWED_ORIGINS"), Value: pulumi.String(fmt.Sprintf("https://%s", frontendDomain))},
-						app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_ID"), SecretRef: pulumi.String("auth0-m2m-client-id")},
-						app.EnvironmentVarArgs{Name: pulumi.String("AUTH0_M2M_CLIENT_SECRET"), SecretRef: pulumi.String("auth0-m2m-client-secret")},
-						app.EnvironmentVarArgs{Name: pulumi.String("ADMIN_API_KEY"), SecretRef: pulumi.String("admin-api-key")},
-						app.EnvironmentVarArgs{Name: pulumi.String("SITE_BUILD_KEY"), SecretRef: pulumi.String("site-build-key")},
-					},
+					Env: apiEnvVars,
 				},
 			},
 			Scale: &app.ScaleArgs{

--- a/infra/shared.go
+++ b/infra/shared.go
@@ -183,6 +183,14 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		return fmt.Errorf("ARM_SUBSCRIPTION_ID must be set for the subscription budget scope")
 	}
 
+	// ARM_TENANT_ID is set by CI and local Pulumi runs via the Azure login step.
+	// A config key (azureTenantId) takes precedence so the value can be pinned per stack
+	// without relying on the environment — mirrors how armSubscriptionID is read above.
+	tenantID := conf.Get("azureTenantId")
+	if tenantID == "" {
+		tenantID = os.Getenv("ARM_TENANT_ID")
+	}
+
 	// Set the native ContainerAppConsoleLogs table to the Basic plan.
 	_, err = operationalinsights.NewTable(ctx, "table-containerappconsolelogs-basic", &operationalinsights.TableArgs{
 		ResourceGroupName: resourceGroup.Name,
@@ -315,6 +323,14 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		Network: &dbforpostgresql.NetworkArgs{
 			PublicNetworkAccess: dbforpostgresql.PublicNetworkAccessEnumEnabled,
 		},
+		// Enable Entra (AAD) authentication alongside password auth. PasswordAuth stays
+		// Enabled to preserve tcadmin break-glass access through the migration; password-only
+		// mode will be disabled in a later hardening step. See GH #653.
+		AuthConfig: &dbforpostgresql.AuthConfigArgs{
+			ActiveDirectoryAuth: pulumi.String("Enabled"),
+			PasswordAuth:        pulumi.String("Enabled"),
+			TenantId:            pulumi.String(tenantID),
+		},
 		Tags: tags,
 	})
 	if err != nil {
@@ -352,6 +368,22 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		Source:            pulumi.String("user-override"),
 		Value:             pulumi.String("POSTGIS"),
 	}, pulumi.DependsOn([]pulumi.Resource{postgresFirewall}))
+	if err != nil {
+		return err
+	}
+
+	// Entra administrator on the shared Postgres server. The repo owner's account is used
+	// so `cmd/pgbootstrap` (Slice B of GH #653) can run locally under `az login` credentials
+	// to create the towncrier_api role and grant least-privilege DML rights. The CI service
+	// principal can be added as a second Administrator later if CI bootstrap is needed.
+	_, err = dbforpostgresql.NewAdministrator(ctx, "psql-town-crier-shared-aad-admin", &dbforpostgresql.AdministratorArgs{
+		ResourceGroupName: resourceGroup.Name,
+		ServerName:        postgresServer.Name,
+		ObjectId:          pulumi.String(conf.Require("postgresAadAdminObjectId")),
+		PrincipalName:     pulumi.String(conf.Require("postgresAadAdminPrincipalName")),
+		PrincipalType:     pulumi.String("User"),
+		TenantId:          pulumi.String(tenantID),
+	}, pulumi.DependsOn([]pulumi.Resource{postgresServer}))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Slice A** of #653 (passwordless Entra managed-identity auth from the Go API to dev Postgres). Epic #645 / tc-hpd2 (Cosmos → Postgres+PostGIS, memo 0010). Bead: tc-megp.

## What
- **shared.go**: `AuthConfig{ActiveDirectoryAuth=Enabled, PasswordAuth=Enabled, TenantId}` on `psql-town-crier-shared` (password auth kept for `tcadmin` break-glass); new `dbforpostgresql.NewAdministrator` Entra admin (repo owner's account) so `cmd/pgbootstrap` (Slice B) can create the least-priv role.
- **environment.go (dev only)**: removed the unconsumed `postgres-connection-string` password secret; added passwordless `POSTGRES_HOST/DB/USER/SSLMODE/AUTH` env vars to the dev API container (`AZURE_CLIENT_ID` already present).
- **Pulumi.shared.yaml**: `azureTenantId`, `postgresAadAdminObjectId`, `postgresAadAdminPrincipalName`.

## Sequencing
Slice A must deploy (shared + dev stacks) before the Slice B bootstrap can create the `towncrier_api` role. Slice B (api-go token auth + bootstrap) follows in a separate PR.

## Validation
`go build ./...`, `go vet ./...`, `gofmt -l .` all clean. No `pulumi up` (PR-only; CD deploys).

## Out of scope
Prod, store wiring/backfill/cutover, disabling password auth entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shared Azure tenant and PostgreSQL Entra admin configuration for the infrastructure stack.
  * Enabled Entra ID authentication for the shared PostgreSQL server.
  * Updated the dev API setup to use environment-based PostgreSQL connection details instead of a stored connection-string secret.

* **Bug Fixes**
  * Removed retired password-based PostgreSQL secret handling from the dev container app configuration.
  * Simplified and standardized API environment variable setup for dev deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->