### PR TITLE
feat: anonymous application search API (tc-geq7h.3)

### DIFF
--- a/api-go/cmd/api/anonymous_patterns_test.go
+++ b/api-go/cmd/api/anonymous_patterns_test.go
@@ -20,6 +20,21 @@ func TestAnonymousPatterns_IncludesBySlugApplicationRead(t *testing.T) {
 	}
 }
 
+// TestAnonymousPatterns_IncludesApplicationSearch pins the anonymity of the
+// public application search endpoint (#821 Phase 3, tc-geq7h.3): a resident
+// searching by reference/address/description needs no token, mirroring the
+// by-slug application read. The middleware keys on the exact registered
+// pattern string, so this must match the route wired in applications
+// byte-for-byte.
+func TestAnonymousPatterns_IncludesApplicationSearch(t *testing.T) {
+	t.Parallel()
+
+	const search = "GET /v1/applications/search"
+	if _, ok := anonymousPatterns[search]; !ok {
+		t.Errorf("anonymousPatterns must include %q", search)
+	}
+}
+
 // TestAnonymousPatterns_IncludesSharePage pins the anonymity of the public
 // server-rendered share page (#738). The auth middleware keys on the exact
 // registered pattern string, so this must match the route wired in sharepage

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -69,6 +69,11 @@ var anonymousPatterns = map[string]struct{}{
 	// and iOS inbound deep-link resolution (#738). The sibling by-id read stays
 	// authed (absent from this map).
 	"GET /v1/applications/by-slug/{authoritySlug}/{ref...}": {},
+	// The anonymous application search (#821 Phase 3, tc-geq7h.3) reads only
+	// public planning data (reference/address/description match, Postgres only —
+	// PlanIt is never touched): a resident finding an application to share needs
+	// no token, mirroring the by-slug read above.
+	"GET /v1/applications/search": {},
 	// The public share page is anonymous (public planning data only; no user data,
 	// no cookies, no client-IP logging): a server-rendered HTML page for a single
 	// application, the tracer surface of the shareable-page epic (#738).
@@ -261,6 +266,14 @@ func newRouter(
 		// 401 fallback.
 		applications.RecentRoutes(mux, appStore, siteBuildKey, logger)
 		applications.NearRoutes(mux, appStore, siteBuildKey, logger)
+		// The anonymous application search (#821 Phase 3, tc-geq7h.3) reads from the
+		// same store; it needs no build key (unlike the two SEO routes above) since
+		// it is not a build-time-only surface — it is the public-facing endpoint the
+		// /search web page (tc-geq7h.4) calls directly from a visitor's browser. It is
+		// anonymous to Auth0 (see anonymousPatterns) and subject to the SAME rate
+		// limiting as every other anonymous route: RateLimit no-ops on a request
+		// with no subject (middleware/ratelimit.go), so no new scheme is needed here.
+		applications.SearchRoutes(mux, appStore, authorities.NewLookup(), logger)
 		// The public share page (#738): an anonymous, server-rendered HTML page for a
 		// single application at GET /a/{authoritySlug}/{ref...}. It point-reads the
 		// same applications store and resolves the authority slug via the static

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -151,6 +151,13 @@ func (f foundAppStore) GetByAuthorityAndName(_ context.Context, authorityCode, _
 	return applications.PlanningApplication{}, false, nil
 }
 
+// Search unconditionally returns the fixture application, ignoring the query/
+// authority/limit args — this fake exists only to give the anonymous search
+// route's end-to-end wiring test a real record to render and serialise.
+func (f foundAppStore) Search(context.Context, string, string, int) ([]applications.PlanningApplication, bool, error) {
+	return []applications.PlanningApplication{f.app}, false, nil
+}
+
 // fakeSavedStore is a savedapplications.Store returning the empty path.
 type fakeSavedStore struct{}
 
@@ -366,6 +373,43 @@ func TestRouter_SharePageAndBySlugAnonymous_ByIdStaysAuthed(t *testing.T) {
 	}
 	if ct := ogCard.Header().Get("Content-Type"); ct != "image/png" {
 		t.Errorf("og:image Content-Type = %q, want image/png", ct)
+	}
+}
+
+// TestRouter_ApplicationSearchAnonymous is the end-to-end wiring guard for the
+// anonymous application search endpoint (#821 Phase 3, tc-geq7h.3): it boots the
+// FULL router with a store that returns a real Croydon application, then proves
+// GET /v1/applications/search serves anonymously (no token, 200 application/json)
+// and its response carries the fields a client needs to build a share URL
+// (authoritySlug + reference), byte-identical to what the by-slug read exposes.
+// The pattern string match is a drift guard: a rename here without updating
+// anonymousPatterns would silently 401 the route.
+func TestRouter_ApplicationSearchAnonymous(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.DiscardHandler)
+	app := applications.PlanningApplication{
+		Name:     "23/03456/FUL",
+		UID:      "croydon-23-03456-FUL",
+		AreaName: "Croydon",
+		AreaID:   301, // the real Croydon id, so SlugForAreaID(301) == "croydon"
+		Address:  "10 Downing Street, London",
+	}
+	appStore := foundAppStore{app: app}
+	h := newRouter(denyAllValidator{}, []string{"https://towncrierapp.uk"}, nil, profiles.NoOpAuth0Client{}, profiles.CascadeDeleters{}, profiles.ExportReaders{}, nil, nil, nil, nil, appStore, nil, testGeocodeClient(t), testDesignationClient(t), nil, nil, "", "", nil, nil, "", nil, nil, nil, logger)
+
+	rec := serveReq(t, h, http.MethodGet, "/v1/applications/search?q=downing", "", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/applications/search status = %d, want 200 (anonymous); body = %s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	if !strings.Contains(rec.Body.String(), `"authoritySlug":"croydon"`) {
+		t.Errorf("body missing authoritySlug croydon; body = %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"reference":"23/03456/FUL"`) {
+		t.Errorf("body missing reference 23/03456/FUL (planit_name, not uid); body = %s", rec.Body.String())
 	}
 }
 

--- a/api-go/cmd/api/wiring_test.go
+++ b/api-go/cmd/api/wiring_test.go
@@ -130,6 +130,9 @@ func (fakeAppStore) RecentNearestTown(context.Context, string, float64, float64,
 func (fakeAppStore) BreakdownNearby(context.Context, string, float64, float64, float64) ([]applications.StateCount, error) {
 	return nil, nil
 }
+func (fakeAppStore) Search(context.Context, string, string, int) ([]applications.PlanningApplication, bool, error) {
+	return nil, false, nil
+}
 
 // foundAppStore is a fakeAppStore that returns one populated application for the
 // Croydon area id (301) — the real id, so authorities.NewLookup().SlugForAreaID(301)

--- a/api-go/internal/applications/handler.go
+++ b/api-go/internal/applications/handler.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
-	"github.com/AmyDe/town-crier/api-go/internal/authorities"
 )
 
 // appStore is the consumer-side store the application read handler uses.
@@ -116,17 +115,8 @@ func (h *handler) getBySlug(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, r, h.logger, result)
 }
 
-// authoritySlug returns the URL slug for the application's authority,
-// round-trip-safe against SlugToAreaID: it prefers the resolver's SlugForAreaID
-// (so the emitted slug is exactly what SlugToAreaID resolves back), and only when
-// the id is unknown falls back to slugifying the PlanIt area name. The fallback is
-// warn-logged because it means PlanIt returned an area id absent from the static
-// authorities data — the emitted slug then may not round-trip back through
-// SlugToAreaID, so a share/by-slug link built from it could 404.
+// authoritySlug returns the URL slug for the application's authority. See
+// resolveAuthoritySlugFor (respond.go) for the round-trip/fallback behaviour.
 func (h *handler) authoritySlug(ctx context.Context, app PlanningApplication) string {
-	if slug, ok := h.resolver.SlugForAreaID(app.AreaID); ok {
-		return slug
-	}
-	h.logger.WarnContext(ctx, "authority slug fallback: area id not in static authorities", "op", "authority slug", "areaId", app.AreaID, "areaName", app.AreaName, "uid", app.UID)
-	return authorities.Slugify(app.AreaName)
+	return resolveAuthoritySlugFor(ctx, h.resolver, h.logger, "authority slug", app)
 }

--- a/api-go/internal/applications/respond.go
+++ b/api-go/internal/applications/respond.go
@@ -1,9 +1,11 @@
 package applications
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 
+	"github.com/AmyDe/town-crier/api-go/internal/authorities"
 	"github.com/AmyDe/town-crier/api-go/internal/httputil"
 )
 
@@ -29,4 +31,22 @@ func writeJSON(w http.ResponseWriter, r *http.Request, logger *slog.Logger, v an
 func serverError(w http.ResponseWriter, r *http.Request, logger *slog.Logger, op string, err error) {
 	logger.ErrorContext(r.Context(), "application request failed", "op", op, "error", err)
 	w.WriteHeader(http.StatusInternalServerError)
+}
+
+// resolveAuthoritySlugFor resolves the URL slug for an application's authority,
+// round-trip-safe against SlugToAreaID: it prefers resolver.SlugForAreaID (so
+// the emitted slug is exactly what SlugToAreaID resolves back), and only when
+// the id is unknown falls back to slugifying the PlanIt area name. The
+// fallback is warn-logged because it means PlanIt returned an area id absent
+// from the static authorities data — the emitted slug then may not round-trip
+// back through SlugToAreaID, so a share/by-slug link built from it could 404.
+// op names the calling handler in the log line (each handler passes its own,
+// distinct string) so a fallback can be traced back to its endpoint. Shared by
+// (h *handler).authoritySlug and (h *searchHandler).authoritySlug.
+func resolveAuthoritySlugFor(ctx context.Context, resolver authoritySlugResolver, logger *slog.Logger, op string, app PlanningApplication) string {
+	if slug, ok := resolver.SlugForAreaID(app.AreaID); ok {
+		return slug
+	}
+	logger.WarnContext(ctx, "authority slug fallback: area id not in static authorities", "op", op, "areaId", app.AreaID, "areaName", app.AreaName, "uid", app.UID)
+	return authorities.Slugify(app.AreaName)
 }

--- a/api-go/internal/applications/search.go
+++ b/api-go/internal/applications/search.go
@@ -2,10 +2,13 @@ package applications
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/AmyDe/town-crier/api-go/internal/authorities"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
@@ -214,4 +217,117 @@ type SearchResponse struct {
 	Query       string         `json:"query"`
 	Results     []SearchResult `json:"results"`
 	RefineQuery bool           `json:"refineQuery"`
+}
+
+// searchQuery ranks applications matching q across three tiers in a single
+// statement (#821 Phase 3), each computed once over the whole table and unioned:
+//
+//  1. Reference exact/prefix match on uid (case-insensitive): an exact match
+//     scores 2.0, a prefix-only match 1.0, so within tier 1 an exact hit still
+//     ranks first. uid — NOT planit_name — is the fuller, human-recognisable
+//     council reference (tc-geq7h.3 decision 2026-07-05); it may legitimately
+//     match rows in more than one authority, since a bare reference is only
+//     unique within a council.
+//  2. Address fuzzy match via pg_trgm word_similarity (<%): the query is
+//     typically a short fragment of a much longer address, so word_similarity
+//     (matching against any word-boundary substring of address) is used
+//     instead of whole-string similarity (%), which would under-score a short,
+//     otherwise-exact fragment.
+//  3. Description full-text match via the english tsvector config, ranked by
+//     ts_rank.
+//
+// matched unions the three tiers (each row tagged with its tier and an
+// in-tier score); best keeps only the single best-tier match per application
+// (DISTINCT ON (area_id, planit_name), the natural-key equivalent already
+// present in appColumns) — an application matching more than one tier is never
+// duplicated, it surfaces once under its highest-priority tier. The final
+// SELECT re-applies the tier/score order (a plain column reference survives
+// DISTINCT ON's row selection but not its projection, so the ORDER BY must be
+// restated) plus a planit_name tie-break for determinism, and the LIMIT is the
+// caller's requested limit+1 — the extra row is how Search detects "more
+// matches exist than the limit" without a second query.
+//
+// searchSelectColumns (not appColumns) backs the three UNION branches: it
+// aliases the two computed geometry accessors to lat/lon. appColumns' raw form
+// (ST_Y(location::geometry) with no alias) only resolves because those
+// branches SELECT directly FROM applications, where the location column is in
+// scope — but matched/best are CTEs, and a CTE's exposed columns are named
+// from their SELECT list (an unaliased function call is named after the
+// function, not "location"), so location does not exist there. The outer
+// SELECT list (searchOutputColumns) therefore reads the already-computed lat/
+// lon straight off best, rather than re-deriving them from a location column
+// that was never carried through the CTE chain.
+const searchSelectColumns = "planit_name, uid, area_name, area_id, address, postcode, " +
+	"description, app_type, app_state, app_size, start_date, decided_date, " +
+	"consulted_date, ST_Y(location::geometry) AS lat, ST_X(location::geometry) AS lon, url, link, last_different"
+
+const searchOutputColumns = "planit_name, uid, area_name, area_id, address, postcode, " +
+	"description, app_type, app_state, app_size, start_date, decided_date, " +
+	"consulted_date, lat, lon, url, link, last_different"
+
+const searchQuery = `
+WITH matched AS (
+	SELECT ` + searchSelectColumns + `, 1 AS tier,
+	       CASE WHEN lower(uid) = lower($1) THEN 2.0 ELSE 1.0 END AS score
+	FROM applications
+	WHERE (lower(uid) = lower($1) OR lower(uid) LIKE $4 ESCAPE '\')
+	  AND ($2::text IS NULL OR authority_code = $2)
+	UNION ALL
+	SELECT ` + searchSelectColumns + `, 2 AS tier, word_similarity(lower($1), lower(address)) AS score
+	FROM applications
+	WHERE lower($1) <% lower(address)
+	  AND ($2::text IS NULL OR authority_code = $2)
+	UNION ALL
+	SELECT ` + searchSelectColumns + `, 3 AS tier,
+	       ts_rank(to_tsvector('english', description), plainto_tsquery('english', $1)) AS score
+	FROM applications
+	WHERE to_tsvector('english', description) @@ plainto_tsquery('english', $1)
+	  AND ($2::text IS NULL OR authority_code = $2)
+),
+best AS (
+	SELECT DISTINCT ON (area_id, planit_name) *
+	FROM matched
+	ORDER BY area_id, planit_name, tier ASC, score DESC
+)
+SELECT ` + searchOutputColumns + `
+FROM best
+ORDER BY tier ASC, score DESC, planit_name ASC
+LIMIT $3`
+
+// escapeLikeWildcards backslash-escapes the LIKE metacharacters (\, %, _) in a
+// user-supplied query before it is used to build a prefix pattern, so a query
+// containing a literal '%' or '_' cannot silently widen the tier-1 prefix match
+// beyond an exact prefix of the typed text.
+func escapeLikeWildcards(s string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+	return replacer.Replace(s)
+}
+
+// Search runs searchQuery and reports whether more matches exist beyond limit:
+// it asks for limit+1 rows, and if that many come back, truncates to limit and
+// returns true (the v1 "no cursor — tell the caller to refine" signal,
+// SearchResponse.RefineQuery). authorityCode "" applies no authority filter,
+// passed to the query as a genuine SQL NULL (not empty-string equality) so
+// "($2::text IS NULL OR ...)" reads naturally.
+func (s *PostgresStore) Search(ctx context.Context, query, authorityCode string, limit int) ([]PlanningApplication, bool, error) {
+	var authorityArg any
+	if authorityCode != "" {
+		authorityArg = authorityCode
+	}
+	likePattern := strings.ToLower(escapeLikeWildcards(query)) + "%"
+
+	rows, err := s.db.Query(ctx, searchQuery, query, authorityArg, limit+1, likePattern)
+	if err != nil {
+		return nil, false, fmt.Errorf("search applications %q: %w", query, err)
+	}
+	apps, err := pgx.CollectRows(rows, scanAppRow)
+	if err != nil {
+		return nil, false, fmt.Errorf("search applications %q: %w", query, err)
+	}
+
+	refine := len(apps) > limit
+	if refine {
+		apps = apps[:limit]
+	}
+	return apps, refine, nil
 }

--- a/api-go/internal/applications/search.go
+++ b/api-go/internal/applications/search.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
-	"github.com/AmyDe/town-crier/api-go/internal/authorities"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
 )
 
@@ -107,16 +106,10 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// authoritySlug resolves the URL slug for the application's authority, mirroring
-// (h *handler).authoritySlug in handler.go: it prefers the resolver's
-// SlugForAreaID and falls back, with a warn log, to slugifying the raw PlanIt
-// area name when the id is unknown to the static authorities data.
+// authoritySlug returns the URL slug for the application's authority. See
+// resolveAuthoritySlugFor (respond.go) for the round-trip/fallback behaviour.
 func (h *searchHandler) authoritySlug(ctx context.Context, app PlanningApplication) string {
-	if slug, ok := h.resolver.SlugForAreaID(app.AreaID); ok {
-		return slug
-	}
-	h.logger.WarnContext(ctx, "authority slug fallback: area id not in static authorities", "op", "search authority slug", "areaId", app.AreaID, "areaName", app.AreaName, "uid", app.UID)
-	return authorities.Slugify(app.AreaName)
+	return resolveAuthoritySlugFor(ctx, h.resolver, h.logger, "search authority slug", app)
 }
 
 // validSearchQuery reports whether q is non-empty, no longer than

--- a/api-go/internal/applications/search.go
+++ b/api-go/internal/applications/search.go
@@ -1,0 +1,217 @@
+package applications
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/AmyDe/town-crier/api-go/internal/authorities"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// searchMinQueryLen and searchMaxQueryLen bound the free-text q parameter: below
+// the minimum q is rejected unless looksLikeReference reports it is probably a
+// planning reference rather than an address/description fragment (a defensible,
+// low-risk heuristic — see looksLikeReference's doc comment); above the maximum
+// it is rejected outright, so a single request cannot force an expensive
+// similarity/ts_rank scan with a pathological input size.
+const (
+	searchMinQueryLen = 3
+	searchMaxQueryLen = 200
+)
+
+// searchDefaultLimit and searchMaxLimit bound how many rows the endpoint
+// returns. Unlike the SEO endpoints (recentDefaultLimit/recentMaxLimit), v1 has
+// no cursor: an over-limit match set is truncated and flagged via
+// SearchResponse.RefineQuery rather than paginated.
+const (
+	searchDefaultLimit = 20
+	searchMaxLimit     = 20
+)
+
+// searchStore is the consumer-side store the search handler needs: a single
+// ranked, capped read across the three match tiers (#821 Phase 3) — reference
+// exact/prefix match on uid, address fuzzy match (pg_trgm), description
+// full-text match (tsvector). authorityCode "" means no authority filter (a
+// bare reference legitimately matches across authorities — application_uid is
+// only unique within a council). The bool return reports whether more matches
+// exist beyond limit (RefineQuery on the wire); the concrete *PostgresStore
+// satisfies it structurally.
+type searchStore interface {
+	Search(ctx context.Context, query, authorityCode string, limit int) ([]PlanningApplication, bool, error)
+}
+
+// searchHandler serves the anonymous application search endpoint.
+type searchHandler struct {
+	store    searchStore
+	resolver authoritySlugResolver
+	logger   *slog.Logger
+}
+
+// SearchRoutes registers the anonymous application search endpoint. It is kept
+// out of auth's fallback-deny set in cmd/api/wiring.go's anonymousPatterns (like
+// the by-slug application read) and reads only public planning data from
+// Postgres — PlanIt is never touched by this endpoint (GH#395 Invariant 1).
+func SearchRoutes(mux *http.ServeMux, store searchStore, resolver authoritySlugResolver, logger *slog.Logger) {
+	h := &searchHandler{store: store, resolver: resolver, logger: logger}
+	mux.HandleFunc("GET /v1/applications/search", h.search)
+}
+
+// search validates q (and the optional authority filter + limit), then returns
+// the ranked match set: reference exact/prefix on uid, ranked above address
+// fuzzy match, ranked above description full-text match. A missing/too-short q
+// (unless it looks like a reference) or an unresolvable authority slug is a
+// bodyless 400; a store failure is a bodyless 500 (both envelopes backfilled by
+// middleware.ErrorBody).
+func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+
+	query := strings.TrimSpace(q.Get("q"))
+	if !validSearchQuery(query) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
+	authorityCode := ""
+	if raw := strings.TrimSpace(q.Get("authority")); raw != "" {
+		code, ok := resolveAuthorityParam(raw, h.resolver)
+		if !ok {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		authorityCode = code
+	}
+
+	limit := parseSearchLimit(q.Get("limit"))
+
+	apps, refine, err := h.store.Search(r.Context(), query, authorityCode, limit)
+	if err != nil {
+		serverError(w, r, h.logger, "search applications", err)
+		return
+	}
+
+	results := make([]SearchResult, 0, len(apps))
+	for _, a := range apps {
+		results = append(results, SearchResultOf(a, h.authoritySlug(r.Context(), a)))
+	}
+
+	writeJSON(w, r, h.logger, SearchResponse{
+		Query:       query,
+		Results:     results,
+		RefineQuery: refine,
+	})
+}
+
+// authoritySlug resolves the URL slug for the application's authority, mirroring
+// (h *handler).authoritySlug in handler.go: it prefers the resolver's
+// SlugForAreaID and falls back, with a warn log, to slugifying the raw PlanIt
+// area name when the id is unknown to the static authorities data.
+func (h *searchHandler) authoritySlug(ctx context.Context, app PlanningApplication) string {
+	if slug, ok := h.resolver.SlugForAreaID(app.AreaID); ok {
+		return slug
+	}
+	h.logger.WarnContext(ctx, "authority slug fallback: area id not in static authorities", "op", "search authority slug", "areaId", app.AreaID, "areaName", app.AreaName, "uid", app.UID)
+	return authorities.Slugify(app.AreaName)
+}
+
+// validSearchQuery reports whether q is non-empty, no longer than
+// searchMaxQueryLen, and either at least searchMinQueryLen runes or
+// looksLikeReference.
+func validSearchQuery(q string) bool {
+	n := len([]rune(q))
+	if n == 0 || n > searchMaxQueryLen {
+		return false
+	}
+	if n >= searchMinQueryLen {
+		return true
+	}
+	return looksLikeReference(q)
+}
+
+// looksLikeReference reports whether q contains at least one digit — the cheap
+// heuristic for "this short query is probably a planning reference, not an
+// address/description fragment" (tc-geq7h.3 decision 2026-07-05). Real
+// references vary too widely in shape (24/0001/FUL, 9/P/2026/0044/HH,
+// 24/SAME/FUL) to anchor a stricter pattern; over-admitting costs nothing since
+// the reference tier is an indexed exact/prefix lookup on uid that simply
+// returns zero rows on a miss.
+func looksLikeReference(q string) bool {
+	return strings.ContainsFunc(q, func(r rune) bool { return r >= '0' && r <= '9' })
+}
+
+// parseSearchLimit clamps the limit query parameter to [1, searchMaxLimit],
+// defaulting to searchDefaultLimit when unset, empty, non-numeric, or
+// non-positive.
+func parseSearchLimit(raw string) int {
+	n, err := strconv.Atoi(strings.TrimSpace(raw))
+	if err != nil || n <= 0 {
+		return searchDefaultLimit
+	}
+	if n > searchMaxLimit {
+		return searchMaxLimit
+	}
+	return n
+}
+
+// resolveAuthorityParam resolves the authority=<id-or-slug> filter to an
+// authority_code (the stringified area id): a numeric value is used directly
+// (matching RecentRoutes/NearRoutes, which never validate a numeric id against
+// the static authorities data either — an id with no applications is just an
+// empty result, not an error); a non-numeric value is resolved as a slug via
+// resolver.SlugToAreaID, and an unresolvable slug is reported false (-> 400),
+// since a slug that cannot resolve at all is unambiguously a client error.
+func resolveAuthorityParam(raw string, resolver authoritySlugResolver) (string, bool) {
+	if id, err := strconv.Atoi(raw); err == nil {
+		return strconv.Itoa(id), true
+	}
+	areaID, ok := resolver.SlugToAreaID(raw)
+	if !ok {
+		return "", false
+	}
+	return strconv.Itoa(areaID), true
+}
+
+// SearchResult is one ranked row of GET /v1/applications/search: just enough to
+// render a result card and build a share URL client-side
+// (share.towncrierapp.uk/a/{authoritySlug}/{reference}). Reference is
+// planit_name (PlanningApplication.Name), NOT uid: uid is only ever the tier-1
+// ranking's match key, never emitted, since the share route resolves by
+// planit_name (sharepage/handler.go -> GetByAuthorityAndName) — echoing uid
+// would 404 the link whenever uid != planit_name, which per real PlanIt data is
+// the common case, not an edge case.
+type SearchResult struct {
+	Reference     string             `json:"reference"`
+	AuthoritySlug string             `json:"authoritySlug"`
+	AuthorityName string             `json:"authorityName"`
+	Address       string             `json:"address"`
+	AppState      *string            `json:"appState"`
+	StartDate     *platform.DateOnly `json:"startDate"`
+	DecidedDate   *platform.DateOnly `json:"decidedDate"`
+}
+
+// SearchResultOf maps a matched domain snapshot plus its resolved authority slug
+// to the wire shape.
+func SearchResultOf(a PlanningApplication, authoritySlug string) SearchResult {
+	return SearchResult{
+		Reference:     a.Name,
+		AuthoritySlug: authoritySlug,
+		AuthorityName: a.AreaName,
+		Address:       a.Address,
+		AppState:      a.AppState,
+		StartDate:     platform.DateOnlyPtr(a.StartDate),
+		DecidedDate:   platform.DateOnlyPtr(a.DecidedDate),
+	}
+}
+
+// SearchResponse is the full wire body of GET /v1/applications/search. Results
+// is always a non-null array (bounded at the request's limit, capped at
+// searchMaxLimit). RefineQuery is true when the match set exceeds the limit: v1
+// has no cursor, so rather than silently truncating a possibly much larger
+// result set, the caller is told to narrow q/authority instead of paging.
+type SearchResponse struct {
+	Query       string         `json:"query"`
+	Results     []SearchResult `json:"results"`
+	RefineQuery bool           `json:"refineQuery"`
+}

--- a/api-go/internal/applications/search_integration_test.go
+++ b/api-go/internal/applications/search_integration_test.go
@@ -1,0 +1,300 @@
+//go:build integration
+
+package applications
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
+)
+
+// searchApp builds a baseline application for the search suite: a distinct uid
+// from name (mirroring pgApp), plus an authority-scoped area id.
+func searchApp(name, uid string, areaID int) PlanningApplication {
+	a := pgApp(name, areaID)
+	a.UID = uid
+	return a
+}
+
+// TestPostgresStore_Search_ReferenceTierExactAndPrefix proves tier 1 matches on
+// uid (NOT planit_name), case-insensitively, both exactly and by prefix.
+func TestPostgresStore_Search_ReferenceTierExactAndPrefix(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+
+	target := searchApp("24/0099", "24/0099/FUL", 100)
+	other := searchApp("24/0100", "24/0100/OUT", 100)
+	for _, a := range []PlanningApplication{target, other} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	t.Run("exact match, case-insensitive", func(t *testing.T) {
+		apps, refine, err := store.Search(ctx, "24/0099/ful", "", 20)
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		if refine {
+			t.Error("refine: got true, want false")
+		}
+		if len(apps) != 1 || apps[0].Name != target.Name {
+			t.Fatalf("got %+v, want exactly [%s]", apps, target.Name)
+		}
+	})
+
+	t.Run("prefix match", func(t *testing.T) {
+		apps, _, err := store.Search(ctx, "24/0099/F", "", 20)
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		if len(apps) != 1 || apps[0].Name != target.Name {
+			t.Fatalf("got %+v, want exactly [%s]", apps, target.Name)
+		}
+	})
+
+	t.Run("no match returns empty, not an error", func(t *testing.T) {
+		apps, refine, err := store.Search(ctx, "no-such-reference-at-all", "", 20)
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		if refine {
+			t.Error("refine: got true, want false")
+		}
+		if len(apps) != 0 {
+			t.Fatalf("got %+v, want empty", apps)
+		}
+	})
+}
+
+// TestPostgresStore_Search_ReferenceTierCrossesAuthorities proves a bare
+// reference legitimately returns rows from MULTIPLE authorities when no
+// authority filter is given (application_uid is only unique within a council —
+// tc-geq7h.3), and that the authority filter scopes it down to one.
+func TestPostgresStore_Search_ReferenceTierCrossesAuthorities(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+
+	sharedUID := "shared-council-ref-24-0001"
+	inA := searchApp("A1", sharedUID, 100)
+	inB := searchApp("B1", sharedUID, 200)
+	for _, a := range []PlanningApplication{inA, inB} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	unfiltered, _, err := store.Search(ctx, sharedUID, "", 20)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(unfiltered) != 2 {
+		t.Fatalf("unfiltered: got %d rows, want 2 (one per authority)", len(unfiltered))
+	}
+
+	scoped, _, err := store.Search(ctx, sharedUID, "200", 20)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(scoped) != 1 || scoped[0].Name != inB.Name {
+		t.Fatalf("scoped to authority 200: got %+v, want exactly [%s]", scoped, inB.Name)
+	}
+}
+
+// TestPostgresStore_Search_AddressFuzzyMatch proves tier 2 finds a distinctive
+// address fragment via pg_trgm word_similarity, case-insensitively, and does
+// NOT match a clearly unrelated address.
+func TestPostgresStore_Search_AddressFuzzyMatch(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+
+	match := searchApp("A1", "uid-a1", 100)
+	match.Address = "42 Willowmere Gardens, Sometown"
+	unrelated := searchApp("A2", "uid-a2", 100)
+	unrelated.Address = "1 Zephyr Industrial Estate, Othertown"
+	for _, a := range []PlanningApplication{match, unrelated} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	apps, _, err := store.Search(ctx, "willowmere", "", 20)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(apps) != 1 || apps[0].Name != match.Name {
+		t.Fatalf("got %+v, want exactly [%s]", apps, match.Name)
+	}
+}
+
+// TestPostgresStore_Search_DescriptionFullTextMatch proves tier 3 finds a
+// description match via the english tsvector config, including basic English
+// stemming (a query for "extension" matches a description containing
+// "extensions").
+func TestPostgresStore_Search_DescriptionFullTextMatch(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+
+	match := searchApp("D1", "uid-d1", 100)
+	match.Description = "Two storey rear extensions and loft conversion"
+	unrelated := searchApp("D2", "uid-d2", 100)
+	unrelated.Description = "Felling of one protected oak tree"
+	for _, a := range []PlanningApplication{match, unrelated} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	apps, _, err := store.Search(ctx, "extension", "", 20)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(apps) != 1 || apps[0].Name != match.Name {
+		t.Fatalf("got %+v, want exactly [%s] (english stemming: extension -> extensions)", apps, match.Name)
+	}
+}
+
+// TestPostgresStore_Search_RankingOrder proves the fixed tier order — reference
+// > address > description — even though all three rows match the SAME query
+// text, each via a different tier.
+func TestPostgresStore_Search_RankingOrder(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+
+	const query = "hawthorn"
+
+	byRef := searchApp("R1", query, 100) // tier 1: exact uid match
+	byAddress := searchApp("R2", "uid-r2", 100)
+	byAddress.Address = "9 Hawthorn Close, Sometown" // tier 2: address fuzzy match
+	byDescription := searchApp("R3", "uid-r3", 100)
+	byDescription.Description = "Removal of a hawthorn hedge" // tier 3: description match
+	for _, a := range []PlanningApplication{byDescription, byAddress, byRef} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	apps, refine, err := store.Search(ctx, query, "", 20)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if refine {
+		t.Error("refine: got true, want false")
+	}
+	if len(apps) != 3 {
+		t.Fatalf("got %d rows, want 3; %+v", len(apps), apps)
+	}
+	gotOrder := []string{apps[0].Name, apps[1].Name, apps[2].Name}
+	wantOrder := []string{byRef.Name, byAddress.Name, byDescription.Name}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Fatalf("rank order: got %v, want %v (reference > address > description)", gotOrder, wantOrder)
+		}
+	}
+}
+
+// TestPostgresStore_Search_LimitAndRefineFlag proves an over-limit match set is
+// truncated to limit and reports refine=true (v1 has no cursor — tc-geq7h.3),
+// while an exactly-at-limit set reports refine=false.
+func TestPostgresStore_Search_LimitAndRefineFlag(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+
+	// 5 applications all sharing a distinctive description word.
+	for i := range 5 {
+		a := searchApp(nameForIndex(i), "uid-"+nameForIndex(i), 100)
+		a.Description = "Demolition of existing outbuilding"
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	t.Run("limit below match count: truncated, refine true", func(t *testing.T) {
+		apps, refine, err := store.Search(ctx, "demolition", "", 3)
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		if len(apps) != 3 {
+			t.Fatalf("got %d rows, want 3 (truncated to limit)", len(apps))
+		}
+		if !refine {
+			t.Error("refine: got false, want true (5 matches > limit 3)")
+		}
+	})
+
+	t.Run("limit at or above match count: refine false", func(t *testing.T) {
+		apps, refine, err := store.Search(ctx, "demolition", "", 5)
+		if err != nil {
+			t.Fatalf("Search: %v", err)
+		}
+		if len(apps) != 5 {
+			t.Fatalf("got %d rows, want 5", len(apps))
+		}
+		if refine {
+			t.Error("refine: got true, want false (5 matches == limit 5)")
+		}
+	})
+}
+
+func nameForIndex(i int) string {
+	return "L" + string(rune('A'+i))
+}
+
+// TestPostgresStore_Search_ExplainUsesTrgmAndFTSIndexes proves the migration's
+// GIN indexes (applications_address_trgm, applications_description_fts) serve
+// the tier-2/tier-3 predicates — so the query never falls back to a sequential
+// scan as the applications table grows. enable_seqscan is disabled for the
+// EXPLAIN so the planner is forced to reveal whether each index is usable,
+// mirroring TestPostgresStore_FindClustersInZone_ExplainUsesGiSTIndex.
+func TestPostgresStore_Search_ExplainUsesTrgmAndFTSIndexes(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "applications", "watch_zones")
+	store := NewPostgresStore(pool)
+	ctx := context.Background()
+	for i := range 20 {
+		a := searchApp(nameForIndex(i), "uid-"+nameForIndex(i), 100)
+		a.Address = "Willowmere Gardens"
+		a.Description = "a garden wall"
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire connection: %v", err)
+	}
+	defer conn.Release()
+	if _, err := conn.Exec(ctx, "SET enable_seqscan = off"); err != nil {
+		t.Fatalf("disable seqscan: %v", err)
+	}
+
+	var authorityArg any
+	rows, err := conn.Query(ctx, "EXPLAIN (FORMAT TEXT) "+searchQuery, "willowmere", authorityArg, 21, "willowmere%")
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v", err)
+	}
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			rows.Close()
+			t.Fatalf("scan plan line: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+
+	planText := strings.ToLower(plan.String())
+	if !strings.Contains(planText, "applications_address_trgm") {
+		t.Errorf("EXPLAIN plan does not use applications_address_trgm:\n%s", plan.String())
+	}
+	if !strings.Contains(planText, "applications_description_fts") {
+		t.Errorf("EXPLAIN plan does not use applications_description_fts:\n%s", plan.String())
+	}
+}

--- a/api-go/internal/applications/search_test.go
+++ b/api-go/internal/applications/search_test.go
@@ -1,0 +1,329 @@
+package applications
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+// errBoom is a fixed sentinel error for store-failure test cases.
+var errBoom = errors.New("boom")
+
+// fakeSearchStore is a hand-written searchStore fake: it records the exact
+// arguments the handler passed through (query, authorityCode, limit) and
+// returns a fixed result set, refine flag and error.
+type fakeSearchStore struct {
+	apps   []PlanningApplication
+	refine bool
+	err    error
+
+	lastQuery         string
+	lastAuthorityCode string
+	lastLimit         int
+	calls             int
+}
+
+func (f *fakeSearchStore) Search(_ context.Context, query, authorityCode string, limit int) ([]PlanningApplication, bool, error) {
+	f.calls++
+	f.lastQuery = query
+	f.lastAuthorityCode = authorityCode
+	f.lastLimit = limit
+	return f.apps, f.refine, f.err
+}
+
+func serveSearch(t *testing.T, store searchStore, resolver authoritySlugResolver, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	mux := http.NewServeMux()
+	SearchRoutes(mux, store, resolver, slog.New(slog.DiscardHandler))
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// searchPath builds the search endpoint path with q query-escaped.
+func searchPath(q string) string {
+	return "/v1/applications/search?q=" + url.QueryEscape(q)
+}
+
+// TestSearchHandler_ValidatesQuery proves the <3-char minimum, its "looks like a
+// reference" bypass (any digit), and the empty rejection, all as bodyless 400s
+// that never reach the store.
+func TestSearchHandler_ValidatesQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		q         string
+		wantCalls int
+		wantOK    bool
+	}{
+		{"empty", "", 0, false},
+		{"whitespace only", "   ", 0, false},
+		{"two chars, no digit", "ab", 0, false},
+		{"three chars, no digit", "abc", 1, true},
+		{"one char with digit looks like a ref", "1", 1, true},
+		{"two chars with digit looks like a ref", "24", 1, true},
+		{"typical short reference", "24/1", 1, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := &fakeSearchStore{}
+			rec := serveSearch(t, store, testResolver(), searchPath(tc.q))
+
+			if store.calls != tc.wantCalls {
+				t.Errorf("store calls: got %d, want %d", store.calls, tc.wantCalls)
+			}
+			wantStatus := http.StatusBadRequest
+			if tc.wantOK {
+				wantStatus = http.StatusOK
+			}
+			if rec.Code != wantStatus {
+				t.Errorf("status: got %d, want %d", rec.Code, wantStatus)
+			}
+		})
+	}
+}
+
+// TestSearchHandler_RejectsOversizeQuery proves an excessively long q is a 400
+// that never reaches the store, so a single request cannot force an expensive
+// similarity/ts_rank scan with a pathological input size.
+func TestSearchHandler_RejectsOversizeQuery(t *testing.T) {
+	t.Parallel()
+	huge := strings.Repeat("a", searchMaxQueryLen+1)
+	store := &fakeSearchStore{}
+	rec := serveSearch(t, store, testResolver(), searchPath(huge))
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", rec.Code)
+	}
+	if store.calls != 0 {
+		t.Errorf("store calls: got %d, want 0", store.calls)
+	}
+}
+
+// TestSearchHandler_ReturnsMappedResults proves the response envelope shape: the
+// reference field is planit_name (Name), NOT uid — echoing uid would break the
+// share-URL the client builds from it (tc-geq7h.3 decision 2026-07-05).
+func TestSearchHandler_ReturnsMappedResults(t *testing.T) {
+	t.Parallel()
+
+	decided := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	app := PlanningApplication{
+		Name:        "24/0123/FUL",
+		UID:         "24-0123-FUL-uid-distinct-from-name",
+		AreaName:    "City of London",
+		AreaID:      471,
+		Address:     "1 Test Street",
+		Description: "an extension",
+		AppState:    strPtr("Permitted"),
+		DecidedDate: &decided,
+	}
+	store := &fakeSearchStore{apps: []PlanningApplication{app}}
+
+	rec := serveSearch(t, store, testResolver(), searchPath("extension"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json; charset=utf-8" {
+		t.Errorf("content-type: got %q", ct)
+	}
+
+	var got SearchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Query != "extension" {
+		t.Errorf("query: got %q, want %q", got.Query, "extension")
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results: got %d, want 1", len(got.Results))
+	}
+	r := got.Results[0]
+	if r.Reference != app.Name {
+		t.Errorf("reference: got %q, want planit_name %q (NOT uid %q)", r.Reference, app.Name, app.UID)
+	}
+	if r.AuthoritySlug != "city-of-london" {
+		t.Errorf("authoritySlug: got %q, want %q", r.AuthoritySlug, "city-of-london")
+	}
+	if r.AuthorityName != app.AreaName {
+		t.Errorf("authorityName: got %q, want %q", r.AuthorityName, app.AreaName)
+	}
+	if r.Address != app.Address {
+		t.Errorf("address: got %q, want %q", r.Address, app.Address)
+	}
+	if r.AppState == nil || *r.AppState != "Permitted" {
+		t.Errorf("appState: got %v, want Permitted", r.AppState)
+	}
+	if r.DecidedDate == nil || r.DecidedDate.String() != "2026-06-01" {
+		t.Errorf("decidedDate: got %v, want 2026-06-01", r.DecidedDate)
+	}
+	if got.RefineQuery {
+		t.Error("refineQuery: got true, want false")
+	}
+}
+
+// TestSearchHandler_AuthorityParam proves the authority=<id-or-slug> filter
+// resolves a numeric id straight through, resolves a known slug via the
+// resolver, and 400s on an unresolvable slug (never reaching the store).
+func TestSearchHandler_AuthorityParam(t *testing.T) {
+	t.Parallel()
+
+	t.Run("numeric id passes through unchanged", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeSearchStore{}
+		rec := serveSearch(t, store, testResolver(), searchPath("abc")+"&authority=471")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status: got %d, want 200", rec.Code)
+		}
+		if store.lastAuthorityCode != "471" {
+			t.Errorf("authorityCode: got %q, want %q", store.lastAuthorityCode, "471")
+		}
+	})
+
+	t.Run("known slug resolves to its area id", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeSearchStore{}
+		rec := serveSearch(t, store, testResolver(), searchPath("abc")+"&authority=city-of-london")
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status: got %d, want 200", rec.Code)
+		}
+		if store.lastAuthorityCode != "471" {
+			t.Errorf("authorityCode: got %q, want %q", store.lastAuthorityCode, "471")
+		}
+	})
+
+	t.Run("unresolvable slug is a 400, store never called", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeSearchStore{}
+		rec := serveSearch(t, store, testResolver(), searchPath("abc")+"&authority=not-a-real-authority")
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("status: got %d, want 400", rec.Code)
+		}
+		if store.calls != 0 {
+			t.Errorf("store calls: got %d, want 0", store.calls)
+		}
+	})
+
+	t.Run("absent authority means no filter", func(t *testing.T) {
+		t.Parallel()
+		store := &fakeSearchStore{}
+		rec := serveSearch(t, store, testResolver(), searchPath("abc"))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status: got %d, want 200", rec.Code)
+		}
+		if store.lastAuthorityCode != "" {
+			t.Errorf("authorityCode: got %q, want empty (no filter)", store.lastAuthorityCode)
+		}
+	})
+}
+
+// TestSearchHandler_LimitClamping proves limit defaults to 20, is capped at 20,
+// and non-numeric/non-positive values fall back to the default.
+func TestSearchHandler_LimitClamping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		raw       string
+		wantLimit int
+	}{
+		{"unset defaults to 20", "", 20},
+		{"within range", "5", 5},
+		{"capped at 20", "9999", 20},
+		{"zero falls back to default", "0", 20},
+		{"negative falls back to default", "-3", 20},
+		{"non-numeric falls back to default", "abc", 20},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := &fakeSearchStore{}
+			path := searchPath("abc")
+			if tc.raw != "" {
+				path += "&limit=" + tc.raw
+			}
+			rec := serveSearch(t, store, testResolver(), path)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status: got %d, want 200", rec.Code)
+			}
+			if store.lastLimit != tc.wantLimit {
+				t.Errorf("limit: got %d, want %d", store.lastLimit, tc.wantLimit)
+			}
+		})
+	}
+}
+
+// TestSearchHandler_RefineQueryFlag proves the store's refine signal (more
+// matches exist than the capped limit) surfaces on the wire as refineQuery.
+func TestSearchHandler_RefineQueryFlag(t *testing.T) {
+	t.Parallel()
+	store := &fakeSearchStore{refine: true}
+	rec := serveSearch(t, store, testResolver(), searchPath("abc"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	var got SearchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.RefineQuery {
+		t.Error("refineQuery: got false, want true")
+	}
+}
+
+// TestSearchHandler_ResultsNeverNull proves an empty match set marshals to []
+// not null.
+func TestSearchHandler_ResultsNeverNull(t *testing.T) {
+	t.Parallel()
+	store := &fakeSearchStore{apps: nil}
+	rec := serveSearch(t, store, testResolver(), searchPath("abc"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if want := `"results":[]`; !strings.Contains(rec.Body.String(), want) {
+		t.Errorf("body missing %q; body=%s", want, rec.Body.String())
+	}
+}
+
+// TestSearchHandler_StoreErrorIsServerError proves a store failure is a bodyless
+// 500, mirroring every other handler in this package.
+func TestSearchHandler_StoreErrorIsServerError(t *testing.T) {
+	t.Parallel()
+	store := &fakeSearchStore{err: errBoom}
+	rec := serveSearch(t, store, testResolver(), searchPath("abc"))
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("status: got %d, want 500", rec.Code)
+	}
+}
+
+// TestSearchHandler_AuthoritySlugFallback proves an application whose area id
+// the resolver doesn't know falls back to slugifying its raw area name, exactly
+// like the by-id/by-slug handlers.
+func TestSearchHandler_AuthoritySlugFallback(t *testing.T) {
+	t.Parallel()
+	app := PlanningApplication{Name: "1/1", AreaName: "Some Unknown Council", AreaID: 999999}
+	store := &fakeSearchStore{apps: []PlanningApplication{app}}
+	rec := serveSearch(t, store, testResolver(), searchPath("abc"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var got SearchResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Results) != 1 {
+		t.Fatalf("results: got %d, want 1", len(got.Results))
+	}
+	if want := "some-unknown-council"; got.Results[0].AuthoritySlug != want {
+		t.Errorf("authoritySlug fallback: got %q, want %q", got.Results[0].AuthoritySlug, want)
+	}
+}

--- a/api-go/internal/applications/store_postgres.go
+++ b/api-go/internal/applications/store_postgres.go
@@ -40,6 +40,7 @@ type Store interface {
 	FindClustersInZone(ctx context.Context, q ClusterQuery) ([]Cluster, error)
 	RecentNearestTown(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64, siblings []TownCentroid, cap int) ([]PlanningApplication, error)
 	BreakdownNearby(ctx context.Context, authorityCode string, lat, lng, radiusMetres float64) ([]StateCount, error)
+	Search(ctx context.Context, query, authorityCode string, limit int) ([]PlanningApplication, bool, error)
 }
 
 // Compile-time check: the Postgres store satisfies the per-handler consumer-side
@@ -48,6 +49,7 @@ var (
 	_ appStore    = (*PostgresStore)(nil)
 	_ recentStore = (*PostgresStore)(nil)
 	_ nearStore   = (*PostgresStore)(nil)
+	_ searchStore = (*PostgresStore)(nil)
 	_ Store       = (*PostgresStore)(nil)
 )
 

--- a/api-go/internal/platform/postgres/migrations/0018_application_search_indexes.sql
+++ b/api-go/internal/platform/postgres/migrations/0018_application_search_indexes.sql
@@ -1,0 +1,46 @@
+-- +goose Up
+
+-- pg_trgm backs the address fuzzy-match tier of GET /v1/applications/search
+-- (#821 Phase 3): the `%` similarity operator and the similarity() ranking
+-- function. Allow-listed on Azure Database for PostgreSQL Flexible Server.
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Tier 2 (address fuzzy match): the query text is typically much shorter than
+-- the full address (a partial/typed-so-far fragment), so matching uses
+-- word_similarity (the <% / %> operator family) rather than plain similarity
+-- (%) — whole-string similarity would under-score a short, otherwise-exact
+-- fragment against a long address. A GIN trigram index on the LOWER-cased
+-- address (matching the lower(address) expression the query side uses, for
+-- case-insensitive matching) serves <%/%> without a sequential scan. Per
+-- pg_trgm convention, the index goes on the argument being searched into
+-- (address), not the search term.
+CREATE INDEX IF NOT EXISTS applications_address_trgm
+    ON applications USING gin (lower(address) gin_trgm_ops);
+
+-- Tier 3 (description full-text match): a GIN index over the `english`-config
+-- tsvector expression. This is an EXPRESSION index, not a stored generated
+-- column, so no change to the Upsert path or appColumns projection is needed —
+-- the query side re-derives the identical expression
+-- (to_tsvector('english', description)), which is what lets the planner match
+-- it to this index.
+CREATE INDEX IF NOT EXISTS applications_description_fts
+    ON applications USING gin (to_tsvector('english', description));
+
+-- Tier 1 (reference exact/prefix match): uid is the fuller, human-recognisable
+-- council planning reference (e.g. "24/0001/FUL") — distinct from planit_name,
+-- PlanIt's own shorter internal id (e.g. "24/0001") that the share/by-slug
+-- routes key on. uid carries no index today. A case-insensitive functional
+-- btree with text_pattern_ops serves both the exact form (lower(uid) = $1) and
+-- the prefix form (lower(uid) LIKE $1 || '%') without a sequential scan,
+-- regardless of the database's collation.
+CREATE INDEX IF NOT EXISTS applications_uid_lower_pattern
+    ON applications (lower(uid) text_pattern_ops);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS applications_uid_lower_pattern;
+DROP INDEX IF EXISTS applications_description_fts;
+DROP INDEX IF EXISTS applications_address_trgm;
+-- pg_trgm is intentionally left installed on Down: it may be shared by other
+-- objects, and re-creating it on a subsequent Up is cheap (IF NOT EXISTS) —
+-- mirroring the postgis extension's Down comment in 0001_init_postgis.sql.


### PR DESCRIPTION
## Changes

- `GET /v1/applications/search?q=&authority=&limit=` in `internal/applications` (`search.go`): handler, validation, `SearchResult`/`SearchResponse` wire types, `PostgresStore.Search`.
- Registered anonymously (`anonymousPatterns` in `cmd/api/wiring.go`) and rate-limited identically to every other anonymous route (RateLimit no-ops on a subject-less request — no new scheme needed). Postgres only — no PlanIt calls anywhere in this path.
- Migration `0018_application_search_indexes.sql`: `CREATE EXTENSION pg_trgm`, a GIN trigram index on `lower(address)` (word_similarity, since queries are short fragments of a longer address), a GIN index on `to_tsvector('english', description)`, plus a functional btree `lower(uid) text_pattern_ops` index so the tier-1 reference match doesn't sequential-scan.
- Ranking: one CTE query, tier 1 = `uid` exact/prefix match (case-insensitive) > tier 2 = address `word_similarity` > tier 3 = description `ts_rank`, deduplicated via `DISTINCT ON (area_id, planit_name)`.
- **Important column split, locked in with an explicit test**: tier-1 matches ranks against `uid` (the fuller council reference, matching this codebase's "application_uid" identity vocabulary), but the response's `reference` field is `planit_name` — the column the share page (`GetByAuthorityAndName`) actually resolves by. Returning `uid` there would 404 the share link whenever `uid != planit_name`, which is the common case.
- `looksLikeReference` heuristic (contains any digit) lets short queries skip the 3-char minimum cheaply, since it's an indexed lookup.
- `limit` capped/defaulted at 20, no cursor — over-limit truncates and sets `refineQuery: true`.
- Response shape: `{query, results:[{reference, authoritySlug, authorityName, address, appState, startDate, decidedDate}], refineQuery}`.

Tests: handler unit tests with hand-written fakes (`search_test.go`), real-DB integration tests for ranking/index behaviour per ADR 0032 (`search_integration_test.go`, `//go:build integration`), wiring/pattern-drift guard tests.

Part of epic tc-geq7h / GH #821 (Phase 3). Unblocks tc-geq7h.4 (public `/search` page).

Gates: `gofmt`, `go vet`, `golangci-lint run ./...`, `go test -race ./...` (1495 passed), `go build ./...`, and `go test -tags=integration ./...` (1660 passed against local Postgres+PostGIS) all green.

---
*Auto-shipped via ship skill*