### PR TITLE
fix(notifications): re-add /advance as a temporary read_at compat shim (tc-ekii)

### DIFF
--- a/api-go/internal/notificationstate/handler.go
+++ b/api-go/internal/notificationstate/handler.go
@@ -25,6 +25,9 @@ type stateStore interface {
 	UnreadCount(ctx context.Context, userID string) (int, error)
 	MarkAllRead(ctx context.Context, userID string, now time.Time) (int64, error)
 	MarkApplicationsRead(ctx context.Context, userID string, refs []string, authorityIDs []int, now time.Time) (int64, error)
+	// MarkReadUpTo backs the TEMPORARY advance compat shim (tc-ekii); see the
+	// advance handler. REMOVE per tc-v5w8 once the new iOS build is live.
+	MarkReadUpTo(ctx context.Context, userID string, asOf, now time.Time) (int64, error)
 }
 
 // stateResult is the GET /v1/me/notification-state response body:
@@ -61,6 +64,17 @@ type markReadRequest struct {
 	Applications []applicationRef `json:"applications"`
 }
 
+// advanceRequest is the POST /v1/me/notification-state/advance request body.
+//
+// TEMPORARY BACKWARD-COMPAT SHIM (tc-ekii). This is the exact byte-identical shape
+// the old (pre-ADR-0035) server parsed, so fire-and-forget requests from App Store
+// iOS builds that predate the per-application read-state change still bind. New
+// iOS/web clients do NOT send this — they call POST /v1/me/applications/mark-read.
+// REMOVE per bead tc-v5w8 once the new iOS build is live.
+type advanceRequest struct {
+	AsOf platform.DotNetTime `json:"asOf"`
+}
+
 // Routes registers the notification read-state endpoints on mux. All are
 // authenticated: the auth middleware guarantees a subject in context.
 func Routes(mux *http.ServeMux, store stateStore, now func() time.Time, logger *slog.Logger) {
@@ -68,6 +82,16 @@ func Routes(mux *http.ServeMux, store stateStore, now func() time.Time, logger *
 	mux.HandleFunc("GET /v1/me/notification-state", h.get)
 	mux.HandleFunc("POST /v1/me/notification-state/mark-all-read", h.markAllRead)
 	mux.HandleFunc("POST /v1/me/applications/mark-read", h.markRead)
+	// TEMPORARY BACKWARD-COMPAT SHIM (tc-ekii). ADR 0035 (#733) removed advance in
+	// favour of per-application read_at, so new iOS/web clients do NOT call it (they
+	// use POST /v1/me/applications/mark-read above). This route is re-added only so
+	// the App Store iOS builds that predate the change (live + one in Apple review)
+	// keep clearing their push badge on tap during the review window — against the new
+	// server those old fire-and-forget calls would 404 and silently stop clearing the
+	// badge. It translates the retired watermark advance to a read_at mark (see the
+	// advance handler). REMOVE per bead tc-v5w8 once the new iOS build is live; advance
+	// 404-ing again is the #733/ADR-0035 end-state.
+	mux.HandleFunc("POST /v1/me/notification-state/advance", h.advance)
 }
 
 type handler struct {
@@ -157,6 +181,41 @@ func (h handler) markRead(w http.ResponseWriter, r *http.Request) {
 
 	if _, err := h.store.MarkApplicationsRead(r.Context(), userID, refs, authorityIDs, h.now()); err != nil {
 		h.logger.ErrorContext(r.Context(), "mark applications read", "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// advance is a TEMPORARY backward-compat shim (tc-ekii) for the retired
+// scroll-to-clear watermark endpoint. ADR 0035 (#733) removed advance in favour of
+// per-application read_at, so new iOS/web clients do NOT call it (they use
+// POST /v1/me/applications/mark-read). This handler is re-added only so the App Store
+// iOS builds that predate the change (live + one in Apple review) keep clearing their
+// push badge on tap during the review window — those old builds fire advance on
+// push-tap and a 404 would silently stop the badge clearing.
+//
+// It parses the old {asOf} body byte-identically (advanceRequest) and translates the
+// watermark advance-to-asOf into a read_at mark: every unread notification created at
+// or before asOf is marked read (MarkReadUpTo). It is idempotent (a repeat is a 204
+// that clears nothing) and returns a bodyless 400 on a malformed body. The retired
+// watermark / State.AdvanceTo / first-touch seeding logic is deliberately NOT restored.
+//
+// REMOVE per bead tc-v5w8 once the new iOS build is live; advance 404-ing again is the
+// #733/ADR-0035 end-state.
+func (h handler) advance(w http.ResponseWriter, r *http.Request) {
+	userID := auth.Subject(r.Context())
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+	var req advanceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	asOf := time.Time(req.AsOf)
+	if _, err := h.store.MarkReadUpTo(r.Context(), userID, asOf, h.now()); err != nil {
+		h.logger.ErrorContext(r.Context(), "advance (mark read up to)", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/api-go/internal/notificationstate/handler_test.go
+++ b/api-go/internal/notificationstate/handler_test.go
@@ -22,11 +22,16 @@ type fakeStateStore struct {
 	cntErr      error
 	markAllErr  error
 	markReadErr error
+	markUpToErr error
 
 	markAllCalls  int
 	markReadCalls int
 	markReadRefs  []string
 	markReadAuths []int
+
+	markUpToCalls int
+	markUpToAsOf  time.Time
+	markUpToNow   time.Time
 }
 
 func newFakeStateStore() *fakeStateStore {
@@ -67,6 +72,18 @@ func (f *fakeStateStore) MarkApplicationsRead(_ context.Context, _ string, refs 
 		return 0, f.markReadErr
 	}
 	return int64(len(refs)), nil
+}
+
+// MarkReadUpTo backs the temporary advance compat shim (tc-ekii): it records the
+// parsed asOf and now so the handler test can assert the translation.
+func (f *fakeStateStore) MarkReadUpTo(_ context.Context, _ string, asOf, now time.Time) (int64, error) {
+	f.markUpToCalls++
+	f.markUpToAsOf = asOf
+	f.markUpToNow = now
+	if f.markUpToErr != nil {
+		return 0, f.markUpToErr
+	}
+	return 0, nil
 }
 
 func testMux(t *testing.T, store stateStore, now time.Time) *http.ServeMux {
@@ -275,6 +292,76 @@ func TestHandler_MarkRead(t *testing.T) {
 
 		body := `{"applications":[{"applicationUid":"24-01234","authorityId":330}]}`
 		rec := doReq(t, testMux(t, store, time.Now()), http.MethodPost, path, body)
+		if rec.Code != http.StatusInternalServerError {
+			t.Fatalf("status = %d, want 500", rec.Code)
+		}
+	})
+}
+
+// TestHandler_Advance covers the TEMPORARY backward-compat shim (tc-ekii): the
+// re-added POST /v1/me/notification-state/advance translates the old
+// {asOf}-watermark request to a read_at MarkReadUpTo(asOf, now) call and returns
+// an idempotent 204. New iOS/web clients do not call this route (they use
+// /v1/me/applications/mark-read); remove per tc-v5w8 once the new iOS build is live.
+func TestHandler_Advance(t *testing.T) {
+	t.Parallel()
+
+	const path = "/v1/me/notification-state/advance"
+
+	t.Run("parses asOf and marks read up to it, returns 204", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+		now := time.Date(2026, 6, 15, 8, 0, 0, 0, time.UTC)
+		asOf := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+		rec := doReq(t, testMux(t, store, now), http.MethodPost, path, `{"asOf":"2026-06-01T12:00:00Z"}`)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("status = %d, want 204", rec.Code)
+		}
+		if store.markUpToCalls != 1 {
+			t.Fatalf("MarkReadUpTo calls = %d, want 1", store.markUpToCalls)
+		}
+		if !store.markUpToAsOf.Equal(asOf) {
+			t.Errorf("asOf passed = %v, want %v", store.markUpToAsOf, asOf)
+		}
+		if !store.markUpToNow.Equal(now) {
+			t.Errorf("now passed = %v, want %v", store.markUpToNow, now)
+		}
+	})
+
+	t.Run("idempotent second call is still 204", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+		mux := testMux(t, store, time.Now())
+		body := `{"asOf":"2026-06-01T12:00:00Z"}`
+
+		if rec := doReq(t, mux, http.MethodPost, path, body); rec.Code != http.StatusNoContent {
+			t.Fatalf("first call status = %d, want 204", rec.Code)
+		}
+		if rec := doReq(t, mux, http.MethodPost, path, body); rec.Code != http.StatusNoContent {
+			t.Fatalf("second call status = %d, want 204", rec.Code)
+		}
+	})
+
+	t.Run("malformed body is a bodyless 400", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+
+		rec := doReq(t, testMux(t, store, time.Now()), http.MethodPost, path, `{"asOf":`)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400", rec.Code)
+		}
+		if store.markUpToCalls != 0 {
+			t.Errorf("malformed body must not touch the store: calls=%d", store.markUpToCalls)
+		}
+	})
+
+	t.Run("store error is 500", func(t *testing.T) {
+		t.Parallel()
+		store := newFakeStateStore()
+		store.markUpToErr = errors.New("db down")
+
+		rec := doReq(t, testMux(t, store, time.Now()), http.MethodPost, path, `{"asOf":"2026-06-01T12:00:00Z"}`)
 		if rec.Code != http.StatusInternalServerError {
 			t.Fatalf("status = %d, want 500", rec.Code)
 		}

--- a/api-go/internal/notificationstate/store_postgres.go
+++ b/api-go/internal/notificationstate/store_postgres.go
@@ -28,6 +28,10 @@ type Store interface {
 	UnreadCount(ctx context.Context, userID string) (int, error)
 	MarkAllRead(ctx context.Context, userID string, now time.Time) (int64, error)
 	MarkApplicationsRead(ctx context.Context, userID string, refs []string, authorityIDs []int, now time.Time) (int64, error)
+	// MarkReadUpTo is a TEMPORARY backward-compat shim for the retired
+	// scroll-to-clear watermark (see the method doc and pgMarkReadUpToQuery).
+	// REMOVE per bead tc-v5w8 once the per-app read-state iOS build is live.
+	MarkReadUpTo(ctx context.Context, userID string, asOf, now time.Time) (int64, error)
 	DeleteByUserID(ctx context.Context, userID string) error
 }
 
@@ -222,6 +226,63 @@ func (s *PostgresStore) MarkApplicationsRead(ctx context.Context, userID string,
 	counts, err := pgx.CollectRows(rows, pgx.RowTo[int64])
 	if err != nil {
 		return 0, fmt.Errorf("scan mark applications read count for %q: %w", userID, err)
+	}
+	if len(counts) == 0 {
+		return 0, nil
+	}
+	return counts[0], nil
+}
+
+// pgMarkReadUpToQuery is the read_at-model translation of the retired
+// scroll-to-clear watermark advance. It clears every unread notification created
+// at or before asOf (the read_at equivalent of moving a watermark to asOf) and
+// bumps the version change token only when it actually cleared a row (upserting
+// the state row when absent) — the same atomic CTE style as
+// pgMarkApplicationsReadQuery. Both tables mutate in one data-modifying
+// statement; the top-level SELECT returns the cleared count.
+//
+// TEMPORARY BACKWARD-COMPAT SHIM (tc-ekii). ADR 0035 (#733) removed the watermark
+// advance in favour of per-application read_at, so new iOS/web clients do NOT call
+// advance (they use POST /v1/me/applications/mark-read). This query exists only to
+// keep the App Store iOS builds that predate that change (still live + one in Apple
+// review) clearing their push badge on tap during the review window. REMOVE per bead
+// tc-v5w8 once the new iOS build is live; advance 404-ing again is the #733/ADR-0035
+// end-state.
+//
+// $1 userID, $2 asOf, $3 now.
+const pgMarkReadUpToQuery = `
+WITH cleared AS (
+    UPDATE notifications
+    SET read_at = $3
+    WHERE user_id = $1 AND created_at <= $2 AND read_at IS NULL
+    RETURNING 1
+), bumped AS (
+    INSERT INTO notification_state (user_id, last_read_at, version)
+    SELECT $1, $3, 1 WHERE EXISTS (SELECT 1 FROM cleared)
+    ON CONFLICT (user_id) DO UPDATE SET version = notification_state.version + 1
+    RETURNING 1
+)
+SELECT count(*) FROM cleared`
+
+// MarkReadUpTo clears every unread notification for the user created at or before
+// asOf and bumps the version change token when it cleared at least one row
+// (leaving the token untouched on a zero-row no-op, so a repeat advance is
+// idempotent). It returns the number of notifications cleared. This is the
+// read_at-model equivalent of the retired watermark advance-to-asOf.
+//
+// TEMPORARY BACKWARD-COMPAT SHIM (tc-ekii) — see pgMarkReadUpToQuery. Called only
+// by the re-added POST /v1/me/notification-state/advance route, which exists purely
+// to keep pre-per-app-read-state iOS clients (App Store live + Apple review) clearing
+// their badge on push-tap. New iOS/web clients use MarkApplicationsRead instead.
+// REMOVE per bead tc-v5w8 once the new iOS build is live.
+func (s *PostgresStore) MarkReadUpTo(ctx context.Context, userID string, asOf, now time.Time) (int64, error) {
+	rows, err := s.db.Query(ctx, pgMarkReadUpToQuery, userID, asOf, now)
+	if err != nil {
+		return 0, fmt.Errorf("mark read up to for %q: %w", userID, err)
+	}
+	counts, err := pgx.CollectRows(rows, pgx.RowTo[int64])
+	if err != nil {
+		return 0, fmt.Errorf("scan mark read up to count for %q: %w", userID, err)
 	}
 	if len(counts) == 0 {
 		return 0, nil

--- a/api-go/internal/notificationstate/store_postgres_integration_test.go
+++ b/api-go/internal/notificationstate/store_postgres_integration_test.go
@@ -405,6 +405,82 @@ func readAtOf(t *testing.T, pool *pgxpool.Pool, id string) *time.Time {
 	return readAt
 }
 
+// --- MarkReadUpTo (temporary advance compat shim, tc-ekii) ---
+
+// TestIntegration_NotificationState_MarkReadUpTo proves the read_at translation of
+// the retired watermark advance: notifications created at or before asOf are marked
+// read (read_at NOT NULL), a later notification stays unread, a repeat clears zero
+// (idempotent), the version token bumps only when a row was cleared, and a first-touch
+// user gets a state row created on the first clear. This is real-DB behaviour (the
+// created_at <= asOf predicate and the conditional CTE bump) the fake querier cannot
+// model. Remove with the shim per bead tc-v5w8.
+func TestIntegration_NotificationState_MarkReadUpTo(t *testing.T) {
+	s, pool := newPGStateStore(t)
+	ctx := context.Background()
+
+	tm2 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // <= asOf
+	tm1 := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC) // <= asOf
+	asOf := time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)
+	tp1 := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC) // > asOf
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	// All three start unread (Create leaves read_at NULL — the first-touch user has
+	// no notification_state row yet).
+	seedUnreadNotif(t, pool, "n1", "user-1", "24-01111", 330, tm2)
+	seedUnreadNotif(t, pool, "n2", "user-1", "24-02222", 330, tm1)
+	seedUnreadNotif(t, pool, "n3", "user-1", "24-03333", 330, tp1)
+	if got := unreadCountFor(t, pool, "user-1"); got != 3 {
+		t.Fatalf("seeded unread: got %d, want 3", got)
+	}
+
+	// Advance to asOf: the two at-or-before rows clear, the later one stays unread.
+	cleared, err := s.MarkReadUpTo(ctx, "user-1", asOf, now)
+	if err != nil {
+		t.Fatalf("MarkReadUpTo: %v", err)
+	}
+	if cleared != 2 {
+		t.Errorf("cleared: got %d, want 2 (rows created_at <= asOf)", cleared)
+	}
+	if got := readAtOf(t, pool, "n1"); got == nil {
+		t.Error("n1 (created_at < asOf) must be read")
+	}
+	if got := readAtOf(t, pool, "n2"); got == nil {
+		t.Error("n2 (created_at < asOf) must be read")
+	}
+	if got := readAtOf(t, pool, "n3"); got != nil {
+		t.Errorf("n3 (created_at > asOf) must stay unread, got read_at %v", got)
+	}
+
+	// First-touch user: the clear upserts a state row at version 1.
+	st, err := s.Get(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("Get after advance: %v", err)
+	}
+	if st == nil || st.Version != 1 {
+		t.Fatalf("state after first advance: got %+v, want version 1", st)
+	}
+
+	// A second advance to the same asOf clears nothing (idempotent) and does not
+	// bump the version token again.
+	second, err := s.MarkReadUpTo(ctx, "user-1", asOf, now)
+	if err != nil {
+		t.Fatalf("second MarkReadUpTo: %v", err)
+	}
+	if second != 0 {
+		t.Errorf("second advance cleared: got %d, want 0 (idempotent)", second)
+	}
+	st, err = s.Get(ctx, "user-1")
+	if err != nil {
+		t.Fatalf("Get after second advance: %v", err)
+	}
+	if st == nil || st.Version != 1 {
+		t.Errorf("version after zero-clear advance: got %+v, want unchanged 1", st)
+	}
+	if got := unreadCountFor(t, pool, "user-1"); got != 1 {
+		t.Errorf("unread after advance: got %d, want 1 (only the post-asOf row)", got)
+	}
+}
+
 // --- DeleteByUserID ---
 
 func TestIntegration_NotificationState_DeleteByUserID(t *testing.T) {

--- a/api-go/internal/notificationstate/store_postgres_test.go
+++ b/api-go/internal/notificationstate/store_postgres_test.go
@@ -299,6 +299,34 @@ func TestPostgresNSStore_MarkApplicationsRead_PropagatesQueryError(t *testing.T)
 	}
 }
 
+// --- MarkReadUpTo (temporary advance compat shim, tc-ekii) ---
+
+func TestPostgresNSStore_MarkReadUpTo_ReturnsClearedCount(t *testing.T) {
+	t.Parallel()
+	q := &fakeNSQuerier{queryResponses: []queryResp{{rows: newNSRows([][]any{{int64(2)}})}}}
+	s := NewPostgresStore(q)
+
+	cleared, err := s.MarkReadUpTo(context.Background(), "user-1", time.Now(), time.Now())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleared != 2 {
+		t.Errorf("cleared: got %d, want 2", cleared)
+	}
+}
+
+func TestPostgresNSStore_MarkReadUpTo_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("mark-up-to boom")
+	q := &fakeNSQuerier{queryResponses: []queryResp{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	_, err := s.MarkReadUpTo(context.Background(), "user-1", time.Now(), time.Now())
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
 // --- DeleteByUserID ---
 
 func TestPostgresNSStore_DeleteByUserID_Success(t *testing.T) {

--- a/docs/adr/0035-per-application-notification-read-state.md
+++ b/docs/adr/0035-per-application-notification-read-state.md
@@ -97,7 +97,10 @@ Track read state per application on the `notifications` table via a nullable
   per-row badges there lag until a mark-read/mark-all creates the row — a known follow-up,
   out of scope for this change.
 - Clients (iOS, web) must add `markApplicationRead` and delete `advance`; these ship as
-  separate PRs. Until they do, the `advance` route returns 404.
+  separate PRs. During the App Store review window for the new iOS build, `advance` is
+  temporarily retained as a read_at-backed compat shim (it marks every unread notification
+  created at or before `asOf` read) so pre-per-app-read-state iOS clients still clear their
+  push badge on tap; it is removed (returning to 404) once that build is live (bead tc-v5w8).
 - `notification_state`/`version` can be dropped in a later cleanup once `version` is
   confirmed unused; GDPR erasure is unchanged (`read_at` is a column on `notifications`
   rows already removed by erasure).


### PR DESCRIPTION
## Why

#736 removed `POST /v1/me/notification-state/advance` (now 404) as part of the per-application read-state change (#733, ADR 0035). But the iOS builds currently on the App Store — the live one and one stuck in Apple review — predate that change and call `advance` on push-notification tap to clear the badge. We're releasing the API to prod **before** the new iOS build is approved, so without this shim those old apps' push-tap would silently stop clearing the badge.

## What

Re-adds the `advance` route with **byte-identical request parsing** (`{"asOf": <DotNetTime>}`), but translates it to the new model instead of the retired watermark:

```sql
UPDATE notifications SET read_at = now()
WHERE user_id = $1 AND created_at <= asOf AND read_at IS NULL
```

Atomic CTE (mirrors `mark-read`): conditional version bump only when a row was cleared, upserts the state row when absent, idempotent `204`, `400` on malformed body. New iOS/web clients do **not** call `advance` (they use `POST /v1/me/applications/mark-read`); this serves only the old binaries during the review window.

Prominent "TEMPORARY — remove per **tc-v5w8**" comments on the route, handler, DTO, query and store method, plus a one-line note in ADR 0035 so the ADR matches the running code. `advance` 404-ing again is the intended end-state.

## Tests
Handler unit (204, idempotent, 400 on bad body, 500 on store error) + integration (`MarkReadUpTo` clears `created_at <= asOf`, leaves newer NULL, idempotent, conditional version bump, first-touch row creation). `go test -race` (1229), `go test -tags=integration` (51), `golangci-lint` all green.

Bead: tc-ekii · Removal follow-up: tc-v5w8 · Issue: #733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added temporary support for the older notification “advance” action, which marks notifications read up to a chosen time.
  * Improved notification state handling so read status can be updated in a more precise, time-based way.

* **Bug Fixes**
  * Made the “advance” action safe to repeat without changing the result.
  * Added validation for malformed requests and proper error responses when updates fail.

* **Documentation**
  * Updated release guidance to reflect the temporary compatibility behavior for older iOS clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->