### PR TITLE
fix(sharepage): postcode dedup, type label, key-dates, backlink, chip mapping (tc-r4n9.6)

### DIFF
--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -144,9 +144,14 @@ func TestServe_KnownApplication_RendersMetaAndVisibleContent(t *testing.T) {
 		"10 Downing Street, London",
 		"CR0 1AB",
 		"23/03456/FUL",
-		"Full planning permission", // AppType, rendered in the reference row
 		"Erection of a two-storey rear extension.",
-		"Under Consideration",
+		// Reference and application type each get their own explicit metadata row
+		// (tc-r4n9.6) — no longer squashed into a cryptic "Reference … · Type" line.
+		`<span class="meta-label">Reference</span><span class="meta-value">23/03456/FUL</span>`,
+		`<span class="meta-label">Type</span><span class="meta-value">Full planning permission</span>`,
+		// "Under Consideration" is not in the shared status vocabulary, so it passes
+		// through as its own label with the neutral colour bucket — never dropped.
+		`class="chip chip--neutral">Under Consideration</span>`,
 		// Key-dates timeline (doubles as status history): the heading and every
 		// row's LABEL and human-formatted VALUE. fullApp sets all three dates, so a
 		// missing timeline or a mis-formatted date is caught here.
@@ -164,6 +169,10 @@ func TestServe_KnownApplication_RendersMetaAndVisibleContent(t *testing.T) {
 		"Contains public sector information licensed under the Open Government Licence. Crown Copyright.",
 		"Contains Ordnance Survey data © Crown Copyright and database right.",
 		"Map data © OpenStreetMap contributors.",
+		// Authority backlink (tc-r4n9.6): points at the SEO planning page for the
+		// same authority, built from the identical Slugify-derived slug.
+		`href="https://towncrierapp.uk/planning/croydon"`,
+		"More planning applications in Croydon",
 		// Sticky CTA: short verb-first label + supporting sentence, plus the
 		// campaign-tagged App Store URL.
 		"Get the app",

--- a/api-go/internal/sharepage/templates/page.gohtml
+++ b/api-go/internal/sharepage/templates/page.gohtml
@@ -27,7 +27,10 @@
 <main class="page">
 <img class="hero" src="{{.OGImage}}" alt="Map showing the approximate location of {{if .Address}}{{.Address}}{{else}}this planning application{{end}}" width="1200" height="630" loading="eager">
 <article class="card">
-<div class="ref-row">Reference {{.Ref}}{{if .AppType}} &middot; {{.AppType}}{{end}}</div>
+<div class="meta-list">
+<div class="meta-row"><span class="meta-label">Reference</span><span class="meta-value">{{.Ref}}</span></div>
+{{if .AppType}}<div class="meta-row"><span class="meta-label">Type</span><span class="meta-value">{{.AppType}}</span></div>{{end}}
+</div>
 {{if .StatusLabel}}<span class="chip chip--{{.StatusModifier}}">{{.StatusLabel}}</span>{{end}}
 <h1 class="address">{{.Address}}{{if .Postcode}}, {{.Postcode}}{{end}}</h1>
 {{if .Description}}<h2>Proposal</h2><p class="proposal">{{.Description}}</p>{{end}}
@@ -47,6 +50,7 @@
 <p>Contains Ordnance Survey data © Crown Copyright and database right.</p>
 <p>Map data © OpenStreetMap contributors.</p>
 </footer>
+{{if .AuthorityURL}}<p class="authority-backlink"><a href="{{.AuthorityURL}}">More planning applications in {{.AuthorityName}} &rarr;</a></p>{{end}}
 </main>
 <div class="cta-bar">
 <a class="cta" href="{{.CTAHref}}">Get the app</a>

--- a/api-go/internal/sharepage/templates/page.gohtml
+++ b/api-go/internal/sharepage/templates/page.gohtml
@@ -28,7 +28,7 @@
 <img class="hero" src="{{.OGImage}}" alt="Map showing the approximate location of {{if .Address}}{{.Address}}{{else}}this planning application{{end}}" width="1200" height="630" loading="eager">
 <article class="card">
 <div class="ref-row">Reference {{.Ref}}{{if .AppType}} &middot; {{.AppType}}{{end}}</div>
-{{if .StatusChip}}<span class="chip">{{.StatusChip}}</span>{{end}}
+{{if .StatusLabel}}<span class="chip chip--{{.StatusModifier}}">{{.StatusLabel}}</span>{{end}}
 <h1 class="address">{{.Address}}{{if .Postcode}}, {{.Postcode}}{{end}}</h1>
 {{if .Description}}<h2>Proposal</h2><p class="proposal">{{.Description}}</p>{{end}}
 {{if .Dates}}<h2>Key dates</h2><ol class="timeline">{{range .Dates}}<li><span class="date-label">{{.Label}}</span><span class="date-value">{{.Value}}</span></li>{{end}}</ol>{{end}}

--- a/api-go/internal/sharepage/templates/styles.gohtml
+++ b/api-go/internal/sharepage/templates/styles.gohtml
@@ -5,12 +5,21 @@
   --text-on-accent:#FFFFFF;--amber-muted:rgba(212,145,10,0.15);
   --radius-sm:8px;--radius-md:12px;
   --space-xs:4px;--space-sm:8px;--space-md:16px;--space-lg:24px;--space-xl:32px;
+  /* Shared status vocabulary (tc-r4n9 decision 4): three colour buckets, not a
+     five-way traffic light — granted (green), refused (red), neutral for
+     "Undecided" and every long-tail state. Mirrors web/scripts/lib/render-shared.mjs. */
+  --status-granted:#1A7D37;--status-granted-bg:rgba(26,125,55,0.15);
+  --status-refused:#C42B2B;--status-refused-bg:rgba(196,43,43,0.15);
+  --status-neutral:#7A7570;--status-neutral-bg:rgba(122,117,112,0.15);
 }
 @media (prefers-color-scheme:dark){
   :root{
     --bg:#1A1A1E;--surface:#242428;--text-primary:#F1EFE9;--text-secondary:#9B9590;
     --text-tertiary:#5C5852;--border:#3A3A3F;--amber:#E9A620;--amber-hover:#F0B83A;
     --text-on-accent:#1C1917;--amber-muted:rgba(233,166,32,0.15);
+    --status-granted:#34C759;--status-granted-bg:rgba(52,199,89,0.15);
+    --status-refused:#FF453A;--status-refused-bg:rgba(255,69,58,0.15);
+    --status-neutral:#8E8A85;--status-neutral-bg:rgba(142,138,133,0.15);
   }
 }
 *{box-sizing:border-box;}
@@ -44,15 +53,20 @@ body{
   box-shadow:0 2px 8px rgba(0,0,0,0.05);
 }
 @media (prefers-color-scheme:dark){.card{box-shadow:none;}}
-.ref-row{
-  color:var(--text-secondary);font-size:14px;font-weight:500;
-  margin-bottom:var(--space-sm);
+.meta-list{margin-bottom:var(--space-sm);}
+.meta-row{
+  display:flex;gap:var(--space-xs);font-size:14px;
+  margin-bottom:2px;
 }
+.meta-label{color:var(--text-secondary);font-weight:500;}
+.meta-value{color:var(--text-primary);font-weight:500;}
 .chip{
   display:inline-block;margin-bottom:var(--space-md);padding:4px 12px;
-  border-radius:9999px;background:var(--amber-muted);border:1px solid var(--border);
-  color:var(--text-primary);font-size:13px;font-weight:500;
+  border-radius:9999px;font-size:13px;font-weight:600;
 }
+.chip--granted{background:var(--status-granted-bg);color:var(--status-granted);}
+.chip--refused{background:var(--status-refused-bg);color:var(--status-refused);}
+.chip--neutral{background:var(--status-neutral-bg);color:var(--status-neutral);}
 h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--space-md);}
 .card h2{
   margin:var(--space-lg) 0 var(--space-sm);font-size:13px;font-weight:600;
@@ -61,12 +75,12 @@ h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--spac
 .proposal{margin:0;}
 .timeline{list-style:none;margin:0;padding:0;}
 .timeline li{
-  display:flex;justify-content:space-between;gap:var(--space-md);
+  display:flex;align-items:baseline;gap:var(--space-sm);
   padding:var(--space-sm) 0;border-bottom:1px solid var(--border);
 }
 .timeline li:last-child{border-bottom:none;}
-.date-label{color:var(--text-secondary);}
-.date-value{font-weight:600;text-align:right;}
+.date-label{color:var(--text-secondary);flex:0 0 auto;}
+.date-value{font-weight:600;}
 .app-cta{margin-top:var(--space-lg);text-align:center;}
 .btn-primary{
   display:block;width:100%;box-sizing:border-box;padding:14px var(--space-md);
@@ -91,6 +105,9 @@ h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--spac
   font-size:12px;line-height:1.5;
 }
 .attribution p{margin:0 0 4px;}
+.authority-backlink{margin:var(--space-md) 0 0;font-size:14px;}
+.authority-backlink a{color:var(--amber);text-decoration:none;font-weight:600;}
+.authority-backlink a:hover{color:var(--amber-hover);text-decoration:underline;}
 .cta-bar{
   position:fixed;left:0;right:0;bottom:0;margin:0 auto;max-width:600px;
   display:flex;flex-direction:column;align-items:stretch;gap:var(--space-xs);

--- a/api-go/internal/sharepage/view.go
+++ b/api-go/internal/sharepage/view.go
@@ -56,15 +56,16 @@ type pageView struct {
 	CTAHref       string
 	HomeURL       string
 
-	Ref         string
-	Address     string
-	Postcode    string
-	AppType     string
-	StatusChip  string
-	Description string
-	Dates       []dateEntry
-	PlanItLink  string
-	CouncilLink string
+	Ref            string
+	Address        string
+	Postcode       string
+	AppType        string
+	StatusLabel    string
+	StatusModifier string
+	Description    string
+	Dates          []dateEntry
+	PlanItLink     string
+	CouncilLink    string
 }
 
 // dateEntry is one row of the key-dates timeline (which doubles as the status
@@ -115,9 +116,7 @@ func buildPageView(app applications.PlanningApplication, slug, ref string) pageV
 		v.AppType = *app.AppType
 	}
 	if app.AppState != nil {
-		// Render the RAW PlanIt status verbatim — mapping it to a friendly label or
-		// a status colour is a web/iOS concern, deliberately not invented here.
-		v.StatusChip = *app.AppState
+		v.StatusLabel, v.StatusModifier = statusChip(*app.AppState)
 	}
 	if app.StartDate != nil {
 		v.Dates = append(v.Dates, dateEntry{Label: "Started", Value: formatDate(*app.StartDate)})
@@ -135,6 +134,40 @@ func buildPageView(app applications.PlanningApplication, slug, ref string) pageV
 		v.CouncilLink = *app.URL
 	}
 	return v
+}
+
+// statusLabels maps a raw PlanIt appState string to the resident-facing label
+// shared across both public surfaces: mirrors STATUS_DISPLAY_LABEL_MAP in
+// web/scripts/lib/format.mjs, so the share pages and the SEO planning pages
+// speak one vocabulary (tc-r4n9 decision 4). A state absent from this map
+// (e.g. "Undecided", "Withdrawn", "Appealed", "Unresolved", "Referred", or any
+// PlanIt string not seen at design time) passes through unchanged in
+// statusChip below — it is real PlanIt data, not wording we invent.
+var statusLabels = map[string]string{
+	"Permitted":  "Granted",
+	"Conditions": "Granted with conditions",
+	"Rejected":   "Refused",
+}
+
+// statusModifiers maps the same raw appState to a broad CSS colour bucket.
+// Deliberately three buckets, not a five-way traffic light: granted (green),
+// refused (red), and neutral for everything else — including "Undecided" and
+// every long-tail state (Withdrawn, Appealed, Unresolved, Referred, unknown).
+// Per decision 4, long-tail states are neutral, not individually coloured.
+var statusModifiers = map[string]string{
+	"Permitted":  "granted",
+	"Conditions": "granted",
+	"Rejected":   "refused",
+}
+
+// statusChip translates a raw PlanIt appState into its (label, CSS modifier)
+// pair. An unrecognised appState renders as itself with the neutral modifier,
+// so an unmapped PlanIt string is still visible rather than silently dropped.
+func statusChip(appState string) (label, modifier string) {
+	if l, ok := statusLabels[appState]; ok {
+		return l, statusModifiers[appState]
+	}
+	return appState, "neutral"
 }
 
 // addressIncludesPostcode reports whether address already ends with postcode,

--- a/api-go/internal/sharepage/view.go
+++ b/api-go/internal/sharepage/view.go
@@ -163,11 +163,16 @@ var statusLabels = map[string]string{
 // statusModifiers maps the same raw appState to a broad CSS colour bucket.
 // Deliberately three buckets, not a five-way traffic light: granted (green),
 // refused (red), and neutral for everything else — including "Undecided" and
-// every long-tail state (Withdrawn, Appealed, Unresolved, Referred, unknown).
-// Per decision 4, long-tail states are neutral, not individually coloured.
+// every long-tail state. "Conditions" ("Granted with conditions") is
+// explicitly one of those long-tail states per issue #794 Phase 3 ("fold the
+// long tail: Withdrawn, Unresolved, Granted with conditions, Referred") and
+// per tc-r4n9.2's web-side bucketing, so it is neutral here too, matching the
+// label lookup in statusLabels (which still spells it out in full) but NOT
+// colouring it green like an unconditional grant. Per decision 4, long-tail
+// states are neutral, not individually coloured.
 var statusModifiers = map[string]string{
 	"Permitted":  "granted",
-	"Conditions": "granted",
+	"Conditions": "neutral",
 	"Rejected":   "refused",
 }
 

--- a/api-go/internal/sharepage/view.go
+++ b/api-go/internal/sharepage/view.go
@@ -66,6 +66,8 @@ type pageView struct {
 	Dates          []dateEntry
 	PlanItLink     string
 	CouncilLink    string
+	AuthorityName  string
+	AuthorityURL   string
 }
 
 // dateEntry is one row of the key-dates timeline (which doubles as the status
@@ -132,6 +134,15 @@ func buildPageView(app applications.PlanningApplication, slug, ref string) pageV
 	}
 	if app.URL != nil {
 		v.CouncilLink = *app.URL
+	}
+	if areaName := strings.TrimSpace(app.AreaName); areaName != "" {
+		v.AuthorityName = areaName
+		// Built from the same slug this page itself was resolved by — the share
+		// page and the SEO planning page (web/scripts/prerender-planning.mjs) both
+		// slugify the authority name with the same byte-equal-ported Slugify, so
+		// this is the correct authority-page path whenever one has been published
+		// for this authority.
+		v.AuthorityURL = homeURL + "/planning/" + slug
 	}
 	return v
 }

--- a/api-go/internal/sharepage/view.go
+++ b/api-go/internal/sharepage/view.go
@@ -108,7 +108,7 @@ func buildPageView(app applications.PlanningApplication, slug, ref string) pageV
 		Description:  app.Description,
 	}
 
-	if app.Postcode != nil {
+	if app.Postcode != nil && !addressIncludesPostcode(app.Address, *app.Postcode) {
 		v.Postcode = *app.Postcode
 	}
 	if app.AppType != nil {
@@ -135,6 +135,21 @@ func buildPageView(app applications.PlanningApplication, slug, ref string) pageV
 		v.CouncilLink = *app.URL
 	}
 	return v
+}
+
+// addressIncludesPostcode reports whether address already ends with postcode,
+// compared case-insensitively after trimming surrounding whitespace from
+// both. PlanIt addresses commonly already carry the postcode as their tail
+// (e.g. "2 High Street, Croydon, CR2 7DY"), so appending it again in the h1
+// would render "... CR2 7DY, CR2 7DY" — the duplication this check guards
+// against (tc-r4n9.6).
+func addressIncludesPostcode(address, postcode string) bool {
+	a := strings.TrimSpace(address)
+	p := strings.TrimSpace(postcode)
+	if a == "" || p == "" {
+		return false
+	}
+	return strings.HasSuffix(strings.ToLower(a), strings.ToLower(p))
 }
 
 // formatDate renders a date as "2 March 2024".

--- a/api-go/internal/sharepage/view_test.go
+++ b/api-go/internal/sharepage/view_test.go
@@ -206,3 +206,59 @@ func TestBuildPageView_PostcodeDeduplication(t *testing.T) {
 	}
 }
 
+// TestStatusChip pins the shared status vocabulary/palette (tc-r4n9 decision
+// 4): the resident-facing label mirrors web/scripts/lib/format.mjs's
+// STATUS_DISPLAY_LABEL_MAP, and the colour modifier deliberately collapses to
+// three buckets — granted (green), refused (red), neutral for everything else
+// including "Undecided" and every long-tail state — rather than a five-way
+// traffic light.
+func TestStatusChip(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		appState     string
+		wantLabel    string
+		wantModifier string
+	}{
+		{appState: "Permitted", wantLabel: "Granted", wantModifier: "granted"},
+		{appState: "Conditions", wantLabel: "Granted with conditions", wantModifier: "granted"},
+		{appState: "Rejected", wantLabel: "Refused", wantModifier: "refused"},
+		{appState: "Undecided", wantLabel: "Undecided", wantModifier: "neutral"},
+		{appState: "Withdrawn", wantLabel: "Withdrawn", wantModifier: "neutral"},
+		{appState: "Appealed", wantLabel: "Appealed", wantModifier: "neutral"},
+		{appState: "Unresolved", wantLabel: "Unresolved", wantModifier: "neutral"},
+		{appState: "Referred", wantLabel: "Referred", wantModifier: "neutral"},
+		{appState: "Some Future PlanIt State", wantLabel: "Some Future PlanIt State", wantModifier: "neutral"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.appState, func(t *testing.T) {
+			t.Parallel()
+			gotLabel, gotModifier := statusChip(tt.appState)
+			if gotLabel != tt.wantLabel || gotModifier != tt.wantModifier {
+				t.Errorf("statusChip(%q) = (%q, %q), want (%q, %q)", tt.appState, gotLabel, gotModifier, tt.wantLabel, tt.wantModifier)
+			}
+		})
+	}
+}
+
+// TestBuildPageView_StatusChip pins buildPageView's wiring of the mapped
+// vocabulary: a nil AppState leaves both fields empty (so the template omits
+// the chip entirely); a set AppState is run through statusChip.
+func TestBuildPageView_StatusChip(t *testing.T) {
+	t.Parallel()
+	t.Run("nil AppState omits the chip", func(t *testing.T) {
+		t.Parallel()
+		app := applications.PlanningApplication{Name: "23/03456/FUL", AreaID: 165}
+		v := buildPageView(app, "croydon", "23/03456/FUL")
+		if v.StatusLabel != "" || v.StatusModifier != "" {
+			t.Errorf("StatusLabel/StatusModifier = %q/%q, want empty/empty", v.StatusLabel, v.StatusModifier)
+		}
+	})
+	t.Run("set AppState is mapped, not passed through raw", func(t *testing.T) {
+		t.Parallel()
+		app := applications.PlanningApplication{Name: "23/03456/FUL", AreaID: 165, AppState: ptr("Permitted")}
+		v := buildPageView(app, "croydon", "23/03456/FUL")
+		if v.StatusLabel != "Granted" || v.StatusModifier != "granted" {
+			t.Errorf("StatusLabel/StatusModifier = %q/%q, want Granted/granted", v.StatusLabel, v.StatusModifier)
+		}
+	})
+}

--- a/api-go/internal/sharepage/view_test.go
+++ b/api-go/internal/sharepage/view_test.go
@@ -92,3 +92,117 @@ func TestSummarise_EmptyDescriptionNoPlace(t *testing.T) {
 		t.Errorf("summary = %q, want %q", got, want)
 	}
 }
+
+// TestAddressIncludesPostcode pins the case/whitespace-insensitive suffix check
+// behind the postcode-duplication fix (tc-r4n9.6): PlanIt addresses usually
+// already end with the postcode, so appending it again in the h1 would render
+// "... CR2 7DY, CR2 7DY".
+func TestAddressIncludesPostcode(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		address  string
+		postcode string
+		want     bool
+	}{
+		{
+			name:     "address already ends with postcode",
+			address:  "2 High Street, Croydon, CR2 7DY",
+			postcode: "CR2 7DY",
+			want:     true,
+		},
+		{
+			name:     "address does not contain postcode",
+			address:  "2 High Street, Croydon",
+			postcode: "CR2 7DY",
+			want:     false,
+		},
+		{
+			name:     "case-insensitive match",
+			address:  "2 High Street, Croydon, cr2 7dy",
+			postcode: "CR2 7DY",
+			want:     true,
+		},
+		{
+			name:     "trailing whitespace on address is ignored",
+			address:  "2 High Street, Croydon, CR2 7DY   ",
+			postcode: "CR2 7DY",
+			want:     true,
+		},
+		{
+			name:     "trailing whitespace on postcode is ignored",
+			address:  "2 High Street, Croydon, CR2 7DY",
+			postcode: "  CR2 7DY  ",
+			want:     true,
+		},
+		{
+			name:     "empty postcode never matches",
+			address:  "2 High Street, Croydon",
+			postcode: "",
+			want:     false,
+		},
+		{
+			name:     "empty address never matches",
+			address:  "",
+			postcode: "CR2 7DY",
+			want:     false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := addressIncludesPostcode(tt.address, tt.postcode); got != tt.want {
+				t.Errorf("addressIncludesPostcode(%q, %q) = %v, want %v", tt.address, tt.postcode, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildPageView_PostcodeDeduplication pins buildPageView's use of
+// addressIncludesPostcode: the view's Postcode field (the h1's ", {postcode}"
+// suffix) is suppressed when the address already carries it, and populated
+// unchanged otherwise.
+func TestBuildPageView_PostcodeDeduplication(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		address      string
+		postcode     *string
+		wantPostcode string
+	}{
+		{
+			name:         "address already includes postcode: suffix suppressed",
+			address:      "2 High Street, Croydon, CR2 7DY",
+			postcode:     ptr("CR2 7DY"),
+			wantPostcode: "",
+		},
+		{
+			name:         "address does not include postcode: unchanged",
+			address:      "2 High Street, Croydon",
+			postcode:     ptr("CR2 7DY"),
+			wantPostcode: "CR2 7DY",
+		},
+		{
+			name:         "nil postcode: unchanged (empty)",
+			address:      "2 High Street, Croydon",
+			postcode:     nil,
+			wantPostcode: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			app := applications.PlanningApplication{
+				Name:     "23/03456/FUL",
+				AreaID:   165,
+				Address:  tt.address,
+				Postcode: tt.postcode,
+			}
+			v := buildPageView(app, "croydon", "23/03456/FUL")
+			if v.Postcode != tt.wantPostcode {
+				t.Errorf("Postcode = %q, want %q", v.Postcode, tt.wantPostcode)
+			}
+		})
+	}
+}
+

--- a/api-go/internal/sharepage/view_test.go
+++ b/api-go/internal/sharepage/view_test.go
@@ -220,7 +220,12 @@ func TestStatusChip(t *testing.T) {
 		wantModifier string
 	}{
 		{appState: "Permitted", wantLabel: "Granted", wantModifier: "granted"},
-		{appState: "Conditions", wantLabel: "Granted with conditions", wantModifier: "granted"},
+		// "Granted with conditions" is explicitly a long-tail state per issue #794
+		// Phase 3 ("fold the long tail: Withdrawn, Unresolved, Granted with
+		// conditions, Referred") and per tc-r4n9.2's web-side implementation
+		// (Permitted->granted/green, Rejected->refused/red, everything else
+		// including Conditions->neutral/grey) — it is NOT a green "granted" bucket.
+		{appState: "Conditions", wantLabel: "Granted with conditions", wantModifier: "neutral"},
 		{appState: "Rejected", wantLabel: "Refused", wantModifier: "refused"},
 		{appState: "Undecided", wantLabel: "Undecided", wantModifier: "neutral"},
 		{appState: "Withdrawn", wantLabel: "Withdrawn", wantModifier: "neutral"},

--- a/api-go/internal/sharepage/view_test.go
+++ b/api-go/internal/sharepage/view_test.go
@@ -262,3 +262,34 @@ func TestBuildPageView_StatusChip(t *testing.T) {
 		}
 	})
 }
+
+// TestBuildPageView_AuthorityBacklink pins the "More planning applications in
+// {area} ->" backlink (tc-r4n9.6): it points at the SEO planning page for the
+// application's authority, built from the SAME slug the share page itself was
+// resolved by — the two page families share one Slugify implementation
+// (api-go/internal/authorities/slug.go, byte-equal ported from
+// web/scripts/lib/slug.mjs), so this is the correct authority-page path
+// whenever that authority actually has a published SEO page (see the worker
+// report for the coverage-gate/area-type caveat).
+func TestBuildPageView_AuthorityBacklink(t *testing.T) {
+	t.Parallel()
+	t.Run("area name present: link built from slug", func(t *testing.T) {
+		t.Parallel()
+		app := applications.PlanningApplication{Name: "23/03456/FUL", AreaID: 165, AreaName: "Croydon"}
+		v := buildPageView(app, "croydon", "23/03456/FUL")
+		if v.AuthorityURL != "https://towncrierapp.uk/planning/croydon" {
+			t.Errorf("AuthorityURL = %q, want https://towncrierapp.uk/planning/croydon", v.AuthorityURL)
+		}
+		if v.AuthorityName != "Croydon" {
+			t.Errorf("AuthorityName = %q, want Croydon", v.AuthorityName)
+		}
+	})
+	t.Run("blank area name: backlink omitted", func(t *testing.T) {
+		t.Parallel()
+		app := applications.PlanningApplication{Name: "23/03456/FUL", AreaID: 165, AreaName: "   "}
+		v := buildPageView(app, "croydon", "23/03456/FUL")
+		if v.AuthorityURL != "" || v.AuthorityName != "" {
+			t.Errorf("AuthorityURL/AuthorityName = %q/%q, want empty/empty", v.AuthorityURL, v.AuthorityName)
+		}
+	})
+}


### PR DESCRIPTION
## Changes
- Postcode dedup: h1 no longer shows the postcode twice when the address already ends with it (case/whitespace-insensitive check in view.go).
- Application type gets its own explicit metadata row instead of a cryptic "Reference … · Type" concatenation.
- Key-dates layout: single date rows no longer stretch full-card-width.
- Authority backlink: "More planning applications in {area} →" to the matching SEO planning page, using the same slug resolution as the share page itself. (Flagged a real, separate eligibility gap — some authorities aren't published as SEO pages — filed as tc-x5o2, out of scope here.)
- Status chips: raw PlanIt appState replaced with the shared 3-bucket vocabulary (Granted/Refused/neutral), matching tc-r4n9.2's web-side implementation. Includes a follow-up fix: "Conditions" (Granted with conditions) was initially miscategorised as granted/green; corrected to neutral per the issue's own long-tail-state list and to match the web side.

Part of the design-review punch list (#794), Phase 6 of 7. Closes tc-r4n9.6.

## Test plan
- `gofmt -l .`, `go vet ./...`, `golangci-lint run ./...` clean
- `go test -race ./...` — 1429 passed / 45 packages
- Visual verification via agent-browser against local API + seeded Postgres: mobile + desktop, light + dark. Confirmed postcode dedup on a matching address, type/reference as separate rows, key-dates no longer full-width, authority backlink present, and status chips (including the corrected neutral "Granted with conditions") render correctly in both themes.

---
*Auto-shipped via ship skill*