### PR TITLE
feat(api): anonymous shareable planning-application page — Slice 1 (#738)

### DIFF
--- a/api-go/cmd/api/anonymous_patterns_test.go
+++ b/api-go/cmd/api/anonymous_patterns_test.go
@@ -1,0 +1,21 @@
+package main
+
+import "testing"
+
+// TestAnonymousPatterns_IncludesBySlugApplicationRead pins the anonymity of the
+// public by-slug application read (#738). The middleware keys on the exact
+// registered pattern string, so this must match the route wired in applications
+// byte-for-byte. The sibling by-id read stays authed (absent from the map).
+func TestAnonymousPatterns_IncludesBySlugApplicationRead(t *testing.T) {
+	t.Parallel()
+
+	const bySlug = "GET /v1/applications/by-slug/{authoritySlug}/{ref...}"
+	if _, ok := anonymousPatterns[bySlug]; !ok {
+		t.Errorf("anonymousPatterns must include %q", bySlug)
+	}
+
+	const byID = "GET /v1/applications/{authorityCode}/{name...}"
+	if _, ok := anonymousPatterns[byID]; ok {
+		t.Errorf("the by-id read must stay authed; %q must NOT be anonymous", byID)
+	}
+}

--- a/api-go/cmd/api/anonymous_patterns_test.go
+++ b/api-go/cmd/api/anonymous_patterns_test.go
@@ -19,3 +19,16 @@ func TestAnonymousPatterns_IncludesBySlugApplicationRead(t *testing.T) {
 		t.Errorf("the by-id read must stay authed; %q must NOT be anonymous", byID)
 	}
 }
+
+// TestAnonymousPatterns_IncludesSharePage pins the anonymity of the public
+// server-rendered share page (#738). The auth middleware keys on the exact
+// registered pattern string, so this must match the route wired in sharepage
+// byte-for-byte.
+func TestAnonymousPatterns_IncludesSharePage(t *testing.T) {
+	t.Parallel()
+
+	const sharePage = "GET /a/{authoritySlug}/{ref...}"
+	if _, ok := anonymousPatterns[sharePage]; !ok {
+		t.Errorf("anonymousPatterns must include %q", sharePage)
+	}
+}

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -24,6 +24,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 	"github.com/AmyDe/town-crier/api-go/internal/savedapplications"
+	"github.com/AmyDe/town-crier/api-go/internal/sharepage"
 	"github.com/AmyDe/town-crier/api-go/internal/subscriptions"
 	"github.com/AmyDe/town-crier/api-go/internal/versionconfig"
 	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
@@ -64,6 +65,10 @@ var anonymousPatterns = map[string]struct{}{
 	// and iOS inbound deep-link resolution (#738). The sibling by-id read stays
 	// authed (absent from this map).
 	"GET /v1/applications/by-slug/{authoritySlug}/{ref...}": {},
+	// The public share page is anonymous (public planning data only; no user data,
+	// no cookies, no client-IP logging): a server-rendered HTML page for a single
+	// application, the tracer surface of the shareable-page epic (#738).
+	"GET /a/{authoritySlug}/{ref...}": {},
 }
 
 // dispatchMux satisfies auth.RequireAuth's routeMatcher: pattern matching comes
@@ -195,6 +200,11 @@ func newRouter(
 		// 401 fallback.
 		applications.RecentRoutes(mux, appStore, siteBuildKey, logger)
 		applications.NearRoutes(mux, appStore, siteBuildKey, logger)
+		// The public share page (#738): an anonymous, server-rendered HTML page for a
+		// single application at GET /a/{authoritySlug}/{ref...}. It point-reads the
+		// same applications store and resolves the authority slug via the static
+		// authority lookup; it reads no user data and emits only public planning data.
+		sharepage.Routes(mux, appStore, authorities.NewLookup(), logger)
 	}
 	if store != nil && watchZoneStore != nil && appStore != nil && notifStore != nil {
 		// Watch-zone create (returns nearby applications) + the per-zone

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -58,6 +58,12 @@ var anonymousPatterns = map[string]struct{}{
 	// authority pages; the second feeds town pages (bounded geo query).
 	"GET /v1/authorities/{id}/applications": {},
 	"GET /v1/applications/near":             {},
+	// The by-slug application read is anonymous (public planning data only, no
+	// user/subscriber data, no refresh-on-tap): it resolves an authority slug to
+	// its area id and point-reads the application, feeding the public share page
+	// and iOS inbound deep-link resolution (#738). The sibling by-id read stays
+	// authed (absent from this map).
+	"GET /v1/applications/by-slug/{authoritySlug}/{ref...}": {},
 }
 
 // dispatchMux satisfies auth.RequireAuth's routeMatcher: pattern matching comes
@@ -177,9 +183,9 @@ func newRouter(
 		// (not a typed-nil pointer) when saving isn't wired, so the handler's
 		// nil-check disables the side effect cleanly.
 		if savedStore != nil {
-			applications.Routes(mux, appStore, savedapplications.NewSnapshotRefresher(savedStore, time.Now), logger)
+			applications.Routes(mux, appStore, savedapplications.NewSnapshotRefresher(savedStore, time.Now), authorities.NewLookup(), logger)
 		} else {
-			applications.Routes(mux, appStore, nil, logger)
+			applications.Routes(mux, appStore, nil, authorities.NewLookup(), logger)
 		}
 		// The build-time SEO endpoints (anonymous to Auth0, gated by the dedicated
 		// X-Build-Key) read recent applications from the same store: RecentRoutes by

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -134,6 +134,23 @@ func (fakeAppStore) BreakdownNearby(context.Context, string, float64, float64, f
 	return nil, nil
 }
 
+// foundAppStore is a fakeAppStore that returns one populated application for the
+// Croydon area id (301) — the real id, so authorities.NewLookup().SlugForAreaID(301)
+// round-trips to "croydon". Every other read stays the empty (not-found) path. It
+// gives the anonymous share-page and by-slug routes a real record to render and
+// serialise in the end-to-end wiring test.
+type foundAppStore struct {
+	fakeAppStore
+	app applications.PlanningApplication
+}
+
+func (f foundAppStore) GetByAuthorityAndName(_ context.Context, authorityCode, _ string) (applications.PlanningApplication, bool, error) {
+	if authorityCode == "301" {
+		return f.app, true, nil
+	}
+	return applications.PlanningApplication{}, false, nil
+}
+
 // fakeSavedStore is a savedapplications.Store returning the empty path.
 type fakeSavedStore struct{}
 
@@ -261,6 +278,68 @@ func TestRouter_AnonymousRoutesServedWithoutToken(t *testing.T) {
 				t.Errorf("status = %d, want %d", rec.Code, tc.wantStatus)
 			}
 		})
+	}
+}
+
+// TestRouter_SharePageAndBySlugAnonymous_ByIdStaysAuthed is the end-to-end wiring
+// guard for the share surface (#738 Slice 1). It boots the FULL router with a
+// store that returns a real Croydon application, then proves:
+//
+//   - GET /a/{slug}/{ref}                       -> 200 text/html, no token
+//   - GET /v1/applications/by-slug/{slug}/{ref} -> 200 application/json, no token
+//   - GET /v1/applications/{authorityCode}/{ref} -> 401, no token (stays authed)
+//
+// The two new routes serve anonymously only if their anonymousPatterns strings
+// match the registered mux patterns byte-for-byte; a drift in either pattern string
+// would silently 401 the public page. The by-id contrast (denyAllValidator, no
+// token) proves the by-id read did NOT accidentally become anonymous.
+func TestRouter_SharePageAndBySlugAnonymous_ByIdStaysAuthed(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	app := applications.PlanningApplication{
+		Name:     "23/03456/FUL",
+		UID:      "croydon-23-03456-FUL",
+		AreaName: "Croydon",
+		AreaID:   301, // the real Croydon id, so SlugForAreaID(301) == "croydon"
+		Address:  "10 Downing Street, London",
+	}
+	appStore := foundAppStore{app: app}
+	// denyAllValidator rejects every token, so the by-id route can only pass if it
+	// were (wrongly) anonymous.
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, logger)
+
+	// (1) Public HTML share page: anonymous, 200 text/html.
+	page := serveReq(t, h, http.MethodGet, "/a/croydon/23/03456/FUL", "", "")
+	if page.Code != http.StatusOK {
+		t.Fatalf("GET /a/croydon/... status = %d, want 200 (anonymous); body = %s", page.Code, page.Body.String())
+	}
+	if ct := page.Header().Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+		t.Errorf("share page Content-Type = %q, want text/html", ct)
+	}
+	if !strings.Contains(page.Body.String(), "10 Downing Street, London") {
+		t.Errorf("share page did not render the application address; body = %s", page.Body.String())
+	}
+
+	// (2) By-slug JSON read: anonymous, 200 application/json, carries authoritySlug.
+	bySlug := serveReq(t, h, http.MethodGet, "/v1/applications/by-slug/croydon/23/03456/FUL", "", "")
+	if bySlug.Code != http.StatusOK {
+		t.Fatalf("GET /v1/applications/by-slug/... status = %d, want 200 (anonymous); body = %s", bySlug.Code, bySlug.Body.String())
+	}
+	if ct := bySlug.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("by-slug Content-Type = %q, want application/json", ct)
+	}
+	if !strings.Contains(bySlug.Body.String(), `"authoritySlug":"croydon"`) {
+		t.Errorf("by-slug body missing authoritySlug croydon; body = %s", bySlug.Body.String())
+	}
+
+	// (3) By-id read stays authed: same application, NO token -> 401 + Bearer.
+	byID := serveReq(t, h, http.MethodGet, "/v1/applications/301/23/03456/FUL", "", "")
+	if byID.Code != http.StatusUnauthorized {
+		t.Fatalf("GET /v1/applications/301/... status = %d, want 401 (authed, no token); body = %s", byID.Code, byID.Body.String())
+	}
+	if got := byID.Header().Get("WWW-Authenticate"); got != "Bearer" {
+		t.Errorf("by-id WWW-Authenticate = %q, want Bearer", got)
 	}
 }
 

--- a/api-go/internal/applications/handler.go
+++ b/api-go/internal/applications/handler.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
+	"github.com/AmyDe/town-crier/api-go/internal/authorities"
 )
 
 // appStore is the consumer-side store the application read handler uses.
@@ -22,25 +24,38 @@ type snapshotRefresher interface {
 	RefreshSnapshot(ctx context.Context, userID string, app PlanningApplication) error
 }
 
-// handler serves GET /v1/applications/{authorityCode}/{name}.
+// authoritySlugResolver resolves between an authority slug and its area id (which
+// equals the authority id / stringified authority_code). It is the narrow
+// consumer-side view of *authorities.Lookup, which satisfies it structurally.
+type authoritySlugResolver interface {
+	SlugToAreaID(slug string) (int, bool)
+	SlugForAreaID(id int) (string, bool)
+}
+
+// handler serves the single-application read endpoints.
 type handler struct {
 	store     appStore
 	refresher snapshotRefresher
+	resolver  authoritySlugResolver
 	logger    *slog.Logger
 }
 
-// Routes registers the application read endpoint. The {name...} wildcard matches
-// the remainder of the path so a PlanIt case reference containing slashes (e.g.
-// "24/0123/FUL") is captured whole. The refresher is optional (nil disables
-// refresh-on-tap).
-func Routes(mux *http.ServeMux, store appStore, refresher snapshotRefresher, logger *slog.Logger) {
-	h := &handler{store: store, refresher: refresher, logger: logger}
+// Routes registers the application read endpoints. The {name...}/{ref...}
+// wildcards match the remainder of the path so a PlanIt case reference containing
+// slashes (e.g. "24/0123/FUL") is captured whole. The refresher is optional (nil
+// disables refresh-on-tap); resolver is required (it computes authoritySlug and
+// resolves the by-slug route). The literal "by-slug" segment makes that pattern
+// strictly more specific than {authorityCode}, so Go 1.22's ServeMux accepts both
+// without a conflict panic.
+func Routes(mux *http.ServeMux, store appStore, refresher snapshotRefresher, resolver authoritySlugResolver, logger *slog.Logger) {
+	h := &handler{store: store, refresher: refresher, resolver: resolver, logger: logger}
 	mux.HandleFunc("GET /v1/applications/{authorityCode}/{name...}", h.getByAuthorityAndName)
+	mux.HandleFunc("GET /v1/applications/by-slug/{authoritySlug}/{ref...}", h.getBySlug)
 }
 
 // getByAuthorityAndName point-reads an application by (authorityCode, name) and
-// returns it, or a bodyless 404 when it is not in Cosmos — there is no PlanIt
-// fallback (GH#395 Invariant 1).
+// returns it, or a bodyless 404 when it is not in the store — there is no PlanIt
+// fallback (GH#395 Invariant 1). This route is authed.
 func (h *handler) getByAuthorityAndName(w http.ResponseWriter, r *http.Request) {
 	authorityCode := r.PathValue("authorityCode")
 	name := r.PathValue("name")
@@ -66,5 +81,48 @@ func (h *handler) getByAuthorityAndName(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	writeJSON(w, r, h.logger, ResultOf(app))
+	result := ResultOf(app)
+	result.AuthoritySlug = h.authoritySlug(app)
+	writeJSON(w, r, h.logger, result)
+}
+
+// getBySlug point-reads an application by (authoritySlug, ref) and returns exactly
+// the same body as the authed by-id read (including authoritySlug). It is
+// ANONYMOUS and public: no auth/user data is read and refresh-on-tap never runs.
+// An unknown slug or unknown ref returns a bodyless 404 (the envelope is
+// backfilled by middleware.ErrorBody, same as the by-id not-found path).
+func (h *handler) getBySlug(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("authoritySlug")
+	ref := r.PathValue("ref")
+
+	areaID, ok := h.resolver.SlugToAreaID(slug)
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	app, found, err := h.store.GetByAuthorityAndName(r.Context(), strconv.Itoa(areaID), ref)
+	if err != nil {
+		serverError(w, r, h.logger, "read application by slug", err)
+		return
+	}
+	if !found {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	result := ResultOf(app)
+	result.AuthoritySlug = h.authoritySlug(app)
+	writeJSON(w, r, h.logger, result)
+}
+
+// authoritySlug returns the URL slug for the application's authority,
+// round-trip-safe against SlugToAreaID: it prefers the resolver's SlugForAreaID
+// (so the emitted slug is exactly what SlugToAreaID resolves back), and only when
+// the id is unknown falls back to slugifying the PlanIt area name.
+func (h *handler) authoritySlug(app PlanningApplication) string {
+	if slug, ok := h.resolver.SlugForAreaID(app.AreaID); ok {
+		return slug
+	}
+	return authorities.Slugify(app.AreaName)
 }

--- a/api-go/internal/applications/handler.go
+++ b/api-go/internal/applications/handler.go
@@ -82,7 +82,7 @@ func (h *handler) getByAuthorityAndName(w http.ResponseWriter, r *http.Request) 
 	}
 
 	result := ResultOf(app)
-	result.AuthoritySlug = h.authoritySlug(app)
+	result.AuthoritySlug = h.authoritySlug(r.Context(), app)
 	writeJSON(w, r, h.logger, result)
 }
 
@@ -112,17 +112,21 @@ func (h *handler) getBySlug(w http.ResponseWriter, r *http.Request) {
 	}
 
 	result := ResultOf(app)
-	result.AuthoritySlug = h.authoritySlug(app)
+	result.AuthoritySlug = h.authoritySlug(r.Context(), app)
 	writeJSON(w, r, h.logger, result)
 }
 
 // authoritySlug returns the URL slug for the application's authority,
 // round-trip-safe against SlugToAreaID: it prefers the resolver's SlugForAreaID
 // (so the emitted slug is exactly what SlugToAreaID resolves back), and only when
-// the id is unknown falls back to slugifying the PlanIt area name.
-func (h *handler) authoritySlug(app PlanningApplication) string {
+// the id is unknown falls back to slugifying the PlanIt area name. The fallback is
+// warn-logged because it means PlanIt returned an area id absent from the static
+// authorities data — the emitted slug then may not round-trip back through
+// SlugToAreaID, so a share/by-slug link built from it could 404.
+func (h *handler) authoritySlug(ctx context.Context, app PlanningApplication) string {
 	if slug, ok := h.resolver.SlugForAreaID(app.AreaID); ok {
 		return slug
 	}
+	h.logger.WarnContext(ctx, "authority slug fallback: area id not in static authorities", "op", "authority slug", "areaId", app.AreaID, "areaName", app.AreaName, "uid", app.UID)
 	return authorities.Slugify(app.AreaName)
 }

--- a/api-go/internal/applications/handler_test.go
+++ b/api-go/internal/applications/handler_test.go
@@ -41,17 +41,41 @@ func (f *fakeRefresher) RefreshSnapshot(_ context.Context, userID string, app Pl
 	return f.err
 }
 
+// fakeResolver is a hand-written authoritySlugResolver. testResolver maps the
+// City of London test application's AreaID (471) both ways.
+type fakeResolver struct {
+	slugToID map[string]int
+	idToSlug map[int]string
+}
+
+func (f *fakeResolver) SlugToAreaID(slug string) (int, bool) {
+	id, ok := f.slugToID[slug]
+	return id, ok
+}
+
+func (f *fakeResolver) SlugForAreaID(id int) (string, bool) {
+	s, ok := f.idToSlug[id]
+	return s, ok
+}
+
+func testResolver() *fakeResolver {
+	return &fakeResolver{
+		slugToID: map[string]int{"city-of-london": 471},
+		idToSlug: map[int]string{471: "city-of-london"},
+	}
+}
+
 // serveGet drives the read endpoint with a refresher absent (the nil-safe path)
 // and an authenticated subject.
 func serveGet(t *testing.T, store appStore, path string) *httptest.ResponseRecorder {
 	t.Helper()
-	return serveGetWith(t, store, nil, "auth0|u", path)
+	return serveGetWith(t, store, nil, testResolver(), "auth0|u", path)
 }
 
-func serveGetWith(t *testing.T, store appStore, refresher snapshotRefresher, subject, path string) *httptest.ResponseRecorder {
+func serveGetWith(t *testing.T, store appStore, refresher snapshotRefresher, resolver authoritySlugResolver, subject, path string) *httptest.ResponseRecorder {
 	t.Helper()
 	mux := http.NewServeMux()
-	Routes(mux, store, refresher, slog.New(slog.DiscardHandler))
+	Routes(mux, store, refresher, resolver, slog.New(slog.DiscardHandler))
 	ctx := context.Background()
 	if subject != "" {
 		ctx = auth.WithSubject(ctx, subject)
@@ -93,6 +117,11 @@ func TestHandler_GetByAuthorityAndName_Found(t *testing.T) {
 	if v, ok := got["latestUnreadEvent"]; !ok || v != nil {
 		t.Errorf("latestUnreadEvent must be present and null: %v (present=%v)", v, ok)
 	}
+	// The by-id detail response now carries the additive authoritySlug, computed
+	// round-trip-safe from the resolver (AreaID 471 -> "city-of-london").
+	if got["authoritySlug"] != "city-of-london" {
+		t.Errorf("authoritySlug: got %v, want city-of-london", got["authoritySlug"])
+	}
 }
 
 func TestHandler_GetByAuthorityAndName_NotFound(t *testing.T) {
@@ -118,7 +147,7 @@ func TestHandler_GetByAuthorityAndName_RefreshesOnTap(t *testing.T) {
 	t.Parallel()
 	a := testApplication(t)
 	refresher := &fakeRefresher{}
-	rec := serveGetWith(t, &fakeAppStore{app: a, found: true}, refresher, "auth0|u", "/v1/applications/471/24/0123/FUL")
+	rec := serveGetWith(t, &fakeAppStore{app: a, found: true}, refresher, testResolver(), "auth0|u", "/v1/applications/471/24/0123/FUL")
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200", rec.Code)
@@ -135,7 +164,7 @@ func TestHandler_GetByAuthorityAndName_RefreshFailureDoesNotFailRead(t *testing.
 	t.Parallel()
 	a := testApplication(t)
 	refresher := &fakeRefresher{err: context.DeadlineExceeded}
-	rec := serveGetWith(t, &fakeAppStore{app: a, found: true}, refresher, "auth0|u", "/v1/applications/471/24/0123/FUL")
+	rec := serveGetWith(t, &fakeAppStore{app: a, found: true}, refresher, testResolver(), "auth0|u", "/v1/applications/471/24/0123/FUL")
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("refresh error must not fail the read: got %d, want 200", rec.Code)
@@ -148,7 +177,7 @@ func TestHandler_GetByAuthorityAndName_RefreshFailureDoesNotFailRead(t *testing.
 func TestHandler_GetByAuthorityAndName_NoRefreshWhenNotFound(t *testing.T) {
 	t.Parallel()
 	refresher := &fakeRefresher{}
-	rec := serveGetWith(t, &fakeAppStore{found: false}, refresher, "auth0|u", "/v1/applications/471/missing")
+	rec := serveGetWith(t, &fakeAppStore{found: false}, refresher, testResolver(), "auth0|u", "/v1/applications/471/missing")
 
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("status: got %d, want 404", rec.Code)
@@ -162,12 +191,153 @@ func TestHandler_GetByAuthorityAndName_NoRefreshWhenAnonymous(t *testing.T) {
 	t.Parallel()
 	a := testApplication(t)
 	refresher := &fakeRefresher{}
-	rec := serveGetWith(t, &fakeAppStore{app: a, found: true}, refresher, "", "/v1/applications/471/24/0123/FUL")
+	rec := serveGetWith(t, &fakeAppStore{app: a, found: true}, refresher, testResolver(), "", "/v1/applications/471/24/0123/FUL")
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200", rec.Code)
 	}
 	if len(refresher.calls) != 0 {
 		t.Errorf("must not refresh without an authenticated subject: %+v", refresher.calls)
+	}
+}
+
+// TestHandler_GetByAuthorityAndName_AuthoritySlugFallsBackToSlugifyAreaName pins
+// the fallback branch: when the resolver doesn't know the AreaID, authoritySlug is
+// authorities.Slugify(AreaName). "City of London" -> "city-of-london".
+func TestHandler_GetByAuthorityAndName_AuthoritySlugFallsBackToSlugifyAreaName(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	resolver := &fakeResolver{slugToID: map[string]int{}, idToSlug: map[int]string{}}
+
+	rec := serveGetWith(t, &fakeAppStore{app: a, found: true}, nil, resolver, "auth0|u", "/v1/applications/471/24/0123/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["authoritySlug"] != "city-of-london" {
+		t.Errorf("authoritySlug fallback: got %v, want city-of-london", got["authoritySlug"])
+	}
+}
+
+// ── GET /v1/applications/by-slug/{authoritySlug}/{ref...} (anonymous) ──────────
+
+func TestHandler_GetBySlug_Found(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	store := &fakeAppStore{app: a, found: true}
+
+	// Anonymous (no subject): resolve slug -> area id 471 -> stringified authority
+	// code, then point-read the app with the slash-bearing ref captured whole.
+	rec := serveGetWith(t, store, nil, testResolver(), "", "/v1/applications/by-slug/city-of-london/24/0123/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if store.lastAuthorityCode != "471" || store.lastName != "24/0123/FUL" {
+		t.Errorf("routing: authorityCode=%q name=%q", store.lastAuthorityCode, store.lastName)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["uid"] != a.UID {
+		t.Errorf("uid: got %v", got["uid"])
+	}
+	if got["authoritySlug"] != "city-of-london" {
+		t.Errorf("authoritySlug: got %v, want city-of-london", got["authoritySlug"])
+	}
+}
+
+// TestHandler_GetBySlug_SameBodyAsById proves the by-slug read returns byte-for-byte
+// the same body as the authed by-id read (both carry the additive authoritySlug).
+func TestHandler_GetBySlug_SameBodyAsById(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+
+	byID := serveGetWith(t, &fakeAppStore{app: a, found: true}, nil, testResolver(), "", "/v1/applications/471/24/0123/FUL")
+	bySlug := serveGetWith(t, &fakeAppStore{app: a, found: true}, nil, testResolver(), "", "/v1/applications/by-slug/city-of-london/24/0123/FUL")
+
+	if byID.Code != http.StatusOK || bySlug.Code != http.StatusOK {
+		t.Fatalf("codes: byId=%d bySlug=%d", byID.Code, bySlug.Code)
+	}
+	if byID.Body.String() != bySlug.Body.String() {
+		t.Errorf("bodies differ:\n by-id:   %s\n by-slug: %s", byID.Body.String(), bySlug.Body.String())
+	}
+}
+
+func TestHandler_GetBySlug_UnknownSlug(t *testing.T) {
+	t.Parallel()
+	store := &fakeAppStore{app: testApplication(t), found: true}
+	rec := serveGetWith(t, store, nil, testResolver(), "", "/v1/applications/by-slug/no-such-place/24/0123/FUL")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("404 must be bodyless, got %s", rec.Body)
+	}
+	// An unknown slug short-circuits before the store read.
+	if store.lastAuthorityCode != "" {
+		t.Errorf("store must not be queried on unknown slug, got %q", store.lastAuthorityCode)
+	}
+}
+
+func TestHandler_GetBySlug_UnknownRef(t *testing.T) {
+	t.Parallel()
+	rec := serveGetWith(t, &fakeAppStore{found: false}, nil, testResolver(), "", "/v1/applications/by-slug/city-of-london/missing")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("404 must be bodyless, got %s", rec.Body)
+	}
+}
+
+// TestHandler_GetBySlug_DoesNotRefreshOnTap pins the anonymity of the by-slug
+// route: even with an authenticated subject on the context and a refresher wired,
+// it must never trigger refresh-on-tap (it reads no user data).
+func TestHandler_GetBySlug_DoesNotRefreshOnTap(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	refresher := &fakeRefresher{}
+
+	rec := serveGetWith(t, &fakeAppStore{app: a, found: true}, refresher, testResolver(), "auth0|u", "/v1/applications/by-slug/city-of-london/24/0123/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if len(refresher.calls) != 0 {
+		t.Errorf("by-slug must not refresh-on-tap: %+v", refresher.calls)
+	}
+}
+
+// TestHandler_Routes_BySlugAndByIdCoexist proves Go 1.22's ServeMux accepts both
+// patterns without a conflict panic (the literal "by-slug" segment is more
+// specific than {authorityCode}) and routes each to its own handler.
+func TestHandler_Routes_BySlugAndByIdCoexist(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+
+	byIDStore := &fakeAppStore{app: a, found: true}
+	recByID := serveGetWith(t, byIDStore, nil, testResolver(), "", "/v1/applications/999/x/y/z")
+	if recByID.Code != http.StatusOK {
+		t.Fatalf("by-id status: got %d, want 200", recByID.Code)
+	}
+	if byIDStore.lastAuthorityCode != "999" || byIDStore.lastName != "x/y/z" {
+		t.Errorf("by-id routed wrong: code=%q name=%q", byIDStore.lastAuthorityCode, byIDStore.lastName)
+	}
+
+	bySlugStore := &fakeAppStore{app: a, found: true}
+	recBySlug := serveGetWith(t, bySlugStore, nil, testResolver(), "", "/v1/applications/by-slug/city-of-london/x/y/z")
+	if recBySlug.Code != http.StatusOK {
+		t.Fatalf("by-slug status: got %d, want 200", recBySlug.Code)
+	}
+	if bySlugStore.lastAuthorityCode != "471" || bySlugStore.lastName != "x/y/z" {
+		t.Errorf("by-slug routed wrong: code=%q name=%q", bySlugStore.lastAuthorityCode, bySlugStore.lastName)
 	}
 }

--- a/api-go/internal/applications/handler_test.go
+++ b/api-go/internal/applications/handler_test.go
@@ -6,10 +6,47 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 )
+
+// capturingHandler is a hand-written slog.Handler that records emitted records so
+// a test can assert a specific log line (and its attributes) was produced.
+type capturingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *capturingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *capturingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *capturingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *capturingHandler) WithGroup(string) slog.Handler      { return h }
+
+// find returns the attributes of the first record matching level and message.
+func (h *capturingHandler) find(level slog.Level, msg string) (map[string]any, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.records {
+		if r.Level == level && r.Message == msg {
+			attrs := map[string]any{}
+			r.Attrs(func(a slog.Attr) bool {
+				attrs[a.Key] = a.Value.Any()
+				return true
+			})
+			return attrs, true
+		}
+	}
+	return nil, false
+}
 
 type fakeAppStore struct {
 	app   PlanningApplication
@@ -220,6 +257,66 @@ func TestHandler_GetByAuthorityAndName_AuthoritySlugFallsBackToSlugifyAreaName(t
 	}
 	if got["authoritySlug"] != "city-of-london" {
 		t.Errorf("authoritySlug fallback: got %v, want city-of-london", got["authoritySlug"])
+	}
+}
+
+// TestHandler_GetByAuthorityAndName_AuthoritySlugFallback_WarnLogged guards the
+// observability of the fallback branch: when PlanIt returns an area id absent from
+// the static authorities data, the emitted slug may not round-trip through
+// SlugToAreaID (so a share/by-slug link built from it could 404). That must not be
+// silent — the branch warns, carrying the area id, area name and uid needed to
+// diagnose the missing authority. Regression guard against the branch going quiet.
+func TestHandler_GetByAuthorityAndName_AuthoritySlugFallback_WarnLogged(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t) // AreaName "City of London", AreaID 471, UID "ABC-24-0123"
+	resolver := &fakeResolver{slugToID: map[string]int{}, idToSlug: map[int]string{}}
+	capture := &capturingHandler{}
+
+	mux := http.NewServeMux()
+	Routes(mux, &fakeAppStore{app: a, found: true}, nil, resolver, slog.New(capture))
+	ctx := auth.WithSubject(context.Background(), "auth0|u")
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/v1/applications/471/24/0123/FUL", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	attrs, ok := capture.find(slog.LevelWarn, "authority slug fallback: area id not in static authorities")
+	if !ok {
+		t.Fatal("expected a warn log for the authority-slug fallback, got none")
+	}
+	if attrs["areaId"] != int64(471) {
+		t.Errorf("areaId attr: got %v (%T), want int64 471", attrs["areaId"], attrs["areaId"])
+	}
+	if attrs["areaName"] != "City of London" {
+		t.Errorf("areaName attr: got %v, want City of London", attrs["areaName"])
+	}
+	if attrs["uid"] != "ABC-24-0123" {
+		t.Errorf("uid attr: got %v, want ABC-24-0123", attrs["uid"])
+	}
+}
+
+// TestHandler_GetByAuthorityAndName_ResolvedSlug_NoWarn is the negative control:
+// when the resolver knows the area id the fallback branch is NOT taken, so no warn
+// is emitted — the warn is specific to the genuinely-missing-authority case.
+func TestHandler_GetByAuthorityAndName_ResolvedSlug_NoWarn(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	capture := &capturingHandler{}
+
+	mux := http.NewServeMux()
+	Routes(mux, &fakeAppStore{app: a, found: true}, nil, testResolver(), slog.New(capture))
+	ctx := auth.WithSubject(context.Background(), "auth0|u")
+	req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/v1/applications/471/24/0123/FUL", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if _, ok := capture.find(slog.LevelWarn, "authority slug fallback: area id not in static authorities"); ok {
+		t.Error("resolver knew the area id; fallback warn must not fire")
 	}
 }
 

--- a/api-go/internal/applications/result.go
+++ b/api-go/internal/applications/result.go
@@ -31,9 +31,17 @@ type Result struct {
 	Link              *string             `json:"link"`
 	LastDifferent     platform.DotNetTime `json:"lastDifferent"`
 	LatestUnreadEvent json.RawMessage     `json:"latestUnreadEvent"`
+	// AuthoritySlug is the URL slug of the application's authority, emitted by the
+	// single-application detail (by-id) and by-slug handlers so clients can build
+	// share URLs (#738). It is DELIBERATELY omitempty and NOT set by ResultOf: the
+	// savedapplications and watchzones responses that embed Result via ResultOf
+	// leave it "" and so stay byte-identical on the wire.
+	AuthoritySlug string `json:"authoritySlug,omitempty"`
 }
 
-// ResultOf maps a domain snapshot to its wire shape.
+// ResultOf maps a domain snapshot to its wire shape. It deliberately leaves
+// AuthoritySlug empty (see the field comment); only the detail and by-slug
+// handlers set it.
 func ResultOf(a PlanningApplication) Result {
 	return Result{
 		Name:          a.Name,

--- a/api-go/internal/authorities/lookup.go
+++ b/api-go/internal/authorities/lookup.go
@@ -23,6 +23,20 @@ func (l *Lookup) All() []Authority {
 	return l.store.all()
 }
 
+// SlugToAreaID resolves an authority slug (as produced by Slugify over the
+// authority Name) to its area id — the authority ID — reporting whether the slug
+// is known. On a slug collision the first authority by list order wins (see
+// newStaticStore). Returns (0, false) for an unknown slug.
+func (l *Lookup) SlugToAreaID(slug string) (int, bool) {
+	return l.store.slugToAreaID(slug)
+}
+
+// SlugForAreaID returns Slugify(Name) for the authority with the given id,
+// reporting whether the id is known. Returns ("", false) for an unknown id.
+func (l *Lookup) SlugForAreaID(id int) (string, bool) {
+	return l.store.slugForAreaID(id)
+}
+
 // CompareOrdinalIgnoreCase exposes the package's ordinal, case-insensitive name
 // comparator so callers building authority lists order them identically to the
 // /v1/authorities list ordering.

--- a/api-go/internal/authorities/slug.go
+++ b/api-go/internal/authorities/slug.go
@@ -1,0 +1,52 @@
+package authorities
+
+import "strings"
+
+// apostropheStripper removes the ASCII apostrophe (') and the Unicode right
+// single quotation mark (U+2019) so possessive names slug cleanly:
+// "King's Lynn" -> "kings-lynn", not "king-s-lynn". This must run BEFORE the
+// non-alphanumeric collapse in Slugify, otherwise the apostrophe would itself
+// become a hyphen.
+var apostropheStripper = strings.NewReplacer("'", "", "’", "")
+
+// Slugify converts an authority name into a lowercase-hyphenated URL slug. It is
+// a byte-equal port of web/scripts/lib/slug.mjs slugify(), guarded against drift
+// by a shared test-vector fixture (see TestSlugify_MatchesSharedFixture). The
+// steps run in this exact order:
+//
+//  1. lowercase;
+//  2. expand every "&" to " and " (space, a, n, d, space);
+//  3. strip apostrophes (ASCII ' and U+2019) — removed, not hyphenated;
+//  4. collapse each maximal run of non-[a-z0-9] runes into a single "-";
+//  5. trim leading and trailing "-".
+//
+// Step 4 is Unicode-aware, matching the JS regex /[^a-z0-9]+/g: it iterates over
+// runes and keeps a rune only when it is an ASCII a-z or 0-9 (after lowercasing);
+// every other rune — accented letters, CJK, punctuation, whitespace — is a
+// separator. Iterating runes (not bytes) avoids splitting a multibyte character.
+func Slugify(name string) string {
+	lowered := strings.ToLower(name)
+	expanded := strings.ReplaceAll(lowered, "&", " and ")
+	stripped := apostropheStripper.Replace(expanded)
+
+	var b strings.Builder
+	b.Grow(len(stripped))
+
+	// pendingSeparator records that at least one separator rune has been seen
+	// since the last kept rune. A single "-" is emitted only when the next kept
+	// rune arrives AND some output already exists, which collapses runs and drops
+	// leading/trailing separators in one pass (equivalent to collapse-then-trim).
+	pendingSeparator := false
+	for _, r := range stripped {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			if pendingSeparator && b.Len() > 0 {
+				b.WriteByte('-')
+			}
+			pendingSeparator = false
+			b.WriteRune(r)
+			continue
+		}
+		pendingSeparator = true
+	}
+	return b.String()
+}

--- a/api-go/internal/authorities/slug_test.go
+++ b/api-go/internal/authorities/slug_test.go
@@ -1,0 +1,122 @@
+package authorities
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// slugFixturePath points at the shared JS/Go slug ground-truth vectors. It is
+// relative to this package's directory (api-go/internal/authorities); go test
+// runs each package with its own directory as the working directory, so three
+// levels up reaches the repo root where web/scripts/lib/slug-fixtures.json lives.
+const slugFixturePath = "../../../web/scripts/lib/slug-fixtures.json"
+
+// TestSlugify_MatchesSharedFixture guards the Go port against drift from the
+// canonical JS algorithm in web/scripts/lib/slug.mjs: both read the SAME fixture.
+func TestSlugify_MatchesSharedFixture(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile(slugFixturePath)
+	if err != nil {
+		t.Fatalf("read shared slug fixture %s: %v (the byte-equal parity fixture must be present in this worktree/PR)", slugFixturePath, err)
+	}
+
+	var vectors []struct {
+		Input    string `json:"input"`
+		Expected string `json:"expected"`
+	}
+	if err := json.Unmarshal(raw, &vectors); err != nil {
+		t.Fatalf("unmarshal shared slug fixture %s: %v", slugFixturePath, err)
+	}
+	if len(vectors) == 0 {
+		t.Fatalf("shared slug fixture %s is empty; expected at least one ground-truth vector", slugFixturePath)
+	}
+
+	for _, v := range vectors {
+		t.Run(v.Input, func(t *testing.T) {
+			t.Parallel()
+			if got := Slugify(v.Input); got != v.Expected {
+				t.Errorf("Slugify(%q) = %q, want %q (drift from web/scripts/lib/slug.mjs)", v.Input, got, v.Expected)
+			}
+		})
+	}
+}
+
+// TestSlugify_Cases documents intent directly, redundant with the fixture but
+// pinning the specific behaviours the port must honour.
+func TestSlugify_Cases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"lowercases and hyphenates words", "Basingstoke and Deane", "basingstoke-and-deane"},
+		{"ampersand expands to and", "Hammersmith & Fulham", "hammersmith-and-fulham"},
+		{"ascii apostrophe stripped not hyphenated", "King's Lynn", "kings-lynn"},
+		{"unicode right single quote stripped", "King’s Lynn", "kings-lynn"},
+		{"comma and whitespace collapse", "Bristol, City of", "bristol-city-of"},
+		{"leading and trailing separators trimmed", "-- Foo --", "foo"},
+		{"internal whitespace runs collapse", "  Test   Name  ", "test-name"},
+		{"digits preserved", "Test 123", "test-123"},
+		{"existing hyphens preserved", "Stratford-on-Avon", "stratford-on-avon"},
+		{"empty string stays empty", "", ""},
+		{"non-ascii letters act as separators", "Café Royal", "caf-royal"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Slugify(tc.in); got != tc.want {
+				t.Errorf("Slugify(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLookup_SlugResolver exercises the slug<->area-id resolution exposed on the
+// cross-package Lookup handle.
+func TestLookup_SlugResolver(t *testing.T) {
+	t.Parallel()
+	lookup := NewLookup()
+
+	// Aberdeen (id 384) and Adur (id 245) are stable entries in the embedded
+	// authorities data (see store_test.go), so their slugs are known-good.
+	known := []struct {
+		id   int
+		slug string
+	}{
+		{384, "aberdeen"},
+		{245, "adur"},
+	}
+	for _, k := range known {
+		t.Run(k.slug, func(t *testing.T) {
+			t.Parallel()
+
+			gotID, ok := lookup.SlugToAreaID(k.slug)
+			if !ok || gotID != k.id {
+				t.Errorf("SlugToAreaID(%q) = (%d, %v), want (%d, true)", k.slug, gotID, ok, k.id)
+			}
+
+			gotSlug, ok := lookup.SlugForAreaID(k.id)
+			if !ok || gotSlug != k.slug {
+				t.Errorf("SlugForAreaID(%d) = (%q, %v), want (%q, true)", k.id, gotSlug, ok, k.slug)
+			}
+		})
+	}
+
+	t.Run("unknown slug", func(t *testing.T) {
+		t.Parallel()
+		if id, ok := lookup.SlugToAreaID("no-such-authority-slug"); ok || id != 0 {
+			t.Errorf("SlugToAreaID(unknown) = (%d, %v), want (0, false)", id, ok)
+		}
+	})
+
+	t.Run("unknown id", func(t *testing.T) {
+		t.Parallel()
+		if slug, ok := lookup.SlugForAreaID(-1); ok || slug != "" {
+			t.Errorf("SlugForAreaID(-1) = (%q, %v), want (\"\", false)", slug, ok)
+		}
+	})
+}

--- a/api-go/internal/authorities/store.go
+++ b/api-go/internal/authorities/store.go
@@ -22,11 +22,14 @@ type Authority struct {
 	AreaType string `json:"areaType"`
 }
 
-// staticStore holds the authorities pre-sorted by name (ordinal-ignore-case)
-// and indexed by id for O(1) point lookups.
+// staticStore holds the authorities pre-sorted by name (ordinal-ignore-case),
+// indexed by id for O(1) point lookups, and indexed both ways between slug and
+// id. The slug maps are built once at construction, never per call.
 type staticStore struct {
-	sorted []Authority
-	byIDx  map[int]Authority
+	sorted   []Authority
+	byIDx    map[int]Authority
+	slugToID map[string]int
+	idToSlug map[int]string
 }
 
 // newStaticStore loads and indexes the embedded authorities once. It panics on
@@ -47,11 +50,29 @@ func newStaticStore() *staticStore {
 	})
 
 	byIDx := make(map[int]Authority, len(records))
+	slugToID := make(map[string]int, len(records))
+	idToSlug := make(map[int]string, len(records))
 	for _, a := range records {
 		byIDx[a.ID] = a
+
+		slug := Slugify(a.Name)
+		idToSlug[a.ID] = slug
+		// Collision policy: if two authority names slugify to the same slug, the
+		// FIRST by store order wins. records is already sorted by name
+		// (ordinal-ignore-case), so the winner is deterministic. Collisions are
+		// not expected among LPA names, but this keeps resolution stable if one
+		// ever appears.
+		if _, exists := slugToID[slug]; !exists {
+			slugToID[slug] = a.ID
+		}
 	}
 
-	return &staticStore{sorted: records, byIDx: byIDx}
+	return &staticStore{
+		sorted:   records,
+		byIDx:    byIDx,
+		slugToID: slugToID,
+		idToSlug: idToSlug,
+	}
 }
 
 func (s *staticStore) all() []Authority {
@@ -61,6 +82,16 @@ func (s *staticStore) all() []Authority {
 func (s *staticStore) byID(id int) (Authority, bool) {
 	a, ok := s.byIDx[id]
 	return a, ok
+}
+
+func (s *staticStore) slugToAreaID(slug string) (int, bool) {
+	id, ok := s.slugToID[slug]
+	return id, ok
+}
+
+func (s *staticStore) slugForAreaID(id int) (string, bool) {
+	slug, ok := s.idToSlug[id]
+	return slug, ok
 }
 
 // compareOrdinalIgnoreCase sorts ASCII strings by code unit after uppercasing,

--- a/api-go/internal/sharepage/handler.go
+++ b/api-go/internal/sharepage/handler.go
@@ -1,0 +1,102 @@
+// Package sharepage serves the public, anonymous, server-rendered HTML share
+// page for a single planning application at GET /a/{authoritySlug}/{ref...} —
+// the tracer surface of the shareable-application-page epic (#738).
+//
+// The page emits ONLY public planning data: it reads no auth or user data, sets
+// no cookies, and logs no client IP. Its identity is the (authority slug, PlanIt
+// ref) pair; the ref is a trailing wildcard because PlanIt case references
+// contain slashes (e.g. "23/03456/FUL"). Rendering uses html/template, whose
+// contextual auto-escaping is a hard requirement here: the application fields
+// come from an external provider and are untrusted.
+package sharepage
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+// appStore is the narrow consumer-side view of the applications store: a single
+// point read by (authorityCode, ref). The authorityCode is the stringified area
+// id. *applications.PostgresStore satisfies it structurally.
+type appStore interface {
+	GetByAuthorityAndName(ctx context.Context, authorityCode, name string) (applications.PlanningApplication, bool, error)
+}
+
+// slugResolver resolves an authority slug to its area id (which equals the
+// authority id / stringified authority_code). *authorities.Lookup satisfies it
+// structurally.
+type slugResolver interface {
+	SlugToAreaID(slug string) (int, bool)
+}
+
+type handler struct {
+	store    appStore
+	resolver slugResolver
+	logger   *slog.Logger
+}
+
+// Routes registers the anonymous share-page route. The {ref...} wildcard captures
+// the remainder of the path so a PlanIt reference containing slashes is matched
+// whole. Keep the pattern in lockstep with the anonymousPatterns entry in
+// cmd/api/wiring.go — the auth middleware keys on the exact pattern string.
+func Routes(mux *http.ServeMux, store appStore, resolver slugResolver, logger *slog.Logger) {
+	h := &handler{store: store, resolver: resolver, logger: logger}
+	mux.HandleFunc("GET /a/{authoritySlug}/{ref...}", h.serve)
+}
+
+// serve resolves the authority slug, point-reads the application, and renders the
+// page. An unknown slug or unknown ref renders the branded 404 (never a 500); a
+// store error is a bodyless 500 (the envelope is backfilled by middleware).
+func (h *handler) serve(w http.ResponseWriter, r *http.Request) {
+	slug := r.PathValue("authoritySlug")
+	ref := r.PathValue("ref")
+
+	areaID, ok := h.resolver.SlugToAreaID(slug)
+	if !ok {
+		h.renderNotFound(w, r)
+		return
+	}
+
+	app, found, err := h.store.GetByAuthorityAndName(r.Context(), strconv.Itoa(areaID), ref)
+	if err != nil {
+		h.logger.ErrorContext(r.Context(), "share page read failed", "op", "read application by slug", "slug", slug, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if !found {
+		h.renderNotFound(w, r)
+		return
+	}
+
+	h.render(w, r, http.StatusOK, "public, max-age=3600", "page", buildPageView(app, slug, ref))
+}
+
+// renderNotFound emits the branded 404. It must NOT carry the 200's
+// max-age=3600: a just-ingested application would otherwise be negatively cached
+// at the edge for an hour, so the 404 is no-store.
+func (h *handler) renderNotFound(w http.ResponseWriter, r *http.Request) {
+	h.render(w, r, http.StatusNotFound, "no-store", "notfound", nil)
+}
+
+// render executes the named template into a buffer first, so a mid-render error
+// becomes a clean bodyless 500 rather than a half-written page, then writes the
+// status, content type and cache header.
+func (h *handler) render(w http.ResponseWriter, r *http.Request, status int, cacheControl, name string, data any) {
+	var buf bytes.Buffer
+	if err := pageTemplates.ExecuteTemplate(&buf, name, data); err != nil {
+		h.logger.ErrorContext(r.Context(), "share page render failed", "template", name, "error", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", cacheControl)
+	w.WriteHeader(status)
+	if _, err := w.Write(buf.Bytes()); err != nil {
+		h.logger.ErrorContext(r.Context(), "share page write failed", "template", name, "error", err)
+	}
+}

--- a/api-go/internal/sharepage/handler.go
+++ b/api-go/internal/sharepage/handler.go
@@ -64,7 +64,7 @@ func (h *handler) serve(w http.ResponseWriter, r *http.Request) {
 
 	app, found, err := h.store.GetByAuthorityAndName(r.Context(), strconv.Itoa(areaID), ref)
 	if err != nil {
-		h.logger.ErrorContext(r.Context(), "share page read failed", "op", "read application by slug", "slug", slug, "error", err)
+		h.logger.ErrorContext(r.Context(), "share page read failed", "op", "read application by slug", "slug", slug, "ref", ref, "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -3,7 +3,6 @@ package sharepage
 import (
 	"context"
 	"errors"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -85,9 +84,9 @@ func fullApp(t *testing.T) applications.PlanningApplication {
 func serve(t *testing.T, store appStore, resolver slugResolver, path string) *httptest.ResponseRecorder {
 	t.Helper()
 	mux := http.NewServeMux()
-	Routes(mux, store, resolver, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	Routes(mux, store, resolver, slog.New(slog.DiscardHandler))
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, path, nil)
 	mux.ServeHTTP(rec, req)
 	return rec
 }

--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -1,0 +1,294 @@
+package sharepage
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+// fakeStore is a hand-written double for the application point read. It records
+// how it was called so tests can assert the (authorityCode, ref) it received.
+type fakeStore struct {
+	app              applications.PlanningApplication
+	found            bool
+	err              error
+	gotAuthorityCode string
+	gotName          string
+	calls            int
+}
+
+func (f *fakeStore) GetByAuthorityAndName(_ context.Context, authorityCode, name string) (applications.PlanningApplication, bool, error) {
+	f.calls++
+	f.gotAuthorityCode = authorityCode
+	f.gotName = name
+	if f.err != nil {
+		return applications.PlanningApplication{}, false, f.err
+	}
+	return f.app, f.found, nil
+}
+
+// fakeResolver is a hand-written double for the authority slug resolver.
+type fakeResolver struct {
+	slugs map[string]int
+}
+
+func (f *fakeResolver) SlugToAreaID(slug string) (int, bool) {
+	id, ok := f.slugs[slug]
+	return id, ok
+}
+
+func ptr[T any](v T) *T { return &v }
+
+func mustDate(t *testing.T, s string) time.Time {
+	t.Helper()
+	d, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse date %q: %v", s, err)
+	}
+	return d
+}
+
+// fullApp is a fully-populated snapshot: every optional field set, so a single
+// render exercises the chip, the timeline and both official-record links.
+func fullApp(t *testing.T) applications.PlanningApplication {
+	t.Helper()
+	return applications.PlanningApplication{
+		Name:          "23/03456/FUL",
+		UID:           "croydon-23-03456-FUL",
+		AreaName:      "Croydon",
+		AreaID:        165,
+		Address:       "10 Downing Street, London",
+		Postcode:      ptr("CR0 1AB"),
+		Description:   "Erection of a two-storey rear extension.",
+		AppType:       ptr("Full planning permission"),
+		AppState:      ptr("Under Consideration"),
+		StartDate:     ptr(mustDate(t, "2024-03-02")),
+		ConsultedDate: ptr(mustDate(t, "2024-03-10")),
+		DecidedDate:   ptr(mustDate(t, "2024-04-15")),
+		URL:           ptr("https://www.croydon.gov.uk/planning/123"),
+		Link:          ptr("https://planit.org.uk/planapplic/165/23/03456/FUL"),
+	}
+}
+
+// serve wires Routes onto a real mux and drives the given path through it, so the
+// "GET /a/{authoritySlug}/{ref...}" pattern (and its slash-carrying ref capture)
+// is exercised, not just the handler in isolation. The request carries no bearer
+// token — the page is anonymous.
+func serve(t *testing.T, store appStore, resolver slugResolver, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	Routes(mux, store, resolver, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestServe_KnownApplication_RendersMetaAndVisibleContent(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{app: fullApp(t), found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "text/html; charset=utf-8" {
+		t.Errorf("Content-Type = %q, want text/html; charset=utf-8", got)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "public, max-age=3600" {
+		t.Errorf("Cache-Control = %q, want public, max-age=3600", got)
+	}
+	// Anonymity: the page must set no cookies.
+	if cookies := rec.Header().Values("Set-Cookie"); len(cookies) != 0 {
+		t.Errorf("share page set cookies %v; must be anonymous", cookies)
+	}
+	// The store is point-read by the resolved area id (stringified) and the raw ref.
+	if store.gotAuthorityCode != "165" || store.gotName != "23/03456/FUL" {
+		t.Errorf("store queried with (%q,%q), want (165, 23/03456/FUL)", store.gotAuthorityCode, store.gotName)
+	}
+
+	body := rec.Body.String()
+	wantContains := []string{
+		// HEAD / meta asserted by the acceptance criteria.
+		`<meta name="robots" content="noindex,follow">`,
+		`<link rel="canonical" href="https://share.towncrierapp.uk/a/croydon/23/03456/FUL">`,
+		`property="og:title"`,
+		`property="og:description"`,
+		`property="og:url" content="https://share.towncrierapp.uk/a/croydon/23/03456/FUL"`,
+		`property="og:site_name" content="Town Crier"`,
+		`property="og:type"`,
+		`name="twitter:card" content="summary_large_image"`,
+		`name="twitter:title"`,
+		`name="twitter:description"`,
+		`name="twitter:image"`,
+		`name="apple-itunes-app" content="app-id=6764095657`,
+		// og:image AND twitter:image both point at the Slice-1 branded placeholder.
+		"https://towncrierapp.uk/android-chrome-512x512.png",
+		// Visible essentials.
+		"10 Downing Street, London",
+		"CR0 1AB",
+		"23/03456/FUL",
+		"Erection of a two-storey rear extension.",
+		"2 March 2024", // human-formatted StartDate
+		"Under Consideration",
+		// Official-record links (PlanIt primary, council secondary), each nofollow.
+		`rel="nofollow noopener"`,
+		"https://planit.org.uk/planapplic/165/23/03456/FUL",
+		"https://www.croydon.gov.uk/planning/123",
+		// Attribution footer — the four ADR-0006 lines, verbatim.
+		"Planning data provided by PlanIt (planit.org.uk)",
+		"Contains public sector information licensed under the Open Government Licence. Crown Copyright.",
+		"Contains Ordnance Survey data © Crown Copyright and database right.",
+		"Map data © OpenStreetMap contributors.",
+		// Sticky CTA: exact copy + the campaign-tagged App Store URL.
+		"Download the app for instant notifications about planning updates",
+		"town-crier-planning-alerts",
+		"ct=share-page",
+		"mt=8",
+	}
+	for _, want := range wantContains {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestServe_UnknownSlug_RendersBranded404(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/nowhere/23/0001/FUL")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if store.calls != 0 {
+		t.Errorf("store queried %d times for an unknown slug, want 0", store.calls)
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", got)
+	}
+	if rec.Body.Len() == 0 {
+		t.Error("404 body is empty, want branded HTML")
+	}
+	if !strings.Contains(rec.Body.String(), "Town Crier") {
+		t.Error("404 body is not branded (missing Town Crier)")
+	}
+	// A just-ingested application must not be negatively cached for an hour.
+	if strings.Contains(rec.Header().Get("Cache-Control"), "max-age=3600") {
+		t.Errorf("404 Cache-Control = %q must not carry max-age=3600", rec.Header().Get("Cache-Control"))
+	}
+}
+
+func TestServe_UnknownRef_RendersBranded404(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{found: false}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/99/9999/XXX")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/html") {
+		t.Errorf("Content-Type = %q, want text/html", got)
+	}
+	if rec.Body.Len() == 0 {
+		t.Error("404 body is empty, want branded HTML")
+	}
+	if strings.Contains(rec.Header().Get("Cache-Control"), "max-age=3600") {
+		t.Errorf("404 Cache-Control = %q must not carry max-age=3600", rec.Header().Get("Cache-Control"))
+	}
+}
+
+func TestServe_StoreError_Returns500(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{err: errors.New("db down")}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/0001/FUL")
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}
+
+func TestServe_EscapesUntrustedFields(t *testing.T) {
+	t.Parallel()
+	app := fullApp(t)
+	app.Description = "<script>alert(1)</script>"
+	app.Address = `"><script>alert(2)</script>`
+	store := &fakeStore{app: app, found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "<script>alert(1)</script>") {
+		t.Error("Description not escaped: raw <script> present in output")
+	}
+	if strings.Contains(body, "<script>alert(2)</script>") {
+		t.Error("Address not escaped: raw <script> present in output")
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Error("expected HTML-escaped <script> in output (proves html/template contextual escaping)")
+	}
+}
+
+func TestServe_NilOptionalFields_Renders200WithoutPanic(t *testing.T) {
+	t.Parallel()
+	app := applications.PlanningApplication{
+		Name:     "24/0001/OUT",
+		AreaName: "Croydon",
+		AreaID:   165,
+		Address:  "Land at Foo Road",
+		// Postcode, AppType, AppState, all dates, URL and Link are nil;
+		// Description is empty.
+	}
+	store := &fakeStore{app: app, found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/24/0001/OUT")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Land at Foo Road") {
+		t.Error("address missing")
+	}
+	if !strings.Contains(body, "24/0001/OUT") {
+		t.Error("ref missing")
+	}
+	// Omitted sections must be absent.
+	if strings.Contains(body, `class="chip"`) {
+		t.Error("status chip rendered despite nil AppState")
+	}
+	if strings.Contains(body, `rel="nofollow noopener"`) {
+		t.Error("official-record link rendered despite nil URL/Link")
+	}
+	if strings.Contains(body, ">Key dates<") {
+		t.Error("key-dates section rendered despite no dates")
+	}
+	// Attribution + CTA still present.
+	if !strings.Contains(body, "Download the app for instant notifications about planning updates") {
+		t.Error("sticky CTA missing")
+	}
+	if !strings.Contains(body, "Map data © OpenStreetMap contributors.") {
+		t.Error("attribution missing")
+	}
+}

--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -1,6 +1,7 @@
 package sharepage
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -121,14 +122,18 @@ func TestServe_KnownApplication_RendersMetaAndVisibleContent(t *testing.T) {
 		// HEAD / meta asserted by the acceptance criteria.
 		`<meta name="robots" content="noindex,follow">`,
 		`<link rel="canonical" href="https://share.towncrierapp.uk/a/croydon/23/03456/FUL">`,
-		`property="og:title"`,
-		`property="og:description"`,
+		// og:/twitter: titles and descriptions asserted by CONTENT, not mere
+		// presence: og:title carries the ref+place headline; og:description carries
+		// the proposal summary. A blank or wrong unfurl would slip past an
+		// attribute-presence check but fails these.
+		`property="og:title" content="23/03456/FUL · 10 Downing Street, London"`,
+		`property="og:description" content="Erection of a two-storey rear extension."`,
 		`property="og:url" content="https://share.towncrierapp.uk/a/croydon/23/03456/FUL"`,
 		`property="og:site_name" content="Town Crier"`,
 		`property="og:type"`,
 		`name="twitter:card" content="summary_large_image"`,
-		`name="twitter:title"`,
-		`name="twitter:description"`,
+		`name="twitter:title" content="23/03456/FUL · 10 Downing Street, London"`,
+		`name="twitter:description" content="Erection of a two-storey rear extension."`,
 		`name="twitter:image"`,
 		`name="apple-itunes-app" content="app-id=6764095657`,
 		// og:image AND twitter:image both point at the Slice-1 branded placeholder.
@@ -137,11 +142,19 @@ func TestServe_KnownApplication_RendersMetaAndVisibleContent(t *testing.T) {
 		"10 Downing Street, London",
 		"CR0 1AB",
 		"23/03456/FUL",
+		"Full planning permission", // AppType, rendered in the reference row
 		"Erection of a two-storey rear extension.",
-		"2 March 2024", // human-formatted StartDate
 		"Under Consideration",
-		// Official-record links (PlanIt primary, council secondary), each nofollow.
-		`rel="nofollow noopener"`,
+		// Key-dates timeline (doubles as status history): the heading and every
+		// row's LABEL and human-formatted VALUE. fullApp sets all three dates, so a
+		// missing timeline or a mis-formatted date is caught here.
+		"<h2>Key dates</h2>",
+		`<span class="date-label">Started</span><span class="date-value">2 March 2024</span>`,
+		`<span class="date-label">Consulted</span><span class="date-value">10 March 2024</span>`,
+		`<span class="date-label">Decided</span><span class="date-value">15 April 2024</span>`,
+		// Official-record links (PlanIt primary, council secondary): nofollow +
+		// noopener + noreferrer (noreferrer strips the Referer to third-party sites).
+		`rel="nofollow noopener noreferrer"`,
 		"https://planit.org.uk/planapplic/165/23/03456/FUL",
 		"https://www.croydon.gov.uk/planning/123",
 		// Attribution footer — the four ADR-0006 lines, verbatim.
@@ -248,6 +261,69 @@ func TestServe_EscapesUntrustedFields(t *testing.T) {
 	}
 }
 
+// TestServe_NeutralisesJavascriptSchemeInOfficialLinks pins the URL-context
+// escaper (distinct from the text-context escaper above): a hostile
+// "javascript:" scheme in the PlanIt/council record URLs must NOT survive into a
+// clickable href. html/template's URL filter rewrites an unsafe scheme to the
+// sentinel "#ZgotmplZ". Asserting the sentinel (and the absence of the raw scheme)
+// means a future move off html/template cannot silently reintroduce a clickable
+// javascript: link.
+func TestServe_NeutralisesJavascriptSchemeInOfficialLinks(t *testing.T) {
+	t.Parallel()
+	app := fullApp(t)
+	app.URL = ptr("javascript:alert(1)")  // council secondary link
+	app.Link = ptr("javascript:alert(2)") // PlanIt primary link
+	store := &fakeStore{app: app, found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "javascript:alert(1)") {
+		t.Error("council href retained raw javascript: scheme — URL filter bypassed")
+	}
+	if strings.Contains(body, "javascript:alert(2)") {
+		t.Error("PlanIt href retained raw javascript: scheme — URL filter bypassed")
+	}
+	if !strings.Contains(body, "#ZgotmplZ") {
+		t.Error("expected html/template's #ZgotmplZ sentinel for the neutralised javascript: scheme")
+	}
+}
+
+// TestServe_EscapesHostileRefInReflectionPoints guards the attribute/URL-context
+// escaping of the attacker-controlled trailing ref, which is reflected into the
+// canonical <link href>, the og:url content, the <title>, and the
+// apple-itunes-app app-argument. A ref that closes the attribute and injects a
+// <script> must not appear raw in ANY of those places. Rendered directly through
+// the template so the hostile bytes are not mangled by request URL parsing first.
+func TestServe_EscapesHostileRefInReflectionPoints(t *testing.T) {
+	t.Parallel()
+	const hostileRef = `23/03456/FUL"><script>alert(1)</script>`
+	view := buildPageView(fullApp(t), "croydon", hostileRef)
+
+	var buf bytes.Buffer
+	if err := pageTemplates.ExecuteTemplate(&buf, "page", view); err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	body := buf.String()
+
+	// The raw break-out sequence must not survive into the output at all.
+	if strings.Contains(body, `"><script>`) {
+		t.Error(`raw "><script> break-out sequence present — attribute/URL escaping failed`)
+	}
+	if strings.Contains(body, "<script>alert(1)</script>") {
+		t.Error("raw <script> injected via ref present in output")
+	}
+	// Sanity: the benign portion of the ref is still rendered (escaping did not
+	// simply drop everything), so the assertion above is meaningful.
+	if !strings.Contains(body, "23/03456/FUL") {
+		t.Error("benign ref prefix missing — render produced nothing to escape")
+	}
+}
+
 func TestServe_NilOptionalFields_Renders200WithoutPanic(t *testing.T) {
 	t.Parallel()
 	app := applications.PlanningApplication{
@@ -277,7 +353,7 @@ func TestServe_NilOptionalFields_Renders200WithoutPanic(t *testing.T) {
 	if strings.Contains(body, `class="chip"`) {
 		t.Error("status chip rendered despite nil AppState")
 	}
-	if strings.Contains(body, `rel="nofollow noopener"`) {
+	if strings.Contains(body, `rel="nofollow noopener noreferrer"`) {
 		t.Error("official-record link rendered despite nil URL/Link")
 	}
 	if strings.Contains(body, ">Key dates<") {

--- a/api-go/internal/sharepage/templates.go
+++ b/api-go/internal/sharepage/templates.go
@@ -1,0 +1,18 @@
+package sharepage
+
+import (
+	"embed"
+	"html/template"
+)
+
+//go:embed templates/*.gohtml
+var templateFS embed.FS
+
+// pageTemplates holds the parsed share-page ("page") and branded-404
+// ("notfound") templates, sharing one "styles" block. Parsing happens exactly
+// once at package initialisation — the templates are compiled into the binary
+// via go:embed, so this touches no filesystem I/O — never per request.
+// html/template (not text/template) is deliberate: its contextual auto-escaping
+// is a hard requirement because the application fields come from an external
+// provider (PlanIt) and are untrusted.
+var pageTemplates = template.Must(template.ParseFS(templateFS, "templates/*.gohtml"))

--- a/api-go/internal/sharepage/templates/notfound.gohtml
+++ b/api-go/internal/sharepage/templates/notfound.gohtml
@@ -1,0 +1,24 @@
+{{define "notfound"}}<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Application not found &middot; Town Crier</title>
+<meta name="robots" content="noindex,follow">
+{{template "styles" .}}
+</head>
+<body>
+<main class="page notfound">
+<div class="brand"><span class="dot"></span>Town Crier</div>
+<h1>We couldn't find that application</h1>
+<p>This planning application may have been removed, or the link may be incorrect.</p>
+<a class="home-link" href="https://towncrierapp.uk">Go to Town Crier</a>
+<footer class="attribution">
+<p>Planning data provided by PlanIt (planit.org.uk)</p>
+<p>Contains public sector information licensed under the Open Government Licence. Crown Copyright.</p>
+<p>Contains Ordnance Survey data © Crown Copyright and database right.</p>
+<p>Map data © OpenStreetMap contributors.</p>
+</footer>
+</main>
+</body>
+</html>{{end}}

--- a/api-go/internal/sharepage/templates/page.gohtml
+++ b/api-go/internal/sharepage/templates/page.gohtml
@@ -30,8 +30,8 @@
 {{if .Description}}<h2>Proposal</h2><p class="proposal">{{.Description}}</p>{{end}}
 {{if .Dates}}<h2>Key dates</h2><ol class="timeline">{{range .Dates}}<li><span class="date-label">{{.Label}}</span><span class="date-value">{{.Value}}</span></li>{{end}}</ol>{{end}}
 {{if or .PlanItLink .CouncilLink}}<h2>Official record</h2><div class="records">
-{{if .PlanItLink}}<a class="record-link primary" href="{{.PlanItLink}}" rel="nofollow noopener" target="_blank">View on PlanIt</a>{{end}}
-{{if .CouncilLink}}<a class="record-link secondary" href="{{.CouncilLink}}" rel="nofollow noopener" target="_blank">View on the council website</a>{{end}}
+{{if .PlanItLink}}<a class="record-link primary" href="{{.PlanItLink}}" rel="nofollow noopener noreferrer" target="_blank">View on PlanIt</a>{{end}}
+{{if .CouncilLink}}<a class="record-link secondary" href="{{.CouncilLink}}" rel="nofollow noopener noreferrer" target="_blank">View on the council website</a>{{end}}
 </div>{{end}}
 </article>
 <footer class="attribution">

--- a/api-go/internal/sharepage/templates/page.gohtml
+++ b/api-go/internal/sharepage/templates/page.gohtml
@@ -1,0 +1,46 @@
+{{define "page"}}<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>{{.Title}}</title>
+<meta name="robots" content="noindex,follow">
+<link rel="canonical" href="{{.CanonicalURL}}">
+<meta name="description" content="{{.OGDescription}}">
+<meta property="og:title" content="{{.OGTitle}}">
+<meta property="og:description" content="{{.OGDescription}}">
+<meta property="og:url" content="{{.CanonicalURL}}">
+<meta property="og:site_name" content="Town Crier">
+<meta property="og:type" content="article">
+<meta property="og:image" content="{{.OGImage}}">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="{{.OGTitle}}">
+<meta name="twitter:description" content="{{.OGDescription}}">
+<meta name="twitter:image" content="{{.OGImage}}">
+<meta name="apple-itunes-app" content="app-id={{.AppleAppID}}, app-argument={{.CanonicalURL}}">
+{{template "styles" .}}
+</head>
+<body>
+<main class="page">
+<div class="brand"><span class="dot"></span>Town Crier</div>
+<article class="card">
+<div class="ref-row">Reference {{.Ref}}{{if .AppType}} &middot; {{.AppType}}{{end}}</div>
+{{if .StatusChip}}<span class="chip">{{.StatusChip}}</span>{{end}}
+<h1 class="address">{{.Address}}{{if .Postcode}}, {{.Postcode}}{{end}}</h1>
+{{if .Description}}<h2>Proposal</h2><p class="proposal">{{.Description}}</p>{{end}}
+{{if .Dates}}<h2>Key dates</h2><ol class="timeline">{{range .Dates}}<li><span class="date-label">{{.Label}}</span><span class="date-value">{{.Value}}</span></li>{{end}}</ol>{{end}}
+{{if or .PlanItLink .CouncilLink}}<h2>Official record</h2><div class="records">
+{{if .PlanItLink}}<a class="record-link primary" href="{{.PlanItLink}}" rel="nofollow noopener" target="_blank">View on PlanIt</a>{{end}}
+{{if .CouncilLink}}<a class="record-link secondary" href="{{.CouncilLink}}" rel="nofollow noopener" target="_blank">View on the council website</a>{{end}}
+</div>{{end}}
+</article>
+<footer class="attribution">
+<p>Planning data provided by PlanIt (planit.org.uk)</p>
+<p>Contains public sector information licensed under the Open Government Licence. Crown Copyright.</p>
+<p>Contains Ordnance Survey data © Crown Copyright and database right.</p>
+<p>Map data © OpenStreetMap contributors.</p>
+</footer>
+</main>
+<a class="cta" href="{{.CTAHref}}">Download the app for instant notifications about planning updates</a>
+</body>
+</html>{{end}}

--- a/api-go/internal/sharepage/templates/styles.gohtml
+++ b/api-go/internal/sharepage/templates/styles.gohtml
@@ -1,0 +1,87 @@
+{{define "styles"}}<style>
+:root{
+  --bg:#FAF8F5;--surface:#FFFFFF;--text-primary:#1C1917;--text-secondary:#6B6560;
+  --text-tertiary:#A39E98;--border:#E8E4DF;--amber:#D4910A;--amber-hover:#B87A08;
+  --text-on-accent:#FFFFFF;--amber-muted:rgba(212,145,10,0.15);
+  --radius-sm:8px;--radius-md:12px;
+  --space-xs:4px;--space-sm:8px;--space-md:16px;--space-lg:24px;--space-xl:32px;
+}
+@media (prefers-color-scheme:dark){
+  :root{
+    --bg:#1A1A1E;--surface:#242428;--text-primary:#F1EFE9;--text-secondary:#9B9590;
+    --text-tertiary:#5C5852;--border:#3A3A3F;--amber:#E9A620;--amber-hover:#F0B83A;
+    --text-on-accent:#1C1917;--amber-muted:rgba(233,166,32,0.15);
+  }
+}
+*{box-sizing:border-box;}
+html{-webkit-text-size-adjust:100%;}
+body{
+  margin:0;background:var(--bg);color:var(--text-primary);
+  font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
+  font-size:17px;line-height:1.4;
+}
+.page{max-width:600px;margin:0 auto;padding:var(--space-lg) var(--space-md) 128px;}
+.brand{
+  display:flex;align-items:center;gap:var(--space-sm);
+  margin-bottom:var(--space-lg);font-size:15px;font-weight:600;
+  color:var(--text-secondary);letter-spacing:0.01em;
+}
+.brand .dot{width:10px;height:10px;border-radius:9999px;background:var(--amber);}
+.card{
+  background:var(--surface);border:1px solid var(--border);
+  border-radius:var(--radius-md);padding:var(--space-md);
+  box-shadow:0 2px 8px rgba(0,0,0,0.05);
+}
+@media (prefers-color-scheme:dark){.card{box-shadow:none;}}
+.ref-row{
+  color:var(--text-secondary);font-size:14px;font-weight:500;
+  margin-bottom:var(--space-sm);
+}
+.chip{
+  display:inline-block;margin-bottom:var(--space-md);padding:4px 12px;
+  border-radius:9999px;background:var(--amber-muted);border:1px solid var(--border);
+  color:var(--text-primary);font-size:13px;font-weight:500;
+}
+h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--space-md);}
+.card h2{
+  margin:var(--space-lg) 0 var(--space-sm);font-size:13px;font-weight:600;
+  text-transform:uppercase;letter-spacing:0.04em;color:var(--text-secondary);
+}
+.proposal{margin:0;}
+.timeline{list-style:none;margin:0;padding:0;}
+.timeline li{
+  display:flex;justify-content:space-between;gap:var(--space-md);
+  padding:var(--space-sm) 0;border-bottom:1px solid var(--border);
+}
+.timeline li:last-child{border-bottom:none;}
+.date-label{color:var(--text-secondary);}
+.date-value{font-weight:600;text-align:right;}
+.records{display:flex;flex-direction:column;gap:var(--space-sm);}
+.record-link{
+  display:block;padding:12px var(--space-md);border-radius:var(--radius-md);
+  text-align:center;text-decoration:none;font-weight:600;
+}
+.record-link.primary{background:var(--amber);color:var(--text-on-accent);}
+.record-link.secondary{
+  background:var(--surface);color:var(--text-primary);border:1px solid var(--border);
+}
+.attribution{
+  margin-top:var(--space-lg);color:var(--text-tertiary);
+  font-size:12px;line-height:1.5;
+}
+.attribution p{margin:0 0 4px;}
+.cta{
+  position:fixed;left:0;right:0;bottom:0;margin:0 auto;max-width:600px;
+  padding:16px var(--space-md);padding-bottom:calc(16px + env(safe-area-inset-bottom));
+  background:var(--amber);color:var(--text-on-accent);
+  text-align:center;text-decoration:none;font-weight:600;
+  box-shadow:0 -2px 12px rgba(0,0,0,0.12);
+}
+.notfound{text-align:center;padding-top:var(--space-xl);}
+.notfound h1{font-size:24px;margin:0 0 var(--space-sm);}
+.notfound p{color:var(--text-secondary);}
+.home-link{
+  display:inline-block;margin-top:var(--space-md);
+  color:var(--amber);text-decoration:none;font-weight:600;
+}
+</style>{{end}}

--- a/api-go/internal/sharepage/view.go
+++ b/api-go/internal/sharepage/view.go
@@ -1,0 +1,156 @@
+package sharepage
+
+import (
+	"strings"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+const (
+	// shareOrigin is the intended public origin for the share page. Canonical and
+	// og:url point here even though this slice serves on the API/localhost host —
+	// the page moves behind share.towncrierapp.uk in Slice 3 (#738). The canonical
+	// path is always built from the slug + ref, never from the raw request host.
+	shareOrigin = "https://share.towncrierapp.uk"
+
+	// appleAppID is the Town Crier App Store numeric id. It drives the Smart App
+	// Banner meta so iOS Safari offers "Open in app" / "Download".
+	appleAppID = "6764095657"
+
+	// ogImageFallback is the Slice-1 branded PLACEHOLDER unfurl image (the app
+	// icon). The real 1200x630 OSM map card — a baked map of the site with a pin —
+	// arrives in Slice 2; until then both og:image and twitter:image point here.
+	// This slice adds no image route and no binary asset.
+	ogImageFallback = "https://towncrierapp.uk/android-chrome-512x512.png"
+
+	// App Store deep link, mirroring the web appStoreUrl('share-page') shape: the
+	// campaign-free base, the share-page campaign token, and mt=8.
+	appStoreBaseURL    = "https://apps.apple.com/gb/app/town-crier-planning-alerts/id6764095657"
+	shareCampaignToken = "share-page"
+	appStoreMediaType  = "8"
+
+	// ogDescriptionMaxRunes bounds the og:/twitter:description so a long proposal
+	// does not overrun a social unfurl card. Counted in runes, not bytes, so a
+	// multibyte character is never split.
+	ogDescriptionMaxRunes = 200
+)
+
+// ctaURL is the sticky-CTA App Store link carrying the share-page campaign token,
+// e.g. .../id6764095657?ct=share-page&mt=8.
+func ctaURL() string {
+	return appStoreBaseURL + "?ct=" + shareCampaignToken + "&mt=" + appStoreMediaType
+}
+
+// pageView is the pre-formatted, template-ready projection of a
+// PlanningApplication. All optional sections are already resolved to empty
+// strings / empty slices here so the template stays logic-light: an empty field
+// means "omit this section". Dates are human-formatted in Go.
+type pageView struct {
+	Title         string
+	OGTitle       string
+	OGDescription string
+	OGImage       string
+	CanonicalURL  string
+	AppleAppID    string
+	CTAHref       string
+
+	Ref         string
+	Address     string
+	Postcode    string
+	AppType     string
+	StatusChip  string
+	Description string
+	Dates       []dateEntry
+	PlanItLink  string
+	CouncilLink string
+}
+
+// dateEntry is one row of the key-dates timeline (which doubles as the status
+// history — the snapshot carries no richer feed).
+type dateEntry struct {
+	Label string
+	Value string
+}
+
+// buildPageView projects an application into its template-ready view. slug and
+// ref come from the resolved request path and are used verbatim to build the
+// canonical URL. Every pointer field is nil-guarded: an absent value collapses
+// to an empty string and the template omits the corresponding section.
+func buildPageView(app applications.PlanningApplication, slug, ref string) pageView {
+	place := strings.TrimSpace(app.Address)
+	if place == "" {
+		place = strings.TrimSpace(app.AreaName)
+	}
+
+	headline := ref
+	if place != "" {
+		headline = ref + " · " + place
+	}
+
+	canonical := shareOrigin + "/a/" + slug + "/" + ref
+
+	v := pageView{
+		Title:         headline + " · Town Crier",
+		OGTitle:       headline,
+		OGDescription: summarise(app.Description, place),
+		OGImage:       ogImageFallback,
+		CanonicalURL:  canonical,
+		AppleAppID:    appleAppID,
+		CTAHref:       ctaURL(),
+		Ref:           ref,
+		Address:       app.Address,
+		Description:   app.Description,
+	}
+
+	if app.Postcode != nil {
+		v.Postcode = *app.Postcode
+	}
+	if app.AppType != nil {
+		v.AppType = *app.AppType
+	}
+	if app.AppState != nil {
+		// Render the RAW PlanIt status verbatim — mapping it to a friendly label or
+		// a status colour is a web/iOS concern, deliberately not invented here.
+		v.StatusChip = *app.AppState
+	}
+	if app.StartDate != nil {
+		v.Dates = append(v.Dates, dateEntry{Label: "Started", Value: formatDate(*app.StartDate)})
+	}
+	if app.ConsultedDate != nil {
+		v.Dates = append(v.Dates, dateEntry{Label: "Consulted", Value: formatDate(*app.ConsultedDate)})
+	}
+	if app.DecidedDate != nil {
+		v.Dates = append(v.Dates, dateEntry{Label: "Decided", Value: formatDate(*app.DecidedDate)})
+	}
+	if app.Link != nil {
+		v.PlanItLink = *app.Link
+	}
+	if app.URL != nil {
+		v.CouncilLink = *app.URL
+	}
+	return v
+}
+
+// formatDate renders a date as "2 March 2024".
+func formatDate(t time.Time) string {
+	return t.Format("2 January 2006")
+}
+
+// summarise builds the og:/twitter:description from the proposal text, trimmed to
+// a concise length on a whole-rune boundary with an ellipsis. It falls back to a
+// place-based sentence when the record carries no proposal text.
+func summarise(description, place string) string {
+	d := strings.TrimSpace(description)
+	if d == "" {
+		if place != "" {
+			return "Planning application at " + place + ". View the details on Town Crier."
+		}
+		return "View this planning application on Town Crier."
+	}
+	runes := []rune(d)
+	if len(runes) <= ogDescriptionMaxRunes {
+		return d
+	}
+	return strings.TrimSpace(string(runes[:ogDescriptionMaxRunes])) + "…"
+}

--- a/api-go/internal/sharepage/view_test.go
+++ b/api-go/internal/sharepage/view_test.go
@@ -1,0 +1,66 @@
+package sharepage
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestSummarise_TruncatesMultibyteRuneSafe pins the truncation branch on a
+// proposal built entirely from 3-byte CJK runes and well over the cap. A byte-wise
+// truncation would split a rune and yield U+FFFD; the rune-wise implementation
+// cannot. Guards against a regression to byte slicing that would corrupt the
+// og:/twitter: description on any non-ASCII proposal.
+func TestSummarise_TruncatesMultibyteRuneSafe(t *testing.T) {
+	t.Parallel()
+	long := strings.Repeat("界", 250) // 250 runes, 750 bytes, > the 200-rune cap
+	got := summarise(long, "")
+
+	if !utf8.ValidString(got) {
+		t.Fatalf("result is not valid UTF-8: %q", got)
+	}
+	if strings.ContainsRune(got, '�') {
+		t.Error("result contains the Unicode replacement char — a multibyte rune was split")
+	}
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncated summary must end with an ellipsis, got %q", got)
+	}
+	if n := utf8.RuneCountInString(got); n > ogDescriptionMaxRunes+1 {
+		t.Errorf("summary rune length = %d, want <= %d (cap + ellipsis)", n, ogDescriptionMaxRunes+1)
+	}
+	if want := strings.Repeat("界", ogDescriptionMaxRunes) + "…"; got != want {
+		t.Errorf("summary = %q, want the first %d runes + ellipsis", got, ogDescriptionMaxRunes)
+	}
+}
+
+// TestSummarise_ShortMultibyteReturnedWhole covers the under-cap path with 2-byte
+// accented runes: the proposal is returned verbatim, untruncated and rune-safe.
+func TestSummarise_ShortMultibyteReturnedWhole(t *testing.T) {
+	t.Parallel()
+	in := "Réfection d'une façade au cœur du café"
+	if got := summarise(in, "Café Royal"); got != in {
+		t.Errorf("summary = %q, want the input returned verbatim", got)
+	}
+}
+
+// TestSummarise_EmptyDescriptionWithPlace pins the place-based fallback sentence
+// used when the record carries no proposal text but does have an address/area.
+func TestSummarise_EmptyDescriptionWithPlace(t *testing.T) {
+	t.Parallel()
+	got := summarise("   ", "10 Downing Street, London")
+	want := "Planning application at 10 Downing Street, London. View the details on Town Crier."
+	if got != want {
+		t.Errorf("summary = %q, want %q", got, want)
+	}
+}
+
+// TestSummarise_EmptyDescriptionNoPlace pins the sane default when neither a
+// proposal nor a place is available.
+func TestSummarise_EmptyDescriptionNoPlace(t *testing.T) {
+	t.Parallel()
+	got := summarise("", "")
+	want := "View this planning application on Town Crier."
+	if got != want {
+		t.Errorf("summary = %q, want %q", got, want)
+	}
+}

--- a/web/scripts/lib/__tests__/slug.test.mjs
+++ b/web/scripts/lib/__tests__/slug.test.mjs
@@ -1,5 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 import { slugify } from '../slug.mjs';
+
+const FIXTURE_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  'slug-fixtures.json',
+);
+const fixtures = JSON.parse(readFileSync(FIXTURE_PATH, 'utf-8'));
 
 describe('slugify', () => {
   it('lowercases and hyphenates a multi-word authority name', () => {
@@ -28,5 +38,19 @@ describe('slugify', () => {
     expect(slugify('Bro Morgannwg / Vale of Glamorgan')).toBe(
       'bro-morgannwg-vale-of-glamorgan',
     );
+  });
+});
+
+// Shared test-vector fixture. The SAME slug-fixtures.json is read by the Go
+// parity test so the two slugify implementations can never drift. Every
+// `expected` value is ground-truth: it is exactly what slug.mjs's slugify()
+// returns for the corresponding `input` (verified by running slug.mjs).
+describe('slugify parity fixture', () => {
+  it('has at least one vector', () => {
+    expect(fixtures.length).toBeGreaterThan(0);
+  });
+
+  it.each(fixtures)('slugify($input) === $expected', ({ input, expected }) => {
+    expect(slugify(input)).toBe(expected);
   });
 });

--- a/web/scripts/lib/slug-fixtures.json
+++ b/web/scripts/lib/slug-fixtures.json
@@ -1,0 +1,42 @@
+[
+  {
+    "input": "Basingstoke and Deane",
+    "expected": "basingstoke-and-deane"
+  },
+  {
+    "input": "Bristol, City of",
+    "expected": "bristol-city-of"
+  },
+  {
+    "input": "King's Lynn and West Norfolk",
+    "expected": "kings-lynn-and-west-norfolk"
+  },
+  {
+    "input": "Hammersmith & Fulham",
+    "expected": "hammersmith-and-fulham"
+  },
+  {
+    "input": "  Test   Name  ",
+    "expected": "test-name"
+  },
+  {
+    "input": "Bro Morgannwg / Vale of Glamorgan",
+    "expected": "bro-morgannwg-vale-of-glamorgan"
+  },
+  {
+    "input": "King’s Lynn",
+    "expected": "kings-lynn"
+  },
+  {
+    "input": "Stratford-on-Avon",
+    "expected": "stratford-on-avon"
+  },
+  {
+    "input": "Test 123",
+    "expected": "test-123"
+  },
+  {
+    "input": "-- Foo --",
+    "expected": "foo"
+  }
+]

--- a/web/scripts/lib/slug-fixtures.json
+++ b/web/scripts/lib/slug-fixtures.json
@@ -38,5 +38,21 @@
   {
     "input": "-- Foo --",
     "expected": "foo"
+  },
+  {
+    "input": "Café Royal",
+    "expected": "caf-royal"
+  },
+  {
+    "input": "Málaga & Sevilla",
+    "expected": "m-laga-and-sevilla"
+  },
+  {
+    "input": "東京 Tokyo",
+    "expected": "tokyo"
+  },
+  {
+    "input": "北京市",
+    "expected": ""
   }
 ]


### PR DESCRIPTION
Slice 1 (tracer) of the public shareable planning-application page (#738). Anonymous, server-rendered HTML per application, proving DB read → template → unfurl end to end. All additive; no existing endpoint behaviour changes.

## Changes
- **authorities:** canonical Go `Slugify` (byte-equal port of `web/scripts/lib/slug.mjs`) + slug↔area-id resolver (`SlugToAreaID`/`SlugForAreaID`). Guarded against drift by a shared `slug-fixtures.json` read by both a Go test and the JS test (incl. non-ASCII vectors).
- **applications:** additive `authoritySlug` field on the single-application detail response (`json:",omitempty"`, set only in the detail/by-slug handlers so saved-application and watch-zone responses stay byte-identical); new anonymous `GET /v1/applications/by-slug/{authoritySlug}/{ref...}` returning the same body as the authed by-id read.
- **sharepage (new pkg):** anonymous `GET /a/{authoritySlug}/{ref...}` server-rendered HTML via `html/template` — `og:`/`twitter:` (summary_large_image)/`canonical`/`robots=noindex,follow`/`apple-itunes-app` (6764095657) meta; visible page (address, ref, status chip, proposal, key dates, PlanIt + council links with `rel="nofollow noopener noreferrer"`, ADR-0006 attribution) and the sticky CTA "Download the app for instant notifications about planning updates". Branded 404 (`no-store`) on unknown slug/ref; 200 carries `Cache-Control: public, max-age=3600`. `og:image` is a branded placeholder this slice (real OSM map card is Slice 2).
- **wiring:** both new routes registered and added to `anonymousPatterns`; by-id read stays authed.

## Not in this slice (per #738)
OSM map `og:image` (Slice 2), `share.towncrierapp.uk` + Cloudflare + AASA (Slice 3), iOS share button (Slice 4), SEO card links (Slice 5). Canonical/`og:url` already point at the future `https://share.towncrierapp.uk` origin though served on the API host for now.

## Verification
- Reviewed by three independent agents (correctness, silent-failure, test coverage): no bugs, no security hole; hardening applied (fallback warn-log, URL/href-escaping + end-to-end anonymous-wiring + `summarise` tests, `noreferrer`, non-ASCII parity vectors).
- Gates green: `go build`/`vet`/`gofmt` clean, `golangci-lint` 0 issues, `go test -race` 1274 pass; JS slug parity 21 pass.
- Local end-to-end against Postgres + a real browser render: 200 HTML with all meta, branded 404s, anonymous by-slug JSON (`authoritySlug: croydon`), XSS non-breakout, sticky CTA rendered.

Bead: tc-it1z.

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)