### PR TITLE
Automate DB migrations in CD (ADR 0036) — close the schema-drift outage class

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -114,6 +114,42 @@ jobs:
           ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
         run: pulumi up --yes --non-interactive
 
+  # ── Database: run migrations ─────────────────────────
+  # Applies pending goose migrations (and the app-role grant sweep) BEFORE the
+  # API and worker deploy jobs, so the new image never serves against a stale
+  # schema. Authenticates as the CI service principal — a Postgres Entra admin
+  # on psql-town-crier-shared — via the OIDC azure-login session, so
+  # DefaultAzureCredential yields a passwordless ossrdbms token; no stored DB
+  # secret is involved. A non-zero exit fails the deploy loudly (never a silent
+  # skip); goose.Up is idempotent, so an up-to-date DB is a no-op. See ADR 0036.
+  migrate-dev:
+    name: "Database: Run migrations (dev)"
+    needs: infra-dev
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: development
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: api-go/go.mod
+
+      - uses: ./.github/actions/azure-login
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Apply migrations
+        working-directory: api-go
+        run: |
+          go run ./cmd/pgmigrate \
+            -host psql-town-crier-shared.postgres.database.azure.com \
+            -admin-user town-crier-github-actions \
+            -db town_crier_dev \
+            -timeout 120s
+
   # ── Go API: build & push image ──────────────────────
   api-go-image:
     name: "Go API: Build & push image"
@@ -162,7 +198,7 @@ jobs:
   # ── Go API: deploy to dev ───────────────────────────
   api-go-deploy:
     name: "Go API: Deploy to dev"
-    needs: [api-go-image, infra-dev]
+    needs: [api-go-image, infra-dev, migrate-dev]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: development
@@ -184,7 +220,7 @@ jobs:
   # ── Worker: deploy to dev ───────────────────────────────
   worker-deploy:
     name: "Worker: Deploy to dev"
-    needs: [worker-go-image, infra-dev]
+    needs: [worker-go-image, infra-dev, migrate-dev]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: development

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -83,10 +83,46 @@ jobs:
         env:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
+  # ── Database: run migrations ─────────────────────────
+  # Applies pending goose migrations (and the app-role grant sweep) BEFORE the
+  # API and worker deploy jobs, so the new image never serves against a stale
+  # schema. Authenticates as the CI service principal — a Postgres Entra admin
+  # on psql-town-crier-shared — via the OIDC azure-login session, so
+  # DefaultAzureCredential yields a passwordless ossrdbms token; no stored DB
+  # secret is involved. A non-zero exit fails the deploy loudly (never a silent
+  # skip); goose.Up is idempotent, so an up-to-date DB is a no-op. See ADR 0036.
+  migrate-prod:
+    name: "Database: Run migrations (prod)"
+    needs: infra
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: api-go/go.mod
+
+      - uses: ./.github/actions/azure-login
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Apply migrations
+        working-directory: api-go
+        run: |
+          go run ./cmd/pgmigrate \
+            -host psql-town-crier-shared.postgres.database.azure.com \
+            -admin-user town-crier-github-actions \
+            -db town_crier_prod \
+            -timeout 120s
+
   # ── Go API ────────────────────────────────────────────
   api-go:
     name: Deploy Go API
-    needs: infra
+    needs: [infra, migrate-prod]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production
@@ -154,7 +190,7 @@ jobs:
   # ── Worker ───────────────────────────────────────────────
   worker:
     name: Deploy Worker
-    needs: infra
+    needs: [infra, migrate-prod]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: production

--- a/api-go/cmd/pgmigrate/grant_sweep.go
+++ b/api-go/cmd/pgmigrate/grant_sweep.go
@@ -42,7 +42,7 @@ func buildGrantSweepSQL(role string) (string, error) {
 // An empty role skips the sweep (logged, not an error). It reuses the Entra
 // token already carried in dsn by opening its own short-lived connection; it
 // does NOT fetch a second token.
-func grantAppRole(ctx context.Context, dsn, role string) error {
+func grantAppRole(ctx context.Context, dsn, role string) (err error) {
 	if role == "" {
 		fmt.Println("pgmigrate: grant sweep skipped (no app role configured)")
 		return nil
@@ -57,7 +57,11 @@ func grantAppRole(ctx context.Context, dsn, role string) error {
 	if err != nil {
 		return fmt.Errorf("connect for grant sweep: %w", err)
 	}
-	defer func() { _ = conn.Close(ctx) }()
+	defer func() {
+		if cerr := conn.Close(ctx); cerr != nil && err == nil {
+			err = fmt.Errorf("close grant sweep connection: %w", cerr)
+		}
+	}()
 
 	// The sweep carries no parameters, so pgx uses the simple protocol and runs
 	// both GRANTs in one round trip. GRANT ... ON ALL TABLES emits a benign

--- a/api-go/cmd/pgmigrate/grant_sweep.go
+++ b/api-go/cmd/pgmigrate/grant_sweep.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// grantRolePattern matches a safe, unquoted SQL identifier, mirroring
+// cmd/pgbootstrap's identifierPattern. The app-role name is validated against it
+// before being interpolated into the grant sweep, so buildGrantSweepSQL is not a
+// SQL-injection surface: the role is the only interpolated value and the two
+// GRANT statements are the only dynamic SQL the migrator emits.
+var grantRolePattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// buildGrantSweepSQL returns the idempotent post-migration grant sweep for role,
+// or an error if role is not a plain SQL identifier (in which case no SQL is
+// emitted). It re-grants the DML-only app role everything a migration may have
+// just created, ownership-agnostically via ON ALL TABLES / ALL SEQUENCES. It is
+// pure and unit-tested; grantAppRole is the thin DB wiring around it.
+func buildGrantSweepSQL(role string) (string, error) {
+	if !grantRolePattern.MatchString(role) {
+		return "", fmt.Errorf("invalid grant role %q: must be a plain SQL identifier", role)
+	}
+	// role is a validated plain SQL identifier, so interpolating it is safe.
+	return fmt.Sprintf(
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO %s;\n"+
+			"GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO %s;\n",
+		role, role,
+	), nil
+}
+
+// grantAppRole runs the idempotent post-migration grant sweep so the DML-only
+// app role keeps SELECT/INSERT/UPDATE/DELETE on every table (and USAGE/SELECT on
+// every sequence) the migrations just created, regardless of which identity owns
+// them. This closes the table-ownership hazard in ADR 0036: whoever runs a
+// migration grants the app DML on the tables it created at creation time,
+// without relying on ALTER DEFAULT PRIVILEGES and its owner-scoping.
+//
+// An empty role skips the sweep (logged, not an error). It reuses the Entra
+// token already carried in dsn by opening its own short-lived connection; it
+// does NOT fetch a second token.
+func grantAppRole(ctx context.Context, dsn, role string) error {
+	if role == "" {
+		fmt.Println("pgmigrate: grant sweep skipped (no app role configured)")
+		return nil
+	}
+
+	sweepSQL, err := buildGrantSweepSQL(role)
+	if err != nil {
+		return err
+	}
+
+	conn, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		return fmt.Errorf("connect for grant sweep: %w", err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	// The sweep carries no parameters, so pgx uses the simple protocol and runs
+	// both GRANTs in one round trip. GRANT ... ON ALL TABLES emits a benign
+	// NOTICE ("no privileges were granted for ...") for objects the migrator
+	// cannot grant on (tables owned by another role, PostGIS system views); a
+	// NOTICE is not an error, so Exec returns nil and those objects keep their
+	// existing bootstrap grants. Only a genuine SQL error (e.g. the role does not
+	// exist) returns non-nil here, which fails the deploy loudly.
+	if _, err := conn.Exec(ctx, sweepSQL); err != nil {
+		return fmt.Errorf("execute grant sweep for role %q: %w", role, err)
+	}
+
+	fmt.Printf("pgmigrate: grant sweep applied — DML granted to %q\n", role)
+	return nil
+}

--- a/api-go/cmd/pgmigrate/grant_sweep_test.go
+++ b/api-go/cmd/pgmigrate/grant_sweep_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildGrantSweepSQL_ContainsBothGrants(t *testing.T) {
+	t.Parallel()
+
+	sql, err := buildGrantSweepSQL("towncrier_api")
+	if err != nil {
+		t.Fatalf("buildGrantSweepSQL() error = %v", err)
+	}
+
+	wantSubstrings := []string{
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO towncrier_api",
+		"GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO towncrier_api",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(sql, want) {
+			t.Errorf("grant sweep SQL missing %q\n---\n%s", want, sql)
+		}
+	}
+}
+
+func TestBuildGrantSweepSQL_TargetsAllTablesAndSequences(t *testing.T) {
+	t.Parallel()
+
+	sql, err := buildGrantSweepSQL("towncrier_api")
+	if err != nil {
+		t.Fatalf("buildGrantSweepSQL() error = %v", err)
+	}
+
+	// The sweep must be ownership-agnostic: ON ALL TABLES / ALL SEQUENCES, never
+	// an enumerated table list (which would miss whatever the latest migration
+	// created — the very bug this closes).
+	for _, want := range []string{
+		"ON ALL TABLES IN SCHEMA public",
+		"ON ALL SEQUENCES IN SCHEMA public",
+	} {
+		if !strings.Contains(sql, want) {
+			t.Errorf("grant sweep SQL missing %q\n---\n%s", want, sql)
+		}
+	}
+}
+
+func TestBuildGrantSweepSQL_RejectsInvalidRole(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		role string
+	}{
+		{"sql injection via semicolon", "towncrier_api; DROP TABLE notifications"},
+		{"leading digit", "1abc"},
+		{"empty after default resolution", ""},
+		{"embedded space", "town crier"},
+		{"double quote", `town"crier`},
+		{"single quote", "town'crier"},
+		{"trailing comment", "towncrier_api --"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			sql, err := buildGrantSweepSQL(tc.role)
+			if err == nil {
+				t.Fatalf("buildGrantSweepSQL(%q) = nil error, want rejection", tc.role)
+			}
+			if sql != "" {
+				t.Errorf("buildGrantSweepSQL(%q) emitted SQL %q on rejection, want empty", tc.role, sql)
+			}
+		})
+	}
+}

--- a/api-go/cmd/pgmigrate/main.go
+++ b/api-go/cmd/pgmigrate/main.go
@@ -16,10 +16,18 @@
 // single stdlib connection and runs well within the token's validity, so no
 // per-connection refresh is needed (unlike the long-lived API pool).
 //
+// After the migrations apply, pgmigrate runs an idempotent grant sweep on the
+// same server, reusing the token already fetched: it re-grants the DML-only app
+// role (-grant-role, default towncrier_api; env POSTGRES_APP_ROLE) SELECT /
+// INSERT / UPDATE / DELETE on ALL TABLES and USAGE / SELECT on ALL SEQUENCES in
+// schema public. This keeps the app role's DML on tables created by future
+// migrations regardless of which identity owns them, closing the
+// table-ownership hazard in ADR 0036. An empty -grant-role skips the sweep.
+//
 // Usage:
 //
 //	pgmigrate -host <fqdn> -admin-user <aad-admin-upn> [-db town_crier_dev] \
-//	    [-sslmode require] [-timeout 60s]
+//	    [-sslmode require] [-timeout 60s] [-grant-role towncrier_api]
 package main
 
 import (
@@ -56,6 +64,7 @@ func run(args []string) int {
 		host      = fs.String("host", os.Getenv("POSTGRES_HOST"), "Postgres server FQDN")
 		adminUser = fs.String("admin-user", os.Getenv("POSTGRES_ADMIN_USER"), "Entra admin principal name (UPN) to connect as")
 		db        = fs.String("db", envOr("POSTGRES_DB", "town_crier_dev"), "app database to migrate")
+		grantRole = fs.String("grant-role", envOr("POSTGRES_APP_ROLE", "towncrier_api"), "app role to re-grant DML/sequence access after migrating; empty skips the grant sweep")
 		sslMode   = fs.String("sslmode", envOr("POSTGRES_SSLMODE", defaultSSLMode), "sslmode")
 		timeout   = fs.Duration("timeout", 60*time.Second, "overall timeout")
 	)
@@ -91,8 +100,18 @@ func run(args []string) int {
 		fmt.Fprintf(os.Stderr, "pgmigrate: migrate %q: %v\n", *db, err)
 		return 1
 	}
-
 	fmt.Printf("pgmigrate: migrations applied to %q on %s\n", *db, *host)
+
+	// Immediately re-grant the DML-only app role on everything the migrations
+	// just created, on the same privileged identity (the token already in dsn).
+	// New tables owned by the migrator would otherwise fall outside the app
+	// role's ALTER DEFAULT PRIVILEGES coverage and silently lose DML — the same
+	// drift class this whole change closes, one layer down. See ADR 0036.
+	if err := grantAppRole(ctx, dsn, *grantRole); err != nil {
+		fmt.Fprintf(os.Stderr, "pgmigrate: grant sweep on %q: %v\n", *db, err)
+		return 1
+	}
+
 	return 0
 }
 

--- a/docs/adr/0036-automate-db-migrations-in-cd.md
+++ b/docs/adr/0036-automate-db-migrations-in-cd.md
@@ -1,0 +1,179 @@
+# 0036. Automate DB migrations in CD
+
+Date: 2026-07-01
+
+## Status
+
+Accepted
+
+Builds on [0032](0032-consolidate-datastore-on-postgres-postgis.md) (Postgres +
+PostGIS as the sole datastore). Implements the migration-automation half of GH
+issue [#745](https://github.com/AmyDe/town-crier/issues/745).
+
+## Context
+
+On 2026-07-01 prod (v0.15.58) shipped code that queried `notifications.read_at`,
+but the column did not exist: the prod database was five goose migrations behind
+(v11 against the code's v16). Every notification and unread query returned 500,
+breaking the applications list and the map for paying customers.
+
+The root cause is that **CI/CD applies no database migrations.** The only applier,
+`api-go/cmd/pgmigrate`, was written as a manual, one-time operation "run by the
+Entra admin (a locally `az login`-ed human), not part of any deploy" (see the
+package doc in `api-go/cmd/pgmigrate/main.go`). This project has no manual
+operations. The agent runs everything and the owner never ran `pgmigrate`, so
+migrations effectively never applied and the schema drifted silently until a
+release depended on a column that was never added.
+
+We are fixing this by running migrations automatically in CD, before the new
+image serves traffic. This ADR records the **identity and execution model** for
+running DDL in CD. The design has to clear four constraints that fall out of how
+the database is currently secured:
+
+1. **The app role is DML-only by design.** `api-go/cmd/pgbootstrap` creates the
+   Entra-mapped role `towncrier_api` and grants it only SELECT / INSERT / UPDATE /
+   DELETE (`api-go/cmd/pgbootstrap/grants.sql`, `principal.sql`); SUPERUSER,
+   CREATEDB, CREATEROLE, ownership, DROP and all DDL are deliberately absent. The
+   app therefore cannot migrate itself at startup. A privileged identity must run
+   the DDL.
+
+2. **Table ownership is the crux.** `grants.sql` runs
+   `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ... TO towncrier_api` with **no
+   `FOR ROLE` clause**, so Postgres only auto-grants the app DML on tables created
+   by *the role that executed that ALTER* — the human Entra admin who ran bootstrap.
+   The existing tables (migrations 0001–0016) were created by the owner and are
+   covered. But if a **different** identity runs `goose up` in future, the new
+   tables are owned by that identity's role and fall outside the owner's default
+   privileges, so `towncrier_api` silently gets no DML on them. That is the same
+   class of outage we are fixing, one layer down. Whatever we choose must guarantee
+   the app role keeps DML on tables created by future migrations, regardless of who
+   owns them.
+
+3. **Network reachability.** `psql-town-crier-shared` has
+   `PublicNetworkAccess: Enabled` plus the firewall rule `allow-azure-services`
+   (the all-zeros 0.0.0.0 special rule; see `infra/shared.go`). GitHub-hosted
+   runners run on Azure infrastructure, so they reach the server through that rule.
+   The dev API already depends on it; a developer laptop, by contrast, needs a
+   manual firewall rule. This is a known security smell (any Azure tenant can reach
+   the public endpoint) but it is the existing baseline, not something this ADR
+   re-fixes.
+
+4. **Passwordless auth already works.** `cmd/pgmigrate` uses
+   `DefaultAzureCredential` to fetch an Entra token for scope
+   `https://ossrdbms-aad.database.windows.net/.default` and uses it as the
+   connection password (`migrateDSN` percent-encodes the admin UPN). In GitHub
+   Actions, `azure/login@v3` (OIDC) signs the CI service principal in via the Azure
+   CLI, so `DefaultAzureCredential` resolves through `AzureCLICredential` and yields
+   a Postgres token for the CI SP on the runner. No stored secret is involved.
+
+The issue framed two identity options:
+
+- **Option A — the CI service principal becomes a second Postgres Entra admin.**
+  `town-crier-github-actions` (objectId `8efcb7cf-f17e-4a93-aab5-df7bc3c2c2cc`,
+  Pulumi key `ciServicePrincipalId`) is already Contributor on the subscription and
+  User Access Administrator on both resource groups; it builds and pushes every
+  image and runs `pulumi up` for the whole stack, so it already effectively controls
+  the database server resource. Adding it as a Postgres admin is one declarative
+  Pulumi resource — `infra/shared.go` already creates the human admin via
+  `dbforpostgresql.NewAdministrator` and its comment notes "The CI service principal
+  can be added as a second Administrator later if CI bootstrap is needed." Migrations
+  then run as a gated CD job authenticating as the CI SP.
+
+- **Option B — a dedicated migration principal** (a separate managed identity or app
+  registration used only for DDL). Cleaner least-privilege in isolation, but
+  provisioning a new identity and its federated credential is directory-level work
+  the CI SP cannot self-provision (it can create role assignments but not app
+  registrations or federated credentials). That reintroduces a manual bootstrap
+  step, which violates the project's no-manual-ops principle, for marginal benefit.
+
+## Decision
+
+Adopt **Option A**. The CI service principal is added as a second Postgres Entra
+admin, and migrations run as a gated CD job on the GitHub runner, authenticating
+as the CI SP over OIDC, before the API and worker deploy. The table-ownership
+hazard is closed the same way regardless of identity, so Option B's isolation buys
+little against its manual-provisioning cost.
+
+Concretely, this is the design slice 2 will implement:
+
+- **Identity.** Add the CI SP as a second `dbforpostgresql.NewAdministrator` on the
+  single shared server in `infra/shared.go`, alongside the existing
+  `psql-town-crier-shared-aad-admin` (object id from `ciServicePrincipalId`,
+  `PrincipalType: "ServicePrincipal"`). It is fully declarative IaC, no manual step,
+  and both databases live on the one shared server so a single admin resource
+  covers dev and prod. **Open point for the implementer:** for a service principal,
+  the Flexible-Server AAD login name is the SP's application display name, not a UPN.
+  Confirm the exact `-admin-user` value the runner must pass (expected
+  `town-crier-github-actions`) and the `PrincipalName` the `NewAdministrator`
+  resource needs, and verify both against the live cd-dev run before wiring prod.
+
+- **Execution.** Add a new gated job to `.github/workflows/cd-dev.yml` and
+  `.github/workflows/cd-prod.yml` that runs `pgmigrate` against the correct database
+  (`town_crier_dev` / `town_crier_prod`) after infrastructure is up and **before**
+  the API and worker deploy jobs. The job `needs:` the infra job (transitively
+  including the shared stack, so the CI-SP admin resource exists), and the
+  `api-go-deploy` / `worker-deploy` jobs (dev) and `api-go` / `worker` jobs (prod)
+  gain a `needs:` on the migrate job. It authenticates via the existing
+  `azure-login` action, so `DefaultAzureCredential` yields the CI SP's Postgres
+  token. A non-zero exit from `pgmigrate` **fails the deploy loudly** — never a
+  silent skip. `goose.Up` is idempotent, so a run against an up-to-date database is
+  a no-op.
+
+- **Table-ownership guarantee.** Every deploy, immediately after `goose up`, the
+  migrator runs an idempotent post-migration grant sweep to `towncrier_api`:
+
+  ```sql
+  GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES    IN SCHEMA public TO towncrier_api;
+  GRANT USAGE, SELECT                ON ALL SEQUENCES IN SCHEMA public TO towncrier_api;
+  ```
+
+  This lives in the `cmd/pgmigrate` / `postgres.Migrate` path
+  (`api-go/internal/platform/postgres/migrate.go`), so it runs as the same
+  privileged identity that just applied the migrations. It is ownership-agnostic:
+  the migrator owns the tables this deploy just created, so its `GRANT` succeeds on
+  them; tables owned by another role (for example the existing 0001–0016 tables
+  owned by the human admin, or PostGIS system views) emit the benign "no privileges
+  were granted" warning already documented in `grants.sql` and are skipped, but they
+  keep their DML from the original bootstrap grant. The sweep is safe to repeat
+  every deploy because `GRANT` is idempotent. This is what stops the drift bug from
+  recurring one layer down: whoever runs a migration grants the app DML on the
+  tables that migration created, at creation time, without relying on
+  `ALTER DEFAULT PRIVILEGES` and its owner-scoping.
+
+- **Ordering / expand-then-contract preserved.** Migrations must complete before the
+  new image serves traffic (that is the whole point of the gating `needs:`). The
+  additive, expand-then-contract migration convention stays, so a schema change can
+  land a release ahead of the code that depends on it.
+
+Prod is already recovered to v16 by a manual `pgmigrate` run; this ADR does not
+re-migrate prod. `town_crier_dev` has never been migrated and is brought fully up to
+date by the automation's first dev run — where, because the CI SP creates every
+table from scratch, the sweep grants clean DML with no mixed ownership.
+
+## Consequences
+
+- The schema-drift outage class is closed at the root: every deploy applies pending
+  migrations before serving, and fails loudly if a migration errors, so code can no
+  longer ship ahead of the schema it needs.
+- The table-ownership trap is closed for good. New tables get app DML from the
+  post-migrate sweep no matter which identity created them, so switching the migrator
+  from the human owner to the CI SP does not silently strip `towncrier_api` of DML.
+- **Least privilege regresses, honestly.** The deploy SP gains Postgres admin
+  (`azure_pg_admin`-equivalent) rights on the shared server, so an identity that can
+  already build images and run `pulumi up` can now also run arbitrary DDL and read or
+  write every table in both databases. The marginal blast radius is small because the
+  CI SP already controls the server resource itself (it can reset the admin password
+  or add itself as admin through Pulumi), but this is a real widening of the
+  crown-jewel identity and should be treated as such.
+- **Future hardening path (documented alternative, not this ADR's choice):** move DDL
+  to a dedicated migration identity (Option B) once app-registration and
+  federated-credential provisioning can itself be automated end to end without a
+  manual bootstrap. At that point the deploy SP can drop its Postgres admin rights and
+  the migrator becomes a least-privilege, single-purpose principal.
+- The public-endpoint reachability smell (constraint 3) is unchanged and inherited,
+  not introduced here; tightening it (private networking / VNet integration) remains a
+  separate hardening item.
+- Bootstrap (the `towncrier_api` role creation and `GRANT CONNECT`, done by
+  `cmd/pgbootstrap`) remains a distinct concern from migrations and is assumed already
+  applied per database. Folding bootstrap into CD, if wanted, is a later step; this ADR
+  covers only DDL execution and the ongoing app-DML guarantee.

--- a/infra/shared.go
+++ b/infra/shared.go
@@ -351,7 +351,7 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 	// so `cmd/pgbootstrap` (Slice B of GH #653) can run locally under `az login` credentials
 	// to create the towncrier_api role and grant least-privilege DML rights. The CI service
 	// principal can be added as a second Administrator later if CI bootstrap is needed.
-	_, err = dbforpostgresql.NewAdministrator(ctx, "psql-town-crier-shared-aad-admin", &dbforpostgresql.AdministratorArgs{
+	aadAdmin, err := dbforpostgresql.NewAdministrator(ctx, "psql-town-crier-shared-aad-admin", &dbforpostgresql.AdministratorArgs{
 		ResourceGroupName: resourceGroup.Name,
 		ServerName:        postgresServer.Name,
 		ObjectId:          pulumi.String(conf.Require("postgresAadAdminObjectId")),
@@ -359,6 +359,30 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		PrincipalType:     pulumi.String("User"),
 		TenantId:          pulumi.String(tenantID),
 	}, pulumi.DependsOn([]pulumi.Resource{postgresServer}))
+	if err != nil {
+		return err
+	}
+
+	// Second Entra administrator: the CI service principal (town-crier-github-actions,
+	// objectId in ciServicePrincipalID). This is the identity half of ADR 0036 — it lets the
+	// gated CD migrate job run `pgmigrate` (goose DDL) against the shared server as itself,
+	// authenticating passwordlessly over OIDC. For a Flexible-Server service-principal admin the
+	// Postgres login username equals this PrincipalName, and the CD migrate job connects with
+	// exactly "town-crier-github-actions", so this literal must stay in lockstep with the
+	// workflow's `-admin-user` value.
+	//
+	// Two Entra-admin writes to the same server can collide with "ServerIsBusy" (the same
+	// class of failure the azure.extensions Configuration guards against by serialising after
+	// the firewall). DependsOn both the server AND the human admin above so the two admin
+	// writes serialise rather than race.
+	_, err = dbforpostgresql.NewAdministrator(ctx, "psql-town-crier-shared-ci-admin", &dbforpostgresql.AdministratorArgs{
+		ResourceGroupName: resourceGroup.Name,
+		ServerName:        postgresServer.Name,
+		ObjectId:          pulumi.String(ciServicePrincipalID),
+		PrincipalName:     pulumi.String("town-crier-github-actions"),
+		PrincipalType:     pulumi.String("ServicePrincipal"),
+		TenantId:          pulumi.String(tenantID),
+	}, pulumi.DependsOn([]pulumi.Resource{postgresServer, aadAdmin}))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Why

On 2026-07-01 prod (v0.15.58) shipped code querying `notifications.read_at` but the column did not exist — the prod DB was 5 goose migrations behind because **CD applies no migrations** (the only applier, `cmd/pgmigrate`, was a manual step that, in a no-manual-ops project, never ran). Every notification/unread query 500'd for paying customers. This automates migrations so schema can never silently drift again. See `docs/adr/0036-automate-db-migrations-in-cd.md`.

## Changes

- **ADR 0036** — records the identity + execution model: CI service principal as a second Postgres Entra admin (fully declarative, no manual identity provisioning), gated migrate-before-serve, ownership-agnostic app-role grant sweep.
- **`cmd/pgmigrate` grant sweep** — after `goose up`, idempotently re-grants the DML-only `towncrier_api` role SELECT/INSERT/UPDATE/DELETE on all tables + USAGE/SELECT on all sequences, so tables created by a new migrator identity never silently lose app DML (the same drift class, one layer down). New `-grant-role` flag (env `POSTGRES_APP_ROLE`, default `towncrier_api`; empty skips). `postgres.Migrate` and the pgtest harness untouched.
- **Infra** — CI SP `town-crier-github-actions` added as a second `dbforpostgresql.NewAdministrator` on `psql-town-crier-shared`; the two admin writes serialise via `DependsOn` to avoid `ServerIsBusy`.
- **CD** — new gated `migrate-{dev,prod}` job in `cd-dev.yml`/`cd-prod.yml` runs `pgmigrate` (passwordless via OIDC → `DefaultAzureCredential`) after infra is up and **before** the API/worker deploy jobs (`needs:`), failing the deploy loudly on any migration error. `web` job unchanged.

## Rollout safety

Staged: merging triggers **cd-dev only**, where CI-SP Postgres auth is proven first (non-customer-facing) and dev is brought up to goose v16. **cd-prod** fires only on a release tag, by which point dev has validated the path; the prod migrate is an idempotent no-op (already at v16). Expand-then-contract convention preserved.

Closes tc-ovl4. Catches up dev per tc-qqtv on first cd-dev run.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated database migrations now run during dev and production deployments before API and worker releases.
  * Post-migration permission updates help newly created tables and sequences stay accessible to the app role.

* **Bug Fixes**
  * Reduced deployment risk from schema or permission drift by ensuring database changes are applied as part of release flow.
  * Added safeguards so invalid role values are rejected during permission updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->