### PR TITLE
fix(api): bound search UNION branches per-tier, add request timeout

### DIFF
--- a/api-go/internal/applications/search.go
+++ b/api-go/internal/applications/search.go
@@ -256,9 +256,22 @@ type SearchResponse struct {
 // matches exist than the limit" without a second query.
 //
 // Each of the three UNION ALL branches is independently bounded by its own
-// "ORDER BY <tier's score> DESC LIMIT $3" (tc-z5i5j — the parentheses around
-// each branch are required Postgres syntax for a per-branch ORDER BY/LIMIT
-// inside a UNION). Without this, best's required DISTINCT ON ordering
+// "ORDER BY <tier's score> DESC, planit_name ASC LIMIT $3" (tc-z5i5j — the
+// parentheses around each branch are required Postgres syntax for a
+// per-branch ORDER BY/LIMIT inside a UNION). The planit_name secondary key
+// matters as much as the LIMIT itself: without it, when many rows in one tier
+// tie on score (a common shape — e.g. every uid prefix match scores exactly
+// 1.0), the branch's own LIMIT can keep an ARBITRARY limit+1-sized subset of
+// the tied rows (whichever the scan happens to visit first), and the final
+// query's planit_name tie-break can then only resolve ties among whatever
+// arbitrary subset survived — not the true full set, as the old unbounded
+// query always had available. Matching the branch's secondary sort key to the
+// final query's tie-break guarantees the specific limit+1 rows each branch
+// keeps are the same ones the old unbounded query would have handed to
+// DISTINCT ON, tie for tie. See
+// TestPostgresStore_Search_TiedScoresStayDeterministicUnderCap.
+//
+// Without this, best's required DISTINCT ON ordering
 // (area_id, planit_name, tier, score) differs from the final ORDER BY (tier,
 // score, planit_name), so Postgres cannot push the final LIMIT down through
 // DISTINCT ON: for any term the trigram/tsvector indexes consider common
@@ -312,14 +325,14 @@ WITH matched AS (
 	FROM applications
 	WHERE (lower(uid) = lower($1) OR lower(uid) LIKE $4 ESCAPE '\')
 	  AND ($2::text IS NULL OR authority_code = $2)
-	ORDER BY score DESC
+	ORDER BY score DESC, planit_name ASC
 	LIMIT $3)
 	UNION ALL
 	(SELECT ` + searchSelectColumns + `, 2 AS tier, word_similarity(lower($1), lower(address)) AS score
 	FROM applications
 	WHERE lower($1) <% lower(address)
 	  AND ($2::text IS NULL OR authority_code = $2)
-	ORDER BY score DESC
+	ORDER BY score DESC, planit_name ASC
 	LIMIT $3)
 	UNION ALL
 	(SELECT ` + searchSelectColumns + `, 3 AS tier,
@@ -327,7 +340,7 @@ WITH matched AS (
 	FROM applications
 	WHERE to_tsvector('english', description) @@ plainto_tsquery('english', $1)
 	  AND ($2::text IS NULL OR authority_code = $2)
-	ORDER BY score DESC
+	ORDER BY score DESC, planit_name ASC
 	LIMIT $3)
 ),
 best AS (

--- a/api-go/internal/applications/search.go
+++ b/api-go/internal/applications/search.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
@@ -32,6 +33,17 @@ const (
 	searchDefaultLimit = 20
 	searchMaxLimit     = 20
 )
+
+// searchTimeout bounds a single Search call end-to-end. This is a public,
+// unauthenticated endpoint (SearchRoutes) sharing a Postgres pool with prod's
+// core watch-zone/notification reads (psql-town-crier-shared) — a
+// pathological query must fail fast with a 500 rather than hold a pool
+// connection open for tens of seconds (tc-z5i5j incident: ?q=extension took
+// 15-53s before searchQuery's per-tier LIMIT fix). It is defense-in-depth on
+// top of that fix, not a substitute for it, and is well under the ~100s
+// Cloudflare/ingress timeout so callers see a clean failure rather than a
+// gateway timeout.
+const searchTimeout = 8 * time.Second
 
 // searchStore is the consumer-side store the search handler needs: a single
 // ranked, capped read across the three match tiers (#821 Phase 3) — reference
@@ -88,7 +100,10 @@ func (h *searchHandler) search(w http.ResponseWriter, r *http.Request) {
 
 	limit := parseSearchLimit(q.Get("limit"))
 
-	apps, refine, err := h.store.Search(r.Context(), query, authorityCode, limit)
+	ctx, cancel := context.WithTimeout(r.Context(), searchTimeout)
+	defer cancel()
+
+	apps, refine, err := h.store.Search(ctx, query, authorityCode, limit)
 	if err != nil {
 		serverError(w, r, h.logger, "search applications", err)
 		return
@@ -240,6 +255,38 @@ type SearchResponse struct {
 // caller's requested limit+1 — the extra row is how Search detects "more
 // matches exist than the limit" without a second query.
 //
+// Each of the three UNION ALL branches is independently bounded by its own
+// "ORDER BY <tier's score> DESC LIMIT $3" (tc-z5i5j — the parentheses around
+// each branch are required Postgres syntax for a per-branch ORDER BY/LIMIT
+// inside a UNION). Without this, best's required DISTINCT ON ordering
+// (area_id, planit_name, tier, score) differs from the final ORDER BY (tier,
+// score, planit_name), so Postgres cannot push the final LIMIT down through
+// DISTINCT ON: for any term the trigram/tsvector indexes consider common
+// (e.g. "extension"), all three branches can each match a large fraction of
+// applications, forcing a full materialize-and-sort of the entire unbounded
+// candidate set TWICE before the caller's limit is ever applied — this was
+// the prod incident (?q=extension: 15-53s; tc-z5i5j).
+//
+// Capping each branch at limit+1 (the same $3 already bound for the outer
+// LIMIT) is provably equivalent to the old unbounded query, not an
+// approximation: the final SELECT can never emit more than limit+1 rows, and
+// DISTINCT ON only ever keeps a matched row for a given (area_id,
+// planit_name) if no higher-priority (lower tier) row exists for it — so a
+// row this query ultimately returns from tier T is always among the top
+// limit+1 tier-T-scored rows in the FULL unbounded tier-T branch (any
+// tier-T row that also has a higher-tier match is going to lose to that
+// higher-tier row in DISTINCT ON regardless, "wasting" at most as many
+// tier-T slots as there are such higher-tier rows — and the higher tiers are
+// themselves capped at limit+1, so at most limit+1 slots can ever be wasted
+// this way). Capping each branch at limit+1 therefore never drops a row the
+// uncapped query would have returned; it only stops materializing/sorting
+// candidates that were never going to survive DISTINCT ON or the final LIMIT
+// in the first place. See search_integration_test.go for the regression
+// tests that pin this down (a tier-1-only multi-match case proving the "+1"
+// is load-bearing for RefineQuery, and a cross-tier case proving a
+// higher-tier duplicate occupying a slot in a lower tier's capped branch does
+// not crowd out a genuine lower-tier winner).
+//
 // searchSelectColumns (not appColumns) backs the three UNION branches: it
 // aliases the two computed geometry accessors to lat/lon. appColumns' raw form
 // (ST_Y(location::geometry) with no alias) only resolves because those
@@ -260,22 +307,28 @@ const searchOutputColumns = "planit_name, uid, area_name, area_id, address, post
 
 const searchQuery = `
 WITH matched AS (
-	SELECT ` + searchSelectColumns + `, 1 AS tier,
-	       CASE WHEN lower(uid) = lower($1) THEN 2.0 ELSE 1.0 END AS score
+	(SELECT ` + searchSelectColumns + `, 1 AS tier,
+	        CASE WHEN lower(uid) = lower($1) THEN 2.0 ELSE 1.0 END AS score
 	FROM applications
 	WHERE (lower(uid) = lower($1) OR lower(uid) LIKE $4 ESCAPE '\')
 	  AND ($2::text IS NULL OR authority_code = $2)
+	ORDER BY score DESC
+	LIMIT $3)
 	UNION ALL
-	SELECT ` + searchSelectColumns + `, 2 AS tier, word_similarity(lower($1), lower(address)) AS score
+	(SELECT ` + searchSelectColumns + `, 2 AS tier, word_similarity(lower($1), lower(address)) AS score
 	FROM applications
 	WHERE lower($1) <% lower(address)
 	  AND ($2::text IS NULL OR authority_code = $2)
+	ORDER BY score DESC
+	LIMIT $3)
 	UNION ALL
-	SELECT ` + searchSelectColumns + `, 3 AS tier,
-	       ts_rank(to_tsvector('english', description), plainto_tsquery('english', $1)) AS score
+	(SELECT ` + searchSelectColumns + `, 3 AS tier,
+	        ts_rank(to_tsvector('english', description), plainto_tsquery('english', $1)) AS score
 	FROM applications
 	WHERE to_tsvector('english', description) @@ plainto_tsquery('english', $1)
 	  AND ($2::text IS NULL OR authority_code = $2)
+	ORDER BY score DESC
+	LIMIT $3)
 ),
 best AS (
 	SELECT DISTINCT ON (area_id, planit_name) *

--- a/api-go/internal/applications/search_integration_test.go
+++ b/api-go/internal/applications/search_integration_test.go
@@ -242,6 +242,54 @@ func nameForIndex(i int) string {
 	return "L" + string(rune('A'+i))
 }
 
+// TestPostgresStore_Search_BoundsEachTierWithLimitPushdown proves each of the
+// three UNION ALL branches inside the matched CTE carries its own bounded
+// ORDER BY ... LIMIT $3 (tc-z5i5j). Before this fix, only the outer SELECT had
+// a LIMIT: because best's required DISTINCT ON ordering (area_id, planit_name,
+// tier, score) differs from the final ORDER BY (tier, score, planit_name),
+// Postgres could not push the final LIMIT down through DISTINCT ON, so any
+// term the trigram/tsvector indexes consider common forced a full
+// materialize-and-sort of the ENTIRE unbounded candidate set TWICE before the
+// caller's limit was ever applied — the root cause of the prod incident
+// (?q=extension: 15-53s). EXPLAIN (no ANALYZE — this needs no seeded rows and
+// is cheap) must show a Limit node for each of the 4 LIMIT clauses in
+// searchQuery (3 per-tier + 1 outer); fewer than 4 means a tier's bound was
+// dropped and the slow, unbounded-materialization plan is back.
+func TestPostgresStore_Search_BoundsEachTierWithLimitPushdown(t *testing.T) {
+	pool := pgtest.New(t)
+	pgtest.Truncate(t, pool, "applications", "watch_zones")
+	ctx := context.Background()
+
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire connection: %v", err)
+	}
+	defer conn.Release()
+
+	var authorityArg any
+	rows, err := conn.Query(ctx, "EXPLAIN (FORMAT TEXT) "+searchQuery, "extension", authorityArg, 21, "extension%")
+	if err != nil {
+		t.Fatalf("EXPLAIN: %v", err)
+	}
+	var plan strings.Builder
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			rows.Close()
+			t.Fatalf("scan plan line: %v", err)
+		}
+		plan.WriteString(line)
+		plan.WriteByte('\n')
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("read plan: %v", err)
+	}
+
+	if got := strings.Count(plan.String(), "Limit"); got < 4 {
+		t.Errorf("plan has %d Limit node(s), want >= 4 (3 per-tier + 1 outer):\n%s", got, plan.String())
+	}
+}
+
 // TestPostgresStore_Search_ExplainUsesTrgmAndFTSIndexes proves the migration's
 // GIN indexes (applications_address_trgm, applications_description_fts) serve
 // the tier-2/tier-3 predicates — so the query never falls back to a sequential

--- a/api-go/internal/applications/search_integration_test.go
+++ b/api-go/internal/applications/search_integration_test.go
@@ -4,8 +4,10 @@ package applications
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/AmyDe/town-crier/api-go/internal/platform/postgres/pgtest"
 )
@@ -438,6 +440,110 @@ func TestPostgresStore_Search_TiedScoresStayDeterministicUnderCap(t *testing.T) 
 // "TIE-AB", ...) for the tied-score determinism test above.
 func tieName(i int) string {
 	return "TIE-" + string(rune('A'+i/26)) + string(rune('A'+i%26))
+}
+
+// TestPostgresStore_Search_LargeScaleCrossTierCandidateSet reproduces the prod
+// incident directly (tc-z5i5j: ?q=extension took 15-53s, sometimes timing out
+// outright) with a seeded dataset large enough that "extension" genuinely
+// exercises a large candidate set across all three tiers, not just a
+// synthetic few-row fixture. It asserts exact top-K correctness — the same
+// result the old, unbounded, correct-but-slow query would have produced: tier
+// 1 first (exact, then the two tied prefix matches broken by planit_name),
+// then the alphabetically-first tier-2 winners, tier 3 never reached because
+// 300 tier-2 matches alone are far more than enough to fill the remaining
+// slots. The elapsed-time assertion is a generous, CI-tolerant smoke
+// trip-wire only; the primary proof that the query no longer needs a full
+// sort of the unbounded candidate set is the structural, non-flaky EXPLAIN
+// check in TestPostgresStore_Search_BoundsEachTierWithLimitPushdown.
+func TestPostgresStore_Search_LargeScaleCrossTierCandidateSet(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+
+	const perTier = 300
+
+	// Tier 1: one exact match plus two prefix matches, tied at score 1.0 and
+	// broken by planit_name (P-AA before P-AB).
+	exact := searchApp("E-EXACT", "extension", 100)
+	prefixA := searchApp("P-AA", "extension-annex", 100)
+	prefixB := searchApp("P-AB", "extension-loft", 100)
+	for _, a := range []PlanningApplication{exact, prefixA, prefixB} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	// Tier 2: perTier applications whose address all fuzzy-match "extension"
+	// with an IDENTICAL word_similarity score (tied) — none also match tier 1
+	// (uid is unrelated) or tier 3 (description is the pgApp default).
+	for i := range perTier {
+		name := "T2-" + fmt.Sprintf("%03d", i)
+		a := searchApp(name, "addr-uid-"+name, 100)
+		a.Address = "10 Extension Close, Sometown"
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	// Tier 3: perTier applications whose description all full-text-match
+	// "extension" with an IDENTICAL ts_rank (tied) — none also match tier 1
+	// (uid is unrelated) or tier 2 (address is the pgApp default).
+	for i := range perTier {
+		name := "T3-" + fmt.Sprintf("%03d", i)
+		a := searchApp(name, "desc-uid-"+name, 100)
+		a.Description = "Two storey rear extension"
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	start := time.Now()
+	apps, refine, err := store.Search(ctx, "extension", "", 20)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+
+	if elapsed > 3*time.Second {
+		t.Errorf("Search took %v against %d rows spanning all 3 tiers — want comfortably sub-second; "+
+			"this is a smoke trip-wire only, see TestPostgresStore_Search_BoundsEachTierWithLimitPushdown "+
+			"for the primary structural proof", elapsed, 3+2*perTier)
+	}
+
+	if len(apps) != 20 {
+		t.Fatalf("got %d rows, want 20 (truncated to limit); names=%v", len(apps), namesOf(apps))
+	}
+	if !refine {
+		t.Error("refine: got false, want true (far more than 20 matches exist across all 3 tiers)")
+	}
+
+	wantOrder := []string{"E-EXACT", "P-AA", "P-AB"}
+	for i := 0; i < 17; i++ {
+		wantOrder = append(wantOrder, fmt.Sprintf("T2-%03d", i))
+	}
+	if got := namesOf(apps); !equalNames(got, wantOrder) {
+		t.Fatalf("rank order:\n got  %v\n want %v (tier 1 first, then the 17 alphabetically-first "+
+			"tier-2 winners needed to fill limit+1=21 before truncation; tier 3 never reached)", got, wantOrder)
+	}
+}
+
+func namesOf(apps []PlanningApplication) []string {
+	names := make([]string, len(apps))
+	for i, a := range apps {
+		names[i] = a.Name
+	}
+	return names
+}
+
+func equalNames(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // TestPostgresStore_Search_ExplainUsesTrgmAndFTSIndexes proves the migration's

--- a/api-go/internal/applications/search_integration_test.go
+++ b/api-go/internal/applications/search_integration_test.go
@@ -242,6 +242,106 @@ func nameForIndex(i int) string {
 	return "L" + string(rune('A'+i))
 }
 
+// TestPostgresStore_Search_TierCapPreservesRefineFlag proves the per-branch
+// cap in searchQuery is genuinely limit+1, not limit (tc-z5i5j). It pins a
+// property that is otherwise easy to get subtly wrong when hand-restructuring
+// SQL: capping a branch at exactly `limit` rows can NEVER change which rows a
+// caller actually sees (the returned page is always the top `limit` rows
+// regardless, and a too-small cap only ever loses the row at rank limit+1 or
+// later — which was always going to be truncated away) but it CAN silently
+// flip RefineQuery from true to false, wrongly telling a client "no more
+// results" when more genuinely exist. Two tier-1 matches (exact + prefix) for
+// the same query, limit=1: the correct limit+1=2 cap keeps both, so Search
+// sees 2 rows and correctly reports refine=true.
+func TestPostgresStore_Search_TierCapPreservesRefineFlag(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+
+	exact := searchApp("T1", "onlyoneref", 100)
+	prefix := searchApp("T2", "onlyonerefplus", 100)
+	for _, a := range []PlanningApplication{exact, prefix} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	apps, refine, err := store.Search(ctx, "onlyoneref", "", 1)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(apps) != 1 || apps[0].Name != exact.Name {
+		t.Fatalf("got %+v, want exactly [%s] (exact match ranks first)", apps, exact.Name)
+	}
+	if !refine {
+		t.Error("refine: got false, want true — 2 tier-1 matches exist beyond limit 1; " +
+			"a branch cap of `limit` instead of `limit+1` would silently drop the prefix " +
+			"match and wrongly report refine=false")
+	}
+}
+
+// TestPostgresStore_Search_CrossTierCrowdingPreservesGenuineWinners proves the
+// per-branch cap is correct even when a higher-tier duplicate occupies a slot
+// in a lower tier's own ranking (tc-z5i5j) — the trickiest part of the
+// restructuring's correctness argument (see the doc comment on searchQuery).
+//
+// TA matches BOTH tier 1 (exact reference) and tier 2 (its own address is the
+// single best address-fuzzy match for the query, word_similarity 1.0) — so
+// within the raw tier-2 branch, before any deduplication, TA occupies the
+// #1-by-score slot. DISTINCT ON then keeps TA under tier 1 (its
+// higher-priority match), discarding TA's tier-2 duplicate. TC and TD are
+// address-only matches (word_similarity 0.8 and 0.7) that never match tier 1
+// at all — the genuine tier-2 winners. TF is a fourth, weaker address match
+// (word_similarity 0.6) that must legitimately be excluded from the top
+// limit+1=3 results.
+//
+// With limit=2 (limit+1=3), the tier-2 branch's raw top-3 by score is exactly
+// {TA, TC, TD} — TA's crowded #1 slot still leaves room for both genuine
+// winners TC and TD, and TF is correctly excluded. If the branch were instead
+// capped at `limit` (2, one too few), TA's crowding would push TD out of the
+// branch entirely: the DISTINCT ON row count would drop from 3 to 2, and
+// RefineQuery would wrongly flip to false even though a third match (TD)
+// genuinely exists.
+func TestPostgresStore_Search_CrossTierCrowdingPreservesGenuineWinners(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+
+	const query = "crowdterm"
+
+	ta := searchApp("CA", query, 100) // tier 1: exact uid match
+	ta.Address = "42 Crowdterm Way, Sometown"
+	tc := searchApp("CC", "uid-cc", 100)
+	tc.Address = "1 Acrowdterm Gardens, Sometown"
+	td := searchApp("CD", "uid-cd", 100)
+	td.Address = "99 Crowdte Close, Sometown"
+	tf := searchApp("CF", "uid-cf", 100)
+	tf.Address = "7 Crowdt Row, Sometown"
+	for _, a := range []PlanningApplication{ta, tc, td, tf} {
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	apps, refine, err := store.Search(ctx, query, "", 2)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(apps) != 2 {
+		t.Fatalf("got %d rows, want 2 (truncated to limit); %+v", len(apps), apps)
+	}
+	gotOrder := []string{apps[0].Name, apps[1].Name}
+	wantOrder := []string{ta.Name, tc.Name}
+	for i := range wantOrder {
+		if gotOrder[i] != wantOrder[i] {
+			t.Fatalf("rank order: got %v, want %v (tier1 TA, then genuine tier2 winner TC — "+
+				"not crowded out, and not TF)", gotOrder, wantOrder)
+		}
+	}
+	if !refine {
+		t.Error("refine: got false, want true — TD is a genuine third match beyond limit 2; " +
+			"an undersized tier-2 cap would let TA's crowding push TD out entirely")
+	}
+}
+
 // TestPostgresStore_Search_BoundsEachTierWithLimitPushdown proves each of the
 // three UNION ALL branches inside the matched CTE carries its own bounded
 // ORDER BY ... LIMIT $3 (tc-z5i5j). Before this fix, only the outer SELECT had
@@ -288,6 +388,56 @@ func TestPostgresStore_Search_BoundsEachTierWithLimitPushdown(t *testing.T) {
 	if got := strings.Count(plan.String(), "Limit"); got < 4 {
 		t.Errorf("plan has %d Limit node(s), want >= 4 (3 per-tier + 1 outer):\n%s", got, plan.String())
 	}
+}
+
+// TestPostgresStore_Search_TiedScoresStayDeterministicUnderCap proves the
+// per-branch cap added for tc-z5i5j does not regress determinism when many
+// rows in one tier tie on score. Each branch's own "ORDER BY score DESC
+// LIMIT $3" needs a secondary "planit_name ASC" key matching the final
+// query's tie-break — without it, Postgres is free to keep an ARBITRARY
+// limit+1-sized subset of the tied rows (whichever the scan happens to visit
+// first), and the final ORDER BY's planit_name tie-break can only resolve
+// ties among whatever subset survived the branch cap, not the true full set.
+// 50 applications share one address (identical word_similarity, so all tied
+// at tier 2), seeded in reverse-name order to catch any reliance on
+// insertion/scan order: the correct, deterministic answer is always the
+// alphabetically-first 10 names, byte-for-byte what the old unbounded query
+// would have returned.
+func TestPostgresStore_Search_TiedScoresStayDeterministicUnderCap(t *testing.T) {
+	store := newAppPGStore(t)
+	ctx := context.Background()
+
+	const n = 50
+	for i := n - 1; i >= 0; i-- {
+		name := tieName(i)
+		a := searchApp(name, "uid-"+name, 100)
+		a.Address = "1 Tieword Lane, Sometown"
+		if err := store.Upsert(ctx, a); err != nil {
+			t.Fatalf("Upsert %s: %v", a.Name, err)
+		}
+	}
+
+	apps, refine, err := store.Search(ctx, "tieword", "", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(apps) != 10 {
+		t.Fatalf("got %d rows, want 10 (truncated to limit)", len(apps))
+	}
+	if !refine {
+		t.Error("refine: got false, want true (50 tied matches > limit 10)")
+	}
+	for i, a := range apps {
+		if want := tieName(i); a.Name != want {
+			t.Errorf("rank %d: got %q, want %q (alphabetically-first tied name)", i, a.Name, want)
+		}
+	}
+}
+
+// tieName generates deterministic, lexicographically-ordered names ("TIE-AA",
+// "TIE-AB", ...) for the tied-score determinism test above.
+func tieName(i int) string {
+	return "TIE-" + string(rune('A'+i/26)) + string(rune('A'+i%26))
 }
 
 // TestPostgresStore_Search_ExplainUsesTrgmAndFTSIndexes proves the migration's

--- a/api-go/internal/applications/search_test.go
+++ b/api-go/internal/applications/search_test.go
@@ -27,14 +27,16 @@ type fakeSearchStore struct {
 	lastQuery         string
 	lastAuthorityCode string
 	lastLimit         int
+	lastCtx           context.Context
 	calls             int
 }
 
-func (f *fakeSearchStore) Search(_ context.Context, query, authorityCode string, limit int) ([]PlanningApplication, bool, error) {
+func (f *fakeSearchStore) Search(ctx context.Context, query, authorityCode string, limit int) ([]PlanningApplication, bool, error) {
 	f.calls++
 	f.lastQuery = query
 	f.lastAuthorityCode = authorityCode
 	f.lastLimit = limit
+	f.lastCtx = ctx
 	return f.apps, f.refine, f.err
 }
 
@@ -302,6 +304,31 @@ func TestSearchHandler_StoreErrorIsServerError(t *testing.T) {
 	rec := serveSearch(t, store, testResolver(), searchPath("abc"))
 	if rec.Code != http.StatusInternalServerError {
 		t.Errorf("status: got %d, want 500", rec.Code)
+	}
+}
+
+// TestSearchHandler_AppliesRequestTimeout proves search wraps the store call in
+// a bounded context.WithTimeout (tc-z5i5j): this is a public, unauthenticated
+// endpoint sharing a Postgres pool with prod's core watch-zone/notification
+// reads, so a pathological query must fail fast rather than hold a pool
+// connection open indefinitely — defense-in-depth on top of the per-tier LIMIT
+// bound in searchQuery, not a substitute for it.
+func TestSearchHandler_AppliesRequestTimeout(t *testing.T) {
+	t.Parallel()
+	store := &fakeSearchStore{}
+	rec := serveSearch(t, store, testResolver(), searchPath("abc"))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if store.lastCtx == nil {
+		t.Fatal("store.Search was never called")
+	}
+	deadline, ok := store.lastCtx.Deadline()
+	if !ok {
+		t.Fatal("store.Search context has no deadline; want a bounded context.WithTimeout")
+	}
+	if remaining := time.Until(deadline); remaining <= 0 || remaining > searchTimeout {
+		t.Errorf("deadline remaining = %v, want in (0, %v]", remaining, searchTimeout)
 	}
 }
 


### PR DESCRIPTION
## Changes
- Live prod incident (tc-z5i5j): `GET /v1/applications/search` (shipped in epic tc-geq7h / PR #824) times out for common search terms — `?q=extension` took 15-53s in prod, `?q=24/00001/FUL` (exact ref) took 176ms. Root cause: the `DISTINCT ON` ordering in the `best` CTE differs from the final `ORDER BY`, so Postgres can't push the final `LIMIT` down — for any common trigram/tsvector term, all 3 UNION branches materialize and get sorted twice before the limit is applied.
- Bound each of the 3 UNION ALL branches in `searchQuery`'s `matched` CTE with its own `ORDER BY score DESC, planit_name ASC LIMIT $3` (same `limit+1` bind already used for the outer LIMIT). Proved this is exactly equivalent to the old unbounded query (not an approximation) via a written proof in the doc comment, then adversarially verified by temporarily breaking the cap (off-by-one) and confirming targeted regression tests fail as predicted.
- Along the way, found and fixed a real determinism bug the naive per-branch cap would have introduced: capping by score alone (no secondary key) lets Postgres keep an arbitrary tied-score subset, breaking the documented `planit_name` tie-break. Fixed by adding `, planit_name ASC` to each branch's own `ORDER BY`.
- Added `searchTimeout = 8s` around the `store.Search()` call via `context.WithTimeout` — defense-in-depth, since this is a public, unauthenticated endpoint sharing `psql-town-crier-shared` with prod's core watch-zone/notification reads.
- New tests: `TestPostgresStore_Search_BoundsEachTierWithLimitPushdown` (EXPLAIN-based structural proof — Limit nodes go from 1 to 4), `TestPostgresStore_Search_TiedScoresStayDeterministicUnderCap`, `TestPostgresStore_Search_CrossTierCrowdingPreservesGenuineWinners`, `TestPostgresStore_Search_LargeScaleCrossTierCandidateSet` (600+ row cross-tier seed reproducing the exact prod `?q=extension` shape), `TestSearchHandler_AppliesRequestTimeout`.
- No schema/migration change — query text and Go code only.

After merge: needs a normal release (tag cut) + prod verification of `?q=24/00001/FUL` and `?q=extension`.

---
*Auto-shipped via ship skill*