### PR TITLE
feat(seo): light-first CSS tokens + share-page tone convergence (tc-r4n9.1)

### DIFF
--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -191,3 +191,83 @@ describe('pageStyles townLinks', () => {
     expect(css).toMatch(/\.townLinks__list a \{[^}]*var\(--tc-/);
   });
 });
+
+describe('pageStyles light-first token flip (tc-r4n9.1)', () => {
+  /**
+   * @param {string} css
+   * @returns {string} the declarations inside the top-level `:root { ... }`
+   *   block (i.e. NOT the one nested inside a @media query).
+   */
+  function rootDeclarations(css) {
+    const match = css.match(/^\s*:root \{([^}]*)\}/m);
+    return match ? match[1] : '';
+  }
+
+  /**
+   * @param {string} css
+   * @returns {string} the declarations inside `:root { ... }` nested within
+   *   `@media (prefers-color-scheme: dark)`.
+   */
+  function darkMediaDeclarations(css) {
+    const match = css.match(
+      /@media \(prefers-color-scheme: dark\) \{\s*:root \{([^}]*)\}/,
+    );
+    return match ? match[1] : '';
+  }
+
+  it('defaults :root to the light-mode values directly (no query needed)', () => {
+    const root = rootDeclarations(pageStyles());
+    expect(root).toMatch(/--tc-amber: #D4910A;/);
+    expect(root).toMatch(/--tc-amber-hover: #B87A08;/);
+    expect(root).toMatch(/--tc-background: #FAF8F5;/);
+    expect(root).toMatch(/--tc-surface: #FFFFFF;/);
+    expect(root).toMatch(/--tc-text-primary: #1C1917;/);
+    expect(root).toMatch(/--tc-text-secondary: #6B6560;/);
+    expect(root).toMatch(/--tc-text-on-accent: #FFFFFF;/);
+    expect(root).toMatch(/--tc-status-permitted: #1A7D37;/);
+    expect(root).toMatch(/--tc-status-conditions: #A85A0A;/);
+    expect(root).toMatch(/--tc-status-rejected: #C42B2B;/);
+    expect(root).toMatch(/--tc-status-withdrawn: #7A7570;/);
+    expect(root).toMatch(/--tc-status-appealed: #7C3AED;/);
+    expect(root).toMatch(/--tc-status-default: #6B6560;/);
+    expect(root).toMatch(/--tc-border: #E8E4DF;/);
+  });
+
+  it('moves the former dark defaults, byte-for-byte, into @media (prefers-color-scheme: dark)', () => {
+    const dark = darkMediaDeclarations(pageStyles());
+    expect(dark).toMatch(/--tc-amber: #E9A620;/);
+    expect(dark).toMatch(/--tc-amber-hover: #F0B83A;/);
+    expect(dark).toMatch(/--tc-background: #1A1A1E;/);
+    expect(dark).toMatch(/--tc-surface: #242428;/);
+    expect(dark).toMatch(/--tc-text-primary: #F1EFE9;/);
+    expect(dark).toMatch(/--tc-text-secondary: #9B9590;/);
+    expect(dark).toMatch(/--tc-text-on-accent: #1C1917;/);
+    expect(dark).toMatch(/--tc-status-permitted: #34C759;/);
+    expect(dark).toMatch(/--tc-status-conditions: #FF9500;/);
+    expect(dark).toMatch(/--tc-status-rejected: #FF453A;/);
+    expect(dark).toMatch(/--tc-status-withdrawn: #8E8A85;/);
+    expect(dark).toMatch(/--tc-status-appealed: #A78BFA;/);
+    expect(dark).toMatch(/--tc-status-default: #9B9590;/);
+    expect(dark).toMatch(/--tc-border: #3A3A3F;/);
+  });
+
+  it('no longer gates light values behind a prefers-color-scheme: light query', () => {
+    expect(pageStyles()).not.toContain('prefers-color-scheme: light');
+  });
+
+  it('keeps exactly one dark override block, gated on prefers-color-scheme: dark', () => {
+    const css = pageStyles();
+    const matches = css.match(/@media \(prefers-color-scheme: dark\)/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it('records the chosen background scale as a comment in the token block, converged with the share page family', () => {
+    const css = pageStyles();
+    const root = rootDeclarations(css);
+    // The comment documenting WHY these values were chosen must live inside the
+    // :root token block itself (not just JSDoc above the function), so it is
+    // visible to anyone reading the generated page source.
+    expect(root).toMatch(/\/\*[^]*share page[^]*\*\//i);
+    expect(root.toLowerCase()).toContain('faf8f5');
+  });
+});

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -163,27 +163,35 @@ export function renderAttributionList(lines = ATTRIBUTION_LINES) {
 /**
  * Inline stylesheet for the standalone static pages. Self-contained (no external
  * CSS request) for first-byte readability and strong Core Web Vitals. Uses the
- * Town Crier design tokens — dark by default, light via prefers-color-scheme —
- * mirroring `src/styles/tokens.css`.
+ * Town Crier design tokens — light by default, dark via prefers-color-scheme —
+ * mirroring `src/styles/tokens.css`. Light-first (rather than gating the light
+ * values behind a media query) means a renderer/webview/reader-mode/print
+ * pipeline that never evaluates prefers-color-scheme still gets the paper-like
+ * default, not the dark palette (tc-r4n9.1).
  *
  * @returns {string}
  */
 export function pageStyles() {
   return `    :root {
-      --tc-amber: #E9A620;
-      --tc-amber-hover: #F0B83A;
-      --tc-background: #1A1A1E;
-      --tc-surface: #242428;
-      --tc-text-primary: #F1EFE9;
-      --tc-text-secondary: #9B9590;
-      --tc-text-on-accent: #1C1917;
-      --tc-status-permitted: #34C759;
-      --tc-status-conditions: #FF9500;
-      --tc-status-rejected: #FF453A;
-      --tc-status-withdrawn: #8E8A85;
-      --tc-status-appealed: #A78BFA;
-      --tc-status-default: #9B9590;
-      --tc-border: #3A3A3F;
+      /* Background scale converged with the share-page family (see
+         api-go/internal/sharepage/templates/styles.gohtml): a warm cream field
+         (--tc-background: #FAF8F5) behind a white card (--tc-surface:
+         #FFFFFF) in light mode, so SEO pages and share pages read as one
+         product rather than two differently-themed properties. */
+      --tc-amber: #D4910A;
+      --tc-amber-hover: #B87A08;
+      --tc-background: #FAF8F5;
+      --tc-surface: #FFFFFF;
+      --tc-text-primary: #1C1917;
+      --tc-text-secondary: #6B6560;
+      --tc-text-on-accent: #FFFFFF;
+      --tc-status-permitted: #1A7D37;
+      --tc-status-conditions: #A85A0A;
+      --tc-status-rejected: #C42B2B;
+      --tc-status-withdrawn: #7A7570;
+      --tc-status-appealed: #7C3AED;
+      --tc-status-default: #6B6560;
+      --tc-border: #E8E4DF;
       --tc-radius-md: 12px;
       --tc-radius-full: 9999px;
       --tc-space-sm: 8px;
@@ -194,22 +202,22 @@ export function pageStyles() {
       --tc-font-family: 'Inter', system-ui, -apple-system, sans-serif;
       --tc-content-max-width: 760px;
     }
-    @media (prefers-color-scheme: light) {
+    @media (prefers-color-scheme: dark) {
       :root {
-        --tc-amber: #D4910A;
-        --tc-amber-hover: #B87A08;
-        --tc-background: #FAF8F5;
-        --tc-surface: #FFFFFF;
-        --tc-text-primary: #1C1917;
-        --tc-text-secondary: #6B6560;
-        --tc-text-on-accent: #FFFFFF;
-        --tc-status-permitted: #1A7D37;
-        --tc-status-conditions: #A85A0A;
-        --tc-status-rejected: #C42B2B;
-        --tc-status-withdrawn: #7A7570;
-        --tc-status-appealed: #7C3AED;
-        --tc-status-default: #6B6560;
-        --tc-border: #E8E4DF;
+        --tc-amber: #E9A620;
+        --tc-amber-hover: #F0B83A;
+        --tc-background: #1A1A1E;
+        --tc-surface: #242428;
+        --tc-text-primary: #F1EFE9;
+        --tc-text-secondary: #9B9590;
+        --tc-text-on-accent: #1C1917;
+        --tc-status-permitted: #34C759;
+        --tc-status-conditions: #FF9500;
+        --tc-status-rejected: #FF453A;
+        --tc-status-withdrawn: #8E8A85;
+        --tc-status-appealed: #A78BFA;
+        --tc-status-default: #9B9590;
+        --tc-border: #3A3A3F;
       }
     }
     @font-face {


### PR DESCRIPTION
## Changes
- `pageStyles()` in `render-shared.mjs`: `:root` now holds light-mode token values directly; dark values moved byte-for-byte into `@media (prefers-color-scheme: dark)`. Zero visual change for users with an expressed dark preference.
- Background/card tones converge with the share page family's warm-cream-field + white-card scheme (values were already identical — documented with a comment in the token block).
- Updated JSDoc to describe the light-first rationale (paper-like default for renderers/webviews/print that never fire the media query).

Part of the design-review punch list (#794), Phase 1 of 7. Closes tc-r4n9.1.

## Test plan
- `npx tsc --noEmit` clean
- `npx vitest run` — 958/958 green (full suite)
- Visual verification via agent-browser: authority page + town page, light/dark emulation, mobile (390x844) + desktop (1440x900). Dark mode confirmed pixel-equivalent to before; light mode shows converged warm-cream/white-card tones at both viewport widths.

---
*Auto-shipped via ship skill*