### PR TITLE
feat(infra): bind cert-share-dev (sharePhase=2, dev) (#738 Slice 3, tc-vwbt)

### DIFF
--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -5,6 +5,7 @@ config:
   town-crier:frontendDomain: dev.towncrierapp.uk
   town-crier:apiDomain: api-dev.towncrierapp.uk
   town-crier:shareDomain: share-dev.towncrierapp.uk
+  town-crier:sharePhase: "2"
   town-crier:auth0Domain: towncrierapp.uk.auth0.com
   town-crier:auth0Audience: https://api-dev.towncrierapp.uk
   town-crier:apnsKeyId: L2J5PQASN5


### PR DESCRIPTION
Phase 2 of the dev share-domain cert. #756 registered `share-dev.towncrierapp.uk` on the API ACA app (binding Disabled); this sets `town-crier:sharePhase: "2"` in Pulumi.dev.yaml so cd-dev mints `cert-share-dev` and flips the binding to SniEnabled. Validation DNS (asuid.share-dev TXT + grey share-dev CNAME) is live in Cloudflare. tc-vwbt.