### PR TITLE
ci: fail-closed detect-changes + anchor trigger-file matching

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -6,6 +6,12 @@
 #   pr          — compares origin/<base-ref>...HEAD
 #   merge_group — compares <base-ref>...HEAD against a raw base SHA (no origin/ prefix)
 #
+#   Edge case: push mode's HEAD~1 diff assumes every push to the default
+#   branch is a single squash-merge commit, so only the last commit is
+#   diffed. A fast-forward merge or a multi-commit push would silently
+#   miss earlier changes. This is a known, accepted assumption — do not
+#   change it silently; see issue #835 for the rationale.
+#
 # Trigger files:
 #   Workflow files (e.g., cd-dev.yml, pr-gate.yml) can force categories
 #   to true when they themselves change. Pass trigger-files as a
@@ -85,12 +91,19 @@ runs:
 
         # Process trigger files — workflow files that force categories
         TRIGGER_FILES="${{ inputs.trigger-files }}"
+        declare -A known_trigger_paths
         if [[ -n "$TRIGGER_FILES" ]]; then
           while IFS= read -r line; do
             [[ -z "$line" ]] && continue
             trigger_path="${line%%:*}"
             trigger_cats="${line#*:}"
-            if echo "$CHANGED" | grep -q "$trigger_path"; then
+            known_trigger_paths["$trigger_path"]=1
+            # Fixed-string, whole-line match: a trigger_path must equal one
+            # of the newline-separated $CHANGED entries exactly, so a path
+            # that merely contains trigger_path as a substring (or where
+            # "." would otherwise be read as a regex wildcard) can't
+            # false-positive.
+            if echo "$CHANGED" | grep -qxF "$trigger_path"; then
               IFS=',' read -ra tcats <<< "$trigger_cats"
               for tc in "${tcats[@]}"; do
                 if [[ -v "flags[$tc]" ]]; then
@@ -101,7 +114,13 @@ runs:
           done <<< "$TRIGGER_FILES"
         fi
 
-        # Map file paths to categories
+        # Map file paths to categories. Any changed file matching neither a
+        # known category prefix nor the ignore-allowlist below is treated as
+        # an unmapped top-level path and forces every requested category to
+        # true — fail-closed, so a new directory gets full lane coverage by
+        # default rather than silently zero. Paths already accounted for via
+        # the trigger-files mechanism above are exempted from the fail-closed
+        # default (they've already forced their specific categories).
         while IFS= read -r file; do
           [[ -z "$file" ]] && continue
           case "$file" in
@@ -111,6 +130,19 @@ runs:
             mobile/android/*) [[ -v "flags[android]" ]] && flags[android]=true ;;
             web/*) [[ -v "flags[web]" ]] && flags[web]=true ;;
             infra/*) [[ -v "flags[infra]" ]] && flags[infra]=true ;;
+            # Ignore-allowlist: these paths legitimately don't need any
+            # pr-gate lane to run.
+            docs/*|.beads/*|.claude/*|scripts/*|*.md|LICENSE|.gitignore|.gitattributes) ;;
+            *)
+              if [[ -v "known_trigger_paths[$file]" ]]; then
+                : # already handled by the trigger-files mechanism above
+              else
+                echo "::warning::Unmapped changed path '$file' matches no known category prefix and no ignore allowlist entry — forcing all requested categories to true (fail-closed)."
+                for cat in "${CATS[@]}"; do
+                  flags["$cat"]=true
+                done
+              fi
+              ;;
           esac
         done <<< "$CHANGED"
 


### PR DESCRIPTION
## Changes
- Anchor trigger-file matching in `detect-changes/action.yml`: `grep -q` (unanchored substring) → `grep -qxF` (fixed-string, whole-line), so a trigger path can't false-positive against an unrelated changed file whose path merely contains it as a substring.
- Fail-closed for unmapped top-level paths: any changed file matching neither a known category prefix (`api-go/`, `cli/`, `mobile/ios/`, `mobile/android/`, `web/`, `infra/`) nor the ignore-allowlist (`docs/`, `.beads/`, `.claude/`, `scripts/`, `*.md`, `LICENSE`, `.gitignore`, `.gitattributes`) now forces every requested category to `true` — a new top-level directory gets full pr-gate coverage by default instead of silently zero.
- Files already covered by the `trigger-files` mechanism are exempted from the fail-closed default, so touching an existing trigger file (e.g. `pr-gate.yml`) sets only its configured categories rather than forcing all of them.
- Documented the push-mode `HEAD~1`/squash-merge assumption in the action's header comment.

Slice 1 of 7 from #835 (memo 0014 CI hardening). Scope: `.github/actions/detect-changes/action.yml` only.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection so matched trigger paths are recognized more reliably.
  * Unmapped changed paths now default to notifying all relevant categories, reducing the chance of missed updates.
  * Paths already covered by trigger rules are excluded from this fallback behavior.
* **Chores**
  * Clarified documentation about expected behavior in push-based workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->