### PR TITLE
feat(api): route ALL cmd/api stores to Postgres behind STORE_BACKEND + GDPR rewire (tc-hpd2.12)

### DIFF
--- a/api-go/cmd/api/backend.go
+++ b/api-go/cmd/api/backend.go
@@ -4,45 +4,70 @@ import (
 	"strings"
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
+	"github.com/AmyDe/town-crier/api-go/internal/subscriptions"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
-// storeBackend selects which datastore backs the Applications and WatchZones
-// route stores. The other nine stores are always Cosmos; only these two move to
-// Postgres + PostGIS in the hybrid migration phase (memo 0010, epic #645,
-// issue #657 Slice 2).
+// storeBackend selects which datastore backs a store. The canonical values are
+// backendCosmos (default) and backendPostgres.
 type storeBackend int
 
 const (
-	// backendCosmos is the default for every value of APPS_ZONES_BACKEND other
-	// than the exact string "postgres" — including unset and "cosmos" — so prod
-	// (flag unset) is never silently flipped off Cosmos.
+	// backendCosmos is the default for any flag value other than the exact
+	// string "postgres" — including unset and "cosmos" — so prod (flag unset)
+	// is never silently flipped off Cosmos.
 	backendCosmos storeBackend = iota
-	// backendPostgres serves Applications + WatchZones from Postgres + PostGIS.
-	// It is set on the dev container only.
+	// backendPostgres routes the store to Postgres + PostGIS.
 	backendPostgres
 )
 
-// appsZonesBackendPostgres is the only APPS_ZONES_BACKEND value that selects
-// Postgres. The flag is dedicated and explicit — never inferred from
-// POSTGRES_AUTH — so a future prod POSTGRES_AUTH can never flip prod's stores.
-const appsZonesBackendPostgres = "postgres"
+// postgresBackendValue is the only flag value (whitespace-trimmed) that selects
+// Postgres. It is shared by both resolvers so the two flags use identical
+// semantics.
+const postgresBackendValue = "postgres"
 
 // resolveBackend maps the APPS_ZONES_BACKEND flag to a storeBackend. Only the
 // exact value "postgres" (whitespace-trimmed) selects Postgres; every other
-// value, including "" and "cosmos", keeps Cosmos.
+// value, including "" and "cosmos", keeps Cosmos. Kept for backward
+// compatibility with the existing APPS_ZONES_BACKEND wiring.
 func resolveBackend(flag string) storeBackend {
-	if strings.TrimSpace(flag) == appsZonesBackendPostgres {
+	if strings.TrimSpace(flag) == postgresBackendValue {
 		return backendPostgres
 	}
 	return backendCosmos
 }
 
+// resolveStoreBackend maps the STORE_BACKEND flag to a storeBackend. Only the
+// exact value "postgres" (whitespace-trimmed) selects Postgres for ALL stores;
+// every other value (including unset) keeps the per-store default. It is a
+// dedicated, explicit flag — never inferred from POSTGRES_AUTH — so a future
+// prod POSTGRES_AUTH can never silently flip prod stores.
+func resolveStoreBackend(flag string) storeBackend {
+	if strings.TrimSpace(flag) == postgresBackendValue {
+		return backendPostgres
+	}
+	return backendCosmos
+}
+
+// choose returns the pg value when backend == backendPostgres (guarding typed-nil),
+// or cosmos when backend == backendCosmos (guarding typed-nil). The generic
+// parameter T is the concrete pointer type; the return type R is the
+// consumer-side interface. Returning R ensures the caller gets a genuine nil
+// interface, not a typed-nil pointer boxed in a non-nil interface.
+//
+// Used by all the per-store chooser helpers below.
+
 // chooseAppStore returns the Applications store for the selected backend as a
 // genuine consumer-side interface. When the chosen backend has no backing store
-// configured it returns a true nil interface — never a typed-nil pointer boxed in
-// a non-nil interface — so newRouter's `appStore != nil` guard correctly leaves
-// the application routes unwired on a store-less boot.
+// configured it returns a true nil interface — never a typed-nil pointer boxed
+// in a non-nil interface — so newRouter's `appStore != nil` guard correctly
+// leaves the application routes unwired on a store-less boot.
 func chooseAppStore(backend storeBackend, pg *applications.PostgresStore, cosmos *applications.CosmosStore) applications.Store {
 	if backend == backendPostgres {
 		if pg == nil {
@@ -58,6 +83,123 @@ func chooseAppStore(backend storeBackend, pg *applications.PostgresStore, cosmos
 
 // chooseZoneStore mirrors chooseAppStore for the WatchZones store.
 func chooseZoneStore(backend storeBackend, pg *watchzones.PostgresStore, cosmos *watchzones.CosmosStore) watchzones.Store {
+	if backend == backendPostgres {
+		if pg == nil {
+			return nil
+		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseProfileStore mirrors chooseAppStore for the user-profile point store.
+func chooseProfileStore(backend storeBackend, pg *profiles.PostgresStore, cosmos *profiles.CosmosStore) profiles.Store {
+	if backend == backendPostgres {
+		if pg == nil {
+			return nil
+		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseAdminStore mirrors chooseAppStore for the admin profile store.
+func chooseAdminStore(backend storeBackend, pg *profiles.PostgresAdminStore, cosmos *profiles.AdminStore) profiles.AdminProfileStore {
+	if backend == backendPostgres {
+		if pg == nil {
+			return nil
+		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseDeviceStore mirrors chooseAppStore for the device-registration store.
+func chooseDeviceStore(backend storeBackend, pg *devicetokens.PostgresStore, cosmos *devicetokens.CosmosStore) devicetokens.Store {
+	if backend == backendPostgres {
+		if pg == nil {
+			return nil
+		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseStateStore mirrors chooseAppStore for the notification-state store.
+func chooseStateStore(backend storeBackend, pg *notificationstate.PostgresStore, cosmos *notificationstate.CosmosStore) notificationstate.Store {
+	if backend == backendPostgres {
+		if pg == nil {
+			return nil
+		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseNotifStore returns the notification store for the NearbyRoutes
+// GetLatestUnreadByApplications path as a notifUnreadReader. It accepts both
+// *notifications.CosmosStore (which only has GetLatestUnreadByApplications) and
+// *notifications.PostgresStore (which satisfies the full Store) via the narrow
+// local interface.
+func chooseNotifStore(backend storeBackend, pg *notifications.PostgresStore, cosmos *notifications.CosmosStore) notifUnreadReader {
+	if backend == backendPostgres {
+		if pg == nil {
+			return nil
+		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseSavedStore mirrors chooseAppStore for the saved-applications store.
+func chooseSavedStore(backend storeBackend, pg *savedapplications.PostgresStore, cosmos *savedapplications.CosmosStore) savedapplications.Store {
+	if backend == backendPostgres {
+		if pg == nil {
+			return nil
+		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseOfferStore mirrors chooseAppStore for the offer-code store.
+func chooseOfferStore(backend storeBackend, pg *offercodes.PostgresStore, cosmos *offercodes.CosmosStore) offercodes.Store {
+	if backend == backendPostgres {
+		if pg == nil {
+			return nil
+		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseAppleNotifStore mirrors chooseAppStore for the Apple-notification
+// idempotency store.
+func chooseAppleNotifStore(backend storeBackend, pg *subscriptions.PostgresNotificationStore, cosmos *subscriptions.CosmosNotificationStore) subscriptions.Store {
 	if backend == backendPostgres {
 		if pg == nil {
 			return nil

--- a/api-go/cmd/api/backend_test.go
+++ b/api-go/cmd/api/backend_test.go
@@ -2,8 +2,16 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
+	"github.com/AmyDe/town-crier/api-go/internal/subscriptions"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
@@ -110,6 +118,322 @@ func TestChooseZoneStore(t *testing.T) {
 		t.Parallel()
 		if got := chooseZoneStore(backendCosmos, pg, nil); got != nil {
 			t.Fatalf("got %T (non-nil interface), want a genuine nil so routes stay unwired", got)
+		}
+	})
+}
+
+// TestResolveStoreBackend pins the STORE_BACKEND contract: only the exact
+// string "postgres" (whitespace-trimmed) selects Postgres for ALL stores;
+// every other value (including unset) keeps the per-store default so prod
+// (flag unset) is never silently flipped.
+func TestResolveStoreBackend(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		flag string
+		want storeBackend
+	}{
+		{"exact postgres selects postgres", "postgres", backendPostgres},
+		{"surrounding whitespace is trimmed", "  postgres\t", backendPostgres},
+		{"unset defaults to cosmos", "", backendCosmos},
+		{"explicit cosmos stays cosmos", "cosmos", backendCosmos},
+		{"uppercase is not the canonical value", "Postgres", backendCosmos},
+		{"junk defaults to cosmos", "nonsense", backendCosmos},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveStoreBackend(tc.flag); got != tc.want {
+				t.Fatalf("resolveStoreBackend(%q) = %v, want %v", tc.flag, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestChooseProfileStore verifies backend selection and the typed-nil trap for
+// the profiles point store.
+func TestChooseProfileStore(t *testing.T) {
+	t.Parallel()
+
+	cosmos := profiles.NewCosmosStore(newFakeItems())
+	pg := profiles.NewPostgresStore(nil)
+
+	t.Run("postgres backend returns the postgres store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseProfileStore(backendPostgres, pg, cosmos)
+		if _, ok := got.(*profiles.PostgresStore); !ok {
+			t.Fatalf("got %T, want *profiles.PostgresStore", got)
+		}
+	})
+	t.Run("cosmos backend returns the cosmos store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseProfileStore(backendCosmos, pg, cosmos)
+		if _, ok := got.(*profiles.CosmosStore); !ok {
+			t.Fatalf("got %T, want *profiles.CosmosStore", got)
+		}
+	})
+	t.Run("postgres backend with no pool yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseProfileStore(backendPostgres, nil, cosmos); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+	t.Run("cosmos backend with no container yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseProfileStore(backendCosmos, pg, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+}
+
+// TestChooseAdminStore mirrors TestChooseProfileStore for the admin profile
+// store.
+func TestChooseAdminStore(t *testing.T) {
+	t.Parallel()
+
+	cosmos := profiles.NewAdminStore(newFakeItems())
+	pg := profiles.NewPostgresAdminStore(nil)
+
+	t.Run("postgres backend returns the postgres admin store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseAdminStore(backendPostgres, pg, cosmos)
+		if _, ok := got.(*profiles.PostgresAdminStore); !ok {
+			t.Fatalf("got %T, want *profiles.PostgresAdminStore", got)
+		}
+	})
+	t.Run("cosmos backend returns the cosmos admin store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseAdminStore(backendCosmos, pg, cosmos)
+		if _, ok := got.(*profiles.AdminStore); !ok {
+			t.Fatalf("got %T, want *profiles.AdminStore", got)
+		}
+	})
+	t.Run("postgres backend with no pool yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseAdminStore(backendPostgres, nil, cosmos); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+	t.Run("cosmos backend with no container yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseAdminStore(backendCosmos, pg, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+}
+
+// TestChooseDeviceStore mirrors TestChooseAppStore for the device-token store.
+func TestChooseDeviceStore(t *testing.T) {
+	t.Parallel()
+
+	cosmos := devicetokens.NewCosmosStore(newFakeItems())
+	pg := devicetokens.NewPostgresStore(nil)
+
+	t.Run("postgres backend returns the postgres store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseDeviceStore(backendPostgres, pg, cosmos)
+		if _, ok := got.(*devicetokens.PostgresStore); !ok {
+			t.Fatalf("got %T, want *devicetokens.PostgresStore", got)
+		}
+	})
+	t.Run("cosmos backend returns the cosmos store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseDeviceStore(backendCosmos, pg, cosmos)
+		if _, ok := got.(*devicetokens.CosmosStore); !ok {
+			t.Fatalf("got %T, want *devicetokens.CosmosStore", got)
+		}
+	})
+	t.Run("postgres backend with no pool yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseDeviceStore(backendPostgres, nil, cosmos); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+	t.Run("cosmos backend with no container yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseDeviceStore(backendCosmos, pg, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+}
+
+// TestChooseStateStore mirrors TestChooseAppStore for the notification-state
+// store.
+func TestChooseStateStore(t *testing.T) {
+	t.Parallel()
+
+	cosmos := notificationstate.NewCosmosStore(newFakeItems(), nil)
+	pg := notificationstate.NewPostgresStore(nil)
+
+	t.Run("postgres backend returns the postgres store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseStateStore(backendPostgres, pg, cosmos)
+		if _, ok := got.(*notificationstate.PostgresStore); !ok {
+			t.Fatalf("got %T, want *notificationstate.PostgresStore", got)
+		}
+	})
+	t.Run("cosmos backend returns the cosmos store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseStateStore(backendCosmos, pg, cosmos)
+		if _, ok := got.(*notificationstate.CosmosStore); !ok {
+			t.Fatalf("got %T, want *notificationstate.CosmosStore", got)
+		}
+	})
+	t.Run("postgres backend with no pool yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseStateStore(backendPostgres, nil, cosmos); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+	t.Run("cosmos backend with no container yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseStateStore(backendCosmos, pg, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+}
+
+// TestChooseNotifStore verifies backend selection for the notification store
+// wired into NearbyRoutes (GetLatestUnreadByApplications path). The chooser
+// returns a notifUnreadReader interface; type assertions confirm the backing
+// concrete type.
+func TestChooseNotifStore(t *testing.T) {
+	t.Parallel()
+
+	cosmos := notifications.NewCosmosStore(newFakeItems())
+	pg := notifications.NewPostgresStore(nil)
+
+	t.Run("postgres backend returns the postgres store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseNotifStore(backendPostgres, pg, cosmos)
+		if _, ok := got.(*notifications.PostgresStore); !ok {
+			t.Fatalf("got %T, want *notifications.PostgresStore", got)
+		}
+	})
+	t.Run("cosmos backend returns the cosmos store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseNotifStore(backendCosmos, pg, cosmos)
+		if _, ok := got.(*notifications.CosmosStore); !ok {
+			t.Fatalf("got %T, want *notifications.CosmosStore", got)
+		}
+	})
+	t.Run("postgres backend with no pool yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseNotifStore(backendPostgres, nil, cosmos); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+	t.Run("cosmos backend with no container yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseNotifStore(backendCosmos, pg, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+}
+
+// TestChooseSavedStore mirrors TestChooseAppStore for the saved-applications
+// store.
+func TestChooseSavedStore(t *testing.T) {
+	t.Parallel()
+
+	cosmos := savedapplications.NewCosmosStore(newFakeItems())
+	pg := savedapplications.NewPostgresStore(nil)
+
+	t.Run("postgres backend returns the postgres store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseSavedStore(backendPostgres, pg, cosmos)
+		if _, ok := got.(*savedapplications.PostgresStore); !ok {
+			t.Fatalf("got %T, want *savedapplications.PostgresStore", got)
+		}
+	})
+	t.Run("cosmos backend returns the cosmos store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseSavedStore(backendCosmos, pg, cosmos)
+		if _, ok := got.(*savedapplications.CosmosStore); !ok {
+			t.Fatalf("got %T, want *savedapplications.CosmosStore", got)
+		}
+	})
+	t.Run("postgres backend with no pool yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseSavedStore(backendPostgres, nil, cosmos); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+	t.Run("cosmos backend with no container yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseSavedStore(backendCosmos, pg, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+}
+
+// TestChooseOfferStore mirrors TestChooseAppStore for the offer-code store.
+func TestChooseOfferStore(t *testing.T) {
+	t.Parallel()
+
+	cosmos := offercodes.NewCosmosStore(newFakeItems())
+	pg := offercodes.NewPostgresStore(nil)
+
+	t.Run("postgres backend returns the postgres store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseOfferStore(backendPostgres, pg, cosmos)
+		if _, ok := got.(*offercodes.PostgresStore); !ok {
+			t.Fatalf("got %T, want *offercodes.PostgresStore", got)
+		}
+	})
+	t.Run("cosmos backend returns the cosmos store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseOfferStore(backendCosmos, pg, cosmos)
+		if _, ok := got.(*offercodes.CosmosStore); !ok {
+			t.Fatalf("got %T, want *offercodes.CosmosStore", got)
+		}
+	})
+	t.Run("postgres backend with no pool yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseOfferStore(backendPostgres, nil, cosmos); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+	t.Run("cosmos backend with no container yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseOfferStore(backendCosmos, pg, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+}
+
+// TestChooseAppleNotifStore mirrors TestChooseAppStore for the Apple
+// notification idempotency store.
+func TestChooseAppleNotifStore(t *testing.T) {
+	t.Parallel()
+
+	cosmos := subscriptions.NewCosmosNotificationStore(newFakeItems(), time.Now)
+	pg := subscriptions.NewPostgresNotificationStore(nil, time.Now)
+
+	t.Run("postgres backend returns the postgres store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseAppleNotifStore(backendPostgres, pg, cosmos)
+		if _, ok := got.(*subscriptions.PostgresNotificationStore); !ok {
+			t.Fatalf("got %T, want *subscriptions.PostgresNotificationStore", got)
+		}
+	})
+	t.Run("cosmos backend returns the cosmos store", func(t *testing.T) {
+		t.Parallel()
+		got := chooseAppleNotifStore(backendCosmos, pg, cosmos)
+		if _, ok := got.(*subscriptions.CosmosNotificationStore); !ok {
+			t.Fatalf("got %T, want *subscriptions.CosmosNotificationStore", got)
+		}
+	})
+	t.Run("postgres backend with no pool yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseAppleNotifStore(backendPostgres, nil, cosmos); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+	t.Run("cosmos backend with no container yields a genuine nil interface", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseAppleNotifStore(backendCosmos, pg, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
 		}
 	})
 }

--- a/api-go/cmd/api/export_adapters.go
+++ b/api-go/cmd/api/export_adapters.go
@@ -67,10 +67,21 @@ func (r watchZoneExportReader) WatchZonesByUser(ctx context.Context, userID stri
 	return rows, nil
 }
 
-// notificationExportReader adapts the notifications digest store to
-// profiles.NotificationReader. It reads the full Notifications-container document
-// (AllByUser) so every exported field is carried.
-type notificationExportReader struct{ store *notifications.DigestStore }
+// allByUserReader is the narrowest consumer-side interface
+// notificationExportReader needs from the notification store. Both
+// *notifications.DigestStore (Cosmos digest path) and *notifications.PostgresStore
+// (which satisfies the full notifications.Store) expose AllByUser, so either
+// can be wired here without casting.
+type allByUserReader interface {
+	AllByUser(ctx context.Context, userID string) ([]notifications.DigestNotification, error)
+}
+
+// notificationExportReader adapts the notifications store to
+// profiles.NotificationReader. It reads the full document (AllByUser) so every
+// exported field is carried. The store field accepts either a Cosmos DigestStore
+// or a Postgres PostgresStore via the narrow allByUserReader interface, so the
+// GDPR export follows the STORE_BACKEND flag (issue #669 Slice 7a).
+type notificationExportReader struct{ store allByUserReader }
 
 func (r notificationExportReader) NotificationsByUser(ctx context.Context, userID string) ([]profiles.ExportedNotification, error) {
 	notifs, err := r.store.AllByUser(ctx, userID)
@@ -97,9 +108,11 @@ func (r notificationExportReader) NotificationsByUser(ctx context.Context, userI
 }
 
 // savedApplicationExportReader adapts the saved-application store to
-// profiles.SavedApplicationReader.
+// profiles.SavedApplicationReader. The store field accepts the consumer-side
+// savedapplications.Store interface so the GDPR export follows the STORE_BACKEND
+// flag (issue #669 Slice 7a) — both *CosmosStore and *PostgresStore satisfy it.
 type savedApplicationExportReader struct {
-	store *savedapplications.CosmosStore
+	store savedapplications.Store
 }
 
 func (r savedApplicationExportReader) SavedApplicationsByUser(ctx context.Context, userID string) ([]profiles.ExportedSavedApplication, error) {
@@ -118,8 +131,10 @@ func (r savedApplicationExportReader) SavedApplicationsByUser(ctx context.Contex
 }
 
 // deviceRegistrationExportReader adapts the device-token store to
-// profiles.DeviceRegistrationReader.
-type deviceRegistrationExportReader struct{ store *devicetokens.CosmosStore }
+// profiles.DeviceRegistrationReader. The store field accepts the consumer-side
+// devicetokens.Store interface so the GDPR export follows the STORE_BACKEND flag
+// (issue #669 Slice 7a) — both *CosmosStore and *PostgresStore satisfy it.
+type deviceRegistrationExportReader struct{ store devicetokens.Store }
 
 func (r deviceRegistrationExportReader) DeviceRegistrationsByUser(ctx context.Context, userID string) ([]profiles.ExportedDeviceRegistration, error) {
 	regs, err := r.store.ListByUser(ctx, userID)
@@ -140,8 +155,10 @@ func (r deviceRegistrationExportReader) DeviceRegistrationsByUser(ctx context.Co
 // offerCodeExportReader adapts the offer-code store to
 // profiles.OfferCodeRedemptionReader. A redeemed-by-user code always has a
 // RedeemedAt set, but a nil is guarded (it serialises as the zero instant) so a
-// malformed document can never panic the export.
-type offerCodeExportReader struct{ store *offercodes.CosmosStore }
+// malformed document can never panic the export. The store field accepts the
+// consumer-side offercodes.Store interface so the GDPR export follows the
+// STORE_BACKEND flag (issue #669 Slice 7a).
+type offerCodeExportReader struct{ store offercodes.Store }
 
 func (r offerCodeExportReader) OfferCodeRedemptionsByUser(ctx context.Context, userID string) ([]profiles.ExportedOfferCodeRedemption, error) {
 	codes, err := r.store.RedeemedByUserID(ctx, userID)

--- a/api-go/cmd/api/main.go
+++ b/api-go/cmd/api/main.go
@@ -77,28 +77,49 @@ func main() {
 		go probePostgresManagedIdentity(logger)
 	}
 
-	// APPS_ZONES_BACKEND gates the Applications + WatchZones route stores onto
-	// Postgres (dev only; prod and every other store stay Cosmos — issue #657
-	// Slice 2). When it selects Postgres we build ONE pool — MI-token auth from
-	// the dev container's POSTGRES_*/AZURE_CLIENT_ID via NewPoolFromEnv — and back
-	// both Postgres stores with it. Dev explicitly wants Postgres, so a pool that
-	// can't be built is fatal rather than a silent Cosmos fallback. The pool closes
-	// on shutdown. When the flag is unset (prod, local) these stay nil and the
-	// existing Cosmos construction is byte-for-byte unchanged.
+	// APPS_ZONES_BACKEND selects Postgres for the Applications + WatchZones stores.
+	// STORE_BACKEND selects Postgres for ALL stores simultaneously (full cutover,
+	// issue #669 Slice 7a). Only the exact string "postgres" (trimmed) activates
+	// either flag; unset / "cosmos" / anything else keeps Cosmos.
+	// STORE_BACKEND=postgres implies apps+zones too, so a single pool is built
+	// whenever EITHER flag selects Postgres. The pool is fatal if it cannot be
+	// built — explicit Postgres selection is intentional and a misconfigured pool
+	// must never silently fall back to Cosmos.
 	appsZonesBackend := resolveBackend(cfg.AppsZonesBackend)
+	fullBackend := resolveStoreBackend(cfg.StoreBackend)
 	var (
-		pgAppStore       *applications.PostgresStore
-		pgWatchZoneStore *watchzones.PostgresStore
+		pgAppStore        *applications.PostgresStore
+		pgWatchZoneStore  *watchzones.PostgresStore
+		pgProfileStore    *profiles.PostgresStore
+		pgAdminStore      *profiles.PostgresAdminStore
+		pgDeviceStore     *devicetokens.PostgresStore
+		pgStateStore      *notificationstate.PostgresStore
+		pgNotifStore      *notifications.PostgresStore
+		pgSavedStore      *savedapplications.PostgresStore
+		pgOfferStore      *offercodes.PostgresStore
+		pgAppleNotifStore *subscriptions.PostgresNotificationStore
 	)
-	if appsZonesBackend == backendPostgres {
+	if appsZonesBackend == backendPostgres || fullBackend == backendPostgres {
 		pool, perr := postgres.NewPoolFromEnv(context.Background())
 		if perr != nil {
-			log.Fatalf("apps/zones backend=postgres: build postgres pool: %v", perr)
+			log.Fatalf("postgres backend: build pool: %v", perr)
 		}
 		defer pool.Close()
 		pgAppStore = applications.NewPostgresStore(pool)
 		pgWatchZoneStore = watchzones.NewPostgresStore(pool)
-		logger.Info("apps/zones backend selected", "backend", "postgres")
+		if fullBackend == backendPostgres {
+			pgProfileStore = profiles.NewPostgresStore(pool)
+			pgAdminStore = profiles.NewPostgresAdminStore(pool)
+			pgDeviceStore = devicetokens.NewPostgresStore(pool)
+			pgStateStore = notificationstate.NewPostgresStore(pool)
+			pgNotifStore = notifications.NewPostgresStore(pool)
+			pgSavedStore = savedapplications.NewPostgresStore(pool)
+			pgOfferStore = offercodes.NewPostgresStore(pool)
+			pgAppleNotifStore = subscriptions.NewPostgresNotificationStore(pool, time.Now)
+			logger.Info("all stores backend selected", "backend", "postgres")
+		} else {
+			logger.Info("apps/zones backend selected", "backend", "postgres")
+		}
 	}
 
 	validator, err := auth.NewAuth0Validator(cfg.Auth0Domain, cfg.Auth0Audience, logger)
@@ -111,20 +132,26 @@ func main() {
 		log.Fatal(err)
 	}
 	cosmos.WithMetrics(registry)
-	var store *profiles.CosmosStore
+	var cosmosProfileStore *profiles.CosmosStore
 	if cosmos != nil {
-		store = profiles.NewCosmosStore(cosmos)
+		cosmosProfileStore = profiles.NewCosmosStore(cosmos)
 	}
+	// store is the flag-selected profile store: Postgres when STORE_BACKEND=postgres,
+	// Cosmos otherwise. chooseProfileStore returns a genuine nil interface when the
+	// chosen backend has no store configured, so newRouter's nil-means-unwired guards
+	// never trip on a typed nil.
+	store := chooseProfileStore(fullBackend, pgProfileStore, cosmosProfileStore)
 
 	devices, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosDeviceRegistrationsContainer, logger)
 	if err != nil {
 		log.Fatal(err)
 	}
 	devices.WithMetrics(registry)
-	var deviceStore *devicetokens.CosmosStore
+	var cosmosDeviceStore *devicetokens.CosmosStore
 	if devices != nil {
-		deviceStore = devicetokens.NewCosmosStore(devices)
+		cosmosDeviceStore = devicetokens.NewCosmosStore(devices)
 	}
+	deviceStore := chooseDeviceStore(fullBackend, pgDeviceStore, cosmosDeviceStore)
 
 	stateContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationStateContainer, logger)
 	if err != nil {
@@ -136,16 +163,20 @@ func main() {
 		log.Fatal(err)
 	}
 	notificationsContainer.WithMetrics(registry)
-	var stateStore *notificationstate.CosmosStore
+	var cosmosStateStore *notificationstate.CosmosStore
 	if stateContainer != nil && notificationsContainer != nil {
-		stateStore = notificationstate.NewCosmosStore(stateContainer, notificationsContainer)
+		cosmosStateStore = notificationstate.NewCosmosStore(stateContainer, notificationsContainer)
 	}
-	// The Notifications container also backs the per-application latest-unread
-	// lookup used by GET /v1/me/watch-zones/{zoneId}/applications.
-	var notifStore *notifications.CosmosStore
+	stateStore := chooseStateStore(fullBackend, pgStateStore, cosmosStateStore)
+	// cosmosNotifStore is the Cosmos latest-unread path. notifStore is the
+	// flag-selected notifUnreadReader for NearbyRoutes: in Postgres mode
+	// pgNotifStore satisfies the interface; in Cosmos mode cosmosNotifStore
+	// does (it only implements GetLatestUnreadByApplications).
+	var cosmosNotifStore *notifications.CosmosStore
 	if notificationsContainer != nil {
-		notifStore = notifications.NewCosmosStore(notificationsContainer)
+		cosmosNotifStore = notifications.NewCosmosStore(notificationsContainer)
 	}
+	notifStore := chooseNotifStore(fullBackend, pgNotifStore, cosmosNotifStore)
 
 	watchZones, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosWatchZonesContainer, logger)
 	if err != nil {
@@ -162,7 +193,14 @@ func main() {
 	if watchZones != nil {
 		cosmosWatchZoneStore = watchzones.NewCosmosStore(watchZones)
 	}
-	watchZoneStore := chooseZoneStore(appsZonesBackend, pgWatchZoneStore, cosmosWatchZoneStore)
+	// The watch-zone and applications stores follow STORE_BACKEND when set
+	// (which implies apps+zones on Postgres), otherwise APPS_ZONES_BACKEND.
+	// Both choosers receive the same effective backend.
+	zoneAndAppsBackend := appsZonesBackend
+	if fullBackend == backendPostgres {
+		zoneAndAppsBackend = backendPostgres
+	}
+	watchZoneStore := chooseZoneStore(zoneAndAppsBackend, pgWatchZoneStore, cosmosWatchZoneStore)
 
 	appsContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosApplicationsContainer, logger)
 	if err != nil {
@@ -176,48 +214,55 @@ func main() {
 	// appStore is the flag-selected consumer-side interface the application routes
 	// use (Postgres on dev, Cosmos elsewhere); a genuine nil interface leaves the
 	// routes unwired on a store-less boot.
-	appStore := chooseAppStore(appsZonesBackend, pgAppStore, cosmosAppStore)
+	appStore := chooseAppStore(zoneAndAppsBackend, pgAppStore, cosmosAppStore)
 
 	savedContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosSavedApplicationsContainer, logger)
 	if err != nil {
 		log.Fatal(err)
 	}
 	savedContainer.WithMetrics(registry)
-	var savedStore *savedapplications.CosmosStore
+	var cosmosSavedStore *savedapplications.CosmosStore
 	if savedContainer != nil {
-		savedStore = savedapplications.NewCosmosStore(savedContainer)
+		cosmosSavedStore = savedapplications.NewCosmosStore(savedContainer)
 	}
+	savedStore := chooseSavedStore(fullBackend, pgSavedStore, cosmosSavedStore)
 
 	offerCodesContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosOfferCodesContainer, logger)
 	if err != nil {
 		log.Fatal(err)
 	}
 	offerCodesContainer.WithMetrics(registry)
-	var offerStore *offercodes.CosmosStore
+	var cosmosOfferStore *offercodes.CosmosStore
 	if offerCodesContainer != nil {
-		offerStore = offercodes.NewCosmosStore(offerCodesContainer)
+		cosmosOfferStore = offercodes.NewCosmosStore(offerCodesContainer)
 	}
+	offerStore := chooseOfferStore(fullBackend, pgOfferStore, cosmosOfferStore)
 
-	// cascade bundles the per-container deleters DELETE /v1/me runs for a complete
-	// GDPR erasure (bead tc-qkf2). It is populated only when Cosmos is configured —
-	// the same condition under which profiles.Routes is wired — so the handler's
-	// deleters are never nil when the route is reachable. The four DeleteAllByUserID
-	// stores satisfy erasure.ChildDeleter directly; notification-state is bridged by
-	// erasure.NotificationStateChild (its store method is DeleteByUserID), shared with
-	// the dormant-cleanup worker (bead tc-gf0g). The offer-code anonymiser scrubs the
-	// redeemer back-reference (redeemedByUserId + redeemedAt) without deleting the
-	// admin-issued code (bead tc-5jyh).
 	// cascadeWatchZoneDeleter and exportWatchZoneReader bind both GDPR paths to
-	// the flag-selected watch-zone store (watchZoneStore) — Postgres on dev, Cosmos
-	// elsewhere — so account erasure and the data export cover a Postgres-resident
-	// user's zones, not just Cosmos ones (bead tc-s8g1). The admin location/bbox
-	// backfill still uses cosmosWatchZoneStore directly (a Cosmos-only migrator).
+	// the flag-selected watch-zone store (watchZoneStore) — Postgres on dev/prod
+	// cutover, Cosmos elsewhere — so account erasure and the data export cover a
+	// Postgres-resident user's zones (bead tc-s8g1). The admin backfill migrator
+	// still uses cosmosWatchZoneStore directly.
 	cascadeWatchZoneDeleter, exportWatchZoneReader := gdprWatchZoneWiring(watchZoneStore)
 
+	// cascade bundles the per-store deleters DELETE /v1/me runs for a complete
+	// GDPR erasure (bead tc-qkf2). All six members are now flag-selected via the
+	// STORE_BACKEND choosers above, so the cascade targets the same backend the
+	// routes use. In Postgres mode pgNotifStore satisfies erasure.ChildDeleter
+	// (DeleteAllByUserID); in Cosmos mode the dedicated DeleteStore wraps the
+	// container. The other four stores satisfy erasure.ChildDeleter or
+	// erasure.RedemptionAnonymiser directly on their exported Store interface.
+	var cascadeNotifDeleter erasure.ChildDeleter
+	if fullBackend == backendPostgres && pgNotifStore != nil {
+		cascadeNotifDeleter = pgNotifStore
+	} else if notificationsContainer != nil {
+		cascadeNotifDeleter = notifications.NewDeleteStore(notificationsContainer)
+	}
+
 	var cascade profiles.CascadeDeleters
-	if notificationsContainer != nil && watchZoneStore != nil && savedContainer != nil && devices != nil && stateContainer != nil && offerStore != nil {
+	if cascadeNotifDeleter != nil && watchZoneStore != nil && savedStore != nil && deviceStore != nil && stateStore != nil && offerStore != nil {
 		cascade = profiles.CascadeDeleters{
-			Notifications:       notifications.NewDeleteStore(notificationsContainer),
+			Notifications:       cascadeNotifDeleter,
 			WatchZones:          cascadeWatchZoneDeleter,
 			SavedApplications:   savedStore,
 			DeviceRegistrations: deviceStore,
@@ -227,21 +272,24 @@ func main() {
 	}
 
 	// exportReaders bundles the per-collection readers GET /v1/me/data uses to
-	// source the GDPR export's child collections (bead tc-lllv). Like cascade it is
-	// populated only when Cosmos is configured — the same condition under which
-	// profiles.Routes is wired — so the export's readers are never nil when the
-	// route is reachable; on a Cosmos-less local boot the readers stay nil and the
-	// export renders every collection as [] (never null). The adapters
-	// (export_adapters.go) map each store's records to the profiles-local export
-	// row types, keeping the store -> row mapping out of profiles (which must not
-	// import the feature packages — offercodes already imports profiles). The
-	// notifications reader uses the digest store's full-document AllByUser read so
-	// every exported field is carried, not the latest-unread projection.
+	// source the GDPR export's child collections (bead tc-lllv). All five members
+	// are now flag-selected, so the export reads from the same backend the routes
+	// use. In Postgres mode pgNotifStore satisfies allByUserReader (AllByUser); in
+	// Cosmos mode the dedicated DigestStore provides the full-document AllByUser
+	// read. The adapters (export_adapters.go) map store records to profiles-local
+	// export row types, keeping store → row mapping out of profiles.
+	var exportNotifReader allByUserReader
+	if fullBackend == backendPostgres && pgNotifStore != nil {
+		exportNotifReader = pgNotifStore
+	} else if notificationsContainer != nil {
+		exportNotifReader = notifications.NewDigestStore(notificationsContainer)
+	}
+
 	var exportReaders profiles.ExportReaders
-	if notificationsContainer != nil && watchZoneStore != nil && savedContainer != nil && devices != nil && offerStore != nil {
+	if exportNotifReader != nil && watchZoneStore != nil && savedStore != nil && deviceStore != nil && offerStore != nil {
 		exportReaders = profiles.ExportReaders{
 			WatchZones:           exportWatchZoneReader,
-			Notifications:        notificationExportReader{store: notifications.NewDigestStore(notificationsContainer)},
+			Notifications:        notificationExportReader{store: exportNotifReader},
 			SavedApplications:    savedApplicationExportReader{store: savedStore},
 			DeviceRegistrations:  deviceRegistrationExportReader{store: deviceStore},
 			OfferCodeRedemptions: offerCodeExportReader{store: offerStore},
@@ -249,22 +297,24 @@ func main() {
 	}
 
 	// The admin grant/list operations query the Users container cross-partition
-	// (by email, and the full list), so the admin store reuses the same container
-	// as the profile store.
-	var adminStore *profiles.AdminStore
+	// (by email, and the full list), so the Cosmos admin store reuses the same
+	// container as the profile store. adminStore is the flag-selected interface.
+	var cosmosAdminStore *profiles.AdminStore
 	if cosmos != nil {
-		adminStore = profiles.NewAdminStore(cosmos)
+		cosmosAdminStore = profiles.NewAdminStore(cosmos)
 	}
+	adminStore := chooseAdminStore(fullBackend, pgAdminStore, cosmosAdminStore)
 
 	appleNotificationsContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosAppleNotificationsContainer, logger)
 	if err != nil {
 		log.Fatal(err)
 	}
 	appleNotificationsContainer.WithMetrics(registry)
-	var appleNotifStore *subscriptions.CosmosNotificationStore
+	var cosmosAppleNotifStore *subscriptions.CosmosNotificationStore
 	if appleNotificationsContainer != nil {
-		appleNotifStore = subscriptions.NewCosmosNotificationStore(appleNotificationsContainer, time.Now)
+		cosmosAppleNotifStore = subscriptions.NewCosmosNotificationStore(appleNotificationsContainer, time.Now)
 	}
+	appleNotifStore := chooseAppleNotifStore(fullBackend, pgAppleNotifStore, cosmosAppleNotifStore)
 
 	// The JWS verifier embeds the Apple Root CA - G3 and needs no Cosmos, so it is
 	// always available; the subscription routes only wire when the backing stores

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"time"
@@ -74,6 +75,15 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	d.dispatch.ServeHTTP(w, r)
 }
 
+// notifUnreadReader is the narrowest consumer-side interface the notification
+// store wired into NearbyRoutes must satisfy. Both *notifications.CosmosStore
+// (which only implements GetLatestUnreadByApplications) and
+// *notifications.PostgresStore (which satisfies the full notifications.Store)
+// satisfy it structurally.
+type notifUnreadReader interface {
+	GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string, lastReadAt time.Time) (map[string]notifications.LatestUnread, error)
+}
+
 // newRouter wires the feature routes onto a mux and wraps it in the production
 // middleware chain. Ordering, from outermost to innermost:
 //
@@ -99,17 +109,44 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // served by profiles.Routes off the profile store, so they come up with the
 // /v1/me routes, not the watch-zone store.)
 //
-// watchZoneStore and appStore are consumer-side interfaces (watchzones.Store /
-// applications.Store), not concrete *CosmosStore pointers, so cmd/api can serve
-// these two from either Cosmos or Postgres per the APPS_ZONES_BACKEND flag
-// (issue #657 Slice 2). They MUST be passed as genuine nil interfaces (not a
-// typed-nil *CosmosStore boxed in an interface) when unconfigured, or the
-// nil-means-unwired guards below would wire dead routes — main.go's chooseAppStore
-// / chooseZoneStore enforce this. adminWatchZones stays the concrete Cosmos
-// *watchzones.CosmosStore because the admin location/bbox backfill it feeds is a
-// Cosmos-era migrator absent from the Postgres port; it is constructed regardless
-// of the flag so the admin surface is unaffected by the backend swap.
-func newRouter(validator auth.TokenValidator, corsOrigins []string, store *profiles.CosmosStore, auth0 profiles.Auth0Manager, cascade profiles.CascadeDeleters, exportReaders profiles.ExportReaders, deviceStore *devicetokens.CosmosStore, stateStore *notificationstate.CosmosStore, notifStore *notifications.CosmosStore, watchZoneStore watchzones.Store, adminWatchZones *watchzones.CosmosStore, appStore applications.Store, savedStore *savedapplications.CosmosStore, geocodeClient *geocoding.Client, designationClient *designations.Client, offerStore *offercodes.CosmosStore, adminStore *profiles.AdminStore, adminKey string, siteBuildKey string, jwsVerifier *subscriptions.JWSVerifier, appleNotifStore *subscriptions.CosmosNotificationStore, appleBundleID string, appleEnvironments []string, registry *metrics.Registry, logger *slog.Logger) http.Handler {
+// store, deviceStore, stateStore, notifStore, savedStore, offerStore,
+// adminStore and appleNotifStore are consumer-side interfaces, not concrete
+// *CosmosStore pointers, so cmd/api can serve each from either Cosmos or
+// Postgres per the STORE_BACKEND / APPS_ZONES_BACKEND flags (issue #669
+// Slice 7a). They MUST be passed as genuine nil interfaces (not a typed-nil
+// *CosmosStore boxed in an interface) when unconfigured, or the
+// nil-means-unwired guards below would wire dead routes — main.go's choose*
+// helpers enforce this. adminWatchZones stays the concrete Cosmos
+// *watchzones.CosmosStore because the admin location/bbox backfill it feeds is
+// a Cosmos-era migrator absent from the Postgres port; it is constructed
+// regardless of the flag so the admin surface is unaffected by the backend swap.
+func newRouter(
+	validator auth.TokenValidator,
+	corsOrigins []string,
+	store profiles.Store,
+	auth0 profiles.Auth0Manager,
+	cascade profiles.CascadeDeleters,
+	exportReaders profiles.ExportReaders,
+	deviceStore devicetokens.Store,
+	stateStore notificationstate.Store,
+	notifStore notifUnreadReader,
+	watchZoneStore watchzones.Store,
+	adminWatchZones *watchzones.CosmosStore,
+	appStore applications.Store,
+	savedStore savedapplications.Store,
+	geocodeClient *geocoding.Client,
+	designationClient *designations.Client,
+	offerStore offercodes.Store,
+	adminStore profiles.AdminProfileStore,
+	adminKey string,
+	siteBuildKey string,
+	jwsVerifier *subscriptions.JWSVerifier,
+	appleNotifStore subscriptions.Store,
+	appleBundleID string,
+	appleEnvironments []string,
+	registry *metrics.Registry,
+	logger *slog.Logger,
+) http.Handler {
 	mux := http.NewServeMux()
 	health.Routes(mux, logger)
 	versionconfig.Routes(mux, logger)

--- a/api-go/internal/offercodes/store_postgres.go
+++ b/api-go/internal/offercodes/store_postgres.go
@@ -21,6 +21,33 @@ type querier interface {
 	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
+// Store is the full offer-code method set that both *CosmosStore and
+// *PostgresStore must satisfy. It serves two purposes: a compile-time parity
+// check (so neither store can silently diverge) and the exported consumer-side
+// interface cmd/api's wiring accepts once a Postgres backend is selected.
+//
+// The set covers:
+//   - the codeStore interface in handler.go (Get/Save/RedeemWithCAS)
+//   - the admin offerCodeStore interface in admin/handler.go (Save)
+//   - erasure.RedemptionAnonymiser (AnonymiseRedemptionsByUserID)
+//   - the GDPR export reader (RedeemedByUserID)
+type Store interface {
+	Get(ctx context.Context, canonical string) (OfferCode, error)
+	Save(ctx context.Context, c OfferCode) error
+	RedeemWithCAS(ctx context.Context, canonical, userID string, now time.Time) error
+	RedeemedByUserID(ctx context.Context, userID string) ([]OfferCode, error)
+	AnonymiseRedemptionsByUserID(ctx context.Context, userID string) error
+}
+
+// Compile-time parity: both stores must satisfy the same exported Store
+// interface. If a new method is added to either store, the corresponding
+// interface and the other store must be updated in the same change — the
+// compiler enforces this.
+var (
+	_ Store = (*CosmosStore)(nil)
+	_ Store = (*PostgresStore)(nil)
+)
+
 // PostgresStore reads and writes offer codes in the Postgres `offer_codes` table
 // (Cosmos → Postgres migration; memo 0010, epic #645).
 //

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -51,8 +51,18 @@ type Config struct {
 	// dedicated, explicit flag (read from APPS_ZONES_BACKEND) set on the dev
 	// container only (epic #645, issue #657 Slice 2), never inferred from
 	// POSTGRES_AUTH, so a future prod POSTGRES_AUTH can never flip prod's stores
-	// off Cosmos. The other nine stores stay Cosmos regardless.
+	// off Cosmos.
 	AppsZonesBackend string
+
+	// StoreBackend is the full-cutover flag: when set to the exact string
+	// "postgres" it routes EVERY store in cmd/api to Postgres. It implies
+	// AppsZonesBackend (apps+zones also move to Postgres). It is a dedicated,
+	// explicit flag (read from STORE_BACKEND) that is NEVER inferred from
+	// POSTGRES_AUTH — a future env change cannot silently flip prod stores.
+	// Default/unset keeps all stores at their individual defaults (AppsZonesBackend
+	// still honoured for the apps+zones pair). Prod stays unset until the infra
+	// slice flips it (epic #645, issue #669 Slice 7a).
+	StoreBackend string
 
 	// Auth0M2MClientID / Auth0M2MClientSecret are the machine-to-machine
 	// client-credentials used to sync subscription tier and delete users in the
@@ -197,6 +207,7 @@ func LoadConfig() (Config, error) {
 		AzureClientID:  os.Getenv("AZURE_CLIENT_ID"),
 
 		AppsZonesBackend: os.Getenv("APPS_ZONES_BACKEND"),
+		StoreBackend:     os.Getenv("STORE_BACKEND"),
 
 		ServiceBusNamespace: os.Getenv("SERVICE_BUS_NAMESPACE"),
 		ServiceBusQueueName: os.Getenv("SERVICE_BUS_QUEUE_NAME"),


### PR DESCRIPTION
Slice 7a of Phase F single-store cutover (epic #645, spec #669, memo 0010).

Introduces one explicit, prod-gated flag — **`STORE_BACKEND=postgres`** — that routes EVERY cmd/api store to Postgres (never inferred from `POSTGRES_AUTH`). `APPS_ZONES_BACKEND=postgres` still flips apps+zones alone; `STORE_BACKEND=postgres` flips all nine remaining stores too (and implies apps+zones).

- `platform.Config.StoreBackend` (env `STORE_BACKEND`); `resolveStoreBackend` + 8 genuine-nil-safe chooser helpers in `cmd/api/backend.go`.
- Pool built when either flag selects Postgres; the 9 PG stores constructed under full-cutover; Cosmos construction unchanged for the flag-off path (byte-identical).
- `newRouter` params interface-ified (profiles/devices/state/notifications/saved/offer/appleNotifications + admin profile store); `adminWatchZones` stays concrete Cosmos (Cosmos-only backfill migrator).
- **GDPR cascade + data export fully flag-selected** — all six cascade members (Notifications/WatchZones/SavedApplications/DeviceRegistrations/NotificationState/OfferCodes) and all export readers target the selected backend, so a Postgres-resident row is never missed by erasure. Offer-code anonymise-not-delete preserved.

cmd/worker wiring + purge mode is the next slice. Unit (fakes, `-race`) green incl. new backend/chooser tests; build/vet/gofmt/golangci clean; tree clean.

Bead: tc-hpd2.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new store routing option so more backend data can be served from Postgres when enabled.
  * Expanded backend support across profiles, device tokens, notifications, saved applications, offer codes, subscriptions, and related data.

* **Bug Fixes**
  * Improved handling of unavailable stores so disabled routes now remain unwired instead of failing with placeholder values.
  * Kept routing behavior consistent when backend settings are unset or non-standard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->