### PR TITLE
feat(sharepage): real header, app CTA primary, cta-bar aligned (tc-r4n9.5)

### DIFF
--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -164,8 +164,10 @@ func TestServe_KnownApplication_RendersMetaAndVisibleContent(t *testing.T) {
 		"Contains public sector information licensed under the Open Government Licence. Crown Copyright.",
 		"Contains Ordnance Survey data © Crown Copyright and database right.",
 		"Map data © OpenStreetMap contributors.",
-		// Sticky CTA: exact copy + the campaign-tagged App Store URL.
-		"Download the app for instant notifications about planning updates",
+		// Sticky CTA: short verb-first label + supporting sentence, plus the
+		// campaign-tagged App Store URL.
+		"Get the app",
+		"Instant notifications about planning updates like this one.",
 		"town-crier-planning-alerts",
 		"ct=share-page",
 		"mt=8",
@@ -527,7 +529,7 @@ func TestServe_NilOptionalFields_Renders200WithoutPanic(t *testing.T) {
 		t.Error("key-dates section rendered despite no dates")
 	}
 	// Attribution + CTA still present.
-	if !strings.Contains(body, "Download the app for instant notifications about planning updates") {
+	if !strings.Contains(body, "Get the app") {
 		t.Error("sticky CTA missing")
 	}
 	if !strings.Contains(body, "Map data © OpenStreetMap contributors.") {

--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -303,6 +303,45 @@ func TestServe_AppCTAIsPrimaryInCardAction(t *testing.T) {
 	}
 }
 
+// TestServe_CTABarShortLabelNoRedundantSecondLink pins Phase 5 (#794): the
+// cta-bar drops the redundant second "Get Town Crier at towncrierapp.uk" link
+// (now covered by the header brand lockup) in favour of a short, verb-first
+// label plus a one-line supporting sentence rendered as plain text.
+func TestServe_CTABarShortLabelNoRedundantSecondLink(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{app: fullApp(t), found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	barIdx := strings.Index(body, `<div class="cta-bar">`)
+	if barIdx == -1 {
+		t.Fatal(`body missing <div class="cta-bar">`)
+	}
+	bar := body[barIdx:]
+
+	if !strings.Contains(bar, `class="cta"`) {
+		t.Error("cta-bar missing the short-label CTA button")
+	}
+	if !strings.Contains(bar, ">Get the app<") {
+		t.Error(`cta-bar CTA button must use the short, verb-first label "Get the app"`)
+	}
+	if !strings.Contains(bar, `class="cta-sub"`) {
+		t.Error("cta-bar missing the one-line supporting sentence")
+	}
+	if strings.Contains(bar, "home-link") {
+		t.Error("cta-bar must drop the redundant second (home) link — the header brand lockup already covers it")
+	}
+	if strings.Contains(bar, "Get Town Crier at towncrierapp.uk") {
+		t.Error("cta-bar must drop the redundant duplicate homepage copy")
+	}
+}
+
 func TestServe_UnknownSlug_RendersBranded404(t *testing.T) {
 	t.Parallel()
 	store := &fakeStore{}

--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -154,7 +154,7 @@ func TestServe_KnownApplication_RendersMetaAndVisibleContent(t *testing.T) {
 		`<span class="date-label">Started</span><span class="date-value">2 March 2024</span>`,
 		`<span class="date-label">Consulted</span><span class="date-value">10 March 2024</span>`,
 		`<span class="date-label">Decided</span><span class="date-value">15 April 2024</span>`,
-		// Official-record links (PlanIt primary, council secondary): nofollow +
+		// Official-record links (PlanIt secondary, council tertiary): nofollow +
 		// noopener + noreferrer (noreferrer strips the Referer to third-party sites).
 		`rel="nofollow noopener noreferrer"`,
 		"https://planit.org.uk/planapplic/165/23/03456/FUL",
@@ -399,8 +399,8 @@ func TestServe_EscapesUntrustedFields(t *testing.T) {
 func TestServe_NeutralisesJavascriptSchemeInOfficialLinks(t *testing.T) {
 	t.Parallel()
 	app := fullApp(t)
-	app.URL = ptr("javascript:alert(1)")  // council secondary link
-	app.Link = ptr("javascript:alert(2)") // PlanIt primary link
+	app.URL = ptr("javascript:alert(1)")  // council tertiary link
+	app.Link = ptr("javascript:alert(2)") // PlanIt secondary link
 	store := &fakeStore{app: app, found: true}
 	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
 

--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -220,6 +220,39 @@ func TestServe_RendersHomepageLink(t *testing.T) {
 	}
 }
 
+// TestServe_RendersHeaderAboveHeroWithBrandLockup pins Phase 5 (#794): the
+// floating "• Town Crier" legend-dot below the map is replaced by a real
+// header element above the hero, whose brand lockup links to the marketing
+// homepage.
+func TestServe_RendersHeaderAboveHeroWithBrandLockup(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{app: fullApp(t), found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	headerIdx := strings.Index(body, `<header class="site-header">`)
+	if headerIdx == -1 {
+		t.Fatal(`body missing <header class="site-header">`)
+	}
+	brandWant := `<a class="brand-link" href="https://towncrierapp.uk">Town Crier</a>`
+	if !strings.Contains(body, brandWant) {
+		t.Errorf("body missing brand lockup %q", brandWant)
+	}
+	heroIdx := strings.Index(body, `<img class="hero"`)
+	if heroIdx == -1 {
+		t.Fatal("body missing hero image")
+	}
+	if headerIdx > heroIdx {
+		t.Error("header must render above the hero image, not below it")
+	}
+}
+
 func TestServe_UnknownSlug_RendersBranded404(t *testing.T) {
 	t.Parallel()
 	store := &fakeStore{}

--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -253,6 +253,56 @@ func TestServe_RendersHeaderAboveHeroWithBrandLockup(t *testing.T) {
 	}
 }
 
+// TestServe_AppCTAIsPrimaryInCardAction pins decision 2 (#794): the App Store
+// CTA is the visually primary action inside the card, rendered above the
+// "Official record" section — whose PlanIt/council links are restyled
+// secondary/tertiary so an external link never outweighs our own CTA.
+func TestServe_AppCTAIsPrimaryInCardAction(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{app: fullApp(t), found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+
+	ctaIdx := strings.Index(body, `<div class="app-cta">`)
+	if ctaIdx == -1 {
+		t.Fatal(`body missing <div class="app-cta">`)
+	}
+	officialIdx := strings.Index(body, ">Official record<")
+	if officialIdx == -1 {
+		t.Fatal("body missing Official record section")
+	}
+	if ctaIdx > officialIdx {
+		t.Fatal("in-card app CTA must render above the Official record section")
+	}
+
+	appCTASection := body[ctaIdx:officialIdx]
+	if !strings.Contains(appCTASection, `class="btn-primary"`) {
+		t.Error(`in-card app CTA missing a "btn-primary" button`)
+	}
+	if !strings.Contains(appCTASection, ">Get the app<") {
+		t.Error(`in-card app CTA button must use the short, verb-first label "Get the app"`)
+	}
+	if !strings.Contains(appCTASection, "apps.apple.com") {
+		t.Error("in-card app CTA must link to the App Store")
+	}
+
+	if !strings.Contains(body, `class="record-link secondary"`) {
+		t.Error(`PlanIt link must carry class "record-link secondary"`)
+	}
+	if !strings.Contains(body, `class="record-link tertiary"`) {
+		t.Error(`council link must carry class "record-link tertiary"`)
+	}
+	if strings.Contains(body, `class="record-link primary"`) {
+		t.Error(`no official-record link may carry the "primary" class — that is now reserved for the app CTA`)
+	}
+}
+
 func TestServe_UnknownSlug_RendersBranded404(t *testing.T) {
 	t.Parallel()
 	store := &fakeStore{}

--- a/api-go/internal/sharepage/templates/page.gohtml
+++ b/api-go/internal/sharepage/templates/page.gohtml
@@ -32,9 +32,13 @@
 <h1 class="address">{{.Address}}{{if .Postcode}}, {{.Postcode}}{{end}}</h1>
 {{if .Description}}<h2>Proposal</h2><p class="proposal">{{.Description}}</p>{{end}}
 {{if .Dates}}<h2>Key dates</h2><ol class="timeline">{{range .Dates}}<li><span class="date-label">{{.Label}}</span><span class="date-value">{{.Value}}</span></li>{{end}}</ol>{{end}}
+<div class="app-cta">
+<a class="btn-primary" href="{{.CTAHref}}">Get the app</a>
+<p class="app-cta-sub">Instant notifications about planning updates like this one.</p>
+</div>
 {{if or .PlanItLink .CouncilLink}}<h2>Official record</h2><div class="records">
-{{if .PlanItLink}}<a class="record-link primary" href="{{.PlanItLink}}" rel="nofollow noopener noreferrer" target="_blank">View on PlanIt</a>{{end}}
-{{if .CouncilLink}}<a class="record-link secondary" href="{{.CouncilLink}}" rel="nofollow noopener noreferrer" target="_blank">View on the council website</a>{{end}}
+{{if .PlanItLink}}<a class="record-link secondary" href="{{.PlanItLink}}" rel="nofollow noopener noreferrer" target="_blank">View on PlanIt</a>{{end}}
+{{if .CouncilLink}}<a class="record-link tertiary" href="{{.CouncilLink}}" rel="nofollow noopener noreferrer" target="_blank">View on the council website</a>{{end}}
 </div>{{end}}
 </article>
 <footer class="attribution">

--- a/api-go/internal/sharepage/templates/page.gohtml
+++ b/api-go/internal/sharepage/templates/page.gohtml
@@ -49,8 +49,8 @@
 </footer>
 </main>
 <div class="cta-bar">
-<a class="cta" href="{{.CTAHref}}">Download the app for instant notifications about planning updates</a>
-<a class="home-link" href="{{.HomeURL}}">Get Town Crier at towncrierapp.uk</a>
+<a class="cta" href="{{.CTAHref}}">Get the app</a>
+<p class="cta-sub">Instant notifications about planning updates like this one.</p>
 </div>
 </body>
 </html>{{end}}

--- a/api-go/internal/sharepage/templates/page.gohtml
+++ b/api-go/internal/sharepage/templates/page.gohtml
@@ -21,9 +21,11 @@
 {{template "styles" .}}
 </head>
 <body>
+<header class="site-header">
+<a class="brand-link" href="{{.HomeURL}}">Town Crier</a>
+</header>
 <main class="page">
 <img class="hero" src="{{.OGImage}}" alt="Map showing the approximate location of {{if .Address}}{{.Address}}{{else}}this planning application{{end}}" width="1200" height="630" loading="eager">
-<div class="brand"><span class="dot"></span>Town Crier</div>
 <article class="card">
 <div class="ref-row">Reference {{.Ref}}{{if .AppType}} &middot; {{.AppType}}{{end}}</div>
 {{if .StatusChip}}<span class="chip">{{.StatusChip}}</span>{{end}}

--- a/api-go/internal/sharepage/templates/styles.gohtml
+++ b/api-go/internal/sharepage/templates/styles.gohtml
@@ -101,9 +101,8 @@ h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--spac
   color:var(--text-on-accent);text-align:center;text-decoration:none;font-weight:600;
   padding:4px 0;
 }
-.cta-bar .home-link{
-  color:var(--text-on-accent);text-decoration:underline;font-weight:500;
-  font-size:13px;text-align:center;margin-top:0;opacity:0.9;
+.cta-sub{
+  margin:0;color:var(--text-on-accent);opacity:0.9;font-size:13px;text-align:center;
 }
 .notfound{text-align:center;padding-top:var(--space-xl);}
 .notfound h1{font-size:24px;margin:0 0 var(--space-sm);}
@@ -119,17 +118,16 @@ h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--spac
   .hero{margin-bottom:var(--space-xl);}
   .card{padding:var(--space-lg);box-shadow:0 4px 24px rgba(0,0,0,0.06);}
   .cta-bar{
-    position:static;flex-direction:row;justify-content:center;align-items:center;
-    gap:var(--space-lg);margin-top:var(--space-xl);max-width:none;
+    position:static;flex-direction:row;justify-content:flex-start;align-items:center;
+    gap:var(--space-lg);max-width:720px;margin:var(--space-xl) auto 0;
     background:transparent;box-shadow:none;padding:0;
   }
   .cta{
     display:inline-block;background:var(--amber);color:var(--text-on-accent);
-    padding:12px var(--space-lg);border-radius:var(--radius-md);
+    padding:12px var(--space-lg);border-radius:var(--radius-md);flex-shrink:0;
   }
-  .cta-bar .home-link{
-    color:var(--amber);text-decoration:none;font-weight:600;
-    font-size:15px;opacity:1;
+  .cta-sub{
+    color:var(--text-secondary);opacity:1;font-size:15px;text-align:left;
   }
 }
 @media (min-width:720px) and (prefers-color-scheme:dark){.card{box-shadow:none;}}

--- a/api-go/internal/sharepage/templates/styles.gohtml
+++ b/api-go/internal/sharepage/templates/styles.gohtml
@@ -67,14 +67,24 @@ h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--spac
 .timeline li:last-child{border-bottom:none;}
 .date-label{color:var(--text-secondary);}
 .date-value{font-weight:600;text-align:right;}
-.records{display:flex;flex-direction:column;gap:var(--space-sm);}
+.app-cta{margin-top:var(--space-lg);text-align:center;}
+.btn-primary{
+  display:block;width:100%;box-sizing:border-box;padding:14px var(--space-md);
+  border-radius:var(--radius-md);background:var(--amber);color:var(--text-on-accent);
+  text-align:center;text-decoration:none;font-weight:600;
+}
+.app-cta-sub{margin:var(--space-sm) 0 0;color:var(--text-secondary);font-size:14px;}
+.records{display:flex;flex-direction:column;gap:var(--space-sm);margin-top:var(--space-sm);}
 .record-link{
   display:block;padding:12px var(--space-md);border-radius:var(--radius-md);
   text-align:center;text-decoration:none;font-weight:600;
 }
-.record-link.primary{background:var(--amber);color:var(--text-on-accent);}
 .record-link.secondary{
   background:var(--surface);color:var(--text-primary);border:1px solid var(--border);
+}
+.record-link.tertiary{
+  background:transparent;color:var(--text-secondary);border:none;
+  font-weight:500;text-decoration:underline;padding:8px var(--space-md);
 }
 .attribution{
   margin-top:var(--space-lg);color:var(--text-tertiary);

--- a/api-go/internal/sharepage/templates/styles.gohtml
+++ b/api-go/internal/sharepage/templates/styles.gohtml
@@ -20,6 +20,12 @@ body{
   font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif;
   font-size:17px;line-height:1.4;
 }
+.site-header{max-width:600px;margin:0 auto;padding:var(--space-md) var(--space-md) 0;}
+.brand-link{
+  display:inline-block;font-size:19px;font-weight:700;color:var(--text-primary);
+  text-decoration:none;letter-spacing:-0.01em;
+}
+.brand-link:hover{color:var(--text-primary);}
 .page{max-width:600px;margin:0 auto;padding:var(--space-lg) var(--space-md) 148px;}
 .hero{
   display:block;width:100%;height:auto;aspect-ratio:1200/630;
@@ -98,6 +104,7 @@ h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--spac
 }
 @media (min-width:720px){
   body{padding:var(--space-xl) var(--space-md);}
+  .site-header{max-width:720px;padding:0;margin:0 auto var(--space-md);}
   .page{max-width:720px;margin:0 auto;padding:0;}
   .hero{margin-bottom:var(--space-xl);}
   .card{padding:var(--space-lg);box-shadow:0 4px 24px rgba(0,0,0,0.06);}


### PR DESCRIPTION
## Changes
- Real header above the hero with a brand lockup linking to https://towncrierapp.uk, replacing the floating "• Town Crier" dot-legend that lived below the map.
- App CTA is now the primary in-card action ("Get the app" + a supporting sentence); "View on PlanIt" restyled secondary, "View on the council website" restyled tertiary under "Official record" — no external link outweighs our own CTA.
- Desktop `cta-bar` constrained to the card column width (was full-bleed/unconstrained) with a short label + one-line subtext; dropped the redundant second link now that the header covers the home link. Mobile sticky bottom bar unchanged structurally.

Part of the design-review punch list (#794), Phase 5 of 7. Closes tc-r4n9.5.

## Test plan
- `gofmt -l .`, `go vet ./...`, `golangci-lint run ./...` clean
- `go test -race ./...` — 1401 passed / 45 packages
- Visual verification via agent-browser against local API + seeded Postgres: mobile (390x844) + desktop (1440x900), light + dark. Confirmed header brand-link href, CTA hierarchy (primary/secondary/tertiary), and desktop cta-bar column alignment. (Hero image renders as a placeholder locally — that route is untouched, out of scope, owned by tc-r4n9.7.)

---
*Auto-shipped via ship skill*