### PR TITLE
feat(api): expose X-Next-Cursor via CORS for browser load-more (tc-q5yc)

### DIFF
--- a/api-go/internal/middleware/cors.go
+++ b/api-go/internal/middleware/cors.go
@@ -34,6 +34,11 @@ func CORS(allowedOrigins []string) func(http.Handler) http.Handler {
 			// Vary: Origin prevents a shared cache from serving one origin's
 			// CORS-decorated response to a request from a different origin.
 			w.Header().Add("Vary", "Origin")
+			// Expose X-Next-Cursor so a browser fetch() can read the keyset
+			// pagination cursor cross-origin (GH#711). Set on the matched-origin
+			// branch before the preflight check so it applies to both the 204
+			// preflight and the normal pass-through response.
+			w.Header().Set("Access-Control-Expose-Headers", "X-Next-Cursor")
 
 			// Preflight: an OPTIONS request carrying Access-Control-Request-Method.
 			// AllowAnyMethod / AllowAnyHeader means we echo exactly what the

--- a/api-go/internal/middleware/cors_test.go
+++ b/api-go/internal/middleware/cors_test.go
@@ -117,6 +117,52 @@ func TestCORS_PreflightShortCircuits(t *testing.T) {
 	}
 }
 
+func TestCORS_ExposesNextCursorHeader(t *testing.T) {
+	t.Parallel()
+
+	h := CORS([]string{"https://towncrierapp.uk"})(okHandler())
+
+	tests := []struct {
+		name       string
+		method     string
+		origin     string
+		preflight  bool
+		wantExpose bool
+	}{
+		{"allowed origin GET", http.MethodGet, "https://towncrierapp.uk", false, true},
+		{"allowed origin preflight", http.MethodOptions, "https://towncrierapp.uk", true, true},
+		{"disallowed origin", http.MethodGet, "https://evil.example.com", false, false},
+		{"no origin header", http.MethodGet, "", false, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequestWithContext(t.Context(), tc.method, "/api/me", nil)
+			if tc.origin != "" {
+				req.Header.Set("Origin", tc.origin)
+			}
+			if tc.preflight {
+				req.Header.Set("Access-Control-Request-Method", "GET")
+			}
+			rec := httptest.NewRecorder()
+
+			h.ServeHTTP(rec, req)
+
+			// A browser fetch() can only read X-Next-Cursor for cursor pagination
+			// when the server exposes it via Access-Control-Expose-Headers, and
+			// only ever for allowed origins.
+			got := rec.Header().Get("Access-Control-Expose-Headers")
+			if tc.wantExpose {
+				if got != "X-Next-Cursor" {
+					t.Errorf("Access-Control-Expose-Headers = %q, want %q", got, "X-Next-Cursor")
+				}
+			} else if got != "" {
+				t.Errorf("Access-Control-Expose-Headers = %q, want empty", got)
+			}
+		})
+	}
+}
+
 func TestCORS_PreflightEchoesRequestedHeaders(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Changes

Slice A of #711 (web watch-zone parity). Hard prerequisite for the web list load-more (Slice B): a browser `fetch()` cannot read the `X-Next-Cursor` keyset-pagination response header cross-origin unless the server exposes it.

- `api-go/internal/middleware/cors.go` — set `Access-Control-Expose-Headers: X-Next-Cursor` on the **matched-origin branch only** (after `Allow-Origin`/`Vary`, before the preflight short-circuit), so it applies to both normal GET responses and the 204 preflight. Non-allowed and origin-less requests return early before any CORS header, so they stay untouched.
- `api-go/internal/middleware/cors_test.go` — table-driven `TestCORS_ExposesNextCursorHeader`: allowed-origin GET ⇒ present, allowed-origin preflight OPTIONS ⇒ present, disallowed origin ⇒ absent, no-origin ⇒ absent.

No other CORS behaviour changes. Backend-only — no `Release-Note:` trailer. The `/clusters` endpoint (Slice C) needs no expose header (it returns a body array).

Closes tc-q5yc. Part of #711.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Responses from allowed browser origins can now expose the `X-Next-Cursor` header, making cursor-based pagination easier to use from client-side apps.
* **Bug Fixes**
  * The exposed header is now included consistently for both normal requests and preflight responses when the origin is permitted.
  * Requests without a matching origin continue to avoid CORS headers as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->