### PR TITLE
chore(web): drop unused domain type-guards (tc-esjg)

### DIFF
--- a/web/src/domain/__tests__/types.test.ts
+++ b/web/src/domain/__tests__/types.test.ts
@@ -8,9 +8,6 @@ import {
   asApplicationUid,
   asWatchZoneId,
   asAuthorityId,
-  isApplicationStatus,
-  isSubscriptionTier,
-  isNotificationEventType,
 } from "../types";
 import * as types from "../types";
 
@@ -31,58 +28,7 @@ describe("branded type constructors", () => {
   });
 });
 
-describe("type guards", () => {
-  describe("isApplicationStatus", () => {
-    it("returns true for valid statuses (PlanIt vocabulary)", () => {
-      expect(isApplicationStatus("Undecided")).toBe(true);
-      expect(isApplicationStatus("Permitted")).toBe(true);
-      expect(isApplicationStatus("Conditions")).toBe(true);
-      expect(isApplicationStatus("Rejected")).toBe(true);
-      expect(isApplicationStatus("Withdrawn")).toBe(true);
-      expect(isApplicationStatus("Appealed")).toBe(true);
-      expect(isApplicationStatus("Unresolved")).toBe(true);
-      expect(isApplicationStatus("Referred")).toBe(true);
-      expect(isApplicationStatus("Not Available")).toBe(true);
-    });
-
-    it("returns false for legacy/invalid statuses", () => {
-      // Legacy vocabulary that PlanIt does not actually use
-      expect(isApplicationStatus("Approved")).toBe(false);
-      expect(isApplicationStatus("Refused")).toBe(false);
-      expect(isApplicationStatus("invalid")).toBe(false);
-      expect(isApplicationStatus("")).toBe(false);
-      expect(isApplicationStatus(42)).toBe(false);
-    });
-  });
-
-  describe("isSubscriptionTier", () => {
-    it("returns true for valid tiers", () => {
-      expect(isSubscriptionTier("Free")).toBe(true);
-      expect(isSubscriptionTier("Personal")).toBe(true);
-      expect(isSubscriptionTier("Pro")).toBe(true);
-    });
-
-    it("returns false for invalid tiers", () => {
-      expect(isSubscriptionTier("Premium")).toBe(false);
-      expect(isSubscriptionTier("")).toBe(false);
-    });
-  });
-
-});
-
 describe("notification-state types", () => {
-  it("isNotificationEventType returns true for the wire-format names", () => {
-    expect(isNotificationEventType("NewApplication")).toBe(true);
-    expect(isNotificationEventType("DecisionUpdate")).toBe(true);
-  });
-
-  it("isNotificationEventType returns false for unknown values", () => {
-    expect(isNotificationEventType("Other")).toBe(false);
-    expect(isNotificationEventType("")).toBe(false);
-    expect(isNotificationEventType(0)).toBe(false);
-    expect(isNotificationEventType(null)).toBe(false);
-  });
-
   it("LatestUnreadEvent surfaces type, decision and createdAt", () => {
     const event: LatestUnreadEvent = {
       type: "DecisionUpdate",

--- a/web/src/domain/types.ts
+++ b/web/src/domain/types.ts
@@ -42,22 +42,6 @@ export type ApplicationStatus =
   | "Referred"
   | "Not Available";
 
-const APPLICATION_STATUSES: readonly string[] = [
-  "Undecided",
-  "Permitted",
-  "Conditions",
-  "Rejected",
-  "Withdrawn",
-  "Appealed",
-  "Unresolved",
-  "Referred",
-  "Not Available",
-];
-
-export function isApplicationStatus(value: unknown): value is ApplicationStatus {
-  return typeof value === "string" && APPLICATION_STATUSES.includes(value);
-}
-
 /**
  * Wire-format tag distinguishing the lifecycle event a notification was raised
  * for. Matches the API's `NotificationEventType`, which serialises as a string.
@@ -68,26 +52,7 @@ export function isApplicationStatus(value: unknown): value is ApplicationStatus 
  */
 export type NotificationEventType = "NewApplication" | "DecisionUpdate";
 
-const NOTIFICATION_EVENT_TYPES: readonly string[] = [
-  "NewApplication",
-  "DecisionUpdate",
-];
-
-export function isNotificationEventType(
-  value: unknown,
-): value is NotificationEventType {
-  return (
-    typeof value === "string" && NOTIFICATION_EVENT_TYPES.includes(value)
-  );
-}
-
 export type SubscriptionTier = "Free" | "Personal" | "Pro";
-
-const SUBSCRIPTION_TIERS: readonly string[] = ["Free", "Personal", "Pro"];
-
-export function isSubscriptionTier(value: unknown): value is SubscriptionTier {
-  return typeof value === "string" && SUBSCRIPTION_TIERS.includes(value);
-}
 
 /**
  * Matches the API's numeric day-of-week enum.


### PR DESCRIPTION
Part of the 2026-06-28 simplification sweep (#702). Behaviour-preserving dead-code removal.

Removes the unused domain type-guards `isApplicationStatus`/`isNotificationEventType`/`isSubscriptionTier` and their backing arrays — no production callers (API adapters cast directly). Union types kept. Bead tc-esjg.

Validation: `npx vitest run` (873 pass) + `npx tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)