### PR TITLE
feat(api): server-side status & unread filters with filter-aware cursor (tc-b7cz, #682 slice 4)

### DIFF
--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -118,7 +118,7 @@ func (fakeAppStore) BreakdownByAuthority(context.Context, string) ([]application
 func (fakeAppStore) FindNearbyPage(context.Context, float64, float64, float64, int, string) ([]applications.PlanningApplication, string, error) {
 	return nil, "", nil
 }
-func (fakeAppStore) FindInZonePage(context.Context, string, float64, float64, float64, applications.Sort, int, string) ([]applications.PlanningApplication, string, error) {
+func (fakeAppStore) FindInZonePage(context.Context, applications.InZoneQuery) ([]applications.PlanningApplication, string, error) {
 	return nil, "", nil
 }
 func (fakeAppStore) RecentNearby(context.Context, string, float64, float64, float64, int) ([]applications.PlanningApplication, error) {

--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -36,7 +36,7 @@ type Store interface {
 	RecentByAuthority(ctx context.Context, authorityCode string, cap int) ([]PlanningApplication, error)
 	BreakdownByAuthority(ctx context.Context, authorityCode string) ([]StateCount, error)
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error)
-	FindInZonePage(ctx context.Context, userID string, latitude, longitude, radiusMetres float64, sort Sort, limit int, cursor string) ([]PlanningApplication, string, error)
+	FindInZonePage(ctx context.Context, q InZoneQuery) ([]PlanningApplication, string, error)
 	RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
 	NearestNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
 	BreakdownNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) ([]StateCount, error)

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -468,6 +468,15 @@ func withStart(a PlanningApplication, d time.Time) PlanningApplication {
 	return a
 }
 
+// zoneQuery is a brief InZoneQuery builder fixed to the standard 6 km London
+// fixture centre, for the cursor/sort-error tests.
+func zoneQuery(sort Sort, limit int, cursor string) InZoneQuery {
+	return InZoneQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,
+		Sort: sort, Limit: limit, Cursor: cursor,
+	}
+}
+
 // pageAllInZone pages FindInZonePage to exhaustion as an anonymous caller (no
 // userID), for the sorts that ignore per-user data.
 func pageAllInZone(t *testing.T, store *PostgresStore, sort Sort, radius float64, limit int) []string {
@@ -484,7 +493,10 @@ func pageAllInZoneAs(t *testing.T, store *PostgresStore, userID string, sort Sor
 	var names []string
 	cursor := ""
 	for range 1000 {
-		page, next, err := store.FindInZonePage(ctx, userID, pgCentreLat, pgCentreLon, radius, sort, limit, cursor)
+		page, next, err := store.FindInZonePage(ctx, InZoneQuery{
+			UserID: userID, Latitude: pgCentreLat, Longitude: pgCentreLon,
+			RadiusMetres: radius, Sort: sort, Limit: limit, Cursor: cursor,
+		})
 		if err != nil {
 			t.Fatalf("FindInZonePage(%s, cursor=%q): %v", sort, cursor, err)
 		}
@@ -670,7 +682,7 @@ func TestPostgresStore_FindInZonePage_CursorSortMismatch(t *testing.T) {
 	store := newAppPGStore(t)
 	sortFixture(t, store)
 
-	_, cursor, err := store.FindInZonePage(ctx, "", pgCentreLat, pgCentreLon, 6000, SortNewest, 1, "")
+	_, cursor, err := store.FindInZonePage(ctx, zoneQuery(SortNewest, 1, ""))
 	if err != nil {
 		t.Fatalf("mint newest cursor: %v", err)
 	}
@@ -678,24 +690,24 @@ func TestPostgresStore_FindInZonePage_CursorSortMismatch(t *testing.T) {
 		t.Fatal("expected a continuation cursor after a full page")
 	}
 
-	if _, _, err := store.FindInZonePage(ctx, "", pgCentreLat, pgCentreLon, 6000, SortOldest, 1, cursor); !errors.Is(err, ErrCursorSortMismatch) {
+	if _, _, err := store.FindInZonePage(ctx, zoneQuery(SortOldest, 1, cursor)); !errors.Is(err, ErrCursorSortMismatch) {
 		t.Errorf("replay newest cursor under oldest: got err %v, want ErrCursorSortMismatch", err)
 	}
 
 	// A cursor minted under status carries mode=status; replaying it under any
 	// other sort is rejected, never a mis-ordered page.
-	_, statusCursor, err := store.FindInZonePage(ctx, "", pgCentreLat, pgCentreLon, 6000, SortStatus, 1, "")
+	_, statusCursor, err := store.FindInZonePage(ctx, zoneQuery(SortStatus, 1, ""))
 	if err != nil {
 		t.Fatalf("mint status cursor: %v", err)
 	}
 	if statusCursor == "" {
 		t.Fatal("expected a continuation cursor after a full status page")
 	}
-	if _, _, err := store.FindInZonePage(ctx, "", pgCentreLat, pgCentreLon, 6000, SortNewest, 1, statusCursor); !errors.Is(err, ErrCursorSortMismatch) {
+	if _, _, err := store.FindInZonePage(ctx, zoneQuery(SortNewest, 1, statusCursor)); !errors.Is(err, ErrCursorSortMismatch) {
 		t.Errorf("replay status cursor under newest: got err %v, want ErrCursorSortMismatch", err)
 	}
 
-	if _, _, err := store.FindInZonePage(ctx, "", pgCentreLat, pgCentreLon, 6000, SortNewest, 1, "!!!not-base64!!!"); !errors.Is(err, ErrCursorInvalid) {
+	if _, _, err := store.FindInZonePage(ctx, zoneQuery(SortNewest, 1, "!!!not-base64!!!")); !errors.Is(err, ErrCursorInvalid) {
 		t.Errorf("malformed cursor: got err %v, want ErrCursorInvalid", err)
 	}
 }
@@ -708,7 +720,7 @@ func TestPostgresStore_FindInZonePage_UnsupportedSort(t *testing.T) {
 	store := newAppPGStore(t)
 	sortFixture(t, store)
 
-	if _, _, err := store.FindInZonePage(ctx, "", pgCentreLat, pgCentreLon, 6000, Sort("nonsense"), 10, ""); !errors.Is(err, ErrUnsupportedSort) {
+	if _, _, err := store.FindInZonePage(ctx, zoneQuery(Sort("nonsense"), 10, "")); !errors.Is(err, ErrUnsupportedSort) {
 		t.Errorf("unsupported sort: got err %v, want ErrUnsupportedSort", err)
 	}
 }

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -477,6 +477,32 @@ func zoneQuery(sort Sort, limit int, cursor string) InZoneQuery {
 	}
 }
 
+// pageAllFiltered pages FindInZonePage to exhaustion for an arbitrary query
+// (sort + status/unread filter + page size), returning the names in the order
+// seen across pages. base.Cursor is ignored (paging starts from page one). It
+// bounds the loop so a keyset bug that fails to advance fails instead of hanging.
+func pageAllFiltered(t *testing.T, store *PostgresStore, base InZoneQuery) []string {
+	t.Helper()
+	ctx := context.Background()
+	var names []string
+	cursor := ""
+	for range 1000 {
+		q := base
+		q.Cursor = cursor
+		page, next, err := store.FindInZonePage(ctx, q)
+		if err != nil {
+			t.Fatalf("FindInZonePage(sort=%s status=%q unread=%t cursor=%q): %v", base.Sort, base.Status, base.Unread, cursor, err)
+		}
+		names = append(names, appNames(page)...)
+		if next == "" {
+			return names
+		}
+		cursor = next
+	}
+	t.Fatalf("FindInZonePage(sort=%s status=%q unread=%t) did not exhaust within the safety bound", base.Sort, base.Status, base.Unread)
+	return nil
+}
+
 // pageAllInZone pages FindInZonePage to exhaustion as an anonymous caller (no
 // userID), for the sorts that ignore per-user data.
 func pageAllInZone(t *testing.T, store *PostgresStore, sort Sort, radius float64, limit int) []string {
@@ -904,6 +930,248 @@ func TestPostgresStore_FindInZonePage_RecentActivity_StrictUnread(t *testing.T) 
 	want := []string{"N", "M"} // N(feb) > M(jan); the at-watermark notification is read.
 	if got := pageAllInZoneAs(t, store, userID, SortRecentActivity, 6000, 100); !reflect.DeepEqual(got, want) {
 		t.Fatalf("recent-activity strict-unread: got %v, want %v (a notification exactly at the watermark is read)", got, want)
+	}
+}
+
+// TestPostgresStore_FindInZonePage_StatusFilter proves ?status= restricts the set
+// to exactly the matching app_state, composes with every scalar sort, and pages to
+// exhaustion with no overlap or gap. Rejected and NULL-app_state rows never appear.
+func TestPostgresStore_FindInZonePage_StatusFilter(t *testing.T) {
+	store := newAppPGStore(t)
+	statusFixture(t, store)
+
+	// Permitted rows only. Under newest/status: start_date DESC NULLS LAST then
+	// (authority_code, planit_name) — P1(mar), P3(feb,100), P4(feb,200), P2(jan),
+	// P5(NULL). Under distance: nearest-first by construction — P1..P5.
+	permittedByDate := []string{"P1", "P3", "P4", "P2", "P5"}
+	permittedByDistance := []string{"P1", "P2", "P3", "P4", "P5"}
+	cases := []struct {
+		sort Sort
+		want []string
+	}{
+		{SortNewest, permittedByDate},
+		{SortStatus, permittedByDate},
+		{SortDistance, permittedByDistance},
+	}
+	for _, tc := range cases {
+		for _, limit := range []int{100, 2, 1} {
+			base := InZoneQuery{
+				Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,
+				Sort: tc.sort, Status: "Permitted", Limit: limit,
+			}
+			if got := pageAllFiltered(t, store, base); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("status=Permitted sort=%s limit=%d: got %v, want %v", tc.sort, limit, got, tc.want)
+			}
+		}
+	}
+
+	// Rejected rows only, newest: R1(feb), R2(NULL).
+	rejected := pageAllFiltered(t, store, InZoneQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,
+		Sort: SortNewest, Status: "Rejected", Limit: 1,
+	})
+	if want := []string{"R1", "R2"}; !reflect.DeepEqual(rejected, want) {
+		t.Fatalf("status=Rejected: got %v, want %v", rejected, want)
+	}
+
+	// A status with no matching rows yields the empty set.
+	empty := pageAllFiltered(t, store, InZoneQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,
+		Sort: SortNewest, Status: "Withdrawn", Limit: 10,
+	})
+	if len(empty) != 0 {
+		t.Fatalf("status=Withdrawn (no rows): got %v, want empty", empty)
+	}
+}
+
+// unreadFixture seeds a deterministic in-radius set for the unread filter under a
+// scalar sort. U1 and U4 have a fresh UNREAD notification; U2 has only a READ one
+// (at/under the watermark); U3 has none. So ?unread=true keeps only {U1, U4}.
+// Distances increase with the name so the distance order is U1..U4.
+func unreadFixture(t *testing.T, store *PostgresStore, pool *pgxpool.Pool, userID string) {
+	t.Helper()
+	ctx := context.Background()
+	jan := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	feb := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	mar := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	apr := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	for _, a := range []PlanningApplication{
+		withStart(at(pgApp("U1", 100), 100), jan), // fresh unread
+		withStart(at(pgApp("U2", 100), 200), feb), // read-only notification
+		withStart(at(pgApp("U3", 100), 300), mar), // no notification
+		withStart(at(pgApp("U4", 100), 400), apr), // fresh unread
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+	watermark := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	seedWatermark(t, pool, userID, watermark)
+	seedNotification(t, pool, "n-U1", userID, "uid-U1", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)) // > watermark: unread
+	seedNotification(t, pool, "n-U2", userID, "uid-U2", 100, time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))  // < watermark: read
+	seedNotification(t, pool, "n-U4", userID, "uid-U4", 100, time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)) // > watermark: unread
+}
+
+// TestPostgresStore_FindInZonePage_UnreadFilter proves ?unread=true (the INNER
+// JOIN to the caller's unread notifications) keeps only applications with an
+// unread notification, composes with scalar sorts, and pages without gaps. A
+// read-only or notification-less application is dropped.
+func TestPostgresStore_FindInZonePage_UnreadFilter(t *testing.T) {
+	store, pool := newActivityPGStore(t)
+	const userID = "user-unread"
+	unreadFixture(t, store, pool, userID)
+
+	// Newest: U4(apr) then U1(jan). Distance: U1(100) then U4(400). U2/U3 excluded.
+	cases := []struct {
+		sort Sort
+		want []string
+	}{
+		{SortNewest, []string{"U4", "U1"}},
+		{SortDistance, []string{"U1", "U4"}},
+	}
+	for _, tc := range cases {
+		for _, limit := range []int{100, 1} {
+			base := InZoneQuery{
+				UserID: userID, Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,
+				Sort: tc.sort, Unread: true, Limit: limit,
+			}
+			if got := pageAllFiltered(t, store, base); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("unread=true sort=%s limit=%d: got %v, want %v", tc.sort, limit, got, tc.want)
+			}
+		}
+	}
+}
+
+// TestPostgresStore_FindInZonePage_UnreadFilter_FirstTouch proves a caller with NO
+// notification_state row (never read) gets the empty set under ?unread=true — the
+// INNER JOIN to notification_state yields nothing, even though matching
+// notifications exist.
+func TestPostgresStore_FindInZonePage_UnreadFilter_FirstTouch(t *testing.T) {
+	store, pool := newActivityPGStore(t)
+	ctx := context.Background()
+	const userID = "user-firsttouch"
+	jan := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	app := withStart(at(pgApp("Z1", 100), 100), jan)
+	if err := store.Upsert(ctx, app); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	// A notification exists, but with no watermark row the user has read nothing,
+	// so the unread subquery (INNER to notification_state) contributes nothing.
+	seedNotification(t, pool, "n-Z1", userID, "uid-Z1", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+
+	got := pageAllFiltered(t, store, InZoneQuery{
+		UserID: userID, Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,
+		Sort: SortNewest, Unread: true, Limit: 10,
+	})
+	if len(got) != 0 {
+		t.Fatalf("first-touch unread=true: got %v, want empty (no notification_state ⇒ no unread)", got)
+	}
+}
+
+// TestPostgresStore_FindInZonePage_UnreadFilter_RecentActivity proves the unread
+// filter composes with the recent-activity sort: the unread join becomes INNER (so
+// an application with no unread is dropped even when its start_date is newest),
+// while the GREATEST(start_date, unread.created_at) ordering still holds.
+func TestPostgresStore_FindInZonePage_UnreadFilter_RecentActivity(t *testing.T) {
+	store, pool := newActivityPGStore(t)
+	ctx := context.Background()
+	const userID = "user-ra-unread"
+	jan := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	feb := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	jun := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	for _, a := range []PlanningApplication{
+		withStart(at(pgApp("AA", 100), 100), jan), // oldest start, fresh unread → top
+		withStart(at(pgApp("BB", 100), 200), jun), // newest start, NO unread → dropped by INNER
+		withStart(at(pgApp("CC", 100), 300), feb), // unread (older) → second
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+	seedWatermark(t, pool, userID, jan)
+	seedNotification(t, pool, "n-AA", userID, "uid-AA", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)) // activity jun15
+	seedNotification(t, pool, "n-CC", userID, "uid-CC", 100, time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))  // activity mar1
+
+	want := []string{"AA", "CC"} // AA(jun15) > CC(mar1); BB dropped (no unread).
+	for _, limit := range []int{100, 1} {
+		base := InZoneQuery{
+			UserID: userID, Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,
+			Sort: SortRecentActivity, Unread: true, Limit: limit,
+		}
+		if got := pageAllFiltered(t, store, base); !reflect.DeepEqual(got, want) {
+			t.Fatalf("recent-activity unread=true limit=%d: got %v, want %v", limit, got, want)
+		}
+	}
+}
+
+// TestPostgresStore_FindInZonePage_CursorFilterMismatch proves a cursor minted
+// under one filter is rejected when replayed under another (status→other status,
+// status→unread, filtered→unfiltered, unfiltered→filtered), and that a cursor
+// replayed under the SAME filter keeps paging. Symmetric with the sort-mismatch
+// guard: never a gapped or overlapping page.
+func TestPostgresStore_FindInZonePage_CursorFilterMismatch(t *testing.T) {
+	ctx := context.Background()
+	store, pool := newActivityPGStore(t)
+	statusFixture(t, store)
+	const userID = "user-cursor"
+	seedWatermark(t, pool, userID, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	seedNotification(t, pool, "n-P1", userID, "uid-P1", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+
+	permitted := InZoneQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,
+		Sort: SortNewest, Status: "Permitted", Limit: 1,
+	}
+	_, cursor, err := store.FindInZonePage(ctx, permitted)
+	if err != nil {
+		t.Fatalf("mint status=Permitted cursor: %v", err)
+	}
+	if cursor == "" {
+		t.Fatal("expected a continuation cursor after a full filtered page")
+	}
+
+	// Replayed under a different status → mismatch.
+	rejectedReplay := permitted
+	rejectedReplay.Status, rejectedReplay.Cursor = "Rejected", cursor
+	if _, _, err := store.FindInZonePage(ctx, rejectedReplay); !errors.Is(err, ErrCursorFilterMismatch) {
+		t.Errorf("replay Permitted cursor under Rejected: got %v, want ErrCursorFilterMismatch", err)
+	}
+
+	// Replayed under the unread filter (status dropped) → mismatch.
+	unreadReplay := InZoneQuery{
+		UserID: userID, Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,
+		Sort: SortNewest, Unread: true, Cursor: cursor,
+	}
+	if _, _, err := store.FindInZonePage(ctx, unreadReplay); !errors.Is(err, ErrCursorFilterMismatch) {
+		t.Errorf("replay Permitted cursor under unread: got %v, want ErrCursorFilterMismatch", err)
+	}
+
+	// Replayed unfiltered → mismatch.
+	unfilteredReplay := InZoneQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,
+		Sort: SortNewest, Cursor: cursor,
+	}
+	if _, _, err := store.FindInZonePage(ctx, unfilteredReplay); !errors.Is(err, ErrCursorFilterMismatch) {
+		t.Errorf("replay Permitted cursor unfiltered: got %v, want ErrCursorFilterMismatch", err)
+	}
+
+	// An unfiltered cursor replayed under a status filter → mismatch.
+	_, plainCursor, err := store.FindInZonePage(ctx, InZoneQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000, Sort: SortNewest, Limit: 1,
+	})
+	if err != nil {
+		t.Fatalf("mint unfiltered cursor: %v", err)
+	}
+	filteredReplay := permitted
+	filteredReplay.Cursor = plainCursor
+	if _, _, err := store.FindInZonePage(ctx, filteredReplay); !errors.Is(err, ErrCursorFilterMismatch) {
+		t.Errorf("replay unfiltered cursor under Permitted: got %v, want ErrCursorFilterMismatch", err)
+	}
+
+	// Replayed under the SAME filter → keeps paging (no error, advances).
+	sameReplay := permitted
+	sameReplay.Cursor = cursor
+	if _, _, err := store.FindInZonePage(ctx, sameReplay); err != nil {
+		t.Errorf("replay Permitted cursor under Permitted: unexpected error %v", err)
 	}
 }
 

--- a/api-go/internal/applications/zonepage.go
+++ b/api-go/internal/applications/zonepage.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -58,6 +59,56 @@ func (s Sort) Supported() bool {
 	}
 }
 
+// The status filter vocabulary (epic #682 slice 4). These are the PlanIt
+// app_state chip values the clients filter on; ?status= exact-matches the raw
+// app_state column against one of these. "All" (or an absent ?status=) means no
+// status filter; any other value is rejected with 400 (see StatusSupported).
+// app_state is a nullable raw string, so the match is on the exact stored value.
+const (
+	StatusUndecided  = "Undecided"
+	StatusPermitted  = "Permitted"
+	StatusConditions = "Conditions"
+	StatusRejected   = "Rejected"
+	StatusWithdrawn  = "Withdrawn"
+	StatusAppealed   = "Appealed"
+)
+
+// StatusSupported reports whether status is one of the recognised app_state
+// filter values. It is the concrete (non-"All", non-empty) vocabulary only:
+// callers map "" / "All" to "no filter" before reaching this.
+func StatusSupported(status string) bool {
+	switch status {
+	case StatusUndecided, StatusPermitted, StatusConditions, StatusRejected, StatusWithdrawn, StatusAppealed:
+		return true
+	default:
+		return false
+	}
+}
+
+// InZoneQuery is the full request descriptor for FindInZonePage: where to look
+// (UserID, Latitude, Longitude, RadiusMetres), how to order (Sort), how to
+// filter (Status, Unread), and how to page (Limit, Cursor). It replaces a long
+// positional parameter list (epic #682 slice 4) so the call site reads as one
+// query object rather than ten arguments.
+//
+// Status is the exact app_state to match; "" means no status filter. Unread true
+// restricts to applications with an unread notification for UserID; false means
+// no unread filter. Status and Unread are mutually exclusive at the API boundary
+// (the handler rejects both together with 400) — the store does not assume so,
+// but the cursor embeds both, so a cursor minted under one filter cannot be
+// replayed under another (ErrCursorFilterMismatch).
+type InZoneQuery struct {
+	UserID       string
+	Latitude     float64
+	Longitude    float64
+	RadiusMetres float64
+	Sort         Sort
+	Status       string
+	Unread       bool
+	Limit        int
+	Cursor       string
+}
+
 var (
 	// ErrCursorInvalid signals a ?cursor= token that is not a well-formed keyset
 	// cursor (bad base64 or non-cursor payload). Consumers map it to HTTP 400.
@@ -67,6 +118,12 @@ var (
 	// was minted under, so replaying it under a different sort would yield a
 	// mis-ordered page; consumers map this to HTTP 400, never a silent reset.
 	ErrCursorSortMismatch = errors.New("cursor sort mode does not match request sort")
+	// ErrCursorFilterMismatch signals a cursor whose embedded filter (status
+	// value and/or unread flag) differs from the request's filter. A keyset cursor
+	// is only valid for the candidate set it was minted over; replaying it under a
+	// different filter would gap or overlap pages, so consumers map this to HTTP
+	// 400 — symmetric with ErrCursorSortMismatch, never a silent reset.
+	ErrCursorFilterMismatch = errors.New("cursor filter does not match request filter")
 	// ErrUnsupportedSort signals a sort value outside the set this slice
 	// implements. Consumers map it to HTTP 400.
 	ErrUnsupportedSort = errors.New("unsupported sort")
@@ -74,7 +131,9 @@ var (
 
 // pageCursor is the opaque, sort-aware keyset position handed back to clients.
 // It embeds the sort mode (M) so a stale cursor cannot silently produce a page
-// in the wrong order, plus exactly the keys that sort's ORDER BY ranks on:
+// in the wrong order, the active filter (F = status value, U = unread flag) so a
+// cursor minted over one candidate set cannot be replayed over another, plus
+// exactly the keys that sort's ORDER BY ranks on:
 //   - distance: D (the KNN distance) + N (planit_name).
 //   - newest/oldest: SD (start_date, nil for a NULL-start_date tail row) + AC
 //     (authority_code) + N (planit_name).
@@ -83,13 +142,18 @@ var (
 //   - recent-activity: TS (the activity timestamp, nil for a NULL-activity tail
 //     row) + AC (authority_code) + N (planit_name).
 //
-// It is base64url-encoded JSON. AS, SD and TS use a nil pointer (omitted field)
-// to mean a NULL key value, so the next page's predicate can pick the matching
-// NULLS-LAST tail branch. SD is a "2006-01-02" date string so the predicate
-// compares against an unambiguous ::date, not a timezone-laden timestamp; TS is
-// an RFC3339Nano timestamp string compared against a ::timestamptz.
+// It is base64url-encoded JSON. F and U are omitempty so an unfiltered cursor is
+// byte-identical to the pre-slice-4 cursors (they decode to F="" U=false, which
+// matches an unfiltered request — old cursors keep working). AS, SD and TS use a
+// nil pointer (omitted field) to mean a NULL key value, so the next page's
+// predicate can pick the matching NULLS-LAST tail branch. SD is a "2006-01-02"
+// date string so the predicate compares against an unambiguous ::date, not a
+// timezone-laden timestamp; TS is an RFC3339Nano timestamp string compared
+// against a ::timestamptz.
 type pageCursor struct {
 	M  Sort    `json:"m"`
+	F  string  `json:"f,omitempty"`
+	U  bool    `json:"u,omitempty"`
 	D  string  `json:"d,omitempty"`
 	AS *string `json:"as,omitempty"`
 	SD *string `json:"sd,omitempty"`
@@ -244,44 +308,61 @@ func scanDatePageRow(row pgx.CollectableRow) (datePageRow, error) {
 	return r, nil
 }
 
-// FindInZonePage returns one page of up to limit applications within radiusMetres
-// of (latitude, longitude), ordered by the requested sort, plus an opaque
-// sort-aware cursor for the next page (empty when exhausted). It generalises
-// FindNearbyPage (which stays the legacy default-distance path with its own
-// cursor) to the {distance, newest, oldest} sorts of epic #682 slice 1. Every
-// sort keeps the ST_DWithin spatial predicate and a total order whose keyset
-// predicate exactly matches its ORDER BY, so pages never overlap or gap. The
-// cursor embeds the sort mode: replaying it under a different sort returns
-// ErrCursorSortMismatch, and a malformed cursor returns ErrCursorInvalid, so the
-// caller can return 400 rather than a mis-ordered page. It is authority-agnostic.
+// FindInZonePage returns one page of up to q.Limit applications within
+// q.RadiusMetres of (q.Latitude, q.Longitude), ordered by q.Sort and filtered by
+// q.Status / q.Unread, plus an opaque sort-and-filter-aware cursor for the next
+// page (empty when exhausted). It generalises FindNearbyPage (which stays the
+// legacy default-distance path with its own cursor) to the {distance, newest,
+// oldest, status, recent-activity} sorts of epic #682 slices 1-3 and the status /
+// unread filters of slice 4. Every sort keeps the ST_DWithin spatial predicate
+// and a total order whose keyset predicate exactly matches its ORDER BY, so pages
+// never overlap or gap; the filters compose by restricting the candidate set
+// without touching the ordering. The cursor embeds the sort mode AND the active
+// filter: replaying it under a different sort returns ErrCursorSortMismatch,
+// under a different filter ErrCursorFilterMismatch, and a malformed cursor returns
+// ErrCursorInvalid, so the caller can return 400 rather than a mis-ordered or
+// gapped page. It is authority-agnostic.
 //
-// userID scopes the per-user data the recent-activity sort joins (the caller's
-// latest unread notification per application). The other sorts ignore it.
-func (s *PostgresStore) FindInZonePage(ctx context.Context, userID string, latitude, longitude, radiusMetres float64, sort Sort, limit int, cursor string) ([]PlanningApplication, string, error) {
-	if !sort.Supported() {
-		return nil, "", fmt.Errorf("sort %q: %w", sort, ErrUnsupportedSort)
+// q.UserID scopes the per-user notification data the recent-activity sort joins
+// (the caller's latest unread per application) and the unread filter restricts on.
+// The scalar sorts ignore it unless q.Unread is set.
+func (s *PostgresStore) FindInZonePage(ctx context.Context, q InZoneQuery) ([]PlanningApplication, string, error) {
+	if !q.Sort.Supported() {
+		return nil, "", fmt.Errorf("sort %q: %w", q.Sort, ErrUnsupportedSort)
 	}
 	var c *pageCursor
-	if cursor != "" {
-		decoded, err := decodePageCursor(cursor)
+	if q.Cursor != "" {
+		decoded, err := decodePageCursor(q.Cursor)
 		if err != nil {
 			return nil, "", err
 		}
-		if decoded.M != sort {
-			return nil, "", fmt.Errorf("cursor sort %q, request sort %q: %w", decoded.M, sort, ErrCursorSortMismatch)
+		if decoded.M != q.Sort {
+			return nil, "", fmt.Errorf("cursor sort %q, request sort %q: %w", decoded.M, q.Sort, ErrCursorSortMismatch)
+		}
+		if decoded.F != q.Status || decoded.U != q.Unread {
+			return nil, "", fmt.Errorf("cursor filter {status:%q unread:%t}, request filter {status:%q unread:%t}: %w",
+				decoded.F, decoded.U, q.Status, q.Unread, ErrCursorFilterMismatch)
 		}
 		c = &decoded
 	}
-	if sort == SortDistance {
-		return s.findDistanceZonePage(ctx, latitude, longitude, radiusMetres, limit, c)
+
+	// Filtered requests (a status value and/or the unread flag) take the dynamic
+	// builder, which composes the status predicate and/or the unread INNER JOIN
+	// into the sort's query. Unfiltered requests stay on the proven per-sort
+	// constant queries unchanged.
+	if q.Status != "" || q.Unread {
+		return s.findFilteredZonePage(ctx, q, c)
 	}
-	if sort == SortStatus {
-		return s.findStatusZonePage(ctx, latitude, longitude, radiusMetres, limit, c)
+	if q.Sort == SortDistance {
+		return s.findDistanceZonePage(ctx, q.Latitude, q.Longitude, q.RadiusMetres, q.Limit, c)
 	}
-	if sort == SortRecentActivity {
-		return s.findRecentActivityZonePage(ctx, userID, latitude, longitude, radiusMetres, limit, c)
+	if q.Sort == SortStatus {
+		return s.findStatusZonePage(ctx, q.Latitude, q.Longitude, q.RadiusMetres, q.Limit, c)
 	}
-	return s.findDateZonePage(ctx, latitude, longitude, radiusMetres, sort, limit, c)
+	if q.Sort == SortRecentActivity {
+		return s.findRecentActivityZonePage(ctx, q.UserID, q.Latitude, q.Longitude, q.RadiusMetres, q.Limit, c)
+	}
+	return s.findDateZonePage(ctx, q.Latitude, q.Longitude, q.RadiusMetres, q.Sort, q.Limit, c)
 }
 
 // findDistanceZonePage serves SortDistance: the legacy KNN nearest-first query
@@ -587,4 +668,287 @@ func activityCursorOf(last activityPageRow) pageCursor {
 		c.TS = &ts
 	}
 	return c
+}
+
+// argBuilder accumulates positional query args and hands out their $N
+// placeholders, so the filtered FindInZonePage path can assemble a query that
+// interleaves spatial, join, status-filter and keyset parameters without
+// hand-numbering them. Only constant SQL fragments and these $N placeholders are
+// concatenated into the query text; every value flows through the args, so the
+// query stays fully parameterised.
+type argBuilder struct {
+	args []any
+}
+
+func (b *argBuilder) add(v any) string {
+	b.args = append(b.args, v)
+	return "$" + strconv.Itoa(len(b.args))
+}
+
+// findFilteredZonePage serves the status / unread filtered requests (epic #682
+// slice 4). It composes the same per-sort ORDER BY + keyset predicates the
+// unfiltered path uses with a status predicate (AND app_state = $x) and/or an
+// INNER JOIN to the caller's unread notifications, then collects with the sort's
+// projection scanner and mints a filter-stamped next cursor. c is the validated
+// (sort- and filter-matched) cursor, nil on the first page.
+func (s *PostgresStore) findFilteredZonePage(ctx context.Context, q InZoneQuery, c *pageCursor) ([]PlanningApplication, string, error) {
+	query, args, err := buildFilteredZoneQuery(q, c)
+	if err != nil {
+		return nil, "", err
+	}
+	switch q.Sort {
+	case SortDistance:
+		return s.collectFilteredDistancePage(ctx, q, query, args)
+	case SortRecentActivity:
+		return s.collectFilteredActivityPage(ctx, q, query, args)
+	default: // newest, oldest, status — the date-projection sorts
+		cursorOf := func(last datePageRow) pageCursor {
+			var cur pageCursor
+			if q.Sort == SortStatus {
+				cur = statusCursorOf(last)
+			} else {
+				cur = dateCursorOf(q.Sort, last)
+			}
+			cur.F, cur.U = q.Status, q.Unread
+			return cur
+		}
+		return s.collectKeysetPage(ctx, q.Sort, q.Latitude, q.Longitude, query, args, q.Limit, cursorOf)
+	}
+}
+
+// buildFilteredZoneQuery assembles the SQL + positional args for a status/unread
+// filtered page. The shape mirrors the unfiltered constants exactly — same
+// projection, ORDER BY and keyset predicates — but with two composable additions:
+// an optional "AND app_state = $x" status predicate, and an optional unread join.
+// The join is INNER when q.Unread is set (it drops applications with no unread for
+// the caller) and LEFT when only recent-activity needs it for ordering; both reuse
+// the slice-3 unread subquery (created_at > last_read_at, INNER to
+// notification_state so a first-touch caller contributes nothing).
+func buildFilteredZoneQuery(q InZoneQuery, c *pageCursor) (string, []any, error) {
+	b := &argBuilder{}
+	lonP := b.add(q.Longitude)
+	latP := b.add(q.Latitude)
+	point := "ST_SetSRID(ST_MakePoint(" + lonP + ", " + latP + "), 4326)::geography"
+
+	var projection string
+	switch q.Sort {
+	case SortDistance:
+		projection = appColumns + ", location <-> " + point + " AS distance"
+	case SortRecentActivity:
+		projection = dateColumns + ", " + activityExpr + " AS activity_ts"
+	default:
+		projection = dateColumns
+	}
+
+	var sb strings.Builder
+	sb.WriteString("SELECT ")
+	sb.WriteString(projection)
+	sb.WriteString(" FROM applications")
+
+	if q.Unread || q.Sort == SortRecentActivity {
+		joinType := "LEFT JOIN"
+		if q.Unread {
+			joinType = "JOIN" // INNER: drop applications with no unread for the caller.
+		}
+		userP := b.add(q.UserID)
+		subquery := "SELECT n.application_uid, n.authority_id, MAX(n.created_at) AS created_at" +
+			" FROM notifications n" +
+			" JOIN notification_state ns ON ns.user_id = n.user_id" +
+			" WHERE n.user_id = " + userP + " AND n.created_at > ns.last_read_at" +
+			" GROUP BY n.application_uid, n.authority_id"
+		sb.WriteString(" " + joinType + " (" + subquery + ") u" +
+			" ON applications.uid = u.application_uid AND applications.area_id = u.authority_id")
+	}
+
+	radiusP := b.add(q.RadiusMetres)
+	sb.WriteString(" WHERE ST_DWithin(location, " + point + ", " + radiusP + ")")
+
+	if q.Status != "" {
+		sb.WriteString(" AND app_state = " + b.add(q.Status))
+	}
+
+	if c != nil {
+		predicate, err := keysetPredicate(q.Sort, point, c, b)
+		if err != nil {
+			return "", nil, err
+		}
+		sb.WriteString(" AND " + predicate)
+	}
+
+	sb.WriteString(" ORDER BY " + orderByExpr(q.Sort, point))
+	sb.WriteString(" LIMIT " + b.add(q.Limit))
+
+	return sb.String(), b.args, nil
+}
+
+// orderByExpr returns the ORDER BY column list (without LIMIT) for the sort. It
+// is the exact ordering the unfiltered constants use, so a filtered page is
+// ordered identically to its unfiltered counterpart — the filter only restricts
+// the candidate set.
+func orderByExpr(sort Sort, point string) string {
+	switch sort {
+	case SortDistance:
+		return "location <-> " + point + ", planit_name"
+	case SortNewest:
+		return "start_date DESC NULLS LAST, authority_code, planit_name"
+	case SortOldest:
+		return "start_date ASC NULLS LAST, authority_code, planit_name"
+	case SortStatus:
+		return "app_state ASC NULLS LAST, start_date DESC NULLS LAST, authority_code, planit_name"
+	case SortRecentActivity:
+		return activityExpr + " DESC NULLS LAST, authority_code, planit_name"
+	default:
+		return ""
+	}
+}
+
+// keysetPredicate builds the "strictly after the cursor" predicate for the sort,
+// assigning its parameters via b. It mirrors the unfiltered keyset constants
+// exactly (each column's direction and NULLS-LAST tail), so a filtered page never
+// overlaps or gaps. A distance cursor's stored decimal is parsed here; a malformed
+// one is ErrCursorInvalid.
+func keysetPredicate(sort Sort, point string, c *pageCursor, b *argBuilder) (string, error) {
+	switch sort {
+	case SortDistance:
+		dist, err := strconv.ParseFloat(c.D, 64)
+		if err != nil {
+			return "", fmt.Errorf("parse distance cursor: %w: %w", ErrCursorInvalid, err)
+		}
+		distP := b.add(dist)
+		nameP := b.add(c.N)
+		expr := "location <-> " + point
+		return "(" + expr + " > " + distP +
+			" OR (" + expr + " = " + distP + " AND planit_name > " + nameP + "))", nil
+	case SortNewest, SortOldest:
+		return dateKeysetPredicate(sort, c, b), nil
+	case SortStatus:
+		return statusKeysetPredicate(c, b), nil
+	case SortRecentActivity:
+		return activityKeysetPredicate(c, b), nil
+	default:
+		return "", fmt.Errorf("sort %q: %w", sort, ErrUnsupportedSort)
+	}
+}
+
+// dateKeysetPredicate mirrors newestKeysetQuery / oldestKeysetQuery (and their
+// NULL-start_date tail forms) with dynamic parameters.
+func dateKeysetPredicate(sort Sort, c *pageCursor, b *argBuilder) string {
+	if c.SD == nil {
+		acP := b.add(c.AC)
+		nameP := b.add(c.N)
+		return "start_date IS NULL AND (authority_code, planit_name) > (" + acP + ", " + nameP + ")"
+	}
+	cmp := "<"
+	if sort == SortOldest {
+		cmp = ">"
+	}
+	sdP := b.add(*c.SD)
+	acP := b.add(c.AC)
+	nameP := b.add(c.N)
+	return "(start_date " + cmp + " " + sdP + "::date OR start_date IS NULL" +
+		" OR (start_date = " + sdP + "::date AND (authority_code, planit_name) > (" + acP + ", " + nameP + ")))"
+}
+
+// statusKeysetPredicate mirrors the four status keyset constants (the cursor row's
+// app_state/start_date NULLS-LAST position) with dynamic parameters.
+func statusKeysetPredicate(c *pageCursor, b *argBuilder) string {
+	switch {
+	case c.AS != nil && c.SD != nil:
+		asP := b.add(*c.AS)
+		sdP := b.add(*c.SD)
+		acP := b.add(c.AC)
+		nameP := b.add(c.N)
+		return "(app_state > " + asP + " OR app_state IS NULL" +
+			" OR (app_state = " + asP + " AND (start_date < " + sdP + "::date OR start_date IS NULL))" +
+			" OR (app_state = " + asP + " AND start_date = " + sdP + "::date AND (authority_code, planit_name) > (" + acP + ", " + nameP + ")))"
+	case c.AS != nil: // start_date NULL: cursor in its group's NULL-start_date tail.
+		asP := b.add(*c.AS)
+		acP := b.add(c.AC)
+		nameP := b.add(c.N)
+		return "(app_state > " + asP + " OR app_state IS NULL" +
+			" OR (app_state = " + asP + " AND start_date IS NULL AND (authority_code, planit_name) > (" + acP + ", " + nameP + ")))"
+	case c.SD != nil: // app_state NULL: cursor in the NULL-app_state tail.
+		sdP := b.add(*c.SD)
+		acP := b.add(c.AC)
+		nameP := b.add(c.N)
+		return "app_state IS NULL AND ((start_date < " + sdP + "::date OR start_date IS NULL)" +
+			" OR (start_date = " + sdP + "::date AND (authority_code, planit_name) > (" + acP + ", " + nameP + ")))"
+	default: // both NULL: the deepest tail.
+		acP := b.add(c.AC)
+		nameP := b.add(c.N)
+		return "app_state IS NULL AND start_date IS NULL AND (authority_code, planit_name) > (" + acP + ", " + nameP + ")"
+	}
+}
+
+// activityKeysetPredicate mirrors recentActivityKeysetQuery / its NULL-activity
+// tail form with dynamic parameters. The GREATEST expression is repeated inline
+// because Postgres cannot reference the SELECT alias in WHERE.
+func activityKeysetPredicate(c *pageCursor, b *argBuilder) string {
+	if c.TS == nil {
+		acP := b.add(c.AC)
+		nameP := b.add(c.N)
+		return activityExpr + " IS NULL AND (authority_code, planit_name) > (" + acP + ", " + nameP + ")"
+	}
+	tsP := b.add(*c.TS)
+	acP := b.add(c.AC)
+	nameP := b.add(c.N)
+	return "(" + activityExpr + " < " + tsP + "::timestamptz OR " + activityExpr + " IS NULL" +
+		" OR (" + activityExpr + " = " + tsP + "::timestamptz AND (authority_code, planit_name) > (" + acP + ", " + nameP + ")))"
+}
+
+// collectFilteredDistancePage runs a filtered distance query (nearbyRow
+// projection) and mints a filter-stamped (distance, planit_name) next cursor.
+func (s *PostgresStore) collectFilteredDistancePage(ctx context.Context, q InZoneQuery, query string, args []any) ([]PlanningApplication, string, error) {
+	rows, err := s.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("find filtered applications by distance near (%v, %v): %w", q.Latitude, q.Longitude, err)
+	}
+	collected, err := pgx.CollectRows(rows, scanNearbyRow)
+	if err != nil {
+		return nil, "", fmt.Errorf("find filtered applications by distance near (%v, %v): %w", q.Latitude, q.Longitude, err)
+	}
+	apps := make([]PlanningApplication, len(collected))
+	for i := range collected {
+		apps[i] = collected[i].app
+	}
+	next := ""
+	if q.Limit > 0 && len(collected) == q.Limit {
+		last := collected[len(collected)-1]
+		next, err = encodePageCursor(pageCursor{
+			M: SortDistance, F: q.Status, U: q.Unread,
+			D: strconv.FormatFloat(last.dist, 'g', -1, 64), N: last.app.Name,
+		})
+		if err != nil {
+			return nil, "", fmt.Errorf("encode distance cursor: %w", err)
+		}
+	}
+	return apps, next, nil
+}
+
+// collectFilteredActivityPage runs a filtered recent-activity query (activity
+// projection) and mints a filter-stamped (activity_ts, authority_code,
+// planit_name) next cursor.
+func (s *PostgresStore) collectFilteredActivityPage(ctx context.Context, q InZoneQuery, query string, args []any) ([]PlanningApplication, string, error) {
+	rows, err := s.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, "", fmt.Errorf("find filtered applications by %s near (%v, %v): %w", SortRecentActivity, q.Latitude, q.Longitude, err)
+	}
+	collected, err := pgx.CollectRows(rows, scanActivityPageRow)
+	if err != nil {
+		return nil, "", fmt.Errorf("find filtered applications by %s near (%v, %v): %w", SortRecentActivity, q.Latitude, q.Longitude, err)
+	}
+	apps := make([]PlanningApplication, len(collected))
+	for i := range collected {
+		apps[i] = collected[i].app
+	}
+	next := ""
+	if q.Limit > 0 && len(collected) == q.Limit {
+		cur := activityCursorOf(collected[len(collected)-1])
+		cur.F, cur.U = q.Status, q.Unread
+		next, err = encodePageCursor(cur)
+		if err != nil {
+			return nil, "", fmt.Errorf("encode %s cursor: %w", SortRecentActivity, err)
+		}
+	}
+	return apps, next, nil
 }

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -159,6 +159,11 @@ const invalidStatusMessage = "Invalid status filter."
 // nor absent.
 const invalidUnreadMessage = "Invalid unread filter."
 
+// filterConflictMessage is the 400 body when a real ?status= filter and
+// ?unread=true are sent together: they are mutually exclusive (mirroring the
+// client rule). "All" is not a real status filter, so it does not conflict.
+const filterConflictMessage = "status and unread filters are mutually exclusive."
+
 // valid reports whether the create request passes the pre-handler guard:
 // non-blank name, positive radius within the server ceiling, in-range
 // coordinates, and a positive authority id when one is supplied.
@@ -337,6 +342,13 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 	unreadFilter, unreadOK := parseUnread(r.URL.Query().Get("unread"))
 	if !unreadOK {
 		h.writeError(w, r, http.StatusBadRequest, invalidUnreadMessage)
+		return
+	}
+
+	// Status and unread are mutually exclusive; reject both together before any
+	// query (a status="" means no real filter, so it never conflicts).
+	if status != "" && unreadFilter {
+		h.writeError(w, r, http.StatusBadRequest, filterConflictMessage)
 		return
 	}
 

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -151,6 +151,10 @@ const invalidCursorMessage = "Invalid cursor."
 // ({distance, newest, oldest, status, recent-activity}).
 const invalidSortMessage = "Invalid sort."
 
+// invalidStatusMessage is the 400 body when ?status= is outside the app_state
+// filter vocabulary (and not "All"/absent, which mean no filter).
+const invalidStatusMessage = "Invalid status filter."
+
 // valid reports whether the create request passes the pre-handler guard:
 // non-blank name, positive radius within the server ceiling, in-range
 // coordinates, and a positive authority id when one is supplied.
@@ -316,6 +320,14 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ?status= filters on the raw app_state; "All"/absent means no filter, any
+	// other non-vocabulary value is a clean 400.
+	status, statusOK := parseStatus(r.URL.Query().Get("status"))
+	if !statusOK {
+		h.writeError(w, r, http.StatusBadRequest, invalidStatusMessage)
+		return
+	}
+
 	// decodeCursor strips the transport-layer base64 wrapping; a malformed wrapper
 	// is a clean 400. The unwrapped token is the store's opaque keyset cursor.
 	cursor, ok := decodeCursor(r.URL.Query().Get("cursor"))
@@ -324,7 +336,7 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apps, nextCursor, err := h.findZonePage(r.Context(), userID, zone, sort, sortPresent, r.URL.Query().Get("limit"), cursor)
+	apps, nextCursor, err := h.findZonePage(r.Context(), userID, zone, sort, sortPresent, status, false, r.URL.Query().Get("limit"), cursor)
 	if err != nil {
 		// A stale or sort-mismatched cursor is a client error (400), not a 500: the
 		// keyset cursor is only valid for the sort it was minted under.
@@ -384,14 +396,16 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 	h.writeJSON(w, r, http.StatusOK, results)
 }
 
-// findZonePage runs the bounded spatial page for the zone. With no ?sort= it
-// keeps the legacy nearest-first finder at the 500 default (byte-identical
-// param-less contract); with ?sort= it uses the sort-aware finder at the 150
-// default and a sort-aware keyset cursor. userID scopes the per-user notification
-// join the recent-activity sort needs (ignored by the other sorts). rawLimit is
-// the unparsed ?limit= value; cursor is the transport-unwrapped continuation token.
-func (h *handler) findZonePage(ctx context.Context, userID string, zone WatchZone, sort applications.Sort, sortPresent bool, rawLimit, cursor string) ([]applications.PlanningApplication, string, error) {
-	if !sortPresent {
+// findZonePage runs the bounded spatial page for the zone. A truly param-less
+// request (no ?sort=, no status filter, no unread filter) keeps the legacy
+// nearest-first finder at the 500 default (byte-identical param-less contract).
+// As soon as a sort OR a filter is requested it uses the sort-aware finder at the
+// 150 default and a sort-and-filter-aware keyset cursor. userID scopes the
+// per-user notification data the recent-activity sort joins and the unread filter
+// restricts on. rawLimit is the unparsed ?limit= value; cursor is the
+// transport-unwrapped continuation token.
+func (h *handler) findZonePage(ctx context.Context, userID string, zone WatchZone, sort applications.Sort, sortPresent bool, status string, unread bool, rawLimit, cursor string) ([]applications.PlanningApplication, string, error) {
+	if !sortPresent && status == "" && !unread {
 		limit := parseLimit(rawLimit, defaultNearbyLimit)
 		return h.apps.FindNearbyPage(ctx, zone.Latitude, zone.Longitude, zone.RadiusMetres, limit, cursor)
 	}
@@ -402,6 +416,8 @@ func (h *handler) findZonePage(ctx context.Context, userID string, zone WatchZon
 		Longitude:    zone.Longitude,
 		RadiusMetres: zone.RadiusMetres,
 		Sort:         sort,
+		Status:       status,
+		Unread:       unread,
 		Limit:        limit,
 		Cursor:       cursor,
 	})
@@ -437,6 +453,20 @@ func parseSort(raw string) (sort applications.Sort, present, ok bool) {
 	}
 	s := applications.Sort(raw)
 	return s, true, s.Supported()
+}
+
+// parseStatus resolves ?status= to an app_state filter value. An absent value or
+// the sentinel "All" both mean "no status filter" (returns "", ok). A recognised
+// app_state value passes through. Any other value is an unsupported filter (ok ==
+// false) so the handler returns a clean 400 rather than silently ignoring it.
+func parseStatus(raw string) (status string, ok bool) {
+	if raw == "" || raw == "All" {
+		return "", true
+	}
+	if applications.StatusSupported(raw) {
+		return raw, true
+	}
+	return "", false
 }
 
 // decodeCursor base64url-decodes an opaque ?cursor= value into the store's raw

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -362,9 +362,12 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 
 	apps, nextCursor, err := h.findZonePage(r.Context(), userID, zone, sort, sortPresent, status, unreadFilter, r.URL.Query().Get("limit"), cursor)
 	if err != nil {
-		// A stale or sort-mismatched cursor is a client error (400), not a 500: the
-		// keyset cursor is only valid for the sort it was minted under.
-		if errors.Is(err, applications.ErrCursorInvalid) || errors.Is(err, applications.ErrCursorSortMismatch) {
+		// A stale, sort-mismatched or filter-mismatched cursor is a client error
+		// (400), not a 500: the keyset cursor is only valid for the sort AND filter
+		// it was minted under.
+		if errors.Is(err, applications.ErrCursorInvalid) ||
+			errors.Is(err, applications.ErrCursorSortMismatch) ||
+			errors.Is(err, applications.ErrCursorFilterMismatch) {
 			h.writeError(w, r, http.StatusBadRequest, invalidCursorMessage)
 			return
 		}

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -155,6 +155,10 @@ const invalidSortMessage = "Invalid sort."
 // filter vocabulary (and not "All"/absent, which mean no filter).
 const invalidStatusMessage = "Invalid status filter."
 
+// invalidUnreadMessage is the 400 body when ?unread= is neither "true", "false"
+// nor absent.
+const invalidUnreadMessage = "Invalid unread filter."
+
 // valid reports whether the create request passes the pre-handler guard:
 // non-blank name, positive radius within the server ceiling, in-range
 // coordinates, and a positive authority id when one is supplied.
@@ -328,6 +332,14 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// ?unread=true restricts to applications with an unread notification for the
+	// caller; false/absent means no unread filter. Anything else is a clean 400.
+	unreadFilter, unreadOK := parseUnread(r.URL.Query().Get("unread"))
+	if !unreadOK {
+		h.writeError(w, r, http.StatusBadRequest, invalidUnreadMessage)
+		return
+	}
+
 	// decodeCursor strips the transport-layer base64 wrapping; a malformed wrapper
 	// is a clean 400. The unwrapped token is the store's opaque keyset cursor.
 	cursor, ok := decodeCursor(r.URL.Query().Get("cursor"))
@@ -336,7 +348,7 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	apps, nextCursor, err := h.findZonePage(r.Context(), userID, zone, sort, sortPresent, status, false, r.URL.Query().Get("limit"), cursor)
+	apps, nextCursor, err := h.findZonePage(r.Context(), userID, zone, sort, sortPresent, status, unreadFilter, r.URL.Query().Get("limit"), cursor)
 	if err != nil {
 		// A stale or sort-mismatched cursor is a client error (400), not a 500: the
 		// keyset cursor is only valid for the sort it was minted under.
@@ -467,6 +479,22 @@ func parseStatus(raw string) (status string, ok bool) {
 		return raw, true
 	}
 	return "", false
+}
+
+// parseUnread resolves ?unread= to the unread-only filter flag. "true" turns it
+// on; "false" or absent leave it off. Any other value is rejected (ok == false)
+// so a typo'd flag is a clean 400 rather than being silently treated as off.
+func parseUnread(raw string) (unread, ok bool) {
+	switch raw {
+	case "":
+		return false, true
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	default:
+		return false, false
+	}
 }
 
 // decodeCursor base64url-decodes an opaque ?cursor= value into the store's raw

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -60,7 +60,7 @@ type authorityResolver interface {
 // needs. *applications.PostgresStore satisfies both.
 type appFinder interface {
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]applications.PlanningApplication, string, error)
-	FindInZonePage(ctx context.Context, userID string, latitude, longitude, radiusMetres float64, sort applications.Sort, limit int, cursor string) ([]applications.PlanningApplication, string, error)
+	FindInZonePage(ctx context.Context, q applications.InZoneQuery) ([]applications.PlanningApplication, string, error)
 }
 
 // watermarkReader reads the caller's notification read-watermark. A nil return
@@ -396,7 +396,15 @@ func (h *handler) findZonePage(ctx context.Context, userID string, zone WatchZon
 		return h.apps.FindNearbyPage(ctx, zone.Latitude, zone.Longitude, zone.RadiusMetres, limit, cursor)
 	}
 	limit := parseLimit(rawLimit, defaultSortedLimit)
-	return h.apps.FindInZonePage(ctx, userID, zone.Latitude, zone.Longitude, zone.RadiusMetres, sort, limit, cursor)
+	return h.apps.FindInZonePage(ctx, applications.InZoneQuery{
+		UserID:       userID,
+		Latitude:     zone.Latitude,
+		Longitude:    zone.Longitude,
+		RadiusMetres: zone.RadiusMetres,
+		Sort:         sort,
+		Limit:        limit,
+		Cursor:       cursor,
+	})
 }
 
 // parseLimit resolves ?limit= to a bounded page size: absent, non-numeric, or

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -52,6 +52,8 @@ type fakeAppFinder struct {
 	lastLimit    int
 	lastCursor   string
 	lastUserID   string
+	lastStatus   string
+	lastUnread   bool
 }
 
 func (f *fakeAppFinder) FindNearbyPage(_ context.Context, _, _, _ float64, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
@@ -72,18 +74,20 @@ func (f *fakeAppFinder) FindNearbyPage(_ context.Context, _, _, _ float64, limit
 	return apps, f.next, nil
 }
 
-func (f *fakeAppFinder) FindInZonePage(_ context.Context, userID string, _, _, _ float64, sort applications.Sort, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
+func (f *fakeAppFinder) FindInZonePage(_ context.Context, q applications.InZoneQuery) ([]applications.PlanningApplication, string, error) {
 	f.inZoneCalled = true
-	f.lastUserID = userID
-	f.lastSort = sort
-	f.lastLimit = limit
-	f.lastCursor = cursor
+	f.lastUserID = q.UserID
+	f.lastSort = q.Sort
+	f.lastLimit = q.Limit
+	f.lastCursor = q.Cursor
+	f.lastStatus = q.Status
+	f.lastUnread = q.Unread
 	if f.inZoneErr != nil {
 		return nil, "", f.inZoneErr
 	}
 	apps := f.apps
-	if limit > 0 && len(apps) > limit {
-		apps = apps[:limit]
+	if q.Limit > 0 && len(apps) > q.Limit {
+		apps = apps[:q.Limit]
 	}
 	return apps, f.next, nil
 }

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -1120,6 +1120,74 @@ func TestApplications_UnknownStatusIs400(t *testing.T) {
 	}
 }
 
+// TestApplications_UnreadFilterRoutesToSortAwarePath proves ?unread=true opts into
+// the sort-aware path (even without ?sort=), threads the flag through, and defaults
+// the page size to 150. ?unread=false (like absent) means no unread filter, so it
+// stays on the legacy distance path.
+func TestApplications_UnreadFilterRoutesToSortAwarePath(t *testing.T) {
+	t.Parallel()
+	t.Run("true routes to the filtered path", func(t *testing.T) {
+		t.Parallel()
+		apps := &fakeAppFinder{}
+		mux := newNearbyMux(t, sortDeps(t, apps))
+		rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?unread=true", "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("unread=true: got %d, want 200", rec.Code)
+		}
+		if !apps.inZoneCalled || !apps.lastUnread {
+			t.Errorf("unread=true must use the filtered path with the flag set: inZone=%v unread=%v", apps.inZoneCalled, apps.lastUnread)
+		}
+		if apps.lastSort != applications.SortDistance || apps.lastLimit != 150 {
+			t.Errorf("unread without ?sort= defaults to distance/150: sort=%q limit=%d", apps.lastSort, apps.lastLimit)
+		}
+	})
+	t.Run("true with a sort carries the flag", func(t *testing.T) {
+		t.Parallel()
+		apps := &fakeAppFinder{}
+		mux := newNearbyMux(t, sortDeps(t, apps))
+		rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?sort=oldest&unread=true", "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("sort=oldest&unread=true: got %d, want 200", rec.Code)
+		}
+		if !apps.inZoneCalled || !apps.lastUnread || apps.lastSort != applications.SortOldest {
+			t.Errorf("got inZone=%v unread=%v sort=%q", apps.inZoneCalled, apps.lastUnread, apps.lastSort)
+		}
+	})
+	t.Run("false alone stays on the legacy path", func(t *testing.T) {
+		t.Parallel()
+		apps := &fakeAppFinder{}
+		mux := newNearbyMux(t, sortDeps(t, apps))
+		rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?unread=false", "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("unread=false: got %d, want 200", rec.Code)
+		}
+		if !apps.called || apps.inZoneCalled {
+			t.Errorf("unread=false alone must use the legacy path: called=%v inZone=%v", apps.called, apps.inZoneCalled)
+		}
+	})
+}
+
+// TestApplications_InvalidUnreadIs400 proves ?unread= that is neither true, false
+// nor absent is a clean 400 before any spatial query — never silently treated as
+// off.
+func TestApplications_InvalidUnreadIs400(t *testing.T) {
+	t.Parallel()
+	for _, val := range []string{"yes", "1", "TRUE", "True", "nope"} {
+		t.Run(val, func(t *testing.T) {
+			t.Parallel()
+			apps := &fakeAppFinder{}
+			mux := newNearbyMux(t, sortDeps(t, apps))
+			rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?unread="+val, "")
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("unread=%q: got %d, want 400", val, rec.Code)
+			}
+			if apps.called || apps.inZoneCalled {
+				t.Error("must not run any spatial query for an invalid unread value")
+			}
+		})
+	}
+}
+
 // manyApps builds n distinct nearby applications, for asserting the bounded page
 // caps the downstream unread UID set.
 func manyApps(n int) []applications.PlanningApplication {

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -1188,6 +1188,38 @@ func TestApplications_InvalidUnreadIs400(t *testing.T) {
 	}
 }
 
+// TestApplications_StatusAndUnreadTogetherIs400 proves a status filter and the
+// unread filter together are rejected with 400 before any spatial query — they
+// are mutually exclusive. "All" is not a real status filter, so All + unread is
+// allowed.
+func TestApplications_StatusAndUnreadTogetherIs400(t *testing.T) {
+	t.Parallel()
+	t.Run("real status + unread is 400", func(t *testing.T) {
+		t.Parallel()
+		apps := &fakeAppFinder{}
+		mux := newNearbyMux(t, sortDeps(t, apps))
+		rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?status=Permitted&unread=true", "")
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status=Permitted&unread=true: got %d, want 400", rec.Code)
+		}
+		if apps.called || apps.inZoneCalled {
+			t.Error("must not run any spatial query when status and unread conflict")
+		}
+	})
+	t.Run("All + unread is allowed", func(t *testing.T) {
+		t.Parallel()
+		apps := &fakeAppFinder{}
+		mux := newNearbyMux(t, sortDeps(t, apps))
+		rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?status=All&unread=true", "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=All&unread=true: got %d, want 200", rec.Code)
+		}
+		if !apps.inZoneCalled || !apps.lastUnread || apps.lastStatus != "" {
+			t.Errorf("All+unread must filter on unread only: inZone=%v unread=%v status=%q", apps.inZoneCalled, apps.lastUnread, apps.lastStatus)
+		}
+	})
+}
+
 // manyApps builds n distinct nearby applications, for asserting the bounded page
 // caps the downstream unread UID set.
 func manyApps(n int) []applications.PlanningApplication {

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -1037,6 +1037,89 @@ func TestApplications_ParamlessGoldenResponse(t *testing.T) {
 	}
 }
 
+// TestApplications_StatusFilterRoutesToSortAwarePath proves ?status= opts into the
+// sort-aware path (even without ?sort=, since a filter needs the filterable
+// finder), threads the exact app_state through, and defaults the page size to 150.
+// "All" means no status filter, so ?status=All alone (no sort) stays on the legacy
+// distance path.
+func TestApplications_StatusFilterRoutesToSortAwarePath(t *testing.T) {
+	t.Parallel()
+	for _, status := range []string{"Undecided", "Permitted", "Conditions", "Rejected", "Withdrawn", "Appealed"} {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			apps := &fakeAppFinder{}
+			mux := newNearbyMux(t, sortDeps(t, apps))
+			rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?status="+status, "")
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status=%q: got %d, want 200", status, rec.Code)
+			}
+			if !apps.inZoneCalled {
+				t.Fatalf("status=%q must use the sort-aware FindInZonePage path", status)
+			}
+			if apps.lastStatus != status {
+				t.Errorf("threaded status: got %q, want %q", apps.lastStatus, status)
+			}
+			if apps.lastSort != applications.SortDistance {
+				t.Errorf("status filter without ?sort= defaults to distance: got %q", apps.lastSort)
+			}
+			if apps.lastLimit != 150 {
+				t.Errorf("filtered default limit: got %d, want 150", apps.lastLimit)
+			}
+		})
+	}
+}
+
+// TestApplications_StatusAllIsNoFilter proves ?status=All means "no status
+// filter": with no sort it stays byte-identical on the legacy distance path, and
+// combined with a sort it routes to the sort-aware path with an empty status.
+func TestApplications_StatusAllIsNoFilter(t *testing.T) {
+	t.Parallel()
+	t.Run("All alone stays on the legacy path", func(t *testing.T) {
+		t.Parallel()
+		apps := &fakeAppFinder{}
+		mux := newNearbyMux(t, sortDeps(t, apps))
+		rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?status=All", "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status=All: got %d, want 200", rec.Code)
+		}
+		if !apps.called || apps.inZoneCalled {
+			t.Errorf("status=All alone must use the legacy FindNearbyPage path: called=%v inZone=%v", apps.called, apps.inZoneCalled)
+		}
+	})
+	t.Run("All with a sort carries no status filter", func(t *testing.T) {
+		t.Parallel()
+		apps := &fakeAppFinder{}
+		mux := newNearbyMux(t, sortDeps(t, apps))
+		rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?sort=newest&status=All", "")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("sort=newest&status=All: got %d, want 200", rec.Code)
+		}
+		if !apps.inZoneCalled || apps.lastStatus != "" {
+			t.Errorf("status=All must thread an empty status filter: inZone=%v status=%q", apps.inZoneCalled, apps.lastStatus)
+		}
+	})
+}
+
+// TestApplications_UnknownStatusIs400 proves any ?status= outside the app_state
+// vocabulary (and absent "All") is rejected with 400 before any spatial query.
+func TestApplications_UnknownStatusIs400(t *testing.T) {
+	t.Parallel()
+	for _, status := range []string{"nonsense", "permitted", "REJECTED", "Approved", "all"} {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			apps := &fakeAppFinder{}
+			mux := newNearbyMux(t, sortDeps(t, apps))
+			rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?status="+status, "")
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status=%q: got %d, want 400", status, rec.Code)
+			}
+			if apps.called || apps.inZoneCalled {
+				t.Error("must not run any spatial query for an unrecognised status")
+			}
+		})
+	}
+}
+
 // manyApps builds n distinct nearby applications, for asserting the bounded page
 // caps the downstream unread UID set.
 func manyApps(n int) []applications.PlanningApplication {

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -1220,6 +1220,21 @@ func TestApplications_StatusAndUnreadTogetherIs400(t *testing.T) {
 	})
 }
 
+// TestApplications_CursorFilterMismatchIs400 proves a cursor minted under one
+// filter and replayed under another (the store reports ErrCursorFilterMismatch)
+// surfaces as 400, never a gapped or overlapping page.
+func TestApplications_CursorFilterMismatchIs400(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{inZoneErr: applications.ErrCursorFilterMismatch}
+	mux := newNearbyMux(t, sortDeps(t, apps))
+
+	cursor := base64.RawURLEncoding.EncodeToString([]byte("cursor-from-another-filter"))
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications?sort=newest&status=Permitted&cursor="+cursor, "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", rec.Code)
+	}
+}
+
 // manyApps builds n distinct nearby applications, for asserting the bounded page
 // caps the downstream unread UID set.
 func manyApps(n int) []applications.PlanningApplication {


### PR DESCRIPTION
## What

Slice 4 (API) of epic #682 — server-side `status` and `unread` filters that compose with every sort and the keyset paging.

- **`?status=<appState>`** ⇒ `AND app_state = $x` injected into the spatial+keyset WHERE for all sorts. Vocabulary: Undecided/Permitted/Conditions/Rejected/Withdrawn/Appealed; `All`/absent ⇒ no filter; unknown ⇒ 400.
- **`?unread=true`** ⇒ INNER JOIN the per-caller latest-unread subquery (`created_at > last_read_at`, joined on `uid` + `area_id=authority_id`). For `recent-activity` it's INNER (filters) and still feeds `GREATEST`; first-touch users (no `notification_state`) get an empty set.
- **`?status=` + `?unread=true` together ⇒ 400** (mutual exclusion), checked in the handler before any spatial query.
- **Filter-aware cursor**: `pageCursor` gains `F` (status) + `U` (unread), both `omitempty` so pre-slice-4 cursors still decode (unfiltered). A cursor whose embedded filter ≠ the request's ⇒ `ErrCursorFilterMismatch` ⇒ 400, symmetric with the sort-mode mismatch.
- **Signature**: `FindInZonePage` refactored to take an `InZoneQuery{UserID, Latitude, Longitude, RadiusMetres, Sort, Status, Unread, Limit, Cursor}` struct (kills the long param list).
- **Zero-regression design**: the proven slice 1–3 constant queries stay untouched for unfiltered requests; filtered requests use a new dynamic builder whose ORDER BY + keyset predicates mirror the constants exactly. No new migration (reuses `app_state`, the sort-keyset indexes, and `notifications_user_app_created`).

distance stays default; param-less call byte-identical (golden test intact).

## Tests

pgtest `//go:build integration` (run by `go-integration` pr-gate; also verified locally on brew PostGIS 3.6.4 — 1273 pass): status filter under distance/newest/status sorts, unread filter incl. first-touch + recent-activity compose, cursor-filter-mismatch (status→status/unread/unfiltered, same-filter continues). Handler fakes: unknown status ⇒ 400, status+unread ⇒ 400 (no query runs), valid filters route to the filtered path, param-less golden intact.

Epic: #682 · Bead: tc-b7cz