### PR TITLE
fix(offercodes): redeem guard uses EffectiveTier so lapsed grants can re-redeem (tc-jh0o)

### DIFF
--- a/api-go/internal/offercodes/handler.go
+++ b/api-go/internal/offercodes/handler.go
@@ -125,13 +125,18 @@ func (h *handler) redeem(w http.ResponseWriter, r *http.Request) {
 		h.serverError(w, r, "load profile", err)
 		return
 	}
-	if profile.Tier != profiles.TierFree {
+
+	now := h.now()
+
+	// Gate on the EFFECTIVE tier, not the raw stored one: a lapsed paid grant
+	// (Tier still Pro/Personal but SubscriptionExpiry — and any grace period —
+	// in the past) is entitled to Free, so it must be allowed to redeem a new
+	// code. Only a currently-active paid tier blocks redemption.
+	if profile.EffectiveTier(now).IsPaid() {
 		h.writeError(r, w, http.StatusConflict, "already_subscribed",
 			"User already has an active subscription; offer codes are only available to free-tier users.")
 		return
 	}
-
-	now := h.now()
 
 	// CAS retry loop: RedeemWithCAS does read→redeem-in-memory→etag-conditional
 	// replace, making the redemption atomic. On ErrCASPreconditionFailed (412 — a

--- a/api-go/internal/offercodes/handler_test.go
+++ b/api-go/internal/offercodes/handler_test.go
@@ -221,17 +221,71 @@ func TestRedeem_AlreadyRedeemed(t *testing.T) {
 	}
 }
 
+// TestRedeem_AlreadySubscribed covers a currently-active paid subscription
+// (SubscriptionExpiry strictly after now): EffectiveTier reports the raw paid
+// tier unchanged, so the guard still blocks redemption.
 func TestRedeem_AlreadySubscribed(t *testing.T) {
 	t.Parallel()
 
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
 	paid := freeProfile(t)
-	paid.ActivateSubscription(profiles.TierPersonal, time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC))
+	paid.ActivateSubscription(profiles.TierPersonal, now.AddDate(0, 6, 0)) // expiry well in the future
 
 	rec := serveRedeem(t, seededCode(t), &fakeProfileStore{profile: paid}, &fakeTierSync{},
-		time.Now(), `{"code":"ABCDEFGHJKMN"}`)
+		now, `{"code":"ABCDEFGHJKMN"}`)
 
 	if rec.Code != http.StatusConflict {
 		t.Fatalf("status = %d", rec.Code)
+	}
+	if got := rec.Body.String(); got != `{"error":"already_subscribed","message":"User already has an active subscription; offer codes are only available to free-tier users."}` {
+		t.Errorf("body = %s", got)
+	}
+}
+
+// TestRedeem_LapsedSubscriptionCanRedeem is the regression test for tc-jh0o:
+// the profile's raw Tier is still paid but SubscriptionExpiry is in the past
+// with no grace period, so EffectiveTier collapses to Free and the guard must
+// allow the redemption to proceed (and succeed).
+func TestRedeem_LapsedSubscriptionCanRedeem(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	lapsed := freeProfile(t)
+	lapsed.ActivateSubscription(profiles.TierPro, now.AddDate(0, 0, -1)) // expired yesterday, no grace period
+
+	codes := seededCode(t)
+	profile := &fakeProfileStore{profile: lapsed}
+	auth0 := &fakeTierSync{}
+
+	rec := serveRedeem(t, codes, profile, auth0, now, `{"code":"ABCDEFGHJKMN"}`)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
+	}
+	if codes.saved == nil || !codes.saved.IsRedeemed() || *codes.saved.RedeemedByUserID != "auth0|u1" {
+		t.Errorf("code not saved redeemed: %+v", codes.saved)
+	}
+	if profile.saved == nil || profile.saved.Tier != profiles.TierPro || profile.saved.SubscriptionExpiry == nil {
+		t.Errorf("profile not activated to the newly granted tier: %+v", profile.saved)
+	}
+}
+
+// TestRedeem_ActiveGracePeriodBlocksRedeem covers the App Store billing-retry
+// window: SubscriptionExpiry has passed but GracePeriodExpiry is still in the
+// future, so EffectiveTier keeps the paid tier and the guard must still block.
+func TestRedeem_ActiveGracePeriodBlocksRedeem(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+	inGrace := freeProfile(t)
+	inGrace.ActivateSubscription(profiles.TierPro, now.AddDate(0, 0, -1)) // expired yesterday
+	inGrace.EnterGracePeriod(now.AddDate(0, 0, 1))                        // grace period active until tomorrow
+
+	rec := serveRedeem(t, seededCode(t), &fakeProfileStore{profile: inGrace}, &fakeTierSync{},
+		now, `{"code":"ABCDEFGHJKMN"}`)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("status = %d body = %s", rec.Code, rec.Body.String())
 	}
 	if got := rec.Body.String(); got != `{"error":"already_subscribed","message":"User already has an active subscription; offer codes are only available to free-tier users."}` {
 		t.Errorf("body = %s", got)


### PR DESCRIPTION
## Problem
The offer-code redeem handler gated on the **raw stored `profile.Tier`**, so any user who had ever held a paid tier was permanently blocked from redeeming a new code once their grant lapsed — the redeem path returned `already_subscribed` even though every other entitlement gate treats a lapsed grant as Free.

`profiles.EffectiveTier` (profile.go L216-219) documents that **every** entitlement gate must read the effective tier, never the raw `Tier`. This guard was the one place missed when EffectiveTier landed (#608 / tc-rlja).

Confirmed in prod: `christy@salter.uk` is `tier=Pro`, `subscription_expiry=2026-06-17` (lapsed), EffectiveTier=Free, yet redeem returned `already_subscribed`.

## Why it matters
Breaks offer-code **re-issuance** — the lifecycle behind a company-benefit programme (bulk codes, users redeem a fresh code when the prior grant expires).

## Fix
Guard now reads `profile.EffectiveTier(now).IsPaid()`. Preserves the original intent — a **currently-active** paid tier (future expiry, active App Store sub, live grace period) still blocks — while allowing lapsed/free users to redeem. `now := h.now()` hoisted above the guard and reused by the CAS loop. Server-only; iOS just maps the server error code.

## Tests
- `TestRedeem_AlreadySubscribed` — active (future-expiry) paid tier → 409 (pinned to a fixed `now`).
- `TestRedeem_LapsedSubscriptionCanRedeem` — lapsed paid tier → **200, redeems** (the fix; verified red→green).
- `TestRedeem_ActiveGracePeriodBlocksRedeem` — expired but in grace → 409.
- Free-tier happy path unchanged.

Full `go test -race ./...` (1381 tests), `go vet`, `gofmt`, `golangci-lint` all green.

Closes tc-jh0o.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Redemption now follows the user’s current subscription status, so lapsed paid subscriptions can redeem offer codes again.
  * Active paid access still blocks redemption with the same “already subscribed” response, including during any grace period.

* **Tests**
  * Added coverage for redemption after subscription expiry.
  * Added coverage to confirm redemption remains blocked while grace access is still active.
  * Made the redemption timing test deterministic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->