### PR TITLE
fix(ios): clear cached Auth0 creds on API environment/audience change (tc-iuvu)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/Auth/Auth0AuthenticationService.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Auth/Auth0AuthenticationService.swift
@@ -74,6 +74,17 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
   public func refreshSession() async throws -> AuthSession {
     do {
       let credentials = try await credentialsManager.credentials()
+      guard Self.audienceMatches(
+        accessToken: credentials.accessToken, expected: config.audience
+      ) else {
+        // The stored token was minted for a different API audience (a
+        // prod-build -> dev-build flip, #660). It is still un-expired, so
+        // handing it back would 401 against the new API. Wipe it and force
+        // a fresh login instead (tc-iuvu).
+        _ = credentialsManager.clear()
+        await sessionCache.clear()
+        throw DomainError.sessionExpired
+      }
       let session = Self.mapToSession(credentials)
       await sessionCache.store(session)
       return session
@@ -108,7 +119,7 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
     // Slow path: consult the keychain. `currentOrLoad` deduplicates
     // concurrent callers so a four-way burst with a cold cache still
     // issues at most one `SecItemCopyMatching`.
-    return await sessionCache.currentOrLoad { [credentialsManager] in
+    return await sessionCache.currentOrLoad { [credentialsManager, config] in
       // `hasValid()` only checks access-token expiry. Per Auth0 SDK docs,
       // apps using refresh tokens must also consult `canRenew()` at
       // startup — otherwise an expired access token forces a fresh login
@@ -118,6 +129,15 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
       }
       do {
         let credentials = try await credentialsManager.credentials()
+        guard Self.audienceMatches(
+          accessToken: credentials.accessToken, expected: config.audience
+        ) else {
+          // Stored token targets a different API audience (env flip, #660).
+          // Discard it; returning nil also nulls the session cache via
+          // `currentOrLoad`, so the next call re-authenticates (tc-iuvu).
+          _ = credentialsManager.clear()
+          return nil
+        }
         return Self.mapToSession(credentials)
       } catch {
         return nil
@@ -141,6 +161,23 @@ public final class Auth0AuthenticationService: TownCrierDomain.AuthenticationSer
     default:
       return false
     }
+  }
+
+  /// Whether the access token was issued for the API audience this build
+  /// targets. After an environment flip (prod build -> dev build, #660) a
+  /// cached but un-expired token still carries the previous audience, which
+  /// the new API rejects with 401. Comparing the `aud` claim against
+  /// `config.audience` lets the cached-credential read paths detect the
+  /// mismatch and force a fresh login.
+  ///
+  /// The `aud` claim may be a string or an array of strings; both are
+  /// matched by membership. **Fails open**: a token that cannot be decoded
+  /// or carries no `aud` claim is treated as matching, so a malformed-token
+  /// hiccup never wipes an otherwise valid session.
+  static func audienceMatches(accessToken: String, expected: String) -> Bool {
+    let audiences = JWTSubscriptionTierExtractor.extractAudiences(from: accessToken)
+    guard !audiences.isEmpty else { return true }
+    return audiences.contains(expected)
   }
 
   private static func mapToSession(_ credentials: Credentials) -> AuthSession {

--- a/mobile/ios/packages/town-crier-data/Sources/Auth/JWTSubscriptionTierExtractor.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Auth/JWTSubscriptionTierExtractor.swift
@@ -27,6 +27,22 @@ enum JWTSubscriptionTierExtractor {
     return payload["sub"] as? String
   }
 
+  /// Extracts the `aud` (audience) claim from a JWT token, normalised to an
+  /// array. Per RFC 7519 the claim may be a single string or an array of
+  /// strings; both shapes are returned as `[String]`. Returns an empty array
+  /// when the claim is absent or the token is malformed -- callers treat that
+  /// as "unknown audience" and fail open.
+  static func extractAudiences(from token: String) -> [String] {
+    guard let payload = decodePayload(from: token) else { return [] }
+    if let single = payload["aud"] as? String {
+      return [single]
+    }
+    if let array = payload["aud"] as? [String] {
+      return array
+    }
+    return []
+  }
+
   /// Decodes the payload segment of a JWT token into a dictionary.
   /// Returns `nil` if the token is malformed or the payload is not valid JSON.
   static func decodePayload(from token: String) -> [String: Any]? {

--- a/mobile/ios/town-crier-tests/Sources/Features/Auth0AudienceMatchTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/Auth0AudienceMatchTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Testing
+
+@testable import TownCrierData
+
+/// Covers the pure audience-matching seam that guards the cached-credential
+/// read paths after an API environment flip (prod build -> dev build, #660).
+/// A cached but still-unexpired access token carries the previous build's
+/// audience; the new API 401s it. `audienceMatches` lets the service detect
+/// the mismatch and force a fresh login.
+@Suite("Auth0AuthenticationService.audienceMatches")
+struct Auth0AudienceMatchTests {
+
+  // Base64url-encoded JWT header: {"alg": "RS256", "typ": "JWT"}
+  private static let header = "eyJhbGciOiAiUlMyNTYiLCAidHlwIjogIkpXVCJ9"
+
+  private static let devAudience = "https://api-dev.towncrierapp.uk"
+  private static let prodAudience = "https://api.towncrierapp.uk"
+
+  private static func jwt(payloadBase64url: String) -> String {
+    header + "." + payloadBase64url + ".fakesignature"
+  }
+
+  // MARK: - String aud claim
+
+  @Test func audienceMatches_returnsTrue_whenStringAudEqualsExpected() {
+    // JWT payload: {"aud": "https://api-dev.towncrierapp.uk"}
+    let token = Self.jwt(
+      payloadBase64url: "eyJhdWQiOiAiaHR0cHM6Ly9hcGktZGV2LnRvd25jcmllcmFwcC51ayJ9"
+    )
+
+    #expect(
+      Auth0AuthenticationService.audienceMatches(
+        accessToken: token, expected: Self.devAudience
+      )
+    )
+  }
+
+  @Test func audienceMatches_returnsFalse_whenStringAudDiffersFromExpected() {
+    // JWT payload: {"aud": "https://api.towncrierapp.uk"}
+    let token = Self.jwt(
+      payloadBase64url: "eyJhdWQiOiAiaHR0cHM6Ly9hcGkudG93bmNyaWVyYXBwLnVrIn0"
+    )
+
+    #expect(
+      !Auth0AuthenticationService.audienceMatches(
+        accessToken: token, expected: Self.devAudience
+      )
+    )
+  }
+
+  // MARK: - Array aud claim
+
+  @Test func audienceMatches_returnsTrue_whenArrayAudContainsExpected() {
+    // JWT payload:
+    // {"aud": ["https://api-dev.towncrierapp.uk",
+    //          "https://towncrier.eu.auth0.com/userinfo"]}
+    let token = Self.jwt(
+      payloadBase64url:
+        "eyJhdWQiOiBbImh0dHBzOi8vYXBpLWRldi50b3duY3JpZXJhcHAudWsiLCAiaHR0cHM6Ly90b3du"
+        + "Y3JpZXIuZXUuYXV0aDAuY29tL3VzZXJpbmZvIl19"
+    )
+
+    #expect(
+      Auth0AuthenticationService.audienceMatches(
+        accessToken: token, expected: Self.devAudience
+      )
+    )
+  }
+
+  @Test func audienceMatches_returnsFalse_whenArrayAudOmitsExpected() {
+    // JWT payload:
+    // {"aud": ["https://api.towncrierapp.uk",
+    //          "https://towncrier.eu.auth0.com/userinfo"]}
+    let token = Self.jwt(
+      payloadBase64url:
+        "eyJhdWQiOiBbImh0dHBzOi8vYXBpLnRvd25jcmllcmFwcC51ayIsICJodHRwczovL3Rvd25j"
+        + "cmllci5ldS5hdXRoMC5jb20vdXNlcmluZm8iXX0"
+    )
+
+    #expect(
+      !Auth0AuthenticationService.audienceMatches(
+        accessToken: token, expected: Self.devAudience
+      )
+    )
+  }
+
+  // MARK: - Fail-open on decode failure or missing claim
+
+  @Test func audienceMatches_returnsTrue_whenTokenIsMalformed() {
+    #expect(
+      Auth0AuthenticationService.audienceMatches(
+        accessToken: "not-a-jwt", expected: Self.devAudience
+      )
+    )
+  }
+
+  @Test func audienceMatches_returnsTrue_whenAudClaimIsAbsent() {
+    // JWT payload: {"sub": "auth0|123"} -- no aud claim
+    let token = Self.jwt(payloadBase64url: "eyJzdWIiOiAiYXV0aDB8MTIzIn0")
+
+    #expect(
+      Auth0AuthenticationService.audienceMatches(
+        accessToken: token, expected: Self.devAudience
+      )
+    )
+  }
+}


### PR DESCRIPTION
## Problem

P0 triage 2026-06-27: after #660 routed TestFlight builds to the **dev** API (`api-dev.towncrierapp.uk`, audience `https://api-dev.towncrierapp.uk`) while App Store stays on **prod**, TestFlight users who upgraded **in place** got HTTP 401 on every authenticated request — the app showed no watch zones and failed to load applications.

**The Cosmos→Postgres cutover was NOT the cause.** Verified in prod: a freshly-minted valid token returns 200; Postgres reads healthy; christy's user migrated fine. Splitting App Insights by `deployment.environment` showed the 401s were all on **dev** (`server.address: api-dev.towncrierapp.uk`, `TownCrierApp/44`), not prod.

## Root cause

`Auth0AuthenticationService` caches credentials in a single keychain slot (`uk.towncrierapp.auth0`) **not keyed by environment**. When a build flips prod→dev, the cached **prod-audience** access token is still un-expired (`hasValid()` true), so `currentSession()`/`refreshSession()` hand it back. The dev API rejects it on audience mismatch (`aud` = prod ≠ dev) → 401, and the app never re-authenticates because it believes the session is valid.

Confirmed by direct API tests: dev API + fresh dev-audience token = **200**; dev API + prod-audience token = **401**. (christy's App Store reinstall works because prod audience matches.)

## Fix

When returning a session built from **stored** credentials, decode the access token's `aud` claim and verify it contains `config.audience`. On mismatch: `clear()` credentials + session cache and force a fresh login.
- `currentSession()` slow path → return `nil`
- `refreshSession()` → throw `DomainError.sessionExpired`
- `login()` untouched (a freshly minted token is correct by definition)

Extracted a pure, unit-tested seam `audienceMatches(accessToken:expected:)`; `CredentialsManager` stays thin glue (mirrors #660's pattern). `aud` matched by membership (String **or** array). **Fails open** on an undecodable / absent `aud` so a malformed-token hiccup never wipes a valid session.

## Tests / gates
- 6 new Swift Testing cases (string/array match, string/array mismatch, malformed → fail-open, missing aud → fail-open)
- `swift build` ✓ · audience suite 6/6 ✓ · `swiftlint lint --strict` 0 violations ✓ · commits signed ✓

No `Release-Note:` trailer — environment plumbing, not App-Store-user-visible (same call as #660).

Closes tc-iuvu. Epic #645 / issue #658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)