### PR TITLE
feat(infra): bind cert-share-prod (sharePhase=2, prod) (#738 Slice 3, tc-vwbt)

### DIFF
--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -5,6 +5,7 @@ config:
   town-crier:frontendDomain: towncrierapp.uk
   town-crier:apiDomain: api.towncrierapp.uk
   town-crier:shareDomain: share.towncrierapp.uk
+  town-crier:sharePhase: "2"
   town-crier:auth0Domain: towncrierapp.uk.auth0.com
   town-crier:auth0Audience: https://api.towncrierapp.uk
   town-crier:customDomainPhase: "2"


### PR DESCRIPTION
Phase 2 of the prod share-domain cert. v0.15.61 registered `share.towncrierapp.uk` on the prod API ACA app (binding Disabled); this sets `town-crier:sharePhase: "2"` in Pulumi.prod.yaml so the next release's cd-prod mints `cert-share-prod` and flips the binding to SniEnabled. Prod validation DNS live (asuid.share TXT + grey share CNAME). After merge I cut the release, then flip the share CNAME to proxied. tc-vwbt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production configuration with an additional share-phase setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->