### PR TITLE
docs: ADR audit + first paying customer status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Town Crier is a mobile-first app for monitoring UK local authority planning applications, delivering push notifications to residents, community groups, and property professionals. It uses PlanIt (planit.org.uk) as its primary data provider, with a polling-based ingestion model (see ADR 0006).
 
+## Business Status
+
+**Town Crier is no longer pre-revenue.** As of 2026-06-29 we have our first paying customer who is not personally known to the owner — a real, arm's-length subscriber. Treat the product as live with real customers, not a test deployment.
+
+Operational consequence: the **fix-forward-always, no-rollback** posture that applied during the pre-revenue window is now **reversed**. A broken deploy can harm a paying user, so production stability matters. Rollback safety, soak/verification gates before promoting, and staged cutovers are back on the table; don't assume "we can just fix forward" is acceptable for anything user-facing. Use judgement about blast radius rather than reaching for blunt cutovers by default.
+
 ## Monorepo Structure
 
 ```

--- a/docs/adr/0001-initial-tech-stack.md
+++ b/docs/adr/0001-initial-tech-stack.md
@@ -3,7 +3,7 @@
 Date: 2026-03-16
 
 ## Status
-Accepted — the backend (item 2) and IaC (item 7) technology choices have since been reversed by [ADR 0028](0028-migrate-backend-from-dotnet-to-go.md) and [ADR 0029](0029-migrate-infrastructure-from-dotnet-to-go.md), and the admin CLI (added after this ADR, originally .NET) was migrated by [ADR 0030](0030-migrate-admin-cli-from-dotnet-to-go.md); **.NET is no longer used anywhere in the repository.** All non-.NET choices stand: iOS (Swift), Azure hosting, Cosmos DB (Serverless), the Cosmos-SDK / no-ORM data-access pattern, and GitHub Actions.
+Accepted — the backend (item 2) and IaC (item 7) technology choices have since been reversed by [ADR 0028](0028-migrate-backend-from-dotnet-to-go.md) and [ADR 0029](0029-migrate-infrastructure-from-dotnet-to-go.md), and the admin CLI (added after this ADR, originally .NET) was migrated by [ADR 0030](0030-migrate-admin-cli-from-dotnet-to-go.md); **.NET is no longer used anywhere in the repository.** The database (item 4) and the Cosmos-SDK / no-ORM data-access pattern (item 5) have since been reversed by [ADR 0032](0032-consolidate-datastore-on-postgres-postgis.md), which retired Cosmos DB for a single Postgres + PostGIS datastore accessed via the `pgx` driver (still no ORM). The remaining original choices stand: iOS (Swift), Azure hosting, and GitHub Actions.
 
 ## Context
 The project "town-crier" requires a mobile application and a supporting backend API. The primary mobile platform is iOS, and the backend needs to be hosted in a cloud environment with strong enterprise support and scalability.

--- a/docs/adr/0008-cosmos-db-data-model.md
+++ b/docs/adr/0008-cosmos-db-data-model.md
@@ -4,7 +4,9 @@ Date: 2026-03-16
 
 ## Status
 
-Accepted
+Superseded by [ADR 0032](0032-consolidate-datastore-on-postgres-postgis.md)
+
+The Cosmos DB data model described here was retired on 2026-06-27 when all data consolidated onto a single Postgres + PostGIS datastore. See [ADR 0032](0032-consolidate-datastore-on-postgres-postgis.md) for the decision and [memo 0010](../memo/0010-cosmos-partition-strategy-and-postgres-postgis.md) for the analysis. The container/partition-key model below is preserved as the historical record of the Cosmos era.
 
 ## Context
 

--- a/docs/adr/0033-server-authoritative-watch-zone-querying.md
+++ b/docs/adr/0033-server-authoritative-watch-zone-querying.md
@@ -1,0 +1,47 @@
+# 0033. Server-authoritative watch-zone application querying
+
+Date: 2026-06-28
+
+## Status
+
+Accepted
+
+See also [ADR 0032](0032-consolidate-datastore-on-postgres-postgis.md) (the Postgres + PostGIS move that made this possible) and [ADR 0014](0014-ios-offline-first-architecture.md) (the iOS offline cache this querying model interacts with).
+
+## Context
+
+A watch zone is a circle (centre plus radius), and the application list behind it is the app's busiest read surface — browsed as a list, sorted, filtered by status and unread state, and rendered on a map. The original design pushed all of this to the client: the iOS app fetched a zone's applications in bulk and did the sort, the status/unread filtering, the unread count, and the map clustering on-device. That worked only while the client could plausibly hold the whole zone.
+
+Two things broke that assumption at the same time:
+
+- **Zones are large.** A 2 km London zone already returns ~1,364 applications and a 10 km zone tens of thousands. A browse page cap had to be introduced (#641/#642), after which the client no longer holds the whole zone, so any client-side sort, filter, or count is computed over a partial set and is silently wrong.
+- **Cosmos could not help.** Under the `/authorityCode` partition key the Cosmos Gateway refused cross-partition `ORDER BY` and aggregates (`BadRequest` substatus 1004 on a `COUNT`), so the server could not take over sorting or counting either. The data model fought the query shape (see [memo 0010](../memo/0010-cosmos-partition-strategy-and-postgres-postgis.md)).
+
+Consolidating on Postgres + PostGIS ([ADR 0032](0032-consolidate-datastore-on-postgres-postgis.md)) removed the database constraint: indexed `ORDER BY`, accurate `COUNT(*)`, `ST_DWithin` radius filtering, and spatial aggregation are all ordinary SQL. That made it both possible and necessary to move the query authority from the client to the server, so every client (iOS today, web next — #701) sees the same correct, paged, filtered, clustered view. The work landed as epic [#682](https://github.com/AmyDe/town-crier/issues/682) (server-side sort/filter and keyset paging, slices 1–4) and [#698](https://github.com/AmyDe/town-crier/issues/698) (server-side map clustering, which superseded the slice-5 client-drain approach).
+
+## Decision
+
+**Watch-zone application reads are server-authoritative.** The API owns sort, filter, paging, and clustering; clients send intent and render what they receive. Three mechanisms implement this:
+
+1. **Keyset (cursor) pagination.** `GET /v1/me/watch-zones/{zoneId}/applications` returns a bounded page plus an opaque base64url `X-Next-Cursor` header that encodes the sort position. Paging is keyset, not offset, so ordering stays deterministic while rows change underneath it. The cursor embeds the sort and filter it was issued under; a request whose sort or filter disagrees with its cursor is rejected with `400` (`ErrCursorSortMismatch` / `ErrCursorFilterMismatch`) rather than silently resetting to a different result set.
+
+2. **Server-side sort and filter.** Sort modes (`app_state` ASC, `start_date` DESC) and filters (status by `app_state`, unread via the notification-state read watermark) are applied in SQL. The server is the single authority for ordering and for the unread count, so every client agrees regardless of how much of the zone it has fetched.
+
+3. **Server-side map clustering.** `GET /v1/me/watch-zones/{zoneId}/applications/clusters` aggregates with PostGIS `ST_SnapToGrid` at a grid size derived from the requested zoom level, clipped to the visible viewport (`ST_MakeEnvelope`) and bounded to the zone circle (`ST_DWithin`). Each cell returns its centroid, member count, and per-status breakdown; single-member cells additionally carry `{authority, name}` so a tap goes straight to the summary. Output is capped at 1000 densest-first cells to bound the payload.
+
+iOS consumes all three: filter chips drive the server filter, infinite scroll follows the cursor, and `ClusteredMapView` renders the `/clusters` response (replacing client-side `MKClusterAnnotation`). The web map will consume the same endpoints (#701), so there is one querying contract across platforms.
+
+## Consequences
+
+### Easier
+
+- **Correctness is independent of zone size.** Sort, status/unread filtering, and counts are computed over the true result set in the database, so they are right for a 10-application village zone and a 20,000-application city zone alike.
+- **The map scales to dense zones.** Grid aggregation returns at most ~1000 cells instead of tens of thousands of pins, so a city-centre zone renders without flooding the client.
+- **Thin, interchangeable clients.** A client needs only to send sort/filter/viewport intent and render the response, which is why the same endpoints serve iOS and the forthcoming web map without re-implementing the logic twice.
+- **One source of truth.** The unread watermark, the ordering, and the cluster counts live in one place, so platforms cannot disagree.
+
+### Harder
+
+- **The cursor contract is strict by design.** A client that changes sort or filter must start a fresh page; reusing an old cursor returns `400`. This prevents silent, confusing result-set resets but means clients must handle the mismatch explicitly.
+- **Clustering is coupled to viewport and zoom.** The cluster set is only valid for the bounds and zoom it was requested at, so the client must refetch on pan/zoom (debounced ~250 ms on iOS) rather than reusing a single download.
+- **Paging bypasses the offline cache.** Paginated pages always hit the network, so the iOS offline cache ([ADR 0014](0014-ios-offline-first-architecture.md)) covers the first view of a zone but not deep scrolling — an accepted trade-off for correct, server-ordered paging.

--- a/docs/adr/0034-ios-crash-reporting-via-metrickit.md
+++ b/docs/adr/0034-ios-crash-reporting-via-metrickit.md
@@ -1,0 +1,33 @@
+# 0034. iOS crash and stability reporting via MetricKit
+
+Date: 2026-06-28
+
+## Status
+
+Accepted
+
+See also [ADR 0018](0018-opentelemetry-observability-with-azure-monitor.md) and [ADR 0027](0027-go-api-observability-via-aca-otel-agent.md) (backend observability), which this complements on the client side.
+
+## Context
+
+The Go backend has full observability — OpenTelemetry traces, metrics, and logs flowing to Azure Monitor ([ADR 0018](0018-opentelemetry-observability-with-azure-monitor.md), [ADR 0027](0027-go-api-observability-via-aca-otel-agent.md)). The iOS app had no equivalent: a crash in the field left no signal at all, so field stability was invisible.
+
+The obvious fix is a third-party crash SDK (Firebase Crashlytics, Sentry). Both are mature and give symbolicated, aggregated, near-real-time crash dashboards. But both also embed an SDK that collects device and installation identifiers and ships diagnostic payloads to a third-party backend. That conflicts directly with Town Crier's public privacy stance — "we do not track", no analytics pixels, no client-IP logging, data minimisation throughout (see the `no_track_privacy_stance` and `ip_logging_gdpr_minimisation` project context). Adding a tracking SDK purely for crash visibility would undercut a positioning the product makes explicitly to users, and would add a third-party dependency and binary weight for a pre-revenue solo app.
+
+## Decision
+
+**Use Apple's MetricKit for crash and stability reporting — first-party, on-device, no third-party SDK, no PII.** A `MetricKitCrashReporter` conforms to `MXMetricManagerSubscriber` and subscribes to MetricKit's diagnostic payloads (crash signal, termination reason, plus the stability and performance metrics MetricKit already gathers). Received payloads are written to the OS unified logger, where they can be read via Console.app or pulled from a device sysdiagnose. The OS batches and delivers these payloads on its own schedule (roughly 0–24 hours after the event); that latency is accepted as the cost of a zero-PII, zero-dependency approach.
+
+## Consequences
+
+### Easier
+
+- **Crash visibility with no privacy regression.** MetricKit is Apple's own framework, runs entirely on-device, and carries no user or installation identifier, so it is consistent with the "we do not track" stance rather than in tension with it.
+- **No third-party dependency.** No extra SDK to integrate, update, or audit, and no binary-size or supply-chain cost — it is part of the platform.
+- **Aligned with the existing posture.** Stability data surfaces through the OS logging tools the app already uses, keeping the diagnostic surface inside Apple's sandbox.
+
+### Harder
+
+- **No real-time alerting.** Delivery is OS-batched (0–24 h), so MetricKit cannot page on a crash spike the way Crashlytics/Sentry can — it is a trend-and-postmortem signal, not an incident trigger.
+- **No managed aggregation or symbolication dashboard.** There is no hosted UI grouping crashes by signature or auto-symbolicating stack traces; payloads are logged locally and must be collected (Console/sysdiagnose) or forwarded by future work if aggregation is ever needed.
+- **Coarse at low volume.** With few devices in the field, the batched, sampled nature of MetricKit makes it weak for reproducing a specific one-off crash quickly. If real-time field debugging becomes necessary, this decision should be revisited against a privacy-preserving forwarding option.

--- a/docs/memo/0001-cosmos-db-scaling-path.md
+++ b/docs/memo/0001-cosmos-db-scaling-path.md
@@ -4,7 +4,9 @@ Date: 2026-04-02
 
 ## Status
 
-Open
+Superseded by ADR [0032](../adr/0032-consolidate-datastore-on-postgres-postgis.md)
+
+> Resolved 2026-06-28. This memo's revisit trigger fired: Cosmos RU cost reached ~£37/month against the "~£15/month consistently" threshold set below, and the product's geographic query shape kept fighting the `/authorityCode` partition key. The migration target named here — Postgres + PostGIS — is exactly what shipped; Cosmos DB was retired entirely on 2026-06-27. The change-feed rearchitecture this memo feared as "the hardest part" never applied, because the Go system has no change feed. The decision is recorded in [ADR 0032](../adr/0032-consolidate-datastore-on-postgres-postgis.md) and the full analysis in [memo 0010](0010-cosmos-partition-strategy-and-postgres-postgis.md). Analysis below retained as the rationale trail.
 
 ## Question
 


### PR DESCRIPTION
## Changes
- Sync ADRs/memo to Postgres reality: update ADR 0001 & 0008 status, graduate Memo 0001 to Superseded, add ADR 0033 (server-authoritative watch-zone querying) and ADR 0034 (iOS crash reporting via MetricKit)
- Record first paying customer (2026-06-29); reverse fix-forward posture in CLAUDE.md — rollback safety, soak gates, and staged cutovers are back on the table

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project status to reflect that the product is now live, with rollback-safe deploy guidance and staged verification for production changes.
  * Added and revised architecture notes covering the latest backend, datastore, and operational decisions.
  * Recorded a server-authoritative approach for watch-zone queries, including cursor-based pagination, deterministic sorting, and clustered map results.
  * Added an iOS crash reporting note describing first-party stability reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->