### PR TITLE
feat(api): admin-token goose migrate runner for dev Postgres (tc-aydo)

### DIFF
--- a/api-go/cmd/pgmigrate/main.go
+++ b/api-go/cmd/pgmigrate/main.go
@@ -1,0 +1,122 @@
+// Command pgmigrate applies the embedded goose schema migrations to a Town
+// Crier app database on the shared Azure Database for PostgreSQL Flexible
+// Server. It is a one-time, idempotent data-plane operation run by the Entra
+// admin (a locally `az login`-ed human), not part of any deploy.
+//
+// The app role (towncrier_api) is DML-only by design and cannot run DDL, so the
+// migrations must be applied by a privileged principal — the Entra admin = repo
+// owner account, the same principal that ran cmd/pgbootstrap. Running them as
+// the owner makes the owner the table owner, which is what the #653 bootstrap's
+// ALTER DEFAULT PRIVILEGES relies on to auto-grant towncrier_api DML on the
+// newly created tables.
+//
+// It authenticates passwordlessly: a short-lived Entra access token (scope
+// https://ossrdbms-aad.database.windows.net/.default) is fetched from a
+// DefaultAzureCredential and used as the connection password. goose opens a
+// single stdlib connection and runs well within the token's validity, so no
+// per-connection refresh is needed (unlike the long-lived API pool).
+//
+// Usage:
+//
+//	pgmigrate -host <fqdn> -admin-user <aad-admin-upn> [-db town_crier_dev] \
+//	    [-sslmode require] [-timeout 60s]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
+)
+
+// defaultSSLMode is applied when -sslmode resolves to empty. require is the
+// minimum for Azure Database for PostgreSQL Flexible Server.
+const defaultSSLMode = "require"
+
+// azurePostgresTokenScope is the fixed OSS RDBMS AAD resource for Azure Database
+// for PostgreSQL. It is a public OAuth scope identifier, not a secret.
+//
+//nolint:gosec // G101: public AAD resource scope URL, not a credential
+const azurePostgresTokenScope = "https://ossrdbms-aad.database.windows.net/.default"
+
+func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
+	fs := flag.NewFlagSet("pgmigrate", flag.ContinueOnError)
+	var (
+		host      = fs.String("host", os.Getenv("POSTGRES_HOST"), "Postgres server FQDN")
+		adminUser = fs.String("admin-user", os.Getenv("POSTGRES_ADMIN_USER"), "Entra admin principal name (UPN) to connect as")
+		db        = fs.String("db", envOr("POSTGRES_DB", "town_crier_dev"), "app database to migrate")
+		sslMode   = fs.String("sslmode", envOr("POSTGRES_SSLMODE", defaultSSLMode), "sslmode")
+		timeout   = fs.Duration("timeout", 60*time.Second, "overall timeout")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	if *host == "" || *adminUser == "" {
+		fmt.Fprintln(os.Stderr, "pgmigrate: -host and -admin-user are required")
+		return 2
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgmigrate: build credential: %v\n", err)
+		return 1
+	}
+
+	// Fetch the Entra token up front and pass it as the connection password.
+	// goose runs a single short-lived connection, so one token covers the run;
+	// there is no need for the API pool's per-connection BeforeConnect refresh.
+	tok, err := cred.GetToken(ctx, policy.TokenRequestOptions{Scopes: []string{azurePostgresTokenScope}})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgmigrate: acquire postgres access token: %v\n", err)
+		return 1
+	}
+
+	dsn := migrateDSN(*host, *db, *adminUser, *sslMode, tok.Token)
+	if err := postgres.Migrate(ctx, dsn); err != nil {
+		fmt.Fprintf(os.Stderr, "pgmigrate: migrate %q: %v\n", *db, err)
+		return 1
+	}
+
+	fmt.Printf("pgmigrate: migrations applied to %q on %s\n", *db, *host)
+	return 0
+}
+
+// migrateDSN builds a token-as-password Postgres DSN from discrete inputs. The
+// admin UPN (which contains '#' and '@') and the token are percent-encoded via
+// url.UserPassword, so neither breaks the userinfo/host split. The token is a
+// short-lived secret carried only in-memory for the single migration run.
+func migrateDSN(host, db, user, sslMode, token string) string {
+	if sslMode == "" {
+		sslMode = defaultSSLMode
+	}
+	u := url.URL{
+		Scheme:   "postgres",
+		User:     url.UserPassword(user, token),
+		Host:     host,
+		Path:     "/" + db,
+		RawQuery: url.Values{"sslmode": {sslMode}}.Encode(),
+	}
+	return u.String()
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/api-go/cmd/pgmigrate/main_test.go
+++ b/api-go/cmd/pgmigrate/main_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// adminUPN is a realistic Entra external-guest admin UPN: it contains the two
+// characters (# and @) that make a token-as-password DSN a percent-encoding
+// trap if naively concatenated.
+const adminUPN = "amy_salter.uk#EXT#@amysalter.onmicrosoft.com"
+
+// fakeToken stands in for an Entra access token. Real tokens are base64url JWTs
+// (only unreserved chars), but the password must still survive characters that
+// require escaping in userinfo, so the fixture deliberately includes '/', ':'
+// and '@'.
+const fakeToken = "header.payload.sig/na:ture@v1"
+
+func TestMigrateDSN(t *testing.T) {
+	t.Parallel()
+
+	const host = "psql-town-crier-shared.postgres.database.azure.com"
+	const db = "town_crier_dev"
+
+	tests := []struct {
+		name        string
+		sslMode     string
+		wantSSLMode string
+	}{
+		{name: "explicit sslmode is preserved", sslMode: "verify-full", wantSSLMode: "verify-full"},
+		{name: "empty sslmode defaults to require", sslMode: "", wantSSLMode: "require"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dsn := migrateDSN(host, db, adminUPN, tc.sslMode, fakeToken)
+
+			// Round-trip through url.Parse: if the UPN '#'/'@' and the token's
+			// reserved chars are correctly percent-encoded, parsing decodes them
+			// back to the exact inputs. A naive concat would mis-split here.
+			u, err := url.Parse(dsn)
+			if err != nil {
+				t.Fatalf("migrateDSN produced an unparseable DSN %q: %v", dsn, err)
+			}
+			if u.Scheme != "postgres" {
+				t.Errorf("scheme = %q, want %q", u.Scheme, "postgres")
+			}
+			if u.Host != host {
+				t.Errorf("host = %q, want %q", u.Host, host)
+			}
+			if u.Path != "/"+db {
+				t.Errorf("path = %q, want %q", u.Path, "/"+db)
+			}
+			if got := u.User.Username(); got != adminUPN {
+				t.Errorf("username = %q, want %q", got, adminUPN)
+			}
+			pw, ok := u.User.Password()
+			if !ok {
+				t.Fatal("DSN carries no password (token)")
+			}
+			if pw != fakeToken {
+				t.Errorf("password = %q, want %q", pw, fakeToken)
+			}
+			if got := u.Query().Get("sslmode"); got != tc.wantSSLMode {
+				t.Errorf("sslmode = %q, want %q", got, tc.wantSSLMode)
+			}
+		})
+	}
+}
+
+// TestMigrateDSN_PercentEncodesUPN asserts the raw DSN string actually carries
+// the encoded forms, so the encoding intent is explicit and not silently lost
+// to a future refactor that round-trips differently.
+func TestMigrateDSN_PercentEncodesUPN(t *testing.T) {
+	t.Parallel()
+
+	dsn := migrateDSN("host.example.com", "town_crier_dev", adminUPN, "require", fakeToken)
+
+	if strings.Contains(dsn, "#") {
+		t.Errorf("DSN contains a raw '#'; the UPN '#' must be percent-encoded: %q", dsn)
+	}
+	if !strings.Contains(dsn, "%23") {
+		t.Errorf("DSN is missing the encoded '#' (%%23): %q", dsn)
+	}
+	if !strings.Contains(dsn, "%40") {
+		t.Errorf("DSN is missing the encoded '@' (%%40) from the UPN: %q", dsn)
+	}
+	// Exactly one literal '@' may remain: the userinfo/host separator. Both the
+	// UPN's '@' and the token's '@' must have been encoded to %40.
+	if n := strings.Count(dsn, "@"); n != 1 {
+		t.Errorf("DSN has %d literal '@', want exactly 1 (userinfo separator): %q", n, dsn)
+	}
+}


### PR DESCRIPTION
Adds `api-go/cmd/pgmigrate` — an admin-token goose migration runner so the Entra admin/owner can apply the Postgres+PostGIS schema (migrations 0001+0002) to `town_crier_dev`. `towncrier_api` is DML-only and cannot run DDL; the owner is the table owner whose `ALTER DEFAULT PRIVILEGES` (#653) auto-grants the API role DML on owner-created tables.

- Pure, unit-tested seam `migrateDSN(...)` builds the token-as-password DSN via `net/url` (percent-encodes the EXT admin UPN's `#`/`@` and the token); thin glue mints an Entra token (scope `ossrdbms-aad`) and calls the shared `postgres.Migrate`.
- Shared `Migrate`/`migrate.go` untouched.

Part of epic #645 (memo 0010), issue #657 Slice 1. Bead tc-aydo.

**Already run against dev** by the orchestrator behind an atomic firewall rule: `applications` + `watch_zones` created (goose v2), `towncrier_api` verified with full DML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMnsU4PvAP3A7sWo2qsp7h

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new database migration command for applying PostgreSQL migrations in Azure-hosted environments.
  * Supports configurable host, admin user, database name, SSL mode, and timeout settings.
  * Uses short-lived sign-in credentials for safer database access.

* **Tests**
  * Added coverage to verify connection details are built correctly, including special-character handling and default SSL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->