### PR TITLE
feat(ios): watch-zone list infinite scroll via server-side sort + X-Next-Cursor (tc-ul1i, #682 slice 1)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/API/URLSessionAPIClient.swift
@@ -28,6 +28,24 @@ public final class URLSessionAPIClient: Sendable {
   }
 
   public func request<T: Decodable & Sendable>(_ endpoint: APIEndpoint) async throws -> T {
+    try await performRequest(endpoint).value
+  }
+
+  /// Performs a request and returns the decoded body alongside the opaque
+  /// `X-Next-Cursor` continuation token from the response headers — `nil` when
+  /// the header is absent (i.e. the last page). Auth, 401 token refresh, and
+  /// HTTP status mapping are identical to ``request(_:)``. Used by the watch-zone
+  /// applications list to page the full set via infinite scroll (GH#682).
+  public func requestPaged<T: Decodable & Sendable>(
+    _ endpoint: APIEndpoint
+  ) async throws -> (value: T, nextCursor: String?) {
+    let result: (value: T, response: HTTPURLResponse) = try await performRequest(endpoint)
+    return (result.value, result.response.value(forHTTPHeaderField: "X-Next-Cursor"))
+  }
+
+  private func performRequest<T: Decodable & Sendable>(
+    _ endpoint: APIEndpoint
+  ) async throws -> (value: T, response: HTTPURLResponse) {
     #if DEBUG
       Self.logger.debug("▶ \(endpoint.method.rawValue) \(endpoint.path)")
     #endif
@@ -130,7 +148,7 @@ public final class URLSessionAPIClient: Sendable {
   private func executeRequest<T: Decodable>(
     _ endpoint: APIEndpoint,
     accessToken: String
-  ) async throws -> T {
+  ) async throws -> (value: T, response: HTTPURLResponse) {
     let urlRequest = try buildRequest(endpoint, accessToken: accessToken)
 
     #if DEBUG
@@ -157,11 +175,11 @@ public final class URLSessionAPIClient: Sendable {
 
     if T.self == EmptyResponse.self {
       // swiftlint:disable:next force_cast
-      return EmptyResponse() as! T
+      return (EmptyResponse() as! T, httpResponse)
     }
 
     do {
-      return try decoder.decode(T.self, from: data)
+      return (try decoder.decode(T.self, from: data), httpResponse)
     } catch {
       #if DEBUG
         Self.logger.error("✗ Decoding failed: \(error.localizedDescription)")

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
@@ -24,6 +24,37 @@ public final class APIPlanningApplicationRepository: PlanningApplicationReposito
     return dtos.map { $0.toDomain() }
   }
 
+  public func fetchApplicationsPage(
+    for zone: WatchZone,
+    sort: ApplicationSortOrder,
+    cursor: String?,
+    limit: Int
+  ) async throws -> ApplicationPage {
+    var query: [URLQueryItem] = [
+      URLQueryItem(name: "sort", value: sort.rawValue),
+      URLQueryItem(name: "limit", value: String(limit)),
+    ]
+    if let cursor, !cursor.isEmpty {
+      query.append(URLQueryItem(name: "cursor", value: cursor))
+    }
+
+    let result: (value: [PlanningApplicationDTO], nextCursor: String?)
+    do {
+      result = try await apiClient.requestPaged(
+        .get("/v1/me/watch-zones/\(zone.id.value)/applications", query: query)
+      )
+    } catch let domainError as DomainError {
+      throw domainError
+    } catch {
+      throw error.toDomainError()
+    }
+
+    return ApplicationPage(
+      applications: result.value.map { $0.toDomain() },
+      nextCursor: result.nextCursor
+    )
+  }
+
   public func fetchApplication(by id: PlanningApplicationId) async throws -> PlanningApplication {
     let dto: PlanningApplicationDTO
     do {

--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/OfflineAwareRepository.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/OfflineAwareRepository.swift
@@ -50,6 +50,22 @@ public final class OfflineAwareRepository: Sendable {
     }
   }
 
+  /// Fetches a single server-sorted, server-paged page straight from the remote.
+  ///
+  /// Pagination deliberately bypasses the offline cache: the cache is keyed
+  /// per-zone on the full first-page set, not on cursor-addressed pages, so the
+  /// list's infinite-scroll pages always hit the network (GH#682 slice 1). The
+  /// param-less ``fetchApplications(for:)`` path keeps its cache behaviour.
+  public func fetchApplicationsPage(
+    for zone: WatchZone,
+    sort: ApplicationSortOrder,
+    cursor: String?,
+    limit: Int
+  ) async throws -> ApplicationPage {
+    try await remote.fetchApplicationsPage(
+      for: zone, sort: sort, cursor: cursor, limit: limit)
+  }
+
   /// Invalidates the cached applications for the given zone id.
   ///
   /// Callers should invoke this after a watch-zone edit changes the zone's

--- a/mobile/ios/packages/town-crier-domain/Sources/Protocols/PlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Protocols/PlanningApplicationRepository.swift
@@ -2,4 +2,16 @@
 public protocol PlanningApplicationRepository: Sendable {
   func fetchApplications(for zone: WatchZone) async throws -> [PlanningApplication]
   func fetchApplication(by id: PlanningApplicationId) async throws -> PlanningApplication
+
+  /// Fetches a single server-sorted, server-paged page of a zone's
+  /// applications, returning the decoded rows plus the continuation cursor for
+  /// the next page (`nil` on the last page). Used by the list's infinite scroll
+  /// to page the full set in the selected server sort order (GH#682 slice 1).
+  /// The map keeps using ``fetchApplications(for:)`` (param-less, first page).
+  func fetchApplicationsPage(
+    for zone: WatchZone,
+    sort: ApplicationSortOrder,
+    cursor: String?,
+    limit: Int
+  ) async throws -> ApplicationPage
 }

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/ApplicationPage.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/ApplicationPage.swift
@@ -1,0 +1,12 @@
+/// One page of watch-zone planning applications plus the opaque continuation
+/// token for the next page. `nextCursor` is `nil` on the last page, which ends
+/// the list's infinite-scroll loop (GH#682 slice 1).
+public struct ApplicationPage: Sendable, Equatable {
+  public let applications: [PlanningApplication]
+  public let nextCursor: String?
+
+  public init(applications: [PlanningApplication], nextCursor: String?) {
+    self.applications = applications
+    self.nextCursor = nextCursor
+  }
+}

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/ApplicationSortOrder.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/ApplicationSortOrder.swift
@@ -1,0 +1,13 @@
+/// The server-supported sort orders for the paged watch-zone applications
+/// endpoint. Raw values are the `?sort=` query vocabulary the API accepts
+/// (GH#682 slice 1) — anything else (status, recent-activity) is still computed
+/// client-side and is *not* representable here.
+public enum ApplicationSortOrder: String, Sendable, CaseIterable {
+  /// Nearest-first via the KNN `<->` operator. The server default and cheapest
+  /// plan; matches the param-less legacy behaviour.
+  case distance
+  /// `start_date` descending, NULLS LAST, with a stable unique tiebreak.
+  case newest
+  /// `start_date` ascending, NULLS LAST, with a stable unique tiebreak.
+  case oldest
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
@@ -45,6 +45,11 @@ public struct ApplicationListView: View {
     .refreshable {
       await viewModel.loadApplications()
     }
+    .onChange(of: viewModel.sort) {
+      // Server-driven sorts re-page from page 1 with a fresh cursor; switching
+      // between the two client-side sorts only re-orders in memory (GH#682).
+      Task { await viewModel.handleSortChanged() }
+    }
   }
 
   // MARK: - Toolbar
@@ -180,6 +185,11 @@ public struct ApplicationListView: View {
           .contentShape(Rectangle())
           .onTapGesture {
             viewModel.selectApplication(application.id)
+          }
+          .onAppear {
+            // Infinite scroll: nearing the end pulls the next server page when
+            // the active sort is server-driven (GH#682). A no-op otherwise.
+            Task { await viewModel.onRowAppear(application) }
           }
       }
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+Pagination.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+Pagination.swift
@@ -1,0 +1,100 @@
+import Foundation
+import TownCrierDomain
+
+/// Infinite-scroll pagination for the watch-zone list (GH#682 slice 1). Split
+/// out of `ApplicationListViewModel` to keep that file under SwiftLint's
+/// `file_length` ceiling. For the three server-supported sorts
+/// (distance/newest/oldest) the server owns the ordering and the list follows
+/// `X-Next-Cursor` to the end; the client-side sorts (recent-activity/status)
+/// keep their param-less single-page path.
+extension ApplicationListViewModel {
+
+  /// Loads the active zone's first page via the path appropriate to the current
+  /// sort. The three server-supported sorts (distance/newest/oldest) fetch a
+  /// server-ordered page and capture the next-page cursor; the client-side sorts
+  /// (recent-activity/status) keep the legacy param-less first-page fetch. Either
+  /// way the cursor resets, so pagination always restarts cleanly.
+  func loadActiveZone(_ zone: WatchZone) async throws {
+    if let order = sort.serverOrder {
+      let page = try await fetchPage(for: zone, sort: order, cursor: nil)
+      applications = page.applications
+      nextCursor = page.nextCursor
+    } else {
+      applications = try await fetchApplications(for: zone)
+      nextCursor = nil
+    }
+    loadedSort = sort
+  }
+
+  /// Fetches and appends the next server page when one exists. No-op unless the
+  /// active sort is server-driven, a cursor is held, and no append is already in
+  /// flight. Following `X-Next-Cursor` until it is absent walks the whole set;
+  /// the last page (no cursor) ends the loop. A fetch error surfaces to `error`.
+  public func loadNextPage() async {
+    guard let order = sort.serverOrder,
+      let cursor = nextCursor,
+      !isPageLoadInFlight,
+      let activeZone = selectedZone ?? zone
+    else { return }
+    isPageLoadInFlight = true
+    defer { isPageLoadInFlight = false }
+    do {
+      let page = try await fetchPage(for: activeZone, sort: order, cursor: cursor)
+      appendPage(page)
+    } catch {
+      handleError(error)
+    }
+  }
+
+  /// Called by the list as each row appears. Kicks off the next-page fetch when
+  /// a server sort is active, more pages remain, and the appearing row is within
+  /// ``prefetchThreshold`` of the end of the loaded set. A no-op for client-side
+  /// sorts, which hold the whole (first-page) set already.
+  public func onRowAppear(_ application: PlanningApplication) async {
+    guard sort.isServerSorted, nextCursor != nil, !isPageLoadInFlight else { return }
+    guard let index = applications.firstIndex(where: { $0.id == application.id }) else { return }
+    guard index >= applications.count - Self.prefetchThreshold else { return }
+    await loadNextPage()
+  }
+
+  /// Reacts to a sort change from the toolbar. A server sort — or any transition
+  /// away from one — reloads from page 1 with a fresh cursor so the list re-pages
+  /// in the new order. A switch between the two client-side sorts only changes
+  /// the in-memory ordering, so it skips the refetch (unchanged from the
+  /// pre-pagination behaviour). The cursor and `loadedSort` reset happen inside
+  /// the reload.
+  public func handleSortChanged() async {
+    guard sort != loadedSort else { return }
+    let newIsServer = sort.isServerSorted
+    let oldWasServer = loadedSort?.isServerSorted ?? false
+    if !newIsServer && !oldWasServer {
+      loadedSort = sort
+      return
+    }
+    await loadApplications()
+  }
+
+  /// Appends a server page, dropping any rows already loaded so a keyset overlap
+  /// at a page boundary never duplicates a row. Captures the new cursor.
+  private func appendPage(_ page: ApplicationPage) {
+    let existingIds = Set(applications.map(\.id))
+    applications.append(contentsOf: page.applications.filter { !existingIds.contains($0.id) })
+    nextCursor = page.nextCursor
+  }
+
+  private func fetchPage(
+    for zone: WatchZone,
+    sort order: ApplicationSortOrder,
+    cursor: String?
+  ) async throws -> ApplicationPage {
+    if let offlineRepository {
+      return try await offlineRepository.fetchApplicationsPage(
+        for: zone, sort: order, cursor: cursor, limit: Self.pageSize)
+    }
+    if let repository {
+      return try await repository.fetchApplicationsPage(
+        for: zone, sort: order, cursor: cursor, limit: Self.pageSize)
+    }
+    return ApplicationPage(applications: [], nextCursor: nil)
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -63,6 +63,27 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   /// request firing 3-6 times within seconds, all cancelled (HTTP 499). While
   /// one load is in flight, further calls short-circuit (bd tc-eum5).
   private var isLoadInFlight = false
+  /// Continuation token for the next server page, or `nil` when no more pages
+  /// exist (the last page omits `X-Next-Cursor`) or the active sort is
+  /// client-side. Reset to `nil` on every fresh first-page load and on any sort
+  /// change so a stale cursor can never page a differently-ordered set
+  /// (GH#682 slice 1).
+  private var nextCursor: String?
+  /// The sort the currently-loaded `applications` were fetched under. Lets a
+  /// sort change decide whether a refetch is needed (server sorts and any
+  /// transition away from one reload; a client→client switch only re-sorts in
+  /// memory, as before).
+  private var loadedSort: ApplicationsSort?
+  /// Re-entrancy guard for next-page fetches — independent of `isLoadInFlight`
+  /// so an in-flight first-page load never blocks (or is blocked by) appends.
+  private var isPageLoadInFlight = false
+  /// Server page size requested for the infinite-scroll path. Matches the API's
+  /// sorted-path default (GH#682); the server clamps anything larger.
+  static let pageSize = 150
+  /// Trigger the next-page fetch once the appearing row is within this many rows
+  /// of the end of the loaded set, so the next page lands before the user hits
+  /// the bottom.
+  private static let prefetchThreshold = 10
   private let userDefaults: UserDefaults
   private let zoneSelectionKey: String
   private let sortKey: String
@@ -212,10 +233,11 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
       }
       guard let activeZone = selectedZone ?? zone else {
         applications = []
+        nextCursor = nil
         isLoading = false
         return
       }
-      applications = try await fetchApplications(for: activeZone)
+      try await loadActiveZone(activeZone)
     } catch {
       handleError(error)
     }
@@ -230,11 +252,100 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     isLoading = true
     error = nil
     do {
-      applications = try await fetchApplications(for: zone)
+      try await loadActiveZone(zone)
     } catch {
       handleError(error)
     }
     isLoading = false
+  }
+
+  /// Loads the active zone's first page via the path appropriate to the current
+  /// sort. The three server-supported sorts (distance/newest/oldest) fetch a
+  /// server-ordered page and capture the next-page cursor; the client-side sorts
+  /// (recent-activity/status) keep the legacy param-less first-page fetch. Either
+  /// way the cursor resets, so pagination always restarts cleanly (GH#682).
+  private func loadActiveZone(_ zone: WatchZone) async throws {
+    if let order = sort.serverOrder {
+      let page = try await fetchPage(for: zone, sort: order, cursor: nil)
+      applications = page.applications
+      nextCursor = page.nextCursor
+    } else {
+      applications = try await fetchApplications(for: zone)
+      nextCursor = nil
+    }
+    loadedSort = sort
+  }
+
+  /// Fetches and appends the next server page when one exists. No-op unless the
+  /// active sort is server-driven, a cursor is held, and no append is already in
+  /// flight. Following `X-Next-Cursor` until it is absent walks the whole set;
+  /// the last page (no cursor) ends the loop. A fetch error surfaces to `error`.
+  public func loadNextPage() async {
+    guard let order = sort.serverOrder,
+      let cursor = nextCursor,
+      !isPageLoadInFlight,
+      let activeZone = selectedZone ?? zone
+    else { return }
+    isPageLoadInFlight = true
+    defer { isPageLoadInFlight = false }
+    do {
+      let page = try await fetchPage(for: activeZone, sort: order, cursor: cursor)
+      appendPage(page)
+    } catch {
+      handleError(error)
+    }
+  }
+
+  /// Called by the list as each row appears. Kicks off the next-page fetch when
+  /// a server sort is active, more pages remain, and the appearing row is within
+  /// ``prefetchThreshold`` of the end of the loaded set. A no-op for client-side
+  /// sorts, which hold the whole (first-page) set already.
+  public func onRowAppear(_ application: PlanningApplication) async {
+    guard sort.isServerSorted, nextCursor != nil, !isPageLoadInFlight else { return }
+    guard let index = applications.firstIndex(where: { $0.id == application.id }) else { return }
+    guard index >= applications.count - Self.prefetchThreshold else { return }
+    await loadNextPage()
+  }
+
+  /// Reacts to a sort change from the toolbar. A server sort — or any transition
+  /// away from one — reloads from page 1 with a fresh cursor so the list re-pages
+  /// in the new order. A switch between the two client-side sorts only changes
+  /// the in-memory ordering, so it skips the refetch (unchanged from the
+  /// pre-pagination behaviour). The cursor and `loadedSort` reset happen inside
+  /// the reload.
+  public func handleSortChanged() async {
+    guard sort != loadedSort else { return }
+    let newIsServer = sort.isServerSorted
+    let oldWasServer = loadedSort?.isServerSorted ?? false
+    if !newIsServer && !oldWasServer {
+      loadedSort = sort
+      return
+    }
+    await loadApplications()
+  }
+
+  /// Appends a server page, dropping any rows already loaded so a keyset overlap
+  /// at a page boundary never duplicates a row. Captures the new cursor.
+  private func appendPage(_ page: ApplicationPage) {
+    let existingIds = Set(applications.map(\.id))
+    applications.append(contentsOf: page.applications.filter { !existingIds.contains($0.id) })
+    nextCursor = page.nextCursor
+  }
+
+  private func fetchPage(
+    for zone: WatchZone,
+    sort order: ApplicationSortOrder,
+    cursor: String?
+  ) async throws -> ApplicationPage {
+    if let offlineRepository {
+      return try await offlineRepository.fetchApplicationsPage(
+        for: zone, sort: order, cursor: cursor, limit: Self.pageSize)
+    }
+    if let repository {
+      return try await repository.fetchApplicationsPage(
+        for: zone, sort: order, cursor: cursor, limit: Self.pageSize)
+    }
+    return ApplicationPage(applications: [], nextCursor: nil)
   }
 
   public func selectApplication(_ id: PlanningApplicationId) {
@@ -262,7 +373,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     await offlineRepository?.invalidateAllCaches()
     guard let activeZone = selectedZone ?? zone else { return }
     do {
-      applications = try await fetchApplications(for: activeZone)
+      try await loadActiveZone(activeZone)
     } catch {
       // Refetch failure is non-fatal — the existing rows stay rendered.
     }
@@ -311,45 +422,15 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
       return applications.sorted { lhs, rhs in
         recentActivityScore(lhs) > recentActivityScore(rhs)
       }
-    case .newest:
-      return applications.sorted { $0.receivedDate > $1.receivedDate }
-    case .oldest:
-      return applications.sorted { $0.receivedDate < $1.receivedDate }
     case .status:
       return applications.sorted { $0.status.rawValue < $1.status.rawValue }
-    case .distance:
-      return sortByDistance(applications)
-    }
-  }
-
-  /// Ascending haversine distance from the active zone's centre. Apps
-  /// without a `location` sort last (preserving their incoming relative
-  /// order via the stable-pair tiebreaker so we don't surface arbitrary
-  /// noise). Falls back to identity when no zone is selected — the sort
-  /// option is hidden in that state, but defensive coding keeps the
-  /// switch total. Spec: tc-mso6 (mirrors the web sibling tc-ge7j).
-  private func sortByDistance(
-    _ applications: [PlanningApplication]
-  ) -> [PlanningApplication] {
-    guard let activeZone = selectedZone ?? zone else {
+    case .distance, .newest, .oldest:
+      // Server-ordered sorts arrive pre-sorted from the API and are paged via
+      // infinite scroll, so they are never re-sorted client-side — that would
+      // only ever order the pages already loaded (GH#682 slice 1). Identity
+      // preserves the server order and keeps the switch total.
       return applications
     }
-    let scored = applications.enumerated().map { index, app in
-      (index: index, app: app, distance: app.location.map { activeZone.distance(to: $0) })
-    }
-    let sorted = scored.sorted { lhs, rhs in
-      switch (lhs.distance, rhs.distance) {
-      case let (.some(left), .some(right)):
-        return left < right
-      case (.some, .none):
-        return true
-      case (.none, .some):
-        return false
-      case (.none, .none):
-        return lhs.index < rhs.index
-      }
-    }
-    return sorted.map(\.app)
   }
 
   /// `max(receivedDate, latestUnreadEvent.createdAt)` per spec decision #9 —

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -14,7 +14,10 @@ import TownCrierDomain
 /// single-select status-chip group.
 @MainActor
 public final class ApplicationListViewModel: ObservableObject, ErrorHandlingViewModel {
-  @Published private(set) var applications: [PlanningApplication] = []
+  // `internal(set)` (the default for this non-public property) rather than
+  // `private(set)`: the paged load/append lives in `+Pagination` extension file
+  // and mutates this. Still read-only outside the presentation module.
+  @Published var applications: [PlanningApplication] = []
   @Published var selectedStatusFilter: ApplicationStatus? {
     didSet {
       // Status and Unread chips share a single-select group (spec decision #7)
@@ -51,11 +54,13 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     }
   }
 
-  private let repository: PlanningApplicationRepository?
-  private let offlineRepository: OfflineAwareRepository?
+  // `repository`/`offlineRepository`/`zone` are internal (not `private`) so the
+  // `+Pagination` extension file can drive the paged fetch.
+  let repository: PlanningApplicationRepository?
+  let offlineRepository: OfflineAwareRepository?
   private let watchZoneRepository: WatchZoneRepository?
   private let notificationStateRepository: NotificationStateRepository?
-  private var zone: WatchZone?
+  var zone: WatchZone?
   /// Re-entrancy guard for ``loadApplications()``. A single user action can
   /// trigger the load repeatedly — `.task` firing alongside `.refreshable`, a
   /// scenePhase change, or the view re-appearing — and each unguarded call
@@ -67,23 +72,23 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   /// exist (the last page omits `X-Next-Cursor`) or the active sort is
   /// client-side. Reset to `nil` on every fresh first-page load and on any sort
   /// change so a stale cursor can never page a differently-ordered set
-  /// (GH#682 slice 1).
-  private var nextCursor: String?
+  /// (GH#682 slice 1). Internal so the `+Pagination` extension can drive it.
+  var nextCursor: String?
   /// The sort the currently-loaded `applications` were fetched under. Lets a
   /// sort change decide whether a refetch is needed (server sorts and any
   /// transition away from one reload; a client→client switch only re-sorts in
   /// memory, as before).
-  private var loadedSort: ApplicationsSort?
+  var loadedSort: ApplicationsSort?
   /// Re-entrancy guard for next-page fetches — independent of `isLoadInFlight`
   /// so an in-flight first-page load never blocks (or is blocked by) appends.
-  private var isPageLoadInFlight = false
+  var isPageLoadInFlight = false
   /// Server page size requested for the infinite-scroll path. Matches the API's
   /// sorted-path default (GH#682); the server clamps anything larger.
   static let pageSize = 150
   /// Trigger the next-page fetch once the appearing row is within this many rows
   /// of the end of the loaded set, so the next page lands before the user hits
   /// the bottom.
-  private static let prefetchThreshold = 10
+  static let prefetchThreshold = 10
   private let userDefaults: UserDefaults
   private let zoneSelectionKey: String
   private let sortKey: String
@@ -259,95 +264,6 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     isLoading = false
   }
 
-  /// Loads the active zone's first page via the path appropriate to the current
-  /// sort. The three server-supported sorts (distance/newest/oldest) fetch a
-  /// server-ordered page and capture the next-page cursor; the client-side sorts
-  /// (recent-activity/status) keep the legacy param-less first-page fetch. Either
-  /// way the cursor resets, so pagination always restarts cleanly (GH#682).
-  private func loadActiveZone(_ zone: WatchZone) async throws {
-    if let order = sort.serverOrder {
-      let page = try await fetchPage(for: zone, sort: order, cursor: nil)
-      applications = page.applications
-      nextCursor = page.nextCursor
-    } else {
-      applications = try await fetchApplications(for: zone)
-      nextCursor = nil
-    }
-    loadedSort = sort
-  }
-
-  /// Fetches and appends the next server page when one exists. No-op unless the
-  /// active sort is server-driven, a cursor is held, and no append is already in
-  /// flight. Following `X-Next-Cursor` until it is absent walks the whole set;
-  /// the last page (no cursor) ends the loop. A fetch error surfaces to `error`.
-  public func loadNextPage() async {
-    guard let order = sort.serverOrder,
-      let cursor = nextCursor,
-      !isPageLoadInFlight,
-      let activeZone = selectedZone ?? zone
-    else { return }
-    isPageLoadInFlight = true
-    defer { isPageLoadInFlight = false }
-    do {
-      let page = try await fetchPage(for: activeZone, sort: order, cursor: cursor)
-      appendPage(page)
-    } catch {
-      handleError(error)
-    }
-  }
-
-  /// Called by the list as each row appears. Kicks off the next-page fetch when
-  /// a server sort is active, more pages remain, and the appearing row is within
-  /// ``prefetchThreshold`` of the end of the loaded set. A no-op for client-side
-  /// sorts, which hold the whole (first-page) set already.
-  public func onRowAppear(_ application: PlanningApplication) async {
-    guard sort.isServerSorted, nextCursor != nil, !isPageLoadInFlight else { return }
-    guard let index = applications.firstIndex(where: { $0.id == application.id }) else { return }
-    guard index >= applications.count - Self.prefetchThreshold else { return }
-    await loadNextPage()
-  }
-
-  /// Reacts to a sort change from the toolbar. A server sort — or any transition
-  /// away from one — reloads from page 1 with a fresh cursor so the list re-pages
-  /// in the new order. A switch between the two client-side sorts only changes
-  /// the in-memory ordering, so it skips the refetch (unchanged from the
-  /// pre-pagination behaviour). The cursor and `loadedSort` reset happen inside
-  /// the reload.
-  public func handleSortChanged() async {
-    guard sort != loadedSort else { return }
-    let newIsServer = sort.isServerSorted
-    let oldWasServer = loadedSort?.isServerSorted ?? false
-    if !newIsServer && !oldWasServer {
-      loadedSort = sort
-      return
-    }
-    await loadApplications()
-  }
-
-  /// Appends a server page, dropping any rows already loaded so a keyset overlap
-  /// at a page boundary never duplicates a row. Captures the new cursor.
-  private func appendPage(_ page: ApplicationPage) {
-    let existingIds = Set(applications.map(\.id))
-    applications.append(contentsOf: page.applications.filter { !existingIds.contains($0.id) })
-    nextCursor = page.nextCursor
-  }
-
-  private func fetchPage(
-    for zone: WatchZone,
-    sort order: ApplicationSortOrder,
-    cursor: String?
-  ) async throws -> ApplicationPage {
-    if let offlineRepository {
-      return try await offlineRepository.fetchApplicationsPage(
-        for: zone, sort: order, cursor: cursor, limit: Self.pageSize)
-    }
-    if let repository {
-      return try await repository.fetchApplicationsPage(
-        for: zone, sort: order, cursor: cursor, limit: Self.pageSize)
-    }
-    return ApplicationPage(applications: [], nextCursor: nil)
-  }
-
   public func selectApplication(_ id: PlanningApplicationId) {
     onApplicationSelected?(id)
   }
@@ -392,7 +308,9 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     selectedZone = zones.first
   }
 
-  private func fetchApplications(for zone: WatchZone) async throws -> [PlanningApplication] {
+  /// Internal (not `private`): the `+Pagination` extension's `loadActiveZone`
+  /// uses this for the client-side sort path.
+  func fetchApplications(for zone: WatchZone) async throws -> [PlanningApplication] {
     if let offlineRepository {
       return try await offlineRepository.fetchApplications(for: zone).data
     } else if let repository {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationsSort.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationsSort.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TownCrierDomain
 
 /// Sort modes for the Applications screen — persisted under
 /// `applicationsListSort` in `UserDefaults` so the user's choice survives
@@ -25,6 +26,29 @@ public enum ApplicationsSort: String, CaseIterable, Sendable {
   /// last. Only meaningful when a single zone is selected — the picker
   /// hides this option in multi-zone "all" views (tc-mso6).
   case distance = "distance"
+
+  /// The server-side sort order the API can page in, or `nil` for the
+  /// client-only sorts (recent-activity, status) which this slice keeps
+  /// computing locally over the fetched page (GH#682 slice 1). Distance, newest,
+  /// and oldest are server-driven and paged via infinite scroll.
+  public var serverOrder: ApplicationSortOrder? {
+    switch self {
+    case .distance:
+      return .distance
+    case .newest:
+      return .newest
+    case .oldest:
+      return .oldest
+    case .recentActivity, .status:
+      return nil
+    }
+  }
+
+  /// Whether the server owns the ordering (and therefore drives the paged
+  /// infinite-scroll path) for this sort.
+  public var isServerSorted: Bool {
+    serverOrder != nil
+  }
 
   /// User-facing label rendered in the sort menu.
   public var displayLabel: String {

--- a/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryPagedTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryPagedTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+/// Covers the paged watch-zone applications fetch (GH#682 slice 1): it passes
+/// `?sort=&cursor=&limit=`, decodes the bare `[PlanningApplicationDTO]` body, and
+/// returns the page alongside the `X-Next-Cursor` continuation token (nil on the
+/// last page). The map keeps using the param-less `fetchApplications(for:)`.
+@Suite("APIPlanningApplicationRepository — paged fetch")
+struct APIPlanningApplicationRepositoryPagedTests {
+  // swiftlint:disable:next force_unwrapping
+  private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
+
+  // swiftlint:disable:next force_try
+  private let testZone = try! WatchZone(
+    id: WatchZoneId("zone-123"),
+    name: "Cambridge",
+    centre: Coordinate(latitude: 52.2053, longitude: 0.1218),
+    radiusMetres: 2000,
+    authorityId: 123
+  )
+
+  private func makeSUT(
+    responses: [(Data, URLResponse)]
+  ) -> (APIPlanningApplicationRepository, StubHTTPTransport) {
+    let authService = SpyAuthenticationService()
+    authService.currentSessionResult = .valid
+    let transport = StubHTTPTransport()
+    transport.responses = responses
+    let apiClient = URLSessionAPIClient(
+      baseURL: baseURL,
+      authService: authService,
+      transport: transport
+    )
+    return (APIPlanningApplicationRepository(apiClient: apiClient), transport)
+  }
+
+  private func httpResponse(statusCode: Int, headers: [String: String]) -> HTTPURLResponse {
+    // swiftlint:disable:next force_unwrapping
+    HTTPURLResponse(url: baseURL, statusCode: statusCode, httpVersion: nil, headerFields: headers)!
+  }
+
+  private func queryItems(_ transport: StubHTTPTransport, at index: Int) throws -> [URLQueryItem] {
+    let url = try #require(transport.requests[index].url)
+    let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+    return components?.queryItems ?? []
+  }
+
+  private static let oneAppJSON = """
+    [
+        {
+            "name": "2026/0042",
+            "uid": "app-001",
+            "areaName": "Cambridge",
+            "areaId": 123,
+            "address": "12 Mill Road, Cambridge, CB1 2AD",
+            "postcode": "CB1 2AD",
+            "description": "Erection of two-storey rear extension",
+            "appType": "Full",
+            "appState": "Undecided",
+            "appSize": null,
+            "startDate": "2026-01-15",
+            "decidedDate": null,
+            "consultedDate": null,
+            "longitude": 0.1243,
+            "latitude": 52.2043,
+            "url": null,
+            "link": null,
+            "lastDifferent": "2026-01-15T00:00:00+00:00"
+        }
+    ]
+    """
+
+  @Test("first page sends ?sort= and ?limit= and omits ?cursor=")
+  func fetchApplicationsPage_firstPage_sendsSortAndLimit() async throws {
+    let (sut, transport) = makeSUT(responses: [
+      (Data("[]".utf8), httpResponse(statusCode: 200, headers: [:]))
+    ])
+
+    _ = try await sut.fetchApplicationsPage(
+      for: testZone, sort: .newest, cursor: nil, limit: 150)
+
+    let url = try #require(transport.requests[0].url)
+    #expect(url.path() == "/v1/me/watch-zones/zone-123/applications")
+    let items = try queryItems(transport, at: 0)
+    let hasCursor = items.contains { $0.name == "cursor" }
+    #expect(items.contains(URLQueryItem(name: "sort", value: "newest")))
+    #expect(items.contains(URLQueryItem(name: "limit", value: "150")))
+    #expect(!hasCursor)
+  }
+
+  @Test("paging beyond the first page sends the cursor")
+  func fetchApplicationsPage_withCursor_includesCursorParam() async throws {
+    let (sut, transport) = makeSUT(responses: [
+      (Data("[]".utf8), httpResponse(statusCode: 200, headers: [:]))
+    ])
+
+    _ = try await sut.fetchApplicationsPage(
+      for: testZone, sort: .oldest, cursor: "abc123", limit: 150)
+
+    let items = try queryItems(transport, at: 0)
+    #expect(items.contains(URLQueryItem(name: "sort", value: "oldest")))
+    #expect(items.contains(URLQueryItem(name: "cursor", value: "abc123")))
+  }
+
+  @Test("decodes the bare array body and returns the next cursor from the header")
+  func fetchApplicationsPage_decodesBodyAndCursor() async throws {
+    let (sut, _) = makeSUT(responses: [
+      (Data(Self.oneAppJSON.utf8), httpResponse(statusCode: 200, headers: ["X-Next-Cursor": "next-1"]))
+    ])
+
+    let page = try await sut.fetchApplicationsPage(
+      for: testZone, sort: .newest, cursor: nil, limit: 150)
+
+    #expect(page.applications.count == 1)
+    #expect(page.applications.first?.reference == ApplicationReference("2026/0042"))
+    #expect(page.nextCursor == "next-1")
+  }
+
+  @Test("returns a nil cursor on the last page (no X-Next-Cursor header)")
+  func fetchApplicationsPage_lastPage_nilCursor() async throws {
+    let (sut, _) = makeSUT(responses: [
+      (Data("[]".utf8), httpResponse(statusCode: 200, headers: [:]))
+    ])
+
+    let page = try await sut.fetchApplicationsPage(
+      for: testZone, sort: .distance, cursor: nil, limit: 150)
+
+    #expect(page.applications.isEmpty)
+    #expect(page.nextCursor == nil)
+  }
+
+  @Test("maps a network error to DomainError.networkUnavailable")
+  func fetchApplicationsPage_networkError_mapsToDomainError() async throws {
+    let authService = SpyAuthenticationService()
+    authService.currentSessionResult = .valid
+    let transport = StubHTTPTransport()
+    transport.error = URLError(.notConnectedToInternet)
+    let apiClient = URLSessionAPIClient(
+      baseURL: baseURL, authService: authService, transport: transport)
+    let sut = APIPlanningApplicationRepository(apiClient: apiClient)
+
+    await #expect(throws: DomainError.networkUnavailable) {
+      _ = try await sut.fetchApplicationsPage(
+        for: testZone, sort: .newest, cursor: nil, limit: 150)
+    }
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelDistanceSortTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelDistanceSortTests.swift
@@ -57,51 +57,22 @@ struct ApplicationListViewModelDistanceSortTests {
     #expect(ApplicationsSort.distance.displayLabel == "Distance")
   }
 
-  // MARK: - Sort behaviour
+  // MARK: - Sort behaviour (server-driven since GH#682 slice 1)
 
-  @Test("distance sort orders by haversine distance from active zone centre, ascending")
-  func sort_distance_ordersByHaversineFromZoneCentre() async throws {
-    // Cambridge centre: 52.2053, 0.1218.
-    // permitted     location 52.2053, 0.1218 — exactly at centre (~0m)
-    // pendingReview location 52.2043, 0.1243 — close
-    // rejected      location 52.2010, 0.1300 — further
-    // (See PlanningApplication+Fixtures for source-of-truth coords.)
-    let (sut, _, _) = try makeSUT(
-      applications: [.rejected, .pendingReview, .permitted]
-    )
-
-    await sut.loadApplications()
-    sut.sort = .distance
-
-    #expect(
-      sut.filteredApplications.map(\.id) == [
-        PlanningApplication.permitted.id,
-        PlanningApplication.pendingReview.id,
-        PlanningApplication.rejected.id,
-      ]
-    )
-  }
-
-  @Test("distance sort places apps without a location last")
-  func sort_distance_appsWithoutLocationLast() async throws {
-    let withoutLocation = PlanningApplication(
-      id: PlanningApplicationId(authority: "CAM", name: "APP-NO-LOC"),
-      reference: ApplicationReference("2026/9999"),
-      authority: .cambridge,
-      status: .undecided,
-      receivedDate: Date(timeIntervalSince1970: 1_700_000_000),
-      description: "Application missing coordinates",
-      address: "Unknown",
-      location: nil
-    )
-    let (sut, _, _) = try makeSUT(
-      applications: [withoutLocation, .permitted, .pendingReview]
-    )
+  @Test("distance sort preserves the server order — no local haversine re-sort")
+  func sort_distance_preservesServerOrder() async throws {
+    // Distance is now server-driven (KNN nearest-first) and paged via infinite
+    // scroll, so the client must not re-order locally — that would only sort the
+    // pages already loaded. The ordering and NULLS-LAST behaviour are proven by
+    // the Go pgtest suite (#688); the client just renders what it receives. The
+    // deliberately non-distance order below proves the client leaves it intact.
+    let serverOrdered: [PlanningApplication] = [.rejected, .permitted, .pendingReview]
+    let (sut, _, _) = try makeSUT(applications: serverOrdered)
 
     await sut.loadApplications()
     sut.sort = .distance
 
-    #expect(sut.filteredApplications.last?.id == withoutLocation.id)
+    #expect(sut.filteredApplications.map(\.id) == serverOrdered.map(\.id))
   }
 
   // MARK: - Persistence

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelPaginationTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelPaginationTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Infinite-scroll pagination for the watch-zone list (GH#682 slice 1). For the
+/// three server-supported sorts (distance/newest/oldest) the ViewModel drives
+/// ordering from the server, follows `X-Next-Cursor` until it is absent, appends
+/// pages as the user nears the end, and resets the cursor when the sort changes.
+/// The client-side sorts (recent-activity/status) keep their param-less,
+/// single-page, client-sorted path unchanged.
+@Suite("ApplicationListViewModel — pagination (GH#682)")
+@MainActor
+struct ApplicationListViewModelPaginationTests {
+
+  private func makeSUT(
+    sort: ApplicationsSort,
+    pages: [ApplicationPage] = []
+  ) throws -> (ApplicationListViewModel, SpyPlanningApplicationRepository) {
+    let spy = SpyPlanningApplicationRepository()
+    spy.pagedResponses = pages
+    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
+    defaults.set(sort.rawValue, forKey: "test.paginationSort")
+    let vm = ApplicationListViewModel(
+      repository: spy,
+      zone: .cambridge,
+      userDefaults: defaults,
+      sortKey: "test.paginationSort"
+    )
+    return (vm, spy)
+  }
+
+  // MARK: - Page append
+
+  @Test("scrolling near the end fetches the next page via the cursor and appends")
+  func loadNextPage_appendsUsingCursor() async throws {
+    let page1 = ApplicationPage(applications: [.pendingReview, .permitted], nextCursor: "cursor-2")
+    let page2 = ApplicationPage(applications: [.rejected, .withdrawn], nextCursor: nil)
+    let (sut, spy) = try makeSUT(sort: .newest, pages: [page1, page2])
+
+    await sut.loadApplications()
+    #expect(
+      sut.filteredApplications.map(\.id) == [PlanningApplication.pendingReview, .permitted].map(\.id)
+    )
+
+    await sut.onRowAppear(.permitted)
+
+    #expect(
+      sut.filteredApplications.map(\.id) == [
+        PlanningApplication.pendingReview, .permitted, .rejected, .withdrawn,
+      ].map(\.id)
+    )
+    #expect(spy.fetchApplicationsPageCalls.count == 2)
+    #expect(spy.fetchApplicationsPageCalls[0].cursor == nil)
+    #expect(spy.fetchApplicationsPageCalls[1].cursor == "cursor-2")
+    #expect(spy.fetchApplicationsPageCalls[1].sort == .newest)
+  }
+
+  @Test("an overlapping row at a page boundary is not duplicated")
+  func loadNextPage_dedupesOverlap() async throws {
+    let page1 = ApplicationPage(applications: [.pendingReview, .permitted], nextCursor: "c2")
+    // `.permitted` repeats across the boundary (keyset overlap).
+    let page2 = ApplicationPage(applications: [.permitted, .rejected], nextCursor: nil)
+    let (sut, _) = try makeSUT(sort: .newest, pages: [page1, page2])
+
+    await sut.loadApplications()
+    await sut.onRowAppear(.permitted)
+
+    #expect(
+      sut.filteredApplications.map(\.id) == [
+        PlanningApplication.pendingReview, .permitted, .rejected,
+      ].map(\.id)
+    )
+  }
+
+  // MARK: - Sort change resets the cursor
+
+  @Test("changing the server sort clears the cursor and reloads from page 1")
+  func changingServerSort_resetsCursorAndReloadsPageOne() async throws {
+    let newestPage = ApplicationPage(applications: [.pendingReview], nextCursor: "newest-cursor")
+    let (sut, spy) = try makeSUT(sort: .newest, pages: [newestPage])
+
+    await sut.loadApplications()
+    #expect(spy.fetchApplicationsPageCalls.last?.sort == .newest)
+
+    spy.pagedResponses = [ApplicationPage(applications: [.rejected], nextCursor: nil)]
+    sut.sort = .oldest
+    await sut.handleSortChanged()
+
+    let last = try #require(spy.fetchApplicationsPageCalls.last)
+    #expect(last.sort == .oldest)
+    #expect(last.cursor == nil)
+  }
+
+  // MARK: - Last page stops the loop
+
+  @Test("a page with no cursor ends pagination — no further fetch")
+  func lastPageWithoutCursor_stopsPagination() async throws {
+    let onlyPage = ApplicationPage(applications: [.pendingReview, .permitted], nextCursor: nil)
+    let (sut, spy) = try makeSUT(sort: .newest, pages: [onlyPage])
+
+    await sut.loadApplications()
+    #expect(spy.fetchApplicationsPageCalls.count == 1)
+
+    await sut.onRowAppear(.permitted)
+    await sut.loadNextPage()
+
+    #expect(spy.fetchApplicationsPageCalls.count == 1)
+  }
+
+  // MARK: - Error path
+
+  @Test("a next-page fetch error surfaces to the ViewModel error state")
+  func pageFetchError_surfacesToErrorState() async throws {
+    let page1 = ApplicationPage(applications: [.pendingReview, .permitted], nextCursor: "c2")
+    let (sut, spy) = try makeSUT(sort: .newest, pages: [page1])
+
+    await sut.loadApplications()
+    #expect(sut.error == nil)
+
+    spy.fetchApplicationsPageError = DomainError.serverError(statusCode: 400, message: "bad cursor")
+    await sut.onRowAppear(.permitted)
+
+    #expect(sut.error == .serverError(statusCode: 400, message: "bad cursor"))
+  }
+
+  // MARK: - Server owns the ordering
+
+  @Test("a server sort preserves the API-returned order (no local re-sort)")
+  func serverSort_preservesServerOrder() async throws {
+    // Deliberately out of date order — the server is the source of truth.
+    let serverOrdered = ApplicationPage(
+      applications: [.rejected, .pendingReview, .permitted], nextCursor: nil)
+    let (sut, _) = try makeSUT(sort: .newest, pages: [serverOrdered])
+
+    await sut.loadApplications()
+
+    #expect(
+      sut.filteredApplications.map(\.id) == [
+        PlanningApplication.rejected, .pendingReview, .permitted,
+      ].map(\.id)
+    )
+  }
+
+  @Test("a server sort drives the paged endpoint, not the param-less fetch")
+  func serverSort_usesPagedFetch() async throws {
+    let (sut, spy) = try makeSUT(
+      sort: .newest, pages: [ApplicationPage(applications: [.pendingReview], nextCursor: nil)])
+
+    await sut.loadApplications()
+
+    #expect(spy.fetchApplicationsPageCalls.count == 1)
+    #expect(spy.fetchApplicationsCalls.isEmpty)
+  }
+
+  // MARK: - Client sorts keep the legacy path
+
+  @Test("a client-side sort keeps the param-less fetch and does not paginate")
+  func clientSort_usesParamlessFetch() async throws {
+    let spy = SpyPlanningApplicationRepository()
+    spy.fetchApplicationsResult = .success([.pendingReview, .permitted])
+    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
+    defaults.set(ApplicationsSort.recentActivity.rawValue, forKey: "test.clientSort")
+    let sut = ApplicationListViewModel(
+      repository: spy, zone: .cambridge, userDefaults: defaults, sortKey: "test.clientSort")
+
+    await sut.loadApplications()
+    await sut.onRowAppear(.permitted)
+
+    #expect(spy.fetchApplicationsCalls.count == 1)
+    #expect(spy.fetchApplicationsPageCalls.isEmpty)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
@@ -213,30 +213,33 @@ struct ApplicationListViewModelUnreadTests {
     #expect(sut.filteredApplications.map(\.id) == [appA.id, appC.id, appB.id])
   }
 
-  @Test("newest sort orders by receivedDate desc")
-  func sort_newest_ordersByReceivedDateDesc() async throws {
-    let older = PlanningApplication.pendingReview  // 1_700_000_000
-    let middle = PlanningApplication.permitted  // 1_700_100_000
-    let newest = PlanningApplication.rejected  // 1_700_200_000
-    let (sut, _, _, _) = try makeSUT(applications: [middle, older, newest])
+  // newest/oldest are server-driven since GH#682 slice 1: the API returns rows
+  // already in `start_date` order (proven by the Go pgtest suite, #688) and the
+  // client pages them via infinite scroll. The client must not re-sort locally —
+  // that would only order the pages already loaded — so it preserves the
+  // server's order verbatim. (The full reset-cursor-and-reload-on-sort-change
+  // flow is covered by ApplicationListViewModelPaginationTests.)
+
+  @Test("newest is server-driven — the list preserves the server's order")
+  func sort_newest_preservesServerOrder() async throws {
+    let serverOrdered: [PlanningApplication] = [.rejected, .permitted, .pendingReview]
+    let (sut, _, _, _) = try makeSUT(applications: serverOrdered)
 
     await sut.loadApplications()
     sut.sort = .newest
 
-    #expect(sut.filteredApplications.map(\.id) == [newest.id, middle.id, older.id])
+    #expect(sut.filteredApplications.map(\.id) == serverOrdered.map(\.id))
   }
 
-  @Test("oldest sort orders by receivedDate asc")
-  func sort_oldest_ordersByReceivedDateAsc() async throws {
-    let older = PlanningApplication.pendingReview
-    let middle = PlanningApplication.permitted
-    let newest = PlanningApplication.rejected
-    let (sut, _, _, _) = try makeSUT(applications: [middle, older, newest])
+  @Test("oldest is server-driven — the list preserves the server's order")
+  func sort_oldest_preservesServerOrder() async throws {
+    let serverOrdered: [PlanningApplication] = [.pendingReview, .permitted, .rejected]
+    let (sut, _, _, _) = try makeSUT(applications: serverOrdered)
 
     await sut.loadApplications()
     sut.sort = .oldest
 
-    #expect(sut.filteredApplications.map(\.id) == [older.id, middle.id, newest.id])
+    #expect(sut.filteredApplications.map(\.id) == serverOrdered.map(\.id))
   }
 
   @Test("status sort orders by appState raw value")

--- a/mobile/ios/town-crier-tests/Sources/Features/URLSessionAPIClientPagedTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/URLSessionAPIClientPagedTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+import TownCrierData
+import TownCrierDomain
+
+// MARK: - Test helpers
+
+private struct PagedTestRow: Decodable, Equatable, Sendable {
+  let id: String
+}
+
+// MARK: - Tests
+
+/// Covers `requestPaged`, the variant of the API client used by the watch-zone
+/// applications list to page the full set: it returns the decoded body plus the
+/// opaque `X-Next-Cursor` continuation token from the response headers (GH#682).
+@Suite("URLSessionAPIClient — paged requests (X-Next-Cursor)")
+struct URLSessionAPIClientPagedTests {
+  // swiftlint:disable:next force_unwrapping
+  private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
+
+  private func makeSUT(
+    _ responses: [(Data, URLResponse)]
+  ) -> (URLSessionAPIClient, StubHTTPTransport) {
+    let authService = SpyAuthenticationService()
+    authService.currentSessionResult = .valid
+    let transport = StubHTTPTransport()
+    transport.responses = responses
+    let client = URLSessionAPIClient(
+      baseURL: baseURL,
+      authService: authService,
+      transport: transport
+    )
+    return (client, transport)
+  }
+
+  private func response(statusCode: Int, headers: [String: String]) -> HTTPURLResponse {
+    // swiftlint:disable:next force_unwrapping
+    HTTPURLResponse(url: baseURL, statusCode: statusCode, httpVersion: nil, headerFields: headers)!
+  }
+
+  @Test("requestPaged surfaces the X-Next-Cursor response header")
+  func requestPaged_surfacesNextCursor() async throws {
+    let json = #"[{"id":"a"}]"#
+    let (sut, _) = makeSUT([
+      (Data(json.utf8), response(statusCode: 200, headers: ["X-Next-Cursor": "cursor-xyz"]))
+    ])
+
+    let page: (value: [PagedTestRow], nextCursor: String?) =
+      try await sut.requestPaged(.get("/things"))
+
+    #expect(page.value == [PagedTestRow(id: "a")])
+    #expect(page.nextCursor == "cursor-xyz")
+  }
+
+  @Test("requestPaged returns a nil cursor when the header is absent (last page)")
+  func requestPaged_nilCursorWhenHeaderAbsent() async throws {
+    let json = #"[{"id":"a"}]"#
+    let (sut, _) = makeSUT([
+      (Data(json.utf8), response(statusCode: 200, headers: [:]))
+    ])
+
+    let page: (value: [PagedTestRow], nextCursor: String?) =
+      try await sut.requestPaged(.get("/things"))
+
+    #expect(page.nextCursor == nil)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyPlanningApplicationRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyPlanningApplicationRepository.swift
@@ -46,6 +46,51 @@ final class SpyPlanningApplicationRepository: PlanningApplicationRepository, @un
     return try fetchApplicationsResult.get()
   }
 
+  // MARK: - Paged fetch (GH#682)
+
+  /// A recorded `fetchApplicationsPage` invocation — lets tests assert the exact
+  /// query params (sort + cursor + limit) the ViewModel drove for each page.
+  struct RecordedPageRequest: Sendable {
+    let zone: WatchZone
+    let sort: ApplicationSortOrder
+    let cursor: String?
+    let limit: Int
+  }
+
+  private(set) var fetchApplicationsPageCalls: [RecordedPageRequest] = []
+
+  /// Queue of pages returned by successive `fetchApplicationsPage` calls. When
+  /// non-empty, each call dequeues the next page (driving multi-page tests).
+  /// When exhausted or never set, the call falls back to a single page built
+  /// from `fetchApplicationsByZone`/`fetchApplicationsResult` with no cursor.
+  var pagedResponses: [ApplicationPage] = []
+
+  /// When set, every paged fetch throws this error after recording the call —
+  /// drives the "fetch error surfaces to the ViewModel" path.
+  var fetchApplicationsPageError: Error?
+
+  func fetchApplicationsPage(
+    for zone: WatchZone,
+    sort: ApplicationSortOrder,
+    cursor: String?,
+    limit: Int
+  ) async throws -> ApplicationPage {
+    fetchApplicationsPageCalls.append(
+      RecordedPageRequest(zone: zone, sort: sort, cursor: cursor, limit: limit))
+    await waitForGateIfNeeded()
+    if let fetchApplicationsPageError {
+      throw fetchApplicationsPageError
+    }
+    if fetchApplicationsFailureZones.contains(zone.id.value) {
+      throw DomainError.unexpected("Simulated failure for \(zone.id.value)")
+    }
+    if !pagedResponses.isEmpty {
+      return pagedResponses.removeFirst()
+    }
+    let apps = fetchApplicationsByZone[zone.id.value] ?? ((try? fetchApplicationsResult.get()) ?? [])
+    return ApplicationPage(applications: apps, nextCursor: nil)
+  }
+
   private(set) var fetchApplicationCalls: [PlanningApplicationId] = []
   var fetchApplicationResult: Result<PlanningApplication, Error> = .success(.pendingReview)
 


### PR DESCRIPTION
## What

Slice 1 (iOS portion) of epic #682 — consumes the server-side `?sort=` API merged in #688. The watch-zone applications **list** now infinite-scrolls the full set, server-ordered, for the three scalar sorts shipped so far.

- **Repository**: new `fetchApplicationsPage(for:sort:cursor:limit:)` returning `ApplicationPage{ applications, nextCursor }`. Sends `?sort=&limit=` (+ `?cursor=` when present), decodes the bare `[PlanningApplicationDTO]`, and surfaces the **`X-Next-Cursor`** response header (nil ⇒ last page) via a new `URLSessionAPIClient.requestPaged`.
- **ApplicationListViewModel**: infinite scroll for **distance / newest / oldest** — ordering driven by the server, local sort removed for those three. `onRowAppear` prefetches within 10 rows of the end; appends with id-dedupe; stops when `X-Next-Cursor` is absent. Changing sort resets the cursor and reloads page 1. Page size 150 (matches the API sorted-path default).
- **Map untouched** (`MapViewModel` not in the diff) — slice 5 owns the map eager-drain.
- **Deferred to later slices**: `status` / `recent-activity` sorts and all status/unread filters stay on their current client-side path (slices 2–4).

## Tests

Swift Testing with a fake API client/repository: page append (no dupes), sort-change resets cursor (next request carries none), last-page (no header) stops the loop, fetch-error surfaces to ViewModel state. Old local-ordering tests for the three server sorts replaced with server-order-preservation tests (ordering correctness now lives in the Go pgtest suite, #688).

Gates: `swift build` clean · `swift test` 1377 pass · `swiftlint lint --strict` 0 violations.

Epic: #682 · Bead: tc-ul1i

Release-Note: Browse every application in a watch zone. The list now loads more as you scroll, sorted by newest, oldest or distance.