### PR TITLE
chore(ios): bump MARKETING_VERSION 1.2.5→1.2.6 (closed train)

### DIFF
--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -26,7 +26,7 @@ targets:
         DEVELOPMENT_TEAM: 4574VQ7N2X
         TARGETED_DEVICE_FAMILY: "1"
         INFOPLIST_GENERATION_MODE: GeneratedFile
-        MARKETING_VERSION: "1.2.5"
+        MARKETING_VERSION: "1.2.6"
         CURRENT_PROJECT_VERSION: "1"
         GENERATE_INFOPLIST_FILE: "YES"
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"


### PR DESCRIPTION
## Changes
- Bump `MARKETING_VERSION` `1.2.5` → `1.2.6` in `mobile/ios/project.yml`.

The CD iOS TestFlight run for v0.15.68 failed at upload with altool **409 Invalid Pre-Release Train** — the `1.2.5` train is closed for new build submissions (1.2.5 shipped to the App Store). The CD beta lane bumps only the build number, so the fix is a manual `MARKETING_VERSION` bump. After merge, a fresh release tag re-triggers CD iOS TestFlight onto the clean `1.2.6` train. Backend/prod unaffected.

Bead: tc-okgt.

---
*Auto-shipped via ship skill*