### PR TITLE
feat(seo): authority breadcrumb + town-links investigation (tc-r4n9.4)

### DIFF
--- a/web/scripts/lib/__tests__/prerender-dedup.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-dedup.test.mjs
@@ -298,3 +298,54 @@ describe('runPrerender — same-name town dedup (tc-77ll)', () => {
     });
   });
 });
+
+describe('real-world case: Croydon shows zero town links (tc-r4n9.4 investigation)', () => {
+  it('documents why: the gazetteer carries exactly one Croydon-authority row, named "Croydon" itself, so the pre-existing same-name dedup (tc-77ll) suppresses it -- not an ordering regression or a stale snapshot', async () => {
+    // Mirrors the real committed values in web/src/data/towns.json for
+    // authorityId 301 (Croydon): a SINGLE row, name "Croydon". ONS's Census 2021
+    // Built-Up-Areas methodology treats each Greater London borough as one
+    // borough-shaped BUA rather than distinct settlements (see the "London
+    // population" note in generate-towns.mjs) -- there is no separate
+    // "Purley" / "Coulsdon" / "South Norwood" row for this dedup to spare.
+    const result = await runWith({
+      authorities: [
+        {
+          id: 301,
+          name: 'Croydon',
+          areaType: 'London Borough',
+          areaName: 'Croydon',
+          total: 40,
+          statusBreakdown: [{ appState: 'Permitted', count: 40 }],
+          applications: [app('CR1')],
+        },
+      ],
+      towns: [
+        {
+          slug: 'croydon',
+          name: 'Croydon',
+          lat: 51.3507,
+          lng: -0.083,
+          authorityId: 301,
+          total: 30, // clears the >=10 coverage gate; suppressed on same-name below
+          statusBreakdown: [{ appState: 'Permitted', count: 30 }],
+          applications: [app('CRT1')],
+        },
+      ],
+      authorityList: [{ id: 301, name: 'Croydon' }],
+    });
+
+    expect(result.publishedTowns).toEqual([]);
+    expect(result.excludedTowns).toContainEqual({
+      name: 'Croydon',
+      reason: 'same-name',
+    });
+
+    const croydonPage = await readFile(
+      join(outDir, 'planning', 'croydon', 'index.html'),
+      'utf-8',
+    );
+    expect(croydonPage).not.toContain('<section class="townLinks">');
+    // The breadcrumb (tc-r4n9.4) still renders regardless of the town-links gap.
+    expect(croydonPage).toContain('class="breadcrumb"');
+  });
+});

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -89,6 +89,68 @@ describe('renderPlanningPage', () => {
     expect(html).toContain('"@type":"ItemList"');
   });
 
+  describe('breadcrumb (tc-r4n9.4)', () => {
+    it('renders a visible breadcrumb with exactly two levels: Home, then the authority (no grandparent level)', () => {
+      const html = renderPlanningPage(pageData());
+      const nav = html.match(
+        /<nav class="breadcrumb" aria-label="Breadcrumb">[\s\S]*?<\/nav>/,
+      );
+      expect(nav).not.toBeNull();
+      const [navHtml] = nav;
+      const liCount = (navHtml.match(/<li/g) ?? []).length;
+      expect(liCount).toBe(2);
+      expect(navHtml).toContain('<li><a href="/">Town Crier</a></li>');
+      expect(navHtml).toContain('<li>Basingstoke and Deane</li>');
+      // The current page is plain text, not a self-link (matches the town-page pattern).
+      expect(navHtml).not.toContain('<a href="/planning/basingstoke-and-deane"');
+    });
+
+    it('places the breadcrumb between the site header and the main content', () => {
+      const html = renderPlanningPage(pageData());
+      expect(html.indexOf('</header>')).toBeLessThan(
+        html.indexOf('class="breadcrumb"'),
+      );
+      expect(html.indexOf('class="breadcrumb"')).toBeLessThan(
+        html.indexOf('<main>'),
+      );
+    });
+
+    it('HTML-escapes the authority name in the visible breadcrumb', () => {
+      const html = renderPlanningPage(
+        pageData({ areaName: 'Stoke & <b>Bramley</b>' }),
+      );
+      expect(html).not.toContain('<li><b>Bramley</b></li>');
+      expect(html).toContain('<li>Stoke &amp; &lt;b&gt;Bramley&lt;/b&gt;</li>');
+    });
+
+    it('embeds a two-item BreadcrumbList in the schema.org JSON-LD, alongside the ItemList and Dataset', () => {
+      const html = renderPlanningPage(pageData());
+      expect(html).toContain('"@type":"BreadcrumbList"');
+      const ld = html.match(
+        /<script type="application\/ld\+json">([\s\S]*?)<\/script>/,
+      );
+      expect(ld).not.toBeNull();
+      const [, json] = ld;
+      const parsed = JSON.parse(json);
+      const breadcrumb = parsed.find((entry) => entry['@type'] === 'BreadcrumbList');
+      expect(breadcrumb).toBeDefined();
+      expect(breadcrumb.itemListElement).toEqual([
+        {
+          '@type': 'ListItem',
+          position: 1,
+          name: 'Town Crier',
+          item: `${SITE_ORIGIN}/`,
+        },
+        {
+          '@type': 'ListItem',
+          position: 2,
+          name: 'Basingstoke and Deane',
+          item: `${SITE_ORIGIN}/planning/basingstoke-and-deane`,
+        },
+      ]);
+    });
+  });
+
   it('renders each application address as the headline and status label', () => {
     const html = renderPlanningPage(pageData());
     expect(html).toContain(

--- a/web/scripts/lib/render-page.mjs
+++ b/web/scripts/lib/render-page.mjs
@@ -99,8 +99,18 @@ function buildJsonLd(data, canonical) {
     license:
       'https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/',
   };
+  // An authority page has no parent above it (unlike a town page, which climbs
+  // Home -> Authority -> Town), so this trail is two levels: Home -> Authority.
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Town Crier', item: `${SITE_ORIGIN}/` },
+      { '@type': 'ListItem', position: 2, name: data.areaName, item: canonical },
+    ],
+  };
   // Escape "<" so a malicious data value can never close the <script> element.
-  return JSON.stringify([itemList, dataset]).replace(/</g, '\\u003c');
+  return JSON.stringify([itemList, dataset, breadcrumb]).replace(/</g, '\\u003c');
 }
 
 /**
@@ -155,6 +165,12 @@ ${pageStyles()}
           <a class="siteHeader__cta" href="${appStoreUrl('seo-lpa')}" rel="noopener" target="_blank">Get the app</a>
         </nav>
       </header>
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <ol>
+          <li><a href="/">Town Crier</a></li>
+          <li>${area}</li>
+        </ol>
+      </nav>
       <main>
         <h1>Planning applications in ${area}</h1>
         ${dataUpdated}


### PR DESCRIPTION
## Changes
- Authority pages gain the same breadcrumb pattern town pages already have (Home → Authority): visible `<nav class="breadcrumb">` + JSON-LD BreadcrumbList, reusing the existing shared CSS.
- Investigated why the Croydon authority page shows zero town links. Root cause: not a regression or ordering bug (the town-render pass already runs before the authority pass) — it's the existing same-name-authority dedup (tc-77ll) correctly suppressing a "Croydon" town page that would duplicate the "Croydon" authority page, combined with a genuine ONS Census 2021 Built-Up-Areas data limitation: Greater London boroughs are modelled as one borough-shaped area with no separate sub-borough entries (Purley, Coulsdon, etc.) to link to. Confirmed this affects 30 of 33 London boroughs by design, not a fixable bug — documented with a regression-pinning test rather than fabricating data Town Crier has no real source for.
- Side finding, filed separately as tc-hch1 (not fixed here, out of scope): 3 boroughs (Westminster, Sutton, City of London) have display-name variants that narrowly evade the same-name dedup and incorrectly publish a duplicate town page.

Part of the design-review punch list (#794), Phase 4 of 7 — the final bead in the epic. Closes tc-r4n9.4.

## Test plan
- `npx tsc --noEmit` clean, `npm run build` clean, `npx vitest run` — 1009/1009 (full suite)
- Visual verification via agent-browser: Croydon (same-name-suppressed) and Cornwall/Truro (has town links) authority pages, plus the Truro town page for parity — light/dark, mobile (390x844) + desktop (1440x900). Breadcrumb renders correctly in all combos; town-links section correctly present/absent per case.

---
*Auto-shipped via ship skill*