### PR TITLE
docs: agent-run UI verification + fastlane beta lane in CLAUDE.md (tc-e4lr)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,8 @@ When looking up user data or entity information, query our own Postgres database
 
 ## Release Process
 
+**The iOS beta lane is fastlane.** `cd-ios-testflight` runs `xcodegen generate` then `bundle exec fastlane beta` (`mobile/ios/fastlane/Fastfile`, signing via match). The `.xcodeproj` is generated output — edit `mobile/ios/project.yml`, never the project file.
+
 iOS patch releases keep tripping on the same two snags — bake the checks in:
 
 - **The version train can close.** After an App Store release, the `MARKETING_VERSION` train closes and the next TestFlight upload fails with an altool **409**. The CD beta lane bumps the *build* number, never `MARKETING_VERSION`. On a 409 — or pre-emptively when the last release shipped to the App Store — bump `MARKETING_VERSION` in `mobile/ios/project.yml` and re-release.
@@ -97,6 +99,15 @@ When diagnosing issues, ask the user for the data source or context before explo
 ## Testing & CI
 
 When fixing CI failures, always check for ALL root causes before declaring the fix complete. Run the full test suite and verify end-to-end, not just the first failure.
+
+## UI Verification — Agent-Run, No Human in the Loop
+
+Front-end changes are verified by the agent itself, live, before the work is declared done:
+
+- **Web** — the `agent-browser` CLI drives a real browser (screenshot paths must be absolute).
+- **iOS / Android** — the `mobile-mcp` MCP server drives the iOS simulator and the Android emulator (AVD `towncrier` on the dev machine): install, launch, tap, type, screenshot.
+
+Never ask the human to click through a UI to confirm a change; drive it yourself and attach screenshots.
 
 ## Development Commands
 


### PR DESCRIPTION
## Changes
- Add **UI Verification — Agent-Run** section: frontend changes are validated by the agent itself — `agent-browser` for web, `mobile-mcp` for the iOS simulator and Android emulator (AVD `towncrier`) — never by asking the human to click through.
- Document the iOS release mechanism in **Release Process**: `cd-ios-testflight` runs `xcodegen generate` then `bundle exec fastlane beta`; the `.xcodeproj` is generated output — edit `project.yml`, never the project file.

Recipes stay one hop away in skills and auto-memory; CLAUDE.md gets only the always-loaded pointer layer.

---
*Auto-shipped via ship skill*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A5aLD4BpBscCT6ikFFtxnL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified iOS beta release steps, including the automated testflight flow and signing process.
  * Added updated guidance for UI verification across web and mobile, including required screenshot handling and fully agent-driven validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->