### PR TITLE
feat(db): notifications.read_at column + backfill + partial index (#733 step 1)

### DIFF
--- a/api-go/internal/notifications/read_at_backfill_integration_test.go
+++ b/api-go/internal/notifications/read_at_backfill_integration_test.go
@@ -1,0 +1,142 @@
+//go:build integration
+
+package notifications
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// These statements mirror migrations/0015_notifications_read_at.sql exactly. The
+// goose migration runs once, against the empty test database, when pgtest.New
+// applies the schema — so it cannot observe fixtures seeded afterwards. To
+// exercise the backfill against real rows we replay the identical UPDATEs here
+// after seeding a pre-migration state (notifications with read_at IS NULL plus a
+// watermark row), then assert the resulting read_at values. Keep these in sync
+// with the migration.
+const (
+	backfillWatermarkedSQL = `
+UPDATE notifications n
+SET read_at = ns.last_read_at
+FROM notification_state ns
+WHERE n.user_id = ns.user_id
+  AND n.created_at <= ns.last_read_at
+  AND n.read_at IS NULL`
+
+	backfillNoWatermarkSQL = `
+UPDATE notifications n
+SET read_at = n.created_at
+WHERE n.read_at IS NULL
+  AND NOT EXISTS (SELECT 1 FROM notification_state ns WHERE ns.user_id = n.user_id)`
+)
+
+// TestIntegration_Migration0015_ReadAtBackfill asserts the acceptance criteria for
+// the read_at backfill: a notification at or before a watermarked user's
+// last_read_at gets a non-null read_at (== the watermark); one after the watermark
+// stays NULL; and a notification for a user with no watermark row gets read_at ==
+// created_at.
+func TestIntegration_Migration0015_ReadAtBackfill(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "notifications", "notification_state")
+	store := NewPostgresStore(pool)
+	ctx := context.Background()
+
+	watermark := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	before := watermark.Add(-24 * time.Hour) // strictly before the watermark
+	after := watermark.Add(24 * time.Hour)   // strictly after the watermark
+	nowmCreated := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	// Seed via the store's Create (which does not set read_at, so every seeded row
+	// starts read_at IS NULL — the pre-migration state).
+	for _, n := range []DigestNotification{
+		intNotif("pre", "u-wm", "uid-pre", EventNewApplication, before),
+		intNotif("exact", "u-wm", "uid-exact", EventNewApplication, watermark),
+		intNotif("post", "u-wm", "uid-post", EventNewApplication, after),
+		intNotif("nowm", "u-nowm", "uid-nowm", EventNewApplication, nowmCreated),
+	} {
+		if err := store.Create(ctx, n); err != nil {
+			t.Fatalf("seed %s: %v", n.ID, err)
+		}
+	}
+
+	// Watermark row for u-wm only; u-nowm has none.
+	if _, err := pool.Exec(ctx,
+		"INSERT INTO notification_state (user_id, last_read_at, version) VALUES ($1, $2, $3)",
+		"u-wm", watermark, 1); err != nil {
+		t.Fatalf("seed watermark: %v", err)
+	}
+
+	// Every row must start unread (read_at NULL) before the backfill runs.
+	for _, id := range []string{"pre", "exact", "post", "nowm"} {
+		if got := readReadAt(t, pool, id); got != nil {
+			t.Fatalf("pre-backfill read_at for %s: got %v, want NULL", id, got)
+		}
+	}
+
+	// Replay the migration backfill.
+	if _, err := pool.Exec(ctx, backfillWatermarkedSQL); err != nil {
+		t.Fatalf("backfill watermarked: %v", err)
+	}
+	if _, err := pool.Exec(ctx, backfillNoWatermarkSQL); err != nil {
+		t.Fatalf("backfill no-watermark: %v", err)
+	}
+
+	// At/before the watermark → read_at == watermark (inclusive boundary).
+	assertReadAt(t, pool, "pre", &watermark)
+	assertReadAt(t, pool, "exact", &watermark)
+	// After the watermark → still unread.
+	assertReadAt(t, pool, "post", nil)
+	// No watermark row → read_at == the notification's own created_at.
+	assertReadAt(t, pool, "nowm", &nowmCreated)
+}
+
+// TestIntegration_Migration0015_PartialIndexExists proves migration 0015's
+// CREATE INDEX ran: the partial index over the unread set exists with the expected
+// columns and read_at IS NULL predicate.
+func TestIntegration_Migration0015_PartialIndexExists(t *testing.T) {
+	pool := pgtest.New(t)
+
+	var indexDef string
+	err := pool.QueryRow(context.Background(),
+		"SELECT indexdef FROM pg_indexes WHERE indexname = 'idx_notifications_unread'").
+		Scan(&indexDef)
+	if err != nil {
+		t.Fatalf("query idx_notifications_unread def: %v", err)
+	}
+
+	for _, want := range []string{"user_id", "application_uid", "created_at", "read_at IS NULL"} {
+		if !strings.Contains(indexDef, want) {
+			t.Errorf("index def %q missing %q", indexDef, want)
+		}
+	}
+}
+
+// readReadAt returns the (nullable) read_at for the notification with the given id.
+func readReadAt(t *testing.T, pool *pgxpool.Pool, id string) *time.Time {
+	t.Helper()
+	var readAt *time.Time
+	if err := pool.QueryRow(context.Background(),
+		"SELECT read_at FROM notifications WHERE id = $1", id).Scan(&readAt); err != nil {
+		t.Fatalf("scan read_at for %s: %v", id, err)
+	}
+	return readAt
+}
+
+// assertReadAt asserts the notification's read_at matches want (nil = NULL).
+func assertReadAt(t *testing.T, pool *pgxpool.Pool, id string, want *time.Time) {
+	t.Helper()
+	got := readReadAt(t, pool, id)
+	switch {
+	case want == nil && got != nil:
+		t.Errorf("%s read_at: got %v, want NULL", id, got)
+	case want != nil && got == nil:
+		t.Errorf("%s read_at: got NULL, want %v", id, *want)
+	case want != nil && got != nil && !got.Equal(*want):
+		t.Errorf("%s read_at: got %v, want %v", id, *got, *want)
+	}
+}

--- a/api-go/internal/platform/postgres/migrations/0015_notifications_read_at.sql
+++ b/api-go/internal/platform/postgres/migrations/0015_notifications_read_at.sql
@@ -1,0 +1,47 @@
+-- +goose Up
+
+-- Per-application read state (issue #733, step 1 of 3). Adds a nullable read_at
+-- to notifications so opening an application can mark only that application's
+-- notifications read for the user (tap-to-read), replacing the single per-user
+-- watermark (notification_state.last_read_at). This migration is deployed ALONE
+-- and is deliberately additive/back-compatible: the running API ignores read_at
+-- and keeps computing unread from the watermark, so nothing breaks until the API
+-- flips to read_at in step 2. The two backfills below make the read_at-based
+-- unread set identical to the watermark-based one at flip time.
+ALTER TABLE notifications ADD COLUMN read_at timestamptz NULL;
+
+-- Watermarked users: everything at or before the watermark is already read, so
+-- stamp read_at with the watermark. Inclusive (<=) mirrors the watermark rule
+-- where created_at == last_read_at counts as read.
+UPDATE notifications n
+SET read_at = ns.last_read_at
+FROM notification_state ns
+WHERE n.user_id = ns.user_id
+  AND n.created_at <= ns.last_read_at
+  AND n.read_at IS NULL;
+
+-- Users with no watermark row read as all-read today (the old GET seeded a
+-- first-touch watermark of "now" on first access, so their history was never
+-- unread). Mark their existing notifications read at their own created_at. Disjoint
+-- from the first UPDATE: this only touches users absent from notification_state.
+UPDATE notifications n
+SET read_at = n.created_at
+WHERE n.read_at IS NULL
+  AND NOT EXISTS (SELECT 1 FROM notification_state ns WHERE ns.user_id = n.user_id);
+
+-- Partial index over the unread set only. Leading user_id (equality) then
+-- application_uid (the per-application mark-read/GROUP BY key) then created_at,
+-- with the WHERE read_at IS NULL predicate keeping the index tiny and self-pruning
+-- as rows are marked read. Backs the step-2 unread-count, latest-unread-per-app,
+-- and zonepage unread-filter queries.
+CREATE INDEX IF NOT EXISTS idx_notifications_unread
+    ON notifications (user_id, application_uid, created_at)
+    WHERE read_at IS NULL;
+
+-- +goose Down
+
+-- The backfill is not reversible (the pre-migration all-NULL read_at state is not
+-- recoverable), which is fine for a Down: dropping the column discards read_at
+-- entirely and the watermark in notification_state remains authoritative.
+DROP INDEX IF EXISTS idx_notifications_unread;
+ALTER TABLE notifications DROP COLUMN IF EXISTS read_at;


### PR DESCRIPTION
## Changes

Step 1 of 3 for #733 (per-application notification read state). This migration deploys **alone** and is deliberately additive and back-compatible — the running API ignores the new column and keeps computing unread from the `notification_state` watermark, so nothing breaks until the API flips to `read_at` in step 2.

- New migration `0015_notifications_read_at.sql`:
  - `ALTER TABLE notifications ADD COLUMN read_at timestamptz NULL`
  - Backfill #1 — watermarked users: `read_at = last_read_at` where `created_at <= last_read_at`
  - Backfill #2 — users with no watermark row: `read_at = created_at` (their history read as all-read under the old first-touch watermark)
  - `CREATE INDEX idx_notifications_unread ON notifications (user_id, application_uid, created_at) WHERE read_at IS NULL` — partial, self-pruning
- Integration test (`//go:build integration`, `pgtest` harness): asserts the backfill boundary cases (pre/at watermark → non-null `read_at`; post-watermark → NULL; no-watermark user → `read_at = created_at`) and that the partial index exists after 0015 runs.

The two backfills make the `read_at`-based unread set identical to the watermark-based one at the step-2 flip.

Bead: tc-0sfx.1 · Epic: tc-0sfx · Issue: #733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications now track when they were read, enabling more accurate unread status.
  * Existing notifications are automatically backfilled so older items reflect the correct read state.
  * Unread notifications are optimized for faster loading with a new index behind the scenes.

* **Bug Fixes**
  * Notifications without prior read history are now treated as read based on when they were created, preventing incorrect unread counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->