### PR TITLE
feat(api): add PostgresStore.RecentInAuthorities for dev-seed job (tc-grvu.3)

### DIFF
--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -201,6 +201,31 @@ func (s *PostgresStore) RecentByAuthority(ctx context.Context, authorityCode str
 	return apps, nil
 }
 
+const pgRecentInAuthoritiesQuery = "SELECT " + appColumns +
+	" FROM applications WHERE area_id = ANY($1) ORDER BY last_different DESC LIMIT $2"
+
+// RecentInAuthorities returns up to limit most-recently-active applications
+// across all of authorityIDs (matched against the numeric area_id, not the
+// stringified authority_code), ordered by last_different DESC. It backs the
+// dev-seed job's prod read (epic #808): a small, cross-authority "most recently
+// changed" window, not a per-authority scoped read like RecentByAuthority.
+//
+// A nil or empty authorityIDs is a normal no-op (e.g. dev has no watch zones
+// yet) and returns an empty slice with no error — pgx correctly binds an empty
+// []int to ANY($1) as an empty array, matching zero rows, rather than erroring
+// or panicking.
+func (s *PostgresStore) RecentInAuthorities(ctx context.Context, authorityIDs []int, limit int) ([]PlanningApplication, error) {
+	rows, err := s.db.Query(ctx, pgRecentInAuthoritiesQuery, authorityIDs, limit)
+	if err != nil {
+		return nil, fmt.Errorf("recent applications in authorities %v: %w", authorityIDs, err)
+	}
+	apps, err := pgx.CollectRows(rows, scanAppRow)
+	if err != nil {
+		return nil, fmt.Errorf("recent applications in authorities %v: %w", authorityIDs, err)
+	}
+	return apps, nil
+}
+
 const pgBreakdownByAuthorityQuery = "SELECT app_state, count(*) FROM applications " +
 	"WHERE authority_code = $1 GROUP BY app_state"
 

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -326,6 +326,57 @@ func TestPostgresStore_RecentByAuthority(t *testing.T) {
 	assertNames(t, appNames(capped), []string{"NEW", "MID"})
 }
 
+// TestPostgresStore_RecentInAuthorities orders by last_different DESC across
+// multiple authorities, bounds by limit, excludes authorities not requested, and
+// returns an empty result (not an error or a panic) for an empty or nil authority
+// list — the dev-seed job's normal "no watch zones yet" state (epic #808).
+func TestPostgresStore_RecentInAuthorities(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	older := pgApp("OLD", 100)
+	older.LastDifferent = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	mid := pgApp("MID", 200)
+	mid.LastDifferent = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	newer := pgApp("NEW", 100)
+	newer.LastDifferent = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	excluded := pgApp("EXCLUDED-AUTH", 300) // authority not requested; must not appear
+	for _, a := range []PlanningApplication{older, mid, newer, excluded} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	got, err := store.RecentInAuthorities(ctx, []int{100, 200}, 10)
+	if err != nil {
+		t.Fatalf("RecentInAuthorities: %v", err)
+	}
+	assertNames(t, appNames(got), []string{"NEW", "MID", "OLD"})
+
+	capped, err := store.RecentInAuthorities(ctx, []int{100, 200}, 2)
+	if err != nil {
+		t.Fatalf("RecentInAuthorities capped: %v", err)
+	}
+	assertNames(t, appNames(capped), []string{"NEW", "MID"})
+
+	empty, err := store.RecentInAuthorities(ctx, []int{}, 10)
+	if err != nil {
+		t.Fatalf("RecentInAuthorities empty authorityIDs: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("RecentInAuthorities empty authorityIDs: got %d rows, want 0", len(empty))
+	}
+
+	var nilIDs []int
+	nilResult, err := store.RecentInAuthorities(ctx, nilIDs, 10)
+	if err != nil {
+		t.Fatalf("RecentInAuthorities nil authorityIDs: %v", err)
+	}
+	if len(nilResult) != 0 {
+		t.Errorf("RecentInAuthorities nil authorityIDs: got %d rows, want 0", len(nilResult))
+	}
+}
+
 // TestPostgresStore_BreakdownByAuthority returns exact per-app_state counts
 // including the NULL-app_state bucket, sorted by sortStateCounts, scoped to the
 // authority and summing to the true total.


### PR DESCRIPTION
## Changes
- Add `applications.PostgresStore.RecentInAuthorities(ctx, authorityIDs []int, limit int)` — selects the most-recently-changed applications (`ORDER BY last_different DESC`) within a set of authority IDs, honoring `LIMIT`. Reuses existing `appColumns`/scan helpers; works over any `querier`, including a second read-only pool bound to a different database.
- Real-DB integration test coverage (`pgtest` harness) for multiple authority IDs, sort order, limit, and empty/nil authority ID slices.

Part of epic tc-grvu (GH #808) — hourly dev-only job that mirrors fresh prod planning applications into dev for real push-notification QA. This slice is read-only and additive; no wiring to a prod pool happens in this PR (that lands in a later bead, tc-grvu.4).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to fetch the most recently active planning applications across multiple authorities.
  * Results are returned in recency order and support a configurable limit.

* **Bug Fixes**
  * Improved handling for empty or missing authority lists by returning an empty result instead of an error.

* **Tests**
  * Added coverage for ordering, filtering, limit behavior, and empty-input cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->