### PR TITLE
feat(sharepage): dark-mode-safe hero map treatment (tc-r4n9.7)

### DIFF
--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -212,6 +212,59 @@ func TestServe_RendersMapHeroInBody(t *testing.T) {
 	}
 }
 
+// TestServe_HeroFramedWithBorderConsistentWithCard pins Phase 7 (#794, tc-r4n9.7):
+// the hero gets the same deliberate border treatment as .card (design-language's
+// "frame with tcBorder" convention) rather than floating as a bare, edgeless
+// image — part of the "deliberate framed treatment" this phase requires instead
+// of a raw, untreated reuse of the OG card.
+func TestServe_HeroFramedWithBorderConsistentWithCard(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{app: fullApp(t), found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `.hero{display:block;width:100%;height:auto;aspect-ratio:1200/630;border:1px solid var(--border);`) {
+		t.Error("hero rule missing the card-style border frame")
+	}
+}
+
+// TestServe_HeroDarkModeFilterAvoidsJarringBrightRectangle pins Phase 7 (#794,
+// tc-r4n9.7): stop reusing the raw OG card PNG as the hero with no dark-mode
+// treatment. Standard 256px OSM tiles render on a near-white/cream basemap, so
+// dropping the 1200x630 card straight onto the dark canvas would show a jarring
+// bright rectangle. The fix recolours the SAME cached PNG with a CSS filter
+// (invert+hue-rotate is the well-known technique for showing a light raster map
+// image acceptably on a dark background — it approximately restores each
+// feature's original hue while flipping overall lightness) — it fetches ZERO
+// additional OSM tiles per page-view; see the tile-budget comment beside the
+// rule in styles.gohtml.
+func TestServe_HeroDarkModeFilterAvoidsJarringBrightRectangle(t *testing.T) {
+	t.Parallel()
+	store := &fakeStore{app: fullApp(t), found: true}
+	resolver := &fakeResolver{slugs: map[string]int{"croydon": 165}}
+
+	rec := serve(t, store, resolver, "/a/croydon/23/03456/FUL")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, `@media (prefers-color-scheme:dark){.hero{box-shadow:none;filter:invert(90%) hue-rotate(180deg);}}`) {
+		t.Error("dark-mode hero filter rule missing")
+	}
+	// The hero must still be the identical cached OG-card route — proof this is a
+	// CSS-only treatment, not a second render pipeline / extra tile fetch.
+	wantSrc := `src="https://share.towncrierapp.uk/og/croydon/23/03456/FUL.png"`
+	if !strings.Contains(body, wantSrc) {
+		t.Errorf("hero must keep reusing the cached OG card route; body should contain %q", wantSrc)
+	}
+}
+
 // TestServe_RendersHomepageLink pins Problem 3 (#763, tc-iuf0): the only CTA was
 // the iOS-only App Store bar, with no link to the web app anywhere. A visible,
 // always-present link to the Town Crier homepage must be present on every device.

--- a/api-go/internal/sharepage/handler_test.go
+++ b/api-go/internal/sharepage/handler_test.go
@@ -228,7 +228,7 @@ func TestServe_HeroFramedWithBorderConsistentWithCard(t *testing.T) {
 		t.Fatalf("status = %d, want 200", rec.Code)
 	}
 	body := rec.Body.String()
-	if !strings.Contains(body, `.hero{display:block;width:100%;height:auto;aspect-ratio:1200/630;border:1px solid var(--border);`) {
+	if !strings.Contains(body, `border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:var(--space-lg);`) {
 		t.Error("hero rule missing the card-style border frame")
 	}
 }

--- a/api-go/internal/sharepage/templates/styles.gohtml
+++ b/api-go/internal/sharepage/templates/styles.gohtml
@@ -36,10 +36,17 @@ body{
 }
 .brand-link:hover{color:var(--text-primary);}
 .page{max-width:600px;margin:0 auto;padding:var(--space-lg) var(--space-md) 148px;}
+/* Hero (tc-r4n9.7): this reuses the SAME cached OSM map-card PNG served as
+   og:image (card.go bakes it once per application; ogimage.go caches it) — this
+   treatment is pure CSS and fetches ZERO additional OSM tiles per page-view.
+   The `border` here frames it deliberately, matching .card's "border, not a
+   floating edgeless image" convention (design-language: cards are framed, not
+   bare). Dark mode below recolours it via `filter` rather than a second
+   tile-fetch/render pipeline. */
 .hero{
   display:block;width:100%;height:auto;aspect-ratio:1200/630;
-  border-radius:var(--radius-md);margin-bottom:var(--space-lg);
-  object-fit:cover;background:var(--border);
+  border:1px solid var(--border);border-radius:var(--radius-md);margin-bottom:var(--space-lg);
+  object-fit:cover;background:var(--border);box-shadow:0 2px 8px rgba(0,0,0,0.05);
 }
 .brand{
   display:flex;align-items:center;gap:var(--space-sm);
@@ -53,6 +60,16 @@ body{
   box-shadow:0 2px 8px rgba(0,0,0,0.05);
 }
 @media (prefers-color-scheme:dark){.card{box-shadow:none;}}
+/* Standard OSM tiles render on a near-white/cream basemap, so the raw hero PNG
+   would sit as a jarring bright rectangle on the dark canvas. invert+hue-rotate
+   is the well-known technique for showing a light raster map acceptably on a
+   dark surface: it flips overall lightness (light basemap -> dark) while
+   approximately restoring each feature's original hue (the brand-amber pin
+   stays amber-ish; water/greenery keep a recognisable, distinct tint), so
+   street context stays legible. 90% (not a full 100%) avoids the flat pure
+   black/white clipping a total inversion would give the baked-in pin/attribution
+   strip. Still zero extra OSM tile fetches — same cached PNG, CSS only. */
+@media (prefers-color-scheme:dark){.hero{box-shadow:none;filter:invert(90%) hue-rotate(180deg);}}
 .meta-list{margin-bottom:var(--space-sm);}
 .meta-row{
   display:flex;gap:var(--space-xs);font-size:14px;
@@ -132,7 +149,7 @@ h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--spac
   body{padding:var(--space-xl) var(--space-md);}
   .site-header{max-width:720px;padding:0;margin:0 auto var(--space-md);}
   .page{max-width:720px;margin:0 auto;padding:0;}
-  .hero{margin-bottom:var(--space-xl);}
+  .hero{margin-bottom:var(--space-xl);box-shadow:0 4px 24px rgba(0,0,0,0.06);}
   .card{padding:var(--space-lg);box-shadow:0 4px 24px rgba(0,0,0,0.06);}
   .cta-bar{
     position:static;flex-direction:row;justify-content:flex-start;align-items:center;
@@ -147,5 +164,5 @@ h1.address{font-size:24px;line-height:1.25;font-weight:700;margin:0 0 var(--spac
     color:var(--text-secondary);opacity:1;font-size:15px;text-align:left;
   }
 }
-@media (min-width:720px) and (prefers-color-scheme:dark){.card{box-shadow:none;}}
+@media (min-width:720px) and (prefers-color-scheme:dark){.card{box-shadow:none;}.hero{box-shadow:none;}}
 </style>{{end}}


### PR DESCRIPTION
## Changes
- Hero now gets a card-style border/shadow frame (matching the design-language convention of framing images, not floating them bare).
- Dark mode: CSS `filter: invert(90%) hue-rotate(180deg)` recolours the light OSM basemap so it no longer shows as a jarring bright rectangle, while keeping the amber pin and terrain features distinguishable. Pure CSS, no new render pipeline.
- **Zero new OSM tile fetches** — reuses the existing cached `/og/...` PNG route unchanged. The OG image itself (social unfurls) is untouched.

Rejected a dedicated hero-render pipeline as overkill: the existing 1200x630 zoom-15 OG card already composes fine as a page hero at both mobile and desktop widths with `object-fit:cover`, so the only real gap was dark-mode presentation.

Part of the design-review punch list (#794), Phase 7 of 7 — the final bead in the epic. Closes tc-r4n9.7.

## Test plan
- `gofmt -l .`, `go vet ./...`, `golangci-lint run ./...` clean
- `go test -race ./...` — 1431 passed
- Visual verification via agent-browser against local API + seeded Postgres: mobile (390x844) + desktop (1440x900), light + dark. Confirmed street context stays legible at all four combos, dark mode shows a recoloured map rather than a bright rectangle, OSM attribution remains legible in both themes, and the border frame matches the card's treatment.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the share page hero image styling with a more polished card-like frame and desktop presentation.
* **Bug Fixes**
  * Enhanced dark mode handling for the hero image so it displays more naturally on dark backgrounds.
  * Kept the same cached hero image source while applying visual adjustments through CSS for a consistent result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->