### PR TITLE
feat(ios): share button + Universal Links for share.towncrierapp.uk (#738 Slice 4)

### DIFF
--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
@@ -123,6 +123,29 @@ public final class APIPlanningApplicationRepository: PlanningApplicationReposito
     }
     return dto.toDomain()
   }
+
+  public func fetchApplication(bySlug authoritySlug: String, ref: String) async throws
+    -> PlanningApplication {
+    let dto: PlanningApplicationDTO
+    do {
+      // Anonymous public read: /v1/applications/by-slug/{authoritySlug}/{**ref}.
+      // The greedy `{**ref}` segment preserves slashes in the full area-prefixed
+      // PlanIt name, so `ref` interpolates raw exactly like `id.name` does in the
+      // by-id read above (GH #738 Slice 4).
+      dto = try await apiClient.request(
+        .get("/v1/applications/by-slug/\(authoritySlug)/\(ref)")
+      )
+    } catch APIError.notFound {
+      throw DomainError.applicationNotFound(
+        PlanningApplicationId(authority: authoritySlug, name: ref)
+      )
+    } catch let domainError as DomainError {
+      throw domainError
+    } catch {
+      throw error.toDomainError()
+    }
+    return dto.toDomain()
+  }
 }
 
 // MARK: - Cluster DTO

--- a/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-data/Sources/Repositories/APIPlanningApplicationRepository.swift
@@ -194,6 +194,10 @@ struct PlanningApplicationDTO: Decodable, Sendable {
   let link: String?
   let lastDifferent: String
   let latestUnreadEvent: LatestUnreadEventDTO?
+  /// URL-safe authority slug for the public share URL. Present on the by-id
+  /// detail read and the anonymous by-slug read; absent (`omitempty`) on the
+  /// list/zone endpoints, so it decodes as optional (GH #738 Slice 4).
+  let authoritySlug: String?
 
   func toDomain() -> PlanningApplication {
     let status = ApplicationStatus(rawValue: appState ?? "") ?? .unknown
@@ -205,7 +209,7 @@ struct PlanningApplicationDTO: Decodable, Sendable {
     return PlanningApplication(
       id: PlanningApplicationId(authority: String(areaId), name: name),
       reference: ApplicationReference(name),
-      authority: LocalAuthority(code: String(areaId), name: areaName),
+      authority: LocalAuthority(code: String(areaId), name: areaName, slug: authoritySlug),
       status: status,
       receivedDate: receivedDate,
       description: description,

--- a/mobile/ios/packages/town-crier-domain/Sources/Protocols/PlanningApplicationRepository.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/Protocols/PlanningApplicationRepository.swift
@@ -3,6 +3,14 @@ public protocol PlanningApplicationRepository: Sendable {
   func fetchApplications(for zone: WatchZone) async throws -> [PlanningApplication]
   func fetchApplication(by id: PlanningApplicationId) async throws -> PlanningApplication
 
+  /// Fetches a single application by its public share identity — the API-emitted
+  /// authority slug plus the full area-prefixed PlanIt ref (slashes preserved).
+  /// Backs inbound Universal Link resolution for `/a/{authoritySlug}/{ref...}`
+  /// via the anonymous by-slug read (GH #738 Slice 4). The slug comes from the
+  /// URL/API; iOS never computes it.
+  func fetchApplication(bySlug authoritySlug: String, ref: String) async throws
+    -> PlanningApplication
+
   /// Fetches a single server-sorted, server-filtered, server-paged page of a
   /// zone's applications, returning the decoded rows plus the continuation
   /// cursor for the next page (`nil` on the last page). The list's infinite

--- a/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/LocalAuthority.swift
+++ b/mobile/ios/packages/town-crier-domain/Sources/ValueObjects/LocalAuthority.swift
@@ -3,10 +3,16 @@ public struct LocalAuthority: Equatable, Hashable, Sendable {
   public let code: String
   public let name: String
   public let areaType: String?
+  /// URL-safe slug for the public share surface (e.g. `"kingston"`), as emitted
+  /// by the API on the detail/by-slug JSON. `nil` on list/zone payloads, which
+  /// omit it. Always supplied by the server — iOS never computes it
+  /// (GH #738 Slice 4).
+  public let slug: String?
 
-  public init(code: String, name: String, areaType: String? = nil) {
+  public init(code: String, name: String, areaType: String? = nil, slug: String? = nil) {
     self.code = code
     self.name = name
     self.areaType = areaType
+    self.slug = slug
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+DeepLink.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+DeepLink.swift
@@ -22,6 +22,14 @@ extension AppCoordinator {
       showApplicationDetail(id)
     case .applicationsList:
       selectedTab = .applications
+    case let .shareApplication(authoritySlug, ref):
+      // Inbound public share Universal Link (GH #738 Slice 4). Switch to the
+      // Applications tab so the hoisted detail sheet modifier is in scope when
+      // SwiftUI evaluates the `detailApplication` mutation, then resolve the
+      // application via the anonymous by-slug read. No review-prompt signal —
+      // arriving from a shared web link is not the instant-alert payoff moment.
+      selectedTab = .applications
+      showApplicationDetail(bySlug: authoritySlug, ref: ref)
     }
   }
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Detail.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator+Detail.swift
@@ -41,6 +41,30 @@ extension AppCoordinator {
     }
   }
 
+  /// Resolves an inbound public share Universal Link `/a/{authoritySlug}/{ref...}`
+  /// (GH #738 Slice 4) into the native detail screen. The anonymous by-slug read
+  /// returns the full application, so this presents it directly — no round-trip
+  /// through the by-id fetch. Same cancellation-guard pattern as
+  /// ``showApplicationDetail(_:)-(PlanningApplicationId)`` so overlapping opens
+  /// collapse to a single presentation.
+  func showApplicationDetail(bySlug authoritySlug: String, ref: String) {
+    pendingDetailLoad?.cancel()
+    pendingDetailLoad = Task { [weak self] in
+      guard let self else { return }
+      do {
+        let application = try await repository.fetchApplication(bySlug: authoritySlug, ref: ref)
+        guard !Task.isCancelled else { return }
+        detailApplication = application
+      } catch let domainError as DomainError {
+        guard !Task.isCancelled else { return }
+        deepLinkError = domainError
+      } catch {
+        guard !Task.isCancelled else { return }
+        deepLinkError = .unexpected(error.localizedDescription)
+      }
+    }
+  }
+
   /// Test-only synchronisation: await the most recent
   /// `showApplicationDetail` fetch. Replaces flaky `Task.sleep` waits.
   public func waitForPendingDetailLoad() async {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/DeepLink.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/DeepLink.swift
@@ -6,4 +6,9 @@ public enum DeepLink: Equatable, Sendable {
   /// The Applications tab root — used when a Universal Link points at
   /// `/applications` exactly (e.g. the digest email's bottom CTA).
   case applicationsList
+  /// A public share link `/a/{authoritySlug}/{ref...}` (GH #738 Slice 4). The
+  /// `authoritySlug` is the API-emitted slug and `ref` is the application's full
+  /// area-prefixed PlanIt name, verbatim (slashes preserved). Resolved into the
+  /// native detail screen via the anonymous by-slug read.
+  case shareApplication(authoritySlug: String, ref: String)
 }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/UniversalLinkParser.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/UniversalLinkParser.swift
@@ -4,15 +4,38 @@ import TownCrierDomain
 /// Parses Universal Link URLs (handed to the app by
 /// `NSUserActivityTypeBrowsingWeb`) into the in-app ``DeepLink`` vocabulary.
 ///
-/// The web app exposes two relevant routes that the AASA file claims:
-/// `/applications/{uid}` (a specific planning application) and `/applications`
-/// (the root list). PlanIt UIDs may contain `/` so the entire path suffix
-/// after `/applications/` is preserved verbatim.
+/// Two schemes are recognised:
+/// - the public share scheme `/a/{authoritySlug}/{ref...}` (GH #738 Slice 4),
+///   where `ref` is the application's full area-prefixed PlanIt name, verbatim
+///   (slashes preserved as path separators);
+/// - the legacy `/applications/{uid}` (a specific planning application) and
+///   `/applications` (the root list). PlanIt UIDs may contain `/`, so the
+///   entire path suffix after `/applications/` is preserved verbatim.
 public enum UniversalLinkParser {
   private static let applicationsPath = "/applications"
+  private static let sharePrefix = "/a/"
 
   public static func parse(_ url: URL) -> DeepLink? {
     let path = url.path
+    if let shareLink = parseShare(path) {
+      return shareLink
+    }
+    return parseApplications(path)
+  }
+
+  /// Parses `/a/{authoritySlug}/{ref...}`: the first segment after `/a/` is the
+  /// slug, everything after it (verbatim, slashes preserved) is the ref. A bare
+  /// `/a` or `/a/`, or a slug with no ref, returns `nil`. The `/a/` separator is
+  /// required, so `/afoo` does not match.
+  private static func parseShare(_ path: String) -> DeepLink? {
+    guard path.hasPrefix(sharePrefix) else { return nil }
+    let suffix = String(path.dropFirst(sharePrefix.count))
+    let parts = suffix.split(separator: "/", maxSplits: 1, omittingEmptySubsequences: false)
+    guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
+    return .shareApplication(authoritySlug: String(parts[0]), ref: String(parts[1]))
+  }
+
+  private static func parseApplications(_ path: String) -> DeepLink? {
     guard path.hasPrefix(applicationsPath) else { return nil }
     let suffix = String(path.dropFirst(applicationsPath.count))
     if suffix.isEmpty {

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailView.swift
@@ -9,6 +9,7 @@ import TownCrierDomain
 public struct ApplicationDetailView: View {
   @ObservedObject private var viewModel: ApplicationDetailViewModel
   @State private var showingSafari = false
+  @State private var showingShareSheet = false
 
   public init(viewModel: ApplicationDetailViewModel) {
     _viewModel = ObservedObject(wrappedValue: viewModel)
@@ -51,6 +52,11 @@ public struct ApplicationDetailView: View {
           SafariView(url: url)
         }
       }
+      .sheet(isPresented: $showingShareSheet) {
+        if let shareURL = viewModel.shareURL {
+          ShareSheet(activityItems: [shareURL])
+        }
+      }
     #endif
     .task {
       await viewModel.loadSavedState()
@@ -70,6 +76,21 @@ public struct ApplicationDetailView: View {
               .foregroundStyle(viewModel.isSaved ? Color.tcAmber : Color.tcTextSecondary)
           }
           .accessibilityLabel(viewModel.isSaved ? "Unsave" : "Save")
+        }
+      }
+      // Present the standard iOS share sheet with the canonical public share
+      // link (GH #738 Slice 4). Gated on a non-nil `shareURL` so a slug-less
+      // (broken) link is never offered — the button appears once `refresh()`
+      // has refetched the by-id payload that carries `authoritySlug`.
+      if viewModel.shareURL != nil {
+        ToolbarItem(placement: .automatic) {
+          Button {
+            showingShareSheet = true
+          } label: {
+            Image(systemName: "square.and.arrow.up")
+              .foregroundStyle(Color.tcTextSecondary)
+          }
+          .accessibilityLabel("Share")
         }
       }
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationDetail/ApplicationDetailViewModel.swift
@@ -38,6 +38,16 @@ public final class ApplicationDetailViewModel: ObservableObject {
   public var statusLabel: String { application.status.displayLabel }
   public var statusIcon: String { application.status.displayIcon }
 
+  /// Canonical public share URL for this application (GH #738 Slice 4), built
+  /// from the API-supplied `authoritySlug` and the full PlanIt ref. `nil` when
+  /// the authority carries no slug (e.g. the cached list payload before
+  /// ``refresh()`` refetches by-id), so the view never offers a broken,
+  /// slug-less link.
+  public var shareURL: URL? {
+    guard let slug = application.authority.slug else { return nil }
+    return ShareURL.build(authoritySlug: slug, ref: application.id.name)
+  }
+
   public var timelineItems: [TimelineItem] {
     let events =
       application.statusHistory.isEmpty

--- a/mobile/ios/packages/town-crier-presentation/Sources/Sharing/ShareURL.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Sharing/ShareURL.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Builds the canonical public share URL for a planning application:
+/// `https://share.towncrierapp.uk/a/{authoritySlug}/{ref}`.
+///
+/// `ref` is the application's full area-prefixed PlanIt `name`, verbatim — it
+/// contains slashes (e.g. `Kingston/25/02755/CLC`), which are preserved as path
+/// separators. `authoritySlug` always comes from the API (`authoritySlug` on
+/// the detail/by-slug JSON); iOS never computes it (GH #738 Slice 4).
+public enum ShareURL {
+  /// Origin of the public share surface. Mirrors the web `SHARE_ORIGIN`
+  /// constant (`web/scripts/lib/constants.mjs`).
+  public static let origin = "https://share.towncrierapp.uk"
+
+  /// Returns the canonical share URL, or `nil` when a component is empty or the
+  /// pieces cannot form a valid URL.
+  ///
+  /// Only unsafe characters in `ref` are percent-encoded; `.urlPathAllowed`
+  /// keeps `/`, so the ref's slashes remain path separators. The slug is
+  /// already URL-safe.
+  public static func build(authoritySlug: String, ref: String) -> URL? {
+    guard !authoritySlug.isEmpty, !ref.isEmpty else { return nil }
+    let encodedRef =
+      ref.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ref
+    return URL(string: "\(origin)/a/\(authoritySlug)/\(encodedRef)")
+  }
+}

--- a/mobile/ios/town-crier-app/TownCrierApp.entitlements
+++ b/mobile/ios/town-crier-app/TownCrierApp.entitlements
@@ -7,6 +7,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:towncrierapp.uk</string>
+		<string>applinks:share.towncrierapp.uk</string>
 	</array>
 </dict>
 </plist>

--- a/mobile/ios/town-crier-tests/Sources/Coordinators/ShareURLTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Coordinators/ShareURLTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+
+@testable import TownCrierPresentation
+
+@Suite("ShareURL")
+struct ShareURLTests {
+  @Test func origin_isTheCanonicalShareSubdomain() {
+    #expect(ShareURL.origin == "https://share.towncrierapp.uk")
+  }
+
+  @Test func build_preservesRefSlashesAsPathSeparators() {
+    // The ref is the application's full area-prefixed PlanIt `name`, verbatim —
+    // it contains slashes and must land as path separators, not be encoded.
+    let url = ShareURL.build(authoritySlug: "kingston", ref: "Kingston/25/02755/CLC")
+
+    #expect(
+      url?.absoluteString == "https://share.towncrierapp.uk/a/kingston/Kingston/25/02755/CLC")
+  }
+
+  @Test func build_withSimpleRef_buildsCanonicalURL() {
+    let url = ShareURL.build(authoritySlug: "croydon", ref: "23/03456/FUL")
+
+    #expect(url?.absoluteString == "https://share.towncrierapp.uk/a/croydon/23/03456/FUL")
+  }
+
+  @Test func build_withEmptySlug_returnsNil() {
+    #expect(ShareURL.build(authoritySlug: "", ref: "23/03456/FUL") == nil)
+  }
+
+  @Test func build_withEmptyRef_returnsNil() {
+    #expect(ShareURL.build(authoritySlug: "croydon", ref: "") == nil)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Coordinators/UniversalLinkParserTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Coordinators/UniversalLinkParserTests.swift
@@ -55,4 +55,62 @@ struct UniversalLinkParserTests {
 
     #expect(result == nil)
   }
+
+  // MARK: - Public share scheme /a/{authoritySlug}/{ref...} (GH #738 Slice 4)
+
+  @Test func parse_shareURLWithPrefixedRef_returnsShareApplicationDeepLink() throws {
+    // The ref is the application's full area-prefixed PlanIt name, verbatim —
+    // it contains slashes, which are preserved as-is after the slug segment.
+    let url = try #require(
+      URL(string: "https://share.towncrierapp.uk/a/kingston/Kingston/25/02755/CLC"))
+
+    let result = UniversalLinkParser.parse(url)
+
+    #expect(result == .shareApplication(authoritySlug: "kingston", ref: "Kingston/25/02755/CLC"))
+  }
+
+  @Test func parse_shareURLWithSimpleRef_returnsShareApplicationDeepLink() throws {
+    let url = try #require(URL(string: "https://share.towncrierapp.uk/a/croydon/23/03456/FUL"))
+
+    let result = UniversalLinkParser.parse(url)
+
+    #expect(result == .shareApplication(authoritySlug: "croydon", ref: "23/03456/FUL"))
+  }
+
+  @Test func parse_sharePrefixWithoutSeparator_returnsNil() throws {
+    // Guard against false-positive matches like `/afoo`: the `/a/` separator is
+    // required, so a path that merely starts with `/a` must not match.
+    let url = try #require(URL(string: "https://share.towncrierapp.uk/afoo"))
+
+    let result = UniversalLinkParser.parse(url)
+
+    #expect(result == nil)
+  }
+
+  @Test func parse_shareBarePathNoRef_returnsNil() throws {
+    // `/a` carries neither a slug nor a ref.
+    let url = try #require(URL(string: "https://share.towncrierapp.uk/a"))
+
+    let result = UniversalLinkParser.parse(url)
+
+    #expect(result == nil)
+  }
+
+  @Test func parse_shareTrailingSlashNoRef_returnsNil() throws {
+    // `/a/` has a separator but no slug/ref.
+    let url = try #require(URL(string: "https://share.towncrierapp.uk/a/"))
+
+    let result = UniversalLinkParser.parse(url)
+
+    #expect(result == nil)
+  }
+
+  @Test func parse_shareSlugWithoutRef_returnsNil() throws {
+    // A slug with no ref segment after it is not a valid share link.
+    let url = try #require(URL(string: "https://share.towncrierapp.uk/a/kingston"))
+
+    let result = UniversalLinkParser.parse(url)
+
+    #expect(result == nil)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryShareTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryShareTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierData
+
+/// Wire tests for GH #738 Slice 4: the additive `authoritySlug` field on the
+/// detail JSON and the anonymous by-slug read that backs inbound Universal Link
+/// resolution.
+@Suite("APIPlanningApplicationRepository — share")
+struct APIPlanningApplicationRepositoryShareTests {
+
+  // MARK: - Helpers
+
+  // swiftlint:disable:next force_unwrapping
+  private let baseURL = URL(string: "https://api-dev.towncrierapp.uk")!
+
+  // swiftlint:disable:next force_try
+  private let testZone = try! WatchZone(
+    id: WatchZoneId("zone-123"),
+    name: "Cambridge",
+    centre: Coordinate(latitude: 52.2053, longitude: 0.1218),
+    radiusMetres: 2000,
+    authorityId: 123
+  )
+
+  private func makeSUT(
+    responses: [(Data, URLResponse)]
+  ) -> (APIPlanningApplicationRepository, StubHTTPTransport) {
+    let authService = SpyAuthenticationService()
+    authService.currentSessionResult = .valid
+    let transport = StubHTTPTransport()
+    transport.responses = responses
+    let apiClient = URLSessionAPIClient(
+      baseURL: baseURL,
+      authService: authService,
+      transport: transport
+    )
+    let sut = APIPlanningApplicationRepository(apiClient: apiClient)
+    return (sut, transport)
+  }
+
+  // swiftlint:disable force_unwrapping
+  private func httpResponse(statusCode: Int) -> HTTPURLResponse {
+    HTTPURLResponse(
+      url: baseURL,
+      statusCode: statusCode,
+      httpVersion: nil,
+      headerFields: nil
+    )!
+  }
+  // swiftlint:enable force_unwrapping
+
+  // MARK: - authoritySlug decode
+
+  @Test("fetchApplication decodes the additive authoritySlug field onto the authority")
+  func fetchApplication_decodesAuthoritySlug() async throws {
+    let json = """
+      {
+          "name": "Kingston/25/02755/CLC",
+          "uid": "app-003",
+          "areaName": "Kingston upon Thames",
+          "areaId": 789,
+          "authoritySlug": "kingston",
+          "address": "1 Market Place, Kingston, KT1 1JS",
+          "postcode": "KT1 1JS",
+          "description": "Certificate of lawfulness",
+          "appType": "Full",
+          "appState": "Undecided",
+          "appSize": null,
+          "startDate": "2026-02-01",
+          "decidedDate": null,
+          "consultedDate": null,
+          "longitude": null,
+          "latitude": null,
+          "url": null,
+          "link": null,
+          "lastDifferent": "2026-02-01T00:00:00+00:00"
+      }
+      """
+    let (sut, _) = makeSUT(responses: [(Data(json.utf8), httpResponse(statusCode: 200))])
+
+    let app = try await sut.fetchApplication(
+      by: PlanningApplicationId(authority: "789", name: "Kingston/25/02755/CLC")
+    )
+
+    #expect(app.authority.slug == "kingston")
+  }
+
+  @Test("fetchApplications leaves authority slug nil when the field is absent (list endpoints)")
+  func fetchApplications_absentAuthoritySlug_isNil() async throws {
+    // The list/zone endpoints omit `authoritySlug` (server-side `omitempty`), so
+    // it must decode as optional and stay nil rather than fail decoding.
+    let json = """
+      [
+          {
+              "name": "2026/0042",
+              "uid": "app-001",
+              "areaName": "Cambridge",
+              "areaId": 123,
+              "address": "12 Mill Road",
+              "postcode": null,
+              "description": "Extension",
+              "appType": "Full",
+              "appState": "Undecided",
+              "appSize": null,
+              "startDate": "2026-01-15",
+              "decidedDate": null,
+              "consultedDate": null,
+              "longitude": null,
+              "latitude": null,
+              "url": null,
+              "link": null,
+              "lastDifferent": "2026-01-15T00:00:00+00:00"
+          }
+      ]
+      """
+    let (sut, _) = makeSUT(responses: [(Data(json.utf8), httpResponse(statusCode: 200))])
+
+    let result = try await sut.fetchApplications(for: testZone)
+
+    #expect(result[0].authority.slug == nil)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryShareTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/APIPlanningApplicationRepositoryShareTests.swift
@@ -121,4 +121,69 @@ struct APIPlanningApplicationRepositoryShareTests {
 
     #expect(result[0].authority.slug == nil)
   }
+
+  // MARK: - fetchApplication(bySlug:ref:)
+
+  @Test("fetchApplication(bySlug:) sends GET /v1/applications/by-slug/{slug}/{ref}")
+  func fetchApplicationBySlug_sendsCorrectRequest() async throws {
+    let json = """
+      {
+          "name": "Kingston/25/02755/CLC",
+          "uid": "app-003",
+          "areaName": "Kingston upon Thames",
+          "areaId": 789,
+          "authoritySlug": "kingston",
+          "address": "1 Market Place, Kingston, KT1 1JS",
+          "postcode": "KT1 1JS",
+          "description": "Certificate of lawfulness",
+          "appType": "Full",
+          "appState": "Undecided",
+          "appSize": null,
+          "startDate": "2026-02-01",
+          "decidedDate": null,
+          "consultedDate": null,
+          "longitude": null,
+          "latitude": null,
+          "url": null,
+          "link": null,
+          "lastDifferent": "2026-02-01T00:00:00+00:00"
+      }
+      """
+    let (sut, transport) = makeSUT(responses: [(Data(json.utf8), httpResponse(statusCode: 200))])
+
+    let app = try await sut.fetchApplication(bySlug: "kingston", ref: "Kingston/25/02755/CLC")
+
+    #expect(transport.requests.count == 1)
+    let request = transport.requests[0]
+    #expect(request.httpMethod == "GET")
+    // The ref's slashes pass through into the path verbatim, exactly like the
+    // by-id read interpolates `id.name`.
+    #expect(
+      request.url?.path().contains("/v1/applications/by-slug/kingston/Kingston/25/02755/CLC")
+        == true)
+    #expect(app.id == PlanningApplicationId(authority: "789", name: "Kingston/25/02755/CLC"))
+    #expect(app.authority.slug == "kingston")
+  }
+
+  @Test("fetchApplication(bySlug:) with 404 throws applicationNotFound")
+  func fetchApplicationBySlug_notFound_throwsApplicationNotFound() async throws {
+    let (sut, _) = makeSUT(responses: [(Data("null".utf8), httpResponse(statusCode: 404))])
+
+    await #expect(throws: DomainError.self) {
+      _ = try await sut.fetchApplication(bySlug: "kingston", ref: "Kingston/25/GONE")
+    }
+  }
+
+  @Test("fetchApplication(bySlug:) with server error throws serverError not networkUnavailable")
+  func fetchApplicationBySlug_serverError_throwsServerError() async throws {
+    let (sut, _) = makeSUT(responses: [
+      (Data("Internal Server Error".utf8), httpResponse(statusCode: 500))
+    ])
+
+    await #expect(
+      throws: DomainError.serverError(statusCode: 500, message: "Internal Server Error")
+    ) {
+      _ = try await sut.fetchApplication(bySlug: "kingston", ref: "Kingston/25/02755/CLC")
+    }
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailViewModelTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationDetailViewModelTests.swift
@@ -188,4 +188,31 @@ struct ApplicationDetailViewModelTests {
     // No crash and the cached payload is unchanged.
     #expect(sut.reference == "2026/0042")
   }
+
+  // MARK: - Share URL (GH #738 Slice 4)
+
+  @Test func shareURL_whenAuthoritySlugPresent_buildsCanonicalShareURL() {
+    let application = PlanningApplication(
+      id: PlanningApplicationId(authority: "789", name: "Kingston/25/02755/CLC"),
+      reference: ApplicationReference("Kingston/25/02755/CLC"),
+      authority: LocalAuthority(code: "789", name: "Kingston upon Thames", slug: "kingston"),
+      status: .undecided,
+      receivedDate: Date(timeIntervalSince1970: 1_700_000_000),
+      description: "Certificate of lawfulness",
+      address: "1 Market Place, Kingston, KT1 1JS"
+    )
+    let sut = ApplicationDetailViewModel(application: application)
+
+    #expect(
+      sut.shareURL?.absoluteString
+        == "https://share.towncrierapp.uk/a/kingston/Kingston/25/02755/CLC")
+  }
+
+  @Test func shareURL_whenAuthoritySlugAbsent_isNil() {
+    // `.pendingReview` carries no authority slug (list-payload shape), so no
+    // slug-less broken link is ever offered.
+    let sut = ApplicationDetailViewModel(application: .pendingReview)
+
+    #expect(sut.shareURL == nil)
+  }
 }

--- a/mobile/ios/town-crier-tests/Sources/Features/DeepLinkTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/DeepLinkTests.swift
@@ -98,6 +98,37 @@ struct DeepLinkTests {
 
     #expect(firstTask?.isCancelled == true)
   }
+
+  // MARK: - Share Universal Link (GH #738 Slice 4)
+
+  @Test func handleDeepLink_shareApplication_fetchesBySlugAndSetsDetailApplication() async {
+    let (sut, spy) = makeSUT()
+    spy.fetchApplicationBySlugResult = .success(.permitted)
+
+    sut.handleDeepLink(.shareApplication(authoritySlug: "kingston", ref: "Kingston/25/02755/CLC"))
+
+    await sut.waitForPendingDetailLoad()
+
+    #expect(sut.detailApplication == .permitted)
+    #expect(sut.selectedTab == .applications)
+    #expect(
+      spy.fetchApplicationBySlugCalls == [
+        .init(authoritySlug: "kingston", ref: "Kingston/25/02755/CLC")
+      ])
+  }
+
+  @Test func handleDeepLink_shareApplicationFailure_setsDeepLinkError() async {
+    let (sut, spy) = makeSUT()
+    let missingId = PlanningApplicationId(authority: "kingston", name: "Kingston/25/GONE")
+    spy.fetchApplicationBySlugResult = .failure(DomainError.applicationNotFound(missingId))
+
+    sut.handleDeepLink(.shareApplication(authoritySlug: "kingston", ref: "Kingston/25/GONE"))
+
+    await sut.waitForPendingDetailLoad()
+
+    #expect(sut.detailApplication == nil)
+    #expect(sut.deepLinkError == .applicationNotFound(missingId))
+  }
 }
 
 @Suite("NotificationPayloadParser")

--- a/mobile/ios/town-crier-tests/Sources/Spies/SpyPlanningApplicationRepository.swift
+++ b/mobile/ios/town-crier-tests/Sources/Spies/SpyPlanningApplicationRepository.swift
@@ -123,6 +123,26 @@ final class SpyPlanningApplicationRepository: PlanningApplicationRepository, @un
     return try fetchApplicationResult.get()
   }
 
+  // MARK: - By-slug fetch (GH #738 Slice 4)
+
+  /// A recorded `fetchApplication(bySlug:ref:)` invocation — lets tests assert the
+  /// exact slug + ref the coordinator drove for an inbound share Universal Link.
+  struct RecordedBySlugRequest: Sendable, Equatable {
+    let authoritySlug: String
+    let ref: String
+  }
+
+  private(set) var fetchApplicationBySlugCalls: [RecordedBySlugRequest] = []
+  var fetchApplicationBySlugResult: Result<PlanningApplication, Error> = .success(.pendingReview)
+
+  func fetchApplication(bySlug authoritySlug: String, ref: String) async throws
+    -> PlanningApplication {
+    fetchApplicationBySlugCalls.append(
+      RecordedBySlugRequest(authoritySlug: authoritySlug, ref: ref))
+    await waitForGateIfNeeded()
+    return try fetchApplicationBySlugResult.get()
+  }
+
   // MARK: - Cluster fetch (GH#698)
 
   /// A recorded `fetchClusters` invocation — lets tests assert the exact


### PR DESCRIPTION
## Changes

Slice 4 of #738 (bead tc-r0ma). Adds the iOS share entry point and inbound Universal Link handling for the public share page shipped in Slices 1–3.

- **Share URL builder** (`ShareURL`): canonical `https://share.towncrierapp.uk/a/{authoritySlug}/{ref}`, ref slashes preserved as path separators (`SHARE_ORIGIN` mirrors the web constant).
- **`authoritySlug` plumbing**: decoded onto `LocalAuthority.slug` (optional, default nil) from the detail/by-slug JSON; iOS never slugifies.
- **Toolbar Share button** on `ApplicationDetailView` (`square.and.arrow.up`, gated on a non-nil share URL) presenting the existing `ShareSheet`.
- **Universal Links**: new `DeepLink.shareApplication(authoritySlug:ref:)`; `UniversalLinkParser` handles `/a/{authoritySlug}/{ref...}` (legacy `/applications/*` kept); resolved async via new repo method `fetchApplication(bySlug:ref:)` → anonymous `GET /v1/applications/by-slug/{slug}/{ref}` → native detail screen.
- **Entitlements**: adds `applinks:share.towncrierapp.uk` (keeps `applinks:towncrierapp.uk`).

## Verification

- `swift build` + full suite green (1427 tests / 179 suites). New tests: `ShareURLTests`, parser `/a/` cases, `APIPlanningApplicationRepositoryShareTests` (by-slug), coordinator `handleDeepLink(.shareApplication)`, ViewModel `shareURL`.
- Simulator: Share button + exact URL `.../a/richmond/Richmond/PA26/2234` confirmed (resolves on dev by-slug). Inbound UL routing is unverifiable on the simulator — `simctl openurl` delivers the activity but the `.onContinueUserActivity` chain doesn't complete for the legacy `/applications/*` link either (identical failure), so it's a sim-wide artifact, not a regression. Real-device confirmation tracked in tc-hk8c.
- Commit carries a `Release-Note:` trailer.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening public share links directly in the app.
  * Added a share button on application details to generate and share a link when available.
  * Added a dedicated share-link format and new Universal Link handling for shared applications.

* **Bug Fixes**
  * Improved error handling for missing shared applications.
  * Kept shared links working even when the application reference contains slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->