### PR TITLE
fix(api): GDPR cascade + export use flag-selected watch-zone store (tc-s8g1)

### DIFF
--- a/api-go/cmd/api/export_adapters.go
+++ b/api-go/cmd/api/export_adapters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/erasure"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
@@ -11,6 +12,24 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
+
+// gdprWatchZoneWiring binds the GDPR erasure cascade (DELETE /v1/me) and the data
+// export (GET /v1/me/data) to the SAME flag-selected watch-zone store the routes
+// use, so a Postgres-resident user's watch zones are erased and exported in both
+// Cosmos and Postgres modes — not silently missed by the always-Cosmos store
+// (bead tc-s8g1). watchzones.Store satisfies erasure.ChildDeleter directly (it
+// exposes DeleteAllByUserID), so the cascade needs no adapter; only the export
+// needs the watchZoneExportReader row mapping.
+//
+// A nil store (no backing configured) yields genuine nil wiring so the caller's
+// atomic cascade/export guards leave the GDPR paths unbuilt rather than holding a
+// nil deleter the cascade would dereference.
+func gdprWatchZoneWiring(store watchzones.Store) (erasure.ChildDeleter, profiles.WatchZoneReader) {
+	if store == nil {
+		return nil, nil
+	}
+	return store, watchZoneExportReader{store: store}
+}
 
 // The GDPR export (GET /v1/me/data) sources its child collections from the
 // per-feature stores. profiles must not import those packages (offercodes already

--- a/api-go/cmd/api/export_adapters.go
+++ b/api-go/cmd/api/export_adapters.go
@@ -22,7 +22,11 @@ import (
 // both the stores and the profiles row types.
 
 // watchZoneExportReader adapts the watch-zone store to profiles.WatchZoneReader.
-type watchZoneExportReader struct{ store *watchzones.CosmosStore }
+// It holds the consumer-side watchzones.Store interface — not the concrete Cosmos
+// store — so GET /v1/me/data exports a user's watch zones from whichever backend
+// the APPS_ZONES_BACKEND flag selects (Postgres on dev), never silently missing a
+// Postgres-resident user's zones (bead tc-s8g1).
+type watchZoneExportReader struct{ store watchzones.Store }
 
 func (r watchZoneExportReader) WatchZonesByUser(ctx context.Context, userID string) ([]profiles.ExportedWatchZone, error) {
 	zones, err := r.store.GetByUserID(ctx, userID)

--- a/api-go/cmd/api/export_adapters_test.go
+++ b/api-go/cmd/api/export_adapters_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// fakeWatchZoneStore is a hand-written watchzones.Store double. Only GetByUserID
+// carries behaviour the export adapter needs; the remaining methods satisfy the
+// interface so the fake can stand in for either backend's concrete store.
+type fakeWatchZoneStore struct {
+	zones []watchzones.WatchZone
+	err   error
+}
+
+func (f *fakeWatchZoneStore) GetByUserID(_ context.Context, _ string) ([]watchzones.WatchZone, error) {
+	return f.zones, f.err
+}
+
+func (f *fakeWatchZoneStore) Get(_ context.Context, _, _ string) (watchzones.WatchZone, error) {
+	return watchzones.WatchZone{}, nil
+}
+
+func (f *fakeWatchZoneStore) Save(_ context.Context, _ watchzones.WatchZone) error { return nil }
+
+func (f *fakeWatchZoneStore) Delete(_ context.Context, _, _ string) error { return nil }
+
+func (f *fakeWatchZoneStore) DeleteAllByUserID(_ context.Context, _ string) error { return nil }
+
+func (f *fakeWatchZoneStore) DistinctAuthorityIDs(_ context.Context) ([]int, error) { return nil, nil }
+
+func (f *fakeWatchZoneStore) FindZonesContaining(_ context.Context, _, _ float64) ([]watchzones.WatchZone, error) {
+	return nil, nil
+}
+
+// TestWatchZoneExportReader_ReadsThroughStoreInterface proves the export adapter
+// is backed by the consumer-side watchzones.Store interface, not the concrete
+// Cosmos store, so GET /v1/me/data exports a Postgres-resident user's watch zones
+// when APPS_ZONES_BACKEND=postgres (bead tc-s8g1). The fake is a plain
+// watchzones.Store, which the adapter must accept and read through.
+func TestWatchZoneExportReader_ReadsThroughStoreInterface(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	store := &fakeWatchZoneStore{zones: []watchzones.WatchZone{
+		{ID: "zone-1", UserID: "u1", Name: "Home", Latitude: 51.5, Longitude: -0.1, RadiusMetres: 500, AuthorityID: 384, CreatedAt: created},
+		{ID: "zone-2", UserID: "u1", Name: "Work", Latitude: 52.2, Longitude: -1.3, RadiusMetres: 250, AuthorityID: 471, CreatedAt: created},
+	}}
+
+	var reader profiles.WatchZoneReader = watchZoneExportReader{store: store}
+	rows, err := reader.WatchZonesByUser(context.Background(), "u1")
+	if err != nil {
+		t.Fatalf("WatchZonesByUser: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+	if rows[0].ID != "zone-1" || rows[0].Name != "Home" || rows[0].RadiusMetres != 500 || rows[0].AuthorityID != 384 {
+		t.Errorf("row[0] = %+v, want zone-1/Home/500/384", rows[0])
+	}
+	if rows[1].ID != "zone-2" || rows[1].Latitude != 52.2 || rows[1].Longitude != -1.3 {
+		t.Errorf("row[1] = %+v, want zone-2 coords 52.2/-1.3", rows[1])
+	}
+	if time.Time(rows[0].CreatedAt) != created {
+		t.Errorf("row[0].CreatedAt = %v, want %v", time.Time(rows[0].CreatedAt), created)
+	}
+}

--- a/api-go/cmd/api/gdpr_wiring_test.go
+++ b/api-go/cmd/api/gdpr_wiring_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// TestGDPRWatchZoneWiring_FollowsBackendFlag proves the GDPR erasure cascade
+// (DELETE /v1/me) and the data export (GET /v1/me/data) are both bound to the
+// SAME flag-selected watch-zone store the routes use — so when
+// APPS_ZONES_BACKEND=postgres an account deletion or export covers a
+// Postgres-resident user's watch zones, instead of silently missing them on the
+// always-Cosmos store (bead tc-s8g1). With the flag unset both stay on Cosmos.
+func TestGDPRWatchZoneWiring_FollowsBackendFlag(t *testing.T) {
+	t.Parallel()
+
+	cosmos := watchzones.NewCosmosStore(newFakeItems())
+	pg := watchzones.NewPostgresStore(nil) // querier never touched by these assertions
+
+	t.Run("postgres backend binds both GDPR paths to the Postgres store", func(t *testing.T) {
+		t.Parallel()
+		deleter, reader := gdprWatchZoneWiring(chooseZoneStore(backendPostgres, pg, cosmos))
+
+		if _, ok := deleter.(*watchzones.PostgresStore); !ok {
+			t.Errorf("cascade deleter = %T, want *watchzones.PostgresStore", deleter)
+		}
+		adapter, ok := reader.(watchZoneExportReader)
+		if !ok {
+			t.Fatalf("export reader = %T, want watchZoneExportReader", reader)
+		}
+		if _, ok := adapter.store.(*watchzones.PostgresStore); !ok {
+			t.Errorf("export reader store = %T, want *watchzones.PostgresStore", adapter.store)
+		}
+	})
+
+	t.Run("cosmos backend binds both GDPR paths to the Cosmos store", func(t *testing.T) {
+		t.Parallel()
+		deleter, reader := gdprWatchZoneWiring(chooseZoneStore(backendCosmos, pg, cosmos))
+
+		if _, ok := deleter.(*watchzones.CosmosStore); !ok {
+			t.Errorf("cascade deleter = %T, want *watchzones.CosmosStore", deleter)
+		}
+		adapter, ok := reader.(watchZoneExportReader)
+		if !ok {
+			t.Fatalf("export reader = %T, want watchZoneExportReader", reader)
+		}
+		if _, ok := adapter.store.(*watchzones.CosmosStore); !ok {
+			t.Errorf("export reader store = %T, want *watchzones.CosmosStore", adapter.store)
+		}
+	})
+
+	t.Run("nil store yields genuine nil wiring so the cascade/export guards leave the GDPR paths unbuilt", func(t *testing.T) {
+		t.Parallel()
+		deleter, reader := gdprWatchZoneWiring(chooseZoneStore(backendPostgres, nil, cosmos))
+
+		if deleter != nil {
+			t.Errorf("cascade deleter = %T, want a genuine nil so the cascade is not built with a nil deleter", deleter)
+		}
+		if reader != nil {
+			t.Errorf("export reader = %T, want a genuine nil so the export is not built with a nil reader", reader)
+		}
+	})
+}

--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -207,11 +207,18 @@ func main() {
 	// the dormant-cleanup worker (bead tc-gf0g). The offer-code anonymiser scrubs the
 	// redeemer back-reference (redeemedByUserId + redeemedAt) without deleting the
 	// admin-issued code (bead tc-5jyh).
+	// cascadeWatchZoneDeleter and exportWatchZoneReader bind both GDPR paths to
+	// the flag-selected watch-zone store (watchZoneStore) — Postgres on dev, Cosmos
+	// elsewhere — so account erasure and the data export cover a Postgres-resident
+	// user's zones, not just Cosmos ones (bead tc-s8g1). The admin location/bbox
+	// backfill still uses cosmosWatchZoneStore directly (a Cosmos-only migrator).
+	cascadeWatchZoneDeleter, exportWatchZoneReader := gdprWatchZoneWiring(watchZoneStore)
+
 	var cascade profiles.CascadeDeleters
-	if notificationsContainer != nil && watchZones != nil && savedContainer != nil && devices != nil && stateContainer != nil && offerStore != nil {
+	if notificationsContainer != nil && watchZoneStore != nil && savedContainer != nil && devices != nil && stateContainer != nil && offerStore != nil {
 		cascade = profiles.CascadeDeleters{
 			Notifications:       notifications.NewDeleteStore(notificationsContainer),
-			WatchZones:          cosmosWatchZoneStore,
+			WatchZones:          cascadeWatchZoneDeleter,
 			SavedApplications:   savedStore,
 			DeviceRegistrations: deviceStore,
 			NotificationState:   erasure.NotificationStateChild(stateStore),
@@ -231,9 +238,9 @@ func main() {
 	// notifications reader uses the digest store's full-document AllByUser read so
 	// every exported field is carried, not the latest-unread projection.
 	var exportReaders profiles.ExportReaders
-	if notificationsContainer != nil && watchZones != nil && savedContainer != nil && devices != nil && offerStore != nil {
+	if notificationsContainer != nil && watchZoneStore != nil && savedContainer != nil && devices != nil && offerStore != nil {
 		exportReaders = profiles.ExportReaders{
-			WatchZones:           watchZoneExportReader{store: cosmosWatchZoneStore},
+			WatchZones:           exportWatchZoneReader,
 			Notifications:        notificationExportReader{store: notifications.NewDigestStore(notificationsContainer)},
 			SavedApplications:    savedApplicationExportReader{store: savedStore},
 			DeviceRegistrations:  deviceRegistrationExportReader{store: deviceStore},


### PR DESCRIPTION
Part of #664 (Phase B). The GDPR erasure cascade (`DELETE /v1/me`) and data export (`GET /v1/me/data`) were hard-bound to the always-Cosmos watch-zone store, so under `APPS_ZONES_BACKEND=postgres` an account deletion/export would silently miss Postgres-resident watch zones. Hard compliance gate before prod cutover.

- `watchZoneExportReader.store` retyped to the `watchzones.Store` interface.
- `cascade.WatchZones` + `exportReaders.WatchZones` now fed by the flag-selected store; guards switched to `watchZoneStore != nil` (load-bearing — `erasure.Cascade` dereferences `DeleteAllByUserID`). `cosmosWatchZoneStore` retained for the Cosmos-only admin location/bbox backfill.

Tests: export adapter over a fake `watchzones.Store`; wiring follows the backend flag (postgres→PostgresStore, cosmos→CosmosStore, nil→genuine-nil). `go build`/`vet`/`golangci-lint`/`gofmt` clean; `go test -race ./...` 1202 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GDPR watch-zone data export and erasure now use the same backend-selected data source, matching the backend flag instead of always relying on one store.
  * Export and erasure paths now safely skip wiring when no watch-zone store is available, preventing broken GDPR flows.
* **Tests**
  * Added coverage for backend-specific watch-zone wiring and export reading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->