### PR TITLE
feat(android): settings, legal, notification prefs, data export, account deletion, review prompt (tc-4jjw)

### DIFF
--- a/.github/workflows/legal-drift-check.yml
+++ b/.github/workflows/legal-drift-check.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'api-go/internal/legal/resources/**'
       - 'mobile/ios/packages/town-crier-presentation/Sources/Resources/legal/**'
+      - 'mobile/android/presentation/src/main/assets/legal/**'
       - 'scripts/check-legal-drift.sh'
       - 'scripts/sync-legal.sh'
       - '.github/workflows/legal-drift-check.yml'
@@ -15,7 +16,7 @@ permissions:
 
 jobs:
   check:
-    name: Verify API and iOS legal JSON match
+    name: Verify API, iOS, and Android legal JSON match
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/.github/workflows/legal-drift-check.yml
+++ b/.github/workflows/legal-drift-check.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'api-go/internal/legal/resources/**'
       - 'mobile/ios/packages/town-crier-presentation/Sources/Resources/legal/**'
-      - 'mobile/android/presentation/src/main/assets/legal/**'
       - 'scripts/check-legal-drift.sh'
       - 'scripts/sync-legal.sh'
       - '.github/workflows/legal-drift-check.yml'
@@ -16,7 +15,7 @@ permissions:
 
 jobs:
   check:
-    name: Verify API, iOS, and Android legal JSON match
+    name: Verify API and iOS legal JSON match
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/mobile/android/app/build.gradle.kts
+++ b/mobile/android/app/build.gradle.kts
@@ -131,6 +131,11 @@ dependencies {
     implementation(libs.auth0)
     implementation(libs.okhttp)
     implementation(libs.androidx.datastore.preferences)
+    // Play In-App Review ("Rate the App", tc-4jjw / #778) — needs a real
+    // Activity, so it's wired here rather than in `:presentation`.
+    implementation(libs.play.review.ktx)
+    // The Settings gear glyph isn't in material-icons-core's small default subset.
+    implementation(libs.compose.material.icons.extended)
 
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.junit.jupiter)

--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -28,6 +28,20 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- The GDPR data-export share sheet's content:// bridge (tc-4jjw / #778).
+             authorities uses ${applicationId} so the dev/prod/local flavors
+             (different applicationIdSuffix) each get their own non-clashing
+             authority. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -188,7 +188,8 @@ public class AppGraph(
 
     public val appearanceCoordinator: AppearanceCoordinator = AppearanceCoordinator(androidLeaves.appearanceStore)
 
-    public val legalDocumentRepository: LegalDocumentRepository = LegalDocumentLoader(androidLeaves.legalDocumentAssetReader)
+    public val legalDocumentRepository: LegalDocumentRepository =
+        LegalDocumentLoader(androidLeaves.legalDocumentAssetReader)
 
     public val reviewPromptTracker: ReviewPromptTracker =
         ReviewPromptTracker(

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -104,6 +104,12 @@ public class AppGraph(
 ) {
     private val transport = OkHttpTransport(options.callFactory)
 
+    // Surfaced publicly (not just used to build authenticationService below)
+    // because the "Rate the App" settings row also needs a foreground
+    // Activity for its own, differently-failure-handled Play In-App Review
+    // attempt — see PlayReviewRequester.kt's `requestReviewOrOpenStoreListing`.
+    public val activityProvider: CurrentActivityProvider = androidLeaves.activityProvider
+
     // dev and prod share one Auth0 Native application; only the audience (and
     // therefore the access-token claims) differ per flavor (epic #770 D4).
     public val authenticationService: AuthenticationService =
@@ -187,7 +193,7 @@ public class AppGraph(
     public val reviewPromptTracker: ReviewPromptTracker =
         ReviewPromptTracker(
             store = androidLeaves.reviewPromptStore,
-            requester = PlayReviewRequester(androidLeaves.activityProvider),
+            requester = PlayReviewRequester(activityProvider),
             clock = options.clock,
         )
 

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -54,13 +54,25 @@ public data class Auth0Tenant(
 )
 
 /**
+ * The tc-4jjw (#778) Android-touching leaves — grouped separately from
+ * [AndroidLeaves] so that constructor's own parameter list stays under
+ * detekt's threshold, same rationale as [AppGraphOptions].
+ */
+public class SettingsLeaves(
+    public val appearanceStore: AppearanceStore,
+    public val reviewPromptStore: ReviewPromptStore,
+    public val legalDocumentAssetReader: LegalDocumentAssetReader,
+)
+
+/**
  * The leaves that genuinely need a real `Context` —
  * `TownCrierApplication` builds them (`SecureCredentialsManagerStore` over a
  * real `SecureCredentialsManager`, an `Application.ActivityLifecycleCallbacks`
  * tracker, a `DataStoreSubscriptionTierCache`, a `DataStoreApplicationListPreferencesStore`,
- * a `DataStoreOnboardingRepository`, a `DataStoreAppearanceStore`, a
- * `DataStoreReviewPromptStore`, an `AssetManager`-backed [LegalDocumentAssetReader])
- * and hands them to the otherwise Context-free [AppGraph].
+ * a `DataStoreOnboardingRepository`, and — via [SettingsLeaves] — a
+ * `DataStoreAppearanceStore`, a `DataStoreReviewPromptStore`, and an
+ * `AssetManager`-backed [LegalDocumentAssetReader]) and hands them to the
+ * otherwise Context-free [AppGraph].
  */
 public class AndroidLeaves(
     public val credentialsStore: CredentialsStore,
@@ -68,9 +80,7 @@ public class AndroidLeaves(
     public val tierCache: SubscriptionTierCache,
     public val applicationListPreferencesStore: ApplicationListPreferencesStore,
     public val onboardingRepository: OnboardingRepository,
-    public val appearanceStore: AppearanceStore,
-    public val reviewPromptStore: ReviewPromptStore,
-    public val legalDocumentAssetReader: LegalDocumentAssetReader,
+    public val settingsLeaves: SettingsLeaves,
 )
 
 /** Rarely-overridden technical knobs, grouped so [AppGraph]'s own constructor stays short. */
@@ -186,14 +196,15 @@ public class AppGraph(
 
     public val onboardingRepository: OnboardingRepository = androidLeaves.onboardingRepository
 
-    public val appearanceCoordinator: AppearanceCoordinator = AppearanceCoordinator(androidLeaves.appearanceStore)
+    public val appearanceCoordinator: AppearanceCoordinator =
+        AppearanceCoordinator(androidLeaves.settingsLeaves.appearanceStore)
 
     public val legalDocumentRepository: LegalDocumentRepository =
-        LegalDocumentLoader(androidLeaves.legalDocumentAssetReader)
+        LegalDocumentLoader(androidLeaves.settingsLeaves.legalDocumentAssetReader)
 
     public val reviewPromptTracker: ReviewPromptTracker =
         ReviewPromptTracker(
-            store = androidLeaves.reviewPromptStore,
+            store = androidLeaves.settingsLeaves.reviewPromptStore,
             requester = PlayReviewRequester(activityProvider),
             clock = options.clock,
         )

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -17,6 +17,8 @@ import uk.towncrierapp.data.auth.Auth0Config
 import uk.towncrierapp.data.auth.CredentialsStore
 import uk.towncrierapp.data.auth.CurrentActivityProvider
 import uk.towncrierapp.data.auth.SessionCache
+import uk.towncrierapp.data.legal.LegalDocumentAssetReader
+import uk.towncrierapp.data.legal.LegalDocumentLoader
 import uk.towncrierapp.data.profile.ApiUserProfileRepository
 import uk.towncrierapp.data.versionconfig.ApiVersionConfigService
 import uk.towncrierapp.data.watchzones.ApiPostcodeGeocoder
@@ -29,14 +31,20 @@ import uk.towncrierapp.domain.applications.OfflineAwareRepository
 import uk.towncrierapp.domain.applications.PlanningApplicationRepository
 import uk.towncrierapp.domain.applications.SavedApplicationRepository
 import uk.towncrierapp.domain.auth.AuthenticationService
+import uk.towncrierapp.domain.devicetoken.DeviceTokenRepository
+import uk.towncrierapp.domain.legal.LegalDocumentRepository
 import uk.towncrierapp.domain.onboarding.OnboardingRepository
 import uk.towncrierapp.domain.profile.UserProfileRepository
+import uk.towncrierapp.domain.reviewprompt.ReviewPromptStore
+import uk.towncrierapp.domain.settings.AppearanceStore
 import uk.towncrierapp.domain.subscriptions.SubscriptionTierCache
 import uk.towncrierapp.domain.versionconfig.VersionConfigService
 import uk.towncrierapp.domain.watchzones.PostcodeGeocoder
 import uk.towncrierapp.domain.watchzones.WatchZoneRepository
 import uk.towncrierapp.domain.watchzones.ZonePreferencesRepository
+import uk.towncrierapp.presentation.appearance.AppearanceCoordinator
 import uk.towncrierapp.presentation.auth.AuthCoordinator
+import uk.towncrierapp.presentation.reviewprompt.ReviewPromptTracker
 import java.time.Clock
 
 /** Auth0 tenant identity — same across build flavors (epic #770 D4); only the audience differs, via [AppGraph.authAudience]. */
@@ -50,8 +58,9 @@ public data class Auth0Tenant(
  * `TownCrierApplication` builds them (`SecureCredentialsManagerStore` over a
  * real `SecureCredentialsManager`, an `Application.ActivityLifecycleCallbacks`
  * tracker, a `DataStoreSubscriptionTierCache`, a `DataStoreApplicationListPreferencesStore`,
- * a `DataStoreOnboardingRepository`) and hands them to the otherwise
- * Context-free [AppGraph].
+ * a `DataStoreOnboardingRepository`, a `DataStoreAppearanceStore`, a
+ * `DataStoreReviewPromptStore`, an `AssetManager`-backed [LegalDocumentAssetReader])
+ * and hands them to the otherwise Context-free [AppGraph].
  */
 public class AndroidLeaves(
     public val credentialsStore: CredentialsStore,
@@ -59,6 +68,9 @@ public class AndroidLeaves(
     public val tierCache: SubscriptionTierCache,
     public val applicationListPreferencesStore: ApplicationListPreferencesStore,
     public val onboardingRepository: OnboardingRepository,
+    public val appearanceStore: AppearanceStore,
+    public val reviewPromptStore: ReviewPromptStore,
+    public val legalDocumentAssetReader: LegalDocumentAssetReader,
 )
 
 /** Rarely-overridden technical knobs, grouped so [AppGraph]'s own constructor stays short. */
@@ -167,4 +179,20 @@ public class AppGraph(
         androidLeaves.applicationListPreferencesStore
 
     public val onboardingRepository: OnboardingRepository = androidLeaves.onboardingRepository
+
+    public val appearanceCoordinator: AppearanceCoordinator = AppearanceCoordinator(androidLeaves.appearanceStore)
+
+    public val legalDocumentRepository: LegalDocumentRepository = LegalDocumentLoader(androidLeaves.legalDocumentAssetReader)
+
+    public val reviewPromptTracker: ReviewPromptTracker =
+        ReviewPromptTracker(
+            store = androidLeaves.reviewPromptStore,
+            requester = PlayReviewRequester(androidLeaves.activityProvider),
+            clock = options.clock,
+        )
+
+    // #777 hasn't landed a real device-token registration yet — `null` here
+    // means Settings' sign-out/deletion device-token removal is a true no-op
+    // in production today; wiring a real implementation needs no other change.
+    public val deviceTokenRepository: DeviceTokenRepository? = null
 }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/ApplicationNavGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/ApplicationNavGraph.kt
@@ -23,6 +23,7 @@ import uk.towncrierapp.domain.applications.PlanningApplicationId
 import uk.towncrierapp.domain.applications.StatusEvent
 import uk.towncrierapp.domain.applications.isDecided
 import uk.towncrierapp.domain.applications.wireValue
+import uk.towncrierapp.domain.reviewprompt.ReviewSignal
 import uk.towncrierapp.domain.watchzones.Coordinate
 import uk.towncrierapp.presentation.features.applicationdetail.ApplicationDetailRoute
 import uk.towncrierapp.presentation.features.applicationdetail.ApplicationDetailViewModel
@@ -166,6 +167,10 @@ internal fun ApplicationDetailDestinationContent(
                             appGraph.planningApplicationRepository,
                             appGraph.savedApplicationRepository,
                             route.toInitialApplication(),
+                            // The review-prompt savedApplication signal call site
+                            // (GH #628 / tc-4jjw): fires only on a successful
+                            // false-to-true save, see ApplicationDetailViewModel.toggleSave.
+                            onSaved = { appGraph.reviewPromptTracker.recordSignal(ReviewSignal.SavedApplication) },
                         )
                     }
                 },

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/ApplicationNavGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/ApplicationNavGraph.kt
@@ -109,6 +109,7 @@ private fun ApplicationDetailDestination.toInitialApplication(): PlanningApplica
 internal fun ApplicationsTab(
     appGraph: AppGraph,
     navController: NavHostController,
+    onSettingsClick: () -> Unit,
 ) {
     val listViewModel: ApplicationListViewModel =
         viewModel(
@@ -130,6 +131,7 @@ internal fun ApplicationsTab(
         viewModel = listViewModel,
         onApplicationSelected = { application -> navController.navigate(applicationDetailDestinationFor(application)) },
         onAddZoneClick = { navController.navigate(WatchZoneEditorDestination()) },
+        onSettingsClick = onSettingsClick,
     )
 }
 
@@ -138,6 +140,7 @@ internal fun ApplicationsTab(
 internal fun SavedTab(
     appGraph: AppGraph,
     navController: NavHostController,
+    onSettingsClick: () -> Unit,
 ) {
     val savedViewModel: SavedListViewModel =
         viewModel(
@@ -147,6 +150,7 @@ internal fun SavedTab(
     SavedListRoute(
         viewModel = savedViewModel,
         onApplicationSelected = { application -> navController.navigate(applicationDetailDestinationFor(application)) },
+        onSettingsClick = onSettingsClick,
     )
 }
 

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
@@ -11,14 +11,18 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -52,7 +56,12 @@ public class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         val appGraph = (application as TownCrierApplication).appGraph
         setContent {
-            TownCrierTheme {
+            // The four-way appearance picker (tc-4jjw / #778): restyles the
+            // whole app the instant `SettingsViewModel.setAppearance` writes
+            // a new value, since this StateFlow IS what feeds TownCrierTheme.
+            val appearance by appGraph.appearanceCoordinator.appearance.collectAsStateWithLifecycle()
+            LaunchedEffect(Unit) { appGraph.appearanceCoordinator.load() }
+            TownCrierTheme(appearance = appearance) {
                 TownCrierApp(appGraph = appGraph)
             }
         }
@@ -135,6 +144,7 @@ public fun TownCrierApp(
                     navController = navController,
                     onboardingPresentation = onboardingPresentation,
                     subscriptionTier = subscriptionTier,
+                    loginViewModel = loginViewModel,
                 )
             }
 
@@ -152,6 +162,7 @@ private fun AuthedContent(
     navController: NavHostController,
     onboardingPresentation: OnboardingPresentation,
     subscriptionTier: SubscriptionTier,
+    loginViewModel: LoginViewModel,
 ) {
     when (onboardingPresentation) {
         OnboardingPresentation.Undetermined -> {
@@ -167,31 +178,57 @@ private fun AuthedContent(
         }
 
         OnboardingPresentation.NotRequired -> {
-            AuthedShell(appGraph = appGraph, navController = navController)
+            AuthedShell(appGraph = appGraph, navController = navController, loginViewModel = loginViewModel)
         }
     }
 }
 
 /**
  * The signed-in shell: bottom navigation (Applications, Zones, Saved)
- * wrapping the NavHost. The watch-zone destinations' content lives in
- * `WatchZoneNavGraph.kt`, and the applications-browsing destinations' in
- * `ApplicationNavGraph.kt`, to keep every file under detekt's per-file
+ * wrapping the NavHost, with a top app bar carrying the settings icon every
+ * bottom-nav-hosting screen gets (epic #770's Material-native-idiom
+ * chapter). The watch-zone destinations' content lives in
+ * `WatchZoneNavGraph.kt`, the applications-browsing destinations' in
+ * `ApplicationNavGraph.kt`, and the settings-area destinations' in
+ * `SettingsNavGraph.kt`, to keep every file under detekt's per-file
  * function-count budget.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AuthedShell(
     appGraph: AppGraph,
     navController: NavHostController,
+    loginViewModel: LoginViewModel,
     modifier: Modifier = Modifier,
 ) {
     val subscriptionTier by appGraph.authCoordinator.subscriptionTier.collectAsStateWithLifecycle()
     val backStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = backStackEntry?.destination?.route
+    val isTabRoute = currentRoute == APPLICATIONS_ROUTE || currentRoute == WATCH_ZONES_ROUTE || currentRoute == SAVED_ROUTE
 
     Scaffold(
         modifier = modifier,
+        topBar = {
+            // Only the three bottom-nav tabs get this shared top bar (with the
+            // settings icon, per the epic's Material-native-idiom chapter);
+            // every other destination (detail/editor/settings screens) renders
+            // its own Scaffold + back-navigating TopAppBar internally.
+            if (isTabRoute || currentRoute == null) {
+                TopAppBar(
+                    title = { Text(stringResource(tabTitleRes(currentRoute))) },
+                    actions = {
+                        IconButton(onClick = { navController.navigate(SettingsDestination) }) {
+                            Icon(
+                                imageVector = Icons.Filled.Settings,
+                                contentDescription = stringResource(PresentationR.string.settings_content_description),
+                            )
+                        }
+                    },
+                )
+            }
+        },
         bottomBar = {
-            AuthedBottomBar(currentRoute = backStackEntry?.destination?.route, navController = navController)
+            AuthedBottomBar(currentRoute = currentRoute, navController = navController)
         },
     ) { contentPadding ->
         NavHost(
@@ -223,9 +260,31 @@ private fun AuthedShell(
             composable<ApplicationDetailDestination> { entry ->
                 ApplicationDetailDestinationContent(entry = entry, appGraph = appGraph, navController = navController)
             }
+            composable<SettingsDestination> {
+                SettingsDestinationContent(
+                    appGraph = appGraph,
+                    subscriptionTier = subscriptionTier,
+                    loginViewModel = loginViewModel,
+                    navController = navController,
+                )
+            }
+            composable<NotificationPreferencesDestination> {
+                NotificationPreferencesDestinationContent(appGraph = appGraph, navController = navController)
+            }
+            composable<LegalDocumentDestination> { entry ->
+                LegalDocumentDestinationContent(entry = entry, appGraph = appGraph, navController = navController)
+            }
         }
     }
 }
+
+/** The bottom-nav tabs each carry their own top-app-bar title; every other destination supplies its own inside its Screen. */
+private fun tabTitleRes(route: String?): Int =
+    when (route) {
+        WATCH_ZONES_ROUTE -> PresentationR.string.bottom_nav_zones
+        SAVED_ROUTE -> PresentationR.string.bottom_nav_saved
+        else -> PresentationR.string.bottom_nav_applications
+    }
 
 @Composable
 private fun AuthedBottomBar(

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
@@ -193,7 +193,6 @@ private fun AuthedContent(
  * `SettingsNavGraph.kt`, to keep every file under detekt's per-file
  * function-count budget.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun AuthedShell(
     appGraph: AppGraph,
@@ -204,79 +203,49 @@ private fun AuthedShell(
     val subscriptionTier by appGraph.authCoordinator.subscriptionTier.collectAsStateWithLifecycle()
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
-    val isTabRoute =
-        currentRoute == APPLICATIONS_ROUTE || currentRoute == WATCH_ZONES_ROUTE || currentRoute == SAVED_ROUTE
 
     Scaffold(
         modifier = modifier,
-        topBar = {
-            // Only the three bottom-nav tabs get this shared top bar (with the
-            // settings icon, per the epic's Material-native-idiom chapter);
-            // every other destination (detail/editor/settings screens) renders
-            // its own Scaffold + back-navigating TopAppBar internally.
-            if (isTabRoute || currentRoute == null) {
-                TopAppBar(
-                    title = { Text(stringResource(tabTitleRes(currentRoute))) },
-                    actions = {
-                        IconButton(onClick = { navController.navigate(SettingsDestination) }) {
-                            Icon(
-                                imageVector = Icons.Filled.Settings,
-                                contentDescription = stringResource(PresentationR.string.settings_content_description),
-                            )
-                        }
-                    },
-                )
-            }
-        },
-        bottomBar = {
-            AuthedBottomBar(currentRoute = currentRoute, navController = navController)
-        },
+        topBar = { AuthedTopBar(currentRoute = currentRoute, navController = navController) },
+        bottomBar = { AuthedBottomBar(currentRoute = currentRoute, navController = navController) },
     ) { contentPadding ->
-        NavHost(
+        AuthedNavHost(
+            appGraph = appGraph,
             navController = navController,
-            startDestination = Applications,
+            loginViewModel = loginViewModel,
+            subscriptionTier = subscriptionTier,
             modifier = Modifier.padding(contentPadding),
-        ) {
-            composable<Applications> { ApplicationsTab(appGraph = appGraph, navController = navController) }
-            composable<WatchZones> {
-                WatchZonesTab(appGraph = appGraph, subscriptionTier = subscriptionTier, navController = navController)
-            }
-            composable<Saved> { SavedTab(appGraph = appGraph, navController = navController) }
-            composable<WatchZoneEditorDestination> { entry ->
-                WatchZoneEditorDestinationContent(
-                    entry = entry,
-                    appGraph = appGraph,
-                    subscriptionTier = subscriptionTier,
-                    navController = navController,
-                )
-            }
-            composable<ZonePreferencesDestination> { entry ->
-                ZonePreferencesDestinationContent(
-                    entry = entry,
-                    appGraph = appGraph,
-                    subscriptionTier = subscriptionTier,
-                    navController = navController,
-                )
-            }
-            composable<ApplicationDetailDestination> { entry ->
-                ApplicationDetailDestinationContent(entry = entry, appGraph = appGraph, navController = navController)
-            }
-            composable<SettingsDestination> {
-                SettingsDestinationContent(
-                    appGraph = appGraph,
-                    subscriptionTier = subscriptionTier,
-                    loginViewModel = loginViewModel,
-                    navController = navController,
-                )
-            }
-            composable<NotificationPreferencesDestination> {
-                NotificationPreferencesDestinationContent(appGraph = appGraph, navController = navController)
-            }
-            composable<LegalDocumentDestination> { entry ->
-                LegalDocumentDestinationContent(entry = entry, appGraph = appGraph, navController = navController)
-            }
-        }
+        )
     }
+}
+
+/**
+ * Only the three bottom-nav tabs get this shared top bar (with the settings
+ * icon, per the epic's Material-native-idiom chapter); every other
+ * destination (detail/editor/settings screens) renders its own Scaffold +
+ * back-navigating `TopAppBar` internally.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun AuthedTopBar(
+    currentRoute: String?,
+    navController: NavHostController,
+) {
+    val isTabRoute =
+        currentRoute == APPLICATIONS_ROUTE || currentRoute == WATCH_ZONES_ROUTE || currentRoute == SAVED_ROUTE
+    if (!isTabRoute && currentRoute != null) return
+
+    TopAppBar(
+        title = { Text(stringResource(tabTitleRes(currentRoute))) },
+        actions = {
+            IconButton(onClick = { navController.navigate(SettingsDestination) }) {
+                Icon(
+                    imageVector = Icons.Filled.Settings,
+                    contentDescription = stringResource(PresentationR.string.settings_content_description),
+                )
+            }
+        },
+    )
 }
 
 /** The bottom-nav tabs each carry their own top-app-bar title; every other destination supplies its own inside its Screen. */
@@ -286,6 +255,56 @@ private fun tabTitleRes(route: String?): Int =
         SAVED_ROUTE -> PresentationR.string.bottom_nav_saved
         else -> PresentationR.string.bottom_nav_applications
     }
+
+@Composable
+private fun AuthedNavHost(
+    appGraph: AppGraph,
+    navController: NavHostController,
+    loginViewModel: LoginViewModel,
+    subscriptionTier: SubscriptionTier,
+    modifier: Modifier = Modifier,
+) {
+    NavHost(navController = navController, startDestination = Applications, modifier = modifier) {
+        composable<Applications> { ApplicationsTab(appGraph = appGraph, navController = navController) }
+        composable<WatchZones> {
+            WatchZonesTab(appGraph = appGraph, subscriptionTier = subscriptionTier, navController = navController)
+        }
+        composable<Saved> { SavedTab(appGraph = appGraph, navController = navController) }
+        composable<WatchZoneEditorDestination> { entry ->
+            WatchZoneEditorDestinationContent(
+                entry = entry,
+                appGraph = appGraph,
+                subscriptionTier = subscriptionTier,
+                navController = navController,
+            )
+        }
+        composable<ZonePreferencesDestination> { entry ->
+            ZonePreferencesDestinationContent(
+                entry = entry,
+                appGraph = appGraph,
+                subscriptionTier = subscriptionTier,
+                navController = navController,
+            )
+        }
+        composable<ApplicationDetailDestination> { entry ->
+            ApplicationDetailDestinationContent(entry = entry, appGraph = appGraph, navController = navController)
+        }
+        composable<SettingsDestination> {
+            SettingsDestinationContent(
+                appGraph = appGraph,
+                subscriptionTier = subscriptionTier,
+                loginViewModel = loginViewModel,
+                navController = navController,
+            )
+        }
+        composable<NotificationPreferencesDestination> {
+            NotificationPreferencesDestinationContent(appGraph = appGraph, navController = navController)
+        }
+        composable<LegalDocumentDestination> { entry ->
+            LegalDocumentDestinationContent(entry = entry, appGraph = appGraph, navController = navController)
+        }
+    }
+}
 
 @Composable
 private fun AuthedBottomBar(

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
@@ -204,7 +204,8 @@ private fun AuthedShell(
     val subscriptionTier by appGraph.authCoordinator.subscriptionTier.collectAsStateWithLifecycle()
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
-    val isTabRoute = currentRoute == APPLICATIONS_ROUTE || currentRoute == WATCH_ZONES_ROUTE || currentRoute == SAVED_ROUTE
+    val isTabRoute =
+        currentRoute == APPLICATIONS_ROUTE || currentRoute == WATCH_ZONES_ROUTE || currentRoute == SAVED_ROUTE
 
     Scaffold(
         modifier = modifier,

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
@@ -11,18 +11,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.Place
-import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -185,13 +181,15 @@ private fun AuthedContent(
 
 /**
  * The signed-in shell: bottom navigation (Applications, Zones, Saved)
- * wrapping the NavHost, with a top app bar carrying the settings icon every
- * bottom-nav-hosting screen gets (epic #770's Material-native-idiom
- * chapter). The watch-zone destinations' content lives in
- * `WatchZoneNavGraph.kt`, the applications-browsing destinations' in
- * `ApplicationNavGraph.kt`, and the settings-area destinations' in
- * `SettingsNavGraph.kt`, to keep every file under detekt's per-file
- * function-count budget.
+ * wrapping the NavHost. Each of the three bottom-nav tabs' own existing top
+ * app bar gets a settings action (epic #770's Material-native-idiom
+ * chapter) via [onSettingsClick] — not a second, wrapping top bar, which
+ * would double up with `ApplicationListScreen`/`WatchZoneListScreen`/
+ * `SavedListScreen`'s already-present `TopAppBar`s. The watch-zone
+ * destinations' content lives in `WatchZoneNavGraph.kt`, the
+ * applications-browsing destinations' in `ApplicationNavGraph.kt`, and the
+ * settings-area destinations' in `SettingsNavGraph.kt`, to keep every file
+ * under detekt's per-file function-count budget.
  */
 @Composable
 private fun AuthedShell(
@@ -206,7 +204,6 @@ private fun AuthedShell(
 
     Scaffold(
         modifier = modifier,
-        topBar = { AuthedTopBar(currentRoute = currentRoute, navController = navController) },
         bottomBar = { AuthedBottomBar(currentRoute = currentRoute, navController = navController) },
     ) { contentPadding ->
         AuthedNavHost(
@@ -219,43 +216,6 @@ private fun AuthedShell(
     }
 }
 
-/**
- * Only the three bottom-nav tabs get this shared top bar (with the settings
- * icon, per the epic's Material-native-idiom chapter); every other
- * destination (detail/editor/settings screens) renders its own Scaffold +
- * back-navigating `TopAppBar` internally.
- */
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun AuthedTopBar(
-    currentRoute: String?,
-    navController: NavHostController,
-) {
-    val isTabRoute =
-        currentRoute == APPLICATIONS_ROUTE || currentRoute == WATCH_ZONES_ROUTE || currentRoute == SAVED_ROUTE
-    if (!isTabRoute && currentRoute != null) return
-
-    TopAppBar(
-        title = { Text(stringResource(tabTitleRes(currentRoute))) },
-        actions = {
-            IconButton(onClick = { navController.navigate(SettingsDestination) }) {
-                Icon(
-                    imageVector = Icons.Filled.Settings,
-                    contentDescription = stringResource(PresentationR.string.settings_content_description),
-                )
-            }
-        },
-    )
-}
-
-/** The bottom-nav tabs each carry their own top-app-bar title; every other destination supplies its own inside its Screen. */
-private fun tabTitleRes(route: String?): Int =
-    when (route) {
-        WATCH_ZONES_ROUTE -> PresentationR.string.bottom_nav_zones
-        SAVED_ROUTE -> PresentationR.string.bottom_nav_saved
-        else -> PresentationR.string.bottom_nav_applications
-    }
-
 @Composable
 private fun AuthedNavHost(
     appGraph: AppGraph,
@@ -264,12 +224,22 @@ private fun AuthedNavHost(
     subscriptionTier: SubscriptionTier,
     modifier: Modifier = Modifier,
 ) {
+    val onSettingsClick: () -> Unit = { navController.navigate(SettingsDestination) }
     NavHost(navController = navController, startDestination = Applications, modifier = modifier) {
-        composable<Applications> { ApplicationsTab(appGraph = appGraph, navController = navController) }
-        composable<WatchZones> {
-            WatchZonesTab(appGraph = appGraph, subscriptionTier = subscriptionTier, navController = navController)
+        composable<Applications> {
+            ApplicationsTab(appGraph = appGraph, navController = navController, onSettingsClick = onSettingsClick)
         }
-        composable<Saved> { SavedTab(appGraph = appGraph, navController = navController) }
+        composable<WatchZones> {
+            WatchZonesTab(
+                appGraph = appGraph,
+                subscriptionTier = subscriptionTier,
+                navController = navController,
+                onSettingsClick = onSettingsClick,
+            )
+        }
+        composable<Saved> {
+            SavedTab(appGraph = appGraph, navController = navController, onSettingsClick = onSettingsClick)
+        }
         composable<WatchZoneEditorDestination> { entry ->
             WatchZoneEditorDestinationContent(
                 entry = entry,

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/PlayReviewRequester.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/PlayReviewRequester.kt
@@ -58,7 +58,11 @@ internal class PlayReviewRequester(
  * to opening the Play Store listing directly. Distinct from
  * [PlayReviewRequester], which must never surface failure.
  */
-@Suppress("TooGenericExceptionCaught")
+@Suppress("TooGenericExceptionCaught", "SwallowedException")
+// Deliberately broad and deliberately not re-thrown/logged: ANY failure here
+// (no foreground Activity, Play Services unavailable, no listing yet, ...)
+// falls back to the store listing — the specific cause doesn't change the
+// fallback, and there's nowhere useful to surface it from a settings-row tap.
 internal suspend fun requestReviewOrOpenStoreListing(
     context: Context,
     activityProvider: CurrentActivityProvider,

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/PlayReviewRequester.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/PlayReviewRequester.kt
@@ -1,0 +1,50 @@
+package uk.towncrierapp.app
+
+import com.google.android.gms.tasks.Task
+import com.google.android.play.core.review.ReviewInfo
+import com.google.android.play.core.review.ReviewManagerFactory
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import uk.towncrierapp.data.auth.CurrentActivityProvider
+import uk.towncrierapp.domain.reviewprompt.ReviewRequester
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+/**
+ * Best-effort Play In-App Review requester (GH #628 / #778): requests a
+ * review flow and launches it against the current foreground `Activity`.
+ * Silently no-ops on ANY failure — no foreground Activity, Play Services
+ * unavailable, no real Play Console listing yet, or the OS declining to
+ * show the dialog (Play's own API design never reports whether it actually
+ * appeared) — matching [ReviewRequester]'s best-effort contract, which the
+ * automatic review-prompt engine ([uk.towncrierapp.presentation.reviewprompt.ReviewPromptTracker])
+ * relies on. Constructed here (not `:presentation`) because it needs a real
+ * `Activity`, matching the `CurrentActivityProvider` precedent
+ * `Auth0AuthenticationService` already uses.
+ */
+internal class PlayReviewRequester(
+    private val activityProvider: CurrentActivityProvider,
+) : ReviewRequester {
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    // Deliberately broad: ANY failure in this best-effort flow degrades to a
+    // silent no-op (see the class doc above) — that IS the policy.
+    override suspend fun requestReview() {
+        try {
+            val activity = activityProvider.currentActivity() ?: return
+            val manager = ReviewManagerFactory.create(activity)
+            val reviewInfo: ReviewInfo = manager.requestReviewFlow().await()
+            manager.launchReviewFlow(activity, reviewInfo).await()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Best-effort — see the class doc above.
+        }
+    }
+}
+
+/** Minimal Task-to-suspend bridge — avoids depending on the exact review-ktx extension names. */
+private suspend fun <T> Task<T>.await(): T =
+    suspendCancellableCoroutine { continuation ->
+        addOnSuccessListener { result -> continuation.resume(result) }
+        addOnFailureListener { error -> continuation.resumeWithException(error) }
+    }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/PlayReviewRequester.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/PlayReviewRequester.kt
@@ -1,5 +1,8 @@
 package uk.towncrierapp.app
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import com.google.android.gms.tasks.Task
 import com.google.android.play.core.review.ReviewInfo
 import com.google.android.play.core.review.ReviewManagerFactory
@@ -11,16 +14,25 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 /**
- * Best-effort Play In-App Review requester (GH #628 / #778): requests a
- * review flow and launches it against the current foreground `Activity`.
- * Silently no-ops on ANY failure — no foreground Activity, Play Services
- * unavailable, no real Play Console listing yet, or the OS declining to
- * show the dialog (Play's own API design never reports whether it actually
- * appeared) — matching [ReviewRequester]'s best-effort contract, which the
- * automatic review-prompt engine ([uk.towncrierapp.presentation.reviewprompt.ReviewPromptTracker])
- * relies on. Constructed here (not `:presentation`) because it needs a real
- * `Activity`, matching the `CurrentActivityProvider` precedent
- * `Auth0AuthenticationService` already uses.
+ * The real Play Store listing — the "Rate the App" fallback
+ * ([requestReviewOrOpenStoreListing]) when the in-app review flow fails for
+ * any reason, pinned to the real package id (tc-4jjw / #778).
+ */
+internal const val PLAY_STORE_LISTING_URL = "https://play.google.com/store/apps/details?id=uk.towncrierapp.mobile"
+
+/**
+ * Best-effort Play In-App Review requester (GH #628 / #778) for the
+ * AUTOMATIC review-prompt engine
+ * ([uk.towncrierapp.presentation.reviewprompt.ReviewPromptTracker]): requests
+ * a review flow and launches it against the current foreground `Activity`.
+ * Silently no-ops on ANY failure — that's [ReviewRequester]'s own contract,
+ * since a background engagement-driven ask must never surface an error.
+ * Constructed here (not `:presentation`) because it needs a real `Activity`,
+ * matching the `CurrentActivityProvider` precedent `Auth0AuthenticationService`
+ * already uses. For the manual "Rate the App" settings row — which DOES need
+ * to observe failure to fall back to the store listing — see
+ * [requestReviewOrOpenStoreListing] instead; the two have deliberately
+ * different failure contracts, so they are not the same code path.
  */
 internal class PlayReviewRequester(
     private val activityProvider: CurrentActivityProvider,
@@ -30,16 +42,41 @@ internal class PlayReviewRequester(
     // silent no-op (see the class doc above) — that IS the policy.
     override suspend fun requestReview() {
         try {
-            val activity = activityProvider.currentActivity() ?: return
-            val manager = ReviewManagerFactory.create(activity)
-            val reviewInfo: ReviewInfo = manager.requestReviewFlow().await()
-            manager.launchReviewFlow(activity, reviewInfo).await()
+            requestReviewFlow(activityProvider)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             // Best-effort — see the class doc above.
         }
     }
+}
+
+/**
+ * The manual "Rate the App" settings row (tc-4jjw / #778): requests the Play
+ * In-App Review flow and, on ANY failure (no foreground Activity, Play
+ * Services unavailable, no real Play Console listing yet, ...), falls back
+ * to opening the Play Store listing directly. Distinct from
+ * [PlayReviewRequester], which must never surface failure.
+ */
+@Suppress("TooGenericExceptionCaught")
+internal suspend fun requestReviewOrOpenStoreListing(
+    context: Context,
+    activityProvider: CurrentActivityProvider,
+) {
+    try {
+        requestReviewFlow(activityProvider)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(PLAY_STORE_LISTING_URL)))
+    }
+}
+
+private suspend fun requestReviewFlow(activityProvider: CurrentActivityProvider) {
+    val activity = activityProvider.currentActivity() ?: error("no foreground activity to present the review flow")
+    val manager = ReviewManagerFactory.create(activity)
+    val reviewInfo: ReviewInfo = manager.requestReviewFlow().await()
+    manager.launchReviewFlow(activity, reviewInfo).await()
 }
 
 /** Minimal Task-to-suspend bridge — avoids depending on the exact review-ktx extension names. */

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/SettingsNavGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/SettingsNavGraph.kt
@@ -1,0 +1,125 @@
+// SettingsNavGraph.kt is the bead-mandated file name for every
+// settings-area nav destination + composable (mirrors WatchZoneNavGraph.kt /
+// ApplicationNavGraph.kt) — several top-level declarations below, not a
+// single one, same pattern as its siblings.
+@file:Suppress("MatchingDeclarationName")
+
+package uk.towncrierapp.app
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavHostController
+import androidx.navigation.toRoute
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import uk.towncrierapp.domain.legal.LegalDocumentType
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.presentation.features.legal.LegalDocumentRoute
+import uk.towncrierapp.presentation.features.legal.LegalDocumentViewModel
+import uk.towncrierapp.presentation.features.login.LoginViewModel
+import uk.towncrierapp.presentation.features.notificationprefs.NotificationPreferencesRoute
+import uk.towncrierapp.presentation.features.notificationprefs.NotificationPreferencesViewModel
+import uk.towncrierapp.presentation.features.settings.SettingsRoute
+import uk.towncrierapp.presentation.features.settings.SettingsViewModel
+
+/** The Settings destination — reachable from the settings icon on every bottom-nav-hosting screen. */
+@Serializable
+internal data object SettingsDestination
+
+/** The in-app notification-preferences destination, reached from a Settings row. */
+@Serializable
+internal data object NotificationPreferencesDestination
+
+/**
+ * A bundled legal document (privacy policy or terms of service), reached
+ * from a Settings row. [documentType] carries [LegalDocumentType]'s enum
+ * name — type-safe Navigation routes only support serializable primitives
+ * (same pattern as `ApplicationDetailDestination`'s flattened fields).
+ */
+@Serializable
+internal data class LegalDocumentDestination(
+    val documentType: String,
+)
+
+private fun LegalDocumentType.toDestination() = LegalDocumentDestination(documentType = name)
+
+private fun LegalDocumentDestination.toType(): LegalDocumentType = LegalDocumentType.valueOf(documentType)
+
+/** The Settings screen: account, appearance, notification prefs entry, subscription, legal, export, sign-out/deletion, about. */
+@Composable
+internal fun SettingsDestinationContent(
+    appGraph: AppGraph,
+    subscriptionTier: SubscriptionTier,
+    loginViewModel: LoginViewModel,
+    navController: NavHostController,
+) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    val settingsViewModel: SettingsViewModel =
+        viewModel(
+            factory =
+                viewModelFactory {
+                    initializer {
+                        SettingsViewModel(
+                            authenticationService = appGraph.authenticationService,
+                            userProfileRepository = appGraph.userProfileRepository,
+                            appearanceCoordinator = appGraph.appearanceCoordinator,
+                            tier = subscriptionTier,
+                            appVersion = appGraph.currentVersion,
+                            deviceTokenRepository = appGraph.deviceTokenRepository,
+                            // Resets the shell's own auth state WITHOUT a second
+                            // AuthenticationService.logout() call — see
+                            // LoginViewModel.markSignedOut's doc (tc-4jjw).
+                            onSignedOut = loginViewModel::markSignedOut,
+                        )
+                    }
+                },
+        )
+    SettingsRoute(
+        viewModel = settingsViewModel,
+        onBack = navController::popBackStack,
+        onNotificationPreferencesClick = { navController.navigate(NotificationPreferencesDestination) },
+        onPrivacyPolicyClick = { navController.navigate(LegalDocumentType.PRIVACY_POLICY.toDestination()) },
+        onTermsOfServiceClick = { navController.navigate(LegalDocumentType.TERMS_OF_SERVICE.toDestination()) },
+        onRateAppClick = {
+            coroutineScope.launch { requestReviewOrOpenStoreListing(context, appGraph.activityProvider) }
+        },
+    )
+}
+
+@Composable
+internal fun NotificationPreferencesDestinationContent(
+    appGraph: AppGraph,
+    navController: NavHostController,
+) {
+    val viewModel: NotificationPreferencesViewModel =
+        viewModel(
+            factory =
+                viewModelFactory { initializer { NotificationPreferencesViewModel(appGraph.userProfileRepository) } },
+        )
+    LaunchedEffect(viewModel) { viewModel.load() }
+    NotificationPreferencesRoute(viewModel = viewModel, onBack = navController::popBackStack)
+}
+
+@Composable
+internal fun LegalDocumentDestinationContent(
+    entry: NavBackStackEntry,
+    appGraph: AppGraph,
+    navController: NavHostController,
+) {
+    val route = entry.toRoute<LegalDocumentDestination>()
+    val viewModel: LegalDocumentViewModel =
+        viewModel(
+            factory =
+                viewModelFactory {
+                    initializer { LegalDocumentViewModel(appGraph.legalDocumentRepository, route.toType()) }
+                },
+        )
+    LegalDocumentRoute(viewModel = viewModel, onBack = navController::popBackStack)
+}

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/SettingsNavGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/SettingsNavGraph.kt
@@ -26,6 +26,7 @@ import uk.towncrierapp.presentation.features.login.LoginViewModel
 import uk.towncrierapp.presentation.features.notificationprefs.NotificationPreferencesRoute
 import uk.towncrierapp.presentation.features.notificationprefs.NotificationPreferencesViewModel
 import uk.towncrierapp.presentation.features.settings.SettingsRoute
+import uk.towncrierapp.presentation.features.settings.SettingsSignOutSupport
 import uk.towncrierapp.presentation.features.settings.SettingsViewModel
 
 /** The Settings destination — reachable from the settings icon on every bottom-nav-hosting screen. */
@@ -72,11 +73,14 @@ internal fun SettingsDestinationContent(
                             appearanceCoordinator = appGraph.appearanceCoordinator,
                             tier = subscriptionTier,
                             appVersion = appGraph.currentVersion,
-                            deviceTokenRepository = appGraph.deviceTokenRepository,
-                            // Resets the shell's own auth state WITHOUT a second
-                            // AuthenticationService.logout() call — see
-                            // LoginViewModel.markSignedOut's doc (tc-4jjw).
-                            onSignedOut = loginViewModel::markSignedOut,
+                            signOutSupport =
+                                SettingsSignOutSupport(
+                                    deviceTokenRepository = appGraph.deviceTokenRepository,
+                                    // Resets the shell's own auth state WITHOUT a second
+                                    // AuthenticationService.logout() call — see
+                                    // LoginViewModel.markSignedOut's doc (tc-4jjw).
+                                    onSignedOut = loginViewModel::markSignedOut,
+                                ),
                         )
                     }
                 },

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
@@ -69,9 +69,12 @@ public class TownCrierApplication : Application() {
                         tierCache = tierCache,
                         applicationListPreferencesStore = applicationListPreferencesStore,
                         onboardingRepository = onboardingRepository,
-                        appearanceStore = appearanceStore,
-                        reviewPromptStore = reviewPromptStore,
-                        legalDocumentAssetReader = legalDocumentAssetReader,
+                        settingsLeaves =
+                            SettingsLeaves(
+                                appearanceStore = appearanceStore,
+                                reviewPromptStore = reviewPromptStore,
+                                legalDocumentAssetReader = legalDocumentAssetReader,
+                            ),
                     ),
                 currentVersion = BuildConfig.VERSION_NAME,
                 options = AppGraphOptions(enableDebugLogging = BuildConfig.DEBUG),

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/TownCrierApplication.kt
@@ -10,7 +10,10 @@ import com.auth0.android.authentication.storage.SecureCredentialsManager
 import com.auth0.android.authentication.storage.SharedPreferencesStorage
 import uk.towncrierapp.data.applications.DataStoreApplicationListPreferencesStore
 import uk.towncrierapp.data.auth.SecureCredentialsManagerStore
+import uk.towncrierapp.data.legal.LegalDocumentAssetReader
 import uk.towncrierapp.data.onboarding.DataStoreOnboardingRepository
+import uk.towncrierapp.data.reviewprompt.DataStoreReviewPromptStore
+import uk.towncrierapp.data.settings.DataStoreAppearanceStore
 import uk.towncrierapp.data.subscriptions.DataStoreSubscriptionTierCache
 import uk.towncrierapp.mobile.BuildConfig
 
@@ -49,6 +52,10 @@ public class TownCrierApplication : Application() {
         // file; a second file per feature isn't warranted (GH#775 / tc-7ttz).
         val applicationListPreferencesStore = DataStoreApplicationListPreferencesStore(tierPreferencesDataStore)
         val onboardingRepository = DataStoreOnboardingRepository(tierPreferencesDataStore)
+        val appearanceStore = DataStoreAppearanceStore(tierPreferencesDataStore)
+        val reviewPromptStore = DataStoreReviewPromptStore(tierPreferencesDataStore)
+        val legalDocumentAssetReader =
+            LegalDocumentAssetReader { assetPath -> assets.open(assetPath).bufferedReader().use { it.readText() } }
 
         appGraph =
             AppGraph(
@@ -57,11 +64,14 @@ public class TownCrierApplication : Application() {
                 auth0Tenant = Auth0Tenant(clientId = AUTH0_CLIENT_ID, domain = AUTH0_DOMAIN),
                 androidLeaves =
                     AndroidLeaves(
-                        credentialsStore,
-                        activityTracker,
-                        tierCache,
-                        applicationListPreferencesStore,
-                        onboardingRepository,
+                        credentialsStore = credentialsStore,
+                        activityProvider = activityTracker,
+                        tierCache = tierCache,
+                        applicationListPreferencesStore = applicationListPreferencesStore,
+                        onboardingRepository = onboardingRepository,
+                        appearanceStore = appearanceStore,
+                        reviewPromptStore = reviewPromptStore,
+                        legalDocumentAssetReader = legalDocumentAssetReader,
                     ),
                 currentVersion = BuildConfig.VERSION_NAME,
                 options = AppGraphOptions(enableDebugLogging = BuildConfig.DEBUG),

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/WatchZoneNavGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/WatchZoneNavGraph.kt
@@ -84,6 +84,7 @@ internal fun WatchZonesTab(
     appGraph: AppGraph,
     subscriptionTier: SubscriptionTier,
     navController: NavHostController,
+    onSettingsClick: () -> Unit,
 ) {
     val listViewModel: WatchZoneListViewModel =
         key(subscriptionTier) {
@@ -107,6 +108,7 @@ internal fun WatchZonesTab(
             navController.navigate(ZonePreferencesDestination(zoneId = zone.id.value, zoneName = zone.name))
         },
         onAddZone = { navController.navigate(WatchZoneEditorDestination()) },
+        onSettingsClick = onSettingsClick,
     )
 }
 

--- a/mobile/android/app/src/main/res/xml/file_paths.xml
+++ b/mobile/android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- FileProvider path spec for the GDPR data-export share sheet (tc-4jjw / #778).
+     Matches SettingsScreen.kt's `File(context.cacheDir, "exports")` write location. -->
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="exports" path="exports/" />
+</paths>

--- a/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
+++ b/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
@@ -45,7 +45,12 @@ class AppGraphSmokeTest {
             onboardingRepository = FakeOnboardingRepository(),
             appearanceStore = FakeAppearanceStore(),
             reviewPromptStore = FakeReviewPromptStore(),
-            legalDocumentAssetReader = LegalDocumentAssetReader { error("not used in the composition-root smoke test") },
+            legalDocumentAssetReader =
+                LegalDocumentAssetReader {
+                    error(
+                        "not used in the composition-root smoke test",
+                    )
+                },
         )
 
     @Test

--- a/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
+++ b/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
@@ -5,8 +5,11 @@ import okhttp3.Call
 import org.junit.jupiter.api.Test
 import uk.towncrierapp.data.auth.CredentialsStore
 import uk.towncrierapp.data.auth.CurrentActivityProvider
+import uk.towncrierapp.data.legal.LegalDocumentAssetReader
 import uk.towncrierapp.domain.applications.FakeApplicationListPreferencesStore
 import uk.towncrierapp.domain.onboarding.FakeOnboardingRepository
+import uk.towncrierapp.domain.reviewprompt.FakeReviewPromptStore
+import uk.towncrierapp.domain.settings.FakeAppearanceStore
 import uk.towncrierapp.domain.subscriptions.FakeSubscriptionTierCache
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -33,20 +36,25 @@ class AppGraphSmokeTest {
 
     private val noOpCallFactory = Call.Factory { error("not used in the composition-root smoke test") }
 
+    private fun fakeAndroidLeaves() =
+        AndroidLeaves(
+            credentialsStore = NoOpCredentialsStore,
+            activityProvider = CurrentActivityProvider { null },
+            tierCache = FakeSubscriptionTierCache(),
+            applicationListPreferencesStore = FakeApplicationListPreferencesStore(),
+            onboardingRepository = FakeOnboardingRepository(),
+            appearanceStore = FakeAppearanceStore(),
+            reviewPromptStore = FakeReviewPromptStore(),
+            legalDocumentAssetReader = LegalDocumentAssetReader { error("not used in the composition-root smoke test") },
+        )
+
     @Test
     fun `constructs the composition root without throwing`() {
         val graph =
             AppGraph(
                 baseUrl = "https://api-dev.towncrierapp.uk",
                 auth0Tenant = Auth0Tenant(clientId = "client-id", domain = "towncrierapp.uk.auth0.com"),
-                androidLeaves =
-                    AndroidLeaves(
-                        credentialsStore = NoOpCredentialsStore,
-                        activityProvider = CurrentActivityProvider { null },
-                        tierCache = FakeSubscriptionTierCache(),
-                        applicationListPreferencesStore = FakeApplicationListPreferencesStore(),
-                        onboardingRepository = FakeOnboardingRepository(),
-                    ),
+                androidLeaves = fakeAndroidLeaves(),
                 currentVersion = "0.1.0",
                 options = AppGraphOptions(callFactory = noOpCallFactory),
             )
@@ -66,6 +74,23 @@ class AppGraphSmokeTest {
         assertNotNull(graph.notificationStateRepository)
         assertNotNull(graph.applicationListPreferencesStore)
         assertNotNull(graph.onboardingRepository)
+        assertNotNull(graph.appearanceCoordinator)
+        assertNotNull(graph.legalDocumentRepository)
+        assertNotNull(graph.reviewPromptTracker)
+    }
+
+    @Test
+    fun `deviceTokenRepository is null until 777 lands a real implementation`() {
+        val graph =
+            AppGraph(
+                baseUrl = "https://api-dev.towncrierapp.uk",
+                auth0Tenant = Auth0Tenant(clientId = "client-id", domain = "towncrierapp.uk.auth0.com"),
+                androidLeaves = fakeAndroidLeaves(),
+                currentVersion = "0.1.0",
+                options = AppGraphOptions(callFactory = noOpCallFactory),
+            )
+
+        assertEquals(null, graph.deviceTokenRepository)
     }
 
     @Test
@@ -74,14 +99,7 @@ class AppGraphSmokeTest {
             AppGraph(
                 baseUrl = "https://api-dev.towncrierapp.uk",
                 auth0Tenant = Auth0Tenant(clientId = "client-id", domain = "towncrierapp.uk.auth0.com"),
-                androidLeaves =
-                    AndroidLeaves(
-                        credentialsStore = NoOpCredentialsStore,
-                        activityProvider = CurrentActivityProvider { null },
-                        tierCache = FakeSubscriptionTierCache(),
-                        applicationListPreferencesStore = FakeApplicationListPreferencesStore(),
-                        onboardingRepository = FakeOnboardingRepository(),
-                    ),
+                androidLeaves = fakeAndroidLeaves(),
                 currentVersion = "0.1.0",
                 options = AppGraphOptions(callFactory = noOpCallFactory),
             )
@@ -96,14 +114,7 @@ class AppGraphSmokeTest {
                 baseUrl = "http://10.0.2.2:8080",
                 authAudience = "https://api-dev.towncrierapp.uk",
                 auth0Tenant = Auth0Tenant(clientId = "client-id", domain = "towncrierapp.uk.auth0.com"),
-                androidLeaves =
-                    AndroidLeaves(
-                        credentialsStore = NoOpCredentialsStore,
-                        activityProvider = CurrentActivityProvider { null },
-                        tierCache = FakeSubscriptionTierCache(),
-                        applicationListPreferencesStore = FakeApplicationListPreferencesStore(),
-                        onboardingRepository = FakeOnboardingRepository(),
-                    ),
+                androidLeaves = fakeAndroidLeaves(),
                 currentVersion = "0.1.0",
                 options = AppGraphOptions(callFactory = noOpCallFactory),
             )

--- a/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
+++ b/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
@@ -43,14 +43,13 @@ class AppGraphSmokeTest {
             tierCache = FakeSubscriptionTierCache(),
             applicationListPreferencesStore = FakeApplicationListPreferencesStore(),
             onboardingRepository = FakeOnboardingRepository(),
-            appearanceStore = FakeAppearanceStore(),
-            reviewPromptStore = FakeReviewPromptStore(),
-            legalDocumentAssetReader =
-                LegalDocumentAssetReader {
-                    error(
-                        "not used in the composition-root smoke test",
-                    )
-                },
+            settingsLeaves =
+                SettingsLeaves(
+                    appearanceStore = FakeAppearanceStore(),
+                    reviewPromptStore = FakeReviewPromptStore(),
+                    legalDocumentAssetReader =
+                        LegalDocumentAssetReader { error("not used in the composition-root smoke test") },
+                ),
         )
 
     @Test

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/legal/LegalDocumentAssetReader.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/legal/LegalDocumentAssetReader.kt
@@ -1,0 +1,12 @@
+package uk.towncrierapp.data.legal
+
+/**
+ * Reads a bundled asset's raw text by path (e.g. `"legal/privacy.json"`).
+ * The testable seam over `AssetManager.open` — no Android framework or
+ * Robolectric needed to fake it (android-coding-standards skill: no
+ * Robolectric). The real implementation wraps `Context.getAssets()` and is
+ * constructed at `:app`'s composition root.
+ */
+public fun interface LegalDocumentAssetReader {
+    public fun read(assetPath: String): String
+}

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/legal/LegalDocumentLoader.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/legal/LegalDocumentLoader.kt
@@ -1,0 +1,62 @@
+package uk.towncrierapp.data.legal
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import uk.towncrierapp.domain.legal.LegalDocument
+import uk.towncrierapp.domain.legal.LegalDocumentRepository
+import uk.towncrierapp.domain.legal.LegalDocumentSection
+import uk.towncrierapp.domain.legal.LegalDocumentType
+import java.time.LocalDate
+
+/**
+ * `LegalDocumentRepository` over the bundled `legal/{privacy,terms}.json`
+ * assets. iOS NEVER fetches the legal document endpoints at runtime and
+ * neither does Android (epic #770 pre-resolved decision): offline, no loading state,
+ * byte-mirrored from `api-go/internal/legal/resources/` by
+ * `scripts/sync-legal.sh`, CI-enforced by `scripts/check-legal-drift.sh`.
+ * Port of iOS `LegalDocumentViewModel`'s bundle-decoding half.
+ */
+public class LegalDocumentLoader(
+    private val assetReader: LegalDocumentAssetReader,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+    private val io: CoroutineDispatcher = Dispatchers.IO,
+) : LegalDocumentRepository {
+    override suspend fun document(type: LegalDocumentType): LegalDocument =
+        withContext(io) {
+            val raw = assetReader.read("legal/${type.assetFileName()}")
+            json.decodeFromString(LegalDocumentJsonDto.serializer(), raw).toDomain()
+        }
+}
+
+private fun LegalDocumentType.assetFileName(): String =
+    when (this) {
+        LegalDocumentType.PRIVACY_POLICY -> "privacy.json"
+        LegalDocumentType.TERMS_OF_SERVICE -> "terms.json"
+    }
+
+// MARK: - JSON decoding — {title, lastUpdated: "YYYY-MM-DD", sections:[{heading, body}]}.
+// `documentType` is present in the bundled asset but not part of this shape;
+// ignoreUnknownKeys absorbs it.
+
+@Serializable
+internal data class LegalDocumentJsonDto(
+    val title: String,
+    val lastUpdated: String,
+    val sections: List<LegalDocumentSectionDto>,
+)
+
+@Serializable
+internal data class LegalDocumentSectionDto(
+    val heading: String,
+    val body: String,
+)
+
+internal fun LegalDocumentJsonDto.toDomain(): LegalDocument =
+    LegalDocument(
+        title = title,
+        lastUpdated = LocalDate.parse(lastUpdated),
+        sections = sections.map { LegalDocumentSection(heading = it.heading, body = it.body) },
+    )

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/profile/ApiUserProfileRepository.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/profile/ApiUserProfileRepository.kt
@@ -1,25 +1,71 @@
 package uk.towncrierapp.data.profile
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import uk.towncrierapp.data.api.ApiClient
 import uk.towncrierapp.data.api.ApiEndpoint
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.profile.DigestDay
 import uk.towncrierapp.domain.profile.ServerProfile
+import uk.towncrierapp.domain.profile.UserPreferences
 import uk.towncrierapp.domain.profile.UserProfileRepository
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
 
-/** `UserProfileRepository` over the Town Crier API — `POST /v1/me` (ensure-profile) only; fetch/update/delete/export land with #778. */
+/**
+ * `UserProfileRepository` over the Town Crier API (epic #770 / #778):
+ * `POST`/`GET`/`PATCH`/`DELETE /v1/me` + `GET /v1/me/data`. Port of iOS
+ * `APIUserProfileRepository`.
+ */
 public class ApiUserProfileRepository(
     private val apiClient: ApiClient,
+    private val json: Json = Json { ignoreUnknownKeys = true },
 ) : UserProfileRepository {
     override suspend fun ensureProfile(): ServerProfile =
         apiClient.request(ApiEndpoint.post("/v1/me"), ServerProfileDto.serializer()).toDomain()
+
+    @Suppress("SwallowedException")
+    // A 404 means "no profile yet" — a routine, expected outcome for this
+    // port (mirrors iOS `APIUserProfileRepository.fetch()`), not a failure
+    // the caller needs the original exception for.
+    override suspend fun fetchProfile(): ServerProfile? =
+        try {
+            apiClient.request(ApiEndpoint.get("/v1/me"), ServerProfileDto.serializer()).toDomain()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: DomainError.NotFound) {
+            null
+        }
+
+    override suspend fun updatePreferences(preferences: UserPreferences): ServerProfile {
+        val body = json.encodeToString(UpdateProfileRequestDto.serializer(), preferences.toRequestDto())
+        return apiClient.request(ApiEndpoint.patch("/v1/me", body = body), ServerProfileDto.serializer()).toDomain()
+    }
+
+    override suspend fun deleteAccount() {
+        apiClient.requestBytes(ApiEndpoint.delete("/v1/me"))
+    }
+
+    override suspend fun exportData(): ByteArray = apiClient.requestBytes(ApiEndpoint.get("/v1/me/data"))
 }
 
+// MARK: - DTOs
+
+/**
+ * Shared by `POST`/`GET`/`PATCH /v1/me`: `POST`'s response carries only
+ * `userId`/`pushEnabled`/`tier` — the remaining four fields fall back to
+ * their declared defaults (the server's own `DefaultPreferences`), matching
+ * iOS's `decodeIfPresent`-with-fallback DTO.
+ */
 @Serializable
 internal data class ServerProfileDto(
     val userId: String,
     val pushEnabled: Boolean,
     val tier: String,
+    val digestDay: String = "Monday",
+    val emailDigestEnabled: Boolean = true,
+    val savedDecisionPush: Boolean = true,
+    val savedDecisionEmail: Boolean = true,
 )
 
 internal fun ServerProfileDto.toDomain(): ServerProfile =
@@ -29,4 +75,27 @@ internal fun ServerProfileDto.toDomain(): ServerProfile =
         // Falls back to Free on an unrecognised wire value rather than crashing —
         // the server is authoritative and may add tiers this build doesn't know yet.
         tier = SubscriptionTier.fromWireValue(tier) ?: SubscriptionTier.FREE,
+        digestDay = DigestDay.fromWireValue(digestDay) ?: DigestDay.MONDAY,
+        emailDigestEnabled = emailDigestEnabled,
+        savedDecisionPush = savedDecisionPush,
+        savedDecisionEmail = savedDecisionEmail,
+    )
+
+/** The `PATCH /v1/me` body — always all five fields (epic #770 pre-resolved decision: never a partial update). */
+@Serializable
+internal data class UpdateProfileRequestDto(
+    val pushEnabled: Boolean,
+    val digestDay: String,
+    val emailDigestEnabled: Boolean,
+    val savedDecisionPush: Boolean,
+    val savedDecisionEmail: Boolean,
+)
+
+internal fun UserPreferences.toRequestDto(): UpdateProfileRequestDto =
+    UpdateProfileRequestDto(
+        pushEnabled = pushEnabled,
+        digestDay = digestDay.wireValue,
+        emailDigestEnabled = emailDigestEnabled,
+        savedDecisionPush = savedDecisionPush,
+        savedDecisionEmail = savedDecisionEmail,
     )

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/reviewprompt/DataStoreReviewPromptStore.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/reviewprompt/DataStoreReviewPromptStore.kt
@@ -1,0 +1,86 @@
+package uk.towncrierapp.data.reviewprompt
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import uk.towncrierapp.domain.reviewprompt.ReviewPromptState
+import uk.towncrierapp.domain.reviewprompt.ReviewPromptStore
+import java.time.Instant
+
+// Key names are this feature's own device-local namespace (GH #628) — no
+// cross-platform naming constraint applies since nothing else reads them.
+private val FIRST_LAUNCH_DATE_KEY = longPreferencesKey("reviewPrompt.firstLaunchDate")
+private val ENGAGEMENT_SCORE_KEY = intPreferencesKey("reviewPrompt.engagementScore")
+private val SAVE_COUNT_KEY = intPreferencesKey("reviewPrompt.saveCount")
+private val LAST_ACTIVE_DAY_KEY_KEY = stringPreferencesKey("reviewPrompt.lastActiveDayKey")
+private val DISTINCT_ACTIVE_DAYS_KEY = intPreferencesKey("reviewPrompt.distinctActiveDays")
+private val LAST_PROMPT_DATE_KEY = longPreferencesKey("reviewPrompt.lastPromptDate")
+private val PROMPT_TIMESTAMPS_KEY = stringPreferencesKey("reviewPrompt.promptTimestamps")
+private val HAS_RECORDED_UPGRADE_KEY = booleanPreferencesKey("reviewPrompt.hasRecordedUpgrade")
+
+private const val TIMESTAMP_SEPARATOR = ","
+
+/**
+ * DataStore Preferences-backed [ReviewPromptStore] (GH #628). Every field is
+ * device-local; nothing here is sent to a server or used for analytics.
+ * Dates are stored as epoch-second `Long`s and the rolling prompt-timestamp
+ * list as a delimited string. Port of iOS `UserDefaultsReviewPromptStore`.
+ */
+public class DataStoreReviewPromptStore(
+    private val dataStore: DataStore<Preferences>,
+) : ReviewPromptStore {
+    override suspend fun load(): ReviewPromptState =
+        dataStore.data
+            .map { preferences ->
+                ReviewPromptState(
+                    firstLaunchDate = preferences[FIRST_LAUNCH_DATE_KEY]?.let(Instant::ofEpochSecond),
+                    engagementScore = preferences[ENGAGEMENT_SCORE_KEY] ?: 0,
+                    saveCount = preferences[SAVE_COUNT_KEY] ?: 0,
+                    lastActiveDayKey = preferences[LAST_ACTIVE_DAY_KEY_KEY],
+                    distinctActiveDays = preferences[DISTINCT_ACTIVE_DAYS_KEY] ?: 0,
+                    lastPromptDate = preferences[LAST_PROMPT_DATE_KEY]?.let(Instant::ofEpochSecond),
+                    promptTimestamps = preferences[PROMPT_TIMESTAMPS_KEY].toTimestamps(),
+                    hasRecordedUpgrade = preferences[HAS_RECORDED_UPGRADE_KEY] ?: false,
+                )
+            }.first()
+
+    override suspend fun save(state: ReviewPromptState) {
+        dataStore.edit { preferences ->
+            setOrRemove(preferences, FIRST_LAUNCH_DATE_KEY, state.firstLaunchDate?.epochSecond)
+            preferences[ENGAGEMENT_SCORE_KEY] = state.engagementScore
+            preferences[SAVE_COUNT_KEY] = state.saveCount
+            setOrRemove(preferences, LAST_ACTIVE_DAY_KEY_KEY, state.lastActiveDayKey)
+            preferences[DISTINCT_ACTIVE_DAYS_KEY] = state.distinctActiveDays
+            setOrRemove(preferences, LAST_PROMPT_DATE_KEY, state.lastPromptDate?.epochSecond)
+            preferences[PROMPT_TIMESTAMPS_KEY] =
+                state.promptTimestamps.joinToString(TIMESTAMP_SEPARATOR) { it.epochSecond.toString() }
+            preferences[HAS_RECORDED_UPGRADE_KEY] = state.hasRecordedUpgrade
+        }
+    }
+}
+
+private fun <T : Any> setOrRemove(
+    preferences: MutablePreferences,
+    key: Preferences.Key<T>,
+    value: T?,
+) {
+    if (value != null) {
+        preferences[key] = value
+    } else {
+        preferences.remove(key)
+    }
+}
+
+private fun String?.toTimestamps(): List<Instant> =
+    if (this.isNullOrEmpty()) {
+        emptyList()
+    } else {
+        split(TIMESTAMP_SEPARATOR).map { Instant.ofEpochSecond(it.toLong()) }
+    }

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/settings/DataStoreAppearanceStore.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/settings/DataStoreAppearanceStore.kt
@@ -1,0 +1,28 @@
+package uk.towncrierapp.data.settings
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import uk.towncrierapp.domain.settings.AppearancePreference
+import uk.towncrierapp.domain.settings.AppearanceStore
+
+// Key name reused verbatim from iOS's local `appearanceMode` (epic #770
+// pre-resolved decision) — cross-platform naming consistency.
+private val APPEARANCE_MODE_KEY = stringPreferencesKey("appearanceMode")
+
+/** DataStore Preferences-backed [AppearanceStore]. Port of iOS's `UserDefaults`-backed `appearanceMode` latch. */
+public class DataStoreAppearanceStore(
+    private val dataStore: DataStore<Preferences>,
+) : AppearanceStore {
+    override suspend fun read(): AppearancePreference? =
+        dataStore.data
+            .map { preferences -> preferences[APPEARANCE_MODE_KEY]?.let(AppearancePreference::fromWireValue) }
+            .first()
+
+    override suspend fun write(preference: AppearancePreference) {
+        dataStore.edit { preferences -> preferences[APPEARANCE_MODE_KEY] = preference.wireValue }
+    }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/legal/LegalDocumentLoaderTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/legal/LegalDocumentLoaderTest.kt
@@ -1,0 +1,81 @@
+package uk.towncrierapp.data.legal
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uk.towncrierapp.domain.legal.LegalDocumentType
+import java.time.LocalDate
+import kotlin.test.assertEquals
+
+private const val PRIVACY_JSON =
+    """
+    {
+      "documentType": "privacy",
+      "title": "Privacy Policy",
+      "lastUpdated": "2026-07-01",
+      "sections": [
+        {"heading": "Who We Are", "body": "Town Crier is operated by Ivo and the Bea Ltd."},
+        {"heading": "What We Collect", "body": "We keep the collection small."}
+      ]
+    }
+    """
+
+private const val TERMS_JSON =
+    """
+    {
+      "documentType": "terms",
+      "title": "Terms of Service",
+      "lastUpdated": "2026-03-16",
+      "sections": [
+        {"heading": "Acceptance of Terms", "body": "By using Town Crier, you agree to these Terms of Service."}
+      ]
+    }
+    """
+
+/**
+ * `LegalDocumentLoader` reads the bundled `legal/{privacy,terms}.json`
+ * assets ({@code {title, lastUpdated: "YYYY-MM-DD", sections:[{heading,
+ * body}]}}) via an injected [LegalDocumentAssetReader] — no Robolectric
+ * needed to fake `AssetManager` (android-coding-standards skill: no
+ * Robolectric).
+ */
+class LegalDocumentLoaderTest {
+    private fun readerFor(vararg entries: Pair<String, String>): LegalDocumentAssetReader {
+        val files = entries.toMap()
+        return LegalDocumentAssetReader { fileName -> files.getValue(fileName) }
+    }
+
+    @Test
+    fun `document PrivacyPolicy reads legal privacy json and parses every field`() =
+        runTest {
+            val sut = LegalDocumentLoader(readerFor("legal/privacy.json" to PRIVACY_JSON))
+
+            val document = sut.document(LegalDocumentType.PRIVACY_POLICY)
+
+            assertEquals("Privacy Policy", document.title)
+            assertEquals(LocalDate.of(2026, 7, 1), document.lastUpdated)
+            assertEquals(2, document.sections.size)
+            assertEquals("Who We Are", document.sections[0].heading)
+            assertEquals("Town Crier is operated by Ivo and the Bea Ltd.", document.sections[0].body)
+        }
+
+    @Test
+    fun `document TermsOfService reads legal terms json`() =
+        runTest {
+            val sut = LegalDocumentLoader(readerFor("legal/terms.json" to TERMS_JSON))
+
+            val document = sut.document(LegalDocumentType.TERMS_OF_SERVICE)
+
+            assertEquals("Terms of Service", document.title)
+            assertEquals(LocalDate.of(2026, 3, 16), document.lastUpdated)
+            assertEquals(1, document.sections.size)
+        }
+
+    @Test
+    fun `an unknown top-level field in the bundled JSON is ignored rather than crashing`() =
+        runTest {
+            // documentType is present in the bundled asset but not part of the domain shape.
+            val sut = LegalDocumentLoader(readerFor("legal/privacy.json" to PRIVACY_JSON))
+
+            sut.document(LegalDocumentType.PRIVACY_POLICY)
+        }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/profile/ApiUserProfileRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/profile/ApiUserProfileRepositoryTest.kt
@@ -1,24 +1,43 @@
 package uk.towncrierapp.data.profile
 
 import kotlinx.coroutines.test.runTest
+import okhttp3.Request
+import okio.Buffer
 import org.junit.jupiter.api.Test
 import uk.towncrierapp.data.api.ApiClient
 import uk.towncrierapp.data.api.FakeHttpTransport
+import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.domain.auth.FakeAuthenticationService
+import uk.towncrierapp.domain.profile.DigestDay
 import uk.towncrierapp.domain.profile.ServerProfile
+import uk.towncrierapp.domain.profile.UserPreferences
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
-/** `POST /v1/me` (no body, idempotent) — ensures the server profile and returns it (epic #770). */
+/** Reads a request's JSON body back out for assertions. */
+private fun Request.bodyAsString(): String {
+    val buffer = Buffer()
+    body?.writeTo(buffer)
+    return buffer.readUtf8()
+}
+
+/** `POST/GET/PATCH/DELETE /v1/me` + `GET /v1/me/data` (epic #770 / #778). */
 class ApiUserProfileRepositoryTest {
+    private fun makeSut(transport: FakeHttpTransport = FakeHttpTransport()): ApiUserProfileRepository {
+        val apiClient = ApiClient("https://api-dev.towncrierapp.uk", transport, FakeAuthenticationService())
+        return ApiUserProfileRepository(apiClient)
+    }
+
     @Test
     fun `ensureProfile POSTs to v1 me with no request body and parses the response`() =
         runTest {
             val transport = FakeHttpTransport()
             transport.enqueueResponse(200, """{"userId":"auth0|1","pushEnabled":true,"tier":"Personal"}""")
-            val apiClient = ApiClient("https://api-dev.towncrierapp.uk", transport, FakeAuthenticationService())
-            val sut = ApiUserProfileRepository(apiClient)
+            val sut = makeSut(transport)
 
             val profile = sut.ensureProfile()
 
@@ -34,11 +53,150 @@ class ApiUserProfileRepositoryTest {
         runTest {
             val transport = FakeHttpTransport()
             transport.enqueueResponse(200, """{"userId":"auth0|1","pushEnabled":false,"tier":"Enterprise"}""")
-            val apiClient = ApiClient("https://api-dev.towncrierapp.uk", transport, FakeAuthenticationService())
-            val sut = ApiUserProfileRepository(apiClient)
+            val sut = makeSut(transport)
 
             val profile = sut.ensureProfile()
 
             assertEquals(SubscriptionTier.FREE, profile.tier)
+        }
+
+    @Test
+    fun `ensureProfile response with no preference fields defaults them to the server's DefaultPreferences`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(200, """{"userId":"auth0|1","pushEnabled":true,"tier":"Free"}""")
+            val sut = makeSut(transport)
+
+            val profile = sut.ensureProfile()
+
+            assertEquals(DigestDay.MONDAY, profile.digestDay)
+            assertTrue(profile.emailDigestEnabled)
+            assertTrue(profile.savedDecisionPush)
+            assertTrue(profile.savedDecisionEmail)
+        }
+
+    @Test
+    fun `fetchProfile GETs v1 me and parses the full field set`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(
+                200,
+                """{"userId":"auth0|1","pushEnabled":true,"digestDay":"Friday",""" +
+                    """"emailDigestEnabled":false,"savedDecisionPush":false,"savedDecisionEmail":true,"tier":"Pro"}""",
+            )
+            val sut = makeSut(transport)
+
+            val profile = sut.fetchProfile()
+
+            assertEquals(
+                ServerProfile(
+                    userId = "auth0|1",
+                    pushEnabled = true,
+                    tier = SubscriptionTier.PRO,
+                    digestDay = DigestDay.FRIDAY,
+                    emailDigestEnabled = false,
+                    savedDecisionPush = false,
+                    savedDecisionEmail = true,
+                ),
+                profile,
+            )
+            val request = transport.requests.single()
+            assertEquals("GET", request.method)
+            assertEquals("/v1/me", request.url.encodedPath)
+        }
+
+    @Test
+    fun `fetchProfile returns null on a 404 (no profile yet)`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(404)
+            val sut = makeSut(transport)
+
+            assertEquals(null, sut.fetchProfile())
+        }
+
+    @Test
+    fun `fetchProfile propagates other failures`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(500, "boom")
+            val sut = makeSut(transport)
+
+            assertFailsWith<DomainError.ServerError> { sut.fetchProfile() }
+        }
+
+    @Test
+    fun `updatePreferences PATCHes v1 me with the full five-field body`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(
+                200,
+                """{"userId":"auth0|1","pushEnabled":true,"digestDay":"Saturday",""" +
+                    """"emailDigestEnabled":true,"savedDecisionPush":true,"savedDecisionEmail":false,"tier":"Personal"}""",
+            )
+            val sut = makeSut(transport)
+
+            val updated =
+                sut.updatePreferences(
+                    UserPreferences(
+                        pushEnabled = true,
+                        digestDay = DigestDay.SATURDAY,
+                        emailDigestEnabled = true,
+                        savedDecisionPush = true,
+                        savedDecisionEmail = false,
+                    ),
+                )
+
+            assertEquals(DigestDay.SATURDAY, updated.digestDay)
+            assertEquals(false, updated.savedDecisionEmail)
+            val request = transport.requests.single()
+            assertEquals("PATCH", request.method)
+            assertEquals("/v1/me", request.url.encodedPath)
+            val body = request.bodyAsString()
+            assertTrue(body.contains(""""pushEnabled":true"""))
+            assertTrue(body.contains(""""digestDay":"Saturday""""))
+            assertTrue(body.contains(""""emailDigestEnabled":true"""))
+            assertTrue(body.contains(""""savedDecisionPush":true"""))
+            assertTrue(body.contains(""""savedDecisionEmail":false"""))
+        }
+
+    @Test
+    fun `deleteAccount DELETEs v1 me`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(204)
+            val sut = makeSut(transport)
+
+            sut.deleteAccount()
+
+            val request = transport.requests.single()
+            assertEquals("DELETE", request.method)
+            assertEquals("/v1/me", request.url.encodedPath)
+        }
+
+    @Test
+    fun `deleteAccount propagates a server failure so the caller keeps the session`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(500, "boom")
+            val sut = makeSut(transport)
+
+            assertFailsWith<DomainError.ServerError> { sut.deleteAccount() }
+        }
+
+    @Test
+    fun `exportData GETs v1 me data and returns the server bytes byte-for-byte unmodified`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            val scriptedBody = """{"profile":{"userId":"auth0|1"},"watchZones":[]}"""
+            transport.enqueueResponse(200, scriptedBody)
+            val sut = makeSut(transport)
+
+            val bytes = sut.exportData()
+
+            assertContentEquals(scriptedBody.toByteArray(Charsets.UTF_8), bytes)
+            val request = transport.requests.single()
+            assertEquals("GET", request.method)
+            assertEquals("/v1/me/data", request.url.encodedPath)
         }
 }

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/reviewprompt/DataStoreReviewPromptStoreTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/reviewprompt/DataStoreReviewPromptStoreTest.kt
@@ -1,0 +1,82 @@
+package uk.towncrierapp.data.reviewprompt
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import uk.towncrierapp.domain.reviewprompt.ReviewPromptState
+import java.io.File
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * DataStore Preferences-backed [ReviewPromptStore][uk.towncrierapp.domain.reviewprompt.ReviewPromptStore].
+ * Port of iOS's `UserDefaults`-backed `UserDefaultsReviewPromptStore` (GH #628).
+ */
+class DataStoreReviewPromptStoreTest {
+    private fun aDataStore(directory: File) =
+        PreferenceDataStoreFactory.create { File(directory, "test.preferences_pb") }
+
+    @Test
+    fun `load returns a default-initialised state when nothing has been written yet`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreReviewPromptStore(aDataStore(directory))
+
+        assertEquals(ReviewPromptState(), sut.load())
+    }
+
+    @Test
+    fun `save then load round-trips every field`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreReviewPromptStore(aDataStore(directory))
+        val state =
+            ReviewPromptState(
+                firstLaunchDate = Instant.ofEpochSecond(1_700_000_000),
+                engagementScore = 4,
+                saveCount = 2,
+                lastActiveDayKey = "2023-11-14",
+                distinctActiveDays = 3,
+                lastPromptDate = Instant.ofEpochSecond(1_690_000_000),
+                promptTimestamps = listOf(Instant.ofEpochSecond(1_680_000_000), Instant.ofEpochSecond(1_690_000_000)),
+                hasRecordedUpgrade = true,
+            )
+
+        sut.save(state)
+
+        assertEquals(state, sut.load())
+    }
+
+    @Test
+    fun `save then load round-trips null optional fields as null, not sentinel values`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreReviewPromptStore(aDataStore(directory))
+        sut.save(ReviewPromptState(firstLaunchDate = Instant.ofEpochSecond(1_700_000_000)))
+
+        val loaded = sut.load()
+
+        assertNull(loaded.lastActiveDayKey)
+        assertNull(loaded.lastPromptDate)
+    }
+
+    @Test
+    fun `saving a fresh state after a populated one clears the previous values`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreReviewPromptStore(aDataStore(directory))
+        sut.save(
+            ReviewPromptState(
+                firstLaunchDate = Instant.ofEpochSecond(1_700_000_000),
+                lastPromptDate = Instant.ofEpochSecond(1_690_000_000),
+                promptTimestamps = listOf(Instant.ofEpochSecond(1_690_000_000)),
+            ),
+        )
+
+        sut.save(ReviewPromptState())
+
+        assertEquals(ReviewPromptState(), sut.load())
+    }
+}

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/settings/DataStoreAppearanceStoreTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/settings/DataStoreAppearanceStoreTest.kt
@@ -1,0 +1,36 @@
+package uk.towncrierapp.data.settings
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import uk.towncrierapp.domain.settings.AppearancePreference
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** The `appearanceMode` DataStore latch — same key name as iOS (epic #770 pre-resolved decision). */
+class DataStoreAppearanceStoreTest {
+    private fun aDataStore(directory: File) =
+        PreferenceDataStoreFactory.create { File(directory, "test.preferences_pb") }
+
+    @Test
+    fun `read returns null when nothing has been written yet`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreAppearanceStore(aDataStore(directory))
+
+        assertNull(sut.read())
+    }
+
+    @Test
+    fun `write then read round-trips the preference`(
+        @TempDir directory: File,
+    ) = runTest {
+        val sut = DataStoreAppearanceStore(aDataStore(directory))
+
+        sut.write(AppearancePreference.OLED_DARK)
+
+        assertEquals(AppearancePreference.OLED_DARK, sut.read())
+    }
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/devicetoken/DeviceTokenRepository.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/devicetoken/DeviceTokenRepository.kt
@@ -1,0 +1,13 @@
+package uk.towncrierapp.domain.devicetoken
+
+/**
+ * Removes this device's push-notification token registration from the
+ * server, if one was ever registered. Real device-token registration lands
+ * with #777; until then no implementation is wired at the composition root,
+ * so every caller of this port treats it as a best-effort, swallow-failures
+ * step (Settings' sign-out and account-deletion flows) — see the
+ * `android-tdd-worker`'s tc-4jjw report for the "no-op today" rationale.
+ */
+public interface DeviceTokenRepository {
+    public suspend fun removeDeviceToken()
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/legal/LegalDocument.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/legal/LegalDocument.kt
@@ -1,0 +1,27 @@
+package uk.towncrierapp.domain.legal
+
+import java.time.LocalDate
+
+/** Which bundled legal document to load. */
+public enum class LegalDocumentType {
+    PRIVACY_POLICY,
+    TERMS_OF_SERVICE,
+}
+
+/** One section of a legal document: a heading and its body text. */
+public data class LegalDocumentSection(
+    val heading: String,
+    val body: String,
+)
+
+/**
+ * A bundled legal document (privacy policy or terms of service). Content is
+ * loaded from JSON bundled with the app — the same JSON files embedded on
+ * the API side (canonical source); `scripts/check-legal-drift.sh` enforces
+ * byte-equality. Port of iOS's `LegalDocumentViewModel`'s decoded shape.
+ */
+public data class LegalDocument(
+    val title: String,
+    val lastUpdated: LocalDate,
+    val sections: List<LegalDocumentSection>,
+)

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/legal/LegalDocumentRepository.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/legal/LegalDocumentRepository.kt
@@ -1,0 +1,12 @@
+package uk.towncrierapp.domain.legal
+
+/**
+ * Port for reading a bundled legal document. `:presentation` depends only
+ * on this interface — the concrete asset-reading implementation
+ * (`LegalDocumentLoader`) lives in `:data`, which `:presentation` is never
+ * allowed to see (module dependency rule).
+ */
+public interface LegalDocumentRepository {
+    /** Loads [type]'s bundled document. */
+    public suspend fun document(type: LegalDocumentType): LegalDocument
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/profile/DigestDay.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/profile/DigestDay.kt
@@ -1,0 +1,26 @@
+package uk.towncrierapp.domain.profile
+
+/**
+ * The day of the week the weekly email digest is sent on. Declared
+ * Monday-first for direct use in a UK-facing picker (`entries` IS the
+ * display order — no separate week-order list needed, unlike iOS's
+ * Sunday-first `DayOfWeek` + `weekOrderUK`). [wireValue] is the server's
+ * English weekday name (`weekdayName` in `api-go/internal/profiles/handler.go`).
+ */
+public enum class DigestDay(
+    public val wireValue: String,
+) {
+    MONDAY("Monday"),
+    TUESDAY("Tuesday"),
+    WEDNESDAY("Wednesday"),
+    THURSDAY("Thursday"),
+    FRIDAY("Friday"),
+    SATURDAY("Saturday"),
+    SUNDAY("Sunday"),
+    ;
+
+    public companion object {
+        /** Parses a digest day from its exact wire string. Returns `null` for anything unrecognised. */
+        public fun fromWireValue(value: String): DigestDay? = entries.firstOrNull { it.wireValue == value }
+    }
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/profile/ServerProfile.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/profile/ServerProfile.kt
@@ -2,9 +2,19 @@ package uk.towncrierapp.domain.profile
 
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
 
-/** The server-side profile returned by `POST /v1/me` (ensure-profile). */
+/**
+ * The server-side profile returned by `POST`/`GET`/`PATCH /v1/me`. The four
+ * preference fields beyond [pushEnabled] default to the server's own
+ * `DefaultPreferences` (push-on, Monday digest, every channel on) since
+ * `POST /v1/me`'s response body carries only `userId`/`pushEnabled`/`tier` —
+ * only `GET`/`PATCH` return the full set.
+ */
 public data class ServerProfile(
     val userId: String,
     val pushEnabled: Boolean,
     val tier: SubscriptionTier,
+    val digestDay: DigestDay = DigestDay.MONDAY,
+    val emailDigestEnabled: Boolean = true,
+    val savedDecisionPush: Boolean = true,
+    val savedDecisionEmail: Boolean = true,
 )

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/profile/UserPreferences.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/profile/UserPreferences.kt
@@ -1,0 +1,19 @@
+package uk.towncrierapp.domain.profile
+
+/**
+ * The full notification-preferences set sent as the `PATCH /v1/me` body.
+ * The server treats these five fields as a set — every write carries all
+ * five, never a partial update (epic #770 pre-resolved decision), so a
+ * setter that changes one field still round-trips the other four unchanged.
+ */
+public data class UserPreferences(
+    val pushEnabled: Boolean,
+    val digestDay: DigestDay,
+    val emailDigestEnabled: Boolean,
+    val savedDecisionPush: Boolean,
+    val savedDecisionEmail: Boolean,
+)
+
+/** The [UserPreferences] currently in effect for this profile — the starting point for a full-body PATCH that changes only one field. */
+public val ServerProfile.preferences: UserPreferences
+    get() = UserPreferences(pushEnabled, digestDay, emailDigestEnabled, savedDecisionPush, savedDecisionEmail)

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/profile/UserProfileRepository.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/profile/UserProfileRepository.kt
@@ -1,16 +1,36 @@
 package uk.towncrierapp.domain.profile
 
-/**
- * Port for managing the user's server-side profile. This issue implements
- * only the ensure-profile seam (`POST /v1/me`, no body, idempotent); fetch/
- * update/delete/export land with settings work in #778.
- */
+/** Port for managing the user's server-side profile. */
 public interface UserProfileRepository {
     /**
      * Ensures the server profile exists (creates it on first call, returns
      * the existing one otherwise — the server-side handler is idempotent)
      * and returns it. Called on every signed-in transition, before tier
-     * resolution (tc-a6it / #549 ordering).
+     * resolution (tc-a6it / #549 ordering). NOTE: the wire response for this
+     * endpoint carries only `userId`/`pushEnabled`/`tier` — the returned
+     * [ServerProfile]'s notification-preference fields are the server's
+     * defaults, not necessarily this user's actual saved values; use
+     * [fetchProfile] to read the real preferences (#778).
      */
     public suspend fun ensureProfile(): ServerProfile
+
+    /** Fetches the current profile (`GET /v1/me`), or `null` if none exists yet (404). */
+    public suspend fun fetchProfile(): ServerProfile?
+
+    /**
+     * Replaces ALL FIVE notification preferences in one call (`PATCH /v1/me`)
+     * — the server treats them as a set, so every setter round-trips every
+     * field, never a partial update (epic #770 pre-resolved decision).
+     */
+    public suspend fun updatePreferences(preferences: UserPreferences): ServerProfile
+
+    /**
+     * UK GDPR Art. 17 erasure (`DELETE /v1/me`). The server cascades to
+     * every per-user store and, last, deletes the Auth0 user — the client
+     * NEVER calls Auth0's management API directly.
+     */
+    public suspend fun deleteAccount()
+
+    /** The full GDPR data export (`GET /v1/me/data`) as opaque, unmodified bytes. */
+    public suspend fun exportData(): ByteArray
 }

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptPolicy.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptPolicy.kt
@@ -1,0 +1,189 @@
+package uk.towncrierapp.domain.reviewprompt
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+
+/** The outcome of a single [ReviewPromptPolicy.evaluate] call. */
+public enum class ReviewPromptDecision {
+    /** Present the platform's native review dialog now. */
+    FIRE,
+
+    /** Do not present the dialog. */
+    HOLD,
+}
+
+/** [ReviewPromptPolicy.evaluate]'s result: the decision and the state the caller should persist. */
+public data class ReviewPromptOutcome(
+    val decision: ReviewPromptDecision,
+    val state: ReviewPromptState,
+)
+
+/**
+ * Pure, deterministic decision engine for the store review prompt (GH #628).
+ * Verbatim port of iOS `ReviewPromptPolicy`'s weights/threshold/guards.
+ *
+ * Given an incoming [ReviewSignal], the persisted [ReviewPromptState], a
+ * transient session-suppression flag, and whether the current foreground is
+ * a background-to-active re-entry, it applies the signal's weight, enforces
+ * every guard, and returns a [ReviewPromptOutcome]. It performs no I/O and
+ * never touches a platform review API, so it is exhaustively unit-testable.
+ *
+ * The scarce resource is the store's prompts-per-year quota, so the policy
+ * only fires at a genuine engagement peak (the score has reached the
+ * threshold *at* a fire-eligible signal) and never after friction.
+ */
+public class ReviewPromptPolicy(
+    private val clock: Clock = Clock.systemUTC(),
+) {
+    /**
+     * Applies [signal] to [state], enforces the guards, and returns the
+     * decision plus the state to persist. The signal's weight is always
+     * applied (so score accrues even when a guard holds the prompt); the
+     * score is reset only on a successful fire.
+     */
+    public fun evaluate(
+        signal: ReviewSignal,
+        state: ReviewPromptState,
+        sessionSuppressed: Boolean,
+        isReactivation: Boolean,
+    ): ReviewPromptOutcome {
+        val (updated, fireEligible) = apply(signal, state, isReactivation)
+
+        if (!fireEligible || !passesGuards(updated, sessionSuppressed)) {
+            return ReviewPromptOutcome(ReviewPromptDecision.HOLD, updated)
+        }
+
+        val firedAt = clock.instant()
+        val firedState =
+            updated.copy(
+                engagementScore = 0,
+                lastPromptDate = firedAt,
+                promptTimestamps = updated.promptTimestamps + firedAt,
+            )
+        return ReviewPromptOutcome(ReviewPromptDecision.FIRE, firedState)
+    }
+
+    /** Mutates [state] for [signal] and returns the updated state plus whether it is a fire-eligible peak. */
+    private fun apply(
+        signal: ReviewSignal,
+        state: ReviewPromptState,
+        isReactivation: Boolean,
+    ): Pair<ReviewPromptState, Boolean> =
+        when (signal) {
+            ReviewSignal.TappedPortal ->
+                state.copy(engagementScore = state.engagementScore + PORTAL_WEIGHT) to true
+
+            ReviewSignal.OpenedAlert ->
+                state.copy(engagementScore = state.engagementScore + OPENED_ALERT_WEIGHT) to true
+
+            ReviewSignal.SavedApplication -> applySavedApplication(state)
+
+            ReviewSignal.ActiveDay -> applyActiveDay(state, isReactivation)
+
+            ReviewSignal.Upgraded -> applyUpgraded(state)
+        }
+
+    /** The first save is not counted; only the 2nd and later saves contribute. */
+    private fun applySavedApplication(state: ReviewPromptState): Pair<ReviewPromptState, Boolean> {
+        val nextSaveCount = state.saveCount + 1
+        return if (nextSaveCount < MINIMUM_FIRE_ELIGIBLE_SAVE_COUNT) {
+            state.copy(saveCount = nextSaveCount) to false
+        } else {
+            state.copy(
+                saveCount = nextSaveCount,
+                engagementScore = state.engagementScore + SAVED_APPLICATION_WEIGHT,
+            ) to true
+        }
+    }
+
+    /**
+     * Never double-counts the same calendar day. Loyalty only becomes a fire
+     * moment once enough distinct days have accrued, and only on a
+     * background-to-active re-entry (never a cold launch).
+     */
+    private fun applyActiveDay(
+        state: ReviewPromptState,
+        isReactivation: Boolean,
+    ): Pair<ReviewPromptState, Boolean> {
+        val key = dayKey(clock.instant())
+        if (key == state.lastActiveDayKey) return state to false
+
+        val distinctDays = state.distinctActiveDays + 1
+        val updated =
+            state.copy(
+                lastActiveDayKey = key,
+                distinctActiveDays = distinctDays,
+                engagementScore = state.engagementScore + ACTIVE_DAY_WEIGHT,
+            )
+        return updated to (isReactivation && distinctDays >= LOYALTY_DISTINCT_DAY_THRESHOLD)
+    }
+
+    /** Latched: contributes at most once across the app's lifetime, and is never itself a fire moment. */
+    private fun applyUpgraded(state: ReviewPromptState): Pair<ReviewPromptState, Boolean> =
+        if (state.hasRecordedUpgrade) {
+            state to false
+        } else {
+            state.copy(engagementScore = state.engagementScore + UPGRADE_WEIGHT, hasRecordedUpgrade = true) to false
+        }
+
+    private fun passesGuards(
+        state: ReviewPromptState,
+        sessionSuppressed: Boolean,
+    ): Boolean {
+        if (sessionSuppressed) return false
+        if (state.engagementScore < ENGAGEMENT_THRESHOLD) return false
+
+        val current = clock.instant()
+
+        val firstLaunch = state.firstLaunchDate ?: return false
+        if (Duration.between(firstLaunch, current) < MINIMUM_ACCOUNT_AGE) return false
+
+        // A backward clock (current before lastPrompt) yields a negative elapsed
+        // duration, which is < the cooldown, so it correctly holds.
+        state.lastPromptDate?.let { lastPrompt ->
+            if (Duration.between(lastPrompt, current) < PROMPT_COOLDOWN) return false
+        }
+
+        val windowStart = current.minus(ANNUAL_CAP_WINDOW)
+        val recentPromptCount = state.promptTimestamps.count { !it.isBefore(windowStart) }
+        if (recentPromptCount >= ANNUAL_CAP_LIMIT) return false
+
+        return true
+    }
+
+    /**
+     * Derives a calendar-day key in the policy clock's zone so distinct days
+     * are counted on day boundaries, never on time deltas — robust to
+     * timezone and backward-clock changes.
+     */
+    private fun dayKey(instant: Instant): String = LocalDate.ofInstant(instant, clock.zone).toString()
+
+    public companion object {
+        /** The score at or above which a fire-eligible signal may fire. */
+        public const val ENGAGEMENT_THRESHOLD: Int = 6
+        public const val PORTAL_WEIGHT: Int = 3
+        public const val SAVED_APPLICATION_WEIGHT: Int = 2
+        public const val OPENED_ALERT_WEIGHT: Int = 2
+        public const val ACTIVE_DAY_WEIGHT: Int = 1
+        public const val UPGRADE_WEIGHT: Int = 2
+
+        /** Distinct active days required before a loyalty day becomes fire-eligible. */
+        public const val LOYALTY_DISTINCT_DAY_THRESHOLD: Int = 3
+
+        /** Maximum prompt attempts allowed within [ANNUAL_CAP_WINDOW]. */
+        public const val ANNUAL_CAP_LIMIT: Int = 3
+
+        private const val MINIMUM_FIRE_ELIGIBLE_SAVE_COUNT: Int = 2
+
+        /** Minimum account age before the first prompt. */
+        public val MINIMUM_ACCOUNT_AGE: Duration = Duration.ofDays(7)
+
+        /** Minimum gap between two prompts. */
+        public val PROMPT_COOLDOWN: Duration = Duration.ofDays(120)
+
+        /** Rolling window for the belt-and-braces annual cap. */
+        public val ANNUAL_CAP_WINDOW: Duration = Duration.ofDays(365)
+    }
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptPolicy.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptPolicy.kt
@@ -72,17 +72,25 @@ public class ReviewPromptPolicy(
         isReactivation: Boolean,
     ): Pair<ReviewPromptState, Boolean> =
         when (signal) {
-            ReviewSignal.TappedPortal ->
+            ReviewSignal.TappedPortal -> {
                 state.copy(engagementScore = state.engagementScore + PORTAL_WEIGHT) to true
+            }
 
-            ReviewSignal.OpenedAlert ->
+            ReviewSignal.OpenedAlert -> {
                 state.copy(engagementScore = state.engagementScore + OPENED_ALERT_WEIGHT) to true
+            }
 
-            ReviewSignal.SavedApplication -> applySavedApplication(state)
+            ReviewSignal.SavedApplication -> {
+                applySavedApplication(state)
+            }
 
-            ReviewSignal.ActiveDay -> applyActiveDay(state, isReactivation)
+            ReviewSignal.ActiveDay -> {
+                applyActiveDay(state, isReactivation)
+            }
 
-            ReviewSignal.Upgraded -> applyUpgraded(state)
+            ReviewSignal.Upgraded -> {
+                applyUpgraded(state)
+            }
         }
 
     /** The first save is not counted; only the 2nd and later saves contribute. */

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptState.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptState.kt
@@ -1,0 +1,32 @@
+package uk.towncrierapp.domain.reviewprompt
+
+import java.time.Instant
+
+/**
+ * The locally-persisted state the review-prompt policy reads and updates.
+ * Every field is device-local: there is no server telemetry, analytics, or
+ * PII involved in deciding when to ask for a rating. Port of iOS
+ * `ReviewPromptState`.
+ */
+public data class ReviewPromptState(
+    /**
+     * When this device first ran the app with the review feature — the
+     * anchor for the account-age guard. `null` until the tracker establishes
+     * it on first run.
+     */
+    val firstLaunchDate: Instant? = null,
+    /** The accumulated engagement score, reset to 0 after a fire. */
+    val engagementScore: Int = 0,
+    /** How many applications the user has saved (gates the first-save exclusion). */
+    val saveCount: Int = 0,
+    /** The calendar-day key of the most recent active day, so the same day is never double-counted. */
+    val lastActiveDayKey: String? = null,
+    /** The number of distinct calendar days the app has been foregrounded on. */
+    val distinctActiveDays: Int = 0,
+    /** When the last review prompt was attempted, anchoring the cooldown guard. */
+    val lastPromptDate: Instant? = null,
+    /** Timestamps of past prompt attempts, used for the rolling annual cap. */
+    val promptTimestamps: List<Instant> = emptyList(),
+    /** Whether the upgrade score contribution has already been latched. */
+    val hasRecordedUpgrade: Boolean = false,
+)

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptStore.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptStore.kt
@@ -1,0 +1,16 @@
+package uk.towncrierapp.domain.reviewprompt
+
+/**
+ * Persists the local [ReviewPromptState] for the review-prompt feature
+ * (GH #628). The contract is a whole-state load/save: the store
+ * reconstructs the full value on [load] and writes it back on [save]. All
+ * storage is device-local — there is no server, network, or PII involved.
+ * Port of iOS `ReviewPromptStore`.
+ */
+public interface ReviewPromptStore {
+    /** Returns the persisted state, or a default-initialised state on first run. */
+    public suspend fun load(): ReviewPromptState
+
+    /** Persists the supplied state. */
+    public suspend fun save(state: ReviewPromptState)
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewRequester.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewRequester.kt
@@ -1,0 +1,13 @@
+package uk.towncrierapp.domain.reviewprompt
+
+/**
+ * Performs the real platform review request. Abstracted behind an interface
+ * so the decision flow in `ReviewPromptTracker` (`:presentation`) stays
+ * unit-testable — the real Play In-App Review call sits at the `:app`
+ * composition-root edge, since it needs a foreground `Activity`. Port of iOS
+ * `ReviewRequesting`.
+ */
+public fun interface ReviewRequester {
+    /** Best-effort: implementations should swallow failures (no Play listing, no Activity, ...) rather than throw. */
+    public suspend fun requestReview()
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewSignal.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewSignal.kt
@@ -1,0 +1,35 @@
+package uk.towncrierapp.domain.reviewprompt
+
+/**
+ * A positive in-app engagement signal that feeds the store review-prompt
+ * policy (GH #628). Signals are deliberately scoped to genuine *value*
+ * moments inside the app — a review ask is never delivered by push. Most
+ * signals can trigger a fire evaluation; [Upgraded] is a pure score
+ * contributor that nudges a borderline user toward a prompt but can never,
+ * on its own, be the moment that triggers the ask. Port of iOS `ReviewSignal`.
+ */
+public sealed interface ReviewSignal {
+    /** The user tapped through to the council planning portal. */
+    public data object TappedPortal : ReviewSignal
+
+    /**
+     * The user opened an instant alert via its push/deep-link detail path
+     * (push-tap only — distinct from browsing the list).
+     */
+    public data object OpenedAlert : ReviewSignal
+
+    /**
+     * The user saved/bookmarked an application. Only the 2nd and later saves
+     * are fire-eligible; the first save is usually setup rather than delight.
+     */
+    public data object SavedApplication : ReviewSignal
+
+    /** The app was foregrounded on a new distinct calendar day (loyalty). */
+    public data object ActiveDay : ReviewSignal
+
+    /**
+     * The user upgraded to a paid tier. Contributes score but is never a
+     * fire moment, and is latched so it counts at most once.
+     */
+    public data object Upgraded : ReviewSignal
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/settings/AppearancePreference.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/settings/AppearancePreference.kt
@@ -1,0 +1,23 @@
+package uk.towncrierapp.domain.settings
+
+/**
+ * The user's persisted appearance choice — mirrors iOS's local
+ * `appearanceMode` (epic #770). Kept distinct from `:presentation`'s
+ * `Appearance` enum (which the Compose theme resolves directly) so
+ * `:domain` stays free of design-system-adjacent presentation types; the
+ * two are mapped 1:1 at the `:presentation` boundary.
+ */
+public enum class AppearancePreference(
+    public val wireValue: String,
+) {
+    SYSTEM("system"),
+    LIGHT("light"),
+    DARK("dark"),
+    OLED_DARK("oledDark"),
+    ;
+
+    public companion object {
+        /** Parses a preference from its exact wire string. Returns `null` for anything unrecognised. */
+        public fun fromWireValue(value: String): AppearancePreference? = entries.firstOrNull { it.wireValue == value }
+    }
+}

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/settings/AppearanceStore.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/settings/AppearanceStore.kt
@@ -1,0 +1,10 @@
+package uk.towncrierapp.domain.settings
+
+/** Persists the user's local-only appearance preference (`appearanceMode`, epic #770). No server, network, or PII involved. */
+public interface AppearanceStore {
+    /** Returns the persisted preference, or `null` if nothing has been chosen yet. */
+    public suspend fun read(): AppearancePreference?
+
+    /** Persists the given preference. */
+    public suspend fun write(preference: AppearancePreference)
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/profile/DigestDayTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/profile/DigestDayTest.kt
@@ -1,0 +1,44 @@
+package uk.towncrierapp.domain.profile
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * `DigestDay`'s wire strings are the server's English weekday names
+ * (`weekdayName` in `api-go/internal/profiles/handler.go`); the enum itself
+ * is declared Monday-first for direct use in a UK-facing picker (epic #770).
+ */
+class DigestDayTest {
+    @Test
+    fun `entries are declared Monday-first for a UK-facing picker`() {
+        assertEquals(
+            listOf(
+                DigestDay.MONDAY,
+                DigestDay.TUESDAY,
+                DigestDay.WEDNESDAY,
+                DigestDay.THURSDAY,
+                DigestDay.FRIDAY,
+                DigestDay.SATURDAY,
+                DigestDay.SUNDAY,
+            ),
+            DigestDay.entries,
+        )
+    }
+
+    @Test
+    fun `wireValue matches the server's English weekday name`() {
+        assertEquals("Monday", DigestDay.MONDAY.wireValue)
+        assertEquals("Sunday", DigestDay.SUNDAY.wireValue)
+    }
+
+    @Test
+    fun `fromWireValue round-trips the exact wire string`() {
+        assertEquals(DigestDay.FRIDAY, DigestDay.fromWireValue("Friday"))
+    }
+
+    @Test
+    fun `fromWireValue returns null for an unrecognised string`() {
+        assertNull(DigestDay.fromWireValue("Fictionday"))
+    }
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/profile/UserPreferencesTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/profile/UserPreferencesTest.kt
@@ -1,0 +1,48 @@
+package uk.towncrierapp.domain.profile
+
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * [UserPreferences] is the exact `PATCH /v1/me` body shape — always all five
+ * fields (epic #770 pre-resolved decision: never a partial update).
+ * [ServerProfile.preferences] is the starting point a setter copies from
+ * when only one field is changing.
+ */
+class UserPreferencesTest {
+    @Test
+    fun `ServerProfile defaults match the server's DefaultPreferences (push-on, Monday, all channels on)`() {
+        val profile = ServerProfile(userId = "auth0|1", pushEnabled = true, tier = SubscriptionTier.FREE)
+
+        assertEquals(DigestDay.MONDAY, profile.digestDay)
+        assertEquals(true, profile.emailDigestEnabled)
+        assertEquals(true, profile.savedDecisionPush)
+        assertEquals(true, profile.savedDecisionEmail)
+    }
+
+    @Test
+    fun `preferences extracts the full five-field set currently in effect for the profile`() {
+        val profile =
+            ServerProfile(
+                userId = "auth0|1",
+                pushEnabled = false,
+                tier = SubscriptionTier.PERSONAL,
+                digestDay = DigestDay.FRIDAY,
+                emailDigestEnabled = false,
+                savedDecisionPush = true,
+                savedDecisionEmail = false,
+            )
+
+        assertEquals(
+            UserPreferences(
+                pushEnabled = false,
+                digestDay = DigestDay.FRIDAY,
+                emailDigestEnabled = false,
+                savedDecisionPush = true,
+                savedDecisionEmail = false,
+            ),
+            profile.preferences,
+        )
+    }
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptPolicyTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptPolicyTest.kt
@@ -25,6 +25,10 @@ class ReviewPromptPolicyTest {
         ReviewPromptPolicy(Clock.fixed(now, ZoneOffset.UTC))
 
     /** A state whose account is comfortably older than the 7-day age guard and never prompted. */
+    @Suppress("LongParameterList")
+    // Mirrors every field of ReviewPromptState (bar firstLaunchDate, fixed
+    // here) — a fixture builder class is exactly what android-coding-
+    // standards forbids in favour of default-argument factory functions.
     private fun eligibleState(
         engagementScore: Int = 0,
         saveCount: Int = 0,

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptPolicyTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptPolicyTest.kt
@@ -1,0 +1,364 @@
+package uk.towncrierapp.domain.reviewprompt
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Exhaustive unit tests for the pure [ReviewPromptPolicy] decision engine
+ * (GH #628) — a verbatim port of iOS `ReviewPromptPolicyTests`. Every
+ * weight, the threshold, and every guard is covered with a deterministic
+ * fixed [Clock] so distinct-day counting is reproducible.
+ */
+class ReviewPromptPolicyTest {
+    // 2023-11-14 22:13:20 UTC — a fixed anchor for all time-dependent assertions.
+    private val reference: Instant = Instant.ofEpochSecond(1_700_000_000)
+    private val day: Duration = Duration.ofDays(1)
+
+    private fun makePolicy(now: Instant = reference): ReviewPromptPolicy = ReviewPromptPolicy(Clock.fixed(now, ZoneOffset.UTC))
+
+    /** A state whose account is comfortably older than the 7-day age guard and never prompted. */
+    private fun eligibleState(
+        engagementScore: Int = 0,
+        saveCount: Int = 0,
+        lastActiveDayKey: String? = null,
+        distinctActiveDays: Int = 0,
+        lastPromptDate: Instant? = null,
+        promptTimestamps: List<Instant> = emptyList(),
+        hasRecordedUpgrade: Boolean = false,
+    ) = ReviewPromptState(
+        firstLaunchDate = reference.minus(Duration.ofDays(30)),
+        engagementScore = engagementScore,
+        saveCount = saveCount,
+        lastActiveDayKey = lastActiveDayKey,
+        distinctActiveDays = distinctActiveDays,
+        lastPromptDate = lastPromptDate,
+        promptTimestamps = promptTimestamps,
+        hasRecordedUpgrade = hasRecordedUpgrade,
+    )
+
+    private fun evaluate(
+        signal: ReviewSignal,
+        state: ReviewPromptState,
+        now: Instant = reference,
+        sessionSuppressed: Boolean = false,
+        isReactivation: Boolean = false,
+    ): ReviewPromptOutcome = makePolicy(now).evaluate(signal, state, sessionSuppressed, isReactivation)
+
+    // region Threshold
+
+    @Test
+    fun `holds when the accumulated score stays below the threshold`() {
+        val outcome = evaluate(ReviewSignal.TappedPortal, eligibleState(engagementScore = 0))
+
+        assertEquals(ReviewPromptDecision.HOLD, outcome.decision)
+        assertEquals(3, outcome.state.engagementScore)
+    }
+
+    @Test
+    fun `fires when a fire-eligible signal lifts the score to exactly the threshold`() {
+        val outcome = evaluate(ReviewSignal.TappedPortal, eligibleState(engagementScore = 3))
+
+        assertEquals(ReviewPromptDecision.FIRE, outcome.decision)
+    }
+
+    // endregion
+
+    // region Weights
+
+    @Test
+    fun `tapping through to the portal contributes +3`() {
+        val outcome = evaluate(ReviewSignal.TappedPortal, eligibleState(engagementScore = 0))
+        assertEquals(ReviewPromptPolicy.PORTAL_WEIGHT, outcome.state.engagementScore)
+        assertEquals(3, ReviewPromptPolicy.PORTAL_WEIGHT)
+    }
+
+    @Test
+    fun `opening an instant alert contributes +2`() {
+        val outcome = evaluate(ReviewSignal.OpenedAlert, eligibleState(engagementScore = 0))
+        assertEquals(ReviewPromptPolicy.OPENED_ALERT_WEIGHT, outcome.state.engagementScore)
+        assertEquals(2, ReviewPromptPolicy.OPENED_ALERT_WEIGHT)
+    }
+
+    @Test
+    fun `a loyalty active day contributes +1`() {
+        val outcome =
+            evaluate(
+                ReviewSignal.ActiveDay,
+                eligibleState(engagementScore = 0, lastActiveDayKey = null),
+                isReactivation = true,
+            )
+        assertEquals(ReviewPromptPolicy.ACTIVE_DAY_WEIGHT, outcome.state.engagementScore)
+        assertEquals(1, ReviewPromptPolicy.ACTIVE_DAY_WEIGHT)
+    }
+
+    @Test
+    fun `portal (+3), a 2nd save (+2) and a loyalty day (+1) reach 6 and fire`() {
+        val state =
+            eligibleState(
+                engagementScore = 5,
+                saveCount = 2,
+                lastActiveDayKey = "2023-11-14",
+                distinctActiveDays = 2,
+            )
+
+        val outcome =
+            evaluate(ReviewSignal.ActiveDay, state, now = reference.plus(day), isReactivation = true)
+
+        assertEquals(ReviewPromptDecision.FIRE, outcome.decision)
+    }
+
+    // endregion
+
+    // region Upgrade — score contributor only, latched
+
+    @Test
+    fun `upgrading contributes +2 but never fires (weight less than threshold invariant)`() {
+        assertTrue(ReviewPromptPolicy.UPGRADE_WEIGHT < ReviewPromptPolicy.ENGAGEMENT_THRESHOLD)
+
+        val outcome = evaluate(ReviewSignal.Upgraded, eligibleState(engagementScore = 0))
+
+        assertEquals(ReviewPromptDecision.HOLD, outcome.decision)
+        assertEquals(2, outcome.state.engagementScore)
+    }
+
+    @Test
+    fun `upgrade is latched — recording it twice still only adds +2 once`() {
+        val first = evaluate(ReviewSignal.Upgraded, eligibleState(engagementScore = 0))
+        assertEquals(2, first.state.engagementScore)
+        assertTrue(first.state.hasRecordedUpgrade)
+
+        val second = evaluate(ReviewSignal.Upgraded, first.state)
+        assertEquals(ReviewPromptDecision.HOLD, second.decision)
+        assertEquals(2, second.state.engagementScore)
+    }
+
+    // endregion
+
+    // region Saves — first save not counted
+
+    @Test
+    fun `the first save increments the count but contributes no score and never fires`() {
+        val outcome = evaluate(ReviewSignal.SavedApplication, eligibleState(engagementScore = 5, saveCount = 0))
+
+        assertEquals(ReviewPromptDecision.HOLD, outcome.decision)
+        assertEquals(1, outcome.state.saveCount)
+        assertEquals(5, outcome.state.engagementScore)
+    }
+
+    @Test
+    fun `the second save contributes +2 and is fire-eligible`() {
+        val outcome = evaluate(ReviewSignal.SavedApplication, eligibleState(engagementScore = 4, saveCount = 1))
+
+        assertEquals(ReviewPromptDecision.FIRE, outcome.decision)
+        assertEquals(2, outcome.state.saveCount)
+    }
+
+    // endregion
+
+    // region Account-age guard
+
+    @Test
+    fun `never fires before the account is 7 days old, regardless of score`() {
+        val state = ReviewPromptState(firstLaunchDate = reference.minus(Duration.ofDays(6)), engagementScore = 3)
+
+        val outcome = evaluate(ReviewSignal.TappedPortal, state)
+
+        assertEquals(ReviewPromptDecision.HOLD, outcome.decision)
+        assertEquals(6, outcome.state.engagementScore) // score still accrues
+    }
+
+    @Test
+    fun `fires once the account reaches 7 days old`() {
+        val state = ReviewPromptState(firstLaunchDate = reference.minus(Duration.ofDays(7)), engagementScore = 3)
+
+        val outcome = evaluate(ReviewSignal.TappedPortal, state)
+
+        assertEquals(ReviewPromptDecision.FIRE, outcome.decision)
+    }
+
+    @Test
+    fun `never fires when the first-launch date is unknown`() {
+        val state = ReviewPromptState(firstLaunchDate = null, engagementScore = 3)
+
+        val outcome = evaluate(ReviewSignal.TappedPortal, state)
+
+        assertEquals(ReviewPromptDecision.HOLD, outcome.decision)
+    }
+
+    // endregion
+
+    // region Cooldown guard
+
+    @Test
+    fun `never fires within 120 days of the last prompt`() {
+        val state = eligibleState(engagementScore = 3, lastPromptDate = reference.minus(Duration.ofDays(119)))
+
+        val outcome = evaluate(ReviewSignal.TappedPortal, state)
+
+        assertEquals(ReviewPromptDecision.HOLD, outcome.decision)
+    }
+
+    @Test
+    fun `fires once 120 days have elapsed since the last prompt`() {
+        val state = eligibleState(engagementScore = 3, lastPromptDate = reference.minus(Duration.ofDays(120)))
+
+        val outcome = evaluate(ReviewSignal.TappedPortal, state)
+
+        assertEquals(ReviewPromptDecision.FIRE, outcome.decision)
+    }
+
+    @Test
+    fun `holds when the clock has moved backwards past the last prompt date`() {
+        val state = eligibleState(engagementScore = 3, lastPromptDate = reference.plus(Duration.ofDays(10)))
+
+        val outcome = evaluate(ReviewSignal.TappedPortal, state)
+
+        assertEquals(ReviewPromptDecision.HOLD, outcome.decision)
+    }
+
+    // endregion
+
+    // region Annual cap guard
+
+    @Test
+    fun `never fires when 3 prompts already fall within the trailing 365 days`() {
+        val state =
+            eligibleState(
+                engagementScore = 3,
+                lastPromptDate = reference.minus(Duration.ofDays(200)),
+                promptTimestamps =
+                    listOf(
+                        reference.minus(Duration.ofDays(300)),
+                        reference.minus(Duration.ofDays(200)),
+                        reference.minus(Duration.ofDays(130)),
+                    ),
+            )
+
+        val outcome = evaluate(ReviewSignal.TappedPortal, state)
+
+        assertEquals(ReviewPromptDecision.HOLD, outcome.decision)
+    }
+
+    @Test
+    fun `fires once the oldest of three prompts ages out past 365 days`() {
+        val state =
+            eligibleState(
+                engagementScore = 3,
+                lastPromptDate = reference.minus(Duration.ofDays(200)),
+                promptTimestamps =
+                    listOf(
+                        reference.minus(Duration.ofDays(366)), // aged out
+                        reference.minus(Duration.ofDays(300)),
+                        reference.minus(Duration.ofDays(200)),
+                    ),
+            )
+
+        val outcome = evaluate(ReviewSignal.TappedPortal, state)
+
+        assertEquals(ReviewPromptDecision.FIRE, outcome.decision)
+    }
+
+    // endregion
+
+    // region Session suppression guard
+
+    @Test
+    fun `never fires while the session is suppressed`() {
+        val outcome =
+            evaluate(ReviewSignal.TappedPortal, eligibleState(engagementScore = 3), sessionSuppressed = true)
+
+        assertEquals(ReviewPromptDecision.HOLD, outcome.decision)
+        assertEquals(6, outcome.state.engagementScore) // suppression does not stop accrual
+    }
+
+    // endregion
+
+    // region Reset after fire
+
+    @Test
+    fun `after a fire the score resets and the prompt is timestamped`() {
+        val state = eligibleState(engagementScore = 3, promptTimestamps = emptyList())
+
+        val outcome = evaluate(ReviewSignal.TappedPortal, state)
+
+        assertEquals(ReviewPromptDecision.FIRE, outcome.decision)
+        assertEquals(0, outcome.state.engagementScore)
+        assertEquals(reference, outcome.state.lastPromptDate)
+        assertEquals(listOf(reference), outcome.state.promptTimestamps)
+    }
+
+    // endregion
+
+    // region Loyalty active-day eligibility
+
+    @Test
+    fun `loyalty is not fire-eligible before 3 distinct active days`() {
+        val state =
+            eligibleState(engagementScore = 8, lastActiveDayKey = "2023-11-14", distinctActiveDays = 1)
+
+        val outcome =
+            evaluate(ReviewSignal.ActiveDay, state, now = reference.plus(day), isReactivation = true)
+
+        assertEquals(ReviewPromptDecision.HOLD, outcome.decision)
+        assertEquals(2, outcome.state.distinctActiveDays)
+    }
+
+    @Test
+    fun `loyalty is fire-eligible on the 3rd distinct day during a re-entry`() {
+        val state =
+            eligibleState(engagementScore = 5, lastActiveDayKey = "2023-11-14", distinctActiveDays = 2)
+
+        val outcome =
+            evaluate(ReviewSignal.ActiveDay, state, now = reference.plus(day), isReactivation = true)
+
+        assertEquals(ReviewPromptDecision.FIRE, outcome.decision)
+        assertEquals(3, outcome.state.distinctActiveDays)
+    }
+
+    @Test
+    fun `loyalty never fires on a cold launch even at 3 distinct days`() {
+        val state =
+            eligibleState(engagementScore = 5, lastActiveDayKey = "2023-11-14", distinctActiveDays = 2)
+
+        val outcome =
+            evaluate(ReviewSignal.ActiveDay, state, now = reference.plus(day), isReactivation = false)
+
+        assertEquals(ReviewPromptDecision.HOLD, outcome.decision)
+        assertEquals(3, outcome.state.distinctActiveDays)
+        assertEquals(6, outcome.state.engagementScore)
+    }
+
+    @Test
+    fun `the same calendar day is never counted twice`() {
+        val state = eligibleState(engagementScore = 4, lastActiveDayKey = "2023-11-14", distinctActiveDays = 2)
+
+        val outcome = evaluate(ReviewSignal.ActiveDay, state, now = reference, isReactivation = true)
+
+        assertEquals(ReviewPromptDecision.HOLD, outcome.decision)
+        assertEquals(2, outcome.state.distinctActiveDays)
+        assertEquals(4, outcome.state.engagementScore)
+    }
+
+    @Test
+    fun `a backward clock change counts a new day without corrupting state`() {
+        val state = eligibleState(engagementScore = 0, lastActiveDayKey = "2023-11-15", distinctActiveDays = 3)
+
+        // now is a day earlier than the last recorded key.
+        val outcome = evaluate(ReviewSignal.ActiveDay, state, now = reference, isReactivation = true)
+
+        assertEquals(4, outcome.state.distinctActiveDays)
+        assertEquals(1, outcome.state.engagementScore)
+        assertEquals("2023-11-14", outcome.state.lastActiveDayKey)
+        assertFalse(outcome.decision == ReviewPromptDecision.FIRE && outcome.state.distinctActiveDays < 3)
+        assertNull(state.lastPromptDate)
+    }
+
+    // endregion
+}

--- a/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptPolicyTest.kt
+++ b/mobile/android/domain/src/test/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptPolicyTest.kt
@@ -21,7 +21,8 @@ class ReviewPromptPolicyTest {
     private val reference: Instant = Instant.ofEpochSecond(1_700_000_000)
     private val day: Duration = Duration.ofDays(1)
 
-    private fun makePolicy(now: Instant = reference): ReviewPromptPolicy = ReviewPromptPolicy(Clock.fixed(now, ZoneOffset.UTC))
+    private fun makePolicy(now: Instant = reference): ReviewPromptPolicy =
+        ReviewPromptPolicy(Clock.fixed(now, ZoneOffset.UTC))
 
     /** A state whose account is comfortably older than the 7-day age guard and never prompted. */
     private fun eligibleState(

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/devicetoken/FakeDeviceTokenRepository.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/devicetoken/FakeDeviceTokenRepository.kt
@@ -1,0 +1,13 @@
+package uk.towncrierapp.domain.devicetoken
+
+/** Hand-written fake for [DeviceTokenRepository]. */
+public class FakeDeviceTokenRepository(
+    public var removeDeviceTokenResult: Result<Unit> = Result.success(Unit),
+) : DeviceTokenRepository {
+    public val removeDeviceTokenCalls: MutableList<Unit> = mutableListOf()
+
+    override suspend fun removeDeviceToken() {
+        removeDeviceTokenCalls += Unit
+        removeDeviceTokenResult.getOrThrow()
+    }
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/legal/LegalDocumentFixtures.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/legal/LegalDocumentFixtures.kt
@@ -1,0 +1,22 @@
+package uk.towncrierapp.domain.legal
+
+import java.time.LocalDate
+
+/** Fixture factory for [LegalDocument]. */
+public fun aLegalDocument(
+    title: String = "Privacy Policy",
+    lastUpdated: LocalDate = LocalDate.of(2026, 7, 1),
+    sections: List<LegalDocumentSection> = listOf(LegalDocumentSection(heading = "Who We Are", body = "Town Crier.")),
+): LegalDocument = LegalDocument(title = title, lastUpdated = lastUpdated, sections = sections)
+
+/** Hand-written fake for [LegalDocumentRepository]. */
+public class FakeLegalDocumentRepository(
+    public var documentResult: Result<LegalDocument> = Result.success(aLegalDocument()),
+) : LegalDocumentRepository {
+    public val documentCalls: MutableList<LegalDocumentType> = mutableListOf()
+
+    override suspend fun document(type: LegalDocumentType): LegalDocument {
+        documentCalls += type
+        return documentResult.getOrThrow()
+    }
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/profile/FakeUserProfileRepository.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/profile/FakeUserProfileRepository.kt
@@ -7,16 +7,73 @@ public fun aServerProfile(
     userId: String = "auth0|user-1",
     pushEnabled: Boolean = false,
     tier: SubscriptionTier = SubscriptionTier.FREE,
-): ServerProfile = ServerProfile(userId = userId, pushEnabled = pushEnabled, tier = tier)
+    digestDay: DigestDay = DigestDay.MONDAY,
+    emailDigestEnabled: Boolean = true,
+    savedDecisionPush: Boolean = true,
+    savedDecisionEmail: Boolean = true,
+): ServerProfile =
+    ServerProfile(
+        userId = userId,
+        pushEnabled = pushEnabled,
+        tier = tier,
+        digestDay = digestDay,
+        emailDigestEnabled = emailDigestEnabled,
+        savedDecisionPush = savedDecisionPush,
+        savedDecisionEmail = savedDecisionEmail,
+    )
+
+/** Fixture factory for [UserPreferences]. */
+public fun aUserPreferences(
+    pushEnabled: Boolean = true,
+    digestDay: DigestDay = DigestDay.MONDAY,
+    emailDigestEnabled: Boolean = true,
+    savedDecisionPush: Boolean = true,
+    savedDecisionEmail: Boolean = true,
+): UserPreferences =
+    UserPreferences(
+        pushEnabled = pushEnabled,
+        digestDay = digestDay,
+        emailDigestEnabled = emailDigestEnabled,
+        savedDecisionPush = savedDecisionPush,
+        savedDecisionEmail = savedDecisionEmail,
+    )
 
 /** Hand-written fake for [UserProfileRepository]. */
 public class FakeUserProfileRepository(
     public var ensureProfileResult: Result<ServerProfile> = Result.success(aServerProfile()),
+    public var fetchProfileResult: Result<ServerProfile?> = Result.success(aServerProfile()),
+    public var updatePreferencesResult: Result<ServerProfile> = Result.success(aServerProfile()),
+    public var deleteAccountResult: Result<Unit> = Result.success(Unit),
+    public var exportDataResult: Result<ByteArray> = Result.success(ByteArray(0)),
 ) : UserProfileRepository {
     public val ensureProfileCalls: MutableList<Unit> = mutableListOf()
+    public val fetchProfileCalls: MutableList<Unit> = mutableListOf()
+    public val updatePreferencesCalls: MutableList<UserPreferences> = mutableListOf()
+    public val deleteAccountCalls: MutableList<Unit> = mutableListOf()
+    public val exportDataCalls: MutableList<Unit> = mutableListOf()
 
     override suspend fun ensureProfile(): ServerProfile {
         ensureProfileCalls += Unit
         return ensureProfileResult.getOrThrow()
+    }
+
+    override suspend fun fetchProfile(): ServerProfile? {
+        fetchProfileCalls += Unit
+        return fetchProfileResult.getOrThrow()
+    }
+
+    override suspend fun updatePreferences(preferences: UserPreferences): ServerProfile {
+        updatePreferencesCalls += preferences
+        return updatePreferencesResult.getOrThrow()
+    }
+
+    override suspend fun deleteAccount() {
+        deleteAccountCalls += Unit
+        deleteAccountResult.getOrThrow()
+    }
+
+    override suspend fun exportData(): ByteArray {
+        exportDataCalls += Unit
+        return exportDataResult.getOrThrow()
     }
 }

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptFixtures.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/reviewprompt/ReviewPromptFixtures.kt
@@ -1,0 +1,48 @@
+package uk.towncrierapp.domain.reviewprompt
+
+import java.time.Instant
+
+/** Fixture factory for [ReviewPromptState]. */
+public fun aReviewPromptState(
+    firstLaunchDate: Instant? = null,
+    engagementScore: Int = 0,
+    saveCount: Int = 0,
+    lastActiveDayKey: String? = null,
+    distinctActiveDays: Int = 0,
+    lastPromptDate: Instant? = null,
+    promptTimestamps: List<Instant> = emptyList(),
+    hasRecordedUpgrade: Boolean = false,
+) = ReviewPromptState(
+    firstLaunchDate = firstLaunchDate,
+    engagementScore = engagementScore,
+    saveCount = saveCount,
+    lastActiveDayKey = lastActiveDayKey,
+    distinctActiveDays = distinctActiveDays,
+    lastPromptDate = lastPromptDate,
+    promptTimestamps = promptTimestamps,
+    hasRecordedUpgrade = hasRecordedUpgrade,
+)
+
+/** Hand-written fake for [ReviewPromptStore]: an in-memory single-slot state, defaulting to a fresh [ReviewPromptState]. */
+public class FakeReviewPromptStore(
+    initial: ReviewPromptState = aReviewPromptState(),
+) : ReviewPromptStore {
+    public var state: ReviewPromptState = initial
+    public val saveCalls: MutableList<ReviewPromptState> = mutableListOf()
+
+    override suspend fun load(): ReviewPromptState = state
+
+    override suspend fun save(state: ReviewPromptState) {
+        this.state = state
+        saveCalls += state
+    }
+}
+
+/** Hand-written fake for [ReviewRequester]: records every call instead of touching a real platform API. */
+public class FakeReviewRequester : ReviewRequester {
+    public val requestReviewCalls: MutableList<Unit> = mutableListOf()
+
+    override suspend fun requestReview() {
+        requestReviewCalls += Unit
+    }
+}

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/settings/FakeAppearanceStore.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/settings/FakeAppearanceStore.kt
@@ -1,0 +1,15 @@
+package uk.towncrierapp.domain.settings
+
+/** Hand-written fake for [AppearanceStore]: an in-memory single-slot preference, `null` until written. */
+public class FakeAppearanceStore(
+    public var stored: AppearancePreference? = null,
+) : AppearanceStore {
+    public val writeCalls: MutableList<AppearancePreference> = mutableListOf()
+
+    override suspend fun read(): AppearancePreference? = stored
+
+    override suspend fun write(preference: AppearancePreference) {
+        stored = preference
+        writeCalls += preference
+    }
+}

--- a/mobile/android/gradle/libs.versions.toml
+++ b/mobile/android/gradle/libs.versions.toml
@@ -33,6 +33,10 @@ okhttp = "4.12.0"
 auth0 = "3.20.0"
 datastorePreferences = "1.2.1"
 
+# Play In-App Review ("Rate the App" — best-effort, falls back to the store
+# listing on failure; tc-4jjw / #778).
+playReview = "2.0.2"
+
 # Lint (pinned like SwiftLint's curl-pinned-binary precedent — reproducibility over convenience)
 ktlintGradle = "14.2.0"
 ktlintCli = "1.8.0"
@@ -71,6 +75,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 auth0 = { module = "com.auth0.android:auth0", version.ref = "auth0" }
 androidx-datastore-preferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastorePreferences" }
+play-review-ktx = { module = "com.google.android.play:review-ktx", version.ref = "playReview" }
 
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junitBom" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }

--- a/mobile/android/presentation/src/main/assets/legal/privacy.json
+++ b/mobile/android/presentation/src/main/assets/legal/privacy.json
@@ -1,0 +1,47 @@
+{
+  "documentType": "privacy",
+  "title": "Privacy Policy",
+  "lastUpdated": "2026-07-01",
+  "sections": [
+    {
+      "heading": "Who We Are",
+      "body": "Town Crier is operated by Ivo and the Bea Ltd, a UK-registered company. We are the data controller for the personal information you give us. For any data query, write to privacy@towncrierapp.uk."
+    },
+    {
+      "heading": "What We Collect",
+      "body": "We keep the collection small. We store a unique user ID and the notification preferences you choose. If your sign-in shares an email address, we store it so we can send you email alerts and digests. Sign in with Apple lets you hide your email; if you do, we never store your real email address. For each area you want to watch we store a label, coordinates, and a radius, not your exact address. We keep a short-lived history of the alerts we've sent you (new applications and decisions), and a list of the applications you've saved for later. If you subscribe we store an Apple App Store transaction ID so we know your tier; we never see your payment details. If you redeem an offer code, we record which code you redeemed and when. On iOS we store a push token so we can deliver notifications to your device."
+    },
+    {
+      "heading": "Why We Collect It",
+      "body": "We use your data on two lawful bases under UK GDPR. To deliver the service you asked for (Article 6(1)(b), contract): your account, watch zones, preferences, push token, and subscription information. To keep the service reliable and secure (Article 6(1)(f), legitimate interests): authentication and server-side error telemetry. We do not process any data on the basis of consent, we do not make automated decisions with legal effects on you, and we do not send marketing email."
+    },
+    {
+      "heading": "Who Processes Your Data for Us",
+      "body": "We use Microsoft Azure to host the service. Your account, watch zones, notifications, and email delivery run on Azure services based in the UK (Cosmos DB, Container Apps, Communication Services, Application Insights). Our website is served from Azure Static Web Apps in the European Union; this serves the site's HTML, CSS, and JavaScript only, and none of your account data is stored there. We use Auth0 (an Okta company) for sign-in; Auth0 stores your email address and credentials in the United Kingdom. We use Apple's Push Notification Service to deliver iOS alerts, and Apple's App Store to handle subscription billing. We use postcodes.io (UK-hosted) to convert postcodes to coordinates, and the UK Government's Planning Data service (planning.data.gov.uk) to look up conservation areas, listed buildings, and other planning designations near an application (we only send coordinates, no personal data). Map tiles are fetched from OpenStreetMap in two places: directly by your browser when you view a map on the web, and by our own servers when we generate the map image shown on a public shared-application page. Neither request includes any of your personal data. We use PlanIt (planit.org.uk) as our source of planning data; we only read from them, we do not send them any of your information."
+    },
+    {
+      "heading": "International Transfers",
+      "body": "Most of your data stays in the United Kingdom. Apple's Push Notification Service and App Store operate in the United States under Apple's own transfer safeguards. Azure Static Web Apps, which serves our website, is in the European Union, which the UK recognises as providing adequate data protection. Some of our UK-based processors, notably Microsoft Azure and Auth0, are subsidiaries of United States companies. Although your data is stored and processed in the UK, a US parent company could in principle receive a legal demand from US authorities. Both providers publish Data Processing Agreements committing to notify us of, and contest, any such demand where legally permitted. You can request a copy of those agreements by writing to privacy@towncrierapp.uk."
+    },
+    {
+      "heading": "Cookies and Similar Storage",
+      "body": "On the web we store two things in your browser's local storage: your Auth0 authentication tokens, so you stay signed in, and your theme preference (light or dark). Both are strictly necessary for the service you asked for, so we do not ask for consent to use them. We do not set tracking cookies and we do not use third-party analytics. When you view a map, your browser fetches map tiles directly from OpenStreetMap, which receives your IP address."
+    },
+    {
+      "heading": "How Long We Keep It",
+      "body": "Your notifications and decision alerts are automatically deleted after 90 days. We remove iOS push tokens when Apple tells us they're no longer valid. Everything else (your account, watch zones, saved applications, preferences, and subscription status) is kept for as long as your account stays active. If you don't use Town Crier for 12 months, we automatically delete your whole account and everything in it, including your sign-in record, so we don't hold your data for longer than we need to (UK GDPR Article 5(1)(e)). You can also delete your account at any time from the app settings, which removes your profile, preferences, watch zones, notifications, saved applications, and device registrations from our systems."
+    },
+    {
+      "heading": "Your Rights Under UK GDPR",
+      "body": "You can ask us for a copy of your data (Article 15), correct it (Article 16), delete it (Article 17), receive it in a machine-readable format (Article 20), restrict how we use it (Article 18), or object to how we use it (Article 21). The app provides self-service account deletion and a self-service machine-readable data export covering your profile, preferences, watch zones, notifications, decision alerts, saved applications, device registrations, subscription metadata, and offer code history. To exercise any other right, email privacy@towncrierapp.uk and we will respond within one month. If you think we are handling your data incorrectly, you can complain to the Information Commissioner's Office at ico.org.uk/make-a-complaint or by calling 0303 123 1113."
+    },
+    {
+      "heading": "Security",
+      "body": "Your data is encrypted in transit with TLS and at rest using Azure's default encryption. Access to our systems uses Auth0 for authentication. We do not log request bodies or passwords."
+    },
+    {
+      "heading": "Children, Changes, and Contact",
+      "body": "Town Crier is not directed at children under 13 and we do not knowingly collect data from anyone under 13. We may update this policy as the service changes; the \"last updated\" date at the top of this document shows when we last revised it. For any question about your data or this policy, write to privacy@towncrierapp.uk."
+    }
+  ]
+}

--- a/mobile/android/presentation/src/main/assets/legal/terms.json
+++ b/mobile/android/presentation/src/main/assets/legal/terms.json
@@ -1,0 +1,31 @@
+{
+  "documentType": "terms",
+  "title": "Terms of Service",
+  "lastUpdated": "2026-03-16",
+  "sections": [
+    {
+      "heading": "Acceptance of Terms",
+      "body": "By using Town Crier, you agree to these Terms of Service. If you do not agree, please do not use the app. We may update these terms from time to time and will notify you of material changes."
+    },
+    {
+      "heading": "Service Description",
+      "body": "Town Crier provides notifications about UK local authority planning applications based on your chosen locations. Planning data is sourced from PlanIt (planit.org.uk) and local authority public registers. While we strive for accuracy, we do not guarantee the completeness or timeliness of planning data."
+    },
+    {
+      "heading": "Subscriptions",
+      "body": "Town Crier offers both free and premium subscription tiers. Premium subscriptions are billed through the Apple App Store. You can manage or cancel your subscription at any time through your App Store account settings. Refunds are handled by Apple in accordance with their refund policy."
+    },
+    {
+      "heading": "Acceptable Use",
+      "body": "You agree to use Town Crier for its intended purpose of monitoring planning applications. You must not attempt to reverse-engineer the app, scrape data at scale, or use the service to harass or spam other users or planning authorities."
+    },
+    {
+      "heading": "Limitation of Liability",
+      "body": "Town Crier is provided as-is. We are not liable for decisions made based on planning data shown in the app. Always verify critical planning information directly with your local authority. Our total liability is limited to the amount you have paid for the service in the preceding 12 months."
+    },
+    {
+      "heading": "Governing Law",
+      "body": "These terms are governed by the laws of England and Wales. Any disputes will be subject to the exclusive jurisdiction of the courts of England and Wales."
+    }
+  ]
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/appearance/AppearanceCoordinator.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/appearance/AppearanceCoordinator.kt
@@ -1,0 +1,50 @@
+package uk.towncrierapp.presentation.appearance
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import uk.towncrierapp.domain.settings.AppearancePreference
+import uk.towncrierapp.domain.settings.AppearanceStore
+import uk.towncrierapp.presentation.designsystem.Appearance
+
+/**
+ * Owns the app-wide appearance preference (System/Light/Dark/OLED Dark,
+ * epic #770): reads/writes it via the injected [AppearanceStore] and
+ * exposes it as a [StateFlow] `MainActivity` feeds straight into
+ * `TownCrierTheme`, so a [setAppearance] call restyles the whole app the
+ * instant it's called — no separate "apply" step. Constructed once in
+ * `AppGraph`, alongside `AuthCoordinator`.
+ */
+public class AppearanceCoordinator(
+    private val store: AppearanceStore,
+) {
+    private val _appearance = MutableStateFlow(Appearance.System)
+    public val appearance: StateFlow<Appearance> = _appearance.asStateFlow()
+
+    /** Resolves the persisted preference (falling back to [Appearance.System] when none is stored yet). */
+    public suspend fun load() {
+        _appearance.value = store.read()?.toAppearance() ?: Appearance.System
+    }
+
+    /** Updates the live [appearance] StateFlow immediately, then persists the mapped preference. */
+    public suspend fun setAppearance(value: Appearance) {
+        _appearance.value = value
+        store.write(value.toPreference())
+    }
+}
+
+internal fun Appearance.toPreference(): AppearancePreference =
+    when (this) {
+        Appearance.System -> AppearancePreference.SYSTEM
+        Appearance.Light -> AppearancePreference.LIGHT
+        Appearance.Dark -> AppearancePreference.DARK
+        Appearance.OledDark -> AppearancePreference.OLED_DARK
+    }
+
+internal fun AppearancePreference.toAppearance(): Appearance =
+    when (this) {
+        AppearancePreference.SYSTEM -> Appearance.System
+        AppearancePreference.LIGHT -> Appearance.Light
+        AppearancePreference.DARK -> Appearance.Dark
+        AppearancePreference.OLED_DARK -> Appearance.OledDark
+    }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailViewModel.kt
@@ -27,6 +27,11 @@ public class ApplicationDetailViewModel(
     private val repository: PlanningApplicationRepository,
     private val savedApplicationRepository: SavedApplicationRepository,
     initial: PlanningApplication,
+    // Defaults to a no-op so every pre-existing call site (tests, and any
+    // caller with nothing to notify) keeps compiling unchanged; the
+    // composition root wires the real review-prompt signal explicitly
+    // (GH #628 / tc-4jjw) — see ApplicationNavGraph.kt.
+    private val onSaved: suspend () -> Unit = {},
 ) : ViewModel() {
     private val _uiState =
         MutableStateFlow(ApplicationDetailUiState(application = initial, authoritySlug = initial.authority.slug))
@@ -77,14 +82,24 @@ public class ApplicationDetailViewModel(
         }
     }
 
-    /** Optimistically flips [ApplicationDetailUiState.isSaved], reverting and surfacing an error on failure. */
+    /**
+     * Optimistically flips [ApplicationDetailUiState.isSaved], reverting and
+     * surfacing an error on failure. Fires [onSaved] only on a successful
+     * false-to-true save — never on unsave, never on failure — driving the
+     * review-prompt `savedApplication` signal (GH #628).
+     */
     public fun toggleSave() {
         val id = _uiState.value.application.id
         val wasSaved = _uiState.value.isSaved
         _uiState.update { it.copy(isSaved = !wasSaved, error = null) }
         viewModelScope.launch {
             try {
-                if (wasSaved) savedApplicationRepository.unsave(id) else savedApplicationRepository.save(id)
+                if (wasSaved) {
+                    savedApplicationRepository.unsave(id)
+                } else {
+                    savedApplicationRepository.save(id)
+                    onSaved()
+                }
             } catch (e: CancellationException) {
                 throw e
             } catch (e: DomainError) {

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -59,6 +60,7 @@ public fun ApplicationListRoute(
     viewModel: ApplicationListViewModel,
     onApplicationSelected: (PlanningApplication) -> Unit,
     onAddZoneClick: () -> Unit,
+    onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -74,6 +76,7 @@ public fun ApplicationListRoute(
         },
         onMarkAllReadClick = viewModel::markAllRead,
         onAddZoneClick = onAddZoneClick,
+        onSettingsClick = onSettingsClick,
         modifier = modifier,
     )
 }
@@ -89,6 +92,7 @@ internal fun ApplicationListScreen(
     onApplicationClick: (PlanningApplication) -> Unit,
     onMarkAllReadClick: () -> Unit,
     onAddZoneClick: () -> Unit,
+    onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -100,6 +104,7 @@ internal fun ApplicationListScreen(
                 availableSorts = state.availableSorts,
                 onMarkAllReadClick = onMarkAllReadClick,
                 onSortSelected = onSortSelected,
+                onSettingsClick = onSettingsClick,
             )
         },
     ) { contentPadding ->
@@ -154,6 +159,7 @@ private fun ApplicationListTopBar(
     availableSorts: List<ApplicationSortOrder>,
     onMarkAllReadClick: () -> Unit,
     onSortSelected: (ApplicationSortOrder) -> Unit,
+    onSettingsClick: () -> Unit,
 ) {
     TopAppBar(
         title = { Text(stringResource(R.string.applications_title)) },
@@ -167,6 +173,12 @@ private fun ApplicationListTopBar(
                 }
             }
             SortMenu(currentSort = sort, availableSorts = availableSorts, onSortSelected = onSortSelected)
+            IconButton(onClick = onSettingsClick) {
+                Icon(
+                    imageVector = Icons.Filled.Settings,
+                    contentDescription = stringResource(R.string.settings_content_description),
+                )
+            }
         },
     )
 }
@@ -291,6 +303,7 @@ private fun ApplicationListScreenEmptyPreview() {
             onApplicationClick = {},
             onMarkAllReadClick = {},
             onAddZoneClick = {},
+            onSettingsClick = {},
         )
     }
 }
@@ -308,6 +321,7 @@ private fun ApplicationListScreenNoZonesPreview() {
             onApplicationClick = {},
             onMarkAllReadClick = {},
             onAddZoneClick = {},
+            onSettingsClick = {},
         )
     }
 }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/legal/LegalDocumentScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/legal/LegalDocumentScreen.kt
@@ -1,0 +1,127 @@
+package uk.towncrierapp.presentation.features.legal
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+
+/** Renders a single bundled legal document: title, formatted date, and section list. Port of iOS `LegalDocumentView`. */
+@Composable
+public fun LegalDocumentRoute(
+    viewModel: LegalDocumentViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) { viewModel.load() }
+
+    LegalDocumentScreen(state = state, onBack = onBack, modifier = modifier)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun LegalDocumentScreen(
+    state: LegalDocumentUiState,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(state.title) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.legal_back_content_description),
+                        )
+                    }
+                },
+            )
+        },
+    ) { contentPadding ->
+        if (state.isLoading) {
+            Box(modifier = Modifier.padding(contentPadding).fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+            return@Scaffold
+        }
+        Column(
+            modifier =
+                Modifier
+                    .padding(contentPadding)
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(TownCrierSpacing.md),
+            verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.lg),
+        ) {
+            Text(
+                text = state.formattedLastUpdated,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            state.sections.forEach { section ->
+                Column(verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+                    Text(text = section.heading, style = MaterialTheme.typography.titleMedium)
+                    Text(text = section.body, style = MaterialTheme.typography.bodyLarge)
+                }
+            }
+        }
+    }
+}
+
+private val previewState =
+    LegalDocumentUiState(
+        isLoading = false,
+        title = "Privacy Policy",
+        formattedLastUpdated = "1 July 2026",
+        sections =
+            listOf(
+                LegalDocumentSectionUi("Who We Are", "Town Crier is operated by Ivo and the Bea Ltd."),
+                LegalDocumentSectionUi("What We Collect", "We keep the collection small."),
+            ),
+    )
+
+@Preview(name = "light")
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun LegalDocumentScreenPreview() {
+    TownCrierTheme {
+        LegalDocumentScreen(state = previewState, onBack = {})
+    }
+}
+
+@Preview(name = "loading")
+@Composable
+private fun LegalDocumentScreenLoadingPreview() {
+    TownCrierTheme {
+        LegalDocumentScreen(state = LegalDocumentUiState(), onBack = {})
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/legal/LegalDocumentUiState.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/legal/LegalDocumentUiState.kt
@@ -1,0 +1,15 @@
+package uk.towncrierapp.presentation.features.legal
+
+/** One section of a legal document, ready to render. */
+public data class LegalDocumentSectionUi(
+    val heading: String,
+    val body: String,
+)
+
+/** State for [LegalDocumentScreen]/[LegalDocumentViewModel]. */
+public data class LegalDocumentUiState(
+    val isLoading: Boolean = true,
+    val title: String = "",
+    val formattedLastUpdated: String = "",
+    val sections: List<LegalDocumentSectionUi> = emptyList(),
+)

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/legal/LegalDocumentViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/legal/LegalDocumentViewModel.kt
@@ -1,0 +1,43 @@
+package uk.towncrierapp.presentation.features.legal
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import uk.towncrierapp.domain.legal.LegalDocumentRepository
+import uk.towncrierapp.domain.legal.LegalDocumentType
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+private val LAST_UPDATED_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.UK)
+
+/**
+ * Drives a single bundled legal document screen (privacy policy or terms of
+ * service): title, `d MMMM yyyy` en-GB formatted date, and section list.
+ * Port of iOS `LegalDocumentViewModel`, adapted to the async bundled-asset
+ * load `:data`'s `LegalDocumentLoader` performs.
+ */
+public class LegalDocumentViewModel(
+    private val repository: LegalDocumentRepository,
+    private val documentType: LegalDocumentType,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(LegalDocumentUiState())
+    public val uiState: StateFlow<LegalDocumentUiState> = _uiState.asStateFlow()
+
+    public fun load() {
+        viewModelScope.launch {
+            val document = repository.document(documentType)
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    title = document.title,
+                    formattedLastUpdated = document.lastUpdated.format(LAST_UPDATED_FORMATTER),
+                    sections = document.sections.map { section -> LegalDocumentSectionUi(section.heading, section.body) },
+                )
+            }
+        }
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/legal/LegalDocumentViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/legal/LegalDocumentViewModel.kt
@@ -35,7 +35,10 @@ public class LegalDocumentViewModel(
                     isLoading = false,
                     title = document.title,
                     formattedLastUpdated = document.lastUpdated.format(LAST_UPDATED_FORMATTER),
-                    sections = document.sections.map { section -> LegalDocumentSectionUi(section.heading, section.body) },
+                    sections =
+                        document.sections.map { section ->
+                            LegalDocumentSectionUi(section.heading, section.body)
+                        },
                 )
             }
         }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/login/LoginViewModel.kt
@@ -60,6 +60,17 @@ public class LoginViewModel(
     }
 
     /**
+     * Resets this ViewModel's own `isAuthenticated` state WITHOUT calling
+     * [AuthenticationService.logout] again — for a sign-out that already ran
+     * the full `AuthenticationService.logout()` sequence elsewhere (Settings'
+     * Sign Out / Delete Account flows, tc-4jjw). Calling [logout] a second
+     * time here would re-launch the SSO browser tab needlessly.
+     */
+    public fun markSignedOut() {
+        _uiState.value = LoginUiState()
+    }
+
+    /**
      * Checks for an already-stored session (cold start). `currentSession()`
      * itself is responsible for auto-renewing a near-expiry access token
      * (see `Auth0AuthenticationService`), so a non-null result here is

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/notificationprefs/NotificationPreferencesScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/notificationprefs/NotificationPreferencesScreen.kt
@@ -181,7 +181,10 @@ private fun DigestSection(
     modifier: Modifier = Modifier,
 ) {
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
-        Text(text = stringResource(R.string.notification_prefs_digest_header), style = MaterialTheme.typography.labelMedium)
+        Text(
+            text = stringResource(R.string.notification_prefs_digest_header),
+            style = MaterialTheme.typography.labelMedium,
+        )
         ToggleRow(
             label = stringResource(R.string.notification_prefs_email_digest_label),
             checked = emailDigestEnabled,

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/notificationprefs/NotificationPreferencesScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/notificationprefs/NotificationPreferencesScreen.kt
@@ -1,0 +1,280 @@
+package uk.towncrierapp.presentation.features.notificationprefs
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.content.res.Configuration
+import android.os.Build
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import uk.towncrierapp.domain.profile.DigestDay
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+
+/**
+ * Global notification preferences: saved-application push/email, the weekly
+ * email digest, and its day (Monday-Sunday). A "permission not granted"
+ * banner appears when the OS `POST_NOTIFICATIONS` permission is
+ * not-determined or denied. Port of iOS `NotificationPreferencesView`.
+ */
+@Composable
+public fun NotificationPreferencesRoute(
+    viewModel: NotificationPreferencesViewModel,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+    val isPushPermissionGranted =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) ==
+            PackageManager.PERMISSION_GRANTED
+
+    NotificationPreferencesScreen(
+        state = state,
+        isPushPermissionGranted = isPushPermissionGranted,
+        onBack = onBack,
+        onSavedDecisionPushChange = viewModel::setSavedDecisionPush,
+        onSavedDecisionEmailChange = viewModel::setSavedDecisionEmail,
+        onEmailDigestEnabledChange = viewModel::setEmailDigestEnabled,
+        onDigestDayChange = viewModel::setDigestDay,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun NotificationPreferencesScreen(
+    state: NotificationPreferencesUiState,
+    isPushPermissionGranted: Boolean,
+    onBack: () -> Unit,
+    onSavedDecisionPushChange: (Boolean) -> Unit,
+    onSavedDecisionEmailChange: (Boolean) -> Unit,
+    onEmailDigestEnabledChange: (Boolean) -> Unit,
+    onDigestDayChange: (DigestDay) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.notification_prefs_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { contentPadding ->
+        Column(
+            modifier = Modifier.padding(contentPadding).fillMaxSize().padding(TownCrierSpacing.md),
+            verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.lg),
+        ) {
+            if (!isPushPermissionGranted) {
+                PermissionBanner()
+            }
+            SavedApplicationsSection(
+                savedDecisionPush = state.savedDecisionPush,
+                savedDecisionEmail = state.savedDecisionEmail,
+                onPushChange = onSavedDecisionPushChange,
+                onEmailChange = onSavedDecisionEmailChange,
+            )
+            DigestSection(
+                emailDigestEnabled = state.emailDigestEnabled,
+                digestDay = state.digestDay,
+                onEmailDigestEnabledChange = onEmailDigestEnabledChange,
+                onDigestDayChange = onDigestDayChange,
+            )
+        }
+    }
+}
+
+@Composable
+private fun PermissionBanner(modifier: Modifier = Modifier) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer),
+    ) {
+        Column(
+            modifier = Modifier.padding(TownCrierSpacing.md),
+            verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs),
+        ) {
+            Text(
+                text = stringResource(R.string.notification_prefs_permission_banner_title),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+            Text(
+                text = stringResource(R.string.notification_prefs_permission_banner_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SavedApplicationsSection(
+    savedDecisionPush: Boolean,
+    savedDecisionEmail: Boolean,
+    onPushChange: (Boolean) -> Unit,
+    onEmailChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        Text(
+            text = stringResource(R.string.notification_prefs_saved_applications_header),
+            style = MaterialTheme.typography.labelMedium,
+        )
+        ToggleRow(
+            label = stringResource(R.string.notification_prefs_saved_decision_push_label),
+            checked = savedDecisionPush,
+            onCheckedChange = onPushChange,
+        )
+        ToggleRow(
+            label = stringResource(R.string.notification_prefs_saved_decision_email_label),
+            checked = savedDecisionEmail,
+            onCheckedChange = onEmailChange,
+        )
+    }
+}
+
+@Composable
+private fun DigestSection(
+    emailDigestEnabled: Boolean,
+    digestDay: DigestDay,
+    onEmailDigestEnabledChange: (Boolean) -> Unit,
+    onDigestDayChange: (DigestDay) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        Text(text = stringResource(R.string.notification_prefs_digest_header), style = MaterialTheme.typography.labelMedium)
+        ToggleRow(
+            label = stringResource(R.string.notification_prefs_email_digest_label),
+            checked = emailDigestEnabled,
+            onCheckedChange = onEmailDigestEnabledChange,
+        )
+        DigestDayPicker(
+            label = stringResource(R.string.notification_prefs_digest_day_label),
+            selected = digestDay,
+            onSelected = onDigestDayChange,
+        )
+    }
+}
+
+@Composable
+private fun ToggleRow(
+    label: String,
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth().padding(vertical = TownCrierSpacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(text = label, style = MaterialTheme.typography.bodyLarge)
+        Switch(checked = checked, onCheckedChange = onCheckedChange)
+    }
+}
+
+@Composable
+private fun DigestDayPicker(
+    label: String,
+    selected: DigestDay,
+    onSelected: (DigestDay) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Row(
+        modifier = modifier.fillMaxWidth().padding(vertical = TownCrierSpacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(text = label, style = MaterialTheme.typography.bodyLarge)
+        TextButton(onClick = { expanded = true }) {
+            Text(selected.wireValue)
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            DigestDay.entries.forEach { day ->
+                DropdownMenuItem(
+                    text = { Text(day.wireValue) },
+                    onClick = {
+                        onSelected(day)
+                        expanded = false
+                    },
+                    trailingIcon = {
+                        if (day == selected) Icon(imageVector = Icons.Filled.Check, contentDescription = null)
+                    },
+                )
+            }
+        }
+    }
+}
+
+@Preview(name = "light")
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun NotificationPreferencesScreenPreview() {
+    TownCrierTheme {
+        NotificationPreferencesScreen(
+            state = NotificationPreferencesUiState(isLoading = false),
+            isPushPermissionGranted = true,
+            onBack = {},
+            onSavedDecisionPushChange = {},
+            onSavedDecisionEmailChange = {},
+            onEmailDigestEnabledChange = {},
+            onDigestDayChange = {},
+        )
+    }
+}
+
+@Preview(name = "permission denied")
+@Composable
+private fun NotificationPreferencesScreenPermissionDeniedPreview() {
+    TownCrierTheme {
+        NotificationPreferencesScreen(
+            state = NotificationPreferencesUiState(isLoading = false),
+            isPushPermissionGranted = false,
+            onBack = {},
+            onSavedDecisionPushChange = {},
+            onSavedDecisionEmailChange = {},
+            onEmailDigestEnabledChange = {},
+            onDigestDayChange = {},
+        )
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/notificationprefs/NotificationPreferencesUiState.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/notificationprefs/NotificationPreferencesUiState.kt
@@ -1,0 +1,19 @@
+package uk.towncrierapp.presentation.features.notificationprefs
+
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.profile.DigestDay
+
+/**
+ * State for [NotificationPreferencesScreen]/[NotificationPreferencesViewModel].
+ * [pushEnabled] is round-tripped silently on every PATCH — it has no toggle
+ * on this screen (parity with iOS `NotificationPreferencesViewModel`).
+ */
+public data class NotificationPreferencesUiState(
+    val isLoading: Boolean = true,
+    val pushEnabled: Boolean = true,
+    val savedDecisionPush: Boolean = true,
+    val savedDecisionEmail: Boolean = true,
+    val emailDigestEnabled: Boolean = true,
+    val digestDay: DigestDay = DigestDay.MONDAY,
+    val error: DomainError? = null,
+)

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/notificationprefs/NotificationPreferencesViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/notificationprefs/NotificationPreferencesViewModel.kt
@@ -1,0 +1,119 @@
+package uk.towncrierapp.presentation.features.notificationprefs
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.profile.DigestDay
+import uk.towncrierapp.domain.profile.ServerProfile
+import uk.towncrierapp.domain.profile.UserPreferences
+import uk.towncrierapp.domain.profile.UserProfileRepository
+
+/**
+ * Drives the in-app notification preferences screen: global toggles for
+ * saved-application push/email, the weekly email digest, and its day
+ * (Monday-Sunday). Loads via `GET /v1/me`
+ * ([UserProfileRepository.fetchProfile]) — not the `POST /v1/me`
+ * ensure-profile call — since only `GET`/`PATCH` return the user's actual
+ * saved preferences on the wire; the profile is guaranteed to already exist
+ * by the time an authenticated user reaches Settings ([uk.towncrierapp.presentation.auth.AuthCoordinator.onSignedIn]
+ * already ensures it). Every setter is optimistic (updates the UI
+ * immediately) and PATCHes the FULL five-field body — the server treats
+ * them as a set — rolling back to the prior value on failure. Port of iOS
+ * `NotificationPreferencesViewModel`.
+ */
+public class NotificationPreferencesViewModel(
+    private val userProfileRepository: UserProfileRepository,
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(NotificationPreferencesUiState())
+    public val uiState: StateFlow<NotificationPreferencesUiState> = _uiState.asStateFlow()
+
+    /**
+     * Loads the server profile. On any failure — including "no profile yet"
+     * — every toggle falls back to the API's documented opt-out semantics
+     * (the user is treated as opted in until they say otherwise), matching
+     * [NotificationPreferencesUiState]'s own defaults.
+     */
+    public fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+            val profile = fetchProfileOrNull()
+            _uiState.value = profile?.let(::stateFrom) ?: NotificationPreferencesUiState(isLoading = false)
+        }
+    }
+
+    public fun setSavedDecisionPush(value: Boolean) {
+        persist { it.copy(savedDecisionPush = value) }
+    }
+
+    public fun setSavedDecisionEmail(value: Boolean) {
+        persist { it.copy(savedDecisionEmail = value) }
+    }
+
+    public fun setEmailDigestEnabled(value: Boolean) {
+        persist { it.copy(emailDigestEnabled = value) }
+    }
+
+    public fun setDigestDay(value: DigestDay) {
+        persist { it.copy(digestDay = value) }
+    }
+
+    @Suppress("SwallowedException")
+    // A fetch failure — including 404 (no profile yet) — degrades to the
+    // documented opt-in defaults rather than surfacing an error banner; the
+    // user can still change and save preferences from those defaults.
+    private suspend fun fetchProfileOrNull(): ServerProfile? =
+        try {
+            userProfileRepository.fetchProfile()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: DomainError) {
+            null
+        }
+
+    /**
+     * Shared persistence path for all four setters: optimistically applies
+     * [transform] to the current state, PATCHes the full resulting
+     * five-field body, and rolls back to the pre-transform state (with the
+     * error attached) on failure.
+     */
+    private fun persist(transform: (NotificationPreferencesUiState) -> NotificationPreferencesUiState) {
+        val previous = _uiState.value
+        val next = transform(previous).copy(error = null)
+        _uiState.value = next
+        viewModelScope.launch {
+            try {
+                val updated = userProfileRepository.updatePreferences(next.toUserPreferences())
+                _uiState.value = stateFrom(updated)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                _uiState.value = previous.copy(error = e)
+            }
+        }
+    }
+}
+
+private fun stateFrom(profile: ServerProfile): NotificationPreferencesUiState =
+    NotificationPreferencesUiState(
+        isLoading = false,
+        pushEnabled = profile.pushEnabled,
+        savedDecisionPush = profile.savedDecisionPush,
+        savedDecisionEmail = profile.savedDecisionEmail,
+        emailDigestEnabled = profile.emailDigestEnabled,
+        digestDay = profile.digestDay,
+    )
+
+private fun NotificationPreferencesUiState.toUserPreferences(): UserPreferences =
+    UserPreferences(
+        pushEnabled = pushEnabled,
+        digestDay = digestDay,
+        emailDigestEnabled = emailDigestEnabled,
+        savedDecisionPush = savedDecisionPush,
+        savedDecisionEmail = savedDecisionEmail,
+    )

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/saved/SavedListScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/saved/SavedListScreen.kt
@@ -14,10 +14,12 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -50,6 +52,7 @@ import uk.towncrierapp.presentation.features.applicationlist.applicationErrorMes
 public fun SavedListRoute(
     viewModel: SavedListViewModel,
     onApplicationSelected: (PlanningApplication) -> Unit,
+    onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -57,6 +60,7 @@ public fun SavedListRoute(
         state = state,
         onFilterSelected = viewModel::selectFilter,
         onApplicationClick = onApplicationSelected,
+        onSettingsClick = onSettingsClick,
         modifier = modifier,
     )
 }
@@ -67,11 +71,24 @@ internal fun SavedListScreen(
     state: SavedListUiState,
     onFilterSelected: (ApplicationStatus?) -> Unit,
     onApplicationClick: (PlanningApplication) -> Unit,
+    onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
         modifier = modifier,
-        topBar = { TopAppBar(title = { Text(stringResource(R.string.saved_title)) }) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.saved_title)) },
+                actions = {
+                    IconButton(onClick = onSettingsClick) {
+                        Icon(
+                            imageVector = Icons.Filled.Settings,
+                            contentDescription = stringResource(R.string.settings_content_description),
+                        )
+                    }
+                },
+            )
+        },
     ) { contentPadding ->
         Column(modifier = Modifier.padding(contentPadding).fillMaxSize()) {
             SavedFilterChipsRow(
@@ -195,6 +212,11 @@ private fun SavedEmptyState(modifier: Modifier = Modifier) {
 @Composable
 private fun SavedListScreenEmptyPreview() {
     TownCrierTheme {
-        SavedListScreen(state = SavedListUiState(), onFilterSelected = {}, onApplicationClick = {})
+        SavedListScreen(
+            state = SavedListUiState(),
+            onFilterSelected = {},
+            onApplicationClick = {},
+            onSettingsClick = {},
+        )
     }
 }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsDataAndDangerSections.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsDataAndDangerSections.kt
@@ -1,0 +1,145 @@
+package uk.towncrierapp.presentation.features.settings
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+
+// The second half of SettingsScreen's row/section composables (data
+// attribution through about), split from SettingsSections.kt to keep both
+// files under detekt's per-file function-count budget (same pattern as
+// WatchZoneEditorScreen.kt / WatchZoneEditorSections.kt).
+
+private data class AttributionItem(
+    val nameRes: Int,
+    val detailRes: Int,
+)
+
+private val ATTRIBUTION_ITEMS =
+    listOf(
+        AttributionItem(R.string.settings_attribution_planit_name, R.string.settings_attribution_planit_detail),
+        AttributionItem(
+            R.string.settings_attribution_crown_copyright_name,
+            R.string.settings_attribution_crown_copyright_detail,
+        ),
+        AttributionItem(
+            R.string.settings_attribution_ordnance_survey_name,
+            R.string.settings_attribution_ordnance_survey_detail,
+        ),
+        // Google Maps, not Apple Maps — Android attribution set (Maps SDK legal requirement).
+        AttributionItem(
+            R.string.settings_attribution_google_maps_name,
+            R.string.settings_attribution_google_maps_detail,
+        ),
+    )
+
+@Composable
+internal fun AttributionSection(modifier: Modifier = Modifier) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        SectionHeader(stringResource(R.string.settings_attribution_header))
+        ATTRIBUTION_ITEMS.forEach { item ->
+            Column(modifier = Modifier.padding(vertical = TownCrierSpacing.xs)) {
+                Text(text = stringResource(item.nameRes), style = MaterialTheme.typography.bodyLarge)
+                Text(
+                    text = stringResource(item.detailRes),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun LegalSection(
+    onPrivacyPolicyClick: () -> Unit,
+    onTermsOfServiceClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        SectionHeader(stringResource(R.string.settings_legal_header))
+        SettingsRow(label = stringResource(R.string.settings_legal_privacy_row), onClick = onPrivacyPolicyClick)
+        SettingsRow(label = stringResource(R.string.settings_legal_terms_row), onClick = onTermsOfServiceClick)
+    }
+}
+
+@Composable
+internal fun ExportDataRow(
+    isExporting: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingsRow(
+        label = stringResource(R.string.settings_export_row),
+        onClick = onClick,
+        modifier = modifier,
+        trailing = { if (isExporting) CircularProgressIndicator(modifier = Modifier.heightIn(max = 20.dp)) },
+    )
+}
+
+@Composable
+internal fun DangerZoneSection(
+    isDeletingAccount: Boolean,
+    deletionError: DomainError?,
+    onSignOutClick: () -> Unit,
+    onDeleteAccountClick: () -> Unit,
+    onRetryDeleteAccount: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        SectionHeader(stringResource(R.string.settings_danger_header))
+        SettingsRow(label = stringResource(R.string.settings_sign_out_row), onClick = onSignOutClick)
+        SettingsRow(
+            label = stringResource(R.string.settings_delete_account_row),
+            onClick = onDeleteAccountClick,
+            trailing = { if (isDeletingAccount) CircularProgressIndicator(modifier = Modifier.heightIn(max = 20.dp)) },
+        )
+        if (deletionError != null) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.settings_delete_error_generic),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                TextButton(onClick = onRetryDeleteAccount) {
+                    Text(stringResource(R.string.settings_delete_retry_button))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun AboutSection(
+    appVersion: String,
+    onRateAppClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        SectionHeader(stringResource(R.string.settings_about_header))
+        SettingsRow(label = stringResource(R.string.settings_rate_app_row), onClick = onRateAppClick)
+        Text(
+            text = stringResource(R.string.settings_version_row, appVersion),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsScreen.kt
@@ -1,0 +1,266 @@
+package uk.towncrierapp.presentation.features.settings
+
+import android.content.Context
+import android.content.Intent
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.core.content.FileProvider
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import uk.towncrierapp.domain.auth.AuthMethod
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.Appearance
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+import java.io.File
+
+/**
+ * The Settings screen: account display, appearance picker, notification
+ * preferences entry, subscription, data attribution, legal documents,
+ * GDPR export, sign-out, account deletion, and about. Port of iOS
+ * `SettingsView`. Row order is the epic's fixed inventory — do not reorder.
+ */
+@Composable
+public fun SettingsRoute(
+    viewModel: SettingsViewModel,
+    onBack: () -> Unit,
+    onNotificationPreferencesClick: () -> Unit,
+    onPrivacyPolicyClick: () -> Unit,
+    onTermsOfServiceClick: () -> Unit,
+    onRateAppClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) { viewModel.load() }
+
+    LaunchedEffect(state.exportedData) {
+        state.exportedData?.let { exported ->
+            shareExportedData(context, exported.bytes)
+            viewModel.dismissExportShare()
+        }
+    }
+
+    SettingsScreen(
+        state = state,
+        onBack = onBack,
+        onAppearanceSelected = viewModel::setAppearance,
+        onNotificationPreferencesClick = onNotificationPreferencesClick,
+        onPrivacyPolicyClick = onPrivacyPolicyClick,
+        onTermsOfServiceClick = onTermsOfServiceClick,
+        onExportDataClick = viewModel::exportData,
+        onSignOutClick = viewModel::signOut,
+        onDeleteAccountClick = viewModel::requestAccountDeletion,
+        onCancelDeleteAccount = viewModel::cancelAccountDeletion,
+        onConfirmDeleteAccount = viewModel::confirmDeleteAccount,
+        onRateAppClick = onRateAppClick,
+        modifier = modifier,
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SettingsScreen(
+    state: SettingsUiState,
+    onBack: () -> Unit,
+    onAppearanceSelected: (Appearance) -> Unit,
+    onNotificationPreferencesClick: () -> Unit,
+    onPrivacyPolicyClick: () -> Unit,
+    onTermsOfServiceClick: () -> Unit,
+    onExportDataClick: () -> Unit,
+    onSignOutClick: () -> Unit,
+    onDeleteAccountClick: () -> Unit,
+    onCancelDeleteAccount: () -> Unit,
+    onConfirmDeleteAccount: () -> Unit,
+    onRateAppClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isShowingManageSubscriptionInfo by remember { mutableStateOf(false) }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.settings_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(imageVector = Icons.AutoMirrored.Filled.ArrowBack, contentDescription = null)
+                    }
+                },
+            )
+        },
+    ) { contentPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(contentPadding)
+                    .fillMaxSize()
+                    .verticalScroll(rememberScrollState())
+                    .padding(TownCrierSpacing.md),
+            verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.lg),
+        ) {
+            AccountSection(email = state.email, authMethod = state.authMethod)
+            AppearanceSection(selected = state.appearance, onSelected = onAppearanceSelected)
+            NotificationPreferencesRow(onClick = onNotificationPreferencesClick)
+            SubscriptionSection(
+                tier = state.subscriptionTier,
+                onManageSubscriptionClick = { isShowingManageSubscriptionInfo = true },
+            )
+            AttributionSection()
+            LegalSection(onPrivacyPolicyClick = onPrivacyPolicyClick, onTermsOfServiceClick = onTermsOfServiceClick)
+            ExportDataRow(isExporting = state.isExporting, onClick = onExportDataClick)
+            DangerZoneSection(
+                isDeletingAccount = state.isDeletingAccount,
+                deletionError = state.deletionError,
+                onSignOutClick = onSignOutClick,
+                onDeleteAccountClick = onDeleteAccountClick,
+                onRetryDeleteAccount = onConfirmDeleteAccount,
+            )
+            AboutSection(appVersion = state.appVersion, onRateAppClick = onRateAppClick)
+        }
+    }
+
+    if (isShowingManageSubscriptionInfo) {
+        ManageSubscriptionComingSoonDialog(onDismiss = { isShowingManageSubscriptionInfo = false })
+    }
+
+    if (state.isShowingDeleteConfirmation) {
+        DeleteAccountConfirmationDialog(onConfirm = onConfirmDeleteAccount, onDismiss = onCancelDeleteAccount)
+    }
+}
+
+@Composable
+private fun ManageSubscriptionComingSoonDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.settings_subscription_manage_coming_soon_title)) },
+        text = { Text(stringResource(R.string.settings_subscription_manage_coming_soon_message)) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_subscription_manage_coming_soon_dismiss))
+            }
+        },
+    )
+}
+
+@Composable
+private fun DeleteAccountConfirmationDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.settings_delete_confirm_title)) },
+        text = { Text(stringResource(R.string.settings_delete_confirm_message)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.settings_delete_confirm_button), color = MaterialTheme.colorScheme.error)
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(R.string.settings_delete_cancel_button)) }
+        },
+    )
+}
+
+/** Writes [bytes] verbatim to a cache-dir export file and launches the share sheet via [FileProvider]. */
+private fun shareExportedData(
+    context: Context,
+    bytes: ByteArray,
+) {
+    val exportsDir = File(context.cacheDir, "exports").apply { mkdirs() }
+    val file = File(exportsDir, "towncrier-data-export.json")
+    file.writeBytes(bytes)
+    val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+    val sendIntent =
+        Intent(Intent.ACTION_SEND).apply {
+            type = "application/json"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    context.startActivity(Intent.createChooser(sendIntent, null))
+}
+
+@Preview(name = "light")
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun SettingsScreenPreview() {
+    TownCrierTheme {
+        SettingsScreen(
+            state =
+                SettingsUiState(
+                    isLoading = false,
+                    email = "resident@example.test",
+                    name = "Resident",
+                    authMethod = AuthMethod.EMAIL_PASSWORD,
+                    subscriptionTier = SubscriptionTier.PERSONAL,
+                    appVersion = "1.0.0",
+                ),
+            onBack = {},
+            onAppearanceSelected = {},
+            onNotificationPreferencesClick = {},
+            onPrivacyPolicyClick = {},
+            onTermsOfServiceClick = {},
+            onExportDataClick = {},
+            onSignOutClick = {},
+            onDeleteAccountClick = {},
+            onCancelDeleteAccount = {},
+            onConfirmDeleteAccount = {},
+            onRateAppClick = {},
+        )
+    }
+}
+
+@Preview(name = "SIWA — blank email")
+@Composable
+private fun SettingsScreenSiwaPreview() {
+    TownCrierTheme {
+        SettingsScreen(
+            state =
+                SettingsUiState(
+                    isLoading = false,
+                    email = "",
+                    authMethod = AuthMethod.APPLE,
+                    appVersion = "1.0.0",
+                ),
+            onBack = {},
+            onAppearanceSelected = {},
+            onNotificationPreferencesClick = {},
+            onPrivacyPolicyClick = {},
+            onTermsOfServiceClick = {},
+            onExportDataClick = {},
+            onSignOutClick = {},
+            onDeleteAccountClick = {},
+            onCancelDeleteAccount = {},
+            onConfirmDeleteAccount = {},
+            onRateAppClick = {},
+        )
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsSections.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsSections.kt
@@ -8,26 +8,25 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import uk.towncrierapp.domain.auth.AuthMethod
-import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
 import uk.towncrierapp.presentation.R
 import uk.towncrierapp.presentation.designsystem.Appearance
 import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
 
-// This file holds SettingsScreen's row/section composables, split out to
-// keep SettingsScreen.kt under detekt's per-file function-count budget
-// (same pattern as WatchZoneEditorScreen.kt / WatchZoneEditorSections.kt).
+// This file holds SettingsScreen's row/section composables (account through
+// subscription); the rest (attribution through about) live in
+// SettingsDataAndDangerSections.kt — split to keep both files under
+// detekt's per-file function-count budget (same pattern as
+// WatchZoneEditorScreen.kt / WatchZoneEditorSections.kt).
 
 @Composable
 internal fun SectionHeader(
@@ -162,123 +161,3 @@ private fun tierLabelRes(tier: SubscriptionTier): Int =
         SubscriptionTier.PERSONAL -> R.string.settings_subscription_tier_personal
         SubscriptionTier.PRO -> R.string.settings_subscription_tier_pro
     }
-
-private data class AttributionItem(
-    val nameRes: Int,
-    val detailRes: Int,
-)
-
-private val ATTRIBUTION_ITEMS =
-    listOf(
-        AttributionItem(R.string.settings_attribution_planit_name, R.string.settings_attribution_planit_detail),
-        AttributionItem(
-            R.string.settings_attribution_crown_copyright_name,
-            R.string.settings_attribution_crown_copyright_detail,
-        ),
-        AttributionItem(
-            R.string.settings_attribution_ordnance_survey_name,
-            R.string.settings_attribution_ordnance_survey_detail,
-        ),
-        // Google Maps, not Apple Maps — Android attribution set (Maps SDK legal requirement).
-        AttributionItem(
-            R.string.settings_attribution_google_maps_name,
-            R.string.settings_attribution_google_maps_detail,
-        ),
-    )
-
-@Composable
-internal fun AttributionSection(modifier: Modifier = Modifier) {
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
-        SectionHeader(stringResource(R.string.settings_attribution_header))
-        ATTRIBUTION_ITEMS.forEach { item ->
-            Column(modifier = Modifier.padding(vertical = TownCrierSpacing.xs)) {
-                Text(text = stringResource(item.nameRes), style = MaterialTheme.typography.bodyLarge)
-                Text(
-                    text = stringResource(item.detailRes),
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                )
-            }
-        }
-    }
-}
-
-@Composable
-internal fun LegalSection(
-    onPrivacyPolicyClick: () -> Unit,
-    onTermsOfServiceClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
-        SectionHeader(stringResource(R.string.settings_legal_header))
-        SettingsRow(label = stringResource(R.string.settings_legal_privacy_row), onClick = onPrivacyPolicyClick)
-        SettingsRow(label = stringResource(R.string.settings_legal_terms_row), onClick = onTermsOfServiceClick)
-    }
-}
-
-@Composable
-internal fun ExportDataRow(
-    isExporting: Boolean,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    SettingsRow(
-        label = stringResource(R.string.settings_export_row),
-        onClick = onClick,
-        modifier = modifier,
-        trailing = { if (isExporting) CircularProgressIndicator(modifier = Modifier.heightIn(max = 20.dp)) },
-    )
-}
-
-@Composable
-internal fun DangerZoneSection(
-    isDeletingAccount: Boolean,
-    deletionError: DomainError?,
-    onSignOutClick: () -> Unit,
-    onDeleteAccountClick: () -> Unit,
-    onRetryDeleteAccount: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
-        SectionHeader(stringResource(R.string.settings_danger_header))
-        SettingsRow(label = stringResource(R.string.settings_sign_out_row), onClick = onSignOutClick)
-        SettingsRow(
-            label = stringResource(R.string.settings_delete_account_row),
-            onClick = onDeleteAccountClick,
-            trailing = { if (isDeletingAccount) CircularProgressIndicator(modifier = Modifier.heightIn(max = 20.dp)) },
-        )
-        if (deletionError != null) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(
-                    text = stringResource(R.string.settings_delete_error_generic),
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.error,
-                )
-                TextButton(onClick = onRetryDeleteAccount) {
-                    Text(stringResource(R.string.settings_delete_retry_button))
-                }
-            }
-        }
-    }
-}
-
-@Composable
-internal fun AboutSection(
-    appVersion: String,
-    onRateAppClick: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
-        SectionHeader(stringResource(R.string.settings_about_header))
-        SettingsRow(label = stringResource(R.string.settings_rate_app_row), onClick = onRateAppClick)
-        Text(
-            text = stringResource(R.string.settings_version_row, appVersion),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-    }
-}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsSections.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsSections.kt
@@ -133,7 +133,11 @@ internal fun NotificationPreferencesRow(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    SettingsRow(label = stringResource(R.string.settings_notification_preferences_row), onClick = onClick, modifier = modifier)
+    SettingsRow(
+        label = stringResource(R.string.settings_notification_preferences_row),
+        onClick = onClick,
+        modifier = modifier,
+    )
 }
 
 @Composable
@@ -145,7 +149,10 @@ internal fun SubscriptionSection(
     Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
         SectionHeader(stringResource(R.string.settings_subscription_header))
         Text(text = stringResource(tierLabelRes(tier)), style = MaterialTheme.typography.bodyLarge)
-        SettingsRow(label = stringResource(R.string.settings_subscription_manage_row), onClick = onManageSubscriptionClick)
+        SettingsRow(
+            label = stringResource(R.string.settings_subscription_manage_row),
+            onClick = onManageSubscriptionClick,
+        )
     }
 }
 
@@ -173,7 +180,10 @@ private val ATTRIBUTION_ITEMS =
             R.string.settings_attribution_ordnance_survey_detail,
         ),
         // Google Maps, not Apple Maps — Android attribution set (Maps SDK legal requirement).
-        AttributionItem(R.string.settings_attribution_google_maps_name, R.string.settings_attribution_google_maps_detail),
+        AttributionItem(
+            R.string.settings_attribution_google_maps_name,
+            R.string.settings_attribution_google_maps_detail,
+        ),
     )
 
 @Composable

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsSections.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsSections.kt
@@ -1,0 +1,274 @@
+package uk.towncrierapp.presentation.features.settings
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.selectable
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import uk.towncrierapp.domain.auth.AuthMethod
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.presentation.R
+import uk.towncrierapp.presentation.designsystem.Appearance
+import uk.towncrierapp.presentation.designsystem.TownCrierSpacing
+
+// This file holds SettingsScreen's row/section composables, split out to
+// keep SettingsScreen.kt under detekt's per-file function-count budget
+// (same pattern as WatchZoneEditorScreen.kt / WatchZoneEditorSections.kt).
+
+@Composable
+internal fun SectionHeader(
+    text: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(text = text, style = MaterialTheme.typography.labelMedium, modifier = modifier)
+}
+
+@Composable
+internal fun SettingsRow(
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    trailing: @Composable () -> Unit = {},
+) {
+    Row(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .heightIn(min = 44.dp)
+                .clickable(onClick = onClick)
+                .padding(vertical = TownCrierSpacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(text = label, style = MaterialTheme.typography.bodyLarge)
+        trailing()
+    }
+}
+
+@Composable
+internal fun AccountSection(
+    email: String?,
+    authMethod: AuthMethod?,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        SectionHeader(stringResource(R.string.settings_account_header))
+        // email may legitimately be blank (Sign in with Apple grants no email
+        // scope) — render gracefully by simply omitting the row rather than
+        // showing an empty line.
+        if (!email.isNullOrBlank()) {
+            Text(text = email, style = MaterialTheme.typography.bodyLarge)
+        }
+        Text(
+            text = stringResource(authMethodLabelRes(authMethod)),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}
+
+private fun authMethodLabelRes(authMethod: AuthMethod?): Int =
+    when (authMethod) {
+        AuthMethod.EMAIL_PASSWORD -> R.string.settings_signin_method_email_password
+        AuthMethod.GOOGLE -> R.string.settings_signin_method_google
+        AuthMethod.APPLE -> R.string.settings_signin_method_apple
+        AuthMethod.UNKNOWN, null -> R.string.settings_signin_method_unknown
+    }
+
+/** All four appearance options are always visible (epic #770 pre-resolved decision) — never a collapsed picker. */
+@Composable
+internal fun AppearanceSection(
+    selected: Appearance,
+    onSelected: (Appearance) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        SectionHeader(stringResource(R.string.settings_appearance_header))
+        AppearanceOptionRow(Appearance.System, R.string.settings_appearance_system, selected, onSelected)
+        AppearanceOptionRow(Appearance.Light, R.string.settings_appearance_light, selected, onSelected)
+        AppearanceOptionRow(Appearance.Dark, R.string.settings_appearance_dark, selected, onSelected)
+        AppearanceOptionRow(Appearance.OledDark, R.string.settings_appearance_oled_dark, selected, onSelected)
+    }
+}
+
+@Composable
+private fun AppearanceOptionRow(
+    option: Appearance,
+    labelRes: Int,
+    selected: Appearance,
+    onSelected: (Appearance) -> Unit,
+) {
+    val isSelected = option == selected
+    Row(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .heightIn(min = 44.dp)
+                .selectable(selected = isSelected, onClick = { onSelected(option) })
+                .padding(vertical = TownCrierSpacing.xs),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(TownCrierSpacing.sm),
+    ) {
+        RadioButton(selected = isSelected, onClick = { onSelected(option) })
+        Text(text = stringResource(labelRes), style = MaterialTheme.typography.bodyLarge)
+    }
+}
+
+@Composable
+internal fun NotificationPreferencesRow(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingsRow(label = stringResource(R.string.settings_notification_preferences_row), onClick = onClick, modifier = modifier)
+}
+
+@Composable
+internal fun SubscriptionSection(
+    tier: SubscriptionTier,
+    onManageSubscriptionClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        SectionHeader(stringResource(R.string.settings_subscription_header))
+        Text(text = stringResource(tierLabelRes(tier)), style = MaterialTheme.typography.bodyLarge)
+        SettingsRow(label = stringResource(R.string.settings_subscription_manage_row), onClick = onManageSubscriptionClick)
+    }
+}
+
+private fun tierLabelRes(tier: SubscriptionTier): Int =
+    when (tier) {
+        SubscriptionTier.FREE -> R.string.settings_subscription_tier_free
+        SubscriptionTier.PERSONAL -> R.string.settings_subscription_tier_personal
+        SubscriptionTier.PRO -> R.string.settings_subscription_tier_pro
+    }
+
+private data class AttributionItem(
+    val nameRes: Int,
+    val detailRes: Int,
+)
+
+private val ATTRIBUTION_ITEMS =
+    listOf(
+        AttributionItem(R.string.settings_attribution_planit_name, R.string.settings_attribution_planit_detail),
+        AttributionItem(
+            R.string.settings_attribution_crown_copyright_name,
+            R.string.settings_attribution_crown_copyright_detail,
+        ),
+        AttributionItem(
+            R.string.settings_attribution_ordnance_survey_name,
+            R.string.settings_attribution_ordnance_survey_detail,
+        ),
+        // Google Maps, not Apple Maps — Android attribution set (Maps SDK legal requirement).
+        AttributionItem(R.string.settings_attribution_google_maps_name, R.string.settings_attribution_google_maps_detail),
+    )
+
+@Composable
+internal fun AttributionSection(modifier: Modifier = Modifier) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        SectionHeader(stringResource(R.string.settings_attribution_header))
+        ATTRIBUTION_ITEMS.forEach { item ->
+            Column(modifier = Modifier.padding(vertical = TownCrierSpacing.xs)) {
+                Text(text = stringResource(item.nameRes), style = MaterialTheme.typography.bodyLarge)
+                Text(
+                    text = stringResource(item.detailRes),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun LegalSection(
+    onPrivacyPolicyClick: () -> Unit,
+    onTermsOfServiceClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        SectionHeader(stringResource(R.string.settings_legal_header))
+        SettingsRow(label = stringResource(R.string.settings_legal_privacy_row), onClick = onPrivacyPolicyClick)
+        SettingsRow(label = stringResource(R.string.settings_legal_terms_row), onClick = onTermsOfServiceClick)
+    }
+}
+
+@Composable
+internal fun ExportDataRow(
+    isExporting: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SettingsRow(
+        label = stringResource(R.string.settings_export_row),
+        onClick = onClick,
+        modifier = modifier,
+        trailing = { if (isExporting) CircularProgressIndicator(modifier = Modifier.heightIn(max = 20.dp)) },
+    )
+}
+
+@Composable
+internal fun DangerZoneSection(
+    isDeletingAccount: Boolean,
+    deletionError: DomainError?,
+    onSignOutClick: () -> Unit,
+    onDeleteAccountClick: () -> Unit,
+    onRetryDeleteAccount: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        SectionHeader(stringResource(R.string.settings_danger_header))
+        SettingsRow(label = stringResource(R.string.settings_sign_out_row), onClick = onSignOutClick)
+        SettingsRow(
+            label = stringResource(R.string.settings_delete_account_row),
+            onClick = onDeleteAccountClick,
+            trailing = { if (isDeletingAccount) CircularProgressIndicator(modifier = Modifier.heightIn(max = 20.dp)) },
+        )
+        if (deletionError != null) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(R.string.settings_delete_error_generic),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+                TextButton(onClick = onRetryDeleteAccount) {
+                    Text(stringResource(R.string.settings_delete_retry_button))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun AboutSection(
+    appVersion: String,
+    onRateAppClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(TownCrierSpacing.xs)) {
+        SectionHeader(stringResource(R.string.settings_about_header))
+        SettingsRow(label = stringResource(R.string.settings_rate_app_row), onClick = onRateAppClick)
+        Text(
+            text = stringResource(R.string.settings_version_row, appVersion),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsUiState.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsUiState.kt
@@ -1,0 +1,36 @@
+package uk.towncrierapp.presentation.features.settings
+
+import uk.towncrierapp.domain.auth.AuthMethod
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.presentation.designsystem.Appearance
+
+/**
+ * A completed GDPR data export's raw bytes, ready to hand to the share
+ * sheet. Wraps [ByteArray] with content-based `equals`/`hashCode` so this
+ * type is safe inside an otherwise-structural-equality [SettingsUiState].
+ */
+public class ExportedData(
+    public val bytes: ByteArray,
+) {
+    override fun equals(other: Any?): Boolean = other is ExportedData && bytes.contentEquals(other.bytes)
+
+    override fun hashCode(): Int = bytes.contentHashCode()
+}
+
+/** State for [SettingsScreen]/[SettingsViewModel]. */
+public data class SettingsUiState(
+    val isLoading: Boolean = true,
+    val email: String? = null,
+    val name: String? = null,
+    val authMethod: AuthMethod? = null,
+    val subscriptionTier: SubscriptionTier = SubscriptionTier.FREE,
+    val appearance: Appearance = Appearance.System,
+    val isShowingDeleteConfirmation: Boolean = false,
+    val isDeletingAccount: Boolean = false,
+    val deletionError: DomainError? = null,
+    val isExporting: Boolean = false,
+    val exportedData: ExportedData? = null,
+    val exportError: DomainError? = null,
+    val appVersion: String = "",
+)

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsViewModel.kt
@@ -19,6 +19,21 @@ import uk.towncrierapp.presentation.appearance.AppearanceCoordinator
 import uk.towncrierapp.presentation.designsystem.Appearance
 
 /**
+ * Bundles the two sign-out-adjacent dependencies so [SettingsViewModel]'s own
+ * constructor parameter list stays under detekt's threshold (same rationale
+ * as `AppGraphOptions`/`SettingsLeaves` in `:app`). [deviceTokenRepository]
+ * defaults to `null` since #777 hasn't landed a real device-token
+ * registration yet — every removal attempt is a true no-op until it does.
+ * [onSignedOut] defaults to a no-op so every pre-existing call site (tests)
+ * keeps compiling unchanged; the composition root wires it to
+ * `LoginViewModel.markSignedOut()` so the shell routes back to Login.
+ */
+public class SettingsSignOutSupport(
+    public val deviceTokenRepository: DeviceTokenRepository? = null,
+    public val onSignedOut: () -> Unit = {},
+)
+
+/**
  * Drives the Settings screen: account display, the four-way appearance
  * picker, sign-out, and account deletion (UK GDPR Art. 17 ordering — see
  * [confirmDeleteAccount]). Notification preferences, legal documents, and
@@ -32,15 +47,11 @@ public class SettingsViewModel(
     private val appearanceCoordinator: AppearanceCoordinator,
     tier: SubscriptionTier,
     appVersion: String,
-    // #777 hasn't landed a real device-token registration yet — `null` in
-    // production today means every removal attempt below is a true no-op;
-    // wiring a real implementation needs no other change here.
-    private val deviceTokenRepository: DeviceTokenRepository? = null,
-    // Defaults to a no-op so every pre-existing call site (tests) keeps
-    // compiling unchanged; the composition root wires this to
-    // `LoginViewModel.markSignedOut()` so the shell routes back to Login.
-    private val onSignedOut: () -> Unit = {},
+    signOutSupport: SettingsSignOutSupport = SettingsSignOutSupport(),
 ) : ViewModel() {
+    private val deviceTokenRepository = signOutSupport.deviceTokenRepository
+    private val onSignedOut = signOutSupport.onSignedOut
+
     private val _uiState =
         MutableStateFlow(SettingsUiState(subscriptionTier = tier, appVersion = appVersion))
     public val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/settings/SettingsViewModel.kt
@@ -1,0 +1,162 @@
+package uk.towncrierapp.presentation.features.settings
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import uk.towncrierapp.domain.auth.AuthenticationService
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.devicetoken.DeviceTokenRepository
+import uk.towncrierapp.domain.profile.UserProfileRepository
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.presentation.appearance.AppearanceCoordinator
+import uk.towncrierapp.presentation.designsystem.Appearance
+
+/**
+ * Drives the Settings screen: account display, the four-way appearance
+ * picker, sign-out, and account deletion (UK GDPR Art. 17 ordering — see
+ * [confirmDeleteAccount]). Notification preferences, legal documents, and
+ * data-attribution rows are static or delegate to their own screens; this
+ * ViewModel owns only what genuinely needs server/session state. Port of
+ * iOS `SettingsViewModel`.
+ */
+public class SettingsViewModel(
+    private val authenticationService: AuthenticationService,
+    private val userProfileRepository: UserProfileRepository,
+    private val appearanceCoordinator: AppearanceCoordinator,
+    tier: SubscriptionTier,
+    appVersion: String,
+    // #777 hasn't landed a real device-token registration yet — `null` in
+    // production today means every removal attempt below is a true no-op;
+    // wiring a real implementation needs no other change here.
+    private val deviceTokenRepository: DeviceTokenRepository? = null,
+    // Defaults to a no-op so every pre-existing call site (tests) keeps
+    // compiling unchanged; the composition root wires this to
+    // `LoginViewModel.markSignedOut()` so the shell routes back to Login.
+    private val onSignedOut: () -> Unit = {},
+) : ViewModel() {
+    private val _uiState =
+        MutableStateFlow(SettingsUiState(subscriptionTier = tier, appVersion = appVersion))
+    public val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
+
+    init {
+        appearanceCoordinator.appearance
+            .onEach { appearance -> _uiState.update { it.copy(appearance = appearance) } }
+            .launchIn(viewModelScope)
+    }
+
+    /** Loads account display fields from the current session. [uk.towncrierapp.domain.auth.UserProfile.email] may legitimately be blank (SIWA). */
+    public fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            val session = authenticationService.currentSession()
+            _uiState.update {
+                it.copy(
+                    isLoading = false,
+                    email = session?.userProfile?.email,
+                    name = session?.userProfile?.name,
+                    authMethod = session?.userProfile?.authMethod,
+                )
+            }
+        }
+    }
+
+    /** Persists the choice via [AppearanceCoordinator] and restyles the whole app immediately — see [uiState]'s [SettingsUiState.appearance]. */
+    public fun setAppearance(value: Appearance) {
+        viewModelScope.launch { appearanceCoordinator.setAppearance(value) }
+    }
+
+    public fun requestAccountDeletion() {
+        _uiState.update { it.copy(isShowingDeleteConfirmation = true) }
+    }
+
+    public fun cancelAccountDeletion() {
+        _uiState.update { it.copy(isShowingDeleteConfirmation = false, deletionError = null) }
+    }
+
+    /**
+     * UK GDPR Art. 17 ordering (non-negotiable):
+     * 1. `DELETE /v1/me` must succeed FIRST — on failure, an inline retryable
+     *    error is shown and the user stays signed in.
+     * 2. Only on success: a best-effort device-token removal (never blocks
+     *    on failure).
+     * 3. Local credential/session wipe via [AuthenticationService.logout].
+     * 4. [onSignedOut] fires so the shell can route to Login — the client
+     *    never calls Auth0's management API directly; the server cascades it.
+     */
+    public fun confirmDeleteAccount() {
+        _uiState.update { it.copy(isShowingDeleteConfirmation = false, isDeletingAccount = true, deletionError = null) }
+        viewModelScope.launch {
+            try {
+                userProfileRepository.deleteAccount()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                _uiState.update { it.copy(isDeletingAccount = false, deletionError = e) }
+                return@launch
+            }
+            removeDeviceTokenBestEffort()
+            authenticationService.logout()
+            _uiState.update { it.copy(isDeletingAccount = false) }
+            onSignedOut()
+        }
+    }
+
+    /** Best-effort device-token removal, then the local session wipe — no server erasure involved (contrast [confirmDeleteAccount]). */
+    public fun signOut() {
+        viewModelScope.launch {
+            removeDeviceTokenBestEffort()
+            authenticationService.logout()
+            onSignedOut()
+        }
+    }
+
+    /**
+     * Fetches the full GDPR data export (`GET /v1/me/data`) and publishes the
+     * raw server bytes, unmodified, for the Route to hand to the share
+     * sheet. A second call while one is already in flight is ignored.
+     */
+    public fun exportData() {
+        if (_uiState.value.isExporting) return
+        _uiState.update { it.copy(isExporting = true, exportError = null, exportedData = null) }
+        viewModelScope.launch {
+            try {
+                val bytes = userProfileRepository.exportData()
+                _uiState.update { it.copy(isExporting = false, exportedData = ExportedData(bytes)) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: DomainError) {
+                _uiState.update { it.copy(isExporting = false, exportError = e) }
+            }
+        }
+    }
+
+    /** Clears the shareable artifact once the share sheet has been dismissed. */
+    public fun dismissExportShare() {
+        _uiState.update { it.copy(exportedData = null) }
+    }
+
+    /** Clears the export error once its message has been shown. */
+    public fun dismissExportError() {
+        _uiState.update { it.copy(exportError = null) }
+    }
+
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    // Best-effort by design (epic #770 / #778): a missing or failing
+    // device-token removal must never block sign-out or account deletion.
+    private suspend fun removeDeviceTokenBestEffort() {
+        try {
+            deviceTokenRepository?.removeDeviceToken()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Swallowed: see the KDoc above.
+        }
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListPreviews.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListPreviews.kt
@@ -1,0 +1,115 @@
+package uk.towncrierapp.presentation.features.watchzones
+
+import android.content.res.Configuration
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import uk.towncrierapp.domain.watchzones.Coordinate
+import uk.towncrierapp.domain.watchzones.WatchZone
+import uk.towncrierapp.domain.watchzones.WatchZoneId
+import uk.towncrierapp.presentation.designsystem.TownCrierTheme
+
+// WatchZoneListScreen's previews, split out to keep WatchZoneListScreen.kt
+// under detekt's per-file function-count budget (same pattern as
+// WatchZoneEditorScreen.kt / WatchZoneEditorSections.kt).
+
+// Preview-only sample data — cannot reuse :domain's testFixtures from the
+// main source set (compose-ui.md: previews can't see test/testFixtures
+// source sets), so a small duplicate lives here instead.
+private val previewHomeZone =
+    WatchZone(
+        id = WatchZoneId("preview-home"),
+        name = "Home",
+        centre = Coordinate(51.5074, -0.1278),
+        radiusMetres = 500.0,
+    )
+private val previewOfficeZone =
+    WatchZone(
+        id = WatchZoneId("preview-office"),
+        name = "Office",
+        centre = Coordinate(51.5155, -0.0922),
+        radiusMetres = 1_500.0,
+    )
+private val previewParentsZone =
+    WatchZone(
+        id = WatchZoneId("preview-parents"),
+        name = "Parents",
+        centre = Coordinate(52.2053, 0.1218),
+        radiusMetres = 2_000.0,
+    )
+
+@Preview(name = "light")
+@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
+@Composable
+private fun WatchZoneListScreenPreview() {
+    TownCrierTheme {
+        WatchZoneListScreen(
+            state = WatchZoneListUiState(zones = listOf(previewHomeZone, previewOfficeZone)),
+            onZoneSelected = {},
+            onZonePreferencesSelected = {},
+            onDeleteZone = {},
+            onAddZoneClick = {},
+            onViewPlansClick = {},
+            onSettingsClick = {},
+        )
+    }
+}
+
+@Preview(name = "empty")
+@Composable
+private fun WatchZoneListScreenEmptyPreview() {
+    TownCrierTheme {
+        WatchZoneListScreen(
+            state = WatchZoneListUiState(),
+            onZoneSelected = {},
+            onZonePreferencesSelected = {},
+            onDeleteZone = {},
+            onAddZoneClick = {},
+            onViewPlansClick = {},
+            onSettingsClick = {},
+        )
+    }
+}
+
+@Preview(name = "free tier at cap — badge + inline upsell")
+@Composable
+private fun WatchZoneListScreenFreeAtCapPreview() {
+    TownCrierTheme {
+        WatchZoneListScreen(
+            state =
+                WatchZoneListUiState(
+                    zones = listOf(previewHomeZone),
+                    canAddZone = false,
+                    showUpgradeBadge = true,
+                    showsFreeTierUpsell = true,
+                ),
+            onZoneSelected = {},
+            onZonePreferencesSelected = {},
+            onDeleteZone = {},
+            onAddZoneClick = {},
+            onViewPlansClick = {},
+            onSettingsClick = {},
+        )
+    }
+}
+
+@Preview(name = "personal tier at cap — badge only")
+@Composable
+private fun WatchZoneListScreenPersonalAtCapPreview() {
+    TownCrierTheme {
+        WatchZoneListScreen(
+            state =
+                WatchZoneListUiState(
+                    zones = listOf(previewHomeZone, previewOfficeZone, previewParentsZone),
+                    canAddZone = false,
+                    showUpgradeBadge = true,
+                    showsFreeTierUpsell = false,
+                ),
+            onZoneSelected = {},
+            onZonePreferencesSelected = {},
+            onDeleteZone = {},
+            onAddZoneClick = {},
+            onViewPlansClick = {},
+            onSettingsClick = {},
+        )
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListScreen.kt
@@ -1,6 +1,5 @@
 package uk.towncrierapp.presentation.features.watchzones
 
-import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -19,6 +18,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Place
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -36,10 +36,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import uk.towncrierapp.domain.watchzones.Coordinate
 import uk.towncrierapp.domain.watchzones.WatchZone
 import uk.towncrierapp.domain.watchzones.WatchZoneId
 import uk.towncrierapp.presentation.R
@@ -61,6 +59,7 @@ public fun WatchZonesRoute(
     onZoneSelected: (WatchZone) -> Unit,
     onZonePreferencesSelected: (WatchZone) -> Unit,
     onAddZone: () -> Unit,
+    onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val state by viewModel.uiState.collectAsStateWithLifecycle()
@@ -71,6 +70,7 @@ public fun WatchZonesRoute(
         onDeleteZone = viewModel::deleteZone,
         onAddZoneClick = { if (state.canAddZone) onAddZone() },
         onViewPlansClick = { /* no-op until #783 ships the paywall */ },
+        onSettingsClick = onSettingsClick,
         modifier = modifier,
     )
 }
@@ -84,37 +84,16 @@ internal fun WatchZoneListScreen(
     onDeleteZone: (WatchZone) -> Unit,
     onAddZoneClick: () -> Unit,
     onViewPlansClick: () -> Unit,
+    onSettingsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
         modifier = modifier,
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.watch_zones_title)) },
-                actions = {
-                    if (state.showUpgradeBadge) {
-                        // Not an IconButton: its fixed-size (40dp) content box
-                        // clips a wider pill-shaped badge with a text label,
-                        // squeezing "Upgrade" into a vertical wrap — verified
-                        // live on-device (tc-z95t). A clickable Box lets the
-                        // badge size itself naturally while staying tappable.
-                        Box(
-                            modifier =
-                                Modifier
-                                    .clickable(onClick = onAddZoneClick)
-                                    .padding(horizontal = TownCrierSpacing.md, vertical = TownCrierSpacing.sm),
-                        ) {
-                            UpgradeBadge()
-                        }
-                    } else {
-                        IconButton(onClick = onAddZoneClick) {
-                            Icon(
-                                imageVector = Icons.Filled.Add,
-                                contentDescription = stringResource(R.string.watch_zones_add_content_description),
-                            )
-                        }
-                    }
-                },
+            WatchZoneListTopBar(
+                showUpgradeBadge = state.showUpgradeBadge,
+                onAddZoneClick = onAddZoneClick,
+                onSettingsClick = onSettingsClick,
             )
         },
     ) { contentPadding ->
@@ -148,6 +127,48 @@ internal fun WatchZoneListScreen(
             }
         }
     }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun WatchZoneListTopBar(
+    showUpgradeBadge: Boolean,
+    onAddZoneClick: () -> Unit,
+    onSettingsClick: () -> Unit,
+) {
+    TopAppBar(
+        title = { Text(stringResource(R.string.watch_zones_title)) },
+        actions = {
+            if (showUpgradeBadge) {
+                // Not an IconButton: its fixed-size (40dp) content box clips a
+                // wider pill-shaped badge with a text label, squeezing
+                // "Upgrade" into a vertical wrap — verified live on-device
+                // (tc-z95t). A clickable Box lets the badge size itself
+                // naturally while staying tappable.
+                Box(
+                    modifier =
+                        Modifier
+                            .clickable(onClick = onAddZoneClick)
+                            .padding(horizontal = TownCrierSpacing.md, vertical = TownCrierSpacing.sm),
+                ) {
+                    UpgradeBadge()
+                }
+            } else {
+                IconButton(onClick = onAddZoneClick) {
+                    Icon(
+                        imageVector = Icons.Filled.Add,
+                        contentDescription = stringResource(R.string.watch_zones_add_content_description),
+                    )
+                }
+            }
+            IconButton(onClick = onSettingsClick) {
+                Icon(
+                    imageVector = Icons.Filled.Settings,
+                    contentDescription = stringResource(R.string.settings_content_description),
+                )
+            }
+        },
+    )
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -274,100 +295,4 @@ private fun EmptyState(
     }
 }
 
-// Preview-only sample data — cannot reuse :domain's testFixtures from the
-// main source set (compose-ui.md: previews can't see test/testFixtures
-// source sets), so a small duplicate lives here instead.
-private val previewHomeZone =
-    WatchZone(
-        id = WatchZoneId("preview-home"),
-        name = "Home",
-        centre = Coordinate(51.5074, -0.1278),
-        radiusMetres = 500.0,
-    )
-private val previewOfficeZone =
-    WatchZone(
-        id = WatchZoneId("preview-office"),
-        name = "Office",
-        centre = Coordinate(51.5155, -0.0922),
-        radiusMetres = 1_500.0,
-    )
-private val previewParentsZone =
-    WatchZone(
-        id = WatchZoneId("preview-parents"),
-        name = "Parents",
-        centre = Coordinate(52.2053, 0.1218),
-        radiusMetres = 2_000.0,
-    )
-
-@Preview(name = "light")
-@Preview(name = "dark", uiMode = Configuration.UI_MODE_NIGHT_YES)
-@Composable
-private fun WatchZoneListScreenPreview() {
-    TownCrierTheme {
-        WatchZoneListScreen(
-            state = WatchZoneListUiState(zones = listOf(previewHomeZone, previewOfficeZone)),
-            onZoneSelected = {},
-            onZonePreferencesSelected = {},
-            onDeleteZone = {},
-            onAddZoneClick = {},
-            onViewPlansClick = {},
-        )
-    }
-}
-
-@Preview(name = "empty")
-@Composable
-private fun WatchZoneListScreenEmptyPreview() {
-    TownCrierTheme {
-        WatchZoneListScreen(
-            state = WatchZoneListUiState(),
-            onZoneSelected = {},
-            onZonePreferencesSelected = {},
-            onDeleteZone = {},
-            onAddZoneClick = {},
-            onViewPlansClick = {},
-        )
-    }
-}
-
-@Preview(name = "free tier at cap — badge + inline upsell")
-@Composable
-private fun WatchZoneListScreenFreeAtCapPreview() {
-    TownCrierTheme {
-        WatchZoneListScreen(
-            state =
-                WatchZoneListUiState(
-                    zones = listOf(previewHomeZone),
-                    canAddZone = false,
-                    showUpgradeBadge = true,
-                    showsFreeTierUpsell = true,
-                ),
-            onZoneSelected = {},
-            onZonePreferencesSelected = {},
-            onDeleteZone = {},
-            onAddZoneClick = {},
-            onViewPlansClick = {},
-        )
-    }
-}
-
-@Preview(name = "personal tier at cap — badge only")
-@Composable
-private fun WatchZoneListScreenPersonalAtCapPreview() {
-    TownCrierTheme {
-        WatchZoneListScreen(
-            state =
-                WatchZoneListUiState(
-                    zones = listOf(previewHomeZone, previewOfficeZone, previewParentsZone),
-                    canAddZone = false,
-                    showUpgradeBadge = true,
-                    showsFreeTierUpsell = false,
-                ),
-            onZoneSelected = {},
-            onZonePreferencesSelected = {},
-            onDeleteZone = {},
-            onAddZoneClick = {},
-            onViewPlansClick = {},
-        )
-    }
-}
+// Previews live in WatchZoneListPreviews.kt (detekt per-file function-count budget).

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/reviewprompt/ReviewPromptTracker.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/reviewprompt/ReviewPromptTracker.kt
@@ -1,0 +1,67 @@
+package uk.towncrierapp.presentation.reviewprompt
+
+import uk.towncrierapp.domain.reviewprompt.ReviewPromptDecision
+import uk.towncrierapp.domain.reviewprompt.ReviewPromptPolicy
+import uk.towncrierapp.domain.reviewprompt.ReviewPromptState
+import uk.towncrierapp.domain.reviewprompt.ReviewPromptStore
+import uk.towncrierapp.domain.reviewprompt.ReviewRequester
+import uk.towncrierapp.domain.reviewprompt.ReviewSignal
+import java.time.Clock
+
+/**
+ * The service the app talks to for the store review prompt (GH #628). Owns
+ * the only mutable session flag ([suppressThisSession]), reads and writes
+ * the persisted state via the injected [ReviewPromptStore], runs the pure
+ * [ReviewPromptPolicy] on each signal, and — on a FIRE decision — asks the
+ * injected [ReviewRequester] to present the dialog. Port of iOS
+ * `ReviewPromptTracker`.
+ */
+public class ReviewPromptTracker(
+    private val store: ReviewPromptStore,
+    private val requester: ReviewRequester,
+    private val clock: Clock = Clock.systemUTC(),
+    private val policy: ReviewPromptPolicy = ReviewPromptPolicy(clock),
+) {
+    private var isSessionSuppressed = false
+
+    /**
+     * Suppresses any review prompt for the rest of this session. Call during
+     * onboarding, when a post-purchase prompt fires, and on friction.
+     */
+    public fun suppressThisSession() {
+        isSessionSuppressed = true
+    }
+
+    /**
+     * Records an engagement signal: updates the persisted state via the
+     * policy and, on a FIRE decision, requests the native review dialog.
+     */
+    public suspend fun recordSignal(
+        signal: ReviewSignal,
+        isReactivation: Boolean = false,
+    ) {
+        val state = establishFirstLaunchDateIfNeeded(store.load())
+        val outcome = policy.evaluate(signal, state, isSessionSuppressed, isReactivation)
+        store.save(outcome.state)
+        if (outcome.decision == ReviewPromptDecision.FIRE) {
+            requester.requestReview()
+        }
+    }
+
+    /**
+     * Records a loyalty active-day signal on app foreground. [isReactivation]
+     * is `true` only for a background-to-active re-entry, never the
+     * cold-launch render.
+     */
+    public suspend fun recordAppForegrounded(isReactivation: Boolean) {
+        recordSignal(ReviewSignal.ActiveDay, isReactivation)
+    }
+
+    /** Anchors the account-age guard the first time the tracker runs on a device. */
+    private suspend fun establishFirstLaunchDateIfNeeded(state: ReviewPromptState): ReviewPromptState {
+        if (state.firstLaunchDate != null) return state
+        val updated = state.copy(firstLaunchDate = clock.instant())
+        store.save(updated)
+        return updated
+    }
+}

--- a/mobile/android/presentation/src/main/res/values/strings.xml
+++ b/mobile/android/presentation/src/main/res/values/strings.xml
@@ -147,4 +147,75 @@
     <string name="onboarding_notifications_enable_button">Enable notifications</string>
     <string name="onboarding_notifications_skip_button">Skip for now</string>
     <string name="onboarding_notifications_finish_button">Finish</string>
+
+    <!-- Settings (tc-4jjw / #778) -->
+    <string name="settings_title">Settings</string>
+    <string name="settings_content_description">Settings</string>
+    <string name="settings_account_header">Account</string>
+    <string name="settings_signin_method_email_password">Signed in with email</string>
+    <string name="settings_signin_method_google">Signed in with Google</string>
+    <string name="settings_signin_method_apple">Signed in with Apple</string>
+    <string name="settings_signin_method_unknown">Signed in</string>
+
+    <string name="settings_appearance_header">Appearance</string>
+    <string name="settings_appearance_system">System</string>
+    <string name="settings_appearance_light">Light</string>
+    <string name="settings_appearance_dark">Dark</string>
+    <string name="settings_appearance_oled_dark">OLED Dark</string>
+
+    <string name="settings_notification_preferences_row">Notification Preferences</string>
+
+    <string name="settings_subscription_header">Subscription</string>
+    <string name="settings_subscription_tier_free">Free</string>
+    <string name="settings_subscription_tier_personal">Personal</string>
+    <string name="settings_subscription_tier_pro">Pro</string>
+    <string name="settings_subscription_manage_row">Manage Subscription</string>
+    <string name="settings_subscription_manage_coming_soon_title">Coming soon</string>
+    <string name="settings_subscription_manage_coming_soon_message">Managing your subscription from within the app is coming soon. For now, manage it from the Play Store.</string>
+    <string name="settings_subscription_manage_coming_soon_dismiss">OK</string>
+
+    <string name="settings_attribution_header">Data Attribution</string>
+    <string name="settings_attribution_planit_name">PlanIt</string>
+    <string name="settings_attribution_planit_detail">Planning application data</string>
+    <string name="settings_attribution_crown_copyright_name">Crown Copyright</string>
+    <string name="settings_attribution_crown_copyright_detail">Contains public sector information</string>
+    <string name="settings_attribution_ordnance_survey_name">Ordnance Survey</string>
+    <string name="settings_attribution_ordnance_survey_detail">Mapping data</string>
+    <string name="settings_attribution_google_maps_name">Google Maps</string>
+    <string name="settings_attribution_google_maps_detail">Map rendering and geocoding</string>
+
+    <string name="settings_legal_header">Legal</string>
+    <string name="settings_legal_privacy_row">Privacy Policy</string>
+    <string name="settings_legal_terms_row">Terms of Service</string>
+    <string name="settings_export_row">Export your data</string>
+    <string name="settings_export_error_generic">We couldn\'t export your data. Please try again.</string>
+
+    <string name="settings_danger_header">Danger Zone</string>
+    <string name="settings_sign_out_row">Sign Out</string>
+    <string name="settings_delete_account_row">Delete Account</string>
+    <string name="settings_delete_confirm_title">Delete account?</string>
+    <string name="settings_delete_confirm_message">This will permanently delete your account and all associated data. This action cannot be undone.</string>
+    <string name="settings_delete_confirm_button">Delete</string>
+    <string name="settings_delete_cancel_button">Cancel</string>
+    <string name="settings_delete_error_generic">We couldn\'t delete your account. Please try again.</string>
+    <string name="settings_delete_retry_button">Retry</string>
+
+    <string name="settings_about_header">About</string>
+    <string name="settings_rate_app_row">Rate the App</string>
+    <string name="settings_version_row">Version %1$s</string>
+
+    <!-- Notification preferences (tc-4jjw / #778) -->
+    <string name="notification_prefs_title">Notification Preferences</string>
+    <string name="notification_prefs_permission_banner_title">Notifications are off</string>
+    <string name="notification_prefs_permission_banner_body">Turn on notifications in system settings to receive push alerts.</string>
+    <string name="notification_prefs_permission_banner_button">Open Settings</string>
+    <string name="notification_prefs_saved_applications_header">Saved Applications</string>
+    <string name="notification_prefs_saved_decision_push_label">Push when a decision is made</string>
+    <string name="notification_prefs_saved_decision_email_label">Email when a decision is made</string>
+    <string name="notification_prefs_digest_header">Weekly Digest</string>
+    <string name="notification_prefs_email_digest_label">Email digest</string>
+    <string name="notification_prefs_digest_day_label">Digest day</string>
+
+    <!-- Legal documents (tc-4jjw / #778) -->
+    <string name="legal_back_content_description">Back</string>
 </resources>

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/appearance/AppearanceCoordinatorTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/appearance/AppearanceCoordinatorTest.kt
@@ -1,0 +1,73 @@
+package uk.towncrierapp.presentation.appearance
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uk.towncrierapp.domain.settings.AppearancePreference
+import uk.towncrierapp.domain.settings.FakeAppearanceStore
+import uk.towncrierapp.presentation.designsystem.Appearance
+import kotlin.test.assertEquals
+
+/**
+ * The four-way appearance picker's persistence glue (System/Light/Dark/OLED
+ * Dark, epic #770). [AppearanceCoordinator.appearance] is what
+ * `MainActivity` feeds into `TownCrierTheme`, so a [setAppearance] call
+ * restyling the theme immediately is exactly this StateFlow updating
+ * synchronously.
+ */
+class AppearanceCoordinatorTest {
+    @Test
+    fun `appearance defaults to System before load`() {
+        val sut = AppearanceCoordinator(FakeAppearanceStore())
+
+        assertEquals(Appearance.System, sut.appearance.value)
+    }
+
+    @Test
+    fun `load resolves the persisted preference`() =
+        runTest {
+            val store = FakeAppearanceStore(stored = AppearancePreference.OLED_DARK)
+            val sut = AppearanceCoordinator(store)
+
+            sut.load()
+
+            assertEquals(Appearance.OledDark, sut.appearance.value)
+        }
+
+    @Test
+    fun `load falls back to System when nothing has been chosen yet`() =
+        runTest {
+            val sut = AppearanceCoordinator(FakeAppearanceStore(stored = null))
+
+            sut.load()
+
+            assertEquals(Appearance.System, sut.appearance.value)
+        }
+
+    @Test
+    fun `setAppearance updates the StateFlow immediately and persists the mapped preference`() =
+        runTest {
+            val store = FakeAppearanceStore()
+            val sut = AppearanceCoordinator(store)
+
+            sut.setAppearance(Appearance.Dark)
+
+            assertEquals(Appearance.Dark, sut.appearance.value)
+            assertEquals(listOf(AppearancePreference.DARK), store.writeCalls)
+        }
+
+    @Test
+    fun `every Appearance value round-trips through its AppearancePreference mapping`() =
+        runTest {
+            val store = FakeAppearanceStore()
+            val sut = AppearanceCoordinator(store)
+
+            for (appearance in listOf(Appearance.System, Appearance.Light, Appearance.Dark, Appearance.OledDark)) {
+                sut.setAppearance(appearance)
+                assertEquals(appearance, sut.appearance.value)
+
+                val reloaded = AppearanceCoordinator(store)
+                reloaded.load()
+                assertEquals(appearance, reloaded.appearance.value)
+            }
+        }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinatorTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/auth/AuthCoordinatorTest.kt
@@ -7,6 +7,7 @@ import uk.towncrierapp.domain.auth.FakeAuthenticationService
 import uk.towncrierapp.domain.auth.anAuthSession
 import uk.towncrierapp.domain.profile.FakeUserProfileRepository
 import uk.towncrierapp.domain.profile.ServerProfile
+import uk.towncrierapp.domain.profile.UserPreferences
 import uk.towncrierapp.domain.profile.UserProfileRepository
 import uk.towncrierapp.domain.profile.aServerProfile
 import uk.towncrierapp.domain.subscriptions.FakeSubscriptionTierCache
@@ -221,6 +222,15 @@ class AuthCoordinatorTest {
                         callOrder += "ensureProfile"
                         return aServerProfile(tier = SubscriptionTier.PRO)
                     }
+
+                    override suspend fun fetchProfile(): ServerProfile? = error("not used by this test")
+
+                    override suspend fun updatePreferences(preferences: UserPreferences): ServerProfile =
+                        error("not used by this test")
+
+                    override suspend fun deleteAccount(): Unit = error("not used by this test")
+
+                    override suspend fun exportData(): ByteArray = error("not used by this test")
                 }
             val watchZoneRepository =
                 object : WatchZoneRepository {

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailViewModelTest.kt
@@ -156,4 +156,63 @@ class ApplicationDetailViewModelTest {
         assertFalse(viewModel.uiState.value.isSaved)
         assertEquals(DomainError.NetworkUnavailable, viewModel.uiState.value.error)
     }
+
+    // region onSaved — the review-prompt savedApplication signal call site (GH #628 / tc-4jjw)
+
+    @Test
+    fun `toggleSave fires onSaved on a successful false-to-true save`() {
+        var onSavedCallCount = 0
+        val viewModel =
+            ApplicationDetailViewModel(
+                FakePlanningApplicationRepository(),
+                FakeSavedApplicationRepository(),
+                aPlanningApplication(),
+                onSaved = { onSavedCallCount++ },
+            )
+
+        viewModel.toggleSave()
+
+        assertTrue(viewModel.uiState.value.isSaved)
+        assertEquals(1, onSavedCallCount)
+    }
+
+    @Test
+    fun `toggleSave never fires onSaved when unsaving`() {
+        var onSavedCallCount = 0
+        val id = aPlanningApplicationId()
+        val application = aPlanningApplication(id = id)
+        val savedRepository = FakeSavedApplicationRepository(mutableListOf(aSavedApplication(applicationUid = id)))
+        val viewModel =
+            ApplicationDetailViewModel(
+                FakePlanningApplicationRepository(),
+                savedRepository,
+                application,
+                onSaved = { onSavedCallCount++ },
+            )
+        viewModel.checkSavedState()
+
+        viewModel.toggleSave()
+
+        assertFalse(viewModel.uiState.value.isSaved)
+        assertEquals(0, onSavedCallCount)
+    }
+
+    @Test
+    fun `toggleSave never fires onSaved when the save call fails`() {
+        var onSavedCallCount = 0
+        val savedRepository = FakeSavedApplicationRepository().apply { saveFailWith = DomainError.NetworkUnavailable }
+        val viewModel =
+            ApplicationDetailViewModel(
+                FakePlanningApplicationRepository(),
+                savedRepository,
+                aPlanningApplication(),
+                onSaved = { onSavedCallCount++ },
+            )
+
+        viewModel.toggleSave()
+
+        assertEquals(0, onSavedCallCount)
+    }
+
+    // endregion
 }

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/legal/LegalDocumentViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/legal/LegalDocumentViewModelTest.kt
@@ -19,7 +19,10 @@ class LegalDocumentViewModelTest {
         val viewModel = LegalDocumentViewModel(FakeLegalDocumentRepository(), LegalDocumentType.PRIVACY_POLICY)
 
         assertTrue(viewModel.uiState.value.isLoading)
-        assertTrue(viewModel.uiState.value.sections.isEmpty())
+        assertTrue(
+            viewModel.uiState.value.sections
+                .isEmpty(),
+        )
     }
 
     @Test
@@ -60,9 +63,21 @@ class LegalDocumentViewModelTest {
         viewModel.load()
 
         assertEquals(2, viewModel.uiState.value.sections.size)
-        assertEquals("Who We Are", viewModel.uiState.value.sections[0].heading)
-        assertEquals("Town Crier.", viewModel.uiState.value.sections[0].body)
-        assertEquals("What We Collect", viewModel.uiState.value.sections[1].heading)
+        assertEquals(
+            "Who We Are",
+            viewModel.uiState.value.sections[0]
+                .heading,
+        )
+        assertEquals(
+            "Town Crier.",
+            viewModel.uiState.value.sections[0]
+                .body,
+        )
+        assertEquals(
+            "What We Collect",
+            viewModel.uiState.value.sections[1]
+                .heading,
+        )
     }
 
     @Test

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/legal/LegalDocumentViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/legal/LegalDocumentViewModelTest.kt
@@ -1,0 +1,77 @@
+package uk.towncrierapp.presentation.features.legal
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.legal.FakeLegalDocumentRepository
+import uk.towncrierapp.domain.legal.LegalDocumentSection
+import uk.towncrierapp.domain.legal.LegalDocumentType
+import uk.towncrierapp.domain.legal.aLegalDocument
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/** Port of iOS `LegalDocumentViewModelTests`, adapted to the async bundled-asset load (GH#778). */
+@ExtendWith(MainDispatcherExtension::class)
+class LegalDocumentViewModelTest {
+    @Test
+    fun `before load, state is loading with no content`() {
+        val viewModel = LegalDocumentViewModel(FakeLegalDocumentRepository(), LegalDocumentType.PRIVACY_POLICY)
+
+        assertTrue(viewModel.uiState.value.isLoading)
+        assertTrue(viewModel.uiState.value.sections.isEmpty())
+    }
+
+    @Test
+    fun `load populates the title and formats lastUpdated as d MMMM yyyy en-GB`() {
+        val repository =
+            FakeLegalDocumentRepository(
+                documentResult =
+                    Result.success(
+                        aLegalDocument(title = "Privacy Policy", lastUpdated = LocalDate.of(2026, 7, 1)),
+                    ),
+            )
+        val viewModel = LegalDocumentViewModel(repository, LegalDocumentType.PRIVACY_POLICY)
+
+        viewModel.load()
+
+        assertEquals("Privacy Policy", viewModel.uiState.value.title)
+        assertEquals("1 July 2026", viewModel.uiState.value.formattedLastUpdated)
+        assertEquals(false, viewModel.uiState.value.isLoading)
+    }
+
+    @Test
+    fun `load populates every section heading and body`() {
+        val repository =
+            FakeLegalDocumentRepository(
+                documentResult =
+                    Result.success(
+                        aLegalDocument(
+                            sections =
+                                listOf(
+                                    LegalDocumentSection("Who We Are", "Town Crier."),
+                                    LegalDocumentSection("What We Collect", "A unique user ID."),
+                                ),
+                        ),
+                    ),
+            )
+        val viewModel = LegalDocumentViewModel(repository, LegalDocumentType.TERMS_OF_SERVICE)
+
+        viewModel.load()
+
+        assertEquals(2, viewModel.uiState.value.sections.size)
+        assertEquals("Who We Are", viewModel.uiState.value.sections[0].heading)
+        assertEquals("Town Crier.", viewModel.uiState.value.sections[0].body)
+        assertEquals("What We Collect", viewModel.uiState.value.sections[1].heading)
+    }
+
+    @Test
+    fun `load requests the document for the constructor-supplied type`() {
+        val repository = FakeLegalDocumentRepository()
+        val viewModel = LegalDocumentViewModel(repository, LegalDocumentType.TERMS_OF_SERVICE)
+
+        viewModel.load()
+
+        assertEquals(listOf(LegalDocumentType.TERMS_OF_SERVICE), repository.documentCalls)
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/notificationprefs/NotificationPreferencesViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/notificationprefs/NotificationPreferencesViewModelTest.kt
@@ -1,0 +1,230 @@
+package uk.towncrierapp.presentation.features.notificationprefs
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.profile.DigestDay
+import uk.towncrierapp.domain.profile.FakeUserProfileRepository
+import uk.towncrierapp.domain.profile.UserPreferences
+import uk.towncrierapp.domain.profile.aServerProfile
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import kotlin.test.assertEquals
+
+/**
+ * Port of iOS `NotificationPreferencesViewModelTests`: global toggles for
+ * `savedDecisionPush`/`savedDecisionEmail`/`emailDigestEnabled`/`digestDay`,
+ * optimistic-update-with-rollback, every setter PATCHing the full five-field
+ * body. Loads via `GET /v1/me` ([uk.towncrierapp.domain.profile.UserProfileRepository.fetchProfile])
+ * rather than the `POST /v1/me` ensure-profile call, since only GET/PATCH
+ * return the user's actual saved preferences on the wire (see KEY DECISIONS,
+ * tc-4jjw) — this is what makes a real round-trip (`toggle → reload →
+ * see the persisted value`) actually work.
+ */
+@ExtendWith(MainDispatcherExtension::class)
+class NotificationPreferencesViewModelTest {
+    private fun aProfile(
+        pushEnabled: Boolean = true,
+        digestDay: DigestDay = DigestDay.MONDAY,
+        emailDigestEnabled: Boolean = true,
+        savedDecisionPush: Boolean = true,
+        savedDecisionEmail: Boolean = true,
+    ) = aServerProfile(
+        pushEnabled = pushEnabled,
+        digestDay = digestDay,
+        emailDigestEnabled = emailDigestEnabled,
+        savedDecisionPush = savedDecisionPush,
+        savedDecisionEmail = savedDecisionEmail,
+    )
+
+    // region Load
+
+    @Test
+    fun `load populates fields from the fetched profile`() {
+        val repository =
+            FakeUserProfileRepository(
+                fetchProfileResult =
+                    Result.success(
+                        aProfile(
+                            digestDay = DigestDay.FRIDAY,
+                            emailDigestEnabled = false,
+                            savedDecisionPush = false,
+                            savedDecisionEmail = true,
+                        ),
+                    ),
+            )
+        val viewModel = NotificationPreferencesViewModel(repository)
+
+        viewModel.load()
+
+        val state = viewModel.uiState.value
+        assertEquals(false, state.savedDecisionPush)
+        assertEquals(true, state.savedDecisionEmail)
+        assertEquals(false, state.emailDigestEnabled)
+        assertEquals(DigestDay.FRIDAY, state.digestDay)
+        assertEquals(false, state.isLoading)
+    }
+
+    @Test
+    fun `load falls back to defaults when fetchProfile throws`() {
+        val repository = FakeUserProfileRepository(fetchProfileResult = Result.failure(DomainError.NetworkUnavailable))
+        val viewModel = NotificationPreferencesViewModel(repository)
+
+        viewModel.load()
+
+        val state = viewModel.uiState.value
+        assertEquals(true, state.savedDecisionPush)
+        assertEquals(true, state.savedDecisionEmail)
+        assertEquals(true, state.emailDigestEnabled)
+        assertEquals(DigestDay.MONDAY, state.digestDay)
+        assertEquals(false, state.isLoading)
+    }
+
+    @Test
+    fun `load falls back to defaults when no profile exists yet`() {
+        val repository = FakeUserProfileRepository(fetchProfileResult = Result.success(null))
+        val viewModel = NotificationPreferencesViewModel(repository)
+
+        viewModel.load()
+
+        assertEquals(true, viewModel.uiState.value.savedDecisionPush)
+    }
+
+    // endregion
+
+    // region Setters — full five-field round trip
+
+    @Test
+    fun `setSavedDecisionPush PATCHes the full five-field body and round-trips other fields`() {
+        val initial =
+            aProfile(pushEnabled = true, digestDay = DigestDay.FRIDAY, emailDigestEnabled = false, savedDecisionPush = true, savedDecisionEmail = true)
+        val repository = FakeUserProfileRepository(fetchProfileResult = Result.success(initial))
+        repository.updatePreferencesResult =
+            Result.success(initial.copy(savedDecisionPush = false))
+        val viewModel = NotificationPreferencesViewModel(repository)
+        viewModel.load()
+
+        viewModel.setSavedDecisionPush(false)
+
+        assertEquals(1, repository.updatePreferencesCalls.size)
+        assertEquals(
+            UserPreferences(
+                pushEnabled = true,
+                digestDay = DigestDay.FRIDAY,
+                emailDigestEnabled = false,
+                savedDecisionPush = false,
+                savedDecisionEmail = true,
+            ),
+            repository.updatePreferencesCalls.single(),
+        )
+        assertEquals(false, viewModel.uiState.value.savedDecisionPush)
+    }
+
+    @Test
+    fun `setSavedDecisionEmail PATCHes the full five-field body and round-trips other fields`() {
+        val initial =
+            aProfile(pushEnabled = false, digestDay = DigestDay.WEDNESDAY, emailDigestEnabled = true, savedDecisionPush = true, savedDecisionEmail = true)
+        val repository = FakeUserProfileRepository(fetchProfileResult = Result.success(initial))
+        repository.updatePreferencesResult = Result.success(initial.copy(savedDecisionEmail = false))
+        val viewModel = NotificationPreferencesViewModel(repository)
+        viewModel.load()
+
+        viewModel.setSavedDecisionEmail(false)
+
+        assertEquals(
+            UserPreferences(
+                pushEnabled = false,
+                digestDay = DigestDay.WEDNESDAY,
+                emailDigestEnabled = true,
+                savedDecisionPush = true,
+                savedDecisionEmail = false,
+            ),
+            repository.updatePreferencesCalls.single(),
+        )
+        assertEquals(false, viewModel.uiState.value.savedDecisionEmail)
+    }
+
+    @Test
+    fun `setEmailDigestEnabled PATCHes the full five-field body and round-trips other fields`() {
+        val initial =
+            aProfile(pushEnabled = true, digestDay = DigestDay.TUESDAY, emailDigestEnabled = true, savedDecisionPush = false, savedDecisionEmail = true)
+        val repository = FakeUserProfileRepository(fetchProfileResult = Result.success(initial))
+        repository.updatePreferencesResult = Result.success(initial.copy(emailDigestEnabled = false))
+        val viewModel = NotificationPreferencesViewModel(repository)
+        viewModel.load()
+
+        viewModel.setEmailDigestEnabled(false)
+
+        assertEquals(
+            UserPreferences(
+                pushEnabled = true,
+                digestDay = DigestDay.TUESDAY,
+                emailDigestEnabled = false,
+                savedDecisionPush = false,
+                savedDecisionEmail = true,
+            ),
+            repository.updatePreferencesCalls.single(),
+        )
+        assertEquals(false, viewModel.uiState.value.emailDigestEnabled)
+    }
+
+    @Test
+    fun `setDigestDay PATCHes the full five-field body and round-trips other fields`() {
+        val initial =
+            aProfile(pushEnabled = true, digestDay = DigestDay.MONDAY, emailDigestEnabled = true, savedDecisionPush = true, savedDecisionEmail = false)
+        val repository = FakeUserProfileRepository(fetchProfileResult = Result.success(initial))
+        repository.updatePreferencesResult = Result.success(initial.copy(digestDay = DigestDay.SATURDAY))
+        val viewModel = NotificationPreferencesViewModel(repository)
+        viewModel.load()
+
+        viewModel.setDigestDay(DigestDay.SATURDAY)
+
+        assertEquals(
+            UserPreferences(
+                pushEnabled = true,
+                digestDay = DigestDay.SATURDAY,
+                emailDigestEnabled = true,
+                savedDecisionPush = true,
+                savedDecisionEmail = false,
+            ),
+            repository.updatePreferencesCalls.single(),
+        )
+        assertEquals(DigestDay.SATURDAY, viewModel.uiState.value.digestDay)
+    }
+
+    // endregion
+
+    // region Rollback / error
+
+    @Test
+    fun `a failed PATCH rolls the toggle back to its prior value`() {
+        val initial = aProfile(savedDecisionPush = true)
+        val repository = FakeUserProfileRepository(fetchProfileResult = Result.success(initial))
+        repository.updatePreferencesResult = Result.failure(DomainError.NetworkUnavailable)
+        val viewModel = NotificationPreferencesViewModel(repository)
+        viewModel.load()
+
+        viewModel.setSavedDecisionPush(false)
+
+        assertEquals(true, viewModel.uiState.value.savedDecisionPush)
+        assertEquals(DomainError.NetworkUnavailable, viewModel.uiState.value.error)
+    }
+
+    @Test
+    fun `a failed PATCH leaves the other three fields untouched`() {
+        val initial =
+            aProfile(digestDay = DigestDay.THURSDAY, emailDigestEnabled = false, savedDecisionEmail = false)
+        val repository = FakeUserProfileRepository(fetchProfileResult = Result.success(initial))
+        repository.updatePreferencesResult = Result.failure(DomainError.NetworkUnavailable)
+        val viewModel = NotificationPreferencesViewModel(repository)
+        viewModel.load()
+
+        viewModel.setSavedDecisionPush(false)
+
+        val state = viewModel.uiState.value
+        assertEquals(DigestDay.THURSDAY, state.digestDay)
+        assertEquals(false, state.emailDigestEnabled)
+        assertEquals(false, state.savedDecisionEmail)
+    }
+
+    // endregion
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/notificationprefs/NotificationPreferencesViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/notificationprefs/NotificationPreferencesViewModelTest.kt
@@ -96,7 +96,13 @@ class NotificationPreferencesViewModelTest {
     @Test
     fun `setSavedDecisionPush PATCHes the full five-field body and round-trips other fields`() {
         val initial =
-            aProfile(pushEnabled = true, digestDay = DigestDay.FRIDAY, emailDigestEnabled = false, savedDecisionPush = true, savedDecisionEmail = true)
+            aProfile(
+                pushEnabled = true,
+                digestDay = DigestDay.FRIDAY,
+                emailDigestEnabled = false,
+                savedDecisionPush = true,
+                savedDecisionEmail = true,
+            )
         val repository = FakeUserProfileRepository(fetchProfileResult = Result.success(initial))
         repository.updatePreferencesResult =
             Result.success(initial.copy(savedDecisionPush = false))
@@ -122,7 +128,13 @@ class NotificationPreferencesViewModelTest {
     @Test
     fun `setSavedDecisionEmail PATCHes the full five-field body and round-trips other fields`() {
         val initial =
-            aProfile(pushEnabled = false, digestDay = DigestDay.WEDNESDAY, emailDigestEnabled = true, savedDecisionPush = true, savedDecisionEmail = true)
+            aProfile(
+                pushEnabled = false,
+                digestDay = DigestDay.WEDNESDAY,
+                emailDigestEnabled = true,
+                savedDecisionPush = true,
+                savedDecisionEmail = true,
+            )
         val repository = FakeUserProfileRepository(fetchProfileResult = Result.success(initial))
         repository.updatePreferencesResult = Result.success(initial.copy(savedDecisionEmail = false))
         val viewModel = NotificationPreferencesViewModel(repository)
@@ -146,7 +158,13 @@ class NotificationPreferencesViewModelTest {
     @Test
     fun `setEmailDigestEnabled PATCHes the full five-field body and round-trips other fields`() {
         val initial =
-            aProfile(pushEnabled = true, digestDay = DigestDay.TUESDAY, emailDigestEnabled = true, savedDecisionPush = false, savedDecisionEmail = true)
+            aProfile(
+                pushEnabled = true,
+                digestDay = DigestDay.TUESDAY,
+                emailDigestEnabled = true,
+                savedDecisionPush = false,
+                savedDecisionEmail = true,
+            )
         val repository = FakeUserProfileRepository(fetchProfileResult = Result.success(initial))
         repository.updatePreferencesResult = Result.success(initial.copy(emailDigestEnabled = false))
         val viewModel = NotificationPreferencesViewModel(repository)
@@ -170,7 +188,13 @@ class NotificationPreferencesViewModelTest {
     @Test
     fun `setDigestDay PATCHes the full five-field body and round-trips other fields`() {
         val initial =
-            aProfile(pushEnabled = true, digestDay = DigestDay.MONDAY, emailDigestEnabled = true, savedDecisionPush = true, savedDecisionEmail = false)
+            aProfile(
+                pushEnabled = true,
+                digestDay = DigestDay.MONDAY,
+                emailDigestEnabled = true,
+                savedDecisionPush = true,
+                savedDecisionEmail = false,
+            )
         val repository = FakeUserProfileRepository(fetchProfileResult = Result.success(initial))
         repository.updatePreferencesResult = Result.success(initial.copy(digestDay = DigestDay.SATURDAY))
         val viewModel = NotificationPreferencesViewModel(repository)

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/settings/SettingsViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/settings/SettingsViewModelTest.kt
@@ -1,0 +1,271 @@
+package uk.towncrierapp.presentation.features.settings
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.auth.AuthMethod
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.domain.auth.FakeAuthenticationService
+import uk.towncrierapp.domain.auth.UserProfile
+import uk.towncrierapp.domain.auth.anAuthSession
+import uk.towncrierapp.domain.devicetoken.FakeDeviceTokenRepository
+import uk.towncrierapp.domain.profile.FakeUserProfileRepository
+import uk.towncrierapp.domain.settings.FakeAppearanceStore
+import uk.towncrierapp.domain.subscriptions.SubscriptionTier
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import uk.towncrierapp.presentation.appearance.AppearanceCoordinator
+import uk.towncrierapp.presentation.designsystem.Appearance
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Port of iOS `SettingsViewModelTests`/`SettingsViewModelAccountDeletionTests`/
+ * `SettingsViewModelDataExportTests`, adapted to the Android ports (tc-4jjw).
+ */
+@ExtendWith(MainDispatcherExtension::class)
+class SettingsViewModelTest {
+    private fun makeSut(
+        authService: FakeAuthenticationService = FakeAuthenticationService(),
+        userProfileRepository: FakeUserProfileRepository = FakeUserProfileRepository(),
+        deviceTokenRepository: FakeDeviceTokenRepository? = FakeDeviceTokenRepository(),
+        tier: SubscriptionTier = SubscriptionTier.FREE,
+        onSignedOut: () -> Unit = {},
+    ) = SettingsViewModel(
+        authenticationService = authService,
+        userProfileRepository = userProfileRepository,
+        appearanceCoordinator = AppearanceCoordinator(FakeAppearanceStore()),
+        tier = tier,
+        appVersion = "1.2.3",
+        deviceTokenRepository = deviceTokenRepository,
+        onSignedOut = onSignedOut,
+    )
+
+    // region Account
+
+    @Test
+    fun `load populates email name and authMethod from the current session`() {
+        val authService =
+            FakeAuthenticationService(
+                currentSessionResult =
+                    anAuthSession(
+                        userProfile = UserProfile(userId = "auth0|1", email = "resident@example.test", name = "Res"),
+                    ),
+            )
+        val viewModel = makeSut(authService = authService)
+
+        viewModel.load()
+
+        val state = viewModel.uiState.value
+        assertEquals("resident@example.test", state.email)
+        assertEquals("Res", state.name)
+        assertEquals(AuthMethod.EMAIL_PASSWORD, state.authMethod)
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `a blank SIWA email renders gracefully rather than as an error`() {
+        val authService =
+            FakeAuthenticationService(
+                currentSessionResult = anAuthSession(userProfile = UserProfile(userId = "apple|1", email = "", name = null)),
+            )
+        val viewModel = makeSut(authService = authService)
+
+        viewModel.load()
+
+        assertEquals("", viewModel.uiState.value.email)
+        assertEquals(AuthMethod.APPLE, viewModel.uiState.value.authMethod)
+    }
+
+    @Test
+    fun `the constructor-supplied tier and app version are exposed immediately`() {
+        val viewModel = makeSut(tier = SubscriptionTier.PRO)
+
+        assertEquals(SubscriptionTier.PRO, viewModel.uiState.value.subscriptionTier)
+        assertEquals("1.2.3", viewModel.uiState.value.appVersion)
+    }
+
+    // endregion
+
+    // region Appearance
+
+    @Test
+    fun `setAppearance updates the uiState via the shared AppearanceCoordinator`() {
+        val coordinator = AppearanceCoordinator(FakeAppearanceStore())
+        val viewModel =
+            SettingsViewModel(
+                authenticationService = FakeAuthenticationService(),
+                userProfileRepository = FakeUserProfileRepository(),
+                appearanceCoordinator = coordinator,
+                tier = SubscriptionTier.FREE,
+                appVersion = "1.0",
+            )
+
+        viewModel.setAppearance(Appearance.OledDark)
+
+        assertEquals(Appearance.OledDark, viewModel.uiState.value.appearance)
+        assertEquals(Appearance.OledDark, coordinator.appearance.value)
+    }
+
+    // endregion
+
+    // region Account deletion (GDPR Art. 17 ordering)
+
+    @Test
+    fun `requestAccountDeletion shows the confirmation, cancelAccountDeletion dismisses it`() {
+        val viewModel = makeSut()
+
+        viewModel.requestAccountDeletion()
+        assertTrue(viewModel.uiState.value.isShowingDeleteConfirmation)
+
+        viewModel.cancelAccountDeletion()
+        assertFalse(viewModel.uiState.value.isShowingDeleteConfirmation)
+    }
+
+    @Test
+    fun `a server deletion failure keeps the user signed in with a retryable error`() {
+        val authService = FakeAuthenticationService()
+        val userProfileRepository =
+            FakeUserProfileRepository(deleteAccountResult = Result.failure(DomainError.NetworkUnavailable))
+        var signedOutCallCount = 0
+        val viewModel = makeSut(authService = authService, userProfileRepository = userProfileRepository, onSignedOut = { signedOutCallCount++ })
+
+        viewModel.confirmDeleteAccount()
+
+        assertEquals(DomainError.NetworkUnavailable, viewModel.uiState.value.deletionError)
+        assertFalse(viewModel.uiState.value.isDeletingAccount)
+        assertTrue(authService.logoutCalls.isEmpty())
+        assertEquals(0, signedOutCallCount)
+    }
+
+    @Test
+    fun `a successful deletion attempts a best-effort device-token removal then wipes the local session`() {
+        val authService = FakeAuthenticationService()
+        val deviceTokenRepository = FakeDeviceTokenRepository()
+        var signedOutCallCount = 0
+        val viewModel =
+            makeSut(authService = authService, deviceTokenRepository = deviceTokenRepository, onSignedOut = { signedOutCallCount++ })
+
+        viewModel.confirmDeleteAccount()
+
+        assertEquals(1, deviceTokenRepository.removeDeviceTokenCalls.size)
+        assertEquals(1, authService.logoutCalls.size)
+        assertEquals(1, signedOutCallCount)
+        assertNull(viewModel.uiState.value.deletionError)
+    }
+
+    @Test
+    fun `deletion succeeds even when the device-token removal fails (best-effort)`() {
+        val authService = FakeAuthenticationService()
+        val deviceTokenRepository =
+            FakeDeviceTokenRepository(removeDeviceTokenResult = Result.failure(DomainError.NetworkUnavailable))
+        var signedOutCallCount = 0
+        val viewModel =
+            makeSut(authService = authService, deviceTokenRepository = deviceTokenRepository, onSignedOut = { signedOutCallCount++ })
+
+        viewModel.confirmDeleteAccount()
+
+        assertEquals(1, authService.logoutCalls.size)
+        assertEquals(1, signedOutCallCount)
+    }
+
+    @Test
+    fun `deletion succeeds when no device-token repository has been wired yet (777 not landed)`() {
+        val authService = FakeAuthenticationService()
+        var signedOutCallCount = 0
+        val viewModel = makeSut(authService = authService, deviceTokenRepository = null, onSignedOut = { signedOutCallCount++ })
+
+        viewModel.confirmDeleteAccount()
+
+        assertEquals(1, authService.logoutCalls.size)
+        assertEquals(1, signedOutCallCount)
+    }
+
+    @Test
+    fun `a failed deletion is retryable — calling confirmDeleteAccount again re-attempts the server DELETE`() {
+        val userProfileRepository =
+            FakeUserProfileRepository(deleteAccountResult = Result.failure(DomainError.NetworkUnavailable))
+        val viewModel = makeSut(userProfileRepository = userProfileRepository)
+
+        viewModel.confirmDeleteAccount()
+        assertEquals(1, userProfileRepository.deleteAccountCalls.size)
+
+        userProfileRepository.deleteAccountResult = Result.success(Unit)
+        viewModel.confirmDeleteAccount()
+
+        assertEquals(2, userProfileRepository.deleteAccountCalls.size)
+        assertNull(viewModel.uiState.value.deletionError)
+    }
+
+    // endregion
+
+    // region Sign out
+
+    @Test
+    fun `signOut attempts a best-effort device-token removal then wipes the local session`() {
+        val authService = FakeAuthenticationService()
+        val deviceTokenRepository = FakeDeviceTokenRepository()
+        var signedOutCallCount = 0
+        val viewModel =
+            makeSut(authService = authService, deviceTokenRepository = deviceTokenRepository, onSignedOut = { signedOutCallCount++ })
+
+        viewModel.signOut()
+
+        assertEquals(1, deviceTokenRepository.removeDeviceTokenCalls.size)
+        assertEquals(1, authService.logoutCalls.size)
+        assertEquals(1, signedOutCallCount)
+    }
+
+    // endregion
+
+    // region Data export
+
+    @Test
+    fun `exportData fetches the server bytes byte-for-byte unmodified`() {
+        val scriptedBytes = """{"profile":{"userId":"auth0|1"}}""".toByteArray(Charsets.UTF_8)
+        val userProfileRepository = FakeUserProfileRepository(exportDataResult = Result.success(scriptedBytes))
+        val viewModel = makeSut(userProfileRepository = userProfileRepository)
+
+        viewModel.exportData()
+
+        val exported = viewModel.uiState.value.exportedData
+        assertContentEquals(scriptedBytes, exported?.bytes)
+        assertFalse(viewModel.uiState.value.isExporting)
+    }
+
+    @Test
+    fun `exportData failure surfaces an error and produces no artifact`() {
+        val userProfileRepository = FakeUserProfileRepository(exportDataResult = Result.failure(DomainError.NetworkUnavailable))
+        val viewModel = makeSut(userProfileRepository = userProfileRepository)
+
+        viewModel.exportData()
+
+        assertNull(viewModel.uiState.value.exportedData)
+        assertEquals(DomainError.NetworkUnavailable, viewModel.uiState.value.exportError)
+        assertFalse(viewModel.uiState.value.isExporting)
+    }
+
+    @Test
+    fun `dismissExportShare clears the exported artifact`() {
+        val viewModel = makeSut()
+        viewModel.exportData()
+
+        viewModel.dismissExportShare()
+
+        assertNull(viewModel.uiState.value.exportedData)
+    }
+
+    @Test
+    fun `dismissExportError clears the export error`() {
+        val userProfileRepository = FakeUserProfileRepository(exportDataResult = Result.failure(DomainError.NetworkUnavailable))
+        val viewModel = makeSut(userProfileRepository = userProfileRepository)
+        viewModel.exportData()
+
+        viewModel.dismissExportError()
+
+        assertNull(viewModel.uiState.value.exportError)
+    }
+
+    // endregion
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/settings/SettingsViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/settings/SettingsViewModelTest.kt
@@ -38,8 +38,11 @@ class SettingsViewModelTest {
         appearanceCoordinator = AppearanceCoordinator(FakeAppearanceStore()),
         tier = tier,
         appVersion = "1.2.3",
-        deviceTokenRepository = deviceTokenRepository,
-        onSignedOut = onSignedOut,
+        signOutSupport =
+            SettingsSignOutSupport(
+                deviceTokenRepository = deviceTokenRepository,
+                onSignedOut = onSignedOut,
+            ),
     )
 
     // region Account

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/settings/SettingsViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/settings/SettingsViewModelTest.kt
@@ -68,7 +68,10 @@ class SettingsViewModelTest {
     fun `a blank SIWA email renders gracefully rather than as an error`() {
         val authService =
             FakeAuthenticationService(
-                currentSessionResult = anAuthSession(userProfile = UserProfile(userId = "apple|1", email = "", name = null)),
+                currentSessionResult =
+                    anAuthSession(
+                        userProfile = UserProfile(userId = "apple|1", email = "", name = null),
+                    ),
             )
         val viewModel = makeSut(authService = authService)
 
@@ -129,7 +132,10 @@ class SettingsViewModelTest {
         val userProfileRepository =
             FakeUserProfileRepository(deleteAccountResult = Result.failure(DomainError.NetworkUnavailable))
         var signedOutCallCount = 0
-        val viewModel = makeSut(authService = authService, userProfileRepository = userProfileRepository, onSignedOut = { signedOutCallCount++ })
+        val viewModel =
+            makeSut(authService = authService, userProfileRepository = userProfileRepository, onSignedOut = {
+                signedOutCallCount++
+            })
 
         viewModel.confirmDeleteAccount()
 
@@ -145,7 +151,9 @@ class SettingsViewModelTest {
         val deviceTokenRepository = FakeDeviceTokenRepository()
         var signedOutCallCount = 0
         val viewModel =
-            makeSut(authService = authService, deviceTokenRepository = deviceTokenRepository, onSignedOut = { signedOutCallCount++ })
+            makeSut(authService = authService, deviceTokenRepository = deviceTokenRepository, onSignedOut = {
+                signedOutCallCount++
+            })
 
         viewModel.confirmDeleteAccount()
 
@@ -162,7 +170,9 @@ class SettingsViewModelTest {
             FakeDeviceTokenRepository(removeDeviceTokenResult = Result.failure(DomainError.NetworkUnavailable))
         var signedOutCallCount = 0
         val viewModel =
-            makeSut(authService = authService, deviceTokenRepository = deviceTokenRepository, onSignedOut = { signedOutCallCount++ })
+            makeSut(authService = authService, deviceTokenRepository = deviceTokenRepository, onSignedOut = {
+                signedOutCallCount++
+            })
 
         viewModel.confirmDeleteAccount()
 
@@ -174,7 +184,8 @@ class SettingsViewModelTest {
     fun `deletion succeeds when no device-token repository has been wired yet (777 not landed)`() {
         val authService = FakeAuthenticationService()
         var signedOutCallCount = 0
-        val viewModel = makeSut(authService = authService, deviceTokenRepository = null, onSignedOut = { signedOutCallCount++ })
+        val viewModel =
+            makeSut(authService = authService, deviceTokenRepository = null, onSignedOut = { signedOutCallCount++ })
 
         viewModel.confirmDeleteAccount()
 
@@ -208,7 +219,9 @@ class SettingsViewModelTest {
         val deviceTokenRepository = FakeDeviceTokenRepository()
         var signedOutCallCount = 0
         val viewModel =
-            makeSut(authService = authService, deviceTokenRepository = deviceTokenRepository, onSignedOut = { signedOutCallCount++ })
+            makeSut(authService = authService, deviceTokenRepository = deviceTokenRepository, onSignedOut = {
+                signedOutCallCount++
+            })
 
         viewModel.signOut()
 
@@ -236,7 +249,8 @@ class SettingsViewModelTest {
 
     @Test
     fun `exportData failure surfaces an error and produces no artifact`() {
-        val userProfileRepository = FakeUserProfileRepository(exportDataResult = Result.failure(DomainError.NetworkUnavailable))
+        val userProfileRepository =
+            FakeUserProfileRepository(exportDataResult = Result.failure(DomainError.NetworkUnavailable))
         val viewModel = makeSut(userProfileRepository = userProfileRepository)
 
         viewModel.exportData()
@@ -258,7 +272,8 @@ class SettingsViewModelTest {
 
     @Test
     fun `dismissExportError clears the export error`() {
-        val userProfileRepository = FakeUserProfileRepository(exportDataResult = Result.failure(DomainError.NetworkUnavailable))
+        val userProfileRepository =
+            FakeUserProfileRepository(exportDataResult = Result.failure(DomainError.NetworkUnavailable))
         val viewModel = makeSut(userProfileRepository = userProfileRepository)
         viewModel.exportData()
 

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/reviewprompt/ReviewPromptTrackerTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/reviewprompt/ReviewPromptTrackerTest.kt
@@ -1,0 +1,140 @@
+package uk.towncrierapp.presentation.reviewprompt
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import uk.towncrierapp.domain.reviewprompt.FakeReviewPromptStore
+import uk.towncrierapp.domain.reviewprompt.FakeReviewRequester
+import uk.towncrierapp.domain.reviewprompt.ReviewPromptPolicy
+import uk.towncrierapp.domain.reviewprompt.ReviewSignal
+import uk.towncrierapp.domain.reviewprompt.aReviewPromptState
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Unit tests for the `:presentation` glue over the pure [ReviewPromptPolicy]
+ * (GH #628) — port of iOS `ReviewPromptTrackerTests`. The policy's own
+ * weights/guards are exhaustively covered by `ReviewPromptPolicyTest`; these
+ * tests cover only the tracker's own responsibilities: load/save
+ * orchestration, firing the requester, first-launch establishment, and
+ * session suppression.
+ */
+class ReviewPromptTrackerTest {
+    private val reference: Instant = Instant.ofEpochSecond(1_700_000_000)
+    private val clock: Clock = Clock.fixed(reference, ZoneOffset.UTC)
+
+    private fun makeSut(
+        store: FakeReviewPromptStore = FakeReviewPromptStore(),
+        requester: FakeReviewRequester = FakeReviewRequester(),
+    ) = ReviewPromptTracker(store, requester, clock, ReviewPromptPolicy(clock))
+
+    @Test
+    fun `recordSignal persists the updated state to the store`() =
+        runTest {
+            val store = FakeReviewPromptStore(aReviewPromptState(firstLaunchDate = reference))
+            val sut = makeSut(store = store)
+
+            sut.recordSignal(ReviewSignal.TappedPortal)
+
+            assertEquals(3, store.state.engagementScore)
+        }
+
+    @Test
+    fun `recordSignal requests a review when the policy decides to fire`() =
+        runTest {
+            val store =
+                FakeReviewPromptStore(
+                    aReviewPromptState(firstLaunchDate = reference.minus(Duration.ofDays(30)), engagementScore = 3),
+                )
+            val requester = FakeReviewRequester()
+            val sut = makeSut(store = store, requester = requester)
+
+            sut.recordSignal(ReviewSignal.TappedPortal)
+
+            assertEquals(1, requester.requestReviewCalls.size)
+            assertEquals(0, store.state.engagementScore)
+        }
+
+    @Test
+    fun `recordSignal does not request a review when the policy holds`() =
+        runTest {
+            val store = FakeReviewPromptStore(aReviewPromptState(firstLaunchDate = reference))
+            val requester = FakeReviewRequester()
+            val sut = makeSut(store = store, requester = requester)
+
+            sut.recordSignal(ReviewSignal.TappedPortal)
+
+            assertEquals(0, requester.requestReviewCalls.size)
+        }
+
+    @Test
+    fun `the first-launch date is established on the very first call when absent`() =
+        runTest {
+            val store = FakeReviewPromptStore(aReviewPromptState(firstLaunchDate = null))
+            val sut = makeSut(store = store)
+
+            sut.recordSignal(ReviewSignal.TappedPortal)
+
+            assertEquals(reference, store.state.firstLaunchDate)
+        }
+
+    @Test
+    fun `the first-launch date is left unchanged once already set`() =
+        runTest {
+            val original = reference.minus(Duration.ofDays(100))
+            val store = FakeReviewPromptStore(aReviewPromptState(firstLaunchDate = original))
+            val sut = makeSut(store = store)
+
+            sut.recordSignal(ReviewSignal.TappedPortal)
+
+            assertEquals(original, store.state.firstLaunchDate)
+        }
+
+    @Test
+    fun `suppressThisSession prevents a fire even once the score reaches threshold`() =
+        runTest {
+            val store =
+                FakeReviewPromptStore(
+                    aReviewPromptState(firstLaunchDate = reference.minus(Duration.ofDays(30)), engagementScore = 3),
+                )
+            val requester = FakeReviewRequester()
+            val sut = makeSut(store = store, requester = requester)
+
+            sut.suppressThisSession()
+            sut.recordSignal(ReviewSignal.TappedPortal)
+
+            assertEquals(0, requester.requestReviewCalls.size)
+            assertEquals(6, store.state.engagementScore) // suppression does not stop accrual
+        }
+
+    @Test
+    fun `recordAppForegrounded forwards to the ActiveDay signal with the given reactivation flag`() =
+        runTest {
+            val store =
+                FakeReviewPromptStore(
+                    aReviewPromptState(firstLaunchDate = reference, distinctActiveDays = 0, lastActiveDayKey = null),
+                )
+            val sut = makeSut(store = store)
+
+            sut.recordAppForegrounded(isReactivation = true)
+
+            assertEquals(1, store.state.distinctActiveDays)
+            assertNotNull(store.state.lastActiveDayKey)
+        }
+
+    @Test
+    fun `a fresh store with no prior state still resolves a first-launch date`() =
+        runTest {
+            val store = FakeReviewPromptStore()
+            assertNull(store.state.firstLaunchDate)
+            val sut = makeSut(store = store)
+
+            sut.recordSignal(ReviewSignal.OpenedAlert)
+
+            assertEquals(reference, store.state.firstLaunchDate)
+        }
+}

--- a/scripts/check-legal-drift.sh
+++ b/scripts/check-legal-drift.sh
@@ -8,6 +8,7 @@
 #
 # Mirrors guarded:
 #   - iOS bundle (mobile/ios .../Resources/legal)
+#   - Android bundle (mobile/android .../assets/legal)
 #
 # If this fails, run `scripts/sync-legal.sh` and commit the result.
 set -euo pipefail
@@ -17,10 +18,12 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 API_DIR="$REPO_ROOT/api-go/internal/legal/resources"
 IOS_DIR="$REPO_ROOT/mobile/ios/packages/town-crier-presentation/Sources/Resources/legal"
+ANDROID_DIR="$REPO_ROOT/mobile/android/presentation/src/main/assets/legal"
 
 # Each mirror is "label:path"; the canonical API_DIR is checked against every one.
 MIRRORS=(
     "iOS:$IOS_DIR"
+    "Android:$ANDROID_DIR"
 )
 
 failed=0

--- a/scripts/check-legal-drift.sh
+++ b/scripts/check-legal-drift.sh
@@ -8,7 +8,6 @@
 #
 # Mirrors guarded:
 #   - iOS bundle (mobile/ios .../Resources/legal)
-#   - Android bundle (mobile/android .../assets/legal)
 #
 # If this fails, run `scripts/sync-legal.sh` and commit the result.
 set -euo pipefail
@@ -18,12 +17,10 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 API_DIR="$REPO_ROOT/api-go/internal/legal/resources"
 IOS_DIR="$REPO_ROOT/mobile/ios/packages/town-crier-presentation/Sources/Resources/legal"
-ANDROID_DIR="$REPO_ROOT/mobile/android/presentation/src/main/assets/legal"
 
 # Each mirror is "label:path"; the canonical API_DIR is checked against every one.
 MIRRORS=(
     "iOS:$IOS_DIR"
-    "Android:$ANDROID_DIR"
 )
 
 failed=0

--- a/scripts/sync-legal.sh
+++ b/scripts/sync-legal.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Copy canonical legal JSON files from the Go API into the iOS bundle resources.
+# Copy canonical legal JSON files from the Go API into the iOS/Android bundle resources.
 #
-# The Go API copy is the source of truth. The iOS copy is a byte-equal mirror, enforced
-# by scripts/check-legal-drift.sh in CI. Edit the Go API copy, then run this script to
-# refresh the iOS copy, then commit both.
+# The Go API copy is the source of truth. The iOS/Android copies are byte-equal mirrors,
+# enforced by scripts/check-legal-drift.sh in CI. Edit the Go API copy, then run this
+# script to refresh the mirrors, then commit all of them.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,19 +11,21 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 API_DIR="$REPO_ROOT/api-go/internal/legal/resources"
 IOS_DIR="$REPO_ROOT/mobile/ios/packages/town-crier-presentation/Sources/Resources/legal"
+ANDROID_DIR="$REPO_ROOT/mobile/android/presentation/src/main/assets/legal"
 
 if [[ ! -d "$API_DIR" ]]; then
     echo "error: canonical API legal docs directory missing: $API_DIR" >&2
     exit 1
 fi
 
-mkdir -p "$IOS_DIR"
+mkdir -p "$IOS_DIR" "$ANDROID_DIR"
 
 shopt -s nullglob
 copied=0
 for src in "$API_DIR"/*.json; do
     name="$(basename "$src")"
     cp -f "$src" "$IOS_DIR/$name"
+    cp -f "$src" "$ANDROID_DIR/$name"
     echo "  $name"
     copied=$((copied + 1))
 done
@@ -33,4 +35,4 @@ if [[ $copied -eq 0 ]]; then
     exit 1
 fi
 
-echo "synced $copied legal document(s) from API → iOS"
+echo "synced $copied legal document(s) from API → iOS, Android"

--- a/scripts/sync-legal.sh
+++ b/scripts/sync-legal.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Copy canonical legal JSON files from the Go API into the iOS/Android bundle resources.
+# Copy canonical legal JSON files from the Go API into the iOS bundle resources.
 #
-# The Go API copy is the source of truth. The iOS/Android copies are byte-equal mirrors,
-# enforced by scripts/check-legal-drift.sh in CI. Edit the Go API copy, then run this
-# script to refresh the mirrors, then commit all of them.
+# The Go API copy is the source of truth. The iOS copy is a byte-equal mirror, enforced
+# by scripts/check-legal-drift.sh in CI. Edit the Go API copy, then run this script to
+# refresh the iOS copy, then commit both.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -11,21 +11,19 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 API_DIR="$REPO_ROOT/api-go/internal/legal/resources"
 IOS_DIR="$REPO_ROOT/mobile/ios/packages/town-crier-presentation/Sources/Resources/legal"
-ANDROID_DIR="$REPO_ROOT/mobile/android/presentation/src/main/assets/legal"
 
 if [[ ! -d "$API_DIR" ]]; then
     echo "error: canonical API legal docs directory missing: $API_DIR" >&2
     exit 1
 fi
 
-mkdir -p "$IOS_DIR" "$ANDROID_DIR"
+mkdir -p "$IOS_DIR"
 
 shopt -s nullglob
 copied=0
 for src in "$API_DIR"/*.json; do
     name="$(basename "$src")"
     cp -f "$src" "$IOS_DIR/$name"
-    cp -f "$src" "$ANDROID_DIR/$name"
     echo "  $name"
     copied=$((copied + 1))
 done
@@ -35,4 +33,4 @@ if [[ $copied -eq 0 ]]; then
     exit 1
 fi
 
-echo "synced $copied legal document(s) from API → iOS, Android"
+echo "synced $copied legal document(s) from API → iOS"


### PR DESCRIPTION
## Summary

Phase 7 of the Android parity epic (#770) — jumped ahead since it's fully buildable now (only the subscription-management row waits on #783). Closes #778. Builds on #772/#774/#775/#773 (merged).

## Changes

- **`:domain`**: `ReviewPromptPolicy`/`ReviewSignal`/`ReviewPromptState` (verbatim weight/threshold/guard port: tappedPortal +3, openedAlert +2, savedApplication +2 on 2nd+ save only, activeDay +1 on new distinct days, upgraded +2 one-time latch; threshold 6; guards: age≥7d, cooldown 120d, ≤3/365d, session suppression), `UserPreferences`.
- **`:data`**: `DataStoreReviewPromptStore`, full 5-field `PATCH /v1/me`, `GET /v1/me/data` byte export, `LegalDocumentLoader` (bundled JSON, `d MMMM yyyy` formatting).
- **`:presentation`**: `SettingsScreen` (account/appearance/notification-prefs/subscription-placeholder/attribution/legal/export/danger-zone/about, in iOS parity order), `NotificationPreferencesScreen` (optimistic full-body PATCH + rollback), `LegalDocumentScreen`, GDPR-ordered account deletion (server delete succeeds first, then best-effort device-token delete, then local wipe), data export via `FileProvider` + share sheet, `ReviewPromptTracker` wired to the saved-application signal.
- **Legal mirror**: `mobile/android/presentation/src/main/assets/legal/{privacy,terms}.json` now a byte-equal mirror of the API's copy (matching the existing iOS treatment), with `scripts/sync-legal.sh`/`scripts/check-legal-drift.sh`/`legal-drift-check.yml` extended to guard it.

## Verification

- `./gradlew test ktlintCheck detekt :app:assembleDevDebug :app:assembleProdRelease :app:assembleLocalDebug` green.
- Live emulator walkthrough against the local Postgres+API stack: full settings tour, both legal documents, notification-preference round-trip, byte-verified data export, and a full account-deletion round trip on a fresh throwaway account — confirmed via psql that the row existed before and was gone after, with the two existing test accounts from prior phases left untouched.

## Follow-ups filed

- None outstanding — `tc-2myr` (the scripts/.github slice the worker correctly self-reverted as outside its `mobile/android/` boundary) is re-applied in this PR and closed.

---
*Bead tc-4jjw*