### PR TITLE
SEO town pages: dedupe same-name pages (301) + lower population floor 20k→5k (#717)

### DIFF
--- a/.github/actions/build-web/action.yml
+++ b/.github/actions/build-web/action.yml
@@ -48,7 +48,7 @@ inputs:
   seo-town-min-population:
     description: SEO_TOWN_MIN_POPULATION — population floor for published town SEO pages (towns below this are not published)
     required: false
-    default: "20000"
+    default: "5000"
   render-mode:
     description: >-
       When "true", build the SPA only and render /planning/* + sitemap.xml from a

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -210,7 +210,7 @@ jobs:
     name: "Web: Deploy to dev"
     needs: infra-dev
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     environment: development
     steps:
       - uses: actions/checkout@v6
@@ -234,7 +234,7 @@ jobs:
           vite-auth0-client-id: ${{ vars.VITE_AUTH0_CLIENT_ID }}
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
-          seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
+          seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '5000' }}
           render-mode: 'true'
           storage-account-name: sttowncrierdev
 

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -186,7 +186,7 @@ jobs:
     name: Deploy web
     needs: infra
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     environment: production
     steps:
       - uses: actions/checkout@v6
@@ -210,7 +210,7 @@ jobs:
           vite-auth0-client-id: ${{ vars.VITE_AUTH0_CLIENT_ID }}
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
-          seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
+          seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '5000' }}
           render-mode: 'true'
           storage-account-name: sttowncrierprod
 

--- a/.github/workflows/seo-refresh.yml
+++ b/.github/workflows/seo-refresh.yml
@@ -42,7 +42,7 @@
 # Requires per-environment GitHub variables (vars.*):
 #   VITE_API_BASE_URL, VITE_AUTH0_DOMAIN, VITE_AUTH0_CLIENT_ID,
 #   VITE_AUTH0_AUDIENCE, VITE_APPLICATIONINSIGHTS_CONNECTION_STRING,
-#   SEO_TOWN_MIN_POPULATION (optional; defaults to 20000)
+#   SEO_TOWN_MIN_POPULATION (optional; defaults to 5000)
 #
 # Requires GitHub Environments:
 #   development, production  — each with an OIDC federated credential. The
@@ -99,7 +99,7 @@ jobs:
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
           site-build-key: ""
-          seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
+          seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '5000' }}
 
       - uses: ./.github/actions/azure-login
         with:
@@ -114,7 +114,7 @@ jobs:
         env:
           SITE_BUILD_KEY: ${{ secrets.SITE_BUILD_KEY }}
           VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
-          SEO_TOWN_MIN_POPULATION: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
+          SEO_TOWN_MIN_POPULATION: ${{ vars.SEO_TOWN_MIN_POPULATION || '5000' }}
 
       # Shared-key access is disabled on the account, so --auth-mode login (AAD).
       - name: Upload snapshot to Azure Blob
@@ -172,7 +172,7 @@ jobs:
           vite-auth0-audience: ${{ vars.VITE_AUTH0_AUDIENCE }}
           vite-applicationinsights-connection-string: ${{ vars.VITE_APPLICATIONINSIGHTS_CONNECTION_STRING }}
           site-build-key: ""
-          seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
+          seo-town-min-population: ${{ vars.SEO_TOWN_MIN_POPULATION || '5000' }}
 
       - uses: ./.github/actions/azure-login
         with:
@@ -187,7 +187,7 @@ jobs:
         env:
           SITE_BUILD_KEY: ${{ secrets.SITE_BUILD_KEY }}
           VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
-          SEO_TOWN_MIN_POPULATION: ${{ vars.SEO_TOWN_MIN_POPULATION || '20000' }}
+          SEO_TOWN_MIN_POPULATION: ${{ vars.SEO_TOWN_MIN_POPULATION || '5000' }}
 
       # Shared-key access is disabled on the account, so --auth-mode login (AAD).
       - name: Upload snapshot to Azure Blob

--- a/web/scripts/lib/__tests__/prerender-dedup.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-dedup.test.mjs
@@ -1,0 +1,300 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, writeFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runPrerender } from '../../prerender-planning.mjs';
+
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+let outDir;
+let baseConfigPath;
+
+const BASE_CONFIG = {
+  navigationFallback: { rewrite: '/index.html', exclude: ['*.{css,js}'] },
+  globalHeaders: { 'X-Frame-Options': 'DENY' },
+  routes: [{ route: '/assets/*', headers: { 'Cache-Control': 'public' } }],
+};
+
+beforeEach(async () => {
+  outDir = await mkdtemp(join(tmpdir(), 'prerender-dedup-'));
+  baseConfigPath = join(outDir, 'base-staticwebapp.config.json');
+  await writeFile(baseConfigPath, JSON.stringify(BASE_CONFIG), 'utf-8');
+});
+
+afterEach(async () => {
+  await rm(outDir, { recursive: true, force: true });
+});
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const app = (uid) => ({
+  uid,
+  name: uid,
+  address: `${uid} address`,
+  description: 'desc',
+  appState: 'Permitted',
+  startDate: '2026-01-10',
+  lastDifferent: '2026-06-10T10:00:00+00:00',
+  link: null,
+  url: null,
+});
+
+/**
+ * Write authority + town fixtures and run the prerender in fixture mode with an
+ * injected base SWA config path. Returns the run result.
+ */
+async function runWith({ authorities, towns, authorityList }) {
+  const authorityFixture = join(outDir, 'authorities.json');
+  const townFixture = join(outDir, 'towns.json');
+  await writeFile(authorityFixture, JSON.stringify(authorities), 'utf-8');
+  await writeFile(townFixture, JSON.stringify(towns), 'utf-8');
+  return runPrerender({
+    outDir,
+    fixturePath: authorityFixture,
+    townFixturePath: townFixture,
+    baseConfigPath,
+    loadAuthorities: async () => authorityList,
+    logger: silentLogger,
+  });
+}
+
+describe('runPrerender — same-name town dedup (tc-77ll)', () => {
+  const wrexhamAndCornwall = {
+    authorities: [
+      {
+        id: 10,
+        name: 'Wrexham',
+        areaType: 'Welsh Principal Area',
+        areaName: 'Wrexham',
+        total: 20,
+        statusBreakdown: [{ appState: 'Permitted', count: 20 }],
+        applications: [app('W1')],
+      },
+      {
+        id: 52,
+        name: 'Cornwall',
+        areaType: 'English Unitary Authority',
+        areaName: 'Cornwall',
+        total: 30,
+        statusBreakdown: [{ appState: 'Permitted', count: 30 }],
+        applications: [app('C1')],
+      },
+    ],
+    towns: [
+      // same-name town under Wrexham -> suppressed + redirected
+      {
+        slug: 'wrexham',
+        name: 'Wrexham',
+        lat: 53.04,
+        lng: -2.99,
+        authorityId: 10,
+        total: 25,
+        statusBreakdown: [{ appState: 'Permitted', count: 25 }],
+        applications: [app('WT1')],
+      },
+      // same-name town under Cornwall -> suppressed + redirected
+      {
+        slug: 'cornwall',
+        name: 'Cornwall',
+        lat: 50.5,
+        lng: -4.6,
+        authorityId: 52,
+        total: 22,
+        statusBreakdown: [{ appState: 'Permitted', count: 22 }],
+        applications: [app('CT1')],
+      },
+      // genuinely different town under Cornwall -> published + linked, no redirect
+      {
+        slug: 'truro',
+        name: 'Truro',
+        lat: 50.2632,
+        lng: -5.051,
+        authorityId: 52,
+        total: 18,
+        statusBreakdown: [{ appState: 'Permitted', count: 18 }],
+        applications: [app('TR1')],
+      },
+    ],
+    authorityList: [
+      { id: 10, name: 'Wrexham' },
+      { id: 52, name: 'Cornwall' },
+    ],
+  };
+
+  it('suppresses a same-name town: no page, not published, not in the sitemap', async () => {
+    const result = await runWith(wrexhamAndCornwall);
+
+    expect(result.publishedTowns).toEqual(['cornwall/truro']);
+    expect(result.publishedTowns).not.toContain('wrexham/wrexham');
+    expect(result.publishedTowns).not.toContain('cornwall/cornwall');
+
+    expect(
+      await exists(join(outDir, 'planning', 'wrexham', 'wrexham', 'index.html')),
+    ).toBe(false);
+    expect(
+      await exists(join(outDir, 'planning', 'cornwall', 'cornwall', 'index.html')),
+    ).toBe(false);
+    // the genuinely different town still publishes
+    expect(
+      await exists(join(outDir, 'planning', 'cornwall', 'truro', 'index.html')),
+    ).toBe(true);
+
+    const sitemap = await readFile(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain(
+      '<loc>https://towncrierapp.uk/planning/cornwall/truro</loc>',
+    );
+    expect(sitemap).not.toContain('/planning/wrexham/wrexham');
+    expect(sitemap).not.toContain('/planning/cornwall/cornwall');
+  });
+
+  it('records a 301 redirect for each suppressed town, none for a published town', async () => {
+    const result = await runWith(wrexhamAndCornwall);
+
+    expect(result.redirects.sort()).toEqual([
+      'cornwall/cornwall',
+      'wrexham/wrexham',
+    ]);
+    expect(result.redirects).not.toContain('cornwall/truro');
+  });
+
+  it('merges the 301 routes into the base SWA config written to the outDir', async () => {
+    await runWith(wrexhamAndCornwall);
+
+    const merged = JSON.parse(
+      await readFile(join(outDir, 'staticwebapp.config.json'), 'utf-8'),
+    );
+    expect(merged.routes).toContainEqual({
+      route: '/planning/wrexham/wrexham',
+      redirect: '/planning/wrexham',
+      statusCode: 301,
+    });
+    expect(merged.routes).toContainEqual({
+      route: '/planning/cornwall/cornwall',
+      redirect: '/planning/cornwall',
+      statusCode: 301,
+    });
+    // hand-written base route survives the merge.
+    expect(merged.routes).toContainEqual({
+      route: '/assets/*',
+      headers: { 'Cache-Control': 'public' },
+    });
+    // and the rest of the base config is untouched.
+    expect(merged.navigationFallback).toEqual(BASE_CONFIG.navigationFallback);
+    expect(merged.globalHeaders).toEqual(BASE_CONFIG.globalHeaders);
+  });
+
+  it('drops the suppressed town from the authority page town-links (no self-link)', async () => {
+    await runWith(wrexhamAndCornwall);
+
+    // Cornwall links down to Truro but NEVER to the suppressed same-name town.
+    const cornwall = await readFile(
+      join(outDir, 'planning', 'cornwall', 'index.html'),
+      'utf-8',
+    );
+    expect(cornwall).toContain('<a href="/planning/cornwall/truro">Truro</a>');
+    expect(cornwall).not.toContain('/planning/cornwall/cornwall');
+
+    // Wrexham has 0 qualifying towns -> the town-links section is omitted.
+    const wrexham = await readFile(
+      join(outDir, 'planning', 'wrexham', 'index.html'),
+      'utf-8',
+    );
+    expect(wrexham).not.toContain('<section class="townLinks">');
+    expect(wrexham).not.toContain('/planning/wrexham/wrexham');
+  });
+
+  it('classifies a suppressed town as excluded with reason "same-name"', async () => {
+    const result = await runWith(wrexhamAndCornwall);
+    expect(result.excludedTowns).toContainEqual({
+      name: 'Wrexham',
+      reason: 'same-name',
+    });
+    expect(result.excludedTowns).toContainEqual({
+      name: 'Cornwall',
+      reason: 'same-name',
+    });
+  });
+
+  it('suppresses a forward-looking "City of" authority/town collision', async () => {
+    const result = await runWith({
+      authorities: [
+        {
+          id: 7,
+          name: 'Bristol, City of',
+          areaType: 'English Unitary Authority',
+          areaName: 'Bristol, City of',
+          total: 40,
+          statusBreakdown: [{ appState: 'Permitted', count: 40 }],
+          applications: [app('B1')],
+        },
+      ],
+      towns: [
+        {
+          slug: 'bristol',
+          name: 'Bristol',
+          lat: 51.4545,
+          lng: -2.5879,
+          authorityId: 7,
+          total: 30,
+          statusBreakdown: [{ appState: 'Permitted', count: 30 }],
+          applications: [app('BT1')],
+        },
+      ],
+      authorityList: [{ id: 7, name: 'Bristol, City of' }],
+    });
+
+    expect(result.publishedTowns).toEqual([]);
+    expect(result.redirects).toEqual(['bristol-city-of/bristol']);
+    const merged = JSON.parse(
+      await readFile(join(outDir, 'staticwebapp.config.json'), 'utf-8'),
+    );
+    expect(merged.routes).toContainEqual({
+      route: '/planning/bristol-city-of/bristol',
+      redirect: '/planning/bristol-city-of',
+      statusCode: 301,
+    });
+  });
+
+  it('does not redirect a same-name town that never cleared the coverage gate', async () => {
+    const result = await runWith({
+      authorities: [
+        {
+          id: 10,
+          name: 'Wrexham',
+          areaType: 'Welsh Principal Area',
+          areaName: 'Wrexham',
+          total: 20,
+          statusBreakdown: [{ appState: 'Permitted', count: 20 }],
+          applications: [app('W1')],
+        },
+      ],
+      towns: [
+        {
+          slug: 'wrexham',
+          name: 'Wrexham',
+          lat: 53.04,
+          lng: -2.99,
+          authorityId: 10,
+          total: 3, // below the >=10 coverage gate -> never published, no redirect
+          statusBreakdown: [{ appState: 'Permitted', count: 3 }],
+          applications: [],
+        },
+      ],
+      authorityList: [{ id: 10, name: 'Wrexham' }],
+    });
+
+    // gated out for coverage, not same-name; a never-published URL needs no 301.
+    expect(result.redirects).toEqual([]);
+    expect(result.excludedTowns).toContainEqual({
+      name: 'Wrexham',
+      reason: 'coverage',
+    });
+  });
+});

--- a/web/scripts/lib/__tests__/redirect-config.test.mjs
+++ b/web/scripts/lib/__tests__/redirect-config.test.mjs
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import { mergeRedirects } from '../redirect-config.mjs';
+
+// tc-77ll: suppressed same-name town URLs are in the sitemap and likely indexed.
+// Stopping emission alone leaves them to the SWA navigationFallback (200 + SPA
+// shell = soft-404, worse than the dup). mergeRedirects folds a 301 for each
+// suppressed URL into the hand-written base staticwebapp.config.json.
+const baseConfig = Object.freeze({
+  navigationFallback: {
+    rewrite: '/index.html',
+    exclude: ['*.{css,js,svg,png}'],
+  },
+  globalHeaders: { 'X-Frame-Options': 'DENY' },
+  routes: [
+    { route: '/assets/*', headers: { 'Cache-Control': 'public' } },
+    {
+      route: '/.well-known/apple-app-site-association',
+      rewrite: '/.well-known/aasa.json',
+    },
+  ],
+});
+
+describe('mergeRedirects', () => {
+  it('appends a 301 redirect route for each suppressed same-name town path', () => {
+    const merged = mergeRedirects(baseConfig, ['wrexham/wrexham']);
+    expect(merged.routes).toContainEqual({
+      route: '/planning/wrexham/wrexham',
+      redirect: '/planning/wrexham',
+      statusCode: 301,
+    });
+  });
+
+  it('keeps every hand-written base route intact (never drops them)', () => {
+    const merged = mergeRedirects(baseConfig, ['birmingham/birmingham']);
+    expect(merged.routes).toContainEqual({
+      route: '/assets/*',
+      headers: { 'Cache-Control': 'public' },
+    });
+    expect(merged.routes).toContainEqual({
+      route: '/.well-known/apple-app-site-association',
+      rewrite: '/.well-known/aasa.json',
+    });
+    // base routes come first, generated redirects appended after.
+    expect(merged.routes).toHaveLength(baseConfig.routes.length + 1);
+  });
+
+  it('preserves the rest of the base config (navigationFallback, globalHeaders)', () => {
+    const merged = mergeRedirects(baseConfig, ['york/york']);
+    expect(merged.navigationFallback).toEqual(baseConfig.navigationFallback);
+    expect(merged.globalHeaders).toEqual(baseConfig.globalHeaders);
+  });
+
+  it('derives the redirect target from the first (authority) path segment', () => {
+    const merged = mergeRedirects(baseConfig, ['stockton-on-tees/stockton-on-tees']);
+    const added = merged.routes.find((r) =>
+      r.route === '/planning/stockton-on-tees/stockton-on-tees',
+    );
+    expect(added).toEqual({
+      route: '/planning/stockton-on-tees/stockton-on-tees',
+      redirect: '/planning/stockton-on-tees',
+      statusCode: 301,
+    });
+  });
+
+  it('returns the base routes unchanged when there are no redirects', () => {
+    const merged = mergeRedirects(baseConfig, []);
+    expect(merged.routes).toEqual(baseConfig.routes);
+  });
+
+  it('dedupes repeated paths into a single redirect route', () => {
+    const merged = mergeRedirects(baseConfig, [
+      'derby/derby',
+      'derby/derby',
+    ]);
+    const derbyRoutes = merged.routes.filter(
+      (r) => r.route === '/planning/derby/derby',
+    );
+    expect(derbyRoutes).toHaveLength(1);
+  });
+
+  it('does not mutate the base config', () => {
+    const before = baseConfig.routes.length;
+    mergeRedirects(baseConfig, ['leeds/leeds']);
+    expect(baseConfig.routes).toHaveLength(before);
+  });
+
+  it('tolerates a base config with no routes array', () => {
+    const merged = mergeRedirects(
+      { navigationFallback: { rewrite: '/index.html' } },
+      ['bath/bath'],
+    );
+    expect(merged.routes).toEqual([
+      {
+        route: '/planning/bath/bath',
+        redirect: '/planning/bath',
+        statusCode: 301,
+      },
+    ]);
+  });
+});

--- a/web/scripts/lib/__tests__/same-name.test.mjs
+++ b/web/scripts/lib/__tests__/same-name.test.mjs
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { isSameNameAsAuthority } from '../same-name.mjs';
+
+// tc-77ll: a town whose normalized slug equals its authority's slug duplicates
+// the stronger authority page with an identical <title>, so it must be
+// suppressed and 301-redirected. The helper decides "is this town the same place
+// as its authority?" on the NORMALIZED slug, never the raw display name.
+describe('isSameNameAsAuthority', () => {
+  describe('strict slug equality (catches all current collisions)', () => {
+    it('matches when the authority name slugifies to the town slug', () => {
+      expect(isSameNameAsAuthority('Wrexham', 'wrexham')).toBe(true);
+      expect(isSameNameAsAuthority('Birmingham', 'birmingham')).toBe(true);
+      expect(isSameNameAsAuthority('York', 'york')).toBe(true);
+    });
+
+    it('matches hyphenated names on their slug, not the display string', () => {
+      expect(isSameNameAsAuthority('Stockton-on-Tees', 'stockton-on-tees')).toBe(
+        true,
+      );
+    });
+
+    it('matches names with ampersands/apostrophes via the shared slugify', () => {
+      // slugify expands & -> "and" and strips apostrophes, so a same-place town
+      // page would carry the expanded slug.
+      expect(
+        isSameNameAsAuthority("King's Lynn and West Norfolk", 'kings-lynn-and-west-norfolk'),
+      ).toBe(true);
+    });
+  });
+
+  describe('forward-looking normalization (no-op on current plain data)', () => {
+    // The committed authorities.json carries PLAIN names today ("Bristol",
+    // "Herefordshire", "Wrexham"), so these synthetic raw-PlanIt forms prove the
+    // normalization works if a future authorities.json ever carries them.
+    it('strips a trailing ", City of" administrative suffix', () => {
+      expect(isSameNameAsAuthority('Bristol, City of', 'bristol')).toBe(true);
+    });
+
+    it('strips a trailing ", County of" administrative suffix', () => {
+      expect(
+        isSameNameAsAuthority('Herefordshire, County of', 'herefordshire'),
+      ).toBe(true);
+    });
+
+    it('strips a multi-word base name with a ", City of" suffix', () => {
+      expect(
+        isSameNameAsAuthority('Kingston upon Hull, City of', 'kingston-upon-hull'),
+      ).toBe(true);
+    });
+
+    it('strips a bilingual slash variant down to its first segment', () => {
+      expect(isSameNameAsAuthority('Wrexham / Wrecsam', 'wrexham')).toBe(true);
+      expect(isSameNameAsAuthority('Anglesey / Ynys Môn', 'anglesey')).toBe(true);
+    });
+
+    it('strips a bilingual trailing parenthetical', () => {
+      expect(isSameNameAsAuthority('Wrexham (Wrecsam)', 'wrexham')).toBe(true);
+    });
+  });
+
+  describe('does NOT over-match distinct nearby places', () => {
+    it('"Hull" does not suppress town "Kingston upon Hull"', () => {
+      expect(isSameNameAsAuthority('Hull', 'kingston-upon-hull')).toBe(false);
+    });
+
+    it('"Herefordshire" does not suppress town "Hereford"', () => {
+      expect(isSameNameAsAuthority('Herefordshire', 'hereford')).toBe(false);
+    });
+
+    it('an authority does not suppress a genuinely different town in it', () => {
+      expect(isSameNameAsAuthority('Cornwall', 'truro')).toBe(false);
+    });
+
+    it('a disambiguating "(District)" parenthetical does not suppress a sibling town', () => {
+      // "New Forest (District)" normalizes to "new-forest"; its towns (Lymington,
+      // Totton, ...) are NOT slugged "new-forest", so none is wrongly suppressed.
+      expect(isSameNameAsAuthority('New Forest (District)', 'lymington')).toBe(
+        false,
+      );
+      expect(isSameNameAsAuthority('Northumberland (County)', 'morpeth')).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/web/scripts/lib/redirect-config.mjs
+++ b/web/scripts/lib/redirect-config.mjs
@@ -1,0 +1,53 @@
+/**
+ * Static Web Apps redirect-config merge for the same-name SEO dedup (tc-77ll /
+ * #717). Suppressed `/planning/<x>/<x>` town URLs are in the sitemap and likely
+ * indexed; simply not emitting their HTML leaves them to the SWA
+ * `navigationFallback` (a 200 + SPA shell = soft-404, worse than the duplicate).
+ * Instead the prerender folds a permanent (301) redirect to the owning authority
+ * page into the hand-written base `staticwebapp.config.json`.
+ *
+ * This module is pure: it takes the parsed base config plus the set of
+ * suppressed town paths and returns a new merged config. The prerender reads the
+ * base from `web/public/staticwebapp.config.json`, calls this, and writes the
+ * result into the build's outDir (`web/dist`).
+ *
+ * Route-count headroom: SWA allows far more routes than we generate. Even at the
+ * full gazetteer there are ≤151 same-name redirects plus a handful of base
+ * routes — comfortably within the SWA limit.
+ */
+
+/**
+ * Merge generated 301 redirect routes for suppressed same-name town pages into a
+ * base Static Web Apps config, without dropping any hand-written base route or
+ * disturbing the rest of the config (navigationFallback, globalHeaders, ...).
+ *
+ * Each path is the suppressed town's path relative to `/planning` (e.g.
+ * `"wrexham/wrexham"`); the redirect target is the authority page derived from
+ * the first (authority-slug) segment. Duplicate paths collapse to one route.
+ *
+ * @param {{ routes?: Array<object> } & Record<string, unknown>} baseConfig
+ * @param {ReadonlyArray<string>} redirectPaths suppressed town paths ("<auth>/<town>")
+ * @returns {{ routes: Array<object> } & Record<string, unknown>} a new merged config
+ */
+export function mergeRedirects(baseConfig, redirectPaths) {
+  const seen = new Set();
+  /** @type {Array<object>} */
+  const redirectRoutes = [];
+  for (const path of redirectPaths) {
+    const route = `/planning/${path}`;
+    if (seen.has(route)) {
+      continue;
+    }
+    seen.add(route);
+    const authoritySlug = path.split('/')[0];
+    redirectRoutes.push({
+      route,
+      redirect: `/planning/${authoritySlug}`,
+      statusCode: 301,
+    });
+  }
+  return {
+    ...baseConfig,
+    routes: [...(baseConfig.routes ?? []), ...redirectRoutes],
+  };
+}

--- a/web/scripts/lib/same-name.mjs
+++ b/web/scripts/lib/same-name.mjs
@@ -1,0 +1,72 @@
+/**
+ * Same-name dedup decision for the programmatic SEO town pages (tc-77ll / #717).
+ *
+ * A town page at `/planning/<authority>/<town>` whose town slug equals its
+ * authority's slug (e.g. `/planning/wrexham/wrexham`) duplicates the stronger
+ * authority page `/planning/wrexham` with an IDENTICAL `<title>`. That is
+ * keyword cannibalization: two URLs competing for the same query, splitting link
+ * equity. The authority page is the broader, stronger page and should own the
+ * `<name> planning` query outright, so the same-name town page is suppressed.
+ *
+ * The decision is made on the NORMALIZED slug, never the raw display name.
+ * Strict `slugify(authorityName) === town.slug` catches every collision in the
+ * current committed data (151 of them). The extra normalization below is purely
+ * forward-looking: it is a NO-OP against today's plain authority names
+ * ("Bristol", "Hull", "Herefordshire", "Wrexham") and only bites IF a future
+ * `authorities.json` ever carries PlanIt's raw administrative/bilingual forms
+ * ("Bristol, City of", "Wrexham / Wrecsam"). It is deliberately conservative so
+ * it never over-matches a genuinely different nearby place — "Hull" must not
+ * suppress "Kingston upon Hull", and "Herefordshire" must not suppress
+ * "Hereford" (their slugs differ).
+ */
+
+import { slugify } from './slug.mjs';
+
+/**
+ * Reduce a PlanIt authority display name to the underlying place name so it is
+ * comparable to a town slug, stripping forward-looking administrative/bilingual
+ * decorations. Applied in addition to (never instead of) the strict slug match.
+ *
+ *   "Bristol, City of"      -> "Bristol"
+ *   "Herefordshire, County of" -> "Herefordshire"
+ *   "Wrexham / Wrecsam"     -> "Wrexham"
+ *   "Wrexham (Wrecsam)"     -> "Wrexham"
+ *   "Wrexham"               -> "Wrexham"  (no-op)
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+function canonicalAuthorityName(name) {
+  let n = name;
+  // Bilingual slash variant ("Anglesey / Ynys Môn") — keep the first segment.
+  const slash = n.indexOf('/');
+  if (slash !== -1) {
+    n = n.slice(0, slash);
+  }
+  // Trailing parenthetical ("Wrexham (Wrecsam)") — drop it. Disambiguating
+  // parentheticals like "New Forest (District)" collapse to "New Forest" too,
+  // which is harmless: no town in such an authority is slugged with the bare
+  // base name, so nothing is wrongly suppressed.
+  n = n.replace(/\s*\([^)]*\)\s*$/, '');
+  // Administrative suffix ("Bristol, City of" / "Herefordshire, County of").
+  n = n.replace(/,\s*(?:city|county)\s+of\s*$/i, '');
+  return n.trim();
+}
+
+/**
+ * Decide whether a town is the same place as its parent authority — i.e. its
+ * page would cannibalize the authority page — and so should be suppressed.
+ *
+ * @param {string} authorityName  the authority's display name (PlanIt area name)
+ * @param {string} townSlug       the town's URL slug from the gazetteer
+ * @returns {boolean} true when the town duplicates its authority page
+ */
+export function isSameNameAsAuthority(authorityName, townSlug) {
+  // Strict equality first — this alone catches every current collision.
+  if (slugify(authorityName) === townSlug) {
+    return true;
+  }
+  // Forward-looking: a normalized administrative/bilingual form may still denote
+  // the same place even when the raw name's slug differs.
+  return slugify(canonicalAuthorityName(authorityName)) === townSlug;
+}

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -45,6 +45,8 @@ import { renderPlanningPage } from './lib/render-page.mjs';
 import { renderTownPage } from './lib/render-town-page.mjs';
 import { resolveAuthority, townPagePath } from './lib/town-path.mjs';
 import { renderSitemap } from './lib/render-sitemap.mjs';
+import { isSameNameAsAuthority } from './lib/same-name.mjs';
+import { mergeRedirects } from './lib/redirect-config.mjs';
 
 const DEFAULT_LIMIT = 30;
 
@@ -172,6 +174,21 @@ export const AUTHORITIES_FILE = join(
 export const TOWNS_FILE = join(SCRIPT_DIR, '..', 'src', 'data', 'towns.json');
 
 /**
+ * The hand-written base Static Web Apps config (`navigationFallback`,
+ * `globalHeaders`, `routes`). Vite copies `public/` -> `dist/` BEFORE the
+ * prerender runs, so this is also present in the outDir; we deliberately read
+ * the SOURCE here (so re-running the prerender never double-merges) and write the
+ * merged result — base routes plus the same-name 301 redirects — into the outDir.
+ * @type {string}
+ */
+export const BASE_SWA_CONFIG_FILE = join(
+  SCRIPT_DIR,
+  '..',
+  'public',
+  'staticwebapp.config.json',
+);
+
+/**
  * @typedef {import('./lib/render-sitemap.mjs').SitemapEntry} SitemapEntry
  */
 
@@ -183,6 +200,7 @@ export const TOWNS_FILE = join(SCRIPT_DIR, '..', 'src', 'data', 'towns.json');
  * @property {Array<{ name: string, reason: string }>} excluded
  * @property {string[]} publishedTowns                  town paths written (<authority>/<town>)
  * @property {Array<{ name: string, reason: string }>} excludedTowns
+ * @property {string[]} [redirects]                     suppressed same-name town paths 301'd to their authority page
  */
 
 /**
@@ -361,6 +379,31 @@ async function writePage(outDir, data) {
 }
 
 /**
+ * Read the hand-written base SWA config, merge a 301 redirect for every
+ * suppressed same-name town page (tc-77ll), and write the result into the build
+ * outDir. Without this, a suppressed `/planning/<x>/<x>` URL would fall through
+ * `navigationFallback` to `index.html` (a 200 SPA shell = soft-404, worse than
+ * the duplicate it replaced). The merged route set stays well within the SWA
+ * route-count limit (≤151 redirects plus a handful of base routes).
+ *
+ * @param {Object} args
+ * @param {string} args.outDir
+ * @param {ReadonlyArray<string>} args.redirects   suppressed town paths ("<auth>/<town>")
+ * @param {string} args.baseConfigPath             source base config (web/public/staticwebapp.config.json)
+ * @returns {Promise<void>}
+ */
+async function writeRedirectConfig({ outDir, redirects, baseConfigPath }) {
+  const raw = await readFile(baseConfigPath, 'utf-8');
+  const baseConfig = JSON.parse(raw);
+  const merged = mergeRedirects(baseConfig, redirects);
+  await writeFile(
+    join(outDir, 'staticwebapp.config.json'),
+    `${JSON.stringify(merged, null, 2)}\n`,
+    'utf-8',
+  );
+}
+
+/**
  * Render and write a page if the authority qualifies and clears the gate.
  * Mutates `published`/`excluded`/`seenSlugs` and returns nothing.
  *
@@ -511,6 +554,8 @@ async function writeTownPage(outDir, data) {
  * @param {string[]} args.publishedTowns
  * @param {SitemapEntry[]} args.sitemapEntries           parallel { path, lastmod } records
  * @param {Array<{ name: string, reason: string }>} args.excludedTowns
+ * @param {string[]} args.redirects
+ *   suppressed same-name town paths to 301-redirect to their authority page
  * @param {Set<string>} args.seenPaths
  * @param {Map<number, Array<{ name: string, slug: string }>>} args.townsByAuthority
  *   accumulates each published town under its parent authorityId so the (later)
@@ -530,6 +575,7 @@ async function considerTown(args) {
     publishedTowns,
     sitemapEntries,
     excludedTowns,
+    redirects,
     seenPaths,
     townsByAuthority,
     logger,
@@ -544,6 +590,21 @@ async function considerTown(args) {
     town.authorityId,
     authorities,
   );
+
+  // Same-name dedup (tc-77ll / #717): a town whose NORMALIZED slug equals its
+  // authority's slug (e.g. /planning/wrexham/wrexham vs /planning/wrexham)
+  // duplicates the stronger authority page with an identical <title>. Suppress
+  // it — no page, no sitemap entry, and (by returning before townsByAuthority is
+  // touched) no self-link from the authority page — and record a 301 to the
+  // authority page so the dead, likely-indexed URL is not a soft-404. Only
+  // reached after the coverage gate, so a same-name town that never published
+  // gets no redirect.
+  if (isSameNameAsAuthority(authorityName, town.slug)) {
+    excludedTowns.push({ name: town.name, reason: 'same-name' });
+    redirects.push(townPagePath(authoritySlug, town.slug));
+    return;
+  }
+
   const path = townPagePath(authoritySlug, town.slug);
   if (seenPaths.has(path)) {
     logger.warn(`[prerender] duplicate town path "${path}" — skipped`);
@@ -595,7 +656,7 @@ async function considerTown(args) {
  * @param {(town: Town) => Promise<{ applications: object[], total: number, statusBreakdown: object[] }>} args.getGeo
  * @param {number} args.limit
  * @param {{ warn: (msg: string) => void }} args.logger
- * @returns {Promise<{ publishedTowns: string[], townSitemapEntries: SitemapEntry[], excludedTowns: Array<{ name: string, reason: string }>, townsByAuthority: Map<number, Array<{ name: string, slug: string }>> }>}
+ * @returns {Promise<{ publishedTowns: string[], townSitemapEntries: SitemapEntry[], excludedTowns: Array<{ name: string, reason: string }>, townsByAuthority: Map<number, Array<{ name: string, slug: string }>>, redirects: string[] }>}
  */
 async function renderTownPages(args) {
   const { outDir, towns, authorities, getGeo, limit, logger } = args;
@@ -606,6 +667,9 @@ async function renderTownPages(args) {
   const townSitemapEntries = [];
   /** @type {Array<{ name: string, reason: string }>} */
   const excludedTowns = [];
+  // Suppressed same-name town paths (tc-77ll), to be 301'd to their authority.
+  /** @type {string[]} */
+  const redirects = [];
   const seenPaths = new Set();
   // Published towns keyed by parent authorityId — handed to the authority pass so
   // each authority page can link down to its own (gated-in) town children.
@@ -627,13 +691,20 @@ async function renderTownPages(args) {
       publishedTowns,
       sitemapEntries: townSitemapEntries,
       excludedTowns,
+      redirects,
       seenPaths,
       townsByAuthority,
       logger,
     });
   }
 
-  return { publishedTowns, townSitemapEntries, excludedTowns, townsByAuthority };
+  return {
+    publishedTowns,
+    townSitemapEntries,
+    excludedTowns,
+    townsByAuthority,
+    redirects,
+  };
 }
 
 /**
@@ -652,12 +723,20 @@ async function renderTownPages(args) {
  * @param {ReadonlyArray<Town & { total: number, statusBreakdown?: object[], applications?: object[] }>} args.townEntries
  * @param {ReadonlyArray<{ id: number, name: string }>} args.authorities  resolves a town's parent-authority slug
  * @param {number} args.limit
+ * @param {string} [args.baseConfigPath]  base SWA config to merge same-name 301s into
  * @param {{ warn: (msg: string) => void }} args.logger
  * @returns {Promise<PrerenderResult>}
  */
 async function renderEntries(args) {
-  const { outDir, authorityEntries, townEntries, authorities, limit, logger } =
-    args;
+  const {
+    outDir,
+    authorityEntries,
+    townEntries,
+    authorities,
+    limit,
+    baseConfigPath = BASE_SWA_CONFIG_FILE,
+    logger,
+  } = args;
 
   // Town pass FIRST: an authority page must link only to towns that actually
   // published (cleared the coverage gate), so the per-authority town map has to
@@ -665,21 +744,26 @@ async function renderEntries(args) {
   // order is immaterial. Town entries carry the geo projection inline, so
   // `getGeo` is a pure lookup — no network. With zero town entries the loop is a
   // no-op and `authorities` is never consulted.
-  const { publishedTowns, townSitemapEntries, excludedTowns, townsByAuthority } =
-    await renderTownPages({
-      outDir,
-      towns: townEntries,
-      authorities,
-      getGeo: async (town) => ({
-        applications: Array.isArray(town.applications) ? town.applications : [],
-        total: town.total,
-        statusBreakdown: Array.isArray(town.statusBreakdown)
-          ? town.statusBreakdown
-          : [],
-      }),
-      limit,
-      logger,
-    });
+  const {
+    publishedTowns,
+    townSitemapEntries,
+    excludedTowns,
+    townsByAuthority,
+    redirects,
+  } = await renderTownPages({
+    outDir,
+    towns: townEntries,
+    authorities,
+    getGeo: async (town) => ({
+      applications: Array.isArray(town.applications) ? town.applications : [],
+      total: town.total,
+      statusBreakdown: Array.isArray(town.statusBreakdown)
+        ? town.statusBreakdown
+        : [],
+    }),
+    limit,
+    logger,
+  });
 
   /** @type {string[]} */
   const published = [];
@@ -720,7 +804,15 @@ async function renderEntries(args) {
     renderSitemap([...authoritySitemapEntries, ...townSitemapEntries]),
     'utf-8',
   );
-  return { skipped: false, published, excluded, publishedTowns, excludedTowns };
+  await writeRedirectConfig({ outDir, redirects, baseConfigPath });
+  return {
+    skipped: false,
+    published,
+    excluded,
+    publishedTowns,
+    excludedTowns,
+    redirects,
+  };
 }
 
 /**
@@ -729,13 +821,21 @@ async function renderEntries(args) {
  * @param {string} args.fixturePath               authority fixture (optional)
  * @param {string} [args.townFixturePath]         town fixture (optional)
  * @param {number} args.limit
+ * @param {string} [args.baseConfigPath]          base SWA config for same-name 301s
  * @param {() => Promise<Array<{ id: number, name: string, areaType: string }>>} args.loadAuthorities
  * @param {{ warn: (msg: string) => void }} args.logger
  * @returns {Promise<PrerenderResult>}
  */
 async function runFixtureMode(args) {
-  const { outDir, fixturePath, townFixturePath, limit, loadAuthorities, logger } =
-    args;
+  const {
+    outDir,
+    fixturePath,
+    townFixturePath,
+    limit,
+    baseConfigPath,
+    loadAuthorities,
+    logger,
+  } = args;
 
   /** @type {Array<{ id: number, name: string, areaType: string }>} */
   let authorityEntries = [];
@@ -768,6 +868,7 @@ async function runFixtureMode(args) {
     townEntries,
     authorities,
     limit,
+    baseConfigPath,
     logger,
   });
 }
@@ -779,6 +880,7 @@ async function runFixtureMode(args) {
  * @param {string} args.buildKey
  * @param {number} args.limit
  * @param {number} args.minPopulation
+ * @param {string} [args.baseConfigPath]  base SWA config for same-name 301s
  * @param {typeof globalThis.fetch} args.fetchImpl
  * @param {() => Promise<Array<{ id: number, name: string, areaType: string }>>} args.loadAuthorities
  * @param {() => Promise<Town[]>} args.loadTowns
@@ -792,6 +894,7 @@ async function runLiveMode(args) {
     buildKey,
     limit,
     minPopulation,
+    baseConfigPath = BASE_SWA_CONFIG_FILE,
     fetchImpl,
     loadAuthorities,
     loadTowns,
@@ -823,16 +926,21 @@ async function runLiveMode(args) {
     }
   }
 
-  const { publishedTowns, townSitemapEntries, excludedTowns, townsByAuthority } =
-    await renderTownPages({
-      outDir,
-      towns: eligibleTowns,
-      authorities,
-      getGeo: (town) =>
-        fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl),
-      limit,
-      logger,
-    });
+  const {
+    publishedTowns,
+    townSitemapEntries,
+    excludedTowns,
+    townsByAuthority,
+    redirects,
+  } = await renderTownPages({
+    outDir,
+    towns: eligibleTowns,
+    authorities,
+    getGeo: (town) =>
+      fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl),
+    limit,
+    logger,
+  });
   excludedTowns.push(...populationExcludedTowns);
 
   /** @type {string[]} */
@@ -879,7 +987,15 @@ async function runLiveMode(args) {
     renderSitemap([...authoritySitemapEntries, ...townSitemapEntries]),
     'utf-8',
   );
-  return { skipped: false, published, excluded, publishedTowns, excludedTowns };
+  await writeRedirectConfig({ outDir, redirects, baseConfigPath });
+  return {
+    skipped: false,
+    published,
+    excluded,
+    publishedTowns,
+    excludedTowns,
+    redirects,
+  };
 }
 
 /**
@@ -1010,6 +1126,7 @@ async function gatherSnapshot(args) {
  * @param {string} [options.townFixturePath]       committed town JSON fixture (fixture mode)
  * @param {number} [options.limit]                 applications rendered per page
  * @param {Record<string, string | undefined>} [options.env]  environment (for SEO_TOWN_MIN_POPULATION)
+ * @param {string} [options.baseConfigPath]        base SWA config to merge same-name 301s into
  * @param {typeof globalThis.fetch} [options.fetchImpl]
  * @param {() => Promise<Array<{ id: number, name: string, areaType: string }>>} [options.loadAuthorities]
  * @param {() => Promise<Town[]>} [options.loadTowns]
@@ -1025,6 +1142,7 @@ export async function runPrerender(options) {
     townFixturePath,
     limit = DEFAULT_LIMIT,
     env = process.env,
+    baseConfigPath = BASE_SWA_CONFIG_FILE,
     fetchImpl = globalThis.fetch,
     loadAuthorities = () => loadAuthoritiesFromFile(AUTHORITIES_FILE, readFile),
     loadTowns = () => loadTownsFromFile(TOWNS_FILE, readFile),
@@ -1037,6 +1155,7 @@ export async function runPrerender(options) {
       fixturePath,
       townFixturePath,
       limit,
+      baseConfigPath,
       loadAuthorities,
       logger,
     });
@@ -1050,6 +1169,7 @@ export async function runPrerender(options) {
       excluded: [],
       publishedTowns: [],
       excludedTowns: [],
+      redirects: [],
     };
   }
 
@@ -1065,6 +1185,7 @@ export async function runPrerender(options) {
     buildKey,
     limit,
     minPopulation: resolveMinPopulation(env),
+    baseConfigPath,
     fetchImpl,
     loadAuthorities,
     loadTowns,
@@ -1171,6 +1292,7 @@ function assertValidSnapshot(snapshot, snapshotPath) {
  * @param {string} options.outDir
  * @param {string} options.snapshotPath
  * @param {number} [options.limit]                  override; defaults to the snapshot's own
+ * @param {string} [options.baseConfigPath]         base SWA config to merge same-name 301s into
  * @param {(path: string, encoding: string) => Promise<string>} [options.readFileImpl]
  * @param {{ log: Function, warn: Function, error: Function }} [options.logger]
  * @returns {Promise<PrerenderResult>}
@@ -1180,6 +1302,7 @@ export async function runRender(options) {
     outDir,
     snapshotPath,
     limit,
+    baseConfigPath = BASE_SWA_CONFIG_FILE,
     readFileImpl = readFile,
     logger = console,
   } = options;
@@ -1221,6 +1344,7 @@ export async function runRender(options) {
     townEntries: snapshot.townPages,
     authorities: snapshot.authorities,
     limit: renderLimit,
+    baseConfigPath,
     logger,
   });
 }


### PR DESCRIPTION
Closes #717. Two tuning slices for the programmatic SEO town pages, one PR.

## Changes

**Part A — same-name dedup (`/web`, tc-77ll)**
- `web/scripts/lib/same-name.mjs` (new) — `isSameNameAsAuthority(authorityName, townSlug)`: strict `slugify(authority)===townSlug` (catches all 151 collisions in current data) plus a conservative, forward-looking normalization that strips `, City of` / `, County of` and bilingual `Name / X` / `Name (X)` forms. Verified NO-OP against today's plain authority names — does not over-match (Hull≠Kingston upon Hull, Herefordshire≠Hereford stay distinct).
- `web/scripts/lib/redirect-config.mjs` (new) — `mergeRedirects(baseConfig, redirectPaths)`: folds a `{route:/planning/<x>/<x>, redirect:/planning/<x>, statusCode:301}` per suppressed town into the hand-written SWA base config, dedupes, preserves all base routes/navigationFallback/globalHeaders.
- `web/scripts/prerender-planning.mjs` — in `considerTown`, after the coverage gate passes, same-name towns are suppressed (no page, no sitemap entry, not added to `townsByAuthority` so the authority page never self-links) and a 301 is recorded. `writeRedirectConfig` reads `web/public/staticwebapp.config.json`, merges, and writes the result to the build outDir; wired into both live and `--render` modes.
- Avoids the SWA soft-404 trap: suppressed URLs 301 to their authority page instead of falling through `navigationFallback` to the SPA shell.

**Part B — lower the floor + build timeout (`.github/`, tc-59za, folds tc-75qo)**
- `SEO_TOWN_MIN_POPULATION` fallback `|| '20000'` → `|| '5000'` across all 6 refs (cd-dev ×1, cd-prod ×1, seo-refresh ×4), the build-web action input default, and the seo-refresh comment. Repo Actions variable already set to `5000`.
- cd-dev + cd-prod web-deploy `timeout-minutes` `10` → `30` so the ~2.9x-larger gazetteer build doesn't time out.

## Notes
- 137 (live same-name pages at the 20k floor) vs 151 (full-gazetteer same-name set) reconcile — redirects are recorded only after the coverage gate passes, so a never-published same-name URL gets no 301.
- The `≥10 apps / 90 days` coverage gate remains the anti-thin-content backstop.

## Tests
- Full web suite: **922 passed / 0 failed** (108 files), incl. new same-name (12), redirect-config (8), prerender-dedup (7) tests. `tsc --noEmit` + `npm run build` clean.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * More town SEO pages will now be generated and refreshed by default, increasing coverage for smaller towns.
  * Same-name town pages are now handled more cleanly by directing visitors to the matching authority page.

* **Bug Fixes**
  * Improved handling of town/authority name collisions to reduce duplicate or incorrect page generation.
  * Deployment workflows now allow more time to complete, lowering the chance of timeouts during builds and releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->