### PR TITLE
fix(infra): two-phase share managed cert — register hostname then bind (#738 Slice 3, tc-vwbt)

### DIFF
--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -4,7 +4,6 @@ config:
   town-crier:ciServicePrincipalId: 8efcb7cf-f17e-4a93-aab5-df7bc3c2c2cc
   town-crier:frontendDomain: towncrierapp.uk
   town-crier:apiDomain: api.towncrierapp.uk
-  town-crier:shareDomain: share.towncrierapp.uk
   town-crier:auth0Domain: towncrierapp.uk.auth0.com
   town-crier:auth0Audience: https://api.towncrierapp.uk
   town-crier:customDomainPhase: "2"

--- a/infra/environment.go
+++ b/infra/environment.go
@@ -199,29 +199,47 @@ func runEnvironmentStack(ctx *pulumi.Context, conf *config.Config, env string, t
 		}
 	}
 
-	// Public share page (#738 Slice 3): bind share.towncrierapp.uk as a SECOND custom domain on
-	// the same API ACA app so one app serves JSON on api. and HTML on share.. The origin-lock
-	// ipSecurityRestrictions on the shared ingress are inherited automatically. Managed cert
-	// validates via CNAME (the orchestrator creates the asuid TXT + CNAME in Cloudflare before
-	// this merges). Gated on shareDomain being set, so prod (unset for now) is simply skipped.
+	// Public share page (#738 Slice 3): bind the share host as a SECOND custom domain on the same
+	// API ACA app so one app serves JSON on api. and HTML on share.. The origin-lock
+	// ipSecurityRestrictions on the shared ingress are inherited automatically.
+	//
+	// Azure requires a TWO-PHASE rollout for a brand-new managed cert (RequireCustomHostnameInEnvironment):
+	//   phase 1 — register the hostname on the app with binding Disabled (no cert); validates domain
+	//             ownership via the asuid CNAME/TXT (cut in Cloudflare beforehand) so Azure will mint a cert.
+	//   phase 2 — create the managed cert (now permitted) and flip the binding to SniEnabled.
+	// sharePhase gates this and defaults to 1 whenever shareDomain is set, so a plain shareDomain change
+	// registers the hostname and an explicit sharePhase=2 later binds the cert. Unset shareDomain = skipped.
+	sharePhase := 1
+	if v, err := conf.TryInt("sharePhase"); err == nil {
+		sharePhase = v
+	}
 	if shareDomain != "" {
-		shareCert, err := app.NewManagedCertificate(ctx, fmt.Sprintf("cert-share-%s", env), &app.ManagedCertificateArgs{
-			EnvironmentName:        containerAppsEnvironmentName,
-			ManagedCertificateName: pulumi.String(fmt.Sprintf("cert-share-%s", env)),
-			ResourceGroupName:      sharedResourceGroupName,
-			Properties: &app.ManagedCertificatePropertiesArgs{
-				SubjectName:             pulumi.String(shareDomain),
-				DomainControlValidation: pulumi.String("CNAME"),
-			},
-		})
-		if err != nil {
-			return err
+		if sharePhase >= 2 {
+			shareCert, err := app.NewManagedCertificate(ctx, fmt.Sprintf("cert-share-%s", env), &app.ManagedCertificateArgs{
+				EnvironmentName:        containerAppsEnvironmentName,
+				ManagedCertificateName: pulumi.String(fmt.Sprintf("cert-share-%s", env)),
+				ResourceGroupName:      sharedResourceGroupName,
+				Properties: &app.ManagedCertificatePropertiesArgs{
+					SubjectName:             pulumi.String(shareDomain),
+					DomainControlValidation: pulumi.String("CNAME"),
+				},
+			})
+			if err != nil {
+				return err
+			}
+			goApiCustomDomains = append(goApiCustomDomains, &app.CustomDomainArgs{
+				Name:          pulumi.String(shareDomain),
+				CertificateId: shareCert.ID(),
+				BindingType:   app.BindingTypeSniEnabled,
+			})
+		} else {
+			// Phase 1: register the hostname with the binding disabled so Azure will permit the
+			// managed cert in phase 2. No CertificateId while disabled.
+			goApiCustomDomains = append(goApiCustomDomains, &app.CustomDomainArgs{
+				Name:        pulumi.String(shareDomain),
+				BindingType: app.BindingTypeDisabled,
+			})
 		}
-		goApiCustomDomains = append(goApiCustomDomains, &app.CustomDomainArgs{
-			Name:          pulumi.String(shareDomain),
-			CertificateId: shareCert.ID(),
-			BindingType:   app.BindingTypeSniEnabled,
-		})
 	}
 
 	ec := envContext{


### PR DESCRIPTION
Fixes the failed `cert-share-dev` create in cd-dev (from #755):
`Status=400 Code="RequireCustomHostnameInEnvironment"` — Azure won't mint a managed cert for a hostname until that hostname is first registered on an app in the environment.

## Change
- `infra/environment.go`: split the share-domain block into a two-phase rollout gated by a new `sharePhase` config (mirrors `customDomainPhase`, `conf.TryInt`, default **1**):
  - **Phase 1** (default when `shareDomain` set): register the hostname with `BindingType: Disabled`, no cert → validates ownership via the asuid CNAME/TXT, makes Azure willing to mint the cert.
  - **Phase 2** (explicit `sharePhase=2`): create `cert-share-{env}` + flip binding to `SniEnabled`.
- `infra/Pulumi.prod.yaml`: removed `shareDomain` (prod deferred to a later staged rollout; avoids the same failure on the next prod release).
- `infra/Pulumi.dev.yaml`: unchanged — `shareDomain: share-dev.towncrierapp.uk`, no `sharePhase` → **phase 1** applies on this merge.

`app.BindingTypeDisabled` confirmed present in azure-native-sdk app/v3 @ v3.16.0 (serializes to `"Disabled"`).

Next: after dev phase 1 registers the hostname, a one-line `sharePhase: "2"` PR binds `cert-share-dev`. tc-vwbt.