### PR TITLE
ci: cd-dev + cd-ios-testflight consume detect-changes

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -1,10 +1,21 @@
-# Monorepo change detection for push, pull_request, and merge_group events.
-# Outputs boolean flags for each component category that changed.
+# Monorepo change detection for push, pull_request, merge_group, and tag
+# (release) events. Outputs boolean flags for each component category that
+# changed.
 #
 # Modes:
 #   push        — compares HEAD~1..HEAD (squash-merge assumed)
 #   pr          — compares origin/<base-ref>...HEAD
 #   merge_group — compares <base-ref>...HEAD against a raw base SHA (no origin/ prefix)
+#   tag         — compares <base-ref>..HEAD, where base-ref is the previous
+#                 release tag (computed by the calling workflow). TWO dots,
+#                 not three — a direct diff between two refs, matching the
+#                 semantics of the hand-rolled guard it replaces
+#                 (git diff --quiet "${PREV}..${GITHUB_REF_NAME}"), not the
+#                 merge-base-relative three-dot diff used by pr/merge_group
+#                 above. If base-ref is empty (no previous tag — first
+#                 release), the diff is skipped entirely and every requested
+#                 category is forced true, matching the previous guard's
+#                 "no PREV -> should-release=true" first-release behavior.
 #
 #   Edge case: push mode's HEAD~1 diff assumes every push to the default
 #   branch is a single squash-merge commit, so only the last commit is
@@ -29,10 +40,10 @@ description: Monorepo change detection with push/pr modes
 
 inputs:
   mode:
-    description: "Detection mode: 'push' (HEAD~1..HEAD), 'pr' (origin/base...HEAD), or 'merge_group' (base-sha...HEAD)"
+    description: "Detection mode: 'push' (HEAD~1..HEAD), 'pr' (origin/base...HEAD), 'merge_group' (base-sha...HEAD), or 'tag' (base-ref..HEAD, two dots)"
     required: true
   base-ref:
-    description: "Base ref for PR mode (e.g., github.base_ref) or raw base SHA for merge_group mode. Ignored in push mode."
+    description: "Base ref for PR mode (e.g., github.base_ref), raw base SHA for merge_group mode, or the previous release tag for tag mode (empty = first release, forces all categories true). Ignored in push mode."
     required: false
     default: ""
   categories:
@@ -82,14 +93,33 @@ runs:
         source "${{ github.action_path }}/category-map.sh"
 
         # Determine changed files based on mode
+        FORCE_ALL_TRUE=false
         if [[ "${{ inputs.mode }}" == "push" ]]; then
           CHANGED=$(git diff --name-only HEAD~1 HEAD)
         elif [[ "${{ inputs.mode }}" == "pr" ]]; then
           CHANGED=$(git diff --name-only origin/${{ inputs.base-ref }}...HEAD)
         elif [[ "${{ inputs.mode }}" == "merge_group" ]]; then
           CHANGED=$(git diff --name-only "${{ inputs.base-ref }}...HEAD")
+        elif [[ "${{ inputs.mode }}" == "tag" ]]; then
+          if [[ -z "${{ inputs.base-ref }}" ]]; then
+            # No previous tag (first release) — nothing to diff against.
+            # Force every requested category true directly rather than
+            # diffing against nothing, matching the pre-existing hand-rolled
+            # guard's "no PREV -> should-release=true" first-release behavior.
+            CHANGED=""
+            FORCE_ALL_TRUE=true
+            echo "::notice::tag mode: no base-ref (first release) — forcing all requested categories true"
+          else
+            # TWO-dot diff — a direct diff between two refs, matching the
+            # hand-rolled guard it replaces (git diff --quiet
+            # "${PREV}..${GITHUB_REF_NAME}") exactly. Do NOT change to the
+            # three-dot merge-base-relative form used by pr/merge_group
+            # above — that would silently change which commits get diffed
+            # against a divergent history.
+            CHANGED=$(git diff --name-only "${{ inputs.base-ref }}..HEAD")
+          fi
         else
-          echo "::error::Unknown mode '${{ inputs.mode }}'. Use 'push', 'pr', or 'merge_group'."
+          echo "::error::Unknown mode '${{ inputs.mode }}'. Use 'push', 'pr', 'merge_group', or 'tag'."
           exit 1
         fi
 
@@ -102,6 +132,12 @@ runs:
         for cat in "${CATS[@]}"; do
           flags["$cat"]=false
         done
+
+        if [[ "$FORCE_ALL_TRUE" == "true" ]]; then
+          for cat in "${CATS[@]}"; do
+            flags["$cat"]=true
+          done
+        else
 
         # Process trigger files — workflow files that force categories
         TRIGGER_FILES="${{ inputs.trigger-files }}"
@@ -184,6 +220,8 @@ runs:
             done
           fi
         done <<< "$CHANGED"
+
+        fi # FORCE_ALL_TRUE
 
         # Write outputs
         for cat in "${CATS[@]}"; do

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -17,6 +17,20 @@
 #                 category is forced true, matching the previous guard's
 #                 "no PREV -> should-release=true" first-release behavior.
 #
+#                 tag mode is a release DECISION, not a validation lane, so
+#                 it does NOT inherit the uniform .github/ fail-closed
+#                 catch-all that push/pr/merge_group apply (see "Coverage
+#                 assertion" / DESIGN_EXCEPTIONS below) — an unmapped
+#                 .github/ path (not already covered by trigger-files) is
+#                 exempted from forcing categories true in tag mode
+#                 specifically, so an unrelated CI/workflow tweak landing
+#                 between two release tags doesn't force a release. Paths
+#                 outside .github/ still fail-closed as normal even in tag
+#                 mode. Callers that need a specific .github/ file to force
+#                 a release (e.g. changes to the release pipeline itself)
+#                 should pass it via trigger-files, as cd-ios-testflight.yml
+#                 does for cd-ios-testflight.yml and detect-changes/action.yml.
+#
 #   Edge case: push mode's HEAD~1 diff assumes every push to the default
 #   branch is a single squash-merge commit, so only the last commit is
 #   diffed. A fast-forward merge or a multi-commit push would silently
@@ -213,6 +227,19 @@ runs:
 
           if [[ -v "known_trigger_paths[$file]" ]]; then
             : # already handled by the trigger-files mechanism above
+          elif [[ "${{ inputs.mode }}" == "tag" && "$file" == .github/* ]]; then
+            # tag mode is a release DECISION, not a validation lane — unlike
+            # push/pr/merge_group (pr-gate.yml, cd-dev.yml), where any
+            # unmapped .github/ churn deliberately fail-closes every
+            # category (a stray workflow edit could affect any validation
+            # lane), here that same blanket rule would force a TestFlight
+            # upload on every unrelated CI tweak landing in a release
+            # window. Narrow carve-out: .github/ paths NOT already covered
+            # by trigger-files are exempted from the fail-closed catch-all
+            # in tag mode specifically. Paths outside .github/ still
+            # fail-closed below — this carve-out is deliberately scoped to
+            # .github/ churn only, not unmapped top-level dirs generally.
+            echo "::notice::tag mode: '$file' is under .github/ and not a trigger-file — exempted from the fail-closed catch-all (see cd-ios-testflight.yml's trigger-files input for the paths that DO matter for iOS releases)."
           else
             echo "::warning::Unmapped changed path '$file' matches no known category prefix and no ignore allowlist entry — forcing all requested categories to true (fail-closed)."
             for cat in "${CATS[@]}"; do

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,11 +1,24 @@
-# Deploys all components to the dev environment.
-# Triggered on every push to main (squash merges assumed) that touches
-# deployable code or infra. Pushes that only change docs, iOS, Android, beads,
-# Claude config, or markdown/license/git metadata are skipped via
-# paths-ignore. Android ships via a future tag-triggered CD lane (#779), not
-# on every main push.
+# Deploys components to the dev environment, gated by what changed.
+# Triggered on every push to main (squash merges assumed) and via
+# workflow_dispatch. A first `changes` job (detect-changes, mode: push)
+# determines which of go/web/infra changed in the last commit; every deploy
+# job below is gated on its relevant category so the chain short-circuits
+# when nothing relevant changed — e.g. a docs-only, iOS-only, or
+# Android-only push finishes fast with every job skipped. workflow_dispatch
+# bypasses all category gating and deploys everything unconditionally — use
+# it to force a full redeploy. Android ships via a future tag-triggered CD
+# lane (#779), not on every main push; iOS ships via cd-ios-testflight.yml on
+# tag push, not here.
 #
-# All components deploy unconditionally to keep dev in sync with main.
+# Fail-open by design (issue #835 slice 3): if there's any doubt whether a
+# job should run for a given change, it runs. A redundant deploy costs a
+# few minutes of CI time; a skipped deploy of paying-customer-facing code
+# is a production incident. Every job whose `needs:` includes another job
+# that can itself be legitimately skipped uses the
+# `always() && (<category> || workflow_dispatch) && (<upstream>.result ==
+# 'success' || <upstream>.result == 'skipped')` pattern so a skipped
+# upstream (e.g. infra-dev skipped because only api-go/ changed) never
+# cascades into skipping a deploy that itself needs to run.
 #
 # Requires secrets:
 #   AZURE_CLIENT_ID        — OIDC federated credential for Azure login
@@ -23,16 +36,6 @@ name: CD Dev
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - 'docs/**'
-      - 'mobile/ios/**'
-      - 'mobile/android/**'
-      - '.beads/**'
-      - '.claude/**'
-      - '**/*.md'
-      - 'LICENSE'
-      - '.gitignore'
-      - '.gitattributes'
   workflow_dispatch:
 
 concurrency:
@@ -44,9 +47,37 @@ permissions:
   id-token: write
 
 jobs:
+  # ── Detect changes ───────────────────────────────────
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      web: ${{ steps.detect.outputs.web }}
+      infra: ${{ steps.detect.outputs.infra }}
+      go: ${{ steps.detect.outputs.go }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # HEAD~1 must be present for push-mode's HEAD~1..HEAD diff — the
+          # default shallow (depth-1) checkout only fetches HEAD itself.
+          fetch-depth: 2
+
+      - name: Detect changed paths
+        id: detect
+        uses: ./.github/actions/detect-changes
+        with:
+          mode: push
+          # cd-dev only ever builds/deploys api-go, worker, web, and infra —
+          # cli/ios/android are irrelevant here (cli has no dev deploy lane;
+          # ios/android ship via other workflows), so they're not requested.
+          categories: go,web,infra
+
   # ── Infrastructure: shared stack ─────────────────────
   infra-shared:
     name: "Infra: Pulumi up (shared)"
+    needs: changes
+    if: needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: development
@@ -76,7 +107,8 @@ jobs:
   # ── Infrastructure: dev stack ────────────────────────
   infra-dev:
     name: "Infra: Pulumi up (dev)"
-    needs: infra-shared
+    needs: [changes, infra-shared]
+    if: needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: development
@@ -127,7 +159,12 @@ jobs:
   # skip); goose.Up is idempotent, so an up-to-date DB is a no-op. See ADR 0036.
   migrate-dev:
     name: "Database: Run migrations (dev)"
-    needs: infra-dev
+    needs: [changes, infra-dev]
+    # Migrations live under api-go/internal/platform/postgres/migrations/ —
+    # go category, not infra — so gate on go OR infra. infra-dev can be
+    # legitimately skipped (e.g. only api-go/ changed), so treat its
+    # 'skipped' result as a pass, not a block.
+    if: always() && (needs.changes.outputs.go == 'true' || needs.changes.outputs.infra == 'true' || github.event_name == 'workflow_dispatch') && (needs.infra-dev.result == 'success' || needs.infra-dev.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: development
@@ -156,6 +193,8 @@ jobs:
   # ── Go API: build & push image ──────────────────────
   api-go-image:
     name: "Go API: Build & push image"
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: development
@@ -179,6 +218,8 @@ jobs:
   # this image (worker-deploy below, image-swap tc-hm20).
   worker-go-image:
     name: "Go Worker: Build & push image"
+    needs: changes
+    if: needs.changes.outputs.go == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: development
@@ -201,7 +242,12 @@ jobs:
   # ── Go API: deploy to dev ───────────────────────────
   api-go-deploy:
     name: "Go API: Deploy to dev"
-    needs: [api-go-image, infra-dev, migrate-dev]
+    needs: [changes, api-go-image, infra-dev, migrate-dev]
+    # infra-dev/migrate-dev can be legitimately skipped (e.g. only api-go/
+    # changed) — a skipped upstream must not cascade-skip this deploy.
+    # api-go-image is gated on the same category as this job, so it's never
+    # legitimately skipped when this job needs to run — require 'success'.
+    if: always() && (needs.changes.outputs.go == 'true' || github.event_name == 'workflow_dispatch') && needs.api-go-image.result == 'success' && (needs.infra-dev.result == 'success' || needs.infra-dev.result == 'skipped') && (needs.migrate-dev.result == 'success' || needs.migrate-dev.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: development
@@ -223,7 +269,11 @@ jobs:
   # ── Worker: deploy to dev ───────────────────────────────
   worker-deploy:
     name: "Worker: Deploy to dev"
-    needs: [worker-go-image, infra-dev, migrate-dev]
+    needs: [changes, worker-go-image, infra-dev, migrate-dev]
+    # Same pattern as api-go-deploy: infra-dev/migrate-dev can be
+    # legitimately skipped without blocking this deploy; worker-go-image is
+    # gated on the same category so it must have succeeded.
+    if: always() && (needs.changes.outputs.go == 'true' || github.event_name == 'workflow_dispatch') && needs.worker-go-image.result == 'success' && (needs.infra-dev.result == 'success' || needs.infra-dev.result == 'skipped') && (needs.migrate-dev.result == 'success' || needs.migrate-dev.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 5
     environment: development
@@ -247,7 +297,10 @@ jobs:
   # ── Web: deploy to dev ──────────────────────────────
   web-deploy:
     name: "Web: Deploy to dev"
-    needs: infra-dev
+    needs: [changes, infra-dev]
+    # infra-dev can be legitimately skipped (e.g. only web/ changed) —
+    # a skipped upstream must not cascade-skip this deploy.
+    if: always() && (needs.changes.outputs.web == 'true' || github.event_name == 'workflow_dispatch') && (needs.infra-dev.result == 'success' || needs.infra-dev.result == 'skipped')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: development

--- a/.github/workflows/cd-ios-testflight.yml
+++ b/.github/workflows/cd-ios-testflight.yml
@@ -39,38 +39,53 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
-      should-release: ${{ steps.check.outputs.should-release }}
-      previous-tag: ${{ steps.check.outputs.previous-tag }}
+      should-release: ${{ steps.should-release.outputs.should-release }}
+      previous-tag: ${{ steps.prev.outputs.previous-tag }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Detect mobile/ios/ changes
-        id: check
+      - name: Compute previous tag
+        id: prev
         run: |
           set -euo pipefail
           if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
-            echo "should-release=true" >> "$GITHUB_OUTPUT"
             echo "previous-tag=" >> "$GITHUB_OUTPUT"
             echo "::notice::Manual workflow_dispatch — bypassing guard, will upload to TestFlight"
             exit 0
           fi
           PREV=$(git describe --tags --abbrev=0 --match 'v*' "${GITHUB_REF_NAME}^" 2>/dev/null || echo "")
+          echo "previous-tag=${PREV}" >> "$GITHUB_OUTPUT"
           if [ -z "$PREV" ]; then
-            echo "should-release=true" >> "$GITHUB_OUTPUT"
-            echo "previous-tag=" >> "$GITHUB_OUTPUT"
             echo "::notice::No previous tag — first release, will upload to TestFlight"
+          fi
+
+      - name: Detect mobile/ios/ changes since previous tag
+        id: detect
+        if: github.event_name != 'workflow_dispatch'
+        uses: ./.github/actions/detect-changes
+        with:
+          mode: tag
+          base-ref: ${{ steps.prev.outputs.previous-tag }}
+          categories: ios
+
+      - name: Derive should-release
+        id: should-release
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            # Manual bypass — skip detect-changes entirely and force a
+            # release, same as today (kept exactly as-is per issue #835
+            # slice 3: this path never routes through detect-changes).
+            echo "should-release=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if git diff --quiet "${PREV}..${GITHUB_REF_NAME}" -- mobile/ios/; then
-            echo "should-release=false" >> "$GITHUB_OUTPUT"
-            echo "previous-tag=${PREV}" >> "$GITHUB_OUTPUT"
-            echo "::notice::No mobile/ios/ changes since ${PREV} — skipping TestFlight upload"
+          echo "should-release=${{ steps.detect.outputs.ios }}" >> "$GITHUB_OUTPUT"
+          if [ "${{ steps.detect.outputs.ios }}" = "true" ]; then
+            echo "::notice::Detected mobile/ios/ changes since ${{ steps.prev.outputs.previous-tag }} — will upload to TestFlight"
           else
-            echo "should-release=true" >> "$GITHUB_OUTPUT"
-            echo "previous-tag=${PREV}" >> "$GITHUB_OUTPUT"
-            echo "::notice::Detected mobile/ios/ changes since ${PREV} — will upload to TestFlight"
+            echo "::notice::No mobile/ios/ changes since ${{ steps.prev.outputs.previous-tag }} — skipping TestFlight upload"
           fi
 
   test:

--- a/.github/workflows/cd-ios-testflight.yml
+++ b/.github/workflows/cd-ios-testflight.yml
@@ -69,6 +69,14 @@ jobs:
           mode: tag
           base-ref: ${{ steps.prev.outputs.previous-tag }}
           categories: ios
+          # tag mode exempts unmapped .github/ churn from its fail-closed
+          # catch-all (a release decision, not a validation lane — see
+          # detect-changes/action.yml's header). These two paths directly
+          # affect the release pipeline itself, so they still force a
+          # release when changed.
+          trigger-files: |
+            .github/workflows/cd-ios-testflight.yml:ios
+            .github/actions/detect-changes/action.yml:ios
 
       - name: Derive should-release
         id: should-release


### PR DESCRIPTION
## Changes
- `cd-dev.yml`: drops the `paths-ignore` trigger block in favor of a first `changes` job (detect-changes, mode: push, categories go/web/infra). Every deploy job is gated on its relevant category so the chain short-circuits when nothing relevant changed (docs-only/iOS-only/Android-only pushes finish fast, all jobs skipped); `workflow_dispatch` remains a deploy-everything override. Fail-open throughout: any job whose upstream can be legitimately skipped uses `always() && (<category> || workflow_dispatch) && (<upstream>.result == 'success' || 'skipped')` so a skipped upstream never cascades into skipping a deploy that itself needs to run.
- `detect-changes/action.yml`: adds a `tag` mode (two-dot diff `base-ref..HEAD`, matching the hand-rolled guard's exact semantics — not the three-dot form used by pr/merge_group) for release-decision consumers. Empty `base-ref` (first release) forces every requested category true rather than diffing against nothing.
- `cd-ios-testflight.yml`: replaces the hand-rolled `git diff --quiet` guard with the new `tag` mode (categories: ios). The manual `workflow_dispatch` bypass is unchanged — it still skips the guard entirely.
- **Design refinement** (after review): tag mode does *not* inherit push/pr/merge_group's uniform ".github/ changes fail-closed everything" rule — that's right for validation lanes but wrong for a release decision (an unrelated CI tweak shouldn't force a TestFlight upload). Tag mode exempts unmapped `.github/*` paths from the fail-closed catch-all; `cd-ios-testflight.yml` uses `trigger-files` to keep forcing a release when `cd-ios-testflight.yml` or `detect-changes/action.yml` itself changes (the two paths that actually affect the release pipeline).

Validated against the real repo's last 3 `v*` tag ranges: new logic now matches the old guard's verdict on all 3 (the one apparent "difference" is `detect-changes/action.yml` itself changing within a range — correctly still forces a release via the designated trigger-file, exercising the mechanism that changed).

Slice 3 of 7 from #835 (memo 0014 CI hardening). Scope: `cd-dev.yml`, `cd-ios-testflight.yml`, `detect-changes/action.yml` only — `cd-prod.yml` and `legal-drift-check.yml` are explicitly out of scope per the issue.

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tag-based release detection, including first-release handling and clearer release gating.
  * Improved dev deployment and iOS TestFlight automation to react only to relevant changes.

* **Bug Fixes**
  * Prevented unrelated workflow-only changes from incorrectly triggering release lanes.
  * Reduced cases where skipped upstream jobs could block downstream deployments or migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->