### PR TITLE
fix(seo): treat IndexNow 403 as warning not failure

### DIFF
--- a/.github/workflows/seo-refresh.yml
+++ b/.github/workflows/seo-refresh.yml
@@ -239,4 +239,7 @@ jobs:
               \"urlList\": $urls
             }")
           echo "IndexNow response: $http_code — $(cat /tmp/indexnow-response.txt)"
-          [ "$http_code" = "200" ] || [ "$http_code" = "202" ] || { echo "IndexNow error $http_code"; exit 1; }
+          # 403 SiteVerificationNotCompleted is a transient CDN propagation race
+          # (key file just deployed); treat as a warning so the workflow doesn't
+          # fail — Bing will pick up the key on its next verification pass.
+          [ "$http_code" = "200" ] || [ "$http_code" = "202" ] || [ "$http_code" = "403" ] || { echo "IndexNow error $http_code"; exit 1; }


### PR DESCRIPTION
## Changes

- Allow HTTP 403 (`SiteVerificationNotCompleted`) from the IndexNow step without failing the workflow

## Context

The `seo-refresh` prod run just after the key file was first deployed got a 403 because Bing's CDN hadn't propagated the key file yet — it's a timing race. The direct submission moments later got a 200. Going forward the weekly run should always 200 (key file is stable), but tolerating 403 is cheap insurance against any future race.

---
*Auto-shipped via ship skill*