### PR TITLE
fix(ci): add dev-seed to cd-dev worker image deploy list (tc-cxr6)

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -239,7 +239,7 @@ jobs:
       - uses: ./.github/actions/deploy-worker-jobs
         with:
           # Dev has no poll or poll-bootstrap jobs (ADR 0024).
-          jobs: digest digest-hourly dormant-cleanup
+          jobs: digest digest-hourly dormant-cleanup dev-seed
           env-suffix: dev
           resource-group: rg-town-crier-dev
           image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker-go:${{ github.sha }}


### PR DESCRIPTION
## Changes
- `.github/workflows/cd-dev.yml`: add `dev-seed` to the `deploy-worker-jobs` step's hardcoded `jobs:` list.

Pulumi seeds every new Container Apps Job with a placeholder image (`mcr.microsoft.com/k8se/quickstart:latest`) and ignores further changes to that field by design — the real worker image is pushed by this CD step, which needs an explicit list of job names. `job-tc-dev-seed-dev` (tc-grvu.6, GH #808, merged/deployed) was silently left off this list, so it's been running the placeholder image and failing every execution (confirmed via a manual test run). This is a one-line fix to unblock it.

Discovered a related but separate, pre-existing gap while investigating (`subscription-sweep`/`pg-purge` missing from both `cd-dev.yml` and `cd-prod.yml`'s lists too, evidenced by `pg-purge`'s last 3 daily dev runs failing) — filed separately as tc-602u, deliberately NOT touched here.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dev deployment workflow to run a specific set of worker jobs consistently during deployment.
  * This helps ensure the expected background tasks are included in dev releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->