### PR TITLE
feat(api): Postgres ports for DeviceRegistrations (+180d purge) + SavedApplications (tc-hpd2.10)

### DIFF
--- a/api-go/cmd/pgbackfill-devices/main.go
+++ b/api-go/cmd/pgbackfill-devices/main.go
@@ -1,0 +1,280 @@
+// Command pgbackfill-devices copies user DeviceRegistrations from prod Cosmos into
+// the Postgres `device_registrations` table, for the Cosmos → Postgres migration
+// (docs/memo/0010, epic #645; GH#669 Slice 5). It is the sibling of
+// cmd/pgbackfill-zones (which copies watch zones); this one copies per-user device
+// tokens. It is idempotent and re-runnable: each record is written with the
+// Postgres store's INSERT ... ON CONFLICT (user_id, token) DO UPDATE, so a re-run
+// reconciles rather than duplicates.
+//
+// PII: device tokens are user personal data. Unlike cmd/pgbackfill's public
+// Applications, this tool copies PII. The prod copy is EXPLICITLY AUTHORIZED in
+// issue #669 — the only prod accounts are the owner, his wife, and personal
+// friends/family. Do not point this at any other dataset without the same
+// authorisation.
+//
+// Source (read): prod Cosmos, authenticated with the account KEY (read from the
+// COSMOS_KEY environment variable, never a flag, so it stays out of shell
+// history). The tool enumerates the whole DeviceRegistrations container with a
+// cross-partition `SELECT * FROM c` query, paged via a continuation token.
+//
+// Target (write): Postgres, authenticated passwordless as the Entra ADMIN
+// (DefaultAzureCredential) — the owner/admin role has full DML, whereas the
+// least-priv towncrier_api managed identity is only usable from inside Azure. Pass
+// -pg-db town_crier_prod for the prod copy; the default is the dev database, the
+// safer failure mode if the flag is forgotten.
+//
+// A document that fails to decode (bad JSON or unknown platform) or a single
+// failed Save is counted and skipped, not fatal — see devicetokens.DecodeDocument.
+//
+// Usage (run locally, prod Cosmos key in the environment):
+//
+//	export COSMOS_KEY="$(az cosmosdb keys list -n cosmos-town-crier-shared \
+//	    -g rg-town-crier-shared --type read-only-keys --query primaryReadonlyMasterKey -o tsv)"
+//	pgbackfill-devices -pg-host <fqdn> -pg-admin-user <aad-admin-upn> -pg-db town_crier_prod \
+//	    [-cosmos-db town-crier-prod] [-batch-size 500] [-limit 0]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
+)
+
+// defaultCosmosEndpoint is the shared Cosmos account hosting prod and dev.
+const defaultCosmosEndpoint = "https://cosmos-town-crier-shared.documents.azure.com:443/"
+
+// defaultCosmosDB is the prod logical database the backfill reads from.
+const defaultCosmosDB = "town-crier-prod"
+
+// defaultPostgresDB is the database the backfill writes to by default. The dev
+// database is the safe default, so a forgotten -pg-db flag never accidentally
+// writes prod.
+const defaultPostgresDB = "town_crier_dev"
+
+// enumerateQuery reads every device registration across all partitions.
+const enumerateQuery = "SELECT * FROM c"
+
+// docPager yields successive pages of raw document bodies. The azcosmos query
+// pager satisfies it via cosmosPager; tests inject a hand-written fake.
+type docPager interface {
+	More() bool
+	NextPage(ctx context.Context) ([][]byte, error)
+}
+
+// deviceUpserter writes one device registration idempotently. *devicetokens.PostgresStore
+// satisfies it via Save (INSERT ... ON CONFLICT DO UPDATE); tests inject a fake.
+type deviceUpserter interface {
+	Save(ctx context.Context, reg devicetokens.DeviceRegistration) error
+}
+
+// backfillOptions tune the run.
+type backfillOptions struct {
+	limit    int
+	logEvery int
+}
+
+// summary is the final tally the tool prints.
+type summary struct {
+	read     int
+	upserted int
+	errors   int
+}
+
+// backfill drains every page from pager, decodes each document with
+// devicetokens.DecodeDocument, and saves it into store. It is the testable core,
+// decoupled from Cosmos and Postgres by the docPager / deviceUpserter seams.
+//
+// Resilience: an undecodable document or a single failed Save is counted and
+// skipped — only a source paging error or context cancellation aborts the run.
+func backfill(ctx context.Context, pager docPager, store deviceUpserter, opts backfillOptions, logger *slog.Logger) (summary, error) {
+	var s summary
+	for pager.More() {
+		if opts.limit > 0 && s.read >= opts.limit {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return s, fmt.Errorf("backfill cancelled after %d records: %w", s.read, err)
+		}
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return s, fmt.Errorf("read source page after %d records: %w", s.read, err)
+		}
+		for _, raw := range page {
+			if opts.limit > 0 && s.read >= opts.limit {
+				break
+			}
+			s.read++
+			reg, derr := devicetokens.DecodeDocument(raw)
+			if derr != nil {
+				s.errors++
+				logger.WarnContext(ctx, "skip undecodable device token", "error", derr)
+				continue
+			}
+			if uerr := store.Save(ctx, reg); uerr != nil {
+				if ctx.Err() != nil {
+					return s, fmt.Errorf("backfill cancelled saving token %q after %d records: %w", reg.Token, s.read, uerr)
+				}
+				s.errors++
+				logger.WarnContext(ctx, "save failed", "token", reg.Token, "user", reg.UserID, "error", uerr)
+				continue
+			}
+			s.upserted++
+			if opts.logEvery > 0 && s.read%opts.logEvery == 0 {
+				logger.InfoContext(ctx, "backfill progress", "read", s.read, "upserted", s.upserted, "errors", s.errors)
+			}
+		}
+	}
+	return s, nil
+}
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	os.Exit(run(os.Args[1:], logger))
+}
+
+func run(args []string, logger *slog.Logger) int {
+	fs := flag.NewFlagSet("pgbackfill-devices", flag.ContinueOnError)
+	var (
+		cosmosEndpoint  = fs.String("cosmos-endpoint", defaultCosmosEndpoint, "source Cosmos account endpoint")
+		cosmosDB        = fs.String("cosmos-db", defaultCosmosDB, "source Cosmos logical database")
+		cosmosContainer = fs.String("cosmos-container", platform.CosmosDeviceRegistrationsContainer, "source Cosmos container id")
+		pgHost          = fs.String("pg-host", os.Getenv("POSTGRES_HOST"), "target Postgres server FQDN")
+		pgDB            = fs.String("pg-db", defaultPostgresDB, "target Postgres database")
+		pgAdminUser     = fs.String("pg-admin-user", os.Getenv("POSTGRES_ADMIN_USER"), "Entra admin principal (UPN) to write as")
+		pgSSLMode       = fs.String("pg-sslmode", envOr("POSTGRES_SSLMODE", "require"), "target Postgres sslmode")
+		batchSize       = fs.Int("batch-size", 500, "Cosmos page size and progress-log cadence")
+		limit           = fs.Int("limit", 0, "max records to process (0 = all; a small value smoke-tests)")
+		timeout         = fs.Duration("timeout", 0, "overall timeout (0 = none; SIGINT/SIGTERM still cancel)")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	cosmosKey := os.Getenv("COSMOS_KEY")
+	if cosmosKey == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill-devices: COSMOS_KEY environment variable is required (read-only prod Cosmos account key)")
+		return 2
+	}
+	if *pgHost == "" || *pgAdminUser == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill-devices: -pg-host and -pg-admin-user are required")
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	pager, err := newCosmosPager(*cosmosEndpoint, cosmosKey, *cosmosDB, *cosmosContainer, *batchSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-devices: build cosmos source: %v\n", err)
+		return 1
+	}
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-devices: build azure credential: %v\n", err)
+		return 1
+	}
+	pool, err := postgres.NewTokenCredentialPool(ctx, postgres.ConnParams{
+		Host:    *pgHost,
+		DB:      *pgDB,
+		User:    *pgAdminUser,
+		SSLMode: *pgSSLMode,
+	}, cred)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-devices: build postgres pool: %v\n", err)
+		return 1
+	}
+	defer pool.Close()
+
+	store := devicetokens.NewPostgresStore(pool)
+
+	logger.InfoContext(ctx, "backfill starting",
+		"cosmosEndpoint", *cosmosEndpoint, "cosmosDb", *cosmosDB, "cosmosContainer", *cosmosContainer,
+		"pgHost", *pgHost, "pgDb", *pgDB, "batchSize", *batchSize, "limit", *limit)
+
+	started := time.Now()
+	s, err := backfill(ctx, pager, store, backfillOptions{limit: *limit, logEvery: *batchSize}, logger)
+	logger.InfoContext(ctx, "backfill complete",
+		"read", s.read, "upserted", s.upserted, "errors", s.errors, "elapsed", time.Since(started).String())
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-devices: aborted: %v\n", err)
+		return 1
+	}
+	if s.errors > 0 {
+		logger.WarnContext(ctx, "backfill finished with per-record errors; re-run to reconcile", "errors", s.errors)
+	}
+	return 0
+}
+
+// cosmosPager adapts the azcosmos query pager to the docPager seam.
+type cosmosPager struct {
+	pager *runtime.Pager[azcosmos.QueryItemsResponse]
+}
+
+func (p *cosmosPager) More() bool { return p.pager.More() }
+
+func (p *cosmosPager) NextPage(ctx context.Context) ([][]byte, error) {
+	resp, err := p.pager.NextPage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cosmos next page: %w", err)
+	}
+	return resp.Items, nil
+}
+
+// newCosmosPager builds a key-authenticated Cosmos client and returns a
+// cross-partition pager over the whole container.
+func newCosmosPager(endpoint, key, db, container string, pageSize int) (docPager, error) {
+	cred, err := azcosmos.NewKeyCredential(key)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos key credential: %w", err)
+	}
+	client, err := azcosmos.NewClientWithKey(endpoint, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos client: %w", err)
+	}
+	c, err := client.NewContainer(db, container)
+	if err != nil {
+		return nil, fmt.Errorf("open container %q in %q: %w", container, db, err)
+	}
+	opts := &azcosmos.QueryOptions{PageSizeHint: clampPageSize(pageSize)}
+	return &cosmosPager{pager: c.NewQueryItemsPager(enumerateQuery, azcosmos.NewPartitionKey(), opts)}, nil
+}
+
+// clampPageSize bounds the requested page size into the SDK's int32 hint.
+func clampPageSize(n int) int32 {
+	const maxPageSize = 1000
+	if n <= 0 {
+		return 100
+	}
+	if n > maxPageSize {
+		return maxPageSize
+	}
+	return int32(n) //nolint:gosec // n is bounded to [1,1000] above, no overflow
+}
+
+// envOr returns the environment variable value for key, or fallback when unset.
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/api-go/cmd/pgbackfill-devices/main_test.go
+++ b/api-go/cmd/pgbackfill-devices/main_test.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+)
+
+// discardLogger is a no-op logger so tests stay quiet.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// rawDeviceDoc builds a minimal valid DeviceRegistrations-container document body.
+func rawDeviceDoc(userID, token string) []byte {
+	return []byte(`{"id":"` + token + `","userId":"` + userID + `","token":"` + token + `",` +
+		`"platform":"Ios","registeredAt":"2026-06-26T12:00:00+00:00","ttl":15552000}`)
+}
+
+// fakeDevicePager yields successive pages of raw document bodies, or a fixed error.
+type fakeDevicePager struct {
+	pages [][][]byte
+	idx   int
+	err   error
+}
+
+func (p *fakeDevicePager) More() bool { return p.idx < len(p.pages) }
+
+func (p *fakeDevicePager) NextPage(_ context.Context) ([][]byte, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	page := p.pages[p.idx]
+	p.idx++
+	return page, nil
+}
+
+// fakeDeviceUpserter records every saved registration and can fail by token.
+type fakeDeviceUpserter struct {
+	saved  []devicetokens.DeviceRegistration
+	failOn map[string]error
+}
+
+func (u *fakeDeviceUpserter) Save(_ context.Context, reg devicetokens.DeviceRegistration) error {
+	if err := u.failOn[reg.Token]; err != nil {
+		return err
+	}
+	u.saved = append(u.saved, reg)
+	return nil
+}
+
+func TestDeviceBackfill_SavesAllRecordsAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakeDevicePager{pages: [][][]byte{
+		{rawDeviceDoc("auth0|u1", "tok-a"), rawDeviceDoc("auth0|u2", "tok-b")},
+		{rawDeviceDoc("auth0|u3", "tok-c")},
+	}}
+	store := &fakeDeviceUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 3 || got.errors != 0 {
+		t.Errorf("summary: got %+v, want read=3 upserted=3 errors=0", got)
+	}
+	if len(store.saved) != 3 {
+		t.Errorf("store: saved %d records, want 3", len(store.saved))
+	}
+}
+
+func TestDeviceBackfill_ContinuesPastDecodeError(t *testing.T) {
+	t.Parallel()
+	pager := &fakeDevicePager{pages: [][][]byte{
+		{rawDeviceDoc("auth0|u1", "tok-a"), []byte("not json"), rawDeviceDoc("auth0|u2", "tok-b")},
+	}}
+	store := &fakeDeviceUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestDeviceBackfill_ContinuesPastSaveError(t *testing.T) {
+	t.Parallel()
+	pager := &fakeDevicePager{pages: [][][]byte{
+		{rawDeviceDoc("auth0|u1", "tok-a"), rawDeviceDoc("auth0|u2", "tok-b"), rawDeviceDoc("auth0|u3", "tok-c")},
+	}}
+	store := &fakeDeviceUpserter{failOn: map[string]error{"tok-b": errors.New("boom")}}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestDeviceBackfill_RespectsLimitAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakeDevicePager{pages: [][][]byte{
+		{rawDeviceDoc("auth0|u1", "tok-a")},
+		{rawDeviceDoc("auth0|u2", "tok-b")},
+		{rawDeviceDoc("auth0|u3", "tok-c")},
+	}}
+	store := &fakeDeviceUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{limit: 2}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 2 || got.upserted != 2 {
+		t.Errorf("summary: got %+v, want read=2 upserted=2", got)
+	}
+	if pager.idx > 2 {
+		t.Errorf("pager consumed %d pages, want it to stop at the limit (<=2)", pager.idx)
+	}
+}
+
+func TestDeviceBackfill_PagerErrorReturnsError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("cosmos read failed")
+	pager := &fakeDevicePager{pages: [][][]byte{{rawDeviceDoc("auth0|u1", "tok-a")}}, err: sentinel}
+	store := &fakeDeviceUpserter{}
+
+	_, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("backfill: got err %v, want wrapped %v", err, sentinel)
+	}
+}
+
+func TestDeviceBackfill_ContextCancelAborts(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pager := &fakeDevicePager{pages: [][][]byte{{rawDeviceDoc("auth0|u1", "tok-a")}}}
+	store := &fakeDeviceUpserter{}
+
+	_, err := backfill(ctx, pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("backfill: got err %v, want context.Canceled", err)
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("store: saved %d records, want 0 (cancelled before any save)", len(store.saved))
+	}
+}

--- a/api-go/cmd/pgbackfill-saved/main.go
+++ b/api-go/cmd/pgbackfill-saved/main.go
@@ -1,0 +1,279 @@
+// Command pgbackfill-saved copies user SavedApplications from prod Cosmos into
+// the Postgres `saved_applications` table, for the Cosmos → Postgres migration
+// (docs/memo/0010, epic #645; GH#669 Slice 5). It is the sibling of
+// cmd/pgbackfill-zones (which copies watch zones); this one copies per-user
+// saved-application bookmarks including the embedded application snapshot. It is
+// idempotent and re-runnable: each record is written with the Postgres store's
+// INSERT ... ON CONFLICT (user_id, application_uid) DO UPDATE, so a re-run
+// reconciles rather than duplicates.
+//
+// PII: saved applications are user personal data (they reveal a user's interest
+// in a specific address). Unlike cmd/pgbackfill's public Applications, this tool
+// copies PII. The prod copy is EXPLICITLY AUTHORIZED in issue #669 — the only
+// prod accounts are the owner, his wife, and personal friends/family. Do not
+// point this at any other dataset without the same authorisation.
+//
+// Source (read): prod Cosmos, authenticated with the account KEY (read from the
+// COSMOS_KEY environment variable, never a flag). The tool enumerates the whole
+// SavedApplications container with a cross-partition `SELECT * FROM c` query,
+// paged via a continuation token.
+//
+// Target (write): Postgres, authenticated passwordless as the Entra ADMIN
+// (DefaultAzureCredential). Pass -pg-db town_crier_prod for the prod copy; the
+// default is the dev database, the safer failure mode if the flag is forgotten.
+//
+// A document that fails to decode or a single failed Save is counted and skipped,
+// not fatal — see savedapplications.DecodeDocument.
+//
+// Usage (run locally, prod Cosmos key in the environment):
+//
+//	export COSMOS_KEY="$(az cosmosdb keys list -n cosmos-town-crier-shared \
+//	    -g rg-town-crier-shared --type read-only-keys --query primaryReadonlyMasterKey -o tsv)"
+//	pgbackfill-saved -pg-host <fqdn> -pg-admin-user <aad-admin-upn> -pg-db town_crier_prod \
+//	    [-cosmos-db town-crier-prod] [-batch-size 500] [-limit 0]
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
+	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
+)
+
+// defaultCosmosEndpoint is the shared Cosmos account hosting prod and dev.
+const defaultCosmosEndpoint = "https://cosmos-town-crier-shared.documents.azure.com:443/"
+
+// defaultCosmosDB is the prod logical database the backfill reads from.
+const defaultCosmosDB = "town-crier-prod"
+
+// defaultPostgresDB is the database the backfill writes to by default. The dev
+// database is the safe default, so a forgotten -pg-db flag never accidentally
+// writes prod.
+const defaultPostgresDB = "town_crier_dev"
+
+// enumerateQuery reads every saved application across all partitions.
+const enumerateQuery = "SELECT * FROM c"
+
+// docPager yields successive pages of raw document bodies. The azcosmos query
+// pager satisfies it via cosmosPager; tests inject a hand-written fake.
+type docPager interface {
+	More() bool
+	NextPage(ctx context.Context) ([][]byte, error)
+}
+
+// savedUpserter writes one saved application idempotently. *savedapplications.PostgresStore
+// satisfies it via Save (INSERT ... ON CONFLICT DO UPDATE); tests inject a fake.
+type savedUpserter interface {
+	Save(ctx context.Context, sa savedapplications.SavedApplication) error
+}
+
+// backfillOptions tune the run.
+type backfillOptions struct {
+	limit    int
+	logEvery int
+}
+
+// summary is the final tally the tool prints.
+type summary struct {
+	read     int
+	upserted int
+	errors   int
+}
+
+// backfill drains every page from pager, decodes each document with
+// savedapplications.DecodeDocument, and saves it into store. It is the testable
+// core, decoupled from Cosmos and Postgres by the docPager / savedUpserter seams.
+//
+// Resilience: an undecodable document or a single failed Save is counted and
+// skipped — only a source paging error or context cancellation aborts the run.
+func backfill(ctx context.Context, pager docPager, store savedUpserter, opts backfillOptions, logger *slog.Logger) (summary, error) {
+	var s summary
+	for pager.More() {
+		if opts.limit > 0 && s.read >= opts.limit {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return s, fmt.Errorf("backfill cancelled after %d records: %w", s.read, err)
+		}
+		page, err := pager.NextPage(ctx)
+		if err != nil {
+			return s, fmt.Errorf("read source page after %d records: %w", s.read, err)
+		}
+		for _, raw := range page {
+			if opts.limit > 0 && s.read >= opts.limit {
+				break
+			}
+			s.read++
+			sa, derr := savedapplications.DecodeDocument(raw)
+			if derr != nil {
+				s.errors++
+				logger.WarnContext(ctx, "skip undecodable saved application", "error", derr)
+				continue
+			}
+			if uerr := store.Save(ctx, sa); uerr != nil {
+				if ctx.Err() != nil {
+					return s, fmt.Errorf("backfill cancelled saving %q after %d records: %w", sa.ApplicationUID, s.read, uerr)
+				}
+				s.errors++
+				logger.WarnContext(ctx, "save failed", "application", sa.ApplicationUID, "user", sa.UserID, "error", uerr)
+				continue
+			}
+			s.upserted++
+			if opts.logEvery > 0 && s.read%opts.logEvery == 0 {
+				logger.InfoContext(ctx, "backfill progress", "read", s.read, "upserted", s.upserted, "errors", s.errors)
+			}
+		}
+	}
+	return s, nil
+}
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	os.Exit(run(os.Args[1:], logger))
+}
+
+func run(args []string, logger *slog.Logger) int {
+	fs := flag.NewFlagSet("pgbackfill-saved", flag.ContinueOnError)
+	var (
+		cosmosEndpoint  = fs.String("cosmos-endpoint", defaultCosmosEndpoint, "source Cosmos account endpoint")
+		cosmosDB        = fs.String("cosmos-db", defaultCosmosDB, "source Cosmos logical database")
+		cosmosContainer = fs.String("cosmos-container", platform.CosmosSavedApplicationsContainer, "source Cosmos container id")
+		pgHost          = fs.String("pg-host", os.Getenv("POSTGRES_HOST"), "target Postgres server FQDN")
+		pgDB            = fs.String("pg-db", defaultPostgresDB, "target Postgres database")
+		pgAdminUser     = fs.String("pg-admin-user", os.Getenv("POSTGRES_ADMIN_USER"), "Entra admin principal (UPN) to write as")
+		pgSSLMode       = fs.String("pg-sslmode", envOr("POSTGRES_SSLMODE", "require"), "target Postgres sslmode")
+		batchSize       = fs.Int("batch-size", 500, "Cosmos page size and progress-log cadence")
+		limit           = fs.Int("limit", 0, "max records to process (0 = all; a small value smoke-tests)")
+		timeout         = fs.Duration("timeout", 0, "overall timeout (0 = none; SIGINT/SIGTERM still cancel)")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+
+	cosmosKey := os.Getenv("COSMOS_KEY")
+	if cosmosKey == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill-saved: COSMOS_KEY environment variable is required (read-only prod Cosmos account key)")
+		return 2
+	}
+	if *pgHost == "" || *pgAdminUser == "" {
+		fmt.Fprintln(os.Stderr, "pgbackfill-saved: -pg-host and -pg-admin-user are required")
+		return 2
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	if *timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, *timeout)
+		defer cancel()
+	}
+
+	pager, err := newCosmosPager(*cosmosEndpoint, cosmosKey, *cosmosDB, *cosmosContainer, *batchSize)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-saved: build cosmos source: %v\n", err)
+		return 1
+	}
+
+	cred, err := azidentity.NewDefaultAzureCredential(nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-saved: build azure credential: %v\n", err)
+		return 1
+	}
+	pool, err := postgres.NewTokenCredentialPool(ctx, postgres.ConnParams{
+		Host:    *pgHost,
+		DB:      *pgDB,
+		User:    *pgAdminUser,
+		SSLMode: *pgSSLMode,
+	}, cred)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-saved: build postgres pool: %v\n", err)
+		return 1
+	}
+	defer pool.Close()
+
+	store := savedapplications.NewPostgresStore(pool)
+
+	logger.InfoContext(ctx, "backfill starting",
+		"cosmosEndpoint", *cosmosEndpoint, "cosmosDb", *cosmosDB, "cosmosContainer", *cosmosContainer,
+		"pgHost", *pgHost, "pgDb", *pgDB, "batchSize", *batchSize, "limit", *limit)
+
+	started := time.Now()
+	s, err := backfill(ctx, pager, store, backfillOptions{limit: *limit, logEvery: *batchSize}, logger)
+	logger.InfoContext(ctx, "backfill complete",
+		"read", s.read, "upserted", s.upserted, "errors", s.errors, "elapsed", time.Since(started).String())
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "pgbackfill-saved: aborted: %v\n", err)
+		return 1
+	}
+	if s.errors > 0 {
+		logger.WarnContext(ctx, "backfill finished with per-record errors; re-run to reconcile", "errors", s.errors)
+	}
+	return 0
+}
+
+// cosmosPager adapts the azcosmos query pager to the docPager seam.
+type cosmosPager struct {
+	pager *runtime.Pager[azcosmos.QueryItemsResponse]
+}
+
+func (p *cosmosPager) More() bool { return p.pager.More() }
+
+func (p *cosmosPager) NextPage(ctx context.Context) ([][]byte, error) {
+	resp, err := p.pager.NextPage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("cosmos next page: %w", err)
+	}
+	return resp.Items, nil
+}
+
+// newCosmosPager builds a key-authenticated Cosmos client and returns a
+// cross-partition pager over the whole container.
+func newCosmosPager(endpoint, key, db, container string, pageSize int) (docPager, error) {
+	cred, err := azcosmos.NewKeyCredential(key)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos key credential: %w", err)
+	}
+	client, err := azcosmos.NewClientWithKey(endpoint, cred, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build cosmos client: %w", err)
+	}
+	c, err := client.NewContainer(db, container)
+	if err != nil {
+		return nil, fmt.Errorf("open container %q in %q: %w", container, db, err)
+	}
+	opts := &azcosmos.QueryOptions{PageSizeHint: clampPageSize(pageSize)}
+	return &cosmosPager{pager: c.NewQueryItemsPager(enumerateQuery, azcosmos.NewPartitionKey(), opts)}, nil
+}
+
+// clampPageSize bounds the requested page size into the SDK's int32 hint.
+func clampPageSize(n int) int32 {
+	const maxPageSize = 1000
+	if n <= 0 {
+		return 100
+	}
+	if n > maxPageSize {
+		return maxPageSize
+	}
+	return int32(n) //nolint:gosec // n is bounded to [1,1000] above, no overflow
+}
+
+// envOr returns the environment variable value for key, or fallback when unset.
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/api-go/cmd/pgbackfill-saved/main_test.go
+++ b/api-go/cmd/pgbackfill-saved/main_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
+)
+
+// discardLogger is a no-op logger so tests stay quiet.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// rawSavedDoc builds a minimal valid SavedApplications-container document body.
+// The embedded application snapshot is included so DecodeDocument produces a
+// non-nil Application field — mirroring the real Cosmos documents.
+func rawSavedDoc(userID, appUID string, authorityID int) []byte {
+	return []byte(`{` +
+		`"id":"` + userID + `:` + appUID + `",` +
+		`"userId":"` + userID + `",` +
+		`"applicationUid":"` + appUID + `",` +
+		`"authorityId":` + itoa(authorityID) + `,` +
+		`"savedAt":"2026-06-26T12:00:00+00:00",` +
+		`"application":{` +
+		`"name":"24/00001/FUL","uid":"uid-1","areaName":"Testshire",` +
+		`"areaId":` + itoa(authorityID) + `,"address":"1 Test St","description":"test",` +
+		`"lastDifferent":"2026-06-26T00:00:00+00:00"` +
+		`}}`)
+}
+
+// itoa converts an int to its decimal string — avoids importing strconv for a
+// test-only helper.
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	s := ""
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		s = string(rune('0'+n%10)) + s
+		n /= 10
+	}
+	if neg {
+		s = "-" + s
+	}
+	return s
+}
+
+// fakeSavedPager yields successive pages of raw document bodies, or a fixed error.
+type fakeSavedPager struct {
+	pages [][][]byte
+	idx   int
+	err   error
+}
+
+func (p *fakeSavedPager) More() bool { return p.idx < len(p.pages) }
+
+func (p *fakeSavedPager) NextPage(_ context.Context) ([][]byte, error) {
+	if p.err != nil {
+		return nil, p.err
+	}
+	page := p.pages[p.idx]
+	p.idx++
+	return page, nil
+}
+
+// fakeSavedUpserter records every saved application and can fail by applicationUID.
+type fakeSavedUpserter struct {
+	saved  []savedapplications.SavedApplication
+	failOn map[string]error
+}
+
+func (u *fakeSavedUpserter) Save(_ context.Context, sa savedapplications.SavedApplication) error {
+	if err := u.failOn[sa.ApplicationUID]; err != nil {
+		return err
+	}
+	u.saved = append(u.saved, sa)
+	return nil
+}
+
+func TestSavedBackfill_SavesAllRecordsAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakeSavedPager{pages: [][][]byte{
+		{rawSavedDoc("auth0|u1", "uid-a", 100), rawSavedDoc("auth0|u2", "uid-b", 100)},
+		{rawSavedDoc("auth0|u3", "uid-c", 200)},
+	}}
+	store := &fakeSavedUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 3 || got.errors != 0 {
+		t.Errorf("summary: got %+v, want read=3 upserted=3 errors=0", got)
+	}
+	if len(store.saved) != 3 {
+		t.Errorf("store: saved %d records, want 3", len(store.saved))
+	}
+}
+
+func TestSavedBackfill_ContinuesPastDecodeError(t *testing.T) {
+	t.Parallel()
+	pager := &fakeSavedPager{pages: [][][]byte{
+		{rawSavedDoc("auth0|u1", "uid-a", 100), []byte("not json"), rawSavedDoc("auth0|u2", "uid-b", 100)},
+	}}
+	store := &fakeSavedUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestSavedBackfill_ContinuesPastSaveError(t *testing.T) {
+	t.Parallel()
+	pager := &fakeSavedPager{pages: [][][]byte{
+		{rawSavedDoc("auth0|u1", "uid-a", 100), rawSavedDoc("auth0|u2", "uid-b", 100), rawSavedDoc("auth0|u3", "uid-c", 100)},
+	}}
+	// Build uid-b's canonical UID: NewSavedApplication computes it as areaId/name
+	// but in DecodeDocument -> toDomain we use the raw applicationUid from the doc.
+	store := &fakeSavedUpserter{failOn: map[string]error{"uid-b": errors.New("boom")}}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 3 || got.upserted != 2 || got.errors != 1 {
+		t.Errorf("summary: got %+v, want read=3 upserted=2 errors=1", got)
+	}
+}
+
+func TestSavedBackfill_RespectsLimitAcrossPages(t *testing.T) {
+	t.Parallel()
+	pager := &fakeSavedPager{pages: [][][]byte{
+		{rawSavedDoc("auth0|u1", "uid-a", 100)},
+		{rawSavedDoc("auth0|u2", "uid-b", 100)},
+		{rawSavedDoc("auth0|u3", "uid-c", 100)},
+	}}
+	store := &fakeSavedUpserter{}
+
+	got, err := backfill(context.Background(), pager, store, backfillOptions{limit: 2}, discardLogger())
+	if err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if got.read != 2 || got.upserted != 2 {
+		t.Errorf("summary: got %+v, want read=2 upserted=2", got)
+	}
+	if pager.idx > 2 {
+		t.Errorf("pager consumed %d pages, want it to stop at the limit (<=2)", pager.idx)
+	}
+}
+
+func TestSavedBackfill_PagerErrorReturnsError(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("cosmos read failed")
+	pager := &fakeSavedPager{pages: [][][]byte{{rawSavedDoc("auth0|u1", "uid-a", 100)}}, err: sentinel}
+	store := &fakeSavedUpserter{}
+
+	_, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("backfill: got err %v, want wrapped %v", err, sentinel)
+	}
+}
+
+func TestSavedBackfill_ContextCancelAborts(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pager := &fakeSavedPager{pages: [][][]byte{{rawSavedDoc("auth0|u1", "uid-a", 100)}}}
+	store := &fakeSavedUpserter{}
+
+	_, err := backfill(ctx, pager, store, backfillOptions{}, discardLogger())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("backfill: got err %v, want context.Canceled", err)
+	}
+	if len(store.saved) != 0 {
+		t.Errorf("store: saved %d records, want 0 (cancelled before any save)", len(store.saved))
+	}
+}
+
+// TestSavedBackfill_DecodePreservesAuthorityID verifies that DecodeDocument
+// populates AuthorityID from the document's authorityId field, not from the
+// embedded snapshot's areaId — the Cosmos toDomain coalescence path.
+func TestSavedBackfill_DecodePreservesAuthorityID(t *testing.T) {
+	t.Parallel()
+	// authorityId=100 in the doc; areaId in the snapshot is also 100 here, but
+	// the coalescence logic is exercised by the non-nil authorityId branch.
+	doc := rawSavedDoc("auth0|u1", "uid-a", 100)
+	pager := &fakeSavedPager{pages: [][][]byte{{doc}}}
+	store := &fakeSavedUpserter{}
+
+	if _, err := backfill(context.Background(), pager, store, backfillOptions{}, discardLogger()); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	if len(store.saved) != 1 {
+		t.Fatalf("store: saved %d records, want 1", len(store.saved))
+	}
+	if store.saved[0].AuthorityID != 100 {
+		t.Errorf("AuthorityID: got %d, want 100", store.saved[0].AuthorityID)
+	}
+	if store.saved[0].SavedAt.IsZero() {
+		t.Error("SavedAt: got zero, want non-zero")
+	}
+	_ = time.Time{} // ensure time import is used
+}

--- a/api-go/internal/devicetokens/decode.go
+++ b/api-go/internal/devicetokens/decode.go
@@ -1,0 +1,20 @@
+package devicetokens
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DecodeDocument hydrates a stored DeviceRegistrations-container document body
+// into a domain DeviceRegistration, reusing the exact field mapping the Cosmos
+// read path uses (deviceDocument.toDomain). It exists so the Cosmos → Postgres
+// device-token backfill (cmd/pgbackfill-devices) shares one transform with the
+// store rather than reinventing the mapping, which keeps the two from silently
+// diverging.
+func DecodeDocument(raw []byte) (DeviceRegistration, error) {
+	var doc deviceDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return DeviceRegistration{}, fmt.Errorf("decode device token document: %w", err)
+	}
+	return doc.toDomain()
+}

--- a/api-go/internal/devicetokens/integration_test.go
+++ b/api-go/internal/devicetokens/integration_test.go
@@ -1,0 +1,270 @@
+//go:build integration
+
+package devicetokens
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// newDevicePGStore returns a Postgres-backed device-token store over a truncated
+// database. Integration tests are NOT parallel: they share the docker-compose DB
+// and the pgtest advisory lock serialises them.
+func newDevicePGStore(t *testing.T) *PostgresStore {
+	t.Helper()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "device_registrations")
+	return NewPostgresStore(pool)
+}
+
+// pgReg builds a DeviceRegistration fixture at a fixed instant.
+func pgReg(t *testing.T, userID, token string, platform DevicePlatform, registeredAt time.Time) DeviceRegistration {
+	t.Helper()
+	reg, err := NewRegistration(userID, token, platform, registeredAt)
+	if err != nil {
+		t.Fatalf("NewRegistration(%s/%s): %v", userID, token, err)
+	}
+	return reg
+}
+
+func assertRegEqual(t *testing.T, got, want DeviceRegistration) {
+	t.Helper()
+	if !got.RegisteredAt.Equal(want.RegisteredAt) {
+		t.Errorf("RegisteredAt: got %v, want %v", got.RegisteredAt, want.RegisteredAt)
+	}
+	g, w := got, want
+	g.RegisteredAt, w.RegisteredAt = time.Time{}, time.Time{}
+	if !reflect.DeepEqual(g, w) {
+		t.Errorf("registration mismatch:\n got = %+v\nwant = %+v", g, w)
+	}
+}
+
+// TestDevicePostgresStore_SaveGetByToken round-trips a registration through Save
+// then GetByToken and asserts field-level equality.
+func TestDevicePostgresStore_SaveGetByToken(t *testing.T) {
+	ctx := context.Background()
+	store := newDevicePGStore(t)
+
+	now := time.Date(2026, 6, 27, 10, 0, 0, 0, time.UTC)
+	want := pgReg(t, "auth0|u1", "tok-abc", PlatformIos, now)
+
+	if err := store.Save(ctx, want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.GetByToken(ctx, "auth0|u1", "tok-abc")
+	if err != nil {
+		t.Fatalf("GetByToken: %v", err)
+	}
+	if got == nil {
+		t.Fatal("GetByToken: got nil, want the saved registration")
+	}
+	assertRegEqual(t, *got, want)
+}
+
+// TestDevicePostgresStore_GetByToken_Missing returns (nil, nil) for an absent token.
+func TestDevicePostgresStore_GetByToken_Missing(t *testing.T) {
+	ctx := context.Background()
+	store := newDevicePGStore(t)
+
+	got, err := store.GetByToken(ctx, "auth0|u1", "no-such-token")
+	if err != nil {
+		t.Fatalf("GetByToken missing: got err %v", err)
+	}
+	if got != nil {
+		t.Errorf("GetByToken missing: got %+v, want nil", got)
+	}
+}
+
+// TestDevicePostgresStore_Save_UpsertResets re-saving updates registered_at and
+// platform (matching the Cosmos TTL-reset semantics on re-PUT).
+func TestDevicePostgresStore_Save_UpsertResets(t *testing.T) {
+	ctx := context.Background()
+	store := newDevicePGStore(t)
+
+	first := pgReg(t, "auth0|u1", "tok", PlatformIos, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err := store.Save(ctx, first); err != nil {
+		t.Fatalf("Save first: %v", err)
+	}
+
+	refreshed := pgReg(t, "auth0|u1", "tok", PlatformAndroid, time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC))
+	if err := store.Save(ctx, refreshed); err != nil {
+		t.Fatalf("Save refreshed: %v", err)
+	}
+
+	got, err := store.GetByToken(ctx, "auth0|u1", "tok")
+	if err != nil || got == nil {
+		t.Fatalf("GetByToken: got (%v, %v)", got, err)
+	}
+	assertRegEqual(t, *got, refreshed)
+}
+
+// TestDevicePostgresStore_Delete removes a token; a second delete is idempotent
+// (no error, unlike the Cosmos variant which also tolerates a 404).
+func TestDevicePostgresStore_Delete(t *testing.T) {
+	ctx := context.Background()
+	store := newDevicePGStore(t)
+
+	reg := pgReg(t, "auth0|u1", "tok", PlatformIos, time.Now())
+	if err := store.Save(ctx, reg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := store.Delete(ctx, "auth0|u1", "tok"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	got, err := store.GetByToken(ctx, "auth0|u1", "tok")
+	if err != nil {
+		t.Fatalf("GetByToken after delete: %v", err)
+	}
+	if got != nil {
+		t.Errorf("GetByToken after delete: got %+v, want nil", got)
+	}
+	// Second delete is idempotent.
+	if err := store.Delete(ctx, "auth0|u1", "tok"); err != nil {
+		t.Fatalf("Delete again: %v", err)
+	}
+}
+
+// TestDevicePostgresStore_ListByUser lists a user's tokens in registered_at order
+// and excludes other users' tokens.
+func TestDevicePostgresStore_ListByUser(t *testing.T) {
+	ctx := context.Background()
+	store := newDevicePGStore(t)
+
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	for _, reg := range []DeviceRegistration{
+		pgReg(t, "auth0|u1", "tok-b", PlatformIos, t2),
+		pgReg(t, "auth0|u1", "tok-a", PlatformIos, t1),
+		pgReg(t, "auth0|other", "tok-c", PlatformIos, t3),
+	} {
+		if err := store.Save(ctx, reg); err != nil {
+			t.Fatalf("Save %s: %v", reg.Token, err)
+		}
+	}
+
+	got, err := store.ListByUser(ctx, "auth0|u1")
+	if err != nil {
+		t.Fatalf("ListByUser: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ListByUser: got %d registrations, want 2", len(got))
+	}
+	// Ordered by registered_at ascending: tok-a first, tok-b second.
+	if got[0].Token != "tok-a" || got[1].Token != "tok-b" {
+		t.Errorf("ListByUser order: got [%s %s], want [tok-a tok-b]", got[0].Token, got[1].Token)
+	}
+}
+
+// TestDevicePostgresStore_DeleteAllByUserID clears one user's tokens and leaves
+// other users' tokens intact.
+func TestDevicePostgresStore_DeleteAllByUserID(t *testing.T) {
+	ctx := context.Background()
+	store := newDevicePGStore(t)
+
+	now := time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)
+	for _, reg := range []DeviceRegistration{
+		pgReg(t, "auth0|u1", "tok-1", PlatformIos, now),
+		pgReg(t, "auth0|u1", "tok-2", PlatformIos, now),
+		pgReg(t, "auth0|other", "tok-3", PlatformIos, now),
+	} {
+		if err := store.Save(ctx, reg); err != nil {
+			t.Fatalf("Save %s: %v", reg.Token, err)
+		}
+	}
+
+	if err := store.DeleteAllByUserID(ctx, "auth0|u1"); err != nil {
+		t.Fatalf("DeleteAllByUserID: %v", err)
+	}
+	left, err := store.ListByUser(ctx, "auth0|u1")
+	if err != nil {
+		t.Fatalf("ListByUser u1: %v", err)
+	}
+	if len(left) != 0 {
+		t.Errorf("expected 0 tokens for u1, got %d", len(left))
+	}
+	other, err := store.ListByUser(ctx, "auth0|other")
+	if err != nil {
+		t.Fatalf("ListByUser other: %v", err)
+	}
+	if len(other) != 1 {
+		t.Errorf("expected other's token untouched, got %d", len(other))
+	}
+}
+
+// TestDevicePostgresStore_PurgeOlderThan deletes only registrations whose
+// registered_at is before the cutoff and returns the correct deleted count.
+func TestDevicePostgresStore_PurgeOlderThan(t *testing.T) {
+	ctx := context.Background()
+	store := newDevicePGStore(t)
+
+	cutoff := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	old1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)   // before cutoff → purged
+	old2 := time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC)  // before cutoff → purged
+	fresh := time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC) // after cutoff → kept
+
+	for _, reg := range []DeviceRegistration{
+		pgReg(t, "auth0|u1", "tok-old1", PlatformIos, old1),
+		pgReg(t, "auth0|u2", "tok-old2", PlatformIos, old2),
+		pgReg(t, "auth0|u3", "tok-fresh", PlatformIos, fresh),
+	} {
+		if err := store.Save(ctx, reg); err != nil {
+			t.Fatalf("Save %s: %v", reg.Token, err)
+		}
+	}
+
+	deleted, err := store.PurgeOlderThan(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("PurgeOlderThan: %v", err)
+	}
+	if deleted != 2 {
+		t.Errorf("PurgeOlderThan deleted %d, want 2", deleted)
+	}
+
+	// Fresh token survives.
+	got, err := store.GetByToken(ctx, "auth0|u3", "tok-fresh")
+	if err != nil || got == nil {
+		t.Fatalf("GetByToken fresh: got (%v, %v)", got, err)
+	}
+	// Old tokens are gone.
+	for _, pair := range [][2]string{{"auth0|u1", "tok-old1"}, {"auth0|u2", "tok-old2"}} {
+		gone, err := store.GetByToken(ctx, pair[0], pair[1])
+		if err != nil {
+			t.Fatalf("GetByToken %s: %v", pair[1], err)
+		}
+		if gone != nil {
+			t.Errorf("PurgeOlderThan: token %s should be gone, got %+v", pair[1], gone)
+		}
+	}
+}
+
+// TestDevicePostgresStore_PurgeOlderThan_NoneMatch returns 0 when no rows are old
+// enough to purge.
+func TestDevicePostgresStore_PurgeOlderThan_NoneMatch(t *testing.T) {
+	ctx := context.Background()
+	store := newDevicePGStore(t)
+
+	now := time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)
+	reg := pgReg(t, "auth0|u1", "tok", PlatformIos, now)
+	if err := store.Save(ctx, reg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Cutoff is before the registration → nothing to purge.
+	deleted, err := store.PurgeOlderThan(ctx, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("PurgeOlderThan: %v", err)
+	}
+	if deleted != 0 {
+		t.Errorf("PurgeOlderThan deleted %d, want 0", deleted)
+	}
+	// Verify errors.Is does not fire incorrectly.
+	_ = errors.Is(err, nil)
+}

--- a/api-go/internal/devicetokens/store_postgres.go
+++ b/api-go/internal/devicetokens/store_postgres.go
@@ -1,0 +1,182 @@
+package devicetokens
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// querier is the consumer-side slice of *pgxpool.Pool the store uses:
+// parameterised exec/query/query-row. Both *pgxpool.Pool and pgx.Tx satisfy it
+// structurally, so the store is testable without a real connection.
+type querier interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// Store is the full device-registration method set both *CosmosStore and
+// *PostgresStore satisfy. It serves two purposes: a compile-time parity check
+// (both stores must satisfy it, so the Postgres port can never silently diverge)
+// and the exported consumer-side interface the later wiring slice flag-selects on.
+//
+// PurgeOlderThan is deliberately NOT in Store: it replaces the Cosmos 180-day TTL
+// and exists only on *PostgresStore (a later slice schedules it).
+type Store interface {
+	GetByToken(ctx context.Context, userID, token string) (*DeviceRegistration, error)
+	Save(ctx context.Context, reg DeviceRegistration) error
+	Delete(ctx context.Context, userID, token string) error
+	ListByUser(ctx context.Context, userID string) ([]DeviceRegistration, error)
+	DeleteAllByUserID(ctx context.Context, userID string) error
+}
+
+// Compile-time parity: both stores satisfy the same consumer-side Store interface.
+var (
+	_ Store = (*CosmosStore)(nil)
+	_ Store = (*PostgresStore)(nil)
+)
+
+// PostgresStore reads and writes device registrations in the Postgres
+// `device_registrations` table (Cosmos → Postgres migration; memo 0010, epic #645).
+//
+// Partition strategy: the Cosmos container is partitioned by /userId with document
+// id == token; the natural PK here is (user_id, token), matching exactly.
+// PurgeOlderThan replaces the Cosmos 180-day TTL: registered_at is the ageing field.
+type PostgresStore struct {
+	db querier
+}
+
+// NewPostgresStore returns a store backed by the given pgx pool or querier.
+func NewPostgresStore(db querier) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+const pgGetByTokenQuery = "SELECT user_id, token, platform, registered_at " +
+	"FROM device_registrations WHERE user_id = $1 AND token = $2"
+
+// GetByToken point-reads the registration for (userID, token). A missing row
+// returns (nil, nil) — the "not registered yet" signal the PUT handler branches on;
+// any other failure is wrapped.
+func (s *PostgresStore) GetByToken(ctx context.Context, userID, token string) (*DeviceRegistration, error) {
+	var (
+		uid          string
+		tok          string
+		platformStr  string
+		registeredAt time.Time
+	)
+	err := s.db.QueryRow(ctx, pgGetByTokenQuery, userID, token).Scan(&uid, &tok, &platformStr, &registeredAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil //nolint:nilnil // absent registration is a valid "not found" signal, not an error
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read device token %q: %w", token, err)
+	}
+	platform, err := ParsePlatform(platformStr)
+	if err != nil {
+		return nil, fmt.Errorf("parse platform for device token %q: %w", token, err)
+	}
+	return &DeviceRegistration{
+		UserID:       uid,
+		Token:        tok,
+		Platform:     platform,
+		RegisteredAt: registeredAt,
+	}, nil
+}
+
+const pgSaveDeviceQuery = `
+INSERT INTO device_registrations (user_id, token, platform, registered_at)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (user_id, token) DO UPDATE SET
+    platform      = EXCLUDED.platform,
+    registered_at = EXCLUDED.registered_at`
+
+// Save upserts the device registration keyed on (user_id, token). A re-PUT
+// resets registered_at (the ageing field for PurgeOlderThan) to the client's
+// current instant, matching the Cosmos TTL-reset semantics.
+func (s *PostgresStore) Save(ctx context.Context, reg DeviceRegistration) error {
+	if _, err := s.db.Exec(ctx, pgSaveDeviceQuery,
+		reg.UserID, reg.Token, reg.Platform.String(), reg.RegisteredAt); err != nil {
+		return fmt.Errorf("upsert device token %q: %w", reg.Token, err)
+	}
+	return nil
+}
+
+const pgDeleteDeviceQuery = "DELETE FROM device_registrations WHERE user_id = $1 AND token = $2"
+
+// Delete removes the registration for (userID, token). A missing row is not an
+// error: the DELETE endpoint is idempotent (the token may already be gone).
+func (s *PostgresStore) Delete(ctx context.Context, userID, token string) error {
+	if _, err := s.db.Exec(ctx, pgDeleteDeviceQuery, userID, token); err != nil {
+		return fmt.Errorf("delete device token %q: %w", token, err)
+	}
+	return nil
+}
+
+const pgListByUserQuery = "SELECT user_id, token, platform, registered_at " +
+	"FROM device_registrations WHERE user_id = $1 ORDER BY registered_at"
+
+// ListByUser returns every registration in the user's partition, ordered by
+// registered_at. Used by the GDPR data-export path.
+func (s *PostgresStore) ListByUser(ctx context.Context, userID string) ([]DeviceRegistration, error) {
+	rows, err := s.db.Query(ctx, pgListByUserQuery, userID)
+	if err != nil {
+		return nil, fmt.Errorf("query device tokens for %q: %w", userID, err)
+	}
+	defer rows.Close()
+
+	var regs []DeviceRegistration
+	for rows.Next() {
+		var (
+			uid          string
+			tok          string
+			platformStr  string
+			registeredAt time.Time
+		)
+		if err := rows.Scan(&uid, &tok, &platformStr, &registeredAt); err != nil {
+			return nil, fmt.Errorf("scan device token for %q: %w", userID, err)
+		}
+		platform, err := ParsePlatform(platformStr)
+		if err != nil {
+			return nil, fmt.Errorf("parse platform for device token %q: %w", tok, err)
+		}
+		regs = append(regs, DeviceRegistration{
+			UserID:       uid,
+			Token:        tok,
+			Platform:     platform,
+			RegisteredAt: registeredAt,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("device token rows for %q: %w", userID, err)
+	}
+	return regs, nil
+}
+
+const pgDeleteAllDevicesQuery = "DELETE FROM device_registrations WHERE user_id = $1"
+
+// DeleteAllByUserID removes every device registration for the user. Used by the
+// GDPR erasure cascade (dormant cleanup and DELETE /v1/me).
+func (s *PostgresStore) DeleteAllByUserID(ctx context.Context, userID string) error {
+	if _, err := s.db.Exec(ctx, pgDeleteAllDevicesQuery, userID); err != nil {
+		return fmt.Errorf("delete all device tokens for %q: %w", userID, err)
+	}
+	return nil
+}
+
+const pgPurgeDevicesQuery = "DELETE FROM device_registrations WHERE registered_at < $1"
+
+// PurgeOlderThan deletes every registration whose registered_at is before cutoff
+// and returns the number of rows deleted. It replaces the Cosmos 180-day TTL: a
+// caller schedules this with time.Now().Add(-180 * 24 * time.Hour) to enforce the
+// UK GDPR Art. 5(1)(e) storage limitation for device identifiers.
+func (s *PostgresStore) PurgeOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
+	tag, err := s.db.Exec(ctx, pgPurgeDevicesQuery, cutoff)
+	if err != nil {
+		return 0, fmt.Errorf("purge device tokens older than %v: %w", cutoff, err)
+	}
+	return tag.RowsAffected(), nil
+}

--- a/api-go/internal/devicetokens/store_postgres_test.go
+++ b/api-go/internal/devicetokens/store_postgres_test.go
@@ -1,0 +1,188 @@
+package devicetokens
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// fakeQuerier is a hand-written fake implementing the querier interface for
+// error-path unit tests of PostgresStore. It stores canned responses for each
+// method; tests set whichever fields they exercise.
+type fakeQuerier struct {
+	execTag  pgconn.CommandTag
+	execErr  error
+	queryErr error
+	rowErr   error
+}
+
+func (f *fakeQuerier) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	return f.execTag, f.execErr
+}
+
+func (f *fakeQuerier) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return &emptyDeviceRows{}, nil
+}
+
+func (f *fakeQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	return &errDeviceRow{err: f.rowErr}
+}
+
+// emptyDeviceRows is a pgx.Rows that reports no rows and no error. It satisfies
+// the full pgx.Rows interface (including the Conn method added in pgx v5).
+type emptyDeviceRows struct{}
+
+func (r *emptyDeviceRows) Close()                                       {}
+func (r *emptyDeviceRows) Err() error                                   { return nil }
+func (r *emptyDeviceRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *emptyDeviceRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *emptyDeviceRows) Next() bool                                   { return false }
+func (r *emptyDeviceRows) Scan(_ ...any) error                          { return errors.New("no rows") }
+func (r *emptyDeviceRows) Values() ([]any, error)                       { return nil, nil }
+func (r *emptyDeviceRows) RawValues() [][]byte                          { return nil }
+func (r *emptyDeviceRows) Conn() *pgx.Conn                              { return nil }
+
+// errDeviceRow is a pgx.Row whose Scan always returns the stored error (or nil).
+type errDeviceRow struct{ err error }
+
+func (r *errDeviceRow) Scan(_ ...any) error { return r.err }
+
+// TestPostgresStore_GetByToken_Missing returns (nil, nil) when the row is absent —
+// the "not registered yet" signal the PUT handler branches on.
+func TestPostgresStore_GetByToken_Missing(t *testing.T) {
+	t.Parallel()
+
+	fq := &fakeQuerier{rowErr: pgx.ErrNoRows}
+	store := NewPostgresStore(fq)
+
+	got, err := store.GetByToken(context.Background(), "auth0|u1", "tok-missing")
+	if err != nil {
+		t.Fatalf("GetByToken missing: got err %v, want nil", err)
+	}
+	if got != nil {
+		t.Errorf("GetByToken missing: got %+v, want nil", got)
+	}
+}
+
+// TestPostgresStore_GetByToken_DBError surfaces a non-ErrNoRows error from the
+// database.
+func TestPostgresStore_GetByToken_DBError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	fq := &fakeQuerier{rowErr: sentinel}
+	store := NewPostgresStore(fq)
+
+	_, err := store.GetByToken(context.Background(), "auth0|u1", "tok")
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("GetByToken DB error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// TestPostgresStore_Save_PropagatesExecError surfaces an Exec failure.
+func TestPostgresStore_Save_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	fq := &fakeQuerier{execErr: sentinel}
+	store := NewPostgresStore(fq)
+
+	reg, _ := NewRegistration("auth0|u1", "tok", PlatformIos, time.Now())
+	if err := store.Save(context.Background(), reg); !errors.Is(err, sentinel) {
+		t.Fatalf("Save error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// TestPostgresStore_Delete_PropagatesExecError surfaces an Exec failure.
+func TestPostgresStore_Delete_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	fq := &fakeQuerier{execErr: sentinel}
+	store := NewPostgresStore(fq)
+
+	if err := store.Delete(context.Background(), "auth0|u1", "tok"); !errors.Is(err, sentinel) {
+		t.Fatalf("Delete error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// TestPostgresStore_ListByUser_EmptyReturnsNil returns nil (not an empty slice)
+// when the user has no registrations — consistent with the zero-value slice and
+// callers that range over the result.
+func TestPostgresStore_ListByUser_EmptyReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	fq := &fakeQuerier{}
+	store := NewPostgresStore(fq)
+
+	got, err := store.ListByUser(context.Background(), "auth0|u1")
+	if err != nil {
+		t.Fatalf("ListByUser empty: got err %v", err)
+	}
+	if got != nil {
+		t.Errorf("ListByUser empty: got %v, want nil", got)
+	}
+}
+
+// TestPostgresStore_ListByUser_QueryError surfaces a Query failure.
+func TestPostgresStore_ListByUser_QueryError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	fq := &fakeQuerier{queryErr: sentinel}
+	store := NewPostgresStore(fq)
+
+	if _, err := store.ListByUser(context.Background(), "auth0|u1"); !errors.Is(err, sentinel) {
+		t.Fatalf("ListByUser query error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// TestPostgresStore_DeleteAllByUserID_PropagatesExecError surfaces an Exec failure.
+func TestPostgresStore_DeleteAllByUserID_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	fq := &fakeQuerier{execErr: sentinel}
+	store := NewPostgresStore(fq)
+
+	if err := store.DeleteAllByUserID(context.Background(), "auth0|u1"); !errors.Is(err, sentinel) {
+		t.Fatalf("DeleteAllByUserID error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// TestPostgresStore_PurgeOlderThan_ReturnsRowCount verifies that PurgeOlderThan
+// returns the RowsAffected count from Exec.
+func TestPostgresStore_PurgeOlderThan_ReturnsRowCount(t *testing.T) {
+	t.Parallel()
+
+	fq := &fakeQuerier{execTag: pgconn.NewCommandTag("DELETE 7")}
+	store := NewPostgresStore(fq)
+
+	got, err := store.PurgeOlderThan(context.Background(), time.Now())
+	if err != nil {
+		t.Fatalf("PurgeOlderThan: got err %v", err)
+	}
+	if got != 7 {
+		t.Errorf("PurgeOlderThan rows affected: got %d, want 7", got)
+	}
+}
+
+// TestPostgresStore_PurgeOlderThan_PropagatesExecError surfaces an Exec failure.
+func TestPostgresStore_PurgeOlderThan_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	fq := &fakeQuerier{execErr: sentinel}
+	store := NewPostgresStore(fq)
+
+	if _, err := store.PurgeOlderThan(context.Background(), time.Now()); !errors.Is(err, sentinel) {
+		t.Fatalf("PurgeOlderThan error: got %v, want wrapped %v", err, sentinel)
+	}
+}

--- a/api-go/internal/platform/postgres/migrations/0009_device_registrations.sql
+++ b/api-go/internal/platform/postgres/migrations/0009_device_registrations.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+
+-- device_registrations mirrors api-go/internal/devicetokens/document.go
+-- (deviceDocument). The Cosmos container is partitioned by /userId with document
+-- id == token, so the natural PK is (user_id, token). registered_at is the
+-- timestamp the 180-day purge job ages on, replacing the Cosmos TTL.
+CREATE TABLE device_registrations (
+    user_id       text        NOT NULL,
+    token         text        NOT NULL,
+    platform      text        NOT NULL,
+    registered_at timestamptz NOT NULL,
+    PRIMARY KEY (user_id, token)
+);
+
+-- Per-user listing for GDPR export / ListByUser.
+CREATE INDEX device_registrations_user ON device_registrations (user_id);
+-- Supports the 180-day purge sweep (DELETE WHERE registered_at < cutoff).
+CREATE INDEX device_registrations_registered_at ON device_registrations (registered_at);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS device_registrations;

--- a/api-go/internal/platform/postgres/migrations/0010_saved_applications.sql
+++ b/api-go/internal/platform/postgres/migrations/0010_saved_applications.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+
+-- saved_applications mirrors api-go/internal/savedapplications/document.go
+-- (savedApplicationDocument). The Cosmos container is partitioned by /userId with
+-- document id "{userId}:{applicationUid}", so the natural PK is
+-- (user_id, application_uid). The embedded applications.SnapshotDocument is stored
+-- as jsonb so the list endpoint and snapshot refresher need no extra hydration
+-- query and nothing the export/refresh needs is lost.
+--
+-- authority_id is load-bearing on the hot poll fan-out path (UserIDsForApplication):
+-- PlanIt uids collide across councils (tc-th98 / GH#384), so the composite index
+-- on (application_uid, authority_id) makes the query index-served.
+CREATE TABLE saved_applications (
+    user_id         text        NOT NULL,
+    application_uid text        NOT NULL,
+    authority_id    integer     NOT NULL DEFAULT 0,
+    saved_at        timestamptz NOT NULL,
+    snapshot        jsonb,
+    PRIMARY KEY (user_id, application_uid)
+);
+
+-- Per-user listing for GDPR export / GetByUserID.
+CREATE INDEX saved_applications_user ON saved_applications (user_id);
+-- Serves the cross-partition UserIDsForApplication fan-out (hot poll path).
+CREATE INDEX saved_applications_application ON saved_applications (application_uid, authority_id);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS saved_applications;

--- a/api-go/internal/savedapplications/decode.go
+++ b/api-go/internal/savedapplications/decode.go
@@ -1,0 +1,24 @@
+package savedapplications
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// DecodeDocument hydrates a stored SavedApplications-container document body into
+// a domain SavedApplication, reusing the exact field mapping the Cosmos read path
+// uses (savedApplicationDocument.toDomain). It exists so the Cosmos → Postgres
+// saved-application backfill (cmd/pgbackfill-saved) shares one transform with
+// the store rather than reinventing the mapping, which keeps the two from
+// silently diverging.
+//
+// authorityID coalesces in toDomain(): the document's authorityId field takes
+// precedence; when absent the embedded snapshot's areaId fills in, exactly as the
+// store read path does.
+func DecodeDocument(raw []byte) (SavedApplication, error) {
+	var doc savedApplicationDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return SavedApplication{}, fmt.Errorf("decode saved application document: %w", err)
+	}
+	return doc.toDomain(), nil
+}

--- a/api-go/internal/savedapplications/integration_test.go
+++ b/api-go/internal/savedapplications/integration_test.go
@@ -1,0 +1,333 @@
+//go:build integration
+
+package savedapplications
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// newSavedPGStore returns a Postgres-backed saved-application store over a
+// truncated database. Integration tests are NOT parallel: they share the
+// docker-compose DB and the pgtest advisory lock serialises them.
+func newSavedPGStore(t *testing.T) *PostgresStore {
+	t.Helper()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "saved_applications")
+	return NewPostgresStore(pool)
+}
+
+// pgApp builds a minimal PlanningApplication fixture.
+func pgApp(name string, areaID int) applications.PlanningApplication {
+	return applications.PlanningApplication{
+		Name:          name,
+		UID:           "uid-" + name,
+		AreaName:      "Testshire",
+		AreaID:        areaID,
+		Address:       "1 Test Street",
+		Description:   "test application",
+		LastDifferent: time.Date(2026, 6, 27, 10, 0, 0, 0, time.UTC),
+	}
+}
+
+// pgSavedApp is a convenience constructor for test fixtures.
+func pgSavedApp(t *testing.T, userID string, app applications.PlanningApplication, savedAt time.Time) SavedApplication {
+	t.Helper()
+	return NewSavedApplication(userID, app, savedAt)
+}
+
+func assertSavedAppEqual(t *testing.T, got, want SavedApplication) {
+	t.Helper()
+	if !got.SavedAt.Equal(want.SavedAt) {
+		t.Errorf("SavedAt: got %v, want %v", got.SavedAt, want.SavedAt)
+	}
+	g, w := got, want
+	g.SavedAt, w.SavedAt = time.Time{}, time.Time{}
+	// Nil-snapshot paths: compare Application pointer vs nil.
+	if (g.Application == nil) != (w.Application == nil) {
+		t.Errorf("Application nil mismatch: got %v, want %v", g.Application, w.Application)
+		return
+	}
+	if g.Application != nil {
+		ga, wa := *g.Application, *w.Application
+		// LastDifferent round-trips through timestamptz.
+		if !ga.LastDifferent.Equal(wa.LastDifferent) {
+			t.Errorf("Application.LastDifferent: got %v, want %v", ga.LastDifferent, wa.LastDifferent)
+		}
+		ga.LastDifferent, wa.LastDifferent = time.Time{}, time.Time{}
+		if !reflect.DeepEqual(ga, wa) {
+			t.Errorf("Application mismatch:\n got  = %+v\nwant = %+v", ga, wa)
+		}
+		g.Application, w.Application = nil, nil
+	}
+	if !reflect.DeepEqual(g, w) {
+		t.Errorf("SavedApplication mismatch:\n got  = %+v\nwant = %+v", g, w)
+	}
+}
+
+// TestSavedPostgresStore_SaveGetByUserID round-trips a saved application through
+// Save and GetByUserID, including the embedded snapshot.
+func TestSavedPostgresStore_SaveGetByUserID(t *testing.T) {
+	ctx := context.Background()
+	store := newSavedPGStore(t)
+
+	app := pgApp("24/00001/FUL", 100)
+	savedAt := time.Date(2026, 6, 27, 10, 0, 0, 0, time.UTC)
+	want := pgSavedApp(t, "auth0|u1", app, savedAt)
+
+	if err := store.Save(ctx, want); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.GetByUserID(ctx, "auth0|u1")
+	if err != nil {
+		t.Fatalf("GetByUserID: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("GetByUserID: got %d records, want 1", len(got))
+	}
+	assertSavedAppEqual(t, got[0], want)
+}
+
+// TestSavedPostgresStore_Exists reports true after a save and false before.
+func TestSavedPostgresStore_Exists(t *testing.T) {
+	ctx := context.Background()
+	store := newSavedPGStore(t)
+
+	app := pgApp("24/00001/FUL", 100)
+	sa := pgSavedApp(t, "auth0|u1", app, time.Now())
+
+	exists, err := store.Exists(ctx, "auth0|u1", sa.ApplicationUID)
+	if err != nil {
+		t.Fatalf("Exists before save: %v", err)
+	}
+	if exists {
+		t.Error("Exists before save: got true, want false")
+	}
+
+	if err := store.Save(ctx, sa); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	exists, err = store.Exists(ctx, "auth0|u1", sa.ApplicationUID)
+	if err != nil {
+		t.Fatalf("Exists after save: %v", err)
+	}
+	if !exists {
+		t.Error("Exists after save: got false, want true")
+	}
+}
+
+// TestSavedPostgresStore_Delete removes a record; a second delete is idempotent.
+func TestSavedPostgresStore_Delete(t *testing.T) {
+	ctx := context.Background()
+	store := newSavedPGStore(t)
+
+	app := pgApp("24/00001/FUL", 100)
+	sa := pgSavedApp(t, "auth0|u1", app, time.Now())
+
+	if err := store.Save(ctx, sa); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := store.Delete(ctx, "auth0|u1", sa.ApplicationUID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	exists, err := store.Exists(ctx, "auth0|u1", sa.ApplicationUID)
+	if err != nil || exists {
+		t.Fatalf("Exists after delete: got (%v, %v)", exists, err)
+	}
+	// Idempotent: second delete must not error.
+	if err := store.Delete(ctx, "auth0|u1", sa.ApplicationUID); err != nil {
+		t.Fatalf("Delete again: %v", err)
+	}
+}
+
+// TestSavedPostgresStore_GetByUserID_OrderedAndScoped returns a user's records in
+// saved_at order and excludes other users' records.
+func TestSavedPostgresStore_GetByUserID_OrderedAndScoped(t *testing.T) {
+	ctx := context.Background()
+	store := newSavedPGStore(t)
+
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t2 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	t3 := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	// Insert out of order to exercise the ORDER BY.
+	for _, sa := range []SavedApplication{
+		pgSavedApp(t, "auth0|u1", pgApp("app-b", 100), t2),
+		pgSavedApp(t, "auth0|u1", pgApp("app-a", 100), t1),
+		pgSavedApp(t, "auth0|other", pgApp("app-c", 100), t3),
+	} {
+		if err := store.Save(ctx, sa); err != nil {
+			t.Fatalf("Save %s: %v", sa.ApplicationUID, err)
+		}
+	}
+
+	got, err := store.GetByUserID(ctx, "auth0|u1")
+	if err != nil {
+		t.Fatalf("GetByUserID: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("GetByUserID: got %d records, want 2", len(got))
+	}
+	// Ordered by saved_at: app-a first.
+	if got[0].ApplicationUID != pgSavedApp(t, "auth0|u1", pgApp("app-a", 100), t1).ApplicationUID {
+		t.Errorf("first record: got %q, want app-a uid", got[0].ApplicationUID)
+	}
+}
+
+// TestSavedPostgresStore_Save_Upsert verifies that re-saving the same
+// (user_id, application_uid) updates the existing row (snapshot + authority_id).
+func TestSavedPostgresStore_Save_Upsert(t *testing.T) {
+	ctx := context.Background()
+	store := newSavedPGStore(t)
+
+	app := pgApp("24/00001/FUL", 100)
+	sa := pgSavedApp(t, "auth0|u1", app, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	if err := store.Save(ctx, sa); err != nil {
+		t.Fatalf("Save first: %v", err)
+	}
+
+	// Update the application state so the snapshot changes.
+	state := "Permitted"
+	app.AppState = &state
+	updated := pgSavedApp(t, "auth0|u1", app, time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC))
+	if err := store.Save(ctx, updated); err != nil {
+		t.Fatalf("Save updated: %v", err)
+	}
+
+	got, err := store.GetByUserID(ctx, "auth0|u1")
+	if err != nil {
+		t.Fatalf("GetByUserID: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("GetByUserID after upsert: got %d records, want 1", len(got))
+	}
+	assertSavedAppEqual(t, got[0], updated)
+}
+
+// TestSavedPostgresStore_UserIDsForApplication returns the distinct user ids that
+// have saved the given (applicationUID, authorityID), scoped by authority.
+func TestSavedPostgresStore_UserIDsForApplication(t *testing.T) {
+	ctx := context.Background()
+	store := newSavedPGStore(t)
+
+	app := pgApp("24/00001/FUL", 100)
+	now := time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)
+
+	// Three users in authority 100 save the same application.
+	for _, userID := range []string{"auth0|u1", "auth0|u2", "auth0|u3"} {
+		sa := pgSavedApp(t, userID, app, now)
+		if err := store.Save(ctx, sa); err != nil {
+			t.Fatalf("Save %s: %v", userID, err)
+		}
+	}
+	// One user in a different authority (200) saves an application with the same uid.
+	otherApp := pgApp("24/00001/FUL", 200) // same planit_name, different authority
+	sa := pgSavedApp(t, "auth0|u4", otherApp, now)
+	if err := store.Save(ctx, sa); err != nil {
+		t.Fatalf("Save u4 (authority 200): %v", err)
+	}
+
+	got, err := store.UserIDsForApplication(ctx, app.CanonicalUID(), 100)
+	if err != nil {
+		t.Fatalf("UserIDsForApplication: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("UserIDsForApplication: got %d users, want 3 (authority 100 only)", len(got))
+	}
+	// Authority 200 user must not appear.
+	for _, uid := range got {
+		if uid == "auth0|u4" {
+			t.Errorf("UserIDsForApplication: auth0|u4 (authority 200) leaked into authority 100 result")
+		}
+	}
+}
+
+// TestSavedPostgresStore_UserIDsForApplication_EmptyForMismatch returns an empty
+// result when the authority does not match any saved row.
+func TestSavedPostgresStore_UserIDsForApplication_EmptyForMismatch(t *testing.T) {
+	ctx := context.Background()
+	store := newSavedPGStore(t)
+
+	app := pgApp("24/00001/FUL", 100)
+	sa := pgSavedApp(t, "auth0|u1", app, time.Now())
+	if err := store.Save(ctx, sa); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	got, err := store.UserIDsForApplication(ctx, app.CanonicalUID(), 999)
+	if err != nil {
+		t.Fatalf("UserIDsForApplication wrong authority: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("UserIDsForApplication wrong authority: got %v, want empty", got)
+	}
+}
+
+// TestSavedPostgresStore_DeleteAllByUserID clears one user's records and leaves
+// other users' records intact.
+func TestSavedPostgresStore_DeleteAllByUserID(t *testing.T) {
+	ctx := context.Background()
+	store := newSavedPGStore(t)
+
+	now := time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)
+	for _, sa := range []SavedApplication{
+		pgSavedApp(t, "auth0|u1", pgApp("app-a", 100), now),
+		pgSavedApp(t, "auth0|u1", pgApp("app-b", 100), now),
+		pgSavedApp(t, "auth0|other", pgApp("app-c", 100), now),
+	} {
+		if err := store.Save(ctx, sa); err != nil {
+			t.Fatalf("Save %s: %v", sa.ApplicationUID, err)
+		}
+	}
+
+	if err := store.DeleteAllByUserID(ctx, "auth0|u1"); err != nil {
+		t.Fatalf("DeleteAllByUserID: %v", err)
+	}
+	left, err := store.GetByUserID(ctx, "auth0|u1")
+	if err != nil {
+		t.Fatalf("GetByUserID u1: %v", err)
+	}
+	if len(left) != 0 {
+		t.Errorf("expected 0 records for u1 after DeleteAll, got %d", len(left))
+	}
+	other, err := store.GetByUserID(ctx, "auth0|other")
+	if err != nil {
+		t.Fatalf("GetByUserID other: %v", err)
+	}
+	if len(other) != 1 {
+		t.Errorf("expected other's record untouched, got %d", len(other))
+	}
+}
+
+// TestSavedPostgresStore_NilSnapshot stores a record with no snapshot (nil
+// Application) and confirms the round-trip returns nil Application.
+func TestSavedPostgresStore_NilSnapshot(t *testing.T) {
+	ctx := context.Background()
+	store := newSavedPGStore(t)
+
+	sa := SavedApplication{
+		UserID:         "auth0|u1",
+		ApplicationUID: "100/24/legacy",
+		AuthorityID:    100,
+		SavedAt:        time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC),
+		Application:    nil,
+	}
+	if err := store.Save(ctx, sa); err != nil {
+		t.Fatalf("Save nil snapshot: %v", err)
+	}
+	got, err := store.GetByUserID(ctx, "auth0|u1")
+	if err != nil || len(got) != 1 {
+		t.Fatalf("GetByUserID: got (%v, %v)", got, err)
+	}
+	if got[0].Application != nil {
+		t.Errorf("round-trip nil snapshot: got non-nil Application %+v", got[0].Application)
+	}
+}

--- a/api-go/internal/savedapplications/store_postgres.go
+++ b/api-go/internal/savedapplications/store_postgres.go
@@ -1,0 +1,215 @@
+package savedapplications
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+// querier is the consumer-side slice of *pgxpool.Pool the store uses:
+// parameterised exec/query/query-row. Both *pgxpool.Pool and pgx.Tx satisfy it
+// structurally, so the store is testable without a real connection.
+type querier interface {
+	Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// Store is the full saved-application method set both *CosmosStore and
+// *PostgresStore satisfy. It serves two purposes: a compile-time parity check
+// (both stores must satisfy it, so the Postgres port can never silently diverge)
+// and the exported consumer-side interface the later wiring slice flag-selects on.
+type Store interface {
+	Save(ctx context.Context, sa SavedApplication) error
+	Exists(ctx context.Context, userID, applicationUID string) (bool, error)
+	Delete(ctx context.Context, userID, applicationUID string) error
+	GetByUserID(ctx context.Context, userID string) ([]SavedApplication, error)
+	UserIDsForApplication(ctx context.Context, applicationUID string, authorityID int) ([]string, error)
+	DeleteAllByUserID(ctx context.Context, userID string) error
+}
+
+// Compile-time parity: both stores satisfy the same consumer-side Store interface.
+var (
+	_ Store = (*CosmosStore)(nil)
+	_ Store = (*PostgresStore)(nil)
+)
+
+// PostgresStore reads and writes saved applications in the Postgres
+// `saved_applications` table (Cosmos → Postgres migration; memo 0010, epic #645).
+//
+// Snapshot: the embedded applications.SnapshotDocument is stored as jsonb, so
+// every field the export/refresh path needs survives the round-trip without loss.
+// A nil snapshot stores NULL.
+//
+// UserIDsForApplication scopes on both application_uid AND authority_id, matching
+// the Cosmos impl exactly (PlanIt uids collide across councils — tc-th98 / GH#384,
+// so a uid-only match would falsely fan out a decision to bookmark holders in
+// another authority). The (application_uid, authority_id) composite index makes
+// this query index-served on the hot poll path.
+type PostgresStore struct {
+	db querier
+}
+
+// NewPostgresStore returns a store backed by the given pgx pool or querier.
+func NewPostgresStore(db querier) *PostgresStore {
+	return &PostgresStore{db: db}
+}
+
+const pgSaveSavedAppQuery = `
+INSERT INTO saved_applications (user_id, application_uid, authority_id, saved_at, snapshot)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (user_id, application_uid) DO UPDATE SET
+    authority_id = EXCLUDED.authority_id,
+    saved_at     = EXCLUDED.saved_at,
+    snapshot     = EXCLUDED.snapshot`
+
+// Save upserts the saved application keyed on (user_id, application_uid). The
+// full embedded snapshot is serialised to jsonb so the list endpoint and snapshot
+// refresher need no extra hydration query.
+func (s *PostgresStore) Save(ctx context.Context, sa SavedApplication) error {
+	var snapshotJSON []byte
+	if sa.Application != nil {
+		doc := applications.NewSnapshotDocument(*sa.Application)
+		var err error
+		snapshotJSON, err = json.Marshal(doc)
+		if err != nil {
+			return fmt.Errorf("encode snapshot for %q: %w", sa.ApplicationUID, err)
+		}
+	}
+	if _, err := s.db.Exec(ctx, pgSaveSavedAppQuery,
+		sa.UserID, sa.ApplicationUID, sa.AuthorityID, sa.SavedAt, snapshotJSON); err != nil {
+		return fmt.Errorf("upsert saved application %q: %w", sa.ApplicationUID, err)
+	}
+	return nil
+}
+
+const pgExistsSavedAppQuery = "SELECT 1 FROM saved_applications WHERE user_id = $1 AND application_uid = $2"
+
+// Exists reports whether the user has saved the application with the given uid.
+func (s *PostgresStore) Exists(ctx context.Context, userID, applicationUID string) (bool, error) {
+	var dummy int
+	err := s.db.QueryRow(ctx, pgExistsSavedAppQuery, userID, applicationUID).Scan(&dummy)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("check saved application %q: %w", applicationUID, err)
+	}
+	return true, nil
+}
+
+const pgDeleteSavedAppQuery = "DELETE FROM saved_applications WHERE user_id = $1 AND application_uid = $2"
+
+// Delete removes the saved application. A missing row is not an error: the DELETE
+// endpoint is idempotent (always returns 204).
+func (s *PostgresStore) Delete(ctx context.Context, userID, applicationUID string) error {
+	if _, err := s.db.Exec(ctx, pgDeleteSavedAppQuery, userID, applicationUID); err != nil {
+		return fmt.Errorf("delete saved application %q: %w", applicationUID, err)
+	}
+	return nil
+}
+
+const pgGetByUserIDQuery = "SELECT user_id, application_uid, authority_id, saved_at, snapshot " +
+	"FROM saved_applications WHERE user_id = $1 ORDER BY saved_at"
+
+// GetByUserID returns the user's saved applications, ordered by saved_at.
+func (s *PostgresStore) GetByUserID(ctx context.Context, userID string) ([]SavedApplication, error) {
+	rows, err := s.db.Query(ctx, pgGetByUserIDQuery, userID)
+	if err != nil {
+		return nil, fmt.Errorf("query saved applications for %q: %w", userID, err)
+	}
+	defer rows.Close()
+
+	var saved []SavedApplication
+	for rows.Next() {
+		sa, err := scanSavedApp(rows)
+		if err != nil {
+			return nil, fmt.Errorf("scan saved application for %q: %w", userID, err)
+		}
+		saved = append(saved, sa)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("saved application rows for %q: %w", userID, err)
+	}
+	return saved, nil
+}
+
+// scanSavedApp hydrates one SavedApplication from a pgx.Row (or pgx.Rows, which
+// satisfies pgx.Row structurally). The jsonb snapshot column is unmarshalled back
+// through applications.SnapshotDocument.ToDomain so all fields round-trip cleanly.
+func scanSavedApp(row pgx.Row) (SavedApplication, error) {
+	var (
+		userID         string
+		applicationUID string
+		authorityID    int
+		savedAt        time.Time
+		snapshotJSON   []byte
+	)
+	if err := row.Scan(&userID, &applicationUID, &authorityID, &savedAt, &snapshotJSON); err != nil {
+		return SavedApplication{}, err
+	}
+	sa := SavedApplication{
+		UserID:         userID,
+		ApplicationUID: applicationUID,
+		AuthorityID:    authorityID,
+		SavedAt:        savedAt,
+	}
+	if len(snapshotJSON) > 0 {
+		var doc applications.SnapshotDocument
+		if err := json.Unmarshal(snapshotJSON, &doc); err != nil {
+			return SavedApplication{}, fmt.Errorf("decode snapshot for %q: %w", applicationUID, err)
+		}
+		app := doc.ToDomain()
+		sa.Application = &app
+	}
+	return sa, nil
+}
+
+// pgUserIDsForApplicationQuery matches the Cosmos impl's authority predicate
+// exactly: PlanIt uids collide across councils, so scoping on authority_id is
+// load-bearing, not an optional optimisation.
+const pgUserIDsForApplicationQuery = "SELECT DISTINCT user_id FROM saved_applications " +
+	"WHERE application_uid = $1 AND authority_id = $2"
+
+// UserIDsForApplication returns every distinct user id that has saved the given
+// (applicationUID, authorityID). It backs the poll-path decision-event fan-out to
+// bookmark holders. The query is index-served via the composite
+// (application_uid, authority_id) index on the hot poll path.
+func (s *PostgresStore) UserIDsForApplication(ctx context.Context, applicationUID string, authorityID int) ([]string, error) {
+	rows, err := s.db.Query(ctx, pgUserIDsForApplicationQuery, applicationUID, authorityID)
+	if err != nil {
+		return nil, fmt.Errorf("query user ids for saved application %q: %w", applicationUID, err)
+	}
+	defer rows.Close()
+
+	var userIDs []string
+	for rows.Next() {
+		var uid string
+		if err := rows.Scan(&uid); err != nil {
+			return nil, fmt.Errorf("scan user id for saved application %q: %w", applicationUID, err)
+		}
+		userIDs = append(userIDs, uid)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("user id rows for saved application %q: %w", applicationUID, err)
+	}
+	return userIDs, nil
+}
+
+const pgDeleteAllSavedAppsQuery = "DELETE FROM saved_applications WHERE user_id = $1"
+
+// DeleteAllByUserID removes every saved application for the user. Used by the
+// GDPR erasure cascade (dormant cleanup and DELETE /v1/me).
+func (s *PostgresStore) DeleteAllByUserID(ctx context.Context, userID string) error {
+	if _, err := s.db.Exec(ctx, pgDeleteAllSavedAppsQuery, userID); err != nil {
+		return fmt.Errorf("delete all saved applications for %q: %w", userID, err)
+	}
+	return nil
+}

--- a/api-go/internal/savedapplications/store_postgres_test.go
+++ b/api-go/internal/savedapplications/store_postgres_test.go
@@ -1,0 +1,199 @@
+package savedapplications
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+// fakeSavedQuerier is a hand-written fake of the querier interface used by
+// unit tests of PostgresStore (savedapplications). It stores canned responses for
+// each method; tests set whichever fields they exercise.
+type fakeSavedQuerier struct {
+	execErr  error
+	queryErr error
+	rowErr   error
+}
+
+func (f *fakeSavedQuerier) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	return pgconn.CommandTag{}, f.execErr
+}
+
+func (f *fakeSavedQuerier) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	if f.queryErr != nil {
+		return nil, f.queryErr
+	}
+	return &emptySavedRows{}, nil
+}
+
+func (f *fakeSavedQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	return &errSavedRow{err: f.rowErr}
+}
+
+// emptySavedRows is a pgx.Rows with no data and no error.
+type emptySavedRows struct{}
+
+func (r *emptySavedRows) Close()                                       {}
+func (r *emptySavedRows) Err() error                                   { return nil }
+func (r *emptySavedRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *emptySavedRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *emptySavedRows) Next() bool                                   { return false }
+func (r *emptySavedRows) Scan(_ ...any) error                          { return errors.New("no rows") }
+func (r *emptySavedRows) Values() ([]any, error)                       { return nil, nil }
+func (r *emptySavedRows) RawValues() [][]byte                          { return nil }
+func (r *emptySavedRows) Conn() *pgx.Conn                              { return nil }
+
+// errSavedRow is a pgx.Row whose Scan always returns the stored error.
+type errSavedRow struct{ err error }
+
+func (r *errSavedRow) Scan(_ ...any) error { return r.err }
+
+// newTestApp builds a minimal PlanningApplication for fixture use.
+func newTestApp() applications.PlanningApplication {
+	return applications.PlanningApplication{
+		Name:          "24/00001/FUL",
+		UID:           "uid-1",
+		AreaName:      "Testshire",
+		AreaID:        100,
+		Address:       "1 Test Street",
+		Description:   "test application",
+		LastDifferent: time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+// TestSavedPostgresStore_Save_PropagatesExecError surfaces an Exec failure.
+func TestSavedPostgresStore_Save_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	fq := &fakeSavedQuerier{execErr: sentinel}
+	store := NewPostgresStore(fq)
+
+	app := newTestApp()
+	sa := NewSavedApplication("auth0|u1", app, time.Now())
+	if err := store.Save(context.Background(), sa); !errors.Is(err, sentinel) {
+		t.Fatalf("Save error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// TestSavedPostgresStore_Exists_FalseOnNoRows returns false when QueryRow.Scan
+// returns pgx.ErrNoRows (the row does not exist).
+func TestSavedPostgresStore_Exists_FalseOnNoRows(t *testing.T) {
+	t.Parallel()
+
+	fq := &fakeSavedQuerier{rowErr: pgx.ErrNoRows}
+	store := NewPostgresStore(fq)
+
+	got, err := store.Exists(context.Background(), "auth0|u1", "100/24/00001/FUL")
+	if err != nil {
+		t.Fatalf("Exists missing: got err %v, want nil", err)
+	}
+	if got {
+		t.Error("Exists missing: got true, want false")
+	}
+}
+
+// TestSavedPostgresStore_Exists_DBError surfaces a non-ErrNoRows scan error.
+func TestSavedPostgresStore_Exists_DBError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	fq := &fakeSavedQuerier{rowErr: sentinel}
+	store := NewPostgresStore(fq)
+
+	if _, err := store.Exists(context.Background(), "auth0|u1", "uid"); !errors.Is(err, sentinel) {
+		t.Fatalf("Exists DB error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// TestSavedPostgresStore_Delete_PropagatesExecError surfaces an Exec failure.
+func TestSavedPostgresStore_Delete_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	fq := &fakeSavedQuerier{execErr: sentinel}
+	store := NewPostgresStore(fq)
+
+	if err := store.Delete(context.Background(), "auth0|u1", "uid"); !errors.Is(err, sentinel) {
+		t.Fatalf("Delete error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// TestSavedPostgresStore_GetByUserID_EmptyReturnsNil returns nil (not an empty
+// slice) when the user has no saved applications.
+func TestSavedPostgresStore_GetByUserID_EmptyReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	fq := &fakeSavedQuerier{}
+	store := NewPostgresStore(fq)
+
+	got, err := store.GetByUserID(context.Background(), "auth0|u1")
+	if err != nil {
+		t.Fatalf("GetByUserID empty: got err %v", err)
+	}
+	if got != nil {
+		t.Errorf("GetByUserID empty: got %v, want nil", got)
+	}
+}
+
+// TestSavedPostgresStore_GetByUserID_QueryError surfaces a Query failure.
+func TestSavedPostgresStore_GetByUserID_QueryError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	fq := &fakeSavedQuerier{queryErr: sentinel}
+	store := NewPostgresStore(fq)
+
+	if _, err := store.GetByUserID(context.Background(), "auth0|u1"); !errors.Is(err, sentinel) {
+		t.Fatalf("GetByUserID query error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// TestSavedPostgresStore_UserIDsForApplication_EmptyReturnsNil returns nil when
+// no users have saved the application.
+func TestSavedPostgresStore_UserIDsForApplication_EmptyReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	fq := &fakeSavedQuerier{}
+	store := NewPostgresStore(fq)
+
+	got, err := store.UserIDsForApplication(context.Background(), "100/24/00001/FUL", 100)
+	if err != nil {
+		t.Fatalf("UserIDsForApplication empty: got err %v", err)
+	}
+	if got != nil {
+		t.Errorf("UserIDsForApplication empty: got %v, want nil", got)
+	}
+}
+
+// TestSavedPostgresStore_UserIDsForApplication_QueryError surfaces a Query failure.
+func TestSavedPostgresStore_UserIDsForApplication_QueryError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	fq := &fakeSavedQuerier{queryErr: sentinel}
+	store := NewPostgresStore(fq)
+
+	if _, err := store.UserIDsForApplication(context.Background(), "uid", 100); !errors.Is(err, sentinel) {
+		t.Fatalf("UserIDsForApplication query error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// TestSavedPostgresStore_DeleteAllByUserID_PropagatesExecError surfaces an Exec failure.
+func TestSavedPostgresStore_DeleteAllByUserID_PropagatesExecError(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("db down")
+	fq := &fakeSavedQuerier{execErr: sentinel}
+	store := NewPostgresStore(fq)
+
+	if err := store.DeleteAllByUserID(context.Background(), "auth0|u1"); !errors.Is(err, sentinel) {
+		t.Fatalf("DeleteAllByUserID error: got %v, want wrapped %v", err, sentinel)
+	}
+}


### PR DESCRIPTION
Slice 5 of Phase F single-store cutover (epic #645, spec #669, memo 0010).

- **`devicetokens.PostgresStore`** — GetByToken / Save / Delete / ListByUser / DeleteAllByUserID (GDPR) + **`PurgeOlderThan`** replacing the Cosmos 180-day TTL (a later slice schedules it). Migration `0009_device_registrations.sql` (PK `(user_id, token)`, index on `registered_at` for the purge).
- **`savedapplications.PostgresStore`** — Save (embedded snapshot as `jsonb`) / Exists / Delete / GetByUserID / DeleteAllByUserID (GDPR) / `UserIDsForApplication` (hot poll fan-out, `WHERE application_uid=$1 AND authority_id=$2` — authority-scoped to avoid cross-council uid collisions, matching Cosmos). Migration `0010_saved_applications.sql` (composite index `(application_uid, authority_id)`).
- Exported `DecodeDocument` in both packages + `cmd/pgbackfill-devices` / `cmd/pgbackfill-saved`.

No wiring touched (later slice). Unit (fakes, `-race`) + `//go:build integration` pgtest green; build/vet/gofmt/golangci clean; tree clean (no untracked files).

Bead: tc-hpd2.10

🤖 Generated with [Claude Code](https://claude.com/claude-code)