### PR TITLE
fix(ios): route inbound Universal Links via .onOpenURL, not just .onContinueUserActivity (tc-28x2, #763)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/OpenURLRoute.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/OpenURLRoute.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// The two possible fates of a URL handed to SwiftUI's `.onOpenURL`
+/// (tc-28x2, GH #763 Problem 1, second attempt).
+///
+/// Root cause of the original bug: in a SwiftUI-lifecycle app, inbound
+/// Universal Links are delivered to `.onOpenURL`, not
+/// `.onContinueUserActivity` -- but `.onOpenURL` (TownCrierApp.swift)
+/// unconditionally handed every URL to `AuthCallbackHandler.handle`, which
+/// resumes Auth0's `WebAuthentication` and silently returns `false` for a
+/// non-auth URL. A tapped share link therefore launched the app but never
+/// reached `UniversalLinkParser`/`AppCoordinator.handleDeepLink`.
+///
+/// `resolve(_:)` is the pure decision `.onOpenURL` delegates to: try the
+/// existing, already-tested `UniversalLinkParser.parse(_:)` first; only if
+/// it returns `nil` (as it does for the Auth0 callback URL and everything
+/// else) does the URL fall through to the auth handler. Extracted into this
+/// package (rather than left inline in the app target's closure) because
+/// `town-crier-app/Sources` is not covered by `swift test` at all, and this
+/// is the only way to drive the routing decision under TDD.
+public enum OpenURLRoute: Equatable {
+  case universalLink(DeepLink)
+  case other(URL)
+
+  public static func resolve(_ url: URL) -> OpenURLRoute {
+    if let deepLink = UniversalLinkParser.parse(url) {
+      return .universalLink(deepLink)
+    }
+    return .other(url)
+  }
+}

--- a/mobile/ios/town-crier-app/Sources/OpenURLModifier.swift
+++ b/mobile/ios/town-crier-app/Sources/OpenURLModifier.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+import TownCrierData
+import TownCrierPresentation
+
+extension View {
+  /// Primary inbound entry point for both Auth0 callbacks and Universal
+  /// Links (tc-28x2, GH #763 Problem 1, second attempt). In a
+  /// SwiftUI-lifecycle app, inbound Universal Links are delivered to
+  /// `.onOpenURL`, NOT `.onContinueUserActivity` — the first attempt
+  /// (`UniversalLinkModifier`, kept as belt-and-braces) never fired
+  /// on-device because iOS never routed through that path here. `.onOpenURL`
+  /// also receives the Auth0 login/logout callback, so the URL is tried
+  /// against `OpenURLRoute.resolve` (== the already-tested
+  /// `UniversalLinkParser.parse`) first; only a non-match falls through to
+  /// `AuthCallbackHandler`.
+  func handlingOpenURL(coordinator: AppCoordinator) -> some View {
+    modifier(OpenURLModifier(coordinator: coordinator))
+  }
+}
+
+private struct OpenURLModifier: ViewModifier {
+  @ObservedObject var coordinator: AppCoordinator
+
+  func body(content: Content) -> some View {
+    content
+      .onOpenURL { url in
+        switch OpenURLRoute.resolve(url) {
+        case .universalLink(let deepLink):
+          UniversalLinkDeliveryLogger.logDelivery(
+            source: "SwiftUI onOpenURL", url: url, deepLink: deepLink)
+          coordinator.handleDeepLink(deepLink)
+        case .other(let url):
+          AuthCallbackHandler.handle(url: url)
+        }
+      }
+  }
+}

--- a/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
+++ b/mobile/ios/town-crier-app/Sources/TownCrierApp.swift
@@ -142,11 +142,10 @@ struct TownCrierApp: App {
           LoginView(viewModel: loginViewModel)
         }
       }
-      .onOpenURL { url in
-        AuthCallbackHandler.handle(url: url)
-      }
-      // Inbound Universal Link entry point — see UniversalLinkModifier.swift
-      // (tc-28x2, GH #763 Problem 1).
+      // Primary inbound UL + Auth0-callback entry point — OpenURLModifier.swift.
+      // `.handlingUniversalLinks` below is a belt-and-braces fallback —
+      // UniversalLinkModifier.swift (tc-28x2, GH #763 Problem 1).
+      .handlingOpenURL(coordinator: coordinator)
       .handlingUniversalLinks(coordinator: coordinator)
       // Keyed on auth state (not a bare `.task`) so profile-ensure RE-RUNS on
       // the unauthenticated->authenticated transition. On a fresh install the

--- a/mobile/ios/town-crier-tests/Sources/Coordinators/OpenURLRouteTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Coordinators/OpenURLRouteTests.swift
@@ -26,17 +26,20 @@ struct OpenURLRouteTests {
 
     #expect(
       result
-        == .universalLink(.shareApplication(authoritySlug: "kingston", ref: "Kingston/25/02755/CLC"))
+        == .universalLink(
+          .shareApplication(authoritySlug: "kingston", ref: "Kingston/25/02755/CLC"))
     )
   }
 
-  @Test func resolve_legacyApplicationURL_returnsUniversalLinkWithApplicationDetailDeepLink() throws {
+  @Test func resolve_legacyURL_returnsUniversalLinkWithApplicationDetailDeepLink() throws {
     let url = try #require(URL(string: "https://towncrierapp.uk/applications/19/00123/FUL"))
 
     let result = OpenURLRoute.resolve(url)
 
     #expect(
-      result == .universalLink(.applicationDetail(PlanningApplicationId(authority: "19", name: "00123/FUL"))))
+      result
+        == .universalLink(
+          .applicationDetail(PlanningApplicationId(authority: "19", name: "00123/FUL"))))
   }
 
   @Test func resolve_auth0CallbackURL_returnsOther() throws {

--- a/mobile/ios/town-crier-tests/Sources/Coordinators/OpenURLRouteTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Coordinators/OpenURLRouteTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// tc-28x2, GH #763 Problem 1 (second attempt). Root cause: in a
+/// SwiftUI-lifecycle app, inbound Universal Links are delivered to
+/// `.onOpenURL`, not `.onContinueUserActivity` -- but `.onOpenURL`
+/// (TownCrierApp.swift) unconditionally handed every URL to
+/// `AuthCallbackHandler`, silently dropping share links.
+///
+/// `OpenURLRoute.resolve` is the pure decision `.onOpenURL` now delegates
+/// to: parse the URL as a Universal Link first, otherwise treat it as an
+/// Auth0 callback. Extracted here (rather than left inline in the app
+/// target's closure) because `swift test` cannot exercise
+/// `town-crier-app/Sources` at all -- this is the only way to drive the
+/// routing decision under TDD.
+@Suite("OpenURLRoute")
+struct OpenURLRouteTests {
+  @Test func resolve_shareURL_returnsUniversalLinkWithShareApplicationDeepLink() throws {
+    let url = try #require(
+      URL(string: "https://share.towncrierapp.uk/a/kingston/Kingston/25/02755/CLC"))
+
+    let result = OpenURLRoute.resolve(url)
+
+    #expect(
+      result
+        == .universalLink(.shareApplication(authoritySlug: "kingston", ref: "Kingston/25/02755/CLC"))
+    )
+  }
+
+  @Test func resolve_legacyApplicationURL_returnsUniversalLinkWithApplicationDetailDeepLink() throws {
+    let url = try #require(URL(string: "https://towncrierapp.uk/applications/19/00123/FUL"))
+
+    let result = OpenURLRoute.resolve(url)
+
+    #expect(
+      result == .universalLink(.applicationDetail(PlanningApplicationId(authority: "19", name: "00123/FUL"))))
+  }
+
+  @Test func resolve_auth0CallbackURL_returnsOther() throws {
+    // Regression guard: an Auth0 login/logout callback must fall through to
+    // AuthCallbackHandler, never be swallowed as a Universal Link.
+    let url = try #require(
+      URL(
+        string:
+          "uk.towncrierapp.mobile://towncrierapp.uk.auth0.com/ios/uk.towncrierapp.mobile/callback"
+      ))
+
+    let result = OpenURLRoute.resolve(url)
+
+    #expect(result == .other(url))
+  }
+
+  @Test func resolve_unrecognisedURL_returnsOther() throws {
+    let url = try #require(URL(string: "https://towncrierapp.uk/foo"))
+
+    let result = OpenURLRoute.resolve(url)
+
+    #expect(result == .other(url))
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Coordinators/UniversalLinkParserTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Coordinators/UniversalLinkParserTests.swift
@@ -162,4 +162,25 @@ struct UniversalLinkParserTests {
 
     #expect(result == nil)
   }
+
+  // MARK: - Auth0 callback regression guard (tc-28x2, second attempt)
+  //
+  // `.onOpenURL` (TownCrierApp.swift) now tries `UniversalLinkParser.parse`
+  // before falling through to `AuthCallbackHandler.handle`, which resumes
+  // Auth0's `WebAuthentication`. Auth0.swift's default (non-universal-link)
+  // redirect URL is `{bundleId}://{domain}/ios/{bundleId}/callback` — this
+  // MUST NOT parse as a Universal Link, or the login/logout round-trip would
+  // be swallowed instead of reaching Auth0.
+
+  @Test func parse_auth0CallbackURL_returnsNil() throws {
+    let url = try #require(
+      URL(
+        string:
+          "uk.towncrierapp.mobile://towncrierapp.uk.auth0.com/ios/uk.towncrierapp.mobile/callback"
+      ))
+
+    let result = UniversalLinkParser.parse(url)
+
+    #expect(result == nil)
+  }
 }


### PR DESCRIPTION
Second attempt at tc-28x2 (#763 Problem 1). The first fix (v0.15.65, TestFlight 1.2.5(53)) did **not** work on a physical device — tapping a share link opened the app but never opened the detail sheet.

## Root cause (confirmed on-device)
In a SwiftUI-lifecycle app, inbound Universal Links are delivered to **`.onOpenURL`**, not `.onContinueUserActivity`. `TownCrierApp.swift`'s `.onOpenURL` unconditionally handed every URL to `AuthCallbackHandler.handle` → `WebAuthentication.resume(with:)`, which returns `false` for a non-auth URL and silently drops it. Share links never reached `UniversalLinkParser` / `handleDeepLink`. The first fix only touched the continue-paths, which iOS never used here — hence no change in behaviour.

## Fix
`.onOpenURL` now resolves the URL through a pure, testable `OpenURLRoute.resolve(_:)` that tries `UniversalLinkParser.parse` first:
- `.universalLink(deepLink)` → `coordinator.handleDeepLink` (+ temporary diagnostic log, source `SwiftUI onOpenURL`)
- `.other(url)` → `AuthCallbackHandler.handle` (unchanged auth path)

The v0.15.65 belt-and-braces paths (`.handlingUniversalLinks` continue-handler + AppDelegate fallback + temp logger) are kept.

## Login regression guard (critical)
Auth0 uses a custom-scheme callback: `uk.towncrierapp.mobile://towncrierapp.uk.auth0.com/ios/uk.towncrierapp.mobile/callback` (no `.useUniversalLink()`). Its path doesn't start with `/a/` or `/applications`, so `UniversalLinkParser.parse` returns `nil` → it falls through to the auth handler. Proven by two tests (`parse_auth0CallbackURL_returnsNil`, `resolve_auth0CallbackURL_returnsOther`). Sign-in is unaffected.

## Verification
`swift build` ✓, `swift test` 1436/1436 ✓, `swiftlint --strict` clean on changed files, `xcodebuild -scheme TownCrierApp` → **BUILD SUCCEEDED**. The simulator cannot verify inbound UL routing (documented artifact); real confirmation is TestFlight → physical device (the reason tc-28x2 stays open).

Bead tc-28x2 (left in_progress — closes on on-device confirmation).

Release-Note: Tapping a shared planning link now opens that application directly.