### PR TITLE
feat(infra): dev-seed reader identity + pgbootstrap readonly grants (tc-grvu.1)

### DIFF
--- a/api-go/cmd/pgbootstrap/grants_readonly.sql
+++ b/api-go/cmd/pgbootstrap/grants_readonly.sql
@@ -1,0 +1,19 @@
+-- Phase 2 (read-only variant): idempotent SELECT-only grant for a
+-- least-privilege reader role. Run this against the APP database (e.g.
+-- town_crier_prod) AFTER principal.sql has been executed against the admin
+-- database. Every GRANT is idempotent.
+--
+-- Selected with `-readonly` in place of grants.sql when the mapped managed
+-- identity must only ever read, never write — e.g. a dev-only job reading
+-- prod data (see docs/adr/0038-dev-seed-least-privilege-prod-read.md).
+--
+-- DELIBERATELY ABSENT: INSERT, UPDATE, DELETE, sequence grants, and
+-- ALTER DEFAULT PRIVILEGES, on top of the same withheld privileges as
+-- grants.sql (SUPERUSER, CREATEDB, CREATEROLE, role/database OWNERSHIP,
+-- DROP, CREATE EXTENSION, and any DDL). This role can read the applications
+-- table and nothing else; it never gains rights to newly created tables.
+--
+-- Identifiers are templated in by cmd/pgbootstrap after validation.
+
+GRANT USAGE ON SCHEMA public TO {{.Role}};
+GRANT SELECT ON applications TO {{.Role}};

--- a/api-go/cmd/pgbootstrap/main.go
+++ b/api-go/cmd/pgbootstrap/main.go
@@ -18,11 +18,17 @@
 // Both phases are idempotent: the principal create is guarded by a pg_roles
 // existence check, and every GRANT is idempotent by design.
 //
+// -readonly selects grants_readonly.sql instead of grants.sql for Phase 2:
+// SELECT on applications only, no INSERT/UPDATE/DELETE, no sequence grants,
+// no ALTER DEFAULT PRIVILEGES. Use it to map a managed identity to a
+// least-privilege reader role, e.g. a dev-only job reading prod
+// (docs/adr/0038-dev-seed-least-privilege-prod-read.md).
+//
 // Usage:
 //
 //	pgbootstrap -host <fqdn> -admin-user <aad-admin-upn> \
 //	    [-admin-db postgres] [-db town_crier_dev] \
-//	    -mi-oid <managed-identity-object-id> [-role towncrier_api]
+//	    -mi-oid <managed-identity-object-id> [-role towncrier_api] [-readonly]
 //	pgbootstrap -host <fqdn> -admin-user <aad-admin-upn> -db town_crier_dev -verify
 //
 // -verify connects to the app DB (as the admin) and prints SELECT current_user so
@@ -57,6 +63,13 @@ var principalSQLTemplate string
 //
 //go:embed grants.sql
 var grantsSQLTemplate string
+
+// grantsReadonlySQLTemplate is the read-only variant of the Phase 2 SQL (app
+// DB): SELECT-only on applications, for a least-privilege reader role.
+// Selected in place of grantsSQLTemplate when -readonly is set.
+//
+//go:embed grants_readonly.sql
+var grantsReadonlySQLTemplate string
 
 // identifierPattern matches a safe, unquoted SQL identifier (role / database
 // name). OID values must be a UUID. Both are validated before being templated
@@ -96,8 +109,13 @@ func buildPrincipalSQL(p bootstrapParams) (string, error) {
 
 // buildGrantsSQL validates identifiers and renders the Phase 2 template.
 // Phase 2 must run against the app database (default: town_crier_dev).
-// Returning the SQL keeps rendering fully unit-testable without a live database.
-func buildGrantsSQL(p bootstrapParams) (string, error) {
+// When readonly is true, the SELECT-only grants_readonly.sql template is
+// rendered instead of the full-DML grants.sql. Returning the SQL keeps
+// rendering fully unit-testable without a live database.
+func buildGrantsSQL(p bootstrapParams, readonly bool) (string, error) {
+	if readonly {
+		return renderTemplate("grants_readonly", grantsReadonlySQLTemplate, p)
+	}
 	return renderTemplate("grants", grantsSQLTemplate, p)
 }
 
@@ -135,6 +153,7 @@ func run(args []string) int {
 		sslMode   = fs.String("sslmode", envOr("POSTGRES_SSLMODE", "require"), "sslmode")
 		timeout   = fs.Duration("timeout", 30*time.Second, "overall timeout")
 		verify    = fs.Bool("verify", false, "connect to the app DB and print SELECT current_user, then exit (no bootstrap)")
+		readonly  = fs.Bool("readonly", false, "grant SELECT-only access (grants_readonly.sql) instead of full DML (grants.sql) in Phase 2")
 	)
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -200,9 +219,10 @@ func run(args []string) int {
 	}
 	fmt.Printf("pgbootstrap: phase 1 complete — role %q mapped to OID %s\n", *role, *miOID)
 
-	// Phase 2: grant DML on the app database. Roles are cluster-global, so the
-	// role created in Phase 1 is visible here immediately.
-	grantsSQL, err := buildGrantsSQL(params)
+	// Phase 2: grant on the app database (full DML, or SELECT-only when
+	// -readonly is set). Roles are cluster-global, so the role created in
+	// Phase 1 is visible here immediately.
+	grantsSQL, err := buildGrantsSQL(params, *readonly)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "pgbootstrap: %v\n", err)
 		return 2
@@ -211,7 +231,11 @@ func run(args []string) int {
 		fmt.Fprintf(os.Stderr, "pgbootstrap: phase 2 (grants): %v\n", err)
 		return 1
 	}
-	fmt.Printf("pgbootstrap: phase 2 complete — DML grants applied on %q\n", *db)
+	if *readonly {
+		fmt.Printf("pgbootstrap: phase 2 complete — read-only (SELECT) grants applied on %q\n", *db)
+	} else {
+		fmt.Printf("pgbootstrap: phase 2 complete — DML grants applied on %q\n", *db)
+	}
 
 	return verifyConnection(ctx, appPool)
 }

--- a/api-go/cmd/pgbootstrap/main_test.go
+++ b/api-go/cmd/pgbootstrap/main_test.go
@@ -80,7 +80,7 @@ func TestBuildPrincipalSQL_GrantsNoElevatedPrivilege(t *testing.T) {
 
 func TestBuildGrantsSQL_ContainsDMLGrants(t *testing.T) {
 	t.Parallel()
-	sql, err := buildGrantsSQL(validParams())
+	sql, err := buildGrantsSQL(validParams(), false)
 	if err != nil {
 		t.Fatalf("buildGrantsSQL() error = %v", err)
 	}
@@ -101,7 +101,7 @@ func TestBuildGrantsSQL_ContainsDMLGrants(t *testing.T) {
 
 func TestBuildGrantsSQL_DoesNotContainPrincipalCreate(t *testing.T) {
 	t.Parallel()
-	sql, err := buildGrantsSQL(validParams())
+	sql, err := buildGrantsSQL(validParams(), false)
 	if err != nil {
 		t.Fatalf("buildGrantsSQL() error = %v", err)
 	}
@@ -113,7 +113,7 @@ func TestBuildGrantsSQL_DoesNotContainPrincipalCreate(t *testing.T) {
 
 func TestBuildGrantsSQL_GrantsNoElevatedPrivilege(t *testing.T) {
 	t.Parallel()
-	sql, err := buildGrantsSQL(validParams())
+	sql, err := buildGrantsSQL(validParams(), false)
 	if err != nil {
 		t.Fatalf("buildGrantsSQL() error = %v", err)
 	}
@@ -125,6 +125,45 @@ func TestBuildGrantsSQL_GrantsNoElevatedPrivilege(t *testing.T) {
 		if strings.Contains(upper, bad) {
 			t.Errorf("Phase 2 SQL must not contain %q (least-privilege only)\n---\n%s", bad, sql)
 		}
+	}
+}
+
+func TestBuildGrantsSQL_ReadonlyTrue_SelectsReadonlyTemplate(t *testing.T) {
+	t.Parallel()
+	sql, err := buildGrantsSQL(validParams(), true)
+	if err != nil {
+		t.Fatalf("buildGrantsSQL() error = %v", err)
+	}
+
+	wantSubstrings := []string{
+		"GRANT USAGE ON SCHEMA public TO towncrier_api",
+		"GRANT SELECT ON applications TO towncrier_api",
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(sql, want) {
+			t.Errorf("readonly Phase 2 SQL missing %q\n---\n%s", want, sql)
+		}
+	}
+
+	// Scan executable SQL only: -- comment lines document withheld privileges and
+	// must not trip the guard.
+	upper := strings.ToUpper(stripSQLComments(sql))
+	absent := []string{"INSERT", "UPDATE", "DELETE", "ALTER DEFAULT PRIVILEGES", "SEQUENCE"}
+	for _, bad := range absent {
+		if strings.Contains(upper, bad) {
+			t.Errorf("readonly Phase 2 SQL must not contain %q (read-only role)\n---\n%s", bad, sql)
+		}
+	}
+}
+
+func TestBuildGrantsSQL_ReadonlyFalse_SelectsDefaultDMLTemplate(t *testing.T) {
+	t.Parallel()
+	sql, err := buildGrantsSQL(validParams(), false)
+	if err != nil {
+		t.Fatalf("buildGrantsSQL() error = %v", err)
+	}
+	if !strings.Contains(sql, "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO towncrier_api") {
+		t.Errorf("non-readonly Phase 2 SQL should retain full DML grants\n---\n%s", sql)
 	}
 }
 

--- a/docs/adr/0038-dev-seed-least-privilege-prod-read.md
+++ b/docs/adr/0038-dev-seed-least-privilege-prod-read.md
@@ -1,0 +1,89 @@
+# 0038. Dedicated least-privilege identity + Postgres role for the dev-seed job's prod read
+
+Date: 2026-07-04
+
+## Status
+
+Accepted
+
+## Context
+
+The dev-seed job (epic tc-grvu, GH #808) is a new hourly, dev-only Container
+Apps Job that reads a small number of recently-changed applications from
+`town_crier_prod` (read-only) and mirrors them into `town_crier_dev`, so that
+a TestFlight build pointed at dev can exercise the real push-notification
+pipeline. This is the first process that needs to read `town_crier_prod` from
+outside the prod environment.
+
+Researching how to grant it access surfaced a pre-existing gap: every
+Container App and Job in **both** dev and prod today shares one Azure
+user-assigned managed identity, `id-town-crier-cosmos-data`
+(`infra/shared.go`), which is mapped to one cluster-global Postgres role,
+`towncrier_api` (`api-go/cmd/pgbootstrap/grants.sql`). Postgres roles are
+cluster-global and `grants.sql` is applied per-database, so `towncrier_api`
+already holds full `SELECT/INSERT/UPDATE/DELETE` on **both** `town_crier_dev`
+and `town_crier_prod` — there is no Postgres-level boundary between the two
+databases today; isolation is by convention (which `POSTGRES_DB` a given
+service happens to point at), not by grant.
+
+The simplest way to ship the dev-seed job would have been to reuse
+`cosmosDataIdentity`/`towncrier_api` and simply point a second pool at
+`town_crier_prod` with `POSTGRES_DB` overridden. This was flagged to the user
+directly before implementation; the user chose to fix it properly for this
+new job rather than lean on the existing broad grant.
+
+## Decision
+
+The dev-seed job gets its own, dedicated Azure user-assigned managed identity,
+`id-town-crier-dev-seed-reader` (`infra/shared.go`), mapped via
+`pgbootstrap -readonly` to a new, dedicated Postgres role,
+`towncrier_dev_seed_reader`, holding only:
+
+```sql
+GRANT USAGE ON SCHEMA public TO towncrier_dev_seed_reader;
+GRANT SELECT ON applications TO towncrier_dev_seed_reader;
+```
+
+(`api-go/cmd/pgbootstrap/grants_readonly.sql`), deliberately omitting
+`INSERT`/`UPDATE`/`DELETE`, sequence grants, and
+`ALTER DEFAULT PRIVILEGES` — this role can read one table and nothing else,
+and gains no rights on tables created by future migrations.
+
+`cmd/pgbootstrap` gains a `-readonly` flag selecting `grants_readonly.sql` in
+place of `grants.sql` for Phase 2; Phase 1 (`principal.sql`, the Entra
+principal-create step) is unchanged and reused as-is, since it is already
+generic. This identity is attached only to the dev-seed Container Apps Job
+(`infra/environment.go`, tc-grvu.6) — no other Container App or Job gains it.
+
+Rationale: a bug in the new job's SQL (or in any future job built the same
+way) must not be able to write to prod. A dedicated identity mapped to a
+`SELECT`-only role makes that structurally impossible rather than relying on
+the job's own code discipline.
+
+**Explicitly not addressed here:** the pre-existing condition that
+`cosmosDataIdentity`/`towncrier_api` already has full DML on both databases.
+Fixing that would touch every existing prod and dev service's credentials —
+a much larger, higher-risk change than this QA-tooling feature warrants, and
+must not happen as an incidental side effect of it. It is tracked separately
+as tc-hif3.
+
+The one-time `pgbootstrap -readonly` run against `town_crier_prod` that
+actually creates `towncrier_dev_seed_reader` is a manual, Entra-admin-run CLI
+step performed after this infra change merges and deploys — consistent with
+`pgbootstrap`'s existing posture of never running as part of CD.
+
+## Consequences
+
+- The dev-seed job's blast radius on `town_crier_prod` is bounded at the
+  Postgres grant level, not just by application code: even a bug that
+  constructs the wrong SQL against the prod pool cannot mutate data.
+- A second managed identity and Postgres role to provision and keep track of,
+  and a second one-time manual `pgbootstrap` run per environment stack that
+  needs it (documented in the dev-seed job's PR).
+- `cmd/pgbootstrap` now supports two Phase-2 grant shapes (full DML,
+  read-only); any future job needing a similarly scoped read can reuse
+  `-readonly` rather than growing a third bespoke bootstrap path.
+- The broader, pre-existing lack of a Postgres-level dev/prod boundary for
+  every other service (`towncrier_api` on both databases) remains
+  unaddressed and is tracked separately as tc-hif3; this ADR narrows the gap
+  for one new consumer without closing it project-wide.

--- a/infra/shared.go
+++ b/infra/shared.go
@@ -249,6 +249,24 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		return err
 	}
 
+	// User-assigned managed identity for the dev-only dev-seed job's read-only
+	// access to town_crier_prod. Deliberately separate from cosmosDataIdentity
+	// (which every other Container App/Job in both dev and prod shares, and
+	// which already holds full DML on both databases): a bug in this job's SQL
+	// must not be able to write to prod. Mapped to a SELECT-only Postgres role
+	// via `pgbootstrap -readonly` — see
+	// docs/adr/0038-dev-seed-least-privilege-prod-read.md. Consumed by the
+	// dev-seed Container Apps Job created in infra/environment.go (tc-grvu.6);
+	// not wired into any resource in this file.
+	devSeedReaderIdentity, err := managedidentity.NewUserAssignedIdentity(ctx, "id-town-crier-dev-seed-reader", &managedidentity.UserAssignedIdentityArgs{
+		ResourceName:      pulumi.String("id-town-crier-dev-seed-reader"),
+		ResourceGroupName: resourceGroup.Name,
+		Tags:              tags,
+	})
+	if err != nil {
+		return err
+	}
+
 	// Azure Database for PostgreSQL — Flexible Server (shared across environments; this single
 	// server hosts both the dev and prod databases long-term). First infra step of the Cosmos →
 	// Postgres + PostGIS migration (memo 0010, epic tc-hpd2 / GH #645). Pre-revenue profile:
@@ -530,6 +548,12 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 	// PrincipalId is required by env-stack role assignments (Service Bus Data Owner on the
 	// polling namespace) because RBAC grants are keyed to the principal (object) ID.
 	ctx.Export("cosmosDataIdentityPrincipalId", cosmosDataIdentity.PrincipalId)
+	ctx.Export("devSeedReaderIdentityId", devSeedReaderIdentity.ID())
+	ctx.Export("devSeedReaderIdentityClientId", devSeedReaderIdentity.ClientId)
+	// PrincipalId is the OID pgbootstrap maps to the SELECT-only Postgres role
+	// (pgaadauth_create_principal_with_oid) — see
+	// docs/adr/0038-dev-seed-least-privilege-prod-read.md.
+	ctx.Export("devSeedReaderIdentityPrincipalId", devSeedReaderIdentity.PrincipalId)
 	ctx.Export("containerAppsEnvironmentId", containerAppsEnv.ID())
 	// Postgres Flexible Server (Cosmos → Postgres migration, epic tc-hpd2). The admin password
 	// is a Pulumi secret (RandomPassword.Result); env stacks read these to build per-env


### PR DESCRIPTION
## Changes
- `infra/shared.go` — new `id-town-crier-dev-seed-reader` managed identity, exported (mirrors `cosmosDataIdentity`). Not yet attached to any Container App/Job — that wiring is tc-grvu.6.
- `api-go/cmd/pgbootstrap` — new `-readonly` flag + `grants_readonly.sql` (Phase 2 template: `GRANT USAGE ON SCHEMA public` + `GRANT SELECT ON applications` only, no DML/sequences/`ALTER DEFAULT PRIVILEGES`). Phase 1 (`principal.sql`) unchanged.
- `docs/adr/0038-dev-seed-least-privilege-prod-read.md` — documents why a dedicated identity/role instead of reusing the existing shared `cosmosDataIdentity`/`towncrier_api` (which already has full DML on both databases — a pre-existing gap explicitly out of scope here, tracked separately as tc-hif3).

Part of epic tc-grvu (GH #808) — hourly dev-only job that mirrors fresh prod planning applications into dev for real push-notification QA.

## Required manual step after merge + deploy

This identity and role are **not usable** until, after this PR merges and `infra` deploys to dev, an Entra-admin-authenticated operator runs (one-time, by hand, not via CD — matching `pgbootstrap`'s existing posture):

```
pgbootstrap -mi-oid <devSeedReaderIdentityPrincipalId from the Pulumi shared stack output> -role towncrier_dev_seed_reader -db town_crier_prod -readonly
```

(plus Phase 1 against the admin DB first, per the tool's existing two-phase usage). This directly touches `town_crier_prod` and requires explicit human sign-off — it is intentionally not automated.

---
*Auto-shipped via ship skill*