### PR TITLE
feat(android): App Links + share action

### DIFF
--- a/mobile/android/app/src/main/AndroidManifest.xml
+++ b/mobile/android/app/src/main/AndroidManifest.xml
@@ -22,10 +22,43 @@
         <activity
             android:name="uk.towncrierapp.app.MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             android:label="@string/app_name">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+
+            <!-- Inbound App Links (GH#782 - Android port of iOS Universal
+                 Links). autoVerify triggers Android's Digital Asset Links
+                 check against each host's assetlinks.json (api-go's share
+                 domain / web's main-domain static file, both already
+                 deployed to dev) so a tap opens this app directly rather
+                 than falling back to the browser. Two hosts:
+                 share.towncrierapp.uk (the public share surface,
+                 /a/{authoritySlug}/{ref...}) and towncrierapp.uk (the
+                 legacy /applications list + /applications/{uid...} detail
+                 links, e.g. from a digest email). MainActivity/AppLinkParser
+                 does the actual routing - see PendingLinkHolder for the
+                 auth-gated dispatch. -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="https"
+                    android:host="share.towncrierapp.uk"
+                    android:pathPattern="/a/.*" />
+
+                <data
+                    android:scheme="https"
+                    android:host="towncrierapp.uk"
+                    android:path="/applications" />
+                <data
+                    android:scheme="https"
+                    android:host="towncrierapp.uk"
+                    android:pathPattern="/applications/.*" />
             </intent-filter>
         </activity>
 

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/AppGraph.kt
@@ -45,6 +45,7 @@ import uk.towncrierapp.domain.watchzones.ZonePreferencesRepository
 import uk.towncrierapp.presentation.appearance.AppearanceCoordinator
 import uk.towncrierapp.presentation.auth.AuthCoordinator
 import uk.towncrierapp.presentation.reviewprompt.ReviewPromptTracker
+import uk.towncrierapp.presentation.sharing.PendingLinkHolder
 import java.time.Clock
 
 /** Auth0 tenant identity — same across build flavors (epic #770 D4); only the audience differs, via [AppGraph.authAudience]. */
@@ -213,4 +214,10 @@ public class AppGraph(
     // means Settings' sign-out/deletion device-token removal is a true no-op
     // in production today; wiring a real implementation needs no other change.
     public val deviceTokenRepository: DeviceTokenRepository? = null
+
+    // Cold-start / running-instance App Link holder (GH#782): MainActivity
+    // feeds every inbound ACTION_VIEW intent's parsed DeepLink in here;
+    // TownCrierApp observes readyLink and dispatches it once authed. One
+    // instance for the process lifetime — plain state, no Android leaf needed.
+    public val pendingLinkHolder: PendingLinkHolder = PendingLinkHolder()
 }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
@@ -303,7 +303,10 @@ private fun DeepLinkDispatcher(
                 navController.navigateToTab(Applications)
                 navController.navigate(applicationDetailDestinationFor(resolution.application))
             }
-            DeepLinkResolution.ShowApplicationsList -> navController.navigateToTab(Applications)
+
+            DeepLinkResolution.ShowApplicationsList -> {
+                navController.navigateToTab(Applications)
+            }
         }
         deepLinkViewModel.consumeResolution()
     }

--- a/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
+++ b/mobile/android/app/src/main/kotlin/uk/towncrierapp/app/MainActivity.kt
@@ -35,6 +35,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import kotlinx.serialization.Serializable
+import uk.towncrierapp.domain.reviewprompt.ReviewSignal
 import uk.towncrierapp.domain.subscriptions.SubscriptionTier
 import uk.towncrierapp.presentation.auth.OnboardingPresentation
 import uk.towncrierapp.presentation.designsystem.TownCrierTheme
@@ -43,14 +44,23 @@ import uk.towncrierapp.presentation.features.forceupdate.ForceUpdateViewModel
 import uk.towncrierapp.presentation.features.forceupdate.PLAY_STORE_URL
 import uk.towncrierapp.presentation.features.login.LoginRoute
 import uk.towncrierapp.presentation.features.login.LoginViewModel
+import uk.towncrierapp.presentation.sharing.AppLinkParser
+import uk.towncrierapp.presentation.sharing.DeepLinkResolution
+import uk.towncrierapp.presentation.sharing.DeepLinkViewModel
 import uk.towncrierapp.presentation.R as PresentationR
 
-/** Town Crier's single activity — see android-coding-standards skill: single-activity Compose, no Fragments. */
+/**
+ * Town Crier's single activity — see android-coding-standards skill:
+ * single-activity Compose, no Fragments. `launchMode="singleTask"`
+ * (AndroidManifest.xml) keeps App Link taps routed to this one instance via
+ * [onNewIntent] rather than spawning a second activity on top (GH#782).
+ */
 public class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         val appGraph = (application as TownCrierApplication).appGraph
+        handleAppLinkIntent(appGraph, intent)
         setContent {
             // The four-way appearance picker (tc-4jjw / #778): restyles the
             // whole app the instant `SettingsViewModel.setAppearance` writes
@@ -62,6 +72,30 @@ public class MainActivity : ComponentActivity() {
             }
         }
     }
+
+    /** Re-delivery to the already-running singleTask instance (a link tapped while the app is open, GH#782). */
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleAppLinkIntent((application as TownCrierApplication).appGraph, intent)
+    }
+}
+
+/**
+ * Parses [intent]'s data (if any) as an App Link and, if recognised, hands it
+ * to [AppGraph.pendingLinkHolder] — held there until the user is
+ * authenticated, then dispatched by [TownCrierApp] (GH#782). Not every
+ * inbound intent carries link data (e.g. the plain launcher intent), and not
+ * every URL this activity could theoretically receive matches one of the
+ * three recognised shapes — both are silently ignored, matching iOS
+ * `OpenURLRoute.resolve`'s "no match falls through" contract.
+ */
+private fun handleAppLinkIntent(
+    appGraph: AppGraph,
+    intent: Intent,
+) {
+    val data = intent.dataString ?: return
+    AppLinkParser.parse(data)?.let(appGraph.pendingLinkHolder::linkReceived)
 }
 
 /**
@@ -124,6 +158,10 @@ public fun TownCrierApp(
         if (loginState.isAuthenticated) {
             appGraph.authCoordinator.onSignedIn()
         }
+        // Auth-gated App Link dispatch (GH#782): a link tapped signed-out is
+        // held, never resolved, until this transitions to true — see
+        // PendingLinkHolder's doc for the "no signed-out detail view day-1" rationale.
+        appGraph.pendingLinkHolder.onAuthenticationChanged(loginState.isAuthenticated)
     }
 
     Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
@@ -202,6 +240,8 @@ private fun AuthedShell(
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route
 
+    DeepLinkDispatcher(appGraph = appGraph, navController = navController)
+
     Scaffold(
         modifier = modifier,
         bottomBar = { AuthedBottomBar(currentRoute = currentRoute, navController = navController) },
@@ -213,6 +253,59 @@ private fun AuthedShell(
             subscriptionTier = subscriptionTier,
             modifier = Modifier.padding(contentPadding),
         )
+    }
+}
+
+/**
+ * Observes [AppGraph.pendingLinkHolder]'s ready link (only ever non-null once
+ * signed in — see `PendingLinkHolder`'s doc), resolves it via
+ * [DeepLinkViewModel], and navigates the moment a resolution lands. A no-UI
+ * composable (GH#782) — kept separate from [AuthedShell] so its two
+ * `LaunchedEffect`s don't crowd that function's own state reads. A failed
+ * resolution (e.g. an unknown/expired share link) is dropped silently —
+ * best-effort, matching `ApplicationDetailViewModel.checkSavedState`'s
+ * precedent for a background fetch the user didn't directly initiate.
+ */
+@Composable
+private fun DeepLinkDispatcher(
+    appGraph: AppGraph,
+    navController: NavHostController,
+) {
+    val deepLinkViewModel: DeepLinkViewModel =
+        viewModel(
+            factory =
+                viewModelFactory {
+                    initializer {
+                        DeepLinkViewModel(
+                            appGraph.planningApplicationRepository,
+                            // openedAlert fires only for the by-id path (push taps and
+                            // legacy /applications/{uid} links) — never for a public
+                            // share link (GH#782, iOS AppCoordinator.handleDeepLink parity).
+                            onOpenedAlert = { appGraph.reviewPromptTracker.recordSignal(ReviewSignal.OpenedAlert) },
+                        )
+                    }
+                },
+        )
+    val readyLink by appGraph.pendingLinkHolder.readyLink.collectAsStateWithLifecycle()
+    val deepLinkState by deepLinkViewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(readyLink) {
+        readyLink?.let {
+            deepLinkViewModel.resolve(it)
+            appGraph.pendingLinkHolder.consume()
+        }
+    }
+
+    LaunchedEffect(deepLinkState.resolution) {
+        val resolution = deepLinkState.resolution ?: return@LaunchedEffect
+        when (resolution) {
+            is DeepLinkResolution.ShowApplication -> {
+                navController.navigateToTab(Applications)
+                navController.navigate(applicationDetailDestinationFor(resolution.application))
+            }
+            DeepLinkResolution.ShowApplicationsList -> navController.navigateToTab(Applications)
+        }
+        deepLinkViewModel.consumeResolution()
     }
 }
 

--- a/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
+++ b/mobile/android/app/src/test/kotlin/uk/towncrierapp/app/AppGraphSmokeTest.kt
@@ -81,6 +81,7 @@ class AppGraphSmokeTest {
         assertNotNull(graph.appearanceCoordinator)
         assertNotNull(graph.legalDocumentRepository)
         assertNotNull(graph.reviewPromptTracker)
+        assertNotNull(graph.pendingLinkHolder)
     }
 
     @Test

--- a/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepository.kt
+++ b/mobile/android/data/src/main/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepository.kt
@@ -65,6 +65,16 @@ public class ApiPlanningApplicationRepository(
             .request(ApiEndpoint.get("/v1/applications/$authority/$name"), ApplicationDetailDto.serializer())
             .toDomain()
 
+    override suspend fun detailBySlug(
+        authoritySlug: String,
+        ref: String,
+    ): PlanningApplication =
+        apiClient
+            .request(
+                ApiEndpoint.get("/v1/applications/by-slug/$authoritySlug/$ref"),
+                ApplicationDetailDto.serializer(),
+            ).toDomain()
+
     public companion object {
         public const val PAGE_SIZE: Int = 150
     }

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepositoryTest.kt
@@ -337,4 +337,45 @@ class ApiPlanningApplicationRepositoryTest {
                     .contains("sort"),
             )
         }
+
+    // ── detailBySlug (GH#782: resolves an inbound public share link) ──
+
+    @Test
+    fun `detailBySlug GETs the anonymous by-slug endpoint, decoding the authoritySlug`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(
+                200,
+                """{"name":"24/0001","uid":"uid-1","areaName":"Camden","areaId":42,"address":"1 Example Street",""" +
+                    """"description":"Extension","appState":"Undecided","startDate":"2026-01-10",""" +
+                    """"lastDifferent":"2026-01-11T09:00:00Z","authoritySlug":"camden"}""",
+            )
+            val sut = makeSut(transport)
+
+            val application = sut.detailBySlug("camden", "24/0001")
+
+            val request = transport.requests.single()
+            assertEquals("/v1/applications/by-slug/camden/24/0001", request.url.encodedPath)
+            assertEquals("camden", application.authority.slug)
+        }
+
+    @Test
+    fun `detailBySlug preserves a slashed ref verbatim in the request path`() =
+        runTest {
+            val transport = FakeHttpTransport()
+            transport.enqueueResponse(
+                200,
+                """{"name":"Kingston/25/02755/CLC","uid":"uid-2","areaName":"Kingston","areaId":19,""" +
+                    """"address":"1 Example Street","description":"Extension","appState":"Undecided",""" +
+                    """"startDate":"2026-01-10","lastDifferent":"2026-01-11T09:00:00Z","authoritySlug":"kingston"}""",
+            )
+            val sut = makeSut(transport)
+
+            sut.detailBySlug("kingston", "Kingston/25/02755/CLC")
+
+            assertEquals(
+                "/v1/applications/by-slug/kingston/Kingston/25/02755/CLC",
+                transport.requests.single().url.encodedPath,
+            )
+        }
 }

--- a/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepositoryTest.kt
+++ b/mobile/android/data/src/test/kotlin/uk/towncrierapp/data/applications/ApiPlanningApplicationRepositoryTest.kt
@@ -375,7 +375,9 @@ class ApiPlanningApplicationRepositoryTest {
 
             assertEquals(
                 "/v1/applications/by-slug/kingston/Kingston/25/02755/CLC",
-                transport.requests.single().url.encodedPath,
+                transport.requests
+                    .single()
+                    .url.encodedPath,
             )
         }
 }

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/OfflineAwareRepository.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/OfflineAwareRepository.kt
@@ -55,6 +55,11 @@ public class OfflineAwareRepository(
         name: String,
     ): PlanningApplication = remote.detail(authority, name)
 
+    override suspend fun detailBySlug(
+        authoritySlug: String,
+        ref: String,
+    ): PlanningApplication = remote.detailBySlug(authoritySlug, ref)
+
     private fun isFresh(cached: CachedApplicationPage): Boolean =
         Duration.between(cached.cachedAt, clock.instant()) < TTL
 

--- a/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/PlanningApplicationRepository.kt
+++ b/mobile/android/domain/src/main/kotlin/uk/towncrierapp/domain/applications/PlanningApplicationRepository.kt
@@ -20,9 +20,22 @@ public interface PlanningApplicationRepository {
         cursor: String? = null,
     ): ApplicationPage
 
-    /** By-id or by-slug detail fetch — [authority] may be either the decimal area id or the authority slug. */
+    /** By-id detail fetch (authed) — [authority] is the decimal area id. */
     public suspend fun detail(
         authority: String,
         name: String,
+    ): PlanningApplication
+
+    /**
+     * Anonymous by-slug detail fetch, used to resolve an inbound public share
+     * link (`/a/{authoritySlug}/{ref...}`, GH#782). The server route itself
+     * requires no auth, but Android only ever calls it once the user is
+     * signed in (no signed-out detail view day-1 — see `PendingLinkHolder`).
+     * [authoritySlug] is the API-emitted slug and [ref] is the application's
+     * full area-prefixed PlanIt name, verbatim (slashes preserved).
+     */
+    public suspend fun detailBySlug(
+        authoritySlug: String,
+        ref: String,
     ): PlanningApplication
 }

--- a/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakePlanningApplicationRepository.kt
+++ b/mobile/android/domain/src/testFixtures/kotlin/uk/towncrierapp/domain/applications/FakePlanningApplicationRepository.kt
@@ -21,6 +21,10 @@ public class FakePlanningApplicationRepository : PlanningApplicationRepository {
     public var detailFailWith: DomainError? = null
     public val detailCalls: MutableList<Pair<String, String>> = mutableListOf()
 
+    public var detailBySlugResult: PlanningApplication = aPlanningApplication()
+    public var detailBySlugFailWith: DomainError? = null
+    public val detailBySlugCalls: MutableList<Pair<String, String>> = mutableListOf()
+
     /**
      * A cooperative gate hook run before [detail] returns — the "iOS
      * spy-gate idiom" (testing.md) for re-entrancy tests. A test sets this to
@@ -49,5 +53,14 @@ public class FakePlanningApplicationRepository : PlanningApplicationRepository {
         beforeDetail()
         detailFailWith?.let { throw it }
         return detailResult
+    }
+
+    override suspend fun detailBySlug(
+        authoritySlug: String,
+        ref: String,
+    ): PlanningApplication {
+        detailBySlugCalls += authoritySlug to ref
+        detailBySlugFailWith?.let { throw it }
+        return detailBySlugResult
     }
 }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailScreen.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/features/applicationdetail/ApplicationDetailScreen.kt
@@ -44,15 +44,8 @@ import uk.towncrierapp.presentation.designsystem.components.StatusBadge
 import uk.towncrierapp.presentation.designsystem.components.StatusTimeline
 import uk.towncrierapp.presentation.designsystem.components.statusDisplay
 import uk.towncrierapp.presentation.features.applicationlist.applicationErrorMessageRes
+import uk.towncrierapp.presentation.sharing.ShareUrl
 import java.time.LocalDate
-
-/** The public share origin the "share" action links to — see `api-go/internal/sharepage`'s `shareOrigin` + `/a/{slug}/{ref}` route. */
-internal const val SHARE_ORIGIN: String = "https://share.towncrierapp.uk"
-
-internal fun shareUrlFor(
-    authoritySlug: String,
-    name: String,
-): String = "$SHARE_ORIGIN/a/$authoritySlug/$name"
 
 /**
  * A full navigation destination (Material idiom — not a bottom sheet):
@@ -148,8 +141,13 @@ private fun ApplicationDetailTopBar(
                         ),
                 )
             }
-            if (authoritySlug != null) {
-                IconButton(onClick = { onShareClick(shareUrlFor(authoritySlug, applicationName)) }) {
+            // Share is hidden entirely when the slug is unknown (list-payload-only
+            // state, before the by-id refresh completes) OR when ShareUrl.build
+            // still declines the pair (e.g. an empty ref) — never a disabled/dead
+            // button (GH#782 port of iOS `ShareURL.build`'s nullability contract).
+            val shareUrl = authoritySlug?.let { slug -> ShareUrl.build(authoritySlug = slug, ref = applicationName) }
+            if (shareUrl != null) {
+                IconButton(onClick = { onShareClick(shareUrl) }) {
                     Icon(
                         imageVector = Icons.Filled.Share,
                         contentDescription = stringResource(R.string.application_detail_share_content_description),

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/AppLinkParser.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/AppLinkParser.kt
@@ -24,6 +24,10 @@ public object AppLinkParser {
     private const val SHARE_PREFIX = "/a/"
 
     /** Parses the full URL string (e.g. `Intent.getDataString()`). Returns `null` for a malformed or unrecognised URL. */
+    @Suppress("SwallowedException")
+    // A malformed URL is routine here (any URL this activity could receive
+    // that isn't one of the three recognised App Link shapes), not a
+    // diagnostic-worthy failure — treated the same as an unrecognised path.
     public fun parse(url: String): DeepLink? {
         val path =
             try {

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/AppLinkParser.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/AppLinkParser.kt
@@ -1,0 +1,66 @@
+package uk.towncrierapp.presentation.sharing
+
+import uk.towncrierapp.domain.applications.PlanningApplicationId
+import java.net.URI
+import java.net.URISyntaxException
+
+/**
+ * Parses inbound App Link URLs (handed to the app via an `ACTION_VIEW` intent
+ * whose data matched one of the manifest's `autoVerify` intent filters) into
+ * the in-app [DeepLink] vocabulary. Port of iOS `UniversalLinkParser.parse`
+ * (GH#782).
+ *
+ * Three shapes are recognised:
+ * - the public share scheme `/a/{authoritySlug}/{ref...}`, where `ref` is the
+ *   application's full area-prefixed PlanIt name, verbatim (slashes preserved
+ *   as path separators);
+ * - the legacy `/applications/{uid...}` (a specific planning application) -
+ *   PlanIt UIDs may contain `/`, so the entire path suffix after
+ *   `/applications/` is preserved verbatim;
+ * - `/applications` (the root list).
+ */
+public object AppLinkParser {
+    private const val APPLICATIONS_PATH = "/applications"
+    private const val SHARE_PREFIX = "/a/"
+
+    /** Parses the full URL string (e.g. `Intent.getDataString()`). Returns `null` for a malformed or unrecognised URL. */
+    public fun parse(url: String): DeepLink? {
+        val path =
+            try {
+                URI(url).path
+            } catch (e: URISyntaxException) {
+                null
+            } ?: return null
+        return parseShare(path) ?: parseApplications(path)
+    }
+
+    /**
+     * Parses `/a/{authoritySlug}/{ref...}`: the first segment after `/a/` is
+     * the slug, everything after it (verbatim, slashes preserved) is the ref.
+     * A bare `/a` or `/a/`, or a slug with no ref, returns `null`. The `/a/`
+     * separator is required, so `/afoo` does not match.
+     */
+    private fun parseShare(path: String): DeepLink? {
+        if (!path.startsWith(SHARE_PREFIX)) return null
+        val parts = path.substring(SHARE_PREFIX.length).split("/", limit = 2)
+        if (parts.size != 2 || parts[0].isEmpty() || parts[1].isEmpty()) return null
+        return DeepLink.ShareApplication(authoritySlug = parts[0], ref = parts[1])
+    }
+
+    private fun parseApplications(path: String): DeepLink? {
+        if (!path.startsWith(APPLICATIONS_PATH)) return null
+        val suffix = path.substring(APPLICATIONS_PATH.length)
+        if (suffix.isEmpty()) return DeepLink.ApplicationsList
+        if (!suffix.startsWith("/")) return null
+        val uid = suffix.substring(1)
+        if (uid.isEmpty()) return DeepLink.ApplicationsList
+        // App Links only carry the uid path segment - split on the first "/" to
+        // reconstruct authority + name. A legacy uid without a "/" is treated as
+        // name-only with an empty authority; this parser is best-effort, and a
+        // URL that doesn't carry an authority fails gracefully at the fetch.
+        val components = uid.split("/", limit = 2)
+        val authority = if (components.size > 1) components[0] else ""
+        val name = if (components.size > 1) components[1] else uid
+        return DeepLink.ApplicationDetail(PlanningApplicationId(authority = authority, name = name))
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLink.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLink.kt
@@ -1,0 +1,19 @@
+package uk.towncrierapp.presentation.sharing
+
+import uk.towncrierapp.domain.applications.PlanningApplicationId
+
+/** Navigation targets reachable via App Links or (future, #777) notification taps. Port of iOS `DeepLink`. */
+public sealed interface DeepLink {
+    public data class ApplicationDetail(val id: PlanningApplicationId) : DeepLink
+
+    /** The Applications tab root - used when an App Link points at `/applications` exactly (e.g. a digest email CTA). */
+    public data object ApplicationsList : DeepLink
+
+    /**
+     * A public share link `/a/{authoritySlug}/{ref...}` (GH#738 Slice 4 / GH#782).
+     * [authoritySlug] is the API-emitted slug and [ref] is the application's
+     * full area-prefixed PlanIt name, verbatim (slashes preserved). Resolved
+     * into the native detail screen via the anonymous by-slug read.
+     */
+    public data class ShareApplication(val authoritySlug: String, val ref: String) : DeepLink
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLink.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLink.kt
@@ -4,7 +4,9 @@ import uk.towncrierapp.domain.applications.PlanningApplicationId
 
 /** Navigation targets reachable via App Links or (future, #777) notification taps. Port of iOS `DeepLink`. */
 public sealed interface DeepLink {
-    public data class ApplicationDetail(val id: PlanningApplicationId) : DeepLink
+    public data class ApplicationDetail(
+        val id: PlanningApplicationId,
+    ) : DeepLink
 
     /** The Applications tab root - used when an App Link points at `/applications` exactly (e.g. a digest email CTA). */
     public data object ApplicationsList : DeepLink
@@ -15,5 +17,8 @@ public sealed interface DeepLink {
      * full area-prefixed PlanIt name, verbatim (slashes preserved). Resolved
      * into the native detail screen via the anonymous by-slug read.
      */
-    public data class ShareApplication(val authoritySlug: String, val ref: String) : DeepLink
+    public data class ShareApplication(
+        val authoritySlug: String,
+        val ref: String,
+    ) : DeepLink
 }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLinkResolution.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLinkResolution.kt
@@ -1,0 +1,12 @@
+package uk.towncrierapp.presentation.sharing
+
+import uk.towncrierapp.domain.applications.PlanningApplication
+
+/** What the NavHost layer should do once a [DeepLink] has been resolved against the repository. */
+public sealed interface DeepLinkResolution {
+    /** Navigate to the Applications tab and push the detail destination for [application]. */
+    public data class ShowApplication(val application: PlanningApplication) : DeepLinkResolution
+
+    /** Navigate to the Applications tab root. */
+    public data object ShowApplicationsList : DeepLinkResolution
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLinkResolution.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLinkResolution.kt
@@ -5,7 +5,9 @@ import uk.towncrierapp.domain.applications.PlanningApplication
 /** What the NavHost layer should do once a [DeepLink] has been resolved against the repository. */
 public sealed interface DeepLinkResolution {
     /** Navigate to the Applications tab and push the detail destination for [application]. */
-    public data class ShowApplication(val application: PlanningApplication) : DeepLinkResolution
+    public data class ShowApplication(
+        val application: PlanningApplication,
+    ) : DeepLinkResolution
 
     /** Navigate to the Applications tab root. */
     public data object ShowApplicationsList : DeepLinkResolution

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLinkUiState.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLinkUiState.kt
@@ -1,0 +1,10 @@
+package uk.towncrierapp.presentation.sharing
+
+import uk.towncrierapp.domain.auth.DomainError
+
+/** `DeepLinkViewModel` state — a one-shot [resolution] the NavHost layer consumes via `consumeResolution()`. */
+public data class DeepLinkUiState(
+    val resolution: DeepLinkResolution? = null,
+    val isResolving: Boolean = false,
+    val error: DomainError? = null,
+)

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLinkViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLinkViewModel.kt
@@ -1,0 +1,85 @@
+package uk.towncrierapp.presentation.sharing
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import uk.towncrierapp.domain.applications.PlanningApplicationRepository
+import uk.towncrierapp.domain.auth.DomainError
+
+/**
+ * Resolves a parsed [DeepLink] (from an App Link, dispatched once
+ * [PendingLinkHolder] has surfaced it post-auth) into a [DeepLinkResolution]
+ * the NavHost layer acts on. Port of iOS `AppCoordinator+Detail`'s
+ * `showApplicationDetail(_:)`/`showApplicationDetail(bySlug:ref:)` (GH#782).
+ *
+ * [onOpenedAlert] fires the review-prompt `openedAlert` signal (GH #628) —
+ * ONLY for the legacy by-id path (push taps and `/applications/{uid}` App
+ * Links, the "instant-alert payoff moment"). A public share link is
+ * deliberately excluded: arriving from a shared web link is not that payoff
+ * moment (iOS `AppCoordinator.handleDeepLink`'s `.shareApplication` case
+ * omits the signal — a deliberate distinction, not an oversight, ported
+ * faithfully here).
+ */
+public class DeepLinkViewModel(
+    private val repository: PlanningApplicationRepository,
+    private val onOpenedAlert: suspend () -> Unit = {},
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(DeepLinkUiState())
+    public val uiState: StateFlow<DeepLinkUiState> = _uiState.asStateFlow()
+
+    public fun resolve(deepLink: DeepLink) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isResolving = true, error = null) }
+            when (deepLink) {
+                DeepLink.ApplicationsList ->
+                    _uiState.update {
+                        it.copy(isResolving = false, resolution = DeepLinkResolution.ShowApplicationsList)
+                    }
+                is DeepLink.ApplicationDetail -> resolveApplicationDetail(deepLink)
+                is DeepLink.ShareApplication -> resolveShareApplication(deepLink)
+            }
+        }
+    }
+
+    private suspend fun resolveApplicationDetail(deepLink: DeepLink.ApplicationDetail) {
+        try {
+            val application = repository.detail(deepLink.id.authority, deepLink.id.name)
+            _uiState.update {
+                it.copy(isResolving = false, resolution = DeepLinkResolution.ShowApplication(application))
+            }
+            onOpenedAlert()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: DomainError) {
+            _uiState.update { it.copy(isResolving = false, error = e) }
+        }
+    }
+
+    private suspend fun resolveShareApplication(deepLink: DeepLink.ShareApplication) {
+        try {
+            val application = repository.detailBySlug(deepLink.authoritySlug, deepLink.ref)
+            _uiState.update {
+                it.copy(isResolving = false, resolution = DeepLinkResolution.ShowApplication(application))
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: DomainError) {
+            _uiState.update { it.copy(isResolving = false, error = e) }
+        }
+    }
+
+    /** Clears [DeepLinkUiState.resolution] once the NavHost layer has acted on it — a one-shot effect (compose-ui.md). */
+    public fun consumeResolution() {
+        _uiState.update { it.copy(resolution = null) }
+    }
+
+    /** Clears [DeepLinkUiState.error] once the caller has surfaced it. */
+    public fun consumeError() {
+        _uiState.update { it.copy(error = null) }
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLinkViewModel.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/DeepLinkViewModel.kt
@@ -36,12 +36,19 @@ public class DeepLinkViewModel(
         viewModelScope.launch {
             _uiState.update { it.copy(isResolving = true, error = null) }
             when (deepLink) {
-                DeepLink.ApplicationsList ->
+                DeepLink.ApplicationsList -> {
                     _uiState.update {
                         it.copy(isResolving = false, resolution = DeepLinkResolution.ShowApplicationsList)
                     }
-                is DeepLink.ApplicationDetail -> resolveApplicationDetail(deepLink)
-                is DeepLink.ShareApplication -> resolveShareApplication(deepLink)
+                }
+
+                is DeepLink.ApplicationDetail -> {
+                    resolveApplicationDetail(deepLink)
+                }
+
+                is DeepLink.ShareApplication -> {
+                    resolveShareApplication(deepLink)
+                }
             }
         }
     }

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/PendingLinkHolder.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/PendingLinkHolder.kt
@@ -1,0 +1,47 @@
+package uk.towncrierapp.presentation.sharing
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * Holds an inbound App Link until the user is authenticated, then hands it
+ * off exactly once (GH#782). A link tapped while signed out must NOT trigger
+ * a fetch - the by-slug read is anonymous, but the app experience is authed
+ * day-1 (no signed-out detail view) - so it is held here until
+ * [onAuthenticationChanged] reports `true`, then surfaced via [readyLink] for
+ * the composition layer to dispatch and [consume]. One instance lives for
+ * the process lifetime, owned by the composition root (`AppGraph`).
+ */
+public class PendingLinkHolder {
+    private var isAuthenticated = false
+    private var heldLink: DeepLink? = null
+
+    private val _readyLink = MutableStateFlow<DeepLink?>(null)
+    public val readyLink: StateFlow<DeepLink?> = _readyLink.asStateFlow()
+
+    /** Called when a new App Link arrives - cold start (`MainActivity.onCreate`) or a running-instance re-delivery (`onNewIntent`). */
+    public fun linkReceived(link: DeepLink) {
+        if (isAuthenticated) {
+            _readyLink.value = link
+        } else {
+            heldLink = link
+        }
+    }
+
+    /** Called on every auth-state transition; dispatches a held link the moment sign-in completes. */
+    public fun onAuthenticationChanged(authenticated: Boolean) {
+        isAuthenticated = authenticated
+        if (authenticated) {
+            heldLink?.let {
+                _readyLink.value = it
+                heldLink = null
+            }
+        }
+    }
+
+    /** Clears the ready link once the caller has dispatched it - a link is delivered exactly once. */
+    public fun consume() {
+        _readyLink.value = null
+    }
+}

--- a/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/ShareUrl.kt
+++ b/mobile/android/presentation/src/main/kotlin/uk/towncrierapp/presentation/sharing/ShareUrl.kt
@@ -1,0 +1,52 @@
+package uk.towncrierapp.presentation.sharing
+
+/**
+ * Builds the canonical public share URL for a planning application:
+ * `https://share.towncrierapp.uk/a/{authoritySlug}/{ref}`. Port of iOS
+ * `ShareURL.build` (GH#738 Slice 4 / GH#782).
+ *
+ * [ref] is the application's full area-prefixed PlanIt name, verbatim — it
+ * contains slashes (e.g. `Kingston/25/02755/CLC`), which are preserved as
+ * path separators. [authoritySlug] always comes from the API (`authoritySlug`
+ * on the detail/by-slug JSON) — this object never computes one.
+ */
+public object ShareUrl {
+    /** Origin of the public share surface. Mirrors the web `SHARE_ORIGIN` constant and iOS `ShareURL.origin`. */
+    public const val ORIGIN: String = "https://share.towncrierapp.uk"
+
+    /**
+     * Returns the canonical share URL, or `null` when either component is
+     * empty. Only unsafe characters in [ref] are percent-encoded —
+     * [encodePathAllowed] keeps `/`, so the ref's slashes remain path
+     * separators. [authoritySlug] is already URL-safe (API-emitted slug).
+     */
+    public fun build(
+        authoritySlug: String,
+        ref: String,
+    ): String? {
+        if (authoritySlug.isEmpty() || ref.isEmpty()) return null
+        return "$ORIGIN/a/$authoritySlug/${encodePathAllowed(ref)}"
+    }
+}
+
+// The Kotlin equivalent of iOS's `CharacterSet.urlPathAllowed`: unreserved
+// characters, sub-delimiters, ":", "@", and "/" (so a literal "/" in `ref`
+// survives as a path separator rather than being escaped to "%2F"). Hand-
+// rolled rather than `android.net.Uri.encode` deliberately — this file needs
+// to be testable as a plain JVM unit (no Robolectric, per android-coding-
+// standards skill), and `android.net.Uri` is unusable off-device.
+private val PATH_ALLOWED_CHARS: Set<Char> =
+    (('A'..'Z') + ('a'..'z') + ('0'..'9') + "-._~!$&'()*+,;=:@/".toList()).toSet()
+
+private fun encodePathAllowed(value: String): String =
+    buildString {
+        for (byte in value.toByteArray(Charsets.UTF_8)) {
+            val char = byte.toInt().toChar()
+            if (byte >= 0 && char in PATH_ALLOWED_CHARS) {
+                append(char)
+            } else {
+                append('%')
+                append("%02X".format(byte.toInt() and 0xFF))
+            }
+        }
+    }

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/sharing/AppLinkParserTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/sharing/AppLinkParserTest.kt
@@ -1,0 +1,104 @@
+package uk.towncrierapp.presentation.sharing
+
+import uk.towncrierapp.domain.applications.PlanningApplicationId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** Port of iOS `UniversalLinkParserTests` — same test matrix, ported test-for-test (GH#782). */
+class AppLinkParserTest {
+    @Test
+    fun `parse applicationDetail URL returns ApplicationDetail deep link`() {
+        val result = AppLinkParser.parse("https://towncrierapp.uk/applications/19/00123/FUL")
+
+        // path /applications/19/00123/FUL -> authority "19", name "00123/FUL"
+        assertEquals(DeepLink.ApplicationDetail(PlanningApplicationId(authority = "19", name = "00123/FUL")), result)
+    }
+
+    @Test
+    fun `parse applications root URL returns ApplicationsList deep link`() {
+        val result = AppLinkParser.parse("https://towncrierapp.uk/applications")
+
+        assertEquals(DeepLink.ApplicationsList, result)
+    }
+
+    @Test
+    fun `parse applications root with trailing slash returns ApplicationsList deep link`() {
+        val result = AppLinkParser.parse("https://towncrierapp.uk/applications/")
+
+        assertEquals(DeepLink.ApplicationsList, result)
+    }
+
+    @Test
+    fun `parse unrecognised path returns null`() {
+        val result = AppLinkParser.parse("https://towncrierapp.uk/foo")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parse empty path returns null`() {
+        val result = AppLinkParser.parse("https://towncrierapp.uk")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parse applications prefix without separator returns null`() {
+        // Guard against false-positive matches like /applicationsfoo.
+        val result = AppLinkParser.parse("https://towncrierapp.uk/applicationsfoo")
+
+        assertNull(result)
+    }
+
+    // MARK: - Public share scheme /a/{authoritySlug}/{ref...} (GH#738 Slice 4 / GH#782)
+
+    @Test
+    fun `parse share URL with prefixed ref returns ShareApplication deep link`() {
+        // The ref is the application's full area-prefixed PlanIt name, verbatim
+        // - it contains slashes, which are preserved as-is after the slug segment.
+        val result = AppLinkParser.parse("https://share.towncrierapp.uk/a/kingston/Kingston/25/02755/CLC")
+
+        assertEquals(DeepLink.ShareApplication(authoritySlug = "kingston", ref = "Kingston/25/02755/CLC"), result)
+    }
+
+    @Test
+    fun `parse share URL with simple ref returns ShareApplication deep link`() {
+        val result = AppLinkParser.parse("https://share.towncrierapp.uk/a/croydon/23/03456/FUL")
+
+        assertEquals(DeepLink.ShareApplication(authoritySlug = "croydon", ref = "23/03456/FUL"), result)
+    }
+
+    @Test
+    fun `parse share prefix without separator returns null`() {
+        // Guard against false-positive matches like /afoo: the /a/ separator is
+        // required, so a path that merely starts with /a must not match.
+        val result = AppLinkParser.parse("https://share.towncrierapp.uk/afoo")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parse share bare path with no ref returns null`() {
+        // /a carries neither a slug nor a ref.
+        val result = AppLinkParser.parse("https://share.towncrierapp.uk/a")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parse share trailing slash with no ref returns null`() {
+        // /a/ has a separator but no slug/ref.
+        val result = AppLinkParser.parse("https://share.towncrierapp.uk/a/")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `parse share slug without ref returns null`() {
+        // A slug with no ref segment after it is not a valid share link.
+        val result = AppLinkParser.parse("https://share.towncrierapp.uk/a/kingston")
+
+        assertNull(result)
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/sharing/DeepLinkViewModelTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/sharing/DeepLinkViewModelTest.kt
@@ -1,0 +1,114 @@
+package uk.towncrierapp.presentation.sharing
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.towncrierapp.domain.applications.FakePlanningApplicationRepository
+import uk.towncrierapp.domain.applications.PlanningApplicationId
+import uk.towncrierapp.domain.applications.aPlanningApplication
+import uk.towncrierapp.domain.auth.DomainError
+import uk.towncrierapp.presentation.MainDispatcherExtension
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Resolves a parsed [DeepLink] into a navigable [DeepLinkResolution] — the
+ * legacy `/applications/{uid}` shape via the authed by-id read, the public
+ * `/a/{slug}/{ref}` share shape via the anonymous by-slug read, and the bare
+ * `/applications` shape with no fetch at all. Only the by-id path fires the
+ * review-prompt `openedAlert` signal — arriving via a share link deliberately
+ * does not (GH#782, iOS parity).
+ */
+@ExtendWith(MainDispatcherExtension::class)
+class DeepLinkViewModelTest {
+    @Test
+    fun `resolving ApplicationsList surfaces ShowApplicationsList with no fetch`() =
+        runTest {
+            val repository = FakePlanningApplicationRepository()
+            val viewModel = DeepLinkViewModel(repository)
+
+            viewModel.resolve(DeepLink.ApplicationsList)
+
+            assertEquals(DeepLinkResolution.ShowApplicationsList, viewModel.uiState.value.resolution)
+            assertTrue(repository.detailCalls.isEmpty())
+            assertTrue(repository.detailBySlugCalls.isEmpty())
+        }
+
+    @Test
+    fun `resolving ApplicationDetail fetches by id and surfaces ShowApplication`() =
+        runTest {
+            val application = aPlanningApplication()
+            val repository = FakePlanningApplicationRepository().apply { detailResult = application }
+            val viewModel = DeepLinkViewModel(repository)
+
+            viewModel.resolve(DeepLink.ApplicationDetail(PlanningApplicationId(authority = "42", name = "24/0001")))
+
+            val resolution = assertIs<DeepLinkResolution.ShowApplication>(viewModel.uiState.value.resolution)
+            assertEquals(application, resolution.application)
+            assertEquals(listOf("42" to "24/0001"), repository.detailCalls)
+        }
+
+    @Test
+    fun `resolving ApplicationDetail fires the openedAlert callback`() =
+        runTest {
+            val repository = FakePlanningApplicationRepository()
+            var openedAlertCalls = 0
+            val viewModel = DeepLinkViewModel(repository, onOpenedAlert = { openedAlertCalls++ })
+
+            viewModel.resolve(DeepLink.ApplicationDetail(PlanningApplicationId(authority = "42", name = "24/0001")))
+
+            assertEquals(1, openedAlertCalls)
+        }
+
+    @Test
+    fun `resolving ShareApplication fetches by slug and surfaces ShowApplication`() =
+        runTest {
+            val application = aPlanningApplication()
+            val repository = FakePlanningApplicationRepository().apply { detailBySlugResult = application }
+            val viewModel = DeepLinkViewModel(repository)
+
+            viewModel.resolve(DeepLink.ShareApplication(authoritySlug = "camden", ref = "24/0001"))
+
+            val resolution = assertIs<DeepLinkResolution.ShowApplication>(viewModel.uiState.value.resolution)
+            assertEquals(application, resolution.application)
+            assertEquals(listOf("camden" to "24/0001"), repository.detailBySlugCalls)
+        }
+
+    @Test
+    fun `resolving ShareApplication does NOT fire the openedAlert callback`() =
+        runTest {
+            val repository = FakePlanningApplicationRepository()
+            var openedAlertCalls = 0
+            val viewModel = DeepLinkViewModel(repository, onOpenedAlert = { openedAlertCalls++ })
+
+            viewModel.resolve(DeepLink.ShareApplication(authoritySlug = "camden", ref = "24/0001"))
+
+            assertEquals(0, openedAlertCalls)
+        }
+
+    @Test
+    fun `a failed by-slug resolution surfaces the error, not a resolution`() =
+        runTest {
+            val repository = FakePlanningApplicationRepository().apply { detailBySlugFailWith = DomainError.NotFound }
+            val viewModel = DeepLinkViewModel(repository)
+
+            viewModel.resolve(DeepLink.ShareApplication(authoritySlug = "unknown-slug", ref = "24/0001"))
+
+            assertNull(viewModel.uiState.value.resolution)
+            assertEquals(DomainError.NotFound, viewModel.uiState.value.error)
+        }
+
+    @Test
+    fun `consumeResolution clears the resolution once dispatched`() =
+        runTest {
+            val repository = FakePlanningApplicationRepository()
+            val viewModel = DeepLinkViewModel(repository)
+            viewModel.resolve(DeepLink.ApplicationsList)
+
+            viewModel.consumeResolution()
+
+            assertNull(viewModel.uiState.value.resolution)
+        }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/sharing/PendingLinkHolderTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/sharing/PendingLinkHolderTest.kt
@@ -1,0 +1,77 @@
+package uk.towncrierapp.presentation.sharing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * A cold-start App Link must NOT resolve while the user is signed out (no
+ * signed-out detail view day-1, GH#782 pre-resolved decision) - it is held
+ * until authentication completes, then dispatched exactly once. iOS parity:
+ * the by-slug read is anonymous, but the app experience is authed.
+ */
+class PendingLinkHolderTest {
+    private val link = DeepLink.ShareApplication(authoritySlug = "camden", ref = "24/0001")
+
+    @Test
+    fun `a link received while signed out is held, not surfaced`() {
+        val holder = PendingLinkHolder()
+
+        holder.linkReceived(link)
+
+        assertNull(holder.readyLink.value)
+    }
+
+    @Test
+    fun `a held link is surfaced the moment authentication completes`() {
+        val holder = PendingLinkHolder()
+        holder.linkReceived(link)
+
+        holder.onAuthenticationChanged(authenticated = true)
+
+        assertEquals(link, holder.readyLink.value)
+    }
+
+    @Test
+    fun `a link received while already signed in is surfaced immediately`() {
+        val holder = PendingLinkHolder()
+        holder.onAuthenticationChanged(authenticated = true)
+
+        holder.linkReceived(link)
+
+        assertEquals(link, holder.readyLink.value)
+    }
+
+    @Test
+    fun `consume clears the ready link so it is only dispatched once`() {
+        val holder = PendingLinkHolder()
+        holder.onAuthenticationChanged(authenticated = true)
+        holder.linkReceived(link)
+
+        holder.consume()
+
+        assertNull(holder.readyLink.value)
+    }
+
+    @Test
+    fun `signing out after holding a link does not surface it retroactively`() {
+        val holder = PendingLinkHolder()
+        holder.linkReceived(link)
+
+        holder.onAuthenticationChanged(authenticated = false)
+
+        assertNull(holder.readyLink.value)
+    }
+
+    @Test
+    fun `a second link received while authenticated replaces the first`() {
+        val holder = PendingLinkHolder()
+        holder.onAuthenticationChanged(authenticated = true)
+        val second = DeepLink.ShareApplication(authoritySlug = "croydon", ref = "23/03456/FUL")
+
+        holder.linkReceived(link)
+        holder.linkReceived(second)
+
+        assertEquals(second, holder.readyLink.value)
+    }
+}

--- a/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/sharing/ShareUrlTest.kt
+++ b/mobile/android/presentation/src/test/kotlin/uk/towncrierapp/presentation/sharing/ShareUrlTest.kt
@@ -1,0 +1,55 @@
+package uk.towncrierapp.presentation.sharing
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/** Port of iOS `ShareURLTests` — same encoding rules, ported test-for-test. */
+class ShareUrlTest {
+    @Test
+    fun `build returns the canonical share URL for a simple ref`() {
+        val result = ShareUrl.build(authoritySlug = "camden", ref = "24/0001")
+
+        assertEquals("https://share.towncrierapp.uk/a/camden/24/0001", result)
+    }
+
+    @Test
+    fun `build preserves literal slashes in a slashed ref`() {
+        val result = ShareUrl.build(authoritySlug = "kingston", ref = "Kingston/25/02755/CLC")
+
+        assertEquals("https://share.towncrierapp.uk/a/kingston/Kingston/25/02755/CLC", result)
+    }
+
+    @Test
+    fun `build percent-encodes a space in the ref`() {
+        val result = ShareUrl.build(authoritySlug = "camden", ref = "24/0001 A")
+
+        assertEquals("https://share.towncrierapp.uk/a/camden/24/0001%20A", result)
+    }
+
+    @Test
+    fun `build percent-encodes a hash in the ref`() {
+        val result = ShareUrl.build(authoritySlug = "camden", ref = "24/0001#A")
+
+        assertEquals("https://share.towncrierapp.uk/a/camden/24/0001%23A", result)
+    }
+
+    @Test
+    fun `build returns null for an empty authority slug`() {
+        val result = ShareUrl.build(authoritySlug = "", ref = "24/0001")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `build returns null for an empty ref`() {
+        val result = ShareUrl.build(authoritySlug = "camden", ref = "")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `origin is the public share domain`() {
+        assertEquals("https://share.towncrierapp.uk", ShareUrl.ORIGIN)
+    }
+}


### PR DESCRIPTION
## Changes

- feat(android): App Links + share action (GH#782, tc-0xqg3) — 15 TDD commits

Android slice of GH#782 (share links + App Links). Its dependencies (api-go + web serving `assetlinks.json`) are already merged and verified live on dev.

- `ShareUrl.kt` — exact port of iOS `ShareURL.build`, hand-rolled percent-encoding (pure JVM, testable without Robolectric); wired into the detail screen's share button, hidden when the slug is unknown.
- `AppLinkParser.kt` — exact port of iOS `UniversalLinkParser.parse`, all 12 iOS test-matrix cases ported verbatim.
- `PendingLinkHolder` + `DeepLinkViewModel` + `DeepLinkDispatcher` — cold-start link held until authenticated, then resolved and navigated. `openedAlert` (review-prompt signal) fires only for the legacy by-id path, never for a share link — matches iOS's literal `AppCoordinator.handleDeepLink` behaviour.
- `AndroidManifest.xml` — `autoVerify` intent filters for both hosts; `MainActivity` now `singleTask` with `onNewIntent` handling.
- New `PlanningApplicationRepository.detailBySlug` hitting the anonymous by-slug endpoint.

Verified live on the `towncrier` emulator: all three intent-filter shapes correctly resolve `MainActivity`; an explicit share-link intent launched the app without crashing. Real Digital Asset Links auto-verification is out of reach on the emulator, as expected.

A follow-up (silent-drop UX on a failed link resolution) is filed as tc-gw9td, discovered-from this bead.

Verified independently: full clean test rerun (244/244 fresh, all pass), `ktlintCheck`, `detekt` all clean, `:app:assembleDevDebug` builds, `:presentation`→`:data` module boundary respected. Scope-checked via three-dot diff against origin/main — 21 files, all under `mobile/android/` (a two-dot diff misleadingly showed `.github/workflows/cd-*.yml` changes, which is just base-branch drift from an unrelated already-merged CI fix, #836 — confirmed via the three-dot diff, which is what GitHub actually shows for this PR).

Release-Note trailer included (user-visible feature).

---
*Auto-shipped via ship skill*