### PR TITLE
feat(web): server-driven Applications list sort/filter + keyset pagination (tc-bmuk)

### DIFF
--- a/web/src/api/__tests__/applications.test.ts
+++ b/web/src/api/__tests__/applications.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from 'vitest';
+import type { ApiClient } from '../client';
+import { applicationsApi } from '../applications';
+import type { PlanningApplicationSummary } from '../../domain/types';
+import { asApplicationUid } from '../../domain/types';
+
+interface RecordedGet {
+  readonly path: string;
+  readonly params: Record<string, string> | undefined;
+}
+
+/**
+ * Hand-written ApiClient spy. Only `get`/`getWithHeaders` are exercised by the
+ * applications API; the rest throw so an accidental call is loud.
+ */
+class SpyApiClient implements ApiClient {
+  getCalls: RecordedGet[] = [];
+  getWithHeadersCalls: RecordedGet[] = [];
+
+  getResult: unknown = [];
+  getWithHeadersBody: unknown = [];
+  getWithHeadersCursor: string | null = null;
+
+  async get<T>(path: string, params?: Record<string, string>): Promise<T> {
+    this.getCalls.push({ path, params });
+    return this.getResult as T;
+  }
+
+  async getWithHeaders<T>(
+    path: string,
+    params?: Record<string, string>,
+  ): Promise<{ body: T; headers: Headers }> {
+    this.getWithHeadersCalls.push({ path, params });
+    const headers = new Headers();
+    if (this.getWithHeadersCursor !== null) {
+      headers.set('X-Next-Cursor', this.getWithHeadersCursor);
+    }
+    return { body: this.getWithHeadersBody as T, headers };
+  }
+
+  post<T>(): Promise<T> {
+    throw new Error('not implemented');
+  }
+  put(): Promise<void> {
+    throw new Error('not implemented');
+  }
+  patch<T>(): Promise<T> {
+    throw new Error('not implemented');
+  }
+  delete(): Promise<void> {
+    throw new Error('not implemented');
+  }
+}
+
+function summary(uid: string): PlanningApplicationSummary {
+  return {
+    uid: asApplicationUid(uid),
+    name: uid,
+    address: '1 Test Street',
+    postcode: null,
+    description: 'Test',
+    appType: 'Full Planning',
+    appState: 'Undecided',
+    areaName: 'Cambridge City Council',
+    startDate: '2026-01-01',
+    url: null,
+    latitude: null,
+    longitude: null,
+    latestUnreadEvent: null,
+  };
+}
+
+describe('applicationsApi.getByZonePaged', () => {
+  it('sends sort/cursor/limit params and returns rows plus the X-Next-Cursor header', async () => {
+    const client = new SpyApiClient();
+    client.getWithHeadersBody = [summary('A'), summary('B')];
+    client.getWithHeadersCursor = 'cursor-2';
+
+    const page = await applicationsApi(client).getByZonePaged('z1', {
+      sort: 'newest',
+      status: null,
+      unread: false,
+      cursor: 'cursor-1',
+      limit: 150,
+    });
+
+    expect(page.rows).toHaveLength(2);
+    expect(page.nextCursor).toBe('cursor-2');
+    const call = client.getWithHeadersCalls[0]!;
+    expect(call.path).toBe('/v1/me/watch-zones/z1/applications');
+    expect(call.params).toEqual({ sort: 'newest', cursor: 'cursor-1', limit: '150' });
+  });
+
+  it('returns a null nextCursor when the response omits the header (last page)', async () => {
+    const client = new SpyApiClient();
+    client.getWithHeadersBody = [summary('A')];
+    client.getWithHeadersCursor = null;
+
+    const page = await applicationsApi(client).getByZonePaged('z1', {
+      sort: 'distance',
+      status: null,
+      unread: false,
+      cursor: null,
+    });
+
+    expect(page.nextCursor).toBeNull();
+    expect(client.getWithHeadersCalls[0]!.params).toEqual({ sort: 'distance' });
+  });
+
+  it('sends status= when a status filter is set', async () => {
+    const client = new SpyApiClient();
+    await applicationsApi(client).getByZonePaged('z1', {
+      sort: 'status',
+      status: 'Permitted',
+      unread: false,
+      cursor: null,
+    });
+
+    expect(client.getWithHeadersCalls[0]!.params).toEqual({
+      sort: 'status',
+      status: 'Permitted',
+    });
+  });
+
+  it('sends unread=true and never status when unread-only is set (mutually exclusive)', async () => {
+    const client = new SpyApiClient();
+    await applicationsApi(client).getByZonePaged('z1', {
+      sort: 'recent-activity',
+      // Even if a stale status slips through, unread wins and status is dropped.
+      status: 'Permitted',
+      unread: true,
+      cursor: null,
+    });
+
+    const params = client.getWithHeadersCalls[0]!.params!;
+    expect(params['unread']).toBe('true');
+    expect(params['status']).toBeUndefined();
+  });
+});
+
+describe('applicationsApi.getByZone (param-less, unchanged)', () => {
+  it('issues a header-blind GET with no params for the backward-compatible call', async () => {
+    const client = new SpyApiClient();
+    client.getResult = [summary('A')];
+
+    const rows = await applicationsApi(client).getByZone('z1');
+
+    expect(rows).toHaveLength(1);
+    expect(client.getWithHeadersCalls).toHaveLength(0);
+    expect(client.getCalls[0]).toEqual({
+      path: '/v1/me/watch-zones/z1/applications',
+      params: undefined,
+    });
+  });
+});

--- a/web/src/api/__tests__/client.test.ts
+++ b/web/src/api/__tests__/client.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { createApiClient } from '../client';
+
+interface RecordedRequest {
+  readonly url: string;
+  readonly init: RequestInit | undefined;
+}
+
+/**
+ * Hand-written fetch spy — records the request and returns a caller-supplied
+ * Response. No `vi.fn()`, in keeping with the no-mocking-frameworks policy.
+ */
+class SpyFetch {
+  calls: RecordedRequest[] = [];
+  response: Response = new Response('null', { status: 200 });
+
+  readonly fn = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    this.calls.push({ url: String(input), init });
+    return Promise.resolve(this.response);
+  };
+}
+
+function clientWith(spy: SpyFetch) {
+  return createApiClient('https://api.test', () => Promise.resolve('tok-123'), spy.fn);
+}
+
+describe('createApiClient — getWithHeaders', () => {
+  it('returns the parsed body alongside the raw response headers', async () => {
+    const spy = new SpyFetch();
+    spy.response = new Response(JSON.stringify([{ uid: 'A' }]), {
+      status: 200,
+      headers: { 'X-Next-Cursor': 'cursor-page-2' },
+    });
+    const client = clientWith(spy);
+
+    const { body, headers } = await client.getWithHeaders<readonly { uid: string }[]>(
+      '/v1/me/watch-zones/z1/applications',
+    );
+
+    expect(body).toEqual([{ uid: 'A' }]);
+    expect(headers.get('X-Next-Cursor')).toBe('cursor-page-2');
+  });
+
+  it('exposes a null X-Next-Cursor header when the response omits it (last page)', async () => {
+    const spy = new SpyFetch();
+    spy.response = new Response(JSON.stringify([]), { status: 200 });
+    const client = clientWith(spy);
+
+    const { headers } = await client.getWithHeaders('/v1/me/watch-zones/z1/applications');
+
+    expect(headers.get('X-Next-Cursor')).toBeNull();
+  });
+
+  it('sends the bearer token and serialises params into the query string', async () => {
+    const spy = new SpyFetch();
+    spy.response = new Response(JSON.stringify([]), { status: 200 });
+    const client = clientWith(spy);
+
+    await client.getWithHeaders('/v1/me/watch-zones/z1/applications', {
+      sort: 'newest',
+      cursor: 'abc',
+    });
+
+    const call = spy.calls[0]!;
+    expect(call.url).toBe(
+      'https://api.test/v1/me/watch-zones/z1/applications?sort=newest&cursor=abc',
+    );
+    const authHeader = (call.init?.headers as Record<string, string>)['Authorization'];
+    expect(authHeader).toBe('Bearer tok-123');
+  });
+
+  it('throws ApiRequestError carrying the status on a non-2xx response', async () => {
+    const spy = new SpyFetch();
+    spy.response = new Response(JSON.stringify({ error: 'bad cursor' }), { status: 400 });
+    const client = clientWith(spy);
+
+    await expect(
+      client.getWithHeaders('/v1/me/watch-zones/z1/applications', { cursor: 'stale' }),
+    ).rejects.toMatchObject({ status: 400, message: 'bad cursor' });
+  });
+
+  it('leaves get() returning the bare parsed body (unchanged contract)', async () => {
+    const spy = new SpyFetch();
+    spy.response = new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'X-Next-Cursor': 'ignored' },
+    });
+    const client = clientWith(spy);
+
+    const body = await client.get<{ ok: boolean }>('/v1/anything');
+
+    expect(body).toEqual({ ok: true });
+  });
+});

--- a/web/src/api/applications.ts
+++ b/web/src/api/applications.ts
@@ -1,5 +1,12 @@
 import type { ApiClient } from './client';
-import type { AuthorityListItem, MapCluster, PlanningApplication } from '../domain/types';
+import type {
+  ApplicationsSort,
+  ApplicationStatus,
+  AuthorityListItem,
+  MapCluster,
+  PlanningApplication,
+  PlanningApplicationSummary,
+} from '../domain/types';
 
 interface UserApplicationAuthoritiesResponse {
   readonly authorities: readonly AuthorityListItem[];
@@ -13,6 +20,29 @@ interface MapClusterDto {
   readonly count: number;
   readonly statusCounts: Record<string, number>;
   readonly applicationId: { readonly authority: string; readonly name: string } | null;
+}
+
+/**
+ * Query for one page of the server-driven watch-zone applications list (GH#711,
+ * Slice B). The server owns sort and status/unread filtering; the client follows
+ * the opaque `X-Next-Cursor` header to exhaustion. `status` and `unread` are
+ * mutually exclusive — sending both is a 400, so `unread` wins here defensively
+ * (the calling hook already enforces single-select).
+ */
+export interface GetByZonePageOptions {
+  readonly sort: ApplicationsSort;
+  readonly status: ApplicationStatus | null;
+  readonly unread: boolean;
+  /** Opaque, sort-aware continuation token; `null`/omitted fetches page one. */
+  readonly cursor: string | null;
+  /** Page size; omitted lets the server apply its default (150, ceiling 500). */
+  readonly limit?: number;
+}
+
+/** One page of list rows plus the cursor for the next page (`null` = last). */
+export interface ZoneApplicationsPage {
+  readonly rows: readonly PlanningApplicationSummary[];
+  readonly nextCursor: string | null;
 }
 
 export interface GetClustersOptions {
@@ -42,6 +72,39 @@ export function applicationsApi(client: ApiClient) {
         .then((r) => r.authorities),
     getByZone: (zoneId: string) =>
       client.get<readonly PlanningApplication[]>(`/v1/me/watch-zones/${zoneId}/applications`),
+    /**
+     * Server-driven, keyset-paginated page of a zone's applications (GH#711).
+     * Drives `?sort/status/unread/cursor/limit` server-side and reads the next
+     * cursor from the `X-Next-Cursor` response header (exposed cross-origin by
+     * Slice A's CORS change). The body stays a bare array. The param-less
+     * `getByZone` above is left untouched for backward-compatible callers.
+     */
+    getByZonePaged: (
+      zoneId: string,
+      options: GetByZonePageOptions,
+    ): Promise<ZoneApplicationsPage> => {
+      const params: Record<string, string> = { sort: options.sort };
+      if (options.unread) {
+        params.unread = 'true';
+      } else if (options.status != null) {
+        params.status = options.status;
+      }
+      if (options.cursor != null) {
+        params.cursor = options.cursor;
+      }
+      if (options.limit != null) {
+        params.limit = String(options.limit);
+      }
+      return client
+        .getWithHeaders<readonly PlanningApplicationSummary[]>(
+          `/v1/me/watch-zones/${zoneId}/applications`,
+          params,
+        )
+        .then(({ body, headers }) => ({
+          rows: body,
+          nextCursor: headers.get('X-Next-Cursor'),
+        }));
+    },
     getByUid: (uid: string) =>
       client.get<PlanningApplication>(`/v1/applications/${uid}`),
     /**

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -10,6 +10,16 @@ export class ApiRequestError extends Error {
 
 export interface ApiClient {
   get<T>(path: string, params?: Record<string, string>): Promise<T>;
+  /**
+   * Like `get`, but also surfaces the raw response headers so callers can read
+   * out-of-band metadata such as the `X-Next-Cursor` keyset-pagination header
+   * exposed by the watch-zone applications list (GH#711). `get` stays the
+   * header-blind fast path for the common case.
+   */
+  getWithHeaders<T>(
+    path: string,
+    params?: Record<string, string>,
+  ): Promise<{ body: T; headers: Headers }>;
   post<T>(path: string, body?: unknown): Promise<T>;
   put(path: string, body?: unknown): Promise<void>;
   patch<T>(path: string, body?: unknown): Promise<T>;
@@ -21,7 +31,12 @@ export function createApiClient(
   getToken: () => Promise<string>,
   fetchFn: typeof globalThis.fetch = globalThis.fetch,
 ): ApiClient {
-  async function request<T>(method: string, path: string, body?: unknown, params?: Record<string, string>): Promise<T> {
+  async function requestRaw(
+    method: string,
+    path: string,
+    body?: unknown,
+    params?: Record<string, string>,
+  ): Promise<{ body: unknown; response: Response }> {
     const token = await getToken();
     let url = `${baseUrl}${path}`;
     if (params) {
@@ -56,14 +71,23 @@ export function createApiClient(
     }
 
     if (response.status === 204) {
-      return undefined as T;
+      return { body: undefined, response };
     }
 
-    return response.json() as Promise<T>;
+    return { body: await response.json(), response };
+  }
+
+  async function request<T>(method: string, path: string, body?: unknown, params?: Record<string, string>): Promise<T> {
+    const { body: parsed } = await requestRaw(method, path, body, params);
+    return parsed as T;
   }
 
   return {
     get: <T>(path: string, params?: Record<string, string>) => request<T>('GET', path, undefined, params),
+    getWithHeaders: async <T>(path: string, params?: Record<string, string>) => {
+      const { body, response } = await requestRaw('GET', path, undefined, params);
+      return { body: body as T, headers: response.headers };
+    },
     post: <T>(path: string, body?: unknown) => request<T>('POST', path, body),
     put: (path: string, body?: unknown) => request<void>('PUT', path, body),
     patch: <T>(path: string, body?: unknown) => request<T>('PATCH', path, body),

--- a/web/src/domain/ports/applications-browse-port.ts
+++ b/web/src/domain/ports/applications-browse-port.ts
@@ -1,5 +1,34 @@
-import type { WatchZoneId, PlanningApplicationSummary } from '../types';
+import type {
+  WatchZoneId,
+  PlanningApplicationSummary,
+  ApplicationStatus,
+  ApplicationsSort,
+} from '../types';
+
+/**
+ * One page request for a watch zone's applications, driving sort and the
+ * status/unread filter **server-side** (GH#711, Slice B). `status` and `unread`
+ * are mutually exclusive (the caller enforces single-select). `cursor` is the
+ * opaque, sort-aware continuation token — `null` fetches the first page.
+ */
+export interface ApplicationsBrowseQuery {
+  readonly zoneId: WatchZoneId;
+  readonly sort: ApplicationsSort;
+  readonly status: ApplicationStatus | null;
+  readonly unread: boolean;
+  readonly cursor: string | null;
+}
+
+/**
+ * One page of list rows plus the cursor for the following page. `nextCursor` is
+ * `null` on the last page (the `X-Next-Cursor` header was absent), which is the
+ * signal to stop paging.
+ */
+export interface ApplicationsPageResult {
+  readonly rows: readonly PlanningApplicationSummary[];
+  readonly nextCursor: string | null;
+}
 
 export interface ApplicationsBrowsePort {
-  fetchByZone(zoneId: WatchZoneId): Promise<readonly PlanningApplicationSummary[]>;
+  fetchByZone(query: ApplicationsBrowseQuery): Promise<ApplicationsPageResult>;
 }

--- a/web/src/domain/types.ts
+++ b/web/src/domain/types.ts
@@ -55,6 +55,20 @@ export type NotificationEventType = "NewApplication" | "DecisionUpdate";
 export type SubscriptionTier = "Free" | "Personal" | "Pro";
 
 /**
+ * Server-side sort vocabulary for the watch-zone applications list. These map
+ * one-to-one onto the `?sort=` values the API accepts
+ * (`GET /v1/me/watch-zones/{zoneId}/applications`); an absent param defaults to
+ * `distance` (nearest-first). The picker hides `distance` when no single zone
+ * is active. Mirrors the iOS list sort modes (#682).
+ */
+export type ApplicationsSort =
+  | "recent-activity"
+  | "newest"
+  | "oldest"
+  | "status"
+  | "distance";
+
+/**
  * Matches the API's numeric day-of-week enum.
  * 0 = Sunday, 1 = Monday, ..., 6 = Saturday.
  */

--- a/web/src/features/Applications/ApplicationsPage.module.css
+++ b/web/src/features/Applications/ApplicationsPage.module.css
@@ -166,3 +166,33 @@
   color: var(--tc-text-secondary);
   font-size: var(--tc-text-body);
 }
+
+.loadMoreButton {
+  display: block;
+  margin: var(--tc-space-lg) auto 0;
+  min-height: 44px;
+  padding: var(--tc-space-sm) var(--tc-space-lg);
+  font: inherit;
+  font-size: var(--tc-text-body);
+  font-weight: var(--tc-weight-medium);
+  color: var(--tc-text-primary);
+  background: var(--tc-surface);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  cursor: pointer;
+  transition: border-color var(--tc-duration-fast) ease, background var(--tc-duration-fast) ease;
+}
+
+.loadMoreButton:hover:not(:disabled) {
+  border-color: var(--tc-amber);
+}
+
+.loadMoreButton:focus-visible {
+  outline: 2px solid var(--tc-border-focused);
+  outline-offset: 2px;
+}
+
+.loadMoreButton:disabled {
+  opacity: 0.4;
+  cursor: default;
+}

--- a/web/src/features/Applications/ApplicationsPage.tsx
+++ b/web/src/features/Applications/ApplicationsPage.tsx
@@ -57,6 +57,8 @@ export function ApplicationsPage({
     selectedZone,
     applications,
     isLoading: isLoadingApps,
+    isLoadingMore,
+    hasMore,
     error: appsError,
     selectedStatusFilter,
     unreadOnly,
@@ -67,6 +69,8 @@ export function ApplicationsPage({
     setStatusFilter,
     setUnreadOnly,
     setSort,
+    loadMore,
+    reload,
     markAllRead,
   } = useApplications({
     browsePort,
@@ -209,7 +213,7 @@ export function ApplicationsPage({
               title="Something went wrong"
               message={appsError}
               actionLabel="Try again"
-              onAction={() => selectedZone && selectZone(selectedZone)}
+              onAction={reload}
             />
           )}
 
@@ -222,13 +226,25 @@ export function ApplicationsPage({
           )}
 
           {!isLoadingApps && appsError === null && applications.length > 0 && (
-            <ul className={styles.list}>
-              {applications.map((app) => (
-                <li key={app.uid}>
-                  <ApplicationCard application={app} />
-                </li>
-              ))}
-            </ul>
+            <>
+              <ul className={styles.list}>
+                {applications.map((app) => (
+                  <li key={app.uid}>
+                    <ApplicationCard application={app} />
+                  </li>
+                ))}
+              </ul>
+              {hasMore && (
+                <button
+                  type="button"
+                  className={styles.loadMoreButton}
+                  onClick={() => loadMore()}
+                  disabled={isLoadingMore}
+                >
+                  {isLoadingMore ? 'Loading…' : 'Load more'}
+                </button>
+              )}
+            </>
           )}
         </>
       )}

--- a/web/src/features/Applications/ConnectedApplicationsPage.tsx
+++ b/web/src/features/Applications/ConnectedApplicationsPage.tsx
@@ -11,8 +11,13 @@ export function ConnectedApplicationsPage() {
 
   const browsePort: ApplicationsBrowsePort = useMemo(
     () => ({
-      fetchByZone: (zoneId) =>
-        applicationsApi(client).getByZone(zoneId as string),
+      fetchByZone: (query) =>
+        applicationsApi(client).getByZonePaged(query.zoneId as string, {
+          sort: query.sort,
+          status: query.status,
+          unread: query.unread,
+          cursor: query.cursor,
+        }),
     }),
     [client],
   );

--- a/web/src/features/Applications/__tests__/ApplicationsPage.test.tsx
+++ b/web/src/features/Applications/__tests__/ApplicationsPage.test.tsx
@@ -11,7 +11,8 @@ import {
   permittedApplication,
   rejectedApplication,
 } from '../../../components/ApplicationCard/__tests__/fixtures/planning-application-summary.fixtures';
-import type { WatchZoneSummary } from '../../../domain/types';
+import { asApplicationUid } from '../../../domain/types';
+import type { PlanningApplicationSummary, WatchZoneSummary } from '../../../domain/types';
 
 class SpyZonesPort {
   fetchZonesCalls = 0;
@@ -53,18 +54,16 @@ function renderPage({
   );
 }
 
+/** Convenience: a single-page result (no further pages). */
+function onePage(rows: readonly PlanningApplicationSummary[]) {
+  return { rows, nextCursor: null };
+}
+
 describe('ApplicationsPage — heading and zone bootstrap', () => {
-  let zonesPort: SpyZonesPort;
-  let browsePort: SpyApplicationsBrowsePort;
-
-  beforeEach(() => {
-    zonesPort = new SpyZonesPort();
-    browsePort = new SpyApplicationsBrowsePort();
-  });
-
   it('renders page heading', async () => {
+    const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [];
-    renderPage({ zonesPort, browsePort });
+    renderPage({ zonesPort });
 
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: 'Applications' })).toBeInTheDocument();
@@ -72,8 +71,9 @@ describe('ApplicationsPage — heading and zone bootstrap', () => {
   });
 
   it('shows empty state when user has no watch zones', async () => {
+    const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [];
-    renderPage({ zonesPort, browsePort });
+    renderPage({ zonesPort });
 
     await waitFor(() => {
       expect(
@@ -88,7 +88,6 @@ describe('ApplicationsPage — filter bar', () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone(), oxfordZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
 
     renderPage({ zonesPort, browsePort });
 
@@ -99,21 +98,20 @@ describe('ApplicationsPage — filter bar', () => {
     expect(screen.getByRole('option', { name: 'Office - Oxford' })).toBeInTheDocument();
   });
 
-  it('switches the active zone when a different option is chosen', async () => {
+  it('switches the active zone (server-side fetch) when a different option is chosen', async () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone(), oxfordZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [undecidedApplication()];
+    browsePort.fetchByZoneResult = onePage([undecidedApplication()]);
     const user = userEvent.setup();
 
     renderPage({ zonesPort, browsePort });
 
     const selector = await screen.findByRole('combobox', { name: /zone/i });
-
     await user.selectOptions(selector, oxfordZone().id);
 
     await waitFor(() => {
-      expect(browsePort.fetchByZoneCalls).toContain(oxfordZone().id);
+      expect(browsePort.fetchByZoneCalls.some((c) => c.zoneId === oxfordZone().id)).toBe(true);
     });
   });
 
@@ -121,7 +119,6 @@ describe('ApplicationsPage — filter bar', () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
 
     renderPage({ zonesPort, browsePort });
 
@@ -132,20 +129,6 @@ describe('ApplicationsPage — filter bar', () => {
     expect(screen.getByRole('button', { name: 'Granted' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Refused' })).toBeInTheDocument();
   });
-
-  it('does not render a Saved toggle (moved to /saved)', async () => {
-    const zonesPort = new SpyZonesPort();
-    zonesPort.fetchZonesResult = [cambridgeZone()];
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
-
-    renderPage({ zonesPort, browsePort });
-
-    await waitFor(() => {
-      expect(screen.getByRole('combobox', { name: /zone/i })).toBeInTheDocument();
-    });
-    expect(screen.queryByRole('switch', { name: /saved/i })).not.toBeInTheDocument();
-  });
 });
 
 describe('ApplicationsPage — Unread chip', () => {
@@ -153,30 +136,19 @@ describe('ApplicationsPage — Unread chip', () => {
     window.localStorage.clear();
   });
 
-  it('renders an Unread chip whose badge equals the distinct count of unread applications in the zone', async () => {
-    // Two of the three loaded apps carry an unread event — the chip must
-    // read "Unread (2)", not the inflated event count that would come from
-    // a server-side notification-state snapshot (tc-u6bm).
+  it('renders an Unread chip whose badge equals the distinct count of unread applications loaded', async () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
+    browsePort.fetchByZoneResult = onePage([
       undecidedApplication({
-        latestUnreadEvent: {
-          type: 'NewApplication',
-          decision: null,
-          createdAt: '2026-04-01T00:00:00Z',
-        },
+        latestUnreadEvent: { type: 'NewApplication', decision: null, createdAt: '2026-04-01T00:00:00Z' },
       }),
-      permittedApplication(), // null — no unread
+      permittedApplication(),
       rejectedApplication({
-        latestUnreadEvent: {
-          type: 'DecisionUpdate',
-          decision: 'Rejected',
-          createdAt: '2026-04-15T00:00:00Z',
-        },
+        latestUnreadEvent: { type: 'DecisionUpdate', decision: 'Rejected', createdAt: '2026-04-15T00:00:00Z' },
       }),
-    ];
+    ]);
 
     renderPage({ zonesPort, browsePort });
 
@@ -185,45 +157,11 @@ describe('ApplicationsPage — Unread chip', () => {
     expect(chip).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('chip count tracks distinct unread apps, not the server-side event total', async () => {
-    // The notification-state snapshot reports 7 (an event count — apps with
-    // multiple events inflate it). Only one of the loaded apps actually
-    // carries an unread event, so the chip must show 1.
+  it('hides the Unread chip when no loaded application has an unread event', async () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
-      undecidedApplication({
-        latestUnreadEvent: {
-          type: 'NewApplication',
-          decision: null,
-          createdAt: '2026-04-01T00:00:00Z',
-        },
-      }),
-      permittedApplication(), // null
-    ];
-    const stateRepo = new SpyNotificationStateRepository();
-    stateRepo.getStateResult = {
-      lastReadAt: '2026-01-01T00:00:00Z',
-      version: 1,
-      totalUnreadCount: 7,
-    };
-
-    renderPage({ zonesPort, browsePort, notificationStateRepository: stateRepo });
-
-    expect(
-      await screen.findByRole('button', { name: /unread \(1\)/i }),
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole('button', { name: /unread \(7\)/i }),
-    ).not.toBeInTheDocument();
-  });
-
-  it('hides the Unread chip when no application in the zone has an unread event', async () => {
-    const zonesPort = new SpyZonesPort();
-    zonesPort.fetchZonesResult = [cambridgeZone()];
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [undecidedApplication(), permittedApplication()];
+    browsePort.fetchByZoneResult = onePage([undecidedApplication(), permittedApplication()]);
 
     renderPage({ zonesPort, browsePort });
 
@@ -233,27 +171,20 @@ describe('ApplicationsPage — Unread chip', () => {
     expect(screen.queryByRole('button', { name: /unread/i })).not.toBeInTheDocument();
   });
 
-  it('toggles the unread filter when the Unread chip is clicked', async () => {
+  it('refetches with unread-only (server-side) when the Unread chip is clicked', async () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
-      undecidedApplication({
-        latestUnreadEvent: {
-          type: 'NewApplication',
-          decision: null,
-          createdAt: '2026-04-01T00:00:00Z',
-        },
-      }),
-      permittedApplication(), // null
-    ];
+    const unread = undecidedApplication({
+      latestUnreadEvent: { type: 'NewApplication', decision: null, createdAt: '2026-04-01T00:00:00Z' },
+    });
+    const read = permittedApplication();
+    browsePort.fetchByZoneResponder = (q) => onePage(q.unread ? [unread] : [unread, read]);
     const user = userEvent.setup();
 
     renderPage({ zonesPort, browsePort });
 
-    await waitFor(() =>
-      expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument());
     expect(screen.getByText('2026/0099/LBC')).toBeInTheDocument();
 
     await user.click(await screen.findByRole('button', { name: /unread \(1\)/i }));
@@ -262,6 +193,7 @@ describe('ApplicationsPage — Unread chip', () => {
       expect(screen.queryByText('2026/0099/LBC')).not.toBeInTheDocument();
     });
     expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument();
+    expect(browsePort.fetchByZoneCalls.at(-1)!.unread).toBe(true);
   });
 });
 
@@ -270,63 +202,30 @@ describe('ApplicationsPage — Mark all read', () => {
     window.localStorage.clear();
   });
 
-  it('renders a Mark all read button when at least one application is unread', async () => {
+  it('renders a Mark all read button when at least one loaded application is unread', async () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
+    browsePort.fetchByZoneResult = onePage([
       undecidedApplication({
-        latestUnreadEvent: {
-          type: 'NewApplication',
-          decision: null,
-          createdAt: '2026-04-01T00:00:00Z',
-        },
+        latestUnreadEvent: { type: 'NewApplication', decision: null, createdAt: '2026-04-01T00:00:00Z' },
       }),
-    ];
+    ]);
 
     renderPage({ zonesPort, browsePort });
 
-    expect(
-      await screen.findByRole('button', { name: /mark all read/i }),
-    ).toBeInTheDocument();
-  });
-
-  it('hides the Mark all read button when nothing in the zone is unread', async () => {
-    const zonesPort = new SpyZonesPort();
-    zonesPort.fetchZonesResult = [cambridgeZone()];
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [undecidedApplication(), permittedApplication()];
-
-    renderPage({ zonesPort, browsePort });
-
-    await waitFor(() =>
-      expect(screen.getByRole('combobox', { name: /zone/i })).toBeInTheDocument(),
-    );
-    expect(
-      screen.queryByRole('button', { name: /mark all read/i }),
-    ).not.toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /mark all read/i })).toBeInTheDocument();
   });
 
   it('calls markAllRead on the repository when clicked', async () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
+    browsePort.fetchByZoneResult = onePage([
       undecidedApplication({
-        latestUnreadEvent: {
-          type: 'NewApplication',
-          decision: null,
-          createdAt: '2026-04-01T00:00:00Z',
-        },
+        latestUnreadEvent: { type: 'NewApplication', decision: null, createdAt: '2026-04-01T00:00:00Z' },
       }),
-      permittedApplication({
-        latestUnreadEvent: {
-          type: 'DecisionUpdate',
-          decision: 'Permitted',
-          createdAt: '2026-04-15T00:00:00Z',
-        },
-      }),
-    ];
+    ]);
     const stateRepo = new SpyNotificationStateRepository();
     const user = userEvent.setup();
 
@@ -350,53 +249,43 @@ describe('ApplicationsPage — Sort menu', () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
 
     renderPage({ zonesPort, browsePort });
 
     const sort = await screen.findByRole('combobox', { name: /sort/i });
     expect(sort).toHaveValue('recent-activity');
-    expect(
-      screen.getByRole('option', { name: /recent activity/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /recent activity/i })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /newest/i })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /oldest/i })).toBeInTheDocument();
     expect(screen.getByRole('option', { name: /^status$/i })).toBeInTheDocument();
   });
 
-  it('changes sort order when a different option is selected', async () => {
+  it('refetches with the chosen sort server-side', async () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
-      undecidedApplication({ startDate: '2026-01-01' }),
-      permittedApplication({ startDate: '2026-03-01' }),
-    ];
+    browsePort.fetchByZoneResult = onePage([undecidedApplication()]);
     const user = userEvent.setup();
 
     renderPage({ zonesPort, browsePort });
 
-    await waitFor(() =>
-      expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument());
 
     const sort = await screen.findByRole('combobox', { name: /sort/i });
     await user.selectOptions(sort, 'oldest');
 
     expect(sort).toHaveValue('oldest');
+    await waitFor(() => expect(browsePort.fetchByZoneCalls.at(-1)!.sort).toBe('oldest'));
+    expect(browsePort.fetchByZoneCalls.at(-1)!.cursor).toBeNull();
   });
 
   it('exposes a "Distance" option once a zone has been auto-selected', async () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
 
     renderPage({ zonesPort, browsePort });
 
-    // The auto-select effect in useApplications fires after zones load —
-    // wait for the resulting Distance option (only emitted once a zone is
-    // active) rather than racing the synchronous picker mount.
     await screen.findByRole('option', { name: /^distance$/i });
   });
 
@@ -404,24 +293,20 @@ describe('ApplicationsPage — Sort menu', () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
 
     renderPage({ zonesPort, browsePort });
 
     await waitFor(() => expect(zonesPort.fetchZonesCalls).toBe(1));
-    // No zones → no auto-selected zone → distance must not appear in any
-    // sort surface. The picker itself only renders once a zone exists, so
-    // simply assert the option is not in the document.
     expect(screen.queryByRole('option', { name: /^distance$/i })).toBeNull();
   });
 });
 
 describe('ApplicationsPage — list rendering', () => {
-  it("auto-selects the first zone and shows its applications", async () => {
+  it('auto-selects the first zone and shows its applications', async () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [undecidedApplication(), permittedApplication()];
+    browsePort.fetchByZoneResult = onePage([undecidedApplication(), permittedApplication()]);
 
     renderPage({ zonesPort, browsePort });
 
@@ -431,15 +316,14 @@ describe('ApplicationsPage — list rendering', () => {
     expect(screen.getByText('2026/0099/LBC')).toBeInTheDocument();
   });
 
-  it('filters list when a status chip is clicked', async () => {
+  it('refetches with the status filter (server-side) when a status chip is clicked', async () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
-      undecidedApplication(),
-      permittedApplication(),
-      rejectedApplication(),
-    ];
+    browsePort.fetchByZoneResponder = (q) => {
+      const all = [undecidedApplication(), permittedApplication(), rejectedApplication()];
+      return onePage(q.status === null ? all : all.filter((a) => a.appState === q.status));
+    };
     const user = userEvent.setup();
 
     renderPage({ zonesPort, browsePort });
@@ -452,5 +336,44 @@ describe('ApplicationsPage — list rendering', () => {
       expect(screen.queryByText('2026/0042/FUL')).not.toBeInTheDocument();
     });
     expect(screen.getByText('2026/0099/LBC')).toBeInTheDocument();
+    expect(browsePort.fetchByZoneCalls.at(-1)!.status).toBe('Permitted');
+  });
+});
+
+describe('ApplicationsPage — Load more (keyset pagination)', () => {
+  it('appends the next page when Load more is clicked, then hides the button on the last page', async () => {
+    const zonesPort = new SpyZonesPort();
+    zonesPort.fetchZonesResult = [cambridgeZone()];
+    const browsePort = new SpyApplicationsBrowsePort();
+    const first = undecidedApplication({ name: 'FIRST/0001' });
+    const second = { ...permittedApplication(), uid: asApplicationUid('SECOND-1'), name: 'SECOND/0002' };
+    browsePort.fetchByZoneResponder = (q) =>
+      q.cursor === null ? { rows: [first], nextCursor: 'c1' } : { rows: [second], nextCursor: null };
+    const user = userEvent.setup();
+
+    renderPage({ zonesPort, browsePort });
+
+    await waitFor(() => expect(screen.getByText('FIRST/0001')).toBeInTheDocument());
+    const loadMore = screen.getByRole('button', { name: /load more/i });
+
+    await user.click(loadMore);
+
+    await waitFor(() => expect(screen.getByText('SECOND/0002')).toBeInTheDocument());
+    // First page row is still present (appended, not replaced).
+    expect(screen.getByText('FIRST/0001')).toBeInTheDocument();
+    // Last page reached — the button is gone.
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render Load more when the first page is already the last', async () => {
+    const zonesPort = new SpyZonesPort();
+    zonesPort.fetchZonesResult = [cambridgeZone()];
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResult = onePage([undecidedApplication()]);
+
+    renderPage({ zonesPort, browsePort });
+
+    await waitFor(() => expect(screen.getByText('2026/0042/FUL')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: /load more/i })).not.toBeInTheDocument();
   });
 });

--- a/web/src/features/Applications/__tests__/spies/spy-applications-browse-port.ts
+++ b/web/src/features/Applications/__tests__/spies/spy-applications-browse-port.ts
@@ -1,16 +1,27 @@
-import type { WatchZoneId, PlanningApplicationSummary } from '../../../../domain/types';
-import type { ApplicationsBrowsePort } from '../../../../domain/ports/applications-browse-port';
+import type {
+  ApplicationsBrowsePort,
+  ApplicationsBrowseQuery,
+  ApplicationsPageResult,
+} from '../../../../domain/ports/applications-browse-port';
 
+/**
+ * Hand-written spy for the server-driven applications browse port. Records the
+ * full query for each call (so tests can assert the sort/status/unread/cursor
+ * sent to the server) and returns either a fixed single-page result or, for
+ * multi-page / filter-aware tests, a caller-supplied responder.
+ */
 export class SpyApplicationsBrowsePort implements ApplicationsBrowsePort {
-  fetchByZoneCalls: WatchZoneId[] = [];
-  fetchByZoneResult: readonly PlanningApplicationSummary[] = [];
+  fetchByZoneCalls: ApplicationsBrowseQuery[] = [];
+  fetchByZoneResult: ApplicationsPageResult = { rows: [], nextCursor: null };
   fetchByZoneError: Error | null = null;
-  fetchByZoneOverride: ((zoneId: WatchZoneId) => Promise<readonly PlanningApplicationSummary[]>) | null = null;
+  fetchByZoneResponder:
+    | ((query: ApplicationsBrowseQuery) => ApplicationsPageResult)
+    | null = null;
 
-  async fetchByZone(zoneId: WatchZoneId): Promise<readonly PlanningApplicationSummary[]> {
-    this.fetchByZoneCalls.push(zoneId);
-    if (this.fetchByZoneOverride) {
-      return this.fetchByZoneOverride(zoneId);
+  async fetchByZone(query: ApplicationsBrowseQuery): Promise<ApplicationsPageResult> {
+    this.fetchByZoneCalls.push(query);
+    if (this.fetchByZoneResponder) {
+      return this.fetchByZoneResponder(query);
     }
     if (this.fetchByZoneError) {
       throw this.fetchByZoneError;

--- a/web/src/features/Applications/__tests__/useApplications.test.ts
+++ b/web/src/features/Applications/__tests__/useApplications.test.ts
@@ -289,7 +289,12 @@ describe('useApplications — keyset pagination (X-Next-Cursor)', () => {
     await waitFor(() => expect(result.current.applications).toHaveLength(1));
 
     act(() => result.current.setSort('newest'));
-    await waitFor(() => expect(browsePort.fetchByZoneCalls.at(-1)!.sort).toBe('newest'));
+    // Wait for the page-1 re-query to settle (so the next cursor is available)
+    // before paging — otherwise loadMore races the in-flight first page.
+    await waitFor(() =>
+      expect(result.current.applications[0]?.uid).toBe(asApplicationUid('newest-null')),
+    );
+    expect(result.current.hasMore).toBe(true);
 
     act(() => result.current.loadMore());
     await waitFor(() => expect(result.current.applications).toHaveLength(2));
@@ -405,26 +410,38 @@ describe('useApplications — markAllRead', () => {
 });
 
 describe('useApplications — sort persistence', () => {
+  // A stable spy per test — `makeOptions` defaults would mint a fresh port on
+  // every render, changing the query effect's dependency identity and looping.
+  function persistenceOptions() {
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResult = { rows: [], nextCursor: null };
+    return makeOptions({ browsePort, zones: [cambridgeZone()] });
+  }
+
   it('defaults to recent-activity', () => {
-    const { result } = renderHook(() => useApplications(makeOptions({ zones: [cambridgeZone()] })));
+    const options = persistenceOptions();
+    const { result } = renderHook(() => useApplications(options));
     expect(result.current.sort).toBe('recent-activity');
   });
 
   it('persists the sort selection to localStorage', () => {
-    const { result } = renderHook(() => useApplications(makeOptions({ zones: [cambridgeZone()] })));
+    const options = persistenceOptions();
+    const { result } = renderHook(() => useApplications(options));
     act(() => result.current.setSort('newest'));
     expect(window.localStorage.getItem('applicationsListSort')).toBe('newest');
   });
 
   it('rehydrates the persisted sort on mount', () => {
     window.localStorage.setItem('applicationsListSort', 'oldest');
-    const { result } = renderHook(() => useApplications(makeOptions({ zones: [cambridgeZone()] })));
+    const options = persistenceOptions();
+    const { result } = renderHook(() => useApplications(options));
     expect(result.current.sort).toBe('oldest');
   });
 
   it('falls back to recent-activity for an unknown persisted value', () => {
     window.localStorage.setItem('applicationsListSort', 'nonsense');
-    const { result } = renderHook(() => useApplications(makeOptions({ zones: [cambridgeZone()] })));
+    const options = persistenceOptions();
+    const { result } = renderHook(() => useApplications(options));
     expect(result.current.sort).toBe('recent-activity');
   });
 });

--- a/web/src/features/Applications/__tests__/useApplications.test.ts
+++ b/web/src/features/Applications/__tests__/useApplications.test.ts
@@ -9,7 +9,11 @@ import {
   rejectedApplication,
 } from '../../../components/ApplicationCard/__tests__/fixtures/planning-application-summary.fixtures';
 import { cambridgeZone, oxfordZone } from './fixtures/zone.fixtures';
-import type { WatchZoneSummary } from '../../../domain/types';
+import { asApplicationUid } from '../../../domain/types';
+import type {
+  PlanningApplicationSummary,
+  WatchZoneSummary,
+} from '../../../domain/types';
 
 function makeOptions(overrides?: {
   browsePort?: SpyApplicationsBrowsePort;
@@ -24,23 +28,32 @@ function makeOptions(overrides?: {
   };
 }
 
+function withUid(
+  base: PlanningApplicationSummary,
+  uid: string,
+): PlanningApplicationSummary {
+  return { ...base, uid: asApplicationUid(uid) };
+}
+
 beforeEach(() => {
   window.localStorage.clear();
 });
 
 describe('useApplications — initial selection', () => {
-  it('starts with no selection when zones are empty', () => {
-    const { result } = renderHook(() => useApplications(makeOptions()));
+  it('starts with no selection and issues no query when zones are empty', async () => {
+    const browsePort = new SpyApplicationsBrowsePort();
+    const { result } = renderHook(() => useApplications(makeOptions({ browsePort })));
 
     expect(result.current.selectedZone).toBeNull();
     expect(result.current.applications).toEqual([]);
     expect(result.current.isLoading).toBe(false);
     expect(result.current.error).toBeNull();
+    expect(browsePort.fetchByZoneCalls).toEqual([]);
   });
 
-  it('auto-selects the first zone when zones become available', async () => {
+  it('auto-selects the first zone and fetches its first page (cursor null, default sort)', async () => {
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [undecidedApplication()];
+    browsePort.fetchByZoneResult = { rows: [undecidedApplication()], nextCursor: null };
     const zones = [cambridgeZone(), oxfordZone()];
 
     const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
@@ -49,14 +62,24 @@ describe('useApplications — initial selection', () => {
       expect(result.current.selectedZone).toEqual(cambridgeZone());
       expect(result.current.applications).toHaveLength(1);
     });
-    expect(browsePort.fetchByZoneCalls).toEqual([cambridgeZone().id]);
+    expect(browsePort.fetchByZoneCalls).toHaveLength(1);
+    expect(browsePort.fetchByZoneCalls[0]).toEqual({
+      zoneId: cambridgeZone().id,
+      sort: 'recent-activity',
+      status: null,
+      unread: false,
+      cursor: null,
+    });
   });
 });
 
 describe('useApplications — selecting a zone', () => {
-  it('fetches applications when a zone is selected', async () => {
+  it('fetches the newly selected zone (page 1)', async () => {
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [undecidedApplication(), permittedApplication()];
+    browsePort.fetchByZoneResult = {
+      rows: [undecidedApplication(), permittedApplication()],
+      nextCursor: null,
+    };
     const zones = [cambridgeZone(), oxfordZone()];
 
     const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
@@ -66,10 +89,10 @@ describe('useApplications — selecting a zone', () => {
     act(() => result.current.selectZone(oxfordZone()));
 
     await waitFor(() => expect(result.current.selectedZone).toEqual(oxfordZone()));
-    expect(browsePort.fetchByZoneCalls).toContain(oxfordZone().id);
+    expect(browsePort.fetchByZoneCalls.some((c) => c.zoneId === oxfordZone().id)).toBe(true);
   });
 
-  it('sets error when fetch fails', async () => {
+  it('sets error when the fetch fails', async () => {
     const browsePort = new SpyApplicationsBrowsePort();
     browsePort.fetchByZoneError = new Error('Network unavailable');
     const zones = [cambridgeZone()];
@@ -82,14 +105,46 @@ describe('useApplications — selecting a zone', () => {
   });
 });
 
-describe('useApplications — status filter', () => {
-  it('filters applications by selected status', async () => {
+describe('useApplications — server-driven rendering (no client sort/filter)', () => {
+  it('renders rows in the exact order the server returned them', async () => {
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
-      undecidedApplication(),
-      permittedApplication(),
-      rejectedApplication(),
-    ];
+    const a = withUid(undecidedApplication({ startDate: '2026-01-01' }), 'A');
+    const b = withUid(permittedApplication({ startDate: '2026-12-01' }), 'B');
+    const c = withUid(rejectedApplication({ startDate: '2026-06-01' }), 'C');
+    // Deliberately not in any natural order — the hook must not re-sort.
+    browsePort.fetchByZoneResult = { rows: [b, a, c], nextCursor: null };
+    const zones = [cambridgeZone()];
+
+    const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
+
+    await waitFor(() => expect(result.current.applications).toHaveLength(3));
+    expect(result.current.applications.map((x) => x.uid)).toEqual([b.uid, a.uid, c.uid]);
+  });
+
+  it('sends the selected sort to the server and resets to page 1 (cursor null)', async () => {
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResult = { rows: [undecidedApplication()], nextCursor: null };
+    const zones = [cambridgeZone()];
+
+    const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
+
+    await waitFor(() => expect(result.current.applications).toHaveLength(1));
+
+    act(() => result.current.setSort('oldest'));
+
+    await waitFor(() => expect(browsePort.fetchByZoneCalls.at(-1)!.sort).toBe('oldest'));
+    expect(browsePort.fetchByZoneCalls.at(-1)!.cursor).toBeNull();
+  });
+});
+
+describe('useApplications — status filter (server-driven)', () => {
+  it('sends ?status to the server and renders the returned rows verbatim', async () => {
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResponder = (q) => {
+      const all = [undecidedApplication(), permittedApplication(), rejectedApplication()];
+      const rows = q.status === null ? all : all.filter((a) => a.appState === q.status);
+      return { rows, nextCursor: null };
+    };
     const zones = [cambridgeZone()];
 
     const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
@@ -98,145 +153,84 @@ describe('useApplications — status filter', () => {
 
     act(() => result.current.setStatusFilter('Permitted'));
 
-    expect(result.current.selectedStatusFilter).toBe('Permitted');
-    expect(result.current.applications).toHaveLength(1);
+    await waitFor(() => expect(result.current.applications).toHaveLength(1));
     expect(result.current.applications[0]?.appState).toBe('Permitted');
+    const lastCall = browsePort.fetchByZoneCalls.at(-1)!;
+    expect(lastCall.status).toBe('Permitted');
+    expect(lastCall.cursor).toBeNull();
   });
 
-  it('returns to unfiltered list when status is cleared', async () => {
+  it('returns to an unfiltered query when the status is cleared', async () => {
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [undecidedApplication(), permittedApplication()];
+    browsePort.fetchByZoneResponder = (q) => {
+      const all = [undecidedApplication(), permittedApplication()];
+      const rows = q.status === null ? all : all.filter((a) => a.appState === q.status);
+      return { rows, nextCursor: null };
+    };
     const zones = [cambridgeZone()];
 
     const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
 
     await waitFor(() => expect(result.current.applications).toHaveLength(2));
-
     act(() => result.current.setStatusFilter('Permitted'));
-    expect(result.current.applications).toHaveLength(1);
+    await waitFor(() => expect(result.current.applications).toHaveLength(1));
 
     act(() => result.current.setStatusFilter(null));
 
-    expect(result.current.selectedStatusFilter).toBeNull();
-    expect(result.current.applications).toHaveLength(2);
+    await waitFor(() => expect(result.current.applications).toHaveLength(2));
+    expect(browsePort.fetchByZoneCalls.at(-1)!.status).toBeNull();
   });
 });
 
-describe('useApplications — unread chip count', () => {
-  it('derives unreadCount from the count of distinct applications with a latestUnreadEvent in the active zone', async () => {
-    // Three applications, two of which carry an unread event. The chip must
-    // report **two** (distinct apps), not a server-side event count — fixing
-    // the regression where multi-event apps inflated the chip beyond the
-    // visible row count (tc-u6bm).
+describe('useApplications — unread filter (server-driven, mutually exclusive)', () => {
+  it('sends ?unread=true and never sends a status alongside it', async () => {
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
-      undecidedApplication({
-        latestUnreadEvent: {
-          type: 'NewApplication',
-          decision: null,
-          createdAt: '2026-04-01T00:00:00Z',
-        },
-      }),
-      permittedApplication(), // null
-      rejectedApplication({
-        latestUnreadEvent: {
-          type: 'DecisionUpdate',
-          decision: 'Rejected',
-          createdAt: '2026-04-15T00:00:00Z',
-        },
-      }),
-    ];
+    browsePort.fetchByZoneResponder = (q) => {
+      const unread = undecidedApplication({
+        latestUnreadEvent: { type: 'NewApplication', decision: null, createdAt: '2026-04-01T00:00:00Z' },
+      });
+      const read = permittedApplication();
+      const rows = q.unread ? [unread] : [unread, read];
+      return { rows, nextCursor: null };
+    };
     const zones = [cambridgeZone()];
 
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
-    await waitFor(() => expect(result.current.applications).toHaveLength(3));
-    expect(result.current.unreadCount).toBe(2);
-  });
-
-  it('does not call notificationStateRepository.getState — chip count is derived client-side', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
-    const stateRepo = new SpyNotificationStateRepository();
-    const zones = [cambridgeZone()];
-
-    renderHook(() =>
-      useApplications(
-        makeOptions({ browsePort, zones, notificationStateRepository: stateRepo }),
-      ),
-    );
-
-    // Allow any pending effects to flush. The hook must not reach for the
-    // notification-state snapshot purely for the chip count.
-    await waitFor(() => expect(browsePort.fetchByZoneCalls.length).toBe(1));
-    expect(stateRepo.getStateCalls).toBe(0);
-  });
-
-  it('reports 0 unread when no applications carry a latestUnreadEvent', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [undecidedApplication(), permittedApplication()];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
+    const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
 
     await waitFor(() => expect(result.current.applications).toHaveLength(2));
-    expect(result.current.unreadCount).toBe(0);
-  });
-});
-
-describe('useApplications — Unread filter', () => {
-  it('keeps only rows with a non-null latestUnreadEvent when Unread is selected', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
-      undecidedApplication({
-        latestUnreadEvent: {
-          type: 'NewApplication',
-          decision: null,
-          createdAt: '2026-04-01T00:00:00Z',
-        },
-      }),
-      permittedApplication(), // null
-      rejectedApplication({
-        latestUnreadEvent: {
-          type: 'DecisionUpdate',
-          decision: 'Rejected',
-          createdAt: '2026-04-15T00:00:00Z',
-        },
-      }),
-    ];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
-    await waitFor(() => expect(result.current.applications).toHaveLength(3));
 
     act(() => result.current.setUnreadOnly(true));
 
-    expect(result.current.unreadOnly).toBe(true);
-    expect(result.current.applications).toHaveLength(2);
-    // Default sort is recent-activity (desc) — rejected event 2026-04-15
-    // outranks undecided 2026-04-01.
-    expect(result.current.applications.map((a) => a.uid)).toEqual([
-      rejectedApplication().uid,
-      undecidedApplication().uid,
-    ]);
+    await waitFor(() => expect(result.current.applications).toHaveLength(1));
+    const lastCall = browsePort.fetchByZoneCalls.at(-1)!;
+    expect(lastCall.unread).toBe(true);
+    expect(lastCall.status).toBeNull();
   });
 
-  it('clears the status filter when Unread is selected (single-select chip group)', async () => {
+  it('never sends status and unread together across the whole session', async () => {
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
+    browsePort.fetchByZoneResult = { rows: [], nextCursor: null };
     const zones = [cambridgeZone()];
 
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
+    const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
+    await waitFor(() => expect(result.current.selectedZone).not.toBeNull());
 
+    act(() => result.current.setStatusFilter('Permitted'));
+    await waitFor(() => expect(browsePort.fetchByZoneCalls.at(-1)!.status).toBe('Permitted'));
+    act(() => result.current.setUnreadOnly(true));
+    await waitFor(() => expect(browsePort.fetchByZoneCalls.at(-1)!.unread).toBe(true));
+
+    for (const call of browsePort.fetchByZoneCalls) {
+      expect(call.status !== null && call.unread).toBe(false);
+    }
+  });
+
+  it('clears the status filter when unread is selected (single-select group)', async () => {
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResult = { rows: [], nextCursor: null };
+    const zones = [cambridgeZone()];
+
+    const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
     await waitFor(() => expect(result.current.selectedZone).not.toBeNull());
 
     act(() => result.current.setStatusFilter('Permitted'));
@@ -249,46 +243,155 @@ describe('useApplications — Unread filter', () => {
   });
 });
 
-describe('useApplications — markAllRead', () => {
-  it('calls the repository, optimistically zeroes unreadCount, and refetches the row data', async () => {
-    // Initial load has two unread apps; the post-mark refetch returns the
-    // same apps with `latestUnreadEvent: null`, so the derived chip count
-    // collapses to zero without any server-side count fetch.
+describe('useApplications — keyset pagination (X-Next-Cursor)', () => {
+  it('follows the cursor across pages until it is absent, appending each page (large zone)', async () => {
     const browsePort = new SpyApplicationsBrowsePort();
-    const initialApps = [
-      undecidedApplication({
-        latestUnreadEvent: {
-          type: 'NewApplication',
-          decision: null,
-          createdAt: '2026-04-01T00:00:00Z',
-        },
-      }),
-      permittedApplication({
-        latestUnreadEvent: {
-          type: 'DecisionUpdate',
-          decision: 'Permitted',
-          createdAt: '2026-04-15T00:00:00Z',
-        },
-      }),
-    ];
-    browsePort.fetchByZoneResult = initialApps;
+    const p1 = withUid(undecidedApplication(), 'P1');
+    const p2 = withUid(permittedApplication(), 'P2');
+    const p3 = withUid(rejectedApplication(), 'P3');
+    browsePort.fetchByZoneResponder = (q) => {
+      if (q.cursor === null) return { rows: [p1], nextCursor: 'c1' };
+      if (q.cursor === 'c1') return { rows: [p2], nextCursor: 'c2' };
+      if (q.cursor === 'c2') return { rows: [p3], nextCursor: null };
+      throw new Error(`unexpected cursor ${String(q.cursor)}`);
+    };
+    const zones = [cambridgeZone()];
+
+    const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
+
+    await waitFor(() => expect(result.current.applications).toHaveLength(1));
+    expect(result.current.hasMore).toBe(true);
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.applications).toHaveLength(2));
+    expect(result.current.hasMore).toBe(true);
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.applications).toHaveLength(3));
+    expect(result.current.hasMore).toBe(false);
+    expect(result.current.applications.map((a) => a.uid)).toEqual([p1.uid, p2.uid, p3.uid]);
+
+    // Paging past the end is a no-op (no extra fetch).
+    const callCount = browsePort.fetchByZoneCalls.length;
+    act(() => result.current.loadMore());
+    expect(browsePort.fetchByZoneCalls.length).toBe(callCount);
+  });
+
+  it('forwards the active sort + filter on every load-more page', async () => {
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResponder = (q) => ({
+      rows: [withUid(undecidedApplication(), `${q.sort}-${String(q.cursor)}`)],
+      nextCursor: q.cursor === null ? 'c1' : null,
+    });
+    const zones = [cambridgeZone()];
+
+    const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
+    await waitFor(() => expect(result.current.applications).toHaveLength(1));
+
+    act(() => result.current.setSort('newest'));
+    await waitFor(() => expect(browsePort.fetchByZoneCalls.at(-1)!.sort).toBe('newest'));
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.applications).toHaveLength(2));
+    const lastCall = browsePort.fetchByZoneCalls.at(-1)!;
+    expect(lastCall.sort).toBe('newest');
+    expect(lastCall.cursor).toBe('c1');
+  });
+
+  it('resets pagination to page 1 (cursor cleared, pages discarded) when the sort changes', async () => {
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResponder = (q) => {
+      if (q.cursor === null) return { rows: [withUid(undecidedApplication(), `first-${q.sort}`)], nextCursor: 'more' };
+      return { rows: [withUid(permittedApplication(), 'second')], nextCursor: null };
+    };
+    const zones = [cambridgeZone()];
+
+    const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
+    await waitFor(() => expect(result.current.applications).toHaveLength(1));
+
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.applications).toHaveLength(2));
+
+    act(() => result.current.setSort('oldest'));
+
+    // The two accumulated pages are discarded; we are back to a single page-1 row.
+    await waitFor(() => expect(result.current.applications).toHaveLength(1));
+    const lastCall = browsePort.fetchByZoneCalls.at(-1)!;
+    expect(lastCall.sort).toBe('oldest');
+    expect(lastCall.cursor).toBeNull();
+    expect(result.current.hasMore).toBe(true);
+  });
+});
+
+describe('useApplications — unread chip count (derived from loaded rows)', () => {
+  it('counts distinct applications carrying a latestUnreadEvent', async () => {
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResult = {
+      rows: [
+        undecidedApplication({
+          latestUnreadEvent: { type: 'NewApplication', decision: null, createdAt: '2026-04-01T00:00:00Z' },
+        }),
+        permittedApplication(),
+        rejectedApplication({
+          latestUnreadEvent: { type: 'DecisionUpdate', decision: 'Rejected', createdAt: '2026-04-15T00:00:00Z' },
+        }),
+      ],
+      nextCursor: null,
+    };
+    const zones = [cambridgeZone()];
+
+    const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
+
+    await waitFor(() => expect(result.current.applications).toHaveLength(3));
+    expect(result.current.unreadCount).toBe(2);
+  });
+
+  it('does not reach for the notification-state snapshot for the chip count', async () => {
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResult = { rows: [], nextCursor: null };
+    const stateRepo = new SpyNotificationStateRepository();
+    const zones = [cambridgeZone()];
+
+    renderHook(() =>
+      useApplications(makeOptions({ browsePort, zones, notificationStateRepository: stateRepo })),
+    );
+
+    await waitFor(() => expect(browsePort.fetchByZoneCalls.length).toBe(1));
+    expect(stateRepo.getStateCalls).toBe(0);
+  });
+});
+
+describe('useApplications — markAllRead', () => {
+  it('marks read on the server then refetches page 1 with the active sort/filter', async () => {
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResult = {
+      rows: [
+        undecidedApplication({
+          latestUnreadEvent: { type: 'NewApplication', decision: null, createdAt: '2026-04-01T00:00:00Z' },
+        }),
+        permittedApplication({
+          latestUnreadEvent: { type: 'DecisionUpdate', decision: 'Permitted', createdAt: '2026-04-15T00:00:00Z' },
+        }),
+      ],
+      nextCursor: null,
+    };
     const stateRepo = new SpyNotificationStateRepository();
     const zones = [cambridgeZone()];
 
     const { result } = renderHook(() =>
-      useApplications(
-        makeOptions({ browsePort, zones, notificationStateRepository: stateRepo }),
-      ),
+      useApplications(makeOptions({ browsePort, zones, notificationStateRepository: stateRepo })),
     );
 
     await waitFor(() => expect(result.current.unreadCount).toBe(2));
-    const initialFetchCount = browsePort.fetchByZoneCalls.length;
+    const before = browsePort.fetchByZoneCalls.length;
 
-    // Simulate the post-mark refetch returning rows with no unread events.
-    browsePort.fetchByZoneResult = [
-      undecidedApplication({ latestUnreadEvent: null }),
-      permittedApplication({ latestUnreadEvent: null }),
-    ];
+    browsePort.fetchByZoneResult = {
+      rows: [
+        undecidedApplication({ latestUnreadEvent: null }),
+        permittedApplication({ latestUnreadEvent: null }),
+      ],
+      nextCursor: null,
+    };
 
     await act(async () => {
       await result.current.markAllRead();
@@ -296,320 +399,64 @@ describe('useApplications — markAllRead', () => {
 
     expect(stateRepo.markAllReadCalls).toBe(1);
     expect(result.current.unreadCount).toBe(0);
-    // After mark-all-read every row's latestUnreadEvent must drop to null —
-    // simplest correct implementation is to refetch the zone applications.
-    expect(browsePort.fetchByZoneCalls.length).toBeGreaterThan(initialFetchCount);
+    expect(browsePort.fetchByZoneCalls.length).toBeGreaterThan(before);
+    expect(browsePort.fetchByZoneCalls.at(-1)!.cursor).toBeNull();
   });
 });
 
-describe('useApplications — sort', () => {
-  it('exposes the recent-activity option as the default sort', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
+describe('useApplications — sort persistence', () => {
+  it('defaults to recent-activity', () => {
+    const { result } = renderHook(() => useApplications(makeOptions({ zones: [cambridgeZone()] })));
     expect(result.current.sort).toBe('recent-activity');
   });
 
-  it('orders rows by max(receivedDate, latestUnreadEvent.createdAt) desc when sort is recent-activity', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    // App A — receivedDate 2026-01-01, no unread → 2026-01-01
-    // App B — receivedDate 2026-02-01, no unread → 2026-02-01
-    // App C — receivedDate 2026-01-15, unread 2026-04-01 → 2026-04-01 (newest)
-    browsePort.fetchByZoneResult = [
-      undecidedApplication({
-        uid: undecidedApplication().uid,
-        startDate: '2026-01-01',
-      }),
-      permittedApplication({ startDate: '2026-02-01' }),
-      rejectedApplication({
-        startDate: '2026-01-15',
-        latestUnreadEvent: {
-          type: 'DecisionUpdate',
-          decision: 'Rejected',
-          createdAt: '2026-04-01T00:00:00Z',
-        },
-      }),
-    ];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
-    await waitFor(() => expect(result.current.applications).toHaveLength(3));
-
-    expect(result.current.applications.map((a) => a.uid)).toEqual([
-      rejectedApplication().uid, // 2026-04-01
-      permittedApplication().uid, // 2026-02-01
-      undecidedApplication().uid, // 2026-01-01
-    ]);
-  });
-
-  it('orders rows by startDate desc when sort is newest', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
-      undecidedApplication({ startDate: '2026-01-01' }),
-      permittedApplication({ startDate: '2026-03-01' }),
-      rejectedApplication({ startDate: '2026-02-01' }),
-    ];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
-    await waitFor(() => expect(result.current.applications).toHaveLength(3));
-
+  it('persists the sort selection to localStorage', () => {
+    const { result } = renderHook(() => useApplications(makeOptions({ zones: [cambridgeZone()] })));
     act(() => result.current.setSort('newest'));
-
-    expect(result.current.applications.map((a) => a.uid)).toEqual([
-      permittedApplication().uid,
-      rejectedApplication().uid,
-      undecidedApplication().uid,
-    ]);
-  });
-
-  it('orders rows by startDate asc when sort is oldest', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
-      undecidedApplication({ startDate: '2026-03-01' }),
-      permittedApplication({ startDate: '2026-01-01' }),
-      rejectedApplication({ startDate: '2026-02-01' }),
-    ];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
-    await waitFor(() => expect(result.current.applications).toHaveLength(3));
-
-    act(() => result.current.setSort('oldest'));
-
-    expect(result.current.applications.map((a) => a.uid)).toEqual([
-      permittedApplication().uid,
-      rejectedApplication().uid,
-      undecidedApplication().uid,
-    ]);
-  });
-
-  it('orders rows by appState alphabetically when sort is status', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [
-      undecidedApplication(),
-      permittedApplication(),
-      rejectedApplication(),
-    ];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
-    await waitFor(() => expect(result.current.applications).toHaveLength(3));
-
-    act(() => result.current.setSort('status'));
-
-    // Expected alphabetical order: Permitted, Rejected, Undecided
-    expect(result.current.applications.map((a) => a.appState)).toEqual([
-      'Permitted',
-      'Rejected',
-      'Undecided',
-    ]);
-  });
-
-  it('persists the sort selection to localStorage under applicationsListSort', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
-    act(() => result.current.setSort('newest'));
-
     expect(window.localStorage.getItem('applicationsListSort')).toBe('newest');
   });
 
-  it('rehydrates the persisted sort selection from localStorage on mount', async () => {
+  it('rehydrates the persisted sort on mount', () => {
     window.localStorage.setItem('applicationsListSort', 'oldest');
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
+    const { result } = renderHook(() => useApplications(makeOptions({ zones: [cambridgeZone()] })));
     expect(result.current.sort).toBe('oldest');
   });
 
-  it('falls back to recent-activity when localStorage holds an unknown value', async () => {
-    window.localStorage.setItem('applicationsListSort', 'unsupported-key');
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
+  it('falls back to recent-activity for an unknown persisted value', () => {
+    window.localStorage.setItem('applicationsListSort', 'nonsense');
+    const { result } = renderHook(() => useApplications(makeOptions({ zones: [cambridgeZone()] })));
     expect(result.current.sort).toBe('recent-activity');
-  });
-});
-
-describe('useApplications — distance sort', () => {
-  // Cambridge city centre. Test fixtures are placed at known offsets so the
-  // expected ordering is independent of haversine constants.
-  const cambridgeCentre = { latitude: 52.2053, longitude: 0.1218 };
-
-  function withLocation(
-    base: ReturnType<typeof undecidedApplication>,
-    location: { latitude: number; longitude: number } | null,
-  ) {
-    return {
-      ...base,
-      latitude: location?.latitude ?? null,
-      longitude: location?.longitude ?? null,
-    };
-  }
-
-  it('orders rows by ascending haversine distance from the selected zone centre', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    // Zone centre is Cambridge (52.2053, 0.1218).
-    // far    — Oxford (~107 km west)
-    // mid    — Royston (~ 17 km south-west)
-    // close  — 200 m east of the centre
-    const far = withLocation(undecidedApplication({ uid: undecidedApplication().uid }), {
-      latitude: 51.752,
-      longitude: -1.2577,
-    });
-    const mid = withLocation(permittedApplication(), {
-      latitude: 52.0497,
-      longitude: -0.0258,
-    });
-    const close = withLocation(rejectedApplication(), {
-      latitude: 52.2053,
-      longitude: 0.1247,
-    });
-    browsePort.fetchByZoneResult = [far, mid, close];
-    const zones = [cambridgeZone({ latitude: cambridgeCentre.latitude, longitude: cambridgeCentre.longitude })];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
-    await waitFor(() => expect(result.current.applications).toHaveLength(3));
-
-    act(() => result.current.setSort('distance'));
-
-    expect(result.current.applications.map((a) => a.uid)).toEqual([
-      close.uid,
-      mid.uid,
-      far.uid,
-    ]);
-  });
-
-  it('places applications without a location at the end of the distance sort', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    const located = withLocation(permittedApplication(), {
-      latitude: 52.2053,
-      longitude: 0.13,
-    });
-    const unlocated = withLocation(rejectedApplication(), null);
-    browsePort.fetchByZoneResult = [unlocated, located];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
-    await waitFor(() => expect(result.current.applications).toHaveLength(2));
-
-    act(() => result.current.setSort('distance'));
-
-    expect(result.current.applications.map((a) => a.uid)).toEqual([
-      located.uid,
-      unlocated.uid,
-    ]);
-  });
-
-  it('preserves incoming order between multiple unlocated rows (stable tiebreak)', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    const a = withLocation(undecidedApplication(), null);
-    const b = withLocation(permittedApplication(), null);
-    const c = withLocation(rejectedApplication(), null);
-    browsePort.fetchByZoneResult = [a, b, c];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
-    await waitFor(() => expect(result.current.applications).toHaveLength(3));
-
-    act(() => result.current.setSort('distance'));
-
-    expect(result.current.applications.map((a) => a.uid)).toEqual([
-      a.uid,
-      b.uid,
-      c.uid,
-    ]);
-  });
-
-  it('persists "distance" to localStorage under applicationsListSort', async () => {
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
-    act(() => result.current.setSort('distance'));
-
-    expect(window.localStorage.getItem('applicationsListSort')).toBe('distance');
-  });
-
-  it('rehydrates "distance" from localStorage on mount when a zone is available', async () => {
-    window.localStorage.setItem('applicationsListSort', 'distance');
-    const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
-    const zones = [cambridgeZone()];
-
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
-
-    expect(result.current.sort).toBe('distance');
   });
 });
 
 describe('useApplications — availableSortOptions', () => {
-  it('omits "distance" when no zone is selected (multi-zone view)', () => {
+  it('omits "distance" when no zone is selected', () => {
     const { result } = renderHook(() => useApplications(makeOptions()));
-
     expect(result.current.selectedZone).toBeNull();
     expect(result.current.availableSortOptions).not.toContain('distance');
   });
 
   it('includes "distance" once a zone has been auto-selected', async () => {
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = [];
+    browsePort.fetchByZoneResult = { rows: [], nextCursor: null };
     const zones = [cambridgeZone()];
 
-    const { result } = renderHook(() =>
-      useApplications(makeOptions({ browsePort, zones })),
-    );
+    const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
 
     await waitFor(() => expect(result.current.selectedZone).not.toBeNull());
-
     expect(result.current.availableSortOptions).toContain('distance');
+  });
+
+  it('sends sort=distance to the server when distance is selected', async () => {
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResult = { rows: [], nextCursor: null };
+    const zones = [cambridgeZone()];
+
+    const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
+    await waitFor(() => expect(result.current.selectedZone).not.toBeNull());
+
+    act(() => result.current.setSort('distance'));
+
+    await waitFor(() => expect(browsePort.fetchByZoneCalls.at(-1)!.sort).toBe('distance'));
   });
 });

--- a/web/src/features/Applications/useApplications.ts
+++ b/web/src/features/Applications/useApplications.ts
@@ -3,26 +3,17 @@ import type {
   WatchZoneSummary,
   PlanningApplicationSummary,
   ApplicationStatus,
+  ApplicationsSort,
 } from '../../domain/types';
 import type { ApplicationsBrowsePort } from '../../domain/ports/applications-browse-port';
 import type { NotificationStateRepository } from '../../domain/ports/notification-state-repository';
-import { haversineDistanceMetres } from '../../domain/geo/distance';
 
 /**
- * Sort modes for the Applications screen — persisted under
- * `applicationsListSort` in localStorage. Default: `recent-activity`.
- *
- * The `distance` mode orders rows by ascending haversine distance from the
- * selected watch-zone centre and is only meaningful when a single zone is
- * active; the picker hides it in multi-zone / no-zone surfaces. Mirrors the
- * iOS sibling tc-mso6 (PR #374).
+ * Re-exported from the domain so existing consumers (`ApplicationsPage`) keep
+ * importing the sort type from this hook. The vocabulary itself, and its
+ * mapping onto the server's `?sort=` param, lives in `domain/types`.
  */
-export type ApplicationsSort =
-  | 'recent-activity'
-  | 'newest'
-  | 'oldest'
-  | 'status'
-  | 'distance';
+export type { ApplicationsSort };
 
 const APPLICATIONS_SORT_VALUES: readonly ApplicationsSort[] = [
   'recent-activity',
@@ -63,102 +54,25 @@ export interface UseApplicationsOptions {
 
 interface State {
   readonly selectedZone: WatchZoneSummary | null;
+  /** Accumulated rows across every page fetched so far for the current query. */
   readonly applications: readonly PlanningApplicationSummary[];
+  /** True while the first page of a (re)query is in flight. */
   readonly isLoading: boolean;
+  /** True while a subsequent page (load-more) is in flight. */
+  readonly isLoadingMore: boolean;
   readonly error: string | null;
   readonly selectedStatusFilter: ApplicationStatus | null;
   readonly unreadOnly: boolean;
   readonly sort: ApplicationsSort;
+  /** Cursor for the next page; `null` once the last page has been reached. */
+  readonly nextCursor: string | null;
+  /** Bumped to force a page-1 refetch without changing the query inputs (retry). */
+  readonly reloadNonce: number;
 }
 
 function extractError(err: unknown): string {
   if (err instanceof Error) return err.message;
   return 'Unknown error';
-}
-
-function recentActivityScore(app: PlanningApplicationSummary): number {
-  const startDateMs = app.startDate ? Date.parse(app.startDate) : 0;
-  const unreadMs = app.latestUnreadEvent
-    ? Date.parse(app.latestUnreadEvent.createdAt)
-    : 0;
-  return Math.max(startDateMs, unreadMs);
-}
-
-function startDateMs(app: PlanningApplicationSummary): number {
-  return app.startDate ? Date.parse(app.startDate) : 0;
-}
-
-function sortApplications(
-  applications: readonly PlanningApplicationSummary[],
-  sort: ApplicationsSort,
-  selectedZone: WatchZoneSummary | null,
-): readonly PlanningApplicationSummary[] {
-  const copy = [...applications];
-  switch (sort) {
-    case 'recent-activity':
-      copy.sort((a, b) => recentActivityScore(b) - recentActivityScore(a));
-      return copy;
-    case 'newest':
-      copy.sort((a, b) => startDateMs(b) - startDateMs(a));
-      return copy;
-    case 'oldest':
-      copy.sort((a, b) => startDateMs(a) - startDateMs(b));
-      return copy;
-    case 'status':
-      copy.sort((a, b) => a.appState.localeCompare(b.appState));
-      return copy;
-    case 'distance':
-      return sortByDistance(copy, selectedZone);
-  }
-}
-
-/**
- * Ascending haversine distance from the active zone's centre. Apps without
- * a location sort last (preserving their incoming relative order via a
- * stable index tiebreaker so we don't surface arbitrary noise). Falls back
- * to identity when no zone is selected — the option is filtered out of the
- * picker in that state, but the defensive fallback keeps the function total.
- * Mirrors `ApplicationListViewModel.sortByDistance` on iOS (tc-mso6).
- */
-function sortByDistance(
-  applications: PlanningApplicationSummary[],
-  selectedZone: WatchZoneSummary | null,
-): readonly PlanningApplicationSummary[] {
-  if (selectedZone === null) {
-    return applications;
-  }
-  const centre = {
-    latitude: selectedZone.latitude,
-    longitude: selectedZone.longitude,
-  };
-  type Scored = {
-    readonly index: number;
-    readonly app: PlanningApplicationSummary;
-    readonly distance: number | null;
-  };
-  const scored: Scored[] = applications.map((app, index) => ({
-    index,
-    app,
-    distance: distanceFromCentre(app, centre),
-  }));
-  scored.sort((a, b) => {
-    if (a.distance === null && b.distance === null) return a.index - b.index;
-    if (a.distance === null) return 1;
-    if (b.distance === null) return -1;
-    return a.distance - b.distance;
-  });
-  return scored.map((s) => s.app);
-}
-
-function distanceFromCentre(
-  app: PlanningApplicationSummary,
-  centre: { latitude: number; longitude: number },
-): number | null {
-  if (app.latitude === null || app.longitude === null) return null;
-  return haversineDistanceMetres(centre, {
-    latitude: app.latitude,
-    longitude: app.longitude,
-  });
 }
 
 export function useApplications(options: UseApplicationsOptions) {
@@ -167,76 +81,118 @@ export function useApplications(options: UseApplicationsOptions) {
     selectedZone: null,
     applications: [],
     isLoading: false,
+    isLoadingMore: false,
     error: null,
     selectedStatusFilter: null,
     unreadOnly: false,
     sort: readPersistedSort(),
+    nextCursor: null,
+    reloadNonce: 0,
   }));
   const hasAutoSelectedRef = useRef(false);
 
-  // Auto-select the first zone the first time zones become non-empty.
+  // Monotonic generation counter. Each page-1 (re)query and each markAllRead
+  // refetch bumps it; an in-flight load-more captures the current value and
+  // discards its result if a newer query has since superseded it (e.g. the
+  // user changed sort/filter mid-load). This is what makes "reset to page 1
+  // on sort/filter change" race-safe.
+  const requestIdRef = useRef(0);
+
+  // Latest query inputs + pagination flags, mirrored into a ref so the
+  // event-driven `loadMore`/`markAllRead` callbacks read fresh values without
+  // re-subscribing. We build a fresh object (never the useState value) to stay
+  // clear of the react-hooks immutability rule.
+  const latestRef = useRef({
+    zone: null as WatchZoneSummary | null,
+    sort: state.sort,
+    status: null as ApplicationStatus | null,
+    unread: false,
+    nextCursor: null as string | null,
+    isLoading: false,
+    isLoadingMore: false,
+  });
+  useEffect(() => {
+    latestRef.current = {
+      zone: state.selectedZone,
+      sort: state.sort,
+      status: state.selectedStatusFilter,
+      unread: state.unreadOnly,
+      nextCursor: state.nextCursor,
+      isLoading: state.isLoading,
+      isLoadingMore: state.isLoadingMore,
+    };
+  });
+
+  // Auto-select the first zone the first time zones become non-empty. The query
+  // effect below reacts to the resulting `selectedZone` change and fetches.
   useEffect(() => {
     if (hasAutoSelectedRef.current) return;
     if (zones.length === 0) return;
     hasAutoSelectedRef.current = true;
     const firstZone = zones[0]!;
     // eslint-disable-next-line react-hooks/set-state-in-effect
+    setState((prev) => ({ ...prev, selectedZone: firstZone }));
+  }, [zones]);
+
+  // Page-1 query. Reacts to any change of the query inputs (zone, sort,
+  // status, unread) or an explicit reload, always resetting pagination to the
+  // first page (cursor null, accumulated rows discarded).
+  useEffect(() => {
+    if (state.selectedZone === null) return;
+    const zone = state.selectedZone;
+    const sort = state.sort;
+    const status = state.selectedStatusFilter;
+    const unread = state.unreadOnly;
+    const requestId = ++requestIdRef.current;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setState((prev) => ({
       ...prev,
-      selectedZone: firstZone,
+      applications: [],
+      nextCursor: null,
       isLoading: true,
+      isLoadingMore: false,
       error: null,
     }));
     browsePort
-      .fetchByZone(firstZone.id)
-      .then((apps) =>
-        setState((prev) => ({ ...prev, applications: apps, isLoading: false })),
-      )
-      .catch((err: unknown) =>
+      .fetchByZone({ zoneId: zone.id, sort, status, unread, cursor: null })
+      .then(({ rows, nextCursor }) => {
+        if (requestId !== requestIdRef.current) return;
+        setState((prev) => ({ ...prev, applications: rows, nextCursor, isLoading: false }));
+      })
+      .catch((err: unknown) => {
+        if (requestId !== requestIdRef.current) return;
         setState((prev) => ({
           ...prev,
           applications: [],
+          nextCursor: null,
           isLoading: false,
           error: extractError(err),
-        })),
-      );
-  }, [zones, browsePort]);
+        }));
+      });
+  }, [
+    state.selectedZone,
+    state.sort,
+    state.selectedStatusFilter,
+    state.unreadOnly,
+    state.reloadNonce,
+    browsePort,
+  ]);
 
-  const selectZone = useCallback(
-    (zone: WatchZoneSummary) => {
-      setState((prev) => ({
-        ...prev,
-        selectedZone: zone,
-        selectedStatusFilter: null,
-        unreadOnly: false,
-        isLoading: true,
-        error: null,
-      }));
-      browsePort
-        .fetchByZone(zone.id)
-        .then((apps) =>
-          setState((prev) => ({ ...prev, applications: apps, isLoading: false })),
-        )
-        .catch((err: unknown) =>
-          setState((prev) => ({
-            ...prev,
-            applications: [],
-            isLoading: false,
-            error: extractError(err),
-          })),
-        );
-    },
-    [browsePort],
-  );
-
-  const setStatusFilter = useCallback((status: ApplicationStatus | null) => {
-    // Status and Unread chips share a single-select group (spec decision #7);
-    // selecting a status clears any unread-only mode.
+  const selectZone = useCallback((zone: WatchZoneSummary) => {
+    // Selecting a zone resets the status/unread filters (and, via the query
+    // effect, pagination) to a clean first page.
     setState((prev) => ({
       ...prev,
-      selectedStatusFilter: status,
+      selectedZone: zone,
+      selectedStatusFilter: null,
       unreadOnly: false,
     }));
+  }, []);
+
+  const setStatusFilter = useCallback((status: ApplicationStatus | null) => {
+    // Status and Unread chips share a single-select group; selecting a status
+    // clears unread-only so the two are never sent to the server together.
+    setState((prev) => ({ ...prev, selectedStatusFilter: status, unreadOnly: false }));
   }, []);
 
   const setUnreadOnly = useCallback((on: boolean) => {
@@ -252,82 +208,95 @@ export function useApplications(options: UseApplicationsOptions) {
     setState((prev) => ({ ...prev, sort }));
   }, []);
 
-  // Track the currently-selected zone in a ref so async actions like
-  // `markAllRead` can refetch the right zone after their await without
-  // closing over stale state. We use a small ref tracking only the zone id
-  // rather than mirroring the full state object — the latter conflicts with
-  // the `react-hooks/immutability` rule that forbids mutating values handed
-  // back from useState.
-  const selectedZoneIdRef = useRef<WatchZoneSummary['id'] | null>(
-    state.selectedZone?.id ?? null,
-  );
-  useEffect(() => {
-    selectedZoneIdRef.current = state.selectedZone?.id ?? null;
-  }, [state.selectedZone]);
+  const reload = useCallback(() => {
+    setState((prev) => ({ ...prev, reloadNonce: prev.reloadNonce + 1 }));
+  }, []);
+
+  // Fetch the next page and append it. Guards against double-firing and against
+  // running once the cursor is exhausted. A query that started before a newer
+  // page-1 (re)query is dropped via the requestId check.
+  const loadMore = useCallback(() => {
+    const snap = latestRef.current;
+    if (
+      snap.zone === null ||
+      snap.nextCursor === null ||
+      snap.isLoading ||
+      snap.isLoadingMore
+    ) {
+      return;
+    }
+    const requestId = requestIdRef.current;
+    const zone = snap.zone;
+    const cursor = snap.nextCursor;
+    setState((prev) => ({ ...prev, isLoadingMore: true }));
+    browsePort
+      .fetchByZone({ zoneId: zone.id, sort: snap.sort, status: snap.status, unread: snap.unread, cursor })
+      .then(({ rows, nextCursor }) => {
+        if (requestId !== requestIdRef.current) return;
+        setState((prev) => ({
+          ...prev,
+          applications: [...prev.applications, ...rows],
+          nextCursor,
+          isLoadingMore: false,
+        }));
+      })
+      .catch((err: unknown) => {
+        if (requestId !== requestIdRef.current) return;
+        setState((prev) => ({ ...prev, isLoadingMore: false, error: extractError(err) }));
+      });
+  }, [browsePort]);
 
   const markAllRead = useCallback(async () => {
-    // Server-side mark-all-read is idempotent. The refetch below replaces
-    // every row with `latestUnreadEvent: null`, which collapses the
-    // client-derived `unreadCount` to zero — no separate snapshot fetch
-    // needed (tc-u6bm).
+    // Server-side mark-all-read is idempotent. The page-1 refetch below replaces
+    // every row with `latestUnreadEvent: null`, collapsing the derived
+    // `unreadCount` to zero — no separate snapshot fetch needed (tc-u6bm).
     try {
       await notificationStateRepository.markAllRead();
     } catch {
-      // Swallow — the post-mark refetch is the source of truth for the
-      // visible unread state. A retry can be added if drift becomes a
-      // problem in practice.
+      // Swallow — the post-mark refetch is the source of truth for unread state.
     }
-    const activeZoneId = selectedZoneIdRef.current;
-    if (activeZoneId !== null) {
-      try {
-        const apps = await browsePort.fetchByZone(activeZoneId);
-        setState((prev) => ({ ...prev, applications: apps }));
-      } catch {
-        // Refetch failure is non-fatal — the existing rows stay rendered.
-      }
+    const snap = latestRef.current;
+    if (snap.zone === null) return;
+    const requestId = ++requestIdRef.current; // supersede any in-flight load-more
+    try {
+      const { rows, nextCursor } = await browsePort.fetchByZone({
+        zoneId: snap.zone.id,
+        sort: snap.sort,
+        status: snap.status,
+        unread: snap.unread,
+        cursor: null,
+      });
+      if (requestId !== requestIdRef.current) return;
+      setState((prev) => ({ ...prev, applications: rows, nextCursor }));
+    } catch {
+      // Refetch failure is non-fatal — the existing rows stay rendered.
     }
   }, [browsePort, notificationStateRepository]);
 
-  // Derived: count of distinct applications in the active zone whose latest
-  // event is unread. Replaces the previous server-side `totalUnreadCount`
-  // (an event count) which inflated the chip beyond the visible row count
-  // when an app had multiple unread events (tc-u6bm).
+  // Derived: count of distinct loaded applications whose latest event is unread.
+  // With server-side paging this reflects the rows fetched so far rather than
+  // the whole zone — accurate for typical zones and for the unread-only view.
   const unreadCount = useMemo(
     () => state.applications.filter((app) => app.latestUnreadEvent !== null).length,
     [state.applications],
   );
 
-  // Derived: filtered, sorted applications.
-  const filteredApplications = useMemo<readonly PlanningApplicationSummary[]>(() => {
-    let rows: readonly PlanningApplicationSummary[] = state.applications;
-    if (state.unreadOnly) {
-      rows = rows.filter((app) => app.latestUnreadEvent !== null);
-    } else if (state.selectedStatusFilter !== null) {
-      rows = rows.filter((app) => app.appState === state.selectedStatusFilter);
-    }
-    return sortApplications(rows, state.sort, state.selectedZone);
-  }, [
-    state.applications,
-    state.selectedStatusFilter,
-    state.unreadOnly,
-    state.sort,
-    state.selectedZone,
-  ]);
-
-  // Sort modes the picker should expose right now. The `distance` option is
-  // only meaningful relative to a chosen zone, so it's filtered out when no
-  // zone is active (multi-zone surfaces or the transient pre-auto-select
-  // state). Mirrors the iOS sibling's `availableSortOptions` (tc-mso6).
-  const availableSortOptions = useMemo<readonly ApplicationsSort[]>(() => {
-    return APPLICATIONS_SORT_VALUES.filter(
-      (mode) => mode !== 'distance' || state.selectedZone !== null,
-    );
-  }, [state.selectedZone]);
+  // Sort modes the picker should expose. `distance` is only meaningful relative
+  // to a chosen zone, so it's hidden when no zone is active.
+  const availableSortOptions = useMemo<readonly ApplicationsSort[]>(
+    () =>
+      APPLICATIONS_SORT_VALUES.filter(
+        (mode) => mode !== 'distance' || state.selectedZone !== null,
+      ),
+    [state.selectedZone],
+  );
 
   return {
     selectedZone: state.selectedZone,
-    applications: filteredApplications,
+    applications: state.applications,
     isLoading: state.isLoading,
+    isLoadingMore: state.isLoadingMore,
+    hasMore: state.nextCursor !== null,
     error: state.error,
     selectedStatusFilter: state.selectedStatusFilter,
     unreadOnly: state.unreadOnly,
@@ -338,6 +307,8 @@ export function useApplications(options: UseApplicationsOptions) {
     setStatusFilter,
     setUnreadOnly,
     setSort,
+    loadMore,
+    reload,
     markAllRead,
   };
 }


### PR DESCRIPTION
## Changes

Slice B of #711 (web watch-zone list parity with iOS #682 slices 1–4). Replaces the web Applications list's "fetch first page, sort/filter in the browser" with **server-driven sort + status/unread filter + keyset pagination** following the `X-Next-Cursor` header to exhaustion. Depends on Slice A (CORS expose, merged #713) so the browser can read the cursor cross-origin.

- `web/src/api/client.ts` — `getWithHeaders<T>()` returning `{ body, headers }` (reads `X-Next-Cursor`); existing `get<T>()` unchanged.
- `web/src/api/applications.ts` — `getByZonePaged({sort,status,unread,cursor,limit})` → `{ rows, nextCursor }`. `getByZone` (param-less) left **byte-identical** for the Dashboard caller; `getClusters`/`getByAuthorityAndName` (Slice C) untouched.
- `web/src/domain/ports/applications-browse-port.ts` — widened to `(query) -> { rows, nextCursor }`; `web/src/domain/types.ts` — `ApplicationsSort`.
- `web/src/features/Applications/useApplications.ts` — drives sort + status/unread server-side, follows `X-Next-Cursor` to exhaustion, resets to page 1 (cursor cleared) on any sort/filter/zone change. **Removed** all client-side `sortApplications`/`filteredApplications`/`recentActivityScore`/`sortByDistance`/haversine. Effect-driven query with a requestId guard discarding stale page/load-more results after a reset.
- `web/src/features/Applications/ApplicationsPage.tsx` — "Load more" button (chosen over IntersectionObserver: accessible + testable without mocking IO in jsdom; the brief allows it).
- status + unread are single-select (never sent together; the paged call drops `status` when `unread`).

## Verification
- **Tests:** `npx tsc --noEmit` clean · `npx vitest run` **891 pass** · eslint clean · `npm run build` ok.
- **API contract** (local API + dense 306-app seed): param-less → 306 bare array; `?sort=newest&limit=150` → 150 rows + `X-Next-Cursor`; cursor drain → 3 pages = all 306; `?status=Rejected` → 50 rows. CORS exposes `X-Next-Cursor`.
- **Real browser** (agent-browser, local API incl. Slice A CORS):
  1. ✅ First page 150 rows + "Load more" visible.
  2. ✅ Load more appends 150 → 300 → 306, then "Load more" disappears (no cursor on last page).
  3. ✅ Changing sort to "Oldest" reorders AND resets to page 1 (150 rows, "Load more" returns) — server-side, not a client re-sort.
  4. ✅ "Refused" chip shows exactly 50 rows (server-side filter; an in-memory filter of the 150 loaded would show ~25).
  5. ✅ "Unread" is mutually exclusive with status (selecting it deselects the status chip).

## Notes / flags
- **Filed tc-je35 (P4):** the unread chip's count reflects loaded pages only (accurate for typical zones / the unread-only view, slightly under-counts a huge unfiltered zone before full drain). Minor; not blocking.
- **tc-z3d3 (dead pagination stack):** built the load-more fresh; created NO new dependency on the dead `usePagination`/`usePaginatedFetch`/`Pagination` — its deletion stays with tc-z3d3.

Closes tc-bmuk. Completes the web remainder of epic #682 / issue #711.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Applications can now be loaded in pages, with a **Load more** button to fetch additional results.
  * Sorting and filtering are now applied server-side, including unread and status filtering.
  * The applications list now preserves server-provided order and supports more sort options.

* **Bug Fixes**
  * Improved refresh behavior after marking items as read.
  * Pagination now stops correctly at the end of the list and avoids duplicate loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->