### PR TITLE
tc list-users: dynamic widths, created-at sort, + watch-zone/last-active/notification columns

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -73,11 +73,13 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	d.dispatch.ServeHTTP(w, r)
 }
 
-// notifUnreadReader is the narrowest consumer-side interface the notification
-// store wired into NearbyRoutes must satisfy. *notifications.PostgresStore (which
-// satisfies the full notifications.Store) satisfies it structurally.
-type notifUnreadReader interface {
+// notifStoreReader is the consumer-side slice of the notification store the
+// router wires into two places: the latest-unread lookup for NearbyRoutes and
+// the batched per-user tally for the admin user list. *notifications.PostgresStore
+// (which satisfies the full notifications.Store) satisfies it structurally.
+type notifStoreReader interface {
 	GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string) (map[string]notifications.LatestUnread, error)
+	CountsByUsers(ctx context.Context, userIDs []string) (map[string]notifications.NotificationCounts, error)
 }
 
 // newRouter wires the feature routes onto a mux and wraps it in the production
@@ -113,7 +115,7 @@ func newRouter(
 	exportReaders profiles.ExportReaders,
 	deviceStore devicetokens.Store,
 	stateStore notificationstate.Store,
-	notifStore notifUnreadReader,
+	notifStore notifStoreReader,
 	watchZoneStore watchzones.Store,
 	appStore applications.Store,
 	savedStore savedapplications.Store,
@@ -223,7 +225,7 @@ func newRouter(
 		// Admin endpoints are anonymous to Auth0 and gated by the X-Admin-Key. The
 		// cross-user admin store backs grant/list; the offer-code store backs
 		// generate.
-		admin.Routes(mux, adminKey, adminStore, auth0, offerStore, offercodes.NewRandomGenerator(), time.Now, logger)
+		admin.Routes(mux, adminKey, adminStore, notifStore, auth0, offerStore, offercodes.NewRandomGenerator(), time.Now, logger)
 	}
 	if store != nil && adminStore != nil && jwsVerifier != nil && appleNotifStore != nil {
 		// Subscriptions: verify (authed, by user id via the profile store) and the

--- a/api-go/internal/admin/handler.go
+++ b/api-go/internal/admin/handler.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/httputil"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
@@ -28,6 +29,12 @@ type tierSync interface {
 	UpdateSubscriptionTier(ctx context.Context, userID, tier string) error
 }
 
+// notificationCounts is the batched notification tally the user list enriches
+// each row with. *notifications.PostgresStore satisfies it.
+type notificationCounts interface {
+	CountsByUsers(ctx context.Context, userIDs []string) (map[string]notifications.NotificationCounts, error)
+}
+
 // offerCodeStore is the offer-code writer the generate endpoint uses.
 // offercodes.PostgresStore satisfies it.
 type offerCodeStore interface {
@@ -41,19 +48,20 @@ type codeGenerator interface {
 }
 
 type handler struct {
-	profiles  profileAdminStore
-	auth0     tierSync
-	codes     offerCodeStore
-	generator codeGenerator
-	now       func() time.Time
-	logger    *slog.Logger
+	profiles    profileAdminStore
+	notifCounts notificationCounts
+	auth0       tierSync
+	codes       offerCodeStore
+	generator   codeGenerator
+	now         func() time.Time
+	logger      *slog.Logger
 }
 
 // Routes registers the admin endpoints on mux, each gated by the shared admin
 // key. The routes are anonymous to Auth0 (the caller carries no bearer token),
 // so the key gate is their only authentication.
-func Routes(mux *http.ServeMux, adminKey string, profileStore profileAdminStore, auth0 tierSync, codes offerCodeStore, generator codeGenerator, now func() time.Time, logger *slog.Logger) {
-	h := &handler{profiles: profileStore, auth0: auth0, codes: codes, generator: generator, now: now, logger: logger}
+func Routes(mux *http.ServeMux, adminKey string, profileStore profileAdminStore, notifCounts notificationCounts, auth0 tierSync, codes offerCodeStore, generator codeGenerator, now func() time.Time, logger *slog.Logger) {
+	h := &handler{profiles: profileStore, notifCounts: notifCounts, auth0: auth0, codes: codes, generator: generator, now: now, logger: logger}
 	mux.HandleFunc("PUT /v1/admin/subscriptions", requireAdminKey(adminKey, h.grantSubscription))
 	mux.HandleFunc("GET /v1/admin/users", requireAdminKey(adminKey, h.listUsers))
 	mux.HandleFunc("POST /v1/admin/offer-codes", requireAdminKey(adminKey, h.generateOfferCodes))

--- a/api-go/internal/admin/handler_test.go
+++ b/api-go/internal/admin/handler_test.go
@@ -9,9 +9,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
+
+// fakeNotifCounts is a hand-written notificationCounts double: it records the
+// user ids it was asked about and returns pre-configured tallies.
+type fakeNotifCounts struct {
+	counts map[string]notifications.NotificationCounts
+	gotIDs []string
+}
+
+func (f *fakeNotifCounts) CountsByUsers(_ context.Context, userIDs []string) (map[string]notifications.NotificationCounts, error) {
+	f.gotIDs = userIDs
+	return f.counts, nil
+}
 
 type fakeAdminStore struct {
 	byEmail map[string]*profiles.UserProfile
@@ -74,14 +87,15 @@ func (f *fakeGenerator) Generate() (string, error) {
 	return c, nil
 }
 
-func newTestHandler(store profileAdminStore, auth0 tierSync, codes offerCodeStore, gen codeGenerator, now time.Time) *handler {
+func newTestHandler(store profileAdminStore, notifCounts notificationCounts, auth0 tierSync, codes offerCodeStore, gen codeGenerator, now time.Time) *handler {
 	return &handler{
-		profiles:  store,
-		auth0:     auth0,
-		codes:     codes,
-		generator: gen,
-		now:       func() time.Time { return now },
-		logger:    slog.New(slog.DiscardHandler),
+		profiles:    store,
+		notifCounts: notifCounts,
+		auth0:       auth0,
+		codes:       codes,
+		generator:   gen,
+		now:         func() time.Time { return now },
+		logger:      slog.New(slog.DiscardHandler),
 	}
 }
 
@@ -113,7 +127,7 @@ func TestGrant_ActivatesPaidTier(t *testing.T) {
 
 	store := &fakeAdminStore{byEmail: map[string]*profiles.UserProfile{"u@example.com": freeProfile(t)}}
 	auth0 := &fakeTierSync{}
-	h := newTestHandler(store, auth0, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	h := newTestHandler(store, &fakeNotifCounts{}, auth0, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
 
 	rec := serve(t, h.grantSubscription, http.MethodPut, "/v1/admin/subscriptions", `{"email":"u@example.com","tier":"Pro"}`)
 
@@ -140,7 +154,7 @@ func TestGrant_FreeExpiresSubscription(t *testing.T) {
 	paid := freeProfile(t)
 	paid.ActivateSubscription(profiles.TierPro, time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC))
 	store := &fakeAdminStore{byEmail: map[string]*profiles.UserProfile{"u@example.com": paid}}
-	h := newTestHandler(store, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	h := newTestHandler(store, &fakeNotifCounts{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
 
 	rec := serve(t, h.grantSubscription, http.MethodPut, "/v1/admin/subscriptions", `{"email":"u@example.com","tier":"Free"}`)
 
@@ -159,7 +173,7 @@ func TestGrant_EmailNotFound(t *testing.T) {
 	t.Parallel()
 
 	store := &fakeAdminStore{byEmail: map[string]*profiles.UserProfile{}}
-	h := newTestHandler(store, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	h := newTestHandler(store, &fakeNotifCounts{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
 
 	rec := serve(t, h.grantSubscription, http.MethodPut, "/v1/admin/subscriptions", `{"email":"missing@example.com","tier":"Pro"}`)
 
@@ -175,7 +189,7 @@ func TestGrant_InvalidTier(t *testing.T) {
 	t.Parallel()
 
 	store := &fakeAdminStore{byEmail: map[string]*profiles.UserProfile{"u@example.com": freeProfile(t)}}
-	h := newTestHandler(store, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	h := newTestHandler(store, &fakeNotifCounts{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
 
 	rec := serve(t, h.grantSubscription, http.MethodPut, "/v1/admin/subscriptions", `{"email":"u@example.com","tier":"Bronze"}`)
 
@@ -187,23 +201,40 @@ func TestGrant_InvalidTier(t *testing.T) {
 func TestListUsers_ReturnsPage(t *testing.T) {
 	t.Parallel()
 
-	p1 := freeProfile(t)
-	p2, _ := profiles.NewProfile("auth0|u2", "b@example.com", time.Now())
+	// p1: has a watch-zone count and 2 unread of 57 notifications.
+	created1 := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	p1, _ := profiles.NewProfile("auth0|u1", "u@example.com", created1)
+	wz := 2
+	p1.WatchZoneCount = &wz
+	// p2: legacy nil watch-zone count and no notifications (absent from counts).
+	created2 := time.Date(2026, 2, 2, 10, 0, 0, 0, time.UTC)
+	p2, _ := profiles.NewProfile("auth0|u2", "b@example.com", created2)
 	p2.Tier = profiles.TierPro
+
 	store := &fakeAdminStore{page: profiles.Page{Profiles: []*profiles.UserProfile{p1, p2}, ContinuationToken: "next"}}
-	h := newTestHandler(store, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	counts := &fakeNotifCounts{counts: map[string]notifications.NotificationCounts{
+		"auth0|u1": {Total: 57, Unread: 2},
+	}}
+	h := newTestHandler(store, counts, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
 
 	rec := serve(t, h.listUsers, http.MethodGet, "/v1/admin/users?search=example&pageSize=50", "")
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
 	}
-	want := `{"items":[{"userId":"auth0|u1","email":"u@example.com","tier":"Free"},{"userId":"auth0|u2","email":"b@example.com","tier":"Pro"}],"continuationToken":"next"}`
+	want := `{"items":[` +
+		`{"userId":"auth0|u1","email":"u@example.com","tier":"Free","watchZoneCount":2,"createdAt":"2026-01-01T09:00:00Z","lastActiveAt":"2026-01-01T09:00:00Z","notificationTotal":57,"notificationUnread":2},` +
+		`{"userId":"auth0|u2","email":"b@example.com","tier":"Pro","watchZoneCount":null,"createdAt":"2026-02-02T10:00:00Z","lastActiveAt":"2026-02-02T10:00:00Z","notificationTotal":0,"notificationUnread":0}` +
+		`],"continuationToken":"next"}`
 	if got := rec.Body.String(); got != want {
 		t.Errorf("body =\n  %s\nwant\n  %s", got, want)
 	}
 	if store.gotSearch != "example" || store.gotPageSize != 50 {
 		t.Errorf("forwarded search=%q pageSize=%d", store.gotSearch, store.gotPageSize)
+	}
+	// The handler batches the whole page's user ids into a single counts lookup.
+	if len(counts.gotIDs) != 2 || counts.gotIDs[0] != "auth0|u1" || counts.gotIDs[1] != "auth0|u2" {
+		t.Errorf("counts lookup ids = %v, want [auth0|u1 auth0|u2]", counts.gotIDs)
 	}
 }
 
@@ -211,7 +242,8 @@ func TestListUsers_DefaultsAndNullToken(t *testing.T) {
 	t.Parallel()
 
 	store := &fakeAdminStore{page: profiles.Page{Profiles: nil, ContinuationToken: ""}}
-	h := newTestHandler(store, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	counts := &fakeNotifCounts{}
+	h := newTestHandler(store, counts, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
 
 	rec := serve(t, h.listUsers, http.MethodGet, "/v1/admin/users", "")
 
@@ -224,12 +256,16 @@ func TestListUsers_DefaultsAndNullToken(t *testing.T) {
 	if store.gotPageSize != 20 {
 		t.Errorf("default pageSize = %d, want 20", store.gotPageSize)
 	}
+	// An empty page must not trigger a counts lookup at all.
+	if counts.gotIDs != nil {
+		t.Errorf("empty page issued a counts lookup for %v", counts.gotIDs)
+	}
 }
 
 func TestListUsers_InvalidPageSize(t *testing.T) {
 	t.Parallel()
 
-	h := newTestHandler(&fakeAdminStore{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	h := newTestHandler(&fakeAdminStore{}, &fakeNotifCounts{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
 	rec := serve(t, h.listUsers, http.MethodGet, "/v1/admin/users?pageSize=abc", "")
 	if rec.Code != http.StatusBadRequest {
 		t.Errorf("status = %d, want 400", rec.Code)
@@ -242,7 +278,7 @@ func TestGenerate_HappyPath(t *testing.T) {
 	offerStore := &fakeOfferStore{}
 	gen := &fakeGenerator{codes: []string{"ABCDEFGHJKMN", "NPQRSTVWXYZ0"}}
 	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
-	h := newTestHandler(&fakeAdminStore{}, &fakeTierSync{}, offerStore, gen, now)
+	h := newTestHandler(&fakeAdminStore{}, &fakeNotifCounts{}, &fakeTierSync{}, offerStore, gen, now)
 
 	rec := serve(t, h.generateOfferCodes, http.MethodPost, "/v1/admin/offer-codes", `{"count":2,"tier":"Pro","durationDays":30}`)
 
@@ -277,7 +313,7 @@ func TestGenerate_ValidationErrors(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			h := newTestHandler(&fakeAdminStore{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+			h := newTestHandler(&fakeAdminStore{}, &fakeNotifCounts{}, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
 			rec := serve(t, h.generateOfferCodes, http.MethodPost, "/v1/admin/offer-codes", tc.body)
 			if rec.Code != http.StatusBadRequest {
 				t.Fatalf("status = %d, want 400", rec.Code)

--- a/api-go/internal/admin/users.go
+++ b/api-go/internal/admin/users.go
@@ -3,15 +3,24 @@ package admin
 import (
 	"net/http"
 	"strconv"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
 
 // defaultPageSize is the default page size for the admin users list.
 const defaultPageSize = 20
 
 type listItem struct {
-	UserID string  `json:"userId"`
-	Email  *string `json:"email"`
-	Tier   string  `json:"tier"`
+	UserID             string  `json:"userId"`
+	Email              *string `json:"email"`
+	Tier               string  `json:"tier"`
+	WatchZoneCount     *int    `json:"watchZoneCount"`
+	CreatedAt          string  `json:"createdAt"`    // RFC3339
+	LastActiveAt       string  `json:"lastActiveAt"` // RFC3339
+	NotificationTotal  int     `json:"notificationTotal"`
+	NotificationUnread int     `json:"notificationUnread"`
 }
 
 // listResult is the response shape for GET /v1/admin/users: { items, continuationToken }.
@@ -44,9 +53,28 @@ func (h *handler) listUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enrich each row with its notification tally in a single batched lookup
+	// after List returns, so the profile query stays purely about profiles.
+	// Users absent from the tally default to {0, 0} via the map zero value.
+	counts, err := h.notificationCountsFor(r, page)
+	if err != nil {
+		h.serverError(w, r, "list users: counts", err)
+		return
+	}
+
 	items := make([]listItem, 0, len(page.Profiles))
 	for _, p := range page.Profiles {
-		items = append(items, listItem{UserID: p.UserID, Email: p.Email, Tier: p.Tier.String()})
+		nc := counts[p.UserID]
+		items = append(items, listItem{
+			UserID:             p.UserID,
+			Email:              p.Email,
+			Tier:               p.Tier.String(),
+			WatchZoneCount:     p.WatchZoneCount,
+			CreatedAt:          p.CreatedAt.Format(time.RFC3339),
+			LastActiveAt:       p.LastActiveAt.Format(time.RFC3339),
+			NotificationTotal:  nc.Total,
+			NotificationUnread: nc.Unread,
+		})
 	}
 	var token *string
 	if page.ContinuationToken != "" {
@@ -54,4 +82,18 @@ func (h *handler) listUsers(w http.ResponseWriter, r *http.Request) {
 		token = &t
 	}
 	h.writeJSON(r, w, listResult{Items: items, ContinuationToken: token})
+}
+
+// notificationCountsFor returns the per-user notification tally for the page in
+// a single batched lookup. An empty page (or an unwired counts store) skips the
+// query and returns an empty map, leaving every row's counts at {0, 0}.
+func (h *handler) notificationCountsFor(r *http.Request, page profiles.Page) (map[string]notifications.NotificationCounts, error) {
+	if h.notifCounts == nil || len(page.Profiles) == 0 {
+		return map[string]notifications.NotificationCounts{}, nil
+	}
+	ids := make([]string, 0, len(page.Profiles))
+	for _, p := range page.Profiles {
+		ids = append(ids, p.UserID)
+	}
+	return h.notifCounts.CountsByUsers(r.Context(), ids)
 }

--- a/api-go/internal/notifications/notification.go
+++ b/api-go/internal/notifications/notification.go
@@ -20,6 +20,15 @@ const (
 	EventDecisionUpdate EventType = "DecisionUpdate"
 )
 
+// NotificationCounts is a per-user notification tally: the total number of
+// notifications and how many are still unread (read_at IS NULL). It backs the
+// admin user list's "unread/total" column and is deliberately kept off
+// UserProfile — it is a list-view aggregate, not a profile property.
+type NotificationCounts struct {
+	Total  int
+	Unread int
+}
+
 // LatestUnread is the per-application unread descriptor surfaced on each row of
 // the applications-by-zone result: the event, the optional PlanIt decision
 // string (decision updates only), and when the notification was raised.

--- a/api-go/internal/notifications/store_postgres.go
+++ b/api-go/internal/notifications/store_postgres.go
@@ -352,6 +352,53 @@ func (s *PostgresStore) DeleteAllByUserID(ctx context.Context, userID string) er
 	return nil
 }
 
+// pgCountsByUsersQuery tallies each user's total and unread (read_at IS NULL)
+// notification counts in one grouped pass. Users with no notifications produce
+// no row — the caller defaults them to {0, 0}.
+const pgCountsByUsersQuery = "SELECT user_id, " +
+	"count(*) AS total, " +
+	"count(*) FILTER (WHERE read_at IS NULL) AS unread " +
+	"FROM notifications WHERE user_id = ANY($1) GROUP BY user_id"
+
+// userCountRow is the scan target for CountsByUsers: (user_id, total, unread).
+type userCountRow struct {
+	userID string
+	total  int
+	unread int
+}
+
+func scanUserCountRow(row pgx.CollectableRow) (userCountRow, error) {
+	var r userCountRow
+	if err := row.Scan(&r.userID, &r.total, &r.unread); err != nil {
+		return userCountRow{}, err
+	}
+	return r, nil
+}
+
+// CountsByUsers returns, for each user id that has at least one notification,
+// the total and unread counts — in a single grouped query instead of N per-user
+// round trips. Users absent from the result are absent from the map; the caller
+// treats a missing key as {0, 0} via the map zero value. An empty user set
+// returns an empty map without issuing a query.
+func (s *PostgresStore) CountsByUsers(ctx context.Context, userIDs []string) (map[string]NotificationCounts, error) {
+	counts := make(map[string]NotificationCounts, len(userIDs))
+	if len(userIDs) == 0 {
+		return counts, nil
+	}
+	rows, err := s.db.Query(ctx, pgCountsByUsersQuery, userIDs)
+	if err != nil {
+		return nil, fmt.Errorf("query notification counts: %w", err)
+	}
+	tallies, err := pgx.CollectRows(rows, scanUserCountRow)
+	if err != nil {
+		return nil, fmt.Errorf("scan notification counts: %w", err)
+	}
+	for _, r := range tallies {
+		counts[r.userID] = NotificationCounts{Total: r.total, Unread: r.unread}
+	}
+	return counts, nil
+}
+
 const pgPurgeOlderThanQuery = "DELETE FROM notifications WHERE created_at < $1"
 
 // PurgeOlderThan deletes every notification created before cutoff and returns

--- a/api-go/internal/notifications/store_postgres_integration_test.go
+++ b/api-go/internal/notifications/store_postgres_integration_test.go
@@ -367,3 +367,44 @@ func TestIntegration_Notifications_PurgeOlderThan(t *testing.T) {
 		t.Errorf("post-purge rows: got %+v, want only n-recent", all)
 	}
 }
+
+// TestIntegration_Notifications_CountsByUsers exercises the grouped
+// count(*) / count(*) FILTER (WHERE read_at IS NULL) tally against a real DB —
+// the read_at FILTER is precisely the SQL a hand-written fake cannot honestly
+// model. user-1 has 3 rows (1 read, 2 unread); user-2 has 1 unread row; user-3
+// is queried but has no rows and must be absent from the result.
+func TestIntegration_Notifications_CountsByUsers(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	seed := []DigestNotification{
+		intNotif("u1-a", "user-1", "uid-A", EventNewApplication, base),
+		intNotif("u1-b", "user-1", "uid-B", EventNewApplication, base.Add(time.Hour)),
+		intNotif("u1-c", "user-1", "uid-C", EventNewApplication, base.Add(2*time.Hour)),
+		intNotif("u2-a", "user-2", "uid-A", EventNewApplication, base),
+	}
+	for _, n := range seed {
+		if err := s.Create(ctx, n); err != nil {
+			t.Fatalf("Create %s: %v", n.ID, err)
+		}
+	}
+	// Mark one of user-1's notifications read.
+	if _, err := s.db.Exec(ctx, "UPDATE notifications SET read_at = $1 WHERE id = 'u1-a'", base.Add(3*time.Hour)); err != nil {
+		t.Fatalf("mark read: %v", err)
+	}
+
+	got, err := s.CountsByUsers(ctx, []string{"user-1", "user-2", "user-3"})
+	if err != nil {
+		t.Fatalf("CountsByUsers: %v", err)
+	}
+	if got["user-1"] != (NotificationCounts{Total: 3, Unread: 2}) {
+		t.Errorf("user-1: got %+v, want {3 2}", got["user-1"])
+	}
+	if got["user-2"] != (NotificationCounts{Total: 1, Unread: 1}) {
+		t.Errorf("user-2: got %+v, want {1 1}", got["user-2"])
+	}
+	if _, ok := got["user-3"]; ok {
+		t.Errorf("user-3 has no notifications and must be absent, got %+v", got["user-3"])
+	}
+}

--- a/api-go/internal/notifications/store_postgres_test.go
+++ b/api-go/internal/notifications/store_postgres_test.go
@@ -384,6 +384,71 @@ func TestPostgresStore_UserIDsWithUnsentEmails_PropagatesQueryError(t *testing.T
 	}
 }
 
+// --- CountsByUsers ---
+
+func TestPostgresStore_CountsByUsers_EmptyUsers(t *testing.T) {
+	t.Parallel()
+	q := &fakeQuerier{}
+	s := NewPostgresStore(q)
+
+	got, err := s.CountsByUsers(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("empty users: got %v, want empty non-nil map", got)
+	}
+	if len(q.recordedSQL) != 0 {
+		t.Error("empty users must not issue any SQL")
+	}
+}
+
+func TestPostgresStore_CountsByUsers_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("counts boom")
+	q := &fakeQuerier{queryResponses: []queryResponse{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	_, err := s.CountsByUsers(context.Background(), []string{"user-1"})
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+func TestPostgresStore_CountsByUsers_MapsPerUser(t *testing.T) {
+	t.Parallel()
+	// The GROUP BY query returns one row per user that HAS notifications.
+	// user-C is queried but absent from the result — the caller defaults it to
+	// {0, 0} via the Go map zero value, so it must NOT appear in the map.
+	q := &fakeQuerier{
+		queryResponses: []queryResponse{
+			{rows: newFakeRows([][]any{
+				// user_id, total, unread
+				{"user-A", 57, 2},
+				{"user-B", 3, 0},
+			})},
+		},
+	}
+	s := NewPostgresStore(q)
+
+	got, err := s.CountsByUsers(context.Background(), []string{"user-A", "user-B", "user-C"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("map size: got %d, want 2 (absent users omitted)", len(got))
+	}
+	if got["user-A"] != (NotificationCounts{Total: 57, Unread: 2}) {
+		t.Errorf("user-A: got %+v, want {57 2}", got["user-A"])
+	}
+	if got["user-B"] != (NotificationCounts{Total: 3, Unread: 0}) {
+		t.Errorf("user-B: got %+v, want {3 0}", got["user-B"])
+	}
+	if _, ok := got["user-C"]; ok {
+		t.Errorf("user-C must be absent (defaults to zero at the call site)")
+	}
+}
+
 // --- MarkEmailSent ---
 
 func TestPostgresStore_MarkEmailSent_PropagatesExecError(t *testing.T) {

--- a/api-go/internal/platform/postgres/migrations/0016_users_created_at.sql
+++ b/api-go/internal/platform/postgres/migrations/0016_users_created_at.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+
+-- Add a creation timestamp to users so the admin user list can sort oldest-first
+-- (issue #729). The column is owned entirely by the database: the DEFAULT
+-- CURRENT_TIMESTAMP stamps it on insert and Go never writes it (the shared
+-- upsert query is deliberately left untouched). Existing rows get the migration
+-- timestamp — not their real sign-up time, which Postgres never captured — which
+-- is acceptable: the compound (created_at, user_id) sort has user_id as the
+-- essential tiebreak so the backfilled rows still order deterministically.
+ALTER TABLE users ADD COLUMN created_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- +goose Down
+ALTER TABLE users DROP COLUMN IF EXISTS created_at;

--- a/api-go/internal/profiles/admin_store_postgres.go
+++ b/api-go/internal/profiles/admin_store_postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -168,58 +169,77 @@ func (s *PostgresAdminStore) Save(ctx context.Context, p *UserProfile) error {
 	return nil
 }
 
-// listCursor is the keyset pagination cursor for List. It encodes the last
-// user_id seen on the previous page as a base64url string so it is opaque to
-// callers — matching the Cosmos continuation-token contract.
+// listCursor is the keyset pagination cursor for List. It carries the
+// (created_at, user_id) pair of the last row on the previous page — the same
+// compound key List orders by — so paging is stable even when many rows share
+// a created_at (the migration backfill gives every pre-existing row the same
+// timestamp, so user_id is the essential tiebreak).
 type listCursor struct {
+	CreatedAt  time.Time
 	LastUserID string
 }
 
-func encodeListCursor(lastUserID string) string {
-	return base64.RawURLEncoding.EncodeToString([]byte(lastUserID))
+// encodeListCursor renders the cursor as base64url("<createdAt RFC3339Nano>|<userID>")
+// so it is opaque to callers. created_at is encoded first: it never contains a
+// "|", so decodeListCursor can split on the first separator and keep any "|" in
+// the user id (auth0|..., apple|...) intact.
+func encodeListCursor(createdAt time.Time, lastUserID string) string {
+	raw := createdAt.UTC().Format(time.RFC3339Nano) + "|" + lastUserID
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
 }
 
-func decodeListCursor(token string) (string, error) {
+func decodeListCursor(token string) (listCursor, error) {
 	b, err := base64.RawURLEncoding.DecodeString(token)
 	if err != nil {
-		return "", fmt.Errorf("decode list cursor: %w", err)
+		return listCursor{}, fmt.Errorf("decode list cursor: %w", err)
 	}
-	return string(b), nil
+	parts := strings.SplitN(string(b), "|", 2)
+	if len(parts) != 2 {
+		return listCursor{}, fmt.Errorf("decode list cursor: malformed cursor %q", string(b))
+	}
+	createdAt, err := time.Parse(time.RFC3339Nano, parts[0])
+	if err != nil {
+		return listCursor{}, fmt.Errorf("decode list cursor: parse created_at: %w", err)
+	}
+	return listCursor{CreatedAt: createdAt, LastUserID: parts[1]}, nil
 }
 
-// List returns one page of profiles ordered by user_id, optionally filtered
-// by a case-insensitive email substring. An empty continuationToken starts
-// from the first page; a non-empty token resumes after the last user_id from
-// the previous page. Mirrors AdminStore.List's contract (Page + opaque token).
+// List returns one page of profiles ordered by (created_at, user_id) — oldest
+// created first, so newly-created users naturally appear at the bottom of the
+// list — optionally filtered by a case-insensitive email substring. An empty
+// continuationToken starts from the first page; a non-empty token resumes after
+// the (created_at, user_id) pair of the previous page's last row via a compound
+// keyset guard. Mirrors AdminStore.List's contract (Page + opaque token).
 func (s *PostgresAdminStore) List(ctx context.Context, emailSearch string, pageSize int, continuationToken string) (Page, error) {
-	var lastUserID string
-	if continuationToken != "" {
+	var cursor listCursor
+	hasCursor := continuationToken != ""
+	if hasCursor {
 		var err error
-		lastUserID, err = decodeListCursor(continuationToken)
+		cursor, err = decodeListCursor(continuationToken)
 		if err != nil {
 			return Page{}, fmt.Errorf("list profiles: %w", err)
 		}
 	}
 
-	// Build the WHERE clause from the two optional predicates.
-	// We always add at least the cursor guard when paging; on the first page
-	// (empty cursor) we still ORDER BY user_id so the cursor is meaningful.
+	// All four branches order by the compound (created_at, user_id) key; the two
+	// cursor branches add the row-value keyset guard, shifting param numbering.
+	const orderLimit = " ORDER BY created_at, user_id LIMIT "
 	var (
 		sql  string
 		args []any
 	)
 	switch {
-	case emailSearch != "" && lastUserID != "":
-		sql = pgAdminSelectCols + "WHERE email ILIKE $1 AND user_id > $2 ORDER BY user_id LIMIT $3"
-		args = []any{"%" + emailSearch + "%", lastUserID, pageSize}
+	case emailSearch != "" && hasCursor:
+		sql = pgAdminSelectCols + "WHERE email ILIKE $1 AND (created_at, user_id) > ($2, $3)" + orderLimit + "$4"
+		args = []any{"%" + emailSearch + "%", cursor.CreatedAt, cursor.LastUserID, pageSize}
 	case emailSearch != "":
-		sql = pgAdminSelectCols + "WHERE email ILIKE $1 ORDER BY user_id LIMIT $2"
+		sql = pgAdminSelectCols + "WHERE email ILIKE $1" + orderLimit + "$2"
 		args = []any{"%" + emailSearch + "%", pageSize}
-	case lastUserID != "":
-		sql = pgAdminSelectCols + "WHERE user_id > $1 ORDER BY user_id LIMIT $2"
-		args = []any{lastUserID, pageSize}
+	case hasCursor:
+		sql = pgAdminSelectCols + "WHERE (created_at, user_id) > ($1, $2)" + orderLimit + "$3"
+		args = []any{cursor.CreatedAt, cursor.LastUserID, pageSize}
 	default:
-		sql = pgAdminSelectCols + "ORDER BY user_id LIMIT $1"
+		sql = pgAdminSelectCols + strings.TrimPrefix(orderLimit, " ") + "$1"
 		args = []any{pageSize}
 	}
 
@@ -236,7 +256,8 @@ func (s *PostgresAdminStore) List(ctx context.Context, emailSearch string, pageS
 	// page means we reached the end.
 	nextToken := ""
 	if len(profiles) == pageSize {
-		nextToken = encodeListCursor(profiles[len(profiles)-1].UserID)
+		last := profiles[len(profiles)-1]
+		nextToken = encodeListCursor(last.CreatedAt, last.UserID)
 	}
 
 	return Page{Profiles: profiles, ContinuationToken: nextToken}, nil

--- a/api-go/internal/profiles/admin_store_postgres_test.go
+++ b/api-go/internal/profiles/admin_store_postgres_test.go
@@ -1,0 +1,230 @@
+package profiles
+
+import (
+	"context"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// fakeUserRows is a pgx.Rows over pre-baked user-column slices. Each element is
+// a full userSelectCols projection; Scan copies it via fakeScanRow so any
+// column-order drift is caught here as well as in scanUserRow's own test.
+type fakeUserRows struct {
+	rows [][]any
+	idx  int
+	err  error
+}
+
+func (r *fakeUserRows) Next() bool {
+	if r.err != nil {
+		return false
+	}
+	return r.idx < len(r.rows)
+}
+
+func (r *fakeUserRows) Scan(dest ...any) error {
+	sr := &fakeScanRow{cols: r.rows[r.idx]}
+	r.idx++
+	return sr.Scan(dest...)
+}
+
+func (r *fakeUserRows) Close()                                       {}
+func (r *fakeUserRows) Err() error                                   { return r.err }
+func (r *fakeUserRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeUserRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeUserRows) RawValues() [][]byte                          { return nil }
+func (r *fakeUserRows) Values() ([]any, error)                       { return nil, nil }
+func (r *fakeUserRows) Conn() *pgx.Conn                              { return nil }
+
+// recordingQuerier captures the SQL and args of the single Query it serves and
+// returns pre-baked rows. Exec/QueryRow panic — List only uses Query.
+type recordingQuerier struct {
+	sql  string
+	args []any
+	rows *fakeUserRows
+	err  error
+}
+
+func (q *recordingQuerier) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+	panic("recordingQuerier.Exec not expected")
+}
+
+func (q *recordingQuerier) Query(_ context.Context, sql string, args ...any) (pgx.Rows, error) {
+	q.sql = sql
+	q.args = args
+	if q.err != nil {
+		return nil, q.err
+	}
+	return q.rows, nil
+}
+
+func (q *recordingQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	panic("recordingQuerier.QueryRow not expected")
+}
+
+// userRow builds one full userSelectCols projection for a user with the given
+// id and created_at. Order MUST match userSelectCols / scanUserRow.
+func userRow(userID string, createdAt time.Time) []any {
+	return []any{
+		// user_id, email, push_enabled, digest_day,
+		userID, nil, true, 1,
+		// email_digest_enabled, saved_decision_push, saved_decision_email,
+		true, true, true,
+		// zone_preferences::text,
+		"{}",
+		// tier, subscription_expiry, original_transaction_id, grace_period_expiry,
+		"Free", nil, nil, nil,
+		// last_active_at, last_active_at_epoch, created_at, watch_zone_count, version
+		createdAt, createdAt.UnixMilli(), createdAt, nil, 0,
+	}
+}
+
+func TestEncodeDecodeListCursor_RoundTrip(t *testing.T) {
+	t.Parallel()
+	created := time.Date(2026, 1, 2, 3, 4, 5, 123456789, time.UTC)
+	// User IDs legitimately contain "|" (auth0|..., apple|...); the cursor must
+	// survive that since created_at is encoded first and split off with SplitN.
+	token := encodeListCursor(created, "auth0|u1")
+	got, err := decodeListCursor(token)
+	if err != nil {
+		t.Fatalf("decodeListCursor: %v", err)
+	}
+	if !got.CreatedAt.Equal(created) {
+		t.Errorf("CreatedAt: got %v, want %v", got.CreatedAt, created)
+	}
+	if got.LastUserID != "auth0|u1" {
+		t.Errorf("LastUserID: got %q, want auth0|u1", got.LastUserID)
+	}
+}
+
+// encodeRaw base64url-encodes an arbitrary payload so malformed-cursor cases can
+// smuggle a payload that decodeListCursor will reject on the "|" split.
+func encodeRaw(raw string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(raw))
+}
+
+func TestDecodeListCursor_Malformed(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		token string
+	}{
+		{"not base64url", "!!!not-base64!!!"},
+		{"no separator", encodeRaw("justonefield")},
+		{"bad timestamp", encodeRaw("not-a-time|auth0|u1")},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := decodeListCursor(tc.token); err == nil {
+				t.Errorf("decodeListCursor(%q): want error, got nil", tc.token)
+			}
+		})
+	}
+}
+
+func TestList_FirstPage_OrdersByCreatedAtUserID(t *testing.T) {
+	t.Parallel()
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	q := &recordingQuerier{rows: &fakeUserRows{rows: [][]any{userRow("a", t0), userRow("b", t0)}}}
+	store := NewPostgresAdminStore(q)
+
+	page, err := store.List(context.Background(), "", 5, "")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if !strings.Contains(q.sql, "ORDER BY created_at, user_id") {
+		t.Errorf("SQL missing compound ORDER BY: %s", q.sql)
+	}
+	if strings.Contains(q.sql, "(created_at, user_id) >") {
+		t.Errorf("first page must not carry a cursor guard: %s", q.sql)
+	}
+	if len(page.Profiles) != 2 {
+		t.Fatalf("profiles: got %d, want 2", len(page.Profiles))
+	}
+	if page.ContinuationToken != "" {
+		t.Errorf("undersized page must not emit a token, got %q", page.ContinuationToken)
+	}
+}
+
+func TestList_FullPage_EmitsCompoundCursor(t *testing.T) {
+	t.Parallel()
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	t1 := t0.Add(time.Hour)
+	q := &recordingQuerier{rows: &fakeUserRows{rows: [][]any{userRow("a", t0), userRow("b", t1)}}}
+	store := NewPostgresAdminStore(q)
+
+	page, err := store.List(context.Background(), "", 2, "")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if page.ContinuationToken == "" {
+		t.Fatal("full page must emit a continuation token")
+	}
+	cur, err := decodeListCursor(page.ContinuationToken)
+	if err != nil {
+		t.Fatalf("decode emitted token: %v", err)
+	}
+	if !cur.CreatedAt.Equal(t1) || cur.LastUserID != "b" {
+		t.Errorf("cursor = {%v, %q}, want {%v, b}", cur.CreatedAt, cur.LastUserID, t1)
+	}
+}
+
+func TestList_WithCursor_AppliesCompoundGuard(t *testing.T) {
+	t.Parallel()
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	q := &recordingQuerier{rows: &fakeUserRows{}}
+	store := NewPostgresAdminStore(q)
+
+	if _, err := store.List(context.Background(), "", 5, encodeListCursor(t0, "a")); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if !strings.Contains(q.sql, "(created_at, user_id) > ($1, $2)") {
+		t.Errorf("SQL missing compound guard: %s", q.sql)
+	}
+	if !strings.Contains(q.sql, "ORDER BY created_at, user_id") {
+		t.Errorf("SQL missing compound ORDER BY: %s", q.sql)
+	}
+	if len(q.args) != 3 {
+		t.Fatalf("args: got %d, want 3", len(q.args))
+	}
+	if got, ok := q.args[0].(time.Time); !ok || !got.Equal(t0) {
+		t.Errorf("args[0] = %v, want createdAt %v", q.args[0], t0)
+	}
+	if q.args[1] != "a" {
+		t.Errorf("args[1] = %v, want user id \"a\"", q.args[1])
+	}
+}
+
+func TestList_EmailAndCursor_Branch(t *testing.T) {
+	t.Parallel()
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	q := &recordingQuerier{rows: &fakeUserRows{}}
+	store := NewPostgresAdminStore(q)
+
+	if _, err := store.List(context.Background(), "bob", 5, encodeListCursor(t0, "a")); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if !strings.Contains(q.sql, "email ILIKE $1 AND (created_at, user_id) > ($2, $3)") {
+		t.Errorf("SQL missing email + compound guard: %s", q.sql)
+	}
+	if len(q.args) != 4 {
+		t.Fatalf("args: got %d, want 4", len(q.args))
+	}
+	if q.args[0] != "%bob%" {
+		t.Errorf("args[0] = %v, want %%bob%%", q.args[0])
+	}
+}
+
+func TestList_BadCursor_ReturnsError(t *testing.T) {
+	t.Parallel()
+	store := NewPostgresAdminStore(&recordingQuerier{rows: &fakeUserRows{}})
+	if _, err := store.List(context.Background(), "", 5, "!!!not-base64!!!"); err == nil {
+		t.Fatal("List with malformed cursor: want error, got nil")
+	}
+}

--- a/api-go/internal/profiles/profile.go
+++ b/api-go/internal/profiles/profile.go
@@ -154,6 +154,11 @@ type UserProfile struct {
 	OriginalTransactionID *string
 	GracePeriodExpiry     *time.Time
 	LastActiveAt          time.Time
+	// CreatedAt is the profile's creation time. It is owned by the database
+	// (users.created_at DEFAULT CURRENT_TIMESTAMP) and read-only in Go: Save
+	// never writes it. NewProfile stamps it for the in-memory create response,
+	// but the DB DEFAULT is authoritative on persistence.
+	CreatedAt time.Time
 	// WatchZoneCount is the CAS-maintained quota counter. A nil value indicates
 	// a legacy profile written before this field existed; the create path
 	// initialises it on first use by reading the live zone count (lazy-init).
@@ -174,6 +179,7 @@ func NewProfile(userID, email string, now time.Time) (*UserProfile, error) {
 		ZonePreferences: map[string]ZonePreferences{},
 		Tier:            TierFree,
 		LastActiveAt:    now,
+		CreatedAt:       now,
 	}, nil
 }
 

--- a/api-go/internal/profiles/profile_test.go
+++ b/api-go/internal/profiles/profile_test.go
@@ -37,6 +37,12 @@ func TestNewProfile_Defaults(t *testing.T) {
 	if !p.LastActiveAt.Equal(now) {
 		t.Errorf("LastActiveAt: got %v, want %v", p.LastActiveAt, now)
 	}
+	// CreatedAt is set for the in-memory create response. On persistence the DB
+	// DEFAULT is authoritative, but NewProfile stamps it so the create path
+	// returns a populated value.
+	if !p.CreatedAt.Equal(now) {
+		t.Errorf("CreatedAt: got %v, want %v", p.CreatedAt, now)
+	}
 }
 
 func TestNewProfile_RejectsEmptyUserID(t *testing.T) {

--- a/api-go/internal/profiles/store_postgres.go
+++ b/api-go/internal/profiles/store_postgres.go
@@ -97,7 +97,7 @@ const userSelectCols = `user_id, email, push_enabled, digest_day,
 	email_digest_enabled, saved_decision_push, saved_decision_email,
 	zone_preferences::text,
 	tier, subscription_expiry, original_transaction_id, grace_period_expiry,
-	last_active_at, last_active_at_epoch, watch_zone_count, version`
+	last_active_at, last_active_at_epoch, created_at, watch_zone_count, version`
 
 // rowScanner is the minimal interface that both pgx.Row (returned by QueryRow)
 // and pgx.Rows (returned by Query, positioned via Next) satisfy. Defining it
@@ -125,6 +125,7 @@ func scanUserRow(row rowScanner) (*UserProfile, int, error) {
 		gracePeriodExpiry            *time.Time
 		lastActiveAt                 time.Time
 		lastActiveAtEpoch            int64
+		createdAt                    time.Time
 		watchZoneCount               *int
 		version                      int
 	)
@@ -134,7 +135,7 @@ func scanUserRow(row rowScanner) (*UserProfile, int, error) {
 		&emailDigestEnabled, &savedDecisionPush, &savedDecisionEmail,
 		&zonePrefText,
 		&tier, &subscriptionExpiry, &originalTransactionID, &gracePeriodExpiry,
-		&lastActiveAt, &lastActiveAtEpoch, &watchZoneCount, &version,
+		&lastActiveAt, &lastActiveAtEpoch, &createdAt, &watchZoneCount, &version,
 	); err != nil {
 		return nil, 0, err
 	}
@@ -165,6 +166,7 @@ func scanUserRow(row rowScanner) (*UserProfile, int, error) {
 		OriginalTransactionID: originalTransactionID,
 		GracePeriodExpiry:     gracePeriodExpiry,
 		LastActiveAt:          lastActiveAt,
+		CreatedAt:             createdAt,
 		WatchZoneCount:        watchZoneCount,
 	}
 	return p, version, nil

--- a/api-go/internal/profiles/store_postgres_integration_test.go
+++ b/api-go/internal/profiles/store_postgres_integration_test.go
@@ -44,6 +44,12 @@ func assertProfileEqual(t *testing.T, got, want *UserProfile) {
 	g, w := *got, *want
 	g.LastActiveAt = got.LastActiveAt.UTC().Truncate(time.Microsecond)
 	w.LastActiveAt = want.LastActiveAt.UTC().Truncate(time.Microsecond)
+	// CreatedAt is DB-owned (DEFAULT CURRENT_TIMESTAMP): the round-tripped value
+	// is the DB insert time, never the in-memory NewProfile timestamp, so it is
+	// excluded from the field-by-field comparison. Round-trip presence is
+	// asserted separately in SaveGetRoundTrip.
+	g.CreatedAt = time.Time{}
+	w.CreatedAt = time.Time{}
 	if !reflect.DeepEqual(g, w) {
 		t.Errorf("profile mismatch:\n got = %+v\nwant = %+v", g, w)
 	}
@@ -71,6 +77,11 @@ func TestPostgresStore_SaveGetRoundTrip(t *testing.T) {
 		t.Fatalf("Get: %v", err)
 	}
 	assertProfileEqual(t, got, p)
+	// created_at is stamped by the DB DEFAULT on insert (Go never writes it), so
+	// the round-tripped value must be populated.
+	if got.CreatedAt.IsZero() {
+		t.Error("CreatedAt: got zero, want DB-stamped creation time")
+	}
 }
 
 // TestPostgresStore_Get_Miss confirms a missing profile returns ErrNotFound.
@@ -499,8 +510,10 @@ func TestPostgresAdminStore_Save(t *testing.T) {
 }
 
 // TestPostgresAdminStore_List_Pagination verifies that List pages correctly
-// through profiles ordered by user_id using the keyset cursor, and that an
-// email filter narrows results.
+// through profiles ordered by (created_at, user_id) using the compound keyset
+// cursor, and that an email filter narrows results. Every seeded row is forced
+// to share a created_at so the test exercises the user_id tiebreak — the exact
+// state the backfill migration leaves pre-existing rows in.
 func TestPostgresAdminStore_List_Pagination(t *testing.T) {
 	pool := pgtest.New(t)
 	pgtest.Truncate(t, pool, "users")
@@ -515,6 +528,11 @@ func TestPostgresAdminStore_List_Pagination(t *testing.T) {
 		if err := store.Save(ctx, pgProfile(t, id, email)); err != nil {
 			t.Fatalf("Save %s: %v", id, err)
 		}
+	}
+	// Force an identical created_at on every row so ordering falls through to the
+	// user_id tiebreak (the realistic post-backfill state).
+	if _, err := pool.Exec(ctx, "UPDATE users SET created_at = '2020-01-01T00:00:00Z'"); err != nil {
+		t.Fatalf("force created_at: %v", err)
 	}
 
 	// Page 1: first 3.
@@ -539,6 +557,17 @@ func TestPostgresAdminStore_List_Pagination(t *testing.T) {
 	}
 	if page2.ContinuationToken != "" {
 		t.Errorf("page 2: expected empty token (last page), got %q", page2.ContinuationToken)
+	}
+
+	// The compound cursor must page stably in user_id order across the two pages
+	// when created_at ties: list1..list5 with no gaps or repeats.
+	var gotIDs []string
+	for _, p := range append(page1.Profiles, page2.Profiles...) {
+		gotIDs = append(gotIDs, p.UserID)
+	}
+	wantIDs := []string{"auth0|list1", "auth0|list2", "auth0|list3", "auth0|list4", "auth0|list5"}
+	if !reflect.DeepEqual(gotIDs, wantIDs) {
+		t.Errorf("paged order = %v, want %v", gotIDs, wantIDs)
 	}
 
 	// Email filter: only profile 3 matches "list3".

--- a/api-go/internal/profiles/store_postgres_test.go
+++ b/api-go/internal/profiles/store_postgres_test.go
@@ -37,6 +37,97 @@ func newFakePGStore(tag pgconn.CommandTag, err error) *PostgresStore {
 	return NewPostgresStore(&fakeExecQuerier{tag: tag, err: err})
 }
 
+// fakeScanRow is a hand-written rowScanner that copies a fixed slice of column
+// values into the scan destinations, mirroring the real pgx scan. It supports
+// only the destination types scanUserRow uses, so an unexpected column change
+// surfaces as a panic rather than a silent zero value.
+type fakeScanRow struct {
+	cols []any
+}
+
+func (r *fakeScanRow) Scan(dest ...any) error {
+	if len(dest) != len(r.cols) {
+		return errors.New("scan: column count mismatch")
+	}
+	for i, d := range dest {
+		switch p := d.(type) {
+		case *string:
+			*p = r.cols[i].(string)
+		case **string:
+			if r.cols[i] == nil {
+				*p = nil
+			} else {
+				s := r.cols[i].(string)
+				*p = &s
+			}
+		case *bool:
+			*p = r.cols[i].(bool)
+		case **bool:
+			if r.cols[i] == nil {
+				*p = nil
+			} else {
+				b := r.cols[i].(bool)
+				*p = &b
+			}
+		case *int:
+			*p = r.cols[i].(int)
+		case **int:
+			if r.cols[i] == nil {
+				*p = nil
+			} else {
+				n := r.cols[i].(int)
+				*p = &n
+			}
+		case *int64:
+			*p = r.cols[i].(int64)
+		case *time.Time:
+			*p = r.cols[i].(time.Time)
+		case **time.Time:
+			if r.cols[i] == nil {
+				*p = nil
+			} else {
+				tt := r.cols[i].(time.Time)
+				*p = &tt
+			}
+		default:
+			return errors.New("scan: unsupported destination type")
+		}
+	}
+	return nil
+}
+
+// TestScanUserRow_CreatedAt verifies created_at is scanned into
+// UserProfile.CreatedAt in the same column order as userSelectCols. The column
+// values below must stay in lockstep with the userSelectCols projection.
+func TestScanUserRow_CreatedAt(t *testing.T) {
+	t.Parallel()
+	lastActive := time.Date(2026, 6, 1, 9, 0, 0, 0, time.UTC)
+	created := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	row := &fakeScanRow{cols: []any{
+		// user_id, email, push_enabled, digest_day,
+		"auth0|u1", "u@example.com", true, 1,
+		// email_digest_enabled, saved_decision_push, saved_decision_email,
+		true, true, true,
+		// zone_preferences::text,
+		"{}",
+		// tier, subscription_expiry, original_transaction_id, grace_period_expiry,
+		"Free", nil, nil, nil,
+		// last_active_at, last_active_at_epoch, created_at, watch_zone_count, version
+		lastActive, lastActive.UnixMilli(), created, nil, 0,
+	}}
+
+	p, _, err := scanUserRow(row)
+	if err != nil {
+		t.Fatalf("scanUserRow: %v", err)
+	}
+	if !p.CreatedAt.Equal(created) {
+		t.Errorf("CreatedAt: got %v, want %v", p.CreatedAt, created)
+	}
+	if !p.LastActiveAt.Equal(lastActive) {
+		t.Errorf("LastActiveAt: got %v, want %v", p.LastActiveAt, lastActive)
+	}
+}
+
 // testProfile builds a minimal valid UserProfile for use in store tests.
 // The userID parameter is intentionally parameterised for readability even
 // though unit tests call it with the same argument — it is also used by the

--- a/cli/internal/tc/commands.go
+++ b/cli/internal/tc/commands.go
@@ -35,9 +35,14 @@ type listUsersResponse struct {
 }
 
 type listUsersItem struct {
-	UserID string  `json:"userId"`
-	Email  *string `json:"email"`
-	Tier   string  `json:"tier"`
+	UserID             string  `json:"userId"`
+	Email              *string `json:"email"`
+	Tier               string  `json:"tier"`
+	WatchZoneCount     *int    `json:"watchZoneCount"`
+	CreatedAt          *string `json:"createdAt"`
+	LastActiveAt       *string `json:"lastActiveAt"`
+	NotificationTotal  int     `json:"notificationTotal"`
+	NotificationUnread int     `json:"notificationUnread"`
 }
 
 // parseStrictInt parses s as a non-negative base-10 integer, accepting only

--- a/cli/internal/tc/http_test.go
+++ b/cli/internal/tc/http_test.go
@@ -155,7 +155,12 @@ func TestRunListUsers_SinglePageTable(t *testing.T) {
 	}
 
 	got := out.String()
-	for _, want := range []string{"UserId", "Email", "Tier", strings.Repeat("-", 66), "u1", "a@b.com", "u2", "(none)", "Free"} {
+	for _, want := range []string{
+		"UserId", "Email", "Tier", "WatchZones", "LastActive", "Created", "Notifs",
+		"u1", "a@b.com", "u2", "(none)", "Free",
+		"-", // legacy rows with no watch-zone / dates render "-"
+		"0/0",
+	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("stdout missing %q; got:\n%s", want, got)
 		}

--- a/cli/internal/tc/listusers.go
+++ b/cli/internal/tc/listusers.go
@@ -76,14 +76,88 @@ func buildListUsersPath(hasSearch bool, search string, pageSize int, continuatio
 	return sb.String()
 }
 
+// printUsersTable renders one page as an aligned table. Column widths are
+// computed per page (rather than hard-coded) so any user-id length — a short
+// Auth0 id or a ~49-char Apple id — renders without pushing the later columns
+// out of alignment.
 func printUsersTable(out io.Writer, page *listUsersResponse) {
-	fmt.Fprintf(out, "%-24s %-32s %-10s\n", "UserId", "Email", "Tier")
-	fmt.Fprintln(out, strings.Repeat("-", 66))
-	for _, item := range page.Items {
-		email := "(none)"
-		if item.Email != nil {
-			email = *item.Email
-		}
-		fmt.Fprintf(out, "%-24s %-32s %-10s\n", item.UserID, email, item.Tier)
+	const (
+		hUserID     = "UserId"
+		hEmail      = "Email"
+		hTier       = "Tier"
+		hWatchZones = "WatchZones"
+		hLastActive = "LastActive"
+		hCreated    = "Created"
+		hNotifs     = "Notifs"
+	)
+
+	type cells struct {
+		userID, email, tier, watchZones, lastActive, created, notifs string
 	}
+	rows := make([]cells, 0, len(page.Items))
+	for _, item := range page.Items {
+		rows = append(rows, cells{
+			userID:     item.UserID,
+			email:      emailCell(item.Email),
+			tier:       item.Tier,
+			watchZones: watchZonesCell(item.WatchZoneCount),
+			lastActive: datePart(item.LastActiveAt),
+			created:    datePart(item.CreatedAt),
+			notifs:     fmt.Sprintf("%d/%d", item.NotificationUnread, item.NotificationTotal),
+		})
+	}
+
+	// Seed widths from the headers, then widen to the longest cell per column.
+	wUserID, wEmail, wTier := len(hUserID), len(hEmail), len(hTier)
+	wWatch, wLast, wCreated, wNotifs := len(hWatchZones), len(hLastActive), len(hCreated), len(hNotifs)
+	for _, r := range rows {
+		wUserID = max(wUserID, len(r.userID))
+		wEmail = max(wEmail, len(r.email))
+		wTier = max(wTier, len(r.tier))
+		wWatch = max(wWatch, len(r.watchZones))
+		wLast = max(wLast, len(r.lastActive))
+		wCreated = max(wCreated, len(r.created))
+		wNotifs = max(wNotifs, len(r.notifs))
+	}
+
+	format := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds\n",
+		wUserID, wEmail, wTier, wWatch, wLast, wCreated, wNotifs)
+
+	header := fmt.Sprintf(format, hUserID, hEmail, hTier, hWatchZones, hLastActive, hCreated, hNotifs)
+	fmt.Fprint(out, header)
+	fmt.Fprintln(out, strings.Repeat("-", len(strings.TrimRight(header, "\n"))))
+	for _, r := range rows {
+		fmt.Fprintf(out, format, r.userID, r.email, r.tier, r.watchZones, r.lastActive, r.created, r.notifs)
+	}
+}
+
+// emailCell renders an optional email, falling back to "(none)" when absent.
+func emailCell(email *string) string {
+	if email == nil {
+		return "(none)"
+	}
+	return *email
+}
+
+// watchZonesCell renders the watch-zone count, or "-" for a legacy profile that
+// never had the counter (nil).
+func watchZonesCell(n *int) string {
+	if n == nil {
+		return "-"
+	}
+	return strconv.Itoa(*n)
+}
+
+// datePart trims an RFC3339 timestamp to its date portion (YYYY-MM-DD) for
+// compact display. A nil or empty value renders as "-"; a value shorter than a
+// full date is passed through unchanged.
+func datePart(s *string) string {
+	if s == nil || *s == "" {
+		return "-"
+	}
+	v := *s
+	if len(v) >= len("2006-01-02") {
+		return v[:len("2006-01-02")]
+	}
+	return v
 }

--- a/cli/internal/tc/listusers_test.go
+++ b/cli/internal/tc/listusers_test.go
@@ -1,0 +1,123 @@
+package tc
+
+import (
+	"strings"
+	"testing"
+)
+
+func intptr(n int) *int { return &n }
+
+// TestPrintUsersTable_DynamicWidthsAndColumns verifies the list table aligns
+// regardless of user-id length (Apple IDs are ~49 chars, Auth0 ~13) and renders
+// the watch-zone, last-active, created, and notification columns.
+func TestPrintUsersTable_DynamicWidthsAndColumns(t *testing.T) {
+	t.Parallel()
+
+	appleID := "apple|000190.0d7a75399d0649229f6de04d0f38d7aa.2023"
+	authID := "auth0|u2"
+	wz := 3
+	page := &listUsersResponse{Items: []listUsersItem{
+		{
+			UserID:             appleID,
+			Email:              strptr("alice@example.com"),
+			Tier:               "Pro",
+			WatchZoneCount:     &wz,
+			CreatedAt:          strptr("2026-01-01T09:00:00Z"),
+			LastActiveAt:       strptr("2026-03-04T10:00:00Z"),
+			NotificationTotal:  57,
+			NotificationUnread: 2,
+		},
+		{
+			UserID:             authID,
+			Email:              nil, // legacy profile, no email
+			Tier:               "Free",
+			WatchZoneCount:     nil, // legacy profile, no watch-zone count
+			CreatedAt:          strptr("2026-02-15T00:00:00Z"),
+			LastActiveAt:       strptr("2026-02-20T08:30:00Z"),
+			NotificationTotal:  0,
+			NotificationUnread: 0,
+		},
+	}}
+
+	var sb strings.Builder
+	printUsersTable(&sb, page)
+	out := sb.String()
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) < 4 {
+		t.Fatalf("expected header + separator + 2 rows, got %d lines:\n%s", len(lines), out)
+	}
+	header := lines[0]
+	row1 := lines[2]
+	row2 := lines[3]
+
+	// All new column headers are present.
+	for _, col := range []string{"UserId", "Email", "Tier", "WatchZones", "LastActive", "Created", "Notifs"} {
+		if !strings.Contains(header, col) {
+			t.Errorf("header missing column %q:\n%s", col, header)
+		}
+	}
+
+	// Dynamic alignment: the Email column starts at the same offset on the header
+	// and on every row, even though the two user ids differ in length.
+	emailOffset := strings.Index(header, "Email")
+	if got := strings.Index(row1, "alice@example.com"); got != emailOffset {
+		t.Errorf("row1 email offset = %d, want %d (aligned with header)\n%s", got, emailOffset, out)
+	}
+	if got := strings.Index(row2, "(none)"); got != emailOffset {
+		t.Errorf("row2 email offset = %d, want %d (aligned with header)\n%s", got, emailOffset, out)
+	}
+
+	// Watch-zone: count when present, "-" when nil.
+	if !strings.Contains(row1, "3") {
+		t.Errorf("row1 should show watch-zone count 3:\n%s", row1)
+	}
+	// Notifs: unread/total.
+	if !strings.Contains(row1, "2/57") {
+		t.Errorf("row1 should show notifs 2/57:\n%s", row1)
+	}
+	if !strings.Contains(row2, "0/0") {
+		t.Errorf("row2 should show notifs 0/0:\n%s", row2)
+	}
+
+	// Dates are truncated to the date portion (no time-of-day / "T").
+	if !strings.Contains(row1, "2026-01-01") || !strings.Contains(row1, "2026-03-04") {
+		t.Errorf("row1 should show created + last-active dates:\n%s", row1)
+	}
+	if strings.Contains(out, "T09:00:00") || strings.Contains(out, "2026-01-01T") {
+		t.Errorf("dates must be truncated to the date portion, got:\n%s", out)
+	}
+}
+
+// TestWatchZonesCell covers the nil-vs-present rendering directly.
+func TestWatchZonesCell(t *testing.T) {
+	t.Parallel()
+	if got := watchZonesCell(nil); got != "-" {
+		t.Errorf("nil watch-zone: got %q, want -", got)
+	}
+	if got := watchZonesCell(intptr(5)); got != "5" {
+		t.Errorf("present watch-zone: got %q, want 5", got)
+	}
+}
+
+// TestDatePart trims an RFC3339 timestamp to its date, tolerating nil/short.
+func TestDatePart(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   *string
+		want string
+	}{
+		{"nil", nil, "-"},
+		{"empty", strptr(""), "-"},
+		{"rfc3339", strptr("2026-01-02T03:04:05Z"), "2026-01-02"},
+		{"short", strptr("2026"), "2026"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := datePart(tc.in); got != tc.want {
+				t.Errorf("datePart(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #729 (bead tc-8pa6).

Fixes `tc list-users` misalignment (Apple IDs ~49 chars vs the hard-coded 24-char column) and enriches the list for support/ops use.

## Changes
- **feat(profiles):** new migration `0016_users_created_at.sql` — DB-owned `created_at timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP`; `UserProfile.CreatedAt` set in `NewProfile`. Go never writes the column (shared upsert/CAS queries untouched).
- **feat(profiles):** `created_at` into `userSelectCols` + `scanUserRow` (lockstep); `List` now `ORDER BY created_at, user_id` with a compound keyset guard `(created_at, user_id) > ($1,$2)`; cursor carries `CreatedAt` (RFC3339Nano) + `LastUserID`, `|`-joined then base64url, malformed cursor → error.
- **feat(notifications):** `NotificationCounts{Total,Unread}` + batched `CountsByUsers` (`count(*) FILTER (WHERE read_at IS NULL)`, `GROUP BY user_id`); users absent from the tally default to `{0,0}`.
- **feat(admin):** `listItem` gains `watchZoneCount`, `createdAt`, `lastActiveAt` (RFC3339), `notificationTotal`, `notificationUnread`; handler enriches each row after `profiles.List` via a new live `notificationCounts` dependency; query errors surface as 500.
- **test(api):** real-DB integration coverage — `created_at` ordering tiebreak + `CountsByUsers` read_at filter.
- **feat(cli):** per-page dynamic column widths + `WatchZones` / `LastActive` / `Created` / `Notifs` (`unread/total`) columns; nil watch-zone renders `-`.

## Verification
- `api-go` + `cli`: gofmt/vet/golangci-lint clean, `go test ./...` and `-race` green.
- Integration suite ran against **live local PostGIS** (not skipped) and passed.
- `created_at` is DB-owned (absent from INSERT/ON CONFLICT/CAS); notification counts kept off `UserProfile`/`userSelectCols`.

## Deploy note
Additive, back-compatible migration (new column with a default). Merge to main deploys to **dev**; prod is a separate tag-triggered release.

---
*Auto-shipped via ship skill*