### PR TITLE
feat(web): serve assetlinks.json on main domain

### DIFF
--- a/web/public/.well-known/assetlinks.json
+++ b/web/public/.well-known/assetlinks.json
@@ -1,0 +1,12 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "uk.towncrierapp.mobile.dev",
+      "sha256_cert_fingerprint": [
+        "75:2F:87:AF:52:B6:4D:33:71:ED:77:2A:2A:1C:D9:7A:A4:67:9E:1A:17:F0:9F:FD:92:12:D6:55:92:FD:0E:07"
+      ]
+    }
+  }
+]

--- a/web/src/__tests__/static-web-app-config.test.ts
+++ b/web/src/__tests__/static-web-app-config.test.ts
@@ -152,3 +152,53 @@ describe('staticwebapp.config.json — AASA route', () => {
     expect(parsed.applinks.details.length).toBeGreaterThan(0);
   });
 });
+
+describe('assetlinks.json', () => {
+  interface AssetLinksTarget {
+    namespace: string;
+    package_name: string;
+    sha256_cert_fingerprint: string[];
+  }
+
+  interface AssetLinksEntry {
+    relation: string[];
+    target: AssetLinksTarget;
+  }
+
+  function loadAssetLinks(): AssetLinksEntry[] {
+    const assetLinksPath = resolve(
+      __dirname,
+      '../../public/.well-known/assetlinks.json',
+    );
+    const raw = readFileSync(assetLinksPath, 'utf-8');
+    return JSON.parse(raw) as AssetLinksEntry[];
+  }
+
+  it('grants delegate_permission/common.handle_all_urls to every entry', () => {
+    const assetLinks = loadAssetLinks();
+
+    expect(assetLinks.length).toBeGreaterThan(0);
+    for (const entry of assetLinks) {
+      expect(entry.relation).toContain('delegate_permission/common.handle_all_urls');
+    }
+  });
+
+  it('targets the android_app namespace for every entry', () => {
+    const assetLinks = loadAssetLinks();
+
+    for (const entry of assetLinks) {
+      expect(entry.target.namespace).toBe('android_app');
+    }
+  });
+
+  it('declares the debug keystore SHA-256 fingerprint for uk.towncrierapp.mobile.dev', () => {
+    const assetLinks = loadAssetLinks();
+    const devEntry = assetLinks.find(
+      (entry) => entry.target.package_name === 'uk.towncrierapp.mobile.dev',
+    );
+
+    expect(devEntry?.target.sha256_cert_fingerprint).toContain(
+      '75:2F:87:AF:52:B6:4D:33:71:ED:77:2A:2A:1C:D9:7A:A4:67:9E:1A:17:F0:9F:FD:92:12:D6:55:92:FD:0E:07',
+    );
+  });
+});


### PR DESCRIPTION
## Changes

- red: assetlinks.json shape tests (tc-fgpoj)
- green: serve assetlinks.json for Android App Links (tc-fgpoj)

Web half of GH#782 (Android App Links / share). Adds a static `web/public/.well-known/assetlinks.json` (real `.json` extension, no rewrite rule needed unlike AASA) with one Digital Asset Links entry for `uk.towncrierapp.mobile.dev`, using the debug keystore's SHA-256 fingerprint. Extends `static-web-app-config.test.ts` with 3 tests mirroring the existing AASA coverage.

The prod package (`uk.towncrierapp.mobile`) entry is deliberately omitted for now — no real fingerprint exists until Play App Signing enrolment (#779) — rather than shipping a placeholder that could get mistaken for real. The api-go sibling (assetlinks.json on the share domain, tc-ar3ys) is shipping as a separate PR and makes the same call.

---
*Auto-shipped via ship skill*