### PR TITLE
fix(ci): cd-prod digest-resolve tolerates missing SHA image (#725 regression)

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -126,11 +126,15 @@ jobs:
               --query digest -o tsv 2>/dev/null
           }
 
-          DIGEST="$(digest_for_tag "$SHA")"
+          # `|| true`: GitHub `run:` steps use `bash -e`, so a failed command
+          # substitution aborts the step. Without it, a missing SHA-tagged image
+          # (e.g. a tag whose commit didn't rebuild this image — an iOS-only or
+          # CI-only merge) kills the job before the `latest` fallback can run.
+          DIGEST="$(digest_for_tag "$SHA" || true)"
           if [ -n "$DIGEST" ]; then
             echo "Using exact image for SHA $SHA ($DIGEST)"
           else
-            DIGEST="$(digest_for_tag latest)"
+            DIGEST="$(digest_for_tag latest || true)"
             if [ -n "$DIGEST" ]; then
               echo "No image for SHA $SHA — falling back to latest ($DIGEST)"
             else
@@ -188,11 +192,15 @@ jobs:
               --query digest -o tsv 2>/dev/null
           }
 
-          DIGEST="$(digest_for_tag "$SHA")"
+          # `|| true`: GitHub `run:` steps use `bash -e`, so a failed command
+          # substitution aborts the step. Without it, a missing SHA-tagged image
+          # (e.g. a tag whose commit didn't rebuild this image — an iOS-only or
+          # CI-only merge) kills the job before the `latest` fallback can run.
+          DIGEST="$(digest_for_tag "$SHA" || true)"
           if [ -n "$DIGEST" ]; then
             echo "Using exact image for SHA $SHA ($DIGEST)"
           else
-            DIGEST="$(digest_for_tag latest)"
+            DIGEST="$(digest_for_tag latest || true)"
             if [ -n "$DIGEST" ]; then
               echo "No image for SHA $SHA — falling back to latest ($DIGEST)"
             else


### PR DESCRIPTION
## Problem

CD Production for **v0.15.56** failed at the #725 "Resolve image digest" step (both Deploy Go API and Deploy Worker, exit 3), leaving prod on the pre-slice-A image — `/clusters` has no `applicationIds`.

GitHub `run:` steps execute under `bash -e`. The step does `DIGEST="$(digest_for_tag "$SHA")"` for the **release tag's commit SHA**. v0.15.56's tag commit was an iOS-only merge, so no `town-crier-api-go`/`-worker` image was ever tagged with that SHA (ACR has `747bb33a`, `2c5af76b`, `latest` — not `52e8c698`). `az acr repository show` returns non-zero, and `set -e` aborts the step **before** the `else` branch that falls back to `latest`.

## Fix

Add `|| true` to both the SHA and `latest` command substitutions in both the Go API and worker steps, so the existing fallback (which is itself digest-pinned, preserving #725's immutable-digest intent) and the genuine "neither found → `exit 1`" path are reachable.

4 lines changed (+ a clarifying comment). `actionlint` clean, YAML valid.

## Follow-up

This unblocks prod deploys for tags whose commit didn't rebuild the image. A new patch tag is needed to actually deploy slice A to prod (re-running v0.15.56 would reuse the old workflow) — cutting that once this merges.

Closes tc-8flu.

---
*Auto-shipped via ship skill*