### PR TITLE
feat(ios): map eager-drain all pages + MKClusterAnnotation clustering (#682 slice 5)

### DIFF
--- a/mobile/ios/packages/town-crier-domain/Sources/Protocols/PlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Protocols/PlanningApplicationRepository.swift
@@ -5,10 +5,10 @@ public protocol PlanningApplicationRepository: Sendable {
 
   /// Fetches a single server-sorted, server-filtered, server-paged page of a
   /// zone's applications, returning the decoded rows plus the continuation
-  /// cursor for the next page (`nil` on the last page). Used by the list's
-  /// infinite scroll to page the full set in the selected server sort order and
-  /// filter (GH#682 slices 1 and 4). The map keeps using
-  /// ``fetchApplications(for:)`` (param-less, first page).
+  /// cursor for the next page (`nil` on the last page). The list's infinite
+  /// scroll pages the full set lazily in the selected server sort order and
+  /// filter (GH#682 slices 1 and 4); the map eager-drains every page to
+  /// exhaustion in `distance` order for clustering (GH#682 slice 5).
   func fetchApplicationsPage(
     for zone: WatchZone,
     sort: ApplicationSortOrder,

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ClusteredMapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/ClusteredMapView.swift
@@ -1,0 +1,293 @@
+#if canImport(UIKit)
+  import MapKit
+  import SwiftUI
+  import TownCrierDomain
+
+  /// A UIKit `MKMapView` wrapped for SwiftUI so the map gets native
+  /// `MKClusterAnnotation` clustering (GH#542). SwiftUI's `Map` has no clustering
+  /// and materialises every annotation, so a dense watch zone with thousands of
+  /// applications stalls. MapKit instead bounds the rendered marker count by
+  /// screen area regardless of how many pins the zone holds — which is what lets
+  /// the eager-drained full set (GH#682 slice 5) render smoothly.
+  ///
+  /// The representable is a thin adapter (MVVM-C): all state lives on
+  /// ``MapViewModel``; this view only translates its published annotations into
+  /// `MKAnnotation`s and forwards taps back to the ViewModel.
+  @MainActor
+  struct ClusteredMapView: UIViewRepresentable {
+    /// Observed so the representable is invalidated — and `updateUIView` re-runs to
+    /// re-diff annotations and re-frame — whenever the ViewModel publishes (filter
+    /// change, zone switch, drained pages). A plain stored reference is NOT enough:
+    /// SwiftUI treats the representable as unchanged when its only stored property
+    /// is the same `MapViewModel` instance, so it skips `updateUIView` and filter
+    /// toggles never reach the map.
+    @ObservedObject var viewModel: MapViewModel
+
+    /// Shared `clusteringIdentifier` on the individual marker views — MapKit
+    /// collapses any markers carrying the same identifier into one
+    /// `MKClusterAnnotation` when they overlap on screen.
+    static let clusteringIdentifier = "planning-application"
+    static let markerReuseIdentifier = "planning-application-marker"
+    static let clusterReuseIdentifier = "planning-application-cluster"
+
+    func makeCoordinator() -> Coordinator {
+      Coordinator(viewModel: viewModel)
+    }
+
+    func makeUIView(context: Context) -> MKMapView {
+      let mapView = MKMapView()
+      mapView.delegate = context.coordinator
+      mapView.pointOfInterestFilter = .excludingAll
+      mapView.register(
+        MKMarkerAnnotationView.self,
+        forAnnotationViewWithReuseIdentifier: Self.markerReuseIdentifier)
+      mapView.register(
+        MKMarkerAnnotationView.self,
+        forAnnotationViewWithReuseIdentifier: Self.clusterReuseIdentifier)
+
+      let coordinator = context.coordinator
+      coordinator.syncAnnotations(on: mapView, desired: viewModel.filteredAnnotations)
+      coordinator.applyRadiusOverlay(
+        to: mapView,
+        centreLat: viewModel.centreLat,
+        centreLon: viewModel.centreLon,
+        radius: viewModel.radiusMetres)
+      coordinator.frameCamera(
+        on: mapView,
+        centre: CLLocationCoordinate2D(
+          latitude: viewModel.centreLat, longitude: viewModel.centreLon),
+        radius: viewModel.radiusMetres,
+        zoneId: viewModel.selectedZone?.id,
+        animated: false)
+      return mapView
+    }
+
+    func updateUIView(_ mapView: MKMapView, context: Context) {
+      let coordinator = context.coordinator
+      coordinator.syncAnnotations(on: mapView, desired: viewModel.filteredAnnotations)
+      coordinator.applyRadiusOverlay(
+        to: mapView,
+        centreLat: viewModel.centreLat,
+        centreLon: viewModel.centreLon,
+        radius: viewModel.radiusMetres)
+      // Reframe the camera only when the selected zone actually changes, so a
+      // filter toggle or a background annotation refresh never yanks the user's
+      // current pan/zoom back to the zone framing.
+      coordinator.frameCameraIfZoneChanged(
+        on: mapView,
+        centreLat: viewModel.centreLat,
+        centreLon: viewModel.centreLon,
+        radius: viewModel.radiusMetres,
+        zoneId: viewModel.selectedZone?.id)
+    }
+  }
+
+  extension ClusteredMapView {
+    /// `MKMapViewDelegate` for ``ClusteredMapView``. Holds no business logic — it
+    /// styles markers, forwards a single-pin tap to ``MapViewModel/selectApplication(_:)``,
+    /// expands a cluster tap by zooming, and renders the zone radius circle. All
+    /// callbacks run on the main thread (MapKit guarantees it), matching the
+    /// `@MainActor` isolation.
+    @MainActor
+    final class Coordinator: NSObject, MKMapViewDelegate {
+      private let viewModel: MapViewModel
+
+      /// The zone the camera is currently framed on, so we only reframe on a real
+      /// zone change rather than on every annotation/filter update.
+      private var framedZoneId: WatchZoneId?
+      /// The currently-rendered radius circle and the centre/radius it was drawn
+      /// for, so we redraw it only when the zone's geometry changes.
+      private var radiusOverlay: MKCircle?
+      private var renderedCentreLat: Double?
+      private var renderedCentreLon: Double?
+      private var renderedRadius: Double?
+
+      init(viewModel: MapViewModel) {
+        self.viewModel = viewModel
+      }
+
+      // MARK: - Annotation diffing
+
+      /// Applies only the delta between the displayed pins and `desired`, so a
+      /// filter change or a partial refresh doesn't churn the whole annotation set
+      /// (which would drop clustering animations and the current selection).
+      func syncAnnotations(on mapView: MKMapView, desired: [MapAnnotationItem]) {
+        let current = mapView.annotations.compactMap { $0 as? PlanningApplicationAnnotation }
+        let currentIds = Set(current.map(\.annotationId))
+        let desiredIds = Set(desired.map(\.id))
+
+        let toRemove = current.filter { !desiredIds.contains($0.annotationId) }
+        if !toRemove.isEmpty {
+          mapView.removeAnnotations(toRemove)
+        }
+
+        let toAdd =
+          desired
+          .filter { !currentIds.contains($0.id) }
+          .map(PlanningApplicationAnnotation.init(item:))
+        if !toAdd.isEmpty {
+          mapView.addAnnotations(toAdd)
+        }
+      }
+
+      // MARK: - Radius overlay
+
+      func applyRadiusOverlay(
+        to mapView: MKMapView, centreLat: Double, centreLon: Double, radius: Double
+      ) {
+        if renderedRadius == radius, renderedCentreLat == centreLat, renderedCentreLon == centreLon {
+          return
+        }
+        if let radiusOverlay {
+          mapView.removeOverlay(radiusOverlay)
+        }
+        let circle = MKCircle(
+          center: CLLocationCoordinate2D(latitude: centreLat, longitude: centreLon),
+          radius: radius)
+        mapView.addOverlay(circle, level: .aboveRoads)
+        radiusOverlay = circle
+        renderedCentreLat = centreLat
+        renderedCentreLon = centreLon
+        renderedRadius = radius
+      }
+
+      // MARK: - Camera framing
+
+      func frameCamera(
+        on mapView: MKMapView,
+        centre: CLLocationCoordinate2D,
+        radius: Double,
+        zoneId: WatchZoneId?,
+        animated: Bool
+      ) {
+        // Mirror the previous SwiftUI framing: span 2.5x the zone radius so the
+        // whole circle plus a margin is visible.
+        let region = MKCoordinateRegion(
+          center: centre,
+          latitudinalMeters: radius * 2.5,
+          longitudinalMeters: radius * 2.5)
+        mapView.setRegion(region, animated: animated)
+        framedZoneId = zoneId
+      }
+
+      func frameCameraIfZoneChanged(
+        on mapView: MKMapView,
+        centreLat: Double,
+        centreLon: Double,
+        radius: Double,
+        zoneId: WatchZoneId?
+      ) {
+        guard zoneId != framedZoneId else { return }
+        frameCamera(
+          on: mapView,
+          centre: CLLocationCoordinate2D(latitude: centreLat, longitude: centreLon),
+          radius: radius,
+          zoneId: zoneId,
+          animated: true)
+      }
+
+      // MARK: - MKMapViewDelegate
+
+      func mapView(_ mapView: MKMapView, viewFor annotation: MKAnnotation) -> MKAnnotationView? {
+        if let cluster = annotation as? MKClusterAnnotation {
+          return clusterView(for: cluster, on: mapView)
+        }
+        if let planning = annotation as? PlanningApplicationAnnotation {
+          return markerView(for: planning, on: mapView)
+        }
+        return nil
+      }
+
+      private func markerView(
+        for annotation: PlanningApplicationAnnotation, on mapView: MKMapView
+      ) -> MKAnnotationView {
+        let view = mapView.dequeueReusableAnnotationView(
+          withIdentifier: ClusteredMapView.markerReuseIdentifier, for: annotation)
+        guard let marker = view as? MKMarkerAnnotationView else { return view }
+        marker.annotation = annotation
+        marker.clusteringIdentifier = ClusteredMapView.clusteringIdentifier
+        marker.glyphImage = UIImage(systemName: "mappin.circle.fill")
+        marker.markerTintColor = UIColor(annotation.status.displayColor)
+        marker.canShowCallout = false
+        // Low priority lets MapKit cluster overlapping pins; the cluster bubble
+        // (required priority) always wins.
+        marker.displayPriority = .defaultLow
+        return marker
+      }
+
+      private func clusterView(
+        for cluster: MKClusterAnnotation, on mapView: MKMapView
+      ) -> MKAnnotationView {
+        let view = mapView.dequeueReusableAnnotationView(
+          withIdentifier: ClusteredMapView.clusterReuseIdentifier, for: cluster)
+        guard let marker = view as? MKMarkerAnnotationView else { return view }
+        marker.annotation = cluster
+        // Brand amber: a cluster is a navigational aggregate, not a status, so it
+        // takes the design system's brand accent rather than any `tcStatus*`
+        // colour (which would falsely imply a single status for the group).
+        marker.markerTintColor = UIColor(Color.tcAmber)
+        marker.glyphText = "\(cluster.memberAnnotations.count)"
+        marker.canShowCallout = false
+        marker.displayPriority = .required
+        return marker
+      }
+
+      func mapView(_ mapView: MKMapView, didSelect view: MKAnnotationView) {
+        if let cluster = view.annotation as? MKClusterAnnotation {
+          let rect = enclosingMapRect(for: cluster.memberAnnotations)
+          mapView.setVisibleMapRect(
+            rect,
+            edgePadding: UIEdgeInsets(top: 60, left: 60, bottom: 60, right: 60),
+            animated: true)
+          mapView.deselectAnnotation(cluster, animated: false)
+          return
+        }
+        if let planning = view.annotation as? PlanningApplicationAnnotation {
+          viewModel.selectApplication(planning.applicationId)
+          // Deselect so tapping the same pin again after dismissing the sheet
+          // fires `didSelect` once more.
+          mapView.deselectAnnotation(planning, animated: false)
+        }
+      }
+
+      func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
+        guard let circle = overlay as? MKCircle else {
+          return MKOverlayRenderer(overlay: overlay)
+        }
+        let renderer = MKCircleRenderer(circle: circle)
+        renderer.strokeColor = UIColor(Color.tcAmber.opacity(0.3))
+        renderer.fillColor = UIColor(Color.tcAmber.opacity(0.08))
+        renderer.lineWidth = 1.5
+        return renderer
+      }
+
+      private func enclosingMapRect(for annotations: [MKAnnotation]) -> MKMapRect {
+        annotations.reduce(MKMapRect.null) { rect, annotation in
+          let point = MKMapPoint(annotation.coordinate)
+          return rect.union(MKMapRect(x: point.x, y: point.y, width: 0, height: 0))
+        }
+      }
+    }
+  }
+
+  /// A reference-type `MKAnnotation` wrapping a value-type ``MapAnnotationItem`` so
+  /// MapKit can hold and cluster it. Carries the `applicationId` and `status` the
+  /// coordinator needs to colour the marker and route a tap.
+  final class PlanningApplicationAnnotation: NSObject, MKAnnotation {
+    let annotationId: String
+    let applicationId: PlanningApplicationId
+    let status: ApplicationStatus
+    let coordinate: CLLocationCoordinate2D
+    let title: String?
+    let subtitle: String?
+
+    init(item: MapAnnotationItem) {
+      self.annotationId = item.id
+      self.applicationId = item.applicationId
+      self.status = item.status
+      self.coordinate = CLLocationCoordinate2D(latitude: item.latitude, longitude: item.longitude)
+      self.title = item.title
+      self.subtitle = item.address
+    }
+  }
+#endif

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapView.swift
@@ -5,13 +5,35 @@ import TownCrierDomain
 /// Map view displaying planning application pins colour-coded by status.
 public struct MapView: View {
   @StateObject private var viewModel: MapViewModel
-  @State private var mapPosition: MapCameraPosition = .automatic
+  // mapPosition and updateMapPosition are only needed on macOS, where
+  // ClusteredMapView (UIViewRepresentable) is unavailable and the SwiftUI
+  // Map(position:) fallback handles camera framing.
+  #if !canImport(UIKit)
+    @State private var mapPosition: MapCameraPosition = .automatic
+  #endif
 
   public init(viewModel: MapViewModel) {
     _viewModel = StateObject(wrappedValue: viewModel)
   }
 
   public var body: some View {
+    // On iOS, ClusteredMapView owns the camera — no onChange needed.
+    // On macOS (SPM compile-time target), fall back to SwiftUI Map + updateMapPosition.
+    #if canImport(UIKit)
+      contentStack
+    #else
+      contentStack
+        .onChange(of: viewModel.selectedZone?.id) { _, _ in
+          withAnimation {
+            updateMapPosition()
+          }
+        }
+    #endif
+  }
+
+  // MARK: - Shared content
+
+  private var contentStack: some View {
     VStack(spacing: 0) {
       if viewModel.showZonePicker {
         zonePickerSection
@@ -24,12 +46,9 @@ public struct MapView: View {
     .background(Color.tcBackground)
     .task {
       await viewModel.loadApplications()
-      updateMapPosition()
-    }
-    .onChange(of: viewModel.selectedZone?.id) { _, _ in
-      withAnimation {
+      #if !canImport(UIKit)
         updateMapPosition()
-      }
+      #endif
     }
     .sheet(
       item: Binding(
@@ -41,50 +60,6 @@ public struct MapView: View {
         ApplicationSummarySheet(application: application, viewModel: viewModel)
       }
     )
-  }
-
-  @ViewBuilder
-  private var mapContent: some View {
-    Map(position: $mapPosition) {
-      ForEach(viewModel.filteredAnnotations) { annotation in
-        Annotation(
-          annotation.title,
-          coordinate: CLLocationCoordinate2D(
-            latitude: annotation.latitude,
-            longitude: annotation.longitude
-          ),
-          anchor: .bottom
-        ) {
-          pinView(for: annotation)
-            .onTapGesture {
-              viewModel.selectApplication(annotation.applicationId)
-            }
-        }
-      }
-
-      MapCircle(
-        center: CLLocationCoordinate2D(
-          latitude: viewModel.centreLat,
-          longitude: viewModel.centreLon
-        ),
-        radius: viewModel.radiusMetres
-      )
-      .foregroundStyle(Color.tcAmber.opacity(0.08))
-      .stroke(Color.tcAmber.opacity(0.3), lineWidth: 1.5)
-    }
-    .mapStyle(.standard(elevation: .flat))
-  }
-
-  private func pinView(for annotation: MapAnnotationItem) -> some View {
-    Image(systemName: "mappin.circle.fill")
-      .font(.system(.title2))
-      .foregroundStyle(annotation.status.displayColor)
-      .background(
-        Circle()
-          .fill(Color.tcSurface)
-          .frame(width: 20, height: 20)
-      )
-      .accessibilityLabel("\(annotation.title), \(annotation.status.displayLabel)")
   }
 
   // MARK: - Zone Picker
@@ -156,7 +131,15 @@ public struct MapView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.tcBackground)
       } else {
-        mapContent
+        // iOS: MKMapView with native clustering (GH#542, GH#682 slice 5).
+        // macOS (SPM compile target): fall back to SwiftUI Map so the package
+        // still compiles for swift test without UIKit.
+        #if canImport(UIKit)
+          ClusteredMapView(viewModel: viewModel)
+            .ignoresSafeArea(edges: .bottom)
+        #else
+          mapContent
+        #endif
         if viewModel.isLoading {
           ProgressView()
             .controlSize(.large)
@@ -174,16 +157,64 @@ public struct MapView: View {
     }
   }
 
-  private func updateMapPosition() {
-    mapPosition = .region(
-      MKCoordinateRegion(
-        center: CLLocationCoordinate2D(
-          latitude: viewModel.centreLat,
-          longitude: viewModel.centreLon
-        ),
-        latitudinalMeters: viewModel.radiusMetres * 2.5,
-        longitudinalMeters: viewModel.radiusMetres * 2.5
+  // MARK: - macOS SwiftUI Map fallback (not compiled on iOS)
+
+  #if !canImport(UIKit)
+    @ViewBuilder
+    private var mapContent: some View {
+      Map(position: $mapPosition) {
+        ForEach(viewModel.filteredAnnotations) { annotation in
+          Annotation(
+            annotation.title,
+            coordinate: CLLocationCoordinate2D(
+              latitude: annotation.latitude,
+              longitude: annotation.longitude
+            ),
+            anchor: .bottom
+          ) {
+            pinView(for: annotation)
+              .onTapGesture {
+                viewModel.selectApplication(annotation.applicationId)
+              }
+          }
+        }
+
+        MapCircle(
+          center: CLLocationCoordinate2D(
+            latitude: viewModel.centreLat,
+            longitude: viewModel.centreLon
+          ),
+          radius: viewModel.radiusMetres
+        )
+        .foregroundStyle(Color.tcAmber.opacity(0.08))
+        .stroke(Color.tcAmber.opacity(0.3), lineWidth: 1.5)
+      }
+      .mapStyle(.standard(elevation: .flat))
+    }
+
+    private func pinView(for annotation: MapAnnotationItem) -> some View {
+      Image(systemName: "mappin.circle.fill")
+        .font(.system(.title2))
+        .foregroundStyle(annotation.status.displayColor)
+        .background(
+          Circle()
+            .fill(Color.tcSurface)
+            .frame(width: 20, height: 20)
+        )
+        .accessibilityLabel("\(annotation.title), \(annotation.status.displayLabel)")
+    }
+
+    private func updateMapPosition() {
+      mapPosition = .region(
+        MKCoordinateRegion(
+          center: CLLocationCoordinate2D(
+            latitude: viewModel.centreLat,
+            longitude: viewModel.centreLon
+          ),
+          latitudinalMeters: viewModel.radiusMetres * 2.5,
+          longitudinalMeters: viewModel.radiusMetres * 2.5
+        )
       )
-    )
-  }
+    }
+  #endif
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/Map/MapViewModel.swift
@@ -36,6 +36,11 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
   private let userDefaults: UserDefaults
   private let zoneSelectionKey: String
 
+  /// Page size for the eager map drain. Matches the server's default page size
+  /// and the list's `pageSize`; the loop simply pulls as many of these as the
+  /// zone holds.
+  private static let pageSize = 150
+
   public var canSave: Bool {
     savedApplicationRepository != nil
   }
@@ -107,17 +112,47 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
       centreLon = zone.centre.longitude
       radiusMetres = zone.radiusMetres
 
-      let fetched = try await repository.fetchApplications(for: zone)
+      let fetched = try await drainAllPages(for: zone)
       applications = fetched
-      annotations = fetched.compactMap { app in
-        guard let location = app.location else { return nil }
-        return MapAnnotationItem(application: app, coordinate: location)
-      }
+      annotations = makeAnnotations(from: fetched)
     } catch {
       handleError(error)
     }
     isLoading = false
     hasLoaded = true
+  }
+
+  /// Eager-drains every page of a zone's applications for the map (GH#682
+  /// slice 5). The list lazily pages on scroll, but a map needs every pin to be
+  /// spatially meaningful, so we follow `X-Next-Cursor` to exhaustion here.
+  /// Sort is irrelevant for pins, so we take the cheapest server plan
+  /// (`distance`, the param-less default) with no filter. The accumulated set is
+  /// returned whole — the caller publishes `annotations` atomically only after a
+  /// clean drain, so a mid-stream failure discards the partial pages rather than
+  /// flashing a half-populated map. Clustering (``ClusteredMapView``) keeps the
+  /// rendered marker count bounded regardless of how many pins this returns.
+  private func drainAllPages(for zone: WatchZone) async throws -> [PlanningApplication] {
+    var allApplications: [PlanningApplication] = []
+    var cursor: String?
+    repeat {
+      let page = try await repository.fetchApplicationsPage(
+        for: zone,
+        sort: .distance,
+        filter: .all,
+        cursor: cursor,
+        limit: Self.pageSize
+      )
+      allApplications.append(contentsOf: page.applications)
+      cursor = page.nextCursor
+    } while cursor != nil
+    return allApplications
+  }
+
+  private func makeAnnotations(from applications: [PlanningApplication]) -> [MapAnnotationItem] {
+    applications.compactMap { app in
+      guard let location = app.location else { return nil }
+      return MapAnnotationItem(application: app, coordinate: location)
+    }
   }
 
   /// Loads the set of saved application UIDs so `isSelectedApplicationSaved`
@@ -142,12 +177,9 @@ public final class MapViewModel: ObservableObject, ErrorHandlingViewModel {
     isLoading = true
     error = nil
     do {
-      let fetched = try await repository.fetchApplications(for: zone)
+      let fetched = try await drainAllPages(for: zone)
       applications = fetched
-      annotations = fetched.compactMap { app in
-        guard let location = app.location else { return nil }
-        return MapAnnotationItem(application: app, coordinate: location)
-      }
+      annotations = makeAnnotations(from: fetched)
     } catch {
       handleError(error)
     }

--- a/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/AppCoordinatorTests.swift
@@ -210,8 +210,8 @@ struct AppCoordinatorTests {
 
     await vm.loadApplications()
 
-    #expect(appSpy.fetchApplicationsCalls.count == 1)
-    #expect(appSpy.fetchApplicationsCalls.first?.id.value == "zone-001")
+    #expect(appSpy.fetchApplicationsPageCalls.count == 1)
+    #expect(appSpy.fetchApplicationsPageCalls.first?.zone.id.value == "zone-001")
     #expect(vm.annotations.count == 1)
   }
 

--- a/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/MapViewModelTests.swift
@@ -40,7 +40,8 @@ struct MapViewModelTests {
 
   @Test func loadApplications_setsErrorOnFailure() async {
     let (sut, spy, _) = makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
+    // drainAllPages calls fetchApplicationsPage; set the paged error path.
+    spy.fetchApplicationsPageError = DomainError.networkUnavailable
 
     await sut.loadApplications()
 
@@ -173,7 +174,8 @@ struct MapViewModelTests {
 
   @Test func isEmpty_falseWhenErrorOccurred() async {
     let (sut, spy, _) = makeSUT()
-    spy.fetchApplicationsResult = .failure(DomainError.networkUnavailable)
+    // drainAllPages calls fetchApplicationsPage; set the paged error path.
+    spy.fetchApplicationsPageError = DomainError.networkUnavailable
 
     await sut.loadApplications()
 
@@ -198,8 +200,8 @@ struct MapViewModelTests {
     let sut = MapViewModel(repository: spy, watchZoneRepository: watchZoneSpy)
     await sut.loadApplications()
 
-    #expect(spy.fetchApplicationsCalls.count == 1)
-    #expect(spy.fetchApplicationsCalls[0].id == zone.id)
+    #expect(spy.fetchApplicationsPageCalls.count == 1)
+    #expect(spy.fetchApplicationsPageCalls[0].zone.id == zone.id)
     #expect(sut.annotations.count == 1)
   }
 
@@ -211,7 +213,7 @@ struct MapViewModelTests {
     let sut = MapViewModel(repository: spy, watchZoneRepository: watchZoneSpy)
     await sut.loadApplications()
 
-    #expect(spy.fetchApplicationsCalls.isEmpty)
+    #expect(spy.fetchApplicationsPageCalls.isEmpty)
     #expect(sut.annotations.isEmpty)
     #expect(sut.isEmpty)
   }
@@ -256,7 +258,7 @@ struct MapViewModelTests {
     await sut.loadApplications()
 
     #expect(sut.selectedZone?.id == WatchZone.cambridge.id)
-    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+    #expect(appSpy.fetchApplicationsPageCalls.first?.zone.id == WatchZone.cambridge.id)
   }
 
   @Test func loadApplications_restoresPersistedZoneSelection() async throws {
@@ -265,7 +267,7 @@ struct MapViewModelTests {
     await sut.loadApplications()
 
     #expect(sut.selectedZone?.id == WatchZone.london.id)
-    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.london.id)
+    #expect(appSpy.fetchApplicationsPageCalls.first?.zone.id == WatchZone.london.id)
     #expect(sut.centreLat == WatchZone.london.centre.latitude)
     #expect(sut.centreLon == WatchZone.london.centre.longitude)
   }
@@ -276,19 +278,19 @@ struct MapViewModelTests {
     await sut.loadApplications()
 
     #expect(sut.selectedZone?.id == WatchZone.cambridge.id)
-    #expect(appSpy.fetchApplicationsCalls.first?.id == WatchZone.cambridge.id)
+    #expect(appSpy.fetchApplicationsPageCalls.first?.zone.id == WatchZone.cambridge.id)
   }
 
   @Test func selectZone_fetchesApplicationsAndUpdatesCentre() async throws {
     let (sut, appSpy, _, _) = try makeSUTWithZones()
     await sut.loadApplications()
-    let initialCallCount = appSpy.fetchApplicationsCalls.count
+    let initialCallCount = appSpy.fetchApplicationsPageCalls.count
 
     await sut.selectZone(.london)
 
     #expect(sut.selectedZone?.id == WatchZone.london.id)
-    #expect(appSpy.fetchApplicationsCalls.count == initialCallCount + 1)
-    #expect(appSpy.fetchApplicationsCalls.last?.id == WatchZone.london.id)
+    #expect(appSpy.fetchApplicationsPageCalls.count == initialCallCount + 1)
+    #expect(appSpy.fetchApplicationsPageCalls.last?.zone.id == WatchZone.london.id)
     #expect(sut.centreLat == WatchZone.london.centre.latitude)
     #expect(sut.centreLon == WatchZone.london.centre.longitude)
     #expect(sut.radiusMetres == WatchZone.london.radiusMetres)
@@ -315,5 +317,73 @@ struct MapViewModelTests {
     await sut.loadApplications()
 
     #expect(!sut.showZonePicker)
+  }
+
+  // MARK: - Eager page drain (GH#682 slice 5)
+
+  @Test func loadApplications_drainsAllPages_followingCursorToExhaustion() async {
+    let (sut, spy, _) = makeSUT()
+    spy.pagedResponses = [
+      ApplicationPage(applications: [.pendingReview], nextCursor: "cursor-1"),
+      ApplicationPage(applications: [.permitted], nextCursor: "cursor-2"),
+      ApplicationPage(applications: [.rejected], nextCursor: nil),
+    ]
+
+    await sut.loadApplications()
+
+    // Every page's applications are merged into the published annotations.
+    #expect(sut.annotations.count == 3)
+    // The cursor threads through: first page sends none, then each prior page's
+    // next-cursor drives the following request.
+    #expect(spy.fetchApplicationsPageCalls.count == 3)
+    #expect(spy.fetchApplicationsPageCalls[0].cursor == nil)
+    #expect(spy.fetchApplicationsPageCalls[1].cursor == "cursor-1")
+    #expect(spy.fetchApplicationsPageCalls[2].cursor == "cursor-2")
+    // The map drains the cheapest (distance) plan, unfiltered.
+    #expect(spy.fetchApplicationsPageCalls.allSatisfy { $0.sort == .distance })
+    #expect(spy.fetchApplicationsPageCalls.allSatisfy { $0.filter == .all })
+  }
+
+  @Test func loadApplications_stopsDraining_onLastPageWithNoCursor() async {
+    let (sut, spy, _) = makeSUT()
+    spy.pagedResponses = [
+      ApplicationPage(applications: [.pendingReview, .permitted], nextCursor: nil)
+    ]
+
+    await sut.loadApplications()
+
+    #expect(spy.fetchApplicationsPageCalls.count == 1)
+    #expect(sut.annotations.count == 2)
+  }
+
+  @Test func loadApplications_discardsPartialResults_whenAPageFails() async {
+    let (sut, spy, _) = makeSUT()
+    // Page 1 succeeds, page 2 throws: the drain aborts and the half-fetched set
+    // is discarded rather than published as a partial map.
+    spy.pagedResults = [
+      .success(ApplicationPage(applications: [.pendingReview], nextCursor: "cursor-1")),
+      .failure(DomainError.networkUnavailable),
+    ]
+
+    await sut.loadApplications()
+
+    #expect(sut.error == .networkUnavailable)
+    #expect(sut.annotations.isEmpty)
+    #expect(spy.fetchApplicationsPageCalls.count == 2)
+  }
+
+  @Test func selectZone_drainsAllPages() async throws {
+    let (sut, spy, _, _) = try makeSUTWithZones()
+    await sut.loadApplications()
+    spy.pagedResponses = [
+      ApplicationPage(applications: [.pendingReview], nextCursor: "cursor-1"),
+      ApplicationPage(applications: [.permitted], nextCursor: nil),
+    ]
+
+    await sut.selectZone(.london)
+
+    let londonCalls = spy.fetchApplicationsPageCalls.filter { $0.zone.id == WatchZone.london.id }
+    #expect(londonCalls.count == 2)
+    #expect(sut.annotations.count == 2)
   }
 }

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyPlanningApplicationRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyPlanningApplicationRepository.swift
@@ -67,6 +67,12 @@ final class SpyPlanningApplicationRepository: PlanningApplicationRepository, @un
   /// from `fetchApplicationsByZone`/`fetchApplicationsResult` with no cursor.
   var pagedResponses: [ApplicationPage] = []
 
+  /// Per-call results for `fetchApplicationsPage`, dequeued one at a time. When
+  /// non-empty this takes precedence over `pagedResponses` and lets a test
+  /// sequence a mid-stream failure — e.g. page 1 succeeds, page 2 throws — to
+  /// prove the map's eager drain discards partial results (GH#682 slice 5).
+  var pagedResults: [Result<ApplicationPage, Error>] = []
+
   /// When set, every paged fetch throws this error after recording the call —
   /// drives the "fetch error surfaces to the ViewModel" path.
   var fetchApplicationsPageError: Error?
@@ -81,6 +87,9 @@ final class SpyPlanningApplicationRepository: PlanningApplicationRepository, @un
     fetchApplicationsPageCalls.append(
       RecordedPageRequest(zone: zone, sort: sort, filter: filter, cursor: cursor, limit: limit))
     await waitForGateIfNeeded()
+    if !pagedResults.isEmpty {
+      return try pagedResults.removeFirst().get()
+    }
     if let fetchApplicationsPageError {
       throw fetchApplicationsPageError
     }
@@ -90,7 +99,8 @@ final class SpyPlanningApplicationRepository: PlanningApplicationRepository, @un
     if !pagedResponses.isEmpty {
       return pagedResponses.removeFirst()
     }
-    let apps = fetchApplicationsByZone[zone.id.value] ?? ((try? fetchApplicationsResult.get()) ?? [])
+    let apps =
+      fetchApplicationsByZone[zone.id.value] ?? ((try? fetchApplicationsResult.get()) ?? [])
     return ApplicationPage(applications: apps, nextCursor: nil)
   }
 


### PR DESCRIPTION
## Changes

Slice 5 of epic #682 (closes the iOS map deferral, bead `tc-69o7`; clustering design per #542).

- **Eager-drain** — `MapViewModel.drainAllPages` loops `fetchApplicationsPage` following `X-Next-Cursor` to exhaustion (distance/`.all` default, page size 150) in both `loadApplications` and `selectZone`. A dense watch zone now shows **every** in-radius application, not just the nearest ~500 bunched at the centre. Annotations are published atomically after a clean drain (partial pages discarded on error).
- **Clustering** — the map render surface moves from SwiftUI `Map(position:)` to a new `ClusteredMapView` (`UIViewRepresentable` over `MKMapView`) using native `MKClusterAnnotation`: zoomed out, pins collapse into amber count bubbles; zoomed in they split to status-coloured markers. Pin tap opens the existing `ApplicationSummarySheet`; cluster tap zooms to expand. The amber radius circle, zone picker, status filter chips, camera framing, and loading/empty/error states are preserved. Guarded with `#if canImport(UIKit)` so the macOS SPM build keeps the SwiftUI `Map` fallback and `swift test` still compiles.
- `MapViewModel` is `@ObservedObject` inside the representable so a filter change / zone switch / drained pages invalidates it and `updateUIView` re-diffs the rendered annotations (a plain stored reference let SwiftUI skip `updateUIView`, so filter chips highlighted but never re-filtered the map).

## Tests
- New Swift Testing coverage for the drain: cursor-to-exhaustion, last-page stop, partial-discard-on-error, and the `selectZone` drain path.
- `swift build`, 1397 tests, and `swiftlint lint --strict` (0 violations) all green.

## Manual simulator verification (the slice blocker; #542 is manual)
Verified on iPhone 17 Pro: pins fill the whole radius (18 clusters spread to the edges, counts up to 194) — **not** 500 bunched; clusters present and split on zoom-in; amber radius circle; status-coloured pins; pin-tap opens the summary sheet; **status filter re-renders the map** (All vs Refused vs Pending give distinct cluster counts; resets restore the baseline); no crash.

**Residual (needs a human eyeball):** zone-switching couldn't be exercised — the test account has a single watch zone (the `selectZone` drain is covered by a unit test). Smooth pan/zoom and zoom-OUT cluster re-merge aren't screenshottable via the sim driver.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The map now supports clustered pins for easier browsing of nearby planning applications.
  * Map interactions are smoother, with selection and zoom behavior that better preserves pan/zoom state.

* **Bug Fixes**
  * Map results now load more reliably by fetching all available pages for the selected area.
  * Improved handling of filtered and sorted map results, including more stable updates when switching zones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->