### PR TITLE
refactor(api): extract polling.Ingester from PollPlanItHandler (tc-grvu.2)

### DIFF
--- a/api-go/internal/polling/handler.go
+++ b/api-go/internal/polling/handler.go
@@ -15,8 +15,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
@@ -129,7 +127,6 @@ type PollPlanItResult struct {
 // not wired into the worker poll path — see bd follow-up).
 type PollPlanItHandler struct {
 	planIt      planItFetcher
-	apps        applicationStore
 	state       pollStateAccess
 	authorities activeAuthorityProvider
 	cycle       cycleSelector
@@ -137,13 +134,12 @@ type PollPlanItHandler struct {
 	now         func() time.Time
 	logger      *slog.Logger
 
-	// decision and enqueuer are the optional poll-path notification fan-out
-	// collaborators wired via WithFanOut. When nil, the handler ingests only (the
-	// behaviour before bead tc-uc2p); when set, each upserted application drives a
-	// decision-event dispatch (on a non-decision -> decision transition) and a
-	// watch-zone notification fan-out.
-	decision DecisionDispatcher
-	enqueuer NotificationEnqueuer
+	// ingester upserts one application and runs the poll-path notification
+	// fan-out (decision dispatch + watch-zone enqueue), wired at construction
+	// with the applicationStore and, when nil, in ingestion-only mode (the
+	// behaviour before bead tc-uc2p) until WithFanOut sets its decision/enqueuer
+	// collaborators.
+	ingester *Ingester
 
 	// flusher drives the poll-cycle push coalescer, wired via WithPushFlusher.
 	// nil in ingestion-only mode and in the many tests that don't wire one — the
@@ -181,8 +177,11 @@ func (h *PollPlanItHandler) recorder() metricsRecorder {
 // ingestion-only call sites and tests are unaffected; cmd/worker calls it once
 // after building the handler. Returns the handler for chaining.
 func (h *PollPlanItHandler) WithFanOut(decision DecisionDispatcher, enqueuer NotificationEnqueuer) *PollPlanItHandler {
-	h.decision = decision
-	h.enqueuer = enqueuer
+	if h.ingester == nil {
+		h.ingester = &Ingester{}
+	}
+	h.ingester.decision = decision
+	h.ingester.enqueuer = enqueuer
 	return h
 }
 
@@ -209,13 +208,13 @@ func NewPollPlanItHandler(
 ) *PollPlanItHandler {
 	return &PollPlanItHandler{
 		planIt:      planIt,
-		apps:        apps,
 		state:       state,
 		authorities: authorities,
 		cycle:       cycle,
 		opts:        opts,
 		now:         now,
 		logger:      logger,
+		ingester:    NewIngester(apps, nil, nil),
 	}
 }
 
@@ -413,7 +412,7 @@ func (h *PollPlanItHandler) pollAuthority(ctx context.Context, authorityID int, 
 			if app.LastDifferent.After(highWaterMark) {
 				highWaterMark = app.LastDifferent
 			}
-			if err := h.processApplication(ctx, app); err != nil {
+			if err := h.ingester.Ingest(ctx, app); err != nil {
 				out.err = err
 				return h.finishAuthority(ctx, authorityID, now, out, highWaterMark, existingHWM, lastPageFetched, firstPageTotal, capHit, hadCursor, cycleType)
 			}
@@ -441,71 +440,6 @@ func (h *PollPlanItHandler) pollAuthority(ctx context.Context, authorityID int, 
 		out.completed = true
 	}
 	return h.finishAuthority(ctx, authorityID, now, out, highWaterMark, existingHWM, lastPageFetched, firstPageTotal, capHit, hadCursor, cycleType)
-}
-
-// processApplication point-reads the persisted application by uid within its
-// authority partition, and — when a business field changed (the reindex-flood
-// guard; a first-time insert always counts as changed) — upserts it, then runs
-// the poll-path notification fan-out: a decision-event dispatch when the app has
-// just transitioned into a decision state, and the watch-zone notification
-// fan-out.
-//
-// The new-decision check is computed BEFORE the upsert so it compares the
-// PERSISTED state, not the incoming one: a non-decision -> decision transition
-// (Permitted/Conditions/Rejected/Appealed), including a first-seen already-decided
-// application (existing is absent), dispatches exactly one decision event.
-// Downstream idempotency (one decision per user/app) makes a re-dispatch harmless,
-// but gating on the transition keeps the dispatch count honest. The fan-out
-// collaborators are skipped entirely when not wired (ingestion-only mode).
-func (h *PollPlanItHandler) processApplication(ctx context.Context, app applications.PlanningApplication) error {
-	authorityCode := strconv.Itoa(app.AreaID)
-	existing, found, err := h.apps.GetByUID(ctx, app.UID, authorityCode)
-	if err != nil {
-		return err
-	}
-	if found && existing.HasSameBusinessFieldsAs(app) {
-		return nil
-	}
-
-	var existingState *string
-	if found {
-		existingState = existing.AppState
-	}
-	isNewDecision := isDecisionState(app.AppState) && !isDecisionState(existingState)
-
-	if err := h.apps.Upsert(ctx, app); err != nil {
-		return err
-	}
-
-	if isNewDecision && h.decision != nil {
-		if err := h.decision.Dispatch(ctx, app); err != nil {
-			return err
-		}
-	}
-	if h.enqueuer != nil {
-		if err := h.enqueuer.EnqueueForApplication(ctx, app); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// isDecisionState reports whether a PlanIt app_state is a decision outcome
-// (Permitted, Conditions, Rejected, Appealed), case-insensitively. A nil/empty
-// state is not a decision.
-func isDecisionState(appState *string) bool {
-	if appState == nil || *appState == "" {
-		return false
-	}
-	switch {
-	case strings.EqualFold(*appState, "Permitted"),
-		strings.EqualFold(*appState, "Conditions"),
-		strings.EqualFold(*appState, "Rejected"),
-		strings.EqualFold(*appState, "Appealed"):
-		return true
-	default:
-		return false
-	}
 }
 
 // finishAuthority persists the authority's advanced poll state. On a cap-hit or

--- a/api-go/internal/polling/handler_test.go
+++ b/api-go/internal/polling/handler_test.go
@@ -58,6 +58,7 @@ type fakeApps struct {
 	existing  map[string]applications.PlanningApplication // uid -> existing record
 	upserts   []applications.PlanningApplication
 	upsertErr error
+	getErr    error
 }
 
 func newFakeApps() *fakeApps {
@@ -65,6 +66,9 @@ func newFakeApps() *fakeApps {
 }
 
 func (f *fakeApps) GetByUID(_ context.Context, uid, _ string) (applications.PlanningApplication, bool, error) {
+	if f.getErr != nil {
+		return applications.PlanningApplication{}, false, f.getErr
+	}
 	a, ok := f.existing[uid]
 	return a, ok, nil
 }

--- a/api-go/internal/polling/ingester.go
+++ b/api-go/internal/polling/ingester.go
@@ -1,0 +1,92 @@
+package polling
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+)
+
+// Ingester ingests a single planning application: upsert (with the reindex-flood
+// dedup guard), decision-transition detection, decision-event dispatch, and
+// watch-zone notification fan-out. It is exported so callers other than the
+// PlanIt poll cycle can feed it one application at a time without pulling in the
+// fetch/state/authority/cycle machinery PollPlanItHandler needs to walk PlanIt
+// itself — e.g. the dev-seed job (bd tc-grvu.4), which sources applications from
+// a read-only prod mirror instead of PlanIt.
+type Ingester struct {
+	apps     applicationStore
+	decision DecisionDispatcher   // may be nil: ingestion-only mode skips decision dispatch
+	enqueuer NotificationEnqueuer // may be nil: ingestion-only mode skips zone fan-out
+}
+
+// NewIngester wires an Ingester. decision and enqueuer may be nil for
+// ingestion-only callers that don't want notification fan-out.
+func NewIngester(apps applicationStore, decision DecisionDispatcher, enqueuer NotificationEnqueuer) *Ingester {
+	return &Ingester{apps: apps, decision: decision, enqueuer: enqueuer}
+}
+
+// Ingest point-reads the persisted application by uid within its authority
+// partition, and — when a business field changed (the reindex-flood guard; a
+// first-time insert always counts as changed) — upserts it, then runs the
+// notification fan-out: a decision-event dispatch when the app has just
+// transitioned into a decision state, and the watch-zone notification fan-out.
+//
+// The new-decision check is computed BEFORE the upsert so it compares the
+// PERSISTED state, not the incoming one: a non-decision -> decision transition
+// (Permitted/Conditions/Rejected/Appealed), including a first-seen already-decided
+// application (existing is absent), dispatches exactly one decision event.
+// Downstream idempotency (one decision per user/app) makes a re-dispatch harmless,
+// but gating on the transition keeps the dispatch count honest. The fan-out
+// collaborators are skipped entirely when not wired (ingestion-only mode).
+func (i *Ingester) Ingest(ctx context.Context, app applications.PlanningApplication) error {
+	authorityCode := strconv.Itoa(app.AreaID)
+	existing, found, err := i.apps.GetByUID(ctx, app.UID, authorityCode)
+	if err != nil {
+		return err
+	}
+	if found && existing.HasSameBusinessFieldsAs(app) {
+		return nil
+	}
+
+	var existingState *string
+	if found {
+		existingState = existing.AppState
+	}
+	isNewDecision := isDecisionState(app.AppState) && !isDecisionState(existingState)
+
+	if err := i.apps.Upsert(ctx, app); err != nil {
+		return err
+	}
+
+	if isNewDecision && i.decision != nil {
+		if err := i.decision.Dispatch(ctx, app); err != nil {
+			return err
+		}
+	}
+	if i.enqueuer != nil {
+		if err := i.enqueuer.EnqueueForApplication(ctx, app); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isDecisionState reports whether a PlanIt app_state is a decision outcome
+// (Permitted, Conditions, Rejected, Appealed), case-insensitively. A nil/empty
+// state is not a decision.
+func isDecisionState(appState *string) bool {
+	if appState == nil || *appState == "" {
+		return false
+	}
+	switch {
+	case strings.EqualFold(*appState, "Permitted"),
+		strings.EqualFold(*appState, "Conditions"),
+		strings.EqualFold(*appState, "Rejected"),
+		strings.EqualFold(*appState, "Appealed"):
+		return true
+	default:
+		return false
+	}
+}

--- a/api-go/internal/polling/ingester_test.go
+++ b/api-go/internal/polling/ingester_test.go
@@ -1,0 +1,123 @@
+package polling
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// --- tests: Ingester exercised directly, independent of PollPlanItHandler ---
+
+func TestIngester_UpsertsNewApplication(t *testing.T) {
+	t.Parallel()
+	apps := newFakeApps()
+	ing := NewIngester(apps, nil, nil)
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	app := testApp("24/0001", 99, ld)
+
+	if err := ing.Ingest(context.Background(), app); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(apps.upserts) != 1 {
+		t.Errorf("upserts: got %d, want 1", len(apps.upserts))
+	}
+}
+
+func TestIngester_SkipsUpsertWhenBusinessFieldsUnchanged(t *testing.T) {
+	t.Parallel()
+	apps := newFakeApps()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	app := testApp("24/0001", 99, ld)
+	existing := app
+	existing.LastDifferent = ld.Add(-time.Hour)
+	apps.existing[app.UID] = existing
+	ing := NewIngester(apps, nil, nil)
+
+	if err := ing.Ingest(context.Background(), app); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if len(apps.upserts) != 0 {
+		t.Errorf("unchanged business fields must skip upsert, got %d upserts, want 0", len(apps.upserts))
+	}
+}
+
+func TestIngester_DispatchesDecisionOnTransitionAndEnqueues(t *testing.T) {
+	t.Parallel()
+	apps := newFakeApps()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	apps.existing["24/0001/FUL"] = decisionApp("Undecided", ld.Add(-time.Hour))
+	disp := &fakeDecisionDispatcher{}
+	enq := &fakeEnqueuer{}
+	ing := NewIngester(apps, disp, enq)
+
+	if err := ing.Ingest(context.Background(), decisionApp("Permitted", ld)); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if disp.count() != 1 {
+		t.Errorf("decision dispatch count: got %d, want 1", disp.count())
+	}
+	if enq.count() != 1 {
+		t.Errorf("enqueue count: got %d, want 1", enq.count())
+	}
+}
+
+func TestIngester_NoDecisionDispatchWhenAlreadyDecided(t *testing.T) {
+	t.Parallel()
+	apps := newFakeApps()
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	apps.existing["24/0001/FUL"] = decisionApp("Permitted", ld.Add(-time.Hour))
+	disp := &fakeDecisionDispatcher{}
+	enq := &fakeEnqueuer{}
+	ing := NewIngester(apps, disp, enq)
+
+	if err := ing.Ingest(context.Background(), decisionApp("Conditions", ld)); err != nil {
+		t.Fatalf("Ingest: %v", err)
+	}
+	if disp.count() != 0 {
+		t.Errorf("decision->decision change is not a new transition, got %d dispatches, want 0", disp.count())
+	}
+	if enq.count() != 1 {
+		t.Errorf("the changed application should still be enqueued, got %d, want 1", enq.count())
+	}
+}
+
+func TestIngester_NilCollaboratorsSkipFanOutGracefully(t *testing.T) {
+	t.Parallel()
+	apps := newFakeApps()
+	ing := NewIngester(apps, nil, nil)
+	ld := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+
+	if err := ing.Ingest(context.Background(), decisionApp("Permitted", ld)); err != nil {
+		t.Fatalf("Ingest with nil fan-out collaborators must not error: %v", err)
+	}
+	if len(apps.upserts) != 1 {
+		t.Errorf("upsert must still happen with nil fan-out collaborators, got %d, want 1", len(apps.upserts))
+	}
+}
+
+func TestIngester_PropagatesGetByUIDError(t *testing.T) {
+	t.Parallel()
+	apps := newFakeApps()
+	wantErr := errors.New("store unavailable")
+	apps.getErr = wantErr
+	ing := NewIngester(apps, nil, nil)
+
+	err := ing.Ingest(context.Background(), testApp("24/0001", 99, time.Now()))
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Ingest error: got %v, want %v", err, wantErr)
+	}
+}
+
+func TestIngester_PropagatesUpsertError(t *testing.T) {
+	t.Parallel()
+	apps := newFakeApps()
+	wantErr := errors.New("upsert failed")
+	apps.upsertErr = wantErr
+	ing := NewIngester(apps, nil, nil)
+
+	err := ing.Ingest(context.Background(), testApp("24/0001", 99, time.Now()))
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Ingest error: got %v, want %v", err, wantErr)
+	}
+}


### PR DESCRIPTION
## Changes
- Extract `Ingester`/`NewIngester`/`Ingest` (+ `isDecisionState`) from `PollPlanItHandler.processApplication` into a new exported `api-go/internal/polling/ingester.go` — pure structural move, no behaviour change. `PollPlanItHandler` now holds `*Ingester`, constructed in `NewPollPlanItHandler`, and `WithFanOut` lazily inits it before wiring `decision`/`enqueuer` (handles callers, e.g. `cmd/worker/wiring_test.go`, that construct a zero-value handler directly).
- Add 7 focused `Ingester.Ingest` unit tests (new-upsert, unchanged-skip, decision-transition dispatch+enqueue, decision→decision no-redispatch, nil-collaborators, GetByUID/Upsert error propagation).
- Full suite: 1438 passing (1431 baseline + 7 new), zero regressions.

Part of epic tc-grvu (GH #808) — hourly dev-only job that mirrors fresh prod planning applications into dev for real push-notification QA. `Ingester` is the reuse point the dev-seed job (tc-grvu.4) will call directly, bypassing the PlanIt-fetch machinery `PollPlanItHandler` otherwise needs.

---
*Auto-shipped via ship skill*