### PR TITLE
feat(ios): route TestFlight to dev API, App Store to prod (tc-7wcg)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/API/APIEnvironment.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/APIEnvironment.swift
@@ -20,9 +20,22 @@ public enum APIEnvironment: Equatable, Sendable {
 
   public static var current: APIEnvironment {
     #if DEBUG
-      .development
+      return .development
     #else
-      .production
+      // TestFlight builds ship a *sandbox* App Store receipt; App Store builds ship a
+      // production receipt. Routing TestFlight to dev lets us exercise the dev backend
+      // on-device without affecting the public App Store build. `Bundle.main` is thin,
+      // untested glue; the decision lives in the pure seam below.
+      return environment(forReceiptLastPathComponent: Bundle.main.appStoreReceiptURL?.lastPathComponent)
     #endif
+  }
+
+  /// Pure decision seam for the release-build branch of ``current``, extracted so the
+  /// sandbox-vs-production choice is unit-testable without touching `Bundle.main`.
+  /// - `"sandboxReceipt"` (TestFlight) → `.development`
+  /// - `"receipt"` (App Store) → `.production`
+  /// - `nil` (ad-hoc / local Release with no receipt) → `.production` (safe default)
+  public static func environment(forReceiptLastPathComponent component: String?) -> APIEnvironment {
+    component == "sandboxReceipt" ? .development : .production
   }
 }

--- a/mobile/ios/packages/town-crier-data/Sources/API/APIEnvironment.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/APIEnvironment.swift
@@ -26,7 +26,8 @@ public enum APIEnvironment: Equatable, Sendable {
       // production receipt. Routing TestFlight to dev lets us exercise the dev backend
       // on-device without affecting the public App Store build. `Bundle.main` is thin,
       // untested glue; the decision lives in the pure seam below.
-      return environment(forReceiptLastPathComponent: Bundle.main.appStoreReceiptURL?.lastPathComponent)
+      return environment(
+        forReceiptLastPathComponent: Bundle.main.appStoreReceiptURL?.lastPathComponent)
     #endif
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/APIEnvironmentTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIEnvironmentTests.swift
@@ -26,4 +26,19 @@ struct APIEnvironmentTests {
       #expect(current == .production)
     #endif
   }
+
+  @Test func environment_sandboxReceipt_routesToDevelopment() {
+    // TestFlight builds ship a sandbox App Store receipt.
+    #expect(APIEnvironment.environment(forReceiptLastPathComponent: "sandboxReceipt") == .development)
+  }
+
+  @Test func environment_productionReceipt_routesToProduction() {
+    // App Store builds ship a production receipt named "receipt".
+    #expect(APIEnvironment.environment(forReceiptLastPathComponent: "receipt") == .production)
+  }
+
+  @Test func environment_missingReceipt_routesToProduction() {
+    // Ad-hoc / local Release runs have no receipt; default to the safe prod choice.
+    #expect(APIEnvironment.environment(forReceiptLastPathComponent: nil) == .production)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/APIEnvironmentTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIEnvironmentTests.swift
@@ -29,7 +29,8 @@ struct APIEnvironmentTests {
 
   @Test func environment_sandboxReceipt_routesToDevelopment() {
     // TestFlight builds ship a sandbox App Store receipt.
-    #expect(APIEnvironment.environment(forReceiptLastPathComponent: "sandboxReceipt") == .development)
+    #expect(
+      APIEnvironment.environment(forReceiptLastPathComponent: "sandboxReceipt") == .development)
   }
 
   @Test func environment_productionReceipt_routesToProduction() {


### PR DESCRIPTION
Routes **TestFlight** builds (Release + sandbox receipt) to the **dev** API (`api-dev.towncrierapp.uk`) while **App Store** builds (Release + production receipt) stay on **prod** (`api.towncrierapp.uk`). Local Debug stays dev (unchanged). Previously both Release variants hit prod.

- Changes only `APIEnvironment.current` + a pure, unit-tested seam `environment(forReceiptLastPathComponent:)`: `sandboxReceipt → .development`, `receipt → .production`, `nil → .production` (safe default).
- `Bundle.main` stays thin untested glue. Base URLs unchanged. `TownCrierApp.swift` Auth0 wiring untouched — the audience still derives from `APIEnvironment.current`.
- No `Release-Note:` trailer (environment plumbing, no App-Store-user-visible change).

Issue #658, epic #645. Bead tc-7wcg. `swift build`/`swift test` (1357 pass)/`swiftlint --strict` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMnsU4PvAP3A7sWo2qsp7h