### PR TITLE
fix(ci): deploy subscription-sweep and pg-purge worker images

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -239,7 +239,7 @@ jobs:
       - uses: ./.github/actions/deploy-worker-jobs
         with:
           # Dev has no poll or poll-bootstrap jobs (ADR 0024).
-          jobs: digest digest-hourly dormant-cleanup dev-seed
+          jobs: digest digest-hourly dormant-cleanup dev-seed subscription-sweep pg-purge
           env-suffix: dev
           resource-group: rg-town-crier-dev
           image: ${{ secrets.ACR_LOGIN_SERVER }}/town-crier-worker-go:${{ github.sha }}

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -267,7 +267,7 @@ jobs:
 
       - uses: ./.github/actions/deploy-worker-jobs
         with:
-          jobs: poll poll-bootstrap digest digest-hourly dormant-cleanup
+          jobs: poll poll-bootstrap digest digest-hourly dormant-cleanup subscription-sweep pg-purge
           env-suffix: prod
           resource-group: ${{ needs.infra.outputs.resource-group }}
           image: ${{ steps.resolve-image.outputs.image }}


### PR DESCRIPTION
## Changes

- Add `subscription-sweep` and `pg-purge` to the `deploy-worker-jobs` `jobs:` list in both `cd-dev.yml` and `cd-prod.yml`. Both jobs exist in dev and prod (created by `createWorkerJob` in `infra/environment.go`) but were never included in CD's image-update list, so they've been stuck on Pulumi's placeholder image (`mcr.microsoft.com/k8se/quickstart:latest`) since creation — every scheduled execution has failed.

Confirmed via `az`: `job-tc-pg-purge-prod` 8/8 consecutive failures since 2026-06-27, `job-tc-subscription-sweep-prod` 12/12 since 2026-06-23. Root cause is purely the missing workflow-list entries — `createWorkerJob` applies `pulumi.IgnoreChanges` to the image field uniformly across every worker job, so Pulumi never fights CD here, same as the five jobs already deployed correctly.

`pg-purge` enforces Postgres retention (90-day Notifications, 180-day DeviceRegistrations) with no other enforcement mechanism — this closes an unenforced GDPR retention gap. `subscription-sweep`'s impact was cosmetic only (already assessed in tc-5tza).

Ref: GH #834, bead tc-xmy5r.

---
*Auto-shipped via ship skill*