### PR TITLE
feat(infra): prod share domain phase 1 — register hostname (#738 Slice 3, tc-vwbt)

### DIFF
--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -4,6 +4,7 @@ config:
   town-crier:ciServicePrincipalId: 8efcb7cf-f17e-4a93-aab5-df7bc3c2c2cc
   town-crier:frontendDomain: towncrierapp.uk
   town-crier:apiDomain: api.towncrierapp.uk
+  town-crier:shareDomain: share.towncrierapp.uk
   town-crier:auth0Domain: towncrierapp.uk.auth0.com
   town-crier:auth0Audience: https://api.towncrierapp.uk
   town-crier:customDomainPhase: "2"


### PR DESCRIPTION
Sets `town-crier:shareDomain: share.towncrierapp.uk` in Pulumi.prod.yaml (sharePhase defaults to 1). On the next prod release, cd-prod registers the hostname on the prod API ACA app (binding Disabled) + provisions the prod share-cards container/RBAC/env + deploys the Go AASA/blob code. Prod validation DNS already cut (asuid.share TXT + grey share CNAME). Phase 2 (cert bind) follows. tc-vwbt.