### PR TITLE
feat: /planning/ authority hub page (A-Z index, sitemap)

### DIFF
--- a/web/scripts/lib/__tests__/prerender-hub.test.mjs
+++ b/web/scripts/lib/__tests__/prerender-hub.test.mjs
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, writeFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runPrerender, runRender } from '../../prerender-planning.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const AUTHORITIES_FIXTURE = join(here, '..', '..', 'fixtures', 'sample-authorities.json');
+
+/**
+ * Coverage for the `/planning/` authority hub page (tc-geq7h.1, GH #821 Phase
+ * 1): rendered by the SAME `renderEntries` pipeline every mode shares, from
+ * data ALREADY present in the snapshot/fixture — zero new API calls, zero new
+ * fetch surface. Exercised primarily through `runRender` (the offline
+ * `--render` mode this bead targets), plus one fixture-mode check proving the
+ * hub is wired into every entry point, not bolted onto one.
+ */
+
+const silentLogger = { log() {}, warn() {}, error() {} };
+
+let outDir;
+
+beforeEach(async () => {
+  outDir = await mkdtemp(join(tmpdir(), 'prerender-hub-'));
+});
+
+afterEach(async () => {
+  await rm(outDir, { recursive: true, force: true });
+});
+
+async function exists(path) {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** @param {string} uid @param {string} lastDifferent */
+function app(uid, lastDifferent) {
+  return {
+    uid,
+    name: uid,
+    address: `${uid} address`,
+    description: 'desc',
+    appState: 'Permitted',
+    startDate: '2026-01-10',
+    lastDifferent,
+    link: null,
+    url: null,
+  };
+}
+
+/**
+ * A snapshot with two qualifying authorities (Adur, Basingstoke and Deane) —
+ * deliberately serialised in REVERSE alphabetical order, so an index.html that
+ * lists them A-Z proves the prerender sorts before handing entries to the
+ * renderer — and one published town under Adur only.
+ *
+ * @param {string} path
+ */
+async function writeReverseOrderSnapshot(path) {
+  await writeFile(
+    path,
+    JSON.stringify({
+      version: 1,
+      generatedAt: '2026-06-25T00:00:00.000Z',
+      minPopulation: 20000,
+      limit: 30,
+      authorities: [
+        { id: 2, name: 'Basingstoke and Deane' },
+        { id: 1, name: 'Adur' },
+      ],
+      authorityPages: [
+        {
+          id: 2,
+          name: 'Basingstoke and Deane',
+          areaType: 'English District',
+          areaName: 'Basingstoke and Deane',
+          total: 42,
+          statusBreakdown: [{ appState: 'Permitted', count: 42 }],
+          applications: [app('BD1', '2026-06-15T10:00:00+00:00')],
+        },
+        {
+          id: 1,
+          name: 'Adur',
+          areaType: 'English District',
+          areaName: 'Adur',
+          total: 12,
+          statusBreakdown: [{ appState: 'Permitted', count: 12 }],
+          applications: [app('A1', '2026-06-10T10:00:00+00:00')],
+        },
+      ],
+      townPages: [
+        {
+          slug: 'lancing',
+          name: 'Lancing',
+          lat: 50.83,
+          lng: -0.32,
+          authorityId: 1,
+          population: 30000,
+          total: 14,
+          statusBreakdown: [{ appState: 'Permitted', count: 14 }],
+          // Freshest lastDifferent of the whole snapshot — the hub's own
+          // sitemap lastmod must pick this up as the max across ALL children.
+          applications: [app('L1', '2026-06-25T10:00:00+00:00')],
+        },
+      ],
+    }),
+    'utf-8',
+  );
+}
+
+describe('runRender — /planning/ hub page (tc-geq7h.1)', () => {
+  it('writes a real dist/planning/index.html, distinct from any authority-slug page', async () => {
+    const snapshotPath = join(outDir, 'seo-snapshot.json');
+    await writeReverseOrderSnapshot(snapshotPath);
+
+    await runRender({ outDir, snapshotPath, logger: silentLogger });
+
+    expect(await exists(join(outDir, 'planning', 'index.html'))).toBe(true);
+    // Distinct from an authority page — no slug directory is literally "index".
+    expect(await exists(join(outDir, 'planning', 'index'))).toBe(false);
+  });
+
+  it('lists every published authority A-Z regardless of snapshot order, each with its application and town counts', async () => {
+    const snapshotPath = join(outDir, 'seo-snapshot.json');
+    await writeReverseOrderSnapshot(snapshotPath);
+
+    await runRender({ outDir, snapshotPath, logger: silentLogger });
+
+    const html = await readFile(join(outDir, 'planning', 'index.html'), 'utf-8');
+    expect(html).toContain('<h1>Planning applications by council</h1>');
+    expect(html).toContain('<a class="hubList__link" href="/planning/adur">Adur</a>');
+    expect(html).toContain(
+      '<a class="hubList__link" href="/planning/basingstoke-and-deane">Basingstoke and Deane</a>',
+    );
+    // Adur's one published town (Lancing) is counted; Basingstoke has none.
+    expect(html).toContain('12 applications tracked · 1 town');
+    expect(html).toContain('42 applications tracked</span>');
+    expect(html).not.toContain('42 applications tracked · 0 towns');
+    // A-Z order, even though the snapshot serialised Basingstoke first.
+    expect(html.indexOf('>Adur<')).toBeLessThan(
+      html.indexOf('>Basingstoke and Deane<'),
+    );
+  });
+
+  it('adds a sitemap entry for the bare /planning root, lastmod = the max across every child page', async () => {
+    const snapshotPath = join(outDir, 'seo-snapshot.json');
+    await writeReverseOrderSnapshot(snapshotPath);
+
+    await runRender({ outDir, snapshotPath, logger: silentLogger });
+
+    const sitemap = await readFile(join(outDir, 'sitemap.xml'), 'utf-8');
+    expect(sitemap).toContain('<loc>https://towncrierapp.uk/planning</loc>');
+    expect(sitemap).not.toContain('<loc>https://towncrierapp.uk/planning/</loc>');
+    // Lancing's 25 Jun app is the freshest of the three (15/10/25 Jun) — the
+    // hub's lastmod must reflect it, not just the authority pages' own dates.
+    expect(sitemap).toContain('<lastmod>2026-06-25</lastmod>');
+  });
+
+  it('never issues any network call while rendering the hub from the snapshot', async () => {
+    const snapshotPath = join(outDir, 'seo-snapshot.json');
+    await writeReverseOrderSnapshot(snapshotPath);
+
+    const calls = [];
+    const original = globalThis.fetch;
+    globalThis.fetch = (...args) => {
+      calls.push(args);
+      throw new Error('render mode must not perform any network I/O');
+    };
+    try {
+      await runRender({ outDir, snapshotPath, logger: silentLogger });
+    } finally {
+      globalThis.fetch = original;
+    }
+    expect(calls).toHaveLength(0);
+    expect(await exists(join(outDir, 'planning', 'index.html'))).toBe(true);
+  });
+});
+
+describe('runPrerender — fixture mode also emits the hub page', () => {
+  it('writes dist/planning/index.html from a fixture, same as --render', async () => {
+    await runPrerender({
+      outDir,
+      fixturePath: AUTHORITIES_FIXTURE,
+      logger: silentLogger,
+    });
+
+    expect(await exists(join(outDir, 'planning', 'index.html'))).toBe(true);
+    const html = await readFile(join(outDir, 'planning', 'index.html'), 'utf-8');
+    expect(html).toContain(
+      '<a class="hubList__link" href="/planning/basingstoke-and-deane">Basingstoke and Deane</a>',
+    );
+  });
+});

--- a/web/scripts/lib/__tests__/render-planning-index.test.mjs
+++ b/web/scripts/lib/__tests__/render-planning-index.test.mjs
@@ -39,6 +39,26 @@ describe('renderPlanningIndexPage', () => {
     expect(html).toContain('<h1>Planning applications by council</h1>');
   });
 
+  it('uses plural "authorities" wording in the lead and meta description for more than one authority', () => {
+    const html = renderPlanningIndexPage(indexData());
+    expect(html).toContain(
+      '<p class="lead">Browse recent planning applications for 3 local planning authorities across the UK.</p>',
+    );
+    expect(html).toContain('for 3 local planning authorities across the UK');
+  });
+
+  it('uses singular "authority" wording when there is exactly one', () => {
+    const html = renderPlanningIndexPage(
+      indexData({
+        authorities: [{ name: 'Adur', slug: 'adur', applicationCount: 42, townCount: 0 }],
+      }),
+    );
+    expect(html).toContain(
+      '<p class="lead">Browse recent planning applications for 1 local planning authority across the UK.</p>',
+    );
+    expect(html).not.toContain('1 local planning authorities');
+  });
+
   it('includes a canonical link to /planning with no trailing slug or slash', () => {
     const html = renderPlanningIndexPage(indexData());
     expect(html).toContain(`<link rel="canonical" href="${SITE_ORIGIN}/planning" />`);

--- a/web/scripts/lib/__tests__/render-planning-index.test.mjs
+++ b/web/scripts/lib/__tests__/render-planning-index.test.mjs
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest';
+import { renderPlanningIndexPage } from '../render-planning-index.mjs';
+import {
+  APP_DOWNLOAD_URL,
+  APPLE_APP_ID,
+  SITE_ORIGIN,
+  appStoreUrl,
+} from '../constants.mjs';
+
+/**
+ * @param {Partial<import('../render-planning-index.mjs').PlanningIndexData>} [overrides]
+ * @returns {import('../render-planning-index.mjs').PlanningIndexData}
+ */
+function indexData(overrides = {}) {
+  return {
+    authorities: [
+      { name: 'Adur', slug: 'adur', applicationCount: 42, townCount: 2 },
+      { name: 'Aberdeen', slug: 'aberdeen', applicationCount: 12, townCount: 0 },
+      {
+        name: 'Basingstoke and Deane',
+        slug: 'basingstoke-and-deane',
+        applicationCount: 1,
+        townCount: 1,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('renderPlanningIndexPage', () => {
+  it('is a complete HTML document with the lang attribute', () => {
+    const html = renderPlanningIndexPage(indexData());
+    expect(html.startsWith('<!doctype html>')).toBe(true);
+    expect(html).toContain('<html lang="en">');
+  });
+
+  it('renders the hub H1', () => {
+    const html = renderPlanningIndexPage(indexData());
+    expect(html).toContain('<h1>Planning applications by council</h1>');
+  });
+
+  it('includes a canonical link to /planning with no trailing slug or slash', () => {
+    const html = renderPlanningIndexPage(indexData());
+    expect(html).toContain(`<link rel="canonical" href="${SITE_ORIGIN}/planning" />`);
+  });
+
+  it('includes Open Graph tags pointing at the canonical url', () => {
+    const html = renderPlanningIndexPage(indexData());
+    expect(html).toContain('property="og:title"');
+    expect(html).toContain('property="og:type"');
+    expect(html).toContain(`property="og:url" content="${SITE_ORIGIN}/planning"`);
+  });
+
+  it('embeds an ItemList JSON-LD with one entry per authority, in order', () => {
+    const html = renderPlanningIndexPage(indexData());
+    const ld = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+    expect(ld).not.toBeNull();
+    const [, json] = ld;
+    const parsed = JSON.parse(json);
+    const itemList = parsed.find((entry) => entry['@type'] === 'ItemList');
+    expect(itemList).toBeDefined();
+    expect(itemList.numberOfItems).toBe(3);
+    expect(itemList.itemListElement).toEqual([
+      { '@type': 'ListItem', position: 1, name: 'Adur', url: `${SITE_ORIGIN}/planning/adur` },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Aberdeen',
+        url: `${SITE_ORIGIN}/planning/aberdeen`,
+      },
+      {
+        '@type': 'ListItem',
+        position: 3,
+        name: 'Basingstoke and Deane',
+        url: `${SITE_ORIGIN}/planning/basingstoke-and-deane`,
+      },
+    ]);
+  });
+
+  it('embeds a two-item BreadcrumbList: Home, then this page (no self-link)', () => {
+    const html = renderPlanningIndexPage(indexData());
+    const nav = html.match(/<nav class="breadcrumb" aria-label="Breadcrumb">[\s\S]*?<\/nav>/);
+    expect(nav).not.toBeNull();
+    const [navHtml] = nav;
+    const liCount = (navHtml.match(/<li/g) ?? []).length;
+    expect(liCount).toBe(2);
+    expect(navHtml).toContain('<li><a href="/">Town Crier</a></li>');
+    expect(navHtml).toContain('<li>Planning applications</li>');
+    expect(navHtml).not.toContain('<a href="/planning"');
+
+    const ld = html.match(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/);
+    const parsed = JSON.parse(ld[1]);
+    const breadcrumb = parsed.find((entry) => entry['@type'] === 'BreadcrumbList');
+    expect(breadcrumb.itemListElement).toEqual([
+      { '@type': 'ListItem', position: 1, name: 'Town Crier', item: `${SITE_ORIGIN}/` },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Planning applications',
+        item: `${SITE_ORIGIN}/planning`,
+      },
+    ]);
+  });
+
+  describe('A-Z grouping', () => {
+    it('groups authorities under their first-letter heading', () => {
+      const html = renderPlanningIndexPage(indexData());
+      expect(html).toContain('<section class="hubGroup" id="letter-A"');
+      expect(html).toContain('<h2 id="letter-A-heading">A</h2>');
+      expect(html).toContain('<section class="hubGroup" id="letter-B"');
+      expect(html).toContain('<h2 id="letter-B-heading">B</h2>');
+    });
+
+    it('keeps entries within the same letter group in the order supplied (sorting happens upstream)', () => {
+      const html = renderPlanningIndexPage(indexData());
+      const groupA = html.match(
+        /<section class="hubGroup" id="letter-A"[\s\S]*?<\/section>/,
+      )[0];
+      // Adur before Aberdeen — exactly the input order, proving this module does
+      // not itself re-sort (the caller sorts before handing entries in).
+      expect(groupA.indexOf('>Adur<')).toBeLessThan(groupA.indexOf('>Aberdeen<'));
+    });
+
+    it('only emits a letter heading/jump-link for letters that actually have entries', () => {
+      const html = renderPlanningIndexPage(indexData());
+      expect(html).not.toContain('id="letter-C"');
+      expect(html).not.toContain('href="#letter-C"');
+      expect(html).toContain('href="#letter-A"');
+      expect(html).toContain('href="#letter-B"');
+    });
+
+    it('renders zero letter sections and no crash for an empty authority list', () => {
+      const html = renderPlanningIndexPage(indexData({ authorities: [] }));
+      expect(html).not.toContain('<section class="hubGroup"');
+      expect(html.startsWith('<!doctype html>')).toBe(true);
+    });
+  });
+
+  describe('authority entries', () => {
+    it('links each entry to its /planning/<slug> page', () => {
+      const html = renderPlanningIndexPage(indexData());
+      expect(html).toContain('<a class="hubList__link" href="/planning/adur">Adur</a>');
+      expect(html).toContain(
+        '<a class="hubList__link" href="/planning/basingstoke-and-deane">Basingstoke and Deane</a>',
+      );
+    });
+
+    it('shows the application count and town count', () => {
+      const html = renderPlanningIndexPage(indexData());
+      expect(html).toContain('42 applications tracked · 2 towns');
+    });
+
+    it('uses singular "application"/"town" wording for a count of exactly 1', () => {
+      const html = renderPlanningIndexPage(indexData());
+      expect(html).toContain('1 application tracked · 1 town');
+    });
+
+    it('omits the town count entirely when an authority has zero published towns', () => {
+      const html = renderPlanningIndexPage(indexData());
+      expect(html).toContain('12 applications tracked</span>');
+      expect(html).not.toContain('12 applications tracked · 0 towns');
+    });
+
+    it('HTML-escapes authority names', () => {
+      const html = renderPlanningIndexPage(
+        indexData({
+          authorities: [
+            {
+              name: 'Stoke & <b>Bramley</b>',
+              slug: 'stoke-bramley',
+              applicationCount: 5,
+              townCount: 0,
+            },
+          ],
+        }),
+      );
+      expect(html).not.toContain('<b>Bramley</b>');
+      expect(html).toContain('Stoke &amp; &lt;b&gt;Bramley&lt;/b&gt;');
+    });
+  });
+
+  it('tags every download CTA with the ct=seo-hub campaign token', () => {
+    const html = renderPlanningIndexPage(indexData());
+    const tagged = appStoreUrl('seo-hub');
+    const occurrences = html.split(`href="${tagged}"`).length - 1;
+    expect(occurrences).toBe(3);
+    expect(html).toContain('ct=seo-hub');
+    expect(html).not.toContain(`href="${APP_DOWNLOAD_URL}"`);
+  });
+
+  it('emits the Apple Smart App Banner meta tag in <head>', () => {
+    const html = renderPlanningIndexPage(indexData());
+    const head = html.match(/<head>[\s\S]*?<\/head>/);
+    expect(head).not.toBeNull();
+    expect(head[0]).toContain(
+      `<meta name="apple-itunes-app" content="app-id=${APPLE_APP_ID}" />`,
+    );
+  });
+
+  it('carries the mandatory PlanIt + OGL + OS + OSM attribution', () => {
+    const html = renderPlanningIndexPage(indexData());
+    expect(html).toContain('PlanIt');
+    expect(html).toContain('Open Government Licence');
+    expect(html).toContain('Ordnance Survey');
+    expect(html).toContain('OpenStreetMap');
+  });
+});

--- a/web/scripts/lib/__tests__/render-sitemap.test.mjs
+++ b/web/scripts/lib/__tests__/render-sitemap.test.mjs
@@ -65,6 +65,23 @@ describe('renderSitemap', () => {
     expect(xml).toContain('<urlset');
     expect((xml.match(/<url>/g) ?? []).length).toBe(0);
   });
+
+  // tc-geq7h.1 (GH #821 Phase 1): the /planning/ hub itself is a sitemap entry
+  // with an empty path — its canonical is exactly /planning, with no trailing
+  // slash, matching the <link rel="canonical"> the hub page renders.
+  it('renders an empty path as the bare /planning root, with no trailing slash', () => {
+    const xml = renderSitemap([{ path: '' }]);
+    expect(xml).toContain(`<loc>${SITE_ORIGIN}/planning</loc>`);
+    expect(xml).not.toContain(`<loc>${SITE_ORIGIN}/planning/</loc>`);
+  });
+
+  it('supports a lastmod on the root /planning entry same as any other', () => {
+    const xml = renderSitemap([
+      { path: '', lastmod: '2026-06-20T10:00:00+00:00' },
+    ]);
+    expect(xml).toContain(`<loc>${SITE_ORIGIN}/planning</loc>`);
+    expect(xml).toContain('<lastmod>2026-06-20</lastmod>');
+  });
 });
 
 describe('sitemapLastmod', () => {

--- a/web/scripts/lib/render-planning-index.mjs
+++ b/web/scripts/lib/render-planning-index.mjs
@@ -1,0 +1,259 @@
+/**
+ * Static renderer for the `/planning/` authority hub page — a single A-Z index
+ * of every published authority page (tc-geq7h.1, GH #821 Phase 1). Same
+ * hydration-free template family as the authority (`render-page.mjs`) and town
+ * (`render-town-page.mjs`) pages, reusing the shared inline-CTA/attribution/
+ * stylesheet building blocks from `render-shared.mjs`.
+ *
+ * Rendered by `prerender-planning.mjs --render` from the existing
+ * `seo-snapshot.json` — this page adds ZERO new API calls. Every authority it
+ * lists already published its own page in the SAME render pass (the caller
+ * only ever hands in published entries), so a hub link can never point at a
+ * 404. Grouped strictly A-Z, never by region: authorities carry no
+ * region/nation data anywhere in the snapshot or `internal/authorities`, and
+ * sourcing one is explicitly out of scope (GH #821).
+ */
+
+import { SITE_ORIGIN, APPLE_APP_ID, appStoreUrl } from './constants.mjs';
+import { escapeHtml } from './format.mjs';
+import { pageStyles, renderInlineCta, renderAttributionList } from './render-shared.mjs';
+
+/**
+ * @typedef {Object} PlanningIndexEntry
+ * @property {string} name             authority display name
+ * @property {string} slug             URL slug, e.g. "basingstoke-and-deane"
+ * @property {number} applicationCount recent-application total — the same
+ *   bounded count shown on the authority's own page
+ * @property {number} townCount        published town-page count under this
+ *   authority (0 when it has none)
+ */
+
+/**
+ * @typedef {Object} PlanningIndexData
+ * @property {PlanningIndexEntry[]} authorities  every PUBLISHED authority, in
+ *   the exact order to render. The caller sorts alphabetically upstream (this
+ *   module groups by first letter but does not itself re-sort) — mirroring how
+ *   `render-page.mjs`'s town-links section renders whatever order it's given.
+ */
+
+/** App Store Connect campaign token for every CTA on this page. */
+const CAMPAIGN = 'seo-hub';
+
+/**
+ * Group already-sorted authority entries into per-letter buckets, keyed by the
+ * uppercased first character of the display name. Preserves input order
+ * within each bucket, and returns buckets in first-seen order — since the
+ * caller supplies an alphabetically-sorted array, first-seen order IS A-Z
+ * order. A letter with zero entries never produces a bucket at all.
+ *
+ * @param {ReadonlyArray<PlanningIndexEntry>} authorities
+ * @returns {Array<{ letter: string, entries: PlanningIndexEntry[] }>}
+ */
+function groupByLetter(authorities) {
+  /** @type {Map<string, PlanningIndexEntry[]>} */
+  const groups = new Map();
+  for (const authority of authorities) {
+    const trimmed = authority.name.trim();
+    const letter = (trimmed.length > 0 ? trimmed[0] : '#').toUpperCase();
+    const bucket = groups.get(letter);
+    if (bucket) {
+      bucket.push(authority);
+    } else {
+      groups.set(letter, [authority]);
+    }
+  }
+  return [...groups.entries()].map(([letter, entries]) => ({ letter, entries }));
+}
+
+/**
+ * Build the "N applications tracked [· N towns]" metadata line for one
+ * authority. The town-count clause is entirely omitted when the authority has
+ * zero published town pages, rather than reading as "0 towns".
+ *
+ * @param {PlanningIndexEntry} authority
+ * @returns {string} plain text (caller HTML-escapes)
+ */
+function metaLine(authority) {
+  const applicationsWord = authority.applicationCount === 1 ? 'application' : 'applications';
+  const parts = [`${authority.applicationCount} ${applicationsWord} tracked`];
+  if (authority.townCount > 0) {
+    const townsWord = authority.townCount === 1 ? 'town' : 'towns';
+    parts.push(`${authority.townCount} ${townsWord}`);
+  }
+  return parts.join(' · ');
+}
+
+/**
+ * @param {PlanningIndexEntry} authority
+ * @returns {string}
+ */
+function renderAuthorityEntry(authority) {
+  const name = escapeHtml(authority.name);
+  const meta = escapeHtml(metaLine(authority));
+  return `            <li class="hubList__item">
+              <a class="hubList__link" href="/planning/${authority.slug}">${name}</a>
+              <span class="hubList__meta">${meta}</span>
+            </li>`;
+}
+
+/**
+ * @param {ReadonlyArray<{ letter: string, entries: PlanningIndexEntry[] }>} groups
+ * @returns {string} '' when there are no groups at all
+ */
+function renderLetterNav(groups) {
+  if (groups.length === 0) {
+    return '';
+  }
+  const links = groups
+    .map(({ letter }) => `<a href="#letter-${letter}">${letter}</a>`)
+    .join('\n          ');
+  return `
+        <nav class="azNav" aria-label="Jump to letter">
+          ${links}
+        </nav>`;
+}
+
+/**
+ * @param {ReadonlyArray<{ letter: string, entries: PlanningIndexEntry[] }>} groups
+ * @returns {string}
+ */
+function renderLetterSections(groups) {
+  return groups
+    .map(({ letter, entries }) => {
+      const items = entries.map(renderAuthorityEntry).join('\n');
+      return `        <section class="hubGroup" id="letter-${letter}" aria-labelledby="letter-${letter}-heading">
+          <h2 id="letter-${letter}-heading">${letter}</h2>
+          <ul class="hubList">
+${items}
+          </ul>
+        </section>`;
+    })
+    .join('\n');
+}
+
+/**
+ * @param {PlanningIndexData} data
+ * @param {string} canonical
+ * @returns {string} JSON-LD, safe to embed inside a <script> element
+ */
+function buildJsonLd(data, canonical) {
+  const itemList = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'UK local planning authorities',
+    url: canonical,
+    numberOfItems: data.authorities.length,
+    itemListElement: data.authorities.map((authority, i) => ({
+      '@type': 'ListItem',
+      position: i + 1,
+      name: authority.name,
+      url: `${SITE_ORIGIN}/planning/${authority.slug}`,
+    })),
+  };
+  // The hub has no parent above it (it IS the top of the /planning tree), so
+  // this trail is two levels: Home -> this page — matching the authority
+  // page's own two-level Home -> Authority trail.
+  const breadcrumb = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Town Crier', item: `${SITE_ORIGIN}/` },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Planning applications',
+        item: canonical,
+      },
+    ],
+  };
+  // Escape "<" so a malicious data value can never close the <script> element.
+  return JSON.stringify([itemList, breadcrumb]).replace(/</g, '\\u003c');
+}
+
+/**
+ * Render the complete, hydration-free static HTML `/planning/` hub page: an
+ * A-Z index of every published authority page.
+ *
+ * @param {PlanningIndexData} data
+ * @returns {string}
+ */
+export function renderPlanningIndexPage(data) {
+  const canonical = `${SITE_ORIGIN}/planning`;
+  const count = data.authorities.length;
+  const title = 'Planning applications by council | Town Crier';
+  const metaDescription = escapeHtml(
+    `Browse recent planning applications for ${count} local planning authorities across the UK. Find your council and get push alerts the moment a new application is submitted or decided.`,
+  );
+  const jsonLd = buildJsonLd(data, canonical);
+  const year = new Date().getFullYear();
+  const groups = groupByLetter(data.authorities);
+  const letterNav = renderLetterNav(groups);
+  const letterSections = renderLetterSections(groups);
+  const attribution = renderAttributionList();
+  const storeHref = appStoreUrl(CAMPAIGN);
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="apple-itunes-app" content="app-id=${APPLE_APP_ID}" />
+    <title>${title}</title>
+    <meta name="description" content="${metaDescription}" />
+    <meta name="robots" content="index,follow" />
+    <link rel="canonical" href="${canonical}" />
+    <link rel="icon" type="image/x-icon" href="/favicon.ico" />
+    <meta property="og:title" content="Planning applications by council" />
+    <meta property="og:description" content="${metaDescription}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="${canonical}" />
+    <meta property="og:site_name" content="Town Crier" />
+    <script type="application/ld+json">${jsonLd}</script>
+    <style>
+${pageStyles()}
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <header class="siteHeader">
+        <a href="/">Town Crier</a>
+        <nav class="siteHeader__nav">
+          <a href="/">Home</a>
+          <a class="siteHeader__cta" href="${storeHref}" rel="noopener" target="_blank">Get the app</a>
+        </nav>
+      </header>
+      <nav class="breadcrumb" aria-label="Breadcrumb">
+        <ol>
+          <li><a href="/">Town Crier</a></li>
+          <li>Planning applications</li>
+        </ol>
+      </nav>
+      <main>
+        <h1>Planning applications by council</h1>
+        <p class="lead">Browse recent planning applications for ${count} local planning authorities across the UK.</p>
+${renderInlineCta('your council', storeHref)}
+${letterNav}
+${letterSections}
+
+        <section class="cta">
+          <h2>Get push alerts for your area</h2>
+          <p>
+            Draw a circle on the map and Town Crier will notify you the moment a new
+            planning application is submitted or decided inside it.
+          </p>
+          <a class="cta__button" href="${storeHref}" rel="noopener" target="_blank">Download on the App Store</a>
+        </section>
+      </main>
+
+      <footer class="siteFooter">
+        <ul class="attribution">
+${attribution}
+        </ul>
+        <p>© ${year} Town Crier · Ivo and the Bea Ltd</p>
+        <p><a href="/legal/privacy">Privacy Policy</a> · <a href="/legal/terms">Terms of Service</a></p>
+      </footer>
+    </div>
+  </body>
+</html>
+`;
+}

--- a/web/scripts/lib/render-planning-index.mjs
+++ b/web/scripts/lib/render-planning-index.mjs
@@ -180,9 +180,10 @@ function buildJsonLd(data, canonical) {
 export function renderPlanningIndexPage(data) {
   const canonical = `${SITE_ORIGIN}/planning`;
   const count = data.authorities.length;
+  const authoritiesNoun = count === 1 ? 'local planning authority' : 'local planning authorities';
   const title = 'Planning applications by council | Town Crier';
   const metaDescription = escapeHtml(
-    `Browse recent planning applications for ${count} local planning authorities across the UK. Find your council and get push alerts the moment a new application is submitted or decided.`,
+    `Browse recent planning applications for ${count} ${authoritiesNoun} across the UK. Find your council and get push alerts the moment a new application is submitted or decided.`,
   );
   const jsonLd = buildJsonLd(data, canonical);
   const year = new Date().getFullYear();
@@ -230,7 +231,7 @@ ${pageStyles()}
       </nav>
       <main>
         <h1>Planning applications by council</h1>
-        <p class="lead">Browse recent planning applications for ${count} local planning authorities across the UK.</p>
+        <p class="lead">Browse recent planning applications for ${count} ${authoritiesNoun} across the UK.</p>
 ${renderInlineCta('your council', storeHref)}
 ${letterNav}
 ${letterSections}

--- a/web/scripts/lib/render-shared.mjs
+++ b/web/scripts/lib/render-shared.mjs
@@ -452,6 +452,26 @@ export function pageStyles() {
       font-weight: 600;
     }
     .townLinks__list a:hover { color: var(--tc-amber-hover); border-color: var(--tc-amber); }
+    /* /planning/ authority hub (tc-geq7h.1): an A-Z jump nav plus one
+       <section> per letter, each holding a flat list of authority links with
+       a small metadata line (application/town counts). */
+    .azNav { display: flex; flex-wrap: wrap; gap: var(--tc-space-sm); margin: 0 0 var(--tc-space-lg); font-weight: 600; }
+    .azNav a { color: var(--tc-amber); text-decoration: none; }
+    .azNav a:hover { color: var(--tc-amber-hover); text-decoration: underline; }
+    .hubGroup { scroll-margin-top: var(--tc-space-md); }
+    .hubList { list-style: none; margin: 0 0 var(--tc-space-lg); padding: 0; display: grid; gap: var(--tc-space-sm); }
+    .hubList__item {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: baseline;
+      justify-content: space-between;
+      gap: var(--tc-space-sm);
+      padding: var(--tc-space-sm) 0;
+      border-bottom: 1px solid var(--tc-border);
+    }
+    .hubList__link { color: var(--tc-text-primary); font-weight: 600; text-decoration: none; }
+    .hubList__link:hover { color: var(--tc-amber); text-decoration: underline; }
+    .hubList__meta { color: var(--tc-text-secondary); font-size: 0.875rem; white-space: nowrap; }
     .explainer p { color: var(--tc-text-secondary); }
     /* Inline alerts CTA pulled above the list (tc-r4n9.3): a lighter pill,
        visually distinct from the rectangular bottom banner button below. */

--- a/web/scripts/lib/render-sitemap.mjs
+++ b/web/scripts/lib/render-sitemap.mjs
@@ -3,13 +3,27 @@ import { SITE_ORIGIN } from './constants.mjs';
 /**
  * @typedef {Object} SitemapEntry
  * @property {string} path        page path under /planning/, e.g. "adur" or
- *                                "cornwall/truro"
+ *                                "cornwall/truro". An EMPTY string is the
+ *                                `/planning/` hub page itself (tc-geq7h.1) —
+ *                                its `<loc>` is the bare `/planning` origin,
+ *                                with no trailing slash, matching the hub
+ *                                page's own `<link rel="canonical">`.
  * @property {string} [lastmod]   the page's content-derived freshness signal —
  *                                the ISO `lastDifferent` of the most-recently
- *                                changed application shown on the page. Reduced
- *                                to a W3C `YYYY-MM-DD` date in the output;
- *                                omitted from the `<url>` when absent/invalid.
+ *                                changed application shown on the page (for
+ *                                the hub page, the max lastmod across every
+ *                                child page). Reduced to a W3C `YYYY-MM-DD`
+ *                                date in the output; omitted from the `<url>`
+ *                                when absent/invalid.
  */
+
+/**
+ * @param {string} path
+ * @returns {string} the absolute canonical URL for a sitemap entry's path
+ */
+function locFor(path) {
+  return path ? `${SITE_ORIGIN}/planning/${path}` : `${SITE_ORIGIN}/planning`;
+}
 
 /**
  * Reduce an ISO `lastDifferent` timestamp to the `YYYY-MM-DD` date the sitemap
@@ -45,7 +59,7 @@ export function sitemapLastmod(iso) {
 export function renderSitemap(entries) {
   const urls = entries
     .map((entry) => {
-      const loc = `    <loc>${SITE_ORIGIN}/planning/${entry.path}</loc>`;
+      const loc = `    <loc>${locFor(entry.path)}</loc>`;
       const lastmod = sitemapLastmod(entry.lastmod);
       const lines = lastmod
         ? `${loc}\n    <lastmod>${lastmod}</lastmod>`

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -1,8 +1,10 @@
 /**
  * Static prerender for the programmatic authority-level SEO pages
- * (`/planning/<slug>`). Runs AFTER `vite build`, emitting fully static,
- * hydration-free HTML into `web/dist/planning/<slug>/index.html` plus a
- * `web/dist/sitemap.xml`.
+ * (`/planning/<slug>`) plus the `/planning/` authority hub page (tc-geq7h.1,
+ * GH #821 Phase 1) — an A-Z index of every published authority, added from the
+ * SAME render pass with ZERO new data. Runs AFTER `vite build`, emitting fully
+ * static, hydration-free HTML into `web/dist/planning/<slug>/index.html` and
+ * `web/dist/planning/index.html`, plus a `web/dist/sitemap.xml`.
  *
  * Default (no-flag) run modes, selected by environment — UNCHANGED, this is what
  * `npm run build` invokes:

--- a/web/scripts/prerender-planning.mjs
+++ b/web/scripts/prerender-planning.mjs
@@ -43,6 +43,7 @@ import { isQualifyingAreaType } from './lib/area-types.mjs';
 import { meetsCoverageGate } from './lib/coverage-gate.mjs';
 import { renderPlanningPage } from './lib/render-page.mjs';
 import { renderTownPage } from './lib/render-town-page.mjs';
+import { renderPlanningIndexPage } from './lib/render-planning-index.mjs';
 import { resolveAuthority, townPagePath } from './lib/town-path.mjs';
 import { renderSitemap } from './lib/render-sitemap.mjs';
 import { isSameNameAsAuthority } from './lib/same-name.mjs';
@@ -429,6 +430,23 @@ async function writePage(outDir, data) {
 }
 
 /**
+ * Write the `/planning/` authority hub page (tc-geq7h.1, GH #821 Phase 1) to
+ * <outDir>/planning/index.html — a real, static file, never a fallback to the
+ * SPA shell. No authority ever slugifies to an empty string (verified against
+ * the full committed authority list), so this can never collide with an
+ * authority-slug directory.
+ *
+ * @param {string} outDir
+ * @param {import('./lib/render-planning-index.mjs').PlanningIndexData} data
+ * @returns {Promise<void>}
+ */
+async function writePlanningIndex(outDir, data) {
+  const dir = join(outDir, 'planning');
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, 'index.html'), renderPlanningIndexPage(data), 'utf-8');
+}
+
+/**
  * Read the hand-written base SWA config, merge a 301 redirect for every
  * suppressed same-name town page (tc-77ll), and write the result into the build
  * outDir. Without this, a suppressed `/planning/<x>/<x>` URL would fall through
@@ -474,6 +492,10 @@ async function writeRedirectConfig({ outDir, redirects, baseConfigPath }) {
  * @param {Map<number, Array<{ name: string, slug: string }>>} args.townsByAuthority
  *   published towns keyed by parent authorityId, accumulated by the (earlier)
  *   town pass; the authority page links down to its own entry (sorted by name).
+ * @param {import('./lib/render-planning-index.mjs').PlanningIndexEntry[]} [args.hubEntries]
+ *   accumulates one entry per PUBLISHED authority for the `/planning/` hub
+ *   page (tc-geq7h.1) — never a non-qualifying or coverage-gated-out one, so
+ *   the hub can never link to a 404.
  * @param {{ warn: (msg: string) => void }} args.logger
  * @returns {Promise<void>}
  */
@@ -492,6 +514,7 @@ async function considerAuthority(args) {
     excluded,
     seenSlugs,
     townsByAuthority,
+    hubEntries,
     logger,
   } = args;
 
@@ -527,6 +550,15 @@ async function considerAuthority(args) {
   });
   published.push(slug);
   sitemapEntries.push({ path: slug, lastmod: maxLastmod(shown) });
+  if (hubEntries) {
+    const displayName = areaName || name;
+    hubEntries.push({
+      name: displayName,
+      slug,
+      applicationCount: total,
+      townCount: towns.length,
+    });
+  }
 }
 
 /**
@@ -832,6 +864,8 @@ async function renderEntries(args) {
   /** @type {Array<{ name: string, reason: string }>} */
   const excluded = [];
   const seenSlugs = new Set();
+  /** @type {import('./lib/render-planning-index.mjs').PlanningIndexEntry[]} */
+  const hubEntries = [];
 
   for (const entry of authorityEntries) {
     if (!isQualifyingAreaType(entry.areaType)) {
@@ -855,13 +889,30 @@ async function renderEntries(args) {
       excluded,
       seenSlugs,
       townsByAuthority,
+      hubEntries,
       logger,
     });
   }
 
+  const allSitemapEntries = [...authoritySitemapEntries, ...townSitemapEntries];
+
+  // `/planning/` hub page (tc-geq7h.1, GH #821 Phase 1): one A-Z index of every
+  // authority that was ACTUALLY published above (never a non-qualifying or
+  // coverage-gated-out one, so it can never link to a 404). Sorted here — the
+  // renderer itself only groups by letter, preserving whatever order it's
+  // given (see render-planning-index.mjs). Zero new data: every field comes
+  // from the SAME entries/towns this render pass already produced.
+  hubEntries.sort((a, b) => a.name.localeCompare(b.name));
+  await writePlanningIndex(outDir, { authorities: hubEntries });
+  // lastmod = the max across every child page (authority + town), the most
+  // honest freshness signal for a page whose own content is just a listing.
+  const hubLastmod = maxLastmod(
+    allSitemapEntries.map((e) => ({ lastDifferent: e.lastmod })),
+  );
+
   await writeFile(
     join(outDir, 'sitemap.xml'),
-    renderSitemap([...authoritySitemapEntries, ...townSitemapEntries]),
+    renderSitemap([{ path: '', lastmod: hubLastmod }, ...allSitemapEntries]),
     'utf-8',
   );
   await writeRedirectConfig({ outDir, redirects, baseConfigPath });


### PR DESCRIPTION
## Changes

- New `web/scripts/lib/render-planning-index.mjs`: hydration-free static template for the `/planning/` authority hub, A-Z grouped, showing town + application counts per authority. Reuses shared card/style helpers from `render-shared.mjs`.
- Wires the hub into `prerender-planning.mjs`'s existing `--render` (offline snapshot) and fixture render paths — zero new API calls. Only lists authorities that actually published a page (never a dead link).
- Writes a real `dist/planning/index.html` (explicit-404 SWA routing requires this, not a fallback route). Verified no authority slug collides with the hub route or `towns`.
- Adds a `/planning` entry (no trailing slash) to `sitemap.xml`, with `lastmod` = max across every authority + town child entry.
- Threads the existing ct-token CTA plumbing (`seo-hub` campaign) through the hub page, matching the other planning pages.
- Pluralization fix for the "N local planning authorities" lead-in wording (singular vs plural).

Tests: new `render-planning-index.test.mjs` (20 cases), `prerender-hub.test.mjs` (5 integration cases including a fetch-tripwire proving zero network calls and a reverse-ordered-snapshot case proving A-Z sort), `render-sitemap.test.mjs` +2 cases.

Part of epic tc-geq7h / GH #821 (Phase 1). Verified locally via a dispatched UI-verification subagent driving agent-browser against a rendered snapshot — hub page, authority link click-through, and sitemap entry all confirmed correct with no visual defects.

---
*Auto-shipped via ship skill*