### PR TITLE
feat(ios): wire watch-zone list status sort to the server (tc-rfp5, #682 slice 2)

### DIFF
--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/ApplicationSortOrder.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/ApplicationSortOrder.swift
@@ -1,7 +1,7 @@
 /// The server-supported sort orders for the paged watch-zone applications
 /// endpoint. Raw values are the `?sort=` query vocabulary the API accepts
-/// (GH#682 slice 1) — anything else (status, recent-activity) is still computed
-/// client-side and is *not* representable here.
+/// (GH#682 slices 1-2) — `recent-activity` is still computed client-side and is
+/// *not* representable here.
 public enum ApplicationSortOrder: String, Sendable, CaseIterable {
   /// Nearest-first via the KNN `<->` operator. The server default and cheapest
   /// plan; matches the param-less legacy behaviour.
@@ -10,4 +10,8 @@ public enum ApplicationSortOrder: String, Sendable, CaseIterable {
   case newest
   /// `start_date` ascending, NULLS LAST, with a stable unique tiebreak.
   case oldest
+  /// `app_state` ascending, NULLS LAST, then `start_date` descending, with a
+  /// stable unique tiebreak (GH#682 slice 2). The server owns this ordering —
+  /// the client must not re-sort the fetched pages by `app_state` locally.
+  case status
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+Pagination.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+Pagination.swift
@@ -1,18 +1,18 @@
 import Foundation
 import TownCrierDomain
 
-/// Infinite-scroll pagination for the watch-zone list (GH#682 slice 1). Split
+/// Infinite-scroll pagination for the watch-zone list (GH#682 slices 1-2). Split
 /// out of `ApplicationListViewModel` to keep that file under SwiftLint's
-/// `file_length` ceiling. For the three server-supported sorts
-/// (distance/newest/oldest) the server owns the ordering and the list follows
-/// `X-Next-Cursor` to the end; the client-side sorts (recent-activity/status)
-/// keep their param-less single-page path.
+/// `file_length` ceiling. For the server-supported sorts
+/// (distance/newest/oldest/status) the server owns the ordering and the list
+/// follows `X-Next-Cursor` to the end; the remaining client-side sort
+/// (recent-activity) keeps its param-less single-page path.
 extension ApplicationListViewModel {
 
   /// Loads the active zone's first page via the path appropriate to the current
-  /// sort. The three server-supported sorts (distance/newest/oldest) fetch a
-  /// server-ordered page and capture the next-page cursor; the client-side sorts
-  /// (recent-activity/status) keep the legacy param-less first-page fetch. Either
+  /// sort. The server-supported sorts (distance/newest/oldest/status) fetch a
+  /// server-ordered page and capture the next-page cursor; the client-side
+  /// `recent-activity` sort keeps the legacy param-less first-page fetch. Either
   /// way the cursor resets, so pagination always restarts cleanly.
   func loadActiveZone(_ zone: WatchZone) async throws {
     if let order = sort.serverOrder {
@@ -48,8 +48,9 @@ extension ApplicationListViewModel {
 
   /// Called by the list as each row appears. Kicks off the next-page fetch when
   /// a server sort is active, more pages remain, and the appearing row is within
-  /// ``prefetchThreshold`` of the end of the loaded set. A no-op for client-side
-  /// sorts, which hold the whole (first-page) set already.
+  /// ``prefetchThreshold`` of the end of the loaded set. A no-op for the
+  /// client-side `recent-activity` sort, which holds the whole (first-page) set
+  /// already.
   public func onRowAppear(_ application: PlanningApplication) async {
     guard sort.isServerSorted, nextCursor != nil, !isPageLoadInFlight else { return }
     guard let index = applications.firstIndex(where: { $0.id == application.id }) else { return }
@@ -59,10 +60,12 @@ extension ApplicationListViewModel {
 
   /// Reacts to a sort change from the toolbar. A server sort — or any transition
   /// away from one — reloads from page 1 with a fresh cursor so the list re-pages
-  /// in the new order. A switch between the two client-side sorts only changes
-  /// the in-memory ordering, so it skips the refetch (unchanged from the
-  /// pre-pagination behaviour). The cursor and `loadedSort` reset happen inside
-  /// the reload.
+  /// in the new order. A switch that stays entirely client-side only changes the
+  /// in-memory ordering, so it skips the refetch (unchanged from the
+  /// pre-pagination behaviour). Since slice 2 promoted `status` to the server,
+  /// `recent-activity` is the only remaining client-side sort, so that branch
+  /// now only guards a `recent-activity` self-change. The cursor and
+  /// `loadedSort` reset happen inside the reload.
   public func handleSortChanged() async {
     guard sort != loadedSort else { return }
     let newIsServer = sort.isServerSorted

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -340,13 +340,14 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
       return applications.sorted { lhs, rhs in
         recentActivityScore(lhs) > recentActivityScore(rhs)
       }
-    case .status:
-      return applications.sorted { $0.status.rawValue < $1.status.rawValue }
-    case .distance, .newest, .oldest:
+    case .distance, .newest, .oldest, .status:
       // Server-ordered sorts arrive pre-sorted from the API and are paged via
       // infinite scroll, so they are never re-sorted client-side — that would
-      // only ever order the pages already loaded (GH#682 slice 1). Identity
-      // preserves the server order and keeps the switch total.
+      // only ever order the pages already loaded (GH#682 slices 1-2). `status`
+      // joined this set in slice 2: the server orders by `app_state ASC NULLS
+      // LAST, start_date DESC`, and a local `app_state` re-sort would destroy
+      // that tiebreak. Identity preserves the server order and keeps the switch
+      // total.
       return applications
     }
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationsSort.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationsSort.swift
@@ -28,9 +28,9 @@ public enum ApplicationsSort: String, CaseIterable, Sendable {
   case distance = "distance"
 
   /// The server-side sort order the API can page in, or `nil` for the
-  /// client-only sorts (recent-activity, status) which this slice keeps
-  /// computing locally over the fetched page (GH#682 slice 1). Distance, newest,
-  /// and oldest are server-driven and paged via infinite scroll.
+  /// client-only `recent-activity` sort, which this slice keeps computing
+  /// locally over the fetched page. Distance, newest, oldest, and status
+  /// (GH#682 slice 2) are server-driven and paged via infinite scroll.
   public var serverOrder: ApplicationSortOrder? {
     switch self {
     case .distance:
@@ -39,7 +39,9 @@ public enum ApplicationsSort: String, CaseIterable, Sendable {
       return .newest
     case .oldest:
       return .oldest
-    case .recentActivity, .status:
+    case .status:
+      return .status
+    case .recentActivity:
       return nil
     }
   }

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelPaginationTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelPaginationTests.swift
@@ -163,6 +163,107 @@ struct ApplicationListViewModelPaginationTests {
     #expect(spy.fetchApplicationsCalls.isEmpty)
   }
 
+  // MARK: - status is server-driven (GH#682 slice 2)
+
+  @Test("selecting status issues ?sort=status and paginates via the cursor")
+  func statusSort_paginatesViaCursor() async throws {
+    // Pages are in the server's status order (app_state ASC, start_date DESC),
+    // deliberately NOT in `status.rawValue` order, so a stray client re-sort
+    // would reorder them and fail this assertion.
+    let page1 = ApplicationPage(applications: [.rejected, .permitted], nextCursor: "status-cursor-2")
+    let page2 = ApplicationPage(applications: [.withdrawn, .pendingReview], nextCursor: nil)
+    let (sut, spy) = try makeSUT(sort: .status, pages: [page1, page2])
+
+    await sut.loadApplications()
+    #expect(spy.fetchApplicationsPageCalls.first?.sort == .status)
+    #expect(spy.fetchApplicationsPageCalls.first?.cursor == nil)
+
+    await sut.onRowAppear(.permitted)
+
+    #expect(
+      sut.filteredApplications.map(\.id) == [
+        PlanningApplication.rejected, .permitted, .withdrawn, .pendingReview,
+      ].map(\.id)
+    )
+    #expect(spy.fetchApplicationsPageCalls.count == 2)
+    #expect(spy.fetchApplicationsPageCalls[1].sort == .status)
+    #expect(spy.fetchApplicationsPageCalls[1].cursor == "status-cursor-2")
+    #expect(spy.fetchApplicationsCalls.isEmpty)
+  }
+
+  @Test("status preserves the server order — no local app_state re-sort")
+  func statusSort_preservesServerOrder() async throws {
+    // Rejected, Undecided, Permitted — not in `status.rawValue` order. The
+    // server owns the ordering; a local re-sort would reorder this set.
+    let serverOrdered = ApplicationPage(
+      applications: [.rejected, .pendingReview, .permitted], nextCursor: nil)
+    let (sut, _) = try makeSUT(sort: .status, pages: [serverOrdered])
+
+    await sut.loadApplications()
+
+    #expect(
+      sut.filteredApplications.map(\.id) == [
+        PlanningApplication.rejected, .pendingReview, .permitted,
+      ].map(\.id)
+    )
+  }
+
+  @Test("switching to status clears the cursor and reloads from page 1")
+  func switchingToStatus_resetsCursorAndReloadsPageOne() async throws {
+    let newestPage = ApplicationPage(applications: [.pendingReview], nextCursor: "newest-cursor")
+    let (sut, spy) = try makeSUT(sort: .newest, pages: [newestPage])
+
+    await sut.loadApplications()
+    #expect(spy.fetchApplicationsPageCalls.last?.sort == .newest)
+
+    spy.pagedResponses = [ApplicationPage(applications: [.permitted], nextCursor: nil)]
+    sut.sort = .status
+    await sut.handleSortChanged()
+
+    let last = try #require(spy.fetchApplicationsPageCalls.last)
+    #expect(last.sort == .status)
+    #expect(last.cursor == nil)
+  }
+
+  @Test("switching away from status clears the cursor and reloads from page 1")
+  func switchingFromStatus_resetsCursorAndReloadsPageOne() async throws {
+    let statusPage = ApplicationPage(applications: [.permitted], nextCursor: "status-cursor")
+    let (sut, spy) = try makeSUT(sort: .status, pages: [statusPage])
+
+    await sut.loadApplications()
+    #expect(spy.fetchApplicationsPageCalls.last?.sort == .status)
+
+    spy.pagedResponses = [ApplicationPage(applications: [.rejected], nextCursor: nil)]
+    sut.sort = .oldest
+    await sut.handleSortChanged()
+
+    let last = try #require(spy.fetchApplicationsPageCalls.last)
+    #expect(last.sort == .oldest)
+    #expect(last.cursor == nil)
+  }
+
+  @Test("switching from client-side recent-activity to status drives the paged endpoint")
+  func switchingRecentActivityToStatus_usesPagedFetch() async throws {
+    // recent-activity stays client-side (param-less); status is now server-driven.
+    let spy = SpyPlanningApplicationRepository()
+    spy.fetchApplicationsResult = .success([.pendingReview, .permitted])
+    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
+    defaults.set(ApplicationsSort.recentActivity.rawValue, forKey: "test.raToStatus")
+    let sut = ApplicationListViewModel(
+      repository: spy, zone: .cambridge, userDefaults: defaults, sortKey: "test.raToStatus")
+
+    await sut.loadApplications()
+    #expect(spy.fetchApplicationsCalls.count == 1)
+    #expect(spy.fetchApplicationsPageCalls.isEmpty)
+
+    spy.pagedResponses = [ApplicationPage(applications: [.rejected, .pendingReview], nextCursor: nil)]
+    sut.sort = .status
+    await sut.handleSortChanged()
+
+    #expect(spy.fetchApplicationsPageCalls.count == 1)
+    #expect(spy.fetchApplicationsPageCalls.first?.sort == .status)
+  }
+
   // MARK: - Client sorts keep the legacy path
 
   @Test("a client-side sort keeps the param-less fetch and does not paginate")

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelPaginationTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelPaginationTests.swift
@@ -31,6 +31,15 @@ struct ApplicationListViewModelPaginationTests {
     return (vm, spy)
   }
 
+  // MARK: - status classification (GH#682 slice 2)
+
+  @Test("status is a server-driven sort mapping to the '?sort=status' raw value")
+  func status_isServerDriven() {
+    #expect(ApplicationsSort.status.serverOrder == .status)
+    #expect(ApplicationsSort.status.isServerSorted)
+    #expect(ApplicationSortOrder.status.rawValue == "status")
+  }
+
   // MARK: - Page append
 
   @Test("scrolling near the end fetches the next page via the cursor and appends")

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
@@ -213,12 +213,13 @@ struct ApplicationListViewModelUnreadTests {
     #expect(sut.filteredApplications.map(\.id) == [appA.id, appC.id, appB.id])
   }
 
-  // newest/oldest are server-driven since GH#682 slice 1: the API returns rows
-  // already in `start_date` order (proven by the Go pgtest suite, #688) and the
-  // client pages them via infinite scroll. The client must not re-sort locally —
-  // that would only order the pages already loaded — so it preserves the
-  // server's order verbatim. (The full reset-cursor-and-reload-on-sort-change
-  // flow is covered by ApplicationListViewModelPaginationTests.)
+  // newest/oldest (GH#682 slice 1) and status (slice 2) are server-driven: the
+  // API returns rows already in the requested order (proven by the Go pgtest
+  // suite, #688/#690) and the client pages them via infinite scroll. The client
+  // must not re-sort locally — that would only order the pages already loaded —
+  // so it preserves the server's order verbatim. (The full
+  // reset-cursor-and-reload-on-sort-change flow is covered by
+  // ApplicationListViewModelPaginationTests.)
 
   @Test("newest is server-driven — the list preserves the server's order")
   func sort_newest_preservesServerOrder() async throws {
@@ -242,18 +243,18 @@ struct ApplicationListViewModelUnreadTests {
     #expect(sut.filteredApplications.map(\.id) == serverOrdered.map(\.id))
   }
 
-  @Test("status sort orders by appState raw value")
-  func sort_status_ordersByAppState() async throws {
-    let permitted = PlanningApplication.permitted  // "Permitted"
-    let rejected = PlanningApplication.rejected  // "Rejected"
-    let undecided = PlanningApplication.pendingReview  // "Undecided"
-    let (sut, _, _, _) = try makeSUT(applications: [undecided, rejected, permitted])
+  @Test("status is server-driven — the list preserves the server's order")
+  func sort_status_preservesServerOrder() async throws {
+    // Rejected, Undecided, Permitted — deliberately not in `status.rawValue`
+    // order. Status moved server-side in GH#682 slice 2, so the client must
+    // render the API order as-is rather than re-sorting by `app_state` locally.
+    let serverOrdered: [PlanningApplication] = [.rejected, .pendingReview, .permitted]
+    let (sut, _, _, _) = try makeSUT(applications: serverOrdered)
 
     await sut.loadApplications()
     sut.sort = .status
 
-    let labels = sut.filteredApplications.map(\.status.rawValue)
-    #expect(labels == labels.sorted())
+    #expect(sut.filteredApplications.map(\.id) == serverOrdered.map(\.id))
   }
 
   // Distance-sort tests live in `ApplicationListViewModelDistanceSortTests`


### PR DESCRIPTION
## What

Slice 2 (iOS) of epic #682 — promotes the list's **status** sort to server-driven, consuming `?sort=status` (API merged in #690).

- `ApplicationSortOrder` gains `case status` (raw value `"status"`); the server-driven set is now `{distance, newest, oldest, status}`. Only `recentActivity` remains client-side (slice 3).
- Removed the client-side `app_state` re-sort from `ApplicationListViewModel.sortApplications` — `status` now falls into the identity arm and the list preserves the server's `app_state ASC NULLS LAST, start_date DESC` order (a local rawValue re-sort would have destroyed the tiebreak). So status now paginates the **whole zone** via `X-Next-Cursor`, with cursor reset on sort change.
- **Untouched**: `recentActivity` (still client-side param-less single page, slice 3), status/unread **filters** (still client-side, slice 4), and the map (slice 5).

## Tests

Swift Testing: `sort_status_preservesServerOrder` (replaces the old local-ordering test), status drives `?sort=status` + paginates, cursor resets on switch, recent-activity stays param-less (regression guard). `swift build` clean · `swift test` 1383 pass · `swiftlint lint --strict` 0 violations.

Epic: #682 · Bead: tc-rfp5

Release-Note: Sort a watch zone by application status across the whole zone, not just the nearest results.