### PR TITLE
feat(seo): make the application reference heading the share link

### DIFF
--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -103,11 +103,12 @@ describe('renderPlanningPage', () => {
     expect(html).toContain('https://planit.org.uk/planapplic/26-0001-FUL');
   });
 
-  it('links each application to its share page using the authority slug and ref', () => {
+  it('links each application heading to its share page using the authority slug and ref', () => {
     const html = renderPlanningPage(pageData());
-    // app.name (26/0001/FUL) is the share ref; slashes are kept as separators.
+    // The reference heading is the share link; app.name (26/0001/FUL) is the ref,
+    // slashes kept as separators.
     expect(html).toContain(
-      '<a class="appLink" href="https://share.towncrierapp.uk/a/basingstoke-and-deane/26/0001/FUL">View on Town Crier</a>',
+      '<h3 class="appCard__ref"><a class="appCard__refLink" href="https://share.towncrierapp.uk/a/basingstoke-and-deane/26/0001/FUL">26/0001/FUL</a></h3>',
     );
     // The share page is the item URL in the ItemList structured data too.
     expect(html).toContain(

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -6,7 +6,6 @@ import {
 } from '../render-shared.mjs';
 import { ATTRIBUTION_LINES } from '../constants.mjs';
 
-const SHARE_CAPTION = 'View on Town Crier';
 const PLANIT_CAPTION = 'View full record on PlanIt';
 const COUNCIL_CAPTION = 'View on the council website';
 
@@ -102,22 +101,30 @@ describe('renderApplicationsList per-application links', () => {
 });
 
 describe('renderApplicationsList share links', () => {
-  it('leads each card with a share link built from the slug and the app ref', () => {
+  it('links the reference heading to the share page built from the slug and ref', () => {
     const html = renderApplicationsList([application()], SLUG);
-    // The share URL uses the app.name (planit_name) verbatim, slashes preserved.
-    expect(captionForHref(html, SHARE_HREF)).toBe(SHARE_CAPTION);
-    // It is the FIRST link on the card, before the PlanIt/council links.
-    expect(html.indexOf(SHARE_HREF)).toBeLessThan(html.indexOf(PLANIT_HREF));
+    // The <h3> reference heading itself is the share link; the ref (app.name /
+    // planit_name) is used verbatim in the URL, slashes preserved.
+    expect(html).toContain(
+      `<h3 class="appCard__ref"><a class="appCard__refLink" href="${SHARE_HREF}">26/0001/FUL</a></h3>`,
+    );
   });
 
-  it('makes the share link do-follow and same-tab (an internal Town Crier page)', () => {
+  it('makes the heading link do-follow and same-tab (an internal Town Crier page)', () => {
     const html = renderApplicationsList([application()], SLUG);
     const anchor = html.match(
-      new RegExp(`<a class="appLink" href="${SHARE_HREF.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}"[^>]*>`),
+      new RegExp(`<a class="appCard__refLink" href="${SHARE_HREF.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}"[^>]*>`),
     );
     expect(anchor).not.toBeNull();
     expect(anchor[0]).not.toContain('nofollow');
     expect(anchor[0]).not.toContain('target="_blank"');
+  });
+
+  it('leaves the meta row with only the two external links (no third action link)', () => {
+    const html = renderApplicationsList([application()], SLUG);
+    const anchors = html.match(/<a class="appLink"[^>]*>/g) ?? [];
+    expect(anchors).toHaveLength(2);
+    expect(html).not.toContain('View on Town Crier');
   });
 
   it('percent-encodes unsafe ref characters per segment while preserving slashes', () => {
@@ -126,20 +133,21 @@ describe('renderApplicationsList share links', () => {
       SLUG,
     );
     expect(html).toContain(
-      `https://share.towncrierapp.uk/a/${SLUG}/DC/2026/0001%20A%26B`,
+      `href="https://share.towncrierapp.uk/a/${SLUG}/DC/2026/0001%20A%26B"`,
     );
   });
 
-  it('omits the share link when no slug is supplied', () => {
+  it('renders the reference as plain heading text when no slug is supplied', () => {
     const html = renderApplicationsList([application()]);
-    expect(html).not.toContain(SHARE_CAPTION);
+    expect(html).toContain('<h3 class="appCard__ref">26/0001/FUL</h3>');
     expect(html).not.toContain('share.towncrierapp.uk');
+    expect(html).not.toContain('appCard__refLink');
   });
 
-  it('omits the share link when the app carries no ref', () => {
+  it('renders a plain heading when the app carries no ref', () => {
     const html = renderApplicationsList([application({ name: '' })], SLUG);
-    expect(html).not.toContain(SHARE_CAPTION);
     expect(html).not.toContain('share.towncrierapp.uk');
+    expect(html).not.toContain('appCard__refLink');
   });
 });
 
@@ -161,6 +169,16 @@ describe('renderAttributionList', () => {
     // HTML in a line is escaped so data can never inject markup.
     expect(html).toContain('<li>Line two &amp; &lt;b&gt;bold&lt;/b&gt;</li>');
     expect((html.match(/<li>/g) ?? []).length).toBe(2);
+  });
+});
+
+describe('pageStyles appCard__refLink', () => {
+  it('styles the heading link to inherit the heading colour and reveal amber on hover', () => {
+    const css = pageStyles();
+    expect(css).toContain('.appCard__refLink');
+    // Neutral by default (inherits the heading colour), amber on hover.
+    expect(css).toMatch(/\.appCard__refLink \{[^}]*color: inherit/);
+    expect(css).toMatch(/\.appCard__refLink:hover \{[^}]*var\(--tc-amber\)/);
   });
 });
 

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -109,12 +109,12 @@ describe('renderTownPage', () => {
     expect(html).toContain('https://planit.org.uk/planapplic/CW-26-0001');
   });
 
-  it('links each application to its share page using the parent authority slug and ref', () => {
+  it('links each application heading to its share page using the parent authority slug and ref', () => {
     const html = renderTownPage(townData());
     // Town-page apps are scoped to the town's own authority, so authoritySlug is
-    // correct for every card.
+    // correct for every card; the reference heading is the share link.
     expect(html).toContain(
-      '<a class="appLink" href="https://share.towncrierapp.uk/a/cornwall/26/0001">View on Town Crier</a>',
+      '<h3 class="appCard__ref"><a class="appCard__refLink" href="https://share.towncrierapp.uk/a/cornwall/26/0001">26/0001</a></h3>',
     );
     expect(html).toContain(
       '"url":"https://share.towncrierapp.uk/a/cornwall/26/0001"',

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -55,10 +55,11 @@ function statusModifier(appState) {
 /**
  * @param {PlanningApplicationItem} app
  * @param {string} [authoritySlug] the page's authority slug; when present (and the
- *   app carries a ref), the card leads with a do-follow link to our own public
- *   share page for the application. Every application on a page belongs to this
- *   one authority (authority pages read one partition; town pages scope the near
- *   query to a single authority), so the slug is correct for every card.
+ *   app carries a ref), the card's reference heading becomes a do-follow link to
+ *   our own public share page for the application. Every application on a page
+ *   belongs to this one authority (authority pages read one partition; town pages
+ *   scope the near query to a single authority), so the slug is correct for every
+ *   card.
  * @returns {string}
  */
 function renderApplication(app, authoritySlug) {
@@ -69,16 +70,19 @@ function renderApplication(app, authoritySlug) {
   const date = formatDate(app.lastDifferent);
   const description = escapeHtml(truncate(app.description, MAX_DESCRIPTION_LENGTH));
 
-  const links = [];
-  // Our own share page leads the list. Unlike the external PlanIt/council links,
-  // it is deliberately do-follow and same-tab: it is an internal Town Crier page,
-  // so we WANT search engines to crawl it and keep residents in-funnel.
+  // The reference heading is the card's title and doubles as the link to our own
+  // share page for the application — a do-follow, same-tab internal link we want
+  // crawled and clicked. It stays plain text when the page has no authority slug
+  // or the app carries no ref. The external PlanIt/council links stay in the meta
+  // row; keeping our link on the title (not a third meta link) avoids a lopsided,
+  // wrapping action row.
+  const ref = escapeHtml(app.name);
   const share = shareUrl(authoritySlug, app.name);
-  if (share) {
-    links.push(
-      `<a class="appLink" href="${escapeHtml(share)}">View on Town Crier</a>`,
-    );
-  }
+  const heading = share
+    ? `<a class="appCard__refLink" href="${escapeHtml(share)}">${ref}</a>`
+    : ref;
+
+  const links = [];
   if (app.link) {
     links.push(
       `<a class="appLink" href="${escapeHtml(app.link)}" rel="nofollow noopener" target="_blank">View full record on PlanIt</a>`,
@@ -92,7 +96,7 @@ function renderApplication(app, authoritySlug) {
 
   return `      <li class="appCard">
         <div class="appCard__head">
-          <h3 class="appCard__ref">${escapeHtml(app.name)}</h3>
+          <h3 class="appCard__ref">${heading}</h3>
           <span class="status status--${modifier}">${label}</span>
         </div>
         <p class="appCard__address">${escapeHtml(app.address)}</p>
@@ -265,6 +269,9 @@ export function pageStyles() {
       padding: var(--tc-space-md);
     }
     .appCard__head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--tc-space-sm); }
+    .appCard__ref { overflow-wrap: anywhere; }
+    .appCard__refLink { color: inherit; text-decoration: none; }
+    .appCard__refLink:hover { color: var(--tc-amber); text-decoration: underline; }
     .appCard__address { margin: var(--tc-space-sm) 0 var(--tc-space-sm); font-weight: 600; }
     .appCard__desc { margin: 0 0 var(--tc-space-sm); color: var(--tc-text-secondary); }
     .appCard__meta { display: flex; flex-wrap: wrap; gap: var(--tc-space-md); align-items: center; font-size: 0.875rem; }


### PR DESCRIPTION
Follow-up to #791, from live review of the dev SEO pages.

## Problem
The card action row had three amber links (`View on Town Crier`, `View full record on PlanIt`, `View on the council website`) which wrapped onto a lopsided second line.

## Change
The application **reference heading** itself is now the do-follow link to the share page. The action row drops back to just the two external links, so it sits on one line.

- Heading link inherits the heading colour at rest and reveals **amber + underline on hover** (design-language: colour signals interactive affordance; headings stay calm). Verified live: hover resolves to `#E9A620` + underline.
- Long refs wrap gracefully beside the status badge (`overflow-wrap: anywhere`).
- JSON-LD `ItemList` item `url` unchanged (still the share page).

## Verification
- 953 web tests pass (share-link tests rewritten for the heading anchor; new style test for the hover affordance), eslint clean.
- Rendered from the actual renderer and screenshotted: meta row is a single line on both a two-link and a one-link card.

Closes tc-rnoz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)