### PR TITLE
chore(ios): bump MARKETING_VERSION 1.2.4→1.2.5 (closed train)

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.2.4"
+        MARKETING_VERSION: "1.2.5"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"


### PR DESCRIPTION
## Changes

- **chore(ios): bump MARKETING_VERSION 1.2.4→1.2.5** (tc-q8gf) — The `v0.15.63` TestFlight upload failed at altool (`90062` + `90186`): the `1.2.4` App Store train is closed for new build submissions. The CD beta lane only bumps the build number, so `MARKETING_VERSION` must be bumped manually. After merge, a fresh `v*` tag re-triggers the iOS TestFlight upload. Precedent: tc-z9qs / #679.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the iOS app version to **1.2.5**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->