### PR TITLE
Preserve release image digests in ACR for ACA rollback (tc-44nf)

### DIFF
--- a/.github/actions/acr-build-push/action.yml
+++ b/.github/actions/acr-build-push/action.yml
@@ -44,16 +44,22 @@ runs:
         docker push "$IMAGE"
         docker push "$LATEST"
 
-    - name: Prune old ACR manifests (keep newest 5)
+    - name: Prune old ACR manifests (preserve release digests)
       shell: bash
       run: |
         # Basic-tier ACR has no RetentionPolicy, so we prune manually after each push.
-        # Keep the 5 newest manifests (by createdTime) for this repo and delete the rest.
-        # The "latest" tag is always on the most recently pushed manifest, so it is
-        # always retained by virtue of being in the top 5.
+        # Rollback safety (tc-44nf): ACA rollback-by-digest needs old release images to
+        # still exist, but frequent dev builds share these repos with prod releases and
+        # used to evict a release within a day (newest-5 window). So the prune now
+        # PROTECTS any manifest carrying a "release-*" tag (applied by cd-prod after a
+        # successful deploy): it keeps the newest KEEP_RELEASE release manifests and the
+        # newest KEEP_DEV non-release (dev-build) manifests, deleting only what falls
+        # outside both windows. The "latest" tag is always on the most recently pushed
+        # manifest, so it is always retained by virtue of being in the newest KEEP_DEV.
         REGISTRY="$(echo "${{ inputs.acr-login-server }}" | cut -d. -f1)"
         IMAGE_NAME="${{ inputs.image-name }}"
-        KEEP=5
+        KEEP_DEV=10
+        KEEP_RELEASE=15
 
         echo "Listing manifests for ${REGISTRY}/${IMAGE_NAME}..."
         MANIFESTS_JSON="$(az acr manifest list-metadata \
@@ -61,14 +67,19 @@ runs:
           --name "$IMAGE_NAME" \
           -o json)"
 
-        # Sort by createdTime descending, drop the first KEEP entries, emit digests for the rest.
+        # Partition by whether a manifest carries a release-* tag. Within each class,
+        # sort newest-first and drop the ones inside the keep window; delete the rest.
+        # A manifest with no tags is treated as non-release (the // [] guards null).
         DIGESTS_TO_DELETE="$(echo "$MANIFESTS_JSON" \
-          | jq -r --argjson keep "$KEEP" '
-              sort_by(.createdTime) | reverse | .[$keep:] | .[].digest
+          | jq -r --argjson kd "$KEEP_DEV" --argjson kr "$KEEP_RELEASE" '
+              def is_release: ((.tags // []) | any(startswith("release-")));
+              ([ .[] | select(is_release)       ] | sort_by(.createdTime) | reverse | .[$kr:])
+              + ([ .[] | select(is_release | not) ] | sort_by(.createdTime) | reverse | .[$kd:])
+              | .[].digest
             ')"
 
         if [ -z "$DIGESTS_TO_DELETE" ]; then
-          echo "Nothing to prune (<= ${KEEP} manifests present)."
+          echo "Nothing to prune (all manifests within the keep windows)."
           exit 0
         fi
 

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -187,6 +187,24 @@ jobs:
           resource-group: ${{ needs.infra.outputs.resource-group }}
           image: ${{ steps.resolve-image.outputs.image }}
 
+      # Durably tag the digest we just shipped as release-<version> inside the
+      # same registry. The acr-build-push prune step protects any manifest
+      # carrying a "release-*" tag, so this digest survives dev-build churn and
+      # stays available for an ACA rollback-by-digest. `az acr import` with the
+      # source and target in the same registry only adds a tag to the existing
+      # manifest (no data movement); `--force` makes it idempotent on re-run.
+      # Runs only after a successful deploy, so we protect digests that shipped.
+      - name: Tag deployed Go API digest as durable release
+        run: |
+          ACR_SERVER="${{ secrets.ACR_LOGIN_SERVER }}"
+          ACR_NAME="${ACR_SERVER%.azurecr.io}"
+          REPO="town-crier-api-go"
+          az acr import \
+            --name "$ACR_NAME" \
+            --source "${{ steps.resolve-image.outputs.image }}" \
+            --image "${REPO}:release-${GITHUB_REF_NAME}" \
+            --force
+
   # ── Worker ───────────────────────────────────────────────
   worker:
     name: Deploy Worker
@@ -253,6 +271,24 @@ jobs:
           env-suffix: prod
           resource-group: ${{ needs.infra.outputs.resource-group }}
           image: ${{ steps.resolve-image.outputs.image }}
+
+      # Durably tag the digest we just shipped as release-<version> inside the
+      # same registry. The acr-build-push prune step protects any manifest
+      # carrying a "release-*" tag, so this digest survives dev-build churn and
+      # stays available for an ACA rollback-by-digest. `az acr import` with the
+      # source and target in the same registry only adds a tag to the existing
+      # manifest (no data movement); `--force` makes it idempotent on re-run.
+      # Runs only after a successful deploy, so we protect digests that shipped.
+      - name: Tag deployed worker digest as durable release
+        run: |
+          ACR_SERVER="${{ secrets.ACR_LOGIN_SERVER }}"
+          ACR_NAME="${ACR_SERVER%.azurecr.io}"
+          REPO="town-crier-worker-go"
+          az acr import \
+            --name "$ACR_NAME" \
+            --source "${{ steps.resolve-image.outputs.image }}" \
+            --image "${REPO}:release-${GITHUB_REF_NAME}" \
+            --force
 
   # ── Web ───────────────────────────────────────────────
   web:


### PR DESCRIPTION
## Why

`acrtowncriershared` is **Basic SKU** (no Azure RetentionPolicy — Premium only), so image digests are pruned by a CI step: `acr-build-push`'s prune kept only the newest **5** manifests per repo. Because frequent dev merges share the same repos (`town-crier-api-go`, `town-crier-worker-go`) as prod releases, a release's digest fell out of that window within ~1–2 days — so ACA rollback-by-old-image was impossible (ImagePullBackOff), and cd-prod's digest resolver silently fell back to `:latest`. This is why fix-forward was the only option during the read_at incident (tc-44nf).

## Changes

- **`cd-prod.yml`** — after a successful deploy, both the `api-go` and `worker` jobs durably tag the shipped digest `release-<version>` via `az acr import` (same-registry, tag-only, `--force` idempotent).
- **`acr-build-push` prune** — rewritten to **protect** any manifest carrying a `release-*` tag: keeps the newest **15 release** digests and the newest **10 non-release** (dev-build) manifests, deleting only what falls outside both windows. `latest` is always retained (newest dev). jq verified on a sample (only oldest dev builds selected; releases + null-tags safe).

## Effect

A prior release's digest now survives subsequent dev merges and later releases, so it can be re-pinned for an ACA rollback. Forward-looking — already-purged digests can't be recovered; releases cut after this ships are protected. No infra change (Basic SKU is correct; Premium's RetentionPolicy only deletes *untagged* manifests and wouldn't help).

Closes tc-44nf.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployed container images are now marked with durable release tags, making it easier to identify exact production versions.

* **Bug Fixes**
  * Improved image cleanup so recent release builds are retained longer, while non-release images continue to be pruned separately.
  * Prevents deployed images from being removed too early during routine cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->