### PR TITLE
feat(api): Postgres ports for Users (profiles point + admin) with quota CAS (tc-hpd2.8)

### DIFF
--- a/api-go/cmd/pgbackfill-users/main.go
+++ b/api-go/cmd/pgbackfill-users/main.go
@@ -1,0 +1,290 @@
+// Command pgbackfill-users copies user profiles from prod Cosmos into the
+// Postgres `users` table, for the Cosmos -> Postgres migration
+// (docs/memo/0010, epic #645; GH#669). It is the sibling of cmd/pgbackfill-zones
+// (which copies per-user WatchZones); this one copies the Users container. It is
+// idempotent and re-runnable: each profile is written with the Postgres store's
+// INSERT ... ON CONFLICT (user_id) DO UPDATE keyed on the Auth0 user id, so a
+// re-run reconciles rather than duplicates.
+//
+// PII: user profiles contain email addresses, subscription state, and activity
+// timestamps. This tool copies PII. The prod copy is EXPLICITLY AUTHORIZED as
+// part of the Cosmos→Postgres migration in issue #669 — the only prod accounts
+// are the owner, his wife, and personal friends/family. Do not point this at
+// any other dataset without the same authorization.
+//
+// Source (read): prod Cosmos, authenticated with the account KEY (read from the
+// COSMOS_KEY environment variable, never a flag, so it stays out of shell
+// history). The tool enumerates the whole Users container with a cross-partition
+// `SELECT * FROM c` query, paged via a continuation token.
+//
+// Target (write): Postgres, authenticated passwordless as the Entra ADMIN
+// (DefaultAzureCredential) — the owner/admin role has full DML, whereas the
+// least-priv towncrier_api managed identity is only usable from inside Azure. Pass
+// -pg-db town_crier_prod for the prod copy; the default is the dev database, the
+// safer failure mode if the flag is forgotten.
+//
+// A document that fails to decode (bad JSON or an unrecognised tier string) or a
+// single failed Save is counted and skipped, not fatal — the run is re-runnable,
+// so a later run reconciles. Only a source paging error or context cancellation
+// aborts the whole run.
+//
+// Usage (run locally, prod Cosmos key in the environment):
+//
+//	export COSMOS_KEY="$(az cosmosdb keys list -n cosmos-town-crier-shared \
+//	    -g rg-town-crier-shared --type read-only-keys --query primaryReadonlyMasterKey -o tsv)"
+//	pgbackfill-users -pg-host <fqdn> -pg-admin-user <aad-admin-upn> -pg-db town_crier_prod \
+//	    [-cosmos-db town-crier-prod] [-batch-size 500] [-limit 0]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// defaultCosmosEndpoint is the shared Cosmos account hosting prod and dev.
+const defaultCosmosEndpoint = "https://cosmos-town-crier-shared.documents.azure.com:443/"
+
+// defaultCosmosDB is the prod logical database the backfill reads from.
+const defaultCosmosDB = "town-crier-prod"
+
+// defaultPostgresDB is the database the backfill writes to by default. The dev
+// database is the safe default — a forgotten -pg-db flag never writes prod.
+// Pass -pg-db town_crier_prod for the prod copy.
+const defaultPostgresDB = "town_crier_dev"
+
+// cosmosUsersContainer is the Cosmos container name for user profiles. The
+// constant in internal/platform/cosmos.go is unexported, so we inline the
+// literal here (same value — "Users" — verified at review time).
+const cosmosUsersContainer = "Users"
+
+// enumerateQuery reads every user profile across all partitions.
+const enumerateQuery = "SELECT * FROM c"
+
+// docPager yields successive pages of raw document bodies. The azcosmos query
+// pager satisfies it via cosmosPager; tests inject a hand-written fake.
+type docPager interface {
+	More() bool
+	NextPage(ctx context.Context) ([][]byte, error)
+}
+
+// profileUpserter writes one user profile idempotently. *profiles.PostgresStore
+// satisfies it via Save (INSERT ... ON CONFLICT (user_id) DO UPDATE); tests
+// inject a fake.
+type profileUpserter interface {
+	Save(ctx context.Context, p *profiles.UserProfile) error
+}
+
+// backfillOptions tunes the run: limit caps the number of records processed
+// (0 = all, a small value enables a smoke run); logEvery sets the progress-log
+// cadence in records (0 = no progress logs).
+type backfillOptions struct {
+	limit    int
+	logEvery int
+}
+
+// summary is the final tally the tool prints.
+type summary struct {
+	read     int
+	upserted int
+	errors   int
+}
+
+// backfill drains every page from pager, decodes each document with
+// profiles.DecodeDocument, and saves it into store. It is the testable core,
+// decoupled from Cosmos and Postgres by the docPager / profileUpserter seams.
+//
+// Resilience: an undecodable document or a single failed Save is counted and
+// skipped (the run is re-runnable). Only a paging error or context cancellation
+// aborts the whole run with an error.
+func backfill(ctx context.Context, pager docPager, store profileUpserter, opts backfillOptions, logger *slog.Logger) (summary, error) {
+	var s summary
+	for pager.More() {
+		if opts.limit > 0 && s.read >= opts.limit {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return s, fmt.Errorf("backfill cancelled after %d records: %w", s.read, err)
+		}
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return s, fmt.Errorf("read source page after %d records: %w", s.read, err)
+		}
+		for _, raw := range page {
+			if opts.limit > 0 && s.read >= opts.limit {
+				break
+			}
+			s.read++
+			p, derr := profiles.DecodeDocument(raw)
+			if derr != nil {
+				s.errors++
+				logger.WarnContext(ctx, "skip undecodable profile", "error", derr)
+				continue
+			}
+			if uerr := store.Save(ctx, p); uerr != nil {
+				if ctx.Err() != nil {
+					return s, fmt.Errorf("backfill cancelled saving profile %q after %d records: %w", p.UserID, s.read, uerr)
+				}
+				s.errors++
+				logger.WarnContext(ctx, "save failed", "userID", p.UserID, "error", uerr)
+				continue
+			}
+			s.upserted++
+			if opts.logEvery > 0 && s.read%opts.logEvery == 0 {
+				logger.InfoContext(ctx, "backfill progress", "read", s.read, "upserted", s.upserted, "errors", s.errors)
+			}
+		}
+	}
+	return s, nil
+}
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	os.Exit(run(os.Args[1:], logger))
+}
+
+func run(args []string, logger *slog.Logger) int {
+	fs := flag.NewFlagSet("pgbackfill-users", flag.ContinueOnError)
+	var (
+		cosmosEndpoint  = fs.String("cosmos-endpoint", defaultCosmosEndpoint, "source Cosmos account endpoint")
+		cosmosDB        = fs.String("cosmos-db", defaultCosmosDB, "source Cosmos logical database")
+		cosmosContainer = fs.String("cosmos-container", cosmosUsersContainer, "source Cosmos container id")
+		pgHost          = fs.String("pg-host", os.Getenv("POSTGRES_HOST"), "target Postgres server FQDN")
+		pgDB            = fs.String("pg-db", defaultPostgresDB, "target Postgres database")
+		pgAdminUser     = fs.String("pg-admin-user", os.Getenv("POSTGRES_ADMIN_USER"), "Entra admin principal (UPN) to write as")
+		pgSSLMode       = fs.String("pg-sslmode", envOr("POSTGRES_SSLMODE", "require"), "target Postgres sslmode")
+		batchSize       = fs.Int("batch-size", 500, "Cosmos page size and progress-log cadence")
+		limit           = fs.Int("limit", 0, "max records to process (0 = all; a small value smoke-tests)")
+		timeout         = fs.Duration("timeout", 0, "overall timeout (0 = none; SIGINT/SIGTERM still cancel)")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	cosmosKey := os.Getenv("COSMOS_KEY")
+	if cosmosKey == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill-users: COSMOS_KEY environment variable is required (read-only prod Cosmos account key)")
+		return 2
+	}
+	if *pgHost == "" || *pgAdminUser == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill-users: -pg-host and -pg-admin-user are required")
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	pager, err := newCosmosPager(*cosmosEndpoint, cosmosKey, *cosmosDB, *cosmosContainer, *batchSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-users: build cosmos source: %v\n", err)
+		return 1
+	}
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-users: build azure credential: %v\n", err)
+		return 1
+	}
+	pool, err := postgres.NewTokenCredentialPool(ctx, postgres.ConnParams{
+		Host:    *pgHost,
+		DB:      *pgDB,
+		User:    *pgAdminUser,
+		SSLMode: *pgSSLMode,
+	}, cred)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-users: build postgres pool: %v\n", err)
+		return 1
+	}
+	defer pool.Close()
+
+	store := profiles.NewPostgresStore(pool)
+
+	logger.InfoContext(ctx, "backfill starting",
+		"cosmosEndpoint", *cosmosEndpoint, "cosmosDb", *cosmosDB, "cosmosContainer", *cosmosContainer,
+		"pgHost", *pgHost, "pgDb", *pgDB, "batchSize", *batchSize, "limit", *limit)
+
+	started := time.Now()
+	s, err := backfill(ctx, pager, store, backfillOptions{limit: *limit, logEvery: *batchSize}, logger)
+	logger.InfoContext(ctx, "backfill complete",
+		"read", s.read, "upserted", s.upserted, "errors", s.errors, "elapsed", time.Since(started).String())
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-users: aborted: %v\n", err)
+		return 1
+	}
+	if s.errors > 0 {
+		logger.WarnContext(ctx, "backfill finished with per-record errors; re-run to reconcile", "errors", s.errors)
+	}
+	return 0
+}
+
+// cosmosPager adapts the azcosmos query pager to the docPager seam.
+type cosmosPager struct {
+	pager *runtime.Pager[azcosmos.QueryItemsResponse]
+}
+
+func (p *cosmosPager) More() bool { return p.pager.More() }
+
+func (p *cosmosPager) NextPage(ctx context.Context) ([][]byte, error) {
+	resp, err := p.pager.NextPage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cosmos next page: %w", err)
+	}
+	return resp.Items, nil
+}
+
+// newCosmosPager builds a key-authenticated Cosmos client and returns a
+// cross-partition pager over the whole container.
+func newCosmosPager(endpoint, key, db, container string, pageSize int) (docPager, error) {
+	cred, err := azcosmos.NewKeyCredential(key)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos key credential: %w", err)
+	}
+	client, err := azcosmos.NewClientWithKey(endpoint, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos client: %w", err)
+	}
+	c, err := client.NewContainer(db, container)
+	if err != nil {
+		return nil, fmt.Errorf("open container %q in %q: %w", container, db, err)
+	}
+	opts := &azcosmos.QueryOptions{PageSizeHint: clampPageSize(pageSize)}
+	return &cosmosPager{pager: c.NewQueryItemsPager(enumerateQuery, azcosmos.NewPartitionKey(), opts)}, nil
+}
+
+// clampPageSize bounds the requested page size to the Cosmos max (1000).
+func clampPageSize(n int) int32 {
+	const maxPageSize = 1000
+	if n <= 0 {
+		return 100
+	}
+	if n > maxPageSize {
+		return maxPageSize
+	}
+	return int32(n) //nolint:gosec // n is bounded to [1,1000] above, no overflow
+}
+
+// envOr returns the environment variable value for key, or fallback when unset.
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/api-go/cmd/pgbackfill-users/main.go
+++ b/api-go/cmd/pgbackfill-users/main.go
@@ -138,7 +138,7 @@ func backfill(ctx context.Context, pager docPager, store profileUpserter, opts b
 					return s, fmt.Errorf("backfill cancelled saving profile %q after %d records: %w", p.UserID, s.read, uerr)
 				}
 				s.errors++
-				logger.WarnContext(ctx, "save failed", "userID", p.UserID, "error", uerr)
+				logger.WarnContext(ctx, "save failed", "userId", p.UserID, "error", uerr)
 				continue
 			}
 			s.upserted++

--- a/api-go/cmd/pgbackfill-users/main_test.go
+++ b/api-go/cmd/pgbackfill-users/main_test.go
@@ -225,8 +225,8 @@ func TestBackfill_LogProgressEveryN(t *testing.T) {
 	t.Parallel()
 
 	// 5 records, log every 2.
-	var docs [][]byte
-	for i := 0; i < 5; i++ {
+	docs := make([][]byte, 0, 5)
+	for i := range 5 {
 		docs = append(docs, rawProfileDoc("auth0|p"+string(rune('0'+i))))
 	}
 	pager := &fakeProfilePager{pages: [][][]byte{docs}}

--- a/api-go/cmd/pgbackfill-users/main_test.go
+++ b/api-go/cmd/pgbackfill-users/main_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// discardLogger is a no-op logger so tests stay quiet.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// rawProfileDoc builds a minimal valid Users-container document body for the
+// given userId, ready for profiles.DecodeDocument.
+func rawProfileDoc(userID string) []byte {
+	return []byte(`{` +
+		`"id":"` + userID + `",` +
+		`"userId":"` + userID + `",` +
+		`"email":"` + userID + `@example.com",` +
+		`"pushEnabled":true,` +
+		`"digestDay":1,` +
+		`"emailDigestEnabled":true,` +
+		`"savedDecisionPush":true,` +
+		`"savedDecisionEmail":true,` +
+		`"zonePreferences":{},` +
+		`"tier":"Free",` +
+		`"lastActiveAt":"2026-06-26T12:00:00Z",` +
+		`"lastActiveAtEpoch":1719403200000` +
+		`}`)
+}
+
+// fakeProfilePager yields successive pages of raw document bodies, or a fixed
+// error.
+type fakeProfilePager struct {
+	pages [][][]byte
+	idx   int
+	err   error
+}
+
+func (p *fakeProfilePager) More() bool { return p.idx < len(p.pages) }
+
+func (p *fakeProfilePager) NextPage(_ context.Context) ([][]byte, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	page := p.pages[p.idx]
+	p.idx++
+	return page, nil
+}
+
+// fakeProfileUpserter records every saved profile and can fail by userID.
+type fakeProfileUpserter struct {
+	saved  []*profiles.UserProfile
+	failOn map[string]error
+}
+
+func (u *fakeProfileUpserter) Save(_ context.Context, p *profiles.UserProfile) error {
+	if err := u.failOn[p.UserID]; err != nil {
+		return err
+	}
+	u.saved = append(u.saved, p)
+	return nil
+}
+
+func TestBackfill_SavesAllRecordsAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakeProfilePager{pages: [][][]byte{
+		{rawProfileDoc("auth0|u1"), rawProfileDoc("auth0|u2")},
+		{rawProfileDoc("auth0|u3")},
+	}}
+	store := &fakeProfileUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 3 || got.errors != 0 {
+		t.Errorf("summary: got %+v, want read=3 upserted=3 errors=0", got)
+	}
+	if len(store.saved) != 3 {
+		t.Errorf("store: saved %d records, want 3", len(store.saved))
+	}
+}
+
+func TestBackfill_ContinuesPastDecodeError(t *testing.T) {
+	t.Parallel()
+	pager := &fakeProfilePager{pages: [][][]byte{
+		{rawProfileDoc("auth0|u1"), []byte("not json"), rawProfileDoc("auth0|u2")},
+	}}
+	store := &fakeProfileUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestBackfill_ContinuesPastSaveError(t *testing.T) {
+	t.Parallel()
+	pager := &fakeProfilePager{pages: [][][]byte{
+		{rawProfileDoc("auth0|u1"), rawProfileDoc("auth0|u2"), rawProfileDoc("auth0|u3")},
+	}}
+	store := &fakeProfileUpserter{failOn: map[string]error{"auth0|u2": errors.New("boom")}}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestBackfill_RespectsLimitAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakeProfilePager{pages: [][][]byte{
+		{rawProfileDoc("auth0|u1")},
+		{rawProfileDoc("auth0|u2")},
+		{rawProfileDoc("auth0|u3")},
+	}}
+	store := &fakeProfileUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{limit: 2}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 2 || got.upserted != 2 {
+		t.Errorf("summary: got %+v, want read=2 upserted=2", got)
+	}
+	if pager.idx > 2 {
+		t.Errorf("pager consumed %d pages, want it to stop at the limit (<=2)", pager.idx)
+	}
+}
+
+func TestBackfill_PagerErrorReturnsError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("cosmos read failed")
+	pager := &fakeProfilePager{pages: [][][]byte{{rawProfileDoc("auth0|u1")}}, err: sentinel}
+	store := &fakeProfileUpserter{}
+
+	_, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("backfill: got err %v, want wrapped %v", err, sentinel)
+	}
+}
+
+func TestBackfill_ContextCancelAborts(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pager := &fakeProfilePager{pages: [][][]byte{{rawProfileDoc("auth0|u1")}}}
+	store := &fakeProfileUpserter{}
+
+	_, err := backfill(ctx, pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("backfill: got err %v, want context.Canceled", err)
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("store: saved %d records, want 0 (cancelled before any save)", len(store.saved))
+	}
+}
+
+// TestBackfill_UnknownTierCounted verifies that a document with an unrecognised
+// tier ("Platinum") is rejected by DecodeDocument and counted as an error,
+// not silently defaulted to Free.
+func TestBackfill_UnknownTierCounted(t *testing.T) {
+	t.Parallel()
+	bad := []byte(`{
+		"id":"auth0|ux","userId":"auth0|ux",
+		"pushEnabled":false,"digestDay":0,"zonePreferences":{},
+		"tier":"Platinum",
+		"lastActiveAt":"2026-06-26T12:00:00Z","lastActiveAtEpoch":1719403200000
+	}`)
+	pager := &fakeProfilePager{pages: [][][]byte{{bad}}}
+	store := &fakeProfileUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.errors != 1 || got.upserted != 0 {
+		t.Errorf("summary: got %+v, want errors=1 upserted=0", got)
+	}
+}
+
+// TestBackfill_CoalesceDefaultsPreserved verifies that a legacy document with
+// absent nullable-bool fields (emailDigestEnabled absent) decodes without error
+// (coalesceTrue path) and is saved correctly.
+func TestBackfill_CoalesceDefaultsPreserved(t *testing.T) {
+	t.Parallel()
+	legacy := []byte(`{
+		"id":"auth0|leg","userId":"auth0|leg",
+		"pushEnabled":false,"digestDay":0,"zonePreferences":{},
+		"tier":"Free",
+		"lastActiveAt":"2026-06-26T12:00:00Z","lastActiveAtEpoch":1719403200000
+	}`)
+	pager := &fakeProfilePager{pages: [][][]byte{{legacy}}}
+	store := &fakeProfileUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.upserted != 1 || got.errors != 0 {
+		t.Errorf("summary: got %+v, want upserted=1 errors=0", got)
+	}
+	if len(store.saved) != 1 {
+		t.Fatalf("saved %d profiles, want 1", len(store.saved))
+	}
+	if !store.saved[0].Preferences.EmailDigestEnabled {
+		t.Error("EmailDigestEnabled should coalesce to true for legacy document")
+	}
+}
+
+// TestBackfill_LogProgressEveryN verifies the logEvery cadence does not panic
+// and does not suppress records.
+func TestBackfill_LogProgressEveryN(t *testing.T) {
+	t.Parallel()
+
+	// 5 records, log every 2.
+	var docs [][]byte
+	for i := 0; i < 5; i++ {
+		docs = append(docs, rawProfileDoc("auth0|p"+string(rune('0'+i))))
+	}
+	pager := &fakeProfilePager{pages: [][][]byte{docs}}
+	store := &fakeProfileUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{logEvery: 2}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 5 || got.upserted != 5 {
+		t.Errorf("summary: got %+v, want read=5 upserted=5", got)
+	}
+}
+
+// Ensure the fake satisfies the interface at compile time.
+var _ profileUpserter = (*fakeProfileUpserter)(nil)

--- a/api-go/internal/platform/postgres/migrations/0006_users.sql
+++ b/api-go/internal/platform/postgres/migrations/0006_users.sql
@@ -1,0 +1,56 @@
+-- +goose Up
+
+-- users mirrors api-go/internal/profiles/document.go (profileDocument).
+-- Partition strategy: in Cosmos the Users container is partitioned by /id (== the
+-- Auth0 user id). In Postgres, user_id is the natural primary key — every /v1/me
+-- operation is a point read/write, and the admin scans are plain WHERE filters
+-- (email, digest_day, last_active_at_epoch, tier).
+--
+-- version is a monotonic optimistic-lock counter for the watch-zone quota CAS:
+-- UpdateZoneCountWithCAS does UPDATE ... WHERE user_id=$1 AND version=$expected
+-- and increments version on success. General Save calls preserve the existing
+-- version (version is excluded from the ON CONFLICT SET clause).
+--
+-- zone_preferences stores the per-zone notification channel settings as jsonb,
+-- mirroring the map[string]zonePreferencesDocument embedded in profileDocument.
+--
+-- Nullable columns follow the profileDocument pointer semantics:
+--   email_digest_enabled / saved_decision_* — NULL hydrates as true (opt-in
+--   default for legacy documents written before these fields existed; see
+--   coalesceTrue in document.go).
+--   email, original_transaction_id — absent until the field is set.
+--   subscription_expiry, grace_period_expiry — absent for Free tier.
+--   watch_zone_count — absent for legacy profiles (lazy-init on first quota use).
+--
+-- last_active_at_epoch is the numeric Unix-millisecond mirror of last_active_at.
+-- It is the dormant-scan filter column: the dormant query uses epoch because the
+-- timestamp string had two wire formats in Cosmos ("+00:00" and "Z") that do not
+-- sort lexicographically. The epoch is always derived from last_active_at.
+CREATE TABLE users (
+    user_id                     text        PRIMARY KEY,
+    email                       text,
+    push_enabled                boolean     NOT NULL,
+    digest_day                  int         NOT NULL,
+    email_digest_enabled        boolean,
+    saved_decision_push         boolean,
+    saved_decision_email        boolean,
+    zone_preferences            jsonb       NOT NULL DEFAULT '{}',
+    tier                        text        NOT NULL,
+    subscription_expiry         timestamptz,
+    original_transaction_id     text,
+    grace_period_expiry         timestamptz,
+    last_active_at              timestamptz NOT NULL,
+    last_active_at_epoch        bigint      NOT NULL,
+    watch_zone_count            int,
+    version                     int         NOT NULL DEFAULT 0
+);
+
+CREATE INDEX users_email                    ON users (email);
+CREATE INDEX users_original_transaction_id  ON users (original_transaction_id);
+CREATE INDEX users_digest_day               ON users (digest_day);
+CREATE INDEX users_last_active_at_epoch     ON users (last_active_at_epoch);
+CREATE INDEX users_tier                     ON users (tier);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS users;

--- a/api-go/internal/profiles/admin_store_postgres.go
+++ b/api-go/internal/profiles/admin_store_postgres.go
@@ -1,0 +1,243 @@
+package profiles
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// PostgresAdminStore serves the admin-surface's cross-user profile operations:
+// find-by-email, find-by-original-transaction-id, digest-day candidates,
+// dormant-account scan, lapsed-paid sweep, save (grant write-back), and the
+// paged user list. It is the Postgres counterpart of *AdminStore (Cosmos) and
+// shares the same AdminProfileStore interface.
+//
+// The querier type is defined in store_postgres.go (same package). Both
+// *pgxpool.Pool and pgx.Tx satisfy it structurally.
+type PostgresAdminStore struct {
+	db querier
+}
+
+// NewPostgresAdminStore returns an admin store over the given pgx pool (or any
+// querier).
+func NewPostgresAdminStore(db querier) *PostgresAdminStore {
+	return &PostgresAdminStore{db: db}
+}
+
+// collectUsers drains pgx.Rows into a []*UserProfile slice, scanning each row
+// with scanUserRow. It closes the rows on return and propagates Rows.Err().
+func collectUsers(rows pgx.Rows) ([]*UserProfile, error) {
+	defer rows.Close()
+	var profiles []*UserProfile
+	for rows.Next() {
+		p, _, err := scanUserRow(rows)
+		if err != nil {
+			return nil, err
+		}
+		profiles = append(profiles, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return profiles, nil
+}
+
+const pgAdminSelectCols = "SELECT " + userSelectCols + " FROM users "
+
+// GetByEmail returns the first profile whose email matches exactly, or
+// ErrNotFound. Mirrors AdminStore.GetByEmail.
+func (s *PostgresAdminStore) GetByEmail(ctx context.Context, email string) (*UserProfile, error) {
+	rows, err := s.db.Query(ctx, pgAdminSelectCols+"WHERE email = $1 LIMIT 1", email)
+	if err != nil {
+		return nil, fmt.Errorf("query profile by email: %w", err)
+	}
+	profiles, err := collectUsers(rows)
+	if err != nil {
+		return nil, fmt.Errorf("decode profile by email: %w", err)
+	}
+	if len(profiles) == 0 {
+		return nil, ErrNotFound
+	}
+	return profiles[0], nil
+}
+
+// GetByOriginalTransactionID returns the profile whose stored Apple original
+// transaction id matches, or ErrNotFound. The App Store Server Notification
+// webhook locates the subscriber by this cross-user lookup.
+func (s *PostgresAdminStore) GetByOriginalTransactionID(ctx context.Context, originalTransactionID string) (*UserProfile, error) {
+	rows, err := s.db.Query(ctx, pgAdminSelectCols+"WHERE original_transaction_id = $1 LIMIT 1", originalTransactionID)
+	if err != nil {
+		return nil, fmt.Errorf("query profile by original transaction id: %w", err)
+	}
+	profiles, err := collectUsers(rows)
+	if err != nil {
+		return nil, fmt.Errorf("decode profile by original transaction id: %w", err)
+	}
+	if len(profiles) == 0 {
+		return nil, ErrNotFound
+	}
+	return profiles[0], nil
+}
+
+// ByDigestDay returns every profile whose configured digest day matches day.
+// The digest day is stored as the int weekday value (Sunday=0 … Saturday=6).
+func (s *PostgresAdminStore) ByDigestDay(ctx context.Context, day time.Weekday) ([]*UserProfile, error) {
+	rows, err := s.db.Query(ctx, pgAdminSelectCols+"WHERE digest_day = $1", int(day))
+	if err != nil {
+		return nil, fmt.Errorf("query profiles by digest day: %w", err)
+	}
+	profiles, err := collectUsers(rows)
+	if err != nil {
+		return nil, fmt.Errorf("decode profiles by digest day: %w", err)
+	}
+	return profiles, nil
+}
+
+// Dormant returns every profile last active strictly before cutoff. The filter
+// runs server-side on last_active_at_epoch (the numeric Unix-millisecond
+// mirror) which sorts unambiguously — the Go-side LastActiveAt.Before(cutoff)
+// check below is the final authority and remains the same as the Cosmos store
+// (it guards against any residual clock drift or NULL epoch). Mirrors
+// AdminStore.Dormant exactly, including the server-side epoch pre-filter and
+// the Go-side strictly-before gate.
+func (s *PostgresAdminStore) Dormant(ctx context.Context, cutoff time.Time) ([]*UserProfile, error) {
+	rows, err := s.db.Query(ctx,
+		pgAdminSelectCols+"WHERE last_active_at_epoch < $1",
+		cutoff.UnixMilli())
+	if err != nil {
+		return nil, fmt.Errorf("query dormant profiles: %w", err)
+	}
+	candidates, err := collectUsers(rows)
+	if err != nil {
+		return nil, fmt.Errorf("decode dormant profiles: %w", err)
+	}
+	dormant := make([]*UserProfile, 0, len(candidates))
+	for _, p := range candidates {
+		if p.LastActiveAt.Before(cutoff) {
+			dormant = append(dormant, p)
+		}
+	}
+	return dormant, nil
+}
+
+// LapsedPaid returns every profile whose stored tier is paid but whose
+// entitlement has lapsed at now — i.e. EffectiveTier(now) has collapsed to
+// Free. Mirrors AdminStore.LapsedPaid exactly: load paid-tier candidates
+// server-side (WHERE tier != 'Free'), then filter in Go with the domain rule
+// so the expiry/grace-period logic is never re-expressed in SQL.
+func (s *PostgresAdminStore) LapsedPaid(ctx context.Context, now time.Time) ([]*UserProfile, error) {
+	rows, err := s.db.Query(ctx, pgAdminSelectCols+"WHERE tier != 'Free'")
+	if err != nil {
+		return nil, fmt.Errorf("query lapsed paid profiles: %w", err)
+	}
+	candidates, err := collectUsers(rows)
+	if err != nil {
+		return nil, fmt.Errorf("decode lapsed paid profiles: %w", err)
+	}
+	lapsed := make([]*UserProfile, 0)
+	for _, p := range candidates {
+		if p.Tier.IsPaid() && p.EffectiveTier(now) == TierFree {
+			lapsed = append(lapsed, p)
+		}
+	}
+	return lapsed, nil
+}
+
+// Save upserts the profile (same SQL as PostgresStore.Save). Used by the
+// subscription sweep and admin grant endpoint as the write-back path.
+func (s *PostgresAdminStore) Save(ctx context.Context, p *UserProfile) error {
+	zonePrefText, err := marshalZonePrefs(p.ZonePreferences)
+	if err != nil {
+		return fmt.Errorf("encode zone_preferences for %q: %w", p.UserID, err)
+	}
+	emailDigest := p.Preferences.EmailDigestEnabled
+	savedPush := p.Preferences.SavedDecisionPush
+	savedEmail := p.Preferences.SavedDecisionEmail
+	_, err = s.db.Exec(ctx, pgSaveUserQuery,
+		p.UserID, p.Email, p.Preferences.PushEnabled, int(p.Preferences.DigestDay),
+		&emailDigest, &savedPush, &savedEmail, zonePrefText,
+		p.Tier.String(), p.SubscriptionExpiry, p.OriginalTransactionID, p.GracePeriodExpiry,
+		p.LastActiveAt, p.LastActiveAt.UnixMilli(), p.WatchZoneCount,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert profile %q (admin): %w", p.UserID, err)
+	}
+	return nil
+}
+
+// listCursor is the keyset pagination cursor for List. It encodes the last
+// user_id seen on the previous page as a base64url string so it is opaque to
+// callers — matching the Cosmos continuation-token contract.
+type listCursor struct {
+	LastUserID string
+}
+
+func encodeListCursor(lastUserID string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(lastUserID))
+}
+
+func decodeListCursor(token string) (string, error) {
+	b, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return "", fmt.Errorf("decode list cursor: %w", err)
+	}
+	return string(b), nil
+}
+
+// List returns one page of profiles ordered by user_id, optionally filtered
+// by a case-insensitive email substring. An empty continuationToken starts
+// from the first page; a non-empty token resumes after the last user_id from
+// the previous page. Mirrors AdminStore.List's contract (Page + opaque token).
+func (s *PostgresAdminStore) List(ctx context.Context, emailSearch string, pageSize int, continuationToken string) (Page, error) {
+	var lastUserID string
+	if continuationToken != "" {
+		var err error
+		lastUserID, err = decodeListCursor(continuationToken)
+		if err != nil {
+			return Page{}, fmt.Errorf("list profiles: %w", err)
+		}
+	}
+
+	// Build the WHERE clause from the two optional predicates.
+	// We always add at least the cursor guard when paging; on the first page
+	// (empty cursor) we still ORDER BY user_id so the cursor is meaningful.
+	var (
+		sql  string
+		args []any
+	)
+	switch {
+	case emailSearch != "" && lastUserID != "":
+		sql = pgAdminSelectCols + "WHERE email ILIKE $1 AND user_id > $2 ORDER BY user_id LIMIT $3"
+		args = []any{"%" + emailSearch + "%", lastUserID, pageSize}
+	case emailSearch != "":
+		sql = pgAdminSelectCols + "WHERE email ILIKE $1 ORDER BY user_id LIMIT $2"
+		args = []any{"%" + emailSearch + "%", pageSize}
+	case lastUserID != "":
+		sql = pgAdminSelectCols + "WHERE user_id > $1 ORDER BY user_id LIMIT $2"
+		args = []any{lastUserID, pageSize}
+	default:
+		sql = pgAdminSelectCols + "ORDER BY user_id LIMIT $1"
+		args = []any{pageSize}
+	}
+
+	rows, err := s.db.Query(ctx, sql, args...)
+	if err != nil {
+		return Page{}, fmt.Errorf("list profiles: %w", err)
+	}
+	profiles, err := collectUsers(rows)
+	if err != nil {
+		return Page{}, fmt.Errorf("list profiles: decode: %w", err)
+	}
+
+	// Emit a continuation token only when we got a full page — an undersized
+	// page means we reached the end.
+	nextToken := ""
+	if len(profiles) == pageSize {
+		nextToken = encodeListCursor(profiles[len(profiles)-1].UserID)
+	}
+
+	return Page{Profiles: profiles, ContinuationToken: nextToken}, nil
+}

--- a/api-go/internal/profiles/decode.go
+++ b/api-go/internal/profiles/decode.go
@@ -1,0 +1,24 @@
+package profiles
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DecodeDocument hydrates a stored Users-container document body into a domain
+// UserProfile, reusing the exact field mapping the Cosmos read path uses
+// (profileDocument.toDomain). It exists so the Cosmos → Postgres users backfill
+// (cmd/pgbackfill-users) shares one transform with the store rather than
+// reinventing the mapping, which keeps the two from silently diverging.
+//
+// The nullable preference flags (emailDigestEnabled / savedDecision*) coalesce
+// to true when absent — the opt-in default for documents written before these
+// fields existed. An unrecognised tier string is rejected with an error rather
+// than silently defaulted.
+func DecodeDocument(raw []byte) (*UserProfile, error) {
+	var doc profileDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("decode profile document: %w", err)
+	}
+	return doc.toDomain()
+}

--- a/api-go/internal/profiles/decode_test.go
+++ b/api-go/internal/profiles/decode_test.go
@@ -1,0 +1,110 @@
+package profiles
+
+import (
+	"testing"
+)
+
+// TestDecodeDocument_Valid hydrates a well-formed Cosmos Users-container
+// document into a domain UserProfile, exercising the field-mapping that the
+// backfill shares with the read path.
+func TestDecodeDocument_Valid(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{
+		"id": "auth0|u1",
+		"userId": "auth0|u1",
+		"email": "alice@example.com",
+		"pushEnabled": true,
+		"digestDay": 1,
+		"emailDigestEnabled": false,
+		"savedDecisionPush": true,
+		"savedDecisionEmail": false,
+		"zonePreferences": {
+			"zone-1": {"newApplicationPush": true, "newApplicationEmail": false, "decisionPush": true, "decisionEmail": false}
+		},
+		"tier": "Free",
+		"lastActiveAt": "2026-06-26T12:00:00Z",
+		"lastActiveAtEpoch": 1719403200000
+	}`)
+
+	p, err := DecodeDocument(raw)
+	if err != nil {
+		t.Fatalf("DecodeDocument: %v", err)
+	}
+	if p.UserID != "auth0|u1" {
+		t.Errorf("UserID = %q, want %q", p.UserID, "auth0|u1")
+	}
+	if p.Email == nil || *p.Email != "alice@example.com" {
+		t.Errorf("Email = %v, want alice@example.com", p.Email)
+	}
+	if p.Preferences.PushEnabled != true {
+		t.Errorf("PushEnabled = %v, want true", p.Preferences.PushEnabled)
+	}
+	if p.Preferences.EmailDigestEnabled != false {
+		t.Errorf("EmailDigestEnabled = %v, want false (explicitly false, not absent)", p.Preferences.EmailDigestEnabled)
+	}
+	if p.Tier != TierFree {
+		t.Errorf("Tier = %v, want TierFree", p.Tier)
+	}
+	if len(p.ZonePreferences) != 1 {
+		t.Errorf("ZonePreferences len = %d, want 1", len(p.ZonePreferences))
+	}
+}
+
+// TestDecodeDocument_CoalesceTrue verifies the opt-in default: a document
+// written before emailDigestEnabled existed (absent / null) hydrates as true
+// rather than the Go zero-value false (coalesceTrue, bead tc-hpd2.8).
+func TestDecodeDocument_CoalesceTrue(t *testing.T) {
+	t.Parallel()
+	// No emailDigestEnabled / savedDecision* fields → must coalesce to true.
+	raw := []byte(`{
+		"id": "auth0|u2",
+		"userId": "auth0|u2",
+		"pushEnabled": false,
+		"digestDay": 0,
+		"zonePreferences": {},
+		"tier": "Free",
+		"lastActiveAt": "2026-06-26T12:00:00Z",
+		"lastActiveAtEpoch": 1719403200000
+	}`)
+
+	p, err := DecodeDocument(raw)
+	if err != nil {
+		t.Fatalf("DecodeDocument: %v", err)
+	}
+	if !p.Preferences.EmailDigestEnabled {
+		t.Error("EmailDigestEnabled should coalesce to true when absent")
+	}
+	if !p.Preferences.SavedDecisionPush {
+		t.Error("SavedDecisionPush should coalesce to true when absent")
+	}
+	if !p.Preferences.SavedDecisionEmail {
+		t.Error("SavedDecisionEmail should coalesce to true when absent")
+	}
+}
+
+// TestDecodeDocument_InvalidJSON confirms that malformed JSON returns an error.
+func TestDecodeDocument_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	if _, err := DecodeDocument([]byte("not json")); err == nil {
+		t.Fatal("DecodeDocument: want error for invalid JSON, got nil")
+	}
+}
+
+// TestDecodeDocument_UnknownTier confirms that an unrecognised tier string
+// returns an error rather than silently defaulting.
+func TestDecodeDocument_UnknownTier(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`{
+		"id": "auth0|u3",
+		"userId": "auth0|u3",
+		"pushEnabled": false,
+		"digestDay": 0,
+		"zonePreferences": {},
+		"tier": "Platinum",
+		"lastActiveAt": "2026-06-26T12:00:00Z",
+		"lastActiveAtEpoch": 1719403200000
+	}`)
+	if _, err := DecodeDocument(raw); err == nil {
+		t.Fatal("DecodeDocument: want error for unknown tier, got nil")
+	}
+}

--- a/api-go/internal/profiles/store_postgres.go
+++ b/api-go/internal/profiles/store_postgres.go
@@ -1,0 +1,365 @@
+package profiles
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// querier is the consumer-side slice of *pgxpool.Pool the store uses:
+// parameterised exec/query/query-row. Defining it here (not importing pgxpool)
+// keeps the store decoupled from the concrete pool and lets a pgx.Tx stand in.
+// Both *pgxpool.Pool and pgx.Tx satisfy it structurally.
+type querier interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// errCASPreconditionFailed is the sentinel returned by UpdateZoneCountWithCAS
+// when the conditional UPDATE matches zero rows (the version guard fired,
+// meaning a concurrent writer won the race). It is identical to
+// platform.ErrCASPreconditionFailed so the watchzones quota CAS handler can
+// branch on a single errors.Is check regardless of which backend is wired.
+//
+// Note: this is NOT a re-declaration. The Postgres store re-uses the platform
+// sentinel directly so callers need not know which backend produced the error.
+var errCASPreconditionFailed = platform.ErrCASPreconditionFailed
+
+// Store is the full point-store method set that both *CosmosStore and
+// *PostgresStore must satisfy. It serves as the compile-time parity check (a
+// Postgres port can never silently diverge from the Cosmos surface) and as the
+// exported consumer-side interface the later wiring slice uses to flag-select
+// between backends.
+//
+// The set covers:
+//   - the profileStore interface in handler.go (Get/Save/Delete)
+//   - the profileCAS interface in watchzones/handler.go (GetWithETag/UpdateZoneCountWithCAS)
+//   - erasure.ProfileDeleter (Delete)
+//   - middleware adapters NewTierLookup/NewActivityRecorder (Get/Save)
+type Store interface {
+	Get(ctx context.Context, userID string) (*UserProfile, error)
+	Save(ctx context.Context, p *UserProfile) error
+	Delete(ctx context.Context, userID string) error
+	GetWithETag(ctx context.Context, userID string) (*UserProfile, string, error)
+	UpdateZoneCountWithCAS(ctx context.Context, userID string, p *UserProfile, etag string) error
+}
+
+// AdminProfileStore is the full admin-store method set that both *AdminStore
+// and *PostgresAdminStore must satisfy. It serves the same parity and
+// flag-selection role as Store for the cross-partition / cross-user surface.
+type AdminProfileStore interface {
+	GetByEmail(ctx context.Context, email string) (*UserProfile, error)
+	GetByOriginalTransactionID(ctx context.Context, originalTransactionID string) (*UserProfile, error)
+	ByDigestDay(ctx context.Context, day time.Weekday) ([]*UserProfile, error)
+	Dormant(ctx context.Context, cutoff time.Time) ([]*UserProfile, error)
+	LapsedPaid(ctx context.Context, now time.Time) ([]*UserProfile, error)
+	Save(ctx context.Context, p *UserProfile) error
+	List(ctx context.Context, emailSearch string, pageSize int, continuationToken string) (Page, error)
+}
+
+// Compile-time parity: both stores must satisfy the same exported interfaces.
+// If a new method is added to either store, the corresponding interface and the
+// other store must be updated in the same change — the compiler enforces this.
+var (
+	_ Store = (*CosmosStore)(nil)
+	_ Store = (*PostgresStore)(nil)
+
+	_ AdminProfileStore = (*AdminStore)(nil)
+	_ AdminProfileStore = (*PostgresAdminStore)(nil)
+)
+
+// PostgresStore reads and writes user profiles in the Postgres `users` table
+// (Cosmos → Postgres + PostGIS migration; memo 0010, epic #645). It is a
+// parallel implementation: the Cosmos store remains wired until the backend
+// flag flips, so nothing here is on a live path yet.
+//
+// Partition strategy: user_id is the natural primary key — every /v1/me
+// operation is a single-row point read/write. Cross-user scans (digest sweep,
+// dormant check) are in PostgresAdminStore.
+//
+// CAS: the version column is a monotonic optimistic-lock counter.
+// UpdateZoneCountWithCAS issues UPDATE ... WHERE user_id=$1 AND version=$n and
+// increments version on success. Zero rows affected → ErrCASPreconditionFailed.
+type PostgresStore struct {
+	db querier
+}
+
+// NewPostgresStore returns a store over the given pgx pool (or any querier).
+func NewPostgresStore(db querier) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+// userSelectCols is the column list for SELECT queries. Order MUST match the
+// scan destinations in scanUserRow.
+const userSelectCols = `user_id, email, push_enabled, digest_day,
+	email_digest_enabled, saved_decision_push, saved_decision_email,
+	zone_preferences::text,
+	tier, subscription_expiry, original_transaction_id, grace_period_expiry,
+	last_active_at, last_active_at_epoch, watch_zone_count, version`
+
+// rowScanner is the minimal interface that both pgx.Row (returned by QueryRow)
+// and pgx.Rows (returned by Query, positioned via Next) satisfy. Defining it
+// here lets scanUserRow serve both point-reads (PostgresStore.Get,
+// GetWithETag) and collection scans (collectUsers in admin_store_postgres.go)
+// without a concrete adapter type.
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+// scanUserRow scans one row from the users table into a UserProfile plus the
+// raw version integer. zone_preferences is cast to text on the wire so pgx
+// delivers it as a plain string we can unmarshal; all nullable columns scan
+// into pointer types.
+func scanUserRow(row rowScanner) (*UserProfile, int, error) {
+	var (
+		userID, tier, zonePrefText   string
+		email, originalTransactionID *string
+		pushEnabled                  bool
+		digestDay                    int
+		emailDigestEnabled           *bool
+		savedDecisionPush            *bool
+		savedDecisionEmail           *bool
+		subscriptionExpiry           *time.Time
+		gracePeriodExpiry            *time.Time
+		lastActiveAt                 time.Time
+		lastActiveAtEpoch            int64
+		watchZoneCount               *int
+		version                      int
+	)
+
+	if err := row.Scan(
+		&userID, &email, &pushEnabled, &digestDay,
+		&emailDigestEnabled, &savedDecisionPush, &savedDecisionEmail,
+		&zonePrefText,
+		&tier, &subscriptionExpiry, &originalTransactionID, &gracePeriodExpiry,
+		&lastActiveAt, &lastActiveAtEpoch, &watchZoneCount, &version,
+	); err != nil {
+		return nil, 0, err
+	}
+
+	t, err := ParseSubscriptionTier(tier)
+	if err != nil {
+		return nil, 0, fmt.Errorf("parse tier %q: %w", tier, err)
+	}
+
+	zones, err := unmarshalZonePrefs(zonePrefText)
+	if err != nil {
+		return nil, 0, fmt.Errorf("unmarshal zone_preferences: %w", err)
+	}
+
+	p := &UserProfile{
+		UserID: userID,
+		Email:  email,
+		Preferences: NotificationPreferences{
+			PushEnabled:        pushEnabled,
+			DigestDay:          time.Weekday(digestDay),
+			EmailDigestEnabled: coalesceTrue(emailDigestEnabled),
+			SavedDecisionPush:  coalesceTrue(savedDecisionPush),
+			SavedDecisionEmail: coalesceTrue(savedDecisionEmail),
+		},
+		ZonePreferences:       zones,
+		Tier:                  t,
+		SubscriptionExpiry:    subscriptionExpiry,
+		OriginalTransactionID: originalTransactionID,
+		GracePeriodExpiry:     gracePeriodExpiry,
+		LastActiveAt:          lastActiveAt,
+		WatchZoneCount:        watchZoneCount,
+	}
+	return p, version, nil
+}
+
+// unmarshalZonePrefs decodes the zone_preferences JSON text from the database
+// into the domain ZonePreferences map. An empty string (or "{}") produces an
+// empty map, never nil.
+func unmarshalZonePrefs(text string) (map[string]ZonePreferences, error) {
+	zones := make(map[string]ZonePreferences)
+	if text == "" || text == "{}" {
+		return zones, nil
+	}
+	var docs map[string]zonePreferencesDocument
+	if err := json.Unmarshal([]byte(text), &docs); err != nil {
+		return nil, err
+	}
+	for id, d := range docs {
+		zones[id] = ZonePreferences(d)
+	}
+	return zones, nil
+}
+
+// marshalZonePrefs encodes the domain ZonePreferences map to a JSON string
+// suitable for passing as a parameter with ::jsonb cast.
+func marshalZonePrefs(zones map[string]ZonePreferences) (string, error) {
+	if len(zones) == 0 {
+		return "{}", nil
+	}
+	docs := make(map[string]zonePreferencesDocument, len(zones))
+	for id, z := range zones {
+		docs[id] = zonePreferencesDocument(z)
+	}
+	b, err := json.Marshal(docs)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+const pgGetUserQuery = "SELECT " + userSelectCols + " FROM users WHERE user_id = $1"
+
+// Get point-reads the profile for userID. A miss surfaces as ErrNotFound;
+// any other failure is wrapped and returned.
+func (s *PostgresStore) Get(ctx context.Context, userID string) (*UserProfile, error) {
+	p, _, err := scanUserRow(s.db.QueryRow(ctx, pgGetUserQuery, userID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read profile %q: %w", userID, err)
+	}
+	return p, nil
+}
+
+const pgSaveUserQuery = `
+INSERT INTO users (
+	user_id, email, push_enabled, digest_day,
+	email_digest_enabled, saved_decision_push, saved_decision_email, zone_preferences,
+	tier, subscription_expiry, original_transaction_id, grace_period_expiry,
+	last_active_at, last_active_at_epoch, watch_zone_count, version
+) VALUES (
+	$1, $2, $3, $4, $5, $6, $7, $8::jsonb,
+	$9, $10, $11, $12, $13, $14, $15, 0
+)
+ON CONFLICT (user_id) DO UPDATE SET
+	email                   = EXCLUDED.email,
+	push_enabled            = EXCLUDED.push_enabled,
+	digest_day              = EXCLUDED.digest_day,
+	email_digest_enabled    = EXCLUDED.email_digest_enabled,
+	saved_decision_push     = EXCLUDED.saved_decision_push,
+	saved_decision_email    = EXCLUDED.saved_decision_email,
+	zone_preferences        = EXCLUDED.zone_preferences,
+	tier                    = EXCLUDED.tier,
+	subscription_expiry     = EXCLUDED.subscription_expiry,
+	original_transaction_id = EXCLUDED.original_transaction_id,
+	grace_period_expiry     = EXCLUDED.grace_period_expiry,
+	last_active_at          = EXCLUDED.last_active_at,
+	last_active_at_epoch    = EXCLUDED.last_active_at_epoch,
+	watch_zone_count        = EXCLUDED.watch_zone_count`
+
+// Save upserts the profile. On conflict (existing user) the version column is
+// deliberately NOT updated — only UpdateZoneCountWithCAS advances the version.
+// A new row starts at version 0 (the column default).
+func (s *PostgresStore) Save(ctx context.Context, p *UserProfile) error {
+	zonePrefText, err := marshalZonePrefs(p.ZonePreferences)
+	if err != nil {
+		return fmt.Errorf("encode zone_preferences for %q: %w", p.UserID, err)
+	}
+	emailDigest := p.Preferences.EmailDigestEnabled
+	savedPush := p.Preferences.SavedDecisionPush
+	savedEmail := p.Preferences.SavedDecisionEmail
+	_, err = s.db.Exec(ctx, pgSaveUserQuery,
+		p.UserID, p.Email, p.Preferences.PushEnabled, int(p.Preferences.DigestDay),
+		&emailDigest, &savedPush, &savedEmail, zonePrefText,
+		p.Tier.String(), p.SubscriptionExpiry, p.OriginalTransactionID, p.GracePeriodExpiry,
+		p.LastActiveAt, p.LastActiveAt.UnixMilli(), p.WatchZoneCount,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert profile %q: %w", p.UserID, err)
+	}
+	return nil
+}
+
+const pgDeleteUserQuery = "DELETE FROM users WHERE user_id = $1"
+
+// Delete removes the profile document. Zero rows affected surfaces as
+// ErrNotFound, matching the Cosmos store's contract (callers may treat a
+// missing profile as tolerable or fatal depending on context).
+func (s *PostgresStore) Delete(ctx context.Context, userID string) error {
+	tag, err := s.db.Exec(ctx, pgDeleteUserQuery, userID)
+	if err != nil {
+		return fmt.Errorf("delete profile %q: %w", userID, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// GetWithETag reads the profile and its current optimistic version as an etag
+// string. Returns (nil, "", nil) when the profile does not exist — the
+// watchzones quota CAS caller treats an absent profile as a benign no-op.
+func (s *PostgresStore) GetWithETag(ctx context.Context, userID string) (*UserProfile, string, error) {
+	p, version, err := scanUserRow(s.db.QueryRow(ctx, pgGetUserQuery, userID))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, "", nil
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("read profile %q with etag: %w", userID, err)
+	}
+	return p, strconv.Itoa(version), nil
+}
+
+const pgUpdateZoneCountCASQuery = `
+UPDATE users SET
+	email                   = $2,
+	push_enabled            = $3,
+	digest_day              = $4,
+	email_digest_enabled    = $5,
+	saved_decision_push     = $6,
+	saved_decision_email    = $7,
+	zone_preferences        = $8::jsonb,
+	tier                    = $9,
+	subscription_expiry     = $10,
+	original_transaction_id = $11,
+	grace_period_expiry     = $12,
+	last_active_at          = $13,
+	last_active_at_epoch    = $14,
+	watch_zone_count        = $15,
+	version                 = version + 1
+WHERE user_id = $1 AND version = $16`
+
+// UpdateZoneCountWithCAS replaces the profile row only when the stored version
+// matches the expected version encoded in etag. The version is atomically
+// incremented on success.
+//
+// Zero rows affected (version guard fired — concurrent writer won) returns
+// platform.ErrCASPreconditionFailed wrapped via %w, identical to the Cosmos
+// store's contract so the watchzones quota handler can branch on a single
+// errors.Is check regardless of which backend is active.
+func (s *PostgresStore) UpdateZoneCountWithCAS(ctx context.Context, userID string, p *UserProfile, etag string) error {
+	expectedVersion, err := strconv.Atoi(etag)
+	if err != nil {
+		return fmt.Errorf("parse CAS etag %q for profile %q: %w", etag, userID, err)
+	}
+
+	zonePrefText, err := marshalZonePrefs(p.ZonePreferences)
+	if err != nil {
+		return fmt.Errorf("encode zone_preferences for CAS update of %q: %w", userID, err)
+	}
+	emailDigest := p.Preferences.EmailDigestEnabled
+	savedPush := p.Preferences.SavedDecisionPush
+	savedEmail := p.Preferences.SavedDecisionEmail
+
+	tag, err := s.db.Exec(ctx, pgUpdateZoneCountCASQuery,
+		userID,
+		p.Email, p.Preferences.PushEnabled, int(p.Preferences.DigestDay),
+		&emailDigest, &savedPush, &savedEmail, zonePrefText,
+		p.Tier.String(), p.SubscriptionExpiry, p.OriginalTransactionID, p.GracePeriodExpiry,
+		p.LastActiveAt, p.LastActiveAt.UnixMilli(), p.WatchZoneCount,
+		expectedVersion,
+	)
+	if err != nil {
+		return fmt.Errorf("CAS update profile %q: %w", userID, err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("CAS update profile %q: %w", userID, errCASPreconditionFailed)
+	}
+	return nil
+}

--- a/api-go/internal/profiles/store_postgres_integration_test.go
+++ b/api-go/internal/profiles/store_postgres_integration_test.go
@@ -1,0 +1,552 @@
+//go:build integration
+
+package profiles
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// newUserPGStore returns a PostgresStore and PostgresAdminStore backed by a
+// freshly truncated test database. Integration tests must NOT call t.Parallel:
+// pgtest.New holds a session-level advisory lock for mutual exclusion.
+func newUserPGStore(t *testing.T) (*PostgresStore, *PostgresAdminStore) {
+	t.Helper()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "users")
+	return NewPostgresStore(pool), NewPostgresAdminStore(pool)
+}
+
+// pgProfile builds a deterministic UserProfile for test seeding. It creates a
+// profile with a fixed active-at time so dormant/lapsed assertions are stable.
+func pgProfile(t *testing.T, userID, email string) *UserProfile {
+	t.Helper()
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	p, err := NewProfile(userID, email, now)
+	if err != nil {
+		t.Fatalf("NewProfile(%s): %v", userID, err)
+	}
+	return p
+}
+
+// assertProfileEqual compares two profiles field-by-field, zeroing timestamps
+// to microsecond precision (Postgres timestamptz truncates sub-µs).
+func assertProfileEqual(t *testing.T, got, want *UserProfile) {
+	t.Helper()
+	// Round trip: Postgres timestamptz is µs precision; Go time.Time may carry ns.
+	g, w := *got, *want
+	g.LastActiveAt = got.LastActiveAt.UTC().Truncate(time.Microsecond)
+	w.LastActiveAt = want.LastActiveAt.UTC().Truncate(time.Microsecond)
+	if !reflect.DeepEqual(g, w) {
+		t.Errorf("profile mismatch:\n got = %+v\nwant = %+v", g, w)
+	}
+}
+
+// TestPostgresStore_SaveGetRoundTrip writes a profile and reads it back,
+// asserting all fields survive the Postgres round-trip unchanged.
+func TestPostgresStore_SaveGetRoundTrip(t *testing.T) {
+	store, _ := newUserPGStore(t)
+	ctx := context.Background()
+
+	p := pgProfile(t, "auth0|rt1", "alice@example.com")
+	one := 1
+	p.WatchZoneCount = &one
+	p.ZonePreferences = map[string]ZonePreferences{
+		"zone-abc": {NewApplicationPush: true, NewApplicationEmail: false, DecisionPush: true, DecisionEmail: false},
+	}
+
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.Get(ctx, p.UserID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	assertProfileEqual(t, got, p)
+}
+
+// TestPostgresStore_Get_Miss confirms a missing profile returns ErrNotFound.
+func TestPostgresStore_Get_Miss(t *testing.T) {
+	store, _ := newUserPGStore(t)
+
+	_, err := store.Get(context.Background(), "auth0|nobody")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get miss: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestPostgresStore_Delete_Miss confirms that deleting a non-existent profile
+// returns ErrNotFound.
+func TestPostgresStore_Delete_Miss(t *testing.T) {
+	store, _ := newUserPGStore(t)
+
+	err := store.Delete(context.Background(), "auth0|nobody")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Delete miss: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestPostgresStore_Delete_Removes verifies that a saved profile is gone after
+// Delete and that Get then returns ErrNotFound.
+func TestPostgresStore_Delete_Removes(t *testing.T) {
+	store, _ := newUserPGStore(t)
+	ctx := context.Background()
+
+	p := pgProfile(t, "auth0|del1", "bob@example.com")
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := store.Delete(ctx, p.UserID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := store.Get(ctx, p.UserID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("post-Delete Get: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestPostgresStore_GetWithETag_Miss confirms that GetWithETag for a missing
+// profile returns (nil, "", nil) — the watch-zone quota handler treats absence
+// as a benign no-op.
+func TestPostgresStore_GetWithETag_Miss(t *testing.T) {
+	store, _ := newUserPGStore(t)
+
+	got, etag, err := store.GetWithETag(context.Background(), "auth0|nobody")
+	if err != nil {
+		t.Fatalf("GetWithETag miss: got error %v, want nil", err)
+	}
+	if got != nil {
+		t.Errorf("GetWithETag miss: profile = %v, want nil", got)
+	}
+	if etag != "" {
+		t.Errorf("GetWithETag miss: etag = %q, want empty", etag)
+	}
+}
+
+// TestPostgresStore_GetWithETag_Present verifies that GetWithETag returns the
+// profile and a non-empty, parseable etag for an existing profile. A new row
+// always starts at version 0 so the etag should be "0".
+func TestPostgresStore_GetWithETag_Present(t *testing.T) {
+	store, _ := newUserPGStore(t)
+	ctx := context.Background()
+
+	p := pgProfile(t, "auth0|etag1", "carol@example.com")
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, etag, err := store.GetWithETag(ctx, p.UserID)
+	if err != nil {
+		t.Fatalf("GetWithETag: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetWithETag: profile is nil")
+	}
+	if etag == "" {
+		t.Fatal("GetWithETag: etag is empty")
+	}
+	// New row starts at version 0.
+	if etag != "0" {
+		t.Errorf("GetWithETag: etag = %q, want \"0\"", etag)
+	}
+}
+
+// TestPostgresStore_UpdateZoneCountWithCAS_Success verifies the happy path:
+// a matching version succeeds and the version increments (etag changes).
+func TestPostgresStore_UpdateZoneCountWithCAS_Success(t *testing.T) {
+	store, _ := newUserPGStore(t)
+	ctx := context.Background()
+
+	p := pgProfile(t, "auth0|cas1", "dave@example.com")
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	_, etag, err := store.GetWithETag(ctx, p.UserID)
+	if err != nil {
+		t.Fatalf("GetWithETag: %v", err)
+	}
+
+	one := 1
+	p.WatchZoneCount = &one
+	if err := store.UpdateZoneCountWithCAS(ctx, p.UserID, p, etag); err != nil {
+		t.Fatalf("UpdateZoneCountWithCAS: %v", err)
+	}
+
+	_, newEtag, err := store.GetWithETag(ctx, p.UserID)
+	if err != nil {
+		t.Fatalf("GetWithETag after CAS: %v", err)
+	}
+	if newEtag == etag {
+		t.Errorf("etag unchanged after CAS success: still %q", etag)
+	}
+}
+
+// TestPostgresStore_CASRaceProof is the required concurrency proof: two
+// goroutines each attempt UpdateZoneCountWithCAS with the same etag; exactly
+// one succeeds and the other gets ErrCASPreconditionFailed. This test directly
+// exercises the optimistic-lock mechanism that the watch-zone quota handler
+// relies on to prevent double-counting.
+func TestPostgresStore_CASRaceProof(t *testing.T) {
+	store, _ := newUserPGStore(t)
+	ctx := context.Background()
+
+	p := pgProfile(t, "auth0|race1", "eve@example.com")
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	_, etag, err := store.GetWithETag(ctx, p.UserID)
+	if err != nil {
+		t.Fatalf("GetWithETag: %v", err)
+	}
+
+	// Both goroutines fire UpdateZoneCountWithCAS concurrently with the same etag.
+	// Exactly one must succeed; the other must return ErrCASPreconditionFailed.
+	var (
+		wg        sync.WaitGroup
+		mu        sync.Mutex
+		successes int
+		casErrs   int
+		otherErrs []error
+	)
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			one := 1
+			cp := *p
+			cp.WatchZoneCount = &one
+			err := store.UpdateZoneCountWithCAS(ctx, p.UserID, &cp, etag)
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case err == nil:
+				successes++
+			case errors.Is(err, platform.ErrCASPreconditionFailed):
+				casErrs++
+			default:
+				otherErrs = append(otherErrs, err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if len(otherErrs) > 0 {
+		t.Fatalf("unexpected errors from CAS race: %v", otherErrs)
+	}
+	if successes != 1 {
+		t.Errorf("CAS race: %d successes, want exactly 1", successes)
+	}
+	if casErrs != 1 {
+		t.Errorf("CAS race: %d precondition failures, want exactly 1", casErrs)
+	}
+}
+
+// TestPostgresStore_LegacyCoalesceRoundTrip verifies the opt-in default: when
+// email_digest_enabled / saved_decision_* are inserted as NULL (legacy profile
+// written before these fields existed), they read back as true.
+func TestPostgresStore_LegacyCoalesceRoundTrip(t *testing.T) {
+	store, _ := newUserPGStore(t)
+	ctx := context.Background()
+
+	// Directly INSERT a row with NULL nullable-bool columns, bypassing Save
+	// (which always writes non-null booleans). This exercises the coalesceTrue
+	// logic in scanUserRow for real rows — the precise scenario DecodeDocument
+	// handles when backfilling legacy Cosmos documents.
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	_, err := store.db.Exec(ctx, `
+		INSERT INTO users (
+			user_id, push_enabled, digest_day,
+			email_digest_enabled, saved_decision_push, saved_decision_email,
+			zone_preferences, tier, last_active_at, last_active_at_epoch
+		) VALUES (
+			$1, true, 1,
+			NULL, NULL, NULL,
+			'{}', 'Free', $2, $3
+		)`,
+		"auth0|legacy1", now, now.UnixMilli(),
+	)
+	if err != nil {
+		t.Fatalf("INSERT legacy row: %v", err)
+	}
+
+	got, err := store.Get(ctx, "auth0|legacy1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.Preferences.EmailDigestEnabled {
+		t.Error("EmailDigestEnabled: got false, want true (NULL should coalesce to true)")
+	}
+	if !got.Preferences.SavedDecisionPush {
+		t.Error("SavedDecisionPush: got false, want true (NULL should coalesce to true)")
+	}
+	if !got.Preferences.SavedDecisionEmail {
+		t.Error("SavedDecisionEmail: got false, want true (NULL should coalesce to true)")
+	}
+}
+
+// ---- Admin store integration tests ----
+
+// TestPostgresAdminStore_GetByEmail verifies point-read by email address and
+// ErrNotFound for a non-existent email.
+func TestPostgresAdminStore_GetByEmail(t *testing.T) {
+	store, admin := newUserPGStore(t)
+	ctx := context.Background()
+
+	p := pgProfile(t, "auth0|adm1", "frank@example.com")
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := admin.GetByEmail(ctx, "frank@example.com")
+	if err != nil {
+		t.Fatalf("GetByEmail: %v", err)
+	}
+	if got.UserID != p.UserID {
+		t.Errorf("GetByEmail: got userID %q, want %q", got.UserID, p.UserID)
+	}
+
+	_, err = admin.GetByEmail(ctx, "nobody@example.com")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetByEmail miss: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestPostgresAdminStore_GetByOriginalTransactionID verifies lookup by Apple
+// transaction id and ErrNotFound for a missing id.
+func TestPostgresAdminStore_GetByOriginalTransactionID(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "users")
+	store := NewPostgresStore(pool)
+	admin := NewPostgresAdminStore(pool)
+	ctx := context.Background()
+
+	p := pgProfile(t, "auth0|adm2", "grace@example.com")
+	txID := "orig-tx-999"
+	p.OriginalTransactionID = &txID
+	if err := store.Save(ctx, p); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := admin.GetByOriginalTransactionID(ctx, txID)
+	if err != nil {
+		t.Fatalf("GetByOriginalTransactionID: %v", err)
+	}
+	if got.UserID != p.UserID {
+		t.Errorf("GetByOriginalTransactionID: got userID %q, want %q", got.UserID, p.UserID)
+	}
+
+	_, err = admin.GetByOriginalTransactionID(ctx, "no-such-tx")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetByOriginalTransactionID miss: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestPostgresAdminStore_ByDigestDay verifies that only profiles whose
+// DigestDay matches are returned.
+func TestPostgresAdminStore_ByDigestDay(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "users")
+	store := NewPostgresStore(pool)
+	admin := NewPostgresAdminStore(pool)
+	ctx := context.Background()
+
+	// Three profiles: two on Monday, one on Tuesday.
+	for _, id := range []string{"auth0|adm3a", "auth0|adm3b"} {
+		p := pgProfile(t, id, id+"@example.com")
+		p.Preferences.DigestDay = time.Monday
+		if err := store.Save(ctx, p); err != nil {
+			t.Fatalf("Save %s: %v", id, err)
+		}
+	}
+	pTue := pgProfile(t, "auth0|adm3c", "adm3c@example.com")
+	pTue.Preferences.DigestDay = time.Tuesday
+	if err := store.Save(ctx, pTue); err != nil {
+		t.Fatalf("Save Tuesday: %v", err)
+	}
+
+	monProfiles, err := admin.ByDigestDay(ctx, time.Monday)
+	if err != nil {
+		t.Fatalf("ByDigestDay Monday: %v", err)
+	}
+	if len(monProfiles) != 2 {
+		t.Errorf("ByDigestDay Monday: got %d, want 2", len(monProfiles))
+	}
+
+	tueProfiles, err := admin.ByDigestDay(ctx, time.Tuesday)
+	if err != nil {
+		t.Fatalf("ByDigestDay Tuesday: %v", err)
+	}
+	if len(tueProfiles) != 1 {
+		t.Errorf("ByDigestDay Tuesday: got %d, want 1", len(tueProfiles))
+	}
+}
+
+// TestPostgresAdminStore_Dormant verifies that profiles last active before the
+// cutoff are returned and profiles active at or after are excluded.
+func TestPostgresAdminStore_Dormant(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "users")
+	store := NewPostgresStore(pool)
+	admin := NewPostgresAdminStore(pool)
+	ctx := context.Background()
+
+	cutoff := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Dormant: last active before cutoff.
+	pDormant := pgProfile(t, "auth0|adm4a", "dorm@example.com")
+	pDormant.LastActiveAt = cutoff.Add(-24 * time.Hour)
+	if err := store.Save(ctx, pDormant); err != nil {
+		t.Fatalf("Save dormant: %v", err)
+	}
+
+	// Active: last active after cutoff.
+	pActive := pgProfile(t, "auth0|adm4b", "active@example.com")
+	pActive.LastActiveAt = cutoff.Add(24 * time.Hour)
+	if err := store.Save(ctx, pActive); err != nil {
+		t.Fatalf("Save active: %v", err)
+	}
+
+	dormant, err := admin.Dormant(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("Dormant: %v", err)
+	}
+	if len(dormant) != 1 {
+		t.Errorf("Dormant: got %d profiles, want 1", len(dormant))
+	}
+	if len(dormant) > 0 && dormant[0].UserID != pDormant.UserID {
+		t.Errorf("Dormant: got userID %q, want %q", dormant[0].UserID, pDormant.UserID)
+	}
+}
+
+// TestPostgresAdminStore_LapsedPaid verifies that profiles with a paid tier but
+// a past subscription expiry appear in LapsedPaid, while active paid and free
+// tier profiles do not.
+func TestPostgresAdminStore_LapsedPaid(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "users")
+	store := NewPostgresStore(pool)
+	admin := NewPostgresAdminStore(pool)
+	ctx := context.Background()
+
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+
+	// Lapsed: Personal tier, expired 30 days ago.
+	pLapsed := pgProfile(t, "auth0|adm5a", "lapsed@example.com")
+	pLapsed.Tier = TierPersonal
+	exp := now.Add(-30 * 24 * time.Hour)
+	pLapsed.SubscriptionExpiry = &exp
+	if err := store.Save(ctx, pLapsed); err != nil {
+		t.Fatalf("Save lapsed: %v", err)
+	}
+
+	// Active paid: Personal tier, expiry in the future.
+	pPaid := pgProfile(t, "auth0|adm5b", "paid@example.com")
+	pPaid.Tier = TierPersonal
+	future := now.Add(30 * 24 * time.Hour)
+	pPaid.SubscriptionExpiry = &future
+	if err := store.Save(ctx, pPaid); err != nil {
+		t.Fatalf("Save paid: %v", err)
+	}
+
+	// Free tier: should never appear.
+	pFree := pgProfile(t, "auth0|adm5c", "free@example.com")
+	if err := store.Save(ctx, pFree); err != nil {
+		t.Fatalf("Save free: %v", err)
+	}
+
+	lapsed, err := admin.LapsedPaid(ctx, now)
+	if err != nil {
+		t.Fatalf("LapsedPaid: %v", err)
+	}
+	if len(lapsed) != 1 {
+		t.Errorf("LapsedPaid: got %d profiles, want 1", len(lapsed))
+	}
+	if len(lapsed) > 0 && lapsed[0].UserID != pLapsed.UserID {
+		t.Errorf("LapsedPaid: got userID %q, want %q", lapsed[0].UserID, pLapsed.UserID)
+	}
+}
+
+// TestPostgresAdminStore_Save verifies that the admin Save method upserts a
+// profile (same contract as PostgresStore.Save but accessible from the admin
+// surface — used by the subscription sweep).
+func TestPostgresAdminStore_Save(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "users")
+	store := NewPostgresStore(pool)
+	admin := NewPostgresAdminStore(pool)
+	ctx := context.Background()
+
+	p := pgProfile(t, "auth0|adm6", "hannah@example.com")
+	if err := admin.Save(ctx, p); err != nil {
+		t.Fatalf("admin Save: %v", err)
+	}
+	got, err := store.Get(ctx, p.UserID)
+	if err != nil {
+		t.Fatalf("Get after admin Save: %v", err)
+	}
+	if got.UserID != p.UserID {
+		t.Errorf("admin Save: got userID %q, want %q", got.UserID, p.UserID)
+	}
+}
+
+// TestPostgresAdminStore_List_Pagination verifies that List pages correctly
+// through profiles ordered by user_id using the keyset cursor, and that an
+// email filter narrows results.
+func TestPostgresAdminStore_List_Pagination(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "users")
+	store := NewPostgresStore(pool)
+	admin := NewPostgresAdminStore(pool)
+	ctx := context.Background()
+
+	// Seed 5 profiles with deterministic, ordered IDs so pagination order is stable.
+	for i := 1; i <= 5; i++ {
+		id := "auth0|list" + string(rune('0'+i))
+		email := id + "@example.com"
+		if err := store.Save(ctx, pgProfile(t, id, email)); err != nil {
+			t.Fatalf("Save %s: %v", id, err)
+		}
+	}
+
+	// Page 1: first 3.
+	page1, err := admin.List(ctx, "", 3, "")
+	if err != nil {
+		t.Fatalf("List page 1: %v", err)
+	}
+	if len(page1.Profiles) != 3 {
+		t.Errorf("page 1: got %d profiles, want 3", len(page1.Profiles))
+	}
+	if page1.ContinuationToken == "" {
+		t.Error("page 1: expected continuation token, got empty")
+	}
+
+	// Page 2: next 2 using token.
+	page2, err := admin.List(ctx, "", 3, page1.ContinuationToken)
+	if err != nil {
+		t.Fatalf("List page 2: %v", err)
+	}
+	if len(page2.Profiles) != 2 {
+		t.Errorf("page 2: got %d profiles, want 2", len(page2.Profiles))
+	}
+	if page2.ContinuationToken != "" {
+		t.Errorf("page 2: expected empty token (last page), got %q", page2.ContinuationToken)
+	}
+
+	// Email filter: only profile 3 matches "list3".
+	filtered, err := admin.List(ctx, "list3", 10, "")
+	if err != nil {
+		t.Fatalf("List filtered: %v", err)
+	}
+	if len(filtered.Profiles) != 1 {
+		t.Errorf("filtered: got %d profiles, want 1", len(filtered.Profiles))
+	}
+}

--- a/api-go/internal/profiles/store_postgres_test.go
+++ b/api-go/internal/profiles/store_postgres_test.go
@@ -1,0 +1,152 @@
+package profiles
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// fakeExecQuerier is a hand-written test double for the querier interface that
+// supports only Exec — the three Exec-based methods (Save, Delete,
+// UpdateZoneCountWithCAS) are the ones whose error paths and CAS logic can be
+// exercised without a real database. Query and QueryRow panic when called, so
+// any unintended use is caught immediately rather than silently no-oping.
+type fakeExecQuerier struct {
+	tag pgconn.CommandTag
+	err error
+}
+
+func (f *fakeExecQuerier) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	return f.tag, f.err
+}
+
+func (f *fakeExecQuerier) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	panic("fakeExecQuerier.Query not expected in this test")
+}
+
+func (f *fakeExecQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	panic("fakeExecQuerier.QueryRow not expected in this test")
+}
+
+// newFakePGStore builds a PostgresStore backed by fakeExecQuerier.
+func newFakePGStore(tag pgconn.CommandTag, err error) *PostgresStore {
+	return NewPostgresStore(&fakeExecQuerier{tag: tag, err: err})
+}
+
+// testProfile builds a minimal valid UserProfile for use in store tests.
+func testProfile(userID string) *UserProfile {
+	p, _ := NewProfile(userID, "test@example.com", time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC))
+	return p
+}
+
+// TestPostgresStore_Save_WrapsDatabaseError verifies that a database error from
+// Exec is wrapped and returned — never swallowed.
+func TestPostgresStore_Save_WrapsDatabaseError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("db exploded")
+	store := newFakePGStore(pgconn.CommandTag{}, sentinel)
+
+	err := store.Save(context.Background(), testProfile("auth0|u1"))
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Save: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// TestPostgresStore_Delete_MissReturnsErrNotFound verifies that zero rows
+// affected on the DELETE statement surfaces as ErrNotFound (not a wrapped
+// database error), matching the Cosmos store's contract.
+func TestPostgresStore_Delete_MissReturnsErrNotFound(t *testing.T) {
+	t.Parallel()
+	// CommandTag "DELETE 0" → RowsAffected() == 0
+	store := newFakePGStore(pgconn.NewCommandTag("DELETE 0"), nil)
+
+	err := store.Delete(context.Background(), "auth0|missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Delete miss: got %v, want ErrNotFound", err)
+	}
+}
+
+// TestPostgresStore_Delete_SuccessReturnsNil verifies that exactly one affected
+// row from the DELETE yields nil.
+func TestPostgresStore_Delete_SuccessReturnsNil(t *testing.T) {
+	t.Parallel()
+	store := newFakePGStore(pgconn.NewCommandTag("DELETE 1"), nil)
+
+	if err := store.Delete(context.Background(), "auth0|u1"); err != nil {
+		t.Fatalf("Delete success: got %v, want nil", err)
+	}
+}
+
+// TestPostgresStore_Delete_WrapsDatabaseError verifies that a database error is
+// returned even when the rows-affected count is irrelevant.
+func TestPostgresStore_Delete_WrapsDatabaseError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("connection refused")
+	store := newFakePGStore(pgconn.CommandTag{}, sentinel)
+
+	err := store.Delete(context.Background(), "auth0|u1")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Delete error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// TestPostgresStore_UpdateZoneCountWithCAS_InvalidEtag verifies that a
+// non-numeric etag (e.g. a raw Cosmos _etag string) is rejected with a
+// descriptive error before any SQL is issued.
+func TestPostgresStore_UpdateZoneCountWithCAS_InvalidEtag(t *testing.T) {
+	t.Parallel()
+	// Any tag/err — should not be reached since etag parsing fails first.
+	store := newFakePGStore(pgconn.NewCommandTag("UPDATE 1"), nil)
+
+	err := store.UpdateZoneCountWithCAS(context.Background(), "auth0|u1", testProfile("auth0|u1"), "not-a-number")
+	if err == nil {
+		t.Fatal("expected error for invalid etag, got nil")
+	}
+}
+
+// TestPostgresStore_UpdateZoneCountWithCAS_ConflictReturnsCASError verifies
+// that zero rows affected from the conditional UPDATE returns the exact
+// platform.ErrCASPreconditionFailed sentinel (wrapped), matching the contract
+// the watchzones quota CAS handler branches on.
+func TestPostgresStore_UpdateZoneCountWithCAS_ConflictReturnsCASError(t *testing.T) {
+	t.Parallel()
+	// CommandTag "UPDATE 0" → RowsAffected() == 0 → precondition failed
+	store := newFakePGStore(pgconn.NewCommandTag("UPDATE 0"), nil)
+
+	err := store.UpdateZoneCountWithCAS(context.Background(), "auth0|u1", testProfile("auth0|u1"), "3")
+	if err == nil {
+		t.Fatal("expected CAS error, got nil")
+	}
+	// Must be detectable via errors.Is so the handler can branch.
+	if !errors.Is(err, errCASPreconditionFailed) {
+		t.Fatalf("UpdateZoneCountWithCAS conflict: got %v, want to wrap errCASPreconditionFailed", err)
+	}
+}
+
+// TestPostgresStore_UpdateZoneCountWithCAS_SuccessReturnsNil verifies that one
+// row affected from the conditional UPDATE yields nil.
+func TestPostgresStore_UpdateZoneCountWithCAS_SuccessReturnsNil(t *testing.T) {
+	t.Parallel()
+	store := newFakePGStore(pgconn.NewCommandTag("UPDATE 1"), nil)
+
+	if err := store.UpdateZoneCountWithCAS(context.Background(), "auth0|u1", testProfile("auth0|u1"), "2"); err != nil {
+		t.Fatalf("UpdateZoneCountWithCAS success: got %v, want nil", err)
+	}
+}
+
+// TestPostgresStore_UpdateZoneCountWithCAS_WrapsDatabaseError verifies that a
+// database error from Exec is wrapped and returned.
+func TestPostgresStore_UpdateZoneCountWithCAS_WrapsDatabaseError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("db timeout")
+	store := newFakePGStore(pgconn.CommandTag{}, sentinel)
+
+	err := store.UpdateZoneCountWithCAS(context.Background(), "auth0|u1", testProfile("auth0|u1"), "0")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("UpdateZoneCountWithCAS db error: got %v, want wrapped %v", err, sentinel)
+	}
+}

--- a/api-go/internal/profiles/store_postgres_test.go
+++ b/api-go/internal/profiles/store_postgres_test.go
@@ -38,6 +38,11 @@ func newFakePGStore(tag pgconn.CommandTag, err error) *PostgresStore {
 }
 
 // testProfile builds a minimal valid UserProfile for use in store tests.
+// The userID parameter is intentionally parameterised for readability even
+// though unit tests call it with the same argument — it is also used by the
+// integration test suite in the same package.
+//
+//nolint:unparam
 func testProfile(userID string) *UserProfile {
 	p, _ := NewProfile(userID, "test@example.com", time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC))
 	return p


### PR DESCRIPTION
Slice 3 of Phase F single-store cutover (epic #645, spec #669, memo 0010).

Postgres ports for BOTH `internal/profiles` stores behind their existing consumer interfaces (exported `Store` + `AdminProfileStore`; Cosmos + Postgres satisfy both, compile-time parity asserted):

- **Point `PostgresStore`** — Get / Save / Delete / GetWithETag / `UpdateZoneCountWithCAS`. The watch-zone quota CAS is an atomic `UPDATE … WHERE user_id=$ AND version=$expected`; zero rows → `platform.ErrCASPreconditionFailed` (the exact sentinel the watchzones create handler branches on), identical to Cosmos. **Quota race proven** by integration test (two goroutines → exactly one wins).
- **`PostgresAdminStore`** — GetByEmail / GetByOriginalTransactionID / ByDigestDay / Dormant (epoch column, not timestamp string) / LapsedPaid (paid candidates filtered Go-side via `EffectiveTier`) / Save / List (keyset pagination + email search).
- Migration `0006_users.sql` — full `profileDocument` field set + `version` CAS column + indexes (email, original_transaction_id, digest_day, last_active_at_epoch, tier). Legacy NULL→opt-in coalesce preserved in hydration.
- Exported `profiles.DecodeDocument` + `cmd/pgbackfill-users` Cosmos→Postgres backfill.

GDPR profile delete covered by `Delete`. No wiring touched (later slice). Unit (fakes, `-race`) + `//go:build integration` pgtest (incl. CAS race) green; build/vet/gofmt/golangci clean.

Bead: tc-hpd2.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line backfill tool to migrate user profiles into the database with progress logging, paging, limits, timeout support, and interrupt handling.
  * Added database-backed profile storage for reading, saving, deleting, listing, and conditional updates.
  * Added admin-oriented profile queries for lookup, filtering, dormant/lapsed account detection, and paginated browsing.

* **Bug Fixes**
  * Improved profile decoding to handle legacy defaults correctly and reject invalid data instead of silently accepting it.
  * Added stronger protection for conditional updates to prevent lost changes during concurrent writes.

* **Tests**
  * Added extensive unit and integration coverage for backfill, decoding, storage round-trips, pagination, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->