### PR TITLE
fix(infra): accept Sandbox StoreKit transactions on dev API so TestFlight purchases unlock pro features (tc-81c9)

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -277,6 +277,13 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 			app.EnvironmentVarArgs{Name: pulumi.String("POSTGRES_USER"), Value: pulumi.String("towncrier_api")},
 			app.EnvironmentVarArgs{Name: pulumi.String("POSTGRES_SSLMODE"), Value: pulumi.String("require")},
 			app.EnvironmentVarArgs{Name: pulumi.String("POSTGRES_AUTH"), Value: pulumi.String("azure-managed-identity")},
+			// Accept Sandbox StoreKit transactions on dev: TestFlight builds route to the dev
+			// API (api-dev) and TestFlight purchases carry environment="Sandbox". Without this,
+			// APPLE_ENVIRONMENT falls back to the code default "Production" only and the verify
+			// handler rejects every TestFlight purchase, so pro features never unlock (tc-81c9).
+			// Prod deliberately stays Production-only (omits this var) so a sandbox tester cannot
+			// self-grant a paid tier against production.
+			app.EnvironmentVarArgs{Name: pulumi.String("APPLE_ENVIRONMENT"), Value: pulumi.String("Sandbox,Production")},
 		)
 	} else if env == "prod" {
 		// Prod runs on Postgres single-store (memo 0010 / GH #669, bead tc-hpd2.14). The prod


### PR DESCRIPTION
## Problem

A TestFlight purchase appeared to go through and the paywall showed the bought tier, but no pro features unlocked.

**Root cause:** `APPLE_ENVIRONMENT` was never wired in `infra/environment.go`, so the dev API fell back to the code default `Production` only (`config.go:263`). TestFlight builds route to the dev API and TestFlight purchases carry `environment="Sandbox"`, so the verify handler rejected every transaction at `subscriptions/handler.go:235`. The profile tier was never written → `GET /v1/me` returned `Free` → the iOS resolver's `max(serverTier, storeKitTier, jwtTier)` collapsed to Free → pro features stayed locked. The paywall 'Current plan' badge still showed the bought tier because it reads **device StoreKit** (`Transaction.currentEntitlements`), not the server.

Verified against the live container apps: both `ca-town-crier-api-go-{dev,prod}` reported zero `APPLE_*` env vars, confirming the fallback.

## Fix

Set `APPLE_ENVIRONMENT=Sandbox,Production` on the **dev** stack only.

Prod intentionally stays Production-only (omits the var): accepting Sandbox in prod would let any Apple sandbox tester + Town Crier login self-grant a paid tier. App Store *review* of IAP (which uses sandbox against the prod build) is covered by the seeded demo account, so prod doesn't need Sandbox today.

`APPLE_BUNDLE_ID` remains unset; its code default `uk.towncrierapp.mobile` already matches the app, so the bundle check passes.

## Validation

- `go build ./...`, `gofmt -l`, `go vet ./...` all clean in `/infra`.
- The ASSN webhook is unaffected (it handles lifecycle events, not the initial purchase) and was already mounted in dev.

## How to verify after deploy

Re-run a TestFlight purchase; `GET /v1/me` should now return the paid tier and pro features should unlock on paywall dismiss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2qG9YCnBSCMr4TAUtPwoB