### PR TITLE
refactor(web): replace identity-map KNOWN_SERVER_ERROR_CODES with a Set (tc-47av)

### DIFF
--- a/web/src/features/offerCode/api/redeemOfferCode.ts
+++ b/web/src/features/offerCode/api/redeemOfferCode.ts
@@ -2,12 +2,12 @@ import { RedeemError, type RedeemErrorCode, type RedeemResult } from './types';
 
 export type RedeemOfferCodeClient = (code: string) => Promise<RedeemResult>;
 
-const KNOWN_SERVER_ERROR_CODES: Record<string, RedeemErrorCode> = {
-  invalid_code_format: 'invalid_code_format',
-  invalid_code: 'invalid_code',
-  code_already_redeemed: 'code_already_redeemed',
-  already_subscribed: 'already_subscribed',
-};
+const KNOWN_SERVER_ERROR_CODES = new Set<string>([
+  'invalid_code_format',
+  'invalid_code',
+  'code_already_redeemed',
+  'already_subscribed',
+]);
 
 export function createRedeemOfferCodeClient(
   getAccessToken: () => Promise<string>,
@@ -31,8 +31,8 @@ export function createRedeemOfferCodeClient(
 
     const serverCode = await readServerErrorCode(response);
     const mapped: RedeemErrorCode =
-      serverCode !== null && serverCode in KNOWN_SERVER_ERROR_CODES
-        ? KNOWN_SERVER_ERROR_CODES[serverCode]!
+      serverCode !== null && KNOWN_SERVER_ERROR_CODES.has(serverCode)
+        ? (serverCode as RedeemErrorCode)
         : 'network';
     throw new RedeemError(mapped, `Redeem failed (${response.status})`);
   };


### PR DESCRIPTION
Part of the 2026-06-28 simplification sweep (#702). Behaviour-preserving over-abstraction cleanup.

Replaces the identity-map `Record<string, RedeemErrorCode>` with a `Set<string>` membership test. Bead tc-47av.

Validation: `npx vitest run` (894 pass) + `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)