### PR TITLE
ci: add actionlint+zizmor pr-gate lint job, SHA-pin all third-party actions

### DIFF
--- a/.github/actions/azure-login/action.yml
+++ b/.github/actions/azure-login/action.yml
@@ -1,4 +1,6 @@
-# Wraps azure/login@v3 with OIDC federated credentials.
+# Wraps azure/login@v3 with OIDC federated credentials. Third-party actions
+# pinned to commit SHA for supply-chain safety (tj-actions CVE-2025-30066) —
+# see the `uses:` step below.
 # Centralises the three-input pattern used across all deployment workflows.
 name: Azure Login (OIDC)
 description: Login to Azure using OIDC federated credentials
@@ -18,7 +20,7 @@ runs:
   using: composite
   steps:
     - name: Login to Azure
-      uses: azure/login@v3
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3
       with:
         client-id: ${{ inputs.client-id }}
         tenant-id: ${{ inputs.tenant-id }}

--- a/.github/actions/build-web/action.yml
+++ b/.github/actions/build-web/action.yml
@@ -1,6 +1,9 @@
 # Installs Node.js, runs npm ci, and builds the Vite web app with
 # environment-specific VITE_ variables baked in at build time.
 #
+# Third-party actions pinned to commit SHA for supply-chain safety
+# (tj-actions CVE-2025-30066 rationale — issue #835 slice 4).
+#
 # Produces the production bundle in web/dist, ready for deployment.
 #
 # Render-mode (epic tc-w5w9 / GH #598, Phase 4):
@@ -67,7 +70,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: 22
         cache: npm

--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -49,6 +49,15 @@
 #   see category-map.sh and the "Coverage assertion" step below. This
 #   catches a new top-level directory that nobody wired up, even if it's
 #   never touched again after the PR that introduced it (issue #835 slice 2).
+#
+# gha output (issue #835 slice 4):
+#   A `gha` category is available for callers that want a lint lane for
+#   .github/ itself (actionlint/zizmor — see pr-gate.yml's
+#   github-actions-lint job). It's computed independently of
+#   CATEGORY_PREFIXES/the fail-closed catch-all above (true whenever any
+#   changed path starts with ".github/"), so requesting it does NOT change
+#   the existing "unmapped .github/ change fail-closes every other
+#   requested category" behavior — it's an additive, separate signal.
 name: Detect Changes
 description: Monorepo change detection with push/pr modes
 
@@ -92,6 +101,9 @@ outputs:
   go:
     description: "true if api-go/ changed"
     value: ${{ steps.detect.outputs.go }}
+  gha:
+    description: "true if .github/ changed (workflows or composite actions) — drives the actionlint/zizmor lint lane (issue #835 slice 4)"
+    value: ${{ steps.detect.outputs.gha }}
 
 runs:
   using: composite
@@ -249,6 +261,20 @@ runs:
         done <<< "$CHANGED"
 
         fi # FORCE_ALL_TRUE
+
+        # gha (issue #835 slice 4): computed independently of the
+        # CATEGORY_PREFIXES loop above, deliberately NOT added as a
+        # mapped prefix there. Mapping ".github" into CATEGORY_PREFIXES
+        # would make a .github/ file "matched" and skip the fail-closed
+        # catch-all a few lines up — undoing slice 1's design, where any
+        # unmapped .github/ change must still force every other requested
+        # category true (a stray workflow/action edit could affect any
+        # lane). Instead, `gha` is a simple independent signal computed
+        # straight from $CHANGED: true whenever any changed path is under
+        # .github/, regardless of mode or the fail-closed logic above.
+        if [[ -v "flags[gha]" ]] && echo "$CHANGED" | grep -qE '^\.github/'; then
+          flags[gha]=true
+        fi
 
         # Write outputs
         for cat in "${CATS[@]}"; do

--- a/.github/actions/setup-go-infra/action.yml
+++ b/.github/actions/setup-go-infra/action.yml
@@ -1,5 +1,8 @@
 # Sets up Go (via infra/go.mod), the Pulumi CLI, and caches Go modules for the
 # infra Pulumi program. Centralises the setup used across infra jobs.
+#
+# Third-party actions pinned to commit SHA for supply-chain safety
+# (tj-actions CVE-2025-30066 rationale — issue #835 slice 4).
 name: Setup Go & Pulumi for Infra
 description: Install Go, the Pulumi CLI, and cache Go modules for the infra Pulumi program
 
@@ -7,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Setup Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version-file: infra/go.mod
         cache-dependency-path: infra/go.sum

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -1,3 +1,6 @@
+# Third-party actions pinned to commit SHA for supply-chain safety
+# (tj-actions CVE-2025-30066 rationale — issue #835 slice 4).
+#
 # Deploys components to the dev environment, gated by what changed.
 # Triggered on every push to main (squash merges assumed) and via
 # workflow_dispatch. A first `changes` job (detect-changes, mode: push)
@@ -57,8 +60,9 @@ jobs:
       infra: ${{ steps.detect.outputs.infra }}
       go: ${{ steps.detect.outputs.go }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          persist-credentials: false
           # HEAD~1 must be present for push-mode's HEAD~1..HEAD diff — the
           # default shallow (depth-1) checkout only fetches HEAD itself.
           fetch-depth: 2
@@ -82,7 +86,9 @@ jobs:
     timeout-minutes: 15
     environment: development
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-go-infra
 
@@ -113,7 +119,9 @@ jobs:
     timeout-minutes: 15
     environment: development
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-go-infra
 
@@ -169,9 +177,11 @@ jobs:
     timeout-minutes: 15
     environment: development
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: api-go/go.mod
 
@@ -199,7 +209,9 @@ jobs:
     timeout-minutes: 10
     environment: development
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/azure-login
         with:
@@ -224,7 +236,9 @@ jobs:
     timeout-minutes: 10
     environment: development
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/azure-login
         with:
@@ -252,7 +266,9 @@ jobs:
     timeout-minutes: 5
     environment: development
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/azure-login
         with:
@@ -278,7 +294,9 @@ jobs:
     timeout-minutes: 5
     environment: development
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/azure-login
         with:
@@ -305,7 +323,9 @@ jobs:
     timeout-minutes: 30
     environment: development
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       # azure-login MUST run before build-web: in render-mode, build-web
       # downloads the weekly seo-snapshot.json from Azure Blob via `az storage
@@ -337,7 +357,7 @@ jobs:
           swa-name: swa-town-crier-dev
 
       - name: Deploy to Azure Static Web Apps
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ steps.swa-token.outputs.token }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd-ios-testflight.yml
+++ b/.github/workflows/cd-ios-testflight.yml
@@ -2,6 +2,9 @@
 # mobile/ios/** has changed since the previous tag. Tags are created by the
 # /release skill via `gh release create`.
 #
+# Third-party actions pinned to commit SHA for supply-chain safety
+# (tj-actions CVE-2025-30066 rationale — issue #835 slice 4).
+#
 # Spec: docs/specs/ios-testflight-automation.md
 # ADR:  docs/adr/0025-ios-testflight-release-automation.md
 #
@@ -42,8 +45,9 @@ jobs:
       should-release: ${{ steps.should-release.outputs.should-release }}
       previous-tag: ${{ steps.prev.outputs.previous-tag }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Compute previous tag
@@ -103,15 +107,17 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Select Xcode (latest stable — needs Swift 6.1+ for our Package.swift)
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: latest-stable
 
       - name: Cache SPM build
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: mobile/ios/.build
           key: spm-test-${{ hashFiles('mobile/ios/Package.resolved') }}
@@ -144,19 +150,20 @@ jobs:
     timeout-minutes: 60
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          persist-credentials: false
           # Full history + tags so the changelog generator can read commit
           # subjects/trailers between the previous tag and this one (tc-9sef).
           fetch-depth: 0
 
       - name: Select Xcode (latest stable — needs Swift 6.1+ for our Package.swift)
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: latest-stable
 
       - name: Cache SPM
-        uses: actions/cache@v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: ~/Library/Developer/Xcode/DerivedData/**/SourcePackages
           key: spm-archive-${{ hashFiles('mobile/ios/Package.resolved', 'mobile/ios/packages/**/Package.resolved') }}
@@ -165,7 +172,7 @@ jobs:
             spm-
 
       - name: Setup Ruby + bundler
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
@@ -179,7 +186,7 @@ jobs:
         run: xcodegen generate
 
       - name: Setup SSH key for fastlane match
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
         with:
           ssh-private-key: ${{ secrets.MATCH_GIT_DEPLOY_KEY }}
 

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -1,6 +1,9 @@
 # Deploys all server-side components to the production environment.
 # Triggered by pushing a semver tag (e.g., v1.0.0).
 #
+# Third-party actions pinned to commit SHA for supply-chain safety
+# (tj-actions CVE-2025-30066 rationale — issue #835 slice 4).
+#
 # Requires repo-level secrets:
 #   AZURE_CLIENT_ID        — OIDC federated credential for Azure login
 #   AZURE_TENANT_ID        — Azure AD tenant
@@ -38,7 +41,9 @@ jobs:
       resource-group: ${{ steps.outputs.outputs.resource-group }}
       swa-name: ${{ steps.outputs.outputs.swa-name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-go-infra
 
@@ -98,9 +103,11 @@ jobs:
     timeout-minutes: 15
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: api-go/go.mod
 
@@ -127,8 +134,9 @@ jobs:
     timeout-minutes: 5
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Resolve tag to commit SHA
@@ -213,8 +221,9 @@ jobs:
     timeout-minutes: 5
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Resolve tag to commit SHA
@@ -298,7 +307,9 @@ jobs:
     timeout-minutes: 30
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       # azure-login MUST run before build-web: in render-mode, build-web
       # downloads the weekly seo-snapshot.json from Azure Blob via `az storage
@@ -330,7 +341,7 @@ jobs:
           swa-name: ${{ needs.infra.outputs.swa-name }}
 
       - name: Deploy to Azure Static Web Apps
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ steps.swa-token.outputs.token }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev-container-app-cleanup.yml
+++ b/.github/workflows/dev-container-app-cleanup.yml
@@ -1,5 +1,8 @@
 # Deactivates non-newest active Container App revisions in rg-town-crier-dev.
 #
+# Third-party actions pinned to commit SHA for supply-chain safety
+# (tj-actions CVE-2025-30066 rationale — issue #835 slice 4).
+#
 # Background: dev's API Container App runs in Multiple revisions mode so that
 # pr-gate.yml can deploy a PR-suffixed staging revision with traffic-weight 0
 # and integration-test it without disturbing the live revision. The cleanup
@@ -54,7 +57,9 @@ jobs:
     timeout-minutes: 15
     environment: development
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/azure-login
         with:

--- a/.github/workflows/ios-capability-ops.yml
+++ b/.github/workflows/ios-capability-ops.yml
@@ -1,6 +1,9 @@
 # Manual ops workflow for one-shot iOS signing/capability changes that should
 # NOT run on every release. Two lanes are exposed via workflow_dispatch:
 #
+# Third-party actions pinned to commit SHA for supply-chain safety
+# (tj-actions CVE-2025-30066 rationale — issue #835 slice 4).
+#
 #   - enable_associated_domains: idempotently enables the Associated Domains
 #     capability on the App ID `uk.towncrierapp.mobile` via Spaceship/App
 #     Store Connect API. Run once after entitlement changes that add a new
@@ -56,22 +59,24 @@ jobs:
     timeout-minutes: 30
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - name: Select Xcode (latest stable — needs Swift 6.1+ for our Package.swift)
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
         with:
           xcode-version: latest-stable
 
       - name: Setup Ruby + bundler
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1
         with:
           ruby-version: '3.3'
           bundler-cache: true
           working-directory: mobile/ios
 
       - name: Setup SSH key for fastlane match
-        uses: webfactory/ssh-agent@v0.9.0
+        uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
         with:
           ssh-private-key: ${{ secrets.MATCH_GIT_DEPLOY_KEY }}
 

--- a/.github/workflows/legal-drift-check.yml
+++ b/.github/workflows/legal-drift-check.yml
@@ -1,3 +1,6 @@
+# Third-party actions pinned to commit SHA for supply-chain safety
+# (tj-actions CVE-2025-30066 rationale — issue #835 slice 4).
+
 name: Legal docs drift check
 
 on:
@@ -20,5 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - run: bash scripts/check-legal-drift.sh

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -1,3 +1,6 @@
+# Third-party actions pinned to commit SHA for supply-chain safety
+# (tj-actions CVE-2025-30066 rationale — issue #835 slice 4).
+#
 # Requires secrets:
 #   AZURE_CLIENT_ID              — OIDC federated credential for Azure login
 #   AZURE_TENANT_ID              — Azure AD tenant
@@ -41,9 +44,11 @@ jobs:
       web: ${{ steps.detect.outputs.web }}
       infra: ${{ steps.detect.outputs.infra }}
       go: ${{ steps.detect.outputs.go }}
+      gha: ${{ steps.detect.outputs.gha }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Detect changed paths
         id: detect
@@ -51,7 +56,10 @@ jobs:
         with:
           mode: ${{ github.event_name == 'merge_group' && 'merge_group' || 'pr' }}
           base-ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || github.base_ref }}
-          categories: cli,ios,android,web,infra,go
+          # `gha` (issue #835 slice 4) drives the github-actions-lint job
+          # below — see detect-changes/action.yml's header for why it's
+          # computed independently rather than as a mapped CATEGORY_PREFIX.
+          categories: cli,ios,android,web,infra,go,gha
           trigger-files: |
             .github/workflows/pr-gate.yml:cli,ios,android,web,infra,go
             .github/workflows/cd-dev.yml:web,infra,go
@@ -67,8 +75,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: api-go/go.mod
           # No go.sum yet (zero dependencies); enable module caching when one appears.
@@ -83,7 +93,7 @@ jobs:
         working-directory: api-go
       - run: go vet ./...
         working-directory: api-go
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: v2.12
           working-directory: api-go
@@ -95,8 +105,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: api-go/go.mod
           cache: false
@@ -105,7 +117,7 @@ jobs:
       - name: Run tests (race detector + coverage)
         run: go test -race -coverprofile=coverage.out ./...
         working-directory: api-go
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: go-coverage
           path: api-go/coverage.out
@@ -133,8 +145,10 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: api-go/go.mod
           cache: false
@@ -156,8 +170,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: cli/go.mod
           # No go.sum yet (zero dependencies); enable module caching when one appears.
@@ -172,7 +188,7 @@ jobs:
         working-directory: cli
       - run: go vet ./...
         working-directory: cli
-      - uses: golangci/golangci-lint-action@v8
+      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: v2.12
           working-directory: cli
@@ -184,8 +200,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version-file: cli/go.mod
           cache: false
@@ -204,7 +222,9 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - name: Install SwiftLint 0.63.2 (pinned — avoids latest-ruleset drift, tc-6kdu)
         run: |
           curl -fsSL -o "$RUNNER_TEMP/swiftlint.zip" \
@@ -222,8 +242,10 @@ jobs:
     runs-on: macos-15
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/cache@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: mobile/ios/.build
           key: ios-${{ runner.os }}-${{ hashFiles('mobile/ios/Package.resolved') }}
@@ -248,8 +270,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Ensure iOS changes carry a user-note signal
         env:
@@ -294,18 +317,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           distribution: temurin
           java-version: '21'
-      - uses: android-actions/setup-android@v4
+      - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
         with:
           # Matches mobile/android/README.md's local toolchain-setup packages
           # (minus the emulator/system-image, which CI never needs — no
           # instrumented tests run here, JVM unit tests only).
           packages: 'platform-tools platforms;android-35 build-tools;35.0.0'
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
       - run: ./gradlew ktlintCheck detekt
         working-directory: mobile/android
 
@@ -316,15 +341,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-java@v5
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5
         with:
           distribution: temurin
           java-version: '21'
-      - uses: android-actions/setup-android@v4
+      - uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4
         with:
           packages: 'platform-tools platforms;android-35 build-tools;35.0.0'
-      - uses: gradle/actions/setup-gradle@v6
+      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6
       - run: ./gradlew test :app:assembleDevDebug
         working-directory: mobile/android
 
@@ -335,8 +362,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Ensure Android changes carry a user-note signal
         env:
@@ -377,8 +405,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
@@ -395,8 +425,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 22
           cache: npm
@@ -423,7 +455,9 @@ jobs:
       id-token: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/setup-go-infra
 
@@ -482,8 +516,71 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           PREVIEW=$(cat /tmp/pulumi-preview.txt)
+          # shellcheck disable=SC2016  # false positive (issue #835 slice 4,
+          # actionlint/zizmor pass): the ${{ vars.PULUMI_STACK }} inside the
+          # single-quoted printf format is a GitHub Actions expression,
+          # substituted server-side before bash ever parses this script — not
+          # a shell variable that needs double quotes to expand. The
+          # single-quoted format string is intentional; %s is the only real
+          # printf substitution, filled from "$PREVIEW" below.
           gh pr comment "${{ github.event.pull_request.number }}" \
             --body "$(printf '<details><summary>Pulumi preview — <code>${{ vars.PULUMI_STACK }}</code></summary>\n\n```\n%s\n```\n\n</details>' "$PREVIEW")"
+
+  # ── GitHub Actions (CI itself) ───────────────────────
+  # issue #835 slice 4: lints the CI's own workflow/action YAML — actionlint
+  # for syntax/shellcheck/semantic issues, zizmor for GitHub-Actions-specific
+  # security findings (unpinned actions, template injection, credential
+  # persistence, etc.). Gated on the `gha` category (any .github/ change),
+  # computed independently in detect-changes so it doesn't disturb slice 1's
+  # existing .github/ fail-closed behavior for the other categories — see
+  # detect-changes/action.yml's header.
+  github-actions-lint:
+    name: "GitHub Actions: Lint (actionlint + zizmor)"
+    needs: changes
+    if: needs.changes.outputs.gha == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Install actionlint 1.7.12 (pinned — matches local dev tooling; checksum-verified)
+        run: |
+          set -euo pipefail
+          curl -fsSL -o "$RUNNER_TEMP/actionlint.tar.gz" \
+            https://github.com/rhysd/actionlint/releases/download/v1.7.12/actionlint_1.7.12_linux_amd64.tar.gz
+          echo "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8  $RUNNER_TEMP/actionlint.tar.gz" | sha256sum -c -
+          tar -xzf "$RUNNER_TEMP/actionlint.tar.gz" -C "$RUNNER_TEMP" actionlint
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+
+      - run: actionlint -version
+
+      - name: Run actionlint
+        run: actionlint -color
+
+      # zizmor (https://zizmor.sh) isn't packaged for apt/local dev tooling
+      # here, so it's installed at run time via uv/uvx — the tool's own
+      # documented recommended CI integration (docs.zizmor.sh/integrations,
+      # "Manual integration" / annotations recipe). uvx runs a pinned
+      # release straight from PyPI without a persistent install step.
+      - name: Install uv (for zizmor via uvx)
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+
+      - name: Run zizmor (GitHub Actions security lint)
+        # --format=github emits GH-native error annotations and preserves
+        # zizmor's severity-based exit codes (11-14) — unlike --format=sarif,
+        # which always exits 0 and requires GitHub Advanced Security to
+        # surface anything. GH_TOKEN enables zizmor's "online" mode (fuller
+        # audit coverage, e.g. impostor-commit checks); the default
+        # read-only github.token is sufficient. zizmor auto-discovers
+        # .github/zizmor.yml for the accepted-risk/deferred waivers
+        # documented there — see that file for the rationale per finding.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: uvx "zizmor@1.26.1" --format=github .
 
   # ── Gate (sole required status check) ────────────────
 
@@ -497,7 +594,7 @@ jobs:
     # so without `changes` in this needs array a failing coverage assertion
     # would be silently swallowed and `gate` would report success (issue
     # #835 slice 2 — found during implementation, not in the original scope).
-    needs: [changes, go-lint, go-test, go-integration, cli-lint, cli-build-test, ios-lint, ios-build-test, ios-release-note-guard, android-lint, android-build-test, android-release-note-guard, web-lint, web-build-test, infra-preview]
+    needs: [changes, go-lint, go-test, go-integration, cli-lint, cli-build-test, ios-lint, ios-build-test, ios-release-note-guard, android-lint, android-build-test, android-release-note-guard, web-lint, web-build-test, infra-preview, github-actions-lint]
     if: always() && (github.event_name != 'pull_request' || github.event.action != 'closed')
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -520,6 +617,7 @@ jobs:
             "${{ needs.web-lint.result }}"
             "${{ needs.web-build-test.result }}"
             "${{ needs.infra-preview.result }}"
+            "${{ needs.github-actions-lint.result }}"
           )
           for r in "${results[@]}"; do
             if [[ "$r" == "failure" || "$r" == "cancelled" ]]; then

--- a/.github/workflows/seo-refresh.yml
+++ b/.github/workflows/seo-refresh.yml
@@ -1,5 +1,8 @@
 # Daily refresh of the SEO snapshot for BOTH dev and prod web.
 #
+# Third-party actions pinned to commit SHA for supply-chain safety
+# (tj-actions CVE-2025-30066 rationale — issue #835 slice 4).
+#
 # This job is the SOLE caller of the gated Go API for the programmatic SEO pages
 # (authority-level AND per-town), plus sitemap.xml (epic tc-w5w9 / GH #598). It
 # decouples *data fetching* (daily, against the API) from *page rendering*
@@ -94,7 +97,9 @@ jobs:
     timeout-minutes: 30
     environment: development
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       # SPA only — empty site-build-key skips the build-time prerender.
       - uses: ./.github/actions/build-web
@@ -145,7 +150,7 @@ jobs:
           swa-name: swa-town-crier-dev
 
       - name: Deploy to Azure Static Web Apps
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ steps.swa-token.outputs.token }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
@@ -167,7 +172,9 @@ jobs:
     timeout-minutes: 30
     environment: production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       # SPA only — empty site-build-key skips the build-time prerender.
       - uses: ./.github/actions/build-web
@@ -218,7 +225,7 @@ jobs:
           swa-name: swa-town-crier-prod
 
       - name: Deploy to Azure Static Web Apps
-        uses: Azure/static-web-apps-deploy@v1
+        uses: Azure/static-web-apps-deploy@4d27395796ac319302594769cfe812bd207490b1 # v1
         with:
           azure_static_web_apps_api_token: ${{ steps.swa-token.outputs.token }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,89 @@
+# zizmor configuration (issue #835 slice 4 — CI hardening: actionlint + zizmor
+# gate). Discovered automatically by `zizmor .` (see
+# https://docs.zizmor.sh/configuration/#discovery).
+#
+# Every waiver below was reviewed by hand against a real `zizmor` run over
+# this repo (both offline and online modes, 2026-07-05) before being added —
+# this file is NOT a blanket "make the gate green" escape hatch. Each entry
+# states why the finding is either a false positive here or deliberately
+# deferred, and deferred items are tracked as a follow-up bead
+# (tc-61eoz.4 discovered-from) rather than silently dropped.
+#
+# Findings that were FIXED instead of waived (not listed here):
+#   - artipacked: every `actions/checkout` step across all workflows now sets
+#     `persist-credentials: false` — a no-risk default (no workflow in this
+#     repo relies on the checkout's ambient git credential to push/commit;
+#     `gh`/`az` calls authenticate via their own explicit tokens/OIDC).
+#   - unpinned-uses: resolved by the SHA-pinning done in this same slice —
+#     zero findings, nothing to waive.
+rules:
+  # template-injection (54 findings, mostly High confidence/severity): the
+  # large majority live inside existing composite actions under
+  # .github/actions/ (acr-build-push, deploy-container-app, deploy-worker-jobs,
+  # detect-changes, setup-pulumi-secrets, build-web, get-swa-token) that
+  # interpolate `${{ inputs.* }}` directly into `run:` scripts. zizmor can't
+  # ignore composite-action findings via this config file (only inline
+  # comments work there — see https://docs.zizmor.sh/configuration/#rulesidignore),
+  # and rewriting those `run:` blocks to route through `env:` indirection
+  # (the standard fix) is a functional change to files this slice's scope
+  # deliberately excludes ("do not touch ... the composite-action-factoring
+  # work — those are slices 5/6, separate PRs"). The handful of remaining
+  # workflow-level findings are Low-confidence/Informational and involve only
+  # job outputs (git SHAs, image digests) or repo-level `vars.*` — never
+  # fork-controllable input (PR titles/bodies, issue titles, branch names) —
+  # so they're not realistically exploitable in this repo's threat model.
+  # Deferred to a follow-up bead (env-var indirection across the composite
+  # actions), filed discovered-from tc-61eoz.4 — natural fit alongside
+  # slice 5's composite-action work, since that's when these files next get
+  # rewritten anyway.
+  template-injection:
+    disable: true
+
+  # github-env (1 finding, Low confidence): setup-go-infra/action.yml's
+  # `echo "$HOME/.pulumi/bin" >> "$GITHUB_PATH"` — this is GitHub's own
+  # documented mechanism for extending PATH (see "Adding a system path" in
+  # GitHub Actions docs), appending a fully static, non-attacker-controllable
+  # string ($HOME is runner-set, not user input). zizmor's own confidence
+  # rating agrees (Low). Lives in a composite action this slice doesn't
+  # otherwise touch, so — same as template-injection above — the only
+  # available waiver mechanism is a config-level disable, not a per-file
+  # ignore rule.
+  github-env:
+    disable: true
+
+  # excessive-permissions (5 findings, High confidence/severity): each of
+  # these 5 workflows declares `id-token: write` (cd-ios-testflight.yml:
+  # `contents: write`) at the workflow level rather than scoped per-job.
+  # This is a real, valid finding — the fix is moving the permission down to
+  # only the jobs that actually need Azure OIDC (or, for cd-ios-testflight,
+  # only the release-annotation step). That's a deploy-pipeline-adjacent
+  # change across cd-dev.yml/cd-prod.yml/cd-ios-testflight.yml — files this
+  # slice's scope says not to touch beyond SHA-pinning ("do not touch
+  # cd-prod.yml deploy logic") — and getting the per-job scoping wrong would
+  # silently break OIDC auth for a real deploy/release run, which needs more
+  # careful verification than a SHA-pinning/lint-gate PR should carry.
+  # Deferred to a follow-up bead (discovered-from tc-61eoz.4) for careful
+  # per-job permission scoping, verified against a live run of each pipeline.
+  excessive-permissions:
+    ignore:
+      - cd-dev.yml
+      - cd-ios-testflight.yml
+      - cd-prod.yml
+      - pr-gate.yml
+      - seo-refresh.yml
+
+  # cache-poisoning (4 findings, High confidence/severity): actions/cache
+  # (SPM) and ruby/setup-ruby's bundler-cache in cd-ios-testflight.yml, and
+  # actions/setup-go's implicit module cache in cd-prod.yml — all inside
+  # tag-triggered release pipelines, where a poisoned cache entry could in
+  # principle taint a published artifact. The recommended fix (remove or
+  # conditionally disable caching for these steps) changes real build
+  # behaviour in the exact pipelines that ship to TestFlight/production —
+  # explicitly out of scope here ("do not touch cd-prod.yml deploy logic").
+  # Deferred to a follow-up bead (discovered-from tc-61eoz.4) to evaluate
+  # removing/conditionalizing these caches without risking release build
+  # time/timeout regressions.
+  cache-poisoning:
+    ignore:
+      - cd-ios-testflight.yml
+      - cd-prod.yml


### PR DESCRIPTION
## Changes
- New `github-actions-lint` job in pr-gate.yml (actionlint + zizmor), gated on a new `gha` detect-changes output that's computed independently of the mapped category prefixes — so requesting it doesn't disturb slice 1's "unmapped .github/ change fail-closes every other category" design. Wired into `gate`'s needs/results arrays.
- **SHA-pins all 16 third-party actions** referenced across `.github/` (15 pre-existing + `astral-sh/setup-uv`, added for zizmor) to full commit SHA with a trailing version comment, per tj-actions CVE-2025-30066 rationale. Zero floating tags remain.
- Every `actions/checkout` step now sets `persist-credentials: false` (zizmor `artipacked` finding) — verified no workflow in this repo relies on the checkout's ambient git credential to push/commit; `gh`/`az` calls authenticate via their own explicit tokens/OIDC.
- zizmor runs via `uvx "zizmor@1.26.1" --format=github .`, auto-discovering `.github/zizmor.yml` for waivers.
- `.github/zizmor.yml`: of 101 raw findings, 37 (artipacked) fixed directly; the remaining 64 (`template-injection` 54, `excessive-permissions` 5, `cache-poisoning` 4, `github-env` 1) are waived with a documented reason each — mostly because a proper fix means rewriting composite-action `run:` bodies or touching deploy-pipeline permissions/caching, which is out of this SHA-pin/lint-gate slice's scope and needs a live-run safety net to verify. Filed **tc-yi970** (discovered-from) to track proper remediation, naturally alongside slice 5's composite-action rewrites.

Independently re-verified before shipping: actionlint checksum matches the real GitHub release; zizmor with the committed config reports 0 findings (exit 0); removing the config reproduces exactly 64 findings matching the waiver categories 1:1; every third-party SHA resolves to the stated tag; actionlint is clean across the whole repo.

Slice 4 of 7 from #835 (memo 0014 CI hardening).

---
*Auto-shipped via ship skill*