### PR TITLE
ci: factor release-note-guard, pgmigrate, resolve-release-image composites

### DIFF
--- a/.github/actions/deploy-worker-jobs/action.yml
+++ b/.github/actions/deploy-worker-jobs/action.yml
@@ -3,7 +3,7 @@
 # topologies (ADR 0024: dev has no poll jobs), so this action is
 # intentionally agnostic about which jobs exist where.
 # Job names follow the convention job-tc-{name}-{env-suffix} and must
-# match infra/EnvironmentStack.cs — Pulumi seeds each job with a
+# match infra/environment.go — Pulumi seeds each job with a
 # quickstart placeholder image on create, and CD is responsible for
 # replacing it on every deploy.
 #

--- a/.github/actions/pgmigrate/action.yml
+++ b/.github/actions/pgmigrate/action.yml
@@ -9,6 +9,11 @@
 # (issue #835 slice 5) — the only difference between the two call sites is
 # `database-name`. The calling workflow keeps its own job-level needs:/if:/
 # environment: gating; this composite is only the steps: body.
+#
+# Assumes the calling job has already run actions/checkout before this
+# composite: a local composite action (`uses: ./path`) can't be resolved by
+# the runner from a workspace that hasn't been checked out yet, so checkout
+# can't live as this composite's own first step.
 name: Postgres Migrate
 description: Run pgmigrate against the given database, authenticating via Azure OIDC
 
@@ -29,10 +34,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      with:
-        persist-credentials: false
-
     - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
       with:
         go-version-file: api-go/go.mod

--- a/.github/actions/pgmigrate/action.yml
+++ b/.github/actions/pgmigrate/action.yml
@@ -1,0 +1,54 @@
+# Applies pending goose migrations (and the app-role grant sweep) against the
+# named database. Authenticates as the CI service principal — a Postgres
+# Entra admin on psql-town-crier-shared — via azure-login's OIDC session, so
+# DefaultAzureCredential yields a passwordless ossrdbms token; no stored DB
+# secret is involved. A non-zero exit fails the deploy loudly (never a silent
+# skip); goose.Up is idempotent, so an up-to-date DB is a no-op. See ADR 0036.
+#
+# Shared by cd-dev.yml's migrate-dev and cd-prod.yml's migrate-prod jobs
+# (issue #835 slice 5) — the only difference between the two call sites is
+# `database-name`. The calling workflow keeps its own job-level needs:/if:/
+# environment: gating; this composite is only the steps: body.
+name: Postgres Migrate
+description: Run pgmigrate against the given database, authenticating via Azure OIDC
+
+inputs:
+  database-name:
+    description: Target Postgres database name (e.g., town_crier_dev, town_crier_prod)
+    required: true
+  client-id:
+    description: Azure AD application (client) ID
+    required: true
+  tenant-id:
+    description: Azure AD tenant ID
+    required: true
+  subscription-id:
+    description: Azure subscription ID
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
+
+    - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+      with:
+        go-version-file: api-go/go.mod
+
+    - uses: ./.github/actions/azure-login
+      with:
+        client-id: ${{ inputs.client-id }}
+        tenant-id: ${{ inputs.tenant-id }}
+        subscription-id: ${{ inputs.subscription-id }}
+
+    - name: Apply migrations
+      shell: bash
+      working-directory: api-go
+      run: |
+        go run ./cmd/pgmigrate \
+          -host psql-town-crier-shared.postgres.database.azure.com \
+          -admin-user town-crier-github-actions \
+          -db ${{ inputs.database-name }} \
+          -timeout 600s

--- a/.github/actions/release-note-guard/action.yml
+++ b/.github/actions/release-note-guard/action.yml
@@ -1,0 +1,83 @@
+# Guards a mobile PR that touches the platform's source tree: it must carry
+# either a `Release-Note:` trailer or a PR title with a recognised
+# conventional-commit type, so the store changelog never silently falls
+# back to a generic stock line.
+#
+# A user-facing platform change must surface in the store changelog. For
+# iOS, scripts/ios-release-notes.sh derives the TestFlight changelog from
+# (1) Release-Note: trailers, then (2) cleaned mobile/ios subjects — a PR
+# whose squash subject (the PR title) has no recognised conventional type
+# AND no Release-Note: trailer falls through to the stock line, which is
+# how v0.15.23's onboarding-wizard launch shipped with no real notes
+# (tc-0557). Android has no Play Store changelog generator yet (CD/signing
+# lands in #779), but enforcing the same Release-Note:/conventional-title
+# discipline now means no mobile/android/ PR needs retrofitting once that
+# automation exists — hence the iOS-only "changelog falls back" error line
+# below.
+#
+# Shared by pr-gate.yml's ios-release-note-guard and
+# android-release-note-guard jobs (issue #835 slice 5) — the two were
+# byte-identical apart from platform-specific wording. The category gating
+# (needs.changes.outputs.ios / .android) stays in pr-gate.yml; only the
+# steps move here.
+name: Release Note Guard
+description: Ensure a platform-touching PR carries a Release-Note trailer or a conventional-commit title
+
+inputs:
+  platform:
+    description: Platform identifier — ios or android
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+
+    - name: Ensure ${{ inputs.platform }} changes carry a user-note signal
+      shell: bash
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+        BASE_REF: ${{ github.base_ref }}
+        PLATFORM: ${{ inputs.platform }}
+      run: |
+        set -euo pipefail
+
+        case "$PLATFORM" in
+          ios)
+            DISPLAY_NAME="iOS"
+            STORE_NAME="App Store"
+            ;;
+          android)
+            DISPLAY_NAME="Android"
+            STORE_NAME="Play Store"
+            ;;
+          *)
+            echo "::error::Unknown platform '$PLATFORM' — expected ios or android"
+            exit 1
+            ;;
+        esac
+
+        # Signal 1: any Release-Note: trailer in the PR's commits.
+        if git log --format='%B' "origin/${BASE_REF}..HEAD" | grep -qiE '^Release-Note:'; then
+          echo "✓ Release-Note: trailer present — ${STORE_NAME} note authored verbatim."
+          exit 0
+        fi
+
+        # Signal 2: PR title carries a recognised conventional-commit type.
+        #   feat/fix   → generates a cleaned user note (Tier 2)
+        #   chore/ci/… → explicit, intentional opt-out (no note, by design)
+        if printf '%s' "$PR_TITLE" \
+            | grep -qiE '^(feat|fix|chore|ci|docs|test|build|style|refactor|perf)(\([^)]*\))?!?:'; then
+          echo "✓ PR title has a conventional-commit type prefix: $PR_TITLE"
+          exit 0
+        fi
+
+        echo "::error::${DISPLAY_NAME}-touching PR has no Release-Note: trailer and the PR title has no conventional-commit type prefix: '$PR_TITLE'"
+        if [ "$PLATFORM" = "ios" ]; then
+          echo "::error::The ${STORE_NAME} / TestFlight changelog would silently fall back to the generic stock line."
+        fi
+        echo "::error::Fix one of: add a 'Release-Note: <plain-English user-facing change>' git trailer; OR retitle the PR with a type prefix — feat(${PLATFORM}):/fix(${PLATFORM}): for user-facing changes, or chore(${PLATFORM}):/test(${PLATFORM}): etc. to opt out."
+        exit 1

--- a/.github/actions/release-note-guard/action.yml
+++ b/.github/actions/release-note-guard/action.yml
@@ -20,6 +20,12 @@
 # byte-identical apart from platform-specific wording. The category gating
 # (needs.changes.outputs.ios / .android) stays in pr-gate.yml; only the
 # steps move here.
+#
+# Assumes the calling job has already run actions/checkout (fetch-depth: 0 —
+# the `git log origin/${BASE_REF}..HEAD` below needs full history) before
+# this composite: a local composite action (`uses: ./path`) can't be
+# resolved by the runner from a workspace that hasn't been checked out yet,
+# so checkout can't live as this composite's own first step.
 name: Release Note Guard
 description: Ensure a platform-touching PR carries a Release-Note trailer or a conventional-commit title
 
@@ -31,11 +37,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      with:
-        persist-credentials: false
-        fetch-depth: 0
-
     - name: Ensure ${{ inputs.platform }} changes carry a user-note signal
       shell: bash
       env:

--- a/.github/actions/resolve-release-image/action.yml
+++ b/.github/actions/resolve-release-image/action.yml
@@ -1,0 +1,106 @@
+# Resolves a cd-prod tag push to an IMMUTABLE DIGEST (registry/repo@sha256:…),
+# never a mutable tag. Prefers the exact tag-SHA image; falls back to the
+# current :latest digest; fails if neither exists. Deploying by digest means
+# a code change always rolls a new revision (digest differs) and an
+# unchanged image is a legitimate no-op — the silent ":latest string ==
+# :latest string" no-op that froze prod becomes impossible.
+#
+# Shared by cd-prod.yml's `api` and `worker` jobs (issue #835 slice 5) — the
+# only differences between call sites are `repo-name` (the ACR image
+# repository) and `display-name` (used in log/error text only: "Go API" vs
+# "worker", matching the pre-extraction wording exactly).
+#
+# Deliberately NOT included here: the actual deploy step
+# (deploy-container-app vs deploy-worker-jobs — different composite
+# actions/input shapes) and the post-deploy "tag deployed digest as durable
+# release" step. Both stay inline, verbatim, in cd-prod.yml:
+#   - the tag step MUST run strictly AFTER a successful deploy (it protects
+#     only digests that actually shipped — see cd-prod.yml's comment on that
+#     step); folding it into this single linear composite would force it to
+#     run before the deploy step, which is a real behavior change, not a
+#     verbatim extraction.
+#   - keeping deploy + tag inline keeps the highest-blast-radius part of a
+#     prod release trivially diffable by eye in the workflow file — this
+#     composite cannot be exercised by pr-gate (cd-prod.yml only triggers on
+#     a v* tag push), so minimising what's hidden behind it matters.
+name: Resolve Release Image
+description: Resolve a cd-prod tag push to an immutable ACR image digest, falling back to :latest
+
+inputs:
+  repo-name:
+    description: ACR image repository name (e.g., town-crier-api-go, town-crier-worker-go)
+    required: true
+  display-name:
+    description: Human-readable name for log/error text (e.g., "Go API", "worker")
+    required: true
+  acr-login-server:
+    description: Azure Container Registry login server
+    required: true
+  client-id:
+    description: Azure AD application (client) ID
+    required: true
+  tenant-id:
+    description: Azure AD tenant ID
+    required: true
+  subscription-id:
+    description: Azure subscription ID
+    required: true
+
+outputs:
+  image:
+    description: Resolved image reference (registry/repo@sha256:…)
+    value: ${{ steps.resolve-image.outputs.image }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      with:
+        persist-credentials: false
+        fetch-depth: 0
+
+    - name: Resolve tag to commit SHA
+      id: resolve
+      shell: bash
+      run: echo "sha=$(git rev-parse "$GITHUB_REF_NAME")" >> "$GITHUB_OUTPUT"
+
+    - uses: ./.github/actions/azure-login
+      with:
+        client-id: ${{ inputs.client-id }}
+        tenant-id: ${{ inputs.tenant-id }}
+        subscription-id: ${{ inputs.subscription-id }}
+
+    - name: Resolve ${{ inputs.display-name }} image digest
+      id: resolve-image
+      shell: bash
+      run: |
+        ACR_SERVER="${{ inputs.acr-login-server }}"
+        ACR_NAME="${ACR_SERVER%.azurecr.io}"
+        REPO="${{ inputs.repo-name }}"
+        SHA="${{ steps.resolve.outputs.sha }}"
+
+        digest_for_tag() {
+          az acr repository show \
+            --name "$ACR_NAME" \
+            --image "${REPO}:$1" \
+            --query digest -o tsv 2>/dev/null
+        }
+
+        # `|| true`: GitHub `run:` steps use `bash -e`, so a failed command
+        # substitution aborts the step. Without it, a missing SHA-tagged image
+        # (e.g. a tag whose commit didn't rebuild this image — an iOS-only or
+        # CI-only merge) kills the job before the `latest` fallback can run.
+        DIGEST="$(digest_for_tag "$SHA" || true)"
+        if [ -n "$DIGEST" ]; then
+          echo "Using exact image for SHA $SHA ($DIGEST)"
+        else
+          DIGEST="$(digest_for_tag latest || true)"
+          if [ -n "$DIGEST" ]; then
+            echo "No image for SHA $SHA — falling back to latest ($DIGEST)"
+          else
+            echo "::error::No ${{ inputs.display-name }} image found (tried SHA $SHA and latest)"
+            exit 1
+          fi
+        fi
+
+        echo "image=${ACR_SERVER}/${REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/resolve-release-image/action.yml
+++ b/.github/actions/resolve-release-image/action.yml
@@ -23,6 +23,13 @@
 #     prod release trivially diffable by eye in the workflow file — this
 #     composite cannot be exercised by pr-gate (cd-prod.yml only triggers on
 #     a v* tag push), so minimising what's hidden behind it matters.
+#
+# Assumes the calling job has already run actions/checkout (fetch-depth: 0 —
+# "Resolve tag to commit SHA" below needs the pushed tag ref resolvable via
+# git rev-parse) before this composite: a local composite action
+# (`uses: ./path`) can't be resolved by the runner from a workspace that
+# hasn't been checked out yet, so checkout can't live as this composite's
+# own first step.
 name: Resolve Release Image
 description: Resolve a cd-prod tag push to an immutable ACR image digest, falling back to :latest
 
@@ -54,11 +61,6 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      with:
-        persist-credentials: false
-        fetch-depth: 0
-
     - name: Resolve tag to commit SHA
       id: resolve
       shell: bash

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -177,28 +177,12 @@ jobs:
     timeout-minutes: 15
     environment: development
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: ./.github/actions/pgmigrate
         with:
-          persist-credentials: false
-
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
-        with:
-          go-version-file: api-go/go.mod
-
-      - uses: ./.github/actions/azure-login
-        with:
+          database-name: town_crier_dev
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Apply migrations
-        working-directory: api-go
-        run: |
-          go run ./cmd/pgmigrate \
-            -host psql-town-crier-shared.postgres.database.azure.com \
-            -admin-user town-crier-github-actions \
-            -db town_crier_dev \
-            -timeout 600s
 
   # ── Go API: build & push image ──────────────────────
   api-go-image:

--- a/.github/workflows/cd-dev.yml
+++ b/.github/workflows/cd-dev.yml
@@ -177,6 +177,9 @@ jobs:
     timeout-minutes: 15
     environment: development
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/pgmigrate
         with:
           database-name: town_crier_dev

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -103,6 +103,9 @@ jobs:
     timeout-minutes: 15
     environment: production
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/pgmigrate
         with:
           database-name: town_crier_prod
@@ -118,6 +121,11 @@ jobs:
     timeout-minutes: 5
     environment: production
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
       - name: Resolve release image
         id: resolve-image
         uses: ./.github/actions/resolve-release-image
@@ -161,6 +169,11 @@ jobs:
     timeout-minutes: 5
     environment: production
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
       # Same rationale as the Go API job above. Pinning the worker jobs to a
       # digest makes each release run an exact, reproducible image instead of
       # whatever :latest happens to resolve to at run time.

--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -103,28 +103,12 @@ jobs:
     timeout-minutes: 15
     environment: production
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: ./.github/actions/pgmigrate
         with:
-          persist-credentials: false
-
-      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
-        with:
-          go-version-file: api-go/go.mod
-
-      - uses: ./.github/actions/azure-login
-        with:
+          database-name: town_crier_prod
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      - name: Apply migrations
-        working-directory: api-go
-        run: |
-          go run ./cmd/pgmigrate \
-            -host psql-town-crier-shared.postgres.database.azure.com \
-            -admin-user town-crier-github-actions \
-            -db town_crier_prod \
-            -timeout 600s
 
   # ── Go API ────────────────────────────────────────────
   api-go:
@@ -134,60 +118,16 @@ jobs:
     timeout-minutes: 5
     environment: production
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Resolve release image
+        id: resolve-image
+        uses: ./.github/actions/resolve-release-image
         with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Resolve tag to commit SHA
-        id: resolve
-        run: echo "sha=$(git rev-parse "$GITHUB_REF_NAME")" >> "$GITHUB_OUTPUT"
-
-      - uses: ./.github/actions/azure-login
-        with:
+          repo-name: town-crier-api-go
+          display-name: "Go API"
+          acr-login-server: ${{ secrets.ACR_LOGIN_SERVER }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      # Resolve to an IMMUTABLE DIGEST (registry/repo@sha256:…), never a
-      # mutable tag. Prefer the exact tag-SHA image; else fall back to the
-      # current :latest digest; else fail. Deploying by digest means a code
-      # change rolls a new revision (digest differs) and an unchanged image is
-      # a legitimate no-op — the silent ":latest string == :latest string"
-      # no-op that froze prod becomes impossible.
-      - name: Resolve Go API image digest
-        id: resolve-image
-        run: |
-          ACR_SERVER="${{ secrets.ACR_LOGIN_SERVER }}"
-          ACR_NAME="${ACR_SERVER%.azurecr.io}"
-          REPO="town-crier-api-go"
-          SHA="${{ steps.resolve.outputs.sha }}"
-
-          digest_for_tag() {
-            az acr repository show \
-              --name "$ACR_NAME" \
-              --image "${REPO}:$1" \
-              --query digest -o tsv 2>/dev/null
-          }
-
-          # `|| true`: GitHub `run:` steps use `bash -e`, so a failed command
-          # substitution aborts the step. Without it, a missing SHA-tagged image
-          # (e.g. a tag whose commit didn't rebuild this image — an iOS-only or
-          # CI-only merge) kills the job before the `latest` fallback can run.
-          DIGEST="$(digest_for_tag "$SHA" || true)"
-          if [ -n "$DIGEST" ]; then
-            echo "Using exact image for SHA $SHA ($DIGEST)"
-          else
-            DIGEST="$(digest_for_tag latest || true)"
-            if [ -n "$DIGEST" ]; then
-              echo "No image for SHA $SHA — falling back to latest ($DIGEST)"
-            else
-              echo "::error::No Go API image found (tried SHA $SHA and latest)"
-              exit 1
-            fi
-          fi
-
-          echo "image=${ACR_SERVER}/${REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - uses: ./.github/actions/deploy-container-app
         with:
@@ -221,58 +161,19 @@ jobs:
     timeout-minutes: 5
     environment: production
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      # Same rationale as the Go API job above. Pinning the worker jobs to a
+      # digest makes each release run an exact, reproducible image instead of
+      # whatever :latest happens to resolve to at run time.
+      - name: Resolve release image
+        id: resolve-image
+        uses: ./.github/actions/resolve-release-image
         with:
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Resolve tag to commit SHA
-        id: resolve
-        run: echo "sha=$(git rev-parse "$GITHUB_REF_NAME")" >> "$GITHUB_OUTPUT"
-
-      - uses: ./.github/actions/azure-login
-        with:
+          repo-name: town-crier-worker-go
+          display-name: "worker"
+          acr-login-server: ${{ secrets.ACR_LOGIN_SERVER }}
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-      # Resolve to an IMMUTABLE DIGEST (registry/repo@sha256:…), never a
-      # mutable tag — same rationale as the Go API job above. Pinning the
-      # worker jobs to a digest makes each release run an exact, reproducible
-      # image instead of whatever :latest happens to resolve to at run time.
-      - name: Resolve worker image digest
-        id: resolve-image
-        run: |
-          ACR_SERVER="${{ secrets.ACR_LOGIN_SERVER }}"
-          ACR_NAME="${ACR_SERVER%.azurecr.io}"
-          REPO="town-crier-worker-go"
-          SHA="${{ steps.resolve.outputs.sha }}"
-
-          digest_for_tag() {
-            az acr repository show \
-              --name "$ACR_NAME" \
-              --image "${REPO}:$1" \
-              --query digest -o tsv 2>/dev/null
-          }
-
-          # `|| true`: GitHub `run:` steps use `bash -e`, so a failed command
-          # substitution aborts the step. Without it, a missing SHA-tagged image
-          # (e.g. a tag whose commit didn't rebuild this image — an iOS-only or
-          # CI-only merge) kills the job before the `latest` fallback can run.
-          DIGEST="$(digest_for_tag "$SHA" || true)"
-          if [ -n "$DIGEST" ]; then
-            echo "Using exact image for SHA $SHA ($DIGEST)"
-          else
-            DIGEST="$(digest_for_tag latest || true)"
-            if [ -n "$DIGEST" ]; then
-              echo "No image for SHA $SHA — falling back to latest ($DIGEST)"
-            else
-              echo "::error::No worker image found (tried SHA $SHA and latest)"
-              exit 1
-            fi
-          fi
-
-          echo "image=${ACR_SERVER}/${REPO}@${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - uses: ./.github/actions/deploy-worker-jobs
         with:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -270,43 +270,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: ./.github/actions/release-note-guard
         with:
-          persist-credentials: false
-          fetch-depth: 0
-      - name: Ensure iOS changes carry a user-note signal
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          set -euo pipefail
-          # A user-facing iOS change must surface in the App Store / TestFlight
-          # changelog. scripts/ios-release-notes.sh derives that changelog from
-          # (1) Release-Note: trailers, then (2) cleaned mobile/ios subjects. A PR
-          # whose squash subject (the PR title) has no recognised conventional
-          # type AND no Release-Note: trailer falls through to the stock line —
-          # which is how v0.15.23's onboarding-wizard launch shipped with no real
-          # notes (tc-0557). Block that class of PR here.
-
-          # Signal 1: any Release-Note: trailer in the PR's commits.
-          if git log --format='%B' "origin/${BASE_REF}..HEAD" | grep -qiE '^Release-Note:'; then
-            echo "✓ Release-Note: trailer present — App Store note authored verbatim."
-            exit 0
-          fi
-
-          # Signal 2: PR title carries a recognised conventional-commit type.
-          #   feat/fix   → generates a cleaned user note (Tier 2)
-          #   chore/ci/… → explicit, intentional opt-out (no note, by design)
-          if printf '%s' "$PR_TITLE" \
-              | grep -qiE '^(feat|fix|chore|ci|docs|test|build|style|refactor|perf)(\([^)]*\))?!?:'; then
-            echo "✓ PR title has a conventional-commit type prefix: $PR_TITLE"
-            exit 0
-          fi
-
-          echo "::error::iOS-touching PR has no Release-Note: trailer and the PR title has no conventional-commit type prefix: '$PR_TITLE'"
-          echo "::error::The App Store / TestFlight changelog would silently fall back to the generic stock line."
-          echo "::error::Fix one of: add a 'Release-Note: <plain-English user-facing change>' git trailer; OR retitle the PR with a type prefix — feat(ios):/fix(ios): for user-facing changes, or chore(ios):/test(ios): etc. to opt out."
-          exit 1
+          platform: ios
 
   # ── Android ──────────────────────────────────────────
 
@@ -362,39 +328,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: ./.github/actions/release-note-guard
         with:
-          persist-credentials: false
-          fetch-depth: 0
-      - name: Ensure Android changes carry a user-note signal
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          set -euo pipefail
-          # Mirrors ios-release-note-guard. There's no Play Store changelog
-          # generator yet (Android CD/signing lands in #779), but enforcing the
-          # same Release-Note:/conventional-title discipline now means no
-          # mobile/android/ PR needs retrofitting once that automation exists.
-
-          # Signal 1: any Release-Note: trailer in the PR's commits.
-          if git log --format='%B' "origin/${BASE_REF}..HEAD" | grep -qiE '^Release-Note:'; then
-            echo "✓ Release-Note: trailer present — Play Store note authored verbatim."
-            exit 0
-          fi
-
-          # Signal 2: PR title carries a recognised conventional-commit type.
-          #   feat/fix   → generates a cleaned user note (Tier 2)
-          #   chore/ci/… → explicit, intentional opt-out (no note, by design)
-          if printf '%s' "$PR_TITLE" \
-              | grep -qiE '^(feat|fix|chore|ci|docs|test|build|style|refactor|perf)(\([^)]*\))?!?:'; then
-            echo "✓ PR title has a conventional-commit type prefix: $PR_TITLE"
-            exit 0
-          fi
-
-          echo "::error::Android-touching PR has no Release-Note: trailer and the PR title has no conventional-commit type prefix: '$PR_TITLE'"
-          echo "::error::Fix one of: add a 'Release-Note: <plain-English user-facing change>' git trailer; OR retitle the PR with a type prefix — feat(android):/fix(android): for user-facing changes, or chore(android):/test(android): etc. to opt out."
-          exit 1
+          platform: android
 
   # ── Web ──────────────────────────────────────────────
 

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -270,6 +270,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
       - uses: ./.github/actions/release-note-guard
         with:
           platform: ios
@@ -328,6 +332,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
       - uses: ./.github/actions/release-note-guard
         with:
           platform: android


### PR DESCRIPTION
## Changes
- **release-note-guard** composite (`platform: ios|android`): pr-gate.yml's two release-note-guard jobs were byte-identical apart from wording. Preserves a subtle asymmetry — iOS's error output has an extra line (no Play Store changelog generator exists yet) that Android never had; handled with an internal platform check rather than dropped.
- **pgmigrate** composite (`database-name` input): cd-dev.yml's `migrate-dev` and cd-prod.yml's `migrate-prod` shrink to a single `uses:` call. Job-level `needs:`/`if:`/`environment:` gating (including cd-dev's slice-3 fail-open expression) is completely untouched.
- **resolve-release-image** composite (`repo-name`/`display-name` inputs): extracts only the shared checkout/resolve-tag/azure-login/resolve-digest portion of cd-prod.yml's `api` and `worker` jobs. The actual deploy step (`deploy-container-app` vs `deploy-worker-jobs` — different actions, different input shapes) and the post-deploy "tag digest as durable release" step stay inline and verbatim — folding the tag step into the composite would have forced it to run before the deploy step, silently breaking "only tag digests that actually shipped."
- Doc fix: `deploy-worker-jobs/action.yml`'s header now references `infra/environment.go` instead of the stale `infra/EnvironmentStack.cs`.

**Verification:** actionlint clean, zizmor 0 findings against the full repo. (a) and (b) are exercised by every real PR and cd-dev push respectively. (c) — the highest-risk part — cannot be exercised by pr-gate (cd-prod.yml only triggers on a real `v*` tag push); hand-traced carefully (same `steps.resolve-image.outputs.image` id preserved at the call site, identical digest-fallback logic, deploy/tag steps byte-for-byte unchanged) but the next real production release is the true proof.

Slice 5 of 7 from #835 (memo 0014 CI hardening).

---
*Auto-shipped via ship skill*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added checks to ensure iOS and Android changes include a release note or clear change-type in the PR title.
  * Introduced standardized deployment steps for database migrations and release image selection.

* **Chores**
  * Consolidated several deployment and validation workflows into shared automation, making releases more consistent and reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->