### PR TITLE
feat(infra): set APPS_ZONES_BACKEND=postgres on dev API container (tc-1mnr)

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -418,6 +418,10 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 			app.EnvironmentVarArgs{Name: pulumi.String("POSTGRES_USER"), Value: pulumi.String("towncrier_api")},
 			app.EnvironmentVarArgs{Name: pulumi.String("POSTGRES_SSLMODE"), Value: pulumi.String("require")},
 			app.EnvironmentVarArgs{Name: pulumi.String("POSTGRES_AUTH"), Value: pulumi.String("azure-managed-identity")},
+			// Explicit backend switch: serve Applications + WatchZones from Postgres on dev
+			// only (GH #657, companion to API bead tc-2skw). Deliberately a dedicated flag,
+			// not inferred from POSTGRES_AUTH, so prod stays Cosmos until its own gated cutover.
+			app.EnvironmentVarArgs{Name: pulumi.String("APPS_ZONES_BACKEND"), Value: pulumi.String("postgres")},
 		)
 	}
 


### PR DESCRIPTION
Sets env var `APPS_ZONES_BACKEND=postgres` on the **dev** API Container App only (`ca-town-crier-api-go-dev`), inside the existing `if env == "dev"` block alongside the #653 `POSTGRES_*` vars. This is the flag the API reads (companion PR, tc-2skw) to serve Applications + WatchZones from Postgres on dev.

Prod and shared stacks get zero change (prod's `env != "dev"`; shared is a separate code path that never builds `apiEnvVars`).

Issue #657 (infra slice), epic #645. Bead tc-1mnr. `go build`/`go vet`/`gofmt` clean; pulumi preview needs CI-injected secrets (verified dev-only-guarded statically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMnsU4PvAP3A7sWo2qsp7h