### PR TITLE
feat(seo): human-first application cards (tc-r4n9.2)

### DIFF
--- a/web/scripts/lib/__tests__/format.test.mjs
+++ b/web/scripts/lib/__tests__/format.test.mjs
@@ -26,15 +26,32 @@ describe('truncate', () => {
     expect(truncate('short', 160)).toBe('short');
   });
 
-  it('cuts long text and appends an ellipsis', () => {
+  it('treats null as empty', () => {
+    expect(truncate(null, 160)).toBe('');
+  });
+
+  it('cuts on the last word boundary rather than mid-word', () => {
+    const text =
+      'Erection of a two-storey rear extension and associated landscaping works to an existing dwelling house with a new detached garage';
+    const result = truncate(text, 60);
+    // Every character up to the cut is a whole word from the source text — no
+    // word is sliced in half.
+    const withoutEllipsis = result.slice(0, -1);
+    expect(text.startsWith(withoutEllipsis)).toBe(true);
+    expect(withoutEllipsis.endsWith(' ')).toBe(false);
+    const nextChar = text[withoutEllipsis.length];
+    expect(nextChar === ' ' || nextChar === undefined).toBe(true);
+    expect(result.endsWith('…')).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(61);
+  });
+
+  it('falls back to a hard cut when the maxLength falls inside the first word', () => {
+    // No space within maxLength characters, so there is no word boundary to cut
+    // on — this preserves the pre-existing hard-cut behaviour for that edge case.
     const long = 'a'.repeat(200);
     const result = truncate(long, 160);
     expect(result.length).toBe(161);
     expect(result.endsWith('…')).toBe(true);
-  });
-
-  it('treats null as empty', () => {
-    expect(truncate(null, 160)).toBe('');
   });
 });
 

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -89,27 +89,38 @@ describe('renderPlanningPage', () => {
     expect(html).toContain('"@type":"ItemList"');
   });
 
-  it('renders each application address, status label, Last updated date and links', () => {
+  it('renders each application address as the headline, status label and Last updated date', () => {
     const html = renderPlanningPage(pageData());
-    expect(html).toContain('12 Mill Road, Basingstoke, RG21 1AA');
+    expect(html).toContain(
+      '<h3 class="appCard__address">12 Mill Road, Basingstoke, RG21 1AA</h3>',
+    );
     expect(html).toContain('Erection of two-storey rear extension');
     expect(html).toContain('Granted'); // Permitted -> Granted
     expect(html).toContain('Refused'); // Rejected -> Refused
     // The visible card date is the lastDifferent date, labelled "Last updated".
     expect(html).toContain('Last updated 12 Jun 2026');
-    expect(html).toContain(
-      'https://www.basingstoke.gov.uk/planning/26-0001-FUL',
-    );
-    expect(html).toContain('https://planit.org.uk/planapplic/26-0001-FUL');
   });
 
-  it('links each application heading to its share page using the authority slug and ref', () => {
+  it('demotes the reference to small card metadata and removes per-card external links (decisions 5 & 6)', () => {
     const html = renderPlanningPage(pageData());
-    // The reference heading is the share link; app.name (26/0001/FUL) is the ref,
-    // slashes kept as separators.
-    expect(html).toContain(
-      '<h3 class="appCard__ref"><a class="appCard__refLink" href="https://share.towncrierapp.uk/a/basingstoke-and-deane/26/0001/FUL">26/0001/FUL</a></h3>',
+    expect(html).toContain('<p class="appCard__ref">26/0001/FUL</p>');
+    expect(html).not.toContain('<h3 class="appCard__ref">');
+    // The per-card PlanIt/council links are gone (decision 6) — official-record
+    // links now live on the share page only.
+    expect(html).not.toContain(
+      'https://www.basingstoke.gov.uk/planning/26-0001-FUL',
     );
+    expect(html).not.toContain('https://planit.org.uk/planapplic/26-0001-FUL');
+    expect(html).not.toContain('class="appLink"');
+  });
+
+  it('makes the whole card a real anchor to its share page, with a visible "View details" affordance', () => {
+    const html = renderPlanningPage(pageData());
+    // app.name (26/0001/FUL) is the ref, slashes kept as separators.
+    expect(html).toContain(
+      '<a class="appCard__link" href="https://share.towncrierapp.uk/a/basingstoke-and-deane/26/0001/FUL">',
+    );
+    expect(html).toContain('<span class="appCard__cta">View details →</span>');
     // The share page is the item URL in the ItemList structured data too.
     expect(html).toContain(
       '"url":"https://share.towncrierapp.uk/a/basingstoke-and-deane/26/0001/FUL"',

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -34,97 +34,80 @@ function application(overrides = {}) {
   };
 }
 
-/**
- * Extract the caption (anchor text) for the `appLink` whose href matches `href`.
- *
- * @param {string} html
- * @param {string} href
- * @returns {string | null}
- */
-function captionForHref(html, href) {
-  const escaped = href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = html.match(
-    new RegExp(`<a class="appLink" href="${escaped}"[^>]*>([^<]*)</a>`),
-  );
-  return match ? match[1] : null;
-}
-
-describe('renderApplicationsList per-application links', () => {
-  it('captions the PlanIt permalink and the council website honestly when both are present', () => {
-    const html = renderApplicationsList([application()]);
-
-    // The PlanIt permalink (app.link) is captioned for PlanIt.
-    expect(captionForHref(html, PLANIT_HREF)).toBe(PLANIT_CAPTION);
-    // The council website (app.url) is captioned for the council site.
-    expect(captionForHref(html, COUNCIL_HREF)).toBe(COUNCIL_CAPTION);
-
-    // And the now-retired dishonest captions are gone.
-    expect(html).not.toContain('View on the council portal');
-    expect(html).not.toContain('Application details');
+describe('renderApplicationsList card structure (decision 5: address is the human hook)', () => {
+  it('renders the address as the <h3> headline', () => {
+    const html = renderApplicationsList([application()], SLUG);
+    expect(html).toContain(
+      '<h3 class="appCard__address">12 Mill Road, Basingstoke, RG21 1AA</h3>',
+    );
   });
 
-  it('emits only the PlanIt caption when only link is present', () => {
-    const html = renderApplicationsList([application({ url: null })]);
-
-    expect(html).toContain(PLANIT_CAPTION);
-    expect(captionForHref(html, PLANIT_HREF)).toBe(PLANIT_CAPTION);
-    expect(html).not.toContain(COUNCIL_CAPTION);
+  it('demotes the council reference to small metadata text, not a heading', () => {
+    const html = renderApplicationsList([application()], SLUG);
+    expect(html).toContain('<p class="appCard__ref">26/0001/FUL</p>');
+    expect(html).not.toContain('<h3 class="appCard__ref">');
+    expect(html).not.toContain('appCard__refLink');
   });
 
-  it('emits only the council caption when only url is present', () => {
-    const html = renderApplicationsList([application({ link: null })]);
-
-    expect(html).toContain(COUNCIL_CAPTION);
-    expect(captionForHref(html, COUNCIL_HREF)).toBe(COUNCIL_CAPTION);
-    expect(html).not.toContain(PLANIT_CAPTION);
+  it('omits the reference metadata line entirely when the app carries no ref', () => {
+    const html = renderApplicationsList([application({ name: '' })], SLUG);
+    expect(html).not.toContain('appCard__ref');
   });
 
-  it('emits no appLink anchors when neither link nor url is present', () => {
-    const html = renderApplicationsList([
-      application({ link: null, url: null }),
-    ]);
-
-    expect(html).not.toContain('class="appLink"');
-    expect(html).not.toContain(PLANIT_CAPTION);
-    expect(html).not.toContain(COUNCIL_CAPTION);
-  });
-
-  it('keeps the link safety attributes on the external anchors', () => {
-    const html = renderApplicationsList([application()]);
-    const anchors = html.match(/<a class="appLink"[^>]*>/g) ?? [];
-    expect(anchors).toHaveLength(2);
-    for (const anchor of anchors) {
-      expect(anchor).toContain('rel="nofollow noopener"');
-      expect(anchor).toContain('target="_blank"');
-    }
+  it('HTML-escapes the address', () => {
+    const html = renderApplicationsList(
+      [application({ address: '<script>alert(1)</script>' })],
+      SLUG,
+    );
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
   });
 });
 
-describe('renderApplicationsList share links', () => {
-  it('links the reference heading to the share page built from the slug and ref', () => {
+describe('renderApplicationsList description truncation (word boundary)', () => {
+  it('truncates a long description on a word boundary with an ellipsis, never mid-word', () => {
+    const longDescription =
+      'Erection of a two-storey rear extension and associated landscaping works to an existing dwelling house with a new detached garage and altered vehicular access from the existing driveway';
+    const html = renderApplicationsList(
+      [application({ description: longDescription })],
+      SLUG,
+    );
+    const match = html.match(/<p class="appCard__desc">([^<]*)<\/p>/);
+    expect(match).not.toBeNull();
+    const rendered = match[1];
+    expect(rendered.endsWith('…')).toBe(true);
+    const withoutEllipsis = rendered.slice(0, -1);
+    expect(longDescription.startsWith(withoutEllipsis)).toBe(true);
+    // No trailing space before the ellipsis, and the next source character is a
+    // space (or end of string) — proof the cut landed on a word boundary.
+    expect(withoutEllipsis.endsWith(' ')).toBe(false);
+    const nextChar = longDescription[withoutEllipsis.length];
+    expect(nextChar === ' ' || nextChar === undefined).toBe(true);
+  });
+
+  it('leaves a short description unchanged with no ellipsis', () => {
     const html = renderApplicationsList([application()], SLUG);
-    // The <h3> reference heading itself is the share link; the ref (app.name /
-    // planit_name) is used verbatim in the URL, slashes preserved.
     expect(html).toContain(
-      `<h3 class="appCard__ref"><a class="appCard__refLink" href="${SHARE_HREF}">26/0001/FUL</a></h3>`,
+      '<p class="appCard__desc">Erection of two-storey rear extension</p>',
     );
   });
+});
 
-  it('makes the heading link do-follow and same-tab (an internal Town Crier page)', () => {
+describe('renderApplicationsList share-page affordance (decision 6)', () => {
+  it('wraps the whole card in a real anchor pointing at the share page', () => {
     const html = renderApplicationsList([application()], SLUG);
-    const anchor = html.match(
-      new RegExp(`<a class="appCard__refLink" href="${SHARE_HREF.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}"[^>]*>`),
-    );
-    expect(anchor).not.toBeNull();
-    expect(anchor[0]).not.toContain('nofollow');
-    expect(anchor[0]).not.toContain('target="_blank"');
+    expect(html).toContain(`<a class="appCard__link" href="${SHARE_HREF}">`);
   });
 
-  it('leaves the meta row with only the two external links (no third action link)', () => {
+  it('includes a visible "View details" affordance inside the card link', () => {
     const html = renderApplicationsList([application()], SLUG);
-    const anchors = html.match(/<a class="appLink"[^>]*>/g) ?? [];
-    expect(anchors).toHaveLength(2);
-    expect(html).not.toContain('View on Town Crier');
+    expect(html).toContain('<span class="appCard__cta">View details →</span>');
+  });
+
+  it('never relies on a JS-only click handler for the share-page target', () => {
+    const html = renderApplicationsList([application()], SLUG);
+    expect(html).not.toContain('onclick');
+    expect(html).toContain(`href="${SHARE_HREF}"`);
   });
 
   it('percent-encodes unsafe ref characters per segment while preserving slashes', () => {
@@ -137,17 +120,95 @@ describe('renderApplicationsList share links', () => {
     );
   });
 
-  it('renders the reference as plain heading text when no slug is supplied', () => {
+  it('falls back to a non-linked card when no share URL can be built (no slug supplied)', () => {
     const html = renderApplicationsList([application()]);
-    expect(html).toContain('<h3 class="appCard__ref">26/0001/FUL</h3>');
+    expect(html).not.toContain('appCard__link');
+    expect(html).not.toContain('View details');
     expect(html).not.toContain('share.towncrierapp.uk');
-    expect(html).not.toContain('appCard__refLink');
   });
 
-  it('renders a plain heading when the app carries no ref', () => {
+  it('falls back to a non-linked card when the app carries no ref', () => {
     const html = renderApplicationsList([application({ name: '' })], SLUG);
+    expect(html).not.toContain('appCard__link');
+    expect(html).not.toContain('View details');
     expect(html).not.toContain('share.towncrierapp.uk');
-    expect(html).not.toContain('appCard__refLink');
+  });
+});
+
+describe('renderApplicationsList external link removal (decision 6)', () => {
+  it('renders no per-card links to PlanIt or the council website', () => {
+    const html = renderApplicationsList([application()], SLUG);
+    expect(html).not.toContain(PLANIT_CAPTION);
+    expect(html).not.toContain(COUNCIL_CAPTION);
+    expect(html).not.toContain(PLANIT_HREF);
+    expect(html).not.toContain(COUNCIL_HREF);
+    expect(html).not.toContain('class="appLink"');
+  });
+
+  it('renders no external links even when the app carries neither link nor url', () => {
+    const html = renderApplicationsList(
+      [application({ link: null, url: null })],
+      SLUG,
+    );
+    expect(html).not.toContain('class="appLink"');
+  });
+});
+
+describe('renderApplicationsList status chip vocabulary (decision 4: shared vocabulary)', () => {
+  it('colours a Granted (Permitted) application with the granted chip', () => {
+    const html = renderApplicationsList(
+      [application({ appState: 'Permitted' })],
+      SLUG,
+    );
+    expect(html).toContain('class="status status--granted"');
+    expect(html).toContain('>Granted<');
+  });
+
+  it('colours a Refused (Rejected) application with the refused chip', () => {
+    const html = renderApplicationsList(
+      [application({ appState: 'Rejected' })],
+      SLUG,
+    );
+    expect(html).toContain('class="status status--refused"');
+    expect(html).toContain('>Refused<');
+  });
+
+  it.each([
+    ['Conditions', 'Granted with conditions'],
+    ['Withdrawn', 'Withdrawn'],
+    ['Appealed', 'Appealed'],
+    ['Undecided', 'Undecided'],
+    [null, 'Unknown'],
+  ])(
+    'buckets the long-tail / undecided state %s under the shared neutral chip',
+    (appState, label) => {
+      const html = renderApplicationsList(
+        [application({ appState })],
+        SLUG,
+      );
+      expect(html).toContain('class="status status--neutral"');
+      expect(html).toContain(`>${label}<`);
+    },
+  );
+
+  it('only ever emits the three canonical chip modifiers, never the old per-state ones', () => {
+    const states = [
+      'Permitted',
+      'Rejected',
+      'Conditions',
+      'Withdrawn',
+      'Appealed',
+      null,
+      'SomeFutureState',
+    ];
+    const html = renderApplicationsList(
+      states.map((appState) => application({ appState })),
+      SLUG,
+    );
+    const modifiers = [...html.matchAll(/class="status status--(\w+)"/g)].map(
+      (m) => m[1],
+    );
+    expect(new Set(modifiers)).toEqual(new Set(['granted', 'refused', 'neutral']));
   });
 });
 
@@ -172,13 +233,18 @@ describe('renderAttributionList', () => {
   });
 });
 
-describe('pageStyles appCard__refLink', () => {
-  it('styles the heading link to inherit the heading colour and reveal amber on hover', () => {
+describe('pageStyles appCard__link (whole-card share-page affordance)', () => {
+  it('styles the whole-card link to inherit colour with no underline', () => {
     const css = pageStyles();
-    expect(css).toContain('.appCard__refLink');
-    // Neutral by default (inherits the heading colour), amber on hover.
-    expect(css).toMatch(/\.appCard__refLink \{[^}]*color: inherit/);
-    expect(css).toMatch(/\.appCard__refLink:hover \{[^}]*var\(--tc-amber\)/);
+    expect(css).toContain('.appCard__link');
+    expect(css).toMatch(/\.appCard__link \{[^}]*color: inherit/);
+    expect(css).toMatch(/\.appCard__link \{[^}]*text-decoration: none/);
+  });
+
+  it('styles the "View details" affordance in the amber accent colour', () => {
+    const css = pageStyles();
+    expect(css).toContain('.appCard__cta');
+    expect(css).toMatch(/\.appCard__cta \{[^}]*var\(--tc-amber\)/);
   });
 });
 
@@ -189,6 +255,75 @@ describe('pageStyles townLinks', () => {
     expect(css).toContain('.townLinks__list a');
     // Uses design tokens (var(--tc-*)), never hard-coded colours/spacing.
     expect(css).toMatch(/\.townLinks__list a \{[^}]*var\(--tc-/);
+  });
+});
+
+describe('pageStyles status chip vocabulary (decision 4: shared palette, filled style)', () => {
+  /**
+   * @param {string} css
+   * @returns {string} the declarations inside the top-level `:root { ... }`
+   *   block (i.e. NOT the one nested inside a @media query).
+   */
+  function rootDeclarations(css) {
+    const match = css.match(/^\s*:root \{([^}]*)\}/m);
+    return match ? match[1] : '';
+  }
+
+  /**
+   * @param {string} css
+   * @returns {string} the declarations inside `:root { ... }` nested within
+   *   `@media (prefers-color-scheme: dark)`.
+   */
+  function darkMediaDeclarations(css) {
+    const match = css.match(
+      /@media \(prefers-color-scheme: dark\) \{\s*:root \{([^}]*)\}/,
+    );
+    return match ? match[1] : '';
+  }
+
+  it('defines the three canonical status colour tokens, light-first, plus their fill backgrounds', () => {
+    const root = rootDeclarations(pageStyles());
+    expect(root).toMatch(/--tc-status-granted: #1A7D37;/);
+    expect(root).toMatch(/--tc-status-refused: #C42B2B;/);
+    expect(root).toMatch(/--tc-status-neutral: #6B6560;/);
+    expect(root).toMatch(/--tc-status-granted-bg:/);
+    expect(root).toMatch(/--tc-status-refused-bg:/);
+    expect(root).toMatch(/--tc-status-neutral-bg:/);
+  });
+
+  it('moves the dark variants of the status tokens into the dark media query', () => {
+    const dark = darkMediaDeclarations(pageStyles());
+    expect(dark).toMatch(/--tc-status-granted: #34C759;/);
+    expect(dark).toMatch(/--tc-status-refused: #FF453A;/);
+    expect(dark).toMatch(/--tc-status-neutral: #9B9590;/);
+  });
+
+  it('no longer defines the old ad-hoc per-state status tokens', () => {
+    const css = pageStyles();
+    expect(css).not.toContain('--tc-status-permitted');
+    expect(css).not.toContain('--tc-status-conditions');
+    expect(css).not.toContain('--tc-status-rejected');
+    expect(css).not.toContain('--tc-status-withdrawn');
+    expect(css).not.toContain('--tc-status-appealed');
+    expect(css).not.toContain('--tc-status-default');
+  });
+
+  it('styles each chip as a filled badge (background fill + full-opacity text) per design-language, not outlined', () => {
+    const css = pageStyles();
+    expect(css).toMatch(
+      /\.status--granted \{[^}]*background: var\(--tc-status-granted-bg\)/,
+    );
+    expect(css).toMatch(
+      /\.status--granted \{[^}]*color: var\(--tc-status-granted\)/,
+    );
+    expect(css).toMatch(
+      /\.status--refused \{[^}]*background: var\(--tc-status-refused-bg\)/,
+    );
+    expect(css).toMatch(
+      /\.status--neutral \{[^}]*background: var\(--tc-status-neutral-bg\)/,
+    );
+    // The base .status rule no longer draws the old outlined-chip border.
+    expect(css).not.toMatch(/\.status \{[^}]*border: 1px solid currentColor/);
   });
 });
 
@@ -224,12 +359,6 @@ describe('pageStyles light-first token flip (tc-r4n9.1)', () => {
     expect(root).toMatch(/--tc-text-primary: #1C1917;/);
     expect(root).toMatch(/--tc-text-secondary: #6B6560;/);
     expect(root).toMatch(/--tc-text-on-accent: #FFFFFF;/);
-    expect(root).toMatch(/--tc-status-permitted: #1A7D37;/);
-    expect(root).toMatch(/--tc-status-conditions: #A85A0A;/);
-    expect(root).toMatch(/--tc-status-rejected: #C42B2B;/);
-    expect(root).toMatch(/--tc-status-withdrawn: #7A7570;/);
-    expect(root).toMatch(/--tc-status-appealed: #7C3AED;/);
-    expect(root).toMatch(/--tc-status-default: #6B6560;/);
     expect(root).toMatch(/--tc-border: #E8E4DF;/);
   });
 
@@ -242,12 +371,6 @@ describe('pageStyles light-first token flip (tc-r4n9.1)', () => {
     expect(dark).toMatch(/--tc-text-primary: #F1EFE9;/);
     expect(dark).toMatch(/--tc-text-secondary: #9B9590;/);
     expect(dark).toMatch(/--tc-text-on-accent: #1C1917;/);
-    expect(dark).toMatch(/--tc-status-permitted: #34C759;/);
-    expect(dark).toMatch(/--tc-status-conditions: #FF9500;/);
-    expect(dark).toMatch(/--tc-status-rejected: #FF453A;/);
-    expect(dark).toMatch(/--tc-status-withdrawn: #8E8A85;/);
-    expect(dark).toMatch(/--tc-status-appealed: #A78BFA;/);
-    expect(dark).toMatch(/--tc-status-default: #9B9590;/);
     expect(dark).toMatch(/--tc-border: #3A3A3F;/);
   });
 

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -97,25 +97,35 @@ describe('renderTownPage', () => {
     expect(html).toMatch(/breadcrumb[\s\S]*?Cornwall/);
   });
 
-  it('renders each application address, status label, Last updated date and links', () => {
+  it('renders each application address as the headline, status label and Last updated date', () => {
     const html = renderTownPage(townData());
-    expect(html).toContain('Lemon Quay, Truro, TR1 2LW');
+    expect(html).toContain(
+      '<h3 class="appCard__address">Lemon Quay, Truro, TR1 2LW</h3>',
+    );
     expect(html).toContain('Change of use of ground floor from retail to café');
     expect(html).toContain('Granted'); // Permitted -> Granted
     expect(html).toContain('Refused'); // Rejected -> Refused
     // The visible card date is the lastDifferent date, labelled "Last updated".
     expect(html).toContain('Last updated 12 Jun 2026');
-    expect(html).toContain('https://planning.cornwall.gov.uk/26-0001');
-    expect(html).toContain('https://planit.org.uk/planapplic/CW-26-0001');
   });
 
-  it('links each application heading to its share page using the parent authority slug and ref', () => {
+  it('demotes the reference to small card metadata and removes per-card external links (decisions 5 & 6)', () => {
+    const html = renderTownPage(townData());
+    expect(html).toContain('<p class="appCard__ref">26/0001</p>');
+    expect(html).not.toContain('<h3 class="appCard__ref">');
+    expect(html).not.toContain('https://planning.cornwall.gov.uk/26-0001');
+    expect(html).not.toContain('https://planit.org.uk/planapplic/CW-26-0001');
+    expect(html).not.toContain('class="appLink"');
+  });
+
+  it('makes the whole card a real anchor to its share page, with a visible "View details" affordance', () => {
     const html = renderTownPage(townData());
     // Town-page apps are scoped to the town's own authority, so authoritySlug is
-    // correct for every card; the reference heading is the share link.
+    // correct for every card.
     expect(html).toContain(
-      '<h3 class="appCard__ref"><a class="appCard__refLink" href="https://share.towncrierapp.uk/a/cornwall/26/0001">26/0001</a></h3>',
+      '<a class="appCard__link" href="https://share.towncrierapp.uk/a/cornwall/26/0001">',
     );
+    expect(html).toContain('<span class="appCard__cta">View details →</span>');
     expect(html).toContain(
       '"url":"https://share.towncrierapp.uk/a/cornwall/26/0001"',
     );

--- a/web/scripts/lib/format.mjs
+++ b/web/scripts/lib/format.mjs
@@ -24,8 +24,11 @@ export function escapeHtml(value) {
 }
 
 /**
- * Truncate text to `maxLength` characters, appending a single ellipsis when
- * cut. Null/undefined coerce to an empty string.
+ * Truncate text to at most `maxLength` characters, cutting on the last word
+ * boundary within that limit so the result never ends mid-word, then
+ * appending a single ellipsis. Falls back to a hard cut at `maxLength` when no
+ * space exists within the limit (e.g. a single word longer than `maxLength`).
+ * Null/undefined coerce to an empty string.
  *
  * @param {string | null | undefined} text
  * @param {number} maxLength
@@ -38,7 +41,10 @@ export function truncate(text, maxLength) {
   if (text.length <= maxLength) {
     return text;
   }
-  return text.slice(0, maxLength) + '…';
+  const cut = text.slice(0, maxLength);
+  const lastSpace = cut.lastIndexOf(' ');
+  const boundary = lastSpace > 0 ? cut.slice(0, lastSpace) : cut;
+  return boundary + '…';
 }
 
 /**

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -27,8 +27,10 @@ import {
  * @property {string | null} appState
  * @property {string | null} startDate      yyyy-MM-dd
  * @property {string} lastDifferent         ISO-8601 with offset; the DESC sort key
- * @property {string | null} link           PlanIt permalink (always a reliable per-application record)
- * @property {string | null} url            council website (may be a generic portal page, not always a per-application deep link)
+ * @property {string | null} link           PlanIt permalink (always a reliable per-application record). No longer rendered
+ *   as a per-card link (decision 6); kept only as a JSON-LD `url` fallback when no share URL can be built.
+ * @property {string | null} url            council website (may be a generic portal page, not always a per-application deep link). No longer
+ *   rendered as a per-card link (decision 6); kept only as a JSON-LD `url` fallback when no share URL can be built.
  */
 
 const MAX_DESCRIPTION_LENGTH = 160;
@@ -120,8 +122,9 @@ ${body}
  *
  * @param {PlanningApplicationItem[]} applications
  * @param {string} [authoritySlug] the page's authority slug, threaded through so
- *   each card can link to its share page. Omitted -> no share links (the external
- *   PlanIt/council links still render).
+ *   each card can link to its share page. Omitted (or no ref on the app) -> the
+ *   card renders without a link at all (decision 6 retired the external
+ *   PlanIt/council per-card links, so there is no other href to fall back to).
  * @returns {string}
  */
 export function renderApplicationsList(applications, authoritySlug) {

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -33,78 +33,85 @@ import {
 
 const MAX_DESCRIPTION_LENGTH = 160;
 
-const STATUS_MODIFIER = {
-  Permitted: 'permitted',
-  Conditions: 'conditions',
-  Rejected: 'rejected',
-  Withdrawn: 'withdrawn',
-  Appealed: 'appealed',
+/**
+ * Shared status→colour vocabulary (decision 4, punch-list #794): only three
+ * chip buckets across the SEO and share-page families. `Permitted` reads as
+ * "granted" (green) and `Rejected` as "refused" (red); every other state —
+ * the long tail (`Conditions`/"Granted with conditions", `Withdrawn`,
+ * `Appealed`), a genuinely undecided wire state, an unrecognised future state,
+ * or no state at all — buckets under the shared neutral chip. The resident-
+ * facing *label* text is unaffected (still `statusDisplayLabel`); this only
+ * consolidates which of the three canonical *colours* a state renders in.
+ * @type {Record<string, 'granted' | 'refused'>}
+ */
+const STATUS_COLOR_MODIFIER = {
+  Permitted: 'granted',
+  Rejected: 'refused',
 };
 
 /**
- * @param {string | null} appState
- * @returns {string}
+ * @param {string | null | undefined} appState
+ * @returns {'granted' | 'refused' | 'neutral'}
  */
-function statusModifier(appState) {
+function statusColorModifier(appState) {
   if (appState === null || appState === undefined) {
-    return 'default';
+    return 'neutral';
   }
-  return STATUS_MODIFIER[appState] ?? 'default';
+  return STATUS_COLOR_MODIFIER[appState] ?? 'neutral';
 }
 
 /**
  * @param {PlanningApplicationItem} app
- * @param {string} [authoritySlug] the page's authority slug; when present (and the
- *   app carries a ref), the card's reference heading becomes a do-follow link to
- *   our own public share page for the application. Every application on a page
- *   belongs to this one authority (authority pages read one partition; town pages
- *   scope the near query to a single authority), so the slug is correct for every
- *   card.
+ * @param {string} [authoritySlug] the page's authority slug; when present (and
+ *   the app carries a ref), the whole card becomes a do-follow link to our own
+ *   public share page for the application (decision 6). Every application on a
+ *   page belongs to this one authority (authority pages read one partition;
+ *   town pages scope the near query to a single authority), so the slug is
+ *   correct for every card.
  * @returns {string}
  */
 function renderApplication(app, authoritySlug) {
   const label = escapeHtml(statusDisplayLabel(app.appState));
-  const modifier = statusModifier(app.appState);
+  const modifier = statusColorModifier(app.appState);
   // The visible date is lastDifferent (the bounded read's DESC sort key), so the
   // dates read top-to-bottom in the same order the cards are listed.
   const date = formatDate(app.lastDifferent);
   const description = escapeHtml(truncate(app.description, MAX_DESCRIPTION_LENGTH));
 
-  // The reference heading is the card's title and doubles as the link to our own
-  // share page for the application — a do-follow, same-tab internal link we want
-  // crawled and clicked. It stays plain text when the page has no authority slug
-  // or the app carries no ref. The external PlanIt/council links stay in the meta
-  // row; keeping our link on the title (not a third meta link) avoids a lopsided,
-  // wrapping action row.
+  // Address is the human hook (decision 5): it is the card's heading. The
+  // council reference is demoted to small metadata underneath, and omitted
+  // entirely when the app carries none.
+  const address = escapeHtml(app.address);
   const ref = escapeHtml(app.name);
+
+  // Per-card external links to PlanIt/the council are retired (decision 6):
+  // the card's one click target is our own share page, surfaced as a real,
+  // crawlable <a href> around the whole card plus a visible "View details"
+  // affordance — never a JS-only click handler. Falls back to a plain,
+  // non-linked card when no share URL can be built (no slug, or no ref).
   const share = shareUrl(authoritySlug, app.name);
-  const heading = share
-    ? `<a class="appCard__refLink" href="${escapeHtml(share)}">${ref}</a>`
-    : ref;
 
-  const links = [];
-  if (app.link) {
-    links.push(
-      `<a class="appLink" href="${escapeHtml(app.link)}" rel="nofollow noopener" target="_blank">View full record on PlanIt</a>`,
-    );
-  }
-  if (app.url) {
-    links.push(
-      `<a class="appLink" href="${escapeHtml(app.url)}" rel="nofollow noopener" target="_blank">View on the council website</a>`,
-    );
-  }
-
-  return `      <li class="appCard">
-        <div class="appCard__head">
-          <h3 class="appCard__ref">${heading}</h3>
+  const body = `        <div class="appCard__head">
+          <h3 class="appCard__address">${address}</h3>
           <span class="status status--${modifier}">${label}</span>
         </div>
-        <p class="appCard__address">${escapeHtml(app.address)}</p>
+        ${ref ? `<p class="appCard__ref">${ref}</p>` : ''}
         <p class="appCard__desc">${description}</p>
         <div class="appCard__meta">
           ${date ? `<span class="appCard__date">Last updated ${escapeHtml(date)}</span>` : ''}
-          ${links.join('\n          ')}
-        </div>
+          ${share ? `<span class="appCard__cta">View details →</span>` : ''}
+        </div>`;
+
+  if (share) {
+    return `      <li class="appCard">
+        <a class="appCard__link" href="${escapeHtml(share)}">
+${body}
+        </a>
+      </li>`;
+  }
+
+  return `      <li class="appCard">
+${body}
       </li>`;
 }
 
@@ -185,12 +192,18 @@ export function pageStyles() {
       --tc-text-primary: #1C1917;
       --tc-text-secondary: #6B6560;
       --tc-text-on-accent: #FFFFFF;
-      --tc-status-permitted: #1A7D37;
-      --tc-status-conditions: #A85A0A;
-      --tc-status-rejected: #C42B2B;
-      --tc-status-withdrawn: #7A7570;
-      --tc-status-appealed: #7C3AED;
-      --tc-status-default: #6B6560;
+      /* Shared status chip vocabulary (decision 4, punch-list #794): three
+         canonical buckets — granted (green), refused (red), neutral (the
+         undecided/long-tail catch-all) — converged with the design-language
+         tcStatusApproved/tcStatusRefused/tcTextSecondary tokens, replacing the
+         previous five-way ad-hoc per-appState palette. The *-bg tokens are the
+         foreground colour at 15% opacity, for the filled badge style. */
+      --tc-status-granted: #1A7D37;
+      --tc-status-granted-bg: #1A7D3726;
+      --tc-status-refused: #C42B2B;
+      --tc-status-refused-bg: #C42B2B26;
+      --tc-status-neutral: #6B6560;
+      --tc-status-neutral-bg: #6B656026;
       --tc-border: #E8E4DF;
       --tc-radius-md: 12px;
       --tc-radius-full: 9999px;
@@ -211,12 +224,12 @@ export function pageStyles() {
         --tc-text-primary: #F1EFE9;
         --tc-text-secondary: #9B9590;
         --tc-text-on-accent: #1C1917;
-        --tc-status-permitted: #34C759;
-        --tc-status-conditions: #FF9500;
-        --tc-status-rejected: #FF453A;
-        --tc-status-withdrawn: #8E8A85;
-        --tc-status-appealed: #A78BFA;
-        --tc-status-default: #9B9590;
+        --tc-status-granted: #34C759;
+        --tc-status-granted-bg: #34C75926;
+        --tc-status-refused: #FF453A;
+        --tc-status-refused-bg: #FF453A26;
+        --tc-status-neutral: #9B9590;
+        --tc-status-neutral-bg: #9B959026;
         --tc-border: #3A3A3F;
       }
     }
@@ -276,16 +289,28 @@ export function pageStyles() {
       border-radius: var(--tc-radius-md);
       padding: var(--tc-space-md);
     }
+    /* The whole card is the share-page click target (decision 6): a real,
+       crawlable <a href> wraps every card that has a share URL, styled to
+       read as plain card content rather than a traditional blue link. */
+    .appCard__link { display: block; color: inherit; text-decoration: none; }
+    .appCard__link:focus-visible {
+      outline: 2px solid var(--tc-amber);
+      outline-offset: 2px;
+      border-radius: var(--tc-radius-md);
+    }
+    .appCard__link:hover .appCard__address { color: var(--tc-amber); }
+    .appCard__link:hover .appCard__cta { color: var(--tc-amber-hover); text-decoration: underline; }
     .appCard__head { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--tc-space-sm); }
-    .appCard__ref { overflow-wrap: anywhere; }
-    .appCard__refLink { color: inherit; text-decoration: none; }
-    .appCard__refLink:hover { color: var(--tc-amber); text-decoration: underline; }
-    .appCard__address { margin: var(--tc-space-sm) 0 var(--tc-space-sm); font-weight: 600; }
+    /* Address is the human hook (decision 5): the card headline. */
+    .appCard__address { margin: 0; font-weight: 600; overflow-wrap: anywhere; }
+    /* The council reference is demoted to small metadata under the headline. */
+    .appCard__ref { margin: var(--tc-space-sm) 0; font-size: 0.8125rem; color: var(--tc-text-secondary); overflow-wrap: anywhere; }
     .appCard__desc { margin: 0 0 var(--tc-space-sm); color: var(--tc-text-secondary); }
     .appCard__meta { display: flex; flex-wrap: wrap; gap: var(--tc-space-md); align-items: center; font-size: 0.875rem; }
     .appCard__date { color: var(--tc-text-secondary); }
-    .appLink { color: var(--tc-amber); text-decoration: none; font-weight: 600; }
-    .appLink:hover { color: var(--tc-amber-hover); text-decoration: underline; }
+    /* Visible share-page affordance (decision 6) — a real anchor, not a
+       JS-only click handler; this is the text cue, the href is the whole card. */
+    .appCard__cta { color: var(--tc-amber); font-weight: 600; }
     .status {
       display: inline-flex;
       align-items: center;
@@ -294,14 +319,13 @@ export function pageStyles() {
       font-size: 0.8125rem;
       font-weight: 600;
       white-space: nowrap;
-      color: var(--tc-status-default);
-      border: 1px solid currentColor;
     }
-    .status--permitted { color: var(--tc-status-permitted); }
-    .status--conditions { color: var(--tc-status-conditions); }
-    .status--rejected { color: var(--tc-status-rejected); }
-    .status--withdrawn { color: var(--tc-status-withdrawn); }
-    .status--appealed { color: var(--tc-status-appealed); }
+    /* Shared filled-chip vocabulary (decision 4): three canonical buckets,
+       background = foreground colour at 15% opacity, converged with the
+       design-language Status Badge pattern. */
+    .status--granted { color: var(--tc-status-granted); background: var(--tc-status-granted-bg); }
+    .status--refused { color: var(--tc-status-refused); background: var(--tc-status-refused-bg); }
+    .status--neutral { color: var(--tc-status-neutral); background: var(--tc-status-neutral-bg); }
     .statRow { display: flex; justify-content: space-between; background: var(--tc-surface); border: 1px solid var(--tc-border); border-radius: var(--tc-radius-md); padding: var(--tc-space-sm) var(--tc-space-md); }
     .statRow__count { font-weight: 700; }
     .townLinks__list { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: var(--tc-space-sm); }


### PR DESCRIPTION
## Changes
- Card markup: address is now the headline; council reference demoted to small metadata; whole card wraps in a real crawlable anchor to the share page with a visible "View details →" affordance.
- Per-card external PlanIt/council links removed (kept only as JSON-LD structured-data `url` fallback, not a rendered link).
- Status chips converged to the shared 3-bucket vocabulary (Granted→green, Refused→red, everything else incl. Undecided/Conditions/Withdrawn/Appealed→neutral), filled chip style matching design-language's Status Badge pattern.
- Description truncation now cuts on a word boundary + ellipsis instead of mid-word.

Part of the design-review punch list (#794), Phase 2 of 7. Closes tc-r4n9.2.

## Test plan
- `npx tsc --noEmit` clean, `npm run build` clean, `npx vitest run` — 977/977 (full suite)
- Visual verification via agent-browser: authority + town pages, light/dark, desktop (1280x1000) + mobile (390x844). Confirmed each card is a single crawlable link to the correct share-page URL, address renders as an h3, truncation ends cleanly at a word boundary, zero external planit.org.uk/council links remain on the page, visible keyboard-focus outline on cards, and chip colours read correctly and consistently in both themes.

---
*Auto-shipped via ship skill*