### PR TITLE
tc CLI: admin stats endpoint (GET /v1/admin/stats + tc stats) + saved/offer/device columns

### DIFF
--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -48,6 +48,7 @@ var anonymousPatterns = map[string]struct{}{
 	// authenticated solely by the X-Admin-Key gate inside the handlers.
 	"PUT /v1/admin/subscriptions": {},
 	"GET /v1/admin/users":         {},
+	"GET /v1/admin/stats":         {},
 	"POST /v1/admin/offer-codes":  {},
 	// The App Store Server Notifications webhook is Apple -> API, not user-facing,
 	// so it is anonymous to Auth0; the signed JWS is its authentication. (The
@@ -85,12 +86,51 @@ func (d *dispatchMux) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 // notifStoreReader is the consumer-side slice of the notification store the
-// router wires into two places: the latest-unread lookup for NearbyRoutes and
-// the batched per-user tally for the admin user list. *notifications.PostgresStore
-// (which satisfies the full notifications.Store) satisfies it structurally.
+// router wires into three places: the latest-unread lookup for NearbyRoutes, the
+// batched per-user tally for the admin user list, and the whole-table totals for
+// the admin stats reach block. *notifications.PostgresStore (which satisfies the
+// full notifications.Store) satisfies it structurally.
 type notifStoreReader interface {
 	GetLatestUnreadByApplications(ctx context.Context, userID string, applicationUIDs []string) (map[string]notifications.LatestUnread, error)
 	CountsByUsers(ctx context.Context, userIDs []string) (map[string]notifications.NotificationCounts, error)
+	Totals(ctx context.Context) (notifications.NotificationTotals, error)
+}
+
+// savedStoreReader is the saved-application store the router wires into the
+// feature routes plus the admin surface. It embeds the full savedapplications
+// Store (feature routes) and adds the admin-read batched count + global total.
+// *savedapplications.PostgresStore satisfies it.
+type savedStoreReader interface {
+	savedapplications.Store
+	CountsByUsers(ctx context.Context, userIDs []string) (map[string]int, error)
+	Count(ctx context.Context) (int, error)
+}
+
+// deviceStoreReader is the device-registration store the router wires into the
+// device routes plus the admin surface. It embeds the full devicetokens Store
+// and adds the admin-read batched count + global total.
+// *devicetokens.PostgresStore satisfies it.
+type deviceStoreReader interface {
+	devicetokens.Store
+	CountsByUsers(ctx context.Context, userIDs []string) (map[string]int, error)
+	Count(ctx context.Context) (int, error)
+}
+
+// offerStoreReader is the offer-code store the router wires into the redeem
+// routes plus the admin surface. It embeds the full offercodes Store and adds
+// the admin-read batched redemption lookup. *offercodes.PostgresStore satisfies it.
+type offerStoreReader interface {
+	offercodes.Store
+	RedeemedByUsers(ctx context.Context, userIDs []string) (map[string][]offercodes.OfferCode, error)
+}
+
+// adminUserStore is the admin profile store the router wires into admin.Routes:
+// the full AdminProfileStore plus the two stats aggregates (paid-tier candidates
+// and the whole-base UserStats). *profiles.PostgresAdminStore satisfies it.
+type adminUserStore interface {
+	profiles.AdminProfileStore
+	PaidCandidates(ctx context.Context) ([]*profiles.UserProfile, error)
+	UserStats(ctx context.Context, now time.Time) (profiles.UserStats, error)
 }
 
 // newRouter wires the feature routes onto a mux and wraps it in the production
@@ -124,16 +164,16 @@ func newRouter(
 	auth0 profiles.Auth0Manager,
 	cascade profiles.CascadeDeleters,
 	exportReaders profiles.ExportReaders,
-	deviceStore devicetokens.Store,
+	deviceStore deviceStoreReader,
 	stateStore notificationstate.Store,
 	notifStore notifStoreReader,
 	watchZoneStore watchzones.Store,
 	appStore applications.Store,
-	savedStore savedapplications.Store,
+	savedStore savedStoreReader,
 	geocodeClient *geocoding.Client,
 	designationClient *designations.Client,
-	offerStore offercodes.Store,
-	adminStore profiles.AdminProfileStore,
+	offerStore offerStoreReader,
+	adminStore adminUserStore,
 	adminKey string,
 	siteBuildKey string,
 	jwsVerifier *subscriptions.JWSVerifier,
@@ -239,9 +279,12 @@ func newRouter(
 	}
 	if adminStore != nil && offerStore != nil {
 		// Admin endpoints are anonymous to Auth0 and gated by the X-Admin-Key. The
-		// cross-user admin store backs grant/list; the offer-code store backs
-		// generate.
-		admin.Routes(mux, adminKey, adminStore, notifStore, auth0, offerStore, offercodes.NewRandomGenerator(), time.Now, logger)
+		// cross-user admin store backs grant/list/stats; the offer-code store backs
+		// both generate (writer) and the active-code column + comped-classification
+		// reader (RedeemedByUsers). The notif/saved/device readers enrich the user
+		// list and feed the stats reach block; each may be nil on a store-less boot,
+		// and the handlers treat a nil reader as "metric absent".
+		admin.Routes(mux, adminKey, adminStore, notifStore, savedStore, deviceStore, offerStore, auth0, offerStore, offercodes.NewRandomGenerator(), time.Now, logger)
 	}
 	if store != nil && adminStore != nil && jwsVerifier != nil && appleNotifStore != nil {
 		// Subscriptions: verify (authed, by user id via the profile store) and the

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -164,6 +164,10 @@ func (fakeSavedStore) UserIDsForApplication(context.Context, string, int) ([]str
 	return nil, nil
 }
 func (fakeSavedStore) DeleteAllByUserID(context.Context, string) error { return nil }
+func (fakeSavedStore) CountsByUsers(context.Context, []string) (map[string]int, error) {
+	return map[string]int{}, nil
+}
+func (fakeSavedStore) Count(context.Context) (int, error) { return 0, nil }
 
 // fakeAdminStore is a profiles.AdminProfileStore returning the empty path.
 type fakeAdminStore struct{}
@@ -187,6 +191,12 @@ func (fakeAdminStore) Save(context.Context, *profiles.UserProfile) error { retur
 func (fakeAdminStore) List(context.Context, string, int, string) (profiles.Page, error) {
 	return profiles.Page{}, nil
 }
+func (fakeAdminStore) PaidCandidates(context.Context) ([]*profiles.UserProfile, error) {
+	return nil, nil
+}
+func (fakeAdminStore) UserStats(context.Context, time.Time) (profiles.UserStats, error) {
+	return profiles.UserStats{}, nil
+}
 
 // fakeSubNotifStore is a subscriptions.Store; nothing is ever processed.
 type fakeSubNotifStore struct{}
@@ -206,6 +216,9 @@ func (fakeOfferStore) RedeemWithCAS(context.Context, string, string, time.Time) 
 }
 func (fakeOfferStore) RedeemedByUserID(context.Context, string) ([]offercodes.OfferCode, error) {
 	return nil, nil
+}
+func (fakeOfferStore) RedeemedByUsers(context.Context, []string) (map[string][]offercodes.OfferCode, error) {
+	return map[string][]offercodes.OfferCode{}, nil
 }
 func (fakeOfferStore) AnonymiseRedemptionsByUserID(context.Context, string) error { return nil }
 
@@ -605,6 +618,60 @@ func TestRouter_AdminGate(t *testing.T) {
 	}
 	if got := withKey.Body.String(); got != `{"items":[],"continuationToken":null}` {
 		t.Errorf("with key: body = %s", got)
+	}
+}
+
+// TestRouter_AdminStatsGate confirms GET /v1/admin/stats is wired into the admin
+// router, gated by the same X-Admin-Key, and serves the pinned contract even
+// when the saved/device/notif reach stores are unwired (nil) — the reach block
+// falls back to zeros rather than 500ing.
+func TestRouter_AdminStatsGate(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	offerStore := fakeOfferStore{}
+	adminStore := fakeAdminStore{}
+	// notif (pos 9), saved (pos 12), device (pos 7) all nil: the reach stores are
+	// unwired, exercising the nil-safe reach path through the full router chain.
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, nil, nil, testGeocodeClient(t), testDesignationClient(t), offerStore, adminStore, "s3cret", "", nil, nil, "", nil, nil, logger)
+
+	statsReq := func(key string) *httptest.ResponseRecorder {
+		t.Helper()
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+		req := httptest.NewRequestWithContext(ctx, http.MethodGet, "/v1/admin/stats", nil)
+		if key != "" {
+			req.Header.Set("X-Admin-Key", key)
+		}
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, req)
+		return rec
+	}
+
+	// No key: bodyless 401 with no WWW-Authenticate (admin gate, not Auth0).
+	noKey := statsReq("")
+	if noKey.Code != http.StatusUnauthorized {
+		t.Fatalf("no key: status = %d, want 401", noKey.Code)
+	}
+	if got := noKey.Header().Get("WWW-Authenticate"); got != "" {
+		t.Errorf("no key: WWW-Authenticate = %q, want empty (admin gate)", got)
+	}
+
+	// Correct key: reaches the stats handler; the empty fakeAdminStore yields the
+	// all-zero contract with a null mostRecent.
+	withKey := statsReq("s3cret")
+	if withKey.Code != http.StatusOK {
+		t.Fatalf("with key: status = %d body = %s", withKey.Code, withKey.Body.String())
+	}
+	want := `{` +
+		`"users":{"total":0,"byTier":{"Free":0,"Personal":0,"Pro":0}},` +
+		`"paying":{"effectivePaid":0,"appStore":0,"comped":0,"lapsed":0,"inGrace":0},` +
+		`"signups":{"last24h":0,"last7d":0,"last30d":0,"mostRecent":null},` +
+		`"activity":{"active24h":0,"active7d":0,"zeroWatchZones":0,"noEmail":0},` +
+		`"reach":{"watchZones":0,"savedApplications":0,"deviceRegistrations":0,"notificationsSent":0,"notificationsUnread":0}` +
+		`}`
+	if got := withKey.Body.String(); got != want {
+		t.Errorf("with key: body =\n  %s\nwant\n  %s", got, want)
 	}
 }
 

--- a/api-go/internal/admin/handler.go
+++ b/api-go/internal/admin/handler.go
@@ -15,12 +15,15 @@ import (
 const maxBodyBytes = 1 << 20
 
 // profileAdminStore is the cross-partition profile store the admin handlers use:
-// find-by-email and save (grant) plus the paged list. profiles.AdminStore
+// find-by-email and save (grant), the paged list, and the stats aggregates
+// (paid-tier candidates + the whole-base UserStats). profiles.PostgresAdminStore
 // satisfies it.
 type profileAdminStore interface {
 	GetByEmail(ctx context.Context, email string) (*profiles.UserProfile, error)
 	Save(ctx context.Context, p *profiles.UserProfile) error
 	List(ctx context.Context, emailSearch string, pageSize int, continuationToken string) (profiles.Page, error)
+	PaidCandidates(ctx context.Context) ([]*profiles.UserProfile, error)
+	UserStats(ctx context.Context, now time.Time) (profiles.UserStats, error)
 }
 
 // tierSync is the Auth0 management interface the admin handlers use: push the
@@ -29,10 +32,35 @@ type tierSync interface {
 	UpdateSubscriptionTier(ctx context.Context, userID, tier string) error
 }
 
-// notificationCounts is the batched notification tally the user list enriches
-// each row with. *notifications.PostgresStore satisfies it.
+// notificationCounts is the notification store the admin surface reads: the
+// batched per-user tally for the user list and the whole-table totals for the
+// stats reach block. *notifications.PostgresStore satisfies it.
 type notificationCounts interface {
 	CountsByUsers(ctx context.Context, userIDs []string) (map[string]notifications.NotificationCounts, error)
+	Totals(ctx context.Context) (notifications.NotificationTotals, error)
+}
+
+// savedCountReader is the saved-application store the admin surface reads: the
+// batched per-user count for the user list and the global total for the stats
+// reach block. *savedapplications.PostgresStore satisfies it.
+type savedCountReader interface {
+	CountsByUsers(ctx context.Context, userIDs []string) (map[string]int, error)
+	Count(ctx context.Context) (int, error)
+}
+
+// deviceCountReader is the device-registration store the admin surface reads:
+// the batched per-user count for the user list and the global total for the
+// stats reach block. *devicetokens.PostgresStore satisfies it.
+type deviceCountReader interface {
+	CountsByUsers(ctx context.Context, userIDs []string) (map[string]int, error)
+	Count(ctx context.Context) (int, error)
+}
+
+// offerRedemptionReader is the batched offer-code redemption reader the user
+// list uses to surface each user's active offer code.
+// *offercodes.PostgresStore satisfies it.
+type offerRedemptionReader interface {
+	RedeemedByUsers(ctx context.Context, userIDs []string) (map[string][]offercodes.OfferCode, error)
 }
 
 // offerCodeStore is the offer-code writer the generate endpoint uses.
@@ -48,22 +76,39 @@ type codeGenerator interface {
 }
 
 type handler struct {
-	profiles    profileAdminStore
-	notifCounts notificationCounts
-	auth0       tierSync
-	codes       offerCodeStore
-	generator   codeGenerator
-	now         func() time.Time
-	logger      *slog.Logger
+	profiles     profileAdminStore
+	notifCounts  notificationCounts
+	savedCounts  savedCountReader
+	deviceCounts deviceCountReader
+	redemptions  offerRedemptionReader
+	auth0        tierSync
+	codes        offerCodeStore
+	generator    codeGenerator
+	now          func() time.Time
+	logger       *slog.Logger
 }
 
 // Routes registers the admin endpoints on mux, each gated by the shared admin
 // key. The routes are anonymous to Auth0 (the caller carries no bearer token),
-// so the key gate is their only authentication.
-func Routes(mux *http.ServeMux, adminKey string, profileStore profileAdminStore, notifCounts notificationCounts, auth0 tierSync, codes offerCodeStore, generator codeGenerator, now func() time.Time, logger *slog.Logger) {
-	h := &handler{profiles: profileStore, notifCounts: notifCounts, auth0: auth0, codes: codes, generator: generator, now: now, logger: logger}
+// so the key gate is their only authentication. The enrichment/reach readers
+// (notifCounts, savedCounts, deviceCounts, redemptions) may be nil on a
+// store-less local boot; the handlers treat a nil reader as "metric absent".
+func Routes(mux *http.ServeMux, adminKey string, profileStore profileAdminStore, notifCounts notificationCounts, savedCounts savedCountReader, deviceCounts deviceCountReader, redemptions offerRedemptionReader, auth0 tierSync, codes offerCodeStore, generator codeGenerator, now func() time.Time, logger *slog.Logger) {
+	h := &handler{
+		profiles:     profileStore,
+		notifCounts:  notifCounts,
+		savedCounts:  savedCounts,
+		deviceCounts: deviceCounts,
+		redemptions:  redemptions,
+		auth0:        auth0,
+		codes:        codes,
+		generator:    generator,
+		now:          now,
+		logger:       logger,
+	}
 	mux.HandleFunc("PUT /v1/admin/subscriptions", requireAdminKey(adminKey, h.grantSubscription))
 	mux.HandleFunc("GET /v1/admin/users", requireAdminKey(adminKey, h.listUsers))
+	mux.HandleFunc("GET /v1/admin/stats", requireAdminKey(adminKey, h.stats))
 	mux.HandleFunc("POST /v1/admin/offer-codes", requireAdminKey(adminKey, h.generateOfferCodes))
 }
 

--- a/api-go/internal/admin/handler_test.go
+++ b/api-go/internal/admin/handler_test.go
@@ -15,9 +15,11 @@ import (
 )
 
 // fakeNotifCounts is a hand-written notificationCounts double: it records the
-// user ids it was asked about and returns pre-configured tallies.
+// user ids it was asked about and returns pre-configured per-user tallies and
+// whole-table totals.
 type fakeNotifCounts struct {
 	counts map[string]notifications.NotificationCounts
+	totals notifications.NotificationTotals
 	gotIDs []string
 }
 
@@ -26,14 +28,70 @@ func (f *fakeNotifCounts) CountsByUsers(_ context.Context, userIDs []string) (ma
 	return f.counts, nil
 }
 
+func (f *fakeNotifCounts) Totals(_ context.Context) (notifications.NotificationTotals, error) {
+	return f.totals, nil
+}
+
+// fakeSavedCounts is a savedCountReader double: per-user saved counts plus a
+// global total. It records the user ids it was asked about.
+type fakeSavedCounts struct {
+	counts map[string]int
+	total  int
+	gotIDs []string
+}
+
+func (f *fakeSavedCounts) CountsByUsers(_ context.Context, userIDs []string) (map[string]int, error) {
+	f.gotIDs = userIDs
+	return f.counts, nil
+}
+
+func (f *fakeSavedCounts) Count(_ context.Context) (int, error) { return f.total, nil }
+
+// fakeDeviceCounts is a deviceCountReader double: per-user device counts plus a
+// global total. It records the user ids it was asked about.
+type fakeDeviceCounts struct {
+	counts map[string]int
+	total  int
+	gotIDs []string
+}
+
+func (f *fakeDeviceCounts) CountsByUsers(_ context.Context, userIDs []string) (map[string]int, error) {
+	f.gotIDs = userIDs
+	return f.counts, nil
+}
+
+func (f *fakeDeviceCounts) Count(_ context.Context) (int, error) { return f.total, nil }
+
+// fakeRedemptions is an offerRedemptionReader double: it returns pre-configured
+// redeemed codes per user and records the user ids it was asked about.
+type fakeRedemptions struct {
+	byUser map[string][]offercodes.OfferCode
+	gotIDs []string
+}
+
+func (f *fakeRedemptions) RedeemedByUsers(_ context.Context, userIDs []string) (map[string][]offercodes.OfferCode, error) {
+	f.gotIDs = userIDs
+	return f.byUser, nil
+}
+
 type fakeAdminStore struct {
-	byEmail map[string]*profiles.UserProfile
-	saved   *profiles.UserProfile
-	page    profiles.Page
+	byEmail    map[string]*profiles.UserProfile
+	saved      *profiles.UserProfile
+	page       profiles.Page
+	candidates []*profiles.UserProfile
+	stats      profiles.UserStats
 
 	gotSearch   string
 	gotPageSize int
 	gotToken    string
+}
+
+func (f *fakeAdminStore) PaidCandidates(_ context.Context) ([]*profiles.UserProfile, error) {
+	return f.candidates, nil
+}
+
+func (f *fakeAdminStore) UserStats(_ context.Context, _ time.Time) (profiles.UserStats, error) {
+	return f.stats, nil
 }
 
 func (f *fakeAdminStore) GetByEmail(_ context.Context, email string) (*profiles.UserProfile, error) {
@@ -98,6 +156,28 @@ func newTestHandler(store profileAdminStore, notifCounts notificationCounts, aut
 		logger:      slog.New(slog.DiscardHandler),
 	}
 }
+
+// activeCode builds a redeemed OfferCode whose window is still open at the test's
+// clock, so OfferCode.ActiveAt(now) is true.
+func activeCode(code string, redeemedAt time.Time) offercodes.OfferCode {
+	at := redeemedAt
+	return offercodes.OfferCode{
+		Code: code, Tier: profiles.TierPro, DurationDays: 30,
+		Redeemed: true, RedeemedByUserID: strPtr("u"), RedeemedAt: &at,
+	}
+}
+
+// expiredCode builds a redeemed OfferCode whose window has closed at the test's
+// clock, so OfferCode.ActiveAt(now) is false.
+func expiredCode(code string, redeemedAt time.Time) offercodes.OfferCode {
+	at := redeemedAt
+	return offercodes.OfferCode{
+		Code: code, Tier: profiles.TierPro, DurationDays: 30,
+		Redeemed: true, RedeemedByUserID: strPtr("u"), RedeemedAt: &at,
+	}
+}
+
+func strPtr(s string) *string { return &s }
 
 func serve(t *testing.T, hf http.HandlerFunc, method, target, body string) *httptest.ResponseRecorder {
 	t.Helper()
@@ -201,12 +281,15 @@ func TestGrant_InvalidTier(t *testing.T) {
 func TestListUsers_ReturnsPage(t *testing.T) {
 	t.Parallel()
 
-	// p1: has a watch-zone count and 2 unread of 57 notifications.
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	// p1: watch-zone count, 2 unread of 57 notifications, 3 saved, 1 device, and
+	// two redeemed offer codes — one expired, one still active.
 	created1 := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
 	p1, _ := profiles.NewProfile("auth0|u1", "u@example.com", created1)
 	wz := 2
 	p1.WatchZoneCount = &wz
-	// p2: legacy nil watch-zone count and no notifications (absent from counts).
+	// p2: legacy nil watch-zone count, no notifications, no saved/devices, and no
+	// offer code (absent from every enrichment map).
 	created2 := time.Date(2026, 2, 2, 10, 0, 0, 0, time.UTC)
 	p2, _ := profiles.NewProfile("auth0|u2", "b@example.com", created2)
 	p2.Tier = profiles.TierPro
@@ -215,7 +298,18 @@ func TestListUsers_ReturnsPage(t *testing.T) {
 	counts := &fakeNotifCounts{counts: map[string]notifications.NotificationCounts{
 		"auth0|u1": {Total: 57, Unread: 2},
 	}}
-	h := newTestHandler(store, counts, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+	saved := &fakeSavedCounts{counts: map[string]int{"auth0|u1": 3}}
+	devices := &fakeDeviceCounts{counts: map[string]int{"auth0|u1": 1}}
+	redemptions := &fakeRedemptions{byUser: map[string][]offercodes.OfferCode{
+		"auth0|u1": {
+			expiredCode("OLDEXPIRED", now.Add(-40*24*time.Hour)),
+			activeCode("NOWACTIVE", now.Add(-1*24*time.Hour)),
+		},
+	}}
+	h := newTestHandler(store, counts, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, now)
+	h.savedCounts = saved
+	h.deviceCounts = devices
+	h.redemptions = redemptions
 
 	rec := serve(t, h.listUsers, http.MethodGet, "/v1/admin/users?search=example&pageSize=50", "")
 
@@ -223,8 +317,8 @@ func TestListUsers_ReturnsPage(t *testing.T) {
 		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
 	}
 	want := `{"items":[` +
-		`{"userId":"auth0|u1","email":"u@example.com","tier":"Free","watchZoneCount":2,"createdAt":"2026-01-01T09:00:00Z","lastActiveAt":"2026-01-01T09:00:00Z","notificationTotal":57,"notificationUnread":2},` +
-		`{"userId":"auth0|u2","email":"b@example.com","tier":"Pro","watchZoneCount":null,"createdAt":"2026-02-02T10:00:00Z","lastActiveAt":"2026-02-02T10:00:00Z","notificationTotal":0,"notificationUnread":0}` +
+		`{"userId":"auth0|u1","email":"u@example.com","tier":"Free","watchZoneCount":2,"createdAt":"2026-01-01T09:00:00Z","lastActiveAt":"2026-01-01T09:00:00Z","notificationTotal":57,"notificationUnread":2,"savedCount":3,"deviceCount":1,"offerCode":"NOWACTIVE"},` +
+		`{"userId":"auth0|u2","email":"b@example.com","tier":"Pro","watchZoneCount":null,"createdAt":"2026-02-02T10:00:00Z","lastActiveAt":"2026-02-02T10:00:00Z","notificationTotal":0,"notificationUnread":0,"savedCount":0,"deviceCount":0,"offerCode":null}` +
 		`],"continuationToken":"next"}`
 	if got := rec.Body.String(); got != want {
 		t.Errorf("body =\n  %s\nwant\n  %s", got, want)
@@ -232,9 +326,41 @@ func TestListUsers_ReturnsPage(t *testing.T) {
 	if store.gotSearch != "example" || store.gotPageSize != 50 {
 		t.Errorf("forwarded search=%q pageSize=%d", store.gotSearch, store.gotPageSize)
 	}
-	// The handler batches the whole page's user ids into a single counts lookup.
-	if len(counts.gotIDs) != 2 || counts.gotIDs[0] != "auth0|u1" || counts.gotIDs[1] != "auth0|u2" {
-		t.Errorf("counts lookup ids = %v, want [auth0|u1 auth0|u2]", counts.gotIDs)
+	// Each enrichment batches the whole page's user ids into a single lookup.
+	for name, got := range map[string][]string{
+		"notifs":      counts.gotIDs,
+		"saved":       saved.gotIDs,
+		"devices":     devices.gotIDs,
+		"redemptions": redemptions.gotIDs,
+	} {
+		if len(got) != 2 || got[0] != "auth0|u1" || got[1] != "auth0|u2" {
+			t.Errorf("%s lookup ids = %v, want [auth0|u1 auth0|u2]", name, got)
+		}
+	}
+}
+
+// TestListUsers_NilEnrichmentStores skips every enrichment when its store is
+// unwired (store-less local boot): the row still renders with zero counts and a
+// null offer code, never a panic or 500.
+func TestListUsers_NilEnrichmentStores(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	p, _ := profiles.NewProfile("auth0|u1", "u@example.com", created)
+	store := &fakeAdminStore{page: profiles.Page{Profiles: []*profiles.UserProfile{p}}}
+	// notifCounts nil too — every enrichment store is unwired.
+	h := newTestHandler(store, nil, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+
+	rec := serve(t, h.listUsers, http.MethodGet, "/v1/admin/users", "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	want := `{"items":[` +
+		`{"userId":"auth0|u1","email":"u@example.com","tier":"Free","watchZoneCount":null,"createdAt":"2026-01-01T09:00:00Z","lastActiveAt":"2026-01-01T09:00:00Z","notificationTotal":0,"notificationUnread":0,"savedCount":0,"deviceCount":0,"offerCode":null}` +
+		`],"continuationToken":null}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body =\n  %s\nwant\n  %s", got, want)
 	}
 }
 
@@ -322,5 +448,101 @@ func TestGenerate_ValidationErrors(t *testing.T) {
 				t.Errorf("body = %q\nwant %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// paidCandidate builds a paid-tier UserProfile for the stats classification test.
+func paidCandidate(userID string, tier profiles.SubscriptionTier, expiry *time.Time, grace *time.Time, otid *string) *profiles.UserProfile {
+	return &profiles.UserProfile{
+		UserID:                userID,
+		Tier:                  tier,
+		SubscriptionExpiry:    expiry,
+		GracePeriodExpiry:     grace,
+		OriginalTransactionID: otid,
+	}
+}
+
+// TestStats_ReturnsPinnedContract exercises the full aggregate: the paying
+// buckets classified via EffectiveTier (an App Store, a comped, a lapsed and an
+// in-grace candidate), the user/tier/signup/activity blocks, and the reach
+// totals — asserting the exact pinned JSON contract the CLI mirror depends on.
+func TestStats_ReturnsPinnedContract(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	future := now.Add(30 * 24 * time.Hour)
+	past := now.Add(-1 * time.Hour)
+	txn := "1000000000000001"
+
+	recent := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	recentEmail := "new@example.com"
+	store := &fakeAdminStore{
+		stats: profiles.UserStats{
+			Total:           100,
+			ByTier:          map[string]int{"Free": 70, "Personal": 20, "Pro": 10},
+			Signups24h:      5,
+			Signups7d:       12,
+			Signups30d:      30,
+			MostRecent:      &profiles.RecentSignup{UserID: "auth0|new", Email: &recentEmail, CreatedAt: recent},
+			Active24h:       8,
+			Active7d:        20,
+			ZeroWatchZones:  15,
+			NoEmail:         3,
+			TotalWatchZones: 250,
+		},
+		candidates: []*profiles.UserProfile{
+			paidCandidate("auth0|appstore", profiles.TierPro, &future, nil, &txn),   // effective-paid + appStore
+			paidCandidate("auth0|comped", profiles.TierPersonal, &future, nil, nil), // effective-paid + comped
+			paidCandidate("auth0|lapsed", profiles.TierPro, &past, nil, nil),        // lapsed (expired, no grace)
+			paidCandidate("auth0|grace", profiles.TierPro, &past, &future, nil),     // effective-paid via live grace + comped + inGrace
+		},
+	}
+	counts := &fakeNotifCounts{totals: notifications.NotificationTotals{Sent: 9000, Unread: 1200}}
+	h := newTestHandler(store, counts, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, now)
+	h.savedCounts = &fakeSavedCounts{total: 500}
+	h.deviceCounts = &fakeDeviceCounts{total: 300}
+	h.redemptions = &fakeRedemptions{}
+
+	rec := serve(t, h.stats, http.MethodGet, "/v1/admin/stats", "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	want := `{` +
+		`"users":{"total":100,"byTier":{"Free":70,"Personal":20,"Pro":10}},` +
+		`"paying":{"effectivePaid":3,"appStore":1,"comped":2,"lapsed":1,"inGrace":1},` +
+		`"signups":{"last24h":5,"last7d":12,"last30d":30,"mostRecent":{"userId":"auth0|new","email":"new@example.com","createdAt":"2026-06-30T09:00:00Z"}},` +
+		`"activity":{"active24h":8,"active7d":20,"zeroWatchZones":15,"noEmail":3},` +
+		`"reach":{"watchZones":250,"savedApplications":500,"deviceRegistrations":300,"notificationsSent":9000,"notificationsUnread":1200}` +
+		`}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body =\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+// TestStats_NoUsers_NullMostRecentAndNilStores renders the empty base with a
+// null mostRecent and skips the reach stores when unwired (nil), never panicking.
+func TestStats_NoUsers_NullMostRecentAndNilStores(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeAdminStore{stats: profiles.UserStats{}} // Total 0, MostRecent nil, ByTier nil
+	// notifCounts nil and saved/device readers left unset (nil): the reach block
+	// must fall back to zeros without a nil dereference.
+	h := newTestHandler(store, nil, &fakeTierSync{}, &fakeOfferStore{}, &fakeGenerator{}, time.Now())
+
+	rec := serve(t, h.stats, http.MethodGet, "/v1/admin/stats", "")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	want := `{` +
+		`"users":{"total":0,"byTier":{"Free":0,"Personal":0,"Pro":0}},` +
+		`"paying":{"effectivePaid":0,"appStore":0,"comped":0,"lapsed":0,"inGrace":0},` +
+		`"signups":{"last24h":0,"last7d":0,"last30d":0,"mostRecent":null},` +
+		`"activity":{"active24h":0,"active7d":0,"zeroWatchZones":0,"noEmail":0},` +
+		`"reach":{"watchZones":0,"savedApplications":0,"deviceRegistrations":0,"notificationsSent":0,"notificationsUnread":0}` +
+		`}`
+	if got := rec.Body.String(); got != want {
+		t.Errorf("body =\n  %s\nwant\n  %s", got, want)
 	}
 }

--- a/api-go/internal/admin/middleware.go
+++ b/api-go/internal/admin/middleware.go
@@ -1,8 +1,8 @@
 // Package admin owns the admin surface: the X-Admin-Key gate and the
-// PUT /v1/admin/subscriptions, GET /v1/admin/users, POST /v1/admin/offer-codes
-// and POST /v1/admin/watchzones/backfill-location handlers. The admin routes are
-// anonymous to Auth0 (absent from the fallback-deny set) and authenticated
-// solely by the shared admin key.
+// PUT /v1/admin/subscriptions, GET /v1/admin/users, GET /v1/admin/stats,
+// POST /v1/admin/offer-codes and POST /v1/admin/watchzones/backfill-location
+// handlers. The admin routes are anonymous to Auth0 (absent from the
+// fallback-deny set) and authenticated solely by the shared admin key.
 package admin
 
 import (

--- a/api-go/internal/admin/stats.go
+++ b/api-go/internal/admin/stats.go
@@ -1,0 +1,221 @@
+package admin
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+// statsResponse is the pinned JSON contract for GET /v1/admin/stats. The field
+// order and names are load-bearing: the tc CLI mirrors this shape byte-for-field.
+type statsResponse struct {
+	Users    statsUsers    `json:"users"`
+	Paying   statsPaying   `json:"paying"`
+	Signups  statsSignups  `json:"signups"`
+	Activity statsActivity `json:"activity"`
+	Reach    statsReach    `json:"reach"`
+}
+
+type statsUsers struct {
+	Total  int         `json:"total"`
+	ByTier statsByTier `json:"byTier"`
+}
+
+// statsByTier is an explicit struct (not a map) so the three tier keys always
+// render, in a fixed order, even when a tier has zero users.
+type statsByTier struct {
+	Free     int `json:"Free"`
+	Personal int `json:"Personal"`
+	Pro      int `json:"Pro"`
+}
+
+type statsPaying struct {
+	EffectivePaid int `json:"effectivePaid"`
+	AppStore      int `json:"appStore"`
+	Comped        int `json:"comped"`
+	Lapsed        int `json:"lapsed"`
+	InGrace       int `json:"inGrace"`
+}
+
+type statsSignups struct {
+	Last24h    int              `json:"last24h"`
+	Last7d     int              `json:"last7d"`
+	Last30d    int              `json:"last30d"`
+	MostRecent *statsMostRecent `json:"mostRecent"`
+}
+
+// statsMostRecent is null when the user base is empty; Email is null when the
+// most-recent account has none (e.g. a Sign-in-with-Apple withheld email).
+type statsMostRecent struct {
+	UserID    string  `json:"userId"`
+	Email     *string `json:"email"`
+	CreatedAt string  `json:"createdAt"` // RFC3339
+}
+
+type statsActivity struct {
+	Active24h      int `json:"active24h"`
+	Active7d       int `json:"active7d"`
+	ZeroWatchZones int `json:"zeroWatchZones"`
+	NoEmail        int `json:"noEmail"`
+}
+
+type statsReach struct {
+	WatchZones          int `json:"watchZones"`
+	SavedApplications   int `json:"savedApplications"`
+	DeviceRegistrations int `json:"deviceRegistrations"`
+	NotificationsSent   int `json:"notificationsSent"`
+	NotificationsUnread int `json:"notificationsUnread"`
+}
+
+// stats implements GET /v1/admin/stats: the whole-user-base aggregate. The user,
+// signup and activity blocks come from the profiles UserStats SQL aggregate; the
+// paying block is classified in Go from the paid-tier candidates via
+// EffectiveTier (so the expiry/grace rule stays in the domain); the reach block
+// sums the per-feature stores. Every reach store is optional — a nil (unwired)
+// store contributes zero, never a 500.
+func (h *handler) stats(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	now := h.now()
+
+	us, err := h.profiles.UserStats(ctx, now)
+	if err != nil {
+		h.serverError(w, r, "stats: user stats", err)
+		return
+	}
+
+	candidates, err := h.profiles.PaidCandidates(ctx)
+	if err != nil {
+		h.serverError(w, r, "stats: paid candidates", err)
+		return
+	}
+
+	savedTotal, err := h.savedTotal(ctx)
+	if err != nil {
+		h.serverError(w, r, "stats: saved total", err)
+		return
+	}
+	deviceTotal, err := h.deviceTotal(ctx)
+	if err != nil {
+		h.serverError(w, r, "stats: device total", err)
+		return
+	}
+	notifTotals, err := h.notifTotals(ctx)
+	if err != nil {
+		h.serverError(w, r, "stats: notification totals", err)
+		return
+	}
+
+	resp := statsResponse{
+		Users: statsUsers{
+			Total: us.Total,
+			ByTier: statsByTier{
+				Free:     us.ByTier["Free"],
+				Personal: us.ByTier["Personal"],
+				Pro:      us.ByTier["Pro"],
+			},
+		},
+		Paying: classifyPaying(candidates, now),
+		Signups: statsSignups{
+			Last24h:    us.Signups24h,
+			Last7d:     us.Signups7d,
+			Last30d:    us.Signups30d,
+			MostRecent: mostRecent(us.MostRecent),
+		},
+		Activity: statsActivity{
+			Active24h:      us.Active24h,
+			Active7d:       us.Active7d,
+			ZeroWatchZones: us.ZeroWatchZones,
+			NoEmail:        us.NoEmail,
+		},
+		Reach: statsReach{
+			WatchZones:          us.TotalWatchZones,
+			SavedApplications:   savedTotal,
+			DeviceRegistrations: deviceTotal,
+			NotificationsSent:   notifTotals.Sent,
+			NotificationsUnread: notifTotals.Unread,
+		},
+	}
+	h.writeJSON(r, w, resp)
+}
+
+// classifyPaying buckets the paid-tier candidates by their EffectiveTier(now),
+// mirroring the domain's lazy-expiry rule rather than the raw stored tier:
+//   - effectivePaid: EffectiveTier(now) is still paid.
+//   - appStore: effective-paid AND backed by an Apple original transaction id.
+//   - comped: effective-paid with no original transaction id (offer/admin grant).
+//   - lapsed: stored tier paid but EffectiveTier(now) has collapsed to Free.
+//   - inGrace: effective-paid held alive ONLY by a live grace period (expiry
+//     passed, grace end still ahead). It overlaps appStore/comped by design.
+func classifyPaying(candidates []*profiles.UserProfile, now time.Time) statsPaying {
+	var p statsPaying
+	for _, c := range candidates {
+		effective := c.EffectiveTier(now)
+		switch {
+		case effective.IsPaid():
+			p.EffectivePaid++
+			if c.OriginalTransactionID != nil {
+				p.AppStore++
+			} else {
+				p.Comped++
+			}
+			if inGrace(c, now) {
+				p.InGrace++
+			}
+		case c.Tier.IsPaid():
+			// Stored paid but effective Free — the entitlement has lapsed.
+			p.Lapsed++
+		}
+	}
+	return p
+}
+
+// inGrace reports whether the profile is kept effective-paid solely by a live
+// grace period: its subscription expiry has passed but its grace-period end is
+// still ahead of now.
+func inGrace(c *profiles.UserProfile, now time.Time) bool {
+	return c.SubscriptionExpiry != nil && !c.SubscriptionExpiry.After(now) &&
+		c.GracePeriodExpiry != nil && c.GracePeriodExpiry.After(now)
+}
+
+// mostRecent renders the profiles RecentSignup into the wire shape, preserving
+// the null-when-empty contract.
+func mostRecent(r *profiles.RecentSignup) *statsMostRecent {
+	if r == nil {
+		return nil
+	}
+	return &statsMostRecent{
+		UserID:    r.UserID,
+		Email:     r.Email,
+		CreatedAt: r.CreatedAt.Format(time.RFC3339),
+	}
+}
+
+// savedTotal returns the global saved-application count, or 0 when the store is
+// unwired (store-less local boot).
+func (h *handler) savedTotal(ctx context.Context) (int, error) {
+	if h.savedCounts == nil {
+		return 0, nil
+	}
+	return h.savedCounts.Count(ctx)
+}
+
+// deviceTotal returns the global device-registration count, or 0 when the store
+// is unwired.
+func (h *handler) deviceTotal(ctx context.Context) (int, error) {
+	if h.deviceCounts == nil {
+		return 0, nil
+	}
+	return h.deviceCounts.Count(ctx)
+}
+
+// notifTotals returns the whole-table notification tally, or the zero value when
+// the store is unwired.
+func (h *handler) notifTotals(ctx context.Context) (notifications.NotificationTotals, error) {
+	if h.notifCounts == nil {
+		return notifications.NotificationTotals{}, nil
+	}
+	return h.notifCounts.Totals(ctx)
+}

--- a/api-go/internal/admin/users.go
+++ b/api-go/internal/admin/users.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/offercodes"
 	"github.com/AmyDe/town-crier/api-go/internal/profiles"
 )
 
@@ -21,6 +22,11 @@ type listItem struct {
 	LastActiveAt       string  `json:"lastActiveAt"` // RFC3339
 	NotificationTotal  int     `json:"notificationTotal"`
 	NotificationUnread int     `json:"notificationUnread"`
+	SavedCount         int     `json:"savedCount"`
+	DeviceCount        int     `json:"deviceCount"`
+	// OfferCode is the user's currently-active offer code (still within its
+	// redeemed_at + duration window), or null when none is active.
+	OfferCode *string `json:"offerCode"`
 }
 
 // listResult is the response shape for GET /v1/admin/users: { items, continuationToken }.
@@ -53,14 +59,31 @@ func (h *handler) listUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Enrich each row with its notification tally in a single batched lookup
-	// after List returns, so the profile query stays purely about profiles.
-	// Users absent from the tally default to {0, 0} via the map zero value.
+	// Enrich each row with its per-user tallies in one batched lookup per column
+	// after List returns, so the profile query stays purely about profiles. Each
+	// enrichment is keyed on the page's user ids and skipped when its store is
+	// unwired; users absent from a tally default to the map zero value.
 	counts, err := h.notificationCountsFor(r, page)
 	if err != nil {
 		h.serverError(w, r, "list users: counts", err)
 		return
 	}
+	savedCounts, err := h.savedCountsFor(r, page)
+	if err != nil {
+		h.serverError(w, r, "list users: saved counts", err)
+		return
+	}
+	deviceCounts, err := h.deviceCountsFor(r, page)
+	if err != nil {
+		h.serverError(w, r, "list users: device counts", err)
+		return
+	}
+	redemptions, err := h.redemptionsFor(r, page)
+	if err != nil {
+		h.serverError(w, r, "list users: redemptions", err)
+		return
+	}
+	now := h.now()
 
 	items := make([]listItem, 0, len(page.Profiles))
 	for _, p := range page.Profiles {
@@ -74,6 +97,9 @@ func (h *handler) listUsers(w http.ResponseWriter, r *http.Request) {
 			LastActiveAt:       p.LastActiveAt.Format(time.RFC3339),
 			NotificationTotal:  nc.Total,
 			NotificationUnread: nc.Unread,
+			SavedCount:         savedCounts[p.UserID],
+			DeviceCount:        deviceCounts[p.UserID],
+			OfferCode:          activeOfferCode(redemptions[p.UserID], now),
 		})
 	}
 	var token *string
@@ -91,9 +117,54 @@ func (h *handler) notificationCountsFor(r *http.Request, page profiles.Page) (ma
 	if h.notifCounts == nil || len(page.Profiles) == 0 {
 		return map[string]notifications.NotificationCounts{}, nil
 	}
+	return h.notifCounts.CountsByUsers(r.Context(), pageUserIDs(page))
+}
+
+// savedCountsFor returns the per-user saved-application count for the page in one
+// batched lookup, skipping the query when the store is unwired or the page empty.
+func (h *handler) savedCountsFor(r *http.Request, page profiles.Page) (map[string]int, error) {
+	if h.savedCounts == nil || len(page.Profiles) == 0 {
+		return map[string]int{}, nil
+	}
+	return h.savedCounts.CountsByUsers(r.Context(), pageUserIDs(page))
+}
+
+// deviceCountsFor returns the per-user device-registration count for the page in
+// one batched lookup, skipping the query when the store is unwired or page empty.
+func (h *handler) deviceCountsFor(r *http.Request, page profiles.Page) (map[string]int, error) {
+	if h.deviceCounts == nil || len(page.Profiles) == 0 {
+		return map[string]int{}, nil
+	}
+	return h.deviceCounts.CountsByUsers(r.Context(), pageUserIDs(page))
+}
+
+// redemptionsFor returns each user's redeemed offer codes for the page in one
+// batched lookup, skipping the query when the store is unwired or the page empty.
+func (h *handler) redemptionsFor(r *http.Request, page profiles.Page) (map[string][]offercodes.OfferCode, error) {
+	if h.redemptions == nil || len(page.Profiles) == 0 {
+		return map[string][]offercodes.OfferCode{}, nil
+	}
+	return h.redemptions.RedeemedByUsers(r.Context(), pageUserIDs(page))
+}
+
+// pageUserIDs collects the page's user ids for a batched enrichment lookup.
+func pageUserIDs(page profiles.Page) []string {
 	ids := make([]string, 0, len(page.Profiles))
 	for _, p := range page.Profiles {
 		ids = append(ids, p.UserID)
 	}
-	return h.notifCounts.CountsByUsers(r.Context(), ids)
+	return ids
+}
+
+// activeOfferCode returns the first still-active code (its redeemed_at + duration
+// window has not closed at now) among the user's redeemed codes, or nil when none
+// is active. A user can hold several redeemed codes; only a live one is surfaced.
+func activeOfferCode(codes []offercodes.OfferCode, now time.Time) *string {
+	for i := range codes {
+		if codes[i].ActiveAt(now) {
+			code := codes[i].Code
+			return &code
+		}
+	}
+	return nil
 }

--- a/api-go/internal/devicetokens/integration_test.go
+++ b/api-go/internal/devicetokens/integration_test.go
@@ -268,3 +268,76 @@ func TestDevicePostgresStore_PurgeOlderThan_NoneMatch(t *testing.T) {
 	// Verify errors.Is does not fire incorrectly.
 	_ = errors.Is(err, nil)
 }
+
+// TestDevicePostgresStore_CountsByUsers_Integration tallies each user's live
+// device registrations in one grouped query, deduped by the (user_id, token)
+// primary key. A user with no rows is absent from the map; a user outside the
+// requested set is excluded.
+func TestDevicePostgresStore_CountsByUsers_Integration(t *testing.T) {
+	ctx := context.Background()
+	store := newDevicePGStore(t)
+
+	now := time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)
+	// u1 registers two tokens, u2 registers one, u3 (queried) none, u4 (not queried).
+	for _, reg := range []DeviceRegistration{
+		pgReg(t, "auth0|u1", "tok-a", PlatformIos, now),
+		pgReg(t, "auth0|u1", "tok-b", PlatformIos, now),
+		pgReg(t, "auth0|u2", "tok-c", PlatformAndroid, now),
+		pgReg(t, "auth0|u4", "tok-d", PlatformIos, now),
+	} {
+		if err := store.Save(ctx, reg); err != nil {
+			t.Fatalf("Save %s: %v", reg.Token, err)
+		}
+	}
+	// A re-registration of an existing (user_id, token) must not inflate the count.
+	if err := store.Save(ctx, pgReg(t, "auth0|u1", "tok-a", PlatformIos, now.Add(time.Hour))); err != nil {
+		t.Fatalf("Save re-register: %v", err)
+	}
+
+	got, err := store.CountsByUsers(ctx, []string{"auth0|u1", "auth0|u2", "auth0|u3"})
+	if err != nil {
+		t.Fatalf("CountsByUsers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("map size: got %d, want 2 (u3 absent, u4 excluded)", len(got))
+	}
+	if got["auth0|u1"] != 2 {
+		t.Errorf("u1: got %d, want 2 (re-register deduped)", got["auth0|u1"])
+	}
+	if got["auth0|u2"] != 1 {
+		t.Errorf("u2: got %d, want 1", got["auth0|u2"])
+	}
+	if _, ok := got["auth0|u3"]; ok {
+		t.Error("u3 (no registrations) must be absent from the map")
+	}
+}
+
+// TestDevicePostgresStore_Count_Integration returns the global count(*) across
+// all users' device registrations.
+func TestDevicePostgresStore_Count_Integration(t *testing.T) {
+	ctx := context.Background()
+	store := newDevicePGStore(t)
+
+	if got, err := store.Count(ctx); err != nil || got != 0 {
+		t.Fatalf("Count empty: got (%d, %v), want (0, nil)", got, err)
+	}
+
+	now := time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)
+	for _, reg := range []DeviceRegistration{
+		pgReg(t, "auth0|u1", "tok-a", PlatformIos, now),
+		pgReg(t, "auth0|u1", "tok-b", PlatformIos, now),
+		pgReg(t, "auth0|u2", "tok-c", PlatformAndroid, now),
+	} {
+		if err := store.Save(ctx, reg); err != nil {
+			t.Fatalf("Save %s: %v", reg.Token, err)
+		}
+	}
+
+	got, err := store.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if got != 3 {
+		t.Errorf("Count = %d, want 3", got)
+	}
+}

--- a/api-go/internal/devicetokens/store_postgres.go
+++ b/api-go/internal/devicetokens/store_postgres.go
@@ -151,6 +151,57 @@ func (s *PostgresStore) ListByUser(ctx context.Context, userID string) ([]Device
 	return regs, nil
 }
 
+// pgDeviceCountsByUsersQuery tallies each user's live device-registration count
+// in one grouped pass. The (user_id, token) primary key makes each row a
+// distinct live token, so count(*) per user is already deduped on (user_id,
+// token). Users with no rows produce no row; the caller defaults them to 0.
+const pgDeviceCountsByUsersQuery = "SELECT user_id, count(*) FROM device_registrations " +
+	"WHERE user_id = ANY($1) GROUP BY user_id"
+
+// CountsByUsers returns each user's live device-token count in a single grouped
+// query, mirroring notifications.PostgresStore.CountsByUsers. The count reflects
+// live (non-TTL-purged) tokens, deduped on (user_id, token) by the primary key.
+// Users absent from the result are absent from the map; the caller treats a
+// missing key as 0 via the map zero value. An empty user set returns an empty
+// map without issuing a query.
+func (s *PostgresStore) CountsByUsers(ctx context.Context, userIDs []string) (map[string]int, error) {
+	counts := make(map[string]int, len(userIDs))
+	if len(userIDs) == 0 {
+		return counts, nil
+	}
+	rows, err := s.db.Query(ctx, pgDeviceCountsByUsersQuery, userIDs)
+	if err != nil {
+		return nil, fmt.Errorf("query device token counts: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			userID string
+			count  int
+		)
+		if err := rows.Scan(&userID, &count); err != nil {
+			return nil, fmt.Errorf("scan device token count: %w", err)
+		}
+		counts[userID] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("device token count rows: %w", err)
+	}
+	return counts, nil
+}
+
+const pgDeviceCountQuery = "SELECT count(*) FROM device_registrations"
+
+// Count returns the global number of live device registrations across all users
+// — the admin stats "reach" total.
+func (s *PostgresStore) Count(ctx context.Context) (int, error) {
+	var total int
+	if err := s.db.QueryRow(ctx, pgDeviceCountQuery).Scan(&total); err != nil {
+		return 0, fmt.Errorf("count device registrations: %w", err)
+	}
+	return total, nil
+}
+
 const pgDeleteAllDevicesQuery = "DELETE FROM device_registrations WHERE user_id = $1"
 
 // DeleteAllByUserID removes every device registration for the user. Used by the

--- a/api-go/internal/devicetokens/store_postgres_test.go
+++ b/api-go/internal/devicetokens/store_postgres_test.go
@@ -14,10 +14,13 @@ import (
 // error-path unit tests of PostgresStore. It stores canned responses for each
 // method; tests set whichever fields they exercise.
 type fakeQuerier struct {
-	execTag  pgconn.CommandTag
-	execErr  error
-	queryErr error
-	rowErr   error
+	execTag   pgconn.CommandTag
+	execErr   error
+	queryErr  error
+	rowErr    error
+	queryRows pgx.Rows // returned from Query() when non-nil (else emptyDeviceRows)
+	countRow  pgx.Row  // returned from QueryRow() when non-nil (else errDeviceRow)
+	queries   int      // number of Query calls issued
 }
 
 func (f *fakeQuerier) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
@@ -25,14 +28,58 @@ func (f *fakeQuerier) Exec(_ context.Context, _ string, _ ...any) (pgconn.Comman
 }
 
 func (f *fakeQuerier) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	f.queries++
 	if f.queryErr != nil {
 		return nil, f.queryErr
+	}
+	if f.queryRows != nil {
+		return f.queryRows, nil
 	}
 	return &emptyDeviceRows{}, nil
 }
 
 func (f *fakeQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	if f.countRow != nil {
+		return f.countRow
+	}
 	return &errDeviceRow{err: f.rowErr}
+}
+
+// countDeviceRows is a pgx.Rows over pre-baked (user_id, count) tuples for the
+// batched CountsByUsers query.
+type countDeviceRows struct {
+	rows [][2]any
+	idx  int
+}
+
+func (r *countDeviceRows) Next() bool { return r.idx < len(r.rows) }
+func (r *countDeviceRows) Scan(dest ...any) error {
+	*dest[0].(*string) = r.rows[r.idx][0].(string)
+	*dest[1].(*int) = r.rows[r.idx][1].(int)
+	r.idx++
+	return nil
+}
+func (r *countDeviceRows) Close()                                       {}
+func (r *countDeviceRows) Err() error                                   { return nil }
+func (r *countDeviceRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *countDeviceRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *countDeviceRows) Values() ([]any, error)                       { return nil, nil }
+func (r *countDeviceRows) RawValues() [][]byte                          { return nil }
+func (r *countDeviceRows) Conn() *pgx.Conn                              { return nil }
+
+// intDeviceRow is a pgx.Row that scans a single int (the Count total) or a
+// pre-configured error.
+type intDeviceRow struct {
+	n   int
+	err error
+}
+
+func (r *intDeviceRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	*dest[0].(*int) = r.n
+	return nil
 }
 
 // emptyDeviceRows is a pgx.Rows that reports no rows and no error. It satisfies
@@ -184,5 +231,92 @@ func TestPostgresStore_PurgeOlderThan_PropagatesExecError(t *testing.T) {
 
 	if _, err := store.PurgeOlderThan(context.Background(), time.Now()); !errors.Is(err, sentinel) {
 		t.Fatalf("PurgeOlderThan error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// --- CountsByUsers ---
+
+// TestPostgresStore_CountsByUsers_Empty short-circuits an empty user set with no
+// query and an empty, non-nil map.
+func TestPostgresStore_CountsByUsers_Empty(t *testing.T) {
+	t.Parallel()
+	fq := &fakeQuerier{}
+	store := NewPostgresStore(fq)
+
+	got, err := store.CountsByUsers(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("CountsByUsers: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("empty users: got %v, want empty non-nil map", got)
+	}
+	if fq.queries != 0 {
+		t.Errorf("empty users issued %d queries, want 0", fq.queries)
+	}
+}
+
+// TestPostgresStore_CountsByUsers_PropagatesQueryError wraps a Query error.
+func TestPostgresStore_CountsByUsers_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("counts boom")
+	fq := &fakeQuerier{queryErr: boom}
+	store := NewPostgresStore(fq)
+
+	if _, err := store.CountsByUsers(context.Background(), []string{"auth0|u1"}); !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+// TestPostgresStore_CountsByUsers_MapsPerUser maps one live-token count per user;
+// a user absent from the grouped result is omitted (defaults to 0 at the call site).
+func TestPostgresStore_CountsByUsers_MapsPerUser(t *testing.T) {
+	t.Parallel()
+	fq := &fakeQuerier{queryRows: &countDeviceRows{rows: [][2]any{
+		{"auth0|u1", 3},
+		{"auth0|u2", 1},
+	}}}
+	store := NewPostgresStore(fq)
+
+	got, err := store.CountsByUsers(context.Background(), []string{"auth0|u1", "auth0|u2", "auth0|u3"})
+	if err != nil {
+		t.Fatalf("CountsByUsers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("map size: got %d, want 2 (absent users omitted)", len(got))
+	}
+	if got["auth0|u1"] != 3 || got["auth0|u2"] != 1 {
+		t.Errorf("counts: got %+v, want {u1:3 u2:1}", got)
+	}
+	if _, ok := got["auth0|u3"]; ok {
+		t.Error("auth0|u3 must be absent (defaults to zero at the call site)")
+	}
+}
+
+// --- Count ---
+
+// TestPostgresStore_Count_ReturnsTotal returns the scalar count(*).
+func TestPostgresStore_Count_ReturnsTotal(t *testing.T) {
+	t.Parallel()
+	fq := &fakeQuerier{countRow: &intDeviceRow{n: 7}}
+	store := NewPostgresStore(fq)
+
+	got, err := store.Count(context.Background())
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if got != 7 {
+		t.Errorf("Count = %d, want 7", got)
+	}
+}
+
+// TestPostgresStore_Count_PropagatesError wraps a scan error.
+func TestPostgresStore_Count_PropagatesError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("count boom")
+	fq := &fakeQuerier{countRow: &intDeviceRow{err: boom}}
+	store := NewPostgresStore(fq)
+
+	if _, err := store.Count(context.Background()); !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
 	}
 }

--- a/api-go/internal/notifications/notification.go
+++ b/api-go/internal/notifications/notification.go
@@ -29,6 +29,15 @@ type NotificationCounts struct {
 	Unread int
 }
 
+// NotificationTotals is the global notification tally across all users: the
+// number sent and how many are still unread (read_at IS NULL). It backs the
+// admin stats "reach" block — a whole-table aggregate, distinct from the
+// per-user NotificationCounts used on the user list.
+type NotificationTotals struct {
+	Sent   int
+	Unread int
+}
+
 // LatestUnread is the per-application unread descriptor surfaced on each row of
 // the applications-by-zone result: the event, the optional PlanIt decision
 // string (decision updates only), and when the notification was raised.

--- a/api-go/internal/notifications/store_postgres.go
+++ b/api-go/internal/notifications/store_postgres.go
@@ -399,6 +399,33 @@ func (s *PostgresStore) CountsByUsers(ctx context.Context, userIDs []string) (ma
 	return counts, nil
 }
 
+// pgTotalsQuery is the whole-table reach aggregate: total sent and how many are
+// still unread. count(*) with no GROUP BY always returns exactly one row (0 on
+// an empty table), so CollectExactlyOneRow is safe.
+const pgTotalsQuery = "SELECT count(*) AS sent, " +
+	"count(*) FILTER (WHERE read_at IS NULL) AS unread FROM notifications"
+
+// Totals returns the global sent/unread notification tally across all users for
+// the admin stats "reach" block. It is a whole-table aggregate, distinct from
+// the per-user CountsByUsers tally used on the user list.
+func (s *PostgresStore) Totals(ctx context.Context) (NotificationTotals, error) {
+	rows, err := s.db.Query(ctx, pgTotalsQuery)
+	if err != nil {
+		return NotificationTotals{}, fmt.Errorf("query notification totals: %w", err)
+	}
+	totals, err := pgx.CollectExactlyOneRow(rows, func(row pgx.CollectableRow) (NotificationTotals, error) {
+		var t NotificationTotals
+		if err := row.Scan(&t.Sent, &t.Unread); err != nil {
+			return NotificationTotals{}, err
+		}
+		return t, nil
+	})
+	if err != nil {
+		return NotificationTotals{}, fmt.Errorf("scan notification totals: %w", err)
+	}
+	return totals, nil
+}
+
 const pgPurgeOlderThanQuery = "DELETE FROM notifications WHERE created_at < $1"
 
 // PurgeOlderThan deletes every notification created before cutoff and returns

--- a/api-go/internal/notifications/store_postgres_integration_test.go
+++ b/api-go/internal/notifications/store_postgres_integration_test.go
@@ -408,3 +408,45 @@ func TestIntegration_Notifications_CountsByUsers(t *testing.T) {
 		t.Errorf("user-3 has no notifications and must be absent, got %+v", got["user-3"])
 	}
 }
+
+// TestIntegration_Notifications_Totals exercises the whole-table
+// count(*) / count(*) FILTER (WHERE read_at IS NULL) aggregate that backs the
+// admin stats "reach" block. An empty table returns {0, 0}; after seeding four
+// rows across two users with one marked read, the totals are {4, 3}.
+func TestIntegration_Notifications_Totals(t *testing.T) {
+	s := newPGNotifStore(t)
+	ctx := context.Background()
+
+	empty, err := s.Totals(ctx)
+	if err != nil {
+		t.Fatalf("Totals empty: %v", err)
+	}
+	if empty != (NotificationTotals{Sent: 0, Unread: 0}) {
+		t.Errorf("Totals empty: got %+v, want {0 0}", empty)
+	}
+
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	seed := []DigestNotification{
+		intNotif("n1", "user-1", "uid-A", EventNewApplication, base),
+		intNotif("n2", "user-1", "uid-B", EventNewApplication, base.Add(time.Hour)),
+		intNotif("n3", "user-1", "uid-C", EventNewApplication, base.Add(2*time.Hour)),
+		intNotif("n4", "user-2", "uid-A", EventNewApplication, base),
+	}
+	for _, n := range seed {
+		if err := s.Create(ctx, n); err != nil {
+			t.Fatalf("Create %s: %v", n.ID, err)
+		}
+	}
+	// Mark one notification read → unread drops from 4 to 3, sent stays 4.
+	if _, err := s.db.Exec(ctx, "UPDATE notifications SET read_at = $1 WHERE id = 'n1'", base.Add(3*time.Hour)); err != nil {
+		t.Fatalf("mark read: %v", err)
+	}
+
+	got, err := s.Totals(ctx)
+	if err != nil {
+		t.Fatalf("Totals: %v", err)
+	}
+	if got != (NotificationTotals{Sent: 4, Unread: 3}) {
+		t.Errorf("Totals: got %+v, want {4 3}", got)
+	}
+}

--- a/api-go/internal/notifications/store_postgres_test.go
+++ b/api-go/internal/notifications/store_postgres_test.go
@@ -449,6 +449,41 @@ func TestPostgresStore_CountsByUsers_MapsPerUser(t *testing.T) {
 	}
 }
 
+// --- Totals ---
+
+func TestPostgresStore_Totals_ReturnsSentAndUnread(t *testing.T) {
+	t.Parallel()
+	// count(*) with no GROUP BY always yields exactly one row.
+	q := &fakeQuerier{
+		queryResponses: []queryResponse{
+			{rows: newFakeRows([][]any{
+				// sent, unread
+				{128, 9},
+			})},
+		},
+	}
+	s := NewPostgresStore(q)
+
+	got, err := s.Totals(context.Background())
+	if err != nil {
+		t.Fatalf("Totals: %v", err)
+	}
+	if got != (NotificationTotals{Sent: 128, Unread: 9}) {
+		t.Errorf("Totals: got %+v, want {128 9}", got)
+	}
+}
+
+func TestPostgresStore_Totals_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("totals boom")
+	q := &fakeQuerier{queryResponses: []queryResponse{{err: boom}}}
+	s := NewPostgresStore(q)
+
+	if _, err := s.Totals(context.Background()); !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
 // --- MarkEmailSent ---
 
 func TestPostgresStore_MarkEmailSent_PropagatesExecError(t *testing.T) {

--- a/api-go/internal/offercodes/code.go
+++ b/api-go/internal/offercodes/code.go
@@ -54,6 +54,19 @@ func NewOfferCode(code string, tier profiles.SubscriptionTier, durationDays int,
 // RedeemedByUserID has been scrubbed, so it can never be re-redeemed.
 func (c *OfferCode) IsRedeemed() bool { return c.Redeemed || c.RedeemedByUserID != nil }
 
+// ActiveAt reports whether the code's granted tier window is still open at now:
+// the redemption instant plus DurationDays has not yet passed. A code that was
+// never redeemed (RedeemedAt == nil) is never active. This is the single
+// authoritative "still-active offer window" rule reused by both the list-users
+// offer-code column and the admin stats comped/active-offer aggregate, so the
+// two surfaces can never disagree on whether a code still counts.
+func (c *OfferCode) ActiveAt(now time.Time) bool {
+	if c.RedeemedAt == nil {
+		return false
+	}
+	return c.RedeemedAt.Add(time.Duration(c.DurationDays) * 24 * time.Hour).After(now)
+}
+
 // Redeem claims the code for userID at now. A second redemption is rejected with
 // ErrAlreadyRedeemed.
 func (c *OfferCode) Redeem(userID string, now time.Time) error {

--- a/api-go/internal/offercodes/code_test.go
+++ b/api-go/internal/offercodes/code_test.go
@@ -74,6 +74,45 @@ func TestOfferCode_Redeem_RejectsSecondRedemption(t *testing.T) {
 	}
 }
 
+// ActiveAt is the single authoritative "still-active offer window" rule reused
+// by both the list-users row column and the admin stats aggregate: a code is
+// active only while its own redeemed_at + duration window has not yet closed.
+func TestOfferCode_ActiveAt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+	redeemedRecently := now.Add(-10 * 24 * time.Hour)
+	redeemedLongAgo := now.Add(-40 * 24 * time.Hour)
+	redeemedExactlyAtBoundary := now.Add(-30 * 24 * time.Hour)
+
+	tests := []struct {
+		name         string
+		durationDays int
+		redeemedAt   *time.Time
+		want         bool
+	}{
+		{"never redeemed", 30, nil, false},
+		{"within window", 30, &redeemedRecently, true},
+		{"past window", 30, &redeemedLongAgo, false},
+		{"exactly at boundary is expired", 30, &redeemedExactlyAtBoundary, false},
+		{"zero duration is never active", 0, &redeemedRecently, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := OfferCode{
+				Code:         "ABCDEFGHJKMN",
+				Tier:         profiles.TierPro,
+				DurationDays: tc.durationDays,
+				RedeemedAt:   tc.redeemedAt,
+			}
+			if got := c.ActiveAt(now); got != tc.want {
+				t.Errorf("ActiveAt(%v) = %v, want %v", now, got, tc.want)
+			}
+		})
+	}
+}
+
 // An anonymised code (redeemer scrubbed for GDPR Art. 17, but the consumed
 // tombstone retained) must still report as redeemed and reject re-redemption,
 // even though its RedeemedByUserID / RedeemedAt are now nil.

--- a/api-go/internal/offercodes/store_postgres.go
+++ b/api-go/internal/offercodes/store_postgres.go
@@ -225,6 +225,43 @@ func (s *PostgresStore) RedeemedByUserID(ctx context.Context, userID string) ([]
 	return codes, nil
 }
 
+// ─── RedeemedByUsers (batched) ───────────────────────────────────────────────
+
+const pgRedeemedByUsersQuery = "SELECT " + pgCodeColumns +
+	" FROM offer_codes WHERE redeemed_by_user_id = ANY($1)"
+
+// RedeemedByUsers returns, for each user id in the set, the codes that user has
+// redeemed — the batched form of RedeemedByUserID used by the admin user list
+// and stats aggregate. It issues one grouped query instead of N per-user round
+// trips, then buckets the flat result in Go by each code's RedeemedByUserID.
+//
+// Users who never redeemed a code are absent from the map (the caller treats a
+// missing key as "no active offer" via the map zero value). Anonymised codes
+// have a NULL redeemed_by_user_id, so they never match ANY($1) and never leak a
+// GDPR-erased user back into the result. An empty user set returns an empty,
+// non-nil map without issuing a query.
+func (s *PostgresStore) RedeemedByUsers(ctx context.Context, userIDs []string) (map[string][]OfferCode, error) {
+	byUser := make(map[string][]OfferCode, len(userIDs))
+	if len(userIDs) == 0 {
+		return byUser, nil
+	}
+	rows, err := s.db.Query(ctx, pgRedeemedByUsersQuery, userIDs)
+	if err != nil {
+		return nil, fmt.Errorf("query redemptions for users: %w", err)
+	}
+	codes, err := pgx.CollectRows(rows, scanCodeRow)
+	if err != nil {
+		return nil, fmt.Errorf("scan redemptions for users: %w", err)
+	}
+	for _, c := range codes {
+		if c.RedeemedByUserID == nil {
+			continue // defensive: the ANY predicate already excludes NULL redeemers
+		}
+		byUser[*c.RedeemedByUserID] = append(byUser[*c.RedeemedByUserID], c)
+	}
+	return byUser, nil
+}
+
 // ─── AnonymiseRedemptionsByUserID ────────────────────────────────────────────
 
 // pgAnonymiseByUserIDQuery scrubs the redeemer PII from every code the user

--- a/api-go/internal/offercodes/store_postgres_integration_test.go
+++ b/api-go/internal/offercodes/store_postgres_integration_test.go
@@ -338,6 +338,62 @@ func TestPostgresStore_LegacyCoalesceHydration_Integration(t *testing.T) {
 	}
 }
 
+// TestPostgresStore_RedeemedByUsers_Integration seeds redemptions for two users
+// (one with two codes) plus an unredeemed code and an anonymised (scrubbed)
+// redemption, then asserts the batched ANY($1) query returns only the redeemed
+// codes grouped by their redeemer — and never the anonymised NULL-redeemer row.
+func TestPostgresStore_RedeemedByUsers_Integration(t *testing.T) {
+	ctx := context.Background()
+	store := newPGStore(t)
+
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	// u1 redeems two codes; u2 redeems one.
+	for code, user := range map[string]string{
+		"AAAAAAAAAAAA": "auth0|u1",
+		"CCCCCCCCCCCC": "auth0|u1",
+		"BBBBBBBBBBBB": "auth0|u2",
+	} {
+		if err := store.Save(ctx, testCode(t, code)); err != nil {
+			t.Fatalf("Save %s: %v", code, err)
+		}
+		if err := store.RedeemWithCAS(ctx, code, user, now); err != nil {
+			t.Fatalf("Redeem %s: %v", code, err)
+		}
+	}
+	// An unredeemed code must never appear.
+	if err := store.Save(ctx, testCode(t, "DDDDDDDDDDDD")); err != nil {
+		t.Fatalf("Save unredeemed: %v", err)
+	}
+	// An anonymised (GDPR-scrubbed) redemption keeps redeemed=true but NULL
+	// redeemer, so it must never appear in a by-user lookup.
+	if err := store.Save(ctx, testCode(t, "EEEEEEEEEEEE")); err != nil {
+		t.Fatalf("Save anon code: %v", err)
+	}
+	if err := store.RedeemWithCAS(ctx, "EEEEEEEEEEEE", "auth0|erased", now); err != nil {
+		t.Fatalf("Redeem anon code: %v", err)
+	}
+	if err := store.AnonymiseRedemptionsByUserID(ctx, "auth0|erased"); err != nil {
+		t.Fatalf("Anonymise: %v", err)
+	}
+
+	got, err := store.RedeemedByUsers(ctx, []string{"auth0|u1", "auth0|u2", "auth0|erased"})
+	if err != nil {
+		t.Fatalf("RedeemedByUsers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("map size: got %d, want 2 (erased user absent)", len(got))
+	}
+	if len(got["auth0|u1"]) != 2 {
+		t.Errorf("u1 codes: got %d, want 2", len(got["auth0|u1"]))
+	}
+	if len(got["auth0|u2"]) != 1 || got["auth0|u2"][0].Code != "BBBBBBBBBBBB" {
+		t.Errorf("u2 codes: got %+v, want [BBBBBBBBBBBB]", got["auth0|u2"])
+	}
+	if _, ok := got["auth0|erased"]; ok {
+		t.Error("anonymised redemption (NULL redeemer) must not appear")
+	}
+}
+
 // isErr reports whether err wraps or equals target.
 func isErr(err, target error) bool {
 	if err == nil {

--- a/api-go/internal/offercodes/store_postgres_test.go
+++ b/api-go/internal/offercodes/store_postgres_test.go
@@ -23,7 +23,8 @@ import (
 type fakeOfferCodeQuerier struct {
 	execTag    pgconn.CommandTag
 	execErr    error
-	queryErr   error // returned from Query()
+	queryErr   error    // returned from Query()
+	queryRows  pgx.Rows // returned from Query() when non-nil (else fakeEmptyRows)
 	rowResults []pgx.Row
 	rowIdx     int
 }
@@ -35,6 +36,9 @@ func (f *fakeOfferCodeQuerier) Exec(_ context.Context, _ string, _ ...any) (pgco
 func (f *fakeOfferCodeQuerier) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
 	if f.queryErr != nil {
 		return nil, f.queryErr
+	}
+	if f.queryRows != nil {
+		return f.queryRows, nil
 	}
 	return &fakeEmptyRows{}, nil
 }
@@ -354,5 +358,89 @@ func TestPostgresStore_Get_LegacyCoalesceHydration(t *testing.T) {
 	}
 	if !got.IsRedeemed() {
 		t.Error("legacy code with non-nil RedeemedByUserID must be considered redeemed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RedeemedByUsers (batched)
+// ---------------------------------------------------------------------------
+
+// fakeCodeRows is a pgx.Rows over pre-baked full-code column tuples, so
+// pgx.CollectRows(scanCodeRow) can hydrate multiple OfferCodes in one Query.
+type fakeCodeRows struct {
+	rows []fakeFullCodeRow
+	idx  int
+}
+
+func (r *fakeCodeRows) Next() bool { return r.idx < len(r.rows) }
+func (r *fakeCodeRows) Scan(dest ...any) error {
+	err := r.rows[r.idx].Scan(dest...)
+	r.idx++
+	return err
+}
+func (r *fakeCodeRows) Close()                                       {}
+func (r *fakeCodeRows) Err() error                                   { return nil }
+func (r *fakeCodeRows) Values() ([]any, error)                       { return nil, nil }
+func (r *fakeCodeRows) RawValues() [][]byte                          { return nil }
+func (r *fakeCodeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeCodeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeCodeRows) Conn() *pgx.Conn                              { return nil }
+
+// TestPostgresStore_RedeemedByUsers_Empty short-circuits an empty user set with
+// no query and an empty, non-nil map.
+func TestPostgresStore_RedeemedByUsers_Empty(t *testing.T) {
+	t.Parallel()
+	q := &fakeOfferCodeQuerier{}
+	store := NewPostgresStore(q)
+
+	got, err := store.RedeemedByUsers(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("RedeemedByUsers: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("empty users: got %v, want empty non-nil map", got)
+	}
+}
+
+// TestPostgresStore_RedeemedByUsers_PropagatesQueryError wraps a Query failure.
+func TestPostgresStore_RedeemedByUsers_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("redemptions boom")
+	q := &fakeOfferCodeQuerier{queryErr: boom}
+	store := NewPostgresStore(q)
+
+	_, err := store.RedeemedByUsers(context.Background(), []string{"auth0|u1"})
+	if !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+// TestPostgresStore_RedeemedByUsers_GroupsByUser groups the flat result by the
+// code's RedeemedByUserID so each user gets exactly their own codes.
+func TestPostgresStore_RedeemedByUsers_GroupsByUser(t *testing.T) {
+	t.Parallel()
+	u1 := "auth0|u1"
+	u2 := "auth0|u2"
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	redeemed := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	q := &fakeOfferCodeQuerier{queryRows: &fakeCodeRows{rows: []fakeFullCodeRow{
+		{code: "AAAAAAAAAAAA", tier: "Pro", durationDays: 30, createdAt: created, redeemed: true, redeemedByUserID: &u1, redeemedAt: &redeemed},
+		{code: "BBBBBBBBBBBB", tier: "Personal", durationDays: 7, createdAt: created, redeemed: true, redeemedByUserID: &u2, redeemedAt: &redeemed},
+		{code: "CCCCCCCCCCCC", tier: "Pro", durationDays: 90, createdAt: created, redeemed: true, redeemedByUserID: &u1, redeemedAt: &redeemed},
+	}}}
+	store := NewPostgresStore(q)
+
+	got, err := store.RedeemedByUsers(context.Background(), []string{u1, u2})
+	if err != nil {
+		t.Fatalf("RedeemedByUsers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("map size: got %d, want 2", len(got))
+	}
+	if len(got[u1]) != 2 {
+		t.Errorf("u1 codes: got %d, want 2", len(got[u1]))
+	}
+	if len(got[u2]) != 1 || got[u2][0].Code != "BBBBBBBBBBBB" {
+		t.Errorf("u2 codes: got %+v, want [BBBBBBBBBBBB]", got[u2])
 	}
 }

--- a/api-go/internal/profiles/admin_store_postgres.go
+++ b/api-go/internal/profiles/admin_store_postgres.go
@@ -147,6 +147,157 @@ func (s *PostgresAdminStore) LapsedPaid(ctx context.Context, now time.Time) ([]*
 	return lapsed, nil
 }
 
+// PaidCandidates loads every profile whose stored tier is paid (tier != 'Free'),
+// unfiltered — the caller classifies each in Go via EffectiveTier(now). Unlike
+// LapsedPaid (which filters to the lapsed subset), this returns ALL paid-tier
+// candidates so the admin stats handler can bucket them into effective-paid /
+// App Store / comped / lapsed / in-grace without re-expressing the expiry/grace
+// rule in SQL. The candidate set is small (only paying users), so loading it
+// whole is cheap.
+func (s *PostgresAdminStore) PaidCandidates(ctx context.Context) ([]*UserProfile, error) {
+	rows, err := s.db.Query(ctx, pgAdminSelectCols+"WHERE tier != 'Free'")
+	if err != nil {
+		return nil, fmt.Errorf("query paid candidates: %w", err)
+	}
+	candidates, err := collectUsers(rows)
+	if err != nil {
+		return nil, fmt.Errorf("decode paid candidates: %w", err)
+	}
+	return candidates, nil
+}
+
+// RecentSignup identifies the single most-recently-created user for the admin
+// stats "signups" block. Email is nil when the account has none (e.g. a
+// Sign-in-with-Apple user who withheld it).
+type RecentSignup struct {
+	UserID    string
+	Email     *string
+	CreatedAt time.Time
+}
+
+// UserStats is the admin-dashboard aggregate over the users table: whole-base
+// counts computed in SQL (COUNT / GROUP BY / MAX) and returned as a plain
+// struct. The paying breakdown is deliberately NOT here — it is classified in Go
+// from PaidCandidates via EffectiveTier so the expiry/grace rule stays in the
+// domain. now is injected by the caller (never SQL now()), matching the
+// codebase's clock convention.
+type UserStats struct {
+	Total           int
+	ByTier          map[string]int
+	Signups24h      int
+	Signups7d       int
+	Signups30d      int
+	MostRecent      *RecentSignup
+	Active24h       int
+	Active7d        int
+	ZeroWatchZones  int
+	NoEmail         int
+	TotalWatchZones int
+}
+
+// pgUserStatsScalarQuery computes every scalar aggregate in one pass. The signup
+// and activity windows compare against caller-supplied cutoffs ($1 = now-24h,
+// $2 = now-7d, $3 = now-30d) rather than SQL now(). Column order MUST match the
+// scan in UserStats.
+const pgUserStatsScalarQuery = `
+SELECT
+    count(*),
+    count(*) FILTER (WHERE created_at > $1),
+    count(*) FILTER (WHERE created_at > $2),
+    count(*) FILTER (WHERE created_at > $3),
+    count(*) FILTER (WHERE last_active_at > $1),
+    count(*) FILTER (WHERE last_active_at > $2),
+    count(*) FILTER (WHERE COALESCE(watch_zone_count, 0) = 0),
+    count(*) FILTER (WHERE email IS NULL),
+    COALESCE(SUM(watch_zone_count), 0)
+FROM users`
+
+const pgUserStatsTierQuery = "SELECT tier, count(*) FROM users GROUP BY tier"
+
+const pgUserStatsMostRecentQuery = "SELECT user_id, email, created_at FROM users ORDER BY created_at DESC LIMIT 1"
+
+// UserStats returns the whole-user-base aggregate for GET /v1/admin/stats. It
+// issues three read queries: the scalar aggregate (counts + total watch zones),
+// the per-tier GROUP BY breakdown, and the single most-recent signup. now is the
+// caller's clock; the 24h/7d/30d cutoffs are derived from it in Go so the SQL
+// carries no now().
+func (s *PostgresAdminStore) UserStats(ctx context.Context, now time.Time) (UserStats, error) {
+	cutoff24h := now.Add(-24 * time.Hour)
+	cutoff7d := now.Add(-7 * 24 * time.Hour)
+	cutoff30d := now.Add(-30 * 24 * time.Hour)
+
+	stats := UserStats{ByTier: map[string]int{"Free": 0, "Personal": 0, "Pro": 0}}
+
+	scalarRows, err := s.db.Query(ctx, pgUserStatsScalarQuery, cutoff24h, cutoff7d, cutoff30d)
+	if err != nil {
+		return UserStats{}, fmt.Errorf("query user stats: %w", err)
+	}
+	scalar, err := pgx.CollectExactlyOneRow(scalarRows, func(row pgx.CollectableRow) (UserStats, error) {
+		var us UserStats
+		if scanErr := row.Scan(
+			&us.Total,
+			&us.Signups24h, &us.Signups7d, &us.Signups30d,
+			&us.Active24h, &us.Active7d,
+			&us.ZeroWatchZones, &us.NoEmail, &us.TotalWatchZones,
+		); scanErr != nil {
+			return UserStats{}, scanErr
+		}
+		return us, nil
+	})
+	if err != nil {
+		return UserStats{}, fmt.Errorf("scan user stats: %w", err)
+	}
+	scalar.ByTier = stats.ByTier
+	stats = scalar
+
+	tierRows, err := s.db.Query(ctx, pgUserStatsTierQuery)
+	if err != nil {
+		return UserStats{}, fmt.Errorf("query user stats tiers: %w", err)
+	}
+	defer tierRows.Close()
+	for tierRows.Next() {
+		var (
+			tier  string
+			count int
+		)
+		if scanErr := tierRows.Scan(&tier, &count); scanErr != nil {
+			return UserStats{}, fmt.Errorf("scan user stats tier: %w", scanErr)
+		}
+		stats.ByTier[tier] = count
+	}
+	if scanErr := tierRows.Err(); scanErr != nil {
+		return UserStats{}, fmt.Errorf("user stats tier rows: %w", scanErr)
+	}
+
+	recent, err := s.mostRecentSignup(ctx)
+	if err != nil {
+		return UserStats{}, err
+	}
+	stats.MostRecent = recent
+	return stats, nil
+}
+
+// mostRecentSignup reads the newest-created user for the stats "signups" block,
+// returning nil (not an error) when the user base is empty.
+func (s *PostgresAdminStore) mostRecentSignup(ctx context.Context) (*RecentSignup, error) {
+	rows, err := s.db.Query(ctx, pgUserStatsMostRecentQuery)
+	if err != nil {
+		return nil, fmt.Errorf("query most recent signup: %w", err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		if scanErr := rows.Err(); scanErr != nil {
+			return nil, fmt.Errorf("most recent signup rows: %w", scanErr)
+		}
+		return nil, nil //nolint:nilnil // an empty user base has no most-recent signup
+	}
+	var r RecentSignup
+	if scanErr := rows.Scan(&r.UserID, &r.Email, &r.CreatedAt); scanErr != nil {
+		return nil, fmt.Errorf("scan most recent signup: %w", scanErr)
+	}
+	return &r, nil
+}
+
 // Save upserts the profile (same SQL as PostgresStore.Save). Used by the
 // subscription sweep and admin grant endpoint as the write-back path.
 func (s *PostgresAdminStore) Save(ctx context.Context, p *UserProfile) error {

--- a/api-go/internal/profiles/admin_store_postgres_test.go
+++ b/api-go/internal/profiles/admin_store_postgres_test.go
@@ -3,6 +3,7 @@ package profiles
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -226,5 +227,197 @@ func TestList_BadCursor_ReturnsError(t *testing.T) {
 	store := NewPostgresAdminStore(&recordingQuerier{rows: &fakeUserRows{}})
 	if _, err := store.List(context.Background(), "", 5, "!!!not-base64!!!"); err == nil {
 		t.Fatal("List with malformed cursor: want error, got nil")
+	}
+}
+
+// --- PaidCandidates ---
+
+// paidUserRow builds a full userSelectCols projection for a paid-tier user with
+// the given expiry and original-transaction id. Order MUST match userSelectCols.
+func paidUserRow(userID, tier string, expiry *time.Time, otid *string) []any {
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	return []any{
+		userID, nil, true, 1,
+		true, true, true,
+		"{}",
+		tier, expiry, otid, nil,
+		created, created.UnixMilli(), created, nil, 0,
+	}
+}
+
+// TestPaidCandidates_LoadsAllUnfiltered returns every paid-tier row unfiltered —
+// including a lapsed one — so the caller classifies via EffectiveTier in Go, and
+// scopes the query with tier != 'Free'.
+func TestPaidCandidates_LoadsAllUnfiltered(t *testing.T) {
+	t.Parallel()
+	expired := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // long past
+	txn := "1000000000000001"
+	q := &recordingQuerier{rows: &fakeUserRows{rows: [][]any{
+		paidUserRow("auth0|active", "Pro", ptrTime(time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)), &txn),
+		paidUserRow("auth0|lapsed", "Personal", &expired, nil),
+	}}}
+	store := NewPostgresAdminStore(q)
+
+	got, err := store.PaidCandidates(context.Background())
+	if err != nil {
+		t.Fatalf("PaidCandidates: %v", err)
+	}
+	if !strings.Contains(q.sql, "tier != 'Free'") {
+		t.Errorf("SQL missing paid-tier scope: %s", q.sql)
+	}
+	if len(got) != 2 {
+		t.Fatalf("candidates: got %d, want 2 (lapsed NOT filtered out)", len(got))
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+// --- UserStats ---
+
+// genRows is a pgx.Rows over pre-baked []any tuples for the aggregate queries.
+type genRows struct {
+	rows [][]any
+	idx  int
+	err  error
+}
+
+func (r *genRows) Next() bool {
+	if r.err != nil {
+		return false
+	}
+	return r.idx < len(r.rows)
+}
+func (r *genRows) Scan(dest ...any) error {
+	src := r.rows[r.idx]
+	r.idx++
+	for i, d := range dest {
+		switch p := d.(type) {
+		case *int:
+			*p = src[i].(int)
+		case *string:
+			*p = src[i].(string)
+		case **string:
+			if src[i] == nil {
+				*p = nil
+			} else {
+				s := src[i].(string)
+				*p = &s
+			}
+		case *time.Time:
+			*p = src[i].(time.Time)
+		}
+	}
+	return nil
+}
+func (r *genRows) Close()                                       {}
+func (r *genRows) Err() error                                   { return r.err }
+func (r *genRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *genRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *genRows) Values() ([]any, error)                       { return nil, nil }
+func (r *genRows) RawValues() [][]byte                          { return nil }
+func (r *genRows) Conn() *pgx.Conn                              { return nil }
+
+// fifoQuerier serves a fixed sequence of Query results (UserStats issues three:
+// scalar aggregate, tier group-by, most-recent). Exec/QueryRow are unused.
+type fifoQuerier struct {
+	results []*genRows
+	idx     int
+	sqls    []string
+}
+
+func (q *fifoQuerier) Exec(context.Context, string, ...any) (pgconn.CommandTag, error) {
+	panic("fifoQuerier.Exec not expected")
+}
+func (q *fifoQuerier) Query(_ context.Context, sql string, _ ...any) (pgx.Rows, error) {
+	q.sqls = append(q.sqls, sql)
+	r := q.results[q.idx]
+	q.idx++
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r, nil
+}
+func (q *fifoQuerier) QueryRow(context.Context, string, ...any) pgx.Row {
+	panic("fifoQuerier.QueryRow not expected")
+}
+
+// TestUserStats_AssemblesAllMetrics maps the three aggregate queries into a
+// single struct: scalar counts, per-tier breakdown, and the most-recent signup.
+func TestUserStats_AssemblesAllMetrics(t *testing.T) {
+	t.Parallel()
+	newest := time.Date(2026, 6, 30, 9, 0, 0, 0, time.UTC)
+	q := &fifoQuerier{results: []*genRows{
+		// scalar: total, signups24h, signups7d, signups30d, active24h, active7d, zeroWZ, noEmail, totalWZ
+		{rows: [][]any{{100, 5, 12, 30, 8, 20, 15, 3, 250}}},
+		// tier group-by: (tier, count)
+		{rows: [][]any{{"Free", 70}, {"Personal", 20}, {"Pro", 10}}},
+		// most-recent: (user_id, email, created_at)
+		{rows: [][]any{{"auth0|newest", "new@example.com", newest}}},
+	}}
+	store := NewPostgresAdminStore(q)
+
+	got, err := store.UserStats(context.Background(), time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("UserStats: %v", err)
+	}
+	if got.Total != 100 {
+		t.Errorf("Total: got %d, want 100", got.Total)
+	}
+	if got.Signups24h != 5 || got.Signups7d != 12 || got.Signups30d != 30 {
+		t.Errorf("signups: got %d/%d/%d, want 5/12/30", got.Signups24h, got.Signups7d, got.Signups30d)
+	}
+	if got.Active24h != 8 || got.Active7d != 20 {
+		t.Errorf("active: got %d/%d, want 8/20", got.Active24h, got.Active7d)
+	}
+	if got.ZeroWatchZones != 15 || got.NoEmail != 3 || got.TotalWatchZones != 250 {
+		t.Errorf("activity/reach: got zeroWZ=%d noEmail=%d totalWZ=%d, want 15/3/250",
+			got.ZeroWatchZones, got.NoEmail, got.TotalWatchZones)
+	}
+	if got.ByTier["Free"] != 70 || got.ByTier["Personal"] != 20 || got.ByTier["Pro"] != 10 {
+		t.Errorf("byTier: got %+v, want Free:70 Personal:20 Pro:10", got.ByTier)
+	}
+	if got.MostRecent == nil {
+		t.Fatal("MostRecent: got nil, want the newest signup")
+	}
+	if got.MostRecent.UserID != "auth0|newest" || got.MostRecent.Email == nil || *got.MostRecent.Email != "new@example.com" {
+		t.Errorf("MostRecent: got %+v", got.MostRecent)
+	}
+	if !got.MostRecent.CreatedAt.Equal(newest) {
+		t.Errorf("MostRecent.CreatedAt: got %v, want %v", got.MostRecent.CreatedAt, newest)
+	}
+}
+
+// TestUserStats_NoUsers_NilMostRecent leaves MostRecent nil when the most-recent
+// query returns no rows (an empty user base).
+func TestUserStats_NoUsers_NilMostRecent(t *testing.T) {
+	t.Parallel()
+	q := &fifoQuerier{results: []*genRows{
+		{rows: [][]any{{0, 0, 0, 0, 0, 0, 0, 0, 0}}},
+		{rows: [][]any{}},
+		{rows: [][]any{}}, // no most-recent row
+	}}
+	store := NewPostgresAdminStore(q)
+
+	got, err := store.UserStats(context.Background(), time.Now())
+	if err != nil {
+		t.Fatalf("UserStats: %v", err)
+	}
+	if got.Total != 0 {
+		t.Errorf("Total: got %d, want 0", got.Total)
+	}
+	if got.MostRecent != nil {
+		t.Errorf("MostRecent: got %+v, want nil", got.MostRecent)
+	}
+}
+
+// TestUserStats_PropagatesQueryError wraps a failure from the scalar query.
+func TestUserStats_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("stats boom")
+	q := &fifoQuerier{results: []*genRows{{err: boom}}}
+	store := NewPostgresAdminStore(q)
+
+	if _, err := store.UserStats(context.Background(), time.Now()); !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
 	}
 }

--- a/api-go/internal/profiles/admin_store_postgres_test.go
+++ b/api-go/internal/profiles/admin_store_postgres_test.go
@@ -232,9 +232,11 @@ func TestList_BadCursor_ReturnsError(t *testing.T) {
 
 // --- PaidCandidates ---
 
-// paidUserRow builds a full userSelectCols projection for a paid-tier user with
-// the given expiry and original-transaction id. Order MUST match userSelectCols.
-func paidUserRow(userID, tier string, expiry *time.Time, otid *string) []any {
+// paidUserRow builds a full userSelectCols projection for a paid-tier user. The
+// expiry (time.Time or nil) and original-transaction id (string or nil) are
+// passed as raw column values, matching how fakeScanRow wraps nullable columns.
+// Order MUST match userSelectCols.
+func paidUserRow(userID, tier string, expiry, otid any) []any {
 	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	return []any{
 		userID, nil, true, 1,
@@ -251,10 +253,9 @@ func paidUserRow(userID, tier string, expiry *time.Time, otid *string) []any {
 func TestPaidCandidates_LoadsAllUnfiltered(t *testing.T) {
 	t.Parallel()
 	expired := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // long past
-	txn := "1000000000000001"
 	q := &recordingQuerier{rows: &fakeUserRows{rows: [][]any{
-		paidUserRow("auth0|active", "Pro", ptrTime(time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC)), &txn),
-		paidUserRow("auth0|lapsed", "Personal", &expired, nil),
+		paidUserRow("auth0|active", "Pro", time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC), "1000000000000001"),
+		paidUserRow("auth0|lapsed", "Personal", expired, nil),
 	}}}
 	store := NewPostgresAdminStore(q)
 
@@ -269,8 +270,6 @@ func TestPaidCandidates_LoadsAllUnfiltered(t *testing.T) {
 		t.Fatalf("candidates: got %d, want 2 (lapsed NOT filtered out)", len(got))
 	}
 }
-
-func ptrTime(t time.Time) *time.Time { return &t }
 
 // --- UserStats ---
 

--- a/api-go/internal/profiles/store_postgres_integration_test.go
+++ b/api-go/internal/profiles/store_postgres_integration_test.go
@@ -579,3 +579,132 @@ func TestPostgresAdminStore_List_Pagination(t *testing.T) {
 		t.Errorf("filtered: got %d profiles, want 1", len(filtered.Profiles))
 	}
 }
+
+// TestPostgresAdminStore_PaidCandidates loads every stored-paid-tier profile
+// unfiltered — including a lapsed one — so the caller classifies in Go via
+// EffectiveTier. Free-tier profiles never appear.
+func TestPostgresAdminStore_PaidCandidates(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "users")
+	store := NewPostgresStore(pool)
+	admin := NewPostgresAdminStore(pool)
+	ctx := context.Background()
+
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+
+	// Lapsed paid: Personal, expired 30 days ago (must STILL be returned).
+	pLapsed := pgProfile(t, "auth0|pc-lapsed", "lapsed@example.com")
+	pLapsed.Tier = TierPersonal
+	exp := now.Add(-30 * 24 * time.Hour)
+	pLapsed.SubscriptionExpiry = &exp
+	// Active paid: Pro, expiry in the future.
+	pActive := pgProfile(t, "auth0|pc-active", "active@example.com")
+	pActive.Tier = TierPro
+	future := now.Add(30 * 24 * time.Hour)
+	pActive.SubscriptionExpiry = &future
+	// Free: must never appear.
+	pFree := pgProfile(t, "auth0|pc-free", "free@example.com")
+	for _, p := range []*UserProfile{pLapsed, pActive, pFree} {
+		if err := store.Save(ctx, p); err != nil {
+			t.Fatalf("Save %s: %v", p.UserID, err)
+		}
+	}
+
+	got, err := admin.PaidCandidates(ctx)
+	if err != nil {
+		t.Fatalf("PaidCandidates: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("candidates: got %d, want 2 (lapsed NOT filtered, free excluded)", len(got))
+	}
+	ids := map[string]bool{}
+	for _, p := range got {
+		ids[p.UserID] = true
+	}
+	if !ids["auth0|pc-lapsed"] || !ids["auth0|pc-active"] {
+		t.Errorf("candidates: got %v, want both paid users incl. the lapsed one", ids)
+	}
+	if ids["auth0|pc-free"] {
+		t.Error("Free-tier profile must not be a paid candidate")
+	}
+}
+
+// TestPostgresAdminStore_UserStats exercises the full aggregate against a real
+// DB: total, per-tier breakdown, signup windows, most-recent signup, active
+// windows, zero-watch-zone / no-email counts, and total watch zones — none of
+// which a hand-written fake can honestly model.
+func TestPostgresAdminStore_UserStats(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "users")
+	store := NewPostgresStore(pool)
+	admin := NewPostgresAdminStore(pool)
+	ctx := context.Background()
+
+	now := time.Date(2026, 6, 30, 12, 0, 0, 0, time.UTC)
+
+	// Empty base: everything zero, MostRecent nil.
+	empty, err := admin.UserStats(ctx, now)
+	if err != nil {
+		t.Fatalf("UserStats empty: %v", err)
+	}
+	if empty.Total != 0 || empty.MostRecent != nil || empty.TotalWatchZones != 0 {
+		t.Errorf("UserStats empty: got %+v, want zero totals and nil MostRecent", empty)
+	}
+
+	// seedUser saves a profile with a given tier / email / watch-zone count /
+	// last-active, then forces created_at (DB-owned) to the requested instant.
+	seedUser := func(id, email string, tier SubscriptionTier, wz *int, lastActive, createdAt time.Time) {
+		t.Helper()
+		p, perr := NewProfile(id, email, now)
+		if perr != nil {
+			t.Fatalf("NewProfile %s: %v", id, perr)
+		}
+		p.Tier = tier
+		p.WatchZoneCount = wz
+		p.LastActiveAt = lastActive
+		if serr := store.Save(ctx, p); serr != nil {
+			t.Fatalf("Save %s: %v", id, serr)
+		}
+		if _, uerr := pool.Exec(ctx, "UPDATE users SET created_at = $1 WHERE user_id = $2", createdAt, id); uerr != nil {
+			t.Fatalf("force created_at %s: %v", id, uerr)
+		}
+	}
+
+	wz2, wz0, wz5 := 2, 0, 5
+	seedUser("auth0|uA", "a@example.com", TierFree, &wz2, now.Add(-1*time.Hour), now.Add(-2*time.Hour))
+	seedUser("auth0|uB", "b@example.com", TierPersonal, &wz0, now.Add(-3*24*time.Hour), now.Add(-3*24*time.Hour))
+	seedUser("auth0|uC", "", TierPro, nil, now.Add(-40*24*time.Hour), now.Add(-10*24*time.Hour))
+	seedUser("auth0|uD", "d@example.com", TierFree, &wz5, now.Add(-2*time.Hour), now.Add(-40*24*time.Hour))
+
+	got, err := admin.UserStats(ctx, now)
+	if err != nil {
+		t.Fatalf("UserStats: %v", err)
+	}
+	if got.Total != 4 {
+		t.Errorf("Total: got %d, want 4", got.Total)
+	}
+	if got.ByTier["Free"] != 2 || got.ByTier["Personal"] != 1 || got.ByTier["Pro"] != 1 {
+		t.Errorf("ByTier: got %+v, want Free:2 Personal:1 Pro:1", got.ByTier)
+	}
+	if got.Signups24h != 1 || got.Signups7d != 2 || got.Signups30d != 3 {
+		t.Errorf("signups: got %d/%d/%d, want 1/2/3", got.Signups24h, got.Signups7d, got.Signups30d)
+	}
+	if got.Active24h != 2 || got.Active7d != 3 {
+		t.Errorf("active: got %d/%d, want 2/3", got.Active24h, got.Active7d)
+	}
+	if got.ZeroWatchZones != 2 {
+		t.Errorf("ZeroWatchZones: got %d, want 2 (uB=0, uC=NULL)", got.ZeroWatchZones)
+	}
+	if got.NoEmail != 1 {
+		t.Errorf("NoEmail: got %d, want 1 (uC)", got.NoEmail)
+	}
+	if got.TotalWatchZones != 7 {
+		t.Errorf("TotalWatchZones: got %d, want 7 (2+0+5, uC NULL ignored)", got.TotalWatchZones)
+	}
+	if got.MostRecent == nil || got.MostRecent.UserID != "auth0|uA" {
+		t.Fatalf("MostRecent: got %+v, want auth0|uA", got.MostRecent)
+	}
+	if got.MostRecent.Email == nil || *got.MostRecent.Email != "a@example.com" {
+		t.Errorf("MostRecent.Email: got %v, want a@example.com", got.MostRecent.Email)
+	}
+}

--- a/api-go/internal/savedapplications/integration_test.go
+++ b/api-go/internal/savedapplications/integration_test.go
@@ -307,6 +307,74 @@ func TestSavedPostgresStore_DeleteAllByUserID(t *testing.T) {
 	}
 }
 
+// TestSavedPostgresStore_CountsByUsers_Integration tallies each user's saved
+// applications in one grouped query. A user with no rows is absent from the map
+// (defaults to 0 at the call site); a user outside the requested set is excluded.
+func TestSavedPostgresStore_CountsByUsers_Integration(t *testing.T) {
+	ctx := context.Background()
+	store := newSavedPGStore(t)
+
+	now := time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)
+	// u1 saves two apps, u2 saves one, u3 (queried) saves none, u4 (not queried).
+	for _, sa := range []SavedApplication{
+		pgSavedApp(t, "auth0|u1", pgApp("app-a", 100), now),
+		pgSavedApp(t, "auth0|u1", pgApp("app-b", 100), now),
+		pgSavedApp(t, "auth0|u2", pgApp("app-c", 100), now),
+		pgSavedApp(t, "auth0|u4", pgApp("app-d", 100), now),
+	} {
+		if err := store.Save(ctx, sa); err != nil {
+			t.Fatalf("Save %s: %v", sa.ApplicationUID, err)
+		}
+	}
+
+	got, err := store.CountsByUsers(ctx, []string{"auth0|u1", "auth0|u2", "auth0|u3"})
+	if err != nil {
+		t.Fatalf("CountsByUsers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("map size: got %d, want 2 (u3 absent, u4 excluded)", len(got))
+	}
+	if got["auth0|u1"] != 2 {
+		t.Errorf("u1: got %d, want 2", got["auth0|u1"])
+	}
+	if got["auth0|u2"] != 1 {
+		t.Errorf("u2: got %d, want 1", got["auth0|u2"])
+	}
+	if _, ok := got["auth0|u3"]; ok {
+		t.Error("u3 (no saved rows) must be absent from the map")
+	}
+}
+
+// TestSavedPostgresStore_Count_Integration returns the global count(*) across all
+// users' saved applications.
+func TestSavedPostgresStore_Count_Integration(t *testing.T) {
+	ctx := context.Background()
+	store := newSavedPGStore(t)
+
+	if got, err := store.Count(ctx); err != nil || got != 0 {
+		t.Fatalf("Count empty: got (%d, %v), want (0, nil)", got, err)
+	}
+
+	now := time.Date(2026, 6, 27, 0, 0, 0, 0, time.UTC)
+	for _, sa := range []SavedApplication{
+		pgSavedApp(t, "auth0|u1", pgApp("app-a", 100), now),
+		pgSavedApp(t, "auth0|u1", pgApp("app-b", 100), now),
+		pgSavedApp(t, "auth0|u2", pgApp("app-c", 100), now),
+	} {
+		if err := store.Save(ctx, sa); err != nil {
+			t.Fatalf("Save %s: %v", sa.ApplicationUID, err)
+		}
+	}
+
+	got, err := store.Count(ctx)
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if got != 3 {
+		t.Errorf("Count = %d, want 3", got)
+	}
+}
+
 // TestSavedPostgresStore_NilSnapshot stores a record with no snapshot (nil
 // Application) and confirms the round-trip returns nil Application.
 func TestSavedPostgresStore_NilSnapshot(t *testing.T) {

--- a/api-go/internal/savedapplications/store_postgres.go
+++ b/api-go/internal/savedapplications/store_postgres.go
@@ -198,6 +198,55 @@ func (s *PostgresStore) UserIDsForApplication(ctx context.Context, applicationUI
 	return userIDs, nil
 }
 
+// pgSavedCountsByUsersQuery tallies each user's saved-application count in one
+// grouped pass. The (user_id, application_uid) primary key makes each row a
+// distinct save, so count(*) per user needs no DISTINCT. Users with no rows
+// produce no row; the caller defaults them to 0.
+const pgSavedCountsByUsersQuery = "SELECT user_id, count(*) FROM saved_applications " +
+	"WHERE user_id = ANY($1) GROUP BY user_id"
+
+// CountsByUsers returns each user's saved-application count in a single grouped
+// query, mirroring notifications.PostgresStore.CountsByUsers. Users absent from
+// the result are absent from the map; the caller treats a missing key as 0 via
+// the map zero value. An empty user set returns an empty map without a query.
+func (s *PostgresStore) CountsByUsers(ctx context.Context, userIDs []string) (map[string]int, error) {
+	counts := make(map[string]int, len(userIDs))
+	if len(userIDs) == 0 {
+		return counts, nil
+	}
+	rows, err := s.db.Query(ctx, pgSavedCountsByUsersQuery, userIDs)
+	if err != nil {
+		return nil, fmt.Errorf("query saved application counts: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var (
+			userID string
+			count  int
+		)
+		if err := rows.Scan(&userID, &count); err != nil {
+			return nil, fmt.Errorf("scan saved application count: %w", err)
+		}
+		counts[userID] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("saved application count rows: %w", err)
+	}
+	return counts, nil
+}
+
+const pgSavedCountQuery = "SELECT count(*) FROM saved_applications"
+
+// Count returns the global number of saved applications across all users — the
+// admin stats "reach" total.
+func (s *PostgresStore) Count(ctx context.Context) (int, error) {
+	var total int
+	if err := s.db.QueryRow(ctx, pgSavedCountQuery).Scan(&total); err != nil {
+		return 0, fmt.Errorf("count saved applications: %w", err)
+	}
+	return total, nil
+}
+
 const pgDeleteAllSavedAppsQuery = "DELETE FROM saved_applications WHERE user_id = $1"
 
 // DeleteAllByUserID removes every saved application for the user. Used by the

--- a/api-go/internal/savedapplications/store_postgres_test.go
+++ b/api-go/internal/savedapplications/store_postgres_test.go
@@ -16,9 +16,12 @@ import (
 // unit tests of PostgresStore (savedapplications). It stores canned responses for
 // each method; tests set whichever fields they exercise.
 type fakeSavedQuerier struct {
-	execErr  error
-	queryErr error
-	rowErr   error
+	execErr   error
+	queryErr  error
+	rowErr    error
+	queryRows pgx.Rows // returned from Query() when non-nil (else emptySavedRows)
+	countRow  pgx.Row  // returned from QueryRow() when non-nil (else errSavedRow)
+	queries   int      // number of Query calls issued
 }
 
 func (f *fakeSavedQuerier) Exec(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
@@ -26,14 +29,58 @@ func (f *fakeSavedQuerier) Exec(_ context.Context, _ string, _ ...any) (pgconn.C
 }
 
 func (f *fakeSavedQuerier) Query(_ context.Context, _ string, _ ...any) (pgx.Rows, error) {
+	f.queries++
 	if f.queryErr != nil {
 		return nil, f.queryErr
+	}
+	if f.queryRows != nil {
+		return f.queryRows, nil
 	}
 	return &emptySavedRows{}, nil
 }
 
 func (f *fakeSavedQuerier) QueryRow(_ context.Context, _ string, _ ...any) pgx.Row {
+	if f.countRow != nil {
+		return f.countRow
+	}
 	return &errSavedRow{err: f.rowErr}
+}
+
+// countSavedRows is a pgx.Rows over pre-baked (user_id, count) tuples for the
+// batched CountsByUsers query.
+type countSavedRows struct {
+	rows [][2]any
+	idx  int
+}
+
+func (r *countSavedRows) Next() bool { return r.idx < len(r.rows) }
+func (r *countSavedRows) Scan(dest ...any) error {
+	*dest[0].(*string) = r.rows[r.idx][0].(string)
+	*dest[1].(*int) = r.rows[r.idx][1].(int)
+	r.idx++
+	return nil
+}
+func (r *countSavedRows) Close()                                       {}
+func (r *countSavedRows) Err() error                                   { return nil }
+func (r *countSavedRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *countSavedRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *countSavedRows) Values() ([]any, error)                       { return nil, nil }
+func (r *countSavedRows) RawValues() [][]byte                          { return nil }
+func (r *countSavedRows) Conn() *pgx.Conn                              { return nil }
+
+// intSavedRow is a pgx.Row that scans a single int (the Count total) or a
+// pre-configured error.
+type intSavedRow struct {
+	n   int
+	err error
+}
+
+func (r *intSavedRow) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	*dest[0].(*int) = r.n
+	return nil
 }
 
 // emptySavedRows is a pgx.Rows with no data and no error.
@@ -195,5 +242,92 @@ func TestSavedPostgresStore_DeleteAllByUserID_PropagatesExecError(t *testing.T) 
 
 	if err := store.DeleteAllByUserID(context.Background(), "auth0|u1"); !errors.Is(err, sentinel) {
 		t.Fatalf("DeleteAllByUserID error: got %v, want wrapped %v", err, sentinel)
+	}
+}
+
+// --- CountsByUsers ---
+
+// TestSavedPostgresStore_CountsByUsers_Empty short-circuits an empty user set
+// with no query and an empty, non-nil map.
+func TestSavedPostgresStore_CountsByUsers_Empty(t *testing.T) {
+	t.Parallel()
+	fq := &fakeSavedQuerier{}
+	store := NewPostgresStore(fq)
+
+	got, err := store.CountsByUsers(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("CountsByUsers: %v", err)
+	}
+	if got == nil || len(got) != 0 {
+		t.Errorf("empty users: got %v, want empty non-nil map", got)
+	}
+	if fq.queries != 0 {
+		t.Errorf("empty users issued %d queries, want 0", fq.queries)
+	}
+}
+
+// TestSavedPostgresStore_CountsByUsers_PropagatesQueryError wraps a Query error.
+func TestSavedPostgresStore_CountsByUsers_PropagatesQueryError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("counts boom")
+	fq := &fakeSavedQuerier{queryErr: boom}
+	store := NewPostgresStore(fq)
+
+	if _, err := store.CountsByUsers(context.Background(), []string{"auth0|u1"}); !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
+	}
+}
+
+// TestSavedPostgresStore_CountsByUsers_MapsPerUser maps one count per user; a
+// user absent from the grouped result is omitted (defaults to 0 at the call site).
+func TestSavedPostgresStore_CountsByUsers_MapsPerUser(t *testing.T) {
+	t.Parallel()
+	fq := &fakeSavedQuerier{queryRows: &countSavedRows{rows: [][2]any{
+		{"auth0|u1", 5},
+		{"auth0|u2", 1},
+	}}}
+	store := NewPostgresStore(fq)
+
+	got, err := store.CountsByUsers(context.Background(), []string{"auth0|u1", "auth0|u2", "auth0|u3"})
+	if err != nil {
+		t.Fatalf("CountsByUsers: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("map size: got %d, want 2 (absent users omitted)", len(got))
+	}
+	if got["auth0|u1"] != 5 || got["auth0|u2"] != 1 {
+		t.Errorf("counts: got %+v, want {u1:5 u2:1}", got)
+	}
+	if _, ok := got["auth0|u3"]; ok {
+		t.Error("auth0|u3 must be absent (defaults to zero at the call site)")
+	}
+}
+
+// --- Count ---
+
+// TestSavedPostgresStore_Count_ReturnsTotal returns the scalar count(*).
+func TestSavedPostgresStore_Count_ReturnsTotal(t *testing.T) {
+	t.Parallel()
+	fq := &fakeSavedQuerier{countRow: &intSavedRow{n: 42}}
+	store := NewPostgresStore(fq)
+
+	got, err := store.Count(context.Background())
+	if err != nil {
+		t.Fatalf("Count: %v", err)
+	}
+	if got != 42 {
+		t.Errorf("Count = %d, want 42", got)
+	}
+}
+
+// TestSavedPostgresStore_Count_PropagatesError wraps a scan error.
+func TestSavedPostgresStore_Count_PropagatesError(t *testing.T) {
+	t.Parallel()
+	boom := errors.New("count boom")
+	fq := &fakeSavedQuerier{countRow: &intSavedRow{err: boom}}
+	store := NewPostgresStore(fq)
+
+	if _, err := store.Count(context.Background()); !errors.Is(err, boom) {
+		t.Fatalf("got %v, want wrapped %v", err, boom)
 	}
 }

--- a/cli/internal/tc/app.go
+++ b/cli/internal/tc/app.go
@@ -17,6 +17,7 @@ Commands:
   generate-offer-codes        Bulk-generate single-use offer codes
   grant-subscription          Grant or change a user's subscription tier
   list-users                  List users with email, ID, and subscription tier
+  stats                       Show aggregate user-base statistics
   help                        Show this help message
   version                     Print version
 
@@ -73,6 +74,8 @@ func Run(ctx context.Context, env Env, rawArgs []string) int {
 		return runGrantSubscription(ctx, client, env, args)
 	case "list-users":
 		return runListUsers(ctx, client, env, args)
+	case "stats":
+		return runStats(ctx, client, env, args)
 	default:
 		fmt.Fprintf(env.Err, "Unknown command: %s\n", args.Command)
 		fmt.Fprintln(env.Err, "Run 'tc help' for a list of commands.")

--- a/cli/internal/tc/app_test.go
+++ b/cli/internal/tc/app_test.go
@@ -33,6 +33,18 @@ func TestRun_Help(t *testing.T) {
 	}
 }
 
+func TestRun_HelpListsStatsCommand(t *testing.T) {
+	t.Parallel()
+	env, out, _ := captureEnv()
+	code := Run(context.Background(), env, []string{"help"})
+	if code != exitOK {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if !strings.Contains(out.String(), "stats") {
+		t.Fatalf("help must list the stats command:\n%s", out.String())
+	}
+}
+
 func TestRun_UnknownCommand(t *testing.T) {
 	t.Parallel()
 	env, _, errBuf := captureEnv()

--- a/cli/internal/tc/commands.go
+++ b/cli/internal/tc/commands.go
@@ -43,6 +43,71 @@ type listUsersItem struct {
 	LastActiveAt       *string `json:"lastActiveAt"`
 	NotificationTotal  int     `json:"notificationTotal"`
 	NotificationUnread int     `json:"notificationUnread"`
+	SavedCount         int     `json:"savedCount"`
+	DeviceCount        int     `json:"deviceCount"`
+	OfferCode          *string `json:"offerCode"`
+}
+
+// statsResponse mirrors the pinned GET /v1/admin/stats JSON contract
+// byte-for-field (api-go/internal/admin/stats.go). Field names and nesting are
+// load-bearing: the API side is authoritative and this type must not drift.
+type statsResponse struct {
+	Users    statsUsers    `json:"users"`
+	Paying   statsPaying   `json:"paying"`
+	Signups  statsSignups  `json:"signups"`
+	Activity statsActivity `json:"activity"`
+	Reach    statsReach    `json:"reach"`
+}
+
+type statsUsers struct {
+	Total  int         `json:"total"`
+	ByTier statsByTier `json:"byTier"`
+}
+
+// statsByTier is an explicit struct (not a map) so the three tier keys always
+// render in a fixed order, matching the API's encoding.
+type statsByTier struct {
+	Free     int `json:"Free"`
+	Personal int `json:"Personal"`
+	Pro      int `json:"Pro"`
+}
+
+type statsPaying struct {
+	EffectivePaid int `json:"effectivePaid"`
+	AppStore      int `json:"appStore"`
+	Comped        int `json:"comped"`
+	Lapsed        int `json:"lapsed"`
+	InGrace       int `json:"inGrace"`
+}
+
+type statsSignups struct {
+	Last24h    int              `json:"last24h"`
+	Last7d     int              `json:"last7d"`
+	Last30d    int              `json:"last30d"`
+	MostRecent *statsMostRecent `json:"mostRecent"`
+}
+
+// statsMostRecent is null when the user base is empty; Email is null when the
+// most-recent account has none (e.g. a Sign-in-with-Apple withheld email).
+type statsMostRecent struct {
+	UserID    string  `json:"userId"`
+	Email     *string `json:"email"`
+	CreatedAt string  `json:"createdAt"`
+}
+
+type statsActivity struct {
+	Active24h      int `json:"active24h"`
+	Active7d       int `json:"active7d"`
+	ZeroWatchZones int `json:"zeroWatchZones"`
+	NoEmail        int `json:"noEmail"`
+}
+
+type statsReach struct {
+	WatchZones          int `json:"watchZones"`
+	SavedApplications   int `json:"savedApplications"`
+	DeviceRegistrations int `json:"deviceRegistrations"`
+	NotificationsSent   int `json:"notificationsSent"`
+	NotificationsUnread int `json:"notificationsUnread"`
 }
 
 // parseStrictInt parses s as a non-negative base-10 integer, accepting only

--- a/cli/internal/tc/http_test.go
+++ b/cli/internal/tc/http_test.go
@@ -225,6 +225,76 @@ func TestRunListUsers_StopsOnNo(t *testing.T) {
 	}
 }
 
+// TestRunListUsers_FetchesSummaryOncePerRun asserts the first-page summary
+// header is fetched from /v1/admin/stats exactly once across a two-page list —
+// not re-fetched on page 2 — and is printed above the table.
+func TestRunListUsers_FetchesSummaryOncePerRun(t *testing.T) {
+	t.Parallel()
+	var statsHits, userHits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/admin/stats" {
+			statsHits++
+			_, _ = io.WriteString(w, testStatsJSON)
+			return
+		}
+		userHits++
+		if r.URL.Query().Get("continuationToken") == "" {
+			_, _ = io.WriteString(w, `{"items":[{"userId":"u1","email":"a@b.com","tier":"Pro"}],"continuationToken":"TOKEN1"}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{"items":[{"userId":"u2","email":"c@d.com","tier":"Free"}],"continuationToken":null}`)
+	}))
+	defer server.Close()
+
+	var out strings.Builder
+	env := Env{In: strings.NewReader("y\n"), Out: &out, Err: io.Discard}
+	code := runListUsers(context.Background(), clientFor(server), env, ParseArgs([]string{"list-users", "--page-size", "1"}))
+	if code != exitOK {
+		t.Fatalf("exit code = %d, want 0", code)
+	}
+	if statsHits != 1 {
+		t.Fatalf("stats endpoint hit %d times, want exactly 1 (first page only)", statsHits)
+	}
+	if userHits != 2 {
+		t.Fatalf("users endpoint hit %d times, want 2 (both pages)", userHits)
+	}
+	if got := out.String(); !strings.Contains(got, "2 users") || !strings.Contains(got, "paying 1") {
+		t.Fatalf("stdout missing first-page summary header:\n%s", got)
+	}
+}
+
+// TestRunListUsers_SummaryFetchFailureDegradesGracefully asserts a failing stats
+// fetch does not abort the command: the users table still renders and exit is 0.
+func TestRunListUsers_SummaryFetchFailureDegradesGracefully(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/admin/stats" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, "stats boom")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"items":[{"userId":"u1","email":"a@b.com","tier":"Pro"}],"continuationToken":null}`)
+	}))
+	defer server.Close()
+
+	var out strings.Builder
+	env := Env{In: strings.NewReader(""), Out: &out, Err: io.Discard}
+	code := runListUsers(context.Background(), clientFor(server), env, ParseArgs([]string{"list-users"}))
+	if code != exitOK {
+		t.Fatalf("exit code = %d, want 0 (stats-header failure must not abort)", code)
+	}
+	got := out.String()
+	if !strings.Contains(got, "u1") || !strings.Contains(got, "a@b.com") {
+		t.Fatalf("users table must still render when the summary fetch fails:\n%s", got)
+	}
+	// The convenience header is skipped silently — no summary line.
+	if strings.Contains(got, "paying") {
+		t.Fatalf("summary line must be absent when stats fetch failed:\n%s", got)
+	}
+}
+
 func TestRunListUsers_InvalidPageSizeReturns1(t *testing.T) {
 	t.Parallel()
 	env, _, errBuf := captureEnv()

--- a/cli/internal/tc/http_test.go
+++ b/cli/internal/tc/http_test.go
@@ -14,6 +14,14 @@ func clientFor(server *httptest.Server) *Client {
 	return NewClient(Config{URL: server.URL, APIKey: "sk-test"})
 }
 
+// testStatsJSON is a minimal but complete GET /v1/admin/stats body, shared by
+// the stats render tests and the list-users summary-header tests.
+const testStatsJSON = `{"users":{"total":2,"byTier":{"Free":1,"Personal":0,"Pro":1}},` +
+	`"paying":{"effectivePaid":1,"appStore":1,"comped":0,"lapsed":0,"inGrace":0},` +
+	`"signups":{"last24h":0,"last7d":1,"last30d":2,"mostRecent":{"userId":"u1","email":"a@b.com","createdAt":"2026-07-01T09:00:00Z"}},` +
+	`"activity":{"active24h":1,"active7d":2,"zeroWatchZones":0,"noEmail":1},` +
+	`"reach":{"watchZones":3,"savedApplications":5,"deviceRegistrations":2,"notificationsSent":10,"notificationsUnread":4}}`
+
 func TestRunGenerateOfferCodes_StreamsCodesOnSuccess(t *testing.T) {
 	t.Parallel()
 	var gotBody generateOfferCodesRequest

--- a/cli/internal/tc/http_test.go
+++ b/cli/internal/tc/http_test.go
@@ -150,8 +150,12 @@ func TestRunGrantSubscription_InvalidTierReturns1(t *testing.T) {
 
 func TestRunListUsers_SinglePageTable(t *testing.T) {
 	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/admin/stats" {
+			_, _ = io.WriteString(w, testStatsJSON)
+			return
+		}
 		_, _ = io.WriteString(w, `{"items":[{"userId":"u1","email":"a@b.com","tier":"Pro"},{"userId":"u2","email":null,"tier":"Free"}],"continuationToken":null}`)
 	}))
 	defer server.Close()
@@ -179,8 +183,12 @@ func TestRunListUsers_PaginatesOnYes(t *testing.T) {
 	t.Parallel()
 	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		paths = append(paths, r.URL.String())
 		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/admin/stats" {
+			_, _ = io.WriteString(w, testStatsJSON)
+			return
+		}
+		paths = append(paths, r.URL.String())
 		if r.URL.Query().Get("continuationToken") == "" {
 			_, _ = io.WriteString(w, `{"items":[{"userId":"u1","email":"a@b.com","tier":"Pro"}],"continuationToken":"TOKEN1"}`)
 			return
@@ -208,9 +216,13 @@ func TestRunListUsers_PaginatesOnYes(t *testing.T) {
 func TestRunListUsers_StopsOnNo(t *testing.T) {
 	t.Parallel()
 	var requests int
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		requests++
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/admin/stats" {
+			_, _ = io.WriteString(w, testStatsJSON)
+			return
+		}
+		requests++
 		_, _ = io.WriteString(w, `{"items":[{"userId":"u1","email":"a@b.com","tier":"Pro"}],"continuationToken":"TOKEN1"}`)
 	}))
 	defer server.Close()

--- a/cli/internal/tc/listusers.go
+++ b/cli/internal/tc/listusers.go
@@ -30,6 +30,7 @@ func runListUsers(ctx context.Context, client *Client, env Env, args *ParsedArgs
 
 	reader := bufio.NewReader(env.In)
 	continuationToken := ""
+	firstPage := true
 
 	for {
 		path := buildListUsersPath(hasSearch, search, pageSize, continuationToken)
@@ -44,6 +45,10 @@ func runListUsers(ctx context.Context, client *Client, env Env, args *ParsedArgs
 			return exitRuntime
 		}
 
+		if firstPage {
+			printStatsSummary(ctx, client, env.Out)
+			firstPage = false
+		}
 		printUsersTable(env.Out, page)
 
 		if page.ContinuationToken == nil {
@@ -59,6 +64,17 @@ func runListUsers(ctx context.Context, client *Client, env Env, args *ParsedArgs
 	}
 
 	return exitOK
+}
+
+// printStatsSummary fetches the aggregate once and prints a one-line header
+// above the first page. It is a convenience, not the payload: any failure
+// (network, non-2xx, empty body) is swallowed so the users table still renders.
+func printStatsSummary(ctx context.Context, client *Client, out io.Writer) {
+	var resp *statsResponse
+	if err := client.GetJSON(ctx, "/v1/admin/stats", &resp); err != nil || resp == nil {
+		return
+	}
+	fmt.Fprintln(out, statsSummaryLine(resp))
 }
 
 func buildListUsersPath(hasSearch bool, search string, pageSize int, continuationToken string) string {

--- a/cli/internal/tc/listusers.go
+++ b/cli/internal/tc/listusers.go
@@ -85,14 +85,17 @@ func printUsersTable(out io.Writer, page *listUsersResponse) {
 		hUserID     = "UserId"
 		hEmail      = "Email"
 		hTier       = "Tier"
+		hOffer      = "Offer"
 		hWatchZones = "WatchZones"
 		hLastActive = "LastActive"
 		hCreated    = "Created"
 		hNotifs     = "Notifs"
+		hSaved      = "Saved"
+		hDevices    = "Devices"
 	)
 
 	type cells struct {
-		userID, email, tier, watchZones, lastActive, created, notifs string
+		userID, email, tier, offer, watchZones, lastActive, created, notifs, saved, devices string
 	}
 	rows := make([]cells, 0, len(page.Items))
 	for _, item := range page.Items {
@@ -100,34 +103,41 @@ func printUsersTable(out io.Writer, page *listUsersResponse) {
 			userID:     item.UserID,
 			email:      emailCell(item.Email),
 			tier:       item.Tier,
+			offer:      offerCell(item.OfferCode),
 			watchZones: watchZonesCell(item.WatchZoneCount),
 			lastActive: datePart(item.LastActiveAt),
 			created:    datePart(item.CreatedAt),
 			notifs:     fmt.Sprintf("%d/%d", item.NotificationUnread, item.NotificationTotal),
+			saved:      strconv.Itoa(item.SavedCount),
+			devices:    strconv.Itoa(item.DeviceCount),
 		})
 	}
 
 	// Seed widths from the headers, then widen to the longest cell per column.
-	wUserID, wEmail, wTier := len(hUserID), len(hEmail), len(hTier)
+	wUserID, wEmail, wTier, wOffer := len(hUserID), len(hEmail), len(hTier), len(hOffer)
 	wWatch, wLast, wCreated, wNotifs := len(hWatchZones), len(hLastActive), len(hCreated), len(hNotifs)
+	wSaved, wDevices := len(hSaved), len(hDevices)
 	for _, r := range rows {
 		wUserID = max(wUserID, len(r.userID))
 		wEmail = max(wEmail, len(r.email))
 		wTier = max(wTier, len(r.tier))
+		wOffer = max(wOffer, len(r.offer))
 		wWatch = max(wWatch, len(r.watchZones))
 		wLast = max(wLast, len(r.lastActive))
 		wCreated = max(wCreated, len(r.created))
 		wNotifs = max(wNotifs, len(r.notifs))
+		wSaved = max(wSaved, len(r.saved))
+		wDevices = max(wDevices, len(r.devices))
 	}
 
-	format := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds\n",
-		wUserID, wEmail, wTier, wWatch, wLast, wCreated, wNotifs)
+	format := fmt.Sprintf("%%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds  %%-%ds\n",
+		wUserID, wEmail, wTier, wOffer, wWatch, wLast, wCreated, wNotifs, wSaved, wDevices)
 
-	header := fmt.Sprintf(format, hUserID, hEmail, hTier, hWatchZones, hLastActive, hCreated, hNotifs)
+	header := fmt.Sprintf(format, hUserID, hEmail, hTier, hOffer, hWatchZones, hLastActive, hCreated, hNotifs, hSaved, hDevices)
 	fmt.Fprint(out, header)
 	fmt.Fprintln(out, strings.Repeat("-", len(strings.TrimRight(header, "\n"))))
 	for _, r := range rows {
-		fmt.Fprintf(out, format, r.userID, r.email, r.tier, r.watchZones, r.lastActive, r.created, r.notifs)
+		fmt.Fprintf(out, format, r.userID, r.email, r.tier, r.offer, r.watchZones, r.lastActive, r.created, r.notifs, r.saved, r.devices)
 	}
 }
 
@@ -146,6 +156,16 @@ func watchZonesCell(n *int) string {
 		return "-"
 	}
 	return strconv.Itoa(*n)
+}
+
+// offerCell renders the user's active offer code, or "-" when none is active
+// (the API sends null for no active code, and for an erased user whose
+// redeemed_by_user_id was scrubbed).
+func offerCell(code *string) string {
+	if code == nil {
+		return "-"
+	}
+	return *code
 }
 
 // datePart trims an RFC3339 timestamp to its date portion (YYYY-MM-DD) for

--- a/cli/internal/tc/listusers_test.go
+++ b/cli/internal/tc/listusers_test.go
@@ -9,7 +9,9 @@ func intptr(n int) *int { return &n }
 
 // TestPrintUsersTable_DynamicWidthsAndColumns verifies the list table aligns
 // regardless of user-id length (Apple IDs are ~49 chars, Auth0 ~13) and renders
-// the watch-zone, last-active, created, and notification columns.
+// the watch-zone, offer, last-active, created, notification, saved, and device
+// columns. Cell values are asserted positionally via strings.Fields so the
+// column ORDER is pinned, not just their presence.
 func TestPrintUsersTable_DynamicWidthsAndColumns(t *testing.T) {
 	t.Parallel()
 
@@ -26,6 +28,9 @@ func TestPrintUsersTable_DynamicWidthsAndColumns(t *testing.T) {
 			LastActiveAt:       strptr("2026-03-04T10:00:00Z"),
 			NotificationTotal:  57,
 			NotificationUnread: 2,
+			SavedCount:         17,
+			DeviceCount:        8,
+			OfferCode:          strptr("SUMMER25"),
 		},
 		{
 			UserID:             authID,
@@ -36,6 +41,9 @@ func TestPrintUsersTable_DynamicWidthsAndColumns(t *testing.T) {
 			LastActiveAt:       strptr("2026-02-20T08:30:00Z"),
 			NotificationTotal:  0,
 			NotificationUnread: 0,
+			SavedCount:         0,
+			DeviceCount:        0,
+			OfferCode:          nil, // no active offer code -> "-"
 		},
 	}}
 
@@ -50,8 +58,8 @@ func TestPrintUsersTable_DynamicWidthsAndColumns(t *testing.T) {
 	row1 := lines[2]
 	row2 := lines[3]
 
-	// All new column headers are present.
-	for _, col := range []string{"UserId", "Email", "Tier", "WatchZones", "LastActive", "Created", "Notifs"} {
+	// All column headers are present, including the three new ones.
+	for _, col := range []string{"UserId", "Email", "Tier", "Offer", "WatchZones", "LastActive", "Created", "Notifs", "Saved", "Devices"} {
 		if !strings.Contains(header, col) {
 			t.Errorf("header missing column %q:\n%s", col, header)
 		}
@@ -67,16 +75,26 @@ func TestPrintUsersTable_DynamicWidthsAndColumns(t *testing.T) {
 		t.Errorf("row2 email offset = %d, want %d (aligned with header)\n%s", got, emailOffset, out)
 	}
 
-	// Watch-zone: count when present, "-" when nil.
-	if !strings.Contains(row1, "3") {
-		t.Errorf("row1 should show watch-zone count 3:\n%s", row1)
+	// Alignment holds through the added columns: the Offer header and the row-1
+	// offer code start at the same offset.
+	if got, want := strings.Index(row1, "SUMMER25"), strings.Index(header, "Offer"); got != want {
+		t.Errorf("row1 offer offset = %d, want %d (aligned with header)\n%s", got, want, out)
 	}
-	// Notifs: unread/total.
-	if !strings.Contains(row1, "2/57") {
-		t.Errorf("row1 should show notifs 2/57:\n%s", row1)
+
+	// Column ORDER + values, positionally. Fields splits on whitespace runs; every
+	// cell is a single token, so the slice indexes map to columns:
+	// 0 UserId 1 Email 2 Tier 3 Offer 4 WatchZones 5 LastActive 6 Created 7 Notifs 8 Saved 9 Devices.
+	f1 := strings.Fields(row1)
+	f2 := strings.Fields(row2)
+	if len(f1) != 10 || len(f2) != 10 {
+		t.Fatalf("expected 10 columns per row, got f1=%d f2=%d:\n%s", len(f1), len(f2), out)
 	}
-	if !strings.Contains(row2, "0/0") {
-		t.Errorf("row2 should show notifs 0/0:\n%s", row2)
+	if f1[3] != "SUMMER25" || f1[7] != "2/57" || f1[8] != "17" || f1[9] != "8" {
+		t.Errorf("row1 columns wrong: offer=%q notifs=%q saved=%q devices=%q\n%s", f1[3], f1[7], f1[8], f1[9], out)
+	}
+	// Null offer code renders "-"; zero counts render "0".
+	if f2[3] != "-" || f2[7] != "0/0" || f2[8] != "0" || f2[9] != "0" {
+		t.Errorf("row2 columns wrong: offer=%q notifs=%q saved=%q devices=%q\n%s", f2[3], f2[7], f2[8], f2[9], out)
 	}
 
 	// Dates are truncated to the date portion (no time-of-day / "T").
@@ -85,6 +103,17 @@ func TestPrintUsersTable_DynamicWidthsAndColumns(t *testing.T) {
 	}
 	if strings.Contains(out, "T09:00:00") || strings.Contains(out, "2026-01-01T") {
 		t.Errorf("dates must be truncated to the date portion, got:\n%s", out)
+	}
+}
+
+// TestOfferCell covers the nil-vs-present rendering directly.
+func TestOfferCell(t *testing.T) {
+	t.Parallel()
+	if got := offerCell(nil); got != "-" {
+		t.Errorf("nil offer code: got %q, want -", got)
+	}
+	if got := offerCell(strptr("SPRING10")); got != "SPRING10" {
+		t.Errorf("present offer code: got %q, want SPRING10", got)
 	}
 }
 

--- a/cli/internal/tc/stats.go
+++ b/cli/internal/tc/stats.go
@@ -1,0 +1,91 @@
+package tc
+
+import (
+	"context"
+	"fmt"
+	"io"
+)
+
+// runStats implements `tc stats`: fetch the whole-user-base aggregate from
+// GET /v1/admin/stats and render it as a compact, grouped plain-text block.
+// Error handling mirrors runListUsers: a non-2xx status or empty body prints to
+// stderr and returns the runtime exit code.
+func runStats(ctx context.Context, client *Client, env Env, _ *ParsedArgs) int {
+	var resp *statsResponse
+	if err := client.GetJSON(ctx, "/v1/admin/stats", &resp); err != nil {
+		fmt.Fprintln(env.Err, err.Error())
+		return exitRuntime
+	}
+	if resp == nil {
+		fmt.Fprintln(env.Err, "Empty response from API")
+		return exitRuntime
+	}
+
+	renderStats(env.Out, resp)
+	return exitOK
+}
+
+// renderStats writes the aggregate as five labelled groups (Users, Paying,
+// Signups, Activity, Reach). It is deliberately plain admin-tooling text — no
+// product voice — kept compact enough to scan in a terminal.
+func renderStats(out io.Writer, s *statsResponse) {
+	fmt.Fprintln(out, "Users")
+	fmt.Fprintf(out, "  Total: %d\n", s.Users.Total)
+	fmt.Fprintf(out, "  By tier: Free %d, Personal %d, Pro %d\n",
+		s.Users.ByTier.Free, s.Users.ByTier.Personal, s.Users.ByTier.Pro)
+	fmt.Fprintln(out)
+
+	fmt.Fprintln(out, "Paying")
+	fmt.Fprintf(out, "  Effective paid: %d\n", s.Paying.EffectivePaid)
+	fmt.Fprintf(out, "  App Store: %d\n", s.Paying.AppStore)
+	fmt.Fprintf(out, "  Comped: %d\n", s.Paying.Comped)
+	fmt.Fprintf(out, "  Lapsed: %d\n", s.Paying.Lapsed)
+	fmt.Fprintf(out, "  In grace: %d\n", s.Paying.InGrace)
+	fmt.Fprintln(out)
+
+	fmt.Fprintln(out, "Signups")
+	fmt.Fprintf(out, "  Last 24h: %d\n", s.Signups.Last24h)
+	fmt.Fprintf(out, "  Last 7d: %d\n", s.Signups.Last7d)
+	fmt.Fprintf(out, "  Last 30d: %d\n", s.Signups.Last30d)
+	fmt.Fprintf(out, "  Most recent: %s\n", mostRecentCell(s.Signups.MostRecent))
+	fmt.Fprintln(out)
+
+	fmt.Fprintln(out, "Activity")
+	fmt.Fprintf(out, "  Active 24h: %d\n", s.Activity.Active24h)
+	fmt.Fprintf(out, "  Active 7d: %d\n", s.Activity.Active7d)
+	fmt.Fprintf(out, "  Zero watch zones: %d\n", s.Activity.ZeroWatchZones)
+	fmt.Fprintf(out, "  No email: %d\n", s.Activity.NoEmail)
+	fmt.Fprintln(out)
+
+	fmt.Fprintln(out, "Reach")
+	fmt.Fprintf(out, "  Watch zones: %d\n", s.Reach.WatchZones)
+	fmt.Fprintf(out, "  Saved applications: %d\n", s.Reach.SavedApplications)
+	fmt.Fprintf(out, "  Device registrations: %d\n", s.Reach.DeviceRegistrations)
+	fmt.Fprintf(out, "  Notifications sent: %d\n", s.Reach.NotificationsSent)
+	fmt.Fprintf(out, "  Notifications unread: %d\n", s.Reach.NotificationsUnread)
+}
+
+// mostRecentCell renders the most-recent signup, degrading gracefully: "(none)"
+// for an empty user base (nil) and "(none)" for a withheld email.
+func mostRecentCell(mr *statsMostRecent) string {
+	if mr == nil {
+		return "(none)"
+	}
+	email := "none"
+	if mr.Email != nil {
+		email = *mr.Email
+	}
+	return fmt.Sprintf("%s (%s) at %s", mr.UserID, email, mr.CreatedAt)
+}
+
+// statsSummaryLine condenses the aggregate into a single line for the
+// list-users first-page header: total + tier split, paying breakdown, and the
+// two freshest signals (new-in-24h, active-in-24h).
+func statsSummaryLine(s *statsResponse) string {
+	return fmt.Sprintf(
+		"%d users (Free %d, Personal %d, Pro %d) · paying %d (App Store %d, comped %d, lapsed %d) · new 24h %d · active 24h %d",
+		s.Users.Total, s.Users.ByTier.Free, s.Users.ByTier.Personal, s.Users.ByTier.Pro,
+		s.Paying.EffectivePaid, s.Paying.AppStore, s.Paying.Comped, s.Paying.Lapsed,
+		s.Signups.Last24h, s.Activity.Active24h,
+	)
+}

--- a/cli/internal/tc/stats_test.go
+++ b/cli/internal/tc/stats_test.go
@@ -1,0 +1,168 @@
+package tc
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// sampleStats builds a fully-populated statsResponse for render assertions.
+func sampleStats() *statsResponse {
+	return &statsResponse{
+		Users: statsUsers{
+			Total:  42,
+			ByTier: statsByTier{Free: 30, Personal: 8, Pro: 4},
+		},
+		Paying: statsPaying{
+			EffectivePaid: 12,
+			AppStore:      9,
+			Comped:        3,
+			Lapsed:        2,
+			InGrace:       1,
+		},
+		Signups: statsSignups{
+			Last24h:    3,
+			Last7d:     11,
+			Last30d:    28,
+			MostRecent: &statsMostRecent{UserID: "auth0|u1", Email: strptr("alice@example.com"), CreatedAt: "2026-07-01T09:00:00Z"},
+		},
+		Activity: statsActivity{
+			Active24h:      5,
+			Active7d:       20,
+			ZeroWatchZones: 7,
+			NoEmail:        2,
+		},
+		Reach: statsReach{
+			WatchZones:          88,
+			SavedApplications:   150,
+			DeviceRegistrations: 40,
+			NotificationsSent:   500,
+			NotificationsUnread: 45,
+		},
+	}
+}
+
+// TestRenderStats_ContainsAggregates asserts the compact block groups every
+// metric under its five headings with the right values.
+func TestRenderStats_ContainsAggregates(t *testing.T) {
+	t.Parallel()
+	var sb strings.Builder
+	renderStats(&sb, sampleStats())
+	out := sb.String()
+
+	for _, want := range []string{
+		// Headings.
+		"Users", "Paying", "Signups", "Activity", "Reach",
+		// Users.
+		"Total: 42", "Free 30, Personal 8, Pro 4",
+		// Paying.
+		"Effective paid: 12", "App Store: 9", "Comped: 3", "Lapsed: 2", "In grace: 1",
+		// Signups.
+		"Last 24h: 3", "Last 7d: 11", "Last 30d: 28",
+		"auth0|u1 (alice@example.com) at 2026-07-01T09:00:00Z",
+		// Activity.
+		"Active 24h: 5", "Active 7d: 20", "Zero watch zones: 7", "No email: 2",
+		// Reach.
+		"Watch zones: 88", "Saved applications: 150", "Device registrations: 40",
+		"Notifications sent: 500", "Notifications unread: 45",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("render missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRenderStats_NullMostRecentAndEmail covers the two null-degradation paths:
+// a nil mostRecent (empty user base) and a non-nil mostRecent with a nil email.
+func TestRenderStats_NullMostRecentAndEmail(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil most recent", func(t *testing.T) {
+		t.Parallel()
+		s := sampleStats()
+		s.Signups.MostRecent = nil
+		var sb strings.Builder
+		renderStats(&sb, s)
+		if !strings.Contains(sb.String(), "Most recent: (none)") {
+			t.Errorf("nil mostRecent should render (none):\n%s", sb.String())
+		}
+	})
+
+	t.Run("nil email", func(t *testing.T) {
+		t.Parallel()
+		s := sampleStats()
+		s.Signups.MostRecent = &statsMostRecent{UserID: "apple|u9", Email: nil, CreatedAt: "2026-07-01T10:00:00Z"}
+		var sb strings.Builder
+		renderStats(&sb, s)
+		if !strings.Contains(sb.String(), "apple|u9 (none) at 2026-07-01T10:00:00Z") {
+			t.Errorf("nil email should render (none):\n%s", sb.String())
+		}
+	})
+}
+
+// TestStatsSummaryLine renders the one-line list-users header from the aggregate.
+func TestStatsSummaryLine(t *testing.T) {
+	t.Parallel()
+	got := statsSummaryLine(sampleStats())
+	for _, want := range []string{
+		"42 users", "Free 30", "Personal 8", "Pro 4",
+		"paying 12", "App Store 9", "comped 3", "lapsed 2",
+		"new 24h 3", "active 24h 5",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("summary line missing %q:\n%s", want, got)
+		}
+	}
+}
+
+// TestRunStats_SuccessRendersBlock drives runStats against a fake endpoint and
+// asserts it GETs the pinned path, sends the admin key, and renders the block.
+func TestRunStats_SuccessRendersBlock(t *testing.T) {
+	t.Parallel()
+	var gotPath, gotMethod, gotKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotKey = r.Header.Get(apiKeyHeader)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, testStatsJSON)
+	}))
+	defer server.Close()
+
+	env, out, errBuf := captureEnv()
+	code := runStats(context.Background(), clientFor(server), env, ParseArgs([]string{"stats"}))
+	if code != exitOK {
+		t.Fatalf("exit code = %d, want 0; stderr=%q", code, errBuf.String())
+	}
+	if gotMethod != http.MethodGet || gotPath != "/v1/admin/stats" {
+		t.Fatalf("request = %s %s, want GET /v1/admin/stats", gotMethod, gotPath)
+	}
+	if gotKey != "sk-test" {
+		t.Fatalf("X-Admin-Key = %q, want sk-test", gotKey)
+	}
+	if got := out.String(); !strings.Contains(got, "Total: 2") || !strings.Contains(got, "Paying") {
+		t.Fatalf("stdout missing rendered stats:\n%s", got)
+	}
+}
+
+// TestRunStats_APIErrorReturns2 mirrors runListUsers' non-2xx handling.
+func TestRunStats_APIErrorReturns2(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	}))
+	defer server.Close()
+
+	env, _, errBuf := captureEnv()
+	code := runStats(context.Background(), clientFor(server), env, ParseArgs([]string{"stats"}))
+	if code != exitRuntime {
+		t.Fatalf("exit code = %d, want 2", code)
+	}
+	if !strings.Contains(errBuf.String(), "API error (500): boom") {
+		t.Fatalf("stderr = %q, want API error (500)", errBuf.String())
+	}
+}


### PR DESCRIPTION
Closes #749.

## Changes

**API (`api-go`)**
- New `GET /v1/admin/stats` (gated by `X-Admin-Key`, registered in `admin.Routes`) returning aggregate metrics computed in SQL: total users + tier breakdown, paying buckets, signup windows (24h/7d/30d + most-recent), activity (active 24h/7d, 0-watch-zone, no-email), and reach (watch zones, saved apps, device registrations, notifications sent + unread).
- Paying counts classified in Go via `EffectiveTier(now)` (not raw `tier`): effective-paid / App Store (`original_transaction_id`) / comped / lapsed / in-grace — the domain expiry/grace rule stays authoritative.
- `GET /v1/admin/users` rows enriched with `savedCount`, `deviceCount`, `offerCode` (active-window code), each batched one-query-per-column-per-page like the existing notification tally.
- New batched/total store reads: `savedapplications`/`devicetokens` `CountsByUsers` + `Count`, `offercodes` `RedeemedByUsers` + `OfferCode.ActiveAt(now)`, `notifications.Totals`, `profiles` `PaidCandidates` + `UserStats`. Reach readers are nil-safe (unwired store contributes 0, never a 500).

**CLI (`tc`)**
- New `tc stats` command rendering the aggregates in a compact block.
- `tc list-users`: one-line summary header on the first page only (fetched once), plus new **Saved** / **Offer** / **Devices** columns (dynamic widths; null offer renders `-`).

## Tests
- Go: 1338 pass (race + real-DB `//go:build integration` for every new SQL query); handler tests cover the paying buckets (lapsed/comped/App Store/in-grace), 0-zone/no-email counts, enrichment `-`/null cases, and nil-store skip paths.
- CLI: 64 pass; render tests for the three columns and `tc stats`, plus a two-page test proving the summary header is fetched exactly once.
- golangci-lint clean (CI configs) for both modules.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin stats page/endpoint and a CLI `stats` command to view overall user, signup, activity, and reach summaries.
  * Expanded the admin user list with saved items, device registrations, and offer-code status.

* **Bug Fixes**
  * Improved handling for missing data so stats and user lists still render with zero values instead of failing.
  * Kept the admin stats endpoint protected by the admin key while allowing it to work without extra token checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->