### PR TITLE
feat(api): server-side map clustering endpoint for watch-zone applications (#698 slice a)

### DIFF
--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -121,6 +121,9 @@ func (fakeAppStore) FindNearbyPage(context.Context, float64, float64, float64, i
 func (fakeAppStore) FindInZonePage(context.Context, applications.InZoneQuery) ([]applications.PlanningApplication, string, error) {
 	return nil, "", nil
 }
+func (fakeAppStore) FindClustersInZone(context.Context, applications.ClusterQuery) ([]applications.Cluster, error) {
+	return nil, nil
+}
 func (fakeAppStore) RecentNearby(context.Context, string, float64, float64, float64, int) ([]applications.PlanningApplication, error) {
 	return nil, nil
 }

--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -37,6 +37,7 @@ type Store interface {
 	BreakdownByAuthority(ctx context.Context, authorityCode string) ([]StateCount, error)
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error)
 	FindInZonePage(ctx context.Context, q InZoneQuery) ([]PlanningApplication, string, error)
+	FindClustersInZone(ctx context.Context, q ClusterQuery) ([]Cluster, error)
 	RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
 	NearestNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
 	BreakdownNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) ([]StateCount, error)

--- a/api-go/internal/applications/zoneclusters.go
+++ b/api-go/internal/applications/zoneclusters.go
@@ -1,0 +1,58 @@
+package applications
+
+import (
+	"context"
+	"errors"
+)
+
+// PlanningApplicationID identifies a single planning application on the wire: the
+// authority (the area_id rendered as a decimal string, byte-identical to the
+// stored authority_code) plus the PlanIt case name. The iOS domain keys its
+// PlanningApplicationId off exactly these two fields, so a single-member cluster
+// can route a map-pin tap straight to the application summary sheet with no
+// re-fetch.
+type PlanningApplicationID struct {
+	Authority string `json:"authority"`
+	Name      string `json:"name"`
+}
+
+// Cluster is one grid-aggregated bucket of in-zone, in-viewport applications, as
+// returned by FindClustersInZone. Latitude/Longitude is the centroid of the
+// bucket's member points; Count is how many applications fall in the cell;
+// StatusCounts is the per-app_state breakdown (it always sums to Count, with a
+// NULL or unrecognised app_state folded under the "Unknown" key). Member is set
+// only when Count == 1, identifying the single application so the client renders
+// a real status-coloured pin and a tap opens the summary sheet; for a multi-member
+// cell it is nil and the client renders a count bubble.
+type Cluster struct {
+	Latitude     float64                `json:"latitude"`
+	Longitude    float64                `json:"longitude"`
+	Count        int                    `json:"count"`
+	StatusCounts map[string]int         `json:"statusCounts"`
+	Member       *PlanningApplicationID `json:"applicationId"`
+}
+
+// ClusterQuery is the full request descriptor for FindClustersInZone: the zone
+// membership circle (Latitude, Longitude, RadiusMetres — the existing ST_DWithin
+// pattern), the visible map rectangle (West, South, East, North — WGS84 decimal
+// degrees), the grid cell size in degrees (GridSizeDegrees — derived from the
+// request's zoom by the handler, so the store stays a pure spatial primitive),
+// and an optional exact app_state filter (Status; "" means no status filter).
+type ClusterQuery struct {
+	Latitude        float64
+	Longitude       float64
+	RadiusMetres    float64
+	West            float64
+	South           float64
+	East            float64
+	North           float64
+	GridSizeDegrees float64
+	Status          string
+}
+
+// FindClustersInZone is implemented in the green cycle; the stub keeps the
+// package and the cmd/api wiring compiling while the handler tests drive the
+// endpoint.
+func (s *PostgresStore) FindClustersInZone(_ context.Context, _ ClusterQuery) ([]Cluster, error) {
+	return nil, errors.New("FindClustersInZone not implemented")
+}

--- a/api-go/internal/applications/zoneclusters.go
+++ b/api-go/internal/applications/zoneclusters.go
@@ -2,7 +2,10 @@ package applications
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
 )
 
 // PlanningApplicationID identifies a single planning application on the wire: the
@@ -21,8 +24,8 @@ type PlanningApplicationID struct {
 // bucket's member points; Count is how many applications fall in the cell;
 // StatusCounts is the per-app_state breakdown (it always sums to Count, with a
 // NULL or unrecognised app_state folded under the "Unknown" key). Member is set
-// only when Count == 1, identifying the single application so the client renders
-// a real status-coloured pin and a tap opens the summary sheet; for a multi-member
+// only when Count == 1, identifying the single application so the client renders a
+// real status-coloured pin and a tap opens the summary sheet; for a multi-member
 // cell it is nil and the client renders a count bubble.
 type Cluster struct {
 	Latitude     float64                `json:"latitude"`
@@ -50,9 +53,109 @@ type ClusterQuery struct {
 	Status          string
 }
 
-// FindClustersInZone is implemented in the green cycle; the stub keeps the
-// package and the cmd/api wiring compiling while the handler tests drive the
-// endpoint.
-func (s *PostgresStore) FindClustersInZone(_ context.Context, _ ClusterQuery) ([]Cluster, error) {
-	return nil, errors.New("FindClustersInZone not implemented")
+// clusterPoint is the zone-centre query point, built from $1 (longitude) and $2
+// (latitude), matching the nearbyPoint convention used elsewhere in the store.
+const clusterPoint = "ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography"
+
+// The cluster query is a single PostGIS grid aggregation, mirroring the SEO
+// "GROUP BY app_state" rollup (store_postgres.go) plus ST_SnapToGrid to bucket by
+// cell. It runs in two stages within one statement:
+//
+//   - per_cell_state pre-aggregates the in-radius, in-viewport applications by
+//     (grid cell, app_state): one row per state present in each cell, carrying the
+//     state's count, the collected member points, and the MIN (authority_code,
+//     planit_name) — which, for a single-member cell, is exactly that member.
+//   - the outer SELECT folds those rows up per cell: the centroid is the mean of
+//     all member points (ST_Centroid over the re-collected points), member_count
+//     is the SUM of the per-state counts, status_counts is jsonb_object_agg over
+//     the distinct per-cell states (NULL app_state folded to 'Unknown', so the
+//     object never has a NULL key and always sums to member_count), and the MIN
+//     authority/name identify the single member when member_count = 1.
+//
+// Filter ($3 radius via ST_DWithin, served by the existing applications_location_gist
+// GiST index) AND ($5..$8 viewport via location::geometry && ST_MakeEnvelope).
+// Group by ST_SnapToGrid(location::geometry, $4) where $4 is GridSizeDegrees. A
+// safety LIMIT of 1000 cells (densest first) bounds a pathological viewport.
+//
+// $1 longitude, $2 latitude, $3 radiusMetres, $4 gridSizeDegrees,
+// $5 west, $6 south, $7 east, $8 north, and (clusterQueryByStatus only) $9 status.
+const clusterQueryHead = `WITH per_cell_state AS (
+	SELECT
+		ST_SnapToGrid(location::geometry, $4) AS cell,
+		COALESCE(app_state, 'Unknown') AS state,
+		COUNT(*) AS n,
+		ST_Collect(location::geometry) AS geoms,
+		MIN(authority_code) AS authority,
+		MIN(planit_name) AS name
+	FROM applications
+	WHERE ST_DWithin(location, ` + clusterPoint + `, $3)
+		AND location::geometry && ST_MakeEnvelope($5, $6, $7, $8, 4326)`
+
+const clusterQueryTail = `
+	GROUP BY cell, COALESCE(app_state, 'Unknown')
+)
+SELECT
+	ST_Y(ST_Centroid(ST_Collect(geoms))) AS centroid_lat,
+	ST_X(ST_Centroid(ST_Collect(geoms))) AS centroid_lon,
+	SUM(n)::bigint AS member_count,
+	jsonb_object_agg(state, n) AS status_counts,
+	MIN(authority) AS member_authority,
+	MIN(name) AS member_name
+FROM per_cell_state
+GROUP BY cell
+ORDER BY member_count DESC
+LIMIT 1000`
+
+const (
+	clusterQueryAllStatuses = clusterQueryHead + clusterQueryTail
+	clusterQueryByStatus    = clusterQueryHead + "\n\t\tAND app_state = $9" + clusterQueryTail
+)
+
+// scanClusterRow hydrates one aggregated cell. status_counts is read as raw JSONB
+// and unmarshalled in Go (independent of the pgx jsonb codec). The member id is
+// attached only for a single-member cell.
+func scanClusterRow(row pgx.CollectableRow) (Cluster, error) {
+	var (
+		c         Cluster
+		count     int64
+		rawCounts []byte
+		authority string
+		name      string
+	)
+	if err := row.Scan(&c.Latitude, &c.Longitude, &count, &rawCounts, &authority, &name); err != nil {
+		return Cluster{}, err
+	}
+	c.Count = int(count)
+	if err := json.Unmarshal(rawCounts, &c.StatusCounts); err != nil {
+		return Cluster{}, fmt.Errorf("decode cluster status counts: %w", err)
+	}
+	if count == 1 {
+		c.Member = &PlanningApplicationID{Authority: authority, Name: name}
+	}
+	return c, nil
+}
+
+// FindClustersInZone returns the grid-aggregated cluster bubbles for the viewport
+// q within the zone circle (q.Latitude, q.Longitude, q.RadiusMetres). Each Cluster
+// is a centroid + member count + per-app_state breakdown; a single-member cell also
+// carries the member's {authority, name}. An optional q.Status restricts the
+// aggregation to that exact app_state. It is authority-agnostic and never paged:
+// a viewport at a sane zoom yields a bounded number of cells (capped at 1000).
+func (s *PostgresStore) FindClustersInZone(ctx context.Context, q ClusterQuery) ([]Cluster, error) {
+	query := clusterQueryAllStatuses
+	args := []any{q.Longitude, q.Latitude, q.RadiusMetres, q.GridSizeDegrees, q.West, q.South, q.East, q.North}
+	if q.Status != "" {
+		query = clusterQueryByStatus
+		args = append(args, q.Status)
+	}
+
+	rows, err := s.db.Query(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("find clusters in zone near (%v, %v): %w", q.Latitude, q.Longitude, err)
+	}
+	clusters, err := pgx.CollectRows(rows, scanClusterRow)
+	if err != nil {
+		return nil, fmt.Errorf("find clusters in zone near (%v, %v): %w", q.Latitude, q.Longitude, err)
+	}
+	return clusters, nil
 }

--- a/api-go/internal/applications/zoneclusters_test.go
+++ b/api-go/internal/applications/zoneclusters_test.go
@@ -1,0 +1,468 @@
+//go:build integration
+
+package applications
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// Cluster fixtures reuse the shared London centre (pgCentreLon/pgCentreLat) and
+// the pgApp/withState/pgPtr helpers from store_postgres_test.go. Points are placed
+// at explicit small degree offsets so the grid-snapping (ST_SnapToGrid) is
+// deterministic. The zone query always uses the centre + a generous radius so
+// membership is governed by the viewport, not the circle, except where a test
+// exercises the radius/bbox predicates directly.
+
+// clusterApp builds an in-radius application at the centre plus (dLng, dLat)
+// degrees, in the given authority, with the baseline nullable fields.
+func clusterApp(name string, areaID int, dLng, dLat float64) PlanningApplication {
+	a := pgApp(name, areaID)
+	a.Longitude = pgPtr(pgCentreLon + dLng)
+	a.Latitude = pgPtr(pgCentreLat + dLat)
+	return a
+}
+
+// wideBBox is a viewport comfortably containing every spread/coarse fixture point
+// (all within base + ~0.031 deg), as west,south,east,north.
+const (
+	bboxWest  = -0.2
+	bboxSouth = 51.48
+	bboxEast  = -0.05
+	bboxNorth = 51.55
+)
+
+// spreadOffsets are eight distinct (dLng, dLat) points spanning ~0.031 deg of
+// longitude in four tight pairs (pair members 0.001 deg apart, pairs 0.01 deg
+// apart). Snapping behaviour by cell size:
+//   - coarse 10 deg     -> all eight in one cell.
+//   - medium 0.01 deg   -> four cells (each pair shares a cell), two members each.
+//   - tiny 1e-6 deg     -> eight cells, one member each.
+var spreadOffsets = [8][2]float64{
+	{0.000, 0.000}, {0.001, 0.000},
+	{0.010, 0.000}, {0.011, 0.000},
+	{0.020, 0.010}, {0.021, 0.010},
+	{0.030, 0.020}, {0.031, 0.020},
+}
+
+// seedSpread inserts the eight spread points, all in authority 100.
+func seedSpread(t *testing.T, store *PostgresStore) {
+	t.Helper()
+	ctx := context.Background()
+	for i, off := range spreadOffsets {
+		a := clusterApp("S"+strconv.Itoa(i), 100, off[0], off[1])
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+}
+
+// clusterQuery is a brief ClusterQuery builder over the wide viewport and a
+// generous radius, varying only the grid size and status.
+func clusterQuery(gridSize float64, status string) ClusterQuery {
+	return ClusterQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 10000,
+		West: bboxWest, South: bboxSouth, East: bboxEast, North: bboxNorth,
+		GridSizeDegrees: gridSize, Status: status,
+	}
+}
+
+// directCount returns COUNT(*) over the same in-radius + in-bbox predicates the
+// cluster query applies, the independent reference for count conservation.
+func directCount(t *testing.T, store *PostgresStore, q ClusterQuery) int {
+	t.Helper()
+	var n int
+	err := store.db.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM applications "+
+			"WHERE ST_DWithin(location, ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography, $3) "+
+			"AND location::geometry && ST_MakeEnvelope($4, $5, $6, $7, 4326)",
+		q.Longitude, q.Latitude, q.RadiusMetres, q.West, q.South, q.East, q.North).Scan(&n)
+	if err != nil {
+		t.Fatalf("direct count: %v", err)
+	}
+	return n
+}
+
+func sumCounts(clusters []Cluster) int {
+	total := 0
+	for _, c := range clusters {
+		total += c.Count
+	}
+	return total
+}
+
+func sumStatusCounts(c Cluster) int {
+	total := 0
+	for _, n := range c.StatusCounts {
+		total += n
+	}
+	return total
+}
+
+// TestPostgresStore_FindClustersInZone_CountConservation proves that, at several
+// grid sizes, the summed cluster Count equals a plain COUNT(*) over the same
+// in-radius + in-bbox predicates — no double counting and no omission.
+func TestPostgresStore_FindClustersInZone_CountConservation(t *testing.T) {
+	store := newAppPGStore(t)
+	seedSpread(t, store)
+	ctx := context.Background()
+
+	for _, grid := range []float64{10.0, 0.01, 1e-6} {
+		q := clusterQuery(grid, "")
+		clusters, err := store.FindClustersInZone(ctx, q)
+		if err != nil {
+			t.Fatalf("grid %v: FindClustersInZone: %v", grid, err)
+		}
+		want := directCount(t, store, q)
+		if got := sumCounts(clusters); got != want {
+			t.Errorf("grid %v: summed Count = %d, want %d (plain COUNT(*))", grid, got, want)
+		}
+		// Every cluster's per-status breakdown must itself sum to its Count.
+		for _, c := range clusters {
+			if got := sumStatusCounts(c); got != c.Count {
+				t.Errorf("grid %v: cluster statusCounts sum = %d, want Count %d", grid, got, c.Count)
+			}
+		}
+	}
+}
+
+// TestPostgresStore_FindClustersInZone_ZoomCellBehaviour proves the grid behaviour
+// across zoom: a coarse grid collapses all points into one cell; a finer grid
+// spreads them into more cells; the finest grid yields one cell per point, each a
+// fully-identified single member.
+func TestPostgresStore_FindClustersInZone_ZoomCellBehaviour(t *testing.T) {
+	store := newAppPGStore(t)
+	seedSpread(t, store)
+	ctx := context.Background()
+
+	coarse, err := store.FindClustersInZone(ctx, clusterQuery(10.0, ""))
+	if err != nil {
+		t.Fatalf("coarse: %v", err)
+	}
+	if len(coarse) != 1 || coarse[0].Count != 8 {
+		t.Fatalf("coarse grid: got %d cells (first count %v), want 1 cell of 8", len(coarse), firstCount(coarse))
+	}
+
+	medium, err := store.FindClustersInZone(ctx, clusterQuery(0.01, ""))
+	if err != nil {
+		t.Fatalf("medium: %v", err)
+	}
+	if len(medium) != 4 {
+		t.Fatalf("medium grid: got %d cells, want 4 (one per tight pair)", len(medium))
+	}
+	for _, c := range medium {
+		if c.Count != 2 {
+			t.Errorf("medium grid: cell count = %d, want 2", c.Count)
+		}
+	}
+	if !(len(coarse) < len(medium)) {
+		t.Errorf("a finer grid must spread into more cells: coarse=%d medium=%d", len(coarse), len(medium))
+	}
+
+	tiny, err := store.FindClustersInZone(ctx, clusterQuery(1e-6, ""))
+	if err != nil {
+		t.Fatalf("tiny: %v", err)
+	}
+	if len(tiny) != 8 {
+		t.Fatalf("tiny grid: got %d cells, want 8 (one per point)", len(tiny))
+	}
+	for _, c := range tiny {
+		if c.Count != 1 {
+			t.Errorf("tiny grid: cell count = %d, want 1", c.Count)
+		}
+		if c.Member == nil {
+			t.Errorf("tiny grid: single-member cell must carry a member id, got nil")
+		}
+	}
+	if !(len(medium) < len(tiny)) {
+		t.Errorf("the finest grid must spread furthest: medium=%d tiny=%d", len(medium), len(tiny))
+	}
+}
+
+func firstCount(clusters []Cluster) any {
+	if len(clusters) == 0 {
+		return "none"
+	}
+	return clusters[0].Count
+}
+
+// TestPostgresStore_FindClustersInZone_SingleMemberIdentity proves a single-member
+// cell carries the member's {authority, name} and its app_state in statusCounts,
+// including the NULL-app_state -> "Unknown" folding.
+func TestPostgresStore_FindClustersInZone_SingleMemberIdentity(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+	for _, a := range []PlanningApplication{
+		withState(clusterApp("PERM", 100, 0.000, 0.000), pgPtr("Permitted")),
+		clusterApp("NOSTATE", 100, 0.020, 0.020), // NULL app_state
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	clusters, err := store.FindClustersInZone(ctx, clusterQuery(1e-6, ""))
+	if err != nil {
+		t.Fatalf("FindClustersInZone: %v", err)
+	}
+	if len(clusters) != 2 {
+		t.Fatalf("got %d clusters, want 2", len(clusters))
+	}
+	byName := map[string]Cluster{}
+	for _, c := range clusters {
+		if c.Member == nil {
+			t.Fatalf("expected every cell to carry a single member, got nil for %+v", c)
+		}
+		byName[c.Member.Name] = c
+	}
+
+	perm, ok := byName["PERM"]
+	if !ok {
+		t.Fatal("missing PERM cluster")
+	}
+	if perm.Member.Authority != "100" {
+		t.Errorf("PERM authority: got %q, want %q (area_id as decimal string)", perm.Member.Authority, "100")
+	}
+	if perm.Count != 1 || perm.StatusCounts["Permitted"] != 1 || len(perm.StatusCounts) != 1 {
+		t.Errorf("PERM: got count=%d statusCounts=%v, want count=1 {Permitted:1}", perm.Count, perm.StatusCounts)
+	}
+
+	noState, ok := byName["NOSTATE"]
+	if !ok {
+		t.Fatal("missing NOSTATE cluster")
+	}
+	if noState.StatusCounts["Unknown"] != 1 || len(noState.StatusCounts) != 1 {
+		t.Errorf("NOSTATE: got statusCounts=%v, want {Unknown:1} (NULL app_state folds to Unknown)", noState.StatusCounts)
+	}
+}
+
+// TestPostgresStore_FindClustersInZone_MultiMemberBreakdown proves a multi-member
+// cell carries a nil member and a per-status breakdown that sums to the count.
+func TestPostgresStore_FindClustersInZone_MultiMemberBreakdown(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+	// Three points within a tiny span so any coarse grid keeps them in one cell.
+	for _, a := range []PlanningApplication{
+		withState(clusterApp("M1", 100, 0.0000, 0.0000), pgPtr("Permitted")),
+		withState(clusterApp("M2", 100, 0.0001, 0.0000), pgPtr("Permitted")),
+		withState(clusterApp("M3", 100, 0.0002, 0.0001), pgPtr("Rejected")),
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	clusters, err := store.FindClustersInZone(ctx, clusterQuery(10.0, ""))
+	if err != nil {
+		t.Fatalf("FindClustersInZone: %v", err)
+	}
+	if len(clusters) != 1 {
+		t.Fatalf("got %d clusters, want 1 coarse cell", len(clusters))
+	}
+	c := clusters[0]
+	if c.Member != nil {
+		t.Errorf("multi-member cell must have a nil member, got %+v", c.Member)
+	}
+	if c.Count != 3 {
+		t.Errorf("count: got %d, want 3", c.Count)
+	}
+	if c.StatusCounts["Permitted"] != 2 || c.StatusCounts["Rejected"] != 1 {
+		t.Errorf("statusCounts: got %v, want {Permitted:2, Rejected:1}", c.StatusCounts)
+	}
+	if sumStatusCounts(c) != c.Count {
+		t.Errorf("statusCounts must sum to count: sum=%d count=%d", sumStatusCounts(c), c.Count)
+	}
+}
+
+// TestPostgresStore_FindClustersInZone_StatusFilter proves ?status= restricts the
+// aggregation to matching rows: the filtered counts reflect only that app_state.
+func TestPostgresStore_FindClustersInZone_StatusFilter(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+	permitted, rejected := pgPtr("Permitted"), pgPtr("Rejected")
+	for _, a := range []PlanningApplication{
+		withState(clusterApp("P1", 100, 0.0000, 0.0000), permitted),
+		withState(clusterApp("P2", 100, 0.0001, 0.0000), permitted),
+		withState(clusterApp("P3", 100, 0.0002, 0.0001), permitted),
+		withState(clusterApp("R1", 100, 0.0003, 0.0000), rejected),
+		withState(clusterApp("R2", 100, 0.0004, 0.0001), rejected),
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	all, err := store.FindClustersInZone(ctx, clusterQuery(10.0, ""))
+	if err != nil {
+		t.Fatalf("unfiltered: %v", err)
+	}
+	if got := sumCounts(all); got != 5 {
+		t.Fatalf("unfiltered count: got %d, want 5", got)
+	}
+
+	permittedOnly, err := store.FindClustersInZone(ctx, clusterQuery(10.0, "Permitted"))
+	if err != nil {
+		t.Fatalf("filtered: %v", err)
+	}
+	if len(permittedOnly) != 1 {
+		t.Fatalf("filtered: got %d clusters, want 1", len(permittedOnly))
+	}
+	c := permittedOnly[0]
+	if c.Count != 3 {
+		t.Errorf("filtered count: got %d, want 3 (only Permitted)", c.Count)
+	}
+	if len(c.StatusCounts) != 1 || c.StatusCounts["Permitted"] != 3 {
+		t.Errorf("filtered statusCounts: got %v, want {Permitted:3}", c.StatusCounts)
+	}
+}
+
+// TestPostgresStore_FindClustersInZone_Centroid proves the cell centroid is the
+// arithmetic mean of its members' points, lies within the grid cell, and lies
+// within the convex hull of the members.
+func TestPostgresStore_FindClustersInZone_Centroid(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+	const grid = 0.01
+	// Three non-collinear points comfortably inside one 0.01-deg cell.
+	offs := [3][2]float64{{0.0000, 0.0000}, {0.0002, 0.0000}, {0.0001, 0.0002}}
+	for i, off := range offs {
+		a := clusterApp("C"+strconv.Itoa(i), 100, off[0], off[1])
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	clusters, err := store.FindClustersInZone(ctx, clusterQuery(grid, ""))
+	if err != nil {
+		t.Fatalf("FindClustersInZone: %v", err)
+	}
+	if len(clusters) != 1 {
+		t.Fatalf("got %d clusters, want 1", len(clusters))
+	}
+	c := clusters[0]
+
+	var meanLng, meanLat float64
+	for _, off := range offs {
+		meanLng += pgCentreLon + off[0]
+		meanLat += pgCentreLat + off[1]
+	}
+	meanLng /= 3
+	meanLat /= 3
+	if !floatNear(c.Longitude, meanLng, 1e-9) || !floatNear(c.Latitude, meanLat, 1e-9) {
+		t.Errorf("centroid: got (%v, %v), want arithmetic mean (%v, %v)", c.Longitude, c.Latitude, meanLng, meanLat)
+	}
+
+	// Within the grid cell: the centroid is within +/- grid/2 of the cell node.
+	nodeLng := math.Round((pgCentreLon+offs[0][0])/grid) * grid
+	nodeLat := math.Round((pgCentreLat+offs[0][1])/grid) * grid
+	if math.Abs(c.Longitude-nodeLng) > grid/2+1e-9 || math.Abs(c.Latitude-nodeLat) > grid/2+1e-9 {
+		t.Errorf("centroid (%v, %v) outside cell node (%v, %v) +/- %v", c.Longitude, c.Latitude, nodeLng, nodeLat, grid/2)
+	}
+
+	// Within the convex hull of the members (PostGIS confirms the spatial fact).
+	var inHull bool
+	hullSQL := "SELECT ST_Within(" +
+		"ST_SetSRID(ST_MakePoint($1, $2), 4326), " +
+		"ST_ConvexHull(ST_Collect(location::geometry))) " +
+		"FROM applications"
+	if err := store.db.QueryRow(ctx, hullSQL, c.Longitude, c.Latitude).Scan(&inHull); err != nil {
+		t.Fatalf("convex-hull check: %v", err)
+	}
+	if !inHull {
+		t.Errorf("centroid (%v, %v) is not within the convex hull of its members", c.Longitude, c.Latitude)
+	}
+}
+
+// TestPostgresStore_FindClustersInZone_RespectsRadiusAndBBox proves both spatial
+// predicates bound the aggregation: a point inside the radius but outside the
+// viewport, and a point inside the viewport but outside the radius, are both
+// excluded; only the point inside both survives. The viewport and circle here
+// partially overlap so each predicate is exercised independently.
+func TestPostgresStore_FindClustersInZone_RespectsRadiusAndBBox(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+	for _, a := range []PlanningApplication{
+		clusterApp("INBOTH", 100, 0.0278, 0.0126),   // ~2.4 km, inside the NE viewport
+		clusterApp("RADONLY", 100, 0.0000, -0.0274), // ~3.0 km but south of the viewport
+		clusterApp("BBOXONLY", 100, 0.0678, 0.0826), // inside the viewport but ~10 km out
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	q := ClusterQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 5000,
+		West: pgCentreLon, South: pgCentreLat, East: 0.0, North: 51.60,
+		GridSizeDegrees: 1e-6,
+	}
+	clusters, err := store.FindClustersInZone(ctx, q)
+	if err != nil {
+		t.Fatalf("FindClustersInZone: %v", err)
+	}
+	if len(clusters) != 1 {
+		t.Fatalf("got %d clusters, want 1 (only the in-radius, in-viewport point)", len(clusters))
+	}
+	if clusters[0].Member == nil || clusters[0].Member.Name != "INBOTH" {
+		t.Errorf("surviving cluster: got %+v, want the INBOTH member", clusters[0].Member)
+	}
+}
+
+// TestPostgresStore_FindClustersInZone_ExplainUsesGiSTIndex proves the existing
+// GiST index (applications_location_gist) serves the ST_DWithin radius predicate
+// of the cluster query — so no new migration/index is needed. enable_seqscan is
+// disabled for the EXPLAIN so the planner is forced to reveal whether the index is
+// usable, rather than preferring a sequential scan over the small fixture table.
+func TestPostgresStore_FindClustersInZone_ExplainUsesGiSTIndex(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "applications", "watch_zones")
+	store := NewPostgresStore(pool)
+	seedSpread(t, store)
+	ctx := context.Background()
+
+	q := clusterQuery(0.01, "")
+	args := append([]any{}, q.Longitude, q.Latitude, q.RadiusMetres, q.GridSizeDegrees, q.West, q.South, q.East, q.North)
+
+	// SET enable_seqscan = off and the EXPLAIN must run on the SAME connection
+	// (the setting is session state), so acquire one pooled connection for both.
+	// Disabling seqscan forces the planner to reveal whether the GiST index is
+	// usable for the predicate, rather than preferring a sequential scan over the
+	// small fixture table.
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire connection: %v", err)
+	}
+	defer conn.Release()
+	if _, err := conn.Exec(ctx, "SET enable_seqscan = off"); err != nil {
+		t.Fatalf("disable seqscan: %v", err)
+	}
+
+	rows, err := conn.Query(ctx, "EXPLAIN (ANALYZE, FORMAT TEXT) "+clusterQueryAllStatuses, args...)
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v", err)
+	}
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			rows.Close()
+			t.Fatalf("scan plan line: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+
+	if !strings.Contains(strings.ToLower(plan.String()), "applications_location_gist") {
+		t.Errorf("EXPLAIN plan does not use the GiST index applications_location_gist:\n%s", plan.String())
+	}
+}
+
+func floatNear(a, b, tol float64) bool { return math.Abs(a-b) <= tol }

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -314,7 +314,11 @@ type apiErrorResponse struct {
 
 // writeJSON encodes v as an application/json; charset=utf-8 response with HTML
 // escaping off and no trailing newline (the same approach the profiles handler
-// uses).
+// uses). status is kept explicit at every call site (mirroring writeCreated's 201
+// and writeError) so the success code is visible where the response is written,
+// even though every JSON success body is a 200 today.
+//
+//nolint:unparam // status is intentionally explicit at call sites; 200-only today.
 func (h *handler) writeJSON(w http.ResponseWriter, r *http.Request, status int, v any) {
 	body, err := httputil.EncodeJSON(v)
 	if err != nil {

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -115,6 +115,7 @@ func NearbyRoutes(
 	}
 	mux.HandleFunc("POST /v1/me/watch-zones", h.create)
 	mux.HandleFunc("GET /v1/me/watch-zones/{zoneId}/applications", h.applications)
+	mux.HandleFunc("GET /v1/me/watch-zones/{zoneId}/applications/clusters", h.clusters)
 }
 
 // createRequest is the POST body. The optional flags default to true
@@ -161,6 +162,14 @@ const invalidSortMessage = "Invalid sort."
 // invalidStatusMessage is the 400 body when ?status= is outside the app_state
 // filter vocabulary (and not "All"/absent, which mean no filter).
 const invalidStatusMessage = "Invalid status filter."
+
+// invalidBBoxMessage is the 400 body when ?bbox= is not four in-range,
+// well-ordered finite decimal degrees (west,south,east,north).
+const invalidBBoxMessage = "Invalid bbox."
+
+// invalidZoomMessage is the 400 body when ?zoom= is not an integer in the slippy
+// range 0..maxZoom.
+const invalidZoomMessage = "Invalid zoom."
 
 // invalidUnreadMessage is the 400 body when ?unread= is neither "true", "false"
 // nor absent.
@@ -455,6 +464,144 @@ func (h *handler) findZonePage(ctx context.Context, userID string, zone WatchZon
 		Limit:        limit,
 		Cursor:       cursor,
 	})
+}
+
+// clusters implements GET /v1/me/watch-zones/{zoneId}/applications/clusters
+// (issue #698): load the zone (404 if not owned, like the sibling applications
+// route), parse the viewport (?bbox=) and zoom (?zoom=) and optional ?status=
+// filter (each malformed value is a clean 400 before any query), translate the
+// zoom into a PostGIS grid cell size, and return the grid-aggregated clusters for
+// the visible rect as a JSON array. The store stays a pure spatial primitive: the
+// zoom -> grid-size policy lives here so density can be tuned without a store change.
+func (h *handler) clusters(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+	zoneID := r.PathValue("zoneId")
+
+	zone, err := h.store.Get(r.Context(), userID, zoneID)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		h.serverError(w, r, "load watch zone", err)
+		return
+	}
+
+	box, ok := parseBBox(r.URL.Query().Get("bbox"))
+	if !ok {
+		h.writeError(w, r, http.StatusBadRequest, invalidBBoxMessage)
+		return
+	}
+
+	gridSize, ok := parseZoom(r.URL.Query().Get("zoom"))
+	if !ok {
+		h.writeError(w, r, http.StatusBadRequest, invalidZoomMessage)
+		return
+	}
+
+	// ?status= filters on the raw app_state; "All"/absent means no filter, any
+	// other non-vocabulary value is a clean 400 (same vocabulary as the list).
+	status, ok := parseStatus(r.URL.Query().Get("status"))
+	if !ok {
+		h.writeError(w, r, http.StatusBadRequest, invalidStatusMessage)
+		return
+	}
+
+	clusters, err := h.apps.FindClustersInZone(r.Context(), applications.ClusterQuery{
+		Latitude:        zone.Latitude,
+		Longitude:       zone.Longitude,
+		RadiusMetres:    zone.RadiusMetres,
+		West:            box.west,
+		South:           box.south,
+		East:            box.east,
+		North:           box.north,
+		GridSizeDegrees: gridSize,
+		Status:          status,
+	})
+	if err != nil {
+		h.serverError(w, r, "find clusters in zone", err)
+		return
+	}
+	// Encode a bare JSON array, never null, for an empty viewport.
+	if clusters == nil {
+		clusters = []applications.Cluster{}
+	}
+	h.writeJSON(w, r, http.StatusOK, clusters)
+}
+
+// viewport is the parsed ?bbox= rectangle in WGS84 decimal degrees.
+type viewport struct {
+	west, south, east, north float64
+}
+
+// parseBBox resolves ?bbox=west,south,east,north into a viewport. It rejects
+// (ok == false) anything that is not exactly four finite decimal degrees, with
+// coordinates in range (lng [-180,180], lat [-90,90]) and strictly ordered
+// (west < east, south < north), so a malformed viewport is a clean 400 rather
+// than a degenerate or world-spanning query.
+func parseBBox(raw string) (viewport, bool) {
+	if raw == "" {
+		return viewport{}, false
+	}
+	parts := strings.Split(raw, ",")
+	if len(parts) != 4 {
+		return viewport{}, false
+	}
+	vals := make([]float64, 4)
+	for i, p := range parts {
+		v, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
+		if err != nil || math.IsNaN(v) || math.IsInf(v, 0) {
+			return viewport{}, false
+		}
+		vals[i] = v
+	}
+	box := viewport{west: vals[0], south: vals[1], east: vals[2], north: vals[3]}
+	if box.west < -180 || box.west > 180 || box.east < -180 || box.east > 180 {
+		return viewport{}, false
+	}
+	if box.south < -90 || box.south > 90 || box.north < -90 || box.north > 90 {
+		return viewport{}, false
+	}
+	if box.west >= box.east || box.south >= box.north {
+		return viewport{}, false
+	}
+	return box, true
+}
+
+// maxZoom is the inclusive upper bound on the standard slippy-map zoom range a
+// client may request; baseGridDegrees is the grid cell size (in degrees) at zoom
+// 0. Each cell is 1/8 of a zoom tile (a tile is 360/2^z degrees wide), so a
+// screenful of a few tiles yields a bounded handful of cluster cells.
+const (
+	maxZoom         = 20
+	baseGridDegrees = 45.0 // 360 / 2^3 (eight cells per tile at zoom 0)
+)
+
+// zoomGridDegrees is the server-owned zoom -> grid-cell-size lookup. Index z holds
+// the cell size in degrees for slippy zoom z: baseGridDegrees / 2^z, so the cell
+// halves with every zoom level (45 deg at z=0 down to ~4.8e-5 deg at z=20, where
+// each application is effectively its own cell). Keeping this table in the handler
+// lets us retune density without touching the store or shipping a client release.
+var zoomGridDegrees = func() [maxZoom + 1]float64 {
+	var table [maxZoom + 1]float64
+	for z := range table {
+		table[z] = baseGridDegrees / float64(uint64(1)<<uint(z))
+	}
+	return table
+}()
+
+// parseZoom resolves ?zoom= to a grid cell size via zoomGridDegrees. An absent,
+// non-integer, or out-of-range (outside 0..maxZoom) value is rejected
+// (ok == false) so a garbage zoom is a clean 400, never a silent default.
+func parseZoom(raw string) (float64, bool) {
+	if raw == "" {
+		return 0, false
+	}
+	z, err := strconv.Atoi(raw)
+	if err != nil || z < 0 || z > maxZoom {
+		return 0, false
+	}
+	return zoomGridDegrees[z], true
 }
 
 // parseLimit resolves ?limit= to a bounded page size: absent, non-numeric, or

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -58,9 +58,16 @@ type authorityResolver interface {
 // 1-3: distance/newest/oldest/status/recent-activity) with a sort-aware keyset
 // cursor; userID scopes the per-user notification join the recent-activity sort
 // needs. *applications.PostgresStore satisfies both.
+//
+// FindClustersInZone (issue #698) backs the server-side map clustering endpoint:
+// it returns PostGIS grid-aggregated cluster bubbles (centroid + count + status
+// breakdown) for a viewport, so the map renders a handful of aggregates instead
+// of eager-draining every application. *applications.PostgresStore satisfies all
+// three.
 type appFinder interface {
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]applications.PlanningApplication, string, error)
 	FindInZonePage(ctx context.Context, q applications.InZoneQuery) ([]applications.PlanningApplication, string, error)
+	FindClustersInZone(ctx context.Context, q applications.ClusterQuery) ([]applications.Cluster, error)
 }
 
 // watermarkReader reads the caller's notification read-watermark. A nil return

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -54,6 +54,11 @@ type fakeAppFinder struct {
 	lastUserID   string
 	lastStatus   string
 	lastUnread   bool
+
+	clusters         []applications.Cluster
+	clusterErr       error
+	clustersCalled   bool
+	lastClusterQuery applications.ClusterQuery
 }
 
 func (f *fakeAppFinder) FindNearbyPage(_ context.Context, _, _, _ float64, limit int, cursor string) ([]applications.PlanningApplication, string, error) {
@@ -90,6 +95,15 @@ func (f *fakeAppFinder) FindInZonePage(_ context.Context, q applications.InZoneQ
 		apps = apps[:q.Limit]
 	}
 	return apps, f.next, nil
+}
+
+func (f *fakeAppFinder) FindClustersInZone(_ context.Context, q applications.ClusterQuery) ([]applications.Cluster, error) {
+	f.clustersCalled = true
+	f.lastClusterQuery = q
+	if f.clusterErr != nil {
+		return nil, f.clusterErr
+	}
+	return f.clusters, nil
 }
 
 type fakeWatermark struct {
@@ -1253,4 +1267,288 @@ func mustZone(t *testing.T, id string, authorityID int) WatchZone {
 		t.Fatalf("NewWatchZone: %v", err)
 	}
 	return z
+}
+
+// clusterDeps builds a standard dependency set for the clusters-endpoint tests:
+// one seeded zone (lat 51.5, lng -0.12, radius 1000) and a configurable finder.
+func clusterDeps(t *testing.T, apps *fakeAppFinder) nearbyDeps {
+	t.Helper()
+	return nearbyDeps{
+		store:    &fakeZoneStore{zones: []WatchZone{mustZone(t, "zone-1", 471)}},
+		apps:     apps,
+		profiles: &fakeProfileReader{},
+		resolver: &fakeResolver{},
+		state:    &fakeWatermark{},
+		unread:   &fakeUnread{},
+	}
+}
+
+// validClusterQuery is a well-formed bbox+zoom query string for the clusters
+// endpoint. bbox=west,south,east,north (WGS84 degrees) around the fixture zone.
+const validClusterQuery = "?bbox=-0.2,51.4,-0.05,51.6&zoom=12"
+
+// TestClusters_ZoneNotFoundIs404 proves an unowned (absent) zone is a 404, like
+// the sibling applications route, before any spatial query runs.
+func TestClusters_ZoneNotFoundIs404(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{}
+	d := clusterDeps(t, apps)
+	d.store = &fakeZoneStore{} // no zones
+	mux := newNearbyMux(t, d)
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/missing/applications/clusters"+validClusterQuery, "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+	if apps.clustersCalled {
+		t.Error("must not run the cluster query for an unowned zone")
+	}
+}
+
+// TestClusters_PassesZoneAndParamsToStore proves the handler loads the zone and
+// threads its centre+radius, the parsed bbox, the zoom-derived grid size, and the
+// status filter into the store query.
+func TestClusters_PassesZoneAndParamsToStore(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{}
+	mux := newNearbyMux(t, clusterDeps(t, apps))
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters?bbox=-0.2,51.4,-0.05,51.6&zoom=12&status=Permitted", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if !apps.clustersCalled {
+		t.Fatal("the cluster query must run for an owned zone")
+	}
+	q := apps.lastClusterQuery
+	if q.Latitude != 51.5 || q.Longitude != -0.12 || q.RadiusMetres != 1000 {
+		t.Errorf("zone centre/radius: got (%v,%v,%v), want (51.5,-0.12,1000)", q.Latitude, q.Longitude, q.RadiusMetres)
+	}
+	if q.West != -0.2 || q.South != 51.4 || q.East != -0.05 || q.North != 51.6 {
+		t.Errorf("bbox: got (%v,%v,%v,%v), want (-0.2,51.4,-0.05,51.6)", q.West, q.South, q.East, q.North)
+	}
+	if q.Status != "Permitted" {
+		t.Errorf("status: got %q, want %q", q.Status, "Permitted")
+	}
+	wantGrid := 45.0 / float64(uint64(1)<<12) // 360/2^(12+3)
+	if q.GridSizeDegrees != wantGrid {
+		t.Errorf("grid size for zoom 12: got %v, want %v", q.GridSizeDegrees, wantGrid)
+	}
+}
+
+// TestClusters_ZoomToGridSizeLookup proves the server-owned zoom -> grid-cell-size
+// table: each cell is 1/8 of a slippy tile (360/2^z), so the size halves per zoom
+// level, and the size passed to the store matches the table for the request zoom.
+func TestClusters_ZoomToGridSizeLookup(t *testing.T) {
+	t.Parallel()
+	for _, zoom := range []int{0, 1, 8, 12, 16, 20} {
+		t.Run(strconv.Itoa(zoom), func(t *testing.T) {
+			t.Parallel()
+			apps := &fakeAppFinder{}
+			mux := newNearbyMux(t, clusterDeps(t, apps))
+			rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters?bbox=-0.2,51.4,-0.05,51.6&zoom="+strconv.Itoa(zoom), "")
+			if rec.Code != http.StatusOK {
+				t.Fatalf("zoom=%d: got %d, want 200", zoom, rec.Code)
+			}
+			want := 45.0 / float64(uint64(1)<<uint(zoom)) // 360/2^(z+3)
+			if apps.lastClusterQuery.GridSizeDegrees != want {
+				t.Errorf("zoom=%d grid size: got %v, want %v", zoom, apps.lastClusterQuery.GridSizeDegrees, want)
+			}
+		})
+	}
+}
+
+// TestClusters_RequiresBBox proves an absent bbox is a clean 400 before any query.
+func TestClusters_RequiresBBox(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{}
+	mux := newNearbyMux(t, clusterDeps(t, apps))
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters?zoom=12", "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", rec.Code)
+	}
+	if apps.clustersCalled {
+		t.Error("must not run the cluster query when bbox is absent")
+	}
+}
+
+// TestClusters_MalformedBBoxIs400 proves a bbox that is not four in-range,
+// well-ordered finite degrees is a clean 400 before any query.
+func TestClusters_MalformedBBoxIs400(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"too few values":    "bbox=-0.2,51.4,-0.05&zoom=12",
+		"too many values":   "bbox=-0.2,51.4,-0.05,51.6,1&zoom=12",
+		"non-numeric":       "bbox=-0.2,abc,-0.05,51.6&zoom=12",
+		"west >= east":      "bbox=-0.05,51.4,-0.2,51.6&zoom=12",
+		"south >= north":    "bbox=-0.2,51.6,-0.05,51.4&zoom=12",
+		"lng out of range":  "bbox=-181,51.4,-0.05,51.6&zoom=12",
+		"lat out of range":  "bbox=-0.2,51.4,-0.05,91&zoom=12",
+		"empty value":       "bbox=&zoom=12",
+		"non-finite (NaN)":  "bbox=-0.2,NaN,-0.05,51.6&zoom=12",
+		"non-finite (+Inf)": "bbox=-0.2,51.4,Inf,51.6&zoom=12",
+	}
+	for name, query := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			apps := &fakeAppFinder{}
+			mux := newNearbyMux(t, clusterDeps(t, apps))
+			rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters?"+query, "")
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("%s: got %d, want 400", name, rec.Code)
+			}
+			if apps.clustersCalled {
+				t.Errorf("%s: must not run the cluster query for a malformed bbox", name)
+			}
+		})
+	}
+}
+
+// TestClusters_RequiresZoom proves an absent zoom is a clean 400 before any query.
+func TestClusters_RequiresZoom(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{}
+	mux := newNearbyMux(t, clusterDeps(t, apps))
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters?bbox=-0.2,51.4,-0.05,51.6", "")
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", rec.Code)
+	}
+	if apps.clustersCalled {
+		t.Error("must not run the cluster query when zoom is absent")
+	}
+}
+
+// TestClusters_ZoomOutOfRangeIs400 proves a zoom outside the slippy range 0..20
+// (or non-integer) is a clean 400 before any query.
+func TestClusters_ZoomOutOfRangeIs400(t *testing.T) {
+	t.Parallel()
+	for _, zoom := range []string{"-1", "21", "100", "abc", "1.5", ""} {
+		t.Run("zoom="+zoom, func(t *testing.T) {
+			t.Parallel()
+			apps := &fakeAppFinder{}
+			mux := newNearbyMux(t, clusterDeps(t, apps))
+			rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters?bbox=-0.2,51.4,-0.05,51.6&zoom="+zoom, "")
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("zoom=%q: got %d, want 400", zoom, rec.Code)
+			}
+			if apps.clustersCalled {
+				t.Errorf("zoom=%q: must not run the cluster query for an out-of-range zoom", zoom)
+			}
+		})
+	}
+}
+
+// TestClusters_UnknownStatusIs400 proves a status outside the app_state vocabulary
+// (and not "All"/absent) is a clean 400 before any query, reusing the same
+// vocabulary as the list endpoint.
+func TestClusters_UnknownStatusIs400(t *testing.T) {
+	t.Parallel()
+	for _, status := range []string{"nonsense", "permitted", "REJECTED", "all"} {
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+			apps := &fakeAppFinder{}
+			mux := newNearbyMux(t, clusterDeps(t, apps))
+			rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters?bbox=-0.2,51.4,-0.05,51.6&zoom=12&status="+status, "")
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status=%q: got %d, want 400", status, rec.Code)
+			}
+			if apps.clustersCalled {
+				t.Errorf("status=%q: must not run the cluster query for an unrecognised status", status)
+			}
+		})
+	}
+}
+
+// TestClusters_StatusAllIsNoFilter proves ?status=All threads an empty status
+// filter (no filter), like the list endpoint.
+func TestClusters_StatusAllIsNoFilter(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{}
+	mux := newNearbyMux(t, clusterDeps(t, apps))
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters?bbox=-0.2,51.4,-0.05,51.6&zoom=12&status=All", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if !apps.clustersCalled || apps.lastClusterQuery.Status != "" {
+		t.Errorf("status=All must thread an empty status filter: called=%v status=%q", apps.clustersCalled, apps.lastClusterQuery.Status)
+	}
+}
+
+// TestClusters_WireShape pins the response contract: an array of cluster objects
+// with latitude/longitude/count/statusCounts, a null applicationId for a
+// multi-member cell, and a {authority,name} applicationId for a single-member cell.
+func TestClusters_WireShape(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{clusters: []applications.Cluster{
+		{
+			Latitude: 51.51, Longitude: -0.12, Count: 194,
+			StatusCounts: map[string]int{"Permitted": 120, "Undecided": 60, "Rejected": 14},
+			Member:       nil,
+		},
+		{
+			Latitude: 51.52, Longitude: -0.13, Count: 1,
+			StatusCounts: map[string]int{"Permitted": 1},
+			Member:       &applications.PlanningApplicationID{Authority: "471", Name: "24/001"},
+		},
+	}}
+	mux := newNearbyMux(t, clusterDeps(t, apps))
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters"+validClusterQuery, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var got []struct {
+		Latitude      float64        `json:"latitude"`
+		Longitude     float64        `json:"longitude"`
+		Count         int            `json:"count"`
+		StatusCounts  map[string]int `json:"statusCounts"`
+		ApplicationID *struct {
+			Authority string `json:"authority"`
+			Name      string `json:"name"`
+		} `json:"applicationId"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v; raw=%s", err, rec.Body.String())
+	}
+	if len(got) != 2 {
+		t.Fatalf("clusters: got %d, want 2", len(got))
+	}
+	if got[0].Count != 194 || got[0].ApplicationID != nil {
+		t.Errorf("multi-member cell: got count=%d applicationId=%+v, want count=194 applicationId=null", got[0].Count, got[0].ApplicationID)
+	}
+	if got[0].StatusCounts["Permitted"] != 120 || got[0].StatusCounts["Undecided"] != 60 || got[0].StatusCounts["Rejected"] != 14 {
+		t.Errorf("multi-member statusCounts: got %v", got[0].StatusCounts)
+	}
+	if got[1].Count != 1 || got[1].ApplicationID == nil {
+		t.Fatalf("single-member cell: got count=%d applicationId=%+v, want count=1 with a non-null id", got[1].Count, got[1].ApplicationID)
+	}
+	if got[1].ApplicationID.Authority != "471" || got[1].ApplicationID.Name != "24/001" {
+		t.Errorf("single-member id: got %+v, want {authority:471, name:24/001}", *got[1].ApplicationID)
+	}
+}
+
+// TestClusters_EmptyReturnsEmptyArray proves an empty result encodes as a bare
+// JSON array, never null.
+func TestClusters_EmptyReturnsEmptyArray(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{} // nil clusters
+	mux := newNearbyMux(t, clusterDeps(t, apps))
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters"+validClusterQuery, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if got := rec.Body.String(); got != "[]" {
+		t.Errorf("empty clusters: got %s, want []", got)
+	}
+}
+
+// TestClusters_StoreErrorIs500 proves a store failure surfaces as a 500.
+func TestClusters_StoreErrorIs500(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{clusterErr: errors.New("postgis down")}
+	mux := newNearbyMux(t, clusterDeps(t, apps))
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters"+validClusterQuery, "")
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status: got %d, want 500", rec.Code)
+	}
 }


### PR DESCRIPTION
## What

Adds `GET /v1/me/watch-zones/{zoneId}/applications/clusters?bbox=west,south,east,north&zoom=<0..20>&status=<optional>` — the API slice of #698. Returns a JSON array of PostGIS grid-aggregated cluster bubbles (centroid + count + per-status breakdown) for the visible map rect, so the iOS map can stop eager-draining all 22k applications in a dense zone.

## How

- **New store primitive** `FindClustersInZone` (`internal/applications/zoneclusters.go`): one parameterised PostGIS query — `ST_DWithin` (zone radius, served by the existing `applications_location_gist` GiST index) AND `location::geometry && ST_MakeEnvelope(...)` (viewport bbox), pre-aggregated by `(ST_SnapToGrid(location::geometry, gridDeg), app_state)`, folded per cell into `ST_Centroid(ST_Collect(...))`, `SUM(count)`, `jsonb_object_agg(state, n)`, and `MIN(authority_code)/MIN(planit_name)` to identify the single member when `count == 1`. `ORDER BY count DESC LIMIT 1000`. Mirrors the SEO `GROUP BY app_state` rollup + the `FindInZonePage` shape.
- **New handler** `clusters` (`internal/watchzones/nearby.go`): auth-scoped like the sibling `applications` route (404 if zone not owned), parses `bbox`/`zoom`/`status` with clean 400s, owns the server-side `zoom → grid cell size` lookup table (so density is tunable without a client release or store change). `status=` reuses the list path's `StatusSupported` vocabulary and filters on raw `app_state`.
- Wire shape: `{ "latitude", "longitude", "count", "statusCounts": {...}, "applicationId": {"authority","name"}|null }`. `applicationId` carries `{areaId-as-decimal-string, planit_name}` only when `count == 1`, so an iOS pin tap routes to the summary sheet with no re-fetch.

## Scope / safety

- **Additive only.** The existing `GET .../applications` list endpoint and its param-less byte-identical contract are untouched. No migration added — the existing GiST index serves both predicates (proven by an `EXPLAIN (ANALYZE)` integration test).
- `//nolint:unparam` on the shared `writeJSON` keeps the list-path call sites byte-identical (the new 200-only caller would otherwise trip unparam).

## Tests

- **pgtest integration suite** (`zoneclusters_test.go`, `//go:build integration`): count conservation vs plain `COUNT(*)`, coarse-zoom-collapses / fine-zoom-spreads / max-zoom-all-singletons, single-member identity + status, multi-member null-member + statusCounts summing to count, centroid containment, status filtering, and the `EXPLAIN (ANALYZE)` index proof. Runs against real PostGIS in CI (pr-gate "Go API: Integration tests").
- **Handler unit tests** (fakes): param parsing, all three 400 cases, 404 for an unowned zone, auth scoping, zoom→grid lookup, params-to-store, and the wire shape incl. the single-member case.
- Local gates green: `go test -race ./...` (1197 pass), `go vet`, `gofmt`, `golangci-lint` (0 issues), `go build -tags=integration`.

Part of #698. iOS map slice follows (consumer).

Closes nothing yet — iOS slice tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new watch-zone clusters endpoint to view grouped application results on a map.
  * Supports filtering by bounding box, zoom level, and optional status.

* **Bug Fixes**
  * Returns clear validation errors for missing or malformed map query parameters.
  * Shows an empty array when no clusters are found and a 404 when the watch zone doesn’t exist.

* **Tests**
  * Added coverage for cluster grouping, status filtering, response shape, empty results, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->