### PR TITLE
fix(migrations): use CREATE INDEX CONCURRENTLY, bump timeouts

### DIFF
--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -151,7 +151,7 @@ jobs:
             -host psql-town-crier-shared.postgres.database.azure.com \
             -admin-user town-crier-github-actions \
             -db town_crier_dev \
-            -timeout 120s
+            -timeout 600s
 
   # ── Go API: build & push image ──────────────────────
   api-go-image:

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -129,7 +129,7 @@ jobs:
     name: "Database: Run migrations (dev)"
     needs: infra-dev
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     environment: development
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -117,7 +117,7 @@ jobs:
             -host psql-town-crier-shared.postgres.database.azure.com \
             -admin-user town-crier-github-actions \
             -db town_crier_prod \
-            -timeout 120s
+            -timeout 600s
 
   # ── Go API ────────────────────────────────────────────
   api-go:

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -95,7 +95,7 @@ jobs:
     name: "Database: Run migrations (prod)"
     needs: infra
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     environment: production
     steps:
       - uses: actions/checkout@v6

--- a/api-go/internal/platform/postgres/migrations/0018_application_search_indexes.sql
+++ b/api-go/internal/platform/postgres/migrations/0018_application_search_indexes.sql
@@ -1,3 +1,4 @@
+-- +goose NO TRANSACTION
 -- +goose Up
 
 -- pg_trgm backs the address fuzzy-match tier of GET /v1/applications/search
@@ -14,7 +15,18 @@ CREATE EXTENSION IF NOT EXISTS pg_trgm;
 -- case-insensitive matching) serves <%/%> without a sequential scan. Per
 -- pg_trgm convention, the index goes on the argument being searched into
 -- (address), not the search term.
-CREATE INDEX IF NOT EXISTS applications_address_trgm
+--
+-- CONCURRENTLY (tc-5i07d): plain CREATE INDEX takes a lock that blocks
+-- writes to applications for the whole build — twice fatal in prod, where it
+-- blocked the polling worker and then hit the pgmigrate timeout. CONCURRENTLY
+-- avoids that lock at the cost of a longer build (two table scans) and
+-- requires running outside a transaction — see the NO TRANSACTION directive
+-- above, which also means this file's statements are NOT atomic as a group:
+-- a failure partway through can leave a later statement unapplied (rerunning
+-- the migration is safe/idempotent via IF NOT EXISTS, except that a failed
+-- CONCURRENTLY build can leave behind an INVALID index that IF NOT EXISTS
+-- will not replace — see incident notes on tc-5i07d).
+CREATE INDEX CONCURRENTLY IF NOT EXISTS applications_address_trgm
     ON applications USING gin (lower(address) gin_trgm_ops);
 
 -- Tier 3 (description full-text match): a GIN index over the `english`-config
@@ -23,7 +35,7 @@ CREATE INDEX IF NOT EXISTS applications_address_trgm
 -- the query side re-derives the identical expression
 -- (to_tsvector('english', description)), which is what lets the planner match
 -- it to this index.
-CREATE INDEX IF NOT EXISTS applications_description_fts
+CREATE INDEX CONCURRENTLY IF NOT EXISTS applications_description_fts
     ON applications USING gin (to_tsvector('english', description));
 
 -- Tier 1 (reference exact/prefix match): uid is the fuller, human-recognisable
@@ -33,14 +45,14 @@ CREATE INDEX IF NOT EXISTS applications_description_fts
 -- btree with text_pattern_ops serves both the exact form (lower(uid) = $1) and
 -- the prefix form (lower(uid) LIKE $1 || '%') without a sequential scan,
 -- regardless of the database's collation.
-CREATE INDEX IF NOT EXISTS applications_uid_lower_pattern
+CREATE INDEX CONCURRENTLY IF NOT EXISTS applications_uid_lower_pattern
     ON applications (lower(uid) text_pattern_ops);
 
 -- +goose Down
 
-DROP INDEX IF EXISTS applications_uid_lower_pattern;
-DROP INDEX IF EXISTS applications_description_fts;
-DROP INDEX IF EXISTS applications_address_trgm;
+DROP INDEX CONCURRENTLY IF EXISTS applications_uid_lower_pattern;
+DROP INDEX CONCURRENTLY IF EXISTS applications_description_fts;
+DROP INDEX CONCURRENTLY IF EXISTS applications_address_trgm;
 -- pg_trgm is intentionally left installed on Down: it may be shared by other
 -- objects, and re-creating it on a subsequent Up is cheap (IF NOT EXISTS) —
 -- mirroring the postgis extension's Down comment in 0001_init_postgis.sql.


### PR DESCRIPTION
## Changes

- fix(migrations): use CREATE INDEX CONCURRENTLY for 0018, bump pgmigrate timeout to 600s (tc-5i07d)
- fix(ci): bump migrate job timeout-minutes so it doesn't SIGKILL before pgmigrate's own timeout (tc-5i07d)

**Production incident fix, unrelated to the Android/FCM epic.** Migration `0018_application_search_indexes.sql` (from an already-merged PR #824) builds 3 indexes on the live `applications` table with plain `CREATE INDEX`, which locks the table against writes for the whole build. Twice now, deploying to prod (the current stalled v0.15.73 release, which carries the FCM push work) has run this migration, blocked live writes for ~2 minutes, then hit the `pgmigrate` command's 120-second budget and rolled back cleanly (goose's default transaction wrapping made this atomic — no data was touched or corrupted).

**Fix**: rewrite the migration to use `CREATE INDEX CONCURRENTLY` (doesn't lock the table, at the cost of a longer build), which requires `-- +goose NO TRANSACTION` (verified against the vendored goose v3.27.1 source, not guessed — no other migration in this repo needed this directive before). Bump `pgmigrate`'s own `-timeout` from 120s to 600s to give the slower `CONCURRENTLY` build room to actually finish.

**Second fix, caught during review**: both `migrate-dev`/`migrate-prod` GitHub Actions jobs had `timeout-minutes: 10` — exactly equal to the new 600s command timeout, leaving zero headroom for checkout/setup-go/azure-login. Now that the migration runs outside a transaction (required for `CONCURRENTLY`), a hard job-level `SIGKILL` is more dangerous than before: it can leave an `INVALID` index behind that needs manual cleanup, whereas the old transactional failure mode always rolled back cleanly regardless of how it was interrupted. Bumped both jobs to `timeout-minutes: 15`.

**Validation — not just reading the SQL:**
- Verified the `NO TRANSACTION` directive placement/semantics against goose's own source (`internal/sqlparser/parser.go`, `migration_sql.go` — confirms it runs each statement via plain `ExecContext`, no `BEGIN`, which `CONCURRENTLY` requires).
- Ran the full integration suite (`go test -tags=integration ./...`) against a **fresh, throwaway** local Postgres+PostGIS (not reusing any container with stale migration-tracking state) — **1694 tests passed**, confirming migrations 0001→0018 apply cleanly in sequence, including the new `CONCURRENTLY`/`NO TRANSACTION` syntax. Re-ran a second time to confirm idempotency.
- Confirmed via direct `psql` query: all three new indexes (`applications_address_trgm`, `applications_description_fts`, `applications_uid_lower_pattern`) have `indisvalid=t, indisready=t`, and `pg_trgm` is installed.
- Full pre-flight green: `go build`, `gofmt`, `go vet`, `golangci-lint`, `go test -race` (1529 passed/48 packages).

Once merged, the still-stalled v0.15.73 `cd-prod` run will be re-run to complete the FCM deploy (infra + web already deployed; only migrations + API + Worker are pending).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased database migration time limits in development and production to help long-running updates complete more reliably.
  * Improved search-related database index changes so they can be created with less disruption during upgrades and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->