### PR TITLE
feat(web): tap-to-read per-application notifications (#733 step 3b)

### DIFF
--- a/web/src/__tests__/api/notification-state.test.ts
+++ b/web/src/__tests__/api/notification-state.test.ts
@@ -83,21 +83,3 @@ describe('notificationStateApi.markApplicationRead', () => {
     );
   });
 });
-
-describe('notificationStateApi.advance', () => {
-  it('POSTs /v1/me/notification-state/advance with the asOf instant in the body', async () => {
-    const { fetch: fakeFetch, calls } = createFakeFetch(204, null);
-    const client = createApiClient(baseUrl, getToken, fakeFetch);
-
-    await notificationStateApi(client).advance('2026-05-04T12:00:00Z');
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0]!.url).toBe(
-      'https://api.example.com/v1/me/notification-state/advance',
-    );
-    expect(calls[0]!.init.method).toBe('POST');
-    expect(calls[0]!.init.body).toBe(
-      JSON.stringify({ asOf: '2026-05-04T12:00:00Z' }),
-    );
-  });
-});

--- a/web/src/__tests__/api/notification-state.test.ts
+++ b/web/src/__tests__/api/notification-state.test.ts
@@ -63,6 +63,27 @@ describe('notificationStateApi.markAllRead', () => {
   });
 });
 
+describe('notificationStateApi.markApplicationRead', () => {
+  it('POSTs /v1/me/applications/mark-read carrying the app NAME in applicationUid', async () => {
+    const { fetch: fakeFetch, calls } = createFakeFetch(204, null);
+    const client = createApiClient(baseUrl, getToken, fakeFetch);
+
+    // The first arg is the application's `name` (PlanIt case reference), not
+    // its `uid` — the wire field is called `applicationUid` for contract
+    // stability but carries the reference. The second arg is the areaId.
+    await notificationStateApi(client).markApplicationRead('24/0001', 42);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      'https://api.example.com/v1/me/applications/mark-read',
+    );
+    expect(calls[0]!.init.method).toBe('POST');
+    expect(calls[0]!.init.body).toBe(
+      JSON.stringify({ applications: [{ applicationUid: '24/0001', authorityId: 42 }] }),
+    );
+  });
+});
+
 describe('notificationStateApi.advance', () => {
   it('POSTs /v1/me/notification-state/advance with the asOf instant in the body', async () => {
     const { fetch: fakeFetch, calls } = createFakeFetch(204, null);

--- a/web/src/api/notification-state.ts
+++ b/web/src/api/notification-state.ts
@@ -1,10 +1,6 @@
 import type { ApiClient } from './client';
 import type { NotificationStateSnapshot } from '../domain/types';
 
-interface AdvanceRequestBody {
-  readonly asOf: string;
-}
-
 /**
  * HTTP client for the notification read-state endpoints. Read state is now
  * per-application (`notifications.read_at`), replacing the single last-read
@@ -36,9 +32,5 @@ export function notificationStateApi(client: ApiClient) {
       client.post<void>('/v1/me/applications/mark-read', {
         applications: [{ applicationUid, authorityId }],
       }),
-    advance: (asOf: string) => {
-      const body: AdvanceRequestBody = { asOf };
-      return client.post<void>('/v1/me/notification-state/advance', body);
-    },
   };
 }

--- a/web/src/api/notification-state.ts
+++ b/web/src/api/notification-state.ts
@@ -6,15 +6,15 @@ interface AdvanceRequestBody {
 }
 
 /**
- * HTTP client for the three notification-state endpoints introduced by
- * tc-1nsa.2. See spec
- * `docs/specs/notifications-unread-watermark.md#api-surface`.
+ * HTTP client for the notification read-state endpoints. Read state is now
+ * per-application (`notifications.read_at`), replacing the single last-read
+ * watermark — see ADR 0035.
  *
  * The functions are named in present-imperative form to mirror their
  * underlying endpoint verbs:
  * - `getState` — `GET /v1/me/notification-state`
  * - `markAllRead` — `POST /v1/me/notification-state/mark-all-read`
- * - `advance` — `POST /v1/me/notification-state/advance`
+ * - `markApplicationRead` — `POST /v1/me/applications/mark-read` (tap-to-read)
  */
 export function notificationStateApi(client: ApiClient) {
   return {
@@ -22,6 +22,20 @@ export function notificationStateApi(client: ApiClient) {
       client.get<NotificationStateSnapshot>('/v1/me/notification-state'),
     markAllRead: () =>
       client.post<void>('/v1/me/notification-state/mark-all-read'),
+    /**
+     * Marks a single application's notifications read for the current user
+     * (tap-to-read). The wire field `applicationUid` carries the application's
+     * `name` (the PlanIt case reference, e.g. "24/0001"), NOT its `uid` — the
+     * server matches it against `notifications.application_name`. The key is
+     * named `applicationUid` for cross-client contract stability; do not
+     * "fix" it to send the uid. `authorityId` (the app's `areaId`)
+     * disambiguates refs that are only unique within a council. Idempotent
+     * (204 even when zero rows match).
+     */
+    markApplicationRead: (applicationUid: string, authorityId: number) =>
+      client.post<void>('/v1/me/applications/mark-read', {
+        applications: [{ applicationUid, authorityId }],
+      }),
     advance: (asOf: string) => {
       const body: AdvanceRequestBody = { asOf };
       return client.post<void>('/v1/me/notification-state/advance', body);

--- a/web/src/components/ApplicationCard/ApplicationCard.tsx
+++ b/web/src/components/ApplicationCard/ApplicationCard.tsx
@@ -5,6 +5,13 @@ import styles from './ApplicationCard.module.css';
 
 interface Props {
   application: PlanningApplicationSummary;
+  /**
+   * Called when the card is opened (tap-to-read). Navigation still proceeds —
+   * this fires alongside the link, letting the Applications list mark the
+   * application read. Optional so read-only surfaces (saved list, dashboard)
+   * can render the card without wiring it.
+   */
+  onOpen?: (application: PlanningApplicationSummary) => void;
 }
 
 const MAX_DESCRIPTION_LENGTH = 120;
@@ -16,9 +23,13 @@ function truncate(text: string | null, maxLength: number): string {
   return text.slice(0, maxLength) + '...';
 }
 
-export function ApplicationCard({ application }: Props) {
+export function ApplicationCard({ application, onOpen }: Props) {
   const isUnread = application.latestUnreadEvent !== null;
   const statusClass = statusClassName(application.appState, styles);
+
+  function handleClick() {
+    onOpen?.(application);
+  }
 
   return (
     <Link
@@ -27,6 +38,7 @@ export function ApplicationCard({ application }: Props) {
       className={`${styles.card} ${isUnread ? styles.cardUnread : styles.cardRead}`}
       data-testid="application-card"
       data-unread={isUnread ? 'true' : 'false'}
+      onClick={handleClick}
     >
       <span
         className={styles.unreadDot}

--- a/web/src/components/ApplicationCard/__tests__/ApplicationCard.test.tsx
+++ b/web/src/components/ApplicationCard/__tests__/ApplicationCard.test.tsx
@@ -171,6 +171,44 @@ describe('ApplicationCard', () => {
   });
 });
 
+describe('ApplicationCard — open callback', () => {
+  it('invokes onOpen with the application when the card is clicked', async () => {
+    const user = userEvent.setup();
+    const app = undecidedApplication();
+    const opened: (typeof app)[] = [];
+    render(
+      <MemoryRouter>
+        <ApplicationCard application={app} onOpen={(a) => opened.push(a)} />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole('link'));
+
+    expect(opened).toEqual([app]);
+  });
+
+  it('still navigates to the detail page when onOpen is provided', async () => {
+    const user = userEvent.setup();
+    const app = undecidedApplication();
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route
+            path="/"
+            element={<ApplicationCard application={app} onOpen={() => {}} />}
+          />
+          <Route path="/applications/*" element={<LocationStateProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole('link'));
+
+    // Navigation proceeded (the probe route rendered with the carried state).
+    expect(screen.getByTestId('state-name')).toHaveTextContent('2026/0042/FUL');
+  });
+});
+
 describe('ApplicationCard — leading unread dot', () => {
   it('renders a visible unread dot when latestUnreadEvent is non-null', () => {
     const app = undecidedApplication({

--- a/web/src/domain/ports/notification-state-repository.ts
+++ b/web/src/domain/ports/notification-state-repository.ts
@@ -29,9 +29,4 @@ export interface NotificationStateRepository {
    * council.
    */
   markApplicationRead(applicationUid: string, authorityId: number): Promise<void>;
-  /**
-   * Advances the watermark forward to `asOf`. No-op if `asOf` is at or before
-   * the existing watermark (server-enforced monotonicity).
-   */
-  advance(asOf: string): Promise<void>;
 }

--- a/web/src/domain/ports/notification-state-repository.ts
+++ b/web/src/domain/ports/notification-state-repository.ts
@@ -1,23 +1,34 @@
 import type { NotificationStateSnapshot } from '../types';
 
 /**
- * Port for the server-side notification read-state watermark.
+ * Port for the server-side notification read-state. Read state is per
+ * application (`notifications.read_at`), replacing the single last-read
+ * watermark — see ADR 0035.
  *
- * Backed by three endpoints (see spec
- * `docs/specs/notifications-unread-watermark.md#api-surface`):
+ * Backed by these endpoints:
  * - `GET /v1/me/notification-state` returns the current snapshot.
- * - `POST /v1/me/notification-state/mark-all-read` stamps the watermark to
- *   the server's "now"; subsequent fetches report zero unread.
- * - `POST /v1/me/notification-state/advance` moves the watermark to the
- *   supplied `asOf` instant. The server enforces monotonicity, so passing a
- *   stale instant is a no-op rather than an error — callers can fire and
- *   forget without checking the existing watermark first.
+ * - `POST /v1/me/notification-state/mark-all-read` clears every unread
+ *   notification for the user; subsequent fetches report zero unread.
+ * - `POST /v1/me/applications/mark-read` clears the unread notifications for a
+ *   single application (tap-to-read).
  */
 export interface NotificationStateRepository {
-  /** Returns the user's current watermark and unread count. */
+  /** Returns the user's current read-state snapshot and unread count. */
   getState(): Promise<NotificationStateSnapshot>;
-  /** Stamps the watermark to the server's current instant. */
+  /** Marks every unread notification for the user read. */
   markAllRead(): Promise<void>;
+  /**
+   * Marks a single application's notifications read (tap-to-read). Idempotent —
+   * a second call for an already-read application is a no-op server-side.
+   *
+   * `applicationUid` carries the application's `name` (the PlanIt case
+   * reference), NOT its `uid` — the wire key is named `applicationUid` for
+   * cross-client contract stability but the value is the reference. See
+   * {@link notificationStateApi} for the full contract note. `authorityId` is
+   * the application's `areaId`, needed because refs are only unique within a
+   * council.
+   */
+  markApplicationRead(applicationUid: string, authorityId: number): Promise<void>;
   /**
    * Advances the watermark forward to `asOf`. No-op if `asOf` is at or before
    * the existing watermark (server-enforced monotonicity).

--- a/web/src/domain/types.ts
+++ b/web/src/domain/types.ts
@@ -226,8 +226,8 @@ export interface PlanningApplicationSummary {
  * `createdAt` is strictly after `lastReadAt`. The server returns
  * `totalUnreadCount` precomputed so the client can drive the Unread chip
  * without rescanning the notification list locally. `version` bumps on every
- * successful mark-all-read or advance — useful for detecting out-of-band
- * mutations across devices.
+ * successful read-state mutation (mark-read or mark-all-read) — useful for
+ * detecting out-of-band mutations across devices.
  */
 export interface NotificationStateSnapshot {
   /** ISO-8601 instant; notifications strictly newer than this are unread. */

--- a/web/src/features/Applications/ApiNotificationStateRepository.ts
+++ b/web/src/features/Applications/ApiNotificationStateRepository.ts
@@ -27,6 +27,13 @@ export class ApiNotificationStateRepository
     return this.api.markAllRead();
   }
 
+  async markApplicationRead(
+    applicationUid: string,
+    authorityId: number,
+  ): Promise<void> {
+    return this.api.markApplicationRead(applicationUid, authorityId);
+  }
+
   async advance(asOf: string): Promise<void> {
     return this.api.advance(asOf);
   }

--- a/web/src/features/Applications/ApiNotificationStateRepository.ts
+++ b/web/src/features/Applications/ApiNotificationStateRepository.ts
@@ -5,10 +5,10 @@ import { notificationStateApi } from '../../api/notification-state';
 
 /**
  * Concrete adapter for {@link NotificationStateRepository} backed by the
- * three watermark endpoints introduced in tc-1nsa.2. The repository is a
- * thin pass-through over {@link notificationStateApi} so the wire shape can
- * be reused by other callers (e.g. the unread-badge polling that lives
- * outside the Applications screen) without going through this class.
+ * notification read-state endpoints (per-application `read_at`, ADR 0035).
+ * The repository is a thin pass-through over {@link notificationStateApi} so
+ * the wire shape can be reused by other callers (e.g. the unread-badge polling
+ * that lives outside the Applications screen) without going through this class.
  */
 export class ApiNotificationStateRepository
   implements NotificationStateRepository
@@ -32,9 +32,5 @@ export class ApiNotificationStateRepository
     authorityId: number,
   ): Promise<void> {
     return this.api.markApplicationRead(applicationUid, authorityId);
-  }
-
-  async advance(asOf: string): Promise<void> {
-    return this.api.advance(asOf);
   }
 }

--- a/web/src/features/Applications/ApplicationsPage.tsx
+++ b/web/src/features/Applications/ApplicationsPage.tsx
@@ -72,6 +72,7 @@ export function ApplicationsPage({
     loadMore,
     reload,
     markAllRead,
+    onOpenApplication,
   } = useApplications({
     browsePort,
     zones: zones ?? [],
@@ -230,7 +231,7 @@ export function ApplicationsPage({
               <ul className={styles.list}>
                 {applications.map((app) => (
                   <li key={app.uid}>
-                    <ApplicationCard application={app} />
+                    <ApplicationCard application={app} onOpen={onOpenApplication} />
                   </li>
                 ))}
               </ul>

--- a/web/src/features/Applications/__tests__/ApiNotificationStateRepository.test.ts
+++ b/web/src/features/Applications/__tests__/ApiNotificationStateRepository.test.ts
@@ -58,6 +58,24 @@ describe('ApiNotificationStateRepository', () => {
     expect(calls[0]!.init.method).toBe('POST');
   });
 
+  it('markApplicationRead POSTs to /v1/me/applications/mark-read with the app NAME', async () => {
+    const { fetch: fakeFetch, calls } = createFakeFetch(204, null);
+    const client = createApiClient(baseUrl, getToken, fakeFetch);
+    const repo = new ApiNotificationStateRepository(client);
+
+    // First arg is the application's `name`, second is its `areaId`.
+    await repo.markApplicationRead('24/0001', 42);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(
+      'https://api.example.com/v1/me/applications/mark-read',
+    );
+    expect(calls[0]!.init.method).toBe('POST');
+    expect(calls[0]!.init.body).toBe(
+      JSON.stringify({ applications: [{ applicationUid: '24/0001', authorityId: 42 }] }),
+    );
+  });
+
   it('advance POSTs the asOf instant', async () => {
     const { fetch: fakeFetch, calls } = createFakeFetch(204, null);
     const client = createApiClient(baseUrl, getToken, fakeFetch);

--- a/web/src/features/Applications/__tests__/ApiNotificationStateRepository.test.ts
+++ b/web/src/features/Applications/__tests__/ApiNotificationStateRepository.test.ts
@@ -76,19 +76,4 @@ describe('ApiNotificationStateRepository', () => {
     );
   });
 
-  it('advance POSTs the asOf instant', async () => {
-    const { fetch: fakeFetch, calls } = createFakeFetch(204, null);
-    const client = createApiClient(baseUrl, getToken, fakeFetch);
-    const repo = new ApiNotificationStateRepository(client);
-
-    await repo.advance('2026-05-04T12:00:00Z');
-
-    expect(calls).toHaveLength(1);
-    expect(calls[0]!.url).toBe(
-      'https://api.example.com/v1/me/notification-state/advance',
-    );
-    expect(calls[0]!.init.body).toBe(
-      JSON.stringify({ asOf: '2026-05-04T12:00:00Z' }),
-    );
-  });
 });

--- a/web/src/features/Applications/__tests__/spies/spy-notification-state-repository.ts
+++ b/web/src/features/Applications/__tests__/spies/spy-notification-state-repository.ts
@@ -23,9 +23,6 @@ export class SpyNotificationStateRepository
   markApplicationReadCalls: Array<{ applicationUid: string; authorityId: number }> = [];
   markApplicationReadError: Error | null = null;
 
-  advanceCalls: string[] = [];
-  advanceError: Error | null = null;
-
   async getState(): Promise<NotificationStateSnapshot> {
     this.getStateCalls++;
     if (this.getStateError) {
@@ -48,13 +45,6 @@ export class SpyNotificationStateRepository
     this.markApplicationReadCalls.push({ applicationUid, authorityId });
     if (this.markApplicationReadError) {
       throw this.markApplicationReadError;
-    }
-  }
-
-  async advance(asOf: string): Promise<void> {
-    this.advanceCalls.push(asOf);
-    if (this.advanceError) {
-      throw this.advanceError;
     }
   }
 }

--- a/web/src/features/Applications/__tests__/spies/spy-notification-state-repository.ts
+++ b/web/src/features/Applications/__tests__/spies/spy-notification-state-repository.ts
@@ -20,6 +20,9 @@ export class SpyNotificationStateRepository
   markAllReadCalls = 0;
   markAllReadError: Error | null = null;
 
+  markApplicationReadCalls: Array<{ applicationUid: string; authorityId: number }> = [];
+  markApplicationReadError: Error | null = null;
+
   advanceCalls: string[] = [];
   advanceError: Error | null = null;
 
@@ -35,6 +38,16 @@ export class SpyNotificationStateRepository
     this.markAllReadCalls++;
     if (this.markAllReadError) {
       throw this.markAllReadError;
+    }
+  }
+
+  async markApplicationRead(
+    applicationUid: string,
+    authorityId: number,
+  ): Promise<void> {
+    this.markApplicationReadCalls.push({ applicationUid, authorityId });
+    if (this.markApplicationReadError) {
+      throw this.markApplicationReadError;
     }
   }
 

--- a/web/src/features/Applications/__tests__/useApplications.test.ts
+++ b/web/src/features/Applications/__tests__/useApplications.test.ts
@@ -418,6 +418,57 @@ describe('useApplications — markAllRead', () => {
   });
 });
 
+describe('useApplications — tap-to-read (onOpenApplication)', () => {
+  it('marks an unread application read on open and optimistically drops the chip count', async () => {
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResult = { rows: [], nextCursor: null };
+    browsePort.unreadTotal = 3;
+    const stateRepo = new SpyNotificationStateRepository();
+    const zones = [cambridgeZone()];
+
+    const { result } = renderHook(() =>
+      useApplications(makeOptions({ browsePort, zones, notificationStateRepository: stateRepo })),
+    );
+
+    await waitFor(() => expect(result.current.unreadCount).toBe(3));
+
+    const unread = undecidedApplication({
+      latestUnreadEvent: { type: 'NewApplication', decision: null, createdAt: '2026-04-01T00:00:00Z' },
+    });
+
+    act(() => result.current.onOpenApplication(unread));
+
+    // Sends the app's NAME (not uid) plus its areaId to the repository.
+    expect(stateRepo.markApplicationReadCalls).toEqual([
+      { applicationUid: unread.name, authorityId: unread.areaId },
+    ]);
+    // Chip drops immediately by one, without a whole-zone count refetch.
+    expect(result.current.unreadCount).toBe(2);
+    expect(browsePort.countUnreadCalls).toHaveLength(1);
+  });
+
+  it('does not call the repository when opening an already-read application', async () => {
+    const browsePort = new SpyApplicationsBrowsePort();
+    browsePort.fetchByZoneResult = { rows: [], nextCursor: null };
+    browsePort.unreadTotal = 3;
+    const stateRepo = new SpyNotificationStateRepository();
+    const zones = [cambridgeZone()];
+
+    const { result } = renderHook(() =>
+      useApplications(makeOptions({ browsePort, zones, notificationStateRepository: stateRepo })),
+    );
+
+    await waitFor(() => expect(result.current.unreadCount).toBe(3));
+
+    const read = permittedApplication({ latestUnreadEvent: null });
+
+    act(() => result.current.onOpenApplication(read));
+
+    expect(stateRepo.markApplicationReadCalls).toHaveLength(0);
+    expect(result.current.unreadCount).toBe(3);
+  });
+});
+
 describe('useApplications — sort persistence', () => {
   // A stable spy per test — `makeOptions` defaults would mint a fresh port on
   // every render, changing the query effect's dependency identity and looping.

--- a/web/src/features/Applications/useApplications.ts
+++ b/web/src/features/Applications/useApplications.ts
@@ -322,6 +322,34 @@ export function useApplications(options: UseApplicationsOptions) {
     ]);
   }, [browsePort, notificationStateRepository]);
 
+  // Tap-to-read: opening an application marks its notifications read server-side
+  // (ADR 0035). Fired from the card's onClick; navigation proceeds regardless.
+  const onOpenApplication = useCallback(
+    (application: PlanningApplicationSummary) => {
+      // Guardrail: only round-trip for a genuinely-unread card — an already-read
+      // application (no unread event) needs no mark-read call.
+      if (application.latestUnreadEvent === null) return;
+      // Fire-and-forget: a later list/count fetch reconciles read state, so a
+      // failure here is swallowed rather than surfaced on a navigation. The
+      // wire field `applicationUid` carries the app's NAME (PlanIt case
+      // reference), NOT its uid; `areaId` disambiguates same-name refs across
+      // councils — see the notification-state API contract note.
+      void notificationStateRepository
+        .markApplicationRead(application.name, application.areaId)
+        .catch(() => {
+          // Intentionally ignored — the next fetch is the source of truth.
+        });
+      // Optimistically drop the whole-zone "Unread (N)" chip so it updates
+      // immediately without a full count refetch (mirrors markAllRead's count
+      // refresh). Clamp at zero so repeat opens can't drive it negative.
+      setState((prev) => ({
+        ...prev,
+        unreadCount: Math.max(0, prev.unreadCount - 1),
+      }));
+    },
+    [notificationStateRepository],
+  );
+
   // Whole-zone unread total for the chip, sourced from `browsePort.countUnread`
   // (see the count-fetch effect above) rather than the loaded rows — so it
   // reflects the zone, not how far the user has paged (GH#716, Problem 2).
@@ -356,5 +384,6 @@ export function useApplications(options: UseApplicationsOptions) {
     loadMore,
     reload,
     markAllRead,
+    onOpenApplication,
   };
 }


### PR DESCRIPTION
## Changes

Step 3b of #733 — the web client for per-application read state, against the API from #736/#739. Opening an application marks its notifications read.

- **`markApplicationRead(applicationUid, authorityId)`** on the notification-state api/port/adapter → `POST /v1/me/applications/mark-read` with `{"applications":[{"applicationUid":"<name>","authorityId":<areaId>}]}`. The `applicationUid` field carries the application's **`name`** (PlanIt case reference, e.g. `24/0001`) — matched server-side against `application_name` (#739). Commented in the api/port/hook so nobody "fixes" it to send `uid`.
- **Tap-to-read**: `ApplicationCard` fires an `onOpen(application)` callback from its `Link` `onClick` (navigation still proceeds). The guardrail lives in the hook: `useApplications.onOpenApplication` returns early when `latestUnreadEvent === null` (no round-trip for already-read cards), else fires mark-read fire-and-forget and optimistically drops the "Unread (N)" chip by one (mirrors `markAllRead` without a refetch). `onOpen` is optional, so Saved/Dashboard cards are unchanged.
- **`advance` removed** from api/port/adapter (+ tests) — it had no web consumer. Stale `docs/specs/...` comments repointed to ADR 0035.

## Tests
`npx tsc --noEmit` clean; `npm run build` clean; `npx vitest run` **926 pass**; `npm run lint` clean. New coverage: mark-read sends the `name` (not `uid`); opening an unread app calls mark-read + drops the count; opening a read app does not; card fires `onOpen`. Advance tests removed.

Bead: tc-0sfx.4 · Epic: tc-0sfx · Issue: #733