### PR TITLE
feat(ios): watch-zone filter chips drive server-side status/unread filtering (tc-22gb, #682 slice 4)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
@@ -35,6 +35,17 @@ public final class APIPlanningApplicationRepository: PlanningApplicationReposito
       URLQueryItem(name: "sort", value: sort.rawValue),
       URLQueryItem(name: "limit", value: String(limit)),
     ]
+    // Status and unread are mutually exclusive at the type level, so at most one
+    // of these is ever appended — the server 400s if both arrive together. The
+    // `.all` case omits both (the "All" chip / Unread off).
+    switch filter {
+    case .all:
+      break
+    case .status(let status):
+      query.append(URLQueryItem(name: "status", value: status.rawValue))
+    case .unread:
+      query.append(URLQueryItem(name: "unread", value: "true"))
+    }
     if let cursor, !cursor.isEmpty {
       query.append(URLQueryItem(name: "cursor", value: cursor))
     }

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
@@ -27,6 +27,7 @@ public final class APIPlanningApplicationRepository: PlanningApplicationReposito
   public func fetchApplicationsPage(
     for zone: WatchZone,
     sort: ApplicationSortOrder,
+    filter: ApplicationFilter,
     cursor: String?,
     limit: Int
   ) async throws -> ApplicationPage {

--- a/mobile/ios/packages/town-crier-domain/Sources/Entities/OfflineAwareRepository.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Entities/OfflineAwareRepository.swift
@@ -59,11 +59,12 @@ public final class OfflineAwareRepository: Sendable {
   public func fetchApplicationsPage(
     for zone: WatchZone,
     sort: ApplicationSortOrder,
+    filter: ApplicationFilter,
     cursor: String?,
     limit: Int
   ) async throws -> ApplicationPage {
     try await remote.fetchApplicationsPage(
-      for: zone, sort: sort, cursor: cursor, limit: limit)
+      for: zone, sort: sort, filter: filter, cursor: cursor, limit: limit)
   }
 
   /// Invalidates the cached applications for the given zone id.

--- a/mobile/ios/packages/town-crier-domain/Sources/Protocols/PlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Protocols/PlanningApplicationRepository.swift
@@ -3,14 +3,16 @@ public protocol PlanningApplicationRepository: Sendable {
   func fetchApplications(for zone: WatchZone) async throws -> [PlanningApplication]
   func fetchApplication(by id: PlanningApplicationId) async throws -> PlanningApplication
 
-  /// Fetches a single server-sorted, server-paged page of a zone's
-  /// applications, returning the decoded rows plus the continuation cursor for
-  /// the next page (`nil` on the last page). Used by the list's infinite scroll
-  /// to page the full set in the selected server sort order (GH#682 slice 1).
-  /// The map keeps using ``fetchApplications(for:)`` (param-less, first page).
+  /// Fetches a single server-sorted, server-filtered, server-paged page of a
+  /// zone's applications, returning the decoded rows plus the continuation
+  /// cursor for the next page (`nil` on the last page). Used by the list's
+  /// infinite scroll to page the full set in the selected server sort order and
+  /// filter (GH#682 slices 1 and 4). The map keeps using
+  /// ``fetchApplications(for:)`` (param-less, first page).
   func fetchApplicationsPage(
     for zone: WatchZone,
     sort: ApplicationSortOrder,
+    filter: ApplicationFilter,
     cursor: String?,
     limit: Int
   ) async throws -> ApplicationPage

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/ApplicationFilter.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/ApplicationFilter.swift
@@ -1,0 +1,16 @@
+/// The server-side filter applied to the paged watch-zone applications
+/// endpoint (GH#682 slice 4). Status and unread are mutually exclusive — the
+/// server 400s when both are sent — so they are modelled as a single sum type
+/// rather than two independent flags, making "both at once" unrepresentable at
+/// the call boundary. The list's status chips and Unread toggle collapse to one
+/// of these cases.
+public enum ApplicationFilter: Sendable, Equatable {
+  /// No filter — the "All" chip with the Unread toggle off. Sends neither
+  /// `?status=` nor `?unread=`.
+  case all
+  /// Restrict to a single PlanIt `app_state`. Sends `?status=<rawValue>`.
+  case status(ApplicationStatus)
+  /// Restrict to applications with an unread notification for the caller.
+  /// Sends `?unread=true`.
+  case unread
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
@@ -50,6 +50,13 @@ public struct ApplicationListView: View {
       // between the two client-side sorts only re-orders in memory (GH#682).
       Task { await viewModel.handleSortChanged() }
     }
+    .onChange(of: viewModel.activeFilter) {
+      // The status chips and Unread toggle now drive the server query, so a
+      // filter change re-pages from page 1 with a fresh cursor (GH#682 slice 4).
+      // Observing the derived `activeFilter` coalesces the chip + Unread updates
+      // into a single reload even when one toggle clears the other.
+      Task { await viewModel.handleFilterChanged() }
+    }
   }
 
   // MARK: - Toolbar

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+Pagination.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+Pagination.swift
@@ -80,7 +80,8 @@ extension ApplicationListViewModel {
   /// cursor and re-pages under the new filter — the same mechanism as a sort
   /// change. A no-op when the active filter has not actually changed.
   public func handleFilterChanged() async {
-    // Implemented in the green step.
+    guard activeFilter != loadedFilter else { return }
+    await loadApplications()
   }
 
   /// Appends a server page, dropping any rows already loaded so a keyset overlap

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+Pagination.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+Pagination.swift
@@ -24,6 +24,7 @@ extension ApplicationListViewModel {
       nextCursor = nil
     }
     loadedSort = sort
+    loadedFilter = activeFilter
   }
 
   /// Fetches and appends the next server page when one exists. No-op unless the
@@ -81,6 +82,11 @@ extension ApplicationListViewModel {
     nextCursor = page.nextCursor
   }
 
+  /// Fetches one page, threading the ViewModel's current ``activeFilter`` into
+  /// the request so every page (first and subsequent) carries the same
+  /// `?status=`/`?unread=` filter. A filter change resets the cursor and
+  /// reloads from page 1 (see ``handleFilterChanged()``), so a cursor is only
+  /// ever replayed under the filter it was minted with.
   private func fetchPage(
     for zone: WatchZone,
     sort order: ApplicationSortOrder,
@@ -88,11 +94,11 @@ extension ApplicationListViewModel {
   ) async throws -> ApplicationPage {
     if let offlineRepository {
       return try await offlineRepository.fetchApplicationsPage(
-        for: zone, sort: order, cursor: cursor, limit: Self.pageSize)
+        for: zone, sort: order, filter: activeFilter, cursor: cursor, limit: Self.pageSize)
     }
     if let repository {
       return try await repository.fetchApplicationsPage(
-        for: zone, sort: order, cursor: cursor, limit: Self.pageSize)
+        for: zone, sort: order, filter: activeFilter, cursor: cursor, limit: Self.pageSize)
     }
     return ApplicationPage(applications: [], nextCursor: nil)
   }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+Pagination.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+Pagination.swift
@@ -74,6 +74,15 @@ extension ApplicationListViewModel {
     await loadApplications()
   }
 
+  /// Reacts to a filter change from the chip group (status chip or Unread
+  /// toggle). The selected filter drives the server query now (GH#682 slice 4),
+  /// not a client-side post-filter, so a change reloads from page 1 with a fresh
+  /// cursor and re-pages under the new filter — the same mechanism as a sort
+  /// change. A no-op when the active filter has not actually changed.
+  public func handleFilterChanged() async {
+    // Implemented in the green step.
+  }
+
   /// Appends a server page, dropping any rows already loaded so a keyset overlap
   /// at a page boundary never duplicates a row. Captures the new cursor.
   private func appendPage(_ page: ApplicationPage) {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -146,13 +146,15 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     }
   }
 
-  /// The rows to render: the loaded `applications` with the client-side
-  /// status/unread filter applied. Ordering is owned entirely by the server
-  /// (every sort is paged via `?sort=` since GH#682 slice 3), so there is no
-  /// local re-sort — that would only ever order the pages already loaded. The
-  /// status/unread filter stays client-side until slice 4.
+  /// The rows to render. Ordering **and** filtering are owned entirely by the
+  /// server now: every sort is paged via `?sort=` (GH#682 slice 3) and the
+  /// status/unread filter is applied server-side via `?status=`/`?unread=`
+  /// (slice 4). The loaded `applications` are therefore the authoritative,
+  /// already-filtered, already-ordered set — rendered verbatim with no local
+  /// re-sort or re-filter (either would only ever touch the pages already
+  /// loaded). The name is kept for call-site stability.
   public var filteredApplications: [PlanningApplication] {
-    filterApplications(applications)
+    applications
   }
 
   public var isEmpty: Bool {
@@ -340,18 +342,6 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
       return try await repository.fetchApplications(for: zone)
     }
     return []
-  }
-
-  private func filterApplications(
-    _ applications: [PlanningApplication]
-  ) -> [PlanningApplication] {
-    if unreadOnly {
-      return applications.filter { $0.latestUnreadEvent != nil }
-    }
-    if let filter = selectedStatusFilter {
-      return applications.filter { $0.status == filter }
-    }
-    return applications
   }
 
   private static func readPersistedSort(

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -47,6 +47,20 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   public var unreadCount: Int {
     applications.filter { $0.latestUnreadEvent != nil }.count
   }
+  /// The single server filter derived from the chip group (GH#682 slice 4). The
+  /// Unread toggle and the status chips are mutually exclusive (enforced by the
+  /// `didSet`s above and the server's 400 on both), so they collapse to exactly
+  /// one ``ApplicationFilter`` case. This is the value sent as `?status=`/
+  /// `?unread=` and the trigger the view observes to reload on a filter change.
+  public var activeFilter: ApplicationFilter {
+    if unreadOnly {
+      return .unread
+    }
+    if let status = selectedStatusFilter {
+      return .status(status)
+    }
+    return .all
+  }
   /// Bound by the sort menu. Setter persists the choice to `UserDefaults`
   /// under `sortKey` so user intent survives relaunches (spec decision #10).
   @Published var sort: ApplicationsSort {
@@ -80,6 +94,10 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   /// transition away from one reload; a client→client switch only re-sorts in
   /// memory, as before).
   var loadedSort: ApplicationsSort?
+  /// The filter the currently-loaded `applications` were fetched under. Lets a
+  /// filter change short-circuit when it would not change the query (GH#682
+  /// slice 4). Set alongside `loadedSort` on every fresh first-page load.
+  var loadedFilter: ApplicationFilter?
   /// Re-entrancy guard for next-page fetches — independent of `isLoadInFlight`
   /// so an in-flight first-page load never blocks (or is blocked by) appends.
   var isPageLoadInFlight = false

--- a/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryPagedTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryPagedTests.swift
@@ -80,7 +80,7 @@ struct APIPlanningApplicationRepositoryPagedTests {
     ])
 
     _ = try await sut.fetchApplicationsPage(
-      for: testZone, sort: .newest, cursor: nil, limit: 150)
+      for: testZone, sort: .newest, filter: .all, cursor: nil, limit: 150)
 
     let url = try #require(transport.requests[0].url)
     #expect(url.path() == "/v1/me/watch-zones/zone-123/applications")
@@ -91,6 +91,48 @@ struct APIPlanningApplicationRepositoryPagedTests {
     #expect(!hasCursor)
   }
 
+  @Test("a status filter sends ?status=<appState> and no ?unread=")
+  func fetchApplicationsPage_statusFilter_sendsStatusParam() async throws {
+    let (sut, transport) = makeSUT(responses: [
+      (Data("[]".utf8), httpResponse(statusCode: 200, headers: [:]))
+    ])
+
+    _ = try await sut.fetchApplicationsPage(
+      for: testZone, sort: .newest, filter: .status(.permitted), cursor: nil, limit: 150)
+
+    let items = try queryItems(transport, at: 0)
+    #expect(items.contains(URLQueryItem(name: "status", value: "Permitted")))
+    #expect(!items.contains { $0.name == "unread" })
+  }
+
+  @Test("the unread filter sends ?unread=true and no ?status=")
+  func fetchApplicationsPage_unreadFilter_sendsUnreadParam() async throws {
+    let (sut, transport) = makeSUT(responses: [
+      (Data("[]".utf8), httpResponse(statusCode: 200, headers: [:]))
+    ])
+
+    _ = try await sut.fetchApplicationsPage(
+      for: testZone, sort: .newest, filter: .unread, cursor: nil, limit: 150)
+
+    let items = try queryItems(transport, at: 0)
+    #expect(items.contains(URLQueryItem(name: "unread", value: "true")))
+    #expect(!items.contains { $0.name == "status" })
+  }
+
+  @Test("the All filter sends neither ?status= nor ?unread=")
+  func fetchApplicationsPage_allFilter_sendsNeitherParam() async throws {
+    let (sut, transport) = makeSUT(responses: [
+      (Data("[]".utf8), httpResponse(statusCode: 200, headers: [:]))
+    ])
+
+    _ = try await sut.fetchApplicationsPage(
+      for: testZone, sort: .newest, filter: .all, cursor: nil, limit: 150)
+
+    let items = try queryItems(transport, at: 0)
+    #expect(!items.contains { $0.name == "status" })
+    #expect(!items.contains { $0.name == "unread" })
+  }
+
   @Test("paging beyond the first page sends the cursor")
   func fetchApplicationsPage_withCursor_includesCursorParam() async throws {
     let (sut, transport) = makeSUT(responses: [
@@ -98,7 +140,7 @@ struct APIPlanningApplicationRepositoryPagedTests {
     ])
 
     _ = try await sut.fetchApplicationsPage(
-      for: testZone, sort: .oldest, cursor: "abc123", limit: 150)
+      for: testZone, sort: .oldest, filter: .all, cursor: "abc123", limit: 150)
 
     let items = try queryItems(transport, at: 0)
     #expect(items.contains(URLQueryItem(name: "sort", value: "oldest")))
@@ -112,7 +154,7 @@ struct APIPlanningApplicationRepositoryPagedTests {
     ])
 
     let page = try await sut.fetchApplicationsPage(
-      for: testZone, sort: .newest, cursor: nil, limit: 150)
+      for: testZone, sort: .newest, filter: .all, cursor: nil, limit: 150)
 
     #expect(page.applications.count == 1)
     #expect(page.applications.first?.reference == ApplicationReference("2026/0042"))
@@ -126,7 +168,7 @@ struct APIPlanningApplicationRepositoryPagedTests {
     ])
 
     let page = try await sut.fetchApplicationsPage(
-      for: testZone, sort: .distance, cursor: nil, limit: 150)
+      for: testZone, sort: .distance, filter: .all, cursor: nil, limit: 150)
 
     #expect(page.applications.isEmpty)
     #expect(page.nextCursor == nil)
@@ -144,7 +186,7 @@ struct APIPlanningApplicationRepositoryPagedTests {
 
     await #expect(throws: DomainError.networkUnavailable) {
       _ = try await sut.fetchApplicationsPage(
-        for: testZone, sort: .newest, cursor: nil, limit: 150)
+        for: testZone, sort: .newest, filter: .all, cursor: nil, limit: 150)
     }
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelFilterTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelFilterTests.swift
@@ -1,0 +1,185 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Server-driven status/unread filtering for the watch-zone list (GH#682
+/// slice 4). The status chips and the Unread toggle now drive the `?status=`/
+/// `?unread=` query params rather than a client-side post-filter, so changing a
+/// filter resets the cursor and reloads from page 1, the server's returned set
+/// is rendered verbatim (no local re-filtering), and status and unread are never
+/// sent together. The per-row `latestUnreadEvent` badge/count stays client-side.
+@Suite("ApplicationListViewModel — server-side filters (GH#682 slice 4)")
+@MainActor
+struct ApplicationListViewModelFilterTests {
+
+  private func makeSUT(
+    pages: [ApplicationPage] = []
+  ) throws -> (ApplicationListViewModel, SpyPlanningApplicationRepository) {
+    let spy = SpyPlanningApplicationRepository()
+    spy.pagedResponses = pages
+    let defaults = try #require(UserDefaults(suiteName: UUID().uuidString))
+    defaults.set(ApplicationsSort.newest.rawValue, forKey: "test.filterSort")
+    let vm = ApplicationListViewModel(
+      repository: spy,
+      zone: .cambridge,
+      userDefaults: defaults,
+      sortKey: "test.filterSort"
+    )
+    return (vm, spy)
+  }
+
+  private func event(at seconds: TimeInterval) -> LatestUnreadEvent {
+    LatestUnreadEvent(type: "NewApplication", decision: nil, createdAt: Date(timeIntervalSince1970: seconds))
+  }
+
+  // MARK: - Filter drives the query param
+
+  @Test("selecting a status chip issues ?status= and reloads from page 1")
+  func selectingStatus_issuesStatusParam_andReloadsPageOne() async throws {
+    let firstPage = ApplicationPage(applications: [.pendingReview], nextCursor: "page-2")
+    let (sut, spy) = try makeSUT(pages: [firstPage])
+
+    await sut.loadApplications()
+    #expect(spy.fetchApplicationsPageCalls.last?.filter == .all)
+
+    spy.pagedResponses = [ApplicationPage(applications: [.permitted], nextCursor: nil)]
+    sut.selectedStatusFilter = .permitted
+    await sut.handleFilterChanged()
+
+    let last = try #require(spy.fetchApplicationsPageCalls.last)
+    #expect(last.filter == .status(.permitted))
+    #expect(last.cursor == nil)
+  }
+
+  @Test("toggling Unread issues ?unread=true and reloads from page 1")
+  func togglingUnread_issuesUnreadParam_andReloadsPageOne() async throws {
+    let firstPage = ApplicationPage(applications: [.pendingReview], nextCursor: "page-2")
+    let (sut, spy) = try makeSUT(pages: [firstPage])
+
+    await sut.loadApplications()
+    #expect(spy.fetchApplicationsPageCalls.last?.filter == .all)
+
+    spy.pagedResponses = [ApplicationPage(applications: [.permitted], nextCursor: nil)]
+    sut.unreadOnly = true
+    await sut.handleFilterChanged()
+
+    let last = try #require(spy.fetchApplicationsPageCalls.last)
+    #expect(last.filter == .unread)
+    #expect(last.cursor == nil)
+  }
+
+  @Test("clearing back to All issues no status/unread and reloads from page 1")
+  func clearingToAll_issuesNoFilter_andReloadsPageOne() async throws {
+    let statusPage = ApplicationPage(applications: [.permitted], nextCursor: "page-2")
+    let (sut, spy) = try makeSUT(pages: [statusPage])
+
+    sut.selectedStatusFilter = .permitted
+    await sut.loadApplications()
+    #expect(spy.fetchApplicationsPageCalls.last?.filter == .status(.permitted))
+
+    spy.pagedResponses = [ApplicationPage(applications: [.pendingReview], nextCursor: nil)]
+    sut.selectedStatusFilter = nil
+    await sut.handleFilterChanged()
+
+    let last = try #require(spy.fetchApplicationsPageCalls.last)
+    #expect(last.filter == .all)
+    #expect(last.cursor == nil)
+  }
+
+  @Test("an unchanged filter does not refetch")
+  func unchangedFilter_doesNotRefetch() async throws {
+    let (sut, spy) = try makeSUT(pages: [ApplicationPage(applications: [.pendingReview], nextCursor: nil)])
+
+    await sut.loadApplications()
+    let callsBefore = spy.fetchApplicationsPageCalls.count
+
+    // activeFilter is still `.all` — no real change, so no reload.
+    await sut.handleFilterChanged()
+
+    #expect(spy.fetchApplicationsPageCalls.count == callsBefore)
+  }
+
+  // MARK: - No client-side re-filtering
+
+  @Test("the server's returned set is rendered verbatim — no local re-filter")
+  func serverFilteredPage_renderedVerbatim() async throws {
+    // Under the Unread filter the server returns the authoritative set. It is
+    // rendered as-is: a row whose latestUnreadEvent is nil (would be dropped by
+    // the old client-side unread filter) must survive, proving no local
+    // re-filtering remains.
+    let unreadRow = PlanningApplication.pendingReview.withLatestUnreadEvent(event(at: 1_700_000_000))
+    let readRow = PlanningApplication.permitted.withLatestUnreadEvent(nil)
+    let allPage = ApplicationPage(applications: [.rejected], nextCursor: nil)
+    let serverFilteredPage = ApplicationPage(applications: [unreadRow, readRow], nextCursor: nil)
+    let (sut, _) = try makeSUT(pages: [allPage, serverFilteredPage])
+
+    await sut.loadApplications()
+    sut.unreadOnly = true
+    await sut.handleFilterChanged()
+
+    #expect(sut.filteredApplications.map(\.id) == [unreadRow, readRow].map(\.id))
+  }
+
+  @Test("a status that no loaded row matches is still rendered verbatim")
+  func statusFilteredPage_renderedVerbatim() async throws {
+    // The server owns which rows match the status; the client does not re-check
+    // `app_state`. The returned page contains a row whose status differs from
+    // the selected chip and it must still render (server is the source of truth).
+    let allPage = ApplicationPage(applications: [.pendingReview], nextCursor: nil)
+    let serverFilteredPage = ApplicationPage(applications: [.rejected, .withdrawn], nextCursor: nil)
+    let (sut, _) = try makeSUT(pages: [allPage, serverFilteredPage])
+
+    await sut.loadApplications()
+    sut.selectedStatusFilter = .permitted
+    await sut.handleFilterChanged()
+
+    #expect(sut.filteredApplications.map(\.id) == [PlanningApplication.rejected, .withdrawn].map(\.id))
+  }
+
+  // MARK: - Mutual exclusivity
+
+  @Test("selecting a status while Unread is on clears Unread — never both")
+  func selectingStatus_whileUnreadOn_clearsUnread() async throws {
+    let (sut, _) = try makeSUT(pages: [ApplicationPage(applications: [.pendingReview], nextCursor: nil)])
+
+    await sut.loadApplications()
+    sut.unreadOnly = true
+    sut.selectedStatusFilter = .permitted
+
+    #expect(!sut.unreadOnly)
+    #expect(sut.activeFilter == .status(.permitted))
+  }
+
+  @Test("toggling Unread while a status is selected clears the status — never both")
+  func togglingUnread_whileStatusSelected_clearsStatus() async throws {
+    let (sut, _) = try makeSUT(pages: [ApplicationPage(applications: [.pendingReview], nextCursor: nil)])
+
+    await sut.loadApplications()
+    sut.selectedStatusFilter = .permitted
+    sut.unreadOnly = true
+
+    #expect(sut.selectedStatusFilter == nil)
+    #expect(sut.activeFilter == .unread)
+  }
+
+  // MARK: - Badge / unread count regression (stays client-side)
+
+  @Test("unreadCount still derives from latestUnreadEvent after a server filter")
+  func unreadCount_stillDerivesFromLatestUnreadEvent() async throws {
+    let unreadRow = PlanningApplication.pendingReview.withLatestUnreadEvent(event(at: 1_700_000_000))
+    let readRow = PlanningApplication.permitted.withLatestUnreadEvent(nil)
+    let allPage = ApplicationPage(applications: [.rejected], nextCursor: nil)
+    let serverFilteredPage = ApplicationPage(applications: [unreadRow, readRow], nextCursor: nil)
+    let (sut, _) = try makeSUT(pages: [allPage, serverFilteredPage])
+
+    await sut.loadApplications()
+    sut.selectedStatusFilter = .permitted
+    await sut.handleFilterChanged()
+
+    // One of the two rendered rows carries a latestUnreadEvent.
+    #expect(sut.unreadCount == 1)
+    #expect(sut.hasUnread)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelTests.swift
@@ -19,10 +19,6 @@ struct ApplicationListViewModelTests {
     return (vm, spy)
   }
 
-  private static let allApps: [PlanningApplication] = [
-    .pendingReview, .permitted, .rejected, .withdrawn,
-  ]
-
   // MARK: - Loading
   @Test func loadApplications_preservesServerReturnedOrder() async throws {
     // The server owns ordering for every sort now (GH#682 slice 3): the client
@@ -93,37 +89,11 @@ struct ApplicationListViewModelTests {
     #expect(selectedId == PlanningApplicationId(authority: "CAM", name: "2026/0042"))
   }
 
-  // MARK: - Status Filtering (free for all tiers — tc-acf0)
-
-  @Test func filterByStatus_filtersByPermitted() async throws {
-    let (sut, _) = try makeSUT(applications: Self.allApps)
-    await sut.loadApplications()
-
-    sut.selectedStatusFilter = .permitted
-
-    #expect(sut.filteredApplications.count == 1)
-    #expect(sut.filteredApplications.first?.status == .permitted)
-  }
-
-  @Test func filterByStatus_nilFilter_showsAll() async throws {
-    let (sut, _) = try makeSUT(applications: Self.allApps)
-    await sut.loadApplications()
-
-    sut.selectedStatusFilter = .permitted
-    #expect(sut.filteredApplications.count == 1)
-
-    sut.selectedStatusFilter = nil
-    #expect(sut.filteredApplications.count == 4)
-  }
-
-  @Test func filterByStatus_noMatchingResults_returnsEmpty() async throws {
-    let (sut, _) = try makeSUT(applications: [.pendingReview])
-    await sut.loadApplications()
-
-    sut.selectedStatusFilter = .permitted
-
-    #expect(sut.filteredApplications.isEmpty)
-  }
+  // Status/unread filtering moved server-side in GH#682 slice 4 — the chips and
+  // Unread toggle now drive `?status=`/`?unread=` and the ViewModel renders the
+  // server's returned set verbatim. That behaviour lives in
+  // `ApplicationListViewModelFilterTests`; there is no longer any client-side
+  // `filterApplications` to exercise here.
 
   // MARK: - Zone Resolution
 

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
@@ -121,21 +121,14 @@ struct ApplicationListViewModelUnreadTests {
   }
 
   // MARK: - Unread filter
-
-  @Test("unreadOnly filter keeps only rows with non-nil latestUnreadEvent")
-  func unreadOnly_filtersToUnreadRows() async throws {
-    let unread = PlanningApplication.pendingReview
-      .withLatestUnreadEvent(event(at: 1_700_500_000))
-    let read = PlanningApplication.permitted
-      .withLatestUnreadEvent(nil)
-    let (sut, _, _, _) = try makeSUT(applications: [unread, read])
-
-    await sut.loadApplications()
-    sut.unreadOnly = true
-
-    #expect(sut.filteredApplications.count == 1)
-    #expect(sut.filteredApplications.first?.id == unread.id)
-  }
+  //
+  // The Unread filter moved server-side in GH#682 slice 4: toggling it issues
+  // `?unread=true`, resets the cursor, and reloads page 1, and the ViewModel
+  // renders the server's returned set verbatim (no client-side
+  // `latestUnreadEvent != nil` post-filter). That behaviour is covered in
+  // `ApplicationListViewModelFilterTests`. The mutual-exclusivity rule below
+  // (the chip + Unread single-select group) is still enforced in the ViewModel's
+  // `didSet`s and stays here.
 
   @Test("toggling unreadOnly clears the status filter (single-select group)")
   func unreadOnly_clearsStatusFilter() async throws {

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyPlanningApplicationRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyPlanningApplicationRepository.swift
@@ -49,10 +49,12 @@ final class SpyPlanningApplicationRepository: PlanningApplicationRepository, @un
   // MARK: - Paged fetch (GH#682)
 
   /// A recorded `fetchApplicationsPage` invocation — lets tests assert the exact
-  /// query params (sort + cursor + limit) the ViewModel drove for each page.
+  /// query params (sort + filter + cursor + limit) the ViewModel drove for each
+  /// page.
   struct RecordedPageRequest: Sendable {
     let zone: WatchZone
     let sort: ApplicationSortOrder
+    let filter: ApplicationFilter
     let cursor: String?
     let limit: Int
   }
@@ -72,11 +74,12 @@ final class SpyPlanningApplicationRepository: PlanningApplicationRepository, @un
   func fetchApplicationsPage(
     for zone: WatchZone,
     sort: ApplicationSortOrder,
+    filter: ApplicationFilter,
     cursor: String?,
     limit: Int
   ) async throws -> ApplicationPage {
     fetchApplicationsPageCalls.append(
-      RecordedPageRequest(zone: zone, sort: sort, cursor: cursor, limit: limit))
+      RecordedPageRequest(zone: zone, sort: sort, filter: filter, cursor: cursor, limit: limit))
     await waitForGateIfNeeded()
     if let fetchApplicationsPageError {
       throw fetchApplicationsPageError


### PR DESCRIPTION
## What

Slice 4 (iOS) of epic #682 — the list's status chips + Unread filter now drive the server query (API merged in #694). **The list is now fully server-driven: sort + filter + paging.**

- New `ApplicationFilter` value object: `enum { all; status(ApplicationStatus); unread }` — a sum type that makes "status AND unread" **unrepresentable** at the call boundary (the server 400s on both; this prevents it ever being sent).
- `fetchApplicationsPage(for:sort:filter:cursor:limit:)` maps `.status(s)` ⇒ `?status=<rawValue>`, `.unread` ⇒ `?unread=true`, `.all` ⇒ neither.
- `ApplicationListViewModel`: `activeFilter` is derived from the chip + Unread state; `.onChange(of: activeFilter)` coalesces both toggles into a **single** reload (avoids a double-fetch when one clears the other). Changing the filter resets the cursor and reloads page 1 (same mechanism as sort change); the filter threads into every subsequent page so a stale cursor is never replayed under a different filter.
- Removed client-side `filterApplications` — `filteredApplications` now renders the server's set verbatim.
- **Kept**: the `latestUnreadEvent` per-row field (still drives the unread **badge**/count). **Map untouched** (slice 5).

## Tests

Swift Testing (`ApplicationListViewModelFilterTests`, 9 new): status chip ⇒ `?status=`, All ⇒ none, Unread ⇒ `?unread=true`, filter change resets cursor, no local re-filtering, mutual exclusivity, badge regression. `swift build` clean · `swift test` 1393 pass · `swiftlint lint --strict` 0 violations.

Epic: #682 · Bead: tc-22gb

Release-Note: Filter a watch zone by status or unread across every application, not just the ones already loaded.