### PR TITLE
fix(infra): allow-list pg_trgm Postgres extension

### DIFF
--- a/infra/shared.go
+++ b/infra/shared.go
@@ -343,12 +343,13 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		return err
 	}
 
-	// Allowlist the PostGIS extension via the azure.extensions server parameter. Without it,
-	// `CREATE EXTENSION postgis` is rejected. Source must be "user-override" or Azure ignores
-	// the assigned value. A server parameter change is a server-level operation that cannot run
-	// while the server is busy with another operation, so this is serialised after the firewall
-	// rule (DependsOn) — applying both concurrently right after server creation trips
-	// "ServerIsBusy".
+	// Allowlist the PostGIS and pg_trgm extensions via the azure.extensions server parameter.
+	// Without it, `CREATE EXTENSION postgis` / `CREATE EXTENSION pg_trgm` are rejected. pg_trgm
+	// (trigram matching) is required by the application-search-indexes migration for fuzzy/
+	// partial text search. Source must be "user-override" or Azure ignores the assigned value.
+	// A server parameter change is a server-level operation that cannot run while the server is
+	// busy with another operation, so this is serialised after the firewall rule (DependsOn) —
+	// applying both concurrently right after server creation trips "ServerIsBusy".
 	//
 	// Note: built-in PgBouncer (the `pgbouncer.enabled` parameter) is deliberately not set — it
 	// is unsupported on the Burstable tier (B1ms) and Azure rejects it with
@@ -359,7 +360,7 @@ func runSharedStack(ctx *pulumi.Context, conf *config.Config, tags pulumi.String
 		ResourceGroupName: resourceGroup.Name,
 		ServerName:        postgresServer.Name,
 		Source:            pulumi.String("user-override"),
-		Value:             pulumi.String("POSTGIS"),
+		Value:             pulumi.String("POSTGIS,pg_trgm"),
 	}, pulumi.DependsOn([]pulumi.Resource{postgresFirewall}))
 	if err != nil {
 		return err


### PR DESCRIPTION
## Changes

- fix(infra): allow-list pg_trgm Postgres extension (tc-6cwo2)

**Production incident, unrelated to the Android/FCM epic in flight.** Migration `0018_application_search_indexes.sql` (PR #824, tc-geq7h.3) requires `CREATE EXTENSION pg_trgm`, but the shared Postgres server's `azure.extensions` allow-list only had `POSTGIS`. This is currently blocking `cd-prod`'s "Database: Run migrations (prod)" step for **every** prod release since #824 merged — including the just-shipped FCM push work (#826/#827, v0.15.73), which is stuck mid-deploy (infra + web deployed, but Go API + Worker skipped pending migrations).

One-line fix in `infra/shared.go`: the existing `azure.extensions` `Configuration` resource (added for PostGIS) now allow-lists `pg_trgm` too: `Value: "POSTGIS"` → `Value: "POSTGIS,pg_trgm"`.

Verified against the live `shared` stack: `pulumi preview --diff` shows exactly one resource updating (`psql-town-crier-shared-azure-extensions`, value change only), 35 unchanged.

This is the **shared** Pulumi stack, which deploys via `cd-dev` on every push to main (not `cd-prod`, which only deploys `prod`/environment). Once this merges and `cd-dev` applies it, the stalled v0.15.73 `cd-prod` run (28734648964) will be re-run to retry migrations and complete the FCM deploy — no new tag needed.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded database support for advanced text search, enabling fuzzy and partial matching in search-related features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->