### PR TITLE
feat(worker): flag-select all stores to Postgres + dormant GDPR rewire + pg-purge mode (tc-hpd2.13)

### DIFF
--- a/api-go/cmd/worker/backend.go
+++ b/api-go/cmd/worker/backend.go
@@ -1,52 +1,110 @@
 package main
 
 import (
+	"context"
 	"strings"
+	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
+	"github.com/AmyDe/town-crier/api-go/internal/polling"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
-// storeBackend selects which datastore backs the Applications and WatchZones
-// stores the worker reads and writes — the poll Upsert + notify
-// FindZonesContaining, the digest watch-zone read, and the dormant erasure
-// cascade. The other stores are always Cosmos; only these two move to Postgres +
-// PostGIS in the hybrid migration phase (memo 0010, epic #645, issue #664 Phase
-// B). This duplicates cmd/api/backend.go on purpose: the two package-main binaries
-// each own their wiring (as buildPushSender / buildEmailSender already do), so the
-// worker mirrors the API rather than sharing a package.
+// storeBackend selects which datastore backs the stores the worker uses. The
+// canonical values are backendCosmos (default) and backendPostgres.
+// This duplicates cmd/api/backend.go on purpose: the two package-main binaries
+// each own their wiring, so the worker mirrors the API rather than sharing a
+// package.
 type storeBackend int
 
 const (
-	// backendCosmos is the default for every value of APPS_ZONES_BACKEND other
-	// than the exact string "postgres" — including unset and "cosmos" — so prod
-	// (flag unset) is never silently flipped off Cosmos.
+	// backendCosmos is the default for any flag value other than the exact
+	// string "postgres" — including unset and "cosmos" — so prod (flag unset)
+	// is never silently flipped off Cosmos.
 	backendCosmos storeBackend = iota
-	// backendPostgres serves Applications + WatchZones from Postgres + PostGIS.
-	// It is set on the dev container only.
+	// backendPostgres routes the store to Postgres + PostGIS.
 	backendPostgres
 )
 
-// appsZonesBackendPostgres is the only APPS_ZONES_BACKEND value that selects
-// Postgres. The flag is dedicated and explicit — never inferred from
-// POSTGRES_AUTH — so a future prod POSTGRES_AUTH can never flip prod's stores.
-const appsZonesBackendPostgres = "postgres"
+// postgresBackendValue is the only flag value (whitespace-trimmed) that
+// selects Postgres for any store flag. Shared by all resolvers so the flags
+// use identical semantics.
+const postgresBackendValue = "postgres"
 
 // resolveBackend maps the APPS_ZONES_BACKEND flag to a storeBackend. Only the
 // exact value "postgres" (whitespace-trimmed) selects Postgres; every other
-// value, including "" and "cosmos", keeps Cosmos.
+// value, including "" and "cosmos", keeps Cosmos. Kept for backward
+// compatibility with the existing APPS_ZONES_BACKEND wiring.
 func resolveBackend(flag string) storeBackend {
-	if strings.TrimSpace(flag) == appsZonesBackendPostgres {
+	if strings.TrimSpace(flag) == postgresBackendValue {
 		return backendPostgres
 	}
 	return backendCosmos
 }
 
-// chooseAppStore returns the Applications store for the selected backend as a
-// genuine consumer-side interface. When the chosen backend has no backing store
-// configured it returns a true nil interface — never a typed-nil pointer boxed in
-// a non-nil interface — so the worker's nil-guard discipline (a missing store
-// leaves the mode unwired) holds.
+// resolveStoreBackend maps the STORE_BACKEND flag to a storeBackend. Only the
+// exact value "postgres" (whitespace-trimmed) selects Postgres for ALL stores;
+// every other value (including unset) keeps the per-store default. It is a
+// dedicated, explicit flag — never inferred from POSTGRES_AUTH — so a future
+// prod POSTGRES_AUTH can never silently flip prod stores.
+func resolveStoreBackend(flag string) storeBackend {
+	if strings.TrimSpace(flag) == postgresBackendValue {
+		return backendPostgres
+	}
+	return backendCosmos
+}
+
+// resolveAppsZonesBackend returns backendPostgres when EITHER the
+// APPS_ZONES_BACKEND flag OR the STORE_BACKEND flag is "postgres". This
+// implements the rule: apps+zones move to Postgres when either flag selects it,
+// so a full-cutover STORE_BACKEND=postgres flag also moves apps+zones without
+// requiring both flags to be set.
+func resolveAppsZonesBackend(appsZonesFlag, storeFlag string) storeBackend {
+	if strings.TrimSpace(appsZonesFlag) == postgresBackendValue ||
+		strings.TrimSpace(storeFlag) == postgresBackendValue {
+		return backendPostgres
+	}
+	return backendCosmos
+}
+
+// pgStores holds every Postgres store instance built from the shared pool.
+// The app and zone fields are populated when EITHER APPS_ZONES_BACKEND or
+// STORE_BACKEND selects Postgres. All other fields are populated only when
+// STORE_BACKEND=postgres (full cutover). Every field is nil when neither flag
+// activates it, so builder choosers that check field nil-ness never get a
+// typed-nil stored in a non-nil interface.
+type pgStores struct {
+	// apps+zones: populated by APPS_ZONES_BACKEND=postgres OR STORE_BACKEND=postgres
+	app  *applications.PostgresStore
+	zone *watchzones.PostgresStore
+
+	// all other stores: populated only by STORE_BACKEND=postgres
+	profile      *profiles.PostgresStore
+	profileAdmin *profiles.PostgresAdminStore
+	notification *notifications.PostgresStore
+	notifState   *notificationstate.PostgresStore
+	device       *devicetokens.PostgresStore
+	savedApp     *savedapplications.PostgresStore
+	offerCode    *offercodes.PostgresStore
+	pollState    *polling.PostgresPollStateStore
+	lease        *polling.PostgresLeaseStore
+}
+
+// ── per-store choosers ────────────────────────────────────────────────────────
+// Each chooser returns a genuine nil interface when the preferred backend has
+// no backing store — never a typed-nil pointer boxed in a non-nil interface —
+// so the worker's nil-guard discipline (a missing store leaves the mode
+// unwired) holds. The app/zone choosers keep the backend-enum API for backward
+// compatibility; all new choosers use the nil-check pattern (pg != nil →
+// select pg).
+
+// chooseAppStore returns the Applications store for the selected backend.
 func chooseAppStore(backend storeBackend, pg *applications.PostgresStore, cosmos *applications.CosmosStore) applications.Store {
 	if backend == backendPostgres {
 		if pg == nil {
@@ -66,6 +124,102 @@ func chooseZoneStore(backend storeBackend, pg *watchzones.PostgresStore, cosmos 
 		if pg == nil {
 			return nil
 		}
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseProfileStore returns the point-read profile store, selecting Postgres
+// when pg is non-nil (STORE_BACKEND=postgres) and Cosmos otherwise.
+func chooseProfileStore(pg *profiles.PostgresStore, cosmos *profiles.CosmosStore) profiles.Store {
+	if pg != nil {
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseAdminProfileStore returns the admin profile store (cross-partition
+// scans: ByDigestDay, Dormant, LapsedPaid, Save), selecting Postgres when pg
+// is non-nil and Cosmos otherwise. Both *profiles.PostgresAdminStore and
+// *profiles.AdminStore satisfy profiles.AdminProfileStore.
+func chooseAdminProfileStore(pg *profiles.PostgresAdminStore, cosmos *profiles.AdminStore) profiles.AdminProfileStore {
+	if pg != nil {
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseDeviceStore returns the device-registration store.
+func chooseDeviceStore(pg *devicetokens.PostgresStore, cosmos *devicetokens.CosmosStore) devicetokens.Store {
+	if pg != nil {
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseNotifStateStore returns the notification-state store.
+func chooseNotifStateStore(pg *notificationstate.PostgresStore, cosmos *notificationstate.CosmosStore) notificationstate.Store {
+	if pg != nil {
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseSavedStore returns the saved-applications store.
+func chooseSavedStore(pg *savedapplications.PostgresStore, cosmos *savedapplications.CosmosStore) savedapplications.Store {
+	if pg != nil {
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// chooseOfferStore returns the offer-code store.
+func chooseOfferStore(pg *offercodes.PostgresStore, cosmos *offercodes.CosmosStore) offercodes.Store {
+	if pg != nil {
+		return pg
+	}
+	if cosmos == nil {
+		return nil
+	}
+	return cosmos
+}
+
+// notifDigestWriter is the consumer-side interface satisfied by both
+// *notifications.PostgresStore and *notifications.DigestStore. It is the
+// minimal slice needed by notifydispatch.Enqueuer / DecisionDispatcher (create
+// + dedup read) and digest.Handler (read + email-sent mark).
+type notifDigestWriter interface {
+	GetByUserAndApplication(ctx context.Context, userID, applicationUID string, authorityID int, eventType notifications.EventType) (*notifications.DigestNotification, error)
+	Create(ctx context.Context, n notifications.DigestNotification) error
+	ByUserSince(ctx context.Context, userID string, since time.Time) ([]notifications.DigestNotification, error)
+	UnsentEmailsByUser(ctx context.Context, userID string) ([]notifications.DigestNotification, error)
+	UserIDsWithUnsentEmails(ctx context.Context) ([]string, error)
+	MarkEmailSent(ctx context.Context, n notifications.DigestNotification) error
+}
+
+// chooseNotifDigestStore returns the notification store for the fan-out and
+// digest paths, selecting Postgres when pg is non-nil and the Cosmos DigestStore
+// otherwise. Both satisfy notifDigestWriter.
+func chooseNotifDigestStore(pg *notifications.PostgresStore, cosmos *notifications.DigestStore) notifDigestWriter {
+	if pg != nil {
 		return pg
 	}
 	if cosmos == nil {

--- a/api-go/cmd/worker/backend_test.go
+++ b/api-go/cmd/worker/backend_test.go
@@ -4,6 +4,12 @@ import (
 	"testing"
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
+	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
 
@@ -31,6 +37,65 @@ func TestResolveBackend(t *testing.T) {
 			t.Parallel()
 			if got := resolveBackend(tc.flag); got != tc.want {
 				t.Fatalf("resolveBackend(%q) = %v, want %v", tc.flag, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveStoreBackend pins the STORE_BACKEND contract: only the exact value
+// "postgres" (whitespace-trimmed) routes ALL stores to Postgres. It is
+// structurally identical to resolveBackend so the two flags use consistent
+// semantics.
+func TestResolveStoreBackend(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		flag string
+		want storeBackend
+	}{
+		{"exact postgres selects postgres", "postgres", backendPostgres},
+		{"surrounding whitespace is trimmed", " postgres ", backendPostgres},
+		{"unset defaults to cosmos", "", backendCosmos},
+		{"explicit cosmos stays cosmos", "cosmos", backendCosmos},
+		{"uppercase is not the canonical value", "Postgres", backendCosmos},
+		{"junk defaults to cosmos", "nonsense", backendCosmos},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveStoreBackend(tc.flag); got != tc.want {
+				t.Fatalf("resolveStoreBackend(%q) = %v, want %v", tc.flag, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveAppsZonesBackend verifies the OR-combination rule: apps+zones use
+// Postgres when EITHER APPS_ZONES_BACKEND=postgres OR STORE_BACKEND=postgres,
+// so a full-cutover STORE_BACKEND flag also moves apps+zones without requiring
+// both flags.
+func TestResolveAppsZonesBackend(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		appsZonesFlag string
+		storeFlag     string
+		want          storeBackend
+	}{
+		{"both unset -> cosmos", "", "", backendCosmos},
+		{"APPS_ZONES_BACKEND=postgres -> postgres", "postgres", "", backendPostgres},
+		{"STORE_BACKEND=postgres -> postgres", "", "postgres", backendPostgres},
+		{"both postgres -> postgres", "postgres", "postgres", backendPostgres},
+		{"APPS_ZONES_BACKEND=cosmos STORE_BACKEND=postgres -> postgres", "cosmos", "postgres", backendPostgres},
+		{"APPS_ZONES_BACKEND=postgres STORE_BACKEND=cosmos -> postgres", "postgres", "cosmos", backendPostgres},
+		{"junk values -> cosmos", "nonsense", "banana", backendCosmos},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := resolveAppsZonesBackend(tc.appsZonesFlag, tc.storeFlag); got != tc.want {
+				t.Fatalf("resolveAppsZonesBackend(%q, %q) = %v, want %v",
+					tc.appsZonesFlag, tc.storeFlag, got, tc.want)
 			}
 		})
 	}
@@ -115,6 +180,186 @@ func TestChooseZoneStore(t *testing.T) {
 		t.Parallel()
 		if got := chooseZoneStore(backendCosmos, pg, nil); got != nil {
 			t.Fatalf("got %T (non-nil interface), want a genuine nil so the mode stays unwired", got)
+		}
+	})
+}
+
+// TestChoosePGStoreChooserNilGuard covers the typed-nil trap for all new
+// per-store choosers that take (pg, cosmos) without a backend enum: when the
+// pg store is nil the chooser must return the cosmos store (or a genuine nil
+// interface if cosmos is also nil), and when pg is non-nil it must be returned
+// regardless.
+//
+// Each sub-test uses the narrowest check that proves the typed-nil property:
+// asserting the returned interface is nil (not just zero-valued) or that the
+// concrete type matches what was passed in.
+func TestChoosePGStoreChooserNilGuard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("chooseProfileStore selects pg when non-nil", func(t *testing.T) {
+		t.Parallel()
+		pg := profiles.NewPostgresStore(nil)
+		got := chooseProfileStore(pg, nil)
+		if got == nil {
+			t.Fatal("got nil, want the postgres store")
+		}
+		if _, ok := got.(*profiles.PostgresStore); !ok {
+			t.Fatalf("got %T, want *profiles.PostgresStore", got)
+		}
+	})
+	t.Run("chooseProfileStore falls back to cosmos when pg nil", func(t *testing.T) {
+		t.Parallel()
+		cosmos := profiles.NewCosmosStore(nil)
+		got := chooseProfileStore(nil, cosmos)
+		if _, ok := got.(*profiles.CosmosStore); !ok {
+			t.Fatalf("got %T, want *profiles.CosmosStore", got)
+		}
+	})
+	t.Run("chooseProfileStore returns genuine nil when both nil", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseProfileStore(nil, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+
+	t.Run("chooseAdminProfileStore selects pg when non-nil", func(t *testing.T) {
+		t.Parallel()
+		pg := profiles.NewPostgresAdminStore(nil)
+		got := chooseAdminProfileStore(pg, nil)
+		if got == nil {
+			t.Fatal("got nil, want the postgres admin store")
+		}
+		if _, ok := got.(*profiles.PostgresAdminStore); !ok {
+			t.Fatalf("got %T, want *profiles.PostgresAdminStore", got)
+		}
+	})
+	t.Run("chooseAdminProfileStore falls back to cosmos when pg nil", func(t *testing.T) {
+		t.Parallel()
+		cosmos := profiles.NewAdminStore(nil)
+		got := chooseAdminProfileStore(nil, cosmos)
+		if _, ok := got.(*profiles.AdminStore); !ok {
+			t.Fatalf("got %T, want *profiles.AdminStore", got)
+		}
+	})
+	t.Run("chooseAdminProfileStore returns genuine nil when both nil", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseAdminProfileStore(nil, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+
+	t.Run("chooseDeviceStore selects pg when non-nil", func(t *testing.T) {
+		t.Parallel()
+		pg := devicetokens.NewPostgresStore(nil)
+		got := chooseDeviceStore(pg, nil)
+		if _, ok := got.(*devicetokens.PostgresStore); !ok {
+			t.Fatalf("got %T, want *devicetokens.PostgresStore", got)
+		}
+	})
+	t.Run("chooseDeviceStore falls back to cosmos when pg nil", func(t *testing.T) {
+		t.Parallel()
+		cosmos := devicetokens.NewCosmosStore(nil)
+		got := chooseDeviceStore(nil, cosmos)
+		if _, ok := got.(*devicetokens.CosmosStore); !ok {
+			t.Fatalf("got %T, want *devicetokens.CosmosStore", got)
+		}
+	})
+	t.Run("chooseDeviceStore returns genuine nil when both nil", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseDeviceStore(nil, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+
+	t.Run("chooseNotifStateStore selects pg when non-nil", func(t *testing.T) {
+		t.Parallel()
+		pg := notificationstate.NewPostgresStore(nil)
+		got := chooseNotifStateStore(pg, nil)
+		if _, ok := got.(*notificationstate.PostgresStore); !ok {
+			t.Fatalf("got %T, want *notificationstate.PostgresStore", got)
+		}
+	})
+	t.Run("chooseNotifStateStore falls back to cosmos when pg nil", func(t *testing.T) {
+		t.Parallel()
+		cosmos := notificationstate.NewCosmosStore(nil, nil)
+		got := chooseNotifStateStore(nil, cosmos)
+		if _, ok := got.(*notificationstate.CosmosStore); !ok {
+			t.Fatalf("got %T, want *notificationstate.CosmosStore", got)
+		}
+	})
+	t.Run("chooseNotifStateStore returns genuine nil when both nil", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseNotifStateStore(nil, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+
+	t.Run("chooseSavedStore selects pg when non-nil", func(t *testing.T) {
+		t.Parallel()
+		pg := savedapplications.NewPostgresStore(nil)
+		got := chooseSavedStore(pg, nil)
+		if _, ok := got.(*savedapplications.PostgresStore); !ok {
+			t.Fatalf("got %T, want *savedapplications.PostgresStore", got)
+		}
+	})
+	t.Run("chooseSavedStore falls back to cosmos when pg nil", func(t *testing.T) {
+		t.Parallel()
+		cosmos := savedapplications.NewCosmosStore(nil)
+		got := chooseSavedStore(nil, cosmos)
+		if _, ok := got.(*savedapplications.CosmosStore); !ok {
+			t.Fatalf("got %T, want *savedapplications.CosmosStore", got)
+		}
+	})
+	t.Run("chooseSavedStore returns genuine nil when both nil", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseSavedStore(nil, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+
+	t.Run("chooseOfferStore selects pg when non-nil", func(t *testing.T) {
+		t.Parallel()
+		pg := offercodes.NewPostgresStore(nil)
+		got := chooseOfferStore(pg, nil)
+		if _, ok := got.(*offercodes.PostgresStore); !ok {
+			t.Fatalf("got %T, want *offercodes.PostgresStore", got)
+		}
+	})
+	t.Run("chooseOfferStore falls back to cosmos when pg nil", func(t *testing.T) {
+		t.Parallel()
+		cosmos := offercodes.NewCosmosStore(nil)
+		got := chooseOfferStore(nil, cosmos)
+		if _, ok := got.(*offercodes.CosmosStore); !ok {
+			t.Fatalf("got %T, want *offercodes.CosmosStore", got)
+		}
+	})
+	t.Run("chooseOfferStore returns genuine nil when both nil", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseOfferStore(nil, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
+		}
+	})
+
+	t.Run("chooseNotifDigestStore selects pg when non-nil", func(t *testing.T) {
+		t.Parallel()
+		pg := notifications.NewPostgresStore(nil)
+		got := chooseNotifDigestStore(pg, nil)
+		if _, ok := got.(*notifications.PostgresStore); !ok {
+			t.Fatalf("got %T, want *notifications.PostgresStore", got)
+		}
+	})
+	t.Run("chooseNotifDigestStore falls back to cosmos when pg nil", func(t *testing.T) {
+		t.Parallel()
+		cosmos := notifications.NewDigestStore(nil)
+		got := chooseNotifDigestStore(nil, cosmos)
+		if _, ok := got.(*notifications.DigestStore); !ok {
+			t.Fatalf("got %T, want *notifications.DigestStore", got)
+		}
+	})
+	t.Run("chooseNotifDigestStore returns genuine nil when both nil", func(t *testing.T) {
+		t.Parallel()
+		if got := chooseNotifDigestStore(nil, nil); got != nil {
+			t.Fatalf("got %T (non-nil interface), want genuine nil", got)
 		}
 	})
 }

--- a/api-go/cmd/worker/dormant_wiring_test.go
+++ b/api-go/cmd/worker/dormant_wiring_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// recordingQuerier is a hand-written profiles.querier double. Its Query records
+// the call and returns a sentinel error so the caller's Dormant scan surfaces
+// it; Exec/QueryRow panic so any unintended use is caught. Returning (nil,
+// sentinel) avoids implementing the full pgx.Rows interface — the dormant
+// finder's error path is all this test needs.
+type recordingQuerier struct {
+	queryCalls int
+	lastSQL    string
+	queryErr   error
+}
+
+func (q *recordingQuerier) Query(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+	q.queryCalls++
+	q.lastSQL = sql
+	return nil, q.queryErr
+}
+
+func (q *recordingQuerier) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	panic("recordingQuerier.Exec not expected in this test")
+}
+
+func (q *recordingQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	panic("recordingQuerier.QueryRow not expected in this test")
+}
+
+// TestBuildDormant_FinderIsFlagSelectedPostgresAdminStore proves the
+// dormant-cleanup FINDER (not just the deleters) is flag-selected to Postgres
+// when the full-cutover stores are present. This is the GDPR-retention guard for
+// tc-hpd2.13: post-cutover the Cosmos Users container is dark, so a finder still
+// hardcoded to Cosmos would scan an empty container, find zero dormant accounts,
+// and silently stop erasing inactive users.
+//
+// The test injects a recording querier through pgStores.profileAdmin, then drives
+// the real handler: handler.Run calls finder.Dormant first, which (for the
+// Postgres admin store) issues the last_active_at_epoch scan through the fake.
+// The sentinel error proves the finder routed through Postgres; if the finder
+// were still the Cosmos admin store the fake would never be touched and the error
+// would be a Cosmos failure instead.
+func TestBuildDormant_FinderIsFlagSelectedPostgresAdminStore(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("pg dormant scan reached")
+	q := &recordingQuerier{queryErr: sentinel}
+	pg := &pgStores{profileAdmin: profiles.NewPostgresAdminStore(q)}
+
+	// A non-empty endpoint clears buildDormant's Cosmos-config guard; the azcosmos
+	// client is built lazily so no network call is made. The Cosmos deleters are
+	// constructed but never reached — Run aborts on the finder's error first.
+	cfg := platform.Config{
+		CosmosEndpoint: "https://example.documents.azure.com:443/",
+		CosmosDatabase: "db",
+	}
+
+	handler, err := buildDormant(cfg, testRegistry(), backendPostgres, pg, discardLogger())
+	if err != nil {
+		t.Fatalf("buildDormant: %v", err)
+	}
+	if handler == nil {
+		t.Fatal("buildDormant returned a nil handler")
+	}
+
+	_, runErr := handler.Run(context.Background())
+	if !errors.Is(runErr, sentinel) {
+		t.Fatalf("dormant finder did not route through the Postgres admin store: %v", runErr)
+	}
+	if q.queryCalls != 1 {
+		t.Fatalf("Postgres admin store Query calls = %d, want 1", q.queryCalls)
+	}
+	if !strings.Contains(q.lastSQL, "last_active_at_epoch") {
+		t.Fatalf("finder query was not the Postgres Dormant scan: %q", q.lastSQL)
+	}
+}

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -685,6 +685,7 @@ func buildDormant(cfg platform.Config, registry *metrics.Registry, backend store
 	}
 
 	// Safely extract pg store fields (nil when STORE_BACKEND != postgres).
+	var pgProfileAdmin *profiles.PostgresAdminStore
 	var pgZone *watchzones.PostgresStore
 	var pgProfile *profiles.PostgresStore
 	var pgNotif *notifications.PostgresStore
@@ -693,6 +694,7 @@ func buildDormant(cfg platform.Config, registry *metrics.Registry, backend store
 	var pgSaved *savedapplications.PostgresStore
 	var pgOffer *offercodes.PostgresStore
 	if pg != nil {
+		pgProfileAdmin = pg.profileAdmin
 		pgZone = pg.zone
 		pgProfile = pg.profile
 		pgNotif = pg.notification
@@ -761,7 +763,14 @@ func buildDormant(cfg platform.Config, registry *metrics.Registry, backend store
 		ProfileAbsent:       func(e error) bool { return errors.Is(e, profiles.ErrNotFound) },
 	}
 
-	return dormant.New(profiles.NewAdminStore(users), deleters, logger, time.Now), nil
+	// The FINDER (dormant-account scan) is flag-selected just like every deleter:
+	// post-cutover the Cosmos Users container is dark, so a Cosmos-hardcoded finder
+	// would scan an empty container, find zero dormant accounts, and silently stop
+	// erasing inactive users — a UK GDPR retention gap. chooseAdminProfileStore
+	// routes the Dormant scan to Postgres when STORE_BACKEND=postgres, Cosmos
+	// otherwise (the same value buildSweep uses for its finder).
+	finder := chooseAdminProfileStore(pgProfileAdmin, profiles.NewAdminStore(users))
+	return dormant.New(finder, deleters, logger, time.Now), nil
 }
 
 // buildAuth0Deleter returns the real Auth0 Management (M2M) client when the M2M

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -214,7 +214,7 @@ func run() int {
 		sweepRunner = sweepHandler
 	}
 
-	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, sweepRunner, logger)
+	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, sweepRunner, nil, logger)
 }
 
 // buildPollOrchestrator wires the poll-sb orchestrator: the PlanIt client, the

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -2,10 +2,10 @@
 // Container Apps Jobs. One process per job: WORKER_MODE selects the mode,
 // the process runs it once, flushes telemetry, and exits with a status code.
 //
-// poll-bootstrap, digest, hourly-digest, dormant-cleanup, and subscription-sweep
-// are implemented; poll-sb remains a loud stub that exits 1 until its own bead
-// (tc-yng2) lands. The Go image is not deployed to any job until the final
-// cutover, so a stub can never strand a real job.
+// poll-bootstrap, digest, hourly-digest, dormant-cleanup, subscription-sweep
+// and pg-purge are implemented; poll-sb remains a loud stub that exits 1 until
+// its own bead (tc-yng2) lands. The Go image is not deployed to any job until
+// the final cutover, so a stub can never strand a real job.
 package main
 
 import (
@@ -32,6 +32,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/notifydispatch"
 	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
+	"github.com/AmyDe/town-crier/api-go/internal/pgpurge"
 	"github.com/AmyDe/town-crier/api-go/internal/planit"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres"
@@ -98,30 +99,47 @@ func run() int {
 	// emit their towncrier.* metrics (tc-21np).
 	registry := metrics.New(otel.Meter(metrics.MeterName))
 
-	// APPS_ZONES_BACKEND gates the Applications + WatchZones stores onto Postgres
-	// (dev only; prod and every other store stay Cosmos — issue #657 / #664 Phase
-	// B), mirroring cmd/api. When it selects Postgres we build ONE pool for the
-	// whole process — MI-token auth from the container's POSTGRES_*/AZURE_CLIENT_ID
-	// via NewPoolFromEnv — and reuse it across the poll, digest and dormant builders
-	// below. The worker explicitly wants Postgres here, so a pool that can't be built
-	// is fatal rather than a silent Cosmos fallback. The pool closes on shutdown.
-	// When the flag is unset (prod, local) these stay nil and every existing Cosmos
-	// construction is byte-for-byte unchanged.
-	appsZonesBackend := resolveBackend(cfg.AppsZonesBackend)
-	var (
-		pgAppStore       *applications.PostgresStore
-		pgWatchZoneStore *watchzones.PostgresStore
-	)
+	// appsZonesBackend selects the Applications + WatchZones store backend.
+	// resolveAppsZonesBackend returns backendPostgres when EITHER APPS_ZONES_BACKEND
+	// or STORE_BACKEND is "postgres" — so a full-cutover STORE_BACKEND=postgres flag
+	// moves apps+zones to Postgres without requiring both flags to be set.
+	appsZonesBackend := resolveAppsZonesBackend(cfg.AppsZonesBackend, cfg.StoreBackend)
+	// fullBackend is the STORE_BACKEND flag resolved independently: backendPostgres
+	// only when STORE_BACKEND="postgres". It gates the full per-store cutover (every
+	// store beyond apps+zones) and the pg-purge job.
+	fullBackend := resolveStoreBackend(cfg.StoreBackend)
+
+	// Build a shared Postgres pool + stores when EITHER flag selects Postgres.
+	// One pool is reused by every store and every builder below; it closes on
+	// process exit. A pool error is always fatal — the operator explicitly requested
+	// Postgres, so a silent Cosmos fallback would be a misconfiguration silenced.
+	var pg *pgStores
 	if appsZonesBackend == backendPostgres {
 		pool, perr := postgres.NewPoolFromEnv(context.Background())
 		if perr != nil {
-			logger.Error("apps/zones backend=postgres: build postgres pool", "error", perr)
+			logger.Error("postgres backend: build pool", "error", perr)
 			return 1
 		}
 		defer pool.Close()
-		pgAppStore = applications.NewPostgresStore(pool)
-		pgWatchZoneStore = watchzones.NewPostgresStore(pool)
-		logger.Info("apps/zones backend selected", "backend", "postgres")
+
+		pg = &pgStores{
+			app:  applications.NewPostgresStore(pool),
+			zone: watchzones.NewPostgresStore(pool),
+		}
+		if fullBackend == backendPostgres {
+			pg.profile = profiles.NewPostgresStore(pool)
+			pg.profileAdmin = profiles.NewPostgresAdminStore(pool)
+			pg.notification = notifications.NewPostgresStore(pool)
+			pg.notifState = notificationstate.NewPostgresStore(pool)
+			pg.device = devicetokens.NewPostgresStore(pool)
+			pg.savedApp = savedapplications.NewPostgresStore(pool)
+			pg.offerCode = offercodes.NewPostgresStore(pool)
+			pg.pollState = polling.NewPostgresPollStateStore(pool)
+			pg.lease = polling.NewPostgresLeaseStore(pool, time.Now)
+		}
+		logger.Info("postgres backend selected",
+			"appsZones", appsZonesBackend == backendPostgres,
+			"full", fullBackend == backendPostgres)
 	}
 
 	// The Service Bus client (and thus the bootstrapper and the poll-sb
@@ -159,7 +177,7 @@ func run() int {
 	// the "no Cosmos" case leaves it nil — assigning a typed-nil *digest.Handler
 	// would make the interface non-nil and defeat worker.Run's nil guard.
 	var digester worker.DigestRunner
-	handler, err := buildDigester(cfg, registry, appsZonesBackend, pgWatchZoneStore, logger)
+	handler, err := buildDigester(cfg, registry, appsZonesBackend, pg, logger)
 	if err != nil {
 		logger.Error("build digest handler", "error", err)
 		return 1
@@ -174,7 +192,7 @@ func run() int {
 	// worker.Run's nil guard). The Auth0 deleter falls back to a no-op when the M2M
 	// credentials are absent, so a Cosmos-only job still boots cleanly.
 	var dormantRunner worker.DormantRunner
-	dormantHandler, err := buildDormant(cfg, registry, appsZonesBackend, pgWatchZoneStore, logger)
+	dormantHandler, err := buildDormant(cfg, registry, appsZonesBackend, pg, logger)
 	if err != nil {
 		logger.Error("build dormant cleanup handler", "error", err)
 		return 1
@@ -189,7 +207,7 @@ func run() int {
 	// run rather than crashing. Declared as the interface so the "unconfigured"
 	// case stays a nil interface value (a typed-nil adapter would defeat the guard).
 	var poller worker.PollOrchestrator
-	pollAdapter, err := buildPollOrchestrator(cfg, sbClient, registry, appsZonesBackend, pgAppStore, pgWatchZoneStore, logger)
+	pollAdapter, err := buildPollOrchestrator(cfg, sbClient, registry, appsZonesBackend, pg, logger)
 	if err != nil {
 		logger.Error("build poll-sb orchestrator", "error", err)
 		return 1
@@ -205,7 +223,7 @@ func run() int {
 	// syncer falls back to a no-op when the M2M credentials are absent, so a
 	// Cosmos-only job still boots cleanly.
 	var sweepRunner worker.SweepRunner
-	sweepHandler, err := buildSweep(cfg, registry, logger)
+	sweepHandler, err := buildSweep(cfg, registry, pg, logger)
 	if err != nil {
 		logger.Error("build subscription sweep handler", "error", err)
 		return 1
@@ -214,19 +232,51 @@ func run() int {
 		sweepRunner = sweepHandler
 	}
 
-	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, sweepRunner, nil, logger)
+	// The pg-purge runner replaces Cosmos TTL for Notifications (90 days by
+	// default, NOTIFICATIONS_RETENTION_DAYS) and DeviceRegistrations (180 days,
+	// DEVICE_REGISTRATIONS_RETENTION_DAYS). It is wired only when
+	// STORE_BACKEND=postgres — on Cosmos deployments the pg-purge mode exits 0
+	// immediately (the worker.Run nil guard logs and exits 0). A nil purger
+	// signals "Cosmos TTL handles expiry; exit 0" — unlike other nil runners
+	// which exit 1.
+	var purger worker.PurgeRunner
+	if fullBackend == backendPostgres && pg != nil {
+		purger = pgpurge.New(
+			pg.notification,
+			pg.device,
+			time.Duration(cfg.NotificationsRetentionDays)*24*time.Hour,
+			time.Duration(cfg.DeviceRegistrationsRetentionDays)*24*time.Hour,
+			time.Now,
+			logger,
+		)
+	}
+
+	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, sweepRunner, purger, logger)
 }
 
 // buildPollOrchestrator wires the poll-sb orchestrator: the PlanIt client, the
-// Cosmos poll-state and etag-CAS lease stores, the cycle-alternating authority
-// provider, the ingestion handler, and the next-run scheduler — bridged to the
-// receive/publish operations of the shared Service Bus client. It returns
-// (nil, nil) when Service Bus or Cosmos config is absent, so poll-sb refuses to
-// run rather than nil-panicking. The cycle budget (replicaTimeout − grace) and
-// the handler/lease budgets all come from config.
-func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, registry *metrics.Registry, backend storeBackend, pgAppStore *applications.PostgresStore, pgWatchZoneStore *watchzones.PostgresStore, logger *slog.Logger) (*pollOrchestratorAdapter, error) {
+// poll-state and lease stores (Postgres or Cosmos, flag-selected from pg),
+// the cycle-alternating authority provider, the ingestion handler, and the
+// next-run scheduler — bridged to the receive/publish operations of the shared
+// Service Bus client. It returns (nil, nil) when Service Bus or Cosmos config
+// is absent, so poll-sb refuses to run rather than nil-panicking. The cycle
+// budget (replicaTimeout − grace) and the handler/lease budgets all come from
+// config.
+func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, registry *metrics.Registry, backend storeBackend, pg *pgStores, logger *slog.Logger) (*pollOrchestratorAdapter, error) {
 	if sbClient == nil || cfg.CosmosEndpoint == "" {
 		return nil, nil //nolint:nilnil // absent SB/Cosmos config is a valid "no poller" state, not an error
+	}
+
+	// Safely extract pg store fields (nil when STORE_BACKEND != postgres).
+	var pgApp *applications.PostgresStore
+	var pgZone *watchzones.PostgresStore
+	var pgPollState *polling.PostgresPollStateStore
+	var pgLease *polling.PostgresLeaseStore
+	if pg != nil {
+		pgApp = pg.app
+		pgZone = pg.zone
+		pgPollState = pg.pollState
+		pgLease = pg.lease
 	}
 
 	planItClient, err := planit.NewClient(planit.Options{
@@ -266,14 +316,29 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 	}
 	zonesContainer.WithMetrics(registry)
 
-	stateStore := polling.NewPollStateStore(stateContainer)
-	leaseStore := polling.NewLeaseStore(leaseItemsAdapter{leasesContainer}, time.Now)
 	// appStore and zoneStore are the flag-selected consumer-side interfaces the
 	// poll handler (Upsert + change dedup) and the watch-zone notify fan-out
-	// (FindZonesContaining) consume — Postgres when APPS_ZONES_BACKEND=postgres,
-	// Cosmos otherwise. The poll-state and lease stores always stay Cosmos.
-	appStore := chooseAppStore(backend, pgAppStore, applications.NewCosmosStore(appsContainer))
-	zoneStore := chooseZoneStore(backend, pgWatchZoneStore, watchzones.NewCosmosStore(zonesContainer))
+	// (FindZonesContaining) consume — Postgres when APPS_ZONES_BACKEND=postgres
+	// or STORE_BACKEND=postgres, Cosmos otherwise.
+	appStore := chooseAppStore(backend, pgApp, applications.NewCosmosStore(appsContainer))
+	zoneStore := chooseZoneStore(backend, pgZone, watchzones.NewCosmosStore(zonesContainer))
+
+	// stateStore and leaseStore are flag-selected from pg when STORE_BACKEND=postgres;
+	// they stay on Cosmos otherwise. Both polling.PollStateAccess and polling.LeaseAccess
+	// are satisfied by both the Cosmos and Postgres concrete types.
+	var stateStore polling.PollStateAccess
+	if pgPollState != nil {
+		stateStore = pgPollState
+	} else {
+		stateStore = polling.NewPollStateStore(stateContainer)
+	}
+
+	var leaseStore polling.LeaseAccess
+	if pgLease != nil {
+		leaseStore = pgLease
+	} else {
+		leaseStore = polling.NewLeaseStore(leaseItemsAdapter{leasesContainer}, time.Now)
+	}
 
 	cycleSelector := polling.NewMinuteCycleSelector(time.Now)
 	authorityProvider := polling.NewCycleAlternatingProvider(
@@ -304,7 +369,7 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 	// watch-zone notification fan-out.
 	// This is the CUTOVER-BLOCKER fan-out (bead tc-uc2p) — without it the
 	// Notifications container stays empty and every alert/digest breaks.
-	if err := wirePollFanOut(cfg, handler, zoneStore, registry, logger); err != nil {
+	if err := wirePollFanOut(cfg, handler, zoneStore, registry, pg, logger); err != nil {
 		return nil, err
 	}
 
@@ -344,14 +409,29 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 // the ingestion handler. They share the WatchZones store with the poll's
 // authority provider (the same watchzones.Store satisfies the zone-containment
 // lookup) and open their own Notifications / Users / NotificationState /
-// DeviceRegistrations / SavedApplications containers. zoneStore is the
-// flag-selected watchzones.Store interface — not the concrete Cosmos store — so
-// the notify FindZonesContaining hot path runs against Postgres when
-// APPS_ZONES_BACKEND=postgres (issue #664 Phase B). The APNs push sender is real
-// when its credentials are present, NoOp otherwise so the poll job boots even
-// without APNs config (the record is still written, so the digest pipeline keeps
-// working).
-func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zoneStore watchzones.Store, registry *metrics.Registry, logger *slog.Logger) error {
+// DeviceRegistrations / SavedApplications containers. Each store is
+// flag-selected from pg when STORE_BACKEND=postgres, Cosmos otherwise — so the
+// full fan-out path uses Postgres when the full cutover flag is set. zoneStore
+// is always the flag-selected watchzones.Store from buildPollOrchestrator so
+// FindZonesContaining already runs against the right backend. The APNs push
+// sender is real when its credentials are present, NoOp otherwise so the poll
+// job boots even without APNs config (the record is still written, so the
+// digest pipeline keeps working).
+func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zoneStore watchzones.Store, registry *metrics.Registry, pg *pgStores, logger *slog.Logger) error {
+	// Safely extract pg store fields (nil when STORE_BACKEND != postgres).
+	var pgNotif *notifications.PostgresStore
+	var pgProfile *profiles.PostgresStore
+	var pgDevice *devicetokens.PostgresStore
+	var pgNotifState *notificationstate.PostgresStore
+	var pgSaved *savedapplications.PostgresStore
+	if pg != nil {
+		pgNotif = pg.notification
+		pgProfile = pg.profile
+		pgDevice = pg.device
+		pgNotifState = pg.notifState
+		pgSaved = pg.savedApp
+	}
+
 	notifsContainer, err := platform.NewCosmosContainerNamed(cfg, platform.CosmosNotificationsContainer, logger)
 	if err != nil {
 		return err
@@ -378,11 +458,11 @@ func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zon
 	}
 	savedContainer.WithMetrics(registry)
 
-	notifStore := notifications.NewDigestStore(notifsContainer)
-	profileStore := profiles.NewCosmosStore(usersContainer)
-	deviceStore := devicetokens.NewCosmosStore(devicesContainer)
-	statePushStore := notificationstate.NewCosmosStore(stateContainer, notifsContainer)
-	savedStore := savedapplications.NewCosmosStore(savedContainer)
+	notifStore := chooseNotifDigestStore(pgNotif, notifications.NewDigestStore(notifsContainer))
+	profileStore := chooseProfileStore(pgProfile, profiles.NewCosmosStore(usersContainer))
+	deviceStore := chooseDeviceStore(pgDevice, devicetokens.NewCosmosStore(devicesContainer))
+	statePushStore := chooseNotifStateStore(pgNotifState, notificationstate.NewCosmosStore(stateContainer, notifsContainer))
+	savedStore := chooseSavedStore(pgSaved, savedapplications.NewCosmosStore(savedContainer))
 	pushSender := buildPushSender(cfg, logger)
 
 	// Record towncrier.notifications.created on each dispatcher (tc-21np).
@@ -484,15 +564,31 @@ func maxInt(a, b int) int {
 }
 
 // buildDigester constructs the digest handler when Cosmos is configured, wiring
-// the per-container stores and the email/push senders (real when their
-// credentials are present, NoOp otherwise so a job without ACS/APNs boots
-// cleanly). It returns (nil, nil) when Cosmos is unconfigured — the digest modes
-// then refuse to run rather than nil-panicking. Returning the concrete
-// *digest.Handler lets worker.Run accept it via its unexported digestRunner
-// interface (structural satisfaction).
-func buildDigester(cfg platform.Config, registry *metrics.Registry, backend storeBackend, pgWatchZoneStore *watchzones.PostgresStore, logger *slog.Logger) (*digest.Handler, error) {
+// the per-container stores (flag-selected from pg when STORE_BACKEND=postgres)
+// and the email/push senders (real when their credentials are present, NoOp
+// otherwise so a job without ACS/APNs boots cleanly). It returns (nil, nil)
+// when Cosmos is unconfigured — the digest modes then refuse to run rather than
+// nil-panicking. Returning the concrete *digest.Handler lets worker.Run accept
+// it via its unexported digestRunner interface (structural satisfaction).
+func buildDigester(cfg platform.Config, registry *metrics.Registry, backend storeBackend, pg *pgStores, logger *slog.Logger) (*digest.Handler, error) {
 	if cfg.CosmosEndpoint == "" {
 		return nil, nil //nolint:nilnil // absent Cosmos config is a valid "no digester" state, not an error
+	}
+
+	// Safely extract pg store fields (nil when STORE_BACKEND != postgres).
+	var pgZone *watchzones.PostgresStore
+	var pgNotif *notifications.PostgresStore
+	var pgProfile *profiles.PostgresStore
+	var pgProfileAdmin *profiles.PostgresAdminStore
+	var pgNotifState *notificationstate.PostgresStore
+	var pgDevice *devicetokens.PostgresStore
+	if pg != nil {
+		pgZone = pg.zone
+		pgNotif = pg.notification
+		pgProfile = pg.profile
+		pgProfileAdmin = pg.profileAdmin
+		pgNotifState = pg.notifState
+		pgDevice = pg.device
 	}
 
 	users, err := platform.NewCosmosContainerNamed(cfg, "Users", logger)
@@ -521,16 +617,23 @@ func buildDigester(cfg platform.Config, registry *metrics.Registry, backend stor
 	}
 	devicesContainer.WithMetrics(registry)
 
-	profileStore := digestProfiles{
-		admin: profiles.NewAdminStore(users),
-		point: profiles.NewCosmosStore(users),
-	}
-	notificationStore := notifications.NewDigestStore(notifs)
 	// zoneStore is the flag-selected watch-zone reader the weekly digest fans out
-	// over — Postgres when APPS_ZONES_BACKEND=postgres, Cosmos otherwise.
-	zoneStore := chooseZoneStore(backend, pgWatchZoneStore, watchzones.NewCosmosStore(zonesContainer))
-	stateStore := notificationstate.NewCosmosStore(stateContainer, notifs)
-	deviceStore := devicetokens.NewCosmosStore(devicesContainer)
+	// over — Postgres when APPS_ZONES_BACKEND=postgres or STORE_BACKEND=postgres,
+	// Cosmos otherwise.
+	zoneStore := chooseZoneStore(backend, pgZone, watchzones.NewCosmosStore(zonesContainer))
+	// notificationStore, stateStore, deviceStore are flag-selected from pg when
+	// STORE_BACKEND=postgres, Cosmos otherwise.
+	notificationStore := chooseNotifDigestStore(pgNotif, notifications.NewDigestStore(notifs))
+	stateStore := chooseNotifStateStore(pgNotifState, notificationstate.NewCosmosStore(stateContainer, notifs))
+	deviceStore := chooseDeviceStore(pgDevice, devicetokens.NewCosmosStore(devicesContainer))
+
+	// digestProfiles combines the cross-partition admin selector (ByDigestDay) and
+	// the point-read store (Get). Both fields accept either the Cosmos or Postgres
+	// store implementation via the exported profiles interfaces.
+	profileStore := digestProfiles{
+		admin: chooseAdminProfileStore(pgProfileAdmin, profiles.NewAdminStore(users)),
+		point: chooseProfileStore(pgProfile, profiles.NewCosmosStore(users)),
+	}
 
 	emailSender := buildEmailSender(cfg, logger)
 	pushSender := buildPushSender(cfg, logger)
@@ -549,12 +652,14 @@ func buildDigester(cfg platform.Config, registry *metrics.Registry, backend stor
 }
 
 // digestProfiles adapts the two profile stores the digest handler needs — the
-// cross-partition digest-day selector (AdminStore) and the per-user point read
-// (CosmosStore) — into the single consumer-side profile interface the handler
-// depends on.
+// cross-partition digest-day selector (AdminProfileStore) and the per-user
+// point read (Store) — into the single consumer-side profile interface the
+// handler depends on. Both fields are exported interfaces satisfied by both the
+// Cosmos and Postgres store implementations, so flag-selection between backends
+// does not require a concrete type change here.
 type digestProfiles struct {
-	admin *profiles.AdminStore
-	point *profiles.CosmosStore
+	admin profiles.AdminProfileStore
+	point profiles.Store
 }
 
 func (p digestProfiles) ByDigestDay(ctx context.Context, day time.Weekday) ([]*profiles.UserProfile, error) {
@@ -566,15 +671,35 @@ func (p digestProfiles) Get(ctx context.Context, userID string) (*profiles.UserP
 }
 
 // buildDormant constructs the dormant-cleanup handler when Cosmos is configured,
-// wiring the dormant-account finder, the per-container erasure stores, and the
-// Auth0 M2M deleter (real when its credentials are present, NoOp otherwise so a
-// job without Auth0 M2M config still erases Cosmos data). It returns (nil, nil)
-// when Cosmos is unconfigured — the dormant-cleanup mode then refuses to run
-// rather than nil-panicking. Returning the concrete *dormant.Handler lets
-// worker.Run accept it via its exported DormantRunner interface.
-func buildDormant(cfg platform.Config, registry *metrics.Registry, backend storeBackend, pgWatchZoneStore *watchzones.PostgresStore, logger *slog.Logger) (*dormant.Handler, error) {
+// wiring the dormant-account finder, the per-container erasure stores (ALL
+// flag-selected from pg when STORE_BACKEND=postgres — GDPR cascade completeness
+// is a hard requirement), and the Auth0 M2M deleter (real when its credentials
+// are present, NoOp otherwise so a job without Auth0 M2M config still erases
+// data). It returns (nil, nil) when Cosmos is unconfigured — the dormant-cleanup
+// mode then refuses to run rather than nil-panicking. Returning the concrete
+// *dormant.Handler lets worker.Run accept it via its exported DormantRunner
+// interface.
+func buildDormant(cfg platform.Config, registry *metrics.Registry, backend storeBackend, pg *pgStores, logger *slog.Logger) (*dormant.Handler, error) {
 	if cfg.CosmosEndpoint == "" {
 		return nil, nil //nolint:nilnil // absent Cosmos config is a valid "no dormant handler" state, not an error
+	}
+
+	// Safely extract pg store fields (nil when STORE_BACKEND != postgres).
+	var pgZone *watchzones.PostgresStore
+	var pgProfile *profiles.PostgresStore
+	var pgNotif *notifications.PostgresStore
+	var pgNotifState *notificationstate.PostgresStore
+	var pgDevice *devicetokens.PostgresStore
+	var pgSaved *savedapplications.PostgresStore
+	var pgOffer *offercodes.PostgresStore
+	if pg != nil {
+		pgZone = pg.zone
+		pgProfile = pg.profile
+		pgNotif = pg.notification
+		pgNotifState = pg.notifState
+		pgDevice = pg.device
+		pgSaved = pg.savedApp
+		pgOffer = pg.offerCode
 	}
 
 	users, err := platform.NewCosmosContainerNamed(cfg, "Users", logger)
@@ -613,25 +738,25 @@ func buildDormant(cfg platform.Config, registry *metrics.Registry, backend store
 	}
 	offerCodesContainer.WithMetrics(registry)
 
-	// The four DeleteAllByUserID stores satisfy erasure.ChildDeleter directly, the
-	// profile store's Delete satisfies erasure.ProfileDeleter directly, and the
-	// notification-state store (whose method is DeleteByUserID) is bridged by
-	// erasure.NotificationStateChild — so no per-step adapter types are needed. The
-	// offer-code store anonymises the redeemer back-reference (redeemedByUserId +
-	// redeemedAt) without deleting the admin-issued code (bead tc-5jyh).
+	// Every erasure.Deleters member is flag-selected: a Postgres row must never be
+	// missed by the GDPR cascade. Notifications uses the Postgres store directly
+	// (which has DeleteAllByUserID) instead of the Cosmos-specific DeleteStore —
+	// so the same pg.notification store serves both the fan-out path and erasure.
+	var notifDeleter erasure.ChildDeleter
+	if pgNotif != nil {
+		notifDeleter = pgNotif
+	} else {
+		notifDeleter = notifications.NewDeleteStore(notifs)
+	}
+
 	deleters := erasure.Deleters{
-		Notifications: notifications.NewDeleteStore(notifs),
-		// WatchZones is the flag-selected store the dormant-account GDPR erasure
-		// cascade deletes a user's watch zones from — Postgres when
-		// APPS_ZONES_BACKEND=postgres, Cosmos otherwise — so a Postgres watch zone is
-		// never missed by erasure (issue #664 Phase B). chooseZoneStore returns a
-		// genuine watchzones.Store (DeleteAllByUserID satisfies erasure.ChildDeleter).
-		WatchZones:          chooseZoneStore(backend, pgWatchZoneStore, watchzones.NewCosmosStore(zonesContainer)),
-		SavedApplications:   savedapplications.NewCosmosStore(savedContainer),
-		DeviceRegistrations: devicetokens.NewCosmosStore(devicesContainer),
-		NotificationState:   erasure.NotificationStateChild(notificationstate.NewCosmosStore(stateContainer, notifs)),
-		OfferCodes:          offercodes.NewCosmosStore(offerCodesContainer),
-		Profile:             profiles.NewCosmosStore(users),
+		Notifications:       notifDeleter,
+		WatchZones:          chooseZoneStore(backend, pgZone, watchzones.NewCosmosStore(zonesContainer)),
+		SavedApplications:   chooseSavedStore(pgSaved, savedapplications.NewCosmosStore(savedContainer)),
+		DeviceRegistrations: chooseDeviceStore(pgDevice, devicetokens.NewCosmosStore(devicesContainer)),
+		NotificationState:   erasure.NotificationStateChild(chooseNotifStateStore(pgNotifState, notificationstate.NewCosmosStore(stateContainer, notifs))),
+		OfferCodes:          chooseOfferStore(pgOffer, offercodes.NewCosmosStore(offerCodesContainer)),
+		Profile:             chooseProfileStore(pgProfile, profiles.NewCosmosStore(users)),
 		Auth0:               buildAuth0Deleter(cfg, logger),
 		ProfileAbsent:       func(e error) bool { return errors.Is(e, profiles.ErrNotFound) },
 	}
@@ -663,16 +788,21 @@ func buildAuth0Deleter(cfg platform.Config, logger *slog.Logger) erasure.Auth0De
 }
 
 // buildSweep constructs the subscription-sweep handler when Cosmos is configured,
-// wiring the lapsed-paid finder and profile saver (both the AdminStore over the
-// Users container) and the Auth0 M2M syncer (real when its credentials are
-// present, NoOp otherwise so a job without Auth0 M2M config still reverts the
-// stored Cosmos tier). It returns (nil, nil) when Cosmos is unconfigured — the
-// subscription-sweep mode then refuses to run rather than nil-panicking.
-// Returning the concrete *subscriptionsweep.Handler lets worker.Run accept it via
-// its exported SweepRunner interface.
-func buildSweep(cfg platform.Config, registry *metrics.Registry, logger *slog.Logger) (*subscriptionsweep.Handler, error) {
+// wiring the lapsed-paid finder and profile saver (both the AdminProfileStore —
+// Postgres or Cosmos, flag-selected from pg) and the Auth0 M2M syncer (real
+// when its credentials are present, NoOp otherwise so a job without Auth0 M2M
+// config still reverts the stored tier). It returns (nil, nil) when Cosmos is
+// unconfigured — the subscription-sweep mode then refuses to run rather than
+// nil-panicking. Returning the concrete *subscriptionsweep.Handler lets
+// worker.Run accept it via its exported SweepRunner interface.
+func buildSweep(cfg platform.Config, registry *metrics.Registry, pg *pgStores, logger *slog.Logger) (*subscriptionsweep.Handler, error) {
 	if cfg.CosmosEndpoint == "" {
 		return nil, nil //nolint:nilnil // absent Cosmos config is a valid "no sweep handler" state, not an error
+	}
+
+	var pgProfileAdmin *profiles.PostgresAdminStore
+	if pg != nil {
+		pgProfileAdmin = pg.profileAdmin
 	}
 
 	users, err := platform.NewCosmosContainerNamed(cfg, "Users", logger)
@@ -681,11 +811,10 @@ func buildSweep(cfg platform.Config, registry *metrics.Registry, logger *slog.Lo
 	}
 	users.WithMetrics(registry)
 
-	// The AdminStore satisfies both the sweep's Finder (LapsedPaid) and Saver
-	// (Save) — the lapsed scan and the downgrade upsert both span / key on the
-	// Users container, so one store serves both roles.
-	store := profiles.NewAdminStore(users)
-	return subscriptionsweep.New(store, store, buildAuth0Syncer(cfg, logger), logger, time.Now), nil
+	// adminStore is flag-selected: both LapsedPaid (Finder) and Save (Saver) come
+	// from the same AdminProfileStore, whether Cosmos or Postgres.
+	adminStore := chooseAdminProfileStore(pgProfileAdmin, profiles.NewAdminStore(users))
+	return subscriptionsweep.New(adminStore, adminStore, buildAuth0Syncer(cfg, logger), logger, time.Now), nil
 }
 
 // buildAuth0Syncer returns the real Auth0 Management (M2M) client when the M2M

--- a/api-go/cmd/worker/wiring_test.go
+++ b/api-go/cmd/worker/wiring_test.go
@@ -65,7 +65,7 @@ func TestWirePollFanOut_AcceptsFlagSelectedZoneStore(t *testing.T) {
 	handler := &polling.PollPlanItHandler{}
 	spy := newSpyZoneStore()
 
-	if err := wirePollFanOut(platform.Config{}, handler, spy, testRegistry(), discardLogger()); err != nil {
+	if err := wirePollFanOut(platform.Config{}, handler, spy, testRegistry(), nil, discardLogger()); err != nil {
 		t.Fatalf("wirePollFanOut with a flag-selected watchzones.Store: %v", err)
 	}
 }

--- a/api-go/internal/pgpurge/handler.go
+++ b/api-go/internal/pgpurge/handler.go
@@ -1,0 +1,91 @@
+// Package pgpurge implements the pg-purge worker mode: a scheduled DELETE sweep
+// that replaces the Cosmos time-to-live (TTL) settings for Notifications (90
+// days) and DeviceRegistrations (180 days) on the Postgres backend. The Cosmos
+// TTL is passive and automatic; Postgres has no native TTL so a periodic purge
+// job must run in its place. The handler is wired only when STORE_BACKEND=postgres
+// — on Cosmos deployments the worker.Run nil guard logs and exits 0.
+package pgpurge
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// notifPurger deletes notification rows older than a cutoff. The
+// *notifications.PostgresStore satisfies it via PurgeOlderThan.
+type notifPurger interface {
+	PurgeOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
+}
+
+// devicePurger deletes device-registration rows older than a cutoff. The
+// *devicetokens.PostgresStore satisfies it via PurgeOlderThan.
+type devicePurger interface {
+	PurgeOlderThan(ctx context.Context, cutoff time.Time) (int64, error)
+}
+
+// Handler runs one pg-purge cycle: deletes notifications older than
+// notifRetention and device registrations older than deviceRetention. It
+// returns the count of rows deleted from each table so the caller can record
+// them as telemetry.
+type Handler struct {
+	notifs          notifPurger
+	devices         devicePurger
+	notifRetention  time.Duration
+	deviceRetention time.Duration
+	now             func() time.Time
+	logger          *slog.Logger
+}
+
+// New wires the purge handler. notifRetention and deviceRetention are the
+// look-back windows (e.g. 90*24*time.Hour and 180*24*time.Hour); now is
+// injected so tests can pin the clock. Production passes time.Now and
+// durations derived from platform.Config retention fields.
+func New(
+	notifs notifPurger,
+	devices devicePurger,
+	notifRetention time.Duration,
+	deviceRetention time.Duration,
+	now func() time.Time,
+	logger *slog.Logger,
+) *Handler {
+	return &Handler{
+		notifs:          notifs,
+		devices:         devices,
+		notifRetention:  notifRetention,
+		deviceRetention: deviceRetention,
+		now:             now,
+		logger:          logger,
+	}
+}
+
+// Run deletes rows older than their respective retention windows and returns
+// (notifsPurged, devicesPurged, error). Notifications are purged first; if
+// that fails the device purge is skipped so the caller can surface a single
+// actionable error.
+func (h *Handler) Run(ctx context.Context) (int, int, error) {
+	now := h.now()
+
+	notifCutoff := now.Add(-h.notifRetention)
+	n, err := h.notifs.PurgeOlderThan(ctx, notifCutoff)
+	if err != nil {
+		return 0, 0, fmt.Errorf("purge notifications: %w", err)
+	}
+	notifsPurged := int(n)
+
+	deviceCutoff := now.Add(-h.deviceRetention)
+	d, err := h.devices.PurgeOlderThan(ctx, deviceCutoff)
+	if err != nil {
+		return notifsPurged, 0, fmt.Errorf("purge device registrations: %w", err)
+	}
+	devicesPurged := int(d)
+
+	h.logger.InfoContext(ctx, "pg-purge: rows deleted",
+		"notificationsDeleted", notifsPurged,
+		"deviceRegistrationsDeleted", devicesPurged,
+		"notifCutoff", notifCutoff,
+		"deviceCutoff", deviceCutoff)
+
+	return notifsPurged, devicesPurged, nil
+}

--- a/api-go/internal/pgpurge/handler_test.go
+++ b/api-go/internal/pgpurge/handler_test.go
@@ -1,0 +1,118 @@
+package pgpurge_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/pgpurge"
+)
+
+// fakePurger is a hand-written double for either notifPurger or devicePurger.
+// It records the cutoff time it received and can be primed with a row count or
+// an error.
+type fakePurger struct {
+	calls      int
+	lastCutoff time.Time
+	rowsResult int64
+	err        error
+}
+
+func (f *fakePurger) PurgeOlderThan(_ context.Context, cutoff time.Time) (int64, error) {
+	f.calls++
+	f.lastCutoff = cutoff
+	return f.rowsResult, f.err
+}
+
+// fixedClock returns a time.Time that never changes, for deterministic tests.
+func fixedClock(t time.Time) func() time.Time { return func() time.Time { return t } }
+
+var testNow = time.Date(2026, 6, 27, 12, 0, 0, 0, time.UTC)
+
+func discardLogger() *slog.Logger { return slog.New(slog.DiscardHandler) }
+
+func TestHandler_Run_PurgesBothStoresWithCorrectCutoffs(t *testing.T) {
+	t.Parallel()
+
+	notifs := &fakePurger{rowsResult: 42}
+	devices := &fakePurger{rowsResult: 7}
+
+	h := pgpurge.New(notifs, devices, 90*24*time.Hour, 180*24*time.Hour, fixedClock(testNow), discardLogger())
+
+	notifsPurged, devicesPurged, err := h.Run(context.Background())
+
+	if err != nil {
+		t.Fatalf("Run: unexpected error: %v", err)
+	}
+	if notifsPurged != 42 {
+		t.Errorf("notifsPurged = %d, want 42", notifsPurged)
+	}
+	if devicesPurged != 7 {
+		t.Errorf("devicesPurged = %d, want 7", devicesPurged)
+	}
+
+	wantNotifCutoff := testNow.Add(-90 * 24 * time.Hour)
+	if !notifs.lastCutoff.Equal(wantNotifCutoff) {
+		t.Errorf("notifs cutoff = %v, want %v", notifs.lastCutoff, wantNotifCutoff)
+	}
+
+	wantDeviceCutoff := testNow.Add(-180 * 24 * time.Hour)
+	if !devices.lastCutoff.Equal(wantDeviceCutoff) {
+		t.Errorf("devices cutoff = %v, want %v", devices.lastCutoff, wantDeviceCutoff)
+	}
+}
+
+func TestHandler_Run_ErrorOnNotifsPurgeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	notifs := &fakePurger{err: errors.New("postgres down")}
+	devices := &fakePurger{rowsResult: 5}
+
+	h := pgpurge.New(notifs, devices, 90*24*time.Hour, 180*24*time.Hour, fixedClock(testNow), discardLogger())
+
+	_, _, err := h.Run(context.Background())
+
+	if err == nil {
+		t.Fatal("Run: expected error from notifs purge, got nil")
+	}
+	if devices.calls != 0 {
+		t.Errorf("device purger called %d times after notifs error, want 0", devices.calls)
+	}
+}
+
+func TestHandler_Run_ErrorOnDevicesPurgeReturnsError(t *testing.T) {
+	t.Parallel()
+
+	notifs := &fakePurger{rowsResult: 10}
+	devices := &fakePurger{err: errors.New("constraint violation")}
+
+	h := pgpurge.New(notifs, devices, 90*24*time.Hour, 180*24*time.Hour, fixedClock(testNow), discardLogger())
+
+	_, _, err := h.Run(context.Background())
+
+	if err == nil {
+		t.Fatal("Run: expected error from devices purge, got nil")
+	}
+}
+
+func TestHandler_Run_BothCallsReceiveContext(t *testing.T) {
+	t.Parallel()
+
+	notifs := &fakePurger{}
+	devices := &fakePurger{}
+
+	h := pgpurge.New(notifs, devices, 90*24*time.Hour, 180*24*time.Hour, fixedClock(testNow), discardLogger())
+
+	if _, _, err := h.Run(context.Background()); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if notifs.calls != 1 {
+		t.Errorf("notifs PurgeOlderThan calls = %d, want 1", notifs.calls)
+	}
+	if devices.calls != 1 {
+		t.Errorf("devices PurgeOlderThan calls = %d, want 1", devices.calls)
+	}
+}

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -166,6 +166,16 @@ type Config struct {
 	PollingHandlerBudgetSeconds         int
 	PollReplicaTimeoutSeconds           int
 	PollShutdownGraceSeconds            int
+
+	// NotificationsRetentionDays is the number of days to keep Notifications rows
+	// when running the pg-purge job (replacing Cosmos 90-day TTL). Loaded from
+	// NOTIFICATIONS_RETENTION_DAYS; defaults to 90 matching the Cosmos TTL.
+	NotificationsRetentionDays int
+
+	// DeviceRegistrationsRetentionDays is the number of days to keep DeviceRegistrations
+	// rows when running the pg-purge job (replacing Cosmos 180-day TTL). Loaded from
+	// DEVICE_REGISTRATIONS_RETENTION_DAYS; defaults to 180 matching the Cosmos TTL.
+	DeviceRegistrationsRetentionDays int
 }
 
 // defaultPlanItBaseURL is the live PlanIt applications API.
@@ -243,6 +253,9 @@ func LoadConfig() (Config, error) {
 		PollingHandlerBudgetSeconds:         getenvInt("POLLING_HANDLER_BUDGET_SECONDS", 240),
 		PollReplicaTimeoutSeconds:           getenvInt("POLL_REPLICA_TIMEOUT_SECONDS", 600),
 		PollShutdownGraceSeconds:            getenvInt("POLL_SHUTDOWN_GRACE_SECONDS", 30),
+
+		NotificationsRetentionDays:       getenvInt("NOTIFICATIONS_RETENTION_DAYS", 90),
+		DeviceRegistrationsRetentionDays: getenvInt("DEVICE_REGISTRATIONS_RETENTION_DAYS", 180),
 	}
 
 	if raw := os.Getenv("LOG_LEVEL"); raw != "" {

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -39,6 +39,12 @@ const dormantBudget = 10 * time.Minute
 // cleanly and flushes telemetry.
 const sweepBudget = 10 * time.Minute
 
+// purgeBudget is the soft self-cancel for a single pg-purge run. A DELETE
+// WHERE created_at < cutoff on two tables is fast even at scale; 10 minutes is
+// generous while still bounded well under the Container Apps replicaTimeout so
+// the process exits cleanly and flushes telemetry.
+const purgeBudget = 10 * time.Minute
+
 // DigestRunner is the consumer-side slice of the digest handler the dispatcher
 // invokes. *digest.Handler satisfies it; the worker depends only on these two
 // methods so it need not know the handler's internals. It is exported so main()
@@ -66,6 +72,17 @@ type DormantRunner interface {
 // defeat the nil guard.
 type SweepRunner interface {
 	Run(ctx context.Context) (int, error)
+}
+
+// PurgeRunner is the consumer-side slice of the pg-purge handler the dispatcher
+// invokes. *pgpurge.Handler satisfies it; Run returns the number of notification
+// rows and device-registration rows deleted so the dispatcher can record them as
+// telemetry tags. It is exported so main() can hold a genuinely nil interface
+// value when STORE_BACKEND is not "postgres" — the nil runner causes dispatch to
+// log and exit 0 (Cosmos TTL handles expiry; pg-purge on a Cosmos deployment is
+// a deliberate no-op, not a deployment error).
+type PurgeRunner interface {
+	Run(ctx context.Context) (notifsPurged int, devicesPurged int, err error)
 }
 
 // PollRunResult is the dispatcher-facing summary of one poll-sb cycle. It mirrors
@@ -97,17 +114,19 @@ type PollOrchestrator interface {
 // Service Bus client + bootstrapper, sets up telemetry, and propagates this
 // code.
 //
-// poll-bootstrap, digest, hourly-digest, dormant-cleanup, and subscription-sweep
-// are implemented; poll-sb remains a loud stub that exits 1 until its own bead
-// (tc-yng2) lands. The Go worker image is not deployed to any job until the final
-// cutover bead, so a stub can never run in production. An unset or unknown mode is
-// a deployment accident and also fails fast.
+// poll-bootstrap, digest, hourly-digest, dormant-cleanup, subscription-sweep,
+// and pg-purge are implemented; poll-sb remains a loud stub that exits 1 until
+// its own bead (tc-yng2) lands. The Go worker image is not deployed to any job
+// until the final cutover bead, so a stub can never run in production. An unset
+// or unknown mode is a deployment accident and also fails fast.
 //
 // bootstrapper may be nil when the job has no Service Bus config; poll-bootstrap
 // then refuses to run rather than nil-panicking. Likewise digester / dormant may
 // be nil when the job has no Cosmos config; those modes then refuse to run rather
-// than nil-panicking.
-func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, dormant DormantRunner, poller PollOrchestrator, sweeper SweepRunner, logger *slog.Logger) int {
+// than nil-panicking. purger may be nil when STORE_BACKEND is not "postgres";
+// pg-purge then logs and exits 0 — Cosmos TTL handles expiry, so this is never
+// an error.
+func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, dormant DormantRunner, poller PollOrchestrator, sweeper SweepRunner, purger PurgeRunner, logger *slog.Logger) int {
 	switch mode {
 	case "":
 		// WORKER_MODE is always set by infra; an unset value is a deployment
@@ -132,6 +151,9 @@ func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester 
 
 	case "poll-sb":
 		return runPollSB(ctx, poller, logger)
+
+	case "pg-purge":
+		return runPurge(ctx, purger, logger)
 
 	default:
 		logger.ErrorContext(ctx, "unknown WORKER_MODE; refusing to run", "mode", mode)
@@ -272,6 +294,43 @@ func runSweep(ctx context.Context, runner SweepRunner, logger *slog.Logger) int 
 		return 1
 	}
 	span.SetAttributes(attribute.Int("subscription_sweep.downgraded_count", downgraded))
+	return 0
+}
+
+// runPurge executes one pg-purge cycle under a soft self-cancel budget, inside a
+// telemetry span named "Postgres Purge Cycle". It tags the span with the count of
+// notification and device-registration rows deleted. A nil runner (STORE_BACKEND
+// not set to "postgres") exits 0 with a log — Cosmos TTL handles expiry for
+// non-Postgres deployments and pg-purge on a Cosmos deployment is deliberate
+// no-op, not a deployment error. A non-nil runner error exits 1 so the job
+// surfaces the failure.
+func runPurge(ctx context.Context, runner PurgeRunner, logger *slog.Logger) int {
+	tracer := otel.Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, "Postgres Purge Cycle")
+	defer span.End()
+
+	if runner == nil {
+		logger.InfoContext(ctx, "pg-purge: store backend is not postgres; Cosmos TTL handles expiry")
+		return 0
+	}
+
+	cycleCtx, cancel := context.WithTimeout(ctx, purgeBudget)
+	defer cancel()
+
+	notifsPurged, devicesPurged, err := runner.Run(cycleCtx)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		logger.ErrorContext(ctx, "pg-purge cycle failed", "error", err)
+		return 1
+	}
+	span.SetAttributes(
+		attribute.Int("pg_purge.notifications_deleted", notifsPurged),
+		attribute.Int("pg_purge.device_registrations_deleted", devicesPurged),
+	)
+	logger.InfoContext(ctx, "pg-purge cycle completed",
+		"notificationsDeleted", notifsPurged,
+		"deviceRegistrationsDeleted", devicesPurged)
 	return 0
 }
 

--- a/api-go/internal/worker/dispatch_test.go
+++ b/api-go/internal/worker/dispatch_test.go
@@ -56,12 +56,26 @@ func (f *fakeSweep) Run(context.Context) (int, error) {
 	return f.downgraded, f.err
 }
 
+// fakePurge is a hand-written double for the PurgeRunner the dispatcher invokes.
+// It records the call and can be primed with purge counts or an error.
+type fakePurge struct {
+	calls         int
+	notifsPurged  int
+	devicesPurged int
+	err           error
+}
+
+func (f *fakePurge) Run(context.Context) (int, int, error) {
+	f.calls++
+	return f.notifsPurged, f.devicesPurged, f.err
+}
+
 func TestRun_UnsetModeFailsFast(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "", nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "", nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unset mode", code)
@@ -76,7 +90,7 @@ func TestRun_DigestModeRunsWeeklyAndExitsZero(t *testing.T) {
 	d := &fakeDigester{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0", code)
@@ -91,7 +105,7 @@ func TestRun_HourlyDigestModeRunsHourlyAndExitsZero(t *testing.T) {
 	d := &fakeDigester{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "hourly-digest", nil, d, nil, nil, nil, logger)
+	code := Run(context.Background(), "hourly-digest", nil, d, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0", code)
@@ -108,7 +122,7 @@ func TestRun_DigestModeWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "digest", nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when digest handler is unconfigured", code)
@@ -120,7 +134,7 @@ func TestRun_DigestCycleErrorExitsOne(t *testing.T) {
 	d := &fakeDigester{weeklyErr: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on digest cycle error", code)
@@ -151,7 +165,7 @@ func TestRun_PollSBRunsOrchestratorAndExitsZeroOnSuccess(t *testing.T) {
 	}}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 for a successful poll cycle", code)
@@ -168,7 +182,7 @@ func TestRun_PollSBWithoutOrchestratorExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when poll-sb is unconfigured", code)
@@ -208,7 +222,7 @@ func TestRun_PollSBExitsOneOnlyWhenNoAppsAndAuthorityErrors(t *testing.T) {
 			t.Parallel()
 			o := &fakePollOrchestrator{result: tc.result}
 			logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
-			code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, logger)
+			code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, logger)
 			if code != tc.wantExit {
 				t.Errorf("exit code: got %d, want %d", code, tc.wantExit)
 			}
@@ -221,7 +235,7 @@ func TestRun_PollSBExitsOneOnOrchestratorError(t *testing.T) {
 	o := &fakePollOrchestrator{err: errors.New("orchestrator blew up")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on orchestrator error", code)
@@ -233,7 +247,7 @@ func TestRun_DormantCleanupRunsAndExitsZero(t *testing.T) {
 	d := &fakeDormant{deleted: 3}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful dormant cleanup)", code)
@@ -250,7 +264,7 @@ func TestRun_DormantCleanupWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when dormant handler is unconfigured", code)
@@ -262,7 +276,7 @@ func TestRun_DormantCleanupCycleErrorExitsOne(t *testing.T) {
 	d := &fakeDormant{err: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on dormant cleanup error", code)
@@ -274,7 +288,7 @@ func TestRun_SubscriptionSweepRunsAndExitsZero(t *testing.T) {
 	s := &fakeSweep{downgraded: 4}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, logger)
+	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful subscription sweep)", code)
@@ -291,7 +305,7 @@ func TestRun_SubscriptionSweepWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when sweep handler is unconfigured", code)
@@ -303,10 +317,55 @@ func TestRun_SubscriptionSweepCycleErrorExitsOne(t *testing.T) {
 	s := &fakeSweep{err: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, logger)
+	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on subscription sweep error", code)
+	}
+}
+
+func TestRun_PgPurgeRunsAndExitsZero(t *testing.T) {
+	t.Parallel()
+	p := &fakePurge{notifsPurged: 12, devicesPurged: 3}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, p, logger)
+
+	if code != 0 {
+		t.Errorf("exit code: got %d, want 0 (successful pg-purge)", code)
+	}
+	if p.calls != 1 {
+		t.Errorf("purge Run calls: got %d, want 1", p.calls)
+	}
+}
+
+func TestRun_PgPurgeWithNilRunnerExitsZero(t *testing.T) {
+	t.Parallel()
+	// When STORE_BACKEND is not postgres the purger is nil; pg-purge must exit 0
+	// (not 1) because Cosmos TTL handles expiry and running pg-purge on a
+	// Cosmos deployment is a deliberate safe no-op.
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, nil, logger)
+
+	if code != 0 {
+		t.Errorf("exit code: got %d, want 0 when purger is nil (Cosmos TTL active)", code)
+	}
+	if !strings.Contains(buf.String(), "Cosmos TTL") {
+		t.Errorf("log should mention Cosmos TTL, got: %s", buf.String())
+	}
+}
+
+func TestRun_PgPurgeCycleErrorExitsOne(t *testing.T) {
+	t.Parallel()
+	p := &fakePurge{err: errors.New("postgres down")}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, p, logger)
+
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1 on pg-purge error", code)
 	}
 }
 
@@ -315,7 +374,7 @@ func TestRun_UnknownModeExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "banana", nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "banana", nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unknown mode", code)
@@ -328,7 +387,7 @@ func TestRun_PollBootstrapSeedsAndExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful bootstrap)", code)
@@ -345,7 +404,7 @@ func TestRun_PollBootstrapWithoutQueueExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when Service Bus is unconfigured", code)
@@ -360,7 +419,7 @@ func TestRun_PollBootstrapProbeFailureStillExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (absorbed probe failure is not a job failure)", code)


### PR DESCRIPTION
Slice 7b of Phase F single-store cutover (epic #645, spec #669, memo 0010). Completes the app-wide wiring flip (cmd/worker side).

- `resolveStoreBackend(STORE_BACKEND)` + per-store choosers in `cmd/worker/backend.go` (mirrors cmd/api; apps/zones = postgres when `APPS_ZONES_BACKEND=postgres` OR `STORE_BACKEND=postgres`; never inferred from `POSTGRES_AUTH`).
- One pool built when either flag selects Postgres; a `pgStores` bundle threaded into every builder. **All five builders flag-select every store** they use: `buildPollOrchestrator` (PollState + Leases), `wirePollFanOut` (notif create / profiles / device / state / saved), `buildDigester`, `buildSweep`, and `buildDormant`.
- **Dormant-cleanup GDPR fully flag-selected** — every `erasure.Deleters` member AND the dormant finder route to the selected backend (a Cosmos-hardcoded finder would scan the dark Users container post-cutover and silently stop erasing dormant accounts — a retention gap, now closed).
- **`pg-purge` worker mode** (`internal/pgpurge`) replaces the Cosmos 90d/180d TTLs: `notifications.PurgeOlderThan(now-90d)` + `devicetokens.PurgeOlderThan(now-180d)`, retention via `NOTIFICATIONS_RETENTION_DAYS` (90) / `DEVICE_REGISTRATIONS_RETENTION_DAYS` (180). No-op + clean exit on the Cosmos path. `worker.Run` extended with the purge runner.

Unit (fakes, `-race`, 1462) green incl. backend/chooser/purge/finder tests; build/vet/gofmt/golangci clean; tree clean.

Bead: tc-hpd2.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)