### PR TITLE
fix(web): source unread chip count from whole-zone query (tc-je35)

### DIFF
--- a/web/src/domain/ports/applications-browse-port.ts
+++ b/web/src/domain/ports/applications-browse-port.ts
@@ -31,4 +31,13 @@ export interface ApplicationsPageResult {
 
 export interface ApplicationsBrowsePort {
   fetchByZone(query: ApplicationsBrowseQuery): Promise<ApplicationsPageResult>;
+  /**
+   * Returns the zone's **full** unread total, independent of the main list's
+   * pagination (GH#716, Problem 2). Sourced from the unread-only query exhausted
+   * across every page, so loading more main-list pages never changes it. This is
+   * what the "Unread (N)" chip counts — a whole-zone signal, not the rows loaded
+   * so far. Deliberately zone-scoped (not the account-wide notification-state
+   * snapshot, which would over-count a multi-zone user).
+   */
+  countUnread(zoneId: WatchZoneId): Promise<number>;
 }

--- a/web/src/features/Applications/ConnectedApplicationsPage.tsx
+++ b/web/src/features/Applications/ConnectedApplicationsPage.tsx
@@ -18,6 +18,25 @@ export function ConnectedApplicationsPage() {
           unread: query.unread,
           cursor: query.cursor,
         }),
+      // Whole-zone unread total for the "Unread (N)" chip: exhaust the
+      // unread-only paged query (following X-Next-Cursor) and sum the rows.
+      // Unread sets are small, so this is typically a single request; `sort` is
+      // irrelevant to a count. Independent of the main list's pagination.
+      countUnread: async (zoneId) => {
+        let total = 0;
+        let cursor: string | null = null;
+        do {
+          const page = await applicationsApi(client).getByZonePaged(zoneId as string, {
+            sort: 'newest',
+            status: null,
+            unread: true,
+            cursor,
+          });
+          total += page.rows.length;
+          cursor = page.nextCursor;
+        } while (cursor !== null);
+        return total;
+      },
     }),
     [client],
   );

--- a/web/src/features/Applications/__tests__/ApplicationsPage.test.tsx
+++ b/web/src/features/Applications/__tests__/ApplicationsPage.test.tsx
@@ -136,10 +136,12 @@ describe('ApplicationsPage — Unread chip', () => {
     window.localStorage.clear();
   });
 
-  it('renders an Unread chip whose badge equals the distinct count of unread applications loaded', async () => {
+  it("renders an Unread chip whose badge equals the zone's whole unread total (not loaded rows)", async () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
+    // Two loaded rows carry an unread event, but the whole zone has five —
+    // the chip must reflect the zone total, not the rows on screen.
     browsePort.fetchByZoneResult = onePage([
       undecidedApplication({
         latestUnreadEvent: { type: 'NewApplication', decision: null, createdAt: '2026-04-01T00:00:00Z' },
@@ -149,15 +151,16 @@ describe('ApplicationsPage — Unread chip', () => {
         latestUnreadEvent: { type: 'DecisionUpdate', decision: 'Rejected', createdAt: '2026-04-15T00:00:00Z' },
       }),
     ]);
+    browsePort.unreadTotal = 5;
 
     renderPage({ zonesPort, browsePort });
 
-    const chip = await screen.findByRole('button', { name: /unread \(2\)/i });
+    const chip = await screen.findByRole('button', { name: /unread \(5\)/i });
     expect(chip).toBeInTheDocument();
     expect(chip).toHaveAttribute('aria-pressed', 'false');
   });
 
-  it('hides the Unread chip when no loaded application has an unread event', async () => {
+  it('hides the Unread chip when the zone has no unread applications', async () => {
     const zonesPort = new SpyZonesPort();
     zonesPort.fetchZonesResult = [cambridgeZone()];
     const browsePort = new SpyApplicationsBrowsePort();
@@ -180,6 +183,7 @@ describe('ApplicationsPage — Unread chip', () => {
     });
     const read = permittedApplication();
     browsePort.fetchByZoneResponder = (q) => onePage(q.unread ? [unread] : [unread, read]);
+    browsePort.unreadTotal = 1;
     const user = userEvent.setup();
 
     renderPage({ zonesPort, browsePort });
@@ -211,6 +215,7 @@ describe('ApplicationsPage — Mark all read', () => {
         latestUnreadEvent: { type: 'NewApplication', decision: null, createdAt: '2026-04-01T00:00:00Z' },
       }),
     ]);
+    browsePort.unreadTotal = 1;
 
     renderPage({ zonesPort, browsePort });
 
@@ -226,6 +231,7 @@ describe('ApplicationsPage — Mark all read', () => {
         latestUnreadEvent: { type: 'NewApplication', decision: null, createdAt: '2026-04-01T00:00:00Z' },
       }),
     ]);
+    browsePort.unreadTotal = 1;
     const stateRepo = new SpyNotificationStateRepository();
     const user = userEvent.setup();
 

--- a/web/src/features/Applications/__tests__/spies/spy-applications-browse-port.ts
+++ b/web/src/features/Applications/__tests__/spies/spy-applications-browse-port.ts
@@ -3,12 +3,18 @@ import type {
   ApplicationsBrowseQuery,
   ApplicationsPageResult,
 } from '../../../../domain/ports/applications-browse-port';
+import type { WatchZoneId } from '../../../../domain/types';
 
 /**
  * Hand-written spy for the server-driven applications browse port. Records the
  * full query for each call (so tests can assert the sort/status/unread/cursor
  * sent to the server) and returns either a fixed single-page result or, for
  * multi-page / filter-aware tests, a caller-supplied responder.
+ *
+ * `countUnread` is modelled by a settable whole-zone total (`unreadTotal`),
+ * decoupled from `fetchByZone`'s pages so a test can return a multi-page list
+ * yet a larger separate unread total — proving the chip count is whole-zone, not
+ * loaded-rows derived.
  */
 export class SpyApplicationsBrowsePort implements ApplicationsBrowsePort {
   fetchByZoneCalls: ApplicationsBrowseQuery[] = [];
@@ -17,6 +23,11 @@ export class SpyApplicationsBrowsePort implements ApplicationsBrowsePort {
   fetchByZoneResponder:
     | ((query: ApplicationsBrowseQuery) => ApplicationsPageResult)
     | null = null;
+
+  /** Whole-zone unread total returned by `countUnread`. */
+  unreadTotal = 0;
+  countUnreadCalls: WatchZoneId[] = [];
+  countUnreadError: Error | null = null;
 
   async fetchByZone(query: ApplicationsBrowseQuery): Promise<ApplicationsPageResult> {
     this.fetchByZoneCalls.push(query);
@@ -27,5 +38,13 @@ export class SpyApplicationsBrowsePort implements ApplicationsBrowsePort {
       throw this.fetchByZoneError;
     }
     return this.fetchByZoneResult;
+  }
+
+  async countUnread(zoneId: WatchZoneId): Promise<number> {
+    this.countUnreadCalls.push(zoneId);
+    if (this.countUnreadError) {
+      throw this.countUnreadError;
+    }
+    return this.unreadTotal;
   }
 }

--- a/web/src/features/Applications/__tests__/useApplications.test.ts
+++ b/web/src/features/Applications/__tests__/useApplications.test.ts
@@ -328,27 +328,33 @@ describe('useApplications — keyset pagination (X-Next-Cursor)', () => {
   });
 });
 
-describe('useApplications — unread chip count (derived from loaded rows)', () => {
-  it('counts distinct applications carrying a latestUnreadEvent', async () => {
+describe('useApplications — unread chip count (whole-zone, not loaded pages)', () => {
+  it('sources the count from the whole-zone unread total, independent of loaded pages', async () => {
     const browsePort = new SpyApplicationsBrowsePort();
-    browsePort.fetchByZoneResult = {
-      rows: [
-        undecidedApplication({
-          latestUnreadEvent: { type: 'NewApplication', decision: null, createdAt: '2026-04-01T00:00:00Z' },
-        }),
-        permittedApplication(),
-        rejectedApplication({
-          latestUnreadEvent: { type: 'DecisionUpdate', decision: 'Rejected', createdAt: '2026-04-15T00:00:00Z' },
-        }),
-      ],
-      nextCursor: null,
-    };
+    // The main list is multi-page: page 1 has one row with more to come.
+    browsePort.fetchByZoneResponder = (q) =>
+      q.cursor === null
+        ? { rows: [withUid(undecidedApplication(), 'P1')], nextCursor: 'c1' }
+        : { rows: [withUid(permittedApplication(), 'P2')], nextCursor: null };
+    // The whole-zone unread total is larger than any single loaded page.
+    browsePort.unreadTotal = 7;
     const zones = [cambridgeZone()];
 
     const { result } = renderHook(() => useApplications(makeOptions({ browsePort, zones })));
 
-    await waitFor(() => expect(result.current.applications).toHaveLength(3));
-    expect(result.current.unreadCount).toBe(2);
+    // Only page 1 is loaded, yet the chip already reflects the whole zone.
+    await waitFor(() => expect(result.current.unreadCount).toBe(7));
+    expect(result.current.applications).toHaveLength(1);
+    expect(result.current.hasMore).toBe(true);
+    expect(browsePort.countUnreadCalls).toHaveLength(1);
+    expect(browsePort.countUnreadCalls[0]).toBe(cambridgeZone().id);
+
+    // Loading another page must NOT change the whole-zone count or refetch it.
+    const countCallsBefore = browsePort.countUnreadCalls.length;
+    act(() => result.current.loadMore());
+    await waitFor(() => expect(result.current.applications).toHaveLength(2));
+    expect(result.current.unreadCount).toBe(7);
+    expect(browsePort.countUnreadCalls.length).toBe(countCallsBefore);
   });
 
   it('does not reach for the notification-state snapshot for the chip count', async () => {
@@ -380,6 +386,7 @@ describe('useApplications — markAllRead', () => {
       ],
       nextCursor: null,
     };
+    browsePort.unreadTotal = 2;
     const stateRepo = new SpyNotificationStateRepository();
     const zones = [cambridgeZone()];
 
@@ -397,6 +404,8 @@ describe('useApplications — markAllRead', () => {
       ],
       nextCursor: null,
     };
+    // Server watermark advances on mark-all-read — the whole-zone count drops.
+    browsePort.unreadTotal = 0;
 
     await act(async () => {
       await result.current.markAllRead();

--- a/web/src/features/Applications/useApplications.ts
+++ b/web/src/features/Applications/useApplications.ts
@@ -68,6 +68,12 @@ interface State {
   readonly nextCursor: string | null;
   /** Bumped to force a page-1 refetch without changing the query inputs (retry). */
   readonly reloadNonce: number;
+  /**
+   * Whole-zone unread total for the "Unread (N)" chip (GH#716, Problem 2).
+   * Sourced from `browsePort.countUnread(zone.id)` — independent of how many
+   * main-list pages are loaded — not derived from the rows fetched so far.
+   */
+  readonly unreadCount: number;
 }
 
 function extractError(err: unknown): string {
@@ -88,6 +94,7 @@ export function useApplications(options: UseApplicationsOptions) {
     sort: readPersistedSort(),
     nextCursor: null,
     reloadNonce: 0,
+    unreadCount: 0,
   }));
   const hasAutoSelectedRef = useRef(false);
 
@@ -97,6 +104,12 @@ export function useApplications(options: UseApplicationsOptions) {
   // user changed sort/filter mid-load). This is what makes "reset to page 1
   // on sort/filter change" race-safe.
   const requestIdRef = useRef(0);
+
+  // Separate generation counter for the whole-zone unread count. Kept distinct
+  // from `requestIdRef` so a count refresh never supersedes an in-flight list
+  // page (and vice versa); it only guards the count's own zone-change/markAllRead
+  // refetches against stale responses overwriting a newer zone's total.
+  const countUnreadRequestIdRef = useRef(0);
 
   // Latest query inputs + pagination flags, mirrored into a ref so the
   // event-driven `loadMore`/`markAllRead` callbacks read fresh values without
@@ -178,6 +191,26 @@ export function useApplications(options: UseApplicationsOptions) {
     browsePort,
   ]);
 
+  // Whole-zone unread total for the chip. Re-fetched only when the selected zone
+  // changes — deliberately independent of sort/status/unread/pagination, so
+  // loading more list pages (or toggling filters) never moves the chip's number.
+  // markAllRead refreshes it explicitly.
+  useEffect(() => {
+    if (state.selectedZone === null) return;
+    const zoneId = state.selectedZone.id;
+    const requestId = ++countUnreadRequestIdRef.current;
+    browsePort
+      .countUnread(zoneId)
+      .then((count) => {
+        if (requestId !== countUnreadRequestIdRef.current) return;
+        setState((prev) => ({ ...prev, unreadCount: count }));
+      })
+      .catch(() => {
+        // Non-fatal: leave the previous count in place rather than zeroing the
+        // chip on a transient failure.
+      });
+  }, [state.selectedZone, browsePort]);
+
   const selectZone = useCallback((zone: WatchZoneSummary) => {
     // Selecting a zone resets the status/unread filters (and, via the query
     // effect, pagination) to a clean first page.
@@ -247,9 +280,10 @@ export function useApplications(options: UseApplicationsOptions) {
   }, [browsePort]);
 
   const markAllRead = useCallback(async () => {
-    // Server-side mark-all-read is idempotent. The page-1 refetch below replaces
-    // every row with `latestUnreadEvent: null`, collapsing the derived
-    // `unreadCount` to zero — no separate snapshot fetch needed (tc-u6bm).
+    // Server-side mark-all-read is idempotent. We then refresh two things in
+    // parallel: page 1 (its rows now carry `latestUnreadEvent: null`, so the
+    // cards render as read) and the whole-zone unread count (the server
+    // watermark advanced, so it should drop — typically to zero).
     try {
       await notificationStateRepository.markAllRead();
     } catch {
@@ -257,29 +291,41 @@ export function useApplications(options: UseApplicationsOptions) {
     }
     const snap = latestRef.current;
     if (snap.zone === null) return;
+    const zoneId = snap.zone.id;
     const requestId = ++requestIdRef.current; // supersede any in-flight load-more
-    try {
-      const { rows, nextCursor } = await browsePort.fetchByZone({
-        zoneId: snap.zone.id,
-        sort: snap.sort,
-        status: snap.status,
-        unread: snap.unread,
-        cursor: null,
-      });
-      if (requestId !== requestIdRef.current) return;
-      setState((prev) => ({ ...prev, applications: rows, nextCursor }));
-    } catch {
-      // Refetch failure is non-fatal — the existing rows stay rendered.
-    }
+    const countRequestId = ++countUnreadRequestIdRef.current;
+    await Promise.all([
+      browsePort
+        .fetchByZone({
+          zoneId,
+          sort: snap.sort,
+          status: snap.status,
+          unread: snap.unread,
+          cursor: null,
+        })
+        .then(({ rows, nextCursor }) => {
+          if (requestId !== requestIdRef.current) return;
+          setState((prev) => ({ ...prev, applications: rows, nextCursor }));
+        })
+        .catch(() => {
+          // Refetch failure is non-fatal — the existing rows stay rendered.
+        }),
+      browsePort
+        .countUnread(zoneId)
+        .then((count) => {
+          if (countRequestId !== countUnreadRequestIdRef.current) return;
+          setState((prev) => ({ ...prev, unreadCount: count }));
+        })
+        .catch(() => {
+          // Non-fatal — leave the previous count in place.
+        }),
+    ]);
   }, [browsePort, notificationStateRepository]);
 
-  // Derived: count of distinct loaded applications whose latest event is unread.
-  // With server-side paging this reflects the rows fetched so far rather than
-  // the whole zone — accurate for typical zones and for the unread-only view.
-  const unreadCount = useMemo(
-    () => state.applications.filter((app) => app.latestUnreadEvent !== null).length,
-    [state.applications],
-  );
+  // Whole-zone unread total for the chip, sourced from `browsePort.countUnread`
+  // (see the count-fetch effect above) rather than the loaded rows — so it
+  // reflects the zone, not how far the user has paged (GH#716, Problem 2).
+  const unreadCount = state.unreadCount;
 
   // Sort modes the picker should expose. `distance` is only meaningful relative
   // to a chosen zone, so it's hidden when no zone is active.


### PR DESCRIPTION
Makes the Applications **"Unread (N)" chip reflect the whole zone**, not just loaded pages (GH #716, Problem 2 / tc-je35).

## Problem
After #711 made the list server-paged, `useApplications` derived `unreadCount` by filtering the **currently loaded rows**. Before paging to exhaustion, a large zone's unread total under-counts — and under a date sort, where unread rows fall to page 2, the chip vanished entirely.

## Fix (web-side only — no API change)
- New `ApplicationsBrowsePort.countUnread(zoneId)` returns the zone's full unread total by exhausting the unread-only query (`unread=true`, following `X-Next-Cursor`).
- `useApplications` sources `unreadCount` from `countUnread` — fetched on zone change (own request-id race guard), refreshed on `markAllRead` — so loading more list pages, changing sort, or toggling filters never moves the chip.

### Why not the notification-state count
`NotificationStateSnapshot.totalUnreadCount` is **account-wide** (the Go `notificationstate.UnreadCount` is keyed only by user, not zone), so it would over-count a multi-zone user. The existing "does not reach for the notification-state snapshot" test stays green.

## Verification
- `npx tsc --noEmit` clean · `eslint` clean · **891 vitest tests pass** · `npm run build` ok.
- Browser-verified against a local API + Postgres with a seeded zone of 180 apps / 12 unread: under a date sort the chip reads **Unread (12)** with **0 unread rows loaded** on page 1, and stays **12** after Load more (180 loaded, 12 unread visible). On the pre-fix build the chip was hidden in this case.

Closes tc-je35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)