### PR TITLE
feat: public /search page with copy-share-link results (tc-geq7h.4)

### DIFF
--- a/web/src/AppRoutes.tsx
+++ b/web/src/AppRoutes.tsx
@@ -3,6 +3,7 @@ import { Routes, Route } from 'react-router-dom';
 import { LandingPage } from './features/LandingPage/LandingPage';
 import { CallbackPage } from './auth/CallbackPage';
 import { ConnectedLegalPage } from './features/legal/ConnectedLegalPage';
+import { ConnectedSearchPage } from './features/Search/ConnectedSearchPage';
 import { AuthGuard } from './auth/AuthGuard';
 import { OnboardingGate } from './auth/OnboardingGate';
 import { AppShell } from './components/AppShell/AppShell';
@@ -51,6 +52,7 @@ export function AppRoutes() {
       <Route path="/" element={<LandingPage />} />
       <Route path="/callback" element={<CallbackPage />} />
       <Route path="/legal/:type" element={<ConnectedLegalPage />} />
+      <Route path="/search" element={<ConnectedSearchPage />} />
 
       {/* Authenticated routes */}
       <Route element={<AuthGuard />}>

--- a/web/src/__tests__/naming-conventions.test.ts
+++ b/web/src/__tests__/naming-conventions.test.ts
@@ -59,7 +59,7 @@ describe('DI wrapper naming convention', () => {
 
     const connectedFiles = findConnectedFiles(featuresDir).sort();
 
-    // All 11 DI wrapper files should use Connected prefix (Groups removed; SavedApplications re-introduced; Search removed pre-launch — see tc-b1jo; Notifications decommissioned — see tc-1nsa.10)
+    // All 12 DI wrapper files should use Connected prefix (Groups removed; SavedApplications re-introduced; old Pro-tier free-text Search removed pre-launch (tc-b1jo) and replaced by the new anonymous public /search page (tc-geq7h.4, #821 Phase 4); Notifications decommissioned — see tc-1nsa.10)
     expect(connectedFiles).toEqual([
       'ConnectedApplicationDetailPage.tsx',
       'ConnectedApplicationsPage.tsx',
@@ -68,6 +68,7 @@ describe('DI wrapper naming convention', () => {
       'ConnectedMapPage.tsx',
       'ConnectedOnboardingPage.tsx',
       'ConnectedSavedApplicationsPage.tsx',
+      'ConnectedSearchPage.tsx',
       'ConnectedSettingsPage.tsx',
       'ConnectedWatchZoneCreatePage.tsx',
       'ConnectedWatchZoneEditPage.tsx',

--- a/web/src/components/Footer/Footer.module.css
+++ b/web/src/components/Footer/Footer.module.css
@@ -46,6 +46,26 @@
   text-decoration: none;
 }
 
+/* ---------- Explore: planning authority/town indexes + search ---------- */
+.explore {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: var(--tc-space-md);
+  margin-bottom: var(--tc-space-lg);
+}
+
+.exploreLink {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+  text-decoration: none;
+}
+
+.exploreLink:hover {
+  color: var(--tc-amber);
+  text-decoration: underline;
+}
+
 /* ---------- Bottom bar: copyright + legal ---------- */
 .bottom {
   display: flex;

--- a/web/src/components/Footer/Footer.tsx
+++ b/web/src/components/Footer/Footer.tsx
@@ -22,6 +22,19 @@ export function Footer() {
           </a>
         </div>
 
+        {/*
+         * Plain full-page <a> tags, not React Router <Link>: /planning/ and
+         * /planning/towns/ are static-generated pages outside the SPA (#821
+         * Phases 1-2), and /search — though an in-SPA route (#821 Phase 4) —
+         * is kept in the same plain-anchor style as the legal nav below for
+         * visual/behavioural consistency across this footer.
+         */}
+        <nav aria-label="Explore" className={styles.explore}>
+          <a href="/planning/" className={styles.exploreLink}>Planning applications by council</a>
+          <a href="/planning/towns/" className={styles.exploreLink}>Planning applications by town</a>
+          <a href="/search" className={styles.exploreLink}>Search planning applications</a>
+        </nav>
+
         <div className={styles.bottom}>
           <p className={styles.copyright}>
             © {currentYear} Town Crier

--- a/web/src/components/Footer/__tests__/Footer.test.tsx
+++ b/web/src/components/Footer/__tests__/Footer.test.tsx
@@ -74,4 +74,22 @@ describe('Footer', () => {
     const links = within(nav).getAllByRole('link');
     expect(links).toHaveLength(2);
   });
+
+  it('renders an Explore nav linking to the planning authority and town indexes plus search', () => {
+    render(<Footer />);
+
+    const nav = screen.getByRole('navigation', { name: /explore/i });
+    expect(nav).toBeInTheDocument();
+
+    const authorityLink = within(nav).getByRole('link', { name: /planning applications by council/i });
+    expect(authorityLink).toHaveAttribute('href', '/planning/');
+
+    const townLink = within(nav).getByRole('link', { name: /planning applications by town/i });
+    expect(townLink).toHaveAttribute('href', '/planning/towns/');
+
+    const searchLink = within(nav).getByRole('link', { name: /search planning applications/i });
+    expect(searchLink).toHaveAttribute('href', '/search');
+
+    expect(within(nav).getAllByRole('link')).toHaveLength(3);
+  });
 });

--- a/web/src/domain/__tests__/share-link.test.ts
+++ b/web/src/domain/__tests__/share-link.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { buildShareUrl } from '../share-link';
+
+describe('buildShareUrl', () => {
+  it('builds the public share-page URL from an authority slug and reference', () => {
+    expect(buildShareUrl('cambridge', '22/1234/FUL')).toBe(
+      'https://share.towncrierapp.uk/a/cambridge/22/1234/FUL',
+    );
+  });
+
+  it('does not URL-encode slashes in the reference', () => {
+    // The share route (`GET /a/{authoritySlug}/{ref...}`) matches a trailing
+    // wildcard on literal path segments — a PlanIt reference such as
+    // "9/P/2026/0044/HH" must survive as raw slashes, not "%2F".
+    const url = buildShareUrl('adur', '9/P/2026/0044/HH');
+    expect(url).toBe('https://share.towncrierapp.uk/a/adur/9/P/2026/0044/HH');
+    expect(url).not.toContain('%2F');
+  });
+
+  it('builds a URL for a reference with no slashes', () => {
+    expect(buildShareUrl('cornwall', '24-0001-FUL')).toBe(
+      'https://share.towncrierapp.uk/a/cornwall/24-0001-FUL',
+    );
+  });
+});

--- a/web/src/domain/ports/search-port.ts
+++ b/web/src/domain/ports/search-port.ts
@@ -1,0 +1,27 @@
+import type { SearchResult } from '../types';
+
+/**
+ * Response shape of one anonymous search call. `refineQuery` is true when the
+ * match set exceeded the server's limit — the caller should nudge the user to
+ * narrow their search rather than treat `results` as exhaustive.
+ */
+export interface SearchOutcome {
+  readonly results: readonly SearchResult[];
+  readonly refineQuery: boolean;
+}
+
+/**
+ * Anonymous application search (#821 Phase 3/4) —
+ * `GET /v1/applications/search`. Public and unauthenticated: no auth token is
+ * ever attached to this call, so it must keep working for a fully logged-out
+ * visitor.
+ */
+export interface SearchPort {
+  /**
+   * @param query non-empty search text (reference, address fragment, or
+   *   description keywords).
+   * @param authority optional authority id-or-slug filter; `null` searches
+   *   across all authorities.
+   */
+  search(query: string, authority: string | null): Promise<SearchOutcome>;
+}

--- a/web/src/domain/share-link.ts
+++ b/web/src/domain/share-link.ts
@@ -1,0 +1,18 @@
+const SHARE_ORIGIN = 'https://share.towncrierapp.uk';
+
+/**
+ * Builds the public share-page URL for a search result (#821 Phase 4). The
+ * result's `reference` is already the correct path segment — the anonymous
+ * search API returns `planit_name`, not `uid`, specifically so this link
+ * resolves (see api-go SearchResult doc comment).
+ *
+ * `reference` is concatenated raw, deliberately NOT URL-encoded: a PlanIt
+ * reference such as "9/P/2026/0044/HH" legitimately contains slashes, and the
+ * share page's route (`GET /a/{authoritySlug}/{ref...}`) matches them as
+ * literal path segments via a trailing wildcard
+ * (api-go/internal/sharepage/handler.go) — encoding them would turn one
+ * wildcard segment into a literal "%2F" that fails to resolve.
+ */
+export function buildShareUrl(authoritySlug: string, reference: string): string {
+  return `${SHARE_ORIGIN}/a/${authoritySlug}/${reference}`;
+}

--- a/web/src/domain/types.ts
+++ b/web/src/domain/types.ts
@@ -237,6 +237,26 @@ export interface NotificationStateSnapshot {
 }
 
 // ---------------------------------------------------------------------------
+// Anonymous application search (#821 Phase 3/4)
+// ---------------------------------------------------------------------------
+
+/**
+ * One ranked row of the anonymous `GET /v1/applications/search` endpoint.
+ * `reference` is `planit_name`, NOT `uid` — the API returns it that way
+ * specifically so `domain/share-link.ts` can build a resolving share URL
+ * without any further lookup or transformation.
+ */
+export interface SearchResult {
+  readonly reference: string;
+  readonly authoritySlug: string;
+  readonly authorityName: string;
+  readonly address: string;
+  readonly appState: string | null;
+  readonly startDate: string | null;
+  readonly decidedDate: string | null;
+}
+
+// ---------------------------------------------------------------------------
 // Map clusters
 // ---------------------------------------------------------------------------
 

--- a/web/src/features/Search/ApiSearchPort.ts
+++ b/web/src/features/Search/ApiSearchPort.ts
@@ -52,7 +52,16 @@ export class ApiSearchPort implements SearchPort {
       params.set('authority', authority);
     }
 
-    const response = await this.fetchFn(`${this.baseUrl}/v1/applications/search?${params.toString()}`);
+    let response: Response;
+    try {
+      response = await this.fetchFn(`${this.baseUrl}/v1/applications/search?${params.toString()}`);
+    } catch {
+      // fetch() itself rejecting (offline, DNS failure, CORS, etc.) throws an
+      // engine-specific, unfriendly message ("Failed to fetch", "NetworkError
+      // when attempting to fetch resource", "Load failed") — never surface
+      // that verbatim to an anonymous visitor of a public page.
+      throw new Error('Could not reach the search service. Check your connection and try again.');
+    }
 
     if (!response.ok) {
       throw new Error('Failed to search applications');

--- a/web/src/features/Search/ApiSearchPort.ts
+++ b/web/src/features/Search/ApiSearchPort.ts
@@ -1,0 +1,67 @@
+import type { SearchOutcome, SearchPort } from '../../domain/ports/search-port';
+import type { SearchResult } from '../../domain/types';
+
+interface SearchResultDto {
+  readonly reference: string;
+  readonly authoritySlug: string;
+  readonly authorityName: string;
+  readonly address: string;
+  readonly appState: string | null;
+  readonly startDate: string | null;
+  readonly decidedDate: string | null;
+}
+
+interface SearchResponseDto {
+  readonly query: string;
+  readonly results: readonly SearchResultDto[];
+  readonly refineQuery: boolean;
+}
+
+function mapToDomain(dto: SearchResultDto): SearchResult {
+  return {
+    reference: dto.reference,
+    authoritySlug: dto.authoritySlug,
+    authorityName: dto.authorityName,
+    address: dto.address,
+    appState: dto.appState,
+    startDate: dto.startDate,
+    decidedDate: dto.decidedDate,
+  };
+}
+
+/**
+ * Anonymous adapter for `GET /v1/applications/search` (#821 Phase 4). Unlike
+ * the authenticated `ApiClient` (`src/api/client.ts`), this never attaches an
+ * `Authorization` header — the endpoint is public and must work for a fully
+ * logged-out visitor, so it talks to `fetch` directly rather than going
+ * through the token-bearing client (mirrors `ApiLegalDocumentPort`, the other
+ * anonymous-page adapter in this codebase).
+ */
+export class ApiSearchPort implements SearchPort {
+  private readonly baseUrl: string;
+  private readonly fetchFn: typeof globalThis.fetch;
+
+  constructor(baseUrl: string, fetchFn: typeof globalThis.fetch = globalThis.fetch.bind(globalThis)) {
+    this.baseUrl = baseUrl;
+    this.fetchFn = fetchFn;
+  }
+
+  async search(query: string, authority: string | null): Promise<SearchOutcome> {
+    const params = new URLSearchParams({ q: query });
+    if (authority !== null && authority !== '') {
+      params.set('authority', authority);
+    }
+
+    const response = await this.fetchFn(`${this.baseUrl}/v1/applications/search?${params.toString()}`);
+
+    if (!response.ok) {
+      throw new Error('Failed to search applications');
+    }
+
+    const dto = (await response.json()) as SearchResponseDto;
+    return {
+      results: dto.results.map(mapToDomain),
+      refineQuery: dto.refineQuery,
+    };
+  }
+}

--- a/web/src/features/Search/ConnectedSearchPage.tsx
+++ b/web/src/features/Search/ConnectedSearchPage.tsx
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { ApiSearchPort } from './ApiSearchPort';
+import { SearchPage } from './SearchPage';
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string || 'http://localhost:5000';
+
+/**
+ * Composition root for the public `/search` route (#821 Phase 4). Wires the
+ * anonymous `ApiSearchPort` directly — never the token-bearing `ApiClient` —
+ * so this page keeps working for a visitor who has never signed in.
+ */
+export function ConnectedSearchPage() {
+  const port = useMemo(() => new ApiSearchPort(API_BASE_URL), []);
+
+  return <SearchPage port={port} />;
+}

--- a/web/src/features/Search/SearchPage.module.css
+++ b/web/src/features/Search/SearchPage.module.css
@@ -1,0 +1,94 @@
+.container {
+  max-width: var(--tc-content-max-width);
+  margin: 0 auto;
+  padding: var(--tc-space-xl) var(--tc-space-md);
+}
+
+.heading {
+  font-size: var(--tc-text-display-small);
+  font-weight: var(--tc-weight-semibold);
+  color: var(--tc-text-primary);
+  margin: 0 0 var(--tc-space-sm);
+}
+
+.intro {
+  font-size: var(--tc-text-body);
+  color: var(--tc-text-secondary);
+  margin: 0 0 var(--tc-space-lg);
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tc-space-sm);
+  margin-bottom: var(--tc-space-lg);
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--tc-space-xs);
+}
+
+.label {
+  font-size: var(--tc-text-caption);
+  font-weight: var(--tc-weight-medium);
+  color: var(--tc-text-secondary);
+}
+
+.input {
+  min-height: 44px;
+  padding: var(--tc-space-sm) var(--tc-space-md);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  background: var(--tc-surface);
+  color: var(--tc-text-primary);
+  font-size: var(--tc-text-body);
+}
+
+.input:focus-visible {
+  outline: 2px solid var(--tc-border-focused);
+  outline-offset: 2px;
+}
+
+.status {
+  font-size: var(--tc-text-body);
+  color: var(--tc-text-secondary);
+  margin: 0 0 var(--tc-space-md);
+}
+
+.error {
+  font-size: var(--tc-text-body);
+  color: var(--tc-status-rejected);
+  margin: 0 0 var(--tc-space-md);
+}
+
+.notice {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+  background: var(--tc-amber-muted);
+  border-radius: var(--tc-radius-md);
+  padding: var(--tc-space-sm) var(--tc-space-md);
+  margin: 0 0 var(--tc-space-md);
+}
+
+.results {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--tc-space-md);
+  margin: 0;
+  padding: 0;
+}
+
+@media (min-width: 640px) {
+  .form {
+    flex-direction: row;
+    align-items: flex-end;
+    flex-wrap: wrap;
+  }
+
+  .field {
+    flex: 1 1 240px;
+  }
+}

--- a/web/src/features/Search/SearchPage.tsx
+++ b/web/src/features/Search/SearchPage.tsx
@@ -1,0 +1,108 @@
+import { useEffect } from 'react';
+import type { SearchPort } from '../../domain/ports/search-port';
+import { useSearch } from './useSearch';
+import { SearchResultCard } from './components/SearchResultCard';
+import styles from './SearchPage.module.css';
+
+interface Props {
+  port: SearchPort;
+}
+
+const PAGE_TITLE = 'Search UK planning applications | Town Crier';
+const PAGE_DESCRIPTION =
+  'Search UK council planning applications by reference, address, or description, and copy a shareable link to any result.';
+
+/**
+ * Public, anonymous `/search` page (#821 Phase 4) — outside `AuthGuard`, works
+ * fully logged out. Sets its own `<title>`/meta description on mount so the
+ * page is indexable in its own right, distinct from the landing page; results
+ * are client-rendered and deliberately never added to `sitemap.xml`.
+ */
+export function SearchPage({ port }: Props) {
+  const {
+    query,
+    setQuery,
+    authority,
+    setAuthority,
+    results,
+    isLoading,
+    error,
+    refineQuery,
+    hasSearched,
+  } = useSearch(port);
+
+  useEffect(() => {
+    const previousTitle = document.title;
+    document.title = PAGE_TITLE;
+
+    const metaDescription = document.querySelector('meta[name="description"]');
+    const previousDescription = metaDescription?.getAttribute('content') ?? null;
+    metaDescription?.setAttribute('content', PAGE_DESCRIPTION);
+
+    return () => {
+      document.title = previousTitle;
+      if (metaDescription && previousDescription !== null) {
+        metaDescription.setAttribute('content', previousDescription);
+      }
+    };
+  }, []);
+
+  const showEmptyState = hasSearched && !isLoading && error === null && results.length === 0;
+
+  return (
+    <main className={styles.container}>
+      <h1 className={styles.heading}>Search planning applications</h1>
+      <p className={styles.intro}>
+        Find a UK council planning application by reference, address, or description, then copy a
+        link to share it.
+      </p>
+
+      <form className={styles.form} onSubmit={(event) => event.preventDefault()}>
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="search-query">
+            Search
+          </label>
+          <input
+            id="search-query"
+            type="search"
+            className={styles.input}
+            placeholder="Reference, address, or description"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+        </div>
+
+        <div className={styles.field}>
+          <label className={styles.label} htmlFor="search-authority">
+            Council (optional)
+          </label>
+          <input
+            id="search-authority"
+            type="text"
+            className={styles.input}
+            placeholder="e.g. cambridge"
+            value={authority}
+            onChange={(event) => setAuthority(event.target.value)}
+          />
+        </div>
+      </form>
+
+      {isLoading && <p className={styles.status}>Searching…</p>}
+      {error !== null && <p className={styles.error}>{error}</p>}
+      {refineQuery && (
+        <p className={styles.notice}>
+          Showing the first 20 matches — try a more specific search to narrow the results.
+        </p>
+      )}
+      {showEmptyState && <p className={styles.status}>No applications matched your search.</p>}
+
+      {results.length > 0 && (
+        <ul className={styles.results}>
+          {results.map((result) => (
+            <SearchResultCard key={`${result.authoritySlug}/${result.reference}`} result={result} />
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/web/src/features/Search/__tests__/ApiSearchPort.test.ts
+++ b/web/src/features/Search/__tests__/ApiSearchPort.test.ts
@@ -126,10 +126,16 @@ describe('ApiSearchPort', () => {
     await expect(port.search('a', null)).rejects.toThrow('Failed to search applications');
   });
 
-  it('throws when fetch rejects', async () => {
+  it('throws a friendly message when fetch itself fails (offline, DNS, CORS, etc.)', async () => {
+    // Real browsers throw an unfriendly, engine-specific message here — Chrome's
+    // "Failed to fetch", Firefox's "NetworkError when attempting to fetch
+    // resource", Safari's "Load failed" — none of which should reach an
+    // anonymous visitor of a public page verbatim.
     stub.shouldReject = true;
-    stub.rejectError = new Error('Network failure');
+    stub.rejectError = new TypeError('Failed to fetch');
 
-    await expect(port.search('mill road', null)).rejects.toThrow('Network failure');
+    await expect(port.search('mill road', null)).rejects.toThrow(
+      'Could not reach the search service. Check your connection and try again.',
+    );
   });
 });

--- a/web/src/features/Search/__tests__/ApiSearchPort.test.ts
+++ b/web/src/features/Search/__tests__/ApiSearchPort.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ApiSearchPort } from '../ApiSearchPort';
+
+class StubFetch {
+  lastUrl: string | null = null;
+  lastInit: RequestInit | undefined = undefined;
+  responseBody: unknown = { query: '', results: [], refineQuery: false };
+  responseStatus = 200;
+  shouldReject = false;
+  rejectError: Error = new Error('Network failure');
+
+  readonly fetch: typeof globalThis.fetch = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => {
+    this.lastUrl = String(input);
+    this.lastInit = init;
+    if (this.shouldReject) {
+      throw this.rejectError;
+    }
+    return {
+      ok: this.responseStatus >= 200 && this.responseStatus < 300,
+      status: this.responseStatus,
+      json: async () => this.responseBody,
+    } as Response;
+  };
+}
+
+describe('ApiSearchPort', () => {
+  let stub: StubFetch;
+  let port: ApiSearchPort;
+  const baseUrl = 'https://api.example.com';
+
+  beforeEach(() => {
+    stub = new StubFetch();
+    port = new ApiSearchPort(baseUrl, stub.fetch);
+  });
+
+  it('fetches from the search endpoint with the query string', async () => {
+    await port.search('mill road', null);
+
+    expect(stub.lastUrl).toBe('https://api.example.com/v1/applications/search?q=mill+road');
+  });
+
+  it('adds the authority filter when provided', async () => {
+    await port.search('mill road', 'cambridge');
+
+    const url = new URL(stub.lastUrl!);
+    expect(url.searchParams.get('q')).toBe('mill road');
+    expect(url.searchParams.get('authority')).toBe('cambridge');
+  });
+
+  it('never attaches an Authorization header — this endpoint is anonymous', async () => {
+    await port.search('mill road', null);
+
+    const headers = stub.lastInit?.headers;
+    expect(headers).toBeUndefined();
+  });
+
+  it('maps a successful response to results and refineQuery', async () => {
+    stub.responseBody = {
+      query: 'mill road',
+      results: [
+        {
+          reference: '22/1234/FUL',
+          authoritySlug: 'cambridge',
+          authorityName: 'Cambridge City Council',
+          address: '12 Mill Road, Cambridge, CB1 2AD',
+          appState: 'Permitted',
+          startDate: '2026-01-15',
+          decidedDate: '2026-03-01',
+        },
+      ],
+      refineQuery: true,
+    };
+
+    const outcome = await port.search('mill road', null);
+
+    expect(outcome.refineQuery).toBe(true);
+    expect(outcome.results).toEqual([
+      {
+        reference: '22/1234/FUL',
+        authoritySlug: 'cambridge',
+        authorityName: 'Cambridge City Council',
+        address: '12 Mill Road, Cambridge, CB1 2AD',
+        appState: 'Permitted',
+        startDate: '2026-01-15',
+        decidedDate: '2026-03-01',
+      },
+    ]);
+  });
+
+  it('maps nullable fields through as null', async () => {
+    stub.responseBody = {
+      query: 'ref',
+      results: [
+        {
+          reference: '24/0001/FUL',
+          authoritySlug: 'adur',
+          authorityName: 'Adur District Council',
+          address: '1 High Street',
+          appState: null,
+          startDate: null,
+          decidedDate: null,
+        },
+      ],
+      refineQuery: false,
+    };
+
+    const outcome = await port.search('ref', null);
+
+    expect(outcome.results[0]).toEqual({
+      reference: '24/0001/FUL',
+      authoritySlug: 'adur',
+      authorityName: 'Adur District Council',
+      address: '1 High Street',
+      appState: null,
+      startDate: null,
+      decidedDate: null,
+    });
+  });
+
+  it('throws when the API returns a non-ok status', async () => {
+    stub.responseStatus = 400;
+
+    await expect(port.search('a', null)).rejects.toThrow('Failed to search applications');
+  });
+
+  it('throws when fetch rejects', async () => {
+    stub.shouldReject = true;
+    stub.rejectError = new Error('Network failure');
+
+    await expect(port.search('mill road', null)).rejects.toThrow('Network failure');
+  });
+});

--- a/web/src/features/Search/__tests__/ConnectedSearchPage.test.tsx
+++ b/web/src/features/Search/__tests__/ConnectedSearchPage.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ConnectedSearchPage } from '../ConnectedSearchPage';
+
+describe('ConnectedSearchPage', () => {
+  it('renders the public search page without any authentication context', () => {
+    // Deliberately rendered with NO Auth0Provider/AuthGuard/router context beyond
+    // what the page itself needs — proves the anonymous /search route never
+    // depends on being signed in (#821 Phase 4 acceptance criterion).
+    render(<ConnectedSearchPage />);
+
+    expect(
+      screen.getByRole('heading', { name: /search planning applications/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/search/i)).toBeInTheDocument();
+  });
+});

--- a/web/src/features/Search/__tests__/SearchPage.test.tsx
+++ b/web/src/features/Search/__tests__/SearchPage.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { SearchPage } from '../SearchPage';
+import { SpySearchPort } from './spies/spy-search-port';
+import { aSearchResult, anotherSearchResult } from './fixtures/search-result.fixtures';
+
+describe('SearchPage', () => {
+  afterEach(() => {
+    document.title = '';
+  });
+
+  it('renders a heading and a search input', () => {
+    render(<SearchPage port={new SpySearchPort()} />);
+
+    expect(screen.getByRole('heading', { name: /search planning applications/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/search/i)).toBeInTheDocument();
+  });
+
+  it('sets an indexable, search-specific document title and meta description', () => {
+    const originalDescription = document.createElement('meta');
+    originalDescription.setAttribute('name', 'description');
+    originalDescription.setAttribute('content', 'Town Crier home');
+    document.head.appendChild(originalDescription);
+
+    const { unmount } = render(<SearchPage port={new SpySearchPort()} />);
+
+    expect(document.title).toMatch(/search/i);
+    expect(document.title).toMatch(/town crier/i);
+    expect(originalDescription.getAttribute('content')).toMatch(/search/i);
+
+    unmount();
+    expect(originalDescription.getAttribute('content')).toBe('Town Crier home');
+    document.head.removeChild(originalDescription);
+  });
+
+  it('shows results after the debounced search resolves', async () => {
+    const spy = new SpySearchPort();
+    spy.searchResult = { results: [aSearchResult(), anotherSearchResult()], refineQuery: false };
+    render(<SearchPage port={spy} />);
+
+    fireEvent.change(screen.getByLabelText(/search/i), { target: { value: 'mill road' } });
+
+    await waitFor(
+      () => {
+        expect(screen.getByRole('heading', { name: '22/1234/FUL' })).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+    expect(screen.getByRole('heading', { name: '24/0001/FUL' })).toBeInTheDocument();
+  });
+
+  it('shows a refine-your-search notice when the match set was truncated', async () => {
+    const spy = new SpySearchPort();
+    spy.searchResult = { results: [aSearchResult()], refineQuery: true };
+    render(<SearchPage port={spy} />);
+
+    fireEvent.change(screen.getByLabelText(/search/i), { target: { value: 'road' } });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/more specific/i)).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('shows an empty-results message when the search returns nothing', async () => {
+    const spy = new SpySearchPort();
+    spy.searchResult = { results: [], refineQuery: false };
+    render(<SearchPage port={spy} />);
+
+    fireEvent.change(screen.getByLabelText(/search/i), { target: { value: 'nonexistent' } });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/no applications matched/i)).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('shows an error message when the search fails', async () => {
+    const spy = new SpySearchPort();
+    spy.searchError = new Error('Request failed with status 500');
+    render(<SearchPage port={spy} />);
+
+    fireEvent.change(screen.getByLabelText(/search/i), { target: { value: 'mill road' } });
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Request failed with status 500')).toBeInTheDocument();
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('passes the authority filter through to the port', async () => {
+    const spy = new SpySearchPort();
+    render(<SearchPage port={spy} />);
+
+    fireEvent.change(screen.getByLabelText(/council/i), { target: { value: 'cambridge' } });
+    fireEvent.change(screen.getByLabelText(/search/i), { target: { value: 'mill road' } });
+
+    await waitFor(
+      () => {
+        expect(spy.searchCalls).toHaveLength(1);
+      },
+      { timeout: 2000 },
+    );
+    expect(spy.searchCalls[0]).toEqual({ query: 'mill road', authority: 'cambridge' });
+  });
+
+  it('does not search on mount, before the user has typed anything', async () => {
+    const spy = new SpySearchPort();
+    render(<SearchPage port={spy} />);
+
+    await new Promise((r) => setTimeout(r, 600));
+    expect(spy.searchCalls).toHaveLength(0);
+  });
+});

--- a/web/src/features/Search/__tests__/fixtures/search-result.fixtures.ts
+++ b/web/src/features/Search/__tests__/fixtures/search-result.fixtures.ts
@@ -1,0 +1,27 @@
+import type { SearchResult } from '../../../../domain/types';
+
+export function aSearchResult(overrides?: Partial<SearchResult>): SearchResult {
+  return {
+    reference: '22/1234/FUL',
+    authoritySlug: 'cambridge',
+    authorityName: 'Cambridge City Council',
+    address: '12 Mill Road, Cambridge, CB1 2AD',
+    appState: 'Permitted',
+    startDate: '2026-01-15',
+    decidedDate: '2026-03-01',
+    ...overrides,
+  };
+}
+
+export function anotherSearchResult(overrides?: Partial<SearchResult>): SearchResult {
+  return aSearchResult({
+    reference: '24/0001/FUL',
+    authoritySlug: 'adur',
+    authorityName: 'Adur District Council',
+    address: '1 High Street, Shoreham-by-Sea, BN43 5WU',
+    appState: null,
+    startDate: null,
+    decidedDate: null,
+    ...overrides,
+  });
+}

--- a/web/src/features/Search/__tests__/spies/spy-search-port.ts
+++ b/web/src/features/Search/__tests__/spies/spy-search-port.ts
@@ -1,0 +1,20 @@
+import type { SearchOutcome, SearchPort } from '../../../../domain/ports/search-port';
+
+interface SearchCall {
+  readonly query: string;
+  readonly authority: string | null;
+}
+
+export class SpySearchPort implements SearchPort {
+  searchCalls: SearchCall[] = [];
+  searchResult: SearchOutcome = { results: [], refineQuery: false };
+  searchError: Error | null = null;
+
+  async search(query: string, authority: string | null): Promise<SearchOutcome> {
+    this.searchCalls.push({ query, authority });
+    if (this.searchError) {
+      throw this.searchError;
+    }
+    return this.searchResult;
+  }
+}

--- a/web/src/features/Search/__tests__/useSearch.test.ts
+++ b/web/src/features/Search/__tests__/useSearch.test.ts
@@ -1,0 +1,172 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { useSearch } from '../useSearch';
+import { SpySearchPort } from './spies/spy-search-port';
+import { aSearchResult, anotherSearchResult } from './fixtures/search-result.fixtures';
+
+describe('useSearch', () => {
+  it('does not call the port while the query is empty', async () => {
+    const spy = new SpySearchPort();
+
+    const { result } = renderHook(() => useSearch(spy));
+
+    expect(result.current.query).toBe('');
+    // Give the debounce window time to elapse — it must not fire.
+    await new Promise((r) => setTimeout(r, 600));
+    expect(spy.searchCalls).toHaveLength(0);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasSearched).toBe(false);
+  });
+
+  it('debounces rapid typing into a single search call with the final query', async () => {
+    const spy = new SpySearchPort();
+    const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.setQuery('m');
+    });
+    act(() => {
+      result.current.setQuery('mi');
+    });
+    act(() => {
+      result.current.setQuery('mill road');
+    });
+
+    await waitFor(
+      () => {
+        expect(spy.searchCalls).toHaveLength(1);
+      },
+      { timeout: 2000 },
+    );
+    expect(spy.searchCalls[0]).toEqual({ query: 'mill road', authority: null });
+  });
+
+  it('populates results after a successful search', async () => {
+    const spy = new SpySearchPort();
+    spy.searchResult = { results: [aSearchResult(), anotherSearchResult()], refineQuery: false };
+    const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.setQuery('mill road');
+    });
+
+    await waitFor(
+      () => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.hasSearched).toBe(true);
+      },
+      { timeout: 2000 },
+    );
+    expect(result.current.results).toEqual([aSearchResult(), anotherSearchResult()]);
+    expect(result.current.error).toBeNull();
+    expect(result.current.refineQuery).toBe(false);
+  });
+
+  it('flags refineQuery when the match set was truncated', async () => {
+    const spy = new SpySearchPort();
+    spy.searchResult = { results: [aSearchResult()], refineQuery: true };
+    const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.setQuery('a common word');
+    });
+
+    await waitFor(
+      () => {
+        expect(result.current.refineQuery).toBe(true);
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it('surfaces an error message when the search fails', async () => {
+    const spy = new SpySearchPort();
+    spy.searchError = new Error('Request failed with status 400');
+    const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.setQuery('zz');
+    });
+
+    await waitFor(
+      () => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.hasSearched).toBe(true);
+      },
+      { timeout: 2000 },
+    );
+    expect(result.current.error).toBe('Request failed with status 400');
+    expect(result.current.results).toEqual([]);
+  });
+
+  it('passes the trimmed authority filter to the port, or null when blank', async () => {
+    const spy = new SpySearchPort();
+    const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.setAuthority('  cambridge  ');
+      result.current.setQuery('mill road');
+    });
+
+    await waitFor(
+      () => {
+        expect(spy.searchCalls).toHaveLength(1);
+      },
+      { timeout: 2000 },
+    );
+    expect(spy.searchCalls[0]).toEqual({ query: 'mill road', authority: 'cambridge' });
+
+    act(() => {
+      result.current.setAuthority('');
+      result.current.setQuery('mill road again');
+    });
+
+    await waitFor(
+      () => {
+        expect(spy.searchCalls).toHaveLength(2);
+      },
+      { timeout: 2000 },
+    );
+    expect(spy.searchCalls[1]).toEqual({ query: 'mill road again', authority: null });
+  });
+
+  it('resets to idle and ignores a stale in-flight response when the query is cleared', async () => {
+    let resolveSearch: ((outcome: { results: never[]; refineQuery: boolean }) => void) | null = null;
+    const spy = new SpySearchPort();
+    spy.search = (query: string, authority: string | null) => {
+      spy.searchCalls.push({ query, authority });
+      return new Promise((resolve) => {
+        resolveSearch = resolve;
+      });
+    };
+
+    const { result } = renderHook(() => useSearch(spy));
+
+    act(() => {
+      result.current.setQuery('mill road');
+    });
+
+    await waitFor(() => {
+      expect(spy.searchCalls).toHaveLength(1);
+    });
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    act(() => {
+      result.current.setQuery('');
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.hasSearched).toBe(false);
+    expect(result.current.results).toEqual([]);
+
+    // The stale in-flight promise resolving afterwards must not repopulate results.
+    act(() => {
+      resolveSearch!({ results: [], refineQuery: false });
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(result.current.hasSearched).toBe(false);
+    expect(result.current.results).toEqual([]);
+  });
+});

--- a/web/src/features/Search/components/SearchResultCard.module.css
+++ b/web/src/features/Search/components/SearchResultCard.module.css
@@ -1,0 +1,149 @@
+.card {
+  list-style: none;
+  background: var(--tc-surface);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  padding: var(--tc-space-md);
+  box-shadow: var(--tc-shadow-card);
+}
+
+.header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--tc-space-sm);
+  margin-bottom: var(--tc-space-sm);
+}
+
+.reference {
+  font-size: var(--tc-text-headline);
+  font-weight: var(--tc-weight-semibold);
+  line-height: var(--tc-leading-normal);
+  color: var(--tc-text-primary);
+  margin: 0;
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--tc-space-xs);
+  padding: var(--tc-space-xs) var(--tc-space-sm);
+  border-radius: var(--tc-radius-full);
+  font-size: var(--tc-text-caption);
+  font-weight: var(--tc-weight-medium);
+  line-height: var(--tc-leading-normal);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.statusUndecided {
+  background: color-mix(in srgb, var(--tc-status-pending) 15%, transparent);
+  color: var(--tc-status-pending);
+}
+
+.statusPermitted {
+  background: color-mix(in srgb, var(--tc-status-permitted) 15%, transparent);
+  color: var(--tc-status-permitted);
+}
+
+.statusConditions {
+  background: color-mix(in srgb, var(--tc-status-conditions) 15%, transparent);
+  color: var(--tc-status-conditions);
+}
+
+.statusRejected {
+  background: color-mix(in srgb, var(--tc-status-rejected) 15%, transparent);
+  color: var(--tc-status-rejected);
+}
+
+.statusWithdrawn {
+  background: color-mix(in srgb, var(--tc-status-withdrawn) 15%, transparent);
+  color: var(--tc-status-withdrawn);
+}
+
+.statusAppealed {
+  background: color-mix(in srgb, var(--tc-status-appealed) 15%, transparent);
+  color: var(--tc-status-appealed);
+}
+
+.statusUnresolved {
+  background: color-mix(in srgb, var(--tc-text-secondary) 15%, transparent);
+  color: var(--tc-text-secondary);
+}
+
+.statusReferred {
+  background: color-mix(in srgb, var(--tc-status-appealed) 15%, transparent);
+  color: var(--tc-status-appealed);
+}
+
+.statusNotAvailable {
+  background: color-mix(in srgb, var(--tc-status-withdrawn) 15%, transparent);
+  color: var(--tc-status-withdrawn);
+}
+
+.statusDefault {
+  background: color-mix(in srgb, var(--tc-text-secondary) 15%, transparent);
+  color: var(--tc-text-secondary);
+}
+
+.address {
+  font-size: var(--tc-text-body);
+  color: var(--tc-text-primary);
+  margin: 0 0 var(--tc-space-xs);
+}
+
+.authority {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+  margin: 0 0 var(--tc-space-sm);
+}
+
+.meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--tc-space-xs) var(--tc-space-md);
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+  margin-bottom: var(--tc-space-sm);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--tc-space-sm);
+  margin-top: var(--tc-space-sm);
+}
+
+.shareLink {
+  font-size: var(--tc-text-caption);
+  font-weight: var(--tc-weight-medium);
+  color: var(--tc-amber);
+  text-decoration: none;
+}
+
+.shareLink:hover {
+  text-decoration: underline;
+}
+
+.copyButton {
+  background: var(--tc-surface);
+  color: var(--tc-text-primary);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius-md);
+  padding: var(--tc-space-xs) var(--tc-space-md);
+  min-height: 44px;
+  font-size: var(--tc-text-caption);
+  font-weight: var(--tc-weight-medium);
+  cursor: pointer;
+  transition: border-color var(--tc-duration-fast) ease;
+}
+
+.copyButton:hover {
+  border-color: var(--tc-amber);
+}
+
+.copyStatus {
+  font-size: var(--tc-text-caption);
+  color: var(--tc-text-secondary);
+}

--- a/web/src/features/Search/components/SearchResultCard.tsx
+++ b/web/src/features/Search/components/SearchResultCard.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import type { SearchResult } from '../../../domain/types';
+import { buildShareUrl } from '../../../domain/share-link';
+import { formatDate, statusClassName, statusDisplayLabel } from '../../../utils/formatting';
+import styles from './SearchResultCard.module.css';
+
+interface Props {
+  result: SearchResult;
+}
+
+type CopyState = 'idle' | 'copied' | 'error';
+
+/**
+ * One row of `/search` results: an application summary, a link to its public
+ * share page, and the copy-to-clipboard button that is this bead's core
+ * acceptance criterion (#821 Phase 4).
+ */
+export function SearchResultCard({ result }: Props) {
+  const [copyState, setCopyState] = useState<CopyState>('idle');
+  const shareUrl = buildShareUrl(result.authoritySlug, result.reference);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(shareUrl);
+      setCopyState('copied');
+    } catch {
+      setCopyState('error');
+    }
+  }
+
+  return (
+    <li className={styles.card}>
+      <div className={styles.header}>
+        <h3 className={styles.reference}>{result.reference}</h3>
+        {result.appState !== null && (
+          <span className={`${styles.statusBadge} ${statusClassName(result.appState, styles)}`}>
+            {statusDisplayLabel(result.appState)}
+          </span>
+        )}
+      </div>
+
+      <p className={styles.address}>{result.address}</p>
+      <p className={styles.authority}>{result.authorityName}</p>
+
+      {(result.startDate !== null || result.decidedDate !== null) && (
+        <div className={styles.meta}>
+          {result.startDate !== null && <span>Received {formatDate(result.startDate)}</span>}
+          {result.decidedDate !== null && <span>Decided {formatDate(result.decidedDate)}</span>}
+        </div>
+      )}
+
+      <div className={styles.actions}>
+        <a href={shareUrl} className={styles.shareLink} target="_blank" rel="noopener noreferrer">
+          View share page
+        </a>
+        <button type="button" className={styles.copyButton} onClick={() => void handleCopy()}>
+          {copyState === 'copied' ? 'Copied!' : 'Copy link'}
+        </button>
+        <span aria-live="polite" className={styles.copyStatus}>
+          {copyState === 'copied' && 'Share link copied to clipboard'}
+          {copyState === 'error' && "Couldn't copy link — try selecting it from the address bar."}
+        </span>
+      </div>
+    </li>
+  );
+}

--- a/web/src/features/Search/components/__tests__/SearchResultCard.test.tsx
+++ b/web/src/features/Search/components/__tests__/SearchResultCard.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SearchResultCard } from '../SearchResultCard';
+import { aSearchResult, anotherSearchResult } from '../../__tests__/fixtures/search-result.fixtures';
+
+class SpyClipboard {
+  writeTextCalls: string[] = [];
+  writeTextError: Error | null = null;
+
+  writeText = async (text: string): Promise<void> => {
+    this.writeTextCalls.push(text);
+    if (this.writeTextError) {
+      throw this.writeTextError;
+    }
+  };
+}
+
+describe('SearchResultCard', () => {
+  let clipboard: SpyClipboard;
+
+  beforeEach(() => {
+    clipboard = new SpyClipboard();
+  });
+
+  // `userEvent.setup()` installs its own clipboard stub on `navigator.clipboard`
+  // (testing-library/user-event's attachClipboardStubToView), unconditionally
+  // overwriting anything set beforehand — so the spy must be installed AFTER
+  // `userEvent.setup()`, not before, or clicks silently hit user-event's stub
+  // instead of this test's spy.
+  function setupUserWithSpyClipboard() {
+    const user = userEvent.setup();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: clipboard,
+      configurable: true,
+      writable: true,
+    });
+    return user;
+  }
+
+  it('renders the reference, address, and authority name', () => {
+    render(<SearchResultCard result={aSearchResult({ reference: '22/1234/FUL' })} />);
+
+    expect(screen.getByRole('heading', { name: '22/1234/FUL' })).toBeInTheDocument();
+    expect(screen.getByText('12 Mill Road, Cambridge, CB1 2AD')).toBeInTheDocument();
+    expect(screen.getByText('Cambridge City Council')).toBeInTheDocument();
+  });
+
+  it('shows a status badge with the user-facing label for a known appState', () => {
+    render(<SearchResultCard result={aSearchResult({ appState: 'Permitted' })} />);
+
+    expect(screen.getByText('Granted')).toBeInTheDocument();
+  });
+
+  it('renders no status badge when appState is null', () => {
+    render(<SearchResultCard result={anotherSearchResult({ appState: null })} />);
+
+    expect(screen.queryByText(/granted|refused|permitted|rejected/i)).not.toBeInTheDocument();
+  });
+
+  it('renders received and decided dates when present', () => {
+    render(
+      <SearchResultCard
+        result={aSearchResult({ startDate: '2026-01-15', decidedDate: '2026-03-01' })}
+      />,
+    );
+
+    expect(screen.getByText(/received/i)).toHaveTextContent('Received 15 Jan 2026');
+    expect(screen.getByText(/decided/i)).toHaveTextContent('Decided 1 Mar 2026');
+  });
+
+  it('omits date rows when both dates are null', () => {
+    render(<SearchResultCard result={anotherSearchResult({ startDate: null, decidedDate: null })} />);
+
+    expect(screen.queryByText(/received/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/decided/i)).not.toBeInTheDocument();
+  });
+
+  it('renders a link to the public share page in a new tab', () => {
+    render(
+      <SearchResultCard
+        result={aSearchResult({ authoritySlug: 'cambridge', reference: '22/1234/FUL' })}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: /view share page/i });
+    expect(link).toHaveAttribute('href', 'https://share.towncrierapp.uk/a/cambridge/22/1234/FUL');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('copies the exact share URL to the clipboard when the copy button is clicked', async () => {
+    const user = setupUserWithSpyClipboard();
+    render(
+      <SearchResultCard
+        result={aSearchResult({ authoritySlug: 'adur', reference: '9/P/2026/0044/HH' })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /copy link/i }));
+
+    await waitFor(() => {
+      expect(clipboard.writeTextCalls).toEqual([
+        'https://share.towncrierapp.uk/a/adur/9/P/2026/0044/HH',
+      ]);
+    });
+  });
+
+  it('shows confirmation feedback after a successful copy', async () => {
+    const user = setupUserWithSpyClipboard();
+    render(<SearchResultCard result={aSearchResult()} />);
+
+    const button = screen.getByRole('button', { name: /copy link/i });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /copied/i })).toBeInTheDocument();
+    });
+    const status = screen.getByText(/share link copied/i);
+    expect(status).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('shows an error state instead of crashing when the clipboard write fails', async () => {
+    clipboard.writeTextError = new Error('denied');
+    const user = setupUserWithSpyClipboard();
+    render(<SearchResultCard result={aSearchResult()} />);
+
+    await user.click(screen.getByRole('button', { name: /copy link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/couldn.?t copy/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/features/Search/useSearch.ts
+++ b/web/src/features/Search/useSearch.ts
@@ -1,0 +1,107 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import type { SearchPort } from '../../domain/ports/search-port';
+import type { SearchResult } from '../../domain/types';
+import { extractErrorMessage } from '../../utils/extractErrorMessage';
+
+/** Debounce window between the last keystroke and firing the search call. */
+const SEARCH_DEBOUNCE_MS = 400;
+
+interface SearchState {
+  readonly results: readonly SearchResult[];
+  readonly isLoading: boolean;
+  readonly error: string | null;
+  readonly refineQuery: boolean;
+  /** True once a search has actually run — distinguishes "no query yet" from "zero results". */
+  readonly hasSearched: boolean;
+}
+
+const IDLE_STATE: SearchState = {
+  results: [],
+  isLoading: false,
+  error: null,
+  refineQuery: false,
+  hasSearched: false,
+};
+
+/**
+ * ViewModel for the public `/search` page (#821 Phase 4). Debounces the query
+ * box (and authority filter) before calling the anonymous `SearchPort`, and
+ * guards against out-of-order responses — a slow response for a query the
+ * user has since changed or cleared must never clobber newer state.
+ */
+export function useSearch(port: SearchPort) {
+  const [query, setQueryState] = useState('');
+  const [authority, setAuthority] = useState('');
+  const [state, setState] = useState<SearchState>(IDLE_STATE);
+
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Incremented on every new search attempt (including a reset-to-idle);
+  // a response is applied only if it is still the most recent attempt.
+  const requestIdRef = useRef(0);
+
+  const runSearch = useCallback(
+    async (trimmedQuery: string, authorityFilter: string | null) => {
+      const requestId = ++requestIdRef.current;
+      setState((prev) => ({ ...prev, isLoading: true, error: null }));
+      try {
+        const outcome = await port.search(trimmedQuery, authorityFilter);
+        if (requestIdRef.current !== requestId) return;
+        setState({
+          results: outcome.results,
+          isLoading: false,
+          error: null,
+          refineQuery: outcome.refineQuery,
+          hasSearched: true,
+        });
+      } catch (err: unknown) {
+        if (requestIdRef.current !== requestId) return;
+        setState({
+          results: [],
+          isLoading: false,
+          error: extractErrorMessage(err, 'Search failed. Try a different search.'),
+          refineQuery: false,
+          hasSearched: true,
+        });
+      }
+    },
+    [port],
+  );
+
+  // setQuery resets to idle immediately (synchronously, as part of handling the
+  // user's own input event) whenever the box becomes blank — never via an
+  // effect, so clearing the box doesn't wait on the debounce window and never
+  // triggers a setState-in-effect cascading render.
+  const setQuery = useCallback((value: string) => {
+    setQueryState(value);
+    if (value.trim() === '') {
+      requestIdRef.current += 1; // invalidate any in-flight response
+      setState(IDLE_STATE);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    const trimmedQuery = query.trim();
+    if (trimmedQuery === '') {
+      return;
+    }
+
+    const trimmedAuthority = authority.trim();
+    debounceRef.current = setTimeout(() => {
+      void runSearch(trimmedQuery, trimmedAuthority === '' ? null : trimmedAuthority);
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, authority, runSearch]);
+
+  return {
+    query,
+    setQuery,
+    authority,
+    setAuthority,
+    ...state,
+  };
+}


### PR DESCRIPTION
## Changes

New public, anonymous `/search` web page — the last phase of epic tc-geq7h / GH #821.

- `web/src/domain/share-link.ts` (`buildShareUrl`): builds `https://share.towncrierapp.uk/a/<authoritySlug>/<reference>`. Deliberately does NOT URL-encode the reference — PlanIt references legitimately contain slashes (e.g. `9/P/2026/0044/HH`) matched by the share page's wildcard route segment; encoding would break resolution.
- `web/src/features/Search/ApiSearchPort.ts`: anonymous adapter for `GET /v1/applications/search` — never attaches an `Authorization` header (mirrors the existing `ApiLegalDocumentPort` anonymous pattern), so it works fully logged out.
- `web/src/features/Search/useSearch.ts`: debounced ViewModel hook over the search port.
- `web/src/features/Search/components/SearchResultCard.tsx`: result card with address/reference/status/dates, a share-page link, and a copy-to-clipboard button for the share URL.
- `web/src/features/Search/SearchPage.tsx` + `ConnectedSearchPage.tsx`: page composition, wired into `web/src/AppRoutes.tsx` as a public route at `/search`, outside `AuthGuard`.
- Landing footer (`web/src/components/Footer/Footer.tsx`): added the `/search` link to the existing "Explore" nav (alongside `/planning/` and `/planning/towns/`, added by a prior PR in this epic).

Tests: full Vitest coverage for `buildShareUrl`, `ApiSearchPort`, `useSearch`, `SearchResultCard`, `SearchPage`, `ConnectedSearchPage`, and the Footer link addition — hand-written spies, no `vi.mock()`.

Gates: `npx tsc --noEmit`, `npx vitest run` (1084 passed), `npm run build`, `npm run lint` all green. Scope-checked to `web/` only.

**Verified live** via a dispatched UI-verification subagent against a local Postgres+API+Vite stack with seeded applications: `/search` loads anonymously (no login redirect), debounced search works for both the address-fuzzy and description full-text ranking tiers, the copy-link button's target exactly matches `https://share.towncrierapp.uk/a/<slug>/<ref>`, and the underlying reference was confirmed to resolve via the local `by-slug` API equivalent (200 with correct application data) — the epic's core acceptance criterion.

Closes the last child bead of epic tc-geq7h.

---
*Auto-shipped via ship skill*