### PR TITLE
feat(android): onboarding wizard (tc-7ttz)

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- Runtime-requested by the onboarding wizard's notification-permission
+         step on API 33+ (tc-7ttz); a no-op declaration below 33, where
+         notification delivery needs no runtime grant at all. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:name="uk.towncrierapp.app.TownCrierApplication"
         android:allowBackup="true"

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -29,6 +29,7 @@ import uk.towncrierapp.domain.applications.OfflineAwareRepository
 import uk.towncrierapp.domain.applications.PlanningApplicationRepository
 import uk.towncrierapp.domain.applications.SavedApplicationRepository
 import uk.towncrierapp.domain.auth.AuthenticationService
+import uk.towncrierapp.domain.onboarding.OnboardingRepository
 import uk.towncrierapp.domain.profile.UserProfileRepository
 import uk.towncrierapp.domain.subscriptions.SubscriptionTierCache
 import uk.towncrierapp.domain.versionconfig.VersionConfigService
@@ -45,17 +46,19 @@ public data class Auth0Tenant(
 )
 
 /**
- * The four leaves that genuinely need a real `Context` —
+ * The leaves that genuinely need a real `Context` —
  * `TownCrierApplication` builds them (`SecureCredentialsManagerStore` over a
  * real `SecureCredentialsManager`, an `Application.ActivityLifecycleCallbacks`
- * tracker, a `DataStoreSubscriptionTierCache`, a `DataStoreApplicationListPreferencesStore`)
- * and hands them to the otherwise Context-free [AppGraph].
+ * tracker, a `DataStoreSubscriptionTierCache`, a `DataStoreApplicationListPreferencesStore`,
+ * a `DataStoreOnboardingRepository`) and hands them to the otherwise
+ * Context-free [AppGraph].
  */
 public class AndroidLeaves(
     public val credentialsStore: CredentialsStore,
     public val activityProvider: CurrentActivityProvider,
     public val tierCache: SubscriptionTierCache,
     public val applicationListPreferencesStore: ApplicationListPreferencesStore,
+    public val onboardingRepository: OnboardingRepository,
 )
 
 /** Rarely-overridden technical knobs, grouped so [AppGraph]'s own constructor stays short. */
@@ -162,4 +165,6 @@ public class AppGraph(
 
     public val applicationListPreferencesStore: ApplicationListPreferencesStore =
         androidLeaves.applicationListPreferencesStore
+
+    public val onboardingRepository: OnboardingRepository = androidLeaves.onboardingRepository
 }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -115,10 +115,10 @@ public class AppGraph(
     // through ApiClient (which always requires a session first).
     public val versionConfigService: VersionConfigService = ApiVersionConfigService(baseUrl, transport)
 
-    public val authCoordinator: AuthCoordinator =
-        AuthCoordinator(authenticationService, userProfileRepository, androidLeaves.tierCache)
-
     public val watchZoneRepository: WatchZoneRepository = ApiWatchZoneRepository(apiClient)
+
+    public val authCoordinator: AuthCoordinator =
+        AuthCoordinator(authenticationService, userProfileRepository, androidLeaves.tierCache, watchZoneRepository)
 
     public val zonePreferencesRepository: ZonePreferencesRepository = ApiZonePreferencesRepository(apiClient)
 

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
@@ -35,6 +35,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import kotlinx.serialization.Serializable
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.presentation.auth.OnboardingPresentation
 import uk.towncrierapp.presentation.designsystem.TownCrierTheme
 import uk.towncrierapp.presentation.features.forceupdate.ForceUpdateScreen
 import uk.towncrierapp.presentation.features.forceupdate.ForceUpdateViewModel
@@ -81,11 +83,14 @@ private val WATCH_ZONES_ROUTE = WatchZones::class.qualifiedName
 private val SAVED_ROUTE = Saved::class.qualifiedName
 
 /**
- * Root routing: pre-login force-update gate, then Login or the authed
- * shell — port of iOS `TownCrierApp.body`'s `Group { if requiresUpdate ...
- * else if isAuthenticated ... else Login }`. Re-checks the version gate and
- * re-runs the signed-in sequence (ensure profile → resolve tier, #549 /
- * tc-f2il) on every auth-state transition, keyed off `isAuthenticated` so a
+ * Root routing: pre-login force-update gate, then Login, then - once
+ * authenticated - the onboarding gate (tc-7ttz: `Undetermined` shows a
+ * loading screen, never a flash of the wrong state) before the authed shell.
+ * Port of iOS `TownCrierApp.body`'s `Group { if requiresUpdate ... else if
+ * isAuthenticated ... else Login }` extended by `AppCoordinator+Onboarding`.
+ * Re-checks the version gate and re-runs the signed-in sequence (ensure
+ * profile → resolve tier → resolve the onboarding gate, #549 / tc-f2il /
+ * tc-7ttz) on every auth-state transition, keyed off `isAuthenticated` so a
  * fresh sign-in re-triggers it.
  */
 @Composable
@@ -105,6 +110,8 @@ public fun TownCrierApp(
 
     val loginState by loginViewModel.uiState.collectAsStateWithLifecycle()
     val forceUpdateState by forceUpdateViewModel.uiState.collectAsStateWithLifecycle()
+    val onboardingPresentation by appGraph.authCoordinator.onboardingPresentation.collectAsStateWithLifecycle()
+    val subscriptionTier by appGraph.authCoordinator.subscriptionTier.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     LaunchedEffect(loginState.isAuthenticated) {
@@ -123,13 +130,40 @@ public fun TownCrierApp(
             }
 
             loginState.isAuthenticated -> {
-                AuthedShell(appGraph = appGraph, navController = navController)
+                AuthedContent(
+                    appGraph = appGraph,
+                    navController = navController,
+                    onboardingPresentation = onboardingPresentation,
+                    subscriptionTier = subscriptionTier,
+                )
             }
 
             else -> {
                 LoginRoute(viewModel = loginViewModel)
             }
         }
+    }
+}
+
+/** Onboarding gate, evaluated only once signed in - see [TownCrierApp]'s doc for the full ordering contract. */
+@Composable
+private fun AuthedContent(
+    appGraph: AppGraph,
+    navController: NavHostController,
+    onboardingPresentation: OnboardingPresentation,
+    subscriptionTier: SubscriptionTier,
+) {
+    when (onboardingPresentation) {
+        OnboardingPresentation.Undetermined -> OnboardingLoadingScreen()
+
+        OnboardingPresentation.Required ->
+            OnboardingGate(
+                appGraph = appGraph,
+                subscriptionTier = subscriptionTier,
+                onOnboardingComplete = appGraph.authCoordinator::onOnboardingCompleted,
+            )
+
+        OnboardingPresentation.NotRequired -> AuthedShell(appGraph = appGraph, navController = navController)
     }
 }
 

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
@@ -154,16 +154,21 @@ private fun AuthedContent(
     subscriptionTier: SubscriptionTier,
 ) {
     when (onboardingPresentation) {
-        OnboardingPresentation.Undetermined -> OnboardingLoadingScreen()
+        OnboardingPresentation.Undetermined -> {
+            OnboardingLoadingScreen()
+        }
 
-        OnboardingPresentation.Required ->
+        OnboardingPresentation.Required -> {
             OnboardingGate(
                 appGraph = appGraph,
                 subscriptionTier = subscriptionTier,
                 onOnboardingComplete = appGraph.authCoordinator::onOnboardingCompleted,
             )
+        }
 
-        OnboardingPresentation.NotRequired -> AuthedShell(appGraph = appGraph, navController = navController)
+        OnboardingPresentation.NotRequired -> {
+            AuthedShell(appGraph = appGraph, navController = navController)
+        }
     }
 }
 

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/OnboardingNavGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/OnboardingNavGraph.kt
@@ -1,0 +1,65 @@
+package uk.towncrierapp.app
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.presentation.features.onboarding.OnboardingRoute
+import uk.towncrierapp.presentation.features.onboarding.OnboardingViewModel
+
+/**
+ * #783 hasn't shipped the paywall composable yet, so the radius step's
+ * "Unlock larger zones" chip is hidden entirely rather than routed to a dead
+ * tap target (tc-7ttz). Flip once the paywall exists and wire
+ * [OnboardingViewModel.reconcileTierAfterUpgrade] to its dismiss callback.
+ */
+internal const val PAYWALL_AVAILABLE: Boolean = false
+
+/**
+ * The onboarding wizard: constructed ONCE per presentation (not scoped to
+ * any nav-graph destination, since it's shown outside the NavHost entirely -
+ * see [TownCrierApp]) so it survives recomposition for as long as the gate
+ * says it's required, matching the "nav-graph-scoped, not screen-scoped"
+ * requirement the wizard's iOS counterpart has (tc-7ttz).
+ */
+@Composable
+internal fun OnboardingGate(
+    appGraph: AppGraph,
+    subscriptionTier: SubscriptionTier,
+    onOnboardingComplete: () -> Unit,
+) {
+    val viewModel: OnboardingViewModel =
+        viewModel(
+            factory =
+                viewModelFactory {
+                    initializer {
+                        OnboardingViewModel(
+                            appGraph.postcodeGeocoder,
+                            appGraph.watchZoneRepository,
+                            appGraph.onboardingRepository,
+                            subscriptionTier,
+                            paywallAvailable = PAYWALL_AVAILABLE,
+                        )
+                    }
+                },
+        )
+    OnboardingRoute(viewModel = viewModel, onOnboardingComplete = onOnboardingComplete)
+}
+
+/** Shown while [uk.towncrierapp.presentation.auth.OnboardingPresentation] is `Undetermined` - never flash Required/NotRequired before account state resolves. */
+@Composable
+internal fun OnboardingLoadingScreen(modifier: Modifier = Modifier) {
+    Surface(modifier = modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+        Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(color = MaterialTheme.colorScheme.primary)
+        }
+    }
+}

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
@@ -10,6 +10,7 @@ import com.auth0.android.authentication.storage.SecureCredentialsManager
 import com.auth0.android.authentication.storage.SharedPreferencesStorage
 import uk.towncrierapp.data.applications.DataStoreApplicationListPreferencesStore
 import uk.towncrierapp.data.auth.SecureCredentialsManagerStore
+import uk.towncrierapp.data.onboarding.DataStoreOnboardingRepository
 import uk.towncrierapp.data.subscriptions.DataStoreSubscriptionTierCache
 import uk.towncrierapp.mobile.BuildConfig
 
@@ -45,8 +46,9 @@ public class TownCrierApplication : Application() {
         val tierCache = DataStoreSubscriptionTierCache(tierPreferencesDataStore)
         // Same shared "town_crier_preferences" DataStore file as tierCache —
         // DataStore Preferences is designed for several unrelated keys in one
-        // file; a second file per feature isn't warranted (GH#775).
+        // file; a second file per feature isn't warranted (GH#775 / tc-7ttz).
         val applicationListPreferencesStore = DataStoreApplicationListPreferencesStore(tierPreferencesDataStore)
+        val onboardingRepository = DataStoreOnboardingRepository(tierPreferencesDataStore)
 
         appGraph =
             AppGraph(
@@ -59,6 +61,7 @@ public class TownCrierApplication : Application() {
                         activityTracker,
                         tierCache,
                         applicationListPreferencesStore,
+                        onboardingRepository,
                     ),
                 currentVersion = BuildConfig.VERSION_NAME,
                 options = AppGraphOptions(enableDebugLogging = BuildConfig.DEBUG),

--- a/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
+++ b/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import uk.towncrierapp.data.auth.CredentialsStore
 import uk.towncrierapp.data.auth.CurrentActivityProvider
 import uk.towncrierapp.domain.applications.FakeApplicationListPreferencesStore
+import uk.towncrierapp.domain.onboarding.FakeOnboardingRepository
 import uk.towncrierapp.domain.subscriptions.FakeSubscriptionTierCache
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -44,6 +45,7 @@ class AppGraphSmokeTest {
                         activityProvider = CurrentActivityProvider { null },
                         tierCache = FakeSubscriptionTierCache(),
                         applicationListPreferencesStore = FakeApplicationListPreferencesStore(),
+                        onboardingRepository = FakeOnboardingRepository(),
                     ),
                 currentVersion = "0.1.0",
                 options = AppGraphOptions(callFactory = noOpCallFactory),
@@ -63,6 +65,7 @@ class AppGraphSmokeTest {
         assertNotNull(graph.savedApplicationRepository)
         assertNotNull(graph.notificationStateRepository)
         assertNotNull(graph.applicationListPreferencesStore)
+        assertNotNull(graph.onboardingRepository)
     }
 
     @Test
@@ -77,6 +80,7 @@ class AppGraphSmokeTest {
                         activityProvider = CurrentActivityProvider { null },
                         tierCache = FakeSubscriptionTierCache(),
                         applicationListPreferencesStore = FakeApplicationListPreferencesStore(),
+                        onboardingRepository = FakeOnboardingRepository(),
                     ),
                 currentVersion = "0.1.0",
                 options = AppGraphOptions(callFactory = noOpCallFactory),
@@ -98,6 +102,7 @@ class AppGraphSmokeTest {
                         activityProvider = CurrentActivityProvider { null },
                         tierCache = FakeSubscriptionTierCache(),
                         applicationListPreferencesStore = FakeApplicationListPreferencesStore(),
+                        onboardingRepository = FakeOnboardingRepository(),
                     ),
                 currentVersion = "0.1.0",
                 options = AppGraphOptions(callFactory = noOpCallFactory),

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/onboarding/DataStoreOnboardingRepository.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/onboarding/DataStoreOnboardingRepository.kt
@@ -1,0 +1,30 @@
+package uk.towncrierapp.data.onboarding
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import uk.towncrierapp.domain.onboarding.OnboardingRepository
+
+private val IS_ONBOARDING_COMPLETE_KEY = booleanPreferencesKey("isOnboardingComplete")
+
+/**
+ * DataStore Preferences-backed [OnboardingRepository] - the
+ * `isOnboardingComplete` device latch (epic #770, same key iOS uses in
+ * `UserDefaults`). A one-shot suspend read/write, not a `Flow`: this is a
+ * fast-path hint, not something the UI observes live.
+ */
+public class DataStoreOnboardingRepository(
+    private val dataStore: DataStore<Preferences>,
+) : OnboardingRepository {
+    override suspend fun isOnboardingComplete(): Boolean =
+        dataStore.data
+            .map { preferences -> preferences[IS_ONBOARDING_COMPLETE_KEY] ?: false }
+            .first()
+
+    override suspend fun setOnboardingComplete(complete: Boolean) {
+        dataStore.edit { preferences -> preferences[IS_ONBOARDING_COMPLETE_KEY] = complete }
+    }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/onboarding/DataStoreOnboardingRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/onboarding/DataStoreOnboardingRepositoryTest.kt
@@ -1,0 +1,52 @@
+package uk.towncrierapp.data.onboarding
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * The `isOnboardingComplete` DataStore Preferences latch - a fast-path hint
+ * only, never the source of truth for whether the wizard is required
+ * (tc-7ttz; see `AuthCoordinator`). `PreferenceDataStoreFactory.create` over
+ * a temp file runs on the plain JVM - no Robolectric needed.
+ */
+class DataStoreOnboardingRepositoryTest {
+    private fun aDataStore(directory: File) =
+        PreferenceDataStoreFactory.create { File(directory, "test.preferences_pb") }
+
+    @Test
+    fun `isOnboardingComplete defaults to false when nothing has been written yet`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreOnboardingRepository(aDataStore(directory))
+
+        assertFalse(sut.isOnboardingComplete())
+    }
+
+    @Test
+    fun `setOnboardingComplete then isOnboardingComplete round-trips true`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreOnboardingRepository(aDataStore(directory))
+
+        sut.setOnboardingComplete(true)
+
+        assertEquals(true, sut.isOnboardingComplete())
+    }
+
+    @Test
+    fun `a second write overwrites the first`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreOnboardingRepository(aDataStore(directory))
+
+        sut.setOnboardingComplete(true)
+        sut.setOnboardingComplete(false)
+
+        assertFalse(sut.isOnboardingComplete())
+    }
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/DomainError.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/auth/DomainError.kt
@@ -27,6 +27,17 @@ public sealed class DomainError : Exception() {
         public val required: String,
     ) : DomainError()
 
+    /**
+     * [postcode] failed local format validation (never reached the network)
+     * or its geocode lookup itself failed remotely - either way, the fix is
+     * the user editing the postcode and resubmitting, so this is presented
+     * the same way as any other geocoding inline error (tc-7ttz, onboarding
+     * wizard's postcode step).
+     */
+    public data class GeocodingFailed(
+        public val postcode: String,
+    ) : DomainError()
+
     /** Any other HTTP error (>= 400 and not one of the cases above). [body] is the raw response text. */
     public data class ServerError(
         public val status: Int,
@@ -83,5 +94,6 @@ public val DomainError.isRetryable: Boolean
             DomainError.NotFound,
             is DomainError.InsufficientEntitlement,
             is DomainError.AuthenticationFailed,
+            is DomainError.GeocodingFailed,
             -> false
         }

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/onboarding/OnboardingRepository.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/onboarding/OnboardingRepository.kt
@@ -1,0 +1,16 @@
+package uk.towncrierapp.domain.onboarding
+
+/**
+ * Device-local "has this device been through onboarding" latch. This is a
+ * fast-path hint only, for perceived speed on a returning user's device -
+ * account state (the user's real watch-zone count, checked by
+ * `AuthCoordinator`) is always the source of truth for whether the wizard is
+ * required, and never gets substituted by this latch. Port of iOS
+ * `OnboardingRepository` / `UserDefaultsOnboardingRepository`.
+ */
+public interface OnboardingRepository {
+    /** Whether this device has completed onboarding before. */
+    public suspend fun isOnboardingComplete(): Boolean
+
+    public suspend fun setOnboardingComplete(complete: Boolean)
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/watchzones/Postcode.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/watchzones/Postcode.kt
@@ -1,0 +1,30 @@
+package uk.towncrierapp.domain.watchzones
+
+/**
+ * A validated UK postcode, normalised to upper case with surrounding
+ * whitespace trimmed. Validity is established once, at [parse] time - every
+ * [Postcode] in hand is already known well-formed, so nothing downstream
+ * re-checks the format. Port of iOS `Postcode`.
+ */
+@JvmInline
+public value class Postcode private constructor(
+    public val value: String,
+) {
+    public companion object {
+        // The internal space is optional ("SW1A1AA" and "SW1A 1AA" both
+        // match); the trailing digit+2-letter "inward code" is not, which is
+        // why a truncated postcode like "SW1A1" (no inward code at all)
+        // fails rather than just matching the outward part.
+        private val FORMAT_REGEX = Regex("^[A-Z]{1,2}\\d[A-Z\\d]?\\s?\\d[A-Z]{2}$")
+
+        /**
+         * Parses [raw] into a [Postcode], upper-casing and trimming first.
+         * Returns `null` when [raw] doesn't match the UK postcode format -
+         * an expected user-input outcome, not a programmer error.
+         */
+        public fun parse(raw: String): Postcode? {
+            val normalised = raw.trim().uppercase()
+            return if (FORMAT_REGEX.matches(normalised)) Postcode(normalised) else null
+        }
+    }
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/auth/DomainErrorTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/auth/DomainErrorTest.kt
@@ -24,6 +24,15 @@ class DomainErrorTest {
         assertFalse(DomainError.NotFound.isRetryable)
         assertFalse(DomainError.InsufficientEntitlement("personal").isRetryable)
         assertFalse(DomainError.AuthenticationFailed("cancelled").isRetryable)
+        assertFalse(DomainError.GeocodingFailed("NOTAPOSTCODE").isRetryable)
+    }
+
+    @Test
+    fun `GeocodingFailed carries the postcode that failed`() {
+        val error = DomainError.GeocodingFailed("NOTAPOSTCODE")
+
+        assertEquals("NOTAPOSTCODE", error.postcode)
+        assertEquals(DomainError.GeocodingFailed("NOTAPOSTCODE"), error)
     }
 
     @Test

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/watchzones/PostcodeTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/watchzones/PostcodeTest.kt
@@ -1,0 +1,56 @@
+package uk.towncrierapp.domain.watchzones
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * `Postcode.parse` validates against
+ * `^[A-Z]{1,2}\d[A-Z\d]?\s?\d[A-Z]{2}$` after uppercasing and trimming the
+ * raw input (tc-7ttz, port of iOS `Postcode`).
+ */
+class PostcodeTest {
+    @Test
+    fun `a garbage string is rejected`() {
+        assertNull(Postcode.parse("NOTAPOSTCODE"))
+    }
+
+    @Test
+    fun `a postcode missing its inward code is rejected`() {
+        // "SW1A1" has no space AND no room for the mandatory digit+2-letter
+        // inward code - the regex requires it, so this is genuinely invalid,
+        // not just missing the optional space.
+        assertNull(Postcode.parse("SW1A1"))
+    }
+
+    @Test
+    fun `a valid postcode without a space is accepted`() {
+        // The regex's internal space is optional - "SW1A1AA" is well-formed.
+        assertEquals("SW1A1AA", Postcode.parse("SW1A1AA")?.value)
+    }
+
+    @Test
+    fun `a valid postcode with a space is accepted`() {
+        assertEquals("SW1A 1AA", Postcode.parse("SW1A 1AA")?.value)
+    }
+
+    @Test
+    fun `lower case input is normalised to upper case`() {
+        assertEquals("SW1A1AA", Postcode.parse("sw1a1aa")?.value)
+    }
+
+    @Test
+    fun `mixed case input with a space is normalised and accepted`() {
+        assertEquals("Cb1 2ad".uppercase(), Postcode.parse("Cb1 2ad")?.value)
+    }
+
+    @Test
+    fun `surrounding whitespace is trimmed before matching`() {
+        assertEquals("SW1A1AA", Postcode.parse("  sw1a1aa  ")?.value)
+    }
+
+    @Test
+    fun `blank input is rejected`() {
+        assertNull(Postcode.parse("   "))
+    }
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/onboarding/FakeOnboardingRepository.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/onboarding/FakeOnboardingRepository.kt
@@ -1,0 +1,15 @@
+package uk.towncrierapp.domain.onboarding
+
+/** Hand-written fake for [OnboardingRepository] - a plain in-memory box standing in for DataStore. */
+public class FakeOnboardingRepository(
+    public var complete: Boolean = false,
+) : OnboardingRepository {
+    public val setOnboardingCompleteCalls: MutableList<Boolean> = mutableListOf()
+
+    override suspend fun isOnboardingComplete(): Boolean = complete
+
+    override suspend fun setOnboardingComplete(complete: Boolean) {
+        setOnboardingCompleteCalls += complete
+        this.complete = complete
+    }
+}

--- a/mobile/android/presentation/build.gradle.kts
+++ b/mobile/android/presentation/build.gradle.kts
@@ -60,6 +60,10 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     // Chrome Custom Tabs for the application-detail "View on Council Portal" button (GH#775).
     implementation(libs.androidx.browser)
+    // rememberLauncherForActivityResult for the onboarding wizard's POST_NOTIFICATIONS
+    // request (tc-7ttz) - needs a composable scope, so it lives in OnboardingRoute
+    // rather than :app's wiring layer.
+    implementation(libs.androidx.activity.compose)
     debugImplementation(libs.compose.ui.tooling)
 
     testImplementation(platform(libs.junit.bom))

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinator.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinator.kt
@@ -10,25 +10,39 @@ import uk.towncrierapp.domain.profile.UserProfileRepository
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
 import uk.towncrierapp.domain.subscriptions.SubscriptionTierCache
 import uk.towncrierapp.domain.subscriptions.resolveTier
+import uk.towncrierapp.domain.watchzones.WatchZoneRepository
 
 /**
  * Owns the signed-in transition's ordering (#549): ensure the server profile
- * exists, THEN resolve the subscription tier, THEN persist it — before any
- * downstream gate (onboarding, in #773) runs. Port of iOS
- * `AppCoordinator.resolveSubscriptionTier()` / `ServerTierResolver` /
- * `SubscriptionTierResolver`, degraded to the 2-way merge this issue
- * implements (`max(serverTier ?? max(cachedTier, jwtTier), jwtTier)` — no
- * store tier until #783).
+ * exists, THEN resolve the subscription tier, THEN persist it, THEN - and
+ * only then (tc-7ttz) - check account state for the onboarding gate. Port of
+ * iOS `AppCoordinator.resolveSubscriptionTier()` / `ServerTierResolver` /
+ * `SubscriptionTierResolver` / `AppCoordinator+Onboarding`, degraded to the
+ * 2-way tier merge this issue implements (`max(serverTier ?? max(cachedTier,
+ * jwtTier), jwtTier)` — no store tier until #783).
  */
 public class AuthCoordinator(
     private val authService: AuthenticationService,
     private val userProfileRepository: UserProfileRepository,
     private val tierCache: SubscriptionTierCache,
+    private val watchZoneRepository: WatchZoneRepository,
 ) {
     private val _subscriptionTier = MutableStateFlow(SubscriptionTier.FREE)
     public val subscriptionTier: StateFlow<SubscriptionTier> = _subscriptionTier.asStateFlow()
 
-    /** Runs the full signed-in sequence: ensure profile → resolve tier → persist. Call on every signed-out→signed-in transition, including cold-start session restore. */
+    private val _onboardingPresentation = MutableStateFlow(OnboardingPresentation.Undetermined)
+
+    /** Whether the onboarding wizard should be shown - `Undetermined` (render a loading screen) until [onSignedIn] has resolved account state. */
+    public val onboardingPresentation: StateFlow<OnboardingPresentation> = _onboardingPresentation.asStateFlow()
+
+    /**
+     * Runs the full signed-in sequence: ensure profile → resolve tier →
+     * persist → resolve the onboarding gate from account state. Call on
+     * every signed-out→signed-in transition, including cold-start session
+     * restore. The final step is the tc-k9fk/#549 fix ported to Android:
+     * moving the watch-zone check any earlier in this function reproduces
+     * that production bug.
+     */
     @Suppress("SwallowedException")
     // Both catches below are deliberate degrade paths (epic #770): a refresh
     // failure keeps the pre-refresh jwtTier; an ensure-profile failure yields
@@ -55,6 +69,13 @@ public class AuthCoordinator(
 
         _subscriptionTier.value = resolved
         tierCache.write(resolved)
+
+        _onboardingPresentation.value = resolveOnboardingPresentation()
+    }
+
+    /** Forces the gate to `NotRequired` once the wizard itself has finished (tc-7ttz) - completion is best-effort, so this doesn't re-check the server. */
+    public fun onOnboardingCompleted() {
+        _onboardingPresentation.value = OnboardingPresentation.NotRequired
     }
 
     /** `null` on failure — [resolveTier] treats that as "server tier unknown", falling back to `max(cachedTier, jwtTier)` rather than Free. */
@@ -66,5 +87,27 @@ public class AuthCoordinator(
             throw e
         } catch (e: DomainError) {
             null
+        }
+
+    /**
+     * Fails open to [OnboardingPresentation.NotRequired] on a transport
+     * error - a transient failure checking zone count must never strand a
+     * returning user on an indefinite loading screen, and must never trap
+     * them in the wizard either (deliberate simplification: the device latch
+     * is not consulted here, since no acceptance criterion depends on it -
+     * see the bead's KEY DECISIONS).
+     */
+    @Suppress("SwallowedException")
+    private suspend fun resolveOnboardingPresentation(): OnboardingPresentation =
+        try {
+            if (watchZoneRepository.zones().isEmpty()) {
+                OnboardingPresentation.Required
+            } else {
+                OnboardingPresentation.NotRequired
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: DomainError) {
+            OnboardingPresentation.NotRequired
         }
 }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/auth/OnboardingPresentation.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/auth/OnboardingPresentation.kt
@@ -1,0 +1,19 @@
+package uk.towncrierapp.presentation.auth
+
+/**
+ * Whether the onboarding wizard should be shown, derived from account state
+ * (the user's real watch-zone count) - never a device-local flag alone. Set
+ * by [AuthCoordinator] only after ensure-profile and tier resolution have
+ * both completed (tc-k9fk/#549: evaluating this any earlier reproduces a
+ * real production bug). Port of iOS `OnboardingPresentation`.
+ */
+public enum class OnboardingPresentation {
+    /** Account state hasn't been checked yet this session - render a loading screen, never guess. */
+    Undetermined,
+
+    /** The account has zero watch zones. */
+    Required,
+
+    /** The account has at least one watch zone. */
+    NotRequired,
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationErrors.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationErrors.kt
@@ -25,5 +25,6 @@ internal fun applicationErrorMessageRes(error: DomainError): Int =
         is DomainError.AuthenticationFailed,
         is DomainError.LogoutFailed,
         is DomainError.Unexpected,
+        is DomainError.GeocodingFailed,
         -> R.string.applications_error_generic
     }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/NotificationPermissionStep.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/NotificationPermissionStep.kt
@@ -1,0 +1,98 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import uk.towncrierapp.presentation.designsystem.components.PrimaryButton
+
+/**
+ * Step 4 - tier-aware. A paid tier (has the instant-alert entitlement) sees
+ * "Enable notifications" + "Skip for now"; a free-tier user sees honest
+ * digest-only copy and a single "Finish" - no OS permission is ever
+ * requested for them, since free accounts get no pushes.
+ */
+@Composable
+internal fun NotificationPermissionStep(
+    state: OnboardingUiState,
+    onEnableClick: () -> Unit,
+    onSkipClick: () -> Unit,
+    onFinishClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize().padding(TownCrierSpacing.lg),
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.onboarding_notifications_title),
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Text(
+                text =
+                    stringResource(
+                        if (state.hasInstantAlertEntitlement) {
+                            R.string.onboarding_notifications_paid_body
+                        } else {
+                            R.string.onboarding_notifications_free_body
+                        },
+                    ),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (state.hasInstantAlertEntitlement) {
+            PrimaryButton(text = stringResource(R.string.onboarding_notifications_enable_button), onClick = onEnableClick)
+            TextButton(onClick = onSkipClick) {
+                Text(stringResource(R.string.onboarding_notifications_skip_button))
+            }
+        } else {
+            PrimaryButton(text = stringResource(R.string.onboarding_notifications_finish_button), onClick = onFinishClick)
+        }
+    }
+}
+
+@Preview(name = "paid tier")
+@Composable
+private fun NotificationPermissionStepPaidPreview() {
+    TownCrierTheme {
+        NotificationPermissionStep(
+            state = OnboardingUiState(hasInstantAlertEntitlement = true),
+            onEnableClick = {},
+            onSkipClick = {},
+            onFinishClick = {},
+        )
+    }
+}
+
+@Preview(name = "free tier", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun NotificationPermissionStepFreePreview() {
+    TownCrierTheme {
+        NotificationPermissionStep(
+            state = OnboardingUiState(hasInstantAlertEntitlement = false),
+            onEnableClick = {},
+            onSkipClick = {},
+            onFinishClick = {},
+        )
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/NotificationPermissionStep.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/NotificationPermissionStep.kt
@@ -61,12 +61,18 @@ internal fun NotificationPermissionStep(
             )
         }
         if (state.hasInstantAlertEntitlement) {
-            PrimaryButton(text = stringResource(R.string.onboarding_notifications_enable_button), onClick = onEnableClick)
+            PrimaryButton(
+                text = stringResource(R.string.onboarding_notifications_enable_button),
+                onClick = onEnableClick,
+            )
             TextButton(onClick = onSkipClick) {
                 Text(stringResource(R.string.onboarding_notifications_skip_button))
             }
         } else {
-            PrimaryButton(text = stringResource(R.string.onboarding_notifications_finish_button), onClick = onFinishClick)
+            PrimaryButton(
+                text = stringResource(R.string.onboarding_notifications_finish_button),
+                onClick = onFinishClick,
+            )
         }
     }
 }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingErrors.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingErrors.kt
@@ -1,0 +1,31 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import androidx.annotation.StringRes
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.presentation.R
+
+/**
+ * Maps a postcode-step [DomainError] to its inline-error string resource
+ * (compose-ui.md: user-facing copy is a `:presentation` resource, keyed off
+ * the sealed outcome). [DomainError.GeocodingFailed] is the local
+ * format-validation failure (never reached the network); every other case
+ * came back from the geocoder itself.
+ */
+@StringRes
+internal fun onboardingPostcodeErrorMessageRes(error: DomainError): Int =
+    when (error) {
+        is DomainError.GeocodingFailed -> R.string.onboarding_postcode_error_invalid
+
+        DomainError.NotFound -> R.string.onboarding_postcode_error_not_found
+
+        DomainError.NetworkUnavailable -> R.string.onboarding_postcode_error_network
+
+        DomainError.SessionExpired -> R.string.login_error_session_expired
+
+        is DomainError.InsufficientEntitlement,
+        is DomainError.ServerError,
+        is DomainError.AuthenticationFailed,
+        is DomainError.LogoutFailed,
+        is DomainError.Unexpected,
+        -> R.string.onboarding_postcode_error_generic
+    }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingScreen.kt
@@ -62,7 +62,8 @@ public fun OnboardingRoute(
         onContinueFromPostcodeClick = viewModel::advance,
         onRadiusChange = viewModel::updateRadius,
         onConfirmRadiusClick = viewModel::confirmRadius,
-        onUnlockLargerZonesClick = {}, // #783 hasn't shipped - the chip is hidden (see OnboardingUiState.canUnlockLargerRadius), so this is never reachable.
+        // #783 hasn't shipped - the chip is hidden (OnboardingUiState.canUnlockLargerRadius), so this is never reached.
+        onUnlockLargerZonesClick = {},
         onEnableNotificationsClick = {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
@@ -101,10 +102,11 @@ internal fun OnboardingScreen(
     ) { contentPadding ->
         Column(modifier = Modifier.padding(contentPadding).fillMaxSize()) {
             when (state.step) {
-                OnboardingStep.Welcome ->
+                OnboardingStep.Welcome -> {
                     WelcomeStep(onGetStartedClick = onGetStartedClick, modifier = Modifier.weight(1f))
+                }
 
-                OnboardingStep.Postcode ->
+                OnboardingStep.Postcode -> {
                     PostcodeEntryStep(
                         state = state,
                         onPostcodeChange = onPostcodeChange,
@@ -112,8 +114,9 @@ internal fun OnboardingScreen(
                         onContinueClick = onContinueFromPostcodeClick,
                         modifier = Modifier.weight(1f),
                     )
+                }
 
-                OnboardingStep.Radius ->
+                OnboardingStep.Radius -> {
                     RadiusPickerStep(
                         state = state,
                         onRadiusChange = onRadiusChange,
@@ -121,8 +124,9 @@ internal fun OnboardingScreen(
                         onUnlockLargerZonesClick = onUnlockLargerZonesClick,
                         modifier = Modifier.weight(1f),
                     )
+                }
 
-                OnboardingStep.NotificationPermission ->
+                OnboardingStep.NotificationPermission -> {
                     NotificationPermissionStep(
                         state = state,
                         onEnableClick = onEnableNotificationsClick,
@@ -130,6 +134,7 @@ internal fun OnboardingScreen(
                         onFinishClick = onFinishClick,
                         modifier = Modifier.weight(1f),
                     )
+                }
             }
         }
     }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingScreen.kt
@@ -1,0 +1,210 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import android.Manifest
+import android.content.res.Configuration
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+
+/**
+ * The onboarding wizard: one route hosting all four steps behind a single
+ * [OnboardingViewModel] instance (never re-created per step), with a linear
+ * progress affordance across the top. Port of iOS `OnboardingView`. The
+ * device-permission request (API 33+) is wired here rather than in the
+ * ViewModel, since `rememberLauncherForActivityResult` needs a composable
+ * scope - its result is deliberately never observed (epic #770 parity:
+ * completion proceeds regardless of grant/deny).
+ */
+@Composable
+public fun OnboardingRoute(
+    viewModel: OnboardingViewModel,
+    onOnboardingComplete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    val notificationPermissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) {
+            // Result intentionally ignored - see the class doc above.
+        }
+
+    LaunchedEffect(state.isComplete) {
+        if (state.isComplete) onOnboardingComplete()
+    }
+
+    OnboardingScreen(
+        state = state,
+        onGetStartedClick = viewModel::advance,
+        onBackClick = viewModel::back,
+        onPostcodeChange = viewModel::updatePostcode,
+        onLookUpClick = viewModel::lookUpPostcode,
+        onContinueFromPostcodeClick = viewModel::advance,
+        onRadiusChange = viewModel::updateRadius,
+        onConfirmRadiusClick = viewModel::confirmRadius,
+        onUnlockLargerZonesClick = {}, // #783 hasn't shipped - the chip is hidden (see OnboardingUiState.canUnlockLargerRadius), so this is never reachable.
+        onEnableNotificationsClick = {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+            viewModel.requestNotificationPermission()
+        },
+        onSkipNotificationsClick = viewModel::skipNotifications,
+        onFinishClick = viewModel::completeOnboarding,
+        modifier = modifier,
+    )
+}
+
+@Composable
+internal fun OnboardingScreen(
+    state: OnboardingUiState,
+    onGetStartedClick: () -> Unit,
+    onBackClick: () -> Unit,
+    onPostcodeChange: (String) -> Unit,
+    onLookUpClick: () -> Unit,
+    onContinueFromPostcodeClick: () -> Unit,
+    onRadiusChange: (Float) -> Unit,
+    onConfirmRadiusClick: () -> Unit,
+    onUnlockLargerZonesClick: () -> Unit,
+    onEnableNotificationsClick: () -> Unit,
+    onSkipNotificationsClick: () -> Unit,
+    onFinishClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            if (state.step != OnboardingStep.Welcome) {
+                OnboardingTopBar(step = state.step, onBackClick = onBackClick)
+            }
+        },
+    ) { contentPadding ->
+        Column(modifier = Modifier.padding(contentPadding).fillMaxSize()) {
+            when (state.step) {
+                OnboardingStep.Welcome ->
+                    WelcomeStep(onGetStartedClick = onGetStartedClick, modifier = Modifier.weight(1f))
+
+                OnboardingStep.Postcode ->
+                    PostcodeEntryStep(
+                        state = state,
+                        onPostcodeChange = onPostcodeChange,
+                        onLookUpClick = onLookUpClick,
+                        onContinueClick = onContinueFromPostcodeClick,
+                        modifier = Modifier.weight(1f),
+                    )
+
+                OnboardingStep.Radius ->
+                    RadiusPickerStep(
+                        state = state,
+                        onRadiusChange = onRadiusChange,
+                        onConfirmClick = onConfirmRadiusClick,
+                        onUnlockLargerZonesClick = onUnlockLargerZonesClick,
+                        modifier = Modifier.weight(1f),
+                    )
+
+                OnboardingStep.NotificationPermission ->
+                    NotificationPermissionStep(
+                        state = state,
+                        onEnableClick = onEnableNotificationsClick,
+                        onSkipClick = onSkipNotificationsClick,
+                        onFinishClick = onFinishClick,
+                        modifier = Modifier.weight(1f),
+                    )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun OnboardingTopBar(
+    step: OnboardingStep,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        TopAppBar(
+            title = {},
+            navigationIcon = {
+                IconButton(onClick = onBackClick) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = stringResource(R.string.onboarding_back_content_description),
+                    )
+                }
+            },
+        )
+        LinearProgressIndicator(progress = { onboardingStepProgress(step) }, modifier = Modifier.fillMaxWidth())
+    }
+}
+
+/** 1 of 3 once past Welcome (which shows no bar at all) through to the last step. */
+private fun onboardingStepProgress(step: OnboardingStep): Float =
+    when (step) {
+        OnboardingStep.Welcome -> 0f
+        OnboardingStep.Postcode -> 1f / 3f
+        OnboardingStep.Radius -> 2f / 3f
+        OnboardingStep.NotificationPermission -> 1f
+    }
+
+@Preview(name = "postcode step")
+@Composable
+private fun OnboardingScreenPostcodePreview() {
+    TownCrierTheme {
+        OnboardingScreen(
+            state = OnboardingUiState(step = OnboardingStep.Postcode),
+            onGetStartedClick = {},
+            onBackClick = {},
+            onPostcodeChange = {},
+            onLookUpClick = {},
+            onContinueFromPostcodeClick = {},
+            onRadiusChange = {},
+            onConfirmRadiusClick = {},
+            onUnlockLargerZonesClick = {},
+            onEnableNotificationsClick = {},
+            onSkipNotificationsClick = {},
+            onFinishClick = {},
+        )
+    }
+}
+
+@Preview(name = "radius step", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun OnboardingScreenRadiusPreview() {
+    TownCrierTheme {
+        OnboardingScreen(
+            state = OnboardingUiState(step = OnboardingStep.Radius, radiusMetres = 1_500f, maxRadiusMetres = 2_000f),
+            onGetStartedClick = {},
+            onBackClick = {},
+            onPostcodeChange = {},
+            onLookUpClick = {},
+            onContinueFromPostcodeClick = {},
+            onRadiusChange = {},
+            onConfirmRadiusClick = {},
+            onUnlockLargerZonesClick = {},
+            onEnableNotificationsClick = {},
+            onSkipNotificationsClick = {},
+            onFinishClick = {},
+        )
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingStep.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingStep.kt
@@ -1,0 +1,13 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+/**
+ * The onboarding wizard's four linear steps (tc-7ttz). There is no step
+ * before [Welcome] (no back navigation from it) and completion happens from
+ * [NotificationPermission] rather than a fifth step.
+ */
+public enum class OnboardingStep {
+    Welcome,
+    Postcode,
+    Radius,
+    NotificationPermission,
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingUiState.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingUiState.kt
@@ -1,0 +1,37 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.domain.watchzones.Coordinate
+import uk.towncrierapp.domain.watchzones.Postcode
+import uk.towncrierapp.domain.watchzones.WatchZone
+
+/**
+ * `OnboardingScreen` state. [isComplete] is a one-shot signal the Route
+ * reconciles (coroutines-and-flow.md "One-shot effects") by leaving the
+ * wizard for the main app - the ViewModel itself never navigates. Port of
+ * iOS `OnboardingViewModel`'s published state.
+ */
+public data class OnboardingUiState(
+    val step: OnboardingStep = OnboardingStep.Welcome,
+    val tier: SubscriptionTier = SubscriptionTier.FREE,
+    val postcodeInput: String = "",
+    val isLookingUpPostcode: Boolean = false,
+    val resolvedPostcode: Postcode? = null,
+    val geocodedCoordinate: Coordinate? = null,
+    val postcodeError: DomainError? = null,
+    val radiusMetres: Float = DEFAULT_RADIUS_METRES,
+    val minRadiusMetres: Float = MIN_RADIUS_METRES,
+    val maxRadiusMetres: Float = DEFAULT_RADIUS_METRES,
+    val showsLargeRadiusWarning: Boolean = false,
+    val canUnlockLargerRadius: Boolean = false,
+    val pendingZone: WatchZone? = null,
+    val hasInstantAlertEntitlement: Boolean = false,
+    val isCompleting: Boolean = false,
+    val isComplete: Boolean = false,
+) {
+    public companion object {
+        public const val MIN_RADIUS_METRES: Float = 100f
+        public const val DEFAULT_RADIUS_METRES: Float = 1_000f
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModel.kt
@@ -1,0 +1,212 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.onboarding.OnboardingRepository
+import uk.towncrierapp.domain.subscriptions.Entitlement
+import uk.towncrierapp.domain.subscriptions.FeatureGate
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.domain.watchzones.Postcode
+import uk.towncrierapp.domain.watchzones.PostcodeGeocoder
+import uk.towncrierapp.domain.watchzones.WatchZone
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import uk.towncrierapp.domain.watchzones.WatchZoneLimits
+import uk.towncrierapp.domain.watchzones.WatchZoneRepository
+import uk.towncrierapp.presentation.designsystem.components.LARGE_RADIUS_WARNING_THRESHOLD_METRES
+import java.util.UUID
+
+private val INSTANT_ALERT_ENTITLEMENT = Entitlement.STATUS_CHANGE_ALERTS
+
+/**
+ * Drives the four-step onboarding wizard: postcode geocoding, tier-based
+ * radius limits, and tier-aware notification-permission copy. Deliberately
+ * constructed ONCE per wizard presentation - never re-created per step or on
+ * a tier change - so [reconcileTierAfterUpgrade] can push a later tier into
+ * the SAME instance's state. That is what lets it survive a future paywall
+ * dialog presented over the wizard (#783) without losing the
+ * postcode/coordinate/radius already entered: the composition root
+ * constructs this ViewModel once for the whole wizard route, not once per
+ * step. Port of iOS `OnboardingViewModel`.
+ */
+public class OnboardingViewModel(
+    private val postcodeGeocoder: PostcodeGeocoder,
+    private val watchZoneRepository: WatchZoneRepository,
+    private val onboardingRepository: OnboardingRepository,
+    tier: SubscriptionTier,
+    private val paywallAvailable: Boolean = false,
+    private val enableDebugLogging: Boolean = false,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(initialState(tier, paywallAvailable))
+    public val uiState: StateFlow<OnboardingUiState> = _uiState.asStateFlow()
+
+    /**
+     * Advances Welcome -> Postcode unconditionally, or Postcode -> Radius
+     * once a postcode has been resolved. Radius -> NotificationPermission
+     * goes through [confirmRadius] instead, since that transition also
+     * builds the in-memory zone.
+     */
+    public fun advance() {
+        val next = nextStep(_uiState.value) ?: return
+        _uiState.update { it.copy(step = next) }
+    }
+
+    /** No-op on [OnboardingStep.Welcome] - the wizard is linear going forward but not one-way. */
+    public fun back() {
+        val previous = previousStep(_uiState.value.step) ?: return
+        _uiState.update { it.copy(step = previous) }
+    }
+
+    public fun updatePostcode(value: String) {
+        _uiState.update { it.copy(postcodeInput = value) }
+    }
+
+    /** Validates the format locally first - a garbage postcode never spends a network call - before calling [postcodeGeocoder]. */
+    public fun lookUpPostcode() {
+        val raw = _uiState.value.postcodeInput
+        val postcode = Postcode.parse(raw)
+        if (postcode == null) {
+            _uiState.update { it.copy(postcodeError = DomainError.GeocodingFailed(raw)) }
+            return
+        }
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLookingUpPostcode = true, postcodeError = null) }
+            try {
+                val coordinate = postcodeGeocoder.geocode(postcode.value)
+                _uiState.update {
+                    it.copy(isLookingUpPostcode = false, resolvedPostcode = postcode, geocodedCoordinate = coordinate)
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                _uiState.update { it.copy(isLookingUpPostcode = false, postcodeError = e) }
+            }
+        }
+    }
+
+    public fun updateRadius(value: Float) {
+        _uiState.update {
+            it.copy(radiusMetres = value, showsLargeRadiusWarning = value >= LARGE_RADIUS_WARNING_THRESHOLD_METRES)
+        }
+    }
+
+    /** Builds the [WatchZone] in memory only - nothing is saved until [completeOnboarding] - and advances to the notification-permission step. */
+    public fun confirmRadius() {
+        val state = _uiState.value
+        val coordinate = state.geocodedCoordinate ?: return
+        val limits = WatchZoneLimits(state.tier)
+        val zone =
+            WatchZone(
+                id = WatchZoneId(UUID.randomUUID().toString()),
+                name = state.resolvedPostcode?.value ?: state.postcodeInput.trim(),
+                centre = coordinate,
+                radiusMetres = limits.clampRadius(state.radiusMetres.toDouble()),
+            )
+        _uiState.update { it.copy(pendingZone = zone, step = OnboardingStep.NotificationPermission) }
+    }
+
+    /**
+     * Called when the user taps "Enable notifications". The actual OS
+     * permission request is the Route's job (`rememberLauncherForActivityResult`
+     * needs a composable scope) - this function's only job is to complete
+     * the wizard regardless of the eventual grant/deny result, which is
+     * intentionally never observed here.
+     */
+    public fun requestNotificationPermission() {
+        completeOnboarding()
+    }
+
+    /** Free-tier's honest path: no OS permission was ever requested. */
+    public fun skipNotifications() {
+        completeOnboarding()
+    }
+
+    /**
+     * Persists the in-memory zone best-effort - a failure is logged, not
+     * blocking - sets the device latch, and signals completion. Matches iOS
+     * `try?` semantics: the zones tab shows empty and the user can retry
+     * from there rather than being trapped in the wizard.
+     */
+    public fun completeOnboarding() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isCompleting = true) }
+            _uiState.value.pendingZone?.let { zone ->
+                try {
+                    watchZoneRepository.create(zone)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: DomainError) {
+                    log(enableDebugLogging) { "best-effort watch zone save failed at onboarding completion: $e" }
+                }
+            }
+            onboardingRepository.setOnboardingComplete(true)
+            _uiState.update { it.copy(isCompleting = false, isComplete = true) }
+        }
+    }
+
+    /**
+     * Pushes a tier raised by a (future, #783) paywall purchase into this
+     * SAME instance - the caller re-resolves the tier after the purchase
+     * flow and calls this rather than recreating the ViewModel, which is
+     * what preserves postcode/coordinate/radius already entered.
+     */
+    public fun reconcileTierAfterUpgrade(newTier: SubscriptionTier) {
+        _uiState.update { state ->
+            val limits = WatchZoneLimits(newTier)
+            val newMax = limits.maxRadiusMetres.toFloat()
+            val clampedRadius = minOf(state.radiusMetres, newMax)
+            state.copy(
+                tier = newTier,
+                maxRadiusMetres = newMax,
+                radiusMetres = clampedRadius,
+                showsLargeRadiusWarning = clampedRadius >= LARGE_RADIUS_WARNING_THRESHOLD_METRES,
+                canUnlockLargerRadius = paywallAvailable && newTier < SubscriptionTier.PRO,
+                hasInstantAlertEntitlement = FeatureGate(newTier).hasEntitlement(INSTANT_ALERT_ENTITLEMENT),
+            )
+        }
+    }
+}
+
+private fun nextStep(state: OnboardingUiState): OnboardingStep? =
+    when (state.step) {
+        OnboardingStep.Welcome -> OnboardingStep.Postcode
+        OnboardingStep.Postcode -> if (state.geocodedCoordinate != null) OnboardingStep.Radius else null
+        OnboardingStep.Radius, OnboardingStep.NotificationPermission -> null
+    }
+
+private fun previousStep(step: OnboardingStep): OnboardingStep? =
+    when (step) {
+        OnboardingStep.Welcome -> null
+        OnboardingStep.Postcode -> OnboardingStep.Welcome
+        OnboardingStep.Radius -> OnboardingStep.Postcode
+        OnboardingStep.NotificationPermission -> OnboardingStep.Radius
+    }
+
+private fun initialState(
+    tier: SubscriptionTier,
+    paywallAvailable: Boolean,
+): OnboardingUiState {
+    val limits = WatchZoneLimits(tier)
+    return OnboardingUiState(
+        tier = tier,
+        maxRadiusMetres = limits.maxRadiusMetres.toFloat(),
+        canUnlockLargerRadius = paywallAvailable && tier < SubscriptionTier.PRO,
+        hasInstantAlertEntitlement = FeatureGate(tier).hasEntitlement(INSTANT_ALERT_ENTITLEMENT),
+    )
+}
+
+private inline fun log(
+    enableDebugLogging: Boolean,
+    message: () -> String,
+) {
+    // Guarded so plain JVM unit tests (enableDebugLogging = false by
+    // default) never touch android.util.Log - mirrors ApiClient's `log`.
+    if (enableDebugLogging) Log.w("OnboardingViewModel", message())
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/PostcodeEntryStep.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/PostcodeEntryStep.kt
@@ -78,26 +78,29 @@ private fun PostcodeStepAction(
     modifier: Modifier = Modifier,
 ) {
     when {
-        state.isLookingUpPostcode ->
+        state.isLookingUpPostcode -> {
             CircularProgressIndicator(
                 modifier = modifier.padding(TownCrierSpacing.sm),
                 color = MaterialTheme.colorScheme.primary,
             )
+        }
 
-        state.geocodedCoordinate != null ->
+        state.geocodedCoordinate != null -> {
             PrimaryButton(
                 text = stringResource(R.string.onboarding_postcode_continue_button),
                 onClick = onContinueClick,
                 modifier = modifier,
             )
+        }
 
-        else ->
+        else -> {
             PrimaryButton(
                 text = stringResource(R.string.onboarding_postcode_lookup_button),
                 onClick = onLookUpClick,
                 enabled = state.postcodeInput.isNotBlank(),
                 modifier = modifier,
             )
+        }
     }
 }
 
@@ -131,7 +134,11 @@ private fun PostcodeEntryStepGeocodedPreview() {
 private fun PostcodeEntryStepErrorPreview() {
     TownCrierTheme {
         PostcodeEntryStep(
-            state = OnboardingUiState(postcodeInput = "NOTAPOSTCODE", postcodeError = DomainError.GeocodingFailed("NOTAPOSTCODE")),
+            state =
+                OnboardingUiState(
+                    postcodeInput = "NOTAPOSTCODE",
+                    postcodeError = DomainError.GeocodingFailed("NOTAPOSTCODE"),
+                ),
             onPostcodeChange = {},
             onLookUpClick = {},
             onContinueClick = {},

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/PostcodeEntryStep.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/PostcodeEntryStep.kt
@@ -1,0 +1,140 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.tooling.preview.Preview
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.watchzones.Coordinate
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import uk.towncrierapp.presentation.designsystem.components.PrimaryButton
+
+/**
+ * Step 2 - free-text postcode entry. Shows a "Look up" button while there's
+ * no resolved coordinate yet (disabled until [OnboardingUiState.postcodeInput]
+ * is non-blank), then swaps to "Continue" once geocoding has succeeded.
+ */
+@Composable
+internal fun PostcodeEntryStep(
+    state: OnboardingUiState,
+    onPostcodeChange: (String) -> Unit,
+    onLookUpClick: () -> Unit,
+    onContinueClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize().padding(TownCrierSpacing.lg),
+        verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.md),
+    ) {
+        Text(
+            text = stringResource(R.string.onboarding_postcode_title),
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Text(
+            text = stringResource(R.string.onboarding_postcode_subtitle),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        OutlinedTextField(
+            value = state.postcodeInput,
+            onValueChange = onPostcodeChange,
+            placeholder = { Text(stringResource(R.string.onboarding_postcode_placeholder)) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(capitalization = KeyboardCapitalization.Characters),
+            modifier = Modifier.fillMaxWidth(),
+        )
+        state.postcodeError?.let { error ->
+            Text(
+                text = stringResource(onboardingPostcodeErrorMessageRes(error)),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+            )
+        }
+        PostcodeStepAction(state = state, onLookUpClick = onLookUpClick, onContinueClick = onContinueClick)
+    }
+}
+
+@Composable
+private fun PostcodeStepAction(
+    state: OnboardingUiState,
+    onLookUpClick: () -> Unit,
+    onContinueClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when {
+        state.isLookingUpPostcode ->
+            CircularProgressIndicator(
+                modifier = modifier.padding(TownCrierSpacing.sm),
+                color = MaterialTheme.colorScheme.primary,
+            )
+
+        state.geocodedCoordinate != null ->
+            PrimaryButton(
+                text = stringResource(R.string.onboarding_postcode_continue_button),
+                onClick = onContinueClick,
+                modifier = modifier,
+            )
+
+        else ->
+            PrimaryButton(
+                text = stringResource(R.string.onboarding_postcode_lookup_button),
+                onClick = onLookUpClick,
+                enabled = state.postcodeInput.isNotBlank(),
+                modifier = modifier,
+            )
+    }
+}
+
+@Preview(name = "empty")
+@Composable
+private fun PostcodeEntryStepEmptyPreview() {
+    TownCrierTheme {
+        PostcodeEntryStep(state = OnboardingUiState(), onPostcodeChange = {}, onLookUpClick = {}, onContinueClick = {})
+    }
+}
+
+@Preview(name = "geocoded")
+@Composable
+private fun PostcodeEntryStepGeocodedPreview() {
+    TownCrierTheme {
+        PostcodeEntryStep(
+            state =
+                OnboardingUiState(
+                    postcodeInput = "SW1A 1AA",
+                    geocodedCoordinate = Coordinate(51.5074, -0.1278),
+                ),
+            onPostcodeChange = {},
+            onLookUpClick = {},
+            onContinueClick = {},
+        )
+    }
+}
+
+@Preview(name = "error", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun PostcodeEntryStepErrorPreview() {
+    TownCrierTheme {
+        PostcodeEntryStep(
+            state = OnboardingUiState(postcodeInput = "NOTAPOSTCODE", postcodeError = DomainError.GeocodingFailed("NOTAPOSTCODE")),
+            onPostcodeChange = {},
+            onLookUpClick = {},
+            onContinueClick = {},
+        )
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/RadiusPickerStep.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/RadiusPickerStep.kt
@@ -1,0 +1,124 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import uk.towncrierapp.presentation.designsystem.components.LargeRadiusWarning
+import uk.towncrierapp.presentation.designsystem.components.PrimaryButton
+import uk.towncrierapp.presentation.designsystem.components.UnlockLargerZonesChip
+import uk.towncrierapp.presentation.features.watchzones.RadiusFormatter
+
+private const val RADIUS_STEP_METRES = 100f
+
+/**
+ * Step 3 - a slider from [OnboardingUiState.minRadiusMetres] to the tier's
+ * max, defaulting to 1 km. [OnboardingUiState.canUnlockLargerRadius] is
+ * false whenever the paywall isn't available yet (#783), which hides the
+ * chip entirely rather than routing to a dead tap target.
+ */
+@Composable
+internal fun RadiusPickerStep(
+    state: OnboardingUiState,
+    onRadiusChange: (Float) -> Unit,
+    onConfirmClick: () -> Unit,
+    onUnlockLargerZonesClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize().padding(TownCrierSpacing.lg),
+        verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.md),
+    ) {
+        Text(
+            text = stringResource(R.string.onboarding_radius_title),
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+        )
+        Text(
+            text = stringResource(R.string.onboarding_radius_subtitle),
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(text = RadiusFormatter.format(state.radiusMetres.toDouble()), style = TownCrierTheme.bodyEmphasis)
+        Slider(
+            value = state.radiusMetres,
+            onValueChange = onRadiusChange,
+            valueRange = state.minRadiusMetres..state.maxRadiusMetres,
+            steps = radiusSliderSteps(state.minRadiusMetres, state.maxRadiusMetres),
+        )
+        Row(modifier = Modifier.fillMaxWidth()) {
+            Text(
+                text = RadiusFormatter.format(state.minRadiusMetres.toDouble()),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Text(
+                text = RadiusFormatter.format(state.maxRadiusMetres.toDouble()),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (state.canUnlockLargerRadius) {
+            UnlockLargerZonesChip(onClick = onUnlockLargerZonesClick)
+        }
+        if (state.showsLargeRadiusWarning) {
+            LargeRadiusWarning()
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        PrimaryButton(text = stringResource(R.string.onboarding_radius_confirm_button), onClick = onConfirmClick)
+    }
+}
+
+/** 100 m steps between [min] and [max] (design-language radius slider spec) - same arithmetic as `WatchZoneEditorSections.radiusSliderSteps`. */
+private fun radiusSliderSteps(
+    min: Float,
+    max: Float,
+): Int = (((max - min) / RADIUS_STEP_METRES).toInt() - 1).coerceAtLeast(0)
+
+@Preview(name = "light")
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun RadiusPickerStepPreview() {
+    TownCrierTheme {
+        RadiusPickerStep(
+            state = OnboardingUiState(radiusMetres = 1_500f, maxRadiusMetres = 2_000f),
+            onRadiusChange = {},
+            onConfirmClick = {},
+            onUnlockLargerZonesClick = {},
+        )
+    }
+}
+
+@Preview(name = "warning + unlock chip")
+@Composable
+private fun RadiusPickerStepWarningPreview() {
+    TownCrierTheme {
+        RadiusPickerStep(
+            state =
+                OnboardingUiState(
+                    radiusMetres = 2_500f,
+                    maxRadiusMetres = 5_000f,
+                    canUnlockLargerRadius = true,
+                    showsLargeRadiusWarning = true,
+                ),
+            onRadiusChange = {},
+            onConfirmClick = {},
+            onUnlockLargerZonesClick = {},
+        )
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/WelcomeStep.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/onboarding/WelcomeStep.kt
@@ -1,0 +1,58 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import uk.towncrierapp.presentation.designsystem.components.PrimaryButton
+
+/** Step 1 - branding + "Get started". No back navigation exists from here. */
+@Composable
+internal fun WelcomeStep(
+    onGetStartedClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize().padding(TownCrierSpacing.lg),
+        verticalArrangement = Arrangement.SpaceBetween,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = stringResource(R.string.onboarding_welcome_title),
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Text(
+                text = stringResource(R.string.onboarding_welcome_subtitle),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        PrimaryButton(text = stringResource(R.string.onboarding_welcome_get_started), onClick = onGetStartedClick)
+    }
+}
+
+@Preview(name = "light")
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun WelcomeStepPreview() {
+    TownCrierTheme {
+        WelcomeStep(onGetStartedClick = {}, modifier = Modifier.fillMaxSize())
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneErrors.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneErrors.kt
@@ -11,13 +11,19 @@ import uk.towncrierapp.presentation.R
  * baked into the ViewModel). [DomainError.InsufficientEntitlement] is listed
  * for exhaustiveness only — those cases route to the paywall placeholder
  * instead of rendering inline (see `WatchZoneEditorViewModel.save`).
+ * [DomainError.GeocodingFailed] is likewise listed for exhaustiveness only —
+ * this editor's postcode field never produces it (that's the onboarding
+ * wizard's postcode step, tc-7ttz); grouped with [DomainError.NotFound]
+ * since the copy fits either way.
  */
 @StringRes
 internal fun watchZoneErrorMessageRes(error: DomainError): Int =
     when (error) {
         DomainError.NetworkUnavailable -> R.string.watch_zone_error_network
 
-        DomainError.NotFound -> R.string.watch_zone_error_not_found
+        DomainError.NotFound,
+        is DomainError.GeocodingFailed,
+        -> R.string.watch_zone_error_not_found
 
         DomainError.SessionExpired -> R.string.login_error_session_expired
 

--- a/mobile/android/presentation/src/main/res/values/strings.xml
+++ b/mobile/android/presentation/src/main/res/values/strings.xml
@@ -120,4 +120,31 @@
     <string name="application_detail_save_content_description">Save application</string>
     <string name="application_detail_unsave_content_description">Remove from saved</string>
     <string name="application_detail_share_content_description">Share application</string>
+
+    <!-- Onboarding wizard (tc-7ttz) -->
+    <string name="onboarding_back_content_description">Back</string>
+    <string name="onboarding_welcome_title">Town Crier</string>
+    <string name="onboarding_welcome_subtitle">Know about planning applications near you, the day they\'re published.</string>
+    <string name="onboarding_welcome_get_started">Get started</string>
+
+    <string name="onboarding_postcode_title">Where should we watch?</string>
+    <string name="onboarding_postcode_subtitle">Enter a postcode. It doesn\'t have to be home, anywhere you care about works.</string>
+    <string name="onboarding_postcode_placeholder">Postcode</string>
+    <string name="onboarding_postcode_lookup_button">Look up</string>
+    <string name="onboarding_postcode_continue_button">Continue</string>
+    <string name="onboarding_postcode_error_invalid">That doesn\'t look like a UK postcode. Check it and try again.</string>
+    <string name="onboarding_postcode_error_not_found">We couldn\'t find that postcode. Check it and try again.</string>
+    <string name="onboarding_postcode_error_network">Check your internet connection and try again.</string>
+    <string name="onboarding_postcode_error_generic">Something went wrong. Try again.</string>
+
+    <string name="onboarding_radius_title">Set your watch zone size</string>
+    <string name="onboarding_radius_subtitle">Drag to choose how far out to watch. You can change this any time.</string>
+    <string name="onboarding_radius_confirm_button">Confirm</string>
+
+    <string name="onboarding_notifications_title">Stay in the loop</string>
+    <string name="onboarding_notifications_paid_body">Turn on notifications and we\'ll tell you the moment something changes nearby.</string>
+    <string name="onboarding_notifications_free_body">Free gives you a weekly email digest. Upgrade any time for instant alerts by push and email.</string>
+    <string name="onboarding_notifications_enable_button">Enable notifications</string>
+    <string name="onboarding_notifications_skip_button">Skip for now</string>
+    <string name="onboarding_notifications_finish_button">Finish</string>
 </resources>

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinatorTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinatorTest.kt
@@ -6,18 +6,28 @@ import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.domain.auth.FakeAuthenticationService
 import uk.towncrierapp.domain.auth.anAuthSession
 import uk.towncrierapp.domain.profile.FakeUserProfileRepository
+import uk.towncrierapp.domain.profile.ServerProfile
+import uk.towncrierapp.domain.profile.UserProfileRepository
 import uk.towncrierapp.domain.profile.aServerProfile
 import uk.towncrierapp.domain.subscriptions.FakeSubscriptionTierCache
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.domain.watchzones.FakeWatchZoneRepository
+import uk.towncrierapp.domain.watchzones.WatchZone
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import uk.towncrierapp.domain.watchzones.WatchZoneRepository
+import uk.towncrierapp.domain.watchzones.aWatchZone
 import kotlin.test.assertEquals
 
 /**
  * The signed-in transition: `POST /v1/me` (ensure-profile) BEFORE tier
  * resolution (#549 ordering), `max(serverTier ?? max(cachedTier, jwtTier),
  * jwtTier)` with a single refresh-and-retry when the first pass lands on
- * Free, and persistence to the `cachedSubscriptionTier` device latch. Port
- * of iOS `AppCoordinator.resolveSubscriptionTier()` / `SubscriptionTierResolver`,
- * degraded to the 2-way merge this issue implements (no store tier until #783).
+ * Free, persistence to the `cachedSubscriptionTier` device latch, and -
+ * strictly after all of that (tc-7ttz) - the onboarding account-state gate:
+ * zero watch zones means the wizard is required. Port of iOS
+ * `AppCoordinator.resolveSubscriptionTier()` / `SubscriptionTierResolver` /
+ * `AppCoordinator+Onboarding`, degraded to the 2-way tier merge this issue
+ * implements (no store tier until #783).
  */
 class AuthCoordinatorTest {
     @Test
@@ -32,7 +42,7 @@ class AuthCoordinatorTest {
                     ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.PRO)),
                 )
             val tierCache = FakeSubscriptionTierCache(stored = SubscriptionTier.FREE)
-            val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
+            val sut = AuthCoordinator(authService, userProfileRepository, tierCache, FakeWatchZoneRepository())
 
             sut.onSignedIn()
 
@@ -50,7 +60,7 @@ class AuthCoordinatorTest {
             val userProfileRepository =
                 FakeUserProfileRepository(ensureProfileResult = Result.failure(DomainError.NetworkUnavailable))
             val tierCache = FakeSubscriptionTierCache(stored = SubscriptionTier.PRO)
-            val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
+            val sut = AuthCoordinator(authService, userProfileRepository, tierCache, FakeWatchZoneRepository())
 
             sut.onSignedIn()
 
@@ -71,7 +81,7 @@ class AuthCoordinatorTest {
                     ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.FREE)),
                 )
             val tierCache = FakeSubscriptionTierCache(stored = SubscriptionTier.FREE)
-            val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
+            val sut = AuthCoordinator(authService, userProfileRepository, tierCache, FakeWatchZoneRepository())
 
             sut.onSignedIn()
 
@@ -93,7 +103,7 @@ class AuthCoordinatorTest {
                     ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.FREE)),
                 )
             val tierCache = FakeSubscriptionTierCache(stored = SubscriptionTier.FREE)
-            val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
+            val sut = AuthCoordinator(authService, userProfileRepository, tierCache, FakeWatchZoneRepository())
 
             sut.onSignedIn()
 
@@ -111,10 +121,130 @@ class AuthCoordinatorTest {
                     ensureProfileResult = Result.success(aServerProfile(tier = SubscriptionTier.PRO)),
                 )
             val tierCache = FakeSubscriptionTierCache()
-            val sut = AuthCoordinator(authService, userProfileRepository, tierCache)
+            val sut = AuthCoordinator(authService, userProfileRepository, tierCache, FakeWatchZoneRepository())
 
             sut.onSignedIn()
 
             assertEquals(listOf(SubscriptionTier.PRO), tierCache.writeCalls)
+        }
+
+    @Test
+    fun `onboardingPresentation starts Undetermined before onSignedIn has run`() {
+        val sut =
+            AuthCoordinator(
+                FakeAuthenticationService(),
+                FakeUserProfileRepository(),
+                FakeSubscriptionTierCache(),
+                FakeWatchZoneRepository(),
+            )
+
+        assertEquals(OnboardingPresentation.Undetermined, sut.onboardingPresentation.value)
+    }
+
+    @Test
+    fun `onSignedIn resolves onboardingPresentation to Required when the account has zero watch zones`() =
+        runTest {
+            val sut =
+                AuthCoordinator(
+                    FakeAuthenticationService(),
+                    FakeUserProfileRepository(),
+                    FakeSubscriptionTierCache(),
+                    FakeWatchZoneRepository(stored = mutableListOf()),
+                )
+
+            sut.onSignedIn()
+
+            assertEquals(OnboardingPresentation.Required, sut.onboardingPresentation.value)
+        }
+
+    @Test
+    fun `onSignedIn resolves onboardingPresentation to NotRequired when the account already has a watch zone`() =
+        runTest {
+            val sut =
+                AuthCoordinator(
+                    FakeAuthenticationService(),
+                    FakeUserProfileRepository(),
+                    FakeSubscriptionTierCache(),
+                    FakeWatchZoneRepository(stored = mutableListOf(aWatchZone())),
+                )
+
+            sut.onSignedIn()
+
+            assertEquals(OnboardingPresentation.NotRequired, sut.onboardingPresentation.value)
+        }
+
+    @Test
+    fun `a watch-zone fetch failure fails open to NotRequired rather than stranding the user Undetermined`() =
+        runTest {
+            val watchZoneRepository = FakeWatchZoneRepository().apply { zonesFailWith = DomainError.NetworkUnavailable }
+            val sut =
+                AuthCoordinator(
+                    FakeAuthenticationService(),
+                    FakeUserProfileRepository(),
+                    FakeSubscriptionTierCache(),
+                    watchZoneRepository,
+                )
+
+            sut.onSignedIn()
+
+            assertEquals(OnboardingPresentation.NotRequired, sut.onboardingPresentation.value)
+        }
+
+    @Test
+    fun `onOnboardingCompleted forces onboardingPresentation to NotRequired`() {
+        val sut =
+            AuthCoordinator(
+                FakeAuthenticationService(),
+                FakeUserProfileRepository(),
+                FakeSubscriptionTierCache(),
+                FakeWatchZoneRepository(stored = mutableListOf()),
+            )
+
+        sut.onOnboardingCompleted()
+
+        assertEquals(OnboardingPresentation.NotRequired, sut.onboardingPresentation.value)
+    }
+
+    /**
+     * The reproduction test for tc-k9fk/#549: evaluating the watch-zone gate
+     * before ensure-profile completes crashed onboarding in production. Two
+     * purpose-built local fakes (not the shared `Fake*` fixtures) record into
+     * one shared list so the ordering, not just the outcome, is asserted.
+     */
+    @Test
+    fun `the watch-zone gate check is never evaluated before ensure-profile completes`() =
+        runTest {
+            val callOrder = mutableListOf<String>()
+            val userProfileRepository =
+                object : UserProfileRepository {
+                    override suspend fun ensureProfile(): ServerProfile {
+                        callOrder += "ensureProfile"
+                        return aServerProfile(tier = SubscriptionTier.PRO)
+                    }
+                }
+            val watchZoneRepository =
+                object : WatchZoneRepository {
+                    override suspend fun zones(): List<WatchZone> {
+                        callOrder += "zones"
+                        return emptyList()
+                    }
+
+                    override suspend fun create(zone: WatchZone): Unit = error("not used by this test")
+
+                    override suspend fun update(zone: WatchZone): Unit = error("not used by this test")
+
+                    override suspend fun delete(id: WatchZoneId): Unit = error("not used by this test")
+                }
+            val sut =
+                AuthCoordinator(
+                    FakeAuthenticationService(),
+                    userProfileRepository,
+                    FakeSubscriptionTierCache(),
+                    watchZoneRepository,
+                )
+
+            sut.onSignedIn()
+
+            assertEquals(listOf("ensureProfile", "zones"), callOrder)
         }
 }

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModelCompletionTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModelCompletionTest.kt
@@ -1,0 +1,85 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.onboarding.FakeOnboardingRepository
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.domain.watchzones.FakePostcodeGeocoder
+import uk.towncrierapp.domain.watchzones.FakeWatchZoneRepository
+import uk.towncrierapp.domain.watchzones.aCoordinate
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Completion is best-effort (tc-7ttz, iOS `try?` parity): the in-memory zone
+ * is saved via `WatchZoneRepository.create`, the device latch is always set,
+ * and a save failure still completes the wizard rather than trapping the
+ * user in it. Port of iOS `OnboardingViewModelTests`'s completion cases.
+ */
+@ExtendWith(MainDispatcherExtension::class)
+class OnboardingViewModelCompletionTest {
+    private fun aViewModelReadyToFinish(
+        watchZoneRepository: FakeWatchZoneRepository,
+        onboardingRepository: FakeOnboardingRepository,
+    ): OnboardingViewModel {
+        val viewModel =
+            OnboardingViewModel(
+                FakePostcodeGeocoder(Result.success(aCoordinate())),
+                watchZoneRepository,
+                onboardingRepository,
+                SubscriptionTier.FREE,
+            )
+        viewModel.advance() // Welcome -> Postcode
+        viewModel.updatePostcode("SW1A 1AA")
+        viewModel.lookUpPostcode()
+        viewModel.advance() // Postcode -> Radius
+        viewModel.confirmRadius() // Radius -> NotificationPermission
+        return viewModel
+    }
+
+    @Test
+    fun `completeOnboarding sends create with exactly the built name, coordinate, and radius`() {
+        val watchZoneRepository = FakeWatchZoneRepository()
+        val onboardingRepository = FakeOnboardingRepository()
+        val viewModel = aViewModelReadyToFinish(watchZoneRepository, onboardingRepository)
+        viewModel.updateRadius(1_500f)
+        // updateRadius happens after confirmRadius here purely to prove the
+        // SENT payload matches uiState.pendingZone (built at confirm time),
+        // not whatever radiusMetres happens to hold afterwards.
+        val expectedZone = viewModel.uiState.value.pendingZone
+
+        viewModel.completeOnboarding()
+
+        val sent = watchZoneRepository.createCalls.single()
+        assertEquals(expectedZone?.name, sent.name)
+        assertEquals(expectedZone?.centre?.latitude, sent.centre.latitude)
+        assertEquals(expectedZone?.centre?.longitude, sent.centre.longitude)
+        assertEquals(expectedZone?.radiusMetres, sent.radiusMetres)
+    }
+
+    @Test
+    fun `completeOnboarding sets the device latch and signals completion`() {
+        val watchZoneRepository = FakeWatchZoneRepository()
+        val onboardingRepository = FakeOnboardingRepository()
+        val viewModel = aViewModelReadyToFinish(watchZoneRepository, onboardingRepository)
+
+        viewModel.completeOnboarding()
+
+        assertEquals(listOf(true), onboardingRepository.setOnboardingCompleteCalls)
+        assertTrue(viewModel.uiState.value.isComplete)
+    }
+
+    @Test
+    fun `a save failure still completes the wizard and still sets the latch`() {
+        val watchZoneRepository = FakeWatchZoneRepository().apply { createFailWith = DomainError.NetworkUnavailable }
+        val onboardingRepository = FakeOnboardingRepository()
+        val viewModel = aViewModelReadyToFinish(watchZoneRepository, onboardingRepository)
+
+        viewModel.completeOnboarding()
+
+        assertTrue(viewModel.uiState.value.isComplete)
+        assertEquals(listOf(true), onboardingRepository.setOnboardingCompleteCalls)
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModelNotificationTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModelNotificationTest.kt
@@ -1,0 +1,69 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.onboarding.FakeOnboardingRepository
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.domain.watchzones.FakePostcodeGeocoder
+import uk.towncrierapp.domain.watchzones.FakeWatchZoneRepository
+import uk.towncrierapp.domain.watchzones.aCoordinate
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Step 4's tier-aware copy switch. `hasInstantAlertEntitlement` is what the
+ * Screen keys its Enable/Skip-vs-Finish rendering on; the actual OS
+ * permission request lives in the Route (`rememberLauncherForActivityResult`
+ * needs a composable scope), so this ViewModel only needs to prove the flag
+ * is right and that both `requestNotificationPermission` and
+ * `skipNotifications` complete the wizard the same way (tc-7ttz). Port of
+ * iOS `OnboardingViewModelTests`'s notification-step cases.
+ */
+@ExtendWith(MainDispatcherExtension::class)
+class OnboardingViewModelNotificationTest {
+    private fun aViewModelReadyToFinish(tier: SubscriptionTier): OnboardingViewModel {
+        val viewModel =
+            OnboardingViewModel(
+                FakePostcodeGeocoder(Result.success(aCoordinate())),
+                FakeWatchZoneRepository(),
+                FakeOnboardingRepository(),
+                tier,
+            )
+        viewModel.advance() // Welcome -> Postcode
+        viewModel.updatePostcode("SW1A 1AA")
+        viewModel.lookUpPostcode()
+        viewModel.advance() // Postcode -> Radius
+        viewModel.confirmRadius() // Radius -> NotificationPermission
+        return viewModel
+    }
+
+    @Test
+    fun `free tier has no instant alert entitlement`() {
+        assertFalse(aViewModelReadyToFinish(SubscriptionTier.FREE).uiState.value.hasInstantAlertEntitlement)
+    }
+
+    @Test
+    fun `personal and pro tiers have the instant alert entitlement`() {
+        assertTrue(aViewModelReadyToFinish(SubscriptionTier.PERSONAL).uiState.value.hasInstantAlertEntitlement)
+        assertTrue(aViewModelReadyToFinish(SubscriptionTier.PRO).uiState.value.hasInstantAlertEntitlement)
+    }
+
+    @Test
+    fun `requestNotificationPermission completes the wizard`() {
+        val viewModel = aViewModelReadyToFinish(SubscriptionTier.PERSONAL)
+
+        viewModel.requestNotificationPermission()
+
+        assertTrue(viewModel.uiState.value.isComplete)
+    }
+
+    @Test
+    fun `skipNotifications also completes the wizard`() {
+        val viewModel = aViewModelReadyToFinish(SubscriptionTier.PERSONAL)
+
+        viewModel.skipNotifications()
+
+        assertTrue(viewModel.uiState.value.isComplete)
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModelPostcodeTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModelPostcodeTest.kt
@@ -1,0 +1,119 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.onboarding.FakeOnboardingRepository
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.domain.watchzones.FakePostcodeGeocoder
+import uk.towncrierapp.domain.watchzones.FakeWatchZoneRepository
+import uk.towncrierapp.domain.watchzones.aCoordinate
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The postcode step: local format validation (never spends a network call on
+ * a garbage string) before `PostcodeGeocoder`, mixed-case/optional-space
+ * acceptance, and inline retryable errors from the `DomainError` catalogue
+ * (tc-7ttz). Port of iOS `OnboardingViewModelTests`'s postcode-step cases.
+ */
+@ExtendWith(MainDispatcherExtension::class)
+class OnboardingViewModelPostcodeTest {
+    private fun makeViewModel(
+        geocoder: FakePostcodeGeocoder = FakePostcodeGeocoder(),
+        tier: SubscriptionTier = SubscriptionTier.FREE,
+    ) = OnboardingViewModel(geocoder, FakeWatchZoneRepository(), FakeOnboardingRepository(), tier)
+
+    @Test
+    fun `a garbage postcode is rejected without ever calling the geocoder`() {
+        val geocoder = FakePostcodeGeocoder()
+        val viewModel = makeViewModel(geocoder)
+        viewModel.updatePostcode("NOTAPOSTCODE")
+
+        viewModel.lookUpPostcode()
+
+        assertTrue(geocoder.geocodeCalls.isEmpty())
+        assertIs<DomainError.GeocodingFailed>(viewModel.uiState.value.postcodeError)
+        assertNull(viewModel.uiState.value.geocodedCoordinate)
+    }
+
+    @Test
+    fun `a postcode missing its inward code is rejected without calling the geocoder`() {
+        val geocoder = FakePostcodeGeocoder()
+        val viewModel = makeViewModel(geocoder)
+        viewModel.updatePostcode("SW1A1")
+
+        viewModel.lookUpPostcode()
+
+        assertTrue(geocoder.geocodeCalls.isEmpty())
+        assertIs<DomainError.GeocodingFailed>(viewModel.uiState.value.postcodeError)
+    }
+
+    @Test
+    fun `a valid postcode without a space is geocoded`() {
+        val geocoder = FakePostcodeGeocoder(Result.success(aCoordinate()))
+        val viewModel = makeViewModel(geocoder)
+        viewModel.updatePostcode("SW1A1AA")
+
+        viewModel.lookUpPostcode()
+
+        assertEquals(listOf("SW1A1AA"), geocoder.geocodeCalls)
+        assertEquals(aCoordinate(), viewModel.uiState.value.geocodedCoordinate)
+        assertNull(viewModel.uiState.value.postcodeError)
+    }
+
+    @Test
+    fun `a valid postcode with a space is geocoded`() {
+        val geocoder = FakePostcodeGeocoder(Result.success(aCoordinate()))
+        val viewModel = makeViewModel(geocoder)
+        viewModel.updatePostcode("SW1A 1AA")
+
+        viewModel.lookUpPostcode()
+
+        assertEquals(listOf("SW1A 1AA"), geocoder.geocodeCalls)
+        assertEquals(aCoordinate(), viewModel.uiState.value.geocodedCoordinate)
+    }
+
+    @Test
+    fun `mixed case input is normalised to upper case before geocoding`() {
+        val geocoder = FakePostcodeGeocoder(Result.success(aCoordinate()))
+        val viewModel = makeViewModel(geocoder)
+        viewModel.updatePostcode("sw1a 1aa")
+
+        viewModel.lookUpPostcode()
+
+        assertEquals(listOf("SW1A 1AA"), geocoder.geocodeCalls)
+    }
+
+    @Test
+    fun `a remote geocode failure surfaces the DomainError inline and does not advance`() {
+        val geocoder = FakePostcodeGeocoder(Result.failure(DomainError.NotFound))
+        val viewModel = makeViewModel(geocoder)
+        viewModel.updatePostcode("ZZ99 9ZZ")
+
+        viewModel.lookUpPostcode()
+
+        val state = viewModel.uiState.value
+        assertEquals(DomainError.NotFound, state.postcodeError)
+        assertNull(state.geocodedCoordinate)
+        assertFalse(state.isLookingUpPostcode)
+    }
+
+    @Test
+    fun `a retry after a failure clears the previous error on success`() {
+        val geocoder = FakePostcodeGeocoder(Result.failure(DomainError.NotFound))
+        val viewModel = makeViewModel(geocoder)
+        viewModel.updatePostcode("ZZ99 9ZZ")
+        viewModel.lookUpPostcode()
+
+        geocoder.geocodeResult = Result.success(aCoordinate())
+        viewModel.lookUpPostcode()
+
+        assertNull(viewModel.uiState.value.postcodeError)
+        assertEquals(aCoordinate(), viewModel.uiState.value.geocodedCoordinate)
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModelRadiusTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModelRadiusTest.kt
@@ -1,0 +1,151 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.onboarding.FakeOnboardingRepository
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.domain.watchzones.FakePostcodeGeocoder
+import uk.towncrierapp.domain.watchzones.FakeWatchZoneRepository
+import uk.towncrierapp.domain.watchzones.aCoordinate
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * The radius step: tier-max clamping, the large-radius warning threshold,
+ * `confirmRadius` building the in-memory `WatchZone` (nothing saved yet),
+ * and [OnboardingViewModel.reconcileTierAfterUpgrade] raising the max on the
+ * SAME live instance without resetting anything already entered (tc-7ttz).
+ * Port of iOS `OnboardingViewModelTests`'s radius-step + paywall-return
+ * cases.
+ */
+@ExtendWith(MainDispatcherExtension::class)
+class OnboardingViewModelRadiusTest {
+    private fun aViewModelOnRadiusStep(tier: SubscriptionTier = SubscriptionTier.FREE): OnboardingViewModel {
+        val viewModel =
+            OnboardingViewModel(
+                FakePostcodeGeocoder(Result.success(aCoordinate())),
+                FakeWatchZoneRepository(),
+                FakeOnboardingRepository(),
+                tier,
+            )
+        viewModel.advance() // Welcome -> Postcode
+        viewModel.updatePostcode("SW1A 1AA")
+        viewModel.lookUpPostcode()
+        viewModel.advance() // Postcode -> Radius
+        return viewModel
+    }
+
+    @Test
+    fun `radius defaults to 1000m with a 100m floor`() {
+        val state = aViewModelOnRadiusStep().uiState.value
+
+        assertEquals(1_000f, state.radiusMetres)
+        assertEquals(100f, state.minRadiusMetres)
+    }
+
+    @Test
+    fun `maxRadiusMetres matches each tier's limit`() {
+        assertEquals(2_000f, aViewModelOnRadiusStep(SubscriptionTier.FREE).uiState.value.maxRadiusMetres)
+        assertEquals(5_000f, aViewModelOnRadiusStep(SubscriptionTier.PERSONAL).uiState.value.maxRadiusMetres)
+        assertEquals(10_000f, aViewModelOnRadiusStep(SubscriptionTier.PRO).uiState.value.maxRadiusMetres)
+    }
+
+    @Test
+    fun `updateRadius shows the large radius warning at or above the threshold`() {
+        val viewModel = aViewModelOnRadiusStep(SubscriptionTier.PRO)
+
+        viewModel.updateRadius(2_100f)
+        assertTrue(viewModel.uiState.value.showsLargeRadiusWarning)
+
+        viewModel.updateRadius(2_099f)
+        assertFalse(viewModel.uiState.value.showsLargeRadiusWarning)
+    }
+
+    @Test
+    fun `confirmRadius builds the zone in memory without saving it`() {
+        val repository = FakeWatchZoneRepository()
+        val viewModel =
+            OnboardingViewModel(
+                FakePostcodeGeocoder(Result.success(aCoordinate())),
+                repository,
+                FakeOnboardingRepository(),
+                SubscriptionTier.FREE,
+            )
+        viewModel.advance()
+        viewModel.updatePostcode("SW1A 1AA")
+        viewModel.lookUpPostcode()
+        viewModel.advance()
+
+        viewModel.confirmRadius()
+
+        val zone = viewModel.uiState.value.pendingZone
+        assertEquals(aCoordinate(), zone?.centre)
+        assertTrue(repository.createCalls.isEmpty())
+    }
+
+    @Test
+    fun `confirmRadius advances to the notification-permission step`() {
+        val viewModel = aViewModelOnRadiusStep()
+
+        viewModel.confirmRadius()
+
+        assertEquals(OnboardingStep.NotificationPermission, viewModel.uiState.value.step)
+    }
+
+    @Test
+    fun `confirmRadius clamps a radius above the tier max`() {
+        val viewModel = aViewModelOnRadiusStep(SubscriptionTier.FREE)
+        viewModel.updateRadius(9_000f)
+
+        viewModel.confirmRadius()
+
+        assertEquals(2_000.0, viewModel.uiState.value.pendingZone?.radiusMetres)
+    }
+
+    @Test
+    fun `reconcileTierAfterUpgrade raises the max without resetting postcode, coordinate, or radius`() {
+        val viewModel = aViewModelOnRadiusStep(SubscriptionTier.FREE)
+        viewModel.updateRadius(1_800f)
+        val beforeCoordinate = viewModel.uiState.value.geocodedCoordinate
+        val beforePostcode = viewModel.uiState.value.postcodeInput
+
+        viewModel.reconcileTierAfterUpgrade(SubscriptionTier.PRO)
+
+        val state = viewModel.uiState.value
+        assertEquals(10_000f, state.maxRadiusMetres)
+        assertEquals(1_800f, state.radiusMetres)
+        assertEquals(beforeCoordinate, state.geocodedCoordinate)
+        assertEquals(beforePostcode, state.postcodeInput)
+    }
+
+    @Test
+    fun `canUnlockLargerRadius is always false while paywallAvailable is false, regardless of tier`() {
+        // #783 hasn't shipped - the chip must be hidden entirely, not merely
+        // routed to a dead tap target, so this must be false even below Pro.
+        assertFalse(aViewModelOnRadiusStep(SubscriptionTier.FREE).uiState.value.canUnlockLargerRadius)
+        assertFalse(aViewModelOnRadiusStep(SubscriptionTier.PERSONAL).uiState.value.canUnlockLargerRadius)
+    }
+
+    @Test
+    fun `when paywallAvailable is true, reconcileTierAfterUpgrade to Pro hides the unlock-larger-zones chip`() {
+        val viewModel =
+            OnboardingViewModel(
+                FakePostcodeGeocoder(Result.success(aCoordinate())),
+                FakeWatchZoneRepository(),
+                FakeOnboardingRepository(),
+                SubscriptionTier.FREE,
+                paywallAvailable = true,
+            )
+        viewModel.advance()
+        viewModel.updatePostcode("SW1A 1AA")
+        viewModel.lookUpPostcode()
+        viewModel.advance()
+        assertTrue(viewModel.uiState.value.canUnlockLargerRadius)
+
+        viewModel.reconcileTierAfterUpgrade(SubscriptionTier.PRO)
+
+        assertFalse(viewModel.uiState.value.canUnlockLargerRadius)
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModelRadiusTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModelRadiusTest.kt
@@ -101,7 +101,11 @@ class OnboardingViewModelRadiusTest {
 
         viewModel.confirmRadius()
 
-        assertEquals(2_000.0, viewModel.uiState.value.pendingZone?.radiusMetres)
+        assertEquals(
+            2_000.0,
+            viewModel.uiState.value.pendingZone
+                ?.radiusMetres,
+        )
     }
 
     @Test

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModelStepTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/onboarding/OnboardingViewModelStepTest.kt
@@ -1,0 +1,120 @@
+package uk.towncrierapp.presentation.features.onboarding
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.onboarding.FakeOnboardingRepository
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.domain.watchzones.FakePostcodeGeocoder
+import uk.towncrierapp.domain.watchzones.FakeWatchZoneRepository
+import uk.towncrierapp.domain.watchzones.aCoordinate
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import kotlin.test.assertEquals
+
+/**
+ * Linear step order, with no back navigation from [OnboardingStep.Welcome]
+ * (tc-7ttz). Port of iOS `OnboardingViewModelTests`'s step-navigation cases.
+ */
+@ExtendWith(MainDispatcherExtension::class)
+class OnboardingViewModelStepTest {
+    private fun makeViewModel(tier: SubscriptionTier = SubscriptionTier.FREE) =
+        OnboardingViewModel(FakePostcodeGeocoder(), FakeWatchZoneRepository(), FakeOnboardingRepository(), tier)
+
+    @Test
+    fun `a fresh wizard starts on the Welcome step`() {
+        assertEquals(OnboardingStep.Welcome, makeViewModel().uiState.value.step)
+    }
+
+    @Test
+    fun `advance moves Welcome to Postcode unconditionally`() {
+        val viewModel = makeViewModel()
+
+        viewModel.advance()
+
+        assertEquals(OnboardingStep.Postcode, viewModel.uiState.value.step)
+    }
+
+    @Test
+    fun `back is a no-op on the Welcome step`() {
+        val viewModel = makeViewModel()
+
+        viewModel.back()
+
+        assertEquals(OnboardingStep.Welcome, viewModel.uiState.value.step)
+    }
+
+    @Test
+    fun `advance from Postcode is blocked until a postcode has been resolved`() {
+        val viewModel = makeViewModel()
+        viewModel.advance() // Welcome -> Postcode
+
+        viewModel.advance()
+
+        assertEquals(OnboardingStep.Postcode, viewModel.uiState.value.step)
+    }
+
+    @Test
+    fun `advance moves Postcode to Radius once geocoding has succeeded`() {
+        val viewModel =
+            OnboardingViewModel(
+                FakePostcodeGeocoder(Result.success(aCoordinate())),
+                FakeWatchZoneRepository(),
+                FakeOnboardingRepository(),
+                SubscriptionTier.FREE,
+            )
+        viewModel.advance() // Welcome -> Postcode
+        viewModel.updatePostcode("SW1A 1AA")
+        viewModel.lookUpPostcode()
+
+        viewModel.advance()
+
+        assertEquals(OnboardingStep.Radius, viewModel.uiState.value.step)
+    }
+
+    @Test
+    fun `advance does nothing from Radius - confirmRadius is the only way past it`() {
+        val viewModel = aViewModelOnRadiusStep()
+
+        viewModel.advance()
+
+        assertEquals(OnboardingStep.Radius, viewModel.uiState.value.step)
+    }
+
+    @Test
+    fun `back steps backward through Postcode and Radius`() {
+        val viewModel = aViewModelOnRadiusStep()
+
+        viewModel.back()
+        assertEquals(OnboardingStep.Postcode, viewModel.uiState.value.step)
+
+        viewModel.back()
+        assertEquals(OnboardingStep.Welcome, viewModel.uiState.value.step)
+
+        viewModel.back()
+        assertEquals(OnboardingStep.Welcome, viewModel.uiState.value.step)
+    }
+
+    @Test
+    fun `back from NotificationPermission returns to Radius`() {
+        val viewModel = aViewModelOnRadiusStep()
+        viewModel.confirmRadius()
+
+        viewModel.back()
+
+        assertEquals(OnboardingStep.Radius, viewModel.uiState.value.step)
+    }
+
+    private fun aViewModelOnRadiusStep(): OnboardingViewModel {
+        val viewModel =
+            OnboardingViewModel(
+                FakePostcodeGeocoder(Result.success(aCoordinate())),
+                FakeWatchZoneRepository(),
+                FakeOnboardingRepository(),
+                SubscriptionTier.FREE,
+            )
+        viewModel.advance() // Welcome -> Postcode
+        viewModel.updatePostcode("SW1A 1AA")
+        viewModel.lookUpPostcode()
+        viewModel.advance() // Postcode -> Radius
+        return viewModel
+    }
+}


### PR DESCRIPTION
## Summary

Phase 4a of the Android parity epic (#770), closes #773. Builds on #772/#774/#775 (merged).

## Changes

- **`:domain`**: `Postcode` value class (validates UK postcode format), `OnboardingRepository` interface, `DomainError.GeocodingFailed` case.
- **`:data`**: `DataStoreOnboardingRepository` (device-latch fast-path).
- **`:presentation`**: `OnboardingViewModel` (linear 4-step state machine: Welcome → Postcode → Radius → NotificationPermission), step composables, account-state gate in `AuthCoordinator` (0 zones → Required, ≥1 → NotRequired, gate never evaluated before ensure-profile/tier-resolution — the exact ordering bug tc-k9fk/#549 fixed on iOS, now regression-tested here). Free-tier step 4 shows honest digest-only copy and never requests the notification permission; paid tiers request it and ignore the result either way. Upsell chip hidden behind `PaywallAvailable=false` until #783.
- Reuses `ApiPostcodeGeocoder` and `WatchZoneLimits`/`EntitlementMap` from #774 rather than duplicating them.

## Verification

- `./gradlew test ktlintCheck detekt :app:assembleDevDebug :app:assembleProdRelease :app:assembleLocalDebug` green.
- Live emulator walkthrough against the local Postgres+API stack: signed up a fresh zero-zone test account (rather than reusing the existing test account, which already has a zone from #774's verification and would correctly skip the wizard), walked all 4 steps with a live postcode geocode, landed on the Zones tab with the created zone. Confirmed server-side via psql (`tier=Free, watch_zone_count=1`).

## Follow-ups filed

- `tc-mpcx` — the android-coding-standards skill documents a stricter type-resolving detekt gate than CI/local workflows actually run; several pre-existing (not regressions from this PR) false positives and threshold violations have been silently accumulating since #774/#775. Doesn't affect what CI enforces today, but the skill doc and reality have drifted.

---
*Bead tc-7ttz*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided onboarding flow with welcome, postcode, radius, and notification steps.
  * Introduced notification permission handling for Android 13+ and tier-based prompts.
  * Added support for saving onboarding progress locally and restoring it later.
  * Added postcode validation and clearer geocoding-related error handling.
  * Added support for larger-radius watch zones and upgrade-aware limits.
  * Android now requests notification permission at runtime with the proper app permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->