### PR TITLE
feat(api): Entra MI token auth for Postgres + least-priv role bootstrap (tc-vnna)

### DIFF
--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -22,6 +23,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/subscriptions"
@@ -64,6 +66,16 @@ func main() {
 	// to it below so towncrier.cosmos.request_charge_ru flows, and it is passed to
 	// newRouter for the watch-zone lifecycle counters (tc-21np).
 	registry := metrics.New(otel.Meter(metrics.MeterName))
+
+	// Strictly non-fatal passwordless-connectivity probe (tc-vnna / #653). When
+	// the API is configured for Azure managed-identity Postgres auth, prove from
+	// the logs that we can connect with an Entra token and no stored password —
+	// the migration milestone (epic #645). It runs in its own short-lived,
+	// self-terminating goroutine so it never blocks boot, wires no route or store,
+	// and only logs (Info on success, Warn on any failure). Cosmos stays live.
+	if os.Getenv("POSTGRES_AUTH") == "azure-managed-identity" {
+		go probePostgresManagedIdentity(logger)
+	}
 
 	validator, err := auth.NewAuth0Validator(cfg.Auth0Domain, cfg.Auth0Audience, logger)
 	if err != nil {
@@ -275,4 +287,29 @@ func main() {
 		logger.Error("shutdown", "error", err)
 	}
 	logger.Info("api stopped")
+}
+
+// probePostgresManagedIdentity opens the managed-identity Postgres pool, runs a
+// single SELECT current_user, and logs who we connected as. It exists solely to
+// make the "dev API connects passwordless" milestone (#653) provable from logs
+// and is strictly non-fatal: every failure is a Warn and never affects the
+// running API. The goroutine self-terminates within its own bounded timeout, so
+// it owns its lifetime and leaks nothing.
+func probePostgresManagedIdentity(logger *slog.Logger) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	pool, err := postgres.NewPoolFromEnv(ctx)
+	if err != nil {
+		logger.Warn("postgres managed-identity probe: build pool", "error", err)
+		return
+	}
+	defer pool.Close()
+
+	var currentUser string
+	if err := pool.QueryRow(ctx, "SELECT current_user").Scan(&currentUser); err != nil {
+		logger.Warn("postgres managed-identity probe: query", "error", err)
+		return
+	}
+	logger.Info("postgres managed-identity probe: connected passwordless", "current_user", currentUser)
 }

--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -311,5 +311,5 @@ func probePostgresManagedIdentity(logger *slog.Logger) {
 		logger.Warn("postgres managed-identity probe: query", "error", err)
 		return
 	}
-	logger.Info("postgres managed-identity probe: connected passwordless", "current_user", currentUser)
+	logger.Info("postgres managed-identity probe: connected passwordless", "currentUser", currentUser)
 }

--- a/api-go/cmd/pgbootstrap/bootstrap.sql
+++ b/api-go/cmd/pgbootstrap/bootstrap.sql
@@ -1,0 +1,30 @@
+-- Idempotent least-privilege bootstrap for the Town Crier API managed identity.
+--
+-- Run once by the Entra admin (a locally `az login`-ed human) against the target
+-- Azure Database for PostgreSQL Flexible Server database. It maps the API's
+-- managed identity to a Postgres role and grants DML only. It is safe to re-run:
+-- the principal create is guarded by a pg_roles existence check, and every GRANT
+-- is idempotent.
+--
+-- DELIBERATELY ABSENT: SUPERUSER, CREATEDB, CREATEROLE, role/database OWNERSHIP,
+-- and any DDL/CREATE/DROP. The API reads and writes rows; it never alters schema.
+-- Schema ownership and migrations are a separate, later concern.
+--
+-- Identifiers are templated in by cmd/pgbootstrap, which validates the role and
+-- database against a strict identifier pattern and the object id against a UUID
+-- pattern before rendering, so this file is not a SQL-injection surface.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{{.Role}}') THEN
+        PERFORM pgaadauth_create_principal_with_oid('{{.Role}}', '{{.OID}}', 'service', false, false);
+    END IF;
+END
+$$;
+
+GRANT CONNECT ON DATABASE {{.DB}} TO {{.Role}};
+GRANT USAGE ON SCHEMA public TO {{.Role}};
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO {{.Role}};
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO {{.Role}};
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO {{.Role}};
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO {{.Role}};

--- a/api-go/cmd/pgbootstrap/main.go
+++ b/api-go/cmd/pgbootstrap/main.go
@@ -1,0 +1,173 @@
+// Command pgbootstrap maps the Town Crier API's Azure managed identity to a
+// least-privilege Postgres role on the shared Flexible Server, then grants it
+// DML only. It is a one-time, idempotent data-plane operation run by the Entra
+// admin (a locally `az login`-ed human), not part of any deploy.
+//
+// It connects as the admin using the admin's own Entra token as the connection
+// password (the same pgx BeforeConnect trick the API uses), via
+// DefaultAzureCredential. The bootstrap SQL lives in the checked-in, reviewable
+// bootstrap.sql and is rendered with validated identifiers. The command runs no
+// destructive statement.
+//
+// Usage:
+//
+//	pgbootstrap -host <fqdn> -admin-user <aad-admin-upn> -db town_crier_dev \
+//	    -mi-oid <managed-identity-object-id> [-role towncrier_api]
+//	pgbootstrap -host <fqdn> -admin-user <aad-admin-upn> -db town_crier_dev -verify
+//
+// -verify connects (as the admin) and prints SELECT current_user so the operator
+// can confirm Entra auth to the server works.
+package main
+
+import (
+	"context"
+	_ "embed"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
+)
+
+// bootstrapSQLTemplate is the reviewable, checked-in least-privilege bootstrap.
+//
+//go:embed bootstrap.sql
+var bootstrapSQLTemplate string
+
+// identifierPattern matches a safe, unquoted SQL identifier (role / database
+// name). OID values must be a UUID. Both are validated before being templated
+// into SQL, so bootstrap.sql is not a SQL-injection surface.
+var (
+	identifierPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+	uuidPattern       = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+)
+
+// bootstrapParams are the validated identifiers rendered into the bootstrap SQL.
+type bootstrapParams struct {
+	Role string
+	DB   string
+	OID  string
+}
+
+func (p bootstrapParams) validate() error {
+	if !identifierPattern.MatchString(p.Role) {
+		return fmt.Errorf("invalid role name %q: must be a plain SQL identifier", p.Role)
+	}
+	if !identifierPattern.MatchString(p.DB) {
+		return fmt.Errorf("invalid database name %q: must be a plain SQL identifier", p.DB)
+	}
+	if !uuidPattern.MatchString(p.OID) {
+		return fmt.Errorf("invalid managed-identity object id %q: must be a UUID", p.OID)
+	}
+	return nil
+}
+
+// buildBootstrapSQL validates the identifiers and renders the embedded template.
+// Returning the SQL (rather than executing it) keeps the assembly fully
+// unit-testable.
+func buildBootstrapSQL(p bootstrapParams) (string, error) {
+	if err := p.validate(); err != nil {
+		return "", err
+	}
+	tmpl, err := template.New("bootstrap").Option("missingkey=error").Parse(bootstrapSQLTemplate)
+	if err != nil {
+		return "", fmt.Errorf("parse bootstrap template: %w", err)
+	}
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, p); err != nil {
+		return "", fmt.Errorf("render bootstrap template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	fs := flag.NewFlagSet("pgbootstrap", flag.ContinueOnError)
+	var (
+		host      = fs.String("host", os.Getenv("POSTGRES_HOST"), "Postgres server FQDN")
+		adminUser = fs.String("admin-user", os.Getenv("POSTGRES_ADMIN_USER"), "Entra admin principal name (UPN) to connect as")
+		db        = fs.String("db", envOr("POSTGRES_DB", "town_crier_dev"), "target database")
+		miOID     = fs.String("mi-oid", os.Getenv("POSTGRES_MI_OBJECT_ID"), "managed-identity object id to map the role to")
+		role      = fs.String("role", envOr("POSTGRES_ROLE", "towncrier_api"), "Postgres role name to create/grant")
+		sslMode   = fs.String("sslmode", envOr("POSTGRES_SSLMODE", "require"), "sslmode")
+		timeout   = fs.Duration("timeout", 30*time.Second, "overall timeout")
+		verify    = fs.Bool("verify", false, "connect and print SELECT current_user, then exit (no bootstrap)")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if *host == "" || *adminUser == "" {
+		fmt.Fprintln(os.Stderr, "pgbootstrap: -host and -admin-user are required")
+		return 2
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbootstrap: build credential: %v\n", err)
+		return 1
+	}
+
+	pool, err := postgres.NewTokenCredentialPool(ctx, postgres.ConnParams{
+		Host:    *host,
+		DB:      *db,
+		User:    *adminUser,
+		SSLMode: *sslMode,
+	}, cred)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbootstrap: build pool: %v\n", err)
+		return 1
+	}
+	defer pool.Close()
+
+	if *verify {
+		return verifyConnection(ctx, pool)
+	}
+
+	sql, err := buildBootstrapSQL(bootstrapParams{Role: *role, DB: *db, OID: *miOID})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbootstrap: %v\n", err)
+		return 2
+	}
+
+	// The rendered SQL carries no parameters, so pgx runs it via the simple
+	// protocol, executing all statements (including the guarded DO block) in one
+	// round trip. Identifiers were validated before rendering.
+	if _, err := pool.Exec(ctx, sql); err != nil {
+		fmt.Fprintf(os.Stderr, "pgbootstrap: run bootstrap: %v\n", err)
+		return 1
+	}
+
+	fmt.Printf("pgbootstrap: bootstrapped role %q on database %q\n", *role, *db)
+	return verifyConnection(ctx, pool)
+}
+
+func verifyConnection(ctx context.Context, pool *pgxpool.Pool) int {
+	var currentUser string
+	if err := pool.QueryRow(ctx, "SELECT current_user").Scan(&currentUser); err != nil {
+		fmt.Fprintf(os.Stderr, "pgbootstrap: verify: %v\n", err)
+		return 1
+	}
+	fmt.Printf("pgbootstrap: connected as %q\n", currentUser)
+	return 0
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/api-go/cmd/pgbootstrap/main_test.go
+++ b/api-go/cmd/pgbootstrap/main_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+const testMIObjectID = "09dd6994-a3d8-4e83-abbd-c4d82888a700"
+
+func validParams() bootstrapParams {
+	return bootstrapParams{
+		Role: "towncrier_api",
+		DB:   "town_crier_dev",
+		OID:  testMIObjectID,
+	}
+}
+
+func TestBuildBootstrapSQL_GrantsLeastPrivilege(t *testing.T) {
+	t.Parallel()
+	sql, err := buildBootstrapSQL(validParams())
+	if err != nil {
+		t.Fatalf("buildBootstrapSQL() error = %v", err)
+	}
+
+	wantSubstrings := []string{
+		"pgaadauth_create_principal_with_oid",
+		"'towncrier_api'",
+		"'" + testMIObjectID + "'",
+		"'service'",
+		"GRANT CONNECT ON DATABASE town_crier_dev TO towncrier_api",
+		"GRANT USAGE ON SCHEMA public TO towncrier_api",
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO towncrier_api",
+		"GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO towncrier_api",
+		"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO towncrier_api",
+		"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO towncrier_api",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(sql, want) {
+			t.Errorf("generated SQL missing %q\n---\n%s", want, sql)
+		}
+	}
+}
+
+func TestBuildBootstrapSQL_GrantsNoElevatedPrivilege(t *testing.T) {
+	t.Parallel()
+	sql, err := buildBootstrapSQL(validParams())
+	if err != nil {
+		t.Fatalf("buildBootstrapSQL() error = %v", err)
+	}
+
+	upper := strings.ToUpper(sql)
+	forbidden := []string{"SUPERUSER", "CREATEDB", "CREATEROLE", "OWNER", "DROP", "ALTER TABLE", "CREATE TABLE"}
+	for _, bad := range forbidden {
+		if strings.Contains(upper, bad) {
+			t.Errorf("generated SQL must not contain %q (least-privilege only)\n---\n%s", bad, sql)
+		}
+	}
+}
+
+func TestBuildBootstrapSQL_RejectsInvalidIdentifiers(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		params bootstrapParams
+	}{
+		{"role injection", bootstrapParams{Role: "api; DROP DATABASE town_crier_dev", DB: "town_crier_dev", OID: testMIObjectID}},
+		{"db injection", bootstrapParams{Role: "towncrier_api", DB: "town_crier_dev; --", OID: testMIObjectID}},
+		{"oid not a uuid", bootstrapParams{Role: "towncrier_api", DB: "town_crier_dev", OID: "not-a-uuid"}},
+		{"empty role", bootstrapParams{Role: "", DB: "town_crier_dev", OID: testMIObjectID}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := buildBootstrapSQL(tc.params); err == nil {
+				t.Fatalf("buildBootstrapSQL(%+v) returned nil error, want rejection", tc.params)
+			}
+		})
+	}
+}
+
+func TestBuildBootstrapSQL_GuardsPrincipalCreationForIdempotency(t *testing.T) {
+	t.Parallel()
+	sql, err := buildBootstrapSQL(validParams())
+	if err != nil {
+		t.Fatalf("buildBootstrapSQL() error = %v", err)
+	}
+	// The principal-create must be guarded so a re-run is a no-op rather than an
+	// "already exists" failure.
+	if !strings.Contains(sql, "pg_roles") {
+		t.Errorf("generated SQL must guard creation against pg_roles for idempotency\n---\n%s", sql)
+	}
+}

--- a/api-go/cmd/pgbootstrap/main_test.go
+++ b/api-go/cmd/pgbootstrap/main_test.go
@@ -48,13 +48,30 @@ func TestBuildBootstrapSQL_GrantsNoElevatedPrivilege(t *testing.T) {
 		t.Fatalf("buildBootstrapSQL() error = %v", err)
 	}
 
-	upper := strings.ToUpper(sql)
+	// Scan the executable SQL only: -- comment lines deliberately name the
+	// privileges this bootstrap withholds, and that documentation must not trip
+	// the guard. What matters is that nothing elevated is actually granted.
+	upper := strings.ToUpper(stripSQLComments(sql))
 	forbidden := []string{"SUPERUSER", "CREATEDB", "CREATEROLE", "OWNER", "DROP", "ALTER TABLE", "CREATE TABLE"}
 	for _, bad := range forbidden {
 		if strings.Contains(upper, bad) {
 			t.Errorf("generated SQL must not contain %q (least-privilege only)\n---\n%s", bad, sql)
 		}
 	}
+}
+
+// stripSQLComments removes -- line comments so privilege assertions inspect only
+// executable statements.
+func stripSQLComments(sql string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(sql, "\n") {
+		if idx := strings.Index(line, "--"); idx >= 0 {
+			line = line[:idx]
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
 }
 
 func TestBuildBootstrapSQL_RejectsInvalidIdentifiers(t *testing.T) {

--- a/api-go/internal/platform/postgres/pool.go
+++ b/api-go/internal/platform/postgres/pool.go
@@ -37,7 +37,9 @@ const (
 const defaultSSLMode = "require"
 
 // azurePostgresTokenScope is the fixed OSS RDBMS AAD resource for Azure Database
-// for PostgreSQL. It is not environment-specific.
+// for PostgreSQL. It is a public OAuth scope identifier, not a secret.
+//
+//nolint:gosec // G101: public AAD resource scope URL, not a credential
 const azurePostgresTokenScope = "https://ossrdbms-aad.database.windows.net/.default"
 
 // defaultDSN points at the docker-compose Postgres on host port 5433. It is used

--- a/api-go/internal/platform/postgres/pool.go
+++ b/api-go/internal/platform/postgres/pool.go
@@ -1,17 +1,44 @@
 // Package postgres provides the connection pool and migration plumbing for the
-// local Postgres + PostGIS test environment. It is Phase 0 of the Cosmos ->
-// Postgres migration (docs/memo/0010): it stands up a real, seedable database
-// that the integration-tagged tests run against. No production code path uses
-// it yet — Cosmos remains the live datastore.
+// Cosmos -> Postgres + PostGIS migration (docs/memo/0010, epic #645).
+//
+// DSNFromEnv + NewPool + Migrate stand up the local, seedable database the
+// integration-tagged tests run against (Phase 0). NewPoolFromEnv adds
+// auth-mode-aware connection for dev/prod: POSTGRES_AUTH=azure-managed-identity
+// selects passwordless Entra-token auth (the token is injected as the
+// connection password via pgx BeforeConnect), while any other value keeps the
+// password/trust path untouched. No store reads are wired onto Postgres yet —
+// Cosmos remains the live datastore; this is the MI-auth connection layer
+// (#653) the later wiring phases build on.
 package postgres
 
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// POSTGRES_AUTH selects how NewPoolFromEnv authenticates. azureManagedIdentity
+// switches to passwordless Entra-token auth; any other value (unset or
+// "password") keeps the existing password/trust path so pgtest and
+// docker-compose are untouched.
+const (
+	authModeAzureManagedIdentity = "azure-managed-identity"
+)
+
+// defaultSSLMode is applied when POSTGRES_SSLMODE is unset. require is the
+// minimum for Azure Database for PostgreSQL Flexible Server.
+const defaultSSLMode = "require"
+
+// azurePostgresTokenScope is the fixed OSS RDBMS AAD resource for Azure Database
+// for PostgreSQL. It is not environment-specific.
+const azurePostgresTokenScope = "https://ossrdbms-aad.database.windows.net/.default"
 
 // defaultDSN points at the docker-compose Postgres on host port 5433. It is used
 // when TEST_DATABASE_URL is unset so a developer with the compose stack up can
@@ -41,4 +68,148 @@ func NewPool(ctx context.Context, dsn string) (*pgxpool.Pool, error) {
 		return nil, fmt.Errorf("create postgres pool: %w", err)
 	}
 	return pool, nil
+}
+
+// ConnParams are the discrete, passwordless connection inputs for Entra
+// managed-identity auth, read from the POSTGRES_* env vars. The password is
+// never one of them: it is a short-lived Entra token minted per connection.
+type ConnParams struct {
+	Host    string
+	DB      string
+	User    string
+	SSLMode string
+}
+
+// tokenSource yields a bearer token to use as the Postgres connection password.
+// It is a consumer-side interface: the real implementation wraps an Azure
+// credential and tests inject a hand-written fake, so neither the build nor the
+// unit tests touch a live token endpoint.
+type tokenSource interface {
+	Token(ctx context.Context) (string, error)
+}
+
+// NewPoolFromEnv constructs a pgx pool whose authentication mode is selected by
+// POSTGRES_AUTH. When the value is anything other than "azure-managed-identity"
+// (including unset and "password") it is byte-for-byte the existing
+// password/trust path — NewPool over DSNFromEnv — so pgtest, make
+// test-integration, and docker-compose are unaffected. When it is
+// "azure-managed-identity" it builds a passwordless pool that injects a fresh
+// Entra token (scope azurePostgresTokenScope) as the connection password on
+// every new physical connection, honouring AZURE_CLIENT_ID exactly as the
+// Cosmos and Service Bus clients do.
+func NewPoolFromEnv(ctx context.Context) (*pgxpool.Pool, error) {
+	if os.Getenv("POSTGRES_AUTH") != authModeAzureManagedIdentity {
+		return NewPool(ctx, DSNFromEnv())
+	}
+
+	cred, err := newManagedIdentityCredential(os.Getenv("AZURE_CLIENT_ID"))
+	if err != nil {
+		return nil, err
+	}
+	return NewTokenCredentialPool(ctx, paramsFromEnv(), cred)
+}
+
+// NewTokenCredentialPool builds a passwordless pgx pool that authenticates every
+// physical connection with a fresh Entra access token (scope
+// azurePostgresTokenScope) drawn from cred and used as the Postgres password.
+// pgx's BeforeConnect runs per new connection, so the pool refreshes the token
+// as it grows or replaces connections with no manual refresh loop. The admin
+// bootstrap command reuses this with a DefaultAzureCredential.
+func NewTokenCredentialPool(ctx context.Context, p ConnParams, cred azcore.TokenCredential) (*pgxpool.Pool, error) {
+	return newTokenPool(ctx, p, aadTokenSource{cred: cred})
+}
+
+func newTokenPool(ctx context.Context, p ConnParams, ts tokenSource) (*pgxpool.Pool, error) {
+	cfg, err := buildMIPoolConfig(p, ts)
+	if err != nil {
+		return nil, err
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create managed-identity postgres pool: %w", err)
+	}
+	return pool, nil
+}
+
+// buildMIPoolConfig parses a passwordless DSN built from p and attaches a
+// BeforeConnect hook that sets each connection's password to a freshly fetched
+// token. It opens no connection, so it is fully unit-testable with a fake
+// tokenSource.
+func buildMIPoolConfig(p ConnParams, ts tokenSource) (*pgxpool.Config, error) {
+	cfg, err := pgxpool.ParseConfig(miDSN(p))
+	if err != nil {
+		return nil, fmt.Errorf("parse managed-identity dsn: %w", err)
+	}
+	cfg.BeforeConnect = func(ctx context.Context, cc *pgx.ConnConfig) error {
+		token, terr := ts.Token(ctx)
+		if terr != nil {
+			return fmt.Errorf("acquire postgres access token: %w", terr)
+		}
+		cc.Password = token
+		return nil
+	}
+	return cfg, nil
+}
+
+// miDSN builds a passwordless Postgres DSN from the discrete parameters. The
+// user is encoded with no password (url.User, not url.UserPassword), so the
+// connection string never carries a secret; the password arrives per connection
+// via BeforeConnect.
+func miDSN(p ConnParams) string {
+	sslMode := p.SSLMode
+	if sslMode == "" {
+		sslMode = defaultSSLMode
+	}
+	u := url.URL{
+		Scheme:   "postgres",
+		User:     url.User(p.User),
+		Host:     p.Host,
+		Path:     "/" + p.DB,
+		RawQuery: url.Values{"sslmode": {sslMode}}.Encode(),
+	}
+	return u.String()
+}
+
+// paramsFromEnv reads the discrete passwordless connection inputs, defaulting
+// sslmode to require.
+func paramsFromEnv() ConnParams {
+	return ConnParams{
+		Host:    os.Getenv("POSTGRES_HOST"),
+		DB:      os.Getenv("POSTGRES_DB"),
+		User:    os.Getenv("POSTGRES_USER"),
+		SSLMode: os.Getenv("POSTGRES_SSLMODE"),
+	}
+}
+
+// aadTokenSource fetches Entra access tokens for Azure Database for PostgreSQL
+// from an azcore.TokenCredential and returns the raw token for use as the
+// connection password.
+type aadTokenSource struct {
+	cred azcore.TokenCredential
+}
+
+func (s aadTokenSource) Token(ctx context.Context) (string, error) {
+	tok, err := s.cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{azurePostgresTokenScope},
+	})
+	if err != nil {
+		return "", fmt.Errorf("get azure postgres token: %w", err)
+	}
+	return tok.Token, nil
+}
+
+// newManagedIdentityCredential builds a user-assigned managed-identity
+// credential pinned to clientID when set, mirroring the Cosmos and Service Bus
+// wiring (cosmos.go:213, servicebus/client.go:70). An empty clientID falls back
+// to the ambient managed identity.
+func newManagedIdentityCredential(clientID string) (azcore.TokenCredential, error) {
+	credOpts := &azidentity.ManagedIdentityCredentialOptions{}
+	if clientID != "" {
+		credOpts.ID = azidentity.ClientID(clientID)
+	}
+	cred, err := azidentity.NewManagedIdentityCredential(credOpts)
+	if err != nil {
+		return nil, fmt.Errorf("build managed-identity credential: %w", err)
+	}
+	return cred, nil
 }

--- a/api-go/internal/platform/postgres/pool_test.go
+++ b/api-go/internal/platform/postgres/pool_test.go
@@ -2,8 +2,151 @@ package postgres
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
+
+	"github.com/jackc/pgx/v5"
 )
+
+// fakeTokenSource is a hand-written stand-in for the Entra token acquirer so the
+// connection-layer tests never touch live Azure.
+type fakeTokenSource struct {
+	token string
+	err   error
+}
+
+func (f fakeTokenSource) Token(ctx context.Context) (string, error) {
+	return f.token, f.err
+}
+
+func testMIParams() ConnParams {
+	return ConnParams{
+		Host:    "psql-town-crier-shared.postgres.database.azure.com",
+		DB:      "town_crier_dev",
+		User:    "towncrier_api",
+		SSLMode: "require",
+	}
+}
+
+func TestMIDSN_OmitsPassword(t *testing.T) {
+	t.Parallel()
+	dsn := miDSN(testMIParams())
+	if !strings.Contains(dsn, "towncrier_api@") {
+		t.Fatalf("miDSN() = %q, want user@host form", dsn)
+	}
+	if strings.Contains(dsn, "towncrier_api:") {
+		t.Fatalf("miDSN() = %q, must not embed a password after the user", dsn)
+	}
+	if !strings.Contains(dsn, "sslmode=require") {
+		t.Fatalf("miDSN() = %q, want sslmode=require", dsn)
+	}
+}
+
+func TestBuildMIPoolConfig_InjectsTokenAsPassword(t *testing.T) {
+	// Not parallel: clears PGPASSWORD so an ambient env var can't bleed into the
+	// no-password assertion below.
+	t.Setenv("PGPASSWORD", "")
+
+	const token = "fake-entra-token-xyz"
+	cfg, err := buildMIPoolConfig(testMIParams(), fakeTokenSource{token: token})
+	if err != nil {
+		t.Fatalf("buildMIPoolConfig() error = %v", err)
+	}
+	if cfg.BeforeConnect == nil {
+		t.Fatal("buildMIPoolConfig() left BeforeConnect nil, want a token hook")
+	}
+	if cfg.ConnConfig.Password != "" {
+		t.Fatalf("parsed DSN carried a password %q, want none", cfg.ConnConfig.Password)
+	}
+
+	cc := &pgx.ConnConfig{}
+	if err := cfg.BeforeConnect(context.Background(), cc); err != nil {
+		t.Fatalf("BeforeConnect() error = %v", err)
+	}
+	if cc.Password != token {
+		t.Fatalf("BeforeConnect set Password = %q, want %q", cc.Password, token)
+	}
+}
+
+func TestBuildMIPoolConfig_BeforeConnectPropagatesTokenError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("token boom")
+	cfg, err := buildMIPoolConfig(testMIParams(), fakeTokenSource{err: sentinel})
+	if err != nil {
+		t.Fatalf("buildMIPoolConfig() error = %v", err)
+	}
+	gotErr := cfg.BeforeConnect(context.Background(), &pgx.ConnConfig{})
+	if !errors.Is(gotErr, sentinel) {
+		t.Fatalf("BeforeConnect() error = %v, want it to wrap %v", gotErr, sentinel)
+	}
+}
+
+func TestNewPoolFromEnv_DefaultsToPasswordPath(t *testing.T) {
+	cases := []struct {
+		name string
+		auth string
+	}{
+		{"unset", ""},
+		{"password", "password"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			const dsn = "postgres://towncrier:towncrier@localhost:5433/towncrier_test?sslmode=disable"
+			t.Setenv("TEST_DATABASE_URL", dsn)
+			t.Setenv("POSTGRES_AUTH", tc.auth)
+
+			pool, err := NewPoolFromEnv(context.Background())
+			if err != nil {
+				t.Fatalf("NewPoolFromEnv() error = %v", err)
+			}
+			defer pool.Close()
+			if got := pool.Config().ConnString(); got != dsn {
+				t.Fatalf("default path used DSN %q, want DSNFromEnv %q", got, dsn)
+			}
+		})
+	}
+}
+
+func TestNewPoolFromEnv_ManagedIdentityBuildsPasswordlessPool(t *testing.T) {
+	t.Setenv("POSTGRES_AUTH", "azure-managed-identity")
+	t.Setenv("POSTGRES_HOST", "psql-town-crier-shared.postgres.database.azure.com")
+	t.Setenv("POSTGRES_DB", "town_crier_dev")
+	t.Setenv("POSTGRES_USER", "towncrier_api")
+	t.Setenv("POSTGRES_SSLMODE", "require")
+	t.Setenv("PGPASSWORD", "")
+
+	pool, err := NewPoolFromEnv(context.Background())
+	if err != nil {
+		t.Fatalf("NewPoolFromEnv() error = %v", err)
+	}
+	defer pool.Close()
+	conn := pool.Config().ConnString()
+	if !strings.Contains(conn, "town_crier_dev") {
+		t.Fatalf("MI pool DSN %q missing target database", conn)
+	}
+	if strings.Contains(conn, "towncrier_api:") {
+		t.Fatalf("MI pool DSN %q must not embed a password", conn)
+	}
+}
+
+func TestNewPoolFromEnv_SSLModeDefaultsToRequire(t *testing.T) {
+	t.Setenv("POSTGRES_AUTH", "azure-managed-identity")
+	t.Setenv("POSTGRES_HOST", "example.postgres.database.azure.com")
+	t.Setenv("POSTGRES_DB", "town_crier_dev")
+	t.Setenv("POSTGRES_USER", "towncrier_api")
+	t.Setenv("POSTGRES_SSLMODE", "")
+	t.Setenv("PGPASSWORD", "")
+
+	pool, err := NewPoolFromEnv(context.Background())
+	if err != nil {
+		t.Fatalf("NewPoolFromEnv() error = %v", err)
+	}
+	defer pool.Close()
+	if got := pool.Config().ConnConfig.TLSConfig; got == nil {
+		t.Fatal("MI pool with default sslmode left TLS unconfigured, want sslmode=require")
+	}
+}
 
 func TestDSNFromEnv_DefaultsWhenUnset(t *testing.T) {
 	t.Setenv("TEST_DATABASE_URL", "")


### PR DESCRIPTION
**Slice B** of #653 (passwordless Entra managed-identity auth from the Go API to dev Postgres). Epic #645 / tc-hpd2 (memo 0010). Bead: tc-vnna. Follows Slice A (#654, merged + deployed to dev).

## What
- **`internal/platform/postgres/pool.go`**: `NewPoolFromEnv` chooses auth by `POSTGRES_AUTH`. `azure-managed-identity` → passwordless pool whose pgx `BeforeConnect` injects a fresh Entra token (scope `…/ossrdbms-aad…/.default`) as the connection password per connection (honours `AZURE_CLIENT_ID`, mirrors cosmos.go/servicebus). Token source is an injectable interface for tests. **Any other value (unset/`password`) is byte-for-byte the existing `NewPool`/`DSNFromEnv` path** — pgtest, `make test-integration`, docker-compose untouched. The MI DSN uses `url.User` (no password in the string).
- **`cmd/pgbootstrap/`**: one-time, idempotent, least-privilege bootstrap run by the Entra admin (`DefaultAzureCredential`, token-as-password). Maps the MI to role `towncrier_api` via `pgaadauth_create_principal_with_oid(...,'service',...)` (guarded by a `pg_roles` check) and grants **DML only** (CONNECT/USAGE/SELECT/INSERT/UPDATE/DELETE + sequences + default privileges). No superuser/owner/DDL. Identifiers validated (identifier/UUID regex) before templating the checked-in `bootstrap.sql`. `-verify` prints `SELECT current_user`.
- **`cmd/api/main.go`**: strictly non-fatal, env-guarded, self-terminating connectivity probe that logs `current_user` so the "dev connects passwordless" milestone is provable from logs. Wires no route or store; Cosmos stays live.

## Tests (TDD, hand-written fakes)
`pool_test.go`: chooser default-to-password, MI passwordless DSN omits password, BeforeConnect injects token + propagates token error, sslmode defaults to require. `cmd/pgbootstrap/main_test.go`: least-priv grant assertions, no-elevated-privilege, idempotency guard, identifier/UUID injection rejection.

## Gates
`gofmt` clean · `go vet` ok · `golangci-lint` 0 issues · `go test -race ./...` 1162 passed · `go build ./...` ok · integration suite still compiles (fallback intact).

## Post-merge (orchestrator)
After CD deploys: run `pgbootstrap` as the Entra admin to create the role, then confirm the dev API logs `connected passwordless currentUser=towncrier_api`.

## Out of scope
Store wiring/backfill/cutover, prod, disabling password auth, schema-migration ownership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)