### PR TITLE
fix(ci): CD Production deploys by immutable digest + verifies revision (tc-rh4w)

### DIFF
--- a/.github/actions/deploy-container-app/action.yml
+++ b/.github/actions/deploy-container-app/action.yml
@@ -1,9 +1,20 @@
-# Deploys a new image to an Azure Container App, then deactivates the
+# Deploys a new image to an Azure Container App, verifies the now-active
+# revision actually runs that image (by digest), then deactivates the
 # previously-active revision to keep the revision list clean.
+#
+# A unique --revision-suffix (run id + attempt) is passed so a fresh revision
+# always rolls — even when the image digest is unchanged — which sidesteps the
+# silent ":latest == :latest" no-op that froze prod (tc-rh4w). The verify step
+# then fails the build if the active revision does NOT run the deployed digest,
+# so a stale/no-op deploy can never report green again.
+#
+# Callers may pass the image as a digest ref (registry/repo@sha256:…, as
+# cd-prod does) or a tag ref (registry/repo:tag, as cd-dev does). Verification
+# normalises both to a digest before comparing.
 #
 # Assumes azure/login has already been called in an earlier step.
 name: Deploy Container App
-description: Update a Container App with a new image and deactivate the old revision
+description: Update a Container App with a new image, verify it took, and deactivate the old revision
 
 inputs:
   app-name:
@@ -13,7 +24,10 @@ inputs:
     description: Azure resource group
     required: true
   image:
-    description: Full image reference including tag (e.g., myregistry.azurecr.io/app:sha)
+    description: >-
+      Full image reference — digest ref (myregistry.azurecr.io/app@sha256:…,
+      preferred) or tag ref (myregistry.azurecr.io/app:sha). Verification
+      normalises either form to a digest.
     required: true
 
 outputs:
@@ -37,10 +51,79 @@ runs:
     - name: Deploy new image
       shell: bash
       run: |
+        set -euo pipefail
+        # Force a unique revision per run-attempt so a new revision always rolls
+        # (belt-and-braces on top of digest deploys). ACA suffix rules: lowercase
+        # [a-z0-9-], start alphabetic; the leading 'r' guarantees that and the
+        # run id/attempt are numeric. <app>--<suffix> stays well under 64 chars.
+        SUFFIX="r${{ github.run_id }}-${{ github.run_attempt }}"
+        SUFFIX="$(printf '%s' "$SUFFIX" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9-' '-')"
         az containerapp update \
           --name "${{ inputs.app-name }}" \
           --resource-group "${{ inputs.resource-group }}" \
-          --image "${{ inputs.image }}"
+          --image "${{ inputs.image }}" \
+          --revision-suffix "$SUFFIX"
+
+    - name: Verify active revision runs the deployed image
+      shell: bash
+      run: |
+        set -euo pipefail
+        APP="${{ inputs.app-name }}"
+        RG="${{ inputs.resource-group }}"
+        WANT_REF="${{ inputs.image }}"
+
+        # Resolve any image ref (digest form or tag form) to its sha256 digest.
+        # A digest ref is returned as-is; a tag ref is resolved against ACR.
+        digest_of() {
+          local ref="$1" server registry repo_ref
+          case "$ref" in
+            *@sha256:*)
+              printf '%s' "${ref##*@}"
+              ;;
+            *)
+              server="${ref%%/*}"
+              registry="${server%%.*}"
+              repo_ref="${ref#*/}"
+              az acr repository show \
+                --name "$registry" \
+                --image "$repo_ref" \
+                --query digest -o tsv
+              ;;
+          esac
+        }
+
+        WANT_DIGEST="$(digest_of "$WANT_REF")"
+
+        LATEST_REV="$(az containerapp show \
+          --name "$APP" \
+          --resource-group "$RG" \
+          --query "properties.latestRevisionName" -o tsv)"
+
+        RUNNING_REF="$(az containerapp revision show \
+          --name "$APP" \
+          --resource-group "$RG" \
+          --revision "$LATEST_REV" \
+          --query "properties.template.containers[0].image" -o tsv)"
+
+        GOT_DIGEST="$(digest_of "$RUNNING_REF")"
+
+        echo "Deployed image  : $WANT_REF"
+        echo "Wanted digest   : $WANT_DIGEST"
+        echo "Latest revision : $LATEST_REV"
+        echo "Running image   : $RUNNING_REF"
+        echo "Running digest  : $GOT_DIGEST"
+
+        if [ -z "$WANT_DIGEST" ] || [ -z "$GOT_DIGEST" ]; then
+          echo "::error::Could not resolve image digests (want='$WANT_DIGEST' got='$GOT_DIGEST')"
+          exit 1
+        fi
+
+        if [ "$WANT_DIGEST" != "$GOT_DIGEST" ]; then
+          echo "::error::Deploy did not take: active revision $LATEST_REV runs $GOT_DIGEST but we deployed $WANT_DIGEST"
+          exit 1
+        fi
+
+        echo "Verified: active revision $LATEST_REV runs the deployed digest."
 
     - name: Deactivate old revision
       if: steps.old-revision.outputs.revision != ''

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -5,6 +5,7 @@
 #   AZURE_CLIENT_ID        — OIDC federated credential for Azure login
 #   AZURE_TENANT_ID        — Azure AD tenant
 #   AZURE_SUBSCRIPTION_ID  — Azure subscription
+#   ACR_LOGIN_SERVER       — Azure Container Registry login server (for digest resolve)
 #   PULUMI_ACCESS_TOKEN    — Pulumi Cloud access token
 #   ADMIN_API_KEY          — API key for admin endpoints
 #
@@ -104,32 +105,47 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Resolve Go API image tag
-        id: check-image
+      # Resolve to an IMMUTABLE DIGEST (registry/repo@sha256:…), never a
+      # mutable tag. Prefer the exact tag-SHA image; else fall back to the
+      # current :latest digest; else fail. Deploying by digest means a code
+      # change rolls a new revision (digest differs) and an unchanged image is
+      # a legitimate no-op — the silent ":latest string == :latest string"
+      # no-op that froze prod becomes impossible.
+      - name: Resolve Go API image digest
+        id: resolve-image
         run: |
-          ACR_NAME="${{ secrets.ACR_LOGIN_SERVER }}"
-          ACR_NAME="${ACR_NAME%.azurecr.io}"
+          ACR_SERVER="${{ secrets.ACR_LOGIN_SERVER }}"
+          ACR_NAME="${ACR_SERVER%.azurecr.io}"
+          REPO="town-crier-api-go"
           SHA="${{ steps.resolve.outputs.sha }}"
-          if az acr manifest show \
-            --registry "$ACR_NAME" \
-            --name "town-crier-api-go:$SHA" 2>/dev/null; then
-            echo "Using exact image for SHA $SHA"
-            echo "tag=$SHA" >> "$GITHUB_OUTPUT"
-          elif az acr manifest show \
-            --registry "$ACR_NAME" \
-            --name "town-crier-api-go:latest" 2>/dev/null; then
-            echo "No image for SHA $SHA — falling back to latest"
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+
+          digest_for_tag() {
+            az acr repository show \
+              --name "$ACR_NAME" \
+              --image "${REPO}:$1" \
+              --query digest -o tsv 2>/dev/null
+          }
+
+          DIGEST="$(digest_for_tag "$SHA")"
+          if [ -n "$DIGEST" ]; then
+            echo "Using exact image for SHA $SHA ($DIGEST)"
           else
-            echo "::error::No Go API image found (tried SHA $SHA and latest)"
-            exit 1
+            DIGEST="$(digest_for_tag latest)"
+            if [ -n "$DIGEST" ]; then
+              echo "No image for SHA $SHA — falling back to latest ($DIGEST)"
+            else
+              echo "::error::No Go API image found (tried SHA $SHA and latest)"
+              exit 1
+            fi
           fi
+
+          echo "image=${ACR_SERVER}/${REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - uses: ./.github/actions/deploy-container-app
         with:
           app-name: ca-town-crier-api-go-prod
           resource-group: ${{ needs.infra.outputs.resource-group }}
-          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-api-go:${{ steps.check-image.outputs.tag }}
+          image: ${{ steps.resolve-image.outputs.image }}
 
   # ── Worker ───────────────────────────────────────────────
   worker:
@@ -153,33 +169,46 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Resolve worker image tag
-        id: check-image
+      # Resolve to an IMMUTABLE DIGEST (registry/repo@sha256:…), never a
+      # mutable tag — same rationale as the Go API job above. Pinning the
+      # worker jobs to a digest makes each release run an exact, reproducible
+      # image instead of whatever :latest happens to resolve to at run time.
+      - name: Resolve worker image digest
+        id: resolve-image
         run: |
-          ACR_NAME="${{ secrets.ACR_LOGIN_SERVER }}"
-          ACR_NAME="${ACR_NAME%.azurecr.io}"
+          ACR_SERVER="${{ secrets.ACR_LOGIN_SERVER }}"
+          ACR_NAME="${ACR_SERVER%.azurecr.io}"
+          REPO="town-crier-worker-go"
           SHA="${{ steps.resolve.outputs.sha }}"
-          if az acr manifest show \
-            --registry "$ACR_NAME" \
-            --name "town-crier-worker-go:$SHA" 2>/dev/null; then
-            echo "Using exact image for SHA $SHA"
-            echo "tag=$SHA" >> "$GITHUB_OUTPUT"
-          elif az acr manifest show \
-            --registry "$ACR_NAME" \
-            --name "town-crier-worker-go:latest" 2>/dev/null; then
-            echo "No image for SHA $SHA — falling back to latest"
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
+
+          digest_for_tag() {
+            az acr repository show \
+              --name "$ACR_NAME" \
+              --image "${REPO}:$1" \
+              --query digest -o tsv 2>/dev/null
+          }
+
+          DIGEST="$(digest_for_tag "$SHA")"
+          if [ -n "$DIGEST" ]; then
+            echo "Using exact image for SHA $SHA ($DIGEST)"
           else
-            echo "::error::No worker image found (tried SHA $SHA and latest)"
-            exit 1
+            DIGEST="$(digest_for_tag latest)"
+            if [ -n "$DIGEST" ]; then
+              echo "No image for SHA $SHA — falling back to latest ($DIGEST)"
+            else
+              echo "::error::No worker image found (tried SHA $SHA and latest)"
+              exit 1
+            fi
           fi
+
+          echo "image=${ACR_SERVER}/${REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - uses: ./.github/actions/deploy-worker-jobs
         with:
           jobs: poll poll-bootstrap digest digest-hourly dormant-cleanup
           env-suffix: prod
           resource-group: ${{ needs.infra.outputs.resource-group }}
-          image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker-go:${{ steps.check-image.outputs.tag }}
+          image: ${{ steps.resolve-image.outputs.image }}
 
   # ── Web ───────────────────────────────────────────────
   web:


### PR DESCRIPTION
## Changes

Durable fix for the CD Production silent no-op that froze the prod Go API on a pre-`/clusters` image (caused the prod `/map` 401). Root cause: cd-prod fell back to the mutable `:latest` tag for release tags whose commit had no SHA-pinned image (iOS/skills-only commits that CD Dev `paths-ignore`s), and `az containerapp update --image :latest` is a no-op against a revision already on `:latest` — so prod never re-pulled, while the workflow stayed green.

- **cd-prod.yml** — Go API + worker resolve steps now emit an **immutable digest** ref (`registry/repo@sha256:…`) via `az acr repository show --query digest`, instead of a mutable tag. SHA-preferred, `:latest` fallback (kept), fail-if-neither (kept). Deploying by digest means a code change always rolls a new revision (digest differs) and an unchanged image is a legitimate no-op — the `:latest == :latest` string no-op becomes impossible.
- **actions/deploy-container-app** (shared by cd-dev + cd-prod) — (a) passes a unique `--revision-suffix` so a fresh revision always rolls; (b) new **verify** step reads the active revision's running image, normalises both the deployed ref and running ref to a sha256 digest, and **fails the build** if they don't match — a stale/no-op deploy can never report green again.

Verified the `az acr repository show --query digest` form against the live ACR (returns `sha256:…`). CI-only change; it does not deploy anything — the next real release exercises it. Note: an iOS/skills-only release will now roll prod forward to the current `:latest` digest (head-of-main API) rather than silently freezing — intended.

Worked around live via release v0.15.55 (prod is already on `/clusters`); this is the durable fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)