### PR TITLE
feat(api): server-side ?sort= with newest/oldest keyset paging + sort-aware cursor (tc-c7mn, #682 slice 1)

### DIFF
--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -118,6 +118,9 @@ func (fakeAppStore) BreakdownByAuthority(context.Context, string) ([]application
 func (fakeAppStore) FindNearbyPage(context.Context, float64, float64, float64, int, string) ([]applications.PlanningApplication, string, error) {
 	return nil, "", nil
 }
+func (fakeAppStore) FindInZonePage(context.Context, float64, float64, float64, applications.Sort, int, string) ([]applications.PlanningApplication, string, error) {
+	return nil, "", nil
+}
 func (fakeAppStore) RecentNearby(context.Context, string, float64, float64, float64, int) ([]applications.PlanningApplication, error) {
 	return nil, nil
 }

--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -36,6 +36,7 @@ type Store interface {
 	RecentByAuthority(ctx context.Context, authorityCode string, cap int) ([]PlanningApplication, error)
 	BreakdownByAuthority(ctx context.Context, authorityCode string) ([]StateCount, error)
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error)
+	FindInZonePage(ctx context.Context, latitude, longitude, radiusMetres float64, sort Sort, limit int, cursor string) ([]PlanningApplication, string, error)
 	RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
 	NearestNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
 	BreakdownNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) ([]StateCount, error)

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -4,6 +4,7 @@ package applications
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -457,6 +458,177 @@ func TestPostgresStore_FindNearbyPage_TieBreak(t *testing.T) {
 		cursor = next
 	}
 	assertNames(t, collected, []string{"APP-1-100", "APP-2-200A", "APP-3-200B", "APP-4-500"})
+}
+
+// withStart sets the application's start_date.
+func withStart(a PlanningApplication, d time.Time) PlanningApplication {
+	a.StartDate = &d
+	return a
+}
+
+// pageAllInZone pages FindInZonePage to exhaustion with the given page size and
+// returns the names in the order seen across pages. It bounds the loop so a
+// keyset bug that fails to advance fails the test instead of hanging.
+func pageAllInZone(t *testing.T, store *PostgresStore, sort Sort, radius float64, limit int) []string {
+	t.Helper()
+	ctx := context.Background()
+	var names []string
+	cursor := ""
+	for range 1000 {
+		page, next, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, radius, sort, limit, cursor)
+		if err != nil {
+			t.Fatalf("FindInZonePage(%s, cursor=%q): %v", sort, cursor, err)
+		}
+		names = append(names, appNames(page)...)
+		if next == "" {
+			return names
+		}
+		cursor = next
+	}
+	t.Fatalf("FindInZonePage(%s) did not exhaust within the safety bound", sort)
+	return nil
+}
+
+// sortFixture seeds a deterministic in-radius set spanning three start_dates
+// (one shared across two authorities, to exercise the (authority_code,
+// planit_name) tiebreak) plus two NULL-start_date rows (to exercise NULLS LAST
+// and a page boundary inside the NULL tail). All rows are within 6 km.
+func sortFixture(t *testing.T, store *PostgresStore) {
+	t.Helper()
+	ctx := context.Background()
+	mar := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	feb := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	jan := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, a := range []PlanningApplication{
+		withStart(at(pgApp("A1", 100), 100), mar),
+		withStart(at(pgApp("A2", 100), 200), jan),
+		withStart(at(pgApp("A3", 100), 300), feb),
+		withStart(at(pgApp("A4", 200), 350), feb), // equal date to A3, other authority
+		at(pgApp("A5", 100), 400),                 // NULL start_date
+		at(pgApp("A6", 100), 500),                 // NULL start_date
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+}
+
+// TestPostgresStore_FindInZonePage_Distance proves the sort-aware path reproduces
+// the legacy nearest-first ordering for SortDistance and pages without gaps.
+func TestPostgresStore_FindInZonePage_Distance(t *testing.T) {
+	store := newAppPGStore(t)
+	sortFixture(t, store)
+
+	// Single page (canonical order) — nearest-first by construction distance.
+	want := []string{"A1", "A2", "A3", "A4", "A5", "A6"}
+	if got := pageAllInZone(t, store, SortDistance, 6000, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("distance single page: got %v, want %v", got, want)
+	}
+	// Paged to exhaustion with a small page size — must equal the canonical order.
+	if got := pageAllInZone(t, store, SortDistance, 6000, 2); !reflect.DeepEqual(got, want) {
+		t.Fatalf("distance paged: got %v, want %v", got, want)
+	}
+}
+
+// TestPostgresStore_FindInZonePage_Newest proves start_date DESC NULLS LAST with
+// the (authority_code, planit_name) tiebreak, paged to exhaustion with no overlap
+// or gap, matches the single unpaged order.
+func TestPostgresStore_FindInZonePage_Newest(t *testing.T) {
+	store := newAppPGStore(t)
+	sortFixture(t, store)
+
+	// DESC by start_date; equal date (A3/A4) tiebreaks on authority_code "100" <
+	// "200"; NULL start_date (A5/A6) sorts last on planit_name "A5" < "A6".
+	want := []string{"A1", "A3", "A4", "A2", "A5", "A6"}
+	if got := pageAllInZone(t, store, SortNewest, 6000, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("newest single page: got %v, want %v", got, want)
+	}
+	if got := pageAllInZone(t, store, SortNewest, 6000, 2); !reflect.DeepEqual(got, want) {
+		t.Fatalf("newest paged: got %v, want %v", got, want)
+	}
+	// Page size 1 forces a keyset boundary at every row, including inside the NULL tail.
+	if got := pageAllInZone(t, store, SortNewest, 6000, 1); !reflect.DeepEqual(got, want) {
+		t.Fatalf("newest paged size 1: got %v, want %v", got, want)
+	}
+}
+
+// TestPostgresStore_FindInZonePage_Oldest proves start_date ASC NULLS LAST with
+// the same tiebreak, paged to exhaustion, matches the single unpaged order.
+func TestPostgresStore_FindInZonePage_Oldest(t *testing.T) {
+	store := newAppPGStore(t)
+	sortFixture(t, store)
+
+	want := []string{"A2", "A3", "A4", "A1", "A5", "A6"}
+	if got := pageAllInZone(t, store, SortOldest, 6000, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("oldest single page: got %v, want %v", got, want)
+	}
+	if got := pageAllInZone(t, store, SortOldest, 6000, 2); !reflect.DeepEqual(got, want) {
+		t.Fatalf("oldest paged: got %v, want %v", got, want)
+	}
+	if got := pageAllInZone(t, store, SortOldest, 6000, 1); !reflect.DeepEqual(got, want) {
+		t.Fatalf("oldest paged size 1: got %v, want %v", got, want)
+	}
+}
+
+// TestPostgresStore_FindInZonePage_RespectsRadius proves the spatial predicate
+// still bounds every sort: a row outside the radius never appears.
+func TestPostgresStore_FindInZonePage_RespectsRadius(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+	far := time.Date(2026, 12, 1, 0, 0, 0, 0, time.UTC) // newest of all, but far away
+	for _, a := range []PlanningApplication{
+		withStart(at(pgApp("IN", 100), 100), time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+		withStart(at(pgApp("OUT", 100), 50000), far), // 50 km, outside 6 km
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+	for _, sort := range []Sort{SortDistance, SortNewest, SortOldest} {
+		got := pageAllInZone(t, store, sort, 6000, 10)
+		if !reflect.DeepEqual(got, []string{"IN"}) {
+			t.Errorf("%s: got %v, want [IN] (OUT is beyond the radius)", sort, got)
+		}
+	}
+}
+
+// TestPostgresStore_FindInZonePage_CursorSortMismatch proves a cursor minted under
+// one sort is rejected when replayed under another, and a malformed cursor is
+// reported as ErrCursorInvalid — both so the handler returns 400, never a
+// mis-ordered page.
+func TestPostgresStore_FindInZonePage_CursorSortMismatch(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+	sortFixture(t, store)
+
+	_, cursor, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, SortNewest, 1, "")
+	if err != nil {
+		t.Fatalf("mint newest cursor: %v", err)
+	}
+	if cursor == "" {
+		t.Fatal("expected a continuation cursor after a full page")
+	}
+
+	if _, _, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, SortOldest, 1, cursor); !errors.Is(err, ErrCursorSortMismatch) {
+		t.Errorf("replay newest cursor under oldest: got err %v, want ErrCursorSortMismatch", err)
+	}
+
+	if _, _, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, SortNewest, 1, "!!!not-base64!!!"); !errors.Is(err, ErrCursorInvalid) {
+		t.Errorf("malformed cursor: got err %v, want ErrCursorInvalid", err)
+	}
+}
+
+// TestPostgresStore_FindInZonePage_UnsupportedSort proves an out-of-set sort is
+// rejected with ErrUnsupportedSort (the handler validates first, but the store
+// fails closed rather than silently running an arbitrary order).
+func TestPostgresStore_FindInZonePage_UnsupportedSort(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+	sortFixture(t, store)
+
+	if _, _, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, Sort("status"), 10, ""); !errors.Is(err, ErrUnsupportedSort) {
+		t.Errorf("unsupported sort: got err %v, want ErrUnsupportedSort", err)
+	}
 }
 
 // TestPostgresStore_RecentNearby_And_NearestNearby distinguishes recency ordering

--- a/api-go/internal/applications/zonepage.go
+++ b/api-go/internal/applications/zonepage.go
@@ -1,0 +1,96 @@
+package applications
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Sort is a server-side ordering for the in-zone applications page. It is part of
+// the API contract: a request's ?sort= value and the mode embedded in a keyset
+// cursor are both this type, so a cursor minted under one sort can be rejected
+// when replayed under another (see FindInZonePage and ErrCursorSortMismatch).
+//
+// Slice 1 (epic #682) implements {distance, newest, oldest}. The remaining UI
+// sorts (status, recent-activity) arrive in later slices; until then they are
+// rejected as unsupported.
+type Sort string
+
+const (
+	// SortDistance orders nearest-first via the KNN <-> operator. It is the
+	// default and the cheapest plan (GiST-served), preserving the legacy
+	// nearest-first browse behaviour.
+	SortDistance Sort = "distance"
+	// SortNewest orders by start_date DESC NULLS LAST, then the unique tiebreak
+	// (authority_code, planit_name).
+	SortNewest Sort = "newest"
+	// SortOldest orders by start_date ASC NULLS LAST, then the unique tiebreak
+	// (authority_code, planit_name). It reuses the newest btree, scanned backward.
+	SortOldest Sort = "oldest"
+)
+
+// Supported reports whether s is a sort this slice implements server-side.
+func (s Sort) Supported() bool {
+	switch s {
+	case SortDistance, SortNewest, SortOldest:
+		return true
+	default:
+		return false
+	}
+}
+
+var (
+	// ErrCursorInvalid signals a ?cursor= token that is not a well-formed keyset
+	// cursor (bad base64 or non-cursor payload). Consumers map it to HTTP 400.
+	ErrCursorInvalid = errors.New("invalid page cursor")
+	// ErrCursorSortMismatch signals a cursor whose embedded sort mode differs
+	// from the request's sort. A keyset cursor is only valid for the ORDER BY it
+	// was minted under, so replaying it under a different sort would yield a
+	// mis-ordered page; consumers map this to HTTP 400, never a silent reset.
+	ErrCursorSortMismatch = errors.New("cursor sort mode does not match request sort")
+	// ErrUnsupportedSort signals a sort value outside the set this slice
+	// implements. Consumers map it to HTTP 400.
+	ErrUnsupportedSort = errors.New("unsupported sort")
+)
+
+// pageCursor is the opaque, sort-aware keyset position handed back to clients.
+// It embeds the sort mode (M) so a stale cursor cannot silently produce a page
+// in the wrong order, plus exactly the keys that sort's ORDER BY ranks on:
+//   - distance: D (the KNN distance) + N (planit_name).
+//   - newest/oldest: SD (start_date, nil for a NULL-start_date tail row) + AC
+//     (authority_code) + N (planit_name).
+//
+// It is base64url-encoded JSON. SD is a "2006-01-02" date string so the next
+// page's predicate compares against an unambiguous ::date, not a timezone-laden
+// timestamp.
+type pageCursor struct {
+	M  Sort    `json:"m"`
+	D  string  `json:"d,omitempty"`
+	SD *string `json:"sd,omitempty"`
+	AC string  `json:"ac,omitempty"`
+	N  string  `json:"n"`
+}
+
+// encodePageCursor serialises the keyset position to a base64url JSON token.
+func encodePageCursor(c pageCursor) (string, error) {
+	b, err := json.Marshal(c)
+	if err != nil {
+		return "", fmt.Errorf("marshal page cursor: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(b), nil
+}
+
+// decodePageCursor parses a base64url JSON token back into a keyset position. A
+// malformed token (bad base64 or non-cursor JSON) is reported as ErrCursorInvalid.
+func decodePageCursor(token string) (pageCursor, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return pageCursor{}, fmt.Errorf("base64 decode page cursor: %w: %w", ErrCursorInvalid, err)
+	}
+	var c pageCursor
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return pageCursor{}, fmt.Errorf("unmarshal page cursor: %w: %w", ErrCursorInvalid, err)
+	}
+	return c, nil
+}

--- a/api-go/internal/applications/zonepage.go
+++ b/api-go/internal/applications/zonepage.go
@@ -1,10 +1,14 @@
 package applications
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
+
+	"github.com/jackc/pgx/v5"
 )
 
 // Sort is a server-side ordering for the in-zone applications page. It is part of
@@ -93,4 +97,210 @@ func decodePageCursor(token string) (pageCursor, error) {
 		return pageCursor{}, fmt.Errorf("unmarshal page cursor: %w: %w", ErrCursorInvalid, err)
 	}
 	return c, nil
+}
+
+// dateColumns is the read projection for the start_date-ordered sorts: the shared
+// appColumns plus authority_code, the second keyset key (a PlanIt name is only
+// unique within an authority, so the tiebreak needs both). Its order MUST match
+// scanDatePageRow.
+const dateColumns = appColumns + ", authority_code"
+
+// The ORDER BY + LIMIT suffix for each date sort. NULLS LAST keeps NULL-start_date
+// rows after every dated row; (authority_code, planit_name) is the unique tiebreak.
+const (
+	newestOrderBy = " ORDER BY start_date DESC NULLS LAST, authority_code, planit_name LIMIT $4"
+	oldestOrderBy = " ORDER BY start_date ASC NULLS LAST, authority_code, planit_name LIMIT $4"
+)
+
+// dateFromWhere is the shared SELECT + spatial predicate for the date sorts. $1
+// is longitude and $2 latitude (via nearbyPoint), $3 the radius, $4 the limit.
+const dateFromWhere = "SELECT " + dateColumns + " FROM applications WHERE ST_DWithin(location, " + nearbyPoint + ", $3)"
+
+// First-page queries: spatial predicate only, ordered, limited.
+const (
+	newestFirstQuery = dateFromWhere + newestOrderBy
+	oldestFirstQuery = dateFromWhere + oldestOrderBy
+)
+
+// Keyset queries resuming after a cursor on a NON-NULL start_date row. The
+// predicate exactly matches the ORDER BY so pages never overlap or gap: rows
+// further along the date order, OR all NULL-start_date rows (they trail in NULLS
+// LAST), OR an equal-date row past the (authority_code, planit_name) tiebreak.
+// $5 is the cursor's start_date (::date), $6 authority_code, $7 planit_name.
+const (
+	newestKeysetQuery = dateFromWhere +
+		" AND (start_date < $5::date OR start_date IS NULL" +
+		" OR (start_date = $5::date AND (authority_code, planit_name) > ($6, $7)))" +
+		newestOrderBy
+	oldestKeysetQuery = dateFromWhere +
+		" AND (start_date > $5::date OR start_date IS NULL" +
+		" OR (start_date = $5::date AND (authority_code, planit_name) > ($6, $7)))" +
+		oldestOrderBy
+)
+
+// Keyset queries resuming after a cursor on a NULL start_date row — the NULLS
+// LAST tail, where the only remaining order is the (authority_code, planit_name)
+// tiebreak. $5 is authority_code, $6 planit_name.
+const (
+	newestKeysetNullQuery = dateFromWhere +
+		" AND start_date IS NULL AND (authority_code, planit_name) > ($5, $6)" +
+		newestOrderBy
+	oldestKeysetNullQuery = dateFromWhere +
+		" AND start_date IS NULL AND (authority_code, planit_name) > ($5, $6)" +
+		oldestOrderBy
+)
+
+// datePageRow carries a hydrated application plus its authority_code, so the last
+// row of a full page can be encoded into the next-page keyset cursor.
+type datePageRow struct {
+	app PlanningApplication
+	ac  string
+}
+
+func scanDatePageRow(row pgx.CollectableRow) (datePageRow, error) {
+	var r datePageRow
+	dest := append(appScanDest(&r.app), &r.ac)
+	if err := row.Scan(dest...); err != nil {
+		return datePageRow{}, err
+	}
+	return r, nil
+}
+
+// FindInZonePage returns one page of up to limit applications within radiusMetres
+// of (latitude, longitude), ordered by the requested sort, plus an opaque
+// sort-aware cursor for the next page (empty when exhausted). It generalises
+// FindNearbyPage (which stays the legacy default-distance path with its own
+// cursor) to the {distance, newest, oldest} sorts of epic #682 slice 1. Every
+// sort keeps the ST_DWithin spatial predicate and a total order whose keyset
+// predicate exactly matches its ORDER BY, so pages never overlap or gap. The
+// cursor embeds the sort mode: replaying it under a different sort returns
+// ErrCursorSortMismatch, and a malformed cursor returns ErrCursorInvalid, so the
+// caller can return 400 rather than a mis-ordered page. It is authority-agnostic.
+func (s *PostgresStore) FindInZonePage(ctx context.Context, latitude, longitude, radiusMetres float64, sort Sort, limit int, cursor string) ([]PlanningApplication, string, error) {
+	if !sort.Supported() {
+		return nil, "", fmt.Errorf("sort %q: %w", sort, ErrUnsupportedSort)
+	}
+	var c *pageCursor
+	if cursor != "" {
+		decoded, err := decodePageCursor(cursor)
+		if err != nil {
+			return nil, "", err
+		}
+		if decoded.M != sort {
+			return nil, "", fmt.Errorf("cursor sort %q, request sort %q: %w", decoded.M, sort, ErrCursorSortMismatch)
+		}
+		c = &decoded
+	}
+	if sort == SortDistance {
+		return s.findDistanceZonePage(ctx, latitude, longitude, radiusMetres, limit, c)
+	}
+	return s.findDateZonePage(ctx, latitude, longitude, radiusMetres, sort, limit, c)
+}
+
+// findDistanceZonePage serves SortDistance: the legacy KNN nearest-first query
+// with a sort-aware (mode="distance") cursor on (distance, planit_name).
+func (s *PostgresStore) findDistanceZonePage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
+	var (
+		rows pgx.Rows
+		err  error
+	)
+	if c == nil {
+		rows, err = s.db.Query(ctx, findNearbyFirstPageQuery, longitude, latitude, radiusMetres, limit)
+	} else {
+		dist, perr := strconv.ParseFloat(c.D, 64)
+		if perr != nil {
+			return nil, "", fmt.Errorf("parse distance cursor: %w: %w", ErrCursorInvalid, perr)
+		}
+		rows, err = s.db.Query(ctx, findNearbyKeysetQuery, longitude, latitude, radiusMetres, limit, dist, c.N)
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("find applications by distance near (%v, %v): %w", latitude, longitude, err)
+	}
+	collected, err := pgx.CollectRows(rows, scanNearbyRow)
+	if err != nil {
+		return nil, "", fmt.Errorf("find applications by distance near (%v, %v): %w", latitude, longitude, err)
+	}
+	apps := make([]PlanningApplication, len(collected))
+	for i := range collected {
+		apps[i] = collected[i].app
+	}
+	next := ""
+	if limit > 0 && len(collected) == limit {
+		last := collected[len(collected)-1]
+		next, err = encodePageCursor(pageCursor{
+			M: SortDistance,
+			D: strconv.FormatFloat(last.dist, 'g', -1, 64),
+			N: last.app.Name,
+		})
+		if err != nil {
+			return nil, "", fmt.Errorf("encode distance cursor: %w", err)
+		}
+	}
+	return apps, next, nil
+}
+
+// findDateZonePage serves SortNewest/SortOldest: the start_date-ordered query with
+// a keyset cursor on (start_date, authority_code, planit_name).
+func (s *PostgresStore) findDateZonePage(ctx context.Context, latitude, longitude, radiusMetres float64, sort Sort, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
+	query, args := dateZoneQuery(sort, latitude, longitude, radiusMetres, limit, c)
+	rows, err := s.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("find applications by %s near (%v, %v): %w", sort, latitude, longitude, err)
+	}
+	collected, err := pgx.CollectRows(rows, scanDatePageRow)
+	if err != nil {
+		return nil, "", fmt.Errorf("find applications by %s near (%v, %v): %w", sort, latitude, longitude, err)
+	}
+	apps := make([]PlanningApplication, len(collected))
+	for i := range collected {
+		apps[i] = collected[i].app
+	}
+	next := ""
+	if limit > 0 && len(collected) == limit {
+		next, err = encodePageCursor(dateCursorOf(sort, collected[len(collected)-1]))
+		if err != nil {
+			return nil, "", fmt.Errorf("encode %s cursor: %w", sort, err)
+		}
+	}
+	return apps, next, nil
+}
+
+// dateZoneQuery selects the first-page, non-null-keyset, or NULL-tail-keyset query
+// for the sort and assembles its positional args. The base args ($1..$4) are
+// longitude, latitude, radius, limit; the keyset args extend them.
+func dateZoneQuery(sort Sort, latitude, longitude, radiusMetres float64, limit int, c *pageCursor) (string, []any) {
+	base := []any{longitude, latitude, radiusMetres, limit}
+	switch {
+	case c == nil:
+		if sort == SortNewest {
+			return newestFirstQuery, base
+		}
+		return oldestFirstQuery, base
+	case c.SD == nil:
+		// Cursor sits in the NULL-start_date tail: keyset on the tiebreak only.
+		args := append(base, c.AC, c.N)
+		if sort == SortNewest {
+			return newestKeysetNullQuery, args
+		}
+		return oldestKeysetNullQuery, args
+	default:
+		args := append(base, *c.SD, c.AC, c.N)
+		if sort == SortNewest {
+			return newestKeysetQuery, args
+		}
+		return oldestKeysetQuery, args
+	}
+}
+
+// dateCursorOf builds the next-page keyset cursor from the last row of a full
+// page: its start_date (nil for a NULL-start_date tail row), authority_code, and
+// planit_name. start_date is formatted as an unambiguous "2006-01-02" so the next
+// predicate compares against a ::date, free of timezone drift.
+func dateCursorOf(sort Sort, last datePageRow) pageCursor {
+	c := pageCursor{M: sort, AC: last.ac, N: last.app.Name}
+	if last.app.StartDate != nil {
+		sd := last.app.StartDate.Format("2006-01-02")
+		c.SD = &sd
+	}
+	return c
 }

--- a/api-go/internal/applications/zonepage_test.go
+++ b/api-go/internal/applications/zonepage_test.go
@@ -1,0 +1,65 @@
+package applications
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestPageCursor_RoundTrip proves the sort-aware keyset cursor survives an
+// encode/decode round-trip for every shape: a distance keyset, a non-null
+// start_date keyset, and a NULL start_date keyset (the tail of a NULLS LAST
+// scan).
+func TestPageCursor_RoundTrip(t *testing.T) {
+	t.Parallel()
+	sd := "2026-01-02"
+	tests := []struct {
+		name string
+		in   pageCursor
+	}{
+		{"distance", pageCursor{M: SortDistance, D: "123.456", N: "24/0001/FUL"}},
+		{"newest non-null", pageCursor{M: SortNewest, SD: &sd, AC: "100", N: "24/0002/FUL"}},
+		{"oldest non-null", pageCursor{M: SortOldest, SD: &sd, AC: "200", N: "24/0003/FUL"}},
+		{"newest null tail", pageCursor{M: SortNewest, SD: nil, AC: "300", N: "24/0004/FUL"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			token, err := encodePageCursor(tc.in)
+			if err != nil {
+				t.Fatalf("encodePageCursor: %v", err)
+			}
+			got, err := decodePageCursor(token)
+			if err != nil {
+				t.Fatalf("decodePageCursor: %v", err)
+			}
+			if got.M != tc.in.M || got.D != tc.in.D || got.AC != tc.in.AC || got.N != tc.in.N {
+				t.Errorf("round-trip mismatch: got %+v, want %+v", got, tc.in)
+			}
+			if (got.SD == nil) != (tc.in.SD == nil) {
+				t.Fatalf("SD nil mismatch: got %v, want %v", got.SD, tc.in.SD)
+			}
+			if got.SD != nil && *got.SD != *tc.in.SD {
+				t.Errorf("SD: got %q, want %q", *got.SD, *tc.in.SD)
+			}
+		})
+	}
+}
+
+// TestDecodePageCursor_Malformed proves a non-base64 token and a base64 token
+// whose payload is not the cursor JSON both surface ErrCursorInvalid, so the
+// handler can map them to a clean 400.
+func TestDecodePageCursor_Malformed(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"not base64url":     "!!!not-base64!!!",
+		"base64 of garbage": "bm90LWpzb24", // base64url("not-json")
+	}
+	for name, token := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := decodePageCursor(token); !errors.Is(err, ErrCursorInvalid) {
+				t.Errorf("decodePageCursor(%q): got err %v, want ErrCursorInvalid", token, err)
+			}
+		})
+	}
+}

--- a/api-go/internal/platform/postgres/migrations/0012_application_sort_indexes.sql
+++ b/api-go/internal/platform/postgres/migrations/0012_application_sort_indexes.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+
+-- Btree index backing the server-side ?sort=newest / ?sort=oldest keyset scan on
+-- the watch-zone applications list (epic #682 slice 1). The newest ORDER BY is
+-- (start_date DESC NULLS LAST, authority_code, planit_name); oldest reuses this
+-- same index scanned backward. (authority_code, planit_name) is the unique
+-- tiebreak — a PlanIt case reference is only unique within an authority — so the
+-- keyset cursor never overlaps or gaps on equal start_dates.
+--
+-- The radius predicate stays served by applications_location_gist (ST_DWithin /
+-- KNN <->); this index orders the in-radius candidate set and keeps the keyset
+-- pagination cheap. NULLS LAST matches the query so NULL-start_date rows trail
+-- the dated rows and still page deterministically.
+CREATE INDEX IF NOT EXISTS applications_start_date_keyset
+    ON applications (start_date DESC NULLS LAST, authority_code, planit_name);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS applications_start_date_keyset;

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -52,9 +52,14 @@ type authorityResolver interface {
 // cross-partition, so a border-spanning zone surfaces neighbour-authority apps
 // (tc-zldl). The fetch is bounded: it returns at most `limit` rows for the given
 // cursor plus an opaque continuation token for the next page (tc-fm8f).
-// *applications.CosmosStore satisfies it.
+//
+// FindNearbyPage is the legacy default-distance path (byte-identical param-less
+// contract). FindInZonePage adds the server-side ?sort= surface (epic #682 slice
+// 1: distance/newest/oldest) with a sort-aware keyset cursor. *applications.PostgresStore
+// satisfies both.
 type appFinder interface {
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]applications.PlanningApplication, string, error)
+	FindInZonePage(ctx context.Context, latitude, longitude, radiusMetres float64, sort applications.Sort, limit int, cursor string) ([]applications.PlanningApplication, string, error)
 }
 
 // watermarkReader reads the caller's notification read-watermark. A nil return
@@ -121,19 +126,29 @@ type createRequest struct {
 // bump this value server-side first before shipping the iOS change.
 const maxRadiusMetres = 10_000
 
-// defaultNearbyLimit and maxNearbyLimit bound the per-request page of nearby
-// applications. The browse path fetches a SINGLE bounded page so a dense urban
-// zone can no longer drain tens of thousands of documents and blow the server
-// write timeout (tc-fm8f). Default and max are equal at 500: ~0.5 MB of full
-// Result rows, sub-second, low RU. The create + demo paths fetch page one only.
+// defaultNearbyLimit, defaultSortedLimit and maxNearbyLimit bound the per-request
+// page of nearby applications. The browse path fetches a SINGLE bounded page so a
+// dense urban zone can no longer drain tens of thousands of documents and blow the
+// server write timeout (tc-fm8f).
+//
+// The legacy param-less path keeps the 500 default (byte-identical backward-compat
+// contract, #541). The sort-aware path (?sort=) uses a smaller 150 default for a
+// snappier first paint and infinite-scroll increment (epic #682). maxNearbyLimit
+// is the shared clamp ceiling for both. The create + demo paths fetch page one only.
 const (
 	defaultNearbyLimit = 500
+	defaultSortedLimit = 150
 	maxNearbyLimit     = 500
 )
 
-// invalidCursorMessage is the 400 body when ?cursor= is not a valid base64url
-// continuation token previously handed out via the X-Next-Cursor header.
+// invalidCursorMessage is the 400 body when ?cursor= is not a valid continuation
+// token: a malformed base64url wrapper, a token that is not a keyset cursor, or a
+// cursor minted under a different ?sort= than the request carries.
 const invalidCursorMessage = "Invalid cursor."
+
+// invalidSortMessage is the 400 body when ?sort= is outside the supported set
+// ({distance, newest, oldest} for this slice).
+const invalidSortMessage = "Invalid sort."
 
 // valid reports whether the create request passes the pre-handler guard:
 // non-blank name, positive radius within the server ceiling, in-range
@@ -274,6 +289,11 @@ type latestUnreadEventWire struct {
 // its latest unread notification. When the caller has no read-watermark yet
 // (first touch) the unread lookup is skipped and every row's latestUnreadEvent
 // is null.
+//
+// Routing: a param-less call (no ?sort=) keeps the legacy nearest-first path
+// (FindNearbyPage, default 500) byte-identical for the in-review iOS build (#541).
+// A ?sort= call opts into the server-side sort surface (FindInZonePage, default
+// 150) with a sort-aware keyset cursor (epic #682 slice 1).
 func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 	zoneID := r.PathValue("zoneId")
@@ -288,16 +308,28 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	limit := parseNearbyLimit(r.URL.Query().Get("limit"))
+	sort, sortPresent, sortOK := parseSort(r.URL.Query().Get("sort"))
+	if !sortOK {
+		h.writeError(w, r, http.StatusBadRequest, invalidSortMessage)
+		return
+	}
+
+	// decodeCursor strips the transport-layer base64 wrapping; a malformed wrapper
+	// is a clean 400. The unwrapped token is the store's opaque keyset cursor.
 	cursor, ok := decodeCursor(r.URL.Query().Get("cursor"))
 	if !ok {
 		h.writeError(w, r, http.StatusBadRequest, invalidCursorMessage)
 		return
 	}
 
-	apps, nextCursor, err := h.apps.FindNearbyPage(
-		r.Context(), zone.Latitude, zone.Longitude, zone.RadiusMetres, limit, cursor)
+	apps, nextCursor, err := h.findZonePage(r.Context(), zone, sort, sortPresent, r.URL.Query().Get("limit"), cursor)
 	if err != nil {
+		// A stale or sort-mismatched cursor is a client error (400), not a 500: the
+		// keyset cursor is only valid for the sort it was minted under.
+		if errors.Is(err, applications.ErrCursorInvalid) || errors.Is(err, applications.ErrCursorSortMismatch) {
+			h.writeError(w, r, http.StatusBadRequest, invalidCursorMessage)
+			return
+		}
 		h.serverError(w, r, "find applications in zone", err)
 		return
 	}
@@ -350,17 +382,32 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(w, r, http.StatusOK, results)
 }
 
-// parseNearbyLimit resolves ?limit= to a bounded page size: absent, non-numeric,
-// or non-positive falls back to the default; anything above the max clamps down.
-// It never rejects — an existing client that omits or fat-fingers the parameter
-// still gets a sane bounded page.
-func parseNearbyLimit(raw string) int {
+// findZonePage runs the bounded spatial page for the zone. With no ?sort= it
+// keeps the legacy nearest-first finder at the 500 default (byte-identical
+// param-less contract); with ?sort= it uses the sort-aware finder at the 150
+// default and a sort-aware keyset cursor. rawLimit is the unparsed ?limit= value;
+// cursor is the transport-unwrapped continuation token.
+func (h *handler) findZonePage(ctx context.Context, zone WatchZone, sort applications.Sort, sortPresent bool, rawLimit, cursor string) ([]applications.PlanningApplication, string, error) {
+	if !sortPresent {
+		limit := parseLimit(rawLimit, defaultNearbyLimit)
+		return h.apps.FindNearbyPage(ctx, zone.Latitude, zone.Longitude, zone.RadiusMetres, limit, cursor)
+	}
+	limit := parseLimit(rawLimit, defaultSortedLimit)
+	return h.apps.FindInZonePage(ctx, zone.Latitude, zone.Longitude, zone.RadiusMetres, sort, limit, cursor)
+}
+
+// parseLimit resolves ?limit= to a bounded page size: absent, non-numeric, or
+// non-positive falls back to def; anything above the ceiling clamps to
+// maxNearbyLimit. It never rejects — an existing client that omits or fat-fingers
+// the parameter still gets a sane bounded page. def lets the legacy path keep its
+// 500 default while the sort-aware path defaults to 150.
+func parseLimit(raw string, def int) int {
 	if raw == "" {
-		return defaultNearbyLimit
+		return def
 	}
 	n, err := strconv.Atoi(raw)
 	if err != nil || n <= 0 {
-		return defaultNearbyLimit
+		return def
 	}
 	if n > maxNearbyLimit {
 		return maxNearbyLimit
@@ -368,10 +415,25 @@ func parseNearbyLimit(raw string) int {
 	return n
 }
 
-// decodeCursor base64url-decodes an opaque ?cursor= value into the raw Cosmos
-// continuation token. An empty value means the first page (ok). A malformed value
-// is rejected (ok == false) so a garbage cursor is a clean 400, not a silent
-// reset to the first page.
+// parseSort resolves ?sort= to a supported Sort. An absent value defaults to
+// SortDistance (the legacy nearest-first behaviour). The boolean reports whether
+// the value is supported in this slice ({distance, newest, oldest}); an
+// unsupported value (status, recent-activity, or garbage) is a clean 400. The
+// caller treats an absent value (ok with SortDistance and present=false) as the
+// legacy param-less path.
+func parseSort(raw string) (sort applications.Sort, present, ok bool) {
+	if raw == "" {
+		return applications.SortDistance, false, true
+	}
+	s := applications.Sort(raw)
+	return s, true, s.Supported()
+}
+
+// decodeCursor base64url-decodes an opaque ?cursor= value into the store's raw
+// keyset continuation token (backend-agnostic; sort-aware for the ?sort= path).
+// An empty value means the first page (ok). A malformed value is rejected
+// (ok == false) so a garbage cursor is a clean 400, not a silent reset to the
+// first page.
 func decodeCursor(raw string) (string, bool) {
 	if raw == "" {
 		return "", true
@@ -383,8 +445,8 @@ func decodeCursor(raw string) (string, bool) {
 	return string(b), true
 }
 
-// encodeCursor base64url-encodes a raw Cosmos continuation token for the
-// X-Next-Cursor response header — header- and URL-safe, unpadded.
+// encodeCursor base64url-encodes the store's raw keyset continuation token for
+// the X-Next-Cursor response header — header- and URL-safe, unpadded.
 func encodeCursor(token string) string {
 	return base64.RawURLEncoding.EncodeToString([]byte(token))
 }

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -42,12 +42,15 @@ func (f *fakeResolver) ResolveAuthority(_ context.Context, _, _ float64) (int, e
 }
 
 type fakeAppFinder struct {
-	apps       []applications.PlanningApplication
-	next       string
-	err        error
-	called     bool
-	lastLimit  int
-	lastCursor string
+	apps         []applications.PlanningApplication
+	next         string
+	err          error
+	called       bool
+	inZoneCalled bool
+	inZoneErr    error
+	lastSort     applications.Sort
+	lastLimit    int
+	lastCursor   string
 }
 
 func (f *fakeAppFinder) FindNearbyPage(_ context.Context, _, _, _ float64, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
@@ -61,6 +64,21 @@ func (f *fakeAppFinder) FindNearbyPage(_ context.Context, _, _, _ float64, limit
 	// The production store caps at the query layer (the page-size hint); the fake
 	// caps here so handler tests can prove the downstream unread lookup receives a
 	// bounded UID set (tc-fm8f).
+	apps := f.apps
+	if limit > 0 && len(apps) > limit {
+		apps = apps[:limit]
+	}
+	return apps, f.next, nil
+}
+
+func (f *fakeAppFinder) FindInZonePage(_ context.Context, _, _, _ float64, sort applications.Sort, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
+	f.inZoneCalled = true
+	f.lastSort = sort
+	f.lastLimit = limit
+	f.lastCursor = cursor
+	if f.inZoneErr != nil {
+		return nil, "", f.inZoneErr
+	}
 	apps := f.apps
 	if limit > 0 && len(apps) > limit {
 		apps = apps[:limit]
@@ -770,6 +788,205 @@ func TestValid_RejectsNonFiniteCoordinates(t *testing.T) {
 				t.Errorf("%s: valid() returned true, want false", tc.name)
 			}
 		})
+	}
+}
+
+// sortDeps builds a standard dependency set for the applications-list sort tests:
+// one seeded zone, a configurable finder, no watermark.
+func sortDeps(t *testing.T, apps *fakeAppFinder) nearbyDeps {
+	t.Helper()
+	return nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{mustZone(t, "zone-1", 471)}},
+		apps:     apps,
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		state:    &fakeWatermark{},
+		unread:   &fakeUnread{},
+	}
+}
+
+// TestApplications_ParamlessUsesLegacyDistancePath proves the byte-identical
+// contract's routing: with no params the handler keeps using the legacy distance
+// finder (FindNearbyPage) at the default 500, never the sort-aware path.
+func TestApplications_ParamlessUsesLegacyDistancePath(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{}
+	mux := newNearbyMux(t, sortDeps(t, apps))
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if !apps.called {
+		t.Error("param-less request must use the legacy FindNearbyPage path")
+	}
+	if apps.inZoneCalled {
+		t.Error("param-less request must NOT use the sort-aware path")
+	}
+	if apps.lastLimit != 500 {
+		t.Errorf("legacy default limit: got %d, want 500", apps.lastLimit)
+	}
+}
+
+// TestApplications_SortRoutesToSortAwarePath proves ?sort= routes to
+// FindInZonePage with the parsed sort and the new default page size of 150.
+func TestApplications_SortRoutesToSortAwarePath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		query    string
+		wantSort applications.Sort
+	}{
+		{"?sort=distance", applications.SortDistance},
+		{"?sort=newest", applications.SortNewest},
+		{"?sort=oldest", applications.SortOldest},
+	}
+	for _, tc := range tests {
+		t.Run(tc.query, func(t *testing.T) {
+			t.Parallel()
+			apps := &fakeAppFinder{}
+			mux := newNearbyMux(t, sortDeps(t, apps))
+
+			rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications"+tc.query, "")
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status: got %d, want 200", rec.Code)
+			}
+			if !apps.inZoneCalled {
+				t.Fatal("a ?sort= request must use the sort-aware FindInZonePage path")
+			}
+			if apps.called {
+				t.Error("a ?sort= request must NOT use the legacy FindNearbyPage path")
+			}
+			if apps.lastSort != tc.wantSort {
+				t.Errorf("sort: got %q, want %q", apps.lastSort, tc.wantSort)
+			}
+			if apps.lastLimit != 150 {
+				t.Errorf("sort-aware default limit: got %d, want 150", apps.lastLimit)
+			}
+		})
+	}
+}
+
+// TestApplications_SortAwareLimitParsing proves the sort-aware path parses ?limit=
+// with a 150 default and clamps to the shared 500 ceiling.
+func TestApplications_SortAwareLimitParsing(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		query     string
+		wantLimit int
+	}{
+		{"explicit below ceiling", "?sort=newest&limit=50", 50},
+		{"at ceiling", "?sort=newest&limit=500", 500},
+		{"above ceiling clamps", "?sort=newest&limit=10000", 500},
+		{"absent uses sort default", "?sort=newest", 150},
+		{"zero uses sort default", "?sort=newest&limit=0", 150},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			apps := &fakeAppFinder{}
+			mux := newNearbyMux(t, sortDeps(t, apps))
+			rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications"+tc.query, "")
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status: got %d, want 200", rec.Code)
+			}
+			if apps.lastLimit != tc.wantLimit {
+				t.Errorf("limit: got %d, want %d", apps.lastLimit, tc.wantLimit)
+			}
+		})
+	}
+}
+
+// TestApplications_UnknownSortIs400 proves any sort outside this slice's set —
+// including the valid-future values status and recent-activity — is rejected with
+// 400 before any spatial query runs.
+func TestApplications_UnknownSortIs400(t *testing.T) {
+	t.Parallel()
+	for _, sortVal := range []string{"status", "recent-activity", "nonsense", "DISTANCE", "Newest"} {
+		t.Run(sortVal, func(t *testing.T) {
+			t.Parallel()
+			apps := &fakeAppFinder{}
+			mux := newNearbyMux(t, sortDeps(t, apps))
+			rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?sort="+sortVal, "")
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("sort=%q: got status %d, want 400", sortVal, rec.Code)
+			}
+			if apps.called || apps.inZoneCalled {
+				t.Error("must not run any spatial query for an unsupported sort")
+			}
+		})
+	}
+}
+
+// TestApplications_CursorSortMismatchIs400 proves a cursor minted under a
+// different sort (the store reports ErrCursorSortMismatch) surfaces as 400, never
+// a mis-ordered page.
+func TestApplications_CursorSortMismatchIs400(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{inZoneErr: applications.ErrCursorSortMismatch}
+	mux := newNearbyMux(t, sortDeps(t, apps))
+
+	cursor := base64.RawURLEncoding.EncodeToString([]byte("cursor-from-another-sort"))
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?sort=oldest&cursor="+cursor, "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", rec.Code)
+	}
+}
+
+// TestApplications_MalformedInnerCursorIs400 proves a cursor that decodes at the
+// transport layer but is not a valid keyset token (store reports ErrCursorInvalid)
+// surfaces as 400.
+func TestApplications_MalformedInnerCursorIs400(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{inZoneErr: applications.ErrCursorInvalid}
+	mux := newNearbyMux(t, sortDeps(t, apps))
+
+	cursor := base64.RawURLEncoding.EncodeToString([]byte("not-a-real-keyset"))
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?sort=newest&cursor="+cursor, "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", rec.Code)
+	}
+}
+
+// TestApplications_SortAwareSetsNextCursorHeader proves the sort-aware path hands
+// the store's continuation token back via X-Next-Cursor, base64url-wrapped like
+// the legacy path.
+func TestApplications_SortAwareSetsNextCursorHeader(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{apps: []applications.PlanningApplication{testApp("uid-1", "24/001")}, next: "sort-token-9"}
+	mux := newNearbyMux(t, sortDeps(t, apps))
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?sort=newest", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	got := rec.Header().Get("X-Next-Cursor")
+	want := base64.RawURLEncoding.EncodeToString([]byte("sort-token-9"))
+	if got != want {
+		t.Errorf("X-Next-Cursor: got %q, want %q", got, want)
+	}
+}
+
+// TestApplications_ParamlessGoldenResponse pins the byte-identical backward-compat
+// contract: the param-less response is the bare []Result array, unchanged by the
+// sort surface. An in-review iOS build depends on these exact bytes.
+func TestApplications_ParamlessGoldenResponse(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{apps: []applications.PlanningApplication{testApp("uid-1", "24/001")}}
+	mux := newNearbyMux(t, sortDeps(t, apps))
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	want := `[{"name":"24/001","uid":"uid-1","areaName":"City of London","areaId":471,` +
+		`"address":"1 Test St","postcode":null,"description":"An extension",` +
+		`"appType":"Full","appState":"Permitted","appSize":null,"startDate":null,` +
+		`"decidedDate":null,"consultedDate":null,"longitude":null,"latitude":null,` +
+		`"url":null,"link":null,"lastDifferent":"2026-06-14T09:00:00+00:00",` +
+		`"latestUnreadEvent":null}]`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("param-less response not byte-identical:\n got = %s\nwant = %s", got, want)
 	}
 }
 


### PR DESCRIPTION
## What

Slice 1 (API portion) of epic #682 — server-side sort + unbounded keyset paging for watch-zone applications. Adds the `?sort=` surface with `newest`/`oldest` keyset queries and a **sort-aware** cursor to `GET /v1/me/watch-zones/{zoneId}/applications`. Postgres store only.

- New `applications.FindInZonePage(ctx, lat, lng, radiusM, sort, limit, cursor)` — per-sort total order + keyset predicate that exactly matches each `ORDER BY` (no overlap, no gap):
  - `distance` (default): `location <-> point, planit_name` (existing KNN)
  - `newest`: `start_date DESC NULLS LAST, authority_code, planit_name`
  - `oldest`: `start_date ASC NULLS LAST, authority_code, planit_name`
  - All keep the `ST_DWithin` radius predicate. NULL `start_date` rows page via a dedicated NULLS-LAST tail keyset.
- **Sort-aware cursor**: base64url JSON embedding the sort mode. Replaying a cursor under a different `sort` ⇒ **400** (`ErrCursorSortMismatch`); malformed ⇒ 400 (`ErrCursorInvalid`); unsupported sort ⇒ 400.
- goose migration `0012_application_sort_indexes.sql`: btree `(start_date DESC NULLS LAST, authority_code, planit_name)`.
- `status` / `recent-activity` sorts and the status/unread filters are **out of scope** for this slice (slices 2–4).

## Backward-compat (HARD)

The **param-less** call is byte-identical: no `?sort=` → legacy `FindNearbyPage`, default limit **500**, bare `[]Result` nearest-first (golden test pins exact bytes). The new **150** default applies only to the `?sort=` path; `maxNearbyLimit=500` clamp shared.

## Tests

- pgtest `//go:build integration`: per-sort exhaustion / no-overlap / no-gap vs. unpaged ordered query, stable `(authority_code, planit_name)` tiebreak, NULLS-LAST paging — run by the `go-integration` pr-gate job (real PostGIS).
- Handler fakes: sort parse, 400s (unknown/unsupported sort, cursor-sort mismatch, malformed cursor), param-less golden, `X-Next-Cursor` set/omitted.

Epic: #682 · Bead: tc-c7mn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sort-aware pagination for in-zone applications, including distance, newest, and oldest ordering.
  * Introduced cursor-based continuation for browsing larger result sets more reliably.

* **Bug Fixes**
  * Improved handling of invalid or mismatched cursors with clearer user-facing errors.
  * Kept legacy nearest-first behavior intact when no sort is provided.

* **Chores**
  * Added database support for faster sorted paging of application results.
  * Expanded automated test coverage for pagination, sorting, and cursor behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->