### PR TITLE
feat(infra): activate share domain managed cert (dev+prod shareDomain config) (#738 Slice 3, tc-vwbt)

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -4,6 +4,7 @@ config:
   town-crier:ciServicePrincipalId: 8efcb7cf-f17e-4a93-aab5-df7bc3c2c2cc
   town-crier:frontendDomain: dev.towncrierapp.uk
   town-crier:apiDomain: api-dev.towncrierapp.uk
+  town-crier:shareDomain: share-dev.towncrierapp.uk
   town-crier:auth0Domain: towncrierapp.uk.auth0.com
   town-crier:auth0Audience: https://api-dev.towncrierapp.uk
   town-crier:apnsKeyId: L2J5PQASN5

--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -4,6 +4,7 @@ config:
   town-crier:ciServicePrincipalId: 8efcb7cf-f17e-4a93-aab5-df7bc3c2c2cc
   town-crier:frontendDomain: towncrierapp.uk
   town-crier:apiDomain: api.towncrierapp.uk
+  town-crier:shareDomain: share.towncrierapp.uk
   town-crier:auth0Domain: towncrierapp.uk.auth0.com
   town-crier:auth0Audience: https://api.towncrierapp.uk
   town-crier:customDomainPhase: "2"


### PR DESCRIPTION
Part of #738 Slice 3. Follow-up to #753 (which shipped the gated custom-domain cert code dormant).

Sets `town-crier:shareDomain`:
- `Pulumi.dev.yaml` → `share-dev.towncrierapp.uk`
- `Pulumi.prod.yaml` → `share.towncrierapp.uk`

This activates the gated `cert-share-{env}` managed certificate + custom-domain binding on the existing API ACA app (origin-lock inherited).

## Ordering (safe)
- **Dev**: the validation DNS (`asuid.share-dev` TXT + grey `share-dev` CNAME) is already created in Cloudflare, so cd-dev's `Pulumi up (dev)` can validate + bind `cert-share-dev` on this merge.
- **Prod**: `Pulumi.prod.yaml` only applies via cd-prod (tag-triggered), so this change sits dormant on main until a release. Prod validation DNS (`asuid.share` + `share` CNAME) will be cut **before** that release.

After the dev cert binds, the `share-dev` CNAME is flipped to proxied (orange) and a `/a/*`+`/og/*` cache rule is added (Cloudflare, outside Pulumi).

Config-only; no code change. tc-vwbt.