### PR TITLE
fix(sharepage): map hero in page body + responsive desktop layout & homepage link (#763)

### DIFF
--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -177,6 +177,30 @@ func TestServe_KnownApplication_RendersMetaAndVisibleContent(t *testing.T) {
 	}
 }
 
+// TestServe_RendersMapHeroInBody pins Problem 2 (#763, tc-9ui9): the baked OSM
+// map card was previously emitted ONLY as og:image/twitter:image in <head>, so
+// browsers never showed it — only social unfurls did. The page body must carry
+// a visible hero <img> pointing at the SAME cached card URL as the unfurl meta.
+func TestServe_RendersMapHeroInBody(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{app: fullApp(t), found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `<img class="hero"`) {
+		t.Error("body missing a hero <img> — the map must render in the page body, not just og:image")
+	}
+	wantSrc := `src="https://share.towncrierapp.uk/og/croydon/23/03456/FUL.png"`
+	if !strings.Contains(body, wantSrc) {
+		t.Errorf("hero <img> src missing or wrong; body should contain %q", wantSrc)
+	}
+}
+
 func TestServe_UnknownSlug_RendersBranded404(t *testing.T) {
 	t.Parallel()
 	store := &fakeStore{}

--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -201,6 +201,25 @@ func TestServe_RendersMapHeroInBody(t *testing.T) {
 	}
 }
 
+// TestServe_RendersHomepageLink pins Problem 3 (#763, tc-iuf0): the only CTA was
+// the iOS-only App Store bar, with no link to the web app anywhere. A visible,
+// always-present link to the Town Crier homepage must be present on every device.
+func TestServe_RendersHomepageLink(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{app: fullApp(t), found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `href="https://towncrierapp.uk"`) {
+		t.Error("body missing a link to the Town Crier homepage (https://towncrierapp.uk)")
+	}
+}
+
 func TestServe_UnknownSlug_RendersBranded404(t *testing.T) {
 	t.Parallel()
 	store := &fakeStore{}

--- a/api-go/internal/sharepage/templates/page.gohtml
+++ b/api-go/internal/sharepage/templates/page.gohtml
@@ -22,6 +22,7 @@
 </head>
 <body>
 <main class="page">
+<img class="hero" src="{{.OGImage}}" alt="Map showing the approximate location of {{if .Address}}{{.Address}}{{else}}this planning application{{end}}" width="1200" height="630" loading="eager">
 <div class="brand"><span class="dot"></span>Town Crier</div>
 <article class="card">
 <div class="ref-row">Reference {{.Ref}}{{if .AppType}} &middot; {{.AppType}}{{end}}</div>

--- a/api-go/internal/sharepage/templates/page.gohtml
+++ b/api-go/internal/sharepage/templates/page.gohtml
@@ -42,6 +42,9 @@
 <p>Map data © OpenStreetMap contributors.</p>
 </footer>
 </main>
+<div class="cta-bar">
 <a class="cta" href="{{.CTAHref}}">Download the app for instant notifications about planning updates</a>
+<a class="home-link" href="{{.HomeURL}}">Get Town Crier at towncrierapp.uk</a>
+</div>
 </body>
 </html>{{end}}

--- a/api-go/internal/sharepage/templates/styles.gohtml
+++ b/api-go/internal/sharepage/templates/styles.gohtml
@@ -20,7 +20,7 @@ body{
   font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
   font-size:17px;line-height:1.4;
 }
-.page{max-width:600px;margin:0 auto;padding:var(--space-lg) var(--space-md) 128px;}
+.page{max-width:600px;margin:0 auto;padding:var(--space-lg) var(--space-md) 148px;}
 .hero{
   display:block;width:100%;height:auto;aspect-ratio:1200/630;
   border-radius:var(--radius-md);margin-bottom:var(--space-lg);
@@ -75,12 +75,19 @@ h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--spac
   font-size:12px;line-height:1.5;
 }
 .attribution p{margin:0 0 4px;}
-.cta{
+.cta-bar{
   position:fixed;left:0;right:0;bottom:0;margin:0 auto;max-width:600px;
-  padding:16px var(--space-md);padding-bottom:calc(16px + env(safe-area-inset-bottom));
-  background:var(--amber);color:var(--text-on-accent);
-  text-align:center;text-decoration:none;font-weight:600;
-  box-shadow:0 -2px 12px rgba(0,0,0,0.12);
+  display:flex;flex-direction:column;align-items:stretch;gap:var(--space-xs);
+  padding:12px var(--space-md);padding-bottom:calc(12px + env(safe-area-inset-bottom));
+  background:var(--amber);box-shadow:0 -2px 12px rgba(0,0,0,0.12);
+}
+.cta{
+  color:var(--text-on-accent);text-align:center;text-decoration:none;font-weight:600;
+  padding:4px 0;
+}
+.cta-bar .home-link{
+  color:var(--text-on-accent);text-decoration:underline;font-weight:500;
+  font-size:13px;text-align:center;margin-top:0;opacity:0.9;
 }
 .notfound{text-align:center;padding-top:var(--space-xl);}
 .notfound h1{font-size:24px;margin:0 0 var(--space-sm);}
@@ -89,4 +96,24 @@ h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--spac
   display:inline-block;margin-top:var(--space-md);
   color:var(--amber);text-decoration:none;font-weight:600;
 }
+@media (min-width:720px){
+  body{padding:var(--space-xl) var(--space-md);}
+  .page{max-width:720px;margin:0 auto;padding:0;}
+  .hero{margin-bottom:var(--space-xl);}
+  .card{padding:var(--space-lg);box-shadow:0 4px 24px rgba(0,0,0,0.06);}
+  .cta-bar{
+    position:static;flex-direction:row;justify-content:center;align-items:center;
+    gap:var(--space-lg);margin-top:var(--space-xl);max-width:none;
+    background:transparent;box-shadow:none;padding:0;
+  }
+  .cta{
+    display:inline-block;background:var(--amber);color:var(--text-on-accent);
+    padding:12px var(--space-lg);border-radius:var(--radius-md);
+  }
+  .cta-bar .home-link{
+    color:var(--amber);text-decoration:none;font-weight:600;
+    font-size:15px;opacity:1;
+  }
+}
+@media (min-width:720px) and (prefers-color-scheme:dark){.card{box-shadow:none;}}
 </style>{{end}}

--- a/api-go/internal/sharepage/templates/styles.gohtml
+++ b/api-go/internal/sharepage/templates/styles.gohtml
@@ -21,6 +21,11 @@ body{
   font-size:17px;line-height:1.4;
 }
 .page{max-width:600px;margin:0 auto;padding:var(--space-lg) var(--space-md) 128px;}
+.hero{
+  display:block;width:100%;height:auto;aspect-ratio:1200/630;
+  border-radius:var(--radius-md);margin-bottom:var(--space-lg);
+  object-fit:cover;background:var(--border);
+}
 .brand{
   display:flex;align-items:center;gap:var(--space-sm);
   margin-bottom:var(--space-lg);font-size:15px;font-weight:600;

--- a/api-go/internal/sharepage/view.go
+++ b/api-go/internal/sharepage/view.go
@@ -24,6 +24,12 @@ const (
 	shareCampaignToken = "share-page"
 	appStoreMediaType  = "8"
 
+	// homeURL is the Town Crier marketing homepage. The share page has no
+	// per-application web destination, so the always-present homepage link
+	// (Problem 3, #763) points here regardless of device or which application is
+	// being viewed.
+	homeURL = "https://towncrierapp.uk"
+
 	// ogDescriptionMaxRunes bounds the og:/twitter:description so a long proposal
 	// does not overrun a social unfurl card. Counted in runes, not bytes, so a
 	// multibyte character is never split.
@@ -48,6 +54,7 @@ type pageView struct {
 	CanonicalURL  string
 	AppleAppID    string
 	CTAHref       string
+	HomeURL       string
 
 	Ref         string
 	Address     string
@@ -95,6 +102,7 @@ func buildPageView(app applications.PlanningApplication, slug, ref string) pageV
 		CanonicalURL: canonical,
 		AppleAppID:   appleAppID,
 		CTAHref:      ctaURL(),
+		HomeURL:      homeURL,
 		Ref:          ref,
 		Address:      app.Address,
 		Description:  app.Description,

--- a/api-go/internal/sharepage/view_test.go
+++ b/api-go/internal/sharepage/view_test.go
@@ -21,6 +21,19 @@ func TestBuildPageView_OGImagePointsAtGeneratedCard(t *testing.T) {
 	}
 }
 
+// TestBuildPageView_HomeURLPointsAtTownCrierHomepage pins Problem 3 (#763,
+// tc-iuf0): the share page has no per-application web destination, so the
+// homepage link always points at the Town Crier marketing site, regardless of
+// device or the (slug, ref) being viewed.
+func TestBuildPageView_HomeURLPointsAtTownCrierHomepage(t *testing.T) {
+	t.Parallel()
+	v := buildPageView(applications.PlanningApplication{Name: "23/03456/FUL", AreaID: 165}, "croydon", "23/03456/FUL")
+	want := "https://towncrierapp.uk"
+	if v.HomeURL != want {
+		t.Errorf("HomeURL = %q, want %q", v.HomeURL, want)
+	}
+}
+
 // TestSummarise_TruncatesMultibyteRuneSafe pins the truncation branch on a
 // proposal built entirely from 3-byte CJK runes and well over the cap. A byte-wise
 // truncation would split a rune and yield U+FFFD; the rune-wise implementation


### PR DESCRIPTION
Fixes two post-launch share-page defects from #738 (spec: #763, Problems 2 & 3). Template + CSS only, no backend/image/API changes.

## Problem 2 — map hero missing in the browser (tc-9ui9)
The baked OSM map PNG was emitted only as `og:image`/`twitter:image` in `<head>`, so social unfurls showed a map but every browser showed none. Added a hero `<img src="{{.OGImage}}">` at the top of `<main>` (same cached `/og` PNG the unfurl uses) plus a `.hero` rule (full width, `aspect-ratio:1200/630`, rounded, `object-fit:cover`, alt text, `loading="eager"`). `og:image` meta unchanged; null-coords amber fallback (handled by `/og`) untouched.

## Problem 3 — poor desktop layout + no web link (tc-iuf0)
`.page` was hard-capped at 600px and the only CTA was the fixed iOS App Store bar, with no link to the web app. Made it responsive (CSS only, no UA sniffing): at ≥720px the column widens to 720px, the card is framed, and the fixed bottom bar becomes an in-flow row. Added an always-present homepage link to `https://towncrierapp.uk` ("Get Town Crier at towncrierapp.uk"). Decision per #763: homepage link, not a per-app web page (none exists). iOS App Store CTA + Smart App Banner still work on iPhone.

## Verification
- `go build`, `go test ./...` (1379 pass), `gofmt -l` clean, `go vet` clean, `-race` clean, `golangci-lint` 0 issues.
- New tests assert the hero `<img>` src (OGImage) and the `towncrierapp.uk` link are in the rendered body.
- Rendered the real templates and eyeballed in a browser at mobile + desktop widths: hero loads at correct aspect ratio at both; desktop reads as an intentional page with the CTA in-flow; homepage link resolves to `towncrierapp.uk`.

Closes tc-9ui9, tc-iuf0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Share pages now show a hero image at the top of the page.
  * The main call-to-action area has been reorganized for clearer presentation, including a visible link to the Town Crier homepage.

* **Style**
  * Updated spacing and responsive layout on share pages for better mobile and desktop display.

* **Tests**
  * Added coverage for the hero image and homepage link on share pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->