### PR TITLE
fix: SEO pages sort by real app dates, not PlanIt re-index (#819)

### DIFF
--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -124,10 +124,7 @@ func (fakeAppStore) FindInZonePage(context.Context, applications.InZoneQuery) ([
 func (fakeAppStore) FindClustersInZone(context.Context, applications.ClusterQuery) ([]applications.Cluster, error) {
 	return nil, nil
 }
-func (fakeAppStore) RecentNearby(context.Context, string, float64, float64, float64, int) ([]applications.PlanningApplication, error) {
-	return nil, nil
-}
-func (fakeAppStore) NearestNearby(context.Context, string, float64, float64, float64, int) ([]applications.PlanningApplication, error) {
+func (fakeAppStore) RecentNearestTown(context.Context, string, float64, float64, float64, []applications.TownCentroid, int) ([]applications.PlanningApplication, error) {
 	return nil, nil
 }
 func (fakeAppStore) BreakdownNearby(context.Context, string, float64, float64, float64) ([]applications.StateCount, error) {

--- a/api-go/internal/applications/application.go
+++ b/api-go/internal/applications/application.go
@@ -37,6 +37,21 @@ type PlanningApplication struct {
 	LastDifferent time.Time
 }
 
+// TownCentroid is a validated WGS84 point plus its OWN safety radius: one
+// gazetteer town's centroid, used by RecentNearestTown's query-time Voronoi
+// partition (#819 decisions 2-3). The town whose read is being served passes
+// its own (lat, lng, radius) as separate parameters; every OTHER gazetteer
+// town in the same authority travels as a TownCentroid "sibling", competing on
+// nearest-centroid assignment. Carrying a radius per town (not one radius
+// shared by every town) is what makes the in-range-nearest rule possible: a
+// farther town with a wider catchment can still claim an application that a
+// nearer but narrower-catchment neighbour cannot reach.
+type TownCentroid struct {
+	Lat          float64
+	Lng          float64
+	RadiusMetres float64
+}
+
 // CanonicalUID is the server-derived identity "{AreaID}/{Name}". PlanIt case
 // references are only unique within a council, so the authority must be part of
 // the key. This is deliberately independent of the raw UID field — a client may

--- a/api-go/internal/applications/near.go
+++ b/api-go/internal/applications/near.go
@@ -14,10 +14,11 @@ import (
 // and response size stay flat regardless of how busy the authority partition is.
 const nearReadCap = 200
 
-// nearDefaultRadiusMetres and nearMaxRadiusMetres bound the spatial search radius.
+// nearDefaultRadiusMetres and nearMaxRadiusMetres bound the spatial search radius
+// — both the target town's own radius and each sibling centroid's own radius.
 // radius defaults to nearDefaultRadiusMetres (a town-centroid catchment) when
 // unset and is hard-clamped to nearMaxRadiusMetres, so a build request can never
-// widen the single-partition scan beyond the intended town footprint.
+// widen the partition scan beyond the intended town footprint.
 const (
 	nearDefaultRadiusMetres = 5000
 	nearMaxRadiusMetres     = 10000
@@ -31,25 +32,21 @@ const (
 	maxLongitude = 180
 )
 
-// nearStore is the consumer-side store the recent-nearby SEO handler needs: two
-// bounded, single-partition spatial top-N reads (recency-ordered and
-// distance-ordered) plus a whole-in-radius per-appState breakdown (whose buckets
-// sum to the exact in-radius total). The concrete *CosmosStore satisfies it
-// structurally.
+// maxSiblingCentroids bounds how many sibling-town centroids a single request
+// may pass, so the partition query's towns CTE can never fan out unboundedly.
+// No authority's gazetteer approaches this many towns.
+const maxSiblingCentroids = 64
+
+// nearStore is the consumer-side store the town-level SEO handler needs: the
+// bounded, authority-scoped Voronoi-partition read (RecentNearestTown, #819)
+// plus a whole-in-radius per-appState breakdown over the target town's own
+// point/radius (whose buckets sum to the exact in-radius total; it is NOT
+// partitioned — see the field comment on RecentNearbyResult). The concrete
+// *PostgresStore satisfies it structurally.
 type nearStore interface {
-	RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
-	NearestNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
+	RecentNearestTown(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, siblings []TownCentroid, cap int) ([]PlanningApplication, error)
 	BreakdownNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) ([]StateCount, error)
 }
-
-// near ordering modes for the optional order query param. recency (the default,
-// also selected by an absent param) orders by lastDifferent DESC via
-// RecentNearby; distance orders by ST_DISTANCE ASC (nearest first) via
-// NearestNearby. Any other value is a 400.
-const (
-	orderRecency  = "recency"
-	orderDistance = "distance"
-)
 
 // nearHandler serves the build-time town-level SEO endpoint.
 type nearHandler struct {
@@ -61,26 +58,29 @@ type nearHandler struct {
 // endpoint that feeds town-level SEO pages. The route is anonymous to Auth0 (kept
 // out of the fallback-deny set in wiring) and authenticated solely by the
 // X-Build-Key gate, mirroring the sibling authority endpoint. It reads only public
-// planning data from Cosmos (GH#395 Invariant 1 — never PlanIt).
+// planning data from Postgres (GH#395 Invariant 1 — never PlanIt).
 func NearRoutes(mux *http.ServeMux, store nearStore, buildKey string, logger *slog.Logger) {
 	h := &nearHandler{store: store, logger: logger}
 	mux.HandleFunc("GET /v1/applications/near", requireBuildKey(buildKey, h.recentNearby))
 }
 
-// recentNearby returns up to limit applications within a bounded radius of (lat,
-// lng), scoped to the required authorityId's single Cosmos partition, drawn from
-// one bounded read of at most nearReadCap documents. The optional order param
-// selects the ordering: recency (default, also when absent) is most-recently-
-// active first; distance is nearest-first (for overlap reduction between adjacent
-// town pages). authorityId scopes the partition; a missing/invalid id, a
-// non-finite or out-of-range coordinate, a non-finite/non-positive radius, or an
-// unknown order value is a bodyless 400 (the build key was already validated by
-// the gate). There is no PlanIt fallback.
+// recentNearby returns up to limit applications assigned to THIS town by the
+// query-time Voronoi partition (#819): among this town's own (lat, lng, radius)
+// and the repeated "sibling" centroids (each an OTHER gazetteer town in the
+// same authority, with its own radius), an application is kept only if at
+// least one of them covers it, assigned to whichever covering town is nearest,
+// and returned only when that town is THIS one — closest-wins, in-range-
+// nearest, single assignment, no overlap between sibling town pages. Ordered
+// by the real-date key (GREATEST(decidedDate, startDate) DESC NULLS LAST).
+// authorityId scopes the read; a missing/invalid id, a non-finite or
+// out-of-range coordinate, a non-finite/non-positive radius, a malformed or
+// excessive sibling list, is a bodyless 400 (the build key was already
+// validated by the gate). There is no PlanIt fallback.
 func (h *nearHandler) recentNearby(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
 
-	// authorityId is required: it scopes the single-partition spatial query to one
-	// authorityCode (the AreaID as a string), exactly as the authority endpoint does.
+	// authorityId is required: it scopes the spatial query to one authorityCode
+	// (the AreaID as a string), exactly as the authority endpoint does.
 	id, err := strconv.Atoi(strings.TrimSpace(q.Get("authorityId")))
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
@@ -102,10 +102,7 @@ func (h *nearHandler) recentNearby(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-
-	// nearby selects the ordering: distance -> NearestNearby (nearest first),
-	// recency or absent -> RecentNearby (lastDifferent DESC, unchanged default).
-	nearby, ok := selectNearbyRead(h.store, q.Get("order"))
+	siblings, ok := parseSiblingCentroids(q["sibling"])
 	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
 		return
@@ -114,16 +111,18 @@ func (h *nearHandler) recentNearby(w http.ResponseWriter, r *http.Request) {
 	limit := parseLimit(q.Get("limit"))
 	authorityCode := strconv.Itoa(id)
 
-	apps, err := nearby(r.Context(), authorityCode, lat, lng, radius, nearReadCap)
+	apps, err := h.store.RecentNearestTown(r.Context(), authorityCode, lat, lng, radius, siblings, nearReadCap)
 	if err != nil {
-		serverError(w, r, h.logger, "recent applications near point", err)
+		serverError(w, r, h.logger, "recent applications nearest town", err)
 		return
 	}
 
-	// breakdown is the per-appState distribution over the WHOLE in-radius set (an
-	// index-served spatial GROUP BY), independent of the bounded read which
-	// saturates at nearReadCap. The render slice must clamp against the bounded
-	// read length, NOT the breakdown total — the total can dwarf len(apps).
+	// breakdown is the per-appState distribution over the WHOLE in-radius set
+	// around THIS town's own point (an index-served spatial GROUP BY) — it is
+	// deliberately NOT partitioned by sibling centroids, independent of the
+	// bounded, partitioned read which saturates at nearReadCap. The render slice
+	// must clamp against the bounded read length, NOT the breakdown total — the
+	// total can dwarf len(apps).
 	breakdown, err := h.store.BreakdownNearby(r.Context(), authorityCode, lat, lng, radius)
 	if err != nil {
 		serverError(w, r, h.logger, "status breakdown near point", err)
@@ -174,38 +173,72 @@ func parseCoordinate(raw string, minVal, maxVal float64) (float64, bool) {
 	return v, true
 }
 
-// selectNearbyRead maps the optional order query param to the bounded
-// single-partition read it selects: an empty or "recency" value picks the
-// recency-ordered RecentNearby (the unchanged default), "distance" picks the
-// distance-ordered NearestNearby (nearest first). The bool reports validity; the
-// caller turns false into a 400. Both reads share the same signature, so the
-// handler calls the result without branching further.
-func selectNearbyRead(store nearStore, order string) (func(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error), bool) {
-	switch strings.TrimSpace(order) {
-	case "", orderRecency:
-		return store.RecentNearby, true
-	case orderDistance:
-		return store.NearestNearby, true
-	default:
-		return nil, false
-	}
-}
-
-// parseRadius parses the optional radius in metres: it defaults to
-// nearDefaultRadiusMetres when unset/empty, rejects a non-numeric, non-finite, or
-// non-positive value (false -> 400), and clamps anything above nearMaxRadiusMetres
-// down to the hard maximum so the spatial scan stays bounded.
-func parseRadius(raw string) (float64, bool) {
-	s := strings.TrimSpace(raw)
-	if s == "" {
-		return nearDefaultRadiusMetres, true
-	}
-	v, err := strconv.ParseFloat(s, 64)
-	if err != nil || math.IsNaN(v) || math.IsInf(v, 0) || v <= 0 {
+// clampRadius validates a required, finite, positive radius and clamps it down
+// to nearMaxRadiusMetres, so no radius (the target town's own, or a sibling's)
+// can widen a spatial scan beyond the hard maximum. Shared by parseRadius
+// (which additionally defaults an empty value) and parseSiblingCentroids
+// (whose radius component is always required, never defaulted).
+func clampRadius(v float64) (float64, bool) {
+	if math.IsNaN(v) || math.IsInf(v, 0) || v <= 0 {
 		return 0, false
 	}
 	if v > nearMaxRadiusMetres {
 		return nearMaxRadiusMetres, true
 	}
 	return v, true
+}
+
+// parseRadius parses the optional radius in metres: it defaults to
+// nearDefaultRadiusMetres when unset/empty, rejects a non-numeric value (false
+// -> 400), and otherwise validates/clamps via clampRadius.
+func parseRadius(raw string) (float64, bool) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return nearDefaultRadiusMetres, true
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+	return clampRadius(v)
+}
+
+// parseSiblingCentroids parses the repeated "sibling" query values, each a
+// "lat,lng,radius" triple identifying one OTHER gazetteer town's centroid (and
+// its own safety radius) in the requested town's authority — the requested
+// town's own point/radius are the primary lat/lng/radius params, not repeated
+// here (#819 decisions 2-3). Every lat/lng is validated with the same WGS84
+// bounds as the primary point; every radius is validated and clamped exactly
+// like the primary radius (clampRadius). More than maxSiblingCentroids values,
+// or any malformed/invalid entry, is a 400 (false). A nil/empty raw is valid
+// and yields an empty (non-partitioned) slice.
+func parseSiblingCentroids(raw []string) ([]TownCentroid, bool) {
+	if len(raw) > maxSiblingCentroids {
+		return nil, false
+	}
+	out := make([]TownCentroid, 0, len(raw))
+	for _, v := range raw {
+		parts := strings.Split(v, ",")
+		if len(parts) != 3 {
+			return nil, false
+		}
+		lat, ok := parseCoordinate(parts[0], minLatitude, maxLatitude)
+		if !ok {
+			return nil, false
+		}
+		lng, ok := parseCoordinate(parts[1], minLongitude, maxLongitude)
+		if !ok {
+			return nil, false
+		}
+		radiusVal, err := strconv.ParseFloat(strings.TrimSpace(parts[2]), 64)
+		if err != nil {
+			return nil, false
+		}
+		radius, ok := clampRadius(radiusVal)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, TownCentroid{Lat: lat, Lng: lng, RadiusMetres: radius})
+	}
+	return out, true
 }

--- a/api-go/internal/applications/near_test.go
+++ b/api-go/internal/applications/near_test.go
@@ -621,7 +621,7 @@ func TestNearHandler_NoSiblingsIsAValidEmptyPartition(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
-	if store.lastSiblings != nil && len(store.lastSiblings) != 0 {
+	if len(store.lastSiblings) != 0 {
 		t.Errorf("siblings: got %v, want none", store.lastSiblings)
 	}
 }

--- a/api-go/internal/applications/near_test.go
+++ b/api-go/internal/applications/near_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 )
 
-// fakeNearStore is a hand-written double for the recent-nearby read. It records
-// the arguments the handler passed (so clamping/defaulting is asserted at the
-// store boundary), honours cap the way Cosmos TOP @cap does, and serves a
-// whole-in-radius status breakdown independently of the bounded read, so a test
-// can prove the rendered Total is the sum of those buckets — not the bounded read
-// length nor the rendered slice.
+// fakeNearStore is a hand-written double for the town-level Voronoi partition
+// read. It records the arguments the handler passed (so clamping/defaulting,
+// and the sibling-centroid forwarding, are asserted at the store boundary),
+// honours cap the way Postgres's LIMIT does, and serves a whole-in-radius
+// status breakdown independently of the bounded read, so a test can prove the
+// rendered Total is the sum of those buckets — not the bounded read length nor
+// the rendered slice.
 type fakeNearStore struct {
 	apps         []PlanningApplication
 	err          error
@@ -25,11 +26,8 @@ type fakeNearStore struct {
 	lastLat           float64
 	lastLng           float64
 	lastRadius        float64
+	lastSiblings      []TownCentroid
 	lastCap           int
-
-	// nearestCalled records whether the distance-ordered read path was taken
-	// (order=distance) instead of the recency-ordered RecentNearby default.
-	nearestCalled bool
 
 	breakdownCalled       bool
 	lastBreakdownAuthCode string
@@ -38,29 +36,13 @@ type fakeNearStore struct {
 	lastBreakdownRadius   float64
 }
 
-func (f *fakeNearStore) RecentNearby(_ context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error) {
+func (f *fakeNearStore) RecentNearestTown(_ context.Context, authorityCode string, lat, lng, radiusMetres float64, siblings []TownCentroid, cap int) ([]PlanningApplication, error) {
 	f.called = true
 	f.lastAuthorityCode = authorityCode
 	f.lastLat = lat
 	f.lastLng = lng
 	f.lastRadius = radiusMetres
-	f.lastCap = cap
-	if f.err != nil {
-		return nil, f.err
-	}
-	if cap >= 0 && cap < len(f.apps) {
-		return f.apps[:cap], nil
-	}
-	return f.apps, nil
-}
-
-func (f *fakeNearStore) NearestNearby(_ context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error) {
-	f.called = true
-	f.nearestCalled = true
-	f.lastAuthorityCode = authorityCode
-	f.lastLat = lat
-	f.lastLng = lng
-	f.lastRadius = radiusMetres
+	f.lastSiblings = siblings
 	f.lastCap = cap
 	if f.err != nil {
 		return nil, f.err
@@ -126,6 +108,9 @@ func TestNearHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 	if store.lastLat != 51.5155 || store.lastLng != -0.0931 || store.lastRadius != 4000 {
 		t.Errorf("store geo args: lat=%v lng=%v radius=%v, want 51.5155 -0.0931 4000", store.lastLat, store.lastLng, store.lastRadius)
 	}
+	if len(store.lastSiblings) != 0 {
+		t.Errorf("siblings: got %v, want none (absent from the request)", store.lastSiblings)
+	}
 	// The whole-in-radius breakdown is computed over the same scoped, clamped geo window.
 	if !store.breakdownCalled || store.lastBreakdownAuthCode != "471" ||
 		store.lastBreakdownLat != 51.5155 || store.lastBreakdownLng != -0.0931 || store.lastBreakdownRadius != 4000 {
@@ -156,7 +141,7 @@ func TestNearHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 		t.Errorf("statusBreakdown must be present: %v", got)
 	}
 	first := apps[0].(map[string]any)
-	for _, key := range []string{"uid", "name", "address", "description", "appState", "startDate", "lastDifferent", "link", "url"} {
+	for _, key := range []string{"uid", "name", "address", "description", "appState", "startDate", "decidedDate", "lastDifferent", "link", "url"} {
 		if _, present := first[key]; !present {
 			t.Errorf("application missing field %q: %v", key, first)
 		}
@@ -530,7 +515,103 @@ func TestNearHandler_BreakdownErrorReturns500(t *testing.T) {
 	}
 }
 
-func TestNearHandler_DefaultOrderRoutesToRecentNearby(t *testing.T) {
+// TestNearHandler_ForwardsSiblingCentroidsToStore proves the repeated "sibling"
+// query params are parsed into TownCentroids (lat, lng, radius) and forwarded
+// to RecentNearestTown verbatim, in order — the #819 town-partition contract.
+func TestNearHandler_ForwardsSiblingCentroidsToStore(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&radius=4000"+
+			"&sibling=51.6,-0.2,5000&sibling=51.4,0.0,3000")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	want := []TownCentroid{
+		{Lat: 51.6, Lng: -0.2, RadiusMetres: 5000},
+		{Lat: 51.4, Lng: 0.0, RadiusMetres: 3000},
+	}
+	if len(store.lastSiblings) != len(want) {
+		t.Fatalf("siblings: got %v, want %v", store.lastSiblings, want)
+	}
+	for i, w := range want {
+		if store.lastSiblings[i] != w {
+			t.Errorf("siblings[%d]: got %+v, want %+v", i, store.lastSiblings[i], w)
+		}
+	}
+}
+
+// TestNearHandler_ClampsSiblingRadiusToMax proves a sibling's own radius is
+// validated/clamped exactly like the primary radius param.
+func TestNearHandler_ClampsSiblingRadiusToMax(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	rec := serveNear(t, store, "buildkey", "buildkey",
+		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&sibling=51.6,-0.2,99999")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	if len(store.lastSiblings) != 1 || store.lastSiblings[0].RadiusMetres != 10000 {
+		t.Errorf("sibling radius: got %v, want clamped to 10000", store.lastSiblings)
+	}
+}
+
+func TestNearHandler_RejectsMalformedSibling(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		sibling string
+	}{
+		{"missing radius component", "sibling=51.6,-0.2"},
+		{"non-numeric lat", "sibling=abc,-0.2,5000"},
+		{"out-of-range lat", "sibling=91,-0.2,5000"},
+		{"out-of-range lng", "sibling=51.6,200,5000"},
+		{"non-finite radius", "sibling=51.6,-0.2,Inf"},
+		{"zero radius", "sibling=51.6,-0.2,0"},
+		{"empty value", "sibling="},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := &fakeNearStore{apps: recentApps(t, 2)}
+
+			rec := serveNear(t, store, "buildkey", "buildkey",
+				"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&"+tc.sibling)
+
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("malformed sibling (%s): got %d, want 400", tc.sibling, rec.Code)
+			}
+			if store.called || store.breakdownCalled {
+				t.Errorf("store must not be hit on a malformed sibling")
+			}
+		})
+	}
+}
+
+func TestNearHandler_RejectsTooManySiblings(t *testing.T) {
+	t.Parallel()
+	store := &fakeNearStore{apps: recentApps(t, 2)}
+
+	query := "/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1"
+	for range maxSiblingCentroids + 1 {
+		query += "&sibling=51.6,-0.2,5000"
+	}
+
+	rec := serveNear(t, store, "buildkey", "buildkey", query)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("too many siblings: got %d, want 400", rec.Code)
+	}
+	if store.called || store.breakdownCalled {
+		t.Errorf("store must not be hit with too many siblings")
+	}
+}
+
+func TestNearHandler_NoSiblingsIsAValidEmptyPartition(t *testing.T) {
 	t.Parallel()
 	store := &fakeNearStore{apps: recentApps(t, 2)}
 
@@ -540,96 +621,7 @@ func TestNearHandler_DefaultOrderRoutesToRecentNearby(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
 	}
-	// Absent order param -> recency-ordered RecentNearby (the unchanged default).
-	if !store.called || store.nearestCalled {
-		t.Errorf("default order must route to RecentNearby, not NearestNearby (called=%v nearest=%v)", store.called, store.nearestCalled)
-	}
-}
-
-func TestNearHandler_OrderRecencyRoutesToRecentNearby(t *testing.T) {
-	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
-
-	rec := serveNear(t, store, "buildkey", "buildkey",
-		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&order=recency")
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
-	}
-	// Explicit order=recency must behave exactly like the default.
-	if !store.called || store.nearestCalled {
-		t.Errorf("order=recency must route to RecentNearby, not NearestNearby (called=%v nearest=%v)", store.called, store.nearestCalled)
-	}
-}
-
-func TestNearHandler_OrderDistanceRoutesToNearestNearby(t *testing.T) {
-	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
-
-	rec := serveNear(t, store, "buildkey", "buildkey",
-		"/v1/applications/near?authorityId=471&lat=51.5155&lng=-0.0931&radius=4000&order=distance")
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
-	}
-	// order=distance must route to the distance-ordered NearestNearby read.
-	if !store.nearestCalled {
-		t.Fatalf("order=distance must route to NearestNearby")
-	}
-	// Same scoping/clamping/cap and geo args reach the distance-ordered read.
-	if store.lastAuthorityCode != "471" || store.lastCap != 200 {
-		t.Errorf("nearest read call: authorityCode=%q cap=%d, want \"471\" 200", store.lastAuthorityCode, store.lastCap)
-	}
-	if store.lastLat != 51.5155 || store.lastLng != -0.0931 || store.lastRadius != 4000 {
-		t.Errorf("nearest geo args: lat=%v lng=%v radius=%v, want 51.5155 -0.0931 4000", store.lastLat, store.lastLng, store.lastRadius)
-	}
-	// The whole-in-radius breakdown is still computed over the same scoped, clamped geo window.
-	if !store.breakdownCalled || store.lastBreakdownAuthCode != "471" {
-		t.Errorf("breakdown call: called=%v auth=%q, want true \"471\"", store.breakdownCalled, store.lastBreakdownAuthCode)
-	}
-}
-
-func TestNearHandler_UnknownOrderReturns400(t *testing.T) {
-	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
-
-	rec := serveNear(t, store, "buildkey", "buildkey",
-		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&order=banana")
-
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("unknown order: got %d, want 400", rec.Code)
-	}
-	if store.called || store.breakdownCalled {
-		t.Errorf("store must not be hit on an unknown order value")
-	}
-}
-
-func TestNearHandler_OrderDistanceStillRejectsOutOfRangeCoord(t *testing.T) {
-	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
-
-	rec := serveNear(t, store, "buildkey", "buildkey",
-		"/v1/applications/near?authorityId=471&lat=91&lng=-0.1&order=distance")
-
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("out-of-range lat with order=distance: got %d, want 400", rec.Code)
-	}
-	if store.called || store.breakdownCalled {
-		t.Errorf("store must not be hit on an out-of-range coord, even with order=distance")
-	}
-}
-
-func TestNearHandler_OrderDistanceStillRejectsNonPositiveRadius(t *testing.T) {
-	t.Parallel()
-	store := &fakeNearStore{apps: recentApps(t, 2)}
-
-	rec := serveNear(t, store, "buildkey", "buildkey",
-		"/v1/applications/near?authorityId=471&lat=51.5&lng=-0.1&radius=0&order=distance")
-
-	if rec.Code != http.StatusBadRequest {
-		t.Fatalf("non-positive radius with order=distance: got %d, want 400", rec.Code)
-	}
-	if store.called || store.breakdownCalled {
-		t.Errorf("store must not be hit on a non-positive radius, even with order=distance")
+	if store.lastSiblings != nil && len(store.lastSiblings) != 0 {
+		t.Errorf("siblings: got %v, want none", store.lastSiblings)
 	}
 }

--- a/api-go/internal/applications/recent_test.go
+++ b/api-go/internal/applications/recent_test.go
@@ -170,7 +170,7 @@ func TestRecentHandler_Returns200WithValidKeyAndNonNullArray(t *testing.T) {
 	// The wire shape of an application carries the SEO-relevant fields, now
 	// including lastDifferent (the list's DESC sort key, for the "Last updated" card).
 	first := apps[0].(map[string]any)
-	for _, key := range []string{"uid", "name", "address", "description", "appState", "startDate", "lastDifferent", "link", "url"} {
+	for _, key := range []string{"uid", "name", "address", "description", "appState", "startDate", "decidedDate", "lastDifferent", "link", "url"} {
 		if _, present := first[key]; !present {
 			t.Errorf("application missing field %q: %v", key, first)
 		}

--- a/api-go/internal/applications/result.go
+++ b/api-go/internal/applications/result.go
@@ -131,7 +131,9 @@ type RecentNearbyResult struct {
 // identity, and the unread-event projection are deliberately omitted.
 // lastDifferent is the DESC sort key of the bounded read, carried so the web card
 // can show a "Last updated" date that matches the list order; it is non-pointer
-// because the domain always carries it.
+// because the domain always carries it. decidedDate (#819 decision 5) is the
+// real-world "Decided" date shown alongside startDate's "Started" on the card;
+// nil while the application is still undecided.
 type RecentApplication struct {
 	UID           string              `json:"uid"`
 	Name          string              `json:"name"`
@@ -139,6 +141,7 @@ type RecentApplication struct {
 	Description   string              `json:"description"`
 	AppState      *string             `json:"appState"`
 	StartDate     *platform.DateOnly  `json:"startDate"`
+	DecidedDate   *platform.DateOnly  `json:"decidedDate"`
 	LastDifferent platform.DotNetTime `json:"lastDifferent"`
 	Link          *string             `json:"link"`
 	URL           *string             `json:"url"`
@@ -153,6 +156,7 @@ func RecentApplicationOf(a PlanningApplication) RecentApplication {
 		Description:   a.Description,
 		AppState:      a.AppState,
 		StartDate:     platform.DateOnlyPtr(a.StartDate),
+		DecidedDate:   platform.DateOnlyPtr(a.DecidedDate),
 		LastDifferent: platform.DotNetTime(a.LastDifferent),
 		Link:          a.Link,
 		URL:           a.URL,

--- a/api-go/internal/applications/result.go
+++ b/api-go/internal/applications/result.go
@@ -110,12 +110,15 @@ type RecentByAuthorityResult struct {
 // GET /v1/applications/near. It mirrors RecentByAuthorityResult but echoes the
 // effective (post-clamp) query point and radius instead of an area name, so the
 // town prerender can label and cache the page by its centroid. Applications is
-// always a non-null array (at most the request's limit). Total is the EXACT
-// whole-in-radius total: the sum of the StatusBreakdown buckets, so the rendered
-// "tracking N applications" lead line always equals the breakdown. StatusBreakdown
-// is the per-appState distribution over the WHOLE in-radius set (its denominator
-// is the whole in-radius set, not the bounded read), computed by an index-served
-// spatial GROUP BY, always a non-null array.
+// always a non-null array (at most the request's limit), assigned to this town
+// by the query-time Voronoi partition against the request's sibling centroids
+// (#819 decisions 2-3) — no application appears on two sibling towns' pages.
+// Total and StatusBreakdown are DELIBERATELY NOT partitioned: they are the
+// EXACT whole-in-radius figures around this town's own point/radius alone (an
+// index-served spatial GROUP BY), so Total is the sum of the StatusBreakdown
+// buckets and always a non-null array — but it can be larger than
+// len(Applications) even discounting the bounded-read cap, since it does not
+// subtract applications a sibling town's nearer centroid has claimed.
 type RecentNearbyResult struct {
 	AuthorityID     int                 `json:"authorityId"`
 	Lat             float64             `json:"lat"`

--- a/api-go/internal/applications/result_test.go
+++ b/api-go/internal/applications/result_test.go
@@ -22,6 +22,37 @@ func TestRecentApplicationOf_IncludesLastDifferent(t *testing.T) {
 	}
 }
 
+// TestRecentApplicationOf_IncludesDecidedDate proves the slim SEO projection
+// carries decidedDate (#819 decision 5) so a card can render "Decided 9 Jul
+// 2021" alongside "Started ...", independent of the ordering-only StartDate.
+func TestRecentApplicationOf_IncludesDecidedDate(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+
+	got := RecentApplicationOf(a)
+
+	if got.DecidedDate == nil {
+		t.Fatalf("DecidedDate: got nil, want %v", *a.DecidedDate)
+	}
+	if !time.Time(*got.DecidedDate).Equal(*a.DecidedDate) {
+		t.Errorf("DecidedDate: got %v, want %v", time.Time(*got.DecidedDate), *a.DecidedDate)
+	}
+}
+
+// TestRecentApplicationOf_NilDecidedDateStaysNil proves an undecided
+// application (still pending) round-trips DecidedDate as nil, not a zero date.
+func TestRecentApplicationOf_NilDecidedDateStaysNil(t *testing.T) {
+	t.Parallel()
+	a := testApplication(t)
+	a.DecidedDate = nil
+
+	got := RecentApplicationOf(a)
+
+	if got.DecidedDate != nil {
+		t.Errorf("DecidedDate: got %v, want nil", *got.DecidedDate)
+	}
+}
+
 // assertBreakdownEqual compares two breakdown slices positionally, including the
 // nullable AppState pointer values.
 func assertBreakdownEqual(t *testing.T, got, want []StateCount) {

--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -38,8 +38,7 @@ type Store interface {
 	FindNearbyPage(ctx context.Context, latitude, longitude, radiusMetres float64, limit int, cursor string) ([]PlanningApplication, string, error)
 	FindInZonePage(ctx context.Context, q InZoneQuery) ([]PlanningApplication, string, error)
 	FindClustersInZone(ctx context.Context, q ClusterQuery) ([]Cluster, error)
-	RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
-	NearestNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error)
+	RecentNearestTown(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, siblings []TownCentroid, cap int) ([]PlanningApplication, error)
 	BreakdownNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) ([]StateCount, error)
 }
 
@@ -333,40 +332,94 @@ func (s *PostgresStore) FindNearbyPage(ctx context.Context, latitude, longitude,
 // built from $2 (longitude) and $3 (latitude); $1 is the authority_code.
 const seoNearbyPoint = "ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography"
 
-const pgRecentNearbyQuery = "SELECT " + appColumns +
-	" FROM applications WHERE authority_code = $1 AND ST_DWithin(location, " + seoNearbyPoint + ", $4) " +
-	"ORDER BY last_different DESC LIMIT $5"
+// pgRecentNearestTownQuery is the town-level Voronoi partition read (#819
+// decisions 2-3). The `towns` CTE puts the target town's own point/radius at
+// idx 0 ($2 lng, $3 lat, $4 radius) and zips the sibling arrays ($5 lngs, $6
+// lats, $7 radii) via one WITH-ORDINALITY unnest into idx 1..N — so the query
+// text never changes shape however many siblings are passed; zero siblings
+// means unnest yields zero rows and the read degrades to a plain, non-
+// partitioned radius read for the target town alone.
+//
+// `candidates` joins every authority-scoped application against every town it
+// is within THAT TOWN'S OWN radius of (ST_DWithin(a.location, t.pt, t.radius))
+// — this is the in-range-nearest rule already taking effect: a town whose
+// radius can't reach an application never produces a candidate row for it, so
+// that application is invisible to it regardless of how much nearer its centroid
+// is. `nearest` then keeps exactly one row per planit_name — the covering town
+// with the smallest KNN distance (DISTINCT ON, ties broken toward the lowest
+// idx for determinism) — which is precisely "closest-wins among the towns that
+// can reach it" and guarantees single-assignment: no application can ever
+// satisfy `idx = 0` for two different requests (this town's and a sibling's).
+//
+// The final SELECT keeps only rows assigned to the target town (idx = 0) and
+// re-applies recentRealDateOrder (decision 1) so a town's own list is ordered
+// exactly like the authority list.
+const pgRecentNearestTownQuery = `
+WITH towns AS (
+	SELECT 0 AS idx,
+	       ST_SetSRID(ST_MakePoint($2, $3), 4326)::geography AS pt,
+	       $4::double precision AS radius
+	UNION ALL
+	SELECT ord::int,
+	       ST_SetSRID(ST_MakePoint(lng, lat), 4326)::geography,
+	       radius
+	FROM unnest($5::double precision[], $6::double precision[], $7::double precision[])
+	     WITH ORDINALITY AS sib(lng, lat, radius, ord)
+),
+candidates AS (
+	SELECT
+		a.planit_name, a.uid, a.area_name, a.area_id, a.address, a.postcode,
+		a.description, a.app_type, a.app_state, a.app_size, a.start_date,
+		a.decided_date, a.consulted_date, a.location, a.url, a.link, a.last_different,
+		t.idx, a.location <-> t.pt AS dist
+	FROM applications a
+	JOIN towns t ON ST_DWithin(a.location, t.pt, t.radius)
+	WHERE a.authority_code = $1
+),
+nearest AS (
+	SELECT DISTINCT ON (planit_name) *
+	FROM candidates
+	ORDER BY planit_name, dist ASC, idx ASC
+)
+SELECT
+	planit_name, uid, area_name, area_id, address, postcode, description,
+	app_type, app_state, app_size, start_date, decided_date, consulted_date,
+	ST_Y(location::geometry), ST_X(location::geometry), url, link, last_different
+FROM nearest
+WHERE idx = 0
+ORDER BY ` + recentRealDateOrder + `
+LIMIT $8`
 
-// RecentNearby returns up to cap most-recently-active applications within
-// radiusMetres of (lat, lng) inside the authority, ordered by last_different DESC.
-// The authority scope is kept for parity with the Cosmos read (memo 0010 notes a
-// later phase may relax it; not relaxed here).
-func (s *PostgresStore) RecentNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error) {
-	rows, err := s.db.Query(ctx, pgRecentNearbyQuery, authorityCode, lng, lat, radiusMetres, cap)
+// RecentNearestTown returns up to cap applications assigned to THIS town by the
+// query-time Voronoi partition (#819 decisions 2-3): authority-scoped, kept
+// only if this town's own (lat, lng, radiusMetres) or one of siblings' own
+// (lat, lng, radiusMetres) covers it, and assigned to whichever covering town
+// is nearest — so an application whose true-nearest centroid can't reach it,
+// but a farther sibling's wider radius can, lands on that farther sibling
+// instead of being orphaned (the in-range-nearest rule). siblings is every
+// OTHER gazetteer town centroid (each with its own radius) in the same
+// authority; a nil/empty siblings degrades to a plain radius read for this
+// town alone. Ordered by GREATEST(decided_date, start_date) DESC NULLS LAST
+// (decision 1), tie-broken by start_date DESC NULLS LAST, planit_name.
+// Authority pages are NOT partitioned (decision 4) — RecentByAuthority is
+// unaffected by this method.
+func (s *PostgresStore) RecentNearestTown(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, siblings []TownCentroid, cap int) ([]PlanningApplication, error) {
+	lngs := make([]float64, len(siblings))
+	lats := make([]float64, len(siblings))
+	radii := make([]float64, len(siblings))
+	for i, c := range siblings {
+		lngs[i] = c.Lng
+		lats[i] = c.Lat
+		radii[i] = c.RadiusMetres
+	}
+	rows, err := s.db.Query(ctx, pgRecentNearestTownQuery,
+		authorityCode, lng, lat, radiusMetres, lngs, lats, radii, cap)
 	if err != nil {
-		return nil, fmt.Errorf("recent applications near %q: %w", authorityCode, err)
+		return nil, fmt.Errorf("recent applications nearest town in %q: %w", authorityCode, err)
 	}
 	apps, err := pgx.CollectRows(rows, scanAppRow)
 	if err != nil {
-		return nil, fmt.Errorf("recent applications near %q: %w", authorityCode, err)
-	}
-	return apps, nil
-}
-
-const pgNearestNearbyQuery = "SELECT " + appColumns +
-	" FROM applications WHERE authority_code = $1 AND ST_DWithin(location, " + seoNearbyPoint + ", $4) " +
-	"ORDER BY location <-> " + seoNearbyPoint + " LIMIT $5"
-
-// NearestNearby returns up to cap applications nearest to (lat, lng) within
-// radiusMetres inside the authority, ordered by the KNN <-> distance ASC.
-func (s *PostgresStore) NearestNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, cap int) ([]PlanningApplication, error) {
-	rows, err := s.db.Query(ctx, pgNearestNearbyQuery, authorityCode, lng, lat, radiusMetres, cap)
-	if err != nil {
-		return nil, fmt.Errorf("nearest applications near %q: %w", authorityCode, err)
-	}
-	apps, err := pgx.CollectRows(rows, scanAppRow)
-	if err != nil {
-		return nil, fmt.Errorf("nearest applications near %q: %w", authorityCode, err)
+		return nil, fmt.Errorf("recent applications nearest town in %q: %w", authorityCode, err)
 	}
 	return apps, nil
 }

--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -184,11 +184,25 @@ func (s *PostgresStore) GetByUID(ctx context.Context, uid, authorityCode string)
 	return a, true, nil
 }
 
+// recentRealDateOrder is the shared "sort by the stable real-world lifecycle
+// date, not PlanIt's last_different re-index marker" ORDER BY clause (#819
+// decision 1). last_different is bumped to "now" whenever PlanIt re-indexes an
+// application regardless of its actual age, which floats stale applications to
+// the top of a last_different-ordered list — GREATEST(decided_date, start_date)
+// never moves on a re-index. Postgres's GREATEST ignores NULL arguments (unlike
+// last_different, which is NOT NULL), so a decided application sorts by its
+// decided_date, an undecided one by its start_date, and an application with
+// neither sorts last (NULLS LAST) rather than erroring or floating to the top.
+// The tie-break (start_date DESC NULLS LAST, then planit_name ASC) makes the
+// order fully deterministic when two applications share the same GREATEST
+// value. Shared by pgRecentByAuthorityQuery and pgRecentNearestTownQuery.
+const recentRealDateOrder = "GREATEST(decided_date, start_date) DESC NULLS LAST, start_date DESC NULLS LAST, planit_name"
+
 const pgRecentByAuthorityQuery = "SELECT " + appColumns +
-	" FROM applications WHERE authority_code = $1 ORDER BY last_different DESC LIMIT $2"
+	" FROM applications WHERE authority_code = $1 ORDER BY " + recentRealDateOrder + " LIMIT $2"
 
 // RecentByAuthority returns up to cap most-recently-active applications in the
-// authority, ordered by last_different DESC. It backs the build-time SEO endpoint.
+// authority, ordered by recentRealDateOrder. It backs the build-time SEO endpoint.
 func (s *PostgresStore) RecentByAuthority(ctx context.Context, authorityCode string, cap int) ([]PlanningApplication, error) {
 	rows, err := s.db.Query(ctx, pgRecentByAuthorityQuery, authorityCode, cap)
 	if err != nil {

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -1385,42 +1385,187 @@ func TestPostgresStore_FindInZonePage_CursorFilterMismatch(t *testing.T) {
 	}
 }
 
-// TestPostgresStore_RecentNearby_And_NearestNearby distinguishes recency ordering
-// (last_different DESC) from distance ordering (nearest first), and proves the
-// radius filter and authority scope.
-func TestPostgresStore_RecentNearby_And_NearestNearby(t *testing.T) {
+// townAt builds a TownCentroid `metresNorth` due north of the fixture centre
+// (the same line applications are placed on via `at`), with its own safety
+// radius — the "own radius per town" the in-range-nearest rule (#819 decision
+// 3) depends on.
+func townAt(metresNorth, radiusMetres float64) TownCentroid {
+	return TownCentroid{Lat: pgLatNorth(metresNorth), Lng: pgCentreLon, RadiusMetres: radiusMetres}
+}
+
+// TestPostgresStore_RecentNearestTown_ClosestWins proves the core Voronoi
+// partition rule (#819 decision 2): among two non-overlapping-enough towns,
+// each application is assigned to whichever centroid — this town's own point,
+// or a sibling's — is nearest, and only rows assigned to THIS town come back.
+func TestPostgresStore_RecentNearestTown_ClosestWins(t *testing.T) {
 	ctx := context.Background()
 	store := newAppPGStore(t)
 
-	near := at(pgApp("NEAR", 100), 100)
-	near.LastDifferent = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // oldest
-	far := at(pgApp("FAR", 100), 500)
-	far.LastDifferent = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC) // newest
-	outside := at(pgApp("OUTSIDE", 100), 5000)                      // beyond 1 km
-	otherAuth := at(pgApp("OTHER-AUTH", 200), 100)                  // wrong authority
-	for _, a := range []PlanningApplication{near, far, outside, otherAuth} {
+	townA := townAt(0, 3000)
+	townB := townAt(2000, 3000)
+
+	closerToA := at(pgApp("CLOSER-A", 100), 500)  // dist A=500, dist B=1500
+	closerToB := at(pgApp("CLOSER-B", 100), 1800) // dist A=1800, dist B=200
+	for _, a := range []PlanningApplication{closerToA, closerToB} {
 		if err := store.Upsert(ctx, a); err != nil {
 			t.Fatalf("Upsert %s: %v", a.Name, err)
 		}
 	}
 
-	recent, err := store.RecentNearby(ctx, "100", pgCentreLat, pgCentreLon, 1000, 10)
+	gotA, err := store.RecentNearestTown(ctx, "100", townA.Lat, townA.Lng, townA.RadiusMetres, []TownCentroid{townB}, 10)
 	if err != nil {
-		t.Fatalf("RecentNearby: %v", err)
+		t.Fatalf("RecentNearestTown (town A): %v", err)
 	}
-	assertNames(t, appNames(recent), []string{"FAR", "NEAR"}) // recency DESC
+	assertNames(t, appNames(gotA), []string{"CLOSER-A"})
 
-	nearest, err := store.NearestNearby(ctx, "100", pgCentreLat, pgCentreLon, 1000, 10)
+	gotB, err := store.RecentNearestTown(ctx, "100", townB.Lat, townB.Lng, townB.RadiusMetres, []TownCentroid{townA}, 10)
 	if err != nil {
-		t.Fatalf("NearestNearby: %v", err)
+		t.Fatalf("RecentNearestTown (town B): %v", err)
 	}
-	assertNames(t, appNames(nearest), []string{"NEAR", "FAR"}) // distance ASC
+	assertNames(t, appNames(gotB), []string{"CLOSER-B"})
+}
 
-	capped, err := store.NearestNearby(ctx, "100", pgCentreLat, pgCentreLon, 1000, 1)
-	if err != nil {
-		t.Fatalf("NearestNearby capped: %v", err)
+// TestPostgresStore_RecentNearestTown_InRangeNearestRule proves #819 decision
+// 3: an application whose true-nearest centroid cannot reach it (its radius is
+// too small), but a FARTHER sibling's WIDER radius does reach it, is assigned
+// to that farther, in-range sibling — never orphaned, never left on the
+// nearer-but-out-of-range town.
+func TestPostgresStore_RecentNearestTown_InRangeNearestRule(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	narrowTown := townAt(0, 1000)     // this town's own radius is too small to reach the app
+	wideSibling := townAt(5000, 6000) // farther away, but its radius reaches back to the app
+
+	// True-nearest is narrowTown (dist 2000 < 3000), but narrowTown's radius
+	// (1000) doesn't reach it; wideSibling's radius (6000) does.
+	inRangeOnly := at(pgApp("IN-RANGE-VIA-SIBLING", 100), 2000)
+	if err := store.Upsert(ctx, inRangeOnly); err != nil {
+		t.Fatalf("Upsert %s: %v", inRangeOnly.Name, err)
 	}
-	assertNames(t, appNames(capped), []string{"NEAR"})
+
+	gotNarrow, err := store.RecentNearestTown(ctx, "100", narrowTown.Lat, narrowTown.Lng, narrowTown.RadiusMetres,
+		[]TownCentroid{wideSibling}, 10)
+	if err != nil {
+		t.Fatalf("RecentNearestTown (narrow town): %v", err)
+	}
+	if len(gotNarrow) != 0 {
+		t.Errorf("narrow (nearer but out-of-range) town: got %v, want none (must not orphan-claim it)", appNames(gotNarrow))
+	}
+
+	gotWide, err := store.RecentNearestTown(ctx, "100", wideSibling.Lat, wideSibling.Lng, wideSibling.RadiusMetres,
+		[]TownCentroid{narrowTown}, 10)
+	if err != nil {
+		t.Fatalf("RecentNearestTown (wide sibling): %v", err)
+	}
+	// Not orphaned: the farther-but-in-range town claims it.
+	assertNames(t, appNames(gotWide), []string{"IN-RANGE-VIA-SIBLING"})
+}
+
+// TestPostgresStore_RecentNearestTown_NoOverlapBetweenSiblingTowns constructs
+// two towns with OVERLAPPING radii (the double-counting risk a plain radius
+// read would hit) and proves an application nearer town A never appears in
+// sibling town B's result, even though B's radius alone would also reach it.
+func TestPostgresStore_RecentNearestTown_NoOverlapBetweenSiblingTowns(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	townA := townAt(0, 4000)
+	townB := townAt(3000, 4000) // overlaps heavily with townA's catchment
+
+	// dist to A = 1000, dist to B = 2000: nearer A, but well within BOTH radii.
+	nearA := at(pgApp("NEAR-A", 100), 1000)
+	if err := store.Upsert(ctx, nearA); err != nil {
+		t.Fatalf("Upsert %s: %v", nearA.Name, err)
+	}
+
+	gotA, err := store.RecentNearestTown(ctx, "100", townA.Lat, townA.Lng, townA.RadiusMetres, []TownCentroid{townB}, 10)
+	if err != nil {
+		t.Fatalf("RecentNearestTown (town A): %v", err)
+	}
+	assertNames(t, appNames(gotA), []string{"NEAR-A"})
+
+	gotB, err := store.RecentNearestTown(ctx, "100", townB.Lat, townB.Lng, townB.RadiusMetres, []TownCentroid{townA}, 10)
+	if err != nil {
+		t.Fatalf("RecentNearestTown (town B): %v", err)
+	}
+	if len(gotB) != 0 {
+		t.Errorf("sibling town B: got %v, want none (NEAR-A belongs to A alone, no overlap)", appNames(gotB))
+	}
+}
+
+// TestPostgresStore_RecentNearestTown_OrdersByRealDateWithTieBreak proves the
+// partitioned read shares decision 1's ordering (GREATEST(decided_date,
+// start_date) DESC NULLS LAST, tie-broken by start_date DESC NULLS LAST then
+// planit_name) — a stale-but-reindexed application must not float to the top
+// within a town's own partition either.
+func TestPostgresStore_RecentNearestTown_OrdersByRealDateWithTieBreak(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	decidedDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	newer := at(pgApp("NEWER", 100), 100)
+	newer.DecidedDate = pgPtr(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC))
+	newer.LastDifferent = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) // deliberately stale marker
+
+	// Tied GREATEST (both decided 2026-01-01), different start_date: the later
+	// start_date sorts first.
+	tieLaterStart := at(pgApp("TIE-LATER-START", 100), 200)
+	tieLaterStart.StartDate = pgPtr(time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC))
+	tieLaterStart.DecidedDate = pgPtr(decidedDate)
+
+	tieEarlierStart := at(pgApp("TIE-EARLIER-START", 100), 200)
+	tieEarlierStart.StartDate = pgPtr(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC))
+	tieEarlierStart.DecidedDate = pgPtr(decidedDate)
+
+	for _, a := range []PlanningApplication{newer, tieLaterStart, tieEarlierStart} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	got, err := store.RecentNearestTown(ctx, "100", pgCentreLat, pgCentreLon, 3000, nil, 10)
+	if err != nil {
+		t.Fatalf("RecentNearestTown: %v", err)
+	}
+	assertNames(t, appNames(got), []string{"NEWER", "TIE-LATER-START", "TIE-EARLIER-START"})
+}
+
+// TestPostgresStore_RecentNearestTown_EmptyAndNearEmptyPartitions proves a
+// town with nothing (or nothing but out-of-authority/out-of-radius noise) in
+// its partition returns an empty, non-error slice, and that a nil siblings
+// slice degrades to a plain (non-partitioned) single-point radius read scoped
+// to the authority.
+func TestPostgresStore_RecentNearestTown_EmptyAndNearEmptyPartitions(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	// Nothing seeded at all: an empty partition must be an empty slice, not an error.
+	empty, err := store.RecentNearestTown(ctx, "100", pgCentreLat, pgCentreLon, 3000, nil, 10)
+	if err != nil {
+		t.Fatalf("RecentNearestTown on an empty table: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Errorf("empty table: got %v, want none", appNames(empty))
+	}
+
+	outOfRadius := at(pgApp("OUTSIDE", 100), 9000)
+	otherAuth := at(pgApp("OTHER-AUTH", 200), 100) // in radius, wrong authority
+	onlyApp := at(pgApp("ONLY", 100), 100)
+	for _, a := range []PlanningApplication{outOfRadius, otherAuth, onlyApp} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	got, err := store.RecentNearestTown(ctx, "100", pgCentreLat, pgCentreLon, 3000, nil, 10)
+	if err != nil {
+		t.Fatalf("RecentNearestTown near-empty: %v", err)
+	}
+	// Only ONLY qualifies: OUTSIDE is beyond the radius, OTHER-AUTH is the wrong
+	// authority, and there are no siblings to steal or duplicate it.
+	assertNames(t, appNames(got), []string{"ONLY"})
 }
 
 // TestPostgresStore_BreakdownNearby returns the exact per-app_state counts over

--- a/api-go/internal/applications/store_postgres_test.go
+++ b/api-go/internal/applications/store_postgres_test.go
@@ -296,18 +296,38 @@ func TestPostgresStore_GetByUID(t *testing.T) {
 
 // TestPostgresStore_RecentByAuthority orders by last_different DESC, bounds by
 // cap, and scopes to the authority.
-func TestPostgresStore_RecentByAuthority(t *testing.T) {
+// TestPostgresStore_RecentByAuthority_OrdersByRealDateDescNullsLast proves the
+// #819 fix directly: ordering is GREATEST(decided_date, start_date) DESC NULLS
+// LAST, NOT last_different (a PlanIt re-index marker that can bump to "now" on
+// an old application and float it to the top). A stale-but-recently-reindexed
+// application (bumped LastDifferent, real dates from years ago) must sort
+// behind a genuinely newer one, and an application with neither date set sorts
+// last rather than erroring or vanishing.
+func TestPostgresStore_RecentByAuthority_OrdersByRealDateDescNullsLast(t *testing.T) {
 	ctx := context.Background()
 	store := newAppPGStore(t)
 
-	older := pgApp("OLD", 100)
-	older.LastDifferent = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	mid := pgApp("MID", 100)
-	mid.LastDifferent = time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
-	newer := pgApp("NEW", 100)
-	newer.LastDifferent = time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	decidedRecent := pgApp("DECIDED-RECENT", 100)
+	decidedRecent.StartDate = pgPtr(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	decidedRecent.DecidedDate = pgPtr(time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC))
+	decidedRecent.LastDifferent = time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC) // NOT the sort key
+
+	startedOnly := pgApp("STARTED-ONLY", 100)
+	startedOnly.StartDate = pgPtr(time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC))
+
+	// Stale application: real dates from 2021, but PlanIt re-indexed it, bumping
+	// LastDifferent to "now" — exactly the Croydon DISC bug (#819). It must NOT
+	// float to the top under the fixed ordering.
+	staleReindexed := pgApp("STALE-REINDEXED", 100)
+	staleReindexed.StartDate = pgPtr(time.Date(2021, 5, 28, 0, 0, 0, 0, time.UTC))
+	staleReindexed.DecidedDate = pgPtr(time.Date(2021, 7, 9, 0, 0, 0, 0, time.UTC))
+	staleReindexed.LastDifferent = time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC) // bumped "now"
+
+	noDates := pgApp("NO-DATES", 100) // neither start nor decided set
+
 	other := pgApp("OTHER-AUTH", 200) // must not appear for authority 100
-	for _, a := range []PlanningApplication{older, mid, newer, other} {
+
+	for _, a := range []PlanningApplication{decidedRecent, startedOnly, staleReindexed, noDates, other} {
 		if err := store.Upsert(ctx, a); err != nil {
 			t.Fatalf("Upsert %s: %v", a.Name, err)
 		}
@@ -317,13 +337,61 @@ func TestPostgresStore_RecentByAuthority(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RecentByAuthority: %v", err)
 	}
-	assertNames(t, appNames(got), []string{"NEW", "MID", "OLD"})
+	// DECIDED-RECENT (2026-05-01) > STARTED-ONLY (2026-02-01) > STALE-REINDEXED
+	// (2021-07-09, despite the "now" LastDifferent) > NO-DATES (NULL, NULLS LAST).
+	assertNames(t, appNames(got), []string{"DECIDED-RECENT", "STARTED-ONLY", "STALE-REINDEXED", "NO-DATES"})
 
 	capped, err := store.RecentByAuthority(ctx, "100", 2)
 	if err != nil {
 		t.Fatalf("RecentByAuthority capped: %v", err)
 	}
-	assertNames(t, appNames(capped), []string{"NEW", "MID"})
+	assertNames(t, appNames(capped), []string{"DECIDED-RECENT", "STARTED-ONLY"})
+}
+
+// TestPostgresStore_RecentByAuthority_TieBreakIsDeterministic proves the
+// decision-1 tie-break (start_date DESC NULLS LAST, then planit_name ASC) when
+// two or more applications share the exact same GREATEST(decided_date,
+// start_date) value.
+func TestPostgresStore_RecentByAuthority_TieBreakIsDeterministic(t *testing.T) {
+	ctx := context.Background()
+	store := newAppPGStore(t)
+
+	decidedDate := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// Same GREATEST (both decided 2026-01-01) but different start_date: the later
+	// start_date breaks the tie and sorts first.
+	laterStart := pgApp("LATER-START", 100)
+	laterStart.StartDate = pgPtr(time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC))
+	laterStart.DecidedDate = pgPtr(decidedDate)
+
+	earlierStart := pgApp("EARLIER-START", 100)
+	earlierStart.StartDate = pgPtr(time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC))
+	earlierStart.DecidedDate = pgPtr(decidedDate)
+
+	// Same GREATEST AND same start_date: falls through to planit_name ASC.
+	sameEverythingA := pgApp("AAA-SAME", 100)
+	sameEverythingA.StartDate = pgPtr(time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC))
+	sameEverythingA.DecidedDate = pgPtr(decidedDate)
+
+	sameEverythingZ := pgApp("ZZZ-SAME", 100)
+	sameEverythingZ.StartDate = pgPtr(time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC))
+	sameEverythingZ.DecidedDate = pgPtr(decidedDate)
+
+	for _, a := range []PlanningApplication{laterStart, earlierStart, sameEverythingA, sameEverythingZ} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	got, err := store.RecentByAuthority(ctx, "100", 10)
+	if err != nil {
+		t.Fatalf("RecentByAuthority: %v", err)
+	}
+	// LATER-START and AAA-SAME/ZZZ-SAME share start_date 2025-07-01 (all later than
+	// EARLIER-START's 2025-06-01), so EARLIER-START sorts last of the four. Among
+	// the tied 2025-07-01 trio, planit_name ASC orders AAA-SAME, LATER-START,
+	// ZZZ-SAME.
+	assertNames(t, appNames(got), []string{"AAA-SAME", "LATER-START", "ZZZ-SAME", "EARLIER-START"})
 }
 
 // TestPostgresStore_RecentInAuthorities orders by last_different DESC across

--- a/api-go/internal/platform/postgres/migrations/0017_application_real_date_sort_index.sql
+++ b/api-go/internal/platform/postgres/migrations/0017_application_real_date_sort_index.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+
+-- Backs the SEO authority read's real-date ordering (#819, decision 1): the
+-- fix swaps last_different (a PlanIt re-index marker that can bump to "now" on
+-- an old application and float it to the top) for
+-- GREATEST(decided_date, start_date) DESC NULLS LAST, tie-broken by
+-- start_date DESC NULLS LAST then planit_name — the exact column order and
+-- direction the query's ORDER BY uses (see recentRealDateOrder in
+-- store_postgres.go), so the whole ORDER BY is index-served, not just a leading
+-- prefix. GREATEST is a deterministic function of its (immutable) date-column
+-- arguments, so it is usable in an expression index.
+CREATE INDEX IF NOT EXISTS applications_authority_real_date
+    ON applications (
+        authority_code,
+        (GREATEST(decided_date, start_date)) DESC NULLS LAST,
+        start_date DESC NULLS LAST,
+        planit_name
+    );
+
+-- +goose Down
+
+DROP INDEX IF EXISTS applications_authority_real_date;

--- a/web/scripts/lib/__tests__/prerender-snapshot.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-snapshot.test.mjs
@@ -248,14 +248,19 @@ describe('runFetch — snapshot mode', () => {
     expect(appsCalls[0].url).toContain('/v1/authorities/1/applications');
     expect(appsCalls[0].init.headers['X-Build-Key']).toBe('test-key');
 
-    // The below-threshold "Tiny" town never hits the geo endpoint: exactly one
-    // near call (for Truro), carrying order=distance and the build key.
+    // The below-threshold "Tiny" town never hits the geo endpoint itself: exactly
+    // one near call (for Truro), radius-bounded, no order=distance (tc-s0yf).
     const nearCalls = stub.calls.filter((c) =>
       c.url.includes('/v1/applications/near'),
     );
     expect(nearCalls).toHaveLength(1);
     expect(nearCalls[0].url).toContain('authorityId=52');
-    expect(nearCalls[0].url).toContain('order=distance');
+    expect(nearCalls[0].url).not.toContain('order=distance');
+    expect(nearCalls[0].url).toContain('radius=5000');
+    // ...but Tiny's centroid is STILL sent as Truro's sibling (decision 2, GH
+    // #819): every gazetteer town in an authority is a Voronoi sibling
+    // candidate for every other town, regardless of the population gate.
+    expect(nearCalls[0].url).toContain('sibling=50.1,-5.1,5000');
     expect(nearCalls[0].init.headers['X-Build-Key']).toBe('test-key');
 
     // Never PlanIt — only our own API.

--- a/web/scripts/lib/__tests__/prerender-towns.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-towns.test.mjs
@@ -222,10 +222,15 @@ describe('runPrerender — town live mode', () => {
     expect(html).toContain('<h1>Planning applications in Truro</h1>');
   });
 
-  it('displays the distance-ordered set newest-first, regardless of the order the API returned', async () => {
-    // The build requests order=distance, so the API returns the nearest-N — NOT
-    // recency-ordered. Here the nearest app (CW-NEAR) is the OLDEST and a farther
-    // app (CW-FAR) is the NEWEST, so a recency display MUST reorder them.
+  it('renders the applications in the exact order the API returned them (no client-side re-sort, tc-s0yf)', async () => {
+    // The near read is now fully server-ordered (town-level Voronoi partition +
+    // GREATEST(decidedDate, startDate) DESC, tc-s0yf) — replacing the old
+    // order=distance + client re-sort-by-lastDifferent pipeline. This fixture
+    // deliberately puts the OLDER-lastDifferent app FIRST in the API response and
+    // the NEWER-lastDifferent app SECOND: if the old client-side recency re-sort
+    // were still running, it would flip them. It must not — the page must render
+    // the API's given order as-is, proving the re-sort is truly gone (not just
+    // reordered to a no-op).
     const stub = new StubFetch((url) => {
       if (url.includes('/v1/applications/near')) {
         return {
@@ -238,25 +243,27 @@ describe('runPrerender — town live mode', () => {
             radius: 5000,
             applications: [
               {
-                uid: 'CW-NEAR',
-                name: 'PA26/NEAR',
-                address: 'Nearest, Truro',
-                description: 'Closest by distance but oldest change',
+                uid: 'CW-FIRST',
+                name: 'PA26/FIRST',
+                address: 'First In API Order, Truro',
+                description: 'Server-ordered first, despite an OLDER lastDifferent',
                 appState: 'Permitted',
                 startDate: '2026-01-01',
+                decidedDate: null,
                 lastDifferent: '2026-06-01T08:00:00+00:00',
-                link: 'https://planit.org.uk/planapplic/CW-NEAR',
+                link: 'https://planit.org.uk/planapplic/CW-FIRST',
                 url: null,
               },
               {
-                uid: 'CW-FAR',
-                name: 'PA26/FAR',
-                address: 'Farther, Truro',
-                description: 'Farther by distance but freshest change',
+                uid: 'CW-SECOND',
+                name: 'PA26/SECOND',
+                address: 'Second In API Order, Truro',
+                description: 'Server-ordered second, despite a NEWER lastDifferent',
                 appState: 'Rejected',
                 startDate: '2026-02-02',
+                decidedDate: '2026-06-20',
                 lastDifferent: '2026-06-20T09:00:00+00:00',
-                link: 'https://planit.org.uk/planapplic/CW-FAR',
+                link: 'https://planit.org.uk/planapplic/CW-SECOND',
                 url: null,
               },
             ],
@@ -282,21 +289,17 @@ describe('runPrerender — town live mode', () => {
       join(outDir, 'planning', 'cornwall', 'truro', 'index.html'),
       'utf-8',
     );
-    // The freshest card (Farther, changed 20 Jun) appears BEFORE the oldest
-    // (Nearest, changed 1 Jun) - recency DESC, even though the API fed them
-    // distance-order (nearest/oldest first). The per-card date is gone
-    // (tc-r4n9.3), so address text is the proxy for card order here; the
-    // single page-level "Data updated" line is asserted separately below.
-    expect(html).toContain('Farther, Truro');
-    expect(html).toContain('Nearest, Truro');
-    expect(html.indexOf('Farther, Truro')).toBeLessThan(
-      html.indexOf('Nearest, Truro'),
+    expect(html).toContain('First In API Order, Truro');
+    expect(html).toContain('Second In API Order, Truro');
+    expect(html.indexOf('First In API Order, Truro')).toBeLessThan(
+      html.indexOf('Second In API Order, Truro'),
     );
-    // The page-level "Data updated" line reflects the freshest shown date.
+    // The page-level "Data updated" line is unaffected by render order — still
+    // the freshest lastDifferent among the shown set.
     expect(html).toContain('Data updated 20 Jun 2026');
 
-    // The page's sitemap lastmod is the freshest shown app (20 Jun), proving the
-    // lastmod is derived AFTER the recency sort and matches what the cards show.
+    // The sitemap lastmod is likewise the freshest shown app's lastDifferent,
+    // independent of render order.
     const sitemap = await readFile(join(outDir, 'sitemap.xml'), 'utf-8');
     expect(sitemap).toContain('<lastmod>2026-06-20</lastmod>');
   });

--- a/web/scripts/lib/__tests__/prerender-towns.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-towns.test.mjs
@@ -211,8 +211,14 @@ describe('runPrerender — town live mode', () => {
     expect(nearCalls[0].url).toContain('lat=50.2632');
     expect(nearCalls[0].url).toContain('lng=-5.051');
     expect(nearCalls[0].url).toContain('limit=30');
-    // Selects the nearest-N by distance (the order=distance variant from tc-2avw.1).
-    expect(nearCalls[0].url).toContain('order=distance');
+    // tc-s0yf: the server now always returns town-partitioned, pre-ordered
+    // results — order=distance is gone, and the primary point carries an
+    // explicit radius (mirroring the server's own 5000m default).
+    expect(nearCalls[0].url).not.toContain('order=distance');
+    expect(nearCalls[0].url).toContain('radius=5000');
+    // Truro is the only gazetteer town in this authority, so no sibling
+    // centroid is sent at all.
+    expect(nearCalls[0].url).not.toContain('sibling=');
     expect(nearCalls[0].init.headers['X-Build-Key']).toBe('test-key');
 
     const html = await readFile(
@@ -468,6 +474,221 @@ describe('runPrerender — town live mode', () => {
   });
 });
 
+// Sibling centroid passthrough (tc-s0yf.2, GH #819): the near query now carries
+// one `sibling=lat,lng,radius` per OTHER gazetteer town in the same authority,
+// so the server can run its town-level Voronoi partition. All radii — primary
+// and sibling alike — use the same build-time default (5000m, mirroring the
+// server's own default) since the committed gazetteer has no per-town radius.
+describe('runPrerender — town live mode: sibling centroid passthrough (tc-s0yf.2)', () => {
+  const cornwallAuthorities = [
+    { id: 52, name: 'Cornwall', areaType: 'English County' },
+  ];
+
+  /** A geo stub that always clears the >=10 coverage gate for any town. */
+  function gatePassingStub() {
+    return new StubFetch((url) => {
+      if (url.includes('/v1/applications/near')) {
+        return {
+          ok: true,
+          status: 200,
+          body: {
+            authorityId: 52,
+            radius: 5000,
+            applications: [
+              {
+                uid: 'CW1',
+                name: 'PA26/0001',
+                address: 'Some address',
+                description: 'Some description',
+                appState: 'Permitted',
+                startDate: '2026-01-12',
+                lastDifferent: '2026-06-12T10:00:00+00:00',
+                link: null,
+                url: null,
+              },
+            ],
+            total: 14,
+            statusBreakdown: [{ appState: 'Permitted', count: 14 }],
+          },
+        };
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+  }
+
+  it('serializes every OTHER same-authority gazetteer town as a repeated sibling=lat,lng,radius param', async () => {
+    const truro = {
+      slug: 'truro',
+      name: 'Truro',
+      lat: 50.2632,
+      lng: -5.051,
+      authorityId: 52,
+      population: 25000,
+    };
+    const falmouth = {
+      slug: 'falmouth',
+      name: 'Falmouth',
+      lat: 50.1526,
+      lng: -5.0745,
+      authorityId: 52,
+      population: 22000,
+    };
+    const newquay = {
+      slug: 'newquay',
+      name: 'Newquay',
+      lat: 50.4155,
+      lng: -5.0904,
+      authorityId: 52,
+      population: 21000,
+    };
+    const stub = gatePassingStub();
+
+    await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => [truro, falmouth, newquay],
+      logger: silentLogger,
+    });
+
+    const nearCalls = stub.calls.filter((c) => c.url.includes('/v1/applications/near'));
+    expect(nearCalls).toHaveLength(3);
+
+    const truroCall = nearCalls.find((c) => c.url.includes('lat=50.2632'));
+    expect(truroCall).toBeDefined();
+    // Truro's siblings are Falmouth + Newquay (NOT Truro itself) — exactly two.
+    expect(truroCall.url).toContain('sibling=50.1526,-5.0745,5000');
+    expect(truroCall.url).toContain('sibling=50.4155,-5.0904,5000');
+    expect((truroCall.url.match(/sibling=/g) ?? [])).toHaveLength(2);
+    expect(truroCall.url).not.toContain('sibling=50.2632,-5.051,5000');
+  });
+
+  it('omits the sibling param entirely when the town is the only gazetteer town in its authority', async () => {
+    const soleTown = {
+      slug: 'truro',
+      name: 'Truro',
+      lat: 50.2632,
+      lng: -5.051,
+      authorityId: 52,
+      population: 25000,
+    };
+    const stub = gatePassingStub();
+
+    await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => [soleTown],
+      logger: silentLogger,
+    });
+
+    const nearCalls = stub.calls.filter((c) => c.url.includes('/v1/applications/near'));
+    expect(nearCalls).toHaveLength(1);
+    expect(nearCalls[0].url).not.toContain('sibling=');
+  });
+
+  it('still passes a below-population-threshold town as a sibling centroid, even though it is never itself fetched', async () => {
+    const truro = {
+      slug: 'truro',
+      name: 'Truro',
+      lat: 50.2632,
+      lng: -5.051,
+      authorityId: 52,
+      population: 25000,
+    };
+    // Below the default 20000 threshold: never gets its own near fetch, but its
+    // gazetteer centroid still contributes to the Voronoi partition (decision 2,
+    // GH #819) — all gazetteer towns in an authority are sibling candidates.
+    const tiny = {
+      slug: 'tiny',
+      name: 'Tiny',
+      lat: 50.3,
+      lng: -5.2,
+      authorityId: 52,
+      population: 5000,
+    };
+    const stub = gatePassingStub();
+
+    await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      env: {},
+      loadAuthorities: async () => cornwallAuthorities,
+      loadTowns: async () => [truro, tiny],
+      logger: silentLogger,
+    });
+
+    // Tiny never gets its own near call (below threshold)...
+    const nearCalls = stub.calls.filter((c) => c.url.includes('/v1/applications/near'));
+    expect(nearCalls).toHaveLength(1);
+    // ...but its centroid IS sent as Truro's sibling.
+    expect(nearCalls[0].url).toContain('sibling=50.3,-5.2,5000');
+  });
+
+  it('never sends siblings for towns in a DIFFERENT authority', async () => {
+    const truro = {
+      slug: 'truro',
+      name: 'Truro',
+      lat: 50.2632,
+      lng: -5.051,
+      authorityId: 52,
+      population: 25000,
+    };
+    const otherAuthorityTown = {
+      slug: 'elsewhere',
+      name: 'Elsewhere',
+      lat: 51.5,
+      lng: -0.1,
+      authorityId: 999,
+      population: 30000,
+    };
+    const stub = new StubFetch((url) => {
+      if (url.includes('/v1/applications/near')) {
+        return {
+          ok: true,
+          status: 200,
+          body: {
+            authorityId: url.includes('authorityId=52') ? 52 : 999,
+            radius: 5000,
+            applications: [],
+            total: 14,
+            statusBreakdown: [],
+          },
+        };
+      }
+      throw new Error(`unexpected url ${url}`);
+    });
+
+    await runPrerender({
+      outDir,
+      apiBase: 'https://api-dev.towncrierapp.uk',
+      buildKey: 'test-key',
+      fetchImpl: stub.fetch,
+      loadAuthorities: async () => [
+        ...cornwallAuthorities,
+        // Non-qualifying areaType (as cornwallAuthorities already is), so this
+        // test isolates the TOWN/near pipeline and never hits the authority
+        // applications endpoint.
+        { id: 999, name: 'Elsewhere Council', areaType: 'English County' },
+      ],
+      loadTowns: async () => [truro, otherAuthorityTown],
+      logger: silentLogger,
+    });
+
+    const nearCalls = stub.calls.filter((c) => c.url.includes('/v1/applications/near'));
+    expect(nearCalls).toHaveLength(2);
+    for (const call of nearCalls) {
+      expect(call.url).not.toContain('sibling=');
+    }
+  });
+});
+
 // resolveMinPopulation (tc-2avw.3): the build-time published-population gate is a
 // config value read from SEO_TOWN_MIN_POPULATION, defaulting to 20000 when the
 // var is missing, empty, or not a positive finite integer.
@@ -708,8 +929,9 @@ describe('runPrerender — population threshold filter (live mode)', () => {
 
 // The integration spine for the per-town SEO pipeline (tc-2avw.2): drives ONE
 // authority end-to-end through the two NEW pieces wired in this bead — the
-// `population` field in the gazetteer schema and the `order=distance` near param —
-// from gazetteer load → near fetch → coverage gate → page write → sitemap.
+// `population` field in the gazetteer schema and the near-query radius param
+// (order=distance is gone — tc-s0yf) — from gazetteer load → near fetch →
+// coverage gate → page write → sitemap.
 describe('runPrerender — per-town integration spine (one authority, end to end)', () => {
   const cornwallAuthorities = [
     { id: 52, name: 'Cornwall', areaType: 'English County' },
@@ -730,7 +952,7 @@ describe('runPrerender — per-town integration spine (one authority, end to end
     await expect(loadTownsFromFile('/fake/towns.json', readImpl)).rejects.toThrow();
   });
 
-  it('loads a population-bearing gazetteer, requests order=distance, gates, writes the page, and lists it in the sitemap', async () => {
+  it('loads a population-bearing gazetteer, requests a radius-bounded near read, gates, writes the page, and lists it in the sitemap', async () => {
     // 1) Gazetteer load: a real loadTownsFromFile round-trip carrying `population`.
     const gazetteer = async () =>
       JSON.stringify([
@@ -791,12 +1013,15 @@ describe('runPrerender — per-town integration spine (one authority, end to end
       logger: silentLogger,
     });
 
-    // 3) order=distance: the near request consumes the tc-2avw.1 param.
+    // 3) The near request is radius-bounded and no longer requests order=distance
+    // (tc-s0yf); a lone town in its authority sends no sibling param.
     const nearCalls = stub.calls.filter((c) =>
       c.url.includes('/v1/applications/near'),
     );
     expect(nearCalls).toHaveLength(1);
-    expect(nearCalls[0].url).toContain('order=distance');
+    expect(nearCalls[0].url).not.toContain('order=distance');
+    expect(nearCalls[0].url).toContain('radius=5000');
+    expect(nearCalls[0].url).not.toContain('sibling=');
 
     // No PlanIt at build time — only our own build-key-gated API.
     expect(stub.calls.every((c) => !c.url.includes('planit.org.uk'))).toBe(true);

--- a/web/scripts/lib/__tests__/render-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-page.test.mjs
@@ -204,10 +204,23 @@ describe('renderPlanningPage', () => {
       expect(html.indexOf('class="dataUpdated"')).toBeLessThan(html.indexOf('class="lead"'));
     });
 
-    it('no longer repeats a "Last updated" line once per card', () => {
+    it('no longer repeats the old "Last updated" line once per card', () => {
       const html = renderPlanningPage(pageData());
       expect(html).not.toContain('Last updated');
-      expect(html).not.toContain('appCard__date');
+    });
+
+    // tc-s0yf (GH #819) deliberately reintroduces a per-card date line — under a
+    // NEW class (`appCard__dates`) and format (Started/Decided, sourced from the
+    // application's own real-world dates, not a re-index marker) — distinct from
+    // the old "Last updated" line this describe block's title refers to.
+    it('renders the Started/Decided date line once per card (tc-s0yf)', () => {
+      const html = renderPlanningPage(pageData());
+      expect(html).toContain(
+        '<p class="appCard__dates">Started 15 Jan 2026 · Awaiting decision</p>',
+      );
+      expect(html).toContain(
+        '<p class="appCard__dates">Started 3 Feb 2026 · Awaiting decision</p>',
+      );
     });
   });
 

--- a/web/scripts/lib/__tests__/render-shared.test.mjs
+++ b/web/scripts/lib/__tests__/render-shared.test.mjs
@@ -215,6 +215,55 @@ describe('renderApplicationsList status chip vocabulary (decision 4: shared voca
   });
 });
 
+describe('renderApplicationsList Started/Decided date line (tc-s0yf, GH #819)', () => {
+  it('renders "Decided <date>" when decidedDate is set, even if startDate is also set (decided takes precedence)', () => {
+    const html = renderApplicationsList(
+      [application({ startDate: '2021-05-28', decidedDate: '2021-07-09' })],
+      SLUG,
+    );
+    expect(html).toContain('<p class="appCard__dates">Decided 9 Jul 2021</p>');
+    expect(html).not.toContain('Started 28 May 2021');
+  });
+
+  it('renders "Started <date> · Awaiting decision" when only startDate is set', () => {
+    const html = renderApplicationsList(
+      [application({ startDate: '2026-07-04', decidedDate: null })],
+      SLUG,
+    );
+    expect(html).toContain(
+      '<p class="appCard__dates">Started 4 Jul 2026 · Awaiting decision</p>',
+    );
+  });
+
+  it('renders "Decided <date>" when only decidedDate is set (no startDate)', () => {
+    const html = renderApplicationsList(
+      [application({ startDate: null, decidedDate: '2021-07-09' })],
+      SLUG,
+    );
+    expect(html).toContain('<p class="appCard__dates">Decided 9 Jul 2021</p>');
+  });
+
+  it('renders no date line at all when neither date is present, without crashing or emitting "undefined"/"Invalid Date"', () => {
+    const html = renderApplicationsList(
+      [application({ startDate: null, decidedDate: null })],
+      SLUG,
+    );
+    expect(html).not.toContain('appCard__dates');
+    expect(html).not.toContain('undefined');
+    expect(html).not.toContain('Invalid Date');
+  });
+
+  it('handles a missing decidedDate key entirely (not just null) without crashing', () => {
+    const app = application({ startDate: '2026-01-15' });
+    delete app.decidedDate;
+    const html = renderApplicationsList([app], SLUG);
+    expect(html).toContain(
+      '<p class="appCard__dates">Started 15 Jan 2026 · Awaiting decision</p>',
+    );
+    expect(html).not.toContain('undefined');
+  });
+});
+
 describe('renderStatusSummary (tc-r4n9.3: compact Granted/Refused/Undecided strip)', () => {
   const BREAKDOWN = [
     { appState: 'Permitted', count: 20 },
@@ -345,6 +394,14 @@ describe('pageStyles appCard__link (whole-card share-page affordance)', () => {
     const css = pageStyles();
     expect(css).toContain('.appCard__cta');
     expect(css).toMatch(/\.appCard__cta \{[^}]*var\(--tc-amber\)/);
+  });
+});
+
+describe('pageStyles appCard__dates (Started/Decided date line, tc-s0yf)', () => {
+  it('styles the date line as secondary metadata text using design tokens', () => {
+    const css = pageStyles();
+    expect(css).toContain('.appCard__dates');
+    expect(css).toMatch(/\.appCard__dates \{[^}]*var\(--tc-text-secondary\)/);
   });
 });
 

--- a/web/scripts/lib/__tests__/render-town-page.test.mjs
+++ b/web/scripts/lib/__tests__/render-town-page.test.mjs
@@ -146,10 +146,23 @@ describe('renderTownPage', () => {
       expect(html.indexOf('class="dataUpdated"')).toBeLessThan(html.indexOf('class="lead"'));
     });
 
-    it('no longer repeats a "Last updated" line once per card', () => {
+    it('no longer repeats the old "Last updated" line once per card', () => {
       const html = renderTownPage(townData());
       expect(html).not.toContain('Last updated');
-      expect(html).not.toContain('appCard__date');
+    });
+
+    // tc-s0yf (GH #819) deliberately reintroduces a per-card date line — under a
+    // NEW class (`appCard__dates`) and format (Started/Decided, sourced from the
+    // application's own real-world dates, not a re-index marker) — distinct from
+    // the old "Last updated" line this describe block's title refers to.
+    it('renders the Started/Decided date line once per card (tc-s0yf)', () => {
+      const html = renderTownPage(townData());
+      expect(html).toContain(
+        '<p class="appCard__dates">Started 12 Jan 2026 · Awaiting decision</p>',
+      );
+      expect(html).toContain(
+        '<p class="appCard__dates">Started 1 Feb 2026 · Awaiting decision</p>',
+      );
     });
   });
 

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -16,6 +16,7 @@ import {
   statusDisplayLabel,
   aggregateStatusSummary,
   dataUpdatedLine,
+  formatDate,
 } from './format.mjs';
 
 /**
@@ -26,6 +27,9 @@ import {
  * @property {string} description
  * @property {string | null} appState
  * @property {string | null} startDate      yyyy-MM-dd
+ * @property {string | null} [decidedDate]  yyyy-MM-dd; when present, takes precedence over
+ *   `startDate` for the card's Started/Decided line (tc-s0yf, GH #819) — the more final,
+ *   informative lifecycle event. Optional/nullable: absent on an undecided application.
  * @property {string} lastDifferent         ISO-8601 with offset; the DESC sort key
  * @property {string | null} link           PlanIt permalink (always a reliable per-application record). No longer rendered
  *   as a per-card link (decision 6); kept only as a JSON-LD `url` fallback when no share URL can be built.
@@ -63,6 +67,31 @@ function statusColorModifier(appState) {
 }
 
 /**
+ * Build the card's Started/Decided date line (tc-s0yf, GH #819 acceptance).
+ * `decidedDate` is the more final, informative lifecycle event, so it takes
+ * precedence over `startDate` when both are present ("Decided 9 Jul 2021").
+ * With only a `startDate`, the application is still awaiting a decision
+ * ("Started 4 Jul 2026 · Awaiting decision"). `formatDate` already reduces a
+ * null/undefined/unparseable date to `''`, so a missing or malformed date
+ * simply falls through — this never emits "undefined" or "Invalid Date".
+ * Returns `''` (no line at all) when neither date is present/parseable.
+ *
+ * @param {PlanningApplicationItem} app
+ * @returns {string}
+ */
+function applicationDateLine(app) {
+  const decided = formatDate(app.decidedDate);
+  if (decided) {
+    return `Decided ${decided}`;
+  }
+  const started = formatDate(app.startDate);
+  if (started) {
+    return `Started ${started} · Awaiting decision`;
+  }
+  return '';
+}
+
+/**
  * @param {PlanningApplicationItem} app
  * @param {string} [authoritySlug] the page's authority slug; when present (and
  *   the app carries a ref), the whole card becomes a do-follow link to our own
@@ -82,6 +111,11 @@ function renderApplication(app, authoritySlug) {
   // entirely when the app carries none.
   const address = escapeHtml(app.address);
   const ref = escapeHtml(app.name);
+  // Real-world Started/Decided date (tc-s0yf, GH #819) — immune to PlanIt's
+  // last_different re-index marker. escapeHtml is redundant here (formatDate's
+  // output is already a safe short-form string) but kept for consistency with
+  // every other data-derived string in this function.
+  const dateLine = escapeHtml(applicationDateLine(app));
 
   // Per-card external links to PlanIt/the council are retired (decision 6):
   // the card's one click target is our own share page, surfaced as a real,
@@ -95,6 +129,7 @@ function renderApplication(app, authoritySlug) {
           <span class="status status--${modifier}">${label}</span>
         </div>
         ${ref ? `<p class="appCard__ref">${ref}</p>` : ''}
+        ${dateLine ? `<p class="appCard__dates">${dateLine}</p>` : ''}
         <p class="appCard__desc">${description}</p>
         <div class="appCard__meta">
           ${share ? `<span class="appCard__cta">View details →</span>` : ''}
@@ -371,6 +406,9 @@ export function pageStyles() {
     .appCard__address { margin: 0; font-weight: 600; overflow-wrap: anywhere; }
     /* The council reference is demoted to small metadata under the headline. */
     .appCard__ref { margin: var(--tc-space-sm) 0; font-size: 0.8125rem; color: var(--tc-text-secondary); overflow-wrap: anywhere; }
+    /* Started/Decided real-world date line (tc-s0yf, GH #819) — same secondary
+       metadata treatment as the reference line above it. */
+    .appCard__dates { margin: 0 0 var(--tc-space-sm); font-size: 0.8125rem; color: var(--tc-text-secondary); }
     .appCard__desc { margin: 0 0 var(--tc-space-sm); color: var(--tc-text-secondary); }
     .appCard__meta { display: flex; flex-wrap: wrap; gap: var(--tc-space-md); align-items: center; font-size: 0.875rem; }
     /* Visible share-page affordance (decision 6) — a real anchor, not a

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -87,30 +87,6 @@ function maxLastmod(applications) {
 }
 
 /**
- * Sort applications by `lastDifferent` DESC (freshest first) for DISPLAY. Town
- * nearby data arrives distance-ordered (the build requests `order=distance` to
- * minimise overlap between adjacent town pages), so the renderer must re-sort it
- * by recency so the cards read newest-first (matching the single page-level
- * "Data updated" line, which reports the freshest of the same shown set).
- * Authority data already arrives recency-ordered, so this is only applied on the
- * town path. Returns a new array; undated rows sort last, original order is kept
- * among equal dates (stable).
- *
- * @param {ReadonlyArray<{ lastDifferent?: string | null }>} applications
- * @returns {Array<{ lastDifferent?: string | null }>}
- */
-function sortByRecencyDesc(applications) {
-  const keyed = applications.map((app, index) => {
-    const iso = app?.lastDifferent;
-    const ms =
-      typeof iso === 'string' && iso !== '' ? new Date(iso).getTime() : NaN;
-    return { app, index, ms: Number.isNaN(ms) ? -Infinity : ms };
-  });
-  keyed.sort((a, b) => b.ms - a.ms || a.index - b.index);
-  return keyed.map((k) => k.app);
-}
-
-/**
  * Default published-population threshold when `SEO_TOWN_MIN_POPULATION` is unset,
  * empty, or not a positive finite integer. A town ships only if its built-up-area
  * population is at least this value (the ≥10 in-radius coverage gate applies on
@@ -614,10 +590,10 @@ async function considerTown(args) {
   }
   seenPaths.add(path);
 
-  // Town nearby data arrives distance-ordered (order=distance, tc-2avw.2). Re-sort
-  // by lastDifferent DESC for display so the cards read newest-first and the
-  // page's lastmod (derived below) is consistent with what is shown.
-  const shown = sortByRecencyDesc(applications).slice(0, limit);
+  // The near read is a fully server-side town-level Voronoi partition, already
+  // ordered by GREATEST(decidedDate, startDate) DESC (tc-s0yf) — like the
+  // authority read (considerAuthority, above), so no re-sort here.
+  const shown = applications.slice(0, limit);
   await writeTownPage(outDir, {
     townName: town.name,
     townSlug: town.slug,

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -51,6 +51,20 @@ import { mergeRedirects } from './lib/redirect-config.mjs';
 const DEFAULT_LIMIT = 30;
 
 /**
+ * Fallback centroid radius (metres) sent to `/v1/applications/near` for BOTH
+ * the primary town point and every sibling centroid (tc-s0yf, GH #819),
+ * mirroring the Go server's own default (`api-go/internal/applications/near.go`).
+ * The committed town gazetteer (`web/src/data/towns.json`) has no per-town
+ * radius field yet, so every town — primary and sibling alike — uses this one
+ * value; the server's own clamp (max 10000m) never engages while every radius
+ * sent equals its own default. Once the gazetteer grows a per-town radius,
+ * this constant is replaced by that data.
+ *
+ * @type {number}
+ */
+const DEFAULT_NEAR_RADIUS_METERS = 5000;
+
+/**
  * Current on-disk schema version of `seo-snapshot.json`. Bump when the snapshot
  * shape changes incompatibly so a stale snapshot can be detected/rejected.
  * @type {number}
@@ -299,6 +313,65 @@ export async function loadTownsFromFile(filePath, readFileImpl) {
 }
 
 /**
+ * Group the FULL committed gazetteer by authorityId, once per build — every
+ * town in an authority is a Voronoi sibling candidate for every OTHER town in
+ * that same authority (tc-s0yf, GH #819), regardless of whether it
+ * individually clears the population/coverage gates. Grouped from the
+ * unfiltered town list (not `eligibleTowns`) so a below-threshold town still
+ * contributes its centroid to a neighbour's partition.
+ *
+ * @param {ReadonlyArray<Town>} towns
+ * @returns {Map<number, Town[]>}
+ */
+function groupTownsByAuthority(towns) {
+  /** @type {Map<number, Town[]>} */
+  const map = new Map();
+  for (const town of towns) {
+    const group = map.get(town.authorityId);
+    if (group) {
+      group.push(town);
+    } else {
+      map.set(town.authorityId, [town]);
+    }
+  }
+  return map;
+}
+
+/**
+ * Every OTHER gazetteer town sharing `town`'s authorityId — the sibling
+ * centroids passed to `/v1/applications/near` for the town-level Voronoi
+ * partition. Identified by slug (unique within an authority — it forms half
+ * of each town's page path) rather than object identity, so it works
+ * regardless of how `gazetteerByAuthority` was built.
+ *
+ * @param {Town} town
+ * @param {Map<number, Town[]>} gazetteerByAuthority
+ * @returns {Town[]}
+ */
+function siblingTownsOf(town, gazetteerByAuthority) {
+  const group = gazetteerByAuthority.get(town.authorityId) ?? [];
+  return group.filter((t) => t.slug !== town.slug);
+}
+
+/**
+ * Serialize each sibling town centroid as a repeated `sibling=lat,lng,radius`
+ * query-string suffix for `/v1/applications/near` (tc-s0yf, GH #819) — one per
+ * OTHER gazetteer town sharing the primary town's authority. Every sibling
+ * uses {@link DEFAULT_NEAR_RADIUS_METERS} for its radius component (no
+ * per-town radius data exists yet — see the {@link Town} typedef). Returns
+ * `''` (no params at all) when `siblings` is empty, e.g. a town that is the
+ * only gazetteer entry in its authority.
+ *
+ * @param {ReadonlyArray<Town>} siblings
+ * @returns {string}
+ */
+function siblingQueryParams(siblings) {
+  return siblings
+    .map((s) => `&sibling=${s.lat},${s.lng},${DEFAULT_NEAR_RADIUS_METERS}`)
+    .join('');
+}
+
+/**
  * Fetch the bounded recent-applications projection for one authority via the
  * build-key-gated endpoint. Throws on any non-OK status or unexpected shape.
  *
@@ -459,24 +532,34 @@ async function considerAuthority(args) {
 /**
  * Fetch the bounded recent-applications-near-a-point projection for one town via
  * the build-key-gated geo endpoint. Scopes the spatial query to the town's
- * authority partition (authorityId) and centroid (lat/lng); the server defaults
- * and clamps the radius. Throws on any non-OK status or unexpected shape.
+ * authority partition (authorityId) and centroid (lat/lng), passing every OTHER
+ * same-authority gazetteer town as a `sibling` centroid so the server can run
+ * its town-level Voronoi partition (tc-s0yf, GH #819) and return ONLY the
+ * applications assigned to THIS town — already ordered by
+ * `GREATEST(decidedDate, startDate) DESC`. No client-side re-sort or
+ * re-partition is needed (`order=distance` is gone). Throws on any non-OK
+ * status or unexpected shape.
  *
  * @param {string} apiBase
  * @param {Town} town
+ * @param {ReadonlyArray<Town>} siblings   every OTHER gazetteer town sharing `town.authorityId`
  * @param {string} buildKey
  * @param {number} limit
  * @param {typeof globalThis.fetch} fetchImpl
  * @returns {Promise<{ applications: object[], total: number, statusBreakdown: object[] }>}
  */
-async function fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl) {
-  // `order=distance` (tc-2avw.1) makes the server return the nearest-N in the
-  // radius by ST_DISTANCE, so adjacent town pages in a conurbation overlap less.
-  // The returned set is left in the API's order here; recency-display re-sorting
-  // is the renderer's job.
+async function fetchRecentNearby(
+  apiBase,
+  town,
+  siblings,
+  buildKey,
+  limit,
+  fetchImpl,
+) {
   const url =
     `${apiBase}/v1/applications/near?authorityId=${town.authorityId}` +
-    `&lat=${town.lat}&lng=${town.lng}&limit=${limit}&order=distance`;
+    `&lat=${town.lat}&lng=${town.lng}&radius=${DEFAULT_NEAR_RADIUS_METERS}` +
+    `&limit=${limit}${siblingQueryParams(siblings)}`;
   const res = await fetchImpl(url, { headers: { 'X-Build-Key': buildKey } });
   if (!res.ok) {
     throw new Error(
@@ -886,6 +969,11 @@ async function runLiveMode(args) {
   // centroid. Reuses the same authority list (no extra HTTP) to resolve slugs.
   const towns = await loadTowns();
 
+  // Grouped from the FULL, unfiltered gazetteer (tc-s0yf) — every town in an
+  // authority is a Voronoi sibling candidate for every other town in that
+  // authority, regardless of the population gate applied below.
+  const gazetteerByAuthority = groupTownsByAuthority(towns);
+
   // Population threshold gate, applied BEFORE the per-town geo fetch so that
   // below-threshold towns never even hit the API. The threshold is a build-time
   // config value (SEO_TOWN_MIN_POPULATION, default 20000); ramping coverage means
@@ -914,7 +1002,14 @@ async function runLiveMode(args) {
     towns: eligibleTowns,
     authorities,
     getGeo: (town) =>
-      fetchRecentNearby(apiBase, town, buildKey, limit, fetchImpl),
+      fetchRecentNearby(
+        apiBase,
+        town,
+        siblingTownsOf(town, gazetteerByAuthority),
+        buildKey,
+        limit,
+        fetchImpl,
+      ),
     limit,
     logger,
   });
@@ -1050,6 +1145,11 @@ async function gatherSnapshot(args) {
 
   const towns = await loadTowns();
 
+  // Grouped from the FULL, unfiltered gazetteer (tc-s0yf) — every town in an
+  // authority is a Voronoi sibling candidate for every other town in that
+  // authority, regardless of the population gate applied below.
+  const gazetteerByAuthority = groupTownsByAuthority(towns);
+
   /** @type {SeoSnapshot['townPages']} */
   const townPages = [];
   for (const town of towns) {
@@ -1061,6 +1161,7 @@ async function gatherSnapshot(args) {
     const geo = await fetchRecentNearby(
       apiBase,
       town,
+      siblingTownsOf(town, gazetteerByAuthority),
       buildKey,
       limit,
       fetchImpl,


### PR DESCRIPTION
## Changes

Fixes #819 — SEO planning pages were ordered by PlanIt's `last_different`, a re-index marker (not a real-world date), so stale re-indexed applications floated to the top of authority/town pages (e.g. Croydon led with a 2021 `DISC` app).

**Go (api-go/internal/applications) — tc-s0yf.1:**
- Authority reads now `ORDER BY GREATEST(decided_date, start_date) DESC NULLS LAST` with a deterministic tie-break, instead of `last_different DESC`.
- New `RecentNearestTown` query-time nearest-town Voronoi partition for town pages: takes the target town's point/radius plus repeated sibling centroids (other same-authority gazetteer towns, each with its own radius), assigns each application to whichever covering centroid is nearest (closest-wins, in-range-nearest rule so a farther-but-in-range town can claim what a nearer-but-out-of-range town can't reach), returns only this town's assigned set, already ordered by the same real-date key. Replaces the old `order=distance`-then-client-resort path.
- `near.go` handler updated for the new `sibling=lat,lng,radius` (repeatable) param; `order` param removed.
- Added `DecidedDate` to the slim `RecentApplication` DTO.
- New migration `0017_application_real_date_sort_index.sql` backing the new sort key.
- Unit + real-DB (`pgtest`, `-tags=integration`) coverage: ordering, NULLS LAST, tie-break, closest-wins predicate, in-range-nearest rule, no-overlap between sibling towns, empty/near-empty partitions, `decidedDate` on the wire.

**Web (web/scripts) — tc-s0yf.2:**
- `fetchRecentNearby` now passes sibling town centroids (grouped from the full gazetteer) and an explicit default radius; `order=distance` dropped.
- Deleted the client-side `sortByRecencyDesc` re-sort for town pages — the API now returns pre-ordered results, same as authority pages.
- Cards (`render-shared.mjs`) now show a Started/Decided date line ("Decided 9 Jul 2021" or "Started 4 Jul 2026 · Awaiting decision").
- Vitest coverage: sibling param serialization, no-resort behavior, card date rendering incl. missing `decidedDate`.

Authority pages are NOT partitioned (whole-authority, just the new sort). `RecentInAuthorities` (dev-seed) intentionally untouched — still keys off `last_different`, different purpose.

All gates green: `go build/vet/test -race`, `golangci-lint`, `go test -tags=integration` (real Postgres+PostGIS), `npx tsc --noEmit`, `npm run lint`, `npx vitest run` (1021 passed).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nearby application results now reflect town-based grouping, including support for related nearby towns and a consistent default search radius.
  * Application cards now show clearer date information, including decided dates when available.

* **Bug Fixes**
  * Improved result ordering so lists are more consistent and match the most relevant application dates.
  * Updated rendering so town pages preserve the API’s returned order and avoid re-sorting issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->