### PR TITLE
feat(api): server-side recent-activity sort via notification join (tc-s0oo, #682 slice 3)

### DIFF
--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -118,7 +118,7 @@ func (fakeAppStore) BreakdownByAuthority(context.Context, string) ([]application
 func (fakeAppStore) FindNearbyPage(context.Context, float64, float64, float64, int, string) ([]applications.PlanningApplication, string, error) {
 	return nil, "", nil
 }
-func (fakeAppStore) FindInZonePage(context.Context, float64, float64, float64, applications.Sort, int, string) ([]applications.PlanningApplication, string, error) {
+func (fakeAppStore) FindInZonePage(context.Context, string, float64, float64, float64, applications.Sort, int, string) ([]applications.PlanningApplication, string, error) {
 	return nil, "", nil
 }
 func (fakeAppStore) RecentNearby(context.Context, string, float64, float64, float64, int) ([]applications.PlanningApplication, error) {

--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -36,7 +36,7 @@ type Store interface {
 	RecentByAuthority(ctx context.Context, authorityCode string, cap int) ([]PlanningApplication, error)
 	BreakdownByAuthority(ctx context.Context, authorityCode string) ([]StateCount, error)
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error)
-	FindInZonePage(ctx context.Context, latitude, longitude, radiusMetres float64, sort Sort, limit int, cursor string) ([]PlanningApplication, string, error)
+	FindInZonePage(ctx context.Context, userID string, latitude, longitude, radiusMetres float64, sort Sort, limit int, cursor string) ([]PlanningApplication, string, error)
 	RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
 	NearestNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
 	BreakdownNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) ([]StateCount, error)

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
 )
 
@@ -466,16 +468,23 @@ func withStart(a PlanningApplication, d time.Time) PlanningApplication {
 	return a
 }
 
-// pageAllInZone pages FindInZonePage to exhaustion with the given page size and
-// returns the names in the order seen across pages. It bounds the loop so a
-// keyset bug that fails to advance fails the test instead of hanging.
+// pageAllInZone pages FindInZonePage to exhaustion as an anonymous caller (no
+// userID), for the sorts that ignore per-user data.
 func pageAllInZone(t *testing.T, store *PostgresStore, sort Sort, radius float64, limit int) []string {
+	t.Helper()
+	return pageAllInZoneAs(t, store, "", sort, radius, limit)
+}
+
+// pageAllInZoneAs pages FindInZonePage to exhaustion for the given caller and
+// page size and returns the names in the order seen across pages. It bounds the
+// loop so a keyset bug that fails to advance fails the test instead of hanging.
+func pageAllInZoneAs(t *testing.T, store *PostgresStore, userID string, sort Sort, radius float64, limit int) []string {
 	t.Helper()
 	ctx := context.Background()
 	var names []string
 	cursor := ""
 	for range 1000 {
-		page, next, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, radius, sort, limit, cursor)
+		page, next, err := store.FindInZonePage(ctx, userID, pgCentreLat, pgCentreLon, radius, sort, limit, cursor)
 		if err != nil {
 			t.Fatalf("FindInZonePage(%s, cursor=%q): %v", sort, cursor, err)
 		}
@@ -661,7 +670,7 @@ func TestPostgresStore_FindInZonePage_CursorSortMismatch(t *testing.T) {
 	store := newAppPGStore(t)
 	sortFixture(t, store)
 
-	_, cursor, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, SortNewest, 1, "")
+	_, cursor, err := store.FindInZonePage(ctx, "", pgCentreLat, pgCentreLon, 6000, SortNewest, 1, "")
 	if err != nil {
 		t.Fatalf("mint newest cursor: %v", err)
 	}
@@ -669,24 +678,24 @@ func TestPostgresStore_FindInZonePage_CursorSortMismatch(t *testing.T) {
 		t.Fatal("expected a continuation cursor after a full page")
 	}
 
-	if _, _, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, SortOldest, 1, cursor); !errors.Is(err, ErrCursorSortMismatch) {
+	if _, _, err := store.FindInZonePage(ctx, "", pgCentreLat, pgCentreLon, 6000, SortOldest, 1, cursor); !errors.Is(err, ErrCursorSortMismatch) {
 		t.Errorf("replay newest cursor under oldest: got err %v, want ErrCursorSortMismatch", err)
 	}
 
 	// A cursor minted under status carries mode=status; replaying it under any
 	// other sort is rejected, never a mis-ordered page.
-	_, statusCursor, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, SortStatus, 1, "")
+	_, statusCursor, err := store.FindInZonePage(ctx, "", pgCentreLat, pgCentreLon, 6000, SortStatus, 1, "")
 	if err != nil {
 		t.Fatalf("mint status cursor: %v", err)
 	}
 	if statusCursor == "" {
 		t.Fatal("expected a continuation cursor after a full status page")
 	}
-	if _, _, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, SortNewest, 1, statusCursor); !errors.Is(err, ErrCursorSortMismatch) {
+	if _, _, err := store.FindInZonePage(ctx, "", pgCentreLat, pgCentreLon, 6000, SortNewest, 1, statusCursor); !errors.Is(err, ErrCursorSortMismatch) {
 		t.Errorf("replay status cursor under newest: got err %v, want ErrCursorSortMismatch", err)
 	}
 
-	if _, _, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, SortNewest, 1, "!!!not-base64!!!"); !errors.Is(err, ErrCursorInvalid) {
+	if _, _, err := store.FindInZonePage(ctx, "", pgCentreLat, pgCentreLon, 6000, SortNewest, 1, "!!!not-base64!!!"); !errors.Is(err, ErrCursorInvalid) {
 		t.Errorf("malformed cursor: got err %v, want ErrCursorInvalid", err)
 	}
 }
@@ -699,8 +708,190 @@ func TestPostgresStore_FindInZonePage_UnsupportedSort(t *testing.T) {
 	store := newAppPGStore(t)
 	sortFixture(t, store)
 
-	if _, _, err := store.FindInZonePage(ctx, pgCentreLat, pgCentreLon, 6000, Sort("nonsense"), 10, ""); !errors.Is(err, ErrUnsupportedSort) {
+	if _, _, err := store.FindInZonePage(ctx, "", pgCentreLat, pgCentreLon, 6000, Sort("nonsense"), 10, ""); !errors.Is(err, ErrUnsupportedSort) {
 		t.Errorf("unsupported sort: got err %v, want ErrUnsupportedSort", err)
+	}
+}
+
+// newActivityPGStore returns a store plus its pool over a database truncated of
+// applications AND the per-user notification tables, so the recent-activity join
+// starts from a clean state. The pool is returned for raw notification seeding
+// (the store has no notification writer).
+func newActivityPGStore(t *testing.T) (*PostgresStore, *pgxpool.Pool) {
+	t.Helper()
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "applications", "notifications", "notification_state", "watch_zones")
+	return NewPostgresStore(pool), pool
+}
+
+// seedWatermark inserts the caller's notification read-watermark. Without a
+// watermark row the recent-activity join classifies nothing as unread (the
+// INNER JOIN to notification_state yields no rows), matching the handler's
+// first-touch rule.
+func seedWatermark(t *testing.T, pool *pgxpool.Pool, userID string, lastReadAt time.Time) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		"INSERT INTO notification_state (user_id, last_read_at) VALUES ($1, $2)",
+		userID, lastReadAt); err != nil {
+		t.Fatalf("seed watermark for %q: %v", userID, err)
+	}
+}
+
+// seedNotification inserts one notification for the caller. authorityID is the
+// INTEGER authority_id that the recent-activity join matches against the
+// application's area_id (NOT the text authority_code).
+func seedNotification(t *testing.T, pool *pgxpool.Pool, id, userID, appUID string, authorityID int, createdAt time.Time) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(),
+		"INSERT INTO notifications (id, user_id, application_uid, authority_id, event_type, created_at) "+
+			"VALUES ($1, $2, $3, $4, $5, $6)",
+		id, userID, appUID, authorityID, "NewApplication", createdAt); err != nil {
+		t.Fatalf("seed notification %q: %v", id, err)
+	}
+}
+
+// activityFixture seeds a deterministic in-radius set for the recent-activity
+// sort. The headline case: AA has the oldest start_date but a fresh UNREAD event,
+// so its activity timestamp (the unread's created_at) floats it above BB, which
+// has the newest start_date but no unread. CC and DD share an activity timestamp
+// (equal start_date, no unread) across two authorities to exercise the
+// (authority_code, planit_name) tiebreak; EE and FF have neither start_date nor
+// unread, so their activity is NULL (the NULLS-LAST tail).
+func activityFixture(t *testing.T, store *PostgresStore, pool *pgxpool.Pool, userID string) {
+	t.Helper()
+	ctx := context.Background()
+	jan := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	feb := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	jun := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	for _, a := range []PlanningApplication{
+		withStart(at(pgApp("AA", 100), 100), jan), // oldest start, but a fresh unread
+		withStart(at(pgApp("BB", 100), 200), jun), // newest start, no unread
+		withStart(at(pgApp("CC", 100), 300), feb), // equal activity to DD
+		withStart(at(pgApp("DD", 200), 350), feb), // equal date, other authority
+		at(pgApp("EE", 100), 400),                 // NULL start, no unread -> NULL activity
+		at(pgApp("FF", 100), 500),                 // NULL start, no unread -> NULL activity
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+	// Watermark well before the unread event so AA's notification is unread.
+	seedWatermark(t, pool, userID, jan)
+	// AA's unread event, later than BB's newest start_date, floats AA to the top.
+	seedNotification(t, pool, "n-AA", userID, "uid-AA", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+}
+
+// TestPostgresStore_FindInZonePage_RecentActivity proves the GREATEST(start_date,
+// unread.created_at) DESC NULLS LAST ordering with the (authority_code,
+// planit_name) tiebreak, paged to exhaustion with no overlap or gap, matches the
+// single unpaged order. The headline behaviour: an app with a fresh UNREAD event
+// (AA) sorts above an app with a newer start_date but no unread (BB).
+func TestPostgresStore_FindInZonePage_RecentActivity(t *testing.T) {
+	store, pool := newActivityPGStore(t)
+	const userID = "user-A"
+	activityFixture(t, store, pool, userID)
+
+	// AA(unread jun15) > BB(start jun01) > CC(feb,auth100) > DD(feb,auth200) >
+	// EE(NULL) > FF(NULL). AA above BB is the headline unread-floats-up case;
+	// CC before DD is the equal-activity authority tiebreak; EE/FF are the
+	// NULL-activity tail ordered by planit_name.
+	want := []string{"AA", "BB", "CC", "DD", "EE", "FF"}
+	if got := pageAllInZoneAs(t, store, userID, SortRecentActivity, 6000, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("recent-activity single page: got %v, want %v", got, want)
+	}
+	if got := pageAllInZoneAs(t, store, userID, SortRecentActivity, 6000, 2); !reflect.DeepEqual(got, want) {
+		t.Fatalf("recent-activity paged: got %v, want %v", got, want)
+	}
+	// Page size 1 forces a keyset boundary at every row, including inside the
+	// NULL-activity tail.
+	if got := pageAllInZoneAs(t, store, userID, SortRecentActivity, 6000, 1); !reflect.DeepEqual(got, want) {
+		t.Fatalf("recent-activity paged size 1: got %v, want %v", got, want)
+	}
+}
+
+// TestPostgresStore_FindInZonePage_RecentActivity_JoinKey proves the join keys on
+// (application_uid AND authority_id->area_id): a notification whose application_uid
+// matches but whose authority_id differs from the application's area_id must NOT
+// contribute to that app's activity. If it falsely joined, X's fresh unread would
+// float it above Y; correctly it does not, so Y (newer start_date) sorts first.
+func TestPostgresStore_FindInZonePage_RecentActivity_JoinKey(t *testing.T) {
+	store, pool := newActivityPGStore(t)
+	ctx := context.Background()
+	const userID = "user-A"
+	jan := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	feb := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	for _, a := range []PlanningApplication{
+		withStart(at(pgApp("X", 100), 100), jan), // area_id 100
+		withStart(at(pgApp("Y", 100), 200), feb), // newer start, no notification
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+	seedWatermark(t, pool, userID, jan)
+	// A fresh unread for X's uid but under the WRONG authority (999 != 100). The
+	// join requires area_id = authority_id, so this must not touch X's activity.
+	seedNotification(t, pool, "n-wrong", userID, "uid-X", 999, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+
+	want := []string{"Y", "X"} // Y(feb) > X(jan); the wrong-authority unread is ignored.
+	if got := pageAllInZoneAs(t, store, userID, SortRecentActivity, 6000, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("recent-activity join-key: got %v, want %v (a wrong-authority notification must not join)", got, want)
+	}
+}
+
+// TestPostgresStore_FindInZonePage_RecentActivity_FirstTouch proves a caller with
+// NO notification_state row has no unread anywhere (the INNER JOIN to
+// notification_state yields nothing), so recent-activity orders by start_date
+// alone — even when a matching notification exists.
+func TestPostgresStore_FindInZonePage_RecentActivity_FirstTouch(t *testing.T) {
+	store, pool := newActivityPGStore(t)
+	ctx := context.Background()
+	const userID = "user-firsttouch"
+	jan := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	feb := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	for _, a := range []PlanningApplication{
+		withStart(at(pgApp("P", 100), 100), jan), // matching notification, but no watermark
+		withStart(at(pgApp("Q", 100), 200), feb), // newer start, no notification
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+	// NOTE: no seedWatermark — the user has never read, so has no state row.
+	seedNotification(t, pool, "n-P", userID, "uid-P", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+
+	want := []string{"Q", "P"} // Q(feb) > P(jan); no watermark means P's notification is not unread.
+	if got := pageAllInZoneAs(t, store, userID, SortRecentActivity, 6000, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("recent-activity first-touch: got %v, want %v (no watermark means no unread influence)", got, want)
+	}
+}
+
+// TestPostgresStore_FindInZonePage_RecentActivity_StrictUnread proves the unread
+// predicate is a STRICT created_at > last_read_at: a notification created exactly
+// at the watermark is read, not unread, so it does not contribute to activity.
+func TestPostgresStore_FindInZonePage_RecentActivity_StrictUnread(t *testing.T) {
+	store, pool := newActivityPGStore(t)
+	ctx := context.Background()
+	const userID = "user-strict"
+	watermark := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	jan := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	feb := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	for _, a := range []PlanningApplication{
+		withStart(at(pgApp("M", 100), 100), jan), // notification exactly AT the watermark
+		withStart(at(pgApp("N", 100), 200), feb), // newer start, no notification
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+	seedWatermark(t, pool, userID, watermark)
+	// created_at == last_read_at: read, not unread (strict >), so M's activity is
+	// its start_date, not this timestamp.
+	seedNotification(t, pool, "n-M", userID, "uid-M", 100, watermark)
+
+	want := []string{"N", "M"} // N(feb) > M(jan); the at-watermark notification is read.
+	if got := pageAllInZoneAs(t, store, userID, SortRecentActivity, 6000, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("recent-activity strict-unread: got %v, want %v (a notification exactly at the watermark is read)", got, want)
 	}
 }
 

--- a/api-go/internal/applications/zonepage.go
+++ b/api-go/internal/applications/zonepage.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -277,6 +278,9 @@ func (s *PostgresStore) FindInZonePage(ctx context.Context, userID string, latit
 	if sort == SortStatus {
 		return s.findStatusZonePage(ctx, latitude, longitude, radiusMetres, limit, c)
 	}
+	if sort == SortRecentActivity {
+		return s.findRecentActivityZonePage(ctx, userID, latitude, longitude, radiusMetres, limit, c)
+	}
 	return s.findDateZonePage(ctx, latitude, longitude, radiusMetres, sort, limit, c)
 }
 
@@ -443,6 +447,144 @@ func statusCursorOf(last datePageRow) pageCursor {
 	if last.app.StartDate != nil {
 		sd := last.app.StartDate.Format("2006-01-02")
 		c.SD = &sd
+	}
+	return c
+}
+
+// activityUnreadSubquery computes, per application, the caller's latest UNREAD
+// notification timestamp. $5 is the caller's userID. The INNER JOIN to
+// notification_state is load-bearing: a user with no watermark row produces no
+// rows here, so "no notification_state ⇒ no unread anywhere" falls out naturally,
+// matching GetLatestUnreadByApplications and the handler's first-touch rule.
+// Unread is the strict created_at > last_read_at. It groups on (application_uid,
+// authority_id) — the same keys the outer LEFT JOIN matches against the
+// application's (uid, area_id) — so the integer authority_id (NOT the text
+// authority_code) is what reconciles a notification to its application.
+const activityUnreadSubquery = "SELECT n.application_uid, n.authority_id, MAX(n.created_at) AS created_at" +
+	" FROM notifications n" +
+	" JOIN notification_state ns ON ns.user_id = n.user_id" +
+	" WHERE n.user_id = $5 AND n.created_at > ns.last_read_at" +
+	" GROUP BY n.application_uid, n.authority_id"
+
+// activityExpr is the recent-activity sort key: the later of the application's
+// start_date (cast to timestamptz) and the caller's latest unread for it. Postgres
+// GREATEST ignores NULL inputs, so an app with no unread orders by start_date
+// alone, an app with a newer unread floats up, and an app with neither is NULL
+// (sorted last under NULLS LAST). u.created_at is the subquery's per-app unread
+// timestamp; start_date resolves to applications (no name collision with u).
+const activityExpr = "GREATEST(start_date::timestamptz, u.created_at)"
+
+// activityFromWhere is the shared SELECT + LEFT JOIN + spatial predicate for the
+// recent-activity sort. The projection is dateColumns (appColumns + authority_code,
+// matching scanActivityPageRow's app+ac scan) plus the computed activity_ts. $1 is
+// longitude and $2 latitude (via nearbyPoint), $3 the radius, $4 the limit, $5 the
+// userID (in the join subquery). The LEFT JOIN keeps apps with no unread (their
+// activity is start_date alone, or NULL).
+const activityFromWhere = "SELECT " + dateColumns + ", " + activityExpr + " AS activity_ts" +
+	" FROM applications" +
+	" LEFT JOIN (" + activityUnreadSubquery + ") u" +
+	" ON applications.uid = u.application_uid AND applications.area_id = u.authority_id" +
+	" WHERE ST_DWithin(location, " + nearbyPoint + ", $3)"
+
+// activityOrderBy is the ORDER BY + LIMIT suffix for SortRecentActivity. NULLS LAST
+// keeps NULL-activity rows after every active row; (authority_code, planit_name) is
+// the unique tiebreak.
+const activityOrderBy = " ORDER BY " + activityExpr + " DESC NULLS LAST, authority_code, planit_name LIMIT $4"
+
+// recentActivityFirstQuery is the recent-activity first page: join + spatial
+// predicate, ordered, limited.
+const recentActivityFirstQuery = activityFromWhere + activityOrderBy
+
+// Keyset queries resuming after a cursor. The predicate exactly mirrors the DESC
+// NULLS LAST order so pages never overlap or gap: rows further along the activity
+// order, OR all NULL-activity rows (they trail in NULLS LAST), OR an equal-activity
+// row past the (authority_code, planit_name) tiebreak. The GREATEST expression is
+// repeated inline because Postgres cannot reference the SELECT alias in WHERE.
+const (
+	// $6 the cursor's activity_ts (::timestamptz), $7 authority_code, $8 planit_name.
+	recentActivityKeysetQuery = activityFromWhere +
+		" AND (" + activityExpr + " < $6::timestamptz OR " + activityExpr + " IS NULL" +
+		" OR (" + activityExpr + " = $6::timestamptz AND (authority_code, planit_name) > ($7, $8)))" +
+		activityOrderBy
+	// $6 authority_code, $7 planit_name. Cursor in the NULL-activity tail, where the
+	// only remaining order is the (authority_code, planit_name) tiebreak.
+	recentActivityKeysetNullQuery = activityFromWhere +
+		" AND " + activityExpr + " IS NULL AND (authority_code, planit_name) > ($6, $7)" +
+		activityOrderBy
+)
+
+// activityPageRow carries a hydrated application plus its authority_code and the
+// computed recent-activity timestamp (NULL when the app has neither a start_date
+// nor an unread), so the last row of a full page can be encoded into the next-page
+// keyset cursor.
+type activityPageRow struct {
+	app      PlanningApplication
+	ac       string
+	activity *time.Time
+}
+
+func scanActivityPageRow(row pgx.CollectableRow) (activityPageRow, error) {
+	var r activityPageRow
+	dest := append(appScanDest(&r.app), &r.ac, &r.activity)
+	if err := row.Scan(dest...); err != nil {
+		return activityPageRow{}, err
+	}
+	return r, nil
+}
+
+// findRecentActivityZonePage serves SortRecentActivity: the GREATEST(start_date,
+// unread.created_at) DESC NULLS LAST query with a keyset cursor on (activity_ts,
+// authority_code, planit_name). userID scopes the joined unread notifications.
+func (s *PostgresStore) findRecentActivityZonePage(ctx context.Context, userID string, latitude, longitude, radiusMetres float64, limit int, c *pageCursor) ([]PlanningApplication, string, error) {
+	query, args := recentActivityZoneQuery(userID, latitude, longitude, radiusMetres, limit, c)
+	rows, err := s.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("find applications by %s near (%v, %v): %w", SortRecentActivity, latitude, longitude, err)
+	}
+	collected, err := pgx.CollectRows(rows, scanActivityPageRow)
+	if err != nil {
+		return nil, "", fmt.Errorf("find applications by %s near (%v, %v): %w", SortRecentActivity, latitude, longitude, err)
+	}
+	apps := make([]PlanningApplication, len(collected))
+	for i := range collected {
+		apps[i] = collected[i].app
+	}
+	next := ""
+	if limit > 0 && len(collected) == limit {
+		next, err = encodePageCursor(activityCursorOf(collected[len(collected)-1]))
+		if err != nil {
+			return nil, "", fmt.Errorf("encode %s cursor: %w", SortRecentActivity, err)
+		}
+	}
+	return apps, next, nil
+}
+
+// recentActivityZoneQuery selects the first-page, non-null-keyset, or
+// NULL-tail-keyset query and assembles its positional args. The base args ($1..$5)
+// are longitude, latitude, radius, limit, userID; the keyset args extend them.
+func recentActivityZoneQuery(userID string, latitude, longitude, radiusMetres float64, limit int, c *pageCursor) (string, []any) {
+	base := []any{longitude, latitude, radiusMetres, limit, userID}
+	switch {
+	case c == nil:
+		return recentActivityFirstQuery, base
+	case c.TS == nil:
+		// Cursor sits in the NULL-activity tail: keyset on the tiebreak only.
+		return recentActivityKeysetNullQuery, append(base, c.AC, c.N)
+	default:
+		return recentActivityKeysetQuery, append(base, *c.TS, c.AC, c.N)
+	}
+}
+
+// activityCursorOf builds the next-page keyset cursor from the last row of a full
+// recent-activity page: its activity timestamp (nil for a NULL-activity tail row),
+// authority_code, and planit_name. The timestamp is formatted as RFC3339Nano in
+// UTC so the next predicate compares against an unambiguous ::timestamptz at the
+// same instant the database produced.
+func activityCursorOf(last activityPageRow) pageCursor {
+	c := pageCursor{M: SortRecentActivity, AC: last.ac, N: last.app.Name}
+	if last.activity != nil {
+		ts := last.activity.UTC().Format(time.RFC3339Nano)
+		c.TS = &ts
 	}
 	return c
 }

--- a/api-go/internal/applications/zonepage.go
+++ b/api-go/internal/applications/zonepage.go
@@ -16,9 +16,8 @@ import (
 // cursor are both this type, so a cursor minted under one sort can be rejected
 // when replayed under another (see FindInZonePage and ErrCursorSortMismatch).
 //
-// Slices 1-2 (epic #682) implement {distance, newest, oldest, status}. The
-// remaining UI sort (recent-activity) arrives in a later slice; until then it is
-// rejected as unsupported.
+// Slices 1-3 (epic #682) implement {distance, newest, oldest, status,
+// recent-activity} — the full UI sort set.
 type Sort string
 
 const (
@@ -37,12 +36,21 @@ const (
 	// directions (app_state ASC / start_date DESC) make the keyset predicate
 	// per-key (see findStatusZonePage).
 	SortStatus Sort = "status"
+	// SortRecentActivity orders by GREATEST(start_date::timestamptz, the caller's
+	// latest unread notification for the application) DESC NULLS LAST, then the
+	// unique tiebreak (authority_code, planit_name). It is per-user: the unread
+	// timestamp comes from a LEFT JOIN of the caller's notifications, so an app
+	// with a fresh unread floats above an app with a newer start_date but no
+	// unread (see findRecentActivityZonePage).
+	SortRecentActivity Sort = "recent-activity"
 )
 
-// Supported reports whether s is a sort this slice implements server-side.
+// Supported reports whether s is a server-side sort. The set is the five UI
+// sorts; anything else is rejected so the handler returns 400 rather than
+// running an arbitrary order.
 func (s Sort) Supported() bool {
 	switch s {
-	case SortDistance, SortNewest, SortOldest, SortStatus:
+	case SortDistance, SortNewest, SortOldest, SortStatus, SortRecentActivity:
 		return true
 	default:
 		return false
@@ -71,16 +79,20 @@ var (
 //     (authority_code) + N (planit_name).
 //   - status: AS (app_state, nil for a NULL-app_state tail row) + SD (start_date,
 //     nil for a NULL-start_date tail row) + AC (authority_code) + N (planit_name).
+//   - recent-activity: TS (the activity timestamp, nil for a NULL-activity tail
+//     row) + AC (authority_code) + N (planit_name).
 //
-// It is base64url-encoded JSON. AS and SD use a nil pointer (omitted field) to
-// mean a NULL key value, so the next page's predicate can pick the matching
+// It is base64url-encoded JSON. AS, SD and TS use a nil pointer (omitted field)
+// to mean a NULL key value, so the next page's predicate can pick the matching
 // NULLS-LAST tail branch. SD is a "2006-01-02" date string so the predicate
-// compares against an unambiguous ::date, not a timezone-laden timestamp.
+// compares against an unambiguous ::date, not a timezone-laden timestamp; TS is
+// an RFC3339Nano timestamp string compared against a ::timestamptz.
 type pageCursor struct {
 	M  Sort    `json:"m"`
 	D  string  `json:"d,omitempty"`
 	AS *string `json:"as,omitempty"`
 	SD *string `json:"sd,omitempty"`
+	TS *string `json:"ts,omitempty"`
 	AC string  `json:"ac,omitempty"`
 	N  string  `json:"n"`
 }

--- a/api-go/internal/applications/zonepage.go
+++ b/api-go/internal/applications/zonepage.go
@@ -253,7 +253,10 @@ func scanDatePageRow(row pgx.CollectableRow) (datePageRow, error) {
 // cursor embeds the sort mode: replaying it under a different sort returns
 // ErrCursorSortMismatch, and a malformed cursor returns ErrCursorInvalid, so the
 // caller can return 400 rather than a mis-ordered page. It is authority-agnostic.
-func (s *PostgresStore) FindInZonePage(ctx context.Context, latitude, longitude, radiusMetres float64, sort Sort, limit int, cursor string) ([]PlanningApplication, string, error) {
+//
+// userID scopes the per-user data the recent-activity sort joins (the caller's
+// latest unread notification per application). The other sorts ignore it.
+func (s *PostgresStore) FindInZonePage(ctx context.Context, userID string, latitude, longitude, radiusMetres float64, sort Sort, limit int, cursor string) ([]PlanningApplication, string, error) {
 	if !sort.Supported() {
 		return nil, "", fmt.Errorf("sort %q: %w", sort, ErrUnsupportedSort)
 	}

--- a/api-go/internal/applications/zonepage_test.go
+++ b/api-go/internal/applications/zonepage_test.go
@@ -7,13 +7,15 @@ import (
 
 // TestPageCursor_RoundTrip proves the sort-aware keyset cursor survives an
 // encode/decode round-trip for every shape: a distance keyset, a non-null
-// start_date keyset, a NULL start_date keyset (the tail of a NULLS LAST scan), and
+// start_date keyset, a NULL start_date keyset (the tail of a NULLS LAST scan),
 // each of the four status keyset NULL-tail positions (the mixed-direction keyset
-// carries an extra nullable app_state key).
+// carries an extra nullable app_state key), and the recent-activity keyset
+// (a nullable activity timestamp + tiebreak, with its NULL-activity tail).
 func TestPageCursor_RoundTrip(t *testing.T) {
 	t.Parallel()
 	sd := "2026-01-02"
 	as := "Permitted"
+	ts := "2026-06-15T12:30:00Z"
 	tests := []struct {
 		name string
 		in   pageCursor
@@ -26,6 +28,8 @@ func TestPageCursor_RoundTrip(t *testing.T) {
 		{"status date-null tail", pageCursor{M: SortStatus, AS: &as, SD: nil, AC: "100", N: "24/0006/FUL"}},
 		{"status state-null tail", pageCursor{M: SortStatus, AS: nil, SD: &sd, AC: "200", N: "24/0007/FUL"}},
 		{"status both-null tail", pageCursor{M: SortStatus, AS: nil, SD: nil, AC: "300", N: "24/0008/FUL"}},
+		{"recent-activity non-null", pageCursor{M: SortRecentActivity, TS: &ts, AC: "100", N: "24/0009/FUL"}},
+		{"recent-activity null tail", pageCursor{M: SortRecentActivity, TS: nil, AC: "400", N: "24/0010/FUL"}},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -53,7 +57,31 @@ func TestPageCursor_RoundTrip(t *testing.T) {
 			if got.SD != nil && *got.SD != *tc.in.SD {
 				t.Errorf("SD: got %q, want %q", *got.SD, *tc.in.SD)
 			}
+			if (got.TS == nil) != (tc.in.TS == nil) {
+				t.Fatalf("TS nil mismatch: got %v, want %v", got.TS, tc.in.TS)
+			}
+			if got.TS != nil && *got.TS != *tc.in.TS {
+				t.Errorf("TS: got %q, want %q", *got.TS, *tc.in.TS)
+			}
 		})
+	}
+}
+
+// TestSort_Supported pins the server-side sort set: the five UI sorts are
+// supported (distance, newest, oldest, status, recent-activity); anything else
+// is rejected so the handler returns 400 rather than running an arbitrary order.
+func TestSort_Supported(t *testing.T) {
+	t.Parallel()
+	supported := []Sort{SortDistance, SortNewest, SortOldest, SortStatus, SortRecentActivity}
+	for _, s := range supported {
+		if !s.Supported() {
+			t.Errorf("Sort(%q).Supported() = false, want true", s)
+		}
+	}
+	for _, s := range []Sort{"", "nonsense", "DISTANCE", "Newest", "recentactivity"} {
+		if s.Supported() {
+			t.Errorf("Sort(%q).Supported() = true, want false", s)
+		}
 	}
 }
 

--- a/api-go/internal/platform/postgres/migrations/0014_recent_activity_notification_index.sql
+++ b/api-go/internal/platform/postgres/migrations/0014_recent_activity_notification_index.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+
+-- Btree index backing the recent-activity sort's per-user latest-unread subquery
+-- (epic #682 slice 3). That subquery is:
+--
+--   SELECT application_uid, authority_id, MAX(created_at)
+--   FROM notifications n JOIN notification_state ns ON ns.user_id = n.user_id
+--   WHERE n.user_id = $1 AND n.created_at > ns.last_read_at
+--   GROUP BY application_uid, authority_id
+--
+-- Migration 0007 already indexes notifications (user_id, created_at) — that serves
+-- the user_id equality + created_at range filter, but it has no application_uid, so
+-- the per-application GROUP BY + MAX(created_at) still needs a sort/aggregate over
+-- the filtered set. This composite leads with user_id (the equality key), then
+-- application_uid (the group key), then created_at DESC (so MAX per app is the
+-- first entry in each group), letting Postgres satisfy the per-app newest-unread
+-- reduction from the index. authority_id is the secondary group key but is
+-- effectively functionally dependent on application_uid (a PlanIt uid belongs to
+-- one authority), so it is left out to keep the index narrow.
+CREATE INDEX IF NOT EXISTS notifications_user_app_created
+    ON notifications (user_id, application_uid, created_at DESC);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS notifications_user_app_created;

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -55,11 +55,12 @@ type authorityResolver interface {
 //
 // FindNearbyPage is the legacy default-distance path (byte-identical param-less
 // contract). FindInZonePage adds the server-side ?sort= surface (epic #682 slices
-// 1-2: distance/newest/oldest/status) with a sort-aware keyset cursor.
-// *applications.PostgresStore satisfies both.
+// 1-3: distance/newest/oldest/status/recent-activity) with a sort-aware keyset
+// cursor; userID scopes the per-user notification join the recent-activity sort
+// needs. *applications.PostgresStore satisfies both.
 type appFinder interface {
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]applications.PlanningApplication, string, error)
-	FindInZonePage(ctx context.Context, latitude, longitude, radiusMetres float64, sort applications.Sort, limit int, cursor string) ([]applications.PlanningApplication, string, error)
+	FindInZonePage(ctx context.Context, userID string, latitude, longitude, radiusMetres float64, sort applications.Sort, limit int, cursor string) ([]applications.PlanningApplication, string, error)
 }
 
 // watermarkReader reads the caller's notification read-watermark. A nil return
@@ -323,7 +324,7 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apps, nextCursor, err := h.findZonePage(r.Context(), zone, sort, sortPresent, r.URL.Query().Get("limit"), cursor)
+	apps, nextCursor, err := h.findZonePage(r.Context(), "", zone, sort, sortPresent, r.URL.Query().Get("limit"), cursor)
 	if err != nil {
 		// A stale or sort-mismatched cursor is a client error (400), not a 500: the
 		// keyset cursor is only valid for the sort it was minted under.
@@ -386,15 +387,16 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 // findZonePage runs the bounded spatial page for the zone. With no ?sort= it
 // keeps the legacy nearest-first finder at the 500 default (byte-identical
 // param-less contract); with ?sort= it uses the sort-aware finder at the 150
-// default and a sort-aware keyset cursor. rawLimit is the unparsed ?limit= value;
-// cursor is the transport-unwrapped continuation token.
-func (h *handler) findZonePage(ctx context.Context, zone WatchZone, sort applications.Sort, sortPresent bool, rawLimit, cursor string) ([]applications.PlanningApplication, string, error) {
+// default and a sort-aware keyset cursor. userID scopes the per-user notification
+// join the recent-activity sort needs (ignored by the other sorts). rawLimit is
+// the unparsed ?limit= value; cursor is the transport-unwrapped continuation token.
+func (h *handler) findZonePage(ctx context.Context, userID string, zone WatchZone, sort applications.Sort, sortPresent bool, rawLimit, cursor string) ([]applications.PlanningApplication, string, error) {
 	if !sortPresent {
 		limit := parseLimit(rawLimit, defaultNearbyLimit)
 		return h.apps.FindNearbyPage(ctx, zone.Latitude, zone.Longitude, zone.RadiusMetres, limit, cursor)
 	}
 	limit := parseLimit(rawLimit, defaultSortedLimit)
-	return h.apps.FindInZonePage(ctx, zone.Latitude, zone.Longitude, zone.RadiusMetres, sort, limit, cursor)
+	return h.apps.FindInZonePage(ctx, userID, zone.Latitude, zone.Longitude, zone.RadiusMetres, sort, limit, cursor)
 }
 
 // parseLimit resolves ?limit= to a bounded page size: absent, non-numeric, or

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -148,8 +148,7 @@ const (
 const invalidCursorMessage = "Invalid cursor."
 
 // invalidSortMessage is the 400 body when ?sort= is outside the supported set
-// ({distance, newest, oldest, status} for this slice; recent-activity arrives in a
-// later slice).
+// ({distance, newest, oldest, status, recent-activity}).
 const invalidSortMessage = "Invalid sort."
 
 // valid reports whether the create request passes the pre-handler guard:
@@ -295,7 +294,8 @@ type latestUnreadEventWire struct {
 // Routing: a param-less call (no ?sort=) keeps the legacy nearest-first path
 // (FindNearbyPage, default 500) byte-identical for the in-review iOS build (#541).
 // A ?sort= call opts into the server-side sort surface (FindInZonePage, default
-// 150) with a sort-aware keyset cursor (epic #682 slice 1).
+// 150) with a sort-aware keyset cursor (epic #682 slices 1-3; recent-activity
+// joins the caller's own notifications via the threaded userID).
 func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 	zoneID := r.PathValue("zoneId")
@@ -324,7 +324,7 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apps, nextCursor, err := h.findZonePage(r.Context(), "", zone, sort, sortPresent, r.URL.Query().Get("limit"), cursor)
+	apps, nextCursor, err := h.findZonePage(r.Context(), userID, zone, sort, sortPresent, r.URL.Query().Get("limit"), cursor)
 	if err != nil {
 		// A stale or sort-mismatched cursor is a client error (400), not a 500: the
 		// keyset cursor is only valid for the sort it was minted under.
@@ -420,10 +420,9 @@ func parseLimit(raw string, def int) int {
 
 // parseSort resolves ?sort= to a supported Sort. An absent value defaults to
 // SortDistance (the legacy nearest-first behaviour). The boolean reports whether
-// the value is supported in this slice ({distance, newest, oldest, status}); an
-// unsupported value (recent-activity or garbage) is a clean 400. The caller treats
-// an absent value (ok with SortDistance and present=false) as the legacy param-less
-// path.
+// the value is supported ({distance, newest, oldest, status, recent-activity});
+// an unsupported value (garbage) is a clean 400. The caller treats an absent value
+// (ok with SortDistance and present=false) as the legacy param-less path.
 func parseSort(raw string) (sort applications.Sort, present, ok bool) {
 	if raw == "" {
 		return applications.SortDistance, false, true

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -51,6 +51,7 @@ type fakeAppFinder struct {
 	lastSort     applications.Sort
 	lastLimit    int
 	lastCursor   string
+	lastUserID   string
 }
 
 func (f *fakeAppFinder) FindNearbyPage(_ context.Context, _, _, _ float64, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
@@ -71,8 +72,9 @@ func (f *fakeAppFinder) FindNearbyPage(_ context.Context, _, _, _ float64, limit
 	return apps, f.next, nil
 }
 
-func (f *fakeAppFinder) FindInZonePage(_ context.Context, _, _, _ float64, sort applications.Sort, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
+func (f *fakeAppFinder) FindInZonePage(_ context.Context, userID string, _, _, _ float64, sort applications.Sort, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
 	f.inZoneCalled = true
+	f.lastUserID = userID
 	f.lastSort = sort
 	f.lastLimit = limit
 	f.lastCursor = cursor
@@ -840,6 +842,7 @@ func TestApplications_SortRoutesToSortAwarePath(t *testing.T) {
 		{"?sort=newest", applications.SortNewest},
 		{"?sort=oldest", applications.SortOldest},
 		{"?sort=status", applications.SortStatus},
+		{"?sort=recent-activity", applications.SortRecentActivity},
 	}
 	for _, tc := range tests {
 		t.Run(tc.query, func(t *testing.T) {
@@ -864,6 +867,45 @@ func TestApplications_SortRoutesToSortAwarePath(t *testing.T) {
 				t.Errorf("sort-aware default limit: got %d, want 150", apps.lastLimit)
 			}
 		})
+	}
+}
+
+// TestApplications_RecentActivityThreadsUserID proves a ?sort=recent-activity
+// request is accepted (200), routes to the sort-aware finder, and threads the
+// authenticated subject through to the store — recent-activity joins the caller's
+// own notifications, so the wrong userID would surface another user's unread data.
+func TestApplications_RecentActivityThreadsUserID(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{}
+	mux := newNearbyMux(t, sortDeps(t, apps))
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?sort=recent-activity", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if !apps.inZoneCalled {
+		t.Fatal("recent-activity must use the sort-aware FindInZonePage path")
+	}
+	if apps.lastSort != applications.SortRecentActivity {
+		t.Errorf("sort: got %q, want recent-activity", apps.lastSort)
+	}
+	if apps.lastUserID != testUser {
+		t.Errorf("userID threaded to store: got %q, want %q", apps.lastUserID, testUser)
+	}
+}
+
+// TestApplications_RecentActivityCursorMismatchIs400 proves a recent-activity
+// cursor replayed under another sort (store reports ErrCursorSortMismatch)
+// surfaces as 400, never a mis-ordered page.
+func TestApplications_RecentActivityCursorMismatchIs400(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{inZoneErr: applications.ErrCursorSortMismatch}
+	mux := newNearbyMux(t, sortDeps(t, apps))
+
+	cursor := base64.RawURLEncoding.EncodeToString([]byte("recent-activity-cursor"))
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?sort=newest&cursor="+cursor, "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", rec.Code)
 	}
 }
 
@@ -898,12 +940,12 @@ func TestApplications_SortAwareLimitParsing(t *testing.T) {
 	}
 }
 
-// TestApplications_UnknownSortIs400 proves any sort outside this slice's set —
-// including the valid-future value recent-activity — is rejected with 400 before
-// any spatial query runs.
+// TestApplications_UnknownSortIs400 proves any sort outside the supported set is
+// rejected with 400 before any spatial query runs. recent-activity is now
+// supported (slice 3), so it is not in this set.
 func TestApplications_UnknownSortIs400(t *testing.T) {
 	t.Parallel()
-	for _, sortVal := range []string{"recent-activity", "nonsense", "DISTANCE", "Newest"} {
+	for _, sortVal := range []string{"nonsense", "DISTANCE", "Newest", "recentactivity"} {
 		t.Run(sortVal, func(t *testing.T) {
 			t.Parallel()
 			apps := &fakeAppFinder{}


### PR DESCRIPTION
## What

Slice 3 (API) of epic #682 — the `recent-activity` sort, the per-user one. Orders by the later of the application's `start_date` and the caller's latest **unread** notification for it.

- `?sort=recent-activity` ⇒ `ORDER BY GREATEST(start_date::timestamptz, u.created_at) DESC NULLS LAST, authority_code, planit_name`, keyset on `(activity_ts, authority_code, planit_name)`; `pageCursor` gains a `ts` (RFC3339Nano) field. Existing cursors unchanged.
- Unread is a `LEFT JOIN` to `SELECT application_uid, authority_id, MAX(created_at) FROM notifications n JOIN notification_state ns ON ns.user_id=n.user_id WHERE n.user_id=$userID AND n.created_at > ns.last_read_at GROUP BY application_uid, authority_id`, joined on **`applications.uid = u.application_uid AND applications.area_id = u.authority_id`** (`authority_id` is INTEGER ↔ `area_id`, **not** text `authority_code`).
- Matches existing unread semantics: strict `>` watermark; the INNER JOIN to `notification_state` means a first-touch user (no watermark row) has no unread, so recent-activity falls back to `start_date` ordering.
- `FindInZonePage` gains a `userID` param (consumed only by recent-activity now; slice 4's unread filter reuses it); other sorts ignore it.
- goose `0014_recent_activity_notification_index.sql`: `notifications (user_id, application_uid, created_at DESC)` — additive (0007's `(user_id, created_at)` doesn't cover the per-application MAX).

distance stays default; param-less byte-identical. Filters remain out of scope (slice 4).

## Tests (pgtest `//go:build integration`, run by `go-integration` pr-gate)

Exhaustion vs. unpaged ordered query (NULLS-LAST tail); **headline**: a newer unread floats an app above one with a newer `start_date` but no unread; **join-key**: a notification with matching uid but different `authority_id` does NOT join; **first-touch**: no `notification_state` ⇒ `start_date` order only; strict `>` watermark (at-watermark = read). Handler: `?sort=recent-activity` now 200, cursor-sort mismatch 400, param-less golden intact.

## Flagged (filed as follow-up, not fixed here — pre-existing)

The per-page `latestUnreadEvent` display badge keys on uid alone, while this ordering join keys on `(uid, authority_id)`; a cross-authority uid collision could disagree. Out of slice-3 scope.

Epic: #682 · Bead: tc-s0oo