### PR TITLE
feat(seo): fold rework — compact status summary, CTA above list, single data-updated line (tc-r4n9.3)

### DIFF
--- a/web/scripts/lib/__tests__/format.test.mjs
+++ b/web/scripts/lib/__tests__/format.test.mjs
@@ -4,7 +4,8 @@ import {
   truncate,
   formatDate,
   statusDisplayLabel,
-  aggregateBreakdown,
+  aggregateStatusSummary,
+  dataUpdatedLine,
   leadLine,
 } from '../format.mjs';
 
@@ -81,41 +82,106 @@ describe('statusDisplayLabel', () => {
   });
 });
 
-describe('aggregateBreakdown', () => {
-  it('maps each raw appState to its resident label and re-aggregates by label', () => {
+describe('aggregateStatusSummary (tc-r4n9.3: compact Granted/Refused/Undecided strip)', () => {
+  it('buckets Permitted as granted and Rejected as refused', () => {
     const breakdown = [
-      { appState: 'Permitted', count: 5 },
-      { appState: 'Conditions', count: 2 },
-      { appState: 'Rejected', count: 3 },
-      { appState: null, count: 1 },
-      { appState: '', count: 1 },
-      { appState: 'Unknown', count: 2 },
+      { appState: 'Permitted', count: 20 },
+      { appState: 'Rejected', count: 12 },
     ];
+    expect(aggregateStatusSummary(breakdown)).toEqual({
+      granted: 20,
+      refused: 12,
+      undecided: 0,
+      total: 32,
+      other: [],
+    });
+  });
 
-    // null, '' and a literal "Unknown" all collapse to the "Unknown" label and
-    // their counts sum (1 + 1 + 2 = 4). Sorted by count DESC, then label ASC.
-    expect(aggregateBreakdown(breakdown)).toEqual([
-      { label: 'Granted', count: 5 },
-      { label: 'Unknown', count: 4 },
-      { label: 'Refused', count: 3 },
-      { label: 'Granted with conditions', count: 2 },
+  it('folds the literal "Undecided" wire state and a null/absent state together into the undecided headline bucket', () => {
+    const breakdown = [
+      { appState: 'Permitted', count: 20 },
+      { appState: 'Rejected', count: 12 },
+      { appState: 'Undecided', count: 8 },
+      { appState: null, count: 2 },
+    ];
+    expect(aggregateStatusSummary(breakdown)).toEqual({
+      granted: 20,
+      refused: 12,
+      undecided: 10,
+      total: 42,
+      other: [],
+    });
+  });
+
+  it('folds long-tail decided-but-different states into "other", not the headline buckets', () => {
+    const breakdown = [
+      { appState: 'Permitted', count: 20 },
+      { appState: 'Rejected', count: 12 },
+      { appState: 'Conditions', count: 5 },
+      { appState: 'Withdrawn', count: 3 },
+      { appState: 'Referred', count: 1 },
+    ];
+    const summary = aggregateStatusSummary(breakdown);
+    expect(summary.granted).toBe(20);
+    expect(summary.refused).toBe(12);
+    expect(summary.undecided).toBe(0);
+    expect(summary.total).toBe(41);
+    // Most-common first, ties broken alphabetically by label — same ordering
+    // rule as the old per-card aggregation.
+    expect(summary.other).toEqual([
+      { label: 'Granted with conditions', count: 5 },
+      { label: 'Withdrawn', count: 3 },
+      { label: 'Referred', count: 1 },
     ]);
   });
 
-  it('breaks count ties alphabetically by label', () => {
+  it('re-aggregates repeated long-tail labels (e.g. two raw states mapping to the same label) into one other row', () => {
     const breakdown = [
-      { appState: 'Rejected', count: 2 },
-      { appState: 'Permitted', count: 2 },
+      { appState: 'Appealed', count: 2 },
+      { appState: 'Unresolved', count: 1 },
     ];
-
-    expect(aggregateBreakdown(breakdown)).toEqual([
-      { label: 'Granted', count: 2 },
-      { label: 'Refused', count: 2 },
+    expect(aggregateStatusSummary(breakdown).other).toEqual([
+      { label: 'Appealed', count: 2 },
+      { label: 'Unresolved', count: 1 },
     ]);
   });
 
-  it('returns an empty array for an empty breakdown', () => {
-    expect(aggregateBreakdown([])).toEqual([]);
+  it('returns all-zero buckets and an empty other list for an empty breakdown', () => {
+    expect(aggregateStatusSummary([])).toEqual({
+      granted: 0,
+      refused: 0,
+      undecided: 0,
+      total: 0,
+      other: [],
+    });
+  });
+});
+
+describe('dataUpdatedLine (tc-r4n9.3: single "Data updated" line replacing the per-card repetition)', () => {
+  it('reports the freshest lastDifferent among the applications shown, formatted en-GB', () => {
+    const applications = [
+      { lastDifferent: '2026-06-12T09:30:00+00:00' },
+      { lastDifferent: '2026-06-15T10:00:00+00:00' },
+      { lastDifferent: '2026-06-09T08:00:00+00:00' },
+    ];
+    expect(dataUpdatedLine(applications)).toBe('Data updated 15 Jun 2026');
+  });
+
+  it('ignores applications with no parseable lastDifferent when finding the max', () => {
+    const applications = [
+      { lastDifferent: null },
+      { lastDifferent: '2026-06-01T08:00:00+00:00' },
+      { lastDifferent: '' },
+    ];
+    expect(dataUpdatedLine(applications)).toBe('Data updated 1 Jun 2026');
+  });
+
+  it('returns an empty string when no application carries a parseable date', () => {
+    expect(dataUpdatedLine([{ lastDifferent: null }, { lastDifferent: '' }])).toBe('');
+  });
+
+  it('returns an empty string for an empty application list', () => {
+    expect(dataUpdatedLine([])).toBe('');
   });
 });
 

--- a/web/scripts/lib/__tests__/format.test.mjs
+++ b/web/scripts/lib/__tests__/format.test.mjs
@@ -185,20 +185,32 @@ describe('dataUpdatedLine (tc-r4n9.3: single "Data updated" line replacing the p
   });
 });
 
-describe('leadLine', () => {
+describe('leadLine (tc-r4n9.3: warmed-up one-sentence intro)', () => {
   it('shows the exact total and the area name', () => {
     expect(leadLine('Adur', 42)).toBe(
-      'Town Crier is tracking 42 planning applications in Adur.',
+      "See what's happening with planning in Adur: 42 planning applications tracked so far.",
     );
   });
 
   it('uses the singular noun for a single application', () => {
     expect(leadLine('Tiny', 1)).toBe(
-      'Town Crier is tracking 1 planning application in Tiny.',
+      "See what's happening with planning in Tiny: 1 planning application tracked so far.",
     );
   });
 
   it('does not describe the count as "recent"', () => {
     expect(leadLine('Adur', 42)).not.toContain('recent');
+  });
+
+  it('is a single sentence (one full stop, at the end)', () => {
+    const line = leadLine('Adur', 42);
+    expect(line.match(/\./g)).toHaveLength(1);
+    expect(line.endsWith('.')).toBe(true);
+  });
+
+  it('never uses an em dash or en dash (voice skill hard rule)', () => {
+    const line = leadLine('Adur', 42);
+    expect(line).not.toContain('—');
+    expect(line).not.toContain('–');
   });
 });

--- a/web/scripts/lib/__tests__/prerender-snapshot.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-snapshot.test.mjs
@@ -361,7 +361,7 @@ describe('runRender — offline mode', () => {
     expect(authorityHtml).toContain(
       '<h1>Planning applications in Basingstoke and Deane</h1>',
     );
-    expect(authorityHtml).toContain('Last updated 15 Jun 2026');
+    expect(authorityHtml).toContain('Data updated 15 Jun 2026');
 
     // The nested town page renders, with the parent-authority slug resolved
     // offline from the embedded authority list (Cornwall id 52 -> "cornwall").

--- a/web/scripts/lib/__tests__/prerender-towns.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-towns.test.mjs
@@ -282,13 +282,18 @@ describe('runPrerender — town live mode', () => {
       join(outDir, 'planning', 'cornwall', 'truro', 'index.html'),
       'utf-8',
     );
-    // The freshest card (20 Jun) appears BEFORE the oldest (1 Jun) — recency DESC,
-    // even though the API fed them distance-order (oldest first).
-    expect(html).toContain('Last updated 20 Jun 2026');
-    expect(html).toContain('Last updated 1 Jun 2026');
-    expect(html.indexOf('Last updated 20 Jun 2026')).toBeLessThan(
-      html.indexOf('Last updated 1 Jun 2026'),
+    // The freshest card (Farther, changed 20 Jun) appears BEFORE the oldest
+    // (Nearest, changed 1 Jun) - recency DESC, even though the API fed them
+    // distance-order (nearest/oldest first). The per-card date is gone
+    // (tc-r4n9.3), so address text is the proxy for card order here; the
+    // single page-level "Data updated" line is asserted separately below.
+    expect(html).toContain('Farther, Truro');
+    expect(html).toContain('Nearest, Truro');
+    expect(html.indexOf('Farther, Truro')).toBeLessThan(
+      html.indexOf('Nearest, Truro'),
     );
+    // The page-level "Data updated" line reflects the freshest shown date.
+    expect(html).toContain('Data updated 20 Jun 2026');
 
     // The page's sitemap lastmod is the freshest shown app (20 Jun), proving the
     // lastmod is derived AFTER the recency sort and matches what the cards show.

--- a/web/scripts/lib/__tests__/prerender.test.mjs
+++ b/web/scripts/lib/__tests__/prerender.test.mjs
@@ -68,11 +68,12 @@ describe('runPrerender — fixture mode', () => {
     );
     expect(html).toContain('PlanIt');
     expect(html).toContain('Get push alerts for Basingstoke and Deane');
-    // The lastDifferent date threads through to a "Last updated" card label.
-    expect(html).toContain('Last updated 15 Jun 2026');
+    // The freshest shown lastDifferent threads through to the single
+    // "Data updated" line near the H1 (tc-r4n9.3), not a per-card repeat.
+    expect(html).toContain('Data updated 15 Jun 2026');
     // The server breakdown (20 Granted) is threaded through and exceeds the three
     // cards rendered — proving the stats are server-driven, not card-counted.
-    expect(html).toMatch(/Granted[\s\S]*?20/);
+    expect(html).toMatch(/20[\s\S]{0,20}Granted/);
   });
 
   it('excludes a non-qualifying areaType (English County) and a below-gate authority', async () => {

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -89,7 +89,7 @@ describe('renderPlanningPage', () => {
     expect(html).toContain('"@type":"ItemList"');
   });
 
-  it('renders each application address as the headline, status label and Last updated date', () => {
+  it('renders each application address as the headline and status label', () => {
     const html = renderPlanningPage(pageData());
     expect(html).toContain(
       '<h3 class="appCard__address">12 Mill Road, Basingstoke, RG21 1AA</h3>',
@@ -97,8 +97,6 @@ describe('renderPlanningPage', () => {
     expect(html).toContain('Erection of two-storey rear extension');
     expect(html).toContain('Granted'); // Permitted -> Granted
     expect(html).toContain('Refused'); // Rejected -> Refused
-    // The visible card date is the lastDifferent date, labelled "Last updated".
-    expect(html).toContain('Last updated 12 Jun 2026');
   });
 
   it('demotes the reference to small card metadata and removes per-card external links (decisions 5 & 6)', () => {
@@ -127,13 +125,28 @@ describe('renderPlanningPage', () => {
     );
   });
 
-  it('orders the visible Last updated dates to match the lastDifferent DESC sort', () => {
+  it('renders the cards in the order the applications were supplied (already lastDifferent DESC upstream)', () => {
     const html = renderPlanningPage(pageData());
-    expect(html).toContain('Last updated 12 Jun 2026');
-    expect(html).toContain('Last updated 10 Jun 2026');
-    expect(html.indexOf('Last updated 12 Jun 2026')).toBeLessThan(
-      html.indexOf('Last updated 10 Jun 2026'),
+    expect(html.indexOf('12 Mill Road, Basingstoke, RG21 1AA')).toBeLessThan(
+      html.indexOf('5 High Street, Basingstoke, RG21 7QN'),
     );
+  });
+
+  describe('single "Data updated" line (tc-r4n9.3, replacing the per-card repetition)', () => {
+    it('renders exactly one "Data updated" line, near the H1, from the freshest shown application date', () => {
+      const html = renderPlanningPage(pageData());
+      const occurrences = (html.match(/class="dataUpdated"/g) ?? []).length;
+      expect(occurrences).toBe(1);
+      expect(html).toContain('<p class="dataUpdated">Data updated 12 Jun 2026</p>');
+      expect(html.indexOf('<h1>')).toBeLessThan(html.indexOf('class="dataUpdated"'));
+      expect(html.indexOf('class="dataUpdated"')).toBeLessThan(html.indexOf('class="lead"'));
+    });
+
+    it('no longer repeats a "Last updated" line once per card', () => {
+      const html = renderPlanningPage(pageData());
+      expect(html).not.toContain('Last updated');
+      expect(html).not.toContain('appCard__date');
+    });
   });
 
   it('shows the exact total in the lead line', () => {
@@ -143,13 +156,15 @@ describe('renderPlanningPage', () => {
     );
   });
 
-  it('renders a stats block from the server breakdown, not the visible cards', () => {
+  it('renders a compact status summary from the server breakdown, not the visible cards', () => {
     const html = renderPlanningPage(pageData());
     // 30 Granted comes from the server breakdown over the bounded read; only two
-    // cards are rendered, so a count of 30 proves the stats are server-driven.
-    expect(html).toMatch(/Granted[\s\S]*?30/);
-    expect(html).toMatch(/Refused[\s\S]*?8/);
-    expect(html).toMatch(/Unknown[\s\S]*?4/);
+    // cards are rendered, so a count of 30 proves the summary is server-driven.
+    expect(html).toContain('<h2 class="statusSummary__heading">Status breakdown</h2>');
+    expect(html).toMatch(/30[\s\S]{0,20}Granted/);
+    expect(html).toMatch(/8[\s\S]{0,20}Refused/);
+    expect(html).toMatch(/4[\s\S]{0,20}Undecided/);
+    expect(html).toMatch(/42[\s\S]{0,20}total/);
   });
 
   it('includes the evergreen how-to-comment explainer for the area', () => {

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -192,9 +192,10 @@ describe('renderPlanningPage', () => {
   it('tags every download CTA with the ct=seo-lpa campaign token', () => {
     const html = renderPlanningPage(pageData());
     const tagged = appStoreUrl('seo-lpa');
-    // Both CTAs (header "Get the app" + bottom "Download on the App Store").
+    // Header "Get the app" + inline CTA above the list + bottom banner CTA
+    // (tc-r4n9.3 adds the inline one, on top of the pre-existing two).
     const occurrences = html.split(`href="${tagged}"`).length - 1;
-    expect(occurrences).toBe(2);
+    expect(occurrences).toBe(3);
     expect(html).toContain('ct=seo-lpa');
     // Never the bare, campaign-free URL in a CTA href.
     expect(html).not.toContain(`href="${APP_DOWNLOAD_URL}"`);
@@ -204,6 +205,23 @@ describe('renderPlanningPage', () => {
     const html = renderPlanningPage(pageData());
     expect(html).toContain('Get push alerts for Basingstoke and Deane');
     expect(html).toContain(APP_DOWNLOAD_URL);
+  });
+
+  describe('inline alerts CTA above the list (tc-r4n9.3)', () => {
+    it('renders an inline "Get push alerts" CTA directly after the intro, above the applications list', () => {
+      const html = renderPlanningPage(pageData());
+      expect(html).toContain('class="ctaInline"');
+      // Directly after the lead paragraph...
+      expect(html.indexOf('class="lead"')).toBeLessThan(html.indexOf('class="ctaInline"'));
+      // ...and above the applications list.
+      expect(html.indexOf('class="ctaInline"')).toBeLessThan(html.indexOf('class="appList"'));
+    });
+
+    it('keeps the existing bottom banner CTA in addition to the inline one (not a replacement)', () => {
+      const html = renderPlanningPage(pageData());
+      expect(html).toContain('<section class="cta">');
+      expect(html.indexOf('class="appList"')).toBeLessThan(html.indexOf('<section class="cta">'));
+    });
   });
 
   it('renders an above-the-fold download button in the site header', () => {

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -151,8 +151,9 @@ describe('renderPlanningPage', () => {
 
   it('shows the exact total in the lead line', () => {
     const html = renderPlanningPage(pageData({ total: 42 }));
+    // Apostrophe in "what's" is HTML-escaped by the shared escapeHtml() call.
     expect(html).toContain(
-      'Town Crier is tracking 42 planning applications in Basingstoke and Deane.',
+      "See what&#39;s happening with planning in Basingstoke and Deane: 42 planning applications tracked so far.",
     );
   });
 

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -4,6 +4,7 @@ import {
   renderAttributionList,
   renderStatusSummary,
   renderDataUpdated,
+  renderInlineCta,
   pageStyles,
 } from '../render-shared.mjs';
 import { ATTRIBUTION_LINES } from '../constants.mjs';
@@ -286,6 +287,28 @@ describe('renderDataUpdated (tc-r4n9.3: single line replacing per-card repetitio
   it('renders nothing when no application carries a parseable date', () => {
     expect(renderDataUpdated([])).toBe('');
     expect(renderDataUpdated([{ lastDifferent: null }])).toBe('');
+  });
+});
+
+describe('renderInlineCta (tc-r4n9.3: alerts CTA pulled above the list)', () => {
+  it('renders a real anchor to the App Store with the area-specific alert copy', () => {
+    const html = renderInlineCta('Basingstoke and Deane', 'https://apps.apple.com/x?ct=seo-lpa');
+    expect(html).toContain('class="ctaInline"');
+    expect(html).toContain('href="https://apps.apple.com/x?ct=seo-lpa"');
+    expect(html).toContain('Get push alerts for Basingstoke and Deane');
+  });
+
+  it('HTML-escapes the area name', () => {
+    const html = renderInlineCta('<script>alert(1)</script>', 'https://apps.apple.com/x');
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('is a real crawlable link, never a JS-only click handler', () => {
+    const html = renderInlineCta('Truro', 'https://apps.apple.com/x');
+    expect(html).not.toContain('onclick');
+    expect(html).toContain('rel="noopener"');
+    expect(html).toContain('target="_blank"');
   });
 });
 

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   renderApplicationsList,
   renderAttributionList,
+  renderStatusSummary,
+  renderDataUpdated,
   pageStyles,
 } from '../render-shared.mjs';
 import { ATTRIBUTION_LINES } from '../constants.mjs';
@@ -209,6 +211,81 @@ describe('renderApplicationsList status chip vocabulary (decision 4: shared voca
       (m) => m[1],
     );
     expect(new Set(modifiers)).toEqual(new Set(['granted', 'refused', 'neutral']));
+  });
+});
+
+describe('renderStatusSummary (tc-r4n9.3: compact Granted/Refused/Undecided strip)', () => {
+  const BREAKDOWN = [
+    { appState: 'Permitted', count: 20 },
+    { appState: 'Rejected', count: 12 },
+    { appState: 'Undecided', count: 8 },
+    { appState: null, count: 2 },
+  ];
+
+  it('renders a single compact strip with the three headline buckets and the total', () => {
+    const html = renderStatusSummary(BREAKDOWN);
+    expect(html).toContain('<h2 class="statusSummary__heading">Status breakdown</h2>');
+    expect(html).toMatch(/20[\s\S]{0,20}Granted/);
+    expect(html).toMatch(/12[\s\S]{0,20}Refused/);
+    expect(html).toMatch(/10[\s\S]{0,20}Undecided/);
+    expect(html).toMatch(/42[\s\S]{0,20}total/);
+  });
+
+  it('reuses the shared per-card status chip vocabulary/colours for the strip items', () => {
+    const html = renderStatusSummary(BREAKDOWN);
+    expect(html).toContain('status--granted');
+    expect(html).toContain('status--refused');
+    expect(html).toContain('status--neutral');
+  });
+
+  it('does not enumerate every top-level status as its own row (compact, not a wall of lines)', () => {
+    const html = renderStatusSummary(BREAKDOWN);
+    // No long tail in this breakdown, so no "Other" disclosure at all.
+    expect(html).not.toContain('statusSummary__other');
+  });
+
+  it('folds long-tail states behind a details disclosure instead of listing them top-level', () => {
+    const withLongTail = [
+      ...BREAKDOWN,
+      { appState: 'Conditions', count: 5 },
+      { appState: 'Withdrawn', count: 3 },
+    ];
+    const html = renderStatusSummary(withLongTail);
+    expect(html).toContain('<details class="statusSummary__other">');
+    expect(html).toContain('<summary>Other (8)</summary>');
+    expect(html).toContain('Granted with conditions');
+    expect(html).toContain('Withdrawn');
+    // The long-tail states are inside the disclosure, not top-level chips.
+    expect(html).not.toMatch(/status--\w+">\s*5 Granted with conditions/);
+  });
+
+  it('omits the Other disclosure entirely when there is no long tail', () => {
+    const html = renderStatusSummary(BREAKDOWN);
+    expect(html).not.toContain('<details');
+    expect(html).not.toContain('Other (');
+  });
+
+  it('HTML-escapes long-tail labels', () => {
+    const html = renderStatusSummary([
+      { appState: '<script>alert(1)</script>', count: 1 },
+    ]);
+    expect(html).not.toContain('<script>alert(1)</script>');
+    expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+});
+
+describe('renderDataUpdated (tc-r4n9.3: single line replacing per-card repetition)', () => {
+  it('renders one "Data updated" line from the freshest application date', () => {
+    const html = renderDataUpdated([
+      { lastDifferent: '2026-06-12T09:30:00+00:00' },
+      { lastDifferent: '2026-06-15T10:00:00+00:00' },
+    ]);
+    expect(html).toBe('<p class="dataUpdated">Data updated 15 Jun 2026</p>');
+  });
+
+  it('renders nothing when no application carries a parseable date', () => {
+    expect(renderDataUpdated([])).toBe('');
+    expect(renderDataUpdated([{ lastDifferent: null }])).toBe('');
   });
 });
 

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -197,12 +197,28 @@ describe('renderTownPage', () => {
   it('tags every download CTA with the ct=seo-town campaign token', () => {
     const html = renderTownPage(townData());
     const tagged = appStoreUrl('seo-town');
-    // Both CTAs (header "Get the app" + bottom "Download on the App Store").
+    // Header "Get the app" + inline CTA above the list + bottom banner CTA
+    // (tc-r4n9.3 adds the inline one, on top of the pre-existing two).
     const occurrences = html.split(`href="${tagged}"`).length - 1;
-    expect(occurrences).toBe(2);
+    expect(occurrences).toBe(3);
     expect(html).toContain('ct=seo-town');
     // Never the bare, campaign-free URL in a CTA href.
     expect(html).not.toContain(`href="${APP_DOWNLOAD_URL}"`);
+  });
+
+  describe('inline alerts CTA above the list (tc-r4n9.3)', () => {
+    it('renders an inline "Get push alerts" CTA directly after the intro, above the applications list', () => {
+      const html = renderTownPage(townData());
+      expect(html).toContain('class="ctaInline"');
+      expect(html.indexOf('class="lead"')).toBeLessThan(html.indexOf('class="ctaInline"'));
+      expect(html.indexOf('class="ctaInline"')).toBeLessThan(html.indexOf('class="appList"'));
+    });
+
+    it('keeps the existing bottom banner CTA in addition to the inline one (not a replacement)', () => {
+      const html = renderTownPage(townData());
+      expect(html).toContain('<section class="cta">');
+      expect(html.indexOf('class="appList"')).toBeLessThan(html.indexOf('<section class="cta">'));
+    });
   });
 
   it('includes a CTA to the App Store for the town', () => {

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -97,7 +97,7 @@ describe('renderTownPage', () => {
     expect(html).toMatch(/breadcrumb[\s\S]*?Cornwall/);
   });
 
-  it('renders each application address as the headline, status label and Last updated date', () => {
+  it('renders each application address as the headline and status label', () => {
     const html = renderTownPage(townData());
     expect(html).toContain(
       '<h3 class="appCard__address">Lemon Quay, Truro, TR1 2LW</h3>',
@@ -105,8 +105,6 @@ describe('renderTownPage', () => {
     expect(html).toContain('Change of use of ground floor from retail to café');
     expect(html).toContain('Granted'); // Permitted -> Granted
     expect(html).toContain('Refused'); // Rejected -> Refused
-    // The visible card date is the lastDifferent date, labelled "Last updated".
-    expect(html).toContain('Last updated 12 Jun 2026');
   });
 
   it('demotes the reference to small card metadata and removes per-card external links (decisions 5 & 6)', () => {
@@ -131,13 +129,28 @@ describe('renderTownPage', () => {
     );
   });
 
-  it('orders the visible Last updated dates to match the lastDifferent DESC sort', () => {
+  it('renders the cards in the order the applications were supplied (already lastDifferent DESC upstream)', () => {
     const html = renderTownPage(townData());
-    expect(html).toContain('Last updated 12 Jun 2026');
-    expect(html).toContain('Last updated 10 Jun 2026');
-    expect(html.indexOf('Last updated 12 Jun 2026')).toBeLessThan(
-      html.indexOf('Last updated 10 Jun 2026'),
+    expect(html.indexOf('Lemon Quay, Truro, TR1 2LW')).toBeLessThan(
+      html.indexOf('Boscawen Street, Truro, TR1 2QU'),
     );
+  });
+
+  describe('single "Data updated" line (tc-r4n9.3, replacing the per-card repetition)', () => {
+    it('renders exactly one "Data updated" line, near the H1, from the freshest shown application date', () => {
+      const html = renderTownPage(townData());
+      const occurrences = (html.match(/class="dataUpdated"/g) ?? []).length;
+      expect(occurrences).toBe(1);
+      expect(html).toContain('<p class="dataUpdated">Data updated 12 Jun 2026</p>');
+      expect(html.indexOf('<h1>')).toBeLessThan(html.indexOf('class="dataUpdated"'));
+      expect(html.indexOf('class="dataUpdated"')).toBeLessThan(html.indexOf('class="lead"'));
+    });
+
+    it('no longer repeats a "Last updated" line once per card', () => {
+      const html = renderTownPage(townData());
+      expect(html).not.toContain('Last updated');
+      expect(html).not.toContain('appCard__date');
+    });
   });
 
   it('shows the exact total in the lead line', () => {
@@ -147,13 +160,15 @@ describe('renderTownPage', () => {
     );
   });
 
-  it('renders a stats block from the server breakdown, not the visible cards', () => {
+  it('renders a compact status summary from the server breakdown, not the visible cards', () => {
     const html = renderTownPage(townData());
     // 12 Granted comes from the server breakdown over the bounded read; only two
-    // cards are rendered, so a count of 12 proves the stats are server-driven.
-    expect(html).toMatch(/Granted[\s\S]*?12/);
-    expect(html).toMatch(/Refused[\s\S]*?4/);
-    expect(html).toMatch(/Unknown[\s\S]*?2/);
+    // cards are rendered, so a count of 12 proves the summary is server-driven.
+    expect(html).toContain('<h2 class="statusSummary__heading">Status breakdown</h2>');
+    expect(html).toMatch(/12[\s\S]{0,20}Granted/);
+    expect(html).toMatch(/4[\s\S]{0,20}Refused/);
+    expect(html).toMatch(/2[\s\S]{0,20}Undecided/);
+    expect(html).toMatch(/18[\s\S]{0,20}total/);
   });
 
   it('includes the evergreen how-to-comment explainer naming the town and its authority', () => {

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -155,8 +155,9 @@ describe('renderTownPage', () => {
 
   it('shows the exact total in the lead line', () => {
     const html = renderTownPage(townData({ total: 18 }));
+    // Apostrophe in "what's" is HTML-escaped by the shared escapeHtml() call.
     expect(html).toContain(
-      'Town Crier is tracking 18 planning applications in Truro.',
+      "See what&#39;s happening with planning in Truro: 18 planning applications tracked so far.",
     );
   });
 

--- a/web/scripts/lib/format.mjs
+++ b/web/scripts/lib/format.mjs
@@ -96,31 +96,6 @@ export function statusDisplayLabel(appState) {
  */
 
 /**
- * Collapse the server's raw per-`appState` distribution into resident-facing
- * labels. Each wire `appState` is translated via `statusDisplayLabel` and then
- * RE-AGGREGATED by that label, so null, "" and a literal "Unknown" all fold into
- * a single "Unknown" row whose count is the sum. Sorted most common first, then
- * alphabetically by label for a stable order.
- *
- * The breakdown is computed server-side over the bounded read (~200 docs), so it
- * can legitimately total more than the handful of cards rendered on the page.
- *
- * @param {ReadonlyArray<{ appState: string | null | undefined, count: number }>} statusBreakdown
- * @returns {LabelCount[]}
- */
-export function aggregateBreakdown(statusBreakdown) {
-  /** @type {Map<string, number>} */
-  const counts = new Map();
-  for (const { appState, count } of statusBreakdown) {
-    const label = statusDisplayLabel(appState);
-    counts.set(label, (counts.get(label) ?? 0) + count);
-  }
-  return [...counts.entries()]
-    .map(([label, count]) => ({ label, count }))
-    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
-}
-
-/**
  * @typedef {Object} StatusSummary
  * @property {number} granted
  * @property {number} refused

--- a/web/scripts/lib/format.mjs
+++ b/web/scripts/lib/format.mjs
@@ -189,7 +189,9 @@ export function dataUpdatedLine(applications) {
 
 /**
  * Build the data-filled lead sentence under the H1: the exact whole-partition
- * total with the right plural.
+ * total with the right plural. Warmed up per the `voice` skill (tc-r4n9.3,
+ * punch-list #794 Phase 3) - speaks to the reader directly rather than
+ * reading as a flat database statement.
  *
  * @param {string} areaName
  * @param {number} total
@@ -197,5 +199,5 @@ export function dataUpdatedLine(applications) {
  */
 export function leadLine(areaName, total) {
   const noun = total === 1 ? 'planning application' : 'planning applications';
-  return `Town Crier is tracking ${total} ${noun} in ${areaName}.`;
+  return `See what's happening with planning in ${areaName}: ${total} ${noun} tracked so far.`;
 }

--- a/web/scripts/lib/format.mjs
+++ b/web/scripts/lib/format.mjs
@@ -121,6 +121,98 @@ export function aggregateBreakdown(statusBreakdown) {
 }
 
 /**
+ * @typedef {Object} StatusSummary
+ * @property {number} granted
+ * @property {number} refused
+ * @property {number} undecided
+ * @property {number} total
+ * @property {LabelCount[]} other   long-tail states that don't fit the three
+ *   headline buckets, most-common first then alphabetical by label — the
+ *   caller folds these behind a disclosure instead of listing each as its own
+ *   top-level row (tc-r4n9.3)
+ */
+
+/**
+ * Collapse the server's raw per-`appState` distribution into the compact
+ * three-bucket headline summary the "Status breakdown" strip needs
+ * (Granted / Refused / Undecided + total), plus whatever doesn't fit those
+ * three buckets so the caller can fold it behind a disclosure rather than
+ * enumerate every long-tail state as its own top-level row (tc-r4n9.3,
+ * punch-list #794 Phase 3).
+ *
+ * `Permitted` is granted and `Rejected` is refused. A `null`/absent state and
+ * the literal `Undecided` wire value both mean no decision has been recorded
+ * yet, so both join the "Undecided" headline bucket. Everything else — the
+ * long tail (`Conditions`/"Granted with conditions", `Withdrawn`, `Appealed`,
+ * `Referred`, `Unresolved`, any future/unrecognised state) — is decided-but-
+ * different (or otherwise doesn't read as a plain yes/no/pending), so it is
+ * aggregated by its resident label into `other` instead.
+ *
+ * @param {ReadonlyArray<{ appState: string | null | undefined, count: number }>} statusBreakdown
+ * @returns {StatusSummary}
+ */
+export function aggregateStatusSummary(statusBreakdown) {
+  let granted = 0;
+  let refused = 0;
+  let undecided = 0;
+  let total = 0;
+  /** @type {Map<string, number>} */
+  const otherCounts = new Map();
+
+  for (const { appState, count } of statusBreakdown) {
+    total += count;
+    if (appState === 'Permitted') {
+      granted += count;
+    } else if (appState === 'Rejected') {
+      refused += count;
+    } else if (appState === 'Undecided' || appState === null || appState === undefined || appState === '') {
+      undecided += count;
+    } else {
+      const label = statusDisplayLabel(appState);
+      otherCounts.set(label, (otherCounts.get(label) ?? 0) + count);
+    }
+  }
+
+  const other = [...otherCounts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+
+  return { granted, refused, undecided, total, other };
+}
+
+/**
+ * Find the most recent (max) `lastDifferent` among the applications actually
+ * shown on a page and render it as the single "Data updated" line that
+ * replaces the old per-card "Last updated {date}" repetition (tc-r4n9.3):
+ * the same honest freshness signal the sitemap's lastmod uses (derived from
+ * what's shown, not the build clock), surfaced once near the H1 instead of
+ * once per card. Returns '' when no shown application carries a parseable
+ * date, so the caller can omit the line rather than show a broken one.
+ *
+ * @param {ReadonlyArray<{ lastDifferent?: string | null }>} applications
+ * @returns {string}
+ */
+export function dataUpdatedLine(applications) {
+  let maxIso;
+  let maxMs = -Infinity;
+  for (const app of applications) {
+    const iso = app?.lastDifferent;
+    if (typeof iso !== 'string' || iso === '') {
+      continue;
+    }
+    const ms = new Date(iso).getTime();
+    if (!Number.isNaN(ms) && ms > maxMs) {
+      maxMs = ms;
+      maxIso = iso;
+    }
+  }
+  if (maxIso === undefined) {
+    return '';
+  }
+  return `Data updated ${formatDate(maxIso)}`;
+}
+
+/**
  * Build the data-filled lead sentence under the H1: the exact whole-partition
  * total with the right plural.
  *

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -6,6 +6,7 @@ import {
   renderApplicationsList,
   renderStatusSummary,
   renderDataUpdated,
+  renderInlineCta,
   renderAttributionList,
 } from './render-shared.mjs';
 
@@ -158,6 +159,7 @@ ${pageStyles()}
         <h1>Planning applications in ${area}</h1>
         ${dataUpdated}
         <p class="lead">${lead}</p>
+${renderInlineCta(data.areaName, appStoreUrl('seo-lpa'))}
 
 ${renderStatusSummary(data.statusBreakdown)}
 

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -4,7 +4,8 @@ import { townPagePath } from './town-path.mjs';
 import {
   pageStyles,
   renderApplicationsList,
-  renderStats,
+  renderStatusSummary,
+  renderDataUpdated,
   renderAttributionList,
 } from './render-shared.mjs';
 
@@ -121,6 +122,7 @@ export function renderPlanningPage(data) {
   const applicationsList = renderApplicationsList(data.applications, data.slug);
   const townLinks = renderTownLinks(data);
   const attribution = renderAttributionList();
+  const dataUpdated = renderDataUpdated(data.applications);
 
   return `<!doctype html>
 <html lang="en">
@@ -154,9 +156,10 @@ ${pageStyles()}
       </header>
       <main>
         <h1>Planning applications in ${area}</h1>
+        ${dataUpdated}
         <p class="lead">${lead}</p>
 
-${renderStats(data.statusBreakdown)}
+${renderStatusSummary(data.statusBreakdown)}
 
         <h2>Recent applications</h2>
         <ul class="appList">

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -16,6 +16,8 @@ import {
   formatDate,
   statusDisplayLabel,
   aggregateBreakdown,
+  aggregateStatusSummary,
+  dataUpdatedLine,
 } from './format.mjs';
 
 /**
@@ -153,6 +155,72 @@ export function renderStats(statusBreakdown) {
 ${rows}
       </ul>
     </section>`;
+}
+
+/**
+ * Render the compact "Status breakdown" strip (tc-r4n9.3, punch-list #794
+ * Phase 3): one line of three headline buckets (Granted / Refused /
+ * Undecided) plus the total, using the SAME `.status--granted` /
+ * `.status--refused` / `.status--neutral` chip vocabulary and colours as the
+ * per-card chips (decision 4) for visual consistency between the aggregate
+ * summary and the individual cards. Replaces the old one-row-per-appState
+ * `renderStats` list, which advertised every long-tail state as its own
+ * top-level row.
+ *
+ * Any state that doesn't fit the three headline buckets (the long tail —
+ * `Conditions`/"Granted with conditions", `Withdrawn`, `Appealed`, `Referred`,
+ * `Unresolved`, any future/unrecognised state) is folded behind a `<details>`
+ * disclosure labelled "Other (N)" instead of being enumerated top-level.
+ * Omitted entirely when there is no long tail at all.
+ *
+ * @param {ReadonlyArray<{ appState: string | null, count: number }>} statusBreakdown
+ * @returns {string}
+ */
+export function renderStatusSummary(statusBreakdown) {
+  const { granted, refused, undecided, total, other } = aggregateStatusSummary(statusBreakdown);
+  const otherTotal = other.reduce((sum, o) => sum + o.count, 0);
+  const otherDisclosure =
+    otherTotal > 0
+      ? `
+      <details class="statusSummary__other">
+        <summary>Other (${otherTotal})</summary>
+        <ul class="statusSummary__otherList">
+${other
+  .map(
+    (o) =>
+      `          <li><span class="statusSummary__otherLabel">${escapeHtml(o.label)}</span><span class="statusSummary__otherCount">${o.count}</span></li>`,
+  )
+  .join('\n')}
+        </ul>
+      </details>`
+      : '';
+  return `    <section class="statusSummary" aria-label="Application status summary">
+      <h2 class="statusSummary__heading">Status breakdown</h2>
+      <div class="statusSummary__strip">
+        <span class="statusSummary__item status status--granted">${granted} Granted</span>
+        <span class="statusSummary__item status status--refused">${refused} Refused</span>
+        <span class="statusSummary__item status status--neutral">${undecided} Undecided</span>
+        <span class="statusSummary__total">${total} total</span>
+      </div>${otherDisclosure}
+    </section>`;
+}
+
+/**
+ * Render the single "Data updated {date}" line (tc-r4n9.3, punch-list #794
+ * Phase 3) that replaces the old per-card "Last updated {date}" line, which
+ * repeated the same handful of snapshot dates once per card (up to 30 times
+ * on a full page) under a "Recent applications" heading — reading as
+ * snapshot staleness rather than a freshness signal. Placed once, near the
+ * H1, using the freshest `lastDifferent` among the applications actually
+ * shown. Returns '' (renders nothing) when no shown application carries a
+ * parseable date.
+ *
+ * @param {ReadonlyArray<{ lastDifferent?: string | null }>} applications
+ * @returns {string}
+ */
+export function renderDataUpdated(applications) {
+  const line = dataUpdatedLine(applications);
+  return line ? `<p class="dataUpdated">${escapeHtml(line)}</p>` : '';
 }
 
 /**

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -194,6 +194,29 @@ export function renderDataUpdated(applications) {
 }
 
 /**
+ * Render the inline "Get push alerts" CTA pulled above the applications list
+ * (tc-r4n9.3, punch-list #794 Phase 3): a single real, crawlable link placed
+ * directly after the intro, in addition to (not replacing) the existing rich
+ * banner CTA at the bottom of the page. Shares the exact "Get push alerts for
+ * {area}" copy with the bottom banner's heading so the two read as the same
+ * offer, just surfaced twice.
+ *
+ * @param {string} area   the area name (authority or town), the resident-facing
+ *   display name — HTML-escaped here
+ * @param {string} storeHref   the campaign-tagged App Store link for this page;
+ *   build-time constructed from a hardcoded campaign literal (never
+ *   user/data-derived), so — matching the header and bottom-banner CTAs — it is
+ *   interpolated as-is rather than through `escapeHtml`, which would otherwise
+ *   mangle the `&` in its query string into `&amp;`
+ * @returns {string}
+ */
+export function renderInlineCta(area, storeHref) {
+  return `        <p class="ctaInline">
+          <a class="ctaInline__button" href="${storeHref}" rel="noopener" target="_blank">Get push alerts for ${escapeHtml(area)} →</a>
+        </p>`;
+}
+
+/**
  * Render the mandatory data-attribution `<li>` items (ADR 0006). Required on
  * every public page. Defaults to the base {@link ATTRIBUTION_LINES}; callers can
  * supply an extended list (e.g. town pages add the ONS/NRS gazetteer credits)
@@ -392,6 +415,19 @@ export function pageStyles() {
     }
     .townLinks__list a:hover { color: var(--tc-amber-hover); border-color: var(--tc-amber); }
     .explainer p { color: var(--tc-text-secondary); }
+    /* Inline alerts CTA pulled above the list (tc-r4n9.3): a lighter pill,
+       visually distinct from the rectangular bottom banner button below. */
+    .ctaInline { margin: 0 0 var(--tc-space-lg); }
+    .ctaInline__button {
+      display: inline-block;
+      padding: var(--tc-space-sm) var(--tc-space-lg);
+      background: var(--tc-amber);
+      color: var(--tc-text-on-accent);
+      border-radius: var(--tc-radius-full);
+      text-decoration: none;
+      font-weight: 700;
+    }
+    .ctaInline__button:hover { background: var(--tc-amber-hover); }
     .cta {
       margin: var(--tc-space-xl) 0;
       padding: var(--tc-space-lg);

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -14,7 +14,6 @@ import {
   escapeHtml,
   truncate,
   statusDisplayLabel,
-  aggregateBreakdown,
   aggregateStatusSummary,
   dataUpdatedLine,
 } from './format.mjs';
@@ -126,30 +125,6 @@ ${body}
  */
 export function renderApplicationsList(applications, authoritySlug) {
   return applications.map((app) => renderApplication(app, authoritySlug)).join('\n');
-}
-
-/**
- * Render the status-breakdown block from the server-provided per-`appState`
- * distribution (computed over the bounded read), folded into resident-facing
- * labels. This is intentionally NOT derived from the handful of cards rendered
- * on the page, so the counts reflect the wider bounded set.
- *
- * @param {ReadonlyArray<{ appState: string | null, count: number }>} statusBreakdown
- * @returns {string}
- */
-export function renderStats(statusBreakdown) {
-  const rows = aggregateBreakdown(statusBreakdown)
-    .map(
-      (s) =>
-        `        <li class="statRow"><span class="statRow__label">${escapeHtml(s.label)}</span><span class="statRow__count">${s.count}</span></li>`,
-    )
-    .join('\n');
-  return `    <section class="stats" aria-label="Application status breakdown">
-      <h2 class="stats__heading">Status breakdown</h2>
-      <ul class="statList">
-${rows}
-      </ul>
-    </section>`;
 }
 
 /**

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -13,7 +13,6 @@ import { ATTRIBUTION_LINES, shareUrl } from './constants.mjs';
 import {
   escapeHtml,
   truncate,
-  formatDate,
   statusDisplayLabel,
   aggregateBreakdown,
   aggregateStatusSummary,
@@ -77,9 +76,6 @@ function statusColorModifier(appState) {
 function renderApplication(app, authoritySlug) {
   const label = escapeHtml(statusDisplayLabel(app.appState));
   const modifier = statusColorModifier(app.appState);
-  // The visible date is lastDifferent (the bounded read's DESC sort key), so the
-  // dates read top-to-bottom in the same order the cards are listed.
-  const date = formatDate(app.lastDifferent);
   const description = escapeHtml(truncate(app.description, MAX_DESCRIPTION_LENGTH));
 
   // Address is the human hook (decision 5): it is the card's heading. The
@@ -102,7 +98,6 @@ function renderApplication(app, authoritySlug) {
         ${ref ? `<p class="appCard__ref">${ref}</p>` : ''}
         <p class="appCard__desc">${description}</p>
         <div class="appCard__meta">
-          ${date ? `<span class="appCard__date">Last updated ${escapeHtml(date)}</span>` : ''}
           ${share ? `<span class="appCard__cta">View details →</span>` : ''}
         </div>`;
 
@@ -352,8 +347,10 @@ export function pageStyles() {
     h1 { font-size: 2rem; line-height: 1.2; margin: var(--tc-space-xl) 0 var(--tc-space-sm); }
     h2 { font-size: 1.5rem; margin: var(--tc-space-xl) 0 var(--tc-space-md); }
     h3 { font-size: 1.125rem; margin: 0; }
+    /* Single freshness line (tc-r4n9.3), placed near the H1. */
+    .dataUpdated { margin: 0 0 var(--tc-space-sm); font-size: 0.875rem; color: var(--tc-text-secondary); }
     .lead { font-size: 1.125rem; color: var(--tc-text-secondary); margin: 0 0 var(--tc-space-lg); }
-    .appList, .statList { list-style: none; margin: 0; padding: 0; display: grid; gap: var(--tc-space-md); }
+    .appList { list-style: none; margin: 0; padding: 0; display: grid; gap: var(--tc-space-md); }
     .appCard {
       background: var(--tc-surface);
       border: 1px solid var(--tc-border);
@@ -378,7 +375,6 @@ export function pageStyles() {
     .appCard__ref { margin: var(--tc-space-sm) 0; font-size: 0.8125rem; color: var(--tc-text-secondary); overflow-wrap: anywhere; }
     .appCard__desc { margin: 0 0 var(--tc-space-sm); color: var(--tc-text-secondary); }
     .appCard__meta { display: flex; flex-wrap: wrap; gap: var(--tc-space-md); align-items: center; font-size: 0.875rem; }
-    .appCard__date { color: var(--tc-text-secondary); }
     /* Visible share-page affordance (decision 6) — a real anchor, not a
        JS-only click handler; this is the text cue, the href is the whole card. */
     .appCard__cta { color: var(--tc-amber); font-weight: 600; }
@@ -397,8 +393,17 @@ export function pageStyles() {
     .status--granted { color: var(--tc-status-granted); background: var(--tc-status-granted-bg); }
     .status--refused { color: var(--tc-status-refused); background: var(--tc-status-refused-bg); }
     .status--neutral { color: var(--tc-status-neutral); background: var(--tc-status-neutral-bg); }
-    .statRow { display: flex; justify-content: space-between; background: var(--tc-surface); border: 1px solid var(--tc-border); border-radius: var(--tc-radius-md); padding: var(--tc-space-sm) var(--tc-space-md); }
-    .statRow__count { font-weight: 700; }
+    /* Compact "Status breakdown" strip (tc-r4n9.3): one row of chip-style
+       headline buckets (reusing the .status--granted/refused/neutral chip
+       vocabulary above) plus the total, with any long tail folded behind the
+       .statusSummary__other <details> instead of a one-row-per-state list. */
+    .statusSummary__strip { display: flex; flex-wrap: wrap; align-items: center; gap: var(--tc-space-sm); }
+    .statusSummary__total { color: var(--tc-text-secondary); font-size: 0.875rem; }
+    .statusSummary__other { margin-top: var(--tc-space-sm); color: var(--tc-text-secondary); font-size: 0.875rem; }
+    .statusSummary__other summary { cursor: pointer; color: var(--tc-amber); font-weight: 600; }
+    .statusSummary__otherList { list-style: none; margin: var(--tc-space-sm) 0 0; padding: 0; display: grid; gap: var(--tc-space-sm); }
+    .statusSummary__otherList li { display: flex; justify-content: space-between; gap: var(--tc-space-md); }
+    .statusSummary__otherCount { font-weight: 700; }
     .townLinks__list { list-style: none; margin: 0; padding: 0; display: flex; flex-wrap: wrap; gap: var(--tc-space-sm); }
     .townLinks__list a {
       display: inline-block;

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -26,6 +26,7 @@ import {
   renderApplicationsList,
   renderStatusSummary,
   renderDataUpdated,
+  renderInlineCta,
   renderAttributionList,
 } from './render-shared.mjs';
 
@@ -167,6 +168,7 @@ ${pageStyles()}
         <h1>Planning applications in ${town}</h1>
         ${dataUpdated}
         <p class="lead">${lead}</p>
+${renderInlineCta(data.townName, appStoreUrl('seo-town'))}
 
 ${renderStatusSummary(data.statusBreakdown)}
 

--- a/web/scripts/lib/render-town-page.mjs
+++ b/web/scripts/lib/render-town-page.mjs
@@ -24,7 +24,8 @@ import { escapeHtml, leadLine } from './format.mjs';
 import {
   pageStyles,
   renderApplicationsList,
-  renderStats,
+  renderStatusSummary,
+  renderDataUpdated,
   renderAttributionList,
 } from './render-shared.mjs';
 
@@ -123,6 +124,7 @@ export function renderTownPage(data) {
   // sources) on top of the base PlanIt/OGL/OS/OSM lines; authority pages keep the
   // base list since they don't use the gazetteer.
   const attribution = renderAttributionList(TOWN_ATTRIBUTION_LINES);
+  const dataUpdated = renderDataUpdated(data.applications);
 
   return `<!doctype html>
 <html lang="en">
@@ -163,9 +165,10 @@ ${pageStyles()}
       </nav>
       <main>
         <h1>Planning applications in ${town}</h1>
+        ${dataUpdated}
         <p class="lead">${lead}</p>
 
-${renderStats(data.statusBreakdown)}
+${renderStatusSummary(data.statusBreakdown)}
 
         <h2>Recent applications</h2>
         <ul class="appList">

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -90,7 +90,8 @@ function maxLastmod(applications) {
  * Sort applications by `lastDifferent` DESC (freshest first) for DISPLAY. Town
  * nearby data arrives distance-ordered (the build requests `order=distance` to
  * minimise overlap between adjacent town pages), so the renderer must re-sort it
- * by recency to read newest-first and match the "Last updated" date order.
+ * by recency so the cards read newest-first (matching the single page-level
+ * "Data updated" line, which reports the freshest of the same shown set).
  * Authority data already arrives recency-ordered, so this is only applied on the
  * town path. Returns a new array; undated rows sort last, original order is kept
  * among equal dates (stable).


### PR DESCRIPTION
## Changes
- Status breakdown compressed to one strip: Granted/Refused/Undecided + total, sharing the same chip vocabulary/colours as per-application cards (tc-r4n9.2). Long-tail states (Conditions, Withdrawn, Referred, Appealed, etc.) fold behind an "Other (N)" `<details>` disclosure instead of enumerating each as its own line.
- "Get push alerts for {area}" CTA now appears directly after the intro, above the applications list, in addition to the existing bottom banner CTA.
- Per-card "Last updated {date}" line (previously repeated once per card) replaced with a single "Data updated {date}" line near the H1.
- Intro copy warmed up per the voice skill (plain, direct, second person).

Part of the design-review punch list (#794), Phase 3 of 7. Closes tc-r4n9.3.

## Test plan
- `npx tsc --noEmit` clean, `npm run build` clean, `npx vitest run` — 1004/1004 (full suite)
- Visual verification via agent-browser: authority + town pages, light/dark, desktop (1280x900) + mobile (390x844). Confirmed compact status strip (no wall of status lines), alerts CTA present both above the list and at the bottom, exactly one "Data updated" line with zero per-card repetition, and the "Other (N)" disclosure expands/collapses correctly with a synthetic long-tail fixture.

---
*Auto-shipped via ship skill*