### PR TITLE
feat(api): cluster wire shape carries capped applicationIds for unsplittable cells (#722)

### DIFF
--- a/api-go/internal/applications/zoneclusters.go
+++ b/api-go/internal/applications/zoneclusters.go
@@ -23,34 +23,47 @@ type PlanningApplicationID struct {
 // returned by FindClustersInZone. Latitude/Longitude is the centroid of the
 // bucket's member points; Count is how many applications fall in the cell;
 // StatusCounts is the per-app_state breakdown (it always sums to Count, with a
-// NULL or unrecognised app_state folded under the "Unknown" key). Member is set
-// only when Count == 1, identifying the single application so the client renders a
-// real status-coloured pin and a tap opens the summary sheet; for a multi-member
-// cell it is nil and the client renders a count bubble.
+// NULL or unrecognised app_state folded under the "Unknown" key).
+//
+// Member and Members are independent:
+//   - Member is set only when Count == 1, identifying the single application so the
+//     client renders a real status-coloured pin and a tap opens the summary sheet.
+//   - Members (JSON applicationIds) is the capped disambiguation list, populated
+//     ONLY for an unsplittable multi-member cell — one whose member-point extent
+//     has already collapsed below the finest (zoom-20) grid cell, so no further
+//     zoom could separate the pins. For every splittable cell it is nil and the
+//     wire field is omitted (omitempty), leaving today's "tap to zoom in"
+//     behaviour untouched.
 type Cluster struct {
-	Latitude     float64                `json:"latitude"`
-	Longitude    float64                `json:"longitude"`
-	Count        int                    `json:"count"`
-	StatusCounts map[string]int         `json:"statusCounts"`
-	Member       *PlanningApplicationID `json:"applicationId"`
+	Latitude     float64                 `json:"latitude"`
+	Longitude    float64                 `json:"longitude"`
+	Count        int                     `json:"count"`
+	StatusCounts map[string]int          `json:"statusCounts"`
+	Member       *PlanningApplicationID  `json:"applicationId"`
+	Members      []PlanningApplicationID `json:"applicationIds,omitempty"`
 }
 
 // ClusterQuery is the full request descriptor for FindClustersInZone: the zone
 // membership circle (Latitude, Longitude, RadiusMetres — the existing ST_DWithin
 // pattern), the visible map rectangle (West, South, East, North — WGS84 decimal
 // degrees), the grid cell size in degrees (GridSizeDegrees — derived from the
-// request's zoom by the handler, so the store stays a pure spatial primitive),
-// and an optional exact app_state filter (Status; "" means no status filter).
+// request's zoom by the handler, so the store stays a pure spatial primitive), an
+// optional exact app_state filter (Status; "" means no status filter), and the
+// coalesce threshold in degrees (CoalesceThresholdDegrees — the finest/zoom-20
+// grid cell size, also supplied by the handler: a multi-member cell whose member
+// points span less than this in both X and Y can never be split by zooming, so it
+// carries an applicationIds member list).
 type ClusterQuery struct {
-	Latitude        float64
-	Longitude       float64
-	RadiusMetres    float64
-	West            float64
-	South           float64
-	East            float64
-	North           float64
-	GridSizeDegrees float64
-	Status          string
+	Latitude                 float64
+	Longitude                float64
+	RadiusMetres             float64
+	West                     float64
+	South                    float64
+	East                     float64
+	North                    float64
+	GridSizeDegrees          float64
+	Status                   string
+	CoalesceThresholdDegrees float64
 }
 
 // clusterPoint is the zone-centre query point, built from $1 (longitude) and $2
@@ -59,70 +72,134 @@ const clusterPoint = "ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography"
 
 // The cluster query is a single PostGIS grid aggregation, mirroring the SEO
 // "GROUP BY app_state" rollup (store_postgres.go) plus ST_SnapToGrid to bucket by
-// cell. It runs in two stages within one statement:
+// cell. It runs as a chain of CTEs within one statement:
 //
-//   - per_cell_state pre-aggregates the in-radius, in-viewport applications by
-//     (grid cell, app_state): one row per state present in each cell, carrying the
-//     state's count, the collected member points, and the MIN (authority_code,
-//     planit_name) — which, for a single-member cell, is exactly that member.
-//   - the outer SELECT folds those rows up per cell: the centroid is the mean of
-//     all member points (ST_Centroid over the re-collected points), member_count
-//     is the SUM of the per-state counts, status_counts is jsonb_object_agg over
-//     the distinct per-cell states (NULL app_state folded to 'Unknown', so the
-//     object never has a NULL key and always sums to member_count), and the MIN
+//   - filtered selects the in-radius, in-viewport (and, for the by-status variant,
+//     in-state) applications once, each tagged with its grid cell, app_state,
+//     authority, name and point. Both downstream rollups read from it, so the
+//     status filter is applied in exactly one place and the member list can never
+//     name an application the filter excludes.
+//   - per_cell_state pre-aggregates filtered by (grid cell, app_state): one row per
+//     state present in each cell, carrying the state's count, the collected member
+//     points, and the MIN (authority, name).
+//   - per_cell folds those rows up per cell: the centroid is the mean of all member
+//     points (ST_Centroid over the re-collected points), member_count is the SUM of
+//     the per-state counts, status_counts is jsonb_object_agg over the distinct
+//     per-cell states (NULL app_state folded to 'Unknown'), and the MIN
 //     authority/name identify the single member when member_count = 1.
+//   - cell_meta computes, per cell, the member-point extent (ST_Extent → ST_XMax -
+//     ST_XMin, ST_YMax - ST_YMin) and, only for an unsplittable multi-member cell
+//     (member_count > 1 AND both extent deltas below the coalesce threshold $9),
+//     the capped {authority, name} member list as JSONB (jsonb_agg over a
+//     deterministically ordered LIMIT-50 subquery of that cell's members). Every
+//     other cell yields a NULL members column. Gating on the threshold keeps the
+//     LIMIT-50 subquery off the splittable hot path, and gating on member_count > 1
+//     keeps the common single-pin cell free of a redundant one-element list.
 //
 // Filter ($3 radius via ST_DWithin, served by the existing applications_location_gist
-// GiST index) AND ($5..$8 viewport via location::geometry && ST_MakeEnvelope).
-// Group by ST_SnapToGrid(location::geometry, $4) where $4 is GridSizeDegrees. A
-// safety LIMIT of 1000 cells (densest first) bounds a pathological viewport.
+// GiST index) AND ($5..$8 viewport via location::geometry && ST_MakeEnvelope). Group
+// by ST_SnapToGrid(location::geometry, $4) where $4 is GridSizeDegrees. A safety
+// LIMIT of 1000 cells (densest first) bounds a pathological viewport.
 //
-// $1 longitude, $2 latitude, $3 radiusMetres, $4 gridSizeDegrees,
-// $5 west, $6 south, $7 east, $8 north, and (clusterQueryByStatus only) $9 status.
-const clusterQueryHead = `WITH per_cell_state AS (
+// $1 longitude, $2 latitude, $3 radiusMetres, $4 gridSizeDegrees, $5 west,
+// $6 south, $7 east, $8 north, $9 coalesceThresholdDegrees, and (clusterQueryByStatus
+// only) $10 status.
+const clusterQueryHead = `WITH filtered AS (
 	SELECT
 		ST_SnapToGrid(location::geometry, $4) AS cell,
 		COALESCE(app_state, 'Unknown') AS state,
-		COUNT(*) AS n,
-		ST_Collect(location::geometry) AS geoms,
-		MIN(authority_code) AS authority,
-		MIN(planit_name) AS name
+		authority_code AS authority,
+		planit_name AS name,
+		location::geometry AS geom
 	FROM applications
 	WHERE ST_DWithin(location, ` + clusterPoint + `, $3)
 		AND location::geometry && ST_MakeEnvelope($5, $6, $7, $8, 4326)`
 
 const clusterQueryTail = `
-	GROUP BY cell, COALESCE(app_state, 'Unknown')
+),
+per_cell_state AS (
+	SELECT
+		cell,
+		state,
+		COUNT(*) AS n,
+		ST_Collect(geom) AS geoms,
+		MIN(authority) AS authority,
+		MIN(name) AS name
+	FROM filtered
+	GROUP BY cell, state
+),
+per_cell AS (
+	SELECT
+		cell,
+		ST_Y(ST_Centroid(ST_Collect(geoms))) AS centroid_lat,
+		ST_X(ST_Centroid(ST_Collect(geoms))) AS centroid_lon,
+		SUM(n)::bigint AS member_count,
+		jsonb_object_agg(state, n) AS status_counts,
+		MIN(authority) AS member_authority,
+		MIN(name) AS member_name
+	FROM per_cell_state
+	GROUP BY cell
+),
+cell_meta AS (
+	SELECT
+		base.cell AS cell,
+		CASE
+			WHEN COUNT(*) > 1
+				AND ST_XMax(ST_Extent(geom)) - ST_XMin(ST_Extent(geom)) < $9
+				AND ST_YMax(ST_Extent(geom)) - ST_YMin(ST_Extent(geom)) < $9
+			THEN (
+				-- Cap the member list at 50: a single address realistically holds a
+				-- handful to a couple of dozen applications, and 50 bounds the payload
+				-- against a pathological centroid-geocoded mega-site. A cell exceeding
+				-- 50 coincident members surfaces only the first 50 by (authority, name)
+				-- — an accepted edge. jsonb_agg has no LIMIT, hence the inner subquery.
+				SELECT jsonb_agg(jsonb_build_object('authority', m.authority, 'name', m.name))
+				FROM (
+					SELECT authority, name
+					FROM filtered f
+					WHERE f.cell = base.cell
+					ORDER BY authority, name
+					LIMIT 50
+				) m
+			)
+			ELSE NULL
+		END AS members
+	FROM filtered base
+	GROUP BY base.cell
 )
 SELECT
-	ST_Y(ST_Centroid(ST_Collect(geoms))) AS centroid_lat,
-	ST_X(ST_Centroid(ST_Collect(geoms))) AS centroid_lon,
-	SUM(n)::bigint AS member_count,
-	jsonb_object_agg(state, n) AS status_counts,
-	MIN(authority) AS member_authority,
-	MIN(name) AS member_name
-FROM per_cell_state
-GROUP BY cell
-ORDER BY member_count DESC
+	per_cell.centroid_lat,
+	per_cell.centroid_lon,
+	per_cell.member_count,
+	per_cell.status_counts,
+	per_cell.member_authority,
+	per_cell.member_name,
+	cell_meta.members
+FROM per_cell
+JOIN cell_meta ON cell_meta.cell = per_cell.cell
+ORDER BY per_cell.member_count DESC
 LIMIT 1000`
 
 const (
 	clusterQueryAllStatuses = clusterQueryHead + clusterQueryTail
-	clusterQueryByStatus    = clusterQueryHead + "\n\t\tAND app_state = $9" + clusterQueryTail
+	clusterQueryByStatus    = clusterQueryHead + "\n\t\tAND app_state = $10" + clusterQueryTail
 )
 
-// scanClusterRow hydrates one aggregated cell. status_counts is read as raw JSONB
-// and unmarshalled in Go (independent of the pgx jsonb codec). The member id is
-// attached only for a single-member cell.
+// scanClusterRow hydrates one aggregated cell. status_counts and the members list
+// are read as raw JSONB and unmarshalled in Go (independent of the pgx jsonb
+// codec). The single-member id is attached only for a Count == 1 cell; the member
+// list is attached only when the members column is non-NULL (an unsplittable
+// multi-member cell) — the two never both apply.
 func scanClusterRow(row pgx.CollectableRow) (Cluster, error) {
 	var (
-		c         Cluster
-		count     int64
-		rawCounts []byte
-		authority string
-		name      string
+		c          Cluster
+		count      int64
+		rawCounts  []byte
+		authority  string
+		name       string
+		rawMembers []byte
 	)
-	if err := row.Scan(&c.Latitude, &c.Longitude, &count, &rawCounts, &authority, &name); err != nil {
+	if err := row.Scan(&c.Latitude, &c.Longitude, &count, &rawCounts, &authority, &name, &rawMembers); err != nil {
 		return Cluster{}, err
 	}
 	c.Count = int(count)
@@ -132,18 +209,26 @@ func scanClusterRow(row pgx.CollectableRow) (Cluster, error) {
 	if count == 1 {
 		c.Member = &PlanningApplicationID{Authority: authority, Name: name}
 	}
+	if rawMembers != nil {
+		if err := json.Unmarshal(rawMembers, &c.Members); err != nil {
+			return Cluster{}, fmt.Errorf("decode cluster member list: %w", err)
+		}
+	}
 	return c, nil
 }
 
 // FindClustersInZone returns the grid-aggregated cluster bubbles for the viewport
 // q within the zone circle (q.Latitude, q.Longitude, q.RadiusMetres). Each Cluster
 // is a centroid + member count + per-app_state breakdown; a single-member cell also
-// carries the member's {authority, name}. An optional q.Status restricts the
-// aggregation to that exact app_state. It is authority-agnostic and never paged:
-// a viewport at a sane zoom yields a bounded number of cells (capped at 1000).
+// carries the member's {authority, name}, and an unsplittable multi-member cell
+// (member-point extent below q.CoalesceThresholdDegrees in both axes) carries the
+// capped applicationIds member list. An optional q.Status restricts the whole
+// aggregation — counts and member list alike — to that exact app_state. It is
+// authority-agnostic and never paged: a viewport at a sane zoom yields a bounded
+// number of cells (capped at 1000).
 func (s *PostgresStore) FindClustersInZone(ctx context.Context, q ClusterQuery) ([]Cluster, error) {
 	query := clusterQueryAllStatuses
-	args := []any{q.Longitude, q.Latitude, q.RadiusMetres, q.GridSizeDegrees, q.West, q.South, q.East, q.North}
+	args := []any{q.Longitude, q.Latitude, q.RadiusMetres, q.GridSizeDegrees, q.West, q.South, q.East, q.North, q.CoalesceThresholdDegrees}
 	if q.Status != "" {
 		query = clusterQueryByStatus
 		args = append(args, q.Status)

--- a/api-go/internal/applications/zoneclusters_integration_test.go
+++ b/api-go/internal/applications/zoneclusters_integration_test.go
@@ -72,6 +72,20 @@ func clusterQuery(gridSize float64, status string) ClusterQuery {
 	}
 }
 
+// finestGridDegrees mirrors the watchzones handler's coalesce threshold policy:
+// baseGridDegrees (45) / 2^maxZoom (20), the zoom-20 cell size (~4.29e-5 deg, ~5 m
+// at UK latitudes). A multi-member cell whose member points span less than this in
+// both axes can never be split by zooming, so it carries an applicationIds list.
+const finestGridDegrees = 45.0 / float64(uint64(1)<<20)
+
+// coalesceQuery is clusterQuery with the finest-grid coalesce threshold wired in,
+// exactly as the handler supplies it, so the member-list behaviour is exercised.
+func coalesceQuery(gridSize float64, status string) ClusterQuery {
+	q := clusterQuery(gridSize, status)
+	q.CoalesceThresholdDegrees = finestGridDegrees
+	return q
+}
+
 // directCount returns COUNT(*) over the same in-radius + in-bbox predicates the
 // cluster query applies, the independent reference for count conservation.
 func directCount(t *testing.T, store *PostgresStore, q ClusterQuery) int {
@@ -426,7 +440,7 @@ func TestPostgresStore_FindClustersInZone_ExplainUsesGiSTIndex(t *testing.T) {
 	ctx := context.Background()
 
 	q := clusterQuery(0.01, "")
-	args := append([]any{}, q.Longitude, q.Latitude, q.RadiusMetres, q.GridSizeDegrees, q.West, q.South, q.East, q.North)
+	args := append([]any{}, q.Longitude, q.Latitude, q.RadiusMetres, q.GridSizeDegrees, q.West, q.South, q.East, q.North, q.CoalesceThresholdDegrees)
 
 	// SET enable_seqscan = off and the EXPLAIN must run on the SAME connection
 	// (the setting is session state), so acquire one pooled connection for both.
@@ -466,3 +480,127 @@ func TestPostgresStore_FindClustersInZone_ExplainUsesGiSTIndex(t *testing.T) {
 }
 
 func floatNear(a, b, tol float64) bool { return math.Abs(a-b) <= tol }
+
+// memberNames projects a member list to its application names for set comparison.
+func memberNames(members []PlanningApplicationID) []string {
+	names := make([]string, len(members))
+	for i, m := range members {
+		names[i] = m.Name
+	}
+	return names
+}
+
+// equalStringSet reports whether a and b hold the same names (order-independent).
+func equalStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := map[string]int{}
+	for _, s := range a {
+		seen[s]++
+	}
+	for _, s := range b {
+		seen[s]--
+	}
+	for _, n := range seen {
+		if n != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// TestFindClustersInZone_CoincidentApplications_ReturnsMemberList is the honest
+// real-PostGIS coverage for the applicationIds member list — the ST_SnapToGrid /
+// ST_Extent behaviour a fake store cannot model:
+//
+//   - coincident points (a single address with several planning rounds) share a
+//     cell at the finest grid, their extent is 0 < threshold, so the cell carries
+//     the full member list — the dead-end the issue fixes;
+//   - a multi-member cell whose points span wider than the finest grid is still
+//     splittable by zoom, so its member list stays nil (unchanged behaviour);
+//   - the ?status= filter restricts the member list to matching applications, so a
+//     filtered map never lists an application the filter excludes.
+func TestFindClustersInZone_CoincidentApplications_ReturnsMemberList(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("coincident points at the finest grid surface the member list", func(t *testing.T) {
+		store := newAppPGStore(t)
+		// Three applications at the IDENTICAL coordinate: no grid size can split them.
+		for _, name := range []string{"A1", "A2", "A3"} {
+			if err := store.Upsert(ctx, clusterApp(name, 100, 0.0, 0.0)); err != nil {
+				t.Fatalf("Upsert %s: %v", name, err)
+			}
+		}
+
+		clusters, err := store.FindClustersInZone(ctx, coalesceQuery(finestGridDegrees, ""))
+		if err != nil {
+			t.Fatalf("FindClustersInZone: %v", err)
+		}
+		if len(clusters) != 1 {
+			t.Fatalf("got %d clusters, want 1 (coincident points share a cell at zoom 20)", len(clusters))
+		}
+		c := clusters[0]
+		if c.Count != 3 {
+			t.Errorf("count: got %d, want 3", c.Count)
+		}
+		if got, want := memberNames(c.Members), []string{"A1", "A2", "A3"}; !equalStringSet(got, want) {
+			t.Errorf("applicationIds names: got %v, want %v", got, want)
+		}
+		for _, m := range c.Members {
+			if m.Authority != "100" {
+				t.Errorf("member authority: got %q, want %q (area_id as decimal string)", m.Authority, "100")
+			}
+		}
+	})
+
+	t.Run("splittable multi-member cell yields a nil member list", func(t *testing.T) {
+		store := newAppPGStore(t)
+		// Two applications 0.001 deg apart — far wider than the finest grid cell.
+		// They fall in one coarse-grid cell now, but zooming in would separate them,
+		// so the cell is splittable and offers no member list.
+		for i, off := range [2]float64{0.000, 0.001} {
+			if err := store.Upsert(ctx, clusterApp("S"+strconv.Itoa(i), 100, off, 0.0)); err != nil {
+				t.Fatalf("Upsert: %v", err)
+			}
+		}
+
+		clusters, err := store.FindClustersInZone(ctx, coalesceQuery(0.01, ""))
+		if err != nil {
+			t.Fatalf("FindClustersInZone: %v", err)
+		}
+		if len(clusters) != 1 {
+			t.Fatalf("got %d clusters, want 1 coarse cell", len(clusters))
+		}
+		if clusters[0].Count != 2 {
+			t.Fatalf("count: got %d, want 2 (multi-member but splittable)", clusters[0].Count)
+		}
+		if clusters[0].Members != nil {
+			t.Errorf("splittable cell must have nil Members, got %v", clusters[0].Members)
+		}
+	})
+
+	t.Run("status filter restricts the member list", func(t *testing.T) {
+		store := newAppPGStore(t)
+		// Five coincident applications: three Permitted, two Rejected.
+		for _, s := range []struct{ name, state string }{
+			{"P1", "Permitted"}, {"P2", "Permitted"}, {"P3", "Permitted"},
+			{"R1", "Rejected"}, {"R2", "Rejected"},
+		} {
+			if err := store.Upsert(ctx, withState(clusterApp(s.name, 100, 0.0, 0.0), pgPtr(s.state))); err != nil {
+				t.Fatalf("Upsert %s: %v", s.name, err)
+			}
+		}
+
+		clusters, err := store.FindClustersInZone(ctx, coalesceQuery(finestGridDegrees, "Permitted"))
+		if err != nil {
+			t.Fatalf("FindClustersInZone: %v", err)
+		}
+		if len(clusters) != 1 {
+			t.Fatalf("got %d clusters, want 1", len(clusters))
+		}
+		if got, want := memberNames(clusters[0].Members), []string{"P1", "P2", "P3"}; !equalStringSet(got, want) {
+			t.Errorf("filtered applicationIds: got %v, want only the Permitted members %v", got, want)
+		}
+	})
+}

--- a/api-go/internal/applications/zoneclusters_integration_test.go
+++ b/api-go/internal/applications/zoneclusters_integration_test.go
@@ -1,0 +1,468 @@
+//go:build integration
+
+package applications
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// Cluster fixtures reuse the shared London centre (pgCentreLon/pgCentreLat) and
+// the pgApp/withState/pgPtr helpers from store_postgres_test.go. Points are placed
+// at explicit small degree offsets so the grid-snapping (ST_SnapToGrid) is
+// deterministic. The zone query always uses the centre + a generous radius so
+// membership is governed by the viewport, not the circle, except where a test
+// exercises the radius/bbox predicates directly.
+
+// clusterApp builds an in-radius application at the centre plus (dLng, dLat)
+// degrees, in the given authority, with the baseline nullable fields.
+func clusterApp(name string, areaID int, dLng, dLat float64) PlanningApplication {
+	a := pgApp(name, areaID)
+	a.Longitude = pgPtr(pgCentreLon + dLng)
+	a.Latitude = pgPtr(pgCentreLat + dLat)
+	return a
+}
+
+// wideBBox is a viewport comfortably containing every spread/coarse fixture point
+// (all within base + ~0.031 deg), as west,south,east,north.
+const (
+	bboxWest  = -0.2
+	bboxSouth = 51.48
+	bboxEast  = -0.05
+	bboxNorth = 51.55
+)
+
+// spreadOffsets are eight distinct (dLng, dLat) points spanning ~0.031 deg of
+// longitude in four tight pairs (pair members 0.001 deg apart, pairs 0.01 deg
+// apart). Snapping behaviour by cell size:
+//   - coarse 10 deg     -> all eight in one cell.
+//   - medium 0.01 deg   -> four cells (each pair shares a cell), two members each.
+//   - tiny 1e-6 deg     -> eight cells, one member each.
+var spreadOffsets = [8][2]float64{
+	{0.000, 0.000}, {0.001, 0.000},
+	{0.010, 0.000}, {0.011, 0.000},
+	{0.020, 0.010}, {0.021, 0.010},
+	{0.030, 0.020}, {0.031, 0.020},
+}
+
+// seedSpread inserts the eight spread points, all in authority 100.
+func seedSpread(t *testing.T, store *PostgresStore) {
+	t.Helper()
+	ctx := context.Background()
+	for i, off := range spreadOffsets {
+		a := clusterApp("S"+strconv.Itoa(i), 100, off[0], off[1])
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+}
+
+// clusterQuery is a brief ClusterQuery builder over the wide viewport and a
+// generous radius, varying only the grid size and status.
+func clusterQuery(gridSize float64, status string) ClusterQuery {
+	return ClusterQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 10000,
+		West: bboxWest, South: bboxSouth, East: bboxEast, North: bboxNorth,
+		GridSizeDegrees: gridSize, Status: status,
+	}
+}
+
+// directCount returns COUNT(*) over the same in-radius + in-bbox predicates the
+// cluster query applies, the independent reference for count conservation.
+func directCount(t *testing.T, store *PostgresStore, q ClusterQuery) int {
+	t.Helper()
+	var n int
+	err := store.db.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM applications "+
+			"WHERE ST_DWithin(location, ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography, $3) "+
+			"AND location::geometry && ST_MakeEnvelope($4, $5, $6, $7, 4326)",
+		q.Longitude, q.Latitude, q.RadiusMetres, q.West, q.South, q.East, q.North).Scan(&n)
+	if err != nil {
+		t.Fatalf("direct count: %v", err)
+	}
+	return n
+}
+
+func sumCounts(clusters []Cluster) int {
+	total := 0
+	for _, c := range clusters {
+		total += c.Count
+	}
+	return total
+}
+
+func sumStatusCounts(c Cluster) int {
+	total := 0
+	for _, n := range c.StatusCounts {
+		total += n
+	}
+	return total
+}
+
+// TestPostgresStore_FindClustersInZone_CountConservation proves that, at several
+// grid sizes, the summed cluster Count equals a plain COUNT(*) over the same
+// in-radius + in-bbox predicates — no double counting and no omission.
+func TestPostgresStore_FindClustersInZone_CountConservation(t *testing.T) {
+	store := newAppPGStore(t)
+	seedSpread(t, store)
+	ctx := context.Background()
+
+	for _, grid := range []float64{10.0, 0.01, 1e-6} {
+		q := clusterQuery(grid, "")
+		clusters, err := store.FindClustersInZone(ctx, q)
+		if err != nil {
+			t.Fatalf("grid %v: FindClustersInZone: %v", grid, err)
+		}
+		want := directCount(t, store, q)
+		if got := sumCounts(clusters); got != want {
+			t.Errorf("grid %v: summed Count = %d, want %d (plain COUNT(*))", grid, got, want)
+		}
+		// Every cluster's per-status breakdown must itself sum to its Count.
+		for _, c := range clusters {
+			if got := sumStatusCounts(c); got != c.Count {
+				t.Errorf("grid %v: cluster statusCounts sum = %d, want Count %d", grid, got, c.Count)
+			}
+		}
+	}
+}
+
+// TestPostgresStore_FindClustersInZone_ZoomCellBehaviour proves the grid behaviour
+// across zoom: a coarse grid collapses all points into one cell; a finer grid
+// spreads them into more cells; the finest grid yields one cell per point, each a
+// fully-identified single member.
+func TestPostgresStore_FindClustersInZone_ZoomCellBehaviour(t *testing.T) {
+	store := newAppPGStore(t)
+	seedSpread(t, store)
+	ctx := context.Background()
+
+	coarse, err := store.FindClustersInZone(ctx, clusterQuery(10.0, ""))
+	if err != nil {
+		t.Fatalf("coarse: %v", err)
+	}
+	if len(coarse) != 1 || coarse[0].Count != 8 {
+		t.Fatalf("coarse grid: got %d cells (first count %v), want 1 cell of 8", len(coarse), firstCount(coarse))
+	}
+
+	medium, err := store.FindClustersInZone(ctx, clusterQuery(0.01, ""))
+	if err != nil {
+		t.Fatalf("medium: %v", err)
+	}
+	if len(medium) != 4 {
+		t.Fatalf("medium grid: got %d cells, want 4 (one per tight pair)", len(medium))
+	}
+	for _, c := range medium {
+		if c.Count != 2 {
+			t.Errorf("medium grid: cell count = %d, want 2", c.Count)
+		}
+	}
+	if !(len(coarse) < len(medium)) {
+		t.Errorf("a finer grid must spread into more cells: coarse=%d medium=%d", len(coarse), len(medium))
+	}
+
+	tiny, err := store.FindClustersInZone(ctx, clusterQuery(1e-6, ""))
+	if err != nil {
+		t.Fatalf("tiny: %v", err)
+	}
+	if len(tiny) != 8 {
+		t.Fatalf("tiny grid: got %d cells, want 8 (one per point)", len(tiny))
+	}
+	for _, c := range tiny {
+		if c.Count != 1 {
+			t.Errorf("tiny grid: cell count = %d, want 1", c.Count)
+		}
+		if c.Member == nil {
+			t.Errorf("tiny grid: single-member cell must carry a member id, got nil")
+		}
+	}
+	if !(len(medium) < len(tiny)) {
+		t.Errorf("the finest grid must spread furthest: medium=%d tiny=%d", len(medium), len(tiny))
+	}
+}
+
+func firstCount(clusters []Cluster) any {
+	if len(clusters) == 0 {
+		return "none"
+	}
+	return clusters[0].Count
+}
+
+// TestPostgresStore_FindClustersInZone_SingleMemberIdentity proves a single-member
+// cell carries the member's {authority, name} and its app_state in statusCounts,
+// including the NULL-app_state -> "Unknown" folding.
+func TestPostgresStore_FindClustersInZone_SingleMemberIdentity(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+	for _, a := range []PlanningApplication{
+		withState(clusterApp("PERM", 100, 0.000, 0.000), pgPtr("Permitted")),
+		clusterApp("NOSTATE", 100, 0.020, 0.020), // NULL app_state
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	clusters, err := store.FindClustersInZone(ctx, clusterQuery(1e-6, ""))
+	if err != nil {
+		t.Fatalf("FindClustersInZone: %v", err)
+	}
+	if len(clusters) != 2 {
+		t.Fatalf("got %d clusters, want 2", len(clusters))
+	}
+	byName := map[string]Cluster{}
+	for _, c := range clusters {
+		if c.Member == nil {
+			t.Fatalf("expected every cell to carry a single member, got nil for %+v", c)
+		}
+		byName[c.Member.Name] = c
+	}
+
+	perm, ok := byName["PERM"]
+	if !ok {
+		t.Fatal("missing PERM cluster")
+	}
+	if perm.Member.Authority != "100" {
+		t.Errorf("PERM authority: got %q, want %q (area_id as decimal string)", perm.Member.Authority, "100")
+	}
+	if perm.Count != 1 || perm.StatusCounts["Permitted"] != 1 || len(perm.StatusCounts) != 1 {
+		t.Errorf("PERM: got count=%d statusCounts=%v, want count=1 {Permitted:1}", perm.Count, perm.StatusCounts)
+	}
+
+	noState, ok := byName["NOSTATE"]
+	if !ok {
+		t.Fatal("missing NOSTATE cluster")
+	}
+	if noState.StatusCounts["Unknown"] != 1 || len(noState.StatusCounts) != 1 {
+		t.Errorf("NOSTATE: got statusCounts=%v, want {Unknown:1} (NULL app_state folds to Unknown)", noState.StatusCounts)
+	}
+}
+
+// TestPostgresStore_FindClustersInZone_MultiMemberBreakdown proves a multi-member
+// cell carries a nil member and a per-status breakdown that sums to the count.
+func TestPostgresStore_FindClustersInZone_MultiMemberBreakdown(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+	// Three points within a tiny span so any coarse grid keeps them in one cell.
+	for _, a := range []PlanningApplication{
+		withState(clusterApp("M1", 100, 0.0000, 0.0000), pgPtr("Permitted")),
+		withState(clusterApp("M2", 100, 0.0001, 0.0000), pgPtr("Permitted")),
+		withState(clusterApp("M3", 100, 0.0002, 0.0001), pgPtr("Rejected")),
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	clusters, err := store.FindClustersInZone(ctx, clusterQuery(10.0, ""))
+	if err != nil {
+		t.Fatalf("FindClustersInZone: %v", err)
+	}
+	if len(clusters) != 1 {
+		t.Fatalf("got %d clusters, want 1 coarse cell", len(clusters))
+	}
+	c := clusters[0]
+	if c.Member != nil {
+		t.Errorf("multi-member cell must have a nil member, got %+v", c.Member)
+	}
+	if c.Count != 3 {
+		t.Errorf("count: got %d, want 3", c.Count)
+	}
+	if c.StatusCounts["Permitted"] != 2 || c.StatusCounts["Rejected"] != 1 {
+		t.Errorf("statusCounts: got %v, want {Permitted:2, Rejected:1}", c.StatusCounts)
+	}
+	if sumStatusCounts(c) != c.Count {
+		t.Errorf("statusCounts must sum to count: sum=%d count=%d", sumStatusCounts(c), c.Count)
+	}
+}
+
+// TestPostgresStore_FindClustersInZone_StatusFilter proves ?status= restricts the
+// aggregation to matching rows: the filtered counts reflect only that app_state.
+func TestPostgresStore_FindClustersInZone_StatusFilter(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+	permitted, rejected := pgPtr("Permitted"), pgPtr("Rejected")
+	for _, a := range []PlanningApplication{
+		withState(clusterApp("P1", 100, 0.0000, 0.0000), permitted),
+		withState(clusterApp("P2", 100, 0.0001, 0.0000), permitted),
+		withState(clusterApp("P3", 100, 0.0002, 0.0001), permitted),
+		withState(clusterApp("R1", 100, 0.0003, 0.0000), rejected),
+		withState(clusterApp("R2", 100, 0.0004, 0.0001), rejected),
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	all, err := store.FindClustersInZone(ctx, clusterQuery(10.0, ""))
+	if err != nil {
+		t.Fatalf("unfiltered: %v", err)
+	}
+	if got := sumCounts(all); got != 5 {
+		t.Fatalf("unfiltered count: got %d, want 5", got)
+	}
+
+	permittedOnly, err := store.FindClustersInZone(ctx, clusterQuery(10.0, "Permitted"))
+	if err != nil {
+		t.Fatalf("filtered: %v", err)
+	}
+	if len(permittedOnly) != 1 {
+		t.Fatalf("filtered: got %d clusters, want 1", len(permittedOnly))
+	}
+	c := permittedOnly[0]
+	if c.Count != 3 {
+		t.Errorf("filtered count: got %d, want 3 (only Permitted)", c.Count)
+	}
+	if len(c.StatusCounts) != 1 || c.StatusCounts["Permitted"] != 3 {
+		t.Errorf("filtered statusCounts: got %v, want {Permitted:3}", c.StatusCounts)
+	}
+}
+
+// TestPostgresStore_FindClustersInZone_Centroid proves the cell centroid is the
+// arithmetic mean of its members' points, lies within the grid cell, and lies
+// within the convex hull of the members.
+func TestPostgresStore_FindClustersInZone_Centroid(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+	const grid = 0.01
+	// Three non-collinear points comfortably inside one 0.01-deg cell.
+	offs := [3][2]float64{{0.0000, 0.0000}, {0.0002, 0.0000}, {0.0001, 0.0002}}
+	for i, off := range offs {
+		a := clusterApp("C"+strconv.Itoa(i), 100, off[0], off[1])
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	clusters, err := store.FindClustersInZone(ctx, clusterQuery(grid, ""))
+	if err != nil {
+		t.Fatalf("FindClustersInZone: %v", err)
+	}
+	if len(clusters) != 1 {
+		t.Fatalf("got %d clusters, want 1", len(clusters))
+	}
+	c := clusters[0]
+
+	var meanLng, meanLat float64
+	for _, off := range offs {
+		meanLng += pgCentreLon + off[0]
+		meanLat += pgCentreLat + off[1]
+	}
+	meanLng /= 3
+	meanLat /= 3
+	if !floatNear(c.Longitude, meanLng, 1e-9) || !floatNear(c.Latitude, meanLat, 1e-9) {
+		t.Errorf("centroid: got (%v, %v), want arithmetic mean (%v, %v)", c.Longitude, c.Latitude, meanLng, meanLat)
+	}
+
+	// Within the grid cell: the centroid is within +/- grid/2 of the cell node.
+	nodeLng := math.Round((pgCentreLon+offs[0][0])/grid) * grid
+	nodeLat := math.Round((pgCentreLat+offs[0][1])/grid) * grid
+	if math.Abs(c.Longitude-nodeLng) > grid/2+1e-9 || math.Abs(c.Latitude-nodeLat) > grid/2+1e-9 {
+		t.Errorf("centroid (%v, %v) outside cell node (%v, %v) +/- %v", c.Longitude, c.Latitude, nodeLng, nodeLat, grid/2)
+	}
+
+	// Within the convex hull of the members (PostGIS confirms the spatial fact).
+	var inHull bool
+	hullSQL := "SELECT ST_Within(" +
+		"ST_SetSRID(ST_MakePoint($1, $2), 4326), " +
+		"ST_ConvexHull(ST_Collect(location::geometry))) " +
+		"FROM applications"
+	if err := store.db.QueryRow(ctx, hullSQL, c.Longitude, c.Latitude).Scan(&inHull); err != nil {
+		t.Fatalf("convex-hull check: %v", err)
+	}
+	if !inHull {
+		t.Errorf("centroid (%v, %v) is not within the convex hull of its members", c.Longitude, c.Latitude)
+	}
+}
+
+// TestPostgresStore_FindClustersInZone_RespectsRadiusAndBBox proves both spatial
+// predicates bound the aggregation: a point inside the radius but outside the
+// viewport, and a point inside the viewport but outside the radius, are both
+// excluded; only the point inside both survives. The viewport and circle here
+// partially overlap so each predicate is exercised independently.
+func TestPostgresStore_FindClustersInZone_RespectsRadiusAndBBox(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+	for _, a := range []PlanningApplication{
+		clusterApp("INBOTH", 100, 0.0278, 0.0126),   // ~2.4 km, inside the NE viewport
+		clusterApp("RADONLY", 100, 0.0000, -0.0274), // ~3.0 km but south of the viewport
+		clusterApp("BBOXONLY", 100, 0.0678, 0.0826), // inside the viewport but ~10 km out
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	q := ClusterQuery{
+		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 5000,
+		West: pgCentreLon, South: pgCentreLat, East: 0.0, North: 51.60,
+		GridSizeDegrees: 1e-6,
+	}
+	clusters, err := store.FindClustersInZone(ctx, q)
+	if err != nil {
+		t.Fatalf("FindClustersInZone: %v", err)
+	}
+	if len(clusters) != 1 {
+		t.Fatalf("got %d clusters, want 1 (only the in-radius, in-viewport point)", len(clusters))
+	}
+	if clusters[0].Member == nil || clusters[0].Member.Name != "INBOTH" {
+		t.Errorf("surviving cluster: got %+v, want the INBOTH member", clusters[0].Member)
+	}
+}
+
+// TestPostgresStore_FindClustersInZone_ExplainUsesGiSTIndex proves the existing
+// GiST index (applications_location_gist) serves the ST_DWithin radius predicate
+// of the cluster query — so no new migration/index is needed. enable_seqscan is
+// disabled for the EXPLAIN so the planner is forced to reveal whether the index is
+// usable, rather than preferring a sequential scan over the small fixture table.
+func TestPostgresStore_FindClustersInZone_ExplainUsesGiSTIndex(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "applications", "watch_zones")
+	store := NewPostgresStore(pool)
+	seedSpread(t, store)
+	ctx := context.Background()
+
+	q := clusterQuery(0.01, "")
+	args := append([]any{}, q.Longitude, q.Latitude, q.RadiusMetres, q.GridSizeDegrees, q.West, q.South, q.East, q.North)
+
+	// SET enable_seqscan = off and the EXPLAIN must run on the SAME connection
+	// (the setting is session state), so acquire one pooled connection for both.
+	// Disabling seqscan forces the planner to reveal whether the GiST index is
+	// usable for the predicate, rather than preferring a sequential scan over the
+	// small fixture table.
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire connection: %v", err)
+	}
+	defer conn.Release()
+	if _, err := conn.Exec(ctx, "SET enable_seqscan = off"); err != nil {
+		t.Fatalf("disable seqscan: %v", err)
+	}
+
+	rows, err := conn.Query(ctx, "EXPLAIN (ANALYZE, FORMAT TEXT) "+clusterQueryAllStatuses, args...)
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v", err)
+	}
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			rows.Close()
+			t.Fatalf("scan plan line: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+
+	if !strings.Contains(strings.ToLower(plan.String()), "applications_location_gist") {
+		t.Errorf("EXPLAIN plan does not use the GiST index applications_location_gist:\n%s", plan.String())
+	}
+}
+
+func floatNear(a, b, tol float64) bool { return math.Abs(a-b) <= tol }

--- a/api-go/internal/applications/zoneclusters_test.go
+++ b/api-go/internal/applications/zoneclusters_test.go
@@ -1,468 +1,155 @@
-//go:build integration
-
 package applications
 
 import (
-	"context"
-	"math"
-	"strconv"
-	"strings"
+	"encoding/json"
 	"testing"
 
-	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
-// Cluster fixtures reuse the shared London centre (pgCentreLon/pgCentreLat) and
-// the pgApp/withState/pgPtr helpers from store_postgres_test.go. Points are placed
-// at explicit small degree offsets so the grid-snapping (ST_SnapToGrid) is
-// deterministic. The zone query always uses the centre + a generous radius so
-// membership is governed by the viewport, not the circle, except where a test
-// exercises the radius/bbox predicates directly.
-
-// clusterApp builds an in-radius application at the centre plus (dLng, dLat)
-// degrees, in the given authority, with the baseline nullable fields.
-func clusterApp(name string, areaID int, dLng, dLat float64) PlanningApplication {
-	a := pgApp(name, areaID)
-	a.Longitude = pgPtr(pgCentreLon + dLng)
-	a.Latitude = pgPtr(pgCentreLat + dLat)
-	return a
+// fakeClusterRow is a hand-written pgx.CollectableRow that feeds scanClusterRow a
+// fixed set of column values in the exact order the SELECT projects them
+// (centroid_lat, centroid_lon, member_count, status_counts, member_authority,
+// member_name, members). It lets us cover the raw-JSONB decode of the new member
+// list without a live database.
+type fakeClusterRow struct {
+	lat, lon   float64
+	count      int64
+	rawCounts  []byte
+	authority  string
+	name       string
+	rawMembers []byte // nil models a SQL NULL members column
 }
 
-// wideBBox is a viewport comfortably containing every spread/coarse fixture point
-// (all within base + ~0.031 deg), as west,south,east,north.
-const (
-	bboxWest  = -0.2
-	bboxSouth = 51.48
-	bboxEast  = -0.05
-	bboxNorth = 51.55
-)
-
-// spreadOffsets are eight distinct (dLng, dLat) points spanning ~0.031 deg of
-// longitude in four tight pairs (pair members 0.001 deg apart, pairs 0.01 deg
-// apart). Snapping behaviour by cell size:
-//   - coarse 10 deg     -> all eight in one cell.
-//   - medium 0.01 deg   -> four cells (each pair shares a cell), two members each.
-//   - tiny 1e-6 deg     -> eight cells, one member each.
-var spreadOffsets = [8][2]float64{
-	{0.000, 0.000}, {0.001, 0.000},
-	{0.010, 0.000}, {0.011, 0.000},
-	{0.020, 0.010}, {0.021, 0.010},
-	{0.030, 0.020}, {0.031, 0.020},
+func (r fakeClusterRow) Scan(dest ...any) error {
+	*(dest[0].(*float64)) = r.lat
+	*(dest[1].(*float64)) = r.lon
+	*(dest[2].(*int64)) = r.count
+	*(dest[3].(*[]byte)) = r.rawCounts
+	*(dest[4].(*string)) = r.authority
+	*(dest[5].(*string)) = r.name
+	*(dest[6].(*[]byte)) = r.rawMembers
+	return nil
 }
 
-// seedSpread inserts the eight spread points, all in authority 100.
-func seedSpread(t *testing.T, store *PostgresStore) {
-	t.Helper()
-	ctx := context.Background()
-	for i, off := range spreadOffsets {
-		a := clusterApp("S"+strconv.Itoa(i), 100, off[0], off[1])
-		if err := store.Upsert(ctx, a); err != nil {
-			t.Fatalf("Upsert %s: %v", a.Name, err)
+func (r fakeClusterRow) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r fakeClusterRow) Values() ([]any, error)                       { return nil, nil }
+func (r fakeClusterRow) RawValues() [][]byte                          { return nil }
+
+// TestScanClusterRow_Members proves scanClusterRow decodes a present applicationIds
+// JSONB column into Cluster.Members, and leaves Members nil for a SQL NULL column.
+func TestScanClusterRow_Members(t *testing.T) {
+	t.Parallel()
+
+	t.Run("present member list decodes into Members", func(t *testing.T) {
+		t.Parallel()
+		row := fakeClusterRow{
+			lat: 51.5, lon: -0.12, count: 3,
+			rawCounts:  []byte(`{"Permitted":3}`),
+			authority:  "100",
+			name:       "A1",
+			rawMembers: []byte(`[{"authority":"100","name":"A1"},{"authority":"100","name":"A2"},{"authority":"100","name":"A3"}]`),
 		}
-	}
-}
-
-// clusterQuery is a brief ClusterQuery builder over the wide viewport and a
-// generous radius, varying only the grid size and status.
-func clusterQuery(gridSize float64, status string) ClusterQuery {
-	return ClusterQuery{
-		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 10000,
-		West: bboxWest, South: bboxSouth, East: bboxEast, North: bboxNorth,
-		GridSizeDegrees: gridSize, Status: status,
-	}
-}
-
-// directCount returns COUNT(*) over the same in-radius + in-bbox predicates the
-// cluster query applies, the independent reference for count conservation.
-func directCount(t *testing.T, store *PostgresStore, q ClusterQuery) int {
-	t.Helper()
-	var n int
-	err := store.db.QueryRow(context.Background(),
-		"SELECT COUNT(*) FROM applications "+
-			"WHERE ST_DWithin(location, ST_SetSRID(ST_MakePoint($1, $2), 4326)::geography, $3) "+
-			"AND location::geometry && ST_MakeEnvelope($4, $5, $6, $7, 4326)",
-		q.Longitude, q.Latitude, q.RadiusMetres, q.West, q.South, q.East, q.North).Scan(&n)
-	if err != nil {
-		t.Fatalf("direct count: %v", err)
-	}
-	return n
-}
-
-func sumCounts(clusters []Cluster) int {
-	total := 0
-	for _, c := range clusters {
-		total += c.Count
-	}
-	return total
-}
-
-func sumStatusCounts(c Cluster) int {
-	total := 0
-	for _, n := range c.StatusCounts {
-		total += n
-	}
-	return total
-}
-
-// TestPostgresStore_FindClustersInZone_CountConservation proves that, at several
-// grid sizes, the summed cluster Count equals a plain COUNT(*) over the same
-// in-radius + in-bbox predicates — no double counting and no omission.
-func TestPostgresStore_FindClustersInZone_CountConservation(t *testing.T) {
-	store := newAppPGStore(t)
-	seedSpread(t, store)
-	ctx := context.Background()
-
-	for _, grid := range []float64{10.0, 0.01, 1e-6} {
-		q := clusterQuery(grid, "")
-		clusters, err := store.FindClustersInZone(ctx, q)
+		c, err := scanClusterRow(row)
 		if err != nil {
-			t.Fatalf("grid %v: FindClustersInZone: %v", grid, err)
+			t.Fatalf("scanClusterRow: %v", err)
 		}
-		want := directCount(t, store, q)
-		if got := sumCounts(clusters); got != want {
-			t.Errorf("grid %v: summed Count = %d, want %d (plain COUNT(*))", grid, got, want)
+		if len(c.Members) != 3 {
+			t.Fatalf("Members: got %d, want 3 (%+v)", len(c.Members), c.Members)
 		}
-		// Every cluster's per-status breakdown must itself sum to its Count.
-		for _, c := range clusters {
-			if got := sumStatusCounts(c); got != c.Count {
-				t.Errorf("grid %v: cluster statusCounts sum = %d, want Count %d", grid, got, c.Count)
+		want := []PlanningApplicationID{
+			{Authority: "100", Name: "A1"},
+			{Authority: "100", Name: "A2"},
+			{Authority: "100", Name: "A3"},
+		}
+		for i, w := range want {
+			if c.Members[i] != w {
+				t.Errorf("Members[%d]: got %+v, want %+v", i, c.Members[i], w)
 			}
 		}
-	}
+		// A multi-member cell still leaves the single-member id nil.
+		if c.Member != nil {
+			t.Errorf("Member: got %+v, want nil for a multi-member cell", c.Member)
+		}
+	})
+
+	t.Run("NULL member column yields nil Members", func(t *testing.T) {
+		t.Parallel()
+		row := fakeClusterRow{
+			lat: 51.5, lon: -0.12, count: 1,
+			rawCounts:  []byte(`{"Permitted":1}`),
+			authority:  "471",
+			name:       "24/001",
+			rawMembers: nil, // SQL NULL
+		}
+		c, err := scanClusterRow(row)
+		if err != nil {
+			t.Fatalf("scanClusterRow: %v", err)
+		}
+		if c.Members != nil {
+			t.Errorf("Members: got %+v, want nil for a NULL members column", c.Members)
+		}
+		// A single-member cell still carries its applicationId.
+		if c.Member == nil || c.Member.Authority != "471" || c.Member.Name != "24/001" {
+			t.Errorf("Member: got %+v, want {471, 24/001}", c.Member)
+		}
+	})
 }
 
-// TestPostgresStore_FindClustersInZone_ZoomCellBehaviour proves the grid behaviour
-// across zoom: a coarse grid collapses all points into one cell; a finer grid
-// spreads them into more cells; the finest grid yields one cell per point, each a
-// fully-identified single member.
-func TestPostgresStore_FindClustersInZone_ZoomCellBehaviour(t *testing.T) {
-	store := newAppPGStore(t)
-	seedSpread(t, store)
-	ctx := context.Background()
+// TestCluster_MembersJSONShape pins the wire contract for the new member list:
+// applicationIds is present (an array) when Members is populated, and is omitted
+// entirely (omitempty) for a splittable cell whose Members is nil.
+func TestCluster_MembersJSONShape(t *testing.T) {
+	t.Parallel()
 
-	coarse, err := store.FindClustersInZone(ctx, clusterQuery(10.0, ""))
-	if err != nil {
-		t.Fatalf("coarse: %v", err)
-	}
-	if len(coarse) != 1 || coarse[0].Count != 8 {
-		t.Fatalf("coarse grid: got %d cells (first count %v), want 1 cell of 8", len(coarse), firstCount(coarse))
-	}
+	t.Run("coincident cell serialises applicationIds", func(t *testing.T) {
+		t.Parallel()
+		c := Cluster{
+			Latitude: 51.5, Longitude: -0.12, Count: 2,
+			StatusCounts: map[string]int{"Permitted": 2},
+			Members: []PlanningApplicationID{
+				{Authority: "100", Name: "A1"},
+				{Authority: "100", Name: "A2"},
+			},
+		}
+		raw, err := json.Marshal(c)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var got map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("unmarshal: %v; raw=%s", err, raw)
+		}
+		ids, ok := got["applicationIds"]
+		if !ok {
+			t.Fatalf("applicationIds missing from %s", raw)
+		}
+		var members []PlanningApplicationID
+		if err := json.Unmarshal(ids, &members); err != nil {
+			t.Fatalf("decode applicationIds: %v", err)
+		}
+		if len(members) != 2 || members[0] != (PlanningApplicationID{Authority: "100", Name: "A1"}) {
+			t.Errorf("applicationIds: got %+v, want the two seeded members", members)
+		}
+	})
 
-	medium, err := store.FindClustersInZone(ctx, clusterQuery(0.01, ""))
-	if err != nil {
-		t.Fatalf("medium: %v", err)
-	}
-	if len(medium) != 4 {
-		t.Fatalf("medium grid: got %d cells, want 4 (one per tight pair)", len(medium))
-	}
-	for _, c := range medium {
-		if c.Count != 2 {
-			t.Errorf("medium grid: cell count = %d, want 2", c.Count)
+	t.Run("splittable cell omits applicationIds", func(t *testing.T) {
+		t.Parallel()
+		c := Cluster{
+			Latitude: 51.5, Longitude: -0.12, Count: 194,
+			StatusCounts: map[string]int{"Permitted": 194},
+			Members:      nil,
 		}
-	}
-	if !(len(coarse) < len(medium)) {
-		t.Errorf("a finer grid must spread into more cells: coarse=%d medium=%d", len(coarse), len(medium))
-	}
-
-	tiny, err := store.FindClustersInZone(ctx, clusterQuery(1e-6, ""))
-	if err != nil {
-		t.Fatalf("tiny: %v", err)
-	}
-	if len(tiny) != 8 {
-		t.Fatalf("tiny grid: got %d cells, want 8 (one per point)", len(tiny))
-	}
-	for _, c := range tiny {
-		if c.Count != 1 {
-			t.Errorf("tiny grid: cell count = %d, want 1", c.Count)
+		raw, err := json.Marshal(c)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
 		}
-		if c.Member == nil {
-			t.Errorf("tiny grid: single-member cell must carry a member id, got nil")
+		var got map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &got); err != nil {
+			t.Fatalf("unmarshal: %v; raw=%s", err, raw)
 		}
-	}
-	if !(len(medium) < len(tiny)) {
-		t.Errorf("the finest grid must spread furthest: medium=%d tiny=%d", len(medium), len(tiny))
-	}
+		if _, ok := got["applicationIds"]; ok {
+			t.Errorf("applicationIds must be omitted for a splittable cell, got %s", raw)
+		}
+	})
 }
-
-func firstCount(clusters []Cluster) any {
-	if len(clusters) == 0 {
-		return "none"
-	}
-	return clusters[0].Count
-}
-
-// TestPostgresStore_FindClustersInZone_SingleMemberIdentity proves a single-member
-// cell carries the member's {authority, name} and its app_state in statusCounts,
-// including the NULL-app_state -> "Unknown" folding.
-func TestPostgresStore_FindClustersInZone_SingleMemberIdentity(t *testing.T) {
-	store := newAppPGStore(t)
-	ctx := context.Background()
-	for _, a := range []PlanningApplication{
-		withState(clusterApp("PERM", 100, 0.000, 0.000), pgPtr("Permitted")),
-		clusterApp("NOSTATE", 100, 0.020, 0.020), // NULL app_state
-	} {
-		if err := store.Upsert(ctx, a); err != nil {
-			t.Fatalf("Upsert %s: %v", a.Name, err)
-		}
-	}
-
-	clusters, err := store.FindClustersInZone(ctx, clusterQuery(1e-6, ""))
-	if err != nil {
-		t.Fatalf("FindClustersInZone: %v", err)
-	}
-	if len(clusters) != 2 {
-		t.Fatalf("got %d clusters, want 2", len(clusters))
-	}
-	byName := map[string]Cluster{}
-	for _, c := range clusters {
-		if c.Member == nil {
-			t.Fatalf("expected every cell to carry a single member, got nil for %+v", c)
-		}
-		byName[c.Member.Name] = c
-	}
-
-	perm, ok := byName["PERM"]
-	if !ok {
-		t.Fatal("missing PERM cluster")
-	}
-	if perm.Member.Authority != "100" {
-		t.Errorf("PERM authority: got %q, want %q (area_id as decimal string)", perm.Member.Authority, "100")
-	}
-	if perm.Count != 1 || perm.StatusCounts["Permitted"] != 1 || len(perm.StatusCounts) != 1 {
-		t.Errorf("PERM: got count=%d statusCounts=%v, want count=1 {Permitted:1}", perm.Count, perm.StatusCounts)
-	}
-
-	noState, ok := byName["NOSTATE"]
-	if !ok {
-		t.Fatal("missing NOSTATE cluster")
-	}
-	if noState.StatusCounts["Unknown"] != 1 || len(noState.StatusCounts) != 1 {
-		t.Errorf("NOSTATE: got statusCounts=%v, want {Unknown:1} (NULL app_state folds to Unknown)", noState.StatusCounts)
-	}
-}
-
-// TestPostgresStore_FindClustersInZone_MultiMemberBreakdown proves a multi-member
-// cell carries a nil member and a per-status breakdown that sums to the count.
-func TestPostgresStore_FindClustersInZone_MultiMemberBreakdown(t *testing.T) {
-	store := newAppPGStore(t)
-	ctx := context.Background()
-	// Three points within a tiny span so any coarse grid keeps them in one cell.
-	for _, a := range []PlanningApplication{
-		withState(clusterApp("M1", 100, 0.0000, 0.0000), pgPtr("Permitted")),
-		withState(clusterApp("M2", 100, 0.0001, 0.0000), pgPtr("Permitted")),
-		withState(clusterApp("M3", 100, 0.0002, 0.0001), pgPtr("Rejected")),
-	} {
-		if err := store.Upsert(ctx, a); err != nil {
-			t.Fatalf("Upsert %s: %v", a.Name, err)
-		}
-	}
-
-	clusters, err := store.FindClustersInZone(ctx, clusterQuery(10.0, ""))
-	if err != nil {
-		t.Fatalf("FindClustersInZone: %v", err)
-	}
-	if len(clusters) != 1 {
-		t.Fatalf("got %d clusters, want 1 coarse cell", len(clusters))
-	}
-	c := clusters[0]
-	if c.Member != nil {
-		t.Errorf("multi-member cell must have a nil member, got %+v", c.Member)
-	}
-	if c.Count != 3 {
-		t.Errorf("count: got %d, want 3", c.Count)
-	}
-	if c.StatusCounts["Permitted"] != 2 || c.StatusCounts["Rejected"] != 1 {
-		t.Errorf("statusCounts: got %v, want {Permitted:2, Rejected:1}", c.StatusCounts)
-	}
-	if sumStatusCounts(c) != c.Count {
-		t.Errorf("statusCounts must sum to count: sum=%d count=%d", sumStatusCounts(c), c.Count)
-	}
-}
-
-// TestPostgresStore_FindClustersInZone_StatusFilter proves ?status= restricts the
-// aggregation to matching rows: the filtered counts reflect only that app_state.
-func TestPostgresStore_FindClustersInZone_StatusFilter(t *testing.T) {
-	store := newAppPGStore(t)
-	ctx := context.Background()
-	permitted, rejected := pgPtr("Permitted"), pgPtr("Rejected")
-	for _, a := range []PlanningApplication{
-		withState(clusterApp("P1", 100, 0.0000, 0.0000), permitted),
-		withState(clusterApp("P2", 100, 0.0001, 0.0000), permitted),
-		withState(clusterApp("P3", 100, 0.0002, 0.0001), permitted),
-		withState(clusterApp("R1", 100, 0.0003, 0.0000), rejected),
-		withState(clusterApp("R2", 100, 0.0004, 0.0001), rejected),
-	} {
-		if err := store.Upsert(ctx, a); err != nil {
-			t.Fatalf("Upsert %s: %v", a.Name, err)
-		}
-	}
-
-	all, err := store.FindClustersInZone(ctx, clusterQuery(10.0, ""))
-	if err != nil {
-		t.Fatalf("unfiltered: %v", err)
-	}
-	if got := sumCounts(all); got != 5 {
-		t.Fatalf("unfiltered count: got %d, want 5", got)
-	}
-
-	permittedOnly, err := store.FindClustersInZone(ctx, clusterQuery(10.0, "Permitted"))
-	if err != nil {
-		t.Fatalf("filtered: %v", err)
-	}
-	if len(permittedOnly) != 1 {
-		t.Fatalf("filtered: got %d clusters, want 1", len(permittedOnly))
-	}
-	c := permittedOnly[0]
-	if c.Count != 3 {
-		t.Errorf("filtered count: got %d, want 3 (only Permitted)", c.Count)
-	}
-	if len(c.StatusCounts) != 1 || c.StatusCounts["Permitted"] != 3 {
-		t.Errorf("filtered statusCounts: got %v, want {Permitted:3}", c.StatusCounts)
-	}
-}
-
-// TestPostgresStore_FindClustersInZone_Centroid proves the cell centroid is the
-// arithmetic mean of its members' points, lies within the grid cell, and lies
-// within the convex hull of the members.
-func TestPostgresStore_FindClustersInZone_Centroid(t *testing.T) {
-	store := newAppPGStore(t)
-	ctx := context.Background()
-	const grid = 0.01
-	// Three non-collinear points comfortably inside one 0.01-deg cell.
-	offs := [3][2]float64{{0.0000, 0.0000}, {0.0002, 0.0000}, {0.0001, 0.0002}}
-	for i, off := range offs {
-		a := clusterApp("C"+strconv.Itoa(i), 100, off[0], off[1])
-		if err := store.Upsert(ctx, a); err != nil {
-			t.Fatalf("Upsert %s: %v", a.Name, err)
-		}
-	}
-
-	clusters, err := store.FindClustersInZone(ctx, clusterQuery(grid, ""))
-	if err != nil {
-		t.Fatalf("FindClustersInZone: %v", err)
-	}
-	if len(clusters) != 1 {
-		t.Fatalf("got %d clusters, want 1", len(clusters))
-	}
-	c := clusters[0]
-
-	var meanLng, meanLat float64
-	for _, off := range offs {
-		meanLng += pgCentreLon + off[0]
-		meanLat += pgCentreLat + off[1]
-	}
-	meanLng /= 3
-	meanLat /= 3
-	if !floatNear(c.Longitude, meanLng, 1e-9) || !floatNear(c.Latitude, meanLat, 1e-9) {
-		t.Errorf("centroid: got (%v, %v), want arithmetic mean (%v, %v)", c.Longitude, c.Latitude, meanLng, meanLat)
-	}
-
-	// Within the grid cell: the centroid is within +/- grid/2 of the cell node.
-	nodeLng := math.Round((pgCentreLon+offs[0][0])/grid) * grid
-	nodeLat := math.Round((pgCentreLat+offs[0][1])/grid) * grid
-	if math.Abs(c.Longitude-nodeLng) > grid/2+1e-9 || math.Abs(c.Latitude-nodeLat) > grid/2+1e-9 {
-		t.Errorf("centroid (%v, %v) outside cell node (%v, %v) +/- %v", c.Longitude, c.Latitude, nodeLng, nodeLat, grid/2)
-	}
-
-	// Within the convex hull of the members (PostGIS confirms the spatial fact).
-	var inHull bool
-	hullSQL := "SELECT ST_Within(" +
-		"ST_SetSRID(ST_MakePoint($1, $2), 4326), " +
-		"ST_ConvexHull(ST_Collect(location::geometry))) " +
-		"FROM applications"
-	if err := store.db.QueryRow(ctx, hullSQL, c.Longitude, c.Latitude).Scan(&inHull); err != nil {
-		t.Fatalf("convex-hull check: %v", err)
-	}
-	if !inHull {
-		t.Errorf("centroid (%v, %v) is not within the convex hull of its members", c.Longitude, c.Latitude)
-	}
-}
-
-// TestPostgresStore_FindClustersInZone_RespectsRadiusAndBBox proves both spatial
-// predicates bound the aggregation: a point inside the radius but outside the
-// viewport, and a point inside the viewport but outside the radius, are both
-// excluded; only the point inside both survives. The viewport and circle here
-// partially overlap so each predicate is exercised independently.
-func TestPostgresStore_FindClustersInZone_RespectsRadiusAndBBox(t *testing.T) {
-	store := newAppPGStore(t)
-	ctx := context.Background()
-	for _, a := range []PlanningApplication{
-		clusterApp("INBOTH", 100, 0.0278, 0.0126),   // ~2.4 km, inside the NE viewport
-		clusterApp("RADONLY", 100, 0.0000, -0.0274), // ~3.0 km but south of the viewport
-		clusterApp("BBOXONLY", 100, 0.0678, 0.0826), // inside the viewport but ~10 km out
-	} {
-		if err := store.Upsert(ctx, a); err != nil {
-			t.Fatalf("Upsert %s: %v", a.Name, err)
-		}
-	}
-
-	q := ClusterQuery{
-		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 5000,
-		West: pgCentreLon, South: pgCentreLat, East: 0.0, North: 51.60,
-		GridSizeDegrees: 1e-6,
-	}
-	clusters, err := store.FindClustersInZone(ctx, q)
-	if err != nil {
-		t.Fatalf("FindClustersInZone: %v", err)
-	}
-	if len(clusters) != 1 {
-		t.Fatalf("got %d clusters, want 1 (only the in-radius, in-viewport point)", len(clusters))
-	}
-	if clusters[0].Member == nil || clusters[0].Member.Name != "INBOTH" {
-		t.Errorf("surviving cluster: got %+v, want the INBOTH member", clusters[0].Member)
-	}
-}
-
-// TestPostgresStore_FindClustersInZone_ExplainUsesGiSTIndex proves the existing
-// GiST index (applications_location_gist) serves the ST_DWithin radius predicate
-// of the cluster query — so no new migration/index is needed. enable_seqscan is
-// disabled for the EXPLAIN so the planner is forced to reveal whether the index is
-// usable, rather than preferring a sequential scan over the small fixture table.
-func TestPostgresStore_FindClustersInZone_ExplainUsesGiSTIndex(t *testing.T) {
-	pool := pgtest.New(t)
-	pgtest.Truncate(t, pool, "applications", "watch_zones")
-	store := NewPostgresStore(pool)
-	seedSpread(t, store)
-	ctx := context.Background()
-
-	q := clusterQuery(0.01, "")
-	args := append([]any{}, q.Longitude, q.Latitude, q.RadiusMetres, q.GridSizeDegrees, q.West, q.South, q.East, q.North)
-
-	// SET enable_seqscan = off and the EXPLAIN must run on the SAME connection
-	// (the setting is session state), so acquire one pooled connection for both.
-	// Disabling seqscan forces the planner to reveal whether the GiST index is
-	// usable for the predicate, rather than preferring a sequential scan over the
-	// small fixture table.
-	conn, err := pool.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire connection: %v", err)
-	}
-	defer conn.Release()
-	if _, err := conn.Exec(ctx, "SET enable_seqscan = off"); err != nil {
-		t.Fatalf("disable seqscan: %v", err)
-	}
-
-	rows, err := conn.Query(ctx, "EXPLAIN (ANALYZE, FORMAT TEXT) "+clusterQueryAllStatuses, args...)
-	if err != nil {
-		t.Fatalf("EXPLAIN: %v", err)
-	}
-	var plan strings.Builder
-	for rows.Next() {
-		var line string
-		if err := rows.Scan(&line); err != nil {
-			rows.Close()
-			t.Fatalf("scan plan line: %v", err)
-		}
-		plan.WriteString(line)
-		plan.WriteByte('\n')
-	}
-	if err := rows.Err(); err != nil {
-		t.Fatalf("read plan: %v", err)
-	}
-
-	if !strings.Contains(strings.ToLower(plan.String()), "applications_location_gist") {
-		t.Errorf("EXPLAIN plan does not use the GiST index applications_location_gist:\n%s", plan.String())
-	}
-}
-
-func floatNear(a, b, tol float64) bool { return math.Abs(a-b) <= tol }

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -517,6 +517,12 @@ func (h *handler) clusters(w http.ResponseWriter, r *http.Request) {
 		North:           box.north,
 		GridSizeDegrees: gridSize,
 		Status:          status,
+		// The coalesce threshold is the finest (zoom-20) grid cell size, not the
+		// request's own grid: a multi-member cell whose member points already span
+		// less than this can never be split by zooming, so the store attaches an
+		// applicationIds member list. Deriving it from the same zoomGridDegrees
+		// table keeps it tracking the zoom -> grid policy with no separate constant.
+		CoalesceThresholdDegrees: zoomGridDegrees[maxZoom],
 	})
 	if err != nil {
 		h.serverError(w, r, "find clusters in zone", err)

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -1334,6 +1334,93 @@ func TestClusters_PassesZoneAndParamsToStore(t *testing.T) {
 	if q.GridSizeDegrees != wantGrid {
 		t.Errorf("grid size for zoom 12: got %v, want %v", q.GridSizeDegrees, wantGrid)
 	}
+	// The coalesce threshold is the finest (zoom-20) grid cell, independent of the
+	// request's own zoom: it is the "zooming can never separate these" boundary
+	// below which a multi-member cell gets an applicationIds member list.
+	wantThreshold := 45.0 / float64(uint64(1)<<20) // 360/2^(20+3)
+	if q.CoalesceThresholdDegrees != wantThreshold {
+		t.Errorf("coalesce threshold: got %v, want the finest-grid size %v", q.CoalesceThresholdDegrees, wantThreshold)
+	}
+}
+
+// TestClusters_CoalesceThresholdIsFinestGridRegardlessOfZoom proves the handler
+// threads the same finest-grid coalesce threshold into the store query for every
+// request zoom — it is the zoom-20 cell size, not the request's own grid size — so
+// the member-list decision is stable across zoom levels.
+func TestClusters_CoalesceThresholdIsFinestGridRegardlessOfZoom(t *testing.T) {
+	t.Parallel()
+	wantThreshold := 45.0 / float64(uint64(1)<<20)
+	for _, zoom := range []int{0, 5, 12, 20} {
+		t.Run(strconv.Itoa(zoom), func(t *testing.T) {
+			t.Parallel()
+			apps := &fakeAppFinder{}
+			mux := newNearbyMux(t, clusterDeps(t, apps))
+			rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters?bbox=-0.2,51.4,-0.05,51.6&zoom="+strconv.Itoa(zoom), "")
+			if rec.Code != http.StatusOK {
+				t.Fatalf("zoom=%d: got %d, want 200", zoom, rec.Code)
+			}
+			if got := apps.lastClusterQuery.CoalesceThresholdDegrees; got != wantThreshold {
+				t.Errorf("zoom=%d coalesce threshold: got %v, want %v", zoom, got, wantThreshold)
+			}
+		})
+	}
+}
+
+// TestClusters_WireShape_ApplicationIds pins the additive member-list contract: an
+// unsplittable coincident cell carries applicationIds listing its members, while a
+// splittable multi-member cell omits the field entirely (omitempty). The status
+// filter is threaded straight through to the store (which restricts the member
+// list at the SQL layer — see the integration suite).
+func TestClusters_WireShape_ApplicationIds(t *testing.T) {
+	t.Parallel()
+	apps := &fakeAppFinder{clusters: []applications.Cluster{
+		{ // splittable multi-member cell: no member list, client zooms in
+			Latitude: 51.51, Longitude: -0.12, Count: 42,
+			StatusCounts: map[string]int{"Permitted": 42},
+			Members:      nil,
+		},
+		{ // unsplittable coincident cell: carries the disambiguation list
+			Latitude: 51.52, Longitude: -0.13, Count: 3,
+			StatusCounts: map[string]int{"Permitted": 2, "Rejected": 1},
+			Members: []applications.PlanningApplicationID{
+				{Authority: "471", Name: "24/001"},
+				{Authority: "471", Name: "24/002"},
+				{Authority: "471", Name: "24/003"},
+			},
+		},
+	}}
+	mux := newNearbyMux(t, clusterDeps(t, apps))
+
+	rec := doReq(t, mux, http.MethodGet, "/v1/me/watch-zones/zone-1/applications/clusters"+validClusterQuery, "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var got []struct {
+		Count          int `json:"count"`
+		ApplicationIDs *[]struct {
+			Authority string `json:"authority"`
+			Name      string `json:"name"`
+		} `json:"applicationIds"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v; raw=%s", err, rec.Body.String())
+	}
+	if len(got) != 2 {
+		t.Fatalf("clusters: got %d, want 2", len(got))
+	}
+	if got[0].ApplicationIDs != nil {
+		t.Errorf("splittable cell must omit applicationIds, got %+v", got[0].ApplicationIDs)
+	}
+	if got[1].ApplicationIDs == nil {
+		t.Fatalf("coincident cell must carry applicationIds, got null")
+	}
+	if len(*got[1].ApplicationIDs) != 3 {
+		t.Fatalf("applicationIds: got %d entries, want 3", len(*got[1].ApplicationIDs))
+	}
+	ids := *got[1].ApplicationIDs
+	if ids[0].Authority != "471" || ids[0].Name != "24/001" {
+		t.Errorf("applicationIds[0]: got %+v, want {471, 24/001}", ids[0])
+	}
 }
 
 // TestClusters_ZoomToGridSizeLookup proves the server-owned zoom -> grid-cell-size


### PR DESCRIPTION
## Changes

Slice A (server, producer) of #722 — coincident-address map clusters.

- `Cluster` gains `Members []PlanningApplicationID` serialized as JSON `applicationIds` (`omitempty`), populated **only** for unsplittable multi-member cells (member-point extent below the finest/zoom-20 grid in both axes). Splittable cells keep `applicationIds` omitted/null — purely additive, no client break.
- `ClusterQuery.CoalesceThresholdDegrees` carries the finest-grid threshold; the `clusters` handler supplies `zoomGridDegrees[maxZoom]`, keeping the zoom→size policy in the handler.
- SQL restructured into a CTE chain (`filtered` → `per_cell_state` → `per_cell` → `cell_meta`): the `?status=` filter lives in one place so the member list can never name a filtered-out application; `cell_meta` computes the extent via `ST_Extent` and emits the capped (50) `{authority, name}` list via `jsonb_agg` over a deterministically-ordered `LIMIT 50` subquery.
- `scanClusterRow` decodes the new members JSONB independently of the pgx codec.
- Tests: unit (scan + JSON shape present/absent), handler (wire shape + status filter + threshold threading), and `//go:build integration` pgtest `TestFindClustersInZone_CoincidentApplications_ReturnsMemberList` seeding ≥2 coincident apps (+ splittable + status-filtered cases).

Gates: `go build`/`vet`/`gofmt` clean, `go test ./...` (+`-race`) green, `golangci-lint` 0 issues, integration suite green against local PostGIS.

iOS consumer follows in slice B (tc-vay6).

Closes part of #722.

---
*Auto-shipped via ship skill*