### PR TITLE
feat(api): FCM push delivery for Android devices

### DIFF
--- a/api-go/cmd/worker/main.go
+++ b/api-go/cmd/worker/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/digest"
 	"github.com/AmyDe/town-crier/api-go/internal/dormant"
 	"github.com/AmyDe/town-crier/api-go/internal/erasure"
+	"github.com/AmyDe/town-crier/api-go/internal/fcm"
 	"github.com/AmyDe/town-crier/api-go/internal/metrics"
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/notificationstate"
@@ -370,8 +371,8 @@ func buildNotifyFanOut(cfg platform.Config, zoneStore watchzones.Store, st *stor
 		savedStore = st.savedApp
 	}
 
-	pushSender := buildPushSender(cfg, logger)
-	coalescer := notifydispatch.NewPushCoalescer(deviceStore, statePushStore, pushSender, zoneStore, logger)
+	pushDispatcher := buildPlatformDispatcher(cfg, logger)
+	coalescer := notifydispatch.NewPushCoalescer(deviceStore, statePushStore, pushDispatcher, zoneStore, logger)
 	enqueuer := notifydispatch.NewEnqueuer(
 		notifStore, zoneStore, profileStore, coalescer,
 		uuid.NewString, time.Now, logger,
@@ -496,7 +497,7 @@ func buildDigester(cfg platform.Config, st *stores, logger *slog.Logger) *digest
 	}
 
 	emailSender := buildEmailSender(cfg, logger)
-	pushSender := buildPushSender(cfg, logger)
+	dispatcher := buildPlatformDispatcher(cfg, logger)
 
 	return digest.NewHandler(
 		profileStore,
@@ -505,7 +506,7 @@ func buildDigester(cfg platform.Config, st *stores, logger *slog.Logger) *digest
 		st.notifState,
 		st.device,
 		emailSender,
-		pushSender,
+		dispatcher,
 		logger,
 		time.Now,
 	)
@@ -649,4 +650,38 @@ func buildPushSender(cfg platform.Config, logger *slog.Logger) apns.PushSender {
 		return apns.NewNoOpSender()
 	}
 	return client
+}
+
+// buildFCMSender returns the real FCM sender when FCM is enabled, else a NoOp so
+// a job without a service-account key boots cleanly (the mirror of
+// buildPushSender for Android delivery).
+func buildFCMSender(cfg platform.Config, logger *slog.Logger) fcm.PushSender {
+	if !cfg.FCMEnabled {
+		logger.Info("fcm disabled; android pushes disabled (NoOp sender)")
+		return fcm.NewNoOpSender()
+	}
+	client, err := fcm.NewClient(fcm.Options{
+		Enabled:            cfg.FCMEnabled,
+		ProjectID:          cfg.FCMProjectID,
+		ServiceAccountJSON: cfg.FCMServiceAccountJSON.Expose(),
+	}, logger, time.Now)
+	if err != nil {
+		logger.Error("build fcm client; falling back to NoOp sender", "error", err)
+		return fcm.NewNoOpSender()
+	}
+	logger.Info("fcm enabled", "projectId", cfg.FCMProjectID)
+	return client
+}
+
+// buildPlatformDispatcher wires the platform-aware push dispatcher over the APNs
+// (iOS) and FCM (Android) senders. Both send sites — the poll-cycle coalescer
+// and the weekly-digest handler — swap their single push sender for this one
+// dispatcher, which splits a recipient's tokens by platform and prunes the union
+// of tokens either sender reports invalid.
+func buildPlatformDispatcher(cfg platform.Config, logger *slog.Logger) *notifydispatch.PlatformDispatcher {
+	return notifydispatch.NewPlatformDispatcher(
+		buildPushSender(cfg, logger),
+		buildFCMSender(cfg, logger),
+		logger,
+	)
 }

--- a/api-go/internal/digest/fcm_handler_test.go
+++ b/api-go/internal/digest/fcm_handler_test.go
@@ -1,0 +1,157 @@
+package digest
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/profiles"
+)
+
+func TestBuildDigestFCMPayload_Shape(t *testing.T) {
+	t.Parallel()
+	raw, err := buildDigestFCMPayload(3)
+	if err != nil {
+		t.Fatalf("buildDigestFCMPayload: %v", err)
+	}
+	var parsed struct {
+		Notification struct {
+			Title string `json:"title"`
+			Body  string `json:"body"`
+		} `json:"notification"`
+		Android struct {
+			Priority     string `json:"priority"`
+			Notification struct {
+				ChannelID string `json:"channel_id"`
+			} `json:"notification"`
+		} `json:"android"`
+		Data map[string]string `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Notification.Title != "Town Crier" {
+		t.Errorf("title: got %q", parsed.Notification.Title)
+	}
+	if parsed.Notification.Body != "3 new applications this week" {
+		t.Errorf("body: got %q", parsed.Notification.Body)
+	}
+	if parsed.Android.Notification.ChannelID != "alerts" {
+		t.Errorf("channel_id: got %q", parsed.Android.Notification.ChannelID)
+	}
+	if parsed.Data["kind"] != "digest" {
+		t.Errorf("data.kind: got %q, want digest", parsed.Data["kind"])
+	}
+	// A digest push carries no deep-link keys and no badge.
+	if _, ok := parsed.Data["badge"]; ok {
+		t.Error("fcm digest must not carry a badge")
+	}
+	if _, ok := parsed.Data["notificationId"]; ok {
+		t.Error("fcm digest must not carry deep-link keys")
+	}
+}
+
+func TestRunWeekly_MixedRecipient_APNsToIosAndFCMToAndroid(t *testing.T) {
+	t.Parallel()
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = false
+	prefs.PushEnabled = true
+	p := mkProfile(t, profiles.TierPro, prefs)
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
+		"user-1": {zoneNotif("uid-A", "zone-1"), zoneNotif("uid-B", "zone-1")},
+	}}
+	state := &fakeState{unread: map[string]int{"user-1": 5}}
+	devices := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
+		"user-1": {
+			{UserID: "user-1", Token: "ios-tok", Platform: devicetokens.PlatformIos},
+			{UserID: "user-1", Token: "and-tok", Platform: devicetokens.PlatformAndroid},
+		},
+	}}
+	ios := &spyPush{}
+	android := &spyPush{}
+	h := newHandlerWithDispatcher(fp, fn, &fakeZones{}, state, devices, &spyEmail{}, &fakeDispatcher{ios: ios, android: android})
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+
+	if ios.calls != 1 || len(ios.tokens) != 1 || ios.tokens[0] != "ios-tok" {
+		t.Errorf("apns should get the iOS token, got calls=%d tokens=%v", ios.calls, ios.tokens)
+	}
+	if android.calls != 1 || len(android.tokens) != 1 || android.tokens[0] != "and-tok" {
+		t.Errorf("fcm should get the Android token, got calls=%d tokens=%v", android.calls, android.tokens)
+	}
+
+	// APNs body: aps digest shape with the badge and rendered body.
+	var apnsParsed struct {
+		Aps struct {
+			Badge int `json:"badge"`
+			Alert struct {
+				Body string `json:"body"`
+			} `json:"alert"`
+		} `json:"aps"`
+	}
+	if err := json.Unmarshal(ios.payload, &apnsParsed); err != nil {
+		t.Fatalf("apns unmarshal: %v", err)
+	}
+	if apnsParsed.Aps.Badge != 5 {
+		t.Errorf("apns badge: got %d, want 5", apnsParsed.Aps.Badge)
+	}
+	if apnsParsed.Aps.Alert.Body != "2 new applications this week" {
+		t.Errorf("apns body: got %q", apnsParsed.Aps.Alert.Body)
+	}
+
+	// FCM body: message shape, kind=digest, same body copy, no badge.
+	var fcmParsed struct {
+		Notification struct {
+			Body string `json:"body"`
+		} `json:"notification"`
+		Data map[string]string `json:"data"`
+	}
+	if err := json.Unmarshal(android.payload, &fcmParsed); err != nil {
+		t.Fatalf("fcm unmarshal: %v", err)
+	}
+	if fcmParsed.Data["kind"] != "digest" {
+		t.Errorf("fcm kind: got %q, want digest", fcmParsed.Data["kind"])
+	}
+	if fcmParsed.Notification.Body != "2 new applications this week" {
+		t.Errorf("fcm body: got %q", fcmParsed.Notification.Body)
+	}
+}
+
+func TestRunWeekly_AndroidOnlyRecipient_PrunesInvalidFCMTokenNoAPNs(t *testing.T) {
+	t.Parallel()
+	prefs := profiles.DefaultPreferences()
+	prefs.EmailDigestEnabled = false
+	prefs.PushEnabled = true
+	p := mkProfile(t, profiles.TierPro, prefs)
+
+	fp := &fakeProfiles{byDay: map[time.Weekday][]*profiles.UserProfile{time.Wednesday: {p}}}
+	fn := &fakeNotifications{sinceByUser: map[string][]notifications.DigestNotification{
+		"user-1": {zoneNotif("uid-A", "zone-1")},
+	}}
+	devices := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
+		"user-1": {{UserID: "user-1", Token: "and-dead", Platform: devicetokens.PlatformAndroid}},
+	}}
+	ios := &spyPush{}
+	android := &spyPush{invalid: []string{"and-dead"}}
+	h := newHandlerWithDispatcher(fp, fn, &fakeZones{}, &fakeState{unread: map[string]int{}}, devices, &spyEmail{}, &fakeDispatcher{ios: ios, android: android})
+
+	if err := h.RunWeekly(context.Background()); err != nil {
+		t.Fatalf("RunWeekly: %v", err)
+	}
+	if ios.calls != 0 {
+		t.Errorf("android-only recipient must not hit APNs, got %d", ios.calls)
+	}
+	if android.calls != 1 {
+		t.Errorf("android-only recipient must hit FCM once, got %d", android.calls)
+	}
+	if len(devices.deleted) != 1 || devices.deleted[0] != "and-dead" {
+		t.Errorf("pruned = %v, want [and-dead]", devices.deleted)
+	}
+}

--- a/api-go/internal/digest/handler.go
+++ b/api-go/internal/digest/handler.go
@@ -65,11 +65,12 @@ type deviceReader interface {
 	Delete(ctx context.Context, userID, token string) error
 }
 
-// pushSender is the consumer-side push contract; apns.PushSender (the real Client
-// or the NoOpSender) satisfies it. It is declared locally so the handler test can
-// substitute a spy without importing apns.
-type pushSender interface {
-	Send(ctx context.Context, tokens []string, payload json.RawMessage) ([]string, error)
+// pushDispatcher is the consumer-side platform-aware push contract; the concrete
+// *notifydispatch.PlatformDispatcher satisfies it. It is declared locally (with
+// the platform token split expressed in the signature) so the handler test can
+// substitute a fake without importing notifydispatch.
+type pushDispatcher interface {
+	Send(ctx context.Context, iosTokens []string, iosPayload json.RawMessage, androidTokens []string, androidPayload json.RawMessage) ([]string, error)
 }
 
 // Handler runs the weekly and hourly digest cycles. It holds the stores and the
@@ -81,7 +82,7 @@ type Handler struct {
 	state         stateReader
 	devices       deviceReader
 	email         acsemail.EmailSender
-	push          pushSender
+	dispatcher    pushDispatcher
 	logger        *slog.Logger
 	now           func() time.Time
 }
@@ -96,7 +97,7 @@ func NewHandler(
 	state stateReader,
 	devices deviceReader,
 	email acsemail.EmailSender,
-	push pushSender,
+	dispatcher pushDispatcher,
 	logger *slog.Logger,
 	now func() time.Time,
 ) *Handler {
@@ -107,7 +108,7 @@ func NewHandler(
 		state:         state,
 		devices:       devices,
 		email:         email,
-		push:          push,
+		dispatcher:    dispatcher,
 		logger:        logger,
 		now:           now,
 	}
@@ -160,10 +161,11 @@ func (h *Handler) RunWeekly(ctx context.Context) error {
 	return nil
 }
 
-// sendWeeklyPush builds and sends the weekly digest push, then prunes any device
-// tokens APNs reports invalid. A user with no devices is a no-op. The badge is
+// sendWeeklyPush builds and sends the weekly digest push across both platforms
+// (APNs for iOS tokens, FCM for Android tokens), then prunes any device tokens
+// either sender reports invalid. A user with no devices is a no-op. The badge is
 // the total unread count (read_at IS NULL, ADR 0035), distinct from the digest
-// application count.
+// application count; FCM carries no badge (Android badges are channel-driven).
 func (h *Handler) sendWeeklyPush(ctx context.Context, profile *profiles.UserProfile, applicationCount int) {
 	devices, err := h.devices.ListByUser(ctx, profile.UserID)
 	if err != nil {
@@ -180,18 +182,34 @@ func (h *Handler) sendWeeklyPush(ctx context.Context, profile *profiles.UserProf
 		return
 	}
 
-	payload, err := buildDigestPayload(applicationCount, totalUnread)
-	if err != nil {
-		h.logger.ErrorContext(ctx, "weekly digest: build payload failed", "user", profile.UserID, "error", err)
-		return
-	}
-
-	tokens := make([]string, 0, len(devices))
+	var iosTokens, androidTokens []string
 	for _, d := range devices {
-		tokens = append(tokens, d.Token)
+		if d.Platform == devicetokens.PlatformAndroid {
+			androidTokens = append(androidTokens, d.Token)
+			continue
+		}
+		iosTokens = append(iosTokens, d.Token)
 	}
 
-	invalid, err := h.push.Send(ctx, tokens, payload)
+	var iosPayload, androidPayload json.RawMessage
+	if len(iosTokens) > 0 {
+		p, err := buildDigestPayload(applicationCount, totalUnread)
+		if err != nil {
+			h.logger.ErrorContext(ctx, "weekly digest: build apns payload failed", "user", profile.UserID, "error", err)
+			return
+		}
+		iosPayload = p
+	}
+	if len(androidTokens) > 0 {
+		p, err := buildDigestFCMPayload(applicationCount)
+		if err != nil {
+			h.logger.ErrorContext(ctx, "weekly digest: build fcm payload failed", "user", profile.UserID, "error", err)
+			return
+		}
+		androidPayload = p
+	}
+
+	invalid, err := h.dispatcher.Send(ctx, iosTokens, iosPayload, androidTokens, androidPayload)
 	if err != nil {
 		h.logger.ErrorContext(ctx, "weekly digest: push send failed", "user", profile.UserID, "error", err)
 		return

--- a/api-go/internal/digest/handler_test.go
+++ b/api-go/internal/digest/handler_test.go
@@ -123,6 +123,29 @@ func (s *spyPush) Send(_ context.Context, tokens []string, payload json.RawMessa
 	return s.invalid, nil
 }
 
+// fakeDispatcher mirrors the real *notifydispatch.PlatformDispatcher's token
+// split: it routes the iOS payload to ios and the Android payload to android,
+// unioning any invalid tokens. It lets the digest handler test assert
+// platform-aware delivery without importing notifydispatch — and lets the
+// pre-existing iOS-only weekly tests keep inspecting the ios spy unchanged.
+type fakeDispatcher struct {
+	ios     *spyPush
+	android *spyPush
+}
+
+func (d *fakeDispatcher) Send(ctx context.Context, iosTokens []string, iosPayload json.RawMessage, androidTokens []string, androidPayload json.RawMessage) ([]string, error) {
+	var invalid []string
+	if len(iosTokens) > 0 {
+		inv, _ := d.ios.Send(ctx, iosTokens, iosPayload)
+		invalid = append(invalid, inv...)
+	}
+	if len(androidTokens) > 0 {
+		inv, _ := d.android.Send(ctx, androidTokens, androidPayload)
+		invalid = append(invalid, inv...)
+	}
+	return invalid, nil
+}
+
 // ---- helpers ----
 
 func testLogger() *slog.Logger {
@@ -165,10 +188,16 @@ func zoneNotif(uid, zoneID string) notifications.DigestNotification {
 	}
 }
 
-func newHandler(p *fakeProfiles, n *fakeNotifications, z *fakeZones, st *fakeState, d *fakeDevices, email acsemail.EmailSender, push interface {
-	Send(context.Context, []string, json.RawMessage) ([]string, error)
-}) *Handler {
-	return NewHandler(p, n, z, st, d, email, push, testLogger(), func() time.Time {
+// newHandler wires a handler whose weekly push routes iOS tokens to the given
+// spy (the platform the pre-existing weekly tests exercise). The Android sender
+// is a throwaway spy those tests never reach; tests needing the FCM path build
+// their own fakeDispatcher via newHandlerWithDispatcher.
+func newHandler(p *fakeProfiles, n *fakeNotifications, z *fakeZones, st *fakeState, d *fakeDevices, email acsemail.EmailSender, push *spyPush) *Handler {
+	return newHandlerWithDispatcher(p, n, z, st, d, email, &fakeDispatcher{ios: push, android: &spyPush{}})
+}
+
+func newHandlerWithDispatcher(p *fakeProfiles, n *fakeNotifications, z *fakeZones, st *fakeState, d *fakeDevices, email acsemail.EmailSender, dispatcher pushDispatcher) *Handler {
+	return NewHandler(p, n, z, st, d, email, dispatcher, testLogger(), func() time.Time {
 		// Pin "now" to a Wednesday so weekly tests select the Wednesday digest day.
 		return time.Date(2026, 2, 4, 9, 0, 0, 0, time.UTC) // 2026-02-04 is a Wednesday
 	})

--- a/api-go/internal/digest/payload.go
+++ b/api-go/internal/digest/payload.go
@@ -22,26 +22,77 @@ type apnsAlertContent struct {
 	Body  string `json:"body"`
 }
 
+// digestTitle is the title both the APNs and FCM digest pushes carry.
+const digestTitle = "Town Crier"
+
+// digestBody renders the digest push body copy ("N new application(s) this
+// week"). Shared by the APNs and FCM builders so the two platforms render
+// byte-identical copy for the same digest.
+func digestBody(applicationCount int) string {
+	plural := "s"
+	if applicationCount == 1 {
+		plural = ""
+	}
+	return fmt.Sprintf("%d new application%s this week", applicationCount, plural)
+}
+
 // buildDigestPayload renders the APNs digest push body. applicationCount is the
 // number of applications in the digest window (rendered in the body copy);
 // totalUnreadCount is the user's total unread tally surfaced as the app icon
 // badge — the two are deliberately distinct.
 func buildDigestPayload(applicationCount, totalUnreadCount int) (json.RawMessage, error) {
-	plural := "s"
-	if applicationCount == 1 {
-		plural = ""
-	}
-	body := fmt.Sprintf("%d new application%s this week", applicationCount, plural)
-
 	raw, err := json.Marshal(apnsDigestPayload{
 		Aps: apnsDigestAps{
-			Alert: apnsAlertContent{Title: "Town Crier", Body: body},
+			Alert: apnsAlertContent{Title: digestTitle, Body: digestBody(applicationCount)},
 			Sound: "default",
 			Badge: totalUnreadCount,
 		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal digest payload: %w", err)
+	}
+	return raw, nil
+}
+
+// fcmDigestMessage is the FCM HTTP v1 "message" object for the weekly digest
+// push, minus the per-recipient token (fcm.Client injects it). It mirrors the
+// APNs digest shape: a system-rendered notification with the same title/body,
+// plus a data dictionary carrying kind=digest (the #777 routing discriminator).
+// A digest push opens the app, so it carries no deep-link keys; there is no
+// badge field (Android badges are channel-driven).
+type fcmDigestMessage struct {
+	Notification fcmDigestNotification `json:"notification"`
+	Android      fcmDigestAndroid      `json:"android"`
+	Data         map[string]string     `json:"data"`
+}
+
+type fcmDigestNotification struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+type fcmDigestAndroid struct {
+	Priority     string                       `json:"priority"`
+	Notification fcmDigestAndroidNotification `json:"notification"`
+}
+
+type fcmDigestAndroidNotification struct {
+	ChannelID string `json:"channel_id"`
+}
+
+// buildDigestFCMPayload renders the weekly digest FCM push body, carrying the
+// same title/body copy as the APNs digest push.
+func buildDigestFCMPayload(applicationCount int) (json.RawMessage, error) {
+	raw, err := json.Marshal(fcmDigestMessage{
+		Notification: fcmDigestNotification{Title: digestTitle, Body: digestBody(applicationCount)},
+		Android: fcmDigestAndroid{
+			Priority:     "HIGH",
+			Notification: fcmDigestAndroidNotification{ChannelID: "alerts"},
+		},
+		Data: map[string]string{"kind": "digest"},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal digest fcm payload: %w", err)
 	}
 	return raw, nil
 }

--- a/api-go/internal/fcm/client.go
+++ b/api-go/internal/fcm/client.go
@@ -1,0 +1,230 @@
+package fcm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+const (
+	// maxRespBytes bounds the FCM error body read. FCM error bodies are a few
+	// hundred bytes; 64 KiB is a generous ceiling.
+	maxRespBytes = 64 << 10
+	// requestTimeout bounds a single FCM (or token) HTTP request.
+	requestTimeout = 30 * time.Second
+)
+
+// fcmErrorResponse is the FCM v1 non-2xx body. The google.rpc.Status carries the
+// canonical status (e.g. NOT_FOUND); the FcmError detail carries the
+// FCM-specific errorCode (e.g. UNREGISTERED) used to decide whether a token is
+// permanently invalid.
+type fcmErrorResponse struct {
+	Error struct {
+		Code    int    `json:"code"`
+		Status  string `json:"status"`
+		Message string `json:"message"`
+		Details []struct {
+			ErrorCode string `json:"errorCode"`
+		} `json:"details"`
+	} `json:"error"`
+}
+
+// Client is a direct FCM HTTP v1 push sender. It posts one request per device
+// token (v1 has no multicast), attaches a cached service-account OAuth bearer,
+// injects each token into the message body, and reports tokens FCM has rejected
+// as permanently invalid (UNREGISTERED / INVALID_ARGUMENT) so the caller can
+// prune them. It mirrors apns.Client's shape and per-device-failure contract.
+type Client struct {
+	http      *http.Client
+	tokens    *tokenProvider
+	projectID string
+	baseURL   string
+	logger    *slog.Logger
+	now       func() time.Time
+}
+
+// NewClient builds a production FCM client from validated options. The caller
+// guarantees opts.Enabled is true; when disabled, wire a NoOpSender instead.
+func NewClient(opts Options, logger *slog.Logger, now func() time.Time) (*Client, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+
+	httpClient := &http.Client{Timeout: requestTimeout}
+	// Wrap the transport so every FCM push emits an OTel client span (Type=HTTP
+	// in AppDependencies) named "FCM push". The static span name keeps
+	// cardinality low (no per-device token in the name), matching the APNs client.
+	httpClient = platform.WrapHTTPClient(httpClient, func(string, *http.Request) string { return "FCM push" })
+	return newClientWithBaseURL(opts, productionBaseURL, httpClient, logger, now)
+}
+
+// newClientWithBaseURL is the constructor seam shared by NewClient and tests. It
+// takes an explicit FCM base URL and HTTP client; the token endpoint URL comes
+// from the service-account JSON, so a test can point both at httptest servers.
+func newClientWithBaseURL(opts Options, baseURL string, httpClient *http.Client, logger *slog.Logger, now func() time.Time) (*Client, error) {
+	tokens, err := newTokenProvider([]byte(opts.ServiceAccountJSON), httpClient, now)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{
+		http:      httpClient,
+		tokens:    tokens,
+		projectID: opts.ProjectID,
+		baseURL:   baseURL,
+		logger:    logger,
+		now:       now,
+	}, nil
+}
+
+// Send posts payload to each device token and returns the subset of tokens FCM
+// rejected as permanently invalid. A per-device transport or server error is
+// logged and skipped (the token is left for the next cycle), never returned as
+// an error — one bad device must not abort the rest. payload is the FCM v1
+// "message" object WITHOUT the token; Send injects each token itself.
+func (c *Client) Send(ctx context.Context, tokens []string, payload json.RawMessage) ([]string, error) {
+	if len(tokens) == 0 {
+		return nil, nil
+	}
+
+	invalid := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		rejected, err := c.sendOne(ctx, token, payload)
+		if err != nil {
+			c.logger.ErrorContext(ctx, "fcm send failed", "token", redactToken(token), "error", err)
+			continue
+		}
+		if rejected {
+			invalid = append(invalid, token)
+		}
+	}
+	if len(invalid) == 0 {
+		return nil, nil
+	}
+	return invalid, nil
+}
+
+// sendOne posts payload to a single device token, returning rejected=true when
+// FCM reports the token is permanently invalid. There is no retry loop day-1
+// (parity with the epic's APNs-parity scope): a transient 5xx/429 is logged and
+// skipped, the token left for the next cycle.
+func (c *Client) sendOne(ctx context.Context, token string, payload json.RawMessage) (rejected bool, err error) {
+	bearer, err := c.tokens.current(ctx)
+	if err != nil {
+		return false, fmt.Errorf("fcm: obtain access token: %w", err)
+	}
+
+	body, err := withToken(payload, token)
+	if err != nil {
+		return false, err
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+	defer cancel()
+
+	url := c.baseURL + "/v1/projects/" + c.projectID + "/messages:send"
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return false, fmt.Errorf("fcm: build request: %w", err)
+	}
+	req.Header.Set("authorization", "Bearer "+bearer)
+	req.Header.Set("content-type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("fcm: request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, maxRespBytes))
+	if err != nil {
+		return false, fmt.Errorf("fcm: read response: %w", err)
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return false, nil
+	}
+
+	status, errorCode := parseError(respBody)
+	if isInvalidToken(resp.StatusCode, status, errorCode) {
+		c.logger.InfoContext(ctx, "fcm token rejected", "token", redactToken(token), "status", status, "errorCode", errorCode)
+		return true, nil
+	}
+	c.logger.WarnContext(ctx, "fcm unhandled status", "http", resp.StatusCode, "status", status, "errorCode", errorCode, "token", redactToken(token))
+	return false, nil
+}
+
+// isInvalidToken reports whether an FCM error identifies the device token itself
+// as permanently invalid (so it should be pruned), as opposed to a transient or
+// server-side fault. UNREGISTERED (device uninstalled / token rotated) and
+// INVALID_ARGUMENT (malformed token) are terminal; a NOT_FOUND canonical status
+// (HTTP 404) covers the same "token gone" case when no FcmError detail is
+// present.
+func isInvalidToken(httpStatus int, status, errorCode string) bool {
+	switch errorCode {
+	case "UNREGISTERED", "INVALID_ARGUMENT":
+		return true
+	}
+	if status == "NOT_FOUND" || httpStatus == http.StatusNotFound {
+		return true
+	}
+	return false
+}
+
+// parseError extracts the canonical status and the FCM-specific errorCode from a
+// non-2xx FCM body, returning empty strings when the body is absent or not the
+// expected shape.
+func parseError(body []byte) (status, errorCode string) {
+	if len(body) == 0 {
+		return "", ""
+	}
+	var parsed fcmErrorResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", ""
+	}
+	if len(parsed.Error.Details) > 0 {
+		errorCode = parsed.Error.Details[0].ErrorCode
+	}
+	return parsed.Error.Status, errorCode
+}
+
+// withToken injects the per-recipient token into a token-less FCM message object
+// and wraps it in the {"message":{...}} envelope the v1 send endpoint expects.
+// The message fields are preserved verbatim; only the token key is added.
+func withToken(message json.RawMessage, token string) ([]byte, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(message, &fields); err != nil {
+		return nil, fmt.Errorf("fcm: parse message payload: %w", err)
+	}
+	tokenJSON, err := json.Marshal(token)
+	if err != nil {
+		return nil, fmt.Errorf("fcm: marshal token: %w", err)
+	}
+	fields["token"] = tokenJSON
+
+	envelope := struct {
+		Message map[string]json.RawMessage `json:"message"`
+	}{Message: fields}
+	return json.Marshal(envelope)
+}
+
+// redactToken keeps only an 8-character prefix so device tokens — which identify
+// a user's device — never land in logs in full.
+func redactToken(token string) string {
+	if len(token) <= 8 {
+		return "***"
+	}
+	return token[:8] + "..."
+}
+
+// compile-time assertions that both senders satisfy the consumer contract.
+var (
+	_ PushSender = (*Client)(nil)
+	_ PushSender = (*NoOpSender)(nil)
+)

--- a/api-go/internal/fcm/client_test.go
+++ b/api-go/internal/fcm/client_test.go
@@ -1,0 +1,299 @@
+package fcm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.DiscardHandler)
+}
+
+// tokenServer returns an httptest server that answers the OAuth token exchange
+// with a fixed access token, counting how often it is called.
+func tokenServer(t *testing.T) (*httptest.Server, func() int) {
+	t.Helper()
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		_, _ = w.Write([]byte(`{"access_token":"ya29.test","expires_in":3599,"token_type":"Bearer"}`))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, func() int { mu.Lock(); defer mu.Unlock(); return calls }
+}
+
+// newTestClient builds a Client whose FCM send requests target fcmSrv and whose
+// token exchange targets tokenSrv (via the service-account JSON's token_uri).
+func newTestClient(t *testing.T, fcmSrv, tokenSrv *httptest.Server) *Client {
+	t.Helper()
+	pemBytes, _ := newTestKeyPEM(t)
+	opts := Options{
+		Enabled:            true,
+		ProjectID:          "town-crier-test",
+		ServiceAccountJSON: newTestServiceAccountJSON(t, tokenSrv.URL, pemBytes),
+	}
+	client, err := newClientWithBaseURL(opts, fcmSrv.URL, &http.Client{}, testLogger(), fixedClock(1_700_000_000))
+	if err != nil {
+		t.Fatalf("newClientWithBaseURL: %v", err)
+	}
+	return client
+}
+
+func TestClient_SendsCorrectRequestShape(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotPath string
+		gotAuth string
+		gotBody []byte
+		mu      sync.Mutex
+	)
+	fcmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("authorization")
+		gotBody = body
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fcmSrv.Close()
+	tokenSrv, _ := tokenServer(t)
+
+	client := newTestClient(t, fcmSrv, tokenSrv)
+	// The message the dispatcher hands us carries no token — the client injects it.
+	payload := json.RawMessage(`{"notification":{"title":"hi","body":"there"},"data":{"kind":"alert"}}`)
+
+	invalid, err := client.Send(context.Background(), []string{"abc123token"}, payload)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(invalid) != 0 {
+		t.Fatalf("invalid = %v, want none", invalid)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if gotPath != "/v1/projects/town-crier-test/messages:send" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotAuth != "Bearer ya29.test" {
+		t.Errorf("authorization = %q, want Bearer ya29.test", gotAuth)
+	}
+
+	// The request body must be {"message":{...,"token":"abc123token"}} with the
+	// dispatcher's message fields preserved verbatim.
+	var envelope struct {
+		Message struct {
+			Token        string `json:"token"`
+			Notification struct {
+				Title string `json:"title"`
+				Body  string `json:"body"`
+			} `json:"notification"`
+			Data struct {
+				Kind string `json:"kind"`
+			} `json:"data"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(gotBody, &envelope); err != nil {
+		t.Fatalf("unmarshal body %q: %v", gotBody, err)
+	}
+	if envelope.Message.Token != "abc123token" {
+		t.Errorf("message.token = %q, want abc123token", envelope.Message.Token)
+	}
+	if envelope.Message.Notification.Title != "hi" || envelope.Message.Notification.Body != "there" {
+		t.Errorf("notification not preserved: %+v", envelope.Message.Notification)
+	}
+	if envelope.Message.Data.Kind != "alert" {
+		t.Errorf("data.kind = %q, want alert", envelope.Message.Data.Kind)
+	}
+}
+
+func TestClient_InjectsDistinctTokenPerRequest(t *testing.T) {
+	t.Parallel()
+
+	var (
+		gotTokens []string
+		mu        sync.Mutex
+	)
+	fcmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var envelope struct {
+			Message struct {
+				Token string `json:"token"`
+			} `json:"message"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &envelope)
+		mu.Lock()
+		gotTokens = append(gotTokens, envelope.Message.Token)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fcmSrv.Close()
+	tokenSrv, _ := tokenServer(t)
+
+	client := newTestClient(t, fcmSrv, tokenSrv)
+	if _, err := client.Send(context.Background(), []string{"tok-a", "tok-b"}, json.RawMessage(`{"data":{}}`)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(gotTokens) != 2 {
+		t.Fatalf("requests = %d, want 2 (one per token)", len(gotTokens))
+	}
+	got := map[string]bool{gotTokens[0]: true, gotTokens[1]: true}
+	if !got["tok-a"] || !got["tok-b"] {
+		t.Errorf("tokens = %v, want tok-a and tok-b", gotTokens)
+	}
+}
+
+func TestClient_ReportsUnregisteredTokenAsInvalid(t *testing.T) {
+	t.Parallel()
+
+	fcmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"code":404,"status":"NOT_FOUND","message":"Requested entity was not found.","details":[{"@type":"type.googleapis.com/google.firebase.fcm.v1.FcmError","errorCode":"UNREGISTERED"}]}}`))
+	}))
+	defer fcmSrv.Close()
+	tokenSrv, _ := tokenServer(t)
+
+	client := newTestClient(t, fcmSrv, tokenSrv)
+	invalid, err := client.Send(context.Background(), []string{"deadtoken"}, json.RawMessage(`{"data":{}}`))
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(invalid) != 1 || invalid[0] != "deadtoken" {
+		t.Fatalf("invalid = %v, want [deadtoken]", invalid)
+	}
+}
+
+func TestClient_ReportsInvalidArgumentAsInvalid(t *testing.T) {
+	t.Parallel()
+
+	fcmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":400,"status":"INVALID_ARGUMENT","message":"The registration token is not a valid FCM registration token","details":[{"@type":"type.googleapis.com/google.firebase.fcm.v1.FcmError","errorCode":"INVALID_ARGUMENT"}]}}`))
+	}))
+	defer fcmSrv.Close()
+	tokenSrv, _ := tokenServer(t)
+
+	client := newTestClient(t, fcmSrv, tokenSrv)
+	invalid, err := client.Send(context.Background(), []string{"badtoken"}, json.RawMessage(`{"data":{}}`))
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(invalid) != 1 || invalid[0] != "badtoken" {
+		t.Fatalf("invalid = %v, want [badtoken]", invalid)
+	}
+}
+
+func TestClient_TransientErrorIsSkippedNotPrunedAndNotRetried(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	fcmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"error":{"code":503,"status":"UNAVAILABLE","message":"The service is currently unavailable."}}`))
+	}))
+	defer fcmSrv.Close()
+	tokenSrv, _ := tokenServer(t)
+
+	client := newTestClient(t, fcmSrv, tokenSrv)
+	invalid, err := client.Send(context.Background(), []string{"tok"}, json.RawMessage(`{"data":{}}`))
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(invalid) != 0 {
+		t.Fatalf("invalid = %v, want none (transient error must not prune)", invalid)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1 (no retry loop day-1)", calls)
+	}
+}
+
+func TestClient_CachesAccessTokenAcrossSends(t *testing.T) {
+	t.Parallel()
+
+	fcmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer fcmSrv.Close()
+	tokenSrv, tokenCalls := tokenServer(t)
+
+	client := newTestClient(t, fcmSrv, tokenSrv)
+	for range 3 {
+		if _, err := client.Send(context.Background(), []string{"tok"}, json.RawMessage(`{"data":{}}`)); err != nil {
+			t.Fatalf("Send: %v", err)
+		}
+	}
+	if tokenCalls() != 1 {
+		t.Errorf("token endpoint calls = %d, want 1 (access token cached across sends)", tokenCalls())
+	}
+}
+
+func TestClient_EmptyTokensIsNoop(t *testing.T) {
+	t.Parallel()
+
+	fcmSrv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("FCM server should not be called with no tokens")
+	}))
+	defer fcmSrv.Close()
+	tokenSrv, tokenCalls := tokenServer(t)
+
+	client := newTestClient(t, fcmSrv, tokenSrv)
+	invalid, err := client.Send(context.Background(), nil, json.RawMessage(`{"data":{}}`))
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(invalid) != 0 {
+		t.Fatalf("invalid = %v, want none", invalid)
+	}
+	if tokenCalls() != 0 {
+		t.Errorf("token endpoint must not be hit for an empty send, got %d", tokenCalls())
+	}
+}
+
+func TestNoOpSender_SendReturnsNoInvalidTokens(t *testing.T) {
+	t.Parallel()
+
+	sender := NewNoOpSender()
+	invalid, err := sender.Send(context.Background(), []string{"a", "b"}, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(invalid) != 0 {
+		t.Fatalf("invalid = %v, want none", invalid)
+	}
+}
+
+func TestNewClient_DisabledOptionsValidateNoop(t *testing.T) {
+	t.Parallel()
+	// A disabled option set must not require project id / service account.
+	if err := (Options{Enabled: false}).validate(); err != nil {
+		t.Fatalf("disabled validate: %v", err)
+	}
+	if err := (Options{Enabled: true, ProjectID: "p"}).validate(); err == nil {
+		t.Fatal("enabled without service account must fail validation")
+	}
+}

--- a/api-go/internal/fcm/errors.go
+++ b/api-go/internal/fcm/errors.go
@@ -1,0 +1,12 @@
+package fcm
+
+import "errors"
+
+// ErrInvalidServiceAccount reports that the configured FCM service-account JSON
+// is missing, malformed, or does not carry the RSA private key / client email /
+// token URI a JWT-bearer token exchange needs.
+var ErrInvalidServiceAccount = errors.New("fcm: invalid service account")
+
+// ErrInvalidOptions reports that the FCM options are enabled but incomplete
+// (missing project id or service-account JSON).
+var ErrInvalidOptions = errors.New("fcm: invalid options")

--- a/api-go/internal/fcm/noop.go
+++ b/api-go/internal/fcm/noop.go
@@ -1,0 +1,19 @@
+package fcm
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// NoOpSender is wired when FCM is disabled (no service-account JSON configured),
+// so a worker job boots cleanly without a real FCM endpoint. It drops every push
+// and reports no invalid tokens — the mirror of apns.NoOpSender.
+type NoOpSender struct{}
+
+// NewNoOpSender returns a sender that does nothing.
+func NewNoOpSender() *NoOpSender { return &NoOpSender{} }
+
+// Send discards the push and returns no invalid tokens.
+func (NoOpSender) Send(context.Context, []string, json.RawMessage) ([]string, error) {
+	return nil, nil
+}

--- a/api-go/internal/fcm/options.go
+++ b/api-go/internal/fcm/options.go
@@ -1,0 +1,42 @@
+package fcm
+
+import "fmt"
+
+// firebaseMessagingScope is the OAuth2 scope a service-account access token must
+// carry to call the FCM HTTP v1 send endpoint.
+const firebaseMessagingScope = "https://www.googleapis.com/auth/firebase.messaging"
+
+// productionBaseURL is the FCM HTTP v1 host. The per-project send path
+// (/v1/projects/{id}/messages:send) is appended by the client; the host is a
+// well-known Google endpoint, not configurable infrastructure.
+const productionBaseURL = "https://fcm.googleapis.com"
+
+// Options configures the FCM sender. When Enabled is false the caller wires a
+// NoOpSender so a worker without a service-account key boots cleanly. When true,
+// ProjectID and ServiceAccountJSON must both be populated.
+type Options struct {
+	// Enabled gates whether a real sender is constructed.
+	Enabled bool
+	// ProjectID is the Firebase/GCP project id the send URL targets
+	// (/v1/projects/{ProjectID}/messages:send).
+	ProjectID string
+	// ServiceAccountJSON is the full service-account key JSON blob (the same
+	// document Firebase issues), carrying the RSA private key, client email, and
+	// token URI the JWT-bearer OAuth exchange uses.
+	ServiceAccountJSON string
+}
+
+// validate checks the required fields when the sender is enabled. It is a no-op
+// when disabled so a worker without FCM config boots without the fields.
+func (o Options) validate() error {
+	if !o.Enabled {
+		return nil
+	}
+	if o.ProjectID == "" {
+		return fmt.Errorf("fcm: %w: ProjectID is empty", ErrInvalidOptions)
+	}
+	if o.ServiceAccountJSON == "" {
+		return fmt.Errorf("fcm: %w: ServiceAccountJSON is empty", ErrInvalidOptions)
+	}
+	return nil
+}

--- a/api-go/internal/fcm/sender.go
+++ b/api-go/internal/fcm/sender.go
@@ -1,0 +1,23 @@
+package fcm
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// PushSender is the contract the platform-aware dispatcher consumes to deliver a
+// pre-built FCM message body to a set of Android device tokens, learning which
+// tokens FCM has permanently rejected so they can be pruned. It mirrors
+// apns.PushSender exactly (same signature) so the dispatcher can treat both
+// platforms uniformly.
+//
+// The payload is the FCM v1 "message" object WITHOUT the per-recipient token —
+// the Client injects each token itself, since v1 has no multicast and posts one
+// request per device.
+type PushSender interface {
+	// Send delivers payload to each token, returning the tokens FCM reported as
+	// permanently invalid (UNREGISTERED / INVALID_ARGUMENT). It never returns an
+	// error for a per-device failure — those are logged and skipped; an error is
+	// reserved for a caller-level fault (e.g. a cancelled context).
+	Send(ctx context.Context, tokens []string, payload json.RawMessage) ([]string, error)
+}

--- a/api-go/internal/fcm/token.go
+++ b/api-go/internal/fcm/token.go
@@ -1,0 +1,227 @@
+package fcm
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+)
+
+// jwtBearerGrant is the OAuth2 grant type for the two-legged service-account
+// flow: a signed JWT assertion is exchanged for an access token. It is a public,
+// well-known grant-type URI, not a credential.
+//
+//nolint:gosec // G101: OAuth grant-type URI, not a hardcoded secret.
+const jwtBearerGrant = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+// assertionTTL is how long a minted assertion JWT claims validity. Google caps
+// service-account assertions at one hour; the assertion is short-lived and
+// re-minted on every token fetch, so the full hour is fine.
+const assertionTTL = time.Hour
+
+// tokenExpiryMargin is subtracted from the access token's reported lifetime so a
+// token is refreshed before it actually expires, absorbing clock skew and the
+// send request's own latency.
+const tokenExpiryMargin = 60 * time.Second
+
+// maxTokenRespBytes bounds the OAuth token endpoint response read.
+const maxTokenRespBytes = 64 << 10
+
+// serviceAccount is the subset of a Firebase/GCP service-account key JSON the
+// JWT-bearer flow needs. The full document carries more fields; only these are
+// read.
+type serviceAccount struct {
+	ClientEmail string `json:"client_email"`
+	PrivateKey  string `json:"private_key"`
+	TokenURI    string `json:"token_uri"`
+	ProjectID   string `json:"project_id"`
+}
+
+// jwtHeader is the JWS header for the assertion: RS256, JWT type.
+type jwtHeader struct {
+	Alg string `json:"alg"`
+	Typ string `json:"typ"`
+}
+
+// jwtClaims is the assertion payload: the service-account email as issuer, the
+// FCM scope, the token endpoint as audience, and the issued-at / expiry epochs.
+type jwtClaims struct {
+	Iss   string `json:"iss"`
+	Scope string `json:"scope"`
+	Aud   string `json:"aud"`
+	Iat   int64  `json:"iat"`
+	Exp   int64  `json:"exp"`
+}
+
+// tokenResponse is the OAuth token endpoint's success body.
+type tokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+	TokenType   string `json:"token_type"`
+}
+
+// tokenProvider mints an RS256-signed JWT assertion, exchanges it at the
+// service-account token endpoint for an OAuth access token, and caches that
+// token until shortly before it expires. It mirrors apns/jwt.go's cache-and-mint
+// shape; FCM differs only in that obtaining a bearer requires a network round
+// trip (the JWT is not itself the bearer), so current takes a context.
+type tokenProvider struct {
+	key         *rsa.PrivateKey
+	clientEmail string
+	tokenURI    string
+	http        *http.Client
+	now         func() time.Time
+
+	mu        sync.Mutex
+	cached    string
+	expiresAt time.Time
+}
+
+// newTokenProvider parses a service-account JSON blob (its RSA private key,
+// client email, and token URI) and returns a provider that exchanges signed
+// assertions for access tokens over httpClient. now supplies the clock so tests
+// can pin time.
+func newTokenProvider(saJSON []byte, httpClient *http.Client, now func() time.Time) (*tokenProvider, error) {
+	var sa serviceAccount
+	if err := json.Unmarshal(saJSON, &sa); err != nil {
+		return nil, fmt.Errorf("fcm: %w: parse json: %w", ErrInvalidServiceAccount, err)
+	}
+	if sa.ClientEmail == "" {
+		return nil, fmt.Errorf("fcm: %w: client_email is empty", ErrInvalidServiceAccount)
+	}
+	if sa.TokenURI == "" {
+		return nil, fmt.Errorf("fcm: %w: token_uri is empty", ErrInvalidServiceAccount)
+	}
+	key, err := parseRSAPrivateKey([]byte(sa.PrivateKey))
+	if err != nil {
+		return nil, err
+	}
+	return &tokenProvider{
+		key:         key,
+		clientEmail: sa.ClientEmail,
+		tokenURI:    sa.TokenURI,
+		http:        httpClient,
+		now:         now,
+	}, nil
+}
+
+// parseRSAPrivateKey decodes the PEM-wrapped PKCS8 RSA private key a Google
+// service-account key carries in its private_key field.
+func parseRSAPrivateKey(pemBytes []byte) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("fcm: %w: private_key is not PEM", ErrInvalidServiceAccount)
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("fcm: %w: parse pkcs8 private key: %w", ErrInvalidServiceAccount, err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("fcm: %w: private_key is not an RSA key", ErrInvalidServiceAccount)
+	}
+	return key, nil
+}
+
+// current returns a cached access token, fetching a fresh one when none is held
+// or the cached token is within tokenExpiryMargin of expiry.
+func (p *tokenProvider) current(ctx context.Context) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	now := p.now()
+	if p.cached != "" && now.Before(p.expiresAt) {
+		return p.cached, nil
+	}
+
+	token, lifetime, err := p.fetch(ctx, now)
+	if err != nil {
+		return "", err
+	}
+	p.cached = token
+	p.expiresAt = now.Add(lifetime - tokenExpiryMargin)
+	return token, nil
+}
+
+// fetch mints an assertion, posts it to the token endpoint, and returns the
+// access token and its reported lifetime.
+func (p *tokenProvider) fetch(ctx context.Context, now time.Time) (token string, lifetime time.Duration, err error) {
+	assertion, err := p.mintAssertion(now)
+	if err != nil {
+		return "", 0, err
+	}
+
+	form := url.Values{
+		"grant_type": {jwtBearerGrant},
+		"assertion":  {assertion},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.tokenURI, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", 0, fmt.Errorf("fcm: build token request: %w", err)
+	}
+	req.Header.Set("content-type", "application/x-www-form-urlencoded")
+
+	resp, err := p.http.Do(req)
+	if err != nil {
+		return "", 0, fmt.Errorf("fcm: token request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxTokenRespBytes))
+	if err != nil {
+		return "", 0, fmt.Errorf("fcm: read token response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", 0, fmt.Errorf("fcm: token endpoint status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var parsed tokenResponse
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return "", 0, fmt.Errorf("fcm: parse token response: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return "", 0, fmt.Errorf("fcm: token response carried no access_token")
+	}
+	return parsed.AccessToken, time.Duration(parsed.ExpiresIn) * time.Second, nil
+}
+
+// mintAssertion signs the RS256 JWT assertion the token endpoint exchanges for
+// an access token.
+func (p *tokenProvider) mintAssertion(now time.Time) (string, error) {
+	headerJSON, err := json.Marshal(jwtHeader{Alg: "RS256", Typ: "JWT"})
+	if err != nil {
+		return "", fmt.Errorf("fcm: marshal jwt header: %w", err)
+	}
+	claimsJSON, err := json.Marshal(jwtClaims{
+		Iss:   p.clientEmail,
+		Scope: firebaseMessagingScope,
+		Aud:   p.tokenURI,
+		Iat:   now.Unix(),
+		Exp:   now.Add(assertionTTL).Unix(),
+	})
+	if err != nil {
+		return "", fmt.Errorf("fcm: marshal jwt claims: %w", err)
+	}
+
+	signingInput := base64.RawURLEncoding.EncodeToString(headerJSON) + "." +
+		base64.RawURLEncoding.EncodeToString(claimsJSON)
+
+	digest := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, p.key, crypto.SHA256, digest[:])
+	if err != nil {
+		return "", fmt.Errorf("fcm: sign jwt: %w", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}

--- a/api-go/internal/fcm/token_test.go
+++ b/api-go/internal/fcm/token_test.go
@@ -1,0 +1,229 @@
+package fcm
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newTestKeyPEM generates an RSA-2048 key encoded as a PKCS8 PEM block, the same
+// shape a Google service-account key carries in its private_key field. Returned
+// alongside the public half so a test can verify the assertion signature.
+func newTestKeyPEM(t *testing.T) (pemBytes []byte, pub *rsa.PublicKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal pkcs8: %v", err)
+	}
+	pemBytes = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	return pemBytes, &key.PublicKey
+}
+
+// newTestServiceAccountJSON builds a service-account key JSON pointing its token
+// endpoint at tokenURI, with the given PEM private key.
+func newTestServiceAccountJSON(t *testing.T, tokenURI string, pemBytes []byte) string {
+	t.Helper()
+	sa := map[string]string{
+		"type":         "service_account",
+		"project_id":   "town-crier-test",
+		"client_email": "fcm@town-crier-test.iam.gserviceaccount.com",
+		"private_key":  string(pemBytes),
+		"token_uri":    tokenURI,
+	}
+	raw, err := json.Marshal(sa)
+	if err != nil {
+		t.Fatalf("marshal service account: %v", err)
+	}
+	return string(raw)
+}
+
+func fixedClock(unix int64) func() time.Time {
+	return func() time.Time { return time.Unix(unix, 0).UTC() }
+}
+
+func TestTokenProvider_MintsValidRS256Assertion(t *testing.T) {
+	t.Parallel()
+	pemBytes, pub := newTestKeyPEM(t)
+	now := time.Unix(1_700_000_000, 0).UTC()
+	saJSON := newTestServiceAccountJSON(t, "https://oauth2.googleapis.com/token", pemBytes)
+
+	provider, err := newTokenProvider([]byte(saJSON), &http.Client{}, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("newTokenProvider: %v", err)
+	}
+
+	assertion, err := provider.mintAssertion(now)
+	if err != nil {
+		t.Fatalf("mintAssertion: %v", err)
+	}
+
+	parts := strings.Split(assertion, ".")
+	if len(parts) != 3 {
+		t.Fatalf("assertion must have 3 dot-separated parts, got %d", len(parts))
+	}
+
+	var header struct {
+		Alg string `json:"alg"`
+		Typ string `json:"typ"`
+	}
+	if err := json.Unmarshal(decodeSegment(t, parts[0]), &header); err != nil {
+		t.Fatalf("decode header: %v", err)
+	}
+	if header.Alg != "RS256" {
+		t.Errorf("alg = %q, want RS256", header.Alg)
+	}
+
+	var claims struct {
+		Iss   string `json:"iss"`
+		Scope string `json:"scope"`
+		Aud   string `json:"aud"`
+		Iat   int64  `json:"iat"`
+		Exp   int64  `json:"exp"`
+	}
+	if err := json.Unmarshal(decodeSegment(t, parts[1]), &claims); err != nil {
+		t.Fatalf("decode claims: %v", err)
+	}
+	if claims.Iss != "fcm@town-crier-test.iam.gserviceaccount.com" {
+		t.Errorf("iss = %q", claims.Iss)
+	}
+	if claims.Scope != firebaseMessagingScope {
+		t.Errorf("scope = %q, want %q", claims.Scope, firebaseMessagingScope)
+	}
+	if claims.Aud != "https://oauth2.googleapis.com/token" {
+		t.Errorf("aud = %q", claims.Aud)
+	}
+	if claims.Iat != now.Unix() {
+		t.Errorf("iat = %d, want %d", claims.Iat, now.Unix())
+	}
+	if claims.Exp != now.Add(time.Hour).Unix() {
+		t.Errorf("exp = %d, want %d", claims.Exp, now.Add(time.Hour).Unix())
+	}
+
+	// The signature must verify against the public key under RS256.
+	signingInput := parts[0] + "." + parts[1]
+	digest := sha256.Sum256([]byte(signingInput))
+	if err := rsa.VerifyPKCS1v15(pub, crypto.SHA256, digest[:], decodeSegment(t, parts[2])); err != nil {
+		t.Fatalf("signature failed to verify: %v", err)
+	}
+}
+
+func TestTokenProvider_ExchangesAssertionForAccessToken(t *testing.T) {
+	t.Parallel()
+	pemBytes, _ := newTestKeyPEM(t)
+
+	var gotGrant, gotAssertion, gotContentType string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotGrant = r.PostForm.Get("grant_type")
+		gotAssertion = r.PostForm.Get("assertion")
+		gotContentType = r.Header.Get("content-type")
+		_, _ = w.Write([]byte(`{"access_token":"ya29.test","expires_in":3599,"token_type":"Bearer"}`))
+	}))
+	defer srv.Close()
+
+	saJSON := newTestServiceAccountJSON(t, srv.URL, pemBytes)
+	provider, err := newTokenProvider([]byte(saJSON), srv.Client(), fixedClock(1_700_000_000))
+	if err != nil {
+		t.Fatalf("newTokenProvider: %v", err)
+	}
+
+	token, err := provider.current(context.Background())
+	if err != nil {
+		t.Fatalf("current: %v", err)
+	}
+	if token != "ya29.test" {
+		t.Errorf("token = %q, want ya29.test", token)
+	}
+	if gotGrant != jwtBearerGrant {
+		t.Errorf("grant_type = %q, want %q", gotGrant, jwtBearerGrant)
+	}
+	if gotAssertion == "" || len(strings.Split(gotAssertion, ".")) != 3 {
+		t.Errorf("assertion = %q, want a 3-part JWT", gotAssertion)
+	}
+	if gotContentType != "application/x-www-form-urlencoded" {
+		t.Errorf("content-type = %q", gotContentType)
+	}
+}
+
+func TestTokenProvider_CachesUntilExpiry(t *testing.T) {
+	t.Parallel()
+	pemBytes, _ := newTestKeyPEM(t)
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		_, _ = w.Write([]byte(`{"access_token":"ya29.test","expires_in":3599,"token_type":"Bearer"}`))
+	}))
+	defer srv.Close()
+
+	current := time.Unix(1_700_000_000, 0).UTC()
+	saJSON := newTestServiceAccountJSON(t, srv.URL, pemBytes)
+	provider, err := newTokenProvider([]byte(saJSON), srv.Client(), func() time.Time { return current })
+	if err != nil {
+		t.Fatalf("newTokenProvider: %v", err)
+	}
+
+	if _, err := provider.current(context.Background()); err != nil {
+		t.Fatalf("first current: %v", err)
+	}
+	// Well inside the token lifetime (3599s - 60s margin): the cached token is reused.
+	current = current.Add(30 * time.Minute)
+	if _, err := provider.current(context.Background()); err != nil {
+		t.Fatalf("second current: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("token endpoint calls = %d, want 1 (cached)", calls)
+	}
+
+	// Past the effective expiry: a fresh token is fetched.
+	current = current.Add(time.Hour)
+	if _, err := provider.current(context.Background()); err != nil {
+		t.Fatalf("third current: %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("token endpoint calls = %d, want 2 (re-fetched after expiry)", calls)
+	}
+}
+
+func TestNewTokenProvider_RejectsBadKey(t *testing.T) {
+	t.Parallel()
+	saJSON := fmt.Sprintf(`{"client_email":"x@y.iam","token_uri":"%s","private_key":"not a pem"}`, "https://oauth2.googleapis.com/token")
+	_, err := newTokenProvider([]byte(saJSON), &http.Client{}, time.Now)
+	if !errors.Is(err, ErrInvalidServiceAccount) {
+		t.Fatalf("err = %v, want ErrInvalidServiceAccount", err)
+	}
+}
+
+func TestNewTokenProvider_RejectsMalformedJSON(t *testing.T) {
+	t.Parallel()
+	_, err := newTokenProvider([]byte("{not json"), &http.Client{}, time.Now)
+	if !errors.Is(err, ErrInvalidServiceAccount) {
+		t.Fatalf("err = %v, want ErrInvalidServiceAccount", err)
+	}
+}
+
+func decodeSegment(t *testing.T, seg string) []byte {
+	t.Helper()
+	b, err := base64.RawURLEncoding.DecodeString(seg)
+	if err != nil {
+		t.Fatalf("base64url decode %q: %v", seg, err)
+	}
+	return b
+}

--- a/api-go/internal/notifydispatch/coalescer.go
+++ b/api-go/internal/notifydispatch/coalescer.go
@@ -44,17 +44,18 @@ const savedBucket = ""
 // flushes them at cycle end as at most one push per (user, watch zone), plus
 // one per-user "saved" bucket for zone-less notifications (GH#784). It owns the
 // send-path collaborators the dispatchers used to call inline per notification:
-// device lookup, the unread badge, the APNs sender, and zone-name resolution.
+// device lookup, the unread badge, the platform dispatcher (APNs + FCM), and
+// zone-name resolution.
 //
 // PushCoalescer is driven by the single-goroutine poll handler loop (Reset at
 // cycle start, Add during the authority walk, Flush at cycle end) and is not
 // safe for concurrent use.
 type PushCoalescer struct {
-	devices deviceReader
-	state   stateReader
-	push    pushSender
-	zones   zoneNameReader
-	logger  *slog.Logger
+	devices    deviceReader
+	state      stateReader
+	dispatcher *PlatformDispatcher
+	zones      zoneNameReader
+	logger     *slog.Logger
 
 	// items is userID -> bucketKey (watch zone id, or savedBucket) -> the
 	// push-eligible notifications queued for that bucket this cycle.
@@ -62,14 +63,14 @@ type PushCoalescer struct {
 }
 
 // NewPushCoalescer wires the coalescer.
-func NewPushCoalescer(devices deviceReader, state stateReader, push pushSender, zones zoneNameReader, logger *slog.Logger) *PushCoalescer {
+func NewPushCoalescer(devices deviceReader, state stateReader, dispatcher *PlatformDispatcher, zones zoneNameReader, logger *slog.Logger) *PushCoalescer {
 	return &PushCoalescer{
-		devices: devices,
-		state:   state,
-		push:    push,
-		zones:   zones,
-		logger:  logger,
-		items:   make(map[string]map[string][]notifications.DigestNotification),
+		devices:    devices,
+		state:      state,
+		dispatcher: dispatcher,
+		zones:      zones,
+		logger:     logger,
+		items:      make(map[string]map[string][]notifications.DigestNotification),
 	}
 }
 
@@ -111,8 +112,10 @@ func (c *PushCoalescer) Flush(ctx context.Context) error {
 }
 
 // flushUser loads the user's devices and badge once, then sends exactly one
-// push per bucket, accumulating any invalid tokens APNs reports across all of
-// this user's sends and pruning the union once at the end.
+// push per bucket per platform (APNs for iOS tokens, FCM for Android tokens),
+// accumulating any invalid tokens either sender reports across all of this
+// user's sends and pruning the union once at the end. The per-platform payload
+// is built only when the user has tokens on that platform.
 func (c *PushCoalescer) flushUser(ctx context.Context, userID string, buckets map[string][]notifications.DigestNotification) {
 	devices, err := c.devices.ListByUser(ctx, userID)
 	if err != nil {
@@ -122,22 +125,32 @@ func (c *PushCoalescer) flushUser(ctx context.Context, userID string, buckets ma
 	if len(devices) == 0 {
 		return
 	}
-	tokens := make([]string, 0, len(devices))
-	for _, d := range devices {
-		tokens = append(tokens, d.Token)
-	}
+	iosTokens, androidTokens := groupTokensByPlatform(devices)
 
 	badge := c.unreadBadge(ctx, userID)
 	zoneNames := c.zoneNames(ctx, userID)
 
 	invalid := make(map[string]struct{})
 	for bucketKey, queued := range buckets {
-		payload, err := buildBucketPayload(bucketKey, queued, zoneNames, badge)
-		if err != nil {
-			c.logger.ErrorContext(ctx, "push coalescer: build payload failed", "user", userID, "bucket", bucketKey, "error", err)
-			continue
+		var iosPayload, androidPayload json.RawMessage
+		if len(iosTokens) > 0 {
+			p, err := buildBucketPayload(bucketKey, queued, zoneNames, badge)
+			if err != nil {
+				c.logger.ErrorContext(ctx, "push coalescer: build apns payload failed", "user", userID, "bucket", bucketKey, "error", err)
+				continue
+			}
+			iosPayload = p
 		}
-		invalidTokens, err := c.push.Send(ctx, tokens, payload)
+		if len(androidTokens) > 0 {
+			p, err := buildBucketFCMPayload(bucketKey, queued, zoneNames)
+			if err != nil {
+				c.logger.ErrorContext(ctx, "push coalescer: build fcm payload failed", "user", userID, "bucket", bucketKey, "error", err)
+				continue
+			}
+			androidPayload = p
+		}
+
+		invalidTokens, err := c.dispatcher.Send(ctx, iosTokens, iosPayload, androidTokens, androidPayload)
 		if err != nil {
 			c.logger.ErrorContext(ctx, "push coalescer: send failed", "user", userID, "bucket", bucketKey, "error", err)
 			continue

--- a/api-go/internal/notifydispatch/coalescer_test.go
+++ b/api-go/internal/notifydispatch/coalescer_test.go
@@ -86,7 +86,11 @@ func newCoalescerHarness(t *testing.T) (*PushCoalescer, *fakeDevices, *fakeState
 	st := &fakeState{unread: 2}
 	push := &fakePush{}
 	zones := &fakeZoneNames{byUser: map[string][]watchzones.WatchZone{}}
-	c := NewPushCoalescer(devs, st, push, zones, testLogger(t))
+	// The default device is iOS (zero-value platform), so the dispatcher routes to
+	// the APNs fake (push) that the existing assertions inspect. A throwaway FCM
+	// fake stands in for the Android sender the iOS-only fixtures never exercise.
+	disp := NewPlatformDispatcher(push, &fakePush{}, testLogger(t))
+	c := NewPushCoalescer(devs, st, disp, zones, testLogger(t))
 	return c, devs, st, push, zones
 }
 

--- a/api-go/internal/notifydispatch/dispatcher.go
+++ b/api-go/internal/notifydispatch/dispatcher.go
@@ -1,0 +1,87 @@
+package notifydispatch
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+)
+
+// PlatformDispatcher delivers a recipient bucket's pushes across both platforms:
+// the iOS payload to the iOS tokens via APNs, the Android payload to the Android
+// tokens via FCM. It holds both senders and returns the union of tokens either
+// reported invalid so a caller loads devices once and prunes once — preserving
+// the coalescer's load-devices-once / single-union-prune properties while adding
+// the platform split.
+//
+// A per-platform send error is logged and skipped: one platform's failure must
+// never block the other's delivery or the union prune. Both apns.PushSender and
+// fcm.PushSender satisfy the (structurally identical) pushSender contract.
+type PlatformDispatcher struct {
+	apns   pushSender
+	fcm    pushSender
+	logger *slog.Logger
+}
+
+// NewPlatformDispatcher wires the dispatcher over an APNs and an FCM sender
+// (either the real client or its NoOp twin).
+func NewPlatformDispatcher(apnsSender, fcmSender pushSender, logger *slog.Logger) *PlatformDispatcher {
+	return &PlatformDispatcher{apns: apnsSender, fcm: fcmSender, logger: logger}
+}
+
+// Send delivers iosPayload to iosTokens (via APNs) and androidPayload to
+// androidTokens (via FCM), returning the union of tokens either sender reported
+// invalid. A platform with no tokens or a nil payload is skipped, so a caller
+// need only build the payload for a platform it actually has tokens for. Send
+// always returns a nil error: per-platform faults are swallowed (logged) so the
+// union prune still runs for the platform that succeeded.
+func (d *PlatformDispatcher) Send(
+	ctx context.Context,
+	iosTokens []string, iosPayload json.RawMessage,
+	androidTokens []string, androidPayload json.RawMessage,
+) ([]string, error) {
+	invalid := make([]string, 0)
+	invalid = d.deliver(ctx, "apns", d.apns, iosTokens, iosPayload, invalid)
+	invalid = d.deliver(ctx, "fcm", d.fcm, androidTokens, androidPayload, invalid)
+	if len(invalid) == 0 {
+		return nil, nil
+	}
+	return invalid, nil
+}
+
+// deliver sends one platform's payload to its tokens, appending any tokens the
+// sender reports invalid to the running union. An empty token slice or nil
+// payload is a no-op; a send error is logged and swallowed.
+func (d *PlatformDispatcher) deliver(
+	ctx context.Context,
+	platformName string,
+	sender pushSender,
+	tokens []string,
+	payload json.RawMessage,
+	invalid []string,
+) []string {
+	if len(tokens) == 0 || payload == nil {
+		return invalid
+	}
+	rejected, err := sender.Send(ctx, tokens, payload)
+	if err != nil {
+		d.logger.ErrorContext(ctx, "platform dispatch: send failed", "platform", platformName, "error", err)
+		return invalid
+	}
+	return append(invalid, rejected...)
+}
+
+// groupTokensByPlatform splits a recipient's device registrations into iOS and
+// Android token slices. An unrecognised platform is treated as iOS (the APNs
+// default), matching devicetokens.DevicePlatform.String's fallback.
+func groupTokensByPlatform(devices []devicetokens.DeviceRegistration) (ios, android []string) {
+	for _, dev := range devices {
+		if dev.Platform == devicetokens.PlatformAndroid {
+			android = append(android, dev.Token)
+			continue
+		}
+		ios = append(ios, dev.Token)
+	}
+	return ios, android
+}

--- a/api-go/internal/notifydispatch/dispatcher_test.go
+++ b/api-go/internal/notifydispatch/dispatcher_test.go
@@ -1,0 +1,201 @@
+package notifydispatch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/AmyDe/town-crier/api-go/internal/devicetokens"
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/watchzones"
+)
+
+func TestPlatformDispatcher_RoutesEachPayloadToItsSender(t *testing.T) {
+	t.Parallel()
+	apns := &fakePush{}
+	fcm := &fakePush{}
+	d := NewPlatformDispatcher(apns, fcm, testLogger(t))
+
+	iosPayload := json.RawMessage(`{"aps":{}}`)
+	androidPayload := json.RawMessage(`{"notification":{}}`)
+	if _, err := d.Send(context.Background(),
+		[]string{"ios-1"}, iosPayload,
+		[]string{"and-1", "and-2"}, androidPayload,
+	); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if apns.calls != 1 || len(apns.tokens) != 1 || apns.tokens[0] != "ios-1" {
+		t.Errorf("apns should get exactly the iOS tokens, got calls=%d tokens=%v", apns.calls, apns.tokens)
+	}
+	if string(apns.payloads[0]) != string(iosPayload) {
+		t.Errorf("apns payload = %s, want %s", apns.payloads[0], iosPayload)
+	}
+	if fcm.calls != 1 || len(fcm.tokens) != 2 {
+		t.Errorf("fcm should get exactly the Android tokens, got calls=%d tokens=%v", fcm.calls, fcm.tokens)
+	}
+	if string(fcm.payloads[0]) != string(androidPayload) {
+		t.Errorf("fcm payload = %s, want %s", fcm.payloads[0], androidPayload)
+	}
+}
+
+func TestPlatformDispatcher_SkipsPlatformWithNoTokens(t *testing.T) {
+	t.Parallel()
+	apns := &fakePush{}
+	fcm := &fakePush{}
+	d := NewPlatformDispatcher(apns, fcm, testLogger(t))
+
+	// Android-only recipient: APNs sender must not be touched.
+	if _, err := d.Send(context.Background(), nil, nil, []string{"and-1"}, json.RawMessage(`{}`)); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if apns.calls != 0 {
+		t.Errorf("apns must not be called with no iOS tokens, got %d", apns.calls)
+	}
+	if fcm.calls != 1 {
+		t.Errorf("fcm should be called once, got %d", fcm.calls)
+	}
+}
+
+func TestPlatformDispatcher_UnionsInvalidTokensAcrossBothSenders(t *testing.T) {
+	t.Parallel()
+	apns := &fakePush{invalid: []string{"ios-dead"}}
+	fcm := &fakePush{invalid: []string{"and-dead"}}
+	d := NewPlatformDispatcher(apns, fcm, testLogger(t))
+
+	invalid, err := d.Send(context.Background(),
+		[]string{"ios-dead"}, json.RawMessage(`{}`),
+		[]string{"and-dead"}, json.RawMessage(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	got := map[string]bool{}
+	for _, tok := range invalid {
+		got[tok] = true
+	}
+	if !got["ios-dead"] || !got["and-dead"] || len(invalid) != 2 {
+		t.Errorf("invalid union = %v, want [ios-dead and-dead]", invalid)
+	}
+}
+
+func TestPlatformDispatcher_OnePlatformErrorDoesNotBlockOther(t *testing.T) {
+	t.Parallel()
+	apns := &fakePush{sendErr: errors.New("apns down")}
+	fcm := &fakePush{invalid: []string{"and-dead"}}
+	d := NewPlatformDispatcher(apns, fcm, testLogger(t))
+
+	invalid, err := d.Send(context.Background(),
+		[]string{"ios-1"}, json.RawMessage(`{}`),
+		[]string{"and-dead"}, json.RawMessage(`{}`),
+	)
+	if err != nil {
+		t.Fatalf("Send must swallow a per-platform error, got %v", err)
+	}
+	// APNs failed but FCM's invalid token is still surfaced for pruning.
+	if len(invalid) != 1 || invalid[0] != "and-dead" {
+		t.Errorf("invalid = %v, want [and-dead] (fcm still pruned despite apns failure)", invalid)
+	}
+	if fcm.calls != 1 {
+		t.Errorf("fcm must still be sent to when apns fails, got %d calls", fcm.calls)
+	}
+}
+
+// ---- coalescer platform-split tests ----
+
+func newMixedCoalescer(t *testing.T) (*PushCoalescer, *fakeDevices, *fakePush, *fakePush) {
+	t.Helper()
+	devs := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
+		"auth0|alice": {
+			{Token: "ios-1", Platform: devicetokens.PlatformIos},
+			{Token: "and-1", Platform: devicetokens.PlatformAndroid},
+		},
+	}}
+	st := &fakeState{unread: 2}
+	apns := &fakePush{}
+	fcm := &fakePush{}
+	zones := &fakeZoneNames{byUser: map[string][]watchzones.WatchZone{}}
+	disp := NewPlatformDispatcher(apns, fcm, testLogger(t))
+	c := NewPushCoalescer(devs, st, disp, zones, testLogger(t))
+	return c, devs, apns, fcm
+}
+
+func TestPushCoalescer_MixedRecipient_SplitsTokensByPlatform(t *testing.T) {
+	t.Parallel()
+	c, _, apns, fcm := newMixedCoalescer(t)
+	zoneID := "zone-1"
+	c.Add("auth0|alice", notifications.DigestNotification{
+		ID: "n-1", ApplicationName: "24/0001", WatchZoneID: &zoneID, ApplicationAddress: "10 High St",
+	})
+
+	if err := c.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+
+	// APNs sender gets the iOS token + the APNs body; FCM sender gets the Android
+	// token + the FCM body — from the SAME single-item bucket.
+	if apns.calls != 1 || len(apns.tokens) != 1 || apns.tokens[0] != "ios-1" {
+		t.Errorf("apns tokens = %v (calls %d), want [ios-1]", apns.tokens, apns.calls)
+	}
+	if fcm.calls != 1 || len(fcm.tokens) != 1 || fcm.tokens[0] != "and-1" {
+		t.Errorf("fcm tokens = %v (calls %d), want [and-1]", fcm.tokens, fcm.calls)
+	}
+
+	// The APNs body is the aps deep-link shape; the FCM body is the message shape.
+	var apnsDecoded struct {
+		Aps            map[string]json.RawMessage `json:"aps"`
+		ApplicationRef string                     `json:"applicationRef"`
+	}
+	if err := json.Unmarshal(apns.payloads[0], &apnsDecoded); err != nil {
+		t.Fatalf("apns unmarshal: %v", err)
+	}
+	if apnsDecoded.ApplicationRef != "24/0001" || apnsDecoded.Aps == nil {
+		t.Errorf("apns payload not the alert shape: %s", apns.payloads[0])
+	}
+	fcmDecoded := decodeFCM(t, fcm.payloads[0])
+	if fcmDecoded.Data["kind"] != "alert" || fcmDecoded.Data["applicationRef"] != "24/0001" {
+		t.Errorf("fcm payload not the alert shape: %s", fcm.payloads[0])
+	}
+}
+
+func TestPushCoalescer_MixedRecipient_PrunesInvalidTokensAcrossBothPlatforms(t *testing.T) {
+	t.Parallel()
+	c, devs, apns, fcm := newMixedCoalescer(t)
+	apns.invalid = []string{"ios-1"}
+	fcm.invalid = []string{"and-1"}
+	c.Add("auth0|alice", notifications.DigestNotification{ID: "n-1", ApplicationAddress: "x"})
+
+	if err := c.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	deleted := map[string]bool{}
+	for _, tok := range devs.deleted {
+		deleted[tok] = true
+	}
+	if !deleted["ios-1"] || !deleted["and-1"] || len(devs.deleted) != 2 {
+		t.Errorf("pruned = %v, want both ios-1 and and-1", devs.deleted)
+	}
+}
+
+func TestPushCoalescer_AndroidOnlyRecipient_NoAPNsSend(t *testing.T) {
+	t.Parallel()
+	devs := &fakeDevices{byUser: map[string][]devicetokens.DeviceRegistration{
+		"auth0|bob": {{Token: "and-1", Platform: devicetokens.PlatformAndroid}},
+	}}
+	apns := &fakePush{}
+	fcm := &fakePush{}
+	disp := NewPlatformDispatcher(apns, fcm, testLogger(t))
+	c := NewPushCoalescer(devs, &fakeState{}, disp, &fakeZoneNames{byUser: map[string][]watchzones.WatchZone{}}, testLogger(t))
+	c.Add("auth0|bob", notifications.DigestNotification{ID: "n-1", ApplicationAddress: "x"})
+
+	if err := c.Flush(context.Background()); err != nil {
+		t.Fatalf("Flush: %v", err)
+	}
+	if apns.calls != 0 {
+		t.Errorf("android-only recipient must not hit APNs, got %d calls", apns.calls)
+	}
+	if fcm.calls != 1 {
+		t.Errorf("android-only recipient must hit FCM once, got %d calls", fcm.calls)
+	}
+}

--- a/api-go/internal/notifydispatch/fcm_payload_test.go
+++ b/api-go/internal/notifydispatch/fcm_payload_test.go
@@ -1,0 +1,222 @@
+package notifydispatch
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/AmyDe/town-crier/api-go/internal/notifications"
+	"github.com/AmyDe/town-crier/api-go/internal/platform"
+)
+
+// decodeFCM unpacks a token-less FCM message body for assertions.
+func decodeFCM(t *testing.T, raw json.RawMessage) struct {
+	Notification struct {
+		Title string `json:"title"`
+		Body  string `json:"body"`
+	} `json:"notification"`
+	Android struct {
+		Priority     string `json:"priority"`
+		Notification struct {
+			ChannelID string `json:"channel_id"`
+		} `json:"notification"`
+	} `json:"android"`
+	Data map[string]string `json:"data"`
+} {
+	t.Helper()
+	var decoded struct {
+		Notification struct {
+			Title string `json:"title"`
+			Body  string `json:"body"`
+		} `json:"notification"`
+		Android struct {
+			Priority     string `json:"priority"`
+			Notification struct {
+				ChannelID string `json:"channel_id"`
+			} `json:"notification"`
+		} `json:"android"`
+		Data map[string]string `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshal fcm payload: %v", err)
+	}
+	return decoded
+}
+
+func TestBuildAlertFCMPayload_CarriesDeepLinkDataAsStrings(t *testing.T) {
+	t.Parallel()
+	zoneID := "zone-1"
+	created := time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC)
+	n := notifications.DigestNotification{
+		ID:                 "notif-1",
+		ApplicationName:    "24/0001",
+		WatchZoneID:        &zoneID,
+		ApplicationAddress: "10 High St",
+		EventType:          notifications.EventNewApplication,
+		AuthorityID:        99,
+		CreatedAt:          created,
+	}
+
+	raw, err := buildAlertFCMPayload(n)
+	if err != nil {
+		t.Fatalf("buildAlertFCMPayload: %v", err)
+	}
+	decoded := decodeFCM(t, raw)
+
+	if decoded.Notification.Title != "Planning update near you" {
+		t.Errorf("title: got %q", decoded.Notification.Title)
+	}
+	if decoded.Notification.Body != "10 High St" {
+		t.Errorf("body: got %q", decoded.Notification.Body)
+	}
+	if decoded.Android.Priority != "HIGH" {
+		t.Errorf("android priority: got %q, want HIGH", decoded.Android.Priority)
+	}
+	if decoded.Android.Notification.ChannelID != "alerts" {
+		t.Errorf("channel_id: got %q, want alerts", decoded.Android.Notification.ChannelID)
+	}
+	if decoded.Data["kind"] != "alert" {
+		t.Errorf("data.kind: got %q, want alert", decoded.Data["kind"])
+	}
+	if decoded.Data["notificationId"] != "notif-1" {
+		t.Errorf("data.notificationId: got %q", decoded.Data["notificationId"])
+	}
+	if decoded.Data["applicationRef"] != "24/0001" {
+		t.Errorf("data.applicationRef: got %q", decoded.Data["applicationRef"])
+	}
+	if decoded.Data["authorityId"] != "99" {
+		t.Errorf("data.authorityId: got %q, want stringified 99", decoded.Data["authorityId"])
+	}
+	wantCreated := platform.DotNetTime(created).String()
+	if decoded.Data["createdAt"] != wantCreated {
+		t.Errorf("data.createdAt: got %q, want %q", decoded.Data["createdAt"], wantCreated)
+	}
+
+	// No badge field anywhere (Android badges are channel-driven).
+	if _, ok := decoded.Data["badge"]; ok {
+		t.Error("fcm data must not carry a badge")
+	}
+	var rawMap map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &rawMap); err != nil {
+		t.Fatalf("unmarshal raw map: %v", err)
+	}
+	if _, ok := rawMap["badge"]; ok {
+		t.Error("fcm message must not carry a top-level badge")
+	}
+}
+
+func TestBuildAlertFCMPayload_SavedNotificationTitle(t *testing.T) {
+	t.Parallel()
+	n := notifications.DigestNotification{
+		ID:                 "notif-2",
+		ApplicationName:    "24/0002",
+		WatchZoneID:        nil,
+		ApplicationAddress: "1 Low St",
+		EventType:          notifications.EventDecisionUpdate,
+		AuthorityID:        5,
+		CreatedAt:          time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC),
+	}
+
+	raw, err := buildAlertFCMPayload(n)
+	if err != nil {
+		t.Fatalf("buildAlertFCMPayload: %v", err)
+	}
+	decoded := decodeFCM(t, raw)
+	if decoded.Notification.Title != "Town Crier" {
+		t.Errorf("saved-only title: got %q, want Town Crier", decoded.Notification.Title)
+	}
+}
+
+func TestBuildZoneSummaryFCMPayload_KindAndWatchZoneNoDeepLink(t *testing.T) {
+	t.Parallel()
+	raw, err := buildZoneSummaryFCMPayload(4, "Riverside", "zone-1")
+	if err != nil {
+		t.Fatalf("buildZoneSummaryFCMPayload: %v", err)
+	}
+	decoded := decodeFCM(t, raw)
+
+	if decoded.Notification.Title != "Planning updates near Riverside" {
+		t.Errorf("title: got %q", decoded.Notification.Title)
+	}
+	if decoded.Notification.Body != "4 updates in this area. Tap to see them." {
+		t.Errorf("body: got %q", decoded.Notification.Body)
+	}
+	if decoded.Data["kind"] != "zoneSummary" {
+		t.Errorf("data.kind: got %q, want zoneSummary", decoded.Data["kind"])
+	}
+	if decoded.Data["watchZoneId"] != "zone-1" {
+		t.Errorf("data.watchZoneId: got %q, want zone-1", decoded.Data["watchZoneId"])
+	}
+	// A summary must never carry the single-app deep-link keys.
+	if _, ok := decoded.Data["applicationRef"]; ok {
+		t.Error("zone summary must not carry applicationRef")
+	}
+	if _, ok := decoded.Data["notificationId"]; ok {
+		t.Error("zone summary must not carry notificationId")
+	}
+}
+
+func TestBuildSavedSummaryFCMPayload_KindNoWatchZoneNoDeepLink(t *testing.T) {
+	t.Parallel()
+	raw, err := buildSavedSummaryFCMPayload(2)
+	if err != nil {
+		t.Fatalf("buildSavedSummaryFCMPayload: %v", err)
+	}
+	decoded := decodeFCM(t, raw)
+
+	if decoded.Notification.Title != "Your saved applications" {
+		t.Errorf("title: got %q", decoded.Notification.Title)
+	}
+	if decoded.Notification.Body != "2 have a decision. Tap to see them." {
+		t.Errorf("body: got %q", decoded.Notification.Body)
+	}
+	if decoded.Data["kind"] != "savedSummary" {
+		t.Errorf("data.kind: got %q, want savedSummary", decoded.Data["kind"])
+	}
+	if _, ok := decoded.Data["watchZoneId"]; ok {
+		t.Error("saved summary must not carry watchZoneId")
+	}
+	if _, ok := decoded.Data["applicationRef"]; ok {
+		t.Error("saved summary must not carry applicationRef")
+	}
+}
+
+// TestFCMAndAPNsShareCopy asserts the two platforms render identical title/body
+// strings for the same event, which is the whole point of the shared helpers.
+func TestFCMAndAPNsShareCopy(t *testing.T) {
+	t.Parallel()
+	zoneID := "zone-1"
+	n := notifications.DigestNotification{
+		ID: "n-1", ApplicationName: "24/0001", WatchZoneID: &zoneID,
+		ApplicationAddress: "10 High St", EventType: notifications.EventNewApplication,
+		AuthorityID: 1, CreatedAt: time.Date(2026, 6, 13, 9, 0, 0, 0, time.UTC),
+	}
+
+	apnsRaw, err := buildAlertPayload(n, 3)
+	if err != nil {
+		t.Fatalf("buildAlertPayload: %v", err)
+	}
+	fcmRaw, err := buildAlertFCMPayload(n)
+	if err != nil {
+		t.Fatalf("buildAlertFCMPayload: %v", err)
+	}
+
+	var apnsDecoded struct {
+		Aps struct {
+			Alert struct {
+				Title string `json:"title"`
+				Body  string `json:"body"`
+			} `json:"alert"`
+		} `json:"aps"`
+	}
+	if err := json.Unmarshal(apnsRaw, &apnsDecoded); err != nil {
+		t.Fatalf("unmarshal apns: %v", err)
+	}
+	fcm := decodeFCM(t, fcmRaw)
+	if fcm.Notification.Title != apnsDecoded.Aps.Alert.Title {
+		t.Errorf("titles differ: fcm %q vs apns %q", fcm.Notification.Title, apnsDecoded.Aps.Alert.Title)
+	}
+	if fcm.Notification.Body != apnsDecoded.Aps.Alert.Body {
+		t.Errorf("bodies differ: fcm %q vs apns %q", fcm.Notification.Body, apnsDecoded.Aps.Alert.Body)
+	}
+}

--- a/api-go/internal/notifydispatch/payload.go
+++ b/api-go/internal/notifydispatch/payload.go
@@ -3,6 +3,7 @@ package notifydispatch
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 
 	"github.com/AmyDe/town-crier/api-go/internal/notifications"
 	"github.com/AmyDe/town-crier/api-go/internal/platform"
@@ -65,15 +66,10 @@ type apnsSummaryAps struct {
 // aps.thread-id is the watch zone id for a zone notification, "saved" for a
 // zone-less one, so iOS groups a zone's pushes together in Notification Center.
 func buildAlertPayload(n notifications.DigestNotification, totalUnreadCount int) (json.RawMessage, error) {
-	title := "Town Crier"
+	title, body := alertTitleBody(n)
 	threadID := savedThreadID
 	if n.WatchZoneID != nil {
-		title = "Planning update near you"
 		threadID = *n.WatchZoneID
-	}
-	body := n.ApplicationAddress
-	if n.EventType == notifications.EventDecisionUpdate {
-		body = buildDecisionBody(n)
 	}
 
 	raw, err := json.Marshal(apnsAlertPayload{
@@ -99,8 +95,7 @@ func buildAlertPayload(n notifications.DigestNotification, totalUnreadCount int)
 // {zoneName}" / "{count} updates in this area. Tap to see them." threadID is
 // the watch zone id (also surfaced as watchZoneId, the iOS routing hint).
 func buildZoneSummaryPayload(count int, zoneName string, badge int, threadID string) (json.RawMessage, error) {
-	title := fmt.Sprintf("Planning updates near %s", zoneName)
-	body := fmt.Sprintf("%d updates in this area. Tap to see them.", count)
+	title, body := zoneSummaryTitleBody(count, zoneName)
 
 	raw, err := json.Marshal(apnsSummaryPayload{
 		Aps: apnsSummaryAps{
@@ -122,11 +117,11 @@ func buildZoneSummaryPayload(count int, zoneName string, badge int, threadID str
 // (zone-less) bucket when it queued more than one notification this cycle:
 // "Your saved applications" / "{count} have a decision. Tap to see them."
 func buildSavedSummaryPayload(count, badge int) (json.RawMessage, error) {
-	body := fmt.Sprintf("%d have a decision. Tap to see them.", count)
+	title, body := savedSummaryTitleBody(count)
 
 	raw, err := json.Marshal(apnsSummaryPayload{
 		Aps: apnsSummaryAps{
-			Alert:    apnsAlertContent{Title: "Your saved applications", Body: body},
+			Alert:    apnsAlertContent{Title: title, Body: body},
 			Sound:    "default",
 			Badge:    badge,
 			ThreadID: savedThreadID,
@@ -148,4 +143,134 @@ func buildDecisionBody(n notifications.DigestNotification) string {
 		return n.ApplicationAddress
 	}
 	return n.ApplicationAddress + " — " + label
+}
+
+// alertTitleBody, zoneSummaryTitleBody, and savedSummaryTitleBody render the
+// server-side title/body copy each push shape carries. They are shared by the
+// APNs and FCM builders so the two platforms always render byte-identical
+// strings for the same event — the copy can never drift between them.
+
+// alertTitleBody renders the instant-push title/body: a zone-matched
+// notification is titled "Planning update near you", a saved-only one "Town
+// Crier"; a decision update body appends the UK display label, otherwise the
+// body is the address.
+func alertTitleBody(n notifications.DigestNotification) (title, body string) {
+	title = "Town Crier"
+	if n.WatchZoneID != nil {
+		title = "Planning update near you"
+	}
+	body = n.ApplicationAddress
+	if n.EventType == notifications.EventDecisionUpdate {
+		body = buildDecisionBody(n)
+	}
+	return title, body
+}
+
+// zoneSummaryTitleBody renders the coalesced watch-zone summary copy.
+func zoneSummaryTitleBody(count int, zoneName string) (title, body string) {
+	return fmt.Sprintf("Planning updates near %s", zoneName),
+		fmt.Sprintf("%d updates in this area. Tap to see them.", count)
+}
+
+// savedSummaryTitleBody renders the coalesced saved-bucket summary copy.
+func savedSummaryTitleBody(count int) (title, body string) {
+	return "Your saved applications",
+		fmt.Sprintf("%d have a decision. Tap to see them.", count)
+}
+
+// fcmMessage is the FCM HTTP v1 "message" object minus the per-recipient token
+// (fcm.Client injects the token itself). It mirrors the three APNs shapes: a
+// system-rendered notification (title/body, same strings as APNs) plus a data
+// dictionary carrying the routing "kind" discriminator and — for the single
+// alert — the deep-link keys the Android client's tap-routing reads, mirroring
+// iOS's custom-key parsing. FCM data values must all be strings, so authorityId
+// is stringified. There is no badge field (Android badges are channel-driven).
+type fcmMessage struct {
+	Notification fcmNotification   `json:"notification"`
+	Android      fcmAndroidConfig  `json:"android"`
+	Data         map[string]string `json:"data"`
+}
+
+type fcmNotification struct {
+	Title string `json:"title"`
+	Body  string `json:"body"`
+}
+
+type fcmAndroidConfig struct {
+	Priority     string                 `json:"priority"`
+	Notification fcmAndroidNotification `json:"notification"`
+}
+
+type fcmAndroidNotification struct {
+	ChannelID string `json:"channel_id"`
+}
+
+// fcmAlertChannelID is the Android notification channel the pushes post to. The
+// #777 client registers this channel; day-1 all shapes share it.
+const fcmAlertChannelID = "alerts"
+
+// marshalFCMMessage builds the token-less FCM message body from a rendered
+// title/body and the data dictionary.
+func marshalFCMMessage(title, body string, data map[string]string) (json.RawMessage, error) {
+	raw, err := json.Marshal(fcmMessage{
+		Notification: fcmNotification{Title: title, Body: body},
+		Android: fcmAndroidConfig{
+			Priority:     "HIGH",
+			Notification: fcmAndroidNotification{ChannelID: fcmAlertChannelID},
+		},
+		Data: data,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal fcm message: %w", err)
+	}
+	return raw, nil
+}
+
+// buildBucketFCMPayload renders one bucket's FCM message body, mirroring
+// buildBucketPayload: the rich single-app alert (with deep-link data) when
+// exactly one notification queued, otherwise the zone or saved summary.
+func buildBucketFCMPayload(bucketKey string, queued []notifications.DigestNotification, zoneNames map[string]string) (json.RawMessage, error) {
+	if len(queued) == 1 {
+		return buildAlertFCMPayload(queued[0])
+	}
+	if bucketKey == savedBucket {
+		return buildSavedSummaryFCMPayload(len(queued))
+	}
+	return buildZoneSummaryFCMPayload(len(queued), zoneNames[bucketKey], bucketKey)
+}
+
+// buildAlertFCMPayload renders the instant-push FCM body for a single
+// notification, carrying the same deep-link keys as the APNs alert
+// (notificationId / applicationRef / authorityId / createdAt) so the Android
+// client's tap-routing mirrors iOS. authorityId is stringified (FCM data values
+// are strings); there is no badge (Android badges are channel-driven).
+func buildAlertFCMPayload(n notifications.DigestNotification) (json.RawMessage, error) {
+	title, body := alertTitleBody(n)
+	return marshalFCMMessage(title, body, map[string]string{
+		"kind":           "alert",
+		"notificationId": n.ID,
+		"applicationRef": n.ApplicationName,
+		"authorityId":    strconv.Itoa(n.AuthorityID),
+		"createdAt":      platform.DotNetTime(n.CreatedAt).String(),
+	})
+}
+
+// buildZoneSummaryFCMPayload renders the coalesced watch-zone summary FCM body.
+// It carries kind=zoneSummary and watchZoneId (the #777 routing discriminators)
+// and, deliberately, none of the single-app deep-link keys.
+func buildZoneSummaryFCMPayload(count int, zoneName, watchZoneID string) (json.RawMessage, error) {
+	title, body := zoneSummaryTitleBody(count, zoneName)
+	return marshalFCMMessage(title, body, map[string]string{
+		"kind":        "zoneSummary",
+		"watchZoneId": watchZoneID,
+	})
+}
+
+// buildSavedSummaryFCMPayload renders the coalesced saved-bucket summary FCM
+// body: kind=savedSummary, no watchZoneId, no deep-link keys.
+func buildSavedSummaryFCMPayload(count int) (json.RawMessage, error) {
+	title, body := savedSummaryTitleBody(count)
+	return marshalFCMMessage(title, body, map[string]string{
+		"kind": "savedSummary",
+	})
 }

--- a/api-go/internal/platform/config.go
+++ b/api-go/internal/platform/config.go
@@ -122,6 +122,22 @@ type Config struct {
 	APNsBundleID   string
 	APNsUseSandbox bool
 
+	// FCM* configure the direct FCM HTTP v1 push client the worker modes use to
+	// deliver instant and digest alerts to Android devices (GH#780), the mirror of
+	// the APNs client for iOS. FCMEnabled gates whether the real sender is
+	// constructed; when false the worker wires a NoOp sender so a job without a
+	// service-account key boots cleanly. FCMProjectID is the Firebase/GCP project
+	// id the send URL targets (/v1/projects/{id}/messages:send). FCMServiceAccountJSON
+	// is the full service-account key JSON blob (the fcm-service-account secret),
+	// carrying the RSA private key, client email, and token URI the JWT-bearer OAuth
+	// exchange uses — the mirror of how APNsAuthKey carries the .p8. FCM has no
+	// sandbox concept (dev and prod share one Firebase project), so there is no
+	// FCM_USE_SANDBOX. A separate infra bead wires these env vars additively onto
+	// the push-sending worker jobs (poll-sb, digest, hourly-digest).
+	FCMEnabled            bool
+	FCMProjectID          string
+	FCMServiceAccountJSON SecretString
+
 	// ACSConnectionString is the Azure Communication Services connection string
 	// (endpoint=...;accesskey=...) the digest worker modes use to send email via
 	// the ACS Email REST client (epic tc-wad3, enabler tc-qyf5). It carries the
@@ -264,6 +280,10 @@ func LoadConfig() (Config, error) {
 		APNsTeamID:     getenv("APNS_TEAM_ID", defaultAPNsTeamID),
 		APNsBundleID:   getenv("APNS_BUNDLE_ID", defaultAppleBundleID),
 		APNsUseSandbox: getenvBool("APNS_USE_SANDBOX"),
+
+		FCMEnabled:            getenvBool("FCM_ENABLED"),
+		FCMProjectID:          os.Getenv("FCM_PROJECT_ID"),
+		FCMServiceAccountJSON: NewSecret(os.Getenv("FCM_SERVICE_ACCOUNT_JSON")),
 
 		ACSConnectionString: NewSecret(os.Getenv("ACS_CONNECTION_STRING")),
 


### PR DESCRIPTION
## Changes

- feat(api): FCM push delivery for Android devices (tc-q4yaa)

api-go half of GH#780 (Android FCM push delivery), part of the Android parity epic (#770). Adds a new `internal/fcm` package mirroring `internal/apns` (HTTP v1 sender, hand-rolled RS256 service-account JWT-bearer OAuth exchange with token caching, NoOp twin, invalid-token pruning), three FCM payload builders mirroring the existing APNs shapes, and a `PlatformDispatcher` that splits a recipient's device tokens by platform and sends the iOS bucket via APNs / Android bucket via FCM, pruning the union of invalid tokens. Wired into both push sites: `notifydispatch/coalescer.go` (instant pushes) and `internal/digest/handler.go` (weekly Pro digest). New `FCM_ENABLED`/`FCM_PROJECT_ID`/`FCM_SERVICE_ACCOUNT_JSON` config vars — names cross-checked to match the infra wiring merged in #826 exactly.

APNs delivery is byte-identical: shared title/body helpers factored out so the two platforms can't drift, and every existing apns/notifydispatch/digest test passes unmodified.

**Deviation from the issue text, flagged for visibility:** the issue's pre-resolved design decision named `golang.org/x/oauth2/google` for the OAuth token exchange. This PR hand-rolls the RS256 JWT-bearer flow with stdlib crypto instead — zero new dependencies, mirrors `internal/apns/jwt.go`'s existing hand-rolled ES256 pattern exactly, and is fully testable with the project's fake-HTTP-transport convention. Reviewed line-by-line (PEM/PKCS8 key parsing, claims, signing, token caching with expiry margin, bounded response read) — straightforward and correct. Easy to swap to the named library if preferred.

Verified independently: `go build ./...`, `gofmt -l .`, `go vet ./...`, `golangci-lint run ./...` all clean; `go test ./...` = 1496 passed across 47 packages.

**Not yet deployed to prod** — needs the merged infra PR's Pulumi config live (#826, already merged) and a tagged prod release to actually send. Prod FCM project id: `town-crier-e4359`.

---
*Auto-shipped via ship skill*