### PR TITLE
feat(api): server-side status sort with mixed-direction keyset + composite index (tc-le1x, #682 slice 2)

### DIFF
--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -673,6 +673,19 @@ func TestPostgresStore_FindInZonePage_CursorSortMismatch(t *testing.T) {
 		t.Errorf("replay newest cursor under oldest: got err %v, want ErrCursorSortMismatch", err)
 	}
 
+	// A cursor minted under status carries mode=status; replaying it under any
+	// other sort is rejected, never a mis-ordered page.
+	_, statusCursor, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, SortStatus, 1, "")
+	if err != nil {
+		t.Fatalf("mint status cursor: %v", err)
+	}
+	if statusCursor == "" {
+		t.Fatal("expected a continuation cursor after a full status page")
+	}
+	if _, _, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, SortNewest, 1, statusCursor); !errors.Is(err, ErrCursorSortMismatch) {
+		t.Errorf("replay status cursor under newest: got err %v, want ErrCursorSortMismatch", err)
+	}
+
 	if _, _, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, SortNewest, 1, "!!!not-base64!!!"); !errors.Is(err, ErrCursorInvalid) {
 		t.Errorf("malformed cursor: got err %v, want ErrCursorInvalid", err)
 	}

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -570,6 +570,66 @@ func TestPostgresStore_FindInZonePage_Oldest(t *testing.T) {
 	}
 }
 
+// statusFixture seeds a deterministic in-radius set spanning two non-NULL
+// app_state values ("Permitted" < "Rejected") plus a NULL-app_state group, each
+// with varied and NULL start_dates, including an equal-(app_state, start_date)
+// pair across two authorities to exercise the (authority_code, planit_name)
+// tiebreak. All rows are within 6 km.
+func statusFixture(t *testing.T, store *PostgresStore) {
+	t.Helper()
+	ctx := context.Background()
+	mar := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	feb := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	jan := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	permitted, rejected := pgPtr("Permitted"), pgPtr("Rejected")
+	for _, a := range []PlanningApplication{
+		withState(withStart(at(pgApp("P1", 100), 100), mar), permitted),
+		withState(withStart(at(pgApp("P2", 100), 200), jan), permitted),
+		withState(withStart(at(pgApp("P3", 100), 300), feb), permitted),
+		withState(withStart(at(pgApp("P4", 200), 350), feb), permitted), // equal (state,date) as P3, other authority
+		withState(at(pgApp("P5", 100), 400), permitted),                 // NULL start_date within Permitted
+		withState(withStart(at(pgApp("R1", 100), 500), feb), rejected),
+		withState(at(pgApp("R2", 100), 600), rejected), // NULL start_date within Rejected
+		withStart(at(pgApp("N1", 100), 700), mar),      // NULL app_state
+		at(pgApp("N2", 100), 800),                      // NULL app_state, NULL start_date
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+}
+
+// TestPostgresStore_FindInZonePage_Status proves the mixed-direction keyset —
+// app_state ASC NULLS LAST, start_date DESC NULLS LAST, (authority_code,
+// planit_name) — pages to exhaustion with no overlap or gap and matches the single
+// unpaged order. NULL app_state rows sort last; within an app_state group NULL
+// start_date rows sort last; equal (app_state, start_date) tiebreaks on
+// (authority_code, planit_name).
+func TestPostgresStore_FindInZonePage_Status(t *testing.T) {
+	store := newAppPGStore(t)
+	statusFixture(t, store)
+
+	// Permitted (state ASC first): mar, feb tiebreak "100"(P3)<"200"(P4), jan, NULL.
+	// Rejected next: feb, NULL. NULL app_state last: mar, NULL.
+	want := []string{"P1", "P3", "P4", "P2", "P5", "R1", "R2", "N1", "N2"}
+	if got := pageAllInZone(t, store, SortStatus, 6000, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("status single page: got %v, want %v", got, want)
+	}
+	if got := pageAllInZone(t, store, SortStatus, 6000, 2); !reflect.DeepEqual(got, want) {
+		t.Fatalf("status paged: got %v, want %v", got, want)
+	}
+	// Page size 1 forces a keyset boundary at every row: across app_state group
+	// boundaries, inside a group's NULL-start_date tail, and into the NULL
+	// app_state tail.
+	if got := pageAllInZone(t, store, SortStatus, 6000, 1); !reflect.DeepEqual(got, want) {
+		t.Fatalf("status paged size 1: got %v, want %v", got, want)
+	}
+	// Page size 3 lands boundaries mid-group and at group edges.
+	if got := pageAllInZone(t, store, SortStatus, 6000, 3); !reflect.DeepEqual(got, want) {
+		t.Fatalf("status paged size 3: got %v, want %v", got, want)
+	}
+}
+
 // TestPostgresStore_FindInZonePage_RespectsRadius proves the spatial predicate
 // still bounds every sort: a row outside the radius never appears.
 func TestPostgresStore_FindInZonePage_RespectsRadius(t *testing.T) {
@@ -584,7 +644,7 @@ func TestPostgresStore_FindInZonePage_RespectsRadius(t *testing.T) {
 			t.Fatalf("Upsert %s: %v", a.Name, err)
 		}
 	}
-	for _, sort := range []Sort{SortDistance, SortNewest, SortOldest} {
+	for _, sort := range []Sort{SortDistance, SortNewest, SortOldest, SortStatus} {
 		got := pageAllInZone(t, store, sort, 6000, 10)
 		if !reflect.DeepEqual(got, []string{"IN"}) {
 			t.Errorf("%s: got %v, want [IN] (OUT is beyond the radius)", sort, got)

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -699,7 +699,7 @@ func TestPostgresStore_FindInZonePage_UnsupportedSort(t *testing.T) {
 	store := newAppPGStore(t)
 	sortFixture(t, store)
 
-	if _, _, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, Sort("status"), 10, ""); !errors.Is(err, ErrUnsupportedSort) {
+	if _, _, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, Sort("nonsense"), 10, ""); !errors.Is(err, ErrUnsupportedSort) {
 		t.Errorf("unsupported sort: got err %v, want ErrUnsupportedSort", err)
 	}
 }

--- a/api-go/internal/applications/zonepage.go
+++ b/api-go/internal/applications/zonepage.go
@@ -69,13 +69,17 @@ var (
 //   - distance: D (the KNN distance) + N (planit_name).
 //   - newest/oldest: SD (start_date, nil for a NULL-start_date tail row) + AC
 //     (authority_code) + N (planit_name).
+//   - status: AS (app_state, nil for a NULL-app_state tail row) + SD (start_date,
+//     nil for a NULL-start_date tail row) + AC (authority_code) + N (planit_name).
 //
-// It is base64url-encoded JSON. SD is a "2006-01-02" date string so the next
-// page's predicate compares against an unambiguous ::date, not a timezone-laden
-// timestamp.
+// It is base64url-encoded JSON. AS and SD use a nil pointer (omitted field) to
+// mean a NULL key value, so the next page's predicate can pick the matching
+// NULLS-LAST tail branch. SD is a "2006-01-02" date string so the predicate
+// compares against an unambiguous ::date, not a timezone-laden timestamp.
 type pageCursor struct {
 	M  Sort    `json:"m"`
 	D  string  `json:"d,omitempty"`
+	AS *string `json:"as,omitempty"`
 	SD *string `json:"sd,omitempty"`
 	AC string  `json:"ac,omitempty"`
 	N  string  `json:"n"`
@@ -155,6 +159,62 @@ const (
 		oldestOrderBy
 )
 
+// statusOrderBy is the ORDER BY + LIMIT suffix for SortStatus. app_state ASC NULLS
+// LAST groups by state with the NULL-app_state rows trailing; within a group
+// start_date DESC NULLS LAST orders newest-first with NULL-start_date rows
+// trailing; (authority_code, planit_name) is the unique tiebreak. The mixed
+// directions (state ASC / date DESC) make the keyset predicate per-key.
+const statusOrderBy = " ORDER BY app_state ASC NULLS LAST, start_date DESC NULLS LAST, authority_code, planit_name LIMIT $4"
+
+// statusFirstQuery is the status first page: spatial predicate only, ordered,
+// limited. It reuses dateFromWhere (same projection: appColumns + authority_code).
+const statusFirstQuery = dateFromWhere + statusOrderBy
+
+// Status keyset queries. The "strictly after the cursor" predicate exactly mirrors
+// statusOrderBy as a lexicographic OR-chain, honouring each column's direction and
+// NULLS LAST, so pages never overlap or gap:
+//
+//	after-col1 (app_state ASC NULLS LAST)
+//	  OR (eq-col1 AND after-col2 (start_date DESC NULLS LAST))
+//	  OR (eq-col1 AND eq-col2 AND (authority_code, planit_name) > tiebreak)
+//
+// Because app_state and start_date are each independently nullable, the cursor row
+// sits in one of four NULLS-LAST positions, each needing its own predicate (a NULL
+// key has no "strictly after" at that column — nothing follows a NULLS-LAST tail —
+// and equality at a NULL key is `IS NULL`):
+//
+//	statusKeysetQuery          app_state non-null, start_date non-null
+//	statusKeysetDateNullQuery  app_state non-null, start_date NULL
+//	statusKeysetStateNullQuery app_state NULL,     start_date non-null
+//	statusKeysetBothNullQuery  app_state NULL,     start_date NULL
+const (
+	// $5 app_state, $6 start_date(::date), $7 authority_code, $8 planit_name.
+	statusKeysetQuery = dateFromWhere +
+		" AND (app_state > $5 OR app_state IS NULL" +
+		" OR (app_state = $5 AND (start_date < $6::date OR start_date IS NULL))" +
+		" OR (app_state = $5 AND start_date = $6::date AND (authority_code, planit_name) > ($7, $8)))" +
+		statusOrderBy
+	// $5 app_state, $6 authority_code, $7 planit_name. Cursor in the NULL-start_date
+	// tail of its app_state group: no start_date follows it, so equal-state only
+	// advances on the tiebreak; a greater (or NULL) app_state still follows.
+	statusKeysetDateNullQuery = dateFromWhere +
+		" AND (app_state > $5 OR app_state IS NULL" +
+		" OR (app_state = $5 AND start_date IS NULL AND (authority_code, planit_name) > ($6, $7)))" +
+		statusOrderBy
+	// $5 start_date(::date), $6 authority_code, $7 planit_name. Cursor in the
+	// NULL-app_state tail: no app_state follows it, so the scan stays within
+	// app_state IS NULL and advances on start_date DESC NULLS LAST then the tiebreak.
+	statusKeysetStateNullQuery = dateFromWhere +
+		" AND app_state IS NULL AND ((start_date < $5::date OR start_date IS NULL)" +
+		" OR (start_date = $5::date AND (authority_code, planit_name) > ($6, $7)))" +
+		statusOrderBy
+	// $5 authority_code, $6 planit_name. Deepest tail: NULL app_state AND NULL
+	// start_date — only the (authority_code, planit_name) tiebreak remains.
+	statusKeysetBothNullQuery = dateFromWhere +
+		" AND app_state IS NULL AND start_date IS NULL AND (authority_code, planit_name) > ($5, $6)" +
+		statusOrderBy
+)
+
 // datePageRow carries a hydrated application plus its authority_code, so the last
 // row of a full page can be encoded into the next-page keyset cursor.
 type datePageRow struct {
@@ -198,6 +258,9 @@ func (s *PostgresStore) FindInZonePage(ctx context.Context, latitude, longitude,
 	}
 	if sort == SortDistance {
 		return s.findDistanceZonePage(ctx, latitude, longitude, radiusMetres, limit, c)
+	}
+	if sort == SortStatus {
+		return s.findStatusZonePage(ctx, latitude, longitude, radiusMetres, limit, c)
 	}
 	return s.findDateZonePage(ctx, latitude, longitude, radiusMetres, sort, limit, c)
 }
@@ -303,6 +366,73 @@ func dateZoneQuery(sort Sort, latitude, longitude, radiusMetres float64, limit i
 // predicate compares against a ::date, free of timezone drift.
 func dateCursorOf(sort Sort, last datePageRow) pageCursor {
 	c := pageCursor{M: sort, AC: last.ac, N: last.app.Name}
+	if last.app.StartDate != nil {
+		sd := last.app.StartDate.Format("2006-01-02")
+		c.SD = &sd
+	}
+	return c
+}
+
+// findStatusZonePage serves SortStatus: the app_state-then-start_date query with a
+// mixed-direction keyset cursor on (app_state, start_date, authority_code,
+// planit_name). It reuses the date-projection row scanner; app_state and start_date
+// are already hydrated on the application.
+func (s *PostgresStore) findStatusZonePage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
+	query, args := statusZoneQuery(latitude, longitude, radiusMetres, limit, c)
+	rows, err := s.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("find applications by status near (%v, %v): %w", latitude, longitude, err)
+	}
+	collected, err := pgx.CollectRows(rows, scanDatePageRow)
+	if err != nil {
+		return nil, "", fmt.Errorf("find applications by status near (%v, %v): %w", latitude, longitude, err)
+	}
+	apps := make([]PlanningApplication, len(collected))
+	for i := range collected {
+		apps[i] = collected[i].app
+	}
+	next := ""
+	if limit > 0 && len(collected) == limit {
+		next, err = encodePageCursor(statusCursorOf(collected[len(collected)-1]))
+		if err != nil {
+			return nil, "", fmt.Errorf("encode status cursor: %w", err)
+		}
+	}
+	return apps, next, nil
+}
+
+// statusZoneQuery selects the first-page or the per-NULL-tail keyset query for
+// SortStatus and assembles its positional args. The base args ($1..$4) are
+// longitude, latitude, radius, limit; the keyset args extend them, their count and
+// meaning matching the chosen query's NULL-tail case (see the status keyset query
+// constants).
+func statusZoneQuery(latitude, longitude, radiusMetres float64, limit int, c *pageCursor) (string, []any) {
+	base := []any{longitude, latitude, radiusMetres, limit}
+	switch {
+	case c == nil:
+		return statusFirstQuery, base
+	case c.AS != nil && c.SD != nil:
+		return statusKeysetQuery, append(base, *c.AS, *c.SD, c.AC, c.N)
+	case c.AS != nil: // start_date NULL: cursor in its group's NULL-start_date tail.
+		return statusKeysetDateNullQuery, append(base, *c.AS, c.AC, c.N)
+	case c.SD != nil: // app_state NULL: cursor in the NULL-app_state tail.
+		return statusKeysetStateNullQuery, append(base, *c.SD, c.AC, c.N)
+	default: // both NULL: the deepest tail.
+		return statusKeysetBothNullQuery, append(base, c.AC, c.N)
+	}
+}
+
+// statusCursorOf builds the next-page keyset cursor from the last row of a full
+// status page: its app_state (nil for a NULL-app_state tail row), start_date (nil
+// for a NULL-start_date tail row), authority_code, and planit_name. start_date is
+// formatted as an unambiguous "2006-01-02" so the next predicate compares against a
+// ::date, free of timezone drift.
+func statusCursorOf(last datePageRow) pageCursor {
+	c := pageCursor{M: SortStatus, AC: last.ac, N: last.app.Name}
+	if last.app.AppState != nil {
+		as := *last.app.AppState
+		c.AS = &as
+	}
 	if last.app.StartDate != nil {
 		sd := last.app.StartDate.Format("2006-01-02")
 		c.SD = &sd

--- a/api-go/internal/applications/zonepage.go
+++ b/api-go/internal/applications/zonepage.go
@@ -311,6 +311,17 @@ func (s *PostgresStore) findDistanceZonePage(ctx context.Context, latitude, long
 // a keyset cursor on (start_date, authority_code, planit_name).
 func (s *PostgresStore) findDateZonePage(ctx context.Context, latitude, longitude, radiusMetres float64, sort Sort, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
 	query, args := dateZoneQuery(sort, latitude, longitude, radiusMetres, limit, c)
+	return s.collectKeysetPage(ctx, sort, latitude, longitude, query, args, limit, func(last datePageRow) pageCursor {
+		return dateCursorOf(sort, last)
+	})
+}
+
+// collectKeysetPage runs a date-projection keyset query (scanDatePageRow rows —
+// appColumns + authority_code, shared by the start_date and app_state sorts) and
+// returns the hydrated apps plus the next-page cursor, empty unless the page is
+// full. cursorOf builds the continuation cursor from the last row of a full page;
+// sort supplies error context only.
+func (s *PostgresStore) collectKeysetPage(ctx context.Context, sort Sort, latitude, longitude float64, query string, args []any, limit int, cursorOf func(datePageRow) pageCursor) ([]PlanningApplication, string, error) {
 	rows, err := s.db.Query(ctx, query, args...)
 	if err != nil {
 		return nil, "", fmt.Errorf("find applications by %s near (%v, %v): %w", sort, latitude, longitude, err)
@@ -325,7 +336,7 @@ func (s *PostgresStore) findDateZonePage(ctx context.Context, latitude, longitud
 	}
 	next := ""
 	if limit > 0 && len(collected) == limit {
-		next, err = encodePageCursor(dateCursorOf(sort, collected[len(collected)-1]))
+		next, err = encodePageCursor(cursorOf(collected[len(collected)-1]))
 		if err != nil {
 			return nil, "", fmt.Errorf("encode %s cursor: %w", sort, err)
 		}
@@ -379,26 +390,7 @@ func dateCursorOf(sort Sort, last datePageRow) pageCursor {
 // are already hydrated on the application.
 func (s *PostgresStore) findStatusZonePage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
 	query, args := statusZoneQuery(latitude, longitude, radiusMetres, limit, c)
-	rows, err := s.db.Query(ctx, query, args...)
-	if err != nil {
-		return nil, "", fmt.Errorf("find applications by status near (%v, %v): %w", latitude, longitude, err)
-	}
-	collected, err := pgx.CollectRows(rows, scanDatePageRow)
-	if err != nil {
-		return nil, "", fmt.Errorf("find applications by status near (%v, %v): %w", latitude, longitude, err)
-	}
-	apps := make([]PlanningApplication, len(collected))
-	for i := range collected {
-		apps[i] = collected[i].app
-	}
-	next := ""
-	if limit > 0 && len(collected) == limit {
-		next, err = encodePageCursor(statusCursorOf(collected[len(collected)-1]))
-		if err != nil {
-			return nil, "", fmt.Errorf("encode status cursor: %w", err)
-		}
-	}
-	return apps, next, nil
+	return s.collectKeysetPage(ctx, SortStatus, latitude, longitude, query, args, limit, statusCursorOf)
 }
 
 // statusZoneQuery selects the first-page or the per-NULL-tail keyset query for

--- a/api-go/internal/applications/zonepage.go
+++ b/api-go/internal/applications/zonepage.go
@@ -16,8 +16,8 @@ import (
 // cursor are both this type, so a cursor minted under one sort can be rejected
 // when replayed under another (see FindInZonePage and ErrCursorSortMismatch).
 //
-// Slice 1 (epic #682) implements {distance, newest, oldest}. The remaining UI
-// sorts (status, recent-activity) arrive in later slices; until then they are
+// Slices 1-2 (epic #682) implement {distance, newest, oldest, status}. The
+// remaining UI sort (recent-activity) arrives in a later slice; until then it is
 // rejected as unsupported.
 type Sort string
 
@@ -32,12 +32,17 @@ const (
 	// SortOldest orders by start_date ASC NULLS LAST, then the unique tiebreak
 	// (authority_code, planit_name). It reuses the newest btree, scanned backward.
 	SortOldest Sort = "oldest"
+	// SortStatus orders by app_state ASC NULLS LAST, then start_date DESC NULLS
+	// LAST, then the unique tiebreak (authority_code, planit_name). The mixed
+	// directions (app_state ASC / start_date DESC) make the keyset predicate
+	// per-key (see findStatusZonePage).
+	SortStatus Sort = "status"
 )
 
 // Supported reports whether s is a sort this slice implements server-side.
 func (s Sort) Supported() bool {
 	switch s {
-	case SortDistance, SortNewest, SortOldest:
+	case SortDistance, SortNewest, SortOldest, SortStatus:
 		return true
 	default:
 		return false

--- a/api-go/internal/applications/zonepage_test.go
+++ b/api-go/internal/applications/zonepage_test.go
@@ -7,11 +7,13 @@ import (
 
 // TestPageCursor_RoundTrip proves the sort-aware keyset cursor survives an
 // encode/decode round-trip for every shape: a distance keyset, a non-null
-// start_date keyset, and a NULL start_date keyset (the tail of a NULLS LAST
-// scan).
+// start_date keyset, a NULL start_date keyset (the tail of a NULLS LAST scan), and
+// each of the four status keyset NULL-tail positions (the mixed-direction keyset
+// carries an extra nullable app_state key).
 func TestPageCursor_RoundTrip(t *testing.T) {
 	t.Parallel()
 	sd := "2026-01-02"
+	as := "Permitted"
 	tests := []struct {
 		name string
 		in   pageCursor
@@ -20,6 +22,10 @@ func TestPageCursor_RoundTrip(t *testing.T) {
 		{"newest non-null", pageCursor{M: SortNewest, SD: &sd, AC: "100", N: "24/0002/FUL"}},
 		{"oldest non-null", pageCursor{M: SortOldest, SD: &sd, AC: "200", N: "24/0003/FUL"}},
 		{"newest null tail", pageCursor{M: SortNewest, SD: nil, AC: "300", N: "24/0004/FUL"}},
+		{"status state+date", pageCursor{M: SortStatus, AS: &as, SD: &sd, AC: "100", N: "24/0005/FUL"}},
+		{"status date-null tail", pageCursor{M: SortStatus, AS: &as, SD: nil, AC: "100", N: "24/0006/FUL"}},
+		{"status state-null tail", pageCursor{M: SortStatus, AS: nil, SD: &sd, AC: "200", N: "24/0007/FUL"}},
+		{"status both-null tail", pageCursor{M: SortStatus, AS: nil, SD: nil, AC: "300", N: "24/0008/FUL"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -34,6 +40,12 @@ func TestPageCursor_RoundTrip(t *testing.T) {
 			}
 			if got.M != tc.in.M || got.D != tc.in.D || got.AC != tc.in.AC || got.N != tc.in.N {
 				t.Errorf("round-trip mismatch: got %+v, want %+v", got, tc.in)
+			}
+			if (got.AS == nil) != (tc.in.AS == nil) {
+				t.Fatalf("AS nil mismatch: got %v, want %v", got.AS, tc.in.AS)
+			}
+			if got.AS != nil && *got.AS != *tc.in.AS {
+				t.Errorf("AS: got %q, want %q", *got.AS, *tc.in.AS)
 			}
 			if (got.SD == nil) != (tc.in.SD == nil) {
 				t.Fatalf("SD nil mismatch: got %v, want %v", got.SD, tc.in.SD)

--- a/api-go/internal/platform/postgres/migrations/0013_application_status_sort_index.sql
+++ b/api-go/internal/platform/postgres/migrations/0013_application_status_sort_index.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+
+-- Btree index backing the server-side ?sort=status keyset scan on the watch-zone
+-- applications list (epic #682 slice 2). The status ORDER BY is
+-- (app_state ASC NULLS LAST, start_date DESC NULLS LAST, authority_code, planit_name);
+-- the index column order, direction, AND nulls-ordering match it exactly so it is
+-- usable for both the ordering and the mixed-direction keyset scan.
+--
+-- start_date DESC is spelled NULLS LAST explicitly: Postgres defaults a DESC column
+-- to NULLS FIRST, which would not match the query's NULLS LAST and would leave the
+-- index unusable for the keyset. (authority_code, planit_name) is the unique
+-- tiebreak — a PlanIt case reference is only unique within an authority — so the
+-- keyset cursor never overlaps or gaps on equal (app_state, start_date).
+--
+-- The radius predicate stays served by applications_location_gist (ST_DWithin /
+-- KNN <->); this index orders the in-radius candidate set and keeps the keyset
+-- pagination cheap.
+CREATE INDEX IF NOT EXISTS applications_app_state_keyset
+    ON applications (app_state ASC NULLS LAST, start_date DESC NULLS LAST, authority_code, planit_name);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS applications_app_state_keyset;

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -54,9 +54,9 @@ type authorityResolver interface {
 // cursor plus an opaque continuation token for the next page (tc-fm8f).
 //
 // FindNearbyPage is the legacy default-distance path (byte-identical param-less
-// contract). FindInZonePage adds the server-side ?sort= surface (epic #682 slice
-// 1: distance/newest/oldest) with a sort-aware keyset cursor. *applications.PostgresStore
-// satisfies both.
+// contract). FindInZonePage adds the server-side ?sort= surface (epic #682 slices
+// 1-2: distance/newest/oldest/status) with a sort-aware keyset cursor.
+// *applications.PostgresStore satisfies both.
 type appFinder interface {
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]applications.PlanningApplication, string, error)
 	FindInZonePage(ctx context.Context, latitude, longitude, radiusMetres float64, sort applications.Sort, limit int, cursor string) ([]applications.PlanningApplication, string, error)
@@ -147,7 +147,8 @@ const (
 const invalidCursorMessage = "Invalid cursor."
 
 // invalidSortMessage is the 400 body when ?sort= is outside the supported set
-// ({distance, newest, oldest} for this slice).
+// ({distance, newest, oldest, status} for this slice; recent-activity arrives in a
+// later slice).
 const invalidSortMessage = "Invalid sort."
 
 // valid reports whether the create request passes the pre-handler guard:
@@ -417,10 +418,10 @@ func parseLimit(raw string, def int) int {
 
 // parseSort resolves ?sort= to a supported Sort. An absent value defaults to
 // SortDistance (the legacy nearest-first behaviour). The boolean reports whether
-// the value is supported in this slice ({distance, newest, oldest}); an
-// unsupported value (status, recent-activity, or garbage) is a clean 400. The
-// caller treats an absent value (ok with SortDistance and present=false) as the
-// legacy param-less path.
+// the value is supported in this slice ({distance, newest, oldest, status}); an
+// unsupported value (recent-activity or garbage) is a clean 400. The caller treats
+// an absent value (ok with SortDistance and present=false) as the legacy param-less
+// path.
 func parseSort(raw string) (sort applications.Sort, present, ok bool) {
 	if raw == "" {
 		return applications.SortDistance, false, true

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -839,6 +839,7 @@ func TestApplications_SortRoutesToSortAwarePath(t *testing.T) {
 		{"?sort=distance", applications.SortDistance},
 		{"?sort=newest", applications.SortNewest},
 		{"?sort=oldest", applications.SortOldest},
+		{"?sort=status", applications.SortStatus},
 	}
 	for _, tc := range tests {
 		t.Run(tc.query, func(t *testing.T) {
@@ -898,11 +899,11 @@ func TestApplications_SortAwareLimitParsing(t *testing.T) {
 }
 
 // TestApplications_UnknownSortIs400 proves any sort outside this slice's set —
-// including the valid-future values status and recent-activity — is rejected with
-// 400 before any spatial query runs.
+// including the valid-future value recent-activity — is rejected with 400 before
+// any spatial query runs.
 func TestApplications_UnknownSortIs400(t *testing.T) {
 	t.Parallel()
-	for _, sortVal := range []string{"status", "recent-activity", "nonsense", "DISTANCE", "Newest"} {
+	for _, sortVal := range []string{"recent-activity", "nonsense", "DISTANCE", "Newest"} {
 		t.Run(sortVal, func(t *testing.T) {
 			t.Parallel()
 			apps := &fakeAppFinder{}


### PR DESCRIPTION
## What

Slice 2 (API) of epic #682 — adds the `status` server-side sort, building on slice 1's `FindInZonePage` + sort-aware cursor.

- `?sort=status` ⇒ `ORDER BY app_state ASC NULLS LAST, start_date DESC NULLS LAST, authority_code, planit_name`.
- **Mixed-direction keyset**: 4 NULL-tail predicate variants (selected by whether the cursor's app_state / start_date are NULL) form a column-by-column lexicographic OR-chain that exactly matches the ORDER BY — so pages never overlap or gap, NULL app_state rows sort last, and NULL start_date rows sort last within each app_state group.
- `pageCursor` gains an `as` (app_state) field; mode embedded as `status`. distance/newest/oldest cursors unchanged.
- goose `0013_application_status_sort_index.sql`: `applications_app_state_keyset` btree `(app_state ASC NULLS LAST, start_date DESC NULLS LAST, authority_code, planit_name)` — DESC spelled `NULLS LAST` explicitly so the index matches the ORDER BY (PG defaults DESC to NULLS FIRST).
- Handler needed no logic change: `parseSort` delegates to `Sort.Supported()`, so adding `SortStatus` routes `?sort=status` to the sort-aware path automatically.

distance stays the default; param-less call byte-identical (golden test untouched). `recent-activity` + filters remain out of scope (slices 3–4).

## Tests

- pgtest `//go:build integration`: status exhaustion / no-overlap / no-gap vs. unpaged ordered query, NULL app_state + NULL start_date tails, stable `(authority_code, planit_name)` tiebreak — run by the `go-integration` pr-gate job.
- Handler fakes: `?sort=status` now 200; status cursor replayed under another sort ⇒ 400; existing 400s + param-less golden still pass.

Epic: #682 · Bead: tc-le1x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `status` sort option for in-zone application listings.
  * Search results now support consistent paging and ordering when status, dates, or both are missing.

* **Bug Fixes**
  * Improved cursor handling so pagination remains correct across page sizes and mixed sort directions.
  * Invalid cursors are now rejected when reused with a different sort option.

* **Documentation**
  * Updated inline guidance to reflect the expanded supported sort options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->