### PR TITLE
feat(skills): android-coding-standards skill + android-tdd-worker

### DIFF
--- a/.claude/agents/android-tdd-worker.md
+++ b/.claude/agents/android-tdd-worker.md
@@ -1,0 +1,81 @@
+---
+name: android-tdd-worker
+description: TDD implementation worker for Android/Kotlin beads. Reads the bead, follows Red-Green-Refactor, commits with conventional prefixes, and stays within mobile/android/.
+tools: Read, Write, Edit, Glob, Grep, Bash, Skill, SendMessage
+model: sonnet
+---
+
+# Android TDD Worker
+
+You implement Android beads using strict Test-Driven Development in an isolated worktree.
+
+## MANDATORY first step
+
+**You MUST invoke `/android-coding-standards` before reading, writing, or editing any Kotlin or Gradle file.** This is not optional and not a suggestion. The skill's `SKILL.md` is a slim **core** — the module dependency rule, the full forbidden list (no Hilt/Koin, no Retrofit, no Room, no mocking libraries, no Fragments/XML), and the hand-written-fake test conventions this worker is required to follow. Without it loaded, you will produce mainstream-tutorial Android code that violates project rules and the PR will be rejected.
+
+The core ends with a **"References (load on demand)"** index. The detailed rules (module/composition-root shapes, Kotlin idiom, coroutines/Flow, Compose UDF, ApiClient/DTO/DataStore patterns, fake/fixture/ViewModel-test examples, workflow & naming) live in `references/*.md`. **Before writing code that touches one of those areas, read the matching reference file** named in the index — e.g. `references/compose-ui.md` for a screen/composable bead, `references/testing.md` for a fake/fixture/test bead, `references/data-access.md` for an ApiClient/repository/DataStore bead, `references/coroutines-and-flow.md` for async work. Don't guess a rule the reference states.
+
+If you are about to call `Read`, `Write`, or `Edit` on a `.kt`, `.kts`, or `libs.versions.toml` file and have not yet invoked `/android-coding-standards` this session, STOP and invoke it first.
+
+## Setup
+
+1. **Invoke `/android-coding-standards`** — required, see above. Do this before anything else, then pull the reference file(s) the bead's area maps to (per the core's "References (load on demand)" index).
+2. `/beads:show <bead-id>` — read what needs building and why
+3. `/beads:update <bead-id> --status=in_progress`
+4. Invoke `/escalation-protocol` — learn when and how to escalate decisions
+5. Invoke `/design-language` — load cross-platform design system (colors, typography, spacing, theming) for any bead that touches UI
+6. If the bead references a GitHub issue (`GH: <url>` or `#<number>`), run `gh issue view <number>` for full context — never look for spec files in the repo. Android beads usually descend from epic #770; its child issues carry the contract details.
+
+## Scope
+
+Only modify files under `mobile/android/`. Before your final commit:
+
+```bash
+git diff --name-only HEAD $(git merge-base HEAD main) | grep -v '^mobile/android/' && echo "SCOPE VIOLATION" || echo "scope ok"
+```
+
+Out-of-scope work gets a bead comment, not code.
+
+## TDD Loop
+
+Plan your Red-Green-Refactor cycles, then for each:
+
+1. **Red** — Write a failing test. Run `cd mobile/android && ./gradlew test`. Confirm failure. Commit: `"red: <test name> (<bead-id>)"`
+2. **Green** — Minimum code to pass. Run `cd mobile/android && ./gradlew test`. Confirm pass. Commit: `"green: <test name> (<bead-id>)"`
+3. **Refactor** (optional) — Clean up, re-run tests, commit: `"refactor: <what> (<bead-id>)"`
+
+A "green build, zero tests run" is a known AGP failure mode — confirm the Red step actually *fails* before writing production code; if a new test passes or isn't executed, fix the JUnit-platform wiring first (see the skill's `references/workflow-and-naming.md`).
+
+## Pre-flight
+
+```bash
+cd mobile/android && ./gradlew ktlintFormat && ./gradlew test ktlintCheck detekt :app:assembleDevDebug
+```
+
+Commit any fixes: `"chore: pre-flight fixes (<bead-id>)"`. User-visible changes get a `Release-Note:` git trailer on the final commit (Play "what's new" is generated from trailers).
+
+## Completion
+
+- Update bead notes with a structured handoff before your last commit (see Bead Hygiene)
+- Do **not** close the bead — the orchestrator handles that
+- Do **not** push — the orchestrator handles merging
+
+## Bead Hygiene
+
+- **Commit trailer** — end every commit subject with `(<bead-id>)` (e.g. `green: decodes watch zones (tc-a1b2)`). Enables `bd doctor` orphan detection.
+- **Handoff notes** — before the pre-flight commit, overwrite the bead notes in this exact shape (for a reader with zero conversation context):
+  ```bash
+  bd update <bead-id> --notes "COMPLETED: <what's done>. IN PROGRESS: <what's mid-flight>. NEXT: <concrete next step>. BLOCKER: <none|what>. KEY DECISIONS: <why the non-obvious choices>."
+  ```
+- **Side-quest work** — if you spot unrelated broken code, tech debt, or a bug outside scope, file it and link provenance instead of fixing it:
+  ```bash
+  bd create --title="<what>" --type=<bug|task> --priority=3
+  bd dep add <new-id> <current-bead-id> --type=discovered-from
+  ```
+
+## Rules
+
+- Never skip Red — every production code is driven by a failing test
+- Stay in `mobile/android/` — escalate if bead requires out-of-scope changes
+- Escalate ambiguity via `/escalation-protocol` — don't guess
+- The stack decisions in the skill's Forbidden list are pre-resolved (epic #770) — never "upgrade" to Hilt/Retrofit/Room/MockK because a tutorial pattern seems easier

--- a/.claude/skills/android-coding-standards/SKILL.md
+++ b/.claude/skills/android-coding-standards/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: android-coding-standards
+description: "MUST consult before writing ANY Kotlin or Android code. Enforces idiomatic, modern Kotlin for the Town Crier Android app (/mobile/android): four Gradle modules (domain/data/presentation/app) with a strict dependency rule, coroutines + Flow with structured concurrency, single-activity Jetpack Compose with unidirectional data flow, manual constructor injection at a composition root (no Hilt/Koin), hand-rolled OkHttp ApiClient + kotlinx.serialization (no Retrofit), DataStore (no Room), and hand-written fakes with JUnit 5 + kotlinx-coroutines-test + Turbine (no MockK/Mockito). Trigger whenever the user asks you to write, scaffold, refactor, review, lint, or test any .kt or .kts file, Gradle build script, or version catalog under mobile/android — including ViewModels, composables, repositories, DTOs, domain entities or value classes, fakes/fixtures, coroutine/Flow code, or ktlint/detekt config. Even for a seemingly trivial Kotlin change, check this skill first — it encodes pre-resolved project decisions (epic #770) that deliberately differ from mainstream Android tutorials. Do NOT use for iOS/Swift, Go, React/web, Pulumi, GitHub Actions, or backend work."
+---
+
+# Android Coding Standards
+
+Idiomatic, modern Kotlin for the Town Crier Android app (`/mobile/android`). Write Kotlin the way JetBrains and the Android teams write it — the kotlinx libraries, the official Kotlin coding conventions, the Compose API guidelines — not Go, Swift, or C# transliterated into Kotlin. **The single overriding rule: if a pattern would look out of place in a kotlinx library or an official Compose sample, don't use it.** This repo's culture (pure domain, hand-written fakes, manual wiring, thin dependencies) is expressed Kotlin-natively: default arguments instead of builders, sealed hierarchies instead of error enums-plus-flags, `internal` instead of ceremony. The stack choices below were pre-resolved in epic #770 with rationale — apply them, don't relitigate them per bead. Read this core first; pull the matching reference when the bead touches that area.
+
+## Architecture (always applies)
+
+- **Four Gradle modules under `mobile/android/`, mirroring the iOS package split.** `:domain` = pure Kotlin/JVM — entities, value classes, repository interfaces; may import only the stdlib, `kotlinx-coroutines-core`, and `java.time`. `:data` = ApiClient over OkHttp, kotlinx.serialization DTOs, DataStore, Auth0 SDK; depends on `:domain`. `:presentation` = Compose UI, ViewModels, design system, navigation; depends on `:domain` ONLY — never `:data`. `:app` = composition root + manifest; the only module that sees everything. All versions pinned in `gradle/libs.versions.toml`.
+- **Package by feature inside each module** (`watchzones`, `applications`, `auth`), never by kind — no `models/`, `utils/`, `repositories/` packages. **Default to `internal`** in library modules; `public` is the module's deliberate API surface, not the compiler default you forgot to narrow.
+- **Rich domain models.** Behaviour lives on the type, not in ViewModels or "service" classes. `@JvmInline value class` for IDs and domain primitives; `init { require(...) }` for programmer-error invariants; smart constructors returning a sealed result for user-input validation. Repository interfaces are declared in `:domain`, implemented in `:data`, and named for what distinguishes them (`HttpWatchZoneRepository`, `InMemoryApplicationCache`) — never `Impl`.
+- **Manual constructor injection, wired once in a composition root in `:app`** — no DI framework. The graph is small, the wiring stays greppable, and a composition-root smoke test replaces framework validation.
+- **Coroutines exclusively.** `suspend` for one-shot work, `Flow` for streams; structured concurrency — every coroutine has an owning scope. Suspend functions are **main-safe**: `withContext` over an injected dispatcher at the lowest level that actually blocks; ViewModels never mention `Dispatchers`.
+- **Single-activity Jetpack Compose + Navigation Compose.** No Fragments, no XML. Unidirectional data flow: each screen is a ViewModel exposing one `StateFlow<UiState>` plus stateless composables; events travel up as lambdas; navigation decisions live in the NavHost layer, never in ViewModels. Consult the `design-language` skill for tokens, theming, and Material 3 mapping before writing any UI.
+- **Data access:** hand-rolled `ApiClient` over OkHttp; kotlinx.serialization DTOs private to `:data`, mapped explicitly to domain types; timestamps decoded per-field through the shared `DotNetTimeParser` port. Persistence is DataStore (device latches) + an in-memory TTL cache. Time comes from an injected `java.time.Clock`.
+
+## Test conventions (always applies)
+
+- **JUnit 5 on the JVM** with `kotlin.test` assertions, `kotlinx-coroutines-test` (`runTest`), and Turbine for Flow assertions. TDD Red-Green-Refactor; ViewModels, use cases, and domain rules are the primary units. **No Robolectric** — if a unit needs Android to be testable, redesign it behind an interface; real-device behaviour is verified on the emulator (mobile-mcp).
+- **Hand-written fakes only** (`FakeWatchZoneRepository`), living in the test source set beside their tests; promote to a `testFixtures` source set only when a second module needs them. State-based first (in-memory backing you assert against), with `<method>Calls` recording lists where the interaction itself is the behaviour, and a configurable failure per method. No mocking libraries.
+- **Fixtures are top-level factory functions with default arguments** (`fun aWatchZone(name: String = "Home") = …`) — Kotlin default args make builder classes redundant.
+- **Test names are backtick sentences stating behaviour** — `` fun `redeeming a lapsed grant reactivates the tier`() ``. One test file per behavioural concern. The main dispatcher is swapped via the shared JUnit 5 `MainDispatcherExtension`.
+
+## Forbidden
+
+- Hilt, Koin, Dagger, kotlin-inject, `javax.inject` (manual DI at the composition root).
+- Retrofit; Gson/Moshi (hand-rolled ApiClient; kotlinx.serialization only).
+- Room (DataStore + in-memory TTL cache is the decided persistence — verified iOS parity).
+- MockK, Mockito, any mocking library; Robolectric.
+- RxJava; `LiveData`; `AsyncTask` (coroutines + Flow).
+- Fragments, XML layouts, view/data binding, `findViewById`.
+- `!!` in production code; `lateinit var` outside framework-imposed cases.
+- `GlobalScope`; `runBlocking`; `Dispatchers.*` referenced inside ViewModels.
+- `runCatching` or blanket `catch (e: Exception)` around suspend calls (swallows `CancellationException`).
+- Exposing mutable state: `MutableStateFlow`, `MutableList`, `var` in a public API.
+- `Base*` super-classes (BaseViewModel, BaseActivity); inheritance where composition fits.
+- `Util`/`Helper`/`Manager` grab-bags; static-holder classes (Kotlin has top-level functions).
+- Builder classes for test data (default arguments instead).
+- `java.util.Date`/`Calendar`/`SimpleDateFormat` (use `java.time`); calling `Instant.now()`/`System.currentTimeMillis()` in domain logic (inject `Clock`).
+- `I` prefix on interfaces; `Impl` suffix on implementations.
+- `open` classes without a documented inheritance need (Kotlin is final by default — keep it).
+- Logging PII or secrets; any analytics/tracking SDK (the public stance is "we do not track").
+
+## References (load on demand)
+
+- `references/architecture-and-modules.md` — read when scaffolding a module or feature, wiring the composition root, modelling a domain type, or deciding visibility/placement.
+- `references/kotlin-idiom.md` — read when unsure of language-level style: null-safety, sealed hierarchies, data/value classes, scope functions, error handling, collections.
+- `references/coroutines-and-flow.md` — read when writing any async code: scopes, main-safety, dispatcher injection, StateFlow patterns, cancellation.
+- `references/compose-ui.md` — read when writing any composable, screen, UiState, or ViewModel state: UDF, state hoisting, previews, theming hookup.
+- `references/data-access.md` — read when the bead touches the ApiClient, DTOs/serialization, DataStore, caching, or a repository implementation.
+- `references/testing.md` — read when writing any test, fake, or fixture (runTest, Turbine, MainDispatcherExtension, fake/fixture conventions).
+- `references/workflow-and-naming.md` — read when running build/test/lint, bootstrapping ktlint/detekt from `assets/`, editing the version catalog, or naming anything.

--- a/.claude/skills/android-coding-standards/assets/.editorconfig
+++ b/.claude/skills/android-coding-standards/assets/.editorconfig
@@ -1,0 +1,18 @@
+# Canonical ktlint/editor config for mobile/android — owned by the
+# android-coding-standards skill. Copy to mobile/android/.editorconfig and keep
+# the two files identical (the skill asset is the source of truth).
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{kt,kts}]
+ktlint_code_style = ktlint_official
+max_line_length = 120
+# Composables are PascalCase by design; exempt them from function-naming.
+ktlint_function_naming_ignore_when_annotated_with = Composable

--- a/.claude/skills/android-coding-standards/assets/detekt.yml
+++ b/.claude/skills/android-coding-standards/assets/detekt.yml
@@ -1,0 +1,89 @@
+# Canonical detekt config for mobile/android — owned by the android-coding-standards
+# skill. Copy to mobile/android/detekt.yml and apply with buildUponDefaultConfig = true,
+# so this file holds ONLY deliberate deviations from the detekt defaults.
+#
+# Philosophy (mirrors the Go skill's .golangci.yml): bug-catching rules on,
+# style-opinion rules off — ktlint owns formatting (.editorconfig).
+#
+# NOTE: rules marked "requires type resolution" only run under the type-resolving
+# Gradle tasks (detektMain/detektTest on JVM modules, detekt<Variant> on Android
+# modules) — the plain `detekt` task silently skips them. CI must run both.
+
+coroutines:
+  GlobalCoroutineUsage:
+    active: true
+  SuspendFunSwallowedCancellation:
+    active: true # requires type resolution
+  SuspendFunWithFlowReturnType:
+    active: true # requires type resolution
+
+exceptions:
+  # Both default-active; pinned here because they enforce the skill's
+  # cancellation-safety rule (no blanket catches around suspend code).
+  TooGenericExceptionCaught:
+    active: true
+  SwallowedException:
+    active: true
+
+naming:
+  FunctionNaming:
+    ignoreAnnotated: ['Composable'] # composables are PascalCase by design
+
+complexity:
+  LongParameterList:
+    ignoreAnnotated: ['Composable'] # state-hoisted screens legitimately take many params
+
+style:
+  UnusedPrivateMember:
+    ignoreAnnotated: ['Preview', 'PreviewLightDark'] # private preview functions are the convention
+  MagicNumber:
+    active: false # style opinion; noisy in UI code, ktlint/review catch real cases
+  ReturnCount:
+    active: false # early returns are idiomatic Kotlin
+  MaxLineLength:
+    active: false # ktlint owns line length (120, .editorconfig)
+  ForbiddenImport:
+    active: true
+    imports:
+      - value: 'io.mockk.*'
+        reason: 'No mocking libraries — hand-written fakes (android-coding-standards).'
+      - value: 'org.mockito.*'
+        reason: 'No mocking libraries — hand-written fakes (android-coding-standards).'
+      - value: 'org.robolectric.*'
+        reason: 'No Robolectric — JVM units behind interfaces; emulator for real-device flows.'
+      - value: 'retrofit2.*'
+        reason: 'Hand-rolled ApiClient over OkHttp (epic #770 pre-resolved decision).'
+      - value: 'androidx.room.*'
+        reason: 'No Room — DataStore + in-memory TTL cache (epic #770).'
+      - value: 'io.reactivex.*'
+        reason: 'Coroutines + Flow, not RxJava.'
+      - value: 'androidx.lifecycle.LiveData'
+        reason: 'StateFlow, not LiveData.'
+      - value: 'androidx.lifecycle.MutableLiveData'
+        reason: 'StateFlow, not LiveData.'
+      - value: 'androidx.fragment.*'
+        reason: 'Single-activity Compose — no Fragments.'
+      - value: 'android.os.AsyncTask'
+        reason: 'Coroutines, not AsyncTask.'
+      - value: 'kotlinx.coroutines.GlobalScope'
+        reason: 'Structured concurrency — every coroutine has an owning scope.'
+      - value: 'kotlinx.coroutines.runBlocking'
+        reason: 'Never block a thread on coroutines; tests use runTest.'
+      - value: 'com.google.gson.*'
+        reason: 'kotlinx.serialization only.'
+      - value: 'com.squareup.moshi.*'
+        reason: 'kotlinx.serialization only.'
+      - value: 'java.util.Date'
+        reason: 'java.time only.'
+      - value: 'java.util.Calendar'
+        reason: 'java.time only.'
+      - value: 'java.text.SimpleDateFormat'
+        reason: 'java.time.format.DateTimeFormatter only.'
+      - value: 'javax.inject.*'
+        reason: 'Manual constructor injection at the composition root — no DI framework.'
+      - value: 'dagger.*'
+        reason: 'Manual constructor injection at the composition root — no DI framework.'
+      - value: 'org.koin.*'
+        reason: 'Manual constructor injection at the composition root — no DI framework.'
+      - value: 'me.tatarka.inject.*'
+        reason: 'Manual constructor injection at the composition root — no DI framework.'

--- a/.claude/skills/android-coding-standards/references/architecture-and-modules.md
+++ b/.claude/skills/android-coding-standards/references/architecture-and-modules.md
@@ -1,0 +1,126 @@
+# Architecture & Modules (reference)
+
+Read when scaffolding a module or feature, wiring the composition root, modelling a domain type, or deciding visibility/placement. The core (`SKILL.md`) states the rules; this file is the rationale and the worked shapes.
+
+## Module graph
+
+```
+mobile/android/
+├── settings.gradle.kts, gradle/libs.versions.toml   # version catalog, everything pinned
+├── domain/          # pure Kotlin/JVM (`kotlin("jvm")`) — zero Android dependencies
+├── data/            # Android library — ApiClient, DTOs, DataStore, Auth0
+├── presentation/    # Android library — Compose UI, ViewModels, design system, navigation
+└── app/             # Android application — composition root, manifest, flavors
+```
+
+Allowed dependencies (anything not listed is a review flag):
+
+| Module | May depend on |
+|---|---|
+| `:domain` | Kotlin stdlib, `kotlinx-coroutines-core`, `java.time` — nothing else. No `android.*`, no `androidx.*`, no serialization, no HTTP. |
+| `:data` | `:domain`, OkHttp, kotlinx.serialization, DataStore, Auth0 SDK |
+| `:presentation` | `:domain`, Compose/Material 3, `androidx.lifecycle` (ViewModel), Navigation Compose, maps-compose. **Never `:data`.** |
+| `:app` | everything — it is the only module that may see the whole graph |
+
+Why `:domain` is a plain `kotlin("jvm")` module and not an Android library: the compiler enforces purity for free (no `android.*` on the classpath at all), and its tests run as fast JVM tests with no Android toolchain in the loop. Repository interfaces live here and use `suspend`/`Flow` in their signatures — that is why `kotlinx-coroutines-core` is a permitted domain dependency; it is a language-level concurrency vocabulary, not a framework. `java.time` is safe everywhere because minSdk is 26 (epic #770) — no core-library desugaring needed.
+
+Turn on `kotlin { explicitApi() }` for `:domain` and `:data` — it makes an unmarked-public declaration a compile error, which is the mechanical enforcement of the `internal`-by-default rule. `:presentation` skips it (explicit-API mode fights Compose ergonomics); there, `internal` stays a review discipline.
+
+## Package-by-feature
+
+Inside each module, slice by feature, not by kind:
+
+```
+domain/src/main/kotlin/uk/towncrierapp/domain/
+├── watchzones/      # WatchZone, Radius, WatchZoneRepository, quota rules
+├── applications/    # PlanningApplication, ApplicationStatus, browsing ports
+├── subscriptions/   # Tier, EntitlementMap, tier max-merge
+└── auth/            # Session, SessionStore port
+```
+
+A feature package owns its entities, its ports, and its rules. Promote a type to a shared package only when a *second* feature genuinely needs it — not pre-emptively.
+
+**Visibility:** Kotlin's default is `public`, which is the wrong default for a library module. Declare `internal` unless the type is deliberately part of the module's API (domain entities and ports are; DTOs, parsers, and cache internals are not). `internal` is the Kotlin-native encapsulation tool — use it instead of directory conventions or naming ceremony.
+
+## Domain modelling
+
+Behaviour on the type; two distinct validation channels:
+
+```kotlin
+// Typed primitives: value classes, zero runtime cost.
+@JvmInline
+value class WatchZoneId(val value: String)
+
+// Value classes carry invariants too. Programmer-error invariant: fail fast
+// and loudly — a caller passing 0 is a bug, not an outcome to model.
+@JvmInline
+value class Radius(val metres: Int) {
+    init {
+        require(metres in 1..MAX_METRES) { "radius must be 1..$MAX_METRES m, was $metres" }
+    }
+
+    companion object {
+        const val MAX_METRES = 10_000
+    }
+}
+
+// Expected outcome the caller must handle: a sealed result, not an exception.
+sealed interface PostcodeLookup {
+    data class Found(val coordinate: Coordinate, val displayName: String) : PostcodeLookup
+    data object NotFound : PostcodeLookup
+}
+
+// Rich entity: the rule lives here, not in a ViewModel.
+data class WatchZone(
+    val id: WatchZoneId,
+    val name: String,
+    val centre: Coordinate,
+    val radius: Radius,
+) {
+    fun withRadiusCappedFor(tier: Tier): WatchZone =
+        copy(radius = Radius(minOf(radius.metres, tier.maxRadiusMetres)))
+}
+```
+
+The distinction matters: `require`/`check` (→ `IllegalArgumentException`/`IllegalStateException`) are for conditions that indicate a bug and should crash a debug build; sealed hierarchies are for outcomes that are part of the feature's contract (invalid postcode, quota exceeded, insufficient entitlement) and must be handled exhaustively by the caller.
+
+## Composition root
+
+`:app` hand-wires the graph top-to-bottom in one place — a plain class, constructed once in `Application.onCreate`. The Android-touching leaves come in **through the constructor** (as their domain interfaces), so the container itself stays a pure-JVM type:
+
+```kotlin
+class AppContainer(
+    baseUrl: String,                        // BuildConfig.API_BASE_URL
+    sessionStore: SessionStore,             // Auth0SessionStore(context) in prod
+    latchStore: DeviceLatchStore,           // DataStore-backed in prod
+    private val clock: Clock = Clock.systemUTC(),
+    callFactory: Call.Factory = OkHttpClient.Builder().build(),
+) {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val apiClient = ApiClient(baseUrl, callFactory, json, sessionStore)
+
+    val watchZoneRepository: WatchZoneRepository = HttpWatchZoneRepository(apiClient)
+    val applicationRepository: ApplicationRepository = OfflineAwareApplicationRepository(
+        remote = HttpApplicationRepository(apiClient),
+        cache = InMemoryApplicationCache(clock),
+    )
+    // …one val per port the UI layer consumes
+}
+```
+
+ViewModels get their dependencies through plain constructors; the NavHost supplies them with the `viewModel(factory = …)` overload (`viewModelFactory { initializer { … } }`) reading from the container. No service locator, no `@EnvironmentObject`-style ambient graph — if a screen's dependency list gets long, that is design feedback, not a reason for a framework.
+
+**Composition-root smoke test:** because the Android leaves are constructor parameters, a plain JVM test can construct the entire graph — `AppContainer("https://api.example.test", FakeSessionStore(), FakeDeviceLatchStore())` — and touch every exposed `val`, so wiring drift fails in `./gradlew test`, not on first launch. This is the replacement for a DI framework's graph validation — keep it green.
+
+## Where things go — quick placement table
+
+| Thing | Module | Notes |
+|---|---|---|
+| Entity, value class, sealed outcome | `:domain` | behaviour on the type |
+| Repository interface (port) | `:domain` | consumer vocabulary, domain types only |
+| Sealed `ApiException` hierarchy | `:domain` | thrown by `:data`, caught by `:presentation` — only `:domain` is visible to both |
+| Repository implementation | `:data` | named `Http*`/`DataStore*`/`InMemory*`, `internal` where possible |
+| DTO + mapper | `:data` | `internal`; domain never sees a DTO |
+| ViewModel, UiState, composable | `:presentation` | depends on `:domain` ports only |
+| Design system component | `:presentation` | see `design-language` skill |
+| Wiring, flavors, manifest, FCM service | `:app` | the only all-seeing module |

--- a/.claude/skills/android-coding-standards/references/compose-ui.md
+++ b/.claude/skills/android-coding-standards/references/compose-ui.md
@@ -1,0 +1,112 @@
+# Compose UI (reference)
+
+Read when writing any composable, screen, UiState, or ViewModel-to-UI wiring. Follow the official Compose API guidelines; the shapes below are how they land in this codebase. For every visual decision — colors, type, spacing, components — consult the `design-language` skill first; this file covers structure, not styling.
+
+## The screen pattern: Route + Screen
+
+Every destination splits into a thin stateful *Route* and a stateless, previewable *Screen*:
+
+```kotlin
+@Composable
+fun WatchZonesRoute(
+    viewModel: WatchZonesViewModel,
+    onZoneSelected: (WatchZoneId) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    WatchZonesScreen(
+        state = state,
+        onZoneSelected = onZoneSelected,
+        onDeleteZone = viewModel::deleteZone,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun WatchZonesScreen(
+    state: WatchZonesUiState,
+    onZoneSelected: (WatchZoneId) -> Unit,
+    onDeleteZone: (WatchZoneId) -> Unit,
+    modifier: Modifier = Modifier,
+) { /* pure function of state */ }
+```
+
+- State flows down as immutable parameters; events flow up as lambdas. The Screen knows nothing about ViewModels, navigation, or repositories — which is exactly what makes it previewable and reusable.
+- Navigation lambdas (`onZoneSelected`) are supplied by the NavHost in the navigation layer. **ViewModels never navigate** — same division of labour as the iOS Coordinators, expressed the Compose-native way.
+- `collectAsStateWithLifecycle()` (not `collectAsState()`) so collection stops when the UI is backgrounded.
+
+## Routes and screen arguments
+
+Destinations are **type-safe routes** — `@Serializable` objects/classes (Navigation 2.8+), which dovetails with the kotlinx.serialization dependency the data layer already mandates. No hand-rolled `"zoneDetail/{id}"` route strings, no manual argument parsing:
+
+```kotlin
+@Serializable data object WatchZones
+@Serializable data class ZoneDetail(val zoneId: String)
+
+// In the NavHost (navigation layer; the composition root supplies `container`):
+composable<ZoneDetail> { backStackEntry ->
+    val route = backStackEntry.toRoute<ZoneDetail>()
+    ZoneDetailRoute(
+        viewModel = viewModel(factory = viewModelFactory {
+            initializer { ZoneDetailViewModel(container.watchZoneRepository, WatchZoneId(route.zoneId)) }
+        }),
+        onBack = navController::popBackStack,
+    )
+}
+```
+
+A detail ViewModel takes its subject's ID as a plain constructor parameter, read from the route in the initializer — no `SavedStateHandle` ceremony needed for nav arguments with this wiring. Reach for `createSavedStateHandle()` inside an `initializer` only for state that must survive **process death** beyond what the route already encodes; UiState itself is reloadable (server + cache), and in-progress text input is `rememberSaveable`'s job.
+
+## UiState modelling
+
+One immutable `UiState` type per screen, exposed as a single `StateFlow`:
+
+- **Flat data class** when aspects overlap (showing data *while* refreshing, error banner *over* content): `data class WatchZonesUiState(val zones: List<WatchZone> = emptyList(), val isLoading: Boolean = false, val error: UiError? = null)`.
+- **Sealed interface** when states are mutually exclusive by design (force-update gate: `Checking` / `UpToDate` / `MustUpdate`). Exhaustive `when` in the Screen then renders each.
+- Fields hold what the Screen renders: domain values directly where they render as-is (a `List<WatchZone>` is fine), a small presentation item type where formatting is logic (dates, distances — the shared formatters run in the ViewModel/mapper, not in composables). No `MutableState`, no lambdas, no ViewModel references inside a UiState.
+- **User-facing text is a resource, not a hardcoded string.** UiState carries either a `@StringRes` id or a tiny sealed `UiText` (resource-backed vs server-supplied dynamic text) that the Screen resolves via `stringResource`. ViewModels and domain code never bake in English copy — the copy-to-outcome mapping shown in `kotlin-idiom.md` belongs in the presentation layer, keyed off the sealed outcome.
+
+## Composable API rules (the ones that get violated)
+
+- PascalCase noun names (`StatusBadge`, not `renderStatusBadge`); a composable either **emits UI or returns a value, never both**.
+- `modifier: Modifier = Modifier` is the **first optional parameter** of every public composable that emits UI, and it is applied exactly once, to the root layout. Accepting no modifier makes a component un-composable into new layouts; applying it twice duplicates padding/click areas.
+- Parameter order: required data first, then `modifier: Modifier = Modifier` leading the optionals, then the remaining optional params, then trailing content lambdas (slot APIs). Variable content is a `@Composable () -> Unit` slot, not a boolean-and-string parameter explosion.
+- Hoist state: components take `value` + `onValueChange`, they don't own state internally. `remember` internal state only for genuinely internal, throwaway UI mechanics (e.g. ripple, scroll positions via `rememberLazyListState`).
+- `remember(key)` and `LaunchedEffect(key)` keys must include everything the computation reads — a stale-key bug is a stale-UI bug. `rememberSaveable` for anything that must survive process death (text input drafts).
+- Lazy lists always set stable `key = { it.id.value }` — without keys, deletion animations and scroll anchoring silently break.
+
+## Theming
+
+- Everything renders inside `TownCrierTheme(mode)`, which maps the Town Crier tokens onto a Material 3 `ColorScheme` and exposes extended tokens (status colors, amberMuted, overlay) via a `CompositionLocal`. Feature code reads `MaterialTheme.colorScheme.*` and `TownCrierTheme.colors.*` — **never a raw hex, never a hardcoded dp for a token that exists**. Token values, the M3 role mapping, and the 4-way appearance mode live in the `design-language` skill and epic #770.
+- Dynamic color is off by design; don't wire `dynamicColorScheme`.
+
+## Previews
+
+Every significant Screen and design-system component gets previews rendering realistic sample data, in at least light + dark. Preview data lives as `private val`/functions in the preview's own file (main source set) — it *cannot* reuse the test fixtures, because previews can't see test or `testFixtures` source sets; keep preview samples small and accept the duplication rather than contorting the build for sharing:
+
+```kotlin
+@Preview(name = "light")
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun WatchZonesScreenPreview() {
+    TownCrierTheme {
+        WatchZonesScreen(
+            state = WatchZonesUiState(zones = listOf(previewZone)),
+            onZoneSelected = {},
+            onDeleteZone = {},
+        )
+    }
+}
+
+private val previewZone = WatchZone(WatchZoneId("wz-1"), "Home", Coordinate(51.5074, -0.1278), Radius(500))
+```
+
+Previews are the fastest feedback loop this codebase has (no emulator round-trip) — treat a Screen without previews as unfinished. Verification of real behaviour (navigation, permissions, deep links) happens on the emulator via mobile-mcp; Compose instrumentation tests are not part of the day-1 loop.
+
+## Performance notes (worry in this order)
+
+1. Correct state reads: read state as late/deep as possible so recomposition scopes stay small.
+2. Immutable parameters: data classes of `val`s and read-only collections. With the current Compose compiler (strong skipping, default since Kotlin 2.0.20) skippability comes from instance equality, so `List` fields are fine; don't chase `@Stable`/`@Immutable` annotations or `kotlinx-collections-immutable` until a measured problem exists.
+3. `derivedStateOf` only when deriving cheaper-changing state from something that changes often (scroll position → "show scroll-to-top affordance" boolean class of problem).
+
+Premature recomposition golf is a smell; broken-by-design state (mutable lists in state, missing keys) is the actual failure mode to prevent.

--- a/.claude/skills/android-coding-standards/references/coroutines-and-flow.md
+++ b/.claude/skills/android-coding-standards/references/coroutines-and-flow.md
@@ -1,0 +1,77 @@
+# Coroutines & Flow (reference)
+
+Read when writing any async code. Coroutines are the concurrency model of this codebase — exclusively. The discipline that matters is *structured* concurrency: every coroutine has an owning scope whose lifecycle bounds it, so nothing leaks, and cancellation composes for free.
+
+## Scopes and ownership
+
+- ViewModels launch in `viewModelScope` — cancelled automatically when the screen's state holder dies.
+- Repositories and data sources **do not launch coroutines**. They expose `suspend` functions and `Flow`s; the caller owns concurrency. A `launch` inside a repository is a fire-and-forget leak wearing a disguise.
+- `GlobalScope` and `runBlocking` are banned outright (detekt enforces). The rare process-lifetime work (e.g. the FCM token refresh callback) gets an explicit, named, injected `CoroutineScope` created at the composition root — ownership is still explicit.
+- Parallel decomposition uses `coroutineScope { }` + `async`: if one child fails, siblings cancel and the failure propagates. Use `supervisorScope` only when children are genuinely independent and you handle each failure inline.
+
+## `suspend` vs `Flow`
+
+- One value, on demand → `suspend fun`. Do not wrap a single value in a `Flow` to look reactive; a flow of exactly one emission is a suspend function with extra steps.
+- A stream that changes over time (DataStore preference, cache invalidation ticks, UI state) → `Flow`/`StateFlow`.
+- Cold flows in the data layer; hot state (`StateFlow`) only where something owns state — practically, ViewModels.
+
+## Main-safety and dispatcher injection
+
+Convention: **every `suspend` function is safe to call from the main thread.** Whoever does blocking work moves itself off the main thread with `withContext`, at the lowest level that actually blocks:
+
+```kotlin
+internal class JsonBodyReader(
+    private val json: Json,
+    private val io: CoroutineDispatcher, // wired to Dispatchers.IO at the composition root
+) {
+    suspend fun <T> read(body: ResponseBody, serializer: KSerializer<T>): T =
+        withContext(io) { json.decodeFromString(serializer, body.string()) } // body.string() blocks
+}
+```
+
+Two important non-cargo-cult notes:
+
+- The OkHttp bridge (`Call.enqueue` via `suspendCancellableCoroutine`, see `data-access.md`) is already non-blocking — wrapping it in `withContext(Dispatchers.IO)` adds a thread hop and nothing else. DataStore is main-safe too. Add `withContext` where something *actually blocks* (large JSON decode, file IO), not as decoration.
+- When a class does need a dispatcher, it takes `CoroutineDispatcher` as a constructor parameter, wired at the composition root. **ViewModels never reference `Dispatchers`** — they call main-safe suspend functions and stay dispatcher-agnostic, which is also what makes them trivially testable.
+
+## ViewModel state: `StateFlow`, privately mutable
+
+```kotlin
+class WatchZonesViewModel(
+    private val repository: WatchZoneRepository,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(WatchZonesUiState())
+    val uiState: StateFlow<WatchZonesUiState> = _uiState.asStateFlow()
+
+    fun refresh() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            try {
+                val zones = repository.zones()
+                _uiState.update { it.copy(isLoading = false, zones = zones, error = null) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: ApiException) {
+                _uiState.update { it.copy(isLoading = false, error = e.toUiError()) }
+            }
+        }
+    }
+}
+```
+
+- Backing property `_uiState` private and mutable; the exposed `uiState` is read-only via `asStateFlow()`.
+- Mutate with `update { it.copy(…) }` — atomic, and it keeps state transitions expressed as value transformations.
+- Deriving state from an upstream flow? `flow.map { … }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), initialValue)` — the 5-second grace keeps state alive across rotation without running when nothing watches.
+
+## Cancellation is sacred
+
+Cancellation propagates as `CancellationException` through suspend calls. Anything that catches broadly will eat it and leave a zombie coroutine "running" after its scope died. The rules:
+
+- Catch **specific** exception types. A specific catch (like the `ApiException` one above) can't swallow cancellation; the `catch (e: CancellationException) { throw e }` line is a defensive convention kept uniform so the guarantee survives someone later broadening the catch. Where a broad `catch (e: Exception)` is truly unavoidable at a boundary, that rethrow line stops being convention and becomes load-bearing.
+- Never `runCatching` around suspend code (it catches everything, including cancellation).
+- Long CPU loops (rare here) call `ensureActive()` or use `yield()` to stay cooperative.
+
+## One-shot effects
+
+Prefer modelling "effects" as state the UI reconciles (a `snackbarMessage: UiMessage?` field, cleared by an `onMessageShown()` event) over `SharedFlow` event buses — state survives recomposition, process death handling, and observer gaps; fired-and-forgotten events don't. Navigation is not an effect at all: it's a lambda passed down from the NavHost (`compose-ui.md`).

--- a/.claude/skills/android-coding-standards/references/data-access.md
+++ b/.claude/skills/android-coding-standards/references/data-access.md
@@ -1,0 +1,64 @@
+# Data Access (reference)
+
+Read when the bead touches the ApiClient, DTOs/serialization, DataStore, caching, or a repository implementation. The wire contract itself (endpoints, error shapes, pagination, retry policy) is specced in epic #770 and its child issues — this file covers *how* that contract is expressed in Kotlin.
+
+## The ApiClient: hand-rolled, one seam
+
+There is no Retrofit. The `ApiClient` in `:data` is a plain class over OkHttp that owns, in one visible place: base URL + standard headers, bearer-token attachment, the single 401-refresh-retry, `X-Next-Cursor` pagination, and 403 entitlement sniffing. The decision is deliberate (#770): this behaviour must be explicit and steppable, not scattered across annotations and a reflective proxy.
+
+- The seam is OkHttp's own `Call.Factory` — production passes the real `OkHttpClient`; transport-level tests substitute a fake that returns canned `Response`s. Don't invent a bespoke transport interface when OkHttp already ships the right one.
+- OkHttp also ships `Interceptor` and `Authenticator`, and using an `Interceptor` for the static headers is fine. The **401-refresh-retry stays explicit in `ApiClient`**, though — a deliberate deviation from the `Authenticator` idiom, because the retry-once policy mirrors the iOS `URLSessionAPIClient` line-for-line and must stay visible and steppable. Don't "fix" it into an `Authenticator`.
+- Bridge OkHttp's callback API to coroutines once, with cancellation wired through. (If the pinned OkHttp version ships the official `okhttp-coroutines` artifact, prefer its `Call.executeAsync()` — it is exactly this bridge, maintained upstream.)
+
+```kotlin
+internal suspend fun Call.await(): Response = suspendCancellableCoroutine { cont ->
+    enqueue(object : Callback {
+        override fun onResponse(call: Call, response: Response) =
+            // The onCancellation lambda closes the response if the coroutine was
+            // cancelled between enqueue completing and resumption — without it,
+            // that race leaks the connection.
+            cont.resume(response) { _, resp, _ -> resp.close() }
+
+        override fun onFailure(call: Call, e: IOException) = cont.resumeWithException(e)
+    })
+    cont.invokeOnCancellation { cancel() }
+}
+```
+
+The cancellation wiring is the point: when the owning scope dies (user leaves the screen), the HTTP call is torn down and nothing leaks. This bridge is already non-blocking — no `withContext(Dispatchers.IO)` around it.
+
+- Transport failures surface as a small sealed hierarchy the ViewModel layer can `catch` specifically — e.g. `ApiException.Unauthorized`, `ApiException.InsufficientEntitlement(required: Tier)` (drives paywall routing), `ApiException.NotFound`, `ApiException.Network(cause)`. Type the failure once; everything above stays exhaustive. **The sealed `ApiException` hierarchy is declared in `:domain`** (plain Kotlin, and it references domain types like `Tier`) — `:data` throws it, `:presentation` catches it; that's the only way the module dependency rule allows all three to see it.
+
+## DTOs and kotlinx.serialization
+
+- DTOs are `@Serializable`, `internal` to `:data`, named `*Dto`, and shaped exactly like the wire — the domain never sees one. Each DTO file carries its explicit mapper: `internal fun WatchZoneDto.toDomain(): WatchZone`. Mapping is where wire-shape weirdness (PascalCase legacy error bodies, explicit nulls) is absorbed.
+- One shared `Json` instance from the composition root: `Json { ignoreUnknownKeys = true }`. Server adding a field must never crash a shipped client.
+- **Dates cross the wire as `String`** and are parsed per-field by the shared `DotNetTimeParser` port inside the mappers — never a global serializer date strategy, which would mask the backend's fractional-seconds-only-when-non-zero behaviour. Date-only fields (`startDate`, `decidedDate`) are bare `yyyy-MM-dd` → `LocalDate`. There is exactly ONE parser; do not let a feature hand-roll its own (iOS made that mistake once — don't port it).
+- Error bodies come in two shapes (PascalCase backfill and lowercase handler-written) — parse defensively for both inside the ApiClient; the sealed `ApiException` is the single normalised output.
+
+## Repositories
+
+- Interface in `:domain`, speaking domain types (`WatchZone`, `Cursor`, sealed outcomes). Implementation in `:data`, `internal` where wiring allows, named for what distinguishes it (`HttpWatchZoneRepository`).
+- Repository functions are main-safe `suspend` functions; they do not launch coroutines and do not cache unless caching *is* the type's job:
+
+```kotlin
+internal class OfflineAwareApplicationRepository(
+    private val remote: ApplicationRepository,
+    private val cache: InMemoryApplicationCache,
+) : ApplicationRepository {
+    override suspend fun detail(id: ApplicationId): PlanningApplication =
+        try {
+            remote.detail(id).also(cache::put)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: ApiException.Network) {
+            cache.get(id) ?: throw e   // stale-if-offline, matching iOS semantics
+        }
+}
+```
+
+## Local persistence: DataStore + in-memory cache (no Room)
+
+- Persistent state is deliberately tiny (iOS-parity, verified): the device latches — onboarding-complete, review-prompt state, cached tier, appearance mode (`appearanceMode` key, same string values as iOS). Each lives behind a small domain port (`OnboardingStateStore`), implemented in `:data` over **Preferences DataStore**. Keys are declared in one place per store; reads are `Flow`-shaped (`data.map { it[KEY] }`), writes are `suspend`.
+- The in-memory TTL cache is a plain class with an injected `Clock` (TTL 900 s, paged reads bypass — semantics per #770). Injected `Clock` is what makes expiry testable without sleeping.
+- If a bead seems to need more persistence than this, stop and flag it — "add Room" is an architecture change, not an implementation detail.

--- a/.claude/skills/android-coding-standards/references/kotlin-idiom.md
+++ b/.claude/skills/android-coding-standards/references/kotlin-idiom.md
@@ -1,0 +1,87 @@
+# Kotlin Idiom (reference)
+
+Read when unsure of language-level style. The test for every construct: would this look at home in a kotlinx library? Kotlin read by a Kotlin engineer should feel expression-oriented, immutable-first, and honest about absence and failure — without being clever for its own sake.
+
+## Immutability first
+
+- `val` everywhere; a `var` is a design statement that something genuinely changes, and it should be `private` when it does.
+- Public APIs speak read-only types: `List`, `Map`, `Set` — never `MutableList` in a signature. Inside a function, `buildList { }`/`buildMap { }` beat declare-then-mutate.
+- Evolve values with `data class` + `copy`, not setters: `zone.copy(name = trimmed)`.
+
+## Null-safety, honestly
+
+- `T?` is the model for absence — use it, and let the compiler force handling via `?.`, `?:`, and smart casts.
+- `!!` is banned in production code. If you "know" it's non-null, encode that knowledge: `requireNotNull(x) { "why it can't be null" }` at the boundary where the guarantee is established, then pass the non-null type onwards.
+- `lateinit var` only where a framework imposes two-phase init (rare in this codebase — Compose + constructor injection removes almost every case).
+- Java interop (OkHttp, Android SDK) returns platform types — pin them to an explicit Kotlin type at the boundary so nullability is decided once, deliberately.
+
+## Sealed hierarchies and exhaustive `when`
+
+Closed sets are sealed interfaces (or enums when there's no payload), consumed with an exhaustive `when` and **no `else` branch** — adding a case must break every consumer at compile time:
+
+```kotlin
+sealed interface RedeemOutcome {
+    data class Redeemed(val tier: Tier, val expiresAt: Instant) : RedeemOutcome
+    data object AlreadyRedeemed : RedeemOutcome
+    data object Expired : RedeemOutcome
+    data class Rejected(val reason: String) : RedeemOutcome
+}
+
+// Presentation layer (user-facing copy is its job — see compose-ui.md on UiText/resources):
+val message: UiText = when (outcome) {
+    is RedeemOutcome.Redeemed -> UiText.Res(R.string.redeem_success, outcome.tier.displayName)
+    RedeemOutcome.AlreadyRedeemed -> UiText.Res(R.string.redeem_already_used)
+    RedeemOutcome.Expired -> UiText.Res(R.string.redeem_expired)
+    is RedeemOutcome.Rejected -> UiText.Dynamic(outcome.reason)
+}
+```
+
+Note `when` used as an expression — prefer that over statement-plus-mutation.
+
+## Expression-oriented style
+
+- A cheap, pure, non-throwing, parameterless computation is a **property**, not a function: `val displayName get() = "$name (${radius.metres} m)"`. A parameterless `fun displayName()` is a Java/C# habit — reserve functions for work (side effects, I/O, non-trivial cost, can fail).
+- Single-expression syntax (`fun cappedTo(tier: Tier) = copy(radius = …)`) when the body is genuinely one expression that fits on a line or two — don't contort a multi-step body to earn the `=`.
+- `if`/`when`/`try` are expressions; use them to initialise a `val` instead of declaring-then-assigning.
+- Prefer stdlib collection transforms (`map`, `filter`, `firstOrNull`, `groupBy`, `partition`, `sumOf`) while the chain still reads top-to-bottom as a sentence. The moment a chain needs a comment to explain a step, name the step with a local `val` or drop to a plain loop. Reach for `asSequence()` only on large inputs or long chains — it's an optimisation, not a style.
+
+## Scope functions — sparingly, one deep
+
+| Function | The one job it's for |
+|---|---|
+| `let` | transform a nullable: `id?.let(::findZone)` |
+| `apply` | configure an object you're constructing: `Json { … }`, builders from Java APIs |
+| `also` | side-effect in a chain (logging) without breaking it |
+| `run`/`with` | grouping several calls on one receiver — fine, same one-deep rule |
+
+Never nest scope functions; never chain two on the same line. If `it` becomes ambiguous or you're renaming lambda parameters to keep track, use a local `val`. Scope-function soup is the most common way generated Kotlin outs itself as non-native.
+
+## Named and default arguments
+
+Default arguments + named call sites replace both the builder pattern and telescoping overload ladders:
+
+```kotlin
+fun paged(cursor: Cursor? = null, pageSize: PageSize = PageSize.DEFAULT): Page
+// call site: paged(pageSize = PageSize(50))
+```
+
+When a call passes two or more literals of the same type, name them. One public function with defaults beats three overloads.
+
+## Extension functions
+
+- Use them to give types you don't own a domain vocabulary (`Instant.toDisplayDate()`), or to keep a helper next to its single consumer as a `private` extension.
+- They live in the feature package of their consumer — **never** in a `utils`/`Extensions.kt` dumping ground. A public extension on a stdlib/platform type is API: it needs the same justification as any public function.
+- Kotlin has top-level functions and properties; there is no reason for a class whose name ends in `Util`, `Helper`, or `Manager` to exist.
+
+## Errors: two channels, never blurred
+
+1. **Bugs and broken infrastructure → exceptions.** `require`/`check` for contract violations; typed exceptions (e.g. a sealed `ApiException` hierarchy) thrown by the data layer for transport-level failure. Catch them **specifically**, at the layer that can act (usually the ViewModel), and always let `CancellationException` fly — see `coroutines-and-flow.md`.
+2. **Expected domain outcomes → sealed results** returned, not thrown (`RedeemOutcome`, `PostcodeLookup`). The caller is forced by `when`-exhaustiveness to handle every case; nothing is handleable-but-forgettable.
+
+Do not use `kotlin.Result` in public signatures and do not wrap suspend calls in `runCatching` — both erase the error type, and `runCatching` also swallows coroutine cancellation. Model the outcome or throw the typed exception; never return `null` to mean "it failed".
+
+## Objects, companions, constants
+
+- Constants: `const val` at top level or in a `companion object` — near their user, UPPER_SNAKE_CASE.
+- `object` is for genuinely stateless singletons (a parser, a `Comparator`); an `object` holding mutable state is a hidden global — inject a class instead.
+- Prefer top-level factory functions to companion factories unless the factory needs private access to the constructor (the smart-constructor pattern).

--- a/.claude/skills/android-coding-standards/references/testing.md
+++ b/.claude/skills/android-coding-standards/references/testing.md
@@ -1,0 +1,110 @@
+# Testing (reference)
+
+Read when writing any test, fake, or fixture. TDD Red-Green-Refactor: the test exists before the implementation, fails for the right reason, then passes. ViewModels, use cases, and domain rules are the primary units; everything they need is reachable through constructor-injected interfaces, which is why no mocking library is needed — or allowed.
+
+## The stack
+
+| Concern | Tool |
+|---|---|
+| Runner | JUnit 5 (Jupiter) on the JVM. `:domain` (`kotlin("jvm")`) just sets `useJUnitPlatform()`. **AGP modules do not run Jupiter tests by default** — without `testOptions { unitTests.all { it.useJUnitPlatform() } }` in the module's build script, the build goes green with zero tests executed. That wiring is mandatory in every Android module with tests. |
+| Assertions | `kotlin.test` (`assertEquals`, `assertIs<T>`, `assertFailsWith`) — first-party, no DSL |
+| Coroutines | `kotlinx-coroutines-test`: `runTest`, `TestDispatcher`s |
+| Flow assertions | Turbine (`flow.test { awaitItem() … }`) |
+| Android framework | **Nothing.** No Robolectric, no instrumentation in the unit loop. If a type can't be tested without Android, put the Android bit behind a domain interface and fake it. Real-device flows are verified on the emulator via mobile-mcp. |
+
+Test names are backtick sentences describing behaviour, from the caller's point of view:
+
+```kotlin
+@Test
+fun `redeeming a lapsed grant reactivates the tier`() = runTest { … }
+```
+
+Keep suites small and cut by behavioural concern — either one file per concern (`WatchZonesViewModelRefreshTest`) or one file per subject with JUnit 5 `@Nested inner class Refresh { … }` groupings; both are acceptable, an 800-line flat test class is not.
+
+## Fakes: hand-written, state-based first
+
+A fake implements the domain port with a real (in-memory) behaviour, so most assertions read from **state**, not interactions:
+
+```kotlin
+class FakeWatchZoneRepository : WatchZoneRepository {
+    val stored = mutableListOf<WatchZone>()
+    var failWith: ApiException? = null
+
+    val deleteCalls = mutableListOf<WatchZoneId>()
+
+    override suspend fun zones(): List<WatchZone> {
+        failWith?.let { throw it }
+        return stored.toList()
+    }
+
+    override suspend fun delete(id: WatchZoneId) {
+        failWith?.let { throw it }
+        deleteCalls += id
+        stored.removeAll { it.id == id }
+    }
+}
+```
+
+- Assert on outcomes (`assertEquals(emptyList(), fake.stored)`) wherever possible; keep `<method>Calls` recording lists only for interactions that *are* the behaviour under test (e.g. "does not call delete when confirmation is dismissed").
+- `failWith` (or per-method variants) makes failure paths one line to arrange. Throwing the real sealed `ApiException` types keeps error-path tests honest.
+- Fakes live in the test source set beside their tests. When a second module needs the same fake (presentation tests faking a domain port), promote it to `:domain`'s `testFixtures` source set via the `java-test-fixtures` plugin — the Gradle-native way to share test code without a "testutils" module. (That plugin is JVM-only; if an *Android* module ever needs to export fixtures, that's AGP's `android.testFixtures.enable` — rare here, since shared ports live in `:domain`.)
+
+## Fixtures: factory functions with default arguments
+
+```kotlin
+fun aWatchZone(
+    id: WatchZoneId = WatchZoneId("wz-1"),
+    name: String = "Home",
+    centre: Coordinate = Coordinate(51.5074, -0.1278),
+    radius: Radius = Radius(500),
+) = WatchZone(id, name, centre, radius)
+```
+
+Each test names only what it cares about: `aWatchZone(radius = Radius(5_000))`. This is the Kotlin-native replacement for builder classes and static fixture catalogues — do not write a `WatchZoneBuilder`. Fixtures follow the same placement rule as fakes (beside tests; `testFixtures` when shared), and previews reuse them.
+
+## Testing ViewModels
+
+ViewModels use `viewModelScope`, which targets `Dispatchers.Main` — swapped in tests by the shared JUnit 5 extension:
+
+```kotlin
+class MainDispatcherExtension : BeforeEachCallback, AfterEachCallback {
+    override fun beforeEach(context: ExtensionContext) =
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+
+    override fun afterEach(context: ExtensionContext) = Dispatchers.resetMain()
+}
+```
+
+`UnconfinedTestDispatcher` executes eagerly, which suits state-machine tests (act, then assert the settled state) — but the eagerness trades away ordering fidelity: intermediate states are overwritten before anything can observe them, and launch-ordering bugs stay invisible. Any test asserting *intermediate* states or ordering must switch to `StandardTestDispatcher` + `advanceUntilIdle()` locally.
+
+```kotlin
+@ExtendWith(MainDispatcherExtension::class)
+class WatchZonesViewModelRefreshTest {
+
+    @Test
+    fun `refresh replaces zones and clears a previous error`() = runTest {
+        val repository = FakeWatchZoneRepository().apply { zones += aWatchZone() }
+        val viewModel = WatchZonesViewModel(repository)
+
+        viewModel.refresh()
+
+        val state = viewModel.uiState.value
+        assertEquals(listOf(aWatchZone()), state.zones)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `refresh failure surfaces a retryable error and keeps stale zones`() = runTest {
+        val repository = FakeWatchZoneRepository().apply { failWith = ApiException.Network(IOException()) }
+        …
+    }
+}
+```
+
+Use Turbine when the *sequence* of emissions is the contract (loading → loaded), `uiState.value` when only the settled state matters — asserting intermediate states everywhere makes tests brittle against harmless refactors. Caveat for sequence tests: `StateFlow` **conflates** — under the eager Unconfined main dispatcher the `isLoading = true` emission is typically overwritten before any collector sees it. Observing a loading→loaded sequence needs `StandardTestDispatcher`, collection started (via Turbine) *before* the act, and stepping the scheduler; if an intermediate state still gets conflated away, assert the settled state instead of fighting the conflation.
+
+## What not to test
+
+- Compose layout/rendering — previews + emulator verification carry that; there is no unit-level substitute worth its maintenance cost day-1.
+- The Android SDK, OkHttp, or kotlinx.serialization themselves — test *your* mappers, parsers, and policies (`DotNetTimeParser` round-trips, error-envelope normalisation, TTL expiry with a fixed `Clock`).
+- Trivial data classes and delegation-only code. A test that cannot fail for a real reason is noise.

--- a/.claude/skills/android-coding-standards/references/workflow-and-naming.md
+++ b/.claude/skills/android-coding-standards/references/workflow-and-naming.md
@@ -1,0 +1,54 @@
+# Workflow & Naming (reference)
+
+Read when running build/test/lint, bootstrapping ktlint/detekt, editing the version catalog, or naming anything.
+
+## Commands (run from `mobile/android/`)
+
+```bash
+./gradlew test                       # All JVM unit tests, every module
+./gradlew ktlintFormat               # Auto-format (run before committing)
+./gradlew ktlintCheck detekt         # Lint + static analysis — CI-blocking, zero findings
+./gradlew :app:assembleDevDebug      # Debug build, dev flavor (emulator work)
+./gradlew :app:assembleProdRelease   # Release build, prod flavor
+```
+
+Two Gradle wirings the lint/test loop silently depends on:
+
+- **JUnit 5 in Android modules.** AGP doesn't run Jupiter tests natively — every Android module with tests needs `testOptions { unitTests.all { it.useJUnitPlatform() } }` (`:domain`, being `kotlin("jvm")`, just calls `useJUnitPlatform()`). Missing wiring = green build, zero tests run.
+- **Type-resolving detekt.** The plain `detekt` task skips type-resolution rules (the coroutines-safety ones in `detekt.yml` marked as such). The full gate also runs `detektMain`/`detektTest` on JVM modules and the `detekt<Variant>` tasks on Android modules.
+
+The pre-commit gate for any Android bead: `ktlintFormat`, then `test ktlintCheck detekt :app:assembleDevDebug` all green. CI runs the same four via the `android-lint` / `android-build-test` PR-gate jobs — a local pass should make CI boring. User-visible changes get a `Release-Note:` git trailer (the Play "what's new" is generated from trailers, same as TestFlight).
+
+## Lint configs are skill assets
+
+The canonical configs live in this skill and are copied into the project (same pattern as the Go skill's `.golangci.yml`):
+
+- `assets/.editorconfig` → `mobile/android/.editorconfig` — ktlint (`ktlint_official` code style, 120 cols, Compose function-naming carve-out).
+- `assets/detekt.yml` → `mobile/android/detekt.yml` — applied with `buildUponDefaultConfig = true`, so the file holds only deliberate deviations. Philosophy matches `.golangci.yml`: bug-catching rules on (coroutines misuse, swallowed exceptions, forbidden imports enforcing the skill's bans), style-opinion rules off (ktlint owns formatting).
+
+If a rule fires on genuinely correct code, prefer restructuring the code; a `@Suppress` needs a justifying comment and should be rare enough to stand out in review. Ratcheting a rule off happens in the skill's asset (with the reasoning), never ad-hoc per module — the asset is the source of truth and the project copy must not drift.
+
+## Gradle discipline
+
+- **Everything through the version catalog** (`gradle/libs.versions.toml`); exact versions pinned — no dynamic versions (`+`), no ranges. The Compose BOM is pinned like any other entry; ktlint/detekt plugin + CLI versions pinned (ruleset drift broke SwiftLint once — tc-6kdu; don't repeat it on Android).
+- Build logic stays boring: Kotlin DSL, no custom plugins until at least two modules repeat the same block, no `buildSrc` speculation.
+- `kotlin { explicitApi() }` on `:domain` and `:data` — mechanical enforcement of `internal`-by-default (see `architecture-and-modules.md`).
+- New dependencies are an architectural decision, not a convenience — the Forbidden list in `SKILL.md` bans the usual suspects; anything else new warrants a line in the PR body saying why.
+
+## Naming
+
+| Thing | Convention | Example |
+|---|---|---|
+| Gradle modules | lowercase | `:domain`, `:data`, `:presentation`, `:app` |
+| Packages | `uk.towncrierapp.<module>.<feature>`, lowercase, no underscores | `uk.towncrierapp.domain.watchzones` |
+| Classes/interfaces | PascalCase; interfaces get the plain domain name, no `I` prefix | `WatchZoneRepository` |
+| Implementations | named by what distinguishes them — never `Impl` | `HttpWatchZoneRepository`, `InMemoryApplicationCache`, `DataStoreOnboardingStateStore` |
+| Composables | PascalCase noun (what it *is*, not what it does) | `StatusBadge`, `WatchZonesScreen` |
+| Functions/properties | camelCase; no `get` prefix on Kotlin properties | `val effectiveTier`, `fun redeem(code)` |
+| Constants | UPPER_SNAKE_CASE `const val`, top-level or companion | `MAX_METRES` |
+| Backing property | leading underscore, private | `_uiState` / `uiState` |
+| Fakes | `Fake` + port name; call-recording lists `<method>Calls` | `FakeWatchZoneRepository`, `deleteCalls` |
+| Fixture factories | indefinite article + type | `aWatchZone()`, `aPlanningApplication()` |
+| Test classes / names | `<Subject><Concern>Test`; backtick behaviour sentences | `WatchZonesViewModelRefreshTest` |
+| DTOs | wire name + `Dto`, `internal` to `:data` | `WatchZoneDto` |
+| Files | one primary type per file, named after it; small sealed families may share the parent's file | `WatchZone.kt` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,12 +140,13 @@ When a bead targets a given tech stack, use the matching skill and worker agent.
 |---------------------|------------------|---------------------------|------------------------|
 | Go                  | `/api-go`, `/cli` | `go-coding-standards`    | `go-tdd-worker`        |
 | iOS / Swift         | `/mobile/ios`    | `ios-coding-standards`    | `ios-tdd-worker`       |
+| Android / Kotlin    | `/mobile/android`| `android-coding-standards`| `android-tdd-worker`   |
 | Web / React / TS    | `/web`           | `react-coding-standards`  | `react-tdd-worker`     |
 | Pulumi infra (Go)   | `/infra`         | `go-coding-standards`     | `pulumi-infra-worker`  |
 | GitHub Actions      | `.github/`       | —                         | `github-actions-worker`|
 | UI (any platform)   | UI code in any of the above | `design-language` (in addition to the platform skill) | — |
 
-Consult the skill before writing, reviewing, or scaffolding code for that stack. Standard lint configs ship as skill assets (`.golangci.yml` under `go-coding-standards`, `.swiftlint.yml` under `ios-coding-standards`).
+Consult the skill before writing, reviewing, or scaffolding code for that stack. Standard lint configs ship as skill assets (`.golangci.yml` under `go-coding-standards`, `.swiftlint.yml` under `ios-coding-standards`, `.editorconfig` + `detekt.yml` under `android-coding-standards`).
 
 ### Worker model policy
 


### PR DESCRIPTION
## Changes

- New `android-coding-standards` skill ahead of the Android epic (#770): ~800-word always-loaded core (module dependency rule, test conventions, forbidden list) + seven on-demand references (architecture/modules, Kotlin idiom, coroutines/Flow, Compose UI, data access, testing, workflow/naming).
- Written as idiomatic principal-engineer Kotlin — not Go/Swift/C# transliterated — while honouring the epic's pre-resolved stack (manual DI, no Retrofit/Room, hand-written fakes, JUnit 5 + coroutines-test + Turbine, ktlint + detekt).
- Canonical lint configs as skill assets (`.editorconfig` with the Compose function-naming carve-out; `detekt.yml` with Compose carve-outs, coroutine-safety rules, and ForbiddenImport entries enforcing the skill's bans) — #771 bootstraps these into `mobile/android/`.
- New `android-tdd-worker` agent mirroring the iOS/Go TDD workers (Sonnet-first, Red-Green-Refactor, `mobile/android/` scope guard, AGP zero-tests-run pitfall called out).
- CLAUDE.md: Android row in the coding-standards routing table + lint-assets note.

Bead: tc-1gdt

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfGE8V9LFuURSQueUMC7NJ