### PR TITLE
feat(api): per-application notification read state + ADR 0035 (#733 step 2)

### DIFF
--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -65,9 +65,9 @@ Two non-negotiables, baked into the brief:
 
 **Dev test login (non-sensitive — keep it in this skill and in the brief):** `christy+tctest10@salter.uk` / `StrongPassword1!`. Use it for the password grant above (local authed+seeded web) or to sign in directly against deployed **dev** (iOS DEBUG, or web pointed at the dev API) when no local seed is needed.
 
-### Execution-environment gotchas (carry a terse line into the brief)
+### Execution-environment gotchas (your reference — the brief points at these, it does not inline them)
 
-These each cost a real session a cycle — bake them in so the next one doesn't rediscover them:
+These each cost a real session a cycle. The brief surfaces them by pointing at the two local-stack memories and CLAUDE.md (the worktree-reset one is already spelled out in the template's DELIVERY step); it does **not** inline them, or the brief blows the 3k cap. Keep this list as your own quick reference:
 
 - **RTK mangles shell output.** A shell hook proxies `curl`, `eslint`, `vitest`, `grep`/`rg` through RTK, which can dump output to stdout (it once **leaked an access token** and broke a pipe), invent phantom lint errors, or print a false "SCOPE VIOLATION". For anything whose output you parse, bypass it: `/usr/bin/curl`, `node ./node_modules/eslint/bin/eslint.js src`, `node ./node_modules/vitest/vitest.mjs run`, plain `grep`, or `rtk proxy <cmd>`.
 - **`curl --data-urlencode` for any value with `+`/reserved chars** — the `+` in the test email sent via plain `--data` is form-decoded to a space → `invalid_grant` "wrong email or password".
@@ -80,61 +80,43 @@ Tool limits to flag rather than paper over: mobile-mcp has no pinch/two-finger g
 
 Output the brief to the user as a single fenced block they can copy. Tell them plainly: **run `/goal` in a fresh session and paste this as the goal.** Fill every placeholder from Phase 1–2; drop any line that genuinely doesn't apply rather than leaving a placeholder.
 
-**MUST verify length before you emit.** Write the brief to its temp deliverable file (see Phase 4 — outside the repo) and measure it — e.g. `python3 -c "print(len(open('<file>').read()))"` (do not trust `wc -c`; a shell proxy can mangle it). If the count is **≥ 3000**, condense and re-measure until it is **< 3000**; only then print the fenced block. State the final character count in one line beneath the block so the user can see it cleared the limit. Never emit a brief you have not measured.
+**MUST verify length before you emit.** Write the brief to its temp deliverable file (see Phase 4 — outside the repo) and measure it — e.g. `python3 -c "print(len(open('<file>').read()))"` (do not trust `wc -c`; a shell proxy can mangle it). If the count is **≥ 3000**, condense and re-measure until it is **< 3000**; only then print the fenced block. State the final character count in one line beneath the block so the user can see it cleared the limit. Never emit a brief you have not measured. The empty template runs ~2.1k, so treat the remaining ~900 as your content budget and aim to land **≤ 2600** — margin so a later tweak can't tip it over 3k. If you're over, cut inlined detail and point at the issue/memories; never trim by dropping guardrails.
 
 ````
-GOAL: <one-sentence objective>. Keep working until this is delivered and shipped.
-DONE WHEN: <testable acceptance — what must be true to call it finished>.
+GOAL: <one-sentence objective>. Keep working until it is delivered and shipped.
+DONE WHEN: <testable acceptance>.
 
-SPEC (source of truth): <github-issue-url>
-Read it first: `gh issue view <n>`. The issue body holds the what/how/why and the
-acceptance criteria, and is authoritative — if it conflicts with this brief, the issue
-wins and you flag the discrepancy rather than guessing.
+SPEC (source of truth): <github-issue-url> — read first: `gh issue view <n>`. The issue is
+authoritative; if it conflicts with this brief, the issue wins and you flag it.
 
-BEAD(S): <tc-id> — <title>. Claim before editing: `bd update <tc-id> --status=in_progress`.
-Close it when the acceptance is met. (No bead yet for some slice? Create one — every code
-change needs a bead.)
+BEAD(S): <tc-id> — <title>. Claim before editing (`bd update <tc-id> --status=in_progress`),
+close when acceptance is met. No bead for a slice? Create one — every code change needs a bead.
 
-DELIVERY — you are the orchestrator; you do NOT write code yourself:
-  1. Worktree first. Create an isolated worktree (`bd worktree create <name> --branch <branch>`),
-     apply the two bd worktree workarounds (GH#3421 port symlink + `chmod 700 .beads/`, see
-     CLAUDE.md), then `git -C <wt> reset --hard origin/main` (it bases off the current branch's
-     HEAD, NOT origin/main — verify `log -1` matches). Dispatch the worker with the path in hand.
-  2. Dispatch the matching TDD worker for the tech area:
-       <selected worker(s) and allowed path(s) from Phase 2>
-     The worker consults its coding-standards skill; UI work also consults design-language.
-  3. OUT OF BOUNDARY: <only if applicable> this work has no TDD worker home, so dispatch a
-     raw `general-purpose` subagent with a prompt that names the exact files (<files>), the
-     acceptance, and the guardrails below. Do not force a misfit TDD worker onto it.
-  4. Validate: run the stack's test/build command and confirm it passes (`go test ./...` /
-     `swift test` / `npx vitest run`). UI change? ALSO verify locally (see VERIFY LOCALLY) —
-     do NOT ship until the running app shows the change correct. Then ship via `/ship` — PR +
-     gate, never a direct push to main.
+DELIVERY — you orchestrate; you do NOT write code yourself:
+  1. Worktree-first: `bd worktree create <name> --branch <branch>`, apply the two bd worktree
+     workarounds, then `git -C <wt> reset --hard origin/main` (it bases off current HEAD, not
+     origin/main — verify `log -1`). See CLAUDE.md.
+  2. Dispatch the matching TDD worker: <worker(s) + allowed path(s)>. UI work also consults
+     design-language. <Out of boundary? dispatch a general-purpose subagent naming the exact
+     files + acceptance + these guardrails instead.>
+  3. Validate the stack's tests/build, then ship via `/ship` (PR + gate, never push to main).
 
-CURRENT STATE:
-  - Branch: <branch>
-  - Landed: <what's already done / merged>
-  - Remaining: <the concrete slices left, in order>
+CURRENT STATE: branch <branch>; landed <done>; remaining <slices, in order>.
 
-VERIFY LOCALLY <keep only for an iOS/web UI change; delete for backend/infra>: before the PR,
-drive the running app from a SONNET subagent (agent-browser=web, mobile-mcp=iOS; reports TEXT,
-screenshots bloat context) and eyeball the change. Data-dependent + authed web ⇒ run the FULL
-stack locally (deployed dev has no seed): `make -C api-go db-up` then migrate (goose-as-library,
-lib/pq) + seed, local `cmd/api` (POSTGRES_AUTH unset, CORS localhost:5173), Vite :5173, and an
-Auth0 password-grant token injected into localStorage (dev SPA blocks localhost login). Recipe +
-scripts: memories reference_local_api_stack_and_seed + reference_local_web_browser_verification_auth.
-Test login: christy+tctest10@salter.uk / StrongPassword1! (non-sensitive). Verify each bead on
-its OWN worktree build. ENV: RTK mangles curl/eslint/vitest/grep — use /usr/bin/curl, the
-node_modules bins, plain grep; `curl --data-urlencode` for the `+` in the email.
+VERIFY LOCALLY <keep only for an iOS/web UI change; else delete>: before the PR, drive the
+running app from a SONNET subagent (mobile-mcp=iOS, agent-browser=web; report TEXT — screenshots
+bloat context) and eyeball the change. Data-dependent + authed ⇒ stand up the full local stack;
+the recipe, seed scripts, test creds, and the RTK + auth-wall gotchas live in memories
+reference_local_api_stack_and_seed + reference_local_web_browser_verification_auth.
 
-KEY DECISIONS (already settled — don't reopen): <decisions, or "none">
-BLOCKERS: <blocker, or "none">
-NEXT CONCRETE STEP: <the single first action the new session should take>
+KEY DECISIONS (settled — don't reopen): <decisions, or none>.
+BLOCKERS: <blocker, or none>.
+NEXT STEP: <the single first action>.
 
-GUARDRAILS: worktree-first; bead-first (a bead per code change, closed when done); tests/build
-green before ship; PR-only — no direct deploys via az/pulumi/git push to main; fix-forward
-(pre-revenue, no rollback/soak). Hold and flag anything privacy/GDPR/auth/telemetry-sensitive
-that the issue doesn't explicitly authorise rather than committing it.
+GUARDRAILS: worktree-first; bead-first (closed when done); tests/build green before ship; PR-only
+(no az/pulumi or direct push to main). Paying customers now — prefer rollback-safe, staged change
+over blunt cutovers (CLAUDE.md Business Status). Hold and flag anything privacy/GDPR/auth/telemetry
+the issue doesn't authorise rather than committing it.
 ````
 
 After the block, in one or two lines, point the user at the spec issue URL and the bead id so they can sanity-check before pasting.
@@ -157,12 +139,12 @@ Also remind the user how to confirm it armed: send `/clear` and `/goal` as **sep
 
 ## Rules
 
-- **Under 3000 characters, measured — not estimated.** The brief is hard-capped at <3k chars because `/goal` truncates beyond it. Write it to a file, count it (`python3 -c "print(len(open('f').read()))"`), and condense until it clears. An over-length brief is a defective brief.
+- **Under 3000 characters, measured — not estimated.** The brief is hard-capped at <3k chars because `/goal` truncates beyond it. Write it to a file, count it (`python3 -c "print(len(open('f').read()))"`), and condense until it clears. An over-length brief is a defective brief. The template skeleton alone runs ~2.1k, so the fixed scaffolding must not regrow: if an edit pushes the *empty* template back toward 3k, that content belongs in Phase 2 guidance or a memory, not in the emitted brief.
 - **Reference a real GitHub issue.** The spec is the issue, never a repo file. No issue → tell the user to raise one with `file-issue` first.
 - **One goal, testable.** The brief names a single objective with a concrete "done when". If the scope is really two goals, say so and produce two briefs.
 - **Self-contained.** Assume zero conversation history. Anything the new session needs goes in the brief.
 - **TDD worker by default, raw subagent only out of boundary.** Pick the worker from the table; reach for a `general-purpose` subagent only when nothing fits, and give it a tailored prompt.
 - **Orchestrator never writes code.** The brief always routes implementation through a worker or subagent in a worktree, validated by tests, shipped via PR.
 - **Visual-verify iOS/web UI changes before ship — always via a Sonnet subagent.** Any user-visible iOS or web change in the handover must instruct the new session to drive the running app and eyeball the change locally *before* the PR opens, and that driving (mobile-mcp / agent-browser) must run in a `model: sonnet` subagent that reports findings as text — their screenshots bloat context. Use the local Docker stack (`make -C api-go db-up` + local `cmd/api`) to simulate data-dependent scenarios without remote infra. Omit the VERIFY LOCALLY block entirely for backend/infra/CI/docs handovers.
-- **Carry the execution-environment gotchas.** Any brief that involves a worktree, shell tooling, or local web/iOS verification must surface the gotchas from Phase 2 (RTK mangling → bypass binaries; `bd worktree create` wrong-bases → reset to origin/main; `--data-urlencode` for the `+` email; the localhost auth wall + password-grant injection; verify each bead on its own build). Inline the test creds; lean on the two local-stack memories for the long-form recipe so the brief stays under 3k.
+- **Point at the execution-environment gotchas — don't inline them.** A brief that involves a worktree, shell tooling, or local web/iOS verification must make the gotchas reachable, but by *reference*: the worktree-reset one-liner already sits in the template's DELIVERY step, and the RTK / `--data-urlencode` / auth-wall / password-grant recipe plus the test creds live in the two local-stack memories the VERIFY LOCALLY block names. Inlining that prose is exactly what blew the 3k cap — resist it.
 - **Don't implement.** This skill produces the brief and stops.

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -190,7 +190,7 @@ func newRouter(
 		applications.RecentRoutes(mux, appStore, siteBuildKey, logger)
 		applications.NearRoutes(mux, appStore, siteBuildKey, logger)
 	}
-	if store != nil && watchZoneStore != nil && appStore != nil && stateStore != nil && notifStore != nil {
+	if store != nil && watchZoneStore != nil && appStore != nil && notifStore != nil {
 		// Watch-zone create (returns nearby applications) + the per-zone
 		// applications list. Create enforces the tier's zone quota atomically via
 		// CAS on the profile counter (WithProfileCAS) — this is the only create
@@ -198,8 +198,8 @@ func newRouter(
 		// store is non-nil here (guarded above), so no typed-nil concern. It
 		// resolves the authority from coordinates via the geocode client when the
 		// request omits one; the applications list augments each row with its
-		// latest unread notification.
-		watchzones.NearbyRoutes(mux, watchZoneStore, store, geocodeClient, appStore, stateStore, notifStore, uuid.NewString, time.Now, logger, watchzones.WithMetricsRecorder(registry), watchzones.WithProfileCAS(store))
+		// latest unread notification (read_at IS NULL, ADR 0035).
+		watchzones.NearbyRoutes(mux, watchZoneStore, store, geocodeClient, appStore, notifStore, uuid.NewString, time.Now, logger, watchzones.WithMetricsRecorder(registry), watchzones.WithProfileCAS(store))
 	}
 	if store != nil && watchZoneStore != nil && appStore != nil {
 		// Demo account (anonymous): seeds a Pro profile, a Westminster watch zone,

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -77,7 +77,7 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // store wired into NearbyRoutes must satisfy. *notifications.PostgresStore (which
 // satisfies the full notifications.Store) satisfies it structurally.
 type notifUnreadReader interface {
-	GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string, lastReadAt time.Time) (map[string]notifications.LatestUnread, error)
+	GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string) (map[string]notifications.LatestUnread, error)
 }
 
 // newRouter wires the feature routes onto a mux and wraps it in the production

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -762,10 +762,10 @@ func newActivityPGStore(t *testing.T) (*PostgresStore, *pgxpool.Pool) {
 	return NewPostgresStore(pool), pool
 }
 
-// seedWatermark inserts the caller's notification read-watermark. Without a
-// watermark row the recent-activity join classifies nothing as unread (the
-// INNER JOIN to notification_state yields no rows), matching the handler's
-// first-touch rule.
+// seedWatermark inserts the caller's notification_state row. Under read_at (ADR
+// 0035) the recent-activity/unread queries no longer JOIN this table; the row is
+// seeded so backfillReadAt can derive read_at from it, exactly reproducing the
+// old watermark semantics for the equivalence assertions.
 func seedWatermark(t *testing.T, pool *pgxpool.Pool, userID string, lastReadAt time.Time) {
 	t.Helper()
 	if _, err := pool.Exec(context.Background(),
@@ -775,8 +775,9 @@ func seedWatermark(t *testing.T, pool *pgxpool.Pool, userID string, lastReadAt t
 	}
 }
 
-// seedNotification inserts one notification for the caller. authorityID is the
-// INTEGER authority_id that the recent-activity join matches against the
+// seedNotification inserts one UNREAD notification for the caller (read_at NULL —
+// the pre-backfill state). authorityID is the INTEGER authority_id the
+// recent-activity subquery groups on and the outer join matches against the
 // application's area_id (NOT the text authority_code).
 func seedNotification(t *testing.T, pool *pgxpool.Pool, id, userID, appUID string, authorityID int, createdAt time.Time) {
 	t.Helper()
@@ -785,6 +786,33 @@ func seedNotification(t *testing.T, pool *pgxpool.Pool, id, userID, appUID strin
 			"VALUES ($1, $2, $3, $4, $5, $6)",
 		id, userID, appUID, authorityID, "NewApplication", createdAt); err != nil {
 		t.Fatalf("seed notification %q: %v", id, err)
+	}
+}
+
+// backfillReadAt replays migration 0015's two backfill UPDATEs, deriving read_at
+// from the seeded watermark rows. Calling it after a watermark+notification
+// fixture makes read_at IS NULL reproduce the old created_at > last_read_at unread
+// set exactly — the equivalence acceptance criterion (ADR 0035). A notification for
+// a user with NO watermark row is marked read (read_at = created_at), matching the
+// old "no notification_state ⇒ no unread" behaviour for existing users.
+func backfillReadAt(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `
+UPDATE notifications n
+SET read_at = ns.last_read_at
+FROM notification_state ns
+WHERE n.user_id = ns.user_id
+  AND n.created_at <= ns.last_read_at
+  AND n.read_at IS NULL`); err != nil {
+		t.Fatalf("backfill watermarked: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+UPDATE notifications n
+SET read_at = n.created_at
+WHERE n.read_at IS NULL
+  AND NOT EXISTS (SELECT 1 FROM notification_state ns WHERE ns.user_id = n.user_id)`); err != nil {
+		t.Fatalf("backfill no-watermark: %v", err)
 	}
 }
 
@@ -817,6 +845,8 @@ func activityFixture(t *testing.T, store *PostgresStore, pool *pgxpool.Pool, use
 	seedWatermark(t, pool, userID, jan)
 	// AA's unread event, later than BB's newest start_date, floats AA to the top.
 	seedNotification(t, pool, "n-AA", userID, "uid-AA", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+	// Derive read_at from the watermark: n-AA (after jan) stays unread (read_at NULL).
+	backfillReadAt(t, pool)
 }
 
 // TestPostgresStore_FindInZonePage_RecentActivity proves the GREATEST(start_date,
@@ -870,6 +900,7 @@ func TestPostgresStore_FindInZonePage_RecentActivity_JoinKey(t *testing.T) {
 	// A fresh unread for X's uid but under the WRONG authority (999 != 100). The
 	// join requires area_id = authority_id, so this must not touch X's activity.
 	seedNotification(t, pool, "n-wrong", userID, "uid-X", 999, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+	backfillReadAt(t, pool) // n-wrong (after jan) stays unread, but under authority 999.
 
 	want := []string{"Y", "X"} // Y(feb) > X(jan); the wrong-authority unread is ignored.
 	if got := pageAllInZoneAs(t, store, userID, SortRecentActivity, 6000, 100); !reflect.DeepEqual(got, want) {
@@ -877,11 +908,12 @@ func TestPostgresStore_FindInZonePage_RecentActivity_JoinKey(t *testing.T) {
 	}
 }
 
-// TestPostgresStore_FindInZonePage_RecentActivity_FirstTouch proves a caller with
-// NO notification_state row has no unread anywhere (the INNER JOIN to
-// notification_state yields nothing), so recent-activity orders by start_date
-// alone — even when a matching notification exists.
-func TestPostgresStore_FindInZonePage_RecentActivity_FirstTouch(t *testing.T) {
+// TestPostgresStore_FindInZonePage_RecentActivity_ExistingNoWatermark proves an
+// existing (pre-migration) caller with NO notification_state row has no unread: the
+// 0015 backfill marked their history read (read_at = created_at), so read_at IS NULL
+// yields nothing and recent-activity orders by start_date alone. This is the
+// equivalence to the old "no notification_state ⇒ no unread" behaviour (ADR 0035).
+func TestPostgresStore_FindInZonePage_RecentActivity_ExistingNoWatermark(t *testing.T) {
 	store, pool := newActivityPGStore(t)
 	ctx := context.Background()
 	const userID = "user-firsttouch"
@@ -897,17 +929,47 @@ func TestPostgresStore_FindInZonePage_RecentActivity_FirstTouch(t *testing.T) {
 	}
 	// NOTE: no seedWatermark — the user has never read, so has no state row.
 	seedNotification(t, pool, "n-P", userID, "uid-P", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+	backfillReadAt(t, pool) // no-watermark backfill marks n-P read (read_at = created_at).
 
-	want := []string{"Q", "P"} // Q(feb) > P(jan); no watermark means P's notification is not unread.
+	want := []string{"Q", "P"} // Q(feb) > P(jan); the backfilled notification is read.
 	if got := pageAllInZoneAs(t, store, userID, SortRecentActivity, 6000, 100); !reflect.DeepEqual(got, want) {
-		t.Fatalf("recent-activity first-touch: got %v, want %v (no watermark means no unread influence)", got, want)
+		t.Fatalf("recent-activity existing-no-watermark: got %v, want %v (backfilled history is read)", got, want)
 	}
 }
 
-// TestPostgresStore_FindInZonePage_RecentActivity_StrictUnread proves the unread
-// predicate is a STRICT created_at > last_read_at: a notification created exactly
-// at the watermark is read, not unread, so it does not contribute to activity.
-func TestPostgresStore_FindInZonePage_RecentActivity_StrictUnread(t *testing.T) {
+// TestPostgresStore_FindInZonePage_RecentActivity_NewUnreadSurfaces proves the new
+// semantic: a genuinely-new caller (no watermark, no backfill) whose notification is
+// unread (read_at IS NULL) DOES surface it — the unread event floats the app above a
+// newer-start_date app with no unread. This is the behaviour change GET-no-seed
+// enables (ADR 0035).
+func TestPostgresStore_FindInZonePage_RecentActivity_NewUnreadSurfaces(t *testing.T) {
+	store, pool := newActivityPGStore(t)
+	ctx := context.Background()
+	const userID = "user-new"
+	jan := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	feb := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	for _, a := range []PlanningApplication{
+		withStart(at(pgApp("P", 100), 100), jan), // oldest start, fresh unread
+		withStart(at(pgApp("Q", 100), 200), feb), // newer start, no notification
+	} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+	// No watermark, no backfill: the notification stays unread (read_at IS NULL).
+	seedNotification(t, pool, "n-P", userID, "uid-P", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+
+	want := []string{"P", "Q"} // P's unread (jun15) floats it above Q(feb).
+	if got := pageAllInZoneAs(t, store, userID, SortRecentActivity, 6000, 100); !reflect.DeepEqual(got, want) {
+		t.Fatalf("recent-activity new-unread: got %v, want %v (a new unread must surface)", got, want)
+	}
+}
+
+// TestPostgresStore_FindInZonePage_RecentActivity_AtWatermarkIsRead proves a
+// notification created exactly at the watermark is read after backfill (the 0015
+// UPDATE uses created_at <= last_read_at), so read_at IS NULL excludes it — the
+// equivalence of the old strict created_at > last_read_at predicate (ADR 0035).
+func TestPostgresStore_FindInZonePage_RecentActivity_AtWatermarkIsRead(t *testing.T) {
 	store, pool := newActivityPGStore(t)
 	ctx := context.Background()
 	const userID = "user-strict"
@@ -923,13 +985,14 @@ func TestPostgresStore_FindInZonePage_RecentActivity_StrictUnread(t *testing.T) 
 		}
 	}
 	seedWatermark(t, pool, userID, watermark)
-	// created_at == last_read_at: read, not unread (strict >), so M's activity is
-	// its start_date, not this timestamp.
+	// created_at == last_read_at: backfilled read (created_at <= last_read_at), so
+	// M's activity is its start_date, not this timestamp.
 	seedNotification(t, pool, "n-M", userID, "uid-M", 100, watermark)
+	backfillReadAt(t, pool)
 
 	want := []string{"N", "M"} // N(feb) > M(jan); the at-watermark notification is read.
 	if got := pageAllInZoneAs(t, store, userID, SortRecentActivity, 6000, 100); !reflect.DeepEqual(got, want) {
-		t.Fatalf("recent-activity strict-unread: got %v, want %v (a notification exactly at the watermark is read)", got, want)
+		t.Fatalf("recent-activity at-watermark: got %v, want %v (a notification exactly at the watermark is read)", got, want)
 	}
 }
 
@@ -1010,6 +1073,8 @@ func unreadFixture(t *testing.T, store *PostgresStore, pool *pgxpool.Pool, userI
 	seedNotification(t, pool, "n-U1", userID, "uid-U1", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)) // > watermark: unread
 	seedNotification(t, pool, "n-U2", userID, "uid-U2", 100, time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))  // < watermark: read
 	seedNotification(t, pool, "n-U4", userID, "uid-U4", 100, time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)) // > watermark: unread
+	// Backfill derives read_at: n-U2 (<= watermark) becomes read; n-U1/n-U4 stay unread.
+	backfillReadAt(t, pool)
 }
 
 // TestPostgresStore_FindInZonePage_UnreadFilter proves ?unread=true (the INNER
@@ -1042,11 +1107,11 @@ func TestPostgresStore_FindInZonePage_UnreadFilter(t *testing.T) {
 	}
 }
 
-// TestPostgresStore_FindInZonePage_UnreadFilter_FirstTouch proves a caller with NO
-// notification_state row (never read) gets the empty set under ?unread=true — the
-// INNER JOIN to notification_state yields nothing, even though matching
-// notifications exist.
-func TestPostgresStore_FindInZonePage_UnreadFilter_FirstTouch(t *testing.T) {
+// TestPostgresStore_FindInZonePage_UnreadFilter_ExistingNoWatermark proves an
+// existing (pre-migration) caller with NO notification_state row gets the empty set
+// under ?unread=true: the 0015 backfill marked their history read, so read_at IS NULL
+// yields nothing (ADR 0035 equivalence to the old INNER-JOIN behaviour).
+func TestPostgresStore_FindInZonePage_UnreadFilter_ExistingNoWatermark(t *testing.T) {
 	store, pool := newActivityPGStore(t)
 	ctx := context.Background()
 	const userID = "user-firsttouch"
@@ -1055,16 +1120,40 @@ func TestPostgresStore_FindInZonePage_UnreadFilter_FirstTouch(t *testing.T) {
 	if err := store.Upsert(ctx, app); err != nil {
 		t.Fatalf("Upsert: %v", err)
 	}
-	// A notification exists, but with no watermark row the user has read nothing,
-	// so the unread subquery (INNER to notification_state) contributes nothing.
 	seedNotification(t, pool, "n-Z1", userID, "uid-Z1", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+	backfillReadAt(t, pool) // no-watermark backfill marks n-Z1 read.
 
 	got := pageAllFiltered(t, store, InZoneQuery{
 		UserID: userID, Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,
 		Sort: SortNewest, Unread: true, Limit: 10,
 	})
 	if len(got) != 0 {
-		t.Fatalf("first-touch unread=true: got %v, want empty (no notification_state ⇒ no unread)", got)
+		t.Fatalf("existing-no-watermark unread=true: got %v, want empty (backfilled history is read)", got)
+	}
+}
+
+// TestPostgresStore_FindInZonePage_UnreadFilter_NewUnreadSurfaces proves the new
+// semantic through the dynamic filtered-query builder: a genuinely-new caller (no
+// watermark, no backfill) whose notification is unread (read_at IS NULL) keeps the
+// app under ?unread=true.
+func TestPostgresStore_FindInZonePage_UnreadFilter_NewUnreadSurfaces(t *testing.T) {
+	store, pool := newActivityPGStore(t)
+	ctx := context.Background()
+	const userID = "user-new"
+	jan := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	app := withStart(at(pgApp("Z1", 100), 100), jan)
+	if err := store.Upsert(ctx, app); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	// No watermark, no backfill: the notification stays unread (read_at IS NULL).
+	seedNotification(t, pool, "n-Z1", userID, "uid-Z1", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+
+	got := pageAllFiltered(t, store, InZoneQuery{
+		UserID: userID, Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,
+		Sort: SortNewest, Unread: true, Limit: 10,
+	})
+	if want := []string{"Z1"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("new-unread unread=true: got %v, want %v (a new unread must be kept)", got, want)
 	}
 }
 
@@ -1091,6 +1180,7 @@ func TestPostgresStore_FindInZonePage_UnreadFilter_RecentActivity(t *testing.T) 
 	seedWatermark(t, pool, userID, jan)
 	seedNotification(t, pool, "n-AA", userID, "uid-AA", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC)) // activity jun15
 	seedNotification(t, pool, "n-CC", userID, "uid-CC", 100, time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC))  // activity mar1
+	backfillReadAt(t, pool)                                                                                // both after jan → stay unread.
 
 	want := []string{"AA", "CC"} // AA(jun15) > CC(mar1); BB dropped (no unread).
 	for _, limit := range []int{100, 1} {
@@ -1116,6 +1206,7 @@ func TestPostgresStore_FindInZonePage_CursorFilterMismatch(t *testing.T) {
 	const userID = "user-cursor"
 	seedWatermark(t, pool, userID, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
 	seedNotification(t, pool, "n-P1", userID, "uid-P1", 100, time.Date(2026, 6, 15, 0, 0, 0, 0, time.UTC))
+	backfillReadAt(t, pool)
 
 	permitted := InZoneQuery{
 		Latitude: pgCentreLat, Longitude: pgCentreLon, RadiusMetres: 6000,

--- a/api-go/internal/applications/zonepage.go
+++ b/api-go/internal/applications/zonepage.go
@@ -570,18 +570,19 @@ func statusCursorOf(last datePageRow) pageCursor {
 }
 
 // activityUnreadSubquery computes, per application, the caller's latest UNREAD
-// notification timestamp. $5 is the caller's userID. The INNER JOIN to
-// notification_state is load-bearing: a user with no watermark row produces no
-// rows here, so "no notification_state ⇒ no unread anywhere" falls out naturally,
-// matching GetLatestUnreadByApplications and the handler's first-touch rule.
-// Unread is the strict created_at > last_read_at. It groups on (application_uid,
-// authority_id) — the same keys the outer LEFT JOIN matches against the
-// application's (uid, area_id) — so the integer authority_id (NOT the text
-// authority_code) is what reconciles a notification to its application.
+// notification timestamp. $5 is the caller's userID. Unread is read_at IS NULL
+// (ADR 0035, replacing the notification_state watermark JOIN). The "no unread
+// for an untouched user" behaviour is preserved by migration 0015's backfill:
+// existing no-watermark users had their history marked read (read_at set), so
+// they contribute no rows here; a genuinely new notification (read_at IS NULL)
+// correctly reads as unread. It groups on (application_uid, authority_id) — the
+// same keys the outer LEFT JOIN matches against the application's (uid, area_id)
+// — so the integer authority_id (NOT the text authority_code) reconciles a
+// notification to its application, and a bare uid shared across authorities
+// cannot cross-contaminate.
 const activityUnreadSubquery = "SELECT n.application_uid, n.authority_id, MAX(n.created_at) AS created_at" +
 	" FROM notifications n" +
-	" JOIN notification_state ns ON ns.user_id = n.user_id" +
-	" WHERE n.user_id = $5 AND n.created_at > ns.last_read_at" +
+	" WHERE n.user_id = $5 AND n.read_at IS NULL" +
 	" GROUP BY n.application_uid, n.authority_id"
 
 // activityExpr is the recent-activity sort key: the later of the application's
@@ -755,8 +756,8 @@ func (s *PostgresStore) findFilteredZonePage(ctx context.Context, q InZoneQuery,
 // an optional "AND app_state = $x" status predicate, and an optional unread join.
 // The join is INNER when q.Unread is set (it drops applications with no unread for
 // the caller) and LEFT when only recent-activity needs it for ordering; both reuse
-// the slice-3 unread subquery (created_at > last_read_at, INNER to
-// notification_state so a first-touch caller contributes nothing).
+// the read_at IS NULL unread subquery (ADR 0035), grouped on (application_uid,
+// authority_id) so the outer join stays authority-safe.
 func buildFilteredZoneQuery(q InZoneQuery, c *pageCursor) (string, []any, error) {
 	b := &argBuilder{}
 	lonP := b.add(q.Longitude)
@@ -786,8 +787,7 @@ func buildFilteredZoneQuery(q InZoneQuery, c *pageCursor) (string, []any, error)
 		userP := b.add(q.UserID)
 		subquery := "SELECT n.application_uid, n.authority_id, MAX(n.created_at) AS created_at" +
 			" FROM notifications n" +
-			" JOIN notification_state ns ON ns.user_id = n.user_id" +
-			" WHERE n.user_id = " + userP + " AND n.created_at > ns.last_read_at" +
+			" WHERE n.user_id = " + userP + " AND n.read_at IS NULL" +
 			" GROUP BY n.application_uid, n.authority_id"
 		sb.WriteString(" " + joinType + " (" + subquery + ") u" +
 			" ON applications.uid = u.application_uid AND applications.area_id = u.authority_id")

--- a/api-go/internal/digest/handler.go
+++ b/api-go/internal/digest/handler.go
@@ -20,7 +20,6 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/acsemail"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
-	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
@@ -52,12 +51,11 @@ type zoneReader interface {
 	GetByUserID(ctx context.Context, userID string) ([]watchzones.WatchZone, error)
 }
 
-// stateReader supplies the unread-count badge inputs for the weekly push:
-// the watermark and the strictly-after-watermark count. notificationstate.CosmosStore
+// stateReader supplies the unread-count badge for the weekly push: the total
+// unread tally (read_at IS NULL, ADR 0035). *notificationstate.PostgresStore
 // satisfies it.
 type stateReader interface {
-	Get(ctx context.Context, userID string) (*notificationstate.State, error)
-	UnreadCount(ctx context.Context, userID string, lastReadAt time.Time) (int, error)
+	UnreadCount(ctx context.Context, userID string) (int, error)
 }
 
 // deviceReader lists a user's device tokens for a push and prunes the ones APNs
@@ -164,8 +162,8 @@ func (h *Handler) RunWeekly(ctx context.Context) error {
 
 // sendWeeklyPush builds and sends the weekly digest push, then prunes any device
 // tokens APNs reports invalid. A user with no devices is a no-op. The badge is
-// the total unread count derived from the watermark (first-touch users start at
-// the zero instant), distinct from the digest application count.
+// the total unread count (read_at IS NULL, ADR 0035), distinct from the digest
+// application count.
 func (h *Handler) sendWeeklyPush(ctx context.Context, profile *profiles.UserProfile, applicationCount int) {
 	devices, err := h.devices.ListByUser(ctx, profile.UserID)
 	if err != nil {
@@ -176,16 +174,7 @@ func (h *Handler) sendWeeklyPush(ctx context.Context, profile *profiles.UserProf
 		return
 	}
 
-	lastReadAt := time.Unix(0, 0).UTC()
-	st, err := h.state.Get(ctx, profile.UserID)
-	if err != nil {
-		h.logger.ErrorContext(ctx, "weekly digest: load notification state failed", "user", profile.UserID, "error", err)
-		return
-	}
-	if st != nil {
-		lastReadAt = st.LastReadAt
-	}
-	totalUnread, err := h.state.UnreadCount(ctx, profile.UserID, lastReadAt)
+	totalUnread, err := h.state.UnreadCount(ctx, profile.UserID)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "weekly digest: unread count failed", "user", profile.UserID, "error", err)
 		return

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/acsemail"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
-	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
@@ -79,15 +78,10 @@ func (f *fakeZones) GetByUserID(_ context.Context, userID string) ([]watchzones.
 }
 
 type fakeState struct {
-	byUser map[string]*notificationstate.State
 	unread map[string]int
 }
 
-func (f *fakeState) Get(_ context.Context, userID string) (*notificationstate.State, error) {
-	return f.byUser[userID], nil
-}
-
-func (f *fakeState) UnreadCount(_ context.Context, userID string, _ time.Time) (int, error) {
+func (f *fakeState) UnreadCount(_ context.Context, userID string) (int, error) {
 	return f.unread[userID], nil
 }
 
@@ -272,9 +266,6 @@ func TestRunWeekly_ProTierGetsPushWithBadgeAndPrunesInvalidTokens(t *testing.T) 
 		"user-1": {zoneNotif("uid-A", "zone-1"), zoneNotif("uid-B", "zone-1")},
 	}}
 	state := &fakeState{
-		byUser: map[string]*notificationstate.State{
-			"user-1": {UserID: "user-1", LastReadAt: time.Unix(0, 0), Version: 1},
-		},
 		unread: map[string]int{"user-1": 5},
 	}
 	devices := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{

--- a/api-go/internal/notifications/store_postgres.go
+++ b/api-go/internal/notifications/store_postgres.go
@@ -27,7 +27,7 @@ type querier interface {
 // called only by the maintenance worker, not the common API paths.
 type Store interface {
 	Create(ctx context.Context, n DigestNotification) error
-	GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string, lastReadAt time.Time) (map[string]LatestUnread, error)
+	GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string) (map[string]LatestUnread, error)
 	ByUserSince(ctx context.Context, userID string, since time.Time) ([]DigestNotification, error)
 	AllByUser(ctx context.Context, userID string) ([]DigestNotification, error)
 	UnsentEmailsByUser(ctx context.Context, userID string) ([]DigestNotification, error)
@@ -179,25 +179,24 @@ func (s *PostgresStore) Create(ctx context.Context, n DigestNotification) error 
 }
 
 // pgLatestUnreadQuery uses DISTINCT ON (application_uid) to return the newest
-// notification per uid in one pass — the Postgres equivalent of the Cosmos
-// "first row seen on a newest-first result set" reduction. The 4-column
+// UNREAD notification per uid in one pass. Unread is read_at IS NULL (ADR 0035,
+// replacing the created_at > last_read_at watermark predicate). The 4-column
 // projection avoids reading full document bodies for a display-only badge.
 const pgLatestUnreadQuery = "SELECT DISTINCT ON (application_uid) " +
 	"application_uid, decision, event_type, created_at " +
 	"FROM notifications " +
-	"WHERE user_id = $1 AND application_uid = ANY($2) AND created_at > $3 " +
+	"WHERE user_id = $1 AND application_uid = ANY($2) AND read_at IS NULL " +
 	"ORDER BY application_uid, created_at DESC"
 
 // GetLatestUnreadByApplications returns, for each application uid that has at
-// least one notification created strictly after lastReadAt, the latest such
-// notification — in a single round trip instead of N+1 per-uid queries.
-// An empty uid set returns an empty map without issuing a query, matching the
-// Cosmos early-return guard.
-func (s *PostgresStore) GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string, lastReadAt time.Time) (map[string]LatestUnread, error) {
+// least one unread notification (read_at IS NULL), the latest such notification
+// — in a single round trip instead of N+1 per-uid queries. An empty uid set
+// returns an empty map without issuing a query.
+func (s *PostgresStore) GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string) (map[string]LatestUnread, error) {
 	if len(applicationUIDs) == 0 {
 		return map[string]LatestUnread{}, nil
 	}
-	rows, err := s.db.Query(ctx, pgLatestUnreadQuery, userID, applicationUIDs, lastReadAt)
+	rows, err := s.db.Query(ctx, pgLatestUnreadQuery, userID, applicationUIDs)
 	if err != nil {
 		return nil, fmt.Errorf("query latest unread for %q: %w", userID, err)
 	}

--- a/api-go/internal/notifications/store_postgres_integration_test.go
+++ b/api-go/internal/notifications/store_postgres_integration_test.go
@@ -108,7 +108,6 @@ func TestIntegration_Notifications_GetLatestUnreadByApplications(t *testing.T) {
 	s := newPGNotifStore(t)
 	ctx := context.Background()
 
-	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	t1 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
 	t2 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
 
@@ -124,8 +123,8 @@ func TestIntegration_Notifications_GetLatestUnreadByApplications(t *testing.T) {
 		t.Fatalf("Create n3: %v", err)
 	}
 
-	// lastReadAt = t0 — all three rows are after the watermark.
-	got, err := s.GetLatestUnreadByApplications(ctx, "user-1", []string{"uid-A", "uid-B"}, t0)
+	// All three rows are unread (read_at IS NULL — Create never sets read_at).
+	got, err := s.GetLatestUnreadByApplications(ctx, "user-1", []string{"uid-A", "uid-B"})
 	if err != nil {
 		t.Fatalf("GetLatestUnreadByApplications: %v", err)
 	}
@@ -141,20 +140,29 @@ func TestIntegration_Notifications_GetLatestUnreadByApplications(t *testing.T) {
 	}
 }
 
-func TestIntegration_Notifications_GetLatestUnreadByApplications_FiltersByLastReadAt(t *testing.T) {
-	s := newPGNotifStore(t)
+// TestIntegration_Notifications_GetLatestUnreadByApplications_ExcludesRead proves a
+// notification with read_at set (read) is excluded — the read_at IS NULL predicate
+// (ADR 0035). This matches what an equivalent watermark past the notification's
+// created_at would have excluded.
+func TestIntegration_Notifications_GetLatestUnreadByApplications_ExcludesRead(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "notifications", "notification_state")
+	s := NewPostgresStore(pool)
 	ctx := context.Background()
 
 	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	t2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
 
-	// Notification at t1.
+	// Notification at t1, then marked read (read_at = t2) — the equivalent of a
+	// watermark past t1.
 	if err := s.Create(ctx, intNotif("n1", "user-1", "uid-A", EventNewApplication, t1)); err != nil {
 		t.Fatalf("Create: %v", err)
 	}
+	if _, err := pool.Exec(ctx, "UPDATE notifications SET read_at = $1 WHERE id = 'n1'", t2); err != nil {
+		t.Fatalf("mark n1 read: %v", err)
+	}
 
-	// lastReadAt = t2 (after the notification): should be excluded.
-	got, err := s.GetLatestUnreadByApplications(ctx, "user-1", []string{"uid-A"}, t2)
+	got, err := s.GetLatestUnreadByApplications(ctx, "user-1", []string{"uid-A"})
 	if err != nil {
 		t.Fatalf("GetLatestUnreadByApplications: %v", err)
 	}

--- a/api-go/internal/notifications/store_postgres_test.go
+++ b/api-go/internal/notifications/store_postgres_test.go
@@ -184,7 +184,7 @@ func TestPostgresStore_GetLatestUnreadByApplications_EmptyUIDs(t *testing.T) {
 	q := &fakeQuerier{}
 	s := NewPostgresStore(q)
 
-	got, err := s.GetLatestUnreadByApplications(context.Background(), "user-1", nil, time.Now())
+	got, err := s.GetLatestUnreadByApplications(context.Background(), "user-1", nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -205,7 +205,7 @@ func TestPostgresStore_GetLatestUnreadByApplications_PropagatesQueryError(t *tes
 	s := NewPostgresStore(q)
 
 	_, err := s.GetLatestUnreadByApplications(
-		context.Background(), "user-1", []string{"uid-A"}, time.Now())
+		context.Background(), "user-1", []string{"uid-A"})
 	if !errors.Is(err, boom) {
 		t.Fatalf("got err %v, want wrapped %v", err, boom)
 	}
@@ -230,7 +230,7 @@ func TestPostgresStore_GetLatestUnreadByApplications_ReturnsLatestPerUID(t *test
 	s := NewPostgresStore(q)
 
 	got, err := s.GetLatestUnreadByApplications(
-		context.Background(), "user-1", []string{"uid-A", "uid-B"}, time.Unix(0, 0))
+		context.Background(), "user-1", []string{"uid-A", "uid-B"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/api-go/internal/notificationstate/handler.go
+++ b/api-go/internal/notificationstate/handler.go
@@ -12,34 +12,53 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
+// maxMarkReadApplications caps the number of applications a single mark-read
+// request may clear, bounding the UPDATE. Clients send exactly one today; the
+// array is forward-compat for a future "mark several read" without a contract
+// change. Over the cap is a 400.
+const maxMarkReadApplications = 500
+
 // stateStore is the consumer-side slice of the store the handlers use.
-// *CosmosStore satisfies it; tests substitute a hand-written fake.
+// *PostgresStore satisfies it; tests substitute a hand-written fake.
 type stateStore interface {
 	Get(ctx context.Context, userID string) (*State, error)
-	Save(ctx context.Context, st State) error
-	UnreadCount(ctx context.Context, userID string, lastReadAt time.Time) (int, error)
+	UnreadCount(ctx context.Context, userID string) (int, error)
+	MarkAllRead(ctx context.Context, userID string, now time.Time) (int64, error)
+	MarkApplicationsRead(ctx context.Context, userID string, uids []string, authorityIDs []int, now time.Time) (int64, error)
 }
 
 // stateResult is the GET /v1/me/notification-state response body:
-// camelCase keys, lastReadAt in DateTimeOffset wire format.
+// camelCase keys, lastReadAt in DateTimeOffset wire format. The shape is frozen
+// for client compatibility (ADR 0035): lastReadAt is vestigial, version is the
+// change token, totalUnreadCount is the read_at IS NULL tally.
 type stateResult struct {
 	LastReadAt       platform.DotNetTime `json:"lastReadAt"`
 	Version          int                 `json:"version"`
 	TotalUnreadCount int                 `json:"totalUnreadCount"`
 }
 
-// advanceRequest is the POST /v1/me/notification-state/advance request body.
-type advanceRequest struct {
-	AsOf platform.DotNetTime `json:"asOf"`
+// applicationRef identifies one application to mark read: the bare per-council
+// PlanIt ref plus its authority id. Both are needed because applicationUid is
+// not unique across authorities (the client exposes uid + areaId on every row).
+type applicationRef struct {
+	ApplicationUID string `json:"applicationUid"`
+	AuthorityID    int    `json:"authorityId"`
 }
 
-// Routes registers the notification-state endpoints on mux. All are
+// markReadRequest is the POST /v1/me/applications/mark-read body: an array of
+// (applicationUid, authorityId) pairs. Empty marks nothing (a 204 no-op, never
+// "all" — mark-all-read is a separate endpoint).
+type markReadRequest struct {
+	Applications []applicationRef `json:"applications"`
+}
+
+// Routes registers the notification read-state endpoints on mux. All are
 // authenticated: the auth middleware guarantees a subject in context.
 func Routes(mux *http.ServeMux, store stateStore, now func() time.Time, logger *slog.Logger) {
 	h := handler{store: store, now: now, logger: logger}
 	mux.HandleFunc("GET /v1/me/notification-state", h.get)
 	mux.HandleFunc("POST /v1/me/notification-state/mark-all-read", h.markAllRead)
-	mux.HandleFunc("POST /v1/me/notification-state/advance", h.advance)
+	mux.HandleFunc("POST /v1/me/applications/mark-read", h.markRead)
 }
 
 type handler struct {
@@ -48,9 +67,11 @@ type handler struct {
 	logger *slog.Logger
 }
 
-// get loads the watermark — seeding and persisting a first-touch one at now,
-// so the unread count is zero by definition — then returns it with the unread
-// tally, mirroring GetNotificationStateQueryHandler.
+// get returns the user's read state. It never writes: for a user with a state
+// row it returns that row's last_read_at and version; for a user with none it
+// returns version 0 and lastReadAt computed at now (not persisted — this avoids
+// an epoch-zero surprise in the payload while keeping GET side-effect-free, ADR
+// 0035). totalUnreadCount is always the live read_at IS NULL tally.
 func (h handler) get(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 
@@ -60,113 +81,69 @@ func (h handler) get(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	if st == nil {
-		seeded, err := NewState(userID, h.now())
-		if err != nil {
-			h.logger.ErrorContext(r.Context(), "seed notification state", "error", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		if err := h.store.Save(r.Context(), seeded); err != nil {
-			h.logger.ErrorContext(r.Context(), "persist seeded notification state", "error", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		st = &seeded
-	}
 
-	unread, err := h.store.UnreadCount(r.Context(), userID, st.LastReadAt)
+	unread, err := h.store.UnreadCount(r.Context(), userID)
 	if err != nil {
 		h.logger.ErrorContext(r.Context(), "count unread notifications", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
+	lastReadAt := h.now()
+	version := 0
+	if st != nil {
+		lastReadAt = st.LastReadAt
+		version = st.Version
+	}
+
 	h.writeJSON(w, r, stateResult{
-		LastReadAt:       platform.DotNetTime(st.LastReadAt),
-		Version:          st.Version,
+		LastReadAt:       platform.DotNetTime(lastReadAt),
+		Version:          version,
 		TotalUnreadCount: unread,
 	})
 }
 
-// markAllRead moves the watermark to now. First-touch users get a fresh seed
-// (same end-state as create-then-mark, without the redundant version bump),
-// mirroring MarkAllNotificationsReadCommandHandler. 204 on success.
+// markAllRead clears every unread notification for the user and bumps the
+// version change token (the store upserts the state row when absent). 204 on
+// success.
 func (h handler) markAllRead(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
-	now := h.now()
 
-	st, err := h.store.Get(r.Context(), userID)
-	if err != nil {
-		h.logger.ErrorContext(r.Context(), "read notification state", "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	if st == nil {
-		seeded, err := NewState(userID, now)
-		if err != nil {
-			h.logger.ErrorContext(r.Context(), "seed notification state", "error", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		st = &seeded
-	} else {
-		st.MarkAllReadAt(now)
-	}
-	if err := h.store.Save(r.Context(), *st); err != nil {
-		h.logger.ErrorContext(r.Context(), "save notification state", "error", err)
+	if _, err := h.store.MarkAllRead(r.Context(), userID, h.now()); err != nil {
+		h.logger.ErrorContext(r.Context(), "mark all notifications read", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// advance moves the watermark forward to the request's asOf. First-touch users
-// are seeded at now and the advance applied on top; for existing state a stale
-// asOf is a no-op without a write. 204 on success; a malformed body returns a
-// bodyless 400.
-func (h handler) advance(w http.ResponseWriter, r *http.Request) {
+// markRead clears the caller's unread notifications for the requested
+// applications (scoped by the composite application_uid + authorityId). It is
+// idempotent — 204 even when zero rows changed — and an empty array marks
+// nothing. A malformed body or an over-cap array returns a bodyless 400.
+func (h handler) markRead(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
-	var req advanceRequest
+	var req markReadRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	asOf := time.Time(req.AsOf)
-
-	st, err := h.store.Get(r.Context(), userID)
-	if err != nil {
-		h.logger.ErrorContext(r.Context(), "read notification state", "error", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return
-	}
-	if st == nil {
-		// First-touch: seed at now, attempt the advance, persist regardless so a
-		// subsequent GET sees the seed even when asOf was stale against it.
-		seeded, err := NewState(userID, h.now())
-		if err != nil {
-			h.logger.ErrorContext(r.Context(), "seed notification state", "error", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		seeded.AdvanceTo(asOf)
-		if err := h.store.Save(r.Context(), seeded); err != nil {
-			h.logger.ErrorContext(r.Context(), "save notification state", "error", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
+	if len(req.Applications) > maxMarkReadApplications {
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 
-	if !st.AdvanceTo(asOf) {
-		w.WriteHeader(http.StatusNoContent)
-		return
+	uids := make([]string, len(req.Applications))
+	authorityIDs := make([]int, len(req.Applications))
+	for i, a := range req.Applications {
+		uids[i] = a.ApplicationUID
+		authorityIDs[i] = a.AuthorityID
 	}
-	if err := h.store.Save(r.Context(), *st); err != nil {
-		h.logger.ErrorContext(r.Context(), "save notification state", "error", err)
+
+	if _, err := h.store.MarkApplicationsRead(r.Context(), userID, uids, authorityIDs, h.now()); err != nil {
+		h.logger.ErrorContext(r.Context(), "mark applications read", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/api-go/internal/notificationstate/handler_test.go
+++ b/api-go/internal/notificationstate/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -14,11 +15,18 @@ import (
 )
 
 type fakeStateStore struct {
-	states  map[string]State
-	unread  int
-	getErr  error
-	saveErr error
-	cntErr  error
+	states map[string]State
+	unread int
+
+	getErr      error
+	cntErr      error
+	markAllErr  error
+	markReadErr error
+
+	markAllCalls  int
+	markReadCalls int
+	markReadUIDs  []string
+	markReadAuths []int
 }
 
 func newFakeStateStore() *fakeStateStore {
@@ -36,19 +44,29 @@ func (f *fakeStateStore) Get(_ context.Context, userID string) (*State, error) {
 	return &st, nil
 }
 
-func (f *fakeStateStore) Save(_ context.Context, st State) error {
-	if f.saveErr != nil {
-		return f.saveErr
-	}
-	f.states[st.UserID] = st
-	return nil
-}
-
-func (f *fakeStateStore) UnreadCount(_ context.Context, _ string, _ time.Time) (int, error) {
+func (f *fakeStateStore) UnreadCount(_ context.Context, _ string) (int, error) {
 	if f.cntErr != nil {
 		return 0, f.cntErr
 	}
 	return f.unread, nil
+}
+
+func (f *fakeStateStore) MarkAllRead(_ context.Context, _ string, _ time.Time) (int64, error) {
+	f.markAllCalls++
+	if f.markAllErr != nil {
+		return 0, f.markAllErr
+	}
+	return 0, nil
+}
+
+func (f *fakeStateStore) MarkApplicationsRead(_ context.Context, _ string, uids []string, authorityIDs []int, _ time.Time) (int64, error) {
+	f.markReadCalls++
+	f.markReadUIDs = uids
+	f.markReadAuths = authorityIDs
+	if f.markReadErr != nil {
+		return 0, f.markReadErr
+	}
+	return int64(len(uids)), nil
 }
 
 func testMux(t *testing.T, store stateStore, now time.Time) *http.ServeMux {
@@ -93,7 +111,10 @@ func TestHandler_Get_ExistingState(t *testing.T) {
 	}
 }
 
-func TestHandler_Get_FirstTouchSeedsAndPersists(t *testing.T) {
+// TestHandler_Get_FirstTouchNoSeed proves GET is side-effect-free for a user
+// with no state row: version 0, lastReadAt computed at now (not persisted), and
+// no write to the store (ADR 0035 removed the first-touch watermark seed).
+func TestHandler_Get_FirstTouchNoSeed(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 12, 9, 30, 0, 0, time.UTC)
@@ -103,97 +124,159 @@ func TestHandler_Get_FirstTouchSeedsAndPersists(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
-	want := `{"lastReadAt":"2026-06-12T09:30:00+00:00","version":1,"totalUnreadCount":0}`
+	want := `{"lastReadAt":"2026-06-12T09:30:00+00:00","version":0,"totalUnreadCount":0}`
 	if rec.Body.String() != want {
 		t.Errorf("body = %s, want %s", rec.Body.String(), want)
 	}
-	// The seed must persist so subsequent reads are idempotent.
-	if st, ok := store.states["auth0|ns1"]; !ok || st.Version != 1 || !st.LastReadAt.Equal(now) {
-		t.Errorf("seed not persisted: %+v", store.states)
+	// No write of any kind: GET must not seed a state row.
+	if len(store.states) != 0 || store.markAllCalls != 0 || store.markReadCalls != 0 {
+		t.Errorf("GET wrote state: states=%v markAll=%d markRead=%d",
+			store.states, store.markAllCalls, store.markReadCalls)
 	}
 }
 
 func TestHandler_MarkAllRead(t *testing.T) {
 	t.Parallel()
 
-	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
-
-	t.Run("existing state bumps version", func(t *testing.T) {
+	t.Run("clears and returns 204", func(t *testing.T) {
 		t.Parallel()
 		store := newFakeStateStore()
-		store.states["auth0|ns1"] = State{UserID: "auth0|ns1", LastReadAt: now.Add(-time.Hour), Version: 2}
 
-		rec := doReq(t, testMux(t, store, now), http.MethodPost, "/v1/me/notification-state/mark-all-read", "")
+		rec := doReq(t, testMux(t, store, time.Now()), http.MethodPost, "/v1/me/notification-state/mark-all-read", "")
 		if rec.Code != http.StatusNoContent {
 			t.Fatalf("status = %d, want 204", rec.Code)
 		}
-		st := store.states["auth0|ns1"]
-		if !st.LastReadAt.Equal(now) || st.Version != 3 {
-			t.Errorf("state = %+v, want lastReadAt=now version=3", st)
+		if store.markAllCalls != 1 {
+			t.Errorf("MarkAllRead calls = %d, want 1", store.markAllCalls)
 		}
 	})
 
-	t.Run("first touch seeds without extra bump", func(t *testing.T) {
+	t.Run("store error is 500", func(t *testing.T) {
 		t.Parallel()
 		store := newFakeStateStore()
+		store.markAllErr = errors.New("db down")
 
-		rec := doReq(t, testMux(t, store, now), http.MethodPost, "/v1/me/notification-state/mark-all-read", "")
-		if rec.Code != http.StatusNoContent {
-			t.Fatalf("status = %d, want 204", rec.Code)
-		}
-		st := store.states["auth0|ns1"]
-		if !st.LastReadAt.Equal(now) || st.Version != 1 {
-			t.Errorf("state = %+v, want seeded version=1", st)
+		rec := doReq(t, testMux(t, store, time.Now()), http.MethodPost, "/v1/me/notification-state/mark-all-read", "")
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500", rec.Code)
 		}
 	})
 }
 
-func TestHandler_Advance(t *testing.T) {
+func TestHandler_MarkRead(t *testing.T) {
 	t.Parallel()
 
-	now := time.Date(2026, 6, 12, 10, 0, 0, 0, time.UTC)
-	baseline := State{UserID: "auth0|ns1", LastReadAt: now.Add(-time.Hour), Version: 2}
+	const path = "/v1/me/applications/mark-read"
 
-	tests := []struct {
-		name        string
-		body        string
-		wantStatus  int
-		wantVersion int
-	}{
-		{"forward advance bumps", `{"asOf":"2026-06-12T09:45:00+00:00"}`, http.StatusNoContent, 3},
-		{"stale asOf is a no-op", `{"asOf":"2026-06-12T08:00:00+00:00"}`, http.StatusNoContent, 2},
-		{"boundary instant is a no-op", `{"asOf":"2026-06-12T09:00:00+00:00"}`, http.StatusNoContent, 2},
-		{"Z suffix accepted on input", `{"asOf":"2026-06-12T09:50:00Z"}`, http.StatusNoContent, 3},
-		{"malformed body", `{"asOf":`, http.StatusBadRequest, 2},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			store := newFakeStateStore()
-			store.states["auth0|ns1"] = baseline
-
-			rec := doReq(t, testMux(t, store, now), http.MethodPost, "/v1/me/notification-state/advance", tc.body)
-			if rec.Code != tc.wantStatus {
-				t.Fatalf("status = %d, want %d", rec.Code, tc.wantStatus)
-			}
-			if got := store.states["auth0|ns1"].Version; got != tc.wantVersion {
-				t.Errorf("version = %d, want %d", got, tc.wantVersion)
-			}
-		})
-	}
-
-	t.Run("first touch seeds at now then advances", func(t *testing.T) {
+	t.Run("single application clears and returns 204", func(t *testing.T) {
 		t.Parallel()
 		store := newFakeStateStore()
 
-		// asOf earlier than the seed: persists the seed untouched (version 1).
-		rec := doReq(t, testMux(t, store, now), http.MethodPost, "/v1/me/notification-state/advance", `{"asOf":"2020-01-01T00:00:00+00:00"}`)
+		body := `{"applications":[{"applicationUid":"24-01234","authorityId":330}]}`
+		rec := doReq(t, testMux(t, store, time.Now()), http.MethodPost, path, body)
 		if rec.Code != http.StatusNoContent {
 			t.Fatalf("status = %d, want 204", rec.Code)
 		}
-		st := store.states["auth0|ns1"]
-		if !st.LastReadAt.Equal(now) || st.Version != 1 {
-			t.Errorf("state = %+v, want seed at now version=1", st)
+		if store.markReadCalls != 1 {
+			t.Fatalf("MarkApplicationsRead calls = %d, want 1", store.markReadCalls)
+		}
+		if !reflect.DeepEqual(store.markReadUIDs, []string{"24-01234"}) ||
+			!reflect.DeepEqual(store.markReadAuths, []int{330}) {
+			t.Errorf("passed uids=%v auths=%v, want [24-01234] [330]", store.markReadUIDs, store.markReadAuths)
+		}
+	})
+
+	t.Run("several applications pass every pair", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+
+		body := `{"applications":[` +
+			`{"applicationUid":"24-01234","authorityId":330},` +
+			`{"applicationUid":"24-05678","authorityId":331}]}`
+		rec := doReq(t, testMux(t, store, time.Now()), http.MethodPost, path, body)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", rec.Code)
+		}
+		if !reflect.DeepEqual(store.markReadUIDs, []string{"24-01234", "24-05678"}) ||
+			!reflect.DeepEqual(store.markReadAuths, []int{330, 331}) {
+			t.Errorf("passed uids=%v auths=%v", store.markReadUIDs, store.markReadAuths)
+		}
+	})
+
+	t.Run("empty array marks nothing and returns 204", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+
+		rec := doReq(t, testMux(t, store, time.Now()), http.MethodPost, path, `{"applications":[]}`)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", rec.Code)
+		}
+		// The store is asked to clear the empty set — never "all".
+		if store.markReadCalls != 1 || len(store.markReadUIDs) != 0 || len(store.markReadAuths) != 0 {
+			t.Errorf("empty array: calls=%d uids=%v auths=%v, want 1 call with empty sets",
+				store.markReadCalls, store.markReadUIDs, store.markReadAuths)
+		}
+	})
+
+	t.Run("idempotent second call is still 204", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+		mux := testMux(t, store, time.Now())
+		body := `{"applications":[{"applicationUid":"24-01234","authorityId":330}]}`
+
+		if rec := doReq(t, mux, http.MethodPost, path, body); rec.Code != http.StatusNoContent {
+			t.Fatalf("first call status = %d, want 204", rec.Code)
+		}
+		if rec := doReq(t, mux, http.MethodPost, path, body); rec.Code != http.StatusNoContent {
+			t.Fatalf("second call status = %d, want 204", rec.Code)
+		}
+	})
+
+	t.Run("malformed body is a bodyless 400", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+
+		rec := doReq(t, testMux(t, store, time.Now()), http.MethodPost, path, `{"applications":`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rec.Code)
+		}
+		if store.markReadCalls != 0 {
+			t.Errorf("malformed body must not touch the store: calls=%d", store.markReadCalls)
+		}
+	})
+
+	t.Run("over the cap is a 400", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+
+		var sb strings.Builder
+		sb.WriteString(`{"applications":[`)
+		for i := 0; i <= maxMarkReadApplications; i++ {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString(`{"applicationUid":"u","authorityId":1}`)
+		}
+		sb.WriteString(`]}`)
+
+		rec := doReq(t, testMux(t, store, time.Now()), http.MethodPost, path, sb.String())
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rec.Code)
+		}
+		if store.markReadCalls != 0 {
+			t.Errorf("over-cap must not touch the store: calls=%d", store.markReadCalls)
+		}
+	})
+
+	t.Run("store error is 500", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+		store.markReadErr = errors.New("db down")
+
+		body := `{"applications":[{"applicationUid":"24-01234","authorityId":330}]}`
+		rec := doReq(t, testMux(t, store, time.Now()), http.MethodPost, path, body)
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500", rec.Code)
 		}
 	})
 }
@@ -201,16 +284,24 @@ func TestHandler_Advance(t *testing.T) {
 func TestHandler_StoreFailures(t *testing.T) {
 	t.Parallel()
 
-	store := newFakeStateStore()
-	store.getErr = errors.New("cosmos down")
-	for _, tc := range []struct{ method, path, body string }{
-		{http.MethodGet, "/v1/me/notification-state", ""},
-		{http.MethodPost, "/v1/me/notification-state/mark-all-read", ""},
-		{http.MethodPost, "/v1/me/notification-state/advance", `{"asOf":"2026-06-12T09:45:00+00:00"}`},
+	markReadBody := `{"applications":[{"applicationUid":"24-01234","authorityId":330}]}`
+	for _, tc := range []struct {
+		name               string
+		method, path, body string
+		configure          func(*fakeStateStore)
+	}{
+		{"get", http.MethodGet, "/v1/me/notification-state", "", func(f *fakeStateStore) { f.getErr = errors.New("boom") }},
+		{"mark-all-read", http.MethodPost, "/v1/me/notification-state/mark-all-read", "", func(f *fakeStateStore) { f.markAllErr = errors.New("boom") }},
+		{"mark-read", http.MethodPost, "/v1/me/applications/mark-read", markReadBody, func(f *fakeStateStore) { f.markReadErr = errors.New("boom") }},
 	} {
-		rec := doReq(t, testMux(t, store, time.Now()), tc.method, tc.path, tc.body)
-		if rec.Code != http.StatusInternalServerError {
-			t.Errorf("%s %s status = %d, want 500", tc.method, tc.path, rec.Code)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := newFakeStateStore()
+			tc.configure(store)
+			rec := doReq(t, testMux(t, store, time.Now()), tc.method, tc.path, tc.body)
+			if rec.Code != http.StatusInternalServerError {
+				t.Errorf("%s %s status = %d, want 500", tc.method, tc.path, rec.Code)
+			}
+		})
 	}
 }

--- a/api-go/internal/notificationstate/state.go
+++ b/api-go/internal/notificationstate/state.go
@@ -1,7 +1,14 @@
-// Package notificationstate owns the per-user read-watermark feature: the
-// State domain value, its Cosmos document shape, the store (watermark document
-// + unread count over the Notifications container), and the
-// GET/mark-all-read/advance HTTP handlers (GH#418 iteration 4).
+// Package notificationstate owns the per-user notification read-state feature:
+// the State value (a version change token plus a vestigial last-read instant),
+// the mark-read / mark-all-read read-state mutations over the notifications
+// table, the unread count, and the GET/mark-all-read/mark-read HTTP handlers.
+//
+// Read state is per-application, keyed on notifications.read_at (ADR 0035,
+// superseding the last-read watermark). A notification is unread iff
+// read_at IS NULL; opening an application clears its rows (mark-read); mark-all
+// clears every unread row. The notification_state.version is retained as an
+// opaque change token that bumps on any read-state mutation so the client's
+// BadgeSync still detects change; last_read_at no longer drives unread.
 package notificationstate
 
 import (
@@ -10,18 +17,20 @@ import (
 	"time"
 )
 
-// State is one user's notification read watermark. LastReadAt is the cutoff
-// (notifications created at exactly that instant count as read); Version
-// increments on every change.
+// State is one user's notification read-state row. Version is the opaque change
+// token that increments on every read-state mutation (mark-read that cleared at
+// least one row, and mark-all-read). LastReadAt is retained for GET DTO shape
+// stability only; it no longer drives the unread computation (that is
+// read_at IS NULL on the notifications table — ADR 0035).
 type State struct {
 	UserID     string
 	LastReadAt time.Time
 	Version    int
 }
 
-// NewState seeds a first-touch watermark at the given instant with version 1,
-// matching NotificationStateAggregate.Create: all existing notifications count
-// as already read ("clean slate", spec pre-resolved decision #13).
+// NewState seeds a first-touch state row at the given instant with version 1.
+// LastReadAt is vestigial (kept for DTO shape); the meaningful field is Version,
+// the change token BadgeSync observes.
 func NewState(userID string, lastReadAt time.Time) (State, error) {
 	if strings.TrimSpace(userID) == "" {
 		return State{}, errors.New("user id is required")
@@ -29,21 +38,8 @@ func NewState(userID string, lastReadAt time.Time) (State, error) {
 	return State{UserID: userID, LastReadAt: lastReadAt, Version: 1}, nil
 }
 
-// MarkAllReadAt moves the watermark to now unconditionally and bumps the
-// version, mirroring MarkAllReadAt.
+// MarkAllReadAt stamps LastReadAt to now and bumps the version change token.
 func (s *State) MarkAllReadAt(now time.Time) {
 	s.LastReadAt = now
 	s.Version++
-}
-
-// AdvanceTo moves the watermark forward to asOf, reporting whether anything
-// changed. A stale asOf (<= the current watermark) is a no-op returning false,
-// mirroring AdvanceTo's redundant-write guard.
-func (s *State) AdvanceTo(asOf time.Time) bool {
-	if !asOf.After(s.LastReadAt) {
-		return false
-	}
-	s.LastReadAt = asOf
-	s.Version++
-	return true
 }

--- a/api-go/internal/notificationstate/store_postgres.go
+++ b/api-go/internal/notificationstate/store_postgres.go
@@ -25,24 +25,29 @@ type querier interface {
 type Store interface {
 	Get(ctx context.Context, userID string) (*State, error)
 	Save(ctx context.Context, st State) error
-	UnreadCount(ctx context.Context, userID string, lastReadAt time.Time) (int, error)
+	UnreadCount(ctx context.Context, userID string) (int, error)
+	MarkAllRead(ctx context.Context, userID string, now time.Time) (int64, error)
+	MarkApplicationsRead(ctx context.Context, userID string, uids []string, authorityIDs []int, now time.Time) (int64, error)
 	DeleteByUserID(ctx context.Context, userID string) error
 }
 
 // Compile-time parity: *PostgresStore must satisfy the full Store surface.
 var _ Store = (*PostgresStore)(nil)
 
-// PostgresStore reads and writes per-user notification watermarks in the
-// `notification_state` table and cross-reads the `notifications` table for
-// the unread count — matching the Cosmos model where CosmosStore spans two
-// containers (NotificationState + Notifications). Both tables live in the
-// same pool, so the cross-read is a plain SQL join on the same connection.
+// PostgresStore owns the per-user notification read state: the change-token row
+// in `notification_state` and the read-state mutations over the `notifications`
+// table (read_at). Both tables live in the same pool, so a mutation and its
+// version bump run atomically in a single data-modifying CTE statement.
 //
-// Partition strategy (vs Cosmos):
-//   - The Cosmos model uses id == partition key == userId (one document per
-//     user). The Postgres equivalent is `user_id TEXT PRIMARY KEY`.
-//   - UnreadCount issues a SELECT count(*) against the notifications table,
-//     replacing the Cosmos cross-container CountItems call.
+//   - Unread is read_at IS NULL (ADR 0035); UnreadCount is a SELECT count(*)
+//     over the partial index idx_notifications_unread.
+//   - MarkApplicationsRead clears the caller's unread rows for a set of
+//     (application_uid, authority_id) pairs — the composite is load-bearing:
+//     application_uid is the bare per-council PlanIt ref and is NOT unique
+//     across authorities, so matching on uid alone would clear the wrong
+//     council's rows. It bumps the version token only when it cleared a row.
+//   - MarkAllRead clears every unread row for the user and always bumps the
+//     version token (upserting the state row when absent).
 type PostgresStore struct {
 	db querier
 }
@@ -107,16 +112,13 @@ func (s *PostgresStore) Save(ctx context.Context, st State) error {
 	return nil
 }
 
-// pgUnreadCountQuery counts notifications created strictly after the watermark
-// for the given user, cross-reading the notifications table — the Postgres
-// equivalent of the Cosmos cross-container CountItems call in CosmosStore.
-const pgUnreadCountQuery = "SELECT count(*) FROM notifications WHERE user_id = $1 AND created_at > $2"
+// pgUnreadCountQuery counts the user's unread notifications (read_at IS NULL),
+// served by the partial index idx_notifications_unread (ADR 0035).
+const pgUnreadCountQuery = "SELECT count(*) FROM notifications WHERE user_id = $1 AND read_at IS NULL"
 
-// UnreadCount counts the user's notifications created strictly after
-// lastReadAt, matching the Cosmos CountItems semantics (the boundary instant
-// itself counts as read).
-func (s *PostgresStore) UnreadCount(ctx context.Context, userID string, lastReadAt time.Time) (int, error) {
-	rows, err := s.db.Query(ctx, pgUnreadCountQuery, userID, lastReadAt)
+// UnreadCount counts the user's unread notifications (read_at IS NULL).
+func (s *PostgresStore) UnreadCount(ctx context.Context, userID string) (int, error) {
+	rows, err := s.db.Query(ctx, pgUnreadCountQuery, userID)
 	if err != nil {
 		return 0, fmt.Errorf("count unread for %q: %w", userID, err)
 	}
@@ -128,6 +130,92 @@ func (s *PostgresStore) UnreadCount(ctx context.Context, userID string, lastRead
 		return 0, nil
 	}
 	return int(counts[0]), nil
+}
+
+// pgMarkAllReadQuery clears every unread notification for the user (read_at set
+// to now) and unconditionally bumps the version change token, upserting the
+// state row when the user has none. Both tables mutate atomically in one
+// data-modifying CTE statement; the top-level SELECT returns the cleared count.
+const pgMarkAllReadQuery = `
+WITH cleared AS (
+    UPDATE notifications
+    SET read_at = $2
+    WHERE user_id = $1 AND read_at IS NULL
+    RETURNING 1
+), bumped AS (
+    INSERT INTO notification_state (user_id, last_read_at, version)
+    VALUES ($1, $2, 1)
+    ON CONFLICT (user_id) DO UPDATE SET
+        last_read_at = EXCLUDED.last_read_at,
+        version      = notification_state.version + 1
+    RETURNING 1
+)
+SELECT count(*) FROM cleared`
+
+// MarkAllRead clears all of the user's unread notifications and bumps the
+// version change token (upserting the state row if absent). It returns the
+// number of notifications cleared. The version bump is unconditional so
+// BadgeSync still observes a change even when nothing was unread.
+func (s *PostgresStore) MarkAllRead(ctx context.Context, userID string, now time.Time) (int64, error) {
+	rows, err := s.db.Query(ctx, pgMarkAllReadQuery, userID, now)
+	if err != nil {
+		return 0, fmt.Errorf("mark all read for %q: %w", userID, err)
+	}
+	counts, err := pgx.CollectRows(rows, pgx.RowTo[int64])
+	if err != nil {
+		return 0, fmt.Errorf("scan mark all read count for %q: %w", userID, err)
+	}
+	if len(counts) == 0 {
+		return 0, nil
+	}
+	return counts[0], nil
+}
+
+// pgMarkApplicationsReadQuery clears the caller's unread notifications for a set
+// of (application_uid, authority_id) pairs supplied as two parallel arrays, and
+// bumps the version change token only when it actually cleared a row (upserting
+// the state row when absent). Scoping by the composite pair is load-bearing:
+// application_uid is the bare per-council PlanIt ref and collides across
+// authorities, so authority_id disambiguates. Empty arrays match nothing (a
+// 204 no-op), never "all". Both tables mutate atomically in one CTE statement;
+// the top-level SELECT returns the cleared count.
+const pgMarkApplicationsReadQuery = `
+WITH cleared AS (
+    UPDATE notifications n
+    SET read_at = $2
+    FROM unnest($3::text[], $4::int[]) AS t(uid, aid)
+    WHERE n.user_id = $1
+      AND n.application_uid = t.uid
+      AND n.authority_id = t.aid
+      AND n.read_at IS NULL
+    RETURNING 1
+), bumped AS (
+    INSERT INTO notification_state (user_id, last_read_at, version)
+    SELECT $1, $2, 1
+    WHERE EXISTS (SELECT 1 FROM cleared)
+    ON CONFLICT (user_id) DO UPDATE SET version = notification_state.version + 1
+    RETURNING 1
+)
+SELECT count(*) FROM cleared`
+
+// MarkApplicationsRead clears the caller's unread notifications for the given
+// (uid, authorityID) pairs and bumps the version change token when it cleared at
+// least one row (leaving the token untouched on a zero-row no-op, so mark-read
+// stays idempotent). uids and authorityIDs are parallel: the i-th pair is
+// (uids[i], authorityIDs[i]). It returns the number of notifications cleared.
+func (s *PostgresStore) MarkApplicationsRead(ctx context.Context, userID string, uids []string, authorityIDs []int, now time.Time) (int64, error) {
+	rows, err := s.db.Query(ctx, pgMarkApplicationsReadQuery, userID, now, uids, authorityIDs)
+	if err != nil {
+		return 0, fmt.Errorf("mark applications read for %q: %w", userID, err)
+	}
+	counts, err := pgx.CollectRows(rows, pgx.RowTo[int64])
+	if err != nil {
+		return 0, fmt.Errorf("scan mark applications read count for %q: %w", userID, err)
+	}
+	if len(counts) == 0 {
+		return 0, nil
+	}
+	return counts[0], nil
 }
 
 const pgDeleteStateQuery = "DELETE FROM notification_state WHERE user_id = $1"

--- a/api-go/internal/notificationstate/store_postgres_integration_test.go
+++ b/api-go/internal/notificationstate/store_postgres_integration_test.go
@@ -23,6 +23,67 @@ func newPGStateStore(t *testing.T) (*PostgresStore, *pgxpool.Pool) {
 	return NewPostgresStore(pool), pool
 }
 
+// Backfill SQL mirrors migrations/0015_notifications_read_at.sql. These integration
+// tests seed a pre-migration state (notifications created via the store, all
+// read_at IS NULL, plus a watermark row) and replay the backfill to derive read_at,
+// then assert read_at IS NULL behaviour matches what the watermark model gave — the
+// explicit equivalence acceptance criterion (ADR 0035). Keep in sync with 0015.
+const (
+	backfillWatermarkedSQL = `
+UPDATE notifications n
+SET read_at = ns.last_read_at
+FROM notification_state ns
+WHERE n.user_id = ns.user_id
+  AND n.created_at <= ns.last_read_at
+  AND n.read_at IS NULL`
+
+	backfillNoWatermarkSQL = `
+UPDATE notifications n
+SET read_at = n.created_at
+WHERE n.read_at IS NULL
+  AND NOT EXISTS (SELECT 1 FROM notification_state ns WHERE ns.user_id = n.user_id)`
+)
+
+// backfillReadAt replays migration 0015's two backfill UPDATEs, deriving read_at
+// from the seeded watermark rows.
+func backfillReadAt(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, backfillWatermarkedSQL); err != nil {
+		t.Fatalf("backfill watermarked: %v", err)
+	}
+	if _, err := pool.Exec(ctx, backfillNoWatermarkSQL); err != nil {
+		t.Fatalf("backfill no-watermark: %v", err)
+	}
+}
+
+// seedUnreadNotif inserts one notification for the user via the notifications
+// store (Create leaves read_at NULL — the unread, pre-backfill state).
+func seedUnreadNotif(t *testing.T, pool *pgxpool.Pool, id, userID, uid string, authorityID int, createdAt time.Time) {
+	t.Helper()
+	nStore := notifications.NewPostgresStore(pool)
+	n := notifications.DigestNotification{
+		ID: id, UserID: userID, ApplicationUID: uid, ApplicationName: uid,
+		AuthorityID: authorityID, EventType: notifications.EventNewApplication,
+		Sources: "Zone", CreatedAt: createdAt,
+	}
+	if err := nStore.Create(context.Background(), n); err != nil {
+		t.Fatalf("seed notification %q: %v", id, err)
+	}
+}
+
+// unreadCountFor reads the raw read_at-IS-NULL count for a user (independent of the
+// store method under test).
+func unreadCountFor(t *testing.T, pool *pgxpool.Pool, userID string) int {
+	t.Helper()
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		"SELECT count(*) FROM notifications WHERE user_id = $1 AND read_at IS NULL", userID).Scan(&n); err != nil {
+		t.Fatalf("count unread for %q: %v", userID, err)
+	}
+	return n
+}
+
 // --- Get / Save round-trip ---
 
 func TestIntegration_NotificationState_GetSave(t *testing.T) {
@@ -92,52 +153,207 @@ func TestIntegration_NotificationState_Save_Idempotent(t *testing.T) {
 	}
 }
 
-// --- UnreadCount cross-reads the notifications table ---
+// --- UnreadCount over read_at IS NULL, equivalent to a watermark fixture ---
 
+// TestIntegration_NotificationState_UnreadCount proves UnreadCount under
+// read_at IS NULL equals the count an equivalent watermark fixture (created_at >
+// last_read_at, backfilled per migration 0015) would give. Watermark at t1 → the
+// two later notifications count; watermark at t3 (the boundary) → nothing counts.
 func TestIntegration_NotificationState_UnreadCount(t *testing.T) {
-	s, pool := newPGStateStore(t)
-	ctx := context.Background()
-
-	// Seed two notifications for user-1 using the notifications PostgresStore
-	// (same pool — correct cross-table read).
-	nStore := notifications.NewPostgresStore(pool)
 	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	t2 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
 	t3 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
 
-	for _, n := range []notifications.DigestNotification{
-		{ID: "n1", UserID: "user-1", ApplicationUID: "uid-A", ApplicationName: "A",
-			AuthorityID: 100, EventType: notifications.EventNewApplication,
-			Sources: "Zone", CreatedAt: t1},
-		{ID: "n2", UserID: "user-1", ApplicationUID: "uid-B", ApplicationName: "B",
-			AuthorityID: 100, EventType: notifications.EventNewApplication,
-			Sources: "Zone", CreatedAt: t2},
-		{ID: "n3", UserID: "user-1", ApplicationUID: "uid-C", ApplicationName: "C",
-			AuthorityID: 100, EventType: notifications.EventNewApplication,
-			Sources: "Zone", CreatedAt: t3},
-	} {
-		if err := nStore.Create(ctx, n); err != nil {
-			t.Fatalf("seed notification %s: %v", n.ID, err)
+	t.Run("watermark at t1 -> 2 unread", func(t *testing.T) {
+		s, pool := newPGStateStore(t)
+		ctx := context.Background()
+		seedUnreadNotif(t, pool, "n1", "user-1", "uid-A", 100, t1)
+		seedUnreadNotif(t, pool, "n2", "user-1", "uid-B", 100, t2)
+		seedUnreadNotif(t, pool, "n3", "user-1", "uid-C", 100, t3)
+		if err := s.Save(ctx, State{UserID: "user-1", LastReadAt: t1, Version: 1}); err != nil {
+			t.Fatalf("seed watermark: %v", err)
 		}
+		backfillReadAt(t, pool) // read_at = t1 for n1 (created_at <= t1); n2, n3 stay NULL.
+
+		count, err := s.UnreadCount(ctx, "user-1")
+		if err != nil {
+			t.Fatalf("UnreadCount: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("unread count: got %d, want 2", count)
+		}
+	})
+
+	t.Run("watermark at t3 (boundary, inclusive) -> 0 unread", func(t *testing.T) {
+		s, pool := newPGStateStore(t)
+		ctx := context.Background()
+		seedUnreadNotif(t, pool, "n1", "user-1", "uid-A", 100, t1)
+		seedUnreadNotif(t, pool, "n2", "user-1", "uid-B", 100, t2)
+		seedUnreadNotif(t, pool, "n3", "user-1", "uid-C", 100, t3)
+		if err := s.Save(ctx, State{UserID: "user-1", LastReadAt: t3, Version: 1}); err != nil {
+			t.Fatalf("seed watermark: %v", err)
+		}
+		backfillReadAt(t, pool) // all created_at <= t3 → all read.
+
+		count, err := s.UnreadCount(ctx, "user-1")
+		if err != nil {
+			t.Fatalf("UnreadCount: %v", err)
+		}
+		if count != 0 {
+			t.Errorf("unread count at boundary: got %d, want 0", count)
+		}
+	})
+}
+
+// --- MarkAllRead ---
+
+// TestIntegration_NotificationState_MarkAllRead proves mark-all clears every unread
+// notification (a subsequent UnreadCount is 0) and bumps the version change token,
+// upserting the state row when the user has none.
+func TestIntegration_NotificationState_MarkAllRead(t *testing.T) {
+	s, pool := newPGStateStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	seedUnreadNotif(t, pool, "n1", "user-1", "uid-A", 100, t1)
+	seedUnreadNotif(t, pool, "n2", "user-1", "uid-B", 100, t1)
+
+	cleared, err := s.MarkAllRead(ctx, "user-1", now)
+	if err != nil {
+		t.Fatalf("MarkAllRead: %v", err)
+	}
+	if cleared != 2 {
+		t.Errorf("cleared: got %d, want 2", cleared)
+	}
+	if got := unreadCountFor(t, pool, "user-1"); got != 0 {
+		t.Errorf("unread after mark-all: got %d, want 0", got)
 	}
 
-	// lastReadAt = t1 → n2 (t2) and n3 (t3) are unread.
-	count, err := s.UnreadCount(ctx, "user-1", t1)
+	// First-touch user: mark-all upserts the state row at version 1.
+	st, err := s.Get(ctx, "user-1")
 	if err != nil {
-		t.Fatalf("UnreadCount: %v", err)
+		t.Fatalf("Get after mark-all: %v", err)
 	}
-	if count != 2 {
-		t.Errorf("unread count: got %d, want 2", count)
+	if st == nil || st.Version != 1 {
+		t.Fatalf("state after first mark-all: got %+v, want version 1", st)
 	}
 
-	// lastReadAt = t3 (at the boundary) → 0 unread (strictly after, t3 itself is read).
-	countAtBoundary, err := s.UnreadCount(ctx, "user-1", t3)
+	// A second mark-all (nothing unread) still bumps the version token.
+	if _, err := s.MarkAllRead(ctx, "user-1", now); err != nil {
+		t.Fatalf("second MarkAllRead: %v", err)
+	}
+	st, err = s.Get(ctx, "user-1")
 	if err != nil {
-		t.Fatalf("UnreadCount at boundary: %v", err)
+		t.Fatalf("Get after second mark-all: %v", err)
 	}
-	if countAtBoundary != 0 {
-		t.Errorf("unread count at boundary: got %d, want 0", countAtBoundary)
+	if st == nil || st.Version != 2 {
+		t.Errorf("version after second mark-all: got %+v, want 2", st)
 	}
+}
+
+// --- MarkApplicationsRead ---
+
+// TestIntegration_NotificationState_MarkApplicationsRead_CrossAuthorityGuard proves
+// the composite (application_uid, authority_id) scoping: two authorities sharing a
+// bare ref must not cross-contaminate. Marking {uid, authority 330} read clears only
+// authority 330's row and leaves authority 331's same-uid row unread.
+func TestIntegration_NotificationState_MarkApplicationsRead_CrossAuthorityGuard(t *testing.T) {
+	s, pool := newPGStateStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Same user, same bare uid "24-01234", two different authorities — both unread.
+	seedUnreadNotif(t, pool, "n-330", "user-1", "24-01234", 330, t1)
+	seedUnreadNotif(t, pool, "n-331", "user-1", "24-01234", 331, t1)
+
+	cleared, err := s.MarkApplicationsRead(ctx, "user-1", []string{"24-01234"}, []int{330}, now)
+	if err != nil {
+		t.Fatalf("MarkApplicationsRead: %v", err)
+	}
+	if cleared != 1 {
+		t.Fatalf("cleared: got %d, want 1 (only authority 330)", cleared)
+	}
+	if got := readAtOf(t, pool, "n-330"); got == nil {
+		t.Error("authority 330's row should be read (read_at set)")
+	}
+	if got := readAtOf(t, pool, "n-331"); got != nil {
+		t.Errorf("authority 331's same-uid row must stay unread, got read_at %v", got)
+	}
+}
+
+// TestIntegration_NotificationState_MarkApplicationsRead_Idempotent proves a second
+// mark-read clears zero rows (idempotent) and does not bump the version a second
+// time, while the first (cleared > 0) does bump it.
+func TestIntegration_NotificationState_MarkApplicationsRead_Idempotent(t *testing.T) {
+	s, pool := newPGStateStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	seedUnreadNotif(t, pool, "n1", "user-1", "24-01234", 330, t1)
+
+	first, err := s.MarkApplicationsRead(ctx, "user-1", []string{"24-01234"}, []int{330}, now)
+	if err != nil {
+		t.Fatalf("first MarkApplicationsRead: %v", err)
+	}
+	if first != 1 {
+		t.Errorf("first call cleared: got %d, want 1", first)
+	}
+	st, _ := s.Get(ctx, "user-1")
+	if st == nil || st.Version != 1 {
+		t.Fatalf("version after first clear: got %+v, want 1", st)
+	}
+
+	second, err := s.MarkApplicationsRead(ctx, "user-1", []string{"24-01234"}, []int{330}, now)
+	if err != nil {
+		t.Fatalf("second MarkApplicationsRead: %v", err)
+	}
+	if second != 0 {
+		t.Errorf("second call cleared: got %d, want 0 (idempotent)", second)
+	}
+	// Zero cleared → no version bump.
+	st, _ = s.Get(ctx, "user-1")
+	if st == nil || st.Version != 1 {
+		t.Errorf("version after zero-clear: got %+v, want unchanged 1", st)
+	}
+}
+
+// TestIntegration_NotificationState_MarkApplicationsRead_EmptyClearsNothing proves an
+// empty request clears nothing (never "all") and does not create or bump a state row.
+func TestIntegration_NotificationState_MarkApplicationsRead_EmptyClearsNothing(t *testing.T) {
+	s, pool := newPGStateStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	seedUnreadNotif(t, pool, "n1", "user-1", "24-01234", 330, t1)
+
+	cleared, err := s.MarkApplicationsRead(ctx, "user-1", []string{}, []int{}, now)
+	if err != nil {
+		t.Fatalf("MarkApplicationsRead(empty): %v", err)
+	}
+	if cleared != 0 {
+		t.Errorf("empty request cleared: got %d, want 0", cleared)
+	}
+	if got := unreadCountFor(t, pool, "user-1"); got != 1 {
+		t.Errorf("unread after empty mark-read: got %d, want 1 (nothing cleared)", got)
+	}
+	if st, _ := s.Get(ctx, "user-1"); st != nil {
+		t.Errorf("empty mark-read must not create a state row, got %+v", st)
+	}
+}
+
+// readAtOf returns the (nullable) read_at for the notification with the given id.
+func readAtOf(t *testing.T, pool *pgxpool.Pool, id string) *time.Time {
+	t.Helper()
+	var readAt *time.Time
+	if err := pool.QueryRow(context.Background(),
+		"SELECT read_at FROM notifications WHERE id = $1", id).Scan(&readAt); err != nil {
+		t.Fatalf("scan read_at for %q: %v", id, err)
+	}
+	return readAt
 }
 
 // --- DeleteByUserID ---

--- a/api-go/internal/notificationstate/store_postgres_test.go
+++ b/api-go/internal/notificationstate/store_postgres_test.go
@@ -207,7 +207,7 @@ func TestPostgresNSStore_UnreadCount_ReturnsCount(t *testing.T) {
 	}
 	s := NewPostgresStore(q)
 
-	count, err := s.UnreadCount(context.Background(), "user-1", time.Now())
+	count, err := s.UnreadCount(context.Background(), "user-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestPostgresNSStore_UnreadCount_PropagatesQueryError(t *testing.T) {
 	q := &fakeNSQuerier{queryResponses: []queryResp{{err: boom}}}
 	s := NewPostgresStore(q)
 
-	_, err := s.UnreadCount(context.Background(), "user-1", time.Now())
+	_, err := s.UnreadCount(context.Background(), "user-1")
 	if !errors.Is(err, boom) {
 		t.Fatalf("got %v, want wrapped %v", err, boom)
 	}
@@ -234,12 +234,68 @@ func TestPostgresNSStore_UnreadCount_ZeroWhenNoRows(t *testing.T) {
 	q := &fakeNSQuerier{queryResponses: []queryResp{{rows: newNSRows(nil)}}}
 	s := NewPostgresStore(q)
 
-	count, err := s.UnreadCount(context.Background(), "user-1", time.Now())
+	count, err := s.UnreadCount(context.Background(), "user-1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if count != 0 {
 		t.Errorf("count: got %d, want 0", count)
+	}
+}
+
+// --- MarkAllRead / MarkApplicationsRead (count parsing + error propagation) ---
+
+func TestPostgresNSStore_MarkAllRead_ReturnsClearedCount(t *testing.T) {
+	t.Parallel()
+	q := &fakeNSQuerier{queryResponses: []queryResp{{rows: newNSRows([][]any{{int64(4)}})}}}
+	s := NewPostgresStore(q)
+
+	cleared, err := s.MarkAllRead(context.Background(), "user-1", time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleared != 4 {
+		t.Errorf("cleared: got %d, want 4", cleared)
+	}
+}
+
+func TestPostgresNSStore_MarkAllRead_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("mark-all boom")
+	q := &fakeNSQuerier{queryResponses: []queryResp{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	_, err := s.MarkAllRead(context.Background(), "user-1", time.Now())
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+func TestPostgresNSStore_MarkApplicationsRead_ReturnsClearedCount(t *testing.T) {
+	t.Parallel()
+	q := &fakeNSQuerier{queryResponses: []queryResp{{rows: newNSRows([][]any{{int64(1)}})}}}
+	s := NewPostgresStore(q)
+
+	cleared, err := s.MarkApplicationsRead(context.Background(), "user-1",
+		[]string{"24-01234"}, []int{330}, time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleared != 1 {
+		t.Errorf("cleared: got %d, want 1", cleared)
+	}
+}
+
+func TestPostgresNSStore_MarkApplicationsRead_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("mark-read boom")
+	q := &fakeNSQuerier{queryResponses: []queryResp{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	_, err := s.MarkApplicationsRead(context.Background(), "user-1",
+		[]string{"24-01234"}, []int{330}, time.Now())
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
 	}
 }
 

--- a/api-go/internal/notifydispatch/enqueuer.go
+++ b/api-go/internal/notifydispatch/enqueuer.go
@@ -27,7 +27,6 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
-	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
@@ -53,11 +52,10 @@ type deviceReader interface {
 	Delete(ctx context.Context, userID, token string) error
 }
 
-// stateReader supplies the unread-badge inputs: the read watermark and the
-// strictly-after-watermark count. *notificationstate.CosmosStore satisfies it.
+// stateReader supplies the unread-badge input: the total unread tally
+// (read_at IS NULL, ADR 0035). *notificationstate.PostgresStore satisfies it.
 type stateReader interface {
-	Get(ctx context.Context, userID string) (*notificationstate.State, error)
-	UnreadCount(ctx context.Context, userID string, lastReadAt time.Time) (int, error)
+	UnreadCount(ctx context.Context, userID string) (int, error)
 }
 
 // pushSender is the consumer-side push contract; apns.PushSender (the real

--- a/api-go/internal/notifydispatch/enqueuer_test.go
+++ b/api-go/internal/notifydispatch/enqueuer_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
-	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
 )
@@ -80,17 +79,12 @@ func (f *fakeDevices) Delete(_ context.Context, _, token string) error {
 	return nil
 }
 
-// fakeState serves the read-watermark and unread count.
+// fakeState serves the unread count (read_at IS NULL, ADR 0035).
 type fakeState struct {
-	state  *notificationstate.State
 	unread int
 }
 
-func (f *fakeState) Get(_ context.Context, _ string) (*notificationstate.State, error) {
-	return f.state, nil
-}
-
-func (f *fakeState) UnreadCount(_ context.Context, _ string, _ time.Time) (int, error) {
+func (f *fakeState) UnreadCount(_ context.Context, _ string) (int, error) {
 	return f.unread, nil
 }
 

--- a/api-go/internal/notifydispatch/push.go
+++ b/api-go/internal/notifydispatch/push.go
@@ -3,7 +3,6 @@ package notifydispatch
 import (
 	"context"
 	"log/slog"
-	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 )
@@ -57,21 +56,11 @@ func sendInstantPush(ctx context.Context, deps instantPushDeps, userID string, n
 	return true
 }
 
-// unreadBadge computes the app-icon badge: notifications created strictly after
-// the read watermark plus 1 for the just-created notification (not yet persisted
-// but unread by construction). A first-touch user (no watermark) starts at the
-// Unix epoch so all existing notifications count.
+// unreadBadge computes the app-icon badge: the user's unread notifications
+// (read_at IS NULL, ADR 0035) plus 1 for the just-created notification (not yet
+// persisted but unread by construction).
 func unreadBadge(ctx context.Context, state stateReader, logger *slog.Logger, userID string) int {
-	lastReadAt := time.Unix(0, 0).UTC()
-	st, err := state.Get(ctx, userID)
-	if err != nil {
-		logger.ErrorContext(ctx, "instant push: load notification state failed", "user", userID, "error", err)
-		return 1
-	}
-	if st != nil {
-		lastReadAt = st.LastReadAt
-	}
-	count, err := state.UnreadCount(ctx, userID, lastReadAt)
+	count, err := state.UnreadCount(ctx, userID)
 	if err != nil {
 		logger.ErrorContext(ctx, "instant push: unread count failed", "user", userID, "error", err)
 		return 1

--- a/api-go/internal/watchzones/cas_test.go
+++ b/api-go/internal/watchzones/cas_test.go
@@ -116,7 +116,6 @@ func TestCreate_ConcurrentCreatesRespectQuota(t *testing.T) {
 		profiles: &fakeProfileReader{profile: p},
 		resolver: &fakeResolver{},
 		apps:     &fakeAppFinder{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMuxWithCAS(t, d, casFake)
@@ -188,7 +187,6 @@ func TestCreate_DeleteFreesQuota(t *testing.T) {
 		profiles: &fakeProfileReader{profile: casFake.profile},
 		resolver: &fakeResolver{},
 		apps:     &fakeAppFinder{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	createMux := newNearbyMuxWithCAS(t, d, casFake)
@@ -223,7 +221,6 @@ func TestCreate_LegacyProfileLazyInit(t *testing.T) {
 		profiles: &fakeProfileReader{profile: p},
 		resolver: &fakeResolver{},
 		apps:     &fakeAppFinder{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMuxWithCAS(t, d, casFake)
@@ -245,7 +242,7 @@ func TestCreate_FailsClosedWhenCASNotWired(t *testing.T) {
 	mux := http.NewServeMux()
 	// NearbyRoutes WITHOUT WithProfileCAS — profileCAS is nil.
 	NearbyRoutes(mux, &fakeZoneStore{}, &fakeProfileReader{profile: freeProfile(t)},
-		&fakeResolver{}, &fakeAppFinder{}, &fakeWatermark{}, &fakeUnread{},
+		&fakeResolver{}, &fakeAppFinder{}, &fakeUnread{},
 		func() string { return "zone-x" }, func() time.Time { return nearbyNow },
 		slog.New(slog.DiscardHandler))
 
@@ -260,7 +257,7 @@ func TestCreate_FailsClosedWhenCASNotWired(t *testing.T) {
 func newNearbyMuxWithCAS(t *testing.T, d nearbyDeps, cas profileCAS) *http.ServeMux {
 	t.Helper()
 	mux := http.NewServeMux()
-	NearbyRoutes(mux, d.store, d.profiles, d.resolver, d.apps, d.state, d.unread,
+	NearbyRoutes(mux, d.store, d.profiles, d.resolver, d.apps, d.unread,
 		func() string { return "zone-cas-" + time.Now().Format("150405.000000000") },
 		func() time.Time { return nearbyNow },
 		slog.New(slog.DiscardHandler),

--- a/api-go/internal/watchzones/handler.go
+++ b/api-go/internal/watchzones/handler.go
@@ -84,7 +84,6 @@ type handler struct {
 	profileCAS profileCAS
 	resolver   authorityResolver
 	apps       appFinder
-	state      watermarkReader
 	unread     unreadReader
 	newID      func() string
 	now        func() time.Time

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -77,10 +77,10 @@ type watermarkReader interface {
 	Get(ctx context.Context, userID string) (*notificationstate.State, error)
 }
 
-// unreadReader batches the per-application latest-unread lookup.
-// *notifications.CosmosStore satisfies it.
+// unreadReader batches the per-application latest-unread lookup (read_at IS NULL,
+// ADR 0035). *notifications.PostgresStore satisfies it.
 type unreadReader interface {
-	GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string, lastReadAt time.Time) (map[string]notifications.LatestUnread, error)
+	GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string) (map[string]notifications.LatestUnread, error)
 }
 
 // NearbyRoutes registers POST /v1/me/watch-zones (create, returning nearby
@@ -397,16 +397,19 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Only classify rows as unread when the user has a watermark; first-touch
-	// users get null latestUnreadEvent everywhere (the dedicated notification-state
-	// seeder owns watermark creation).
+	// Only classify rows as unread when the user has a notification_state row.
+	// Unread is now read_at IS NULL (ADR 0035); this gate is retained unchanged
+	// from the watermark model to preserve behaviour for existing users. It is
+	// deliberately out of scope for the read_at migration — see the follow-up on
+	// making this display path independent of the state row so brand-new users
+	// (who no longer get a seeded row) also surface per-row unread badges.
 	var unread map[string]notifications.LatestUnread
 	if state != nil {
 		uids := make([]string, 0, len(apps))
 		for _, a := range apps {
 			uids = append(uids, a.UID)
 		}
-		unread, err = h.unread.GetLatestUnreadByApplications(r.Context(), userID, uids, state.LastReadAt)
+		unread, err = h.unread.GetLatestUnreadByApplications(r.Context(), userID, uids)
 		if err != nil {
 			h.serverError(w, r, "load latest unread", err)
 			return

--- a/api-go/internal/watchzones/nearby.go
+++ b/api-go/internal/watchzones/nearby.go
@@ -18,7 +18,6 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
-	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
@@ -70,13 +69,6 @@ type appFinder interface {
 	FindClustersInZone(ctx context.Context, q applications.ClusterQuery) ([]applications.Cluster, error)
 }
 
-// watermarkReader reads the caller's notification read-watermark. A nil return
-// is the first-touch signal (no watermark yet). *notificationstate.CosmosStore
-// satisfies it.
-type watermarkReader interface {
-	Get(ctx context.Context, userID string) (*notificationstate.State, error)
-}
-
 // unreadReader batches the per-application latest-unread lookup (read_at IS NULL,
 // ADR 0035). *notifications.PostgresStore satisfies it.
 type unreadReader interface {
@@ -92,7 +84,6 @@ func NearbyRoutes(
 	profileReader profileReader,
 	resolver authorityResolver,
 	apps appFinder,
-	state watermarkReader,
 	unread unreadReader,
 	newID func() string,
 	now func() time.Time,
@@ -104,7 +95,6 @@ func NearbyRoutes(
 		profiles: profileReader,
 		resolver: resolver,
 		apps:     apps,
-		state:    state,
 		unread:   unread,
 		newID:    newID,
 		now:      now,
@@ -391,29 +381,18 @@ func (h *handler) applications(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	state, err := h.state.Get(r.Context(), userID)
-	if err != nil {
-		h.serverError(w, r, "load notification state", err)
-		return
+	// Classify each row's latest unread notification. Unread is purely
+	// read_at IS NULL (ADR 0035), independent of any notification_state row, so
+	// this runs unconditionally — a brand-new user (who no longer gets a seeded
+	// state row) still surfaces per-application unread badges.
+	uids := make([]string, 0, len(apps))
+	for _, a := range apps {
+		uids = append(uids, a.UID)
 	}
-
-	// Only classify rows as unread when the user has a notification_state row.
-	// Unread is now read_at IS NULL (ADR 0035); this gate is retained unchanged
-	// from the watermark model to preserve behaviour for existing users. It is
-	// deliberately out of scope for the read_at migration — see the follow-up on
-	// making this display path independent of the state row so brand-new users
-	// (who no longer get a seeded row) also surface per-row unread badges.
-	var unread map[string]notifications.LatestUnread
-	if state != nil {
-		uids := make([]string, 0, len(apps))
-		for _, a := range apps {
-			uids = append(uids, a.UID)
-		}
-		unread, err = h.unread.GetLatestUnreadByApplications(r.Context(), userID, uids)
-		if err != nil {
-			h.serverError(w, r, "load latest unread", err)
-			return
-		}
+	unread, err := h.unread.GetLatestUnreadByApplications(r.Context(), userID, uids)
+	if err != nil {
+		h.serverError(w, r, "load latest unread", err)
+		return
 	}
 
 	results := make([]applications.Result, 0, len(apps))

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -122,7 +122,7 @@ type fakeUnread struct {
 	lastUIDs []string
 }
 
-func (f *fakeUnread) GetLatestUnreadByApplications(_ context.Context, _ string, uids []string, _ time.Time) (map[string]notifications.LatestUnread, error) {
+func (f *fakeUnread) GetLatestUnreadByApplications(_ context.Context, _ string, uids []string) (map[string]notifications.LatestUnread, error) {
 	f.called = true
 	f.lastUIDs = uids
 	return f.result, f.err

--- a/api-go/internal/watchzones/nearby_test.go
+++ b/api-go/internal/watchzones/nearby_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
-	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
 
@@ -106,15 +105,6 @@ func (f *fakeAppFinder) FindClustersInZone(_ context.Context, q applications.Clu
 	return f.clusters, nil
 }
 
-type fakeWatermark struct {
-	state *notificationstate.State
-	err   error
-}
-
-func (f *fakeWatermark) Get(_ context.Context, _ string) (*notificationstate.State, error) {
-	return f.state, f.err
-}
-
 type fakeUnread struct {
 	result   map[string]notifications.LatestUnread
 	err      error
@@ -133,7 +123,6 @@ type nearbyDeps struct {
 	profiles *fakeProfileReader
 	resolver *fakeResolver
 	apps     *fakeAppFinder
-	state    *fakeWatermark
 	unread   *fakeUnread
 }
 
@@ -146,7 +135,7 @@ func newNearbyMux(t *testing.T, d nearbyDeps) *http.ServeMux {
 	// the existing quota assertions (Free at limit -> 403, Pro -> unlimited)
 	// continue to hold.
 	cas := newFakeProfileCAS(d.profiles.profile)
-	NearbyRoutes(mux, d.store, d.profiles, d.resolver, d.apps, d.state, d.unread,
+	NearbyRoutes(mux, d.store, d.profiles, d.resolver, d.apps, d.unread,
 		func() string { return "zone-123" }, func() time.Time { return nearbyNow },
 		slog.New(slog.DiscardHandler), WithProfileCAS(cas))
 	return mux
@@ -210,7 +199,6 @@ func TestCreate_PersistsZoneAndReturnsNearbyApplications(t *testing.T) {
 			testAppInAuthority("uid-1", "24/001", 471),
 			testAppInAuthority("uid-2", "24/002", 246),
 		}},
-		state:  &fakeWatermark{},
 		unread: &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -265,7 +253,6 @@ func TestCreate_ResolvesAuthorityWhenAbsent(t *testing.T) {
 		profiles: &fakeProfileReader{profile: proProfile(t)},
 		resolver: &fakeResolver{id: 326},
 		apps:     &fakeAppFinder{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -292,7 +279,6 @@ func TestCreate_QuotaExceededIs403(t *testing.T) {
 		profiles: &fakeProfileReader{profile: freeProfile(t)},
 		resolver: &fakeResolver{},
 		apps:     &fakeAppFinder{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -326,7 +312,6 @@ func TestCreate_ProTierBypassesQuota(t *testing.T) {
 		profiles: &fakeProfileReader{profile: proProfile(t)},
 		resolver: &fakeResolver{},
 		apps:     &fakeAppFinder{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -357,7 +342,6 @@ func TestCreate_ExpiredProTierQuotaIs403(t *testing.T) {
 		profiles: &fakeProfileReader{profile: lapsed},
 		resolver: &fakeResolver{},
 		apps:     &fakeAppFinder{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -388,7 +372,7 @@ func TestCreate_InvalidPayloadIs400(t *testing.T) {
 			d := nearbyDeps{
 				store:    &fakeZoneStore{},
 				profiles: &fakeProfileReader{profile: proProfile(t)},
-				resolver: &fakeResolver{}, apps: &fakeAppFinder{}, state: &fakeWatermark{}, unread: &fakeUnread{},
+				resolver: &fakeResolver{}, apps: &fakeAppFinder{}, unread: &fakeUnread{},
 			}
 			mux := newNearbyMux(t, d)
 			rec := doReq(t, mux, http.MethodPost, "/v1/me/watch-zones", body)
@@ -407,7 +391,7 @@ func TestCreate_MissingProfileIs500(t *testing.T) {
 	d := nearbyDeps{
 		store:    &fakeZoneStore{},
 		profiles: &fakeProfileReader{profile: nil},
-		resolver: &fakeResolver{}, apps: &fakeAppFinder{}, state: &fakeWatermark{}, unread: &fakeUnread{},
+		resolver: &fakeResolver{}, apps: &fakeAppFinder{}, unread: &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
 	body := `{"name":"Z","latitude":51.5,"longitude":-0.12,"radiusMetres":1000,"authorityId":471}`
@@ -423,7 +407,7 @@ func TestCreate_ResolverErrorIs500(t *testing.T) {
 		store:    &fakeZoneStore{},
 		profiles: &fakeProfileReader{profile: proProfile(t)},
 		resolver: &fakeResolver{err: errors.New("upstream down")},
-		apps:     &fakeAppFinder{}, state: &fakeWatermark{}, unread: &fakeUnread{},
+		apps:     &fakeAppFinder{}, unread: &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
 	body := `{"name":"Z","latitude":51.5,"longitude":-0.12,"radiusMetres":1000}`
@@ -444,7 +428,6 @@ func TestApplications_AugmentsUnreadAndNullsTheRest(t *testing.T) {
 		}},
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{state: &notificationstate.State{UserID: testUser, LastReadAt: time.Unix(0, 0), Version: 1}},
 		unread: &fakeUnread{result: map[string]notifications.LatestUnread{
 			"uid-1": {ApplicationUID: "uid-1", EventType: notifications.EventDecisionUpdate, Decision: &decision, CreatedAt: unreadAt},
 		}},
@@ -490,7 +473,6 @@ func TestApplications_DefaultsLimitTo500(t *testing.T) {
 		apps:     &fakeAppFinder{},
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -527,7 +509,6 @@ func TestApplications_LimitParsing(t *testing.T) {
 				apps:     &fakeAppFinder{},
 				profiles: &fakeProfileReader{},
 				resolver: &fakeResolver{},
-				state:    &fakeWatermark{},
 				unread:   &fakeUnread{},
 			}
 			mux := newNearbyMux(t, d)
@@ -549,7 +530,6 @@ func TestApplications_SetsNextCursorHeaderWhenMorePagesExist(t *testing.T) {
 		apps:     &fakeAppFinder{apps: []applications.PlanningApplication{testApp("uid-1", "24/001")}, next: "raw-token-123"},
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -572,7 +552,6 @@ func TestApplications_OmitsNextCursorHeaderWhenExhausted(t *testing.T) {
 		apps:     &fakeAppFinder{apps: []applications.PlanningApplication{testApp("uid-1", "24/001")}}, // next == ""
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -593,7 +572,6 @@ func TestApplications_ResumesFromCursorParam(t *testing.T) {
 		apps:     &fakeAppFinder{},
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -616,7 +594,6 @@ func TestApplications_RejectsUndecodableCursorWith400(t *testing.T) {
 		apps:     &fakeAppFinder{},
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -642,7 +619,6 @@ func TestApplications_BoundsUnreadLookupToReturnedPage(t *testing.T) {
 		apps:     &fakeAppFinder{apps: manyApps(600)},
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{state: &notificationstate.State{UserID: testUser, LastReadAt: time.Unix(0, 0), Version: 1}},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -652,7 +628,7 @@ func TestApplications_BoundsUnreadLookupToReturnedPage(t *testing.T) {
 		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
 	}
 	if !d.unread.called {
-		t.Fatal("unread lookup must run when the user has a watermark")
+		t.Fatal("unread lookup must always run (read_at IS NULL, independent of any state row)")
 	}
 	if got := len(d.unread.lastUIDs); got != 500 {
 		t.Errorf("unread lookup UID set: got %d, want 500 (bounded to the returned page)", got)
@@ -672,7 +648,6 @@ func TestApplications_SurfacesNeighbourAuthorityApps(t *testing.T) {
 		}},
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -696,15 +671,22 @@ func TestApplications_SurfacesNeighbourAuthorityApps(t *testing.T) {
 	}
 }
 
-func TestApplications_NoWatermarkSkipsUnreadLookup(t *testing.T) {
+// TestApplications_UnreadSurfacesWithoutStateRow proves the ADR 0035 flip: a
+// brand-new user with NO notification_state row (GET no longer seeds one) still
+// gets per-application unread badges, because unread is purely read_at IS NULL.
+// The lookup runs unconditionally and its result is mapped onto the row.
+func TestApplications_UnreadSurfacesWithoutStateRow(t *testing.T) {
 	t.Parallel()
+	decision := "Permitted"
+	unreadAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
 	d := nearbyDeps{
 		store:    &fakeZoneStore{zones: []WatchZone{mustZone(t, "zone-1", 471)}},
 		apps:     &fakeAppFinder{apps: []applications.PlanningApplication{testApp("uid-1", "24/001")}},
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{state: nil}, // first touch: no watermark
-		unread:   &fakeUnread{},
+		unread: &fakeUnread{result: map[string]notifications.LatestUnread{
+			"uid-1": {ApplicationUID: "uid-1", EventType: notifications.EventNewApplication, CreatedAt: unreadAt, Decision: &decision},
+		}},
 	}
 	mux := newNearbyMux(t, d)
 
@@ -712,8 +694,18 @@ func TestApplications_NoWatermarkSkipsUnreadLookup(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200", rec.Code)
 	}
-	if d.unread.called {
-		t.Error("unread lookup must be skipped when the user has no watermark")
+	if !d.unread.called {
+		t.Fatal("unread lookup must run even without a notification_state row (read_at IS NULL)")
+	}
+	var rows []struct {
+		UID               string          `json:"uid"`
+		LatestUnreadEvent json.RawMessage `json:"latestUnreadEvent"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("decode rows: %v; raw=%s", err, rec.Body.String())
+	}
+	if len(rows) != 1 || rows[0].UID != "uid-1" || rows[0].LatestUnreadEvent == nil {
+		t.Errorf("uid-1 must carry latestUnreadEvent without a state row: got %+v", rows)
 	}
 }
 
@@ -724,7 +716,6 @@ func TestApplications_ZoneNotFoundIs404(t *testing.T) {
 		apps:     &fakeAppFinder{},
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -742,7 +733,6 @@ func TestApplications_EmptyZoneReturnsEmptyArray(t *testing.T) {
 		apps:     &fakeAppFinder{},
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 	mux := newNearbyMux(t, d)
@@ -775,7 +765,6 @@ func TestCreate_RejectsOversizedRadius(t *testing.T) {
 				profiles: &fakeProfileReader{profile: proProfile(t)},
 				resolver: &fakeResolver{},
 				apps:     &fakeAppFinder{},
-				state:    &fakeWatermark{},
 				unread:   &fakeUnread{},
 			}
 			mux := newNearbyMux(t, d)
@@ -820,7 +809,6 @@ func sortDeps(t *testing.T, apps *fakeAppFinder) nearbyDeps {
 		apps:     apps,
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 }
@@ -1278,7 +1266,6 @@ func clusterDeps(t *testing.T, apps *fakeAppFinder) nearbyDeps {
 		apps:     apps,
 		profiles: &fakeProfileReader{},
 		resolver: &fakeResolver{},
-		state:    &fakeWatermark{},
 		unread:   &fakeUnread{},
 	}
 }

--- a/docs/adr/0035-per-application-notification-read-state.md
+++ b/docs/adr/0035-per-application-notification-read-state.md
@@ -1,0 +1,103 @@
+# 0035. Per-application notification read state
+
+Date: 2026-07-01
+
+## Status
+
+Accepted
+
+Supersedes the single per-user last-read watermark read-state design (the read-state
+assumptions of [0033](0033-server-authoritative-watch-zone-querying.md)). Builds on
+[0032](0032-consolidate-datastore-on-postgres-postgis.md). Graduates memo
+[0012](../memo/0012-notification-read-state-per-application.md).
+
+## Context
+
+Notification read state was a single per-user watermark:
+`notification_state(user_id PK, last_read_at timestamptz, version int)`, one row per
+user, with a notification unread iff `notifications.created_at > last_read_at`. The
+watermark was chosen to dodge Cosmos per-write economics — one timestamp move instead
+of N per-item writes. Three SQL sites computed the unread rule (the total unread badge
+count, `GetLatestUnreadByApplications` for the per-application badge, and the zonepage
+recent-activity / unread-filter subquery, which INNER JOINed `notification_state` so a
+user with no watermark row contributed no unread rows). Read state also moved forward
+implicitly as the user scrolled, via a `POST .../advance` endpoint.
+
+Two problems motivated a change:
+
+- **The product wants genuine tap-to-read.** Opening an application should clear only
+  that application's unread state, which a single monotonic watermark cannot express —
+  a watermark can only say "everything before instant T is read".
+- **The cost constraint is gone.** [0032](0032-consolidate-datastore-on-postgres-postgis.md)
+  consolidated all data on a fixed-price Azure Postgres Burstable `Standard_B1ms`. There
+  is no per-operation billing, so per-row read writes are effectively free at our scale
+  (memo [0012](../memo/0012-notification-read-state-per-application.md) analyses this and
+  concludes the change is net-neutral to net-negative on DB load: a self-pruning partial
+  index replaces a growing `created_at > last_read_at` scan, and retiring scroll-to-clear
+  for tap-to-read reduces write frequency).
+
+The client contract exposes no notification IDs — clients operate on applications keyed
+by `application_uid` — so per-notification-row read state (with a new list endpoint and
+ID exposure) was rejected in favour of per-application granularity (memo 0012, option B).
+
+## Decision
+
+Track read state per application on the `notifications` table via a nullable
+`read_at timestamptz`. A notification is unread iff `read_at IS NULL`.
+
+- **Migration 0015** (shipped separately, ahead of the API) adds the column, backfills
+  it so the unread set is identical at the flip (`read_at = last_read_at` where
+  `created_at <= last_read_at`; `read_at = created_at` for users with no watermark row,
+  who read as all-read today), and adds the partial index
+  `idx_notifications_unread (user_id, application_uid, created_at) WHERE read_at IS NULL`.
+- **New endpoint** `POST /v1/me/applications/mark-read` with body
+  `{"applications": [{"applicationUid", "authorityId"}]}` clears the caller's unread rows
+  for those applications and returns `204` (idempotent). The array is forward-compatible
+  (clients send one today); an empty array marks nothing — never "all". It is scoped by
+  the composite `(application_uid, authority_id)`: `application_uid` is the bare
+  per-council PlanIt ref and is **not** unique across authorities, so matching on the uid
+  alone (user-scoped) would clear the wrong council's rows. The endpoint uses a fixed path
+  (no path parameter) because application UIDs contain slashes that Go's `ServeMux` cannot
+  route.
+- **Mark-all-read** (`POST /v1/me/notification-state/mark-all-read`) clears every unread
+  row for the user.
+- The three unread SQL sites are repointed to `read_at IS NULL`. The zonepage subqueries
+  drop the `notification_state` JOIN but keep `GROUP BY application_uid, authority_id` and
+  the outer join on both keys, so they stay authority-safe. The "untouched user has no
+  unread" behaviour is preserved by the backfill (existing no-watermark users' history is
+  marked read), while a genuinely new notification correctly reads as unread.
+- **`notification_state` is retained** (table and `version`) as an opaque **change token**:
+  `version` bumps on any read-state mutation — unconditionally on mark-all, and on
+  mark-read only when it actually cleared a row — so the client's BadgeSync still detects
+  change. The mutation and its version bump run atomically in a single data-modifying CTE.
+  `last_read_at` is vestigial (kept only for GET DTO shape stability) and no longer drives
+  unread.
+- **`GET /v1/me/notification-state` no longer seeds a first-touch watermark row** (it must
+  not write): for a user with a row it returns that row's `last_read_at` + `version`; for a
+  user with none it returns `version 0` and `lastReadAt` computed at `now` (not persisted).
+  The DTO shape `{ lastReadAt, version, totalUnreadCount }` is unchanged; `totalUnreadCount`
+  is now the `read_at IS NULL` tally.
+- **`advance` (scroll-to-clear) is removed** — endpoint, handler, and `State.AdvanceTo`.
+  Unread now clears only via tap-to-read or mark-all, giving one source of truth.
+
+## Consequences
+
+- Tap-to-read is expressible: opening an application clears exactly that application's
+  unread notifications, not everything older than a timestamp.
+- The hot unread paths (badge count, unread filter) scan the self-pruning partial index
+  instead of comparing `created_at > last_read_at` over a growing set, so the read path is
+  slightly cheaper; per-row read writes are single-row, indexed, and human-paced.
+- Cross-authority safety is now explicit in the mutation path (composite scoping). The
+  **display** path (`GetLatestUnreadByApplications` and the watch-zone nearby handler) still
+  correlates the per-row unread badge by bare `application_uid` alone, a pre-existing
+  collision left unchanged here and tracked as a follow-up.
+- Because GET no longer seeds a watermark, brand-new users' incoming notifications read as
+  unread immediately (the intended behaviour). The watch-zone nearby handler still gates its
+  per-row unread badge on the presence of a `notification_state` row, so a brand-new user's
+  per-row badges there lag until a mark-read/mark-all creates the row — a known follow-up,
+  out of scope for this change.
+- Clients (iOS, web) must add `markApplicationRead` and delete `advance`; these ship as
+  separate PRs. Until they do, the `advance` route returns 404.
+- `notification_state`/`version` can be dropped in a later cleanup once `version` is
+  confirmed unused; GDPR erasure is unchanged (`read_at` is a column on `notifications`
+  rows already removed by erasure).

--- a/docs/memo/0012-notification-read-state-per-application.md
+++ b/docs/memo/0012-notification-read-state-per-application.md
@@ -1,0 +1,64 @@
+# 0012. Per-application notification read state (replacing the last-read watermark)
+
+Date: 2026-07-01
+
+## Status
+
+Superseded by ADR [0035](../adr/0035-per-application-notification-read-state.md)
+
+## Question
+
+Now that all data lives on Postgres + PostGIS (ADR [0032](../adr/0032-consolidate-datastore-on-postgres-postgis.md)) and we no longer pay per-operation Cosmos RUs, should we replace the single per-user "last read" watermark with per-notification read tracking, so that opening a notification marks just that item read? And does the extra write volume increase the cost of running the application, especially at scale?
+
+## Analysis
+
+### Current model
+
+Read state today is a single per-user watermark, not a per-item flag:
+
+- `notification_state(user_id PK, last_read_at timestamptz, version int)` — one row per user.
+- A notification is unread iff `notifications.created_at > last_read_at`.
+- The `notifications` table carries no read column (only `push_sent` / `email_sent` delivery booleans). Notification rows are already per-user (`user_id` on every row).
+- Three endpoints: `GET /v1/me/notification-state`, `POST /v1/me/notification-state/mark-all-read`, `POST /v1/me/notification-state/advance` (moves the watermark forward as the user scrolls past items).
+- The unread rule (`created_at > last_read_at`) is computed in three SQL sites: the total unread badge count, `GetLatestUnreadByApplications` (per-application badge), and the zonepage recent-activity subquery (which INNER JOINs `notification_state` to implement a first-touch clean slate).
+- The client contract has no notification IDs. Clients operate on applications (keyed by `application_uid`), not individual notification rows. There is no list-notifications endpoint.
+
+The watermark was almost certainly chosen to dodge Cosmos economics: one timestamp move instead of N per-item writes, and unread-count as a single query rather than a maintained counter. ADR 0032 removed that constraint.
+
+### Cost analysis
+
+The prod database is an Azure Postgres Flexible Server, **Burstable `Standard_B1ms`** (1 vCore, 2 GB RAM, 32 GB storage, HA disabled) — see `infra/shared.go`. This is a fixed monthly cost billed by the hour regardless of query volume. There is no per-operation billing.
+
+Consequences for this change:
+
+- **Writes are free until the tier saturates.** A mark-read is a single-row, indexed `UPDATE ... WHERE user_id = $1 AND application_uid = $2 AND read_at IS NULL` touching (usually) one row. It is human-paced — one write per app-open-with-unread, plus the occasional mark-all — not a poll, background job, or fan-out.
+- **Headroom is large.** 1,000 daily-active users clearing 30 notifications/day is 30k writes/day, under 0.5 writes/sec average. A B1ms does not notice that. Write volume alone would not register until tens of thousands of concurrently active users.
+- **The scaling ceiling is unchanged.** The workload that forces a tier bump is reads — the PostGIS zone queries, `/clusters` grid snapping, recent-activity sort — not mark-read. When "significant users" arrives, compute is scaled for reads regardless, and mark-read remains a rounding error on top.
+- **This is net-neutral to net-negative on load.** We retire `advance` (a scroll-frequency write, potentially chatty) and replace it with tap-to-read (tap-frequency, less often). The partial index `WHERE read_at IS NULL` is self-pruning — read rows drop out of it — so the hot unread-count and unread-filter queries scan a small index instead of comparing `created_at > last_read_at` across a growing set. The read path gets slightly cheaper.
+- **Storage delta is negligible.** One nullable `timestamptz` per row (~8 bytes), tens of MB at millions of rows, on £-per-GB storage.
+
+Conclusion: the migration to per-application read state does not materially increase running cost and may slightly reduce DB load. The concern that motivated the watermark (per-write cost) no longer applies.
+
+## Options Considered
+
+**A. Keep the watermark.** Cheapest possible writes and O(1) mark-all, but cannot express "I read this one and not that one." Rejected: the product wants tap-to-read.
+
+**B. Per-application `read_at` column on `notifications` (chosen).** Add `read_at timestamptz NULL`; unread iff `read_at IS NULL`. Mark-one is scoped to an application (`WHERE user_id, application_uid, read_at IS NULL`), matching the existing client contract, which keys everything on `application_uid`. Mark-all becomes a bulk UPDATE over the user's unread rows. No join table needed because notification rows are already per-user. A partial index keeps the hot paths fast. Requires a one-time backfill and rewriting the three unread SQL sites.
+
+**C. True per-notification-row read state.** Full per-item granularity, but the client has no notification IDs today, so it needs a new list-notifications endpoint and an ID exposed to iOS/web — a larger contract change for no product benefit over (B), since the user reads at the application level. Rejected.
+
+### Decisions taken with the owner
+
+- **Granularity: per application.** Tapping into an application marks its unread notifications read. No notification IDs exposed to clients.
+- **Explicit only.** Retire `advance` / scroll-to-clear. Unread clears on tap-to-read or mark-all. One source of truth (`read_at`).
+- **Keep mark-all as its own endpoint.** Do not overload mark-one with "empty list means all" — that is a mass-mutation footgun.
+
+## Recommendation
+
+Proceed with option B, staged so the change is additive and back-compatible (relevant now we have a paying customer and rollback safety is back on the table — see CLAUDE.md Business Status):
+
+1. **Migration first**: add `read_at`, backfill (`read_at = last_read_at` where `created_at <= last_read_at`; `read_at = created_at` for users with no watermark row; everything after the watermark stays NULL/unread), add the partial index. Old API ignores the column; watermark still works. Safe to deploy alone.
+2. **API next**: add `POST /v1/me/applications/{applicationUid}/mark-read`; re-point `mark-all-read` and the three unread SQL sites to `read_at IS NULL`; keep `GET` returning `totalUnreadCount`; remove `advance`. The backfill guarantees the unread set is identical at the flip.
+3. **Clients last** (iOS, web): add `markApplicationRead`, wire tap-to-read, delete `advance`. Retire the endpoint once nothing calls it.
+
+Write the superseding ADR as part of step 2. Guardrail worth building in: the client only calls mark-read when the application actually shows an unread badge, avoiding pointless round-trips.


### PR DESCRIPTION
## Changes

Step 2 of 3 for #733 — the API flip from the per-user last-read watermark to per-application `read_at`. Migration 0015 (step 1, #734) already added the column, backfill and partial index, so the unread set is identical at this flip.

**New endpoint**
- `POST /v1/me/applications/mark-read` (auth required), body `{"applications":[{"applicationUid":"24-01234","authorityId":330}]}`. Idempotent `204`; empty array is a no-op that marks nothing (mark-all stays a separate endpoint). Scoped by the **composite `(application_uid, authority_id)`** — application refs are only unique within a council, so matching on `application_uid` alone would clear another authority's same-ref notifications. Array shape is forward-compat (clients send one today).

**Repointed unread to `read_at IS NULL`** (dropping the `lastReadAt` params)
- `pgUnreadCountQuery`, `pgLatestUnreadQuery`, and both zonepage subqueries (const `activityUnreadSubquery` + the dynamic `buildFilteredZoneQuery`) — the latter keep `GROUP BY application_uid, authority_id` and the outer join on both keys (already authority-safe).
- `mark-all-read` → bulk `UPDATE ... WHERE read_at IS NULL`, still bumps the `version` change token (atomic CTE, upserts the state row).
- `version` bumps on any read-state mutation (mark-all always; mark-read when it clears ≥1 row) so BadgeSync keeps detecting change.

**Behavioural**
- `GET /v1/me/notification-state` DTO unchanged (`lastReadAt`, `version`, `totalUnreadCount`); it no longer seeds a first-touch watermark row (side-effect-free); `totalUnreadCount` from `read_at IS NULL`.
- Removed `advance` entirely (route now 404s, handler + `State.AdvanceTo` gone).
- `watchzones/nearby.go`: dropped the `notification_state`-row gate on the per-app unread badge — under `read_at IS NULL`, brand-new users (no seeded row) now correctly surface per-app unread.
- Mechanical `UnreadCount` signature ripple through `digest` and `notifydispatch` badge counts (output preserved).

**Docs**
- New ADR `0035-per-application-notification-read-state.md` (Accepted); memo 0012 flipped to `Superseded by ADR 0035`.

## Tests
`go test ./...` (1222) + `go test -tags=integration ./...` (1358, real PostGIS) + `golangci-lint` all green. New integration coverage: backfill/read_at equivalence for unread-count, `GetLatestUnreadByApplications`, and zonepage recent-activity/unread-filter; mark-read idempotency; and the cross-authority guard (mark-read for authority 330 leaves authority 331's same-ref rows untouched).

## Follow-up (out of scope, filed)
- tc-4o3h — make the `GetLatestUnreadByApplications` *display* path authority-aware (pre-existing bare-uid collision).

Bead: tc-0sfx.2 · Epic: tc-0sfx · Issue: #733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-application read tracking for notifications, including a way to mark selected application notifications as read.
  * Notification badges and unread lists now reflect unread items directly, even for first-time users.

* **Bug Fixes**
  * Improved unread counts and notification lists so already-read items no longer appear as unread.
  * Updated watch-zone and digest badge behavior to stay in sync with the new unread model.

* **Documentation**
  * Added an update describing the new notification read-state behavior and related client changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->