### PR TITLE
fix(ios): route inbound share Universal Links to the shared application (#763)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/UniversalLinkParser.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/UniversalLinkParser.swift
@@ -23,6 +23,19 @@ public enum UniversalLinkParser {
     return parseApplications(path)
   }
 
+  /// Convenience overload for the raw `NSUserActivity` continuation object
+  /// both SwiftUI's `.onContinueUserActivity` and the UIKit-level
+  /// `application(_:continue:restorationHandler:)` fallback receive
+  /// (tc-28x2). Guards the activity type and unwraps `webpageURL` before
+  /// delegating to ``parse(_:URL)`` — the URL-path parsing logic is not
+  /// duplicated.
+  public static func parse(_ activity: NSUserActivity) -> DeepLink? {
+    guard activity.activityType == NSUserActivityTypeBrowsingWeb,
+      let url = activity.webpageURL
+    else { return nil }
+    return parse(url)
+  }
+
   /// Parses `/a/{authoritySlug}/{ref...}`: the first segment after `/a/` is the
   /// slug, everything after it (verbatim, slashes preserved) is the ref. A bare
   /// `/a` or `/a/`, or a slug with no ref, returns `nil`. The `/a/` separator is

--- a/mobile/ios/town-crier-app/Sources/AppDelegate.swift
+++ b/mobile/ios/town-crier-app/Sources/AppDelegate.swift
@@ -2,17 +2,24 @@ import TownCrierPresentation
 import UIKit
 
 /// Hosts the UIKit lifecycle hooks SwiftUI does not surface natively —
-/// specifically the APNs registration callbacks. Forwards captured device
-/// tokens (and registration failures) to the `PushNotificationRegistrar`.
+/// the APNs registration callbacks, and (tc-28x2) a belt-and-braces
+/// fallback for inbound Universal Links. Forwards captured device tokens
+/// (and registration failures) to the `PushNotificationRegistrar`, and
+/// forwards continued browsing activities to the `AppCoordinator`.
 final class AppDelegate: NSObject, UIApplicationDelegate {
   /// Set by `TownCrierApp.init()` so the delegate can forward APNs callbacks
   /// to the registrar. Optional because `@UIApplicationDelegateAdaptor`
   /// requires a no-arg init and the registrar is built in the composition root.
   var registrar: PushNotificationRegistrar?
 
+  /// Set by `TownCrierApp.init()`, mirroring `registrar` above, so the
+  /// UIKit-level Universal Link fallback below can forward to the existing
+  /// `AppCoordinator.handleDeepLink` seam (tc-28x2).
+  var coordinator: AppCoordinator?
+
   func application(
     _ application: UIApplication,
-    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     // Re-register on every launch so the backend always has the freshest
     // token. APNs may rotate tokens between launches; `didRegister...` will
@@ -34,5 +41,41 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
     didFailToRegisterForRemoteNotificationsWithError error: Error
   ) {
     Task { await registrar?.didFailToRegister(error: error) }
+  }
+
+  /// UIKit-level Universal Link fallback (tc-28x2, GH #763 Problem 1).
+  /// SwiftUI's `.onContinueUserActivity` (TownCrierApp.swift) is the
+  /// primary handler, but was confirmed on a physical device to sometimes
+  /// not fire at all — this is the belt-and-braces second path. Apple's
+  /// docs state the system calls this method for both a warm continuation
+  /// (app already running) and a cold launch (after
+  /// `application(_:didFinishLaunchingWithOptions:)` returns), so one
+  /// implementation covers both cases. Reuses the existing
+  /// `UniversalLinkParser` / `AppCoordinator.handleDeepLink` seam — parsing
+  /// is not duplicated here.
+  ///
+  /// Deprecated by Apple in iOS 26 in favour of `UIScene`'s
+  /// `scene(_:continue:)`, but still functional and the lowest-risk
+  /// fallback given this app has no custom `UISceneDelegate` (SwiftUI owns
+  /// scene lifecycle here) — kept for the iOS 17+ deployment target.
+  ///
+  /// `@escaping` below is required even though this implementation never
+  /// calls `restorationHandler`: the closure is bridged from an
+  /// Objective-C block in the `UIApplicationDelegate` protocol requirement,
+  /// so dropping the keyword risks silently failing to satisfy that
+  /// requirement (i.e. never being called by UIKit at all).
+  func application(
+    _ application: UIApplication,
+    continue userActivity: NSUserActivity,
+    // swiftlint:disable:next unneeded_escaping
+    restorationHandler: @escaping ([any UIUserActivityRestoring]?) -> Void
+  ) -> Bool {
+    guard let deepLink = UniversalLinkParser.parse(userActivity) else { return false }
+    UniversalLinkDeliveryLogger.logDelivery(
+      source: "AppDelegate.continue:", url: userActivity.webpageURL, deepLink: deepLink)
+    Task { @MainActor [weak self] in
+      self?.coordinator?.handleDeepLink(deepLink)
+    }
+    return true
   }
 }

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -124,6 +124,9 @@ struct TownCrierApp: App {
     // callbacks (didRegisterForRemoteNotificationsWithDeviceToken /
     // didFailToRegisterForRemoteNotificationsWithError) can forward to it.
     appDelegate.registrar = registrar
+    // Mirrors the registrar wiring above: lets the AppDelegate's Universal
+    // Link fallback forward to the coordinator (tc-28x2, GH #763 Problem 1).
+    appDelegate.coordinator = appCoordinator
   }
 
   var body: some Scene {
@@ -142,12 +145,9 @@ struct TownCrierApp: App {
       .onOpenURL { url in
         AuthCallbackHandler.handle(url: url)
       }
-      .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
-        guard let url = activity.webpageURL,
-          let deepLink = UniversalLinkParser.parse(url)
-        else { return }
-        coordinator.handleDeepLink(deepLink)
-      }
+      // Inbound Universal Link entry point — see UniversalLinkModifier.swift
+      // (tc-28x2, GH #763 Problem 1).
+      .handlingUniversalLinks(coordinator: coordinator)
       // Keyed on auth state (not a bare `.task`) so profile-ensure RE-RUNS on
       // the unauthenticated->authenticated transition. On a fresh install the
       // launch-time task fires while still signed out (no token -> the

--- a/mobile/ios/town-crier-app/Sources/UniversalLinkDeliveryLogger.swift
+++ b/mobile/ios/town-crier-app/Sources/UniversalLinkDeliveryLogger.swift
@@ -1,0 +1,17 @@
+import Foundation
+import TownCrierPresentation
+import os
+
+/// TEMPORARY (tc-28x2, GH #763 Problem 1): logs which of the two inbound
+/// Universal Link delivery paths — SwiftUI's `.onContinueUserActivity`
+/// (`UniversalLinkModifier`) or the `AppDelegate` fallback — actually fires
+/// on-device. Confirms the next TestFlight build's routing; remove once
+/// confirmed.
+enum UniversalLinkDeliveryLogger {
+  private static let logger = Logger(subsystem: "uk.towncrierapp", category: "UniversalLink")
+
+  static func logDelivery(source: String, url: URL?, deepLink: DeepLink) {
+    logger.debug(
+      "UL via \(source): \(url?.absoluteString ?? "nil") -> \(String(describing: deepLink))")
+  }
+}

--- a/mobile/ios/town-crier-app/Sources/UniversalLinkDeliveryLogger.swift
+++ b/mobile/ios/town-crier-app/Sources/UniversalLinkDeliveryLogger.swift
@@ -11,7 +11,7 @@ enum UniversalLinkDeliveryLogger {
   private static let logger = Logger(subsystem: "uk.towncrierapp", category: "UniversalLink")
 
   static func logDelivery(source: String, url: URL?, deepLink: DeepLink) {
-    logger.debug(
+    logger.notice(
       "UL via \(source): \(url?.absoluteString ?? "nil") -> \(String(describing: deepLink))")
   }
 }

--- a/mobile/ios/town-crier-app/Sources/UniversalLinkModifier.swift
+++ b/mobile/ios/town-crier-app/Sources/UniversalLinkModifier.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import TownCrierPresentation
+
+extension View {
+  /// Wires SwiftUI's inbound Universal Link entry point (tc-28x2, GH #763
+  /// Problem 1): continues a browsing activity into the existing
+  /// `UniversalLinkParser` / `AppCoordinator.handleDeepLink` seam, and
+  /// ensures the activity is routed into this app's single window rather
+  /// than risking no window being considered eligible to handle it — a
+  /// documented cause of `.onContinueUserActivity` silently not firing.
+  func handlingUniversalLinks(coordinator: AppCoordinator) -> some View {
+    modifier(UniversalLinkModifier(coordinator: coordinator))
+  }
+}
+
+private struct UniversalLinkModifier: ViewModifier {
+  @ObservedObject var coordinator: AppCoordinator
+
+  func body(content: Content) -> some View {
+    content
+      .onContinueUserActivity(NSUserActivityTypeBrowsingWeb) { activity in
+        guard let url = activity.webpageURL, let deepLink = UniversalLinkParser.parse(url) else {
+          return
+        }
+        UniversalLinkDeliveryLogger.logDelivery(
+          source: "SwiftUI onContinueUserActivity", url: url, deepLink: deepLink)
+        coordinator.handleDeepLink(deepLink)
+      }
+      // `TownCrierApp` has one `WindowGroup` and no iPad multi-window
+      // support, so "prefer and allow everything" is unconditionally safe.
+      .handlesExternalEvents(preferring: Set(["*"]), allowing: Set(["*"]))
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Coordinators/UniversalLinkParserTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Coordinators/UniversalLinkParserTests.swift
@@ -134,9 +134,7 @@ struct UniversalLinkParserTests {
     #expect(result == .shareApplication(authoritySlug: "kingston", ref: "Kingston/25/02755/CLC"))
   }
 
-  @Test func parse_browsingWebActivityWithLegacyApplicationURL_returnsApplicationDetailDeepLink()
-    throws
-  {
+  @Test func parse_browsingWebActivityWithLegacyURL_returnsApplicationDetailDeepLink() throws {
     let url = try #require(URL(string: "https://towncrierapp.uk/applications/19/00123/FUL"))
     let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
     activity.webpageURL = url

--- a/mobile/ios/town-crier-tests/Sources/Coordinators/UniversalLinkParserTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Coordinators/UniversalLinkParserTests.swift
@@ -113,4 +113,55 @@ struct UniversalLinkParserTests {
 
     #expect(result == nil)
   }
+
+  // MARK: - NSUserActivity convenience overload (tc-28x2)
+  //
+  // Both SwiftUI's `.onContinueUserActivity` (TownCrierApp.swift) and the
+  // UIKit-level `application(_:continue:restorationHandler:)` fallback
+  // (AppDelegate) hand this parser a raw `NSUserActivity` rather than a
+  // bare `URL`. This overload is the single place that guards the activity
+  // type and unwraps `webpageURL` before delegating to `parse(_:URL)`, so
+  // neither call site re-implements that guard.
+
+  @Test func parse_browsingWebActivityWithShareURL_returnsShareApplicationDeepLink() throws {
+    let url = try #require(
+      URL(string: "https://share.towncrierapp.uk/a/kingston/Kingston/25/02755/CLC"))
+    let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+    activity.webpageURL = url
+
+    let result = UniversalLinkParser.parse(activity)
+
+    #expect(result == .shareApplication(authoritySlug: "kingston", ref: "Kingston/25/02755/CLC"))
+  }
+
+  @Test func parse_browsingWebActivityWithLegacyApplicationURL_returnsApplicationDetailDeepLink()
+    throws
+  {
+    let url = try #require(URL(string: "https://towncrierapp.uk/applications/19/00123/FUL"))
+    let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+    activity.webpageURL = url
+
+    let result = UniversalLinkParser.parse(activity)
+
+    #expect(
+      result == .applicationDetail(PlanningApplicationId(authority: "19", name: "00123/FUL")))
+  }
+
+  @Test func parse_activityOfWrongType_returnsNil() throws {
+    let url = try #require(URL(string: "https://share.towncrierapp.uk/a/kingston/23/03456/FUL"))
+    let activity = NSUserActivity(activityType: "uk.towncrierapp.mobile.someOtherActivity")
+    activity.webpageURL = url
+
+    let result = UniversalLinkParser.parse(activity)
+
+    #expect(result == nil)
+  }
+
+  @Test func parse_browsingWebActivityWithoutWebpageURL_returnsNil() {
+    let activity = NSUserActivity(activityType: NSUserActivityTypeBrowsingWeb)
+
+    let result = UniversalLinkParser.parse(activity)
+
+    #expect(result == nil)
+  }
 }


### PR DESCRIPTION
Fixes #763 Problem 1 (bead tc-28x2): tapping `https://share.towncrierapp.uk/a/{slug}/{ref}` on a physical device launched the app but never opened the shared application. Delivery gap, not a logic bug — the parser/route/fetch/entitlement/AASA were all verified correct and are **untouched**.

## Fix (belt-and-braces, as specced)
- **`.handlesExternalEvents(preferring:allowing:["*"])`** on the WindowGroup (via a new `handlingUniversalLinks(coordinator:)` modifier) so the incoming browsing activity is routed to the app's single scene — the documented cause of `.onContinueUserActivity` silently not firing.
- **UIKit-level fallback** in `AppDelegate.application(_:continue:restorationHandler:)`, wired to the coordinator the same way the APNs registrar is. Forwards to the existing seam; parsing not duplicated.
- **Additive** `UniversalLinkParser.parse(NSUserActivity)` overload (guards activity type + unwraps `webpageURL`, delegates to the untouched `parse(URL)`). 4 new unit tests (share URL, legacy `/applications/*`, wrong type, missing URL).
- **Temporary diagnostic logger** (`.notice`, tagged tc-28x2) on both entry points with a `source` label, so the next TestFlight build tells us on-device which path fires. To be removed once confirmed.

## Verification
- `swift build` ✓, `swift test` ✓ (1431 tests; one pre-existing unrelated flake filed as tc-wyih), `swiftlint --strict` ✓ (0 in changed files), `xcodebuild -scheme TownCrierApp` → BUILD SUCCEEDED.
- **The simulator cannot verify inbound UL routing** (documented artifact: the activity is delivered but the SwiftUI continue chain never completes for either link format). Real verification is TestFlight → physical device (cold launch, warm resume, foreground). tc-28x2 stays open until that on-device confirmation.

## Known follow-up (not in scope)
`application(_:continue:restorationHandler:)` is deprecated in iOS 26 in favour of `UIScene.scene(_:continue:)`. Kept here because the app has no custom `UISceneDelegate` (SwiftUI owns scene lifecycle); moving to a scene delegate is higher-risk and beyond this issue's ask.

Bead tc-28x2 (left in_progress — closes on on-device confirmation).