### PR TITLE
feat(api): wire WORKER_MODE=dev-seed (tc-grvu.5)

### DIFF
--- a/api-go/cmd/worker/devseed_wiring_test.go
+++ b/api-go/cmd/worker/devseed_wiring_test.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+// TestBuildDevSeeder_UnconfiguredReturnsNil proves buildDevSeeder returns a
+// genuinely nil worker.DevSeedRunner — not a typed-nil *devseed.Seeder, which
+// would defeat runDevSeed's nil guard — whenever either half of the dev-seed
+// job's dedicated prod-read config (DEV_SEED_PROD_AZURE_CLIENT_ID /
+// DEV_SEED_PROD_POSTGRES_USER) is absent. This mirrors the "unconfigured
+// optional job" posture buildPollOrchestrator/buildPushSender already use.
+func TestBuildDevSeeder_UnconfiguredReturnsNil(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		cfg  platform.Config
+	}{
+		{"both unset", platform.Config{}},
+		{"missing azure client id", platform.Config{DevSeedProdPostgresUser: "towncrier_dev_seed_reader"}},
+		{"missing postgres user", platform.Config{DevSeedProdAzureClientID: "11111111-2222-3333-4444-555555555555"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runner := buildDevSeeder(tc.cfg, &stores{}, discardLogger())
+			if runner != nil {
+				t.Fatalf("buildDevSeeder: got non-nil runner, want nil (job unconfigured)")
+			}
+		})
+	}
+}
+
+// TestBuildDevSeeder_ConfiguredReturnsNonNilSeeder proves buildDevSeeder builds
+// a real Seeder once both halves of the prod-read config are present. It needs
+// no live Azure infra: azidentity.NewManagedIdentityCredential and
+// postgres.NewTokenCredentialPool both construct lazily — the credential holds
+// no token until GetToken is called, and the pgx pool opens no connection until
+// a query is issued — the same "SDK clients constructed in main(), but actual
+// connections open lazily" posture every other builder in this file relies on.
+func TestBuildDevSeeder_ConfiguredReturnsNonNilSeeder(t *testing.T) {
+	t.Parallel()
+	cfg := platform.Config{
+		DevSeedProdAzureClientID: "11111111-2222-3333-4444-555555555555",
+		DevSeedProdPostgresUser:  "towncrier_dev_seed_reader",
+		DevSeedProdPostgresDB:    "town_crier_prod",
+		DevSeedLimit:             5,
+		PostgresHost:             "psql-town-crier-shared.postgres.database.azure.com",
+		PostgresSSLMode:          "require",
+	}
+	st := &stores{
+		app:  applications.NewPostgresStore(nil),
+		zone: watchzones.NewPostgresStore(nil),
+	}
+
+	runner := buildDevSeeder(cfg, st, discardLogger())
+
+	if runner == nil {
+		t.Fatal("buildDevSeeder: got nil runner, want a configured Seeder")
+	}
+}

--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/google/uuid"
 
 	"github.com/AmyDe/town-crier/api-go/internal/acsemail"
@@ -24,6 +25,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
 	"github.com/AmyDe/town-crier/api-go/internal/authorities"
 	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/devseed"
 	"github.com/AmyDe/town-crier/api-go/internal/digest"
 	"github.com/AmyDe/town-crier/api-go/internal/dormant"
 	"github.com/AmyDe/town-crier/api-go/internal/erasure"
@@ -201,7 +203,15 @@ func run() int {
 		logger,
 	)
 
-	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, sweepRunner, purger, logger)
+	// The dev-seed job is built only when its dedicated prod-read config
+	// (DEV_SEED_PROD_AZURE_CLIENT_ID / DEV_SEED_PROD_POSTGRES_USER) is present.
+	// It is created dev-only (tc-grvu.6), so a job missing it (every prod job,
+	// and any dev job before that infra bead deploys) leaves devSeeder a
+	// genuinely nil interface; dev-seed then refuses to run rather than
+	// crashing.
+	devSeeder := buildDevSeeder(cfg, st, logger)
+
+	return worker.Run(context.Background(), mode, bootstrapper, digester, dormantRunner, poller, sweepRunner, purger, devSeeder, logger)
 }
 
 // buildPollOrchestrator wires the poll-sb orchestrator: the PlanIt client, the
@@ -319,6 +329,32 @@ func buildPollOrchestrator(cfg platform.Config, sbClient *servicebus.Client, reg
 // fields are extracted under a nil guard so the fan-out wires with no other
 // store dependency.
 func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zoneStore watchzones.Store, registry *metrics.Registry, st *stores, logger *slog.Logger) {
+	dispatcher, enqueuer, coalescer := buildNotifyFanOut(cfg, zoneStore, st, logger)
+
+	// Record towncrier.notifications.created on each dispatcher (tc-21np). Only
+	// the real poll-sb path is on this KPI surface, so metrics wiring is this
+	// caller's job, not buildNotifyFanOut's.
+	enqueuer = enqueuer.WithMetrics(registry)
+	dispatcher = dispatcher.WithMetrics(registry)
+
+	handler.WithFanOut(dispatcher, enqueuer)
+	handler.WithPushFlusher(coalescer)
+}
+
+// buildNotifyFanOut constructs the decision-dispatch, zone-enqueue and
+// push-coalescer collaborators the notification fan-out needs. It is shared by
+// wirePollFanOut (the real poll-sb path, prod-only) and buildDevSeeder (the
+// dev-seed job, dev-only, tc-grvu.5/GH#808) so both feed applications through
+// byte-for-byte the same notification pipeline, whatever their application
+// source (PlanIt poll vs. the read-only prod mirror). Metrics wiring
+// (WithMetrics) is left to the caller: dev-seed is a QA aid, not part of the
+// towncrier.notifications.* KPI surface poll-sb's real cycle feeds, so it
+// deliberately skips it.
+//
+// st may be nil in tests that only exercise the zone-containment path; the
+// store fields are extracted under a nil guard so the fan-out wires with no
+// other store dependency.
+func buildNotifyFanOut(cfg platform.Config, zoneStore watchzones.Store, st *stores, logger *slog.Logger) (*notifydispatch.DecisionDispatcher, *notifydispatch.Enqueuer, *notifydispatch.PushCoalescer) {
 	var (
 		notifStore     *notifications.PostgresStore
 		profileStore   *profiles.PostgresStore
@@ -336,19 +372,71 @@ func wirePollFanOut(cfg platform.Config, handler *polling.PollPlanItHandler, zon
 
 	pushSender := buildPushSender(cfg, logger)
 	coalescer := notifydispatch.NewPushCoalescer(deviceStore, statePushStore, pushSender, zoneStore, logger)
-
-	// Record towncrier.notifications.created on each dispatcher (tc-21np).
 	enqueuer := notifydispatch.NewEnqueuer(
 		notifStore, zoneStore, profileStore, coalescer,
 		uuid.NewString, time.Now, logger,
-	).WithMetrics(registry)
+	)
 	dispatcher := notifydispatch.NewDecisionDispatcher(
 		notifStore, zoneStore, savedStore, profileStore, coalescer,
 		uuid.NewString, time.Now, logger,
-	).WithMetrics(registry)
+	)
+	return dispatcher, enqueuer, coalescer
+}
 
-	handler.WithFanOut(dispatcher, enqueuer)
-	handler.WithPushFlusher(coalescer)
+// buildDevSeeder constructs the dev-seed job's collaborators: a second,
+// read-only pgxpool.Pool authenticated as the dedicated
+// towncrier_dev_seed_reader Postgres role via its own managed identity
+// (DEV_SEED_PROD_AZURE_CLIENT_ID, infra bead tc-grvu.1 — a distinct identity
+// from AzureClientID, which stays scoped to this process's own pool), wrapped
+// in applications.PostgresStore to read prod's most-recently-changed
+// applications, fed through a polling.Ingester built over the SAME
+// decision-dispatch/enqueue/push-coalescer collaborators wirePollFanOut builds
+// for the real poll path (via the shared buildNotifyFanOut, bound here to
+// dev's own stores), into a devseed.Seeder.
+//
+// It returns nil when DEV_SEED_PROD_AZURE_CLIENT_ID or
+// DEV_SEED_PROD_POSTGRES_USER is unset — the "unconfigured optional job"
+// posture buildPollOrchestrator/buildPushSender already use — so dev-seed
+// refuses to run rather than nil-panicking. This mode is created dev-only
+// (tc-grvu.6): every prod job, and any dev job before that infra bead deploys,
+// takes this path. A credential or pool build error is also treated as
+// unconfigured (logged, nil returned) rather than fatal, since a malformed
+// managed-identity/DSN input at boot must not crash the OTHER modes this same
+// binary dispatches (digest, dormant-cleanup, etc.) when they share a process.
+func buildDevSeeder(cfg platform.Config, st *stores, logger *slog.Logger) worker.DevSeedRunner {
+	if cfg.DevSeedProdAzureClientID == "" || cfg.DevSeedProdPostgresUser == "" {
+		logger.Info("dev-seed unconfigured (DEV_SEED_PROD_AZURE_CLIENT_ID / DEV_SEED_PROD_POSTGRES_USER unset); dev-seed mode will refuse to run")
+		return nil
+	}
+
+	cred, err := azidentity.NewManagedIdentityCredential(&azidentity.ManagedIdentityCredentialOptions{
+		ID: azidentity.ClientID(cfg.DevSeedProdAzureClientID),
+	})
+	if err != nil {
+		logger.Error("dev-seed: build managed-identity credential; dev-seed mode will refuse to run", "error", err)
+		return nil
+	}
+
+	prodPool, err := postgres.NewTokenCredentialPool(context.Background(), postgres.ConnParams{
+		Host:    cfg.PostgresHost,
+		DB:      cfg.DevSeedProdPostgresDB,
+		User:    cfg.DevSeedProdPostgresUser,
+		SSLMode: cfg.PostgresSSLMode,
+	}, cred)
+	if err != nil {
+		logger.Error("dev-seed: build prod read-only pool; dev-seed mode will refuse to run", "error", err)
+		return nil
+	}
+
+	prodApps := applications.NewPostgresStore(prodPool)
+
+	// registry is deliberately nil here: buildNotifyFanOut's metrics wiring is
+	// wirePollFanOut's job (the poll-sb KPI surface); dev-seed's ingestion is a
+	// QA aid and skips it.
+	decision, enqueuer, coalescer := buildNotifyFanOut(cfg, st.zone, st, logger)
+	ingester := polling.NewIngester(st.app, decision, enqueuer)
+
+	return devseed.NewSeeder(st.zone, prodApps, ingester, coalescer, cfg.DevSeedLimit, logger)
 }
 
 // pollOrchestratorAdapter flattens polling.OrchestratorRunResult into the

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -162,7 +162,48 @@ type Config struct {
 	// rows when running the pg-purge job. Loaded from
 	// DEVICE_REGISTRATIONS_RETENTION_DAYS; defaults to 180.
 	DeviceRegistrationsRetentionDays int
+
+	// PostgresHost and PostgresSSLMode are the discrete connection parameters
+	// for the shared Azure Postgres Flexible Server (POSTGRES_HOST /
+	// POSTGRES_SSLMODE), the same env vars internal/platform/postgres's
+	// NewPoolFromEnv already reads directly for the process's primary pool.
+	// They are threaded through Config too because the dev-seed job
+	// (WORKER_MODE=dev-seed, epic tc-grvu, GH#808) opens a SECOND pool, bound
+	// to town_crier_prod under a distinct read-only role, on the same
+	// physical host — cmd/worker/main.go's buildDevSeeder needs the host/SSL
+	// mode to build that pool's ConnParams.
+	PostgresHost    string
+	PostgresSSLMode string
+
+	// DevSeed* configure the hourly dev-seed job (WORKER_MODE=dev-seed, epic
+	// tc-grvu, GH#808), which mirrors a small slice of recently-changed prod
+	// planning applications into dev so a TestFlight build pointed at dev gets
+	// real push notifications to test against (dev otherwise runs no PlanIt
+	// poller, ADR 0024). DevSeedLimit caps how many prod applications are
+	// pulled per cycle (DEV_SEED_LIMIT, default 5). DevSeedProdPostgresDB is
+	// the prod database name the second pool connects to
+	// (DEV_SEED_PROD_POSTGRES_DB, default town_crier_prod).
+	// DevSeedProdPostgresUser is the dedicated least-privilege Postgres role
+	// (DEV_SEED_PROD_POSTGRES_USER, e.g. towncrier_dev_seed_reader, bootstrapped
+	// out-of-band by cmd/pgbootstrap -readonly). DevSeedProdAzureClientID pins
+	// the dedicated id-town-crier-dev-seed-reader managed identity
+	// (DEV_SEED_PROD_AZURE_CLIENT_ID, infra bead tc-grvu.1) used to mint that
+	// role's Entra token — a separate identity from AzureClientID, which stays
+	// scoped to the process's own (dev) pool. DevSeedProdPostgresUser and
+	// DevSeedProdAzureClientID have no default: both empty is the "job
+	// unconfigured" signal cmd/worker/main.go's buildDevSeeder checks so the
+	// mode refuses to run rather than nil-panicking on a job/environment (e.g.
+	// prod) that never wires this config — this mode is created dev-only,
+	// tc-grvu.6.
+	DevSeedLimit             int
+	DevSeedProdPostgresDB    string
+	DevSeedProdPostgresUser  string
+	DevSeedProdAzureClientID string
 }
+
+// defaultDevSeedProdPostgresDB is the prod database name the dev-seed job's
+// second, read-only pool connects to.
+const defaultDevSeedProdPostgresDB = "town_crier_prod"
 
 // defaultPlanItBaseURL is the live PlanIt applications API.
 const defaultPlanItBaseURL = "https://www.planit.org.uk/"
@@ -239,6 +280,14 @@ func LoadConfig() (Config, error) {
 
 		NotificationsRetentionDays:       getenvInt("NOTIFICATIONS_RETENTION_DAYS", 90),
 		DeviceRegistrationsRetentionDays: getenvInt("DEVICE_REGISTRATIONS_RETENTION_DAYS", 180),
+
+		PostgresHost:    os.Getenv("POSTGRES_HOST"),
+		PostgresSSLMode: os.Getenv("POSTGRES_SSLMODE"),
+
+		DevSeedLimit:             getenvInt("DEV_SEED_LIMIT", 5),
+		DevSeedProdPostgresDB:    getenv("DEV_SEED_PROD_POSTGRES_DB", defaultDevSeedProdPostgresDB),
+		DevSeedProdPostgresUser:  os.Getenv("DEV_SEED_PROD_POSTGRES_USER"),
+		DevSeedProdAzureClientID: os.Getenv("DEV_SEED_PROD_AZURE_CLIENT_ID"),
 	}
 
 	if raw := os.Getenv("LOG_LEVEL"); raw != "" {

--- a/api-go/internal/platform/config_test.go
+++ b/api-go/internal/platform/config_test.go
@@ -434,6 +434,72 @@ func TestLoadConfig_AppleEnvironments(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_DevSeed(t *testing.T) {
+	t.Run("set", func(t *testing.T) {
+		t.Setenv("DEV_SEED_LIMIT", "10")
+		t.Setenv("DEV_SEED_PROD_POSTGRES_DB", "town_crier_prod_replica")
+		t.Setenv("DEV_SEED_PROD_POSTGRES_USER", "towncrier_dev_seed_reader")
+		t.Setenv("DEV_SEED_PROD_AZURE_CLIENT_ID", "11111111-2222-3333-4444-555555555555")
+
+		cfg, err := LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.DevSeedLimit != 10 {
+			t.Errorf("DevSeedLimit: got %d, want 10", cfg.DevSeedLimit)
+		}
+		if cfg.DevSeedProdPostgresDB != "town_crier_prod_replica" {
+			t.Errorf("DevSeedProdPostgresDB: got %q", cfg.DevSeedProdPostgresDB)
+		}
+		if cfg.DevSeedProdPostgresUser != "towncrier_dev_seed_reader" {
+			t.Errorf("DevSeedProdPostgresUser: got %q", cfg.DevSeedProdPostgresUser)
+		}
+		if cfg.DevSeedProdAzureClientID != "11111111-2222-3333-4444-555555555555" {
+			t.Errorf("DevSeedProdAzureClientID: got %q", cfg.DevSeedProdAzureClientID)
+		}
+	})
+
+	t.Run("absent defaults limit=5, db=town_crier_prod, empty user/client id (job unconfigured)", func(t *testing.T) {
+		t.Setenv("DEV_SEED_LIMIT", "")
+		t.Setenv("DEV_SEED_PROD_POSTGRES_DB", "")
+		t.Setenv("DEV_SEED_PROD_POSTGRES_USER", "")
+		t.Setenv("DEV_SEED_PROD_AZURE_CLIENT_ID", "")
+
+		cfg, err := LoadConfig()
+		if err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if cfg.DevSeedLimit != 5 {
+			t.Errorf("DevSeedLimit default: got %d, want 5", cfg.DevSeedLimit)
+		}
+		if cfg.DevSeedProdPostgresDB != "town_crier_prod" {
+			t.Errorf("DevSeedProdPostgresDB default: got %q, want town_crier_prod", cfg.DevSeedProdPostgresDB)
+		}
+		if cfg.DevSeedProdPostgresUser != "" {
+			t.Errorf("DevSeedProdPostgresUser: got %q, want empty (job unconfigured)", cfg.DevSeedProdPostgresUser)
+		}
+		if cfg.DevSeedProdAzureClientID != "" {
+			t.Errorf("DevSeedProdAzureClientID: got %q, want empty (job unconfigured)", cfg.DevSeedProdAzureClientID)
+		}
+	})
+}
+
+func TestLoadConfig_PostgresConnParams(t *testing.T) {
+	t.Setenv("POSTGRES_HOST", "psql-town-crier-shared.postgres.database.azure.com")
+	t.Setenv("POSTGRES_SSLMODE", "require")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.PostgresHost != "psql-town-crier-shared.postgres.database.azure.com" {
+		t.Errorf("PostgresHost: got %q", cfg.PostgresHost)
+	}
+	if cfg.PostgresSSLMode != "require" {
+		t.Errorf("PostgresSSLMode: got %q", cfg.PostgresSSLMode)
+	}
+}
+
 func TestLoadConfig_PollingOverrides(t *testing.T) {
 	t.Setenv("PLANIT_BASE_URL", "https://stub.planit.test/")
 	t.Setenv("POLLING_MAX_PAGES_PER_AUTHORITY_PER_CYCLE", "5")

--- a/api-go/internal/worker/dispatch.go
+++ b/api-go/internal/worker/dispatch.go
@@ -45,6 +45,15 @@ const sweepBudget = 10 * time.Minute
 // the process exits cleanly and flushes telemetry.
 const purgeBudget = 10 * time.Minute
 
+// devSeedBudget is the soft self-cancel for a single dev-seed run. The cycle
+// reads dev's watched authorities, pulls at most DEV_SEED_LIMIT
+// recently-changed prod applications over a second, read-only pool, and feeds
+// each through the same upsert + decision-dispatch + zone-enqueue + push-flush
+// pipeline poll-sb uses; 5 minutes is generous for a handful of applications
+// while still bounded well under the Container Apps replicaTimeout so the
+// process exits cleanly and flushes telemetry.
+const devSeedBudget = 5 * time.Minute
+
 // DigestRunner is the consumer-side slice of the digest handler the dispatcher
 // invokes. *digest.Handler satisfies it; the worker depends only on these two
 // methods so it need not know the handler's internals. It is exported so main()
@@ -109,6 +118,17 @@ type PollOrchestrator interface {
 	RunOnce(ctx context.Context) (PollRunResult, error)
 }
 
+// DevSeedRunner is the consumer-side slice of the dev-seed job the dispatcher
+// invokes. *devseed.Seeder satisfies it; Run returns the number of applications
+// ingested so the dispatcher can record it as a telemetry tag. It is exported so
+// main() can hold a genuinely nil interface value when the job is missing its
+// dedicated prod-read config (DEV_SEED_PROD_AZURE_CLIENT_ID /
+// DEV_SEED_PROD_POSTGRES_USER) — passing a typed-nil *devseed.Seeder would
+// defeat the nil guard below.
+type DevSeedRunner interface {
+	Run(ctx context.Context) (int, error)
+}
+
 // Run dispatches on WORKER_MODE and returns the process exit code. It is the
 // testable core of cmd/worker/main.go — main() only loads config, wires the
 // Service Bus client + bootstrapper, sets up telemetry, and propagates this
@@ -123,8 +143,10 @@ type PollOrchestrator interface {
 // bootstrapper may be nil when the job has no Service Bus config; poll-bootstrap
 // then refuses to run rather than nil-panicking. purger may be nil when no purge
 // runner is configured; pg-purge then logs and exits 0, so this is never an
-// error.
-func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, dormant DormantRunner, poller PollOrchestrator, sweeper SweepRunner, purger PurgeRunner, logger *slog.Logger) int {
+// error. devSeeder may be nil when the job is missing its dedicated prod-read
+// config; dev-seed then refuses to run rather than nil-panicking (it is a
+// dev-only job — tc-grvu.6 — so this never fires in prod).
+func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester DigestRunner, dormant DormantRunner, poller PollOrchestrator, sweeper SweepRunner, purger PurgeRunner, devSeeder DevSeedRunner, logger *slog.Logger) int {
 	switch mode {
 	case "":
 		// WORKER_MODE is always set by infra; an unset value is a deployment
@@ -152,6 +174,9 @@ func Run(ctx context.Context, mode string, bootstrapper *Bootstrapper, digester 
 
 	case "pg-purge":
 		return runPurge(ctx, purger, logger)
+
+	case "dev-seed":
+		return runDevSeed(ctx, devSeeder, logger)
 
 	default:
 		logger.ErrorContext(ctx, "unknown WORKER_MODE; refusing to run", "mode", mode)
@@ -327,6 +352,39 @@ func runPurge(ctx context.Context, runner PurgeRunner, logger *slog.Logger) int 
 	logger.InfoContext(ctx, "pg-purge cycle completed",
 		"notificationsDeleted", notifsPurged,
 		"deviceRegistrationsDeleted", devicesPurged)
+	return 0
+}
+
+// runDevSeed executes one dev-seed cycle under a soft self-cancel budget,
+// inside a telemetry span named "Dev Seed Cycle". It records the number of
+// applications ingested as the dev_seed.ingested_count tag. A nil runner (job
+// missing its dedicated prod-read config, DEV_SEED_PROD_AZURE_CLIENT_ID /
+// DEV_SEED_PROD_POSTGRES_USER) is an exit-1 condition, mirroring
+// dormant-cleanup/subscription-sweep's posture for an unconfigured optional
+// job — dev-seed is created dev-only (tc-grvu.6), so this never fires in prod.
+// A cycle error is recorded on the span and also exits 1 so the job surfaces
+// the failure.
+func runDevSeed(ctx context.Context, runner DevSeedRunner, logger *slog.Logger) int {
+	tracer := otel.Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, "Dev Seed Cycle")
+	defer span.End()
+
+	if runner == nil {
+		logger.ErrorContext(ctx, "dev-seed requires prod-read config (DEV_SEED_PROD_AZURE_CLIENT_ID / DEV_SEED_PROD_POSTGRES_USER); refusing to run")
+		return 1
+	}
+
+	cycleCtx, cancel := context.WithTimeout(ctx, devSeedBudget)
+	defer cancel()
+
+	ingested, err := runner.Run(cycleCtx)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		logger.ErrorContext(ctx, "dev-seed cycle failed", "error", err)
+		return 1
+	}
+	span.SetAttributes(attribute.Int("dev_seed.ingested_count", ingested))
 	return 0
 }
 

--- a/api-go/internal/worker/dispatch_test.go
+++ b/api-go/internal/worker/dispatch_test.go
@@ -70,12 +70,26 @@ func (f *fakePurge) Run(context.Context) (int, int, error) {
 	return f.notifsPurged, f.devicesPurged, f.err
 }
 
+// fakeDevSeed is a hand-written double for the DevSeedRunner the dispatcher
+// invokes. It records the call and can be primed with an ingested count or an
+// error.
+type fakeDevSeed struct {
+	calls    int
+	ingested int
+	err      error
+}
+
+func (f *fakeDevSeed) Run(context.Context) (int, error) {
+	f.calls++
+	return f.ingested, f.err
+}
+
 func TestRun_UnsetModeFailsFast(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "", nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "", nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unset mode", code)
@@ -90,7 +104,7 @@ func TestRun_DigestModeRunsWeeklyAndExitsZero(t *testing.T) {
 	d := &fakeDigester{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0", code)
@@ -105,7 +119,7 @@ func TestRun_HourlyDigestModeRunsHourlyAndExitsZero(t *testing.T) {
 	d := &fakeDigester{}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "hourly-digest", nil, d, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "hourly-digest", nil, d, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0", code)
@@ -122,7 +136,7 @@ func TestRun_DigestModeWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "digest", nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when digest handler is unconfigured", code)
@@ -134,7 +148,7 @@ func TestRun_DigestCycleErrorExitsOne(t *testing.T) {
 	d := &fakeDigester{weeklyErr: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "digest", nil, d, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on digest cycle error", code)
@@ -165,7 +179,7 @@ func TestRun_PollSBRunsOrchestratorAndExitsZeroOnSuccess(t *testing.T) {
 	}}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 for a successful poll cycle", code)
@@ -182,7 +196,7 @@ func TestRun_PollSBWithoutOrchestratorExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when poll-sb is unconfigured", code)
@@ -222,7 +236,7 @@ func TestRun_PollSBExitsOneOnlyWhenNoAppsAndAuthorityErrors(t *testing.T) {
 			t.Parallel()
 			o := &fakePollOrchestrator{result: tc.result}
 			logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
-			code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, logger)
+			code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, logger)
 			if code != tc.wantExit {
 				t.Errorf("exit code: got %d, want %d", code, tc.wantExit)
 			}
@@ -235,7 +249,7 @@ func TestRun_PollSBExitsOneOnOrchestratorError(t *testing.T) {
 	o := &fakePollOrchestrator{err: errors.New("orchestrator blew up")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, logger)
+	code := Run(context.Background(), "poll-sb", nil, nil, nil, o, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on orchestrator error", code)
@@ -247,7 +261,7 @@ func TestRun_DormantCleanupRunsAndExitsZero(t *testing.T) {
 	d := &fakeDormant{deleted: 3}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful dormant cleanup)", code)
@@ -264,7 +278,7 @@ func TestRun_DormantCleanupWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when dormant handler is unconfigured", code)
@@ -276,7 +290,7 @@ func TestRun_DormantCleanupCycleErrorExitsOne(t *testing.T) {
 	d := &fakeDormant{err: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, nil, logger)
+	code := Run(context.Background(), "dormant-cleanup", nil, nil, d, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on dormant cleanup error", code)
@@ -288,7 +302,7 @@ func TestRun_SubscriptionSweepRunsAndExitsZero(t *testing.T) {
 	s := &fakeSweep{downgraded: 4}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, nil, logger)
+	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful subscription sweep)", code)
@@ -305,7 +319,7 @@ func TestRun_SubscriptionSweepWithoutHandlerExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when sweep handler is unconfigured", code)
@@ -317,7 +331,7 @@ func TestRun_SubscriptionSweepCycleErrorExitsOne(t *testing.T) {
 	s := &fakeSweep{err: errors.New("cosmos down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, nil, logger)
+	code := Run(context.Background(), "subscription-sweep", nil, nil, nil, nil, s, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on subscription sweep error", code)
@@ -329,7 +343,7 @@ func TestRun_PgPurgeRunsAndExitsZero(t *testing.T) {
 	p := &fakePurge{notifsPurged: 12, devicesPurged: 3}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, p, logger)
+	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, p, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful pg-purge)", code)
@@ -346,7 +360,7 @@ func TestRun_PgPurgeWithNilRunnerExitsZero(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 when purger is nil (Cosmos TTL active)", code)
@@ -361,7 +375,7 @@ func TestRun_PgPurgeCycleErrorExitsOne(t *testing.T) {
 	p := &fakePurge{err: errors.New("postgres down")}
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, p, logger)
+	code := Run(context.Background(), "pg-purge", nil, nil, nil, nil, nil, p, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 on pg-purge error", code)
@@ -373,7 +387,7 @@ func TestRun_UnknownModeExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "banana", nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "banana", nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 for unknown mode", code)
@@ -386,7 +400,7 @@ func TestRun_PollBootstrapSeedsAndExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (successful bootstrap)", code)
@@ -403,7 +417,7 @@ func TestRun_PollBootstrapWithoutQueueExitsOne(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", nil, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", nil, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 1 {
 		t.Errorf("exit code: got %d, want 1 when Service Bus is unconfigured", code)
@@ -418,9 +432,51 @@ func TestRun_PollBootstrapProbeFailureStillExitsZero(t *testing.T) {
 	b := newTestBootstrapper(t, q)
 	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
 
-	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, logger)
+	code := Run(context.Background(), "poll-bootstrap", b, nil, nil, nil, nil, nil, nil, logger)
 
 	if code != 0 {
 		t.Errorf("exit code: got %d, want 0 (absorbed probe failure is not a job failure)", code)
+	}
+}
+
+func TestRun_DevSeedRunsAndExitsZero(t *testing.T) {
+	t.Parallel()
+	ds := &fakeDevSeed{ingested: 3}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "dev-seed", nil, nil, nil, nil, nil, nil, ds, logger)
+
+	if code != 0 {
+		t.Errorf("exit code: got %d, want 0 (successful dev-seed cycle)", code)
+	}
+	if ds.calls != 1 {
+		t.Errorf("dev-seed Run calls: got %d, want 1", ds.calls)
+	}
+}
+
+func TestRun_DevSeedWithoutRunnerExitsOne(t *testing.T) {
+	t.Parallel()
+	// A job missing its dedicated prod-read config (DEV_SEED_PROD_AZURE_CLIENT_ID
+	// / DEV_SEED_PROD_POSTGRES_USER) leaves the dev-seed runner nil; the mode must
+	// refuse to run rather than nil-panic.
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	code := Run(context.Background(), "dev-seed", nil, nil, nil, nil, nil, nil, nil, logger)
+
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1 when dev-seed is unconfigured", code)
+	}
+}
+
+func TestRun_DevSeedCycleErrorExitsOne(t *testing.T) {
+	t.Parallel()
+	ds := &fakeDevSeed{err: errors.New("postgres down")}
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+
+	code := Run(context.Background(), "dev-seed", nil, nil, nil, nil, nil, nil, ds, logger)
+
+	if code != 1 {
+		t.Errorf("exit code: got %d, want 1 on dev-seed cycle error", code)
 	}
 }


### PR DESCRIPTION
## Changes
- `internal/worker/dispatch.go` — new `DevSeedRunner` interface, `case "dev-seed"`, `runDevSeed` (span "Dev Seed Cycle", 5-min soft budget, nil-guard exits 1 mirroring the file's other unconfigured-optional-job cases). `Run()` gains `devSeeder DevSeedRunner` as a new parameter.
- `internal/platform/config.go` — new `DevSeedLimit`/`DevSeedProdPostgresDB`/`DevSeedProdPostgresUser`/`DevSeedProdAzureClientID` fields (env `DEV_SEED_LIMIT`/`DEV_SEED_PROD_POSTGRES_DB`/`DEV_SEED_PROD_POSTGRES_USER`/`DEV_SEED_PROD_AZURE_CLIENT_ID`), plus `PostgresHost`/`PostgresSSLMode` surfaced on `Config` (previously read only inside `postgres.paramsFromEnv`) so `buildDevSeeder` can build the second pool's connection params.
- `cmd/worker/main.go` — `buildDevSeeder` builds a second read-only `pgxpool.Pool` via `azidentity.NewManagedIdentityCredential` + `postgres.NewTokenCredentialPool`, wraps it in `applications.NewPostgresStore`, and constructs a `polling.Ingester` + `devseed.Seeder` over dev's own stores. Extracted `buildNotifyFanOut` (pure refactor) so both the real poll-sb path and the dev-seed job build their decision-dispatch/enqueue/push-coalescer collaborators identically. Returns `nil` (genuinely, not typed-nil) whenever `DEV_SEED_PROD_AZURE_CLIENT_ID`/`DEV_SEED_PROD_POSTGRES_USER` are unset — every prod job, and dev before tc-grvu.6's infra deploys.
- Full suite: 1459 passing, zero regressions.

Part of epic tc-grvu (GH #808) — hourly dev-only job that mirrors fresh prod planning applications into dev for real push-notification QA. Builds on tc-grvu.1 (identity, merged), tc-grvu.3/.4 (store method + Seeder, merged). Last remaining bead: tc-grvu.6 creates the actual dev-only Container Apps Job and sets these env vars in infra.

---
*Auto-shipped via ship skill*