### PR TITLE
feat(api): Postgres ports for Notifications (+90d purge) + NotificationState (tc-hpd2.9)

### DIFF
--- a/api-go/cmd/pgbackfill-notifications/main.go
+++ b/api-go/cmd/pgbackfill-notifications/main.go
@@ -1,0 +1,268 @@
+// Command pgbackfill-notifications copies user Notifications from prod Cosmos
+// into the Postgres `notifications` table, for the Cosmos → Postgres migration
+// (docs/memo/0010, epic #645; GH#669 Slice 4). It is the sibling of
+// cmd/pgbackfill-zones (which copies WatchZones); this one copies per-user
+// notifications.
+//
+// It is idempotent and re-runnable: each notification is written with
+// INSERT ... ON CONFLICT (id) DO UPDATE keyed on the Cosmos document id, so a
+// re-run reconciles rather than duplicates.
+//
+// PII: notifications are user personal data (they reference a user's specific
+// watch zone and the planning application it matched). Unlike cmd/pgbackfill's
+// public Applications, this tool copies PII. The prod copy is EXPLICITLY
+// AUTHORIZED in issue #669 — the only prod accounts are the owner, his wife,
+// and personal friends/family. Do not point this at any other dataset without
+// the same authorization.
+//
+// Source (read): prod Cosmos, authenticated with the account KEY (read from
+// the COSMOS_KEY environment variable, never a flag, so it stays out of shell
+// history). The tool enumerates the whole Notifications container with a
+// cross-partition SELECT * query, paged via a continuation token.
+//
+// Target (write): Postgres, authenticated passwordless as the Entra ADMIN
+// (DefaultAzureCredential). Pass -pg-db town_crier_prod for the prod copy;
+// the default is the dev database, the safer failure mode if the flag is
+// forgotten.
+//
+// A document that fails to decode (bad JSON) is counted and skipped rather
+// than aborting the run; the run is re-runnable so a later run reconciles.
+//
+// Usage (run locally, prod Cosmos key in the environment):
+//
+//	export COSMOS_KEY="$(az cosmosdb keys list -n cosmos-town-crier-shared \
+//	    -g rg-town-crier-shared --type read-only-keys --query primaryReadonlyMasterKey -o tsv)"
+//	pgbackfill-notifications -pg-host <fqdn> -pg-admin-user <aad-admin-upn> \
+//	    -pg-db town_crier_prod \
+//	    [-cosmos-db town-crier-prod] [-batch-size 500] [-limit 0]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
+)
+
+const defaultCosmosEndpoint = "https://cosmos-town-crier-shared.documents.azure.com:443/"
+const defaultCosmosDB = "town-crier-prod"
+const defaultPostgresDB = "town_crier_dev"
+const enumerateQuery = "SELECT * FROM c"
+
+// docPager yields successive pages of raw Notifications-container document
+// bodies. The azcosmos query pager satisfies it via cosmosPager; tests inject
+// a hand-written fake.
+type docPager interface {
+	More() bool
+	NextPage(ctx context.Context) ([][]byte, error)
+}
+
+// notifCreator writes one notification idempotently. *notifications.PostgresStore
+// satisfies it via Create (INSERT ... ON CONFLICT (id) DO UPDATE).
+type notifCreator interface {
+	Create(ctx context.Context, n notifications.DigestNotification) error
+}
+
+// backfillOptions tune the run.
+type backfillOptions struct {
+	limit    int
+	logEvery int
+}
+
+// summary is the final tally.
+type summary struct {
+	read     int
+	upserted int
+	errors   int
+}
+
+// backfill drains every page from pager, decodes each document with the shared
+// notifications.DecodeDocument transform, and upserts it into store. A failed
+// decode or store write is counted and skipped (the run is re-runnable); only
+// a source paging error or context cancellation aborts the whole run.
+func backfill(ctx context.Context, pager docPager, store notifCreator, opts backfillOptions, logger *slog.Logger) (summary, error) {
+	var s summary
+	for pager.More() {
+		if opts.limit > 0 && s.read >= opts.limit {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return s, fmt.Errorf("backfill cancelled after %d records: %w", s.read, err)
+		}
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return s, fmt.Errorf("read source page after %d records: %w", s.read, err)
+		}
+		for _, raw := range page {
+			if opts.limit > 0 && s.read >= opts.limit {
+				break
+			}
+			s.read++
+			n, derr := notifications.DecodeDocument(raw)
+			if derr != nil {
+				s.errors++
+				logger.WarnContext(ctx, "skip undecodable notification", "error", derr)
+				continue
+			}
+			if uerr := store.Create(ctx, n); uerr != nil {
+				if ctx.Err() != nil {
+					return s, fmt.Errorf("backfill cancelled saving notification %q after %d records: %w", n.ID, s.read, uerr)
+				}
+				s.errors++
+				logger.WarnContext(ctx, "save failed", "id", n.ID, "user", n.UserID, "error", uerr)
+				continue
+			}
+			s.upserted++
+			if opts.logEvery > 0 && s.read%opts.logEvery == 0 {
+				logger.InfoContext(ctx, "backfill progress", "read", s.read, "upserted", s.upserted, "errors", s.errors)
+			}
+		}
+	}
+	return s, nil
+}
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	os.Exit(run(os.Args[1:], logger))
+}
+
+func run(args []string, logger *slog.Logger) int {
+	fs := flag.NewFlagSet("pgbackfill-notifications", flag.ContinueOnError)
+	var (
+		cosmosEndpoint  = fs.String("cosmos-endpoint", defaultCosmosEndpoint, "source Cosmos account endpoint")
+		cosmosDB        = fs.String("cosmos-db", defaultCosmosDB, "source Cosmos logical database")
+		cosmosContainer = fs.String("cosmos-container", platform.CosmosNotificationsContainer, "source Cosmos container id")
+		pgHost          = fs.String("pg-host", os.Getenv("POSTGRES_HOST"), "target Postgres server FQDN")
+		pgDB            = fs.String("pg-db", defaultPostgresDB, "target Postgres database")
+		pgAdminUser     = fs.String("pg-admin-user", os.Getenv("POSTGRES_ADMIN_USER"), "Entra admin principal (UPN) to write as")
+		pgSSLMode       = fs.String("pg-sslmode", envOr("POSTGRES_SSLMODE", "require"), "target Postgres sslmode")
+		batchSize       = fs.Int("batch-size", 500, "Cosmos page size and progress-log cadence")
+		limit           = fs.Int("limit", 0, "max records to process (0 = all; a small value smoke-tests)")
+		timeout         = fs.Duration("timeout", 0, "overall timeout (0 = none; SIGINT/SIGTERM still cancel)")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	cosmosKey := os.Getenv("COSMOS_KEY")
+	if cosmosKey == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill-notifications: COSMOS_KEY environment variable is required")
+		return 2
+	}
+	if *pgHost == "" || *pgAdminUser == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill-notifications: -pg-host and -pg-admin-user are required")
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	pager, err := newCosmosPager(*cosmosEndpoint, cosmosKey, *cosmosDB, *cosmosContainer, *batchSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-notifications: build cosmos source: %v\n", err)
+		return 1
+	}
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-notifications: build azure credential: %v\n", err)
+		return 1
+	}
+	pool, err := postgres.NewTokenCredentialPool(ctx, postgres.ConnParams{
+		Host:    *pgHost,
+		DB:      *pgDB,
+		User:    *pgAdminUser,
+		SSLMode: *pgSSLMode,
+	}, cred)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-notifications: build postgres pool: %v\n", err)
+		return 1
+	}
+	defer pool.Close()
+
+	store := notifications.NewPostgresStore(pool)
+
+	logger.InfoContext(ctx, "backfill starting",
+		"cosmosEndpoint", *cosmosEndpoint, "cosmosDb", *cosmosDB, "cosmosContainer", *cosmosContainer,
+		"pgHost", *pgHost, "pgDb", *pgDB, "batchSize", *batchSize, "limit", *limit)
+
+	started := time.Now()
+	s, err := backfill(ctx, pager, store, backfillOptions{limit: *limit, logEvery: *batchSize}, logger)
+	logger.InfoContext(ctx, "backfill complete",
+		"read", s.read, "upserted", s.upserted, "errors", s.errors, "elapsed", time.Since(started).String())
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-notifications: aborted: %v\n", err)
+		return 1
+	}
+	if s.errors > 0 {
+		logger.WarnContext(ctx, "backfill finished with per-record errors; re-run to reconcile", "errors", s.errors)
+	}
+	return 0
+}
+
+type cosmosPager struct {
+	pager *runtime.Pager[azcosmos.QueryItemsResponse]
+}
+
+func (p *cosmosPager) More() bool { return p.pager.More() }
+
+func (p *cosmosPager) NextPage(ctx context.Context) ([][]byte, error) {
+	resp, err := p.pager.NextPage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cosmos next page: %w", err)
+	}
+	return resp.Items, nil
+}
+
+func newCosmosPager(endpoint, key, db, container string, pageSize int) (docPager, error) {
+	cred, err := azcosmos.NewKeyCredential(key)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos key credential: %w", err)
+	}
+	client, err := azcosmos.NewClientWithKey(endpoint, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos client: %w", err)
+	}
+	c, err := client.NewContainer(db, container)
+	if err != nil {
+		return nil, fmt.Errorf("open container %q in %q: %w", container, db, err)
+	}
+	opts := &azcosmos.QueryOptions{PageSizeHint: clampPageSize(pageSize)}
+	return &cosmosPager{pager: c.NewQueryItemsPager(enumerateQuery, azcosmos.NewPartitionKey(), opts)}, nil
+}
+
+func clampPageSize(n int) int32 {
+	const maxPageSize = 1000
+	if n <= 0 {
+		return 100
+	}
+	if n > maxPageSize {
+		return maxPageSize
+	}
+	return int32(n) //nolint:gosec // n is bounded to [1,1000] above, no overflow
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/api-go/cmd/pgbackfill-notifications/main_test.go
+++ b/api-go/cmd/pgbackfill-notifications/main_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+)
+
+// discardLogger is a no-op logger so tests stay quiet.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// rawNotifDoc builds a minimal valid Notifications-container document body for
+// id. The JSON shape mirrors the digestDocument wire format (camelCase keys,
+// DotNetTime createdAt), which is what the Cosmos pager yields.
+func rawNotifDoc(id string) []byte {
+	return []byte(`{"id":"` + id + `","userId":"auth0|u-` + id + `","applicationUid":"uid-` + id + `",` +
+		`"applicationName":"App ` + id + `","authorityId":100,"eventType":"NewApplication",` +
+		`"sources":"Zone","pushSent":false,"emailSent":false,` +
+		`"createdAt":"2026-06-26T12:00:00+00:00","ttl":7776000}`)
+}
+
+// fakeNotifPager yields successive pages of raw document bodies, or a fixed error.
+type fakeNotifPager struct {
+	pages [][][]byte
+	idx   int
+	err   error
+}
+
+func (p *fakeNotifPager) More() bool { return p.idx < len(p.pages) }
+
+func (p *fakeNotifPager) NextPage(_ context.Context) ([][]byte, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	page := p.pages[p.idx]
+	p.idx++
+	return page, nil
+}
+
+// fakeNotifCreator records every saved notification and can fail by notification id.
+type fakeNotifCreator struct {
+	saved  []notifications.DigestNotification
+	failOn map[string]error
+}
+
+func (u *fakeNotifCreator) Create(_ context.Context, n notifications.DigestNotification) error {
+	if err := u.failOn[n.ID]; err != nil {
+		return err
+	}
+	u.saved = append(u.saved, n)
+	return nil
+}
+
+func TestBackfill_SavesAllRecordsAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakeNotifPager{pages: [][][]byte{
+		{rawNotifDoc("a"), rawNotifDoc("b")},
+		{rawNotifDoc("c")},
+	}}
+	store := &fakeNotifCreator{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 3 || got.errors != 0 {
+		t.Errorf("summary: got %+v, want read=3 upserted=3 errors=0", got)
+	}
+	if len(store.saved) != 3 {
+		t.Errorf("store: saved %d records, want 3", len(store.saved))
+	}
+}
+
+func TestBackfill_ContinuesPastDecodeError(t *testing.T) {
+	t.Parallel()
+	pager := &fakeNotifPager{pages: [][][]byte{
+		{rawNotifDoc("a"), []byte("not json"), rawNotifDoc("b")},
+	}}
+	store := &fakeNotifCreator{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestBackfill_ContinuesPastSaveError(t *testing.T) {
+	t.Parallel()
+	pager := &fakeNotifPager{pages: [][][]byte{
+		{rawNotifDoc("a"), rawNotifDoc("b"), rawNotifDoc("c")},
+	}}
+	store := &fakeNotifCreator{failOn: map[string]error{"b": errors.New("boom")}}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestBackfill_RespectsLimitAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakeNotifPager{pages: [][][]byte{
+		{rawNotifDoc("a")},
+		{rawNotifDoc("b")},
+		{rawNotifDoc("c")},
+	}}
+	store := &fakeNotifCreator{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{limit: 2}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 2 || got.upserted != 2 {
+		t.Errorf("summary: got %+v, want read=2 upserted=2", got)
+	}
+	if pager.idx > 2 {
+		t.Errorf("pager consumed %d pages, want it to stop at the limit (<=2)", pager.idx)
+	}
+}
+
+func TestBackfill_PagerErrorReturnsError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("cosmos read failed")
+	pager := &fakeNotifPager{pages: [][][]byte{{rawNotifDoc("a")}}, err: sentinel}
+	store := &fakeNotifCreator{}
+
+	_, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("backfill: got err %v, want wrapped %v", err, sentinel)
+	}
+}
+
+func TestBackfill_ContextCancelAborts(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pager := &fakeNotifPager{pages: [][][]byte{{rawNotifDoc("a")}}}
+	store := &fakeNotifCreator{}
+
+	_, err := backfill(ctx, pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("backfill: got err %v, want context.Canceled", err)
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("store: saved %d records, want 0 (cancelled before any save)", len(store.saved))
+	}
+}

--- a/api-go/cmd/pgbackfill-notifstate/main.go
+++ b/api-go/cmd/pgbackfill-notifstate/main.go
@@ -1,0 +1,268 @@
+// Command pgbackfill-notifstate copies per-user notification watermarks from
+// prod Cosmos into the Postgres `notification_state` table, for the Cosmos →
+// Postgres migration (docs/memo/0010, epic #645; GH#669 Slice 4). It is the
+// sibling of cmd/pgbackfill-notifications — that tool copies the per-user
+// Notifications; this one copies the read watermarks (NotificationState).
+//
+// It is idempotent and re-runnable: each state document is written with
+// INSERT ... ON CONFLICT (user_id) DO UPDATE, so a re-run reconciles rather
+// than duplicates.
+//
+// PII: notification state documents contain the userId and their last-read
+// timestamp — minimal PII but personal data under GDPR. The prod copy is
+// EXPLICITLY AUTHORIZED in issue #669 — the only prod accounts are the owner,
+// his wife, and personal friends/family. Do not point this at any other dataset
+// without the same authorization.
+//
+// Source (read): prod Cosmos, authenticated with the account KEY (read from
+// the COSMOS_KEY environment variable, never a flag, so it stays out of shell
+// history). The tool enumerates the whole NotificationState container with a
+// cross-partition SELECT * query, paged via a continuation token.
+//
+// Target (write): Postgres, authenticated passwordless as the Entra ADMIN
+// (DefaultAzureCredential). Pass -pg-db town_crier_prod for the prod copy;
+// the default is the dev database, the safer failure mode if the flag is
+// forgotten.
+//
+// A document that fails to decode (bad JSON) is counted and skipped rather
+// than aborting the run; the run is re-runnable so a later run reconciles.
+//
+// Usage (run locally, prod Cosmos key in the environment):
+//
+//	export COSMOS_KEY="$(az cosmosdb keys list -n cosmos-town-crier-shared \
+//	    -g rg-town-crier-shared --type read-only-keys --query primaryReadonlyMasterKey -o tsv)"
+//	pgbackfill-notifstate -pg-host <fqdn> -pg-admin-user <aad-admin-upn> \
+//	    -pg-db town_crier_prod \
+//	    [-cosmos-db town-crier-prod] [-batch-size 500] [-limit 0]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
+)
+
+const defaultCosmosEndpoint = "https://cosmos-town-crier-shared.documents.azure.com:443/"
+const defaultCosmosDB = "town-crier-prod"
+const defaultPostgresDB = "town_crier_dev"
+const enumerateQuery = "SELECT * FROM c"
+
+// docPager yields successive pages of raw NotificationState-container document
+// bodies. The azcosmos query pager satisfies it via cosmosPager; tests inject
+// a hand-written fake.
+type docPager interface {
+	More() bool
+	NextPage(ctx context.Context) ([][]byte, error)
+}
+
+// stateSaver writes one notification watermark idempotently.
+// *notificationstate.PostgresStore satisfies it via Save
+// (INSERT ... ON CONFLICT (user_id) DO UPDATE).
+type stateSaver interface {
+	Save(ctx context.Context, st notificationstate.State) error
+}
+
+// backfillOptions tune the run.
+type backfillOptions struct {
+	limit    int
+	logEvery int
+}
+
+// summary is the final tally.
+type summary struct {
+	read     int
+	upserted int
+	errors   int
+}
+
+// backfill drains every page from pager, decodes each document with the shared
+// notificationstate.DecodeDocument transform, and upserts it into store. A failed
+// decode or store write is counted and skipped (the run is re-runnable); only
+// a source paging error or context cancellation aborts the whole run.
+func backfill(ctx context.Context, pager docPager, store stateSaver, opts backfillOptions, logger *slog.Logger) (summary, error) {
+	var s summary
+	for pager.More() {
+		if opts.limit > 0 && s.read >= opts.limit {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return s, fmt.Errorf("backfill cancelled after %d records: %w", s.read, err)
+		}
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return s, fmt.Errorf("read source page after %d records: %w", s.read, err)
+		}
+		for _, raw := range page {
+			if opts.limit > 0 && s.read >= opts.limit {
+				break
+			}
+			s.read++
+			st, derr := notificationstate.DecodeDocument(raw)
+			if derr != nil {
+				s.errors++
+				logger.WarnContext(ctx, "skip undecodable notification state", "error", derr)
+				continue
+			}
+			if serr := store.Save(ctx, st); serr != nil {
+				if ctx.Err() != nil {
+					return s, fmt.Errorf("backfill cancelled saving state for %q after %d records: %w", st.UserID, s.read, serr)
+				}
+				s.errors++
+				logger.WarnContext(ctx, "save failed", "user", st.UserID, "error", serr)
+				continue
+			}
+			s.upserted++
+			if opts.logEvery > 0 && s.read%opts.logEvery == 0 {
+				logger.InfoContext(ctx, "backfill progress", "read", s.read, "upserted", s.upserted, "errors", s.errors)
+			}
+		}
+	}
+	return s, nil
+}
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	os.Exit(run(os.Args[1:], logger))
+}
+
+func run(args []string, logger *slog.Logger) int {
+	fs := flag.NewFlagSet("pgbackfill-notifstate", flag.ContinueOnError)
+	var (
+		cosmosEndpoint  = fs.String("cosmos-endpoint", defaultCosmosEndpoint, "source Cosmos account endpoint")
+		cosmosDB        = fs.String("cosmos-db", defaultCosmosDB, "source Cosmos logical database")
+		cosmosContainer = fs.String("cosmos-container", platform.CosmosNotificationStateContainer, "source Cosmos container id")
+		pgHost          = fs.String("pg-host", os.Getenv("POSTGRES_HOST"), "target Postgres server FQDN")
+		pgDB            = fs.String("pg-db", defaultPostgresDB, "target Postgres database")
+		pgAdminUser     = fs.String("pg-admin-user", os.Getenv("POSTGRES_ADMIN_USER"), "Entra admin principal (UPN) to write as")
+		pgSSLMode       = fs.String("pg-sslmode", envOr("POSTGRES_SSLMODE", "require"), "target Postgres sslmode")
+		batchSize       = fs.Int("batch-size", 500, "Cosmos page size and progress-log cadence")
+		limit           = fs.Int("limit", 0, "max records to process (0 = all; a small value smoke-tests)")
+		timeout         = fs.Duration("timeout", 0, "overall timeout (0 = none; SIGINT/SIGTERM still cancel)")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	cosmosKey := os.Getenv("COSMOS_KEY")
+	if cosmosKey == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill-notifstate: COSMOS_KEY environment variable is required")
+		return 2
+	}
+	if *pgHost == "" || *pgAdminUser == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill-notifstate: -pg-host and -pg-admin-user are required")
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	pager, err := newCosmosPager(*cosmosEndpoint, cosmosKey, *cosmosDB, *cosmosContainer, *batchSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-notifstate: build cosmos source: %v\n", err)
+		return 1
+	}
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-notifstate: build azure credential: %v\n", err)
+		return 1
+	}
+	pool, err := postgres.NewTokenCredentialPool(ctx, postgres.ConnParams{
+		Host:    *pgHost,
+		DB:      *pgDB,
+		User:    *pgAdminUser,
+		SSLMode: *pgSSLMode,
+	}, cred)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-notifstate: build postgres pool: %v\n", err)
+		return 1
+	}
+	defer pool.Close()
+
+	store := notificationstate.NewPostgresStore(pool)
+
+	logger.InfoContext(ctx, "backfill starting",
+		"cosmosEndpoint", *cosmosEndpoint, "cosmosDb", *cosmosDB, "cosmosContainer", *cosmosContainer,
+		"pgHost", *pgHost, "pgDb", *pgDB, "batchSize", *batchSize, "limit", *limit)
+
+	started := time.Now()
+	s, err := backfill(ctx, pager, store, backfillOptions{limit: *limit, logEvery: *batchSize}, logger)
+	logger.InfoContext(ctx, "backfill complete",
+		"read", s.read, "upserted", s.upserted, "errors", s.errors, "elapsed", time.Since(started).String())
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-notifstate: aborted: %v\n", err)
+		return 1
+	}
+	if s.errors > 0 {
+		logger.WarnContext(ctx, "backfill finished with per-record errors; re-run to reconcile", "errors", s.errors)
+	}
+	return 0
+}
+
+type cosmosPager struct {
+	pager *runtime.Pager[azcosmos.QueryItemsResponse]
+}
+
+func (p *cosmosPager) More() bool { return p.pager.More() }
+
+func (p *cosmosPager) NextPage(ctx context.Context) ([][]byte, error) {
+	resp, err := p.pager.NextPage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cosmos next page: %w", err)
+	}
+	return resp.Items, nil
+}
+
+func newCosmosPager(endpoint, key, db, container string, pageSize int) (docPager, error) {
+	cred, err := azcosmos.NewKeyCredential(key)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos key credential: %w", err)
+	}
+	client, err := azcosmos.NewClientWithKey(endpoint, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos client: %w", err)
+	}
+	c, err := client.NewContainer(db, container)
+	if err != nil {
+		return nil, fmt.Errorf("open container %q in %q: %w", container, db, err)
+	}
+	opts := &azcosmos.QueryOptions{PageSizeHint: clampPageSize(pageSize)}
+	return &cosmosPager{pager: c.NewQueryItemsPager(enumerateQuery, azcosmos.NewPartitionKey(), opts)}, nil
+}
+
+func clampPageSize(n int) int32 {
+	const maxPageSize = 1000
+	if n <= 0 {
+		return 100
+	}
+	if n > maxPageSize {
+		return maxPageSize
+	}
+	return int32(n) //nolint:gosec // n is bounded to [1,1000] above, no overflow
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/api-go/cmd/pgbackfill-notifstate/main_test.go
+++ b/api-go/cmd/pgbackfill-notifstate/main_test.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+)
+
+// discardLogger is a no-op logger so tests stay quiet.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// rawStateDoc builds a minimal valid NotificationState-container document body
+// for userId. The JSON shape mirrors the stateDocument wire format (camelCase
+// keys, DotNetTime lastReadAt), which is what the Cosmos pager yields.
+func rawStateDoc(userID string) []byte {
+	return []byte(`{"id":"` + userID + `","userId":"` + userID + `",` +
+		`"lastReadAt":"2026-06-26T12:00:00+00:00","version":1}`)
+}
+
+// fakeStatePager yields successive pages of raw document bodies, or a fixed error.
+type fakeStatePager struct {
+	pages [][][]byte
+	idx   int
+	err   error
+}
+
+func (p *fakeStatePager) More() bool { return p.idx < len(p.pages) }
+
+func (p *fakeStatePager) NextPage(_ context.Context) ([][]byte, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	page := p.pages[p.idx]
+	p.idx++
+	return page, nil
+}
+
+// fakeStateSaver records every saved state and can fail by user id.
+type fakeStateSaver struct {
+	saved  []notificationstate.State
+	failOn map[string]error
+}
+
+func (u *fakeStateSaver) Save(_ context.Context, st notificationstate.State) error {
+	if err := u.failOn[st.UserID]; err != nil {
+		return err
+	}
+	u.saved = append(u.saved, st)
+	return nil
+}
+
+func TestBackfill_SavesAllRecordsAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakeStatePager{pages: [][][]byte{
+		{rawStateDoc("auth0|u-a"), rawStateDoc("auth0|u-b")},
+		{rawStateDoc("auth0|u-c")},
+	}}
+	store := &fakeStateSaver{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 3 || got.errors != 0 {
+		t.Errorf("summary: got %+v, want read=3 upserted=3 errors=0", got)
+	}
+	if len(store.saved) != 3 {
+		t.Errorf("store: saved %d records, want 3", len(store.saved))
+	}
+}
+
+func TestBackfill_ContinuesPastDecodeError(t *testing.T) {
+	t.Parallel()
+	pager := &fakeStatePager{pages: [][][]byte{
+		{rawStateDoc("auth0|u-a"), []byte("not json"), rawStateDoc("auth0|u-b")},
+	}}
+	store := &fakeStateSaver{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestBackfill_ContinuesPastSaveError(t *testing.T) {
+	t.Parallel()
+	pager := &fakeStatePager{pages: [][][]byte{
+		{rawStateDoc("auth0|u-a"), rawStateDoc("auth0|u-b"), rawStateDoc("auth0|u-c")},
+	}}
+	store := &fakeStateSaver{failOn: map[string]error{"auth0|u-b": errors.New("boom")}}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestBackfill_RespectsLimitAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakeStatePager{pages: [][][]byte{
+		{rawStateDoc("auth0|u-a")},
+		{rawStateDoc("auth0|u-b")},
+		{rawStateDoc("auth0|u-c")},
+	}}
+	store := &fakeStateSaver{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{limit: 2}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 2 || got.upserted != 2 {
+		t.Errorf("summary: got %+v, want read=2 upserted=2", got)
+	}
+	if pager.idx > 2 {
+		t.Errorf("pager consumed %d pages, want it to stop at the limit (<=2)", pager.idx)
+	}
+}
+
+func TestBackfill_PagerErrorReturnsError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("cosmos read failed")
+	pager := &fakeStatePager{pages: [][][]byte{{rawStateDoc("auth0|u-a")}}, err: sentinel}
+	store := &fakeStateSaver{}
+
+	_, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("backfill: got err %v, want wrapped %v", err, sentinel)
+	}
+}
+
+func TestBackfill_ContextCancelAborts(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pager := &fakeStatePager{pages: [][][]byte{{rawStateDoc("auth0|u-a")}}}
+	store := &fakeStateSaver{}
+
+	_, err := backfill(ctx, pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("backfill: got err %v, want context.Canceled", err)
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("store: saved %d records, want 0 (cancelled before any save)", len(store.saved))
+	}
+}

--- a/api-go/internal/notifications/decode.go
+++ b/api-go/internal/notifications/decode.go
@@ -1,0 +1,25 @@
+package notifications
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DecodeDocument hydrates a stored Notifications-container document body into
+// a DigestNotification, reusing the exact field mapping the Cosmos read path
+// uses (digestDocument.toDigest). It exists so the Cosmos → Postgres
+// notifications backfill (cmd/pgbackfill-notifications) shares one transform
+// with the store rather than reinventing the mapping, keeping the two from
+// silently diverging.
+//
+// Legacy rows (predating the eventType / applicationUid fields) are coalesced
+// exactly as the store read path does: a null eventType becomes NewApplication
+// and a null applicationUid falls back to applicationName. A row that fails
+// JSON decode is returned as an error; structural coalescing is not an error.
+func DecodeDocument(raw []byte) (DigestNotification, error) {
+	var doc digestDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return DigestNotification{}, fmt.Errorf("decode notification document: %w", err)
+	}
+	return doc.toDigest(), nil
+}

--- a/api-go/internal/notifications/store_postgres.go
+++ b/api-go/internal/notifications/store_postgres.go
@@ -1,0 +1,368 @@
+package notifications
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// querier is the consumer-side slice of *pgxpool.Pool the store uses.
+// Only Exec and Query are needed — all reads use Query + CollectRows,
+// which keeps the interface fakeable for unit tests (no concrete pgx.Row).
+// Both *pgxpool.Pool and pgx.Tx satisfy it structurally.
+type querier interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+// Store is the full exported method set that notifications consumers rely on.
+// It serves two purposes: a compile-time parity check so *PostgresStore can
+// never silently diverge from the Cosmos method set, and the consumer-side
+// interface the API wiring accepts once the Postgres backend is selected.
+//
+// PurgeOlderThan is deliberately excluded: it has no Cosmos equivalent and is
+// called only by the maintenance worker, not the common API paths.
+type Store interface {
+	Create(ctx context.Context, n DigestNotification) error
+	GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string, lastReadAt time.Time) (map[string]LatestUnread, error)
+	ByUserSince(ctx context.Context, userID string, since time.Time) ([]DigestNotification, error)
+	AllByUser(ctx context.Context, userID string) ([]DigestNotification, error)
+	UnsentEmailsByUser(ctx context.Context, userID string) ([]DigestNotification, error)
+	UserIDsWithUnsentEmails(ctx context.Context) ([]string, error)
+	MarkEmailSent(ctx context.Context, n DigestNotification) error
+	GetByUserAndApplication(ctx context.Context, userID, applicationUID string, authorityID int, eventType EventType) (*DigestNotification, error)
+	DeleteAllByUserID(ctx context.Context, userID string) error
+}
+
+// Compile-time parity: *PostgresStore must satisfy the full Store surface.
+var _ Store = (*PostgresStore)(nil)
+
+// PostgresStore reads and writes notifications in the Postgres `notifications`
+// table (Cosmos → Postgres migration; memo 0010, epic #645).
+//
+// Key differences from the Cosmos split model (CosmosStore / DigestStore /
+// DeleteStore across three types):
+//   - Single struct over one table; the consumer-side interface union is
+//     satisfied by one concrete type, so wiring is simpler.
+//   - UserIDsWithUnsentEmails uses native SELECT DISTINCT — no cross-partition
+//     client-side dedup needed (contrast tc-b7cm and the Cosmos gateway 400).
+//   - The 90-day TTL is replaced by PurgeOlderThan; the INDEX on created_at
+//     makes the DELETE efficient.
+//   - GetLatestUnreadByApplications uses DISTINCT ON for the per-uid reduction,
+//     replacing the Cosmos "first seen wins on newest-first ordered results".
+type PostgresStore struct {
+	db querier
+}
+
+// NewPostgresStore returns a store over the given pgx pool (or any querier).
+func NewPostgresStore(db querier) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+// notifColumns is the full read projection for DigestNotification rows.
+// Its order MUST match scanDigestRow.
+const notifColumns = "id, user_id, application_uid, application_name, watch_zone_id, " +
+	"application_address, application_description, application_type, " +
+	"authority_id, decision, event_type, sources, push_sent, email_sent, created_at"
+
+// scanDigestRow hydrates one row into a full DigestNotification. Used by
+// ByUserSince, AllByUser, UnsentEmailsByUser, and GetByUserAndApplication.
+func scanDigestRow(row pgx.CollectableRow) (DigestNotification, error) {
+	var (
+		id, userID, applicationUID, applicationName string
+		watchZoneID                                 *string
+		applicationAddress, applicationDescription  string
+		applicationType                             *string
+		authorityID                                 int
+		decision                                    *string
+		eventType, sources                          string
+		pushSent, emailSent                         bool
+		createdAt                                   time.Time
+	)
+	if err := row.Scan(
+		&id, &userID, &applicationUID, &applicationName, &watchZoneID,
+		&applicationAddress, &applicationDescription, &applicationType,
+		&authorityID, &decision, &eventType, &sources, &pushSent, &emailSent, &createdAt,
+	); err != nil {
+		return DigestNotification{}, err
+	}
+	et := EventNewApplication
+	if eventType != "" {
+		et = EventType(eventType)
+	}
+	return DigestNotification{
+		ID:                     id,
+		UserID:                 userID,
+		ApplicationUID:         applicationUID,
+		ApplicationName:        applicationName,
+		WatchZoneID:            watchZoneID,
+		ApplicationAddress:     applicationAddress,
+		ApplicationDescription: applicationDescription,
+		ApplicationType:        applicationType,
+		AuthorityID:            authorityID,
+		Decision:               decision,
+		EventType:              et,
+		Sources:                sources,
+		PushSent:               pushSent,
+		EmailSent:              emailSent,
+		CreatedAt:              createdAt,
+	}, nil
+}
+
+// scanLatestUnreadRow hydrates the minimal 4-column projection used by
+// GetLatestUnreadByApplications (application_uid, decision, event_type,
+// created_at). Coalesces an empty event_type to NewApplication so legacy
+// rows (if any exist post-backfill) remain safe.
+func scanLatestUnreadRow(row pgx.CollectableRow) (LatestUnread, error) {
+	var (
+		applicationUID string
+		decision       *string
+		eventType      string
+		createdAt      time.Time
+	)
+	if err := row.Scan(&applicationUID, &decision, &eventType, &createdAt); err != nil {
+		return LatestUnread{}, err
+	}
+	et := EventNewApplication
+	if eventType != "" {
+		et = EventType(eventType)
+	}
+	return LatestUnread{
+		ApplicationUID: applicationUID,
+		EventType:      et,
+		Decision:       decision,
+		CreatedAt:      createdAt,
+	}, nil
+}
+
+const pgCreateQuery = `
+INSERT INTO notifications (
+    id, user_id, application_uid, application_name, watch_zone_id,
+    application_address, application_description, application_type,
+    authority_id, decision, event_type, sources, push_sent, email_sent, created_at
+) VALUES (
+    $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+)
+ON CONFLICT (id) DO UPDATE SET
+    user_id                 = EXCLUDED.user_id,
+    application_uid         = EXCLUDED.application_uid,
+    application_name        = EXCLUDED.application_name,
+    watch_zone_id           = EXCLUDED.watch_zone_id,
+    application_address     = EXCLUDED.application_address,
+    application_description = EXCLUDED.application_description,
+    application_type        = EXCLUDED.application_type,
+    authority_id            = EXCLUDED.authority_id,
+    decision                = EXCLUDED.decision,
+    event_type              = EXCLUDED.event_type,
+    sources                 = EXCLUDED.sources,
+    push_sent               = EXCLUDED.push_sent,
+    email_sent              = EXCLUDED.email_sent,
+    created_at              = EXCLUDED.created_at`
+
+// Create writes a dispatched notification. Idempotent on the notification id
+// (ON CONFLICT (id) DO UPDATE), mirroring the Cosmos UpsertItem-by-document-id
+// contract: re-creating the same id overwrites in place.
+func (s *PostgresStore) Create(ctx context.Context, n DigestNotification) error {
+	_, err := s.db.Exec(ctx, pgCreateQuery,
+		n.ID, n.UserID, n.ApplicationUID, n.ApplicationName, n.WatchZoneID,
+		n.ApplicationAddress, n.ApplicationDescription, n.ApplicationType,
+		n.AuthorityID, n.Decision, string(n.EventType), n.Sources,
+		n.PushSent, n.EmailSent, n.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("create notification %q: %w", n.ID, err)
+	}
+	return nil
+}
+
+// pgLatestUnreadQuery uses DISTINCT ON (application_uid) to return the newest
+// notification per uid in one pass — the Postgres equivalent of the Cosmos
+// "first row seen on a newest-first result set" reduction. The 4-column
+// projection avoids reading full document bodies for a display-only badge.
+const pgLatestUnreadQuery = "SELECT DISTINCT ON (application_uid) " +
+	"application_uid, decision, event_type, created_at " +
+	"FROM notifications " +
+	"WHERE user_id = $1 AND application_uid = ANY($2) AND created_at > $3 " +
+	"ORDER BY application_uid, created_at DESC"
+
+// GetLatestUnreadByApplications returns, for each application uid that has at
+// least one notification created strictly after lastReadAt, the latest such
+// notification — in a single round trip instead of N+1 per-uid queries.
+// An empty uid set returns an empty map without issuing a query, matching the
+// Cosmos early-return guard.
+func (s *PostgresStore) GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string, lastReadAt time.Time) (map[string]LatestUnread, error) {
+	if len(applicationUIDs) == 0 {
+		return map[string]LatestUnread{}, nil
+	}
+	rows, err := s.db.Query(ctx, pgLatestUnreadQuery, userID, applicationUIDs, lastReadAt)
+	if err != nil {
+		return nil, fmt.Errorf("query latest unread for %q: %w", userID, err)
+	}
+	items, err := pgx.CollectRows(rows, scanLatestUnreadRow)
+	if err != nil {
+		return nil, fmt.Errorf("scan latest unread for %q: %w", userID, err)
+	}
+	latest := make(map[string]LatestUnread, len(items))
+	for _, lu := range items {
+		latest[lu.ApplicationUID] = lu
+	}
+	return latest, nil
+}
+
+const pgByUserSinceQuery = "SELECT " + notifColumns +
+	" FROM notifications WHERE user_id = $1 AND created_at >= $2 ORDER BY created_at DESC"
+
+// ByUserSince returns the user's notifications created at or after since,
+// newest first — the weekly-digest window.
+func (s *PostgresStore) ByUserSince(ctx context.Context, userID string, since time.Time) ([]DigestNotification, error) {
+	rows, err := s.db.Query(ctx, pgByUserSinceQuery, userID, since)
+	if err != nil {
+		return nil, fmt.Errorf("query notifications since for %q: %w", userID, err)
+	}
+	items, err := pgx.CollectRows(rows, scanDigestRow)
+	if err != nil {
+		return nil, fmt.Errorf("scan notifications since for %q: %w", userID, err)
+	}
+	if items == nil {
+		return []DigestNotification{}, nil
+	}
+	return items, nil
+}
+
+const pgAllByUserQuery = "SELECT " + notifColumns +
+	" FROM notifications WHERE user_id = $1 ORDER BY created_at ASC"
+
+// AllByUser returns every notification for the user, oldest first, for the
+// GDPR data export (GET /v1/me/data). No time window — the export covers the
+// whole notification history (90 days bounded by PurgeOlderThan, analogous to
+// the Cosmos 90-day TTL).
+func (s *PostgresStore) AllByUser(ctx context.Context, userID string) ([]DigestNotification, error) {
+	rows, err := s.db.Query(ctx, pgAllByUserQuery, userID)
+	if err != nil {
+		return nil, fmt.Errorf("query all notifications for %q: %w", userID, err)
+	}
+	items, err := pgx.CollectRows(rows, scanDigestRow)
+	if err != nil {
+		return nil, fmt.Errorf("scan all notifications for %q: %w", userID, err)
+	}
+	if items == nil {
+		return []DigestNotification{}, nil
+	}
+	return items, nil
+}
+
+const pgUnsentEmailsQuery = "SELECT " + notifColumns +
+	" FROM notifications WHERE user_id = $1 AND NOT email_sent ORDER BY created_at ASC"
+
+// UnsentEmailsByUser returns the user's notifications awaiting an email
+// (email_sent = false), oldest first — the hourly-digest pipeline's per-user
+// read. Replaces the Cosmos OR NOT IS_DEFINED(emailSent) guard: every PG row
+// has email_sent NOT NULL DEFAULT false, so legacy-row handling is unnecessary.
+func (s *PostgresStore) UnsentEmailsByUser(ctx context.Context, userID string) ([]DigestNotification, error) {
+	rows, err := s.db.Query(ctx, pgUnsentEmailsQuery, userID)
+	if err != nil {
+		return nil, fmt.Errorf("query unsent emails for %q: %w", userID, err)
+	}
+	items, err := pgx.CollectRows(rows, scanDigestRow)
+	if err != nil {
+		return nil, fmt.Errorf("scan unsent emails for %q: %w", userID, err)
+	}
+	if items == nil {
+		return []DigestNotification{}, nil
+	}
+	return items, nil
+}
+
+const pgUserIDsWithUnsentEmailsQuery = "SELECT DISTINCT user_id FROM notifications WHERE NOT email_sent"
+
+// UserIDsWithUnsentEmails returns every user id with at least one unsent-email
+// notification — the hourly cycle's candidate set. Uses native DISTINCT instead
+// of the Cosmos cross-partition client-side dedup (the gateway 400 on
+// cross-partition DISTINCT; tc-b7cm does not apply here). A defensive client-
+// side dedup is retained to preserve the contract regardless of the SQL.
+func (s *PostgresStore) UserIDsWithUnsentEmails(ctx context.Context) ([]string, error) {
+	rows, err := s.db.Query(ctx, pgUserIDsWithUnsentEmailsQuery)
+	if err != nil {
+		return nil, fmt.Errorf("query users with unsent emails: %w", err)
+	}
+	raw, err := pgx.CollectRows(rows, pgx.RowTo[string])
+	if err != nil {
+		return nil, fmt.Errorf("scan users with unsent emails: %w", err)
+	}
+	seen := make(map[string]struct{}, len(raw))
+	out := make([]string, 0, len(raw))
+	for _, id := range raw {
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	return out, nil
+}
+
+const pgMarkEmailSentQuery = "UPDATE notifications SET email_sent = true WHERE id = $1"
+
+// MarkEmailSent flips email_sent on the notification so it is excluded from
+// the next hourly cycle, matching the Cosmos UpsertItem path that re-writes
+// the full document with EmailSent = true.
+func (s *PostgresStore) MarkEmailSent(ctx context.Context, n DigestNotification) error {
+	if _, err := s.db.Exec(ctx, pgMarkEmailSentQuery, n.ID); err != nil {
+		return fmt.Errorf("mark email sent for notification %q: %w", n.ID, err)
+	}
+	return nil
+}
+
+const pgGetByUserAndApplicationQuery = "SELECT " + notifColumns +
+	" FROM notifications" +
+	" WHERE user_id = $1 AND application_uid = $2 AND authority_id = $3 AND event_type = $4 LIMIT 1"
+
+// GetByUserAndApplication returns the user's existing notification for the
+// (applicationUID, authorityID, eventType) tuple, or nil when none exists —
+// the "not yet notified" dedup signal the poll fan-out branches on. The UNIQUE
+// constraint on (user_id, application_uid, authority_id, event_type) ensures at
+// most one row matches; LIMIT 1 makes the planner's intent explicit.
+func (s *PostgresStore) GetByUserAndApplication(ctx context.Context, userID, applicationUID string, authorityID int, eventType EventType) (*DigestNotification, error) {
+	rows, err := s.db.Query(ctx, pgGetByUserAndApplicationQuery,
+		userID, applicationUID, authorityID, string(eventType))
+	if err != nil {
+		return nil, fmt.Errorf("query existing notification for %q: %w", userID, err)
+	}
+	items, err := pgx.CollectRows(rows, scanDigestRow)
+	if err != nil {
+		return nil, fmt.Errorf("scan existing notification for %q: %w", userID, err)
+	}
+	if len(items) == 0 {
+		return nil, nil //nolint:nilnil // absent notification is the "not yet notified" signal, not an error
+	}
+	return &items[0], nil
+}
+
+const pgDeleteAllByUserIDQuery = "DELETE FROM notifications WHERE user_id = $1"
+
+// DeleteAllByUserID removes every notification for the user — the GDPR
+// Art. 17 erasure cascade (erasure.ChildDeleter). Deleting zero rows is not
+// an error.
+func (s *PostgresStore) DeleteAllByUserID(ctx context.Context, userID string) error {
+	if _, err := s.db.Exec(ctx, pgDeleteAllByUserIDQuery, userID); err != nil {
+		return fmt.Errorf("delete all notifications for %q: %w", userID, err)
+	}
+	return nil
+}
+
+const pgPurgeOlderThanQuery = "DELETE FROM notifications WHERE created_at < $1"
+
+// PurgeOlderThan deletes every notification created before cutoff and returns
+// the number of rows deleted. It is the Postgres replacement for the Cosmos
+// 90-day TTL: a maintenance worker (later slice) calls it on a schedule.
+// The INDEX on created_at makes the full-table sweep efficient.
+func (s *PostgresStore) PurgeOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	tag, err := s.db.Exec(ctx, pgPurgeOlderThanQuery, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("purge notifications older than %v: %w", cutoff, err)
+	}
+	return tag.RowsAffected(), nil
+}

--- a/api-go/internal/notifications/store_postgres_integration_test.go
+++ b/api-go/internal/notifications/store_postgres_integration_test.go
@@ -1,0 +1,361 @@
+//go:build integration
+
+package notifications
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// newPGNotifStore returns a notifications PostgresStore over a freshly
+// truncated integration-test database. Integration tests must NOT call
+// t.Parallel: pgtest.New holds a session-level advisory lock ensuring all
+// integration tests run serially across the whole module.
+func newPGNotifStore(t *testing.T) *PostgresStore {
+	t.Helper()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "notifications", "notification_state")
+	return NewPostgresStore(pool)
+}
+
+// fixtures
+
+func intNotif(id, userID, applicationUID string, eventType EventType, createdAt time.Time) DigestNotification {
+	return DigestNotification{
+		ID:                     id,
+		UserID:                 userID,
+		ApplicationUID:         applicationUID,
+		ApplicationName:        "22/TEST",
+		ApplicationAddress:     "1 Test Street",
+		ApplicationDescription: "outline planning",
+		AuthorityID:            100,
+		EventType:              eventType,
+		Sources:                "Zone",
+		CreatedAt:              createdAt,
+	}
+}
+
+// --- Create / GetByUserAndApplication (dedup) ---
+
+func TestIntegration_Notifications_CreateAndGetByUserAndApplication(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+	n := intNotif("id-1", "user-1", "uid-A", EventNewApplication,
+		time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC))
+
+	if err := s.Create(ctx, n); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := s.GetByUserAndApplication(ctx, "user-1", "uid-A", 100, EventNewApplication)
+	if err != nil {
+		t.Fatalf("GetByUserAndApplication: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected notification, got nil")
+	}
+	if got.ID != "id-1" {
+		t.Errorf("ID: got %q, want id-1", got.ID)
+	}
+	if got.EventType != EventNewApplication {
+		t.Errorf("EventType: got %q, want NewApplication", got.EventType)
+	}
+}
+
+func TestIntegration_Notifications_Create_Idempotent(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+	n := intNotif("id-1", "user-1", "uid-A", EventNewApplication,
+		time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC))
+
+	if err := s.Create(ctx, n); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	// Same id — ON CONFLICT DO UPDATE must not error.
+	if err := s.Create(ctx, n); err != nil {
+		t.Fatalf("second Create (idempotent): %v", err)
+	}
+
+	// Only one row should exist.
+	all, err := s.AllByUser(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("AllByUser: %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("row count after idempotent create: got %d, want 1", len(all))
+	}
+}
+
+func TestIntegration_Notifications_GetByUserAndApplication_NotFound(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+
+	got, err := s.GetByUserAndApplication(ctx, "user-x", "uid-x", 100, EventNewApplication)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for absent notification, got %+v", got)
+	}
+}
+
+// --- GetLatestUnreadByApplications ---
+
+func TestIntegration_Notifications_GetLatestUnreadByApplications(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	// uid-A: two notifications; the newer (t2) must win.
+	if err := s.Create(ctx, intNotif("n1", "user-1", "uid-A", EventNewApplication, t1)); err != nil {
+		t.Fatalf("Create n1: %v", err)
+	}
+	if err := s.Create(ctx, intNotif("n2", "user-1", "uid-A", EventDecisionUpdate, t2)); err != nil {
+		t.Fatalf("Create n2: %v", err)
+	}
+	// uid-B: one notification.
+	if err := s.Create(ctx, intNotif("n3", "user-1", "uid-B", EventNewApplication, t1)); err != nil {
+		t.Fatalf("Create n3: %v", err)
+	}
+
+	// lastReadAt = t0 — all three rows are after the watermark.
+	got, err := s.GetLatestUnreadByApplications(ctx, "user-1", []string{"uid-A", "uid-B"}, t0)
+	if err != nil {
+		t.Fatalf("GetLatestUnreadByApplications: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("map size: got %d, want 2", len(got))
+	}
+	a := got["uid-A"]
+	if a.EventType != EventDecisionUpdate {
+		t.Errorf("uid-A event: got %q, want DecisionUpdate", a.EventType)
+	}
+	if !a.CreatedAt.Equal(t2) {
+		t.Errorf("uid-A createdAt: got %v, want %v", a.CreatedAt, t2)
+	}
+}
+
+func TestIntegration_Notifications_GetLatestUnreadByApplications_FiltersByLastReadAt(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	// Notification at t1.
+	if err := s.Create(ctx, intNotif("n1", "user-1", "uid-A", EventNewApplication, t1)); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// lastReadAt = t2 (after the notification): should be excluded.
+	got, err := s.GetLatestUnreadByApplications(ctx, "user-1", []string{"uid-A"}, t2)
+	if err != nil {
+		t.Fatalf("GetLatestUnreadByApplications: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty map (all read), got %d entries", len(got))
+	}
+}
+
+// --- ByUserSince / AllByUser ---
+
+func TestIntegration_Notifications_ByUserSince(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, n := range []DigestNotification{
+		intNotif("n1", "user-1", "uid-A", EventNewApplication, t1),
+		intNotif("n2", "user-1", "uid-B", EventNewApplication, t2),
+		intNotif("n3", "user-1", "uid-C", EventNewApplication, t3),
+	} {
+		if err := s.Create(ctx, n); err != nil {
+			t.Fatalf("Create %s: %v", n.ID, err)
+		}
+	}
+
+	// since = t2 (inclusive) → expect n2 and n3 only.
+	got, err := s.ByUserSince(ctx, "user-1", t2)
+	if err != nil {
+		t.Fatalf("ByUserSince: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("count: got %d, want 2", len(got))
+	}
+}
+
+func TestIntegration_Notifications_AllByUser(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := s.Create(ctx, intNotif("n1", "user-1", "uid-A", EventNewApplication, t1)); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.Create(ctx, intNotif("n2", "user-1", "uid-B", EventNewApplication, t2)); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Different user — must not be returned.
+	if err := s.Create(ctx, intNotif("n3", "user-2", "uid-C", EventNewApplication, t1)); err != nil {
+		t.Fatalf("Create user-2: %v", err)
+	}
+
+	got, err := s.AllByUser(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("AllByUser: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("count: got %d, want 2 (user-1 only)", len(got))
+	}
+	// AllByUser returns oldest first.
+	if got[0].ID != "n1" {
+		t.Errorf("first row ID: got %q, want n1 (oldest first)", got[0].ID)
+	}
+}
+
+// --- UnsentEmailsByUser / UserIDsWithUnsentEmails / MarkEmailSent ---
+
+func TestIntegration_Notifications_UnsentEmailsFlow(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	n := intNotif("n1", "user-1", "uid-A", EventNewApplication, t1)
+	if err := s.Create(ctx, n); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Before marking: should appear in unsent list.
+	unsent, err := s.UnsentEmailsByUser(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("UnsentEmailsByUser before mark: %v", err)
+	}
+	if len(unsent) != 1 {
+		t.Fatalf("unsent count before mark: got %d, want 1", len(unsent))
+	}
+
+	// MarkEmailSent.
+	if err := s.MarkEmailSent(ctx, unsent[0]); err != nil {
+		t.Fatalf("MarkEmailSent: %v", err)
+	}
+
+	// After marking: should disappear from unsent list.
+	after, err := s.UnsentEmailsByUser(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("UnsentEmailsByUser after mark: %v", err)
+	}
+	if len(after) != 0 {
+		t.Errorf("unsent count after mark: got %d, want 0", len(after))
+	}
+}
+
+func TestIntegration_Notifications_UserIDsWithUnsentEmails(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := s.Create(ctx, intNotif("n1", "user-A", "uid-1", EventNewApplication, t1)); err != nil {
+		t.Fatalf("Create user-A: %v", err)
+	}
+	if err := s.Create(ctx, intNotif("n2", "user-B", "uid-2", EventNewApplication, t1)); err != nil {
+		t.Fatalf("Create user-B: %v", err)
+	}
+	// Two notifications for user-A — should appear only once.
+	if err := s.Create(ctx, intNotif("n3", "user-A", "uid-3", EventDecisionUpdate, t1)); err != nil {
+		t.Fatalf("Create user-A n3: %v", err)
+	}
+
+	ids, err := s.UserIDsWithUnsentEmails(ctx)
+	if err != nil {
+		t.Fatalf("UserIDsWithUnsentEmails: %v", err)
+	}
+	if len(ids) != 2 {
+		t.Errorf("unique user count: got %d, want 2 (user-A and user-B)", len(ids))
+	}
+}
+
+// --- DeleteAllByUserID ---
+
+func TestIntegration_Notifications_DeleteAllByUserID(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	if err := s.Create(ctx, intNotif("n1", "user-1", "uid-A", EventNewApplication, t1)); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := s.Create(ctx, intNotif("n2", "user-1", "uid-B", EventNewApplication, t1)); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	// Different user — must survive the delete.
+	if err := s.Create(ctx, intNotif("n3", "user-2", "uid-C", EventNewApplication, t1)); err != nil {
+		t.Fatalf("Create user-2: %v", err)
+	}
+
+	if err := s.DeleteAllByUserID(ctx, "user-1"); err != nil {
+		t.Fatalf("DeleteAllByUserID: %v", err)
+	}
+
+	remaining, err := s.AllByUser(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("AllByUser after delete: %v", err)
+	}
+	if len(remaining) != 0 {
+		t.Errorf("user-1 notifications after delete: got %d, want 0", len(remaining))
+	}
+
+	// user-2's row must be intact.
+	other, err := s.AllByUser(ctx, "user-2")
+	if err != nil {
+		t.Fatalf("AllByUser user-2: %v", err)
+	}
+	if len(other) != 1 {
+		t.Errorf("user-2 notifications after user-1 delete: got %d, want 1", len(other))
+	}
+}
+
+// --- PurgeOlderThan ---
+
+func TestIntegration_Notifications_PurgeOlderThan(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+
+	old := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	recent := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	cutoff := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := s.Create(ctx, intNotif("n-old", "user-1", "uid-A", EventNewApplication, old)); err != nil {
+		t.Fatalf("Create old: %v", err)
+	}
+	if err := s.Create(ctx, intNotif("n-recent", "user-1", "uid-B", EventNewApplication, recent)); err != nil {
+		t.Fatalf("Create recent: %v", err)
+	}
+
+	deleted, err := s.PurgeOlderThan(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("PurgeOlderThan: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("rows deleted: got %d, want 1 (only the old row)", deleted)
+	}
+
+	// Recent row must survive.
+	all, err := s.AllByUser(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("AllByUser after purge: %v", err)
+	}
+	if len(all) != 1 || all[0].ID != "n-recent" {
+		t.Errorf("post-purge rows: got %+v, want only n-recent", all)
+	}
+}

--- a/api-go/internal/notifications/store_postgres_test.go
+++ b/api-go/internal/notifications/store_postgres_test.go
@@ -1,0 +1,455 @@
+package notifications
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// --- fakes ---
+
+// fakeQuerier implements querier using pre-configured responses. A single
+// Exec error or Query/scan configuration is set per test; multiple calls
+// can be sequenced via a slice of responses.
+type fakeQuerier struct {
+	// execResponses is consumed in order, one per Exec call.
+	execResponses []execResponse
+	execIdx       int
+	// queryResponses is consumed in order, one per Query call.
+	queryResponses []queryResponse
+	queryIdx       int
+	// recordedSQL captures every SQL statement issued.
+	recordedSQL []string
+}
+
+type execResponse struct {
+	tag pgconn.CommandTag
+	err error
+}
+
+type queryResponse struct {
+	rows pgx.Rows
+	err  error
+}
+
+func (f *fakeQuerier) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	f.recordedSQL = append(f.recordedSQL, sql)
+	if f.execIdx >= len(f.execResponses) {
+		return pgconn.NewCommandTag("EXEC"), nil
+	}
+	r := f.execResponses[f.execIdx]
+	f.execIdx++
+	return r.tag, r.err
+}
+
+func (f *fakeQuerier) Query(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+	f.recordedSQL = append(f.recordedSQL, sql)
+	if f.queryIdx >= len(f.queryResponses) {
+		return &fakeRows{}, nil
+	}
+	r := f.queryResponses[f.queryIdx]
+	f.queryIdx++
+	return r.rows, r.err
+}
+
+// fakeRows is a minimal pgx.Rows implementation backed by pre-baked scan values.
+// Each element of rows is a []any slice that Scan() copies into the dest pointers.
+type fakeRows struct {
+	rows [][]any
+	idx  int
+	err  error
+}
+
+func newFakeRows(rows [][]any) *fakeRows { return &fakeRows{rows: rows} }
+func errRows(err error) *fakeRows        { return &fakeRows{err: err} }
+
+func (r *fakeRows) Next() bool {
+	if r.err != nil {
+		return false
+	}
+	return r.idx < len(r.rows)
+}
+
+func (r *fakeRows) Scan(dest ...any) error {
+	if r.idx >= len(r.rows) {
+		return errors.New("no more rows")
+	}
+	src := r.rows[r.idx]
+	r.idx++
+	if len(src) != len(dest) {
+		return errors.New("scan: column count mismatch")
+	}
+	for i, d := range dest {
+		switch p := d.(type) {
+		case *string:
+			if v, ok := src[i].(string); ok {
+				*p = v
+			} else if src[i] == nil {
+				// leave as zero
+			}
+		case **string:
+			switch v := src[i].(type) {
+			case nil:
+				*p = nil
+			case string:
+				s := v
+				*p = &s
+			case *string:
+				*p = v
+			}
+		case *bool:
+			if v, ok := src[i].(bool); ok {
+				*p = v
+			}
+		case *int:
+			if v, ok := src[i].(int); ok {
+				*p = v
+			}
+		case *int64:
+			if v, ok := src[i].(int64); ok {
+				*p = v
+			}
+		case *time.Time:
+			if v, ok := src[i].(time.Time); ok {
+				*p = v
+			}
+		}
+	}
+	return nil
+}
+
+func (r *fakeRows) Close()                                       {}
+func (r *fakeRows) Err() error                                   { return r.err }
+func (r *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeRows) RawValues() [][]byte                          { return nil }
+func (r *fakeRows) Values() ([]any, error)                       { return nil, nil }
+func (r *fakeRows) Conn() *pgx.Conn                              { return nil }
+
+// --- helpers ---
+
+func newTestNotification() DigestNotification {
+	return DigestNotification{
+		ID:                     "notif-id-1",
+		UserID:                 "user-1",
+		ApplicationUID:         "uid-A",
+		ApplicationName:        "22/0001",
+		ApplicationAddress:     "1 Test Street",
+		ApplicationDescription: "outline planning permission",
+		AuthorityID:            100,
+		EventType:              EventNewApplication,
+		Sources:                "Zone",
+		CreatedAt:              time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+// --- Create ---
+
+func TestPostgresStore_Create_Success(t *testing.T) {
+	t.Parallel()
+	q := &fakeQuerier{
+		execResponses: []execResponse{{tag: pgconn.NewCommandTag("INSERT 0 1")}},
+	}
+	s := NewPostgresStore(q)
+	n := newTestNotification()
+
+	if err := s.Create(context.Background(), n); err != nil {
+		t.Fatalf("Create: unexpected error: %v", err)
+	}
+	if len(q.recordedSQL) != 1 {
+		t.Fatalf("Create: expected 1 SQL call, got %d", len(q.recordedSQL))
+	}
+}
+
+func TestPostgresStore_Create_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("db boom")
+	q := &fakeQuerier{
+		execResponses: []execResponse{{err: boom}},
+	}
+	s := NewPostgresStore(q)
+
+	err := s.Create(context.Background(), newTestNotification())
+	if !errors.Is(err, boom) {
+		t.Fatalf("Create: got err %v, want wrapped %v", err, boom)
+	}
+}
+
+// --- GetLatestUnreadByApplications ---
+
+func TestPostgresStore_GetLatestUnreadByApplications_EmptyUIDs(t *testing.T) {
+	t.Parallel()
+	q := &fakeQuerier{}
+	s := NewPostgresStore(q)
+
+	got, err := s.GetLatestUnreadByApplications(context.Background(), "user-1", nil, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("empty UIDs: got %v, want empty non-nil map", got)
+	}
+	if len(q.recordedSQL) != 0 {
+		t.Error("empty UIDs must not issue any SQL")
+	}
+}
+
+func TestPostgresStore_GetLatestUnreadByApplications_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("query boom")
+	q := &fakeQuerier{
+		queryResponses: []queryResponse{{err: boom}},
+	}
+	s := NewPostgresStore(q)
+
+	_, err := s.GetLatestUnreadByApplications(
+		context.Background(), "user-1", []string{"uid-A"}, time.Now())
+	if !errors.Is(err, boom) {
+		t.Fatalf("got err %v, want wrapped %v", err, boom)
+	}
+}
+
+func TestPostgresStore_GetLatestUnreadByApplications_ReturnsLatestPerUID(t *testing.T) {
+	t.Parallel()
+	// DISTINCT ON returns one row per application_uid (the newest). The fake
+	// returns 2 rows — one per uid — matching the 4-column projection:
+	// application_uid, decision, event_type, created_at.
+	newerCreatedAt := time.Date(2026, 2, 1, 10, 0, 0, 0, time.UTC)
+	uidBCreatedAt := time.Date(2026, 1, 15, 8, 0, 0, 0, time.UTC)
+	q := &fakeQuerier{
+		queryResponses: []queryResponse{
+			{rows: newFakeRows([][]any{
+				// application_uid, decision, event_type, created_at
+				{"uid-A", "Permitted", string(EventDecisionUpdate), newerCreatedAt},
+				{"uid-B", nil, string(EventNewApplication), uidBCreatedAt},
+			})},
+		},
+	}
+	s := NewPostgresStore(q)
+
+	got, err := s.GetLatestUnreadByApplications(
+		context.Background(), "user-1", []string{"uid-A", "uid-B"}, time.Unix(0, 0))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("map size: got %d, want 2", len(got))
+	}
+	a := got["uid-A"]
+	if a.EventType != EventDecisionUpdate {
+		t.Errorf("uid-A event type: got %q, want DecisionUpdate", a.EventType)
+	}
+	if a.Decision == nil || *a.Decision != "Permitted" {
+		t.Errorf("uid-A decision: got %v, want 'Permitted'", a.Decision)
+	}
+	if !a.CreatedAt.Equal(newerCreatedAt) {
+		t.Errorf("uid-A createdAt: got %v, want %v", a.CreatedAt, newerCreatedAt)
+	}
+	b := got["uid-B"]
+	if b.EventType != EventNewApplication {
+		t.Errorf("uid-B event type: got %q, want NewApplication", b.EventType)
+	}
+}
+
+// --- GetByUserAndApplication ---
+
+func TestPostgresStore_GetByUserAndApplication_NotFound(t *testing.T) {
+	t.Parallel()
+	q := &fakeQuerier{
+		queryResponses: []queryResponse{{rows: newFakeRows(nil)}},
+	}
+	s := NewPostgresStore(q)
+
+	got, err := s.GetByUserAndApplication(context.Background(), "user-1", "uid-A", 100, EventNewApplication)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestPostgresStore_GetByUserAndApplication_Found(t *testing.T) {
+	t.Parallel()
+	createdAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	q := &fakeQuerier{
+		queryResponses: []queryResponse{
+			{rows: newFakeRows([][]any{
+				{"notif-id-1", "user-1", "uid-A", "22/0001", nil, "", "", nil,
+					100, nil, string(EventNewApplication), "", false, false, createdAt},
+			})},
+		},
+	}
+	s := NewPostgresStore(q)
+
+	got, err := s.GetByUserAndApplication(context.Background(), "user-1", "uid-A", 100, EventNewApplication)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil notification, got nil")
+	}
+	if got.ID != "notif-id-1" {
+		t.Errorf("ID: got %q, want notif-id-1", got.ID)
+	}
+}
+
+// --- ByUserSince / AllByUser ---
+
+func TestPostgresStore_ByUserSince_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("since boom")
+	q := &fakeQuerier{queryResponses: []queryResponse{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	_, err := s.ByUserSince(context.Background(), "user-1", time.Now())
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+func TestPostgresStore_ByUserSince_ReturnsEmptySliceWhenNone(t *testing.T) {
+	t.Parallel()
+	q := &fakeQuerier{queryResponses: []queryResponse{{rows: newFakeRows(nil)}}}
+	s := NewPostgresStore(q)
+
+	got, err := s.ByUserSince(context.Background(), "user-1", time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("want empty non-nil slice, got %v", got)
+	}
+}
+
+func TestPostgresStore_AllByUser_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("all boom")
+	q := &fakeQuerier{queryResponses: []queryResponse{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	_, err := s.AllByUser(context.Background(), "user-1")
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+// --- UnsentEmailsByUser / UserIDsWithUnsentEmails ---
+
+func TestPostgresStore_UnsentEmailsByUser_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("unsent boom")
+	q := &fakeQuerier{queryResponses: []queryResponse{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	_, err := s.UnsentEmailsByUser(context.Background(), "user-1")
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+func TestPostgresStore_UserIDsWithUnsentEmails_DeduplicatesIDs(t *testing.T) {
+	t.Parallel()
+	q := &fakeQuerier{
+		queryResponses: []queryResponse{
+			{rows: newFakeRows([][]any{
+				{"user-A"},
+				{"user-B"},
+				{"user-A"}, // duplicate — should be deduped
+			})},
+		},
+	}
+	s := NewPostgresStore(q)
+
+	got, err := s.UserIDsWithUnsentEmails(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("want 2 unique user IDs, got %d: %v", len(got), got)
+	}
+}
+
+func TestPostgresStore_UserIDsWithUnsentEmails_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("ids boom")
+	q := &fakeQuerier{queryResponses: []queryResponse{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	_, err := s.UserIDsWithUnsentEmails(context.Background())
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+// --- MarkEmailSent ---
+
+func TestPostgresStore_MarkEmailSent_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("mark boom")
+	q := &fakeQuerier{execResponses: []execResponse{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	err := s.MarkEmailSent(context.Background(), newTestNotification())
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+// --- DeleteAllByUserID ---
+
+func TestPostgresStore_DeleteAllByUserID_Success(t *testing.T) {
+	t.Parallel()
+	q := &fakeQuerier{execResponses: []execResponse{{tag: pgconn.NewCommandTag("DELETE 5")}}}
+	s := NewPostgresStore(q)
+
+	if err := s.DeleteAllByUserID(context.Background(), "user-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPostgresStore_DeleteAllByUserID_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("delete boom")
+	q := &fakeQuerier{execResponses: []execResponse{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	err := s.DeleteAllByUserID(context.Background(), "user-1")
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+// --- PurgeOlderThan ---
+
+func TestPostgresStore_PurgeOlderThan_ReturnsRowsDeleted(t *testing.T) {
+	t.Parallel()
+	q := &fakeQuerier{
+		execResponses: []execResponse{{tag: pgconn.NewCommandTag("DELETE 42")}},
+	}
+	s := NewPostgresStore(q)
+
+	n, err := s.PurgeOlderThan(context.Background(), time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 42 {
+		t.Errorf("rows deleted: got %d, want 42", n)
+	}
+}
+
+func TestPostgresStore_PurgeOlderThan_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("purge boom")
+	q := &fakeQuerier{execResponses: []execResponse{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	_, err := s.PurgeOlderThan(context.Background(), time.Now())
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}

--- a/api-go/internal/notifications/store_postgres_test.go
+++ b/api-go/internal/notifications/store_postgres_test.go
@@ -88,8 +88,6 @@ func (r *fakeRows) Scan(dest ...any) error {
 		case *string:
 			if v, ok := src[i].(string); ok {
 				*p = v
-			} else if src[i] == nil {
-				// leave as zero
 			}
 		case **string:
 			switch v := src[i].(type) {

--- a/api-go/internal/notificationstate/decode.go
+++ b/api-go/internal/notificationstate/decode.go
@@ -1,0 +1,20 @@
+package notificationstate
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DecodeDocument hydrates a stored NotificationState-container document body
+// into a State, reusing the exact field mapping the Cosmos read path uses
+// (stateDocument.toDomain). It exists so the Cosmos → Postgres notification-
+// state backfill (cmd/pgbackfill-notifstate) shares one transform with the
+// store rather than reinventing the mapping, keeping the two from silently
+// diverging.
+func DecodeDocument(raw []byte) (State, error) {
+	var doc stateDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return State{}, fmt.Errorf("decode notification state document: %w", err)
+	}
+	return doc.toDomain(), nil
+}

--- a/api-go/internal/notificationstate/store_postgres.go
+++ b/api-go/internal/notificationstate/store_postgres.go
@@ -1,0 +1,144 @@
+package notificationstate
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// querier is the consumer-side slice of *pgxpool.Pool the store uses.
+// Only Exec and Query are needed — all reads use Query + CollectRows,
+// keeping the interface fakeable for unit tests. Both *pgxpool.Pool and
+// pgx.Tx satisfy it structurally.
+type querier interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+}
+
+// Store is the full exported method set the notificationstate consumers rely
+// on. It serves two purposes: compile-time parity so *PostgresStore can never
+// silently diverge from the method set callers need, and the consumer-side
+// interface the API wiring accepts once the Postgres backend is selected.
+type Store interface {
+	Get(ctx context.Context, userID string) (*State, error)
+	Save(ctx context.Context, st State) error
+	UnreadCount(ctx context.Context, userID string, lastReadAt time.Time) (int, error)
+	DeleteByUserID(ctx context.Context, userID string) error
+}
+
+// Compile-time parity: *PostgresStore must satisfy the full Store surface.
+var _ Store = (*PostgresStore)(nil)
+
+// PostgresStore reads and writes per-user notification watermarks in the
+// `notification_state` table and cross-reads the `notifications` table for
+// the unread count — matching the Cosmos model where CosmosStore spans two
+// containers (NotificationState + Notifications). Both tables live in the
+// same pool, so the cross-read is a plain SQL join on the same connection.
+//
+// Partition strategy (vs Cosmos):
+//   - The Cosmos model uses id == partition key == userId (one document per
+//     user). The Postgres equivalent is `user_id TEXT PRIMARY KEY`.
+//   - UnreadCount issues a SELECT count(*) against the notifications table,
+//     replacing the Cosmos cross-container CountItems call.
+type PostgresStore struct {
+	db querier
+}
+
+// NewPostgresStore returns a store over the given pgx pool (or any querier).
+func NewPostgresStore(db querier) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+// scanStateRow hydrates one row from notification_state.
+// Column order: user_id, last_read_at, version — MUST match all SELECT queries.
+func scanStateRow(row pgx.CollectableRow) (State, error) {
+	var (
+		userID     string
+		lastReadAt time.Time
+		version    int
+	)
+	if err := row.Scan(&userID, &lastReadAt, &version); err != nil {
+		return State{}, err
+	}
+	return State{
+		UserID:     userID,
+		LastReadAt: lastReadAt,
+		Version:    version,
+	}, nil
+}
+
+const pgGetStateQuery = "SELECT user_id, last_read_at, version FROM notification_state WHERE user_id = $1"
+
+// Get point-reads the user's watermark. A missing row returns (nil, nil) —
+// the first-touch signal the handlers branch on, identical to the Cosmos
+// 404-on-ReadItem behaviour.
+func (s *PostgresStore) Get(ctx context.Context, userID string) (*State, error) {
+	rows, err := s.db.Query(ctx, pgGetStateQuery, userID)
+	if err != nil {
+		return nil, fmt.Errorf("read notification state %q: %w", userID, err)
+	}
+	items, err := pgx.CollectRows(rows, scanStateRow)
+	if err != nil {
+		return nil, fmt.Errorf("scan notification state %q: %w", userID, err)
+	}
+	if len(items) == 0 {
+		return nil, nil //nolint:nilnil // absent watermark is the first-touch signal, not an error
+	}
+	st := items[0]
+	return &st, nil
+}
+
+const pgSaveStateQuery = `
+INSERT INTO notification_state (user_id, last_read_at, version)
+VALUES ($1, $2, $3)
+ON CONFLICT (user_id) DO UPDATE SET
+    last_read_at = EXCLUDED.last_read_at,
+    version      = EXCLUDED.version`
+
+// Save upserts the watermark, matching the Cosmos UpsertItem-by-userId
+// contract.
+func (s *PostgresStore) Save(ctx context.Context, st State) error {
+	if _, err := s.db.Exec(ctx, pgSaveStateQuery, st.UserID, st.LastReadAt, st.Version); err != nil {
+		return fmt.Errorf("upsert notification state %q: %w", st.UserID, err)
+	}
+	return nil
+}
+
+// pgUnreadCountQuery counts notifications created strictly after the watermark
+// for the given user, cross-reading the notifications table — the Postgres
+// equivalent of the Cosmos cross-container CountItems call in CosmosStore.
+const pgUnreadCountQuery = "SELECT count(*) FROM notifications WHERE user_id = $1 AND created_at > $2"
+
+// UnreadCount counts the user's notifications created strictly after
+// lastReadAt, matching the Cosmos CountItems semantics (the boundary instant
+// itself counts as read).
+func (s *PostgresStore) UnreadCount(ctx context.Context, userID string, lastReadAt time.Time) (int, error) {
+	rows, err := s.db.Query(ctx, pgUnreadCountQuery, userID, lastReadAt)
+	if err != nil {
+		return 0, fmt.Errorf("count unread for %q: %w", userID, err)
+	}
+	counts, err := pgx.CollectRows(rows, pgx.RowTo[int64])
+	if err != nil {
+		return 0, fmt.Errorf("scan unread count for %q: %w", userID, err)
+	}
+	if len(counts) == 0 {
+		return 0, nil
+	}
+	return int(counts[0]), nil
+}
+
+const pgDeleteStateQuery = "DELETE FROM notification_state WHERE user_id = $1"
+
+// DeleteByUserID removes the user's watermark — the GDPR Art. 17 erasure
+// cascade (bridged to erasure.ChildDeleter by erasure.NotificationStateChild).
+// A missing row (no watermark yet) is not an error, matching the Cosmos
+// 404-tolerant DeleteItem behaviour.
+func (s *PostgresStore) DeleteByUserID(ctx context.Context, userID string) error {
+	if _, err := s.db.Exec(ctx, pgDeleteStateQuery, userID); err != nil {
+		return fmt.Errorf("delete notification state %q: %w", userID, err)
+	}
+	return nil
+}

--- a/api-go/internal/notificationstate/store_postgres_integration_test.go
+++ b/api-go/internal/notificationstate/store_postgres_integration_test.go
@@ -1,0 +1,175 @@
+//go:build integration
+
+package notificationstate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// newPGStateStore returns a PostgresStore over a freshly truncated integration-
+// test database. Both notification_state and notifications are truncated so
+// UnreadCount cross-reads start from a clean slate.
+// Integration tests must NOT call t.Parallel (pgtest advisory lock).
+func newPGStateStore(t *testing.T) (*PostgresStore, *pgxpool.Pool) {
+	t.Helper()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "notification_state", "notifications")
+	return NewPostgresStore(pool), pool
+}
+
+// --- Get / Save round-trip ---
+
+func TestIntegration_NotificationState_GetSave(t *testing.T) {
+	s, _ := newPGStateStore(t)
+	ctx := context.Background()
+
+	// Get on a brand-new user must return nil (first-touch).
+	got, err := s.Get(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("Get (first touch): %v", err)
+	}
+	if got != nil {
+		t.Fatalf("first-touch Get: expected nil, got %+v", got)
+	}
+
+	// Save and read back.
+	lastReadAt := time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC)
+	st := State{UserID: "user-1", LastReadAt: lastReadAt, Version: 2}
+	if err := s.Save(ctx, st); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	back, err := s.Get(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("Get after Save: %v", err)
+	}
+	if back == nil {
+		t.Fatal("Get after Save: expected non-nil state")
+	}
+	if back.UserID != "user-1" {
+		t.Errorf("UserID: got %q, want user-1", back.UserID)
+	}
+	if !back.LastReadAt.Equal(lastReadAt) {
+		t.Errorf("LastReadAt: got %v, want %v", back.LastReadAt, lastReadAt)
+	}
+	if back.Version != 2 {
+		t.Errorf("Version: got %d, want 2", back.Version)
+	}
+}
+
+func TestIntegration_NotificationState_Save_Idempotent(t *testing.T) {
+	s, _ := newPGStateStore(t)
+	ctx := context.Background()
+
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := s.Save(ctx, State{UserID: "user-1", LastReadAt: t1, Version: 1}); err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+	if err := s.Save(ctx, State{UserID: "user-1", LastReadAt: t2, Version: 2}); err != nil {
+		t.Fatalf("second Save: %v", err)
+	}
+
+	got, err := s.Get(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get: expected non-nil state")
+	}
+	if !got.LastReadAt.Equal(t2) {
+		t.Errorf("LastReadAt after update: got %v, want %v", got.LastReadAt, t2)
+	}
+	if got.Version != 2 {
+		t.Errorf("Version after update: got %d, want 2", got.Version)
+	}
+}
+
+// --- UnreadCount cross-reads the notifications table ---
+
+func TestIntegration_NotificationState_UnreadCount(t *testing.T) {
+	s, pool := newPGStateStore(t)
+	ctx := context.Background()
+
+	// Seed two notifications for user-1 using the notifications PostgresStore
+	// (same pool — correct cross-table read).
+	nStore := notifications.NewPostgresStore(pool)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, n := range []notifications.DigestNotification{
+		{ID: "n1", UserID: "user-1", ApplicationUID: "uid-A", ApplicationName: "A",
+			AuthorityID: 100, EventType: notifications.EventNewApplication,
+			Sources: "Zone", CreatedAt: t1},
+		{ID: "n2", UserID: "user-1", ApplicationUID: "uid-B", ApplicationName: "B",
+			AuthorityID: 100, EventType: notifications.EventNewApplication,
+			Sources: "Zone", CreatedAt: t2},
+		{ID: "n3", UserID: "user-1", ApplicationUID: "uid-C", ApplicationName: "C",
+			AuthorityID: 100, EventType: notifications.EventNewApplication,
+			Sources: "Zone", CreatedAt: t3},
+	} {
+		if err := nStore.Create(ctx, n); err != nil {
+			t.Fatalf("seed notification %s: %v", n.ID, err)
+		}
+	}
+
+	// lastReadAt = t1 → n2 (t2) and n3 (t3) are unread.
+	count, err := s.UnreadCount(ctx, "user-1", t1)
+	if err != nil {
+		t.Fatalf("UnreadCount: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("unread count: got %d, want 2", count)
+	}
+
+	// lastReadAt = t3 (at the boundary) → 0 unread (strictly after, t3 itself is read).
+	countAtBoundary, err := s.UnreadCount(ctx, "user-1", t3)
+	if err != nil {
+		t.Fatalf("UnreadCount at boundary: %v", err)
+	}
+	if countAtBoundary != 0 {
+		t.Errorf("unread count at boundary: got %d, want 0", countAtBoundary)
+	}
+}
+
+// --- DeleteByUserID ---
+
+func TestIntegration_NotificationState_DeleteByUserID(t *testing.T) {
+	s, _ := newPGStateStore(t)
+	ctx := context.Background()
+
+	st := State{UserID: "user-1", LastReadAt: time.Now(), Version: 1}
+	if err := s.Save(ctx, st); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if err := s.DeleteByUserID(ctx, "user-1"); err != nil {
+		t.Fatalf("DeleteByUserID: %v", err)
+	}
+
+	got, err := s.Get(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("Get after delete: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil after delete, got %+v", got)
+	}
+}
+
+func TestIntegration_NotificationState_DeleteByUserID_MissingIsNotError(t *testing.T) {
+	s, _ := newPGStateStore(t)
+	ctx := context.Background()
+
+	// Delete a user that has no state row — must not error.
+	if err := s.DeleteByUserID(ctx, "nonexistent-user"); err != nil {
+		t.Fatalf("DeleteByUserID on absent row: %v", err)
+	}
+}

--- a/api-go/internal/notificationstate/store_postgres_test.go
+++ b/api-go/internal/notificationstate/store_postgres_test.go
@@ -1,0 +1,268 @@
+package notificationstate
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// --- fakes ---
+
+type fakeNSQuerier struct {
+	execResponses  []execResp
+	execIdx        int
+	queryResponses []queryResp
+	queryIdx       int
+	recordedSQL    []string
+}
+
+type execResp struct {
+	tag pgconn.CommandTag
+	err error
+}
+
+type queryResp struct {
+	rows pgx.Rows
+	err  error
+}
+
+func (f *fakeNSQuerier) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	f.recordedSQL = append(f.recordedSQL, sql)
+	if f.execIdx >= len(f.execResponses) {
+		return pgconn.NewCommandTag("EXEC"), nil
+	}
+	r := f.execResponses[f.execIdx]
+	f.execIdx++
+	return r.tag, r.err
+}
+
+func (f *fakeNSQuerier) Query(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+	f.recordedSQL = append(f.recordedSQL, sql)
+	if f.queryIdx >= len(f.queryResponses) {
+		return &fakeNSRows{}, nil
+	}
+	r := f.queryResponses[f.queryIdx]
+	f.queryIdx++
+	return r.rows, r.err
+}
+
+// fakeNSRows is a minimal pgx.Rows backed by pre-baked scan values.
+type fakeNSRows struct {
+	rows [][]any
+	idx  int
+	err  error
+}
+
+func newNSRows(rows [][]any) *fakeNSRows { return &fakeNSRows{rows: rows} }
+func errNSRows(err error) *fakeNSRows    { return &fakeNSRows{err: err} }
+
+func (r *fakeNSRows) Next() bool {
+	if r.err != nil {
+		return false
+	}
+	return r.idx < len(r.rows)
+}
+
+func (r *fakeNSRows) Scan(dest ...any) error {
+	if r.idx >= len(r.rows) {
+		return errors.New("no more rows")
+	}
+	src := r.rows[r.idx]
+	r.idx++
+	if len(src) != len(dest) {
+		return errors.New("scan: column count mismatch")
+	}
+	for i, d := range dest {
+		switch p := d.(type) {
+		case *string:
+			if v, ok := src[i].(string); ok {
+				*p = v
+			}
+		case *int:
+			if v, ok := src[i].(int); ok {
+				*p = v
+			}
+		case *int64:
+			if v, ok := src[i].(int64); ok {
+				*p = v
+			}
+		case *time.Time:
+			if v, ok := src[i].(time.Time); ok {
+				*p = v
+			}
+		}
+	}
+	return nil
+}
+
+func (r *fakeNSRows) Close()                                       {}
+func (r *fakeNSRows) Err() error                                   { return r.err }
+func (r *fakeNSRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeNSRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeNSRows) RawValues() [][]byte                          { return nil }
+func (r *fakeNSRows) Values() ([]any, error)                       { return nil, nil }
+func (r *fakeNSRows) Conn() *pgx.Conn                              { return nil }
+
+// --- Get ---
+
+func TestPostgresNSStore_Get_NotFound(t *testing.T) {
+	t.Parallel()
+	q := &fakeNSQuerier{queryResponses: []queryResp{{rows: newNSRows(nil)}}}
+	s := NewPostgresStore(q)
+
+	got, err := s.Get(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil (first-touch), got %+v", got)
+	}
+}
+
+func TestPostgresNSStore_Get_Found(t *testing.T) {
+	t.Parallel()
+	lastReadAt := time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC)
+	q := &fakeNSQuerier{
+		queryResponses: []queryResp{
+			{rows: newNSRows([][]any{
+				// user_id, last_read_at, version
+				{"user-1", lastReadAt, 3},
+			})},
+		},
+	}
+	s := NewPostgresStore(q)
+
+	got, err := s.Get(context.Background(), "user-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected non-nil state, got nil")
+	}
+	if got.UserID != "user-1" {
+		t.Errorf("UserID: got %q, want user-1", got.UserID)
+	}
+	if !got.LastReadAt.Equal(lastReadAt) {
+		t.Errorf("LastReadAt: got %v, want %v", got.LastReadAt, lastReadAt)
+	}
+	if got.Version != 3 {
+		t.Errorf("Version: got %d, want 3", got.Version)
+	}
+}
+
+func TestPostgresNSStore_Get_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("get boom")
+	q := &fakeNSQuerier{queryResponses: []queryResp{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	_, err := s.Get(context.Background(), "user-1")
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+// --- Save ---
+
+func TestPostgresNSStore_Save_Success(t *testing.T) {
+	t.Parallel()
+	q := &fakeNSQuerier{execResponses: []execResp{{tag: pgconn.NewCommandTag("INSERT 0 1")}}}
+	s := NewPostgresStore(q)
+	st := State{UserID: "user-1", LastReadAt: time.Now(), Version: 1}
+
+	if err := s.Save(context.Background(), st); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(q.recordedSQL) != 1 {
+		t.Errorf("expected 1 SQL call, got %d", len(q.recordedSQL))
+	}
+}
+
+func TestPostgresNSStore_Save_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("save boom")
+	q := &fakeNSQuerier{execResponses: []execResp{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	err := s.Save(context.Background(), State{UserID: "user-1", LastReadAt: time.Now()})
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+// --- UnreadCount ---
+
+func TestPostgresNSStore_UnreadCount_ReturnsCount(t *testing.T) {
+	t.Parallel()
+	q := &fakeNSQuerier{
+		queryResponses: []queryResp{
+			{rows: newNSRows([][]any{
+				{int64(7)},
+			})},
+		},
+	}
+	s := NewPostgresStore(q)
+
+	count, err := s.UnreadCount(context.Background(), "user-1", time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 7 {
+		t.Errorf("count: got %d, want 7", count)
+	}
+}
+
+func TestPostgresNSStore_UnreadCount_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("count boom")
+	q := &fakeNSQuerier{queryResponses: []queryResp{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	_, err := s.UnreadCount(context.Background(), "user-1", time.Now())
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+func TestPostgresNSStore_UnreadCount_ZeroWhenNoRows(t *testing.T) {
+	t.Parallel()
+	// An empty result from the count query means 0 unread.
+	q := &fakeNSQuerier{queryResponses: []queryResp{{rows: newNSRows(nil)}}}
+	s := NewPostgresStore(q)
+
+	count, err := s.UnreadCount(context.Background(), "user-1", time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("count: got %d, want 0", count)
+	}
+}
+
+// --- DeleteByUserID ---
+
+func TestPostgresNSStore_DeleteByUserID_Success(t *testing.T) {
+	t.Parallel()
+	q := &fakeNSQuerier{execResponses: []execResp{{tag: pgconn.NewCommandTag("DELETE 1")}}}
+	s := NewPostgresStore(q)
+
+	if err := s.DeleteByUserID(context.Background(), "user-1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPostgresNSStore_DeleteByUserID_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("del boom")
+	q := &fakeNSQuerier{execResponses: []execResp{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	err := s.DeleteByUserID(context.Background(), "user-1")
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}

--- a/api-go/internal/platform/postgres/migrations/0007_notifications.sql
+++ b/api-go/internal/platform/postgres/migrations/0007_notifications.sql
@@ -1,0 +1,48 @@
+-- +goose Up
+
+-- notifications mirrors api-go/internal/notifications/digest.go (DigestNotification)
+-- and the Notifications Cosmos container (partition key /userId, TTL 90 days).
+-- The TTL is replaced by a scheduled PurgeOlderThan(cutoff) DELETE on Postgres.
+--
+-- Primary key: the notification id (a UUID string minted by the poll fan-out).
+-- Uniqueness on (user_id, application_uid, authority_id, event_type) enforces the
+-- GetByUserAndApplication dedup invariant at the DB level — the poll fan-out can
+-- never insert two notifications for the same (user, app, authority, event).
+CREATE TABLE notifications (
+    id                      text        PRIMARY KEY,
+    user_id                 text        NOT NULL,
+    application_uid         text        NOT NULL,
+    application_name        text        NOT NULL DEFAULT '',
+    watch_zone_id           text,
+    application_address     text        NOT NULL DEFAULT '',
+    application_description text        NOT NULL DEFAULT '',
+    application_type        text,
+    authority_id            integer     NOT NULL,
+    decision                text,
+    event_type              text        NOT NULL,
+    sources                 text        NOT NULL DEFAULT '',
+    push_sent               boolean     NOT NULL DEFAULT false,
+    email_sent              boolean     NOT NULL DEFAULT false,
+    created_at              timestamptz NOT NULL,
+    UNIQUE (user_id, application_uid, authority_id, event_type)
+);
+
+-- (user_id, created_at) backs ByUserSince, AllByUser, and the per-user part of
+-- GetLatestUnreadByApplications (WHERE user_id=$1 AND created_at > $3).
+CREATE INDEX notifications_user_created ON notifications (user_id, created_at);
+
+-- application_uid alone backs the ANY($2) application set filter inside
+-- GetLatestUnreadByApplications.
+CREATE INDEX notifications_application_uid ON notifications (application_uid);
+
+-- created_at alone backs the PurgeOlderThan full-table sweep
+-- (DELETE WHERE created_at < $1), avoiding a sequential scan at 90-day TTL runs.
+CREATE INDEX notifications_created_at ON notifications (created_at);
+
+-- (user_id, email_sent) backs UnsentEmailsByUser (WHERE user_id=$1 AND email_sent=false)
+-- and the outer DISTINCT user_id scan in UserIDsWithUnsentEmails.
+CREATE INDEX notifications_user_email_sent ON notifications (user_id, email_sent);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS notifications;

--- a/api-go/internal/platform/postgres/migrations/0008_notification_state.sql
+++ b/api-go/internal/platform/postgres/migrations/0008_notification_state.sql
@@ -1,0 +1,18 @@
+-- +goose Up
+
+-- notification_state mirrors api-go/internal/notificationstate/state.go (State)
+-- and the NotificationState Cosmos container (one document per user, document
+-- id == partition key == user_id). Each user has at most one watermark row.
+--
+-- The notificationstate PostgresStore reads the notifications table (same pool)
+-- for its UnreadCount cross-read, matching the Cosmos store's cross-container
+-- COUNT query.
+CREATE TABLE notification_state (
+    user_id      text        PRIMARY KEY,
+    last_read_at timestamptz NOT NULL,
+    version      integer     NOT NULL DEFAULT 1
+);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS notification_state;


### PR DESCRIPTION
Slice 4 of Phase F single-store cutover (epic #645, spec #669, memo 0010).

- **`notifications.PostgresStore`** — single store over a `notifications` table covering the union of the Cosmos CosmosStore/DeleteStore/DigestStore surface: `Create` (append, dedup via `UNIQUE(user_id, application_uid, authority_id, event_type)`), `GetLatestUnreadByApplications` (`ANY(...)` + lastReadAt), `ByUserSince`/`AllByUser`, `UnsentEmailsByUser`/`UserIDsWithUnsentEmails`/`MarkEmailSent`, `GetByUserAndApplication`, `DeleteAllByUserID` (GDPR), and **`PurgeOlderThan`** replacing the Cosmos 90-day TTL (a later slice schedules it). Migration `0007_notifications.sql`.
- **`notificationstate.PostgresStore`** — Get/Save/`UnreadCount` (cross-reads the notifications table) /`DeleteByUserID` (GDPR). Migration `0008_notification_state.sql`.
- Exported `DecodeDocument` in both packages + `cmd/pgbackfill-notifications` / `cmd/pgbackfill-notifstate`.

No wiring touched (later slice). Unit (fakes, `-race`) + `//go:build integration` pgtest green; build/vet/gofmt/golangci clean.

Bead: tc-hpd2.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)