### PR TITLE
fix(android): bottom-nav tabs no longer refetch on every revisit (tc-hlbx)

### DIFF
--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
@@ -229,12 +229,13 @@ private fun AuthedNavHost(
         composable<Applications> {
             ApplicationsTab(appGraph = appGraph, navController = navController, onSettingsClick = onSettingsClick)
         }
-        composable<WatchZones> {
+        composable<WatchZones> { backStackEntry ->
             WatchZonesTab(
                 appGraph = appGraph,
                 subscriptionTier = subscriptionTier,
                 navController = navController,
                 onSettingsClick = onSettingsClick,
+                backStackEntry = backStackEntry,
             )
         }
         composable<Saved> {

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/WatchZoneNavGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/WatchZoneNavGraph.kt
@@ -2,7 +2,9 @@ package uk.towncrierapp.app
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
@@ -49,6 +51,17 @@ internal data class ZonePreferencesDestination(
     val zoneName: String,
 )
 
+/**
+ * Nav-result key (tc-yg0q): [WatchZoneEditorDestinationContent] sets this on
+ * `previousBackStackEntry`'s `SavedStateHandle` on a successful save so
+ * [WatchZonesTab] — which never observes the editor's own state directly,
+ * ViewModels/Routes don't navigate — knows to call
+ * [WatchZoneListViewModel.reload] instead of relying on the tc-hlbx
+ * load-once guard's default no-op. Standard Compose Navigation
+ * "returning a result" pattern.
+ */
+private const val ZONE_SAVED_RESULT_KEY = "zone_saved"
+
 internal fun watchZoneEditorDestinationFor(zone: WatchZone) =
     WatchZoneEditorDestination(
         zoneId = zone.id.value,
@@ -78,6 +91,12 @@ private fun WatchZoneEditorDestination.toEditingZone(): WatchZone? {
  * The watch-zones tab: rebuilds [WatchZoneListViewModel] whenever
  * [subscriptionTier] changes (`key(subscriptionTier)`) so the upgrade
  * badge/upsell state never goes stale after a tier change (tc-ujct parity).
+ * [backStackEntry] is this destination's own back-stack entry — its
+ * `SavedStateHandle` is where a successful zone edit/create leaves the
+ * [ZONE_SAVED_RESULT_KEY] result (tc-yg0q) telling this tab to
+ * [WatchZoneListViewModel.reload], bypassing the tc-hlbx load-once guard
+ * for that one explicit "something changed" signal — a plain tab revisit
+ * with no such signal still does not refetch.
  */
 @Composable
 internal fun WatchZonesTab(
@@ -85,6 +104,7 @@ internal fun WatchZonesTab(
     subscriptionTier: SubscriptionTier,
     navController: NavHostController,
     onSettingsClick: () -> Unit,
+    backStackEntry: NavBackStackEntry,
 ) {
     val listViewModel: WatchZoneListViewModel =
         key(subscriptionTier) {
@@ -101,6 +121,15 @@ internal fun WatchZonesTab(
             )
         }
     LaunchedEffect(listViewModel) { listViewModel.load() }
+    val zoneSaved by backStackEntry.savedStateHandle
+        .getStateFlow(ZONE_SAVED_RESULT_KEY, false)
+        .collectAsStateWithLifecycle()
+    LaunchedEffect(zoneSaved) {
+        if (zoneSaved) {
+            backStackEntry.savedStateHandle[ZONE_SAVED_RESULT_KEY] = false
+            listViewModel.reload()
+        }
+    }
     WatchZonesRoute(
         viewModel = listViewModel,
         onZoneSelected = { zone -> navController.navigate(watchZoneEditorDestinationFor(zone)) },
@@ -142,6 +171,14 @@ internal fun WatchZoneEditorDestinationContent(
         )
     WatchZoneEditorRoute(
         viewModel = editorViewModel,
+        onSaveSuccess = {
+            // tc-yg0q: tell the Zones tab (if that's where we came from) its
+            // data is stale — see ZONE_SAVED_RESULT_KEY's doc above.
+            navController.previousBackStackEntry
+                ?.savedStateHandle
+                ?.set(ZONE_SAVED_RESULT_KEY, true)
+            navController.popBackStack()
+        },
         onDismiss = navController::popBackStack,
         // #783 hasn't shipped the paywall yet — dismiss the editor (matching
         // the "quota breach" UX) and no-op the rest.

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakeSavedApplicationRepository.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakeSavedApplicationRepository.kt
@@ -10,10 +10,12 @@ public class FakeSavedApplicationRepository(
     public var saveFailWith: DomainError? = null
     public var unsaveFailWith: DomainError? = null
 
+    public var savedApplicationsCallCount: Int = 0
     public val saveCalls: MutableList<PlanningApplicationId> = mutableListOf()
     public val unsaveCalls: MutableList<PlanningApplicationId> = mutableListOf()
 
     override suspend fun savedApplications(): List<SavedApplication> {
+        savedApplicationsCallCount++
         savedApplicationsFailWith?.let { throw it }
         return stored.toList()
     }

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/watchzones/FakeWatchZoneRepository.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/watchzones/FakeWatchZoneRepository.kt
@@ -11,11 +11,13 @@ public class FakeWatchZoneRepository(
     public var updateFailWith: DomainError? = null
     public var deleteFailWith: DomainError? = null
 
+    public var zonesCallCount: Int = 0
     public val createCalls: MutableList<WatchZone> = mutableListOf()
     public val updateCalls: MutableList<WatchZone> = mutableListOf()
     public val deleteCalls: MutableList<WatchZoneId> = mutableListOf()
 
     override suspend fun zones(): List<WatchZone> {
+        zonesCallCount++
         zonesFailWith?.let { throw it }
         return stored.toList()
     }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListViewModel.kt
@@ -34,7 +34,15 @@ public class ApplicationListViewModel(
     private val _uiState = MutableStateFlow(ApplicationListUiState())
     public val uiState: StateFlow<ApplicationListUiState> = _uiState.asStateFlow()
 
+    // Guards against the spurious refetch-on-every-tab-revisit (tc-hlbx) —
+    // see SavedListViewModel's matching field doc for the full rationale.
+    // markAllRead()/selectZone()/selectSort()/selectFilter() call
+    // fetchFirstPage() directly and are unaffected by this guard, so their
+    // explicit refresh behaviour (tc-cnme) is unchanged.
+    private var hasLoadedSuccessfully = false
+
     public fun load() {
+        if (hasLoadedSuccessfully) return
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             try {
@@ -43,6 +51,7 @@ public class ApplicationListViewModel(
                 val selected = zones.firstOrNull { it.id == persistedZoneId }?.id ?: zones.firstOrNull()?.id
                 val sort = preferencesStore.readSort() ?: ApplicationSortOrder.DEFAULT
                 _uiState.update { it.copy(zones = zones, sort = sort, selectedZoneId = selected) }
+                hasLoadedSuccessfully = true
             } catch (e: CancellationException) {
                 throw e
             } catch (e: DomainError) {

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/saved/SavedListViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/saved/SavedListViewModel.kt
@@ -19,12 +19,24 @@ public class SavedListViewModel(
     private val _uiState = MutableStateFlow(SavedListUiState())
     public val uiState: StateFlow<SavedListUiState> = _uiState.asStateFlow()
 
+    // Guards against the spurious refetch-on-every-tab-revisit (tc-hlbx):
+    // the bottom-nav tabs' LaunchedEffect(viewModel){ viewModel.load() }
+    // re-fires every time this ViewModel's composable re-enters composition
+    // (Navigation Compose already preserves the ViewModel instance itself via
+    // saveState/restoreState — the composable subtree re-entering
+    // composition is a separate event). A prior success makes further calls
+    // a no-op; a prior failure does not, so revisiting the tab remains the
+    // existing (if implicit) retry affordance.
+    private var hasLoadedSuccessfully = false
+
     public fun load() {
+        if (hasLoadedSuccessfully) return
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             try {
                 val saved = repository.savedApplications()
                 _uiState.update { it.copy(savedApplications = saved, isLoading = false) }
+                hasLoadedSuccessfully = true
             } catch (e: CancellationException) {
                 throw e
             } catch (e: DomainError) {

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneEditorScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneEditorScreen.kt
@@ -30,13 +30,17 @@ import uk.towncrierapp.presentation.designsystem.TownCrierTheme
  * slider → static map placeholder (#776's job, see [ZoneMapPlaceholder]) →
  * gated instant-alert toggles → save. Section composables live in
  * `WatchZoneEditorSections.kt`. Port of iOS `WatchZoneEditorView`.
- * [onDismiss]/[onUpgradeRequired] are one-shot navigation reconciliations
- * driven by [WatchZoneEditorUiState.saveCompleted]/`navigateToPaywall` —
- * ViewModels never navigate (compose-ui.md).
+ * [onSaveSuccess]/[onDismiss]/[onUpgradeRequired] are one-shot navigation
+ * reconciliations driven by
+ * [WatchZoneEditorUiState.saveCompleted]/`navigateToPaywall` — ViewModels
+ * never navigate (compose-ui.md). [onSaveSuccess] is distinct from
+ * [onDismiss] (Cancel/back) so the nav layer can signal the zone list to
+ * refetch only on an actual save (tc-yg0q) — see `WatchZoneNavGraph.kt`.
  */
 @Composable
 public fun WatchZoneEditorRoute(
     viewModel: WatchZoneEditorViewModel,
+    onSaveSuccess: () -> Unit,
     onDismiss: () -> Unit,
     onUpgradeRequired: () -> Unit,
     modifier: Modifier = Modifier,
@@ -46,7 +50,7 @@ public fun WatchZoneEditorRoute(
     LaunchedEffect(state.saveCompleted) {
         if (state.saveCompleted) {
             viewModel.consumeSaveCompleted()
-            onDismiss()
+            onSaveSuccess()
         }
     }
     LaunchedEffect(state.navigateToPaywall) {

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListViewModel.kt
@@ -29,12 +29,18 @@ public class WatchZoneListViewModel(
     private val _uiState = MutableStateFlow(WatchZoneListUiState().deriveFromGate())
     public val uiState: StateFlow<WatchZoneListUiState> = _uiState.asStateFlow()
 
+    // Guards against the spurious refetch-on-every-tab-revisit (tc-hlbx) —
+    // see SavedListViewModel's matching field doc for the full rationale.
+    private var hasLoadedSuccessfully = false
+
     public fun load() {
+        if (hasLoadedSuccessfully) return
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             try {
                 val zones = repository.zones()
                 _uiState.update { it.copy(zones = zones, isLoading = false, error = null).deriveFromGate() }
+                hasLoadedSuccessfully = true
             } catch (e: CancellationException) {
                 throw e
             } catch (e: DomainError) {

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListViewModel.kt
@@ -35,6 +35,23 @@ public class WatchZoneListViewModel(
 
     public fun load() {
         if (hasLoadedSuccessfully) return
+        fetchZones()
+    }
+
+    /**
+     * Forces a refetch regardless of [hasLoadedSuccessfully] — for an
+     * explicit "something changed" signal rather than a plain tab revisit
+     * (tc-yg0q: a successful watch-zone edit, surfaced to this ViewModel via
+     * the editor's nav-result SavedStateHandle signal in `WatchZoneNavGraph`,
+     * since ViewModels never navigate/observe nav state directly). Mirrors
+     * how [uk.towncrierapp.presentation.features.applicationlist.ApplicationListViewModel.markAllRead]
+     * already bypasses its own load-once guard via `fetchFirstPage()`.
+     */
+    public fun reload() {
+        fetchZones()
+    }
+
+    private fun fetchZones() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, error = null) }
             try {

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/applicationlist/ApplicationListViewModelTest.kt
@@ -60,6 +60,39 @@ class ApplicationListViewModelTest {
     }
 
     @Test
+    fun `load does not refetch once it has already succeeded — tc-hlbx`() {
+        val watchZoneRepository = FakeWatchZoneRepository(mutableListOf(aWatchZone()))
+        val applicationRepository = FakePlanningApplicationRepository()
+        val viewModel =
+            makeSut(applicationRepository = applicationRepository, watchZoneRepository = watchZoneRepository)
+        viewModel.load()
+        val zonesCallsAfterFirstLoad = watchZoneRepository.zonesCallCount
+        val applicationsCallsAfterFirstLoad = applicationRepository.applicationsCalls.size
+
+        viewModel.load()
+
+        assertEquals(zonesCallsAfterFirstLoad, watchZoneRepository.zonesCallCount)
+        assertEquals(applicationsCallsAfterFirstLoad, applicationRepository.applicationsCalls.size)
+    }
+
+    @Test
+    fun `load retries after a previous attempt failed — tc-hlbx`() {
+        val watchZoneRepository =
+            FakeWatchZoneRepository(mutableListOf(aWatchZone())).apply {
+                zonesFailWith = DomainError.NetworkUnavailable
+            }
+        val viewModel = makeSut(watchZoneRepository = watchZoneRepository)
+        viewModel.load()
+        assertEquals(1, watchZoneRepository.zonesCallCount)
+
+        watchZoneRepository.zonesFailWith = null
+        viewModel.load()
+
+        assertEquals(2, watchZoneRepository.zonesCallCount)
+        assertNull(viewModel.uiState.value.error)
+    }
+
+    @Test
     fun `selecting a sort persists it and refetches the first page`() {
         val preferences = FakeApplicationListPreferencesStore()
         val applicationRepository = FakePlanningApplicationRepository()

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/saved/SavedListViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/saved/SavedListViewModelTest.kt
@@ -40,7 +40,11 @@ class SavedListViewModelTest {
 
     @Test
     fun `load retries after a previous attempt failed — tc-hlbx`() {
-        val repository = FakeSavedApplicationRepository().apply { savedApplicationsFailWith = DomainError.NetworkUnavailable }
+        val repository =
+            FakeSavedApplicationRepository().apply {
+                savedApplicationsFailWith =
+                    DomainError.NetworkUnavailable
+            }
         val viewModel = SavedListViewModel(repository)
         viewModel.load()
         assertEquals(1, repository.savedApplicationsCallCount)

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/saved/SavedListViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/saved/SavedListViewModelTest.kt
@@ -7,9 +7,11 @@ import uk.towncrierapp.domain.applications.FakeSavedApplicationRepository
 import uk.towncrierapp.domain.applications.aPlanningApplication
 import uk.towncrierapp.domain.applications.aPlanningApplicationId
 import uk.towncrierapp.domain.applications.aSavedApplication
+import uk.towncrierapp.domain.auth.DomainError
 import uk.towncrierapp.presentation.MainDispatcherExtension
 import java.time.OffsetDateTime
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /** Port of iOS `SavedApplicationListViewModelTests` (GH#775). */
@@ -23,6 +25,31 @@ class SavedListViewModelTest {
         viewModel.load()
 
         assertEquals(1, viewModel.uiState.value.savedApplications.size)
+    }
+
+    @Test
+    fun `load does not refetch once it has already succeeded — tc-hlbx`() {
+        val repository = FakeSavedApplicationRepository(mutableListOf(aSavedApplication()))
+        val viewModel = SavedListViewModel(repository)
+        viewModel.load()
+
+        viewModel.load()
+
+        assertEquals(1, repository.savedApplicationsCallCount)
+    }
+
+    @Test
+    fun `load retries after a previous attempt failed — tc-hlbx`() {
+        val repository = FakeSavedApplicationRepository().apply { savedApplicationsFailWith = DomainError.NetworkUnavailable }
+        val viewModel = SavedListViewModel(repository)
+        viewModel.load()
+        assertEquals(1, repository.savedApplicationsCallCount)
+
+        repository.savedApplicationsFailWith = null
+        viewModel.load()
+
+        assertEquals(2, repository.savedApplicationsCallCount)
+        assertNull(viewModel.uiState.value.error)
     }
 
     @Test

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListViewModelTest.kt
@@ -49,6 +49,31 @@ class WatchZoneListViewModelTest {
     }
 
     @Test
+    fun `load does not refetch once it has already succeeded — tc-hlbx`() {
+        val repository = FakeWatchZoneRepository(mutableListOf(aWatchZone()))
+        val viewModel = WatchZoneListViewModel(repository, FeatureGate(SubscriptionTier.PERSONAL))
+        viewModel.load()
+
+        viewModel.load()
+
+        assertEquals(1, repository.zonesCallCount)
+    }
+
+    @Test
+    fun `load retries after a previous attempt failed — tc-hlbx`() {
+        val repository = FakeWatchZoneRepository().apply { zonesFailWith = DomainError.NetworkUnavailable }
+        val viewModel = WatchZoneListViewModel(repository, FeatureGate(SubscriptionTier.FREE))
+        viewModel.load()
+        assertEquals(1, repository.zonesCallCount)
+
+        repository.zonesFailWith = null
+        viewModel.load()
+
+        assertEquals(2, repository.zonesCallCount)
+        assertNull(viewModel.uiState.value.error)
+    }
+
+    @Test
     fun `free tier at quota shows the inline upsell card and the upgrade badge`() {
         val repository = FakeWatchZoneRepository(mutableListOf(aWatchZone()))
         val viewModel = WatchZoneListViewModel(repository, FeatureGate(SubscriptionTier.FREE))

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListViewModelTest.kt
@@ -85,7 +85,12 @@ class WatchZoneListViewModelTest {
         viewModel.reload()
 
         assertEquals(2, repository.zonesCallCount)
-        assertEquals(zone.radiusMetres + 400.0, viewModel.uiState.value.zones.single().radiusMetres)
+        assertEquals(
+            zone.radiusMetres + 400.0,
+            viewModel.uiState.value.zones
+                .single()
+                .radiusMetres,
+        )
     }
 
     @Test

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/features/watchzones/WatchZoneListViewModelTest.kt
@@ -74,6 +74,34 @@ class WatchZoneListViewModelTest {
     }
 
     @Test
+    fun `reload refetches even though load has already succeeded — tc-yg0q`() {
+        val zone = aWatchZone()
+        val repository = FakeWatchZoneRepository(mutableListOf(zone))
+        val viewModel = WatchZoneListViewModel(repository, FeatureGate(SubscriptionTier.PERSONAL))
+        viewModel.load()
+        assertEquals(1, repository.zonesCallCount)
+
+        repository.stored = mutableListOf(zone.copy(radiusMetres = zone.radiusMetres + 400.0))
+        viewModel.reload()
+
+        assertEquals(2, repository.zonesCallCount)
+        assertEquals(zone.radiusMetres + 400.0, viewModel.uiState.value.zones.single().radiusMetres)
+    }
+
+    @Test
+    fun `a later load call after reload is still a no-op — tc-yg0q`() {
+        val repository = FakeWatchZoneRepository(mutableListOf(aWatchZone()))
+        val viewModel = WatchZoneListViewModel(repository, FeatureGate(SubscriptionTier.PERSONAL))
+        viewModel.load()
+        viewModel.reload()
+        assertEquals(2, repository.zonesCallCount)
+
+        viewModel.load()
+
+        assertEquals(2, repository.zonesCallCount)
+    }
+
+    @Test
     fun `free tier at quota shows the inline upsell card and the upgrade badge`() {
         val repository = FakeWatchZoneRepository(mutableListOf(aWatchZone()))
         val viewModel = WatchZoneListViewModel(repository, FeatureGate(SubscriptionTier.FREE))


### PR DESCRIPTION
## Summary

Closes tc-hlbx (a follow-up from #775) and tc-yg0q (a regression it exposed).

## Changes

- **tc-hlbx**: `ApplicationListViewModel`/`WatchZoneListViewModel`/`SavedListViewModel` gained a `hasLoadedSuccessfully` guard on `load()` — skips the refetch once already succeeded, still retries after a prior failure. Root cause was `LaunchedEffect(viewModel) { viewModel.load() }` re-firing on every tab-switch composition, not a ViewModel-lifetime issue (Compose Navigation's `saveState`/`restoreState` was already working correctly). Explicit refresh triggers (`markAllRead()`, sort/filter/zone changes) are untouched — they bypass `load()` entirely via `fetchFirstPage()`.
- **tc-yg0q** (discovered during live verification of the above): the new guard exposed a real regression — editing a zone's radius and returning to the Zones list showed the stale pre-edit value, because the old *unconditional* `load()` used to accidentally paper over this. Fixed with a proper signal: `WatchZoneListViewModel.reload()` (unconditional refetch) wired via the standard Compose Navigation "returning a result" pattern — the editor sets a flag on the previous back-stack entry's `SavedStateHandle` on successful save, the Zones tab observes it and reloads exactly once.

## Verification

- `./gradlew test ktlintCheck detekt :app:assembleDevDebug :app:assembleProdRelease :app:assembleLocalDebug` green.
- Live logcat verification against the local Postgres+API stack: confirmed each tab fetches exactly once on cold visit and zero times on revisit; confirmed editing a zone's radius now correctly refreshes the list; confirmed a plain tab revisit (no edit) still fires no network calls.

---
*Beads tc-hlbx, tc-yg0q*