### PR TITLE
fix(web): assetlinks.json field must be sha256_cert_fingerprints (plural)

### DIFF
--- a/web/public/.well-known/assetlinks.json
+++ b/web/public/.well-known/assetlinks.json
@@ -4,7 +4,7 @@
     "target": {
       "namespace": "android_app",
       "package_name": "uk.towncrierapp.mobile.dev",
-      "sha256_cert_fingerprint": [
+      "sha256_cert_fingerprints": [
         "75:2F:87:AF:52:B6:4D:33:71:ED:77:2A:2A:1C:D9:7A:A4:67:9E:1A:17:F0:9F:FD:92:12:D6:55:92:FD:0E:07"
       ]
     }

--- a/web/src/__tests__/static-web-app-config.test.ts
+++ b/web/src/__tests__/static-web-app-config.test.ts
@@ -157,7 +157,7 @@ describe('assetlinks.json', () => {
   interface AssetLinksTarget {
     namespace: string;
     package_name: string;
-    sha256_cert_fingerprint: string[];
+    sha256_cert_fingerprints: string[];
   }
 
   interface AssetLinksEntry {
@@ -197,7 +197,7 @@ describe('assetlinks.json', () => {
       (entry) => entry.target.package_name === 'uk.towncrierapp.mobile.dev',
     );
 
-    expect(devEntry?.target.sha256_cert_fingerprint).toContain(
+    expect(devEntry?.target.sha256_cert_fingerprints).toContain(
       '75:2F:87:AF:52:B6:4D:33:71:ED:77:2A:2A:1C:D9:7A:A4:67:9E:1A:17:F0:9F:FD:92:12:D6:55:92:FD:0E:07',
     );
   });


### PR DESCRIPTION
## Changes

- fix(web): assetlinks.json field must be sha256_cert_fingerprints (plural) (tc-g8iv6)

PR #830 (just merged) shipped `web/public/.well-known/assetlinks.json` with the field name `sha256_cert_fingerprint` (singular) — this was an error in the orchestrating session's own dispatch prompt, followed verbatim. Confirmed against the official Android docs (developer.android.com/training/app-links/configure-assetlinks) that the correct Digital Asset Links field is `sha256_cert_fingerprints` (plural, array) — Android's domain-verification system will not recognize the singular form, making the file currently non-functional for its intended purpose.

The sibling api-go slice (`internal/assetlinks`, GH#782, tc-ar3ys) already used the correct plural form independently — this fix brings the web slice in line with it and the real spec.

---
*Auto-shipped via ship skill*