### PR TITLE
fix(infra): wire APNS onto poll-sb worker so instant pushes actually send (tc-wjbm)

### DIFF
--- a/infra/environment.go
+++ b/infra/environment.go
@@ -603,8 +603,13 @@ func addGoWorkerEnv(envVars app.EnvironmentVarArray, ec envContext, workerMode s
 		)
 	}
 
-	// digest / hourly-digest: APNs push + ACS email.
-	if workerMode == "digest" || workerMode == "hourly-digest" {
+	// APNs push: poll-sb sends the instant new-application / decision alerts
+	// (notifydispatch fan-out, #456); digest / hourly-digest send the weekly
+	// digest push. The apns-auth-key secret is on every worker job (see the
+	// shared secrets above). Without these env vars buildPushSender falls back to
+	// the NoOp sender and silently drops every push — which is exactly why the
+	// poll worker delivered no instant pushes in prod (tc-wjbm).
+	if workerMode == "poll-sb" || workerMode == "digest" || workerMode == "hourly-digest" {
 		envVars = append(envVars,
 			app.EnvironmentVarArgs{Name: pulumi.String("APNS_ENABLED"), Value: pulumi.String("true")},
 			app.EnvironmentVarArgs{Name: pulumi.String("APNS_AUTH_KEY"), SecretRef: pulumi.String("apns-auth-key")},
@@ -612,6 +617,12 @@ func addGoWorkerEnv(envVars app.EnvironmentVarArray, ec envContext, workerMode s
 			app.EnvironmentVarArgs{Name: pulumi.String("APNS_TEAM_ID"), Value: pulumi.String("4574VQ7N2X")},
 			app.EnvironmentVarArgs{Name: pulumi.String("APNS_BUNDLE_ID"), Value: pulumi.String(apnsBundleID)},
 			app.EnvironmentVarArgs{Name: pulumi.String("APNS_USE_SANDBOX"), Value: pulumi.String(ec.apnsUseSandbox)},
+		)
+	}
+
+	// digest / hourly-digest: ACS email transport (the poll worker sends no email).
+	if workerMode == "digest" || workerMode == "hourly-digest" {
+		envVars = append(envVars,
 			app.EnvironmentVarArgs{Name: pulumi.String("ACS_CONNECTION_STRING"), SecretRef: pulumi.String("acs-connection-string")},
 		)
 	}


### PR DESCRIPTION
## Problem

iOS users stopped receiving push notifications. Investigation traced it to the **poll worker sending nothing**.

Real-time alerts (new application in a watch zone, decision updates) are dispatched from the poll worker (`job-tc-poll-prod`) via the `notifydispatch` fan-out. On **every cycle** the worker logs:

```
"apns disabled; digest pushes disabled (NoOp sender)"
```

`cmd/worker` `buildPushSender` returns the **NoOp APNs sender** unless `APNS_ENABLED` is set, and the NoOp sender returns `(nil, nil)` — success with no delivery. So instant pushes were silently dropped while `push_sent` was still recorded `true`.

Root cause: `infra/environment.go` attached the `APNS_*` env block **only** to `workerMode == "digest" || "hourly-digest"`. The `poll-sb` worker never got it. This has been the case since the poll-path fan-out (#456) shipped on **2026-06-14** — confirmed by the earliest `"apns disabled"` log line at `2026-06-14T17:10`. The pre-Go .NET infra gated it the same way, so the poll worker never had APNS.

## Evidence (prod, read-only)

- Notification records are healthy: 6,556 total, 832 in the last 7 days, created right up to today.
- Users are registered: 17 iOS device tokens across 12 users.
- `christy@salter.uk`: 4 iOS devices, 5,492 notifications, **1,088 marked `push_sent=true`** — all NoOp'd, none delivered.
- `job-tc-poll-prod` has **zero `APNS_*` env vars**; `job-tc-digest-prod` / `job-tc-digest-hourly-prod` have the full block.

## Fix

Extend the APNS env block to `workerMode == "poll-sb"`, and split `ACS_CONNECTION_STRING` (email) into a digest-only branch since the poll worker sends no email. The `apns-auth-key` secret is already mounted on every worker job, so only the env wiring was missing.

## Verification

- `go build ./...`, `go vet ./...`, `gofmt` all clean in `/infra`.
- After deploy, confirm `job-tc-poll-prod` shows the six `APNS_*` env vars and the worker no longer logs `"apns disabled"`, then confirm a real push lands on device.

## Notes / follow-ups

- `push_sent=true` under the NoOp sender is a latent false-positive (NoOp returns no error → treated as delivered). Once APNS is live it becomes truthful. Already-created records won't retroactively push — going forward only.
- Not fixed here: the `tc list-users` `0/0` display is a separate CLI/API version-skew artifact (prod API predates #743's count fields), not a data problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)