### PR TITLE
feat(ios): wire watch-zone list recent-activity sort to the server (tc-fhqo, #682 slice 3)

### DIFF
--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/ApplicationSortOrder.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/ApplicationSortOrder.swift
@@ -1,7 +1,7 @@
 /// The server-supported sort orders for the paged watch-zone applications
-/// endpoint. Raw values are the `?sort=` query vocabulary the API accepts
-/// (GH#682 slices 1-2) — `recent-activity` is still computed client-side and is
-/// *not* representable here.
+/// endpoint. Raw values are the `?sort=` query vocabulary the API accepts. With
+/// `recent-activity` promoted to the server (GH#682 slice 3, #692) all five UI
+/// sorts are representable here and the client computes none locally.
 public enum ApplicationSortOrder: String, Sendable, CaseIterable {
   /// Nearest-first via the KNN `<->` operator. The server default and cheapest
   /// plan; matches the param-less legacy behaviour.
@@ -14,4 +14,9 @@ public enum ApplicationSortOrder: String, Sendable, CaseIterable {
   /// stable unique tiebreak (GH#682 slice 2). The server owns this ordering —
   /// the client must not re-sort the fetched pages by `app_state` locally.
   case status
+  /// `GREATEST(start_date, unread.created_at) DESC NULLS LAST`, with a stable
+  /// unique tiebreak (GH#682 slice 3, #692). The server joins the caller's
+  /// unread notifications and owns the ordering — the client must not re-derive
+  /// `max(startDate, latestUnreadEvent.createdAt)` over the fetched pages.
+  case recentActivity = "recent-activity"
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+Pagination.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+Pagination.swift
@@ -1,19 +1,19 @@
 import Foundation
 import TownCrierDomain
 
-/// Infinite-scroll pagination for the watch-zone list (GH#682 slices 1-2). Split
-/// out of `ApplicationListViewModel` to keep that file under SwiftLint's
-/// `file_length` ceiling. For the server-supported sorts
-/// (distance/newest/oldest/status) the server owns the ordering and the list
-/// follows `X-Next-Cursor` to the end; the remaining client-side sort
-/// (recent-activity) keeps its param-less single-page path.
+/// Infinite-scroll pagination for the watch-zone list (GH#682). Split out of
+/// `ApplicationListViewModel` to keep that file under SwiftLint's `file_length`
+/// ceiling. Every UI sort is server-driven now — distance/newest/oldest
+/// (slice 1), status (slice 2) and recent-activity (slice 3, #692) — so the
+/// server owns the ordering and the list follows `X-Next-Cursor` to the end for
+/// all of them. The `serverOrder == nil` fallback below is dormant defensive
+/// plumbing kept generic should a future client-only sort ever be added.
 extension ApplicationListViewModel {
 
-  /// Loads the active zone's first page via the path appropriate to the current
-  /// sort. The server-supported sorts (distance/newest/oldest/status) fetch a
-  /// server-ordered page and capture the next-page cursor; the client-side
-  /// `recent-activity` sort keeps the legacy param-less first-page fetch. Either
-  /// way the cursor resets, so pagination always restarts cleanly.
+  /// Loads the active zone's first page in the server-ordered, cursor-paged way:
+  /// fetch the first page for the current sort and capture its next-page cursor.
+  /// The cursor resets here, so pagination always restarts cleanly on a fresh
+  /// load or sort change.
   func loadActiveZone(_ zone: WatchZone) async throws {
     if let order = sort.serverOrder {
       let page = try await fetchPage(for: zone, sort: order, cursor: nil)
@@ -47,10 +47,9 @@ extension ApplicationListViewModel {
   }
 
   /// Called by the list as each row appears. Kicks off the next-page fetch when
-  /// a server sort is active, more pages remain, and the appearing row is within
-  /// ``prefetchThreshold`` of the end of the loaded set. A no-op for the
-  /// client-side `recent-activity` sort, which holds the whole (first-page) set
-  /// already.
+  /// more pages remain (a cursor is held) and the appearing row is within
+  /// ``prefetchThreshold`` of the end of the loaded set. Every sort is
+  /// server-driven now, so this drives infinite scroll for all of them.
   public func onRowAppear(_ application: PlanningApplication) async {
     guard sort.isServerSorted, nextCursor != nil, !isPageLoadInFlight else { return }
     guard let index = applications.firstIndex(where: { $0.id == application.id }) else { return }
@@ -58,14 +57,11 @@ extension ApplicationListViewModel {
     await loadNextPage()
   }
 
-  /// Reacts to a sort change from the toolbar. A server sort — or any transition
-  /// away from one — reloads from page 1 with a fresh cursor so the list re-pages
-  /// in the new order. A switch that stays entirely client-side only changes the
-  /// in-memory ordering, so it skips the refetch (unchanged from the
-  /// pre-pagination behaviour). Since slice 2 promoted `status` to the server,
-  /// `recent-activity` is the only remaining client-side sort, so that branch
-  /// now only guards a `recent-activity` self-change. The cursor and
-  /// `loadedSort` reset happen inside the reload.
+  /// Reacts to a sort change from the toolbar. Every sort is server-driven now
+  /// (GH#682 slice 3), so any change to a different sort reloads from page 1 with
+  /// a fresh cursor and re-pages in the new order; the cursor and `loadedSort`
+  /// reset happen inside the reload. The `!newIsServer && !oldWasServer` branch
+  /// is dormant defensive plumbing for a hypothetical future client-only sort.
   public func handleSortChanged() async {
     guard sort != loadedSort else { return }
     let newIsServer = sort.isServerSorted

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -9,9 +9,10 @@ import TownCrierDomain
 /// Owns the unread-watermark plumbing (tc-1nsa.8) when a
 /// ``NotificationStateRepository`` is injected: derives the per-zone unread
 /// count client-side from each row's `latestUnreadEvent` (tc-e9ox), exposes
-/// the four sort modes from the spec, drives the Mark-All-Read toolbar
-/// action, and supplies an Unread filter that mirrors the web bead's
-/// single-select status-chip group.
+/// the five sort modes (all server-driven and paged since GH#682 slice 3),
+/// drives the Mark-All-Read toolbar action, and supplies an Unread filter
+/// that mirrors the web bead's single-select status-chip group. Ordering is
+/// the server's; only the status/unread filter stays client-side (slice 4).
 @MainActor
 public final class ApplicationListViewModel: ObservableObject, ErrorHandlingViewModel {
   // `internal(set)` (the default for this non-public property) rather than

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -127,9 +127,13 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     }
   }
 
+  /// The rows to render: the loaded `applications` with the client-side
+  /// status/unread filter applied. Ordering is owned entirely by the server
+  /// (every sort is paged via `?sort=` since GH#682 slice 3), so there is no
+  /// local re-sort — that would only ever order the pages already loaded. The
+  /// status/unread filter stays client-side until slice 4.
   public var filteredApplications: [PlanningApplication] {
-    let base = filterApplications(applications)
-    return sortApplications(base, by: sort)
+    filterApplications(applications)
   }
 
   public var isEmpty: Bool {
@@ -329,36 +333,6 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
       return applications.filter { $0.status == filter }
     }
     return applications
-  }
-
-  private func sortApplications(
-    _ applications: [PlanningApplication],
-    by sort: ApplicationsSort
-  ) -> [PlanningApplication] {
-    switch sort {
-    case .recentActivity:
-      return applications.sorted { lhs, rhs in
-        recentActivityScore(lhs) > recentActivityScore(rhs)
-      }
-    case .distance, .newest, .oldest, .status:
-      // Server-ordered sorts arrive pre-sorted from the API and are paged via
-      // infinite scroll, so they are never re-sorted client-side — that would
-      // only ever order the pages already loaded (GH#682 slices 1-2). `status`
-      // joined this set in slice 2: the server orders by `app_state ASC NULLS
-      // LAST, start_date DESC`, and a local `app_state` re-sort would destroy
-      // that tiebreak. Identity preserves the server order and keeps the switch
-      // total.
-      return applications
-    }
-  }
-
-  /// `max(receivedDate, latestUnreadEvent.createdAt)` per spec decision #9 —
-  /// surfaces newly-decided rows alongside newly-received ones.
-  private func recentActivityScore(_ application: PlanningApplication) -> Date {
-    if let event = application.latestUnreadEvent {
-      return max(application.receivedDate, event.createdAt)
-    }
-    return application.receivedDate
   }
 
   private static func readPersistedSort(

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationsSort.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationsSort.swift
@@ -11,8 +11,10 @@ import TownCrierDomain
 /// Spec: `docs/specs/notifications-unread-watermark.md`, Pre-Resolved
 /// Decisions #9 (default sort) and #10 (4 client-side options persisted).
 public enum ApplicationsSort: String, CaseIterable, Sendable {
-  /// Default mode — orders by `max(receivedDate, latestUnreadEvent.createdAt)`
-  /// descending so newly-decided rows surface alongside newly-received ones.
+  /// Default mode — the server orders by
+  /// `GREATEST(start_date, unread.created_at) DESC` via the notification join
+  /// (GH#682 slice 3, #692) so newly-decided rows surface alongside
+  /// newly-received ones. Server-driven and paged like every other sort.
   case recentActivity = "recent-activity"
   /// Receive-date descending (the previous default before unread tracking).
   case newest = "newest"
@@ -27,10 +29,12 @@ public enum ApplicationsSort: String, CaseIterable, Sendable {
   /// hides this option in multi-zone "all" views (tc-mso6).
   case distance = "distance"
 
-  /// The server-side sort order the API can page in, or `nil` for the
-  /// client-only `recent-activity` sort, which this slice keeps computing
-  /// locally over the fetched page. Distance, newest, oldest, and status
-  /// (GH#682 slice 2) are server-driven and paged via infinite scroll.
+  /// The server-side sort order the API pages in. Every UI sort now maps to a
+  /// server order: distance/newest/oldest (GH#682 slice 1), status (slice 2),
+  /// and recent-activity (slice 3, #692). The client never sorts locally, so
+  /// this is non-`nil` for all cases. It stays `Optional` only so the paged
+  /// infinite-scroll plumbing in `+Pagination` can remain generic over a future
+  /// client-only sort, should one ever be added.
   public var serverOrder: ApplicationSortOrder? {
     switch self {
     case .distance:
@@ -42,12 +46,12 @@ public enum ApplicationsSort: String, CaseIterable, Sendable {
     case .status:
       return .status
     case .recentActivity:
-      return nil
+      return .recentActivity
     }
   }
 
   /// Whether the server owns the ordering (and therefore drives the paged
-  /// infinite-scroll path) for this sort.
+  /// infinite-scroll path) for this sort. True for every sort since slice 3.
   public var isServerSorted: Bool {
     serverOrder != nil
   }

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -123,7 +123,7 @@ struct AppCoordinatorTests {
 
     await vm.loadApplications()
 
-    #expect(spy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+    #expect(spy.fetchApplicationsPageCalls.first?.zone.id == WatchZone.cambridge.id)
   }
 
   @Test func applicationListViewModel_onApplicationSelected_fetchesAndSetsDetail() async {
@@ -160,7 +160,7 @@ struct AppCoordinatorTests {
     await vm.loadApplications()
 
     #expect(zoneSpy.loadAllCallCount == 1)
-    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+    #expect(appSpy.fetchApplicationsPageCalls.first?.zone.id == WatchZone.cambridge.id)
     #expect(vm.filteredApplications.count == 1)
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelConcurrentLoadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelConcurrentLoadTests.swift
@@ -33,14 +33,16 @@ struct ApplicationListViewModelConcurrentLoadTests {
     await Task.yield()
     await Task.yield()
 
-    // The guard means the in-flight fetch count is still exactly 1.
-    #expect(spy.fetchApplicationsCalls.count == 1)
+    // The guard means the in-flight fetch count is still exactly 1. The list is
+    // paged for every sort now (GH#682 slice 3), so the load drives the paged
+    // endpoint rather than the param-less fetch.
+    #expect(spy.fetchApplicationsPageCalls.count == 1)
 
     spy.releaseGate()
     await first.value
     await second.value
 
-    #expect(spy.fetchApplicationsCalls.count == 1)
+    #expect(spy.fetchApplicationsPageCalls.count == 1)
   }
 
   @Test func loadApplications_afterPriorLoadCompletes_fetchesAgain() async {
@@ -53,6 +55,6 @@ struct ApplicationListViewModelConcurrentLoadTests {
 
     // Sequential (non-overlapping) loads are still allowed — pull-to-refresh
     // after the first load completes must hit the network.
-    #expect(spy.fetchApplicationsCalls.count == 2)
+    #expect(spy.fetchApplicationsPageCalls.count == 2)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelMarkAllReadCacheTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelMarkAllReadCacheTests.swift
@@ -26,13 +26,16 @@ struct ApplicationListViewModelMarkAllReadCacheTests {
     SpyNotificationStateRepository
   ) {
     let remote = SpyPlanningApplicationRepository()
-    remote.fetchApplicationsResult = .success(refetchedApplications)
+    // The list path is paged for every sort now (GH#682 slice 3) and paging
+    // deliberately bypasses the offline cache, so the first load and the
+    // post-mark-all-read refetch are driven as successive server pages: the
+    // first carries the still-unread rows, the second the read rows the server
+    // returns once the watermark has advanced.
+    remote.pagedResponses = [
+      ApplicationPage(applications: cachedApplications, nextCursor: nil),
+      ApplicationPage(applications: refetchedApplications, nextCursor: nil),
+    ]
     let cache = SpyApplicationCacheStore()
-    cache.storedEntry = CacheEntry(
-      data: cachedApplications,
-      fetchedAt: Date().addingTimeInterval(-60),
-      ttlSeconds: 900
-    )
     let offlineRepository = OfflineAwareRepository(
       remote: remote,
       cache: cache,
@@ -56,10 +59,10 @@ struct ApplicationListViewModelMarkAllReadCacheTests {
     )
   }
 
-  /// Without invalidation, the refetch after the mark-all-read POST would
-  /// short-circuit on the TTL-fresh cache and the chip would stay stuck
-  /// at the prior count. The view-model must clear every cached zone
-  /// before refetching.
+  /// mark-all-read is a global mutation, so the view-model must clear every
+  /// cached zone before refetching. The paged list path bypasses the cache,
+  /// but the param-less map path still reads it, so the invalidation keeps that
+  /// cache from serving stale unread flags after the watermark advances.
   @Test func markAllRead_invalidatesEveryCachedZoneBeforeRefetch() async {
     let cachedUnread = PlanningApplication.pendingReview
       .withLatestUnreadEvent(event(at: 1_700_500_000))
@@ -78,11 +81,11 @@ struct ApplicationListViewModelMarkAllReadCacheTests {
     #expect(cache.invalidateAllCallCount == 1)
   }
 
-  /// End-to-end behavioural assertion: a TTL-fresh cache must not stop the
-  /// chip from zeroing after mark-all-read. With the invalidation in place,
-  /// the refetch goes to the network, returns rows with `latestUnreadEvent
-  /// == nil`, and `unreadCount` drops to 0 (tc-e3bu repro path).
-  @Test func markAllRead_zeroesUnreadCount_evenWhenCacheIsFresh() async {
+  /// End-to-end behavioural assertion (tc-e3bu contract, preserved through the
+  /// GH#682 slice 3 paged migration): after mark-all-read the paged refetch goes
+  /// to the network, returns rows with `latestUnreadEvent == nil`, and
+  /// `unreadCount` drops to 0 so the `Unread (N)` chip clears.
+  @Test func markAllRead_zeroesUnreadCount_viaPagedRefetch() async {
     let cachedUnread = PlanningApplication.pendingReview
       .withLatestUnreadEvent(event(at: 1_700_500_000))
     let refetchedRead = PlanningApplication.pendingReview
@@ -93,13 +96,13 @@ struct ApplicationListViewModelMarkAllReadCacheTests {
     )
 
     await sut.loadApplications()
-    let remoteCallsBeforeMar = remote.fetchApplicationsCalls.count
+    let remoteCallsBeforeMar = remote.fetchApplicationsPageCalls.count
     #expect(sut.unreadCount == 1)
 
     await sut.markAllRead()
 
     #expect(sut.unreadCount == 0)
     #expect(!sut.hasUnread)
-    #expect(remote.fetchApplicationsCalls.count > remoteCallsBeforeMar)
+    #expect(remote.fetchApplicationsPageCalls.count > remoteCallsBeforeMar)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelPaginationTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelPaginationTests.swift
@@ -4,12 +4,12 @@ import TownCrierDomain
 
 @testable import TownCrierPresentation
 
-/// Infinite-scroll pagination for the watch-zone list (GH#682 slice 1). For the
-/// three server-supported sorts (distance/newest/oldest) the ViewModel drives
+/// Infinite-scroll pagination for the watch-zone list (GH#682). Every UI sort
+/// is server-driven now — distance/newest/oldest (slice 1), status (slice 2)
+/// and recent-activity (slice 3) — so for all of them the ViewModel drives
 /// ordering from the server, follows `X-Next-Cursor` until it is absent, appends
 /// pages as the user nears the end, and resets the cursor when the sort changes.
-/// The client-side sorts (recent-activity/status) keep their param-less,
-/// single-page, client-sorted path unchanged.
+/// No sort is sorted or paged client-side any more.
 @Suite("ApplicationListViewModel — pagination (GH#682)")
 @MainActor
 struct ApplicationListViewModelPaginationTests {
@@ -240,28 +240,6 @@ struct ApplicationListViewModelPaginationTests {
     let last = try #require(spy.fetchApplicationsPageCalls.last)
     #expect(last.sort == .oldest)
     #expect(last.cursor == nil)
-  }
-
-  @Test("switching from client-side recent-activity to status drives the paged endpoint")
-  func switchingRecentActivityToStatus_usesPagedFetch() async throws {
-    // recent-activity stays client-side (param-less); status is now server-driven.
-    let spy = SpyPlanningApplicationRepository()
-    spy.fetchApplicationsResult = .success([.pendingReview, .permitted])
-    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
-    defaults.set(ApplicationsSort.recentActivity.rawValue, forKey: "test.raToStatus")
-    let sut = ApplicationListViewModel(
-      repository: spy, zone: .cambridge, userDefaults: defaults, sortKey: "test.raToStatus")
-
-    await sut.loadApplications()
-    #expect(spy.fetchApplicationsCalls.count == 1)
-    #expect(spy.fetchApplicationsPageCalls.isEmpty)
-
-    spy.pagedResponses = [ApplicationPage(applications: [.rejected, .pendingReview], nextCursor: nil)]
-    sut.sort = .status
-    await sut.handleSortChanged()
-
-    #expect(spy.fetchApplicationsPageCalls.count == 1)
-    #expect(spy.fetchApplicationsPageCalls.first?.sort == .status)
   }
 
   // MARK: - recent-activity is server-driven (GH#682 slice 3)

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelPaginationTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelPaginationTests.swift
@@ -264,21 +264,85 @@ struct ApplicationListViewModelPaginationTests {
     #expect(spy.fetchApplicationsPageCalls.first?.sort == .status)
   }
 
-  // MARK: - Client sorts keep the legacy path
+  // MARK: - recent-activity is server-driven (GH#682 slice 3)
 
-  @Test("a client-side sort keeps the param-less fetch and does not paginate")
-  func clientSort_usesParamlessFetch() async throws {
-    let spy = SpyPlanningApplicationRepository()
-    spy.fetchApplicationsResult = .success([.pendingReview, .permitted])
-    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
-    defaults.set(ApplicationsSort.recentActivity.rawValue, forKey: "test.clientSort")
-    let sut = ApplicationListViewModel(
-      repository: spy, zone: .cambridge, userDefaults: defaults, sortKey: "test.clientSort")
+  @Test("selecting recent-activity issues ?sort=recent-activity and paginates via the cursor")
+  func recentActivitySort_paginatesViaCursor() async throws {
+    // Pages are in the server's recent-activity order
+    // (GREATEST(start_date, unread.created_at) DESC), deliberately NOT in any
+    // local order, so a stray client re-sort would reorder them and fail this
+    // assertion. `sort.rawValue` is asserted rather than the enum case so the
+    // test compiles before the `ApplicationSortOrder.recentActivity` case lands.
+    let page1 = ApplicationPage(applications: [.rejected, .permitted], nextCursor: "ra-cursor-2")
+    let page2 = ApplicationPage(applications: [.withdrawn, .pendingReview], nextCursor: nil)
+    let (sut, spy) = try makeSUT(sort: .recentActivity, pages: [page1, page2])
 
     await sut.loadApplications()
+    #expect(spy.fetchApplicationsPageCalls.first?.sort.rawValue == "recent-activity")
+    #expect(spy.fetchApplicationsPageCalls.first?.cursor == nil)
+
     await sut.onRowAppear(.permitted)
 
-    #expect(spy.fetchApplicationsCalls.count == 1)
-    #expect(spy.fetchApplicationsPageCalls.isEmpty)
+    #expect(
+      sut.filteredApplications.map(\.id) == [
+        PlanningApplication.rejected, .permitted, .withdrawn, .pendingReview,
+      ].map(\.id)
+    )
+    #expect(spy.fetchApplicationsPageCalls.count == 2)
+    #expect(spy.fetchApplicationsPageCalls[1].sort.rawValue == "recent-activity")
+    #expect(spy.fetchApplicationsPageCalls[1].cursor == "ra-cursor-2")
+    #expect(spy.fetchApplicationsCalls.isEmpty)
+  }
+
+  @Test("recent-activity preserves the server order — no local max(startDate, unread) re-sort")
+  func recentActivitySort_preservesServerOrder() async throws {
+    // The server owns recent-activity ordering now; the client must render the
+    // API order verbatim. This set is deliberately not in any client-derivable
+    // order so a leftover `max(startDate, unread.createdAt)` sort would reorder it.
+    let serverOrdered = ApplicationPage(
+      applications: [.rejected, .pendingReview, .permitted], nextCursor: nil)
+    let (sut, _) = try makeSUT(sort: .recentActivity, pages: [serverOrdered])
+
+    await sut.loadApplications()
+
+    #expect(
+      sut.filteredApplications.map(\.id) == [
+        PlanningApplication.rejected, .pendingReview, .permitted,
+      ].map(\.id)
+    )
+  }
+
+  @Test("switching to recent-activity clears the cursor and reloads from page 1")
+  func switchingToRecentActivity_resetsCursorAndReloadsPageOne() async throws {
+    let newestPage = ApplicationPage(applications: [.pendingReview], nextCursor: "newest-cursor")
+    let (sut, spy) = try makeSUT(sort: .newest, pages: [newestPage])
+
+    await sut.loadApplications()
+    #expect(spy.fetchApplicationsPageCalls.last?.sort == .newest)
+
+    spy.pagedResponses = [ApplicationPage(applications: [.permitted], nextCursor: nil)]
+    sut.sort = .recentActivity
+    await sut.handleSortChanged()
+
+    let last = try #require(spy.fetchApplicationsPageCalls.last)
+    #expect(last.sort.rawValue == "recent-activity")
+    #expect(last.cursor == nil)
+  }
+
+  @Test("switching away from recent-activity clears the cursor and reloads from page 1")
+  func switchingFromRecentActivity_resetsCursorAndReloadsPageOne() async throws {
+    let raPage = ApplicationPage(applications: [.permitted], nextCursor: "ra-cursor")
+    let (sut, spy) = try makeSUT(sort: .recentActivity, pages: [raPage])
+
+    await sut.loadApplications()
+    #expect(spy.fetchApplicationsPageCalls.last?.sort.rawValue == "recent-activity")
+
+    spy.pagedResponses = [ApplicationPage(applications: [.rejected], nextCursor: nil)]
+    sut.sort = .oldest
+    await sut.handleSortChanged()
+
+    let last = try #require(spy.fetchApplicationsPageCalls.last)
+    #expect(last.sort == .oldest)
+    #expect(last.cursor == nil)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTests.swift
@@ -24,18 +24,18 @@ struct ApplicationListViewModelTests {
   ]
 
   // MARK: - Loading
-  @Test func loadApplications_populatesApplicationsSortedByDateDescending() async throws {
-    let older = PlanningApplication.pendingReview  // 1_700_000_000
-    let newer = PlanningApplication.permitted  // 1_700_100_000
-    let newest = PlanningApplication.rejected  // 1_700_200_000
-    let (sut, _) = try makeSUT(applications: [older, newest, newer])
+  @Test func loadApplications_preservesServerReturnedOrder() async throws {
+    // The server owns ordering for every sort now (GH#682 slice 3): the client
+    // renders the API order verbatim and never re-sorts locally — that would
+    // only ever order the pages already loaded. This input is deliberately not
+    // in date order so a leftover client-side `recent-activity` sort would
+    // reorder it and fail this assertion.
+    let serverOrdered: [PlanningApplication] = [.permitted, .pendingReview, .rejected]
+    let (sut, _) = try makeSUT(applications: serverOrdered)
 
     await sut.loadApplications()
 
-    #expect(sut.filteredApplications.count == 3)
-    #expect(sut.filteredApplications[0].id == newest.id)
-    #expect(sut.filteredApplications[1].id == newer.id)
-    #expect(sut.filteredApplications[2].id == older.id)
+    #expect(sut.filteredApplications.map(\.id) == serverOrdered.map(\.id))
   }
 
   @Test func loadApplications_setsIsLoadingFalseAfterFetch() async throws {
@@ -48,7 +48,10 @@ struct ApplicationListViewModelTests {
 
   @Test func loadApplications_setsErrorOnFailure() async throws {
     let (sut, spy) = try makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
+    // The list path is paged now (GH#682 slice 3), so the error must surface
+    // from the paged fetch — `fetchApplicationsResult` only feeds the spy's
+    // param-less fallback, which the page path no longer uses.
+    spy.fetchApplicationsPageError = DomainError.networkUnavailable
 
     await sut.loadApplications()
 
@@ -58,9 +61,10 @@ struct ApplicationListViewModelTests {
 
   @Test func loadApplications_clearsErrorOnRetry() async throws {
     let (sut, spy) = try makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
+    spy.fetchApplicationsPageError = DomainError.networkUnavailable
     await sut.loadApplications()
 
+    spy.fetchApplicationsPageError = nil
     spy.fetchApplicationsResult = .success([.pendingReview])
     await sut.loadApplications()
 
@@ -73,8 +77,8 @@ struct ApplicationListViewModelTests {
 
     await sut.loadApplications()
 
-    #expect(spy.fetchApplicationsCalls.count == 1)
-    #expect(spy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+    #expect(spy.fetchApplicationsPageCalls.count == 1)
+    #expect(spy.fetchApplicationsPageCalls.first?.zone.id == WatchZone.cambridge.id)
   }
 
   // MARK: - Selection
@@ -139,8 +143,8 @@ struct ApplicationListViewModelTests {
     await sut.loadApplications()
 
     #expect(zoneSpy.loadAllCallCount == 1)
-    #expect(appSpy.fetchApplicationsCalls.count == 1)
-    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+    #expect(appSpy.fetchApplicationsPageCalls.count == 1)
+    #expect(appSpy.fetchApplicationsPageCalls.first?.zone.id == WatchZone.cambridge.id)
     #expect(sut.filteredApplications.count == 1)
   }
 
@@ -178,7 +182,7 @@ struct ApplicationListViewModelTests {
     await sut.loadApplications()
 
     #expect(sut.error == .networkUnavailable)
-    #expect(appSpy.fetchApplicationsCalls.isEmpty)
+    #expect(appSpy.fetchApplicationsPageCalls.isEmpty)
   }
 
   @Test func loadApplications_withWatchZoneRepository_refreshesZonesOnEveryCall() async throws {
@@ -198,7 +202,7 @@ struct ApplicationListViewModelTests {
     await sut.loadApplications()
 
     #expect(zoneSpy.loadAllCallCount == 2)
-    #expect(appSpy.fetchApplicationsCalls.count == 2)
+    #expect(appSpy.fetchApplicationsPageCalls.count == 2)
   }
 
   // MARK: - Empty State
@@ -254,31 +258,31 @@ struct ApplicationListViewModelTests {
     let (sut, appSpy, _, _) = try makeSUTWithZones()
     await sut.loadApplications()
     #expect(sut.selectedZone?.id == WatchZone.cambridge.id)
-    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+    #expect(appSpy.fetchApplicationsPageCalls.first?.zone.id == WatchZone.cambridge.id)
   }
 
   @Test func loadApplications_restoresPersistedZoneSelection() async throws {
     let (sut, appSpy, _, _) = try makeSUTWithZones(persistedZoneId: "zone-002")
     await sut.loadApplications()
     #expect(sut.selectedZone?.id == WatchZone.london.id)
-    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.london.id)
+    #expect(appSpy.fetchApplicationsPageCalls.first?.zone.id == WatchZone.london.id)
   }
 
   @Test func loadApplications_fallsBackToFirstZone_whenPersistedZoneDeleted() async throws {
     let (sut, appSpy, _, _) = try makeSUTWithZones(persistedZoneId: "zone-deleted")
     await sut.loadApplications()
     #expect(sut.selectedZone?.id == WatchZone.cambridge.id)
-    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+    #expect(appSpy.fetchApplicationsPageCalls.first?.zone.id == WatchZone.cambridge.id)
   }
 
   @Test func selectZone_fetchesApplicationsForNewZone() async throws {
     let (sut, appSpy, _, _) = try makeSUTWithZones()
     await sut.loadApplications()
-    let callsBefore = appSpy.fetchApplicationsCalls.count
+    let callsBefore = appSpy.fetchApplicationsPageCalls.count
     await sut.selectZone(.london)
     #expect(sut.selectedZone?.id == WatchZone.london.id)
-    #expect(appSpy.fetchApplicationsCalls.count == callsBefore + 1)
-    #expect(appSpy.fetchApplicationsCalls.last?.id == WatchZone.london.id)
+    #expect(appSpy.fetchApplicationsPageCalls.count == callsBefore + 1)
+    #expect(appSpy.fetchApplicationsPageCalls.last?.zone.id == WatchZone.london.id)
   }
 
   @Test func selectZone_persistsSelectionToUserDefaults() async throws {

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
@@ -194,32 +194,36 @@ struct ApplicationListViewModelUnreadTests {
     #expect(sut.sort == .status)
   }
 
-  @Test("recent-activity sort orders by max(receivedDate, latestUnreadEvent.createdAt) desc")
-  func sort_recentActivity_ordersByLatestActivity() async throws {
-    // app A: received earliest, but has a much-later unread event → top
-    // app B: received in the middle, no unread event → middle
-    // app C: received latest, no unread event → just below A
+  @Test("recent-activity is server-driven — the list preserves the server's order")
+  func sort_recentActivity_preservesServerOrder() async throws {
+    // recent-activity moved server-side in GH#682 slice 3 (#692): the API orders
+    // by GREATEST(start_date, unread.created_at) DESC via the notification join
+    // and the client renders that order as-is. The set below is deliberately
+    // NOT in the order a local max(receivedDate, latestUnreadEvent.createdAt)
+    // sort would produce (that would be [appA, appC, appB]), so a leftover
+    // client-side re-sort would reorder it and fail this assertion.
     let appA = PlanningApplication.pendingReview  // 1_700_000_000
       .withLatestUnreadEvent(event(at: 1_700_900_000))
     let appB = PlanningApplication.permitted  // 1_700_100_000
       .withLatestUnreadEvent(nil)
     let appC = PlanningApplication.rejected  // 1_700_200_000
       .withLatestUnreadEvent(nil)
-    let (sut, _, _, _) = try makeSUT(applications: [appB, appA, appC])
+    let serverOrdered = [appB, appA, appC]
+    let (sut, _, _, _) = try makeSUT(applications: serverOrdered)
 
     await sut.loadApplications()
     sut.sort = .recentActivity
 
-    #expect(sut.filteredApplications.map(\.id) == [appA.id, appC.id, appB.id])
+    #expect(sut.filteredApplications.map(\.id) == serverOrdered.map(\.id))
   }
 
-  // newest/oldest (GH#682 slice 1) and status (slice 2) are server-driven: the
-  // API returns rows already in the requested order (proven by the Go pgtest
-  // suite, #688/#690) and the client pages them via infinite scroll. The client
-  // must not re-sort locally — that would only order the pages already loaded —
-  // so it preserves the server's order verbatim. (The full
-  // reset-cursor-and-reload-on-sort-change flow is covered by
-  // ApplicationListViewModelPaginationTests.)
+  // newest/oldest (GH#682 slice 1), status (slice 2) and recent-activity
+  // (slice 3) are all server-driven: the API returns rows already in the
+  // requested order (proven by the Go pgtest suite, #688/#690/#692) and the
+  // client pages them via infinite scroll. The client must not re-sort locally —
+  // that would only order the pages already loaded — so it preserves the
+  // server's order verbatim. (The full reset-cursor-and-reload-on-sort-change
+  // flow is covered by ApplicationListViewModelPaginationTests.)
 
   @Test("newest is server-driven — the list preserves the server's order")
   func sort_newest_preservesServerOrder() async throws {
@@ -311,16 +315,17 @@ struct ApplicationListViewModelUnreadTests {
     let (sut, appSpy, _, _) = try makeSUT(applications: [unread])
 
     await sut.loadApplications()
-    let callsBefore = appSpy.fetchApplicationsCalls.count
+    let callsBefore = appSpy.fetchApplicationsPageCalls.count
 
-    // Server-side mark-all-read flips every row's latestUnreadEvent to nil
+    // Server-side mark-all-read flips every row's latestUnreadEvent to nil. The
+    // refetch is paged now (GH#682 slice 3), so it drives the paged endpoint.
     appSpy.fetchApplicationsResult = .success([
       PlanningApplication.pendingReview.withLatestUnreadEvent(nil)
     ])
 
     await sut.markAllRead()
 
-    #expect(appSpy.fetchApplicationsCalls.count > callsBefore)
+    #expect(appSpy.fetchApplicationsPageCalls.count > callsBefore)
     #expect(sut.applications.first?.latestUnreadEvent == nil)
   }
 


### PR DESCRIPTION
## What

Slice 3 (iOS) of epic #682 — the last sort to migrate. Promotes the list's **recent-activity** sort to server-driven (`?sort=recent-activity`, API merged in #692). **All five sorts are now server-driven + infinite scroll.**

- `ApplicationSortOrder` gains `case recentActivity = "recent-activity"`; the server-driven set is now all five, the client-driven set is empty.
- Removed the client-side `recentActivity` ordering (`max(startDate, latestUnreadEvent.createdAt)`) — deleted `sortApplications`/`recentActivityScore`; `filteredApplications` is now filter-only. The server returns recent-activity ordered (`GREATEST(start_date, unread.created_at) DESC`); the client preserves it.
- **Untouched**: status/unread **filters** (still client-side, slice 4), the **map** (slice 5), and the `latestUnreadEvent` per-row field (still drives the unread badge/count/filter).

## Tests

Swift Testing: recent-activity issues `?sort=recent-activity` + paginates via `X-Next-Cursor` (server order preserved), cursor resets on switch to/from it, server-order-preservation replaces the removed local-ordering assertions. Default-sort suites migrated to the paged spy (the default sort is recentActivity). `swift build` clean · `swift test` 1385 pass · `swiftlint lint --strict` 0 violations.

## FYI (filed as follow-up)

recentActivity was the default and the paged path bypasses the offline cache (slice-1 decision), so the list now uses no offline cache; `markAllRead` still zeroes the Unread chip via paged refetch (proven). Dead cache plumbing retirement deferred to `tc-0e6k` after the map slice.

Epic: #682 · Bead: tc-fhqo

Release-Note: Sort a watch zone by recent activity across every application, with the most recently updated first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application lists now support server-driven sorting for “recent activity.”
  * Infinite scrolling now works consistently across all sort options.

* **Bug Fixes**
  * Preserves the server’s item order instead of re-sorting results on the device.
  * Refreshes and “mark all read” updates now reload list data using paged requests, reducing stale unread states.

* **Chores**
  * Updated tests and supporting notes to match the new paging and sorting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->