### PR TITLE
chore(ios): bump MARKETING_VERSION 1.2.3→1.2.4 (closed train) (tc-z9qs)

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.2.3"
+        MARKETING_VERSION: "1.2.4"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"


### PR DESCRIPTION
## Why

The `v0.15.46` TestFlight upload [failed](https://github.com/AmyDe/town-crier/actions/runs/28280522596) at the altool step:

- `90062` — `CFBundleShortVersionString [1.2.3]` must be higher than the previously approved version `[1.2.3]`
- `90186` — pre-release train `1.2.3` is closed for new build submissions

`1.2.3` already shipped to the App Store, so Apple closed that version train. The CD beta lane only bumps the **build** number, never `MARKETING_VERSION`, so every re-upload collides. This is the documented patch-release snag (precedent tc-xap5).

## Change

Bump `MARKETING_VERSION` `1.2.3` → `1.2.4` in `mobile/ios/project.yml`. After merge, cut a fresh `v*` release tag to re-trigger the iOS TestFlight upload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)