### PR TITLE
feat(api): gate Apps+WatchZones stores on APPS_ZONES_BACKEND (postgres on dev) (tc-2skw)

### DIFF
--- a/api-go/cmd/api/backend.go
+++ b/api-go/cmd/api/backend.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// storeBackend selects which datastore backs the Applications and WatchZones
+// route stores. The other nine stores are always Cosmos; only these two move to
+// Postgres + PostGIS in the hybrid migration phase (memo 0010, epic #645,
+// issue #657 Slice 2).
+type storeBackend int
+
+const (
+	// backendCosmos is the default for every value of APPS_ZONES_BACKEND other
+	// than the exact string "postgres" — including unset and "cosmos" — so prod
+	// (flag unset) is never silently flipped off Cosmos.
+	backendCosmos storeBackend = iota
+	// backendPostgres serves Applications + WatchZones from Postgres + PostGIS.
+	// It is set on the dev container only.
+	backendPostgres
+)
+
+// appsZonesBackendPostgres is the only APPS_ZONES_BACKEND value that selects
+// Postgres. The flag is dedicated and explicit — never inferred from
+// POSTGRES_AUTH — so a future prod POSTGRES_AUTH can never flip prod's stores.
+const appsZonesBackendPostgres = "postgres"
+
+// resolveBackend maps the APPS_ZONES_BACKEND flag to a storeBackend. Only the
+// exact value "postgres" (whitespace-trimmed) selects Postgres; every other
+// value, including "" and "cosmos", keeps Cosmos.
+func resolveBackend(flag string) storeBackend {
+	if strings.TrimSpace(flag) == appsZonesBackendPostgres {
+		return backendPostgres
+	}
+	return backendCosmos
+}
+
+// chooseAppStore returns the Applications store for the selected backend as a
+// genuine consumer-side interface. When the chosen backend has no backing store
+// configured it returns a true nil interface — never a typed-nil pointer boxed in
+// a non-nil interface — so newRouter's `appStore != nil` guard correctly leaves
+// the application routes unwired on a store-less boot.
+func chooseAppStore(backend storeBackend, pg *applications.PostgresStore, cosmos *applications.CosmosStore) applications.Store {
+	if backend == backendPostgres {
+		if pg == nil {
+			return nil
+		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseZoneStore mirrors chooseAppStore for the WatchZones store.
+func chooseZoneStore(backend storeBackend, pg *watchzones.PostgresStore, cosmos *watchzones.CosmosStore) watchzones.Store {
+	if backend == backendPostgres {
+		if pg == nil {
+			return nil
+		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}

--- a/api-go/cmd/api/backend_test.go
+++ b/api-go/cmd/api/backend_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// TestResolveBackend pins the APPS_ZONES_BACKEND contract: only the exact value
+// "postgres" (whitespace-trimmed) selects Postgres; every other value, including
+// unset and "cosmos", keeps Cosmos so prod (flag unset) is never silently
+// flipped, and a non-canonical casing is treated as "any other value".
+func TestResolveBackend(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		flag string
+		want storeBackend
+	}{
+		{"exact postgres selects postgres", "postgres", backendPostgres},
+		{"surrounding whitespace is trimmed", "  postgres\t", backendPostgres},
+		{"unset defaults to cosmos", "", backendCosmos},
+		{"explicit cosmos stays cosmos", "cosmos", backendCosmos},
+		{"uppercase is not the canonical value", "Postgres", backendCosmos},
+		{"junk defaults to cosmos", "nonsense", backendCosmos},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveBackend(tc.flag); got != tc.want {
+				t.Fatalf("resolveBackend(%q) = %v, want %v", tc.flag, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestChooseAppStore covers both the backend selection and the typed-nil trap:
+// when the chosen backend has no backing store the chooser must return a GENUINE
+// nil interface (not a typed-nil pointer boxed in a non-nil interface), so
+// newRouter's `appStore != nil` guard leaves the application routes unwired.
+func TestChooseAppStore(t *testing.T) {
+	t.Parallel()
+
+	cosmos := applications.NewCosmosStore(newFakeItems())
+	pg := applications.NewPostgresStore(nil) // querier is never touched in these tests
+
+	t.Run("postgres backend returns the postgres store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseAppStore(backendPostgres, pg, cosmos)
+		if _, ok := got.(*applications.PostgresStore); !ok {
+			t.Fatalf("got %T, want *applications.PostgresStore", got)
+		}
+	})
+
+	t.Run("cosmos backend returns the cosmos store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseAppStore(backendCosmos, pg, cosmos)
+		if _, ok := got.(*applications.CosmosStore); !ok {
+			t.Fatalf("got %T, want *applications.CosmosStore", got)
+		}
+	})
+
+	t.Run("postgres backend with no pool yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseAppStore(backendPostgres, nil, cosmos); got != nil {
+			t.Fatalf("got %T (non-nil interface), want a genuine nil so routes stay unwired", got)
+		}
+	})
+
+	t.Run("cosmos backend with no container yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseAppStore(backendCosmos, pg, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want a genuine nil so routes stay unwired", got)
+		}
+	})
+}
+
+// TestChooseZoneStore mirrors TestChooseAppStore for the watch-zone store.
+func TestChooseZoneStore(t *testing.T) {
+	t.Parallel()
+
+	cosmos := watchzones.NewCosmosStore(newFakeItems())
+	pg := watchzones.NewPostgresStore(nil)
+
+	t.Run("postgres backend returns the postgres store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseZoneStore(backendPostgres, pg, cosmos)
+		if _, ok := got.(*watchzones.PostgresStore); !ok {
+			t.Fatalf("got %T, want *watchzones.PostgresStore", got)
+		}
+	})
+
+	t.Run("cosmos backend returns the cosmos store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseZoneStore(backendCosmos, pg, cosmos)
+		if _, ok := got.(*watchzones.CosmosStore); !ok {
+			t.Fatalf("got %T, want *watchzones.CosmosStore", got)
+		}
+	})
+
+	t.Run("postgres backend with no pool yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseZoneStore(backendPostgres, nil, cosmos); got != nil {
+			t.Fatalf("got %T (non-nil interface), want a genuine nil so routes stay unwired", got)
+		}
+	})
+
+	t.Run("cosmos backend with no container yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseZoneStore(backendCosmos, pg, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want a genuine nil so routes stay unwired", got)
+		}
+	})
+}

--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -77,6 +77,30 @@ func main() {
 		go probePostgresManagedIdentity(logger)
 	}
 
+	// APPS_ZONES_BACKEND gates the Applications + WatchZones route stores onto
+	// Postgres (dev only; prod and every other store stay Cosmos — issue #657
+	// Slice 2). When it selects Postgres we build ONE pool — MI-token auth from
+	// the dev container's POSTGRES_*/AZURE_CLIENT_ID via NewPoolFromEnv — and back
+	// both Postgres stores with it. Dev explicitly wants Postgres, so a pool that
+	// can't be built is fatal rather than a silent Cosmos fallback. The pool closes
+	// on shutdown. When the flag is unset (prod, local) these stay nil and the
+	// existing Cosmos construction is byte-for-byte unchanged.
+	appsZonesBackend := resolveBackend(cfg.AppsZonesBackend)
+	var (
+		pgAppStore       *applications.PostgresStore
+		pgWatchZoneStore *watchzones.PostgresStore
+	)
+	if appsZonesBackend == backendPostgres {
+		pool, perr := postgres.NewPoolFromEnv(context.Background())
+		if perr != nil {
+			log.Fatalf("apps/zones backend=postgres: build postgres pool: %v", perr)
+		}
+		defer pool.Close()
+		pgAppStore = applications.NewPostgresStore(pool)
+		pgWatchZoneStore = watchzones.NewPostgresStore(pool)
+		logger.Info("apps/zones backend selected", "backend", "postgres")
+	}
+
 	validator, err := auth.NewAuth0Validator(cfg.Auth0Domain, cfg.Auth0Audience, logger)
 	if err != nil {
 		log.Fatal(err)
@@ -128,20 +152,31 @@ func main() {
 		log.Fatal(err)
 	}
 	watchZones.WithMetrics(registry)
-	var watchZoneStore *watchzones.CosmosStore
+	// cosmosWatchZoneStore is always the concrete Cosmos store: it backs the GDPR
+	// erasure cascade, the data export, and the admin location/bbox backfill — all
+	// Cosmos-era paths that stay on Cosmos regardless of the route backend.
+	// watchZoneStore is the flag-selected consumer-side interface the route wiring
+	// uses (Postgres on dev, Cosmos elsewhere); chooseZoneStore returns a genuine
+	// nil interface when neither backing is configured.
+	var cosmosWatchZoneStore *watchzones.CosmosStore
 	if watchZones != nil {
-		watchZoneStore = watchzones.NewCosmosStore(watchZones)
+		cosmosWatchZoneStore = watchzones.NewCosmosStore(watchZones)
 	}
+	watchZoneStore := chooseZoneStore(appsZonesBackend, pgWatchZoneStore, cosmosWatchZoneStore)
 
 	appsContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosApplicationsContainer, logger)
 	if err != nil {
 		log.Fatal(err)
 	}
 	appsContainer.WithMetrics(registry)
-	var appStore *applications.CosmosStore
+	var cosmosAppStore *applications.CosmosStore
 	if appsContainer != nil {
-		appStore = applications.NewCosmosStore(appsContainer)
+		cosmosAppStore = applications.NewCosmosStore(appsContainer)
 	}
+	// appStore is the flag-selected consumer-side interface the application routes
+	// use (Postgres on dev, Cosmos elsewhere); a genuine nil interface leaves the
+	// routes unwired on a store-less boot.
+	appStore := chooseAppStore(appsZonesBackend, pgAppStore, cosmosAppStore)
 
 	savedContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosSavedApplicationsContainer, logger)
 	if err != nil {
@@ -176,7 +211,7 @@ func main() {
 	if notificationsContainer != nil && watchZones != nil && savedContainer != nil && devices != nil && stateContainer != nil && offerStore != nil {
 		cascade = profiles.CascadeDeleters{
 			Notifications:       notifications.NewDeleteStore(notificationsContainer),
-			WatchZones:          watchZoneStore,
+			WatchZones:          cosmosWatchZoneStore,
 			SavedApplications:   savedStore,
 			DeviceRegistrations: deviceStore,
 			NotificationState:   erasure.NotificationStateChild(stateStore),
@@ -198,7 +233,7 @@ func main() {
 	var exportReaders profiles.ExportReaders
 	if notificationsContainer != nil && watchZones != nil && savedContainer != nil && devices != nil && offerStore != nil {
 		exportReaders = profiles.ExportReaders{
-			WatchZones:           watchZoneExportReader{store: watchZoneStore},
+			WatchZones:           watchZoneExportReader{store: cosmosWatchZoneStore},
 			Notifications:        notificationExportReader{store: notifications.NewDigestStore(notificationsContainer)},
 			SavedApplications:    savedApplicationExportReader{store: savedStore},
 			DeviceRegistrations:  deviceRegistrationExportReader{store: deviceStore},
@@ -266,7 +301,7 @@ func main() {
 		log.Fatalf("designations client: %v", err)
 	}
 
-	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cascade, exportReaders, deviceStore, stateStore, notifStore, watchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, cfg.SiteBuildKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, cfg.AppleEnvironments, registry, logger))
+	srv := platform.NewServer(":"+cfg.Port, newRouter(validator, cfg.CorsAllowedOrigins, store, manager, cascade, exportReaders, deviceStore, stateStore, notifStore, watchZoneStore, cosmosWatchZoneStore, appStore, savedStore, geocodeClient, designationClient, offerStore, adminStore, cfg.AdminAPIKey, cfg.SiteBuildKey, jwsVerifier, appleNotifStore, cfg.AppleBundleID, cfg.AppleEnvironments, registry, logger))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -98,7 +98,18 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // nil-means-unwired convention. (The watch-zone preferences endpoints are
 // served by profiles.Routes off the profile store, so they come up with the
 // /v1/me routes, not the watch-zone store.)
-func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, cascade profiles.CascadeDeleters, exportReaders profiles.ExportReaders, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore *watchzones.CosmosStore, appStore *applications.CosmosStore, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, siteBuildKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, appleEnvironments []string, registry *metrics.Registry, logger *slog.Logger) http.Handler {
+//
+// watchZoneStore and appStore are consumer-side interfaces (watchzones.Store /
+// applications.Store), not concrete *CosmosStore pointers, so cmd/api can serve
+// these two from either Cosmos or Postgres per the APPS_ZONES_BACKEND flag
+// (issue #657 Slice 2). They MUST be passed as genuine nil interfaces (not a
+// typed-nil *CosmosStore boxed in an interface) when unconfigured, or the
+// nil-means-unwired guards below would wire dead routes — main.go's chooseAppStore
+// / chooseZoneStore enforce this. adminWatchZones stays the concrete Cosmos
+// *watchzones.CosmosStore because the admin location/bbox backfill it feeds is a
+// Cosmos-era migrator absent from the Postgres port; it is constructed regardless
+// of the flag so the admin surface is unaffected by the backend swap.
+func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, cascade profiles.CascadeDeleters, exportReaders profiles.ExportReaders, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore watchzones.Store, adminWatchZones *watchzones.CosmosStore, appStore applications.Store, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, siteBuildKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, appleEnvironments []string, registry *metrics.Registry, logger *slog.Logger) http.Handler {
 	mux := http.NewServeMux()
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)
@@ -188,13 +199,15 @@ func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profi
 		// coded tier, and syncs Auth0. Needs both the profile and offer-code stores.
 		offercodes.Routes(mux, offerStore, store, auth0, time.Now, logger)
 	}
-	if adminStore != nil && offerStore != nil && watchZoneStore != nil {
+	if adminStore != nil && offerStore != nil && adminWatchZones != nil {
 		// Admin endpoints are anonymous to Auth0 and gated by the X-Admin-Key. The
 		// cross-partition admin store backs grant/list; the offer-code store backs
-		// generate; the watch-zone store backs the one-shot location backfill. All
-		// three are Cosmos-gated, so the added guard never disables admin in a real
-		// deployment (Cosmos configures every store together).
-		admin.Routes(mux, adminKey, adminStore, auth0, offerStore, offercodes.NewRandomGenerator(), watchZoneStore, time.Now, logger)
+		// generate; the Cosmos watch-zone store backs the one-shot location/bbox
+		// backfill (a Cosmos-era migrator, hence adminWatchZones not the flag-selected
+		// store). All three are Cosmos-gated, so the guard never disables admin in a
+		// real deployment (Cosmos configures every store together, even when the
+		// Applications/WatchZones routes are served from Postgres).
+		admin.Routes(mux, adminKey, adminStore, auth0, offerStore, offercodes.NewRandomGenerator(), adminWatchZones, time.Now, logger)
 	}
 	if store != nil && adminStore != nil && jwsVerifier != nil && appleNotifStore != nil {
 		// Subscriptions: verify (authed, by user id via the profile store) and the

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -180,7 +180,7 @@ func testDesignationClientWith(t *testing.T, baseURL string, httpClient *http.Cl
 
 func newTestHandler(t *testing.T) http.Handler {
 	t.Helper()
-	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, slog.New(slog.DiscardHandler))
+	return newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, slog.New(slog.DiscardHandler))
 }
 
 // TestRouter_AnonymousRoutesServedWithoutToken confirms the iteration-0/1
@@ -285,7 +285,7 @@ func TestRouter_AuthenticatedPipeline(t *testing.T) {
 	appStore := applications.NewCosmosStore(newFakeItems())
 	savedStore := savedapplications.NewCosmosStore(newFakeItems())
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, watchZoneStore, appStore, savedStore, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, watchZoneStore, watchZoneStore, appStore, savedStore, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, logger)
 
 	// Create the profile, then read it back through the same chain.
 	rec := serveReq(t, h, http.MethodPost, "/v1/me", "", "Bearer tok")
@@ -383,7 +383,7 @@ func TestRouter_GeocodeAndDesignationsDispatch(t *testing.T) {
 	validator := staticValidator{claims: auth.Claims{Subject: "auth0|wiretest", Email: "wire@example.com", EmailVerified: true}}
 	geocodeClient := testGeocodeClientWith(t, upstream.URL, upstream.Client())
 	designationClient := testDesignationClientWith(t, upstream.URL, upstream.Client())
-	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", "", nil, nil, "", nil, nil, logger)
+	h := newRouter(validator, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, nil, geocodeClient, designationClient, nil, nil, "", "", nil, nil, "", nil, nil, logger)
 
 	rec := serveReq(t, h, http.MethodGet, "/v1/geocode/SW1A%201AA", "", "Bearer tok")
 	if rec.Code != http.StatusOK {
@@ -422,7 +422,7 @@ func TestRouter_SubscriptionsWired(t *testing.T) {
 		t.Fatalf("NewJWSVerifier: %v", err)
 	}
 
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, adminStore, "", "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, store, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), nil, adminStore, "", "", verifier, notifStore, "uk.towncrierapp.mobile", []string{"Production"}, nil, logger)
 
 	// Webhook is anonymous: a malformed body reaches the handler -> 400 with the
 	// malformed_request envelope, not the WWW-Authenticate 401 fallback.
@@ -456,7 +456,7 @@ func TestRouter_AdminGate(t *testing.T) {
 	// location-backfill endpoint), so supply one — all admin stores are Cosmos-gated
 	// together in a real deployment.
 	watchZoneStore := watchzones.NewCosmosStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, watchZoneStore, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, watchZoneStore, watchZoneStore, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, logger)
 
 	// No key: the admin gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).
@@ -488,7 +488,7 @@ func TestRouter_RecentApplicationsBuildKeyGate(t *testing.T) {
 
 	logger := slog.New(slog.DiscardHandler)
 	appStore := applications.NewCosmosStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, logger)
 
 	// No key: the build gate rejects with a bodyless 401 and NO WWW-Authenticate
 	// (distinguishing it from the Auth0 fallback-deny).
@@ -534,7 +534,7 @@ func TestRouter_NearApplicationsBuildKeyGate(t *testing.T) {
 
 	logger := slog.New(slog.DiscardHandler)
 	appStore := applications.NewCosmosStore(newFakeItems())
-	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, logger)
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "buildsecret", nil, nil, "", nil, nil, logger)
 
 	noKey := nearRequest(t, h, "")
 	if noKey.Code != http.StatusUnauthorized {

--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -22,13 +22,17 @@ type querier interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
-// storeSurface is the full method set the Applications store exposes to its
-// consumers across packages (handler's appStore, recent.go's recentStore,
-// near.go's nearStore, watchzones.appFinder's FindNearbyPage, the savedapplications
-// snapshot backfill's GetByUID, and the poll Upsert). It exists only as a
-// compile-time parity check: both *CosmosStore and *PostgresStore must satisfy it,
-// so a Postgres port can never silently diverge from the Cosmos surface.
-type storeSurface interface {
+// Store is the full method set the Applications store exposes to its consumers
+// across packages (handler's appStore, recent.go's recentStore, near.go's
+// nearStore, watchzones.appFinder's FindNearbyPage, the savedapplications snapshot
+// backfill's GetByUID, demoaccount's Upsert + FindNearbyPage, and the poll
+// Upsert). It serves two purposes: a compile-time parity check (both *CosmosStore
+// and *PostgresStore must satisfy it, so a Postgres port can never silently
+// diverge from the Cosmos surface) and the exported consumer-side interface
+// cmd/api's newRouter accepts, so the Applications routes can be served from
+// either backend behind the APPS_ZONES_BACKEND flag (issue #657 Slice 2). Every
+// narrower per-handler interface is a subset of this set.
+type Store interface {
 	Upsert(ctx context.Context, a PlanningApplication) error
 	GetByAuthorityAndName(ctx context.Context, authorityCode, name string) (PlanningApplication, bool, error)
 	GetByUID(ctx context.Context, uid, authorityCode string) (PlanningApplication, bool, error)
@@ -41,13 +45,13 @@ type storeSurface interface {
 }
 
 // Compile-time parity: the Postgres store satisfies the same consumer-side
-// interfaces the Cosmos store does, and both satisfy the full storeSurface.
+// interfaces the Cosmos store does, and both satisfy the full Store surface.
 var (
-	_ appStore     = (*PostgresStore)(nil)
-	_ recentStore  = (*PostgresStore)(nil)
-	_ nearStore    = (*PostgresStore)(nil)
-	_ storeSurface = (*PostgresStore)(nil)
-	_ storeSurface = (*CosmosStore)(nil)
+	_ appStore    = (*PostgresStore)(nil)
+	_ recentStore = (*PostgresStore)(nil)
+	_ nearStore   = (*PostgresStore)(nil)
+	_ Store       = (*PostgresStore)(nil)
+	_ Store       = (*CosmosStore)(nil)
 )
 
 // PostgresStore reads and writes planning applications in the Postgres

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -45,6 +45,15 @@ type Config struct {
 	CosmosDatabase string
 	AzureClientID  string
 
+	// AppsZonesBackend selects the datastore for the Applications and WatchZones
+	// route stores. The only value that selects Postgres + PostGIS is the exact
+	// string "postgres"; every other value (including unset) keeps Cosmos. It is a
+	// dedicated, explicit flag (read from APPS_ZONES_BACKEND) set on the dev
+	// container only (epic #645, issue #657 Slice 2), never inferred from
+	// POSTGRES_AUTH, so a future prod POSTGRES_AUTH can never flip prod's stores
+	// off Cosmos. The other nine stores stay Cosmos regardless.
+	AppsZonesBackend string
+
 	// Auth0M2MClientID / Auth0M2MClientSecret are the machine-to-machine
 	// client-credentials used to sync subscription tier and delete users in the
 	// Auth0 Management API. When any of these (or Auth0Domain) is absent, the
@@ -186,6 +195,8 @@ func LoadConfig() (Config, error) {
 		CosmosEndpoint: os.Getenv("COSMOS_ENDPOINT"),
 		CosmosDatabase: os.Getenv("COSMOS_DATABASE"),
 		AzureClientID:  os.Getenv("AZURE_CLIENT_ID"),
+
+		AppsZonesBackend: os.Getenv("APPS_ZONES_BACKEND"),
 
 		ServiceBusNamespace: os.Getenv("SERVICE_BUS_NAMESPACE"),
 		ServiceBusQueueName: os.Getenv("SERVICE_BUS_QUEUE_NAME"),

--- a/api-go/internal/watchzones/store_postgres.go
+++ b/api-go/internal/watchzones/store_postgres.go
@@ -19,10 +19,18 @@ type querier interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
-// storeSurface is the full watch-zone store method set its consumers rely on. It
-// exists only as a compile-time parity check: both *CosmosStore and *PostgresStore
-// must satisfy it, so the Postgres port can never silently diverge.
-type storeSurface interface {
+// Store is the full watch-zone store method set its consumers rely on. It serves
+// two purposes: a compile-time parity check (both *CosmosStore and *PostgresStore
+// must satisfy it, so the Postgres port can never silently diverge) and the
+// exported consumer-side interface cmd/api's newRouter accepts, so the watch-zone
+// routes can be served from either backend behind the APPS_ZONES_BACKEND flag
+// (issue #657 Slice 2). The narrower per-handler interfaces (zoneStore,
+// zoneAuthorityLister, demoaccount.zoneStore) are all subsets of this set.
+//
+// The Cosmos-era BackfillLocation / BackfillBoundingBox one-shot migrators are
+// deliberately NOT here: they exist only on *CosmosStore and the admin backfill
+// route binds to it directly, so the Postgres port stays honest (no no-op stubs).
+type Store interface {
 	GetByUserID(ctx context.Context, userID string) ([]WatchZone, error)
 	Get(ctx context.Context, userID, zoneID string) (WatchZone, error)
 	Save(ctx context.Context, z WatchZone) error
@@ -33,8 +41,8 @@ type storeSurface interface {
 }
 
 var (
-	_ storeSurface = (*PostgresStore)(nil)
-	_ storeSurface = (*CosmosStore)(nil)
+	_ Store = (*PostgresStore)(nil)
+	_ Store = (*CosmosStore)(nil)
 )
 
 // PostgresStore reads and writes watch zones in the Postgres `watch_zones` table


### PR DESCRIPTION
Introduces an explicit, dev-only backend switch so the **dev** API serves **Applications + WatchZones** from **Postgres+PostGIS** while **prod stays Cosmos** and the other 9 stores stay Cosmos everywhere.

- New `platform.Config.AppsZonesBackend` (env `APPS_ZONES_BACKEND`); `resolveBackend` selects Postgres only on the exact value `postgres` (NOT inferred from `POSTGRES_AUTH`).
- `newRouter`: `appStore`/`watchZoneStore` widened to exported consumer-side interfaces `applications.Store`/`watchzones.Store`; a separate concrete `adminWatchZones *watchzones.CosmosStore` keeps the Cosmos-era admin location/bbox backfiller (absent from the Postgres port) on Cosmos in both modes.
- `main.go`: when `postgres`, builds one pool via `postgres.NewPoolFromEnv` and constructs the Postgres stores; `log.Fatal` on pool failure (no silent Cosmos fallback). The Cosmos watch-zone store is still built for the admin backfiller / GDPR cascade / export.
- Prod (flag unset/`cosmos`) is byte-for-byte unchanged. Compile-time parity asserts kept.

Issue #657 Slice 2, epic #645. Bead tc-2skw.

**Follow-up filed (tc-s8g1, discovered-from tc-2skw):** in Postgres mode the GDPR erasure cascade + data export remain Cosmos-bound, so they'd miss Postgres-resident watch zones. Deliberately out of scope for this dev-only proof phase (owner-created test zones, no prod PII); must be wired before any prod cutover.

Gates green locally: `go build`/`go test -race` (1182) /`go vet`/`gofmt`/`golangci-lint` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMnsU4PvAP3A7sWo2qsp7h