### PR TITLE
feat(android): core networking, Auth0 auth, session mgmt, profile ensure, force-update gate (tc-f2il)

### DIFF
--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
 

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
         minSdk = 26
         targetSdk = 35
         versionCode = 1
-        versionName = "0.1.0"
+        versionName = "1.0.0"
 
         // Auth0 Android SDK manifest placeholders (tc-f2il, epic #770 D4).
         // Same tenant + domain for both flavors — only the applicationId

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -15,6 +15,13 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "0.1.0"
+
+        // Auth0 Android SDK manifest placeholders (tc-f2il, epic #770 D4).
+        // Same tenant + domain for both flavors — only the applicationId
+        // suffix differs, which the SDK reads automatically to build the
+        // per-flavor callback path (.../android/{applicationId}/callback).
+        manifestPlaceholders["auth0Domain"] = "towncrierapp.uk.auth0.com"
+        manifestPlaceholders["auth0Scheme"] = "https"
     }
 
     compileOptions {
@@ -69,6 +76,7 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
 
@@ -83,10 +91,19 @@ dependencies {
     // Type-safe Navigation Compose routes (@Serializable destinations).
     implementation(libs.kotlinx.serialization.json)
 
+    // Auth0 SDK, OkHttp transport, DataStore latch — the composition root is
+    // the only module that constructs the Android-touching leaves these need
+    // (SecureCredentialsManager, DataStore<Preferences>) (tc-f2il).
+    implementation(libs.auth0)
+    implementation(libs.okhttp)
+    implementation(libs.androidx.datastore.preferences)
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
     testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
+    // FakeSubscriptionTierCache etc. shared via :domain's testFixtures.
+    testImplementation(testFixtures(project(":domain")))
 }

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name="uk.towncrierapp.app.TownCrierApplication"
         android:allowBackup="true"
         android:icon="@android:drawable/sym_def_app_icon"
         android:label="@string/app_name"

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -1,5 +1,27 @@
 package uk.towncrierapp.app
 
+import uk.towncrierapp.data.api.ApiClient
+import uk.towncrierapp.data.api.OkHttpTransport
+import uk.towncrierapp.data.auth.Auth0AuthenticationService
+import uk.towncrierapp.data.auth.Auth0Config
+import uk.towncrierapp.data.auth.CredentialsStore
+import uk.towncrierapp.data.auth.CurrentActivityProvider
+import uk.towncrierapp.data.auth.SessionCache
+import uk.towncrierapp.data.profile.ApiUserProfileRepository
+import uk.towncrierapp.data.versionconfig.ApiVersionConfigService
+import uk.towncrierapp.domain.auth.AuthenticationService
+import uk.towncrierapp.domain.profile.UserProfileRepository
+import uk.towncrierapp.domain.subscriptions.SubscriptionTierCache
+import uk.towncrierapp.domain.versionconfig.VersionConfigService
+import uk.towncrierapp.presentation.auth.AuthCoordinator
+import com.auth0.android.Auth0
+import java.time.Clock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import okhttp3.Call
+import okhttp3.OkHttpClient
+
 /**
  * Town Crier's composition root: the single place `:app` hand-wires the
  * dependency graph from `:domain` ports to `:data` implementations, via
@@ -8,14 +30,53 @@ package uk.towncrierapp.app
  * interfaces, so this class itself stays a pure-JVM type — which is what
  * lets [AppGraphSmokeTest] construct it in a plain JVM test.
  *
- * Empty today; each later phase of the Android parity epic adds one `val`
- * per port the UI layer consumes, plus whatever shared leaves those ports
- * need (a `java.time.Clock`, an `OkHttp.Call.Factory`, ...) — see
- * android-coding-standards skill, architecture-and-modules.md.
+ * [credentialsStore] (a `SecureCredentialsManagerStore` over a real
+ * `SecureCredentialsManager`), [activityProvider] (an `Application.
+ * ActivityLifecycleCallbacks`-backed tracker), and [tierCache] (a
+ * `DataStoreSubscriptionTierCache`) are the three leaves that genuinely need
+ * a `Context` — `TownCrierApplication` builds them and passes them in here.
  */
 public class AppGraph(
     public val baseUrl: String,
+    auth0ClientId: String,
+    auth0Domain: String,
+    credentialsStore: CredentialsStore,
+    activityProvider: CurrentActivityProvider,
+    tierCache: SubscriptionTierCache,
+    public val currentVersion: String,
+    enableDebugLogging: Boolean = false,
+    callFactory: Call.Factory = OkHttpClient.Builder().build(),
+    scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    clock: Clock = Clock.systemUTC(),
 ) {
-    // Wiring lands feature-by-feature, e.g.:
-    // val watchZoneRepository: WatchZoneRepository = HttpWatchZoneRepository(apiClient)
+    private val transport = OkHttpTransport(callFactory)
+
+    // Audience = the flavor's own API base URL (epic #770 D4) — dev and prod
+    // share one Auth0 Native application; only the audience (and therefore
+    // the access-token claims) differ per flavor.
+    public val authenticationService: AuthenticationService =
+        Auth0AuthenticationService(
+            config = Auth0Config(clientId = auth0ClientId, domain = auth0Domain, audience = baseUrl),
+            credentialsStore = credentialsStore,
+            activityProvider = activityProvider,
+            auth0 = lazy { Auth0.getInstance(auth0ClientId, auth0Domain) },
+            sessionCache = SessionCache(scope),
+            clock = clock,
+        )
+
+    private val apiClient =
+        ApiClient(
+            baseUrl = baseUrl,
+            transport = transport,
+            authService = authenticationService,
+            enableDebugLogging = enableDebugLogging,
+        )
+
+    public val userProfileRepository: UserProfileRepository = ApiUserProfileRepository(apiClient)
+
+    // Anonymous, pre-login — shares the same raw transport but never goes
+    // through ApiClient (which always requires a session first).
+    public val versionConfigService: VersionConfigService = ApiVersionConfigService(baseUrl, transport)
+
+    public val authCoordinator: AuthCoordinator = AuthCoordinator(authenticationService, userProfileRepository, tierCache)
 }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -22,46 +22,62 @@ import uk.towncrierapp.domain.versionconfig.VersionConfigService
 import uk.towncrierapp.presentation.auth.AuthCoordinator
 import java.time.Clock
 
+/** Auth0 tenant identity — same for both build flavors (epic #770 D4); only the audience differs, and that's [AppGraph.baseUrl]. */
+public data class Auth0Tenant(
+    val clientId: String,
+    val domain: String,
+)
+
+/**
+ * The three leaves that genuinely need a real `Context` —
+ * `TownCrierApplication` builds them (`SecureCredentialsManagerStore` over a
+ * real `SecureCredentialsManager`, an `Application.ActivityLifecycleCallbacks`
+ * tracker, a `DataStoreSubscriptionTierCache`) and hands them to the
+ * otherwise Context-free [AppGraph].
+ */
+public class AndroidLeaves(
+    public val credentialsStore: CredentialsStore,
+    public val activityProvider: CurrentActivityProvider,
+    public val tierCache: SubscriptionTierCache,
+)
+
+/** Rarely-overridden technical knobs, grouped so [AppGraph]'s own constructor stays short. */
+public class AppGraphOptions(
+    public val enableDebugLogging: Boolean = false,
+    public val callFactory: Call.Factory = OkHttpClient.Builder().build(),
+    public val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+    public val clock: Clock = Clock.systemUTC(),
+)
+
 /**
  * Town Crier's composition root: the single place `:app` hand-wires the
  * dependency graph from `:domain` ports to `:data` implementations, via
  * manual constructor injection (epic #770 — no DI framework, no Hilt/Koin).
- * Android-touching leaves come in through the constructor as their domain
- * interfaces, so this class itself stays a pure-JVM type — which is what
- * lets [AppGraphSmokeTest] construct it in a plain JVM test.
- *
- * [credentialsStore] (a `SecureCredentialsManagerStore` over a real
- * `SecureCredentialsManager`), [activityProvider] (an `Application.
- * ActivityLifecycleCallbacks`-backed tracker), and [tierCache] (a
- * `DataStoreSubscriptionTierCache`) are the three leaves that genuinely need
- * a `Context` — `TownCrierApplication` builds them and passes them in here.
+ * Android-touching leaves come in through the constructor (via
+ * [AndroidLeaves]) as their domain interfaces, so this class itself stays a
+ * pure-JVM type — which is what lets [AppGraphSmokeTest] construct it in a
+ * plain JVM test.
  */
 public class AppGraph(
     public val baseUrl: String,
-    auth0ClientId: String,
-    auth0Domain: String,
-    credentialsStore: CredentialsStore,
-    activityProvider: CurrentActivityProvider,
-    tierCache: SubscriptionTierCache,
+    auth0Tenant: Auth0Tenant,
+    androidLeaves: AndroidLeaves,
     public val currentVersion: String,
-    enableDebugLogging: Boolean = false,
-    callFactory: Call.Factory = OkHttpClient.Builder().build(),
-    scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
-    clock: Clock = Clock.systemUTC(),
+    options: AppGraphOptions = AppGraphOptions(),
 ) {
-    private val transport = OkHttpTransport(callFactory)
+    private val transport = OkHttpTransport(options.callFactory)
 
     // Audience = the flavor's own API base URL (epic #770 D4) — dev and prod
     // share one Auth0 Native application; only the audience (and therefore
     // the access-token claims) differ per flavor.
     public val authenticationService: AuthenticationService =
         Auth0AuthenticationService(
-            config = Auth0Config(clientId = auth0ClientId, domain = auth0Domain, audience = baseUrl),
-            credentialsStore = credentialsStore,
-            activityProvider = activityProvider,
-            auth0 = lazy { Auth0.getInstance(auth0ClientId, auth0Domain) },
-            sessionCache = SessionCache(scope),
-            clock = clock,
+            config = Auth0Config(clientId = auth0Tenant.clientId, domain = auth0Tenant.domain, audience = baseUrl),
+            credentialsStore = androidLeaves.credentialsStore,
+            activityProvider = androidLeaves.activityProvider,
+            auth0 = lazy { Auth0.getInstance(auth0Tenant.clientId, auth0Tenant.domain) },
+            sessionCache = SessionCache(options.scope),
+            clock = options.clock,
         )
 
     private val apiClient =
@@ -69,7 +85,7 @@ public class AppGraph(
             baseUrl = baseUrl,
             transport = transport,
             authService = authenticationService,
-            enableDebugLogging = enableDebugLogging,
+            enableDebugLogging = options.enableDebugLogging,
         )
 
     public val userProfileRepository: UserProfileRepository = ApiUserProfileRepository(apiClient)
@@ -79,5 +95,5 @@ public class AppGraph(
     public val versionConfigService: VersionConfigService = ApiVersionConfigService(baseUrl, transport)
 
     public val authCoordinator: AuthCoordinator =
-        AuthCoordinator(authenticationService, userProfileRepository, tierCache)
+        AuthCoordinator(authenticationService, userProfileRepository, androidLeaves.tierCache)
 }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -1,5 +1,11 @@
 package uk.towncrierapp.app
 
+import com.auth0.android.Auth0
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import okhttp3.Call
+import okhttp3.OkHttpClient
 import uk.towncrierapp.data.api.ApiClient
 import uk.towncrierapp.data.api.OkHttpTransport
 import uk.towncrierapp.data.auth.Auth0AuthenticationService
@@ -14,13 +20,7 @@ import uk.towncrierapp.domain.profile.UserProfileRepository
 import uk.towncrierapp.domain.subscriptions.SubscriptionTierCache
 import uk.towncrierapp.domain.versionconfig.VersionConfigService
 import uk.towncrierapp.presentation.auth.AuthCoordinator
-import com.auth0.android.Auth0
 import java.time.Clock
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import okhttp3.Call
-import okhttp3.OkHttpClient
 
 /**
  * Town Crier's composition root: the single place `:app` hand-wires the
@@ -78,5 +78,6 @@ public class AppGraph(
     // through ApiClient (which always requires a session first).
     public val versionConfigService: VersionConfigService = ApiVersionConfigService(baseUrl, transport)
 
-    public val authCoordinator: AuthCoordinator = AuthCoordinator(authenticationService, userProfileRepository, tierCache)
+    public val authCoordinator: AuthCoordinator =
+        AuthCoordinator(authenticationService, userProfileRepository, tierCache)
 }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/CurrentActivityTracker.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/CurrentActivityTracker.kt
@@ -1,0 +1,45 @@
+package uk.towncrierapp.app
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import uk.towncrierapp.data.auth.CurrentActivityProvider
+
+/**
+ * Tracks the currently-resumed [Activity] via `Application.
+ * ActivityLifecycleCallbacks` — never held longer than the Activity is
+ * actually in the foreground, never leaked. Registered once from
+ * [TownCrierApplication.onCreate]; this is the one leaf `AppGraph` needs
+ * that a real `Context`/Activity lifecycle can supply (auth `login()`/
+ * `logout()` need an Activity to launch Custom Tabs).
+ */
+public class CurrentActivityTracker : Application.ActivityLifecycleCallbacks, CurrentActivityProvider {
+    @Volatile
+    private var resumedActivity: Activity? = null
+
+    override fun currentActivity(): Activity? = resumedActivity
+
+    override fun onActivityResumed(activity: Activity) {
+        resumedActivity = activity
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        if (resumedActivity === activity) resumedActivity = null
+    }
+
+    override fun onActivityCreated(
+        activity: Activity,
+        savedInstanceState: Bundle?,
+    ) = Unit
+
+    override fun onActivityStarted(activity: Activity) = Unit
+
+    override fun onActivityStopped(activity: Activity) = Unit
+
+    override fun onActivitySaveInstanceState(
+        activity: Activity,
+        outState: Bundle,
+    ) = Unit
+
+    override fun onActivityDestroyed(activity: Activity) = Unit
+}

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/CurrentActivityTracker.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/CurrentActivityTracker.kt
@@ -13,7 +13,9 @@ import uk.towncrierapp.data.auth.CurrentActivityProvider
  * that a real `Context`/Activity lifecycle can supply (auth `login()`/
  * `logout()` need an Activity to launch Custom Tabs).
  */
-public class CurrentActivityTracker : Application.ActivityLifecycleCallbacks, CurrentActivityProvider {
+public class CurrentActivityTracker :
+    Application.ActivityLifecycleCallbacks,
+    CurrentActivityProvider {
     @Volatile
     private var resumedActivity: Activity? = null
 

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
@@ -3,12 +3,6 @@ package uk.towncrierapp.app
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import uk.towncrierapp.presentation.designsystem.TownCrierTheme
-import uk.towncrierapp.presentation.features.forceupdate.ForceUpdateScreen
-import uk.towncrierapp.presentation.features.forceupdate.ForceUpdateViewModel
-import uk.towncrierapp.presentation.features.forceupdate.PLAY_STORE_URL
-import uk.towncrierapp.presentation.features.login.LoginRoute
-import uk.towncrierapp.presentation.features.login.LoginViewModel
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -34,6 +28,12 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import kotlinx.serialization.Serializable
 import uk.towncrierapp.mobile.R
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import uk.towncrierapp.presentation.features.forceupdate.ForceUpdateScreen
+import uk.towncrierapp.presentation.features.forceupdate.ForceUpdateViewModel
+import uk.towncrierapp.presentation.features.forceupdate.PLAY_STORE_URL
+import uk.towncrierapp.presentation.features.login.LoginRoute
+import uk.towncrierapp.presentation.features.login.LoginViewModel
 
 /** Town Crier's single activity — see android-coding-standards skill: single-activity Compose, no Fragments. */
 public class MainActivity : ComponentActivity() {
@@ -89,15 +89,21 @@ public fun TownCrierApp(
 
     Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
         when {
-            forceUpdateState.requiresUpdate ->
+            forceUpdateState.requiresUpdate -> {
                 ForceUpdateScreen(
                     onUpdateClick = { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(PLAY_STORE_URL))) },
                 )
-            loginState.isAuthenticated ->
+            }
+
+            loginState.isAuthenticated -> {
                 NavHost(navController = navController, startDestination = Home) {
                     composable<Home> { HomeRoute() }
                 }
-            else -> LoginRoute(viewModel = loginViewModel)
+            }
+
+            else -> {
+                LoginRoute(viewModel = loginViewModel)
+            }
         }
     }
 }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
@@ -1,6 +1,14 @@
 package uk.towncrierapp.app
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import uk.towncrierapp.presentation.features.forceupdate.ForceUpdateScreen
+import uk.towncrierapp.presentation.features.forceupdate.ForceUpdateViewModel
+import uk.towncrierapp.presentation.features.forceupdate.PLAY_STORE_URL
+import uk.towncrierapp.presentation.features.login.LoginRoute
+import uk.towncrierapp.presentation.features.login.LoginViewModel
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -10,25 +18,32 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import kotlinx.serialization.Serializable
 import uk.towncrierapp.mobile.R
-import uk.towncrierapp.presentation.designsystem.TownCrierTheme
 
 /** Town Crier's single activity — see android-coding-standards skill: single-activity Compose, no Fragments. */
 public class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        val appGraph = (application as TownCrierApplication).appGraph
         setContent {
             TownCrierTheme {
-                TownCrierApp()
+                TownCrierApp(appGraph = appGraph)
             }
         }
     }
@@ -38,14 +53,51 @@ public class MainActivity : ComponentActivity() {
 @Serializable
 private data object Home
 
+/**
+ * Root routing: pre-login force-update gate, then Login or the authed
+ * shell — port of iOS `TownCrierApp.body`'s `Group { if requiresUpdate ...
+ * else if isAuthenticated ... else Login }`. Re-checks the version gate and
+ * re-runs the signed-in sequence (ensure profile → resolve tier, #549 /
+ * tc-f2il) on every auth-state transition, keyed off `isAuthenticated` so a
+ * fresh sign-in re-triggers it.
+ */
 @Composable
-public fun TownCrierApp(navController: NavHostController = rememberNavController()) {
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
-        NavHost(navController = navController, startDestination = Home) {
-            composable<Home> { HomeRoute() }
+public fun TownCrierApp(
+    appGraph: AppGraph,
+    navController: NavHostController = rememberNavController(),
+) {
+    val loginViewModel: LoginViewModel =
+        viewModel(factory = viewModelFactory { initializer { LoginViewModel(appGraph.authenticationService) } })
+    val forceUpdateViewModel: ForceUpdateViewModel =
+        viewModel(
+            factory =
+                viewModelFactory {
+                    initializer { ForceUpdateViewModel(appGraph.versionConfigService, appGraph.currentVersion) }
+                },
+        )
+
+    val loginState by loginViewModel.uiState.collectAsStateWithLifecycle()
+    val forceUpdateState by forceUpdateViewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    LaunchedEffect(loginState.isAuthenticated) {
+        forceUpdateViewModel.checkVersion()
+        if (loginState.isAuthenticated) {
+            appGraph.authCoordinator.onSignedIn()
+        }
+    }
+
+    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        when {
+            forceUpdateState.requiresUpdate ->
+                ForceUpdateScreen(
+                    onUpdateClick = { context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(PLAY_STORE_URL))) },
+                )
+            loginState.isAuthenticated ->
+                NavHost(navController = navController, startDestination = Home) {
+                    composable<Home> { HomeRoute() }
+                }
+            else -> LoginRoute(viewModel = loginViewModel)
         }
     }
 }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
@@ -46,13 +46,10 @@ public class TownCrierApplication : Application() {
         appGraph =
             AppGraph(
                 baseUrl = BuildConfig.API_BASE_URL,
-                auth0ClientId = AUTH0_CLIENT_ID,
-                auth0Domain = AUTH0_DOMAIN,
-                credentialsStore = credentialsStore,
-                activityProvider = activityTracker,
-                tierCache = tierCache,
+                auth0Tenant = Auth0Tenant(clientId = AUTH0_CLIENT_ID, domain = AUTH0_DOMAIN),
+                androidLeaves = AndroidLeaves(credentialsStore, activityTracker, tierCache),
                 currentVersion = BuildConfig.VERSION_NAME,
-                enableDebugLogging = BuildConfig.DEBUG,
+                options = AppGraphOptions(enableDebugLogging = BuildConfig.DEBUG),
             )
     }
 }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
@@ -2,21 +2,23 @@ package uk.towncrierapp.app
 
 import android.app.Application
 import android.content.Context
-import uk.towncrierapp.data.auth.SecureCredentialsManagerStore
-import uk.towncrierapp.data.subscriptions.DataStoreSubscriptionTierCache
-import uk.towncrierapp.mobile.BuildConfig
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
 import com.auth0.android.Auth0
 import com.auth0.android.authentication.storage.SecureCredentialsManager
 import com.auth0.android.authentication.storage.SharedPreferencesStorage
+import uk.towncrierapp.data.auth.SecureCredentialsManagerStore
+import uk.towncrierapp.data.subscriptions.DataStoreSubscriptionTierCache
+import uk.towncrierapp.mobile.BuildConfig
 
 /** Auth0 tenant — same for both flavors; only the audience (`BuildConfig.API_BASE_URL`) differs (epic #770 D4). */
 internal const val AUTH0_CLIENT_ID = "2HHUYWnJ3q37a6Elv0cqyFVGbGIbqx34"
 internal const val AUTH0_DOMAIN = "towncrierapp.uk.auth0.com"
 
-private val Context.tierPreferencesDataStore: DataStore<Preferences> by preferencesDataStore(name = "town_crier_preferences")
+private val Context.tierPreferencesDataStore: DataStore<Preferences> by preferencesDataStore(
+    name = "town_crier_preferences",
+)
 
 /**
  * Constructs [AppGraph] — the one place `:app` builds the Android-touching

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
@@ -1,0 +1,56 @@
+package uk.towncrierapp.app
+
+import android.app.Application
+import android.content.Context
+import uk.towncrierapp.data.auth.SecureCredentialsManagerStore
+import uk.towncrierapp.data.subscriptions.DataStoreSubscriptionTierCache
+import uk.towncrierapp.mobile.BuildConfig
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.auth0.android.Auth0
+import com.auth0.android.authentication.storage.SecureCredentialsManager
+import com.auth0.android.authentication.storage.SharedPreferencesStorage
+
+/** Auth0 tenant — same for both flavors; only the audience (`BuildConfig.API_BASE_URL`) differs (epic #770 D4). */
+internal const val AUTH0_CLIENT_ID = "2HHUYWnJ3q37a6Elv0cqyFVGbGIbqx34"
+internal const val AUTH0_DOMAIN = "towncrierapp.uk.auth0.com"
+
+private val Context.tierPreferencesDataStore: DataStore<Preferences> by preferencesDataStore(name = "town_crier_preferences")
+
+/**
+ * Constructs [AppGraph] — the one place `:app` builds the Android-touching
+ * leaves that need a real `Context` (Keystore-backed credentials storage,
+ * DataStore, the current-Activity tracker) before handing them to the
+ * otherwise Context-free composition root (android-coding-standards skill,
+ * architecture-and-modules.md).
+ */
+public class TownCrierApplication : Application() {
+    public lateinit var appGraph: AppGraph
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+
+        val activityTracker = CurrentActivityTracker()
+        registerActivityLifecycleCallbacks(activityTracker)
+
+        val auth0 = Auth0.getInstance(AUTH0_CLIENT_ID, AUTH0_DOMAIN)
+        val credentialsManager = SecureCredentialsManager(this, auth0, SharedPreferencesStorage(this))
+        val credentialsStore = SecureCredentialsManagerStore(credentialsManager)
+
+        val tierCache = DataStoreSubscriptionTierCache(tierPreferencesDataStore)
+
+        appGraph =
+            AppGraph(
+                baseUrl = BuildConfig.API_BASE_URL,
+                auth0ClientId = AUTH0_CLIENT_ID,
+                auth0Domain = AUTH0_DOMAIN,
+                credentialsStore = credentialsStore,
+                activityProvider = activityTracker,
+                tierCache = tierCache,
+                currentVersion = BuildConfig.VERSION_NAME,
+                enableDebugLogging = BuildConfig.DEBUG,
+            )
+    }
+}

--- a/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
+++ b/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
@@ -1,19 +1,54 @@
 package uk.towncrierapp.app
 
+import uk.towncrierapp.data.auth.CredentialsStore
+import uk.towncrierapp.data.auth.CurrentActivityProvider
+import uk.towncrierapp.domain.subscriptions.FakeSubscriptionTierCache
+import com.auth0.android.result.Credentials
+import okhttp3.Call
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 
 /**
  * Because the Android leaves are constructor parameters, a plain JVM test
  * can construct the whole composition root — wiring drift fails here, in
  * `./gradlew test`, rather than on first launch (android-coding-standards
- * skill, architecture-and-modules.md).
+ * skill, architecture-and-modules.md). Every Android-touching leaf here is
+ * an explicit fake — even the default `Call.Factory` — so this test never
+ * depends on whether a *real* `OkHttpClient`/`Auth0` happens to tolerate the
+ * AGP unit-test android.jar stub.
  */
 class AppGraphSmokeTest {
+    private object NoOpCredentialsStore : CredentialsStore {
+        override fun hasValidCredentials(): Boolean = false
+
+        override suspend fun credentials(): Credentials = error("not used in the composition-root smoke test")
+
+        override fun saveCredentials(credentials: Credentials) = Unit
+
+        override fun clearCredentials() = Unit
+    }
+
+    private val noOpCallFactory = Call.Factory { error("not used in the composition-root smoke test") }
+
     @Test
     fun `constructs the composition root without throwing`() {
-        val graph = AppGraph(baseUrl = "https://api-dev.towncrierapp.uk")
+        val graph =
+            AppGraph(
+                baseUrl = "https://api-dev.towncrierapp.uk",
+                auth0ClientId = "client-id",
+                auth0Domain = "towncrierapp.uk.auth0.com",
+                credentialsStore = NoOpCredentialsStore,
+                activityProvider = CurrentActivityProvider { null },
+                tierCache = FakeSubscriptionTierCache(),
+                currentVersion = "0.1.0",
+                callFactory = noOpCallFactory,
+            )
 
         assertEquals("https://api-dev.towncrierapp.uk", graph.baseUrl)
+        assertNotNull(graph.authenticationService)
+        assertNotNull(graph.userProfileRepository)
+        assertNotNull(graph.versionConfigService)
+        assertNotNull(graph.authCoordinator)
     }
 }

--- a/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
+++ b/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
@@ -36,13 +36,15 @@ class AppGraphSmokeTest {
         val graph =
             AppGraph(
                 baseUrl = "https://api-dev.towncrierapp.uk",
-                auth0ClientId = "client-id",
-                auth0Domain = "towncrierapp.uk.auth0.com",
-                credentialsStore = NoOpCredentialsStore,
-                activityProvider = CurrentActivityProvider { null },
-                tierCache = FakeSubscriptionTierCache(),
+                auth0Tenant = Auth0Tenant(clientId = "client-id", domain = "towncrierapp.uk.auth0.com"),
+                androidLeaves =
+                    AndroidLeaves(
+                        credentialsStore = NoOpCredentialsStore,
+                        activityProvider = CurrentActivityProvider { null },
+                        tierCache = FakeSubscriptionTierCache(),
+                    ),
                 currentVersion = "0.1.0",
-                callFactory = noOpCallFactory,
+                options = AppGraphOptions(callFactory = noOpCallFactory),
             )
 
         assertEquals("https://api-dev.towncrierapp.uk", graph.baseUrl)

--- a/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
+++ b/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
@@ -1,11 +1,11 @@
 package uk.towncrierapp.app
 
-import uk.towncrierapp.data.auth.CredentialsStore
-import uk.towncrierapp.data.auth.CurrentActivityProvider
-import uk.towncrierapp.domain.subscriptions.FakeSubscriptionTierCache
 import com.auth0.android.result.Credentials
 import okhttp3.Call
 import org.junit.jupiter.api.Test
+import uk.towncrierapp.data.auth.CredentialsStore
+import uk.towncrierapp.data.auth.CurrentActivityProvider
+import uk.towncrierapp.domain.subscriptions.FakeSubscriptionTierCache
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 

--- a/mobile/android/data/build.gradle.kts
+++ b/mobile/android/data/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.okhttp)
-    implementation(libs.okhttp.coroutines)
     implementation(libs.auth0)
     implementation(libs.androidx.datastore.preferences)
 

--- a/mobile/android/data/build.gradle.kts
+++ b/mobile/android/data/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -35,6 +36,11 @@ dependencies {
     implementation(project(":domain"))
 
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.coroutines)
+    implementation(libs.auth0)
+    implementation(libs.androidx.datastore.preferences)
 
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)
@@ -42,4 +48,6 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
+    // FakeAuthenticationService, anAuthSession(), ... shared via :domain's testFixtures.
+    testImplementation(testFixtures(project(":domain")))
 }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/ApiClient.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/ApiClient.kt
@@ -3,7 +3,6 @@ package uk.towncrierapp.data.api
 import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.MediaType.Companion.toMediaType
@@ -22,16 +21,7 @@ internal data class PagedResult<T>(
     val nextCursor: String?,
 )
 
-// No charset parameter: BridgeInterceptor rewrites the Content-Type header
-// from this RequestBody's contentType() unconditionally once a real
-// OkHttpClient executes the request, so the media type set here — not the
-// explicit header() call below — is what actually reaches the wire. Bare
-// "application/json" keeps both the wire value and the (BridgeInterceptor-
-// free) FakeHttpTransport-observed value equal to the epic's exact contract.
-private val jsonMediaType = "application/json".toMediaType()
-private val emptyBody: RequestBody = ByteArray(0).toRequestBody(null)
-
-/** Marks a 401 response internally so [performRequest] can trigger exactly one refresh-and-retry. */
+/** Marks a 401 response internally so [ApiClient] can trigger exactly one refresh-and-retry. */
 private class UnauthorizedException : Exception()
 
 /**
@@ -42,7 +32,11 @@ private class UnauthorizedException : Exception()
  * always, `Content-Type: application/json` only with a body; on 401,
  * refreshes the session once and retries once; 403 is sniffed for an
  * `insufficient_entitlement` body; 404 and other >=400 map to their
- * `DomainError` cases; nothing else retries.
+ * `DomainError` cases; nothing else retries. Request building and status
+ * mapping are top-level functions in this file, not members — they need
+ * none of this class's mutable/session state, only [baseUrl]/[json] passed
+ * explicitly, which keeps this class's own responsibility to session +
+ * retry orchestration.
  */
 public class ApiClient(
     private val baseUrl: String,
@@ -65,24 +59,7 @@ public class ApiClient(
     /** Returns the raw response body bytes untouched — for opaque payloads (e.g. a future GDPR export). */
     internal suspend fun requestBytes(endpoint: ApiEndpoint): ByteArray {
         val session = requireSession()
-        return try {
-            executeBytes(endpoint, session.accessToken)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: UnauthorizedException) {
-            val refreshed = refreshOrThrow()
-            try {
-                executeBytes(endpoint, refreshed.accessToken)
-            } catch (e2: CancellationException) {
-                throw e2
-            } catch (e2: IOException) {
-                throw DomainError.NetworkUnavailable
-            } catch (e2: UnauthorizedException) {
-                throw DomainError.SessionExpired
-            }
-        } catch (e: IOException) {
-            throw DomainError.NetworkUnavailable
-        }
+        return withRetryOn401(session.accessToken) { accessToken -> executeBytes(endpoint, accessToken) }
     }
 
     private suspend fun <T> performRequest(
@@ -90,14 +67,35 @@ public class ApiClient(
         serializer: KSerializer<T>,
     ): PagedResult<T> {
         val session = requireSession()
-        return try {
-            executeAndDecode(endpoint, session.accessToken, serializer)
+        return withRetryOn401(
+            session.accessToken,
+        ) { accessToken -> executeAndDecode(endpoint, accessToken, serializer) }
+    }
+
+    /**
+     * Runs [action] with [initialAccessToken]; on a 401, refreshes the
+     * session exactly once and retries [action] exactly once with the
+     * refreshed token — the epic's whole retry-policy contract ("no other
+     * retries") lives in this one place so [performRequest] and
+     * [requestBytes] don't each carry their own copy of it.
+     */
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    // The three deliberately-generic catches below ARE the policy table this
+    // function exists to centralise (epic #770: 401 -> refresh-once-retry-
+    // once; IOException -> NetworkUnavailable; anything else -> SessionExpired
+    // with no further retry) — narrowing them would make the policy incomplete.
+    private suspend fun <T> withRetryOn401(
+        initialAccessToken: String,
+        action: suspend (accessToken: String) -> T,
+    ): T =
+        try {
+            action(initialAccessToken)
         } catch (e: CancellationException) {
             throw e
         } catch (e: UnauthorizedException) {
             val refreshed = refreshOrThrow()
             try {
-                executeAndDecode(endpoint, refreshed.accessToken, serializer)
+                action(refreshed.accessToken)
             } catch (e2: CancellationException) {
                 throw e2
             } catch (e2: IOException) {
@@ -110,17 +108,23 @@ public class ApiClient(
         } catch (e: IOException) {
             throw DomainError.NetworkUnavailable
         }
-    }
 
     private suspend fun requireSession(): AuthSession {
-        log { "▶ requesting session" }
+        log(enableDebugLogging) { "▶ requesting session" }
         return authService.currentSession() ?: run {
-            log { "✗ no active session" }
+            log(enableDebugLogging) { "✗ no active session" }
             throw DomainError.SessionExpired
         }
     }
 
-    /** Refreshes the session, normalising every failure per the epic's retry-policy contract. */
+    /**
+     * Refreshes the session, normalising every failure per the epic's
+     * retry-policy contract: [IOException] -> [DomainError.NetworkUnavailable],
+     * anything else -> [DomainError.SessionExpired]. The final catch is
+     * deliberately generic — it's the policy's "anything else" case, not an
+     * oversight — so narrowing it further isn't possible while staying correct.
+     */
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
     private suspend fun refreshOrThrow(): AuthSession =
         try {
             authService.refreshSession()
@@ -139,8 +143,8 @@ public class ApiClient(
     ): PagedResult<T> {
         val response = executeRaw(endpoint, accessToken)
         val bodyText = response.body?.string().orEmpty()
-        mapHttpStatus(response.code, bodyText)
-        return PagedResult(decode(bodyText, serializer), response.header("X-Next-Cursor"))
+        mapHttpStatus(json, response.code, bodyText)
+        return PagedResult(decode(json, bodyText, serializer), response.header("X-Next-Cursor"))
     }
 
     private suspend fun executeBytes(
@@ -149,7 +153,7 @@ public class ApiClient(
     ): ByteArray {
         val response = executeRaw(endpoint, accessToken)
         val bytes = response.body?.bytes() ?: ByteArray(0)
-        mapHttpStatus(response.code, String(bytes, Charsets.UTF_8))
+        mapHttpStatus(json, response.code, String(bytes, Charsets.UTF_8))
         return bytes
     }
 
@@ -157,100 +161,125 @@ public class ApiClient(
         endpoint: ApiEndpoint,
         accessToken: String,
     ): Response {
-        val request = buildRequest(endpoint, accessToken)
-        log { "→ ${endpoint.method} ${endpoint.path}" }
+        val request = buildRequest(baseUrl, endpoint, accessToken)
+        log(enableDebugLogging) { "→ ${endpoint.method} ${endpoint.path}" }
         val response = transport.execute(request)
-        log { "← ${endpoint.method} ${endpoint.path} ${response.code}" }
+        log(enableDebugLogging) { "← ${endpoint.method} ${endpoint.path} ${response.code}" }
         return response
     }
+}
 
-    private fun buildRequest(
-        endpoint: ApiEndpoint,
-        accessToken: String,
-    ): Request {
-        val urlBuilder = baseUrl.toHttpUrl().newBuilder()
-        endpoint.path
-            .trim('/')
-            .split("/")
-            .filter { it.isNotEmpty() }
-            .forEach { urlBuilder.addPathSegment(it) }
-        endpoint.query.forEach { (name, value) -> urlBuilder.addQueryParameter(name, value) }
+private inline fun log(
+    enableDebugLogging: Boolean,
+    message: () -> String,
+) {
+    // Debug-flavor-only request logging (method/path/status — never tokens),
+    // wired from :app via BuildConfig.DEBUG. Guarded so plain JVM unit tests
+    // (enableDebugLogging = false by default) never touch android.util.Log.
+    if (enableDebugLogging) Log.d("ApiClient", message())
+}
 
-        val builder =
-            Request
-                .Builder()
-                .url(urlBuilder.build())
-                .header("Authorization", "Bearer $accessToken")
-                .header("Accept", "application/json")
+// No charset parameter: BridgeInterceptor rewrites the Content-Type header
+// from this RequestBody's contentType() unconditionally once a real
+// OkHttpClient executes the request, so the media type set here — not the
+// explicit header() call below — is what actually reaches the wire. Bare
+// "application/json" keeps both the wire value and the (BridgeInterceptor-
+// free) FakeHttpTransport-observed value equal to the epic's exact contract.
+private val jsonMediaType = "application/json".toMediaType()
+private val emptyBody: RequestBody = ByteArray(0).toRequestBody(null)
 
-        val requestBody = endpoint.body?.toRequestBody(jsonMediaType)
-        if (requestBody != null) {
-            builder.header("Content-Type", "application/json")
-        }
-        when (endpoint.method) {
-            "GET" -> builder.get()
-            "DELETE" -> if (requestBody != null) builder.delete(requestBody) else builder.delete()
-            "POST" -> builder.post(requestBody ?: emptyBody)
-            "PUT" -> builder.put(requestBody ?: emptyBody)
-            "PATCH" -> builder.patch(requestBody ?: emptyBody)
-            else -> error("Unsupported HTTP method: ${endpoint.method}")
-        }
-        return builder.build()
+private fun buildRequest(
+    baseUrl: String,
+    endpoint: ApiEndpoint,
+    accessToken: String,
+): Request {
+    val urlBuilder = baseUrl.toHttpUrl().newBuilder()
+    endpoint.path
+        .trim('/')
+        .split("/")
+        .filter { it.isNotEmpty() }
+        .forEach { urlBuilder.addPathSegment(it) }
+    endpoint.query.forEach { (name, value) -> urlBuilder.addQueryParameter(name, value) }
+
+    val builder =
+        Request
+            .Builder()
+            .url(urlBuilder.build())
+            .header("Authorization", "Bearer $accessToken")
+            .header("Accept", "application/json")
+
+    val requestBody = endpoint.body?.toRequestBody(jsonMediaType)
+    if (requestBody != null) {
+        builder.header("Content-Type", "application/json")
     }
-
-    private fun mapHttpStatus(
-        code: Int,
-        body: String,
-    ) {
-        when {
-            code in 200..299 -> return
-            code == 401 -> throw UnauthorizedException()
-            code == 403 -> throw mapForbidden(body)
-            code == 404 -> throw DomainError.NotFound
-            code >= 400 -> throw DomainError.ServerError(code, body.ifBlank { null })
-        }
+    when (endpoint.method) {
+        "GET" -> builder.get()
+        "DELETE" -> if (requestBody != null) builder.delete(requestBody) else builder.delete()
+        "POST" -> builder.post(requestBody ?: emptyBody)
+        "PUT" -> builder.put(requestBody ?: emptyBody)
+        "PATCH" -> builder.patch(requestBody ?: emptyBody)
+        else -> error("Unsupported HTTP method: ${endpoint.method}")
     }
+    return builder.build()
+}
 
-    private fun mapForbidden(body: String): DomainError {
-        val required = insufficientEntitlementRequired(body)
-        return if (required !=
-            null
-        ) {
-            DomainError.InsufficientEntitlement(required)
-        } else {
-            DomainError.ServerError(403, body.ifBlank { null })
-        }
-    }
-
-    private fun insufficientEntitlementRequired(body: String): String? =
-        try {
-            val decoded = json.decodeFromString(InsufficientEntitlementBody.serializer(), body)
-            decoded.required.takeIf { decoded.error == "insufficient_entitlement" }
-        } catch (e: SerializationException) {
-            null
-        } catch (e: IllegalArgumentException) {
-            null
-        }
-
-    private fun <T> decode(
-        body: String,
-        serializer: KSerializer<T>,
-    ): T =
-        try {
-            json.decodeFromString(serializer, body)
-        } catch (e: SerializationException) {
-            throw DomainError.Unexpected("Failed to decode response: ${e.message}")
-        } catch (e: IllegalArgumentException) {
-            throw DomainError.Unexpected("Failed to decode response: ${e.message}")
-        }
-
-    private inline fun log(message: () -> String) {
-        // Debug-flavor-only request logging (method/path/status — never tokens),
-        // wired from :app via BuildConfig.DEBUG. Guarded so plain JVM unit tests
-        // (enableDebugLogging = false by default) never touch android.util.Log.
-        if (enableDebugLogging) Log.d("ApiClient", message())
+// A status-code-to-error dispatcher inherently branches once per HTTP status
+// bucket (epic #770's exact contract: 401/403/404/other-4xx-5xx) — that IS
+// the function, not a complexity smell to fix by merging branches.
+@Suppress("ThrowsCount")
+private fun mapHttpStatus(
+    json: Json,
+    code: Int,
+    body: String,
+) {
+    when {
+        code in 200..299 -> return
+        code == 401 -> throw UnauthorizedException()
+        code == 403 -> throw mapForbidden(json, body)
+        code == 404 -> throw DomainError.NotFound
+        code >= 400 -> throw DomainError.ServerError(code, body.ifBlank { null })
     }
 }
+
+private fun mapForbidden(
+    json: Json,
+    body: String,
+): DomainError {
+    val required = insufficientEntitlementRequired(json, body)
+    return if (required != null) {
+        DomainError.InsufficientEntitlement(required)
+    } else {
+        DomainError.ServerError(403, body.ifBlank { null })
+    }
+}
+
+@Suppress("SwallowedException")
+// A 403 body that isn't the entitlement envelope is routine (most 403s
+// aren't entitlement-gated) — falling back to a generic ServerError, not a
+// diagnostic-worthy failure.
+private fun insufficientEntitlementRequired(
+    json: Json,
+    body: String,
+): String? =
+    try {
+        val decoded = json.decodeFromString(InsufficientEntitlementBody.serializer(), body)
+        decoded.required.takeIf { decoded.error == "insufficient_entitlement" }
+    } catch (e: IllegalArgumentException) {
+        // SerializationException extends IllegalArgumentException.
+        null
+    }
+
+private fun <T> decode(
+    json: Json,
+    body: String,
+    serializer: KSerializer<T>,
+): T =
+    try {
+        json.decodeFromString(serializer, body)
+    } catch (e: IllegalArgumentException) {
+        // SerializationException extends IllegalArgumentException.
+        throw DomainError.Unexpected("Failed to decode response: ${e.message}", cause = e)
+    }
 
 @kotlinx.serialization.Serializable
 private data class InsufficientEntitlementBody(

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/ApiClient.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/ApiClient.kt
@@ -138,7 +138,7 @@ public class ApiClient(
         serializer: KSerializer<T>,
     ): PagedResult<T> {
         val response = executeRaw(endpoint, accessToken)
-        val bodyText = response.body.string()
+        val bodyText = response.body?.string().orEmpty()
         mapHttpStatus(response.code, bodyText)
         return PagedResult(decode(bodyText, serializer), response.header("X-Next-Cursor"))
     }
@@ -148,7 +148,7 @@ public class ApiClient(
         accessToken: String,
     ): ByteArray {
         val response = executeRaw(endpoint, accessToken)
-        val bytes = response.body.bytes()
+        val bytes = response.body?.bytes() ?: ByteArray(0)
         mapHttpStatus(response.code, String(bytes, Charsets.UTF_8))
         return bytes
     }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/ApiClient.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/ApiClient.kt
@@ -1,0 +1,248 @@
+package uk.towncrierapp.data.api
+
+import android.util.Log
+import uk.towncrierapp.domain.auth.AuthenticationService
+import uk.towncrierapp.domain.auth.AuthSession
+import uk.towncrierapp.domain.auth.DomainError
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+
+/** `requestPaged`'s result: the decoded body plus the opaque `X-Next-Cursor` continuation token (`null` on the last page). */
+internal data class PagedResult<T>(
+    val value: T,
+    val nextCursor: String?,
+)
+
+// No charset parameter: BridgeInterceptor rewrites the Content-Type header
+// from this RequestBody's contentType() unconditionally once a real
+// OkHttpClient executes the request, so the media type set here — not the
+// explicit header() call below — is what actually reaches the wire. Bare
+// "application/json" keeps both the wire value and the (BridgeInterceptor-
+// free) FakeHttpTransport-observed value equal to the epic's exact contract.
+private val jsonMediaType = "application/json".toMediaType()
+private val emptyBody: RequestBody = ByteArray(0).toRequestBody(null)
+
+/** Marks a 401 response internally so [performRequest] can trigger exactly one refresh-and-retry. */
+private class UnauthorizedException : Exception()
+
+/**
+ * Hand-rolled API client — 1:1 port of iOS `URLSessionAPIClient` behaviour
+ * (epic #770 "API contract essentials"; no Retrofit). Every request:
+ * requires a session first (else [DomainError.SessionExpired], no network
+ * call); attaches `Authorization: Bearer`, `Accept: application/json`
+ * always, `Content-Type: application/json` only with a body; on 401,
+ * refreshes the session once and retries once; 403 is sniffed for an
+ * `insufficient_entitlement` body; 404 and other >=400 map to their
+ * `DomainError` cases; nothing else retries.
+ */
+public class ApiClient(
+    private val baseUrl: String,
+    private val transport: HttpTransport,
+    private val authService: AuthenticationService,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+    private val enableDebugLogging: Boolean = false,
+) {
+    internal suspend fun <T> request(
+        endpoint: ApiEndpoint,
+        serializer: KSerializer<T>,
+    ): T = performRequest(endpoint, serializer).value
+
+    /** Returns the decoded body alongside the `X-Next-Cursor` header (`null` = last page). See [PagedResult]. */
+    internal suspend fun <T> requestPaged(
+        endpoint: ApiEndpoint,
+        serializer: KSerializer<T>,
+    ): PagedResult<T> = performRequest(endpoint, serializer)
+
+    /** Returns the raw response body bytes untouched — for opaque payloads (e.g. a future GDPR export). */
+    internal suspend fun requestBytes(endpoint: ApiEndpoint): ByteArray {
+        val session = requireSession()
+        return try {
+            executeBytes(endpoint, session.accessToken)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: UnauthorizedException) {
+            val refreshed = refreshOrThrow()
+            try {
+                executeBytes(endpoint, refreshed.accessToken)
+            } catch (e2: CancellationException) {
+                throw e2
+            } catch (e2: IOException) {
+                throw DomainError.NetworkUnavailable
+            } catch (e2: UnauthorizedException) {
+                throw DomainError.SessionExpired
+            }
+        } catch (e: IOException) {
+            throw DomainError.NetworkUnavailable
+        }
+    }
+
+    private suspend fun <T> performRequest(
+        endpoint: ApiEndpoint,
+        serializer: KSerializer<T>,
+    ): PagedResult<T> {
+        val session = requireSession()
+        return try {
+            executeAndDecode(endpoint, session.accessToken, serializer)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: UnauthorizedException) {
+            val refreshed = refreshOrThrow()
+            try {
+                executeAndDecode(endpoint, refreshed.accessToken, serializer)
+            } catch (e2: CancellationException) {
+                throw e2
+            } catch (e2: IOException) {
+                throw DomainError.NetworkUnavailable
+            } catch (e2: UnauthorizedException) {
+                // The retry itself got another 401 — stop here rather than loop; the
+                // session is unusable either way (epic #770: "no other retries").
+                throw DomainError.SessionExpired
+            }
+        } catch (e: IOException) {
+            throw DomainError.NetworkUnavailable
+        }
+    }
+
+    private suspend fun requireSession(): AuthSession {
+        log { "▶ requesting session" }
+        return authService.currentSession() ?: run {
+            log { "✗ no active session" }
+            throw DomainError.SessionExpired
+        }
+    }
+
+    /** Refreshes the session, normalising every failure per the epic's retry-policy contract. */
+    private suspend fun refreshOrThrow(): AuthSession =
+        try {
+            authService.refreshSession()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: IOException) {
+            throw DomainError.NetworkUnavailable
+        } catch (e: Exception) {
+            throw DomainError.SessionExpired
+        }
+
+    private suspend fun <T> executeAndDecode(
+        endpoint: ApiEndpoint,
+        accessToken: String,
+        serializer: KSerializer<T>,
+    ): PagedResult<T> {
+        val response = executeRaw(endpoint, accessToken)
+        val bodyText = response.body.string()
+        mapHttpStatus(response.code, bodyText)
+        return PagedResult(decode(bodyText, serializer), response.header("X-Next-Cursor"))
+    }
+
+    private suspend fun executeBytes(
+        endpoint: ApiEndpoint,
+        accessToken: String,
+    ): ByteArray {
+        val response = executeRaw(endpoint, accessToken)
+        val bytes = response.body.bytes()
+        mapHttpStatus(response.code, String(bytes, Charsets.UTF_8))
+        return bytes
+    }
+
+    private suspend fun executeRaw(
+        endpoint: ApiEndpoint,
+        accessToken: String,
+    ): Response {
+        val request = buildRequest(endpoint, accessToken)
+        log { "→ ${endpoint.method} ${endpoint.path}" }
+        val response = transport.execute(request)
+        log { "← ${endpoint.method} ${endpoint.path} ${response.code}" }
+        return response
+    }
+
+    private fun buildRequest(
+        endpoint: ApiEndpoint,
+        accessToken: String,
+    ): Request {
+        val urlBuilder = baseUrl.toHttpUrl().newBuilder()
+        endpoint.path.trim('/').split("/").filter { it.isNotEmpty() }.forEach { urlBuilder.addPathSegment(it) }
+        endpoint.query.forEach { (name, value) -> urlBuilder.addQueryParameter(name, value) }
+
+        val builder =
+            Request.Builder()
+                .url(urlBuilder.build())
+                .header("Authorization", "Bearer $accessToken")
+                .header("Accept", "application/json")
+
+        val requestBody = endpoint.body?.toRequestBody(jsonMediaType)
+        if (requestBody != null) {
+            builder.header("Content-Type", "application/json")
+        }
+        when (endpoint.method) {
+            "GET" -> builder.get()
+            "DELETE" -> if (requestBody != null) builder.delete(requestBody) else builder.delete()
+            "POST" -> builder.post(requestBody ?: emptyBody)
+            "PUT" -> builder.put(requestBody ?: emptyBody)
+            "PATCH" -> builder.patch(requestBody ?: emptyBody)
+            else -> error("Unsupported HTTP method: ${endpoint.method}")
+        }
+        return builder.build()
+    }
+
+    private fun mapHttpStatus(
+        code: Int,
+        body: String,
+    ) {
+        when {
+            code in 200..299 -> return
+            code == 401 -> throw UnauthorizedException()
+            code == 403 -> throw mapForbidden(body)
+            code == 404 -> throw DomainError.NotFound
+            code >= 400 -> throw DomainError.ServerError(code, body.ifBlank { null })
+        }
+    }
+
+    private fun mapForbidden(body: String): DomainError {
+        val required = insufficientEntitlementRequired(body)
+        return if (required != null) DomainError.InsufficientEntitlement(required) else DomainError.ServerError(403, body.ifBlank { null })
+    }
+
+    private fun insufficientEntitlementRequired(body: String): String? =
+        try {
+            val decoded = json.decodeFromString(InsufficientEntitlementBody.serializer(), body)
+            decoded.required.takeIf { decoded.error == "insufficient_entitlement" }
+        } catch (e: SerializationException) {
+            null
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+
+    private fun <T> decode(
+        body: String,
+        serializer: KSerializer<T>,
+    ): T =
+        try {
+            json.decodeFromString(serializer, body)
+        } catch (e: SerializationException) {
+            throw DomainError.Unexpected("Failed to decode response: ${e.message}")
+        } catch (e: IllegalArgumentException) {
+            throw DomainError.Unexpected("Failed to decode response: ${e.message}")
+        }
+
+    private inline fun log(message: () -> String) {
+        // Debug-flavor-only request logging (method/path/status — never tokens),
+        // wired from :app via BuildConfig.DEBUG. Guarded so plain JVM unit tests
+        // (enableDebugLogging = false by default) never touch android.util.Log.
+        if (enableDebugLogging) Log.d("ApiClient", message())
+    }
+}
+
+@kotlinx.serialization.Serializable
+private data class InsufficientEntitlementBody(
+    val error: String,
+    val required: String,
+)

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/ApiClient.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/ApiClient.kt
@@ -1,20 +1,20 @@
 package uk.towncrierapp.data.api
 
 import android.util.Log
-import uk.towncrierapp.domain.auth.AuthenticationService
-import uk.towncrierapp.domain.auth.AuthSession
-import uk.towncrierapp.domain.auth.DomainError
-import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import uk.towncrierapp.domain.auth.AuthSession
+import uk.towncrierapp.domain.auth.AuthenticationService
+import uk.towncrierapp.domain.auth.DomainError
+import java.io.IOException
 
 /** `requestPaged`'s result: the decoded body plus the opaque `X-Next-Cursor` continuation token (`null` on the last page). */
 internal data class PagedResult<T>(
@@ -169,11 +169,16 @@ public class ApiClient(
         accessToken: String,
     ): Request {
         val urlBuilder = baseUrl.toHttpUrl().newBuilder()
-        endpoint.path.trim('/').split("/").filter { it.isNotEmpty() }.forEach { urlBuilder.addPathSegment(it) }
+        endpoint.path
+            .trim('/')
+            .split("/")
+            .filter { it.isNotEmpty() }
+            .forEach { urlBuilder.addPathSegment(it) }
         endpoint.query.forEach { (name, value) -> urlBuilder.addQueryParameter(name, value) }
 
         val builder =
-            Request.Builder()
+            Request
+                .Builder()
                 .url(urlBuilder.build())
                 .header("Authorization", "Bearer $accessToken")
                 .header("Accept", "application/json")
@@ -208,7 +213,13 @@ public class ApiClient(
 
     private fun mapForbidden(body: String): DomainError {
         val required = insufficientEntitlementRequired(body)
-        return if (required != null) DomainError.InsufficientEntitlement(required) else DomainError.ServerError(403, body.ifBlank { null })
+        return if (required !=
+            null
+        ) {
+            DomainError.InsufficientEntitlement(required)
+        } else {
+            DomainError.ServerError(403, body.ifBlank { null })
+        }
     }
 
     private fun insufficientEntitlementRequired(body: String): String? =

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/ApiEndpoint.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/ApiEndpoint.kt
@@ -1,0 +1,39 @@
+package uk.towncrierapp.data.api
+
+/**
+ * Describes a request `ApiClient` should make: method, path, an optional
+ * already-JSON-encoded [body] (`null` means no request body at all — e.g.
+ * `POST /v1/me` — not an empty string), and optional query parameters.
+ * `internal`: only `:data`'s own repository implementations construct these
+ * (port of iOS `APIEndpoint`).
+ */
+internal data class ApiEndpoint(
+    val method: String,
+    val path: String,
+    val body: String? = null,
+    val query: List<Pair<String, String>> = emptyList(),
+) {
+    companion object {
+        fun get(
+            path: String,
+            query: List<Pair<String, String>> = emptyList(),
+        ) = ApiEndpoint(method = "GET", path = path, query = query)
+
+        fun post(
+            path: String,
+            body: String? = null,
+        ) = ApiEndpoint(method = "POST", path = path, body = body)
+
+        fun put(
+            path: String,
+            body: String? = null,
+        ) = ApiEndpoint(method = "PUT", path = path, body = body)
+
+        fun patch(
+            path: String,
+            body: String,
+        ) = ApiEndpoint(method = "PATCH", path = path, body = body)
+
+        fun delete(path: String) = ApiEndpoint(method = "DELETE", path = path)
+    }
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/DotNetTimeParser.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/DotNetTimeParser.kt
@@ -1,0 +1,45 @@
+package uk.towncrierapp.data.api
+
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+/**
+ * Parses timestamp strings emitted by the Go backend's `platform.DotNetTime`
+ * format (`2006-01-02T15:04:05.9999999-07:00`) — one shared parser applied
+ * per-field by DTO mappers, never a global kotlinx.serialization date
+ * strategy (epic #770 "API contract essentials"; port of iOS
+ * `DotNetTimeParser`).
+ *
+ * Fractional seconds appear on the wire **only** when the sub-second part is
+ * non-zero, and the offset is spelled either `Z` or `±hh:mm`:
+ *
+ * - `2026-07-20T14:23:45.6789123+00:00` — fractional, numeric offset.
+ * - `2026-06-12T09:30:00+00:00` — whole second, numeric offset.
+ * - `2026-06-12T09:30:00Z` — whole second, `Z` offset.
+ * - `2026-07-20T14:23:45.5Z` — fractional, `Z` offset.
+ *
+ * [DateTimeFormatter.ISO_OFFSET_DATE_TIME] already accepts every one of
+ * these (0-9 optional fractional digits, `Z` or `±hh:mm`), so there is no
+ * need to try multiple formatters like the iOS `ISO8601DateFormatter` port
+ * does — `OffsetDateTime.parse` with the default formatter covers the whole
+ * matrix in one call.
+ */
+public object DotNetTimeParser {
+    /** Returns the parsed instant, or `null` on genuinely unparseable input — never throws. */
+    public fun parse(value: String): OffsetDateTime? =
+        try {
+            OffsetDateTime.parse(value, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        } catch (e: DateTimeParseException) {
+            null
+        }
+
+    /** Parses a bare `yyyy-MM-dd` date-only field (e.g. `startDate`, `decidedDate`) — a separate, simpler format. */
+    public fun parseDate(value: String): LocalDate? =
+        try {
+            LocalDate.parse(value, DateTimeFormatter.ISO_LOCAL_DATE)
+        } catch (e: DateTimeParseException) {
+            null
+        }
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/HttpTransport.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/HttpTransport.kt
@@ -1,0 +1,16 @@
+package uk.towncrierapp.data.api
+
+import okhttp3.Request
+import okhttp3.Response
+
+/**
+ * The transport seam `ApiClient` is built over. Production wires
+ * [OkHttpTransport]; unit tests substitute a hand-written `FakeHttpTransport`
+ * that returns canned [Response]s — no MockWebServer (epic #770 "API
+ * contract essentials" test strategy). This is a deliberately thin,
+ * coroutine-friendly wrapper around OkHttp's own `Call.Factory` seam (see
+ * [OkHttpTransport]), not a reinvention of OkHttp's request/response types.
+ */
+public interface HttpTransport {
+    public suspend fun execute(request: Request): Response
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/OkHttpTransport.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/OkHttpTransport.kt
@@ -25,6 +25,10 @@ public class OkHttpTransport(
     override suspend fun execute(request: Request): Response = callFactory.newCall(request).await()
 }
 
+@Suppress("RedundantSuspendModifier")
+// False positive: this is the textbook suspendCancellableCoroutine bridge —
+// detekt 1.23.8's type-resolution against Kotlin 2.4.0 doesn't recognise it
+// as a suspending call (tracked: tc side-quest bead).
 private suspend fun Call.await(): Response =
     suspendCancellableCoroutine { continuation ->
         enqueue(

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/OkHttpTransport.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/OkHttpTransport.kt
@@ -1,20 +1,48 @@
 package uk.towncrierapp.data.api
 
+import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
+import okhttp3.Callback
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.coroutines.executeAsync
 
 /**
  * Production [HttpTransport]: bridges OkHttp's [Call.Factory] to a suspend
- * call via the official `okhttp-coroutines` artifact's `executeAsync()` —
- * already cancellation-aware (closes the response if the coroutine is
+ * call (android-coding-standards: data-access.md). OkHttp is pinned to the
+ * 4.x line here (the 5.x "okhttp-android" variant declares a compileSdk-36
+ * floor this project doesn't meet), so the official `okhttp-coroutines`
+ * artifact (5.x-only) isn't available — this is that same bridge, hand-
+ * rolled: cancellation-aware (closes the response if the coroutine is
  * cancelled mid-flight) and already non-blocking, so no `withContext`
- * dispatcher hop is needed here (android-coding-standards: coroutines-and-
- * flow.md).
+ * dispatcher hop is needed here.
  */
 public class OkHttpTransport(
     private val callFactory: Call.Factory,
 ) : HttpTransport {
-    override suspend fun execute(request: Request): Response = callFactory.newCall(request).executeAsync()
+    override suspend fun execute(request: Request): Response = callFactory.newCall(request).await()
 }
+
+private suspend fun Call.await(): Response =
+    suspendCancellableCoroutine { continuation ->
+        enqueue(
+            object : Callback {
+                override fun onResponse(
+                    call: Call,
+                    response: Response,
+                ) {
+                    continuation.resume(response) { _, value, _ -> value.close() }
+                }
+
+                override fun onFailure(
+                    call: Call,
+                    e: IOException,
+                ) {
+                    continuation.resumeWithException(e)
+                }
+            },
+        )
+        continuation.invokeOnCancellation { cancel() }
+    }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/OkHttpTransport.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/OkHttpTransport.kt
@@ -1,13 +1,13 @@
 package uk.towncrierapp.data.api
 
-import java.io.IOException
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Request
 import okhttp3.Response
+import java.io.IOException
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * Production [HttpTransport]: bridges OkHttp's [Call.Factory] to a suspend

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/OkHttpTransport.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/OkHttpTransport.kt
@@ -1,0 +1,20 @@
+package uk.towncrierapp.data.api
+
+import okhttp3.Call
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.coroutines.executeAsync
+
+/**
+ * Production [HttpTransport]: bridges OkHttp's [Call.Factory] to a suspend
+ * call via the official `okhttp-coroutines` artifact's `executeAsync()` —
+ * already cancellation-aware (closes the response if the coroutine is
+ * cancelled mid-flight) and already non-blocking, so no `withContext`
+ * dispatcher hop is needed here (android-coding-standards: coroutines-and-
+ * flow.md).
+ */
+public class OkHttpTransport(
+    private val callFactory: Call.Factory,
+) : HttpTransport {
+    override suspend fun execute(request: Request): Response = callFactory.newCall(request).executeAsync()
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationService.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationService.kt
@@ -50,7 +50,7 @@ public class Auth0AuthenticationService(
         } catch (e: CancellationException) {
             throw e
         } catch (e: AuthenticationException) {
-            throw DomainError.AuthenticationFailed(e.getDescription())
+            throw DomainError.AuthenticationFailed(e.getDescription(), cause = e)
         }
     }
 
@@ -65,10 +65,13 @@ public class Auth0AuthenticationService(
         } catch (e: CancellationException) {
             throw e
         } catch (e: AuthenticationException) {
-            throw DomainError.LogoutFailed(e.getDescription())
+            throw DomainError.LogoutFailed(e.getDescription(), cause = e)
         }
     }
 
+    @Suppress("SwallowedException")
+    // The Unrecoverable case doesn't need e's contents: any unrecoverable
+    // failure means "wipe and force re-login", regardless of which one it was.
     override suspend fun refreshSession(): AuthSession {
         val credentials =
             try {
@@ -100,6 +103,10 @@ public class Auth0AuthenticationService(
         return sessionCache.currentOrLoad(clock) { loadFromStore() }
     }
 
+    @Suppress("SwallowedException")
+    // Any credentials-store failure here degrades to "signed out" (matches
+    // iOS's blanket catch in the equivalent slow path) — the specific
+    // failure reason doesn't change the outcome.
     private suspend fun loadFromStore(): AuthSession? {
         // hasValidCredentials() on the real SDK already folds in refresh-token
         // renewability — an expired access token with a valid, non-expired

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationService.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationService.kt
@@ -4,12 +4,12 @@ import com.auth0.android.Auth0
 import com.auth0.android.authentication.AuthenticationException
 import com.auth0.android.provider.WebAuthProvider
 import com.auth0.android.result.Credentials
+import kotlinx.coroutines.CancellationException
 import uk.towncrierapp.domain.auth.AuthSession
 import uk.towncrierapp.domain.auth.AuthenticationService
 import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.domain.auth.UserProfile
 import java.time.Clock
-import kotlinx.coroutines.CancellationException
 
 /**
  * Auth0 Android SDK implementation of [AuthenticationService] — port of iOS

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationService.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationService.kt
@@ -1,0 +1,137 @@
+package uk.towncrierapp.data.auth
+
+import com.auth0.android.Auth0
+import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.provider.WebAuthProvider
+import com.auth0.android.result.Credentials
+import uk.towncrierapp.domain.auth.AuthSession
+import uk.towncrierapp.domain.auth.AuthenticationService
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.auth.UserProfile
+import java.time.Clock
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Auth0 Android SDK implementation of [AuthenticationService] — port of iOS
+ * `Auth0AuthenticationService` (epic #770 "API contract essentials").
+ * `login()`/`logout()` need a real Activity + Custom Tabs and are verified
+ * on-device; `currentSession()`/`refreshSession()`'s logic is unit-tested
+ * entirely against [CredentialsStore] (see `Auth0AuthenticationServiceTest`).
+ *
+ * [auth0] is lazy: constructing a real `com.auth0.android.Auth0` touches
+ * `android.text.TextUtils` (via its user-agent header), which crashes under
+ * plain JVM unit tests (no Robolectric). Deferring construction until
+ * `login()`/`logout()` actually run keeps the rest of this class's testable
+ * surface free of that Android dependency.
+ */
+public class Auth0AuthenticationService(
+    private val config: Auth0Config,
+    private val credentialsStore: CredentialsStore,
+    private val activityProvider: CurrentActivityProvider,
+    private val auth0: Lazy<Auth0>,
+    private val sessionCache: SessionCache,
+    private val clock: Clock = Clock.systemUTC(),
+) : AuthenticationService {
+    override suspend fun login(): AuthSession {
+        val activity =
+            activityProvider.currentActivity()
+                ?: throw DomainError.AuthenticationFailed("No active screen to present sign-in")
+        try {
+            val credentials =
+                WebAuthProvider
+                    .login(auth0.value)
+                    .withScope(Auth0Config.SCOPE)
+                    .withAudience(config.audience)
+                    .await(activity)
+            credentialsStore.saveCredentials(credentials)
+            val session = credentials.toAuthSession()
+            sessionCache.store(session)
+            return session
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: AuthenticationException) {
+            throw DomainError.AuthenticationFailed(e.getDescription())
+        }
+    }
+
+    override suspend fun logout() {
+        try {
+            // Clearing the SSO cookie needs a foreground Activity; if none is
+            // available we still clear local state below rather than leaving
+            // the user stuck signed-in on this device (safe degrade).
+            activityProvider.currentActivity()?.let { activity -> WebAuthProvider.logout(auth0.value).await(activity) }
+            credentialsStore.clearCredentials()
+            sessionCache.clear()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: AuthenticationException) {
+            throw DomainError.LogoutFailed(e.getDescription())
+        }
+    }
+
+    override suspend fun refreshSession(): AuthSession {
+        val credentials =
+            try {
+                credentialsStore.credentials()
+            } catch (e: CredentialsStoreException.Unrecoverable) {
+                credentialsStore.clearCredentials()
+                sessionCache.clear()
+                throw DomainError.SessionExpired
+            } catch (e: CredentialsStoreException.Transient) {
+                // Network/Keystore hiccup — never wipe; surface the cause so
+                // ApiClient can distinguish NetworkUnavailable from SessionExpired.
+                throw e.cause ?: DomainError.SessionExpired
+            }
+        if (!JwtClaims.audienceMatches(credentials.accessToken, config.audience)) {
+            // Stored token targets a different API audience (env flip, #680) —
+            // still un-expired, but the new API would 401 it. Wipe and force a
+            // fresh login rather than hand back a token that can't work.
+            credentialsStore.clearCredentials()
+            sessionCache.clear()
+            throw DomainError.SessionExpired
+        }
+        val session = credentials.toAuthSession()
+        sessionCache.store(session)
+        return session
+    }
+
+    override suspend fun currentSession(): AuthSession? {
+        sessionCache.current(clock)?.let { return it }
+        return sessionCache.currentOrLoad(clock) { loadFromStore() }
+    }
+
+    private suspend fun loadFromStore(): AuthSession? {
+        // hasValidCredentials() on the real SDK already folds in refresh-token
+        // renewability — an expired access token with a valid, non-expired
+        // refresh token reports true here (tc-funq), so this does not need a
+        // separate canRenew() check the way the iOS port does.
+        if (!credentialsStore.hasValidCredentials()) return null
+        val credentials =
+            try {
+                credentialsStore.credentials()
+            } catch (e: CredentialsStoreException) {
+                return null
+            }
+        if (!JwtClaims.audienceMatches(credentials.accessToken, config.audience)) {
+            // Fails open elsewhere (see JwtClaims.audienceMatches); a genuine
+            // mismatch here means the token is unusable — discard it (#680).
+            credentialsStore.clearCredentials()
+            return null
+        }
+        return credentials.toAuthSession()
+    }
+}
+
+private fun Credentials.toAuthSession(): AuthSession =
+    AuthSession(
+        accessToken = accessToken,
+        idToken = idToken,
+        expiresAt = expiresAt.toInstant(),
+        userProfile =
+            UserProfile(
+                userId = JwtClaims.extractSubject(idToken) ?: JwtClaims.extractSubject(accessToken).orEmpty(),
+                email = JwtClaims.extractEmail(idToken).orEmpty(),
+                name = JwtClaims.extractName(idToken),
+            ),
+        subscriptionTier = JwtClaims.extractTier(accessToken),
+    )

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/Auth0Config.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/Auth0Config.kt
@@ -1,0 +1,17 @@
+package uk.towncrierapp.data.auth
+
+/** Auth0 tenant configuration for one build flavor. Both flavors share [clientId] and [domain]; only [audience] differs (epic #770 D4). */
+public data class Auth0Config(
+    val clientId: String,
+    val domain: String,
+    val audience: String,
+) {
+    init {
+        require(audience.isNotEmpty()) { "Auth0Config.audience must not be empty" }
+    }
+
+    internal companion object {
+        /** Scope requested at login — `offline_access` is what makes the refresh token flow work at all. */
+        const val SCOPE = "openid profile email offline_access"
+    }
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/CredentialsStore.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/CredentialsStore.kt
@@ -1,0 +1,42 @@
+package uk.towncrierapp.data.auth
+
+import com.auth0.android.result.Credentials
+
+/**
+ * Seam over the Auth0 Android SDK's `SecureCredentialsManager` (which has an
+ * `internal` constructor and needs a real `Context`, so it cannot itself be
+ * subclassed or faked). [Auth0AuthenticationService]'s testable logic
+ * (aud-mismatch wipe, renewability, refresh unrecoverable-vs-transient) is
+ * written entirely against this interface; [SecureCredentialsManagerStore]
+ * is the thin, untested-by-design Android adapter, and `FakeCredentialsStore`
+ * (test source set) stands in for unit tests.
+ */
+public interface CredentialsStore {
+    /** Whether stored credentials are valid — including refresh-token renewability (the real SDK's `hasValidCredentials()` already folds this in; tc-funq). */
+    public fun hasValidCredentials(): Boolean
+
+    /** Returns the current credentials, renewing via the refresh token if the access token has expired. Throws [CredentialsStoreException]. */
+    public suspend fun credentials(): Credentials
+
+    public fun saveCredentials(credentials: Credentials)
+
+    public fun clearCredentials()
+}
+
+/**
+ * Normalised failure classification for [CredentialsStore.credentials] — the
+ * real adapter is responsible for inspecting the Auth0 SDK's
+ * `CredentialsManagerException` (whose `Code` enum is internal to the SDK
+ * module and not visible here) and mapping it to one of these two cases.
+ */
+internal sealed class CredentialsStoreException(
+    override val cause: Throwable? = null,
+) : Exception(cause) {
+    /** No refresh token present, or it is invalid/revoked — re-authentication is required. */
+    internal object Unrecoverable : CredentialsStoreException()
+
+    /** A network or Keystore hiccup — transient, must NOT wipe stored credentials. */
+    internal class Transient(
+        cause: Throwable,
+    ) : CredentialsStoreException(cause)
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/CurrentActivityProvider.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/CurrentActivityProvider.kt
@@ -1,0 +1,16 @@
+package uk.towncrierapp.data.auth
+
+import android.app.Activity
+
+/**
+ * Supplies the current foreground [Activity] to [Auth0AuthenticationService]
+ * at the moment `login()`/`logout()` run — Auth0's `WebAuthProvider` needs an
+ * Activity context to launch Custom Tabs, but the `:domain` port
+ * (`AuthenticationService.login()`) deliberately takes none, so it can stay
+ * a plain-Kotlin interface. `:app` wires the real implementation by tracking
+ * `Application.ActivityLifecycleCallbacks` — never held longer than needed,
+ * never stored across process states.
+ */
+public fun interface CurrentActivityProvider {
+    public fun currentActivity(): Activity?
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/JwtClaims.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/JwtClaims.kt
@@ -1,13 +1,13 @@
 package uk.towncrierapp.data.auth
 
-import uk.towncrierapp.domain.subscriptions.SubscriptionTier
-import java.util.Base64
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import java.util.Base64
 
 /**
  * Decodes JWT payloads and extracts the individual claims

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/JwtClaims.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/JwtClaims.kt
@@ -1,6 +1,5 @@
 package uk.towncrierapp.data.auth
 
-import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonObject
@@ -63,15 +62,17 @@ public object JwtClaims {
     }
 
     /** Decodes the base64url JSON payload segment of [token] into a [JsonObject], or `null` if malformed. */
+    @Suppress("SwallowedException")
+    // Malformed/foreign tokens are expected, routine input here (not a bug to
+    // diagnose) — every caller's contract is "null means fail open" (#680).
     internal fun decodePayload(token: String): JsonObject? {
         val segments = token.split(".")
         if (segments.size < 2) return null
         return try {
             val bytes = Base64.getUrlDecoder().decode(padBase64Url(segments[1]))
+            // SerializationException extends IllegalArgumentException.
             Json.parseToJsonElement(String(bytes, Charsets.UTF_8)) as? JsonObject
         } catch (e: IllegalArgumentException) {
-            null
-        } catch (e: SerializationException) {
             null
         }
     }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/JwtClaims.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/JwtClaims.kt
@@ -1,0 +1,83 @@
+package uk.towncrierapp.data.auth
+
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import java.util.Base64
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Decodes JWT payloads and extracts the individual claims
+ * `Auth0AuthenticationService` needs — base64url decode of the payload
+ * segment only, **no signature verification** (Auth0 already validated the
+ * token; this is purely for reading claims client-side). Port of iOS
+ * `JWTSubscriptionTierExtractor`.
+ */
+public object JwtClaims {
+    /** Extracts the `subscription_tier` claim. Defaults to [SubscriptionTier.FREE] when absent, unrecognised, or malformed. */
+    public fun extractTier(accessToken: String): SubscriptionTier {
+        val claim = decodePayload(accessToken)?.get("subscription_tier")?.jsonPrimitive?.contentOrNull
+        return claim?.let { SubscriptionTier.fromWireValue(it) } ?: SubscriptionTier.FREE
+    }
+
+    /** Extracts the `sub` claim, or `null` if absent or the token is malformed. */
+    public fun extractSubject(token: String): String? = decodePayload(token)?.get("sub")?.jsonPrimitive?.contentOrNull
+
+    /** Extracts the `email` claim, or `null` if absent or the token is malformed. May legitimately be blank (Sign in with Apple has no email scope). */
+    public fun extractEmail(token: String): String? = decodePayload(token)?.get("email")?.jsonPrimitive?.contentOrNull
+
+    /** Extracts the `name` claim, or `null` if absent or the token is malformed. */
+    public fun extractName(token: String): String? = decodePayload(token)?.get("name")?.jsonPrimitive?.contentOrNull
+
+    /**
+     * Extracts the `aud` claim, normalised to a list. Per RFC 7519 the claim
+     * may be a single string or an array of strings; both shapes return as
+     * `List<String>`. Returns an empty list when the claim is absent or the
+     * token is malformed — callers treat that as "unknown audience" and fail
+     * open (see [audienceMatches]).
+     */
+    public fun extractAudiences(token: String): List<String> {
+        val aud = decodePayload(token)?.get("aud") ?: return emptyList()
+        return when (aud) {
+            is JsonArray -> aud.mapNotNull { it.jsonPrimitive.contentOrNull }
+            else -> listOfNotNull(aud.jsonPrimitive.contentOrNull)
+        }
+    }
+
+    /**
+     * Whether [accessToken] was issued for [expectedAudience]. **Fails
+     * open**: a token whose `aud` claim is absent or undecodable is treated
+     * as matching, so a parsing hiccup never signs a user out (#680 aud-
+     * mismatch wipe semantics — the wipe only fires on a genuine mismatch).
+     */
+    public fun audienceMatches(
+        accessToken: String,
+        expectedAudience: String,
+    ): Boolean {
+        val audiences = extractAudiences(accessToken)
+        if (audiences.isEmpty()) return true
+        return expectedAudience in audiences
+    }
+
+    /** Decodes the base64url JSON payload segment of [token] into a [JsonObject], or `null` if malformed. */
+    internal fun decodePayload(token: String): JsonObject? {
+        val segments = token.split(".")
+        if (segments.size < 2) return null
+        return try {
+            val bytes = Base64.getUrlDecoder().decode(padBase64Url(segments[1]))
+            Json.parseToJsonElement(String(bytes, Charsets.UTF_8)) as? JsonObject
+        } catch (e: IllegalArgumentException) {
+            null
+        } catch (e: SerializationException) {
+            null
+        }
+    }
+
+    private fun padBase64Url(segment: String): String {
+        val remainder = segment.length % 4
+        return if (remainder == 0) segment else segment + "=".repeat(4 - remainder)
+    }
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/SecureCredentialsManagerStore.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/SecureCredentialsManagerStore.kt
@@ -24,7 +24,14 @@ public class SecureCredentialsManagerStore(
         try {
             manager.awaitCredentials()
         } catch (e: CredentialsManagerException) {
-            throw if (isUnrecoverable(e)) CredentialsStoreException.Unrecoverable else CredentialsStoreException.Transient(e)
+            throw if (isUnrecoverable(
+                    e,
+                )
+            ) {
+                CredentialsStoreException.Unrecoverable
+            } else {
+                CredentialsStoreException.Transient(e)
+            }
         }
 
     override fun saveCredentials(credentials: Credentials): Unit = manager.saveCredentials(credentials)
@@ -33,12 +40,22 @@ public class SecureCredentialsManagerStore(
 
     private fun isUnrecoverable(error: CredentialsManagerException): Boolean =
         when {
-            error == CredentialsManagerException.NO_REFRESH_TOKEN -> true
-            error == CredentialsManagerException.NO_CREDENTIALS -> true
-            error == CredentialsManagerException.RENEW_FAILED || error == CredentialsManagerException.SSO_EXCHANGE_FAILED -> {
+            error == CredentialsManagerException.NO_REFRESH_TOKEN -> {
+                true
+            }
+
+            error == CredentialsManagerException.NO_CREDENTIALS -> {
+                true
+            }
+
+            error == CredentialsManagerException.RENEW_FAILED ||
+                error == CredentialsManagerException.SSO_EXCHANGE_FAILED -> {
                 val cause = error.cause as? AuthenticationException
                 cause?.isInvalidRefreshToken == true || cause?.isRefreshTokenDeleted == true
             }
-            else -> false
+
+            else -> {
+                false
+            }
         }
 }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/SecureCredentialsManagerStore.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/SecureCredentialsManagerStore.kt
@@ -1,0 +1,44 @@
+package uk.towncrierapp.data.auth
+
+import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.authentication.storage.CredentialsManagerException
+import com.auth0.android.authentication.storage.SecureCredentialsManager
+import com.auth0.android.result.Credentials
+
+/**
+ * Production [CredentialsStore]: a thin adapter over the real
+ * `SecureCredentialsManager` (Keystore-backed). Deliberately not unit tested
+ * — `SecureCredentialsManager` needs a real `Context`/Keystore and has an
+ * `internal` SDK constructor (android-coding-standards testing.md: "what not
+ * to test" — thin, delegation-only Android glue; verified on the emulator).
+ * [isUnrecoverable] is the one piece of real logic here, classifying the
+ * SDK's `CredentialsManagerException` (whose `Code` enum is internal to the
+ * SDK module) via its exposed singleton constants.
+ */
+public class SecureCredentialsManagerStore(
+    private val manager: SecureCredentialsManager,
+) : CredentialsStore {
+    override fun hasValidCredentials(): Boolean = manager.hasValidCredentials()
+
+    override suspend fun credentials(): Credentials =
+        try {
+            manager.awaitCredentials()
+        } catch (e: CredentialsManagerException) {
+            throw if (isUnrecoverable(e)) CredentialsStoreException.Unrecoverable else CredentialsStoreException.Transient(e)
+        }
+
+    override fun saveCredentials(credentials: Credentials): Unit = manager.saveCredentials(credentials)
+
+    override fun clearCredentials(): Unit = manager.clearCredentials()
+
+    private fun isUnrecoverable(error: CredentialsManagerException): Boolean =
+        when {
+            error == CredentialsManagerException.NO_REFRESH_TOKEN -> true
+            error == CredentialsManagerException.NO_CREDENTIALS -> true
+            error == CredentialsManagerException.RENEW_FAILED || error == CredentialsManagerException.SSO_EXCHANGE_FAILED -> {
+                val cause = error.cause as? AuthenticationException
+                cause?.isInvalidRefreshToken == true || cause?.isRefreshTokenDeleted == true
+            }
+            else -> false
+        }
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/SessionCache.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/SessionCache.kt
@@ -32,6 +32,10 @@ public class SessionCache(
     private var inFlight: Deferred<AuthSession?>? = null
 
     /** A cached session, or `null` if none is held or it's within [leadTimeSeconds] of expiry. Never triggers a load. */
+    @Suppress("RedundantSuspendModifier")
+    // False positive: this genuinely suspends via mutex.withLock (suspend
+    // inline fun) — detekt 1.23.8's type-resolution against Kotlin 2.4.0
+    // doesn't see through the inline call (tracked: tc side-quest bead).
     public suspend fun current(clock: Clock): AuthSession? = mutex.withLock { validOrNull(clock) }
 
     private fun validOrNull(clock: Clock): AuthSession? =
@@ -60,11 +64,15 @@ public class SessionCache(
     }
 
     /** Stores [session] directly — used after a successful login or refresh round-trip. */
+    @Suppress("RedundantSuspendModifier")
+    // False positive — see current() above.
     public suspend fun store(session: AuthSession) {
         mutex.withLock { cached = session }
     }
 
     /** Drops the cached session and cancels any in-flight load — used on logout and unrecoverable refresh failures. */
+    @Suppress("RedundantSuspendModifier")
+    // False positive — see current() above.
     public suspend fun clear() {
         mutex.withLock {
             cached = null

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/SessionCache.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/SessionCache.kt
@@ -1,0 +1,72 @@
+package uk.towncrierapp.data.auth
+
+import uk.towncrierapp.domain.auth.AuthSession
+import java.time.Clock
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * In-memory cache for the current [AuthSession] (iOS tc-3d7b). Concurrent
+ * foreground bursts (a push tap arriving while the login check and the tier
+ * resolver are already in flight) were each hitting
+ * `SecureCredentialsManager` independently; this cache holds the most
+ * recently loaded session while its access token has at least
+ * [leadTimeSeconds] left before expiry, and single-flights concurrent cold
+ * reads to one [loader] invocation via a shared [Deferred] so a four-way
+ * burst issues at most one credentials-store read.
+ *
+ * [scope] is the rare case of an explicit, injected `CoroutineScope` for
+ * process-lifetime work (android-coding-standards: coroutines-and-flow.md)
+ * — the in-flight load must outlive whichever individual caller's coroutine
+ * happens to create it, so every concurrent caller observes the same result.
+ */
+internal class SessionCache(
+    private val scope: CoroutineScope,
+    private val leadTimeSeconds: Long = 60,
+) {
+    private val mutex = Mutex()
+    private var cached: AuthSession? = null
+    private var inFlight: Deferred<AuthSession?>? = null
+
+    /** A cached session, or `null` if none is held or it's within [leadTimeSeconds] of expiry. Never triggers a load. */
+    suspend fun current(clock: Clock): AuthSession? = mutex.withLock { validOrNull(clock) }
+
+    private fun validOrNull(clock: Clock): AuthSession? = cached?.takeIf { it.expiresAt.minusSeconds(leadTimeSeconds).isAfter(clock.instant()) }
+
+    /** Returns the cached session if valid, otherwise runs [loader] — sharing one in-flight call across concurrent cold callers. */
+    suspend fun currentOrLoad(
+        clock: Clock,
+        loader: suspend () -> AuthSession?,
+    ): AuthSession? {
+        val deferred =
+            mutex.withLock {
+                validOrNull(clock)?.let { return it }
+                inFlight ?: scope.async { loader() }.also { inFlight = it }
+            }
+        val result = deferred.await()
+        mutex.withLock {
+            if (inFlight === deferred) {
+                cached = result
+                inFlight = null
+            }
+        }
+        return result
+    }
+
+    /** Stores [session] directly — used after a successful login or refresh round-trip. */
+    suspend fun store(session: AuthSession) {
+        mutex.withLock { cached = session }
+    }
+
+    /** Drops the cached session and cancels any in-flight load — used on logout and unrecoverable refresh failures. */
+    suspend fun clear() {
+        mutex.withLock {
+            cached = null
+            inFlight?.cancel()
+            inFlight = null
+        }
+    }
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/SessionCache.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/SessionCache.kt
@@ -23,7 +23,7 @@ import kotlinx.coroutines.sync.withLock
  * — the in-flight load must outlive whichever individual caller's coroutine
  * happens to create it, so every concurrent caller observes the same result.
  */
-internal class SessionCache(
+public class SessionCache(
     private val scope: CoroutineScope,
     private val leadTimeSeconds: Long = 60,
 ) {
@@ -32,12 +32,12 @@ internal class SessionCache(
     private var inFlight: Deferred<AuthSession?>? = null
 
     /** A cached session, or `null` if none is held or it's within [leadTimeSeconds] of expiry. Never triggers a load. */
-    suspend fun current(clock: Clock): AuthSession? = mutex.withLock { validOrNull(clock) }
+    public suspend fun current(clock: Clock): AuthSession? = mutex.withLock { validOrNull(clock) }
 
     private fun validOrNull(clock: Clock): AuthSession? = cached?.takeIf { it.expiresAt.minusSeconds(leadTimeSeconds).isAfter(clock.instant()) }
 
     /** Returns the cached session if valid, otherwise runs [loader] — sharing one in-flight call across concurrent cold callers. */
-    suspend fun currentOrLoad(
+    public suspend fun currentOrLoad(
         clock: Clock,
         loader: suspend () -> AuthSession?,
     ): AuthSession? {
@@ -57,12 +57,12 @@ internal class SessionCache(
     }
 
     /** Stores [session] directly — used after a successful login or refresh round-trip. */
-    suspend fun store(session: AuthSession) {
+    public suspend fun store(session: AuthSession) {
         mutex.withLock { cached = session }
     }
 
     /** Drops the cached session and cancels any in-flight load — used on logout and unrecoverable refresh failures. */
-    suspend fun clear() {
+    public suspend fun clear() {
         mutex.withLock {
             cached = null
             inFlight?.cancel()

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/SessionCache.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/auth/SessionCache.kt
@@ -1,12 +1,12 @@
 package uk.towncrierapp.data.auth
 
-import uk.towncrierapp.domain.auth.AuthSession
-import java.time.Clock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import uk.towncrierapp.domain.auth.AuthSession
+import java.time.Clock
 
 /**
  * In-memory cache for the current [AuthSession] (iOS tc-3d7b). Concurrent
@@ -34,7 +34,10 @@ public class SessionCache(
     /** A cached session, or `null` if none is held or it's within [leadTimeSeconds] of expiry. Never triggers a load. */
     public suspend fun current(clock: Clock): AuthSession? = mutex.withLock { validOrNull(clock) }
 
-    private fun validOrNull(clock: Clock): AuthSession? = cached?.takeIf { it.expiresAt.minusSeconds(leadTimeSeconds).isAfter(clock.instant()) }
+    private fun validOrNull(clock: Clock): AuthSession? =
+        cached?.takeIf {
+            it.expiresAt.minusSeconds(leadTimeSeconds).isAfter(clock.instant())
+        }
 
     /** Returns the cached session if valid, otherwise runs [loader] — sharing one in-flight call across concurrent cold callers. */
     public suspend fun currentOrLoad(

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/profile/ApiUserProfileRepository.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/profile/ApiUserProfileRepository.kt
@@ -1,17 +1,18 @@
 package uk.towncrierapp.data.profile
 
+import kotlinx.serialization.Serializable
 import uk.towncrierapp.data.api.ApiClient
 import uk.towncrierapp.data.api.ApiEndpoint
 import uk.towncrierapp.domain.profile.ServerProfile
 import uk.towncrierapp.domain.profile.UserProfileRepository
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
-import kotlinx.serialization.Serializable
 
 /** `UserProfileRepository` over the Town Crier API — `POST /v1/me` (ensure-profile) only; fetch/update/delete/export land with #778. */
 public class ApiUserProfileRepository(
     private val apiClient: ApiClient,
 ) : UserProfileRepository {
-    override suspend fun ensureProfile(): ServerProfile = apiClient.request(ApiEndpoint.post("/v1/me"), ServerProfileDto.serializer()).toDomain()
+    override suspend fun ensureProfile(): ServerProfile =
+        apiClient.request(ApiEndpoint.post("/v1/me"), ServerProfileDto.serializer()).toDomain()
 }
 
 @Serializable

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/profile/ApiUserProfileRepository.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/profile/ApiUserProfileRepository.kt
@@ -1,0 +1,31 @@
+package uk.towncrierapp.data.profile
+
+import uk.towncrierapp.data.api.ApiClient
+import uk.towncrierapp.data.api.ApiEndpoint
+import uk.towncrierapp.domain.profile.ServerProfile
+import uk.towncrierapp.domain.profile.UserProfileRepository
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import kotlinx.serialization.Serializable
+
+/** `UserProfileRepository` over the Town Crier API — `POST /v1/me` (ensure-profile) only; fetch/update/delete/export land with #778. */
+public class ApiUserProfileRepository(
+    private val apiClient: ApiClient,
+) : UserProfileRepository {
+    override suspend fun ensureProfile(): ServerProfile = apiClient.request(ApiEndpoint.post("/v1/me"), ServerProfileDto.serializer()).toDomain()
+}
+
+@Serializable
+internal data class ServerProfileDto(
+    val userId: String,
+    val pushEnabled: Boolean,
+    val tier: String,
+)
+
+internal fun ServerProfileDto.toDomain(): ServerProfile =
+    ServerProfile(
+        userId = userId,
+        pushEnabled = pushEnabled,
+        // Falls back to Free on an unrecognised wire value rather than crashing —
+        // the server is authoritative and may add tiers this build doesn't know yet.
+        tier = SubscriptionTier.fromWireValue(tier) ?: SubscriptionTier.FREE,
+    )

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/subscriptions/DataStoreSubscriptionTierCache.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/subscriptions/DataStoreSubscriptionTierCache.kt
@@ -1,0 +1,31 @@
+package uk.towncrierapp.data.subscriptions
+
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.domain.subscriptions.SubscriptionTierCache
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+private val CACHED_SUBSCRIPTION_TIER_KEY = stringPreferencesKey("cachedSubscriptionTier")
+
+/**
+ * DataStore Preferences-backed [SubscriptionTierCache] — the
+ * `cachedSubscriptionTier` device latch (epic #770, same key iOS uses in
+ * `UserDefaults`). A one-shot suspend read/write, not a `Flow`: this is the
+ * cold-start fast-path value, not something the UI observes live.
+ */
+public class DataStoreSubscriptionTierCache(
+    private val dataStore: DataStore<Preferences>,
+) : SubscriptionTierCache {
+    override suspend fun read(): SubscriptionTier? =
+        dataStore.data
+            .map { preferences -> preferences[CACHED_SUBSCRIPTION_TIER_KEY]?.let { SubscriptionTier.fromWireValue(it) } }
+            .first()
+
+    override suspend fun write(tier: SubscriptionTier) {
+        dataStore.edit { preferences -> preferences[CACHED_SUBSCRIPTION_TIER_KEY] = tier.wireValue }
+    }
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/subscriptions/DataStoreSubscriptionTierCache.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/subscriptions/DataStoreSubscriptionTierCache.kt
@@ -1,13 +1,13 @@
 package uk.towncrierapp.data.subscriptions
 
-import uk.towncrierapp.domain.subscriptions.SubscriptionTier
-import uk.towncrierapp.domain.subscriptions.SubscriptionTierCache
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.domain.subscriptions.SubscriptionTierCache
 
 private val CACHED_SUBSCRIPTION_TIER_KEY = stringPreferencesKey("cachedSubscriptionTier")
 
@@ -22,8 +22,9 @@ public class DataStoreSubscriptionTierCache(
 ) : SubscriptionTierCache {
     override suspend fun read(): SubscriptionTier? =
         dataStore.data
-            .map { preferences -> preferences[CACHED_SUBSCRIPTION_TIER_KEY]?.let { SubscriptionTier.fromWireValue(it) } }
-            .first()
+            .map { preferences ->
+                preferences[CACHED_SUBSCRIPTION_TIER_KEY]?.let { SubscriptionTier.fromWireValue(it) }
+            }.first()
 
     override suspend fun write(tier: SubscriptionTier) {
         dataStore.edit { preferences -> preferences[CACHED_SUBSCRIPTION_TIER_KEY] = tier.wireValue }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/versionconfig/ApiVersionConfigService.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/versionconfig/ApiVersionConfigService.kt
@@ -23,6 +23,14 @@ public class ApiVersionConfigService(
     private val transport: HttpTransport,
     private val json: Json = Json { ignoreUnknownKeys = true },
 ) : VersionConfigService {
+    @Suppress("SwallowedException", "UnreachableCode")
+    // SwallowedException: DomainError.NetworkUnavailable carries no payload
+    // by design (matches every other transport-failure mapping in this
+    // codebase) — nothing to preserve from the underlying IOException.
+    // UnreachableCode: false positive on the `val dto = try {...}` and
+    // `return ... ?: throw ...` statements below — both are genuinely
+    // reachable on the success path; detekt 1.23.8's type-resolution against
+    // Kotlin 2.4.0 misreports them (tracked: tc side-quest bead).
     override suspend fun fetchMinimumVersion(): AppVersion {
         val url =
             baseUrl
@@ -57,7 +65,7 @@ public class ApiVersionConfigService(
             try {
                 json.decodeFromString(VersionConfigDto.serializer(), bodyText)
             } catch (e: SerializationException) {
-                throw DomainError.Unexpected("Invalid version config response")
+                throw DomainError.Unexpected("Invalid version config response: ${e.message}", cause = e)
             }
 
         return AppVersion.parse(dto.minimumVersion)

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/versionconfig/ApiVersionConfigService.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/versionconfig/ApiVersionConfigService.kt
@@ -36,7 +36,7 @@ public class ApiVersionConfigService(
                 throw DomainError.NetworkUnavailable
             }
 
-        val bodyText = response.body.string()
+        val bodyText = response.body?.string().orEmpty()
         if (response.code !in 200..299) {
             throw DomainError.ServerError(response.code, bodyText.ifBlank { null })
         }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/versionconfig/ApiVersionConfigService.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/versionconfig/ApiVersionConfigService.kt
@@ -1,16 +1,16 @@
 package uk.towncrierapp.data.versionconfig
 
-import uk.towncrierapp.data.api.HttpTransport
-import uk.towncrierapp.domain.auth.DomainError
-import uk.towncrierapp.domain.versionconfig.AppVersion
-import uk.towncrierapp.domain.versionconfig.VersionConfigService
-import java.io.IOException
 import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Request
+import uk.towncrierapp.data.api.HttpTransport
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.versionconfig.AppVersion
+import uk.towncrierapp.domain.versionconfig.VersionConfigService
+import java.io.IOException
 
 /**
  * Fetches the minimum supported app version — the one endpoint that must
@@ -24,8 +24,20 @@ public class ApiVersionConfigService(
     private val json: Json = Json { ignoreUnknownKeys = true },
 ) : VersionConfigService {
     override suspend fun fetchMinimumVersion(): AppVersion {
-        val url = baseUrl.toHttpUrl().newBuilder().addPathSegment("v1").addPathSegment("version-config").build()
-        val request = Request.Builder().url(url).header("Accept", "application/json").get().build()
+        val url =
+            baseUrl
+                .toHttpUrl()
+                .newBuilder()
+                .addPathSegment("v1")
+                .addPathSegment("version-config")
+                .build()
+        val request =
+            Request
+                .Builder()
+                .url(url)
+                .header("Accept", "application/json")
+                .get()
+                .build()
 
         val response =
             try {
@@ -48,7 +60,8 @@ public class ApiVersionConfigService(
                 throw DomainError.Unexpected("Invalid version config response")
             }
 
-        return AppVersion.parse(dto.minimumVersion) ?: throw DomainError.Unexpected("Invalid version string: ${dto.minimumVersion}")
+        return AppVersion.parse(dto.minimumVersion)
+            ?: throw DomainError.Unexpected("Invalid version string: ${dto.minimumVersion}")
     }
 }
 

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/versionconfig/ApiVersionConfigService.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/versionconfig/ApiVersionConfigService.kt
@@ -1,0 +1,58 @@
+package uk.towncrierapp.data.versionconfig
+
+import uk.towncrierapp.data.api.HttpTransport
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.versionconfig.AppVersion
+import uk.towncrierapp.domain.versionconfig.VersionConfigService
+import java.io.IOException
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.Request
+
+/**
+ * Fetches the minimum supported app version — the one endpoint that must
+ * work before the user is authenticated, so it goes over the raw
+ * [HttpTransport] directly (no `Authorization` header, no session check)
+ * rather than through [uk.towncrierapp.data.api.ApiClient].
+ */
+public class ApiVersionConfigService(
+    private val baseUrl: String,
+    private val transport: HttpTransport,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) : VersionConfigService {
+    override suspend fun fetchMinimumVersion(): AppVersion {
+        val url = baseUrl.toHttpUrl().newBuilder().addPathSegment("v1").addPathSegment("version-config").build()
+        val request = Request.Builder().url(url).header("Accept", "application/json").get().build()
+
+        val response =
+            try {
+                transport.execute(request)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: IOException) {
+                throw DomainError.NetworkUnavailable
+            }
+
+        val bodyText = response.body.string()
+        if (response.code !in 200..299) {
+            throw DomainError.ServerError(response.code, bodyText.ifBlank { null })
+        }
+
+        val dto =
+            try {
+                json.decodeFromString(VersionConfigDto.serializer(), bodyText)
+            } catch (e: SerializationException) {
+                throw DomainError.Unexpected("Invalid version config response")
+            }
+
+        return AppVersion.parse(dto.minimumVersion) ?: throw DomainError.Unexpected("Invalid version string: ${dto.minimumVersion}")
+    }
+}
+
+@Serializable
+internal data class VersionConfigDto(
+    val minimumVersion: String,
+)

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientPagedTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientPagedTest.kt
@@ -1,0 +1,62 @@
+package uk.towncrierapp.data.api
+
+import uk.towncrierapp.domain.auth.FakeAuthenticationService
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@Serializable
+private data class PagedRow(val id: String)
+
+/**
+ * `requestPaged` surfaces the opaque `X-Next-Cursor` response header
+ * alongside the decoded body — used by keyset-paged list endpoints (later
+ * issues). `requestBytes` returns the raw response body untouched, for
+ * opaque payloads (e.g. the future GDPR export). Port of iOS
+ * `URLSessionAPIClientPagedTests`.
+ */
+class ApiClientPagedTest {
+    private val baseUrl = "https://api-dev.towncrierapp.uk"
+
+    private fun makeSut(transport: FakeHttpTransport) = ApiClient(baseUrl, transport, FakeAuthenticationService())
+
+    @Test
+    fun `requestPaged surfaces the X-Next-Cursor response header`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, """[{"id":"a"}]""", headers = mapOf("X-Next-Cursor" to "cursor-xyz"))
+            val sut = makeSut(transport)
+
+            val page = sut.requestPaged(ApiEndpoint.get("/things"), ListSerializer(PagedRow.serializer()))
+
+            assertEquals(listOf(PagedRow("a")), page.value)
+            assertEquals("cursor-xyz", page.nextCursor)
+        }
+
+    @Test
+    fun `requestPaged returns a null cursor when the header is absent (last page)`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, """[{"id":"a"}]""")
+            val sut = makeSut(transport)
+
+            val page = sut.requestPaged(ApiEndpoint.get("/things"), ListSerializer(PagedRow.serializer()))
+
+            assertNull(page.nextCursor)
+        }
+
+    @Test
+    fun `requestBytes returns the raw response body untouched`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, """{"opaque":"payload"}""")
+            val sut = makeSut(transport)
+
+            val bytes = sut.requestBytes(ApiEndpoint.get("/v1/me/data"))
+
+            assertEquals("""{"opaque":"payload"}""", String(bytes))
+        }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientPagedTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientPagedTest.kt
@@ -1,15 +1,17 @@
 package uk.towncrierapp.data.api
 
-import uk.towncrierapp.domain.auth.FakeAuthenticationService
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import org.junit.jupiter.api.Test
+import uk.towncrierapp.domain.auth.FakeAuthenticationService
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 @Serializable
-private data class PagedRow(val id: String)
+private data class PagedRow(
+    val id: String,
+)
 
 /**
  * `requestPaged` surfaces the opaque `X-Next-Cursor` response header

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTest.kt
@@ -1,12 +1,12 @@
 package uk.towncrierapp.data.api
 
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
 import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.domain.auth.FakeAuthenticationService
 import uk.towncrierapp.domain.auth.anAuthSession
 import java.io.IOException
-import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.json.Json
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
@@ -30,7 +30,8 @@ class ApiClientTest {
     fun `GET request attaches the Bearer token and Accept header, and no Content-Type without a body`() =
         runTest {
             val transport = FakeHttpTransport()
-            val authService = FakeAuthenticationService(currentSessionResult = anAuthSession(accessToken = "test-token"))
+            val authService =
+                FakeAuthenticationService(currentSessionResult = anAuthSession(accessToken = "test-token"))
             transport.enqueueResponse(200, """{"id":"1","name":"Test"}""")
             val sut = makeSut(transport, authService)
 
@@ -111,7 +112,12 @@ class ApiClientTest {
             val sut = makeSut(transport, authService)
 
             assertIs<DomainError.SessionExpired>(
-                assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer()) },
+                assertFailsWith<DomainError> {
+                    sut.request(
+                        ApiEndpoint.get("/applications"),
+                        TestResponse.serializer(),
+                    )
+                },
             )
             assertEquals(0, transport.requests.size)
         }
@@ -124,7 +130,12 @@ class ApiClientTest {
             val sut = makeSut(transport)
 
             assertIs<DomainError.NotFound>(
-                assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications/999"), TestResponse.serializer()) },
+                assertFailsWith<DomainError> {
+                    sut.request(
+                        ApiEndpoint.get("/applications/999"),
+                        TestResponse.serializer(),
+                    )
+                },
             )
         }
 
@@ -137,7 +148,12 @@ class ApiClientTest {
 
             val error =
                 assertIs<DomainError.ServerError>(
-                    assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer()) },
+                    assertFailsWith<DomainError> {
+                        sut.request(
+                            ApiEndpoint.get("/applications"),
+                            TestResponse.serializer(),
+                        )
+                    },
                 )
 
             assertEquals(500, error.status)
@@ -154,7 +170,12 @@ class ApiClientTest {
 
             val error =
                 assertIs<DomainError.InsufficientEntitlement>(
-                    assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/notifications"), TestResponse.serializer()) },
+                    assertFailsWith<DomainError> {
+                        sut.request(
+                            ApiEndpoint.get("/notifications"),
+                            TestResponse.serializer(),
+                        )
+                    },
                 )
 
             assertEquals("personal", error.required)
@@ -183,7 +204,12 @@ class ApiClientTest {
             val sut = makeSut(transport)
 
             assertIs<DomainError.NetworkUnavailable>(
-                assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer()) },
+                assertFailsWith<DomainError> {
+                    sut.request(
+                        ApiEndpoint.get("/applications"),
+                        TestResponse.serializer(),
+                    )
+                },
             )
         }
 }

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTest.kt
@@ -1,0 +1,196 @@
+package uk.towncrierapp.data.api
+
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.auth.FakeAuthenticationService
+import uk.towncrierapp.domain.auth.anAuthSession
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+@Serializable
+private data class TestResponse(val id: String, val name: String)
+
+@Serializable
+private data class TestBody(val title: String)
+
+/**
+ * Core `ApiClient` behaviour: headers, JSON decoding, and HTTP status
+ * mapping to `DomainError` — port of iOS `URLSessionAPIClientTests` (epic
+ * #770 "API contract essentials"). 401-refresh-retry and paging have their
+ * own files ([ApiClientTokenRefreshTest], [ApiClientPagedTest]).
+ */
+class ApiClientTest {
+    private val baseUrl = "https://api-dev.towncrierapp.uk"
+
+    private fun makeSut(
+        transport: FakeHttpTransport = FakeHttpTransport(),
+        authService: FakeAuthenticationService = FakeAuthenticationService(),
+    ) = ApiClient(baseUrl = baseUrl, transport = transport, authService = authService)
+
+    @Test
+    fun `GET request attaches the Bearer token and Accept header, and no Content-Type without a body`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            val authService = FakeAuthenticationService(currentSessionResult = anAuthSession(accessToken = "test-token"))
+            transport.enqueueResponse(200, """{"id":"1","name":"Test"}""")
+            val sut = makeSut(transport, authService)
+
+            sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer())
+
+            val request = transport.requests.single()
+            assertEquals("Bearer test-token", request.header("Authorization"))
+            assertEquals("application/json", request.header("Accept"))
+            assertNull(request.header("Content-Type"))
+            assertEquals("GET", request.method)
+            assertEquals("https://api-dev.towncrierapp.uk/applications", request.url.toString())
+        }
+
+    @Test
+    fun `a successful response is decoded to the requested type`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, """{"id":"42","name":"Extension"}""")
+            val sut = makeSut(transport)
+
+            val result = sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer())
+
+            assertEquals(TestResponse("42", "Extension"), result)
+        }
+
+    @Test
+    fun `POST request sets Content-Type and encodes the body as JSON`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(201, """{"id":"new","name":"Created"}""")
+            val sut = makeSut(transport)
+            val body = Json.encodeToString(TestBody.serializer(), TestBody("New Application"))
+
+            val result = sut.request(ApiEndpoint.post("/applications", body = body), TestResponse.serializer())
+
+            assertEquals(TestResponse("new", "Created"), result)
+            val request = transport.requests.single()
+            assertEquals("POST", request.method)
+            assertEquals("application/json; charset=utf-8", request.header("Content-Type"))
+        }
+
+    @Test
+    fun `a bodyless POST sends no Content-Type header`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, """{"id":"1","name":"Test"}""")
+            val sut = makeSut(transport)
+
+            sut.request(ApiEndpoint.post("/v1/me"), TestResponse.serializer())
+
+            val request = transport.requests.single()
+            assertEquals("POST", request.method)
+            assertNull(request.header("Content-Type"))
+        }
+
+    @Test
+    fun `query parameters are included in the request URL`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, """{"id":"1","name":"Test"}""")
+            val sut = makeSut(transport)
+
+            sut.request(
+                ApiEndpoint.get("/applications", query = listOf("authority" to "camden", "status" to "pending")),
+                TestResponse.serializer(),
+            )
+
+            val url = transport.requests.single().url
+            assertEquals("camden", url.queryParameter("authority"))
+            assertEquals("pending", url.queryParameter("status"))
+        }
+
+    @Test
+    fun `when no session exists, throws SessionExpired without calling the transport`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            val authService = FakeAuthenticationService(currentSessionResult = null)
+            val sut = makeSut(transport, authService)
+
+            assertIs<DomainError.SessionExpired>(
+                assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer()) },
+            )
+            assertEquals(0, transport.requests.size)
+        }
+
+    @Test
+    fun `404 response throws DomainError NotFound`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(404)
+            val sut = makeSut(transport)
+
+            assertIs<DomainError.NotFound>(
+                assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications/999"), TestResponse.serializer()) },
+            )
+        }
+
+    @Test
+    fun `500 response throws DomainError ServerError carrying the status and raw body, with no retry`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(500, "boom")
+            val sut = makeSut(transport)
+
+            val error =
+                assertIs<DomainError.ServerError>(
+                    assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer()) },
+                )
+
+            assertEquals(500, error.status)
+            assertEquals("boom", error.body)
+            assertEquals(1, transport.requests.size)
+        }
+
+    @Test
+    fun `403 with an insufficient_entitlement body throws the typed DomainError`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(403, """{"error":"insufficient_entitlement","required":"personal"}""")
+            val sut = makeSut(transport)
+
+            val error =
+                assertIs<DomainError.InsufficientEntitlement>(
+                    assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/notifications"), TestResponse.serializer()) },
+                )
+
+            assertEquals("personal", error.required)
+        }
+
+    @Test
+    fun `403 without the insufficient_entitlement shape throws a generic ServerError`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(403, """{"error":"forbidden","message":"Access denied"}""")
+            val sut = makeSut(transport)
+
+            val error =
+                assertIs<DomainError.ServerError>(
+                    assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/admin"), TestResponse.serializer()) },
+                )
+
+            assertEquals(403, error.status)
+        }
+
+    @Test
+    fun `a transport-level network failure maps to NetworkUnavailable`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueFailure(IOException("no connection"))
+            val sut = makeSut(transport)
+
+            assertIs<DomainError.NetworkUnavailable>(
+                assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer()) },
+            )
+        }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTest.kt
@@ -5,19 +5,12 @@ import uk.towncrierapp.domain.auth.FakeAuthenticationService
 import uk.towncrierapp.domain.auth.anAuthSession
 import java.io.IOException
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.test.assertNull
-
-@Serializable
-private data class TestResponse(val id: String, val name: String)
-
-@Serializable
-private data class TestBody(val title: String)
 
 /**
  * Core `ApiClient` behaviour: headers, JSON decoding, and HTTP status
@@ -76,7 +69,7 @@ class ApiClientTest {
             assertEquals(TestResponse("new", "Created"), result)
             val request = transport.requests.single()
             assertEquals("POST", request.method)
-            assertEquals("application/json; charset=utf-8", request.header("Content-Type"))
+            assertEquals("application/json", request.header("Content-Type"))
         }
 
     @Test

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTestFixtures.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTestFixtures.kt
@@ -6,7 +6,12 @@ import kotlinx.serialization.Serializable
 // occupy the package namespace, so duplicate per-file declarations of the
 // same name genuinely collide; one shared internal DTO avoids that.
 @Serializable
-internal data class TestResponse(val id: String, val name: String)
+internal data class TestResponse(
+    val id: String,
+    val name: String,
+)
 
 @Serializable
-internal data class TestBody(val title: String)
+internal data class TestBody(
+    val title: String,
+)

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTestFixtures.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTestFixtures.kt
@@ -1,0 +1,12 @@
+package uk.towncrierapp.data.api
+
+import kotlinx.serialization.Serializable
+
+// Shared across the ApiClient*Test files — top-level `private` classes still
+// occupy the package namespace, so duplicate per-file declarations of the
+// same name genuinely collide; one shared internal DTO avoids that.
+@Serializable
+internal data class TestResponse(val id: String, val name: String)
+
+@Serializable
+internal data class TestBody(val title: String)

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTokenRefreshTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTokenRefreshTest.kt
@@ -1,0 +1,131 @@
+package uk.towncrierapp.data.api
+
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.auth.FakeAuthenticationService
+import uk.towncrierapp.domain.auth.anAuthSession
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.Serializable
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+@Serializable
+private data class TestResponse(val id: String, val name: String)
+
+/**
+ * The single 401-refresh-retry policy (epic #770 "API contract essentials",
+ * acceptance criteria) — port of iOS `URLSessionAPIClientTokenRefreshTests`.
+ * Refresh throwing [IOException] maps to [DomainError.NetworkUnavailable];
+ * any other refresh failure maps to [DomainError.SessionExpired]. No status
+ * code other than 401 ever triggers a retry.
+ */
+class ApiClientTokenRefreshTest {
+    private val baseUrl = "https://api-dev.towncrierapp.uk"
+
+    @Test
+    fun `on 401, refreshes the session exactly once and retries the request exactly once`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(401)
+            transport.enqueueResponse(200, """{"id":"1","name":"Test"}""")
+            val refreshed = anAuthSession(accessToken = "refreshed-token")
+            val authService =
+                FakeAuthenticationService(currentSessionResult = anAuthSession(accessToken = "stale-token")).apply {
+                    refreshSessionResult = Result.success(refreshed)
+                }
+            val sut = ApiClient(baseUrl, transport, authService)
+
+            val result = sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer())
+
+            assertEquals(TestResponse("1", "Test"), result)
+            assertEquals(1, authService.refreshSessionCalls.size)
+            assertEquals(2, transport.requests.size)
+            assertEquals("Bearer stale-token", transport.requests[0].header("Authorization"))
+            assertEquals("Bearer refreshed-token", transport.requests[1].header("Authorization"))
+        }
+
+    @Test
+    fun `on 401, when refresh throws IOException, throws NetworkUnavailable`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(401)
+            val authService =
+                FakeAuthenticationService().apply {
+                    refreshSessionResult = Result.failure(IOException("no connection"))
+                }
+            val sut = ApiClient(baseUrl, transport, authService)
+
+            assertIs<DomainError.NetworkUnavailable>(
+                assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer()) },
+            )
+        }
+
+    @Test
+    fun `on 401, when refresh fails for any other reason, throws SessionExpired`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(401)
+            val authService =
+                FakeAuthenticationService().apply {
+                    refreshSessionResult = Result.failure(DomainError.SessionExpired)
+                }
+            val sut = ApiClient(baseUrl, transport, authService)
+
+            assertIs<DomainError.SessionExpired>(
+                assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer()) },
+            )
+        }
+
+    @Test
+    fun `a 5xx response never triggers a refresh — only 401 does`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(500)
+            val authService = FakeAuthenticationService()
+            val sut = ApiClient(baseUrl, transport, authService)
+
+            assertFailsWith<DomainError.ServerError> {
+                sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer())
+            }
+
+            assertEquals(0, authService.refreshSessionCalls.size)
+            assertEquals(1, transport.requests.size)
+        }
+
+    @Test
+    fun `on 401, when the refreshed retry also fails over the network, throws NetworkUnavailable`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(401)
+            transport.enqueueFailure(IOException("dropped"))
+            val authService =
+                FakeAuthenticationService().apply {
+                    refreshSessionResult = Result.success(anAuthSession())
+                }
+            val sut = ApiClient(baseUrl, transport, authService)
+
+            assertIs<DomainError.NetworkUnavailable>(
+                assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer()) },
+            )
+        }
+
+    @Test
+    fun `on 401, when the refreshed retry also gets a server error, propagates it rather than looping`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(401)
+            transport.enqueueResponse(500)
+            val authService =
+                FakeAuthenticationService().apply {
+                    refreshSessionResult = Result.success(anAuthSession())
+                }
+            val sut = ApiClient(baseUrl, transport, authService)
+
+            assertFailsWith<DomainError.ServerError> {
+                sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer())
+            }
+            assertEquals(1, authService.refreshSessionCalls.size)
+        }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTokenRefreshTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTokenRefreshTest.kt
@@ -5,14 +5,10 @@ import uk.towncrierapp.domain.auth.FakeAuthenticationService
 import uk.towncrierapp.domain.auth.anAuthSession
 import java.io.IOException
 import kotlinx.coroutines.test.runTest
-import kotlinx.serialization.Serializable
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
-
-@Serializable
-private data class TestResponse(val id: String, val name: String)
 
 /**
  * The single 401-refresh-retry policy (epic #770 "API contract essentials",

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTokenRefreshTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/ApiClientTokenRefreshTest.kt
@@ -1,11 +1,11 @@
 package uk.towncrierapp.data.api
 
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
 import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.domain.auth.FakeAuthenticationService
 import uk.towncrierapp.domain.auth.anAuthSession
 import java.io.IOException
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
@@ -54,7 +54,12 @@ class ApiClientTokenRefreshTest {
             val sut = ApiClient(baseUrl, transport, authService)
 
             assertIs<DomainError.NetworkUnavailable>(
-                assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer()) },
+                assertFailsWith<DomainError> {
+                    sut.request(
+                        ApiEndpoint.get("/applications"),
+                        TestResponse.serializer(),
+                    )
+                },
             )
         }
 
@@ -70,7 +75,12 @@ class ApiClientTokenRefreshTest {
             val sut = ApiClient(baseUrl, transport, authService)
 
             assertIs<DomainError.SessionExpired>(
-                assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer()) },
+                assertFailsWith<DomainError> {
+                    sut.request(
+                        ApiEndpoint.get("/applications"),
+                        TestResponse.serializer(),
+                    )
+                },
             )
         }
 
@@ -103,7 +113,12 @@ class ApiClientTokenRefreshTest {
             val sut = ApiClient(baseUrl, transport, authService)
 
             assertIs<DomainError.NetworkUnavailable>(
-                assertFailsWith<DomainError> { sut.request(ApiEndpoint.get("/applications"), TestResponse.serializer()) },
+                assertFailsWith<DomainError> {
+                    sut.request(
+                        ApiEndpoint.get("/applications"),
+                        TestResponse.serializer(),
+                    )
+                },
             )
         }
 

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/DotNetTimeParserTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/DotNetTimeParserTest.kt
@@ -1,0 +1,68 @@
+package uk.towncrierapp.data.api
+
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * Port of iOS `DotNetTimeParserTests` — one shared parser for the Go
+ * backend's `platform.DotNetTime` wire format, applied per-field by DTO
+ * mappers (epic #770 "API contract essentials"). Fractional seconds appear
+ * on the wire only when the sub-second part is non-zero, and the offset is
+ * spelled either `Z` or `±hh:mm` — the parser must accept every combination,
+ * and never throw on garbage.
+ */
+class DotNetTimeParserTest {
+    @Test
+    fun `parses a fractional-seconds timestamp with a numeric offset`() {
+        val parsed = DotNetTimeParser.parse("2026-07-20T14:23:45.6789123+00:00")
+
+        assertEquals(
+            OffsetDateTime.of(2026, 7, 20, 14, 23, 45, 678_912_300, ZoneOffset.UTC),
+            parsed,
+        )
+    }
+
+    @Test
+    fun `parses a whole-second timestamp with an explicit numeric offset`() {
+        val parsed = DotNetTimeParser.parse("2026-06-12T09:30:00+00:00")
+
+        assertEquals(OffsetDateTime.of(2026, 6, 12, 9, 30, 0, 0, ZoneOffset.UTC), parsed)
+    }
+
+    @Test
+    fun `parses a whole-second timestamp in Z form`() {
+        val parsed = DotNetTimeParser.parse("2026-06-12T09:30:00Z")
+
+        assertEquals(OffsetDateTime.of(2026, 6, 12, 9, 30, 0, 0, ZoneOffset.UTC), parsed)
+    }
+
+    @Test
+    fun `parses a fractional-seconds timestamp in Z form`() {
+        val parsed = DotNetTimeParser.parse("2026-07-20T14:23:45.5Z")
+
+        assertEquals(OffsetDateTime.of(2026, 7, 20, 14, 23, 45, 500_000_000, ZoneOffset.UTC), parsed)
+    }
+
+    @Test
+    fun `returns null on genuine garbage rather than throwing`() {
+        assertNull(DotNetTimeParser.parse("not a date"))
+        assertNull(DotNetTimeParser.parse(""))
+        assertNull(DotNetTimeParser.parse("2026-13-45"))
+    }
+
+    @Test
+    fun `date-only fields parse as a separate simple LocalDate, not conflated with the timestamp parser`() {
+        val parsed = DotNetTimeParser.parseDate("2026-06-12")
+
+        assertEquals(java.time.LocalDate.of(2026, 6, 12), parsed)
+    }
+
+    @Test
+    fun `parseDate returns null on garbage`() {
+        assertNull(DotNetTimeParser.parseDate("2026-06-12T09:30:00Z"))
+        assertNull(DotNetTimeParser.parseDate("not a date"))
+    }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/DotNetTimeParserTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/DotNetTimeParserTest.kt
@@ -1,8 +1,8 @@
 package uk.towncrierapp.data.api
 
+import org.junit.jupiter.api.Test
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/FakeHttpTransport.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/FakeHttpTransport.kt
@@ -1,0 +1,55 @@
+package uk.towncrierapp.data.api
+
+import java.io.IOException
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+
+/**
+ * Hand-written [HttpTransport] fake: a queue of scripted per-request
+ * responses (or failures), no MockWebServer (epic #770 "API contract
+ * essentials" test strategy). Each [execute] call records the [Request] it
+ * received so tests can assert headers/method/URL, and pops the next
+ * queued response/failure.
+ */
+internal class FakeHttpTransport : HttpTransport {
+    val requests: MutableList<Request> = mutableListOf()
+    private val queue: ArrayDeque<(Request) -> Response> = ArrayDeque()
+
+    fun enqueueResponse(
+        code: Int,
+        body: String = "",
+        headers: Map<String, String> = emptyMap(),
+    ) {
+        queue.addLast { request -> fakeResponse(request, code, body, headers) }
+    }
+
+    fun enqueueFailure(exception: IOException) {
+        queue.addLast { throw exception }
+    }
+
+    override suspend fun execute(request: Request): Response {
+        requests += request
+        val next = queue.removeFirstOrNull() ?: throw IOException("FakeHttpTransport: no response queued for $request")
+        return next(request)
+    }
+}
+
+private fun fakeResponse(
+    request: Request,
+    code: Int,
+    body: String,
+    headers: Map<String, String>,
+): Response {
+    val builder =
+        Response.Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message("fake")
+            .body(body.toResponseBody("application/json".toMediaType()))
+    headers.forEach { (name, value) -> builder.addHeader(name, value) }
+    return builder.build()
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/FakeHttpTransport.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/api/FakeHttpTransport.kt
@@ -1,11 +1,11 @@
 package uk.towncrierapp.data.api
 
-import java.io.IOException
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
+import java.io.IOException
 
 /**
  * Hand-written [HttpTransport] fake: a queue of scripted per-request
@@ -44,7 +44,8 @@ private fun fakeResponse(
     headers: Map<String, String>,
 ): Response {
     val builder =
-        Response.Builder()
+        Response
+            .Builder()
             .request(request)
             .protocol(Protocol.HTTP_1_1)
             .code(code)

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationServiceTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationServiceTest.kt
@@ -1,0 +1,196 @@
+package uk.towncrierapp.data.auth
+
+import uk.towncrierapp.domain.auth.DomainError
+import com.auth0.android.Auth0
+import com.auth0.android.result.Credentials
+import java.io.IOException
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.Date
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private const val DEV_AUDIENCE = "https://api-dev.towncrierapp.uk"
+
+/**
+ * `currentSession()`/`refreshSession()` are the unit-testable surface of
+ * [Auth0AuthenticationService] — `login()`/`logout()` need a real Activity
+ * and Custom Tabs and are verified on-device (epic #770 test strategy: "one
+ * Auth0-SDK-boundary integration is accepted as emulator-verified"). Covers
+ * the four ported bug fixes: #680 (aud-mismatch wipe, fail-open), tc-funq
+ * (renewability), and the refresh unrecoverable-vs-transient split.
+ */
+class Auth0AuthenticationServiceTest {
+    private fun aCredentials(
+        accessToken: String = fakeJwt("""{"sub":"auth0|1","aud":"$DEV_AUDIENCE"}"""),
+        idToken: String = fakeJwt("""{"sub":"auth0|1","email":"resident@example.test"}"""),
+        expiresAt: Instant = Instant.parse("2026-07-20T15:00:00Z"),
+        refreshToken: String? = "refresh-token",
+    ) = Credentials(idToken, accessToken, "Bearer", refreshToken, Date.from(expiresAt), "openid profile email offline_access")
+
+    private fun makeSut(
+        credentialsStore: FakeCredentialsStore = FakeCredentialsStore(),
+        audience: String = DEV_AUDIENCE,
+    ) = Auth0AuthenticationService(
+        config = Auth0Config(clientId = "client-id", domain = "towncrierapp.uk.auth0.com", audience = audience),
+        credentialsStore = credentialsStore,
+        activityProvider = CurrentActivityProvider { null },
+        auth0 = Auth0.getInstance("client-id", "towncrierapp.uk.auth0.com"),
+        sessionCache = SessionCache(scope = CoroutineScope(Dispatchers.Unconfined)),
+        clock = Clock.fixed(Instant.parse("2026-07-20T10:00:00Z"), ZoneOffset.UTC),
+    )
+
+    // MARK: - currentSession()
+
+    @Test
+    fun `currentSession returns null when there are no valid credentials (signed out)`() =
+        runTest {
+            val store = FakeCredentialsStore(hasValidCredentialsResult = false)
+            val sut = makeSut(store)
+
+            assertNull(sut.currentSession())
+        }
+
+    @Test
+    fun `currentSession with valid credentials returns a session built from the access and id tokens`() =
+        runTest {
+            val store =
+                FakeCredentialsStore(
+                    hasValidCredentialsResult = true,
+                    credentialsResult = Result.success(aCredentials()),
+                )
+            val sut = makeSut(store)
+
+            val session = sut.currentSession()
+
+            assertEquals("resident@example.test", session?.userProfile?.email)
+            assertEquals("auth0|1", session?.userProfile?.userId)
+        }
+
+    @Test
+    fun `tc-funq an expired access token with a valid refresh token still counts as signed-in (renewable)`() =
+        runTest {
+            // hasValidCredentials() on the real SDK already folds in refresh-token
+            // renewability (see Auth0AuthenticationService doc comment) — this
+            // fake simply asserts our currentSession() trusts that contract
+            // rather than short-circuiting to signed-out on its own.
+            val store =
+                FakeCredentialsStore(
+                    hasValidCredentialsResult = true,
+                    credentialsResult = Result.success(aCredentials(expiresAt = Instant.parse("2026-07-20T09:00:00Z"))),
+                )
+            val sut = makeSut(store)
+
+            val session = sut.currentSession()
+
+            assertEquals("auth0|1", session?.userProfile?.userId)
+        }
+
+    @Test
+    fun `aud-mismatch wipes credentials and cache, ending up signed-out (#680)`() =
+        runTest {
+            val store =
+                FakeCredentialsStore(
+                    hasValidCredentialsResult = true,
+                    credentialsResult =
+                        Result.success(
+                            aCredentials(accessToken = fakeJwt("""{"sub":"auth0|1","aud":"https://api.towncrierapp.uk"}""")),
+                        ),
+                )
+            val sut = makeSut(store, audience = DEV_AUDIENCE)
+
+            val session = sut.currentSession()
+
+            assertNull(session)
+            assertEquals(1, store.clearCredentialsCalls.size)
+        }
+
+    @Test
+    fun `an undecodable or missing aud claim keeps the session (fail open)`() =
+        runTest {
+            val store =
+                FakeCredentialsStore(
+                    hasValidCredentialsResult = true,
+                    credentialsResult = Result.success(aCredentials(accessToken = fakeJwt("""{"sub":"auth0|1"}"""))),
+                )
+            val sut = makeSut(store)
+
+            val session = sut.currentSession()
+
+            assertEquals("auth0|1", session?.userProfile?.userId)
+            assertEquals(0, store.clearCredentialsCalls.size)
+        }
+
+    @Test
+    fun `a credentials-store failure while loading is treated as signed-out, not a crash`() =
+        runTest {
+            val store =
+                FakeCredentialsStore(
+                    hasValidCredentialsResult = true,
+                    credentialsResult = Result.failure(CredentialsStoreException.Transient(IOException("keystore hiccup"))),
+                )
+            val sut = makeSut(store)
+
+            assertNull(sut.currentSession())
+        }
+
+    // MARK: - refreshSession()
+
+    @Test
+    fun `refreshSession returns the refreshed session and caches it`() =
+        runTest {
+            val store = FakeCredentialsStore(credentialsResult = Result.success(aCredentials()))
+            val sut = makeSut(store)
+
+            val session = sut.refreshSession()
+
+            assertEquals("auth0|1", session.userProfile.userId)
+        }
+
+    @Test
+    fun `refreshSession wipes credentials and throws SessionExpired on an unrecoverable failure`() =
+        runTest {
+            val store = FakeCredentialsStore(credentialsResult = Result.failure(CredentialsStoreException.Unrecoverable))
+            val sut = makeSut(store)
+
+            assertIs<DomainError.SessionExpired>(assertFailsWith<DomainError> { sut.refreshSession() })
+            assertEquals(1, store.clearCredentialsCalls.size)
+        }
+
+    @Test
+    fun `refreshSession surfaces a transient IOException without wiping credentials`() =
+        runTest {
+            val networkFailure = IOException("no connection")
+            val store = FakeCredentialsStore(credentialsResult = Result.failure(CredentialsStoreException.Transient(networkFailure)))
+            val sut = makeSut(store)
+
+            val thrown = assertFailsWith<IOException> { sut.refreshSession() }
+
+            assertEquals(networkFailure, thrown)
+            assertTrue(store.clearCredentialsCalls.isEmpty())
+        }
+
+    @Test
+    fun `refreshSession on an audience mismatch wipes credentials and throws SessionExpired`() =
+        runTest {
+            val store =
+                FakeCredentialsStore(
+                    credentialsResult =
+                        Result.success(
+                            aCredentials(accessToken = fakeJwt("""{"sub":"auth0|1","aud":"https://api.towncrierapp.uk"}""")),
+                        ),
+                )
+            val sut = makeSut(store, audience = DEV_AUDIENCE)
+
+            assertIs<DomainError.SessionExpired>(assertFailsWith<DomainError> { sut.refreshSession() })
+            assertEquals(1, store.clearCredentialsCalls.size)
+        }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationServiceTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationServiceTest.kt
@@ -2,7 +2,7 @@ package uk.towncrierapp.data.auth
 
 import com.auth0.android.result.Credentials
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import uk.towncrierapp.domain.auth.DomainError
@@ -10,7 +10,6 @@ import java.io.IOException
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
-import java.util.Date
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
@@ -38,7 +37,11 @@ class Auth0AuthenticationServiceTest {
         accessToken,
         "Bearer",
         refreshToken,
-        Date.from(expiresAt),
+        // Not `import java.util.Date` (forbidden — java.time only): the Auth0
+        // SDK's own Credentials constructor mandates java.util.Date, so this
+        // fully-qualified reference is a one-off interop conversion, not our
+        // own date type creeping in.
+        java.util.Date.from(expiresAt),
         "openid profile email offline_access",
     )
 
@@ -52,7 +55,7 @@ class Auth0AuthenticationServiceTest {
         // currentSession()/refreshSession() never touch auth0 — only login()/logout() do
         // (verified on-device, see class doc), so a real Auth0 instance is never needed here.
         auth0 = lazy { error("not used by currentSession()/refreshSession()") },
-        sessionCache = SessionCache(scope = CoroutineScope(Dispatchers.Unconfined)),
+        sessionCache = SessionCache(scope = CoroutineScope(UnconfinedTestDispatcher())),
         clock = Clock.fixed(Instant.parse("2026-07-20T10:00:00Z"), ZoneOffset.UTC),
     )
 

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationServiceTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationServiceTest.kt
@@ -1,7 +1,6 @@
 package uk.towncrierapp.data.auth
 
 import uk.towncrierapp.domain.auth.DomainError
-import com.auth0.android.Auth0
 import com.auth0.android.result.Credentials
 import java.io.IOException
 import java.time.Clock
@@ -43,7 +42,9 @@ class Auth0AuthenticationServiceTest {
         config = Auth0Config(clientId = "client-id", domain = "towncrierapp.uk.auth0.com", audience = audience),
         credentialsStore = credentialsStore,
         activityProvider = CurrentActivityProvider { null },
-        auth0 = Auth0.getInstance("client-id", "towncrierapp.uk.auth0.com"),
+        // currentSession()/refreshSession() never touch auth0 — only login()/logout() do
+        // (verified on-device, see class doc), so a real Auth0 instance is never needed here.
+        auth0 = lazy { error("not used by currentSession()/refreshSession()") },
         sessionCache = SessionCache(scope = CoroutineScope(Dispatchers.Unconfined)),
         clock = Clock.fixed(Instant.parse("2026-07-20T10:00:00Z"), ZoneOffset.UTC),
     )

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationServiceTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/Auth0AuthenticationServiceTest.kt
@@ -1,16 +1,16 @@
 package uk.towncrierapp.data.auth
 
-import uk.towncrierapp.domain.auth.DomainError
 import com.auth0.android.result.Credentials
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uk.towncrierapp.domain.auth.DomainError
 import java.io.IOException
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
 import java.util.Date
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
@@ -33,7 +33,14 @@ class Auth0AuthenticationServiceTest {
         idToken: String = fakeJwt("""{"sub":"auth0|1","email":"resident@example.test"}"""),
         expiresAt: Instant = Instant.parse("2026-07-20T15:00:00Z"),
         refreshToken: String? = "refresh-token",
-    ) = Credentials(idToken, accessToken, "Bearer", refreshToken, Date.from(expiresAt), "openid profile email offline_access")
+    ) = Credentials(
+        idToken,
+        accessToken,
+        "Bearer",
+        refreshToken,
+        Date.from(expiresAt),
+        "openid profile email offline_access",
+    )
 
     private fun makeSut(
         credentialsStore: FakeCredentialsStore = FakeCredentialsStore(),
@@ -103,7 +110,9 @@ class Auth0AuthenticationServiceTest {
                     hasValidCredentialsResult = true,
                     credentialsResult =
                         Result.success(
-                            aCredentials(accessToken = fakeJwt("""{"sub":"auth0|1","aud":"https://api.towncrierapp.uk"}""")),
+                            aCredentials(
+                                accessToken = fakeJwt("""{"sub":"auth0|1","aud":"https://api.towncrierapp.uk"}"""),
+                            ),
                         ),
                 )
             val sut = makeSut(store, audience = DEV_AUDIENCE)
@@ -136,7 +145,10 @@ class Auth0AuthenticationServiceTest {
             val store =
                 FakeCredentialsStore(
                     hasValidCredentialsResult = true,
-                    credentialsResult = Result.failure(CredentialsStoreException.Transient(IOException("keystore hiccup"))),
+                    credentialsResult =
+                        Result.failure(
+                            CredentialsStoreException.Transient(IOException("keystore hiccup")),
+                        ),
                 )
             val sut = makeSut(store)
 
@@ -159,7 +171,8 @@ class Auth0AuthenticationServiceTest {
     @Test
     fun `refreshSession wipes credentials and throws SessionExpired on an unrecoverable failure`() =
         runTest {
-            val store = FakeCredentialsStore(credentialsResult = Result.failure(CredentialsStoreException.Unrecoverable))
+            val store =
+                FakeCredentialsStore(credentialsResult = Result.failure(CredentialsStoreException.Unrecoverable))
             val sut = makeSut(store)
 
             assertIs<DomainError.SessionExpired>(assertFailsWith<DomainError> { sut.refreshSession() })
@@ -170,7 +183,10 @@ class Auth0AuthenticationServiceTest {
     fun `refreshSession surfaces a transient IOException without wiping credentials`() =
         runTest {
             val networkFailure = IOException("no connection")
-            val store = FakeCredentialsStore(credentialsResult = Result.failure(CredentialsStoreException.Transient(networkFailure)))
+            val store =
+                FakeCredentialsStore(
+                    credentialsResult = Result.failure(CredentialsStoreException.Transient(networkFailure)),
+                )
             val sut = makeSut(store)
 
             val thrown = assertFailsWith<IOException> { sut.refreshSession() }
@@ -186,7 +202,9 @@ class Auth0AuthenticationServiceTest {
                 FakeCredentialsStore(
                     credentialsResult =
                         Result.success(
-                            aCredentials(accessToken = fakeJwt("""{"sub":"auth0|1","aud":"https://api.towncrierapp.uk"}""")),
+                            aCredentials(
+                                accessToken = fakeJwt("""{"sub":"auth0|1","aud":"https://api.towncrierapp.uk"}"""),
+                            ),
                         ),
                 )
             val sut = makeSut(store, audience = DEV_AUDIENCE)

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/FakeCredentialsStore.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/FakeCredentialsStore.kt
@@ -1,0 +1,24 @@
+package uk.towncrierapp.data.auth
+
+import com.auth0.android.result.Credentials
+
+/** Hand-written fake for [CredentialsStore] — no real Keystore/Context involved. */
+internal class FakeCredentialsStore(
+    var hasValidCredentialsResult: Boolean = false,
+    var credentialsResult: Result<Credentials> = Result.failure(CredentialsStoreException.Unrecoverable),
+) : CredentialsStore {
+    val saveCredentialsCalls: MutableList<Credentials> = mutableListOf()
+    val clearCredentialsCalls: MutableList<Unit> = mutableListOf()
+
+    override fun hasValidCredentials(): Boolean = hasValidCredentialsResult
+
+    override suspend fun credentials(): Credentials = credentialsResult.getOrThrow()
+
+    override fun saveCredentials(credentials: Credentials) {
+        saveCredentialsCalls += credentials
+    }
+
+    override fun clearCredentials() {
+        clearCredentialsCalls += Unit
+    }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/JwtClaimsTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/JwtClaimsTest.kt
@@ -1,0 +1,110 @@
+package uk.towncrierapp.data.auth
+
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import java.util.Base64
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `JwtClaims` decodes the JWT payload segment (base64url JSON, no signature
+ * verification — the server already validated the token; this is purely for
+ * reading claims client-side) and exposes the individual claims
+ * `Auth0AuthenticationService` needs. Port of iOS
+ * `JWTSubscriptionTierExtractor`.
+ */
+class JwtClaimsTest {
+    @Test
+    fun `extractSubject reads the sub claim`() {
+        val token = fakeJwt("""{"sub":"auth0|abc123"}""")
+
+        assertEquals("auth0|abc123", JwtClaims.extractSubject(token))
+    }
+
+    @Test
+    fun `extractSubject returns null for a malformed token`() {
+        assertNull(JwtClaims.extractSubject("not-a-jwt"))
+        assertNull(JwtClaims.extractSubject(""))
+    }
+
+    @Test
+    fun `extractAudiences accepts a single string aud claim`() {
+        val token = fakeJwt("""{"aud":"https://api-dev.towncrierapp.uk"}""")
+
+        assertEquals(listOf("https://api-dev.towncrierapp.uk"), JwtClaims.extractAudiences(token))
+    }
+
+    @Test
+    fun `extractAudiences accepts a JSON array aud claim`() {
+        val token = fakeJwt("""{"aud":["https://api-dev.towncrierapp.uk","https://other.example"]}""")
+
+        assertEquals(
+            listOf("https://api-dev.towncrierapp.uk", "https://other.example"),
+            JwtClaims.extractAudiences(token),
+        )
+    }
+
+    @Test
+    fun `extractAudiences returns empty for a missing claim or malformed token`() {
+        assertTrue(JwtClaims.extractAudiences(fakeJwt("""{"sub":"auth0|abc"}""")).isEmpty())
+        assertTrue(JwtClaims.extractAudiences("not-a-jwt").isEmpty())
+    }
+
+    @Test
+    fun `extractTier reads the lowercase subscription_tier claim`() {
+        val token = fakeJwt("""{"subscription_tier":"pro"}""")
+
+        assertEquals(SubscriptionTier.PRO, JwtClaims.extractTier(token))
+    }
+
+    @Test
+    fun `extractTier defaults to Free when the claim is absent, unrecognised, or the token is malformed`() {
+        assertEquals(SubscriptionTier.FREE, JwtClaims.extractTier(fakeJwt("""{"sub":"auth0|abc"}""")))
+        assertEquals(SubscriptionTier.FREE, JwtClaims.extractTier(fakeJwt("""{"subscription_tier":"enterprise"}""")))
+        assertEquals(SubscriptionTier.FREE, JwtClaims.extractTier("not-a-jwt"))
+    }
+
+    @Test
+    fun `extractEmail reads the email claim and tolerates a blank value (Sign in with Apple has no email scope)`() {
+        val token = fakeJwt("""{"email":""}""")
+
+        assertEquals("", JwtClaims.extractEmail(token))
+        assertNull(JwtClaims.extractEmail("not-a-jwt"))
+    }
+
+    @Test
+    fun `extractName reads the name claim`() {
+        val token = fakeJwt("""{"name":"Resident"}""")
+
+        assertEquals("Resident", JwtClaims.extractName(token))
+    }
+
+    @Test
+    fun `audienceMatches fails open when the aud claim is missing or the token is undecodable`() {
+        assertTrue(JwtClaims.audienceMatches(fakeJwt("""{"sub":"auth0|abc"}"""), "https://api-dev.towncrierapp.uk"))
+        assertTrue(JwtClaims.audienceMatches("not-a-jwt", "https://api-dev.towncrierapp.uk"))
+    }
+
+    @Test
+    fun `audienceMatches is true when the expected audience is present`() {
+        val token = fakeJwt("""{"aud":"https://api-dev.towncrierapp.uk"}""")
+
+        assertTrue(JwtClaims.audienceMatches(token, "https://api-dev.towncrierapp.uk"))
+    }
+
+    @Test
+    fun `audienceMatches is false when a real aud claim does not contain the expected audience`() {
+        val token = fakeJwt("""{"aud":"https://api.towncrierapp.uk"}""")
+
+        assertEquals(false, JwtClaims.audienceMatches(token, "https://api-dev.towncrierapp.uk"))
+    }
+}
+
+/** Builds a JWT-shaped string (header.payload.signature) with a real base64url-encoded payload for tests. */
+internal fun fakeJwt(payloadJson: String): String {
+    val encoder = Base64.getUrlEncoder().withoutPadding()
+    val header = encoder.encodeToString("""{"alg":"RS256"}""".toByteArray())
+    val payload = encoder.encodeToString(payloadJson.toByteArray())
+    return "$header.$payload.signature"
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/JwtClaimsTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/JwtClaimsTest.kt
@@ -1,8 +1,8 @@
 package uk.towncrierapp.data.auth
 
+import org.junit.jupiter.api.Test
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
 import java.util.Base64
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 import kotlin.test.assertTrue

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/SessionCacheTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/SessionCacheTest.kt
@@ -1,15 +1,15 @@
 package uk.towncrierapp.data.auth
 
-import uk.towncrierapp.domain.auth.AuthSession
-import uk.towncrierapp.domain.auth.anAuthSession
-import java.time.Clock
-import java.time.Instant
-import java.time.ZoneOffset
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import uk.towncrierapp.domain.auth.AuthSession
+import uk.towncrierapp.domain.auth.anAuthSession
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
@@ -62,7 +62,11 @@ class SessionCacheTest {
             cache.store(session)
             var loaderCalls = 0
 
-            val result = cache.currentOrLoad(clockAt(expiresAt.minusSeconds(120))) { loaderCalls++; anAuthSession() }
+            val result =
+                cache.currentOrLoad(clockAt(expiresAt.minusSeconds(120))) {
+                    loaderCalls++
+                    anAuthSession()
+                }
 
             assertEquals(session, result)
             assertEquals(0, loaderCalls)

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/SessionCacheTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/SessionCacheTest.kt
@@ -1,0 +1,114 @@
+package uk.towncrierapp.data.auth
+
+import uk.towncrierapp.domain.auth.anAuthSession
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * In-memory session cache (iOS tc-3d7b): a hit while the access token has
+ * >= [SessionCache]'s lead time to expiry avoids a `SecureCredentialsManager`
+ * read on every call, and concurrent cold reads single-flight to one loader
+ * invocation rather than each hitting the credentials store.
+ */
+class SessionCacheTest {
+    private val expiresAt = Instant.parse("2026-07-20T15:00:00Z")
+
+    private fun clockAt(instant: Instant): Clock = Clock.fixed(instant, ZoneOffset.UTC)
+
+    @Test
+    fun `current is null when nothing has been cached yet`() =
+        runTest {
+            val cache = SessionCache(scope = backgroundScope)
+
+            assertNull(cache.current(clockAt(expiresAt.minusSeconds(120))))
+        }
+
+    @Test
+    fun `current returns the cached session while the access token has at least the lead time left`() =
+        runTest {
+            val cache = SessionCache(scope = backgroundScope, leadTimeSeconds = 60)
+            val session = anAuthSession(expiresAt = expiresAt)
+            cache.store(session)
+
+            val result = cache.current(clockAt(expiresAt.minusSeconds(61)))
+
+            assertEquals(session, result)
+        }
+
+    @Test
+    fun `current is null once the access token is within the lead time of expiry`() =
+        runTest {
+            val cache = SessionCache(scope = backgroundScope, leadTimeSeconds = 60)
+            cache.store(anAuthSession(expiresAt = expiresAt))
+
+            assertNull(cache.current(clockAt(expiresAt.minusSeconds(59))))
+            assertNull(cache.current(clockAt(expiresAt)))
+        }
+
+    @Test
+    fun `currentOrLoad returns the cached session without invoking the loader when the cache is valid`() =
+        runTest {
+            val cache = SessionCache(scope = backgroundScope, leadTimeSeconds = 60)
+            val session = anAuthSession(expiresAt = expiresAt)
+            cache.store(session)
+            var loaderCalls = 0
+
+            val result = cache.currentOrLoad(clockAt(expiresAt.minusSeconds(120))) { loaderCalls++; anAuthSession() }
+
+            assertEquals(session, result)
+            assertEquals(0, loaderCalls)
+        }
+
+    @Test
+    fun `currentOrLoad invokes the loader and caches the result on a cold cache`() =
+        runTest {
+            val cache = SessionCache(scope = backgroundScope)
+            val loaded = anAuthSession(accessToken = "freshly-loaded")
+
+            val result = cache.currentOrLoad(clockAt(expiresAt.minusSeconds(120))) { loaded }
+
+            assertEquals(loaded, result)
+            assertEquals(loaded, cache.current(clockAt(expiresAt.minusSeconds(120))))
+        }
+
+    @Test
+    fun `concurrent cold callers single-flight to exactly one loader invocation`() =
+        runTest {
+            val cache = SessionCache(scope = backgroundScope)
+            var loaderCalls = 0
+            val gate = CompletableDeferred<Unit>()
+            val loader: suspend () -> uk.towncrierapp.domain.auth.AuthSession? = {
+                loaderCalls++
+                gate.await()
+                anAuthSession()
+            }
+            val clock = clockAt(expiresAt.minusSeconds(120))
+
+            val first = async { cache.currentOrLoad(clock, loader) }
+            val second = async { cache.currentOrLoad(clock, loader) }
+            advanceUntilIdle()
+            assertEquals(1, loaderCalls)
+
+            gate.complete(Unit)
+            assertEquals(first.await(), second.await())
+        }
+
+    @Test
+    fun `clear drops the cached session`() =
+        runTest {
+            val cache = SessionCache(scope = backgroundScope)
+            cache.store(anAuthSession(expiresAt = expiresAt))
+
+            cache.clear()
+
+            assertNull(cache.current(clockAt(expiresAt.minusSeconds(120))))
+        }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/SessionCacheTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/auth/SessionCacheTest.kt
@@ -1,5 +1,6 @@
 package uk.towncrierapp.data.auth
 
+import uk.towncrierapp.domain.auth.AuthSession
 import uk.towncrierapp.domain.auth.anAuthSession
 import java.time.Clock
 import java.time.Instant
@@ -82,10 +83,13 @@ class SessionCacheTest {
     @Test
     fun `concurrent cold callers single-flight to exactly one loader invocation`() =
         runTest {
-            val cache = SessionCache(scope = backgroundScope)
+            // Scoped to the test coroutine itself (not backgroundScope) so
+            // advanceUntilIdle() deterministically drives both the outer
+            // callers and SessionCache's internal loader coroutine.
+            val cache = SessionCache(scope = this)
             var loaderCalls = 0
             val gate = CompletableDeferred<Unit>()
-            val loader: suspend () -> uk.towncrierapp.domain.auth.AuthSession? = {
+            val loader: suspend () -> AuthSession? = {
                 loaderCalls++
                 gate.await()
                 anAuthSession()

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/profile/ApiUserProfileRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/profile/ApiUserProfileRepositoryTest.kt
@@ -1,0 +1,44 @@
+package uk.towncrierapp.data.profile
+
+import uk.towncrierapp.data.api.ApiClient
+import uk.towncrierapp.data.api.FakeHttpTransport
+import uk.towncrierapp.domain.auth.FakeAuthenticationService
+import uk.towncrierapp.domain.profile.ServerProfile
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** `POST /v1/me` (no body, idempotent) — ensures the server profile and returns it (epic #770). */
+class ApiUserProfileRepositoryTest {
+    @Test
+    fun `ensureProfile POSTs to v1 me with no request body and parses the response`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, """{"userId":"auth0|1","pushEnabled":true,"tier":"Personal"}""")
+            val apiClient = ApiClient("https://api-dev.towncrierapp.uk", transport, FakeAuthenticationService())
+            val sut = ApiUserProfileRepository(apiClient)
+
+            val profile = sut.ensureProfile()
+
+            assertEquals(ServerProfile("auth0|1", pushEnabled = true, tier = SubscriptionTier.PERSONAL), profile)
+            val request = transport.requests.single()
+            assertEquals("POST", request.method)
+            assertEquals("/v1/me", request.url.encodedPath)
+            assertNull(request.header("Content-Type"))
+        }
+
+    @Test
+    fun `an unrecognised tier string falls back to Free rather than crashing`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, """{"userId":"auth0|1","pushEnabled":false,"tier":"Enterprise"}""")
+            val apiClient = ApiClient("https://api-dev.towncrierapp.uk", transport, FakeAuthenticationService())
+            val sut = ApiUserProfileRepository(apiClient)
+
+            val profile = sut.ensureProfile()
+
+            assertEquals(SubscriptionTier.FREE, profile.tier)
+        }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/profile/ApiUserProfileRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/profile/ApiUserProfileRepositoryTest.kt
@@ -1,12 +1,12 @@
 package uk.towncrierapp.data.profile
 
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
 import uk.towncrierapp.data.api.ApiClient
 import uk.towncrierapp.data.api.FakeHttpTransport
 import uk.towncrierapp.domain.auth.FakeAuthenticationService
 import uk.towncrierapp.domain.profile.ServerProfile
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/subscriptions/DataStoreSubscriptionTierCacheTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/subscriptions/DataStoreSubscriptionTierCacheTest.kt
@@ -1,11 +1,11 @@
 package uk.towncrierapp.data.subscriptions
 
-import uk.towncrierapp.domain.subscriptions.SubscriptionTier
 import androidx.datastore.preferences.core.PreferenceDataStoreFactory
-import java.io.File
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import java.io.File
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
@@ -17,7 +17,8 @@ import kotlin.test.assertNull
  * — no Robolectric needed.
  */
 class DataStoreSubscriptionTierCacheTest {
-    private fun aDataStore(directory: File) = PreferenceDataStoreFactory.create { File(directory, "test.preferences_pb") }
+    private fun aDataStore(directory: File) =
+        PreferenceDataStoreFactory.create { File(directory, "test.preferences_pb") }
 
     @Test
     fun `read returns null when nothing has been written yet`(

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/subscriptions/DataStoreSubscriptionTierCacheTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/subscriptions/DataStoreSubscriptionTierCacheTest.kt
@@ -1,0 +1,53 @@
+package uk.towncrierapp.data.subscriptions
+
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import java.io.File
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The `cachedSubscriptionTier` DataStore Preferences latch — the fast-path
+ * read on cold start, before [uk.towncrierapp.domain.subscriptions.resolveTier]'s
+ * network round-trip completes (epic #770 "API contract essentials").
+ * `PreferenceDataStoreFactory.create` over a temp file runs on the plain JVM
+ * — no Robolectric needed.
+ */
+class DataStoreSubscriptionTierCacheTest {
+    private fun aDataStore(directory: File) = PreferenceDataStoreFactory.create { File(directory, "test.preferences_pb") }
+
+    @Test
+    fun `read returns null when nothing has been written yet`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreSubscriptionTierCache(aDataStore(directory))
+
+        assertNull(sut.read())
+    }
+
+    @Test
+    fun `write then read round-trips the tier`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreSubscriptionTierCache(aDataStore(directory))
+
+        sut.write(SubscriptionTier.PRO)
+
+        assertEquals(SubscriptionTier.PRO, sut.read())
+    }
+
+    @Test
+    fun `a second write overwrites the first`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreSubscriptionTierCache(aDataStore(directory))
+
+        sut.write(SubscriptionTier.PERSONAL)
+        sut.write(SubscriptionTier.FREE)
+
+        assertEquals(SubscriptionTier.FREE, sut.read())
+    }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/versionconfig/ApiVersionConfigServiceTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/versionconfig/ApiVersionConfigServiceTest.kt
@@ -1,11 +1,11 @@
 package uk.towncrierapp.data.versionconfig
 
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
 import uk.towncrierapp.data.api.FakeHttpTransport
 import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.domain.versionconfig.AppVersion
 import java.io.IOException
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertIs

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/versionconfig/ApiVersionConfigServiceTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/versionconfig/ApiVersionConfigServiceTest.kt
@@ -1,0 +1,58 @@
+package uk.towncrierapp.data.versionconfig
+
+import uk.towncrierapp.data.api.FakeHttpTransport
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.versionconfig.AppVersion
+import java.io.IOException
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+/**
+ * `GET /v1/version-config` is anonymous — no session, no `Authorization`
+ * header — so it goes over the raw [uk.towncrierapp.data.api.HttpTransport],
+ * never through [uk.towncrierapp.data.api.ApiClient] (which always requires
+ * a session first). Must work before login for the force-update gate.
+ */
+class ApiVersionConfigServiceTest {
+    private val baseUrl = "https://api-dev.towncrierapp.uk"
+
+    @Test
+    fun `fetchMinimumVersion GETs v1 version-config with no Authorization header`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, """{"minimumVersion":"1.2.0"}""")
+            val sut = ApiVersionConfigService(baseUrl, transport)
+
+            val version = sut.fetchMinimumVersion()
+
+            assertEquals(AppVersion(1, 2, 0), version)
+            val request = transport.requests.single()
+            assertEquals("GET", request.method)
+            assertEquals("/v1/version-config", request.url.encodedPath)
+            assertNull(request.header("Authorization"))
+        }
+
+    @Test
+    fun `a transport failure maps to NetworkUnavailable`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueFailure(IOException("down"))
+            val sut = ApiVersionConfigService(baseUrl, transport)
+
+            assertIs<DomainError.NetworkUnavailable>(assertFailsWith<DomainError> { sut.fetchMinimumVersion() })
+        }
+
+    @Test
+    fun `a non-2xx response maps to a DomainError rather than throwing raw`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(500, "boom")
+            val sut = ApiVersionConfigService(baseUrl, transport)
+
+            assertFailsWith<DomainError> { sut.fetchMinimumVersion() }
+        }
+}

--- a/mobile/android/domain/build.gradle.kts
+++ b/mobile/android/domain/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    `java-test-fixtures`
 }
 
 kotlin {
@@ -22,6 +23,11 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
+
+    // Shared fakes/fixtures for domain ports (FakeAuthenticationService, aAuthSession(), ...)
+    // consumed by both :data and :presentation tests — testing.md's documented
+    // cross-module fake-sharing mechanism (java-test-fixtures, not a "testutils" module).
+    testFixturesImplementation(kotlin("test"))
 }
 
 tasks.test {

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/AuthMethod.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/AuthMethod.kt
@@ -1,0 +1,9 @@
+package uk.towncrierapp.domain.auth
+
+/** How the user signed in, derived from the JWT `sub` claim prefix (see [UserProfile.authMethod]). */
+public enum class AuthMethod {
+    EMAIL_PASSWORD,
+    GOOGLE,
+    APPLE,
+    UNKNOWN,
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/AuthSession.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/AuthSession.kt
@@ -1,0 +1,17 @@
+package uk.towncrierapp.domain.auth
+
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import java.time.Clock
+import java.time.Instant
+
+/** An authenticated user session: tokens, identity, and the tier read off the access token's JWT claim. */
+public data class AuthSession(
+    val accessToken: String,
+    val idToken: String,
+    val expiresAt: Instant,
+    val userProfile: UserProfile,
+    val subscriptionTier: SubscriptionTier = SubscriptionTier.FREE,
+) {
+    /** Whether the access token has expired as of [clock] (injected — domain code never reads the wall clock itself). */
+    public fun isExpired(clock: Clock): Boolean = !expiresAt.isAfter(clock.instant())
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/AuthenticationService.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/AuthenticationService.kt
@@ -1,0 +1,28 @@
+package uk.towncrierapp.domain.auth
+
+/**
+ * Port for authentication operations. Implementations handle Universal Login,
+ * signed-in-session storage, and token refresh via Auth0. `login()`/`logout()`
+ * intentionally take no Android `Context` — the `:data` implementation sources
+ * the current foreground activity itself (see `CurrentActivityProvider` in
+ * `:data`) so this port stays plain-Kotlin and mockable-by-fake.
+ */
+public interface AuthenticationService {
+    /** Presents Universal Login and returns the resulting session. */
+    public suspend fun login(): AuthSession
+
+    /** Clears the current session (local credentials + remote SSO cookie). */
+    public suspend fun logout()
+
+    /**
+     * Refreshes an expired (or about-to-expire) session. Throws
+     * [java.io.IOException] when the failure is a transport-level network
+     * problem (callers map that to [DomainError.NetworkUnavailable]); any
+     * other failure means the refresh token is unusable and callers should
+     * treat it as [DomainError.SessionExpired].
+     */
+    public suspend fun refreshSession(): AuthSession
+
+    /** Returns the current session, or `null` if the user is not signed in. */
+    public suspend fun currentSession(): AuthSession?
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/DomainError.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/DomainError.kt
@@ -1,0 +1,67 @@
+package uk.towncrierapp.domain.auth
+
+/**
+ * Errors thrown from `:data` and caught in `:presentation` (only `:domain`
+ * is visible to both, per the module dependency rule). Port of iOS
+ * `DomainError`'s catalogue, trimmed to what this issue's seams need — later
+ * issues (watch zones, applications, purchases) extend this sealed hierarchy
+ * feature-by-feature, the same way [uk.towncrierapp.domain.DomainModule]'s
+ * placeholder comment describes for other domain types.
+ *
+ * User-facing `userTitle`/`userMessage` strings are deliberately NOT here:
+ * they live as `:presentation` string resources, keyed off these cases (see
+ * the login screen's error caption mapping).
+ */
+public sealed class DomainError : Exception() {
+    /** No session (or an unrecoverable refresh failure) — the user must sign in again. */
+    public object SessionExpired : DomainError()
+
+    /** The transport itself failed (no connectivity, DNS, timeout, ...). */
+    public object NetworkUnavailable : DomainError()
+
+    /** The resource genuinely does not exist (HTTP 404). */
+    public object NotFound : DomainError()
+
+    /** HTTP 403 with an `{"error":"insufficient_entitlement","required":"..."}` body. */
+    public data class InsufficientEntitlement(
+        public val required: String,
+    ) : DomainError()
+
+    /** Any other HTTP error (>= 400 and not one of the cases above). [body] is the raw response text. */
+    public data class ServerError(
+        public val status: Int,
+        public val body: String?,
+    ) : DomainError()
+
+    /** Sign-in itself failed (cancelled, provider error, ...). */
+    public data class AuthenticationFailed(
+        public val reason: String,
+    ) : DomainError()
+
+    /** Sign-out failed to fully clear the remote session. */
+    public data class LogoutFailed(
+        public val reason: String,
+    ) : DomainError()
+
+    /** A failure that doesn't fit the cases above (e.g. a malformed response body). */
+    public data class Unexpected(
+        public val reason: String,
+    ) : DomainError()
+}
+
+/** Whether the error is transient and retrying may succeed. */
+public val DomainError.isRetryable: Boolean
+    get() =
+        when (this) {
+            DomainError.NetworkUnavailable,
+            DomainError.SessionExpired,
+            is DomainError.ServerError,
+            is DomainError.Unexpected,
+            is DomainError.LogoutFailed,
+            -> true
+
+            DomainError.NotFound,
+            is DomainError.InsufficientEntitlement,
+            is DomainError.AuthenticationFailed,
+            -> false
+        }

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/DomainError.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/DomainError.kt
@@ -33,20 +33,40 @@ public sealed class DomainError : Exception() {
         public val body: String?,
     ) : DomainError()
 
-    /** Sign-in itself failed (cancelled, provider error, ...). */
+    /**
+     * Sign-in itself failed (cancelled, provider error, ...). The optional
+     * [cause] overload calls [initCause] rather than becoming a stored
+     * property — a data class's primary constructor can only declare
+     * properties, and threading `cause` through as one would fold it into
+     * `equals`/`copy`, breaking `AuthenticationFailed(reason)` comparisons in
+     * tests. This is purely so the original SDK exception isn't lost from
+     * the stack trace / crash report.
+     */
     public data class AuthenticationFailed(
         public val reason: String,
-    ) : DomainError()
+    ) : DomainError() {
+        public constructor(reason: String, cause: Throwable) : this(reason) {
+            initCause(cause)
+        }
+    }
 
-    /** Sign-out failed to fully clear the remote session. */
+    /** Sign-out failed to fully clear the remote session. See [AuthenticationFailed] on the [cause] overload. */
     public data class LogoutFailed(
         public val reason: String,
-    ) : DomainError()
+    ) : DomainError() {
+        public constructor(reason: String, cause: Throwable) : this(reason) {
+            initCause(cause)
+        }
+    }
 
-    /** A failure that doesn't fit the cases above (e.g. a malformed response body). */
+    /** A failure that doesn't fit the cases above (e.g. a malformed response body). See [AuthenticationFailed] on the [cause] overload. */
     public data class Unexpected(
         public val reason: String,
-    ) : DomainError()
+    ) : DomainError() {
+        public constructor(reason: String, cause: Throwable) : this(reason) {
+            initCause(cause)
+        }
+    }
 }
 
 /** Whether the error is transient and retrying may succeed. */

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/UserProfile.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/UserProfile.kt
@@ -1,0 +1,22 @@
+package uk.towncrierapp.domain.auth
+
+/**
+ * A user's identity information from the authentication provider. [email]
+ * may legitimately be blank — Sign in with Apple grants no email scope — so
+ * callers must render it gracefully rather than treat blank as an error.
+ */
+public data class UserProfile(
+    val userId: String,
+    val email: String,
+    val name: String?,
+) {
+    /** Derives the authentication method from the [userId] (JWT `sub` claim) prefix. */
+    public val authMethod: AuthMethod
+        get() =
+            when {
+                userId.startsWith("auth0|") -> AuthMethod.EMAIL_PASSWORD
+                userId.startsWith("google-oauth2|") -> AuthMethod.GOOGLE
+                userId.startsWith("apple|") -> AuthMethod.APPLE
+                else -> AuthMethod.UNKNOWN
+            }
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/profile/ServerProfile.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/profile/ServerProfile.kt
@@ -1,0 +1,10 @@
+package uk.towncrierapp.domain.profile
+
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+
+/** The server-side profile returned by `POST /v1/me` (ensure-profile). */
+public data class ServerProfile(
+    val userId: String,
+    val pushEnabled: Boolean,
+    val tier: SubscriptionTier,
+)

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/profile/UserProfileRepository.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/profile/UserProfileRepository.kt
@@ -1,0 +1,16 @@
+package uk.towncrierapp.domain.profile
+
+/**
+ * Port for managing the user's server-side profile. This issue implements
+ * only the ensure-profile seam (`POST /v1/me`, no body, idempotent); fetch/
+ * update/delete/export land with settings work in #778.
+ */
+public interface UserProfileRepository {
+    /**
+     * Ensures the server profile exists (creates it on first call, returns
+     * the existing one otherwise — the server-side handler is idempotent)
+     * and returns it. Called on every signed-in transition, before tier
+     * resolution (tc-a6it / #549 ordering).
+     */
+    public suspend fun ensureProfile(): ServerProfile
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/subscriptions/SubscriptionTier.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/subscriptions/SubscriptionTier.kt
@@ -1,0 +1,27 @@
+package uk.towncrierapp.domain.subscriptions
+
+/**
+ * Subscription level determining feature access. Declaration order is
+ * significant: enum ordinal gives `Comparable` for free, so `maxOf(a, b)`
+ * always picks the richer tier when merging multiple sources (server
+ * profile, cached value, JWT claim — see [resolveTier]).
+ */
+public enum class SubscriptionTier(
+    public val wireValue: String,
+) {
+    FREE("Free"),
+    PERSONAL("Personal"),
+    PRO("Pro"),
+    ;
+
+    public companion object {
+        /**
+         * Parses a tier from its wire string. Case-insensitive so it accepts
+         * both the server's PascalCase vocabulary ("Personal") and the JWT
+         * `subscription_tier` claim's lowercase spelling ("personal").
+         * Returns `null` for anything unrecognised — callers decide the
+         * fallback (never silently default to FREE here, see tc-exg6).
+         */
+        public fun fromWireValue(value: String): SubscriptionTier? = entries.firstOrNull { it.wireValue.equals(value, ignoreCase = true) }
+    }
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/subscriptions/SubscriptionTier.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/subscriptions/SubscriptionTier.kt
@@ -22,6 +22,7 @@ public enum class SubscriptionTier(
          * Returns `null` for anything unrecognised — callers decide the
          * fallback (never silently default to FREE here, see tc-exg6).
          */
-        public fun fromWireValue(value: String): SubscriptionTier? = entries.firstOrNull { it.wireValue.equals(value, ignoreCase = true) }
+        public fun fromWireValue(value: String): SubscriptionTier? =
+            entries.firstOrNull { it.wireValue.equals(value, ignoreCase = true) }
     }
 }

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/subscriptions/SubscriptionTierCache.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/subscriptions/SubscriptionTierCache.kt
@@ -1,0 +1,14 @@
+package uk.towncrierapp.domain.subscriptions
+
+/**
+ * Device-local latch for the last resolved [SubscriptionTier] (DataStore
+ * Preferences key `cachedSubscriptionTier` in `:data`) — the fast-path read
+ * on cold start, before the network round-trip in [resolveTier] completes,
+ * and the fallback source when ensure-profile fails.
+ */
+public interface SubscriptionTierCache {
+    /** The last persisted tier, or `null` if nothing has been cached yet. */
+    public suspend fun read(): SubscriptionTier?
+
+    public suspend fun write(tier: SubscriptionTier)
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/subscriptions/TierResolution.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/subscriptions/TierResolution.kt
@@ -1,0 +1,23 @@
+package uk.towncrierapp.domain.subscriptions
+
+/**
+ * Single-pass tier merge (port of iOS `SubscriptionTierResolver.resolveOnce`,
+ * degraded to the 2-way form epic #772 assigns — no store tier until #783):
+ *
+ * `max(serverTier ?? max(cachedTier, jwtTier), jwtTier)`
+ *
+ * [serverTier] is `null` when ensure-profile failed (network/server error) —
+ * the fallback to `max(cachedTier, jwtTier)` means a transient failure never
+ * downgrades a paying user to Free (tc-exg6). The retry-once-when-Free
+ * orchestration (refresh the session and call this again) lives in
+ * `:presentation`'s auth coordinator, which owns the suspend/async glue this
+ * pure function deliberately has none of.
+ */
+public fun resolveTier(
+    serverTier: SubscriptionTier?,
+    cachedTier: SubscriptionTier,
+    jwtTier: SubscriptionTier,
+): SubscriptionTier {
+    val effectiveServerTier = serverTier ?: maxOf(cachedTier, jwtTier)
+    return maxOf(effectiveServerTier, jwtTier)
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/versionconfig/AppVersion.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/versionconfig/AppVersion.kt
@@ -1,0 +1,21 @@
+package uk.towncrierapp.domain.versionconfig
+
+/** Semantic version (major.minor.patch) for comparing the running app build against the server's minimum. */
+public data class AppVersion(
+    val major: Int,
+    val minor: Int,
+    val patch: Int,
+) : Comparable<AppVersion> {
+    override fun compareTo(other: AppVersion): Int =
+        compareValuesBy(this, other, AppVersion::major, AppVersion::minor, AppVersion::patch)
+
+    public companion object {
+        /** Parses a version string like "1.2.3". Returns `null` if the format is invalid. */
+        public fun parse(value: String): AppVersion? {
+            val segments = value.split(".")
+            if (segments.size != 3) return null
+            val parts = segments.map { it.toIntOrNull() ?: return null }
+            return AppVersion(parts[0], parts[1], parts[2])
+        }
+    }
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/versionconfig/VersionConfigService.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/versionconfig/VersionConfigService.kt
@@ -1,0 +1,6 @@
+package uk.towncrierapp.domain.versionconfig
+
+/** Fetches the minimum supported app version from the server (`GET /v1/version-config`, anonymous). */
+public interface VersionConfigService {
+    public suspend fun fetchMinimumVersion(): AppVersion
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/auth/AuthSessionTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/auth/AuthSessionTest.kt
@@ -1,0 +1,42 @@
+package uk.towncrierapp.domain.auth
+
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import org.junit.jupiter.api.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * `isExpired` takes an injected [Clock] rather than calling `Instant.now()`
+ * itself (android-coding-standards: no wall-clock reads in domain logic).
+ */
+class AuthSessionTest {
+    private val expiresAt: Instant = Instant.parse("2026-07-20T14:00:00Z")
+
+    private fun aSession(expiresAt: Instant = this.expiresAt) =
+        AuthSession(
+            accessToken = "access-token",
+            idToken = "id-token",
+            expiresAt = expiresAt,
+            userProfile = UserProfile(userId = "auth0|1", email = "a@example.test", name = null),
+            subscriptionTier = SubscriptionTier.FREE,
+        )
+
+    @Test
+    fun `a session is not expired before its expiry instant`() {
+        val clock = Clock.fixed(expiresAt.minusSeconds(1), ZoneOffset.UTC)
+
+        assertFalse(aSession().isExpired(clock))
+    }
+
+    @Test
+    fun `a session is expired exactly at or after its expiry instant`() {
+        val atExpiry = Clock.fixed(expiresAt, ZoneOffset.UTC)
+        val afterExpiry = Clock.fixed(expiresAt.plusSeconds(1), ZoneOffset.UTC)
+
+        assertTrue(aSession().isExpired(atExpiry))
+        assertTrue(aSession().isExpired(afterExpiry))
+    }
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/auth/AuthSessionTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/auth/AuthSessionTest.kt
@@ -1,10 +1,10 @@
 package uk.towncrierapp.domain.auth
 
+import org.junit.jupiter.api.Test
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
 import java.time.Clock
 import java.time.Instant
 import java.time.ZoneOffset
-import org.junit.jupiter.api.Test
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/auth/DomainErrorTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/auth/DomainErrorTest.kt
@@ -1,0 +1,50 @@
+package uk.towncrierapp.domain.auth
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Port of iOS `DomainError`'s `isRetryable` catalogue (user-facing
+ * `userTitle`/`userMessage` strings stay in `:presentation` resources per the
+ * bead — see LoginScreen's error captions).
+ */
+class DomainErrorTest {
+    @Test
+    fun `transient failures are retryable`() {
+        assertTrue(DomainError.NetworkUnavailable.isRetryable)
+        assertTrue(DomainError.ServerError(500, null).isRetryable)
+        assertTrue(DomainError.Unexpected("boom").isRetryable)
+        assertTrue(DomainError.SessionExpired.isRetryable)
+    }
+
+    @Test
+    fun `permanent or user-input failures are not retryable`() {
+        assertFalse(DomainError.NotFound.isRetryable)
+        assertFalse(DomainError.InsufficientEntitlement("personal").isRetryable)
+        assertFalse(DomainError.AuthenticationFailed("cancelled").isRetryable)
+    }
+
+    @Test
+    fun `InsufficientEntitlement carries the required tier string`() {
+        val error = DomainError.InsufficientEntitlement("personal")
+
+        assertEquals("personal", error.required)
+    }
+
+    @Test
+    fun `ServerError carries the status and body`() {
+        val error = DomainError.ServerError(status = 503, body = "maintenance")
+
+        assertEquals(503, error.status)
+        assertEquals("maintenance", error.body)
+    }
+
+    @Test
+    fun `same-case DomainError instances are equal`() {
+        assertEquals(DomainError.InsufficientEntitlement("personal"), DomainError.InsufficientEntitlement("personal"))
+        assertEquals(DomainError.ServerError(404, "x"), DomainError.ServerError(404, "x"))
+        assertEquals(DomainError.SessionExpired, DomainError.SessionExpired)
+    }
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/auth/DomainErrorTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/auth/DomainErrorTest.kt
@@ -47,4 +47,14 @@ class DomainErrorTest {
         assertEquals(DomainError.ServerError(404, "x"), DomainError.ServerError(404, "x"))
         assertEquals(DomainError.SessionExpired, DomainError.SessionExpired)
     }
+
+    @Test
+    fun `Unexpected preserves the original throwable as its cause without affecting equality`() {
+        val original = IllegalStateException("boom")
+
+        val error = DomainError.Unexpected("wrapped", cause = original)
+
+        assertEquals(original, error.cause)
+        assertEquals(DomainError.Unexpected("wrapped"), error)
+    }
 }

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/auth/UserProfileTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/auth/UserProfileTest.kt
@@ -1,0 +1,42 @@
+package uk.towncrierapp.domain.auth
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/** Auth method is derived from the JWT `sub` claim prefix (port of iOS `UserProfile.authMethod`). */
+class UserProfileTest {
+    @Test
+    fun `auth0 prefix derives EmailPassword`() {
+        val profile = UserProfile(userId = "auth0|abc123", email = "a@example.test", name = null)
+
+        assertEquals(AuthMethod.EMAIL_PASSWORD, profile.authMethod)
+    }
+
+    @Test
+    fun `google-oauth2 prefix derives Google`() {
+        val profile = UserProfile(userId = "google-oauth2|abc123", email = "a@example.test", name = null)
+
+        assertEquals(AuthMethod.GOOGLE, profile.authMethod)
+    }
+
+    @Test
+    fun `apple prefix derives Apple`() {
+        val profile = UserProfile(userId = "apple|abc123", email = "", name = null)
+
+        assertEquals(AuthMethod.APPLE, profile.authMethod)
+    }
+
+    @Test
+    fun `an unrecognised prefix derives Unknown`() {
+        val profile = UserProfile(userId = "samlp|abc123", email = "a@example.test", name = null)
+
+        assertEquals(AuthMethod.UNKNOWN, profile.authMethod)
+    }
+
+    @Test
+    fun `an empty email (Sign in with Apple, no email scope) never crashes and stays blank`() {
+        val profile = UserProfile(userId = "apple|abc123", email = "", name = null)
+
+        assertEquals("", profile.email)
+    }
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/subscriptions/SubscriptionTierTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/subscriptions/SubscriptionTierTest.kt
@@ -1,0 +1,48 @@
+package uk.towncrierapp.domain.subscriptions
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `SubscriptionTier` is ordered Free < Personal < Pro (epic #770) so tier
+ * merging (`maxOf`) picks the richer tier, and its wire strings are the
+ * server's PascalCase vocabulary ("Free"/"Personal"/"Pro").
+ */
+class SubscriptionTierTest {
+    @Test
+    fun `tiers are ordered Free less than Personal less than Pro`() {
+        assertTrue(SubscriptionTier.FREE < SubscriptionTier.PERSONAL)
+        assertTrue(SubscriptionTier.PERSONAL < SubscriptionTier.PRO)
+        assertTrue(SubscriptionTier.FREE < SubscriptionTier.PRO)
+    }
+
+    @Test
+    fun `maxOf picks the richer tier`() {
+        assertEquals(SubscriptionTier.PRO, maxOf(SubscriptionTier.PRO, SubscriptionTier.FREE))
+        assertEquals(SubscriptionTier.PERSONAL, maxOf(SubscriptionTier.PERSONAL, SubscriptionTier.FREE))
+    }
+
+    @Test
+    fun `wireValue matches the server's PascalCase vocabulary`() {
+        assertEquals("Free", SubscriptionTier.FREE.wireValue)
+        assertEquals("Personal", SubscriptionTier.PERSONAL.wireValue)
+        assertEquals("Pro", SubscriptionTier.PRO.wireValue)
+    }
+
+    @Test
+    fun `fromWireValue round-trips the exact wire string "Personal"`() {
+        assertEquals(SubscriptionTier.PERSONAL, SubscriptionTier.fromWireValue("Personal"))
+    }
+
+    @Test
+    fun `fromWireValue is case-insensitive to also accept the lowercase JWT claim spelling`() {
+        assertEquals(SubscriptionTier.PRO, SubscriptionTier.fromWireValue("pro"))
+    }
+
+    @Test
+    fun `fromWireValue returns null for an unrecognised string`() {
+        assertNull(SubscriptionTier.fromWireValue("enterprise"))
+    }
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/subscriptions/TierResolutionTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/subscriptions/TierResolutionTest.kt
@@ -1,0 +1,62 @@
+package uk.towncrierapp.domain.subscriptions
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pure port of iOS `SubscriptionTierResolver`'s per-pass formula, degraded to
+ * the 2-way form epic #770 assigns this issue (no store tier until #783):
+ * `max(serverTier ?? max(cachedTier, jwtTier), jwtTier)`. The retry-once-on-
+ * free orchestration (calling this twice around a session refresh) lives in
+ * `:presentation`'s auth coordinator — this function is the single-pass
+ * arithmetic it calls.
+ */
+class TierResolutionTest {
+    @Test
+    fun `a present server tier wins outright when it is the richest source`() {
+        val resolved =
+            resolveTier(
+                serverTier = SubscriptionTier.PRO,
+                cachedTier = SubscriptionTier.FREE,
+                jwtTier = SubscriptionTier.FREE,
+            )
+
+        assertEquals(SubscriptionTier.PRO, resolved)
+    }
+
+    @Test
+    fun `a richer jwt tier still wins over a lower server tier`() {
+        val resolved =
+            resolveTier(
+                serverTier = SubscriptionTier.FREE,
+                cachedTier = SubscriptionTier.FREE,
+                jwtTier = SubscriptionTier.PERSONAL,
+            )
+
+        assertEquals(SubscriptionTier.PERSONAL, resolved)
+    }
+
+    @Test
+    fun `a null server tier falls back to max of cached and jwt, never Free outright`() {
+        val resolved =
+            resolveTier(
+                serverTier = null,
+                cachedTier = SubscriptionTier.PRO,
+                jwtTier = SubscriptionTier.FREE,
+            )
+
+        assertEquals(SubscriptionTier.PRO, resolved)
+    }
+
+    @Test
+    fun `a null server tier and both fallbacks free resolves free`() {
+        val resolved =
+            resolveTier(
+                serverTier = null,
+                cachedTier = SubscriptionTier.FREE,
+                jwtTier = SubscriptionTier.FREE,
+            )
+
+        assertEquals(SubscriptionTier.FREE, resolved)
+    }
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/versionconfig/AppVersionTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/versionconfig/AppVersionTest.kt
@@ -1,0 +1,44 @@
+package uk.towncrierapp.domain.versionconfig
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AppVersionTest {
+    @Test
+    fun `parses a well-formed semver string`() {
+        assertEquals(AppVersion(1, 2, 3), AppVersion.parse("1.2.3"))
+    }
+
+    @Test
+    fun `parse returns null for a malformed string`() {
+        assertNull(AppVersion.parse("1.2"))
+        assertNull(AppVersion.parse("not-a-version"))
+        assertNull(AppVersion.parse(""))
+    }
+
+    @Test
+    fun `compares major, then minor, then patch`() {
+        assertTrue(AppVersion(1, 0, 0) < AppVersion(2, 0, 0))
+        assertTrue(AppVersion(1, 1, 0) < AppVersion(1, 2, 0))
+        assertTrue(AppVersion(1, 0, 1) < AppVersion(1, 0, 2))
+        assertTrue(AppVersion(1, 2, 3) == AppVersion(1, 2, 3))
+    }
+
+    @Test
+    fun `a version below the minimum compares less than it`() {
+        val current = AppVersion.parse("1.0.0")
+        val minimum = AppVersion.parse("1.1.0")
+
+        assertTrue(current != null && minimum != null && current < minimum)
+    }
+
+    @Test
+    fun `a version equal to or above the minimum does not compare less than it`() {
+        val current = AppVersion.parse("1.1.0")
+        val minimum = AppVersion.parse("1.1.0")
+
+        assertTrue(current != null && minimum != null && !(current < minimum))
+    }
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/auth/AuthFixtures.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/auth/AuthFixtures.kt
@@ -1,0 +1,27 @@
+package uk.towncrierapp.domain.auth
+
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import java.time.Instant
+
+/** Fixture factory for [AuthSession] — override only what a test cares about. */
+public fun anAuthSession(
+    accessToken: String = "access-token",
+    idToken: String = "id-token",
+    expiresAt: Instant = Instant.parse("2026-07-20T15:00:00Z"),
+    userProfile: UserProfile = aUserProfile(),
+    subscriptionTier: SubscriptionTier = SubscriptionTier.FREE,
+): AuthSession =
+    AuthSession(
+        accessToken = accessToken,
+        idToken = idToken,
+        expiresAt = expiresAt,
+        userProfile = userProfile,
+        subscriptionTier = subscriptionTier,
+    )
+
+/** Fixture factory for [UserProfile]. */
+public fun aUserProfile(
+    userId: String = "auth0|user-1",
+    email: String = "resident@example.test",
+    name: String? = "Resident",
+): UserProfile = UserProfile(userId = userId, email = email, name = name)

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/auth/FakeAuthenticationService.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/auth/FakeAuthenticationService.kt
@@ -1,0 +1,34 @@
+package uk.towncrierapp.domain.auth
+
+/**
+ * Hand-written fake for [AuthenticationService], shared (via `:domain`'s
+ * `testFixtures` source set) by `:data`'s `ApiClient` tests and
+ * `:presentation`'s auth-coordinator/ViewModel tests — see testing.md's
+ * cross-module fake-sharing convention.
+ */
+public class FakeAuthenticationService(
+    public var currentSessionResult: AuthSession? = anAuthSession(),
+) : AuthenticationService {
+    public var loginResult: Result<AuthSession> = Result.success(anAuthSession())
+    public var refreshSessionResult: Result<AuthSession> = Result.success(anAuthSession())
+
+    public val loginCalls: MutableList<Unit> = mutableListOf()
+    public val logoutCalls: MutableList<Unit> = mutableListOf()
+    public val refreshSessionCalls: MutableList<Unit> = mutableListOf()
+
+    override suspend fun login(): AuthSession {
+        loginCalls += Unit
+        return loginResult.getOrThrow()
+    }
+
+    override suspend fun logout() {
+        logoutCalls += Unit
+    }
+
+    override suspend fun refreshSession(): AuthSession {
+        refreshSessionCalls += Unit
+        return refreshSessionResult.getOrThrow()
+    }
+
+    override suspend fun currentSession(): AuthSession? = currentSessionResult
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/profile/FakeUserProfileRepository.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/profile/FakeUserProfileRepository.kt
@@ -1,0 +1,22 @@
+package uk.towncrierapp.domain.profile
+
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+
+/** Fixture factory for [ServerProfile]. */
+public fun aServerProfile(
+    userId: String = "auth0|user-1",
+    pushEnabled: Boolean = false,
+    tier: SubscriptionTier = SubscriptionTier.FREE,
+): ServerProfile = ServerProfile(userId = userId, pushEnabled = pushEnabled, tier = tier)
+
+/** Hand-written fake for [UserProfileRepository]. */
+public class FakeUserProfileRepository(
+    public var ensureProfileResult: Result<ServerProfile> = Result.success(aServerProfile()),
+) : UserProfileRepository {
+    public val ensureProfileCalls: MutableList<Unit> = mutableListOf()
+
+    override suspend fun ensureProfile(): ServerProfile {
+        ensureProfileCalls += Unit
+        return ensureProfileResult.getOrThrow()
+    }
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/subscriptions/FakeSubscriptionTierCache.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/subscriptions/FakeSubscriptionTierCache.kt
@@ -1,0 +1,15 @@
+package uk.towncrierapp.domain.subscriptions
+
+/** Hand-written fake for [SubscriptionTierCache] — a plain in-memory box standing in for DataStore. */
+public class FakeSubscriptionTierCache(
+    public var stored: SubscriptionTier? = null,
+) : SubscriptionTierCache {
+    public val writeCalls: MutableList<SubscriptionTier> = mutableListOf()
+
+    override suspend fun read(): SubscriptionTier? = stored
+
+    override suspend fun write(tier: SubscriptionTier) {
+        writeCalls += tier
+        stored = tier
+    }
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/versionconfig/FakeVersionConfigService.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/versionconfig/FakeVersionConfigService.kt
@@ -1,0 +1,13 @@
+package uk.towncrierapp.domain.versionconfig
+
+/** Hand-written fake for [VersionConfigService]. */
+public class FakeVersionConfigService(
+    public var fetchMinimumVersionResult: Result<AppVersion> = Result.success(AppVersion(1, 0, 0)),
+) : VersionConfigService {
+    public val fetchMinimumVersionCalls: MutableList<Unit> = mutableListOf()
+
+    override suspend fun fetchMinimumVersion(): AppVersion {
+        fetchMinimumVersionCalls += Unit
+        return fetchMinimumVersionResult.getOrThrow()
+    }
+}

--- a/mobile/android/gradle/libs.versions.toml
+++ b/mobile/android/gradle/libs.versions.toml
@@ -21,7 +21,11 @@ coroutines = "1.11.0"
 serialization = "1.11.0"
 
 # Networking / auth / persistence (tc-f2il, epic #770 "API contract essentials")
-okhttp = "5.4.0"
+# okhttp pinned to the 4.x line deliberately: 5.x's "okhttp-android" variant
+# artifact declares a compileSdk-36 AAR-metadata floor (see the compileSdk-35
+# comment above) — 4.12.0 is also what the Auth0 SDK itself depends on
+# (its own POM), so there is no version conflict either way.
+okhttp = "4.12.0"
 auth0 = "3.20.0"
 datastorePreferences = "1.2.1"
 
@@ -56,7 +60,6 @@ kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-t
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
 
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-okhttp-coroutines = { module = "com.squareup.okhttp3:okhttp-coroutines", version.ref = "okhttp" }
 auth0 = { module = "com.auth0.android:auth0", version.ref = "auth0" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 

--- a/mobile/android/gradle/libs.versions.toml
+++ b/mobile/android/gradle/libs.versions.toml
@@ -20,6 +20,11 @@ coreKtx = "1.15.0"
 coroutines = "1.11.0"
 serialization = "1.11.0"
 
+# Networking / auth / persistence (tc-f2il, epic #770 "API contract essentials")
+okhttp = "5.4.0"
+auth0 = "3.20.0"
+datastorePreferences = "1.2.1"
+
 # Lint (pinned like SwiftLint's curl-pinned-binary precedent — reproducibility over convenience)
 ktlintGradle = "14.2.0"
 ktlintCli = "1.8.0"
@@ -48,6 +53,11 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
+
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+okhttp-coroutines = { module = "com.squareup.okhttp3:okhttp-coroutines", version.ref = "okhttp" }
+auth0 = { module = "com.auth0.android:auth0", version.ref = "auth0" }
+androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
 
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junitBom" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }

--- a/mobile/android/gradle/libs.versions.toml
+++ b/mobile/android/gradle/libs.versions.toml
@@ -37,6 +37,7 @@ turbine = "1.2.1"
 [libraries]
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycle" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }

--- a/mobile/android/presentation/build.gradle.kts
+++ b/mobile/android/presentation/build.gradle.kts
@@ -62,4 +62,6 @@ dependencies {
     testImplementation(kotlin("test"))
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
+    // FakeAuthenticationService, anAuthSession(), ... shared via :domain's testFixtures.
+    testImplementation(testFixtures(project(":domain")))
 }

--- a/mobile/android/presentation/build.gradle.kts
+++ b/mobile/android/presentation/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.compose.material3)
     implementation(libs.compose.material.icons.core)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.lifecycle.runtime.compose)
     debugImplementation(libs.compose.ui.tooling)
 
     testImplementation(platform(libs.junit.bom))

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinator.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinator.kt
@@ -29,6 +29,10 @@ public class AuthCoordinator(
     public val subscriptionTier: StateFlow<SubscriptionTier> = _subscriptionTier.asStateFlow()
 
     /** Runs the full signed-in sequence: ensure profile → resolve tier → persist. Call on every signed-out→signed-in transition, including cold-start session restore. */
+    @Suppress("SwallowedException")
+    // Both catches below are deliberate degrade paths (epic #770): a refresh
+    // failure keeps the pre-refresh jwtTier; an ensure-profile failure yields
+    // "server tier unknown" to resolveTier — neither cares WHY, just THAT.
     public suspend fun onSignedIn() {
         val cachedTier = tierCache.read() ?: SubscriptionTier.FREE
         val jwtTier = authService.currentSession()?.subscriptionTier ?: SubscriptionTier.FREE
@@ -54,6 +58,7 @@ public class AuthCoordinator(
     }
 
     /** `null` on failure — [resolveTier] treats that as "server tier unknown", falling back to `max(cachedTier, jwtTier)` rather than Free. */
+    @Suppress("SwallowedException")
     private suspend fun ensureProfileTier(): SubscriptionTier? =
         try {
             userProfileRepository.ensureProfile().tier

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinator.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinator.kt
@@ -1,15 +1,15 @@
 package uk.towncrierapp.presentation.auth
 
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import uk.towncrierapp.domain.auth.AuthenticationService
 import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.domain.profile.UserProfileRepository
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
 import uk.towncrierapp.domain.subscriptions.SubscriptionTierCache
 import uk.towncrierapp.domain.subscriptions.resolveTier
-import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Owns the signed-in transition's ordering (#549): ensure the server profile

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinator.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinator.kt
@@ -1,0 +1,65 @@
+package uk.towncrierapp.presentation.auth
+
+import uk.towncrierapp.domain.auth.AuthenticationService
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.profile.UserProfileRepository
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.domain.subscriptions.SubscriptionTierCache
+import uk.towncrierapp.domain.subscriptions.resolveTier
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Owns the signed-in transition's ordering (#549): ensure the server profile
+ * exists, THEN resolve the subscription tier, THEN persist it — before any
+ * downstream gate (onboarding, in #773) runs. Port of iOS
+ * `AppCoordinator.resolveSubscriptionTier()` / `ServerTierResolver` /
+ * `SubscriptionTierResolver`, degraded to the 2-way merge this issue
+ * implements (`max(serverTier ?? max(cachedTier, jwtTier), jwtTier)` — no
+ * store tier until #783).
+ */
+public class AuthCoordinator(
+    private val authService: AuthenticationService,
+    private val userProfileRepository: UserProfileRepository,
+    private val tierCache: SubscriptionTierCache,
+) {
+    private val _subscriptionTier = MutableStateFlow(SubscriptionTier.FREE)
+    public val subscriptionTier: StateFlow<SubscriptionTier> = _subscriptionTier.asStateFlow()
+
+    /** Runs the full signed-in sequence: ensure profile → resolve tier → persist. Call on every signed-out→signed-in transition, including cold-start session restore. */
+    public suspend fun onSignedIn() {
+        val cachedTier = tierCache.read() ?: SubscriptionTier.FREE
+        val jwtTier = authService.currentSession()?.subscriptionTier ?: SubscriptionTier.FREE
+
+        var resolved = resolveTier(ensureProfileTier(), cachedTier, jwtTier)
+
+        if (resolved == SubscriptionTier.FREE) {
+            // Winner is Free — the JWT tier claim may be stale (e.g. right after
+            // an upgrade). Refresh once and re-resolve; never loop beyond this.
+            val refreshedJwtTier =
+                try {
+                    authService.refreshSession().subscriptionTier
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: DomainError) {
+                    jwtTier
+                }
+            resolved = resolveTier(ensureProfileTier(), cachedTier, refreshedJwtTier)
+        }
+
+        _subscriptionTier.value = resolved
+        tierCache.write(resolved)
+    }
+
+    /** `null` on failure — [resolveTier] treats that as "server tier unknown", falling back to `max(cachedTier, jwtTier)` rather than Free. */
+    private suspend fun ensureProfileTier(): SubscriptionTier? =
+        try {
+            userProfileRepository.ensureProfile().tier
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: DomainError) {
+            null
+        }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateScreen.kt
@@ -1,0 +1,67 @@
+package uk.towncrierapp.presentation.features.forceupdate
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import uk.towncrierapp.presentation.designsystem.components.PrimaryButton
+
+/** The Play Store listing to deep-link to — the real package id, never the `.dev`-suffixed one (don't repeat iOS's placeholder-store-id bug). */
+public const val PLAY_STORE_URL: String = "https://play.google.com/store/apps/details?id=uk.towncrierapp.mobile"
+
+/**
+ * Full-screen, non-dismissable blocking update prompt. There is no back
+ * button or skip action here by design — the app is unusable below the
+ * server's minimum version.
+ */
+@Composable
+public fun ForceUpdateScreen(
+    onUpdateClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(PaddingValues(horizontal = TownCrierSpacing.lg, vertical = TownCrierSpacing.xxl)),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.force_update_title),
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Text(
+                text = stringResource(R.string.force_update_message),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = TownCrierSpacing.sm, bottom = TownCrierSpacing.lg),
+            )
+            PrimaryButton(text = stringResource(R.string.force_update_button), onClick = onUpdateClick)
+        }
+    }
+}
+
+@Preview(name = "light")
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ForceUpdateScreenPreview() {
+    TownCrierTheme {
+        ForceUpdateScreen(onUpdateClick = {})
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateUiState.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateUiState.kt
@@ -1,0 +1,7 @@
+package uk.towncrierapp.presentation.features.forceupdate
+
+/** Pre-login force-update gate state (`GET /v1/version-config` vs the running build). */
+public data class ForceUpdateUiState(
+    val isChecking: Boolean = false,
+    val requiresUpdate: Boolean = false,
+)

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateViewModel.kt
@@ -1,0 +1,44 @@
+package uk.towncrierapp.presentation.features.forceupdate
+
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.versionconfig.AppVersion
+import uk.towncrierapp.domain.versionconfig.VersionConfigService
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Blocking pre-login version gate: unauthenticated `GET /v1/version-config`
+ * versus [currentVersion] (`BuildConfig.VERSION_NAME`, injected from `:app`
+ * since `:presentation` cannot see another module's generated BuildConfig).
+ * Re-checked on every auth-state transition (epic #770). A failed check
+ * never blocks the user — port of iOS `ForceUpdateViewModel`.
+ */
+public class ForceUpdateViewModel(
+    private val versionConfigService: VersionConfigService,
+    private val currentVersion: String,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(ForceUpdateUiState())
+    public val uiState: StateFlow<ForceUpdateUiState> = _uiState.asStateFlow()
+
+    public fun checkVersion() {
+        val runningVersion = AppVersion.parse(currentVersion) ?: return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isChecking = true) }
+            try {
+                val minimumVersion = versionConfigService.fetchMinimumVersion()
+                _uiState.update { it.copy(isChecking = false, requiresUpdate = runningVersion < minimumVersion) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                // Fail open — a version-config outage must never lock users out.
+                _uiState.update { it.copy(isChecking = false) }
+            }
+        }
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateViewModel.kt
@@ -26,6 +26,9 @@ public class ForceUpdateViewModel(
     private val _uiState = MutableStateFlow(ForceUpdateUiState())
     public val uiState: StateFlow<ForceUpdateUiState> = _uiState.asStateFlow()
 
+    @Suppress("SwallowedException")
+    // Fail open by design — a version-config outage must never lock users
+    // out, regardless of which DomainError case it was (matches iOS).
     public fun checkVersion() {
         val runningVersion = AppVersion.parse(currentVersion) ?: return
         viewModelScope.launch {
@@ -36,7 +39,6 @@ public class ForceUpdateViewModel(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: DomainError) {
-                // Fail open — a version-config outage must never lock users out.
                 _uiState.update { it.copy(isChecking = false) }
             }
         }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateViewModel.kt
@@ -1,8 +1,5 @@
 package uk.towncrierapp.presentation.features.forceupdate
 
-import uk.towncrierapp.domain.auth.DomainError
-import uk.towncrierapp.domain.versionconfig.AppVersion
-import uk.towncrierapp.domain.versionconfig.VersionConfigService
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CancellationException
@@ -11,6 +8,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.versionconfig.AppVersion
+import uk.towncrierapp.domain.versionconfig.VersionConfigService
 
 /**
  * Blocking pre-login version gate: unauthenticated `GET /v1/version-config`

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginScreen.kt
@@ -56,7 +56,11 @@ internal fun LoginScreen(
 
 @Composable
 private fun BrandingSection(modifier: Modifier = Modifier) {
-    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Center) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
         Text(
             text = stringResource(R.string.login_branding_title),
             style = MaterialTheme.typography.headlineLarge,
@@ -78,7 +82,10 @@ private fun SignInSection(
 ) {
     Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
         if (state.isLoading) {
-            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary, modifier = Modifier.padding(TownCrierSpacing.md))
+            CircularProgressIndicator(
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(TownCrierSpacing.md),
+            )
         } else {
             PrimaryButton(text = stringResource(R.string.login_sign_in_button), onClick = onSignInClick)
         }
@@ -114,6 +121,9 @@ private fun LoginScreenLoadingPreview() {
 @Composable
 private fun LoginScreenErrorPreview() {
     TownCrierTheme {
-        LoginScreen(state = LoginUiState(errorMessageRes = R.string.login_error_authentication_failed), onSignInClick = {})
+        LoginScreen(
+            state = LoginUiState(errorMessageRes = R.string.login_error_authentication_failed),
+            onSignInClick = {},
+        )
     }
 }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginScreen.kt
@@ -1,0 +1,119 @@
+package uk.towncrierapp.presentation.features.login
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import uk.towncrierapp.presentation.designsystem.components.PrimaryButton
+
+@Composable
+public fun LoginRoute(
+    viewModel: LoginViewModel,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    LaunchedEffect(Unit) { viewModel.checkExistingSession() }
+    LoginScreen(state = state, onSignInClick = viewModel::login, modifier = modifier)
+}
+
+@Composable
+internal fun LoginScreen(
+    state: LoginUiState,
+    onSignInClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(PaddingValues(horizontal = TownCrierSpacing.lg, vertical = TownCrierSpacing.xxl)),
+            verticalArrangement = Arrangement.SpaceBetween,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            BrandingSection()
+            SignInSection(state = state, onSignInClick = onSignInClick)
+        }
+    }
+}
+
+@Composable
+private fun BrandingSection(modifier: Modifier = Modifier) {
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally, verticalArrangement = Arrangement.Center) {
+        Text(
+            text = stringResource(R.string.login_branding_title),
+            style = MaterialTheme.typography.headlineLarge,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Text(
+            text = stringResource(R.string.login_branding_subtitle),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Composable
+private fun SignInSection(
+    state: LoginUiState,
+    onSignInClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        if (state.isLoading) {
+            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary, modifier = Modifier.padding(TownCrierSpacing.md))
+        } else {
+            PrimaryButton(text = stringResource(R.string.login_sign_in_button), onClick = onSignInClick)
+        }
+        state.errorMessageRes?.let { errorRes ->
+            Text(
+                text = stringResource(errorRes),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.padding(top = TownCrierSpacing.sm),
+            )
+        }
+    }
+}
+
+@Preview(name = "light")
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun LoginScreenPreview() {
+    TownCrierTheme {
+        LoginScreen(state = LoginUiState(), onSignInClick = {})
+    }
+}
+
+@Preview(name = "loading")
+@Composable
+private fun LoginScreenLoadingPreview() {
+    TownCrierTheme {
+        LoginScreen(state = LoginUiState(isLoading = true), onSignInClick = {})
+    }
+}
+
+@Preview(name = "error")
+@Composable
+private fun LoginScreenErrorPreview() {
+    TownCrierTheme {
+        LoginScreen(state = LoginUiState(errorMessageRes = R.string.login_error_authentication_failed), onSignInClick = {})
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginUiState.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginUiState.kt
@@ -1,0 +1,14 @@
+package uk.towncrierapp.presentation.features.login
+
+import androidx.annotation.StringRes
+
+/**
+ * Login screen state. [errorMessageRes] is a resource id rather than a raw
+ * string — user-facing copy stays a `:presentation` resource, never baked
+ * into the ViewModel (android-coding-standards: compose-ui.md).
+ */
+public data class LoginUiState(
+    val isLoading: Boolean = false,
+    val isAuthenticated: Boolean = false,
+    @StringRes val errorMessageRes: Int? = null,
+)

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginViewModel.kt
@@ -1,0 +1,83 @@
+package uk.towncrierapp.presentation.features.login
+
+import uk.towncrierapp.domain.auth.AuthenticationService
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.presentation.R
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Sign in, sign out, and cold-start session restore — port of iOS
+ * `LoginViewModel`. [onAuthenticated] fires on every transition into the
+ * signed-in state (fresh login or a restored session), which is what the
+ * auth-state coordinator hooks to sequence ensure-profile → tier resolution
+ * (#549 ordering) and what a future push registrar hooks to flush a pending
+ * device-token registration.
+ */
+public class LoginViewModel(
+    private val authService: AuthenticationService,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(LoginUiState())
+    public val uiState: StateFlow<LoginUiState> = _uiState.asStateFlow()
+
+    public var onAuthenticated: (() -> Unit)? = null
+
+    /** Presents Universal Login. */
+    public fun login() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessageRes = null) }
+            try {
+                authService.login()
+                _uiState.update { it.copy(isLoading = false, isAuthenticated = true) }
+                onAuthenticated?.invoke()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                _uiState.update { it.copy(isLoading = false, errorMessageRes = errorMessageRes(e)) }
+            }
+        }
+    }
+
+    /** Clears the current session. */
+    public fun logout() {
+        viewModelScope.launch {
+            try {
+                authService.logout()
+                _uiState.value = LoginUiState()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                _uiState.update { it.copy(errorMessageRes = errorMessageRes(e)) }
+            }
+        }
+    }
+
+    /**
+     * Checks for an already-stored session (cold start). `currentSession()`
+     * itself is responsible for auto-renewing a near-expiry access token
+     * (see `Auth0AuthenticationService`), so a non-null result here is
+     * already usable — no separate expiry-then-refresh dance is needed.
+     */
+    public fun checkExistingSession() {
+        viewModelScope.launch {
+            val existing = authService.currentSession() ?: return@launch
+            _uiState.update { it.copy(isAuthenticated = true) }
+            onAuthenticated?.invoke()
+        }
+    }
+
+    @StringRes
+    private fun errorMessageRes(error: DomainError): Int =
+        when (error) {
+            is DomainError.AuthenticationFailed -> R.string.login_error_authentication_failed
+            DomainError.SessionExpired -> R.string.login_error_session_expired
+            else -> R.string.login_error_generic
+        }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginViewModel.kt
@@ -1,8 +1,5 @@
 package uk.towncrierapp.presentation.features.login
 
-import uk.towncrierapp.domain.auth.AuthenticationService
-import uk.towncrierapp.domain.auth.DomainError
-import uk.towncrierapp.presentation.R
 import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -12,6 +9,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import uk.towncrierapp.domain.auth.AuthenticationService
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.presentation.R
 
 /**
  * Sign in, sign out, and cold-start session restore — port of iOS

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginViewModel.kt
@@ -67,7 +67,7 @@ public class LoginViewModel(
      */
     public fun checkExistingSession() {
         viewModelScope.launch {
-            val existing = authService.currentSession() ?: return@launch
+            authService.currentSession() ?: return@launch
             _uiState.update { it.copy(isAuthenticated = true) }
             onAuthenticated?.invoke()
         }

--- a/mobile/android/presentation/src/main/res/values/strings.xml
+++ b/mobile/android/presentation/src/main/res/values/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Login (epic #770 "API contract essentials") -->
+    <string name="login_branding_title">Town Crier</string>
+    <string name="login_branding_subtitle">Planning applications near you</string>
+    <string name="login_sign_in_button">Sign in</string>
+    <string name="login_error_authentication_failed">Sign in failed. Please try again.</string>
+    <string name="login_error_session_expired">Your session has expired. Please sign in again.</string>
+    <string name="login_error_generic">Something went wrong. Please try again.</string>
+
+    <!-- Force update (epic #770 "API contract essentials") -->
+    <string name="force_update_title">Update Required</string>
+    <string name="force_update_message">A newer version of Town Crier is available. Please update to continue using the app.</string>
+    <string name="force_update_button">Update Now</string>
+</resources>

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/MainDispatcherExtension.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/MainDispatcherExtension.kt
@@ -1,0 +1,25 @@
+package uk.towncrierapp.presentation
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * Swaps `Dispatchers.Main` for a [UnconfinedTestDispatcher] around every
+ * test so `viewModelScope.launch { ... }` runs synchronously (android-
+ * coding-standards: testing.md). Shared across every ViewModel test in
+ * `:presentation`.
+ */
+internal class MainDispatcherExtension : BeforeEachCallback, AfterEachCallback {
+    override fun beforeEach(context: ExtensionContext) {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    override fun afterEach(context: ExtensionContext) {
+        Dispatchers.resetMain()
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/MainDispatcherExtension.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/MainDispatcherExtension.kt
@@ -14,7 +14,9 @@ import org.junit.jupiter.api.extension.ExtensionContext
  * coding-standards: testing.md). Shared across every ViewModel test in
  * `:presentation`.
  */
-internal class MainDispatcherExtension : BeforeEachCallback, AfterEachCallback {
+internal class MainDispatcherExtension :
+    BeforeEachCallback,
+    AfterEachCallback {
     override fun beforeEach(context: ExtensionContext) {
         Dispatchers.setMain(UnconfinedTestDispatcher())
     }

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinatorTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinatorTest.kt
@@ -1,0 +1,98 @@
+package uk.towncrierapp.presentation.auth
+
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.auth.FakeAuthenticationService
+import uk.towncrierapp.domain.auth.anAuthSession
+import uk.towncrierapp.domain.profile.FakeUserProfileRepository
+import uk.towncrierapp.domain.profile.aServerProfile
+import uk.towncrierapp.domain.subscriptions.FakeSubscriptionTierCache
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * The signed-in transition: `POST /v1/me` (ensure-profile) BEFORE tier
+ * resolution (#549 ordering), `max(serverTier ?? max(cachedTier, jwtTier),
+ * jwtTier)` with a single refresh-and-retry when the first pass lands on
+ * Free, and persistence to the `cachedSubscriptionTier` device latch. Port
+ * of iOS `AppCoordinator.resolveSubscriptionTier()` / `SubscriptionTierResolver`,
+ * degraded to the 2-way merge this issue implements (no store tier until #783).
+ */
+class AuthCoordinatorTest {
+    @Test
+    fun `onSignedIn calls ensure-profile and folds its tier into the resolved result`() =
+        runTest {
+            val authService = FakeAuthenticationService(currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.FREE))
+            val userProfileRepository =
+                FakeUserProfileRepository(ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.PRO)))
+            val tierCache = FakeSubscriptionTierCache(stored = SubscriptionTier.FREE)
+            val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
+
+            sut.onSignedIn()
+
+            assertEquals(1, userProfileRepository.ensureProfileCalls.size)
+            assertEquals(SubscriptionTier.PRO, sut.subscriptionTier.value)
+        }
+
+    @Test
+    fun `an ensure-profile failure falls back to max of cached and jwt, never forced to Free`() =
+        runTest {
+            val authService = FakeAuthenticationService(currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.FREE))
+            val userProfileRepository = FakeUserProfileRepository(ensureProfileResult = Result.failure(DomainError.NetworkUnavailable))
+            val tierCache = FakeSubscriptionTierCache(stored = SubscriptionTier.PRO)
+            val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
+
+            sut.onSignedIn()
+
+            assertEquals(SubscriptionTier.PRO, sut.subscriptionTier.value)
+        }
+
+    @Test
+    fun `landing on Free on the first pass refreshes the session exactly once and re-resolves`() =
+        runTest {
+            val authService =
+                FakeAuthenticationService(currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.FREE)).apply {
+                    refreshSessionResult = Result.success(anAuthSession(subscriptionTier = SubscriptionTier.PERSONAL))
+                }
+            val userProfileRepository =
+                FakeUserProfileRepository(ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.FREE)))
+            val tierCache = FakeSubscriptionTierCache(stored = SubscriptionTier.FREE)
+            val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
+
+            sut.onSignedIn()
+
+            assertEquals(1, authService.refreshSessionCalls.size)
+            assertEquals(SubscriptionTier.PERSONAL, sut.subscriptionTier.value)
+        }
+
+    @Test
+    fun `a resolution that is still Free after the retry stays Free, without a second refresh`() =
+        runTest {
+            val authService = FakeAuthenticationService(currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.FREE)).apply {
+                refreshSessionResult = Result.success(anAuthSession(subscriptionTier = SubscriptionTier.FREE))
+            }
+            val userProfileRepository =
+                FakeUserProfileRepository(ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.FREE)))
+            val tierCache = FakeSubscriptionTierCache(stored = SubscriptionTier.FREE)
+            val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
+
+            sut.onSignedIn()
+
+            assertEquals(SubscriptionTier.FREE, sut.subscriptionTier.value)
+            assertEquals(1, authService.refreshSessionCalls.size)
+        }
+
+    @Test
+    fun `the resolved tier is persisted to the subscription tier cache`() =
+        runTest {
+            val authService = FakeAuthenticationService(currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.PRO))
+            val userProfileRepository = FakeUserProfileRepository(ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.PRO)))
+            val tierCache = FakeSubscriptionTierCache()
+            val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
+
+            sut.onSignedIn()
+
+            assertEquals(listOf(SubscriptionTier.PRO), tierCache.writeCalls)
+        }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinatorTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinatorTest.kt
@@ -1,5 +1,7 @@
 package uk.towncrierapp.presentation.auth
 
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
 import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.domain.auth.FakeAuthenticationService
 import uk.towncrierapp.domain.auth.anAuthSession
@@ -7,8 +9,6 @@ import uk.towncrierapp.domain.profile.FakeUserProfileRepository
 import uk.towncrierapp.domain.profile.aServerProfile
 import uk.towncrierapp.domain.subscriptions.FakeSubscriptionTierCache
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
-import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
 /**
@@ -23,9 +23,14 @@ class AuthCoordinatorTest {
     @Test
     fun `onSignedIn calls ensure-profile and folds its tier into the resolved result`() =
         runTest {
-            val authService = FakeAuthenticationService(currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.FREE))
+            val authService =
+                FakeAuthenticationService(
+                    currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.FREE),
+                )
             val userProfileRepository =
-                FakeUserProfileRepository(ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.PRO)))
+                FakeUserProfileRepository(
+                    ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.PRO)),
+                )
             val tierCache = FakeSubscriptionTierCache(stored = SubscriptionTier.FREE)
             val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
 
@@ -38,8 +43,12 @@ class AuthCoordinatorTest {
     @Test
     fun `an ensure-profile failure falls back to max of cached and jwt, never forced to Free`() =
         runTest {
-            val authService = FakeAuthenticationService(currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.FREE))
-            val userProfileRepository = FakeUserProfileRepository(ensureProfileResult = Result.failure(DomainError.NetworkUnavailable))
+            val authService =
+                FakeAuthenticationService(
+                    currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.FREE),
+                )
+            val userProfileRepository =
+                FakeUserProfileRepository(ensureProfileResult = Result.failure(DomainError.NetworkUnavailable))
             val tierCache = FakeSubscriptionTierCache(stored = SubscriptionTier.PRO)
             val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
 
@@ -52,11 +61,15 @@ class AuthCoordinatorTest {
     fun `landing on Free on the first pass refreshes the session exactly once and re-resolves`() =
         runTest {
             val authService =
-                FakeAuthenticationService(currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.FREE)).apply {
+                FakeAuthenticationService(
+                    currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.FREE),
+                ).apply {
                     refreshSessionResult = Result.success(anAuthSession(subscriptionTier = SubscriptionTier.PERSONAL))
                 }
             val userProfileRepository =
-                FakeUserProfileRepository(ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.FREE)))
+                FakeUserProfileRepository(
+                    ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.FREE)),
+                )
             val tierCache = FakeSubscriptionTierCache(stored = SubscriptionTier.FREE)
             val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
 
@@ -69,11 +82,16 @@ class AuthCoordinatorTest {
     @Test
     fun `a resolution that is still Free after the retry stays Free, without a second refresh`() =
         runTest {
-            val authService = FakeAuthenticationService(currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.FREE)).apply {
-                refreshSessionResult = Result.success(anAuthSession(subscriptionTier = SubscriptionTier.FREE))
-            }
+            val authService =
+                FakeAuthenticationService(
+                    currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.FREE),
+                ).apply {
+                    refreshSessionResult = Result.success(anAuthSession(subscriptionTier = SubscriptionTier.FREE))
+                }
             val userProfileRepository =
-                FakeUserProfileRepository(ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.FREE)))
+                FakeUserProfileRepository(
+                    ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.FREE)),
+                )
             val tierCache = FakeSubscriptionTierCache(stored = SubscriptionTier.FREE)
             val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
 
@@ -86,8 +104,12 @@ class AuthCoordinatorTest {
     @Test
     fun `the resolved tier is persisted to the subscription tier cache`() =
         runTest {
-            val authService = FakeAuthenticationService(currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.PRO))
-            val userProfileRepository = FakeUserProfileRepository(ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.PRO)))
+            val authService =
+                FakeAuthenticationService(currentSessionResult = anAuthSession(subscriptionTier = SubscriptionTier.PRO))
+            val userProfileRepository =
+                FakeUserProfileRepository(
+                    ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.PRO)),
+                )
             val tierCache = FakeSubscriptionTierCache()
             val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
 

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateViewModelTest.kt
@@ -1,11 +1,11 @@
 package uk.towncrierapp.presentation.features.forceupdate
 
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.domain.versionconfig.AppVersion
 import uk.towncrierapp.domain.versionconfig.FakeVersionConfigService
 import uk.towncrierapp.presentation.MainDispatcherExtension
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -49,7 +49,8 @@ class ForceUpdateViewModelTest {
 
     @Test
     fun `a version-config failure never blocks the user`() {
-        val service = FakeVersionConfigService(fetchMinimumVersionResult = Result.failure(DomainError.NetworkUnavailable))
+        val service =
+            FakeVersionConfigService(fetchMinimumVersionResult = Result.failure(DomainError.NetworkUnavailable))
         val viewModel = ForceUpdateViewModel(service, currentVersion = "1.0.0")
 
         viewModel.checkVersion()

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/forceupdate/ForceUpdateViewModelTest.kt
@@ -1,0 +1,70 @@
+package uk.towncrierapp.presentation.features.forceupdate
+
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.versionconfig.AppVersion
+import uk.towncrierapp.domain.versionconfig.FakeVersionConfigService
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pre-login force-update gate: `GET /v1/version-config` vs the running
+ * build's version. Port of iOS `ForceUpdateViewModelTests` — a check
+ * failure must never block the user (fail open).
+ */
+@ExtendWith(MainDispatcherExtension::class)
+class ForceUpdateViewModelTest {
+    @Test
+    fun `a running version below the minimum blocks with requiresUpdate`() {
+        val service = FakeVersionConfigService(fetchMinimumVersionResult = Result.success(AppVersion(1, 1, 0)))
+        val viewModel = ForceUpdateViewModel(service, currentVersion = "1.0.0")
+
+        viewModel.checkVersion()
+
+        assertTrue(viewModel.uiState.value.requiresUpdate)
+        assertFalse(viewModel.uiState.value.isChecking)
+    }
+
+    @Test
+    fun `a running version equal to the minimum proceeds normally`() {
+        val service = FakeVersionConfigService(fetchMinimumVersionResult = Result.success(AppVersion(1, 1, 0)))
+        val viewModel = ForceUpdateViewModel(service, currentVersion = "1.1.0")
+
+        viewModel.checkVersion()
+
+        assertFalse(viewModel.uiState.value.requiresUpdate)
+    }
+
+    @Test
+    fun `a running version above the minimum proceeds normally`() {
+        val service = FakeVersionConfigService(fetchMinimumVersionResult = Result.success(AppVersion(1, 1, 0)))
+        val viewModel = ForceUpdateViewModel(service, currentVersion = "2.0.0")
+
+        viewModel.checkVersion()
+
+        assertFalse(viewModel.uiState.value.requiresUpdate)
+    }
+
+    @Test
+    fun `a version-config failure never blocks the user`() {
+        val service = FakeVersionConfigService(fetchMinimumVersionResult = Result.failure(DomainError.NetworkUnavailable))
+        val viewModel = ForceUpdateViewModel(service, currentVersion = "1.0.0")
+
+        viewModel.checkVersion()
+
+        assertFalse(viewModel.uiState.value.requiresUpdate)
+        assertFalse(viewModel.uiState.value.isChecking)
+    }
+
+    @Test
+    fun `a malformed running version string never blocks the user`() {
+        val service = FakeVersionConfigService(fetchMinimumVersionResult = Result.success(AppVersion(1, 1, 0)))
+        val viewModel = ForceUpdateViewModel(service, currentVersion = "not-a-version")
+
+        viewModel.checkVersion()
+
+        assertFalse(viewModel.uiState.value.requiresUpdate)
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/login/LoginViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/login/LoginViewModelTest.kt
@@ -1,0 +1,109 @@
+package uk.towncrierapp.presentation.features.login
+
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.auth.FakeAuthenticationService
+import uk.towncrierapp.domain.auth.anAuthSession
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import uk.towncrierapp.presentation.R
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `login()`/`logout()`/`checkExistingSession()` — port of iOS
+ * `LoginViewModelTests`. Error copy is verbatim iOS wording, resolved as
+ * string resources (compose-ui.md), asserted here by resource id.
+ */
+@ExtendWith(MainDispatcherExtension::class)
+class LoginViewModelTest {
+    @Test
+    fun `initial state is unauthenticated with no error`() {
+        val viewModel = LoginViewModel(FakeAuthenticationService())
+
+        val state = viewModel.uiState.value
+
+        assertFalse(state.isAuthenticated)
+        assertFalse(state.isLoading)
+        assertNull(state.errorMessageRes)
+    }
+
+    @Test
+    fun `login succeeds, becomes authenticated, and fires onAuthenticated once`() {
+        val authService = FakeAuthenticationService()
+        val viewModel = LoginViewModel(authService)
+        var authenticatedCalls = 0
+        viewModel.onAuthenticated = { authenticatedCalls++ }
+
+        viewModel.login()
+
+        assertTrue(viewModel.uiState.value.isAuthenticated)
+        assertFalse(viewModel.uiState.value.isLoading)
+        assertEquals(1, authenticatedCalls)
+        assertEquals(1, authService.loginCalls.size)
+    }
+
+    @Test
+    fun `login failure surfaces the sign-in-failed caption and does not authenticate`() {
+        val authService = FakeAuthenticationService().apply { loginResult = Result.failure(DomainError.AuthenticationFailed("cancelled")) }
+        val viewModel = LoginViewModel(authService)
+        var authenticatedCalls = 0
+        viewModel.onAuthenticated = { authenticatedCalls++ }
+
+        viewModel.login()
+
+        assertFalse(viewModel.uiState.value.isAuthenticated)
+        assertEquals(R.string.login_error_authentication_failed, viewModel.uiState.value.errorMessageRes)
+        assertEquals(0, authenticatedCalls)
+    }
+
+    @Test
+    fun `a session-expired login failure surfaces the session-expired caption`() {
+        val authService = FakeAuthenticationService().apply { loginResult = Result.failure(DomainError.SessionExpired) }
+        val viewModel = LoginViewModel(authService)
+
+        viewModel.login()
+
+        assertEquals(R.string.login_error_session_expired, viewModel.uiState.value.errorMessageRes)
+    }
+
+    @Test
+    fun `logout resets to the signed-out state`() {
+        val authService = FakeAuthenticationService()
+        val viewModel = LoginViewModel(authService)
+        viewModel.login()
+
+        viewModel.logout()
+
+        assertFalse(viewModel.uiState.value.isAuthenticated)
+        assertEquals(1, authService.logoutCalls.size)
+    }
+
+    @Test
+    fun `checkExistingSession authenticates and fires onAuthenticated when a session is already stored`() {
+        val authService = FakeAuthenticationService(currentSessionResult = anAuthSession())
+        val viewModel = LoginViewModel(authService)
+        var authenticatedCalls = 0
+        viewModel.onAuthenticated = { authenticatedCalls++ }
+
+        viewModel.checkExistingSession()
+
+        assertTrue(viewModel.uiState.value.isAuthenticated)
+        assertEquals(1, authenticatedCalls)
+    }
+
+    @Test
+    fun `checkExistingSession leaves the signed-out state alone when there is no stored session`() {
+        val authService = FakeAuthenticationService(currentSessionResult = null)
+        val viewModel = LoginViewModel(authService)
+        var authenticatedCalls = 0
+        viewModel.onAuthenticated = { authenticatedCalls++ }
+
+        viewModel.checkExistingSession()
+
+        assertFalse(viewModel.uiState.value.isAuthenticated)
+        assertEquals(0, authenticatedCalls)
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/login/LoginViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/login/LoginViewModelTest.kt
@@ -1,12 +1,12 @@
 package uk.towncrierapp.presentation.features.login
 
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.domain.auth.FakeAuthenticationService
 import uk.towncrierapp.domain.auth.anAuthSession
 import uk.towncrierapp.presentation.MainDispatcherExtension
 import uk.towncrierapp.presentation.R
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
@@ -47,7 +47,11 @@ class LoginViewModelTest {
 
     @Test
     fun `login failure surfaces the sign-in-failed caption and does not authenticate`() {
-        val authService = FakeAuthenticationService().apply { loginResult = Result.failure(DomainError.AuthenticationFailed("cancelled")) }
+        val authService =
+            FakeAuthenticationService().apply {
+                loginResult =
+                    Result.failure(DomainError.AuthenticationFailed("cancelled"))
+            }
         val viewModel = LoginViewModel(authService)
         var authenticatedCalls = 0
         viewModel.onAuthenticated = { authenticatedCalls++ }


### PR DESCRIPTION
## Summary

Phase 2 of the Android parity epic (#770), closes #772. Builds on the #771 scaffold (merged).

## Changes

- **`:domain`**: `DomainError` sealed hierarchy, `AuthSession`/`UserProfile`/`AuthMethod`/`SubscriptionTier` (Comparable), profile/version-config interfaces, `resolveTier()` pure function, shared test fixtures.
- **`:data`**: hand-rolled `ApiClient` over `OkHttpTransport` — 401 refresh-once-retry-once, 403 entitlement sniff, `X-Next-Cursor` paging, dual error-envelope parsing. `DotNetTimeParser` (single `OffsetDateTime`-based parser covering the full 4-format matrix). `Auth0AuthenticationService` — aud-mismatch wipe (#680, fail-open on undecodable claims), tc-funq renewability (expired access token + valid refresh token = signed-in), session cache with 60s lead-time TTL + single-flight reads, unrecoverable-vs-transient refresh-failure split. `JwtClaims`, `ApiUserProfileRepository` (`POST /v1/me`), `ApiVersionConfigService` (anonymous), `DataStoreSubscriptionTierCache`.
- **`:presentation`**: `LoginScreen`/`LoginViewModel`, `ForceUpdateScreen`/`ForceUpdateViewModel` (real Play Store URL, no placeholder-ID bug), `AuthCoordinator` (ensure-profile before tier resolution, never downgrades to Free on ensure-profile failure, refresh-once-on-Free retry).
- **`:app`**: `AppGraph` wiring (manual DI), `TownCrierApplication`, `CurrentActivityTracker`, Auth0 manifest placeholders, Force-Update → Login → authed-shell routing in `MainActivity`.
- Auth0 tenant: new "Town Crier Android" Native application (client ID recorded on issue #772), shared by both flavors per the epic's D4 decision; `mobile.android` App Links registration set for the dev package so the HTTPS callback verifies (prod package will need the same treatment at #779/Play-track time).
- `versionName` bumped 0.1.0→1.0.0 (tc-a4j5) — the placeholder value sat below the backend's static `minimumVersion` floor, permanently blocking every launch behind the force-update gate.

## Verification

- `./gradlew test ktlintCheck detekt :app:assembleDevDebug :app:assembleProdRelease` green.
- Live emulator round-trip on the `towncrier` AVD (mobile-mcp): fresh install, launch, real Auth0 Universal Login against the live dev tenant, signed in with a real test account, redirected back into the app and landed on the authed shell — confirmed twice.
- Found and worked around an Android App Links domain-verification cache gotcha (`adb install -r` doesn't re-trigger verification after a tenant-side assetlinks.json fix; a full uninstall+reinstall does) — noted in the bead for future verification runs.

## Follow-ups filed

- `tc-2b3t` — ~6 verified detekt 1.23.8/Kotlin 2.4.0 false positives, suppressed with comments, revisit on a detekt upgrade.

---
*Bead tc-f2il (+ tc-a4j5)*