### PR TITLE
feat(api): serve assetlinks.json on share domain

### DIFF
--- a/api-go/cmd/api/anonymous_patterns_test.go
+++ b/api-go/cmd/api/anonymous_patterns_test.go
@@ -74,3 +74,17 @@ func TestAnonymousPatterns_IncludesAASA(t *testing.T) {
 		t.Errorf("anonymousPatterns must include %q", aasa)
 	}
 }
+
+// TestAnonymousPatterns_IncludesAssetLinks pins the anonymity of the Android
+// Digital Asset Links document served on the share host (GH#782). Android's
+// package manager fetches it without a bearer token to verify the app's
+// autoVerify intent filter, mirroring the AASA entry above; the auth
+// middleware keys on the registered pattern string byte-for-byte.
+func TestAnonymousPatterns_IncludesAssetLinks(t *testing.T) {
+	t.Parallel()
+
+	const assetLinks = "GET /.well-known/assetlinks.json"
+	if _, ok := anonymousPatterns[assetLinks]; !ok {
+		t.Errorf("anonymousPatterns must include %q", assetLinks)
+	}
+}

--- a/api-go/cmd/api/wiring.go
+++ b/api-go/cmd/api/wiring.go
@@ -10,6 +10,7 @@ import (
 	"github.com/AmyDe/town-crier/api-go/internal/admin"
 	"github.com/AmyDe/town-crier/api-go/internal/api"
 	"github.com/AmyDe/town-crier/api-go/internal/applications"
+	"github.com/AmyDe/town-crier/api-go/internal/assetlinks"
 	"github.com/AmyDe/town-crier/api-go/internal/auth"
 	"github.com/AmyDe/town-crier/api-go/internal/authorities"
 	"github.com/AmyDe/town-crier/api-go/internal/blobstore"
@@ -88,6 +89,10 @@ var anonymousPatterns = map[string]struct{}{
 	// Universal Links (#738 Slice 3). Content-Type is application/json and the path
 	// carries no ".json" extension.
 	"GET /.well-known/apple-app-site-association": {},
+	// The Android Digital Asset Links document is anonymous: Android's package
+	// manager fetches it without a bearer token to verify the app's autoVerify
+	// intent filter for App Links (GH#782), mirroring the AASA entry above.
+	"GET /.well-known/assetlinks.json": {},
 }
 
 // dispatchMux satisfies auth.RequireAuth's routeMatcher: pattern matching comes
@@ -213,6 +218,11 @@ func newRouter(
 	// is composed from the canonical team + bundle constants (fixed contract), not
 	// runtime config.
 	aasa.Routes(mux, platform.AppleUniversalLinkAppID(), logger)
+	// The Android Digital Asset Links document (GH#782) is stateless and needs
+	// no store, so it is registered unconditionally on the share host, mirroring
+	// AASA above. The package/fingerprint contract is composed from fixed
+	// constants (not runtime config): see assetlinks.DefaultPackages.
+	assetlinks.Routes(mux, assetlinks.DefaultPackages(), logger)
 	// Geocode and designations are authed (absent from anonymousPatterns) and
 	// have no store dependency — they call outbound UK services — so they are
 	// always wired, even on a store-less local boot.

--- a/api-go/internal/assetlinks/default.go
+++ b/api-go/internal/assetlinks/default.go
@@ -1,0 +1,29 @@
+package assetlinks
+
+// devPackageName is the dev-flavor Android application id (mirrors iOS's
+// dev/prod bundle-id split, epic #770).
+const devPackageName = "uk.towncrierapp.mobile.dev"
+
+// devDebugKeystoreFingerprint is the SHA-256 certificate fingerprint of the
+// shared debug keystore (colon-separated uppercase hex, computed locally for
+// GH#782), which signs local and CI dev-flavor builds.
+const devDebugKeystoreFingerprint = "75:2F:87:AF:52:B6:4D:33:71:ED:77:2A:2A:1C:D9:7A:A4:67:9E:1A:17:F0:9F:FD:92:12:D6:55:92:FD:0E:07"
+
+// DefaultPackages returns the fixed Digital Asset Links contract for the
+// Android package flavors (GH#782), composed from fixed constants rather than
+// runtime config — mirroring platform.AppleUniversalLinkAppID's approach for
+// the equivalent Apple contract.
+//
+// The prod package, uk.towncrierapp.mobile, has no entry yet: the Play App
+// Signing certificate fingerprint is unavailable until Play Console
+// enrolment (#779). It is omitted entirely — rather than published with a
+// placeholder that would fail verification — matching Routes' own rule of
+// dropping any Package with no fingerprints. Once #779 lands a real
+// fingerprint, add its entry here.
+// TestDefaultPackages_OmitsProdPackageUntilPlayConsoleEnrolment pins this gap
+// so it surfaces as a test to update rather than a silent omission.
+func DefaultPackages() []Package {
+	return []Package{
+		{Name: devPackageName, Fingerprints: []string{devDebugKeystoreFingerprint}},
+	}
+}

--- a/api-go/internal/assetlinks/default_test.go
+++ b/api-go/internal/assetlinks/default_test.go
@@ -1,0 +1,43 @@
+package assetlinks
+
+import "testing"
+
+// TestDefaultPackages_IncludesDebugKeystoreFingerprintForDevPackage pins the
+// dev-flavor entry to the debug keystore's SHA-256 fingerprint (computed
+// locally for GH#782) so a locally-built dev APK verifies against the
+// deployed document.
+func TestDefaultPackages_IncludesDebugKeystoreFingerprintForDevPackage(t *testing.T) {
+	t.Parallel()
+
+	const wantFingerprint = "75:2F:87:AF:52:B6:4D:33:71:ED:77:2A:2A:1C:D9:7A:A4:67:9E:1A:17:F0:9F:FD:92:12:D6:55:92:FD:0E:07"
+
+	packages := DefaultPackages()
+
+	var dev *Package
+	for i := range packages {
+		if packages[i].Name == "uk.towncrierapp.mobile.dev" {
+			dev = &packages[i]
+		}
+	}
+	if dev == nil {
+		t.Fatalf("DefaultPackages() = %+v, want an entry for uk.towncrierapp.mobile.dev", packages)
+	}
+	if len(dev.Fingerprints) != 1 || dev.Fingerprints[0] != wantFingerprint {
+		t.Errorf("uk.towncrierapp.mobile.dev fingerprints = %v, want [%q]", dev.Fingerprints, wantFingerprint)
+	}
+}
+
+// TestDefaultPackages_OmitsProdPackageUntilPlayConsoleEnrolment documents the
+// deliberate gap: uk.towncrierapp.mobile has no Play App Signing certificate
+// fingerprint until Play Console enrolment (#779). This test exists so that
+// bead lands loudly (as a failing test to update) rather than silently once a
+// real fingerprint is available.
+func TestDefaultPackages_OmitsProdPackageUntilPlayConsoleEnrolment(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range DefaultPackages() {
+		if p.Name == "uk.towncrierapp.mobile" {
+			t.Fatalf("uk.towncrierapp.mobile must be absent until #779 lands a real fingerprint; got %+v", p)
+		}
+	}
+}

--- a/api-go/internal/assetlinks/handler.go
+++ b/api-go/internal/assetlinks/handler.go
@@ -58,12 +58,18 @@ type handler struct {
 }
 
 // Routes registers the anonymous assetlinks endpoint for the given packages.
+// A Package with no fingerprints yet (e.g. uk.towncrierapp.mobile, pending
+// Play Console enrolment, #779) is skipped rather than published with an
+// empty or placeholder fingerprint that would fail verification anyway.
 //
 // The document is marshalled once at wiring time so the handler does no
 // per-request work, mirroring internal/aasa's Routes.
 func Routes(mux *http.ServeMux, packages []Package, logger *slog.Logger) {
 	statements := make([]statement, 0, len(packages))
 	for _, p := range packages {
+		if len(p.Fingerprints) == 0 {
+			continue
+		}
 		statements = append(statements, statement{
 			Relation: []string{relationHandleAllURLs},
 			Target: target{

--- a/api-go/internal/assetlinks/handler.go
+++ b/api-go/internal/assetlinks/handler.go
@@ -1,0 +1,92 @@
+// Package assetlinks serves the Android Digital Asset Links document on the
+// public share host (GH#782, Android App Links). Android's package manager
+// fetches GET /.well-known/assetlinks.json over HTTPS to verify a package
+// claiming an https intent-filter with android:autoVerify="true" — the
+// Android equivalent of internal/aasa's apple-app-site-association document,
+// served from the same share host.
+//
+// The endpoint is stateless (no store) and emits only the fixed, public
+// association document, so wiring registers it unconditionally alongside
+// AASA.
+package assetlinks
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+)
+
+// wellKnownPath is the Digital Asset Links location Android's package manager
+// fetches. Unlike Apple's AASA path, Google's convention keeps the ".json"
+// extension.
+const wellKnownPath = "/.well-known/assetlinks.json"
+
+const (
+	// relationHandleAllURLs is the only relation Digital Asset Links defines
+	// for App Links verification.
+	relationHandleAllURLs = "delegate_permission/common.handle_all_urls"
+	// namespaceAndroidApp identifies the target as an Android application.
+	namespaceAndroidApp = "android_app"
+)
+
+// Package pairs an Android application id with the SHA-256 certificate
+// fingerprints (colon-separated uppercase hex, the format Digital Asset
+// Links requires) of the signing key(s) Play Console reports for it — the
+// upload key and/or the Play App Signing key.
+type Package struct {
+	Name         string
+	Fingerprints []string
+}
+
+// statement, target model the Digital Asset Links JSON so it is marshalled
+// from typed data (always valid) rather than string-built, mirroring
+// internal/aasa's document/applinks/detail/componentEntry types.
+type statement struct {
+	Relation []string `json:"relation"`
+	Target   target   `json:"target"`
+}
+
+type target struct {
+	Namespace              string   `json:"namespace"`
+	PackageName            string   `json:"package_name"`
+	SHA256CertFingerprints []string `json:"sha256_cert_fingerprints"`
+}
+
+type handler struct {
+	body   []byte
+	logger *slog.Logger
+}
+
+// Routes registers the anonymous assetlinks endpoint for the given packages.
+//
+// The document is marshalled once at wiring time so the handler does no
+// per-request work, mirroring internal/aasa's Routes.
+func Routes(mux *http.ServeMux, packages []Package, logger *slog.Logger) {
+	statements := make([]statement, 0, len(packages))
+	for _, p := range packages {
+		statements = append(statements, statement{
+			Relation: []string{relationHandleAllURLs},
+			Target: target{
+				Namespace:              namespaceAndroidApp,
+				PackageName:            p.Name,
+				SHA256CertFingerprints: p.Fingerprints,
+			},
+		})
+	}
+
+	body, err := json.Marshal(statements)
+	if err != nil {
+		logger.Error("assetlinks: marshal document", "error", err)
+		return
+	}
+	h := &handler{body: body, logger: logger}
+	mux.HandleFunc("GET "+wellKnownPath, h.serve)
+}
+
+func (h *handler) serve(w http.ResponseWriter, r *http.Request) {
+	// Google's verifier requires exactly application/json.
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(h.body); err != nil {
+		h.logger.ErrorContext(r.Context(), "write assetlinks response", "error", err)
+	}
+}

--- a/api-go/internal/assetlinks/handler_test.go
+++ b/api-go/internal/assetlinks/handler_test.go
@@ -63,3 +63,34 @@ func TestAssetLinks_ServesJSONDocument(t *testing.T) {
 		t.Errorf("target.sha256_cert_fingerprints = %v, want [%q]", s.Target.SHA256CertFingerprints, fingerprint)
 	}
 }
+
+// TestAssetLinks_OmitsPackagesWithNoFingerprints covers the prod package
+// (uk.towncrierapp.mobile) before Play Console enrolment (#779): it has no
+// known signing-key fingerprint yet, so publishing it with an empty or
+// placeholder fingerprint would fail Digital Asset Links verification
+// anyway. Routes drops any Package with no fingerprints rather than
+// serving a broken entry.
+func TestAssetLinks_OmitsPackagesWithNoFingerprints(t *testing.T) {
+	t.Parallel()
+
+	mux := http.NewServeMux()
+	Routes(mux, []Package{
+		{Name: "uk.towncrierapp.mobile", Fingerprints: nil},
+		{Name: "uk.towncrierapp.mobile.dev", Fingerprints: []string{"AA:BB"}},
+	}, slog.New(slog.DiscardHandler))
+
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/.well-known/assetlinks.json", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	var statements []assetLinksStatement
+	if err := json.Unmarshal(rec.Body.Bytes(), &statements); err != nil {
+		t.Fatalf("body is not valid JSON: %v (%q)", err, rec.Body.String())
+	}
+	if len(statements) != 1 {
+		t.Fatalf("statements = %d, want 1 (the fingerprint-less package must be omitted)", len(statements))
+	}
+	if statements[0].Target.PackageName != "uk.towncrierapp.mobile.dev" {
+		t.Errorf("target.package_name = %q, want uk.towncrierapp.mobile.dev", statements[0].Target.PackageName)
+	}
+}

--- a/api-go/internal/assetlinks/handler_test.go
+++ b/api-go/internal/assetlinks/handler_test.go
@@ -1,0 +1,65 @@
+package assetlinks
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// assetLinksStatement mirrors the on-the-wire Digital Asset Links shape so the
+// test parses the served body back and asserts the exact contract (relation,
+// namespace, package name, fingerprints) rather than matching a byte string.
+type assetLinksStatement struct {
+	Relation []string `json:"relation"`
+	Target   struct {
+		Namespace              string   `json:"namespace"`
+		PackageName            string   `json:"package_name"`
+		SHA256CertFingerprints []string `json:"sha256_cert_fingerprints"`
+	} `json:"target"`
+}
+
+func TestAssetLinks_ServesJSONDocument(t *testing.T) {
+	t.Parallel()
+
+	const pkgName = "uk.towncrierapp.mobile.dev"
+	const fingerprint = "75:2F:87:AF:52:B6:4D:33:71:ED:77:2A:2A:1C:D9:7A:A4:67:9E:1A:17:F0:9F:FD:92:12:D6:55:92:FD:0E:07"
+
+	mux := http.NewServeMux()
+	Routes(mux, []Package{{Name: pkgName, Fingerprints: []string{fingerprint}}}, slog.New(slog.DiscardHandler))
+
+	// Android's package manager fetches the extensionless well-known path over
+	// HTTPS to verify the autoVerify intent filter.
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/.well-known/assetlinks.json", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", got)
+	}
+
+	var statements []assetLinksStatement
+	if err := json.Unmarshal(rec.Body.Bytes(), &statements); err != nil {
+		t.Fatalf("body is not valid JSON: %v (%q)", err, rec.Body.String())
+	}
+	if len(statements) != 1 {
+		t.Fatalf("statements = %d, want 1", len(statements))
+	}
+	s := statements[0]
+	if len(s.Relation) != 1 || s.Relation[0] != "delegate_permission/common.handle_all_urls" {
+		t.Errorf("relation = %v, want [delegate_permission/common.handle_all_urls]", s.Relation)
+	}
+	if s.Target.Namespace != "android_app" {
+		t.Errorf("target.namespace = %q, want android_app", s.Target.Namespace)
+	}
+	if s.Target.PackageName != pkgName {
+		t.Errorf("target.package_name = %q, want %q", s.Target.PackageName, pkgName)
+	}
+	if len(s.Target.SHA256CertFingerprints) != 1 || s.Target.SHA256CertFingerprints[0] != fingerprint {
+		t.Errorf("target.sha256_cert_fingerprints = %v, want [%q]", s.Target.SHA256CertFingerprints, fingerprint)
+	}
+}


### PR DESCRIPTION
## Changes

- red/green: TestAssetLinks_ServesJSONDocument (tc-ar3ys)
- red/green: TestAssetLinks_OmitsPackagesWithNoFingerprints (tc-ar3ys)
- red/green: TestDefaultPackages_* (tc-ar3ys)
- red/green: TestAnonymousPatterns_IncludesAssetLinks (tc-ar3ys)

api-go half of GH#782 (Android App Links / share). New `internal/assetlinks` package mirroring `internal/aasa`'s structure: `Routes(mux, packages, logger)` serves a fixed Digital Asset Links JSON array at `GET /.well-known/assetlinks.json`, `Content-Type: application/json`, anonymous route. `DefaultPackages()` supplies `uk.towncrierapp.mobile.dev` with the debug keystore's SHA-256 fingerprint (`sha256_cert_fingerprints`, confirmed correct plural field name against the official Android docs). The prod package is deliberately omitted until Play App Signing enrolment (#779), pinned by a test so it surfaces as a to-do rather than silently missing.

The web sibling (assetlinks.json on the main domain, tc-fgpoj/#830) shipped separately and needed a follow-up fix (#832) for an incorrect singular field name in the original orchestrator brief — this api-go slice used the correct plural form from the start.

Verified independently: `go build`, `gofmt`, `go vet`, `golangci-lint` all clean; `go test -race ./...` = 1529 passed across 48 packages.

---
*Auto-shipped via ship skill*