### PR TITLE
feat(api): Postgres port for AppleNotifications idempotency store (tc-hpd2.7)

### DIFF
--- a/api-go/cmd/pgbackfill-applenotifs/main.go
+++ b/api-go/cmd/pgbackfill-applenotifs/main.go
@@ -1,0 +1,270 @@
+// Command pgbackfill-applenotifs copies processed App Store Server Notification
+// UUIDs from the prod Cosmos AppleNotifications container into the Postgres
+// apple_notifications table, for the Cosmos -> Postgres migration (docs/memo/0010,
+// epic #645). It is the sibling of cmd/pgbackfill (Applications) and
+// cmd/pgbackfill-zones (WatchZones).
+//
+// The tool is idempotent and re-runnable: each UUID is written with INSERT ...
+// ON CONFLICT (notification_uuid) DO UPDATE, so a re-run reconciles rather than
+// duplicates. Historical processedAt timestamps from Cosmos are preserved.
+//
+// Source (read): prod Cosmos, authenticated with the account KEY (read from
+// the COSMOS_KEY environment variable, never a flag, so it stays out of shell
+// history). The tool enumerates the whole AppleNotifications container with a
+// cross-partition SELECT query, paged via a continuation token.
+//
+// Target (write): Postgres, authenticated passwordless as the Entra ADMIN
+// (DefaultAzureCredential). Pass -pg-db town_crier_prod for the prod copy; the
+// default is the dev database, the safer failure mode if the flag is forgotten.
+//
+// A document that fails to decode or a single failed UpsertProcessed is counted
+// and skipped — the run is re-runnable, so a later run reconciles. Only a
+// source paging error or context cancellation aborts with an error.
+//
+// Usage (run locally, prod Cosmos key in the environment):
+//
+//	export COSMOS_KEY="$(az cosmosdb keys list -n cosmos-town-crier-shared \
+//	    -g rg-town-crier-shared --type read-only-keys --query primaryReadonlyMasterKey -o tsv)"
+//	pgbackfill-applenotifs -pg-host <fqdn> -pg-admin-user <aad-admin-upn> \
+//	    -pg-db town_crier_prod [-cosmos-db town-crier-prod] [-batch-size 500] [-limit 0]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
+	"github.com/AmyDe/town-crier/api-go/internal/subscriptions"
+)
+
+const defaultCosmosEndpoint = "https://cosmos-town-crier-shared.documents.azure.com:443/"
+const defaultCosmosDB = "town-crier-prod"
+const defaultPostgresDB = "town_crier_dev"
+
+// enumerateQuery reads every document across all partitions. Cross-partition
+// reads without ORDER BY / aggregates are allowed by the Cosmos Gateway.
+const enumerateQuery = "SELECT * FROM c"
+
+// docPager yields successive pages of raw document bodies. The azcosmos query
+// pager satisfies it via cosmosPager; tests inject a hand-written fake.
+type docPager interface {
+	More() bool
+	NextPage(ctx context.Context) ([][]byte, error)
+}
+
+// notificationUpserter writes one processed notification idempotently.
+// *subscriptions.PostgresNotificationStore satisfies it via UpsertProcessed.
+type notificationUpserter interface {
+	UpsertProcessed(ctx context.Context, uuid string, processedAt time.Time) error
+}
+
+// backfillOptions tunes the run.
+type backfillOptions struct {
+	limit    int
+	logEvery int
+}
+
+// summary is the final tally the tool prints.
+type summary struct {
+	read     int
+	upserted int
+	errors   int
+}
+
+// backfill drains every page from pager, decodes each document with
+// subscriptions.DecodeDocument, and calls store.UpsertProcessed. It is the
+// testable core, decoupled from Cosmos and Postgres by the docPager /
+// notificationUpserter seams.
+//
+// Resilience: an undecodable document or a failed UpsertProcessed is counted
+// and skipped; only a source paging error or context cancellation aborts.
+func backfill(ctx context.Context, pager docPager, store notificationUpserter, opts backfillOptions, logger *slog.Logger) (summary, error) {
+	var s summary
+	for pager.More() {
+		if opts.limit > 0 && s.read >= opts.limit {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return s, fmt.Errorf("backfill cancelled after %d records: %w", s.read, err)
+		}
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return s, fmt.Errorf("read source page after %d records: %w", s.read, err)
+		}
+		for _, raw := range page {
+			if opts.limit > 0 && s.read >= opts.limit {
+				break
+			}
+			s.read++
+			notif, derr := subscriptions.DecodeDocument(raw)
+			if derr != nil {
+				s.errors++
+				logger.WarnContext(ctx, "skip undecodable notification", "error", derr)
+				continue
+			}
+			if uerr := store.UpsertProcessed(ctx, notif.UUID, notif.ProcessedAt); uerr != nil {
+				if ctx.Err() != nil {
+					return s, fmt.Errorf("backfill cancelled upserting %q after %d records: %w", notif.UUID, s.read, uerr)
+				}
+				s.errors++
+				logger.WarnContext(ctx, "upsert failed", "uuid", notif.UUID, "error", uerr)
+				continue
+			}
+			s.upserted++
+			if opts.logEvery > 0 && s.read%opts.logEvery == 0 {
+				logger.InfoContext(ctx, "backfill progress", "read", s.read, "upserted", s.upserted, "errors", s.errors)
+			}
+		}
+	}
+	return s, nil
+}
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	os.Exit(run(os.Args[1:], logger))
+}
+
+func run(args []string, logger *slog.Logger) int {
+	fs := flag.NewFlagSet("pgbackfill-applenotifs", flag.ContinueOnError)
+	var (
+		cosmosEndpoint  = fs.String("cosmos-endpoint", defaultCosmosEndpoint, "source Cosmos account endpoint")
+		cosmosDB        = fs.String("cosmos-db", defaultCosmosDB, "source Cosmos logical database")
+		cosmosContainer = fs.String("cosmos-container", platform.CosmosAppleNotificationsContainer, "source Cosmos container id")
+		pgHost          = fs.String("pg-host", os.Getenv("POSTGRES_HOST"), "target Postgres server FQDN")
+		pgDB            = fs.String("pg-db", defaultPostgresDB, "target Postgres database")
+		pgAdminUser     = fs.String("pg-admin-user", os.Getenv("POSTGRES_ADMIN_USER"), "Entra admin principal (UPN) to write as")
+		pgSSLMode       = fs.String("pg-sslmode", envOr("POSTGRES_SSLMODE", "require"), "target Postgres sslmode")
+		batchSize       = fs.Int("batch-size", 500, "Cosmos page size and progress-log cadence")
+		limit           = fs.Int("limit", 0, "max records to process (0 = all; a small value smoke-tests)")
+		timeout         = fs.Duration("timeout", 0, "overall timeout (0 = none; SIGINT/SIGTERM still cancel)")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	cosmosKey := os.Getenv("COSMOS_KEY")
+	if cosmosKey == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill-applenotifs: COSMOS_KEY environment variable is required (read-only prod Cosmos account key)")
+		return 2
+	}
+	if *pgHost == "" || *pgAdminUser == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill-applenotifs: -pg-host and -pg-admin-user are required")
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	pager, err := newCosmosPager(*cosmosEndpoint, cosmosKey, *cosmosDB, *cosmosContainer, *batchSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-applenotifs: build cosmos source: %v\n", err)
+		return 1
+	}
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-applenotifs: build azure credential: %v\n", err)
+		return 1
+	}
+	pool, err := postgres.NewTokenCredentialPool(ctx, postgres.ConnParams{
+		Host:    *pgHost,
+		DB:      *pgDB,
+		User:    *pgAdminUser,
+		SSLMode: *pgSSLMode,
+	}, cred)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-applenotifs: build postgres pool: %v\n", err)
+		return 1
+	}
+	defer pool.Close()
+
+	store := subscriptions.NewPostgresNotificationStore(pool, time.Now)
+
+	logger.InfoContext(ctx, "backfill starting",
+		"cosmosEndpoint", *cosmosEndpoint, "cosmosDb", *cosmosDB, "cosmosContainer", *cosmosContainer,
+		"pgHost", *pgHost, "pgDb", *pgDB, "batchSize", *batchSize, "limit", *limit)
+
+	started := time.Now()
+	s, err := backfill(ctx, pager, store, backfillOptions{limit: *limit, logEvery: *batchSize}, logger)
+	logger.InfoContext(ctx, "backfill complete",
+		"read", s.read, "upserted", s.upserted, "errors", s.errors, "elapsed", time.Since(started).String())
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-applenotifs: aborted: %v\n", err)
+		return 1
+	}
+	if s.errors > 0 {
+		logger.WarnContext(ctx, "backfill finished with per-record errors; re-run to reconcile", "errors", s.errors)
+	}
+	return 0
+}
+
+// cosmosPager adapts the azcosmos query pager to the docPager seam.
+type cosmosPager struct {
+	pager *runtime.Pager[azcosmos.QueryItemsResponse]
+}
+
+func (p *cosmosPager) More() bool { return p.pager.More() }
+
+func (p *cosmosPager) NextPage(ctx context.Context) ([][]byte, error) {
+	resp, err := p.pager.NextPage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cosmos next page: %w", err)
+	}
+	return resp.Items, nil
+}
+
+// newCosmosPager builds a key-authenticated Cosmos client and returns a
+// cross-partition pager over the whole container.
+func newCosmosPager(endpoint, key, db, container string, pageSize int) (docPager, error) {
+	cred, err := azcosmos.NewKeyCredential(key)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos key credential: %w", err)
+	}
+	client, err := azcosmos.NewClientWithKey(endpoint, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos client: %w", err)
+	}
+	c, err := client.NewContainer(db, container)
+	if err != nil {
+		return nil, fmt.Errorf("open container %q in %q: %w", container, db, err)
+	}
+	opts := &azcosmos.QueryOptions{PageSizeHint: clampPageSize(pageSize)}
+	return &cosmosPager{pager: c.NewQueryItemsPager(enumerateQuery, azcosmos.NewPartitionKey(), opts)}, nil
+}
+
+// clampPageSize bounds the requested page size into the SDK's int32 hint.
+func clampPageSize(n int) int32 {
+	const maxPageSize = 1000
+	if n <= 0 {
+		return 100
+	}
+	if n > maxPageSize {
+		return maxPageSize
+	}
+	return int32(n) //nolint:gosec // n is bounded to [1,1000] above, no overflow
+}
+
+// envOr returns the environment variable value for key, or fallback when unset.
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/api-go/cmd/pgbackfill-applenotifs/main_test.go
+++ b/api-go/cmd/pgbackfill-applenotifs/main_test.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/subscriptions"
+)
+
+// discardLogger is a no-op logger so tests stay quiet.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// rawNotifDoc builds a minimal valid AppleNotifications-container document
+// body for the given UUID.
+func rawNotifDoc(uuid string) []byte {
+	return []byte(`{"id":"` + uuid + `","processedAt":"2026-01-15T09:00:00+00:00"}`)
+}
+
+// fakeNotifPager yields successive pages of raw document bodies, or a fixed error.
+type fakeNotifPager struct {
+	pages [][][]byte
+	idx   int
+	err   error
+}
+
+func (p *fakeNotifPager) More() bool { return p.idx < len(p.pages) }
+
+func (p *fakeNotifPager) NextPage(_ context.Context) ([][]byte, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	page := p.pages[p.idx]
+	p.idx++
+	return page, nil
+}
+
+// fakeNotifUpserter records every upserted notification and can fail on a
+// specific UUID.
+type fakeNotifUpserter struct {
+	upserted []subscriptions.ProcessedNotification
+	failOn   map[string]error
+}
+
+func (u *fakeNotifUpserter) UpsertProcessed(_ context.Context, uuid string, processedAt time.Time) error {
+	if err := u.failOn[uuid]; err != nil {
+		return err
+	}
+	u.upserted = append(u.upserted, subscriptions.ProcessedNotification{UUID: uuid, ProcessedAt: processedAt})
+	return nil
+}
+
+func TestBackfill_SavesAllRecordsAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakeNotifPager{pages: [][][]byte{
+		{rawNotifDoc("uuid-a"), rawNotifDoc("uuid-b")},
+		{rawNotifDoc("uuid-c")},
+	}}
+	store := &fakeNotifUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 3 || got.errors != 0 {
+		t.Errorf("summary: got %+v, want read=3 upserted=3 errors=0", got)
+	}
+	if len(store.upserted) != 3 {
+		t.Errorf("store: upserted %d records, want 3", len(store.upserted))
+	}
+}
+
+func TestBackfill_ContinuesPastDecodeError(t *testing.T) {
+	t.Parallel()
+	pager := &fakeNotifPager{pages: [][][]byte{
+		{rawNotifDoc("uuid-a"), []byte("not json"), rawNotifDoc("uuid-b")},
+	}}
+	store := &fakeNotifUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestBackfill_ContinuesPastSaveError(t *testing.T) {
+	t.Parallel()
+	pager := &fakeNotifPager{pages: [][][]byte{
+		{rawNotifDoc("uuid-a"), rawNotifDoc("uuid-b"), rawNotifDoc("uuid-c")},
+	}}
+	store := &fakeNotifUpserter{failOn: map[string]error{"uuid-b": errors.New("boom")}}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestBackfill_RespectsLimit(t *testing.T) {
+	t.Parallel()
+	pager := &fakeNotifPager{pages: [][][]byte{
+		{rawNotifDoc("uuid-a")},
+		{rawNotifDoc("uuid-b")},
+		{rawNotifDoc("uuid-c")},
+	}}
+	store := &fakeNotifUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{limit: 2}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 2 || got.upserted != 2 {
+		t.Errorf("summary: got %+v, want read=2 upserted=2", got)
+	}
+	if pager.idx > 2 {
+		t.Errorf("pager consumed %d pages; should stop at limit (<=2)", pager.idx)
+	}
+}
+
+func TestBackfill_PagerErrorReturnsError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("cosmos read failed")
+	pager := &fakeNotifPager{pages: [][][]byte{{rawNotifDoc("uuid-a")}}, err: sentinel}
+	store := &fakeNotifUpserter{}
+
+	_, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("got err %v, want wrapped sentinel", err)
+	}
+}
+
+func TestBackfill_ContextCancelAborts(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pager := &fakeNotifPager{pages: [][][]byte{{rawNotifDoc("uuid-a")}}}
+	store := &fakeNotifUpserter{}
+
+	_, err := backfill(ctx, pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got err %v, want context.Canceled", err)
+	}
+	if len(store.upserted) != 0 {
+		t.Errorf("store: upserted %d records, want 0 (cancelled before any save)", len(store.upserted))
+	}
+}
+
+func TestBackfill_PreservesProcessedAt(t *testing.T) {
+	t.Parallel()
+	pager := &fakeNotifPager{pages: [][][]byte{
+		{rawNotifDoc("uuid-ts")},
+	}}
+	store := &fakeNotifUpserter{}
+
+	_, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if len(store.upserted) != 1 {
+		t.Fatalf("expected 1 upserted, got %d", len(store.upserted))
+	}
+	want := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
+	if !store.upserted[0].ProcessedAt.Equal(want) {
+		t.Errorf("ProcessedAt = %v, want %v", store.upserted[0].ProcessedAt, want)
+	}
+}

--- a/api-go/internal/platform/postgres/migrations/0005_apple_notifications.sql
+++ b/api-go/internal/platform/postgres/migrations/0005_apple_notifications.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+
+-- apple_notifications records App Store Server Notification UUIDs that have
+-- been successfully processed, giving the webhook handler at-most-once
+-- semantics (Cosmos -> Postgres migration; memo 0010, epic #645). The
+-- natural key is notification_uuid: Apple supplies it on every delivery and
+-- guarantees uniqueness per notification. A duplicate delivery is detected
+-- with one EXISTS read; an idempotent re-mark is absorbed by ON CONFLICT DO
+-- UPDATE — matching CosmosNotificationStore's last-writer-wins UpsertItem.
+CREATE TABLE apple_notifications (
+    notification_uuid  text PRIMARY KEY,
+    processed_at       timestamptz NOT NULL
+);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS apple_notifications;

--- a/api-go/internal/subscriptions/decode.go
+++ b/api-go/internal/subscriptions/decode.go
@@ -1,0 +1,35 @@
+package subscriptions
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// ProcessedNotification is the domain record for a processed App Store Server
+// Notification, as decoded from a stored AppleNotifications-container document.
+type ProcessedNotification struct {
+	UUID        string
+	ProcessedAt time.Time
+}
+
+// DecodeDocument hydrates a stored AppleNotifications-container document body
+// into a ProcessedNotification domain record, reusing the exact field mapping
+// the Cosmos store uses (processedNotificationDocument). It exists so the
+// Cosmos -> Postgres backfill (cmd/pgbackfill-applenotifs) shares one
+// transform with the store rather than reinventing the mapping, which keeps
+// the two from silently diverging. A document with an empty id is rejected
+// with an error.
+func DecodeDocument(raw []byte) (ProcessedNotification, error) {
+	var doc processedNotificationDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return ProcessedNotification{}, fmt.Errorf("decode apple notification document: %w", err)
+	}
+	if doc.ID == "" {
+		return ProcessedNotification{}, fmt.Errorf("apple notification document has empty id")
+	}
+	return ProcessedNotification{
+		UUID:        doc.ID,
+		ProcessedAt: time.Time(doc.ProcessedAt),
+	}, nil
+}

--- a/api-go/internal/subscriptions/integration_test.go
+++ b/api-go/internal/subscriptions/integration_test.go
@@ -1,0 +1,130 @@
+//go:build integration
+
+package subscriptions
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// newNotifPGStore returns a Postgres-backed notification store over a
+// truncated database. Integration tests must NOT call t.Parallel: pgtest.New
+// holds a session-level advisory lock for the test's whole duration to
+// serialise all packages that share the single docker-compose database.
+func newNotifPGStore(t *testing.T) *PostgresNotificationStore {
+	t.Helper()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "apple_notifications")
+	return NewPostgresNotificationStore(pool, time.Now)
+}
+
+// TestPostgresNotificationStore_IsProcessed_RoundTrip marks a UUID and confirms
+// IsProcessed returns true on the next call.
+func TestPostgresNotificationStore_IsProcessed_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := newNotifPGStore(t)
+
+	const uuid = "test-uuid-roundtrip"
+
+	got, err := store.IsProcessed(ctx, uuid)
+	if err != nil {
+		t.Fatalf("IsProcessed before mark: %v", err)
+	}
+	if got {
+		t.Fatal("want not processed before mark")
+	}
+
+	if err := store.MarkProcessed(ctx, uuid); err != nil {
+		t.Fatalf("MarkProcessed: %v", err)
+	}
+
+	got, err = store.IsProcessed(ctx, uuid)
+	if err != nil {
+		t.Fatalf("IsProcessed after mark: %v", err)
+	}
+	if !got {
+		t.Fatal("want processed after mark")
+	}
+}
+
+// TestPostgresNotificationStore_MarkProcessed_Idempotent proves ON CONFLICT
+// (notification_uuid) DO UPDATE absorbs a second mark of the same UUID without
+// a unique-constraint error — matching CosmosNotificationStore's
+// last-writer-wins UpsertItem behaviour.
+func TestPostgresNotificationStore_MarkProcessed_Idempotent(t *testing.T) {
+	ctx := context.Background()
+	store := newNotifPGStore(t)
+
+	const uuid = "test-uuid-idempotent"
+
+	if err := store.MarkProcessed(ctx, uuid); err != nil {
+		t.Fatalf("first MarkProcessed: %v", err)
+	}
+	if err := store.MarkProcessed(ctx, uuid); err != nil {
+		t.Fatalf("second MarkProcessed (idempotent): %v", err)
+	}
+
+	// Exactly one row in the table.
+	var count int
+	if err := store.db.QueryRow(ctx,
+		"SELECT count(*) FROM apple_notifications WHERE notification_uuid = $1", uuid,
+	).Scan(&count); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 row after two marks, got %d", count)
+	}
+}
+
+// TestPostgresNotificationStore_UpsertProcessed_PreservesTimestamp proves the
+// backfill path writes the supplied processedAt and that a re-run with a
+// different timestamp updates the row in place.
+func TestPostgresNotificationStore_UpsertProcessed_PreservesTimestamp(t *testing.T) {
+	ctx := context.Background()
+	store := newNotifPGStore(t)
+
+	const uuid = "test-uuid-upsert"
+	original := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
+
+	if err := store.UpsertProcessed(ctx, uuid, original); err != nil {
+		t.Fatalf("UpsertProcessed first: %v", err)
+	}
+
+	var got time.Time
+	if err := store.db.QueryRow(ctx,
+		"SELECT processed_at FROM apple_notifications WHERE notification_uuid = $1", uuid,
+	).Scan(&got); err != nil {
+		t.Fatalf("read processed_at: %v", err)
+	}
+	if !got.Equal(original) {
+		t.Errorf("processed_at = %v, want %v", got, original)
+	}
+
+	// Re-run with a different timestamp (ON CONFLICT DO UPDATE).
+	updated := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	if err := store.UpsertProcessed(ctx, uuid, updated); err != nil {
+		t.Fatalf("UpsertProcessed second: %v", err)
+	}
+	if err := store.db.QueryRow(ctx,
+		"SELECT processed_at FROM apple_notifications WHERE notification_uuid = $1", uuid,
+	).Scan(&got); err != nil {
+		t.Fatalf("read processed_at after re-upsert: %v", err)
+	}
+	if !got.Equal(updated) {
+		t.Errorf("processed_at after re-upsert = %v, want %v", got, updated)
+	}
+
+	// Still exactly one row.
+	var count int
+	if err := store.db.QueryRow(ctx,
+		"SELECT count(*) FROM apple_notifications",
+	).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 row after two upserts, got %d", count)
+	}
+}

--- a/api-go/internal/subscriptions/store_postgres.go
+++ b/api-go/internal/subscriptions/store_postgres.go
@@ -1,0 +1,114 @@
+package subscriptions
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// querier is the consumer-side slice of *pgxpool.Pool the Postgres store uses:
+// parameterised exec/query/query-row. Defining it here (not importing pgxpool)
+// keeps the store decoupled from the concrete pool and lets a pgx.Tx stand in.
+// Both *pgxpool.Pool and pgx.Tx satisfy it structurally.
+type querier interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// Store is the full method set the apple-notification idempotency store exposes
+// to its consumers. It serves two purposes: a compile-time parity check (both
+// *CosmosNotificationStore and *PostgresNotificationStore must satisfy it, so a
+// Postgres port can never silently diverge from the Cosmos surface) and the
+// exported consumer-side interface cmd/api's wiring will accept so the store can
+// be flag-selected between backends (a later slice wires the flip).
+type Store interface {
+	IsProcessed(ctx context.Context, notificationUUID string) (bool, error)
+	MarkProcessed(ctx context.Context, notificationUUID string) error
+}
+
+// Compile-time parity: both the Cosmos and Postgres stores satisfy the exported
+// Store interface and the handler's package-local idempotencyStore interface.
+var (
+	_ Store            = (*CosmosNotificationStore)(nil)
+	_ Store            = (*PostgresNotificationStore)(nil)
+	_ idempotencyStore = (*PostgresNotificationStore)(nil)
+)
+
+// PostgresNotificationStore records and detects processed App Store Server
+// Notifications in the apple_notifications table (Cosmos -> Postgres migration;
+// memo 0010, epic #645). It is a parallel implementation: Cosmos remains wired
+// until the flag flip in a later slice.
+//
+// The natural key is notification_uuid (the UUID Apple supplies on every
+// delivery), so IsProcessed is a single EXISTS point read and MarkProcessed is
+// an INSERT ... ON CONFLICT (notification_uuid) DO UPDATE — last-writer-wins,
+// so a re-delivery that races past IsProcessed is silently absorbed.
+type PostgresNotificationStore struct {
+	db  querier
+	now func() time.Time
+}
+
+// NewPostgresNotificationStore returns a store over the given pgx pool (or any
+// querier). now supplies the processed_at timestamp for MarkProcessed (injected
+// for deterministic tests).
+func NewPostgresNotificationStore(db querier, now func() time.Time) *PostgresNotificationStore {
+	return &PostgresNotificationStore{db: db, now: now}
+}
+
+const isProcessedQuery = "SELECT EXISTS(SELECT 1 FROM apple_notifications WHERE notification_uuid = $1)"
+
+// IsProcessed reports whether the notification UUID has already been handled.
+// It maps a SELECT EXISTS result directly to bool; the database guarantees this
+// query always returns exactly one row, so ErrNoRows cannot occur.
+func (s *PostgresNotificationStore) IsProcessed(ctx context.Context, notificationUUID string) (bool, error) {
+	var processed bool
+	if err := s.db.QueryRow(ctx, isProcessedQuery, notificationUUID).Scan(&processed); err != nil {
+		return false, fmt.Errorf("check processed notification %q: %w", notificationUUID, err)
+	}
+	return processed, nil
+}
+
+// markProcessedQuery inserts or silently refreshes an apple_notifications row.
+// ON CONFLICT DO UPDATE makes this last-writer-wins idempotent: a duplicate
+// delivery that races past IsProcessed is absorbed without a constraint error,
+// matching the Cosmos UpsertItem last-writer-wins semantics exactly.
+const markProcessedQuery = `
+INSERT INTO apple_notifications (notification_uuid, processed_at)
+VALUES ($1, $2)
+ON CONFLICT (notification_uuid) DO UPDATE SET processed_at = EXCLUDED.processed_at`
+
+// MarkProcessed records the notification as handled. It uses now() as the
+// processed_at timestamp. For idempotency under concurrent delivery see the
+// SQL constant above.
+func (s *PostgresNotificationStore) MarkProcessed(ctx context.Context, notificationUUID string) error {
+	_, err := s.db.Exec(ctx, markProcessedQuery, notificationUUID, s.now())
+	if err != nil {
+		return fmt.Errorf("mark processed notification %q: %w", notificationUUID, err)
+	}
+	return nil
+}
+
+// upsertProcessedQuery is identical to markProcessedQuery but named separately
+// for clarity: the backfill uses it with the original processedAt from Cosmos
+// rather than s.now(), preserving historical timestamps across the migration.
+const upsertProcessedQuery = `
+INSERT INTO apple_notifications (notification_uuid, processed_at)
+VALUES ($1, $2)
+ON CONFLICT (notification_uuid) DO UPDATE SET processed_at = EXCLUDED.processed_at`
+
+// UpsertProcessed inserts a processed notification with the given processedAt
+// timestamp. This is used exclusively by the Cosmos -> Postgres backfill
+// (cmd/pgbackfill-applenotifs) to preserve the original processing timestamp;
+// it is not part of the Store interface (the runtime path uses MarkProcessed
+// with the injected now clock).
+func (s *PostgresNotificationStore) UpsertProcessed(ctx context.Context, notificationUUID string, processedAt time.Time) error {
+	_, err := s.db.Exec(ctx, upsertProcessedQuery, notificationUUID, processedAt)
+	if err != nil {
+		return fmt.Errorf("upsert processed notification %q: %w", notificationUUID, err)
+	}
+	return nil
+}

--- a/api-go/internal/subscriptions/store_postgres_test.go
+++ b/api-go/internal/subscriptions/store_postgres_test.go
@@ -1,0 +1,176 @@
+package subscriptions
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// fakeBoolRow implements pgx.Row, scanning a single bool result. Used by
+// fakeQuerier to simulate the SELECT EXISTS query in IsProcessed.
+type fakeBoolRow struct {
+	val bool
+	err error
+}
+
+func (r *fakeBoolRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	*dest[0].(*bool) = r.val //nolint:forcetypeassert // controlled in tests
+	return nil
+}
+
+// fakeQuerier implements querier without a real database.
+// rowResult/rowErr feed QueryRow; execErr/execCalls feed Exec.
+type fakeQuerier struct {
+	rowResult bool
+	rowErr    error
+	execErr   error
+	execCalls []execCall
+}
+
+type execCall struct {
+	sql  string
+	args []any
+}
+
+func (f *fakeQuerier) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	f.execCalls = append(f.execCalls, execCall{sql: sql, args: args})
+	return pgconn.CommandTag{}, f.execErr
+}
+
+func (f *fakeQuerier) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	return nil, errors.New("Query not used by PostgresNotificationStore")
+}
+
+func (f *fakeQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	return &fakeBoolRow{val: f.rowResult, err: f.rowErr}
+}
+
+// TestPostgresNotificationStore_IsProcessed_Miss returns false when no row exists.
+func TestPostgresNotificationStore_IsProcessed_Miss(t *testing.T) {
+	t.Parallel()
+	q := &fakeQuerier{rowResult: false}
+	store := NewPostgresNotificationStore(q, time.Now)
+
+	got, err := store.IsProcessed(context.Background(), "uuid-1")
+	if err != nil {
+		t.Fatalf("IsProcessed: %v", err)
+	}
+	if got {
+		t.Error("want not processed for absent uuid, got true")
+	}
+}
+
+// TestPostgresNotificationStore_IsProcessed_Hit returns true when the row exists.
+func TestPostgresNotificationStore_IsProcessed_Hit(t *testing.T) {
+	t.Parallel()
+	q := &fakeQuerier{rowResult: true}
+	store := NewPostgresNotificationStore(q, time.Now)
+
+	got, err := store.IsProcessed(context.Background(), "uuid-2")
+	if err != nil {
+		t.Fatalf("IsProcessed: %v", err)
+	}
+	if !got {
+		t.Error("want processed for present uuid, got false")
+	}
+}
+
+// TestPostgresNotificationStore_IsProcessed_Error wraps database errors.
+func TestPostgresNotificationStore_IsProcessed_Error(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("db scan error")
+	q := &fakeQuerier{rowErr: sentinel}
+	store := NewPostgresNotificationStore(q, time.Now)
+
+	_, err := store.IsProcessed(context.Background(), "uuid-3")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("got err %v, want wrapped sentinel", err)
+	}
+}
+
+// TestPostgresNotificationStore_MarkProcessed calls Exec once with the uuid
+// and the injected timestamp.
+func TestPostgresNotificationStore_MarkProcessed(t *testing.T) {
+	t.Parallel()
+	fixed := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	q := &fakeQuerier{}
+	store := NewPostgresNotificationStore(q, func() time.Time { return fixed })
+
+	if err := store.MarkProcessed(context.Background(), "uuid-4"); err != nil {
+		t.Fatalf("MarkProcessed: %v", err)
+	}
+	if len(q.execCalls) != 1 {
+		t.Fatalf("expected 1 exec call, got %d", len(q.execCalls))
+	}
+	call := q.execCalls[0]
+	if len(call.args) < 2 {
+		t.Fatalf("expected at least 2 args, got %d", len(call.args))
+	}
+	if call.args[0] != "uuid-4" {
+		t.Errorf("first arg = %v, want uuid-4", call.args[0])
+	}
+	if call.args[1] != fixed {
+		t.Errorf("second arg = %v, want %v", call.args[1], fixed)
+	}
+}
+
+// TestPostgresNotificationStore_MarkProcessed_Idempotent proves MarkProcessed
+// can be called twice without error at the code level. The ON CONFLICT DO UPDATE
+// idempotency against a real unique constraint is exercised in the integration
+// test.
+func TestPostgresNotificationStore_MarkProcessed_Idempotent(t *testing.T) {
+	t.Parallel()
+	q := &fakeQuerier{}
+	store := NewPostgresNotificationStore(q, time.Now)
+
+	if err := store.MarkProcessed(context.Background(), "uuid-6"); err != nil {
+		t.Fatalf("first MarkProcessed: %v", err)
+	}
+	if err := store.MarkProcessed(context.Background(), "uuid-6"); err != nil {
+		t.Fatalf("second MarkProcessed (idempotent): %v", err)
+	}
+	if len(q.execCalls) != 2 {
+		t.Errorf("expected 2 exec calls, got %d", len(q.execCalls))
+	}
+}
+
+// TestPostgresNotificationStore_MarkProcessed_Error wraps database errors.
+func TestPostgresNotificationStore_MarkProcessed_Error(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("db exec error")
+	q := &fakeQuerier{execErr: sentinel}
+	store := NewPostgresNotificationStore(q, time.Now)
+
+	if err := store.MarkProcessed(context.Background(), "uuid-5"); !errors.Is(err, sentinel) {
+		t.Fatalf("got err %v, want wrapped sentinel", err)
+	}
+}
+
+// TestPostgresNotificationStore_UpsertProcessed calls Exec with explicit processedAt.
+func TestPostgresNotificationStore_UpsertProcessed(t *testing.T) {
+	t.Parallel()
+	at := time.Date(2026, 1, 15, 9, 0, 0, 0, time.UTC)
+	q := &fakeQuerier{}
+	store := NewPostgresNotificationStore(q, time.Now)
+
+	if err := store.UpsertProcessed(context.Background(), "uuid-7", at); err != nil {
+		t.Fatalf("UpsertProcessed: %v", err)
+	}
+	if len(q.execCalls) != 1 {
+		t.Fatalf("expected 1 exec call, got %d", len(q.execCalls))
+	}
+	call := q.execCalls[0]
+	if call.args[0] != "uuid-7" {
+		t.Errorf("first arg = %v, want uuid-7", call.args[0])
+	}
+	if call.args[1] != at {
+		t.Errorf("second arg = %v, want %v", call.args[1], at)
+	}
+}

--- a/api-go/internal/subscriptions/store_postgres_test.go
+++ b/api-go/internal/subscriptions/store_postgres_test.go
@@ -121,11 +121,11 @@ func TestPostgresNotificationStore_MarkProcessed(t *testing.T) {
 	}
 }
 
-// TestPostgresNotificationStore_MarkProcessed_Idempotent proves MarkProcessed
+// TestPostgresNotificationStore_MarkProcessed_CallsTwice proves MarkProcessed
 // can be called twice without error at the code level. The ON CONFLICT DO UPDATE
 // idempotency against a real unique constraint is exercised in the integration
-// test.
-func TestPostgresNotificationStore_MarkProcessed_Idempotent(t *testing.T) {
+// test (TestPostgresNotificationStore_MarkProcessed_Idempotent).
+func TestPostgresNotificationStore_MarkProcessed_CallsTwice(t *testing.T) {
 	t.Parallel()
 	q := &fakeQuerier{}
 	store := NewPostgresNotificationStore(q, time.Now)


### PR DESCRIPTION
Slice 2 of Phase F single-store cutover (epic #645, spec #669, memo 0010).

Postgres port for the App Store Server Notifications webhook idempotency store (`internal/subscriptions`), behind a new exported `subscriptions.Store` consumer interface (both Cosmos and Postgres satisfy it):

- `PostgresNotificationStore` — `IsProcessed` (SELECT EXISTS), `MarkProcessed` (INSERT … ON CONFLICT, `now()`), plus backfill-only `UpsertProcessed` (caller-supplied timestamp to preserve history).
- Migration `0005_apple_notifications.sql` (`notification_uuid` PK, `processed_at`).
- `cmd/pgbackfill-applenotifs` Cosmos→Postgres backfill (sibling of `cmd/pgbackfill-zones`), preserves `processedAt`.

Not in the GDPR cascade. No wiring touched (later slice). Unit (fakes, `-race`) + `//go:build integration` pgtest tests green; `go build`/`vet`/`gofmt`/`golangci-lint` clean.

Bead: tc-hpd2.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)