### PR TITLE
feat(android): application browsing — list, sort/filter, paging, detail, saved, read state (tc-oibm)

### DIFF
--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -8,6 +8,10 @@ import okhttp3.Call
 import okhttp3.OkHttpClient
 import uk.towncrierapp.data.api.ApiClient
 import uk.towncrierapp.data.api.OkHttpTransport
+import uk.towncrierapp.data.applications.ApiNotificationStateRepository
+import uk.towncrierapp.data.applications.ApiPlanningApplicationRepository
+import uk.towncrierapp.data.applications.ApiSavedApplicationRepository
+import uk.towncrierapp.data.applications.InMemoryApplicationCacheStore
 import uk.towncrierapp.data.auth.Auth0AuthenticationService
 import uk.towncrierapp.data.auth.Auth0Config
 import uk.towncrierapp.data.auth.CredentialsStore
@@ -18,6 +22,12 @@ import uk.towncrierapp.data.versionconfig.ApiVersionConfigService
 import uk.towncrierapp.data.watchzones.ApiPostcodeGeocoder
 import uk.towncrierapp.data.watchzones.ApiWatchZoneRepository
 import uk.towncrierapp.data.watchzones.ApiZonePreferencesRepository
+import uk.towncrierapp.domain.applications.ApplicationCacheStore
+import uk.towncrierapp.domain.applications.ApplicationListPreferencesStore
+import uk.towncrierapp.domain.applications.NotificationStateRepository
+import uk.towncrierapp.domain.applications.OfflineAwareRepository
+import uk.towncrierapp.domain.applications.PlanningApplicationRepository
+import uk.towncrierapp.domain.applications.SavedApplicationRepository
 import uk.towncrierapp.domain.auth.AuthenticationService
 import uk.towncrierapp.domain.profile.UserProfileRepository
 import uk.towncrierapp.domain.subscriptions.SubscriptionTierCache
@@ -35,16 +45,17 @@ public data class Auth0Tenant(
 )
 
 /**
- * The three leaves that genuinely need a real `Context` —
+ * The four leaves that genuinely need a real `Context` —
  * `TownCrierApplication` builds them (`SecureCredentialsManagerStore` over a
  * real `SecureCredentialsManager`, an `Application.ActivityLifecycleCallbacks`
- * tracker, a `DataStoreSubscriptionTierCache`) and hands them to the
- * otherwise Context-free [AppGraph].
+ * tracker, a `DataStoreSubscriptionTierCache`, a `DataStoreApplicationListPreferencesStore`)
+ * and hands them to the otherwise Context-free [AppGraph].
  */
 public class AndroidLeaves(
     public val credentialsStore: CredentialsStore,
     public val activityProvider: CurrentActivityProvider,
     public val tierCache: SubscriptionTierCache,
+    public val applicationListPreferencesStore: ApplicationListPreferencesStore,
 )
 
 /** Rarely-overridden technical knobs, grouped so [AppGraph]'s own constructor stays short. */
@@ -112,4 +123,24 @@ public class AppGraph(
     public val zonePreferencesRepository: ZonePreferencesRepository = ApiZonePreferencesRepository(apiClient)
 
     public val postcodeGeocoder: PostcodeGeocoder = ApiPostcodeGeocoder(apiClient)
+
+    // The offline cache seam (GH#775 / tc-cnme): a single InMemoryApplicationCacheStore
+    // instance backs BOTH the OfflineAwareRepository decorator below AND the
+    // explicit invalidate(zoneId)/invalidateAll() hooks a watch-zone edit and
+    // a mark-all-read fire — same object, so an invalidation is always visible
+    // to the next applications() read.
+    public val applicationCacheStore: ApplicationCacheStore = InMemoryApplicationCacheStore()
+
+    public val planningApplicationRepository: PlanningApplicationRepository =
+        OfflineAwareRepository(
+            remote = ApiPlanningApplicationRepository(apiClient),
+            cache = applicationCacheStore,
+            clock = options.clock,
+        )
+
+    public val savedApplicationRepository: SavedApplicationRepository = ApiSavedApplicationRepository(apiClient)
+
+    public val notificationStateRepository: NotificationStateRepository = ApiNotificationStateRepository(apiClient)
+
+    public val applicationListPreferencesStore: ApplicationListPreferencesStore = androidLeaves.applicationListPreferencesStore
 }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -125,15 +125,33 @@ public class AppGraph(
     public val postcodeGeocoder: PostcodeGeocoder = ApiPostcodeGeocoder(apiClient)
 
     // The offline cache seam (GH#775 / tc-cnme): a single InMemoryApplicationCacheStore
-    // instance backs BOTH the OfflineAwareRepository decorator below AND the
-    // explicit invalidate(zoneId)/invalidateAll() hooks a watch-zone edit and
-    // a mark-all-read fire — same object, so an invalidation is always visible
-    // to the next applications() read.
+    // instance backs BOTH the (currently dormant — see offlineAwareApplicationRepository
+    // below) OfflineAwareRepository decorator AND the explicit
+    // invalidate(zoneId)/invalidateAll() hooks a watch-zone edit and a
+    // mark-all-read fire — same object, so an invalidation is always visible.
     public val applicationCacheStore: ApplicationCacheStore = InMemoryApplicationCacheStore()
 
+    // The interactive Applications tab/detail screen's every fetch — first
+    // page included — goes straight to the network, matching iOS parity: on
+    // iOS every current sort is server-driven, so ApplicationListViewModel's
+    // `fetchPage` always calls `offlineRepository.fetchApplicationsPage`
+    // (network-only) and the OfflineAwareRepository-cached
+    // `fetchApplications(for:)` path is DORMANT plumbing "kept generic
+    // should a future client-only sort ever be added" (iOS
+    // ApplicationListViewModel+Pagination.swift) — it is never reached in
+    // practice. Routing the interactive screen through the cache instead
+    // would silently freeze filter/sort changes for the 900s TTL, since the
+    // cache key is zone-only (verified live on-device, GH#775).
     public val planningApplicationRepository: PlanningApplicationRepository =
+        ApiPlanningApplicationRepository(apiClient)
+
+    // Built and available (mirrors iOS's own dormant `OfflineAwareRepository`
+    // — kept for a hypothetical future non-server-sorted mode) but not
+    // currently consumed by any ViewModel; see planningApplicationRepository's
+    // doc above.
+    public val offlineAwareApplicationRepository: OfflineAwareRepository =
         OfflineAwareRepository(
-            remote = ApiPlanningApplicationRepository(apiClient),
+            remote = planningApplicationRepository,
             cache = applicationCacheStore,
             clock = options.clock,
         )

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -142,5 +142,6 @@ public class AppGraph(
 
     public val notificationStateRepository: NotificationStateRepository = ApiNotificationStateRepository(apiClient)
 
-    public val applicationListPreferencesStore: ApplicationListPreferencesStore = androidLeaves.applicationListPreferencesStore
+    public val applicationListPreferencesStore: ApplicationListPreferencesStore =
+        androidLeaves.applicationListPreferencesStore
 }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/ApplicationNavGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/ApplicationNavGraph.kt
@@ -1,0 +1,161 @@
+package uk.towncrierapp.app
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavHostController
+import androidx.navigation.toRoute
+import kotlinx.serialization.Serializable
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.applications.LocalAuthority
+import uk.towncrierapp.domain.applications.PlanningApplication
+import uk.towncrierapp.domain.applications.PlanningApplicationId
+import uk.towncrierapp.domain.applications.StatusEvent
+import uk.towncrierapp.domain.applications.isDecided
+import uk.towncrierapp.domain.applications.wireValue
+import uk.towncrierapp.domain.watchzones.Coordinate
+import uk.towncrierapp.presentation.features.applicationdetail.ApplicationDetailRoute
+import uk.towncrierapp.presentation.features.applicationdetail.ApplicationDetailViewModel
+import uk.towncrierapp.presentation.features.applicationlist.ApplicationListRoute
+import uk.towncrierapp.presentation.features.applicationlist.ApplicationListViewModel
+import uk.towncrierapp.presentation.features.saved.SavedListRoute
+import uk.towncrierapp.presentation.features.saved.SavedListViewModel
+import java.time.LocalDate
+
+/**
+ * The application-detail destination: every field flattened to a primitive
+ * nav arg — type-safe Navigation routes only support serializable
+ * primitives, and the domain `PlanningApplication` deliberately isn't
+ * `@Serializable` (see android-coding-standards skill, data-access.md on
+ * domain/DTO separation; same pattern as `WatchZoneEditorDestination`). This
+ * is what makes stale-while-revalidate possible: the tapped row's full data
+ * travels with the navigation, so [ApplicationDetailViewModel] can render it
+ * before its background by-id refresh completes.
+ */
+@Serializable
+internal data class ApplicationDetailDestination(
+    val authority: String,
+    val name: String,
+    val authorityName: String,
+    val status: String,
+    val receivedDate: String,
+    val description: String,
+    val address: String,
+    val latitude: Double? = null,
+    val longitude: Double? = null,
+    val portalUrl: String? = null,
+    val decidedDate: String? = null,
+)
+
+internal fun applicationDetailDestinationFor(application: PlanningApplication): ApplicationDetailDestination =
+    ApplicationDetailDestination(
+        authority = application.id.authority,
+        name = application.id.name,
+        authorityName = application.authority.name,
+        status = application.status.wireValue,
+        receivedDate = application.receivedDate.toString(),
+        description = application.description,
+        address = application.address,
+        latitude = application.location?.latitude,
+        longitude = application.location?.longitude,
+        portalUrl = application.portalUrl,
+        // At most 2 statusHistory points by construction (GH#775): index 0 is
+        // always the Undecided/submitted event, index 1 (if present) is the
+        // decided one.
+        decidedDate = application.statusHistory.getOrNull(1)?.date?.toString(),
+    )
+
+private fun ApplicationDetailDestination.toInitialApplication(): PlanningApplication {
+    val resolvedStatus = ApplicationStatus.fromWireValue(status)
+    val received = LocalDate.parse(receivedDate)
+    val history =
+        buildList {
+            add(StatusEvent(ApplicationStatus.Undecided, received))
+            if (resolvedStatus.isDecided) {
+                decidedDate?.let { add(StatusEvent(resolvedStatus, LocalDate.parse(it))) }
+            }
+        }
+    return PlanningApplication(
+        id = PlanningApplicationId(authority, name),
+        reference = name,
+        authority = LocalAuthority(code = authority, name = authorityName),
+        status = resolvedStatus,
+        receivedDate = received,
+        description = description,
+        address = address,
+        location = if (latitude != null && longitude != null) Coordinate(latitude, longitude) else null,
+        portalUrl = portalUrl,
+        statusHistory = history,
+    )
+}
+
+/** The Applications tab (GH#775) — first bottom-nav destination, replacing the #771 Home placeholder. */
+@Composable
+internal fun ApplicationsTab(
+    appGraph: AppGraph,
+    navController: NavHostController,
+) {
+    val listViewModel: ApplicationListViewModel =
+        viewModel(
+            factory =
+                viewModelFactory {
+                    initializer {
+                        ApplicationListViewModel(
+                            appGraph.planningApplicationRepository,
+                            appGraph.watchZoneRepository,
+                            appGraph.notificationStateRepository,
+                            appGraph.applicationCacheStore,
+                            appGraph.applicationListPreferencesStore,
+                        )
+                    }
+                },
+        )
+    LaunchedEffect(listViewModel) { listViewModel.load() }
+    ApplicationListRoute(
+        viewModel = listViewModel,
+        onApplicationSelected = { application -> navController.navigate(applicationDetailDestinationFor(application)) },
+        onAddZoneClick = { navController.navigate(WatchZoneEditorDestination()) },
+    )
+}
+
+/** The Saved tab (GH#775). */
+@Composable
+internal fun SavedTab(
+    appGraph: AppGraph,
+    navController: NavHostController,
+) {
+    val savedViewModel: SavedListViewModel =
+        viewModel(factory = viewModelFactory { initializer { SavedListViewModel(appGraph.savedApplicationRepository) } })
+    LaunchedEffect(savedViewModel) { savedViewModel.load() }
+    SavedListRoute(
+        viewModel = savedViewModel,
+        onApplicationSelected = { application -> navController.navigate(applicationDetailDestinationFor(application)) },
+    )
+}
+
+/** Application detail — a full navigation destination reachable from any tab (GH#775 pre-resolved decision: not a bottom sheet). */
+@Composable
+internal fun ApplicationDetailDestinationContent(
+    entry: NavBackStackEntry,
+    appGraph: AppGraph,
+    navController: NavHostController,
+) {
+    val route = entry.toRoute<ApplicationDetailDestination>()
+    val detailViewModel: ApplicationDetailViewModel =
+        viewModel(
+            factory =
+                viewModelFactory {
+                    initializer {
+                        ApplicationDetailViewModel(
+                            appGraph.planningApplicationRepository,
+                            appGraph.savedApplicationRepository,
+                            route.toInitialApplication(),
+                        )
+                    }
+                },
+        )
+    ApplicationDetailRoute(viewModel = detailViewModel, onBack = navController::popBackStack)
+}

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/ApplicationNavGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/ApplicationNavGraph.kt
@@ -1,3 +1,10 @@
+// ApplicationNavGraph.kt is the bead-mandated file name for every
+// applications-browsing nav destination + composable (mirrors
+// WatchZoneNavGraph.kt) — ApplicationDetailDestination below is only ONE of
+// several top-level declarations this file thematically groups, not its sole
+// declaration in spirit.
+@file:Suppress("MatchingDeclarationName")
+
 package uk.towncrierapp.app
 
 import androidx.compose.runtime.Composable

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/ApplicationNavGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/ApplicationNavGraph.kt
@@ -65,7 +65,11 @@ internal fun applicationDetailDestinationFor(application: PlanningApplication): 
         // At most 2 statusHistory points by construction (GH#775): index 0 is
         // always the Undecided/submitted event, index 1 (if present) is the
         // decided one.
-        decidedDate = application.statusHistory.getOrNull(1)?.date?.toString(),
+        decidedDate =
+            application.statusHistory
+                .getOrNull(1)
+                ?.date
+                ?.toString(),
     )
 
 private fun ApplicationDetailDestination.toInitialApplication(): PlanningApplication {
@@ -128,7 +132,9 @@ internal fun SavedTab(
     navController: NavHostController,
 ) {
     val savedViewModel: SavedListViewModel =
-        viewModel(factory = viewModelFactory { initializer { SavedListViewModel(appGraph.savedApplicationRepository) } })
+        viewModel(
+            factory = viewModelFactory { initializer { SavedListViewModel(appGraph.savedApplicationRepository) } },
+        )
     LaunchedEffect(savedViewModel) { savedViewModel.load() }
     SavedListRoute(
         viewModel = savedViewModel,

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
@@ -6,12 +6,12 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -22,7 +22,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -36,7 +35,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import kotlinx.serialization.Serializable
-import uk.towncrierapp.mobile.R
 import uk.towncrierapp.presentation.designsystem.TownCrierTheme
 import uk.towncrierapp.presentation.features.forceupdate.ForceUpdateScreen
 import uk.towncrierapp.presentation.features.forceupdate.ForceUpdateViewModel
@@ -59,20 +57,28 @@ public class MainActivity : ComponentActivity() {
     }
 }
 
-/** The placeholder destination from #771 — a real Home/dashboard lands in a later phase of epic #770. */
+/**
+ * The Applications tab (GH#775) — first bottom-nav destination, replacing the
+ * #771 Home placeholder now that there's a real daily-use surface to land on.
+ */
 @Serializable
-internal data object Home
+internal data object Applications
 
-/** The watch-zones tab (tc-z95t) — 2nd bottom-nav destination alongside [Home]; more tabs land with #775/#776. */
+/** The watch-zones tab (tc-z95t) — 2nd bottom-nav destination. */
 @Serializable
 internal data object WatchZones
+
+/** The Saved tab (GH#775) — 3rd bottom-nav destination. */
+@Serializable
+internal data object Saved
 
 // A no-arg `@Serializable data object` route's KSerializer serialName is its
 // fully qualified class name — comparing against it is a simpler, equally
 // reliable way to tell "is this bottom-nav tab currently selected" than the
 // generic `NavDestination.hasRoute<T>()` extension.
-private val HOME_ROUTE = Home::class.qualifiedName
+private val APPLICATIONS_ROUTE = Applications::class.qualifiedName
 private val WATCH_ZONES_ROUTE = WatchZones::class.qualifiedName
+private val SAVED_ROUTE = Saved::class.qualifiedName
 
 /**
  * Root routing: pre-login force-update gate, then Login or the authed
@@ -128,9 +134,11 @@ public fun TownCrierApp(
 }
 
 /**
- * The signed-in shell: bottom navigation (Home, Zones) wrapping the NavHost.
- * The watch-zone destinations' content lives in `WatchZoneNavGraph.kt` to
- * keep both files under detekt's per-file function-count budget.
+ * The signed-in shell: bottom navigation (Applications, Zones, Saved)
+ * wrapping the NavHost. The watch-zone destinations' content lives in
+ * `WatchZoneNavGraph.kt`, and the applications-browsing destinations' in
+ * `ApplicationNavGraph.kt`, to keep every file under detekt's per-file
+ * function-count budget.
  */
 @Composable
 private fun AuthedShell(
@@ -149,13 +157,14 @@ private fun AuthedShell(
     ) { contentPadding ->
         NavHost(
             navController = navController,
-            startDestination = Home,
+            startDestination = Applications,
             modifier = Modifier.padding(contentPadding),
         ) {
-            composable<Home> { HomeRoute() }
+            composable<Applications> { ApplicationsTab(appGraph = appGraph, navController = navController) }
             composable<WatchZones> {
                 WatchZonesTab(appGraph = appGraph, subscriptionTier = subscriptionTier, navController = navController)
             }
+            composable<Saved> { SavedTab(appGraph = appGraph, navController = navController) }
             composable<WatchZoneEditorDestination> { entry ->
                 WatchZoneEditorDestinationContent(
                     entry = entry,
@@ -172,6 +181,9 @@ private fun AuthedShell(
                     navController = navController,
                 )
             }
+            composable<ApplicationDetailDestination> { entry ->
+                ApplicationDetailDestinationContent(entry = entry, appGraph = appGraph, navController = navController)
+            }
         }
     }
 }
@@ -183,16 +195,22 @@ private fun AuthedBottomBar(
 ) {
     NavigationBar {
         NavigationBarItem(
-            selected = currentRoute == HOME_ROUTE,
-            onClick = { navController.navigateToTab(Home) },
-            icon = { Icon(imageVector = Icons.Filled.Home, contentDescription = null) },
-            label = { Text(stringResource(PresentationR.string.bottom_nav_home)) },
+            selected = currentRoute == APPLICATIONS_ROUTE,
+            onClick = { navController.navigateToTab(Applications) },
+            icon = { Icon(imageVector = Icons.AutoMirrored.Filled.List, contentDescription = null) },
+            label = { Text(stringResource(PresentationR.string.bottom_nav_applications)) },
         )
         NavigationBarItem(
             selected = currentRoute == WATCH_ZONES_ROUTE,
             onClick = { navController.navigateToTab(WatchZones) },
             icon = { Icon(imageVector = Icons.Filled.Place, contentDescription = null) },
             label = { Text(stringResource(PresentationR.string.bottom_nav_zones)) },
+        )
+        NavigationBarItem(
+            selected = currentRoute == SAVED_ROUTE,
+            onClick = { navController.navigateToTab(Saved) },
+            icon = { Icon(imageVector = Icons.Filled.Star, contentDescription = null) },
+            label = { Text(stringResource(PresentationR.string.bottom_nav_saved)) },
         )
     }
 }
@@ -203,21 +221,5 @@ internal fun NavHostController.navigateToTab(route: Any) {
         popUpTo(graph.startDestinationId) { saveState = true }
         launchSingleTop = true
         restoreState = true
-    }
-}
-
-@Composable
-private fun HomeRoute(modifier: Modifier = Modifier) {
-    HomeScreen(modifier = modifier)
-}
-
-@Composable
-internal fun HomeScreen(modifier: Modifier = Modifier) {
-    Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Text(
-            text = stringResource(R.string.app_name),
-            style = MaterialTheme.typography.headlineLarge,
-            color = MaterialTheme.colorScheme.onBackground,
-        )
     }
 }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.auth0.android.Auth0
 import com.auth0.android.authentication.storage.SecureCredentialsManager
 import com.auth0.android.authentication.storage.SharedPreferencesStorage
+import uk.towncrierapp.data.applications.DataStoreApplicationListPreferencesStore
 import uk.towncrierapp.data.auth.SecureCredentialsManagerStore
 import uk.towncrierapp.data.subscriptions.DataStoreSubscriptionTierCache
 import uk.towncrierapp.mobile.BuildConfig
@@ -42,13 +43,17 @@ public class TownCrierApplication : Application() {
         val credentialsStore = SecureCredentialsManagerStore(credentialsManager)
 
         val tierCache = DataStoreSubscriptionTierCache(tierPreferencesDataStore)
+        // Same shared "town_crier_preferences" DataStore file as tierCache —
+        // DataStore Preferences is designed for several unrelated keys in one
+        // file; a second file per feature isn't warranted (GH#775).
+        val applicationListPreferencesStore = DataStoreApplicationListPreferencesStore(tierPreferencesDataStore)
 
         appGraph =
             AppGraph(
                 baseUrl = BuildConfig.API_BASE_URL,
                 authAudience = BuildConfig.AUTH0_AUDIENCE,
                 auth0Tenant = Auth0Tenant(clientId = AUTH0_CLIENT_ID, domain = AUTH0_DOMAIN),
-                androidLeaves = AndroidLeaves(credentialsStore, activityTracker, tierCache),
+                androidLeaves = AndroidLeaves(credentialsStore, activityTracker, tierCache, applicationListPreferencesStore),
                 currentVersion = BuildConfig.VERSION_NAME,
                 options = AppGraphOptions(enableDebugLogging = BuildConfig.DEBUG),
             )

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
@@ -53,7 +53,13 @@ public class TownCrierApplication : Application() {
                 baseUrl = BuildConfig.API_BASE_URL,
                 authAudience = BuildConfig.AUTH0_AUDIENCE,
                 auth0Tenant = Auth0Tenant(clientId = AUTH0_CLIENT_ID, domain = AUTH0_DOMAIN),
-                androidLeaves = AndroidLeaves(credentialsStore, activityTracker, tierCache, applicationListPreferencesStore),
+                androidLeaves =
+                    AndroidLeaves(
+                        credentialsStore,
+                        activityTracker,
+                        tierCache,
+                        applicationListPreferencesStore,
+                    ),
                 currentVersion = BuildConfig.VERSION_NAME,
                 options = AppGraphOptions(enableDebugLogging = BuildConfig.DEBUG),
             )

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/WatchZoneNavGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/WatchZoneNavGraph.kt
@@ -130,6 +130,10 @@ internal fun WatchZoneEditorDestinationContent(
                             appGraph.watchZoneRepository,
                             subscriptionTier,
                             editingZone,
+                            // Closes the #774/#775 cache-invalidation loop (tc-cnme):
+                            // a successful edit-save invalidates this zone's
+                            // applications cache entry.
+                            appGraph.applicationCacheStore,
                         )
                     }
                 },

--- a/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
+++ b/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
@@ -5,6 +5,7 @@ import okhttp3.Call
 import org.junit.jupiter.api.Test
 import uk.towncrierapp.data.auth.CredentialsStore
 import uk.towncrierapp.data.auth.CurrentActivityProvider
+import uk.towncrierapp.domain.applications.FakeApplicationListPreferencesStore
 import uk.towncrierapp.domain.subscriptions.FakeSubscriptionTierCache
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -42,6 +43,7 @@ class AppGraphSmokeTest {
                         credentialsStore = NoOpCredentialsStore,
                         activityProvider = CurrentActivityProvider { null },
                         tierCache = FakeSubscriptionTierCache(),
+                        applicationListPreferencesStore = FakeApplicationListPreferencesStore(),
                     ),
                 currentVersion = "0.1.0",
                 options = AppGraphOptions(callFactory = noOpCallFactory),
@@ -55,6 +57,11 @@ class AppGraphSmokeTest {
         assertNotNull(graph.watchZoneRepository)
         assertNotNull(graph.zonePreferencesRepository)
         assertNotNull(graph.postcodeGeocoder)
+        assertNotNull(graph.applicationCacheStore)
+        assertNotNull(graph.planningApplicationRepository)
+        assertNotNull(graph.savedApplicationRepository)
+        assertNotNull(graph.notificationStateRepository)
+        assertNotNull(graph.applicationListPreferencesStore)
     }
 
     @Test
@@ -68,6 +75,7 @@ class AppGraphSmokeTest {
                         credentialsStore = NoOpCredentialsStore,
                         activityProvider = CurrentActivityProvider { null },
                         tierCache = FakeSubscriptionTierCache(),
+                        applicationListPreferencesStore = FakeApplicationListPreferencesStore(),
                     ),
                 currentVersion = "0.1.0",
                 options = AppGraphOptions(callFactory = noOpCallFactory),
@@ -88,6 +96,7 @@ class AppGraphSmokeTest {
                         credentialsStore = NoOpCredentialsStore,
                         activityProvider = CurrentActivityProvider { null },
                         tierCache = FakeSubscriptionTierCache(),
+                        applicationListPreferencesStore = FakeApplicationListPreferencesStore(),
                     ),
                 currentVersion = "0.1.0",
                 options = AppGraphOptions(callFactory = noOpCallFactory),

--- a/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
+++ b/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
@@ -59,6 +59,7 @@ class AppGraphSmokeTest {
         assertNotNull(graph.postcodeGeocoder)
         assertNotNull(graph.applicationCacheStore)
         assertNotNull(graph.planningApplicationRepository)
+        assertNotNull(graph.offlineAwareApplicationRepository)
         assertNotNull(graph.savedApplicationRepository)
         assertNotNull(graph.notificationStateRepository)
         assertNotNull(graph.applicationListPreferencesStore)

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/ApiClient.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/api/ApiClient.kt
@@ -198,7 +198,14 @@ private fun buildRequest(
         .trim('/')
         .split("/")
         .filter { it.isNotEmpty() }
-        .forEach { urlBuilder.addPathSegment(it) }
+        // addEncodedPathSegment (not addPathSegment): a caller that has
+        // pre-percent-encoded a literal "/" it needs preserved WITHIN one
+        // segment (e.g. ApiSavedApplicationRepository's "%2F"-escaped id)
+        // would otherwise have that escape's "%" itself re-encoded to "%25"
+        // (double-encoding it into mush). Every OTHER unsafe character still
+        // gets encoded either way, so existing callers passing plain,
+        // unencoded segments (UUIDs, postcodes with a space) are unaffected.
+        .forEach { urlBuilder.addEncodedPathSegment(it) }
     endpoint.query.forEach { (name, value) -> urlBuilder.addQueryParameter(name, value) }
 
     val builder =

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/ApiNotificationStateRepository.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/ApiNotificationStateRepository.kt
@@ -1,0 +1,74 @@
+package uk.towncrierapp.data.applications
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import uk.towncrierapp.data.api.ApiClient
+import uk.towncrierapp.data.api.ApiEndpoint
+import uk.towncrierapp.data.api.DotNetTimeParser
+import uk.towncrierapp.domain.applications.NotificationState
+import uk.towncrierapp.domain.applications.NotificationStateRepository
+import uk.towncrierapp.domain.applications.PlanningApplicationId
+
+/**
+ * `NotificationStateRepository` over the Town Crier API (ADR 0035). ⚠️
+ * [MarkReadItemDto.applicationUid] carries [PlanningApplicationId.name] (the
+ * case reference), NOT the uid — a wire misnomer ported as-is, never "fixed"
+ * (GH#775). [markRead] batches at [MARK_READ_BATCH_SIZE] ids per request. The
+ * legacy `/advance` endpoint is deliberately not implemented.
+ */
+public class ApiNotificationStateRepository(
+    private val apiClient: ApiClient,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) : NotificationStateRepository {
+    override suspend fun state(): NotificationState =
+        apiClient.request(ApiEndpoint.get("/v1/me/notification-state"), NotificationStateDto.serializer()).toDomain()
+
+    override suspend fun markRead(ids: List<PlanningApplicationId>) {
+        ids.chunked(MARK_READ_BATCH_SIZE).forEach { batch ->
+            val body =
+                json.encodeToString(
+                    MarkReadRequestDto.serializer(),
+                    MarkReadRequestDto(batch.map { MarkReadItemDto(applicationUid = it.name, authorityId = it.authority.toInt()) }),
+                )
+            apiClient.requestBytes(ApiEndpoint.post("/v1/me/applications/mark-read", body = body))
+        }
+    }
+
+    override suspend fun markAllRead() {
+        apiClient.requestBytes(ApiEndpoint.post("/v1/me/notification-state/mark-all-read"))
+    }
+
+    public companion object {
+        public const val MARK_READ_BATCH_SIZE: Int = 500
+    }
+}
+
+// MARK: - DTOs
+
+@Serializable
+internal data class NotificationStateDto(
+    val lastReadAt: String? = null,
+    val version: Int,
+    val totalUnreadCount: Int,
+)
+
+internal fun NotificationStateDto.toDomain(): NotificationState =
+    NotificationState(
+        lastReadAt = lastReadAt?.let(DotNetTimeParser::parse),
+        version = version,
+        totalUnreadCount = totalUnreadCount,
+    )
+
+// The `applicationUid` key literally holds the case NAME, not a uid — an
+// intentional, ported-as-is server misnomer (GH#775). Do not rename this to
+// match its actual content; the wire contract is the wire contract.
+@Serializable
+internal data class MarkReadItemDto(
+    val applicationUid: String,
+    val authorityId: Int,
+)
+
+@Serializable
+internal data class MarkReadRequestDto(
+    val applications: List<MarkReadItemDto>,
+)

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/ApiNotificationStateRepository.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/ApiNotificationStateRepository.kt
@@ -28,7 +28,9 @@ public class ApiNotificationStateRepository(
             val body =
                 json.encodeToString(
                     MarkReadRequestDto.serializer(),
-                    MarkReadRequestDto(batch.map { MarkReadItemDto(applicationUid = it.name, authorityId = it.authority.toInt()) }),
+                    MarkReadRequestDto(
+                        batch.map { MarkReadItemDto(applicationUid = it.name, authorityId = it.authority.toInt()) },
+                    ),
                 )
             apiClient.requestBytes(ApiEndpoint.post("/v1/me/applications/mark-read", body = body))
         }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepository.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepository.kt
@@ -1,0 +1,204 @@
+package uk.towncrierapp.data.applications
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import uk.towncrierapp.data.api.ApiClient
+import uk.towncrierapp.data.api.ApiEndpoint
+import uk.towncrierapp.data.api.DotNetTimeParser
+import uk.towncrierapp.domain.applications.ApplicationFilter
+import uk.towncrierapp.domain.applications.ApplicationPage
+import uk.towncrierapp.domain.applications.ApplicationSortOrder
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.applications.LatestUnreadEvent
+import uk.towncrierapp.domain.applications.LocalAuthority
+import uk.towncrierapp.domain.applications.PlanningApplication
+import uk.towncrierapp.domain.applications.PlanningApplicationId
+import uk.towncrierapp.domain.applications.PlanningApplicationRepository
+import uk.towncrierapp.domain.applications.StatusEvent
+import uk.towncrierapp.domain.applications.isDecided
+import uk.towncrierapp.domain.applications.wireValue
+import uk.towncrierapp.domain.watchzones.Coordinate
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import java.time.LocalDate
+
+/**
+ * `PlanningApplicationRepository` over the Town Crier API. Always sends
+ * `sort` (epic #770: Android never exercises the legacy param-less path) and
+ * `limit=`[PAGE_SIZE]; `status`/`unread` are mutually exclusive by
+ * [ApplicationFilter]'s shape, not a runtime check. Continuation is the
+ * opaque `X-Next-Cursor` response header via [ApiClient.requestPaged]. Port
+ * of iOS `APIApplicationRepository` (GH#775).
+ */
+public class ApiPlanningApplicationRepository(
+    private val apiClient: ApiClient,
+) : PlanningApplicationRepository {
+    override suspend fun applications(
+        zoneId: WatchZoneId,
+        sort: ApplicationSortOrder,
+        filter: ApplicationFilter,
+        cursor: String?,
+    ): ApplicationPage {
+        val query =
+            buildList {
+                add("sort" to sort.wireValue)
+                add("limit" to PAGE_SIZE.toString())
+                when (filter) {
+                    ApplicationFilter.All -> Unit
+                    is ApplicationFilter.Status -> add("status" to filter.status.wireValue)
+                    ApplicationFilter.Unread -> add("unread" to "true")
+                }
+                cursor?.let { add("cursor" to it) }
+            }
+        val result =
+            apiClient.requestPaged(
+                ApiEndpoint.get("/v1/me/watch-zones/${zoneId.value}/applications", query = query),
+                ListSerializer(PlanningApplicationRowDto.serializer()),
+            )
+        return ApplicationPage(result.value.map { it.toDomain() }, result.nextCursor)
+    }
+
+    override suspend fun detail(
+        authority: String,
+        name: String,
+    ): PlanningApplication =
+        apiClient
+            .request(ApiEndpoint.get("/v1/applications/$authority/$name"), ApplicationDetailDto.serializer())
+            .toDomain()
+
+    public companion object {
+        public const val PAGE_SIZE: Int = 150
+    }
+}
+
+// MARK: - DTOs
+
+@Serializable
+internal data class LatestUnreadEventDto(
+    val type: String,
+    val decision: String? = null,
+    val createdAt: String,
+)
+
+@Serializable
+internal data class PlanningApplicationRowDto(
+    val name: String,
+    val uid: String,
+    val areaName: String,
+    val areaId: Int,
+    val address: String,
+    val postcode: String? = null,
+    val description: String,
+    val appType: String? = null,
+    val appState: String? = null,
+    val appSize: String? = null,
+    val startDate: String? = null,
+    val decidedDate: String? = null,
+    val longitude: Double? = null,
+    val latitude: Double? = null,
+    val url: String? = null,
+    val link: String? = null,
+    val lastDifferent: String,
+    val latestUnreadEvent: LatestUnreadEventDto? = null,
+)
+
+@Serializable
+internal data class ApplicationDetailDto(
+    val name: String,
+    val uid: String,
+    val areaName: String,
+    val areaId: Int,
+    val address: String,
+    val postcode: String? = null,
+    val description: String,
+    val appType: String? = null,
+    val appState: String? = null,
+    val appSize: String? = null,
+    val startDate: String? = null,
+    val decidedDate: String? = null,
+    val longitude: Double? = null,
+    val latitude: Double? = null,
+    val url: String? = null,
+    val link: String? = null,
+    val lastDifferent: String,
+    val latestUnreadEvent: LatestUnreadEventDto? = null,
+    val authoritySlug: String? = null,
+    val areaType: String? = null,
+)
+
+internal fun PlanningApplicationRowDto.toDomain(): PlanningApplication {
+    val status = resolveStatus(appState)
+    return PlanningApplication(
+        id = PlanningApplicationId(authority = areaId.toString(), name = name),
+        reference = name,
+        authority = LocalAuthority(code = areaId.toString(), name = areaName),
+        status = status,
+        receivedDate = resolveReceivedDate(startDate, lastDifferent),
+        description = description,
+        address = address,
+        location = resolveLocation(latitude, longitude),
+        // "link" (the external council-portal URL) takes priority over "url"
+        // (PlanIt's own page) — the "View on Council Portal" action wants the
+        // former (GH#775).
+        portalUrl = link ?: url,
+        statusHistory = synthesizeStatusHistory(status, startDate, decidedDate),
+        latestUnreadEvent = latestUnreadEvent?.toDomain(),
+    )
+}
+
+internal fun ApplicationDetailDto.toDomain(): PlanningApplication {
+    val status = resolveStatus(appState)
+    return PlanningApplication(
+        id = PlanningApplicationId(authority = areaId.toString(), name = name),
+        reference = name,
+        authority = LocalAuthority(code = areaId.toString(), name = areaName, areaType = areaType, slug = authoritySlug),
+        status = status,
+        receivedDate = resolveReceivedDate(startDate, lastDifferent),
+        description = description,
+        address = address,
+        location = resolveLocation(latitude, longitude),
+        portalUrl = link ?: url,
+        statusHistory = synthesizeStatusHistory(status, startDate, decidedDate),
+        latestUnreadEvent = latestUnreadEvent?.toDomain(),
+    )
+}
+
+// A missing/unparseable createdAt drops just the unread indicator, not the
+// whole row — a stale or malformed event server-side shouldn't hide an
+// otherwise-good application (GH#775).
+internal fun LatestUnreadEventDto.toDomain(): LatestUnreadEvent? =
+    DotNetTimeParser.parse(createdAt)?.let { LatestUnreadEvent(type = type, decision = decision, createdAt = it) }
+
+// An absent appState is wire-legitimate (optional field) — treated the same
+// as any other unrecognised raw value: Unknown, never a crash.
+private fun resolveStatus(appState: String?): ApplicationStatus = appState?.let(ApplicationStatus::fromWireValue) ?: ApplicationStatus.Unknown("")
+
+// startDate is the primary source; lastDifferent (always present) is the
+// fallback for the rare row missing it — receivedDate is non-nullable
+// domain-side and must resolve to SOMETHING (GH#775).
+private fun resolveReceivedDate(
+    startDate: String?,
+    lastDifferent: String,
+): LocalDate =
+    startDate?.let(DotNetTimeParser::parseDate)
+        ?: DotNetTimeParser.parse(lastDifferent)?.toLocalDate()
+        ?: LocalDate.EPOCH
+
+private fun resolveLocation(
+    latitude: Double?,
+    longitude: Double?,
+): Coordinate? = if (latitude != null && longitude != null) Coordinate(latitude, longitude) else null
+
+// Max two points: startDate -> Undecided, decidedDate -> the actual decided
+// status, but ONLY when that status really is decided — a decidedDate on a
+// still-Unresolved/Referred/etc. row is folded away (GH#775).
+private fun synthesizeStatusHistory(
+    status: ApplicationStatus,
+    startDate: String?,
+    decidedDate: String?,
+): List<StatusEvent> =
+    buildList {
+        startDate?.let(DotNetTimeParser::parseDate)?.let { add(StatusEvent(ApplicationStatus.Undecided, it)) }
+        if (status.isDecided) {
+            decidedDate?.let(DotNetTimeParser::parseDate)?.let { add(StatusEvent(status, it)) }
+        }
+    }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepository.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepository.kt
@@ -150,7 +150,13 @@ internal fun ApplicationDetailDto.toDomain(): PlanningApplication {
     return PlanningApplication(
         id = PlanningApplicationId(authority = areaId.toString(), name = name),
         reference = name,
-        authority = LocalAuthority(code = areaId.toString(), name = areaName, areaType = areaType, slug = authoritySlug),
+        authority =
+            LocalAuthority(
+                code = areaId.toString(),
+                name = areaName,
+                areaType = areaType,
+                slug = authoritySlug,
+            ),
         status = status,
         receivedDate = resolveReceivedDate(startDate, lastDifferent),
         description = description,
@@ -170,7 +176,8 @@ internal fun LatestUnreadEventDto.toDomain(): LatestUnreadEvent? =
 
 // An absent appState is wire-legitimate (optional field) — treated the same
 // as any other unrecognised raw value: Unknown, never a crash.
-private fun resolveStatus(appState: String?): ApplicationStatus = appState?.let(ApplicationStatus::fromWireValue) ?: ApplicationStatus.Unknown("")
+private fun resolveStatus(appState: String?): ApplicationStatus =
+    appState?.let(ApplicationStatus::fromWireValue) ?: ApplicationStatus.Unknown("")
 
 // startDate is the primary source; lastDifferent (always present) is the
 // fallback for the rare row missing it — receivedDate is non-nullable

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/ApiSavedApplicationRepository.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/ApiSavedApplicationRepository.kt
@@ -1,0 +1,52 @@
+package uk.towncrierapp.data.applications
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.ListSerializer
+import uk.towncrierapp.data.api.ApiClient
+import uk.towncrierapp.data.api.ApiEndpoint
+import uk.towncrierapp.data.api.DotNetTimeParser
+import uk.towncrierapp.domain.applications.PlanningApplicationId
+import uk.towncrierapp.domain.applications.SavedApplication
+import uk.towncrierapp.domain.applications.SavedApplicationRepository
+
+/**
+ * `SavedApplicationRepository` over the Town Crier API: a flat, cross-zone
+ * list, plus save/unsave keyed by [PlanningApplicationId.value] with its
+ * slash(es) percent-encoded so the reconstructed id stays a SINGLE path
+ * segment on the wire (the case reference itself routinely contains further
+ * slashes, e.g. `"24/0001"`). Port of iOS `APISavedApplicationRepository`
+ * (GH#775).
+ */
+public class ApiSavedApplicationRepository(
+    private val apiClient: ApiClient,
+) : SavedApplicationRepository {
+    override suspend fun savedApplications(): List<SavedApplication> =
+        apiClient
+            .request(ApiEndpoint.get("/v1/me/saved-applications"), ListSerializer(SavedApplicationDto.serializer()))
+            .map { it.toDomain() }
+
+    override suspend fun save(id: PlanningApplicationId) {
+        apiClient.requestBytes(ApiEndpoint.put("/v1/me/saved-applications/${id.encodedPathSegment()}"))
+    }
+
+    override suspend fun unsave(id: PlanningApplicationId) {
+        apiClient.requestBytes(ApiEndpoint.delete("/v1/me/saved-applications/${id.encodedPathSegment()}"))
+    }
+}
+
+/** Percent-encodes every `/` in [PlanningApplicationId.value] so it survives [ApiClient]'s path-segment building as ONE segment. */
+private fun PlanningApplicationId.encodedPathSegment(): String = value.replace("/", "%2F")
+
+@Serializable
+internal data class SavedApplicationDto(
+    val applicationUid: String,
+    val savedAt: String,
+    val application: PlanningApplicationRowDto? = null,
+)
+
+internal fun SavedApplicationDto.toDomain(): SavedApplication =
+    SavedApplication(
+        applicationUid = PlanningApplicationId.parse(applicationUid),
+        savedAt = requireNotNull(DotNetTimeParser.parse(savedAt)) { "unparseable savedAt: $savedAt" },
+        application = application?.toDomain(),
+    )

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/DataStoreApplicationListPreferencesStore.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/DataStoreApplicationListPreferencesStore.kt
@@ -1,0 +1,40 @@
+package uk.towncrierapp.data.applications
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import uk.towncrierapp.domain.applications.ApplicationListPreferencesStore
+import uk.towncrierapp.domain.applications.ApplicationSortOrder
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+
+// Key names reused verbatim from iOS UserDefaults (epic #770 pre-resolved
+// decision) — cross-platform naming consistency, even though nothing else
+// reads these keys cross-platform.
+private val APPLICATIONS_LIST_SORT_KEY = stringPreferencesKey("applicationsListSort")
+private val LAST_SELECTED_ZONE_KEY = stringPreferencesKey("lastSelectedZone.applications")
+
+/** DataStore Preferences-backed [ApplicationListPreferencesStore]. Port of iOS's `UserDefaults`-backed equivalent (GH#775). */
+public class DataStoreApplicationListPreferencesStore(
+    private val dataStore: DataStore<Preferences>,
+) : ApplicationListPreferencesStore {
+    override suspend fun readSort(): ApplicationSortOrder? =
+        dataStore.data
+            .map { preferences -> preferences[APPLICATIONS_LIST_SORT_KEY]?.let(ApplicationSortOrder::fromWireValue) }
+            .first()
+
+    override suspend fun writeSort(sort: ApplicationSortOrder) {
+        dataStore.edit { preferences -> preferences[APPLICATIONS_LIST_SORT_KEY] = sort.wireValue }
+    }
+
+    override suspend fun readLastSelectedZoneId(): WatchZoneId? =
+        dataStore.data
+            .map { preferences -> preferences[LAST_SELECTED_ZONE_KEY]?.let(::WatchZoneId) }
+            .first()
+
+    override suspend fun writeLastSelectedZoneId(zoneId: WatchZoneId) {
+        dataStore.edit { preferences -> preferences[LAST_SELECTED_ZONE_KEY] = zoneId.value }
+    }
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/InMemoryApplicationCacheStore.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/InMemoryApplicationCacheStore.kt
@@ -1,0 +1,35 @@
+package uk.towncrierapp.data.applications
+
+import uk.towncrierapp.domain.applications.ApplicationCacheStore
+import uk.towncrierapp.domain.applications.CachedApplicationPage
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * In-memory, process-lifetime [ApplicationCacheStore] — no persistence, no
+ * TTL logic of its own (that policy lives entirely in
+ * [uk.towncrierapp.domain.applications.OfflineAwareRepository], which is what
+ * lets this be a plain keyed map). A `ConcurrentHashMap` is enough
+ * concurrency safety for a handful of zone-keyed reads/writes; no explicit
+ * locking is warranted. Port of iOS `InMemoryApplicationCacheStore` (GH#775).
+ */
+public class InMemoryApplicationCacheStore : ApplicationCacheStore {
+    private val entries = ConcurrentHashMap<WatchZoneId, CachedApplicationPage>()
+
+    override suspend fun get(zoneId: WatchZoneId): CachedApplicationPage? = entries[zoneId]
+
+    override suspend fun put(
+        zoneId: WatchZoneId,
+        entry: CachedApplicationPage,
+    ) {
+        entries[zoneId] = entry
+    }
+
+    override suspend fun invalidate(zoneId: WatchZoneId) {
+        entries.remove(zoneId)
+    }
+
+    override suspend fun invalidateAll() {
+        entries.clear()
+    }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiNotificationStateRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiNotificationStateRepositoryTest.kt
@@ -1,0 +1,93 @@
+package uk.towncrierapp.data.applications
+
+import kotlinx.coroutines.test.runTest
+import okhttp3.Request
+import okio.Buffer
+import org.junit.jupiter.api.Test
+import uk.towncrierapp.data.api.ApiClient
+import uk.towncrierapp.data.api.FakeHttpTransport
+import uk.towncrierapp.domain.applications.PlanningApplicationId
+import uk.towncrierapp.domain.auth.FakeAuthenticationService
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private fun Request.bodyAsString(): String {
+    val buffer = Buffer()
+    body?.writeTo(buffer)
+    return buffer.readUtf8()
+}
+
+/**
+ * `GET /v1/me/notification-state`, `POST /v1/me/applications/mark-read`
+ * (⚠️ the `applicationUid` wire key holds the case NAME, i.e. [PlanningApplicationId.name],
+ * not the uid — ported as-is, not "fixed"), and
+ * `POST /v1/me/notification-state/mark-all-read`. Port of the iOS
+ * `APINotificationStateRepositoryTests` suite (GH#775). The legacy `/advance`
+ * endpoint is deliberately not implemented.
+ */
+class ApiNotificationStateRepositoryTest {
+    private fun makeSut(transport: FakeHttpTransport = FakeHttpTransport()): ApiNotificationStateRepository {
+        val apiClient = ApiClient("https://api-dev.towncrierapp.uk", transport, FakeAuthenticationService())
+        return ApiNotificationStateRepository(apiClient)
+    }
+
+    @Test
+    fun `state GETs and decodes lastReadAt, version and totalUnreadCount`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, """{"lastReadAt":"2026-01-01T00:00:00Z","version":3,"totalUnreadCount":7}""")
+            val sut = makeSut(transport)
+
+            val state = sut.state()
+
+            assertEquals("/v1/me/notification-state", transport.requests.single().url.encodedPath)
+            assertEquals(3, state.version)
+            assertEquals(7, state.totalUnreadCount)
+        }
+
+    @Test
+    fun `markRead POSTs applicationUid as the case name (not the uid) and authorityId as an int`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(204)
+            val sut = makeSut(transport)
+
+            sut.markRead(listOf(PlanningApplicationId(authority = "42", name = "24/0001")))
+
+            val request = transport.requests.single()
+            assertEquals("POST", request.method)
+            assertEquals("/v1/me/applications/mark-read", request.url.encodedPath)
+            assertEquals(
+                """{"applications":[{"applicationUid":"24/0001","authorityId":42}]}""",
+                request.bodyAsString(),
+            )
+        }
+
+    @Test
+    fun `markRead batches more than 500 ids into multiple requests`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            repeat(2) { transport.enqueueResponse(204) }
+            val sut = makeSut(transport)
+            val ids = (1..501).map { PlanningApplicationId(authority = "42", name = "24/$it") }
+
+            sut.markRead(ids)
+
+            assertEquals(2, transport.requests.size)
+            assertTrue(transport.requests[0].bodyAsString().contains(""""authorityId":42"""))
+        }
+
+    @Test
+    fun `markAllRead POSTs with no body`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(204)
+            val sut = makeSut(transport)
+
+            sut.markAllRead()
+
+            val request = transport.requests.single()
+            assertEquals("POST", request.method)
+            assertEquals("/v1/me/notification-state/mark-all-read", request.url.encodedPath)
+        }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiNotificationStateRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiNotificationStateRepositoryTest.kt
@@ -40,7 +40,12 @@ class ApiNotificationStateRepositoryTest {
 
             val state = sut.state()
 
-            assertEquals("/v1/me/notification-state", transport.requests.single().url.encodedPath)
+            assertEquals(
+                "/v1/me/notification-state",
+                transport.requests
+                    .single()
+                    .url.encodedPath,
+            )
             assertEquals(3, state.version)
             assertEquals(7, state.totalUnreadCount)
         }

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepositoryTest.kt
@@ -70,7 +70,11 @@ class ApiPlanningApplicationRepositoryTest {
             transport.enqueueResponse(200, "[]")
             val sut = makeSut(transport)
 
-            sut.applications(zoneId, ApplicationSortOrder.NEWEST, filter = ApplicationFilter.Status(ApplicationStatus.Permitted))
+            sut.applications(
+                zoneId,
+                ApplicationSortOrder.NEWEST,
+                filter = ApplicationFilter.Status(ApplicationStatus.Permitted),
+            )
 
             val url = transport.requests.single().url
             assertEquals("Permitted", url.queryParameter("status"))
@@ -100,7 +104,13 @@ class ApiPlanningApplicationRepositoryTest {
 
             sut.applications(zoneId, ApplicationSortOrder.NEWEST, cursor = "cursor-abc")
 
-            assertEquals("cursor-abc", transport.requests.single().url.queryParameter("cursor"))
+            assertEquals(
+                "cursor-abc",
+                transport.requests
+                    .single()
+                    .url
+                    .queryParameter("cursor"),
+            )
         }
 
     @Test
@@ -176,12 +186,23 @@ class ApiPlanningApplicationRepositoryTest {
     fun `statusHistory has only an Undecided event when there is no decidedDate`() =
         runTest {
             val transport = FakeHttpTransport()
-            transport.enqueueResponse(200, "[${row(appState = "Undecided", startDate = "2026-01-10", decidedDate = null)}]")
+            transport.enqueueResponse(
+                200,
+                "[${row(appState = "Undecided", startDate = "2026-01-10", decidedDate = null)}]",
+            )
             val sut = makeSut(transport)
 
             val application = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single()
 
-            assertEquals(listOf(uk.towncrierapp.domain.applications.StatusEvent(ApplicationStatus.Undecided, LocalDate.of(2026, 1, 10))), application.statusHistory)
+            assertEquals(
+                listOf(
+                    uk.towncrierapp.domain.applications.StatusEvent(
+                        ApplicationStatus.Undecided,
+                        LocalDate.of(2026, 1, 10),
+                    ),
+                ),
+                application.statusHistory,
+            )
         }
 
     @Test
@@ -235,13 +256,17 @@ class ApiPlanningApplicationRepositoryTest {
     fun `latestUnreadEvent decodes type, decision and createdAt when present`() =
         runTest {
             val transport = FakeHttpTransport()
-            transport.enqueueResponse(
-                200,
-                "[${row(latestUnreadEvent = """{"type":"DecisionUpdate","decision":"Permitted","createdAt":"2026-02-02T10:00:00Z"}""")}]",
-            )
+            val unreadEventJson =
+                """{"type":"DecisionUpdate","decision":"Permitted","createdAt":"2026-02-02T10:00:00Z"}"""
+            transport.enqueueResponse(200, "[${row(latestUnreadEvent = unreadEventJson)}]")
             val sut = makeSut(transport)
 
-            val event = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single().latestUnreadEvent
+            val event =
+                sut
+                    .applications(zoneId, ApplicationSortOrder.NEWEST)
+                    .applications
+                    .single()
+                    .latestUnreadEvent
             assertEquals("DecisionUpdate", event?.type)
             assertEquals("Permitted", event?.decision)
         }
@@ -304,6 +329,11 @@ class ApiPlanningApplicationRepositoryTest {
 
             sut.applications(zoneId, ApplicationSortOrder.DEFAULT)
 
-            assertTrue(transport.requests.single().url.queryParameterNames.contains("sort"))
+            assertTrue(
+                transport.requests
+                    .single()
+                    .url.queryParameterNames
+                    .contains("sort"),
+            )
         }
 }

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepositoryTest.kt
@@ -31,15 +31,16 @@ class ApiPlanningApplicationRepositoryTest {
         return ApiPlanningApplicationRepository(apiClient)
     }
 
+    // name/areaId never vary across this file's tests — dropped as parameters
+    // (rather than left as unused-in-practice knobs) to keep this fixture
+    // under detekt's LongParameterList budget.
     private fun row(
-        name: String = "24/0001",
-        areaId: Int = 42,
         appState: String? = "Undecided",
         startDate: String? = "2026-01-10",
         decidedDate: String? = null,
         latestUnreadEvent: String? = null,
     ): String =
-        """{"name":"$name","uid":"uid-1","areaName":"Camden","areaId":$areaId,"address":"1 Example Street",""" +
+        """{"name":"24/0001","uid":"uid-1","areaName":"Camden","areaId":42,"address":"1 Example Street",""" +
             """"description":"Extension","appState":${appState?.let { "\"$it\"" }},""" +
             """"startDate":${startDate?.let { "\"$it\"" }},"decidedDate":${decidedDate?.let { "\"$it\"" }},""" +
             """"lastDifferent":"2026-01-11T09:00:00Z","latestUnreadEvent":$latestUnreadEvent}"""
@@ -142,7 +143,7 @@ class ApiPlanningApplicationRepositoryTest {
     fun `a row decodes its identity, authority and address fields`() =
         runTest {
             val transport = FakeHttpTransport()
-            transport.enqueueResponse(200, "[${row(name = "24/0001", areaId = 42)}]")
+            transport.enqueueResponse(200, "[${row()}]")
             val sut = makeSut(transport)
 
             val application = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single()

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepositoryTest.kt
@@ -1,0 +1,309 @@
+package uk.towncrierapp.data.applications
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uk.towncrierapp.data.api.ApiClient
+import uk.towncrierapp.data.api.FakeHttpTransport
+import uk.towncrierapp.domain.applications.ApplicationFilter
+import uk.towncrierapp.domain.applications.ApplicationSortOrder
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.auth.FakeAuthenticationService
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `GET /v1/me/watch-zones/{zoneId}/applications` — cursor paging via
+ * `X-Next-Cursor`, the always-sent `sort` (never the legacy param-less path),
+ * `status`/`unread` mutual exclusivity (guaranteed by [ApplicationFilter]'s
+ * shape, exercised here at the query-building boundary), and DTO->domain
+ * mapping including `statusHistory` synthesis. Port of the iOS
+ * `APIApplicationRepositoryTests` suites (GH#775).
+ */
+class ApiPlanningApplicationRepositoryTest {
+    private val zoneId = WatchZoneId("wz-1")
+
+    private fun makeSut(transport: FakeHttpTransport = FakeHttpTransport()): ApiPlanningApplicationRepository {
+        val apiClient = ApiClient("https://api-dev.towncrierapp.uk", transport, FakeAuthenticationService())
+        return ApiPlanningApplicationRepository(apiClient)
+    }
+
+    private fun row(
+        name: String = "24/0001",
+        areaId: Int = 42,
+        appState: String? = "Undecided",
+        startDate: String? = "2026-01-10",
+        decidedDate: String? = null,
+        latestUnreadEvent: String? = null,
+    ): String =
+        """{"name":"$name","uid":"uid-1","areaName":"Camden","areaId":$areaId,"address":"1 Example Street",""" +
+            """"description":"Extension","appState":${appState?.let { "\"$it\"" }},""" +
+            """"startDate":${startDate?.let { "\"$it\"" }},"decidedDate":${decidedDate?.let { "\"$it\"" }},""" +
+            """"lastDifferent":"2026-01-11T09:00:00Z","latestUnreadEvent":$latestUnreadEvent}"""
+
+    @Test
+    fun `applications GETs the zone endpoint always sending sort and limit`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[]")
+            val sut = makeSut(transport)
+
+            sut.applications(zoneId, ApplicationSortOrder.NEWEST)
+
+            val request = transport.requests.single()
+            assertEquals("GET", request.method)
+            assertEquals("/v1/me/watch-zones/wz-1/applications", request.url.encodedPath)
+            assertEquals("newest", request.url.queryParameter("sort"))
+            assertEquals("150", request.url.queryParameter("limit"))
+            assertNull(request.url.queryParameter("status"))
+            assertNull(request.url.queryParameter("unread"))
+            assertNull(request.url.queryParameter("cursor"))
+        }
+
+    @Test
+    fun `applications sends status for a Status filter, never unread`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[]")
+            val sut = makeSut(transport)
+
+            sut.applications(zoneId, ApplicationSortOrder.NEWEST, filter = ApplicationFilter.Status(ApplicationStatus.Permitted))
+
+            val url = transport.requests.single().url
+            assertEquals("Permitted", url.queryParameter("status"))
+            assertNull(url.queryParameter("unread"))
+        }
+
+    @Test
+    fun `applications sends unread=true for the Unread filter, never status`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[]")
+            val sut = makeSut(transport)
+
+            sut.applications(zoneId, ApplicationSortOrder.NEWEST, filter = ApplicationFilter.Unread)
+
+            val url = transport.requests.single().url
+            assertEquals("true", url.queryParameter("unread"))
+            assertNull(url.queryParameter("status"))
+        }
+
+    @Test
+    fun `applications forwards a continuation cursor as a query parameter`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[]")
+            val sut = makeSut(transport)
+
+            sut.applications(zoneId, ApplicationSortOrder.NEWEST, cursor = "cursor-abc")
+
+            assertEquals("cursor-abc", transport.requests.single().url.queryParameter("cursor"))
+        }
+
+    @Test
+    fun `applications surfaces the X-Next-Cursor header as nextCursor`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[${row()}]", headers = mapOf("X-Next-Cursor" to "cursor-xyz"))
+            val sut = makeSut(transport)
+
+            val page = sut.applications(zoneId, ApplicationSortOrder.NEWEST)
+
+            assertEquals("cursor-xyz", page.nextCursor)
+            assertEquals(1, page.applications.size)
+        }
+
+    @Test
+    fun `applications returns a null nextCursor when the header is absent (last page)`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[${row()}]")
+            val sut = makeSut(transport)
+
+            val page = sut.applications(zoneId, ApplicationSortOrder.NEWEST)
+
+            assertNull(page.nextCursor)
+        }
+
+    @Test
+    fun `a row decodes its identity, authority and address fields`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[${row(name = "24/0001", areaId = 42)}]")
+            val sut = makeSut(transport)
+
+            val application = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single()
+
+            assertEquals("42", application.id.authority)
+            assertEquals("24/0001", application.id.name)
+            assertEquals("24/0001", application.reference)
+            assertEquals("42", application.authority.code)
+            assertEquals("Camden", application.authority.name)
+            assertNull(application.authority.slug)
+            assertEquals("1 Example Street", application.address)
+            assertEquals("Extension", application.description)
+        }
+
+    @Test
+    fun `appState 'Not Available' decodes to the NotAvailable status`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[${row(appState = "Not Available")}]")
+            val sut = makeSut(transport)
+
+            val application = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single()
+
+            assertEquals(ApplicationStatus.NotAvailable, application.status)
+        }
+
+    @Test
+    fun `an unrecognised appState decodes to Unknown`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[${row(appState = "BrandNewState")}]")
+            val sut = makeSut(transport)
+
+            val application = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single()
+
+            val unknown = assertIs<ApplicationStatus.Unknown>(application.status)
+            assertEquals("BrandNewState", unknown.raw)
+        }
+
+    @Test
+    fun `statusHistory has only an Undecided event when there is no decidedDate`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[${row(appState = "Undecided", startDate = "2026-01-10", decidedDate = null)}]")
+            val sut = makeSut(transport)
+
+            val application = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single()
+
+            assertEquals(listOf(uk.towncrierapp.domain.applications.StatusEvent(ApplicationStatus.Undecided, LocalDate.of(2026, 1, 10))), application.statusHistory)
+        }
+
+    @Test
+    fun `statusHistory adds a second decided event when the status is actually decided`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(
+                200,
+                "[${row(appState = "Permitted", startDate = "2026-01-10", decidedDate = "2026-02-01")}]",
+            )
+            val sut = makeSut(transport)
+
+            val application = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single()
+
+            assertEquals(2, application.statusHistory.size)
+            assertEquals(ApplicationStatus.Undecided, application.statusHistory[0].status)
+            assertEquals(LocalDate.of(2026, 1, 10), application.statusHistory[0].date)
+            assertEquals(ApplicationStatus.Permitted, application.statusHistory[1].status)
+            assertEquals(LocalDate.of(2026, 2, 1), application.statusHistory[1].date)
+        }
+
+    @Test
+    fun `a decidedDate is folded away (dropped) when the status is not actually decided`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(
+                200,
+                "[${row(appState = "Unresolved", startDate = "2026-01-10", decidedDate = "2026-02-01")}]",
+            )
+            val sut = makeSut(transport)
+
+            val application = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single()
+
+            assertEquals(1, application.statusHistory.size)
+            assertEquals(ApplicationStatus.Undecided, application.statusHistory.single().status)
+        }
+
+    @Test
+    fun `latestUnreadEvent is null when absent from the row`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[${row(latestUnreadEvent = null)}]")
+            val sut = makeSut(transport)
+
+            val application = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single()
+
+            assertNull(application.latestUnreadEvent)
+        }
+
+    @Test
+    fun `latestUnreadEvent decodes type, decision and createdAt when present`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(
+                200,
+                "[${row(latestUnreadEvent = """{"type":"DecisionUpdate","decision":"Permitted","createdAt":"2026-02-02T10:00:00Z"}""")}]",
+            )
+            val sut = makeSut(transport)
+
+            val event = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single().latestUnreadEvent
+            assertEquals("DecisionUpdate", event?.type)
+            assertEquals("Permitted", event?.decision)
+        }
+
+    @Test
+    fun `detail GETs applications by authority and name, decoding the authoritySlug`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(
+                200,
+                """{"name":"24/0001","uid":"uid-1","areaName":"Camden","areaId":42,"address":"1 Example Street",""" +
+                    """"description":"Extension","appState":"Undecided","startDate":"2026-01-10",""" +
+                    """"lastDifferent":"2026-01-11T09:00:00Z","authoritySlug":"camden"}""",
+            )
+            val sut = makeSut(transport)
+
+            val application = sut.detail("42", "24/0001")
+
+            val request = transport.requests.single()
+            assertEquals("/v1/applications/42/24/0001", request.url.encodedPath)
+            assertEquals("camden", application.authority.slug)
+        }
+
+    @Test
+    fun `portalUrl prefers link over url when both are present`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(
+                200,
+                """[{"name":"24/0001","uid":"uid-1","areaName":"Camden","areaId":42,"address":"1 Example Street",""" +
+                    """"description":"Extension","appState":"Undecided","startDate":"2026-01-10",""" +
+                    """"url":"https://planit.example/24-0001","link":"https://council.example/24-0001",""" +
+                    """"lastDifferent":"2026-01-11T09:00:00Z"}]""",
+            )
+            val sut = makeSut(transport)
+
+            val application = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single()
+
+            assertEquals("https://council.example/24-0001", application.portalUrl)
+        }
+
+    @Test
+    fun `location is null when latitude or longitude is absent`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[${row()}]")
+            val sut = makeSut(transport)
+
+            val application = sut.applications(zoneId, ApplicationSortOrder.NEWEST).applications.single()
+
+            assertNull(application.location)
+        }
+
+    @Test
+    fun `a legacy default sort call is never made — sort is always present`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, "[]")
+            val sut = makeSut(transport)
+
+            sut.applications(zoneId, ApplicationSortOrder.DEFAULT)
+
+            assertTrue(transport.requests.single().url.queryParameterNames.contains("sort"))
+        }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiSavedApplicationRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiSavedApplicationRepositoryTest.kt
@@ -1,0 +1,96 @@
+package uk.towncrierapp.data.applications
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uk.towncrierapp.data.api.ApiClient
+import uk.towncrierapp.data.api.FakeHttpTransport
+import uk.towncrierapp.domain.applications.PlanningApplicationId
+import uk.towncrierapp.domain.auth.FakeAuthenticationService
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * `GET/PUT/DELETE /v1/me/saved-applications` — the flat, cross-zone saved
+ * list (client-sorted `savedAt` DESC by the ViewModel, not here), legacy
+ * null-payload rows, and the save/unsave path segment built from
+ * [PlanningApplicationId.value] with its slash(es) percent-encoded so the
+ * whole id stays ONE path segment (GH#775). Port of the iOS
+ * `APISavedApplicationRepositoryTests` suite.
+ */
+class ApiSavedApplicationRepositoryTest {
+    private fun makeSut(transport: FakeHttpTransport = FakeHttpTransport()): ApiSavedApplicationRepository {
+        val apiClient = ApiClient("https://api-dev.towncrierapp.uk", transport, FakeAuthenticationService())
+        return ApiSavedApplicationRepository(apiClient)
+    }
+
+    @Test
+    fun `savedApplications GETs the flat list and decodes each row`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(
+                200,
+                """[{"applicationUid":"42/24/0001","savedAt":"2026-01-16T09:00:00Z","application":{"name":"24/0001",""" +
+                    """"uid":"uid-1","areaName":"Camden","areaId":42,"address":"1 Example Street",""" +
+                    """"description":"Extension","appState":"Undecided","startDate":"2026-01-10",""" +
+                    """"lastDifferent":"2026-01-11T09:00:00Z"}}]""",
+            )
+            val sut = makeSut(transport)
+
+            val saved = sut.savedApplications()
+
+            val request = transport.requests.single()
+            assertEquals("GET", request.method)
+            assertEquals("/v1/me/saved-applications", request.url.encodedPath)
+            val row = saved.single()
+            assertEquals(PlanningApplicationId("42", "24/0001"), row.applicationUid)
+            assertEquals("24/0001", row.application?.reference)
+        }
+
+    @Test
+    fun `a legacy row with a null application payload decodes with a null application`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(
+                200,
+                """[{"applicationUid":"42/24/9999","savedAt":"2026-01-16T09:00:00Z","application":null}]""",
+            )
+            val sut = makeSut(transport)
+
+            val row = sut.savedApplications().single()
+
+            assertNull(row.application)
+        }
+
+    @Test
+    fun `save PUTs to a single, correctly-encoded path segment built from id-value`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200)
+            val sut = makeSut(transport)
+
+            sut.save(PlanningApplicationId(authority = "42", name = "24/0001"))
+
+            val request = transport.requests.single()
+            assertEquals("PUT", request.method)
+            // Exactly 4 path segments: v1, me, saved-applications, <the whole id as one>.
+            assertEquals(4, request.url.pathSegments.size)
+            assertEquals("42/24/0001", request.url.pathSegments.last())
+            assertTrue(request.url.encodedPath.endsWith("saved-applications/42%2F24%2F0001"))
+        }
+
+    @Test
+    fun `unsave DELETEs the same correctly-encoded path segment`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(204)
+            val sut = makeSut(transport)
+
+            sut.unsave(PlanningApplicationId(authority = "42", name = "24/0001"))
+
+            val request = transport.requests.single()
+            assertEquals("DELETE", request.method)
+            assertEquals(4, request.url.pathSegments.size)
+            assertEquals("42/24/0001", request.url.pathSegments.last())
+        }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiSavedApplicationRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiSavedApplicationRepositoryTest.kt
@@ -28,13 +28,12 @@ class ApiSavedApplicationRepositoryTest {
     fun `savedApplications GETs the flat list and decodes each row`() =
         runTest {
             val transport = FakeHttpTransport()
-            transport.enqueueResponse(
-                200,
-                """[{"applicationUid":"42/24/0001","savedAt":"2026-01-16T09:00:00Z","application":{"name":"24/0001",""" +
-                    """"uid":"uid-1","areaName":"Camden","areaId":42,"address":"1 Example Street",""" +
-                    """"description":"Extension","appState":"Undecided","startDate":"2026-01-10",""" +
-                    """"lastDifferent":"2026-01-11T09:00:00Z"}}]""",
-            )
+            val savedRowJson =
+                """[{"applicationUid":"42/24/0001","savedAt":"2026-01-16T09:00:00Z",""" +
+                    """"application":{"name":"24/0001","uid":"uid-1","areaName":"Camden","areaId":42,""" +
+                    """"address":"1 Example Street","description":"Extension","appState":"Undecided",""" +
+                    """"startDate":"2026-01-10","lastDifferent":"2026-01-11T09:00:00Z"}}]"""
+            transport.enqueueResponse(200, savedRowJson)
             val sut = makeSut(transport)
 
             val saved = sut.savedApplications()

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/DataStoreApplicationListPreferencesStoreTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/DataStoreApplicationListPreferencesStoreTest.kt
@@ -1,0 +1,61 @@
+package uk.towncrierapp.data.applications
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import uk.towncrierapp.domain.applications.ApplicationSortOrder
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The `applicationsListSort` / `lastSelectedZone.applications` DataStore
+ * latches — key names reused verbatim from iOS (epic #770 pre-resolved
+ * decision). Port of the DataStore latch pattern established by
+ * `DataStoreSubscriptionTierCacheTest` (GH#775).
+ */
+class DataStoreApplicationListPreferencesStoreTest {
+    private fun aDataStore(directory: File) = PreferenceDataStoreFactory.create { File(directory, "test.preferences_pb") }
+
+    @Test
+    fun `readSort returns null when nothing has been written yet`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreApplicationListPreferencesStore(aDataStore(directory))
+
+        assertNull(sut.readSort())
+    }
+
+    @Test
+    fun `writeSort then readSort round-trips the sort order`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreApplicationListPreferencesStore(aDataStore(directory))
+
+        sut.writeSort(ApplicationSortOrder.OLDEST)
+
+        assertEquals(ApplicationSortOrder.OLDEST, sut.readSort())
+    }
+
+    @Test
+    fun `readLastSelectedZoneId returns null when nothing has been written yet`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreApplicationListPreferencesStore(aDataStore(directory))
+
+        assertNull(sut.readLastSelectedZoneId())
+    }
+
+    @Test
+    fun `writeLastSelectedZoneId then readLastSelectedZoneId round-trips the zone id`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreApplicationListPreferencesStore(aDataStore(directory))
+
+        sut.writeLastSelectedZoneId(WatchZoneId("wz-9"))
+
+        assertEquals(WatchZoneId("wz-9"), sut.readLastSelectedZoneId())
+    }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/DataStoreApplicationListPreferencesStoreTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/DataStoreApplicationListPreferencesStoreTest.kt
@@ -17,7 +17,8 @@ import kotlin.test.assertNull
  * `DataStoreSubscriptionTierCacheTest` (GH#775).
  */
 class DataStoreApplicationListPreferencesStoreTest {
-    private fun aDataStore(directory: File) = PreferenceDataStoreFactory.create { File(directory, "test.preferences_pb") }
+    private fun aDataStore(directory: File) =
+        PreferenceDataStoreFactory.create { File(directory, "test.preferences_pb") }
 
     @Test
     fun `readSort returns null when nothing has been written yet`(

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/InMemoryApplicationCacheStoreTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/InMemoryApplicationCacheStoreTest.kt
@@ -1,0 +1,60 @@
+package uk.towncrierapp.data.applications
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uk.towncrierapp.domain.applications.ApplicationPage
+import uk.towncrierapp.domain.applications.CachedApplicationPage
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** Plain keyed storage, no TTL logic of its own (see `OfflineAwareRepository` for that policy). Port of iOS `InMemoryApplicationCacheStore` (GH#775). */
+class InMemoryApplicationCacheStoreTest {
+    @Test
+    fun `get returns null when nothing has been cached for a zone`() =
+        runTest {
+            val sut = InMemoryApplicationCacheStore()
+
+            assertNull(sut.get(WatchZoneId("wz-1")))
+        }
+
+    @Test
+    fun `put then get round-trips the cached entry`() =
+        runTest {
+            val sut = InMemoryApplicationCacheStore()
+            val entry = CachedApplicationPage(ApplicationPage(emptyList()), Instant.parse("2026-01-01T00:00:00Z"))
+
+            sut.put(WatchZoneId("wz-1"), entry)
+
+            assertEquals(entry, sut.get(WatchZoneId("wz-1")))
+        }
+
+    @Test
+    fun `invalidate removes only the entry for that zone`() =
+        runTest {
+            val sut = InMemoryApplicationCacheStore()
+            val entry = CachedApplicationPage(ApplicationPage(emptyList()), Instant.parse("2026-01-01T00:00:00Z"))
+            sut.put(WatchZoneId("wz-1"), entry)
+            sut.put(WatchZoneId("wz-2"), entry)
+
+            sut.invalidate(WatchZoneId("wz-1"))
+
+            assertNull(sut.get(WatchZoneId("wz-1")))
+            assertEquals(entry, sut.get(WatchZoneId("wz-2")))
+        }
+
+    @Test
+    fun `invalidateAll clears every zone's entry`() =
+        runTest {
+            val sut = InMemoryApplicationCacheStore()
+            val entry = CachedApplicationPage(ApplicationPage(emptyList()), Instant.parse("2026-01-01T00:00:00Z"))
+            sut.put(WatchZoneId("wz-1"), entry)
+            sut.put(WatchZoneId("wz-2"), entry)
+
+            sut.invalidateAll()
+
+            assertNull(sut.get(WatchZoneId("wz-1")))
+            assertNull(sut.get(WatchZoneId("wz-2")))
+        }
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationCacheStore.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationCacheStore.kt
@@ -1,0 +1,32 @@
+package uk.towncrierapp.domain.applications
+
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import java.time.Instant
+
+/** An [ApplicationPage] snapshot plus the instant it was cached — the freshness check lives in [OfflineAwareRepository], not here. */
+public data class CachedApplicationPage(
+    public val page: ApplicationPage,
+    public val cachedAt: Instant,
+)
+
+/**
+ * Pure keyed storage for [OfflineAwareRepository]'s zone-scoped first-page
+ * snapshots — no TTL/freshness logic of its own (that policy lives in the
+ * decorator, which is what makes "stale but still servable offline" and
+ * "fresh enough to skip the network" two different questions the store
+ * doesn't need to answer). [invalidate]/[invalidateAll] are the explicit hooks
+ * a watch-zone edit (tc-cnme) or a mark-all-read fires. Port of iOS
+ * `ApplicationCacheStore`.
+ */
+public interface ApplicationCacheStore {
+    public suspend fun get(zoneId: WatchZoneId): CachedApplicationPage?
+
+    public suspend fun put(
+        zoneId: WatchZoneId,
+        entry: CachedApplicationPage,
+    )
+
+    public suspend fun invalidate(zoneId: WatchZoneId)
+
+    public suspend fun invalidateAll()
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationFilter.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationFilter.kt
@@ -1,0 +1,19 @@
+package uk.towncrierapp.domain.applications
+
+/**
+ * The list screen's active chip selection: everything, one specific status,
+ * or unread-only. A sum type rather than a `status: ApplicationStatus?` +
+ * `unreadOnly: Boolean` pair — "status AND unread" is unrepresentable BY
+ * CONSTRUCTION (the server 400s if both are sent; this makes that combination
+ * impossible to build in the first place, so no runtime guard is needed).
+ * Port of iOS `ApplicationFilter` (GH#775).
+ */
+public sealed interface ApplicationFilter {
+    public data object All : ApplicationFilter
+
+    public data class Status(
+        public val status: ApplicationStatus,
+    ) : ApplicationFilter
+
+    public data object Unread : ApplicationFilter
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationListPreferencesStore.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationListPreferencesStore.kt
@@ -1,0 +1,20 @@
+package uk.towncrierapp.domain.applications
+
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+
+/**
+ * The two applications-list device latches (epic #770 iOS-key parity):
+ * `applicationsListSort` and `lastSelectedZone.applications`. A one-shot
+ * suspend read/write, not a `Flow` — this is the cold-start restore value,
+ * not something the UI observes live (mirrors
+ * [uk.towncrierapp.domain.subscriptions.SubscriptionTierCache]'s shape).
+ */
+public interface ApplicationListPreferencesStore {
+    public suspend fun readSort(): ApplicationSortOrder?
+
+    public suspend fun writeSort(sort: ApplicationSortOrder)
+
+    public suspend fun readLastSelectedZoneId(): WatchZoneId?
+
+    public suspend fun writeLastSelectedZoneId(zoneId: WatchZoneId)
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationPage.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationPage.kt
@@ -1,0 +1,7 @@
+package uk.towncrierapp.domain.applications
+
+/** One page of a zone's application list. A `null` [nextCursor] means this was the last page. Port of iOS `ApplicationPage` (GH#775). */
+public data class ApplicationPage(
+    public val applications: List<PlanningApplication>,
+    public val nextCursor: String? = null,
+)

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationSortOrder.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationSortOrder.kt
@@ -23,6 +23,7 @@ public enum class ApplicationSortOrder(
         public val DEFAULT: ApplicationSortOrder = RECENT_ACTIVITY
 
         /** Decodes a persisted/wire sort token; anything unrecognised falls back to [DEFAULT]. */
-        public fun fromWireValue(value: String): ApplicationSortOrder = entries.firstOrNull { it.wireValue == value } ?: DEFAULT
+        public fun fromWireValue(value: String): ApplicationSortOrder =
+            entries.firstOrNull { it.wireValue == value } ?: DEFAULT
     }
 }

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationSortOrder.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationSortOrder.kt
@@ -1,0 +1,28 @@
+package uk.towncrierapp.domain.applications
+
+/**
+ * The five server-supported sort orders for `GET
+ * /v1/me/watch-zones/{zoneId}/applications`. Android always sends one (never
+ * exercises the legacy param-less path — epic #770 pre-resolved decision).
+ * [DEFAULT] is the CLIENT default (`recent-activity`); the server's own
+ * default (`distance`) is deliberately not the client default, and
+ * `distance` itself is hidden from the sort picker whenever no zone is
+ * active. Port of iOS `ApplicationSortOrder`.
+ */
+public enum class ApplicationSortOrder(
+    public val wireValue: String,
+) {
+    DISTANCE("distance"),
+    NEWEST("newest"),
+    OLDEST("oldest"),
+    STATUS("status"),
+    RECENT_ACTIVITY("recent-activity"),
+    ;
+
+    public companion object {
+        public val DEFAULT: ApplicationSortOrder = RECENT_ACTIVITY
+
+        /** Decodes a persisted/wire sort token; anything unrecognised falls back to [DEFAULT]. */
+        public fun fromWireValue(value: String): ApplicationSortOrder = entries.firstOrNull { it.wireValue == value } ?: DEFAULT
+    }
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationStatus.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/ApplicationStatus.kt
@@ -1,0 +1,91 @@
+package uk.towncrierapp.domain.applications
+
+/**
+ * PlanIt's `app_state` vocabulary. Every raw value the wire can send has its
+ * own case — including [Unresolved]/[Referred]/[NotAvailable], which decode
+ * successfully but are display-grouped with [Unknown] (see `StatusDisplay` in
+ * `:presentation`) — so a genuinely unrecognised future value still has
+ * somewhere honest to land: [Unknown]. Port of iOS `ApplicationStatus`
+ * (GH#775).
+ */
+public sealed interface ApplicationStatus {
+    public data object Undecided : ApplicationStatus
+
+    public data object Permitted : ApplicationStatus
+
+    public data object Conditions : ApplicationStatus
+
+    public data object Rejected : ApplicationStatus
+
+    public data object Withdrawn : ApplicationStatus
+
+    public data object Appealed : ApplicationStatus
+
+    public data object Unresolved : ApplicationStatus
+
+    public data object Referred : ApplicationStatus
+
+    public data object NotAvailable : ApplicationStatus
+
+    /** A raw value outside the known PlanIt vocabulary above. [raw] is preserved for diagnostics. */
+    public data class Unknown(
+        public val raw: String,
+    ) : ApplicationStatus
+
+    public companion object {
+        /** Decodes a wire `app_state` value; anything unrecognised (including blank) becomes [Unknown]. */
+        public fun fromWireValue(value: String): ApplicationStatus =
+            when (value) {
+                "Undecided" -> Undecided
+                "Permitted" -> Permitted
+                "Conditions" -> Conditions
+                "Rejected" -> Rejected
+                "Withdrawn" -> Withdrawn
+                "Appealed" -> Appealed
+                "Unresolved" -> Unresolved
+                "Referred" -> Referred
+                "Not Available" -> NotAvailable
+                else -> Unknown(value)
+            }
+    }
+}
+
+/** The wire `app_state` string this status decoded from (or would encode to) — the inverse of [ApplicationStatus.fromWireValue]. */
+public val ApplicationStatus.wireValue: String
+    get() =
+        when (this) {
+            ApplicationStatus.Undecided -> "Undecided"
+            ApplicationStatus.Permitted -> "Permitted"
+            ApplicationStatus.Conditions -> "Conditions"
+            ApplicationStatus.Rejected -> "Rejected"
+            ApplicationStatus.Withdrawn -> "Withdrawn"
+            ApplicationStatus.Appealed -> "Appealed"
+            ApplicationStatus.Unresolved -> "Unresolved"
+            ApplicationStatus.Referred -> "Referred"
+            ApplicationStatus.NotAvailable -> "Not Available"
+            is ApplicationStatus.Unknown -> raw
+        }
+
+/**
+ * Whether a decision has actually been made — the exact set `statusHistory`
+ * synthesis (GH#775) uses to decide whether a `decidedDate` becomes a second
+ * timeline event, or is folded away because the application isn't actually
+ * decided yet (e.g. [ApplicationStatus.Unresolved]).
+ */
+public val ApplicationStatus.isDecided: Boolean
+    get() =
+        when (this) {
+            ApplicationStatus.Permitted,
+            ApplicationStatus.Conditions,
+            ApplicationStatus.Rejected,
+            ApplicationStatus.Withdrawn,
+            ApplicationStatus.Appealed,
+            -> true
+
+            ApplicationStatus.Undecided,
+            ApplicationStatus.Unresolved,
+            ApplicationStatus.Referred,
+            ApplicationStatus.NotAvailable,
+            is ApplicationStatus.Unknown,
+            -> false
+        }

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/LatestUnreadEvent.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/LatestUnreadEvent.kt
@@ -1,0 +1,18 @@
+package uk.towncrierapp.domain.applications
+
+import java.time.OffsetDateTime
+
+/**
+ * The most recent event a user hasn't yet acknowledged for a
+ * [PlanningApplication] — its presence (non-`null` on the row) is what marks
+ * a row "unread" throughout `:presentation` (the client-derived unread count
+ * and the unread dot both key off this, never `totalUnreadCount`). [type] is
+ * kept as the raw server string (`"NewApplication"` / `"DecisionUpdate"`) —
+ * deliberately not modelled as a closed set, matching iOS. Port of iOS
+ * `LatestUnreadEvent` (GH#775).
+ */
+public data class LatestUnreadEvent(
+    public val type: String,
+    public val decision: String? = null,
+    public val createdAt: OffsetDateTime,
+)

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/LocalAuthority.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/LocalAuthority.kt
@@ -1,0 +1,15 @@
+package uk.towncrierapp.domain.applications
+
+/**
+ * The local planning authority a [PlanningApplication] belongs to. [slug] (the
+ * human-readable authority identifier used in share URLs and by-slug detail
+ * lookups) is only ever populated on detail reads (`GET
+ * /v1/applications/{authority}/{name}`) — list rows leave it `null`. Port of
+ * iOS `LocalAuthority` (GH#775).
+ */
+public data class LocalAuthority(
+    public val code: String,
+    public val name: String,
+    public val areaType: String? = null,
+    public val slug: String? = null,
+)

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/NotificationState.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/NotificationState.kt
@@ -1,0 +1,15 @@
+package uk.towncrierapp.domain.applications
+
+import java.time.OffsetDateTime
+
+/**
+ * `GET /v1/me/notification-state`'s payload (ADR 0035). [lastReadAt] is
+ * vestigial (kept only for wire parity). [totalUnreadCount] drives the OS
+ * app-icon badge ONLY (#777 D7) — the list screen's displayed unread count is
+ * always client-derived from loaded rows instead, never this field.
+ */
+public data class NotificationState(
+    public val lastReadAt: OffsetDateTime?,
+    public val version: Int,
+    public val totalUnreadCount: Int,
+)

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/NotificationStateRepository.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/NotificationStateRepository.kt
@@ -1,0 +1,18 @@
+package uk.towncrierapp.domain.applications
+
+/**
+ * Read state (ADR 0035). [markRead] and [markAllRead] take domain
+ * [PlanningApplicationId]s — the wire's `applicationUid`-key-holds-a-name
+ * misnomer and the int `authorityId` conversion are entirely a `:data`
+ * concern (see `ApiNotificationStateRepository`). Port of iOS
+ * `NotificationStateRepository`. The legacy `/advance` endpoint is
+ * deliberately NOT represented here.
+ */
+public interface NotificationStateRepository {
+    public suspend fun state(): NotificationState
+
+    /** Marks [ids] read. Capped at 500 ids per underlying request by the `:data` implementation. */
+    public suspend fun markRead(ids: List<PlanningApplicationId>)
+
+    public suspend fun markAllRead()
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/OfflineAwareRepository.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/OfflineAwareRepository.kt
@@ -55,7 +55,8 @@ public class OfflineAwareRepository(
         name: String,
     ): PlanningApplication = remote.detail(authority, name)
 
-    private fun isFresh(cached: CachedApplicationPage): Boolean = Duration.between(cached.cachedAt, clock.instant()) < TTL
+    private fun isFresh(cached: CachedApplicationPage): Boolean =
+        Duration.between(cached.cachedAt, clock.instant()) < TTL
 
     public companion object {
         public val TTL: Duration = Duration.ofSeconds(900)

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/OfflineAwareRepository.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/OfflineAwareRepository.kt
@@ -1,0 +1,63 @@
+package uk.towncrierapp.domain.applications
+
+import kotlinx.coroutines.CancellationException
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import java.time.Clock
+import java.time.Duration
+
+/**
+ * A 900s TTL read-through cache in front of [remote]'s first-page (param-less,
+ * `cursor == null`) fetch, keyed by [WatchZoneId] alone — regardless of which
+ * [ApplicationSortOrder]/[ApplicationFilter] produced it (epic #770 parity: the
+ * cache is "the last known good snapshot for this zone", not sort/filter-
+ * aware). A non-null `cursor` (a pagination continuation) always bypasses the
+ * cache entirely, going straight to [remote].
+ *
+ * Failure handling: ANY [DomainError] from [remote] (not just
+ * [DomainError.NetworkUnavailable]) falls back to a cached entry when one
+ * exists, however stale — this is deliberately broader than "network errors
+ * only", matching iOS `OfflineAwareRepository`. With no cached entry to fall
+ * back to, the original error propagates unchanged (so a genuine offline
+ * failure surfaces as [DomainError.NetworkUnavailable], not something
+ * misleading). [detail] is a plain, uncached pass-through — only the zone
+ * application list is cached. Port of iOS `OfflineAwareRepository` (GH#775).
+ */
+public class OfflineAwareRepository(
+    private val remote: PlanningApplicationRepository,
+    private val cache: ApplicationCacheStore,
+    private val clock: Clock = Clock.systemUTC(),
+) : PlanningApplicationRepository {
+    override suspend fun applications(
+        zoneId: WatchZoneId,
+        sort: ApplicationSortOrder,
+        filter: ApplicationFilter,
+        cursor: String?,
+    ): ApplicationPage {
+        if (cursor != null) return remote.applications(zoneId, sort, filter, cursor)
+
+        val cached = cache.get(zoneId)
+        if (cached != null && isFresh(cached)) return cached.page
+
+        return try {
+            val page = remote.applications(zoneId, sort, filter, cursor = null)
+            cache.put(zoneId, CachedApplicationPage(page, cachedAt = clock.instant()))
+            page
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: DomainError) {
+            cached?.page ?: throw e
+        }
+    }
+
+    override suspend fun detail(
+        authority: String,
+        name: String,
+    ): PlanningApplication = remote.detail(authority, name)
+
+    private fun isFresh(cached: CachedApplicationPage): Boolean = Duration.between(cached.cachedAt, clock.instant()) < TTL
+
+    public companion object {
+        public val TTL: Duration = Duration.ofSeconds(900)
+    }
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/PlanningApplication.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/PlanningApplication.kt
@@ -1,0 +1,28 @@
+package uk.towncrierapp.domain.applications
+
+import uk.towncrierapp.domain.watchzones.Coordinate
+import java.time.LocalDate
+
+/**
+ * A single PlanIt planning application, as browsed from a watch zone's list,
+ * a saved-applications row, or a by-id/by-slug detail fetch. [reference] is
+ * the display case reference — the same value backing [id]'s
+ * [PlanningApplicationId.name], kept as its own field so the presentation
+ * layer never has to reach into [id] to render the fields card. [location] is
+ * `null` when the row carries no coordinate; [portalUrl] is `null` when
+ * PlanIt has no external council-portal link for this application. Port of
+ * iOS `PlanningApplication` (GH#775).
+ */
+public data class PlanningApplication(
+    public val id: PlanningApplicationId,
+    public val reference: String,
+    public val authority: LocalAuthority,
+    public val status: ApplicationStatus,
+    public val receivedDate: LocalDate,
+    public val description: String,
+    public val address: String,
+    public val location: Coordinate? = null,
+    public val portalUrl: String? = null,
+    public val statusHistory: List<StatusEvent> = emptyList(),
+    public val latestUnreadEvent: LatestUnreadEvent? = null,
+)

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/PlanningApplicationId.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/PlanningApplicationId.kt
@@ -1,0 +1,24 @@
+package uk.towncrierapp.domain.applications
+
+/**
+ * A planning application's identity: [authority] (the decimal local-authority
+ * area id, as a string) and [name] (the PlanIt case reference, e.g.
+ * `"24/0001"` — itself routinely containing further slashes). [value] is the
+ * canonical `"authority/name"` wire encoding used as the saved-applications
+ * path segment (percent-encoded there — see `ApiSavedApplicationRepository`)
+ * and as the reconstruction key for saved-application rows (GH#775; tc-jjl4:
+ * saved-state comparison must use this reconstructed id, not a raw uid
+ * string). Port of iOS `PlanningApplicationId`.
+ */
+public data class PlanningApplicationId(
+    public val authority: String,
+    public val name: String,
+) {
+    public val value: String get() = "$authority/$name"
+
+    public companion object {
+        /** Splits on the FIRST `/` only — [name] itself may contain further slashes. */
+        public fun parse(raw: String): PlanningApplicationId =
+            PlanningApplicationId(authority = raw.substringBefore("/"), name = raw.substringAfter("/"))
+    }
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/PlanningApplicationRepository.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/PlanningApplicationRepository.kt
@@ -1,0 +1,28 @@
+package uk.towncrierapp.domain.applications
+
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+
+/**
+ * Browses a zone's planning applications and fetches a single application's
+ * detail. Port of iOS `ApplicationRepository`.
+ */
+public interface PlanningApplicationRepository {
+    /**
+     * A page of [zoneId]'s applications under [sort]/[filter]. `cursor ==
+     * null` requests the first page — the ONLY shape
+     * [OfflineAwareRepository] caches; a non-null [cursor] (a continuation
+     * fetch) always bypasses the cache entirely.
+     */
+    public suspend fun applications(
+        zoneId: WatchZoneId,
+        sort: ApplicationSortOrder,
+        filter: ApplicationFilter = ApplicationFilter.All,
+        cursor: String? = null,
+    ): ApplicationPage
+
+    /** By-id or by-slug detail fetch — [authority] may be either the decimal area id or the authority slug. */
+    public suspend fun detail(
+        authority: String,
+        name: String,
+    ): PlanningApplication
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/SavedApplication.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/SavedApplication.kt
@@ -1,0 +1,19 @@
+package uk.towncrierapp.domain.applications
+
+import java.time.OffsetDateTime
+
+/**
+ * A row from `GET /v1/me/saved-applications`. [applicationUid] is always the
+ * RECONSTRUCTED [PlanningApplicationId] (tc-jjl4: saved-state comparison must
+ * use this, never a raw uid string) — the field name is kept as `Uid` for
+ * parity with the wire/iOS naming, even though its type is structured, not a
+ * bare string. A `null` [application] means a legacy save whose payload
+ * predates this field being populated server-side; those rows are dropped
+ * from display entirely, never shown as an empty/placeholder row. Port of iOS
+ * `SavedApplication` (GH#775).
+ */
+public data class SavedApplication(
+    public val applicationUid: PlanningApplicationId,
+    public val savedAt: OffsetDateTime,
+    public val application: PlanningApplication? = null,
+)

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/SavedApplicationRepository.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/SavedApplicationRepository.kt
@@ -1,0 +1,11 @@
+package uk.towncrierapp.domain.applications
+
+/** The user's flat, cross-zone saved-applications list. Port of iOS `SavedApplicationRepository`. */
+public interface SavedApplicationRepository {
+    /** Every saved row, in wire order — callers sort by `savedAt` DESC themselves (list is small, cross-zone, unpaged). */
+    public suspend fun savedApplications(): List<SavedApplication>
+
+    public suspend fun save(id: PlanningApplicationId)
+
+    public suspend fun unsave(id: PlanningApplicationId)
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/StatusEvent.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/StatusEvent.kt
@@ -1,0 +1,17 @@
+package uk.towncrierapp.domain.applications
+
+import java.time.LocalDate
+
+/**
+ * One point in a [PlanningApplication.statusHistory] timeline, CLIENT-
+ * synthesized from the list/detail row (there is no server-side history
+ * endpoint): a `startDate` row always produces an [ApplicationStatus.Undecided]
+ * event, and a `decidedDate` row produces a second event carrying the
+ * application's actual (decided) status — but only when
+ * [ApplicationStatus.isDecided] is true, otherwise it is folded away. Max 2
+ * points. Port of iOS `StatusEvent` (GH#775).
+ */
+public data class StatusEvent(
+    public val status: ApplicationStatus,
+    public val date: LocalDate,
+)

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/applications/ApplicationSortOrderTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/applications/ApplicationSortOrderTest.kt
@@ -1,0 +1,33 @@
+package uk.towncrierapp.domain.applications
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/** Wire-value round trip and the client-side default (GH#775: server default `distance` is NOT the client default). */
+class ApplicationSortOrderTest {
+    @Test
+    fun `wireValue matches the server's five sort tokens`() {
+        assertEquals("distance", ApplicationSortOrder.DISTANCE.wireValue)
+        assertEquals("newest", ApplicationSortOrder.NEWEST.wireValue)
+        assertEquals("oldest", ApplicationSortOrder.OLDEST.wireValue)
+        assertEquals("status", ApplicationSortOrder.STATUS.wireValue)
+        assertEquals("recent-activity", ApplicationSortOrder.RECENT_ACTIVITY.wireValue)
+    }
+
+    @Test
+    fun `fromWireValue is the inverse of wireValue for every case`() {
+        ApplicationSortOrder.entries.forEach { sort ->
+            assertEquals(sort, ApplicationSortOrder.fromWireValue(sort.wireValue))
+        }
+    }
+
+    @Test
+    fun `fromWireValue falls back to the client default for an unrecognised value`() {
+        assertEquals(ApplicationSortOrder.DEFAULT, ApplicationSortOrder.fromWireValue("made-up"))
+    }
+
+    @Test
+    fun `the client default is recent-activity, not the server default distance`() {
+        assertEquals(ApplicationSortOrder.RECENT_ACTIVITY, ApplicationSortOrder.DEFAULT)
+    }
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/applications/ApplicationStatusTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/applications/ApplicationStatusTest.kt
@@ -1,0 +1,74 @@
+package uk.towncrierapp.domain.applications
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * PlanIt `app_state` raw-value decode, incl. the `unknown` fallback for any
+ * genuinely unrecognised value, and the [isDecided] classification that
+ * drives `statusHistory` synthesis (GH#775).
+ */
+class ApplicationStatusTest {
+    @Test
+    fun `fromWireValue decodes every known raw value`() {
+        assertEquals(ApplicationStatus.Undecided, ApplicationStatus.fromWireValue("Undecided"))
+        assertEquals(ApplicationStatus.Permitted, ApplicationStatus.fromWireValue("Permitted"))
+        assertEquals(ApplicationStatus.Conditions, ApplicationStatus.fromWireValue("Conditions"))
+        assertEquals(ApplicationStatus.Rejected, ApplicationStatus.fromWireValue("Rejected"))
+        assertEquals(ApplicationStatus.Withdrawn, ApplicationStatus.fromWireValue("Withdrawn"))
+        assertEquals(ApplicationStatus.Appealed, ApplicationStatus.fromWireValue("Appealed"))
+        assertEquals(ApplicationStatus.Unresolved, ApplicationStatus.fromWireValue("Unresolved"))
+        assertEquals(ApplicationStatus.Referred, ApplicationStatus.fromWireValue("Referred"))
+        assertEquals(ApplicationStatus.NotAvailable, ApplicationStatus.fromWireValue("Not Available"))
+    }
+
+    @Test
+    fun `fromWireValue falls back to Unknown for a genuinely unrecognised value`() {
+        val status = ApplicationStatus.fromWireValue("SomeFutureState")
+
+        val unknown = assertIs<ApplicationStatus.Unknown>(status)
+        assertEquals("SomeFutureState", unknown.raw)
+    }
+
+    @Test
+    fun `wireValue round-trips every known status`() {
+        val known =
+            listOf(
+                ApplicationStatus.Undecided,
+                ApplicationStatus.Permitted,
+                ApplicationStatus.Conditions,
+                ApplicationStatus.Rejected,
+                ApplicationStatus.Withdrawn,
+                ApplicationStatus.Appealed,
+                ApplicationStatus.Unresolved,
+                ApplicationStatus.Referred,
+                ApplicationStatus.NotAvailable,
+            )
+        known.forEach { status ->
+            assertEquals(status, ApplicationStatus.fromWireValue(status.wireValue))
+        }
+    }
+
+    @Test
+    fun `wireValue for Unknown is the original raw string`() {
+        assertEquals("SomeFutureState", ApplicationStatus.Unknown("SomeFutureState").wireValue)
+    }
+
+    @Test
+    fun `isDecided is true only for the five decided statuses`() {
+        assertTrue(ApplicationStatus.Permitted.isDecided)
+        assertTrue(ApplicationStatus.Conditions.isDecided)
+        assertTrue(ApplicationStatus.Rejected.isDecided)
+        assertTrue(ApplicationStatus.Withdrawn.isDecided)
+        assertTrue(ApplicationStatus.Appealed.isDecided)
+
+        assertFalse(ApplicationStatus.Undecided.isDecided)
+        assertFalse(ApplicationStatus.Unresolved.isDecided)
+        assertFalse(ApplicationStatus.Referred.isDecided)
+        assertFalse(ApplicationStatus.NotAvailable.isDecided)
+        assertFalse(ApplicationStatus.Unknown("SomeFutureState").isDecided)
+    }
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/applications/OfflineAwareRepositoryTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/applications/OfflineAwareRepositoryTest.kt
@@ -45,7 +45,10 @@ class OfflineAwareRepositoryTest {
             val remote = FakePlanningApplicationRepository().apply { applicationsResult = anApplicationPage() }
             val cache = FakeApplicationCacheStore()
             cache.entries[zoneId] =
-                CachedApplicationPage(anApplicationPage(applications = emptyList()), cachedAt = fixedNow.minusSeconds(900))
+                CachedApplicationPage(
+                    anApplicationPage(applications = emptyList()),
+                    cachedAt = fixedNow.minusSeconds(900),
+                )
             val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
 
             sut.applications(zoneId, ApplicationSortOrder.RECENT_ACTIVITY)
@@ -60,7 +63,10 @@ class OfflineAwareRepositoryTest {
             val remote = FakePlanningApplicationRepository().apply { applicationsResult = freshPage }
             val cache = FakeApplicationCacheStore()
             cache.entries[zoneId] =
-                CachedApplicationPage(anApplicationPage(applications = emptyList()), cachedAt = fixedNow.minusSeconds(901))
+                CachedApplicationPage(
+                    anApplicationPage(applications = emptyList()),
+                    cachedAt = fixedNow.minusSeconds(901),
+                )
             val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
 
             val result = sut.applications(zoneId, ApplicationSortOrder.RECENT_ACTIVITY)
@@ -74,7 +80,11 @@ class OfflineAwareRepositoryTest {
     fun `a stale cache entry is served when the remote fetch fails offline (stale-offline)`() =
         runTest {
             val stalePage = anApplicationPage()
-            val remote = FakePlanningApplicationRepository().apply { applicationsFailWith = DomainError.NetworkUnavailable }
+            val remote =
+                FakePlanningApplicationRepository().apply {
+                    applicationsFailWith =
+                        DomainError.NetworkUnavailable
+                }
             val cache = FakeApplicationCacheStore()
             cache.entries[zoneId] = CachedApplicationPage(stalePage, cachedAt = fixedNow.minusSeconds(901))
             val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
@@ -87,7 +97,11 @@ class OfflineAwareRepositoryTest {
     @Test
     fun `no cache entry and an offline remote failure throws NetworkUnavailable (no-cache-offline)`() =
         runTest {
-            val remote = FakePlanningApplicationRepository().apply { applicationsFailWith = DomainError.NetworkUnavailable }
+            val remote =
+                FakePlanningApplicationRepository().apply {
+                    applicationsFailWith =
+                        DomainError.NetworkUnavailable
+                }
             val cache = FakeApplicationCacheStore()
             val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
 
@@ -100,7 +114,11 @@ class OfflineAwareRepositoryTest {
     fun `a cached entry is served when an online (non-network) remote failure occurs`() =
         runTest {
             val cachedPage = anApplicationPage()
-            val remote = FakePlanningApplicationRepository().apply { applicationsFailWith = DomainError.ServerError(500, "boom") }
+            val remote =
+                FakePlanningApplicationRepository().apply {
+                    applicationsFailWith =
+                        DomainError.ServerError(500, "boom")
+                }
             val cache = FakeApplicationCacheStore()
             cache.entries[zoneId] = CachedApplicationPage(cachedPage, cachedAt = fixedNow.minusSeconds(901))
             val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
@@ -113,7 +131,11 @@ class OfflineAwareRepositoryTest {
     @Test
     fun `no cache entry and a non-network remote failure propagates the original error`() =
         runTest {
-            val remote = FakePlanningApplicationRepository().apply { applicationsFailWith = DomainError.ServerError(500, "boom") }
+            val remote =
+                FakePlanningApplicationRepository().apply {
+                    applicationsFailWith =
+                        DomainError.ServerError(500, "boom")
+                }
             val cache = FakeApplicationCacheStore()
             val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
 
@@ -129,7 +151,8 @@ class OfflineAwareRepositoryTest {
         runTest {
             val remote = FakePlanningApplicationRepository().apply { applicationsResult = anApplicationPage() }
             val cache = FakeApplicationCacheStore()
-            cache.entries[zoneId] = CachedApplicationPage(anApplicationPage(applications = emptyList()), cachedAt = fixedNow)
+            cache.entries[zoneId] =
+                CachedApplicationPage(anApplicationPage(applications = emptyList()), cachedAt = fixedNow)
             val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
 
             sut.applications(zoneId, ApplicationSortOrder.RECENT_ACTIVITY, cursor = "next-page-cursor")
@@ -137,7 +160,12 @@ class OfflineAwareRepositoryTest {
             assertEquals(1, remote.applicationsCalls.size)
             assertEquals("next-page-cursor", remote.applicationsCalls.single().cursor)
             // The cache is untouched by a paged fetch — still holds only the original first-page entry.
-            assertEquals(0, cache.entries.getValue(zoneId).page.applications.size)
+            assertEquals(
+                0,
+                cache.entries
+                    .getValue(zoneId)
+                    .page.applications.size,
+            )
         }
 
     @Test

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/applications/OfflineAwareRepositoryTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/applications/OfflineAwareRepositoryTest.kt
@@ -1,0 +1,161 @@
+package uk.towncrierapp.domain.applications
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The 900s TTL cache decorator over [PlanningApplicationRepository]'s
+ * first-page (param-less) fetch, keyed by zone id only. Port of iOS
+ * `OfflineAwareRepository` (GH#775).
+ */
+class OfflineAwareRepositoryTest {
+    private val zoneId = WatchZoneId("wz-1")
+    private val fixedNow = Instant.parse("2026-01-01T12:00:00Z")
+
+    private fun clockAt(instant: Instant): Clock = Clock.fixed(instant, ZoneOffset.UTC)
+
+    @Test
+    fun `a fresh cache entry is served without calling the remote repository`() =
+        runTest {
+            val remote = FakePlanningApplicationRepository()
+            val cache = FakeApplicationCacheStore()
+            val cachedPage = anApplicationPage()
+            cache.entries[zoneId] = CachedApplicationPage(cachedPage, cachedAt = fixedNow.minusSeconds(60))
+            val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
+
+            val result = sut.applications(zoneId, ApplicationSortOrder.RECENT_ACTIVITY)
+
+            assertEquals(cachedPage, result)
+            assertTrue(remote.applicationsCalls.isEmpty())
+        }
+
+    @Test
+    fun `a cache entry exactly at the 900s TTL boundary is treated as stale`() =
+        runTest {
+            val remote = FakePlanningApplicationRepository().apply { applicationsResult = anApplicationPage() }
+            val cache = FakeApplicationCacheStore()
+            cache.entries[zoneId] =
+                CachedApplicationPage(anApplicationPage(applications = emptyList()), cachedAt = fixedNow.minusSeconds(900))
+            val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
+
+            sut.applications(zoneId, ApplicationSortOrder.RECENT_ACTIVITY)
+
+            assertEquals(1, remote.applicationsCalls.size)
+        }
+
+    @Test
+    fun `a stale cache entry is refreshed from remote and re-cached on success`() =
+        runTest {
+            val freshPage = anApplicationPage()
+            val remote = FakePlanningApplicationRepository().apply { applicationsResult = freshPage }
+            val cache = FakeApplicationCacheStore()
+            cache.entries[zoneId] =
+                CachedApplicationPage(anApplicationPage(applications = emptyList()), cachedAt = fixedNow.minusSeconds(901))
+            val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
+
+            val result = sut.applications(zoneId, ApplicationSortOrder.RECENT_ACTIVITY)
+
+            assertEquals(freshPage, result)
+            assertEquals(freshPage, cache.entries.getValue(zoneId).page)
+            assertEquals(fixedNow, cache.entries.getValue(zoneId).cachedAt)
+        }
+
+    @Test
+    fun `a stale cache entry is served when the remote fetch fails offline (stale-offline)`() =
+        runTest {
+            val stalePage = anApplicationPage()
+            val remote = FakePlanningApplicationRepository().apply { applicationsFailWith = DomainError.NetworkUnavailable }
+            val cache = FakeApplicationCacheStore()
+            cache.entries[zoneId] = CachedApplicationPage(stalePage, cachedAt = fixedNow.minusSeconds(901))
+            val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
+
+            val result = sut.applications(zoneId, ApplicationSortOrder.RECENT_ACTIVITY)
+
+            assertEquals(stalePage, result)
+        }
+
+    @Test
+    fun `no cache entry and an offline remote failure throws NetworkUnavailable (no-cache-offline)`() =
+        runTest {
+            val remote = FakePlanningApplicationRepository().apply { applicationsFailWith = DomainError.NetworkUnavailable }
+            val cache = FakeApplicationCacheStore()
+            val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
+
+            assertIs<DomainError.NetworkUnavailable>(
+                assertFailsWith<DomainError> { sut.applications(zoneId, ApplicationSortOrder.RECENT_ACTIVITY) },
+            )
+        }
+
+    @Test
+    fun `a cached entry is served when an online (non-network) remote failure occurs`() =
+        runTest {
+            val cachedPage = anApplicationPage()
+            val remote = FakePlanningApplicationRepository().apply { applicationsFailWith = DomainError.ServerError(500, "boom") }
+            val cache = FakeApplicationCacheStore()
+            cache.entries[zoneId] = CachedApplicationPage(cachedPage, cachedAt = fixedNow.minusSeconds(901))
+            val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
+
+            val result = sut.applications(zoneId, ApplicationSortOrder.RECENT_ACTIVITY)
+
+            assertEquals(cachedPage, result)
+        }
+
+    @Test
+    fun `no cache entry and a non-network remote failure propagates the original error`() =
+        runTest {
+            val remote = FakePlanningApplicationRepository().apply { applicationsFailWith = DomainError.ServerError(500, "boom") }
+            val cache = FakeApplicationCacheStore()
+            val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
+
+            val error =
+                assertIs<DomainError.ServerError>(
+                    assertFailsWith<DomainError> { sut.applications(zoneId, ApplicationSortOrder.RECENT_ACTIVITY) },
+                )
+            assertEquals(500, error.status)
+        }
+
+    @Test
+    fun `a paged fetch (non-null cursor) bypasses the cache entirely`() =
+        runTest {
+            val remote = FakePlanningApplicationRepository().apply { applicationsResult = anApplicationPage() }
+            val cache = FakeApplicationCacheStore()
+            cache.entries[zoneId] = CachedApplicationPage(anApplicationPage(applications = emptyList()), cachedAt = fixedNow)
+            val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
+
+            sut.applications(zoneId, ApplicationSortOrder.RECENT_ACTIVITY, cursor = "next-page-cursor")
+
+            assertEquals(1, remote.applicationsCalls.size)
+            assertEquals("next-page-cursor", remote.applicationsCalls.single().cursor)
+            // The cache is untouched by a paged fetch — still holds only the original first-page entry.
+            assertEquals(0, cache.entries.getValue(zoneId).page.applications.size)
+        }
+
+    @Test
+    fun `detail delegates straight to the remote repository, uncached`() =
+        runTest {
+            val detail = aPlanningApplication()
+            val remote = FakePlanningApplicationRepository().apply { detailResult = detail }
+            val cache = FakeApplicationCacheStore()
+            val sut = OfflineAwareRepository(remote, cache, clockAt(fixedNow))
+
+            val result = sut.detail("42", "24/0001")
+
+            assertEquals(detail, result)
+            assertEquals("42" to "24/0001", remote.detailCalls.single())
+        }
+
+    @Test
+    fun `the TTL constant is 900 seconds`() {
+        assertEquals(Duration.ofSeconds(900), OfflineAwareRepository.TTL)
+    }
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/applications/PlanningApplicationIdTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/applications/PlanningApplicationIdTest.kt
@@ -1,0 +1,34 @@
+package uk.towncrierapp.domain.applications
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * Canonical `"authority/name"` encoding/decoding. [PlanningApplicationId.parse]
+ * splits on the FIRST `/` only, because [PlanningApplicationId.name] (the
+ * PlanIt case reference) routinely contains further slashes itself, e.g.
+ * `"24/0001"` (GH#775).
+ */
+class PlanningApplicationIdTest {
+    @Test
+    fun `value joins authority and name with a slash`() {
+        val id = PlanningApplicationId(authority = "42", name = "24/0001")
+
+        assertEquals("42/24/0001", id.value)
+    }
+
+    @Test
+    fun `parse splits on the first slash only, keeping further slashes in name`() {
+        val id = PlanningApplicationId.parse("42/24/0001/FUL")
+
+        assertEquals("42", id.authority)
+        assertEquals("24/0001/FUL", id.name)
+    }
+
+    @Test
+    fun `parse is the inverse of value`() {
+        val id = PlanningApplicationId(authority = "7", name = "S/24/0099")
+
+        assertEquals(id, PlanningApplicationId.parse(id.value))
+    }
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/ApplicationFixtures.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/ApplicationFixtures.kt
@@ -1,0 +1,66 @@
+package uk.towncrierapp.domain.applications
+
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+/** Fixture factory for [PlanningApplicationId] — override only what a test cares about. */
+public fun aPlanningApplicationId(
+    authority: String = "42",
+    name: String = "24/0001",
+): PlanningApplicationId = PlanningApplicationId(authority, name)
+
+/** Fixture factory for [LocalAuthority]. */
+public fun aLocalAuthority(
+    code: String = "42",
+    name: String = "Camden",
+    areaType: String? = null,
+    slug: String? = null,
+): LocalAuthority = LocalAuthority(code, name, areaType, slug)
+
+/** Fixture factory for [PlanningApplication] — a pending application with no history, matching a freshly-submitted row. */
+public fun aPlanningApplication(
+    id: PlanningApplicationId = aPlanningApplicationId(),
+    reference: String = id.name,
+    authority: LocalAuthority = aLocalAuthority(code = id.authority),
+    status: ApplicationStatus = ApplicationStatus.Undecided,
+    receivedDate: LocalDate = LocalDate.of(2026, 1, 15),
+    description: String = "Two-storey rear extension",
+    address: String = "1 Example Street, Camden",
+    location: uk.towncrierapp.domain.watchzones.Coordinate? = null,
+    portalUrl: String? = null,
+    statusHistory: List<StatusEvent> = listOf(StatusEvent(ApplicationStatus.Undecided, receivedDate)),
+    latestUnreadEvent: LatestUnreadEvent? = null,
+): PlanningApplication =
+    PlanningApplication(
+        id = id,
+        reference = reference,
+        authority = authority,
+        status = status,
+        receivedDate = receivedDate,
+        description = description,
+        address = address,
+        location = location,
+        portalUrl = portalUrl,
+        statusHistory = statusHistory,
+        latestUnreadEvent = latestUnreadEvent,
+    )
+
+/** Fixture factory for [LatestUnreadEvent]. */
+public fun aLatestUnreadEvent(
+    type: String = "NewApplication",
+    decision: String? = null,
+    createdAt: OffsetDateTime = OffsetDateTime.parse("2026-01-15T09:00:00Z"),
+): LatestUnreadEvent = LatestUnreadEvent(type, decision, createdAt)
+
+/** Fixture factory for [SavedApplication]. */
+public fun aSavedApplication(
+    applicationUid: PlanningApplicationId = aPlanningApplicationId(),
+    savedAt: OffsetDateTime = OffsetDateTime.parse("2026-01-16T09:00:00Z"),
+    application: PlanningApplication? = aPlanningApplication(id = applicationUid),
+): SavedApplication = SavedApplication(applicationUid, savedAt, application)
+
+/** Fixture factory for [ApplicationPage]. */
+public fun anApplicationPage(
+    applications: List<PlanningApplication> = listOf(aPlanningApplication()),
+    nextCursor: String? = null,
+): ApplicationPage = ApplicationPage(applications, nextCursor)

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakeApplicationCacheStore.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakeApplicationCacheStore.kt
@@ -1,0 +1,29 @@
+package uk.towncrierapp.domain.applications
+
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+
+/** Hand-written fake for [ApplicationCacheStore] — state-based, per testing.md conventions. */
+public class FakeApplicationCacheStore : ApplicationCacheStore {
+    public val entries: MutableMap<WatchZoneId, CachedApplicationPage> = mutableMapOf()
+    public val invalidateCalls: MutableList<WatchZoneId> = mutableListOf()
+    public var invalidateAllCallCount: Int = 0
+
+    override suspend fun get(zoneId: WatchZoneId): CachedApplicationPage? = entries[zoneId]
+
+    override suspend fun put(
+        zoneId: WatchZoneId,
+        entry: CachedApplicationPage,
+    ) {
+        entries[zoneId] = entry
+    }
+
+    override suspend fun invalidate(zoneId: WatchZoneId) {
+        invalidateCalls += zoneId
+        entries.remove(zoneId)
+    }
+
+    override suspend fun invalidateAll() {
+        invalidateAllCallCount++
+        entries.clear()
+    }
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakeApplicationListPreferencesStore.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakeApplicationListPreferencesStore.kt
@@ -1,0 +1,21 @@
+package uk.towncrierapp.domain.applications
+
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+
+/** Hand-written fake for [ApplicationListPreferencesStore] — state-based, per testing.md conventions. */
+public class FakeApplicationListPreferencesStore(
+    public var storedSort: ApplicationSortOrder? = null,
+    public var storedZoneId: WatchZoneId? = null,
+) : ApplicationListPreferencesStore {
+    override suspend fun readSort(): ApplicationSortOrder? = storedSort
+
+    override suspend fun writeSort(sort: ApplicationSortOrder) {
+        storedSort = sort
+    }
+
+    override suspend fun readLastSelectedZoneId(): WatchZoneId? = storedZoneId
+
+    override suspend fun writeLastSelectedZoneId(zoneId: WatchZoneId) {
+        storedZoneId = zoneId
+    }
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakeNotificationStateRepository.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakeNotificationStateRepository.kt
@@ -1,0 +1,31 @@
+package uk.towncrierapp.domain.applications
+
+import uk.towncrierapp.domain.auth.DomainError
+import java.time.OffsetDateTime
+
+/** Hand-written fake for [NotificationStateRepository] — state-based, per testing.md conventions. */
+public class FakeNotificationStateRepository(
+    public var stateResult: NotificationState = NotificationState(lastReadAt = OffsetDateTime.now(), version = 1, totalUnreadCount = 0),
+) : NotificationStateRepository {
+    public var stateFailWith: DomainError? = null
+    public var markReadFailWith: DomainError? = null
+    public var markAllReadFailWith: DomainError? = null
+
+    public val markReadCalls: MutableList<List<PlanningApplicationId>> = mutableListOf()
+    public var markAllReadCallCount: Int = 0
+
+    override suspend fun state(): NotificationState {
+        stateFailWith?.let { throw it }
+        return stateResult
+    }
+
+    override suspend fun markRead(ids: List<PlanningApplicationId>) {
+        markReadCalls += ids
+        markReadFailWith?.let { throw it }
+    }
+
+    override suspend fun markAllRead() {
+        markAllReadCallCount++
+        markAllReadFailWith?.let { throw it }
+    }
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakeNotificationStateRepository.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakeNotificationStateRepository.kt
@@ -5,7 +5,8 @@ import java.time.OffsetDateTime
 
 /** Hand-written fake for [NotificationStateRepository] — state-based, per testing.md conventions. */
 public class FakeNotificationStateRepository(
-    public var stateResult: NotificationState = NotificationState(lastReadAt = OffsetDateTime.now(), version = 1, totalUnreadCount = 0),
+    public var stateResult: NotificationState =
+        NotificationState(lastReadAt = OffsetDateTime.now(), version = 1, totalUnreadCount = 0),
 ) : NotificationStateRepository {
     public var stateFailWith: DomainError? = null
     public var markReadFailWith: DomainError? = null

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakePlanningApplicationRepository.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakePlanningApplicationRepository.kt
@@ -1,0 +1,43 @@
+package uk.towncrierapp.domain.applications
+
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+
+/** One recorded call to [FakePlanningApplicationRepository.applications]. */
+public data class ApplicationsCall(
+    public val zoneId: WatchZoneId,
+    public val sort: ApplicationSortOrder,
+    public val filter: ApplicationFilter,
+    public val cursor: String?,
+)
+
+/** Hand-written fake for [PlanningApplicationRepository] — state-based, per testing.md conventions. */
+public class FakePlanningApplicationRepository : PlanningApplicationRepository {
+    public var applicationsResult: ApplicationPage = ApplicationPage(emptyList())
+    public var applicationsFailWith: DomainError? = null
+    public val applicationsCalls: MutableList<ApplicationsCall> = mutableListOf()
+
+    public var detailResult: PlanningApplication = aPlanningApplication()
+    public var detailFailWith: DomainError? = null
+    public val detailCalls: MutableList<Pair<String, String>> = mutableListOf()
+
+    override suspend fun applications(
+        zoneId: WatchZoneId,
+        sort: ApplicationSortOrder,
+        filter: ApplicationFilter,
+        cursor: String?,
+    ): ApplicationPage {
+        applicationsCalls += ApplicationsCall(zoneId, sort, filter, cursor)
+        applicationsFailWith?.let { throw it }
+        return applicationsResult
+    }
+
+    override suspend fun detail(
+        authority: String,
+        name: String,
+    ): PlanningApplication {
+        detailCalls += authority to name
+        detailFailWith?.let { throw it }
+        return detailResult
+    }
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakePlanningApplicationRepository.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakePlanningApplicationRepository.kt
@@ -21,6 +21,15 @@ public class FakePlanningApplicationRepository : PlanningApplicationRepository {
     public var detailFailWith: DomainError? = null
     public val detailCalls: MutableList<Pair<String, String>> = mutableListOf()
 
+    /**
+     * A cooperative gate hook run before [detail] returns — the "iOS
+     * spy-gate idiom" (testing.md) for re-entrancy tests. A test sets this to
+     * `{ someDeferred.await() }` to hold a call in flight until it explicitly
+     * releases it, so it can assert a second concurrent call was suppressed.
+     * A no-op by default.
+     */
+    public var beforeDetail: suspend () -> Unit = {}
+
     override suspend fun applications(
         zoneId: WatchZoneId,
         sort: ApplicationSortOrder,
@@ -37,6 +46,7 @@ public class FakePlanningApplicationRepository : PlanningApplicationRepository {
         name: String,
     ): PlanningApplication {
         detailCalls += authority to name
+        beforeDetail()
         detailFailWith?.let { throw it }
         return detailResult
     }

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakeSavedApplicationRepository.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakeSavedApplicationRepository.kt
@@ -1,0 +1,31 @@
+package uk.towncrierapp.domain.applications
+
+import uk.towncrierapp.domain.auth.DomainError
+
+/** Hand-written fake for [SavedApplicationRepository] — state-based, per testing.md conventions. */
+public class FakeSavedApplicationRepository(
+    public var stored: MutableList<SavedApplication> = mutableListOf(),
+) : SavedApplicationRepository {
+    public var savedApplicationsFailWith: DomainError? = null
+    public var saveFailWith: DomainError? = null
+    public var unsaveFailWith: DomainError? = null
+
+    public val saveCalls: MutableList<PlanningApplicationId> = mutableListOf()
+    public val unsaveCalls: MutableList<PlanningApplicationId> = mutableListOf()
+
+    override suspend fun savedApplications(): List<SavedApplication> {
+        savedApplicationsFailWith?.let { throw it }
+        return stored.toList()
+    }
+
+    override suspend fun save(id: PlanningApplicationId) {
+        saveCalls += id
+        saveFailWith?.let { throw it }
+    }
+
+    override suspend fun unsave(id: PlanningApplicationId) {
+        unsaveCalls += id
+        unsaveFailWith?.let { throw it }
+        stored.removeAll { it.applicationUid == id }
+    }
+}

--- a/mobile/android/gradle/libs.versions.toml
+++ b/mobile/android/gradle/libs.versions.toml
@@ -15,6 +15,10 @@ navigationCompose = "2.8.9"
 lifecycle = "2.8.7"
 activityCompose = "1.9.3"
 coreKtx = "1.15.0"
+# Chrome Custom Tabs for the application-detail "View on Council Portal"
+# button (epic #770 pre-resolved decision, GH#775) — not managed by the
+# Compose BOM, so pinned explicitly like every other dependency here.
+browser = "1.8.0"
 
 # kotlinx
 coroutines = "1.11.0"
@@ -53,6 +57,11 @@ compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
 compose-material-icons-core = { module = "androidx.compose.material:material-icons-core" }
+# The status-glyph set GH#775 needs (Schedule, Cancel, Undo, HelpOutline, ...)
+# isn't in material-icons-core's small default subset — extended is the
+# official androidx.compose.material superset, BOM-managed like core.
+compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
+androidx-browser = { module = "androidx.browser:browser", version.ref = "browser" }
 
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }

--- a/mobile/android/presentation/build.gradle.kts
+++ b/mobile/android/presentation/build.gradle.kts
@@ -53,8 +53,13 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
     implementation(libs.compose.material.icons.core)
+    // The status-glyph set GH#775 needs (Schedule, Cancel, Undo, HelpOutline,
+    // ...) isn't in core's small default subset.
+    implementation(libs.compose.material.icons.extended)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
+    // Chrome Custom Tabs for the application-detail "View on Council Portal" button (GH#775).
+    implementation(libs.androidx.browser)
     debugImplementation(libs.compose.ui.tooling)
 
     testImplementation(platform(libs.junit.bom))

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/DateDisplayFormatter.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/DateDisplayFormatter.kt
@@ -1,0 +1,18 @@
+package uk.towncrierapp.presentation.designsystem
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/**
+ * Absolute dates ONLY — no relative/"time ago" text anywhere in the app
+ * (byte-exact port of iOS `Date+TownCrier.swift`'s shared formatter). Any
+ * `OffsetDateTime`/`Instant` this formats has already been reduced to a UTC
+ * [LocalDate] by the data layer's mapping, so no timezone conversion happens
+ * here.
+ */
+public object DateDisplayFormatter {
+    private val formatter = DateTimeFormatter.ofPattern("d MMM yyyy", Locale.UK)
+
+    public fun format(date: LocalDate): String = date.format(formatter)
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/components/ApplicationRow.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/components/ApplicationRow.kt
@@ -1,0 +1,113 @@
+package uk.towncrierapp.presentation.designsystem.components
+
+import android.content.res.Configuration
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.applications.LatestUnreadEvent
+import uk.towncrierapp.domain.applications.LocalAuthority
+import uk.towncrierapp.domain.applications.PlanningApplication
+import uk.towncrierapp.domain.applications.PlanningApplicationId
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import java.time.LocalDate
+import java.time.OffsetDateTime
+
+/**
+ * A single applications-list row: status badge, address/description, and an
+ * 8dp leading unread dot in `tcAmber` when
+ * [PlanningApplication.latestUnreadEvent] is present (design-language skill —
+ * status is never color-alone, so [StatusBadge] always pairs its color with
+ * an icon and label too). Port of iOS `ApplicationRow` (GH#775).
+ */
+@Composable
+public fun ApplicationRow(
+    application: PlanningApplication,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = TownCrierSpacing.md, vertical = TownCrierSpacing.sm),
+        horizontalArrangement = Arrangement.spacedBy(TownCrierSpacing.sm),
+    ) {
+        UnreadDot(isUnread = application.latestUnreadEvent != null, modifier = Modifier.padding(top = 6.dp))
+        Column(modifier = Modifier.weight(1f), verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+            val display = statusDisplay(application.status)
+            StatusBadge(label = display.label, color = display.color, icon = display.icon)
+            Text(text = application.address, style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = application.description,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+@Composable
+private fun UnreadDot(
+    isUnread: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val color = if (isUnread) MaterialTheme.colorScheme.primary else Color.Transparent
+    Box(modifier = modifier.size(8.dp).background(color, CircleShape))
+}
+
+// Preview-only sample data — cannot reuse :domain's testFixtures from the
+// main source set (compose-ui.md: previews can't see test/testFixtures
+// source sets), so a small duplicate lives here instead.
+private val previewApplication =
+    PlanningApplication(
+        id = PlanningApplicationId("42", "24/0001"),
+        reference = "24/0001",
+        authority = LocalAuthority(code = "42", name = "Camden"),
+        status = ApplicationStatus.Undecided,
+        receivedDate = LocalDate.of(2026, 1, 15),
+        description = "Two-storey rear extension with roof lantern",
+        address = "1 Example Street, Camden, London",
+    )
+
+@Preview(name = "unread, light")
+@Preview(name = "unread, dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ApplicationRowUnreadPreview() {
+    TownCrierTheme {
+        ApplicationRow(
+            application =
+                previewApplication.copy(
+                    latestUnreadEvent = LatestUnreadEvent(type = "NewApplication", createdAt = OffsetDateTime.now()),
+                ),
+            onClick = {},
+        )
+    }
+}
+
+@Preview(name = "read")
+@Composable
+private fun ApplicationRowReadPreview() {
+    TownCrierTheme {
+        ApplicationRow(application = previewApplication, onClick = {})
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/components/StatusDisplay.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/components/StatusDisplay.kt
@@ -1,0 +1,56 @@
+package uk.towncrierapp.presentation.designsystem.components
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.HelpOutline
+import androidx.compose.material.icons.automirrored.filled.Undo
+import androidx.compose.material.icons.filled.Cancel
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Schedule
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.applications.wireValue
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+
+/** The resolved label/color/icon for one [ApplicationStatus] — feeds [StatusBadge] wherever a status renders. Port of iOS's status display mapping (GH#775). */
+public data class StatusDisplay(
+    public val label: String,
+    public val color: Color,
+    public val icon: ImageVector,
+)
+
+/**
+ * The exact status -> (label, token, icon) table from the design spec: the
+ * six known/actionable statuses get a friendly label and their own status
+ * color; [ApplicationStatus.Unresolved]/[ApplicationStatus.Referred]/
+ * [ApplicationStatus.NotAvailable] display AS-IS (their own wire value,
+ * server-supplied dynamic text — not a hardcoded UI string) in
+ * `tcTextTertiary`; a genuinely unrecognised [ApplicationStatus.Unknown]
+ * value falls back to the literal word "Unknown", also in `tcTextTertiary`.
+ */
+@Composable
+public fun statusDisplay(status: ApplicationStatus): StatusDisplay {
+    val colors = TownCrierTheme.colors
+    return when (status) {
+        ApplicationStatus.Undecided ->
+            StatusDisplay(stringResource(R.string.application_status_pending), colors.statusPending, Icons.Filled.Schedule)
+        ApplicationStatus.Permitted ->
+            StatusDisplay(stringResource(R.string.application_status_permitted), colors.statusPermitted, Icons.Filled.CheckCircle)
+        ApplicationStatus.Conditions ->
+            StatusDisplay(stringResource(R.string.application_status_conditions), colors.statusConditions, Icons.Filled.CheckCircle)
+        ApplicationStatus.Rejected ->
+            StatusDisplay(stringResource(R.string.application_status_rejected), colors.statusRejected, Icons.Filled.Cancel)
+        ApplicationStatus.Withdrawn ->
+            StatusDisplay(stringResource(R.string.application_status_withdrawn), colors.statusWithdrawn, Icons.AutoMirrored.Filled.Undo)
+        ApplicationStatus.Appealed ->
+            StatusDisplay(stringResource(R.string.application_status_appealed), colors.statusAppealed, Icons.Filled.Warning)
+        ApplicationStatus.Unresolved, ApplicationStatus.Referred, ApplicationStatus.NotAvailable ->
+            StatusDisplay(status.wireValue, colors.textTertiary, Icons.AutoMirrored.Filled.HelpOutline)
+        is ApplicationStatus.Unknown ->
+            StatusDisplay(stringResource(R.string.application_status_unknown), colors.textTertiary, Icons.AutoMirrored.Filled.HelpOutline)
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/components/StatusDisplay.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/components/StatusDisplay.kt
@@ -36,21 +36,64 @@ public data class StatusDisplay(
 public fun statusDisplay(status: ApplicationStatus): StatusDisplay {
     val colors = TownCrierTheme.colors
     return when (status) {
-        ApplicationStatus.Undecided ->
-            StatusDisplay(stringResource(R.string.application_status_pending), colors.statusPending, Icons.Filled.Schedule)
-        ApplicationStatus.Permitted ->
-            StatusDisplay(stringResource(R.string.application_status_permitted), colors.statusPermitted, Icons.Filled.CheckCircle)
-        ApplicationStatus.Conditions ->
-            StatusDisplay(stringResource(R.string.application_status_conditions), colors.statusConditions, Icons.Filled.CheckCircle)
-        ApplicationStatus.Rejected ->
-            StatusDisplay(stringResource(R.string.application_status_rejected), colors.statusRejected, Icons.Filled.Cancel)
-        ApplicationStatus.Withdrawn ->
-            StatusDisplay(stringResource(R.string.application_status_withdrawn), colors.statusWithdrawn, Icons.AutoMirrored.Filled.Undo)
-        ApplicationStatus.Appealed ->
-            StatusDisplay(stringResource(R.string.application_status_appealed), colors.statusAppealed, Icons.Filled.Warning)
-        ApplicationStatus.Unresolved, ApplicationStatus.Referred, ApplicationStatus.NotAvailable ->
+        ApplicationStatus.Undecided -> {
+            StatusDisplay(
+                stringResource(R.string.application_status_pending),
+                colors.statusPending,
+                Icons.Filled.Schedule,
+            )
+        }
+
+        ApplicationStatus.Permitted -> {
+            StatusDisplay(
+                stringResource(R.string.application_status_permitted),
+                colors.statusPermitted,
+                Icons.Filled.CheckCircle,
+            )
+        }
+
+        ApplicationStatus.Conditions -> {
+            StatusDisplay(
+                stringResource(R.string.application_status_conditions),
+                colors.statusConditions,
+                Icons.Filled.CheckCircle,
+            )
+        }
+
+        ApplicationStatus.Rejected -> {
+            StatusDisplay(
+                stringResource(R.string.application_status_rejected),
+                colors.statusRejected,
+                Icons.Filled.Cancel,
+            )
+        }
+
+        ApplicationStatus.Withdrawn -> {
+            StatusDisplay(
+                stringResource(R.string.application_status_withdrawn),
+                colors.statusWithdrawn,
+                Icons.AutoMirrored.Filled.Undo,
+            )
+        }
+
+        ApplicationStatus.Appealed -> {
+            StatusDisplay(
+                stringResource(R.string.application_status_appealed),
+                colors.statusAppealed,
+                Icons.Filled.Warning,
+            )
+        }
+
+        ApplicationStatus.Unresolved, ApplicationStatus.Referred, ApplicationStatus.NotAvailable -> {
             StatusDisplay(status.wireValue, colors.textTertiary, Icons.AutoMirrored.Filled.HelpOutline)
-        is ApplicationStatus.Unknown ->
-            StatusDisplay(stringResource(R.string.application_status_unknown), colors.textTertiary, Icons.AutoMirrored.Filled.HelpOutline)
+        }
+
+        is ApplicationStatus.Unknown -> {
+            StatusDisplay(
+                stringResource(R.string.application_status_unknown),
+                colors.textTertiary,
+                Icons.AutoMirrored.Filled.HelpOutline,
+            )
+        }
     }
 }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/components/StatusTimeline.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/components/StatusTimeline.kt
@@ -1,0 +1,77 @@
+package uk.towncrierapp.presentation.designsystem.components
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.applications.StatusEvent
+import uk.towncrierapp.presentation.designsystem.DateDisplayFormatter
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import java.time.LocalDate
+
+/**
+ * Renders the CLIENT-synthesized `statusHistory` (max 2 points: submitted,
+ * then decided) as a Monzo-activity-feed-style vertical list — a
+ * Transaction-feed list per the design-language skill, not a graphical
+ * connector timeline. Dates are absolute only via [DateDisplayFormatter],
+ * never relative. Port of iOS `StatusTimelineView` (GH#775).
+ */
+@Composable
+public fun StatusTimeline(
+    events: List<StatusEvent>,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.md)) {
+        events.forEach { event ->
+            val display = statusDisplay(event.status)
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(TownCrierSpacing.sm),
+            ) {
+                Icon(imageVector = display.icon, contentDescription = null, tint = display.color, modifier = Modifier.size(20.dp))
+                Column {
+                    Text(text = display.label, style = MaterialTheme.typography.bodyLarge)
+                    Text(
+                        text = DateDisplayFormatter.format(event.date),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(name = "two points, light")
+@Preview(name = "two points, dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun StatusTimelineTwoPointsPreview() {
+    TownCrierTheme {
+        StatusTimeline(
+            events =
+                listOf(
+                    StatusEvent(ApplicationStatus.Undecided, LocalDate.of(2026, 1, 15)),
+                    StatusEvent(ApplicationStatus.Permitted, LocalDate.of(2026, 3, 2)),
+                ),
+        )
+    }
+}
+
+@Preview(name = "one point (undecided only)")
+@Composable
+private fun StatusTimelineOnePointPreview() {
+    TownCrierTheme {
+        StatusTimeline(events = listOf(StatusEvent(ApplicationStatus.Undecided, LocalDate.of(2026, 1, 15))))
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/components/StatusTimeline.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/designsystem/components/StatusTimeline.kt
@@ -39,7 +39,12 @@ public fun StatusTimeline(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(TownCrierSpacing.sm),
             ) {
-                Icon(imageVector = display.icon, contentDescription = null, tint = display.color, modifier = Modifier.size(20.dp))
+                Icon(
+                    imageVector = display.icon,
+                    contentDescription = null,
+                    tint = display.color,
+                    modifier = Modifier.size(20.dp),
+                )
                 Column {
                     Text(text = display.label, style = MaterialTheme.typography.bodyLarge)
                     Text(

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailScreen.kt
@@ -1,0 +1,278 @@
+package uk.towncrierapp.presentation.features.applicationdetail
+
+import android.content.Context
+import android.content.Intent
+import android.content.res.Configuration
+import android.net.Uri
+import androidx.browser.customtabs.CustomTabsIntent
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.BookmarkBorder
+import androidx.compose.material.icons.filled.Share
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.applications.LocalAuthority
+import uk.towncrierapp.domain.applications.PlanningApplication
+import uk.towncrierapp.domain.applications.PlanningApplicationId
+import uk.towncrierapp.domain.applications.StatusEvent
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.DateDisplayFormatter
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import uk.towncrierapp.presentation.designsystem.components.PrimaryButton
+import uk.towncrierapp.presentation.designsystem.components.StatusBadge
+import uk.towncrierapp.presentation.designsystem.components.StatusTimeline
+import uk.towncrierapp.presentation.designsystem.components.statusDisplay
+import uk.towncrierapp.presentation.features.applicationlist.applicationErrorMessageRes
+import java.time.LocalDate
+
+/** The public share origin the "share" action links to — see `api-go/internal/sharepage`'s `shareOrigin` + `/a/{slug}/{ref}` route. */
+internal const val SHARE_ORIGIN: String = "https://share.towncrierapp.uk"
+
+internal fun shareUrlFor(
+    authoritySlug: String,
+    name: String,
+): String = "$SHARE_ORIGIN/a/$authoritySlug/$name"
+
+/**
+ * A full navigation destination (Material idiom — not a bottom sheet):
+ * status badge, description headline, fields card, [StatusTimeline], a
+ * "View on Council Portal" Custom Tab button when present, and toolbar
+ * save-toggle + share (share enabled only once the by-id refresh supplies an
+ * `authoritySlug`). Port of iOS `ApplicationDetailView` (GH#775).
+ */
+@Composable
+public fun ApplicationDetailRoute(
+    viewModel: ApplicationDetailViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.refresh()
+        viewModel.checkSavedState()
+    }
+
+    ApplicationDetailScreen(
+        state = state,
+        onBack = onBack,
+        onSaveToggleClick = viewModel::toggleSave,
+        onPortalClick = { url -> openCouncilPortal(context, url) },
+        onShareClick = { url -> shareApplication(context, url) },
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ApplicationDetailScreen(
+    state: ApplicationDetailUiState,
+    onBack: () -> Unit,
+    onSaveToggleClick: () -> Unit,
+    onPortalClick: (String) -> Unit,
+    onShareClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val application = state.application
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {},
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+                actions = {
+                    IconButton(onClick = onSaveToggleClick) {
+                        Icon(
+                            imageVector = if (state.isSaved) Icons.Filled.Bookmark else Icons.Filled.BookmarkBorder,
+                            contentDescription =
+                                stringResource(
+                                    if (state.isSaved) {
+                                        R.string.application_detail_unsave_content_description
+                                    } else {
+                                        R.string.application_detail_save_content_description
+                                    },
+                                ),
+                        )
+                    }
+                    val authoritySlug = state.authoritySlug
+                    if (authoritySlug != null) {
+                        IconButton(onClick = { onShareClick(shareUrlFor(authoritySlug, application.id.name)) }) {
+                            Icon(
+                                imageVector = Icons.Filled.Share,
+                                contentDescription = stringResource(R.string.application_detail_share_content_description),
+                            )
+                        }
+                    }
+                },
+            )
+        },
+    ) { contentPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(contentPadding)
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(TownCrierSpacing.md),
+            verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.lg),
+        ) {
+            val display = statusDisplay(application.status)
+            StatusBadge(label = display.label, color = display.color, icon = display.icon)
+            Text(text = application.description, style = MaterialTheme.typography.titleLarge)
+            FieldsCard(application)
+            if (application.statusHistory.isNotEmpty()) {
+                StatusTimeline(events = application.statusHistory)
+            }
+            application.portalUrl?.let { url ->
+                PrimaryButton(
+                    text = stringResource(R.string.application_detail_portal_button),
+                    onClick = { onPortalClick(url) },
+                )
+            }
+            state.error?.let { error ->
+                Text(
+                    text = stringResource(applicationErrorMessageRes(error)),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun FieldsCard(
+    application: PlanningApplication,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surface,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+    ) {
+        Column(
+            modifier = Modifier.padding(TownCrierSpacing.md),
+            verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.sm),
+        ) {
+            FieldRow(label = stringResource(R.string.application_detail_address_label), value = application.address)
+            FieldRow(label = stringResource(R.string.application_detail_reference_label), value = application.reference)
+            FieldRow(label = stringResource(R.string.application_detail_authority_label), value = application.authority.name)
+            FieldRow(
+                label = stringResource(R.string.application_detail_received_label),
+                value = DateDisplayFormatter.format(application.receivedDate),
+            )
+        }
+    }
+}
+
+@Composable
+private fun FieldRow(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(text = label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(text = value, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+private fun openCouncilPortal(
+    context: Context,
+    url: String,
+) {
+    CustomTabsIntent.Builder().build().launchUrl(context, Uri.parse(url))
+}
+
+private fun shareApplication(
+    context: Context,
+    url: String,
+) {
+    val sendIntent =
+        Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_TEXT, url)
+        }
+    context.startActivity(Intent.createChooser(sendIntent, null))
+}
+
+// Preview-only sample data — cannot reuse :domain's testFixtures from the
+// main source set (compose-ui.md).
+private val previewApplication =
+    PlanningApplication(
+        id = PlanningApplicationId("42", "24/0001"),
+        reference = "24/0001",
+        authority = LocalAuthority(code = "42", name = "Camden", slug = "camden"),
+        status = ApplicationStatus.Permitted,
+        receivedDate = LocalDate.of(2026, 1, 15),
+        description = "Two-storey rear extension with roof lantern",
+        address = "1 Example Street, Camden, London",
+        portalUrl = "https://planningpublicaccess.camden.gov.uk/example",
+        statusHistory =
+            listOf(
+                StatusEvent(ApplicationStatus.Undecided, LocalDate.of(2026, 1, 15)),
+                StatusEvent(ApplicationStatus.Permitted, LocalDate.of(2026, 3, 2)),
+            ),
+    )
+
+@Preview(name = "light")
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ApplicationDetailScreenPreview() {
+    TownCrierTheme {
+        ApplicationDetailScreen(
+            state = ApplicationDetailUiState(application = previewApplication, isSaved = true, authoritySlug = "camden"),
+            onBack = {},
+            onSaveToggleClick = {},
+            onPortalClick = {},
+            onShareClick = {},
+        )
+    }
+}
+
+@Preview(name = "before by-id refresh (no slug, no share)")
+@Composable
+private fun ApplicationDetailScreenBeforeRefreshPreview() {
+    TownCrierTheme {
+        ApplicationDetailScreen(
+            state = ApplicationDetailUiState(application = previewApplication.copy(statusHistory = emptyList())),
+            onBack = {},
+            onSaveToggleClick = {},
+            onPortalClick = {},
+            onShareClick = {},
+        )
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailScreen.kt
@@ -5,12 +5,9 @@ import android.content.Intent
 import android.content.res.Configuration
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -24,7 +21,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -34,7 +30,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import uk.towncrierapp.domain.applications.ApplicationStatus
 import uk.towncrierapp.domain.applications.LocalAuthority
@@ -42,7 +37,6 @@ import uk.towncrierapp.domain.applications.PlanningApplication
 import uk.towncrierapp.domain.applications.PlanningApplicationId
 import uk.towncrierapp.domain.applications.StatusEvent
 import uk.towncrierapp.presentation.R
-import uk.towncrierapp.presentation.designsystem.DateDisplayFormatter
 import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
 import uk.towncrierapp.presentation.designsystem.TownCrierTheme
 import uk.towncrierapp.presentation.designsystem.components.PrimaryButton
@@ -105,118 +99,98 @@ internal fun ApplicationDetailScreen(
     Scaffold(
         modifier = modifier,
         topBar = {
-            TopAppBar(
-                title = {},
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
-                    }
-                },
-                actions = {
-                    IconButton(onClick = onSaveToggleClick) {
-                        Icon(
-                            imageVector = if (state.isSaved) Icons.Filled.Bookmark else Icons.Filled.BookmarkBorder,
-                            contentDescription =
-                                stringResource(
-                                    if (state.isSaved) {
-                                        R.string.application_detail_unsave_content_description
-                                    } else {
-                                        R.string.application_detail_save_content_description
-                                    },
-                                ),
-                        )
-                    }
-                    val authoritySlug = state.authoritySlug
-                    if (authoritySlug != null) {
-                        IconButton(onClick = { onShareClick(shareUrlFor(authoritySlug, application.id.name)) }) {
-                            Icon(
-                                imageVector = Icons.Filled.Share,
-                                contentDescription =
-                                    stringResource(
-                                        R.string.application_detail_share_content_description,
-                                    ),
-                            )
-                        }
-                    }
-                },
+            ApplicationDetailTopBar(
+                isSaved = state.isSaved,
+                authoritySlug = state.authoritySlug,
+                applicationName = application.id.name,
+                onBack = onBack,
+                onSaveToggleClick = onSaveToggleClick,
+                onShareClick = onShareClick,
             )
         },
     ) { contentPadding ->
-        Column(
-            modifier =
-                Modifier
-                    .padding(contentPadding)
-                    .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
-                    .padding(TownCrierSpacing.md),
-            verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.lg),
-        ) {
-            val display = statusDisplay(application.status)
-            StatusBadge(label = display.label, color = display.color, icon = display.icon)
-            Text(text = application.description, style = MaterialTheme.typography.titleLarge)
-            FieldsCard(application)
-            if (application.statusHistory.isNotEmpty()) {
-                StatusTimeline(events = application.statusHistory)
-            }
-            application.portalUrl?.let { url ->
-                PrimaryButton(
-                    text = stringResource(R.string.application_detail_portal_button),
-                    onClick = { onPortalClick(url) },
-                )
-            }
-            state.error?.let { error ->
-                Text(
-                    text = stringResource(applicationErrorMessageRes(error)),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun FieldsCard(
-    application: PlanningApplication,
-    modifier: Modifier = Modifier,
-) {
-    Surface(
-        modifier = modifier.fillMaxWidth(),
-        shape = MaterialTheme.shapes.medium,
-        color = MaterialTheme.colorScheme.surface,
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
-    ) {
-        Column(
-            modifier = Modifier.padding(TownCrierSpacing.md),
-            verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.sm),
-        ) {
-            FieldRow(label = stringResource(R.string.application_detail_address_label), value = application.address)
-            FieldRow(label = stringResource(R.string.application_detail_reference_label), value = application.reference)
-            FieldRow(
-                label = stringResource(R.string.application_detail_authority_label),
-                value = application.authority.name,
-            )
-            FieldRow(
-                label = stringResource(R.string.application_detail_received_label),
-                value = DateDisplayFormatter.format(application.receivedDate),
-            )
-        }
-    }
-}
-
-@Composable
-private fun FieldRow(
-    label: String,
-    value: String,
-    modifier: Modifier = Modifier,
-) {
-    Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-        Text(
-            text = label,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        ApplicationDetailContent(
+            state = state,
+            onPortalClick = onPortalClick,
+            modifier = Modifier.padding(contentPadding).fillMaxSize(),
         )
-        Text(text = value, style = MaterialTheme.typography.bodyMedium)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ApplicationDetailTopBar(
+    isSaved: Boolean,
+    authoritySlug: String?,
+    applicationName: String,
+    onBack: () -> Unit,
+    onSaveToggleClick: () -> Unit,
+    onShareClick: (String) -> Unit,
+) {
+    TopAppBar(
+        title = {},
+        navigationIcon = {
+            IconButton(onClick = onBack) {
+                Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+            }
+        },
+        actions = {
+            IconButton(onClick = onSaveToggleClick) {
+                Icon(
+                    imageVector = if (isSaved) Icons.Filled.Bookmark else Icons.Filled.BookmarkBorder,
+                    contentDescription =
+                        stringResource(
+                            if (isSaved) {
+                                R.string.application_detail_unsave_content_description
+                            } else {
+                                R.string.application_detail_save_content_description
+                            },
+                        ),
+                )
+            }
+            if (authoritySlug != null) {
+                IconButton(onClick = { onShareClick(shareUrlFor(authoritySlug, applicationName)) }) {
+                    Icon(
+                        imageVector = Icons.Filled.Share,
+                        contentDescription = stringResource(R.string.application_detail_share_content_description),
+                    )
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun ApplicationDetailContent(
+    state: ApplicationDetailUiState,
+    onPortalClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val application = state.application
+    Column(
+        modifier = modifier.verticalScroll(rememberScrollState()).padding(TownCrierSpacing.md),
+        verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.lg),
+    ) {
+        val display = statusDisplay(application.status)
+        StatusBadge(label = display.label, color = display.color, icon = display.icon)
+        Text(text = application.description, style = MaterialTheme.typography.titleLarge)
+        FieldsCard(application)
+        if (application.statusHistory.isNotEmpty()) {
+            StatusTimeline(events = application.statusHistory)
+        }
+        application.portalUrl?.let { url ->
+            PrimaryButton(
+                text = stringResource(R.string.application_detail_portal_button),
+                onClick = { onPortalClick(url) },
+            )
+        }
+        state.error?.let { error ->
+            Text(
+                text = stringResource(applicationErrorMessageRes(error)),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
     }
 }
 

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailScreen.kt
@@ -131,7 +131,10 @@ internal fun ApplicationDetailScreen(
                         IconButton(onClick = { onShareClick(shareUrlFor(authoritySlug, application.id.name)) }) {
                             Icon(
                                 imageVector = Icons.Filled.Share,
-                                contentDescription = stringResource(R.string.application_detail_share_content_description),
+                                contentDescription =
+                                    stringResource(
+                                        R.string.application_detail_share_content_description,
+                                    ),
                             )
                         }
                     }
@@ -189,7 +192,10 @@ private fun FieldsCard(
         ) {
             FieldRow(label = stringResource(R.string.application_detail_address_label), value = application.address)
             FieldRow(label = stringResource(R.string.application_detail_reference_label), value = application.reference)
-            FieldRow(label = stringResource(R.string.application_detail_authority_label), value = application.authority.name)
+            FieldRow(
+                label = stringResource(R.string.application_detail_authority_label),
+                value = application.authority.name,
+            )
             FieldRow(
                 label = stringResource(R.string.application_detail_received_label),
                 value = DateDisplayFormatter.format(application.receivedDate),
@@ -205,7 +211,11 @@ private fun FieldRow(
     modifier: Modifier = Modifier,
 ) {
     Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
-        Text(text = label, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
         Text(text = value, style = MaterialTheme.typography.bodyMedium)
     }
 }
@@ -254,7 +264,12 @@ private val previewApplication =
 private fun ApplicationDetailScreenPreview() {
     TownCrierTheme {
         ApplicationDetailScreen(
-            state = ApplicationDetailUiState(application = previewApplication, isSaved = true, authoritySlug = "camden"),
+            state =
+                ApplicationDetailUiState(
+                    application = previewApplication,
+                    isSaved = true,
+                    authoritySlug = "camden",
+                ),
             onBack = {},
             onSaveToggleClick = {},
             onPortalClick = {},

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailUiState.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailUiState.kt
@@ -1,0 +1,23 @@
+package uk.towncrierapp.presentation.features.applicationdetail
+
+import uk.towncrierapp.domain.applications.PlanningApplication
+import uk.towncrierapp.domain.auth.DomainError
+
+/**
+ * `ApplicationDetailScreen` state. [application] starts as the row passed in
+ * from the list/saved screen (stale-while-revalidate: rendered instantly,
+ * never a blank/loading flash) and is replaced once [ApplicationDetailViewModel.refresh]'s
+ * by-id fetch completes. [canShare] is only true once that fetch has supplied
+ * an `authoritySlug` — share needs the by-slug identity, which list/saved
+ * rows never carry. Port of iOS `ApplicationDetailViewModel`'s published
+ * state (GH#775).
+ */
+public data class ApplicationDetailUiState(
+    val application: PlanningApplication,
+    val isRefreshing: Boolean = false,
+    val isSaved: Boolean = false,
+    val authoritySlug: String? = null,
+    val error: DomainError? = null,
+) {
+    public val canShare: Boolean get() = authoritySlug != null
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailViewModel.kt
@@ -1,0 +1,88 @@
+package uk.towncrierapp.presentation.features.applicationdetail
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import uk.towncrierapp.domain.applications.PlanningApplication
+import uk.towncrierapp.domain.applications.PlanningApplicationRepository
+import uk.towncrierapp.domain.applications.SavedApplicationRepository
+import uk.towncrierapp.domain.auth.DomainError
+
+/**
+ * Drives the application detail screen: stale-while-revalidate (the passed-in
+ * [initial] row renders instantly; [refresh] replaces it with the by-id
+ * fetch's fresh copy, re-entrancy-guarded against a second rapid
+ * navigation), and save/unsave with saved-state comparison by the
+ * RECONSTRUCTED [uk.towncrierapp.domain.applications.PlanningApplicationId]
+ * (tc-jjl4), never a raw uid string. Port of iOS `ApplicationDetailViewModel`
+ * (GH#775).
+ */
+public class ApplicationDetailViewModel(
+    private val repository: PlanningApplicationRepository,
+    private val savedApplicationRepository: SavedApplicationRepository,
+    initial: PlanningApplication,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(ApplicationDetailUiState(application = initial, authoritySlug = initial.authority.slug))
+    public val uiState: StateFlow<ApplicationDetailUiState> = _uiState.asStateFlow()
+
+    private var refreshJob: Job? = null
+
+    /** Refreshes by id in the background. A second call while one is already in flight is ignored, not queued or restarted. */
+    public fun refresh() {
+        if (refreshJob?.isActive == true) return
+        refreshJob =
+            viewModelScope.launch {
+                _uiState.update { it.copy(isRefreshing = true, error = null) }
+                val id = _uiState.value.application.id
+                try {
+                    val fresh = repository.detail(id.authority, id.name)
+                    _uiState.update { it.copy(application = fresh, authoritySlug = fresh.authority.slug, isRefreshing = false) }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: DomainError) {
+                    _uiState.update { it.copy(isRefreshing = false, error = e) }
+                }
+            }
+    }
+
+    /** Resolves [ApplicationDetailUiState.isSaved] by comparing the RECONSTRUCTED id, never the raw wire uid (tc-jjl4). */
+    @Suppress("SwallowedException")
+    // Best-effort by design: a failed saved-state check leaves the toggle at
+    // its last-known value rather than surfacing an error banner for a
+    // background consistency check the user didn't initiate.
+    public fun checkSavedState() {
+        viewModelScope.launch {
+            try {
+                val currentId = _uiState.value.application.id
+                val isSaved = savedApplicationRepository.savedApplications().any { it.applicationUid == currentId }
+                _uiState.update { it.copy(isSaved = isSaved) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                // Best-effort — a failed saved-state check leaves the toggle at its last-known state.
+            }
+        }
+    }
+
+    /** Optimistically flips [ApplicationDetailUiState.isSaved], reverting and surfacing an error on failure. */
+    public fun toggleSave() {
+        val id = _uiState.value.application.id
+        val wasSaved = _uiState.value.isSaved
+        _uiState.update { it.copy(isSaved = !wasSaved, error = null) }
+        viewModelScope.launch {
+            try {
+                if (wasSaved) savedApplicationRepository.unsave(id) else savedApplicationRepository.save(id)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                _uiState.update { it.copy(isSaved = wasSaved, error = e) }
+            }
+        }
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailViewModel.kt
@@ -28,7 +28,8 @@ public class ApplicationDetailViewModel(
     private val savedApplicationRepository: SavedApplicationRepository,
     initial: PlanningApplication,
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow(ApplicationDetailUiState(application = initial, authoritySlug = initial.authority.slug))
+    private val _uiState =
+        MutableStateFlow(ApplicationDetailUiState(application = initial, authoritySlug = initial.authority.slug))
     public val uiState: StateFlow<ApplicationDetailUiState> = _uiState.asStateFlow()
 
     private var refreshJob: Job? = null
@@ -42,7 +43,13 @@ public class ApplicationDetailViewModel(
                 val id = _uiState.value.application.id
                 try {
                     val fresh = repository.detail(id.authority, id.name)
-                    _uiState.update { it.copy(application = fresh, authoritySlug = fresh.authority.slug, isRefreshing = false) }
+                    _uiState.update {
+                        it.copy(
+                            application = fresh,
+                            authoritySlug = fresh.authority.slug,
+                            isRefreshing = false,
+                        )
+                    }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: DomainError) {

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationFieldsCard.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationFieldsCard.kt
@@ -1,0 +1,69 @@
+package uk.towncrierapp.presentation.features.applicationdetail
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import uk.towncrierapp.domain.applications.PlanningApplication
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.DateDisplayFormatter
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+
+/**
+ * The detail screen's address/reference/authority/received-date card. Split
+ * into its own file to keep `ApplicationDetailScreen.kt` under detekt's
+ * per-file function budget.
+ */
+@Composable
+internal fun FieldsCard(
+    application: PlanningApplication,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        color = MaterialTheme.colorScheme.surface,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+    ) {
+        Column(
+            modifier = Modifier.padding(TownCrierSpacing.md),
+            verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.sm),
+        ) {
+            FieldRow(label = stringResource(R.string.application_detail_address_label), value = application.address)
+            FieldRow(label = stringResource(R.string.application_detail_reference_label), value = application.reference)
+            FieldRow(
+                label = stringResource(R.string.application_detail_authority_label),
+                value = application.authority.name,
+            )
+            FieldRow(
+                label = stringResource(R.string.application_detail_received_label),
+                value = DateDisplayFormatter.format(application.receivedDate),
+            )
+        }
+    }
+}
+
+@Composable
+private fun FieldRow(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(text = value, style = MaterialTheme.typography.bodyMedium)
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationErrors.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationErrors.kt
@@ -1,0 +1,29 @@
+package uk.towncrierapp.presentation.features.applicationlist
+
+import androidx.annotation.StringRes
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.presentation.R
+
+/**
+ * Maps a [DomainError] to the inline-error string resource shared by the
+ * three applications-browsing screens (list/saved/detail) — `internal` is
+ * module-wide in Kotlin, so this single mapping is reused across those
+ * feature packages rather than duplicated per screen (compose-ui.md:
+ * user-facing copy is a `:presentation` resource, keyed off the sealed
+ * outcome).
+ */
+@StringRes
+internal fun applicationErrorMessageRes(error: DomainError): Int =
+    when (error) {
+        DomainError.NetworkUnavailable -> R.string.applications_error_network
+
+        DomainError.SessionExpired -> R.string.login_error_session_expired
+
+        DomainError.NotFound,
+        is DomainError.InsufficientEntitlement,
+        is DomainError.ServerError,
+        is DomainError.AuthenticationFailed,
+        is DomainError.LogoutFailed,
+        is DomainError.Unexpected,
+        -> R.string.applications_error_generic
+    }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListScreen.kt
@@ -1,0 +1,387 @@
+package uk.towncrierapp.presentation.features.applicationlist
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.automirrored.filled.Sort
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.filled.Place
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import uk.towncrierapp.domain.applications.ApplicationFilter
+import uk.towncrierapp.domain.applications.ApplicationSortOrder
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.applications.PlanningApplication
+import uk.towncrierapp.domain.watchzones.Coordinate
+import uk.towncrierapp.domain.watchzones.WatchZone
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import uk.towncrierapp.presentation.designsystem.components.ApplicationRow
+import uk.towncrierapp.presentation.designsystem.components.CapsuleChip
+import uk.towncrierapp.presentation.designsystem.components.PrimaryButton
+
+/**
+ * The Applications tab: zone chips, status/unread filter chips, a sort menu
+ * in the top app bar, and cursor-based infinite scroll. Port of iOS
+ * `ApplicationListView` (GH#775).
+ */
+@Composable
+public fun ApplicationListRoute(
+    viewModel: ApplicationListViewModel,
+    onApplicationSelected: (PlanningApplication) -> Unit,
+    onAddZoneClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    ApplicationListScreen(
+        state = state,
+        onZoneSelected = viewModel::selectZone,
+        onSortSelected = viewModel::selectSort,
+        onFilterSelected = viewModel::selectFilter,
+        onItemVisible = viewModel::onItemVisible,
+        onApplicationClick = { application ->
+            viewModel.markAsRead(application)
+            onApplicationSelected(application)
+        },
+        onMarkAllReadClick = viewModel::markAllRead,
+        onAddZoneClick = onAddZoneClick,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ApplicationListScreen(
+    state: ApplicationListUiState,
+    onZoneSelected: (WatchZoneId) -> Unit,
+    onSortSelected: (ApplicationSortOrder) -> Unit,
+    onFilterSelected: (ApplicationFilter) -> Unit,
+    onItemVisible: (Int) -> Unit,
+    onApplicationClick: (PlanningApplication) -> Unit,
+    onMarkAllReadClick: () -> Unit,
+    onAddZoneClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.applications_title)) },
+                actions = {
+                    if (state.unreadCount > 0) {
+                        IconButton(onClick = onMarkAllReadClick) {
+                            Icon(
+                                imageVector = Icons.Filled.DoneAll,
+                                contentDescription = stringResource(R.string.applications_mark_all_read),
+                            )
+                        }
+                    }
+                    SortMenu(currentSort = state.sort, availableSorts = state.availableSorts, onSortSelected = onSortSelected)
+                },
+            )
+        },
+    ) { contentPadding ->
+        Column(modifier = Modifier.padding(contentPadding).fillMaxSize()) {
+            if (state.zones.isEmpty() && !state.isLoading) {
+                NoZonesEmptyState(onAddZoneClick = onAddZoneClick, modifier = Modifier.fillMaxSize())
+            } else {
+                if (state.zones.size > 1) {
+                    ZoneChipsRow(
+                        zones = state.zones,
+                        selectedZoneId = state.selectedZoneId,
+                        onZoneSelected = onZoneSelected,
+                        modifier = Modifier.padding(top = TownCrierSpacing.sm),
+                    )
+                }
+                FilterChipsRow(
+                    filter = state.filter,
+                    unreadCount = state.unreadCount,
+                    onFilterSelected = onFilterSelected,
+                    modifier = Modifier.padding(vertical = TownCrierSpacing.sm),
+                )
+                Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                    when {
+                        state.isLoading && state.applications.isEmpty() ->
+                            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+
+                        state.applications.isEmpty() ->
+                            EmptyApplicationsState(modifier = Modifier.align(Alignment.Center))
+
+                        else ->
+                            ApplicationsList(
+                                applications = state.applications,
+                                isLoadingMore = state.isLoadingMore,
+                                onItemVisible = onItemVisible,
+                                onApplicationClick = onApplicationClick,
+                            )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ApplicationsList(
+    applications: List<PlanningApplication>,
+    isLoadingMore: Boolean,
+    onItemVisible: (Int) -> Unit,
+    onApplicationClick: (PlanningApplication) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(modifier = modifier.fillMaxSize()) {
+        itemsIndexed(applications, key = { _, application -> application.id.value }) { index, application ->
+            // Hand-rolled prefetch trigger (no Paging 3): firing once per row
+            // as it enters composition is enough for the ~40-line cursor
+            // loop this app deliberately keeps simple.
+            LaunchedEffect(index) { onItemVisible(index) }
+            ApplicationRow(application = application, onClick = { onApplicationClick(application) })
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+        }
+        if (isLoadingMore) {
+            item {
+                Box(modifier = Modifier.fillMaxWidth().padding(TownCrierSpacing.md), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ZoneChipsRow(
+    zones: List<WatchZone>,
+    selectedZoneId: WatchZoneId?,
+    onZoneSelected: (WatchZoneId) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(TownCrierSpacing.sm),
+        contentPadding = PaddingValues(horizontal = TownCrierSpacing.md),
+    ) {
+        items(zones, key = { it.id.value }) { zone ->
+            CapsuleChip(label = zone.name, selected = zone.id == selectedZoneId, onClick = { onZoneSelected(zone.id) })
+        }
+    }
+}
+
+private val FILTERABLE_STATUSES =
+    listOf(
+        ApplicationStatus.Undecided,
+        ApplicationStatus.Permitted,
+        ApplicationStatus.Conditions,
+        ApplicationStatus.Rejected,
+        ApplicationStatus.Withdrawn,
+        ApplicationStatus.Appealed,
+    )
+
+@Composable
+private fun FilterChipsRow(
+    filter: ApplicationFilter,
+    unreadCount: Int,
+    onFilterSelected: (ApplicationFilter) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(TownCrierSpacing.sm),
+        contentPadding = PaddingValues(horizontal = TownCrierSpacing.md),
+    ) {
+        item {
+            CapsuleChip(
+                label = stringResource(R.string.applications_filter_all),
+                selected = filter == ApplicationFilter.All,
+                onClick = { onFilterSelected(ApplicationFilter.All) },
+            )
+        }
+        items(FILTERABLE_STATUSES) { status ->
+            CapsuleChip(
+                label = statusFilterLabel(status),
+                selected = filter == ApplicationFilter.Status(status),
+                onClick = { onFilterSelected(ApplicationFilter.Status(status)) },
+            )
+        }
+        item {
+            CapsuleChip(
+                label = "${stringResource(R.string.applications_filter_unread)} ($unreadCount)",
+                selected = filter == ApplicationFilter.Unread,
+                onClick = { onFilterSelected(ApplicationFilter.Unread) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun statusFilterLabel(status: ApplicationStatus): String =
+    when (status) {
+        ApplicationStatus.Undecided -> stringResource(R.string.application_status_pending)
+        ApplicationStatus.Permitted -> stringResource(R.string.application_status_permitted)
+        ApplicationStatus.Conditions -> stringResource(R.string.application_status_conditions)
+        ApplicationStatus.Rejected -> stringResource(R.string.application_status_rejected)
+        ApplicationStatus.Withdrawn -> stringResource(R.string.application_status_withdrawn)
+        ApplicationStatus.Appealed -> stringResource(R.string.application_status_appealed)
+        else -> stringResource(R.string.application_status_unknown)
+    }
+
+@Composable
+private fun SortMenu(
+    currentSort: ApplicationSortOrder,
+    availableSorts: List<ApplicationSortOrder>,
+    onSortSelected: (ApplicationSortOrder) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    IconButton(onClick = { expanded = true }) {
+        Icon(imageVector = Icons.AutoMirrored.Filled.Sort, contentDescription = stringResource(R.string.applications_sort_content_description))
+    }
+    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        availableSorts.forEach { sort ->
+            DropdownMenuItem(
+                text = { Text(sortLabel(sort)) },
+                onClick = {
+                    onSortSelected(sort)
+                    expanded = false
+                },
+                trailingIcon = {
+                    if (sort == currentSort) Icon(imageVector = Icons.Filled.Check, contentDescription = null)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun sortLabel(sort: ApplicationSortOrder): String =
+    when (sort) {
+        ApplicationSortOrder.DISTANCE -> stringResource(R.string.applications_sort_distance)
+        ApplicationSortOrder.NEWEST -> stringResource(R.string.applications_sort_newest)
+        ApplicationSortOrder.OLDEST -> stringResource(R.string.applications_sort_oldest)
+        ApplicationSortOrder.STATUS -> stringResource(R.string.applications_sort_status)
+        ApplicationSortOrder.RECENT_ACTIVITY -> stringResource(R.string.applications_sort_recent_activity)
+    }
+
+@Composable
+private fun NoZonesEmptyState(
+    onAddZoneClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        Column(
+            modifier = Modifier.padding(TownCrierSpacing.xl),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.md),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Place,
+                contentDescription = null,
+                tint = TownCrierTheme.colors.textTertiary,
+                modifier = Modifier.size(48.dp),
+            )
+            Text(text = stringResource(R.string.applications_no_zones_title), style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = stringResource(R.string.applications_no_zones_message),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            PrimaryButton(text = stringResource(R.string.applications_no_zones_cta), onClick = onAddZoneClick)
+        }
+    }
+}
+
+@Composable
+private fun EmptyApplicationsState(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(TownCrierSpacing.xl),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.md),
+    ) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.List,
+            contentDescription = null,
+            tint = TownCrierTheme.colors.textTertiary,
+            modifier = Modifier.size(48.dp),
+        )
+        Text(text = stringResource(R.string.applications_empty_title), style = MaterialTheme.typography.titleMedium)
+        Text(
+            text = stringResource(R.string.applications_empty_message),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+// Preview-only sample data — cannot reuse :domain's testFixtures from the
+// main source set (compose-ui.md).
+private val previewZone = WatchZone(id = WatchZoneId("wz-1"), name = "Home", centre = Coordinate(51.5074, -0.1278), radiusMetres = 500.0)
+
+@Preview(name = "light")
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun ApplicationListScreenEmptyPreview() {
+    TownCrierTheme {
+        ApplicationListScreen(
+            state = ApplicationListUiState(zones = listOf(previewZone), selectedZoneId = previewZone.id),
+            onZoneSelected = {},
+            onSortSelected = {},
+            onFilterSelected = {},
+            onItemVisible = {},
+            onApplicationClick = {},
+            onMarkAllReadClick = {},
+            onAddZoneClick = {},
+        )
+    }
+}
+
+@Preview(name = "no zones")
+@Composable
+private fun ApplicationListScreenNoZonesPreview() {
+    TownCrierTheme {
+        ApplicationListScreen(
+            state = ApplicationListUiState(),
+            onZoneSelected = {},
+            onSortSelected = {},
+            onFilterSelected = {},
+            onItemVisible = {},
+            onApplicationClick = {},
+            onMarkAllReadClick = {},
+            onAddZoneClick = {},
+        )
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListScreen.kt
@@ -113,7 +113,11 @@ internal fun ApplicationListScreen(
                             )
                         }
                     }
-                    SortMenu(currentSort = state.sort, availableSorts = state.availableSorts, onSortSelected = onSortSelected)
+                    SortMenu(
+                        currentSort = state.sort,
+                        availableSorts = state.availableSorts,
+                        onSortSelected = onSortSelected,
+                    )
                 },
             )
         },
@@ -138,19 +142,22 @@ internal fun ApplicationListScreen(
                 )
                 Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
                     when {
-                        state.isLoading && state.applications.isEmpty() ->
+                        state.isLoading && state.applications.isEmpty() -> {
                             CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                        }
 
-                        state.applications.isEmpty() ->
+                        state.applications.isEmpty() -> {
                             EmptyApplicationsState(modifier = Modifier.align(Alignment.Center))
+                        }
 
-                        else ->
+                        else -> {
                             ApplicationsList(
                                 applications = state.applications,
                                 isLoadingMore = state.isLoadingMore,
                                 onItemVisible = onItemVisible,
                                 onApplicationClick = onApplicationClick,
                             )
+                        }
                     }
                 }
             }
@@ -177,7 +184,10 @@ private fun ApplicationsList(
         }
         if (isLoadingMore) {
             item {
-                Box(modifier = Modifier.fillMaxWidth().padding(TownCrierSpacing.md), contentAlignment = Alignment.Center) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(TownCrierSpacing.md),
+                    contentAlignment = Alignment.Center,
+                ) {
                     CircularProgressIndicator()
                 }
             }
@@ -269,7 +279,10 @@ private fun SortMenu(
 ) {
     var expanded by remember { mutableStateOf(false) }
     IconButton(onClick = { expanded = true }) {
-        Icon(imageVector = Icons.AutoMirrored.Filled.Sort, contentDescription = stringResource(R.string.applications_sort_content_description))
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.Sort,
+            contentDescription = stringResource(R.string.applications_sort_content_description),
+        )
     }
     DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
         availableSorts.forEach { sort ->
@@ -314,7 +327,10 @@ private fun NoZonesEmptyState(
                 tint = TownCrierTheme.colors.textTertiary,
                 modifier = Modifier.size(48.dp),
             )
-            Text(text = stringResource(R.string.applications_no_zones_title), style = MaterialTheme.typography.titleMedium)
+            Text(
+                text = stringResource(R.string.applications_no_zones_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
             Text(
                 text = stringResource(R.string.applications_no_zones_message),
                 style = MaterialTheme.typography.bodyLarge,
@@ -349,7 +365,8 @@ private fun EmptyApplicationsState(modifier: Modifier = Modifier) {
 
 // Preview-only sample data — cannot reuse :domain's testFixtures from the
 // main source set (compose-ui.md).
-private val previewZone = WatchZone(id = WatchZoneId("wz-1"), name = "Home", centre = Coordinate(51.5074, -0.1278), radiusMetres = 500.0)
+private val previewZone =
+    WatchZone(id = WatchZoneId("wz-1"), name = "Home", centre = Coordinate(51.5074, -0.1278), radiusMetres = 500.0)
 
 @Preview(name = "light")
 @Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListScreen.kt
@@ -16,13 +16,9 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
-import androidx.compose.material.icons.automirrored.filled.Sort
-import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -34,9 +30,6 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -45,7 +38,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import uk.towncrierapp.domain.applications.ApplicationFilter
 import uk.towncrierapp.domain.applications.ApplicationSortOrder
-import uk.towncrierapp.domain.applications.ApplicationStatus
 import uk.towncrierapp.domain.applications.PlanningApplication
 import uk.towncrierapp.domain.watchzones.Coordinate
 import uk.towncrierapp.domain.watchzones.WatchZone
@@ -102,23 +94,12 @@ internal fun ApplicationListScreen(
     Scaffold(
         modifier = modifier,
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.applications_title)) },
-                actions = {
-                    if (state.unreadCount > 0) {
-                        IconButton(onClick = onMarkAllReadClick) {
-                            Icon(
-                                imageVector = Icons.Filled.DoneAll,
-                                contentDescription = stringResource(R.string.applications_mark_all_read),
-                            )
-                        }
-                    }
-                    SortMenu(
-                        currentSort = state.sort,
-                        availableSorts = state.availableSorts,
-                        onSortSelected = onSortSelected,
-                    )
-                },
+            ApplicationListTopBar(
+                unreadCount = state.unreadCount,
+                sort = state.sort,
+                availableSorts = state.availableSorts,
+                onMarkAllReadClick = onMarkAllReadClick,
+                onSortSelected = onSortSelected,
             )
         },
     ) { contentPadding ->
@@ -163,6 +144,31 @@ internal fun ApplicationListScreen(
             }
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ApplicationListTopBar(
+    unreadCount: Int,
+    sort: ApplicationSortOrder,
+    availableSorts: List<ApplicationSortOrder>,
+    onMarkAllReadClick: () -> Unit,
+    onSortSelected: (ApplicationSortOrder) -> Unit,
+) {
+    TopAppBar(
+        title = { Text(stringResource(R.string.applications_title)) },
+        actions = {
+            if (unreadCount > 0) {
+                IconButton(onClick = onMarkAllReadClick) {
+                    Icon(
+                        imageVector = Icons.Filled.DoneAll,
+                        contentDescription = stringResource(R.string.applications_mark_all_read),
+                    )
+                }
+            }
+            SortMenu(currentSort = sort, availableSorts = availableSorts, onSortSelected = onSortSelected)
+        },
+    )
 }
 
 @Composable
@@ -212,103 +218,6 @@ private fun ZoneChipsRow(
         }
     }
 }
-
-private val FILTERABLE_STATUSES =
-    listOf(
-        ApplicationStatus.Undecided,
-        ApplicationStatus.Permitted,
-        ApplicationStatus.Conditions,
-        ApplicationStatus.Rejected,
-        ApplicationStatus.Withdrawn,
-        ApplicationStatus.Appealed,
-    )
-
-@Composable
-private fun FilterChipsRow(
-    filter: ApplicationFilter,
-    unreadCount: Int,
-    onFilterSelected: (ApplicationFilter) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    LazyRow(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(TownCrierSpacing.sm),
-        contentPadding = PaddingValues(horizontal = TownCrierSpacing.md),
-    ) {
-        item {
-            CapsuleChip(
-                label = stringResource(R.string.applications_filter_all),
-                selected = filter == ApplicationFilter.All,
-                onClick = { onFilterSelected(ApplicationFilter.All) },
-            )
-        }
-        items(FILTERABLE_STATUSES) { status ->
-            CapsuleChip(
-                label = statusFilterLabel(status),
-                selected = filter == ApplicationFilter.Status(status),
-                onClick = { onFilterSelected(ApplicationFilter.Status(status)) },
-            )
-        }
-        item {
-            CapsuleChip(
-                label = "${stringResource(R.string.applications_filter_unread)} ($unreadCount)",
-                selected = filter == ApplicationFilter.Unread,
-                onClick = { onFilterSelected(ApplicationFilter.Unread) },
-            )
-        }
-    }
-}
-
-@Composable
-private fun statusFilterLabel(status: ApplicationStatus): String =
-    when (status) {
-        ApplicationStatus.Undecided -> stringResource(R.string.application_status_pending)
-        ApplicationStatus.Permitted -> stringResource(R.string.application_status_permitted)
-        ApplicationStatus.Conditions -> stringResource(R.string.application_status_conditions)
-        ApplicationStatus.Rejected -> stringResource(R.string.application_status_rejected)
-        ApplicationStatus.Withdrawn -> stringResource(R.string.application_status_withdrawn)
-        ApplicationStatus.Appealed -> stringResource(R.string.application_status_appealed)
-        else -> stringResource(R.string.application_status_unknown)
-    }
-
-@Composable
-private fun SortMenu(
-    currentSort: ApplicationSortOrder,
-    availableSorts: List<ApplicationSortOrder>,
-    onSortSelected: (ApplicationSortOrder) -> Unit,
-) {
-    var expanded by remember { mutableStateOf(false) }
-    IconButton(onClick = { expanded = true }) {
-        Icon(
-            imageVector = Icons.AutoMirrored.Filled.Sort,
-            contentDescription = stringResource(R.string.applications_sort_content_description),
-        )
-    }
-    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
-        availableSorts.forEach { sort ->
-            DropdownMenuItem(
-                text = { Text(sortLabel(sort)) },
-                onClick = {
-                    onSortSelected(sort)
-                    expanded = false
-                },
-                trailingIcon = {
-                    if (sort == currentSort) Icon(imageVector = Icons.Filled.Check, contentDescription = null)
-                },
-            )
-        }
-    }
-}
-
-@Composable
-private fun sortLabel(sort: ApplicationSortOrder): String =
-    when (sort) {
-        ApplicationSortOrder.DISTANCE -> stringResource(R.string.applications_sort_distance)
-        ApplicationSortOrder.NEWEST -> stringResource(R.string.applications_sort_newest)
-        ApplicationSortOrder.OLDEST -> stringResource(R.string.applications_sort_oldest)
-        ApplicationSortOrder.STATUS -> stringResource(R.string.applications_sort_status)
-        ApplicationSortOrder.RECENT_ACTIVITY -> stringResource(R.string.applications_sort_recent_activity)
-    }
 
 @Composable
 private fun NoZonesEmptyState(

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListUiState.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListUiState.kt
@@ -1,0 +1,36 @@
+package uk.towncrierapp.presentation.features.applicationlist
+
+import uk.towncrierapp.domain.applications.ApplicationFilter
+import uk.towncrierapp.domain.applications.ApplicationSortOrder
+import uk.towncrierapp.domain.applications.PlanningApplication
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import uk.towncrierapp.domain.watchzones.WatchZone
+
+/**
+ * `ApplicationListScreen` state. [unreadCount] is CLIENT-derived from
+ * currently-loaded [applications] (never a server `totalUnreadCount` — that
+ * field drives the OS badge only, #777 D7). [hasMore] is a page's
+ * `nextCursor != null`. [availableSorts] hides
+ * [ApplicationSortOrder.DISTANCE] whenever no zone is active (nothing to be
+ * distant from). Port of iOS `ApplicationListViewModel`'s published state
+ * (GH#775).
+ */
+public data class ApplicationListUiState(
+    val zones: List<WatchZone> = emptyList(),
+    val selectedZoneId: WatchZoneId? = null,
+    val applications: List<PlanningApplication> = emptyList(),
+    val filter: ApplicationFilter = ApplicationFilter.All,
+    val sort: ApplicationSortOrder = ApplicationSortOrder.DEFAULT,
+    val nextCursor: String? = null,
+    val isLoading: Boolean = false,
+    val isLoadingMore: Boolean = false,
+    val error: DomainError? = null,
+) {
+    public val hasMore: Boolean get() = nextCursor != null
+
+    public val unreadCount: Int get() = applications.count { it.latestUnreadEvent != null }
+
+    public val availableSorts: List<ApplicationSortOrder>
+        get() = ApplicationSortOrder.entries.filter { it != ApplicationSortOrder.DISTANCE || selectedZoneId != null }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListUiState.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListUiState.kt
@@ -4,8 +4,8 @@ import uk.towncrierapp.domain.applications.ApplicationFilter
 import uk.towncrierapp.domain.applications.ApplicationSortOrder
 import uk.towncrierapp.domain.applications.PlanningApplication
 import uk.towncrierapp.domain.auth.DomainError
-import uk.towncrierapp.domain.watchzones.WatchZoneId
 import uk.towncrierapp.domain.watchzones.WatchZone
+import uk.towncrierapp.domain.watchzones.WatchZoneId
 
 /**
  * `ApplicationListScreen` state. [unreadCount] is CLIENT-derived from

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListViewModel.kt
@@ -1,0 +1,169 @@
+package uk.towncrierapp.presentation.features.applicationlist
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import uk.towncrierapp.domain.applications.ApplicationCacheStore
+import uk.towncrierapp.domain.applications.ApplicationFilter
+import uk.towncrierapp.domain.applications.ApplicationListPreferencesStore
+import uk.towncrierapp.domain.applications.ApplicationSortOrder
+import uk.towncrierapp.domain.applications.NotificationStateRepository
+import uk.towncrierapp.domain.applications.PlanningApplication
+import uk.towncrierapp.domain.applications.PlanningApplicationRepository
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import uk.towncrierapp.domain.watchzones.WatchZoneRepository
+
+/**
+ * Drives the Applications tab: zone chips, status/unread filter chips, sort
+ * persistence, cursor-based infinite scroll, tap-to-read, and mark-all-read.
+ * Port of iOS `ApplicationListViewModel` (GH#775).
+ */
+public class ApplicationListViewModel(
+    private val applicationRepository: PlanningApplicationRepository,
+    private val watchZoneRepository: WatchZoneRepository,
+    private val notificationStateRepository: NotificationStateRepository,
+    private val applicationCacheStore: ApplicationCacheStore,
+    private val preferencesStore: ApplicationListPreferencesStore,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(ApplicationListUiState())
+    public val uiState: StateFlow<ApplicationListUiState> = _uiState.asStateFlow()
+
+    public fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val zones = watchZoneRepository.zones()
+                val persistedZoneId = preferencesStore.readLastSelectedZoneId()
+                val selected = zones.firstOrNull { it.id == persistedZoneId }?.id ?: zones.firstOrNull()?.id
+                val sort = preferencesStore.readSort() ?: ApplicationSortOrder.DEFAULT
+                _uiState.update { it.copy(zones = zones, sort = sort, selectedZoneId = selected) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                _uiState.update { it.copy(isLoading = false, error = e) }
+                return@launch
+            }
+            fetchFirstPage()
+        }
+    }
+
+    public fun selectZone(zoneId: WatchZoneId) {
+        viewModelScope.launch { preferencesStore.writeLastSelectedZoneId(zoneId) }
+        _uiState.update { it.copy(selectedZoneId = zoneId, applications = emptyList(), nextCursor = null) }
+        fetchFirstPage()
+    }
+
+    public fun selectSort(sort: ApplicationSortOrder) {
+        viewModelScope.launch { preferencesStore.writeSort(sort) }
+        _uiState.update { it.copy(sort = sort, applications = emptyList(), nextCursor = null) }
+        fetchFirstPage()
+    }
+
+    /** Sets the active chip. [ApplicationFilter]'s shape makes status/unread mutual exclusivity automatic — this always replaces the whole filter. */
+    public fun selectFilter(filter: ApplicationFilter) {
+        _uiState.update { it.copy(filter = filter, applications = emptyList(), nextCursor = null) }
+        fetchFirstPage()
+    }
+
+    /** Called by the Screen for each composed row index; prefetches the next page once within [PREFETCH_THRESHOLD] rows of the end. */
+    public fun onItemVisible(index: Int) {
+        val state = _uiState.value
+        if (state.hasMore && !state.isLoadingMore && index >= state.applications.size - PREFETCH_THRESHOLD) {
+            loadMore()
+        }
+    }
+
+    /** Optimistically clears [application]'s unread state, then fires-and-forgets the mark-read request (errors swallowed). */
+    @Suppress("SwallowedException")
+    // Fire-and-forget by design (GH#775): the optimistic local clear already
+    // reflects the user's intent; a failed background sync isn't worth an
+    // error banner the user didn't ask to see.
+    public fun markAsRead(application: PlanningApplication) {
+        if (application.latestUnreadEvent == null) return
+        _uiState.update { state ->
+            state.copy(
+                applications =
+                    state.applications.map { row ->
+                        if (row.id == application.id) row.copy(latestUnreadEvent = null) else row
+                    },
+            )
+        }
+        viewModelScope.launch {
+            try {
+                notificationStateRepository.markRead(listOf(application.id))
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                // Swallowed — see the function doc.
+            }
+        }
+    }
+
+    /** Marks every application read server-side, invalidates every zone's offline cache, then refetches the active zone. */
+    public fun markAllRead() {
+        viewModelScope.launch {
+            try {
+                notificationStateRepository.markAllRead()
+                applicationCacheStore.invalidateAll()
+                fetchFirstPage()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                _uiState.update { it.copy(error = e) }
+            }
+        }
+    }
+
+    private fun fetchFirstPage() {
+        val zoneId = _uiState.value.selectedZoneId
+        if (zoneId == null) {
+            _uiState.update { it.copy(isLoading = false) }
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val state = _uiState.value
+                val page = applicationRepository.applications(zoneId, state.sort, state.filter)
+                _uiState.update { it.copy(applications = page.applications, nextCursor = page.nextCursor, isLoading = false) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                _uiState.update { it.copy(isLoading = false, error = e) }
+            }
+        }
+    }
+
+    private fun loadMore() {
+        val state = _uiState.value
+        val zoneId = state.selectedZoneId ?: return
+        val cursor = state.nextCursor ?: return
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingMore = true) }
+            try {
+                val page = applicationRepository.applications(zoneId, state.sort, state.filter, cursor)
+                _uiState.update {
+                    it.copy(
+                        applications = it.applications + page.applications,
+                        nextCursor = page.nextCursor,
+                        isLoadingMore = false,
+                    )
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                _uiState.update { it.copy(isLoadingMore = false, error = e) }
+            }
+        }
+    }
+
+    public companion object {
+        public const val PREFETCH_THRESHOLD: Int = 10
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListViewModel.kt
@@ -131,7 +131,13 @@ public class ApplicationListViewModel(
             try {
                 val state = _uiState.value
                 val page = applicationRepository.applications(zoneId, state.sort, state.filter)
-                _uiState.update { it.copy(applications = page.applications, nextCursor = page.nextCursor, isLoading = false) }
+                _uiState.update {
+                    it.copy(
+                        applications = page.applications,
+                        nextCursor = page.nextCursor,
+                        isLoading = false,
+                    )
+                }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: DomainError) {

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/FilterChipsRow.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/FilterChipsRow.kt
@@ -1,0 +1,78 @@
+package uk.towncrierapp.presentation.features.applicationlist
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import uk.towncrierapp.domain.applications.ApplicationFilter
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.components.CapsuleChip
+
+private val FILTERABLE_STATUSES =
+    listOf(
+        ApplicationStatus.Undecided,
+        ApplicationStatus.Permitted,
+        ApplicationStatus.Conditions,
+        ApplicationStatus.Rejected,
+        ApplicationStatus.Withdrawn,
+        ApplicationStatus.Appealed,
+    )
+
+/**
+ * The All/6-status/Unread chip row — single-select, status vs unread
+ * mutually exclusive BY [ApplicationFilter]'s shape (see the type itself),
+ * not a runtime check here. Split into its own file to keep
+ * `ApplicationListScreen.kt` under detekt's per-file function budget.
+ */
+@Composable
+internal fun FilterChipsRow(
+    filter: ApplicationFilter,
+    unreadCount: Int,
+    onFilterSelected: (ApplicationFilter) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(TownCrierSpacing.sm),
+        contentPadding = PaddingValues(horizontal = TownCrierSpacing.md),
+    ) {
+        item {
+            CapsuleChip(
+                label = stringResource(R.string.applications_filter_all),
+                selected = filter == ApplicationFilter.All,
+                onClick = { onFilterSelected(ApplicationFilter.All) },
+            )
+        }
+        items(FILTERABLE_STATUSES) { status ->
+            CapsuleChip(
+                label = statusFilterLabel(status),
+                selected = filter == ApplicationFilter.Status(status),
+                onClick = { onFilterSelected(ApplicationFilter.Status(status)) },
+            )
+        }
+        item {
+            CapsuleChip(
+                label = "${stringResource(R.string.applications_filter_unread)} ($unreadCount)",
+                selected = filter == ApplicationFilter.Unread,
+                onClick = { onFilterSelected(ApplicationFilter.Unread) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun statusFilterLabel(status: ApplicationStatus): String =
+    when (status) {
+        ApplicationStatus.Undecided -> stringResource(R.string.application_status_pending)
+        ApplicationStatus.Permitted -> stringResource(R.string.application_status_permitted)
+        ApplicationStatus.Conditions -> stringResource(R.string.application_status_conditions)
+        ApplicationStatus.Rejected -> stringResource(R.string.application_status_rejected)
+        ApplicationStatus.Withdrawn -> stringResource(R.string.application_status_withdrawn)
+        ApplicationStatus.Appealed -> stringResource(R.string.application_status_appealed)
+        else -> stringResource(R.string.application_status_unknown)
+    }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/SortMenu.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/SortMenu.kt
@@ -1,0 +1,64 @@
+package uk.towncrierapp.presentation.features.applicationlist
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Sort
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
+import uk.towncrierapp.domain.applications.ApplicationSortOrder
+import uk.towncrierapp.presentation.R
+
+/**
+ * The top-app-bar sort menu: [availableSorts] already has `distance` filtered
+ * out by [ApplicationListUiState.availableSorts] whenever no zone is active —
+ * this composable has no opinion on that, it just renders whatever list it's
+ * given with a checkmark on the current selection. Split into its own file
+ * to keep `ApplicationListScreen.kt` under detekt's per-file function budget.
+ */
+@Composable
+internal fun SortMenu(
+    currentSort: ApplicationSortOrder,
+    availableSorts: List<ApplicationSortOrder>,
+    onSortSelected: (ApplicationSortOrder) -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    IconButton(onClick = { expanded = true }) {
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.Sort,
+            contentDescription = stringResource(R.string.applications_sort_content_description),
+        )
+    }
+    DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+        availableSorts.forEach { sort ->
+            DropdownMenuItem(
+                text = { Text(sortLabel(sort)) },
+                onClick = {
+                    onSortSelected(sort)
+                    expanded = false
+                },
+                trailingIcon = {
+                    if (sort == currentSort) Icon(imageVector = Icons.Filled.Check, contentDescription = null)
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun sortLabel(sort: ApplicationSortOrder): String =
+    when (sort) {
+        ApplicationSortOrder.DISTANCE -> stringResource(R.string.applications_sort_distance)
+        ApplicationSortOrder.NEWEST -> stringResource(R.string.applications_sort_newest)
+        ApplicationSortOrder.OLDEST -> stringResource(R.string.applications_sort_oldest)
+        ApplicationSortOrder.STATUS -> stringResource(R.string.applications_sort_status)
+        ApplicationSortOrder.RECENT_ACTIVITY -> stringResource(R.string.applications_sort_recent_activity)
+    }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/saved/SavedListScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/saved/SavedListScreen.kt
@@ -82,18 +82,28 @@ internal fun SavedListScreen(
             Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
                 val displayed = state.displayed
                 when {
-                    state.isLoading && displayed.isEmpty() -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-                    displayed.isEmpty() -> SavedEmptyState(modifier = Modifier.align(Alignment.Center))
-                    else ->
+                    state.isLoading && displayed.isEmpty() -> {
+                        CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                    }
+
+                    displayed.isEmpty() -> {
+                        SavedEmptyState(modifier = Modifier.align(Alignment.Center))
+                    }
+
+                    else -> {
                         LazyColumn(modifier = Modifier.fillMaxSize()) {
                             items(displayed, key = { it.applicationUid.value }) { saved ->
                                 val application = saved.application
                                 if (application != null) {
-                                    ApplicationRow(application = application, onClick = { onApplicationClick(application) })
+                                    ApplicationRow(
+                                        application = application,
+                                        onClick = { onApplicationClick(application) },
+                                    )
                                     HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
                                 }
                             }
                         }
+                    }
                 }
             }
             state.error?.let { error ->
@@ -137,7 +147,11 @@ private fun SavedFilterChipsRow(
             )
         }
         items(SAVED_FILTERABLE_STATUSES) { status ->
-            CapsuleChip(label = savedStatusLabel(status), selected = filter == status, onClick = { onFilterSelected(status) })
+            CapsuleChip(
+                label = savedStatusLabel(status),
+                selected = filter == status,
+                onClick = { onFilterSelected(status) },
+            )
         }
     }
 }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/saved/SavedListScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/saved/SavedListScreen.kt
@@ -1,0 +1,186 @@
+package uk.towncrierapp.presentation.features.saved
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.applications.PlanningApplication
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import uk.towncrierapp.presentation.designsystem.components.ApplicationRow
+import uk.towncrierapp.presentation.designsystem.components.CapsuleChip
+import uk.towncrierapp.presentation.features.applicationlist.applicationErrorMessageRes
+
+/**
+ * The Saved tab: the flat, cross-zone saved list with a client-side status
+ * filter. Tapping a row hands the already-cached [PlanningApplication]
+ * straight to the caller so detail can render it instantly (stale-while-
+ * revalidate happens there). Port of iOS `SavedApplicationListView`
+ * (GH#775).
+ */
+@Composable
+public fun SavedListRoute(
+    viewModel: SavedListViewModel,
+    onApplicationSelected: (PlanningApplication) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    SavedListScreen(
+        state = state,
+        onFilterSelected = viewModel::selectFilter,
+        onApplicationClick = onApplicationSelected,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SavedListScreen(
+    state: SavedListUiState,
+    onFilterSelected: (ApplicationStatus?) -> Unit,
+    onApplicationClick: (PlanningApplication) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = { TopAppBar(title = { Text(stringResource(R.string.saved_title)) }) },
+    ) { contentPadding ->
+        Column(modifier = Modifier.padding(contentPadding).fillMaxSize()) {
+            SavedFilterChipsRow(
+                filter = state.filter,
+                onFilterSelected = onFilterSelected,
+                modifier = Modifier.padding(vertical = TownCrierSpacing.sm),
+            )
+            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                val displayed = state.displayed
+                when {
+                    state.isLoading && displayed.isEmpty() -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                    displayed.isEmpty() -> SavedEmptyState(modifier = Modifier.align(Alignment.Center))
+                    else ->
+                        LazyColumn(modifier = Modifier.fillMaxSize()) {
+                            items(displayed, key = { it.applicationUid.value }) { saved ->
+                                val application = saved.application
+                                if (application != null) {
+                                    ApplicationRow(application = application, onClick = { onApplicationClick(application) })
+                                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                                }
+                            }
+                        }
+                }
+            }
+            state.error?.let { error ->
+                Text(
+                    text = stringResource(applicationErrorMessageRes(error)),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(TownCrierSpacing.md),
+                )
+            }
+        }
+    }
+}
+
+private val SAVED_FILTERABLE_STATUSES =
+    listOf(
+        ApplicationStatus.Undecided,
+        ApplicationStatus.Permitted,
+        ApplicationStatus.Conditions,
+        ApplicationStatus.Rejected,
+        ApplicationStatus.Withdrawn,
+        ApplicationStatus.Appealed,
+    )
+
+@Composable
+private fun SavedFilterChipsRow(
+    filter: ApplicationStatus?,
+    onFilterSelected: (ApplicationStatus?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(TownCrierSpacing.sm),
+        contentPadding = PaddingValues(horizontal = TownCrierSpacing.md),
+    ) {
+        item {
+            CapsuleChip(
+                label = stringResource(R.string.applications_filter_all),
+                selected = filter == null,
+                onClick = { onFilterSelected(null) },
+            )
+        }
+        items(SAVED_FILTERABLE_STATUSES) { status ->
+            CapsuleChip(label = savedStatusLabel(status), selected = filter == status, onClick = { onFilterSelected(status) })
+        }
+    }
+}
+
+@Composable
+private fun savedStatusLabel(status: ApplicationStatus): String =
+    when (status) {
+        ApplicationStatus.Undecided -> stringResource(R.string.application_status_pending)
+        ApplicationStatus.Permitted -> stringResource(R.string.application_status_permitted)
+        ApplicationStatus.Conditions -> stringResource(R.string.application_status_conditions)
+        ApplicationStatus.Rejected -> stringResource(R.string.application_status_rejected)
+        ApplicationStatus.Withdrawn -> stringResource(R.string.application_status_withdrawn)
+        ApplicationStatus.Appealed -> stringResource(R.string.application_status_appealed)
+        else -> stringResource(R.string.application_status_unknown)
+    }
+
+@Composable
+private fun SavedEmptyState(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.padding(TownCrierSpacing.xl),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.md),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Bookmark,
+            contentDescription = null,
+            tint = TownCrierTheme.colors.textTertiary,
+            modifier = Modifier.size(48.dp),
+        )
+        Text(text = stringResource(R.string.saved_empty_title), style = MaterialTheme.typography.titleMedium)
+        Text(
+            text = stringResource(R.string.saved_empty_message),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+@Preview(name = "empty, light")
+@Preview(name = "empty, dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun SavedListScreenEmptyPreview() {
+    TownCrierTheme {
+        SavedListScreen(state = SavedListUiState(), onFilterSelected = {}, onApplicationClick = {})
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/saved/SavedListUiState.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/saved/SavedListUiState.kt
@@ -1,0 +1,27 @@
+package uk.towncrierapp.presentation.features.saved
+
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.applications.SavedApplication
+import uk.towncrierapp.domain.auth.DomainError
+
+/**
+ * `SavedListScreen` state. [displayed] is the presentation-ready projection
+ * of [savedApplications]: legacy rows with a `null` payload are dropped
+ * entirely (never shown as an empty/placeholder row), [filter] (client-side
+ * only — the endpoint itself is unfiltered) narrows by status when set, and
+ * the result is always `savedAt` DESC. Port of iOS
+ * `SavedApplicationListViewModel`'s published state (GH#775).
+ */
+public data class SavedListUiState(
+    val savedApplications: List<SavedApplication> = emptyList(),
+    val filter: ApplicationStatus? = null,
+    val isLoading: Boolean = false,
+    val error: DomainError? = null,
+) {
+    public val displayed: List<SavedApplication>
+        get() =
+            savedApplications
+                .filter { it.application != null }
+                .filter { filter == null || it.application?.status == filter }
+                .sortedByDescending { it.savedAt }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/saved/SavedListViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/saved/SavedListViewModel.kt
@@ -1,0 +1,40 @@
+package uk.towncrierapp.presentation.features.saved
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.applications.SavedApplicationRepository
+import uk.towncrierapp.domain.auth.DomainError
+
+/** Drives the Saved tab: the flat cross-zone saved list, with a client-side status filter. Port of iOS `SavedApplicationListViewModel` (GH#775). */
+public class SavedListViewModel(
+    private val repository: SavedApplicationRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(SavedListUiState())
+    public val uiState: StateFlow<SavedListUiState> = _uiState.asStateFlow()
+
+    public fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            try {
+                val saved = repository.savedApplications()
+                _uiState.update { it.copy(savedApplications = saved, isLoading = false) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                _uiState.update { it.copy(isLoading = false, error = e) }
+            }
+        }
+    }
+
+    /** `null` shows every (non-legacy) saved application. */
+    public fun selectFilter(status: ApplicationStatus?) {
+        _uiState.update { it.copy(filter = status) }
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneEditorViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneEditorViewModel.kt
@@ -8,6 +8,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import uk.towncrierapp.domain.applications.ApplicationCacheStore
+import uk.towncrierapp.domain.applications.CachedApplicationPage
 import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.domain.subscriptions.Entitlement
 import uk.towncrierapp.domain.subscriptions.FeatureGate
@@ -31,6 +33,10 @@ public class WatchZoneEditorViewModel(
     private val repository: WatchZoneRepository,
     tier: SubscriptionTier,
     private val editingZone: WatchZone? = null,
+    // Defaults to a no-op so every pre-existing call site (tests, and any
+    // future caller with nothing to invalidate) keeps compiling unchanged;
+    // the composition root wires the real cache seam explicitly (tc-cnme).
+    private val applicationCacheStore: ApplicationCacheStore = NoOpApplicationCacheStore,
 ) : ViewModel() {
     private val limits = WatchZoneLimits(tier)
 
@@ -113,7 +119,16 @@ public class WatchZoneEditorViewModel(
                     emailInstantEnabled = state.emailInstantEnabled,
                 )
             try {
-                if (editingZone != null) repository.update(zone) else repository.create(zone)
+                if (editingZone != null) {
+                    repository.update(zone)
+                    // Only the edit path invalidates (tc-cnme): a brand-new
+                    // zone has no prior applications-list cache entry to
+                    // invalidate, mirroring iOS AppCoordinator+WatchZones.swift's
+                    // onSave callback.
+                    applicationCacheStore.invalidate(zone.id)
+                } else {
+                    repository.create(zone)
+                }
                 _uiState.update { it.copy(saveCompleted = true) }
             } catch (e: CancellationException) {
                 throw e
@@ -140,6 +155,21 @@ public class WatchZoneEditorViewModel(
 // count under detekt's TooManyFunctions budget — it needs no instance state.
 private fun WatchZoneEditorUiState.withSaveEnabled(): WatchZoneEditorUiState =
     copy(isSaveEnabled = geocodedCoordinate != null && name.isNotBlank())
+
+// The default ApplicationCacheStore (tc-cnme) — genuinely stateless, so a
+// shared `object` (not a hidden mutable global) is the right shape here.
+private object NoOpApplicationCacheStore : ApplicationCacheStore {
+    override suspend fun get(zoneId: WatchZoneId): CachedApplicationPage? = null
+
+    override suspend fun put(
+        zoneId: WatchZoneId,
+        entry: CachedApplicationPage,
+    ) = Unit
+
+    override suspend fun invalidate(zoneId: WatchZoneId) = Unit
+
+    override suspend fun invalidateAll() = Unit
+}
 
 private fun initialState(
     tier: SubscriptionTier,

--- a/mobile/android/presentation/src/main/res/values/strings.xml
+++ b/mobile/android/presentation/src/main/res/values/strings.xml
@@ -13,9 +13,10 @@
     <string name="force_update_message">A newer version of Town Crier is available. Please update to continue using the app.</string>
     <string name="force_update_button">Update Now</string>
 
-    <!-- Bottom navigation (tc-z95t) -->
-    <string name="bottom_nav_home">Home</string>
+    <!-- Bottom navigation (tc-z95t / GH#775: Applications replaces the Home placeholder as the first destination) -->
+    <string name="bottom_nav_applications">Applications</string>
     <string name="bottom_nav_zones">Zones</string>
+    <string name="bottom_nav_saved">Saved</string>
 
     <!-- Shared gating copy (tc-z95t) -->
     <string name="upgrade_badge_label">Upgrade</string>
@@ -76,4 +77,46 @@
     <string name="zone_preferences_email_label">Email</string>
     <string name="zone_preferences_save_button">Save</string>
     <string name="zone_preferences_cancel_button">Cancel</string>
+
+    <!-- Application status display mapping (GH#775, ported byte-exact from the spec table) -->
+    <string name="application_status_pending">Pending</string>
+    <string name="application_status_permitted">Granted</string>
+    <string name="application_status_conditions">Granted with conditions</string>
+    <string name="application_status_rejected">Refused</string>
+    <string name="application_status_withdrawn">Withdrawn</string>
+    <string name="application_status_appealed">Appealed</string>
+    <string name="application_status_unknown">Unknown</string>
+
+    <!-- Application list (GH#775) -->
+    <string name="applications_title">Applications</string>
+    <string name="applications_filter_all">All</string>
+    <string name="applications_filter_unread">Unread</string>
+    <string name="applications_sort_content_description">Sort</string>
+    <string name="applications_sort_distance">Distance</string>
+    <string name="applications_sort_newest">Newest</string>
+    <string name="applications_sort_oldest">Oldest</string>
+    <string name="applications_sort_status">Status</string>
+    <string name="applications_sort_recent_activity">Recent activity</string>
+    <string name="applications_mark_all_read">Mark all read</string>
+    <string name="applications_empty_title">No applications yet</string>
+    <string name="applications_empty_message">We haven\'t seen any planning applications in this watch zone yet. Check back soon.</string>
+    <string name="applications_no_zones_title">No watch zones yet</string>
+    <string name="applications_no_zones_message">Add a watch zone to start browsing planning applications near you.</string>
+    <string name="applications_no_zones_cta">Add Watch Zone</string>
+    <string name="applications_error_network">Check your internet connection and try again.</string>
+    <string name="applications_error_generic">Something went wrong. Please try again.</string>
+
+    <!-- Saved applications (GH#775) -->
+    <string name="saved_title">Saved</string>
+    <string name="saved_empty_title">No saved applications</string>
+    <string name="saved_empty_message">Applications you save will show up here.</string>
+
+    <!-- Application detail (GH#775) -->
+    <string name="application_detail_reference_label">Reference</string>
+    <string name="application_detail_authority_label">Authority</string>
+    <string name="application_detail_received_label">Received</string>
+    <string name="application_detail_portal_button">View on Council Portal</string>
+    <string name="application_detail_save_content_description">Save application</string>
+    <string name="application_detail_unsave_content_description">Remove from saved</string>
+    <string name="application_detail_share_content_description">Share application</string>
 </resources>

--- a/mobile/android/presentation/src/main/res/values/strings.xml
+++ b/mobile/android/presentation/src/main/res/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="saved_empty_message">Applications you save will show up here.</string>
 
     <!-- Application detail (GH#775) -->
+    <string name="application_detail_address_label">Address</string>
     <string name="application_detail_reference_label">Reference</string>
     <string name="application_detail_authority_label">Authority</string>
     <string name="application_detail_received_label">Received</string>

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/designsystem/DateDisplayFormatterTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/designsystem/DateDisplayFormatterTest.kt
@@ -1,0 +1,22 @@
+package uk.towncrierapp.presentation.designsystem
+
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import kotlin.test.assertEquals
+
+/**
+ * Absolute dates ONLY, never relative/"time ago" text, anywhere (GH#775 —
+ * byte-exact port of iOS `Date+TownCrier.swift`'s shared formatter):
+ * `d MMM yyyy`, en-GB.
+ */
+class DateDisplayFormatterTest {
+    @Test
+    fun `formats a date as day, short month, year`() {
+        assertEquals("14 Nov 2023", DateDisplayFormatter.format(LocalDate.of(2023, 11, 14)))
+    }
+
+    @Test
+    fun `does not zero-pad a single-digit day`() {
+        assertEquals("1 Jan 2026", DateDisplayFormatter.format(LocalDate.of(2026, 1, 1)))
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailViewModelTest.kt
@@ -1,0 +1,153 @@
+package uk.towncrierapp.presentation.features.applicationdetail
+
+import kotlinx.coroutines.CompletableDeferred
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.applications.FakePlanningApplicationRepository
+import uk.towncrierapp.domain.applications.FakeSavedApplicationRepository
+import uk.towncrierapp.domain.applications.aLocalAuthority
+import uk.towncrierapp.domain.applications.aPlanningApplication
+import uk.towncrierapp.domain.applications.aPlanningApplicationId
+import uk.towncrierapp.domain.applications.aSavedApplication
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Port of iOS `ApplicationDetailViewModelTests` (GH#775). */
+@ExtendWith(MainDispatcherExtension::class)
+class ApplicationDetailViewModelTest {
+    @Test
+    fun `the passed-in application renders instantly, before any refresh completes`() {
+        val initial = aPlanningApplication(description = "Initial description")
+        val viewModel = ApplicationDetailViewModel(FakePlanningApplicationRepository(), FakeSavedApplicationRepository(), initial)
+
+        assertEquals(initial, viewModel.uiState.value.application)
+        assertFalse(viewModel.uiState.value.isRefreshing)
+    }
+
+    @Test
+    fun `refresh replaces the rendered application with the fresh by-id fetch`() {
+        val initial = aPlanningApplication(description = "Initial description")
+        val fresh = aPlanningApplication(description = "Fresh description")
+        val repository = FakePlanningApplicationRepository().apply { detailResult = fresh }
+        val viewModel = ApplicationDetailViewModel(repository, FakeSavedApplicationRepository(), initial)
+
+        viewModel.refresh()
+
+        assertEquals(fresh, viewModel.uiState.value.application)
+        assertFalse(viewModel.uiState.value.isRefreshing)
+        assertEquals(initial.id.authority to initial.id.name, repository.detailCalls.single())
+    }
+
+    @Test
+    fun `a second rapid refresh while one is already in flight is ignored (re-entrancy guard)`() {
+        val repository = FakePlanningApplicationRepository()
+        val gate = CompletableDeferred<Unit>()
+        repository.beforeDetail = { gate.await() }
+        val viewModel = ApplicationDetailViewModel(repository, FakeSavedApplicationRepository(), aPlanningApplication())
+
+        viewModel.refresh()
+        viewModel.refresh()
+
+        assertEquals(1, repository.detailCalls.size)
+        assertTrue(viewModel.uiState.value.isRefreshing)
+
+        gate.complete(Unit)
+
+        assertFalse(viewModel.uiState.value.isRefreshing)
+        assertEquals(1, repository.detailCalls.size)
+    }
+
+    @Test
+    fun `a refresh failure surfaces an error but keeps the stale application rendered`() {
+        val initial = aPlanningApplication()
+        val repository = FakePlanningApplicationRepository().apply { detailFailWith = DomainError.NetworkUnavailable }
+        val viewModel = ApplicationDetailViewModel(repository, FakeSavedApplicationRepository(), initial)
+
+        viewModel.refresh()
+
+        assertEquals(initial, viewModel.uiState.value.application)
+        assertEquals(DomainError.NetworkUnavailable, viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `share is disabled until the by-id refresh supplies an authoritySlug`() {
+        val initial = aPlanningApplication(authority = aLocalAuthority(slug = null))
+        val repository =
+            FakePlanningApplicationRepository().apply { detailResult = aPlanningApplication(authority = aLocalAuthority(slug = "camden")) }
+        val viewModel = ApplicationDetailViewModel(repository, FakeSavedApplicationRepository(), initial)
+
+        assertFalse(viewModel.uiState.value.canShare)
+
+        viewModel.refresh()
+
+        assertTrue(viewModel.uiState.value.canShare)
+        assertEquals("camden", viewModel.uiState.value.authoritySlug)
+    }
+
+    @Test
+    fun `checkSavedState compares by the reconstructed PlanningApplicationId, not a raw uid string`() {
+        val id = aPlanningApplicationId(authority = "42", name = "24/0001")
+        val application = aPlanningApplication(id = id)
+        val savedRepository = FakeSavedApplicationRepository(mutableListOf(aSavedApplication(applicationUid = id)))
+        val viewModel = ApplicationDetailViewModel(FakePlanningApplicationRepository(), savedRepository, application)
+
+        viewModel.checkSavedState()
+
+        assertTrue(viewModel.uiState.value.isSaved)
+    }
+
+    @Test
+    fun `checkSavedState is false when no saved row's reconstructed id matches`() {
+        val application = aPlanningApplication(id = aPlanningApplicationId(name = "24/0001"))
+        val savedRepository =
+            FakeSavedApplicationRepository(mutableListOf(aSavedApplication(applicationUid = aPlanningApplicationId(name = "24/9999"))))
+        val viewModel = ApplicationDetailViewModel(FakePlanningApplicationRepository(), savedRepository, application)
+
+        viewModel.checkSavedState()
+
+        assertFalse(viewModel.uiState.value.isSaved)
+    }
+
+    @Test
+    fun `toggleSave saves when not currently saved`() {
+        val application = aPlanningApplication()
+        val savedRepository = FakeSavedApplicationRepository()
+        val viewModel = ApplicationDetailViewModel(FakePlanningApplicationRepository(), savedRepository, application)
+
+        viewModel.toggleSave()
+
+        assertTrue(viewModel.uiState.value.isSaved)
+        assertEquals(listOf(application.id), savedRepository.saveCalls)
+        assertTrue(savedRepository.unsaveCalls.isEmpty())
+    }
+
+    @Test
+    fun `toggleSave unsaves when currently saved`() {
+        val id = aPlanningApplicationId()
+        val application = aPlanningApplication(id = id)
+        val savedRepository = FakeSavedApplicationRepository(mutableListOf(aSavedApplication(applicationUid = id)))
+        val viewModel = ApplicationDetailViewModel(FakePlanningApplicationRepository(), savedRepository, application)
+        viewModel.checkSavedState()
+
+        viewModel.toggleSave()
+
+        assertFalse(viewModel.uiState.value.isSaved)
+        assertEquals(listOf(id), savedRepository.unsaveCalls)
+    }
+
+    @Test
+    fun `toggleSave reverts the optimistic state and surfaces an error on failure`() {
+        val application = aPlanningApplication()
+        val savedRepository = FakeSavedApplicationRepository().apply { saveFailWith = DomainError.NetworkUnavailable }
+        val viewModel = ApplicationDetailViewModel(FakePlanningApplicationRepository(), savedRepository, application)
+
+        viewModel.toggleSave()
+
+        assertFalse(viewModel.uiState.value.isSaved)
+        assertEquals(DomainError.NetworkUnavailable, viewModel.uiState.value.error)
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailViewModelTest.kt
@@ -22,7 +22,8 @@ class ApplicationDetailViewModelTest {
     @Test
     fun `the passed-in application renders instantly, before any refresh completes`() {
         val initial = aPlanningApplication(description = "Initial description")
-        val viewModel = ApplicationDetailViewModel(FakePlanningApplicationRepository(), FakeSavedApplicationRepository(), initial)
+        val viewModel =
+            ApplicationDetailViewModel(FakePlanningApplicationRepository(), FakeSavedApplicationRepository(), initial)
 
         assertEquals(initial, viewModel.uiState.value.application)
         assertFalse(viewModel.uiState.value.isRefreshing)
@@ -77,7 +78,10 @@ class ApplicationDetailViewModelTest {
     fun `share is disabled until the by-id refresh supplies an authoritySlug`() {
         val initial = aPlanningApplication(authority = aLocalAuthority(slug = null))
         val repository =
-            FakePlanningApplicationRepository().apply { detailResult = aPlanningApplication(authority = aLocalAuthority(slug = "camden")) }
+            FakePlanningApplicationRepository().apply {
+                detailResult =
+                    aPlanningApplication(authority = aLocalAuthority(slug = "camden"))
+            }
         val viewModel = ApplicationDetailViewModel(repository, FakeSavedApplicationRepository(), initial)
 
         assertFalse(viewModel.uiState.value.canShare)
@@ -104,7 +108,9 @@ class ApplicationDetailViewModelTest {
     fun `checkSavedState is false when no saved row's reconstructed id matches`() {
         val application = aPlanningApplication(id = aPlanningApplicationId(name = "24/0001"))
         val savedRepository =
-            FakeSavedApplicationRepository(mutableListOf(aSavedApplication(applicationUid = aPlanningApplicationId(name = "24/9999"))))
+            FakeSavedApplicationRepository(
+                mutableListOf(aSavedApplication(applicationUid = aPlanningApplicationId(name = "24/9999"))),
+            )
         val viewModel = ApplicationDetailViewModel(FakePlanningApplicationRepository(), savedRepository, application)
 
         viewModel.checkSavedState()

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListViewModelTest.kt
@@ -1,0 +1,202 @@
+package uk.towncrierapp.presentation.features.applicationlist
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.applications.ApplicationFilter
+import uk.towncrierapp.domain.applications.ApplicationSortOrder
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.applications.FakeApplicationCacheStore
+import uk.towncrierapp.domain.applications.FakeApplicationListPreferencesStore
+import uk.towncrierapp.domain.applications.FakeNotificationStateRepository
+import uk.towncrierapp.domain.applications.FakePlanningApplicationRepository
+import uk.towncrierapp.domain.applications.aLatestUnreadEvent
+import uk.towncrierapp.domain.applications.aPlanningApplication
+import uk.towncrierapp.domain.applications.anApplicationPage
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.watchzones.FakeWatchZoneRepository
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import uk.towncrierapp.domain.watchzones.aWatchZone
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/** Port of the iOS `ApplicationListViewModel*Tests` suites (GH#775). */
+@ExtendWith(MainDispatcherExtension::class)
+class ApplicationListViewModelTest {
+    private fun makeSut(
+        applicationRepository: FakePlanningApplicationRepository = FakePlanningApplicationRepository(),
+        watchZoneRepository: FakeWatchZoneRepository = FakeWatchZoneRepository(mutableListOf(aWatchZone())),
+        notificationStateRepository: FakeNotificationStateRepository = FakeNotificationStateRepository(),
+        applicationCacheStore: FakeApplicationCacheStore = FakeApplicationCacheStore(),
+        preferencesStore: FakeApplicationListPreferencesStore = FakeApplicationListPreferencesStore(),
+    ) = ApplicationListViewModel(
+        applicationRepository,
+        watchZoneRepository,
+        notificationStateRepository,
+        applicationCacheStore,
+        preferencesStore,
+    )
+
+    @Test
+    fun `the default sort is recent-activity when nothing is persisted`() {
+        val viewModel = makeSut()
+
+        viewModel.load()
+
+        assertEquals(ApplicationSortOrder.RECENT_ACTIVITY, viewModel.uiState.value.sort)
+    }
+
+    @Test
+    fun `load restores a persisted sort`() {
+        val preferences = FakeApplicationListPreferencesStore(storedSort = ApplicationSortOrder.OLDEST)
+        val viewModel = makeSut(preferencesStore = preferences)
+
+        viewModel.load()
+
+        assertEquals(ApplicationSortOrder.OLDEST, viewModel.uiState.value.sort)
+    }
+
+    @Test
+    fun `selecting a sort persists it and refetches the first page`() {
+        val preferences = FakeApplicationListPreferencesStore()
+        val applicationRepository = FakePlanningApplicationRepository()
+        val viewModel = makeSut(applicationRepository = applicationRepository, preferencesStore = preferences)
+        viewModel.load()
+
+        viewModel.selectSort(ApplicationSortOrder.NEWEST)
+
+        assertEquals(ApplicationSortOrder.NEWEST, preferences.storedSort)
+        assertEquals(ApplicationSortOrder.NEWEST, applicationRepository.applicationsCalls.last().sort)
+    }
+
+    @Test
+    fun `load restores a persisted last-selected zone when it is still in the zone list`() {
+        val zoneA = aWatchZone(id = WatchZoneId("wz-a"))
+        val zoneB = aWatchZone(id = WatchZoneId("wz-b"))
+        val watchZoneRepository = FakeWatchZoneRepository(mutableListOf(zoneA, zoneB))
+        val preferences = FakeApplicationListPreferencesStore(storedZoneId = WatchZoneId("wz-b"))
+        val viewModel = makeSut(watchZoneRepository = watchZoneRepository, preferencesStore = preferences)
+
+        viewModel.load()
+
+        assertEquals(WatchZoneId("wz-b"), viewModel.uiState.value.selectedZoneId)
+    }
+
+    @Test
+    fun `selecting a filter replaces it entirely — status and unread are mutually exclusive`() {
+        val applicationRepository = FakePlanningApplicationRepository()
+        val viewModel = makeSut(applicationRepository = applicationRepository)
+        viewModel.load()
+
+        viewModel.selectFilter(ApplicationFilter.Status(ApplicationStatus.Permitted))
+        assertEquals(ApplicationFilter.Status(ApplicationStatus.Permitted), viewModel.uiState.value.filter)
+        assertIs<ApplicationFilter.Status>(applicationRepository.applicationsCalls.last().filter)
+
+        viewModel.selectFilter(ApplicationFilter.Unread)
+        assertEquals(ApplicationFilter.Unread, viewModel.uiState.value.filter)
+        assertEquals(ApplicationFilter.Unread, applicationRepository.applicationsCalls.last().filter)
+    }
+
+    @Test
+    fun `availableSorts hides distance when no zone is active`() {
+        val watchZoneRepository = FakeWatchZoneRepository(mutableListOf())
+        val viewModel = makeSut(watchZoneRepository = watchZoneRepository)
+
+        viewModel.load()
+
+        assertFalse(viewModel.uiState.value.availableSorts.contains(ApplicationSortOrder.DISTANCE))
+    }
+
+    @Test
+    fun `availableSorts includes distance once a zone is active`() {
+        val viewModel = makeSut()
+
+        viewModel.load()
+
+        assertTrue(viewModel.uiState.value.availableSorts.contains(ApplicationSortOrder.DISTANCE))
+    }
+
+    @Test
+    fun `onItemVisible prefetches the next page once within 10 rows of the end`() {
+        val applications = List(20) { aPlanningApplication() }
+        val applicationRepository =
+            FakePlanningApplicationRepository().apply {
+                applicationsResult = anApplicationPage(applications = applications, nextCursor = "cursor-2")
+            }
+        val viewModel = makeSut(applicationRepository = applicationRepository)
+        viewModel.load()
+        applicationRepository.applicationsResult = anApplicationPage(applications = emptyList(), nextCursor = null)
+
+        viewModel.onItemVisible(applications.size - 11)
+        assertEquals(1, applicationRepository.applicationsCalls.size)
+
+        viewModel.onItemVisible(applications.size - 10)
+        assertEquals(2, applicationRepository.applicationsCalls.size)
+        assertEquals("cursor-2", applicationRepository.applicationsCalls.last().cursor)
+    }
+
+    @Test
+    fun `unreadCount counts only currently-loaded rows with an unread event`() {
+        val unread = aPlanningApplication(latestUnreadEvent = aLatestUnreadEvent())
+        val read = aPlanningApplication(id = uk.towncrierapp.domain.applications.aPlanningApplicationId(name = "24/0002"))
+        val applicationRepository =
+            FakePlanningApplicationRepository().apply { applicationsResult = anApplicationPage(listOf(unread, read)) }
+        val viewModel = makeSut(applicationRepository = applicationRepository)
+
+        viewModel.load()
+
+        assertEquals(1, viewModel.uiState.value.unreadCount)
+    }
+
+    @Test
+    fun `markAsRead optimistically clears the row's unread state and fires-and-forgets the request`() {
+        val unread = aPlanningApplication(latestUnreadEvent = aLatestUnreadEvent())
+        val applicationRepository = FakePlanningApplicationRepository().apply { applicationsResult = anApplicationPage(listOf(unread)) }
+        val notificationStateRepository = FakeNotificationStateRepository()
+        val viewModel = makeSut(applicationRepository = applicationRepository, notificationStateRepository = notificationStateRepository)
+        viewModel.load()
+
+        viewModel.markAsRead(unread)
+
+        assertNull(viewModel.uiState.value.applications.single().latestUnreadEvent)
+        assertEquals(listOf(unread.id), notificationStateRepository.markReadCalls.single())
+    }
+
+    @Test
+    fun `markAsRead swallows a mark-read failure — the optimistic clear stands and no error surfaces`() {
+        val unread = aPlanningApplication(latestUnreadEvent = aLatestUnreadEvent())
+        val applicationRepository = FakePlanningApplicationRepository().apply { applicationsResult = anApplicationPage(listOf(unread)) }
+        val notificationStateRepository = FakeNotificationStateRepository().apply { markReadFailWith = DomainError.NetworkUnavailable }
+        val viewModel = makeSut(applicationRepository = applicationRepository, notificationStateRepository = notificationStateRepository)
+        viewModel.load()
+
+        viewModel.markAsRead(unread)
+
+        assertNull(viewModel.uiState.value.applications.single().latestUnreadEvent)
+        assertNull(viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `markAllRead invalidates every zone's cache then refetches the active zone`() {
+        val applicationRepository = FakePlanningApplicationRepository()
+        val applicationCacheStore = FakeApplicationCacheStore()
+        val notificationStateRepository = FakeNotificationStateRepository()
+        val viewModel =
+            makeSut(
+                applicationRepository = applicationRepository,
+                applicationCacheStore = applicationCacheStore,
+                notificationStateRepository = notificationStateRepository,
+            )
+        viewModel.load()
+        val callsBeforeMarkAllRead = applicationRepository.applicationsCalls.size
+
+        viewModel.markAllRead()
+
+        assertEquals(1, notificationStateRepository.markAllReadCallCount)
+        assertEquals(1, applicationCacheStore.invalidateAllCallCount)
+        assertTrue(applicationRepository.applicationsCalls.size > callsBeforeMarkAllRead)
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListViewModelTest.kt
@@ -107,7 +107,10 @@ class ApplicationListViewModelTest {
 
         viewModel.load()
 
-        assertFalse(viewModel.uiState.value.availableSorts.contains(ApplicationSortOrder.DISTANCE))
+        assertFalse(
+            viewModel.uiState.value.availableSorts
+                .contains(ApplicationSortOrder.DISTANCE),
+        )
     }
 
     @Test
@@ -116,7 +119,10 @@ class ApplicationListViewModelTest {
 
         viewModel.load()
 
-        assertTrue(viewModel.uiState.value.availableSorts.contains(ApplicationSortOrder.DISTANCE))
+        assertTrue(
+            viewModel.uiState.value.availableSorts
+                .contains(ApplicationSortOrder.DISTANCE),
+        )
     }
 
     @Test
@@ -141,7 +147,12 @@ class ApplicationListViewModelTest {
     @Test
     fun `unreadCount counts only currently-loaded rows with an unread event`() {
         val unread = aPlanningApplication(latestUnreadEvent = aLatestUnreadEvent())
-        val read = aPlanningApplication(id = uk.towncrierapp.domain.applications.aPlanningApplicationId(name = "24/0002"))
+        val read =
+            aPlanningApplication(
+                id =
+                    uk.towncrierapp.domain.applications
+                        .aPlanningApplicationId(name = "24/0002"),
+            )
         val applicationRepository =
             FakePlanningApplicationRepository().apply { applicationsResult = anApplicationPage(listOf(unread, read)) }
         val viewModel = makeSut(applicationRepository = applicationRepository)
@@ -154,28 +165,56 @@ class ApplicationListViewModelTest {
     @Test
     fun `markAsRead optimistically clears the row's unread state and fires-and-forgets the request`() {
         val unread = aPlanningApplication(latestUnreadEvent = aLatestUnreadEvent())
-        val applicationRepository = FakePlanningApplicationRepository().apply { applicationsResult = anApplicationPage(listOf(unread)) }
+        val applicationRepository =
+            FakePlanningApplicationRepository().apply {
+                applicationsResult =
+                    anApplicationPage(listOf(unread))
+            }
         val notificationStateRepository = FakeNotificationStateRepository()
-        val viewModel = makeSut(applicationRepository = applicationRepository, notificationStateRepository = notificationStateRepository)
+        val viewModel =
+            makeSut(
+                applicationRepository = applicationRepository,
+                notificationStateRepository = notificationStateRepository,
+            )
         viewModel.load()
 
         viewModel.markAsRead(unread)
 
-        assertNull(viewModel.uiState.value.applications.single().latestUnreadEvent)
+        assertNull(
+            viewModel.uiState.value.applications
+                .single()
+                .latestUnreadEvent,
+        )
         assertEquals(listOf(unread.id), notificationStateRepository.markReadCalls.single())
     }
 
     @Test
     fun `markAsRead swallows a mark-read failure — the optimistic clear stands and no error surfaces`() {
         val unread = aPlanningApplication(latestUnreadEvent = aLatestUnreadEvent())
-        val applicationRepository = FakePlanningApplicationRepository().apply { applicationsResult = anApplicationPage(listOf(unread)) }
-        val notificationStateRepository = FakeNotificationStateRepository().apply { markReadFailWith = DomainError.NetworkUnavailable }
-        val viewModel = makeSut(applicationRepository = applicationRepository, notificationStateRepository = notificationStateRepository)
+        val applicationRepository =
+            FakePlanningApplicationRepository().apply {
+                applicationsResult =
+                    anApplicationPage(listOf(unread))
+            }
+        val notificationStateRepository =
+            FakeNotificationStateRepository().apply {
+                markReadFailWith =
+                    DomainError.NetworkUnavailable
+            }
+        val viewModel =
+            makeSut(
+                applicationRepository = applicationRepository,
+                notificationStateRepository = notificationStateRepository,
+            )
         viewModel.load()
 
         viewModel.markAsRead(unread)
 
-        assertNull(viewModel.uiState.value.applications.single().latestUnreadEvent)
+        assertNull(
+            viewModel.uiState.value.applications
+                .single()
+                .latestUnreadEvent,
+        )
         assertNull(viewModel.uiState.value.error)
     }
 

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/saved/SavedListViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/saved/SavedListViewModelTest.kt
@@ -1,0 +1,96 @@
+package uk.towncrierapp.presentation.features.saved
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.applications.ApplicationStatus
+import uk.towncrierapp.domain.applications.FakeSavedApplicationRepository
+import uk.towncrierapp.domain.applications.aPlanningApplication
+import uk.towncrierapp.domain.applications.aPlanningApplicationId
+import uk.towncrierapp.domain.applications.aSavedApplication
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import java.time.OffsetDateTime
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Port of iOS `SavedApplicationListViewModelTests` (GH#775). */
+@ExtendWith(MainDispatcherExtension::class)
+class SavedListViewModelTest {
+    @Test
+    fun `load fetches the flat saved list`() {
+        val repository = FakeSavedApplicationRepository(mutableListOf(aSavedApplication()))
+        val viewModel = SavedListViewModel(repository)
+
+        viewModel.load()
+
+        assertEquals(1, viewModel.uiState.value.savedApplications.size)
+    }
+
+    @Test
+    fun `a legacy row with a null application payload is dropped from the displayed list`() {
+        val legacy = aSavedApplication(applicationUid = aPlanningApplicationId(name = "24/9999"), application = null)
+        val real = aSavedApplication(applicationUid = aPlanningApplicationId(name = "24/0001"))
+        val repository = FakeSavedApplicationRepository(mutableListOf(legacy, real))
+        val viewModel = SavedListViewModel(repository)
+
+        viewModel.load()
+
+        assertEquals(2, viewModel.uiState.value.savedApplications.size)
+        assertEquals(listOf(real), viewModel.uiState.value.displayed)
+    }
+
+    @Test
+    fun `selecting a status filter narrows the displayed list client-side`() {
+        val permitted =
+            aSavedApplication(
+                applicationUid = aPlanningApplicationId(name = "24/0001"),
+                application = aPlanningApplication(id = aPlanningApplicationId(name = "24/0001"), status = ApplicationStatus.Permitted),
+            )
+        val rejected =
+            aSavedApplication(
+                applicationUid = aPlanningApplicationId(name = "24/0002"),
+                application = aPlanningApplication(id = aPlanningApplicationId(name = "24/0002"), status = ApplicationStatus.Rejected),
+            )
+        val repository = FakeSavedApplicationRepository(mutableListOf(permitted, rejected))
+        val viewModel = SavedListViewModel(repository)
+        viewModel.load()
+
+        viewModel.selectFilter(ApplicationStatus.Permitted)
+
+        assertEquals(listOf(permitted), viewModel.uiState.value.displayed)
+    }
+
+    @Test
+    fun `a null filter shows every (non-legacy) saved application`() {
+        val a = aSavedApplication(applicationUid = aPlanningApplicationId(name = "24/0001"))
+        val b = aSavedApplication(applicationUid = aPlanningApplicationId(name = "24/0002"))
+        val repository = FakeSavedApplicationRepository(mutableListOf(a, b))
+        val viewModel = SavedListViewModel(repository)
+        viewModel.load()
+        viewModel.selectFilter(ApplicationStatus.Permitted)
+
+        viewModel.selectFilter(null)
+
+        assertEquals(2, viewModel.uiState.value.displayed.size)
+    }
+
+    @Test
+    fun `displayed is sorted by savedAt descending regardless of wire order`() {
+        val older =
+            aSavedApplication(
+                applicationUid = aPlanningApplicationId(name = "24/0001"),
+                savedAt = OffsetDateTime.parse("2026-01-01T00:00:00Z"),
+            )
+        val newer =
+            aSavedApplication(
+                applicationUid = aPlanningApplicationId(name = "24/0002"),
+                savedAt = OffsetDateTime.parse("2026-02-01T00:00:00Z"),
+            )
+        val repository = FakeSavedApplicationRepository(mutableListOf(older, newer))
+        val viewModel = SavedListViewModel(repository)
+
+        viewModel.load()
+
+        assertEquals(listOf(newer, older), viewModel.uiState.value.displayed)
+        assertTrue(viewModel.uiState.value.displayed.first().savedAt.isAfter(viewModel.uiState.value.displayed.last().savedAt))
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/saved/SavedListViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/saved/SavedListViewModelTest.kt
@@ -43,12 +43,20 @@ class SavedListViewModelTest {
         val permitted =
             aSavedApplication(
                 applicationUid = aPlanningApplicationId(name = "24/0001"),
-                application = aPlanningApplication(id = aPlanningApplicationId(name = "24/0001"), status = ApplicationStatus.Permitted),
+                application =
+                    aPlanningApplication(
+                        id = aPlanningApplicationId(name = "24/0001"),
+                        status = ApplicationStatus.Permitted,
+                    ),
             )
         val rejected =
             aSavedApplication(
                 applicationUid = aPlanningApplicationId(name = "24/0002"),
-                application = aPlanningApplication(id = aPlanningApplicationId(name = "24/0002"), status = ApplicationStatus.Rejected),
+                application =
+                    aPlanningApplication(
+                        id = aPlanningApplicationId(name = "24/0002"),
+                        status = ApplicationStatus.Rejected,
+                    ),
             )
         val repository = FakeSavedApplicationRepository(mutableListOf(permitted, rejected))
         val viewModel = SavedListViewModel(repository)
@@ -91,6 +99,15 @@ class SavedListViewModelTest {
         viewModel.load()
 
         assertEquals(listOf(newer, older), viewModel.uiState.value.displayed)
-        assertTrue(viewModel.uiState.value.displayed.first().savedAt.isAfter(viewModel.uiState.value.displayed.last().savedAt))
+        assertTrue(
+            viewModel.uiState.value.displayed
+                .first()
+                .savedAt
+                .isAfter(
+                    viewModel.uiState.value.displayed
+                        .last()
+                        .savedAt,
+                ),
+        )
     }
 }

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneEditorViewModelCacheInvalidationTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneEditorViewModelCacheInvalidationTest.kt
@@ -1,0 +1,67 @@
+package uk.towncrierapp.presentation.features.watchzones
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.applications.FakeApplicationCacheStore
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.domain.watchzones.FakePostcodeGeocoder
+import uk.towncrierapp.domain.watchzones.FakeWatchZoneRepository
+import uk.towncrierapp.domain.watchzones.aCoordinate
+import uk.towncrierapp.domain.watchzones.aWatchZone
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import kotlin.test.assertTrue
+import kotlin.test.assertEquals
+
+/**
+ * tc-cnme: closes #774's cache-invalidation loop now that #775 introduces the
+ * cache seam ([uk.towncrierapp.domain.applications.ApplicationCacheStore]).
+ * Only the EDIT path (`isEditing == true`) invalidates — mirrors iOS
+ * `AppCoordinator+WatchZones.swift`'s `onSave` callback, which has no
+ * equivalent zone identity to invalidate on a brand-new create.
+ */
+@ExtendWith(MainDispatcherExtension::class)
+class WatchZoneEditorViewModelCacheInvalidationTest {
+    @Test
+    fun `a successful edit-save invalidates that zone's applications cache`() {
+        val zone = aWatchZone()
+        val repository = FakeWatchZoneRepository(mutableListOf(zone))
+        val geocoder = FakePostcodeGeocoder(Result.success(aCoordinate()))
+        val cacheStore = FakeApplicationCacheStore()
+        val viewModel =
+            WatchZoneEditorViewModel(geocoder, repository, SubscriptionTier.PRO, editingZone = zone, applicationCacheStore = cacheStore)
+
+        viewModel.save()
+
+        assertEquals(listOf(zone.id), cacheStore.invalidateCalls)
+    }
+
+    @Test
+    fun `creating a brand-new zone does not invalidate any cache`() {
+        val repository = FakeWatchZoneRepository()
+        val geocoder = FakePostcodeGeocoder(Result.success(aCoordinate()))
+        val cacheStore = FakeApplicationCacheStore()
+        val viewModel = WatchZoneEditorViewModel(geocoder, repository, SubscriptionTier.FREE, applicationCacheStore = cacheStore)
+        viewModel.updateName("Home")
+        viewModel.updatePostcode("CB1 2AD")
+        viewModel.submitPostcode()
+
+        viewModel.save()
+
+        assertTrue(cacheStore.invalidateCalls.isEmpty())
+    }
+
+    @Test
+    fun `a failed edit-save does not invalidate the cache`() {
+        val zone = aWatchZone()
+        val repository = FakeWatchZoneRepository(mutableListOf(zone)).apply { updateFailWith = DomainError.NetworkUnavailable }
+        val geocoder = FakePostcodeGeocoder(Result.success(aCoordinate()))
+        val cacheStore = FakeApplicationCacheStore()
+        val viewModel =
+            WatchZoneEditorViewModel(geocoder, repository, SubscriptionTier.PRO, editingZone = zone, applicationCacheStore = cacheStore)
+
+        viewModel.save()
+
+        assertTrue(cacheStore.invalidateCalls.isEmpty())
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneEditorViewModelCacheInvalidationTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneEditorViewModelCacheInvalidationTest.kt
@@ -10,8 +10,8 @@ import uk.towncrierapp.domain.watchzones.FakeWatchZoneRepository
 import uk.towncrierapp.domain.watchzones.aCoordinate
 import uk.towncrierapp.domain.watchzones.aWatchZone
 import uk.towncrierapp.presentation.MainDispatcherExtension
-import kotlin.test.assertTrue
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * tc-cnme: closes #774's cache-invalidation loop now that #775 introduces the
@@ -29,7 +29,13 @@ class WatchZoneEditorViewModelCacheInvalidationTest {
         val geocoder = FakePostcodeGeocoder(Result.success(aCoordinate()))
         val cacheStore = FakeApplicationCacheStore()
         val viewModel =
-            WatchZoneEditorViewModel(geocoder, repository, SubscriptionTier.PRO, editingZone = zone, applicationCacheStore = cacheStore)
+            WatchZoneEditorViewModel(
+                geocoder,
+                repository,
+                SubscriptionTier.PRO,
+                editingZone = zone,
+                applicationCacheStore = cacheStore,
+            )
 
         viewModel.save()
 
@@ -41,7 +47,8 @@ class WatchZoneEditorViewModelCacheInvalidationTest {
         val repository = FakeWatchZoneRepository()
         val geocoder = FakePostcodeGeocoder(Result.success(aCoordinate()))
         val cacheStore = FakeApplicationCacheStore()
-        val viewModel = WatchZoneEditorViewModel(geocoder, repository, SubscriptionTier.FREE, applicationCacheStore = cacheStore)
+        val viewModel =
+            WatchZoneEditorViewModel(geocoder, repository, SubscriptionTier.FREE, applicationCacheStore = cacheStore)
         viewModel.updateName("Home")
         viewModel.updatePostcode("CB1 2AD")
         viewModel.submitPostcode()
@@ -54,11 +61,21 @@ class WatchZoneEditorViewModelCacheInvalidationTest {
     @Test
     fun `a failed edit-save does not invalidate the cache`() {
         val zone = aWatchZone()
-        val repository = FakeWatchZoneRepository(mutableListOf(zone)).apply { updateFailWith = DomainError.NetworkUnavailable }
+        val repository =
+            FakeWatchZoneRepository(mutableListOf(zone)).apply {
+                updateFailWith =
+                    DomainError.NetworkUnavailable
+            }
         val geocoder = FakePostcodeGeocoder(Result.success(aCoordinate()))
         val cacheStore = FakeApplicationCacheStore()
         val viewModel =
-            WatchZoneEditorViewModel(geocoder, repository, SubscriptionTier.PRO, editingZone = zone, applicationCacheStore = cacheStore)
+            WatchZoneEditorViewModel(
+                geocoder,
+                repository,
+                SubscriptionTier.PRO,
+                editingZone = zone,
+                applicationCacheStore = cacheStore,
+            )
 
         viewModel.save()
 


### PR DESCRIPTION
## Summary

Phase 3b of the Android parity epic (#770), closes #775. Builds on #774 (merged). Also closes tc-cnme (the zone-cache invalidation hook #774 deferred).

## Changes

- **`:domain`**: `PlanningApplication`/`PlanningApplicationId`/`LocalAuthority`/`ApplicationStatus`/`LatestUnreadEvent`/`SavedApplication`, `ApplicationFilter` (sum type, status/unread mutually exclusive by construction), `ApplicationSortOrder`, `ApplicationPage`, `OfflineAwareRepository` (900s TTL, param-less-fetch-only, paged bypass).
- **`:data`**: `ApiPlanningApplicationRepository` (cursor paging via `X-Next-Cursor`, client-side status-history synthesis, always sends `sort`), `ApiSavedApplicationRepository`, `ApiNotificationStateRepository` (mark-read's `applicationUid`-key-carries-the-name wire misnomer ported as-is), `InMemoryApplicationCacheStore`.
- **`:presentation`**: `ApplicationListScreen`/`ViewModel` (zone/status/unread chips, 5 sorts, infinite scroll, tap-to-read, mark-all-read), `SavedListScreen`/`ViewModel`, `ApplicationDetailScreen`/`ViewModel` (stale-while-revalidate, re-entrancy guarded), `StatusDisplay`/`StatusTimeline`/`ApplicationRow` components. Applications/Saved wired as bottom-nav destinations, detail as a full nav destination.
- **tc-cnme**: `WatchZoneEditorViewModel`'s edit-save path now invalidates the matching zone's application cache entry.

## Verification

- `./gradlew test ktlintCheck detekt :app:assembleDevDebug :app:assembleProdRelease :app:assembleLocalDebug` — 525 tests, all green.
- Live emulator walkthrough against the local Postgres+API stack: signed in, exercised all status/unread chips and all 5 sorts, correct empty state (no seeded applications yet, expected), Saved tab empty state, full zone edit-save round trip exercising the new cache-invalidation wiring. No crashes (confirmed via logcat).
- **Real bug caught by live testing, not unit tests**: initially wired the interactive list/detail screens through `OfflineAwareRepository`, which froze filter/sort changes for the full 900s TTL (cache keyed by zone id only, blind to filter/sort params). Confirmed against iOS source that the cached path is dormant there too (all current sorts are server-driven) — routed the live screens to the network-only repository directly; `OfflineAwareRepository` stays built and unit-tested for when a future feature needs it.

## Follow-ups filed

- `tc-hlbx` — bottom-nav tabs re-fetch from scratch on every revisit (pre-existing since #774, not a regression here).

---
*Bead tc-oibm (+ tc-cnme)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Applications and Saved tabs with full list browsing, filtering, sorting, and detail screens.
  * Added application detail actions including save/unsave, share, and opening the council portal.
  * Added offline-aware loading and remembered list preferences for a smoother return experience.
* **Bug Fixes**
  * Improved handling of unread state, saved items, and pagination.
  * Fixed request path encoding issues to better support IDs containing slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->