### PR TITLE
feat(api): Cosmos→Postgres Applications backfill tool (tc-7voq)

### DIFF
--- a/api-go/cmd/pgbackfill/main.go
+++ b/api-go/cmd/pgbackfill/main.go
@@ -1,0 +1,286 @@
+// Command pgbackfill copies the master planning Applications from prod Cosmos
+// into the dev Postgres + PostGIS database, for the Cosmos -> Postgres migration
+// (docs/memo/0010, epic #645; GH#657 Slice 3). It is idempotent and
+// re-runnable: each record is written with the Postgres store's
+// INSERT ... ON CONFLICT (authority_code, planit_name) DO UPDATE, so a re-run
+// reconciles rather than duplicates.
+//
+// Source (read): prod Cosmos, authenticated with the account KEY (read from the
+// COSMOS_KEY environment variable, never a flag, so it stays out of shell
+// history). Applications are public planning data; WatchZones and any per-user
+// PII are deliberately out of scope. The tool enumerates the whole Applications
+// container with a cross-partition `SELECT * FROM c` query, paged via a
+// continuation token.
+//
+// Target (write): dev Postgres, authenticated passwordless as the Entra ADMIN
+// (DefaultAzureCredential) — the owner/admin role has full DML, whereas the
+// least-priv towncrier_api managed identity is only usable from inside Azure.
+//
+// A record with an absent or malformed location is carried with a NULL location
+// (not skipped) — see applications.DecodeDocument and the Postgres Upsert.
+//
+// Usage (run locally, prod Cosmos key in the environment):
+//
+//	export COSMOS_KEY="$(az cosmosdb keys list -n cosmos-town-crier-shared \
+//	    -g rg-town-crier-shared --type keys --query primaryMasterKey -o tsv)"
+//	pgbackfill -pg-host <fqdn> -pg-admin-user <aad-admin-upn> \
+//	    [-cosmos-db town-crier-prod] [-pg-db town_crier_dev] \
+//	    [-batch-size 500] [-limit 0]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
+)
+
+// defaultCosmosEndpoint is the shared Cosmos account hosting prod and dev.
+const defaultCosmosEndpoint = "https://cosmos-town-crier-shared.documents.azure.com:443/"
+
+// defaultCosmosDB is the prod logical database the backfill reads from.
+const defaultCosmosDB = "town-crier-prod"
+
+// defaultPostgresDB is the dev database the backfill writes to.
+const defaultPostgresDB = "town_crier_dev"
+
+// enumerateQuery reads every application across all partitions. Plain
+// cross-partition reads are allowed by the Cosmos Gateway; only ORDER BY /
+// aggregates are refused cross-partition, so this uses neither.
+const enumerateQuery = "SELECT * FROM c"
+
+// docPager yields successive pages of raw Applications-container document
+// bodies. The azcosmos query pager satisfies it via cosmosPager; tests inject a
+// hand-written fake. Defining it consumer-side keeps the backfill loop testable
+// with no network.
+type docPager interface {
+	More() bool
+	NextPage(ctx context.Context) ([][]byte, error)
+}
+
+// appUpserter writes one application idempotently. *applications.PostgresStore
+// satisfies it; tests inject a fake.
+type appUpserter interface {
+	Upsert(ctx context.Context, a applications.PlanningApplication) error
+}
+
+// backfillOptions tune the run: limit caps the number of records processed (0 =
+// all, a small value enables a smoke run); logEvery sets the progress-log
+// cadence in records (0 = no progress logs).
+type backfillOptions struct {
+	limit    int
+	logEvery int
+}
+
+// summary is the final tally the tool prints.
+type summary struct {
+	read     int
+	upserted int
+	errors   int
+}
+
+// backfill drains every page from pager, decodes each document with the shared
+// applications transform, and upserts it into store. It is the testable core,
+// decoupled from Cosmos and Postgres by the docPager / appUpserter seams.
+//
+// Resilience: an undecodable document or a single failed Upsert is counted and
+// skipped (the run is re-runnable, so a later run reconciles) — only a source
+// paging error or context cancellation aborts the whole run with an error.
+func backfill(ctx context.Context, pager docPager, store appUpserter, opts backfillOptions, logger *slog.Logger) (summary, error) {
+	var s summary
+	for pager.More() {
+		if opts.limit > 0 && s.read >= opts.limit {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return s, fmt.Errorf("backfill cancelled after %d records: %w", s.read, err)
+		}
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return s, fmt.Errorf("read source page after %d records: %w", s.read, err)
+		}
+		for _, raw := range page {
+			if opts.limit > 0 && s.read >= opts.limit {
+				break
+			}
+			s.read++
+			app, derr := applications.DecodeDocument(raw)
+			if derr != nil {
+				s.errors++
+				logger.Warn("skip undecodable application", "error", derr)
+				continue
+			}
+			if uerr := store.Upsert(ctx, app); uerr != nil {
+				if ctx.Err() != nil {
+					return s, fmt.Errorf("backfill cancelled upserting %q after %d records: %w", app.Name, s.read, uerr)
+				}
+				s.errors++
+				logger.Warn("upsert failed", "application", app.Name, "authority", app.AreaID, "error", uerr)
+				continue
+			}
+			s.upserted++
+			if opts.logEvery > 0 && s.read%opts.logEvery == 0 {
+				logger.Info("backfill progress", "read", s.read, "upserted", s.upserted, "errors", s.errors)
+			}
+		}
+	}
+	return s, nil
+}
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	os.Exit(run(os.Args[1:], logger))
+}
+
+func run(args []string, logger *slog.Logger) int {
+	fs := flag.NewFlagSet("pgbackfill", flag.ContinueOnError)
+	var (
+		cosmosEndpoint  = fs.String("cosmos-endpoint", defaultCosmosEndpoint, "source Cosmos account endpoint")
+		cosmosDB        = fs.String("cosmos-db", defaultCosmosDB, "source Cosmos logical database")
+		cosmosContainer = fs.String("cosmos-container", platform.CosmosApplicationsContainer, "source Cosmos container id")
+		pgHost          = fs.String("pg-host", os.Getenv("POSTGRES_HOST"), "target Postgres server FQDN")
+		pgDB            = fs.String("pg-db", defaultPostgresDB, "target Postgres database")
+		pgAdminUser     = fs.String("pg-admin-user", os.Getenv("POSTGRES_ADMIN_USER"), "Entra admin principal (UPN) to write as")
+		pgSSLMode       = fs.String("pg-sslmode", envOr("POSTGRES_SSLMODE", "require"), "target Postgres sslmode")
+		batchSize       = fs.Int("batch-size", 500, "Cosmos page size and progress-log cadence")
+		limit           = fs.Int("limit", 0, "max records to process (0 = all; a small value smoke-tests)")
+		timeout         = fs.Duration("timeout", 0, "overall timeout (0 = none; SIGINT/SIGTERM still cancel)")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	cosmosKey := os.Getenv("COSMOS_KEY")
+	if cosmosKey == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill: COSMOS_KEY environment variable is required (read-only prod Cosmos account key)")
+		return 2
+	}
+	if *pgHost == "" || *pgAdminUser == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill: -pg-host and -pg-admin-user are required")
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	pager, err := newCosmosPager(*cosmosEndpoint, cosmosKey, *cosmosDB, *cosmosContainer, *batchSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill: build cosmos source: %v\n", err)
+		return 1
+	}
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill: build azure credential: %v\n", err)
+		return 1
+	}
+	pool, err := postgres.NewTokenCredentialPool(ctx, postgres.ConnParams{
+		Host:    *pgHost,
+		DB:      *pgDB,
+		User:    *pgAdminUser,
+		SSLMode: *pgSSLMode,
+	}, cred)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill: build postgres pool: %v\n", err)
+		return 1
+	}
+	defer pool.Close()
+
+	store := applications.NewPostgresStore(pool)
+
+	logger.Info("backfill starting",
+		"cosmosEndpoint", *cosmosEndpoint, "cosmosDB", *cosmosDB, "cosmosContainer", *cosmosContainer,
+		"pgHost", *pgHost, "pgDB", *pgDB, "batchSize", *batchSize, "limit", *limit)
+
+	started := time.Now()
+	s, err := backfill(ctx, pager, store, backfillOptions{limit: *limit, logEvery: *batchSize}, logger)
+	logger.Info("backfill complete",
+		"read", s.read, "upserted", s.upserted, "errors", s.errors, "elapsed", time.Since(started).String())
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill: aborted: %v\n", err)
+		return 1
+	}
+	if s.errors > 0 {
+		// Per-record errors do not fail the run (re-running reconciles), but make
+		// the count loud so the operator can decide whether to re-run.
+		logger.Warn("backfill finished with per-record errors; re-run to reconcile", "errors", s.errors)
+	}
+	return 0
+}
+
+// cosmosPager adapts the azcosmos query pager to the docPager seam.
+type cosmosPager struct {
+	pager *runtime.Pager[azcosmos.QueryItemsResponse]
+}
+
+func (p *cosmosPager) More() bool { return p.pager.More() }
+
+func (p *cosmosPager) NextPage(ctx context.Context) ([][]byte, error) {
+	resp, err := p.pager.NextPage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cosmos next page: %w", err)
+	}
+	return resp.Items, nil
+}
+
+// newCosmosPager builds a key-authenticated Cosmos client and returns a
+// cross-partition pager over the whole container. This is thin, untested wiring
+// around the official SDK.
+func newCosmosPager(endpoint, key, db, container string, pageSize int) (docPager, error) {
+	cred, err := azcosmos.NewKeyCredential(key)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos key credential: %w", err)
+	}
+	client, err := azcosmos.NewClientWithKey(endpoint, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos client: %w", err)
+	}
+	c, err := client.NewContainer(db, container)
+	if err != nil {
+		return nil, fmt.Errorf("open container %q in %q: %w", container, db, err)
+	}
+	opts := &azcosmos.QueryOptions{PageSizeHint: clampPageSize(pageSize)}
+	// An empty partition key drives the cross-partition path (default
+	// cross-partition flag), matching platform.CosmosContainer's cross-partition reads.
+	return &cosmosPager{pager: c.NewQueryItemsPager(enumerateQuery, azcosmos.NewPartitionKey(), opts)}, nil
+}
+
+// clampPageSize bounds the requested page size into the SDK's int32 hint, with a
+// 1000-item ceiling (the Cosmos max item count per page) and a 100 default for a
+// non-positive request.
+func clampPageSize(n int) int32 {
+	const maxPageSize = 1000
+	if n <= 0 {
+		return 100
+	}
+	if n > maxPageSize {
+		return maxPageSize
+	}
+	return int32(n) //nolint:gosec // n is bounded to [1,1000] above, no overflow
+}
+
+// envOr returns the environment variable value for key, or fallback when unset.
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/api-go/cmd/pgbackfill/main.go
+++ b/api-go/cmd/pgbackfill/main.go
@@ -119,7 +119,7 @@ func backfill(ctx context.Context, pager docPager, store appUpserter, opts backf
 			app, derr := applications.DecodeDocument(raw)
 			if derr != nil {
 				s.errors++
-				logger.Warn("skip undecodable application", "error", derr)
+				logger.WarnContext(ctx, "skip undecodable application", "error", derr)
 				continue
 			}
 			if uerr := store.Upsert(ctx, app); uerr != nil {
@@ -127,12 +127,12 @@ func backfill(ctx context.Context, pager docPager, store appUpserter, opts backf
 					return s, fmt.Errorf("backfill cancelled upserting %q after %d records: %w", app.Name, s.read, uerr)
 				}
 				s.errors++
-				logger.Warn("upsert failed", "application", app.Name, "authority", app.AreaID, "error", uerr)
+				logger.WarnContext(ctx, "upsert failed", "application", app.Name, "authority", app.AreaID, "error", uerr)
 				continue
 			}
 			s.upserted++
 			if opts.logEvery > 0 && s.read%opts.logEvery == 0 {
-				logger.Info("backfill progress", "read", s.read, "upserted", s.upserted, "errors", s.errors)
+				logger.InfoContext(ctx, "backfill progress", "read", s.read, "upserted", s.upserted, "errors", s.errors)
 			}
 		}
 	}
@@ -205,13 +205,13 @@ func run(args []string, logger *slog.Logger) int {
 
 	store := applications.NewPostgresStore(pool)
 
-	logger.Info("backfill starting",
-		"cosmosEndpoint", *cosmosEndpoint, "cosmosDB", *cosmosDB, "cosmosContainer", *cosmosContainer,
-		"pgHost", *pgHost, "pgDB", *pgDB, "batchSize", *batchSize, "limit", *limit)
+	logger.InfoContext(ctx, "backfill starting",
+		"cosmosEndpoint", *cosmosEndpoint, "cosmosDb", *cosmosDB, "cosmosContainer", *cosmosContainer,
+		"pgHost", *pgHost, "pgDb", *pgDB, "batchSize", *batchSize, "limit", *limit)
 
 	started := time.Now()
 	s, err := backfill(ctx, pager, store, backfillOptions{limit: *limit, logEvery: *batchSize}, logger)
-	logger.Info("backfill complete",
+	logger.InfoContext(ctx, "backfill complete",
 		"read", s.read, "upserted", s.upserted, "errors", s.errors, "elapsed", time.Since(started).String())
 
 	if err != nil {
@@ -221,7 +221,7 @@ func run(args []string, logger *slog.Logger) int {
 	if s.errors > 0 {
 		// Per-record errors do not fail the run (re-running reconciles), but make
 		// the count loud so the operator can decide whether to re-run.
-		logger.Warn("backfill finished with per-record errors; re-run to reconcile", "errors", s.errors)
+		logger.WarnContext(ctx, "backfill finished with per-record errors; re-run to reconcile", "errors", s.errors)
 	}
 	return 0
 }

--- a/api-go/cmd/pgbackfill/main_integration_test.go
+++ b/api-go/cmd/pgbackfill/main_integration_test.go
@@ -1,0 +1,80 @@
+//go:build integration
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// rawDocWithState builds a valid Applications-container document body for name
+// with a given app_state, so the re-run can assert an in-place field update.
+func rawDocWithState(name, state string) []byte {
+	return []byte(`{"planitName":"` + name + `","authorityCode":"100","areaId":100,` +
+		`"uid":"u-` + name + `","areaName":"Testshire","address":"1 Test Street",` +
+		`"description":"d","appState":"` + state + `",` +
+		`"location":{"type":"Point","coordinates":[-0.1278,51.5074]},` +
+		`"lastDifferent":"2026-06-26T12:00:00+00:00"}`)
+}
+
+// TestBackfill_IdempotentReRun proves the ON CONFLICT (authority_code,
+// planit_name) DO UPDATE path against a real PostGIS: backfilling the same record
+// twice leaves exactly one row, and the second run updates fields in place.
+//
+// A test that calls pgtest.New must NOT call t.Parallel (it holds a session-level
+// advisory lock released in t.Cleanup).
+func TestBackfill_IdempotentReRun(t *testing.T) {
+	ctx := context.Background()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "applications")
+
+	store := applications.NewPostgresStore(pool)
+
+	first := &fakePager{pages: [][][]byte{{rawDocWithState("24/0001", "Pending")}}}
+	s1, err := backfill(ctx, first, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("first backfill: %v", err)
+	}
+	if s1.read != 1 || s1.upserted != 1 || s1.errors != 0 {
+		t.Fatalf("first summary: got %+v, want read=1 upserted=1 errors=0", s1)
+	}
+	assertRowCount(t, pool, 1)
+
+	second := &fakePager{pages: [][][]byte{{rawDocWithState("24/0001", "Permitted")}}}
+	s2, err := backfill(ctx, second, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("second backfill: %v", err)
+	}
+	if s2.upserted != 1 {
+		t.Fatalf("second summary: got %+v, want upserted=1", s2)
+	}
+
+	assertRowCount(t, pool, 1)
+
+	got, ok, err := store.GetByAuthorityAndName(ctx, "100", "24/0001")
+	if err != nil || !ok {
+		t.Fatalf("read back 24/0001: ok=%v err=%v", ok, err)
+	}
+	if got.AppState == nil || *got.AppState != "Permitted" {
+		t.Errorf("app_state after re-run: got %v, want Permitted", got.AppState)
+	}
+	if got.Longitude == nil || got.Latitude == nil {
+		t.Errorf("coordinates lost on round trip: lon=%v lat=%v", got.Longitude, got.Latitude)
+	}
+}
+
+func assertRowCount(t *testing.T, pool *pgxpool.Pool, want int) {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(), "SELECT count(*) FROM applications").Scan(&n); err != nil {
+		t.Fatalf("count applications: %v", err)
+	}
+	if n != want {
+		t.Fatalf("row count: got %d, want %d", n, want)
+	}
+}

--- a/api-go/cmd/pgbackfill/main_test.go
+++ b/api-go/cmd/pgbackfill/main_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+// discardLogger is a no-op logger so tests stay quiet.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// rawDoc builds a minimal valid Applications-container document body for name,
+// with a London point so the decode produces coordinates.
+func rawDoc(name string) []byte {
+	return []byte(`{"planitName":"` + name + `","authorityCode":"100","areaId":100,` +
+		`"uid":"u-` + name + `","areaName":"Testshire","address":"1 Test Street",` +
+		`"description":"d","location":{"type":"Point","coordinates":[-0.1278,51.5074]},` +
+		`"lastDifferent":"2026-06-26T12:00:00+00:00"}`)
+}
+
+// fakePager yields successive pages of raw document bodies, or a fixed error.
+type fakePager struct {
+	pages [][][]byte
+	idx   int
+	err   error
+}
+
+func (p *fakePager) More() bool { return p.idx < len(p.pages) }
+
+func (p *fakePager) NextPage(_ context.Context) ([][]byte, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	page := p.pages[p.idx]
+	p.idx++
+	return page, nil
+}
+
+// fakeUpserter records every upserted application and can fail by app name.
+type fakeUpserter struct {
+	upserted []applications.PlanningApplication
+	failOn   map[string]error
+}
+
+func (u *fakeUpserter) Upsert(_ context.Context, a applications.PlanningApplication) error {
+	if err := u.failOn[a.Name]; err != nil {
+		return err
+	}
+	u.upserted = append(u.upserted, a)
+	return nil
+}
+
+func TestBackfill_UpsertsAllRecordsAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakePager{pages: [][][]byte{
+		{rawDoc("a"), rawDoc("b")},
+		{rawDoc("c")},
+	}}
+	store := &fakeUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 3 || got.errors != 0 {
+		t.Errorf("summary: got %+v, want read=3 upserted=3 errors=0", got)
+	}
+	if len(store.upserted) != 3 {
+		t.Errorf("store: upserted %d records, want 3", len(store.upserted))
+	}
+}
+
+func TestBackfill_ContinuesPastDecodeError(t *testing.T) {
+	t.Parallel()
+	pager := &fakePager{pages: [][][]byte{
+		{rawDoc("a"), []byte("not json"), rawDoc("b")},
+	}}
+	store := &fakeUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestBackfill_ContinuesPastUpsertError(t *testing.T) {
+	t.Parallel()
+	pager := &fakePager{pages: [][][]byte{
+		{rawDoc("a"), rawDoc("b"), rawDoc("c")},
+	}}
+	store := &fakeUpserter{failOn: map[string]error{"b": errors.New("boom")}}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestBackfill_RespectsLimitAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakePager{pages: [][][]byte{
+		{rawDoc("a")},
+		{rawDoc("b")},
+		{rawDoc("c")},
+	}}
+	store := &fakeUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{limit: 2}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 2 || got.upserted != 2 {
+		t.Errorf("summary: got %+v, want read=2 upserted=2", got)
+	}
+	if pager.idx > 2 {
+		t.Errorf("pager consumed %d pages, want it to stop at the limit (<=2)", pager.idx)
+	}
+}
+
+func TestBackfill_PagerErrorReturnsError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("cosmos read failed")
+	pager := &fakePager{pages: [][][]byte{{rawDoc("a")}}, err: sentinel}
+	store := &fakeUpserter{}
+
+	_, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("backfill: got err %v, want wrapped %v", err, sentinel)
+	}
+}

--- a/api-go/cmd/pgbackfill/main_test.go
+++ b/api-go/cmd/pgbackfill/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"io"
 	"log/slog"
 	"testing"
 
@@ -12,7 +11,7 @@ import (
 
 // discardLogger is a no-op logger so tests stay quiet.
 func discardLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+	return slog.New(slog.DiscardHandler)
 }
 
 // rawDoc builds a minimal valid Applications-container document body for name,

--- a/api-go/internal/applications/decode.go
+++ b/api-go/internal/applications/decode.go
@@ -1,0 +1,27 @@
+package applications
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DecodeDocument hydrates a stored Applications-container document body into a
+// domain PlanningApplication, reusing the exact field and GeoJSON-point mapping
+// the Cosmos read path uses (applicationDocument.toDomain). It exists so the
+// Cosmos -> Postgres backfill (cmd/pgbackfill) shares one transform with the
+// store rather than reinventing the mapping, which keeps the two from silently
+// diverging.
+//
+// A document with an absent or malformed location (fewer than two coordinates)
+// decodes to nil Longitude/Latitude — it is NOT rejected. That mirrors the
+// store's both-or-nothing coordinate rule (newGeoPoint / coordsToLatLng) and
+// lets the backfill carry coordinate-less planning records faithfully; the
+// Postgres Upsert then stores a NULL location for them. An explicit [0,0] point
+// is a valid coordinate and is preserved, not treated as missing.
+func DecodeDocument(raw []byte) (PlanningApplication, error) {
+	var doc applicationDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return PlanningApplication{}, fmt.Errorf("decode application document: %w", err)
+	}
+	return doc.toDomain(), nil
+}

--- a/api-go/internal/applications/decode_test.go
+++ b/api-go/internal/applications/decode_test.go
@@ -1,0 +1,110 @@
+package applications
+
+import (
+	"testing"
+	"time"
+)
+
+// TestDecodeDocument covers the raw-document -> domain transform the backfill
+// shares with the Cosmos read path: a valid GeoJSON point, an absent point, a
+// malformed point, an explicit zero point, and invalid JSON.
+func TestDecodeDocument(t *testing.T) {
+	t.Parallel()
+
+	const fullDoc = `{
+		"id": "24/0001",
+		"authorityCode": "100",
+		"planitName": "24/0001",
+		"uid": "raw-uid-1",
+		"areaName": "Testshire",
+		"areaId": 100,
+		"address": "1 Test Street",
+		"postcode": "TE1 1ST",
+		"description": "Single storey rear extension",
+		"appType": "Full",
+		"appState": "Permitted",
+		"appSize": "Small",
+		"startDate": "2026-01-02",
+		"decidedDate": "2026-03-04",
+		"consultedDate": "2026-02-03",
+		"location": {"type": "Point", "coordinates": [-0.1278, 51.5074]},
+		"url": "https://planit.example/24-0001",
+		"link": "https://council.example/24-0001",
+		"lastDifferent": "2026-06-26T12:00:00+00:00"
+	}`
+
+	t.Run("valid point maps all fields and unpacks coordinates", func(t *testing.T) {
+		t.Parallel()
+		got, err := DecodeDocument([]byte(fullDoc))
+		if err != nil {
+			t.Fatalf("DecodeDocument: %v", err)
+		}
+		if got.Name != "24/0001" || got.AreaID != 100 || got.UID != "raw-uid-1" {
+			t.Errorf("identity fields: got %+v", got)
+		}
+		if got.Longitude == nil || got.Latitude == nil {
+			t.Fatalf("coordinates: got lon=%v lat=%v, want both set", got.Longitude, got.Latitude)
+		}
+		if *got.Longitude != -0.1278 || *got.Latitude != 51.5074 {
+			t.Errorf("coordinates: got lon=%v lat=%v", *got.Longitude, *got.Latitude)
+		}
+		if got.AppState == nil || *got.AppState != "Permitted" {
+			t.Errorf("appState: got %v", got.AppState)
+		}
+		if got.StartDate == nil || !got.StartDate.Equal(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)) {
+			t.Errorf("startDate: got %v", got.StartDate)
+		}
+		if !got.LastDifferent.Equal(time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)) {
+			t.Errorf("lastDifferent: got %v", got.LastDifferent)
+		}
+	})
+
+	t.Run("absent location yields nil coordinates without error", func(t *testing.T) {
+		t.Parallel()
+		const noLoc = `{"planitName":"24/0002","authorityCode":"100","areaId":100,"uid":"u2","areaName":"Testshire","address":"a","description":"d","lastDifferent":"2026-06-26T12:00:00+00:00"}`
+		got, err := DecodeDocument([]byte(noLoc))
+		if err != nil {
+			t.Fatalf("DecodeDocument: %v", err)
+		}
+		if got.Longitude != nil || got.Latitude != nil {
+			t.Errorf("coordinates: got lon=%v lat=%v, want nil/nil", got.Longitude, got.Latitude)
+		}
+		if got.Name != "24/0002" {
+			t.Errorf("name: got %q", got.Name)
+		}
+	})
+
+	t.Run("malformed point with one coordinate yields nil coordinates", func(t *testing.T) {
+		t.Parallel()
+		const oneCoord = `{"planitName":"24/0003","authorityCode":"100","areaId":100,"uid":"u3","areaName":"Testshire","address":"a","description":"d","location":{"type":"Point","coordinates":[-0.1278]},"lastDifferent":"2026-06-26T12:00:00+00:00"}`
+		got, err := DecodeDocument([]byte(oneCoord))
+		if err != nil {
+			t.Fatalf("DecodeDocument: %v", err)
+		}
+		if got.Longitude != nil || got.Latitude != nil {
+			t.Errorf("coordinates: got lon=%v lat=%v, want nil/nil", got.Longitude, got.Latitude)
+		}
+	})
+
+	t.Run("explicit zero point is preserved not treated as missing", func(t *testing.T) {
+		t.Parallel()
+		const zeroPoint = `{"planitName":"24/0004","authorityCode":"100","areaId":100,"uid":"u4","areaName":"Testshire","address":"a","description":"d","location":{"type":"Point","coordinates":[0,0]},"lastDifferent":"2026-06-26T12:00:00+00:00"}`
+		got, err := DecodeDocument([]byte(zeroPoint))
+		if err != nil {
+			t.Fatalf("DecodeDocument: %v", err)
+		}
+		if got.Longitude == nil || got.Latitude == nil {
+			t.Fatalf("coordinates: got lon=%v lat=%v, want both set to zero", got.Longitude, got.Latitude)
+		}
+		if *got.Longitude != 0 || *got.Latitude != 0 {
+			t.Errorf("coordinates: got lon=%v lat=%v, want 0/0", *got.Longitude, *got.Latitude)
+		}
+	})
+
+	t.Run("invalid json is an error", func(t *testing.T) {
+		t.Parallel()
+		if _, err := DecodeDocument([]byte("not json")); err == nil {
+			t.Fatal("DecodeDocument: want error for invalid json, got nil")
+		}
+	})
+}


### PR DESCRIPTION
Adds `api-go/cmd/pgbackfill` — an idempotent, batched, re-runnable tool that copies prod Cosmos `Applications` (public planning data, ~638k) into `town_crier_dev` Postgres. Reads prod Cosmos by account key; writes dev Postgres as the Entra admin (the MI role is Azure-internal only). Transform reuses the Cosmos document mapping via a new exported `applications.DecodeDocument` (no remapping). Idempotent via `ON CONFLICT (authority_code, planit_name) DO UPDATE`; a record with absent/malformed geometry is upserted with NULL location (not skipped), matching the store's both-or-nothing rule.

WatchZones / any PII are explicitly NOT backfilled.

Issue #657 Slice 3, epic #645. Bead tc-7voq.

**Already running against dev** by the orchestrator (behind an atomic firewall rule) to populate dev PG. Tests: fakes-only loop tests + a `//go:build integration` ON CONFLICT idempotency proof (pgtest); `go build`/`go test -race` (1176)/`go vet`/`gofmt`/`golangci-lint` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WMnsU4PvAP3A7sWo2qsp7h