### PR TITLE
feat(worker): flag-select Apps+WatchZones Postgres stores in cmd/worker (tc-hpd2.1)

### DIFF
--- a/api-go/cmd/worker/backend.go
+++ b/api-go/cmd/worker/backend.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// storeBackend selects which datastore backs the Applications and WatchZones
+// stores the worker reads and writes — the poll Upsert + notify
+// FindZonesContaining, the digest watch-zone read, and the dormant erasure
+// cascade. The other stores are always Cosmos; only these two move to Postgres +
+// PostGIS in the hybrid migration phase (memo 0010, epic #645, issue #664 Phase
+// B). This duplicates cmd/api/backend.go on purpose: the two package-main binaries
+// each own their wiring (as buildPushSender / buildEmailSender already do), so the
+// worker mirrors the API rather than sharing a package.
+type storeBackend int
+
+const (
+	// backendCosmos is the default for every value of APPS_ZONES_BACKEND other
+	// than the exact string "postgres" — including unset and "cosmos" — so prod
+	// (flag unset) is never silently flipped off Cosmos.
+	backendCosmos storeBackend = iota
+	// backendPostgres serves Applications + WatchZones from Postgres + PostGIS.
+	// It is set on the dev container only.
+	backendPostgres
+)
+
+// appsZonesBackendPostgres is the only APPS_ZONES_BACKEND value that selects
+// Postgres. The flag is dedicated and explicit — never inferred from
+// POSTGRES_AUTH — so a future prod POSTGRES_AUTH can never flip prod's stores.
+const appsZonesBackendPostgres = "postgres"
+
+// resolveBackend maps the APPS_ZONES_BACKEND flag to a storeBackend. Only the
+// exact value "postgres" (whitespace-trimmed) selects Postgres; every other
+// value, including "" and "cosmos", keeps Cosmos.
+func resolveBackend(flag string) storeBackend {
+	if strings.TrimSpace(flag) == appsZonesBackendPostgres {
+		return backendPostgres
+	}
+	return backendCosmos
+}
+
+// chooseAppStore returns the Applications store for the selected backend as a
+// genuine consumer-side interface. When the chosen backend has no backing store
+// configured it returns a true nil interface — never a typed-nil pointer boxed in
+// a non-nil interface — so the worker's nil-guard discipline (a missing store
+// leaves the mode unwired) holds.
+func chooseAppStore(backend storeBackend, pg *applications.PostgresStore, cosmos *applications.CosmosStore) applications.Store {
+	if backend == backendPostgres {
+		if pg == nil {
+			return nil
+		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseZoneStore mirrors chooseAppStore for the WatchZones store.
+func chooseZoneStore(backend storeBackend, pg *watchzones.PostgresStore, cosmos *watchzones.CosmosStore) watchzones.Store {
+	if backend == backendPostgres {
+		if pg == nil {
+			return nil
+		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}

--- a/api-go/cmd/worker/backend_test.go
+++ b/api-go/cmd/worker/backend_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// TestResolveBackend pins the APPS_ZONES_BACKEND contract for the worker, exactly
+// as cmd/api does: only the exact value "postgres" (whitespace-trimmed) selects
+// Postgres; every other value, including unset and "cosmos", keeps Cosmos so prod
+// (flag unset) is never silently flipped, and a non-canonical casing is treated
+// as "any other value".
+func TestResolveBackend(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		flag string
+		want storeBackend
+	}{
+		{"exact postgres selects postgres", "postgres", backendPostgres},
+		{"surrounding whitespace is trimmed", "  postgres\t", backendPostgres},
+		{"unset defaults to cosmos", "", backendCosmos},
+		{"explicit cosmos stays cosmos", "cosmos", backendCosmos},
+		{"uppercase is not the canonical value", "Postgres", backendCosmos},
+		{"junk defaults to cosmos", "nonsense", backendCosmos},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveBackend(tc.flag); got != tc.want {
+				t.Fatalf("resolveBackend(%q) = %v, want %v", tc.flag, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestChooseAppStore covers both the backend selection and the typed-nil trap:
+// when the chosen backend has no backing store the chooser must return a GENUINE
+// nil interface (not a typed-nil pointer boxed in a non-nil interface), so the
+// worker's nil-guard discipline (a missing store leaves the mode unwired) holds.
+// The selected interface is what the poll handler consumes for the Applications
+// Upsert write.
+func TestChooseAppStore(t *testing.T) {
+	t.Parallel()
+
+	cosmos := applications.NewCosmosStore(newFakeItems())
+	pg := applications.NewPostgresStore(nil) // querier is never touched in these tests
+
+	t.Run("postgres backend returns the postgres store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseAppStore(backendPostgres, pg, cosmos)
+		if _, ok := got.(*applications.PostgresStore); !ok {
+			t.Fatalf("got %T, want *applications.PostgresStore", got)
+		}
+	})
+
+	t.Run("cosmos backend returns the cosmos store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseAppStore(backendCosmos, pg, cosmos)
+		if _, ok := got.(*applications.CosmosStore); !ok {
+			t.Fatalf("got %T, want *applications.CosmosStore", got)
+		}
+	})
+
+	t.Run("postgres backend with no pool yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseAppStore(backendPostgres, nil, cosmos); got != nil {
+			t.Fatalf("got %T (non-nil interface), want a genuine nil so the mode stays unwired", got)
+		}
+	})
+
+	t.Run("cosmos backend with no container yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseAppStore(backendCosmos, pg, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want a genuine nil so the mode stays unwired", got)
+		}
+	})
+}
+
+// TestChooseZoneStore mirrors TestChooseAppStore for the watch-zone store — the
+// store the worker threads into the notify fan-out (FindZonesContaining), the
+// poll authority provider, the digest reader, and the dormant erasure cascade.
+func TestChooseZoneStore(t *testing.T) {
+	t.Parallel()
+
+	cosmos := watchzones.NewCosmosStore(newFakeItems())
+	pg := watchzones.NewPostgresStore(nil)
+
+	t.Run("postgres backend returns the postgres store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseZoneStore(backendPostgres, pg, cosmos)
+		if _, ok := got.(*watchzones.PostgresStore); !ok {
+			t.Fatalf("got %T, want *watchzones.PostgresStore", got)
+		}
+	})
+
+	t.Run("cosmos backend returns the cosmos store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseZoneStore(backendCosmos, pg, cosmos)
+		if _, ok := got.(*watchzones.CosmosStore); !ok {
+			t.Fatalf("got %T, want *watchzones.CosmosStore", got)
+		}
+	})
+
+	t.Run("postgres backend with no pool yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseZoneStore(backendPostgres, nil, cosmos); got != nil {
+			t.Fatalf("got %T (non-nil interface), want a genuine nil so the mode stays unwired", got)
+		}
+	})
+
+	t.Run("cosmos backend with no container yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseZoneStore(backendCosmos, pg, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want a genuine nil so the mode stays unwired", got)
+		}
+	})
+}

--- a/api-go/cmd/worker/fakes_test.go
+++ b/api-go/cmd/worker/fakes_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"sync"
+
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// fakeCosmosItems is an in-memory store backend that satisfies both
+// applications.CosmosItems and watchzones.CosmosItems, so the chooser tests can
+// build a real *CosmosStore with no Cosmos dependency. The chooser tests only
+// construct the stores (never call a method), so every method returns the empty
+// path.
+type fakeCosmosItems struct{}
+
+func newFakeItems() *fakeCosmosItems { return &fakeCosmosItems{} }
+
+func (f *fakeCosmosItems) ReadItem(_ context.Context, _, _ string) ([]byte, error) {
+	return nil, nil
+}
+
+func (f *fakeCosmosItems) UpsertItem(_ context.Context, _ string, _ []byte) error {
+	return nil
+}
+
+func (f *fakeCosmosItems) DeleteItem(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (f *fakeCosmosItems) QueryItems(_ context.Context, _, _ string, _ map[string]any) ([][]byte, error) {
+	return nil, nil
+}
+
+func (f *fakeCosmosItems) QueryItemsLongRead(_ context.Context, _, _ string, _ map[string]any) ([][]byte, error) {
+	return nil, nil
+}
+
+func (f *fakeCosmosItems) QueryItemsCrossPartition(_ context.Context, _ string, _ map[string]any) ([][]byte, error) {
+	return nil, nil
+}
+
+func (f *fakeCosmosItems) QueryPageCrossPartition(_ context.Context, _ string, _ map[string]any, _ int, _ string) ([][]byte, string, error) {
+	return nil, "", nil
+}
+
+// spyZoneStore is a hand-written full watchzones.Store double used by the notify
+// wiring tests. It records the FindZonesContaining coordinates so a test can
+// prove the notify fan-out reaches the flag-selected store through the
+// watchzones.Store interface (the riskiest poll path — issue #664 Phase B). Every
+// other method returns the empty path; the notify tests only drive
+// FindZonesContaining.
+type spyZoneStore struct {
+	mu              sync.Mutex
+	findCalls       int
+	lastFindLat     float64
+	lastFindLng     float64
+	findReturnZones []watchzones.WatchZone
+}
+
+// Compile-time proof the spy is a genuine watchzones.Store — the exact interface
+// chooseZoneStore returns and the worker wiring threads through the notify,
+// digest and dormant paths.
+var _ watchzones.Store = (*spyZoneStore)(nil)
+
+func newSpyZoneStore() *spyZoneStore { return &spyZoneStore{} }
+
+func (s *spyZoneStore) FindZonesContaining(_ context.Context, latitude, longitude float64) ([]watchzones.WatchZone, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.findCalls++
+	s.lastFindLat = latitude
+	s.lastFindLng = longitude
+	return s.findReturnZones, nil
+}
+
+func (s *spyZoneStore) GetByUserID(_ context.Context, _ string) ([]watchzones.WatchZone, error) {
+	return nil, nil
+}
+
+func (s *spyZoneStore) Get(_ context.Context, _, _ string) (watchzones.WatchZone, error) {
+	return watchzones.WatchZone{}, nil
+}
+
+func (s *spyZoneStore) Save(_ context.Context, _ watchzones.WatchZone) error { return nil }
+
+func (s *spyZoneStore) Delete(_ context.Context, _, _ string) error { return nil }
+
+func (s *spyZoneStore) DeleteAllByUserID(_ context.Context, _ string) error { return nil }
+
+func (s *spyZoneStore) DistinctAuthorityIDs(_ context.Context) ([]int, error) { return nil, nil }

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/planit"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
 	"github.com/AmyDe/town-crier/api-go/internal/polling"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
@@ -97,6 +98,32 @@ func run() int {
 	// emit their towncrier.* metrics (tc-21np).
 	registry := metrics.New(otel.Meter(metrics.MeterName))
 
+	// APPS_ZONES_BACKEND gates the Applications + WatchZones stores onto Postgres
+	// (dev only; prod and every other store stay Cosmos — issue #657 / #664 Phase
+	// B), mirroring cmd/api. When it selects Postgres we build ONE pool for the
+	// whole process — MI-token auth from the container's POSTGRES_*/AZURE_CLIENT_ID
+	// via NewPoolFromEnv — and reuse it across the poll, digest and dormant builders
+	// below. The worker explicitly wants Postgres here, so a pool that can't be built
+	// is fatal rather than a silent Cosmos fallback. The pool closes on shutdown.
+	// When the flag is unset (prod, local) these stay nil and every existing Cosmos
+	// construction is byte-for-byte unchanged.
+	appsZonesBackend := resolveBackend(cfg.AppsZonesBackend)
+	var (
+		pgAppStore       *applications.PostgresStore
+		pgWatchZoneStore *watchzones.PostgresStore
+	)
+	if appsZonesBackend == backendPostgres {
+		pool, perr := postgres.NewPoolFromEnv(context.Background())
+		if perr != nil {
+			logger.Error("apps/zones backend=postgres: build postgres pool", "error", perr)
+			return 1
+		}
+		defer pool.Close()
+		pgAppStore = applications.NewPostgresStore(pool)
+		pgWatchZoneStore = watchzones.NewPostgresStore(pool)
+		logger.Info("apps/zones backend selected", "backend", "postgres")
+	}
+
 	// The Service Bus client (and thus the bootstrapper and the poll-sb
 	// orchestrator) is built only when the job carries Service Bus config. Jobs
 	// that don't touch Service Bus (digest, hourly-digest, dormant-cleanup) leave
@@ -132,7 +159,7 @@ func run() int {
 	// the "no Cosmos" case leaves it nil — assigning a typed-nil *digest.Handler
 	// would make the interface non-nil and defeat worker.Run's nil guard.
 	var digester worker.DigestRunner
-	handler, err := buildDigester(cfg, registry, logger)
+	handler, err := buildDigester(cfg, registry, appsZonesBackend, pgWatchZoneStore, logger)
 	if err != nil {
 		logger.Error("build digest handler", "error", err)
 		return 1
@@ -147,7 +174,7 @@ func run() int {
 	// worker.Run's nil guard). The Auth0 deleter falls back to a no-op when the M2M
 	// credentials are absent, so a Cosmos-only job still boots cleanly.
 	var dormantRunner worker.DormantRunner
-	dormantHandler, err := buildDormant(cfg, registry, logger)
+	dormantHandler, err := buildDormant(cfg, registry, appsZonesBackend, pgWatchZoneStore, logger)
 	if err != nil {
 		logger.Error("build dormant cleanup handler", "error", err)
 		return 1
@@ -162,7 +189,7 @@ func run() int {
 	// run rather than crashing. Declared as the interface so the "unconfigured"
 	// case stays a nil interface value (a typed-nil adapter would defeat the guard).
 	var poller worker.PollOrchestrator
-	pollAdapter, err := buildPollOrchestrator(cfg, sbClient, registry, logger)
+	pollAdapter, err := buildPollOrchestrator(cfg, sbClient, registry, appsZonesBackend, pgAppStore, pgWatchZoneStore, logger)
 	if err != nil {
 		logger.Error("build poll-sb orchestrator", "error", err)
 		return 1
@@ -197,7 +224,7 @@ func run() int {
 // (nil, nil) when Service Bus or Cosmos config is absent, so poll-sb refuses to
 // run rather than nil-panicking. The cycle budget (replicaTimeout − grace) and
 // the handler/lease budgets all come from config.
-func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, registry *metrics.Registry, logger *slog.Logger) (*pollOrchestratorAdapter, error) {
+func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, registry *metrics.Registry, backend storeBackend, pgAppStore *applications.PostgresStore, pgWatchZoneStore *watchzones.PostgresStore, logger *slog.Logger) (*pollOrchestratorAdapter, error) {
 	if sbClient == nil || cfg.CosmosEndpoint == "" {
 		return nil, nil //nolint:nilnil // absent SB/Cosmos config is a valid "no poller" state, not an error
 	}
@@ -241,8 +268,12 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 
 	stateStore := polling.NewPollStateStore(stateContainer)
 	leaseStore := polling.NewLeaseStore(leaseItemsAdapter{leasesContainer}, time.Now)
-	appStore := applications.NewCosmosStore(appsContainer)
-	zoneStore := watchzones.NewCosmosStore(zonesContainer)
+	// appStore and zoneStore are the flag-selected consumer-side interfaces the
+	// poll handler (Upsert + change dedup) and the watch-zone notify fan-out
+	// (FindZonesContaining) consume — Postgres when APPS_ZONES_BACKEND=postgres,
+	// Cosmos otherwise. The poll-state and lease stores always stay Cosmos.
+	appStore := chooseAppStore(backend, pgAppStore, applications.NewCosmosStore(appsContainer))
+	zoneStore := chooseZoneStore(backend, pgWatchZoneStore, watchzones.NewCosmosStore(zonesContainer))
 
 	cycleSelector := polling.NewMinuteCycleSelector(time.Now)
 	authorityProvider := polling.NewCycleAlternatingProvider(
@@ -311,13 +342,16 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 // wirePollFanOut builds the poll-path notification fan-out collaborators — the
 // decision-event dispatcher and the watch-zone enqueuer — and attaches them to
 // the ingestion handler. They share the WatchZones store with the poll's
-// authority provider (the same *watchzones.CosmosStore satisfies the
-// zone-containment lookup) and open their own Notifications / Users /
-// NotificationState / DeviceRegistrations / SavedApplications containers. The
-// APNs push sender is real when its credentials are present, NoOp otherwise so
-// the poll job boots even without APNs config (the record is still written, so
-// the digest pipeline keeps working).
-func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zoneStore *watchzones.CosmosStore, registry *metrics.Registry, logger *slog.Logger) error {
+// authority provider (the same watchzones.Store satisfies the zone-containment
+// lookup) and open their own Notifications / Users / NotificationState /
+// DeviceRegistrations / SavedApplications containers. zoneStore is the
+// flag-selected watchzones.Store interface — not the concrete Cosmos store — so
+// the notify FindZonesContaining hot path runs against Postgres when
+// APPS_ZONES_BACKEND=postgres (issue #664 Phase B). The APNs push sender is real
+// when its credentials are present, NoOp otherwise so the poll job boots even
+// without APNs config (the record is still written, so the digest pipeline keeps
+// working).
+func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zoneStore watchzones.Store, registry *metrics.Registry, logger *slog.Logger) error {
 	notifsContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationsContainer, logger)
 	if err != nil {
 		return err
@@ -456,7 +490,7 @@ func maxInt(a, b int) int {
 // then refuse to run rather than nil-panicking. Returning the concrete
 // *digest.Handler lets worker.Run accept it via its unexported digestRunner
 // interface (structural satisfaction).
-func buildDigester(cfg platform.Config, registry *metrics.Registry, logger *slog.Logger) (*digest.Handler, error) {
+func buildDigester(cfg platform.Config, registry *metrics.Registry, backend storeBackend, pgWatchZoneStore *watchzones.PostgresStore, logger *slog.Logger) (*digest.Handler, error) {
 	if cfg.CosmosEndpoint == "" {
 		return nil, nil //nolint:nilnil // absent Cosmos config is a valid "no digester" state, not an error
 	}
@@ -492,7 +526,9 @@ func buildDigester(cfg platform.Config, registry *metrics.Registry, logger *slog
 		point: profiles.NewCosmosStore(users),
 	}
 	notificationStore := notifications.NewDigestStore(notifs)
-	zoneStore := watchzones.NewCosmosStore(zonesContainer)
+	// zoneStore is the flag-selected watch-zone reader the weekly digest fans out
+	// over — Postgres when APPS_ZONES_BACKEND=postgres, Cosmos otherwise.
+	zoneStore := chooseZoneStore(backend, pgWatchZoneStore, watchzones.NewCosmosStore(zonesContainer))
 	stateStore := notificationstate.NewCosmosStore(stateContainer, notifs)
 	deviceStore := devicetokens.NewCosmosStore(devicesContainer)
 
@@ -536,7 +572,7 @@ func (p digestProfiles) Get(ctx context.Context, userID string) (*profiles.UserP
 // when Cosmos is unconfigured — the dormant-cleanup mode then refuses to run
 // rather than nil-panicking. Returning the concrete *dormant.Handler lets
 // worker.Run accept it via its exported DormantRunner interface.
-func buildDormant(cfg platform.Config, registry *metrics.Registry, logger *slog.Logger) (*dormant.Handler, error) {
+func buildDormant(cfg platform.Config, registry *metrics.Registry, backend storeBackend, pgWatchZoneStore *watchzones.PostgresStore, logger *slog.Logger) (*dormant.Handler, error) {
 	if cfg.CosmosEndpoint == "" {
 		return nil, nil //nolint:nilnil // absent Cosmos config is a valid "no dormant handler" state, not an error
 	}
@@ -584,8 +620,13 @@ func buildDormant(cfg platform.Config, registry *metrics.Registry, logger *slog.
 	// offer-code store anonymises the redeemer back-reference (redeemedByUserId +
 	// redeemedAt) without deleting the admin-issued code (bead tc-5jyh).
 	deleters := erasure.Deleters{
-		Notifications:       notifications.NewDeleteStore(notifs),
-		WatchZones:          watchzones.NewCosmosStore(zonesContainer),
+		Notifications: notifications.NewDeleteStore(notifs),
+		// WatchZones is the flag-selected store the dormant-account GDPR erasure
+		// cascade deletes a user's watch zones from — Postgres when
+		// APPS_ZONES_BACKEND=postgres, Cosmos otherwise — so a Postgres watch zone is
+		// never missed by erasure (issue #664 Phase B). chooseZoneStore returns a
+		// genuine watchzones.Store (DeleteAllByUserID satisfies erasure.ChildDeleter).
+		WatchZones:          chooseZoneStore(backend, pgWatchZoneStore, watchzones.NewCosmosStore(zonesContainer)),
 		SavedApplications:   savedapplications.NewCosmosStore(savedContainer),
 		DeviceRegistrations: devicetokens.NewCosmosStore(devicesContainer),
 		NotificationState:   erasure.NotificationStateChild(notificationstate.NewCosmosStore(stateContainer, notifs)),

--- a/api-go/cmd/worker/wiring_test.go
+++ b/api-go/cmd/worker/wiring_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"testing"
 	"time"
@@ -45,7 +44,7 @@ var (
 )
 
 func discardLogger() *slog.Logger {
-	return slog.New(slog.NewTextHandler(io.Discard, nil))
+	return slog.New(slog.DiscardHandler)
 }
 
 func testRegistry() *metrics.Registry {

--- a/api-go/cmd/worker/wiring_test.go
+++ b/api-go/cmd/worker/wiring_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/metrics"
+	"github.com/AmyDe/town-crier/api-go/internal/notifydispatch"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/polling"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// pollAppConsumer mirrors polling's unexported applicationStore: the exact slice
+// of applications.Store the poll handler consumes — the change-dedup read and the
+// Upsert write the poll cycle performs. The worker hands NewPollPlanItHandler the
+// flag-selected applications.Store interface, so that interface (and thus both
+// the Postgres and Cosmos backends) must satisfy this contract for the poll
+// Upsert to reach either backend.
+type pollAppConsumer interface {
+	GetByUID(ctx context.Context, uid, authorityCode string) (applications.PlanningApplication, bool, error)
+	Upsert(ctx context.Context, a applications.PlanningApplication) error
+}
+
+// notifyZoneConsumer mirrors notifydispatch's unexported zoneMatcher: the notify
+// fan-out's only watch-zone dependency, the FindZonesContaining containment
+// lookup. The worker threads the flag-selected watchzones.Store into the fan-out,
+// so the interface must satisfy this — the proof that FindZonesContaining reaches
+// whichever backend the flag selects.
+type notifyZoneConsumer interface {
+	FindZonesContaining(ctx context.Context, latitude, longitude float64) ([]watchzones.WatchZone, error)
+}
+
+// Compile-time proof the flag-selected interfaces satisfy what the worker's poll
+// Upsert and notify fan-out actually consume.
+var (
+	_ pollAppConsumer    = (applications.Store)(nil)
+	_ notifyZoneConsumer = (watchzones.Store)(nil)
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func testRegistry() *metrics.Registry {
+	return metrics.New(otel.Meter(metrics.MeterName))
+}
+
+// TestWirePollFanOut_AcceptsFlagSelectedZoneStore is the notify-path guard for
+// the riskiest wiring change (issue #664 Phase B): wirePollFanOut must take the
+// watchzones.Store interface, not the concrete *watchzones.CosmosStore, so the
+// poll fan-out's FindZonesContaining can run against the Postgres store when
+// APPS_ZONES_BACKEND=postgres. The test passes a non-Cosmos watchzones.Store (a
+// spy) — it compiles only once the parameter is the interface. An empty Config
+// leaves every other collaborator's Cosmos container nil (the constructors are
+// nil-tolerant), so the wiring runs with no Cosmos dependency.
+func TestWirePollFanOut_AcceptsFlagSelectedZoneStore(t *testing.T) {
+	t.Parallel()
+
+	handler := &polling.PollPlanItHandler{}
+	spy := newSpyZoneStore()
+
+	if err := wirePollFanOut(platform.Config{}, handler, spy, testRegistry(), discardLogger()); err != nil {
+		t.Fatalf("wirePollFanOut with a flag-selected watchzones.Store: %v", err)
+	}
+}
+
+// TestEnqueuer_FindZonesContainingFlowsThroughInterface proves the notify fan-out
+// reaches the watch-zone store solely through the watchzones.Store interface:
+// EnqueueForApplication's entry point is FindZonesContaining, so whichever backend
+// the flag selects is consumed identically. It mirrors the enqueuer wirePollFanOut
+// builds. A zero-zone result keeps the test scoped to the containment lookup — the
+// downstream collaborators are never reached.
+func TestEnqueuer_FindZonesContainingFlowsThroughInterface(t *testing.T) {
+	t.Parallel()
+
+	spy := newSpyZoneStore()
+	enqueuer := notifydispatch.NewEnqueuer(
+		nil, spy, nil, nil, nil, nil,
+		func() string { return "id" },
+		func() time.Time { return time.Unix(0, 0).UTC() },
+		discardLogger(),
+	)
+
+	lat, lng := 51.501, -0.142
+	app := applications.PlanningApplication{Latitude: &lat, Longitude: &lng}
+
+	if err := enqueuer.EnqueueForApplication(context.Background(), app); err != nil {
+		t.Fatalf("EnqueueForApplication: %v", err)
+	}
+
+	if spy.findCalls != 1 {
+		t.Fatalf("FindZonesContaining calls = %d, want 1", spy.findCalls)
+	}
+	if spy.lastFindLat != lat || spy.lastFindLng != lng {
+		t.Fatalf("FindZonesContaining coords = (%v, %v), want (%v, %v)",
+			spy.lastFindLat, spy.lastFindLng, lat, lng)
+	}
+}


### PR DESCRIPTION
Part of #664 (Phase B). Wires `cmd/worker` to serve/write the Applications + WatchZones stores from the flag-selected backend (Postgres when `APPS_ZONES_BACKEND=postgres`, Cosmos otherwise), mirroring `cmd/api`. Only the API was wired (#661); the worker was not.

- New `cmd/worker/backend.go` (mirrors `cmd/api/backend.go`: `resolveBackend`/`chooseAppStore`/`chooseZoneStore`).
- One pgx pool built via `NewPoolFromEnv` when flag=postgres (fatal on build error — no silent Cosmos fallback), reused across poll/digest/dormant.
- Poll path (Upsert + notify `FindZonesContaining` + authority provider), digest zone read, and dormant erasure cascade all flag-selected. `wirePollFanOut` now takes the `watchzones.Store` interface.
- Flag unset (prod, local) → stays nil, Cosmos construction unchanged. **Prod stays Cosmos**; this does not flip prod.

Tests: backend choosers + notify-path wiring (hand-written fakes, no Docker). `go build`/`vet`/`golangci-lint`/`gofmt` clean; `go test -race ./...` 1216 pass.