### PR TITLE
fix(ios): show Mark-all-read whenever the badge is non-zero (tc-c5m1)

### DIFF
--- a/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Coordinators/AppCoordinator.swift
@@ -185,13 +185,15 @@ public final class AppCoordinator: ObservableObject {
       viewModel = ApplicationListViewModel(
         offlineRepository: offlineRepository,
         zone: zone,
-        notificationStateRepository: notificationStateRepository
+        notificationStateRepository: notificationStateRepository,
+        badgeSetter: badgeSetter
       )
     } else {
       viewModel = ApplicationListViewModel(
         repository: repository,
         zone: zone,
-        notificationStateRepository: notificationStateRepository
+        notificationStateRepository: notificationStateRepository,
+        badgeSetter: badgeSetter
       )
     }
     viewModel.onApplicationSelected = { [weak self] id in
@@ -208,13 +210,15 @@ public final class AppCoordinator: ObservableObject {
       viewModel = ApplicationListViewModel(
         watchZoneRepository: watchZoneRepository,
         offlineRepository: offlineRepository,
-        notificationStateRepository: notificationStateRepository
+        notificationStateRepository: notificationStateRepository,
+        badgeSetter: badgeSetter
       )
     } else {
       viewModel = ApplicationListViewModel(
         watchZoneRepository: watchZoneRepository,
         repository: repository,
-        notificationStateRepository: notificationStateRepository
+        notificationStateRepository: notificationStateRepository,
+        badgeSetter: badgeSetter
       )
     }
     viewModel.onApplicationSelected = { [weak self] id in
@@ -228,8 +232,8 @@ public final class AppCoordinator: ObservableObject {
   /// tab is meaningful only when bookmarking is wired, but a fatal error here
   /// would crash users who never tap the tab.
   public func makeSavedApplicationListViewModel() -> SavedApplicationListViewModel {
-    let repository = savedApplicationRepository ?? UnavailableSavedApplicationRepository()
-    let viewModel = SavedApplicationListViewModel(savedApplicationRepository: repository)
+    let savedRepository = savedApplicationRepository ?? UnavailableSavedApplicationRepository()
+    let viewModel = SavedApplicationListViewModel(savedApplicationRepository: savedRepository)
     viewModel.onApplicationSelected = { [weak self] id in
       self?.showApplicationDetail(id)
     }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListView.swift
@@ -15,7 +15,11 @@ import TownCrierDomain
 /// - an Unread filter chip (visible only when `hasUnread`) that mirrors the
 ///   web bead's single-select behaviour with the existing status chips,
 /// - a sort menu in the toolbar with the four sort modes from the spec,
-/// - a Mark-All-Read toolbar action (visible only when `hasUnread`).
+/// - a Mark-All-Read toolbar action, visible whenever the app-icon badge has
+///   something to clear (`hasClearableUnread`, the GLOBAL unread count) —
+///   deliberately decoupled from the per-zone `hasUnread` chip so the badge
+///   stays reachable even when the active zone has no unread rows of its own
+///   (tc-c5m1, GH#793).
 public struct ApplicationListView: View {
   @StateObject private var viewModel: ApplicationListViewModel
 
@@ -80,7 +84,7 @@ public struct ApplicationListView: View {
 
   @ToolbarContentBuilder
   private var markAllReadToolbarItem: some ToolbarContent {
-    if viewModel.hasUnread {
+    if viewModel.hasClearableUnread {
       ToolbarItem(placement: sortToolbarPlacement) {
         Button("Mark all read") {
           Task { await viewModel.markAllRead() }

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+GlobalUnread.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+GlobalUnread.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Best-effort refresh of the global unread count that gates the
+/// Mark-All-Read toolbar button (tc-c5m1, GH#793). Split out of
+/// `ApplicationListViewModel` to keep that file under SwiftLint's
+/// `file_length` ceiling.
+extension ApplicationListViewModel {
+
+  /// Refreshes `globalUnreadCount` from the notification-state repository.
+  /// Swallows all errors and never touches `error`/`isLoading` — this is a
+  /// background enrichment of the Mark-All-Read button's visibility, not the
+  /// primary load. No-ops when no repository was injected (count stays 0).
+  func refreshGlobalUnread() async {
+    guard let notificationStateRepository else { return }
+    do {
+      let state = try await notificationStateRepository.fetchState()
+      globalUnreadCount = state.totalUnreadCount
+    } catch {
+      // Swallow — best-effort background enrichment; a later load retries.
+    }
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+TapToRead.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel+TapToRead.swift
@@ -1,0 +1,42 @@
+import Foundation
+import TownCrierDomain
+
+/// Per-application "tap to read" mark-read flow (ADR 0035). Split out of
+/// `ApplicationListViewModel` to keep that file under SwiftLint's
+/// `file_length` ceiling.
+extension ApplicationListViewModel {
+
+  /// Fires a per-application mark-read when the opened row shows an unread
+  /// badge, optimistically clearing that badge locally so ``unreadCount`` and
+  /// the Unread chip update without a refetch. Already-read/absent rows and
+  /// non-numeric authorities issue no request. Errors are swallowed — a later
+  /// fetch reconciles (ADR 0035). The composite mirrors the deep-link parser:
+  /// `applicationUid` is `id.name`; `authorityId` is `Int(id.authority)`.
+  func markReadOnOpen(_ id: PlanningApplicationId) {
+    guard let notificationStateRepository,
+      let index = applications.firstIndex(where: { $0.id == id }),
+      applications[index].latestUnreadEvent != nil,
+      let authorityId = Int(id.authority)
+    else {
+      return
+    }
+    let applicationUid = id.name
+    applications[index] = applications[index].withLatestUnreadEvent(nil)
+    pendingMarkRead = Task { [weak self] in
+      do {
+        try await notificationStateRepository.markApplicationRead(
+          applicationUid: applicationUid,
+          authorityId: authorityId
+        )
+      } catch {
+        // Swallow — optimistic UI; a later fetch reconciles (ADR 0035).
+        _ = self
+      }
+    }
+  }
+
+  /// Test-only: await the most recent tap-to-read mark-read.
+  public func waitForPendingMarkRead() async {
+    await pendingMarkRead?.value
+  }
+}

--- a/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
+++ b/mobile/ios/packages/town-crier-presentation/Sources/Features/ApplicationList/ApplicationListViewModel.swift
@@ -74,7 +74,11 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   let repository: PlanningApplicationRepository?
   let offlineRepository: OfflineAwareRepository?
   private let watchZoneRepository: WatchZoneRepository?
-  private let notificationStateRepository: NotificationStateRepository?
+  // Internal (not `private`) so the `+GlobalUnread` extension file can drive
+  // `refreshGlobalUnread()` (tc-c5m1).
+  let notificationStateRepository: NotificationStateRepository?
+  /// Clears the app-icon badge on a successful `markAllRead()` (tc-c5m1).
+  private let badgeSetter: BadgeSetting?
   var zone: WatchZone?
   /// Re-entrancy guard for ``loadApplications()``. A single user action can
   /// trigger the load repeatedly — `.task` firing alongside `.refreshable`, a
@@ -119,9 +123,10 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
 
   var onApplicationSelected: ((PlanningApplicationId) -> Void)?
 
-  /// In-flight per-application mark-read fired by ``selectApplication(_:)`` —
-  /// fire-and-forget in production; stored so tests can await it.
-  private var pendingMarkRead: Task<Void, Never>?
+  // Internal (not `private`) so the `+TapToRead` extension file can drive
+  // the per-application mark-read flow. Fire-and-forget in production;
+  // stored so tests can await it.
+  var pendingMarkRead: Task<Void, Never>?
 
   /// True when the zone picker should render — i.e. the user has more than one
   /// real watch zone to choose between. Single-zone users have no meaningful
@@ -132,10 +137,24 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
   }
 
   /// True when the global watermark reports at least one unread notification.
-  /// Drives the conditional visibility of the Unread chip and Mark-All-Read
-  /// toolbar action (spec decision #8).
+  /// Drives the conditional visibility of the Unread chip (spec decision #8).
   public var hasUnread: Bool {
     unreadCount > 0
+  }
+
+  /// Server's global unread count — same source as the app-icon badge.
+  /// Refreshed best-effort per ``loadApplications()`` call, zone-independent.
+  /// Internal (not `private(set)`) so the `+GlobalUnread` extension file can
+  /// mutate it; still read-only outside the presentation module (no `public`
+  /// modifier) (tc-c5m1, GH#793).
+  @Published var globalUnreadCount = 0
+
+  /// True when the global unread count is non-zero. Gates the Mark-All-Read
+  /// button; deliberately decoupled from `hasUnread` (the per-zone chip) so
+  /// the button stays reachable even when the active zone has no unread rows
+  /// of its own (tc-c5m1, GH#793).
+  public var hasClearableUnread: Bool {
+    globalUnreadCount > 0
   }
 
   /// Sort modes the picker should expose right now. The `.distance` option
@@ -169,6 +188,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     repository: PlanningApplicationRepository,
     zone: WatchZone,
     notificationStateRepository: NotificationStateRepository? = nil,
+    badgeSetter: BadgeSetting? = nil,
     userDefaults: UserDefaults = .standard,
     sortKey: String = defaultSortKey
   ) {
@@ -176,6 +196,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     self.offlineRepository = nil
     self.watchZoneRepository = nil
     self.notificationStateRepository = notificationStateRepository
+    self.badgeSetter = badgeSetter
     self.zone = zone
     self.userDefaults = userDefaults
     self.zoneSelectionKey = ""
@@ -187,6 +208,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     offlineRepository: OfflineAwareRepository,
     zone: WatchZone,
     notificationStateRepository: NotificationStateRepository? = nil,
+    badgeSetter: BadgeSetting? = nil,
     userDefaults: UserDefaults = .standard,
     sortKey: String = defaultSortKey
   ) {
@@ -194,6 +216,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     self.offlineRepository = offlineRepository
     self.watchZoneRepository = nil
     self.notificationStateRepository = notificationStateRepository
+    self.badgeSetter = badgeSetter
     self.zone = zone
     self.userDefaults = userDefaults
     self.zoneSelectionKey = ""
@@ -205,6 +228,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     watchZoneRepository: WatchZoneRepository,
     repository: PlanningApplicationRepository,
     notificationStateRepository: NotificationStateRepository? = nil,
+    badgeSetter: BadgeSetting? = nil,
     userDefaults: UserDefaults = .standard,
     zoneSelectionKey: String = "lastSelectedZone.applications",
     sortKey: String = defaultSortKey
@@ -213,6 +237,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     self.offlineRepository = nil
     self.watchZoneRepository = watchZoneRepository
     self.notificationStateRepository = notificationStateRepository
+    self.badgeSetter = badgeSetter
     self.zone = nil
     self.userDefaults = userDefaults
     self.zoneSelectionKey = zoneSelectionKey
@@ -224,6 +249,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     watchZoneRepository: WatchZoneRepository,
     offlineRepository: OfflineAwareRepository,
     notificationStateRepository: NotificationStateRepository? = nil,
+    badgeSetter: BadgeSetting? = nil,
     userDefaults: UserDefaults = .standard,
     zoneSelectionKey: String = "lastSelectedZone.applications",
     sortKey: String = defaultSortKey
@@ -232,6 +258,7 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     self.offlineRepository = offlineRepository
     self.watchZoneRepository = watchZoneRepository
     self.notificationStateRepository = notificationStateRepository
+    self.badgeSetter = badgeSetter
     self.zone = nil
     self.userDefaults = userDefaults
     self.zoneSelectionKey = zoneSelectionKey
@@ -250,6 +277,9 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
 
     isLoading = true
     error = nil
+    // Zone-independent, so it runs even when the no-active-zone branch below
+    // returns early (tc-c5m1, GH#793).
+    await refreshGlobalUnread()
     do {
       if let watchZoneRepository {
         let loadedZones = try await watchZoneRepository.loadAll()
@@ -298,39 +328,9 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     onApplicationSelected?(id)
   }
 
-  /// Fires a per-application mark-read when the opened row shows an unread
-  /// badge, optimistically clearing that badge locally so ``unreadCount`` and
-  /// the Unread chip update without a refetch. Already-read/absent rows and
-  /// non-numeric authorities issue no request. Errors are swallowed — a later
-  /// fetch reconciles (ADR 0035). The composite mirrors the deep-link parser:
-  /// `applicationUid` is `id.name`; `authorityId` is `Int(id.authority)`.
-  private func markReadOnOpen(_ id: PlanningApplicationId) {
-    guard let notificationStateRepository,
-      let index = applications.firstIndex(where: { $0.id == id }),
-      applications[index].latestUnreadEvent != nil,
-      let authorityId = Int(id.authority)
-    else {
-      return
-    }
-    let applicationUid = id.name
-    applications[index] = applications[index].withLatestUnreadEvent(nil)
-    pendingMarkRead = Task { [weak self] in
-      do {
-        try await notificationStateRepository.markApplicationRead(
-          applicationUid: applicationUid,
-          authorityId: authorityId
-        )
-      } catch {
-        // Swallow — optimistic UI; a later fetch reconciles (ADR 0035).
-        _ = self
-      }
-    }
-  }
-
-  /// Test-only: await the most recent tap-to-read mark-read.
-  public func waitForPendingMarkRead() async {
-    await pendingMarkRead?.value
-  }
+  // `markReadOnOpen(_:)` and `waitForPendingMarkRead()` live in the
+  // `+TapToRead` extension file (split out to keep this file under
+  // SwiftLint's `file_length` ceiling).
 
   /// Stamps the watermark to "now" via the notification-state repository,
   /// then refetches the active zone so each row's `latestUnreadEvent` drops
@@ -347,6 +347,10 @@ public final class ApplicationListViewModel: ObservableObject, ErrorHandlingView
     guard let notificationStateRepository else { return }
     do {
       try await notificationStateRepository.markAllRead()
+      // Clear immediately on success only — a false zero on failure would
+      // revert on the next foreground sync (tc-c5m1, GH#793).
+      globalUnreadCount = 0
+      badgeSetter?.setBadge(0)
     } catch {
       // Swallow — optimistic UI per spec decision #8.
     }

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelGlobalUnreadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelGlobalUnreadTests.swift
@@ -46,7 +46,8 @@ struct ApplicationListViewModelGlobalUnreadTests {
   }
 
   private func event(at seconds: TimeInterval) -> LatestUnreadEvent {
-    LatestUnreadEvent(type: "NewApplication", decision: nil, createdAt: Date(timeIntervalSince1970: seconds))
+    LatestUnreadEvent(
+      type: "NewApplication", decision: nil, createdAt: Date(timeIntervalSince1970: seconds))
   }
 
   // MARK: - hasClearableUnread

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelGlobalUnreadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelGlobalUnreadTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+import TownCrierDomain
+
+@testable import TownCrierPresentation
+
+/// Tests for gating the Mark-All-Read toolbar button on the GLOBAL unread
+/// count rather than the per-zone chip (tc-c5m1, GH#793).
+///
+/// The app-icon badge is set from the server's global
+/// `notification-state.totalUnreadCount`, but the Mark-All-Read button was
+/// gated on `hasUnread` — derived purely from the currently loaded zone's
+/// rows. When global unread existed but no loaded row carried it (different
+/// zone, deleted zone, unfetched page), the button hid and the badge became
+/// unclearable. `hasClearableUnread` decouples the button from the per-zone
+/// chip so it always tracks the same count the badge does, and
+/// `markAllRead()` now clears that badge immediately on success.
+@Suite("ApplicationListViewModel — global unread / clearable badge (tc-c5m1)")
+@MainActor
+struct ApplicationListViewModelGlobalUnreadTests {
+
+  // MARK: - Helpers
+
+  private func makeSUT(
+    applications: [PlanningApplication] = [],
+    totalUnreadCount: Int = 0,
+    badgeSetter: SpyBadgeSetter? = nil
+  ) -> (ApplicationListViewModel, SpyNotificationStateRepository) {
+    let appSpy = SpyPlanningApplicationRepository()
+    appSpy.fetchApplicationsResult = .success(applications)
+    let stateSpy = SpyNotificationStateRepository()
+    stateSpy.fetchStateResult = .success(
+      NotificationState(
+        lastReadAt: Date(timeIntervalSince1970: 0),
+        version: 1,
+        totalUnreadCount: totalUnreadCount
+      )
+    )
+    let sut = ApplicationListViewModel(
+      repository: appSpy,
+      zone: .cambridge,
+      notificationStateRepository: stateSpy,
+      badgeSetter: badgeSetter
+    )
+    return (sut, stateSpy)
+  }
+
+  private func event(at seconds: TimeInterval) -> LatestUnreadEvent {
+    LatestUnreadEvent(type: "NewApplication", decision: nil, createdAt: Date(timeIntervalSince1970: seconds))
+  }
+
+  // MARK: - hasClearableUnread
+
+  @Test("hasClearableUnread is true when global unread exists even with no unread rows loaded")
+  func hasClearableUnread_trueWhenGlobalUnreadExists_withNoUnreadRowsLoaded() async {
+    let (sut, _) = makeSUT(
+      applications: [.pendingReview.withLatestUnreadEvent(nil)],
+      totalUnreadCount: 5
+    )
+
+    await sut.loadApplications()
+
+    #expect(sut.hasClearableUnread)
+    #expect(!sut.hasUnread)
+  }
+
+  @Test("hasClearableUnread is false when global unread is zero")
+  func hasClearableUnread_falseWhenGlobalUnreadIsZero() async {
+    let (sut, _) = makeSUT(totalUnreadCount: 0)
+
+    await sut.loadApplications()
+
+    #expect(!sut.hasClearableUnread)
+  }
+
+  @Test("hasUnread and hasClearableUnread are independent: unread row but zero global count")
+  func hasUnread_andHasClearableUnread_areIndependent() async {
+    let (sut, _) = makeSUT(
+      applications: [.pendingReview.withLatestUnreadEvent(event(at: 1_700_500_000))],
+      totalUnreadCount: 0
+    )
+
+    await sut.loadApplications()
+
+    #expect(sut.hasUnread)
+    #expect(!sut.hasClearableUnread)
+  }
+
+  // MARK: - markAllRead badge clearing
+
+  @Test("markAllRead clears the global count and sets the badge to zero on success")
+  func markAllRead_clearsCountAndBadge_onSuccess() async {
+    let badgeSetter = SpyBadgeSetter()
+    let (sut, stateSpy) = makeSUT(totalUnreadCount: 5, badgeSetter: badgeSetter)
+
+    await sut.loadApplications()
+    await sut.markAllRead()
+
+    #expect(stateSpy.markAllReadCallCount == 1)
+    #expect(sut.globalUnreadCount == 0)
+    #expect(badgeSetter.setBadgeCalls.last == 0)
+  }
+
+  @Test("markAllRead leaves the badge untouched when the repository call fails")
+  func markAllRead_leavesBadgeUntouched_onFailure() async {
+    let badgeSetter = SpyBadgeSetter()
+    let (sut, stateSpy) = makeSUT(totalUnreadCount: 5, badgeSetter: badgeSetter)
+    stateSpy.markAllReadResult = .failure(DomainError.networkUnavailable)
+
+    await sut.loadApplications()
+    await sut.markAllRead()
+
+    #expect(badgeSetter.setBadgeCalls.isEmpty)
+    #expect(sut.globalUnreadCount == 5)
+  }
+}

--- a/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
+++ b/mobile/ios/town-crier-tests/Sources/Features/ApplicationListViewModelUnreadTests.swift
@@ -106,18 +106,28 @@ struct ApplicationListViewModelUnreadTests {
     #expect(!sut.hasUnread)
   }
 
-  @Test("loadApplications does not call fetchState (chip is derived client-side)")
-  func loadApplications_doesNotCallFetchState() async throws {
+  @Test("loadApplications calls fetchState for the global count, but the chip stays client-side")
+  func loadApplications_callsFetchStateForGlobalCountOnly() async throws {
     let (sut, _, stateSpy, _) = try makeSUT(
       applications: [
         PlanningApplication.pendingReview
           .withLatestUnreadEvent(event(at: 1_700_500_000))
-      ]
+      ],
+      state: NotificationState(
+        lastReadAt: Date(timeIntervalSince1970: 0),
+        version: 1,
+        totalUnreadCount: 99
+      )
     )
 
     await sut.loadApplications()
 
-    #expect(stateSpy.fetchStateCallCount == 0)
+    // `loadApplications` now refreshes the GLOBAL unread count (tc-c5m1,
+    // GH#793) via `fetchState`, but the per-zone `unreadCount` chip stays
+    // derived from each row's `latestUnreadEvent` and is untouched by the
+    // server's global figure.
+    #expect(stateSpy.fetchStateCallCount == 1)
+    #expect(sut.unreadCount == 1)
   }
 
   // MARK: - Unread filter


### PR DESCRIPTION
## Problem

The app-icon badge can show a non-zero unread count with **no way to clear it**. The "Mark all read" toolbar button on the Applications screen is gated on the per-zone `viewModel.hasUnread` (derived from the loaded rows of the selected watch zone), but the badge is the server's *global* `notification-state.totalUnreadCount`. When global unread exists but no currently-loaded row carries it (a different zone, a deleted zone, items outside the loaded page, or notifications that never correlate onto a visible row), the button hides and the badge is unclearable.

Regression from GH#380 / tc-e9ox, which switched `unreadCount` from the global count to a per-zone derived count so the Unread *chip* matches each zone — correct for the chip, but it silently severed the Mark-all-read button from the badge it clears.

Fixes #793.

## Fix

- `ApplicationListViewModel` fetches the global `totalUnreadCount` (via the already-injected `NotificationStateRepository.fetchState()`) on load and exposes `hasClearableUnread`.
- The toolbar button now gates on `hasClearableUnread` (global) instead of `hasUnread` (per-zone). The **Unread chip is unchanged** — it stays per-zone.
- On a successful `markAllRead()`, the global count is zeroed and the app-icon badge is set to 0 immediately (via an injected `BadgeSetting`), so the badge drops on tap rather than on the next foreground sync. On failure the badge is left untouched (no false zero; a later sync reconciles).

Out of scope: the pre-existing `GetLatestUnreadByApplications` cross-authority correlation gap (tc-4o3h) — mark-all-read clears globally regardless, which fully resolves the stuck badge.

## Verification

- Independent `swift build`: clean.
- New tests (Swift Testing, hand-written spies) staging the exact broken state, all green:
  - `hasClearableUnread is true when global unread exists even with no unread rows loaded`
  - `hasClearableUnread is false when global unread is zero`
  - `hasUnread and hasClearableUnread are independent`
  - `markAllRead clears the global count and sets the badge to zero on success`
  - `markAllRead leaves the badge untouched when the repository call fails`
- Full suite: 1441 tests pass. `swiftlint lint --strict` on touched files: 0 violations.
- Live: reproduced the "before" state on the simulator (Applications screen with no Mark-all-read button). The "after" (button appears when global unread > 0) is staged by the first unit test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ESyHtoRwMj8xhU3HoFtD4t

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App list now supports a separate global unread badge count, so “Mark All Read” can appear even when the current zone has no unread items.
  * Opening an unread application can now mark it as read immediately, with the app updating optimistically.
  * App badge counts are now cleared when all items are marked read.

* **Bug Fixes**
  * Unread status now refreshes more consistently during list loading, keeping badge and read-state indicators in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->