### PR TITLE
fix(seo): make IndexNow submission survive post-deploy verification race (tc-8tyz)

### DIFF
--- a/.github/workflows/seo-refresh.yml
+++ b/.github/workflows/seo-refresh.yml
@@ -222,24 +222,72 @@ jobs:
           skip_api_build: true
 
       # Notify Bing (IndexNow) of all live URLs so the crawl queue is skipped.
-      # Key file at https://towncrierapp.uk/1cb201daee1a485fb8cce2a68e8ee465.txt
-      # is part of web/public/ and therefore already deployed above.
+      # Bing's IndexNow verifier fetches the key file from the CDN edge to
+      # confirm ownership. The SWA upload above redeploys that file, and for a
+      # short window afterwards the edge can serve the SPA fallback / a cold
+      # cache for the key URL, so verification returns 403
+      # SiteVerificationNotCompleted and the whole batch is rejected. We
+      # therefore (1) wait until the edge serves the correct key contents, then
+      # (2) submit with retry-on-403 backoff. A persistent 403 means the URLs
+      # were NOT accepted, so it fails the step — it must never be silently
+      # swallowed again (that masked a total IndexNow outage for weeks).
       - name: Submit sitemap URLs to IndexNow
+        env:
+          INDEXNOW_KEY: 1cb201daee1a485fb8cce2a68e8ee465
         run: |
-          urls=$(grep -oP '(?<=<loc>)[^<]+' web/dist/sitemap.xml | jq -R '.' | jq -s '.')
-          count=$(echo "$urls" | jq 'length')
+          set -uo pipefail
+          key_url="https://towncrierapp.uk/${INDEXNOW_KEY}.txt"
+
+          # 1. Wait for the freshly-deployed key file to be served at the edge
+          #    with the exact key contents (not the SPA fallback). Up to ~3 min.
+          for attempt in $(seq 1 12); do
+            body=$(curl -fsS "$key_url" 2>/dev/null || true)
+            if [ "$body" = "$INDEXNOW_KEY" ]; then
+              echo "Key file live at edge (attempt $attempt)."
+              break
+            fi
+            echo "Key file not settled yet (attempt $attempt); waiting 15s..."
+            sleep 15
+          done
+          # Extra margin: Bing's verifier fetches the key file independently of
+          # the check above and may still be hitting a colder edge.
+          sleep 30
+
+          # 2. Build the payload and submit, retrying on 403 with backoff.
+          urls=$(grep -oP '(?<=<loc>)[^<]+' web/dist/sitemap.xml | jq -R '.' | jq -s '.' || true)
+          count=$(echo "$urls" | jq 'length' 2>/dev/null || echo 0)
+          if [ "$count" -lt 1 ]; then
+            echo "No URLs parsed from web/dist/sitemap.xml — failing."
+            exit 1
+          fi
+          payload=$(jq -n \
+            --arg host "towncrierapp.uk" \
+            --arg key "$INDEXNOW_KEY" \
+            --arg keyLocation "$key_url" \
+            --argjson urlList "$urls" \
+            '{host: $host, key: $key, keyLocation: $keyLocation, urlList: $urlList}')
+
           echo "Submitting $count URLs to IndexNow..."
-          http_code=$(curl -s -o /tmp/indexnow-response.txt -w "%{http_code}" \
-            -X POST "https://api.indexnow.org/IndexNow" \
-            -H "Content-Type: application/json; charset=utf-8" \
-            -d "{
-              \"host\": \"towncrierapp.uk\",
-              \"key\": \"1cb201daee1a485fb8cce2a68e8ee465\",
-              \"keyLocation\": \"https://towncrierapp.uk/1cb201daee1a485fb8cce2a68e8ee465.txt\",
-              \"urlList\": $urls
-            }")
-          echo "IndexNow response: $http_code — $(cat /tmp/indexnow-response.txt)"
-          # 403 SiteVerificationNotCompleted is a transient CDN propagation race
-          # (key file just deployed); treat as a warning so the workflow doesn't
-          # fail — Bing will pick up the key on its next verification pass.
-          [ "$http_code" = "200" ] || [ "$http_code" = "202" ] || [ "$http_code" = "403" ] || { echo "IndexNow error $http_code"; exit 1; }
+          for attempt in $(seq 1 6); do
+            http_code=$(curl -s -o /tmp/indexnow-response.txt -w "%{http_code}" \
+              -X POST "https://api.indexnow.org/IndexNow" \
+              -H "Content-Type: application/json; charset=utf-8" \
+              --data "$payload")
+            echo "Attempt $attempt: IndexNow response $http_code — $(cat /tmp/indexnow-response.txt)"
+            case "$http_code" in
+              200|202)
+                echo "IndexNow accepted $count URLs."
+                exit 0
+                ;;
+              403)
+                echo "Verification not complete yet; retrying in 30s..."
+                sleep 30
+                ;;
+              *)
+                echo "IndexNow hard error $http_code — failing."
+                exit 1
+                ;;
+            esac
+          done
+          echo "IndexNow still returning 403 after retries — submissions were NOT accepted."
+          exit 1


### PR DESCRIPTION
## Problem

Bing shows our SEO pages (e.g. `https://towncrierapp.uk/planning/wrexham`) as **Discovered but not crawled** and never indexes them. The page itself is fine — 200 to Bingbot, fast TTFB, `robots: index,follow`, self-canonical, ~2,300 words, in the sitemap.

The real cause: the weekly `seo-refresh` **IndexNow push has never delivered a single URL.** Every run POSTs all ~1,677 sitemap URLs to `api.indexnow.org` *immediately after* the SWA deploy, before the CDN edge serves the freshly-uploaded key file. Bing's verifier can't confirm ownership and returns:

```
403 — {"errorCode":"SiteVerificationNotCompleted", ...}
```

The step treated 403 as a "harmless transient CDN race" and passed green, so the outage was invisible for weeks. Bing only ever got passive sitemap discovery.

**Verified:** once the edge settles, a manual IndexNow POST for the same key/URLs returns `200`. So verification works — the workflow just submits inside the dead window every time.

## Fix

- Wait until the edge serves the key file with the **exact key contents** (not the SPA fallback), then a short settle margin.
- Submit with **retry-on-403 backoff** (up to 6 attempts).
- A **persistent 403 now fails the step** instead of being swallowed — a real IndexNow outage can never hide again. Non-403 hard errors fail immediately.

## Validation

- `actionlint` clean; YAML parses; `bash -n` clean on the embedded script.
- Scoped to the single prod IndexNow step in `seo-refresh.yml`; no other steps touched.

## Note

IndexNow gets URLs into Bing's queue faster; it doesn't override Bing's trust-based crawl scheduling for a young domain. This is the necessary fix for the broken push, not an instant flip to indexed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)