### PR TITLE
feat(seo): link planning pages to per-application share pages

### DIFF
--- a/web/scripts/lib/__tests__/constants.test.mjs
+++ b/web/scripts/lib/__tests__/constants.test.mjs
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { SHARE_ORIGIN, shareUrl } from '../constants.mjs';
+
+describe('shareUrl', () => {
+  it('builds the canonical /a/{slug}/{ref} share URL', () => {
+    expect(shareUrl('croydon', '23/03456/FUL')).toBe(
+      `${SHARE_ORIGIN}/a/croydon/23/03456/FUL`,
+    );
+  });
+
+  it('keeps ref slashes as path separators but encodes other unsafe characters', () => {
+    // A space and an ampersand are percent-encoded; the slashes are preserved.
+    expect(shareUrl('cornwall', 'PA/2026/00123 A&B')).toBe(
+      `${SHARE_ORIGIN}/a/cornwall/PA/2026/00123%20A%26B`,
+    );
+    // A '?' or '#' in a ref must be encoded so it cannot truncate the path.
+    expect(shareUrl('cornwall', 'PA?2026#1')).toBe(
+      `${SHARE_ORIGIN}/a/cornwall/PA%3F2026%231`,
+    );
+  });
+
+  it('returns null when the slug or ref is missing, so callers can omit the link', () => {
+    expect(shareUrl('', '23/03456/FUL')).toBeNull();
+    expect(shareUrl('croydon', '')).toBeNull();
+    expect(shareUrl(undefined, undefined)).toBeNull();
+  });
+});

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -103,6 +103,18 @@ describe('renderPlanningPage', () => {
     expect(html).toContain('https://planit.org.uk/planapplic/26-0001-FUL');
   });
 
+  it('links each application to its share page using the authority slug and ref', () => {
+    const html = renderPlanningPage(pageData());
+    // app.name (26/0001/FUL) is the share ref; slashes are kept as separators.
+    expect(html).toContain(
+      '<a class="appLink" href="https://share.towncrierapp.uk/a/basingstoke-and-deane/26/0001/FUL">View on Town Crier</a>',
+    );
+    // The share page is the item URL in the ItemList structured data too.
+    expect(html).toContain(
+      '"url":"https://share.towncrierapp.uk/a/basingstoke-and-deane/26/0001/FUL"',
+    );
+  });
+
   it('orders the visible Last updated dates to match the lastDifferent DESC sort', () => {
     const html = renderPlanningPage(pageData());
     expect(html).toContain('Last updated 12 Jun 2026');

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -6,9 +6,13 @@ import {
 } from '../render-shared.mjs';
 import { ATTRIBUTION_LINES } from '../constants.mjs';
 
+const SHARE_CAPTION = 'View on Town Crier';
 const PLANIT_CAPTION = 'View full record on PlanIt';
 const COUNCIL_CAPTION = 'View on the council website';
 
+const SLUG = 'basingstoke-and-deane';
+// The share ref is the app's `name` (planit_name), NOT its uid; slashes are kept.
+const SHARE_HREF = `https://share.towncrierapp.uk/a/${SLUG}/26/0001/FUL`;
 const PLANIT_HREF = 'https://planit.org.uk/planapplic/26-0001-FUL';
 const COUNCIL_HREF = 'https://www.basingstoke.gov.uk/planning/26-0001-FUL';
 
@@ -86,7 +90,7 @@ describe('renderApplicationsList per-application links', () => {
     expect(html).not.toContain(COUNCIL_CAPTION);
   });
 
-  it('keeps the link safety attributes on each anchor', () => {
+  it('keeps the link safety attributes on the external anchors', () => {
     const html = renderApplicationsList([application()]);
     const anchors = html.match(/<a class="appLink"[^>]*>/g) ?? [];
     expect(anchors).toHaveLength(2);
@@ -94,6 +98,48 @@ describe('renderApplicationsList per-application links', () => {
       expect(anchor).toContain('rel="nofollow noopener"');
       expect(anchor).toContain('target="_blank"');
     }
+  });
+});
+
+describe('renderApplicationsList share links', () => {
+  it('leads each card with a share link built from the slug and the app ref', () => {
+    const html = renderApplicationsList([application()], SLUG);
+    // The share URL uses the app.name (planit_name) verbatim, slashes preserved.
+    expect(captionForHref(html, SHARE_HREF)).toBe(SHARE_CAPTION);
+    // It is the FIRST link on the card, before the PlanIt/council links.
+    expect(html.indexOf(SHARE_HREF)).toBeLessThan(html.indexOf(PLANIT_HREF));
+  });
+
+  it('makes the share link do-follow and same-tab (an internal Town Crier page)', () => {
+    const html = renderApplicationsList([application()], SLUG);
+    const anchor = html.match(
+      new RegExp(`<a class="appLink" href="${SHARE_HREF.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}"[^>]*>`),
+    );
+    expect(anchor).not.toBeNull();
+    expect(anchor[0]).not.toContain('nofollow');
+    expect(anchor[0]).not.toContain('target="_blank"');
+  });
+
+  it('percent-encodes unsafe ref characters per segment while preserving slashes', () => {
+    const html = renderApplicationsList(
+      [application({ name: 'DC/2026/0001 A&B' })],
+      SLUG,
+    );
+    expect(html).toContain(
+      `https://share.towncrierapp.uk/a/${SLUG}/DC/2026/0001%20A%26B`,
+    );
+  });
+
+  it('omits the share link when no slug is supplied', () => {
+    const html = renderApplicationsList([application()]);
+    expect(html).not.toContain(SHARE_CAPTION);
+    expect(html).not.toContain('share.towncrierapp.uk');
+  });
+
+  it('omits the share link when the app carries no ref', () => {
+    const html = renderApplicationsList([application({ name: '' })], SLUG);
+    expect(html).not.toContain(SHARE_CAPTION);
+    expect(html).not.toContain('share.towncrierapp.uk');
   });
 });
 

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -109,6 +109,18 @@ describe('renderTownPage', () => {
     expect(html).toContain('https://planit.org.uk/planapplic/CW-26-0001');
   });
 
+  it('links each application to its share page using the parent authority slug and ref', () => {
+    const html = renderTownPage(townData());
+    // Town-page apps are scoped to the town's own authority, so authoritySlug is
+    // correct for every card.
+    expect(html).toContain(
+      '<a class="appLink" href="https://share.towncrierapp.uk/a/cornwall/26/0001">View on Town Crier</a>',
+    );
+    expect(html).toContain(
+      '"url":"https://share.towncrierapp.uk/a/cornwall/26/0001"',
+    );
+  });
+
   it('orders the visible Last updated dates to match the lastDifferent DESC sort', () => {
     const html = renderTownPage(townData());
     expect(html).toContain('Last updated 12 Jun 2026');

--- a/web/scripts/lib/constants.mjs
+++ b/web/scripts/lib/constants.mjs
@@ -6,6 +6,40 @@
 export const SITE_ORIGIN = 'https://towncrierapp.uk';
 
 /**
+ * Canonical origin for the public per-application share pages
+ * (`/a/{authoritySlug}/{ref}`). Mirrors the iOS `ShareURL.origin`
+ * (`mobile/ios/.../Sharing/ShareURL.swift`) and the API `shareOrigin`
+ * (`api-go/internal/sharepage/view.go`) — the three MUST stay in lockstep.
+ * @type {string}
+ */
+export const SHARE_ORIGIN = 'https://share.towncrierapp.uk';
+
+/**
+ * Build the canonical share URL for one planning application:
+ * `https://share.towncrierapp.uk/a/{authoritySlug}/{ref}`.
+ *
+ * `ref` is the application's PlanIt `name` (the `planit_name` column, exposed as
+ * `name` on the SEO snapshot) — the exact key the share page looks up by. It can
+ * contain slashes (e.g. `Kingston/25/02755/CLC`), which are kept as path
+ * separators; every other segment is percent-encoded. This mirrors the iOS
+ * `ShareURL.build` behaviour (`.urlPathAllowed`, which keeps `/`). The slug is
+ * already URL-safe (lowercase-hyphenated `Slugify` output), so it is used
+ * verbatim. Returns `null` when either component is empty, so a caller can omit
+ * the link rather than emit a broken one.
+ *
+ * @param {string} authoritySlug
+ * @param {string} ref
+ * @returns {string | null}
+ */
+export function shareUrl(authoritySlug, ref) {
+  if (!authoritySlug || !ref) {
+    return null;
+  }
+  const encodedRef = ref.split('/').map(encodeURIComponent).join('/');
+  return `${SHARE_ORIGIN}/a/${authoritySlug}/${encodedRef}`;
+}
+
+/**
  * Public App Store listing for the iOS app. Mirrors `src/config/links.ts`
  * (`APP_DOWNLOAD_URL`) — kept in lockstep by the drift-guard test in
  * `src/__tests__/planning-cta-link.test.ts`, because this build-time `.mjs`

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -1,4 +1,4 @@
-import { SITE_ORIGIN, APPLE_APP_ID, appStoreUrl } from './constants.mjs';
+import { SITE_ORIGIN, APPLE_APP_ID, appStoreUrl, shareUrl } from './constants.mjs';
 import { escapeHtml, leadLine } from './format.mjs';
 import { townPagePath } from './town-path.mjs';
 import {
@@ -77,7 +77,9 @@ function buildJsonLd(data, canonical) {
       '@type': 'ListItem',
       position: i + 1,
       name: [app.name, app.address].filter(Boolean).join(' — '),
-      url: app.url || app.link || canonical,
+      // Prefer our own share page (the application's canonical Town Crier page)
+      // as the item URL; fall back to the council/PlanIt record, then the page.
+      url: shareUrl(data.slug, app.name) || app.url || app.link || canonical,
     })),
   };
   const dataset = {
@@ -116,7 +118,7 @@ export function renderPlanningPage(data) {
   const jsonLd = buildJsonLd(data, canonical);
   const year = new Date().getFullYear();
 
-  const applicationsList = renderApplicationsList(data.applications);
+  const applicationsList = renderApplicationsList(data.applications, data.slug);
   const townLinks = renderTownLinks(data);
   const attribution = renderAttributionList();
 

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -9,7 +9,7 @@
  * passed through `escapeHtml` before interpolation.
  */
 
-import { ATTRIBUTION_LINES } from './constants.mjs';
+import { ATTRIBUTION_LINES, shareUrl } from './constants.mjs';
 import {
   escapeHtml,
   truncate,
@@ -21,7 +21,7 @@ import {
 /**
  * @typedef {Object} PlanningApplicationItem
  * @property {string} uid
- * @property {string} name
+ * @property {string} name                   PlanIt `planit_name`; the share page's lookup key (the share-URL ref)
  * @property {string} address
  * @property {string} description
  * @property {string | null} appState
@@ -54,9 +54,14 @@ function statusModifier(appState) {
 
 /**
  * @param {PlanningApplicationItem} app
+ * @param {string} [authoritySlug] the page's authority slug; when present (and the
+ *   app carries a ref), the card leads with a do-follow link to our own public
+ *   share page for the application. Every application on a page belongs to this
+ *   one authority (authority pages read one partition; town pages scope the near
+ *   query to a single authority), so the slug is correct for every card.
  * @returns {string}
  */
-function renderApplication(app) {
+function renderApplication(app, authoritySlug) {
   const label = escapeHtml(statusDisplayLabel(app.appState));
   const modifier = statusModifier(app.appState);
   // The visible date is lastDifferent (the bounded read's DESC sort key), so the
@@ -65,6 +70,15 @@ function renderApplication(app) {
   const description = escapeHtml(truncate(app.description, MAX_DESCRIPTION_LENGTH));
 
   const links = [];
+  // Our own share page leads the list. Unlike the external PlanIt/council links,
+  // it is deliberately do-follow and same-tab: it is an internal Town Crier page,
+  // so we WANT search engines to crawl it and keep residents in-funnel.
+  const share = shareUrl(authoritySlug, app.name);
+  if (share) {
+    links.push(
+      `<a class="appLink" href="${escapeHtml(share)}">View on Town Crier</a>`,
+    );
+  }
   if (app.link) {
     links.push(
       `<a class="appLink" href="${escapeHtml(app.link)}" rel="nofollow noopener" target="_blank">View full record on PlanIt</a>`,
@@ -94,10 +108,13 @@ function renderApplication(app) {
  * Render the recent-applications list body (the `<li>` cards joined by newlines).
  *
  * @param {PlanningApplicationItem[]} applications
+ * @param {string} [authoritySlug] the page's authority slug, threaded through so
+ *   each card can link to its share page. Omitted -> no share links (the external
+ *   PlanIt/council links still render).
  * @returns {string}
  */
-export function renderApplicationsList(applications) {
-  return applications.map(renderApplication).join('\n');
+export function renderApplicationsList(applications, authoritySlug) {
+  return applications.map((app) => renderApplication(app, authoritySlug)).join('\n');
 }
 
 /**

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -17,6 +17,7 @@ import {
   SITE_ORIGIN,
   APPLE_APP_ID,
   appStoreUrl,
+  shareUrl,
   TOWN_ATTRIBUTION_LINES,
 } from './constants.mjs';
 import { escapeHtml, leadLine } from './format.mjs';
@@ -60,7 +61,9 @@ function buildTownJsonLd(data, canonical, authorityCanonical) {
       '@type': 'ListItem',
       position: i + 1,
       name: [app.name, app.address].filter(Boolean).join(' — '),
-      url: app.url || app.link || canonical,
+      // Prefer our own share page (the application's canonical Town Crier page)
+      // as the item URL; fall back to the council/PlanIt record, then the page.
+      url: shareUrl(data.authoritySlug, app.name) || app.url || app.link || canonical,
     })),
   };
   const dataset = {
@@ -115,7 +118,7 @@ export function renderTownPage(data) {
   const jsonLd = buildTownJsonLd(data, canonical, authorityCanonical);
   const year = new Date().getFullYear();
 
-  const applicationsList = renderApplicationsList(data.applications);
+  const applicationsList = renderApplicationsList(data.applications, data.authoritySlug);
   // Town pages credit the ONS Built-Up-Area + NRS gazetteers (their centroid
   // sources) on top of the base PlanIt/OGL/OS/OSM lines; authority pages keep the
   // base list since they don't use the gazetteer.


### PR DESCRIPTION
## What

Each application card on the authority (`/planning/<lpa>`) and town (`/planning/<lpa>/<town>`) SEO pages now leads with a do-follow **View on Town Crier** link to that application's public share page (`share.towncrierapp.uk/a/{slug}/{ref}`). The `ItemList` structured-data `url` for each item points there too, so the share pages get an internal, crawlable link from the programmatic SEO set.

## Why it's correct

- The share page resolves an application by its **`planit_name`** — which is the snapshot's `app.name`, **not** `app.uid`. Building from `uid` would 404 every link.
- Every card on a page belongs to a single authority: authority pages read one partition; the town `near` query is hard-scoped to one `authorityId`. So the page's own slug (`data.slug` / `data.authoritySlug`) is the correct authority slug for every card — no cross-boundary 404 risk.
- Pure render-time change: **no API/DTO change and no snapshot re-fetch.** The link is built entirely from data already in the snapshot.

## How

- New `shareUrl(authoritySlug, ref)` in `constants.mjs`, mirroring iOS `ShareURL.swift` encoding (slashes kept as path separators, other characters percent-encoded) and the API `shareOrigin`.
- `renderApplicationsList` takes the authority slug and emits the share link first on each card (do-follow, same-tab — it's our own page).

## Verification

- 951 web tests pass (new unit tests for `shareUrl`, share-link rendering, encoding, and JSON-LD url; existing tests unchanged and green); eslint clean.
- Rendered a real authority page from the actual renderer and viewed it in a browser: link text, ordering, and encoding (`%20`/`%26`, preserved slashes) all correct.

Closes tc-8lgq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added share links for individual application pages on authority, planning, and town pages.
  * Share URLs now use a consistent canonical format and preserve valid path separators while encoding unsafe characters.
  * Structured data for application listings now points to the same share page URL.

* **Bug Fixes**
  * Improved link generation so missing values no longer produce broken share URLs.

* **Tests**
  * Added coverage for share-link formatting, placement, and structured-data URL output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->