### PR TITLE
fix(notifications): mark-read matches application_name not application_uid (#733)

### DIFF
--- a/api-go/internal/notificationstate/handler.go
+++ b/api-go/internal/notificationstate/handler.go
@@ -24,7 +24,7 @@ type stateStore interface {
 	Get(ctx context.Context, userID string) (*State, error)
 	UnreadCount(ctx context.Context, userID string) (int, error)
 	MarkAllRead(ctx context.Context, userID string, now time.Time) (int64, error)
-	MarkApplicationsRead(ctx context.Context, userID string, uids []string, authorityIDs []int, now time.Time) (int64, error)
+	MarkApplicationsRead(ctx context.Context, userID string, refs []string, authorityIDs []int, now time.Time) (int64, error)
 }
 
 // stateResult is the GET /v1/me/notification-state response body:
@@ -37,10 +37,19 @@ type stateResult struct {
 	TotalUnreadCount int                 `json:"totalUnreadCount"`
 }
 
-// applicationRef identifies one application to mark read: the bare per-council
-// PlanIt ref plus its authority id. Both are needed because applicationUid is
-// not unique across authorities (the client exposes uid + areaId on every row).
+// applicationRef identifies one application to mark read: a PlanIt case reference
+// plus its authority id. Both are needed because the case reference is unique only
+// within a council; authorityId disambiguates across councils.
 type applicationRef struct {
+	// ApplicationUID keeps the JSON key `applicationUid` for wire compatibility
+	// with the already-merged iOS client — but the value it carries is the PlanIt
+	// case REFERENCE (= a.Name, e.g. "24/0001"), NOT the application_uid column
+	// (= a.UID, e.g. "24/0001/FUL"). The store matches it against application_name,
+	// never application_uid (#733). This is required because everything that would
+	// call mark-read carries a.Name: the push payload sets applicationRef =
+	// n.ApplicationName, iOS sends id.name, and web sends summary.name. a.Name is
+	// unique within a council, so authorityId disambiguates cross-council. Do not
+	// rename this JSON key without shipping a coordinated client change.
 	ApplicationUID string `json:"applicationUid"`
 	AuthorityID    int    `json:"authorityId"`
 }
@@ -118,9 +127,11 @@ func (h handler) markAllRead(w http.ResponseWriter, r *http.Request) {
 }
 
 // markRead clears the caller's unread notifications for the requested
-// applications (scoped by the composite application_uid + authorityId). It is
-// idempotent — 204 even when zero rows changed — and an empty array marks
-// nothing. A malformed body or an over-cap array returns a bodyless 400.
+// applications (scoped by the composite case reference + authorityId; the store
+// matches the reference against application_name, not application_uid — see
+// applicationRef). It is idempotent — 204 even when zero rows changed — and an
+// empty array marks nothing. A malformed body or an over-cap array returns a
+// bodyless 400.
 func (h handler) markRead(w http.ResponseWriter, r *http.Request) {
 	userID := auth.Subject(r.Context())
 
@@ -135,14 +146,16 @@ func (h handler) markRead(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	uids := make([]string, len(req.Applications))
+	// refs carry PlanIt case references (a.Name), matched against application_name
+	// by the store — the applicationUid JSON key is a wire-compat misnomer (#733).
+	refs := make([]string, len(req.Applications))
 	authorityIDs := make([]int, len(req.Applications))
 	for i, a := range req.Applications {
-		uids[i] = a.ApplicationUID
+		refs[i] = a.ApplicationUID
 		authorityIDs[i] = a.AuthorityID
 	}
 
-	if _, err := h.store.MarkApplicationsRead(r.Context(), userID, uids, authorityIDs, h.now()); err != nil {
+	if _, err := h.store.MarkApplicationsRead(r.Context(), userID, refs, authorityIDs, h.now()); err != nil {
 		h.logger.ErrorContext(r.Context(), "mark applications read", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return

--- a/api-go/internal/notificationstate/handler_test.go
+++ b/api-go/internal/notificationstate/handler_test.go
@@ -25,7 +25,7 @@ type fakeStateStore struct {
 
 	markAllCalls  int
 	markReadCalls int
-	markReadUIDs  []string
+	markReadRefs  []string
 	markReadAuths []int
 }
 
@@ -59,14 +59,14 @@ func (f *fakeStateStore) MarkAllRead(_ context.Context, _ string, _ time.Time) (
 	return 0, nil
 }
 
-func (f *fakeStateStore) MarkApplicationsRead(_ context.Context, _ string, uids []string, authorityIDs []int, _ time.Time) (int64, error) {
+func (f *fakeStateStore) MarkApplicationsRead(_ context.Context, _ string, refs []string, authorityIDs []int, _ time.Time) (int64, error) {
 	f.markReadCalls++
-	f.markReadUIDs = uids
+	f.markReadRefs = refs
 	f.markReadAuths = authorityIDs
 	if f.markReadErr != nil {
 		return 0, f.markReadErr
 	}
-	return int64(len(uids)), nil
+	return int64(len(refs)), nil
 }
 
 func testMux(t *testing.T, store stateStore, now time.Time) *http.ServeMux {
@@ -180,9 +180,9 @@ func TestHandler_MarkRead(t *testing.T) {
 		if store.markReadCalls != 1 {
 			t.Fatalf("MarkApplicationsRead calls = %d, want 1", store.markReadCalls)
 		}
-		if !reflect.DeepEqual(store.markReadUIDs, []string{"24-01234"}) ||
+		if !reflect.DeepEqual(store.markReadRefs, []string{"24-01234"}) ||
 			!reflect.DeepEqual(store.markReadAuths, []int{330}) {
-			t.Errorf("passed uids=%v auths=%v, want [24-01234] [330]", store.markReadUIDs, store.markReadAuths)
+			t.Errorf("passed refs=%v auths=%v, want [24-01234] [330]", store.markReadRefs, store.markReadAuths)
 		}
 	})
 
@@ -197,9 +197,9 @@ func TestHandler_MarkRead(t *testing.T) {
 		if rec.Code != http.StatusNoContent {
 			t.Fatalf("status = %d, want 204", rec.Code)
 		}
-		if !reflect.DeepEqual(store.markReadUIDs, []string{"24-01234", "24-05678"}) ||
+		if !reflect.DeepEqual(store.markReadRefs, []string{"24-01234", "24-05678"}) ||
 			!reflect.DeepEqual(store.markReadAuths, []int{330, 331}) {
-			t.Errorf("passed uids=%v auths=%v", store.markReadUIDs, store.markReadAuths)
+			t.Errorf("passed refs=%v auths=%v", store.markReadRefs, store.markReadAuths)
 		}
 	})
 
@@ -212,9 +212,9 @@ func TestHandler_MarkRead(t *testing.T) {
 			t.Fatalf("status = %d, want 204", rec.Code)
 		}
 		// The store is asked to clear the empty set — never "all".
-		if store.markReadCalls != 1 || len(store.markReadUIDs) != 0 || len(store.markReadAuths) != 0 {
-			t.Errorf("empty array: calls=%d uids=%v auths=%v, want 1 call with empty sets",
-				store.markReadCalls, store.markReadUIDs, store.markReadAuths)
+		if store.markReadCalls != 1 || len(store.markReadRefs) != 0 || len(store.markReadAuths) != 0 {
+			t.Errorf("empty array: calls=%d refs=%v auths=%v, want 1 call with empty sets",
+				store.markReadCalls, store.markReadRefs, store.markReadAuths)
 		}
 	})
 

--- a/api-go/internal/notificationstate/store_postgres.go
+++ b/api-go/internal/notificationstate/store_postgres.go
@@ -27,7 +27,7 @@ type Store interface {
 	Save(ctx context.Context, st State) error
 	UnreadCount(ctx context.Context, userID string) (int, error)
 	MarkAllRead(ctx context.Context, userID string, now time.Time) (int64, error)
-	MarkApplicationsRead(ctx context.Context, userID string, uids []string, authorityIDs []int, now time.Time) (int64, error)
+	MarkApplicationsRead(ctx context.Context, userID string, refs []string, authorityIDs []int, now time.Time) (int64, error)
 	DeleteByUserID(ctx context.Context, userID string) error
 }
 
@@ -42,10 +42,11 @@ var _ Store = (*PostgresStore)(nil)
 //   - Unread is read_at IS NULL (ADR 0035); UnreadCount is a SELECT count(*)
 //     over the partial index idx_notifications_unread.
 //   - MarkApplicationsRead clears the caller's unread rows for a set of
-//     (application_uid, authority_id) pairs — the composite is load-bearing:
-//     application_uid is the bare per-council PlanIt ref and is NOT unique
-//     across authorities, so matching on uid alone would clear the wrong
-//     council's rows. It bumps the version token only when it cleared a row.
+//     (application_name, authority_id) pairs — it matches application_name (=
+//     a.Name, the PlanIt case reference the clients and push payload carry), NOT
+//     application_uid (#733). The composite is load-bearing: a.Name is unique
+//     within a council but collides across councils, so authority_id disambiguates.
+//     It bumps the version token only when it cleared a row.
 //   - MarkAllRead clears every unread row for the user and always bumps the
 //     version token (upserting the state row when absent).
 type PostgresStore struct {
@@ -172,20 +173,28 @@ func (s *PostgresStore) MarkAllRead(ctx context.Context, userID string, now time
 }
 
 // pgMarkApplicationsReadQuery clears the caller's unread notifications for a set
-// of (application_uid, authority_id) pairs supplied as two parallel arrays, and
+// of (application_name, authority_id) pairs supplied as two parallel arrays, and
 // bumps the version change token only when it actually cleared a row (upserting
-// the state row when absent). Scoping by the composite pair is load-bearing:
-// application_uid is the bare per-council PlanIt ref and collides across
-// authorities, so authority_id disambiguates. Empty arrays match nothing (a
-// 204 no-op), never "all". Both tables mutate atomically in one CTE statement;
-// the top-level SELECT returns the cleared count.
+// the state row when absent).
+//
+// It matches application_name, NOT application_uid — this is the #733 fix and is
+// load-bearing. The `ref` values in $3 are PlanIt CASE REFERENCES (= a.Name, e.g.
+// "24/0001"), which is what every caller carries: the push payload sets
+// applicationRef = n.ApplicationName (notifydispatch/payload.go), iOS sends id.name,
+// and web sends summary.name. The `application_uid` column instead holds a.UID (e.g.
+// "24/0001/FUL") and no client ever sends it, so the previous application_uid match
+// silently cleared zero rows in production. a.Name is unique within a council but
+// collides across councils, so authority_id disambiguates — the composite pair is
+// therefore load-bearing. Empty arrays match nothing (a 204 no-op), never "all".
+// Both tables mutate atomically in one CTE statement; the top-level SELECT returns
+// the cleared count.
 const pgMarkApplicationsReadQuery = `
 WITH cleared AS (
     UPDATE notifications n
     SET read_at = $2
-    FROM unnest($3::text[], $4::int[]) AS t(uid, aid)
+    FROM unnest($3::text[], $4::int[]) AS t(ref, aid)
     WHERE n.user_id = $1
-      AND n.application_uid = t.uid
+      AND n.application_name = t.ref
       AND n.authority_id = t.aid
       AND n.read_at IS NULL
     RETURNING 1
@@ -199,12 +208,14 @@ WITH cleared AS (
 SELECT count(*) FROM cleared`
 
 // MarkApplicationsRead clears the caller's unread notifications for the given
-// (uid, authorityID) pairs and bumps the version change token when it cleared at
+// (ref, authorityID) pairs and bumps the version change token when it cleared at
 // least one row (leaving the token untouched on a zero-row no-op, so mark-read
-// stays idempotent). uids and authorityIDs are parallel: the i-th pair is
-// (uids[i], authorityIDs[i]). It returns the number of notifications cleared.
-func (s *PostgresStore) MarkApplicationsRead(ctx context.Context, userID string, uids []string, authorityIDs []int, now time.Time) (int64, error) {
-	rows, err := s.db.Query(ctx, pgMarkApplicationsReadQuery, userID, now, uids, authorityIDs)
+// stays idempotent). refs and authorityIDs are parallel: the i-th pair is
+// (refs[i], authorityIDs[i]). Each ref is a PlanIt case reference (= a.Name),
+// matched against application_name — see pgMarkApplicationsReadQuery for why it is
+// NOT application_uid. It returns the number of notifications cleared.
+func (s *PostgresStore) MarkApplicationsRead(ctx context.Context, userID string, refs []string, authorityIDs []int, now time.Time) (int64, error) {
+	rows, err := s.db.Query(ctx, pgMarkApplicationsReadQuery, userID, now, refs, authorityIDs)
 	if err != nil {
 		return 0, fmt.Errorf("mark applications read for %q: %w", userID, err)
 	}

--- a/api-go/internal/notificationstate/store_postgres_integration_test.go
+++ b/api-go/internal/notificationstate/store_postgres_integration_test.go
@@ -57,13 +57,19 @@ func backfillReadAt(t *testing.T, pool *pgxpool.Pool) {
 	}
 }
 
-// seedUnreadNotif inserts one notification for the user via the notifications
-// store (Create leaves read_at NULL — the unread, pre-backfill state).
-func seedUnreadNotif(t *testing.T, pool *pgxpool.Pool, id, userID, uid string, authorityID int, createdAt time.Time) {
+// seedUnreadNotif inserts one unread notification (Create leaves read_at NULL —
+// the pre-backfill state) for the user via the notifications store. The `name`
+// argument is written to application_name (= a.Name, the PlanIt case reference
+// every client and the push payload carry); application_uid is set to a DISTINCT
+// value (name + "/FUL", = a.UID) so the two columns never coincide. This mirrors
+// real PlanIt data (name "24/0001", uid "24/0001/FUL") and is load-bearing: it
+// makes mark-read fixtures fail loudly if the mutation ever matches
+// application_uid again instead of application_name (#733).
+func seedUnreadNotif(t *testing.T, pool *pgxpool.Pool, id, userID, name string, authorityID int, createdAt time.Time) {
 	t.Helper()
 	nStore := notifications.NewPostgresStore(pool)
 	n := notifications.DigestNotification{
-		ID: id, UserID: userID, ApplicationUID: uid, ApplicationName: uid,
+		ID: id, UserID: userID, ApplicationName: name, ApplicationUID: name + "/FUL",
 		AuthorityID: authorityID, EventType: notifications.EventNewApplication,
 		Sources: "Zone", CreatedAt: createdAt,
 	}
@@ -254,17 +260,60 @@ func TestIntegration_NotificationState_MarkAllRead(t *testing.T) {
 
 // --- MarkApplicationsRead ---
 
+// TestIntegration_NotificationState_MarkApplicationsRead_MatchesNameNotUID is the
+// #733 regression guard. The mutation must scope by application_name (= a.Name, the
+// PlanIt case reference every client and the push payload carry), NOT application_uid.
+// The seeded row's name and uid differ ("24-01234" vs "24-01234/FUL"): marking by the
+// uid must clear nothing, marking by the name must clear the row. Under the old
+// application_uid match this was inverted — a silent prod no-op, because the clients
+// never send the uid.
+func TestIntegration_NotificationState_MarkApplicationsRead_MatchesNameNotUID(t *testing.T) {
+	s, pool := newPGStateStore(t)
+	ctx := context.Background()
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// name "24-01234", uid "24-01234/FUL" (seedUnreadNotif derives the distinct uid).
+	seedUnreadNotif(t, pool, "n1", "user-1", "24-01234", 330, t1)
+
+	// The uid is NOT what the clients send: marking by it must clear nothing.
+	clearedByUID, err := s.MarkApplicationsRead(ctx, "user-1", []string{"24-01234/FUL"}, []int{330}, now)
+	if err != nil {
+		t.Fatalf("MarkApplicationsRead(uid): %v", err)
+	}
+	if clearedByUID != 0 {
+		t.Errorf("marking by uid cleared %d rows, want 0 (match must be on application_name)", clearedByUID)
+	}
+	if got := readAtOf(t, pool, "n1"); got != nil {
+		t.Errorf("row must stay unread after a uid-keyed mark-read, got read_at %v", got)
+	}
+
+	// The name (a.Name) is what iOS/web/push carry: marking by it clears the row.
+	clearedByName, err := s.MarkApplicationsRead(ctx, "user-1", []string{"24-01234"}, []int{330}, now)
+	if err != nil {
+		t.Fatalf("MarkApplicationsRead(name): %v", err)
+	}
+	if clearedByName != 1 {
+		t.Errorf("marking by name cleared %d rows, want 1", clearedByName)
+	}
+	if got := readAtOf(t, pool, "n1"); got == nil {
+		t.Error("row must be read (read_at set) after a name-keyed mark-read")
+	}
+}
+
 // TestIntegration_NotificationState_MarkApplicationsRead_CrossAuthorityGuard proves
-// the composite (application_uid, authority_id) scoping: two authorities sharing a
-// bare ref must not cross-contaminate. Marking {uid, authority 330} read clears only
-// authority 330's row and leaves authority 331's same-uid row unread.
+// the composite (application_name, authority_id) scoping: two authorities sharing a
+// case reference must not cross-contaminate. a.Name is unique within a council but
+// collides across councils, so authority_id disambiguates. Marking {name, authority
+// 330} read clears only authority 330's row and leaves authority 331's same-name row
+// unread.
 func TestIntegration_NotificationState_MarkApplicationsRead_CrossAuthorityGuard(t *testing.T) {
 	s, pool := newPGStateStore(t)
 	ctx := context.Background()
 	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
 	t1 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	// Same user, same bare uid "24-01234", two different authorities — both unread.
+	// Same user, same case reference name "24-01234", two different authorities — both unread.
 	seedUnreadNotif(t, pool, "n-330", "user-1", "24-01234", 330, t1)
 	seedUnreadNotif(t, pool, "n-331", "user-1", "24-01234", 331, t1)
 
@@ -279,7 +328,7 @@ func TestIntegration_NotificationState_MarkApplicationsRead_CrossAuthorityGuard(
 		t.Error("authority 330's row should be read (read_at set)")
 	}
 	if got := readAtOf(t, pool, "n-331"); got != nil {
-		t.Errorf("authority 331's same-uid row must stay unread, got read_at %v", got)
+		t.Errorf("authority 331's same-name row must stay unread, got read_at %v", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

`POST /v1/me/applications/mark-read` (shipped in #736) scoped by `notifications.application_uid`, which holds the app's **UID** (e.g. `24/0001/FUL`). But every caller sends the app's **Name** — the PlanIt case reference (e.g. `24/0001`):

- the push payload sets `applicationRef = n.ApplicationName`,
- iOS sends `id.name` (both list-tap and push-tap),
- web sends `summary.name`.

`Name ≠ UID` (PlanIt fixture: `{"name":"24/0001","uid":"24/0001/FUL"}`), so the match found nothing — **mark-read was a silent no-op in production**. It slipped through Stage 2 because a test fixture used a uid-shaped value for the name.

## Fix

`pgMarkApplicationsReadQuery` now matches `application_name` (not `application_uid`); authority scoping and the conditional version bump are unchanged. The JSON request field stays named `applicationUid` for wire-compat with the already-merged iOS client — but it carries the reference and is matched against `application_name` (heavily commented on the field, the query, and the mark handler; internal Go param renamed `uids`→`refs`).

The display path (`GetLatestUnreadByApplications`, zonepage) still matches `application_uid` — out of scope, and `Name↔UID` is 1:1 within a council so it stays consistent.

## Tests
- `MatchesNameNotUID`: seed name `24-01234` / uid `24-01234/FUL`; marking by the **uid** clears 0 (regression guard), marking by the **name** clears 1.
- `CrossAuthorityGuard` (now name-based): authorities 330 and 331 share name `24-01234`; marking `(24-01234, 330)` clears only 330's row.
- Idempotency + empty-array no-op retained.
- `go test -race ./...` (1222), `go test -tags=integration ./...` (1359), `golangci-lint` all green.

This is a prerequisite for the iOS (#737) and web mark-read to actually clear notifications.

Bead: tc-0sfx.5 · Epic: tc-0sfx · Issue: #733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mark-read actions now correctly match applications by their case reference rather than the internal ID, so the right notifications are cleared.
  * Added stronger handling for council-specific matching, preventing notifications from being marked read in the wrong authority.
  * Updated tests to cover the new matching behavior and confirm unread items are cleared only when the correct reference is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->